### PR TITLE
host_build_graph: time the prepare path from one rotating record pool

### DIFF
--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -170,6 +170,10 @@ python -m simpler_setup.tools.strace_timing path/to/log --trace-out strace.json
 
 # emit the L3/L4 host scheduler timeline on real OS pid/tid lanes
 python -m simpler_setup.tools.strace_timing path/to/log --swimlane host_swimlane.json
+
+# ... and subdivide the bind stage with a runtime's own per-event records
+python -m simpler_setup.tools.strace_timing path/to/log --swimlane host_swimlane.json \
+    --host-phase-records outputs/<case>/host_phase_records.jsonl
 ```
 
 The tool groups by `(pid, inv)`, rebuilds each invocation's tree from `depth`,
@@ -180,6 +184,17 @@ per-invocation lane, so each call renders as an isolated nested tree in
 
 `--swimlane` is a separate view. Host slices keep their real OS pid/tid, and
 task submission-to-dispatch handoffs render as flow arrows.
+
+A runtime may subdivide a stage it owns, which the markers deliberately do not
+describe — the marker grammar is a fixed per-run-stage contract, and a runtime's
+internal breakdown of one stage does not belong in it. `--host-phase-records`
+takes such a breakdown from the artifact the runtime wrote and draws each record
+inside its `simpler_run.bind`, matched on `(pid, inv)`. Both sides are the same
+`CLOCK_MONOTONIC` axis, so nothing is converted. Without the artifact the tool
+still recovers the stage's own segments from the runtime's timing log lines; where
+both are present the artifact wins, so a segment is not drawn twice. See
+[host_build_graph's profiling levels](../../src/a2a3/runtime/host_build_graph/docs/profiling_levels.md)
+for what that runtime records.
 
 **One exception, because a K-deep pipeline is not K threads.** The direct-chip
 lane drives prepare(N+1) and finalize(N) from the *same* OS thread, so a 40-run

--- a/simpler_setup/tools/strace_timing.py
+++ b/simpler_setup/tools/strace_timing.py
@@ -75,6 +75,15 @@ _STRACE_RE = re.compile(
 # A record start, matched independently of whether the rest of that record
 # survived the write that emitted it.
 _STRACE_HEAD_RE = re.compile(r"\[STRACE\]\s+v=\d+")
+# `bind phase=` timing lines from a runtime with a host prepare path. Not
+# `[STRACE]` markers by design — they are a runtime's breakdown of one stage, not
+# a platform run stage. Every line is written at the end of the pass, off the path
+# being measured, so the line carries its own `start_ns` rather than leaving the
+# interval to be inferred from the log prefix's emission time.
+_BIND_PHASE_RE = re.compile(
+    r"\[mono_ns=\d+\]\[T0x(?P<tid_hex>[0-9a-fA-F]+)\]\[TIMING\]\s+\S+:\s+"
+    r"\[[^\]]*\]\s+bind phase=(?P<phase>\w+)\s+start_ns=(?P<start>\d+)\s+dur_ns=(?P<dur>\d+)(?P<attrs>[^\r\n]*)",
+)
 _CLOCK_ANCHOR_RE = re.compile(
     r"\[mono_ns=\d+\]\[T0x[0-9a-fA-F]+\]\[TIMING\]\s+clock_anchor:\s+"
     r"\[CLOCK_ANCHOR\]\s+v=(?P<v>\d+)\s+pid=(?P<pid>\d+)\s+"
@@ -772,6 +781,159 @@ def _assign_lanes(host_entries, host_threads):
     return lane_of, lane_names
 
 
+def load_host_phase_records(paths):
+    """Read host phase records from ``host_phase_records.jsonl`` files.
+
+    One JSON object per prepare pass, as written by a runtime with a host prepare
+    path. Malformed lines are skipped rather than fatal: the artifact is appended
+    to while a run is in flight, so a truncated last line is an ordinary outcome,
+    not a broken file. A line that parses but is not an object, or whose
+    ``records`` is not a list, is malformed in the same sense and skipped here so
+    no consumer has to re-check it.
+    """
+    passes = []
+    for path in paths:
+        with open(path, encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    one_pass = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(one_pass, dict) or not isinstance(one_pass.get("records", []), list):
+                    continue
+                passes.append(one_pass)
+    return passes
+
+
+# The bind stage's own segments, whose durations partition it. Everything else a
+# pass records is an orchestrator operation nested inside the host_orch segment.
+_BIND_PHASE_NAMES = frozenset(
+    {
+        "args",
+        "arena_build",
+        "static_arena",
+        "gm_heap",
+        "shared_mem",
+        "runtime_init",
+        "host_orch",
+        "graph_upload",
+        "relocate",
+        "sm_h2d",
+        "arena_h2d",
+        "host_view_close",
+    }
+)
+
+
+def host_record_spans(spans, passes):
+    """Turn phase records into spans nested under their pass's ``bind``.
+
+    A record carries only ``(pid, inv)`` and a host-clock interval; the thread and
+    the tree position come from the ``simpler_run.bind`` span of the same
+    invocation, which is the stage the records subdivide. Records whose pass has
+    no such span are dropped — without it there is no lane to draw them on and no
+    parent to nest them under.
+
+    A bind segment sits directly under ``bind``; an orchestrator operation sits a
+    level deeper, under the ``host_orch`` segment it happened inside.
+
+    The clock needs no conversion: both sides are the same CLOCK_MONOTONIC axis.
+
+    Returns the spans, the number of passes with no matching ``bind`` span, and
+    the ``(pid, inv)`` keys the artifact covered — a caller uses the last to avoid
+    drawing the same segment twice from the log lines as well.
+    """
+    bind_by_key = {
+        (span.pid, span.inv): span for span in spans if span.name == "simpler_run.bind" and not span.is_device
+    }
+    out = []
+    dropped_passes = 0
+    covered_keys = set()
+    for one_pass in passes:
+        key = (one_pass.get("pid"), one_pass.get("inv"))
+        parent = bind_by_key.get(key)
+        if parent is None:
+            dropped_passes += 1
+            continue
+        for record in one_pass.get("records", []):
+            try:
+                start = int(record["start_ns"])
+                end = int(record["end_ns"])
+                phase = str(record["phase"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            if phase in _BIND_PHASE_NAMES:
+                name = f"simpler_run.bind.{phase}"
+                depth = parent.depth + 1
+                covered_keys.add(key)
+            else:
+                name = f"simpler_run.bind.host_orch.{phase}"
+                depth = parent.depth + 2
+            out.append(
+                Span(
+                    pid=parent.pid,
+                    tid=parent.tid,
+                    inv=parent.inv,
+                    hid=parent.hid,
+                    depth=depth,
+                    name=name,
+                    ts=start,
+                    dur=max(0, end - start),
+                    attrs=f"detail={record.get('detail', 0)} src=host_phase_records",
+                )
+            )
+    return out, dropped_passes, frozenset(covered_keys)
+
+
+def bind_phase_spans(text, spans, skip_keys=frozenset()):
+    """Recover `bind phase=` timing lines as spans nested under their ``bind``.
+
+    Without these the swimlane draws ``simpler_run.bind`` as one empty bar, which
+    for a runtime with a host prepare path is most of the trace: on a 40-layer
+    qwen decode the stage is seconds of tensor staging and host-view teardown,
+    while the orchestration inside it is around a millisecond. The per-event
+    records then land in well under a pixel with nothing to indicate where to zoom.
+
+    The line carries its own ``start_ns``. The owning invocation is whichever
+    ``simpler_run.bind`` of that thread contains the interval; a phase outside
+    every bind is dropped rather than guessed at.
+
+    ``skip_keys`` holds the ``(pid, inv)`` a record artifact already covered, so
+    the same segment is not drawn twice when both channels are present.
+    """
+    binds = [span for span in spans if span.name == "simpler_run.bind" and not span.is_device]
+    out = []
+    for match in _BIND_PHASE_RE.finditer(text):
+        start = int(match["start"])
+        dur = int(match["dur"])
+        parent = next(
+            (b for b in binds if b.ts <= start and start + dur <= b.ts + b.dur),
+            None,
+        )
+        if parent is None or (parent.pid, parent.inv) in skip_keys:
+            continue
+        out.append(
+            Span(
+                pid=parent.pid,
+                # The log's T0x id is a pthread handle, not the tid the markers
+                # carry, so take the lane from the enclosing bind and keep the
+                # raw value only as an attribute.
+                tid=parent.tid,
+                inv=parent.inv,
+                hid=parent.hid,
+                depth=parent.depth + 1,
+                name=f"simpler_run.bind.{match['phase']}",
+                ts=start,
+                dur=dur,
+                attrs=f"{match['attrs'].strip()} log_thread=0x{match['tid_hex']} src=bind_phase".strip(),
+            )
+        )
+    return out
+
+
 def to_host_swimlane(spans, anchors=None):
     """Build a real-pid/tid host scheduling timeline for Perfetto.
 
@@ -1015,6 +1177,47 @@ def print_tree(buckets, stream=sys.stdout):
         print(file=stream)
 
 
+def write_host_swimlane(args, spans, lines, anchors):
+    """Write the host swimlane, adding whatever prepare-path detail is available.
+
+    A runtime's own stage breakdown reaches this view through two channels that
+    describe the same segments: the per-event artifact, and the timing lines in the
+    log. The artifact wins for any pass it covers and the lines fill in the rest —
+    a run with no output directory has no artifact at all, and then the lines are
+    the only source.
+    """
+    lane_spans = spans
+    record_count = 0
+    covered = frozenset()
+    if args.host_phase_records:
+        passes = load_host_phase_records(args.host_phase_records)
+        extra, orphaned, covered = host_record_spans(spans, passes)
+        lane_spans = lane_spans + extra
+        record_count = len(extra)
+        if orphaned:
+            print(
+                f"warning: {orphaned} phase-record pass(es) had no matching simpler_run.bind span "
+                "in this log and were dropped — is the log from the same run as the artifact?",
+                file=sys.stderr,
+            )
+    phase_spans = bind_phase_spans("".join(lines), spans, skip_keys=covered)
+    if phase_spans:
+        lane_spans = lane_spans + phase_spans
+    with open(args.swimlane, "w", encoding="utf-8") as f:
+        json.dump(to_host_swimlane(lane_spans, anchors=anchors), f)
+    host_count = sum(not span.is_device for span in spans)
+    extras = []
+    if phase_spans:
+        extras.append(f"{len(phase_spans)} bind phases")
+    if record_count:
+        extras.append(f"{record_count} host phase records")
+    suffix = (", " + ", ".join(extras)) if extras else ""
+    print(
+        f"Wrote host swimlane: {args.swimlane} "
+        f"({host_count} host spans, {len(spans) - host_count} unaligned device spans{suffix})"
+    )
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("log", help="path to a host/CANN log containing [STRACE] lines (or '-' for stdin)")
@@ -1024,6 +1227,15 @@ def main(argv=None):
     ap.add_argument(
         "--swimlane",
         help="write a real-pid/tid L3/L4 host swimlane JSON here (load in chrome://tracing or perfetto)",
+    )
+    ap.add_argument(
+        "--host-phase-records",
+        action="append",
+        metavar="PATH",
+        help="a host_phase_records.jsonl from the same run; its per-event bind segments and "
+        "orchestrator operations are drawn inside the matching simpler_run.bind. Repeatable. Only "
+        "affects --swimlane, because the summed host-orch timing lines are cost shares and cannot "
+        "be placed on a timeline",
     )
     ap.add_argument(
         "--rounds-table",
@@ -1098,13 +1310,7 @@ def main(argv=None):
         print(f"Wrote Chrome trace: {args.trace_out} ({len(legacy)} spans)")
 
     if args.swimlane:
-        with open(args.swimlane, "w", encoding="utf-8") as f:
-            json.dump(to_host_swimlane(spans, anchors=anchors), f)
-        host_count = sum(not span.is_device for span in spans)
-        print(
-            f"Wrote host swimlane: {args.swimlane} "
-            f"({host_count} host spans, {len(spans) - host_count} unaligned device spans)"
-        )
+        write_host_swimlane(args, spans, lines, anchors)
 
     return 0
 

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -305,21 +305,19 @@ def read_perf_data(filepath):  # noqa: PLR0912, PLR0915
         dropped_records = int(raw_dropped_records) if raw_dropped_records is not None else None
         reported_records = host_capture.get("recorded_records")
         count_matches = reported_records is None or int(reported_records) == actual_host_record_count
-        capture_finished = host_capture.get("finished") is True
+        # Completeness is per kind: the producer records every timed host
+        # operation, of which this file carries the ones that submit a task, so
+        # `expected_records` is the pass's task count and not its record count.
+        # `pool_records`, when present, is the whole population and is carried
+        # through for context rather than checked here.
         expected_records = host_capture.get("expected_records")
         expected_count_matches = expected_records is not None and int(expected_records) == actual_host_record_count
         host_capture_complete = (
-            capture_status == "complete"
-            and dropped_records == 0
-            and count_matches
-            and capture_finished
-            and expected_count_matches
+            capture_status == "complete" and dropped_records == 0 and count_matches and expected_count_matches
         )
         validation_errors = []
         if not count_matches:
             validation_errors.append("recorded_record_count_mismatch")
-        if not capture_finished:
-            validation_errors.append("capture_not_finished")
         if expected_records is None:
             validation_errors.append("expected_record_count_missing")
         elif not expected_count_matches:
@@ -556,6 +554,19 @@ def read_perf_data(filepath):  # noqa: PLR0912, PLR0915
             converted.append(out)
         aicpu_orchestrator_phases.append(converted)
 
+    host_device_uploads = []
+    for pr in data.get("host_device_uploads") or []:
+        start_ns = int(pr.get("start_host_ns", 0))
+        end_ns = int(pr.get("end_host_ns", 0))
+        if start_ns < host_origin_ns or end_ns < start_ns:
+            raise ValueError(f"invalid host device upload: origin={host_origin_ns}, start={start_ns}, end={end_ns}")
+        out = dict(pr)
+        out["start_time_us"] = (start_ns - host_origin_ns) / 1000.0
+        out["end_time_us"] = (end_ns - host_origin_ns) / 1000.0
+        out.pop("start_host_ns", None)
+        out.pop("end_host_ns", None)
+        host_device_uploads.append(out)
+
     host_orchestrator_phases = []
     for thread_records in host_orch_phases_raw:
         converted = []
@@ -585,6 +596,8 @@ def read_perf_data(filepath):  # noqa: PLR0912, PLR0915
     if aicpu_orchestrator_phases:
         out["aicpu_orchestrator_phases"] = aicpu_orchestrator_phases
         out["orchestrator_source"] = "aicpu"
+    if host_device_uploads:
+        out["host_device_uploads"] = host_device_uploads
     if host_mode:
         if clock_alignment is None:
             raise RuntimeError("host timeline is missing its clock-alignment result")
@@ -1331,6 +1344,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     deps_kernel_map=None,
     deps_block_map=None,
     emit_overhead=False,
+    host_device_uploads=None,
 ):
     """Generate Chrome Trace Event Format JSON from task data.
 
@@ -1998,6 +2012,34 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                 "tid": 3999,
             }
         )
+
+    # Host-to-device transfer lane. These are bind segments, not orchestrator
+    # operations, and they are the ones a device timeline can say something about:
+    # drawn beside the device lanes they show the handover the device waits on,
+    # where the rest of the bind stage is host-only setup with no counterpart here.
+    if host_device_uploads:
+        events.append(
+            {"args": {"name": "Host Prepare"}, "cat": "__metadata", "name": "process_name", "ph": "M", "pid": 1}
+        )
+        events.append(
+            {"args": {"name": "H2D"}, "cat": "__metadata", "name": "thread_name", "ph": "M", "pid": 1, "tid": 4100}
+        )
+        for upload in host_device_uploads:
+            start_us = float(upload.get("start_time_us", 0.0))
+            end_us = float(upload.get("end_time_us", start_us))
+            events.append(
+                {
+                    "name": str(upload.get("phase", "upload")),
+                    "cat": "host_h2d",
+                    "ph": "X",
+                    "pid": 1,
+                    "tid": 4100,
+                    "ts": start_us,
+                    "dur": max(0.0, end_us - start_us),
+                    "cname": "thread_state_iowait",
+                    "args": {"bytes": upload.get("detail", 0)},
+                }
+            )
 
     # AICPU Orchestrator lane (chip_swimlane_level >= 4)
     #
@@ -2965,6 +3007,7 @@ def main():
             orchestrator_source=data.get("orchestrator_source"),
             timeline_metadata=data.get("timeline_metadata"),
             core_to_thread=data.get("core_to_thread"),
+            host_device_uploads=data.get("host_device_uploads"),
             deps_edges=deps_edges,
             deps_kernel_map=deps_kernel_map,
             deps_block_map=deps_block_map,

--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -165,6 +165,22 @@ constexpr int PLATFORM_PROF_SCHED_BUFFERS_PER_THREAD = 6;
 constexpr int PLATFORM_PROF_ORCH_BUFFERS_PER_THREAD = 8;
 
 /**
+ * Host phase-record pool geometry (host_build_graph's bind path and host
+ * orchestrator).
+ *
+ * Same rotating-pool shape as the sched/orch pools above, sized for its own
+ * producer rather than theirs: a scheduler thread emits tens of thousands of
+ * records per run, while one host orchestration pass emits a few hundred (a
+ * 40-layer decode: 12 bind segments + ~325 submit-level operations). Inheriting
+ * PLATFORM_PHASE_RECORDS_PER_THREAD here would allocate 4 MB to hold 11 KB and
+ * leave the rotation path unreachable, so per-buffer capacity is 1024 records
+ * (32 KB) and the pool holds 5 of them — the floor that lets
+ * PLATFORM_PROF_SLOT_COUNT spares fill the free_queue with one buffer active.
+ */
+constexpr int PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER = 1024;
+constexpr int PLATFORM_HOST_PHASE_BUFFERS = PLATFORM_PROF_SLOT_COUNT + 1;
+
+/**
  * Ready queue capacity for performance data collection.
  * Queue holds ReadyQueueEntry structs for buffers ready to be read by Host.
  * Sized to match pre-allocation total across all cores and threads, summed

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -63,6 +63,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/host_regs.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/host_phase_records.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/args_dump_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/comm_hccl.cpp"

--- a/src/a2a3/platform/sim/host/CMakeLists.txt
+++ b/src/a2a3/platform/sim/host/CMakeLists.txt
@@ -49,6 +49,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/pto_runtime_c_api.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/host_phase_records.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/args_dump_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -38,6 +38,7 @@
 #include "common/unified_log.h"
 #include "cpu_sim_context.h"
 #include "host_log.h"
+#include "host/host_phase_records_artifact.h"
 #include "host/raii_scope_guard.h"
 #include "host/runtime_timeout_config.h"
 #include "runtime.h"
@@ -677,6 +678,7 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
         chip_swimlane_collector_.stop();
         chip_swimlane_collector_.read_phase_header_metadata();
         chip_swimlane_collector_.reconcile_counters();
+        publish_host_phase_records_to_swimlane();
         chip_swimlane_collector_.export_swimlane_json();
     }
 
@@ -710,6 +712,14 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
                 }
             }
         }
+    }
+
+    // Per-event view of the prepare path. Keyed on output_prefix_ rather than a
+    // flag because it is non-empty exactly when this run produces diagnostic
+    // artifacts, and on the store having finished a pass, which is what a
+    // host-orchestrating runtime leaves behind.
+    if (!output_prefix_.empty() && host_phase_records_.finished()) {
+        (void)host_phase_records_.write_records_jsonl(make_host_phase_records_path(output_prefix_));
     }
 
     if (enable_scope_stats_) {

--- a/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
@@ -232,6 +232,111 @@ Thread X:   overlap checks : XXX, hits=XXX (XX.X%)
 
 ---
 
+## Prepare-Path Timing: One Pool, Three Views
+
+`host_build_graph` times its prepare path — the `simpler_run.bind` stage's
+segments, and the host orchestrator's submit-level operations inside it. One
+recorder feeds three views, and two independent switches decide which of them
+appear.
+
+### What is recorded
+
+Seventeen kinds, all on the host monotonic clock the `[STRACE]` host spans use,
+so records and spans read against each other with no alignment step.
+
+| Group | Kinds |
+| ----- | ----- |
+| Bind segments (partition the stage) | `args`, `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init`, `host_orch`, `graph_upload`, `relocate`, `sm_h2d`, `arena_h2d`, `host_view_close` |
+| Orchestrator operations (inside `host_orch`) | `submit_task`, `alloc_tensors`, `record_node`, `graph_submit`, `build_definition` |
+
+Three of the orchestrator kinds end with a task submitted — `submit_task`,
+`alloc_tensors`, `graph_submit` — so their count is the pass's `total_tasks`.
+The other two are sub-operations of one of those, which is why a per-kind total
+is a **cost share, not an interval**: a per-event mean is `total_ns / count`, and
+the spread is not recoverable from it.
+
+### The two switches
+
+| Switch | Turns on |
+| ------ | -------- |
+| `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` (env, off unless it starts with `1`, `t` or `T`) | the `LOG_TIMING` breakdown; needs no rebuild and works at any `--rounds` |
+| `--enable-chip-swimlane 4` (CallConfig `chip_swimlane_level`) | the host lane in `chip_swimlane_records.json`, with its records clock-aligned against the device timeline |
+
+Collection is armed by **either** — a level-4 run collects records with the
+variable unset, and the variable collects them with the level at 0. What is
+recorded does not depend on which one armed the pass: the swimlane's share is a
+projection at export, not a branch at record time, so the two configurations
+measure the same overhead and their numbers are comparable.
+
+```bash
+# breakdown only, any --rounds, no rebuild
+SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 python -m pytest <case> --platform <platform> --device 0
+
+# host lane on the chip swimlane, aligned against the device timeline
+python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 4
+```
+
+### The three views
+
+- **`LOG_TIMING` lines**, at the default log threshold, gated by the env
+  variable. One `bind phase=<p> start_ns=<n> dur_ns=<n> <attrs>` line per
+  segment, plus one `host-orch phase=<p> total_ns=<n> count=<k> detail_sum=<n>
+  dropped=<n>` line per orchestrator kind. They come from per-kind counters, not
+  from the record pool, so a total stays exact even if the pool was never armed or
+  overflowed — that is what makes this the channel for steady state, where
+  `--rounds > 1` switches every artifact collector off.
+
+  Every line is written at the end of the pass, keeping the log write off the path
+  being measured. The line therefore carries its own `start_ns`; the log prefix
+  timestamps the write, not the segment.
+
+- **`host_phase_records.jsonl`** in the per-case output directory, when the run
+  has one. One JSON Lines object per pass carrying `pid` / `inv` — the identity
+  the `[STRACE]` tree groups by — and one record per operation. This is the
+  channel to read for a distribution or a per-event timeline; the summed lines
+  cannot express either. `strace_timing.py --swimlane --host-phase-records <path>`
+  draws each record inside the matching `simpler_run.bind`.
+
+- **The host lanes of `chip_swimlane_records.json`**, at level 4 only, joined to
+  the device timeline through the clock anchors (see `host/clock_correlation.h`).
+  Two projections of the pool land there:
+
+  | Key | Kinds | Rendered as |
+  | --- | ----- | ----------- |
+  | `host_orchestrator_phases` | the task-submitting kinds | `Host Orchestrator` process |
+  | `host_device_uploads` | `graph_upload`, `sm_h2d`, `arena_h2d`, with byte counts | `Host Prepare` / `H2D` lane |
+
+  The upload lane is the one place the whole question — orchestration plus H2D
+  inside a millisecond — is visible against the device execution it precedes; the
+  rest of the bind stage is host-only setup with no device counterpart.
+
+  The `host_capture` block reports `expected_records` (the pass's task count)
+  against `recorded_records` (the submit projection), plus `pool_records` for the
+  whole population — a pool count above the projection is normal, not incomplete.
+
+The stage's *duration* is already published as the `simpler_run.bind` `[STRACE]`
+marker, so the marker and this breakdown are a total and its parts rather than two
+spellings of one number. The parts are not markers themselves: the marker grammar
+is the platform's public per-run-stage contract (see `pto_runtime_c_api.h` and
+[docs/dfx/host-trace.md](../../../../../docs/dfx/host-trace.md)), whose consumers
+key off a fixed stage set, and a runtime's internal breakdown of one stage does
+not belong in it.
+
+### Cost and capacity
+
+A record costs two clock reads, a store and two counter updates — roughly 47 ns
+on an aarch64 host, for ~337 operations in a 40-layer decode pass. Cheap, but it
+sits on the path being measured, which is why neither switch is on by default.
+
+The pool holds `PLATFORM_HOST_PHASE_BUFFERS × PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER`
+records (5 × 1024 = 5120, 160 KB) in fixed-size buffers rotated in index order,
+the same shape as the device sched/orch pools with host DDR as its backing.
+Beyond that, records are dropped from the tail and counted: the per-event views
+truncate, the per-kind totals stay exact, and `dropped=` on every `host-orch` line
+plus `dropped_records` in `host_capture` say so.
+
+---
+
 ## Runtime Flag: enable_chip_swimlane (perf_level)
 
 `--enable-chip-swimlane` accepts an integer perf_level (0–4). Transport

--- a/src/a2a3/runtime/host_build_graph/host/host_phase_trace.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/host_phase_trace.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Prepare-path timing: per-kind counters and the binding to the platform's
+ * record pool. See runtime/host_phase_trace.h.
+ */
+
+#include "../runtime/host_phase_trace.h"
+
+#include <stdio.h>
+
+#include <array>
+#include <cstdlib>
+
+#include "common/host_api.h"
+#include "common/log_clock.h"
+#include "common/strace.h"
+#include "common/unified_log.h"
+#include "host/host_phase_records.h"
+
+namespace {
+
+// Bind segments carry a few attributes each beyond their duration (byte counts,
+// tensor counts). They are formatted when the segment ends and printed at flush,
+// so a segment's values need not outlive it and the log write stays off the
+// measured path.
+constexpr size_t kBindAttrsCapacity = 96;
+
+struct KindCounter {
+    uint64_t total_ns;
+    uint64_t count;
+    uint64_t payload_sum;
+    uint64_t first_start_ns;
+};
+
+struct TraceState {
+    HostPhaseRecordPool *pool;
+    const HostApi *api;
+    bool active;
+    uint64_t submitted_tasks;
+    std::array<KindCounter, kHostPhaseKindCount> counters;
+    std::array<std::array<char, kBindAttrsCapacity>, kHostPhaseKindCount> bind_attrs;
+};
+
+TraceState &state() {
+    static TraceState s{};
+    return s;
+}
+
+bool is_bind_kind(uint32_t kind) { return kind < static_cast<uint32_t>(HostPhaseKind::OrchSubmitTask); }
+
+}  // namespace
+
+bool host_phase_timing_enabled() {
+    // Read once: the value cannot change within a process, and the orchestrator
+    // asks per submit-level operation. Opt-in spelling matches the runtime's
+    // other default-off switch, SIMPLER_TMR_SERIAL_ORCH_SCHED_ENABLE, so that
+    // `=false` / `=off` / `=no` read as off rather than as a non-zero string.
+    static const bool enabled = [] {
+        const char *env = std::getenv("SIMPLER_HBG_BIND_BREAKDOWN_ENABLE");
+        return env != nullptr && (env[0] == '1' || env[0] == 't' || env[0] == 'T');
+    }();
+    return enabled;
+}
+
+// Strong definitions overriding the orchestrator core's weak fallbacks, which
+// exist so builds without this translation unit still link.
+__attribute__((visibility("hidden"))) uint64_t host_phase_now_ns() {
+    if (!state().active) {
+        return 0;
+    }
+    return static_cast<uint64_t>(simpler::log::monotonic_now_ns());
+}
+
+__attribute__((visibility("hidden"))) void
+host_phase_record(uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload, uint32_t index) {
+    TraceState &s = state();
+    if (!s.active || kind >= kHostPhaseKindCount || end_ns < start_ns) {
+        return;
+    }
+    KindCounter &counter = s.counters[kind];
+    if (counter.count == 0) {
+        counter.first_start_ns = start_ns;
+    }
+    counter.total_ns += end_ns - start_ns;
+    counter.count++;
+    counter.payload_sum += payload;
+    host_phase_pool_append(s.pool, static_cast<HostPhaseKind>(kind), start_ns, end_ns, payload, index);
+}
+
+void host_phase_record_bind(uint32_t kind, uint64_t start_ns, const char *attrs, uint64_t payload) {
+    TraceState &s = state();
+    if (!s.active || !is_bind_kind(kind)) {
+        return;
+    }
+    const uint64_t end_ns = static_cast<uint64_t>(simpler::log::monotonic_now_ns());
+    if (attrs != nullptr) {
+        snprintf(s.bind_attrs[kind].data(), kBindAttrsCapacity, "%s", attrs);
+    }
+    host_phase_record(start_ns, end_ns, kind, payload, 0);
+}
+
+void host_phase_trace_begin(const void *host_api) {
+    TraceState &s = state();
+    s.api = static_cast<const HostApi *>(host_api);
+    s.pool = s.api != nullptr ?
+                 static_cast<HostPhaseRecordPool *>(s.api->host_phase_pool_arm(host_phase_timing_enabled())) :
+                 nullptr;
+    // Timestamps are taken whenever either sink wants them. Gating the clock on
+    // the environment variable alone would leave a level-4 run recording zeros.
+    s.active = s.pool != nullptr || host_phase_timing_enabled();
+    s.submitted_tasks = 0;
+    s.counters.fill(KindCounter{});
+    for (auto &attrs : s.bind_attrs) {
+        attrs[0] = '\0';
+    }
+}
+
+void host_phase_trace_note_submitted(uint64_t submitted_tasks) { state().submitted_tasks = submitted_tasks; }
+
+void host_phase_trace_end() {
+    TraceState &s = state();
+    if (!s.active) {
+        return;
+    }
+    // Read the pool's own tally before handing it back, and drop the pointer
+    // after: the pool belongs to the runner from finish() onward, and the pass is
+    // over either way, so nothing here may outlive it. Clearing `active` also
+    // makes a second end() without an intervening begin() a no-op rather than a
+    // stale read plus a duplicate report.
+    const uint64_t dropped = s.pool != nullptr ? s.pool->head.dropped_record_count : 0;
+    if (s.api != nullptr) {
+        uint64_t inv = 0;
+#if SIMPLER_HOST_STRACE
+        // The invocation id the enclosing run's spans carry, so a per-event
+        // artifact joins to them on (pid, inv).
+        inv = simpler::strace::StraceScope::current_inv();
+#endif
+        s.api->host_phase_pool_finish(s.submitted_tasks, inv);
+    }
+    s.pool = nullptr;
+    s.active = false;
+    if (!host_phase_timing_enabled()) {
+        // Records were collected for a per-event reader alone, which has its own
+        // report; this breakdown was not asked for.
+        return;
+    }
+
+    for (uint32_t kind = 0; kind < kHostPhaseKindCount; ++kind) {
+        const KindCounter &counter = s.counters[kind];
+        if (counter.count == 0) {
+            continue;
+        }
+        const char *name = host_phase_kind_name(static_cast<HostPhaseKind>(kind));
+        if (is_bind_kind(kind)) {
+            // One occurrence per pass, so the summed time is the segment's own
+            // duration and the twelve of them partition the bind stage. The line
+            // carries its own start because every line is written at the end of
+            // the pass, off the path being measured — the write time says nothing
+            // about when the segment ran.
+            LOG_TIMING(
+                "bind phase=%s start_ns=%llu dur_ns=%llu %s", name,
+                static_cast<unsigned long long>(counter.first_start_ns),
+                static_cast<unsigned long long>(counter.total_ns), s.bind_attrs[kind].data()
+            );
+            continue;
+        }
+        // A summed cost share, not an interval: several of these kinds are
+        // sub-operations of another, so there is no honest way to draw the total
+        // on a timeline. Per-event bars come from the artifact instead.
+        LOG_TIMING(
+            "host-orch phase=%s total_ns=%llu count=%llu detail_sum=%llu dropped=%llu", name,
+            static_cast<unsigned long long>(counter.total_ns), static_cast<unsigned long long>(counter.count),
+            static_cast<unsigned long long>(counter.payload_sum), static_cast<unsigned long long>(dropped)
+        );
+    }
+}

--- a/src/a2a3/runtime/host_build_graph/host/host_tensor_access.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/host_tensor_access.cpp
@@ -38,6 +38,8 @@ struct HostTensorAccessor::Impl {
     const HostApi *api;
     std::vector<HostTensorRegion> regions;
     std::vector<void *> mappings;
+    // Bytes covered by `mappings`, i.e. excluding regions serving a fallback view.
+    uint64_t mapped_bytes;
 };
 
 // The region serving the whole of [dev_addr, dev_addr + bytes), or nullptr.
@@ -59,7 +61,7 @@ find_region(const std::vector<HostTensorRegion> &regions, uint64_t dev_addr, uin
 }
 
 HostTensorAccessor::HostTensorAccessor(const HostApi *api) :
-    impl_(new Impl{api, {}, {}}) {}
+    impl_(new Impl{api, {}, {}, 0}) {}
 
 HostTensorAccessor::~HostTensorAccessor() {
     close();
@@ -77,6 +79,7 @@ bool HostTensorAccessor::add(uint64_t dev_base, uint64_t size, void *fallback_ho
     void *host_view = impl_->api->register_device_memory_to_host(reinterpret_cast<void *>(dev_base), size);
     if (host_view != nullptr) {
         impl_->mappings.push_back(reinterpret_cast<void *>(dev_base));
+        impl_->mapped_bytes += size;
     } else {
         host_view = fallback_host_view;
     }
@@ -113,12 +116,17 @@ bool HostTensorAccessor::write(uint64_t dev_addr, const void *src, uint64_t byte
     return impl_->api->copy_to_device(reinterpret_cast<void *>(dev_addr), dst, static_cast<size_t>(bytes)) == 0;
 }
 
+size_t HostTensorAccessor::mapping_count() const noexcept { return impl_->mappings.size(); }
+
+uint64_t HostTensorAccessor::mapped_bytes() const noexcept { return impl_->mapped_bytes; }
+
 void HostTensorAccessor::close() noexcept {
     for (void *dev_ptr : impl_->mappings) {
         impl_->api->unregister_device_memory_from_host(dev_ptr);
     }
     impl_->mappings.clear();
     impl_->regions.clear();
+    impl_->mapped_bytes = 0;
 }
 
 bool host_tensor_read(HostTensorAccessor *accessor, uint64_t dev_addr, void *dst, uint64_t bytes) {

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -31,7 +31,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/stat.h>
-#include <sys/time.h>
 #include <unistd.h>
 
 #include <atomic>
@@ -48,6 +47,7 @@
 #include <optional>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <unordered_map>
 #include <vector>
 
@@ -57,6 +57,7 @@
 #include "../runtime/graph_execution.h"
 #include "../runtime/host_tensor_access.h"
 #include "../runtime/graph_host_state.h"
+#include "../runtime/host_phase_trace.h"
 #include "../runtime/pto_orchestrator.h"
 #include "../runtime/pto_runtime2.h"
 #include "../runtime/pto_shared_memory.h"
@@ -67,9 +68,11 @@
 #include "../../../../common/worker/pto_runtime_c_api.h"
 #include "callable.h"
 #include "common/host_log_binding.h"
+#include "common/log_clock.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "host_log.h"
+#include "host/raii_scope_guard.h"
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
@@ -104,64 +107,24 @@ extern "C" int concurrent_native_prepare_supported_impl(void) {
 // first slot; it must fit within the ABI's slot budget, not equal it.
 static_assert(PTO2_MAX_RING_DEPTH <= RUNTIME_ENV_RING_COUNT, "PTO2 runtime ring depth must fit RuntimeEnv ring slots");
 
-// Helper: return current time in milliseconds
-static int64_t _now_ms() {
-    struct timeval tv;
-    gettimeofday(&tv, nullptr);
-    return static_cast<int64_t>(tv.tv_sec) * 1000 + tv.tv_usec / 1000;
-}
-
-namespace {
-
-thread_local const HostApi *g_host_orch_profile_api = nullptr;
-thread_local uint32_t g_host_orch_submit_idx = 0;
-
-uint64_t host_fallback_cycles_to_ns(uint64_t cycles) {
-    constexpr uint64_t kNsPerSecond = 1000000000ull;
-    return (cycles / PLATFORM_PROF_SYS_CNT_FREQ) * kNsPerSecond +
-           (cycles % PLATFORM_PROF_SYS_CNT_FREQ) * kNsPerSecond / PLATFORM_PROF_SYS_CNT_FREQ;
-}
-
-class HostOrchestratorProfileBinding {
-public:
-    HostOrchestratorProfileBinding(const HostApi *api, uint64_t task_window_size) :
-        previous_(g_host_orch_profile_api),
-        previous_submit_idx_(g_host_orch_submit_idx) {
-        if (api != nullptr && api->chip_swimlane_level() == static_cast<uint32_t>(ChipSwimlaneLevel::ORCH_PHASES)) {
-            api->begin_host_orchestrator_capture(task_window_size);
-            g_host_orch_profile_api = api;
-            g_host_orch_submit_idx = 0;
-        }
-    }
-
-    ~HostOrchestratorProfileBinding() {
-        g_host_orch_profile_api = previous_;
-        g_host_orch_submit_idx = previous_submit_idx_;
-    }
-
-private:
-    const HostApi *previous_;
-    uint32_t previous_submit_idx_;
-};
-
-}  // namespace
-
-// Strong host-side override for the weak fallback in pto_orchestrator.cpp.
-// Its inputs are the host fallback's frequency-scaled CLOCK_MONOTONIC values;
-// convert them back to ns and route the typed record through this run's
-// HostApi binding. The AICPU build does not link runtime_maker.cpp and keeps
-// using the device collector's implementation.
-__attribute__((visibility("hidden"))) void
-chip_swimlane_aicpu_record_orch_phase(uint64_t start_time, uint64_t end_time, uint64_t task_id, uint32_t) {
-    if (g_host_orch_profile_api == nullptr) return;
-    ChipSwimlaneHostOrchPhaseRecord record{
-        host_fallback_cycles_to_ns(start_time), host_fallback_cycles_to_ns(end_time), task_id, g_host_orch_submit_idx++,
-        0
-    };
-    g_host_orch_profile_api->record_host_orchestrator_phase(record);
-}
-
 static bool is_power_of_2_u64(uint64_t value) { return value != 0 && (value & (value - 1)) == 0; }
+
+// Host monotonic clock, shared with the record pool so spans and records can be
+// read against each other.
+static int64_t bind_now_ns() { return static_cast<int64_t>(host_phase_now_ns()); }
+
+// Close one segment of the bind path, recording it and keeping its attributes for
+// the line the breakdown prints at the end of the pass.
+//
+// The breakdown is LOG_TIMING lines rather than `[STRACE]` markers on purpose:
+// the marker grammar is the platform's public per-run-stage contract (see
+// pto_runtime_c_api.h and docs/dfx/host-trace.md) whose consumers key off a fixed
+// stage set, while everything below is host_build_graph's internal breakdown of
+// one stage. LOG_TIMING sits at the default log threshold, so these are visible
+// without a flag and at any --rounds.
+static void record_bind_phase(HostPhaseKind kind, int64_t start_ns, const char *attrs = "", uint64_t payload = 0) {
+    host_phase_record_bind(static_cast<uint32_t>(kind), static_cast<uint64_t>(start_ns), attrs, payload);
+}
 
 template <typename T>
 static std::string format_ring_array(const T (&values)[PTO2_MAX_RING_DEPTH]) {
@@ -453,8 +416,11 @@ static bool relocate_host_orch_image(
     return ok;
 }
 
-bool upload_graph_submissions(Runtime *runtime, const HostApi *api, GraphHostState &graph_state) {
+bool upload_graph_submissions(
+    Runtime *runtime, const HostApi *api, GraphHostState &graph_state, uint64_t &uploaded_bytes
+) {
     std::unordered_map<uint64_t, uint32_t> occurrences;
+    uploaded_bytes = 0;
     const size_t count = graph_host_upload_count(graph_state);
     for (size_t index = 0; index < count; ++index) {
         std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
@@ -508,6 +474,7 @@ bool upload_graph_submissions(Runtime *runtime, const HostApi *api, GraphHostSta
         }
         upload->outer_slot->graph_context = device_submission;
         runtime->tensor_pairs_.push_back({nullptr, device_submission, upload->bytes, false});
+        uploaded_bytes += static_cast<uint64_t>(upload->bytes);
     }
     return true;
 }
@@ -548,9 +515,6 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: orchestrator re-init against host SM failed");
         return -1;
     }
-#if SIMPLER_DFX
-    rt->orchestrator.chip_swimlane_level = static_cast<ChipSwimlaneLevel>(api->chip_swimlane_level());
-#endif
     rt->orchestrator.wire_arena_pointers(layout.orch, host_arena, &rt->scheduler);
 
     PTO2SharedMemoryHandle host_sm_handle;
@@ -590,14 +554,50 @@ int32_t run_host_orchestration(
     // rt_orchestration_done take the runtime as an argument.
     entry_points->bind(rt);
 
-    HostOrchestratorProfileBinding profile_binding(api, eff_task_window_sizes[0]);
+    const int64_t t_orch_ns = bind_now_ns();
     rt_scope_begin(rt);
     entry_points->entry(orch_l2);
     rt_scope_end(rt);
     rt_orchestration_done(rt);
+#if SIMPLER_ORCH_PROFILING
+    // Per-sub-step cumulatives across this pass's submits. The accumulators only
+    // exist in a SIMPLER_ORCH_PROFILING build (build_runtimes.py --profiling-orch 1),
+    // and reading them also resets them, so this is the pass's own total. Emitted
+    // as spans rather than LOG_INFO because INFO is suppressed at the default log
+    // level. Like the phase spans these are summed cost shares, not intervals.
+    {
+        const PTO2OrchProfilingData prof = orchestrator_get_profiling();
+        const std::pair<const char *, uint64_t> steps[] = {
+            {"sync", prof.sync_cycle},           {"alloc", prof.alloc_cycle},           {"args", prof.args_cycle},
+            {"lookup", prof.lookup_cycle},       {"insert", prof.insert_cycle},         {"fanin", prof.fanin_cycle},
+            {"scope_end", prof.scope_end_cycle}, {"alloc_wait", prof.alloc_wait_cycle},
+        };
+        for (const auto &step : steps) {
+            if (step.second == 0) continue;
+            LOG_TIMING(
+                "host-orch step=%s cycles=%" PRIu64 " submits=%" PRId64, step.first, step.second, prof.submit_count
+            );
+        }
+    }
+#endif
 
     const int32_t total_tasks = pto2_sm_layout::ring_current_task_index_addr(host_sm)->load(std::memory_order_acquire);
-    if (!upload_graph_submissions(runtime, api, *graph_state)) return -1;
+    {
+        char attrs[64];
+        snprintf(attrs, sizeof(attrs), "tasks=%" PRId32, total_tasks);
+        record_bind_phase(HostPhaseKind::BindHostOrch, t_orch_ns, attrs);
+    }
+    // After the span closes: the reduction walks a few hundred records and emits
+    // five markers, which must not be charged to the pass it measures.
+
+    const int64_t t_graph_ns = bind_now_ns();
+    uint64_t graph_bytes = 0;
+    if (!upload_graph_submissions(runtime, api, *graph_state, graph_bytes)) return -1;
+    {
+        char attrs[96];
+        snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, graph_host_upload_count(*graph_state), graph_bytes);
+        record_bind_phase(HostPhaseKind::BindGraphUpload, t_graph_ns, attrs, graph_bytes);
+    }
 
     // total_tasks sizes the bounded per-segment H2D copies below; a value outside
     // [0, task_window] would make those copies read/write out of bounds.
@@ -605,7 +605,7 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: total_tasks %d out of range [0, %" PRIu64 "]", total_tasks, eff_task_window_sizes[0]);
         return -1;
     }
-    api->finish_host_orchestrator_capture(static_cast<uint64_t>(total_tasks));
+    host_phase_trace_note_submitted(static_cast<uint64_t>(total_tasks));
 
     // Relocate the host-DDR cross-task pointers to their final DEVICE addresses
     // on the host, before the SM and arena leave for the device. Pointers into
@@ -616,6 +616,7 @@ int32_t run_host_orchestration(
                              static_cast<int64_t>(reinterpret_cast<uint64_t>(host_sm));
     const int64_t arena_delta = static_cast<int64_t>(reinterpret_cast<uint64_t>(device_arena)) -
                                 static_cast<int64_t>(reinterpret_cast<uint64_t>(host_arena.base()));
+    const int64_t t_reloc_ns = bind_now_ns();
     if (!relocate_host_orch_image(
             host_sm_handle, reinterpret_cast<uint64_t>(host_sm), sm_size, sm_delta,
             reinterpret_cast<uint64_t>(host_arena.base()), layout.arena_size, arena_delta
@@ -623,6 +624,7 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: relocation failed; refusing to H2D an image with unrelocated host pointers");
         return -1;
     }
+    record_bind_phase(HostPhaseKind::BindRelocate, t_reloc_ns);
 
     // Ship only the live prefix of each segment: the device reads no slot past
     // total_tasks, so upload header + descriptors[0,N), payloads[0,N),
@@ -632,6 +634,7 @@ int32_t run_host_orchestration(
     const uint64_t hdr_desc_bytes = sm_segs.descriptors + nt * sizeof(PTO2TaskDescriptor);
     char *host_base = static_cast<char *>(host_sm);
     char *dev_base = static_cast<char *>(device_sm);
+    const int64_t t_sm_h2d_ns = bind_now_ns();
     if (api->copy_to_device(dev_base, host_base, hdr_desc_bytes) != 0 ||
         api->copy_to_device(dev_base + sm_segs.payloads, host_base + sm_segs.payloads, nt * sizeof(PTO2TaskPayload)) !=
             0 ||
@@ -643,6 +646,13 @@ int32_t run_host_orchestration(
         ) != 0) {
         LOG_ERROR("host-orch: H2D of populated SM failed");
         return -1;
+    }
+    {
+        const uint64_t sm_h2d_bytes = hdr_desc_bytes + nt * sizeof(PTO2TaskPayload) + nt * sizeof(PTO2TaskSlotState) +
+                                      nt * sizeof(std::atomic<uint8_t>);
+        char attrs[96];
+        snprintf(attrs, sizeof(attrs), "nt=%" PRIu64 " bytes=%" PRIu64, nt, sm_h2d_bytes);
+        record_bind_phase(HostPhaseKind::BindSmH2d, t_sm_h2d_ns, attrs, sm_h2d_bytes);
     }
     return total_tasks;
 }
@@ -797,7 +807,15 @@ extern "C" int bind_callable_to_runtime_impl(
     int scalar_count = orch_args->scalar_count();
     LOG_INFO("RT2 bind: %d tensors + %d scalars, host orchestration mode", tensor_count, scalar_count);
 
-    int64_t t_total_start = _now_ms();
+    // Arm before the first segment below: the record pool has to exist for
+    // `args`, which runs well before the device collector is provisioned. The
+    // guard ends the pass on every exit, not just the successful one — a bind
+    // that fails part-way is exactly when its breakdown is worth having, and an
+    // unfinished pass publishes nothing.
+    host_phase_trace_begin(api);
+    auto host_phase_guard = RAIIScopeGuard([]() {
+        host_phase_trace_end();
+    });
 
     uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH];
     uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH];
@@ -816,7 +834,9 @@ extern "C" int bind_callable_to_runtime_impl(
     // the point at which a task could make it stale.
     HostTensorAccessor tensor_access(api);
 
-    int64_t t_args_start = _now_ms();
+    const int64_t t_args_ns = bind_now_ns();
+    uint64_t staged_bytes = 0;
+    int staged_tensors = 0;
     for (int i = 0; i < tensor_count; i++) {
         ChipTensor t = orch_args->tensor(i);
 
@@ -847,6 +867,8 @@ extern "C" int bind_callable_to_runtime_impl(
                 api->device_free(dev_ptr);
                 return -1;
             }
+            staged_bytes += static_cast<uint64_t>(size);
+            ++staged_tensors;
         }
         // Read-only INPUT tensors are never written by the kernel, so there is
         // no point copying them back D2H at the end. Index the signature
@@ -879,7 +901,13 @@ extern "C" int bind_callable_to_runtime_impl(
     for (int i = 0; i < scalar_count; i++) {
         device_args.add_scalar(orch_args->scalar(i));
     }
-    int64_t t_args_end = _now_ms();
+    {
+        char attrs[128];
+        snprintf(
+            attrs, sizeof(attrs), "ntensor=%d staged=%d bytes=%" PRIu64, tensor_count, staged_tensors, staged_bytes
+        );
+        record_bind_phase(HostPhaseKind::BindArgs, t_args_ns, attrs);
+    }
 
     // Lay out the per-Worker static device arena. GM heap, PTO2 shared memory,
     // and the prebuilt runtime arena use three independent pooled device
@@ -897,33 +925,42 @@ extern "C" int bind_callable_to_runtime_impl(
     }
     uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(eff_task_window_sizes);
 
-    int64_t t_prebuilt_start = _now_ms();
+    const int64_t t_arena_build_ns = bind_now_ns();
     DeviceArena host_arena;
     PTO2RuntimeArenaLayout layout = runtime_reserve_layout(host_arena, eff_task_window_sizes, eff_heap_sizes);
     if (host_arena.commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
         LOG_ERROR("Failed to commit host arena for prebuilt runtime image");
         return -1;
     }
+    {
+        char attrs[64];
+        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, static_cast<uint64_t>(layout.arena_size));
+        record_bind_phase(HostPhaseKind::BindArenaBuild, t_arena_build_ns, attrs);
+    }
 
-    int64_t t_setup_start = _now_ms();
+    const int64_t t_static_arena_ns = bind_now_ns();
     if (api->setup_static_arena(total_heap_size, sm_size, layout.arena_size) != 0) {
         LOG_ERROR("Failed to setup pooled static arena");
         return -1;
     }
-    int64_t t_setup_end = _now_ms();
+    {
+        char attrs[96];
+        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " sm=%" PRIu64, total_heap_size, sm_size);
+        record_bind_phase(HostPhaseKind::BindStaticArena, t_static_arena_ns, attrs);
+    }
 
-    int64_t t_heap_start = _now_ms();
+    const int64_t t_heap_ns = bind_now_ns();
     void *gm_heap = api->acquire_pooled_gm_heap();
-    int64_t t_heap_end = _now_ms();
+    record_bind_phase(HostPhaseKind::BindGmHeap, t_heap_ns);
     if (gm_heap == nullptr) {
         LOG_ERROR("Failed to acquire pooled GM heap");
         return -1;
     }
     runtime->set_gm_heap(gm_heap);
 
-    int64_t t_sm_start = _now_ms();
+    const int64_t t_sm_ns = bind_now_ns();
     void *sm_ptr = api->acquire_pooled_gm_sm();
-    int64_t t_sm_end = _now_ms();
+    record_bind_phase(HostPhaseKind::BindSharedMem, t_sm_ns);
     if (sm_ptr == nullptr) {
         LOG_ERROR("Failed to acquire pooled PTO2 shared memory");
         return -1;
@@ -949,6 +986,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // boot becomes attach + wire (cheap pointer fixup) + sm_handle->init (SM
     // reset) + a handful of device-only field fixups.
     // -------------------------------------------------------------------------
+    const int64_t t_runtime_init_ns = bind_now_ns();
     PTO2Runtime *rt =
         runtime_init_data_from_layout(host_arena, layout, PTO2_MODE_EXECUTE, sm_ptr, sm_size, gm_heap, eff_heap_sizes);
     if (rt == nullptr) {
@@ -956,6 +994,7 @@ extern "C" int bind_callable_to_runtime_impl(
         return -1;
     }
     runtime_wire_arena_pointers(host_arena, layout, rt);
+    record_bind_phase(HostPhaseKind::BindRuntimeInit, t_runtime_init_ns);
 
     if (host_orch_func_ptr == nullptr) {
         LOG_ERROR("host-orch: orchestration entry points were not resolved");
@@ -970,7 +1009,15 @@ extern "C" int bind_callable_to_runtime_impl(
         );
         // The orchestrator is the only host-view reader; from here the device
         // owns these buffers, so drop the window on both exits.
+        const size_t view_count = tensor_access.mapping_count();
+        const uint64_t view_bytes = tensor_access.mapped_bytes();
+        const int64_t t_view_close_ns = bind_now_ns();
         tensor_access.close();
+        {
+            char attrs[96];
+            snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, view_count, view_bytes);
+            record_bind_phase(HostPhaseKind::BindHostViewClose, t_view_close_ns, attrs);
+        }
         if (total_tasks < 0) {
             LOG_ERROR("host-orch: orchestration run failed");
             return -1;
@@ -1000,6 +1047,7 @@ extern "C" int bind_callable_to_runtime_impl(
     always_assert(orch_start <= orch_end);
     char *arena_host = static_cast<char *>(host_arena.base());
     char *arena_dev = static_cast<char *>(runtime_arena_dev);
+    const int64_t t_arena_h2d_ns = bind_now_ns();
     int rc_upload = api->copy_to_device(arena_dev, arena_host, orch_start);
     if (rc_upload == 0) {
         rc_upload = api->copy_to_device(arena_dev + orch_end, arena_host + orch_end, layout.arena_size - orch_end);
@@ -1008,18 +1056,16 @@ extern "C" int bind_callable_to_runtime_impl(
         LOG_ERROR("Failed to rtMemcpy prebuilt runtime arena to device (rc=%d)", rc_upload);
         return -1;
     }
+    {
+        const uint64_t arena_h2d_bytes =
+            static_cast<uint64_t>(orch_start) + static_cast<uint64_t>(layout.arena_size - orch_end);
+        char attrs[96];
+        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, arena_h2d_bytes);
+        record_bind_phase(HostPhaseKind::BindArenaH2d, t_arena_h2d_ns, attrs, arena_h2d_bytes);
+    }
     runtime->set_prebuilt_arena(runtime_arena_dev, layout.off_runtime);
-    int64_t t_prebuilt_end = _now_ms();
 
     LOG_INFO("Device orchestration ready: %d tensors + %d scalars", tensor_count, scalar_count);
-
-    int64_t t_total_end = _now_ms();
-    LOG_INFO("TIMING: args_malloc_copy = %" PRId64 "ms", t_args_end - t_args_start);
-    LOG_INFO("TIMING: static_arena_setup = %" PRId64 "ms", t_setup_end - t_setup_start);
-    LOG_INFO("TIMING: gm_heap_acquire = %" PRId64 "ms", t_heap_end - t_heap_start);
-    LOG_INFO("TIMING: shared_mem_acquire = %" PRId64 "ms", t_sm_end - t_sm_start);
-    LOG_INFO("TIMING: prebuilt_runtime_arena = %" PRId64 "ms", t_prebuilt_end - t_prebuilt_start);
-    LOG_INFO("TIMING: total_init_runtime_impl = %" PRId64 "ms", t_total_end - t_total_start);
 
     return 0;
 }

--- a/src/a2a3/runtime/host_build_graph/runtime/host_phase_trace.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/host_phase_trace.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+/**
+ * Timing of this runtime's prepare path: the bind stage's segments and the host
+ * orchestrator's submit-level operations.
+ *
+ * One record call feeds two independent sinks, and the split is what lets each
+ * survive without the other:
+ *
+ *   - **Per-kind counters**, owned here. They produce the `LOG_TIMING`
+ *     breakdown and are exact whether or not records are being kept, so they are
+ *     the channel that works at `--rounds > 1`, where the artifact collectors are
+ *     switched off entirely.
+ *   - **The platform's host phase pool**, when a per-event reader is enabled.
+ *     Records go straight into platform-allocated memory (see
+ *     host/host_phase_records.h); this runtime holds only the pool pointer.
+ *
+ * Timestamps are host monotonic nanoseconds — the clock the `[STRACE]` host
+ * spans use — so records nest inside `simpler_run.bind` with no alignment step
+ * and share the enclosing run's (pid, inv) identity.
+ */
+
+/**
+ * Whether this runtime asks for its own prepare-path breakdown.
+ *
+ * True only when `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` starts with `1`, `t` or
+ * `T`, read once on first use. This is the producer's own condition; the runner
+ * ORs it with the chip-swimlane level when deciding whether to arm the pool, so
+ * a level-4 run collects records with the variable unset, and this variable
+ * collects them with the level at 0.
+ *
+ * "Breakdown" rather than "timing" because the bind stage's *duration* is
+ * already published as the `simpler_run.bind` `[STRACE]` marker; what this adds
+ * is the division of that one number into its parts.
+ */
+bool host_phase_timing_enabled();
+
+/**
+ * Host monotonic nanoseconds, or 0 when this pass records nothing — which is
+ * what keeps the orchestrator's per-operation hooks down to two calls returning
+ * a constant.
+ */
+uint64_t host_phase_now_ns();
+
+/**
+ * Append one record and fold it into its kind's counters.
+ *
+ * `kind` is a HostPhaseKind; it is passed as a plain integer because the
+ * orchestrator core declares a weak fallback for this function and is also
+ * compiled for the AICPU, where the platform's host headers are absent.
+ *
+ * @param payload  task id for the kinds that submit a task, else a detail count
+ * @param index    submit_idx for orchestrator operations, 0 for bind segments
+ */
+void host_phase_record(uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload, uint32_t index);
+
+/**
+ * Record one bind segment along with the attributes its log line carries.
+ *
+ * The attributes are formatted here rather than at flush so the values need not
+ * outlive the segment, and they are not written to the log here so the log write
+ * stays off the path being measured.
+ *
+ * @param payload  the segment's one machine-readable quantity, for readers that
+ *                 cannot parse the attribute text — byte count on a transfer
+ *                 segment, 0 where the segment moves nothing
+ */
+void host_phase_record_bind(uint32_t kind, uint64_t start_ns, const char *attrs, uint64_t payload = 0);
+
+/**
+ * Arm a pass: take the pool the runner offers, and clear the counters.
+ *
+ * Must run before the first bind segment, which is before the orchestration
+ * phase and therefore well before the device collector exists.
+ *
+ * @param host_api  this run's `const HostApi *`, void-typed to keep the
+ *                  platform headers out of the orchestrator core's include set
+ */
+void host_phase_trace_begin(const void *host_api);
+
+/**
+ * Report how many tasks this pass submitted, at the point that becomes known —
+ * inside the orchestration segment, well before the pass ends. A reader compares
+ * it against the records whose kind submits a task.
+ */
+void host_phase_trace_note_submitted(uint64_t submitted_tasks);
+
+/**
+ * Close the pass: hand the submitted-task count and the run's invocation id to
+ * the runner, then emit the per-kind `LOG_TIMING` breakdown from the counters.
+ *
+ * The records stay in the pool for its readers.
+ */
+void host_phase_trace_end();

--- a/src/a2a3/runtime/host_build_graph/runtime/host_tensor_access.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/host_tensor_access.h
@@ -101,6 +101,12 @@ public:
     /** Drop every region and unregister every mapping this accessor installed. */
     void close() noexcept;
 
+    /** Mappings installed by `add` and not yet dropped by `close`. */
+    size_t mapping_count() const noexcept;
+
+    /** Total bytes covered by those mappings; excludes fallback staging views. */
+    uint64_t mapped_bytes() const noexcept;
+
 private:
     struct Impl;
     Impl *impl_;

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -130,8 +130,6 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() {
 // Weak fallback for builds that don't link chip_swimlane_collector_aicpu.cpp.
 // The strong symbol from the AICPU build wins when profiling is available.
 // Also hidden to prevent HOST .so from polluting the global symbol table.
-__attribute__((weak, visibility("hidden"))) void
-chip_swimlane_aicpu_record_orch_phase(uint64_t, uint64_t, uint64_t, uint32_t) {}
 // Accumulated cycles per sub-step (only needed for ORCH_PROFILING export)
 static uint64_t g_orch_sync_cycle = 0;       // tensormap sync
 static uint64_t g_orch_alloc_cycle = 0;      // unified task+heap alloc
@@ -149,30 +147,16 @@ uint64_t g_orch_args_atomic_count = 0;
 uint64_t g_orch_scope_end_atomic_count = 0;
 // Cycle accumulation is unconditional under SIMPLER_ORCH_PROFILING (that's what
 // the flag is for) and feeds the per-sub-step `g_orch_*_cycle` cumulatives
-// printed in the cold-path log.
-//
-// Per-submit ORCH_SUBMIT record is the only swim-lane emit on the orch
-// path — one record per submit_task() / alloc_tensors() call spanning
-// the entire [start, end] window. Per-sub-step phase records were dropped
-// in favour of the cumulatives + per-submit envelope; the dispatcher
-// already inserts one record at the end of each submit path via
-// CYCLE_COUNT_ORCH_SUBMIT_RECORD.
-#define CYCLE_COUNT_START()                                                            \
-    bool _prof_active = (orch->chip_swimlane_level >= ChipSwimlaneLevel::ORCH_PHASES); \
-    uint64_t _t0 = get_sys_cnt_aicpu(), _t1;                                           \
-    uint64_t _submit_start_ts = _t0
+// printed in the cold-path log. Per-event records are a separate channel on a
+// separate clock — see ORCH_PHASE_END below.
+#define CYCLE_COUNT_START()                  \
+    uint64_t _t0 = get_sys_cnt_aicpu(), _t1; \
+    (void)_t1
 #define CYCLE_COUNT_LAP(acc)       \
     do {                           \
         _t1 = get_sys_cnt_aicpu(); \
         acc += (_t1 - _t0);        \
         _t0 = _t1;                 \
-    } while (0)
-#define CYCLE_COUNT_ORCH_SUBMIT_RECORD(tid)                                                         \
-    do {                                                                                            \
-        if (_prof_active) {                                                                         \
-            _t1 = get_sys_cnt_aicpu();                                                              \
-            chip_swimlane_aicpu_record_orch_phase(_submit_start_ts, _t1, (tid), g_orch_submit_idx); \
-        }                                                                                           \
     } while (0)
 #elif SIMPLER_DFX
 #include "aicpu/device_time.h"
@@ -189,28 +173,54 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() {
     return static_cast<uint64_t>(ts.tv_sec) * PLATFORM_PROF_SYS_CNT_FREQ +
            static_cast<uint64_t>(ts.tv_nsec) * PLATFORM_PROF_SYS_CNT_FREQ / 1000000000ull;
 }
-__attribute__((weak, visibility("hidden"))) void
-chip_swimlane_aicpu_record_orch_phase(uint64_t, uint64_t, uint64_t, uint32_t) {}
-// submit_idx needed for swimlane task_id tagging (no cycle accumulation at this level)
+// submit_idx tags a record with its position in the pass's submit order.
 static uint32_t g_orch_submit_idx = 0;
-#define CYCLE_COUNT_START()                                                            \
-    bool _prof_active = (orch->chip_swimlane_level >= ChipSwimlaneLevel::ORCH_PHASES); \
-    uint64_t _t0 = _prof_active ? get_sys_cnt_aicpu() : 0, _t1 = 0;                    \
-    uint64_t _submit_start_ts = _t0
-#define CYCLE_COUNT_LAP(acc) \
-    do {                     \
-    } while (0)
-#define CYCLE_COUNT_ORCH_SUBMIT_RECORD(tid)                                                         \
-    do {                                                                                            \
-        if (_prof_active) {                                                                         \
-            _t1 = get_sys_cnt_aicpu();                                                              \
-            chip_swimlane_aicpu_record_orch_phase(_submit_start_ts, _t1, (tid), g_orch_submit_idx); \
-        }                                                                                           \
-    } while (0)
+// The per-sub-step accumulators exist only in an ORCH_PROFILING build, so at this
+// level there is nothing to time.
+#define CYCLE_COUNT_START()
+#define CYCLE_COUNT_LAP(acc)
 #else
 #define CYCLE_COUNT_START()
 #define CYCLE_COUNT_LAP(acc)
-#define CYCLE_COUNT_ORCH_SUBMIT_RECORD(tid)
+#endif
+
+// Host phase record sink. The host build links a strong definition that folds the
+// record into its kind's counters and appends it to the platform's record pool;
+// every other build keeps this no-op. Kind values are HostPhaseKind, passed as a
+// plain integer because this file is also compiled for the AICPU, where the
+// platform's host headers are absent.
+__attribute__((weak, visibility("hidden"))) void host_phase_record(uint64_t, uint64_t, uint32_t, uint64_t, uint32_t) {}
+
+// Host monotonic clock shared with the `[STRACE]` span tree, so a record nests
+// under simpler_run.bind.host_orch without any clock conversion. The host build
+// links the strong definition in host_phase_trace.cpp; this fallback keeps
+// non-host builds linking, where the recorder above is a no-op anyway.
+__attribute__((weak, visibility("hidden"))) uint64_t host_phase_now_ns() { return 0; }
+
+#if SIMPLER_DFX
+// Kinds this file records, spelled as the HostPhaseKind values the host side
+// reads. Only the host orchestrator reaches these sites, so the bind-stage kinds
+// that precede them in the enum are not named here.
+enum class HostOrchPhase : uint32_t {
+    Submit = 12,           // submit_task_common: one ordinary ring task
+    Prepare = 13,          // prepare_task: one alloc_tensors slot
+    RecordNode = 14,       // graph_record_submit_node: one recorded Graph node
+    GraphSubmit = 15,      // graph_submit_definition: one outer GRAPH task
+    BuildDefinition = 16,  // graph_build_definition: nodes compacted into the image
+};
+#define ORCH_PHASE_START() const uint64_t _orch_phase_t0 = host_phase_now_ns()
+#define ORCH_PHASE_END(phase, detail)                                                                         \
+    do {                                                                                                      \
+        host_phase_record(                                                                                    \
+            _orch_phase_t0, host_phase_now_ns(), static_cast<uint32_t>(phase), static_cast<uint64_t>(detail), \
+            g_orch_submit_idx                                                                                 \
+        );                                                                                                    \
+    } while (0)
+#else
+#define ORCH_PHASE_START()
+#define ORCH_PHASE_END(phase, detail) \
+    do {                              \
+    } while (0)
 #endif
 
 static int32_t orch_mark_fatal(PTO2OrchestratorState *orch, int32_t error_code) {
@@ -1116,6 +1126,7 @@ static TaskOutputTensors submit_task_common(
     int32_t aic_kernel_id, int32_t aiv0_kernel_id, int32_t aiv1_kernel_id
 ) {
     CYCLE_COUNT_START();
+    ORCH_PHASE_START();
     TaskOutputTensors result;
     PTO2OutputLayout layout = calculate_output_layout(args);
     PTO2PreparedTask prepared;
@@ -1298,7 +1309,7 @@ static TaskOutputTensors submit_task_common(
     (void)sched;
 
     CYCLE_COUNT_LAP(g_orch_fanin_cycle);
-    CYCLE_COUNT_ORCH_SUBMIT_RECORD(task_id.raw);
+    ORCH_PHASE_END(HostOrchPhase::Submit, task_id.raw);
 
 #if SIMPLER_DFX
     orch->tasks_submitted++;
@@ -1433,7 +1444,6 @@ bool graph_submit_definition(
     PTO2OrchestratorState *orch, GraphHostState *state, const std::vector<std::byte> &definition_image,
     const CoreTaskArgs &args, PTO2TaskId *submitted_id
 ) {
-    CYCLE_COUNT_START();
     const GraphDefinition *definition = graph_definition(definition_image);
     if (definition == nullptr || !graph_boundary_matches(*definition, args) ||
         definition->required_heap > static_cast<uint64_t>(INT32_MAX)) {
@@ -1499,7 +1509,6 @@ bool graph_submit_definition(
     pending.outer_slot = &slot;
     state->pending_uploads.push_back(std::move(pending));
     if (submitted_id != nullptr) *submitted_id = task_id;
-    CYCLE_COUNT_ORCH_SUBMIT_RECORD(task_id.raw);
 #if SIMPLER_DFX
     orch->tasks_submitted++;
 #endif
@@ -1519,6 +1528,7 @@ TaskOutputTensors graph_record_submit_node(
     PTO2OrchestratorState *orch, const CoreTaskArgs &args, ActiveMask active_mask, TaskAttrs task_attrs,
     int32_t aic_kernel_id, int32_t aiv0_kernel_id, int32_t aiv1_kernel_id
 ) {
+    ORCH_PHASE_START();
     TaskOutputTensors result;
     GraphRecording &recording = *graph_state_from(orch)->recording;
 
@@ -1652,6 +1662,7 @@ TaskOutputTensors graph_record_submit_node(
     }
 
     recording.nodes.push_back(std::move(node));
+    ORCH_PHASE_END(HostOrchPhase::RecordNode, task_id.raw);
     return result;
 }
 
@@ -1677,9 +1688,11 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const CoreTaskArgs &args,
     auto definition_it = state->definitions.find(full_key);
     if (definition_it != state->definitions.end()) {
         PTO2TaskId submitted = PTO2TaskId::invalid();
+        ORCH_PHASE_START();
         if (graph_submit_definition(orch, state, definition_it->second, args, &submitted)) {
             result.execute_block = false;
             result.task_id = submitted;
+            ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
 #if SIMPLER_DFX
             g_orch_submit_idx++;
 #if SIMPLER_ORCH_PROFILING
@@ -1735,11 +1748,13 @@ bool PTO2OrchestratorState::graph_end() {
     this->ring.task_allocator.restore_heap_top(recording->heap_watermark);
 
     std::vector<std::byte> definition;
+    ORCH_PHASE_START();
     if (!graph_build_definition(*recording, &definition)) {
         debug_assert(false && "The recorded Graph contains a construct that Graph Execution does not support");
         LOG_WARN("%s", "[GraphExecution] unsupported construct observed; falling back to the ordinary path");
         return false;
     }
+    ORCH_PHASE_END(HostOrchPhase::BuildDefinition, recording->nodes.size());
     const GraphDefinition *header = graph_definition(definition);
     if (header == nullptr) return false;
     LOG_DEBUG(
@@ -1754,9 +1769,13 @@ bool PTO2OrchestratorState::graph_end() {
     // block instead of one per internal node. The Definition stays cached for
     // subsequent invocations even if this placement fails.
     PTO2TaskId submitted = PTO2TaskId::invalid();
-    if (recording->boundary_args == nullptr ||
-        !graph_submit_definition(this, state, cached, *recording->boundary_args, &submitted)) {
-        return false;
+    {
+        ORCH_PHASE_START();
+        if (recording->boundary_args == nullptr ||
+            !graph_submit_definition(this, state, cached, *recording->boundary_args, &submitted)) {
+            return false;
+        }
+        ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
     }
 #if SIMPLER_DFX
     g_orch_submit_idx++;
@@ -1923,6 +1942,7 @@ TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const CoreTaskArgs &args)
     }
 
     CYCLE_COUNT_START();
+    ORCH_PHASE_START();
 
     if (args.has_error) {
         report_fatal(
@@ -2009,7 +2029,7 @@ TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const CoreTaskArgs &args)
     orch->inline_completed_tasks++;
 
     CYCLE_COUNT_LAP(g_orch_fanin_cycle);
-    CYCLE_COUNT_ORCH_SUBMIT_RECORD(prepared.task_id.raw);
+    ORCH_PHASE_END(HostOrchPhase::Prepare, prepared.task_id.raw);
 
 #if SIMPLER_DFX
     orch->tasks_submitted++;

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_orchestrator.h
@@ -96,10 +96,6 @@ struct PTO2OrchestratorState {
     // Total core counts set once at executor init; used for submit-time deadlock detection.
     int32_t total_cluster_count{0};  // AIC cores = MIX clusters
     int32_t total_aiv_count{0};      // AIV cores (= 2 × clusters on standard hardware)
-#if SIMPLER_DFX
-    // chip swimlane_level copied from get_chip_swimlane_level().
-    ChipSwimlaneLevel chip_swimlane_level{ChipSwimlaneLevel::DISABLED};
-#endif
 
     // === GM HEAP (for output buffers) ===
     void *gm_heap_base;     // Base address of GM heap

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -184,6 +184,22 @@ constexpr int PLATFORM_PROF_SCHED_BUFFERS_PER_THREAD = 6;
 constexpr int PLATFORM_PROF_ORCH_BUFFERS_PER_THREAD = 8;
 
 /**
+ * Host phase-record pool geometry (host_build_graph's bind path and host
+ * orchestrator).
+ *
+ * Same rotating-pool shape as the sched/orch pools above, sized for its own
+ * producer rather than theirs: a scheduler thread emits tens of thousands of
+ * records per run, while one host orchestration pass emits a few hundred (a
+ * 40-layer decode: 12 bind segments + ~325 submit-level operations). Inheriting
+ * PLATFORM_PHASE_RECORDS_PER_THREAD here would allocate 4 MB to hold 11 KB and
+ * leave the rotation path unreachable, so per-buffer capacity is 1024 records
+ * (32 KB) and the pool holds 5 of them — the floor that lets
+ * PLATFORM_PROF_SLOT_COUNT spares fill the free_queue with one buffer active.
+ */
+constexpr int PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER = 1024;
+constexpr int PLATFORM_HOST_PHASE_BUFFERS = PLATFORM_PROF_SLOT_COUNT + 1;
+
+/**
  * Per-core ChipSwimlaneAicoreTaskBuffer pre-allocation count.
  * 1 goes into the free_queue at init, the rest are recycled by host as
  * AICPU rotates per BUFFER_SIZE dispatches. Declared here so the ready-queue

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -68,6 +68,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/host_regs.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/host_phase_records.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/dep_gen_collector.cpp"

--- a/src/a5/platform/sim/host/CMakeLists.txt
+++ b/src/a5/platform/sim/host/CMakeLists.txt
@@ -49,6 +49,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/pto_runtime_c_api.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/host_phase_records.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/dep_gen_collector.cpp"

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -39,6 +39,7 @@
 #include "common/unified_log.h"
 #include "cpu_sim_context.h"
 #include "host_log.h"
+#include "host/host_phase_records_artifact.h"
 #include "host/raii_scope_guard.h"
 #include "host/runtime_timeout_config.h"
 #include "runtime.h"
@@ -623,6 +624,7 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
         chip_swimlane_collector_.stop();
         chip_swimlane_collector_.read_phase_header_metadata();
         chip_swimlane_collector_.reconcile_counters();
+        publish_host_phase_records_to_swimlane();
         chip_swimlane_collector_.export_swimlane_json();
     }
 
@@ -647,6 +649,14 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
                 LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", replay_rc);
             }
         }
+    }
+
+    // Per-event view of the prepare path. Keyed on output_prefix_ rather than a
+    // flag because it is non-empty exactly when this run produces diagnostic
+    // artifacts, and on the store having finished a pass, which is what a
+    // host-orchestrating runtime leaves behind.
+    if (!output_prefix_.empty() && host_phase_records_.finished()) {
+        (void)host_phase_records_.write_records_jsonl(make_host_phase_records_path(output_prefix_));
     }
 
     if (enable_scope_stats_) {

--- a/src/a5/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a5/runtime/host_build_graph/docs/profiling_levels.md
@@ -232,6 +232,111 @@ Thread X:   overlap checks : XXX, hits=XXX (XX.X%)
 
 ---
 
+## Prepare-Path Timing: One Pool, Three Views
+
+`host_build_graph` times its prepare path — the `simpler_run.bind` stage's
+segments, and the host orchestrator's submit-level operations inside it. One
+recorder feeds three views, and two independent switches decide which of them
+appear.
+
+### What is recorded
+
+Seventeen kinds, all on the host monotonic clock the `[STRACE]` host spans use,
+so records and spans read against each other with no alignment step.
+
+| Group | Kinds |
+| ----- | ----- |
+| Bind segments (partition the stage) | `args`, `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init`, `host_orch`, `graph_upload`, `relocate`, `sm_h2d`, `arena_h2d`, `host_view_close` |
+| Orchestrator operations (inside `host_orch`) | `submit_task`, `alloc_tensors`, `record_node`, `graph_submit`, `build_definition` |
+
+Three of the orchestrator kinds end with a task submitted — `submit_task`,
+`alloc_tensors`, `graph_submit` — so their count is the pass's `total_tasks`.
+The other two are sub-operations of one of those, which is why a per-kind total
+is a **cost share, not an interval**: a per-event mean is `total_ns / count`, and
+the spread is not recoverable from it.
+
+### The two switches
+
+| Switch | Turns on |
+| ------ | -------- |
+| `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` (env, off unless it starts with `1`, `t` or `T`) | the `LOG_TIMING` breakdown; needs no rebuild and works at any `--rounds` |
+| `--enable-chip-swimlane 4` (CallConfig `chip_swimlane_level`) | the host lane in `chip_swimlane_records.json`, with its records clock-aligned against the device timeline |
+
+Collection is armed by **either** — a level-4 run collects records with the
+variable unset, and the variable collects them with the level at 0. What is
+recorded does not depend on which one armed the pass: the swimlane's share is a
+projection at export, not a branch at record time, so the two configurations
+measure the same overhead and their numbers are comparable.
+
+```bash
+# breakdown only, any --rounds, no rebuild
+SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 python -m pytest <case> --platform <platform> --device 0
+
+# host lane on the chip swimlane, aligned against the device timeline
+python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 4
+```
+
+### The three views
+
+- **`LOG_TIMING` lines**, at the default log threshold, gated by the env
+  variable. One `bind phase=<p> start_ns=<n> dur_ns=<n> <attrs>` line per
+  segment, plus one `host-orch phase=<p> total_ns=<n> count=<k> detail_sum=<n>
+  dropped=<n>` line per orchestrator kind. They come from per-kind counters, not
+  from the record pool, so a total stays exact even if the pool was never armed or
+  overflowed — that is what makes this the channel for steady state, where
+  `--rounds > 1` switches every artifact collector off.
+
+  Every line is written at the end of the pass, keeping the log write off the path
+  being measured. The line therefore carries its own `start_ns`; the log prefix
+  timestamps the write, not the segment.
+
+- **`host_phase_records.jsonl`** in the per-case output directory, when the run
+  has one. One JSON Lines object per pass carrying `pid` / `inv` — the identity
+  the `[STRACE]` tree groups by — and one record per operation. This is the
+  channel to read for a distribution or a per-event timeline; the summed lines
+  cannot express either. `strace_timing.py --swimlane --host-phase-records <path>`
+  draws each record inside the matching `simpler_run.bind`.
+
+- **The host lanes of `chip_swimlane_records.json`**, at level 4 only, joined to
+  the device timeline through the clock anchors (see `host/clock_correlation.h`).
+  Two projections of the pool land there:
+
+  | Key | Kinds | Rendered as |
+  | --- | ----- | ----------- |
+  | `host_orchestrator_phases` | the task-submitting kinds | `Host Orchestrator` process |
+  | `host_device_uploads` | `graph_upload`, `sm_h2d`, `arena_h2d`, with byte counts | `Host Prepare` / `H2D` lane |
+
+  The upload lane is the one place the whole question — orchestration plus H2D
+  inside a millisecond — is visible against the device execution it precedes; the
+  rest of the bind stage is host-only setup with no device counterpart.
+
+  The `host_capture` block reports `expected_records` (the pass's task count)
+  against `recorded_records` (the submit projection), plus `pool_records` for the
+  whole population — a pool count above the projection is normal, not incomplete.
+
+The stage's *duration* is already published as the `simpler_run.bind` `[STRACE]`
+marker, so the marker and this breakdown are a total and its parts rather than two
+spellings of one number. The parts are not markers themselves: the marker grammar
+is the platform's public per-run-stage contract (see `pto_runtime_c_api.h` and
+[docs/dfx/host-trace.md](../../../../../docs/dfx/host-trace.md)), whose consumers
+key off a fixed stage set, and a runtime's internal breakdown of one stage does
+not belong in it.
+
+### Cost and capacity
+
+A record costs two clock reads, a store and two counter updates — roughly 47 ns
+on an aarch64 host, for ~337 operations in a 40-layer decode pass. Cheap, but it
+sits on the path being measured, which is why neither switch is on by default.
+
+The pool holds `PLATFORM_HOST_PHASE_BUFFERS × PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER`
+records (5 × 1024 = 5120, 160 KB) in fixed-size buffers rotated in index order,
+the same shape as the device sched/orch pools with host DDR as its backing.
+Beyond that, records are dropped from the tail and counted: the per-event views
+truncate, the per-kind totals stay exact, and `dropped=` on every `host-orch` line
+plus `dropped_records` in `host_capture` say so.
+
+---
+
 ## Runtime Flag: enable_chip_swimlane (perf_level)
 
 `--enable-chip-swimlane` accepts an integer perf_level (0–4). Transport

--- a/src/a5/runtime/host_build_graph/host/host_phase_trace.cpp
+++ b/src/a5/runtime/host_build_graph/host/host_phase_trace.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Prepare-path timing: per-kind counters and the binding to the platform's
+ * record pool. See runtime/host_phase_trace.h.
+ */
+
+#include "../runtime/host_phase_trace.h"
+
+#include <stdio.h>
+
+#include <array>
+#include <cstdlib>
+
+#include "common/host_api.h"
+#include "common/log_clock.h"
+#include "common/strace.h"
+#include "common/unified_log.h"
+#include "host/host_phase_records.h"
+
+namespace {
+
+// Bind segments carry a few attributes each beyond their duration (byte counts,
+// tensor counts). They are formatted when the segment ends and printed at flush,
+// so a segment's values need not outlive it and the log write stays off the
+// measured path.
+constexpr size_t kBindAttrsCapacity = 96;
+
+struct KindCounter {
+    uint64_t total_ns;
+    uint64_t count;
+    uint64_t payload_sum;
+    uint64_t first_start_ns;
+};
+
+struct TraceState {
+    HostPhaseRecordPool *pool;
+    const HostApi *api;
+    bool active;
+    uint64_t submitted_tasks;
+    std::array<KindCounter, kHostPhaseKindCount> counters;
+    std::array<std::array<char, kBindAttrsCapacity>, kHostPhaseKindCount> bind_attrs;
+};
+
+TraceState &state() {
+    static TraceState s{};
+    return s;
+}
+
+bool is_bind_kind(uint32_t kind) { return kind < static_cast<uint32_t>(HostPhaseKind::OrchSubmitTask); }
+
+}  // namespace
+
+bool host_phase_timing_enabled() {
+    // Read once: the value cannot change within a process, and the orchestrator
+    // asks per submit-level operation. Opt-in spelling matches the runtime's
+    // other default-off switch, SIMPLER_TMR_SERIAL_ORCH_SCHED_ENABLE, so that
+    // `=false` / `=off` / `=no` read as off rather than as a non-zero string.
+    static const bool enabled = [] {
+        const char *env = std::getenv("SIMPLER_HBG_BIND_BREAKDOWN_ENABLE");
+        return env != nullptr && (env[0] == '1' || env[0] == 't' || env[0] == 'T');
+    }();
+    return enabled;
+}
+
+// Strong definitions overriding the orchestrator core's weak fallbacks, which
+// exist so builds without this translation unit still link.
+__attribute__((visibility("hidden"))) uint64_t host_phase_now_ns() {
+    if (!state().active) {
+        return 0;
+    }
+    return static_cast<uint64_t>(simpler::log::monotonic_now_ns());
+}
+
+__attribute__((visibility("hidden"))) void
+host_phase_record(uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload, uint32_t index) {
+    TraceState &s = state();
+    if (!s.active || kind >= kHostPhaseKindCount || end_ns < start_ns) {
+        return;
+    }
+    KindCounter &counter = s.counters[kind];
+    if (counter.count == 0) {
+        counter.first_start_ns = start_ns;
+    }
+    counter.total_ns += end_ns - start_ns;
+    counter.count++;
+    counter.payload_sum += payload;
+    host_phase_pool_append(s.pool, static_cast<HostPhaseKind>(kind), start_ns, end_ns, payload, index);
+}
+
+void host_phase_record_bind(uint32_t kind, uint64_t start_ns, const char *attrs, uint64_t payload) {
+    TraceState &s = state();
+    if (!s.active || !is_bind_kind(kind)) {
+        return;
+    }
+    const uint64_t end_ns = static_cast<uint64_t>(simpler::log::monotonic_now_ns());
+    if (attrs != nullptr) {
+        snprintf(s.bind_attrs[kind].data(), kBindAttrsCapacity, "%s", attrs);
+    }
+    host_phase_record(start_ns, end_ns, kind, payload, 0);
+}
+
+void host_phase_trace_begin(const void *host_api) {
+    TraceState &s = state();
+    s.api = static_cast<const HostApi *>(host_api);
+    s.pool = s.api != nullptr ?
+                 static_cast<HostPhaseRecordPool *>(s.api->host_phase_pool_arm(host_phase_timing_enabled())) :
+                 nullptr;
+    // Timestamps are taken whenever either sink wants them. Gating the clock on
+    // the environment variable alone would leave a level-4 run recording zeros.
+    s.active = s.pool != nullptr || host_phase_timing_enabled();
+    s.submitted_tasks = 0;
+    s.counters.fill(KindCounter{});
+    for (auto &attrs : s.bind_attrs) {
+        attrs[0] = '\0';
+    }
+}
+
+void host_phase_trace_note_submitted(uint64_t submitted_tasks) { state().submitted_tasks = submitted_tasks; }
+
+void host_phase_trace_end() {
+    TraceState &s = state();
+    if (!s.active) {
+        return;
+    }
+    // Read the pool's own tally before handing it back, and drop the pointer
+    // after: the pool belongs to the runner from finish() onward, and the pass is
+    // over either way, so nothing here may outlive it. Clearing `active` also
+    // makes a second end() without an intervening begin() a no-op rather than a
+    // stale read plus a duplicate report.
+    const uint64_t dropped = s.pool != nullptr ? s.pool->head.dropped_record_count : 0;
+    if (s.api != nullptr) {
+        uint64_t inv = 0;
+#if SIMPLER_HOST_STRACE
+        // The invocation id the enclosing run's spans carry, so a per-event
+        // artifact joins to them on (pid, inv).
+        inv = simpler::strace::StraceScope::current_inv();
+#endif
+        s.api->host_phase_pool_finish(s.submitted_tasks, inv);
+    }
+    s.pool = nullptr;
+    s.active = false;
+    if (!host_phase_timing_enabled()) {
+        // Records were collected for a per-event reader alone, which has its own
+        // report; this breakdown was not asked for.
+        return;
+    }
+
+    for (uint32_t kind = 0; kind < kHostPhaseKindCount; ++kind) {
+        const KindCounter &counter = s.counters[kind];
+        if (counter.count == 0) {
+            continue;
+        }
+        const char *name = host_phase_kind_name(static_cast<HostPhaseKind>(kind));
+        if (is_bind_kind(kind)) {
+            // One occurrence per pass, so the summed time is the segment's own
+            // duration and the twelve of them partition the bind stage. The line
+            // carries its own start because every line is written at the end of
+            // the pass, off the path being measured — the write time says nothing
+            // about when the segment ran.
+            LOG_TIMING(
+                "bind phase=%s start_ns=%llu dur_ns=%llu %s", name,
+                static_cast<unsigned long long>(counter.first_start_ns),
+                static_cast<unsigned long long>(counter.total_ns), s.bind_attrs[kind].data()
+            );
+            continue;
+        }
+        // A summed cost share, not an interval: several of these kinds are
+        // sub-operations of another, so there is no honest way to draw the total
+        // on a timeline. Per-event bars come from the artifact instead.
+        LOG_TIMING(
+            "host-orch phase=%s total_ns=%llu count=%llu detail_sum=%llu dropped=%llu", name,
+            static_cast<unsigned long long>(counter.total_ns), static_cast<unsigned long long>(counter.count),
+            static_cast<unsigned long long>(counter.payload_sum), static_cast<unsigned long long>(dropped)
+        );
+    }
+}

--- a/src/a5/runtime/host_build_graph/host/host_tensor_access.cpp
+++ b/src/a5/runtime/host_build_graph/host/host_tensor_access.cpp
@@ -38,6 +38,8 @@ struct HostTensorAccessor::Impl {
     const HostApi *api;
     std::vector<HostTensorRegion> regions;
     std::vector<void *> mappings;
+    // Bytes covered by `mappings`, i.e. excluding regions serving a fallback view.
+    uint64_t mapped_bytes;
 };
 
 // The region serving the whole of [dev_addr, dev_addr + bytes), or nullptr.
@@ -59,7 +61,7 @@ find_region(const std::vector<HostTensorRegion> &regions, uint64_t dev_addr, uin
 }
 
 HostTensorAccessor::HostTensorAccessor(const HostApi *api) :
-    impl_(new Impl{api, {}, {}}) {}
+    impl_(new Impl{api, {}, {}, 0}) {}
 
 HostTensorAccessor::~HostTensorAccessor() {
     close();
@@ -77,6 +79,7 @@ bool HostTensorAccessor::add(uint64_t dev_base, uint64_t size, void *fallback_ho
     void *host_view = impl_->api->register_device_memory_to_host(reinterpret_cast<void *>(dev_base), size);
     if (host_view != nullptr) {
         impl_->mappings.push_back(reinterpret_cast<void *>(dev_base));
+        impl_->mapped_bytes += size;
     } else {
         host_view = fallback_host_view;
     }
@@ -113,12 +116,17 @@ bool HostTensorAccessor::write(uint64_t dev_addr, const void *src, uint64_t byte
     return impl_->api->copy_to_device(reinterpret_cast<void *>(dev_addr), dst, static_cast<size_t>(bytes)) == 0;
 }
 
+size_t HostTensorAccessor::mapping_count() const noexcept { return impl_->mappings.size(); }
+
+uint64_t HostTensorAccessor::mapped_bytes() const noexcept { return impl_->mapped_bytes; }
+
 void HostTensorAccessor::close() noexcept {
     for (void *dev_ptr : impl_->mappings) {
         impl_->api->unregister_device_memory_from_host(dev_ptr);
     }
     impl_->mappings.clear();
     impl_->regions.clear();
+    impl_->mapped_bytes = 0;
 }
 
 bool host_tensor_read(HostTensorAccessor *accessor, uint64_t dev_addr, void *dst, uint64_t bytes) {

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -31,7 +31,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/stat.h>
-#include <sys/time.h>
 #include <unistd.h>
 
 #include <atomic>
@@ -48,6 +47,7 @@
 #include <optional>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <unordered_map>
 #include <vector>
 
@@ -57,6 +57,7 @@
 #include "../runtime/graph_execution.h"
 #include "../runtime/host_tensor_access.h"
 #include "../runtime/graph_host_state.h"
+#include "../runtime/host_phase_trace.h"
 #include "../runtime/pto_orchestrator.h"
 #include "../runtime/pto_runtime2.h"
 #include "../runtime/pto_shared_memory.h"
@@ -67,9 +68,11 @@
 #include "../../../../common/worker/pto_runtime_c_api.h"
 #include "callable.h"
 #include "common/host_log_binding.h"
+#include "common/log_clock.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "host_log.h"
+#include "host/raii_scope_guard.h"
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
@@ -104,64 +107,24 @@ extern "C" int concurrent_native_prepare_supported_impl(void) {
 // first slot; it must fit within the ABI's slot budget, not equal it.
 static_assert(PTO2_MAX_RING_DEPTH <= RUNTIME_ENV_RING_COUNT, "PTO2 runtime ring depth must fit RuntimeEnv ring slots");
 
-// Helper: return current time in milliseconds
-static int64_t _now_ms() {
-    struct timeval tv;
-    gettimeofday(&tv, nullptr);
-    return static_cast<int64_t>(tv.tv_sec) * 1000 + tv.tv_usec / 1000;
-}
-
-namespace {
-
-thread_local const HostApi *g_host_orch_profile_api = nullptr;
-thread_local uint32_t g_host_orch_submit_idx = 0;
-
-uint64_t host_fallback_cycles_to_ns(uint64_t cycles) {
-    constexpr uint64_t kNsPerSecond = 1000000000ull;
-    return (cycles / PLATFORM_PROF_SYS_CNT_FREQ) * kNsPerSecond +
-           (cycles % PLATFORM_PROF_SYS_CNT_FREQ) * kNsPerSecond / PLATFORM_PROF_SYS_CNT_FREQ;
-}
-
-class HostOrchestratorProfileBinding {
-public:
-    HostOrchestratorProfileBinding(const HostApi *api, uint64_t task_window_size) :
-        previous_(g_host_orch_profile_api),
-        previous_submit_idx_(g_host_orch_submit_idx) {
-        if (api != nullptr && api->chip_swimlane_level() == static_cast<uint32_t>(ChipSwimlaneLevel::ORCH_PHASES)) {
-            api->begin_host_orchestrator_capture(task_window_size);
-            g_host_orch_profile_api = api;
-            g_host_orch_submit_idx = 0;
-        }
-    }
-
-    ~HostOrchestratorProfileBinding() {
-        g_host_orch_profile_api = previous_;
-        g_host_orch_submit_idx = previous_submit_idx_;
-    }
-
-private:
-    const HostApi *previous_;
-    uint32_t previous_submit_idx_;
-};
-
-}  // namespace
-
-// Strong host-side override for the weak fallback in pto_orchestrator.cpp.
-// Its inputs are the host fallback's frequency-scaled CLOCK_MONOTONIC values;
-// convert them back to ns and route the typed record through this run's
-// HostApi binding. The AICPU build does not link runtime_maker.cpp and keeps
-// using the device collector's implementation.
-__attribute__((visibility("hidden"))) void
-chip_swimlane_aicpu_record_orch_phase(uint64_t start_time, uint64_t end_time, uint64_t task_id, uint32_t) {
-    if (g_host_orch_profile_api == nullptr) return;
-    ChipSwimlaneHostOrchPhaseRecord record{
-        host_fallback_cycles_to_ns(start_time), host_fallback_cycles_to_ns(end_time), task_id, g_host_orch_submit_idx++,
-        0
-    };
-    g_host_orch_profile_api->record_host_orchestrator_phase(record);
-}
-
 static bool is_power_of_2_u64(uint64_t value) { return value != 0 && (value & (value - 1)) == 0; }
+
+// Host monotonic clock, shared with the record pool so spans and records can be
+// read against each other.
+static int64_t bind_now_ns() { return static_cast<int64_t>(host_phase_now_ns()); }
+
+// Close one segment of the bind path, recording it and keeping its attributes for
+// the line the breakdown prints at the end of the pass.
+//
+// The breakdown is LOG_TIMING lines rather than `[STRACE]` markers on purpose:
+// the marker grammar is the platform's public per-run-stage contract (see
+// pto_runtime_c_api.h and docs/dfx/host-trace.md) whose consumers key off a fixed
+// stage set, while everything below is host_build_graph's internal breakdown of
+// one stage. LOG_TIMING sits at the default log threshold, so these are visible
+// without a flag and at any --rounds.
+static void record_bind_phase(HostPhaseKind kind, int64_t start_ns, const char *attrs = "", uint64_t payload = 0) {
+    host_phase_record_bind(static_cast<uint32_t>(kind), static_cast<uint64_t>(start_ns), attrs, payload);
+}
 
 template <typename T>
 static std::string format_ring_array(const T (&values)[PTO2_MAX_RING_DEPTH]) {
@@ -498,8 +461,11 @@ static bool relocate_host_orch_image(
     return ok;
 }
 
-bool upload_graph_submissions(Runtime *runtime, const HostApi *api, GraphHostState &graph_state) {
+bool upload_graph_submissions(
+    Runtime *runtime, const HostApi *api, GraphHostState &graph_state, uint64_t &uploaded_bytes
+) {
     std::unordered_map<uint64_t, uint32_t> occurrences;
+    uploaded_bytes = 0;
     const size_t count = graph_host_upload_count(graph_state);
     for (size_t index = 0; index < count; ++index) {
         std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
@@ -553,6 +519,7 @@ bool upload_graph_submissions(Runtime *runtime, const HostApi *api, GraphHostSta
         }
         upload->outer_slot->graph_context = device_submission;
         runtime->tensor_pairs_.push_back({nullptr, device_submission, upload->bytes, false});
+        uploaded_bytes += static_cast<uint64_t>(upload->bytes);
     }
     return true;
 }
@@ -594,9 +561,6 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: orchestrator re-init against host SM failed");
         return -1;
     }
-#if SIMPLER_DFX
-    rt->orchestrator.chip_swimlane_level = static_cast<ChipSwimlaneLevel>(api->chip_swimlane_level());
-#endif
     rt->orchestrator.wire_arena_pointers(layout.orch, host_arena, &rt->scheduler);
 
     // Initialize the host SM header (ring flow control) so submit_task can run.
@@ -646,14 +610,50 @@ int32_t run_host_orchestration(
     // rt_orchestration_done take the runtime as an argument.
     entry_points->bind(rt);
 
-    HostOrchestratorProfileBinding profile_binding(api, eff_task_window_sizes[0]);
+    const int64_t t_orch_ns = bind_now_ns();
     rt_scope_begin(rt);
     entry_points->entry(orch_l2);
     rt_scope_end(rt);
     rt_orchestration_done(rt);
+#if SIMPLER_ORCH_PROFILING
+    // Per-sub-step cumulatives across this pass's submits. The accumulators only
+    // exist in a SIMPLER_ORCH_PROFILING build (build_runtimes.py --profiling-orch 1),
+    // and reading them also resets them, so this is the pass's own total. Emitted
+    // as spans rather than LOG_INFO because INFO is suppressed at the default log
+    // level. Like the phase spans these are summed cost shares, not intervals.
+    {
+        const PTO2OrchProfilingData prof = orchestrator_get_profiling();
+        const std::pair<const char *, uint64_t> steps[] = {
+            {"sync", prof.sync_cycle},           {"alloc", prof.alloc_cycle},           {"args", prof.args_cycle},
+            {"lookup", prof.lookup_cycle},       {"insert", prof.insert_cycle},         {"fanin", prof.fanin_cycle},
+            {"scope_end", prof.scope_end_cycle}, {"alloc_wait", prof.alloc_wait_cycle},
+        };
+        for (const auto &step : steps) {
+            if (step.second == 0) continue;
+            LOG_TIMING(
+                "host-orch step=%s cycles=%" PRIu64 " submits=%" PRId64, step.first, step.second, prof.submit_count
+            );
+        }
+    }
+#endif
 
     const int32_t total_tasks = pto2_sm_layout::ring_current_task_index_addr(host_sm)->load(std::memory_order_acquire);
-    if (!upload_graph_submissions(runtime, api, *graph_state)) return -1;
+    {
+        char attrs[64];
+        snprintf(attrs, sizeof(attrs), "tasks=%" PRId32, total_tasks);
+        record_bind_phase(HostPhaseKind::BindHostOrch, t_orch_ns, attrs);
+    }
+    // After the span closes: the reduction walks a few hundred records and emits
+    // five markers, which must not be charged to the pass it measures.
+
+    const int64_t t_graph_ns = bind_now_ns();
+    uint64_t graph_bytes = 0;
+    if (!upload_graph_submissions(runtime, api, *graph_state, graph_bytes)) return -1;
+    {
+        char attrs[96];
+        snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, graph_host_upload_count(*graph_state), graph_bytes);
+        record_bind_phase(HostPhaseKind::BindGraphUpload, t_graph_ns, attrs, graph_bytes);
+    }
 
     // total_tasks sizes the bounded per-segment H2D copies below; a value outside
     // [0, task_window] would make those copies read/write out of bounds.
@@ -661,7 +661,7 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: total_tasks %d out of range [0, %" PRIu64 "]", total_tasks, eff_task_window_sizes[0]);
         return -1;
     }
-    api->finish_host_orchestrator_capture(static_cast<uint64_t>(total_tasks));
+    host_phase_trace_note_submitted(static_cast<uint64_t>(total_tasks));
 
     // Relocate the host-DDR cross-task pointers to their final DEVICE addresses
     // on the host, before the SM and arena leave for the device. Pointers into
@@ -672,6 +672,7 @@ int32_t run_host_orchestration(
                              static_cast<int64_t>(reinterpret_cast<uint64_t>(host_sm));
     const int64_t arena_delta = static_cast<int64_t>(reinterpret_cast<uint64_t>(device_arena)) -
                                 static_cast<int64_t>(reinterpret_cast<uint64_t>(host_arena.base()));
+    const int64_t t_reloc_ns = bind_now_ns();
     if (!relocate_host_orch_image(
             host_sm_handle, reinterpret_cast<uint64_t>(host_sm), sm_size, sm_delta,
             reinterpret_cast<uint64_t>(host_arena.base()), layout.arena_size, arena_delta
@@ -679,6 +680,7 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: relocation failed; refusing to H2D an image with unrelocated host pointers");
         return -1;
     }
+    record_bind_phase(HostPhaseKind::BindRelocate, t_reloc_ns);
 
     // Ship only the live prefix of each segment: the device reads no slot past
     // total_tasks, so upload header + descriptors[0,N), payloads[0,N),
@@ -688,6 +690,7 @@ int32_t run_host_orchestration(
     const uint64_t hdr_desc_bytes = sm_segs.descriptors + nt * sizeof(PTO2TaskDescriptor);
     char *host_base = static_cast<char *>(host_sm);
     char *dev_base = static_cast<char *>(device_sm);
+    const int64_t t_sm_h2d_ns = bind_now_ns();
     if (api->copy_to_device(dev_base, host_base, hdr_desc_bytes) != 0 ||
         api->copy_to_device(dev_base + sm_segs.payloads, host_base + sm_segs.payloads, nt * sizeof(PTO2TaskPayload)) !=
             0 ||
@@ -699,6 +702,13 @@ int32_t run_host_orchestration(
         ) != 0) {
         LOG_ERROR("host-orch: H2D of populated SM failed");
         return -1;
+    }
+    {
+        const uint64_t sm_h2d_bytes = hdr_desc_bytes + nt * sizeof(PTO2TaskPayload) + nt * sizeof(PTO2TaskSlotState) +
+                                      nt * sizeof(std::atomic<uint8_t>);
+        char attrs[96];
+        snprintf(attrs, sizeof(attrs), "nt=%" PRIu64 " bytes=%" PRIu64, nt, sm_h2d_bytes);
+        record_bind_phase(HostPhaseKind::BindSmH2d, t_sm_h2d_ns, attrs, sm_h2d_bytes);
     }
     return total_tasks;
 }
@@ -853,7 +863,15 @@ extern "C" int bind_callable_to_runtime_impl(
     int scalar_count = orch_args->scalar_count();
     LOG_INFO("RT2 bind: %d tensors + %d scalars, host orchestration mode", tensor_count, scalar_count);
 
-    int64_t t_total_start = _now_ms();
+    // Arm before the first segment below: the record pool has to exist for
+    // `args`, which runs well before the device collector is provisioned. The
+    // guard ends the pass on every exit, not just the successful one — a bind
+    // that fails part-way is exactly when its breakdown is worth having, and an
+    // unfinished pass publishes nothing.
+    host_phase_trace_begin(api);
+    auto host_phase_guard = RAIIScopeGuard([]() {
+        host_phase_trace_end();
+    });
 
     uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH];
     uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH];
@@ -872,7 +890,9 @@ extern "C" int bind_callable_to_runtime_impl(
     // the point at which a task could make it stale.
     HostTensorAccessor tensor_access(api);
 
-    int64_t t_args_start = _now_ms();
+    const int64_t t_args_ns = bind_now_ns();
+    uint64_t staged_bytes = 0;
+    int staged_tensors = 0;
     for (int i = 0; i < tensor_count; i++) {
         ChipTensor t = orch_args->tensor(i);
 
@@ -903,6 +923,8 @@ extern "C" int bind_callable_to_runtime_impl(
                 api->device_free(dev_ptr);
                 return -1;
             }
+            staged_bytes += static_cast<uint64_t>(size);
+            ++staged_tensors;
         }
         // Read-only INPUT tensors are never written by the kernel, so there is
         // no point copying them back D2H at the end. Index the signature
@@ -935,7 +957,13 @@ extern "C" int bind_callable_to_runtime_impl(
     for (int i = 0; i < scalar_count; i++) {
         device_args.add_scalar(orch_args->scalar(i));
     }
-    int64_t t_args_end = _now_ms();
+    {
+        char attrs[128];
+        snprintf(
+            attrs, sizeof(attrs), "ntensor=%d staged=%d bytes=%" PRIu64, tensor_count, staged_tensors, staged_bytes
+        );
+        record_bind_phase(HostPhaseKind::BindArgs, t_args_ns, attrs);
+    }
 
     // Lay out the per-Worker static device arena. GM heap, PTO2 shared memory,
     // and the prebuilt runtime arena use three independent pooled device
@@ -953,33 +981,42 @@ extern "C" int bind_callable_to_runtime_impl(
     }
     uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(eff_task_window_sizes);
 
-    int64_t t_prebuilt_start = _now_ms();
-    DeviceArena host_arena;  // libc malloc backend by default
+    const int64_t t_arena_build_ns = bind_now_ns();
+    DeviceArena host_arena;
     PTO2RuntimeArenaLayout layout = runtime_reserve_layout(host_arena, eff_task_window_sizes, eff_heap_sizes);
     if (host_arena.commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
         LOG_ERROR("Failed to commit host arena for prebuilt runtime image");
         return -1;
     }
+    {
+        char attrs[64];
+        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, static_cast<uint64_t>(layout.arena_size));
+        record_bind_phase(HostPhaseKind::BindArenaBuild, t_arena_build_ns, attrs);
+    }
 
-    int64_t t_setup_start = _now_ms();
+    const int64_t t_static_arena_ns = bind_now_ns();
     if (api->setup_static_arena(total_heap_size, sm_size, layout.arena_size) != 0) {
         LOG_ERROR("Failed to setup pooled static arena");
         return -1;
     }
-    int64_t t_setup_end = _now_ms();
+    {
+        char attrs[96];
+        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " sm=%" PRIu64, total_heap_size, sm_size);
+        record_bind_phase(HostPhaseKind::BindStaticArena, t_static_arena_ns, attrs);
+    }
 
-    int64_t t_heap_start = _now_ms();
+    const int64_t t_heap_ns = bind_now_ns();
     void *gm_heap = api->acquire_pooled_gm_heap();
-    int64_t t_heap_end = _now_ms();
+    record_bind_phase(HostPhaseKind::BindGmHeap, t_heap_ns);
     if (gm_heap == nullptr) {
         LOG_ERROR("Failed to acquire pooled GM heap");
         return -1;
     }
     runtime->set_gm_heap(gm_heap);
 
-    int64_t t_sm_start = _now_ms();
+    const int64_t t_sm_ns = bind_now_ns();
     void *sm_ptr = api->acquire_pooled_gm_sm();
-    int64_t t_sm_end = _now_ms();
+    record_bind_phase(HostPhaseKind::BindSharedMem, t_sm_ns);
     if (sm_ptr == nullptr) {
         LOG_ERROR("Failed to acquire pooled PTO2 shared memory");
         return -1;
@@ -1005,6 +1042,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // boot becomes attach + wire (cheap pointer fixup) + sm_handle->init (SM
     // reset) + a handful of device-only field fixups.
     // -------------------------------------------------------------------------
+    const int64_t t_runtime_init_ns = bind_now_ns();
     PTO2Runtime *rt =
         runtime_init_data_from_layout(host_arena, layout, PTO2_MODE_EXECUTE, sm_ptr, sm_size, gm_heap, eff_heap_sizes);
     if (rt == nullptr) {
@@ -1012,6 +1050,7 @@ extern "C" int bind_callable_to_runtime_impl(
         return -1;
     }
     runtime_wire_arena_pointers(host_arena, layout, rt);
+    record_bind_phase(HostPhaseKind::BindRuntimeInit, t_runtime_init_ns);
 
     // host_build_graph host-orch: run the orchestrator on the host now, against
     // a host SM mirror, and ship the populated SM to the device. The arena
@@ -1032,7 +1071,15 @@ extern "C" int bind_callable_to_runtime_impl(
         );
         // The orchestrator is the only host-view reader; from here the device
         // owns these buffers, so drop the window on both exits.
+        const size_t view_count = tensor_access.mapping_count();
+        const uint64_t view_bytes = tensor_access.mapped_bytes();
+        const int64_t t_view_close_ns = bind_now_ns();
         tensor_access.close();
+        {
+            char attrs[96];
+            snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, view_count, view_bytes);
+            record_bind_phase(HostPhaseKind::BindHostViewClose, t_view_close_ns, attrs);
+        }
         if (total_tasks < 0) {
             LOG_ERROR("host-orch: orchestration run failed");
             return -1;
@@ -1062,6 +1109,7 @@ extern "C" int bind_callable_to_runtime_impl(
     always_assert(orch_start <= orch_end);
     char *arena_host = static_cast<char *>(host_arena.base());
     char *arena_dev = static_cast<char *>(runtime_arena_dev);
+    const int64_t t_arena_h2d_ns = bind_now_ns();
     int rc_upload = api->copy_to_device(arena_dev, arena_host, orch_start);
     if (rc_upload == 0) {
         rc_upload = api->copy_to_device(arena_dev + orch_end, arena_host + orch_end, layout.arena_size - orch_end);
@@ -1070,18 +1118,16 @@ extern "C" int bind_callable_to_runtime_impl(
         LOG_ERROR("Failed to rtMemcpy prebuilt runtime arena to device (rc=%d)", rc_upload);
         return -1;
     }
+    {
+        const uint64_t arena_h2d_bytes =
+            static_cast<uint64_t>(orch_start) + static_cast<uint64_t>(layout.arena_size - orch_end);
+        char attrs[96];
+        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, arena_h2d_bytes);
+        record_bind_phase(HostPhaseKind::BindArenaH2d, t_arena_h2d_ns, attrs, arena_h2d_bytes);
+    }
     runtime->set_prebuilt_arena(runtime_arena_dev, layout.off_runtime);
-    int64_t t_prebuilt_end = _now_ms();
 
     LOG_INFO("Device orchestration ready: %d tensors + %d scalars", tensor_count, scalar_count);
-
-    int64_t t_total_end = _now_ms();
-    LOG_INFO("TIMING: args_malloc_copy = %" PRId64 "ms", t_args_end - t_args_start);
-    LOG_INFO("TIMING: static_arena_setup = %" PRId64 "ms", t_setup_end - t_setup_start);
-    LOG_INFO("TIMING: gm_heap_acquire = %" PRId64 "ms", t_heap_end - t_heap_start);
-    LOG_INFO("TIMING: shared_mem_acquire = %" PRId64 "ms", t_sm_end - t_sm_start);
-    LOG_INFO("TIMING: prebuilt_runtime_arena = %" PRId64 "ms", t_prebuilt_end - t_prebuilt_start);
-    LOG_INFO("TIMING: total_init_runtime_impl = %" PRId64 "ms", t_total_end - t_total_start);
 
     return 0;
 }

--- a/src/a5/runtime/host_build_graph/runtime/host_phase_trace.h
+++ b/src/a5/runtime/host_build_graph/runtime/host_phase_trace.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+/**
+ * Timing of this runtime's prepare path: the bind stage's segments and the host
+ * orchestrator's submit-level operations.
+ *
+ * One record call feeds two independent sinks, and the split is what lets each
+ * survive without the other:
+ *
+ *   - **Per-kind counters**, owned here. They produce the `LOG_TIMING`
+ *     breakdown and are exact whether or not records are being kept, so they are
+ *     the channel that works at `--rounds > 1`, where the artifact collectors are
+ *     switched off entirely.
+ *   - **The platform's host phase pool**, when a per-event reader is enabled.
+ *     Records go straight into platform-allocated memory (see
+ *     host/host_phase_records.h); this runtime holds only the pool pointer.
+ *
+ * Timestamps are host monotonic nanoseconds — the clock the `[STRACE]` host
+ * spans use — so records nest inside `simpler_run.bind` with no alignment step
+ * and share the enclosing run's (pid, inv) identity.
+ */
+
+/**
+ * Whether this runtime asks for its own prepare-path breakdown.
+ *
+ * True only when `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` starts with `1`, `t` or
+ * `T`, read once on first use. This is the producer's own condition; the runner
+ * ORs it with the chip-swimlane level when deciding whether to arm the pool, so
+ * a level-4 run collects records with the variable unset, and this variable
+ * collects them with the level at 0.
+ *
+ * "Breakdown" rather than "timing" because the bind stage's *duration* is
+ * already published as the `simpler_run.bind` `[STRACE]` marker; what this adds
+ * is the division of that one number into its parts.
+ */
+bool host_phase_timing_enabled();
+
+/**
+ * Host monotonic nanoseconds, or 0 when this pass records nothing — which is
+ * what keeps the orchestrator's per-operation hooks down to two calls returning
+ * a constant.
+ */
+uint64_t host_phase_now_ns();
+
+/**
+ * Append one record and fold it into its kind's counters.
+ *
+ * `kind` is a HostPhaseKind; it is passed as a plain integer because the
+ * orchestrator core declares a weak fallback for this function and is also
+ * compiled for the AICPU, where the platform's host headers are absent.
+ *
+ * @param payload  task id for the kinds that submit a task, else a detail count
+ * @param index    submit_idx for orchestrator operations, 0 for bind segments
+ */
+void host_phase_record(uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload, uint32_t index);
+
+/**
+ * Record one bind segment along with the attributes its log line carries.
+ *
+ * The attributes are formatted here rather than at flush so the values need not
+ * outlive the segment, and they are not written to the log here so the log write
+ * stays off the path being measured.
+ *
+ * @param payload  the segment's one machine-readable quantity, for readers that
+ *                 cannot parse the attribute text — byte count on a transfer
+ *                 segment, 0 where the segment moves nothing
+ */
+void host_phase_record_bind(uint32_t kind, uint64_t start_ns, const char *attrs, uint64_t payload = 0);
+
+/**
+ * Arm a pass: take the pool the runner offers, and clear the counters.
+ *
+ * Must run before the first bind segment, which is before the orchestration
+ * phase and therefore well before the device collector exists.
+ *
+ * @param host_api  this run's `const HostApi *`, void-typed to keep the
+ *                  platform headers out of the orchestrator core's include set
+ */
+void host_phase_trace_begin(const void *host_api);
+
+/**
+ * Report how many tasks this pass submitted, at the point that becomes known —
+ * inside the orchestration segment, well before the pass ends. A reader compares
+ * it against the records whose kind submits a task.
+ */
+void host_phase_trace_note_submitted(uint64_t submitted_tasks);
+
+/**
+ * Close the pass: hand the submitted-task count and the run's invocation id to
+ * the runner, then emit the per-kind `LOG_TIMING` breakdown from the counters.
+ *
+ * The records stay in the pool for its readers.
+ */
+void host_phase_trace_end();

--- a/src/a5/runtime/host_build_graph/runtime/host_tensor_access.h
+++ b/src/a5/runtime/host_build_graph/runtime/host_tensor_access.h
@@ -101,6 +101,12 @@ public:
     /** Drop every region and unregister every mapping this accessor installed. */
     void close() noexcept;
 
+    /** Mappings installed by `add` and not yet dropped by `close`. */
+    size_t mapping_count() const noexcept;
+
+    /** Total bytes covered by those mappings; excludes fallback staging views. */
+    uint64_t mapped_bytes() const noexcept;
+
 private:
     struct Impl;
     Impl *impl_;

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -130,8 +130,6 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() {
 // Weak fallback for builds that don't link chip_swimlane_collector_aicpu.cpp.
 // The strong symbol from the AICPU build wins when profiling is available.
 // Also hidden to prevent HOST .so from polluting the global symbol table.
-__attribute__((weak, visibility("hidden"))) void
-chip_swimlane_aicpu_record_orch_phase(uint64_t, uint64_t, uint64_t, uint32_t) {}
 // Accumulated cycles per sub-step (only needed for ORCH_PROFILING export)
 static uint64_t g_orch_sync_cycle = 0;       // tensormap sync
 static uint64_t g_orch_alloc_cycle = 0;      // unified task+heap alloc
@@ -149,30 +147,16 @@ uint64_t g_orch_args_atomic_count = 0;
 uint64_t g_orch_scope_end_atomic_count = 0;
 // Cycle accumulation is unconditional under SIMPLER_ORCH_PROFILING (that's what
 // the flag is for) and feeds the per-sub-step `g_orch_*_cycle` cumulatives
-// printed in the cold-path log.
-//
-// Per-submit ORCH_SUBMIT record is the only swim-lane emit on the orch
-// path — one record per submit_task() / alloc_tensors() call spanning
-// the entire [start, end] window. Per-sub-step phase records were dropped
-// in favour of the cumulatives + per-submit envelope; the dispatcher
-// already inserts one record at the end of each submit path via
-// CYCLE_COUNT_ORCH_SUBMIT_RECORD.
-#define CYCLE_COUNT_START()                                                            \
-    bool _prof_active = (orch->chip_swimlane_level >= ChipSwimlaneLevel::ORCH_PHASES); \
-    uint64_t _t0 = get_sys_cnt_aicpu(), _t1;                                           \
-    uint64_t _submit_start_ts = _t0
+// printed in the cold-path log. Per-event records are a separate channel on a
+// separate clock — see ORCH_PHASE_END below.
+#define CYCLE_COUNT_START()                  \
+    uint64_t _t0 = get_sys_cnt_aicpu(), _t1; \
+    (void)_t1
 #define CYCLE_COUNT_LAP(acc)       \
     do {                           \
         _t1 = get_sys_cnt_aicpu(); \
         acc += (_t1 - _t0);        \
         _t0 = _t1;                 \
-    } while (0)
-#define CYCLE_COUNT_ORCH_SUBMIT_RECORD(tid)                                                         \
-    do {                                                                                            \
-        if (_prof_active) {                                                                         \
-            _t1 = get_sys_cnt_aicpu();                                                              \
-            chip_swimlane_aicpu_record_orch_phase(_submit_start_ts, _t1, (tid), g_orch_submit_idx); \
-        }                                                                                           \
     } while (0)
 #elif SIMPLER_DFX
 #include "aicpu/device_time.h"
@@ -189,28 +173,54 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() {
     return static_cast<uint64_t>(ts.tv_sec) * PLATFORM_PROF_SYS_CNT_FREQ +
            static_cast<uint64_t>(ts.tv_nsec) * PLATFORM_PROF_SYS_CNT_FREQ / 1000000000ull;
 }
-__attribute__((weak, visibility("hidden"))) void
-chip_swimlane_aicpu_record_orch_phase(uint64_t, uint64_t, uint64_t, uint32_t) {}
-// submit_idx needed for swimlane task_id tagging (no cycle accumulation at this level)
+// submit_idx tags a record with its position in the pass's submit order.
 static uint32_t g_orch_submit_idx = 0;
-#define CYCLE_COUNT_START()                                                            \
-    bool _prof_active = (orch->chip_swimlane_level >= ChipSwimlaneLevel::ORCH_PHASES); \
-    uint64_t _t0 = _prof_active ? get_sys_cnt_aicpu() : 0, _t1 = 0;                    \
-    uint64_t _submit_start_ts = _t0
-#define CYCLE_COUNT_LAP(acc) \
-    do {                     \
-    } while (0)
-#define CYCLE_COUNT_ORCH_SUBMIT_RECORD(tid)                                                         \
-    do {                                                                                            \
-        if (_prof_active) {                                                                         \
-            _t1 = get_sys_cnt_aicpu();                                                              \
-            chip_swimlane_aicpu_record_orch_phase(_submit_start_ts, _t1, (tid), g_orch_submit_idx); \
-        }                                                                                           \
-    } while (0)
+// The per-sub-step accumulators exist only in an ORCH_PROFILING build, so at this
+// level there is nothing to time.
+#define CYCLE_COUNT_START()
+#define CYCLE_COUNT_LAP(acc)
 #else
 #define CYCLE_COUNT_START()
 #define CYCLE_COUNT_LAP(acc)
-#define CYCLE_COUNT_ORCH_SUBMIT_RECORD(tid)
+#endif
+
+// Host phase record sink. The host build links a strong definition that folds the
+// record into its kind's counters and appends it to the platform's record pool;
+// every other build keeps this no-op. Kind values are HostPhaseKind, passed as a
+// plain integer because this file is also compiled for the AICPU, where the
+// platform's host headers are absent.
+__attribute__((weak, visibility("hidden"))) void host_phase_record(uint64_t, uint64_t, uint32_t, uint64_t, uint32_t) {}
+
+// Host monotonic clock shared with the `[STRACE]` span tree, so a record nests
+// under simpler_run.bind.host_orch without any clock conversion. The host build
+// links the strong definition in host_phase_trace.cpp; this fallback keeps
+// non-host builds linking, where the recorder above is a no-op anyway.
+__attribute__((weak, visibility("hidden"))) uint64_t host_phase_now_ns() { return 0; }
+
+#if SIMPLER_DFX
+// Kinds this file records, spelled as the HostPhaseKind values the host side
+// reads. Only the host orchestrator reaches these sites, so the bind-stage kinds
+// that precede them in the enum are not named here.
+enum class HostOrchPhase : uint32_t {
+    Submit = 12,           // submit_task_common: one ordinary ring task
+    Prepare = 13,          // prepare_task: one alloc_tensors slot
+    RecordNode = 14,       // graph_record_submit_node: one recorded Graph node
+    GraphSubmit = 15,      // graph_submit_definition: one outer GRAPH task
+    BuildDefinition = 16,  // graph_build_definition: nodes compacted into the image
+};
+#define ORCH_PHASE_START() const uint64_t _orch_phase_t0 = host_phase_now_ns()
+#define ORCH_PHASE_END(phase, detail)                                                                         \
+    do {                                                                                                      \
+        host_phase_record(                                                                                    \
+            _orch_phase_t0, host_phase_now_ns(), static_cast<uint32_t>(phase), static_cast<uint64_t>(detail), \
+            g_orch_submit_idx                                                                                 \
+        );                                                                                                    \
+    } while (0)
+#else
+#define ORCH_PHASE_START()
+#define ORCH_PHASE_END(phase, detail) \
+    do {                              \
+    } while (0)
 #endif
 
 static int32_t orch_mark_fatal(PTO2OrchestratorState *orch, int32_t error_code) {
@@ -1116,6 +1126,7 @@ static TaskOutputTensors submit_task_common(
     int32_t aic_kernel_id, int32_t aiv0_kernel_id, int32_t aiv1_kernel_id
 ) {
     CYCLE_COUNT_START();
+    ORCH_PHASE_START();
     TaskOutputTensors result;
     PTO2OutputLayout layout = calculate_output_layout(args);
     PTO2PreparedTask prepared;
@@ -1298,7 +1309,7 @@ static TaskOutputTensors submit_task_common(
     (void)sched;
 
     CYCLE_COUNT_LAP(g_orch_fanin_cycle);
-    CYCLE_COUNT_ORCH_SUBMIT_RECORD(task_id.raw);
+    ORCH_PHASE_END(HostOrchPhase::Submit, task_id.raw);
 
 #if SIMPLER_DFX
     orch->tasks_submitted++;
@@ -1433,7 +1444,6 @@ bool graph_submit_definition(
     PTO2OrchestratorState *orch, GraphHostState *state, const std::vector<std::byte> &definition_image,
     const CoreTaskArgs &args, PTO2TaskId *submitted_id
 ) {
-    CYCLE_COUNT_START();
     const GraphDefinition *definition = graph_definition(definition_image);
     if (definition == nullptr || !graph_boundary_matches(*definition, args) ||
         definition->required_heap > static_cast<uint64_t>(INT32_MAX)) {
@@ -1499,7 +1509,6 @@ bool graph_submit_definition(
     pending.outer_slot = &slot;
     state->pending_uploads.push_back(std::move(pending));
     if (submitted_id != nullptr) *submitted_id = task_id;
-    CYCLE_COUNT_ORCH_SUBMIT_RECORD(task_id.raw);
 #if SIMPLER_DFX
     orch->tasks_submitted++;
 #endif
@@ -1519,6 +1528,7 @@ TaskOutputTensors graph_record_submit_node(
     PTO2OrchestratorState *orch, const CoreTaskArgs &args, ActiveMask active_mask, TaskAttrs task_attrs,
     int32_t aic_kernel_id, int32_t aiv0_kernel_id, int32_t aiv1_kernel_id
 ) {
+    ORCH_PHASE_START();
     TaskOutputTensors result;
     GraphRecording &recording = *graph_state_from(orch)->recording;
 
@@ -1652,6 +1662,7 @@ TaskOutputTensors graph_record_submit_node(
     }
 
     recording.nodes.push_back(std::move(node));
+    ORCH_PHASE_END(HostOrchPhase::RecordNode, task_id.raw);
     return result;
 }
 
@@ -1677,9 +1688,11 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const CoreTaskArgs &args,
     auto definition_it = state->definitions.find(full_key);
     if (definition_it != state->definitions.end()) {
         PTO2TaskId submitted = PTO2TaskId::invalid();
+        ORCH_PHASE_START();
         if (graph_submit_definition(orch, state, definition_it->second, args, &submitted)) {
             result.execute_block = false;
             result.task_id = submitted;
+            ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
 #if SIMPLER_DFX
             g_orch_submit_idx++;
 #if SIMPLER_ORCH_PROFILING
@@ -1735,11 +1748,13 @@ bool PTO2OrchestratorState::graph_end() {
     this->ring.task_allocator.restore_heap_top(recording->heap_watermark);
 
     std::vector<std::byte> definition;
+    ORCH_PHASE_START();
     if (!graph_build_definition(*recording, &definition)) {
         debug_assert(false && "The recorded Graph contains a construct that Graph Execution does not support");
         LOG_WARN("%s", "[GraphExecution] unsupported construct observed; falling back to the ordinary path");
         return false;
     }
+    ORCH_PHASE_END(HostOrchPhase::BuildDefinition, recording->nodes.size());
     const GraphDefinition *header = graph_definition(definition);
     if (header == nullptr) return false;
     LOG_DEBUG(
@@ -1754,9 +1769,13 @@ bool PTO2OrchestratorState::graph_end() {
     // block instead of one per internal node. The Definition stays cached for
     // subsequent invocations even if this placement fails.
     PTO2TaskId submitted = PTO2TaskId::invalid();
-    if (recording->boundary_args == nullptr ||
-        !graph_submit_definition(this, state, cached, *recording->boundary_args, &submitted)) {
-        return false;
+    {
+        ORCH_PHASE_START();
+        if (recording->boundary_args == nullptr ||
+            !graph_submit_definition(this, state, cached, *recording->boundary_args, &submitted)) {
+            return false;
+        }
+        ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
     }
 #if SIMPLER_DFX
     g_orch_submit_idx++;
@@ -1923,6 +1942,7 @@ TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const CoreTaskArgs &args)
     }
 
     CYCLE_COUNT_START();
+    ORCH_PHASE_START();
 
     if (args.has_error) {
         report_fatal(
@@ -2009,7 +2029,7 @@ TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const CoreTaskArgs &args)
     orch->inline_completed_tasks++;
 
     CYCLE_COUNT_LAP(g_orch_fanin_cycle);
-    CYCLE_COUNT_ORCH_SUBMIT_RECORD(prepared.task_id.raw);
+    ORCH_PHASE_END(HostOrchPhase::Prepare, prepared.task_id.raw);
 
 #if SIMPLER_DFX
     orch->tasks_submitted++;

--- a/src/a5/runtime/host_build_graph/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_orchestrator.h
@@ -96,10 +96,6 @@ struct PTO2OrchestratorState {
     // Total core counts set once at executor init; used for submit-time deadlock detection.
     int32_t total_cluster_count{0};  // AIC cores = MIX clusters
     int32_t total_aiv_count{0};      // AIV cores (= 2 × clusters on standard hardware)
-#if SIMPLER_DFX
-    // chip swimlane_level copied from get_chip_swimlane_level().
-    ChipSwimlaneLevel chip_swimlane_level{ChipSwimlaneLevel::DISABLED};
-#endif
 
     // === GM HEAP (for output buffers) ===
     void *gm_heap_base;     // Base address of GM heap

--- a/src/common/platform/include/common/chip_swimlane_profiling.h
+++ b/src/common/platform/include/common/chip_swimlane_profiling.h
@@ -614,22 +614,122 @@ struct ChipSwimlaneAicpuOrchPhaseRecord {
 static_assert(sizeof(ChipSwimlaneAicpuOrchPhaseRecord) == 32, "ChipSwimlaneAicpuOrchPhaseRecord layout drift");
 
 /**
- * Host orchestrator phase record.
+ * Host phase record (32 bytes).
  *
- * host_build_graph constructs the complete runtime graph on the host before
- * device execution starts. Keep these timestamps in the host monotonic-ns
- * clock domain. The converter uses platform anchors for a physical alignment;
- * if that fails, it emits an explicitly marked causal composite and forbids
- * cross-domain latency calculations.
+ * One record per timed host operation on host_build_graph's prepare path —
+ * both the bind stage's segments and the host orchestrator's submit-level
+ * operations, distinguished by `kind`. Timestamps are host monotonic
+ * nanoseconds, the clock the `[STRACE]` host spans use, so records and spans
+ * read against each other with no alignment step.
+ *
+ * `payload` is kind-discriminated: a task id for the kinds that submit a task
+ * (see host_phase_kind_submits_task), otherwise a per-kind detail count such as
+ * a byte or node count. Readers must consult `kind` before interpreting it.
  */
-struct ChipSwimlaneHostOrchPhaseRecord {
-    uint64_t start_time_ns;
-    uint64_t end_time_ns;
-    uint64_t task_id;
-    uint32_t submit_idx;
-    uint32_t _pad;
+struct HostPhaseRecord {
+    uint64_t start_ns;
+    uint64_t end_ns;
+    uint64_t payload;
+    uint32_t kind;   // HostPhaseKind
+    uint32_t index;  // submit_idx for orchestrator operations, 0 for bind segments
 };
-static_assert(sizeof(ChipSwimlaneHostOrchPhaseRecord) == 32, "ChipSwimlaneHostOrchPhaseRecord layout drift");
+static_assert(sizeof(HostPhaseRecord) == 32, "HostPhaseRecord layout drift");
+
+/**
+ * What one HostPhaseRecord measured.
+ *
+ * The bind kinds partition the bind stage: their durations sum to the
+ * `simpler_run.bind` span. The orchestrator kinds are nested inside BindHostOrch
+ * and do not partition it — some are sub-operations of others.
+ */
+enum class HostPhaseKind : uint32_t {
+    BindArgs = 0,
+    BindArenaBuild,
+    BindStaticArena,
+    BindGmHeap,
+    BindSharedMem,
+    BindRuntimeInit,
+    BindHostOrch,
+    BindGraphUpload,
+    BindRelocate,
+    BindSmH2d,
+    BindArenaH2d,
+    BindHostViewClose,
+    OrchSubmitTask,
+    OrchAllocTensors,
+    OrchRecordNode,
+    OrchGraphSubmit,
+    OrchBuildDefinition,
+    Count
+};
+
+constexpr uint32_t kHostPhaseKindCount = static_cast<uint32_t>(HostPhaseKind::Count);
+
+/**
+ * Whether this kind ends with a task submitted to the runtime, i.e. whether its
+ * record's `payload` is a task id and whether it counts towards the pass's
+ * total_tasks. The three that do are what a per-submit consumer sees; the rest
+ * are sub-operations of a submit, or bind work with no task at all.
+ */
+inline bool host_phase_kind_submits_task(HostPhaseKind kind) {
+    return kind == HostPhaseKind::OrchSubmitTask || kind == HostPhaseKind::OrchAllocTensors ||
+           kind == HostPhaseKind::OrchGraphSubmit;
+}
+
+/**
+ * Whether this kind is a host-to-device transfer, i.e. host work that has to
+ * finish before the device can start on what it produced.
+ *
+ * These are the bind segments a device timeline can say something about: drawn
+ * beside the device lanes they show the handover, where the rest of the bind
+ * stage is host-only setup with no device counterpart.
+ */
+inline bool host_phase_kind_is_device_upload(HostPhaseKind kind) {
+    return kind == HostPhaseKind::BindGraphUpload || kind == HostPhaseKind::BindSmH2d ||
+           kind == HostPhaseKind::BindArenaH2d;
+}
+
+inline const char *host_phase_kind_name(HostPhaseKind kind) {
+    switch (kind) {
+    case HostPhaseKind::BindArgs:
+        return "args";
+    case HostPhaseKind::BindArenaBuild:
+        return "arena_build";
+    case HostPhaseKind::BindStaticArena:
+        return "static_arena";
+    case HostPhaseKind::BindGmHeap:
+        return "gm_heap";
+    case HostPhaseKind::BindSharedMem:
+        return "shared_mem";
+    case HostPhaseKind::BindRuntimeInit:
+        return "runtime_init";
+    case HostPhaseKind::BindHostOrch:
+        return "host_orch";
+    case HostPhaseKind::BindGraphUpload:
+        return "graph_upload";
+    case HostPhaseKind::BindRelocate:
+        return "relocate";
+    case HostPhaseKind::BindSmH2d:
+        return "sm_h2d";
+    case HostPhaseKind::BindArenaH2d:
+        return "arena_h2d";
+    case HostPhaseKind::BindHostViewClose:
+        return "host_view_close";
+    case HostPhaseKind::OrchSubmitTask:
+        return "submit_task";
+    case HostPhaseKind::OrchAllocTensors:
+        return "alloc_tensors";
+    case HostPhaseKind::OrchRecordNode:
+        return "record_node";
+    case HostPhaseKind::OrchGraphSubmit:
+        return "graph_submit";
+    case HostPhaseKind::OrchBuildDefinition:
+        return "build_definition";
+    case HostPhaseKind::Count:
+        break;
+    }
+    return "unknown";
+}
 
 constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 16384;  // ~512KB per sched thread, ~512KB per orch thread
 
@@ -645,6 +745,15 @@ using ChipSwimlaneAicpuOrchPhaseBuffer =
 // identical. Aliasing keeps the drain machinery polymorphic.
 using ChipSwimlaneAicpuSchedPhasePool = ChipSwimlaneAicpuTaskPool;
 using ChipSwimlaneAicpuOrchPhasePool = ChipSwimlaneAicpuTaskPool;
+
+// The host phase pool is the same head + free_queue plumbing over host DDR
+// instead of device shared memory: one producer rotates through a fixed set of
+// fixed-size buffers, and a reader walks them in rotation order. Its buffers are
+// smaller and fewer than a device thread's because its producer emits hundreds
+// of records per pass rather than tens of thousands (see
+// PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER).
+using HostPhaseRecordBuffer = TypedBuffer<HostPhaseRecord, PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER>;
+using HostPhaseRecordPool = ChipSwimlaneAicpuTaskPool;
 
 // =============================================================================
 // Helper Functions - Memory Layout

--- a/src/common/platform/include/common/host_api.h
+++ b/src/common/platform/include/common/host_api.h
@@ -13,8 +13,6 @@
 #include <cstddef>
 #include <cstdint>
 
-struct ChipSwimlaneHostOrchPhaseRecord;
-
 /**
  * Host API function pointers for device memory operations.
  * Allows a runtime to use pluggable device-memory backends.
@@ -112,13 +110,15 @@ struct HostApiOps {
     // DeviceRunner::bind_callable_to_runtime replays onto the runtime's
     // func_id_to_addr_ before each run.
     uint64_t (*upload_chip_callable_buffer)(void *runner_ctx, const void *callable);
-    // Host-build-graph level-4 profiling. Capture begins during bind, before
-    // the device collector is initialized; the runner therefore owns the
-    // pending host vector and merges it into the eventual JSON export.
+    // Host phase records. The pool is platform-allocated but written directly by
+    // the runtime through the inline path in host/host_phase_records.h, so these
+    // two run once per prepare pass rather than once per record. Arming is the
+    // union of the two enabling conditions: the runner contributes the
+    // chip-swimlane level, `producer_wants_records` carries the producer's own
+    // (a runtime knob the platform does not read).
     uint32_t (*get_chip_swimlane_level)(void *runner_ctx);
-    void (*begin_host_orchestrator_capture)(void *runner_ctx, uint64_t reserve_capacity);
-    void (*record_host_orchestrator_phase)(void *runner_ctx, const ChipSwimlaneHostOrchPhaseRecord *record);
-    void (*finish_host_orchestrator_capture)(void *runner_ctx, uint64_t expected_records);
+    void *(*host_phase_pool_arm)(void *runner_ctx, int producer_wants_records);
+    void (*host_phase_pool_finish)(void *runner_ctx, uint64_t submitted_tasks, uint64_t invocation_id);
 };
 
 /**
@@ -195,19 +195,22 @@ public:
     uint32_t chip_swimlane_level() const {
         return ops_->get_chip_swimlane_level != nullptr ? ops_->get_chip_swimlane_level(runner_ctx_) : 0;
     }
-    void begin_host_orchestrator_capture(uint64_t reserve_capacity) const noexcept {
-        if (ops_->begin_host_orchestrator_capture != nullptr) {
-            ops_->begin_host_orchestrator_capture(runner_ctx_, reserve_capacity);
-        }
+    /**
+     * Arm this pass's host phase pool.
+     *
+     * @param producer_wants_records  the producer's own enabling condition; the
+     *                                runner ORs it with the chip-swimlane level
+     * @return HostPhaseRecordPool* to record into, or nullptr when this pass
+     *         collects no records (typed void* to keep the profiling headers out
+     *         of this one)
+     */
+    void *host_phase_pool_arm(bool producer_wants_records) const noexcept {
+        if (ops_->host_phase_pool_arm == nullptr) return nullptr;
+        return ops_->host_phase_pool_arm(runner_ctx_, producer_wants_records ? 1 : 0);
     }
-    void record_host_orchestrator_phase(const ChipSwimlaneHostOrchPhaseRecord &record) const noexcept {
-        if (ops_->record_host_orchestrator_phase != nullptr) {
-            ops_->record_host_orchestrator_phase(runner_ctx_, &record);
-        }
-    }
-    void finish_host_orchestrator_capture(uint64_t expected_records) const noexcept {
-        if (ops_->finish_host_orchestrator_capture != nullptr) {
-            ops_->finish_host_orchestrator_capture(runner_ctx_, expected_records);
+    void host_phase_pool_finish(uint64_t submitted_tasks, uint64_t invocation_id) const noexcept {
+        if (ops_->host_phase_pool_finish != nullptr) {
+            ops_->host_phase_pool_finish(runner_ctx_, submitted_tasks, invocation_id);
         }
     }
 

--- a/src/common/platform/include/host/chip_swimlane_collector.h
+++ b/src/common/platform/include/host/chip_swimlane_collector.h
@@ -408,12 +408,39 @@ public:
      */
     void set_core_types(const CoreType *types, int n);
 
-    /** Reset and append host-build-graph level-4 submit records. These calls
-     * happen during bind, before initialize(), because HBG finishes host graph
-     * construction before the device collector is provisioned. */
-    void begin_host_orchestrator_capture(size_t reserve_capacity) noexcept;
-    void record_host_orchestrator_phase(const ChipSwimlaneHostOrchPhaseRecord &record) noexcept;
-    void finish_host_orchestrator_capture(uint64_t expected_records) noexcept;
+    /**
+     * Whether this run's orchestrator phases come from a host orchestrator.
+     *
+     * Known when the runner arms the host phase pool, which is during bind and
+     * therefore before initialize() — early enough for the device orch-phase
+     * pool to be left unallocated, which is the point. The records themselves
+     * arrive later, via set_host_phase_records().
+     */
+    void set_host_orchestrated(bool host_orchestrated) noexcept { host_orchestrated_ = host_orchestrated; }
+
+    /**
+     * Supply this run's host phase records, projected to the ones the swimlane
+     * places against device timestamps.
+     *
+     * The records are the platform runner's, not this collector's: their other
+     * reader is enabled independently. The runner hands them over before
+     * export_swimlane_json(), which is also after initialize() — unlike the
+     * records themselves, which a host-orchestrating runtime writes during bind,
+     * before the device collector is provisioned.
+     *
+     * @param submit_records   records whose kind submits a task, in order
+     * @param upload_records   records whose kind is a host-to-device transfer, in
+     *                         order; host work the device waits on, so it belongs
+     *                         beside the device lanes
+     * @param submitted_tasks  what the producer reported submitting, for the
+     *                         completeness check
+     * @param total_records    every record the producer attempted, of any kind
+     * @param dropped_records  records the pool could not store
+     */
+    void set_host_phase_records(
+        std::vector<HostPhaseRecord> submit_records, std::vector<HostPhaseRecord> upload_records,
+        uint64_t submitted_tasks, uint64_t total_records, uint64_t dropped_records
+    );
     void begin_clock_correlation_session(const char *provider_name, const char *raw_device_timestamp_unit);
     void record_clock_anchor_samples(std::vector<simpler::dfx::ClockAnchorSample> samples);
     void finish_clock_correlation_session();
@@ -540,7 +567,8 @@ private:
     // orch records (kind-tagged at routing time; no parse-time discrimination).
     std::vector<std::vector<ChipSwimlaneAicpuSchedPhaseRecord>> collected_sched_phase_records_;
     std::vector<std::vector<ChipSwimlaneAicpuOrchPhaseRecord>> collected_orch_phase_records_;
-    std::vector<ChipSwimlaneHostOrchPhaseRecord> collected_host_orch_phase_records_;
+    std::vector<HostPhaseRecord> host_submit_records_;
+    std::vector<HostPhaseRecord> host_upload_records_;
     simpler::dfx::ClockCorrelationSession clock_correlation_session_;
 
     // Core-to-thread mapping (core_id → scheduler thread index, -1 = unassigned)
@@ -558,14 +586,13 @@ private:
     uint64_t total_orch_phase_collected_{0};
     bool has_phase_data_{false};
     bool collector_shards_merged_{false};
-    bool host_orchestrator_capture_started_{false};
-    bool host_orchestrator_capture_enabled_{false};
-    enum class HostCaptureError : uint8_t { None = 0, ReserveFailed, RecordAllocationFailed };
-    HostCaptureError host_capture_error_{HostCaptureError::None};
-    uint64_t host_capture_reserve_requested_{0};
-    uint64_t host_capture_dropped_records_{0};
-    uint64_t host_capture_expected_records_{0};
-    bool host_capture_finished_{false};
+    // Set once the runner has handed over a pass's host phase records, which is
+    // also what makes the host orchestrator this run's record source.
+    bool host_orchestrated_{false};
+    bool host_phase_records_present_{false};
+    uint64_t host_phase_total_records_{0};
+    uint64_t host_phase_dropped_records_{0};
+    uint64_t host_phase_submitted_tasks_{0};
 
     size_t normalize_collector_shard(int collector_shard) const;
     void reset_collector_shards();

--- a/src/common/platform/include/host/host_phase_records.h
+++ b/src/common/platform/include/host/host_phase_records.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "common/chip_swimlane_profiling.h"
+#include "common/platform_config.h"
+
+/**
+ * Rotating pool of host phase records, written on host_build_graph's prepare
+ * path and read by whichever diagnostics are enabled for the run.
+ *
+ * The pool is a platform resource with two independently gated readers — the
+ * chip-swimlane export at level 4, and the per-event artifact the host trace
+ * tooling consumes — so it belongs to neither of them. Storage and lifetime are
+ * the platform's; the write cursor lives in the pool head, exactly as the
+ * device sched/orch pools put it in shared memory for the AICPU to advance.
+ *
+ * Recording is a header-inline store into platform-allocated memory rather than
+ * a call through HostApi: a pass performs a few hundred operations a few
+ * microseconds apart on the very path whose budget is under measurement, so the
+ * per-event cost must stay at two clock reads and a store. HostApi carries only
+ * the once-per-pass arm and finish.
+ */
+
+namespace simpler::dfx {
+
+/**
+ * Allocation, lifetime and reader access for one host phase pool.
+ *
+ * Held by the platform runner. `arm()` is called once per prepare pass, before
+ * the first bind segment; `records()` is valid from `finish()` until the next
+ * `arm()`.
+ */
+class HostPhaseRecordStore {
+public:
+    HostPhaseRecordStore() = default;
+    // Neither copying nor moving is representable: pool_ holds raw pointers into
+    // buffers_, and the producer holds &pool_ for the duration of a pass. A copy
+    // would alias the source's buffers and a move would invalidate the pointer
+    // already handed out, both silently.
+    HostPhaseRecordStore(const HostPhaseRecordStore &) = delete;
+    HostPhaseRecordStore &operator=(const HostPhaseRecordStore &) = delete;
+    HostPhaseRecordStore(HostPhaseRecordStore &&) = delete;
+    HostPhaseRecordStore &operator=(HostPhaseRecordStore &&) = delete;
+
+    /**
+     * Arm a fresh pass.
+     *
+     * @param collect_records  whether per-event records are wanted at all
+     *                         (a per-event reader is enabled for this run)
+     * @return the pool to write into, or nullptr when nothing is collected
+     */
+    HostPhaseRecordPool *arm(bool collect_records);
+
+    /**
+     * Close the pass.
+     *
+     * @param submitted_tasks  what the producer reported submitting, for a
+     *                         reader's completeness check
+     * @param invocation_id    the run's `[STRACE]` invocation id, so an artifact
+     *                         can be joined to that run's span tree
+     */
+    void finish(uint64_t submitted_tasks, uint64_t invocation_id);
+
+    /**
+     * Append this pass's records to `path` as one JSON Lines object.
+     *
+     * @return 0 on success, -1 when the path cannot be written
+     */
+    int write_records_jsonl(const std::string &path) const;
+
+    /** Records in rotation order. Empty unless a pass was armed with collection. */
+    std::vector<HostPhaseRecord> records() const;
+
+    /** Records whose kind submits a task, in rotation order. */
+    std::vector<HostPhaseRecord> submit_records() const;
+
+    /** Records whose kind is a host-to-device transfer, in rotation order. */
+    std::vector<HostPhaseRecord> device_upload_records() const;
+
+    bool armed() const { return armed_; }
+    bool finished() const { return finished_; }
+    uint64_t submitted_tasks() const { return submitted_tasks_; }
+    uint64_t invocation_id() const { return invocation_id_; }
+    uint64_t total_records() const { return pool_.head.total_record_count; }
+    uint64_t dropped_records() const { return pool_.head.dropped_record_count; }
+    /** Capacity in records, i.e. how many fit before any is dropped. */
+    static constexpr size_t capacity() {
+        return static_cast<size_t>(PLATFORM_HOST_PHASE_BUFFERS) * PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER;
+    }
+
+private:
+    HostPhaseRecordPool pool_{};
+    std::vector<HostPhaseRecordBuffer> buffers_{};
+    bool armed_{false};
+    bool finished_{false};
+    uint64_t submitted_tasks_{0};
+    uint64_t invocation_id_{0};
+};
+
+}  // namespace simpler::dfx
+
+/**
+ * Take the next free buffer as the active one.
+ *
+ * Cold path: reached once per PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER records, and
+ * on the pass's first record. Returns nullptr when the free queue is exhausted,
+ * which is the pool's only lossy outcome and is counted in the head.
+ */
+inline HostPhaseRecordBuffer *host_phase_pool_rotate(HostPhaseRecordPool *pool) {
+    ChipSwimlaneFreeQueue &free_queue = pool->free_queue;
+    if (free_queue.head == free_queue.tail) return nullptr;
+    const uint32_t slot = free_queue.head % PLATFORM_PROF_SLOT_COUNT;
+    auto *next = reinterpret_cast<HostPhaseRecordBuffer *>(free_queue.buffer_ptrs[slot]);
+    free_queue.head = free_queue.head + 1;
+    pool->head.current_buf_ptr = reinterpret_cast<uint64_t>(next);
+    pool->head.current_buf_seq = pool->head.current_buf_seq + 1;
+    return next;
+}
+
+/**
+ * Append one record. A null pool means this pass collects no records, which is
+ * the common case and costs one branch.
+ *
+ * @param start_ns,end_ns  host monotonic nanoseconds
+ * @param payload          task id for kinds that submit a task, else a detail count
+ * @param index            submit_idx for orchestrator operations, 0 for bind segments
+ */
+inline void host_phase_pool_append(
+    HostPhaseRecordPool *pool, HostPhaseKind kind, uint64_t start_ns, uint64_t end_ns, uint64_t payload, uint32_t index
+) {
+    if (pool == nullptr) return;
+    pool->head.total_record_count = pool->head.total_record_count + 1;
+    auto *active = reinterpret_cast<HostPhaseRecordBuffer *>(pool->head.current_buf_ptr);
+    if (active == nullptr || active->count >= PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER) {
+        active = host_phase_pool_rotate(pool);
+        if (active == nullptr) {
+            pool->head.dropped_record_count = pool->head.dropped_record_count + 1;
+            return;
+        }
+    }
+    active->records[active->count] = HostPhaseRecord{start_ns, end_ns, payload, static_cast<uint32_t>(kind), index};
+    active->count = active->count + 1;
+}

--- a/src/common/platform/include/host/host_phase_records_artifact.h
+++ b/src/common/platform/include/host/host_phase_records_artifact.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <system_error>
+
+#include "common/unified_log.h"
+
+/**
+ * Output path (JSON Lines, one object per prepare pass) for the host phase
+ * records a run collected.
+ *
+ * Only the platform runner knows the per-case directory, so it is the runner that
+ * names the file. Filename is fixed — the directory is the per-task uniqueness
+ * boundary, mirroring make_deps_json_path() / make_pmu_csv_path().
+ */
+inline std::string make_host_phase_records_path(const std::string &output_dir) {
+    std::filesystem::path dir(output_dir);
+    std::error_code ec;
+    std::filesystem::create_directories(dir, ec);
+    if (ec) {
+        LOG_WARN(
+            "Failed to create host phase records output directory %s: %s", output_dir.c_str(), ec.message().c_str()
+        );
+    }
+    return (dir / "host_phase_records.jsonl").string();
+}

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -183,19 +183,14 @@ static uint32_t get_chip_swimlane_level(void *runner_ctx) {
     return static_cast<DeviceRunnerBase *>(runner_ctx)->chip_swimlane_level();
 }
 
-static void begin_host_orchestrator_capture(void *runner_ctx, uint64_t reserve_capacity) noexcept {
-    if (runner_ctx == nullptr) return;
-    static_cast<DeviceRunnerBase *>(runner_ctx)->begin_host_orchestrator_capture(reserve_capacity);
+static void *host_phase_pool_arm(void *runner_ctx, int producer_wants_records) {
+    if (runner_ctx == nullptr) return nullptr;
+    return static_cast<DeviceRunnerBase *>(runner_ctx)->host_phase_pool_arm(producer_wants_records != 0);
 }
 
-static void record_host_orchestrator_phase(void *runner_ctx, const ChipSwimlaneHostOrchPhaseRecord *record) noexcept {
-    if (runner_ctx == nullptr || record == nullptr) return;
-    static_cast<DeviceRunnerBase *>(runner_ctx)->record_host_orchestrator_phase(*record);
-}
-
-static void finish_host_orchestrator_capture(void *runner_ctx, uint64_t expected_records) noexcept {
+static void host_phase_pool_finish(void *runner_ctx, uint64_t submitted_tasks, uint64_t invocation_id) {
     if (runner_ctx == nullptr) return;
-    static_cast<DeviceRunnerBase *>(runner_ctx)->finish_host_orchestrator_capture(expected_records);
+    static_cast<DeviceRunnerBase *>(runner_ctx)->host_phase_pool_finish(submitted_tasks, invocation_id);
 }
 
 static int setup_static_arena_wrapper(
@@ -295,9 +290,8 @@ static const HostApiOps g_host_api_ops = {
     .mark_prebuilt_runtime_arena_cached = mark_prebuilt_runtime_arena_cached_wrapper,
     .upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper,
     .get_chip_swimlane_level = get_chip_swimlane_level,
-    .begin_host_orchestrator_capture = begin_host_orchestrator_capture,
-    .record_host_orchestrator_phase = record_host_orchestrator_phase,
-    .finish_host_orchestrator_capture = finish_host_orchestrator_capture,
+    .host_phase_pool_arm = host_phase_pool_arm,
+    .host_phase_pool_finish = host_phase_pool_finish,
 };
 
 /* ===========================================================================

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -41,6 +41,7 @@
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "host/acl_error_log.h"
+#include "host/host_phase_records_artifact.h"
 #include "host/raii_scope_guard.h"
 #include "host_log.h"
 #include "platform_comm/comm.h"
@@ -1057,14 +1058,26 @@ void DeviceRunnerBase::apply_call_config(const CallConfig &config) {
     set_output_prefix(config.output_prefix);
 }
 
-void DeviceRunnerBase::begin_host_orchestrator_capture(uint64_t reserve_capacity) noexcept {
+HostPhaseRecordPool *DeviceRunnerBase::host_phase_pool_arm(bool producer_wants_records) noexcept {
     if (clock_correlation_provider_ != nullptr) {
         clock_correlation_provider_->release(false);
         clock_correlation_provider_.reset();
     }
-    chip_swimlane_collector_.begin_host_orchestrator_capture(static_cast<size_t>(reserve_capacity));
-    if (chip_swimlane_level_ != ChipSwimlaneLevel::ORCH_PHASES) return;
+    const bool swimlane_wants_records = chip_swimlane_level_ == ChipSwimlaneLevel::ORCH_PHASES;
+    chip_swimlane_collector_.set_host_orchestrated(swimlane_wants_records);
+    // arm() allocates the pool's buffers, so it can throw; this path is noexcept,
+    // where an escaping exception is std::terminate. A pass that cannot get its
+    // storage collects no records and says so by handing back nullptr.
+    HostPhaseRecordPool *pool = nullptr;
+    try {
+        pool = host_phase_records_.arm(producer_wants_records || swimlane_wants_records);
+    } catch (...) {
+        LOG_WARN("Host phase pool could not be armed; this pass collects no per-event records");
+    }
+    if (!swimlane_wants_records) return pool;
 
+    // Only the chip-swimlane reader places these records against device
+    // timestamps, so only it needs the two clocks anchored.
     try {
         clock_correlation_provider_ = simpler::dfx::make_clock_correlation_provider();
         chip_swimlane_collector_.begin_clock_correlation_session(
@@ -1085,6 +1098,16 @@ void DeviceRunnerBase::begin_host_orchestrator_capture(uint64_t reserve_capacity
             chip_swimlane_collector_.finish_clock_correlation_session();
         }
     }
+    return pool;
+}
+
+void DeviceRunnerBase::publish_host_phase_records_to_swimlane() {
+    if (!host_phase_records_.finished()) return;
+    chip_swimlane_collector_.set_host_phase_records(
+        host_phase_records_.submit_records(), host_phase_records_.device_upload_records(),
+        host_phase_records_.submitted_tasks(), host_phase_records_.total_records(),
+        host_phase_records_.dropped_records()
+    );
 }
 
 void DeviceRunnerBase::finish_clock_correlation_session(
@@ -1654,7 +1677,18 @@ void DeviceRunnerBase::teardown_shared_collectors_after_run(bool device_executio
         chip_swimlane_collector_.stop();
         chip_swimlane_collector_.read_phase_header_metadata();
         chip_swimlane_collector_.reconcile_counters();
+        publish_host_phase_records_to_swimlane();
         chip_swimlane_collector_.export_swimlane_json();
+    }
+
+    // Per-event view of the prepare path. Written here rather than in the reap
+    // tail because a device error reaches this teardown but not that tail, and a
+    // failed run is when the prepare timing is worth having. Keyed on
+    // output_prefix_ because it is non-empty exactly when this run produces
+    // diagnostic artifacts, and on the store having finished a pass, which is what
+    // a host-orchestrating runtime leaves behind.
+    if (!output_prefix_.empty() && host_phase_records_.finished()) {
+        (void)host_phase_records_.write_records_jsonl(make_host_phase_records_path(output_prefix_));
     }
 
     if (enable_dump_args_) {

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -64,6 +64,7 @@
 #include "device_runner_helpers.h"
 #include "aicpu_loader/host/load_aicpu_op.h"
 #include "host/chip_swimlane_collector.h"
+#include "host/host_phase_records.h"
 #include "host/memory_allocator.h"
 #include "host/pmu_collector.h"
 #include "host/runtime_timeout_config.h"
@@ -675,13 +676,13 @@ public:
         enable_chip_swimlane_ = (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED);
     }
     uint32_t chip_swimlane_level() const { return static_cast<uint32_t>(chip_swimlane_level_); }
-    void begin_host_orchestrator_capture(uint64_t reserve_capacity) noexcept;
-    void record_host_orchestrator_phase(const ChipSwimlaneHostOrchPhaseRecord &record) noexcept {
-        chip_swimlane_collector_.record_host_orchestrator_phase(record);
+    HostPhaseRecordPool *host_phase_pool_arm(bool producer_wants_records) noexcept;
+    void host_phase_pool_finish(uint64_t submitted_tasks, uint64_t invocation_id) noexcept {
+        host_phase_records_.finish(submitted_tasks, invocation_id);
     }
-    void finish_host_orchestrator_capture(uint64_t expected_records) noexcept {
-        chip_swimlane_collector_.finish_host_orchestrator_capture(expected_records);
-    }
+    const simpler::dfx::HostPhaseRecordStore &host_phase_records() const { return host_phase_records_; }
+    /** Hand this pass's records to the swimlane reader, just before its export. */
+    void publish_host_phase_records_to_swimlane();
     void finish_clock_correlation_session(bool capture_device_complete, bool abandon_device_resources) noexcept;
     void set_dump_args_enabled(int level) {
         dump_args_level_ = static_cast<DumpArgsLevel>(level);
@@ -1148,6 +1149,10 @@ protected:
     // on the base. `DepGenCollector` is not shared — each arch that
     // implements dep_gen (a2a3, a5) keeps it on its own subclass.
     ChipSwimlaneCollector chip_swimlane_collector_;
+    // Not a collector: the pool the runtime's prepare path writes into, read by
+    // whichever per-event views the run enabled. Its two readers are gated
+    // independently, so it belongs to neither.
+    simpler::dfx::HostPhaseRecordStore host_phase_records_;
     std::unique_ptr<simpler::dfx::ClockCorrelationProvider> clock_correlation_provider_{};
     ArgsDumpCollector dump_collector_;
     PmuCollector pmu_collector_;

--- a/src/common/platform/shared/host/chip_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/chip_swimlane_collector.cpp
@@ -411,8 +411,7 @@ int ChipSwimlaneCollector::initialize(
     auto orch_get_state = [](void *base, int n_cores, int t) {
         return get_orch_phase_buffer_state(base, n_cores, t);
     };
-    const int orch_buffer_count =
-        chip_swimlane_level_ >= ChipSwimlaneLevel::ORCH_PHASES && !host_orchestrator_capture_started_ ? 1 : 0;
+    const int orch_buffer_count = chip_swimlane_level_ >= ChipSwimlaneLevel::ORCH_PHASES && !host_orchestrated_ ? 1 : 0;
     if (init_phase_pools(
             static_cast<ChipSwimlaneAicpuOrchPhaseBuffer *>(nullptr), orch_get_state,
             /*state_count=*/num_phase_threads, /*buffer_count=*/orch_buffer_count,
@@ -899,53 +898,16 @@ void ChipSwimlaneCollector::set_core_types(const CoreType *types, int n) {
     core_types_.assign(types, types + n);
 }
 
-void ChipSwimlaneCollector::begin_host_orchestrator_capture(size_t reserve_capacity) noexcept {
-    // HBG profiling is depth-one while diagnostics are enabled, and its host
-    // orchestrator is synchronous. No collector thread exists yet at this
-    // point, so the runner-owned vector needs no locking.
-    collected_host_orch_phase_records_.clear();
-    clock_correlation_session_.reset();
-    host_orchestrator_capture_started_ = true;
-    host_orchestrator_capture_enabled_ = true;
-    host_capture_error_ = HostCaptureError::None;
-    host_capture_reserve_requested_ = reserve_capacity;
-    host_capture_dropped_records_ = 0;
-    host_capture_expected_records_ = 0;
-    host_capture_finished_ = false;
-    try {
-        collected_host_orch_phase_records_.reserve(reserve_capacity);
-    } catch (...) {
-        host_orchestrator_capture_enabled_ = false;
-        host_capture_error_ = HostCaptureError::ReserveFailed;
-    }
-}
-
-void ChipSwimlaneCollector::finish_host_orchestrator_capture(uint64_t expected_records) noexcept {
-    if (!host_orchestrator_capture_started_) return;
-    host_capture_expected_records_ = expected_records;
-    host_capture_finished_ = true;
-}
-
-void ChipSwimlaneCollector::record_host_orchestrator_phase(const ChipSwimlaneHostOrchPhaseRecord &record) noexcept {
-    if (!host_orchestrator_capture_enabled_) {
-        ++host_capture_dropped_records_;
-        return;
-    }
-    if (record.end_time_ns < record.start_time_ns) {
-        LOG_WARN(
-            "Ignoring invalid host orchestrator phase: task_id=%lu start_ns=%lu end_ns=%lu",
-            static_cast<unsigned long>(record.task_id), static_cast<unsigned long>(record.start_time_ns),
-            static_cast<unsigned long>(record.end_time_ns)
-        );
-        return;
-    }
-    try {
-        collected_host_orch_phase_records_.push_back(record);
-    } catch (...) {
-        host_orchestrator_capture_enabled_ = false;
-        host_capture_error_ = HostCaptureError::RecordAllocationFailed;
-        ++host_capture_dropped_records_;
-    }
+void ChipSwimlaneCollector::set_host_phase_records(
+    std::vector<HostPhaseRecord> submit_records, std::vector<HostPhaseRecord> upload_records, uint64_t submitted_tasks,
+    uint64_t total_records, uint64_t dropped_records
+) {
+    host_submit_records_ = std::move(submit_records);
+    host_upload_records_ = std::move(upload_records);
+    host_phase_submitted_tasks_ = submitted_tasks;
+    host_phase_total_records_ = total_records;
+    host_phase_dropped_records_ = dropped_records;
+    host_phase_records_present_ = true;
 }
 
 void ChipSwimlaneCollector::begin_clock_correlation_session(
@@ -975,7 +937,8 @@ int ChipSwimlaneCollector::export_swimlane_json() {
     // Every stream is independently useful for DFX. In particular, a legal
     // HBG can contain only host-side dummy/hidden-allocation records and no
     // AICore dispatch at all.
-    bool has_any_records = !collected_host_orch_phase_records_.empty() || clock_correlation_session_.started();
+    bool has_any_records =
+        !host_submit_records_.empty() || !host_upload_records_.empty() || clock_correlation_session_.started();
     for (const auto &core_records : collected_perf_records_) {
         if (!core_records.empty()) {
             has_any_records = true;
@@ -1002,7 +965,7 @@ int ChipSwimlaneCollector::export_swimlane_json() {
         LOG_WARN("Warning: No performance data to export.");
         return -1;
     }
-    if (has_aicpu_orch_phases && host_orchestrator_capture_started_) {
+    if (has_aicpu_orch_phases && host_orchestrated_) {
         LOG_ERROR("Both host and AICPU orchestrator records are present; refusing mixed clock-domain export");
         return -1;
     }
@@ -1039,50 +1002,43 @@ int ChipSwimlaneCollector::export_swimlane_json() {
         outfile << "\"" << ((ct == CoreType::AIC) ? "aic" : "aiv") << "\"";
     }
     outfile << "]";
-    if (host_orchestrator_capture_started_) {
+    if (host_phase_records_present_) {
+        // Earliest of both projections: an upload segment can start before the
+        // first submit, and a negative offset from the origin is not renderable.
         uint64_t host_origin_ns = 0;
-        if (!collected_host_orch_phase_records_.empty()) {
-            host_origin_ns = collected_host_orch_phase_records_.front().start_time_ns;
-            for (const auto &record : collected_host_orch_phase_records_) {
-                if (record.start_time_ns < host_origin_ns) host_origin_ns = record.start_time_ns;
+        for (const auto *population : {&host_submit_records_, &host_upload_records_}) {
+            for (const auto &record : *population) {
+                if (host_origin_ns == 0 || record.start_ns < host_origin_ns) host_origin_ns = record.start_ns;
             }
         }
         outfile << ",\n    \"orchestrator_source\": \"host\"";
         outfile << ",\n    \"orchestrator_clock_domain\": \"host_monotonic_ns\"";
         outfile << ",\n    \"device_clock_domain\": \"device_syscnt_cycles\"";
-        constexpr uint64_t kNsPerSecond = 1'000'000'000ull;
-        constexpr uint64_t host_timestamp_resolution_ns =
-            (kNsPerSecond + PLATFORM_PROF_SYS_CNT_FREQ - 1) / PLATFORM_PROF_SYS_CNT_FREQ;
-        constexpr uint64_t host_timestamp_quantization_ns =
-            host_timestamp_resolution_ns > 1 ? host_timestamp_resolution_ns : 0;
-        outfile << ",\n    \"host_timestamp_resolution_ns\": " << host_timestamp_resolution_ns;
-        outfile << ",\n    \"host_timestamp_quantization_ns\": " << host_timestamp_quantization_ns;
+        // The producer stamps records straight from the host monotonic clock, so
+        // a record's resolution is the clock's nanosecond and nothing is
+        // quantized away on top of it.
+        outfile << ",\n    \"host_timestamp_resolution_ns\": 1";
+        outfile << ",\n    \"host_timestamp_quantization_ns\": 0";
         outfile << ",\n    \"host_orchestration_origin_ns\": " << host_origin_ns;
         outfile << ",\n    \"timeline_relation\": \"host_orchestration_precedes_device\"";
-        const char *capture_error = "none";
-        if (host_capture_error_ == HostCaptureError::ReserveFailed) {
-            capture_error = "reserve_failed";
-        } else if (host_capture_error_ == HostCaptureError::RecordAllocationFailed) {
-            capture_error = "record_allocation_failed";
-        }
-        const bool host_record_count_matches =
-            host_capture_finished_ && collected_host_orch_phase_records_.size() == host_capture_expected_records_;
-        const bool host_capture_complete = host_capture_error_ == HostCaptureError::None && host_record_count_matches;
-        const char *host_capture_status = host_capture_complete                         ? "complete" :
-                                          host_capture_error_ != HostCaptureError::None ? "dropped" :
-                                                                                          "incomplete";
+        // Completeness is per kind, not per record: the pool holds every timed
+        // host operation, of which the task-submitting kinds are the projection
+        // this file carries. Comparing the pool's total against total_tasks would
+        // count the sub-operations of a submit as if each were a submit.
+        const bool host_record_count_matches = host_submit_records_.size() == host_phase_submitted_tasks_;
+        const bool host_capture_complete = host_phase_dropped_records_ == 0 && host_record_count_matches;
+        const char *host_capture_status = host_capture_complete           ? "complete" :
+                                          host_phase_dropped_records_ > 0 ? "dropped" :
+                                                                            "incomplete";
         outfile << ",\n    \"host_capture\": {\"status\": \"" << host_capture_status
-                << "\", \"reserve_requested\": " << host_capture_reserve_requested_
-                << ", \"finished\": " << (host_capture_finished_ ? "true" : "false")
-                << ", \"expected_records\": " << host_capture_expected_records_
-                << ", \"recorded_records\": " << collected_host_orch_phase_records_.size()
-                << ", \"dropped_records\": " << host_capture_dropped_records_ << ", \"error\": ";
+                << "\", \"expected_records\": " << host_phase_submitted_tasks_
+                << ", \"recorded_records\": " << host_submit_records_.size()
+                << ", \"pool_records\": " << host_phase_total_records_
+                << ", \"dropped_records\": " << host_phase_dropped_records_ << ", \"error\": ";
         if (host_capture_complete) {
             outfile << "null}";
-        } else if (host_capture_error_ != HostCaptureError::None) {
-            outfile << "\"" << capture_error << "\"}";
-        } else if (!host_capture_finished_) {
-            outfile << "\"capture_not_finished\"}";
+        } else if (host_phase_dropped_records_ > 0) {
+            outfile << "\"pool_overflow\"}";
         } else {
             outfile << "\"record_count_mismatch\"}";
         }
@@ -1281,18 +1237,30 @@ int ChipSwimlaneCollector::export_swimlane_json() {
             }
             outfile << "  ]";
         }
-        if (!collected_host_orch_phase_records_.empty()) {
+        if (!host_submit_records_.empty()) {
             outfile << ",\n  \"host_orchestrator_phases\": [[";
             bool first = true;
-            for (const auto &record : collected_host_orch_phase_records_) {
+            for (const auto &record : host_submit_records_) {
                 if (!first) outfile << ",";
-                outfile << "\n      {\"submit_idx\": " << record.submit_idx << ", \"task_id\": " << record.task_id
-                        << ", \"start_host_ns\": " << record.start_time_ns
-                        << ", \"end_host_ns\": " << record.end_time_ns << "}";
+                outfile << "\n      {\"submit_idx\": " << record.index << ", \"task_id\": " << record.payload
+                        << ", \"start_host_ns\": " << record.start_ns << ", \"end_host_ns\": " << record.end_ns << "}";
                 first = false;
             }
             if (!first) outfile << "\n    ";
             outfile << "]]";
+        }
+        if (!host_upload_records_.empty()) {
+            outfile << ",\n  \"host_device_uploads\": [";
+            bool first = true;
+            for (const auto &record : host_upload_records_) {
+                if (!first) outfile << ",";
+                outfile << "\n      {\"phase\": \"" << host_phase_kind_name(static_cast<HostPhaseKind>(record.kind))
+                        << "\", \"start_host_ns\": " << record.start_ns << ", \"end_host_ns\": " << record.end_ns
+                        << ", \"detail\": " << record.payload << "}";
+                first = false;
+            }
+            if (!first) outfile << "\n    ";
+            outfile << "]";
         }
     }
 
@@ -1423,7 +1391,8 @@ int ChipSwimlaneCollector::finalize(
     collected_aicore_records_.clear();
     collected_sched_phase_records_.clear();
     collected_orch_phase_records_.clear();
-    collected_host_orch_phase_records_.clear();
+    host_submit_records_.clear();
+    host_upload_records_.clear();
     clock_correlation_session_.reset();
     perf_records_by_collector_.clear();
     aicore_records_by_collector_.clear();
@@ -1436,13 +1405,11 @@ int ChipSwimlaneCollector::finalize(
     total_sched_phase_collected_ = 0;
     total_orch_phase_collected_ = 0;
     collector_shards_merged_ = false;
-    host_orchestrator_capture_started_ = false;
-    host_orchestrator_capture_enabled_ = false;
-    host_capture_error_ = HostCaptureError::None;
-    host_capture_reserve_requested_ = 0;
-    host_capture_dropped_records_ = 0;
-    host_capture_expected_records_ = 0;
-    host_capture_finished_ = false;
+    host_orchestrated_ = false;
+    host_phase_records_present_ = false;
+    host_phase_total_records_ = 0;
+    host_phase_dropped_records_ = 0;
+    host_phase_submitted_tasks_ = 0;
     clear_memory_context();
 
     LOG_DEBUG("Performance profiling cleanup complete");

--- a/src/common/platform/shared/host/host_phase_records.cpp
+++ b/src/common/platform/shared/host/host_phase_records.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "host/host_phase_records.h"
+
+#include <unistd.h>
+
+#include <fstream>
+
+#include "common/unified_log.h"
+
+namespace simpler::dfx {
+
+HostPhaseRecordPool *HostPhaseRecordStore::arm(bool collect_records) {
+    pool_ = HostPhaseRecordPool{};
+    armed_ = false;
+    finished_ = false;
+    submitted_tasks_ = 0;
+    // A pass's identity must not survive into the next one: write_records_jsonl
+    // asks only whether the store is armed, so a pass written before finish()
+    // would otherwise carry the previous invocation id and join to the wrong span.
+    invocation_id_ = 0;
+    if (!collect_records) {
+        buffers_.clear();
+        buffers_.shrink_to_fit();
+        return nullptr;
+    }
+
+    // Allocated once and reused for every later pass: a pass's records are only
+    // valid until the next arm(), so the storage can be too.
+    buffers_.resize(static_cast<size_t>(PLATFORM_HOST_PHASE_BUFFERS));
+    for (auto &buffer : buffers_) {
+        buffer.count = 0;
+    }
+
+    // Buffer 0 is active and the rest fill the free queue in index order, so the
+    // reader recovers fill order from the buffer index alone — the free queue
+    // holds exactly PLATFORM_PROF_SLOT_COUNT spares, which is why the pool is
+    // one buffer larger than that.
+    pool_.head.current_buf_ptr = reinterpret_cast<uint64_t>(&buffers_[0]);
+    pool_.head.current_buf_seq = 1;
+    for (size_t i = 1; i < buffers_.size(); ++i) {
+        pool_.free_queue.buffer_ptrs[(i - 1) % PLATFORM_PROF_SLOT_COUNT] = reinterpret_cast<uint64_t>(&buffers_[i]);
+    }
+    pool_.free_queue.head = 0;
+    pool_.free_queue.tail = static_cast<uint32_t>(buffers_.size() - 1);
+    armed_ = true;
+    return &pool_;
+}
+
+void HostPhaseRecordStore::finish(uint64_t submitted_tasks, uint64_t invocation_id) {
+    if (!armed_) return;
+    submitted_tasks_ = submitted_tasks;
+    invocation_id_ = invocation_id;
+    finished_ = true;
+    if (pool_.head.dropped_record_count > 0) {
+        LOG_WARN(
+            "Host phase pool dropped %u of %u records (capacity %zu); the per-event views are truncated while the "
+            "per-kind totals stay exact",
+            static_cast<unsigned>(pool_.head.dropped_record_count),
+            static_cast<unsigned>(pool_.head.total_record_count), capacity()
+        );
+    }
+}
+
+int HostPhaseRecordStore::write_records_jsonl(const std::string &path) const {
+    if (!armed_) return 0;
+    const std::vector<HostPhaseRecord> all = records();
+    if (all.empty() && dropped_records() == 0) return 0;
+
+    // Appended one object per pass: a --rounds run emits a pass per round, and
+    // each object carries the identity needed to join it to that round's spans.
+    std::ofstream out(path, std::ios::app);
+    if (!out.is_open()) {
+        LOG_ERROR("Host phase records: cannot open '%s' for append", path.c_str());
+        return -1;
+    }
+    // One line per pass (JSON Lines), matching scope_stats.jsonl: a reader can
+    // take a pass at a time without buffering the file or tracking brace depth.
+    out << "{\"pid\": " << static_cast<int>(getpid()) << ", \"inv\": " << invocation_id_
+        << ", \"clock\": \"host_monotonic_ns\", \"dropped\": " << dropped_records() << ", \"records\": [";
+    bool first = true;
+    for (const auto &record : all) {
+        if (!first) out << ", ";
+        out << "{\"phase\": \"" << host_phase_kind_name(static_cast<HostPhaseKind>(record.kind))
+            << "\", \"start_ns\": " << record.start_ns << ", \"end_ns\": " << record.end_ns
+            << ", \"detail\": " << record.payload << "}";
+        first = false;
+    }
+    out << "]}\n";
+    out.flush();
+    if (!out.good()) {
+        LOG_ERROR("Host phase records: write to '%s' failed", path.c_str());
+        return -1;
+    }
+    LOG_DEBUG("Host phase records: appended %zu records to %s", all.size(), path.c_str());
+    return 0;
+}
+
+std::vector<HostPhaseRecord> HostPhaseRecordStore::records() const {
+    std::vector<HostPhaseRecord> out;
+    if (!armed_) return out;
+    out.reserve(pool_.head.total_record_count);
+    for (const auto &buffer : buffers_) {
+        const uint32_t count = buffer.count < PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER ?
+                                   buffer.count :
+                                   static_cast<uint32_t>(PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER);
+        for (uint32_t i = 0; i < count; ++i) {
+            out.push_back(buffer.records[i]);
+        }
+    }
+    return out;
+}
+
+std::vector<HostPhaseRecord> HostPhaseRecordStore::submit_records() const {
+    std::vector<HostPhaseRecord> out;
+    for (const auto &record : records()) {
+        if (host_phase_kind_submits_task(static_cast<HostPhaseKind>(record.kind))) {
+            out.push_back(record);
+        }
+    }
+    return out;
+}
+
+std::vector<HostPhaseRecord> HostPhaseRecordStore::device_upload_records() const {
+    std::vector<HostPhaseRecord> out;
+    for (const auto &record : records()) {
+        if (host_phase_kind_is_device_upload(static_cast<HostPhaseKind>(record.kind))) {
+            out.push_back(record);
+        }
+    }
+    return out;
+}
+
+}  // namespace simpler::dfx

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -169,19 +169,14 @@ static uint32_t get_chip_swimlane_level(void *runner_ctx) {
     return static_cast<SimDeviceRunnerBase *>(runner_ctx)->chip_swimlane_level();
 }
 
-static void begin_host_orchestrator_capture(void *runner_ctx, uint64_t reserve_capacity) noexcept {
-    if (runner_ctx == nullptr) return;
-    static_cast<SimDeviceRunnerBase *>(runner_ctx)->begin_host_orchestrator_capture(reserve_capacity);
+static void *host_phase_pool_arm(void *runner_ctx, int producer_wants_records) {
+    if (runner_ctx == nullptr) return nullptr;
+    return static_cast<SimDeviceRunnerBase *>(runner_ctx)->host_phase_pool_arm(producer_wants_records != 0);
 }
 
-static void record_host_orchestrator_phase(void *runner_ctx, const ChipSwimlaneHostOrchPhaseRecord *record) noexcept {
-    if (runner_ctx == nullptr || record == nullptr) return;
-    static_cast<SimDeviceRunnerBase *>(runner_ctx)->record_host_orchestrator_phase(*record);
-}
-
-static void finish_host_orchestrator_capture(void *runner_ctx, uint64_t expected_records) noexcept {
+static void host_phase_pool_finish(void *runner_ctx, uint64_t submitted_tasks, uint64_t invocation_id) {
     if (runner_ctx == nullptr) return;
-    static_cast<SimDeviceRunnerBase *>(runner_ctx)->finish_host_orchestrator_capture(expected_records);
+    static_cast<SimDeviceRunnerBase *>(runner_ctx)->host_phase_pool_finish(submitted_tasks, invocation_id);
 }
 
 static int setup_static_arena_wrapper(
@@ -282,9 +277,8 @@ static const HostApiOps g_host_api_ops = {
     .mark_prebuilt_runtime_arena_cached = mark_prebuilt_runtime_arena_cached_wrapper,
     .upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper,
     .get_chip_swimlane_level = get_chip_swimlane_level,
-    .begin_host_orchestrator_capture = begin_host_orchestrator_capture,
-    .record_host_orchestrator_phase = record_host_orchestrator_phase,
-    .finish_host_orchestrator_capture = finish_host_orchestrator_capture,
+    .host_phase_pool_arm = host_phase_pool_arm,
+    .host_phase_pool_finish = host_phase_pool_finish,
 };
 
 /* ===========================================================================

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -675,14 +675,26 @@ void SimDeviceRunnerBase::apply_call_config(const CallConfig &config) {
     set_output_prefix(config.output_prefix);
 }
 
-void SimDeviceRunnerBase::begin_host_orchestrator_capture(uint64_t reserve_capacity) noexcept {
+HostPhaseRecordPool *SimDeviceRunnerBase::host_phase_pool_arm(bool producer_wants_records) noexcept {
     if (clock_correlation_provider_ != nullptr) {
         clock_correlation_provider_->release(false);
         clock_correlation_provider_.reset();
     }
-    chip_swimlane_collector_.begin_host_orchestrator_capture(static_cast<size_t>(reserve_capacity));
-    if (chip_swimlane_level_ != ChipSwimlaneLevel::ORCH_PHASES) return;
+    const bool swimlane_wants_records = chip_swimlane_level_ == ChipSwimlaneLevel::ORCH_PHASES;
+    chip_swimlane_collector_.set_host_orchestrated(swimlane_wants_records);
+    // arm() allocates the pool's buffers, so it can throw; this path is noexcept,
+    // where an escaping exception is std::terminate. A pass that cannot get its
+    // storage collects no records and says so by handing back nullptr.
+    HostPhaseRecordPool *pool = nullptr;
+    try {
+        pool = host_phase_records_.arm(producer_wants_records || swimlane_wants_records);
+    } catch (...) {
+        LOG_WARN("Host phase pool could not be armed; this pass collects no per-event records");
+    }
+    if (!swimlane_wants_records) return pool;
 
+    // Only the chip-swimlane reader places these records against device
+    // timestamps, so only it needs the two clocks anchored.
     try {
         clock_correlation_provider_ = simpler::dfx::make_clock_correlation_provider();
         chip_swimlane_collector_.begin_clock_correlation_session(
@@ -703,6 +715,16 @@ void SimDeviceRunnerBase::begin_host_orchestrator_capture(uint64_t reserve_capac
             chip_swimlane_collector_.finish_clock_correlation_session();
         }
     }
+    return pool;
+}
+
+void SimDeviceRunnerBase::publish_host_phase_records_to_swimlane() {
+    if (!host_phase_records_.finished()) return;
+    chip_swimlane_collector_.set_host_phase_records(
+        host_phase_records_.submit_records(), host_phase_records_.device_upload_records(),
+        host_phase_records_.submitted_tasks(), host_phase_records_.total_records(),
+        host_phase_records_.dropped_records()
+    );
 }
 
 void SimDeviceRunnerBase::finish_clock_correlation_session(bool capture_device_complete) noexcept {

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -54,6 +54,7 @@
 #include "common/unified_log.h"
 #include "host/memory_allocator.h"
 #include "host/chip_swimlane_collector.h"
+#include "host/host_phase_records.h"
 #include "host/args_dump_collector.h"
 #include "host/pmu_collector.h"
 #include "host/scope_stats_collector.h"
@@ -269,13 +270,13 @@ public:
         enable_chip_swimlane_ = (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED);
     }
     uint32_t chip_swimlane_level() const { return static_cast<uint32_t>(chip_swimlane_level_); }
-    void begin_host_orchestrator_capture(uint64_t reserve_capacity) noexcept;
-    void record_host_orchestrator_phase(const ChipSwimlaneHostOrchPhaseRecord &record) noexcept {
-        chip_swimlane_collector_.record_host_orchestrator_phase(record);
+    HostPhaseRecordPool *host_phase_pool_arm(bool producer_wants_records) noexcept;
+    void host_phase_pool_finish(uint64_t submitted_tasks, uint64_t invocation_id) noexcept {
+        host_phase_records_.finish(submitted_tasks, invocation_id);
     }
-    void finish_host_orchestrator_capture(uint64_t expected_records) noexcept {
-        chip_swimlane_collector_.finish_host_orchestrator_capture(expected_records);
-    }
+    const simpler::dfx::HostPhaseRecordStore &host_phase_records() const { return host_phase_records_; }
+    /** Hand this pass's records to the swimlane reader, just before its export. */
+    void publish_host_phase_records_to_swimlane();
     void finish_clock_correlation_session(bool capture_device_complete) noexcept;
     void set_dump_args_enabled(int level) {
         dump_args_level_ = static_cast<DumpArgsLevel>(level);
@@ -460,6 +461,10 @@ protected:
 
     // Performance / diagnostics collectors shared across arches.
     ChipSwimlaneCollector chip_swimlane_collector_;
+    // Not a collector: the pool the runtime's prepare path writes into, read by
+    // whichever per-event views the run enabled. Its two readers are gated
+    // independently, so it belongs to neither.
+    simpler::dfx::HostPhaseRecordStore host_phase_records_;
     std::unique_ptr<simpler::dfx::ClockCorrelationProvider> clock_correlation_provider_{};
     ArgsDumpCollector dump_collector_;
     PmuCollector pmu_collector_;

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -685,6 +685,26 @@ target_link_libraries(test_scope_stats_collector PRIVATE
 add_test(NAME test_scope_stats_collector COMMAND test_scope_stats_collector)
 set_tests_properties(test_scope_stats_collector PROPERTIES LABELS "no_hardware")
 
+add_executable(test_host_phase_records
+    common/test_host_phase_records.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/host/host_phase_records.cpp
+    ${CMAKE_SOURCE_DIR}/stubs/test_stubs.cpp
+)
+target_include_directories(test_host_phase_records PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common
+)
+target_link_libraries(test_host_phase_records PRIVATE
+    ${GTEST_MAIN_LIB}
+    ${GTEST_LIB}
+    pthread
+)
+add_test(NAME test_host_phase_records COMMAND test_host_phase_records)
+set_tests_properties(test_host_phase_records PROPERTIES LABELS "no_hardware")
+
 add_executable(test_chip_swimlane_aicore
     common/test_chip_swimlane_aicore.cpp
 )

--- a/tests/ut/cpp/common/test_host_phase_records.cpp
+++ b/tests/ut/cpp/common/test_host_phase_records.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include "host/host_phase_records.h"
+
+using simpler::dfx::HostPhaseRecordStore;
+
+namespace {
+
+void record_n(HostPhaseRecordPool *pool, HostPhaseKind kind, uint32_t n, uint64_t first_start = 0) {
+    for (uint32_t i = 0; i < n; ++i) {
+        const uint64_t start = first_start + i;
+        host_phase_pool_append(pool, kind, start, start + 1, i, i);
+    }
+}
+
+TEST(HostPhaseRecords, DisarmedPoolCollectsNothing) {
+    HostPhaseRecordStore store;
+    HostPhaseRecordPool *pool = store.arm(/*collect_records=*/false);
+    EXPECT_EQ(pool, nullptr);
+    EXPECT_FALSE(store.armed());
+
+    // The producer's record call must tolerate a null pool — that is the common
+    // configuration, where only the per-kind counters run.
+    record_n(pool, HostPhaseKind::OrchRecordNode, 10);
+    store.finish(0, /*invocation_id=*/9);
+    EXPECT_TRUE(store.records().empty());
+    EXPECT_EQ(store.total_records(), 0u);
+    EXPECT_EQ(store.dropped_records(), 0u);
+}
+
+TEST(HostPhaseRecords, RecordsSurviveInOrderWithinOneBuffer) {
+    HostPhaseRecordStore store;
+    HostPhaseRecordPool *pool = store.arm(true);
+    ASSERT_NE(pool, nullptr);
+
+    record_n(pool, HostPhaseKind::OrchRecordNode, 337, /*first_start=*/1000);
+    store.finish(0, /*invocation_id=*/9);
+
+    const auto records = store.records();
+    ASSERT_EQ(records.size(), 337u);
+    EXPECT_EQ(store.total_records(), 337u);
+    EXPECT_EQ(store.dropped_records(), 0u);
+    for (size_t i = 0; i < records.size(); ++i) {
+        EXPECT_EQ(records[i].start_ns, 1000u + i) << "record " << i << " out of rotation order";
+        EXPECT_EQ(records[i].kind, static_cast<uint32_t>(HostPhaseKind::OrchRecordNode));
+    }
+}
+
+TEST(HostPhaseRecords, RotationSpansEveryBufferInOrder) {
+    HostPhaseRecordStore store;
+    HostPhaseRecordPool *pool = store.arm(true);
+    ASSERT_NE(pool, nullptr);
+
+    // Exactly fills the pool: one active buffer plus PLATFORM_PROF_SLOT_COUNT
+    // spares, so the last record lands without a drop.
+    const uint32_t capacity = static_cast<uint32_t>(HostPhaseRecordStore::capacity());
+    record_n(pool, HostPhaseKind::OrchGraphSubmit, capacity, /*first_start=*/1);
+    store.finish(0, /*invocation_id=*/9);
+
+    const auto records = store.records();
+    ASSERT_EQ(records.size(), capacity);
+    EXPECT_EQ(store.dropped_records(), 0u);
+    EXPECT_EQ(pool->head.current_buf_seq, static_cast<uint32_t>(PLATFORM_HOST_PHASE_BUFFERS));
+    for (uint32_t i = 0; i < capacity; ++i) {
+        EXPECT_EQ(records[i].start_ns, 1u + i) << "record " << i << " out of rotation order";
+    }
+}
+
+TEST(HostPhaseRecords, OverflowDropsAndCountsWithoutLosingEarlierRecords) {
+    HostPhaseRecordStore store;
+    HostPhaseRecordPool *pool = store.arm(true);
+    ASSERT_NE(pool, nullptr);
+
+    const uint32_t capacity = static_cast<uint32_t>(HostPhaseRecordStore::capacity());
+    const uint32_t overshoot = 25;
+    record_n(pool, HostPhaseKind::OrchRecordNode, capacity + overshoot, /*first_start=*/1);
+    store.finish(0, /*invocation_id=*/9);
+
+    const auto records = store.records();
+    EXPECT_EQ(records.size(), capacity);
+    EXPECT_EQ(store.total_records(), capacity + overshoot);
+    EXPECT_EQ(store.dropped_records(), overshoot);
+    // Dropping is tail-loss, not corruption: the retained prefix is intact.
+    ASSERT_FALSE(records.empty());
+    EXPECT_EQ(records.front().start_ns, 1u);
+    EXPECT_EQ(records.back().start_ns, static_cast<uint64_t>(capacity));
+}
+
+TEST(HostPhaseRecords, ReArmClearsThePreviousPass) {
+    HostPhaseRecordStore store;
+    HostPhaseRecordPool *pool = store.arm(true);
+    ASSERT_NE(pool, nullptr);
+    record_n(pool, HostPhaseKind::OrchRecordNode, 50);
+    store.finish(7, /*invocation_id=*/9);
+    EXPECT_EQ(store.records().size(), 50u);
+    EXPECT_EQ(store.submitted_tasks(), 7u);
+
+    pool = store.arm(true);
+    ASSERT_NE(pool, nullptr);
+    EXPECT_TRUE(store.records().empty());
+    EXPECT_EQ(store.total_records(), 0u);
+    EXPECT_FALSE(store.finished());
+    record_n(pool, HostPhaseKind::OrchGraphSubmit, 3);
+    store.finish(3, /*invocation_id=*/9);
+    EXPECT_EQ(store.records().size(), 3u);
+}
+
+TEST(HostPhaseRecords, SubmitProjectionKeepsOnlyTaskSubmittingKinds) {
+    HostPhaseRecordStore store;
+    HostPhaseRecordPool *pool = store.arm(true);
+    ASSERT_NE(pool, nullptr);
+
+    // Mirrors one qwen decode pass: the three task-submitting kinds sum to the
+    // pass's total_tasks, and the sub-operations do not count.
+    record_n(pool, HostPhaseKind::OrchSubmitTask, 5);
+    record_n(pool, HostPhaseKind::OrchAllocTensors, 2);
+    record_n(pool, HostPhaseKind::OrchRecordNode, 277);
+    record_n(pool, HostPhaseKind::OrchGraphSubmit, 40);
+    record_n(pool, HostPhaseKind::OrchBuildDefinition, 1);
+    record_n(pool, HostPhaseKind::BindHostOrch, 1);
+    store.finish(47, /*invocation_id=*/9);
+
+    EXPECT_EQ(store.records().size(), 326u);
+    EXPECT_EQ(store.submit_records().size(), 47u);
+    EXPECT_EQ(store.submitted_tasks(), 47u);
+    for (const auto &record : store.submit_records()) {
+        EXPECT_TRUE(host_phase_kind_submits_task(static_cast<HostPhaseKind>(record.kind)));
+    }
+}
+
+TEST(HostPhaseRecords, EveryKindHasItsOwnName) {
+    for (uint32_t i = 0; i < kHostPhaseKindCount; ++i) {
+        const char *name = host_phase_kind_name(static_cast<HostPhaseKind>(i));
+        EXPECT_STRNE(name, "unknown") << "kind " << i << " has no name";
+        for (uint32_t j = i + 1; j < kHostPhaseKindCount; ++j) {
+            EXPECT_STRNE(name, host_phase_kind_name(static_cast<HostPhaseKind>(j)))
+                << "kinds " << i << " and " << j << " share a name";
+        }
+    }
+    EXPECT_STREQ(host_phase_kind_name(HostPhaseKind::Count), "unknown");
+}
+
+}  // namespace

--- a/tests/ut/py/test_strace_timing.py
+++ b/tests/ut/py/test_strace_timing.py
@@ -20,7 +20,9 @@ from simpler_setup.tools.strace_timing import (
     bucket_by_hid,
     count_record_heads,
     group_invocations,
+    host_record_spans,
     legacy_spans,
+    load_host_phase_records,
     main,
     parse_clock_anchors,
     parse_spans,
@@ -742,3 +744,73 @@ def test_chrome_trace_cli_writes_wall_time(tmp_path):
     event = next(event for event in trace["traceEvents"] if event.get("name") == "simpler_run")
     assert event["ts"] == 0.1
     assert event["args"]["wall_ts_ns"] == "1700000000000000050"
+
+
+def test_host_phase_records_loader_keeps_only_well_formed_passes(tmp_path):
+    """Every line a consumer would choke on is dropped by the loader.
+
+    The artifact is appended to while a run is in flight, so a truncated tail is
+    ordinary. A line that parses but is not an object is malformed in the same
+    sense — the consumer indexes it as a mapping — so it is dropped here rather
+    than left for each consumer to re-check.
+    """
+    artifact = tmp_path / "host_phase_records.jsonl"
+    artifact.write_text(
+        "\n".join(
+            [
+                json.dumps({"pid": 7, "inv": 1, "records": [{"phase": "args", "start_ns": 10, "end_ns": 20}]}),
+                "null",
+                "[1, 2, 3]",
+                "42",
+                '"a string"',
+                json.dumps({"pid": 7, "inv": 2, "records": "not-a-list"}),
+                '{"pid": 7, "inv": 3, "records": [',
+                "",
+                json.dumps({"pid": 7, "inv": 4, "records": []}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    passes = load_host_phase_records([str(artifact)])
+
+    assert [one_pass["inv"] for one_pass in passes] == [1, 4]
+
+
+def test_host_record_spans_nest_bind_segments_and_orchestrator_operations(tmp_path):
+    """A record's kind decides its depth: a bind segment sits under the stage, an
+    orchestrator operation one level further in, under the segment it ran inside."""
+    spans = list(parse_spans([_span_record(pid=9, tid=9, inv=5, name="simpler_run.bind", ts=1_000, dur=500)]))
+    passes = [
+        {
+            "pid": 9,
+            "inv": 5,
+            "records": [
+                {"phase": "args", "start_ns": 1_000, "end_ns": 1_100, "detail": 4096},
+                {"phase": "graph_submit", "start_ns": 1_200, "end_ns": 1_250, "detail": 77},
+            ],
+        }
+    ]
+
+    out, orphaned, covered = host_record_spans(spans, passes)
+
+    assert orphaned == 0
+    assert covered == frozenset({(9, 5)})
+    by_name = {span.name: span for span in out}
+    bind_depth = spans[0].depth
+    assert by_name["simpler_run.bind.args"].depth == bind_depth + 1
+    assert by_name["simpler_run.bind.host_orch.graph_submit"].depth == bind_depth + 2
+    assert by_name["simpler_run.bind.args"].ts == 1_000
+    assert by_name["simpler_run.bind.args"].dur == 100
+
+
+def test_host_record_spans_drop_passes_with_no_matching_bind(tmp_path):
+    spans = list(parse_spans([_span_record(pid=9, tid=9, inv=5, name="simpler_run.bind", ts=1_000, dur=500)]))
+    passes = [{"pid": 9, "inv": 999, "records": [{"phase": "args", "start_ns": 1_000, "end_ns": 1_100}]}]
+
+    out, orphaned, covered = host_record_spans(spans, passes)
+
+    assert out == []
+    assert orphaned == 1
+    assert covered == frozenset()

--- a/tests/ut/py/test_swimlane_converter.py
+++ b/tests/ut/py/test_swimlane_converter.py
@@ -180,7 +180,6 @@ def test_host_orchestrator_phases_without_anchors_are_marked_unaligned(tmp_path)
                     "timeline_relation": "host_orchestration_precedes_device",
                     "host_capture": {
                         "status": "complete",
-                        "finished": True,
                         "expected_records": 1,
                         "recorded_records": 1,
                         "dropped_records": 0,
@@ -220,7 +219,6 @@ def test_host_orchestrator_phases_without_anchors_are_marked_unaligned(tmp_path)
         },
         "host_capture": {
             "status": "complete",
-            "finished": True,
             "expected_records": 1,
             "recorded_records": 1,
             "dropped_records": 0,
@@ -255,6 +253,57 @@ def test_host_orchestrator_phases_without_anchors_are_marked_unaligned(tmp_path)
     )
 
 
+def test_host_capture_is_complete_when_the_pool_holds_more_than_the_submit_projection(tmp_path):
+    """A pool record count above the projected one is normal, not incomplete.
+
+    The producer records every timed host operation — bind segments and the
+    sub-operations of a submit — while this file carries only the ones that
+    submit a task. Completeness therefore compares `expected_records` (the pass's
+    task count) against the projection, and `pool_records` is context.
+    """
+    raw = tmp_path / "chip_swimlane_records.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "chip_swimlane_level": 4,
+                "metadata": {
+                    "clock_freq_hz": 1_000_000,
+                    "num_cores": 1,
+                    "core_types": ["aiv"],
+                    "core_to_thread": [0],
+                    "orchestrator_source": "host",
+                    "orchestrator_clock_domain": "host_monotonic_ns",
+                    "host_orchestration_origin_ns": 1_000,
+                    "timeline_relation": "host_orchestration_precedes_device",
+                    "host_capture": {
+                        "status": "complete",
+                        "expected_records": 2,
+                        "recorded_records": 2,
+                        "pool_records": 339,
+                        "dropped_records": 0,
+                        "error": None,
+                    },
+                },
+                "aicore_tasks": [[0, 7, 1, 100, 110, 0]],
+                "aicpu_tasks": [[0, 1, 90, 120]],
+                "host_orchestrator_phases": [
+                    [
+                        {"submit_idx": 0, "task_id": 7, "start_host_ns": 1_000, "end_host_ns": 3_000},
+                        {"submit_idx": 1, "task_id": 8, "start_host_ns": 3_000, "end_host_ns": 4_000},
+                    ]
+                ],
+            }
+        )
+    )
+
+    data = sc.read_perf_data(raw)
+
+    assert data["timeline_metadata"]["host_records_complete"] is True
+    assert data["timeline_metadata"]["host_capture"]["status"] == "complete"
+    assert data["timeline_metadata"]["host_capture"]["pool_records"] == 339
+    assert "converter_validation_errors" not in data["timeline_metadata"]["host_capture"]
+
+
 def test_host_and_device_timestamps_use_calibrated_clock_alignment(tmp_path):
     raw = tmp_path / "chip_swimlane_records.json"
     raw.write_text(
@@ -272,7 +321,6 @@ def test_host_and_device_timestamps_use_calibrated_clock_alignment(tmp_path):
                     "timeline_relation": "host_orchestration_precedes_device",
                     "host_capture": {
                         "status": "complete",
-                        "finished": True,
                         "expected_records": 1,
                         "recorded_records": 1,
                         "dropped_records": 0,
@@ -335,7 +383,6 @@ def test_host_and_device_timestamps_use_calibrated_clock_alignment(tmp_path):
         },
         "host_capture": {
             "status": "complete",
-            "finished": True,
             "expected_records": 1,
             "recorded_records": 1,
             "dropped_records": 0,
@@ -374,7 +421,6 @@ def test_dropped_host_capture_is_visible_and_disables_cross_domain_flows(tmp_pat
                         "host_timestamp_quantization_ns": 0,
                         "host_capture": {
                             "status": capture_status,
-                            "finished": True,
                             "expected_records": sum(len(records) for records in host_phases) + 1,
                             "recorded_records": sum(len(records) for records in host_phases),
                             "dropped_records": dropped_records,


### PR DESCRIPTION
## Summary

The prepare path of `host_build_graph` is timed in two places — the bind stage's
segments, and the host orchestrator's submit-level operations inside it — and each
buffered its own copy. A level-4 run and a bind-breakdown run therefore recorded
the same submits twice: four clock reads per operation instead of two, on the path
whose millisecond budget is the thing being measured. Both now call one recorder.

### One producer, two sinks, three views

`HostPhaseRecord` (32 B, kind-tagged) carries both populations on the host
monotonic clock the `[STRACE]` host spans use, so records and spans read against
each other with no alignment step. `payload` is kind-discriminated: a task id for
the three kinds that submit a task, a byte count on a transfer segment, else a
detail count.

```
host_phase_record(start, end, kind, payload, index)
  |-- counter[kind] += dur; count++        <- never reads the pool
  `-- host_phase_pool_append(pool, ...)
            |
      +-----+-----+
   reader 1     reader 2
```

- **Per-kind counters**, owned by the runtime, produce the `LOG_TIMING` breakdown.
  Exact whether or not records are kept, so the breakdown survives `--rounds > 1`,
  where every artifact collector is switched off.
- **Reader 1** writes `host_phase_records.jsonl` for the host trace tooling.
- **Reader 2** projects into the chip swimlane's two host lanes at level 4, joined
  to the device timeline through the existing clock anchors.

The pool is the same `head` + `free_queue` plumbing the device sched/orch pools
use, over host DDR: one buffer active, `PLATFORM_PROF_SLOT_COUNT` spares in the
free queue, rotation in buffer-index order so a reader recovers fill order from the
index. Geometry is sized for this producer rather than inherited from the device
one — a scheduler thread emits tens of thousands of records per run where an
orchestration pass emits a few hundred, so 1024 records over 5 buffers holds 5120
where `PLATFORM_PHASE_RECORDS_PER_THREAD` would have allocated 4 MB to hold 11 KB
and left the rotation path unreachable.

Arming is the union of the two enabling conditions, so a level-4 run collects
records with `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` unset and the variable collects
them with the level at 0. Content does not vary with which one armed the pass: a
reader's share is a projection at export, not a branch at record time, so the two
configurations measure the same overhead and their numbers are comparable.

### Lifetime rules the two switches imply

A pass is armed at the first bind segment and must end on **every** exit from
bind, so a scope guard ends it — 15 of the 16 exits are `return -1`, and a bind
that fails part-way is exactly when its breakdown is worth having. An unfinished
pass publishes nothing.

The same reasoning puts the onboard artifact write in
`teardown_shared_collectors_after_run`, which a device error reaches and the reap
tail does not; it now behaves like the sibling diagnostics that already export
there. Sim keeps its write in the drain tail, where a runtime error skips every
collector alike.

Arming allocates, so it can throw, and both `host_phase_pool_arm` overrides are
`noexcept` — they catch and hand back a null pool, so a pass with no storage
collects no records rather than terminating the process. `HostPhaseRecordStore` is
neither copyable nor movable: `pool_` holds raw pointers into `buffers_` and the
producer holds `&pool_`, so a copy would alias the source's buffers and a move
would invalidate a pointer already handed out.

### The transfers get a lane

`graph_upload`, `sm_h2d` and `arena_h2d` project onto their own swimlane lane with
byte counts, beside the device execution that waits on them — the half of
"orchestration plus H2D inside a millisecond" that previously had no view at all,
since a summed total cannot be placed on a timeline. On a 40-layer qwen decode the
lane immediately separates `graph_upload` (5.31 MB in 16.6 ms, 320 MB/s across 40
small uploads) from `sm_h2d` and `arena_h2d` (3.0 and 3.3 GB/s). The remaining bind
segments stay out of that file: they are host-only setup with no device
counterpart, and belong in the host trace tooling's view instead.

### Consequences worth naming

- **Completeness is per kind.** The pool holds every timed operation, of which the
  task-submitting kinds are what the swimlane carries, so `host_capture` compares
  the pass's task count against that projection and reports the whole population as
  `pool_records`. Comparing the total would count each sub-operation of a submit as
  a submit.
- Records are stamped straight from the host monotonic clock rather than routed
  through the profiling counter's tick domain, so `host_timestamp_quantization_ns`
  is 0 rather than 20 on a 50 MHz part.
- **`HostApi` loses its per-event entry** (4 ops to 3): the runtime writes the pool
  directly through the inline path, and the interface carries only the once-per-pass
  arm and finish. The weak cross-boundary emit hook is gone too — the store writes
  its own artifact, holding both the records and the output directory.
- The bind breakdown's log writes move to the end of the pass, off the measured
  path, so each line carries its own `start_ns`; the emission timestamp no longer
  says when the segment ran. `strace_timing.py` gains `--host-phase-records`,
  replacing `--orch-records`.
- `graph_submit_definition`'s per-submit record was redundant with the record both
  of its callers already take, and with it gone the `CYCLE_COUNT` machinery outside
  an `ORCH_PROFILING` build has no consumer left.
- `PTO2OrchestratorState::chip_swimlane_level` was write-only in this runtime even
  before this change — only the AICPU executor assigned it, and the gate that read
  it could not fire on the host. Both are removed; the level now reaches the arming
  decision on the platform side, where it is known.

## Testing

- [x] `tests/ut/cpp/common/test_host_phase_records.cpp` — 7 cases over rotation
      order, exact-fill, tail-loss on overflow, re-arm, and the submit projection
- [x] `tests/ut/py/test_strace_timing.py` — 3 cases over the artifact loader's
      tolerance, the kind-to-depth nesting, and passes with no matching bind span
- [x] cpput 101/101 (`no_hardware`), pyut 1525 passed
- [x] Simulation tests pass — verification matrix on a2a3sim and a5sim
- [x] Hardware tests pass — same matrix on a2a3 onboard via `task-submit`

The matrix covers the four switch combinations plus `--rounds 3`:

| level | env | rounds | expected | observed |
| ----- | --- | ------ | -------- | -------- |
| 0 | off | 1 | nothing, `[STRACE]` intact | pass |
| 0 | on | 1 | breakdown lines, no artifacts | pass |
| 4 | off | 1 | chip swimlane only, `status=complete` | pass |
| 4 | on | 1 | both, pool content identical to the row above | pass |
| 0 | on | 3 | lines x3, counters exact | pass |

Two invariants demonstrated rather than argued:

- **Content does not vary with which switch armed the pass** — `pool_records` is
  identical between the level-4-only and both-on rows.
- **The counters are independent of the pool** — with the pool shrunk to 20
  records it dropped 8 of 28, and every per-kind total stayed identical to the
  non-overflow run while the swimlane reported `status=dropped`,
  `error=pool_overflow`.

On qwen3-14b decode (a2a3 onboard, batch 16 / seq 3500), before and after: every
event count identical (5 / 2 / 277 / 40 / 1, the submit kinds summing to
`total_tasks` 47), with the segments covering 99.93% of the bind stage.

The 16 report lines cost 33 us of measured wall time. The rest of the collection
cost is below the run-to-run variance of this measurement, so no net saving is
claimed from removing the duplicate recording.

The onboard matrix above ran against the pre-review commit; the review fixes were
pushed without re-running it locally, so CI's hardware jobs are the check on them.

Builds on #1846, which introduced the level-4 host capture and the clock
correlation this reuses. Resolves the dead orchestrator-phase gate noted in #1802.