### PR TITLE
CI: run A5 SDMA tests on x86

### DIFF
--- a/.claude/skills/test-all-device/SKILL.md
+++ b/.claude/skills/test-all-device/SKILL.md
@@ -18,11 +18,20 @@ Detection / isolation procedures referenced below live in
    `task-submit`, let it pick via `--device auto --device-num <range size>`.
 5. **Read the marker selector out of the same job** you took the timeout from.
    `st-onboard-a2a3` is two pytest passes, not one: the sweep deselects
-   `-m "not sdma"` and a later step runs `-m sdma`. `st-onboard-a5` has no
-   marker filter. Take the expression from `ci.yml` rather than assuming, so
-   this skill cannot drift from the job it reproduces.
-6. **Run through `task-submit`** (§E). The underlying command, on a platform
-   whose job carries the filter:
+   `-m "not sdma"` and a later step runs `-m sdma`. `st-onboard-a5` uses
+   `-m "not pod"` and does not exclude `sdma`. Take the expression from
+   `ci.yml` rather than assuming, so this skill cannot drift from the job it
+   reproduces.
+6. **Run through `task-submit`** (§E). On a5, the underlying command excludes
+   only pod tests, so SDMA remains in the sweep:
+
+   ```bash
+   pytest examples tests/st -m "not pod" --platform a5 \
+     --device <range-or-$TASK_DEVICE> --pto-session-timeout <timeout> -v
+   ```
+
+   On a platform whose job separates SDMA tests, the underlying sweep command
+   is:
 
    ```bash
    pytest examples tests/st -m "not sdma" --platform <platform> \
@@ -45,5 +54,6 @@ Detection / isolation procedures referenced below live in
    Parallelism is auto-driven by `--device`: on hardware, one in-flight
    subprocess per device (`--max-parallel auto` = `len(--device)`); see
    `docs/testing.md` for the full reuse hierarchy.
-7. Report the results summary (pass/fail counts per task), across both passes.
+7. Report the results summary (pass/fail counts per task) across all applicable
+   passes.
 8. If any tests fail, show the relevant error output and which device failed.

--- a/.claude/skills/test-runtime-device/SKILL.md
+++ b/.claude/skills/test-runtime-device/SKILL.md
@@ -20,10 +20,21 @@ Detection / isolation procedures referenced below live in
    `task-submit`, let it pick via `--device auto --device-num <range size>`.
 6. **Read the marker selector out of the same job** you took the timeout from.
    `st-onboard-a2a3` is two pytest passes: the sweep deselects `-m "not sdma"`
-   and a later step runs `-m sdma`. `st-onboard-a5` has no marker filter. Both
-   quarantined tests are `tensormap_and_ringbuffer`, so the second pass is only
-   needed when `$ARGUMENTS` names that runtime.
-7. **Run through `task-submit`** (§E). The underlying command:
+   and a later step runs `-m sdma`. `st-onboard-a5` uses `-m "not pod"` and
+   does not exclude `sdma`. Both quarantined tests are
+   `tensormap_and_ringbuffer`, so the second pass is only needed when
+   `$ARGUMENTS` names that runtime.
+7. **Run through `task-submit`** (§E). On a5, the underlying command excludes
+   only pod tests, so SDMA remains in the sweep:
+
+   ```bash
+   pytest examples tests/st -m "not pod" --platform a5 --runtime $ARGUMENTS \
+     --device <range-or-$TASK_DEVICE> \
+     --pto-session-timeout <timeout> -v
+   ```
+
+   On a platform whose job separates SDMA tests, the underlying sweep command
+   is:
 
    ```bash
    pytest examples tests/st -m "not sdma" --platform <platform> --runtime $ARGUMENTS \
@@ -43,5 +54,6 @@ Detection / isolation procedures referenced below live in
 
    Hardware parallelism is auto-driven by `--device` (one subprocess per
    device); no extra flag needed.
-8. Report the results summary (pass/fail counts per task), across both passes.
+8. Report the results summary (pass/fail counts per task) across all applicable
+   passes.
 9. If any tests fail, show the relevant error output and which device failed.

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -14,26 +14,24 @@ description: Testing guide and pre-commit testing strategy for simpler. Use when
 ## Running Tests
 
 **Important**: Always read `.github/workflows/ci.yml` first for the current
-`--pto-session-timeout` values. Quarantines are **not** in the workflow — they
-are markers on the tests, so mirror the sweep with `-m "not sdma"` rather than
-copying a path list. PTO-ISA reproducibility comes from the repo-root
-`pto_isa.pin`.
+`--pto-session-timeout` values. Quarantines are marker-based, so mirror the
+a2a3 sweep with `-m "not sdma"` rather than copying a path list. PTO-ISA
+reproducibility comes from the repo-root `pto_isa.pin`.
 
-**CI does not run one flat sweep.** SDMA selection is marker-based on both
-platforms. On a2a3, marked tests are quarantined out of the general onboard
-sweep and run in a step of their own, after it, because they are only correct
-in isolation. On a5, ARM64 runs the full corpus while x86_64 deselects the
-marker. Reproducing a2a3 CI means reproducing that
+**CI does not run one flat sweep on a2a3.** Marked tests are quarantined out of
+the general onboard sweep and run in a step of their own, after it, because
+they are only correct in isolation. A5 runs the non-pod corpus, including
+SDMA tests, on both x86_64 and ARM64. Reproducing a2a3 CI means reproducing that
 shape — a bare `pytest examples tests/st --platform a2a3` is *not* what CI runs
 and will report failures that CI never sees:
 
 | Marker | Tests | CI behavior |
 | ------ | ----- | ----------- |
-| `@pytest.mark.sdma` | a2a3: `sdma_async_completion_demo`, `prefetch_async_demo`; a5: `sdma_async_completion_demo` | a2a3: the dedicated SDMA step; a5: included on ARM64 and deselected on x86_64 |
+| `@pytest.mark.sdma` | a2a3: `sdma_async_completion_demo`, `prefetch_async_demo`; a5: `sdma_async_completion_demo` | a2a3: the dedicated SDMA step; a5: included in the non-pod sweep |
 
-The SDMA demos provision 48 device-only STARS streams, which makes an AICore
-fault take ~306 s to tear down instead of ~0.3 s — so they must not share a
-sweep with the `aicore_op_timeout` fault-injection test
+The a2a3 SDMA demos provision 48 device-only STARS streams, which makes an
+AICore fault take ~306 s to tear down instead of ~0.3 s — so they must not
+share a sweep with the `aicore_op_timeout` fault-injection test
 ([investigations/2026-07-a2a3-sdma-fault-teardown.md](../../../docs/investigations/2026-07-a2a3-sdma-fault-teardown.md),
 issue #1425).
 
@@ -84,10 +82,8 @@ pytest examples tests/st -m "not sdma" --platform a2a3 --device <range> \
 pytest examples tests/st -m sdma \
     --platform a2a3 --device <2 devs> --pto-session-timeout <timeout>
 
-# A5 ARM64 runs the full corpus; A5 x86_64 deselects SDMA tests.
-pytest examples tests/st --platform a5 --device <range> \
-    --pto-session-timeout <timeout>
-pytest examples tests/st -m "not sdma" --platform a5 --device <range> \
+# A5 runs the non-pod corpus, including SDMA tests, on both host architectures.
+pytest examples tests/st -m "not pod" --platform a5 --device <range> \
     --pto-session-timeout <timeout>
 
 # Single runtime

--- a/.github/workflows/_st-npu-a5.yml
+++ b/.github/workflows/_st-npu-a5.yml
@@ -59,11 +59,8 @@ jobs:
           python -m simpler_setup.tools.scene_test_compile examples tests/st \
             --platform a5 --require-pto-isa --compile-workers 8 -q
           DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          PYTEST="python -m pytest examples tests/st --platform a5 --device ${DEVICE_RANGE} -v --require-pto-isa -m 'not pod'"
-          if [ "$(uname -m)" = "x86_64" ]; then
-            PYTEST="python -m pytest examples tests/st --platform a5 --device ${DEVICE_RANGE} -v --require-pto-isa -m 'not sdma and not pod'"
-          fi
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "$PYTEST --pto-session-timeout 1200"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" \
+            --run "python -m pytest examples tests/st --platform a5 --device ${DEVICE_RANGE} -v --require-pto-isa -m 'not pod' --pto-session-timeout 1200"
 
       - name: DFX smokes (a5)
         if: inputs.include_dfx_smokes

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -60,7 +60,7 @@ PullRequest
 | `ut-a2a3` | a2a3 self-hosted | `pytest tests/ut --platform a2a3` + `ctest -L "^requires_hardware(_a2a3)?$" --resource-spec-file ...` + build `tools/cann-examples/query` and run `query version` (no device) + build `tools/cann-examples/aicpu-device-query` and `tools/cann-examples/aicpu-kernel-launch` (host + cross-compiled device SO, link smoke only) |
 | `st-onboard-a2a3` | a2a3 self-hosted | `pytest examples tests/st -m "not sdma and not pod" --platform a2a3 --device ...`, then a separate `-m sdma` step, then adaptive-parallel DFX feature smokes |
 | `ut-a5` | a5 self-hosted | `pytest tests/ut --platform a5` + `ctest -L "^requires_hardware(_a5)?$"` + build `tools/cann-examples/query` and run `query version` (no device) + build `tools/cann-examples/aicpu-device-query` and `tools/cann-examples/aicpu-kernel-launch` (link smoke only) |
-| `st-onboard-a5` | a5 self-hosted | `pytest examples tests/st -m "not pod" --platform a5 --device ...`, then adaptive-parallel DFX feature smokes; x86_64 runners use `-m "not sdma and not pod"` |
+| `st-onboard-a5` | a5 self-hosted | `pytest examples tests/st -m "not pod" --platform a5 --device ...`, including SDMA tests, then adaptive-parallel DFX feature smokes |
 | `st-pod-onboard-a2a3` | a pair of `a2a3pod` machines | `pytest examples tests/st -m pod --platform a2a3 --device ... --max-parallel 1`, one L3 daemon on the peer |
 
 ### Multi-machine pod jobs
@@ -135,11 +135,8 @@ benefit — device bin-packing for L3, xdist fanout for L2, and a shared
 pytest examples tests/st -m "not sdma and not pod" --platform a2a3 --device 4-7 -x
 pytest examples tests/st -m sdma --platform a2a3 --device 4-5 -x
 
-# A5 ARM64 runners run the non-pod corpus
+# A5 runners run the non-pod corpus, including SDMA tests
 pytest examples tests/st -m "not pod" --platform a5 --device 0-7 -x
-
-# A5 x86_64 runners deselect SDMA and pod tests
-pytest examples tests/st -m "not sdma and not pod" --platform a5 --device 0-7 -x
 ```
 
 `-x` (`--exitfirst`) is appropriate for CI, where aborting on first
@@ -240,9 +237,9 @@ runner pools, branched at run time on the host arch (`uname -m`):
   the runner — so the step runs `pytest`/`ctest` directly with
   `--device ${DEVICE_RANGE}`.
 
-a5 runners always use `task-submit`. The x86_64 A5 scene-test sweep deselects
-the `sdma` marker; ARM64 runs the full non-pod corpus, including SDMA tests. Steps that
-only build (cmake, `RuntimeBuilder`, the
+a5 runners always use `task-submit` and run the full non-pod scene-test corpus,
+including SDMA tests, on both x86_64 and ARM64. Steps that only build (cmake,
+`RuntimeBuilder`, the
 `cann-examples` smokes) take no lock on either arch. The same device-lock rule
 applies to local onboard work — see
 [.claude/rules/running-onboard.md](../.claude/rules/running-onboard.md).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -58,9 +58,8 @@ python -m simpler_setup.tools.scene_test_compile examples tests/st \
 # provisioned SDMA workspace (issue #1425)
 pytest examples tests/st -m sdma --platform a2a3 --device 4-5
 
-# A5 ARM64 runs the non-pod corpus; A5 x86_64 also deselects SDMA tests
+# A5 runs the non-pod corpus, including SDMA tests, on both host architectures
 pytest examples tests/st -m "not pod" --platform a5 --device 0-7
-pytest examples tests/st -m "not sdma and not pod" --platform a5 --device 0-7
 
 # Single scene test (standalone)
 python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py -p a2a3sim


### PR DESCRIPTION
## Summary

- Run the full A5 onboard scene-test corpus, including SDMA, on x86_64 and ARM64 runners.
- Remove the A5 x86_64 `not sdma` marker filter while preserving the A2/A3 SDMA isolation policy.
- Update CI and testing documentation to match the runner capability.

## Testing

- [x] Pre-commit hooks passed.
- [x] Workflow YAML and Markdown lint passed.
- [ ] Hardware tests not run locally; the updated A5 CI job exercises the full corpus.