### PR TITLE
[Performance] A5 TMR: batch progress publication every 16 advances

### DIFF
--- a/.claude/rules/running-onboard.md
+++ b/.claude/rules/running-onboard.md
@@ -173,7 +173,7 @@ for the signature that actually fired:**
 | device-log signature | mechanism | note |
 | -------------------- | --------- | ---- |
 | `FATAL: Task Allocator Deadlock` / `FATAL: Dependency Pool Deadlock` / `FATAL: Fanin Spill Pool Deadlock` | an allocator or pool could not reclaim enough space | This header identifies the blocked resource, not the root cause. Classify it using the structural/timeout line that follows. |
-| `Provable head-of-line deadlock` | **proven open-scope structural deadlock** | TRB only: the reclaim head is the oldest task owned by an open scope on that ring. The blocked orchestrator cannot end that scope, so the head cannot become consumed. |
+| `Provable head-of-line deadlock` | **proven open-scope structural deadlock** | TRB only: the reclaim head is the oldest task owned by an open scope on that ring. The blocked orchestrator cannot end that scope, so the head cannot become consumed. On A5, classification waits for at least 10 ms without reclaim progress and an exact-watermark publication acknowledgment. |
 | `No reclaim progress for ~500 ms` / `cannot reclaim space after ~500 ms` | allocator/pool **reclaim timeout** | The 500ms backstop (`PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES`) exists in HBG and TRB. It proves prolonged lack of reclaim progress, not why progress stopped; check capacity, the dumped head, consumers and scheduler state. |
 | `Timeout (N cycles): producer/consumers ...` | **SPIN** wait on a specific producer/consumer | `pto_runtime2.cpp`. |
 | `HandleTaskTimeout` / `kill aicpu-sd` | **OS op-execute timeout** | STARS/tsdaemon, default 45s (`PLATFORM_OP_EXECUTE_TIMEOUT_US`). **A 45s kill ≠ deadlock** — the op was merely long or stalled. Raise this constant to measure true on-device duration. |

--- a/docs/investigations/2026-06-cross-task-batched-publish.md
+++ b/docs/investigations/2026-06-cross-task-batched-publish.md
@@ -159,10 +159,32 @@ pending sync_start task is either already dispatched (a stale re-popped slot)
 or moot under teardown, and `deinit()` resets `drain_state_` before the next
 run. Applied to both a2a3 and a5.
 
+## Related A5 reclaim-watermark batching (2026-08-17)
+
+A5 later batched scheduler publication of `last_task_alive` every 16 local
+advances. The first design force-published only when a ring fully drained or a
+deferred consumed-head request reached the scheduler idle path. That was not a
+complete liveness boundary: the watermark is allocation credit for task slots,
+heap bytes, dependency entries, fanin spill entries, and TensorMap entries. An
+orchestrator blocked on any of those resources can prevent an open scope from
+ending, so a final partial batch cannot wait for full-ring drain.
+
+The retained design keeps K=16 on the non-blocking path and adds an explicit
+pressure handshake. A reclaim consumer requests publication per ring only after
+10 ms with no reclaim progress; scheduler thread 0 force-publishes the
+scheduler-local head and acknowledges it from both productive and idle
+iterations. Scheduler try-lock contention uses a separate deferred mask that
+only idle loops drain, so it cannot turn the productive request path into eager
+publication. Structural deadlock checks use only an acknowledged head. This is
+the same general lesson as the sync-start incident above: a batched publication
+needs a receiver-visible escape whenever that receiver depends on the
+publication for forward progress.
+
 ## References
 
 - PR #989 (this PR): where per-task batched publish + the sync_start-
   gated cross-task batched publish ship together.
+- PR #1575: A5 reclaim-watermark batching with pressure-triggered publication.
 - `spmd_sync_start_stress`
   (`tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/`).
 - Issue #545 comment #2: the SPMD dispatch-stagger symptom the PR

--- a/docs/tensormap-and-ringbuffer-a2a3-vs-a5.md
+++ b/docs/tensormap-and-ringbuffer-a2a3-vs-a5.md
@@ -3,9 +3,9 @@
 This document describes the substantive differences in the current code under
 `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/`.
 
-> **Maintenance baseline:** This document uses commit
-> `317a19c2ee04bcc3e36d1cb49d2037084455a3ad` as its baseline. Update this
-> document whenever the files or constants it describes change.
+> **Maintenance baseline:** The source layout and classifications were verified
+> on 2026-08-17. Recompute the counts and update the affected sections whenever
+> the files or constants described here change.
 
 ## Comparison Boundary and Classification
 
@@ -17,9 +17,9 @@ categories:
 
 | Category | Count | Definition |
 | -------- | ----: | ---------- |
-| Byte-identical | 28 | The files at the same relative path have identical bytes |
-| Compile-time or non-functional differences | 12 | Text differs, but the generated runtime behavior and data semantics are equivalent |
-| Functional differences | 15 | Thirteen matching paths and two A5-only paths encode or document differences in runtime behavior, capacity, diagnostics, or supported backends |
+| Byte-identical | 24 | The files at the same relative path have identical bytes |
+| Compile-time or non-functional differences | 11 | Text differs, but the generated runtime behavior and data semantics are equivalent |
+| Functional differences | 20 | Eighteen matching paths and two A5-only paths encode or document differences in runtime behavior, capacity, diagnostics, or supported backends |
 
 A file is classified as functional when any part of its diff changes behavior,
 even if the same diff also contains include-order, comment, or formatting
@@ -28,19 +28,18 @@ PMU collector implementations, are cited only as supporting evidence.
 
 ## Byte-Identical Files
 
-The following 28 files are byte-identical:
+The following 24 files are byte-identical:
 
 ```text
 build_config.py
-docs/{MULTI_RING.md,SCALAR_DATA_ACCESS.md,SUBMIT_BY_CLUSTER.md,device_log_profiling.md,
-      profiling_levels.md}
+docs/{SCALAR_DATA_ACCESS.md,SUBMIT_BY_CLUSTER.md,device_log_profiling.md,profiling_levels.md}
 host/{dep_gen_replay.cpp,runtime_compile_info.cpp}
 orchestration/{common.cpp,pto_arg_with_deps.h,pto_orchestration_api.h}
 runtime/{common.h,pto_async_kernel_api.h,pto_dep_compute.h,pto_orchestrator.h,
-         pto_ring_buffer.cpp,pto_ring_buffer.h,pto_runtime2.cpp,pto_runtime2.h,
-         pto_shared_memory.h,pto_tensormap.h,tensor_create_info.h}
+         pto_runtime2.cpp,pto_runtime2.h,pto_shared_memory.h,pto_tensormap.h,
+         tensor_create_info.h}
 runtime/scheduler/{pto_scheduler.cpp,scheduler_types.h}
-runtime/shared/{pto_runtime2_init.cpp,pto_shared_memory.cpp,pto_tensormap.cpp,runtime.cpp}
+runtime/shared/{pto_shared_memory.cpp,pto_tensormap.cpp,runtime.cpp}
 ```
 
 Byte identity is a textual result only. A shared file may still consume
@@ -49,7 +48,7 @@ boundary.
 
 ## Compile-Time or Non-Functional Differences
 
-The following 12 matching paths differ textually without changing runtime
+The following 11 matching paths differ textually without changing runtime
 behavior:
 
 | Files | Difference |
@@ -62,7 +61,6 @@ behavior:
 | `runtime/pto_completion_token.h` | Path-derived include guards and an A2/A3-only explanatory comment |
 | `runtime/pto_runtime2_types.h` | Comments state the corresponding 72- or 108-worker capacity; the mask remains two 64-bit words on both platforms |
 | `runtime/pto_submit_types.h` | The launch accessor and backing field are named `block_num` on A2/A3 and `core_num` on A5; both represent the logical SPMD block count |
-| `runtime/pto_orchestrator.cpp` | Calls the corresponding launch accessor; the remaining differences are equivalent expression layout and comments |
 
 The first two rows, covering five files, are the strict "compile macro only"
 subset. The `s_block_*` names are also a compile-time constraint rather than a
@@ -72,22 +70,27 @@ modified.
 
 ## Files with Functional Differences
 
-The following 13 matching paths have at least one functional difference:
+The following 18 matching paths have at least one functional difference:
 
 ```text
 aicore/aicore_executor.cpp
 aicpu/aicpu_executor.cpp
+docs/MULTI_RING.md
 docs/RUNTIME_LOGIC.md
 host/runtime_maker.cpp
 runtime/aicore_completion_mailbox_types.h
 runtime/backend/sdma/sdma_completion_scheduler.h
 runtime/pto_async_wait.h
+runtime/pto_orchestrator.cpp
+runtime/pto_ring_buffer.cpp
+runtime/pto_ring_buffer.h
 runtime/runtime.h
 runtime/scheduler/pto_scheduler.h
 runtime/scheduler/scheduler_cold_path.cpp
 runtime/scheduler/scheduler_completion.cpp
 runtime/scheduler/scheduler_context.h
 runtime/scheduler/scheduler_dispatch.cpp
+runtime/shared/pto_runtime2_init.cpp
 ```
 
 A5 also has two backend files with no A2/A3 counterpart:
@@ -108,6 +111,7 @@ The functional differences group into the following themes:
 | System counter and DMB | Hardware timing and register layout | Yes | Use the constants for each platform |
 | URMA completion | A5-specific implementation and product capability gate | Yes, for now | Retain the A5 path; do not claim that URMA is available in the default build |
 | Next-block prefetch | A2/A3-only performance optimization | No | Retain on A2/A3; validate on A5 before considering a port |
+| Scheduler progress publication | AICPU topology and measured publication cost | No | Retain A5's 16-task batching; keep per-advance publication on A2/A3, where the portable implementation showed no significant benefit |
 | Fatal teardown | Software reliability strategy | No | Retain the current implementations; decide whether to converge after measuring the worst-case A5 teardown time |
 | Scheduler trace attribution | Software diagnostic strategy | No | Preserve the current traces; converge only after comparing generated timelines |
 
@@ -219,6 +223,75 @@ cache capacity. The repository does not contain an A5 measurement that
 establishes a benefit, so the optimization should not be ported mechanically.
 This is a platform-sensitive performance strategy, not a different scheduler
 architecture.
+
+### Scheduler Progress Publication: Why A5 Only
+
+A2/A3 publishes `ring->fc.last_task_alive` after every local ring-pointer
+advance. A5 tracks `last_published_to_sm` and publishes the shared watermark
+every 16 local advances while no reclaim consumer is blocked. This reduces
+Scheduler-to-Orchestrator cache-line transfers while allowing the shared
+watermark to trail local reclamation by at most 15 tasks on the non-blocking
+path.
+
+The optimization is portable, but its benefit is topology-specific. A2/A3 has
+four physical AICPU cores per cluster and runs four active roles by default
+(`1 Orchestrator + 3 Schedulers`). Its affinity policy prefers one cluster that
+can hold all four roles, so progress publication is normally cluster-local. A5
+has two physical AICPU cores per cluster and runs five active roles by default
+(`1 Orchestrator + 4 Schedulers`). Even with SMT, those five roles cannot all
+fit in one cluster. They must span clusters and, depending on SMT and the
+available CPU pool, may span dies.
+
+Any A5 Scheduler may win `advance_lock`, advance the authoritative
+Scheduler-side `last_task_alive`, and publish `ring->fc.last_task_alive` for the
+Orchestrator. A remote publisher transfers or invalidates a cache line that the
+Orchestrator repeatedly reads for slot, heap, and TensorMap reclamation. K=16
+does not remove Scheduler-to-Scheduler contention on `advance_lock`; it reduces
+the frequency of Scheduler-to-Orchestrator publication by up to 16x.
+
+| Property | A2/A3 | A5 |
+| -------- | ----- | -- |
+| Physical AICPU cores per cluster | 4 | 2 |
+| Default active roles | 1 Orchestrator + 3 Schedulers = 4 | 1 Orchestrator + 4 Schedulers = 5 |
+| Normal placement | All active roles fit in one cluster | Active roles must span clusters and may span dies |
+| Shared-watermark publication | Normally cluster-local | Can require cross-cluster or cross-die cache-line transfer |
+| Port benchmark | Mean Effective change `-0.24%`; all workloads within approximately +/-2% | Mean Effective change `-2.81%`; all eight workloads improved |
+| Decision | Keep per-advance publication | Enable K=16 batching |
+
+A5 force-publishes when the local watermark reaches `current_task_index` or an
+orchestrator reclaim consumer has observed no reclaim progress for 10 ms and
+requests an exact watermark. Task-slot, heap, dependency-list, fanin-spill, and
+TensorMap pressure then set per-ring request bits; scheduler thread 0 services
+them under `advance_lock` from both productive and idle iterations, publishes
+the local watermark, and acknowledges completion. Structural deadlock checks
+run only after this acknowledgment, so their reclaim head is not a batched
+lower bound. These request bits are cache-line-isolated from scheduler
+lock-contention retries, which remain deferred to idle loops. K=16 batching is
+enabled only after all reclaim request/ack pointers are wired to the current
+scheduler; incomplete wiring keeps per-advance publication. Initialization,
+arena relocation, and ring reuse reset local progress and disable batching
+until that validation succeeds again.
+
+This pressure handshake follows the same liveness rule recorded in
+[`2026-06-cross-task-batched-publish.md`](investigations/2026-06-cross-task-batched-publish.md):
+delaying a publication is safe only while no peer is waiting on it for forward
+progress.
+
+| File | A5-only difference introduced by PR #1575 |
+| ---- | ----------------------------------------- |
+| `runtime/pto_ring_buffer.{h,cpp}` | A5 reclaim consumers request and await exact watermark publication after 10 ms without progress and before structural classification |
+| `runtime/pto_orchestrator.cpp` | A5 TensorMap pressure requests publication from every ring after the same 10 ms no-progress interval |
+| `runtime/scheduler/{pto_scheduler.h,scheduler_dispatch.cpp}` | A5 batches non-blocking publication at K=16 and services pressure requests in productive and idle loops; A2/A3 continues to publish every local advance |
+| `runtime/shared/pto_runtime2_init.cpp` | A5 initializes, resets, and wires the publication shadow and pressure handshake |
+
+The A2/A3 result is not a correctness limitation. A local port passed targeted
+and complete non-hardware tests, but its eight workload deltas were all within
+the approximately +/-2% noise band, with an unweighted mean of `-0.24%`.
+Batching would therefore add up to 15 tasks of non-blocking reclamation lag
+without a demonstrated payoff. The same-device A5
+measurements instead showed lower Effective time in all eight workloads, with
+an unweighted mean reduction of `2.81%`. Full A2/A3 measurements are recorded
+in the [PR benchmark follow-up](https://github.com/hw-native-sys/simpler/pull/1575#issuecomment-5310909143).
 
 ### Fatal Teardown
 

--- a/docs/troubleshooting/device-error-codes/capacity.md
+++ b/docs/troubleshooting/device-error-codes/capacity.md
@@ -8,7 +8,9 @@ how strong that diagnosis is:
 
 - `Provable head-of-line deadlock` is a structural proof: in TRB the reclaim head
   is the oldest task owned by an open scope on that ring, and the blocked
-  orchestrator cannot end the scope that pins it.
+  orchestrator cannot end the scope that pins it. On A5, this verdict is reached
+  only after at least 10 ms without reclaim progress and an exact-watermark
+  publication acknowledgment.
 - `No reclaim progress for ~500 ms` or `cannot reclaim space after ~500 ms` is
   the backstop. It proves that reclaim remained stalled, but not whether the root
   cause is undersizing, a stuck consumer, or a stalled scheduler.

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -187,6 +187,8 @@ advance_ring_pointers(ring_id):  // protected by per-ring advance_lock
 
 Per-ring try-locks in the scheduler state prevent concurrent scheduler threads from interleaving heap_tail writes within the same ring. A scheduler thread that changes a ring head to `CONSUMED` but fails to acquire that ring's `advance_lock` records a coalesced request in `advance_pending_mask`. Scheduler no-progress iterations retry pending rings under the same lock; a busy lock leaves the bit set, and a successful retry clears the bit before rescanning.
 
+Orchestrator reclaim consumers that see no reclaim progress for 10 ms use the separate `publication_request_mask`. Scheduler thread 0 polls only this mask in productive and no-progress iterations, force-publishes the requested ring watermark, and sets `publication_ack_mask`. Scheduler lock-contention retries never acknowledge an orchestrator request. K=16 batching is enabled only after every reclaim consumer is wired to the current request/ack masks; otherwise each local advance is published.
+
 For ring-heap stall triage, a `CONSUMED` head whose ring bit remains set means the deferred request has not yet been cleared by a retry that acquired `advance_lock`. If the bit clears and `last_task_alive` is still pinned, the stall is not caused by this deferred advance path.
 
 ### 5.2 Cross-Ring Dependencies

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -251,6 +251,15 @@ The ring buffer mechanism provides **flow control** between the orchestrator (pr
 
 **TensorMap pool back-pressure**: Before STEP 4 registers a task's outputs, the orchestrator's `ensure_tensormap_capacity` reserves pool space for the inserts. When the shared entry pool is exhausted, it reclaims retired entries across all rings and spin-waits until reclaim actually frees entries, with a 500 ms wall-clock deadlock backstop (see Section 5.4).
 
+On A5, a reclaim consumer that observes no reclaim progress for 10 ms sets its
+ring bit in `publication_request_mask`. The scheduler force-publishes its exact
+local `last_task_alive` under `advance_lock` and acknowledges the request before
+the orchestrator uses the watermark for structural deadlock detection.
+TensorMap pressure requests this publication from every ring because all rings
+share one entry pool. K=16 batching is enabled only after every reclaim
+consumer is wired to the current request/ack masks; incomplete wiring keeps
+per-advance publication.
+
 This back-pressure is essential for correctness with small ring sizes — for example, with `PTO2_RING_TASK_WINDOW=16` and 208 tasks, the orchestrator blocks ~192 times, each time waiting for the scheduler to drain completed tasks before continuing.
 
 ### 4.5 Deadlock Detection
@@ -590,12 +599,16 @@ advance_ring_pointers(ring_id):  // protected by per-ring advance_lock
         if task_state[la & mask] < CONSUMED: break
         reset slot for reuse
         la++
-    sync_to_sm()  // release-store last_task_alive
+    if force_publish or la - last_published_to_sm >= 16 or la == current_task_index:
+        sync_to_sm()  // release-store last_task_alive
 ```
 
-This is protected by a per-ring try-lock (`advance_lock`) in `RingSchedState`, ensuring only one scheduler thread advances a given ring's watermark at a time. If a scheduler thread changes a ring head to `CONSUMED` but loses this try-lock, it sets the ring bit in `advance_pending_mask`. Scheduler no-progress iterations drain that mask: each pending ring retries the same in-order `advance_ring_pointers()` under `advance_lock`, leaves the bit set while the lock is still busy, and treats a successful watermark advance as scheduler progress.
+This is protected by a per-ring try-lock (`advance_lock`) in `RingSchedState`, ensuring only one scheduler thread advances a given ring's watermark at a time. A scheduler thread that changes a ring head to `CONSUMED` but loses this try-lock sets the ring bit in `advance_pending_mask`; no-progress loops drain that mask. An orchestrator reclaim consumer with no reclaim progress for 10 ms instead sets `publication_request_mask`. Scheduler thread 0 drains only that request mask in both productive and no-progress iterations, force-publishes the exact watermark, and sets the matching bit in `publication_ack_mask`. The two masks occupy separate cache lines, so scheduler lock contention neither triggers acknowledgments nor invalidates the productive-loop request poll. Runtime wiring, relocation, and reuse enable K=16 batching only after the allocator, fanin pool, and dependency pool all point to the current masks; otherwise `sync_to_sm()` publishes each advance.
 
-For ring-heap stall triage, a `CONSUMED` head whose ring bit is still set means no retry has acquired `advance_lock` and cleared the deferred request yet. If the bit clears and the published `last_task_alive` remains pinned, the stall is outside this deferred consumed-head advance path.
+For ring-heap stall triage, a set request bit means no retry has yet acquired
+`advance_lock`. A matching acknowledgment means the published
+`last_task_alive` was synchronized with scheduler-local reclamation; only that
+acknowledged value is eligible for the exact open-scope head check.
 
 ### 8.5 SchedulerContext
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -514,11 +514,10 @@ static bool orch_wire_live_fanin_task(PTO2OrchestratorState *orch, PTO2TaskSlotS
     auto &rss = sched->ring_sched_states[slot_state.ring_id];
 
     // dep_pool is orchestrator-exclusive (no lock). ensure_space waits for the
-    // scheduler to advance last_task_alive and, on a wedged reclaim watermark,
-    // detects the deadlock with the same structural + wall-clock logic the
-    // heap/task-window allocator uses (all three share last_task_alive), latches
-    // PTO2_ERROR_DEP_POOL_OVERFLOW, and emits the structured report. A false
-    // return also covers a fatal already latched elsewhere.
+    // scheduler to publish last_task_alive and, on a wedged reclaim watermark,
+    // uses the same acknowledged-head structural check and wall-clock backstop
+    // as the heap/task-window allocator. A false return also covers a fatal
+    // already latched elsewhere.
     if (!rss.dep_pool.ensure_space(*rss.ring, wfanin, oldest_open_task_on_current_ring(orch))) {
         orch->fatal = true;
         return false;
@@ -782,6 +781,17 @@ static bool ensure_tensormap_capacity(PTO2OrchestratorState *orch, int32_t neede
         return true;
     }
 
+    uint32_t all_ring_bits = 0;
+    for (int32_t r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        all_ring_bits |= PTO2SchedulerState::ring_advance_pending_bit(r);
+    }
+    // No acknowledgment is consumed here because TensorMap reclamation has no
+    // structural head classification; repeated watermark reads are sufficient.
+    auto request_reclaim_publication = [&]() {
+        if (orch->scheduler == nullptr) return;
+        orch->scheduler->publication_ack_mask.fetch_and(~all_ring_bits, std::memory_order_acq_rel);
+        orch->scheduler->publication_request_mask.fetch_or(all_ring_bits, std::memory_order_release);
+    };
     int32_t alive[PTO2_MAX_RING_DEPTH];
     auto read_alive = [&]() {
         for (int32_t r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -839,7 +849,10 @@ static bool ensure_tensormap_capacity(PTO2OrchestratorState *orch, int32_t neede
             if (!block_timing) {
                 block_cycle0 = now;
                 block_timing = true;
-            } else if (now - block_cycle0 >= PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES) {
+            } else if (now - block_cycle0 >= PTO2_PUBLICATION_REQUEST_TIMEOUT_CYCLES) {
+                request_reclaim_publication();
+            }
+            if (now - block_cycle0 >= PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES) {
                 LOG_ERROR("========================================");
                 LOG_ERROR("FATAL: TensorMap Entry Pool Deadlock Detected!");
                 LOG_ERROR("========================================");

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -60,7 +60,15 @@ bool PTO2FaninPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t neede
     int32_t prev_last_alive = ring.fc.last_task_alive.load(std::memory_order_acquire);
     uint64_t block_cycle0 = 0;  // wall-clock anchor for the deadlock backstop
     bool block_timing = false;  // false until the first no-reclaim-progress spin
+    ReclaimPublicationRequest publication_request(reclaim_request_mask, reclaim_ack_mask, ring_id);
+    bool watermark_synchronized = !publication_request.enabled();
     while (available() < needed) {
+        if (!watermark_synchronized && publication_request.poll_acknowledged()) {
+            prev_last_alive = ring.fc.last_task_alive.load(std::memory_order_acquire);
+            reclaim(ring, prev_last_alive);
+            watermark_synchronized = true;
+            if (available() >= needed) return true;
+        }
         reclaim(ring, prev_last_alive);
         if (available() >= needed) return true;
 
@@ -71,6 +79,7 @@ bool PTO2FaninPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t neede
             spin_count = 0;
             prev_last_alive = cur_last_alive;
             block_timing = false;
+            watermark_synchronized = !publication_request.enabled();
         } else if ((spin_count & 1023) == 0) {
             // A fatal latched elsewhere breaks this otherwise-unbounded spin; the
             // caller maps the failed ensure_space to orch_mark_fatal. Cold path.
@@ -85,7 +94,10 @@ bool PTO2FaninPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t neede
             if (!block_timing) {
                 block_cycle0 = now;
                 block_timing = true;
-            } else if (now - block_cycle0 >= PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES) {
+            } else if (!watermark_synchronized && now - block_cycle0 >= PTO2_PUBLICATION_REQUEST_TIMEOUT_CYCLES) {
+                publication_request.request();
+            }
+            if (now - block_cycle0 >= PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES) {
                 int32_t current = ring.fc.current_task_index.load(std::memory_order_acquire);
                 LOG_ERROR("========================================");
                 LOG_ERROR("FATAL: Fanin Spill Pool Deadlock Detected!");
@@ -115,6 +127,7 @@ bool PTO2FaninPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t neede
                 latch_pool_error(error_code_ptr, PTO2_ERROR_DEP_POOL_OVERFLOW);
                 return false;
             }
+            watermark_synchronized = !publication_request.enabled();
         }
         SPIN_WAIT_HINT();
     }
@@ -185,7 +198,15 @@ bool PTO2DepListPool::ensure_space(
     int32_t prev_last_alive = ring.fc.last_task_alive.load(std::memory_order_acquire);
     uint64_t block_cycle0 = 0;  // wall-clock anchor for the deadlock backstop
     bool block_timing = false;  // false until the first no-reclaim-progress spin
+    ReclaimPublicationRequest publication_request(reclaim_request_mask, reclaim_ack_mask, ring_id);
+    bool watermark_synchronized = !publication_request.enabled();
     while (available() < needed) {
+        if (!watermark_synchronized && publication_request.poll_acknowledged()) {
+            prev_last_alive = ring.fc.last_task_alive.load(std::memory_order_acquire);
+            reclaim(ring, prev_last_alive);
+            watermark_synchronized = true;
+            if (available() >= needed) return true;
+        }
         reclaim(ring, prev_last_alive);
         if (available() >= needed) return true;
 
@@ -196,18 +217,28 @@ bool PTO2DepListPool::ensure_space(
             spin_count = 0;
             prev_last_alive = cur_last_alive;
             block_timing = false;
+            // Natural K-batched progress invalidates an older exact-publication
+            // acknowledgment before structural head classification.
+            watermark_synchronized = !publication_request.enabled();
         } else if ((spin_count & 1023) == 0) {
             // A fatal latched elsewhere breaks this otherwise-unbounded spin; the
             // caller maps the failed ensure_space to orch_mark_fatal. Cold path.
             if (error_code_ptr != nullptr && error_code_ptr->load(std::memory_order_acquire) != PTO2_ERROR_NONE) {
                 return false;
             }
-            // (1) Structural, immediate: no open scope can end while this
-            // orchestrator is blocked here, so its oldest task on this ring
-            // cannot become CONSUMED.
-            bool head_is_oldest_open_task = oldest_open_task != nullptr && ring.slot_states != nullptr &&
-                                            oldest_open_task == &ring.get_slot_state_by_task_id(cur_last_alive);
-            if (head_is_oldest_open_task) {
+            // (1) Structural, after publication acknowledgment: no open scope
+            // can end while this orchestrator is blocked here, so the
+            // synchronized oldest task on this ring cannot become CONSUMED.
+            uint64_t now = get_sys_cnt_aicpu();
+            if (!block_timing) {
+                block_cycle0 = now;
+                block_timing = true;
+            } else if (!watermark_synchronized && now - block_cycle0 >= PTO2_PUBLICATION_REQUEST_TIMEOUT_CYCLES) {
+                publication_request.request();
+            }
+            bool head_is_oldest_open_task = ring.slot_states != nullptr &&
+                                            reclaim_head_matches_open_task(cur_last_alive, ring_id, oldest_open_task);
+            if (watermark_synchronized && head_is_oldest_open_task) {
                 report_deadlock(ring, needed, cur_last_alive, /*scope_gated=*/true);
                 latch_pool_error(error_code_ptr, PTO2_ERROR_DEP_POOL_OVERFLOW);
                 return false;
@@ -215,15 +246,12 @@ bool PTO2DepListPool::ensure_space(
             // (2) Wall-clock backstop for the residual case the head test cannot
             // prove. Absolute time (get_sys_cnt_aicpu is an MMIO read), sampled
             // once per 1024 spins.
-            uint64_t now = get_sys_cnt_aicpu();
-            if (!block_timing) {
-                block_cycle0 = now;
-                block_timing = true;
-            } else if (now - block_cycle0 >= PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES) {
+            if (now - block_cycle0 >= PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES) {
                 report_deadlock(ring, needed, cur_last_alive, /*scope_gated=*/false);
                 latch_pool_error(error_code_ptr, PTO2_ERROR_DEP_POOL_OVERFLOW);
                 return false;
             }
+            watermark_synchronized = !publication_request.enabled();
         }
         SPIN_WAIT_HINT();
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -53,11 +53,55 @@
 
 // Block notification interval (in spin counts)
 #define PTO2_BLOCK_NOTIFY_INTERVAL 10000
+// Productive-loop publication is a liveness escape, not the normal pressure
+// path. Require sustained no-progress before bypassing K-batched publication.
+#define PTO2_PUBLICATION_REQUEST_TIMEOUT_CYCLES (PLATFORM_PROF_SYS_CNT_FREQ / 100)  // 10 ms
 // Heap/task deadlock is detected structurally when the reclaim head is the
 // oldest task owned by an open scope on the blocked ring. This wall-clock value
 // is the backstop for all other cases; it is an ABSOLUTE TIME (not a spin
 // count), so it is stable across chips/contention.
 #define PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES (PLATFORM_PROF_SYS_CNT_FREQ / 2)  // 500 ms
+
+constexpr uint32_t ring_mask_bit(int32_t ring_id) {
+    static_assert(PTO2_MAX_RING_DEPTH <= 32, "ring masks use one uint32_t bit per ring");
+    return 1u << static_cast<uint32_t>(ring_id);
+}
+
+inline bool
+reclaim_head_matches_open_task(int32_t head_task_id, uint8_t ring_id, const PTO2TaskSlotState *oldest_open_task) {
+    return oldest_open_task != nullptr && oldest_open_task->task != nullptr &&
+           oldest_open_task->task->task_id == PTO2TaskId::make(ring_id, static_cast<uint32_t>(head_task_id));
+}
+
+class ReclaimPublicationRequest {
+public:
+    ReclaimPublicationRequest(std::atomic<uint32_t> *request_mask, std::atomic<uint32_t> *ack_mask, uint8_t ring_id) :
+        request_mask_(request_mask),
+        ack_mask_(ack_mask),
+        bit_(ring_mask_bit(ring_id)) {}
+
+    bool enabled() const { return request_mask_ != nullptr && ack_mask_ != nullptr; }
+
+    void request() {
+        if (!enabled() || outstanding_) return;
+        ack_mask_->fetch_and(~bit_, std::memory_order_acq_rel);
+        request_mask_->fetch_or(bit_, std::memory_order_release);
+        outstanding_ = true;
+    }
+
+    bool poll_acknowledged() {
+        if (!enabled()) return true;
+        if (!outstanding_ || (ack_mask_->load(std::memory_order_acquire) & bit_) == 0) return false;
+        outstanding_ = false;
+        return true;
+    }
+
+private:
+    std::atomic<uint32_t> *request_mask_;
+    std::atomic<uint32_t> *ack_mask_;
+    uint32_t bit_;
+    bool outstanding_{false};
+};
 
 // =============================================================================
 // Task Allocator (unified task slot + heap buffer allocation)
@@ -109,6 +153,19 @@ public:
         heap_tail_ = 0;
         last_alive_seen_ = 0;
         heap_rebase_anchor_task_id_ = -1;
+        reclaim_request_mask_ = nullptr;
+        reclaim_ack_mask_ = nullptr;
+    }
+
+    void set_reclaim_publication_request(std::atomic<uint32_t> *request_mask, std::atomic<uint32_t> *ack_mask) {
+        reclaim_request_mask_ = request_mask;
+        reclaim_ack_mask_ = ack_mask;
+    }
+
+    bool reclaim_publication_is_wired_to(
+        const std::atomic<uint32_t> *request_mask, const std::atomic<uint32_t> *ack_mask, uint8_t expected_ring_id
+    ) const {
+        return reclaim_request_mask_ == request_mask && reclaim_ack_mask_ == ack_mask && ring_id_ == expected_ring_id;
     }
 
     /**
@@ -133,6 +190,8 @@ public:
         bool blocked_on_heap = false;
         uint64_t block_cycle0 = 0;  // wall-clock anchor for the deadlock backstop
         bool block_timing = false;  // false until the first no-reclaim-progress spin
+        ReclaimPublicationRequest publication_request(reclaim_request_mask_, reclaim_ack_mask_, ring_id_);
+        bool watermark_synchronized = !publication_request.enabled();
 #if SIMPLER_ORCH_PROFILING
         uint64_t wait_start = 0;
         bool waiting = false;
@@ -164,11 +223,20 @@ public:
 #endif
             last_alive = last_alive_ptr_->load(std::memory_order_acquire);
             update_heap_tail(last_alive);
+            if (!watermark_synchronized && publication_request.poll_acknowledged()) {
+                last_alive = last_alive_ptr_->load(std::memory_order_acquire);
+                update_heap_tail(last_alive);
+                watermark_synchronized = true;
+            }
             if (last_alive > prev_last_alive) {
                 // Reclaim advanced -> productive backpressure, not a deadlock.
                 spin_count = 0;
                 prev_last_alive = last_alive;
                 block_timing = false;
+                // Any later shared progress can again trail scheduler-local
+                // reclamation by K - 1, so a prior exact acknowledgment no
+                // longer proves that the current watermark is exact.
+                watermark_synchronized = !publication_request.enabled();
             } else if ((spin_count & 1023) == 0) {
                 // A fatal latched elsewhere breaks this otherwise-unbounded spin; the
                 // caller maps the failed alloc to orch_mark_fatal. Polled on the
@@ -181,21 +249,24 @@ public:
                 // get_sys_cnt_aicpu() is a cheap cntvct_el0 read, while this
                 // block polls the fatal flag and compares the reclaim head with
                 // the oldest task pinned by an open scope on this ring.
-                // (1) Structural, immediate: no open scope can end while this
-                // orchestrator is blocked here, so that head cannot become
-                // CONSUMED.
-                if (head_is_oldest_open_task(last_alive, oldest_open_task)) {
+                uint64_t now = get_sys_cnt_aicpu();
+                if (!block_timing) {
+                    block_cycle0 = now;
+                    block_timing = true;
+                } else if (!watermark_synchronized && now - block_cycle0 >= PTO2_PUBLICATION_REQUEST_TIMEOUT_CYCLES) {
+                    publication_request.request();
+                }
+                // (1) Structural, after publication acknowledgment: no open
+                // scope can end while this orchestrator is blocked here, so
+                // the synchronized head cannot become CONSUMED.
+                if (watermark_synchronized && head_is_oldest_open_task(last_alive, oldest_open_task)) {
                     report_deadlock(output_size, blocked_on_heap, /*scope_gated=*/true);
                     return {-1, -1, nullptr, nullptr};
                 }
                 // (2) Wall-clock backstop for the residual case the local head
                 // test can't prove (e.g. a closed sibling whose consumer is
                 // deferred). Absolute time, not a spin count.
-                uint64_t now = get_sys_cnt_aicpu();
-                if (!block_timing) {
-                    block_cycle0 = now;
-                    block_timing = true;
-                } else if (now - block_cycle0 >= PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES) {
+                if (now - block_cycle0 >= PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES) {
                     report_deadlock(output_size, blocked_on_heap, /*scope_gated=*/false);
                     return {-1, -1, nullptr, nullptr};
                 }
@@ -207,6 +278,7 @@ public:
                         heap_size_, heap_available(), heap_top_, blocked_on_heap ? "heap" : "task", spin_count
                     );
                 }
+                watermark_synchronized = !publication_request.enabled();
             }
             SPIN_WAIT_HINT();
         }
@@ -278,6 +350,8 @@ private:
 
     // --- Shared ---
     std::atomic<int32_t> *error_code_ptr_ = nullptr;
+    std::atomic<uint32_t> *reclaim_request_mask_ = nullptr;
+    std::atomic<uint32_t> *reclaim_ack_mask_ = nullptr;
 
     // =========================================================================
     // Internal helpers
@@ -406,8 +480,7 @@ private:
 #endif
 
     bool head_is_oldest_open_task(int32_t head_task_id, const PTO2TaskSlotState *oldest_open_task) const {
-        return oldest_open_task != nullptr && slot_states_ != nullptr &&
-               oldest_open_task == &slot_states_[head_task_id & window_mask_];
+        return slot_states_ != nullptr && reclaim_head_matches_open_task(head_task_id, ring_id_, oldest_open_task);
     }
 
     /**
@@ -511,6 +584,9 @@ struct PTO2FaninPool {
     int32_t reclaim_task_cursor{0};  // Last task id scanned for reclaim on this pool
 
     std::atomic<int32_t> *error_code_ptr = nullptr;
+    std::atomic<uint32_t> *reclaim_request_mask = nullptr;
+    std::atomic<uint32_t> *reclaim_ack_mask = nullptr;
+    uint8_t ring_id = 0;
 
     void init(PTO2FaninSpillEntry *in_base, int32_t in_capacity, std::atomic<int32_t> *in_error_code_ptr) {
         base = in_base;
@@ -521,6 +597,23 @@ struct PTO2FaninPool {
         reclaim_task_cursor = 0;
         base[0].clear();
         error_code_ptr = in_error_code_ptr;
+        reclaim_request_mask = nullptr;
+        reclaim_ack_mask = nullptr;
+        ring_id = 0;
+    }
+
+    void set_reclaim_publication_request(
+        std::atomic<uint32_t> *request_mask, std::atomic<uint32_t> *ack_mask, uint8_t in_ring_id
+    ) {
+        reclaim_request_mask = request_mask;
+        reclaim_ack_mask = ack_mask;
+        ring_id = in_ring_id;
+    }
+
+    bool reclaim_publication_is_wired_to(
+        const std::atomic<uint32_t> *request_mask, const std::atomic<uint32_t> *ack_mask, uint8_t expected_ring_id
+    ) const {
+        return reclaim_request_mask == request_mask && reclaim_ack_mask == ack_mask && ring_id == expected_ring_id;
     }
 
     void reset_for_reuse(std::atomic<int32_t> *in_error_code_ptr) {
@@ -679,6 +772,9 @@ struct PTO2DepListPool {
 
     // Error code pointer for fatal error reporting (→ sm_header->orch_error_code)
     std::atomic<int32_t> *error_code_ptr = nullptr;
+    std::atomic<uint32_t> *reclaim_request_mask = nullptr;
+    std::atomic<uint32_t> *reclaim_ack_mask = nullptr;
+    uint8_t ring_id = 0;
 
     /**
      *
@@ -699,6 +795,23 @@ struct PTO2DepListPool {
         base[0].next = nullptr;
 
         error_code_ptr = in_error_code_ptr;
+        reclaim_request_mask = nullptr;
+        reclaim_ack_mask = nullptr;
+        ring_id = 0;
+    }
+
+    void set_reclaim_publication_request(
+        std::atomic<uint32_t> *request_mask, std::atomic<uint32_t> *ack_mask, uint8_t in_ring_id
+    ) {
+        reclaim_request_mask = request_mask;
+        reclaim_ack_mask = ack_mask;
+        ring_id = in_ring_id;
+    }
+
+    bool reclaim_publication_is_wired_to(
+        const std::atomic<uint32_t> *request_mask, const std::atomic<uint32_t> *ack_mask, uint8_t expected_ring_id
+    ) const {
+        return reclaim_request_mask == request_mask && reclaim_ack_mask == ack_mask && ring_id == expected_ring_id;
     }
 
     void reset_for_reuse(std::atomic<int32_t> *in_error_code_ptr) {
@@ -724,8 +837,9 @@ struct PTO2DepListPool {
      * Ensure dep pool for a specific ring has at least `needed` entries available.
      * Spin-waits for reclamation under pressure. The dep pool shares
      * last_task_alive with the heap and task rings, so it detects a wedged
-     * reclaim watermark the same way PTO2TaskAllocator::alloc does: a structural
-     * head-of-line check plus a wall-clock backstop, each emitting report_deadlock.
+     * reclaim watermark the same way PTO2TaskAllocator::alloc does: request an
+     * exact publication, then use a structural head-of-line check plus a
+     * wall-clock backstop, each emitting report_deadlock.
      */
     bool ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed, PTO2TaskSlotState *oldest_open_task = nullptr);
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -448,9 +448,15 @@ struct PTO2SchedulerState {
 
     // Per-ring state
     struct alignas(64) RingSchedState {
+        static constexpr int32_t PUBLISH_INTERVAL_K = 16;
+
         // --- Cache Line 0: ring pointer (read-only) + hot path (read-write) ---
         PTO2SharedMemoryRingHeader *ring;
         int32_t last_task_alive;
+        // Publication may trail local reclamation by PUBLISH_INTERVAL_K - 1
+        // tasks only while no reclaim consumer is blocked on the watermark.
+        int32_t last_published_to_sm{0};
+        bool publication_batching_enabled{false};
         std::atomic<int32_t> advance_lock;  // multi-thread CAS
 
         // --- Cache Line 1+: Orch-side wiring dep_pool ---
@@ -470,7 +476,14 @@ struct PTO2SchedulerState {
         void reset_for_reuse(void *sm_dev_base, int32_t ring_id, std::atomic<int32_t> *orch_err);
         void destroy();
 
-        void sync_to_sm() { ring->fc.last_task_alive.store(last_task_alive, std::memory_order_release); }
+        void sync_to_sm(bool force = false) {
+            if (last_task_alive == last_published_to_sm) return;
+            if (publication_batching_enabled && !force && last_task_alive - last_published_to_sm < PUBLISH_INTERVAL_K) {
+                return;
+            }
+            ring->fc.last_task_alive.store(last_task_alive, std::memory_order_release);
+            last_published_to_sm = last_task_alive;
+        }
 
 #if SIMPLER_DFX
         void publish_dep_pool_snapshot() {
@@ -485,7 +498,7 @@ struct PTO2SchedulerState {
         }
 #endif
 
-        void advance_ring_pointers() {
+        void advance_ring_pointers(bool force_publish = false) {
             int32_t current_task_index = ring->fc.current_task_index.load(std::memory_order_acquire);
             int32_t old_last_task_alive = last_task_alive;
 
@@ -506,11 +519,13 @@ struct PTO2SchedulerState {
                 ring->get_slot_state_by_task_id(id).reset_for_reuse();
             }
 
-            sync_to_sm();
+            sync_to_sm(force_publish || last_task_alive == current_task_index);
         }
     } ring_sched_states[PTO2_MAX_RING_DEPTH];
 
     alignas(64) std::atomic<uint32_t> advance_pending_mask;
+    alignas(64) std::atomic<uint32_t> publication_request_mask;
+    std::atomic<uint32_t> publication_ack_mask;
 
     // Ready queues remain global (scheduling is ring-agnostic)
     PTO2ReadyQueue ready_queues[PTO2_NUM_RESOURCE_SHAPES];
@@ -554,15 +569,15 @@ struct PTO2SchedulerState {
         }
     }
 
-    static uint32_t ring_advance_pending_bit(int32_t ring_id) {
-        static_assert(PTO2_MAX_RING_DEPTH <= 32, "advance_pending_mask uses one uint32_t bit per ring");
-        return 1u << static_cast<uint32_t>(ring_id);
+    static uint32_t ring_advance_pending_bit(int32_t ring_id) { return ring_mask_bit(ring_id); }
+
+    void set_publication_batching_enabled(bool enabled) {
+        for (auto &ring_sched : ring_sched_states) {
+            ring_sched.publication_batching_enabled = enabled;
+        }
     }
 
-    // A failed consumed-head advance is a deferred reclaim publication request.
-    // The mask keeps one coalesced request per ring. Later successful advances
-    // may cover it before the scheduler no-progress path drains the final
-    // missed edge.
+    // Failed consumed-head advances remain deferred until a no-progress drain.
     void mark_ring_advance_pending(int32_t ring_id) {
         advance_pending_mask.fetch_or(ring_advance_pending_bit(ring_id), std::memory_order_release);
     }
@@ -586,8 +601,37 @@ struct PTO2SchedulerState {
 
             advance_pending_mask.fetch_and(~bit, std::memory_order_acq_rel);
             int32_t before = ring_sched.last_task_alive;
-            ring_sched.advance_ring_pointers();
+            ring_sched.advance_ring_pointers(true);
             advanced = advanced || ring_sched.last_task_alive != before;
+            ring_sched.advance_lock.store(0, std::memory_order_release);
+        }
+        return advanced;
+    }
+
+    bool drain_publication_requests() {
+        uint32_t requests = publication_request_mask.load(std::memory_order_acquire);
+        if (requests == 0) return false;
+
+        bool advanced = false;
+        for (int32_t ring_id = 0; ring_id < PTO2_MAX_RING_DEPTH; ring_id++) {
+            uint32_t bit = ring_advance_pending_bit(ring_id);
+            if ((requests & bit) == 0) continue;
+
+            auto &ring_sched = ring_sched_states[ring_id];
+            int32_t expected_lock = 0;
+            if (!ring_sched.advance_lock.compare_exchange_strong(
+                    expected_lock, 1, std::memory_order_acquire, std::memory_order_relaxed
+                )) {
+                continue;
+            }
+
+            publication_request_mask.fetch_and(~bit, std::memory_order_acq_rel);
+            int32_t before_alive = ring_sched.last_task_alive;
+            int32_t before_published = ring_sched.last_published_to_sm;
+            ring_sched.advance_ring_pointers(true);
+            publication_ack_mask.fetch_or(bit, std::memory_order_release);
+            advanced = advanced || ring_sched.last_task_alive != before_alive ||
+                       ring_sched.last_published_to_sm != before_published;
             ring_sched.advance_lock.store(0, std::memory_order_release);
         }
         return advanced;
@@ -1258,8 +1302,9 @@ struct PTO2SchedulerState {
     void reset_for_reuse(const PTO2SchedulerLayout &layout, void *sm_dev_base);
 
     // Phase 3b: write the arena-internal pointer fields
-    // (ready_queues[].slots, dummy_ready_queue.slots, dep_pool.base for each
-    // ring). Called on both host and device sides.
+    // (ready_queues[].slots, dummy_ready_queue.slots, and dep_pool base plus
+    // reclaim-publication pointers for each ring). Called on both host and
+    // device sides.
     void wire_arena_pointers(const PTO2SchedulerLayout &layout, DeviceArena &arena);
 
     // Forget per-region pointers; arena owns the backing memory.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -1281,6 +1281,13 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         (void)try_pushed;
 #endif
 
+        // One servicer is sufficient because request bits stay latched until
+        // acknowledged. Drain mode can delay thread 0, but its completion
+        // depends on worker-core release rather than orchestrator reclamation.
+        if (thread_idx == 0 && made_progress && sched_->drain_publication_requests()) {
+            last_progress_ts = get_sys_cnt_aicpu();
+        }
+
         if (made_progress) {
             idle_iterations = 0;
             last_progress_ts = get_sys_cnt_aicpu();
@@ -1312,7 +1319,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             // still set means no retry has acquired advance_lock and cleared
             // the request yet. If the bit clears and the watermark remains
             // pinned, the stall is outside this deferred-advance path.
-            bool advanced_reclaim = sched_->drain_pending_ring_advances();
+            bool advanced_reclaim = thread_idx == 0 && sched_->drain_publication_requests();
+            advanced_reclaim = sched_->drain_pending_ring_advances() || advanced_reclaim;
             if (advanced_reclaim) {
                 idle_iterations = 0;
                 last_progress_ts = get_sys_cnt_aicpu();

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
@@ -90,6 +90,8 @@ bool PTO2SchedulerState::RingSchedState::init_data_from_layout(void *sm_dev_base
     // arithmetic, no SM load.
     ring = pto2_sm_layout::ring_header_addr(sm_dev_base, ring_id);
     last_task_alive = 0;
+    last_published_to_sm = 0;
+    publication_batching_enabled = false;
     advance_lock.store(0, std::memory_order_relaxed);
 #if SIMPLER_DFX
     dep_pool_snapshot_tail.store(1, std::memory_order_relaxed);
@@ -109,6 +111,8 @@ void PTO2SchedulerState::RingSchedState::reset_for_reuse(
 ) {
     ring = pto2_sm_layout::ring_header_addr(sm_dev_base, ring_id);
     last_task_alive = 0;
+    last_published_to_sm = 0;
+    publication_batching_enabled = false;
     advance_lock.store(0, std::memory_order_relaxed);
     dep_pool.reset_for_reuse(orch_err);
 #if SIMPLER_DFX
@@ -117,7 +121,10 @@ void PTO2SchedulerState::RingSchedState::reset_for_reuse(
 #endif
 }
 
-void PTO2SchedulerState::RingSchedState::destroy() { ring = nullptr; }
+void PTO2SchedulerState::RingSchedState::destroy() {
+    publication_batching_enabled = false;
+    ring = nullptr;
+}
 
 PTO2SchedulerLayout PTO2SchedulerState::reserve_layout(DeviceArena &arena, int32_t dep_pool_capacity) {
     int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
@@ -161,6 +168,8 @@ bool PTO2SchedulerState::init_data_from_layout(
     PTO2SchedulerState *sched = this;
     sched->sm_header = reinterpret_cast<PTO2SharedMemoryHeader *>(sm_dev_base);
     sched->advance_pending_mask.store(0, std::memory_order_relaxed);
+    sched->publication_request_mask.store(0, std::memory_order_relaxed);
+    sched->publication_ack_mask.store(0, std::memory_order_relaxed);
 #if SIMPLER_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
     sched->tasks_consumed.store(0, std::memory_order_relaxed);
@@ -211,6 +220,9 @@ bool PTO2SchedulerState::init_data_from_layout(
         auto *dep_entries = static_cast<PTO2DepListEntry *>(arena.region_ptr(layout.off_dep_pool_entries[r]));
         memset(dep_entries, 0, static_cast<size_t>(layout.dep_pool_capacities[r]) * sizeof(PTO2DepListEntry));
         sched->ring_sched_states[r].dep_pool.init(dep_entries, layout.dep_pool_capacities[r], orch_err);
+        sched->ring_sched_states[r].dep_pool.set_reclaim_publication_request(
+            &sched->publication_request_mask, &sched->publication_ack_mask, static_cast<uint8_t>(r)
+        );
     }
 
     return true;
@@ -220,6 +232,8 @@ void PTO2SchedulerState::reset_for_reuse(const PTO2SchedulerLayout &layout, void
     PTO2SchedulerState *sched = this;
     sched->sm_header = reinterpret_cast<PTO2SharedMemoryHeader *>(sm_dev_base);
     sched->advance_pending_mask.store(0, std::memory_order_relaxed);
+    sched->publication_request_mask.store(0, std::memory_order_relaxed);
+    sched->publication_ack_mask.store(0, std::memory_order_relaxed);
 #if SIMPLER_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
     sched->tasks_consumed.store(0, std::memory_order_relaxed);
@@ -262,8 +276,11 @@ void PTO2SchedulerState::wire_arena_pointers(const PTO2SchedulerLayout &layout, 
     }
     ready_queue_wire_arena_pointers(&sched->early_sync_start_queue, arena, layout.off_early_sync_start_queue_slots);
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        sched->ring_sched_states[r].dep_pool.base =
-            static_cast<PTO2DepListEntry *>(arena.region_ptr(layout.off_dep_pool_entries[r]));
+        auto &dep_pool = sched->ring_sched_states[r].dep_pool;
+        dep_pool.base = static_cast<PTO2DepListEntry *>(arena.region_ptr(layout.off_dep_pool_entries[r]));
+        dep_pool.set_reclaim_publication_request(
+            &sched->publication_request_mask, &sched->publication_ack_mask, static_cast<uint8_t>(r)
+        );
     }
 }
 
@@ -456,6 +473,11 @@ bool PTO2OrchestratorState::reset_for_reuse(
             task_descs_dev, static_cast<int32_t>(task_window_sizes[r]), cur_idx_dev, last_alive_dev, ring_heap_base,
             heap_sizes[r], orch_err, slot_states_dev, 0, static_cast<uint8_t>(r)
         );
+        if (orch->scheduler != nullptr) {
+            orch->rings[r].task_allocator.set_reclaim_publication_request(
+                &orch->scheduler->publication_request_mask, &orch->scheduler->publication_ack_mask
+            );
+        }
         heap_offset += heap_sizes[r];
         orch->rings[r].fanin_pool.reset_for_reuse(orch_err);
     }
@@ -487,7 +509,7 @@ void PTO2OrchestratorState::wire_arena_pointers(
     orch->tensor_map.wire_arena_pointers(layout.tensor_map, arena);
     orch->scope_tasks = static_cast<PTO2TaskSlotState **>(arena.region_ptr(layout.off_scope_tasks));
     orch->scope_begins = static_cast<int32_t *>(arena.region_ptr(layout.off_scope_begins));
-    orch->scheduler = scheduler_arg;
+    orch->set_scheduler(scheduler_arg);
 }
 
 void PTO2OrchestratorState::destroy() {
@@ -501,7 +523,18 @@ void PTO2OrchestratorState::destroy() {
     orch->scope_begins = nullptr;
 }
 
-void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler) { this->scheduler = scheduler; }
+void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler_arg) {
+    scheduler = scheduler_arg;
+    if (scheduler == nullptr) return;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        rings[r].task_allocator.set_reclaim_publication_request(
+            &scheduler->publication_request_mask, &scheduler->publication_ack_mask
+        );
+        rings[r].fanin_pool.set_reclaim_publication_request(
+            &scheduler->publication_request_mask, &scheduler->publication_ack_mask, static_cast<uint8_t>(r)
+        );
+    }
+}
 
 // =============================================================================
 // Top-level runtime arena
@@ -593,11 +626,37 @@ PTO2Runtime *runtime_init_data_from_layout(
     return rt;
 }
 
+static bool reclaim_publication_wiring_is_complete(const PTO2Runtime *rt) {
+    if (rt == nullptr || rt->orchestrator.scheduler != &rt->scheduler) return false;
+
+    const auto *request_mask = &rt->scheduler.publication_request_mask;
+    const auto *ack_mask = &rt->scheduler.publication_ack_mask;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        uint8_t ring_id = static_cast<uint8_t>(r);
+        if (!rt->orchestrator.rings[r].task_allocator.reclaim_publication_is_wired_to(
+                request_mask, ack_mask, ring_id
+            ) ||
+            !rt->orchestrator.rings[r].fanin_pool.reclaim_publication_is_wired_to(request_mask, ack_mask, ring_id) ||
+            !rt->scheduler.ring_sched_states[r].dep_pool.reclaim_publication_is_wired_to(
+                request_mask, ack_mask, ring_id
+            )) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void enable_publication_batching_if_safe(PTO2Runtime *rt) {
+    rt->scheduler.set_publication_batching_enabled(reclaim_publication_wiring_is_complete(rt));
+}
+
 void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt) {
+    rt->scheduler.set_publication_batching_enabled(false);
     rt->sm_handle = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(layout.offsets.off_sm_handle));
     rt->aicore_mailbox = static_cast<AICoreCompletionMailbox *>(arena.region_ptr(layout.offsets.off_mailbox));
     rt->orchestrator.wire_arena_pointers(layout.offsets.orch, arena, &rt->scheduler);
     rt->scheduler.wire_arena_pointers(layout.offsets.sched, arena);
+    enable_publication_batching_if_safe(rt);
 }
 
 bool runtime_reset_for_reuse(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt) {
@@ -605,6 +664,8 @@ bool runtime_reset_for_reuse(DeviceArena &arena, const PTO2RuntimeArenaLayout &l
     if (rt == nullptr) {
         return false;
     }
+
+    rt->scheduler.set_publication_batching_enabled(false);
 
     rt->pending_scope_mode = PTO2ScopeMode::AUTO;
     rt->total_cycles = 0;
@@ -623,6 +684,7 @@ bool runtime_reset_for_reuse(DeviceArena &arena, const PTO2RuntimeArenaLayout &l
         return false;
     }
     rt->scheduler.reset_for_reuse(layout.offsets.sched, rt->sm_handle->sm_base);
+    enable_publication_batching_if_safe(rt);
     return true;
 }
 

--- a/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
+++ b/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "utils/device_arena.h"
@@ -57,6 +58,16 @@ protected:
         sched.destroy();
         runtime_arena.release();
         sm_arena.release();
+    }
+
+    std::thread service_reclaim_publication_once(uint8_t ring_id) {
+        return std::thread([this, ring_id]() {
+            uint32_t bit = PTO2SchedulerState::ring_advance_pending_bit(ring_id);
+            while ((sched.publication_request_mask.load(std::memory_order_acquire) & bit) == 0) {
+                std::this_thread::yield();
+            }
+            sched.drain_publication_requests();
+        });
     }
 };
 
@@ -258,9 +269,11 @@ TEST_F(OrchestratorFaninTest, SubmitPathHeapDeadlockLogReportsRingAndRealHeapSta
 
     CoreTaskArgs blocked_args;
     add_runtime_output_arg(blocked_args, create_infos, 1);
+    std::thread scheduler = service_reclaim_publication_once(1);
     testing::internal::CaptureStderr();
     TaskOutputTensors blocked = orch.submit_dummy_task(blocked_args);
     std::string log = testing::internal::GetCapturedStderr();
+    scheduler.join();
 
     EXPECT_FALSE(blocked.task_id().is_valid());
     EXPECT_TRUE(orch.fatal);
@@ -292,9 +305,11 @@ TEST_F(OrchestratorFaninTest, StructuralCheckRejectsOpenAncestorWhenNestedScopes
 
     CoreTaskArgs child_args;
     add_runtime_output_arg(child_args, create_infos, 1);
+    std::thread scheduler = service_reclaim_publication_once(PTO2_MAX_RING_DEPTH - 1);
     testing::internal::CaptureStderr();
     TaskOutputTensors child = orch.submit_dummy_task(child_args);
     std::string log = testing::internal::GetCapturedStderr();
+    scheduler.join();
 
     EXPECT_FALSE(child.task_id().is_valid());
     EXPECT_TRUE(orch.fatal);

--- a/tests/ut/cpp/a5/test_scheduler_state.cpp
+++ b/tests/ut/cpp/a5/test_scheduler_state.cpp
@@ -161,6 +161,22 @@ protected:
 // check_and_handle_consumed
 // =============================================================================
 
+TEST_F(SchedulerStateTest, UnvalidatedWiringPublishesEveryAdvance) {
+    constexpr int32_t ring_id = 0;
+    PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
+    PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
+
+    EXPECT_FALSE(ring_sched.publication_batching_enabled);
+    ring.fc.current_task_index.store(2, std::memory_order_release);
+    init_ring_slot(ring, 0, PTO2_TASK_CONSUMED, ring_id);
+    init_ring_slot(ring, 1, PTO2_TASK_PENDING, ring_id);
+
+    ring_sched.advance_ring_pointers();
+
+    EXPECT_EQ(ring_sched.last_task_alive, 1);
+    EXPECT_EQ(ring.fc.last_task_alive.load(std::memory_order_acquire), 1);
+}
+
 TEST_F(SchedulerStateTest, ConsumedNotReady) {
     alignas(64) PTO2TaskSlotState slot;
     init_slot(slot, PTO2_TASK_COMPLETED, 1, 2);
@@ -250,6 +266,43 @@ TEST_F(SchedulerStateTest, ContendedConsumedHeadSetsPendingAndIdleDrainAdvances)
     EXPECT_TRUE(sched.drain_pending_ring_advances());
     EXPECT_EQ(ring_sched.last_task_alive, head_task_id + 1);
     EXPECT_EQ(ring.fc.last_task_alive.load(std::memory_order_acquire), head_task_id + 1);
+    EXPECT_EQ(sched.advance_pending_mask.load(std::memory_order_acquire) & pending_bit, 0u);
+}
+
+TEST_F(SchedulerStateTest, DeferredAdvanceDoesNotAcknowledgePublication) {
+    constexpr int32_t ring_id = PTO2_MAX_RING_DEPTH - 1;
+    constexpr int32_t head_task_id = 17;
+    setup_contended_head_case(ring_id, head_task_id);
+
+    PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
+    PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
+    PTO2TaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
+    uint32_t pending_bit = PTO2SchedulerState::ring_advance_pending_bit(ring_id);
+
+    sched.publication_ack_mask.store(0, std::memory_order_release);
+    ring_sched.advance_lock.store(1, std::memory_order_release);
+    sched.check_and_handle_consumed(head);
+    ring_sched.advance_lock.store(0, std::memory_order_release);
+
+    ASSERT_TRUE(sched.drain_pending_ring_advances());
+    EXPECT_EQ(sched.publication_ack_mask.load(std::memory_order_acquire) & pending_bit, 0u);
+    EXPECT_EQ(sched.publication_request_mask.load(std::memory_order_acquire) & pending_bit, 0u);
+}
+
+TEST_F(SchedulerStateTest, PublicationRequestDoesNotConsumeDeferredAdvance) {
+    constexpr int32_t ring_id = PTO2_MAX_RING_DEPTH - 1;
+    setup_ring_for_reclaim_race(ring_id, /*current_task_index=*/1, /*blocked_task_id=*/1);
+
+    uint32_t pending_bit = PTO2SchedulerState::ring_advance_pending_bit(ring_id);
+    sched.advance_pending_mask.fetch_or(pending_bit, std::memory_order_release);
+    sched.publication_request_mask.fetch_or(pending_bit, std::memory_order_release);
+
+    ASSERT_TRUE(sched.drain_publication_requests());
+    EXPECT_EQ(sched.publication_request_mask.load(std::memory_order_acquire) & pending_bit, 0u);
+    EXPECT_NE(sched.publication_ack_mask.load(std::memory_order_acquire) & pending_bit, 0u);
+    EXPECT_NE(sched.advance_pending_mask.load(std::memory_order_acquire) & pending_bit, 0u);
+
+    EXPECT_FALSE(sched.drain_pending_ring_advances());
     EXPECT_EQ(sched.advance_pending_mask.load(std::memory_order_acquire) & pending_bit, 0u);
 }
 

--- a/tests/ut/cpp/a5/test_shared_memory.cpp
+++ b/tests/ut/cpp/a5/test_shared_memory.cpp
@@ -255,6 +255,9 @@ TEST(RuntimeArenaLayout, PerRingConfigInitializesRuntimeComponents) {
     PTO2Runtime *rt =
         runtime_init_data_from_layout(runtime_arena, layout, PTO2_MODE_EXECUTE, sm, sm_size, gm.data(), heaps);
     ASSERT_NE(rt, nullptr);
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        EXPECT_FALSE(rt->scheduler.ring_sched_states[r].publication_batching_enabled);
+    }
     runtime_wire_arena_pointers(runtime_arena, layout, rt);
 
     EXPECT_EQ(rt->gm_heap_size, total_heap);
@@ -266,6 +269,50 @@ TEST(RuntimeArenaLayout, PerRingConfigInitializesRuntimeComponents) {
         EXPECT_EQ(rt->orchestrator.rings[r].task_allocator.heap_capacity(), heaps[r]);
         EXPECT_EQ(rt->orchestrator.rings[r].fanin_pool.capacity, dep_caps[r]);
         EXPECT_EQ(rt->scheduler.ring_sched_states[r].dep_pool.capacity, dep_caps[r]);
+        EXPECT_TRUE(rt->scheduler.ring_sched_states[r].publication_batching_enabled);
+    }
+
+    rt->sm_handle->sm_base = sm;
+    ASSERT_TRUE(runtime_reset_for_reuse(runtime_arena, layout, rt));
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        EXPECT_TRUE(rt->scheduler.ring_sched_states[r].publication_batching_enabled);
+    }
+}
+
+TEST(RuntimeArenaLayout, RewiresReclaimPublicationPointersAfterRelocation) {
+    uint64_t ws[PTO2_MAX_RING_DEPTH] = {16, 32, 64, 128};
+    uint64_t heaps[PTO2_MAX_RING_DEPTH] = {10 * 1024, 20 * 1024, 30 * 1024, 40 * 1024};
+    int32_t dep_caps[PTO2_MAX_RING_DEPTH] = {4, 8, 16, 32};
+    const uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(ws);
+
+    DeviceArena source_arena;
+    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(source_arena, ws, heaps, dep_caps);
+    ASSERT_NE(source_arena.commit(DeviceArena::kDefaultBaseAlign), nullptr);
+
+    std::vector<char> sm(static_cast<size_t>(sm_size));
+    std::vector<char> gm(100 * 1024);
+    PTO2Runtime *source_rt =
+        runtime_init_data_from_layout(source_arena, layout, PTO2_MODE_EXECUTE, sm.data(), sm_size, gm.data(), heaps);
+    ASSERT_NE(source_rt, nullptr);
+    runtime_wire_arena_pointers(source_arena, layout, source_rt);
+
+    DeviceArena relocated_arena;
+    PTO2RuntimeArenaLayout relocated_layout = runtime_reserve_layout(relocated_arena, ws, heaps, dep_caps);
+    ASSERT_EQ(relocated_layout.offsets.off_runtime, layout.offsets.off_runtime);
+    ASSERT_EQ(relocated_arena.total_size(), source_arena.total_size());
+    ASSERT_NE(relocated_arena.commit(DeviceArena::kDefaultBaseAlign), nullptr);
+    std::memcpy(relocated_arena.base(), source_arena.base(), source_arena.total_size());
+
+    auto *relocated_rt = static_cast<PTO2Runtime *>(relocated_arena.region_ptr(layout.offsets.off_runtime));
+    runtime_wire_arena_pointers(relocated_arena, layout, relocated_rt);
+
+    ASSERT_NE(&relocated_rt->scheduler, &source_rt->scheduler);
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        auto &dep_pool = relocated_rt->scheduler.ring_sched_states[r].dep_pool;
+        EXPECT_EQ(dep_pool.reclaim_request_mask, &relocated_rt->scheduler.publication_request_mask);
+        EXPECT_EQ(dep_pool.reclaim_ack_mask, &relocated_rt->scheduler.publication_ack_mask);
+        EXPECT_EQ(dep_pool.ring_id, r);
+        EXPECT_TRUE(relocated_rt->scheduler.ring_sched_states[r].publication_batching_enabled);
     }
 }
 

--- a/tests/ut/cpp/a5/test_wiring.cpp
+++ b/tests/ut/cpp/a5/test_wiring.cpp
@@ -25,6 +25,7 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
 #include <cstring>
 #include <thread>
 #include <vector>
@@ -61,6 +62,7 @@ protected:
         ASSERT_TRUE(sched.init_data_from_layout(layout, sched_arena, sm_handle->header));
         sched.wire_arena_pointers(layout, sched_arena);
         orch.set_scheduler(&sched);
+        sched.set_publication_batching_enabled(true);
     }
 
     void TearDown() override {
@@ -110,7 +112,38 @@ protected:
         }
         ASSERT_TRUE(ok);
     }
+
+    // Service reclaim-publication requests until the blocked waiter sets
+    // `done`. The waiter thread can start arbitrarily late when ctest runs
+    // several large binaries in parallel, so the servicing loop must keep
+    // draining until the waiter finishes: a request latched after a
+    // fixed-window sample would never be serviced, and the waiter would
+    // burn its 500 ms wall-clock backstop into a false deadlock.
+    bool service_reclaim_publication_until_done(const std::atomic<bool> &done) {
+        bool saw_request = false;
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(15);
+        while (!done.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < deadline) {
+            if (sched.publication_request_mask.load(std::memory_order_acquire) != 0) {
+                saw_request = true;
+                EXPECT_TRUE(sched.drain_publication_requests());
+            }
+            std::this_thread::yield();
+        }
+        return saw_request;
+    }
 };
+
+TEST(ReclaimHeadMatchTest, ComparesExactRingAndLocalTaskId) {
+    PTO2TaskDescriptor descriptor{};
+    PTO2TaskSlotState slot{};
+    slot.task = &descriptor;
+    descriptor.task_id = PTO2TaskId::make(0, 16);
+
+    EXPECT_FALSE(reclaim_head_matches_open_task(0, 0, &slot));
+    EXPECT_TRUE(reclaim_head_matches_open_task(16, 0, &slot));
+    EXPECT_FALSE(reclaim_head_matches_open_task(16, 1, &slot));
+    EXPECT_FALSE(reclaim_head_matches_open_task(16, 0, nullptr));
+}
 
 // =============================================================================
 // Orch-side publish: no fanin (independent task)
@@ -583,6 +616,220 @@ TEST_F(WiringTest, AdvanceRingPointersScansConsumed) {
 
     // Verify SM was synced
     EXPECT_EQ(ring->fc.last_task_alive.load(), 3);
+}
+
+TEST_F(WiringTest, AdvanceRingPointersBatchesSharedMemoryPublication) {
+    auto &rss = sched.ring_sched_states[0];
+    auto *ring = rss.ring;
+
+    ring->fc.current_task_index.store(18, std::memory_order_release);
+    for (int i = 0; i < 17; i++) {
+        ring->get_slot_state_by_task_id(i).task_state.store(PTO2_TASK_CONSUMED);
+    }
+
+    rss.advance_ring_pointers();
+    EXPECT_EQ(rss.last_task_alive, 17);
+    EXPECT_EQ(ring->fc.last_task_alive.load(), 17);
+
+    ring->fc.last_task_alive.store(0);
+    rss.last_task_alive = 0;
+    rss.last_published_to_sm = 0;
+    for (int advances : {1, 15, 16, 17}) {
+        for (int i = 0; i < advances; i++) {
+            ring->get_slot_state_by_task_id(i).task_state.store(PTO2_TASK_CONSUMED);
+        }
+        ring->get_slot_state_by_task_id(advances).task_state.store(PTO2_TASK_COMPLETED);
+        rss.advance_ring_pointers();
+        EXPECT_EQ(ring->fc.last_task_alive.load(), advances >= 16 ? advances : 0);
+
+        ring->fc.last_task_alive.store(0);
+        rss.last_task_alive = 0;
+        rss.last_published_to_sm = 0;
+    }
+}
+
+TEST_F(WiringTest, AdvanceRingPointersPublishesDrainedTail) {
+    auto &rss = sched.ring_sched_states[0];
+    auto *ring = rss.ring;
+
+    for (int advances : {1, 15, 16, 17}) {
+        ring->fc.current_task_index.store(advances, std::memory_order_release);
+        for (int i = 0; i < advances; i++) {
+            ring->get_slot_state_by_task_id(i).task_state.store(PTO2_TASK_CONSUMED);
+        }
+
+        rss.advance_ring_pointers();
+        EXPECT_EQ(rss.last_task_alive, advances);
+        EXPECT_EQ(ring->fc.last_task_alive.load(), advances);
+
+        ring->fc.last_task_alive.store(0);
+        rss.last_task_alive = 0;
+        rss.last_published_to_sm = 0;
+    }
+}
+
+TEST_F(WiringTest, TaskAllocatorPressurePublishesWithheldProgress) {
+    auto &rss = sched.ring_sched_states[0];
+    auto *ring = rss.ring;
+
+    alignas(64) char heap[64] = {};
+    ring->fc.current_task_index.store(3, std::memory_order_release);
+    ring->get_task_by_task_id(0).packed_buffer_end = heap;
+    ring->get_slot_state_by_task_id(0).task_state.store(PTO2_TASK_CONSUMED);
+    ring->get_slot_state_by_task_id(1).task_state.store(PTO2_TASK_PENDING);
+    rss.advance_ring_pointers();
+
+    ASSERT_EQ(rss.last_task_alive, 1);
+    ASSERT_EQ(ring->fc.last_task_alive.load(), 0);
+
+    PTO2TaskAllocator allocator;
+    auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_handle->sm_base);
+    allocator.init(
+        ring->task_descriptors, 4, &ring->fc.current_task_index, &ring->fc.last_task_alive, heap, sizeof(heap),
+        orch_err, ring->slot_states, 3, 0
+    );
+    allocator.set_reclaim_publication_request(&sched.publication_request_mask, &sched.publication_ack_mask);
+
+    PTO2TaskAllocResult result{-1, -1, nullptr, nullptr};
+    std::atomic<bool> alloc_done{false};
+    std::thread blocked_allocator([&] {
+        result = allocator.alloc(0, &ring->get_slot_state_by_task_id(0));
+        alloc_done.store(true, std::memory_order_release);
+    });
+
+    EXPECT_TRUE(service_reclaim_publication_until_done(alloc_done));
+    blocked_allocator.join();
+
+    EXPECT_FALSE(result.failed());
+    EXPECT_EQ(result.task_id, 3);
+    EXPECT_EQ(ring->fc.last_task_alive.load(), 1);
+}
+
+TEST_F(WiringTest, HeapPressurePublishesWithheldProgress) {
+    auto &rss = sched.ring_sched_states[0];
+    auto *ring = rss.ring;
+
+    alignas(64) char heap[64] = {};
+    PTO2TaskAllocator allocator;
+    auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_handle->sm_base);
+    allocator.init(
+        ring->task_descriptors, 8, &ring->fc.current_task_index, &ring->fc.last_task_alive, heap, sizeof(heap),
+        orch_err, ring->slot_states, 0, 0
+    );
+    allocator.set_reclaim_publication_request(&sched.publication_request_mask, &sched.publication_ack_mask);
+
+    auto full_heap = allocator.alloc(sizeof(heap));
+    ASSERT_FALSE(full_heap.failed());
+    ring->get_task_by_task_id(full_heap.task_id).packed_buffer_end = full_heap.packed_end;
+    auto live_tail = allocator.alloc(0);
+    ASSERT_FALSE(live_tail.failed());
+    ring->get_task_by_task_id(live_tail.task_id).packed_buffer_end = live_tail.packed_end;
+
+    ring->get_slot_state_by_task_id(0).task_state.store(PTO2_TASK_CONSUMED);
+    ring->get_slot_state_by_task_id(1).task_state.store(PTO2_TASK_PENDING);
+    rss.advance_ring_pointers();
+
+    ASSERT_EQ(rss.last_task_alive, 1);
+    ASSERT_EQ(ring->fc.last_task_alive.load(), 0);
+
+    PTO2TaskAllocResult result{-1, -1, nullptr, nullptr};
+    std::atomic<bool> alloc_done{false};
+    std::thread blocked_allocator([&] {
+        result = allocator.alloc(8);
+        alloc_done.store(true, std::memory_order_release);
+    });
+
+    EXPECT_TRUE(service_reclaim_publication_until_done(alloc_done));
+    blocked_allocator.join();
+
+    EXPECT_FALSE(result.failed());
+    EXPECT_EQ(result.task_id, 2);
+    EXPECT_EQ(result.packed_base, heap);
+    EXPECT_EQ(ring->fc.last_task_alive.load(), 1);
+}
+
+TEST_F(WiringTest, DependencyPoolPressurePublishesWithheldProgress) {
+    auto &rss = sched.ring_sched_states[0];
+    auto *ring = rss.ring;
+
+    ring->fc.current_task_index.store(129, std::memory_order_release);
+    ring->fc.last_task_alive.store(113, std::memory_order_release);
+    ring->get_slot_state_by_task_id(127).dep_pool_mark = 5;
+    ring->get_slot_state_by_task_id(128).task_state.store(PTO2_TASK_PENDING);
+    rss.last_task_alive = 128;
+    rss.last_published_to_sm = 113;
+    rss.dep_pool.capacity = 8;
+    rss.dep_pool.top = 9;
+    rss.dep_pool.tail = 1;
+    rss.dep_pool.last_reclaimed = 64;
+
+    bool has_space = false;
+    std::atomic<bool> ensure_done{false};
+    std::thread blocked_allocator([&] {
+        has_space = rss.dep_pool.ensure_space(*ring, 1);
+        ensure_done.store(true, std::memory_order_release);
+    });
+
+    EXPECT_TRUE(service_reclaim_publication_until_done(ensure_done));
+    blocked_allocator.join();
+
+    EXPECT_TRUE(has_space);
+    EXPECT_EQ(rss.dep_pool.tail, 5);
+    EXPECT_EQ(ring->fc.last_task_alive.load(), 128);
+}
+
+TEST_F(WiringTest, FaninPoolPressurePublishesWithheldProgress) {
+    auto &rss = sched.ring_sched_states[0];
+    auto *ring = rss.ring;
+
+    ring->fc.current_task_index.store(2, std::memory_order_release);
+    ring->get_slot_state_by_task_id(0).task_state.store(PTO2_TASK_CONSUMED);
+    ring->get_slot_state_by_task_id(1).task_state.store(PTO2_TASK_PENDING);
+    rss.advance_ring_pointers();
+    ASSERT_EQ(rss.last_task_alive, 1);
+    ASSERT_EQ(ring->fc.last_task_alive.load(), 0);
+
+    PTO2FaninSpillEntry entries[4]{};
+    PTO2FaninPool pool{};
+    auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_handle->sm_base);
+    pool.init(entries, 4, orch_err);
+    pool.set_reclaim_publication_request(&sched.publication_request_mask, &sched.publication_ack_mask, 0);
+    for (int i = 0; i < 4; i++) {
+        ASSERT_NE(pool.alloc(), nullptr);
+    }
+
+    auto &payload = ring->get_payload_by_task_id(0);
+    payload.fanin_actual_count = PTO2_FANIN_INLINE_CAP + 1;
+    payload.fanin_spill_start = 1;
+    payload.fanin_spill_pool = &pool;
+
+    bool has_space = false;
+    std::atomic<bool> ensure_done{false};
+    std::thread blocked_allocator([&] {
+        has_space = pool.ensure_space(*ring, 1);
+        ensure_done.store(true, std::memory_order_release);
+    });
+
+    EXPECT_TRUE(service_reclaim_publication_until_done(ensure_done));
+    blocked_allocator.join();
+
+    EXPECT_TRUE(has_space);
+    EXPECT_EQ(pool.tail, 2);
+    EXPECT_EQ(ring->fc.last_task_alive.load(), 1);
+}
+
+TEST_F(WiringTest, RingReuseResetsPublicationShadow) {
+    auto &rss = sched.ring_sched_states[0];
+    rss.last_task_alive = 17;
+    rss.last_published_to_sm = 16;
+
+    auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_handle->sm_base);
+    rss.reset_for_reuse(sm_handle->sm_base, 0, orch_err);
+
+    EXPECT_EQ(rss.last_task_alive, 0);
+    EXPECT_EQ(rss.last_published_to_sm, 0);
+    EXPECT_FALSE(rss.publication_batching_enabled);
+    EXPECT_EQ(rss.ring, pto2_sm_layout::ring_header_addr(sm_handle->sm_base, 0));
 }
 
 TEST_F(WiringTest, AdvanceRingPointersStopsAtNonConsumed) {

--- a/tests/ut/cpp/common/test_scope_deadlock_detection.cpp
+++ b/tests/ut/cpp/common/test_scope_deadlock_detection.cpp
@@ -22,7 +22,11 @@ namespace {
 constexpr int32_t WINDOW_SIZE = 16;
 constexpr int32_t POOL_CAPACITY = 8;
 
-void make_head_match_old_structural_predicate(PTO2TaskSlotState &head) {
+void make_head_match_old_structural_predicate(
+    PTO2TaskSlotState &head, PTO2TaskDescriptor &descriptor, uint8_t ring_id, uint32_t local_task_id
+) {
+    descriptor.task_id = PTO2TaskId::make(ring_id, local_task_id);
+    head.task = &descriptor;
     head.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
     head.fanout_count = PTO2_FANOUT_SCOPE_BIT;
     head.fanout_refcount.store(0, std::memory_order_release);
@@ -40,6 +44,7 @@ TEST(ScopeDeadlockDetectionTest, DepPoolUsesTimeoutForDifferentScopeHead) {
     }
 
     alignas(64) PTO2TaskSlotState slot_states[WINDOW_SIZE]{};
+    PTO2TaskDescriptor task_descriptors[WINDOW_SIZE]{};
     PTO2SharedMemoryRingHeader ring{};
     ring.fc.init();
     ring.task_window_size = WINDOW_SIZE;
@@ -48,7 +53,7 @@ TEST(ScopeDeadlockDetectionTest, DepPoolUsesTimeoutForDifferentScopeHead) {
     ring.fc.current_task_index.store(2, std::memory_order_release);
     ring.fc.last_task_alive.store(0, std::memory_order_release);
 
-    make_head_match_old_structural_predicate(slot_states[0]);
+    make_head_match_old_structural_predicate(slot_states[0], task_descriptors[0], 0, 0);
     PTO2TaskSlotState *oldest_open_task = &slot_states[1];
 
     testing::internal::CaptureStderr();
@@ -71,6 +76,7 @@ TEST(ScopeDeadlockDetectionTest, DepPoolRejectsCurrentScopeHeadStructurally) {
     }
 
     alignas(64) PTO2TaskSlotState slot_states[WINDOW_SIZE]{};
+    PTO2TaskDescriptor task_descriptors[WINDOW_SIZE]{};
     PTO2SharedMemoryRingHeader ring{};
     ring.fc.init();
     ring.task_window_size = WINDOW_SIZE;
@@ -78,6 +84,7 @@ TEST(ScopeDeadlockDetectionTest, DepPoolRejectsCurrentScopeHeadStructurally) {
     ring.slot_states = slot_states;
     ring.fc.current_task_index.store(1, std::memory_order_release);
     PTO2TaskSlotState *oldest_open_task = &slot_states[0];
+    make_head_match_old_structural_predicate(slot_states[0], task_descriptors[0], 0, 0);
 
     testing::internal::CaptureStderr();
     bool available = pool.ensure_space(ring, 1, oldest_open_task);


### PR DESCRIPTION
## Summary

- Batch A5 TMR `ring->fc.last_task_alive` publication every 16 Scheduler-local advances on the non-blocking path.
- Keep Scheduler `advance_lock` contention on the original `advance_pending_mask`, drained only from no-progress iterations.
- Use a cache-line-separated `publication_request_mask` only when an Orchestrator reclaim consumer has made no progress for 10 ms; Scheduler thread 0 then force-publishes and acknowledges from productive or no-progress iterations.
- Enable batching only after the allocator, fanin-pool, and dependency-pool request/ack wiring is validated against the current Scheduler; otherwise fall back to per-advance publication.
- Classify structural open-scope deadlock by exact ring-local task identity, and only against a freshly acknowledged watermark; retain the 500 ms wall-clock backstop.

## Scope

This PR changes only:

- A5 `tensormap_and_ringbuffer` Scheduler progress publication and Orchestrator reclaim back-pressure;
- A5 runtime initialization/reuse and prebuilt-arena pointer wiring;
- A5 C++ unit coverage, plus the shared `test_scope_deadlock_detection` fixture that the exact-identity head check requires; and
- the A5 runtime, A2/A3-versus-A5 comparison, and reclaim-triage documentation.

It does not change host-build-graph, A2/A3 runtime behavior, benchmark tooling, PTO-ISA checkout, or CI workflows.

## Why A5 only

| Property | A2/A3 | A5 |
|---|---|---|
| Physical AICPU cores per cluster | 4 | 2 |
| Default active roles | 1 Orchestrator + 3 Schedulers = 4 | 1 Orchestrator + 4 Schedulers = 5 |
| Normal placement | All roles fit in one cluster | Roles must span clusters and may span dies |
| Progress-publication cost | Normally cluster-local | Can transfer/invalidate the Orchestrator's cache line across clusters or dies |
| Port result | Mean Effective change `-0.24%`; all results within approximately +/-2% | Batch Case1 change `-3.83%` |
| Decision | Keep per-advance publication | Enable K=16 batching with a pressure-only liveness escape |

Any Scheduler may win `advance_lock` and publish the shared watermark that the Orchestrator repeatedly reads. K=16 does not remove Scheduler-to-Scheduler contention; it reduces Scheduler-to-Orchestrator publication frequency by up to 16x on A5's distributed placement.

The implementation is not unsafe or unsupported on A2/A3. A local A2/A3 port passed its tests, but batching added reclamation lag without a measurable payoff, so A2/A3 remains unchanged. See the [A2/A3 benchmark follow-up](https://github.com/hw-native-sys/simpler/pull/1575#issuecomment-5310909143).

## Correctness

`last_task_alive` is not a progress statistic: it is the allocation credit for task slots, heap bytes, dependency entries, fanin spill entries, and TensorMap entries. A blocked reclaim consumer can itself prevent an open scope from ending, so a withheld batch must never depend on full-ring drain to be published.

- Scheduler-local `last_task_alive` remains authoritative; the published watermark is a lower bound.
- K=16 applies on the non-blocking path. A resource-short consumer first waits for ordinary batched publication; only 10 ms of continuous no-progress sets its exact-publication request bit.
- All five reclaim consumers participate: task slots and heap (`PTO2TaskAllocator::alloc`), `PTO2DepListPool::ensure_space`, `PTO2FaninPool::ensure_space`, and `ensure_tensormap_capacity`.
- Scheduler try-lock contention and Orchestrator pressure use separate cache lines and separate drain semantics. A deferred Scheduler retry cannot acknowledge an Orchestrator request.
- Scheduler thread 0 services pressure requests during productive **and** no-progress loops, so a genuinely blocked ring does not wait for global Scheduler idleness. One servicer suffices because request bits stay latched until acknowledged.
- **Batching is self-disabling.** `publication_batching_enabled` defaults false at initialization, arena relocation, reuse, and teardown. `runtime_wire_arena_pointers` and `runtime_reset_for_reuse` enable it only after verifying every ring's allocator, fanin-pool, and dependency-pool request/ack pointers against the live Scheduler. Incomplete wiring degrades to pre-change per-advance publication rather than batching without a liveness escape.
- Structural open-scope classification runs only after a fresh exact-publication acknowledgement, and compares exact ring-local task identity rather than a slot address, so a wrapped slot cannot alias the reclaim head. Natural watermark progress invalidates an older acknowledgement.
- Terminal drain still force-publishes the final partial batch, and initialization/reuse resets local, published, deferred, request, and acknowledgement state.
- Arena relocation rewires dependency-pool request/ack pointers from the host prebuilt image to the AICPU runtime address.

## Validation

Rebased on `main` at `a59ffde75c2907819a45690eee065056857330dc`.

Measured on the current head:

- Complete independent C++ suite: **100/100 passed**.
- Local commit-stage pre-commit: **passed** (clang-format, clang-tidy, cpplint, markdownlint).

Measured on the immediately preceding head, which differs from the current one only by removing three files unrelated to this change:

- Full CI matrix green, including `st-onboard-a5`, `st-sim-a5sim`, `ut-a5`, `ut-a2a3`, and `packaging-matrix`.
- Timing-coupled pressure suites under parallel load (`--repeat until-fail:12 -j 4` across `wiring`, `fanin_pool`, `orchestrator_fanin`, `task_allocator`, `shared_memory`, `scheduler_state`, `scope_deadlock_detection`): **96/96 passed, no flakes**.

Measured on earlier heads of this branch:

- A5 simulator `paged_attention_ringbuffer`: **258/258 checks passed**.
- Locked A5 `paged_attention_ringbuffer` with `ring_task_window=64`, `ring_heap=4 MiB`, `ring_dep_pool=256`: **passed**.
- Locked A5 `paged_attention_manual_scope` with `PTO2_RING_TASK_WINDOW=64`: **4/4 cases passed** — the small-window plus manual-scope combination that exercises the pressure path.
- Locked A5 Batch Paged Attention Case1 with golden comparison: **passed**.

## A5 performance

Batch Paged Attention Case1 on `Ascend950PR` device 0. Four groups, each running baseline immediately followed by this branch, 100 measured rounds per side. Negative deltas mean this branch is faster.

| Metric | Main mean (us) | PR mean (us) | Change |
|---|---:|---:|---:|
| Device | 7342.7 | 7062.5 | -3.82% |
| Effective | 7310.0 | 7029.9 | **-3.83%** |
| Orchestrator | 6309.7 | 5991.3 | -5.05% |
| Scheduler | 7301.9 | 7022.0 | -3.83% |

The four paired Effective changes were `-4.92%`, `-2.29%`, `-4.20%`, and `-3.91%`. Profiling showed that an earlier implementation promoted 36 short-lived allocation-pressure episodes per Case1 run into exact publication handshakes; the 10 ms no-progress criterion promoted zero in this workload while preserving the liveness path for a genuinely blocked Orchestrator.

Directional context from a seven-workload sweep:

| Workload | Effective change |
|---|---:|
| Alternating matmul add | -5.30% |
| BGEMM | -10.85% |
| Manual attention Case1 | -3.21% |
| Manual attention Case2 | -0.21% |
| Unroll attention Case1 | -8.53% |
| Unroll attention Case2 | -3.52% |
| Qwen3 14B decode (five-run median) | -0.07% |

**Measurement provenance.** Every number above was collected before the wiring-validation gate and the exact-identity head check landed; the seven-workload rows predate the Case1 table. They are not a single-SHA aggregate. Both later additions are off the steady-state path — a `bool` read on a cache line the hot path already writes, and one extra indirection inside the 1024-spin cold block — so no steady-state change is expected, but that expectation is unmeasured. A re-run of the Case1 table on the current head would close it. See the [full earlier evidence](https://github.com/hw-native-sys/simpler/pull/1575#issuecomment-5315519432).
