### PR TITLE
feat(runtime): Orchestration PTOParam error handling

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -336,6 +336,21 @@ void pto2_submit_mixed_task(
     // Fast path after fatal error — all subsequent submits are no-ops
     if (orch->fatal) { return; }
 
+    // Validate PTOParam construction (errors recorded by add_input/add_output/etc.)
+    if (params.has_error) {
+        LOG_ERROR("========================================");
+        LOG_ERROR("FATAL: Invalid PTOParam Detected!");
+        LOG_ERROR("========================================");
+        LOG_ERROR("Error: %s", params.error_msg ? params.error_msg : "(unknown)");
+        LOG_ERROR("  tensor_count: %d, scalar_count: %d", params.tensor_count, params.scalar_count);
+        LOG_ERROR("This is a bug in the orchestration code.");
+        LOG_ERROR("========================================");
+        orch->sm_handle->header->orch_error_code.store(
+            PTO2_ERROR_INVALID_PARAM, std::memory_order_release);
+        orch->fatal = true;
+        return;
+    }
+
     CYCLE_COUNT_START();
 
     // === Validate submit inputs ===

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -64,6 +64,7 @@
 #define PTO2_ERROR_HEAP_RING_DEADLOCK         2
 #define PTO2_ERROR_FLOW_CONTROL_DEADLOCK      3
 #define PTO2_ERROR_DEP_POOL_OVERFLOW          4
+#define PTO2_ERROR_INVALID_PARAM              5   // PTOParam construction error (invalid params)
 
 // Scheduler errors (100+): detected in scheduler threads
 #define PTO2_ERROR_SCHEDULER_TIMEOUT          100

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -15,7 +15,6 @@
 #define ORCH_BUILD_GRAPH_PTO_TYPES_H
 
 #include <stdint.h>
-#include <assert.h>
 #include <string.h>
 
 #if defined(__aarch64__)
@@ -68,56 +67,78 @@ struct PTOParam {
     uint64_t scalars[PTO2_MAX_SCALAR_PARAMS];
     int32_t tensor_count{0};
     int32_t scalar_count{0};
+    bool has_error{false};
+    const char* error_msg{nullptr};
 
     void reset() {
         tensor_count = 0;
         scalar_count = 0;
+        has_error = false;
+        error_msg = nullptr;
     }
 
-    bool check_add_tensor_valid() const {
-        assert(scalar_count == 0 && "scalar must add after all tensor added");
+    void set_error(const char* msg) {
+        if (!has_error) {
+            has_error = true;
+            error_msg = msg;
+        }
+    }
+
+    bool check_add_tensor_valid() {
+        if (scalar_count != 0) {
+            set_error("add_input/add_output/add_inout called after add_scalar: "
+                      "all tensors must be added before any scalars");
+            return false;
+        }
+        if (tensor_count >= PTO2_MAX_TENSOR_PARAMS) {
+            set_error("Too many tensor params (exceeds PTO2_MAX_TENSOR_PARAMS=32)");
+            return false;
+        }
         return true;
     }
 
     void add_input(Tensor& t) {
-        if (!check_add_tensor_valid()) {
+        if (!check_add_tensor_valid()) { return; }
+        if (t.buffer.addr == 0) {
+            set_error("INPUT tensor must have a non-NULL buffer address");
             return;
         }
-        assert(t.buffer.addr != 0 && "INPUT param must have a non-NULL buffer address");
-        assert(tensor_count < PTO2_MAX_TENSOR_PARAMS && "Too many tensor params");
         tensors[tensor_count] = &t;
         tensor_types[tensor_count] = PTOParamType::INPUT;
         tensor_count++;
     }
 
     void add_output(Tensor& t) {
-        if (!check_add_tensor_valid()) {
-            return;
-        }
-        assert(tensor_count < PTO2_MAX_TENSOR_PARAMS && "Too many tensor params");
+        if (!check_add_tensor_valid()) { return; }
         tensors[tensor_count] = &t;
         tensor_types[tensor_count] = PTOParamType::OUTPUT;
         tensor_count++;
     }
 
     void add_inout(Tensor& t) {
-        if (!check_add_tensor_valid()) {
+        if (!check_add_tensor_valid()) { return; }
+        if (t.buffer.addr == 0) {
+            set_error("INOUT tensor must have a non-NULL buffer address");
             return;
         }
-        assert(t.buffer.addr != 0 && "INOUT param must have a non-NULL buffer address");
-        assert(tensor_count < PTO2_MAX_TENSOR_PARAMS && "Too many tensor params");
         tensors[tensor_count] = &t;
         tensor_types[tensor_count] = PTOParamType::INOUT;
         tensor_count++;
     }
 
     void add_scalar(uint64_t v) {
-        assert(scalar_count < PTO2_MAX_SCALAR_PARAMS && "Too many scalar params");
+        if (scalar_count >= PTO2_MAX_SCALAR_PARAMS) {
+            set_error("Too many scalar params (exceeds PTO2_MAX_SCALAR_PARAMS=128)");
+            return;
+        }
         scalars[scalar_count++] = v;
     }
 
     void add_scalars(const uint64_t* values, int count) {
-        assert(scalar_count + count <= PTO2_MAX_SCALAR_PARAMS && "Too many scalar params");
+        if (scalar_count + count > PTO2_MAX_SCALAR_PARAMS) {
+            set_error("Too many scalar params (exceeds PTO2_MAX_SCALAR_PARAMS=128)");
+            return;
+        }
         memcpy(&scalars[scalar_count], values, count * sizeof(uint64_t));
         scalar_count += count;
     }
@@ -129,7 +150,10 @@ struct PTOParam {
      * Uses NEON to process 4 elements per iteration on aarch64.
      */
     void add_scalars_i32(const int32_t* values, int count) {
-        assert(scalar_count + count <= PTO2_MAX_SCALAR_PARAMS && "Too many scalar params");
+        if (scalar_count + count > PTO2_MAX_SCALAR_PARAMS) {
+            set_error("Too many scalar params (exceeds PTO2_MAX_SCALAR_PARAMS=128)");
+            return;
+        }
         uint64_t* dst = &scalars[scalar_count];
 #if defined(__aarch64__)
         int i = 0;
@@ -154,13 +178,17 @@ struct PTOParam {
     /**
      * Copy scalars from another PTOParam's scalar array.
      * Useful when multiple tasks share the same scalar data (e.g., block indices).
-     * Rounds up to cache line boundary — both arrays are 1024B so no overrun.
      */
     void copy_scalars_from(const PTOParam& src, int src_offset, int count) {
-        assert(src_offset + count <= src.scalar_count && "Source scalar range out of bounds");
-        assert(scalar_count + count <= PTO2_MAX_SCALAR_PARAMS && "Too many scalar params");
-        size_t bytes = (count * sizeof(uint64_t) + 63) & ~size_t(63);
-        memcpy(&scalars[scalar_count], &src.scalars[src_offset], bytes);
+        if (src_offset + count > src.scalar_count) {
+            set_error("Source scalar range out of bounds in copy_scalars_from");
+            return;
+        }
+        if (scalar_count + count > PTO2_MAX_SCALAR_PARAMS) {
+            set_error("Too many scalar params (exceeds PTO2_MAX_SCALAR_PARAMS=128)");
+            return;
+        }
+        memcpy(&scalars[scalar_count], &src.scalars[src_offset], count * sizeof(uint64_t));
         scalar_count += count;
     }
 };


### PR DESCRIPTION
## Summary
- Replace all `assert()` calls in `PTOParam` with a deferred error-flag mechanism (`has_error` / `error_msg`) that works in both debug and release builds
- Integrate PTOParam validation into the orchestration error path: `LOG_ERROR` → `orch_error_code` → `fatal` → `emergency_shutdown`
- Previously, `assert()` was stripped in release builds (NDEBUG), allowing invalid parameters to silently pass through

## Key Changes
- `pto_types.h`: Add `has_error`/`error_msg` fields and `set_error()` helper to PTOParam; convert all `assert()` in `add_input`/`add_output`/`add_inout`/`add_scalar`/`add_scalars`/`add_scalars_i32`/`copy_scalars_from` to `set_error()` with descriptive messages
- `pto_orchestrator.cpp`: Add `params.has_error` validation at `pto2_submit_mixed_task` entry, before any resource allocation, following the same pattern as existing scope deadlock detection
- `pto_runtime2_types.h`: Add `PTO2_ERROR_INVALID_PARAM (5)` error code in orchestrator error range (1-99)
- `scheduler-orchestration-error-handling.md`: Update error code table and error setting locations with the new error type

## Error Scenarios Covered
| Scenario | Trigger | Error Message |
|----------|---------|---------------|
| Scalar before tensor | `params.add_scalar(v); params.add_input(t);` | `add_input/add_output/add_inout called after add_scalar` |
| Too many tensors | More than 32 `add_input/add_output/add_inout` calls | `Too many tensor params (exceeds MAX_TENSORS=32)` |
| NULL input address | `add_input(t)` where `t.buffer.addr == 0` | `INPUT tensor must have a non-NULL buffer address` |
| NULL inout address | `add_inout(t)` where `t.buffer.addr == 0` | `INOUT tensor must have a non-NULL buffer address` |
| Too many scalars | More than 128 scalar values | `Too many scalar params (exceeds MAX_SCALARS=128)` |
| Scalar copy out of bounds | `copy_scalars_from` with invalid range | `Source scalar range out of bounds` |

Expected output includes:
```
[ERROR] FATAL: Invalid PTOParam Detected!
[ERROR] Error: add_input/add_output/add_inout called after add_scalar: all tensors must be added before any scalars
[ERROR]   tensor_count: 0, scalar_count: 1
[ERROR] This is a bug in the orchestration code.
...
[ERROR] Thread 0: Fatal error (code=5), sending EXIT_SIGNAL to all cores
[WARN]  Emergency shutdown: sending exit signal to all initialized cores
```