### PR TITLE
CI: Allocate A5 devices dynamically

### DIFF
--- a/.github/actions/run-onboard-dfx-smokes/action.yml
+++ b/.github/actions/run-onboard-dfx-smokes/action.yml
@@ -169,11 +169,11 @@ runs:
           task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
             --run "bash '$DRIVER' a2a3 \$TASK_DEVICE"
         else
-          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
           if [[ "$DFX_PLATFORM" == "a2a3" ]]; then
+            DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
             bash "$DRIVER" a2a3 "$DEVICE_LIST"
           else
-            task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" \
+            task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
               --run "bash '$DRIVER' a5 \$TASK_DEVICE"
           fi
         fi

--- a/.github/workflows/_st-npu-a5.yml
+++ b/.github/workflows/_st-npu-a5.yml
@@ -78,9 +78,8 @@ jobs:
 
       - name: Run pytest scene tests (a5)
         run: |
-          DEVICE_LIST=$(.venv/bin/python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" \
-            --run ".venv/bin/python -m pytest examples tests/st --platform a5 --exclude-level 4 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 1200 --manual '$MANUAL_MODE'"
+          task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
+            --run ".venv/bin/python -m pytest examples tests/st --platform a5 --exclude-level 4 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 1200 --manual '$MANUAL_MODE'"
 
       - name: DFX smokes (a5)
         if: inputs.include_dfx_smokes

--- a/.github/workflows/_ut-npu-a5.yml
+++ b/.github/workflows/_ut-npu-a5.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Run Python hardware unit tests (a5)
         run: |
           source .venv/bin/activate
-          DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "python -m pytest tests/ut -m requires_hardware --platform a5 --device ${DEVICE_RANGE} -v"
+          task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
+            --run "python -m pytest tests/ut -m requires_hardware --platform a5 --device \$TASK_DEVICE -v"
 
       - name: Build cann-examples/query
         if: inputs.include_cann_examples

--- a/tests/ut/py/test_run_onboard_dfx_smokes_action.py
+++ b/tests/ut/py/test_run_onboard_dfx_smokes_action.py
@@ -50,6 +50,7 @@ def test_a5_dfx_smokes_adapt_to_device_count_without_overlap(tmp_path: Path, dev
               fi
               shift
             done
+            DEVICE_NUM=${DEVICE_NUM:-4}
             TASK_DEVICE=$FAKE_TASK_DEVICE bash -c "$run"
             """
         )
@@ -103,6 +104,7 @@ def test_a5_dfx_smokes_adapt_to_device_count_without_overlap(tmp_path: Path, dev
     env.update(
         {
             "DEVICE_RANGE": f"7-{6 + device_count}",
+            "DEVICE_NUM": str(device_count),
             "DFX_PLATFORM": "a5",
             "FAKE_STATE": str(state_dir),
             "FAKE_TASK_DEVICE": ",".join(str(device) for device in range(7, 7 + device_count)),


### PR DESCRIPTION
## Summary

- Align A5 with the existing A3 (`a2a3`) device-allocation convention: let `task-submit` select available devices and expose the allocation through `$TASK_DEVICE`.
- Apply dynamic allocation to A5 Python hardware unit tests, scene tests, and DFX smoke tests using `task-submit --device auto --device-num "$DEVICE_NUM"`.
- Preserve the existing fixed-device path for A2A3 x86_64 runners.
- Update the DFX smoke action unit-test harness to provide `DEVICE_NUM` for dynamic allocation.

## Testing

- `pytest tests/ut/py/test_run_onboard_dfx_smokes_action.py`: 4 passed.
- Parsed all three YAML files successfully with PyYAML.
- `git diff --check` passes.
- PR CI `pre-commit`, Python UT, `ut-a5`, and `st-onboard-a5` checks pass.