### PR TITLE
Add: parallelisation of runtime and platform builds

### DIFF
--- a/simpler_setup/build_runtimes.py
+++ b/simpler_setup/build_runtimes.py
@@ -152,11 +152,7 @@ def build_all(
             return
         
         logger.info(f"  Building {platform}/{runtime_name}...")
-        try:
-            builder.get_binaries(runtime_name, build=True)
-        except Exception as e:
-            logger.error(f"  Failed to build {platform}/{runtime_name}: {e}")
-            raise
+        builder.get_binaries(runtime_name, build=True)
 
     with ThreadPoolExecutor(max_workers=len(tasks) or 1) as executor:
         futures = {executor.submit(_build_runtime, p, r): (p, r) for p, r in tasks}
@@ -166,6 +162,7 @@ def build_all(
                 future.result()
             except Exception as e:
                 logger.error(f"  Failed to build {platform}/{runtime_name}: {e}")
+                executor.shutdown(wait=True, cancel_futures=True)
                 raise
 
 

--- a/simpler_setup/build_runtimes.py
+++ b/simpler_setup/build_runtimes.py
@@ -150,7 +150,7 @@ def build_all(
         except (ValueError, FileNotFoundError) as e:
             logger.warning(f"  {platform}: cannot initialize builder: {e}")
             return
-        
+
         logger.info(f"  Building {platform}/{runtime_name}...")
         builder.get_binaries(runtime_name, build=True)
 

--- a/simpler_setup/build_runtimes.py
+++ b/simpler_setup/build_runtimes.py
@@ -165,6 +165,12 @@ def build_all(
                 executor.shutdown(wait=True, cancel_futures=True)
                 raise
 
+        # No device-side deployment step here. The dispatcher SO is uploaded
+        # into the main aicpu_scheduler at runtime, on the first
+        # DeviceRunner::ensure_binaries_loaded call, via
+        # LoadAicpuOp::BootstrapDispatcher (see src/common/host/load_aicpu_op.cpp
+        # and src/common/aicpu_dispatcher/aicpu_dispatcher.h for architecture).
+
 
 def main():
     parser = argparse.ArgumentParser(description="Pre-build runtime binaries for available platforms")

--- a/simpler_setup/build_runtimes.py
+++ b/simpler_setup/build_runtimes.py
@@ -24,6 +24,7 @@ import logging
 import os
 import shutil
 import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Optional
 
@@ -130,6 +131,8 @@ def build_all(
                 logger.error(f"Failed to build cpu_sim_context: {e}")
                 raise
 
+    # Collect all (platform, runtime_name) tasks, validating each platform first.
+    tasks: list[tuple[str, str]] = []
     for platform in platforms:
         arch, _ = parse_platform(platform)
         runtimes = discover_runtimes(arch)
@@ -138,25 +141,32 @@ def build_all(
             logger.warning(f"  {platform}: no runtimes found, skipping")
             continue
 
+        for runtime_name in runtimes:
+            tasks.append((platform, runtime_name))
+
+    def _build_runtime(platform: str, runtime_name: str) -> None:
         try:
             builder = RuntimeBuilder(platform=platform)
         except (ValueError, FileNotFoundError) as e:
             logger.warning(f"  {platform}: cannot initialize builder: {e}")
-            continue
+            return
+        
+        logger.info(f"  Building {platform}/{runtime_name}...")
+        try:
+            builder.get_binaries(runtime_name, build=True)
+        except Exception as e:
+            logger.error(f"  Failed to build {platform}/{runtime_name}: {e}")
+            raise
 
-        for runtime_name in runtimes:
-            logger.info(f"  Building {platform}/{runtime_name}...")
+    with ThreadPoolExecutor(max_workers=len(tasks) or 1) as executor:
+        futures = {executor.submit(_build_runtime, p, r): (p, r) for p, r in tasks}
+        for future in as_completed(futures):
+            platform, runtime_name = futures[future]
             try:
-                builder.get_binaries(runtime_name, build=True)
+                future.result()
             except Exception as e:
                 logger.error(f"  Failed to build {platform}/{runtime_name}: {e}")
                 raise
-
-        # No device-side deployment step here. The dispatcher SO is uploaded
-        # into the main aicpu_scheduler at runtime, on the first
-        # DeviceRunner::ensure_binaries_loaded call, via
-        # LoadAicpuOp::BootstrapDispatcher (see src/common/host/load_aicpu_op.cpp
-        # and src/common/aicpu_dispatcher/aicpu_dispatcher.h for architecture).
 
 
 def main():

--- a/simpler_setup/build_runtimes.py
+++ b/simpler_setup/build_runtimes.py
@@ -131,7 +131,7 @@ def build_all(
                 logger.error(f"Failed to build cpu_sim_context: {e}")
                 raise
 
-    # Collect all (platform, runtime_name) tasks, validating each platform first.
+    # Collect all (platform, runtime_name) tasks to run in parallel
     tasks: list[tuple[str, str]] = []
     for platform in platforms:
         arch, _ = parse_platform(platform)


### PR DESCRIPTION
Improved build time from 311 seconds to 80 seconds by parallelising over the different (platform / runtime) builds.

---

Rebased onto latest `main` and re-pushed from a fork I control, since the original PR's head branch lives on an org-owned fork that doesn't allow maintainer edits.

- Original PR: #885 by @raphael-s-steiner
- All commits retain original authorship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)