### PR TITLE
Docs: align the threading model with the single progress owner

### DIFF
--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -291,8 +291,8 @@ wins; a losing claim cannot overwrite cancellation's terminal bookkeeping.
 At dispatch time the Scheduler checks the group FIFO head and resolves every
 entry in `workers` to that exact stable worker ID. It dispatches only if the
 entire target set is idle. A blocked group reserves all of its targets against
-new singles but does not cause a scan past the FIFO head. Each WorkerThread
-runs `worker->run` with its own `task_args_list[i]`. Completion remains
+new singles but does not cause a scan past the FIFO head. Each member lane is
+submitted with its own `task_args_list[i]`. Completion remains
 aggregated at the group slot, so downstream consumers are released once after
 every member is terminal. Completion validates both bookkeeping-vector sizes;
 repair preserves already-terminal and still-running members before indexing.

--- a/docs/remote-l3-worker-design.md
+++ b/docs/remote-l3-worker-design.md
@@ -137,7 +137,8 @@ Relevant code paths:
   - `_child_worker_loop()` runs a nested `Worker` child via shm mailbox.
   - `_run_chip_main_loop()` handles task and control mailbox states.
 - `src/common/hierarchical/worker_manager.{h,cpp}`
-  - `WorkerThread` owns one local mailbox and blocks until `TASK_DONE`.
+  - `WorkerThread` owns one local mailbox; the Scheduler thread advances it
+    to `TASK_DONE` through non-blocking submit/poll calls.
   - Control commands share the same mailbox and serialize on `mailbox_mu_`.
   - Errors are reported through `MAILBOX_OFF_ERROR` and
     `MAILBOX_OFF_ERROR_MSG`.
@@ -517,8 +518,8 @@ run as if the producer succeeded.
 
 Required parent-side behavior:
 
-- `RemoteL3Endpoint::run()` blocks for the matching completion sequence.
-- `LocalMailboxEndpoint::run()` maps a non-zero mailbox error to
+- `RemoteL3Endpoint::poll_progress()` reports the matching completion sequence.
+- `LocalMailboxEndpoint::poll_progress()` maps a non-zero mailbox error to
   `task_failure` instead of reporting a successful completion.
 - Non-zero task or endpoint errors become candidates for the worker's first
   reported error.

--- a/docs/remote-l3-worker-design/buffers-and-transports.md
+++ b/docs/remote-l3-worker-design/buffers-and-transports.md
@@ -332,8 +332,9 @@ CONTROL, CONTROL_REPLY, COMPLETION, and SHUTDOWN frames use the HCOMM RPC
 adapter; tensor data and remote buffer copies use the HCOMM data adapter.
 
 The endpoint owns the adapter objects. `Orchestrator`, Scheduler, and
-`WorkerThread` see only `WorkerEndpoint::run()`, `WorkerEndpoint::control()`,
-and logical capability bits from `WorkerEndpoint::caps()`.
+`WorkerThread` see only the progress calls (`WorkerEndpoint::submit_progress()`,
+`poll_progress()`, `activate_progress()`), the `control_*` commands, and logical
+capability bits from `WorkerEndpoint::caps()`.
 
 Current status: `RemoteL3Endpoint` owns a transport-neutral
 `RemoteL3Transport` and the ordered TASK/COMPLETION boundary. The HCOMM RPC

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -57,17 +57,21 @@ work must push a completion or advance the generation.** The predicate no
 longer re-reads queue occupancy or worker state, so a change that only mutates
 those is invisible to a parked Scheduler.
 
-Two producers are easy to miss because the change happens outside the
-Scheduler thread and outside `Orchestrator`. `dispatch_ready` re-queues work it
-could not place — through `enqueue_ready_cb`, which by design does not notify —
-so the retry depends entirely on a later edge. And a `WorkerThread` publishes
-its completion *before* it publishes its lane state: it calls `on_complete` and
-only then stores `active_inflight_`/`inflight_`. That order is deliberate, so a
-stopping Scheduler cannot read a worker as no longer busy while its final
-completion is still unqueued — which means the completion wake alone can land
-on a worker that still reads as occupied, and the dispatch pass it triggers
-finds nothing placeable. The `on_idle` callback fires after that publication
-and supplies the edge that makes the retry happen.
+Two producers are easy to miss because neither pushes a completion.
+`dispatch_ready` re-queues work it could not place — through
+`enqueue_ready_cb`, which by design does not notify — so the retry depends
+entirely on a later edge. And an endpoint lane publishes its completion *before*
+it publishes its lane state: it calls `on_complete` and only then decrements
+`inflight_`. That order is deliberate, so a stopping Scheduler cannot read a
+worker as no longer busy while its final completion is still unqueued — which
+means the completion wake alone can land on a worker that still reads as
+occupied, and the dispatch pass it triggers finds nothing placeable.
+
+What makes the retry happen is that the Scheduler does not park while any lane
+is busy: the wait on `completion_cv_` is taken only when
+`WorkerManager::any_busy()` is false. A lane that is still occupied therefore
+gets another progress round and another dispatch pass without needing an edge
+at all, and the edge-triggered predicate governs only the genuinely idle case.
 
 Popping a slot is not the same as owning it. A run whose graph callback throws
 fails and consumes its own unstarted slots, so the Scheduler claims each slot

--- a/docs/worker-manager.md
+++ b/docs/worker-manager.md
@@ -446,15 +446,31 @@ children never do. Putting the slot in shm would force cross-process atomics
 and shm-safe containers for no benefit. See
 [task-flow.md](task-flow.md) §11 for full rationale.
 
-### 5.3 Why one WorkerThread per child?
+### 5.3 Why one progress owner for every child?
 
-Alternative: N children share one dispatch queue. Rejected because:
+Alternative: one thread per child, each driving its own endpoint. Rejected
+because `submit_progress` / `poll_progress` never wait for child completion, so
+a dedicated thread has no completion to block on — it spins for as long as its
+child is busy, and N children cost N spinning cores. The Scheduler already wakes
+on completions and already owns the dispatch decision, so folding progress into
+it costs one poll round per iteration and removes both the threads and the queue
+that fed them.
 
-- `WorkerThread` is the natural execution unit. Directed NEXT_LEVEL work waits
-  in child `i`'s ready FIFO if that child is busy; SUB work may use another
-  idle SUB child
-- Simpler mental model: one child = one thread that drives it
-- Zero contention on queue access (only one producer, one consumer per queue)
+Not waiting for completion is not the same as never blocking: `submit_progress`
+still takes `mailbox_mu_`, and the second bullet below is what that costs.
+
+What that trades away:
+
+- One endpoint's progress latency is now bounded by the whole round, since a
+  single thread visits every lane in turn rather than each lane having its own
+- A blocking call reached from the progress path stalls every lane, not just
+  its own. `submit_progress` waits on `mailbox_mu_`, which `run_control_command`
+  holds while it blocks on the child; see the comment at that acquisition in
+  `worker_manager.cpp`
+
+What is unchanged: per-child work still queues per child. Directed NEXT_LEVEL
+work waits in child `i`'s ready FIFO if that child is busy, while SUB work may
+use another idle SUB child.
 
 ---
 

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -649,6 +649,15 @@ void LocalMailboxEndpoint::submit_progress(Ring *ring, const WorkerDispatch &dis
     // control mutex is released immediately after the task state release-store;
     // controls may still execute while the native run is active, subject to
     // the child-side registry lifetime gate.
+    //
+    // Acquiring it is not always cheap, and the cost is shared. This runs on
+    // the Scheduler thread, which holds loop_mu_ and is the sole progress owner
+    // for every endpoint; run_control_command holds this same mutex while it
+    // blocks on the child, with no deadline by default. So while a control
+    // command is outstanding on any one endpoint, no endpoint makes progress
+    // and loop_mu_ stays held — and Orchestrator shares loop_mu_ with allocator
+    // compaction. Blocking here is bounded only by the child's control latency,
+    // not by anything this function does.
     std::lock_guard<std::mutex> mailbox_lk(mailbox_mu_);
     std::lock_guard<std::mutex> lk(progress_mu_);
     if (endpoint_poisoned_) {


### PR DESCRIPTION
## Summary

The async-pipeline track (W1a #1650 → W1b #1748 → W1c #1750 → W1d #1754, plus E1′ #1739) changed who runs endpoint progress and what it costs. Five places in the tree still describe the previous world.

Two of them are **reasoning, not description**, which is why this is worth a PR rather than a drive-by:

- `docs/worker-manager.md` §5.3 asked *"Why one WorkerThread per child?"* and justified it with "one child = one thread that drives it" and "zero contention on queue access". Both describe machinery #1754 deleted — and the alternative that section **rejects** ("N children share one dispatch queue") is close to the design that was then adopted. #1754 updated §2 but left §5.3 arguing against its own change.
- `docs/scheduler.md` explained the missed-edge hazard by saying the change happens "outside the Scheduler thread", and closed by crediting the `on_idle` callback for the retry. Completion is now published *on* the Scheduler thread, and `on_idle` no longer exists.

A reader trusting either draws a wrong conclusion about thread safety. That is worse than the docs saying nothing.

## The one item that is mine

I raised the `mailbox_mu_` stall widening as a Should-fix on my [#1754 review](https://github.com/hw-native-sys/simpler/pull/1754) and asked for it to be recorded before merge. It merged without it, so the behavior change is on `main` with nothing describing it. This PR closes that.

`submit_progress` takes `mailbox_mu_` and now runs on the Scheduler thread, which holds `loop_mu_` and is the sole progress owner for every endpoint. `run_control_command` holds that same mutex **while blocking on the child, with no deadline by default**. So an outstanding control command on any one endpoint stops progress on *all* of them and keeps `loop_mu_` held — which `Orchestrator::set_scheduler_loop_mutex` shares with allocator compaction.

To be precise about provenance: **this is not a defect being introduced or fixed.** The wait already existed per endpoint before #1754; only the set of work it blocks got wider. Removing it needs a wakeup primitive on the mailbox, which changes the host↔child contract and is deliberately out of scope for W1d and for this PR.

## Changes

| File | What was wrong |
|---|---|
| `src/common/hierarchical/worker_manager.cpp` | *(nothing recorded)* — now states the stall invariant at the acquisition where it happens |
| `docs/worker-manager.md` §5.3 | rationale for a design that was replaced; now asks why *one progress owner*, and states the two costs that answer carries |
| `docs/scheduler.md` | false premise + deleted `on_idle` + deleted `active_inflight_`; ordering conclusion preserved because it is still load-bearing for the stop path |
| `docs/orchestrator.md` | "Each WorkerThread runs `worker->run`" — `WorkerEndpoint::run` retired by #1739 |
| `docs/remote-l3-worker-design.md` | "blocks until `TASK_DONE`" — same, and it sits in a *current* file-map section |

`orchestrator.md` and `remote-l3-worker-design.md` trace to my own #1739; `worker-manager.md` and `scheduler.md` to #1754, which I reviewed and approved.

## No behavior change

The only edit under `src/` is a comment. Verified mechanically — the diff contains no non-comment lines there:

```
git diff cf0fbc06 -- src/ | grep -E "^[+-]" | grep -vE "^[+-]{3}" | grep -vE "^[+-]\s*//"   # empty
```

## Testing

- **91/91** C++ unit tests (`ctest -LE requires_hardware`, CI's filter) after rebuilding
- `clang-format --dry-run --Werror` clean
- `markdownlint-cli2` clean against `tests/lint/.markdownlint.yaml`
- **Grep audit**: none of the five stale spellings survive (`one thread that drives it`, `active_inflight_`, `worker->run`, `blocks until TASK_DONE`, `on_idle`) — each 0-hit result paired with a non-zero positive control, so an empty result cannot pass for a correct one

Python UT and the onboard sweep were **not** run: nothing executable changes, and running them would be theatre rather than evidence.
