### PR TITLE
Fix: honor ASCEND_RT_VISIBLE_DEVICES at comm_hccl MemSetAccess sites

### DIFF
--- a/src/a2a3/platform/onboard/host/comm_hccl.cpp
+++ b/src/a2a3/platform/onboard/host/comm_hccl.cpp
@@ -24,6 +24,7 @@
 #include "platform_comm/comm_context.h"
 #include "pto_runtime_c_api.h"
 
+#include "common/acl_hal_device.h"
 #include "common/unified_log.h"
 #include "host/file_marker_handshake.h"
 
@@ -268,10 +269,14 @@ static aclError reserve_and_map_vmm_window(
         return status;
     }
 
+    // aclrtMemAccessDesc::location.id is consumed in the driver-visible space, unlike
+    // aclrtPhysicalMemProp::location.id above, which takes the ACL-logical id. Under
+    // ASCEND_RT_VISIBLE_DEVICES the logical id here names the wrong card and aclrtMemSetAccess
+    // fails with 507899 (ACL_ERROR_RT_DRV_INTERNAL_ERROR). See common/acl_hal_device.h.
     aclrtMemAccessDesc access_desc{};
     access_desc.flags = ACL_RT_MEM_ACCESS_FLAGS_READWRITE;
     access_desc.location.type = ACL_MEM_LOCATION_TYPE_DEVICE;
-    access_desc.location.id = static_cast<uint32_t>(device_id);
+    access_desc.location.id = static_cast<uint32_t>(pto::acl_to_hal_device_id(device_id));
     status = aclrtMemSetAccess(base, size, &access_desc, 1);
     if (status != ACL_SUCCESS) {
         aclrtUnmapMem(base);

--- a/src/a2a3/platform/onboard/host/comm_hccl.cpp
+++ b/src/a2a3/platform/onboard/host/comm_hccl.cpp
@@ -270,8 +270,8 @@ static aclError reserve_and_map_vmm_window(
     }
 
     // aclrtMemAccessDesc::location.id is consumed in the driver-visible space, unlike
-    // aclrtPhysicalMemProp::location.id above, which takes the ACL-logical id. Under
-    // ASCEND_RT_VISIBLE_DEVICES the logical id here names the wrong card and aclrtMemSetAccess
+    // aclrtPhysicalMemProp::location.id in its caller create_local_vmm_window, which takes the ACL-logical
+    // id. Under ASCEND_RT_VISIBLE_DEVICES the logical id here names the wrong card and aclrtMemSetAccess
     // fails with 507899 (ACL_ERROR_RT_DRV_INTERNAL_ERROR). See common/acl_hal_device.h.
     aclrtMemAccessDesc access_desc{};
     access_desc.flags = ACL_RT_MEM_ACCESS_FLAGS_READWRITE;

--- a/src/a5/platform/onboard/host/comm_hccl.cpp
+++ b/src/a5/platform/onboard/host/comm_hccl.cpp
@@ -25,6 +25,7 @@
 #include "platform_comm/comm.h"
 #include "platform_comm/comm_context.h"
 
+#include "common/acl_hal_device.h"
 #include "common/unified_log.h"
 #include "host/file_marker_handshake.h"
 
@@ -488,10 +489,15 @@ static int alloc_windows_via_ipc(CommHandle h, uint64_t win_size) {
         aclrtFreePhysical(handle);
         return -1;
     }
+    // aclrtMemAccessDesc::location.id is consumed in the driver-visible space, unlike
+    // aclrtPhysicalMemProp::location.id above, which takes the ACL-logical id. Under
+    // ASCEND_RT_VISIBLE_DEVICES the logical id here names the wrong card and aclrtMemSetAccess
+    // fails with 507899 (ACL_ERROR_RT_DRV_INTERNAL_ERROR). See common/acl_hal_device.h. The same
+    // descriptor is reused for the peer mappings below, so it carries the translation with it.
     aclrtMemAccessDesc accessDesc{};
     accessDesc.flags = ACL_RT_MEM_ACCESS_FLAGS_READWRITE;
     accessDesc.location.type = ACL_MEM_LOCATION_TYPE_DEVICE;
-    accessDesc.location.id = static_cast<uint32_t>(myDevice);
+    accessDesc.location.id = static_cast<uint32_t>(pto::acl_to_hal_device_id(myDevice));
     aret = aclrtMemSetAccess(localBuf, aligned_size, &accessDesc, 1);
     if (aret != ACL_SUCCESS) {
         LOG_ERROR("[comm rank %d] ipc: MemSetAccess -> %d", rank, static_cast<int>(aret));
@@ -896,10 +902,11 @@ static int domain_alloc_via_ipc(
         aclrtFreePhysical(handle);
         return -1;
     }
+    // Driver-visible id, as in alloc_windows_via_ipc above; the peer mappings reuse this descriptor.
     aclrtMemAccessDesc accessDesc{};
     accessDesc.flags = ACL_RT_MEM_ACCESS_FLAGS_READWRITE;
     accessDesc.location.type = ACL_MEM_LOCATION_TYPE_DEVICE;
-    accessDesc.location.id = static_cast<uint32_t>(myDevice);
+    accessDesc.location.id = static_cast<uint32_t>(pto::acl_to_hal_device_id(myDevice));
     aret = aclrtMemSetAccess(localBuf, aligned_size, &accessDesc, 1);
     if (aret != ACL_SUCCESS) {
         LOG_ERROR("[comm rank %d] alloc_domain: MemSetAccess -> %d", h->rank, static_cast<int>(aret));

--- a/src/common/platform/include/common/acl_hal_device.h
+++ b/src/common/platform/include/common/acl_hal_device.h
@@ -33,6 +33,16 @@ namespace pto {
  *     function: `hal_fn(acl_to_hal_device_id(device_id))`.
  *   - ACL/rt entry points (`aclrtSetDevice`, `rtMalloc`, `rtMemcpy`, stream
  *     APIs, ...) take the logical id and MUST NOT.
+ *   - One ACL exception, measured on CANN 9.0.0 / a2a3:
+ *     `aclrtMemAccessDesc::location.id` reaches the driver untranslated and MUST
+ *     translate, even though `aclrtMemSetAccess` is an ACL entry point. Its
+ *     sibling `aclrtPhysicalMemProp::location.id` does NOT — `aclrtMallocPhysical`
+ *     rejects a driver-visible id with 107001. Under isolation, binding logical
+ *     0 of `ASCEND_RT_VISIBLE_DEVICES=1,2`:
+ *       aclrtMallocPhysical  prop.location.id=0 -> 0        prop.location.id=2 -> 107001
+ *       aclrtMemSetAccess    desc.location.id=0 -> 507899   desc.location.id=1 -> 0
+ *     The asymmetry is per-field, not per-API, so neither half generalises to the
+ *     other.
  *
  * `ASCEND_RT_VISIBLE_DEVICES` renumbers the logical space to `0..N-1` while the
  * HAL keeps indexing the driver-visible space; a direct HAL call made with the

--- a/src/common/platform/include/common/acl_hal_device.h
+++ b/src/common/platform/include/common/acl_hal_device.h
@@ -36,11 +36,27 @@ namespace pto {
  *   - One ACL exception, measured on CANN 9.0.0 / a2a3:
  *     `aclrtMemAccessDesc::location.id` reaches the driver untranslated and MUST
  *     translate, even though `aclrtMemSetAccess` is an ACL entry point. Its
- *     sibling `aclrtPhysicalMemProp::location.id` does NOT — `aclrtMallocPhysical`
- *     rejects a driver-visible id with 107001. Under isolation, binding logical
- *     0 of `ASCEND_RT_VISIBLE_DEVICES=1,2`:
- *       aclrtMallocPhysical  prop.location.id=0 -> 0        prop.location.id=2 -> 107001
- *       aclrtMemSetAccess    desc.location.id=0 -> 507899   desc.location.id=1 -> 0
+ *     sibling `aclrtPhysicalMemProp::location.id` MUST NOT: it is read in the
+ *     logical space, and must in fact name the *bound* logical device.
+ *
+ *     Measured under `ASCEND_RT_VISIBLE_DEVICES=2,3` bound to logical 0 (card 2).
+ *     The grant matters: the translated id of the bound device (2) has to fall
+ *     outside the logical range `[0,1]`, or the same value is legal in both
+ *     spaces and no outcome can tell them apart.
+ *
+ *       aclrtMallocPhysical  prop.location.id=0 (bound logical) -> 0        2 GiB appears on card 2
+ *                            prop.location.id=2 (translated)    -> 107001   ACL_ERROR_RT_INVALID_DEVICEID
+ *                            prop.location.id=1 (other logical) -> 507899
+ *       aclrtMemSetAccess    desc.location.id=0 (logical)        -> 507899
+ *                            desc.location.id=2 (translated)     -> 0        OK
+ *
+ *     The 107001 row is what settles the field's space: under a driver-visible
+ *     reading, 2 *is* the bound card and the call would have succeeded.
+ *     `aclrtMemGetAllocationGranularity` rejects it identically, so the check is
+ *     not specific to the allocation call. A symmetric "fix" of the memory
+ *     property therefore fails loudly rather than silently allocating elsewhere —
+ *     107001 for the translated id, 507899 for any other logical id.
+ *
  *     The asymmetry is per-field, not per-API, so neither half generalises to the
  *     other.
  *

--- a/tests/st/vis_isolation/test_vis_isolation.py
+++ b/tests/st/vis_isolation/test_vis_isolation.py
@@ -24,6 +24,13 @@ the wrong device and fails with ``halMemCtl rc=42`` in
 onboard chip bring-up, so *any* scene test launched under the variable covers
 all of those call sites. ``dummy_task`` is the cheapest one.
 
+Allocating a comm domain crosses a second, independent device-id layer that chip
+init never reaches, so it gets its own case: ``aclrtMemAccessDesc::location.id``
+is consumed in the driver-visible space even though ``aclrtMemSetAccess`` is an
+ACL entry point, and a logical id there fails with 507899. Its sibling
+``aclrtPhysicalMemProp::location.id`` is logical, so the two must not be treated
+alike — see ``common/acl_hal_device.h``.
+
 The scene test runs in a subprocess: the variable has to be set before the
 process performing ACL init starts, and mutating it in-process would leak into
 the pooled workers the rest of the session shares.
@@ -46,8 +53,29 @@ _DUMMY_TASK = {
     "a5": _ST_ROOT / "a5" / RUNTIME / "dummy_task" / "test_dummy_task.py",
 }
 
+# A comm domain maps device memory, which is a second device-id layer the chip-init path never
+# reaches: `aclrtMemAccessDesc::location.id` is consumed in the driver-visible space, so a logical id
+# there fails with 507899 on every card pair except an identity mapping. Both ranks take part, so
+# this one runs on all the granted cards rather than a single logical id.
+_COMM_DOMAIN = _ST_ROOT / "worker" / "comm_domain" / "async_notify" / "test_async_notify.py"
+
 # The subprocess re-runs a full scene test (build cache hit + one chip bring-up).
 _TIMEOUT_S = 600
+
+
+def _remapped_visible(st_device_ids):
+    """Return the granted cards as an ascending list, skipping if they map to themselves.
+
+    The list must be ascending: CANN rejects any other order outright
+    (`Runtime::GetVisibleDevices`, RT_ALL_ORDER_ERROR), which voids the whole mapping and makes even
+    rtSetDevice fail with 107001. Position i is logical id i, so a card whose id differs from its
+    position is what makes a translation observable — under an identity grant both id spaces hold
+    the same number and the test would pass without proving anything.
+    """
+    visible = sorted(int(d) for d in st_device_ids)
+    if all(card == i for i, card in enumerate(visible)):
+        pytest.skip(f"granted cards {visible} map to themselves; no remap to verify")
+    return visible
 
 
 @pytest.mark.platforms(["a2a3", "a5"])
@@ -58,18 +86,8 @@ def test_chip_init_under_visible_devices(st_platform, st_device_ids):
     scene_test = _DUMMY_TASK[st_platform]
     assert scene_test.is_file(), f"missing scene test: {scene_test}"
 
-    # The list must be ascending: CANN rejects any other order outright
-    # (`Runtime::GetVisibleDevices`, RT_ALL_ORDER_ERROR), which voids the whole
-    # mapping and makes even rtSetDevice fail with 107001.
-    visible = sorted(int(d) for d in st_device_ids)
-
-    # Position i in the list is logical id i, so a card whose id differs from
-    # its position is what makes the translation observable. Addressing one
-    # where they coincide would pass under the identity mapping this test
-    # exists to reject.
-    logical = next((i for i, card in enumerate(visible) if card != i), None)
-    if logical is None:
-        pytest.skip(f"granted cards {visible} map to themselves; no remap to verify")
+    visible = _remapped_visible(st_device_ids)
+    logical = next(i for i, card in enumerate(visible) if card != i)
     expected = visible[logical]
 
     env = {**os.environ, "ASCEND_RT_VISIBLE_DEVICES": ",".join(str(d) for d in visible)}
@@ -87,4 +105,35 @@ def test_chip_init_under_visible_devices(st_platform, st_device_ids):
     assert proc.returncode == 0, (
         f"dummy_task failed under ASCEND_RT_VISIBLE_DEVICES={env['ASCEND_RT_VISIBLE_DEVICES']} "
         f"(logical {logical} -> driver-visible {expected}), rc={proc.returncode}"
+    )
+
+
+@pytest.mark.platforms(["a2a3", "a5"])
+@pytest.mark.device_count(2)
+@pytest.mark.runtime(RUNTIME)
+def test_comm_domain_under_visible_devices(st_platform, st_device_ids):
+    """A comm domain allocates and maps its windows when the cards are renumbered."""
+    assert _COMM_DOMAIN.is_file(), f"missing scene test: {_COMM_DOMAIN}"
+
+    visible = _remapped_visible(st_device_ids)
+    # Every rank participates, and under isolation the ranks are logical 0..N-1 whatever the
+    # granted cards are.
+    logical = ",".join(str(i) for i in range(len(visible)))
+
+    env = {**os.environ, "ASCEND_RT_VISIBLE_DEVICES": ",".join(str(d) for d in visible)}
+    proc = subprocess.run(
+        [sys.executable, str(_COMM_DOMAIN), "-p", st_platform, "-d", logical],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=_TIMEOUT_S,
+        check=False,
+    )
+    if proc.returncode != 0:
+        print(proc.stdout, file=sys.stderr)
+    assert proc.returncode == 0, (
+        f"comm_domain/async_notify failed under "
+        f"ASCEND_RT_VISIBLE_DEVICES={env['ASCEND_RT_VISIBLE_DEVICES']} "
+        f"(logical {logical} -> driver-visible {visible}), rc={proc.returncode}"
     )


### PR DESCRIPTION
## Problem

Under `ASCEND_RT_VISIBLE_DEVICES` isolation, `comm_alloc_domain_windows` fails on every card pair except an identity mapping:

```
domain_alloc_via_fabric: [comm_hccl.cpp:1165] [comm rank 0] alloc_domain: create local Fabric window -> 507899
```

`507899` is `ACL_ERROR_RT_DRV_INTERNAL_ERROR` — the driver was handed a device id in a numbering it does not use. Cards `0,1` hide it because there logical == physical, which is also why serving has never hit it: DeepSeek V4 takes all 8 cards.

This is the class #1600 fixed, at a site it did not cover — neither arch's `comm_hccl.cpp` included `common/acl_hal_device.h`.

## Root cause — the two `location.id` fields want different id spaces

`aclrtMemAccessDesc::location.id` is consumed in the driver-visible space and must translate, even though `aclrtMemSetAccess` is an ACL entry point. Its sibling `aclrtPhysicalMemProp::location.id` must **not** — `aclrtMallocPhysical` rejects a driver-visible id outright.

Measured by walking the window sequence one call at a time, in one process. The grant matters: the translated id of the bound device has to fall outside the logical range, or the same value is legal in both spaces and no outcome can tell them apart — an earlier revision of this section probed `1,2`, where it cannot. Under `ASCEND_RT_VISIBLE_DEVICES=2,3` bound to logical `0` (= card 2), logical space `[0,1]`:

```
aclrtMemGetAllocationGranularity  prop.location.id=0 (bound logical) -> 0        OK
aclrtMallocPhysical               prop.location.id=0 (bound logical) -> 0        OK, 2 GiB appears on card 2
aclrtMemGetAllocationGranularity  prop.location.id=2 (translated)    -> 107001   rejected
aclrtMallocPhysical               prop.location.id=2 (translated)    -> 107001   rejected
aclrtMallocPhysical               prop.location.id=1 (other logical) -> 507899   rejected
aclrtReserveMemAddress                                               -> 0        OK
aclrtMapMem                                                          -> 0        OK
aclrtMemSetAccess                 desc.location.id=0 (logical)       -> 507899   FAILS
aclrtMemSetAccess                 desc.location.id=2 (translated)    -> 0        OK
```

`107001` is `ACL_ERROR_RT_INVALID_DEVICEID`, and that row is what fixes the field's id space: under a driver-visible reading, `2` *is* the bound card and the call would have succeeded. The card the memory lands on was read off npu-smi's HBM column during a 2 GiB hold, not inferred.

With the variable unset and the card bound directly, the whole sequence completes — measured on card 1 when this was first traced, and identical for `ACL_HBM_MEM_HUGE` (fabric) and `ACL_HBM_MEM_NORMAL` (ipc). Today's re-measurement above covers `ACL_HBM_MEM_HUGE` only; the id spaces are a property of the fields, not of `memAttr`.

The asymmetry is **per-field, not per-API**, so `acl_hal_device.h` now records both halves. A symmetric "fix" of the memory property fails loudly rather than silently allocating elsewhere — `107001` for the translated id, `507899` for any other logical id — because the field must name the *bound* logical device, not merely a logical one.

## Change

Three sites carry the id into `aclrtMemSetAccess`:

- a2a3 `reserve_and_map_vmm_window` — the funnel for every local and imported window, fabric and IPC
- a5 `alloc_windows_via_ipc` and `domain_alloc_via_ipc` — their descriptors are reused for the peer mappings, so the translation rides along

No CMake change: both onboard host targets already carry `src/common/platform/include`.

## Test

`tests/st/vis_isolation` gains a comm-domain case next to the chip-init one, so both device-id layers live in one module. Chip init never maps device memory, so it cannot catch this. The new case runs on all granted cards rather than a single logical id, and reuses the existing ascending-list rule and skip-on-identity guard — under an identity grant the two id spaces hold the same number and the test would pass without proving anything.

## Verification

**a2a3, on 910B2** — A/B on the same granted cards in the same job, only the runtime differing:

| Cards | Mapping | Stock | This change |
|---|---|---|---|
| visible `1,2`, logical 0,1 | non-identity | both ranks abort, `create local Fabric window -> 507899` | both complete byte-exact |
| visible `0,1`, logical 0,1 | identity | passes | passes (no regression) |

The identity case matters: the broker hands out the lowest free cards, so a two-card request usually lands on exactly the mapping that proves nothing.

**a5** — no a5 hardware available to me; it rides on `_st-npu-a5.yml`. The change there is the same pattern as a2a3, applied to the two inlined copies.

## Related, not fixed here

The peer-access-status confusion already recorded in comments at a5 `comm_hccl.cpp:553-561` and `:972-977` (#1018) is the same id-space split at a different call (`aclrtDevicePeerAccessStatus` / `aclrtDeviceEnablePeerAccess` take a *peer* id). Left untouched rather than widening this diff.

