### PR TITLE
Add: report the TMR depth-one fallback and mark the lease preview const

### DIFF
--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -730,7 +730,25 @@ int simpler_prepare_run(
                 );
             }
             if (compatibility_rc <= 0) {
-                if (compatibility_rc == 0) compatibility_rc = PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE;
+                // A miss is normal — the successor keeps its lease and prepares
+                // after the predecessor's fence — so it is reported at INFO and
+                // kept distinct from a probe that failed to answer at all.
+                // Without this the two are indistinguishable from outside: a
+                // pipeline that silently never overlaps looks the same whether
+                // the runtime_env disagrees or the feature is broken.
+                if (compatibility_rc == 0) {
+                    LOG_INFO(
+                        "simpler_prepare_run: shared-arena layout differs from the active run; preparing at depth one "
+                        "after its fence (%s)",
+                        state->trace_attrs
+                    );
+                    compatibility_rc = PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE;
+                } else {
+                    LOG_ERROR(
+                        "simpler_prepare_run: prepared-run compatibility probe failed: %d (%s)", compatibility_rc,
+                        state->trace_attrs
+                    );
+                }
                 return cleanup_failed_prepare(state, compatibility_rc, true);
             }
         }

--- a/src/common/worker/pipeline_slot_pool.h
+++ b/src/common/worker/pipeline_slot_pool.h
@@ -113,7 +113,11 @@ private:
  */
 class PipelineSlotGenerationFilter {
 public:
-    bool is_admissible(const PipelineSlotLease &lease) {
+    // Preview half of the preview/commit pair: reports the same verdict admit()
+    // would give, without advancing the slot. Const because committing nothing
+    // is the whole reason it exists — preparation can fail after this check, and
+    // a generation spent on a run that then falls back is not recoverable.
+    bool is_admissible(const PipelineSlotLease &lease) const {
         if (lease.slot_id >= newest_.size()) return false;
         std::lock_guard<std::mutex> lock(mu_);
         return lease.generation >= newest_[lease.slot_id];
@@ -134,7 +138,7 @@ public:
     }
 
 private:
-    std::mutex mu_;
+    mutable std::mutex mu_;
     std::array<uint64_t, PTO_PIPELINE_MAX_DEPTH> newest_{};
 };
 


### PR DESCRIPTION
Follow-ups from my review of #1588, which merged as `6e2731dc` with these left open. Both were non-blocking there; neither changes behavior.

## 1. The compatibility fallback was silent (was: Should-fix)

A `prepared_run_config_compatible_impl` miss returns through `cleanup_failed_prepare` → `PreparedRunIncompatible` → `depth_one_fallback`, and the successor quietly prepares after the predecessor's fence instead of overlapping.

That is the *correct* outcome — the plan calls compatibility fallback "normal behavior, not an error" — which is precisely why it was hard to observe. **A pipeline that silently never overlaps looks identical whether the user's `runtime_env` genuinely disagrees or the feature has regressed.** Every other decision on this path emits a `LOG_ERROR` or an `STRACE` marker; this one emitted neither.

The previous code also collapsed two different outcomes into one branch:

```cpp
if (compatibility_rc == 0) compatibility_rc = PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE;
```

`0` means *incompatible* (normal). `< 0` means *the probe failed to answer* (not normal). Those now log at INFO and ERROR respectively.

## 2. `is_admissible` is now `const` (was: Consider)

With `mu_` made `mutable`. It exists only to answer the question `admit()` answers **without** advancing the slot — because preparation can fail after the check, and a generation burned on a run that then falls back is unrecoverable. The signature now states that.

## 3. SDMA ownership — checked, nothing to do (was: Consider)

I flagged that the plan lists SDMA ownership among the compatibility inputs but I could not find it in the key. Traced it: `simpler_provision_dma_workspace` runs **once** in `ChipWorker::init` (`chip_worker.cpp:394`) and its addresses are latched into the resident `KernelArgs`, so every run carries the same ones. It is per-worker state that cannot differ between a predecessor and its successor, so the key correctly omits it. No change.

## Validation

- **91/91** cpp UT (`ctest -LE requires_hardware`)
- **1277** passed / 13 skipped — full `tests/ut/py`
- a2a3 **onboard** sweep: **56 passed**, plus 24 passed / 2 skipped in the resource phase — including `TestWorkerAsyncWholeRunFifoTmr::test_incompatible_runtime_env_falls_back_to_depth_one`, the test that drives the branch this PR touches

⚠️ **One honest limitation.** I could not get the new `LOG_INFO` to appear in captured output, so I have **not** empirically proven that exact line executes. `simpler_prepare_run` lives in the host-runtime DSO with no unit harness, and host INFO is level-gated — my attempt to lower the threshold from the parent did not reach the forked child, so the run showed no host INFO lines at all rather than showing mine missing. What is verified: the branch itself is exercised on hardware (the fallback ST passes and is the reason the sweep reports 56), the file compiles with `LOG_INFO` resolving to `unified_log.h`'s host macro, and the surrounding `LOG_ERROR` calls in this same function use the identical mechanism. The risk is confined to log formatting, not control flow.