### PR TITLE
Fix: close level-4 chip swimlane follow-ups

### DIFF
--- a/.github/workflows/_st-sim-a2a3.yml
+++ b/.github/workflows/_st-sim-a2a3.yml
@@ -120,6 +120,13 @@ jobs:
             --require-pto-isa --manual "${{ inputs.manual_mode == 'only' && 'only' || 'include' }}" \
             --enable-chip-swimlane --enable-dep-gen
 
+      - name: chip_swimlane smoke (a2a3 host_build_graph)
+        if: inputs.include_dfx_smokes
+        run: |
+          .venv/bin/python -m pytest tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution.py \
+            --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
+            --require-pto-isa --enable-chip-swimlane --case record_then_replay_2d
+
       - name: PMU smoke (a2a3)
         if: inputs.include_dfx_smokes
         run: |

--- a/.github/workflows/_st-sim-a5.yml
+++ b/.github/workflows/_st-sim-a5.yml
@@ -113,6 +113,13 @@ jobs:
             --require-pto-isa --manual "${{ inputs.manual_mode == 'only' && 'only' || 'include' }}" \
             --enable-chip-swimlane --enable-dep-gen
 
+      - name: chip_swimlane smoke (a5 host_build_graph)
+        if: inputs.include_dfx_smokes
+        run: |
+          .venv/bin/python -m pytest tests/st/a5/host_build_graph/graph_execution/test_graph_execution.py \
+            --platform a5sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
+            --require-pto-isa --enable-chip-swimlane --case record_then_replay_2d
+
       - name: PMU smoke (a5)
         if: inputs.include_dfx_smokes
         run: |

--- a/docs/dfx/chip-swimlane-profiling.md
+++ b/docs/dfx/chip-swimlane-profiling.md
@@ -104,7 +104,7 @@ backward-compatible with the old boolean behavior).
 | 1 | AICore timing only (start_time_us/end_time_us/task_id/func_id/core_type) | No AICPU timestamps |
 | 2 | + dispatch_time_us, finish_time_us | Full per-task AICPU record |
 | 3 | + scheduler phases (`aicpu_scheduler_phases[]`) | Skips orchestrator phases |
-| 4 | + orchestrator phases (`aicpu_orchestrator_phases[]`) | Full collection |
+| 4 | + orchestrator phases | `tensormap_and_ringbuffer` (TMR) captures AICPU phases; `host_build_graph` (HBG) captures host phases and aligns them with the device clock |
 
 Dependency arrows are not produced by any swimlane level — see
 [§3.5](#35-dependency-arrows-from-dep_gen) for the dep_gen join.
@@ -133,7 +133,9 @@ region and publishes its base address through
 per-task WIP slots; AICPU commits the records on FIN. Per-task
 dispatch/finish timestamps are recorded only at level >= 2,
 scheduler phase records only at level >= 3, and orchestrator phase
-records only at level >= 4.
+records only at level >= 4. `tensormap_and_ringbuffer` records those
+orchestrator phases on AICPU; `host_build_graph` records them on the host
+and emits clock-correlation anchors around device execution.
 
 The JSON output `"chip_swimlane_level"` field is the captured perf_level:
 `1` = AICore timing only, `2` = +AICPU dispatch/finish,
@@ -186,34 +188,100 @@ layers to be aware of:**
     "clock_freq_hz": <int>,            // cycle→µs factor. a2a3=50e6, a5=1e9.
     "num_cores": <int>,                // == len(core_types)
     "core_types": ["aic"|"aiv", ...],  // indexed by core_id
-    "core_to_thread": [<int>, ...]     // optional; level >= 3 only
+    "core_to_thread": [<int>, ...],    // optional; level >= 3 only
+
+    // HBG level 4 only. The host-capture and correlation objects remain
+    // present on partial/failing captures so readers can fail closed.
+    "orchestrator_source": "host",
+    "orchestrator_clock_domain": "host_monotonic_ns",
+    "device_clock_domain": "device_syscnt_cycles",
+    "host_timestamp_resolution_ns": <int>,
+    "host_timestamp_quantization_ns": <int>,
+    "host_orchestration_origin_ns": <int>,
+    "timeline_relation": "host_orchestration_precedes_device",
+    "host_capture": {
+      "status": "complete"|"dropped"|"incomplete",
+      "expected_records": <int>,
+      "recorded_records": <int>,
+      "pool_records": <int>,
+      "dropped_records": <int>,
+      "error": null|<string>
+    },
+    "clock_anchors": {
+      "schema_version": 1,
+      "provider": "acl_event"|"sim_syscnt"|"unavailable",
+      "device_timestamp_unit": "syscnt_cycles",
+      "raw_device_timestamp_unit": "device_uptime_us"|"syscnt_cycles"|"unknown",
+      "samples_per_position": 3,
+      "samples": [{...}, ...]
+    }
   },
 
   // Bulk task streams — flat array of tuples. Column order is fixed.
   //   aicore_tasks: [core_id, task_token_raw, reg_task_id,
-  //                  start_cycles, end_cycles]
+  //                  start_cycles, end_cycles, receive_to_start_cycles]
   //   aicpu_tasks:  [core_id, reg_task_id,
   //                  dispatch_cycles, finish_cycles]
   "aicore_tasks": [[...], ...],
   "aicpu_tasks":  [[...], ...],
 
-  // Per-scheduler-thread arrays of objects (level >= 3 only).
+  // Per-lane arrays of objects (level >= 3 only).
   //   sched record: {kind, start_cycles, end_cycles, loop_iter,
   //                  tasks_processed, [pop_hit, pop_miss]}
-  //   orch record:  {submit_idx, task_id, start_cycles, end_cycles}
+  //   AICPU orch record: {submit_idx, task_id, start_cycles, end_cycles}
+  //   host orch record:  {submit_idx, task_id, start_host_ns, end_host_ns}
   // pop_hit / pop_miss are present only on Dispatch records.
   "aicpu_scheduler_phases":    [ [ {...}, ... ], ... ],
-  "aicpu_orchestrator_phases": [ [ {...}, ... ], ... ]   // level >= 4 only
+  "aicpu_orchestrator_phases": [ [ {...}, ... ], ... ],  // TMR level >= 4
+  "host_orchestrator_phases":  [ [ {...}, ... ] ]         // HBG single host lane, level >= 4
 }
 ```
 
-All timestamps on disk are raw `get_sys_cnt` cycles (uint64). The
+Task, scheduler, and TMR orchestrator timestamps on disk are raw
+`get_sys_cnt` cycles (uint64). HBG orchestrator timestamps are host monotonic
+nanoseconds; the reader maps device cycles into that domain only when the
+anchor coverage is complete. The
 join key between `aicore_tasks` and `aicpu_tasks` is
 `(core_id, reg_task_id)` — *not* `task_token_raw`, because SPMD
 `block_num > num_cores` and MIX cluster spread can dispatch the same
 `task_token_raw` to the same core multiple times. AICore is the
 canonical producer of `task_token_raw`; AICPU only stamps the
 dispatch / finish timestamps and the per-core join token.
+
+The exporter writes a file when any diagnostic stream is useful: task records,
+scheduler/orchestrator phases, host records, or a started clock-correlation
+session. A sched-only TMR capture and a metadata-only failed HBG capture are
+therefore valid artifacts. A run with none of those streams still returns
+without creating a file.
+
+On onboard platforms, `aclrtEventGetTimestamp` supplies device-uptime
+microseconds. Both platform configurations declare that 1 MHz source and the
+profiling system-counter frequency used to normalize it (50 MHz on a2a3,
+1 GHz on a5). The same-epoch contract is checked at conversion time: all device
+timestamps must fall between the selected pre-orchestration and post-execution
+anchors. Missing, invalid, or non-covering anchors produce a causal composite
+instead of cross-domain latency. Onboard validation bounded the maximum
+alignment uncertainty to 13.9–21.4 µs across a2a3 and a5 Graph Execution
+cases.
+
+#### Onboard clock-correlation validation
+
+The A2/A3 and A5 Graph Execution scene tests ran in onboard environments, with
+level 4 enabled for the `record_then_replay_1d` and
+`record_then_replay_2d` cases. Each generated `chip_swimlane_records.json` was
+loaded through `read_perf_data()`, which selected the minimum-RTT anchor from
+each three-sample endpoint group. Validation checked `layout=clock_aligned`,
+`clock_alignment.status=calibrated`, complete host capture with zero drops,
+and `cross_domain_latency_available=true`. Record counts came from the raw host,
+AICore, and AICPU streams; maximum uncertainty came from
+`timeline_metadata.clock_alignment.max_uncertainty_ns`.
+
+| Platform | Case | Syscnt frequency | Host records | AICore / AICPU tasks | Max uncertainty | Result |
+| -------- | ---- | ---------------: | -----------: | -------------------: | --------------: | ------ |
+| A3 (`a2a3`) | `record_then_replay_1d` | 50 MHz | 4 / 4 | 13 / 13 | 13.930 µs | PASS |
+| A3 (`a2a3`) | `record_then_replay_2d` | 50 MHz | 4 / 4 | 13 / 13 | 15.136 µs | PASS |
+| A5 | `record_then_replay_1d` | 1 GHz | 4 / 4 | 13 / 13 | 20.610 µs | PASS |
+| A5 | `record_then_replay_2d` | 1 GHz | 4 / 4 | 13 / 13 | 21.391 µs | PASS |
 
 #### Reader output (µs domain)
 
@@ -228,14 +296,19 @@ microseconds, downstream code sees:
 | `start_time_us` / `end_time_us` / `duration_us` | AICore execution window in microseconds |
 | `dispatch_time_us` | AICPU timestamp when this task was dispatched (filled at level >= 2; `0.0` at level 1) |
 | `finish_time_us` | AICPU timestamp when AICPU observed FIN (filled at level >= 2; `0.0` at level 1) |
+| `orchestrator_source` | `"aicpu"` for TMR or `"host"` for HBG |
+| `timeline_metadata` | HBG clock-alignment, host-capture completeness, and cross-domain latency availability; absent for TMR |
+| `aicpu_orchestrator_phases` | TMR AICPU orchestrator records |
+| `host_orchestrator_phases` | HBG host orchestrator records, expressed in the selected reader timeline |
 
 Note: per-task records carry **no** fanout edges. Dependency arrows
 come from a separate `deps.json` (dep_gen) joined at convert time —
 see [§3.5](#35-dependency-arrows-from-dep_gen).
 
-Phase records (per scheduler thread, level >= 3 for
-`aicpu_scheduler_phases[]` and level >= 4 for
-`aicpu_orchestrator_phases[]`):
+Phase records are grouped per scheduler/orchestrator lane. Level >= 3 uses
+`aicpu_scheduler_phases[]`; at level >= 4, TMR uses
+`aicpu_orchestrator_phases[]` and HBG uses `host_orchestrator_phases[]`.
+`orchestrator_source` remains the explicit source discriminator.
 
 | Field | Meaning |
 | ----- | ------- |
@@ -1072,15 +1145,20 @@ this as ERROR and does not recover. AICPU did not flush its
 active chip swimlane buffer at run end. Check the AICPU flush path runs
 for every thread that produced records.
 
-**Phase records empty.** Either the runtime did not emit phase
-data or phase initialization did not run. Both a2a3 runtimes and a5
-`tensormap_and_ringbuffer` provide the dummy-task path; a5
-`host_build_graph` does not. On both architectures collection is gated on
-`ChipSwimlaneDataHeader::num_sched_phase_threads > 0` (sched) or
-`num_orch_phase_threads > 0` (orch). Verify the runtime calls
-`chip_swimlane_aicpu_init_phase()` in its scheduler init path; check the host's
-`ChipSwimlaneCollector::initialize` zero-inits the relevant metadata
-fields.
+**Phase records empty.** Either the runtime did not emit phase data or phase
+initialization did not run. Scheduler phases and TMR orchestrator phases are
+gated on `ChipSwimlaneDataHeader::num_sched_phase_threads > 0` and
+`num_orch_phase_threads > 0`, respectively. Verify TMR calls
+`chip_swimlane_aicpu_init_phase()` and check the collector initializes the
+relevant metadata fields. HBG level 4 intentionally keeps
+`num_orch_phase_threads == 0` because it records orchestration on the host;
+inspect `metadata.host_capture`, `metadata.clock_anchors`, and
+`host_orchestrator_phases` instead.
+
+After a C++ profiling change, rebuild the platform and runtime binaries with
+`pip install --no-build-isolation -e .` before reproducing a capture. A stale
+`build/lib` can otherwise pair a runtime compiled against an older `HostApiOps`
+layout with a newer host library.
 
 **`dispatch_time_us` < `finish_time_us` mismatch.** Verify the runtime
 overwrites `task_id` with the full encoding on FIN

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -589,8 +589,9 @@ Top-level layout depends on `chip_swimlane_level`:
 - `>= 3`: also `aicpu_scheduler_phases[]` (per-thread phase records:
   scan / complete / dispatch / idle) and `core_to_thread[]` (core_id →
   scheduler thread index).
-- `>= 4`: also `aicpu_orchestrator_phases[]` (per-task orchestrator
-  phase records).
+- `>= 4`: also source-specific orchestrator phase records. TMR uses
+  `aicpu_orchestrator_phases[]`; HBG uses `host_orchestrator_phases[]` and
+  includes clock-alignment and capture status in `timeline_metadata`.
 
 ### Kernel Config Format
 

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -248,8 +248,8 @@ def read_perf_data(filepath):  # noqa: PLR0912, PLR0915
 
     Returns a dict shaped for `generate_chrome_trace_json`,
     `print_task_statistics`, and `sched_overhead_analysis`: `tasks`,
-    `aicpu_scheduler_phases`, `aicpu_orchestrator_phases`,
-    `core_to_thread`.
+    `aicpu_scheduler_phases`, source-specific `aicpu_orchestrator_phases`
+    or `host_orchestrator_phases`, and `core_to_thread`.
 
     The join logic that used to live in `export_swimlane_json` (host C++):
 
@@ -621,7 +621,7 @@ def read_perf_data(filepath):  # noqa: PLR0912, PLR0915
                 }
             )
         if host_orchestrator_phases:
-            out["aicpu_orchestrator_phases"] = host_orchestrator_phases
+            out["host_orchestrator_phases"] = host_orchestrator_phases
         else:
             out["timeline_metadata"]["host_records_missing"] = True
     if core_to_thread:
@@ -2887,7 +2887,7 @@ def _print_verbose_data_info(data, verbose):
         print(f"  Time Range: {min_time:.3f} us - {max_time:.3f} us (span: {max_time - min_time:.3f} us)")
     print()
     scheduler_phases = data.get("aicpu_scheduler_phases")
-    orchestrator_phases = data.get("aicpu_orchestrator_phases")
+    orchestrator_phases = data.get("host_orchestrator_phases") or data.get("aicpu_orchestrator_phases")
     core_to_thread = data.get("core_to_thread")
     if scheduler_phases:
         print(f"  Scheduler threads: {len(scheduler_phases)}")
@@ -3003,7 +3003,7 @@ def main():
             args.verbose,
             orchestrator_name=orchestrator_name,
             scheduler_phases=data.get("aicpu_scheduler_phases"),
-            orchestrator_phases=data.get("aicpu_orchestrator_phases"),
+            orchestrator_phases=data.get("host_orchestrator_phases") or data.get("aicpu_orchestrator_phases"),
             orchestrator_source=data.get("orchestrator_source"),
             timeline_metadata=data.get("timeline_metadata"),
             core_to_thread=data.get("core_to_thread"),

--- a/src/common/platform/include/host/clock_correlation.h
+++ b/src/common/platform/include/host/clock_correlation.h
@@ -46,11 +46,6 @@ struct ClockAnchorSample {
     uint64_t host_after_ns{0};
     ClockAnchorErrorStage error_stage{ClockAnchorErrorStage::None};
     int32_t error_code{0};
-
-    bool valid() const {
-        return error_stage == ClockAnchorErrorStage::None && error_code == 0 && host_before_ns != 0 &&
-               host_after_ns >= host_before_ns && device_cycles != 0;
-    }
 };
 
 const char *clock_anchor_position_name(ClockAnchorPosition position);

--- a/src/common/platform/onboard/host/clock_correlation.cpp
+++ b/src/common/platform/onboard/host/clock_correlation.cpp
@@ -21,6 +21,8 @@
 namespace simpler::dfx {
 namespace {
 
+static_assert(PLATFORM_ACL_EVENT_TIMESTAMP_FREQ_HZ > 0, "ACL event timestamp frequency must be positive");
+
 class OnboardClockCorrelationProvider final : public ClockCorrelationProvider {
 public:
     ~OnboardClockCorrelationProvider() override { release(false); }
@@ -60,14 +62,12 @@ public:
             sample.error_code = static_cast<int32_t>(rc);
             sample.raw_device_timestamp = 0;
         } else {
-            if constexpr (PLATFORM_ACL_EVENT_TIMESTAMP_FREQ_HZ != 0) {
-                // Preserve the exact backend value, then normalize it to the
-                // platform's verified profiling-counter frequency.
-                sample.device_cycles = static_cast<uint64_t>(
-                    static_cast<__uint128_t>(sample.raw_device_timestamp) * PLATFORM_PROF_SYS_CNT_FREQ /
-                    PLATFORM_ACL_EVENT_TIMESTAMP_FREQ_HZ
-                );
-            }
+            // Preserve the exact backend value, then normalize it to the
+            // platform's verified profiling-counter frequency.
+            sample.device_cycles = static_cast<uint64_t>(
+                static_cast<__uint128_t>(sample.raw_device_timestamp) * PLATFORM_PROF_SYS_CNT_FREQ /
+                PLATFORM_ACL_EVENT_TIMESTAMP_FREQ_HZ
+            );
         }
         return sample;
     }

--- a/tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution.py
+++ b/tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution.py
@@ -9,10 +9,16 @@
 # -----------------------------------------------------------------------------------------------------------
 """Graph Execution replays dynamic tensor and scalar bindings across config-keyed definitions."""
 
+import time
+
 import torch
 from simpler.task_interface import ArgDirection as D
 
 from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+from tests.st.chip_swimlane_validation import scene_case_selected, validate_host_orchestrator_capture
+
+_HOST_ORCHESTRATOR_RECORDS = 4
+_SWIMLANE_CASE = "record_then_replay_2d"
 
 
 @scene_test(level=2, runtime="host_build_graph")
@@ -79,6 +85,22 @@ class TestGraphExecutionHostBuildGraph(SceneTestCase):
         args.output_1[:] = (base + 1.0) * (base + 2.0)
         args.output_3[:] = (base + 100.0) * (base + 4.0)
         args.output_5[:] = (base + 5.0) * (base + 6.0)
+
+    def test_run(self, st_platform, st_worker, request):
+        run_marker = time.time()
+        super().test_run(st_platform, st_worker, request)
+        if (
+            not st_platform.endswith("sim")
+            or not request.config.getoption("--enable-chip-swimlane", default=0)
+            or request.config.getoption("--rounds", default=1) > 1
+            or not scene_case_selected(request, self.__class__.__name__, _SWIMLANE_CASE)
+        ):
+            return
+        validate_host_orchestrator_capture(
+            f"{self.__class__.__name__}_{_SWIMLANE_CASE}",
+            since=run_marker,
+            expected_records=_HOST_ORCHESTRATOR_RECORDS,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/_swimlane_validate.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/_swimlane_validate.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 from simpler_setup.tools.swimlane_converter import read_perf_data
+from tests.st.chip_swimlane_validation import validate_aicpu_orchestrator_capture
 
 _REQUIRED_TASK_FIELDS = (
     "task_id",
@@ -74,9 +75,10 @@ def validate_perf_artifact(case_label: str, *, since: float, expected_task_count
     # oracle below) expects. Direct json.load(perf) would see only raw
     # aicore_tasks / aicpu_tasks arrays under v2.
     data = read_perf_data(perf)
-    assert data.get("chip_swimlane_level") in (1, 2, 3, 4), (
-        f"unexpected chip_swimlane_level: {data.get('chip_swimlane_level')}"
-    )
+    level = data.get("chip_swimlane_level")
+    assert level in (1, 2, 3, 4), f"unexpected chip_swimlane_level: {data.get('chip_swimlane_level')}"
+    if level >= 4:
+        validate_aicpu_orchestrator_capture(data, perf)
     tasks = data.get("tasks")
     assert isinstance(tasks, list), "tasks field missing or not a list"
     assert len(tasks) > 0, f"perf records empty under {perf}"

--- a/tests/st/a5/host_build_graph/graph_execution/test_graph_execution.py
+++ b/tests/st/a5/host_build_graph/graph_execution/test_graph_execution.py
@@ -9,10 +9,16 @@
 # -----------------------------------------------------------------------------------------------------------
 """Graph Execution replays dynamic tensor and scalar bindings across config-keyed definitions."""
 
+import time
+
 import torch
 from simpler.task_interface import ArgDirection as D
 
 from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+from tests.st.chip_swimlane_validation import scene_case_selected, validate_host_orchestrator_capture
+
+_HOST_ORCHESTRATOR_RECORDS = 4
+_SWIMLANE_CASE = "record_then_replay_2d"
 
 
 @scene_test(level=2, runtime="host_build_graph")
@@ -79,6 +85,22 @@ class TestGraphExecutionHostBuildGraphA5(SceneTestCase):
         args.output_1[:] = (base + 1.0) * (base + 2.0)
         args.output_3[:] = (base + 100.0) * (base + 4.0)
         args.output_5[:] = (base + 5.0) * (base + 6.0)
+
+    def test_run(self, st_platform, st_worker, request):
+        run_marker = time.time()
+        super().test_run(st_platform, st_worker, request)
+        if (
+            not st_platform.endswith("sim")
+            or not request.config.getoption("--enable-chip-swimlane", default=0)
+            or request.config.getoption("--rounds", default=1) > 1
+            or not scene_case_selected(request, self.__class__.__name__, _SWIMLANE_CASE)
+        ):
+            return
+        validate_host_orchestrator_capture(
+            f"{self.__class__.__name__}_{_SWIMLANE_CASE}",
+            since=run_marker,
+            expected_records=_HOST_ORCHESTRATOR_RECORDS,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/_swimlane_validate.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/_swimlane_validate.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 from simpler_setup.tools.swimlane_converter import read_perf_data
+from tests.st.chip_swimlane_validation import validate_aicpu_orchestrator_capture
 
 _REQUIRED_TASK_FIELDS = (
     "task_id",
@@ -86,9 +87,10 @@ def validate_perf_artifact(
     # oracle below) expects. Direct json.load(perf) would see only raw
     # aicore_tasks / aicpu_tasks arrays under v2.
     data = read_perf_data(perf)
-    assert data.get("chip_swimlane_level") in (1, 2, 3, 4), (
-        f"unexpected chip_swimlane_level: {data.get('chip_swimlane_level')}"
-    )
+    level = data.get("chip_swimlane_level")
+    assert level in (1, 2, 3, 4), f"unexpected chip_swimlane_level: {data.get('chip_swimlane_level')}"
+    if level >= 4:
+        validate_aicpu_orchestrator_capture(data, perf)
     tasks = data.get("tasks")
     assert isinstance(tasks, list), "tasks field missing or not a list"
     assert len(tasks) > 0, f"perf records empty under {perf}"

--- a/tests/st/chip_swimlane_validation.py
+++ b/tests/st/chip_swimlane_validation.py
@@ -1,0 +1,104 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Cross-runtime assertions for level-4 chip-swimlane scene tests."""
+
+import json
+from pathlib import Path
+
+from simpler_setup.scene_test import _match_selectors, _outputs_dir, _parse_case_selector, _sanitize_for_filename
+from simpler_setup.tools.swimlane_converter import read_perf_data
+
+
+def scene_case_selected(request, class_name: str, case_name: str) -> bool:
+    """Return whether the current ``--case`` selectors include one scene case."""
+    raw_selectors = request.config.getoption("--case", default=None) or []
+    selectors = [_parse_case_selector(value) for value in raw_selectors]
+    return _match_selectors(class_name, case_name, selectors)
+
+
+def locate_swimlane_artifact(case_label: str, *, since: float) -> Path:
+    """Find the profiling artifact created for one case after ``since``."""
+    safe_label = _sanitize_for_filename(case_label)
+    matches = [path for path in _outputs_dir().glob(f"{safe_label}_*") if path.stat().st_mtime >= since]
+    assert matches, f"no output dir for {safe_label!r} created this run — swimlane capture failed?"
+    out_dir = max(matches, key=lambda path: path.stat().st_mtime)
+    artifact = out_dir / "chip_swimlane_records.json"
+    assert artifact.exists(), f"chip_swimlane_records.json missing under {out_dir} — swimlane capture failed?"
+    return artifact
+
+
+def validate_host_orchestrator_capture(case_label: str, *, since: float, expected_records: int) -> None:
+    """Validate HBG host capture, sim clock anchors, and reader alignment."""
+    artifact = locate_swimlane_artifact(case_label, since=since)
+    with artifact.open() as stream:
+        raw = json.load(stream)
+
+    metadata = raw.get("metadata")
+    assert isinstance(metadata, dict), f"metadata missing or not an object under {artifact}"
+    assert metadata.get("orchestrator_source") == "host", f"host orchestrator source missing under {artifact}"
+
+    capture = metadata.get("host_capture")
+    assert isinstance(capture, dict), f"host_capture missing or not an object under {artifact}"
+    host_records = sum(len(lane) for lane in raw.get("host_orchestrator_phases", []))
+    assert capture.get("status") == "complete", f"incomplete host capture under {artifact}: {capture}"
+    assert capture.get("expected_records") == expected_records, (
+        f"unexpected expected_records under {artifact}: {capture}"
+    )
+    assert capture.get("recorded_records") == expected_records, (
+        f"unexpected recorded_records under {artifact}: {capture}"
+    )
+    assert capture.get("dropped_records") == 0, f"host capture dropped records under {artifact}: {capture}"
+    assert capture.get("error") is None, f"host capture reported an error under {artifact}: {capture}"
+    assert host_records == expected_records, (
+        f"got {host_records} host records, expected {expected_records} under {artifact}"
+    )
+
+    anchors = metadata.get("clock_anchors")
+    assert isinstance(anchors, dict), f"clock_anchors missing or not an object under {artifact}"
+    assert anchors.get("provider") == "sim_syscnt", f"unexpected clock provider under {artifact}: {anchors}"
+    assert anchors.get("samples_per_position") == 3, f"unexpected anchor group size under {artifact}: {anchors}"
+    samples = anchors.get("samples")
+    assert isinstance(samples, list), f"clock anchor samples missing under {artifact}"
+    for position in ("pre_host_orchestration", "post_device_execution"):
+        position_samples = [sample for sample in samples if sample.get("position") == position]
+        assert len(position_samples) == 3, f"expected three {position} anchors under {artifact}: {samples}"
+        assert all(sample.get("error") is None for sample in position_samples), (
+            f"invalid {position} anchor under {artifact}: {position_samples}"
+        )
+
+    data = read_perf_data(artifact)
+    assert data.get("orchestrator_source") == "host", f"reader lost host orchestrator source under {artifact}"
+    assert "aicpu_orchestrator_phases" not in data, f"reader mislabeled host records as AICPU under {artifact}"
+    reader_records = sum(len(lane) for lane in data.get("host_orchestrator_phases", []))
+    assert reader_records == expected_records, (
+        f"reader returned {reader_records} host records, expected {expected_records} under {artifact}"
+    )
+    timeline = data.get("timeline_metadata")
+    assert isinstance(timeline, dict), f"timeline_metadata missing or not an object under {artifact}"
+    assert timeline.get("layout") == "clock_aligned", (
+        f"host/device clocks were not aligned under {artifact}: {timeline}"
+    )
+    assert timeline.get("trace_status") == "complete", f"reader reported a partial trace under {artifact}: {timeline}"
+    assert timeline.get("host_records_complete") is True, f"reader rejected host records under {artifact}: {timeline}"
+    assert timeline.get("cross_domain_latency_available") is True, (
+        f"cross-domain latency unavailable under {artifact}: {timeline}"
+    )
+
+
+def validate_aicpu_orchestrator_capture(data: dict, artifact: Path) -> None:
+    """Validate the TMR device-orchestrator stream at level 4."""
+    records = data.get("aicpu_orchestrator_phases")
+    assert isinstance(records, list) and any(records), f"level-4 AICPU orchestrator phases missing under {artifact}"
+    assert any(record for lane in records for record in lane), (
+        f"level-4 AICPU orchestrator records empty under {artifact}"
+    )
+    assert data.get("orchestrator_source") == "aicpu", f"unexpected orchestrator source under {artifact}: {data}"
+    assert "timeline_metadata" not in data, (
+        f"AICPU-only capture unexpectedly carries cross-domain metadata under {artifact}"
+    )

--- a/tests/ut/py/test_swimlane_converter.py
+++ b/tests/ut/py/test_swimlane_converter.py
@@ -201,8 +201,9 @@ def test_host_orchestrator_phases_without_anchors_are_marked_unaligned(tmp_path)
     data = sc.read_perf_data(raw)
 
     assert data["orchestrator_source"] == "host"
-    assert data["aicpu_orchestrator_phases"][0][0]["start_time_us"] == 0.0
-    assert data["aicpu_orchestrator_phases"][0][0]["end_time_us"] == 2.0
+    assert "aicpu_orchestrator_phases" not in data
+    assert data["host_orchestrator_phases"][0][0]["start_time_us"] == 0.0
+    assert data["host_orchestrator_phases"][0][0]["end_time_us"] == 2.0
     assert data["aicpu_scheduler_phases"][0][0]["start_time_us"] == 2.0
     assert data["tasks"][0]["dispatch_time_us"] == 12.0
     assert data["timeline_metadata"] == {
@@ -235,7 +236,7 @@ def test_host_orchestrator_phases_without_anchors_are_marked_unaligned(tmp_path)
         data["tasks"],
         str(trace_path),
         scheduler_phases=data["aicpu_scheduler_phases"],
-        orchestrator_phases=data.get("aicpu_orchestrator_phases"),
+        orchestrator_phases=data.get("host_orchestrator_phases"),
         orchestrator_source=data["orchestrator_source"],
         timeline_metadata=data["timeline_metadata"],
         core_to_thread=data["core_to_thread"],
@@ -362,8 +363,9 @@ def test_host_and_device_timestamps_use_calibrated_clock_alignment(tmp_path):
 
     data = sc.read_perf_data(raw)
 
-    assert data["aicpu_orchestrator_phases"][0][0]["start_time_us"] == 0.0
-    assert data["aicpu_orchestrator_phases"][0][0]["end_time_us"] == 0.3
+    assert "aicpu_orchestrator_phases" not in data
+    assert data["host_orchestrator_phases"][0][0]["start_time_us"] == 0.0
+    assert data["host_orchestrator_phases"][0][0]["end_time_us"] == 0.3
     assert data["tasks"][0]["dispatch_time_us"] == 1.447
     assert data["tasks"][0]["start_time_us"] == 1.55
     assert data["timeline_metadata"] == {
@@ -403,6 +405,13 @@ def test_dropped_host_capture_is_visible_and_disables_cross_domain_flows(tmp_pat
             "record_allocation_failed",
         ),
         ("all_dropped", [], "dropped", 1, "record_allocation_failed"),
+        (
+            "invalid_interval",
+            [[{"submit_idx": 0, "task_id": 7, "start_host_ns": 1_500, "end_host_ns": 1_800}]],
+            "dropped",
+            1,
+            "invalid_record_interval",
+        ),
         ("silent_missing", [], "complete", 0, None),
     ):
         raw = tmp_path / f"{case_name}.json"
@@ -462,6 +471,7 @@ def test_dropped_host_capture_is_visible_and_disables_cross_domain_flows(tmp_pat
         assert data["timeline_metadata"]["trace_status"] == "partial"
         assert data["timeline_metadata"]["clock_alignment"]["status"] == "calibrated"
         assert data["timeline_metadata"]["host_capture"]["status"] == capture_status
+        assert data["timeline_metadata"]["host_capture"]["error"] == capture_error
         assert data["timeline_metadata"]["host_records_complete"] is False
         assert data["timeline_metadata"]["cross_domain_latency_available"] is False
         assert data["timeline_metadata"].get("host_records_missing", False) is (not host_phases)
@@ -475,7 +485,7 @@ def test_dropped_host_capture_is_visible_and_disables_cross_domain_flows(tmp_pat
             data["tasks"],
             str(trace_path),
             scheduler_phases=data["aicpu_scheduler_phases"],
-            orchestrator_phases=data.get("aicpu_orchestrator_phases"),
+            orchestrator_phases=data.get("host_orchestrator_phases"),
             orchestrator_source=data["orchestrator_source"],
             timeline_metadata=data["timeline_metadata"],
             core_to_thread=data["core_to_thread"],


### PR DESCRIPTION
## Summary

- Close the level-4 chip-swimlane follow-ups from #1846 across documentation, capture accounting, reader output, and automated coverage.
- Document the runtime-specific lane schemas, export semantics, host-capture failure metadata, clock correlation, and recorded onboard alignment results.
- Add A2/A3 and A5 simulation smokes for HBG host-orchestrator capture and TMR AICPU-orchestrator phases; keep the HBG artifact post-validation simulation-only because it asserts the `sim_syscnt` provider contract.
- Count invalid host intervals as dropped records, preserve the first capture error, and make level-4 gates forward-compatible.
- Expose HBG records as `host_orchestrator_phases` while retaining `aicpu_orchestrator_phases` for TMR, including updated converter consumers and regression tests.
- Remove unused clock-correlation helpers, replace an always-true frequency branch with a compile-time invariant, and use subsecond artifact boundaries so stale output cannot satisfy a new smoke run.

Follow-up to #1846.

## Testing

- `pip install --no-build-isolation -e .`
- `pytest tests/ut/py/test_clock_correlation.py tests/ut/py/test_swimlane_converter.py tests/ut/py/test_scene_level_selection.py -q` — 41 passed
- A2/A3sim HBG Graph Execution level-4 smoke — 1 passed
- A5sim HBG Graph Execution level-4 smoke — 1 passed
- A2/A3sim TMR chip-swimlane level-4 smoke — 4 passed
- A5sim TMR chip-swimlane level-4 smoke — 4 passed
- Pre-commit over all 19 PR files, including clang-tidy, markdownlint, Ruff, and Pyright — passed
