### PR TITLE
Fix: pace the idle mailbox poll in forked sub/child workers

### DIFF
--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -952,6 +952,28 @@ def _buffer_field_addr(buf, offset: int) -> int:
     return ctypes.addressof(ctypes.c_char.from_buffer(buf)) + offset
 
 
+# Pacing for the idle branch of the forked sub/child worker mailbox polls.
+# The first _MAILBOX_SPIN_POLLS consecutive idle passes spin, so a child that
+# is dispatched again right away still answers at spin latency; past that the
+# poll sleeps, matching the 50 us granularity the parent's dispatch poll
+# already uses (worker_manager.cpp::LocalMailboxEndpoint::run).
+_MAILBOX_SPIN_POLLS = 200
+_MAILBOX_IDLE_POLL_S = 50e-6
+
+
+def _mailbox_idle_wait(idle_polls: int) -> int:
+    """Pace one idle pass of a child mailbox poll; returns the new idle count.
+
+    A forked child whose poll never pauses holds a core for its entire
+    lifetime, so once the live sub/child workers outnumber the available cores
+    they starve each other and parallel dispatch degrades toward serial.
+    Callers reset the count to 0 whenever a pass finds work.
+    """
+    if idle_polls >= _MAILBOX_SPIN_POLLS:
+        time.sleep(_MAILBOX_IDLE_POLL_S)
+    return idle_polls + 1
+
+
 def _write_error(buf, code: int, msg: str = "") -> None:
     """Write an (error code, message) tuple into the mailbox error region.
 
@@ -1003,7 +1025,7 @@ def _read_args_from_mailbox(buf) -> TaskArgs:
     return read_args_from_blob(mailbox_addr + _OFF_TASK_ARGS_BLOB)
 
 
-def _sub_worker_loop(
+def _sub_worker_loop(  # noqa: PLR0912 -- unified TASK_READY / CONTROL_REQUEST / SHUTDOWN / idle state machine
     buf,
     registry: dict[int, Any],
     identity_table: dict[bytes, int],
@@ -1019,10 +1041,12 @@ def _sub_worker_loop(
     state_addr = _buffer_field_addr(buf, _OFF_STATE)
     host_buf_table: dict[int, tuple[SharedMemory, int, int, int]] = {}
     host_buf_ranges: list[tuple[int, int, int]] = []
+    idle_polls = 0
     try:
         while True:
             state = _mailbox_load_i32(state_addr)
             if state == _TASK_READY:
+                idle_polls = 0
                 digest = _read_task_digest(buf)
                 cid = identity_table.get(digest)
                 fn = registry.get(int(cid)) if cid is not None else None
@@ -1043,6 +1067,7 @@ def _sub_worker_loop(
                 _write_error(buf, code, msg)
                 _mailbox_store_i32(state_addr, _TASK_DONE)
             elif state == _CONTROL_REQUEST:
+                idle_polls = 0
                 sub_cmd = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
                 code = 0
                 msg = ""
@@ -1067,6 +1092,8 @@ def _sub_worker_loop(
                 _mailbox_store_i32(state_addr, _CONTROL_DONE)
             elif state == _SHUTDOWN:
                 break
+            else:
+                idle_polls = _mailbox_idle_wait(idle_polls)
     finally:
         for host_shm, _lo, _hi, _base in host_buf_table.values():
             try:
@@ -1739,9 +1766,11 @@ def _child_worker_loop(
     into the inner Worker (see docs section 7).
     """
     state_addr = _buffer_field_addr(buf, _OFF_STATE)
+    idle_polls = 0
     while True:
         state = _mailbox_load_i32(state_addr)
         if state == _TASK_READY:
+            idle_polls = 0
             digest = _read_task_digest(buf)
             cid = identity_table.get(digest)
             orch_fn = registry.get(int(cid)) if cid is not None else None
@@ -1761,6 +1790,7 @@ def _child_worker_loop(
             _write_error(buf, code, msg)
             _mailbox_store_i32(state_addr, _TASK_DONE)
         elif state == _CONTROL_REQUEST:
+            idle_polls = 0
             sub_cmd = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
             code = 0
             msg = ""
@@ -1821,6 +1851,8 @@ def _child_worker_loop(
         elif state == _SHUTDOWN:
             inner_worker.close()
             break
+        else:
+            idle_polls = _mailbox_idle_wait(idle_polls)
 
 
 class _Lifecycle(enum.Enum):

--- a/tests/ut/py/test_worker/test_idle_worker_cpu.py
+++ b/tests/ut/py/test_worker/test_idle_worker_cpu.py
@@ -1,0 +1,74 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Idle forked workers must not hold a core.
+
+A child whose mailbox poll never pauses burns a full core for its entire
+lifetime, so once the live sub/child workers outnumber the available cores
+they starve each other and parallel dispatch degrades toward serial.
+
+The assertion is on **CPU time consumed**, not wall time: it measures the
+spin directly instead of inferring it from how long some parallel workload
+took, so it does not depend on the scheduler's choices and cannot flake under
+load. Reads `/proc`, so it is Linux-only; the loops under test are
+platform-independent.
+"""
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+from simpler.worker import Worker
+
+pytestmark = pytest.mark.skipif(not sys.platform.startswith("linux"), reason="reads /proc for per-child CPU time")
+
+NUM_SUB_WORKERS = 4
+IDLE_WINDOW_S = 1.0
+# The paced loop measures ~1% of a core per child; an unpaced one measures
+# 80-100%. Anything under this is decisively "not spinning" without depending
+# on how loaded the machine is.
+MAX_IDLE_CORE_FRACTION = 0.25
+
+
+def _child_cpu_seconds(pids: list[int]) -> float:
+    """Summed utime+stime of `pids`, in seconds."""
+    ticks = 0
+    for pid in pids:
+        try:
+            with open(f"/proc/{pid}/stat") as f:
+                # Fields after the (possibly space-containing) comm field:
+                # utime and stime are indices 11 and 12.
+                fields = f.read().rsplit(") ", 1)[1].split()
+        except OSError:
+            continue
+        ticks += int(fields[11]) + int(fields[12])
+    return ticks / os.sysconf("SC_CLK_TCK")
+
+
+def test_idle_sub_workers_do_not_spin():
+    worker = Worker(level=3, num_sub_workers=NUM_SUB_WORKERS)
+    worker.register(lambda args: None)
+    worker.init()
+    try:
+        children = [int(p) for p in subprocess.check_output(["pgrep", "-P", str(os.getpid())]).split()]
+        assert len(children) >= NUM_SUB_WORKERS, f"expected at least {NUM_SUB_WORKERS} forked children, saw {children}"
+
+        before = _child_cpu_seconds(children)
+        time.sleep(IDLE_WINDOW_S)
+        burned = _child_cpu_seconds(children) - before
+    finally:
+        worker.close()
+
+    per_child = burned / (IDLE_WINDOW_S * len(children))
+    assert per_child < MAX_IDLE_CORE_FRACTION, (
+        f"{len(children)} idle children burned {burned:.2f} CPU-seconds over {IDLE_WINDOW_S}s "
+        f"({per_child:.0%} of a core each, limit {MAX_IDLE_CORE_FRACTION:.0%}) — "
+        f"the mailbox poll is spinning instead of pacing itself"
+    )


### PR DESCRIPTION
## Summary

`_sub_worker_loop` and `_child_worker_loop` polled their mailbox state word in a bare `while True:` with **no sleep and no yield**, so every forked child held a core for its entire lifetime whether or not it had work. Once the live sub/child workers outnumber the available cores they starve each other and parallel dispatch degrades toward serial.

**Measured, 4 sub workers idle for 3 s (aarch64 Linux):**

| | CPU burned per idle child |
| --- | --- |
| before | **80% of a core** |
| after | **1% of a core** |

## Why this is the child side's bug

The parent already paces itself. `LocalMailboxEndpoint::run` sleeps 50 us between `TASK_DONE` polls (`src/common/hierarchical/worker_manager.cpp`), and `WorkerThread` blocks on a condition variable. The child side was the asymmetry, not a deliberate latency trade.

## Fix

Pace the idle branch to match. The first `_MAILBOX_SPIN_POLLS` (200) consecutive idle passes still spin, so a child dispatched again right away answers at spin latency; past that the poll sleeps for the **same 50 us quantum the parent already accepts**. A burst of back-to-back dispatches is therefore unaffected, while a genuinely idle child releases its core.

The counter resets to 0 on any pass that finds work, so the hot-spin window is fresh after every dispatch.

### Deliberately not changed

`_run_chip_main_loop` (the device-owning chip process) keeps spinning: it is latency-critical on the NPU dispatch path, and its count is bounded by the physical devices, so it is not a source of the oversubscription this fixes. Extending the pacing there would trade real dispatch latency for a saving that does not apply.

## Regression test

`tests/ut/py/test_worker/test_idle_worker_cpu.py` asserts on **CPU time consumed** (per-child `utime+stime` over an idle window), not on the wall time of a parallel workload. That observes the spin directly instead of inferring it from scheduling outcomes, so it does not depend on the scheduler's choices and cannot flake under load. The 25% threshold sits an order of magnitude away from both measured states.

Linux-only (reads `/proc`); the loops under test are platform-independent.

**Red-to-green verified:**

```
# without the fix
AssertionError: 5 idle children burned 4.00 CPU-seconds over 1.0s
(80% of a core each, limit 25%) - the mailbox poll is spinning instead of pacing itself

# with the fix
1 passed in 1.21s
```

## How this surfaced

Triaging the recurring red `ut (macos-latest, 3.10)` check. `test_hostsub_fork_shm.py::test_parallel_wall_time` failed 4 times in 218 sampled macOS jobs (0 in 101 Ubuntu jobs) with wall times of 0.49-0.57 s against a fully-serial baseline of 0.60 s — three children that only `time.sleep(0.2)`, needing no CPU to finish, getting near-zero effective concurrency on a narrow-core runner.

The cost is not confined to CI. While running these tests I found six orphaned pytest processes on this shared dev box, each pinned at ~99.6% CPU for **5-7 days** — leaked children of long-dead test runs, still spinning. An unbounded busy-wait turns every leaked child into a permanently occupied core.

## Verification

- `pytest tests/ut/py -q` -> **825 passed, 2 skipped**.
- `pre-commit` clean.

`_sub_worker_loop` crosses ruff's 15-branch limit with the added idle branch; it carries the same `# noqa: PLR0912` with a reason that its sibling `_run_chip_main_loop` already uses for the identical state-machine shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)