### PR TITLE
Refactor: remove unused HBG fanin readiness helper

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -1289,11 +1289,14 @@ static TaskOutputTensors submit_task_common(
     // Polling + host-orch: append_fanin_or_fail already wrote each producer's
     // local id into payload.fanin_local_ids and bumped its last_consumer_local_id.
     // All that remains is to record how many. There is NO fanout adjacency, NO
-    // dep_pool, and NO ready routing here — the device boot scan classifies every
-    // task exactly once (fanin_satisfied -> push_ready_routed, else register_wake)
-    // before the scheduler dispatch loop starts. Because fanin is now a flat array
-    // of position-independent integers, none of this needs host->device pointer
-    // relocation.
+    // dep_pool, and NO ready routing here — the initial device boot scan classifies
+    // each task once. A -1 result from classify_fanin_state routes the task through
+    // push_ready_routed; otherwise the returned index selects the producer passed
+    // to register_wake. Wake retargeting in register_wake may reclassify a task
+    // when the selected producer is already complete.
+    // The initial scan happens before the scheduler dispatch loop starts. Because
+    // fanin is a flat array of position-independent integers, none of this needs
+    // host->device pointer relocation.
     payload.fanin_count = fanin_builder.count;
     (void)sched;
 

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -269,8 +269,9 @@ struct PTO2TaskPayload {
     int32_t fanin_count{0};  // Producer dependency count (raw, no +1 redundance)
     // Producer dependencies as position-independent local task ids. Single-ring
     // hbg: every producer is ring 0, so no per-edge ring id is stored. Scanned
-    // by fanin_satisfied / classify_fanin_state against the ring completion_flags.
-    // Hard-capped at PTO2_MAX_FANIN (no dep-pool spill).
+    // by classify_fanin_state against the ring completion_flags. A -1 result
+    // means every fanin is complete; otherwise it is the first unmet
+    // fanin index. Hard-capped at PTO2_MAX_FANIN (no dep-pool spill).
     int32_t fanin_local_ids[PTO2_MAX_FANIN];
     // Reserved: preserves the early-dispatch block and tensors[] offsets. tensors
     // must stay at byte 576 (AICore arg-materialization contract), so this fanin

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -539,15 +539,6 @@ struct PTO2SchedulerState {
     // set its completion_flags byte. Single-ring: all producers are ring 0, so
     // there is no per-edge ring indirection.
 
-    bool fanin_satisfied(const PTO2TaskSlotState *s) const {
-        const PTO2TaskPayload &p = *s->payload;
-        const PTO2SharedMemoryRingHeader &ring = *ring_sched_state.ring;
-        for (int32_t i = 0; i < p.fanin_count; i++) {
-            if (!ring.is_completion_flag_set(p.fanin_local_ids[i])) return false;
-        }
-        return true;
-    }
-
     // First-unmet classification. Returns -1 (all fanins met -> route to ready)
     // or the index of the first unmet fanin (register on that producer's wake
     // list). The decision is terminal: tasks are never re-polled; a producer's

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -1289,11 +1289,14 @@ static TaskOutputTensors submit_task_common(
     // Polling + host-orch: append_fanin_or_fail already wrote each producer's
     // local id into payload.fanin_local_ids and bumped its last_consumer_local_id.
     // All that remains is to record how many. There is NO fanout adjacency, NO
-    // dep_pool, and NO ready routing here — the device boot scan classifies every
-    // task exactly once (fanin_satisfied -> push_ready_routed, else register_wake)
-    // before the scheduler dispatch loop starts. Because fanin is now a flat array
-    // of position-independent integers, none of this needs host->device pointer
-    // relocation.
+    // dep_pool, and NO ready routing here — the initial device boot scan classifies
+    // each task once. A -1 result from classify_fanin_state routes the task through
+    // push_ready_routed; otherwise the returned index selects the producer passed
+    // to register_wake. Wake retargeting in register_wake may reclassify a task
+    // when the selected producer is already complete.
+    // The initial scan happens before the scheduler dispatch loop starts. Because
+    // fanin is a flat array of position-independent integers, none of this needs
+    // host->device pointer relocation.
     payload.fanin_count = fanin_builder.count;
     (void)sched;
 

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -268,8 +268,9 @@ struct PTO2TaskPayload {
     int32_t fanin_count{0};  // Producer dependency count (raw, no +1 redundance)
     // Producer dependencies as position-independent local task ids. Single-ring
     // hbg: every producer is ring 0, so no per-edge ring id is stored. Scanned
-    // by fanin_satisfied / classify_fanin_state against the ring completion_flags.
-    // Hard-capped at PTO2_MAX_FANIN (no dep-pool spill).
+    // by classify_fanin_state against the ring completion_flags. A -1 result
+    // means every fanin is complete; otherwise it is the first unmet
+    // fanin index. Hard-capped at PTO2_MAX_FANIN (no dep-pool spill).
     int32_t fanin_local_ids[PTO2_MAX_FANIN];
     // Reserved: preserves the early-dispatch block and tensors[] offsets. tensors
     // must stay at byte 576 (AICore arg-materialization contract), so this fanin

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -539,15 +539,6 @@ struct PTO2SchedulerState {
     // set its completion_flags byte. Single-ring: all producers are ring 0, so
     // there is no per-edge ring indirection.
 
-    bool fanin_satisfied(const PTO2TaskSlotState *s) const {
-        const PTO2TaskPayload &p = *s->payload;
-        const PTO2SharedMemoryRingHeader &ring = *ring_sched_state.ring;
-        for (int32_t i = 0; i < p.fanin_count; i++) {
-            if (!ring.is_completion_flag_set(p.fanin_local_ids[i])) return false;
-        }
-        return true;
-    }
-
     // First-unmet classification. Returns -1 (all fanins met -> route to ready)
     // or the index of the first unmet fanin (register on that producer's wake
     // list). The decision is terminal: tasks are never re-polled; a producer's


### PR DESCRIPTION
## Summary

- Remove the zero-caller `fanin_satisfied` helper from the a2a3 and a5 HBG schedulers.
- Update fanin comments to describe the live `classify_fanin_state` routing path used by device boot and wake-list handling.

## Testing

- [x] `.venv/bin/pip install --no-build-isolation -e .`
- [x] a2a3sim host_build_graph: 26 passed, 7 skipped
- [x] a5sim host_build_graph: 18 passed
- [ ] Hardware tests (not run: `npu-smi info` returned no device data)

Fixes #1719