### PR TITLE
Update: pass block table and context lens as Tensor* in paged attention

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -8,6 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+
 // Batched PV Matmul Kernel: for each batch b, pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
 // Processes batch_count batches in a single kernel invocation.
@@ -16,10 +17,12 @@
 // Template: M=q_tile, K=block_size, N=head_dim
 
 #include <cstdint>
+// NOLINTBEGIN(clang-diagnostic-error,bugprone-reserved-identifier,bugprone-easily-swappable-parameters,modernize-use-auto)
 #include <pto/pto-inst.hpp>
 
 #include "tensor.h"
 
+// NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
 #ifndef __gm__
@@ -27,19 +30,18 @@ using namespace pto;
 #endif
 
 #ifndef __aicore__
-#define __aicore__ [aicore]
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
 #endif
 
 template <int M, int K, int N>
 static __aicore__ void pv_matmul_batch_impl(
-    __gm__ Tensor *pij_batch, __gm__ Tensor *value_cache, __gm__ Tensor *oi_new_batch, uint64_t block_table_ptr,
+    __gm__ Tensor *pij_batch, __gm__ Tensor *value_cache, __gm__ Tensor *block_table_t, __gm__ Tensor *oi_new_batch,
     uint64_t batch_count, uint64_t block_idx, uint64_t block_num, uint64_t batch_start
 ) {
     __gm__ half *pij_base = reinterpret_cast<__gm__ half *>(pij_batch->buffer.addr);
     __gm__ half *val_base = reinterpret_cast<__gm__ half *>(value_cache->buffer.addr);
     __gm__ float *oi_base = reinterpret_cast<__gm__ float *>(oi_new_batch->buffer.addr);
-    // Block table values are always non-negative (physical block indices)
-    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_ptr);
+    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr);
 
     using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
@@ -67,7 +69,7 @@ static __aicore__ void pv_matmul_batch_impl(
     for (uint64_t b = 0; b < batch_count; b++) {
         __gm__ half *pij_addr = pij_base + b * M * K;
         int32_t phys_block = bt[(batch_start + b) * block_num + block_idx];
-        __gm__ half *vj_addr = val_base + (uint64_t)phys_block * K * N;
+        __gm__ half *vj_addr = val_base + static_cast<uint64_t>(phys_block) * K * N;
         __gm__ float *oi_addr = oi_base + b * M * N;
 
         GlobalA pijGlobal(pij_addr);
@@ -102,14 +104,15 @@ static __aicore__ void pv_matmul_batch_impl(
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ Tensor *pij_batch = reinterpret_cast<__gm__ Tensor *>(args[0]);
     __gm__ Tensor *value_cache = reinterpret_cast<__gm__ Tensor *>(args[1]);
-    __gm__ Tensor *oi_new_batch = reinterpret_cast<__gm__ Tensor *>(args[2]);
-    uint64_t block_table_ptr = static_cast<uint64_t>(args[3]);
+    __gm__ Tensor *block_table_t = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *oi_new_batch = reinterpret_cast<__gm__ Tensor *>(args[3]);
     uint64_t batch_count = static_cast<uint64_t>(args[4]);
     uint64_t block_idx = static_cast<uint64_t>(args[5]);
     uint64_t block_num = static_cast<uint64_t>(args[6]);
     uint64_t batch_start = static_cast<uint64_t>(args[7]);
 
     pv_matmul_batch_impl<16, 16, 16>(
-        pij_batch, value_cache, oi_new_batch, block_table_ptr, batch_count, block_idx, block_num, batch_start
+        pij_batch, value_cache, block_table_t, oi_new_batch, batch_count, block_idx, block_num, batch_start
     );
 }
+// NOLINTEND(clang-diagnostic-error,bugprone-reserved-identifier,bugprone-easily-swappable-parameters,modernize-use-auto)

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -8,6 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+
 // Batched QK Matmul Kernel: for each batch b, qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
 // Processes batch_count batches in a single kernel invocation.
@@ -20,6 +21,7 @@
 
 #include "tensor.h"
 
+// NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
 #ifndef __gm__
@@ -27,20 +29,19 @@ using namespace pto;
 #endif
 
 #ifndef __aicore__
-#define __aicore__ [aicore]
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
 #endif
 
 template <int M, int K, int N>
 static __aicore__ void qk_matmul_batch_impl(
-    __gm__ Tensor *query, __gm__ Tensor *key_cache, __gm__ Tensor *sij_batch, uint64_t block_table_ptr,
+    __gm__ Tensor *query, __gm__ Tensor *key_cache, __gm__ Tensor *block_table_t, __gm__ Tensor *sij_batch,
     uint64_t batch_count, uint64_t block_idx, uint64_t q_offset, uint64_t block_num, uint64_t num_heads,
     uint64_t batch_start
 ) {
     __gm__ half *query_base = reinterpret_cast<__gm__ half *>(query->buffer.addr);
     __gm__ half *key_base = reinterpret_cast<__gm__ half *>(key_cache->buffer.addr);
     __gm__ float *sij_base = reinterpret_cast<__gm__ float *>(sij_batch->buffer.addr);
-    // Block table values are always non-negative (physical block indices)
-    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_ptr);
+    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr);
 
     using GlobalA = GlobalTensor<half, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<half, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
@@ -68,7 +69,7 @@ static __aicore__ void qk_matmul_batch_impl(
     for (uint64_t b = 0; b < batch_count; b++) {
         __gm__ half *qi_addr = query_base + ((batch_start + b) * num_heads + q_offset) * K;
         int32_t phys_block = bt[(batch_start + b) * block_num + block_idx];
-        __gm__ half *kj_addr = key_base + (uint64_t)phys_block * N * K;
+        __gm__ half *kj_addr = key_base + static_cast<uint64_t>(phys_block) * N * K;
         __gm__ float *sij_addr = sij_base + b * M * N;
 
         GlobalA qiGlobal(qi_addr);
@@ -103,8 +104,8 @@ static __aicore__ void qk_matmul_batch_impl(
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ Tensor *query = reinterpret_cast<__gm__ Tensor *>(args[0]);
     __gm__ Tensor *key_cache = reinterpret_cast<__gm__ Tensor *>(args[1]);
-    __gm__ Tensor *sij_batch = reinterpret_cast<__gm__ Tensor *>(args[2]);
-    uint64_t block_table_ptr = static_cast<uint64_t>(args[3]);
+    __gm__ Tensor *block_table_t = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *sij_batch = reinterpret_cast<__gm__ Tensor *>(args[3]);
     uint64_t batch_count = static_cast<uint64_t>(args[4]);
     uint64_t block_idx = static_cast<uint64_t>(args[5]);
     uint64_t q_offset = static_cast<uint64_t>(args[6]);
@@ -113,7 +114,6 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     uint64_t batch_start = static_cast<uint64_t>(args[9]);
 
     qk_matmul_batch_impl<16, 16, 16>(
-        query, key_cache, sij_batch, block_table_ptr, batch_count, block_idx, q_offset, block_num, num_heads,
-        batch_start
+        query, key_cache, block_table_t, sij_batch, batch_count, block_idx, q_offset, block_num, num_heads, batch_start
     );
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -23,7 +23,7 @@
 #include <cstdint>
 #include <pto/pto-inst.hpp>
 
-#include "tensor.h"  // NOLINT(build/include_subdir)
+#include "tensor.h"
 
 // NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
@@ -38,14 +38,14 @@ using namespace pto;
 
 template <int M, int N>
 static __aicore__ void softmax_prepare_batch_impl(
-    __gm__ Tensor *sij_batch, __gm__ Tensor *pij_batch, __gm__ Tensor *mij_batch, __gm__ Tensor *lij_batch,
-    float scale_value, uint64_t context_lens_ptr, uint64_t batch_count, uint64_t block_idx, uint64_t batch_start
+    __gm__ Tensor *sij_batch, __gm__ Tensor *context_lens_t, __gm__ Tensor *pij_batch, __gm__ Tensor *mij_batch,
+    __gm__ Tensor *lij_batch, float scale_value, uint64_t batch_count, uint64_t block_idx, uint64_t batch_start
 ) {
     __gm__ float *sij_base = reinterpret_cast<__gm__ float *>(sij_batch->buffer.addr);
     __gm__ half *pij_base = reinterpret_cast<__gm__ half *>(pij_batch->buffer.addr);
     __gm__ float *mij_base = reinterpret_cast<__gm__ float *>(mij_batch->buffer.addr);
     __gm__ float *lij_base = reinterpret_cast<__gm__ float *>(lij_batch->buffer.addr);
-    __gm__ int32_t *ctx_lens = reinterpret_cast<__gm__ int32_t *>(context_lens_ptr);
+    __gm__ int32_t *ctx_lens = reinterpret_cast<__gm__ int32_t *>(context_lens_t->buffer.addr);
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -153,16 +153,16 @@ static __aicore__ void softmax_prepare_batch_impl(
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ Tensor *sij_batch = reinterpret_cast<__gm__ Tensor *>(args[0]);
-    __gm__ Tensor *pij_batch = reinterpret_cast<__gm__ Tensor *>(args[1]);
-    __gm__ Tensor *mij_batch = reinterpret_cast<__gm__ Tensor *>(args[2]);
-    __gm__ Tensor *lij_batch = reinterpret_cast<__gm__ Tensor *>(args[3]);
-    float scale_value = from_u64<float>(static_cast<uint64_t>(args[4]));
-    uint64_t context_lens_ptr = static_cast<uint64_t>(args[5]);
+    __gm__ Tensor *context_lens_t = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *pij_batch = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *mij_batch = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *lij_batch = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    float scale_value = from_u64<float>(static_cast<uint64_t>(args[5]));
     uint64_t batch_count = static_cast<uint64_t>(args[6]);
     uint64_t block_idx = static_cast<uint64_t>(args[7]);
     uint64_t batch_start = static_cast<uint64_t>(args[8]);
 
     softmax_prepare_batch_impl<16, 16>(
-        sij_batch, pij_batch, mij_batch, lij_batch, scale_value, context_lens_ptr, batch_count, block_idx, batch_start
+        sij_batch, context_lens_t, pij_batch, mij_batch, lij_batch, scale_value, batch_count, block_idx, batch_start
     );
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -26,7 +26,7 @@
 
 #include <cinttypes>
 
-#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+#include "pto_orchestration_api.h"
 
 #define FUNC_QK_MATMUL 0
 #define FUNC_SOFTMAX_PREPARE 1
@@ -39,7 +39,7 @@ extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
 aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
-    (void)orch_args;  // NOLINT(readability/casting)
+    (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
@@ -64,12 +64,18 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
 
     LOG_INFO("batch_paged_attention: batch=%" PRIu64 ", num_heads=%" PRIu64, batch, num_heads);
 
-    int *host_block_table = orch_args.tensor(3).data_as<int>();
-    int *host_context_lens = orch_args.tensor(4).data_as<int>();
+    uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
+    Tensor block_table =
+        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+
+    uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
+    Tensor context_lens =
+        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
     uint64_t max_bn = 0;
     for (uint64_t b = 0; b < batch; b++) {
-        uint64_t cur_seq = host_context_lens[b];
+        uint32_t cl_idx[1] = {static_cast<uint32_t>(b)};
+        uint64_t cur_seq = static_cast<uint64_t>(get_tensor_data<int32_t>(context_lens, 1, cl_idx));
         uint64_t bn_b = (cur_seq + block_size - 1) / block_size;
         if (bn_b > max_bn) max_bn = bn_b;
     }
@@ -92,9 +98,6 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     Tensor key_cache = make_tensor_external(kc_ptr, key_cache_shapes, 2, data_type);
     Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type);
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32, true);
-
-    uint64_t bt_addr = reinterpret_cast<uintptr_t>(host_block_table);
-    uint64_t cl_addr = reinterpret_cast<uintptr_t>(host_context_lens);
 
     uint64_t IN_CORE_BATCH = 16;
     uint64_t num_chunks = (batch + IN_CORE_BATCH - 1) / IN_CORE_BATCH;
@@ -129,8 +132,8 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                     Arg params_qk;
                     params_qk.add_input(query);
                     params_qk.add_input(key_cache);
+                    params_qk.add_input(block_table);
                     params_qk.add_output(sij_ci);
-                    params_qk.add_scalar(bt_addr);
                     params_qk.add_scalar(chunk_bc);
                     params_qk.add_scalar(bn);
                     params_qk.add_scalar(q_offset);
@@ -142,11 +145,11 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
 
                     Arg params_sf;
                     params_sf.add_input(sij_b);
+                    params_sf.add_input(context_lens);
                     params_sf.add_output(pij_ci);
                     params_sf.add_output(scalar_ci);
                     params_sf.add_output(scalar_ci);
                     params_sf.add_scalar(scale_value);
-                    params_sf.add_scalar(cl_addr);
                     params_sf.add_scalar(chunk_bc);
                     params_sf.add_scalar(bn);
                     params_sf.add_scalar(batch_start);
@@ -158,8 +161,8 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                     Arg params_pv;
                     params_pv.add_input(pij_b);
                     params_pv.add_input(value_cache);
+                    params_pv.add_input(block_table);
                     params_pv.add_output(tile2d_ci);
-                    params_pv.add_scalar(bt_addr);
                     params_pv.add_scalar(chunk_bc);
                     params_pv.add_scalar(bn);
                     params_pv.add_scalar(block_num);

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -28,7 +28,7 @@
 
 #include <cinttypes>
 
-#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+#include "pto_orchestration_api.h"
 
 #define FUNC_QK_MATMUL 0
 #define FUNC_SOFTMAX_PREPARE 1
@@ -41,7 +41,7 @@ extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
 aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
-    (void)orch_args;  // NOLINT(readability/casting)
+    (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
@@ -102,8 +102,12 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     LOG_DEBUG("value_cache=%s", value_cache.dump().c_str());
     LOG_DEBUG("out=%s", out.dump().c_str());
 
-    int *host_block_table = orch_args.tensor(3).data_as<int>();
-    int *host_context_lens = orch_args.tensor(4).data_as<int>();
+    uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
+    Tensor block_table =
+        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+    uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
+    Tensor context_lens =
+        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
     // Create infos are loop-invariant — shapes depend only on q_tile/head_dim/block_size
     uint32_t tile2d_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
@@ -115,7 +119,8 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     TensorCreateInfo pij_f16_ci(sij_shapes, 2, data_type);
 
     for (uint64_t b_idx = b_start; b_idx < b_end; b_idx++) {
-        uint64_t cur_seq = host_context_lens[b_idx];
+        uint32_t cl_idx[1] = {static_cast<uint32_t>(b_idx)};
+        uint64_t cur_seq = static_cast<uint64_t>(get_tensor_data<int32_t>(context_lens, 1, cl_idx));
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
             PTO2_SCOPE() {
@@ -136,7 +141,8 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                 const Tensor &mi_update = hub_outs.get_ref(2);
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn++) {
-                    uint64_t cur_block_idx = host_block_table[b_idx * block_num + bn];
+                    uint32_t bt_idx[2] = {static_cast<uint32_t>(b_idx), static_cast<uint32_t>(bn)};
+                    uint64_t cur_block_idx = static_cast<uint64_t>(get_tensor_data<int32_t>(block_table, 2, bt_idx));
                     uint64_t valid_len =
                         block_size < (cur_seq - bn * block_size) ? block_size : (cur_seq - bn * block_size);
                     uint32_t kv_shapes[2] = {static_cast<uint32_t>(block_size), static_cast<uint32_t>(head_dim)};

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -102,8 +102,12 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     LOG_DEBUG("value_cache=%s", value_cache.dump().c_str());
     LOG_DEBUG("out=%s", out.dump().c_str());
 
-    int *host_block_table = orch_args.tensor(3).data_as<int>();
-    int *host_context_lens = orch_args.tensor(4).data_as<int>();
+    uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
+    Tensor block_table =
+        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+    uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
+    Tensor context_lens =
+        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
     // Create infos are loop-invariant — shapes depend only on q_tile/head_dim/block_size
     uint32_t tile2d_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
@@ -115,7 +119,8 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     TensorCreateInfo pij_f16_ci(sij_shapes, 2, data_type);
 
     for (uint64_t b_idx = b_start; b_idx < b_end; b_idx++) {
-        uint64_t cur_seq = host_context_lens[b_idx];
+        uint32_t cl_idx[1] = {static_cast<uint32_t>(b_idx)};
+        uint64_t cur_seq = static_cast<uint64_t>(get_tensor_data<int32_t>(context_lens, 1, cl_idx));
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
             PTO2_SCOPE() {
@@ -136,7 +141,8 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                 const Tensor &mi_update = hub_outs.get_ref(2);
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn++) {
-                    uint64_t cur_block_idx = host_block_table[b_idx * block_num + bn];
+                    uint32_t bt_idx[2] = {static_cast<uint32_t>(b_idx), static_cast<uint32_t>(bn)};
+                    uint64_t cur_block_idx = static_cast<uint64_t>(get_tensor_data<int32_t>(block_table, 2, bt_idx));
                     uint64_t valid_len =
                         block_size < (cur_seq - bn * block_size) ? block_size : (cur_seq - bn * block_size);
                     uint32_t kv_shapes[2] = {static_cast<uint32_t>(block_size), static_cast<uint32_t>(head_dim)};

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -8,6 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+
 // Batched PV Matmul Kernel: for each batch b, pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
 // Processes batch_count batches in a single kernel invocation.
@@ -24,6 +25,7 @@
 
 #include "tensor.h"
 
+// NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
 #ifndef __gm__
@@ -31,19 +33,18 @@ using namespace pto;
 #endif
 
 #ifndef __aicore__
-#define __aicore__ [aicore]
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
 #endif
 
 template <int M, int K, int N>
 static __aicore__ void pv_matmul_batch_impl(
-    __gm__ Tensor *pij_batch, __gm__ Tensor *value_cache, __gm__ Tensor *oi_new_batch, uint64_t block_table_ptr,
+    __gm__ Tensor *pij_batch, __gm__ Tensor *value_cache, __gm__ Tensor *block_table_t, __gm__ Tensor *oi_new_batch,
     uint64_t batch_count, uint64_t block_idx, uint64_t block_num, uint64_t batch_start
 ) {
     __gm__ bfloat16_t *pij_base = reinterpret_cast<__gm__ bfloat16_t *>(pij_batch->buffer.addr);
     __gm__ bfloat16_t *val_base = reinterpret_cast<__gm__ bfloat16_t *>(value_cache->buffer.addr);
     __gm__ float *oi_base = reinterpret_cast<__gm__ float *>(oi_new_batch->buffer.addr);
-    // Block table values are always non-negative (physical block indices)
-    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_ptr);
+    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr);
 
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
@@ -71,7 +72,7 @@ static __aicore__ void pv_matmul_batch_impl(
     for (uint64_t b = 0; b < batch_count; b++) {
         __gm__ bfloat16_t *pij_addr = pij_base + b * M * K;
         int32_t phys_block = bt[(batch_start + b) * block_num + block_idx];
-        __gm__ bfloat16_t *vj_addr = val_base + (uint64_t)phys_block * K * N;
+        __gm__ bfloat16_t *vj_addr = val_base + static_cast<uint64_t>(phys_block) * K * N;
         __gm__ float *oi_addr = oi_base + b * M * N;
 
         GlobalA pijGlobal(pij_addr);
@@ -106,8 +107,8 @@ static __aicore__ void pv_matmul_batch_impl(
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ Tensor *pij_batch = reinterpret_cast<__gm__ Tensor *>(args[0]);
     __gm__ Tensor *value_cache = reinterpret_cast<__gm__ Tensor *>(args[1]);
-    __gm__ Tensor *oi_new_batch = reinterpret_cast<__gm__ Tensor *>(args[2]);
-    uint64_t block_table_ptr = static_cast<uint64_t>(args[3]);
+    __gm__ Tensor *block_table_t = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *oi_new_batch = reinterpret_cast<__gm__ Tensor *>(args[3]);
     uint64_t batch_count = static_cast<uint64_t>(args[4]);
     uint64_t block_idx = static_cast<uint64_t>(args[5]);
     uint64_t block_num = static_cast<uint64_t>(args[6]);
@@ -117,11 +118,11 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
 
     if (q_tile_size == 16) {
         pv_matmul_batch_impl<16, 128, 128>(
-            pij_batch, value_cache, oi_new_batch, block_table_ptr, batch_count, block_idx, block_num, batch_start
+            pij_batch, value_cache, block_table_t, oi_new_batch, batch_count, block_idx, block_num, batch_start
         );
     } else {
         pv_matmul_batch_impl<64, 64, 128>(
-            pij_batch, value_cache, oi_new_batch, block_table_ptr, batch_count, block_idx, block_num, batch_start
+            pij_batch, value_cache, block_table_t, oi_new_batch, batch_count, block_idx, block_num, batch_start
         );
     }
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -8,6 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+
 // Batched QK Matmul Kernel: for each batch b, qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
 // Processes batch_count batches in a single kernel invocation.
@@ -24,6 +25,7 @@
 
 #include "tensor.h"
 
+// NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
 #ifndef __gm__
@@ -31,20 +33,19 @@ using namespace pto;
 #endif
 
 #ifndef __aicore__
-#define __aicore__ [aicore]
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
 #endif
 
 template <int M, int K, int N>
 static __aicore__ void qk_matmul_batch_impl(
-    __gm__ Tensor *query, __gm__ Tensor *key_cache, __gm__ Tensor *sij_batch, uint64_t block_table_ptr,
+    __gm__ Tensor *query, __gm__ Tensor *key_cache, __gm__ Tensor *block_table_t, __gm__ Tensor *sij_batch,
     uint64_t batch_count, uint64_t block_idx, uint64_t q_offset, uint64_t block_num, uint64_t num_heads,
     uint64_t batch_start
 ) {
     __gm__ bfloat16_t *query_base = reinterpret_cast<__gm__ bfloat16_t *>(query->buffer.addr);
     __gm__ bfloat16_t *key_base = reinterpret_cast<__gm__ bfloat16_t *>(key_cache->buffer.addr);
     __gm__ float *sij_base = reinterpret_cast<__gm__ float *>(sij_batch->buffer.addr);
-    // Block table values are always non-negative (physical block indices)
-    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_ptr);
+    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr);
 
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
@@ -72,7 +73,7 @@ static __aicore__ void qk_matmul_batch_impl(
     for (uint64_t b = 0; b < batch_count; b++) {
         __gm__ bfloat16_t *qi_addr = query_base + ((batch_start + b) * num_heads + q_offset) * K;
         int32_t phys_block = bt[(batch_start + b) * block_num + block_idx];
-        __gm__ bfloat16_t *kj_addr = key_base + (uint64_t)phys_block * N * K;
+        __gm__ bfloat16_t *kj_addr = key_base + static_cast<uint64_t>(phys_block) * N * K;
         __gm__ float *sij_addr = sij_base + b * M * N;
 
         GlobalA qiGlobal(qi_addr);
@@ -108,8 +109,8 @@ static __aicore__ void qk_matmul_batch_impl(
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ Tensor *query = reinterpret_cast<__gm__ Tensor *>(args[0]);
     __gm__ Tensor *key_cache = reinterpret_cast<__gm__ Tensor *>(args[1]);
-    __gm__ Tensor *sij_batch = reinterpret_cast<__gm__ Tensor *>(args[2]);
-    uint64_t block_table_ptr = static_cast<uint64_t>(args[3]);
+    __gm__ Tensor *block_table_t = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *sij_batch = reinterpret_cast<__gm__ Tensor *>(args[3]);
     uint64_t batch_count = static_cast<uint64_t>(args[4]);
     uint64_t block_idx = static_cast<uint64_t>(args[5]);
     uint64_t q_offset = static_cast<uint64_t>(args[6]);
@@ -121,12 +122,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
 
     if (q_tile_size == 16) {
         qk_matmul_batch_impl<16, 128, 128>(
-            query, key_cache, sij_batch, block_table_ptr, batch_count, block_idx, q_offset, block_num, num_heads,
+            query, key_cache, block_table_t, sij_batch, batch_count, block_idx, q_offset, block_num, num_heads,
             batch_start
         );
     } else {
         qk_matmul_batch_impl<64, 128, 64>(
-            query, key_cache, sij_batch, block_table_ptr, batch_count, block_idx, q_offset, block_num, num_heads,
+            query, key_cache, block_table_t, sij_batch, batch_count, block_idx, q_offset, block_num, num_heads,
             batch_start
         );
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_softmax_prepare.cpp
@@ -8,6 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+
 // Batched Softmax Preparation Kernel (AIV)
 //
 // Processes batch_count batches in a single kernel invocation.
@@ -28,6 +29,7 @@
 
 #include "tensor.h"
 
+// NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
 #ifndef __gm__
@@ -35,19 +37,19 @@ using namespace pto;
 #endif
 
 #ifndef __aicore__
-#define __aicore__ [aicore]
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
 #endif
 
 template <int M, int N>
 static __aicore__ void softmax_prepare_batch_impl(
-    __gm__ Tensor *sij_batch, __gm__ Tensor *pij_batch, __gm__ Tensor *mij_batch, __gm__ Tensor *lij_batch,
-    float scale_value, uint64_t context_lens_ptr, uint64_t batch_count, uint64_t block_idx, uint64_t batch_start
+    __gm__ Tensor *sij_batch, __gm__ Tensor *context_lens_t, __gm__ Tensor *pij_batch, __gm__ Tensor *mij_batch,
+    __gm__ Tensor *lij_batch, float scale_value, uint64_t batch_count, uint64_t block_idx, uint64_t batch_start
 ) {
     __gm__ float *sij_base = reinterpret_cast<__gm__ float *>(sij_batch->buffer.addr);
     __gm__ bfloat16_t *pij_base = reinterpret_cast<__gm__ bfloat16_t *>(pij_batch->buffer.addr);
     __gm__ float *mij_base = reinterpret_cast<__gm__ float *>(mij_batch->buffer.addr);
     __gm__ float *lij_base = reinterpret_cast<__gm__ float *>(lij_batch->buffer.addr);
-    __gm__ int32_t *ctx_lens = reinterpret_cast<__gm__ int32_t *>(context_lens_ptr);
+    __gm__ int32_t *ctx_lens = reinterpret_cast<__gm__ int32_t *>(context_lens_t->buffer.addr);
 
     constexpr int kAlignedRows = ((M * sizeof(float) + 31) / 32) * (32 / sizeof(float));
 
@@ -82,8 +84,8 @@ static __aicore__ void softmax_prepare_batch_impl(
         int32_t cur_seq = ctx_lens[batch_start + b];
         uint64_t start = block_idx * N;
         uint64_t valid_len = 0;
-        if (start < (uint64_t)cur_seq) {
-            uint64_t remaining = (uint64_t)cur_seq - start;
+        if (start < static_cast<uint64_t>(cur_seq)) {
+            uint64_t remaining = static_cast<uint64_t>(cur_seq) - start;
             valid_len = (remaining < N) ? remaining : N;
         }
 
@@ -161,16 +163,16 @@ static __aicore__ void softmax_prepare_batch_impl(
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ Tensor *sij_batch = reinterpret_cast<__gm__ Tensor *>(args[0]);
-    __gm__ Tensor *pij_batch = reinterpret_cast<__gm__ Tensor *>(args[1]);
-    __gm__ Tensor *mij_batch = reinterpret_cast<__gm__ Tensor *>(args[2]);
-    __gm__ Tensor *lij_batch = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *context_lens_t = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *pij_batch = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *mij_batch = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *lij_batch = reinterpret_cast<__gm__ Tensor *>(args[4]);
     union {
         uint64_t u;
         float f;
     } scale_conv;
-    scale_conv.u = static_cast<uint64_t>(args[4]);
+    scale_conv.u = static_cast<uint64_t>(args[5]);
     float scale_value = scale_conv.f;
-    uint64_t context_lens_ptr = static_cast<uint64_t>(args[5]);
     uint64_t batch_count = static_cast<uint64_t>(args[6]);
     uint64_t block_idx = static_cast<uint64_t>(args[7]);
     uint64_t batch_start = static_cast<uint64_t>(args[8]);
@@ -179,13 +181,11 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
 
     if (q_tile_size == 16) {
         softmax_prepare_batch_impl<16, 128>(
-            sij_batch, pij_batch, mij_batch, lij_batch, scale_value, context_lens_ptr, batch_count, block_idx,
-            batch_start
+            sij_batch, context_lens_t, pij_batch, mij_batch, lij_batch, scale_value, batch_count, block_idx, batch_start
         );
     } else {
         softmax_prepare_batch_impl<64, 64>(
-            sij_batch, pij_batch, mij_batch, lij_batch, scale_value, context_lens_ptr, batch_count, block_idx,
-            batch_start
+            sij_batch, context_lens_t, pij_batch, mij_batch, lij_batch, scale_value, batch_count, block_idx, batch_start
         );
     }
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -43,7 +43,7 @@
 #include <algorithm>
 #include <cinttypes>
 
-#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+#include "pto_orchestration_api.h"
 
 #define FUNC_QK_MATMUL 0
 #define FUNC_SOFTMAX_PREPARE 1
@@ -56,7 +56,7 @@ extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
 aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
-    (void)orch_args;  // NOLINT(readability/casting)
+    (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
@@ -86,12 +86,18 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     void *vc_ptr = orch_args.tensor(2).data_as<void>();
     void *out_ptr = orch_args.tensor(5).data_as<void>();
 
-    int *host_block_table = orch_args.tensor(3).data_as<int>();
-    int *host_context_lens = orch_args.tensor(4).data_as<int>();
+    uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
+    Tensor block_table =
+        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+
+    uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
+    Tensor context_lens =
+        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
     uint64_t max_bn = 0;
     for (uint64_t b = 0; b < batch; b++) {
-        uint64_t cur_seq = host_context_lens[b];
+        uint32_t cl_idx[1] = {static_cast<uint32_t>(b)};
+        uint64_t cur_seq = static_cast<uint64_t>(get_tensor_data<int32_t>(context_lens, 1, cl_idx));
         uint64_t bn_b = (cur_seq + block_size - 1) / block_size;
         if (bn_b > max_bn) max_bn = bn_b;
     }
@@ -107,9 +113,6 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     Tensor key_cache = make_tensor_external(kc_ptr, key_cache_shapes, 2, data_type);
     Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type);
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32, true);
-
-    uint64_t bt_addr = reinterpret_cast<uintptr_t>(host_block_table);
-    uint64_t cl_addr = reinterpret_cast<uintptr_t>(host_context_lens);
 
     constexpr uint64_t IN_CORE_BATCH = 16;
     uint64_t num_chunks = (batch + IN_CORE_BATCH - 1) / IN_CORE_BATCH;
@@ -151,8 +154,8 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                         Arg params_qk;
                         params_qk.add_input(query);
                         params_qk.add_input(key_cache);
+                        params_qk.add_input(block_table);
                         params_qk.add_output(sij_ci);
-                        params_qk.add_scalar(bt_addr);
                         params_qk.add_scalar(chunk_bc);
                         params_qk.add_scalar(bn);
                         params_qk.add_scalar(q_offset);
@@ -164,11 +167,11 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
 
                         Arg params_sf;
                         params_sf.add_input(sij_b);
+                        params_sf.add_input(context_lens);
                         params_sf.add_output(pij_ci);
                         params_sf.add_output(vec_ci);
                         params_sf.add_output(vec_ci);
                         params_sf.add_scalar(scale_value);
-                        params_sf.add_scalar(cl_addr);
                         params_sf.add_scalar(chunk_bc);
                         params_sf.add_scalar(bn);
                         params_sf.add_scalar(batch_start);
@@ -180,8 +183,8 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                         Arg params_pv;
                         params_pv.add_input(pij_b);
                         params_pv.add_input(value_cache);
+                        params_pv.add_input(block_table);
                         params_pv.add_output(oi_new_ci);
-                        params_pv.add_scalar(bt_addr);
                         params_pv.add_scalar(chunk_bc);
                         params_pv.add_scalar(bn);
                         params_pv.add_scalar(block_num);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -25,7 +25,7 @@
 #include <cstdint>
 #include <cstring>
 
-#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+#include "pto_orchestration_api.h"
 
 #define FUNC_QK_MATMUL 0
 #define FUNC_SOFTMAX_PREPARE 1
@@ -58,7 +58,7 @@ extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
 aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
-    (void)orch_args;  // NOLINT(readability/casting)
+    (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
@@ -66,8 +66,8 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
 
 __attribute__((visibility("default"))) void
 aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;    // NOLINT(readability/casting)
-    (void)orch_thread_index;  // NOLINT(readability/casting)
+    (void)orch_thread_num;
+    (void)orch_thread_index;
     uint64_t prof_param_extract = 0;
     uint64_t prof_ext_tensor = 0;
     uint64_t prof_scope = 0;
@@ -121,8 +121,12 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
     CYCLE_COUNT_LAP(prof_ext_tensor);
 
-    int *host_block_table = orch_args.tensor(3).data_as<int>();
-    int *host_context_lens = orch_args.tensor(4).data_as<int>();
+    uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
+    Tensor block_table =
+        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+    uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
+    Tensor context_lens =
+        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
     // Create infos are loop-invariant — shapes depend only on q_tile/head_dim/block_size
     uint32_t tile2d_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
@@ -139,7 +143,8 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     int total_tasks = 0;
 
     for (uint64_t b_idx = 0; b_idx < batch; b_idx++) {
-        uint64_t cur_seq = host_context_lens[b_idx];
+        uint32_t cl_idx[1] = {static_cast<uint32_t>(b_idx)};
+        uint64_t cur_seq = static_cast<uint64_t>(get_tensor_data<int32_t>(context_lens, 1, cl_idx));
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
             PTO2_SCOPE() {
@@ -168,7 +173,8 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                 for (uint64_t bn = 0; bn < bn_this_batch; bn++) {
                     PTO2_SCOPE_GUARD();
 
-                    uint64_t cur_block_idx = host_block_table[b_idx * block_num + bn];
+                    uint32_t bt_idx[2] = {static_cast<uint32_t>(b_idx), static_cast<uint32_t>(bn)};
+                    uint64_t cur_block_idx = static_cast<uint64_t>(get_tensor_data<int32_t>(block_table, 2, bt_idx));
                     uint64_t valid_len = std::min(block_size, cur_seq - bn * block_size);
                     CYCLE_COUNT_LAP(prof_param_extract);
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -8,6 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+
 // SplitK PV Matmul Kernel: Accumulated P @ V across n_blocks
 //
 // Processes n_blocks blocks using SplitK accumulation pattern:
@@ -33,10 +34,12 @@
 // vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
 
 #include <cstdint>
+// NOLINTBEGIN(clang-diagnostic-error,bugprone-reserved-identifier,bugprone-easily-swappable-parameters,modernize-avoid-c-arrays,modernize-use-auto)
 #include <pto/pto-inst.hpp>
 
 #include "tensor.h"
 
+// NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
 #ifndef __gm__
@@ -44,13 +47,13 @@ using namespace pto;
 #endif
 
 #ifndef __aicore__
-#define __aicore__ [aicore]
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
 #endif
 
 template <int M, int K, int N>
 static __aicore__ void pv_matmul_n_impl(
     __gm__ bfloat16_t *pij_base, __gm__ bfloat16_t *val_base, __gm__ float *oi_base, uint64_t n_blocks,
-    __gm__ int32_t *block_table
+    __gm__ int32_t *bt, uint64_t bt_offset
 ) {
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, N, 1>>;
@@ -97,7 +100,7 @@ static __aicore__ void pv_matmul_n_impl(
     for (uint64_t i = 0; i < n_blocks; i++) {
         int cur = static_cast<int>(i % 2);
         GlobalA pijGlobal(pij_base + i * M * K);
-        GlobalB vjGlobal(val_base + block_table[i] * K * N);
+        GlobalB vjGlobal(val_base + bt[bt_offset + i] * K * N);
 
         // Stage 1: TLOAD (MTE2: GM → L1[cur])
         // Wait for MTE1 to release L1[cur] (reverse dep from previous iteration)
@@ -144,19 +147,22 @@ static __aicore__ void pv_matmul_n_impl(
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ Tensor *pij_buf = reinterpret_cast<__gm__ Tensor *>(args[0]);
     __gm__ Tensor *value_cache = reinterpret_cast<__gm__ Tensor *>(args[1]);
-    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[2]);
-    uint64_t n_blocks = static_cast<uint64_t>(args[3]);
-    __gm__ int32_t *block_table = reinterpret_cast<__gm__ int32_t *>(args[4]);
+    __gm__ Tensor *block_table_t = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    uint64_t n_blocks = static_cast<uint64_t>(args[4]);
+    uint64_t bt_offset = static_cast<uint64_t>(args[5]);
 
     __gm__ bfloat16_t *pij_base = reinterpret_cast<__gm__ bfloat16_t *>(pij_buf->buffer.addr) + pij_buf->start_offset;
     __gm__ bfloat16_t *val_base = reinterpret_cast<__gm__ bfloat16_t *>(value_cache->buffer.addr);
     __gm__ float *oi_base = reinterpret_cast<__gm__ float *>(oi_new->buffer.addr) + oi_new->start_offset;
+    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr);
 
     uint64_t q_tile_size = static_cast<uint64_t>(pij_buf->shapes[0]);
 
     if (q_tile_size == 16) {
-        pv_matmul_n_impl<16, 128, 128>(pij_base, val_base, oi_base, n_blocks, block_table);
+        pv_matmul_n_impl<16, 128, 128>(pij_base, val_base, oi_base, n_blocks, bt, bt_offset);
     } else {
-        pv_matmul_n_impl<64, 64, 128>(pij_base, val_base, oi_base, n_blocks, block_table);
+        pv_matmul_n_impl<64, 64, 128>(pij_base, val_base, oi_base, n_blocks, bt, bt_offset);
     }
 }
+// NOLINTEND(clang-diagnostic-error,bugprone-reserved-identifier,bugprone-easily-swappable-parameters,modernize-avoid-c-arrays,modernize-use-auto)

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -8,6 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+
 // Multi-block QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N) for each block
 //
 // Processes n_blocks blocks in a single kernel invocation.
@@ -27,10 +28,12 @@
 // Template: M=q_tile, K=head_dim, N=block_size
 
 #include <cstdint>
+// NOLINTBEGIN(clang-diagnostic-error,bugprone-reserved-identifier,bugprone-easily-swappable-parameters,modernize-use-auto)
 #include <pto/pto-inst.hpp>
 
 #include "tensor.h"
 
+// NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
 #ifndef __gm__
@@ -38,13 +41,13 @@ using namespace pto;
 #endif
 
 #ifndef __aicore__
-#define __aicore__ [aicore]
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
 #endif
 
 template <int M, int K, int N>
 static __aicore__ void qk_matmul_n_impl(
     __gm__ bfloat16_t *qi_base, __gm__ bfloat16_t *key_base, __gm__ float *sij_base, uint64_t n_blocks,
-    __gm__ int32_t *block_table
+    __gm__ int32_t *bt, uint64_t bt_offset
 ) {
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
@@ -74,7 +77,7 @@ static __aicore__ void qk_matmul_n_impl(
     TLOAD(aMatTile, qiGlobal);
 
     for (uint64_t i = 0; i < n_blocks; i++) {
-        GlobalB kjGlobal(key_base + block_table[i] * N * K);
+        GlobalB kjGlobal(key_base + bt[bt_offset + i] * N * K);
         GlobalOut sijGlobal(sij_base + i * M * N);
 
         // Load only B each iteration (qi already in L1 from hoist)
@@ -108,19 +111,22 @@ static __aicore__ void qk_matmul_n_impl(
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ Tensor *qi = reinterpret_cast<__gm__ Tensor *>(args[0]);
     __gm__ Tensor *key_cache = reinterpret_cast<__gm__ Tensor *>(args[1]);
-    __gm__ Tensor *sij_buf = reinterpret_cast<__gm__ Tensor *>(args[2]);
-    uint64_t n_blocks = static_cast<uint64_t>(args[3]);
-    __gm__ int32_t *block_table = reinterpret_cast<__gm__ int32_t *>(args[4]);
+    __gm__ Tensor *block_table_t = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *sij_buf = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    uint64_t n_blocks = static_cast<uint64_t>(args[4]);
+    uint64_t bt_offset = static_cast<uint64_t>(args[5]);
 
     __gm__ bfloat16_t *qi_base = reinterpret_cast<__gm__ bfloat16_t *>(qi->buffer.addr) + qi->start_offset;
     __gm__ bfloat16_t *key_base = reinterpret_cast<__gm__ bfloat16_t *>(key_cache->buffer.addr);
     __gm__ float *sij_base = reinterpret_cast<__gm__ float *>(sij_buf->buffer.addr) + sij_buf->start_offset;
+    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr);
 
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
 
     if (q_tile_size == 16) {
-        qk_matmul_n_impl<16, 128, 128>(qi_base, key_base, sij_base, n_blocks, block_table);
+        qk_matmul_n_impl<16, 128, 128>(qi_base, key_base, sij_base, n_blocks, bt, bt_offset);
     } else {
-        qk_matmul_n_impl<64, 128, 64>(qi_base, key_base, sij_base, n_blocks, block_table);
+        qk_matmul_n_impl<64, 128, 64>(qi_base, key_base, sij_base, n_blocks, bt, bt_offset);
     }
 }
+// NOLINTEND(clang-diagnostic-error,bugprone-reserved-identifier,bugprone-easily-swappable-parameters,modernize-use-auto)

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -27,7 +27,7 @@
 #include <cstdint>
 #include <cstring>
 
-#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+#include "pto_orchestration_api.h"
 
 #define N_UNROLL 64
 
@@ -70,7 +70,7 @@ extern "C" {
  */
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
 aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
-    (void)orch_args;  // NOLINT(readability/casting)
+    (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
@@ -78,8 +78,8 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
 
 __attribute__((visibility("default"))) void
 aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_num, int orch_thread_index) {
-    (void)orch_thread_num;    // NOLINT(readability/casting)
-    (void)orch_thread_index;  // NOLINT(readability/casting)
+    (void)orch_thread_num;
+    (void)orch_thread_index;
 #ifdef ENABLE_PROFILING
     uint64_t prof_param_extract = 0;
     uint64_t prof_ext_tensor = 0;
@@ -136,15 +136,16 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type, false);
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
 
-    int *host_block_table = orch_args.tensor(3).data_as<int>();
-    int *host_context_lens = orch_args.tensor(4).data_as<int>();
+    uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
+    Tensor block_table =
+        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+    uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
+    Tensor context_lens =
+        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
 #ifdef ENABLE_PROFILING
     CYCLE_COUNT_LAP(prof_ext_tensor);
 #endif
-
-    // Prefetch first block host_context_lens data into cache
-    __builtin_prefetch(&host_context_lens[0], 0, 3);
 
     // Create infos are loop-invariant — shapes depend only on q_tile/head_dim
     uint32_t oi_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
@@ -158,15 +159,10 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
 #endif
 
     for (uint64_t b_idx = 0; b_idx < batch; b_idx++) {
-        uint64_t cur_seq = host_context_lens[b_idx];
+        uint32_t cl_idx[1] = {static_cast<uint32_t>(b_idx)};
+        uint64_t cur_seq = static_cast<uint64_t>(get_tensor_data<int32_t>(context_lens, 1, cl_idx));
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
-        // Pre-compute block table base pointer for this batch
-        int *bt_base = host_block_table + b_idx * block_num;
 
-        // Prefetch next block host_context_lens data while processing current batch
-        if (b_idx + 1 < batch) {
-            __builtin_prefetch(&host_context_lens[b_idx + 1], 0, 3);
-        }
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
             CYCLE_COUNT_LAP(prof_scope_and_loop);
             PTO2_SCOPE() {
@@ -221,9 +217,10 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                     params_qk.reset();
                     params_qk.add_input(qi);
                     params_qk.add_input(key_cache);
+                    params_qk.add_input(block_table);
                     params_qk.add_output(sij_buf_ci);
                     params_qk.add_scalar(n_blocks);
-                    params_qk.add_scalar(reinterpret_cast<uint64_t>(bt_base + bn));
+                    params_qk.add_scalar(b_idx * block_num + bn);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
                     const Tensor &sij_buf = qk_outs.get_ref(0);
@@ -264,9 +261,10 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                     params_pv.reset();
                     params_pv.add_input(pij_buf);
                     params_pv.add_input(value_cache);
+                    params_pv.add_input(block_table);
                     params_pv.add_output(tile2d_ci);
                     params_pv.add_scalar(n_blocks);
-                    params_pv.add_scalar(reinterpret_cast<uint64_t>(bt_base + bn));
+                    params_pv.add_scalar(b_idx * block_num + bn);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                     const Tensor &oi_new = pv_outs.get_ref(0);

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -121,8 +121,12 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
     CYCLE_COUNT_LAP(prof_ext_tensor);
 
-    int *host_block_table = orch_args.tensor(3).data_as<int>();
-    int *host_context_lens = orch_args.tensor(4).data_as<int>();
+    uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
+    Tensor block_table =
+        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+    uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
+    Tensor context_lens =
+        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
     // Create infos are loop-invariant — shapes depend only on q_tile/head_dim/block_size
     uint32_t tile2d_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
@@ -139,7 +143,8 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     int total_tasks = 0;
 
     for (uint64_t b_idx = 0; b_idx < batch; b_idx++) {
-        uint64_t cur_seq = host_context_lens[b_idx];
+        uint32_t cl_idx[1] = {static_cast<uint32_t>(b_idx)};
+        uint64_t cur_seq = static_cast<uint64_t>(get_tensor_data<int32_t>(context_lens, 1, cl_idx));
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
             PTO2_SCOPE() {
@@ -168,7 +173,8 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                 for (uint64_t bn = 0; bn < bn_this_batch; bn++) {
                     PTO2_SCOPE_GUARD();
 
-                    uint64_t cur_block_idx = host_block_table[b_idx * block_num + bn];
+                    uint32_t bt_idx[2] = {static_cast<uint32_t>(b_idx), static_cast<uint32_t>(bn)};
+                    uint64_t cur_block_idx = static_cast<uint64_t>(get_tensor_data<int32_t>(block_table, 2, bt_idx));
                     uint64_t valid_len = std::min(block_size, cur_seq - bn * block_size);
                     CYCLE_COUNT_LAP(prof_param_extract);
 

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -33,10 +33,12 @@
 // vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
 
 #include <cstdint>
+// NOLINTBEGIN(clang-diagnostic-error,bugprone-reserved-identifier,bugprone-easily-swappable-parameters,modernize-avoid-c-arrays,modernize-use-auto)
 #include <pto/pto-inst.hpp>
 
 #include "tensor.h"
 
+// NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
 #ifndef __gm__
@@ -50,7 +52,7 @@ using namespace pto;
 template <int M, int K, int N>
 static __aicore__ void pv_matmul_n_impl(
     __gm__ bfloat16_t *pij_base, __gm__ bfloat16_t *val_base, __gm__ float *oi_base, uint64_t n_blocks,
-    __gm__ int32_t *block_table
+    __gm__ int32_t *bt, uint64_t bt_offset
 ) {
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, N, 1>>;
@@ -97,7 +99,7 @@ static __aicore__ void pv_matmul_n_impl(
     for (uint64_t i = 0; i < n_blocks; i++) {
         int cur = static_cast<int>(i % 2);
         GlobalA pijGlobal(pij_base + i * M * K);
-        GlobalB vjGlobal(val_base + block_table[i] * K * N);
+        GlobalB vjGlobal(val_base + bt[bt_offset + i] * K * N);
 
         // Stage 1: TLOAD (MTE2: GM → L1[cur])
         // Wait for MTE1 to release L1[cur] (reverse dep from previous iteration)
@@ -141,19 +143,23 @@ static __aicore__ void pv_matmul_n_impl(
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ Tensor *pij_buf = reinterpret_cast<__gm__ Tensor *>(args[0]);
     __gm__ Tensor *value_cache = reinterpret_cast<__gm__ Tensor *>(args[1]);
-    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[2]);
-    uint64_t n_blocks = static_cast<uint64_t>(args[3]);
-    __gm__ int32_t *block_table = reinterpret_cast<__gm__ int32_t *>(args[4]);
+    __gm__ Tensor *block_table_t = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *oi_new = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    uint64_t n_blocks = static_cast<uint64_t>(args[4]);
+    uint64_t bt_offset = static_cast<uint64_t>(args[5]);
 
     __gm__ bfloat16_t *pij_base = reinterpret_cast<__gm__ bfloat16_t *>(pij_buf->buffer.addr) + pij_buf->start_offset;
     __gm__ bfloat16_t *val_base = reinterpret_cast<__gm__ bfloat16_t *>(value_cache->buffer.addr);
     __gm__ float *oi_base = reinterpret_cast<__gm__ float *>(oi_new->buffer.addr) + oi_new->start_offset;
+    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr);
 
     uint64_t q_tile_size = static_cast<uint64_t>(pij_buf->shapes[0]);
 
     if (q_tile_size == 16) {
-        pv_matmul_n_impl<16, 128, 128>(pij_base, val_base, oi_base, n_blocks, block_table);
+        pv_matmul_n_impl<16, 128, 128>(pij_base, val_base, oi_base, n_blocks, bt, bt_offset);
     } else {
-        pv_matmul_n_impl<64, 64, 128>(pij_base, val_base, oi_base, n_blocks, block_table);
+        pv_matmul_n_impl<64, 64, 128>(pij_base, val_base, oi_base, n_blocks, bt, bt_offset);
     }
 }
+
+// NOLINTEND(clang-diagnostic-error,bugprone-reserved-identifier,bugprone-easily-swappable-parameters,modernize-avoid-c-arrays,modernize-use-auto)

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -27,10 +27,12 @@
 // Template: M=q_tile, K=head_dim, N=block_size
 
 #include <cstdint>
+// NOLINTBEGIN(clang-diagnostic-error,bugprone-reserved-identifier,bugprone-easily-swappable-parameters,modernize-avoid-c-arrays,modernize-use-auto)
 #include <pto/pto-inst.hpp>
 
 #include "tensor.h"
 
+// NOLINTNEXTLINE(build/namespaces)
 using namespace pto;
 
 #ifndef __gm__
@@ -44,7 +46,7 @@ using namespace pto;
 template <int M, int K, int N>
 static __aicore__ void qk_matmul_n_impl(
     __gm__ bfloat16_t *qi_base, __gm__ bfloat16_t *key_base, __gm__ float *sij_base, uint64_t n_blocks,
-    __gm__ int32_t *block_table
+    __gm__ int32_t *bt, uint64_t bt_offset
 ) {
     using GlobalA = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
     using GlobalB = GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
@@ -74,7 +76,7 @@ static __aicore__ void qk_matmul_n_impl(
     TLOAD(aMatTile, qiGlobal);
 
     for (uint64_t i = 0; i < n_blocks; i++) {
-        GlobalB kjGlobal(key_base + block_table[i] * N * K);
+        GlobalB kjGlobal(key_base + bt[bt_offset + i] * N * K);
         GlobalOut sijGlobal(sij_base + i * M * N);
 
         // Load only B each iteration (qi already in L1 from hoist)
@@ -106,19 +108,23 @@ static __aicore__ void qk_matmul_n_impl(
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ Tensor *qi = reinterpret_cast<__gm__ Tensor *>(args[0]);
     __gm__ Tensor *key_cache = reinterpret_cast<__gm__ Tensor *>(args[1]);
-    __gm__ Tensor *sij_buf = reinterpret_cast<__gm__ Tensor *>(args[2]);
-    uint64_t n_blocks = static_cast<uint64_t>(args[3]);
-    __gm__ int32_t *block_table = reinterpret_cast<__gm__ int32_t *>(args[4]);
+    __gm__ Tensor *block_table_t = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *sij_buf = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    uint64_t n_blocks = static_cast<uint64_t>(args[4]);
+    uint64_t bt_offset = static_cast<uint64_t>(args[5]);
 
     __gm__ bfloat16_t *qi_base = reinterpret_cast<__gm__ bfloat16_t *>(qi->buffer.addr) + qi->start_offset;
     __gm__ bfloat16_t *key_base = reinterpret_cast<__gm__ bfloat16_t *>(key_cache->buffer.addr);
     __gm__ float *sij_base = reinterpret_cast<__gm__ float *>(sij_buf->buffer.addr) + sij_buf->start_offset;
+    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr);
 
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
 
     if (q_tile_size == 16) {
-        qk_matmul_n_impl<16, 128, 128>(qi_base, key_base, sij_base, n_blocks, block_table);
+        qk_matmul_n_impl<16, 128, 128>(qi_base, key_base, sij_base, n_blocks, bt, bt_offset);
     } else {
-        qk_matmul_n_impl<64, 128, 64>(qi_base, key_base, sij_base, n_blocks, block_table);
+        qk_matmul_n_impl<64, 128, 64>(qi_base, key_base, sij_base, n_blocks, bt, bt_offset);
     }
 }
+
+// NOLINTEND(clang-diagnostic-error,bugprone-reserved-identifier,bugprone-easily-swappable-parameters,modernize-avoid-c-arrays,modernize-use-auto)

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -136,15 +136,16 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
     Tensor value_cache = make_tensor_external(vc_ptr, value_cache_shapes, 2, data_type, false);
     Tensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
 
-    int *host_block_table = orch_args.tensor(3).data_as<int>();
-    int *host_context_lens = orch_args.tensor(4).data_as<int>();
+    uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
+    Tensor block_table =
+        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+    uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
+    Tensor context_lens =
+        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
 #ifdef ENABLE_PROFILING
     CYCLE_COUNT_LAP(prof_ext_tensor);
 #endif
-
-    // Prefetch first block host_context_lens data into cache
-    __builtin_prefetch(&host_context_lens[0], 0, 3);
 
     // Create infos are loop-invariant — shapes depend only on q_tile/head_dim
     uint32_t oi_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
@@ -158,15 +159,9 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
 #endif
 
     for (uint64_t b_idx = 0; b_idx < batch; b_idx++) {
-        uint64_t cur_seq = host_context_lens[b_idx];
+        uint32_t cl_idx[1] = {static_cast<uint32_t>(b_idx)};
+        uint64_t cur_seq = static_cast<uint64_t>(get_tensor_data<int32_t>(context_lens, 1, cl_idx));
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
-        // Pre-compute block table base pointer for this batch
-        int *bt_base = host_block_table + b_idx * block_num;
-
-        // Prefetch next block host_context_lens data while processing current batch
-        if (b_idx + 1 < batch) {
-            __builtin_prefetch(&host_context_lens[b_idx + 1], 0, 3);
-        }
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
             CYCLE_COUNT_LAP(prof_scope_and_loop);
             PTO2_SCOPE() {
@@ -221,9 +216,10 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                     params_qk.reset();
                     params_qk.add_input(qi);
                     params_qk.add_input(key_cache);
+                    params_qk.add_input(block_table);
                     params_qk.add_output(sij_buf_ci);
                     params_qk.add_scalar(n_blocks);
-                    params_qk.add_scalar(reinterpret_cast<uint64_t>(bt_base + bn));
+                    params_qk.add_scalar(b_idx * block_num + bn);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
                     const Tensor &sij_buf = qk_outs.get_ref(0);
@@ -264,9 +260,10 @@ aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args, int orch_thread_
                     params_pv.reset();
                     params_pv.add_input(pij_buf);
                     params_pv.add_input(value_cache);
+                    params_pv.add_input(block_table);
                     params_pv.add_output(tile2d_ci);
                     params_pv.add_scalar(n_blocks);
-                    params_pv.add_scalar(reinterpret_cast<uint64_t>(bt_base + bn));
+                    params_pv.add_scalar(b_idx * block_num + bn);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                     const Tensor &oi_new = pv_outs.get_ref(0);


### PR DESCRIPTION
## Summary
- Replace raw GM pointers (uint64_t) with Tensor* for block_table and
  context_lens in batch QK/PV matmul and softmax_prepare kernels
- Sync orchestration argument order and mirrored ST / unroll test kernels
- Add CANN license headers and cpplint cleanups (NOLINT, static_cast)

## Testing
- [x] All tests pass (6/6 tensormap_and_ringbuffer sim examples)
- [x] Pre-commit hooks pass
- [x] Code reviewed and formatted with clang-format/cpplint

## Related Issues
Updates Tensor interface in paged attention kernels to align with runtime conventions.