### PR TITLE
Add: per-worker timeline to the parallel wall-time assertion

### DIFF
--- a/tests/ut/py/test_hostsub_fork_shm.py
+++ b/tests/ut/py/test_hostsub_fork_shm.py
@@ -300,19 +300,39 @@ class TestParallelExecution:
         pool = _SubWorkerPool(num_workers=n_workers, registry=registry)
 
         try:
+            # Per-worker timestamps, so a failure says *which* worker ran late
+            # rather than only that the total was too high. Workers are
+            # dispatched in a loop, so if the parent is descheduled between
+            # iterations the later workers start a full sleep period behind —
+            # a shape the total alone cannot distinguish from every worker
+            # being slow. See #1496.
+            dispatched: list[float] = []
+            completed: list[float] = []
+
             start = time.monotonic()
             for i in range(n_workers):
                 pool.dispatch(i, i)
+                dispatched.append(time.monotonic() - start)
             for i in range(n_workers):
                 result, err = pool.wait(i, timeout=5.0)
+                completed.append(time.monotonic() - start)
                 assert err == 0
                 assert result == int(sleep_sec * 1000)
             elapsed = time.monotonic() - start
 
             serial_time = n_workers * sleep_sec
+            timeline = ", ".join(
+                f"w{i}: dispatched +{dispatched[i] * 1000:.1f}ms, done +{completed[i] * 1000:.1f}ms"
+                for i in range(n_workers)
+            )
+            # macOS has no sched_getaffinity; cpu_count alone can overstate what
+            # a container actually lets this process run on.
+            affinity = len(os.sched_getaffinity(0)) if hasattr(os, "sched_getaffinity") else "n/a"
             assert elapsed < serial_time * 0.8, (
                 f"expected parallel wall time < {serial_time * 0.8:.2f}s "
-                f"(serial would be {serial_time:.2f}s), got {elapsed:.2f}s"
+                f"(serial would be {serial_time:.2f}s), got {elapsed:.2f}s\n"
+                f"cpu_count={os.cpu_count()} affinity={affinity}\n"
+                f"{timeline}"
             )
         finally:
             pool.shutdown()


### PR DESCRIPTION
Makes the next occurrence of #1496 self-diagnosing. **No behaviour change, no threshold change.**

## Why

`test_parallel_wall_time` fails on macOS CI in ~2% of runs (4 of 218 sampled `ut (macos-latest, 3.10)` jobs; **0 of 101** on Ubuntu) with a total of 0.49-0.57 s against a **0.203 s Linux median** (max 0.204 s over 7 runs). That is near-serial, not a marginal threshold.

But the assertion reports only the total, which cannot separate the two shapes:

- the parent was descheduled between its three sequential `dispatch()` calls, so w1/w2 started a full sleep period behind, **or**
- every worker was dispatched on time and finished late.

Those are different bugs. The total is identical either way.

## What

Record each worker's dispatch and completion offset and include them — plus the visible CPU count — in the failure message. Verified by temporarily tightening the threshold:

```
AssertionError: expected parallel wall time < 0.48s (serial would be 0.60s), got 0.20s
  cpu_count=320 affinity=320
  w0: dispatched +0.1ms, done +200.6ms, w1: dispatched +0.1ms, done +200.6ms, w2: dispatched +0.1ms, done +204.5ms
```

On Linux all three dispatch at +0.1 ms and finish together — the healthy shape. On the next macOS failure the same line says which worker started late, and the question in #1496 is answered from the CI log alone.

`sched_getaffinity` is Linux-only, hence the guard. `cpu_count()` alone can overstate what a container actually lets the process run on, and the runner's real width is one of the unknowns #1496 could not close.

## What this deliberately does not do

**It does not touch the assertion.** #1496 asks explicitly that the threshold not be relaxed and no retry be added: at 0.49-0.57 s against 0.203 s, something is serialising three processes that are each only in `time.sleep(0.2)`. A wider bound would make the symptom disappear and leave the cause running.

This is the same approach as #1501 for #1489 — when a failure is rare and cannot be reproduced on demand, the highest-value move is to guarantee the next natural occurrence yields the evidence, rather than spending exclusive hardware or CI time trying to force one.

## Verification

- `pytest tests/ut/py/test_hostsub_fork_shm.py -q` → 6 passed.
- Failure path exercised by temporarily tightening the bound (output above), then restored.
- `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)