### PR TITLE
Perf: precompute dispatch args and slim PTO2DispatchPayload to one cache line

### DIFF
--- a/src/a2a3/platform/include/aicore/aicore.h
+++ b/src/a2a3/platform/include/aicore/aicore.h
@@ -18,21 +18,7 @@
 // Common Memory Qualifiers (All Platforms)
 // =============================================================================
 
-#ifndef __gm__
-#define __gm__
-#endif
-
-#ifndef __global__
-#define __global__
-#endif
-
-#ifndef __in__
-#define __in__
-#endif
-
-#ifndef __out__
-#define __out__
-#endif
+#include "common/qualifier.h"
 
 // =============================================================================
 // Platform-Specific Definitions

--- a/src/a2a3/platform/include/common/qualifier.h
+++ b/src/a2a3/platform/include/common/qualifier.h
@@ -1,0 +1,28 @@
+/**
+ * @file qualifier.h
+ * @brief Memory qualifier fallbacks for non-AICore builds
+ *
+ * On real AICore the compiler provides __gm__, __global__, etc. natively.
+ * For AICPU, Host, and simulation builds these are no-ops.
+ */
+
+#ifndef PLATFORM_COMMON_QUALIFIER_H_
+#define PLATFORM_COMMON_QUALIFIER_H_
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __global__
+#define __global__
+#endif
+
+#ifndef __in__
+#define __in__
+#endif
+
+#ifndef __out__
+#define __out__
+#endif
+
+#endif  // PLATFORM_COMMON_QUALIFIER_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -38,10 +38,13 @@ __aicore__ __attribute__((always_inline)) static void execute_task(
  * Implements the AICPU-AICore register-based dispatch protocol:
  * 1. Wait for AICPU ready signal via handshake buffer
  * 2. Report physical core ID and core type, signal AICore ready
- * 3. Poll DATA_MAIN_BASE register for task dispatch until exit signal
+ * 3. Cache per-core PTO2DispatchPayload pointer from hank->task
+ * 4. Poll DATA_MAIN_BASE register for task dispatch until exit signal
  *
- * Task dispatch reads PTO2DispatchPayload address from Handshake.task.
- * Task ID is derived from the register value (task_id + 1 encoding).
+ * AICPU writes &s_pto2_payload_per_core[i] to hank->task before setting
+ * aicpu_ready=1. AICore caches this pointer and reads function_bin_addr +
+ * args pointer from it on each dispatch. reg_val is a monotonically
+ * increasing task ID used only for dispatch signaling and ACK/FIN protocol.
  *
  * @param runtime Pointer to Runtime in global memory
  * @param block_idx Block index (core ID)
@@ -72,7 +75,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
 
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
-    // Cache payload address (set once by AICPU during initialization, never changes)
+    // Cache per-core dispatch payload pointer (set by AICPU before aicpu_ready)
     __gm__ PTO2DispatchPayload* payload =
         reinterpret_cast<__gm__ PTO2DispatchPayload*>(my_hank->task);
 
@@ -113,7 +116,6 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime* runtime, in
             execute_task(payload);
 
             // Performance profiling: record task execution
-            // (func_id and core_type are filled by AICPU at completion time)
             if (profiling_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ PerfBuffer* perf_buf = (__gm__ PerfBuffer*)my_hank->perf_records_addr;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -71,7 +71,7 @@ constexpr int32_t PROGRESS_LOG_INTERVAL = 250;      // log every N completions a
 
 static PTO2Runtime *rt{nullptr};
 
-// Per-core dispatch payload storage (one per physical core)
+// Per-core dispatch payload storage (one aligned cache line per physical core)
 static PTO2DispatchPayload s_pto2_payload_per_core[RUNTIME_MAX_WORKER];
 
 // Core information for discovery (with register address for fast dispatch)
@@ -265,10 +265,6 @@ struct AicpuExecutor {
     uint64_t core_id_to_reg_addr_[MAX_CORES_PER_THREAD];
 
     // Per-core monotonic dispatch counter for register protocol uniqueness.
-    // Multi-ring task_ids can collide in the lower 32 bits (e.g., ring 0 local 0
-    // and ring 1 local 0 both truncate to 0), breaking the AICore's last_reg_val
-    // duplicate detection and causing false-positive COND completion. A per-core
-    // counter guarantees each dispatch writes a unique DATA_MAIN_BASE value.
     uint32_t dispatch_seq_by_core_[RUNTIME_MAX_WORKER]{};
 
     // Per-core subtask slot tracking (which PTO2SubtaskSlot is running on each core)
@@ -339,24 +335,6 @@ struct AicpuExecutor {
     void diagnose_stuck_state(
         Runtime* runtime, int32_t thread_idx, const int32_t* cur_thread_cores, int32_t core_num, Handshake* hank);
 
-    // Build slim PTO2DispatchPayload: only function_bin_addr + args.
-    // Metadata (mixed_task_id, subslot, kernel_id, core_type) stays in TaskDescriptor.
-    // Dispatch order: tensor args first, then scalar args.
-    void build_pto2_payload(PTO2DispatchPayload& out,
-        int32_t kernel_id,
-        PTO2TaskPayload& task_pl) {
-        out.function_bin_addr = get_function_bin_addr(kernel_id);
-        int32_t n = 0;
-        for (int32_t i = 0; i < task_pl.tensor_count; i++) {
-            task_pl.tensors[i].update_start_offset();
-            out.args[n++] = reinterpret_cast<uint64_t>(&task_pl.tensors[i]);
-        }
-        for (int32_t i = 0; i < task_pl.scalar_count; i++) {
-            out.args[n++] = task_pl.scalars[i];
-        }
-    }
-
-    // Template methods for Phase 1 and Phase 2
     template <CoreType CT>
     void check_running_cores_for_completion(int32_t thread_idx,
         Handshake* hank,
@@ -601,10 +579,11 @@ struct AicpuExecutor {
 #if !PTO2_PROFILING
         (void)runtime;
 #endif
+        // Set function address and args pointer for this core payload.
         PTO2DispatchPayload& payload = s_pto2_payload_per_core[core_id];
-        PTO2TaskDescriptor& task = *slot_state.task;
         int32_t slot_idx = static_cast<int32_t>(subslot);
-        build_pto2_payload(payload, task.kernel_id[slot_idx], *slot_state.payload);
+        payload.function_bin_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
+        payload.args = slot_state.payload->dispatch_args;
         executing_subslot_by_core_[core_id] = subslot;
         executing_slot_state_by_core_[core_id] = &slot_state;
 #if PTO2_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/build_config.py
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/build_config.py
@@ -4,7 +4,7 @@
 # This is a device-orchestration runtime where:
 # - AICPU thread 3 runs the orchestrator (builds task graph on device)
 # - AICPU threads 0/1/2 run schedulers (dispatch tasks to AICore)
-# - AICore executes tasks via PTO2DispatchPayload
+# - AICore executes tasks via an aligned PTO2DispatchPayload + pre-built dispatch_args
 #
 # The "orchestration" directory contains source files compiled into both
 # runtime targets AND the orchestration .so (e.g., tensor methods needed

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -1,33 +1,45 @@
 /**
  * @file pto2_dispatch_payload.h
- * @brief Minimal dispatch payload for AICore kernel execution
+ * @brief Per-core dispatch payload for AICore kernel execution
  *
- * Shared between AICPU (builds in-place) and AICore (reads to run kernel).
- * Handshake.task points to PTO2DispatchPayload embedded in PTO2TaskPayload.
+ * PTO2DispatchPayload holds the kernel function address and a pointer to the
+ * pre-built args[] array in the task payload. AICPU maintains a static array
+ * of these (one per core) and writes both fields before each dispatch. AICore
+ * caches a pointer to its per-core slot at startup and reads from it on each
+ * dispatch. The struct is cache-line aligned to avoid false sharing across
+ * concurrently dispatched cores.
  *
- * Only contains fields AICore needs to execute: function address + arguments.
- * Metadata (task_id, kernel_id, core_type) lives in PTO2TaskDescriptor and
- * is accessed by AICPU when needed (profiling, diagnostics).
+ * The args[] array (tensor GM pointers followed by scalar values) is built once
+ * by the Orchestrator at submit time in PTO2TaskPayload::init().
+ *
+ * The DATA_MAIN_BASE register protocol is unchanged from the base runtime:
+ * a monotonically increasing reg_task_id signals new work to AICore.
  */
 
 #ifndef RT2_PTO2_DISPATCH_PAYLOAD_H_
 #define RT2_PTO2_DISPATCH_PAYLOAD_H_
 
 #include <stdint.h>
+#include "pto_types.h"
+#include "common/qualifier.h"
 
-/** Max arguments per task; must match RUNTIME_MAX_ARGS and PTO2_MAX_OUTPUTS */
+/** Max dispatch arguments: 128 scalars + up to 16 tensor pointers */
 #ifndef PTO2_DISPATCH_MAX_ARGS
-#define PTO2_DISPATCH_MAX_ARGS 128
+#define PTO2_DISPATCH_MAX_ARGS (PTO2_MAX_SCALAR_PARAMS + PTO2_MAX_TENSOR_PARAMS)
 #endif
 
 /**
- * Dispatch payload: minimal execution interface for AICore.
- * Layout: function_bin_addr followed by args[].
- * AICore reads function_bin_addr, casts to UnifiedKernelFunc, calls with args.
+ * Per-core dispatch payload: function address + args pointer.
+ *
+ * AICPU maintains a static array s_pto2_payload_per_core[RUNTIME_MAX_WORKER].
+ * Before each dispatch, AICPU writes function_bin_addr (looked up from
+ * func_id_to_addr_[kernel_id]) and args (pointer to pre-built dispatch_args[]
+ * in PTO2TaskPayload). AICore caches a pointer to its slot at startup (via
+ * Handshake.task) and reads both fields after each DATA_MAIN_BASE change.
  */
-struct PTO2DispatchPayload {
-    uint64_t function_bin_addr; /**< Kernel entry in GM: (UnifiedKernelFunc)function_bin_addr */
-    uint64_t args[PTO2_DISPATCH_MAX_ARGS]; /**< Kernel arguments (GM pointers + scalars) */
+struct alignas(64) PTO2DispatchPayload {
+    uint64_t function_bin_addr;    /**< Kernel entry address in GM (set by Scheduler) */
+    __gm__ uint64_t* args;         /**< Pre-built args in task payload GM (set by Scheduler) */
 };
 
 #endif  // RT2_PTO2_DISPATCH_PAYLOAD_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -353,8 +353,8 @@ void pto2_submit_mixed_task(
         __builtin_prefetch(&payload->tensors[i], 1, 3);
         __builtin_prefetch(reinterpret_cast<char*>(&payload->tensors[i]) + 64, 1, 3);
     }
-    for (int32_t i = 0; i < params.scalar_count; i += 8) {
-        __builtin_prefetch(&payload->scalars[i], 1, 3);
+    for (int32_t i = 0; i < params.tensor_count + params.scalar_count; i += 8) {
+        __builtin_prefetch(&payload->dispatch_args[i], 1, 3);
     }
     __builtin_prefetch(payload, 1, 3);
     __builtin_prefetch(reinterpret_cast<char*>(payload) + 64, 1, 3);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -21,6 +21,7 @@
 
 #include "pto_types.h"
 #include "pto_submit_types.h"
+#include "pto2_dispatch_payload.h"
 
 // =============================================================================
 // Profiling Configuration
@@ -346,9 +347,12 @@ struct PTO2TaskDescriptor {
  * Task payload data (cold path - only accessed during orchestration and dispatch)
  *
  * Layout: metadata (counts, fanin pointers) packed in the first 3 cache lines,
- * followed by bulk tensor and scalar data. This gives sequential write access
- * during orchestration and groups scheduler-hot fields (fanin_actual_count +
- * fanin_slot_states) together for on_task_release.
+ * followed by pre-built dispatch args and bulk tensor data. Scalar values are
+ * written directly into dispatch_args[] (after tensor pointers), eliminating
+ * the separate scalars[] array.
+ *
+ * The Scheduler writes function_bin_addr and a pointer to dispatch_args[] into
+ * PTO2DispatchPayload, then signals AICore via DATA_MAIN_BASE register.
  */
 struct PTO2TaskPayload {
     // === Cache line 0 (64B) — metadata ===
@@ -357,22 +361,34 @@ struct PTO2TaskPayload {
     int32_t fanin_actual_count{0};             // Actual fanin count (without the +1 redundance)
     int32_t _reserved{0};                      // Reserved (dep_pool_mark moved to SlotState for local access)
     PTO2TaskSlotState* fanin_slot_states[PTO2_MAX_INPUTS]; // Producer slot states (used by on_task_release)
-    // === Cache lines 3-34 (2048B) — tensors (alignas(64) forces alignment) ===
+    // === Tensors (2048B) — alignas(64) Tensor forces alignment ===
     Tensor tensors[PTO2_MAX_TENSOR_PARAMS];
-    // === Cache lines 35-50 (1024B) — scalars ===
-    uint64_t scalars[PTO2_MAX_SCALAR_PARAMS];
+    // === Pre-built args for AICore dispatch (1152B = 16 tensor ptrs + 128 scalars) ===
+    uint64_t dispatch_args[PTO2_DISPATCH_MAX_ARGS];
 
+    /**
+     * Initialize payload: copy tensors, build dispatch args.
+     *
+     * @param params            Task parameters (tensors + scalars)
+     */
     void init(const PTOParam& params) {
         tensor_count = params.tensor_count;
         scalar_count = params.scalar_count;
+
+        // 1. Copy tensors from PTOParam
         auto src_tensors = params.tensors;
         for (int32_t i = 0; i < params.tensor_count; i++) {
             tensors[i].copy(*src_tensors[i]);
         }
-        static_assert(sizeof(scalars) == sizeof(params.scalars));
-        // Round up to cache line boundary. Both arrays are 1024B so no overrun.
-        // Eliminates branches; extra bytes within the same CL have zero additional cost.
-        memcpy(scalars, params.scalars,
+
+        // 2. Build dispatch_args[]: tensor pointers first, then scalar values
+        for (int32_t i = 0; i < params.tensor_count; i++) {
+            tensors[i].update_start_offset();
+            dispatch_args[i] = reinterpret_cast<uint64_t>(&tensors[i]);
+        }
+        // Bulk-copy scalars into dispatch_args[tensor_count..], rounded up to
+        // cache-line boundary (extra bytes within the same CL cost nothing).
+        memcpy(&dispatch_args[params.tensor_count], params.scalars,
                PTO2_ALIGN_UP(params.scalar_count * sizeof(uint64_t), 64));
     }
 };

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -91,7 +91,7 @@ struct PTOParam {
             return false;
         }
         if (tensor_count >= PTO2_MAX_TENSOR_PARAMS) {
-            set_error("Too many tensor params (exceeds PTO2_MAX_TENSOR_PARAMS=32)");
+            set_error("Too many tensor params (exceeds PTO2_MAX_TENSOR_PARAMS=16)");
             return false;
         }
         return true;
@@ -128,7 +128,7 @@ struct PTOParam {
 
     void add_scalar(uint64_t v) {
         if (scalar_count >= PTO2_MAX_SCALAR_PARAMS) {
-            set_error("Too many scalar params (exceeds PTO2_MAX_SCALAR_PARAMS=128)");
+            set_error("Too many scalar params (exceeds PTO2_MAX_SCALAR_PARAMS)");
             return;
         }
         scalars[scalar_count++] = v;
@@ -136,7 +136,7 @@ struct PTOParam {
 
     void add_scalars(const uint64_t* values, int count) {
         if (scalar_count + count > PTO2_MAX_SCALAR_PARAMS) {
-            set_error("Too many scalar params (exceeds PTO2_MAX_SCALAR_PARAMS=128)");
+            set_error("Too many scalar params (exceeds PTO2_MAX_SCALAR_PARAMS)");
             return;
         }
         memcpy(&scalars[scalar_count], values, count * sizeof(uint64_t));
@@ -151,7 +151,7 @@ struct PTOParam {
      */
     void add_scalars_i32(const int32_t* values, int count) {
         if (scalar_count + count > PTO2_MAX_SCALAR_PARAMS) {
-            set_error("Too many scalar params (exceeds PTO2_MAX_SCALAR_PARAMS=128)");
+            set_error("Too many scalar params (exceeds PTO2_MAX_SCALAR_PARAMS)");
             return;
         }
         uint64_t* dst = &scalars[scalar_count];
@@ -185,7 +185,7 @@ struct PTOParam {
             return;
         }
         if (scalar_count + count > PTO2_MAX_SCALAR_PARAMS) {
-            set_error("Too many scalar params (exceeds PTO2_MAX_SCALAR_PARAMS=128)");
+            set_error("Too many scalar params (exceeds PTO2_MAX_SCALAR_PARAMS)");
             return;
         }
         memcpy(&scalars[scalar_count], &src.scalars[src_offset], count * sizeof(uint64_t));

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -10,7 +10,9 @@
  * - Device orchestration state (pto2_gm_sm_ptr_, orch_args_)
  * - Function address mapping (func_id_to_addr_)
  *
- * Task dispatch uses PTO2DispatchPayload from PTO2 shared memory.
+ * Task dispatch uses a per-core PTO2DispatchPayload written by the scheduler.
+ * The Orchestrator pre-builds dispatch_args[] in each task payload; the
+ * scheduler only fills function_bin_addr + args before signaling AICore.
  */
 
 #ifndef RUNTIME_H
@@ -52,9 +54,9 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * Protocol State Machine:
  * 1. Initialization: AICPU sets aicpu_ready=1
  * 2. Acknowledgment: AICore sets aicore_done=core_id+1
- * 3. Task Dispatch: AICPU assigns task pointer and sets task_status=1
- * 4. Task Execution: AICore reads task, executes, sets task_status=0
- * 5. Task Completion: AICPU reads task_status=0, clears task=0
+ * 3. Task Dispatch: AICPU writes DATA_MAIN_BASE after updating the per-core payload
+ * 4. Task Execution: AICore reads the cached PTO2DispatchPayload and executes
+ * 5. Task Completion: AICore writes FIN to COND; AICPU observes completion
  * 6. Shutdown: AICPU sets control=1, AICore exits
  *
  * Each AICore instance has its own handshake buffer to enable concurrent
@@ -71,7 +73,7 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * Field Access Patterns:
  * - aicpu_ready: Written by AICPU, read by AICore
  * - aicore_done: Written by AICore, read by AICPU
- * - task: Written by AICPU, read by AICore (0 = no task, non-zero = PTO2DispatchPayload*)
+ * - task: Written by AICPU, read by AICore (0 = not ready, non-zero = PTO2DispatchPayload*)
  * - task_status: Written by both (AICPU=1 on dispatch, AICore=0 on completion)
  * - control: Written by AICPU, read by AICore (0 = continue, 1 = quit)
  * - core_type: Written by AICPU, read by AICore (CoreType::AIC or CoreType::AIV)
@@ -79,7 +81,7 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
 struct Handshake {
     volatile uint32_t aicpu_ready;         // AICPU ready signal: 0=not ready, 1=ready
     volatile uint32_t aicore_done;         // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;                // Task pointer: 0=no task, non-zero=PTO2DispatchPayload*
+    volatile uint64_t task;                // Init: PTO2DispatchPayload* (set before aicpu_ready); runtime: unused
     volatile int32_t task_status;          // Task execution status: 0=idle, 1=busy
     volatile int32_t control;              // Control signal: 0=execute, 1=quit
     volatile CoreType core_type;           // Core type: CoreType::AIC or CoreType::AIV


### PR DESCRIPTION
## Summary
- Build `dispatch_args[]` (tensor pointers + scalars) once at submit time in `PTO2TaskPayload::init()`, eliminating per-dispatch arg assembly
- Slim `PTO2DispatchPayload` to `{function_bin_addr, __gm__ uint64_t* args}` (64B cache-line aligned), removing the 1KB inline `args[]` array
- Scheduler now only writes function address + args pointer before dispatch
- Reorder `PTO2TaskPayload` layout: tensors before dispatch_args for sequential forward writes during init
- Extract `common/qualifier.h` from `aicore.h` for shared `__gm__` fallback defines
- Remove redundant `always_assert` in `PTO2TaskPayload::init()`
- Prefetch `dispatch_args[]` cache lines during task submission

## Benchmark (device 2, 100 rounds, trim 10+10)

| Example | Base (us) | HEAD (us) | Change |
| --- | ---: | ---: | ---: |
| alternating_matmul_add | 1085.7 | 1066.8 | -1.74% |
| benchmark_bgemm | 775.9 | 774.1 | -0.23% |
| paged_attention_unroll (Case1) | 1405.8 | 1407.9 | +0.15% |
| paged_attention_unroll (Case2) | 718.8 | 719.9 | +0.15% |
| batch_paged_attention | 3734.2 | 3707.0 | -0.73% |

All within noise margin (< 2%). No regressions.

## Testing
- [x] Simulation tests pass (tensormap_and_ringbuffer, 6/6)
- [ ] Hardware device tests (CI)