### PR TITLE
Fix: harden Buffer.close() -- close-failure ordering + post-release Tensor derivation

### DIFF
--- a/python/simpler/buffer.py
+++ b/python/simpler/buffer.py
@@ -143,9 +143,12 @@ class Buffer:
     # backing lives on (0 for a host backing or an L2 own-device malloc). The device-pointer provenance
     # guard and free/copy key on (owner_worker_id, base).
     owner_worker_id: int = 0
+    closed: bool = False
 
     def to_descriptor(self) -> BufferDescriptor:
         """The wire descriptor for this backing — what a consumer needs to resolve it."""
+        if self.closed:
+            raise ValueError(f"Buffer: cannot derive a descriptor from a released buffer ({self.identity})")
         return BufferDescriptor(
             identity=self.identity,
             address_space=self.address_space,
@@ -182,11 +185,19 @@ class Buffer:
 
     def close(self) -> None:
         """Release the backing. The owner unlinks it, so a later consumer map fails rather than
-        resolving a name whose bytes are gone. Idempotent."""
-        if self.shm is not None:
-            self.shm.close()
-            self.shm.unlink()
-            self.shm = None
+        resolving a name whose bytes are gone. Idempotent; a released Buffer's ``tensor()``/
+        ``to_descriptor()`` are refused rather than building a view over memory that may already be
+        gone."""
+        if self.closed:
+            return
+        self.closed = True
+        shm = self.shm
+        self.shm = None
+        if shm is not None:
+            try:
+                shm.close()
+            finally:
+                shm.unlink()
 
 
 def create_host_shared_buffer(

--- a/tests/ut/py/test_buffer.py
+++ b/tests/ut/py/test_buffer.py
@@ -17,6 +17,7 @@ registry and the Buffer constructors that are genuinely defined there.
 """
 
 import ctypes
+from unittest.mock import patch
 
 import pytest
 from _task_interface import OWNER_INSTANCE_ID_BYTES, DataType
@@ -145,6 +146,35 @@ def test_create_export_import_resolve_zero_copy():
     finally:
         reg.close()
         buffer.close()
+
+
+def test_close_unlinks_even_when_shm_close_raises():
+    # A close() failure must not skip owner unlink: the shm's named backing is the actual leak risk,
+    # not the local close() call, so unlink must run regardless of whether close() itself succeeded.
+    buffer = create_host_shared_buffer(nbytes=64, owner_instance_id=mint_owner_instance_id(), buffer_id=1)
+    shm = buffer.shm
+    assert shm is not None
+    with (
+        patch.object(shm, "close", side_effect=OSError("injected close failure")),
+        patch.object(shm, "unlink") as unlink,
+    ):
+        with pytest.raises(OSError, match="injected close failure"):
+            buffer.close()
+        unlink.assert_called_once()
+    assert buffer.closed
+    shm.unlink()  # the mock above swallowed the real unlink; do it for real so the test leaves no /dev/shm litter
+
+
+def test_closed_buffer_refuses_to_derive_a_tensor():
+    # A released Buffer's identity may already be unlinked, so deriving a Tensor from it would embed
+    # a descriptor for memory that no longer exists.
+    buffer = create_host_shared_buffer(nbytes=64, owner_instance_id=mint_owner_instance_id(), buffer_id=1)
+    buffer.close()
+    assert buffer.closed
+    with pytest.raises(ValueError, match="released buffer"):
+        buffer.to_descriptor()
+    with pytest.raises(ValueError, match="released buffer"):
+        buffer.tensor(shapes=(16,), dtype=DataType.FLOAT32)
 
 
 def test_resolve_unregistered_raises():


### PR DESCRIPTION
## Summary

`feature_roadmap.md`'s P1-B gate table lists G5 as the last remaining red gate: "a mapping-close failure must not skip owner unlink; a released handle must not go on deriving `Tensor`." `Buffer.close()` already exists and is used throughout the test suite as the release path for `create_buffer()`-issued buffers, but had exactly the two bugs G5 names — neither previously covered by a test:

- **A `close()` failure skipped unlink.** If `self.shm.close()` raised, `self.shm.unlink()` never ran and `self.shm` was never cleared — the shared-memory segment leaks on the filesystem, and a retry just raises again on the same broken `close()`, never reaching `unlink()`. `close()` now clears `self.shm` and marks the `Buffer` closed up front, then unlinks in a `finally` so it runs even if `close()` itself raises.
- **A closed `Buffer` still derived a `Tensor`.** `close()` never marked the `Buffer` as dead, so `buffer.tensor(...)` after `buffer.close()` happily built a `Tensor` embedding a descriptor for a shm segment that (with the first bug fixed) no longer exists. Added a `closed` field, set unconditionally in `close()` — including for `FORK_COW`/`FORK_SHM`/`DEVICE_MALLOC`/`VMM_WINDOW`-backed buffers, which never had an `shm` to begin with and for which `close()` was previously a complete no-op — plus a guard in `to_descriptor()` (which `tensor()` calls internally, so one guard covers both derivation paths).

**Out of scope**: the broader P1-B "registry + lifetime" work — `release_buffer()` as a public API distinct from `close()`, in-flight retain tracking for a `Buffer` still referenced by a submitted run, and `buffer_id` reuse with a generation bump. None of these exist anywhere in this codebase today (`generation` is hard-coded to 1 at every call site; `_next_buffer_id()` never reuses freed ids), and none are required by G5's actual text.

## Test plan

- [x] `test_close_unlinks_even_when_shm_close_raises` — injects a `close()` failure via mock, asserts `unlink` still runs; confirmed failing against the prior code
- [x] `test_closed_buffer_refuses_to_derive_a_tensor` — asserts `to_descriptor()` and `tensor()` both raise after `close()`; confirmed failing against the prior code
- [x] `pytest tests/ut` — 1283 passed / 13 skipped / 0 failed
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
