### PR TITLE
Fix: move DATA_MAIN_BASE clear before handshake to prevent multi-round hang

### DIFF
--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -20,13 +20,17 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* 
 __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
+    // In multi-round execution the DeviceRunner singleton keeps AICore threads alive
+    // across rounds. DATA_MAIN_BASE still holds the EXIT_SIGNAL from the previous
+    // round, so clear it before the handshake wait. Clearing after the wait would
+    // race with AICPU, which may finish all tasks and write a new EXIT_SIGNAL while
+    // this thread is descheduled between the wait and the clear.
+    write_reg(RegId::DATA_MAIN_BASE, 0);
+
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {
         dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);
     }
-
-    // Clear stale EXIT_SIGNAL from previous round before entering main loop
-    write_reg(RegId::DATA_MAIN_BASE, 0);
 
     // Report physical core ID and core type for AICPU
     my_hank->physical_core_id = get_physical_core_id();

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -52,13 +52,17 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ void* 
 __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int block_idx, CoreType core_type) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[block_idx]);
 
+    // In multi-round execution the DeviceRunner singleton keeps AICore threads alive
+    // across rounds. DATA_MAIN_BASE still holds the EXIT_SIGNAL from the previous
+    // round, so clear it before the handshake wait. Clearing after the wait would
+    // race with AICPU, which may finish all tasks and write a new EXIT_SIGNAL while
+    // this thread is descheduled between the wait and the clear.
+    write_reg(RegId::DATA_MAIN_BASE, 0);
+
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {
         dcci(my_hank, SINGLE_CACHE_LINE);
     }
-
-    // Clear stale EXIT_SIGNAL from previous round before entering main loop
-    write_reg(RegId::DATA_MAIN_BASE, 0);
 
     // Phase 2: Report physical core ID and core type, signal ready
     my_hank->physical_core_id = get_physical_core_id();

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -24,6 +24,13 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ Task* 
 __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, int core_idx, CoreType core_type) {
     __gm__ Handshake* my_hank = (__gm__ Handshake*)(&runtime->workers[core_idx]);
 
+    // In multi-round execution the DeviceRunner singleton keeps AICore threads alive
+    // across rounds. DATA_MAIN_BASE still holds the EXIT_SIGNAL from the previous
+    // round, so clear it before the handshake wait. Clearing after the wait would
+    // race with AICPU, which may finish all tasks and write a new EXIT_SIGNAL while
+    // this thread is descheduled between the wait and the clear.
+    write_reg(RegId::DATA_MAIN_BASE, 0);
+
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {
         dcci(my_hank, ENTIRE_DATA_CACHE, CACHELINE_OUT);


### PR DESCRIPTION
## Summary

Move `write_reg(DATA_MAIN_BASE, 0)` from after the handshake wait to before it in all AICore executors that use register-based dispatch, preventing a race that causes probabilistic hangs in multi-round execution.

Also add the missing clear to `a5/host_build_graph` which had no clear at all.

## Root Cause

In multi-round execution the DeviceRunner singleton keeps AICore threads alive across rounds. `DATA_MAIN_BASE` retains the `EXIT_SIGNAL` from the previous round and must be cleared before the next round begins.

The clear was placed after the handshake wait, creating a race window: if the AICore thread is descheduled between the wait and the clear, AICPU may complete all tasks and write a new `EXIT_SIGNAL`. The belated clear then overwrites it with 0, leaving the AICore thread spinning forever.

## Changes

- `a2a3/tensormap_and_ringbuffer/aicore`: move clear before handshake wait
- `a2a3/host_build_graph/aicore`: move clear before handshake wait
- `a5/host_build_graph/aicore`: add missing clear before handshake wait