### PR TITLE
Retire the blocking endpoint channel and tighten the mailbox contract

### DIFF
--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -538,7 +538,7 @@ Local mailbox path:
 ```text
 slot.callable.digest ─┐
 slot.config          ─┼─► memcpy into shm mailbox ─► child resolves digest
-slot.pipeline_lease  ─┤    (dispatch_process)         and runs local slot
+slot.pipeline_lease  ─┤    (submit_progress)         and runs local slot
 slot.task_args       ─┘
 ```
 

--- a/docs/worker-manager.md
+++ b/docs/worker-manager.md
@@ -141,13 +141,11 @@ private:
     std::array<LaneState, 2> lanes_;     // active and staged identities
 
     void loop();  // the sole progress owner for this endpoint
-    WorkerCompletion dispatch_process(WorkerDispatch d,
-                                      const std::function<void()> &on_accept);
 };
 ```
 
-Registered local and remote endpoints are progressable: the thread publishes
-queued work, forwards a latched activation when supported, and polls monotonic
+Every endpoint is progress-driven: the thread publishes queued work, forwards a
+latched activation when supported, and polls monotonic
 `FRAME_STAGED`, `ACCEPTED`, and `COMPLETED` events. The lane array owns task
 identity and disposition while `inflight_` independently enforces endpoint
 capacity. The forked child loop lives in Python (`_chip_process_loop`,
@@ -299,8 +297,8 @@ The parent reports `ACCEPTED` at most once per `dispatch_id`, before its termina
 completion when the real word is observed. A task that fails before launch
 still advances the run-level acceptance waiter at terminal completion so the
 waiter cannot hang, but that conservative fallback does not set the mailbox
-word. Blocking chip dispatch uses the same sticky marker. Endpoint paths with
-no earlier native marker retain completion-time acceptance.
+word. Endpoint paths with no earlier native marker retain completion-time
+acceptance.
 
 The child inherits the parent's full address space at fork time, so:
 
@@ -345,7 +343,7 @@ iteration alongside the state word.
 
 `Worker::close()` first asks the Scheduler to stop admitting dispatch, then
 calls `WorkerManager::stop_workers()` while Scheduler callbacks and worker pool
-entries are still valid. A progressable `WorkerThread` repeatedly publishes
+entries are still valid. A `WorkerThread` repeatedly publishes
 `SHUTDOWN` on the control base until its frames terminalize; the sticky
 shutdown word (section 3.4) is what makes the request itself unloseable, while
 the repetition keeps the *state* word from resting on a `CONTROL_DONE` a

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -483,7 +483,7 @@ inline void bind_worker(nb::module_ &m) {
 
         // --- Mailbox control plane (parent side) ---
         // These hold the per-WorkerThread mailbox_mu_ inside C++, so they
-        // serialize against dispatch_process without any Python-side lock.
+        // serialize against task-frame publication without any Python-side lock.
         // Release the GIL during the spin-poll wait so other Python threads
         // (e.g. a concurrent Worker.run) can keep running.
         .def(

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -1805,11 +1805,10 @@ def _run_mailbox_loop(
     parent_pid = os.getppid()
     liveness_countdown = _PARENT_LIVENESS_POLL_INTERVAL
     shutdown_addr = _buffer_field_addr(buf, _OFF_SHUTDOWN)
-    task_buf = None
-    task_state_addr = None
-    if len(buf) >= 2 * MAILBOX_FRAME_SIZE:
-        task_buf = buf[MAILBOX_FRAME_SIZE : 2 * MAILBOX_FRAME_SIZE]
-        task_state_addr = _buffer_field_addr(task_buf, _OFF_STATE)
+    # `buf` is a whole mailbox: a base frame followed by the task frames, so
+    # frame 1 always exists.
+    task_buf = buf[MAILBOX_FRAME_SIZE : 2 * MAILBOX_FRAME_SIZE]
+    task_state_addr = _buffer_field_addr(task_buf, _OFF_STATE)
     try:
         while True:
             state = _mailbox_load_i32(state_addr)
@@ -1817,16 +1816,10 @@ def _run_mailbox_loop(
                 if on_shutdown is not None:
                     on_shutdown()
                 break
-            if task_buf is not None and _mailbox_load_i32(task_state_addr) == _TASK_READY:
+            if _mailbox_load_i32(task_state_addr) == _TASK_READY:
                 code, msg = handle_task(task_buf)
                 _write_error(task_buf, code, msg)
                 _mailbox_store_i32(task_state_addr, _TASK_DONE)
-            elif state == _TASK_READY:
-                # Compatibility for a direct endpoint.run() caller. WorkerThread
-                # dispatches use the dedicated task frame.
-                code, msg = handle_task(buf)
-                _write_error(buf, code, msg)
-                _mailbox_store_i32(state_addr, _TASK_DONE)
             elif state == _CONTROL_REQUEST:
                 sub_cmd = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
                 code, msg = handle_control(int(sub_cmd))
@@ -1860,8 +1853,8 @@ def _sub_worker_loop(
 
     On success writes ``error=0`` and an empty message. On failure writes
     ``error=1`` and ``f"sub_worker: <ExcType>: <msg>"`` into the mailbox
-    error-message region; the parent's ``WorkerThread::dispatch_process``
-    rethrows it as ``std::runtime_error``.
+    error-message region; the parent's endpoint reports it as a failed
+    completion, which the run's waiter rethrows as ``std::runtime_error``.
     """
     state_addr = _buffer_field_addr(buf, _OFF_STATE)
     host_buf_table: dict[int, tuple[SharedMemory, int, int, int]] = {}

--- a/src/common/hierarchical/remote_endpoint.cpp
+++ b/src/common/hierarchical/remote_endpoint.cpp
@@ -728,7 +728,9 @@ remote_l3::TaskPayloadWire RemoteL3Endpoint::build_task_payload(const TaskSlotSt
     TaskArgsView view = slot.args_view(group_index);
     const RemoteTaskArgsSidecar &sidecar = slot.remote_sidecar_for(group_index);
     if (!sidecar.tensors.empty() && sidecar.tensors.size() != static_cast<size_t>(view.tensor_count)) {
-        throw std::runtime_error("RemoteL3Endpoint::run: remote sidecar tensor count does not match TaskArgs");
+        throw std::runtime_error(
+            "RemoteL3Endpoint::build_task_payload: remote sidecar tensor count does not match TaskArgs"
+        );
     }
     payload.args.inline_payload = sidecar.inline_payload;
     payload.args.tensor_metadata.reserve(static_cast<size_t>(view.tensor_count));
@@ -739,13 +741,19 @@ remote_l3::TaskPayloadWire RemoteL3Endpoint::build_task_payload(const TaskSlotSt
         RemoteTensorSidecar tensor_sidecar{};
         if (!sidecar.tensors.empty()) tensor_sidecar = sidecar.tensors[static_cast<size_t>(i)];
         if (tensor.buffer.addr != 0 && !tensor_sidecar.present) {
-            throw std::runtime_error("RemoteL3Endpoint::run: bare host pointer submitted without remote sidecar");
+            throw std::runtime_error(
+                "RemoteL3Endpoint::build_task_payload: bare host pointer submitted without remote sidecar"
+            );
         }
         if (tensor.is_child_memory() && !tensor_sidecar.present) {
-            throw std::runtime_error("RemoteL3Endpoint::run: child-memory tensor submitted without remote sidecar");
+            throw std::runtime_error(
+                "RemoteL3Endpoint::build_task_payload: child-memory tensor submitted without remote sidecar"
+            );
         }
         if (!tensor_sidecar.present && tensor.nbytes() != 0) {
-            throw std::runtime_error("RemoteL3Endpoint::run: tensor payload submitted without remote sidecar");
+            throw std::runtime_error(
+                "RemoteL3Endpoint::build_task_payload: tensor payload submitted without remote sidecar"
+            );
         }
         tensor.buffer.addr = 0;
         payload.args.tensor_metadata.push_back(tensor);
@@ -755,56 +763,6 @@ remote_l3::TaskPayloadWire RemoteL3Endpoint::build_task_payload(const TaskSlotSt
     for (int32_t i = 0; i < view.scalar_count; ++i)
         payload.args.scalars.push_back(view.scalars[i]);
     return payload;
-}
-
-WorkerCompletion RemoteL3Endpoint::run(Ring *ring, const WorkerDispatch &dispatch) {
-    if (ring == nullptr) throw std::invalid_argument("RemoteL3Endpoint::run: null ring");
-    TaskSlotState &slot = *ring->slot_state(dispatch.task_slot);
-
-    WorkerCompletion completion;
-    completion.task_slot = dispatch.task_slot;
-    completion.group_index = dispatch.group_index;
-
-    uint64_t sequence = 0;
-    std::unique_lock<std::mutex> command_lk(command_mu_);
-    try {
-        sequence = command_lane_.begin_command();
-        auto payload = remote_l3::encode_task_payload(build_task_payload(slot, dispatch.group_index));
-        remote_l3::FrameHeader header;
-        header.frame_type = remote_l3::FrameType::TASK;
-        header.session_id = session_id_;
-        header.worker_id = caps_.worker_id;
-        header.sequence = sequence;
-        transport_->submit_frame(remote_l3::encode_frame(header, payload));
-
-        auto reply_bytes = transport_->wait_for_reply(remote_l3::FrameType::COMPLETION, sequence);
-        auto reply = remote_l3::decode_frame(reply_bytes);
-        if (reply.header.frame_type != remote_l3::FrameType::COMPLETION) {
-            throw std::runtime_error("RemoteL3Endpoint::run: expected COMPLETION reply");
-        }
-        if (reply.header.session_id != session_id_ || reply.header.worker_id != caps_.worker_id) {
-            throw std::runtime_error("RemoteL3Endpoint::run: completion session or worker mismatch");
-        }
-        auto decoded = remote_l3::decode_completion(reply.payload.data(), reply.payload.size(), sequence);
-        command_lane_.finish_reply(sequence);
-
-        if (decoded.error_code == 0) {
-            completion.outcome = EndpointOutcome::SUCCESS;
-        } else {
-            completion.outcome = EndpointOutcome::TASK_FAILURE;
-            completion.error_message = decoded.error_message;
-        }
-    } catch (const std::exception &e) {
-        if (sequence != 0 && command_lane_.in_flight()) {
-            try {
-                command_lane_.finish_reply(sequence);
-            } catch (...) {}
-        }
-        completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
-        completion.error_message =
-            std::string("RemoteL3Endpoint::run(worker_id=") + std::to_string(caps_.worker_id) + "): " + e.what();
-    }
-    return completion;
 }
 
 void RemoteL3Endpoint::finish_progress_command(uint64_t sequence) {

--- a/src/common/hierarchical/remote_endpoint.h
+++ b/src/common/hierarchical/remote_endpoint.h
@@ -95,8 +95,6 @@ public:
     );
 
     const WorkerEndpointCaps &caps() const override { return caps_; }
-    WorkerCompletion run(Ring *ring, const WorkerDispatch &dispatch) override;
-    bool progressable() const override { return true; }
     void submit_progress(Ring *ring, const WorkerDispatch &dispatch) override;
     bool poll_progress(WorkerEndpointProgress &progress) override;
     void request_progress_stop() noexcept override;

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -142,13 +142,6 @@ void WorkerEndpoint::control_worker_chip_region_release(uint64_t) {
     throw_unsupported_control("control_worker_chip_region_release");
 }
 
-WorkerCompletion
-WorkerEndpoint::run_with_accept(Ring *ring, const WorkerDispatch &dispatch, const std::function<void()> &on_accept) {
-    WorkerCompletion completion = run(ring, dispatch);
-    if (on_accept) on_accept();
-    return completion;
-}
-
 void WorkerEndpoint::submit_progress(Ring *, const WorkerDispatch &) {
     throw std::runtime_error("progress submission is not supported by this WorkerEndpoint");
 }
@@ -500,163 +493,96 @@ int32_t WorkerThread::worker_id() const { return caps().worker_id; }
 // =============================================================================
 
 void WorkerThread::loop() {
-    if (endpoint_->progressable()) {
-        while (true) {
-            WorkerDispatch dispatch;
-            bool have_dispatch = false;
-            {
-                std::unique_lock<std::mutex> lk(mu_);
-                if (queue_.empty() && inflight_.load(std::memory_order_acquire) == 0 &&
-                    !shutdown_.load(std::memory_order_acquire)) {
-                    cv_.wait(lk, [this] {
-                        return !queue_.empty() || shutdown_.load(std::memory_order_acquire);
-                    });
-                }
-                if (!queue_.empty()) {
-                    dispatch = queue_.front();
-                    queue_.pop();
-                    have_dispatch = true;
-                } else if (shutdown_.load(std::memory_order_acquire) &&
-                           inflight_.load(std::memory_order_acquire) == 0) {
-                    break;
-                }
+    while (true) {
+        WorkerDispatch dispatch;
+        bool have_dispatch = false;
+        {
+            std::unique_lock<std::mutex> lk(mu_);
+            if (queue_.empty() && inflight_.load(std::memory_order_acquire) == 0 &&
+                !shutdown_.load(std::memory_order_acquire)) {
+                cv_.wait(lk, [this] {
+                    return !queue_.empty() || shutdown_.load(std::memory_order_acquire);
+                });
             }
+            if (!queue_.empty()) {
+                dispatch = queue_.front();
+                queue_.pop();
+                have_dispatch = true;
+            } else if (shutdown_.load(std::memory_order_acquire) && inflight_.load(std::memory_order_acquire) == 0) {
+                break;
+            }
+        }
 
+        if (shutdown_.load(std::memory_order_acquire)) {
+            // Repeat until every frame terminalizes. A child finishing a
+            // control handler may publish CONTROL_DONE after an earlier
+            // SHUTDOWN store; the next pass restores the stop request.
+            endpoint_->request_progress_stop();
+        }
+
+        if (have_dispatch) {
             if (shutdown_.load(std::memory_order_acquire)) {
-                // Repeat until every frame terminalizes. A child finishing a
-                // control handler may publish CONTROL_DONE after an earlier
-                // SHUTDOWN store; the next pass restores the stop request.
-                endpoint_->request_progress_stop();
-            }
-
-            if (have_dispatch) {
-                if (shutdown_.load(std::memory_order_acquire)) {
+                WorkerEndpointProgress progress;
+                progress.kind = WorkerProgressKind::COMPLETED;
+                progress.dispatch = dispatch;
+                progress.completion = WorkerCompletion{
+                    dispatch.task_slot, dispatch.group_index, EndpointOutcome::ENDPOINT_FAILURE,
+                    "WorkerThread endpoint stopped before frame publication"
+                };
+                finish_progress_dispatch(progress);
+            } else {
+                try {
+                    endpoint_->submit_progress(ring_, dispatch);
+                } catch (const std::exception &e) {
                     WorkerEndpointProgress progress;
                     progress.kind = WorkerProgressKind::COMPLETED;
                     progress.dispatch = dispatch;
                     progress.completion = WorkerCompletion{
                         dispatch.task_slot, dispatch.group_index, EndpointOutcome::ENDPOINT_FAILURE,
-                        "WorkerThread endpoint stopped before frame publication"
+                        std::string("WorkerThread endpoint failed before frame publication: ") + e.what()
                     };
                     finish_progress_dispatch(progress);
-                } else {
-                    try {
-                        endpoint_->submit_progress(ring_, dispatch);
-                    } catch (const std::exception &e) {
-                        WorkerEndpointProgress progress;
-                        progress.kind = WorkerProgressKind::COMPLETED;
-                        progress.dispatch = dispatch;
-                        progress.completion = WorkerCompletion{
-                            dispatch.task_slot, dispatch.group_index, EndpointOutcome::ENDPOINT_FAILURE,
-                            std::string("WorkerThread endpoint failed before frame publication: ") + e.what()
-                        };
-                        finish_progress_dispatch(progress);
-                    } catch (...) {
-                        WorkerEndpointProgress progress;
-                        progress.kind = WorkerProgressKind::COMPLETED;
-                        progress.dispatch = dispatch;
-                        progress.completion = WorkerCompletion{
-                            dispatch.task_slot, dispatch.group_index, EndpointOutcome::ENDPOINT_FAILURE,
-                            "WorkerThread endpoint failed before frame publication with unknown exception"
-                        };
-                        finish_progress_dispatch(progress);
-                    }
-                }
-            }
-
-            RunId activated = INVALID_RUN_ID;
-            {
-                std::lock_guard<std::mutex> lane_lk(lane_mu_);
-                const LaneState &active = lane(LaneKind::ACTIVE);
-                if (active.occupied && active.activation_requested) activated = active.run_id;
-            }
-            if (activated != INVALID_RUN_ID) {
-                try {
-                    if (endpoint_->activate_progress(activated)) {
-                        std::lock_guard<std::mutex> lane_lk(lane_mu_);
-                        LaneState &active = lane(LaneKind::ACTIVE);
-                        if (active.occupied && active.run_id == activated) active.activation_requested = false;
-                    }
-                } catch (const std::exception &e) {
-                    fail_progress_driver(std::string("activate_progress failed: ") + e.what());
                 } catch (...) {
-                    fail_progress_driver("activate_progress failed with unknown exception");
+                    WorkerEndpointProgress progress;
+                    progress.kind = WorkerProgressKind::COMPLETED;
+                    progress.dispatch = dispatch;
+                    progress.completion = WorkerCompletion{
+                        dispatch.task_slot, dispatch.group_index, EndpointOutcome::ENDPOINT_FAILURE,
+                        "WorkerThread endpoint failed before frame publication with unknown exception"
+                    };
+                    finish_progress_dispatch(progress);
                 }
             }
-
-            WorkerEndpointProgress progress;
-            try {
-                if (endpoint_->poll_progress(progress)) finish_progress_dispatch(progress);
-            } catch (const std::exception &e) {
-                fail_progress_driver(std::string("poll_progress failed: ") + e.what());
-            } catch (...) {
-                fail_progress_driver("poll_progress failed with unknown exception");
-            }
         }
-        return;
-    }
 
-    while (true) {
-        WorkerDispatch d;
+        RunId activated = INVALID_RUN_ID;
         {
-            std::unique_lock<std::mutex> lk(mu_);
-            cv_.wait(lk, [this] {
-                return !queue_.empty() || shutdown_.load(std::memory_order_acquire);
-            });
-            if (queue_.empty()) break;
-            d = queue_.front();
-            queue_.pop();
+            std::lock_guard<std::mutex> lane_lk(lane_mu_);
+            const LaneState &active = lane(LaneKind::ACTIVE);
+            if (active.occupied && active.activation_requested) activated = active.run_id;
         }
-
-        WorkerCompletion completion;
-        bool accepted = false;
-        auto accept_once = [&]() {
-            if (accepted) return;
-            accepted = true;
-            if (on_accept_) on_accept_(d);
-        };
-        try {
-            completion = dispatch_process(d, accept_once);
-        } catch (const std::exception &e) {
-            completion.task_slot = d.task_slot;
-            completion.group_index = d.group_index;
-            completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
-            completion.error_message = std::string("WorkerThread endpoint failed: ") + e.what();
-        } catch (...) {
-            completion.task_slot = d.task_slot;
-            completion.group_index = d.group_index;
-            completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
-            completion.error_message = "WorkerThread endpoint failed with unknown exception";
-        }
-        // The fence must advance even when the dispatch failed — a waiter on
-        // wait_run_accepted would otherwise block forever — and it must not
-        // throw out of this thread, where an escaping exception terminates the
-        // process. mark_task_accepted is non-throwing by construction; this
-        // keeps that a local property rather than a remote assumption.
-        try {
-            accept_once();
-        } catch (const std::exception &e) {
-            if (completion.outcome == EndpointOutcome::SUCCESS) {
-                completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
-                completion.error_message = std::string("WorkerThread accept fence failed: ") + e.what();
-            }
-        } catch (...) {
-            if (completion.outcome == EndpointOutcome::SUCCESS) {
-                completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
-                completion.error_message = "WorkerThread accept fence failed with unknown exception";
+        if (activated != INVALID_RUN_ID) {
+            try {
+                if (endpoint_->activate_progress(activated)) {
+                    std::lock_guard<std::mutex> lane_lk(lane_mu_);
+                    LaneState &active = lane(LaneKind::ACTIVE);
+                    if (active.occupied && active.run_id == activated) active.activation_requested = false;
+                }
+            } catch (const std::exception &e) {
+                fail_progress_driver(std::string("activate_progress failed: ") + e.what());
+            } catch (...) {
+                fail_progress_driver("activate_progress failed with unknown exception");
             }
         }
 
-        // on_complete_ runs before the lane state is published so a stopping
-        // scheduler cannot read this worker as no longer busy while its final
-        // completion is still unqueued. That leaves the reverse window — the
-        // scheduler placing work sees a stale non-idle lane — which is what
-        // on_idle_ closes.
-        on_complete_(std::move(completion));
-        release_lane(LaneKind::ACTIVE, d.dispatch_id);
-        inflight_.fetch_sub(1, std::memory_order_acq_rel);
-        cv_.notify_one();
-        if (on_idle_) on_idle_();
+        WorkerEndpointProgress progress;
+        try {
+            if (endpoint_->poll_progress(progress)) finish_progress_dispatch(progress);
+        } catch (const std::exception &e) {
+            fail_progress_driver(std::string("poll_progress failed: ") + e.what());
+        } catch (...) {
+            fail_progress_driver("poll_progress failed with unknown exception");
+        }
     }
 }
 
@@ -728,151 +654,7 @@ void WorkerThread::fail_progress_driver(const std::string &reason) noexcept {
     cv_.notify_all();
 }
 
-WorkerCompletion WorkerThread::dispatch_process(WorkerDispatch d, const std::function<void()> &on_accept) {
-    if (!endpoint_) throw std::runtime_error("WorkerThread::dispatch_process: null endpoint");
-    if (d.prepare_only) throw std::logic_error("prepared dispatch requires a progressable endpoint");
-    return endpoint_->run_with_accept(ring_, d, on_accept);
-}
-
-WorkerCompletion LocalMailboxEndpoint::run(Ring *ring, const WorkerDispatch &dispatch) {
-    return run_with_accept(ring, dispatch, {});
-}
-
-WorkerCompletion LocalMailboxEndpoint::run_with_accept(
-    Ring *ring, const WorkerDispatch &dispatch, const std::function<void()> &on_accept
-) {
-    if (task_frame_count_ > 1) {
-        throw std::logic_error("LocalMailboxEndpoint::run_with_accept: two-frame endpoints require progress driving");
-    }
-    if (ring == nullptr) throw std::invalid_argument("LocalMailboxEndpoint::run: null ring");
-    TaskSlotState &s = *ring->slot_state(dispatch.task_slot);
-    int32_t group_index = dispatch.group_index;
-    TaskArgsView view = s.args_view(group_index);
-    if (!s.remote_sidecar_for(group_index).empty()) {
-        WorkerCompletion completion;
-        completion.task_slot = dispatch.task_slot;
-        completion.group_index = group_index;
-        completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
-        completion.error_message = "LocalMailboxEndpoint::run: remote task sidecar is not supported by local mailbox";
-        return completion;
-    }
-    WorkerCompletion completion;
-    completion.task_slot = dispatch.task_slot;
-    completion.group_index = group_index;
-    // Hold mailbox_mu_ for the entire round trip (write payload + state +
-    // spin-poll TASK_DONE + reset to IDLE). Any control_* request from the
-    // orch thread waits for the dispatch to finish before claiming the
-    // mailbox; without this they would race on MAILBOX_OFF_STATE.
-    std::lock_guard<std::mutex> lk(mailbox_mu_);
-    if (mailbox_control_timed_out_) {
-        completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
-        completion.error_message = "LocalMailboxEndpoint::run: mailbox has an unresolved timed-out control command";
-        return completion;
-    }
-
-    // Clear the child-writable error fields so stale bytes from a prior
-    // dispatch cannot masquerade as a fresh failure.
-    int32_t zero_err = 0;
-    std::memcpy(mbox() + MAILBOX_OFF_ERROR, &zero_err, sizeof(int32_t));
-    std::memset(mbox() + MAILBOX_OFF_ERROR_MSG, 0, MAILBOX_ERROR_MSG_SIZE);
-
-    uint64_t reserved_callable = 0;
-    std::memcpy(mbox() + MAILBOX_OFF_CALLABLE, &reserved_callable, sizeof(uint64_t));
-
-    // Write config as a single packed POD block (see call_config.h).
-    std::memcpy(mbox() + MAILBOX_OFF_CONFIG, &s.config, sizeof(CallConfig));
-    std::memcpy(mbox() + MAILBOX_OFF_PIPELINE_LEASE, &s.pipeline_lease, sizeof(PipelineSlotLease));
-
-    // Write length-prefixed TaskArgs blob: [T][S][tensors][scalars].
-    size_t blob_bytes = TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(view.tensor_count) * sizeof(ChipTensor) +
-                        static_cast<size_t>(view.scalar_count) * sizeof(uint64_t);
-    if (blob_bytes > MAILBOX_ARGS_CAPACITY) {
-        completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
-        completion.error_message =
-            "LocalMailboxEndpoint::run: args blob exceeds mailbox capacity: need " + std::to_string(blob_bytes) +
-            " bytes, capacity " + std::to_string(MAILBOX_ARGS_CAPACITY) +
-            " bytes, tensors=" + std::to_string(view.tensor_count) + ", scalars=" + std::to_string(view.scalar_count);
-        return completion;
-    }
-    uint8_t *hash_dst = reinterpret_cast<uint8_t *>(mbox() + MAILBOX_OFF_TASK_CALLABLE_HASH);
-    std::memcpy(hash_dst, s.callable.digest.data(), CALLABLE_HASH_DIGEST_SIZE);
-
-    uint8_t *d = reinterpret_cast<uint8_t *>(mbox() + MAILBOX_OFF_TASK_ARGS_BLOB);
-    std::memcpy(d + 0, &view.tensor_count, sizeof(int32_t));
-    std::memcpy(d + 4, &view.scalar_count, sizeof(int32_t));
-    if (view.tensor_count > 0) {
-        std::memcpy(
-            d + TASK_ARGS_BLOB_HEADER_SIZE, view.tensor_bytes,
-            static_cast<size_t>(view.tensor_count) * sizeof(ChipTensor)
-        );
-    }
-    if (view.scalar_count > 0) {
-        std::memcpy(
-            d + TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(view.tensor_count) * sizeof(ChipTensor), view.scalars,
-            static_cast<size_t>(view.scalar_count) * sizeof(uint64_t)
-        );
-    }
-
-    // Clear the sticky ACK before the child can set it, so the previous task's
-    // acceptance cannot satisfy this one's fence.
-    clear_task_accepted();
-
-    // Signal child process.
-    write_mailbox_state(MailboxState::TASK_READY);
-
-    // Spin-poll until child signals TASK_DONE, observing the sticky launch ACK
-    // on the way. The task's latency runs through this wait, so it never sleeps
-    // (codestyle rule 5). A child that dies without publishing TASK_DONE would
-    // otherwise leave the loop spinning forever, so its liveness is sampled on a
-    // kChildLivenessPollPeriod wall clock rather than an iteration count, which
-    // no longer maps to a wall time once the loop runs at spin speed.
-    auto next_liveness_check = std::chrono::steady_clock::now() + kChildLivenessPollPeriod;
-    bool acceptance_observed = false;
-    while (true) {
-        MailboxState state = read_mailbox_state();
-        // Read the ACK after the state. The child sets the sticky word before
-        // TASK_DONE, so observing TASK_DONE here implies this load sees it —
-        // a task that finishes between two polls cannot lose its acceptance.
-        if (!acceptance_observed && read_task_accepted()) {
-            acceptance_observed = true;
-            if (on_accept) on_accept();
-        }
-        if (state == MailboxState::TASK_DONE) break;
-        auto now = std::chrono::steady_clock::now();
-        if (now >= next_liveness_check) {
-            next_liveness_check = now + kChildLivenessPollPeriod;
-            std::string death = check_child_death();
-            if (!death.empty()) {
-                completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
-                completion.error_message = "LocalMailboxEndpoint::run: " + death;
-                return completion;
-            }
-        }
-    }
-
-    // Inspect the child's error report before releasing the mailbox back
-    // to IDLE. Non-zero error_code means the child-side Python loop
-    // caught an exception and filled OFF_ERROR_MSG with
-    // `f"{type(e).__name__}: {e}"` (truncated to MAILBOX_ERROR_MSG_SIZE).
-    int32_t error_code = 0;
-    std::memcpy(&error_code, mbox() + MAILBOX_OFF_ERROR, sizeof(int32_t));
-    if (error_code != 0) {
-        std::string msg = read_error_msg(mbox());
-        write_mailbox_state(MailboxState::IDLE);
-        completion.outcome = EndpointOutcome::TASK_FAILURE;
-        completion.error_message =
-            "LocalMailboxEndpoint::run: child failed (worker_id=" + std::to_string(caps_.worker_id) +
-            ", code=" + std::to_string(error_code) + "): " + msg;
-        return completion;
-    }
-
-    write_mailbox_state(MailboxState::IDLE);
-    completion.outcome = EndpointOutcome::SUCCESS;
-    return completion;
-}
-
 void LocalMailboxEndpoint::submit_progress(Ring *ring, const WorkerDispatch &dispatch) {
-    if (!progressable()) throw std::logic_error("LocalMailboxEndpoint::submit_progress: endpoint is not progressable");
     if (ring == nullptr) throw std::invalid_argument("LocalMailboxEndpoint::submit_progress: null ring");
     TaskSlotState *slot_state = ring->slot_state(dispatch.task_slot);
     if (slot_state == nullptr) throw std::out_of_range("LocalMailboxEndpoint::submit_progress: invalid task slot");
@@ -894,6 +676,9 @@ void LocalMailboxEndpoint::submit_progress(Ring *ring, const WorkerDispatch &dis
         );
     }
 
+    // The lease slot id is a native pipeline slot bounded by the runtime's
+    // PipelineContract, not a mailbox frame number. A two-frame endpoint maps
+    // the two 1:1; a single-frame endpoint always publishes to frame 0.
     const size_t frame_index = task_frame_count_ == 1 ? 0 : state.pipeline_lease.slot_id;
     // Linearize task-frame publication against base-frame controls. The
     // control mutex is released immediately after the task state release-store;

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -286,17 +286,12 @@ public:
     virtual ~WorkerEndpoint() = default;
 
     virtual const WorkerEndpointCaps &caps() const = 0;
-    virtual WorkerCompletion run(Ring *ring, const WorkerDispatch &dispatch) = 0;
-    // Compatibility endpoints without progress support use completion-time
-    // acceptance unless they override this boundary.
-    virtual WorkerCompletion
-    run_with_accept(Ring *ring, const WorkerDispatch &dispatch, const std::function<void()> &on_accept);
 
-    // Progressable endpoints are driven by the owning WorkerThread without a
-    // blocking call per frame. submit_progress publishes one complete frame;
-    // poll_progress reports monotonic events; activate_progress is a sticky
-    // FIFO-launch permission that may arrive before the child stages the frame.
-    virtual bool progressable() const { return false; }
+    // Every endpoint is progress-driven: the owning WorkerThread drives it
+    // without a blocking call per frame. submit_progress publishes one complete
+    // frame; poll_progress reports monotonic events; activate_progress is a
+    // sticky FIFO-launch permission that may arrive before the child stages the
+    // frame.
     virtual void submit_progress(Ring *ring, const WorkerDispatch &dispatch);
     virtual bool poll_progress(WorkerEndpointProgress &progress);
     virtual bool activate_progress(RunId run_id);
@@ -360,10 +355,6 @@ public:
     LocalMailboxEndpoint(int32_t worker_id, void *mailbox, int child_pid = -1, uint32_t task_frame_count = 1);
 
     const WorkerEndpointCaps &caps() const override { return caps_; }
-    WorkerCompletion run(Ring *ring, const WorkerDispatch &dispatch) override;
-    WorkerCompletion
-    run_with_accept(Ring *ring, const WorkerDispatch &dispatch, const std::function<void()> &on_accept) override;
-    bool progressable() const override { return true; }
     void submit_progress(Ring *ring, const WorkerDispatch &dispatch) override;
     bool poll_progress(WorkerEndpointProgress &progress) override;
     bool activate_progress(RunId run_id) override;
@@ -634,7 +625,6 @@ private:
     std::unordered_map<uint64_t, std::string> accept_errors_;
 
     void loop();
-    WorkerCompletion dispatch_process(WorkerDispatch d, const std::function<void()> &on_accept);
     EnqueueDispatchResult enqueue_dispatch(WorkerDispatch d, LaneKind lane, RunId expected_run_id = INVALID_RUN_ID);
     LaneState &lane(LaneKind kind) { return lanes_[static_cast<size_t>(kind)]; }
     const LaneState &lane(LaneKind kind) const { return lanes_[static_cast<size_t>(kind)]; }

--- a/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
+++ b/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
@@ -415,23 +415,6 @@ TaskArgs bare_pointer_args() {
 
 }  // namespace
 
-TEST(RemoteEndpoint, SuccessCompletionMapsToSuccess) {
-    Ring ring;
-    ring.init(1ULL << 20);
-    TaskSlot slot = make_slot(ring, scalar_args());
-
-    auto *transport = new FakeRemoteTransport();
-    RemoteL3Endpoint endpoint(3, 99, "fake", std::unique_ptr<RemoteL3Transport>(transport));
-
-    WorkerDispatch dispatch;
-    dispatch.task_slot = slot;
-    WorkerCompletion completion = endpoint.run(&ring, dispatch);
-
-    EXPECT_EQ(completion.outcome, EndpointOutcome::SUCCESS);
-    EXPECT_FALSE(transport->last_frame.empty());
-    ring.shutdown();
-}
-
 TEST(RemoteEndpoint, TaskDispatchUsesProgressSubmissionAndPolling) {
     Ring ring;
     ring.init(1ULL << 20);
@@ -440,7 +423,6 @@ TEST(RemoteEndpoint, TaskDispatchUsesProgressSubmissionAndPolling) {
     auto *transport = new FakeRemoteTransport();
     transport->progress_polls_before_ready = 1;
     RemoteL3Endpoint endpoint(3, 99, "fake", std::unique_ptr<RemoteL3Transport>(transport));
-    ASSERT_TRUE(endpoint.progressable());
 
     WorkerDispatch dispatch;
     dispatch.task_slot = slot;
@@ -453,6 +435,7 @@ TEST(RemoteEndpoint, TaskDispatchUsesProgressSubmissionAndPolling) {
     EXPECT_EQ(progress.kind, WorkerProgressKind::COMPLETED);
     EXPECT_EQ(progress.dispatch.dispatch_id, 7u);
     EXPECT_EQ(progress.completion.outcome, EndpointOutcome::SUCCESS);
+    EXPECT_FALSE(transport->last_frame.empty());
     ring.shutdown();
 }
 
@@ -474,10 +457,6 @@ TEST(RemoteEndpoint, ProgressStopReleasesWaitingControl) {
     EXPECT_EQ(control.wait_for(std::chrono::milliseconds(50)), std::future_status::timeout);
 
     endpoint.request_progress_stop();
-    if (control.wait_for(std::chrono::milliseconds(500)) != std::future_status::ready) {
-        WorkerEndpointProgress progress;
-        EXPECT_TRUE(endpoint.poll_progress(progress));
-    }
     ASSERT_EQ(control.wait_for(std::chrono::milliseconds(500)), std::future_status::ready);
     EXPECT_THROW(control.get(), std::runtime_error);
     ring.shutdown();
@@ -495,10 +474,12 @@ TEST(RemoteEndpoint, RemoteTaskErrorMapsToTaskFailure) {
 
     WorkerDispatch dispatch;
     dispatch.task_slot = slot;
-    WorkerCompletion completion = endpoint.run(&ring, dispatch);
+    endpoint.submit_progress(&ring, dispatch);
 
-    EXPECT_EQ(completion.outcome, EndpointOutcome::TASK_FAILURE);
-    EXPECT_EQ(completion.error_message, "remote orch failed");
+    WorkerEndpointProgress progress;
+    ASSERT_TRUE(endpoint.poll_progress(progress));
+    EXPECT_EQ(progress.completion.outcome, EndpointOutcome::TASK_FAILURE);
+    EXPECT_EQ(progress.completion.error_message, "remote orch failed");
     ring.shutdown();
 }
 
@@ -804,7 +785,7 @@ TEST(RemoteSocketTransport, RuntimeWriteToStalledReaderTimesOut) {
     server.stop_and_join();
 }
 
-TEST(RemoteEndpoint, BareHostPointerWithoutSidecarIsEndpointFailure) {
+TEST(RemoteEndpoint, BareHostPointerWithoutSidecarIsRejectedAtSubmission) {
     Ring ring;
     ring.init(1ULL << 20);
     TaskSlot slot = make_slot(ring, bare_pointer_args());
@@ -814,10 +795,16 @@ TEST(RemoteEndpoint, BareHostPointerWithoutSidecarIsEndpointFailure) {
 
     WorkerDispatch dispatch;
     dispatch.task_slot = slot;
-    WorkerCompletion completion = endpoint.run(&ring, dispatch);
-
-    EXPECT_EQ(completion.outcome, EndpointOutcome::ENDPOINT_FAILURE);
-    EXPECT_NE(completion.error_message.find("bare host pointer"), std::string::npos);
+    // Encoding happens while publishing, so an unsidecar'd bare host pointer is
+    // rejected at submission rather than reported as a completion. Match the
+    // message: submit_progress has several other runtime_error paths, and a
+    // bare EXPECT_THROW would pass on any of them.
+    try {
+        endpoint.submit_progress(&ring, dispatch);
+        ADD_FAILURE() << "expected the bare host pointer to be rejected";
+    } catch (const std::runtime_error &e) {
+        EXPECT_NE(std::string(e.what()).find("bare host pointer"), std::string::npos) << e.what();
+    }
     EXPECT_TRUE(transport->last_frame.empty());
     ring.shutdown();
 }

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -273,14 +273,29 @@ public:
 
     const WorkerEndpointCaps &caps() const override { return caps_; }
 
-    WorkerCompletion run(Ring *ring, const WorkerDispatch &dispatch) override {
-        (void)ring;
-        WorkerCompletion completion;
-        completion.task_slot = dispatch.task_slot;
-        completion.group_index = dispatch.group_index;
-        completion.outcome = EndpointOutcome::SUCCESS;
-        return completion;
+    // Immediate success: submit_progress queues the completion the very next
+    // poll_progress reports, so a dispatch through this endpoint finishes
+    // without any test-side stepping.
+    void submit_progress(Ring *, const WorkerDispatch &dispatch) override {
+        std::lock_guard<std::mutex> lk(mu_);
+        WorkerEndpointProgress progress;
+        progress.kind = WorkerProgressKind::COMPLETED;
+        progress.dispatch = dispatch;
+        progress.completion.task_slot = dispatch.task_slot;
+        progress.completion.group_index = dispatch.group_index;
+        progress.completion.outcome = EndpointOutcome::SUCCESS;
+        events_.push_back(progress);
     }
+
+    bool poll_progress(WorkerEndpointProgress &progress) override {
+        std::lock_guard<std::mutex> lk(mu_);
+        if (events_.empty()) return false;
+        progress = events_.front();
+        events_.pop_front();
+        return true;
+    }
+
+    bool activate_progress(RunId) override { return true; }
 
     void control_prepare(const uint8_t *) override {
         if (prepare_count_ != nullptr) prepare_count_->fetch_add(1, std::memory_order_relaxed);
@@ -289,6 +304,8 @@ public:
 private:
     WorkerEndpointCaps caps_;
     std::atomic<int> *prepare_count_{nullptr};
+    std::mutex mu_;
+    std::deque<WorkerEndpointProgress> events_;
 };
 
 class DeterministicProgressEndpoint final : public WorkerEndpoint {
@@ -300,11 +317,6 @@ public:
     }
 
     const WorkerEndpointCaps &caps() const override { return caps_; }
-    bool progressable() const override { return true; }
-
-    WorkerCompletion run(Ring *, const WorkerDispatch &) override {
-        throw std::logic_error("progress endpoint must not use blocking run");
-    }
 
     void submit_progress(Ring *ring, const WorkerDispatch &dispatch) override {
         ProgressCall call(*this);
@@ -573,6 +585,16 @@ static TaskSlot make_progress_slot(Ring &ring, RunId run_id, uint32_t pipeline_s
     slot->run_id = run_id;
     slot->pipeline_lease = PipelineSlotLease{pipeline_slot, 0, generation};
     return allocation.slot;
+}
+
+// Poll an endpoint until it reports one progress event, or the budget expires.
+static bool poll_until(WorkerEndpoint &endpoint, WorkerEndpointProgress &progress) {
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (endpoint.poll_progress(progress)) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -1208,7 +1230,6 @@ TEST(WorkerManagerTest, CapacityOneMailboxUsesTheProgressTaskFrame) {
     ASSERT_NE(task_slot, INVALID_SLOT);
 
     LocalMailboxEndpoint endpoint(/*worker_id=*/0, mailbox.data(), /*child_pid=*/-1, /*task_frame_count=*/1);
-    EXPECT_TRUE(endpoint.progressable());
     EXPECT_FALSE(endpoint.caps().supports_frame_staging);
 
     WorkerDispatch dispatch{task_slot, 0, /*dispatch_id=*/41, /*prepare_only=*/false};
@@ -2041,54 +2062,50 @@ TEST_F(ProgressSchedulerFixture, PreparedSuccessorSingleCannotBypassItsReadyGrou
     if (orchestrator.run_done(second_run)) orchestrator.release_run(second_run);
 }
 
+// The endpoint must report acceptance as its own progress event, ahead of the
+// completion event, so a waiter on wait_run_accepted is released while the task
+// is still running rather than only once it finishes.
 TEST(WorkerManagerTest, LocalMailboxPublishesAcceptanceBeforeCompletion) {
     MockMailboxWorker child;
     child.start();
 
     Ring allocator;
     allocator.init(/*heap_bytes=*/0);
-    AllocResult ar = allocator.alloc(/*heap_bytes=*/0, /*depth=*/0);
-    ASSERT_NE(ar.slot, INVALID_SLOT);
-    TaskSlotState *slot = allocator.slot_state(ar.slot);
+    TaskSlot task_slot = make_progress_slot(allocator, /*run_id=*/31, /*pipeline_slot=*/1, /*generation=*/7);
+    ASSERT_NE(task_slot, INVALID_SLOT);
+    TaskSlotState *slot = allocator.slot_state(task_slot);
     ASSERT_NE(slot, nullptr);
-    slot->reset();
     slot->callable.digest[0] = 0x42;
-    slot->pipeline_lease = PipelineSlotLease{1, 0, 7};
 
     LocalMailboxEndpoint endpoint(/*worker_id=*/0, child.mailbox_ptr());
-    std::promise<WorkerCompletion> result;
-    auto done = result.get_future();
-    std::atomic<bool> accepted{false};
-    std::thread caller([&] {
-        result.set_value(endpoint.run_with_accept(&allocator, WorkerDispatch{ar.slot, 0}, [&] {
-            accepted.store(true, std::memory_order_release);
-        }));
-    });
+    WorkerDispatch dispatch{task_slot, 0, /*dispatch_id=*/71, /*prepare_only=*/false};
+    endpoint.submit_progress(&allocator, dispatch);
 
     child.wait_running();
     EXPECT_TRUE(child.is_running.load(std::memory_order_acquire));
+    // The lease travels in the task frame the dispatch was published to, not
+    // the control base frame.
+    const char *published_frame =
+        static_cast<const char *>(child.mailbox_ptr()) + MAILBOX_FIRST_TASK_FRAME * MAILBOX_FRAME_SIZE;
     PipelineSlotLease wire_lease{};
-    std::memcpy(
-        &wire_lease, static_cast<char *>(child.mailbox_ptr()) + MAILBOX_OFF_PIPELINE_LEASE, sizeof(PipelineSlotLease)
-    );
+    std::memcpy(&wire_lease, published_frame + MAILBOX_OFF_PIPELINE_LEASE, sizeof(PipelineSlotLease));
     EXPECT_EQ(wire_lease.slot_id, 1u);
     EXPECT_EQ(wire_lease.generation, 7u);
-    child.write_task_accepted();
-    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
-    while (!accepted.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < deadline) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    }
-    EXPECT_TRUE(accepted.load(std::memory_order_acquire));
-    EXPECT_EQ(done.wait_for(std::chrono::milliseconds(0)), std::future_status::timeout);
 
-    // Non-fatal from here on: a fatal assertion would return with `caller`
-    // joinable, and ~std::thread would terminate the whole test binary.
+    child.write_task_accepted();
+    WorkerEndpointProgress progress;
+    ASSERT_TRUE(poll_until(endpoint, progress));
+    EXPECT_EQ(progress.kind, WorkerProgressKind::ACCEPTED);
+    EXPECT_EQ(progress.dispatch.dispatch_id, dispatch.dispatch_id);
+
+    // Acceptance is a distinct earlier event: the task is not complete yet.
+    WorkerEndpointProgress not_yet;
+    EXPECT_FALSE(endpoint.poll_progress(not_yet));
+
     child.complete();
-    EXPECT_EQ(done.wait_for(std::chrono::seconds(3)), std::future_status::ready);
-    if (done.valid() && done.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-        EXPECT_EQ(done.get().outcome, EndpointOutcome::SUCCESS);
-    }
-    caller.join();
+    ASSERT_TRUE(poll_until(endpoint, progress));
+    EXPECT_EQ(progress.kind, WorkerProgressKind::COMPLETED);
+    EXPECT_EQ(progress.completion.outcome, EndpointOutcome::SUCCESS);
     allocator.shutdown();
 }
 
@@ -2098,8 +2115,8 @@ TEST(WorkerManagerTest, LocalMailboxPublishesAcceptanceBeforeCompletion) {
 // state word observes none at all.
 //
 // This does not force the parent to skip a poll between the two writes: the
-// parent is already spinning by then and nothing here can stop it. What it
-// pins is the property that makes that interleaving harmless — acceptance is
+// parent is already polling by then and nothing here can stop it. What it pins
+// is the property that makes that interleaving harmless — acceptance is
 // readable after TASK_DONE, so losing a poll cannot lose the ACK.
 TEST(WorkerManagerTest, AcceptanceIsReadableAfterTaskDone) {
     MockMailboxWorker child;
@@ -2107,23 +2124,15 @@ TEST(WorkerManagerTest, AcceptanceIsReadableAfterTaskDone) {
 
     Ring allocator;
     allocator.init(/*heap_bytes=*/0);
-    AllocResult ar = allocator.alloc(/*heap_bytes=*/0, /*depth=*/0);
-    ASSERT_NE(ar.slot, INVALID_SLOT);
-    TaskSlotState *slot = allocator.slot_state(ar.slot);
+    TaskSlot task_slot = make_progress_slot(allocator, /*run_id=*/33, /*pipeline_slot=*/0, /*generation=*/1);
+    ASSERT_NE(task_slot, INVALID_SLOT);
+    TaskSlotState *slot = allocator.slot_state(task_slot);
     ASSERT_NE(slot, nullptr);
-    slot->reset();
     slot->callable.digest[0] = 0x42;
 
     LocalMailboxEndpoint endpoint(/*worker_id=*/0, child.mailbox_ptr());
-    std::promise<WorkerCompletion> result;
-    auto done = result.get_future();
-    std::atomic<bool> accepted{false};
-
-    std::thread caller([&] {
-        result.set_value(endpoint.run_with_accept(&allocator, WorkerDispatch{ar.slot, 0}, [&] {
-            accepted.store(true, std::memory_order_release);
-        }));
-    });
+    WorkerDispatch dispatch{task_slot, 0, /*dispatch_id=*/73, /*prepare_only=*/false};
+    endpoint.submit_progress(&allocator, dispatch);
 
     child.wait_running();
     EXPECT_TRUE(child.is_running.load(std::memory_order_acquire));
@@ -2131,15 +2140,23 @@ TEST(WorkerManagerTest, AcceptanceIsReadableAfterTaskDone) {
     child.write_task_accepted();
     child.complete();
 
-    // Non-fatal: a fatal assertion would return with `caller` joinable, and
-    // ~std::thread would terminate the whole test binary.
-    EXPECT_EQ(done.wait_for(std::chrono::seconds(3)), std::future_status::ready);
-    if (done.valid() && done.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-        EXPECT_EQ(done.get().outcome, EndpointOutcome::SUCCESS);
+    bool saw_accepted = false;
+    bool saw_completed = false;
+    WorkerEndpointProgress progress;
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (!saw_completed && std::chrono::steady_clock::now() < deadline) {
+        if (!endpoint.poll_progress(progress)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            continue;
+        }
+        if (progress.kind == WorkerProgressKind::ACCEPTED) saw_accepted = true;
+        if (progress.kind == WorkerProgressKind::COMPLETED) {
+            saw_completed = true;
+            EXPECT_EQ(progress.completion.outcome, EndpointOutcome::SUCCESS);
+        }
     }
-    EXPECT_TRUE(accepted.load(std::memory_order_acquire))
-        << "the endpoint lost the launch ACK to a task that completed first";
-    caller.join();
+    EXPECT_TRUE(saw_completed);
+    EXPECT_TRUE(saw_accepted) << "the endpoint lost the launch ACK to a task that completed first";
     allocator.shutdown();
 }
 

--- a/tests/ut/py/test_worker/test_admission_fence.py
+++ b/tests/ut/py/test_worker/test_admission_fence.py
@@ -315,7 +315,7 @@ def _serve_until_shutdown(mailbox: SharedMemory, gate: SharedMemory) -> None:
     assert gate_buf is not None
     state_addr = worker_mod._buffer_field_addr(mailbox_buf, worker_mod._OFF_STATE)
 
-    def handle_task():
+    def handle_task(_task_buf):
         return 0, ""
 
     def handle_control(_sub_cmd):
@@ -348,7 +348,7 @@ class TestOneWayShutdown:
         """A shutdown requested while a control command is in flight must still
         end the child, even though the CONTROL_DONE it publishes overwrites the
         SHUTDOWN state word."""
-        mailbox = SharedMemory(create=True, size=worker_mod.MAILBOX_FRAME_SIZE)
+        mailbox = SharedMemory(create=True, size=worker_mod.MAILBOX_SIZE)
         gate = SharedMemory(create=True, size=8)
         mailbox_buf = mailbox.buf
         gate_buf = gate.buf

--- a/tests/ut/py/test_worker/test_error_propagation.py
+++ b/tests/ut/py/test_worker/test_error_propagation.py
@@ -209,12 +209,12 @@ class TestL4ChainedFailure:
         """A SentinelError in the innermost sub callable must reach the L4
         caller's run() with enough context to identify both layers.
 
-        The error first bubbles from the SubWorker through the parent's
-        dispatch_process as `std::runtime_error("sub_worker: ... SentinelError: ...")`.
+        The error first bubbles from the SubWorker through the parent's failed
+        completion as `std::runtime_error("sub_worker: ... SentinelError: ...")`.
         Inside the L3 orch fn this reaches the per-run wait, which rethrows. The L3
         child process catches that in _child_worker_loop and rewrites it
         as `child_worker level=3: RuntimeError: <original>`. The L4 parent's
-        dispatch_process rethrows again. The final string visible at the L4
+        completion path rethrows again. The final string visible at the L4
         caller contains both prefixes.
         """
 

--- a/tests/ut/py/test_worker/test_host_buffer_registration.py
+++ b/tests/ut/py/test_worker/test_host_buffer_registration.py
@@ -147,6 +147,7 @@ def test_l3_sub_worker_maps_rewrites_and_unmaps_host_buffer(monkeypatch):
     mailbox = SharedMemory(create=True, size=MAILBOX_SIZE)
     host = SharedMemory(create=True, size=8)
     staged = None
+    task_frame = None
     mailbox_buf = mailbox.buf
     host_buf = host.buf
     assert mailbox_buf is not None
@@ -167,35 +168,48 @@ def test_l3_sub_worker_maps_rewrites_and_unmaps_host_buffer(monkeypatch):
 
         digest = bytes(range(32))
         # MAP, use the child mapping, UNMAP, verify rewriting stops, then exit.
-        states = iter(
+        # Tasks arrive on the dedicated task frame; the base frame carries only
+        # controls and shutdown.
+        base_states = iter(
             (
                 worker_mod._CONTROL_REQUEST,
-                worker_mod._TASK_READY,
+                worker_mod._IDLE,
                 worker_mod._CONTROL_REQUEST,
-                worker_mod._TASK_READY,
+                worker_mod._IDLE,
                 worker_mod._SHUTDOWN,
             )
         )
+        task_states = iter(
+            (
+                worker_mod._IDLE,
+                worker_mod._TASK_READY,
+                worker_mod._IDLE,
+                worker_mod._TASK_READY,
+                worker_mod._IDLE,
+            )
+        )
         called = []
-        # The loop polls two words per iteration; only the state word is
+        # The loop polls three words per iteration; only the state words are
         # scripted, so the sticky shutdown word always reads "not requested".
         shutdown_addr = worker_mod._buffer_field_addr(mailbox_buf, worker_mod._OFF_SHUTDOWN)
         task_state_addr = (
             worker_mod._buffer_field_addr(mailbox_buf, worker_mod._OFF_STATE) + worker_mod.MAILBOX_FRAME_SIZE
         )
+        task_frame = mailbox_buf[worker_mod.MAILBOX_FRAME_SIZE : 2 * worker_mod.MAILBOX_FRAME_SIZE]
 
         def load_state(state_addr):
             if state_addr == shutdown_addr:
                 return 0
             if state_addr == task_state_addr:
-                return worker_mod._IDLE
-            state = next(states)
-            if state == worker_mod._TASK_READY:
-                start = worker_mod._OFF_TASK_CALLABLE_HASH
-                mailbox_buf[start : start + len(digest)] = digest
-                struct.pack_into("<ii", mailbox_buf, worker_mod._OFF_TASK_ARGS_BLOB, 1, 0)
-                struct.pack_into("<Q", mailbox_buf, worker_mod._OFF_TASK_ARGS_BLOB + 8, parent_addr)
-            elif state == worker_mod._CONTROL_REQUEST and called:
+                state = next(task_states)
+                if state == worker_mod._TASK_READY:
+                    start = worker_mod._OFF_TASK_CALLABLE_HASH
+                    task_frame[start : start + len(digest)] = digest
+                    struct.pack_into("<ii", task_frame, worker_mod._OFF_TASK_ARGS_BLOB, 1, 0)
+                    struct.pack_into("<Q", task_frame, worker_mod._OFF_TASK_ARGS_BLOB + 8, parent_addr)
+                return state
+            state = next(base_states)
+            if state == worker_mod._CONTROL_REQUEST and called:
                 unmap_payload = worker_mod._HOST_BUF_UNMAP.pack(7)
                 assert staged is not None
                 staged_buf = staged.buf
@@ -235,6 +249,10 @@ def test_l3_sub_worker_maps_rewrites_and_unmaps_host_buffer(monkeypatch):
         assert called == [True, True], worker_mod._read_error_msg(mailbox_buf)
         assert struct.unpack_from("<Q", host_buf, 0)[0] == 42
     finally:
+        # Before mailbox_buf: releasing a buffer with an exported slice raises
+        # BufferError, which would replace a real assertion failure above.
+        if task_frame is not None:
+            task_frame.release()
         mailbox_buf.release()
         host_buf.release()
         mailbox.close()


### PR DESCRIPTION
Follow-ups to the review on #1728, which merged as `9a03d92c`. All five items addressed.

## ② Blocking channel deleted (was: "delete or explain")

Once both endpoint kinds became progress-driven, the blocking channel lost its
last production caller. Deleted end to end:

- `WorkerEndpoint::run` (pure virtual) and `run_with_accept` off the interface
- `LocalMailboxEndpoint::run` / `run_with_accept`, `RemoteL3Endpoint::run`
- `WorkerThread::dispatch_process` and the non-progress half of `WorkerThread::loop`
- the Python base-frame `_TASK_READY` branch
- `progressable()` — with no blocking path left, its `false` case selects nothing

**The review's survey was one caller short.** It listed only C++ UTs, but
`test_l3_sub_worker_maps_rewrites_and_unmaps_host_buffer` scripts `_TASK_READY`
on the *base* frame, so deleting the Python branch broke it. That test is
rescripted onto the task frame.

Tests reaching the channel covered invariants that outlive it, so they move to
the progress path rather than being dropped:

| Test | Disposition |
|---|---|
| `LocalMailboxPublishesAcceptanceBeforeCompletion` | Ported. Still pins that acceptance is a distinct event *ahead* of completion. |
| `AcceptanceIsReadableAfterTaskDone` | Ported. Still pins that the ACK survives a `TASK_DONE` landing with no poll in between. |
| `RemoteTaskErrorMapsToTaskFailure` | Ported; `poll_progress` reproduces the `TASK_FAILURE` mapping unchanged. |
| `BareHostPointerWithoutSidecarIsRejectedAtSubmission` | **Changes shape honestly** — encoding happens while publishing, so an unsidecar'd bare pointer is now rejected at `submit_progress` rather than reported as a completion. Renamed to match, and it asserts the message since `submit_progress` has several other `runtime_error` paths. |
| `SuccessCompletionMapsToSuccess` | Dropped as redundant; `TaskDispatchUsesProgressSubmissionAndPolling` already covers it. Its `last_frame` assertion moved there. |
| `FakeEndpoint` | Now progress-driven, queueing the completion its next poll reports — which preserves the completion-time acceptance `run_with_accept` used to give it. |

## ① Guard removed, fixture fixed

Verified both halves of the claim before acting: all three production mailboxes
are `MAILBOX_SIZE`, and CPython's `SharedMemory` reports the exact requested
length (`size=64` → `len(buf) == 64`), so a one-frame buffer is not page-rounded
back into range. The fixture now allocates a whole mailbox, and the guard plus
both `task_buf is not None` checks are gone — `buf` is a whole mailbox by
construction. A short buffer now fails fast at `_buffer_field_addr` with a clear
`ValueError` during setup rather than producing a garbage address.

## ③ Invariant stated at the ternary

`frame_index` reads as if `slot_id` were a frame number. A present-tense comment
now states it is a native pipeline slot bounded by the runtime
`PipelineContract`, mapped 1:1 by two-frame endpoints and pinned to frame 0 by
single-frame ones.

## ④ Fallback removed — and verified non-vacuous

`ProgressStopReleasesWaitingControl` polled progress when the control future was
not ready, so it passed whether or not `request_progress_stop` woke the waiter —
the one thing it exists to prove. Fallback removed; **verified by mutation**:
with `command_cv_.notify_all()` deleted the test hangs, and with it restored it
passes in 50 ms.

## ⑤ Stale comments

Three words per iteration, not two; the admission-fence handler takes the task
buffer.

## Stale references the removal left behind

Per `doc-consistency.md` §1, grepping the deleted names surfaced references my
change made wrong — `docs/worker-manager.md` (blocking-dispatch wording, ×3),
`docs/task-flow.md`, `python/bindings/worker_bind.h`, `python/simpler/worker.py`,
`test_error_propagation.py`, and the four `build_task_payload` throws that still
named `RemoteL3Endpoint::run`. All updated to describe the paths that now exist.

## Validation

- `73/73` cpp UT (`ctest -L no_hardware`)
- `1189` passed / 13 skipped — full `tests/ut/py`
- a2a3 **onboard** sweep: 54 passed, plus 24 passed / 2 skipped in the resource phase; quarantined `sdma` lane 1 passed
- a2a3sim sweep: 45 passed, plus 21 passed / 4 skipped

## One open thread

CodeRabbit suggests a bounded `cv_` wait in `WorkerThread::loop()` so the
in-flight branch does not spin a core. Declined and left unresolved for a human
call: `codestyle.md` rule 5 forbids backoff timers on the dispatch path, nothing
notifies `cv_` on child completion (so a `wait_for` would be a pure timer that
adds latency to every task), and the spin is pre-existing — this PR only deleted
the *other* loop branch. A real wakeup primitive would be the rule-compliant fix
and deserves its own PR.
