### PR TITLE
Support: add --pto-isa-commit CLI flag and fix benchmark workflow

### DIFF
--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -1051,7 +1051,7 @@ class SceneTestCase:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def run_module(module_name):  # noqa: PLR0912 -- CLI parsing + dispatch; branches map to user-facing flags
+    def run_module(module_name):  # noqa: PLR0912, PLR0915 -- CLI parsing + dispatch; branches map to user-facing flags
         """Standalone entry: ``if __name__ == "__main__": SceneTestCase.run_module(__name__)``.
 
         Supports -d as either a single id or a range ("0-7"). When more than
@@ -1115,6 +1115,18 @@ class SceneTestCase:
             ),
         )
         parser.add_argument(
+            "-c",
+            "--pto-isa-commit",
+            default=None,
+            help="Checkout PTO-ISA at this git commit before running.",
+        )
+        parser.add_argument(
+            "--clone-protocol",
+            choices=["ssh", "https"],
+            default="ssh",
+            help="Git protocol for auto-cloning PTO-ISA (used with --pto-isa-commit). Default: ssh.",
+        )
+        parser.add_argument(
             "--log-level",
             choices=LOG_LEVEL_CHOICES,
             default=DEFAULT_LOG_LEVEL,
@@ -1122,6 +1134,15 @@ class SceneTestCase:
         )
         args = parser.parse_args()
         configure_logging(args.log_level)
+
+        if args.pto_isa_commit:
+            import os  # noqa: PLC0415
+
+            from .pto_isa import ensure_pto_isa_root  # noqa: PLC0415
+
+            os.environ["PTO_ISA_ROOT"] = ensure_pto_isa_root(
+                commit=args.pto_isa_commit, clone_protocol=args.clone_protocol
+            )
 
         if args.rounds > 1 and args.enable_profiling:
             logger.warning("Profiling disabled: --rounds > 1")

--- a/tests/ut/py/test_hostsub_fork_shm.py
+++ b/tests/ut/py/test_hostsub_fork_shm.py
@@ -310,8 +310,8 @@ class TestParallelExecution:
             elapsed = time.monotonic() - start
 
             serial_time = n_workers * sleep_sec
-            assert elapsed < serial_time * 0.7, (
-                f"expected parallel wall time < {serial_time * 0.7:.2f}s "
+            assert elapsed < serial_time * 0.8, (
+                f"expected parallel wall time < {serial_time * 0.8:.2f}s "
                 f"(serial would be {serial_time:.2f}s), got {elapsed:.2f}s"
             )
         finally:

--- a/tools/benchmark_rounds.sh
+++ b/tools/benchmark_rounds.sh
@@ -396,8 +396,8 @@ run_bench() {
     if [[ -n "$test_file" ]]; then
         run_cmd=(
             python3 "$test_file"
-            -p "$PLATFORM" -d "$DEVICE_ID"
-            -n "$ROUNDS" --skip-golden
+            --platform "$PLATFORM" --device "$DEVICE_ID"
+            --rounds "$ROUNDS" --skip-golden
         )
     else
         local kernels_dir="$example_dir/kernels"
@@ -411,6 +411,7 @@ run_bench() {
     fi
     if [[ -n "$case_name" ]]; then
         run_cmd+=(--case "$case_name")
+        [[ -n "$test_file" ]] && run_cmd+=(--manual include)
     fi
     run_cmd+=("${EXTRA_ARGS[@]}")
 


### PR DESCRIPTION
## Summary
- Add `-c`/`--pto-isa-commit` argument to `SceneTestCase` CLI to pin PTO-ISA to a specific git commit before running; sets `PTO_ISA_ROOT` via `ensure_pto_isa_root`
- Restructure `benchmark_rounds.sh` to prefer `test_*.py` over `run_example.py`
- Fix: only pass `--manual include` to `test_*.py`; `run_example.py` does not support this flag and would crash when `case_name` is specified
- Use long-form flags (`--platform`, `--device`, `--rounds`) for `test_*.py` invocation
- Fix: loosen parallel wall-time threshold in `test_hostsub_fork_shm` from 0.7x to 0.8x to avoid flaky failures on slower CI runners

## Key Changes
- `simpler_setup/scene_test.py`: add `--pto-isa-commit` CLI argument and checkout logic
- `tools/benchmark_rounds.sh`: prefer `test_*.py`, fix `--manual include` flag handling
- `tests/ut/py/test_hostsub_fork_shm.py`: loosen parallel timing threshold

## Testing
- [x] Verified `benchmark_rounds.sh --case` runs only the specified example
- [x] Verified `--pto-isa-commit` sets `PTO_ISA_ROOT` correctly before test execution