### PR TITLE
Refactor: rename SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR -> SIMPLER_OUTPUT_DIR

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -244,16 +244,14 @@ def pytest_configure(config):
         # Python post-processing always point at the same filesystem location
         # regardless of where pytest was invoked. Only set if the parent
         # hasn't already scoped us into a subprocess dir.
-        if "SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR" not in os.environ:
-            os.environ["SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR"] = str(
-                config.rootpath / "outputs" / f"l2_perf_records_{worker_id}"
-            )
+        if "SIMPLER_OUTPUT_DIR" not in os.environ:
+            os.environ["SIMPLER_OUTPUT_DIR"] = str(config.rootpath / "outputs" / f"l2_perf_records_{worker_id}")
         # else: more xdist workers than devices — fall through with original range;
         # DevicePool will fail clearly if the test tries to allocate.
 
     # Note: profiling + parallelism used to be blocked here because perf files
     # shared a process-global directory. The test dispatcher now scopes each
-    # subprocess to its own SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR (see _dispatch_test_phases and
+    # subprocess to its own SIMPLER_OUTPUT_DIR (see _dispatch_test_phases and
     # the xdist slicing above) and flatten_l2_perf_records_subdirs reassembles outputs/
     # at the end, so the combination is now safe.
 
@@ -387,7 +385,7 @@ class _ResourceJob(typing.NamedTuple):
     """One device-allocating subprocess job fed into Resource phase.
 
     ``kind`` drives only two things: the ``--level 3`` filter added to the
-    child command (for L3 classes) and the ``SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR``
+    child command (for L3 classes) and the ``SIMPLER_OUTPUT_DIR``
     prefix. The dispatch itself (bin-pack over ``--device`` pool,
     ``run_jobs`` scheduling, fail-fast semantics) is identical.
     """
@@ -583,14 +581,12 @@ def _dispatch_test_phases(session, resource_specs):  # noqa: PLR0912
                     cmd.extend(["--platform", platform])
                 return cmd
 
-            # SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR scopes this job's perf files to its own
+            # SIMPLER_OUTPUT_DIR scopes this job's perf files to its own
             # subdir so concurrent jobs can't collide on filename.
             safe_nodeid = spec.nodeid.replace("/", "_").replace(":", "_").replace(".", "_")
             child_env = {
                 **os.environ,
-                "SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR": str(
-                    cfg.rootpath / "outputs" / f"l2_perf_records_{spec.kind}_{safe_nodeid}"
-                ),
+                "SIMPLER_OUTPUT_DIR": str(cfg.rootpath / "outputs" / f"l2_perf_records_{spec.kind}_{safe_nodeid}"),
             }
             jobs.append(
                 _ps.Job(

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -240,7 +240,7 @@ A single file can declare both L2 and L3 classes; they're grouped by `(runtime, 
 
 ### Profiling under parallelism
 
-`--enable-l2-swimlane` writes `outputs/l2_perf_records_*.json`; the runtime's filename has second-precision timestamps, so two subprocesses producing perf files in the same second would collide on one path. The dispatcher sidesteps this by giving each subprocess its own directory via the `SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR` env var:
+`--enable-l2-swimlane` writes `outputs/l2_perf_records_*.json`; the runtime's filename has second-precision timestamps, so two subprocesses producing perf files in the same second would collide on one path. The dispatcher sidesteps this by giving each subprocess its own directory via the `SIMPLER_OUTPUT_DIR` env var:
 
 | Subprocess | Scoped directory |
 | ---------- | ---------------- |
@@ -251,7 +251,7 @@ A single file can declare both L2 and L3 classes; they're grouped by `(runtime, 
 
 After all phases drain, `flatten_l2_perf_records_subdirs()` moves the contents of every `outputs/l2_perf_records_*/` subdir back to `outputs/` so downstream tools (`swimlane_converter.py`, CI artifact upload) still find everything in one place. Name collisions on the destination keep the first writer and suffix the loser with the subdir tag (e.g. `l2_perf_records_…__gw1.json`) so nothing is silently overwritten.
 
-The C++ runtime honors `SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR` at `L2PerfCollector::export_swimlane_json` — empty/unset falls through to the caller-supplied path (historical `outputs/` default), so standalone invocations that don't set the env var behave exactly as before.
+The C++ runtime honors `SIMPLER_OUTPUT_DIR` at `L2PerfCollector::export_swimlane_json` — empty/unset falls through to the caller-supplied path (historical `outputs/` default), so standalone invocations that don't set the env var behave exactly as before.
 
 ### Dispatcher skip conditions (normal pytest runs)
 

--- a/simpler_setup/parallel_scheduler.py
+++ b/simpler_setup/parallel_scheduler.py
@@ -380,7 +380,7 @@ def format_device_range(ids: list[int]) -> str:
 def flatten_l2_perf_records_subdirs(outputs_dir: str | os.PathLike = "outputs") -> int:
     """Move files from ``outputs/l2_perf_records_*`` subdirs back up to ``outputs/``.
 
-    The test dispatcher scopes each subprocess's ``SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR`` to a
+    The test dispatcher scopes each subprocess's ``SIMPLER_OUTPUT_DIR`` to a
     distinct ``outputs/l2_perf_records_<tag>/`` subdir so concurrent perf file writes
     can't collide on second-precision filenames. After all phases drain,
     call this to flatten the subdirs back to the historical ``outputs/``

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -489,12 +489,12 @@ def _project_root() -> Path:
 def _outputs_dir() -> Path:
     """Return the directory where l2_perf_records_*.json lands.
 
-    Honors ``SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR`` so the parallel test dispatcher can give each
+    Honors ``SIMPLER_OUTPUT_DIR`` so the parallel test dispatcher can give each
     subprocess its own isolated output directory. Absolute paths pass through;
     relative paths are interpreted against the project root. Empty/unset env
     var falls back to ``<project>/outputs`` (the historical default).
     """
-    env = os.environ.get("SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR")
+    env = os.environ.get("SIMPLER_OUTPUT_DIR")
     if env:
         p = Path(env)
         return p if p.is_absolute() else _project_root() / p
@@ -1253,7 +1253,7 @@ class SceneTestCase:
                 sys.exit(2)
         # Note: profiling + parallelism used to be blocked here because perf
         # files shared a process-global directory. The test dispatcher now scopes
-        # each subprocess to its own SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR so the combination
+        # each subprocess to its own SIMPLER_OUTPUT_DIR so the combination
         # is safe.
 
         module = sys.modules[module_name]
@@ -1436,9 +1436,7 @@ def _dispatch_test_phases_standalone(module_name, selected_by_cls, args):  # noq
         # own CWD) and Python post-processing agree on the location.
         child_env = {
             **os.environ,
-            "SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR": str(
-                _project_root() / "outputs" / f"l2_perf_records_l3_{cls.__name__}"
-            ),
+            "SIMPLER_OUTPUT_DIR": str(_project_root() / "outputs" / f"l2_perf_records_l3_{cls.__name__}"),
         }
         l3_jobs.append(Job(label=label, device_count=class_dev_count, build_cmd=_build, env=child_env))
 
@@ -1541,9 +1539,7 @@ def _dispatch_test_phases_standalone(module_name, selected_by_cls, args):  # noq
             # Python post-processing agree on the filesystem location.
             child_env = {
                 **os.environ,
-                "SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR": str(
-                    _project_root() / "outputs" / f"l2_perf_records_l2_{rt}_dev{dev}"
-                ),
+                "SIMPLER_OUTPUT_DIR": str(_project_root() / "outputs" / f"l2_perf_records_l2_{rt}_dev{dev}"),
             }
             l2_jobs.append(Job(label=label, device_count=1, build_cmd=_build, env=child_env))
 

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -16,8 +16,9 @@ no repo checkout required.
 - **[device_log_resolver](#device_log_resolver)** — shared device-log path resolver library
 
 Auto-detection paths (`outputs/l2_perf_records_*.json`, `outputs/tensor_dump_*/`)
-are resolved relative to the **current working directory** — run these from the
-directory that holds your `outputs/`.
+are resolved against `$SIMPLER_OUTPUT_DIR` when set (the same env var the
+runtime and parallel test dispatcher use), otherwise `./outputs` under the
+current working directory.
 
 ---
 

--- a/simpler_setup/tools/__init__.py
+++ b/simpler_setup/tools/__init__.py
@@ -16,3 +16,19 @@ Invoke via ``python -m simpler_setup.tools.<name>``:
 - ``dump_viewer``           : inspect tensor dumps
 - ``device_log_resolver``   : shared library used by the converters
 """
+
+import os
+from pathlib import Path
+
+
+def get_outputs_dir() -> Path:
+    """Directory where the runtime writes ``l2_perf_records_*.json`` etc.
+
+    Honors ``SIMPLER_OUTPUT_DIR`` — the same env var the C++ runtime and the
+    parallel test dispatcher use to scope each subprocess to its own directory.
+    Empty/unset falls back to ``./outputs`` under CWD.
+    """
+    env = os.environ.get("SIMPLER_OUTPUT_DIR")
+    if env:
+        return Path(env)
+    return Path.cwd() / "outputs"

--- a/simpler_setup/tools/dump_viewer.py
+++ b/simpler_setup/tools/dump_viewer.py
@@ -44,6 +44,8 @@ import struct
 import sys
 from pathlib import Path
 
+from . import get_outputs_dir
+
 DTYPE_INFO = {
     "float32": ("f", 4),
     "float16": ("e", 2),
@@ -197,9 +199,10 @@ def list_tensors(tensors: list):
 def _resolve_dump_dir(dump_dir_arg: str | None) -> Path:
     if dump_dir_arg is not None:
         return Path(dump_dir_arg)
-    candidates = sorted(Path("outputs").glob("tensor_dump_*"), key=lambda p: p.name)
+    outputs_dir = get_outputs_dir()
+    candidates = sorted(outputs_dir.glob("tensor_dump_*"), key=lambda p: p.name)
     if not candidates:
-        print("Error: no tensor_dump_* directory found in outputs/", file=sys.stderr)
+        print(f"Error: no tensor_dump_* directory found in {outputs_dir}", file=sys.stderr)
         sys.exit(1)
     print(f"Using latest dump directory: {candidates[-1]}")
     return candidates[-1]

--- a/simpler_setup/tools/perf_to_mermaid.py
+++ b/simpler_setup/tools/perf_to_mermaid.py
@@ -29,6 +29,8 @@ import traceback
 from datetime import datetime
 from pathlib import Path
 
+from . import get_outputs_dir
+
 
 def read_perf_data(filepath):
     """Read performance data from JSON file.
@@ -273,7 +275,7 @@ def _resolve_input_path(args):
             return None
         return input_path
 
-    outputs_dir = Path.cwd() / "outputs"
+    outputs_dir = get_outputs_dir()
     json_files = list(outputs_dir.glob("l2_perf_records_*.json"))
     if not json_files:
         print(f"Error: no l2_perf_records_*.json under {outputs_dir}", file=sys.stderr)
@@ -297,7 +299,7 @@ def _resolve_output_path(args, input_path):
     else:
         suffix_part = datetime.now().strftime("%Y%m%d_%H%M%S")
 
-    outputs_dir = Path.cwd() / "outputs"
+    outputs_dir = get_outputs_dir()
     outputs_dir.mkdir(exist_ok=True)
     return outputs_dir / f"mermaid_diagram_{suffix_part}.md"
 

--- a/simpler_setup/tools/sched_overhead_analysis.py
+++ b/simpler_setup/tools/sched_overhead_analysis.py
@@ -28,12 +28,13 @@ import re
 import sys
 from pathlib import Path
 
+from . import get_outputs_dir
 from .device_log_resolver import infer_device_id_from_log_path, resolve_device_log_path
 
 
 def auto_select_l2_perf_records_json():
-    """Find the latest l2_perf_records_*.json under ./outputs/."""
-    outputs_dir = Path.cwd() / "outputs"
+    """Find the latest l2_perf_records_*.json under the outputs directory."""
+    outputs_dir = get_outputs_dir()
     files = sorted(outputs_dir.glob("l2_perf_records_*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
     if not files:
         raise FileNotFoundError(f"No l2_perf_records_*.json files found in {outputs_dir}")

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -31,6 +31,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from . import get_outputs_dir
 from .device_log_resolver import infer_device_id_from_log_path, resolve_device_log_path
 from .sched_overhead_analysis import parse_scheduler_threads
 from .sched_overhead_analysis import run_analysis as run_sched_overhead_analysis
@@ -1145,7 +1146,7 @@ def _resolve_input_path(args):
             return None
         return input_path
 
-    outputs_dir = Path.cwd() / "outputs"
+    outputs_dir = get_outputs_dir()
     json_files = list(outputs_dir.glob("l2_perf_records_*.json"))
     if not json_files:
         print(f"Error: No l2_perf_records_*.json files found in {outputs_dir}", file=sys.stderr)
@@ -1169,7 +1170,7 @@ def _resolve_output_path(args, input_path):
     else:
         suffix_part = datetime.now().strftime("%Y%m%d_%H%M%S")
 
-    outputs_dir = Path.cwd() / "outputs"
+    outputs_dir = get_outputs_dir()
     outputs_dir.mkdir(exist_ok=True)
     return outputs_dir / f"merged_swimlane_{suffix_part}.json"
 

--- a/src/a2a3/platform/src/host/l2_perf_collector.cpp
+++ b/src/a2a3/platform/src/host/l2_perf_collector.cpp
@@ -1161,12 +1161,12 @@ void L2PerfCollector::collect_phase_data() {
 }
 
 int L2PerfCollector::export_swimlane_json(const std::string &output_path_arg) {
-    // Step 0: Resolve effective output directory. SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR (when set)
+    // Step 0: Resolve effective output directory. SIMPLER_OUTPUT_DIR (when set)
     // overrides the caller-supplied path so the parallel test orchestrator can
     // give each subprocess its own directory — avoids filename collisions when
     // two concurrent runs produce a l2_perf_records_*.json with the same
     // second-precision timestamp. Empty env var is treated as unset.
-    const char *env_dir = std::getenv("SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR");
+    const char *env_dir = std::getenv("SIMPLER_OUTPUT_DIR");
     const std::string output_path = (env_dir != nullptr && env_dir[0] != '\0') ? std::string(env_dir) : output_path_arg;
 
     // Step 1: Validate collected data

--- a/src/a5/platform/src/host/l2_perf_collector.cpp
+++ b/src/a5/platform/src/host/l2_perf_collector.cpp
@@ -320,12 +320,12 @@ int L2PerfCollector::collect_all() {
 }
 
 int L2PerfCollector::export_swimlane_json(const std::string &output_path_arg) {
-    // Step 0: Resolve effective output directory. SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR (when set)
+    // Step 0: Resolve effective output directory. SIMPLER_OUTPUT_DIR (when set)
     // overrides the caller-supplied path so the parallel test orchestrator can
     // give each subprocess its own directory — avoids filename collisions when
     // two concurrent runs produce a l2_perf_records_*.json with the same
     // second-precision timestamp. Empty env var is treated as unset.
-    const char *env_dir = std::getenv("SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR");
+    const char *env_dir = std::getenv("SIMPLER_OUTPUT_DIR");
     const std::string output_path = (env_dir != nullptr && env_dir[0] != '\0') ? std::string(env_dir) : output_path_arg;
 
     // Step 1: Validate collected data


### PR DESCRIPTION
## Summary

- Rename the per-subprocess output-directory env var across Python, C++, docs, and the four `simpler_setup/tools/` CLIs. The original name (`SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR`) was both long and unnecessarily L2-perf-specific — the variable is generic enough to scope any per-subprocess output (e.g. `tensor_dump_*/`).
- Add a small `get_outputs_dir()` helper in `simpler_setup/tools/__init__.py` so the CLI tools resolve auto-detection paths through the same env var the C++ runtime (`L2PerfCollector::export_swimlane_json`) and the parallel test dispatcher honor.
- No behavior change beyond the name. Empty/unset still falls back to the historical `./outputs` default.

## Test plan

- [ ] CI: lint + tests pass (clang-tidy was skipped locally because `simpler` isn't `pip install`'d in this venv; rename is purely mechanical, CI will lint the C++ side)
- [ ] `rg SIMPLER_L2_PERF_RECORDS_OUTPUT_DIR` returns no matches (verified locally)
- [ ] Spot-check the parallel test dispatcher still scopes subprocess perf files into per-job subdirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)