### PR TITLE
Docs: state the launched invariant in simpler_finalize_run

### DIFF
--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -853,6 +853,12 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     STRACE_CONTEXT(state->trace_inv, state->trace_hid, 1);
 
     int execution_rc = state->completion_rc;
+    // The launch transaction hands back an ActiveExecution only once it has
+    // reached the device (LaunchProgress::Partial or Complete); a NotStarted
+    // launch returns its PreparedExecution instead and leaves this null. So
+    // `launched` means "this run owns device work" — it is what separates a run
+    // that must be drained, whose rc is the run's result, and whose runtime
+    // holds a live GM/SM pointer, from one that never touched a stream.
     const bool launched = state->active_execution != nullptr;
     // Both drain_execution() and validate_runtime_impl() touch the device, so
     // the attach covers each of them. rtSetDevice is idempotent on an

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -759,6 +759,12 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     STRACE_CONTEXT(state->trace_inv, state->trace_hid, 1);
 
     int execution_rc = state->completion_rc;
+    // The launch transaction hands back an ActiveExecution only once it has
+    // reached the device (LaunchProgress::Partial or Complete); a NotStarted
+    // launch returns its PreparedExecution instead and leaves this null. So
+    // `launched` means "this run owns device work" — it is what separates a run
+    // that must be drained, whose rc is the run's result, and whose runtime
+    // holds a live GM/SM pointer, from one that never touched a stream.
     const bool launched = state->active_execution != nullptr;
     // Bind the calling thread to this runner's simulated device before the
     // drain and the validation below. attach_current_thread() is idempotent


### PR DESCRIPTION
Fixes #1742.

## What the issue asked for

`launched` in `simpler_finalize_run` was redefined from `phase != NativeRunPhase::Prepared` to `state->active_execution != nullptr` by #1694, and the invariant behind it was never written down — not in a comment, not in either #1694's or #1725's commit message. The new definition is correct; the problem is that a future regression on this path has nothing to `git bisect` back to, and the next reader has to re-derive it.

## What the invariant actually is

I traced it rather than paraphrasing the issue. `launch_execution` populates `active` only when the transaction reached the device:

```cpp
// src/a2a3/platform/onboard/host/device_runner.cpp
if (transaction.progress == LaunchProgress::NotStarted) {
    outcome.prepared = std::move(prepared);          // active stays null
} else {                                             // Partial or Complete
    outcome.active = std::make_unique<ActiveExecution>(std::move(prepared), transaction.progress);
}
```

So a null `active_execution` is **exactly** a run that never touched a stream — which is why it should take the `-1` / `set_gm_sm_ptr(nullptr)` path rather than being treated as launched. The sim runner has the same rule (`device_runner.cpp:494-496`), so both copies get the same comment.

## The change

A comment at the definition in both `c_api_shared.cpp` variants, stating the present-tense fact per `comments.md` — no reference to #1694 or to the edit that produced it, since that belongs in the commit message and not the code.

**Comment only. No behavior change**; the diff is 12 added lines, zero modified.

> One thing I got wrong mid-way and corrected: my first draft said `launched` "decides all four uses below". Enumerating them found **five** (`:876`, `:894`, `:898`, `:900`, `:938`). The comment now states the invariant instead of counting call sites, which is both accurate and won't rot when a sixth appears.

## Validation

Comment-only, so this is really just proving nothing else moved:

- **91/91** cpp UT (`ctest -LE requires_hardware`)
- **1277** passed / 13 skipped — full `tests/ut/py`
- a2a3 **onboard** sweep: 54 passed, plus 24 passed / 2 skipped in the resource phase
- `git diff --stat` is `+12 / -0` across the two files — pure addition, no reformatting churn