### PR TITLE
Fix: exclude imported classes from standalone scenes (port of #1858 to perf/hbg-orch)

### DIFF
--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -880,6 +880,19 @@ def _select_cases(test_classes, platform: str, selectors: list[tuple], manual_mo
     return selected
 
 
+def _discover_module_test_classes(module):
+    """Return scene-test classes defined by ``module``, excluding imported helpers."""
+    return [
+        value
+        for value in vars(module).values()
+        if isinstance(value, type)
+        and issubclass(value, SceneTestCase)
+        and value is not SceneTestCase
+        and value.__module__ == module.__name__
+        and hasattr(value, "CASES")
+    ]
+
+
 def _project_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
@@ -1932,11 +1945,7 @@ class SceneTestCase:
         # artifacts land in distinct directories with no shared filenames.
 
         module = sys.modules[module_name]
-        test_classes = [
-            v
-            for v in vars(module).values()
-            if isinstance(v, type) and issubclass(v, SceneTestCase) and v is not SceneTestCase and hasattr(v, "CASES")
-        ]
+        test_classes = _discover_module_test_classes(module)
 
         # Apply --runtime/--level filters (child mode sets both; parent may also
         # use them when the user wants a narrow run).

--- a/tests/ut/py/test_scene_level_selection.py
+++ b/tests/ut/py/test_scene_level_selection.py
@@ -11,12 +11,13 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 from _pytest.outcomes import Failed
 
-from simpler_setup import SceneTestLevel, scene_level, scene_test
+from simpler_setup import SceneTestCase, SceneTestLevel, scene_level, scene_test
+from simpler_setup.scene_test import _discover_module_test_classes
 
 _ROOT = Path(__file__).resolve().parents[3]
 _SPEC = importlib.util.spec_from_file_location("_root_conftest_for_scene_level_tests", _ROOT / "conftest.py")
@@ -89,6 +90,18 @@ def test_scene_test_accepts_int_levels():
 
     assert L2._st_level is SceneTestLevel.CHIP
     assert L2._st_runtime == "tensormap_and_ringbuffer"
+
+
+def test_standalone_discovery_excludes_imported_scene_test_classes():
+    imported_module = ModuleType("tmr_case")
+    current_module = ModuleType("hbg_case")
+
+    imported_cls = type("TestTmr", (SceneTestCase,), {"__module__": imported_module.__name__, "CASES": []})
+    local_cls = type("TestHbg", (SceneTestCase,), {"__module__": current_module.__name__, "CASES": []})
+    current_module._ImportedTmr = imported_cls
+    current_module.TestHbg = local_cls
+
+    assert _discover_module_test_classes(current_module) == [local_cls]
 
 
 def test_invalid_scene_level_rejected():


### PR DESCRIPTION
## Summary

Ports #1858 (commit `8b314f97`, author @doraemonmj) onto `perf/hbg-orch` via cherry-pick — the two touched files (`simpler_setup/scene_test.py`, `tests/ut/py/test_scene_level_selection.py`) are byte-identical to the merged original.

- Restrict standalone scene discovery to `SceneTestCase` subclasses defined by the invoked module.
- Prevent imported test classes used to share `CALLABLE` definitions from running as additional runtime groups.
- Add regression coverage for an imported TMR class alongside a local HBG class.

## Why a port

`perf/hbg-orch` branched from `main` before #1858 merged and does not contain it. The branch adds its own standalone-run HBG scene tests (DSV4 FLASH decode, #1838/#1860) where sharing an imported `CALLABLE` class is exactly the pattern this fix governs, so the branch needs it too.

## Testing

- `python -m pytest tests/ut/py/test_scene_test_rehost.py tests/ut/py/test_scene_test_golden_hooks.py tests/ut/py/test_scene_test_dep_gen_hook.py tests/ut/py/test_scene_test_compile.py tests/ut/py/test_scene_test_cache.py tests/ut/py/test_scene_level_selection.py -q` — `test_scene_level_selection.py` fully passes (9/9, including the new regression test). The 10 failures elsewhere are a pre-existing editable-build stamp mismatch (`_task_interface was built from …`) that reproduces identically on pristine `upstream/perf/hbg-orch` — unrelated to this change.
- `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
