### PR TITLE
test: add manual cross-runtime SPMD paged attention coverage

### DIFF
--- a/examples/a5/host_build_graph/benchmark_bgemm/test_benchmark_bgemm.py
+++ b/examples/a5/host_build_graph/benchmark_bgemm/test_benchmark_bgemm.py
@@ -51,7 +51,7 @@ class TestBenchmarkBgemmHostBuildGraph(SceneTestCase):
     CASES = [
         {
             "name": "Case0",
-            "platforms": ["a5"],
+            "platforms": ["a5sim", "a5"],
             "params": {"matmul_add_task_num": 500, "incore_data_size": 128, "incore_loop": 4, "grid_k": 2},
         },
     ]

--- a/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/README.md
+++ b/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/README.md
@@ -1,0 +1,29 @@
+# benchmark_bgemm on A5
+
+This example runs the `Case0` batched matrix-multiplication graph on the A5
+`tensormap_and_ringbuffer` runtime. Each group submits a GEMM task for every
+`grid_k` partition and an ADD task that accumulates the partial result into
+`C`.
+
+The A5 port intentionally supports only the 128 × 128 tile used by `Case0`.
+Unlike the A2/A3 version, which passes
+`[tile_size, grid_k, num_groups, incore_loop]` in a configuration tensor, A5
+passes those four topology values as scalar orchestration arguments. The A5
+incore kernels derive the number of 128 × 128 tiles from their `ChipTensor`
+views, so their callable signatures contain only the data tensors.
+
+`Case0` runs in both simulation and on hardware:
+
+```bash
+pytest examples/a5/tensormap_and_ringbuffer/benchmark_bgemm --platform a5sim
+
+pytest examples/a5/tensormap_and_ringbuffer/benchmark_bgemm \
+  --platform a5 --device 0
+```
+
+The host-build-graph counterpart references the same orchestration and incore
+sources, ensuring both runtimes exercise the same fixed-tile compute graph.
+
+`C` is declared `INOUT` because every ADD task reads the previous partial sum
+before writing the updated value. The host therefore initializes `C` to zero
+and stages it to the runtime before execution.

--- a/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/test_benchmark_bgemm.py
+++ b/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/test_benchmark_bgemm.py
@@ -49,7 +49,7 @@ class TestBenchmarkBgemm(SceneTestCase):
     CASES = [
         {
             "name": "Case0",
-            "platforms": ["a5"],
+            "platforms": ["a5sim", "a5"],
             "params": {"matmul_add_task_num": 500, "incore_data_size": 128, "incore_loop": 4, "grid_k": 2},
         }
     ]

--- a/tests/st/a2a3/host_build_graph/spmd_paged_attention/test_spmd_paged_attention.py
+++ b/tests/st/a2a3/host_build_graph/spmd_paged_attention/test_spmd_paged_attention.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Manual HBG coverage for the disabled SPMD paged-attention workload."""
+
+from copy import deepcopy
+from pathlib import Path
+
+from simpler_setup import scene_test
+from tests.st.a2a3.tensormap_and_ringbuffer.spmd_paged_attention.test_spmd_paged_attention import (
+    TestPagedAttentionUnrollTpushPop as _TmrBase,
+)
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestSpmdPagedAttentionHbgA2A3(_TmrBase):
+    _SHARED_DIR = Path(__file__).resolve().parents[2] / "tensormap_and_ringbuffer/spmd_paged_attention"
+    CALLABLE = deepcopy(_TmrBase.CALLABLE)
+    CALLABLE["orchestration"]["source"] = str(_SHARED_DIR / "kernels/orchestration/spmd_paged_attention_orch.cpp")
+    for _incore in CALLABLE["incores"]:
+        _incore["source"] = str(_SHARED_DIR / "kernels/mix/paged_attention_parallel.cpp")
+
+    CASES = [
+        {
+            "name": "TwoWayOneBlockZeroQuery",
+            "platforms": ["a2a3sim", "a2a3"],
+            "manual": True,
+            "params": {
+                "batch": 2,
+                "num_heads": 16,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 128,
+                "context_len": 128,
+                "max_model_len": 256,
+                "dtype": "bfloat16",
+            },
+        }
+    ]
+
+    def generate_args(self, params):
+        args = super().generate_args(params)
+        args.query.zero_()
+        return args
+
+
+if __name__ == "__main__":
+    TestSpmdPagedAttentionHbgA2A3.run_module(__name__)

--- a/tests/st/a5/host_build_graph/spmd_paged_attention/test_spmd_paged_attention.py
+++ b/tests/st/a5/host_build_graph/spmd_paged_attention/test_spmd_paged_attention.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Manual HBG coverage for the disabled A5 SPMD paged-attention workload."""
+
+from simpler_setup import scene_test
+from tests.st.a5.tensormap_and_ringbuffer.spmd_paged_attention.test_spmd_paged_attention import (
+    TestSpmdPagedAttentionA5 as _TmrBase,
+)
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestSpmdPagedAttentionHbgA5(_TmrBase):
+    CASES = [{**case, "platforms": ["a5sim", "a5"], "manual": True} for case in _TmrBase.CASES]
+
+
+if __name__ == "__main__":
+    TestSpmdPagedAttentionHbgA5.run_module(__name__)

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/kernels/mix/paged_attention_parallel.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/kernels/mix/paged_attention_parallel.cpp
@@ -1,0 +1,709 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Paged Attention MIX Kernel — AIC + AIV in single source via TPUSH/TPOP
+ *
+ * Hardware block_num is fixed at 24. Each hardware block strides over
+ * total_logical_blocks = batch * q_loop logical work items:
+ *   for (block_idx = hw_block_idx; block_idx < total_logical_blocks; block_idx += 24)
+ * Each logical block_idx encodes one (batch_idx, q_tile_idx) position.
+ *
+ * q_tile adapts to num_heads at runtime: q_tile = min(num_heads, MAX_Q_TILE).
+ * When num_heads <= MAX_Q_TILE, q_loop = 1 and each block processes all heads.
+ * Two q_tile shapes are statically dispatched: 16 (default) and 64.
+ *
+ * Compiled twice: once with __DAV_CUBE__ (AIC), once with __DAV_VEC__ (AIV).
+ * AIC and AIV cooperate via 3 GM-backed FIFO pipes (one set per hardware block,
+ * reused across stride-loop iterations):
+ *   - sij_pipe (C2V): QK scores    (Q_TILE, block_size) fp32, TILE_UP_DOWN
+ *   - pij_pipe (V2C): softmax probs (Q_TILE, block_size) bf16, TILE_UP_DOWN
+ *   - oi_pipe  (C2V): PV output    (Q_TILE, head_dim)   fp32, TILE_UP_DOWN
+ *
+ * Per-block pipeline:
+ *   AIC: QK matmul → TPUSH(sij) → TPOP(pij) → PV matmul → TPUSH(oi_new)
+ *   AIV: TPOP(sij) → online softmax → TPUSH(pij) → TPOP(oi_new) → online update
+ *
+ * MixedKernels args:
+ *   args[0]  = query         ChipTensor* (batch*num_heads, head_dim) bf16
+ *   args[1]  = key_cache     ChipTensor* (kv_total_rows, head_dim) bf16
+ *   args[2]  = value_cache   ChipTensor* (kv_total_rows, head_dim) bf16
+ *   args[3]  = block_table   ChipTensor* (batch, max_blocks_per_req) int32
+ *   args[4]  = context_lens  ChipTensor* (batch,) int32
+ *   args[5]  = out           ChipTensor* (batch*num_heads, head_dim) float32 [output]
+ *   args[6]  = sij_fifo      ChipTensor* GM ring buffer for sij pipe
+ *   args[7]  = pij_fifo      ChipTensor* GM ring buffer for pij pipe
+ *   args[8]  = oi_fifo       ChipTensor* GM ring buffer for oi_new pipe
+ *   args[9]  = scale_value   scalar (float bits in uint64)
+ *   args[10] = num_heads     scalar
+ *   args[11] = head_dim      scalar
+ *   args[12] = block_size    scalar
+ *   args[13] = max_num_blocks_per_req scalar
+ *   args[14] = q_loop        scalar
+ *   args[15] = total_logical_blocks scalar (= batch * q_loop)
+ *   args[16] = q_tile        scalar (16 or 64)
+ */
+
+#include <cstdint>
+// NOLINTBEGIN(clang-diagnostic-error,bugprone-reserved-identifier,bugprone-easily-swappable-parameters,modernize-use-auto)
+#include <pto/pto-inst.hpp>
+#include <pto/common/fifo.hpp>
+
+#include "tensor.h"
+
+using pto::BLayout;
+using pto::Direction;
+using pto::GlobalTensor;
+using pto::Layout;
+using pto::PadValue;
+using pto::RoundMode;
+using pto::Shape;
+using pto::SLayout;
+using pto::Stride;
+using pto::Tile;
+using pto::TileAcc;
+using pto::TileLeft;
+using pto::TileRight;
+using pto::TileSplitAxis;
+using pto::TileType;
+using pto::TPipe;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#ifdef __DAV_CUBE__
+constexpr bool DAV_CUBE = true;
+#else
+constexpr bool DAV_CUBE = false;
+#endif
+
+#ifdef __DAV_VEC__
+constexpr bool DAV_VEC = true;
+#else
+constexpr bool DAV_VEC = false;
+#endif
+
+#include "intrinsic.h"
+
+static constexpr int MAX_Q_TILE = 64;
+static constexpr int HEAD_DIM = 128;
+static constexpr int MAX_BLOCK_SIZE = 128;
+
+// TPUSH/TPOP pipe flag IDs (each consumes 2 consecutive IDs: data + backpressure)
+static constexpr uint16_t SIJ_FLAG_ID = 0;
+static constexpr uint16_t PIJ_FLAG_ID = 2;
+static constexpr uint16_t OI_FLAG_ID = 4;
+static constexpr uint8_t FIFO_DEPTH = 2;
+
+// Per-q_tile compile-time configuration: pipe types, slot sizes, UB/L1 layouts.
+// QT must be 16 or 64. SUB_QT = QT / 2 (each of AIV0/AIV1 handles half the rows).
+template <int QT>
+struct PAConfig {
+    static constexpr int Q_TILE = QT;
+    static constexpr int SUB_QT = QT / 2;
+
+    // GM FIFO slot sizes (full tile per slot, sized for max block_size to allow
+    // the same FIFO to host both block_size=64 and block_size=128 cases).
+    static constexpr uint32_t SIJ_SLOT_SIZE = QT * MAX_BLOCK_SIZE * sizeof(float);
+    static constexpr uint32_t PIJ_SLOT_SIZE = QT * MAX_BLOCK_SIZE * sizeof(bfloat16_t);
+    static constexpr uint32_t OI_SLOT_SIZE = QT * HEAD_DIM * sizeof(float);
+
+    using SijPipeT = TPipe<SIJ_FLAG_ID, Direction::DIR_C2V, SIJ_SLOT_SIZE, FIFO_DEPTH>;
+    using PijPipeT = TPipe<PIJ_FLAG_ID, Direction::DIR_V2C, PIJ_SLOT_SIZE, FIFO_DEPTH>;
+    using OiPipeT = TPipe<OI_FLAG_ID, Direction::DIR_C2V, OI_SLOT_SIZE, FIFO_DEPTH>;
+
+    // AIV UB consumer buffer layout (sized for SUB_QT rows per AIV lane)
+    static constexpr uint32_t SIJ_UB_BASE = 0x0;
+    static constexpr uint32_t SIJ_UB_SIZE = 2 * SUB_QT * MAX_BLOCK_SIZE * sizeof(float);
+    static constexpr uint32_t OI_UB_BASE = SIJ_UB_BASE + SIJ_UB_SIZE;
+    static constexpr uint32_t OI_UB_SIZE = 2 * SUB_QT * HEAD_DIM * sizeof(float);
+    static constexpr uint32_t WORK_UB_BASE = OI_UB_BASE + OI_UB_SIZE;
+
+    // AIC L1 consumer buffer for V2C pij pipe (full QT * MAX_BLOCK_SIZE rows)
+    static constexpr uint32_t PIJ_L1_BASE = 0x40000;
+    static constexpr uint32_t PIJ_L1_SIZE = 2 * QT * MAX_BLOCK_SIZE * sizeof(bfloat16_t);
+};
+
+// ============================================================================
+// AIC (Cube) processing — QK-first offset-loop software pipeline
+//
+// QK-first order: each steady-state iteration does QK[i] then PV[i-1].
+// This maximizes overlap by hiding AIV's softmax behind AIC's QK matmul:
+// while AIC computes QK[i], AIV concurrently processes SF[i-1].
+// By the time AIC finishes QK[i] and needs pij[i-1], SF[i-1] is done.
+// FIFO_DEPTH=2 supports the 2-deep sij buffering (sij[i-1] + sij[i]).
+//
+// Timeline (steady state):
+//   AIC:  QK[i] → TPUSH(sij[i]) → TPOP(pij[i-1]) → PV[i-1] → TPUSH(oi[i-1])
+//   AIV:  TPOP(sij[i-1]) → SF[i-1] → TPUSH(pij[i-1]) → TPOP(oi[i-2]) → UP[i-2]
+//   ──────────────────────────────────────────────────────────────────────────
+//   QK[i] overlaps with SF[i-1]   (Cube compute ∥ Vector softmax)
+//   PV[i-1] overlaps with UP[i-2] (Cube compute ∥ Vector online update)
+// ============================================================================
+
+// Helper: QK matmul for block i — load key, move to L0, matmul, TPUSH sij
+template <
+    int M, int K, int N, typename SijPipeT, typename GlobalB_QK, typename TileMatA_QK, typename TileMatB_QK,
+    typename LeftTile_QK, typename RightTile_QK, typename AccTile_QK>
+static __aicore__ void aic_qk_step(
+    __gm__ bfloat16_t *key_base, uint64_t kv_block_id, TileMatA_QK &aMatTile_QK, TileMatB_QK &bMatTile_QK,
+    LeftTile_QK &aTile_QK, RightTile_QK &bTile_QK, AccTile_QK &cTile_QK, SijPipeT &sij_pipe
+) {
+    GlobalB_QK kjGlobal(key_base + kv_block_id * N * K);
+    TLOAD(bMatTile_QK, kjGlobal);
+
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+    TMOV(aTile_QK, aMatTile_QK);
+    TMOV(bTile_QK, bMatTile_QK);
+
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+    TMATMUL(cTile_QK, aTile_QK, bTile_QK);
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+    TPUSH<SijPipeT, AccTile_QK, TileSplitAxis::TILE_UP_DOWN>(sij_pipe, cTile_QK);
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+}
+
+// Helper: PV matmul for block i — TPOP pij, load value, move to L0, matmul, TPUSH oi
+template <
+    int M, int K, int N, typename PijPipeT, typename OiPipeT, typename GlobalB_PV, typename PijMatTile,
+    typename TileMatB_PV, typename LeftTile_PV, typename RightTile_PV, typename AccTile_PV>
+static __aicore__ void aic_pv_step(
+    __gm__ bfloat16_t *val_base, uint64_t kv_block_id, PijMatTile &pijMatTile, TileMatB_PV &bMatTile_PV,
+    LeftTile_PV &aTile_PV, RightTile_PV &bTile_PV, AccTile_PV &cTile_PV, PijPipeT &pij_pipe, OiPipeT &oi_pipe
+) {
+    GlobalB_PV vjGlobal(val_base + kv_block_id * N * K);
+    TLOAD(bMatTile_PV, vjGlobal);
+
+    TPOP<PijPipeT, PijMatTile, TileSplitAxis::TILE_NO_SPLIT>(pij_pipe, pijMatTile);
+
+    // PV step uses EVENT_ID1 (QK step uses EVENT_ID0) to avoid flag aliasing
+    // when pipe_barrier(PIPE_ALL) is removed between steps.
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);
+
+    TMOV(aTile_PV, pijMatTile);
+    TMOV(bTile_PV, bMatTile_PV);
+
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID1);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID1);
+
+    TMATMUL(cTile_PV, aTile_PV, bTile_PV);
+
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID1);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID1);
+
+    TPUSH<OiPipeT, AccTile_PV, TileSplitAxis::TILE_UP_DOWN>(oi_pipe, cTile_PV);
+    set_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_FIX, PIPE_S, EVENT_ID7);
+}
+
+template <typename Cfg, int K, int N>
+static __aicore__ void aic_process_blocks(
+    __gm__ bfloat16_t *qi_base, __gm__ bfloat16_t *key_base, __gm__ bfloat16_t *val_base, __gm__ int32_t *bt,
+    uint64_t bt_offset, uint64_t n_blocks, typename Cfg::SijPipeT &sij_pipe, typename Cfg::PijPipeT &pij_pipe,
+    typename Cfg::OiPipeT &oi_pipe
+) {
+    constexpr int M = Cfg::Q_TILE;
+    using SijPipeT = typename Cfg::SijPipeT;
+    using PijPipeT = typename Cfg::PijPipeT;
+    using OiPipeT = typename Cfg::OiPipeT;
+
+    using GlobalA_QK = GlobalTensor<bfloat16_t, Shape<1, 1, 1, M, K>, pto::Stride<M * K, M * K, M * K, K, 1>>;
+    using GlobalB_QK =
+        GlobalTensor<bfloat16_t, Shape<1, 1, 1, K, N>, pto::Stride<K * N, K * N, K * N, 1, K>, Layout::DN>;
+    using TileMatA_QK = Tile<TileType::Mat, bfloat16_t, M, K, BLayout::ColMajor, M, K, SLayout::RowMajor, 512>;
+    using TileMatB_QK = Tile<TileType::Mat, bfloat16_t, K, N, BLayout::RowMajor, K, N, SLayout::ColMajor, 512>;
+    using LeftTile_QK = TileLeft<bfloat16_t, M, K, M, K>;
+    using RightTile_QK = TileRight<bfloat16_t, K, N, K, N>;
+    using AccTile_QK = TileAcc<float, M, N, M, N>;
+
+    using GlobalB_PV = GlobalTensor<bfloat16_t, Shape<1, 1, 1, N, K>, pto::Stride<N * K, N * K, N * K, K, 1>>;
+    using TileMatB_PV = Tile<TileType::Mat, bfloat16_t, N, K, BLayout::ColMajor, N, K, SLayout::RowMajor, 512>;
+    using PijMatTile = Tile<TileType::Mat, bfloat16_t, M, N, BLayout::ColMajor, M, N, SLayout::RowMajor, 512>;
+    using LeftTile_PV = TileLeft<bfloat16_t, M, N, M, N>;
+    using RightTile_PV = TileRight<bfloat16_t, N, K, N, K>;
+    using AccTile_PV = TileAcc<float, M, K, M, K>;
+
+    TileMatA_QK aMatTile_QK;
+    TileMatB_QK bMatTile_QK;
+    TASSIGN(aMatTile_QK, 0x0);
+    TASSIGN(bMatTile_QK, 0x20000);
+
+    LeftTile_QK aTile_QK;
+    RightTile_QK bTile_QK;
+    AccTile_QK cTile_QK;
+    TASSIGN(aTile_QK, 0x0);
+    TASSIGN(bTile_QK, 0x0);
+    TASSIGN(cTile_QK, 0x0);
+
+    PijMatTile pijMatTile;
+    TileMatB_PV bMatTile_PV;
+    TASSIGN(bMatTile_PV, Cfg::PIJ_L1_BASE + Cfg::PIJ_L1_SIZE);
+
+    LeftTile_PV aTile_PV;
+    RightTile_PV bTile_PV;
+    AccTile_PV cTile_PV;
+    TASSIGN(aTile_PV, 0x0);
+    TASSIGN(bTile_PV, 0x0);
+    TASSIGN(cTile_PV, 0x0);
+
+    GlobalA_QK qiGlobal(qi_base);
+    TLOAD(aMatTile_QK, qiGlobal);
+
+    // A5 MIX dispatch requires each FIFO handshake to complete before the
+    // next one starts.  The former QK-first cross-iteration pipeline can fill
+    // sij while Cube is waiting for pij, producing a circular backpressure
+    // wait with the two Vector lanes.  Use the same per-block handshake for
+    // all lengths; this is the correctness baseline for the SPMD port.
+    for (uint64_t i = 0; i < n_blocks; ++i) {
+        uint64_t block_id = static_cast<uint64_t>(bt[bt_offset + i]);
+        aic_qk_step<M, K, N, SijPipeT, GlobalB_QK>(
+            key_base, block_id, aMatTile_QK, bMatTile_QK, aTile_QK, bTile_QK, cTile_QK, sij_pipe
+        );
+        aic_pv_step<M, K, N, PijPipeT, OiPipeT, GlobalB_PV>(
+            val_base, block_id, pijMatTile, bMatTile_PV, aTile_PV, bTile_PV, cTile_PV, pij_pipe, oi_pipe
+        );
+    }
+}
+
+// ============================================================================
+// AIV (Vector) processing — SF-first offset-loop software pipeline
+//
+// SF-first order: each steady-state iteration does SF[i] then UP[i-1].
+// This ensures pij[i] is produced as early as possible so AIC's TPOP(pij)
+// never stalls behind a pending UP computation. Combined with AIC's
+// QK-first order, SF[i] overlaps with AIC's PV[i-1] Cube matmul.
+// ============================================================================
+
+// Helper: softmax step for block i — TPOP sij, compute softmax, TPUSH pij
+//
+// globalMaxRow is used as a running accumulator: on entry it holds the max
+// from the previous iteration (or is undefined when i==0). SF updates it
+// in-place to max(globalMaxRow, localMaxRow_i * scale). The caller must
+// save globalMaxRow before calling SF if the old value is still needed.
+template <
+    typename Cfg, int TM, int TN, typename SijVecTile, typename TileSijPad, typename TileVecMxN,
+    typename PijVecBf16Tile, typename TileScalarDN, typename TileScalarRow>
+static __aicore__ void aiv_sf_step(
+    uint64_t i, bool is_last_partial, uint64_t valid_len_last, float scale_value, SijVecTile &sijTile,
+    TileSijPad &sijPadTile, TileVecMxN &pijTile, TileVecMxN &tmpTile, PijVecBf16Tile &pijBf16Tile,
+    TileScalarDN &localMaxDN, TileScalarDN &globalMaxDN, TileScalarDN &llDN, TileScalarRow &localMaxRow,
+    TileScalarRow &globalMaxRow, typename Cfg::SijPipeT &sij_pipe, typename Cfg::PijPipeT &pij_pipe
+) {
+    using TileSijDyn = Tile<TileType::Vec, float, TM, TN, BLayout::RowMajor, TM, -1>;
+    using SijPipeT = typename Cfg::SijPipeT;
+    using PijPipeT = typename Cfg::PijPipeT;
+
+    TPOP<SijPipeT, SijVecTile, TileSplitAxis::TILE_UP_DOWN>(sij_pipe, sijTile);
+
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    if (is_last_partial) {
+        int sij_addr =
+            Cfg::SIJ_UB_BASE + static_cast<int>((i % 2) * TM * MAX_BLOCK_SIZE * static_cast<int>(sizeof(float)));
+        TASSIGN(sijPadTile, sij_addr);
+        TileSijDyn sijDynTile(static_cast<size_t>(valid_len_last));
+        TASSIGN(sijDynTile, sij_addr);
+        TFILLPAD_INPLACE(sijPadTile, sijDynTile);
+        pipe_barrier(PIPE_ALL);
+    }
+
+    TROWMAX(localMaxDN, sijTile, tmpTile);
+    pipe_barrier(PIPE_ALL);
+    TRESHAPE(localMaxRow, localMaxDN);
+
+    if (i == 0) {
+        TMULS(globalMaxRow, localMaxRow, scale_value);
+    } else {
+        TMULS(localMaxRow, localMaxRow, scale_value);
+        pipe_barrier(PIPE_ALL);
+        TMAX(globalMaxRow, globalMaxRow, localMaxRow);
+    }
+    TRESHAPE(globalMaxDN, globalMaxRow);
+
+    TMULS(sijTile, sijTile, scale_value);
+    pipe_barrier(PIPE_ALL);
+    TROWEXPANDSUB(pijTile, sijTile, globalMaxDN);
+    pipe_barrier(PIPE_ALL);
+    TEXP(pijTile, pijTile);
+    pipe_barrier(PIPE_ALL);
+
+    TCVT(pijBf16Tile, pijTile, RoundMode::CAST_ROUND);
+    pipe_barrier(PIPE_ALL);
+    TCVT(pijTile, pijBf16Tile, RoundMode::CAST_ROUND);
+    pipe_barrier(PIPE_ALL);
+
+    TROWSUM(llDN, pijTile, tmpTile);
+
+    pipe_barrier(PIPE_ALL);
+    TPUSH<PijPipeT, PijVecBf16Tile, TileSplitAxis::TILE_UP_DOWN>(pij_pipe, pijBf16Tile);
+}
+
+// Helper: online update step for block i — TPOP oi, merge with accumulators
+//
+// curMaxRow  = M[i]   = running max over blocks 0..i   (mij in FlashAttention notation)
+// prevMaxRow = M[i-1] = running max over blocks 0..i-1 (dm / old max)
+// llDN_i     = row-sum of pij for block i
+//
+// alpha = exp(prevMaxRow - curMaxRow), used to rescale accumulated go and gl.
+template <
+    typename Cfg, int TM, int TN, typename OiVecTile, typename TileDataMxHD, typename TileScalarDN,
+    typename TileScalarND, typename TileScalarRow>
+static __aicore__ void aiv_up_step(
+    uint64_t i, OiVecTile &oiNewTile, TileDataMxHD &goTile, TileScalarDN &alphaDN_dn, TileScalarDN &llDN_i,
+    TileScalarND &glND, TileScalarND &alphaND, TileScalarND &llND, TileScalarND &dmND, TileScalarND &mijND,
+    TileScalarRow &curMaxRow, TileScalarRow &prevMaxRow, typename Cfg::OiPipeT &oi_pipe
+) {
+    using OiPipeT = typename Cfg::OiPipeT;
+    TPOP<OiPipeT, OiVecTile, TileSplitAxis::TILE_UP_DOWN>(oi_pipe, oiNewTile);
+
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+
+    if (i == 0) {
+        TMULS(goTile, oiNewTile, 1.0f);
+        TRESHAPE(llND, llDN_i);
+        pipe_barrier(PIPE_ALL);
+        TMULS(glND, llND, 1.0f);
+    } else {
+        TRESHAPE(llND, llDN_i);
+        TRESHAPE(mijND, curMaxRow);
+        TRESHAPE(dmND, prevMaxRow);
+
+        TSUB(alphaND, dmND, mijND);
+        pipe_barrier(PIPE_ALL);
+        TEXP(alphaND, alphaND);
+        pipe_barrier(PIPE_ALL);
+
+        TRESHAPE(alphaDN_dn, alphaND);
+        TROWEXPANDMUL(goTile, goTile, alphaDN_dn);
+        pipe_barrier(PIPE_ALL);
+        TADD(goTile, goTile, oiNewTile);
+
+        TMUL(glND, glND, alphaND);
+        pipe_barrier(PIPE_ALL);
+        TADD(glND, glND, llND);
+    }
+
+    pipe_barrier(PIPE_ALL);
+}
+
+template <typename Cfg, int TN>
+static __aicore__ void aiv_process_blocks(
+    int32_t sub_block_id, float scale_value, uint64_t n_blocks, uint64_t valid_len_last, __gm__ float *dst_ptr,
+    typename Cfg::SijPipeT &sij_pipe, typename Cfg::PijPipeT &pij_pipe, typename Cfg::OiPipeT &oi_pipe
+) {
+    constexpr int TM = Cfg::SUB_QT;
+    constexpr int HD = HEAD_DIM;
+    constexpr int kAlignedRows = ((TM * sizeof(float) + 31) / 32) * (32 / sizeof(float));
+    constexpr int kScalarCols = 32 / sizeof(float);
+    constexpr int kScalarRows = TM / kScalarCols;
+
+    using SijVecTile = Tile<TileType::Vec, float, TM, TN, BLayout::RowMajor, TM, TN>;
+    using PijVecBf16Tile = Tile<TileType::Vec, bfloat16_t, TM, TN, BLayout::RowMajor, TM, TN>;
+    using OiVecTile = Tile<TileType::Vec, float, TM, HD, BLayout::RowMajor, TM, HD>;
+
+    using TileVecMxN = Tile<TileType::Vec, float, TM, TN, BLayout::RowMajor, TM, TN>;
+    using TileSijPad =
+        Tile<TileType::Vec, float, TM, TN, BLayout::RowMajor, TM, TN, SLayout::NoneBox, 512, PadValue::Min>;
+    using TileScalarDN = Tile<TileType::Vec, float, kAlignedRows, 1, BLayout::ColMajor, TM, 1>;
+    using TileScalarND =
+        Tile<TileType::Vec, float, kScalarRows, kScalarCols, BLayout::RowMajor, kScalarRows, kScalarCols>;
+    using TileScalarRow = Tile<TileType::Vec, float, 1, TM, BLayout::RowMajor, 1, TM>;
+    using TileDataMxHD = Tile<TileType::Vec, float, TM, HD, BLayout::RowMajor, TM, HD>;
+    using GlobalDataMxHD = GlobalTensor<float, Shape<1, 1, 1, TM, HD>, pto::Stride<1, 1, 1, HD, 1>>;
+
+    constexpr int kSijBytes = TM * TN * sizeof(float);
+    constexpr int kPijBf16Bytes = TM * TN * sizeof(bfloat16_t);
+    constexpr int kScalarDNBytes = kAlignedRows * sizeof(float);
+    constexpr int kScalarNDBytes = kScalarRows * kScalarCols * sizeof(float);
+
+    SijVecTile sijTile;
+    TileSijPad sijPadTile;
+    TileVecMxN pijTile;
+    TileVecMxN tmpTile;
+    PijVecBf16Tile pijBf16Tile;
+    TileScalarDN localMaxDN, globalMaxDN;
+    TileScalarDN alphaDN_dn, llDN, glDN;
+    TileScalarND glND, alphaND, llND, dmND, mijND;
+    TileScalarRow localMaxRow, globalMaxRow;
+    TileScalarRow savedMaxRow, prevMaxRow;
+    OiVecTile oiNewTile;
+    TileDataMxHD goTile;
+
+    int ub = Cfg::WORK_UB_BASE;
+    TASSIGN(pijTile, ub);
+    ub += kSijBytes;
+    TASSIGN(pijBf16Tile, ub);
+    ub += kPijBf16Bytes;
+    TASSIGN(tmpTile, ub);
+    ub += kSijBytes;
+
+    int sb = ub;
+    TASSIGN(localMaxDN, sb);
+    TASSIGN(localMaxRow, sb);
+    sb += kScalarDNBytes;
+    TASSIGN(globalMaxDN, sb);
+    TASSIGN(globalMaxRow, sb);
+    sb += kScalarDNBytes;
+    TASSIGN(savedMaxRow, sb);
+    sb += kScalarDNBytes;
+    TASSIGN(glND, sb);
+    TASSIGN(glDN, sb);
+    sb += kScalarDNBytes;
+    TASSIGN(alphaND, sb);
+    TASSIGN(alphaDN_dn, sb);
+    sb += kScalarDNBytes;
+    TASSIGN(llND, sb);
+    TASSIGN(llDN, sb);
+    sb += kScalarDNBytes;
+    TASSIGN(dmND, sb);
+    sb += kScalarNDBytes;
+    TASSIGN(mijND, sb);
+    sb += kScalarNDBytes;
+    TASSIGN(prevMaxRow, sb);
+    sb += kScalarDNBytes;
+
+    TASSIGN(goTile, sb);
+
+    GlobalDataMxHD dstGlobal(dst_ptr);
+
+    bool last_partial = (valid_len_last < static_cast<uint64_t>(TN));
+
+    for (uint64_t i = 0; i < n_blocks; ++i) {
+        if (i > 0) {
+            TMULS(savedMaxRow, globalMaxRow, 1.0f);
+            pipe_barrier(PIPE_ALL);
+        }
+        bool cur_last_partial = (i == n_blocks - 1) && last_partial;
+        aiv_sf_step<Cfg, TM, TN>(
+            i, cur_last_partial, valid_len_last, scale_value, sijTile, sijPadTile, pijTile, tmpTile, pijBf16Tile,
+            localMaxDN, globalMaxDN, llDN, localMaxRow, globalMaxRow, sij_pipe, pij_pipe
+        );
+        aiv_up_step<Cfg, TM, TN>(
+            i, oiNewTile, goTile, alphaDN_dn, llDN, glND, alphaND, llND, dmND, mijND, globalMaxRow,
+            i == 0 ? globalMaxRow : savedMaxRow, oi_pipe
+        );
+    }
+
+    // Final normalization: output = goTile / glDN
+    TRESHAPE(glDN, glND);
+    pipe_barrier(PIPE_ALL);
+    TROWEXPANDDIV(goTile, goTile, glDN);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(dstGlobal, goTile);
+
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+}
+
+// ============================================================================
+// Per-config dispatch: builds pipes from per-hw-block FIFO bases, then runs
+// the AIC or AIV stride loop over total_logical_blocks.
+// ============================================================================
+
+template <typename Cfg>
+static __aicore__ void run_aic(
+    __gm__ int64_t *args, __gm__ int32_t *ctx_ptr, int32_t hw_block_idx, int32_t hw_block_num,
+    int64_t total_logical_blocks, int64_t num_heads, int64_t head_dim, int64_t block_size, int64_t max_blocks_per_req,
+    int64_t q_loop, __gm__ void *sij_fifo_base, __gm__ void *pij_fifo_base, __gm__ void *oi_fifo_base
+) {
+    if (head_dim != HEAD_DIM) return;
+
+    typename Cfg::SijPipeT sij_pipe(sij_fifo_base, Cfg::SIJ_UB_BASE, 0U);
+    typename Cfg::PijPipeT pij_pipe(pij_fifo_base, 0U, Cfg::PIJ_L1_BASE);
+    typename Cfg::OiPipeT oi_pipe(oi_fifo_base, Cfg::OI_UB_BASE, 0U);
+
+    __gm__ ChipTensor *query_t = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+    __gm__ ChipTensor *key_cache_t = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
+    __gm__ ChipTensor *value_cache_t = reinterpret_cast<__gm__ ChipTensor *>(args[2]);
+    __gm__ ChipTensor *block_table_t = reinterpret_cast<__gm__ ChipTensor *>(args[3]);
+
+    __gm__ bfloat16_t *query_base = reinterpret_cast<__gm__ bfloat16_t *>(query_t->buffer.addr) + query_t->start_offset;
+    __gm__ bfloat16_t *key_base =
+        reinterpret_cast<__gm__ bfloat16_t *>(key_cache_t->buffer.addr) + key_cache_t->start_offset;
+    __gm__ bfloat16_t *val_base =
+        reinterpret_cast<__gm__ bfloat16_t *>(value_cache_t->buffer.addr) + value_cache_t->start_offset;
+    __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr) + block_table_t->start_offset;
+
+    for (int32_t block_idx = hw_block_idx; block_idx < total_logical_blocks; block_idx += hw_block_num) {
+        int64_t batch_idx = block_idx / q_loop;
+        int64_t q_tile_idx = block_idx % q_loop;
+
+        int64_t cur_seq = static_cast<int64_t>(ctx_ptr[batch_idx]);
+        int64_t n_blocks = (cur_seq + block_size - 1) / block_size;
+        if (n_blocks <= 0) continue;
+
+        int64_t q_offset = (batch_idx * num_heads + q_tile_idx * Cfg::Q_TILE) * head_dim;
+        __gm__ bfloat16_t *qi_base = query_base + q_offset;
+        uint64_t bt_offset = static_cast<uint64_t>(batch_idx * max_blocks_per_req);
+
+        if (block_size == 128) {
+            aic_process_blocks<Cfg, 128, 128>(
+                qi_base, key_base, val_base, bt, bt_offset, static_cast<uint64_t>(n_blocks), sij_pipe, pij_pipe, oi_pipe
+            );
+        } else {
+            aic_process_blocks<Cfg, 128, 64>(
+                qi_base, key_base, val_base, bt, bt_offset, static_cast<uint64_t>(n_blocks), sij_pipe, pij_pipe, oi_pipe
+            );
+        }
+    }
+}
+
+template <typename Cfg>
+static __aicore__ void run_aiv(
+    __gm__ int64_t *args, __gm__ int32_t *ctx_ptr, int32_t hw_block_idx, int32_t hw_block_num,
+    int64_t total_logical_blocks, int64_t num_heads, int64_t head_dim, int64_t block_size, int64_t q_loop,
+    __gm__ void *sij_fifo_base, __gm__ void *pij_fifo_base, __gm__ void *oi_fifo_base
+) {
+    if (head_dim != HEAD_DIM) return;
+
+    typename Cfg::SijPipeT sij_pipe(sij_fifo_base, Cfg::SIJ_UB_BASE, 0U);
+    typename Cfg::PijPipeT pij_pipe(pij_fifo_base, 0U, Cfg::PIJ_L1_BASE);
+    typename Cfg::OiPipeT oi_pipe(oi_fifo_base, Cfg::OI_UB_BASE, 0U);
+
+    __gm__ ChipTensor *out_t = reinterpret_cast<__gm__ ChipTensor *>(args[5]);
+    float scale_value = from_u64<float>(static_cast<uint64_t>(args[9]));
+
+    int32_t sub_block_id = get_sub_block_id(args);
+    int64_t row_offset = sub_block_id * Cfg::SUB_QT;
+
+    __gm__ float *out_base = reinterpret_cast<__gm__ float *>(out_t->buffer.addr) + out_t->start_offset;
+
+    for (int32_t block_idx = hw_block_idx; block_idx < total_logical_blocks; block_idx += hw_block_num) {
+        int64_t batch_idx = block_idx / q_loop;
+        int64_t q_tile_idx = block_idx % q_loop;
+
+        int64_t cur_seq = static_cast<int64_t>(ctx_ptr[batch_idx]);
+        int64_t n_blocks = (cur_seq + block_size - 1) / block_size;
+
+        int64_t out_offset = (batch_idx * num_heads + q_tile_idx * Cfg::Q_TILE + row_offset) * head_dim;
+        __gm__ float *dst = out_base + out_offset;
+
+        if (n_blocks <= 0) {
+            using ZeroTile =
+                Tile<TileType::Vec, float, Cfg::SUB_QT, HEAD_DIM, BLayout::RowMajor, Cfg::SUB_QT, HEAD_DIM>;
+            using ZeroGlobal =
+                GlobalTensor<float, Shape<1, 1, 1, Cfg::SUB_QT, HEAD_DIM>, pto::Stride<1, 1, 1, HEAD_DIM, 1>>;
+            ZeroTile zeroTile;
+            TASSIGN(zeroTile, Cfg::WORK_UB_BASE);
+            TEXPANDS(zeroTile, 0.0f);
+            pipe_barrier(PIPE_ALL);
+            ZeroGlobal dstZero(dst);
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            TSTORE(dstZero, zeroTile);
+            pipe_barrier(PIPE_MTE3);
+            continue;
+        }
+
+        int64_t last_block_seq = (n_blocks - 1) * block_size;
+        int64_t remaining = cur_seq - last_block_seq;
+        uint64_t valid_len_last = (remaining >= block_size) ? static_cast<uint64_t>(block_size) :
+                                                              (remaining > 0 ? static_cast<uint64_t>(remaining) : 0);
+
+        if (block_size == 128) {
+            aiv_process_blocks<Cfg, 128>(
+                sub_block_id, scale_value, static_cast<uint64_t>(n_blocks), valid_len_last, dst, sij_pipe, pij_pipe,
+                oi_pipe
+            );
+        } else {
+            aiv_process_blocks<Cfg, 64>(
+                sub_block_id, scale_value, static_cast<uint64_t>(n_blocks), valid_len_last, dst, sij_pipe, pij_pipe,
+                oi_pipe
+            );
+        }
+    }
+}
+
+// ============================================================================
+// Entry point — shared by AIC and AIV via DAV_CUBE / DAV_VEC guards
+// ============================================================================
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ ChipTensor *context_lens_t = reinterpret_cast<__gm__ ChipTensor *>(args[4]);
+    __gm__ ChipTensor *sij_fifo_t = reinterpret_cast<__gm__ ChipTensor *>(args[6]);
+    __gm__ ChipTensor *pij_fifo_t = reinterpret_cast<__gm__ ChipTensor *>(args[7]);
+    __gm__ ChipTensor *oi_fifo_t = reinterpret_cast<__gm__ ChipTensor *>(args[8]);
+
+    int64_t num_heads = static_cast<int64_t>(args[10]);
+    int64_t head_dim = static_cast<int64_t>(args[11]);
+    int64_t block_size = static_cast<int64_t>(args[12]);
+    int64_t max_blocks_per_req = static_cast<int64_t>(args[13]);
+    int64_t q_loop = static_cast<int64_t>(args[14]);
+    int64_t total_logical_blocks = static_cast<int64_t>(args[15]);
+    int64_t q_tile = static_cast<int64_t>(args[16]);
+
+    int32_t hw_block_idx = get_block_idx(args);
+    int32_t hw_block_num = get_block_num(args);
+
+    __gm__ int32_t *ctx_ptr =
+        reinterpret_cast<__gm__ int32_t *>(context_lens_t->buffer.addr) + context_lens_t->start_offset;
+
+    // GM FIFO buffer per hardware block (reused across stride-loop iterations).
+    // Slot stride is sized for max(Q_TILE) so the same offset works for both q_tile=16 and 64.
+    constexpr uint32_t SIJ_HW_STRIDE = PAConfig<MAX_Q_TILE>::SIJ_SLOT_SIZE * FIFO_DEPTH;
+    constexpr uint32_t PIJ_HW_STRIDE = PAConfig<MAX_Q_TILE>::PIJ_SLOT_SIZE * FIFO_DEPTH;
+    constexpr uint32_t OI_HW_STRIDE = PAConfig<MAX_Q_TILE>::OI_SLOT_SIZE * FIFO_DEPTH;
+
+    __gm__ void *sij_fifo_base = reinterpret_cast<__gm__ void *>(
+        reinterpret_cast<__gm__ uint8_t *>(sij_fifo_t->buffer.addr) + hw_block_idx * SIJ_HW_STRIDE
+    );
+    __gm__ void *pij_fifo_base = reinterpret_cast<__gm__ void *>(
+        reinterpret_cast<__gm__ uint8_t *>(pij_fifo_t->buffer.addr) + hw_block_idx * PIJ_HW_STRIDE
+    );
+    __gm__ void *oi_fifo_base = reinterpret_cast<__gm__ void *>(
+        reinterpret_cast<__gm__ uint8_t *>(oi_fifo_t->buffer.addr) + hw_block_idx * OI_HW_STRIDE
+    );
+
+    if constexpr (DAV_CUBE) {
+        if (q_tile == 16) {
+            run_aic<PAConfig<16>>(
+                args, ctx_ptr, hw_block_idx, hw_block_num, total_logical_blocks, num_heads, head_dim, block_size,
+                max_blocks_per_req, q_loop, sij_fifo_base, pij_fifo_base, oi_fifo_base
+            );
+        } else {
+            run_aic<PAConfig<MAX_Q_TILE>>(
+                args, ctx_ptr, hw_block_idx, hw_block_num, total_logical_blocks, num_heads, head_dim, block_size,
+                max_blocks_per_req, q_loop, sij_fifo_base, pij_fifo_base, oi_fifo_base
+            );
+        }
+    }
+
+    if constexpr (DAV_VEC) {
+        if (q_tile == 16) {
+            run_aiv<PAConfig<16>>(
+                args, ctx_ptr, hw_block_idx, hw_block_num, total_logical_blocks, num_heads, head_dim, block_size,
+                q_loop, sij_fifo_base, pij_fifo_base, oi_fifo_base
+            );
+        } else {
+            run_aiv<PAConfig<MAX_Q_TILE>>(
+                args, ctx_ptr, hw_block_idx, hw_block_num, total_logical_blocks, num_heads, head_dim, block_size,
+                q_loop, sij_fifo_base, pij_fifo_base, oi_fifo_base
+            );
+        }
+    }
+}
+// NOLINTEND(clang-diagnostic-error,bugprone-reserved-identifier,bugprone-easily-swappable-parameters,modernize-use-auto)

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * SPMD Paged Attention Orchestration with TPUSH/TPOP (fixed block_num=24)
+ *
+ * Submits a single MixedKernels task with hardware block_num fixed at 24.
+ * total_logical_blocks = batch * q_loop logical work items are distributed
+ * across the 24 hardware blocks via a stride loop inside the kernel:
+ *   for (block_idx = hw_block_idx; block_idx < total_logical_blocks; block_idx += 24)
+ *
+ * q_tile adapts to num_heads at runtime: q_tile = min(num_heads, MAX_Q_TILE).
+ * When num_heads <= MAX_Q_TILE (=64), q_loop = 1 and each block processes all heads.
+ *
+ * Each iteration of the stride loop processes one (batch_idx, q_tile_idx) logical
+ * position, running the full AIC/AIV cooperative pipeline via TPUSH/TPOP pipes:
+ *   AIC: QK matmul -> TPUSH(sij) -> TPOP(pij) -> PV matmul -> TPUSH(oi_new)
+ *   AIV: TPOP(sij) -> online softmax -> TPUSH(pij) -> TPOP(oi_new) -> online update
+ *
+ * GM FIFO buffers for TPUSH/TPOP are sized for the 24 hardware blocks (not for
+ * total_logical_blocks). Each hardware block owns its own FIFO slots and reuses
+ * them across stride-loop iterations.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <cinttypes>
+
+#include "pto_orchestration_api.h"
+
+#define FUNC_PA_AIC 0
+#define FUNC_PA_AIV 1
+
+static constexpr uint64_t MAX_Q_TILE = 64;
+static constexpr uint64_t HEAD_DIM = 128;
+static constexpr uint64_t MAX_BLOCK_SIZE = 128;
+static constexpr int16_t SPMD_BLOCK_NUM = 24;
+
+// GM FIFO slot sizes (must match kernel's PAConfig<MAX_Q_TILE> constants).
+// Sized for the maximum (q_tile, block_size) so the same FIFO layout works
+// for both q_tile=16 and q_tile=64 dispatch paths inside the kernel.
+static constexpr uint32_t SIJ_SLOT_SIZE = MAX_Q_TILE * MAX_BLOCK_SIZE * sizeof(float);
+static constexpr uint32_t PIJ_SLOT_SIZE = MAX_Q_TILE * MAX_BLOCK_SIZE * sizeof(uint16_t);
+static constexpr uint32_t OI_SLOT_SIZE = MAX_Q_TILE * HEAD_DIM * sizeof(float);
+static constexpr uint32_t FIFO_DEPTH = 2;
+
+static inline void set_block_count(CoreTaskArgs &args, int16_t n) {
+#if defined(SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_TYPES_H_)
+    args.launch_spec.set_core_num(n);
+#else
+    args.launch_spec.set_block_num(n);
+#endif
+}
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 7,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
+    uint64_t batch = orch_args.tensor(0).ref().shapes[0];
+    uint64_t num_heads = orch_args.tensor(0).ref().shapes[1];
+    uint64_t head_dim = orch_args.tensor(0).ref().shapes[2];
+    DataType data_type = orch_args.tensor(0).ref().dtype;
+
+    uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
+    uint64_t max_num_blocks_per_req = orch_args.tensor(3).ref().shapes[1];
+    uint64_t scale_value = orch_args.scalar(0);
+
+    uint64_t q_tile = (num_heads < MAX_Q_TILE) ? num_heads : MAX_Q_TILE;
+    if ((q_tile != 16 && q_tile != MAX_Q_TILE) || num_heads % q_tile != 0) {
+        LOG_ERROR("SPMD PA: num_heads=%" PRIu64 " requires q_tile 16 or 64 and an exact tile multiple", num_heads);
+        return;
+    }
+    if (head_dim != HEAD_DIM) {
+        LOG_ERROR("SPMD PA: head_dim=%" PRIu64 " is unsupported; expected %" PRIu64, head_dim, HEAD_DIM);
+        return;
+    }
+    if (block_size != 64 && block_size != MAX_BLOCK_SIZE) {
+        LOG_ERROR("SPMD PA: block_size=%" PRIu64 " is unsupported; expected 64 or 128", block_size);
+        return;
+    }
+    uint64_t q_loop = (num_heads + q_tile - 1) / q_tile;
+    int64_t total_logical_blocks = static_cast<int64_t>(batch * q_loop);
+
+    LOG_INFO(
+        "SPMD PA TPUSH/TPOP: batch=%" PRIu64 " heads=%" PRIu64 " hd=%" PRIu64 " bs=%" PRIu64 " q_tile=%" PRIu64
+        " q_loop=%" PRIu64 " hw_blocks=%d logical_blocks=%" PRId64,
+        batch, num_heads, head_dim, block_size, q_tile, q_loop, SPMD_BLOCK_NUM, total_logical_blocks
+    );
+
+    // Wrap host tensors
+    void *query_ptr = orch_args.tensor(0).ref().data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).ref().data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).ref().data_as<void>();
+    void *out_ptr = orch_args.tensor(5).ref().data_as<void>();
+
+    uint64_t total_kv_blocks = orch_args.tensor(1).ref().shapes[0];
+    uint64_t kv_total_rows = total_kv_blocks * block_size;
+
+    uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
+    uint32_t kv_shapes[2] = {static_cast<uint32_t>(kv_total_rows), static_cast<uint32_t>(head_dim)};
+    uint32_t out_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
+
+    ChipTensor query = make_tensor_external(query_ptr, query_shapes, 2, data_type);
+    ChipTensor key_cache = make_tensor_external(kc_ptr, kv_shapes, 2, data_type);
+    ChipTensor value_cache = make_tensor_external(vc_ptr, kv_shapes, 2, data_type);
+    ChipTensor out = make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
+
+    uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(max_num_blocks_per_req)};
+    ChipTensor block_table =
+        make_tensor_external(orch_args.tensor(3).ref().data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+    uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
+    ChipTensor context_lens =
+        make_tensor_external(orch_args.tensor(4).ref().data_as<void>(), cl_shapes, 1, DataType::INT32, false);
+
+    // GM FIFO buffers for TPUSH/TPOP (one set of slots per hardware block)
+    uint32_t sij_fifo_total = static_cast<uint32_t>(SPMD_BLOCK_NUM) * SIJ_SLOT_SIZE * FIFO_DEPTH;
+    uint32_t pij_fifo_total = static_cast<uint32_t>(SPMD_BLOCK_NUM) * PIJ_SLOT_SIZE * FIFO_DEPTH;
+    uint32_t oi_fifo_total = static_cast<uint32_t>(SPMD_BLOCK_NUM) * OI_SLOT_SIZE * FIFO_DEPTH;
+
+    // Allocate as 1D byte tensors (using INT32 for 4-byte alignment, divide by 4)
+    uint32_t sij_fifo_shapes[1] = {sij_fifo_total / sizeof(int32_t)};
+    uint32_t pij_fifo_shapes[1] = {pij_fifo_total / sizeof(int32_t)};
+    uint32_t oi_fifo_shapes[1] = {oi_fifo_total / sizeof(int32_t)};
+
+    TensorCreateInfo sij_fifo_ci(sij_fifo_shapes, 1, DataType::INT32);
+    TensorCreateInfo pij_fifo_ci(pij_fifo_shapes, 1, DataType::INT32);
+    TensorCreateInfo oi_fifo_ci(oi_fifo_shapes, 1, DataType::INT32);
+
+    PTO2_SCOPE() {
+        CoreTaskArgs args;
+        args.add_input(query);
+        args.add_input(key_cache);
+        args.add_input(value_cache);
+        args.add_input(block_table);
+        args.add_input(context_lens);
+        args.add_inout(out);
+        args.add_output(sij_fifo_ci);
+        args.add_output(pij_fifo_ci);
+        args.add_output(oi_fifo_ci);
+        args.add_scalar(scale_value);
+        args.add_scalar(static_cast<int64_t>(num_heads));
+        args.add_scalar(static_cast<int64_t>(head_dim));
+        args.add_scalar(static_cast<int64_t>(block_size));
+        args.add_scalar(static_cast<int64_t>(max_num_blocks_per_req));
+        args.add_scalar(static_cast<int64_t>(q_loop));
+        args.add_scalar(total_logical_blocks);
+        args.add_scalar(static_cast<int64_t>(q_tile));
+        set_block_count(args, SPMD_BLOCK_NUM);
+
+        MixedKernels mk;
+        mk.aic_kernel_id = FUNC_PA_AIC;
+        mk.aiv0_kernel_id = FUNC_PA_AIV;
+        mk.aiv1_kernel_id = FUNC_PA_AIV;
+        rt_submit_task(mk, args);
+    }
+
+    LOG_INFO(
+        "SPMD PA TPUSH/TPOP: submitted 1 MixedKernels task, hw_blocks=%d logical=%" PRId64,
+        static_cast<int>(SPMD_BLOCK_NUM), total_logical_blocks
+    );
+}
+
+}  // extern "C"

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""A5 port of the benchmark SPMD paged-attention MIX workload."""
+
+from pathlib import Path
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+from simpler_setup.goldens.paged_attention import compute_golden as _pa_compute_golden
+from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generate_inputs
+
+CASE_DIR = Path(__file__).resolve().parent
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestSpmdPagedAttentionA5(SceneTestCase):
+    RTOL = 1e-2
+    ATOL = 1e-2
+
+    CALLABLE = {
+        "orchestration": {
+            "source": str(CASE_DIR / "kernels/orchestration/spmd_paged_attention_orch.cpp"),
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.IN, D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "PA_AIC",
+                "source": str(CASE_DIR / "kernels/mix/paged_attention_parallel.cpp"),
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.IN, D.IN, D.IN, D.INOUT, D.OUT, D.OUT, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "name": "PA_AIV",
+                "source": str(CASE_DIR / "kernels/mix/paged_attention_parallel.cpp"),
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.IN, D.IN, D.IN, D.INOUT, D.OUT, D.OUT, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "TwoWayOneBlockZeroQuery",
+            "platforms": ["a5sim", "a5"],
+            "manual": True,
+            "params": {
+                "batch": 2,
+                "num_heads": 16,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 128,
+                "context_len": 128,
+                "max_model_len": 256,
+                "dtype": "bfloat16",
+            },
+        },
+    ]
+
+    def generate_args(self, params):
+        specs = []
+        for name, value in _pa_generate_inputs(params):
+            if name == "query":
+                value.zero_()
+            specs.append(TensorArg(name, value) if isinstance(value, torch.Tensor) else Scalar(name, value))
+        return TaskArgsBuilder(*specs)
+
+    def compute_golden(self, args, params):
+        tensors = {s.name: s.value for s in args.specs if isinstance(s, TensorArg)}
+        _pa_compute_golden(tensors, params)
+        for spec in args.specs:
+            if isinstance(spec, TensorArg) and spec.name in tensors:
+                getattr(args, spec.name)[:] = tensors[spec.name]
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)


### PR DESCRIPTION
## Summary

- add an A5-specific SPMD paged-attention port
- add manual coverage for A2/A3 HBG and A5 TMR/HBG
- keep the original A2/A3 TMR case unchanged
- keep the benchmark disablement unchanged

All newly added cases are manual because A5 currently only passes the small zero-query flow. Larger multi-block workloads stall, and random-query workloads still have numerical mismatches.

Tracks #1816.