### PR TITLE
CI: build only job-targeted runtime platforms

### DIFF
--- a/.github/actions/cache-pip/action.yml
+++ b/.github/actions/cache-pip/action.yml
@@ -8,6 +8,6 @@ runs:
       uses: actions/cache@v5
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/*.py') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-pip-${{ hashFiles('pyproject.toml') }}
         restore-keys: |
-          ${{ runner.os }}-pip-
+          ${{ runner.os }}-${{ runner.arch }}-pip-

--- a/.github/actions/pod-stage/action.yml
+++ b/.github/actions/pod-stage/action.yml
@@ -4,13 +4,24 @@ description: >-
   the tree and the venv it produces are what every pod example then runs
   against, so re-staging per example would repeat the job's whole cost.
 
+inputs:
+  platform:
+    description: Onboard platform to build on the peer, either a2a3 or a5.
+    required: true
+
 runs:
   using: composite
   steps:
     - shell: bash
       working-directory: ${{ github.workspace }}
+      env:
+        POD_PLATFORM: ${{ inputs.platform }}
       run: |
         set -euo pipefail
+        case "$POD_PLATFORM" in
+          a2a3|a5) ;;
+          *) echo "::error::unsupported pod platform: $POD_PLATFORM"; exit 2 ;;
+        esac
         if ! command -v rsync >/dev/null 2>&1; then
           echo "::error::rsync is required on the pod runner for remote checkout sync"
           exit 1
@@ -111,5 +122,5 @@ runs:
           python3 -m venv --system-site-packages .venv
           source .venv/bin/activate
           pip install --upgrade pip
-          pip install '.[test]'
+          pip install --config-settings=build.targets=build_package_$POD_PLATFORM '.[test]'
         REMOTE_STAGE

--- a/.github/actions/setup-venv/action.yml
+++ b/.github/actions/setup-venv/action.yml
@@ -2,6 +2,10 @@ name: Set up venv
 description: Create .venv and install Python dependencies.
 
 inputs:
+  build-packages:
+    description: Packages installed before the main pip invocation, such as scikit-build-core and nanobind.
+    required: false
+    default: ""
   packages:
     description: Arguments passed to pip install after torch, for example ".[test]" or "-e .[test]".
     required: false
@@ -48,6 +52,7 @@ runs:
     - name: Create venv and install dependencies
       shell: bash
       env:
+        BUILD_PACKAGES: ${{ inputs.build-packages }}
         PACKAGES: ${{ inputs.packages }}
         CANN_ENV: ${{ inputs.cann-env }}
         IN_HTTP_PROXY: ${{ inputs.http-proxy }}
@@ -77,6 +82,9 @@ runs:
         pip install --upgrade pip
         if [ "${{ inputs.install-torch }}" = "true" ]; then
           pip install torch --index-url https://download.pytorch.org/whl/cpu
+        fi
+        if [ -n "$BUILD_PACKAGES" ]; then
+          pip install $BUILD_PACKAGES
         fi
         if [ -n "$PACKAGES" ]; then
           pip install $PACKAGES

--- a/.github/workflows/_packaging.yml
+++ b/.github/workflows/_packaging.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install build + runtime deps in venv
         uses: ./.github/actions/setup-venv
         with:
-          packages: "scikit-build-core nanobind cmake pytest"
+          packages: "scikit-build-core nanobind cmake>=3.15 pytest"
 
       - name: Run packaging matrix
         run: |

--- a/.github/workflows/_pre-commit.yml
+++ b/.github/workflows/_pre-commit.yml
@@ -91,29 +91,13 @@ jobs:
 
       - name: Install package (for pyright C extension symbol resolution)
         if: inputs.setup_variant == 'github'
-        run: pip install .
+        run: pip install --config-settings=build.targets=build_package_sim .
 
       - name: venv + deps
         if: inputs.setup_variant == 'self-cpu'
         uses: ./.github/actions/setup-venv
         with:
-          packages: "."
-
-      - name: Cache cmake build directories
-        if: inputs.setup_variant == 'github'
-        uses: actions/cache@v5
-        with:
-          path: build/cache
-          key: cmake-sim-${{ runner.os }}-${{ hashFiles('src/**/CMakeLists.txt', 'src/**/build_config.py', 'simpler_setup/runtime_compiler.py', 'simpler_setup/kernel_compiler.py', 'simpler_setup/toolchain.py') }}
-          restore-keys: |
-            cmake-sim-${{ runner.os }}-
-
-      - name: Build sim runtimes
-        run: |
-          if [ "${{ inputs.setup_variant }}" = "self-cpu" ]; then
-            source .venv/bin/activate
-          fi
-          python simpler_setup/build_runtimes.py --platforms a2a3sim a5sim
+          packages: "--config-settings=build.targets=build_package_sim ."
 
       - name: Resolve base SHA
         id: base

--- a/.github/workflows/_profiling-flags-smoke.yml
+++ b/.github/workflows/_profiling-flags-smoke.yml
@@ -51,24 +51,14 @@ jobs:
       - name: Cache pip packages
         uses: ./.github/actions/cache-pip
 
-      - name: Install dependencies
-        if: inputs.setup_variant == 'github'
-        run: |
-          pip install torch --index-url https://download.pytorch.org/whl/cpu
-          pip install -e '.[test]'
-
-      - name: venv + editable install
-        if: inputs.setup_variant == 'self-cpu'
+      - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
-          packages: "-e .[test]"
+          build-packages: "scikit-build-core nanobind cmake>=3.15"
+          packages: "--no-build-isolation --config-settings=build.targets=_task_interface -e .[test]"
 
       - name: Run all profiling flag combos x 2 arches
         run: |
-          if [ "${{ inputs.setup_variant }}" = "self-cpu" ]; then
-            source .venv/bin/activate
-          fi
-
           COMBO_NAMES=(dfx-off orch orch-tensormap sched orch-sched all-on)
           COMBO_DEFS=(
             "-DSIMPLER_DFX=0"
@@ -87,13 +77,13 @@ jobs:
               NAME=${COMBO_NAMES[$i]}
               DEFS=${COMBO_DEFS[$i]}
               echo "::group::$ARCH / $NAME - CXX defines: $DEFS"
-              if ! CXX="g++ $DEFS" python simpler_setup/build_runtimes.py --platforms "$ARCH"; then
+              if ! CXX="g++ $DEFS" .venv/bin/python simpler_setup/build_runtimes.py --platforms "$ARCH"; then
                 echo "::error::Build failed: $ARCH / $NAME"
                 FAIL+=("$ARCH/$NAME (build)")
                 echo "::endgroup::"
                 continue
               fi
-              if ! python -m pytest \
+              if ! .venv/bin/python -m pytest \
                    "examples/${ARCH_DIR}/tensormap_and_ringbuffer/vector_example/test_vector_example.py" \
                    --platform "$ARCH" --device 0-1 -p no:xdist \
                    --pto-session-timeout 600; then

--- a/.github/workflows/_st-npu-a2a3.yml
+++ b/.github/workflows/_st-npu-a2a3.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
-          packages: ".[test]"
+          build-packages: "scikit-build-core nanobind cmake>=3.15"
+          packages: "--no-build-isolation --config-settings=build.targets=build_package_a2a3 .[test]"
           install-torch: "false"
           system-site-packages: "true"
           source-cann: "true"

--- a/.github/workflows/_st-npu-a2a3.yml
+++ b/.github/workflows/_st-npu-a2a3.yml
@@ -69,59 +69,54 @@ jobs:
       - name: Compile scene-test kernels (a2a3)
         run: |
           source /usr/local/Ascend/cann/set_env.sh
-          source .venv/bin/activate
-          python -m simpler_setup.tools.scene_test_compile examples tests/st \
+          .venv/bin/python -m simpler_setup.tools.scene_test_compile examples tests/st \
             --platform a2a3 --exclude-level 4 --require-pto-isa --compile-workers 8 -q
 
       - name: Run pytest scene tests (a2a3)
         if: inputs.a2a3_sdma_mode == 'marker'
         run: |
           source /usr/local/Ascend/cann/set_env.sh
-          source .venv/bin/activate
           if [ "$(uname -m)" = "x86_64" ]; then
-            python -m pytest examples tests/st -m "not sdma" --platform a2a3 --exclude-level 4 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 1200
+            .venv/bin/python -m pytest examples tests/st -m "not sdma" --platform a2a3 --exclude-level 4 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 1200
           else
             task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
-              --run "python -m pytest examples tests/st -m 'not sdma' --platform a2a3 --exclude-level 4 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 1200"
+              --run ".venv/bin/python -m pytest examples tests/st -m 'not sdma' --platform a2a3 --exclude-level 4 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 1200"
           fi
 
       - name: Run pytest scene tests (a2a3 legacy SDMA paths)
         if: inputs.a2a3_sdma_mode == 'legacy-paths'
         run: |
           source /usr/local/Ascend/cann/set_env.sh
-          source .venv/bin/activate
           SDMA_IGNORE="--ignore=examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo --ignore=examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo"
           if [ "$(uname -m)" = "x86_64" ]; then
-            python -m pytest examples tests/st $SDMA_IGNORE --platform a2a3 --exclude-level 4 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 600
+            .venv/bin/python -m pytest examples tests/st $SDMA_IGNORE --platform a2a3 --exclude-level 4 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 600
           else
             task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
-              --run "python -m pytest examples tests/st $SDMA_IGNORE --platform a2a3 --exclude-level 4 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 600"
+              --run ".venv/bin/python -m pytest examples tests/st $SDMA_IGNORE --platform a2a3 --exclude-level 4 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 600"
           fi
 
       - name: SDMA pytest (a2a3)
         if: inputs.a2a3_sdma_mode == 'marker'
         run: |
           source /usr/local/Ascend/cann/set_env.sh
-          source .venv/bin/activate
           SDMA_TESTS="examples tests/st -m sdma"
           if [ "$(uname -m)" = "x86_64" ]; then
-            python -m pytest $SDMA_TESTS --platform a2a3 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 600
+            .venv/bin/python -m pytest $SDMA_TESTS --platform a2a3 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 600
           else
             task-submit --timeout 1800 --max-time 1800 --device auto --device-num 2 \
-              --run "python -m pytest $SDMA_TESTS --platform a2a3 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 600"
+              --run ".venv/bin/python -m pytest $SDMA_TESTS --platform a2a3 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 600"
           fi
 
       - name: SDMA pytest (a2a3 legacy paths)
         if: inputs.a2a3_sdma_mode == 'legacy-paths'
         run: |
           source /usr/local/Ascend/cann/set_env.sh
-          source .venv/bin/activate
           SDMA_TESTS="examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo"
           if [ "$(uname -m)" = "x86_64" ]; then
-            python -m pytest $SDMA_TESTS --platform a2a3 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 600
+            .venv/bin/python -m pytest $SDMA_TESTS --platform a2a3 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 600
           else
             task-submit --timeout 1800 --max-time 1800 --device auto --device-num 2 \
-              --run "python -m pytest $SDMA_TESTS --platform a2a3 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 600"
+              --run ".venv/bin/python -m pytest $SDMA_TESTS --platform a2a3 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 600"
           fi
 
       - name: DFX smokes (a2a3)

--- a/.github/workflows/_st-npu-a5.yml
+++ b/.github/workflows/_st-npu-a5.yml
@@ -48,19 +48,22 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
-          packages: ".[test]"
+          build-packages: "scikit-build-core nanobind cmake>=3.15"
+          packages: "--no-build-isolation --config-settings=build.targets=build_package_a5 .[test]"
           install-torch: "false"
           system-site-packages: "true"
           source-cann: "false"
 
+      - name: Compile scene-test kernels (a5)
+        run: |
+          .venv/bin/python -m simpler_setup.tools.scene_test_compile examples tests/st \
+            --platform a5 --exclude-level 4 --require-pto-isa --compile-workers 8 -q
+
       - name: Run pytest scene tests (a5)
         run: |
-          source .venv/bin/activate
-          python -m simpler_setup.tools.scene_test_compile examples tests/st \
-            --platform a5 --exclude-level 4 --require-pto-isa --compile-workers 8 -q
-          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
+          DEVICE_LIST=$(.venv/bin/python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
           task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" \
-            --run "python -m pytest examples tests/st --platform a5 --exclude-level 4 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 1200"
+            --run ".venv/bin/python -m pytest examples tests/st --platform a5 --exclude-level 4 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 1200"
 
       - name: DFX smokes (a5)
         if: inputs.include_dfx_smokes

--- a/.github/workflows/_st-pod.yml
+++ b/.github/workflows/_st-pod.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
-          packages: ".[test]"
+          packages: "--config-settings=build.targets=build_package_${{ inputs.platform }} .[test]"
           install-torch: "false"
           system-site-packages: "true"
           source-cann: "true"
@@ -175,6 +175,8 @@ jobs:
       # repeat the whole cost of the job.
       - name: Stage the checkout on the peer
         uses: ./.github/actions/pod-stage
+        with:
+          platform: ${{ inputs.platform }}
 
       - name: Run pod pytest
         uses: ./.github/actions/pod-run-pytest

--- a/.github/workflows/_st-sim-a2a3.yml
+++ b/.github/workflows/_st-sim-a2a3.yml
@@ -80,57 +80,48 @@ jobs:
       - name: Cache pip packages
         uses: ./.github/actions/cache-pip
 
-      - name: Install dependencies
-        if: inputs.setup_variant == 'github'
-        run: |
-          pip install torch --index-url https://download.pytorch.org/whl/cpu
-          pip install '.[test]'
-
-      - name: venv + deps
-        if: inputs.setup_variant == 'self-cpu'
+      - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
-          packages: ".[test]"
+          build-packages: "scikit-build-core nanobind cmake>=3.15"
+          packages: "--no-build-isolation --config-settings=build.targets=build_package_a2a3sim .[test]"
 
       - name: Run pytest scene tests
         run: |
-          if [ "${{ inputs.setup_variant }}" = "self-cpu" ]; then
-            source .venv/bin/activate
-          fi
-          python -m pytest examples tests/st --platform a2a3sim --device 0-15 -v \
+          .venv/bin/python -m pytest examples tests/st --platform a2a3sim --device 0-15 -v \
             --pto-session-timeout 600 --require-pto-isa
 
       - name: dep_gen smoke (a2a3)
         if: inputs.include_dfx_smokes
         run: |
-          pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py \
+          .venv/bin/python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py \
             --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --enable-dep-gen
 
       - name: dep_gen smoke (a2a3 host_build_graph)
         if: inputs.include_dfx_smokes
         run: |
-          pytest tests/st/a2a3/host_build_graph/dfx/dep_gen/test_dep_gen.py \
+          .venv/bin/python -m pytest tests/st/a2a3/host_build_graph/dfx/dep_gen/test_dep_gen.py \
             --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --enable-dep-gen
 
       - name: chip_swimlane smoke (a2a3)
         if: inputs.include_dfx_smokes
         run: |
-          pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/ \
+          .venv/bin/python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/ \
             --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --enable-chip-swimlane --enable-dep-gen
 
       - name: PMU smoke (a2a3)
         if: inputs.include_dfx_smokes
         run: |
-          pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py \
+          .venv/bin/python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py \
             --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --enable-pmu 2
 
       - name: args_dump smoke (a2a3)
         if: inputs.include_dfx_smokes
         run: |
-          pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py \
+          .venv/bin/python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py \
             --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --dump-args

--- a/.github/workflows/_st-sim-a5.yml
+++ b/.github/workflows/_st-sim-a5.yml
@@ -80,50 +80,41 @@ jobs:
       - name: Cache pip packages
         uses: ./.github/actions/cache-pip
 
-      - name: Install dependencies
-        if: inputs.setup_variant == 'github'
-        run: |
-          pip install torch --index-url https://download.pytorch.org/whl/cpu
-          pip install '.[test]'
-
-      - name: venv + deps
-        if: inputs.setup_variant == 'self-cpu'
+      - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
-          packages: ".[test]"
+          build-packages: "scikit-build-core nanobind cmake>=3.15"
+          packages: "--no-build-isolation --config-settings=build.targets=build_package_a5sim .[test]"
 
       - name: Run pytest scene tests
         run: |
-          if [ "${{ inputs.setup_variant }}" = "self-cpu" ]; then
-            source .venv/bin/activate
-          fi
-          python -m pytest examples tests/st --platform a5sim --device 0-15 -v \
+          .venv/bin/python -m pytest examples tests/st --platform a5sim --device 0-15 -v \
             --pto-session-timeout 600 --require-pto-isa
 
       - name: dep_gen smoke (a5)
         if: inputs.include_dfx_smokes
         run: |
-          pytest tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py \
+          .venv/bin/python -m pytest tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py \
             --platform a5sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --enable-dep-gen
 
       - name: chip_swimlane smoke (a5)
         if: inputs.include_dfx_smokes
         run: |
-          pytest tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/ \
+          .venv/bin/python -m pytest tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/ \
             --platform a5sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --enable-chip-swimlane --enable-dep-gen
 
       - name: PMU smoke (a5)
         if: inputs.include_dfx_smokes
         run: |
-          pytest tests/st/a5/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py \
+          .venv/bin/python -m pytest tests/st/a5/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py \
             --platform a5sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --enable-pmu 2
 
       - name: args_dump smoke (a5)
         if: inputs.include_dfx_smokes
         run: |
-          pytest tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py \
+          .venv/bin/python -m pytest tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py \
             --platform a5sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --dump-args

--- a/.github/workflows/_ut-npu-a2a3.yml
+++ b/.github/workflows/_ut-npu-a2a3.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
-          packages: ".[test]"
+          build-packages: "scikit-build-core nanobind cmake>=3.15"
+          packages: "--no-build-isolation --config-settings=build.targets=build_package_a2a3 .[test]"
           install-torch: "false"
           system-site-packages: "true"
           source-cann: "true"

--- a/.github/workflows/_ut-npu-a5.yml
+++ b/.github/workflows/_ut-npu-a5.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
-          packages: ".[test]"
+          build-packages: "scikit-build-core nanobind cmake>=3.15"
+          packages: "--no-build-isolation --config-settings=build.targets=build_package_a5 .[test]"
           install-torch: "false"
           system-site-packages: "true"
           source-cann: "false"

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -60,7 +60,8 @@ jobs:
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           # --no-cache-dir so pip rebuilds rather than reusing a non-sanitizer wheel.
           pip install --no-cache-dir \
-            --config-settings=cmake.define.SIMPLER_SANITIZER=${{ matrix.sanitizer }} '.[test]'
+            --config-settings=cmake.define.SIMPLER_SANITIZER=${{ matrix.sanitizer }} \
+            --config-settings=build.targets=build_package_${{ matrix.platform }} '.[test]'
 
       - name: Run sanitized scene tests (${{ matrix.sanitizer }}, ${{ matrix.platform }})
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,13 +36,32 @@ set(SIMPLER_SANITIZER "none" CACHE STRING
     "Sanitizer for host targets during install (none/asan/ubsan/tsan)")
 
 # Pre-build runtime binaries (persistent build dirs for incremental compilation)
+set(_SIMPLER_BUILD_RUNTIMES_COMMAND
+    ${Python_EXECUTABLE}
+    ${CMAKE_SOURCE_DIR}/simpler_setup/build_runtimes.py
+    --lib-dir ${CMAKE_SOURCE_DIR}/build/lib
+    --cache-dir ${CMAKE_SOURCE_DIR}/build/cache
+    --sanitizer ${SIMPLER_SANITIZER}
+)
 add_custom_target(build_runtimes ALL
-    COMMAND ${Python_EXECUTABLE}
-        ${CMAKE_SOURCE_DIR}/simpler_setup/build_runtimes.py
-        --lib-dir ${CMAKE_SOURCE_DIR}/build/lib
-        --cache-dir ${CMAKE_SOURCE_DIR}/build/cache
-        --sanitizer ${SIMPLER_SANITIZER}
+    COMMAND ${_SIMPLER_BUILD_RUNTIMES_COMMAND}
     COMMENT "Building runtime binaries (incremental)..."
+)
+foreach(_platform IN ITEMS a2a3sim a5sim a2a3 a5)
+    add_custom_target(build_runtimes_${_platform}
+        COMMAND ${_SIMPLER_BUILD_RUNTIMES_COMMAND} --platforms ${_platform}
+        COMMENT "Building ${_platform} runtime binaries (incremental)..."
+    )
+    add_custom_target(build_package_${_platform}
+        DEPENDS _task_interface build_runtimes_${_platform}
+    )
+endforeach()
+add_custom_target(build_runtimes_sim
+    COMMAND ${_SIMPLER_BUILD_RUNTIMES_COMMAND} --platforms a2a3sim a5sim
+    COMMENT "Building sim runtime binaries (incremental)..."
+)
+add_custom_target(build_package_sim
+    DEPENDS _task_interface build_runtimes_sim
 )
 
 if(SKBUILD_MODE)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -152,6 +152,21 @@ same in both pytest and standalone on purpose; see
 for the full hierarchy, fail-fast semantics, and the
 profiling-vs-parallelism trade-off.
 
+### Targeted runtime builds
+
+The sim, onboard, and pod jobs select one explicit
+`build_package_<platform>` CMake target during package install. That aggregate
+target depends on both the `_task_interface` binding and the selected platform's
+runtime target, so scikit-build-core makes one `cmake --build` call and CMake can
+build both dependencies in parallel while omitting unused platforms. The
+selection is not a cached CMake variable, so a later ordinary package install
+in the same worktree still uses the default `ALL` target and auto-detects every
+available platform. The pod stage passes the same target to its peer.
+Pre-commit selects the combined `build_package_sim` target, while each
+sanitizer matrix cell selects its own platform. The profiling-flags smoke
+installs only the `_task_interface` binding because its matrix builds every
+runtime configuration itself.
+
 ### Sim jobs on CPU-constrained runners
 
 Sim jobs (`st-sim-a2a3`, `st-sim-a5`) run on `ubuntu-latest`, whose standard
@@ -289,8 +304,13 @@ Entries are content-addressed and therefore never overwritten, so a run prunes
 entries whose last use is more than 14 days old before it exits. Without that,
 the directory grows by one entry per kernel change forever and the saved
 `actions/cache` archive — one new entry per push, restored by prefix — would
-crowd the repository's 10 GB cache budget and evict the pip and cmake caches
+crowd the repository's 10 GB cache budget and evict the pip and other caches
 the other jobs depend on.
+
+The pip download cache is keyed by runner OS, runner architecture, and
+`pyproject.toml`. Source-only changes therefore reuse the same dependency cache
+instead of creating another roughly 200 MB archive; pip still resolves and
+validates requested versions on every install.
 
 ## Test Sources
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,7 +107,7 @@ All workflows assume an activated project-local venv (see [`.claude/rules/venv-i
 ```bash
 python3 -m venv --system-site-packages .venv
 source .venv/bin/activate
-pip install --no-build-isolation scikit-build-core nanobind cmake pytest torch
+pip install --no-build-isolation scikit-build-core nanobind 'cmake>=3.15' pytest torch
 pip install --no-build-isolation -e .
 ```
 

--- a/docs/python-packaging.md
+++ b/docs/python-packaging.md
@@ -123,7 +123,7 @@ For developers who don't want to use pip at all:
 
 ```bash
 . .venv/bin/activate
-pip install scikit-build-core nanobind cmake pytest torch  # one-time
+pip install scikit-build-core nanobind 'cmake>=3.15' pytest torch  # one-time
 cmake -S . -B build/cmake_only -Dnanobind_DIR=$(python -c 'import nanobind; print(nanobind.cmake_dir())')
 cmake --build build/cmake_only
 export PYTHONPATH=$(pwd):$(pwd)/python
@@ -158,7 +158,7 @@ Any change that touches:
 ```bash
 # Locally — same script CI runs.
 source .venv/bin/activate
-pip install scikit-build-core nanobind cmake pytest torch  # one-time
+pip install scikit-build-core nanobind 'cmake>=3.15' pytest torch  # one-time
 bash tools/verify_packaging.sh
 ```
 

--- a/tools/verify_packaging.sh
+++ b/tools/verify_packaging.sh
@@ -83,7 +83,7 @@ print('incore helpers OK:', inc_dirs)
 # ---------------------------------------------------------------------------
 python -c "import scikit_build_core, nanobind, cmake, torch, pytest" 2>/dev/null || {
     echo "ERROR: venv missing required deps. Install with:" >&2
-    echo "  pip install scikit-build-core nanobind cmake pytest torch" >&2
+    echo "  pip install scikit-build-core nanobind 'cmake>=3.15' pytest torch" >&2
     exit 1
 }
 
@@ -96,12 +96,19 @@ pip install .
 smoke "pip install ."
 
 # ---------------------------------------------------------------------------
-# Mode 2: pip install --no-build-isolation .
+# Mode 2: targeted install followed by a default --no-build-isolation install.
+# The second install deliberately reuses the CMake build directory: targeted
+# platform selection must not leak into an ordinary package install.
 # ---------------------------------------------------------------------------
-echo "===== Mode 2: pip install --no-build-isolation . ====="
+echo "===== Mode 2: targeted install -> default install ====="
 wipe_state
+pip install --no-build-isolation \
+    --config-settings=build.targets=build_package_a2a3sim .
+test -f build/lib/a2a3/sim/host_build_graph/libhost_runtime.so
+test ! -e build/lib/a5/sim
 pip install --no-build-isolation .
-smoke "pip install --no-build-isolation ."
+test -f build/lib/a5/sim/host_build_graph/libhost_runtime.so
+smoke "targeted -> default --no-build-isolation install"
 
 # ---------------------------------------------------------------------------
 # Mode 3: pip install -e .


### PR DESCRIPTION
## Summary

- Add one non-cached aggregate CMake target per CI platform so CMake can build the binding and selected runtimes in one dependency graph.
- Make sim, onboard, pod, pre-commit, profiling, and sanitizer installs omit runtime platforms they do not consume, without splitting jobs or changing test selection.
- Remove the repeated pre-commit runtime build and ineffective CMake cache, and stabilize pip cache keys across source-only changes.
- Provision `cmake>=3.15` for every `--no-build-isolation` path and add a targeted-install to default-install packaging regression.

Ordinary package installs still use the default `ALL` target and auto-detect every available platform. Target selection is not stored in the CMake cache.

## Performance

Local cold-wheel measurements show the single-platform build path reducing fixed Package/CMake time by about 40-47% with four CPUs and 11-12% on the high-core host. A recent pre-commit run spent 92 seconds in the now-removed second runtime build.

The aggregate-target Ninja log confirms the binding and runtime dependency windows overlap; scikit-build-core receives one target and therefore performs one project build rather than serially iterating a target list. Final Job p50/p90 still needs validation on matching GitHub-hosted and self-hosted runner tiers.

## Testing

- [x] Targeted `a2a3sim` wheel followed by a default wheel in the same build directory; the default build adds `a5sim` and no platform selection remains in CMake cache
- [x] Four-CPU cold aggregate-target builds for the combined sim target and single-platform target
- [x] Ninja log inspection confirms binding/runtime overlap
- [x] `pre-commit run --from-ref upstream/main --to-ref HEAD`
- [x] YAML parse, `bash -n tools/verify_packaging.sh`, and `git diff --check`
- [ ] Full GitHub-hosted and self-hosted CI

No NPU execution was needed for the local build validation.

Refs #1772