### PR TITLE
Support: cache and parallelize scene-test kernels

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -311,10 +311,12 @@ populates the `build/cache/kernels/` cache; the subsequent pytest invocation
 keeps the existing batch-level device allocation and reconstructs each
 `ChipCallable` from that cache. The warm-up does not acquire one lock per case,
 and runners with exclusive devices continue to execute pytest directly.
-Compilation is serial by default; both onboard jobs pass `--compile-workers 8`,
-which assumes the runner's CPU is theirs alone — it starts eight `ccec`
-processes at once. The sim jobs run on ephemeral GitHub-hosted runners with no
-restored cache, so they compile cold every time and get no warm-up step.
+Both onboard jobs pass `--compile-workers 8`, which caps the entire warm-up at
+eight compiler processes. Class-level concurrency and the parallel artifacts
+inside a large callable share that budget instead of multiplying it. Without an
+override the automatic budget reserves two logical CPUs and caps at eight. The
+sim jobs run on ephemeral GitHub-hosted runners with no restored cache, so they
+compile cold every time and get no warm-up step.
 
 The DFX smokes reuse the runner's device allocation after the main scene-test
 sweep. The `run-onboard-dfx-smokes` CI action distributes `dep_gen`, chip
@@ -336,13 +338,19 @@ unbuildable kernel costing the whole batch its results.
 `actions/checkout` cleans ignored files before each job, so the onboard jobs
 restore and save `build/cache/kernels/` through `actions/cache`. Cache keys are
 partitioned by target architecture, runner OS/architecture, and PTO-ISA pin.
-The artifact's own key covers the contents of its orchestration, incore, and
+The callable key covers the contents of its orchestration, incore, and
 transitively included sources, the compiler identities and effective fixed
 flags, a digest of the modules that decide artifact bytes
 (`kernel_compiler.py`, `toolchain.py`, `elf_parser.py`), the binding's
-serialized-callable ABI, and a manual schema constant. It also carries the
-owning test class's qualified name, so two scene tests built from identical
-sources keep separate entries rather than sharing one.
+serialized-callable ABI, a manual schema constant, and the owning test class's
+qualified name. Each incore key covers the source closure, stable
+compiler-visible paths, and the compilation inputs that affect that kernel
+binary. The compiler runs from the checkout root and receives checkout-local
+paths relative to it, so `__FILE__` and `__BASE_FILE__` stay stable when CI
+runs on a different runner; paths outside the checkout remain absolute. The key
+excludes orchestration, callable ABI, `func_id`,
+signature, and owning test class, so callables that reference the same kernel
+path can share its artifact.
 
 Entries are content-addressed and therefore never overwritten, so a run prunes
 entries whose last use is more than 14 days old before it exits. Without that,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -100,12 +100,27 @@ If a module is pure C++ with no Python binding, test in **ut-cpp** (`tests/ut/cp
 paths and selection arguments as the subsequent scene-test command. It runs
 pytest collection, compiles each selected `SceneTestCase` class once, and
 stores the resulting `ChipCallable` under `build/cache/kernels/`. It does not
-create a `Worker` or access an NPU. Compilation is serial by default so callers
-with large models do not unexpectedly overload the host. Pass
-`--compile-workers N` to opt into compiling up to `N` test classes concurrently
-— each worker starts its own compiler process, so only raise it on a host whose
-CPU is yours. simpler's two onboard CI jobs (a2a3, a5) use eight; the sim jobs
-have no warm-up step.
+create a `Worker` or access an NPU. The default compiler budget is
+`min(8, max(1, available CPUs - 2))`; pass `--compile-workers N` to override it.
+The budget counts actual orchestration and incore compiler subprocesses rather
+than class threads. Compilation may proceed across classes and across the
+artifacts of one large callable, but all levels share the same process-local
+semaphore. Consequently class-level and per-callable parallelism do not
+multiply the number of active compilers within one process.
+simpler's two onboard CI jobs (a2a3, a5) explicitly use eight; the sim jobs have
+no warm-up step and use the same automatic token pool during cold pytest runs.
+
+The persistent cache has two levels. An unchanged callable loads its complete
+`callable.bin` directly. When that entry misses, each incore kernel loads an
+independent artifact from `build/cache/kernels/incore/`; only missing or changed
+kernels are compiled before the new callable is assembled. The incore key is
+independent of orchestration source, callable ABI, `func_id`, signature, and
+the owning test class. It uses the same compiler-visible paths as the compiler:
+paths under the checkout are relative to its root, while paths outside it stay
+absolute. This keeps `__FILE__` and `__BASE_FILE__` correct while allowing a
+cache restored on another CI runner to hit. Callables
+across case directories still share an artifact when they reference the same
+physical kernel path with the same source closure and compilation inputs.
 
 A class that fails to compile is reported and skipped rather than aborting the
 pass, so the run that follows still recompiles it and reports the error against
@@ -116,10 +131,10 @@ Pass the same paths, `-m`, `--platform`, `--runtime`, `--level`, and
 standalone run loads matching
 artifacts from the persistent cache; changed orchestration, incore, or included
 source content, compiler identity, fixed compilation flags, compilation logic,
-or compilation schema produces a new cache entry automatically. Entries unused
-for 14 days are pruned. When `build/` is not writable — a wheel installed into
-a read-only `site-packages` — the cache is skipped with a warning and every
-callable is compiled in-process, exactly as before the cache existed.
+or compilation schema produces the corresponding new cache entry automatically.
+Entries unused for 14 days are pruned. When `build/` is not writable — a wheel
+installed into a read-only `site-packages` — the cache is skipped with a warning
+and every callable is compiled in-process, exactly as before the cache existed.
 
 Scene tests support advanced CLI options for benchmarking, profiling, and runtime control. These work identically in both pytest and standalone mode.
 

--- a/simpler_setup/compile_paths.py
+++ b/simpler_setup/compile_paths.py
@@ -1,0 +1,26 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Stable compiler-visible spellings for files under the simpler checkout."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from .environment import PROJECT_ROOT
+
+
+def compiler_visible_path(path: str | Path) -> Path:
+    """Return a stable path relative to the checkout, or an absolute external path."""
+    absolute_path = Path(os.path.abspath(path))
+    project_root = Path(os.path.abspath(PROJECT_ROOT))
+    try:
+        return absolute_path.relative_to(project_root)
+    except ValueError:
+        return absolute_path

--- a/simpler_setup/compile_pool.py
+++ b/simpler_setup/compile_pool.py
@@ -1,0 +1,76 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Process-wide concurrency budget for scene-test compiler subprocesses."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import threading
+from dataclasses import dataclass
+
+_MAX_AUTO_COMPILE_WORKERS = 8
+
+
+def _available_cpu_count() -> int:
+    try:
+        return max(1, len(os.sched_getaffinity(0)))
+    except (AttributeError, OSError):
+        return max(1, os.cpu_count() or 1)
+
+
+def default_compile_workers() -> int:
+    """Reserve two logical CPUs for pytest/Python and cap compiler fanout at eight."""
+    cpu_count = _available_cpu_count()
+    return min(_MAX_AUTO_COMPILE_WORKERS, max(1, cpu_count - 2))
+
+
+@dataclass(frozen=True)
+class _CompileBudget:
+    workers: int
+    semaphore: threading.BoundedSemaphore
+
+
+@dataclass
+class _CompilePoolState:
+    budget: _CompileBudget
+
+
+_budget_guard = threading.Lock()
+_initial_workers = default_compile_workers()
+_state = _CompilePoolState(_CompileBudget(_initial_workers, threading.BoundedSemaphore(_initial_workers)))
+
+
+def current_compile_workers() -> int:
+    with _budget_guard:
+        return _state.budget.workers
+
+
+@contextlib.contextmanager
+def compile_worker_budget(max_workers: int):
+    """Temporarily set the process-wide compiler budget for a complete compile batch."""
+    if max_workers < 1:
+        raise ValueError("max_workers must be at least 1")
+    with _budget_guard:
+        previous = _state.budget
+        _state.budget = _CompileBudget(max_workers, threading.BoundedSemaphore(max_workers))
+    try:
+        yield
+    finally:
+        with _budget_guard:
+            _state.budget = previous
+
+
+@contextlib.contextmanager
+def compile_slot():
+    """Hold one process-wide compiler token."""
+    with _budget_guard:
+        budget = _state.budget
+    with budget.semaphore:
+        yield

--- a/simpler_setup/kernel_compiler.py
+++ b/simpler_setup/kernel_compiler.py
@@ -19,6 +19,7 @@ from typing import Optional, Union
 
 from simpler import env_manager
 
+from .compile_paths import compiler_visible_path
 from .environment import PROJECT_ROOT
 from .toolchain import (
     Aarch64GxxToolchain,
@@ -41,7 +42,7 @@ _COMPILE_CACHE_SCHEMA = 1
 # Modules whose logic turns kernel sources into artifact bytes: compiler
 # invocation and flags, toolchain selection, and the ELF section extraction
 # applied to every onboard incore.
-_ARTIFACT_LOGIC_MODULES = ("kernel_compiler.py", "toolchain.py", "elf_parser.py")
+_ARTIFACT_LOGIC_MODULES = ("kernel_compiler.py", "toolchain.py", "compile_paths.py", "elf_parser.py")
 
 
 @cache
@@ -324,27 +325,10 @@ class KernelCompiler:
     def compile_cache_token(self, runtime_name: str, core_types: list[str]) -> dict[str, object]:
         """Describe every compiler and fixed flag that affects kernel artifacts."""
         orchestration = self._orchestration_toolchain(runtime_name)
-        if self.platform.endswith("sim"):
-            incore = self.gxx15
-            incore_entries = [
-                {
-                    "core_type": core_type,
-                    "flags": [*incore.get_compile_flags(core_type=core_type), *self._sanitizer_flags(incore)],
-                }
-                for core_type in sorted(set(core_types))
-            ]
-            linker = None
-        else:
-            assert self.ccec is not None, "ccec toolchain is only available for hardware platforms"
-            incore = self.ccec
-            incore_entries = [
-                {"core_type": core_type, "flags": incore.get_compile_flags(core_type=core_type)}
-                for core_type in sorted(set(core_types))
-            ]
-            linker = {
-                "identity": _executable_cache_identity(self.ccec.linker_path),
-                "flags": ["-e", "kernel_entry"],
-            }
+        incore_tokens = [self.incore_compile_cache_token(core_type) for core_type in sorted(set(core_types))]
+        incore_identity = incore_tokens[0]["identity"] if incore_tokens else None
+        incore_linker = incore_tokens[0]["linker"] if incore_tokens else None
+        incore_entries = [{"core_type": token["core_type"], "flags": token["flags"]} for token in incore_tokens]
         return {
             "schema": _COMPILE_CACHE_SCHEMA,
             "logic": _artifact_logic_token(),
@@ -354,10 +338,33 @@ class KernelCompiler:
                 "link_flags": self._orchestration_link_flags(orchestration),
             },
             "incore": {
-                "identity": _executable_cache_identity(incore.cxx_path),
+                "identity": incore_identity,
                 "variants": incore_entries,
-                "linker": linker,
+                "linker": incore_linker,
             },
+        }
+
+    def incore_compile_cache_token(self, core_type: str) -> dict[str, object]:
+        """Describe the compiler inputs shared by identical incore sources."""
+        if self.platform.endswith("sim"):
+            incore = self.gxx15
+            flags = [*incore.get_compile_flags(core_type=core_type), *self._sanitizer_flags(incore)]
+            linker = None
+        else:
+            assert self.ccec is not None, "ccec toolchain is only available for hardware platforms"
+            incore = self.ccec
+            flags = incore.get_compile_flags(core_type=core_type)
+            linker = {
+                "identity": _executable_cache_identity(self.ccec.linker_path),
+                "flags": ["-e", "kernel_entry"],
+            }
+        return {
+            "schema": _COMPILE_CACHE_SCHEMA,
+            "logic": _artifact_logic_token(),
+            "identity": _executable_cache_identity(incore.cxx_path),
+            "core_type": core_type,
+            "flags": flags,
+            "linker": linker,
         }
 
     def _run_subprocess(
@@ -366,7 +373,7 @@ class KernelCompiler:
         """Run a subprocess command with standardized logging and error handling."""
         logger.debug(f"[{label}] Command: {' '.join(cmd)}")
         try:
-            result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+            result = subprocess.run(cmd, check=False, capture_output=True, text=True, cwd=self.project_root)
 
             if result.stdout and logger.isEnabledFor(10):  # DEBUG = 10
                 logger.debug(f"[{label}] stdout:\n{result.stdout}")
@@ -435,12 +442,13 @@ class KernelCompiler:
 
     @staticmethod
     def _make_temp_path(prefix: str, suffix: str, build_dir: Optional[str] = None) -> str:
-        """Create a unique temporary file path in /tmp via mkstemp.
+        """Create a unique absolute temporary file path via mkstemp.
 
         The file is created atomically to avoid races, then immediately
         closed so the caller can overwrite it with compiler output.
         """
-        fd, path = tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=build_dir or "/tmp")
+        directory = os.path.abspath(build_dir) if build_dir else "/tmp"
+        fd, path = tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=directory)
         os.close(fd)
         return path
 
@@ -510,17 +518,17 @@ class KernelCompiler:
         )
 
         # Build command from toolchain
-        cmd = [self.ccec.cxx_path] + self.ccec.get_compile_flags(core_type=core_type)
-        cmd.extend([f"-I{pto_include}", f"-I{pto_pto_include}"])
+        cmd = [self.ccec.cxx_path, *self.ccec.get_compile_flags(core_type=core_type)]
+        cmd.extend([f"-I{compiler_visible_path(pto_include)}", f"-I{compiler_visible_path(pto_pto_include)}"])
 
         for inc_dir in self.get_incore_include_dirs():
-            cmd.append(f"-I{os.path.abspath(inc_dir)}")
+            cmd.append(f"-I{compiler_visible_path(inc_dir)}")
 
         if extra_include_dirs:
             for inc_dir in extra_include_dirs:
-                cmd.append(f"-I{os.path.abspath(inc_dir)}")
+                cmd.append(f"-I{compiler_visible_path(inc_dir)}")
 
-        cmd.extend(["-o", output_path, source_path])
+        cmd.extend(["-o", output_path, str(compiler_visible_path(source_path))])
 
         # Execute compilation
         core_type_name = "AIV" if core_type == "aiv" else "AIC"
@@ -658,16 +666,16 @@ class KernelCompiler:
             for src in extra_sources:
                 src = os.path.abspath(src)
                 if os.path.isfile(src):
-                    cmd.append(src)
+                    cmd.append(str(compiler_visible_path(src)))
                     logger.debug(f"  Including extra source: {os.path.basename(src)}")
 
         # Add include dirs
         if extra_include_dirs:
             for inc_dir in extra_include_dirs:
-                cmd.append(f"-I{os.path.abspath(inc_dir)}")
+                cmd.append(f"-I{compiler_visible_path(inc_dir)}")
 
         # Output and input
-        cmd.extend(["-o", output_path, source_path])
+        cmd.extend(["-o", output_path, str(compiler_visible_path(source_path))])
 
         # Log compilation command
         logger.info(f"[Orchestration] Compiling: {source_path}")
@@ -717,7 +725,7 @@ class KernelCompiler:
         )
 
         # Build command from toolchain
-        cmd = [self.gxx15.cxx_path] + self.gxx15.get_compile_flags(core_type=core_type)
+        cmd = [self.gxx15.cxx_path, *self.gxx15.get_compile_flags(core_type=core_type)]
         cmd += self._sanitizer_flags(self.gxx15)
 
         # Add PTO ISA header paths if provided. The path always comes from
@@ -726,17 +734,17 @@ class KernelCompiler:
         if pto_isa_root:
             pto_include = os.path.join(pto_isa_root, "include")
             pto_pto_include = os.path.join(pto_isa_root, "include", "pto")
-            cmd.extend([f"-I{pto_include}", f"-I{pto_pto_include}"])
+            cmd.extend([f"-I{compiler_visible_path(pto_include)}", f"-I{compiler_visible_path(pto_pto_include)}"])
 
         for inc_dir in self.get_incore_include_dirs():
-            cmd.append(f"-I{os.path.abspath(inc_dir)}")
+            cmd.append(f"-I{compiler_visible_path(inc_dir)}")
 
         # Add extra include directories if provided
         if extra_include_dirs:
             for inc_dir in extra_include_dirs:
-                cmd.append(f"-I{os.path.abspath(inc_dir)}")
+                cmd.append(f"-I{compiler_visible_path(inc_dir)}")
 
-        cmd.extend(["-o", output_path, source_path])
+        cmd.extend(["-o", output_path, str(compiler_visible_path(source_path))])
 
         # Log compilation command
         logger.info(f"[SimKernel] Compiling: {source_path}")

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -28,14 +28,21 @@ import logging
 import os
 import platform as host_platform
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from enum import IntEnum
 from pathlib import Path
 from typing import Any, NamedTuple
 
+from .compile_pool import compile_slot, current_compile_workers
 from .log_config import DEFAULT_LOG_LEVEL, LOG_LEVEL_CHOICES, configure_logging
 from .pto_isa import ensure_pto_isa_root
-from .scene_test_cache import compile_artifact_key, get_or_compile
+from .scene_test_cache import (
+    compile_artifact_key,
+    compile_incore_artifact_key,
+    get_or_compile,
+    get_or_compile_incore,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1173,25 +1180,36 @@ def _compile_chip_callable_from_spec(spec, platform, runtime, cache_key):
     inc_dirs = kc.get_orchestration_include_dirs(runtime)
     orch_include_dirs, orch_sources = kc.get_orchestration_cache_inputs(runtime)
     orch_units = [orch["source"], *orch_sources]
-    compilation_units: list[tuple[str | Path, list[str | Path]]] = [
+    orchestration_units: list[tuple[str | Path, list[str | Path]]] = [
         (source, orch_include_dirs) for source in orch_units
     ]
     resolved_extra_dirs = []
+    incore_artifact_keys = []
     for k in incores:
         extra = _resolve_incore_include_dirs(k["extra_include_dirs"], k) if k.get("extra_include_dirs") else []
         resolved_extra_dirs.append(extra)
-        compilation_units.append(
-            (
+        include_dirs = [
+            Path(pto_isa_root) / "include",
+            Path(pto_isa_root) / "include" / "pto",
+            *kc.get_incore_include_dirs(),
+            *inc_dirs,
+            *extra,
+        ]
+        incore_artifact_keys.append(
+            compile_incore_artifact_key(
+                {
+                    "platform": platform,
+                    "host_platform": sys.platform,
+                    "host_machine": host_platform.machine(),
+                    "compiler": kc.incore_compile_cache_token(k["core_type"]),
+                },
                 k["source"],
-                [
-                    Path(pto_isa_root) / "include",
-                    Path(pto_isa_root) / "include" / "pto",
-                    *kc.get_incore_include_dirs(),
-                    *inc_dirs,
-                    *extra,
-                ],
+                include_dirs,
             )
         )
+    if len(resolved_extra_dirs) != len(incores) or len(incore_artifact_keys) != len(incores):
+        raise AssertionError("per-incore cache inputs must match the incore specification")
+    compiler_token = kc.compile_cache_token(runtime, [k["core_type"] for k in incores])
     artifact_key = compile_artifact_key(
         {
             "cache_key": cache_key,
@@ -1200,7 +1218,7 @@ def _compile_chip_callable_from_spec(spec, platform, runtime, cache_key):
             "host_platform": sys.platform,
             "host_machine": host_platform.machine(),
             "sanitizers": KernelCompiler._sanitizers,
-            "compiler": kc.compile_cache_token(runtime, [k["core_type"] for k in incores]),
+            "compiler": compiler_token,
             "orchestration": {
                 "function_name": orch["function_name"],
                 "config_name": orch.get("config_name", ""),
@@ -1211,30 +1229,55 @@ def _compile_chip_callable_from_spec(spec, platform, runtime, cache_key):
                     "func_id": k["func_id"],
                     "core_type": k["core_type"],
                     "signature": k.get("signature", []),
+                    "artifact_key": incore_artifact_key,
                 }
-                for k in incores
+                for k, incore_artifact_key in zip(incores, incore_artifact_keys)
             ],
         },
-        compilation_units,
+        orchestration_units,
     )
 
     def compile_callable():
-        orch_binary = kc.compile_orchestration(runtime, orch["source"])
+        def compile_orchestration():
+            with compile_slot():
+                return kc.compile_orchestration(runtime, orch["source"])
+
+        def compile_one_incore(k, extra, incore_artifact_key):
+            def compile_missing_incore():
+                with compile_slot():
+                    binary = kc.compile_incore(
+                        k["source"],
+                        core_type=k["core_type"],
+                        pto_isa_root=pto_isa_root,
+                        extra_include_dirs=inc_dirs + extra,
+                    )
+                return binary if is_sim else extract_text_section(binary)
+
+            return get_or_compile_incore(incore_artifact_key, compile_missing_incore)
+
+        max_workers = min(current_compile_workers(), len(incores) + 1)
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            orch_future = executor.submit(compile_orchestration)
+            incore_futures = [
+                executor.submit(
+                    compile_one_incore,
+                    k,
+                    extra,
+                    incore_artifact_key,
+                )
+                for k, extra, incore_artifact_key in zip(incores, resolved_extra_dirs, incore_artifact_keys)
+            ]
+            orch_binary = orch_future.result()
+            incores_binary = [future.result() for future in incore_futures]
+
+        if len(incores_binary) != len(incores):
+            raise AssertionError("compiled incore binaries must match the incore specification")
         kernel_binaries = []
-        for k, extra in zip(incores, resolved_extra_dirs, strict=True):
-            signature = k.get("signature", [])
-            incore = kc.compile_incore(
-                k["source"],
-                core_type=k["core_type"],
-                pto_isa_root=pto_isa_root,
-                extra_include_dirs=inc_dirs + extra,
-            )
-            if not is_sim:
-                incore = extract_text_section(incore)
+        for k, incore in zip(incores, incores_binary):
             kernel_binaries.append(
                 (
                     k["func_id"],
-                    CoreCallable.build(signature=signature, binary=incore),
+                    CoreCallable.build(signature=k.get("signature", []), binary=incore),
                 )
             )
 

--- a/simpler_setup/scene_test_cache.py
+++ b/simpler_setup/scene_test_cache.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Persistent cache for compiled scene-test ``ChipCallable`` blobs."""
+"""Persistent cache for compiled scene-test callable and incore artifacts."""
 
 from __future__ import annotations
 
@@ -26,6 +26,7 @@ from functools import cache
 from pathlib import Path
 from typing import Any
 
+from .compile_paths import compiler_visible_path
 from .environment import PROJECT_ROOT
 
 logger = logging.getLogger(__name__)
@@ -33,7 +34,10 @@ logger = logging.getLogger(__name__)
 KERNEL_CACHE_DIR = PROJECT_ROOT / "build" / "cache" / "kernels"
 
 _CACHE_VERSION = 1
+_INCORE_CACHE_VERSION = 1
 _BINARY_FILE = "callable.bin"
+_INCORE_DIR = "incore"
+_INCORE_BINARY_FILE = "artifact.bin"
 _MANIFEST_FILE = "manifest.json"
 _LOCK_DIR = ".locks"
 _INCLUDE_RE = re.compile(rb"^\s*#\s*include\s*([<\"])([^>\"]+)[>\"]", re.MULTILINE)
@@ -84,7 +88,7 @@ def _resolve_include(name: str, quoted: bool, including_file: Path, include_dirs
     for directory in candidates:
         candidate = directory / name
         if candidate.is_file():
-            return candidate.resolve()
+            return Path(os.path.abspath(candidate))
     return None
 
 
@@ -129,17 +133,19 @@ def _source_closure(
 ) -> tuple[Path, dict[Path, bytes], list[tuple[Path, str, Path]]]:
     """Return the root path, the digest of every file in its include closure, and the closure's edges.
 
-    The closure holds only includes that resolve within ``include_dirs`` — or,
-    for a quoted include, beside the including file — mirroring the search order
-    the compiler applies to the same ``-I`` list. Headers the toolchain supplies
-    from its own search path (ccec builtins, CANN headers under
-    ``ASCEND_HOME_PATH``) resolve outside that list and are absent from the key;
-    the compiler ``--version`` identity carried in the key metadata is what
-    covers those. ``#if`` conditions are not evaluated, so the closure is an
-    over-approximation of what any single build compiles.
+    Paths use the same absolute, non-realpath normalization as the compiler
+    invocation, so path-sensitive macros such as ``__FILE__`` and symlink
+    spellings are part of the key. The closure holds only includes that resolve
+    within ``include_dirs`` — or, for a quoted include, beside the including
+    file — mirroring the search order the compiler applies to the same ``-I``
+    list. Headers the toolchain supplies from its own search path (ccec builtins,
+    CANN headers under ``ASCEND_HOME_PATH``) resolve outside that list and are
+    absent from the key; the compiler ``--version`` identity carried in the key
+    metadata is what covers those. ``#if`` conditions are not evaluated, so the
+    closure is an over-approximation of what any single build compiles.
     """
-    roots = tuple(Path(directory).resolve() for directory in include_dirs if Path(directory).is_dir())
-    source_path = Path(source).resolve()
+    roots = tuple(Path(os.path.abspath(directory)) for directory in include_dirs if Path(directory).is_dir())
+    source_path = Path(os.path.abspath(source))
     pending = [source_path]
     files: dict[Path, bytes] = {}
     edges = []
@@ -158,35 +164,80 @@ def _source_closure(
     return source_path, files, edges
 
 
-def compile_artifact_key(
-    metadata: Mapping[str, Any], compilation_units: Iterable[tuple[str | Path, Iterable[str | Path]]]
+def _compile_source_key(
+    metadata: Mapping[str, Any],
+    compilation_units: Iterable[tuple[str | Path, Iterable[str | Path]]],
+    *,
+    abi_token: str | None,
 ) -> str:
-    """Return a content key for callable metadata and source include closures."""
     digest = hashlib.sha256()
-    abi_token = _chip_callable_abi_token().encode()
-    digest.update(len(abi_token).to_bytes(8, "little"))
-    digest.update(abi_token)
+    if abi_token is not None:
+        encoded_abi_token = abi_token.encode()
+        digest.update(len(encoded_abi_token).to_bytes(8, "little"))
+        digest.update(encoded_abi_token)
     encoded_metadata = json.dumps(_stable_value(metadata), sort_keys=True, separators=(",", ":")).encode()
     digest.update(len(encoded_metadata).to_bytes(8, "little"))
     digest.update(encoded_metadata)
 
     for source, include_dirs in compilation_units:
-        source_path, file_digests, edges = _source_closure(source, include_dirs)
+        normalized_include_dirs = tuple(Path(os.path.abspath(directory)) for directory in include_dirs)
+        source_path, file_digests, edges = _source_closure(source, normalized_include_dirs)
         digest.update(b"unit")
+        # The complete, ordered -I list affects preprocessing even when no
+        # matching #include appears in the source closure (for example,
+        # __has_include can select different source branches).
+        for include_dir in normalized_include_dirs:
+            encoded_include_dir = os.fsencode(compiler_visible_path(include_dir))
+            digest.update(b"include-dir")
+            digest.update(len(encoded_include_dir).to_bytes(8, "little"))
+            digest.update(encoded_include_dir)
+        encoded_source_path = os.fsencode(compiler_visible_path(source_path))
+        digest.update(len(encoded_source_path).to_bytes(8, "little"))
+        digest.update(encoded_source_path)
         digest.update(file_digests[source_path])
-        for file_digest in sorted(file_digests.values()):
+        file_records = sorted(
+            (os.fsencode(compiler_visible_path(path)), file_digest) for path, file_digest in file_digests.items()
+        )
+        for encoded_path, file_digest in file_records:
             digest.update(b"file")
+            digest.update(len(encoded_path).to_bytes(8, "little"))
+            digest.update(encoded_path)
             digest.update(file_digest)
         edge_records = sorted(
-            (file_digests[parent], name.encode(), file_digests[dependency]) for parent, name, dependency in edges
+            (
+                os.fsencode(compiler_visible_path(parent)),
+                file_digests[parent],
+                name.encode(),
+                os.fsencode(compiler_visible_path(dependency)),
+                file_digests[dependency],
+            )
+            for parent, name, dependency in edges
         )
-        for parent_digest, name, dependency_digest in edge_records:
+        for parent_path, parent_digest, name, dependency_path, dependency_digest in edge_records:
             digest.update(b"edge")
+            digest.update(len(parent_path).to_bytes(8, "little"))
+            digest.update(parent_path)
             digest.update(parent_digest)
             digest.update(len(name).to_bytes(8, "little"))
             digest.update(name)
+            digest.update(len(dependency_path).to_bytes(8, "little"))
+            digest.update(dependency_path)
             digest.update(dependency_digest)
     return digest.hexdigest()
+
+
+def compile_artifact_key(
+    metadata: Mapping[str, Any], compilation_units: Iterable[tuple[str | Path, Iterable[str | Path]]]
+) -> str:
+    """Return a content key for callable metadata and source include closures."""
+    return _compile_source_key(metadata, compilation_units, abi_token=_chip_callable_abi_token())
+
+
+def compile_incore_artifact_key(
+    metadata: Mapping[str, Any], source: str | Path, include_dirs: Iterable[str | Path]
+) -> str:
+    """Return a content key for one independently compiled incore artifact."""
+    return _compile_source_key(metadata, [(source, include_dirs)], abi_token=None)
 
 
 def _entry_paths(key: str) -> tuple[Path, Path, Path]:
@@ -194,25 +245,41 @@ def _entry_paths(key: str) -> tuple[Path, Path, Path]:
     return entry, entry / _BINARY_FILE, entry / _MANIFEST_FILE
 
 
-def _touch(key: str) -> None:
-    entry, _binary_path, _manifest_path = _entry_paths(key)
+def _incore_entry_paths(key: str) -> tuple[Path, Path, Path]:
+    entry = KERNEL_CACHE_DIR / _INCORE_DIR / key
+    return entry, entry / _INCORE_BINARY_FILE, entry / _MANIFEST_FILE
+
+
+def _touch_entry(entry: Path) -> None:
     with contextlib.suppress(OSError):
         os.utime(entry)
 
 
-def _load(key: str):
-    _entry, binary_path, manifest_path = _entry_paths(key)
+def _touch(key: str) -> None:
+    entry, _binary_path, _manifest_path = _entry_paths(key)
+    _touch_entry(entry)
+
+
+def _load_bytes(key: str, binary_path: Path, manifest_path: Path, version: int) -> bytes | None:
     try:
         manifest = json.loads(manifest_path.read_text())
         raw = binary_path.read_bytes()
     except (OSError, json.JSONDecodeError):
         return None
     if manifest != {
-        "version": _CACHE_VERSION,
+        "version": version,
         "key": key,
         "size": len(raw),
         "sha256": hashlib.sha256(raw).hexdigest(),
     }:
+        return None
+    return raw
+
+
+def _load(key: str):
+    _entry, binary_path, manifest_path = _entry_paths(key)
+    raw = _load_bytes(key, binary_path, manifest_path, _CACHE_VERSION)
+    if raw is None:
         return None
 
     from simpler.task_interface import ChipCallable  # noqa: PLC0415
@@ -225,18 +292,16 @@ def _load(key: str):
     return callable_obj
 
 
-def _publish(key: str, callable_obj) -> None:
-    entry, binary_path, manifest_path = _entry_paths(key)
+def _publish_bytes(key: str, raw: bytes, entry: Path, binary_path: Path, manifest_path: Path, version: int) -> None:
     entry.mkdir(parents=True, exist_ok=True)
-    raw = ctypes.string_at(int(callable_obj.buffer_ptr()), int(callable_obj.buffer_size()))
     manifest = {
-        "version": _CACHE_VERSION,
+        "version": version,
         "key": key,
         "size": len(raw),
         "sha256": hashlib.sha256(raw).hexdigest(),
     }
     suffix = f".{os.getpid()}.{uuid.uuid4().hex}.tmp"
-    binary_tmp = entry / f"{_BINARY_FILE}{suffix}"
+    binary_tmp = entry / f"{binary_path.name}{suffix}"
     manifest_tmp = entry / f"{_MANIFEST_FILE}{suffix}"
     try:
         binary_tmp.write_bytes(raw)
@@ -248,7 +313,14 @@ def _publish(key: str, callable_obj) -> None:
         manifest_tmp.unlink(missing_ok=True)
 
 
+def _publish(key: str, callable_obj) -> None:
+    entry, binary_path, manifest_path = _entry_paths(key)
+    raw = ctypes.string_at(int(callable_obj.buffer_ptr()), int(callable_obj.buffer_size()))
+    _publish_bytes(key, raw, entry, binary_path, manifest_path, _CACHE_VERSION)
+
+
 _pruned_dirs: set[Path] = set()
+_disabled_dirs: set[Path] = set()
 
 
 def prune_stale_entries() -> int:
@@ -264,12 +336,13 @@ def prune_stale_entries() -> int:
     cutoff = time.time() - _ENTRY_RETENTION_S
     removed = 0
     try:
-        entries = list(KERNEL_CACHE_DIR.iterdir())
+        root_entries = list(KERNEL_CACHE_DIR.iterdir())
     except OSError:
         return 0
+    entries = [entry for entry in root_entries if entry.name not in {_LOCK_DIR, _INCORE_DIR}]
+    with contextlib.suppress(OSError):
+        entries.extend((KERNEL_CACHE_DIR / _INCORE_DIR).iterdir())
     for entry in entries:
-        if entry.name == _LOCK_DIR:
-            continue
         try:
             if entry.stat().st_mtime >= cutoff:
                 continue
@@ -300,6 +373,10 @@ def _entry_lock(key: str):
     degrades the caller to plain compilation instead of failing a scene test
     that used to pass.
     """
+    if KERNEL_CACHE_DIR in _disabled_dirs:
+        yield None
+        return
+
     lock_file = None
     try:
         lock_dir = KERNEL_CACHE_DIR / _LOCK_DIR
@@ -310,6 +387,7 @@ def _entry_lock(key: str):
         if lock_file is not None:
             lock_file.close()
             lock_file = None
+        _disabled_dirs.add(KERNEL_CACHE_DIR)
         logger.warning(
             "[SceneTestCache] disabled: %s is not usable (%s: %s); compiling without a cache",
             KERNEL_CACHE_DIR,
@@ -353,3 +431,36 @@ def get_or_compile(key: str, compile_fn: Callable[[], Any]):
         else:
             prune_stale_entries()
         return callable_obj
+
+
+def get_or_compile_incore(key: str, compile_fn: Callable[[], bytes]) -> bytes:
+    """Load one incore binary or compile and atomically publish it."""
+    entry, binary_path, manifest_path = _incore_entry_paths(key)
+    cached = _load_bytes(key, binary_path, manifest_path, _INCORE_CACHE_VERSION)
+    if cached is not None:
+        _touch_entry(entry)
+        logger.info("[SceneTestCache] incore hit: %s", key[:12])
+        return cached
+
+    with _entry_lock(f"incore-{key}") as lock_file:
+        if lock_file is None:
+            return compile_fn()
+        cached = _load_bytes(key, binary_path, manifest_path, _INCORE_CACHE_VERSION)
+        if cached is not None:
+            _touch_entry(entry)
+            logger.info("[SceneTestCache] incore hit after wait: %s", key[:12])
+            return cached
+        logger.info("[SceneTestCache] incore miss: %s", key[:12])
+        binary = compile_fn()
+        try:
+            _publish_bytes(key, binary, entry, binary_path, manifest_path, _INCORE_CACHE_VERSION)
+        except OSError as error:
+            logger.warning(
+                "[SceneTestCache] incore publish failed for %s (%s: %s); artifact not cached",
+                key[:12],
+                type(error).__name__,
+                error,
+            )
+        else:
+            prune_stale_entries()
+        return binary

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -37,14 +37,23 @@ python -m simpler_setup.tools.scene_test_compile examples tests/st \
     -m "not sdma" --platform a2a3 --require-pto-isa --compile-workers 8
 ```
 
-Compiled `ChipCallable` blobs are stored under `build/cache/kernels/`. A normal
-pytest or standalone scene-test run loads a matching blob from that directory;
-source, transitive-include, compiler, or compilation-logic changes produce a
-different content key, and entries unused for 14 days are pruned. Cache misses
-compile serially by default; pass `--compile-workers N` to opt into compiling
-up to `N` test classes concurrently, one compiler process per worker. A class
-that fails to compile is reported without aborting the rest of the pass. The
-warm-up does not inspect or access NPU devices.
+Compiled `ChipCallable` blobs are stored under `build/cache/kernels/`, with
+independent incore artifacts under `build/cache/kernels/incore/`. A normal
+pytest or standalone scene-test run first loads a matching callable blob. On a
+callable miss, unchanged incore artifacts are reused and only missing kernels
+are compiled before assembly. Source, transitive-include, compiler,
+compilation-logic, or compiler-visible path changes produce the corresponding
+new content key. The compiler runs from the checkout root, so checkout-local
+paths are stable relative paths: path-sensitive macros remain correct and cache
+entries can move between CI runners. Paths outside the checkout remain absolute.
+Entries unused for 14 days are pruned. Cache misses compile with an automatic
+process-wide budget: two logical CPUs remain available to pytest/Python and at
+most eight compiler processes run across all test classes and callable artifacts.
+`--compile-workers N` overrides that budget. Class-level and per-callable
+parallelism share it, so their worker counts never multiply into additional
+compiler processes in one process. A class that fails to compile is reported
+without aborting the rest of the pass. The warm-up does not inspect or access
+NPU devices.
 
 ---
 

--- a/simpler_setup/tools/scene_test_compile.py
+++ b/simpler_setup/tools/scene_test_compile.py
@@ -15,6 +15,8 @@ import sys
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 
+from ..compile_pool import compile_worker_budget, default_compile_workers
+
 try:
     from _pytest.skipping import evaluate_skip_marks
 except ImportError:
@@ -22,7 +24,7 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_COMPILE_WORKERS = 1
+_DEFAULT_COMPILE_WORKERS = None
 
 
 def _is_skipped(item) -> bool:
@@ -45,7 +47,7 @@ def _compile_scene_test_class(cls, platform: str) -> None:
 
 
 def compile_collected_scene_tests(
-    items, platform: str, *, max_workers: int = _DEFAULT_COMPILE_WORKERS
+    items, platform: str, *, max_workers: int | None = _DEFAULT_COMPILE_WORKERS
 ) -> tuple[int, list[tuple[str, Exception]]]:
     """Compile each non-skipped scene-test class represented by ``items``.
 
@@ -76,8 +78,10 @@ def compile_collected_scene_tests(
             return (cls.__name__, error)
         return None
 
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        results = list(executor.map(compile_one, selected_classes))
+    resolved_workers = default_compile_workers() if max_workers is None else max_workers
+    with compile_worker_budget(resolved_workers):
+        with ThreadPoolExecutor(max_workers=resolved_workers) as executor:
+            results = list(executor.map(compile_one, selected_classes))
     failures = [result for result in results if result is not None]
     return len(selected_classes) - len(failures), failures
 
@@ -90,7 +94,7 @@ class _CompilePlugin:
             action="store",
             type=int,
             default=_DEFAULT_COMPILE_WORKERS,
-            help="Maximum concurrent SceneTestCase compilations (default: 1)",
+            help="Maximum compiler processes across all SceneTestCase compilations (default: auto)",
         )
 
     def pytest_collection_finish(self, session):
@@ -100,7 +104,7 @@ class _CompilePlugin:
 
             raise pytest.UsageError("--platform is required for scene-test compilation")
         max_workers = session.config.getoption("--compile-workers")
-        if max_workers < 1:
+        if max_workers is not None and max_workers < 1:
             import pytest  # noqa: PLC0415
 
             raise pytest.UsageError("--compile-workers must be at least 1")

--- a/tests/ut/py/test_compile_pool.py
+++ b/tests/ut/py/test_compile_pool.py
@@ -1,0 +1,76 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier, Event, Lock
+
+from simpler_setup import compile_pool
+
+
+def test_default_compile_workers_reserves_two_cpus_and_caps_at_eight(monkeypatch):
+    monkeypatch.setattr(compile_pool, "_available_cpu_count", lambda: 4)
+    assert compile_pool.default_compile_workers() == 2
+
+    monkeypatch.setattr(compile_pool, "_available_cpu_count", lambda: 1)
+    assert compile_pool.default_compile_workers() == 1
+
+    monkeypatch.setattr(compile_pool, "_available_cpu_count", lambda: 3)
+    assert compile_pool.default_compile_workers() == 1
+
+    monkeypatch.setattr(compile_pool, "_available_cpu_count", lambda: 320)
+    assert compile_pool.default_compile_workers() == 8
+
+
+def test_available_cpu_count_uses_process_affinity(monkeypatch):
+    monkeypatch.setattr(compile_pool.os, "sched_getaffinity", lambda _pid: set(range(4)), raising=False)
+    monkeypatch.setattr(compile_pool.os, "cpu_count", lambda: 320)
+
+    assert compile_pool._available_cpu_count() == 4
+
+
+def test_available_cpu_count_falls_back_when_affinity_is_unavailable(monkeypatch):
+    monkeypatch.delattr(compile_pool.os, "sched_getaffinity", raising=False)
+    monkeypatch.setattr(compile_pool.os, "cpu_count", lambda: 4)
+    assert compile_pool._available_cpu_count() == 4
+
+    monkeypatch.setattr(compile_pool.os, "cpu_count", lambda: None)
+    assert compile_pool._available_cpu_count() == 1
+
+
+def test_compile_slots_bound_nested_thread_pools():
+    first_two_started = Barrier(3, timeout=2)
+    release = Event()
+    state_lock = Lock()
+    active = 0
+    peak = 0
+
+    def compile_one(index):
+        nonlocal active, peak
+        with compile_pool.compile_slot():
+            with state_lock:
+                active += 1
+                peak = max(peak, active)
+            if index < 2:
+                first_two_started.wait()
+            release.wait(timeout=2)
+            with state_lock:
+                active -= 1
+
+    with compile_pool.compile_worker_budget(2):
+        with ThreadPoolExecutor(max_workers=3) as outer:
+            futures = [outer.submit(compile_one, index) for index in range(3)]
+            first_two_started.wait()
+            assert peak == 2
+            release.set()
+            for future in futures:
+                future.result()
+
+    assert peak == 2

--- a/tests/ut/py/test_kernel_compiler.py
+++ b/tests/ut/py/test_kernel_compiler.py
@@ -8,6 +8,9 @@
 # -----------------------------------------------------------------------------------------------------------
 """Tests for KernelCompiler host toolchain selection."""
 
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 
 
@@ -72,3 +75,40 @@ def test_host_orchestration_is_a_self_contained_log_consumer(
         assert "host_log.cpp" not in source_names
         assert "unified_log_host.cpp" not in source_names
         assert "-pthread" not in compiler._orchestration_link_flags(compiler._orchestration_toolchain(target_runtime))
+
+
+def test_direct_compiler_command_uses_checkout_relative_paths(monkeypatch, tmp_path):
+    from simpler_setup import kernel_compiler  # noqa: PLC0415
+    from simpler_setup.environment import PROJECT_ROOT  # noqa: PLC0415
+
+    compiler = kernel_compiler.KernelCompiler("a2a3sim")
+    source = PROJECT_ROOT / "simpler_setup" / "incore" / "pipe_sync.h"
+    captured = {}
+    monkeypatch.setattr(compiler, "_make_temp_path", lambda **_kwargs: str(tmp_path / "kernel.so"))
+
+    def capture_compile(cmd, *_args, **_kwargs):
+        captured["cmd"] = cmd
+        return b"compiled"
+
+    monkeypatch.setattr(compiler, "_compile_to_bytes", capture_compile)
+
+    assert compiler._compile_incore_sim(str(source), core_type="aiv") == b"compiled"
+    assert captured["cmd"][-1] == str(Path("simpler_setup") / "incore" / "pipe_sync.h")
+    assert f"-I{Path('simpler_setup') / 'incore'}" in captured["cmd"]
+
+
+def test_compiler_subprocess_runs_from_checkout_root(monkeypatch):
+    from simpler_setup import kernel_compiler  # noqa: PLC0415
+    from simpler_setup.environment import PROJECT_ROOT  # noqa: PLC0415
+
+    compiler = kernel_compiler.KernelCompiler("a2a3sim")
+    captured = {}
+
+    def fake_run(*_args, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(kernel_compiler.subprocess, "run", fake_run)
+    compiler._run_subprocess(["compiler"], "test")
+
+    assert captured["cwd"] == PROJECT_ROOT

--- a/tests/ut/py/test_scene_test_cache.py
+++ b/tests/ut/py/test_scene_test_cache.py
@@ -25,7 +25,7 @@ import os
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from threading import Barrier, Lock
+from threading import Barrier, Event, Lock
 
 import pytest
 from _task_interface import ArgDirection, ChipCallable  # pyright: ignore[reportMissingImports]
@@ -33,7 +33,8 @@ from _task_interface import ArgDirection, ChipCallable  # pyright: ignore[report
 # ``simpler_setup/__init__.py`` re-exports the ``scene_test`` *decorator*,
 # which shadows the submodule attribute when accessed via ``simpler_setup``.
 # Importing the names directly from the submodule avoids that ambiguity.
-from simpler_setup import scene_test_cache
+from simpler_setup import compile_paths, scene_test_cache
+from simpler_setup.compile_pool import compile_worker_budget
 from simpler_setup.scene_test import (
     SceneTestCase,
     _compile_cache,
@@ -110,6 +111,7 @@ class _FakeKernelCompiler:
     cache_schema = 1
     orchestration_compiles = 0
     incore_compiles = 0
+    compile_barrier = None
 
     def __init__(self, platform):
         self.platform = platform
@@ -126,12 +128,19 @@ class _FakeKernelCompiler:
     def compile_cache_token(self, runtime, core_types):
         return {"schema": self.cache_schema}
 
+    def incore_compile_cache_token(self, core_type):
+        return {"schema": self.cache_schema, "core_type": core_type}
+
     def compile_orchestration(self, runtime, source):
         type(self).orchestration_compiles += 1
+        if type(self).compile_barrier is not None:
+            type(self).compile_barrier.wait()
         return Path(source).read_bytes()
 
     def compile_incore(self, source, **kwargs):
         type(self).incore_compiles += 1
+        if type(self).compile_barrier is not None:
+            type(self).compile_barrier.wait()
         return Path(source).read_bytes()
 
 
@@ -170,7 +179,74 @@ def _configure_fake_compilation(monkeypatch, tmp_path):
     _FakeKernelCompiler.cache_schema = 1
     _FakeKernelCompiler.orchestration_compiles = 0
     _FakeKernelCompiler.incore_compiles = 0
+    _FakeKernelCompiler.compile_barrier = None
     clear_compile_cache()
+
+
+def test_callable_compiles_orchestration_and_incore_concurrently(monkeypatch, tmp_path):
+    _configure_fake_compilation(monkeypatch, tmp_path)
+    spec, _header = _cacheable_spec(tmp_path)
+    cache_key = ("TestScene", "a2a3sim", "host_build_graph", "pin")
+    _FakeKernelCompiler.compile_barrier = Barrier(2, timeout=2)
+
+    with compile_worker_budget(2):
+        compiled = _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+
+    assert compiled.child_count == 1
+
+
+def test_callable_preserves_spec_order_when_kernels_finish_out_of_order(monkeypatch, tmp_path):
+    _configure_fake_compilation(monkeypatch, tmp_path)
+    spec, _header = _cacheable_spec(tmp_path)
+    second = tmp_path / "kernel_second.cpp"
+    second.write_text('extern "C" void kernel_entry() {}\n')
+    spec["incores"].append(
+        {
+            "source": str(second),
+            "func_id": 7,
+            "core_type": "aiv",
+            "signature": [ArgDirection.OUT],
+            "extra_include_dirs": [],
+        }
+    )
+    cache_key = ("TestScene", "a2a3sim", "host_build_graph", "pin")
+    second_finished = Event()
+    original_compile_incore = _FakeKernelCompiler.compile_incore
+
+    def finish_second_first(self, source, **kwargs):
+        if Path(source) == second:
+            result = original_compile_incore(self, source, **kwargs)
+            second_finished.set()
+            return result
+        assert second_finished.wait(timeout=2)
+        return original_compile_incore(self, source, **kwargs)
+
+    monkeypatch.setattr(_FakeKernelCompiler, "compile_incore", finish_second_first)
+    with compile_worker_budget(3):
+        compiled = _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+
+    assert [compiled.child_func_id(index) for index in range(compiled.child_count)] == [0, 7]
+
+
+def test_callable_key_reuses_precomputed_incore_keys(monkeypatch, tmp_path):
+    _configure_fake_compilation(monkeypatch, tmp_path)
+    spec, _header = _cacheable_spec(tmp_path)
+    cache_key = ("TestScene", "a2a3sim", "host_build_graph", "pin")
+    captured = {}
+    scene_test_module = importlib.import_module("simpler_setup.scene_test")
+    original = scene_test_module.compile_artifact_key
+
+    def recording_key(metadata, compilation_units):
+        captured["metadata"] = metadata
+        captured["units"] = list(compilation_units)
+        return original(metadata, captured["units"])
+
+    monkeypatch.setattr(scene_test_module, "compile_artifact_key", recording_key)
+    _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+
+    assert [Path(source).name for source, _include_dirs in captured["units"]] == ["orchestration.cpp"]
+    assert len(captured["metadata"]["incores"]) == 1
+    assert len(captured["metadata"]["incores"][0]["artifact_key"]) == 64
 
 
 def test_compile_cache_survives_session_cache_clear(monkeypatch, tmp_path):
@@ -206,6 +282,85 @@ def test_compile_cache_invalidates_transitive_include(monkeypatch, tmp_path):
     assert _FakeKernelCompiler.incore_compiles == 2
 
 
+def test_orchestration_change_reuses_incore_artifact(monkeypatch, tmp_path):
+    _configure_fake_compilation(monkeypatch, tmp_path)
+    spec, _header = _cacheable_spec(tmp_path)
+    cache_key = ("TestScene", "a2a3sim", "host_build_graph", "pin")
+
+    _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+    clear_compile_cache()
+    Path(spec["orchestration"]["source"]).write_text('extern "C" void orchestration_changed() {}\n')
+    _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+
+    assert _FakeKernelCompiler.orchestration_compiles == 2
+    assert _FakeKernelCompiler.incore_compiles == 1
+
+
+def test_only_changed_incore_recompiles(monkeypatch, tmp_path):
+    _configure_fake_compilation(monkeypatch, tmp_path)
+    spec, _header = _cacheable_spec(tmp_path)
+    second = tmp_path / "kernel_second.cpp"
+    second.write_text('extern "C" void kernel_entry() {}\n')
+    spec["incores"].append(
+        {
+            "source": str(second),
+            "func_id": 1,
+            "core_type": "aiv",
+            "signature": [ArgDirection.OUT],
+            "extra_include_dirs": [],
+        }
+    )
+    cache_key = ("TestScene", "a2a3sim", "host_build_graph", "pin")
+
+    _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+    clear_compile_cache()
+    second.write_text('extern "C" void kernel_entry() { int changed = 1; }\n')
+    _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+
+    assert _FakeKernelCompiler.orchestration_compiles == 2
+    assert _FakeKernelCompiler.incore_compiles == 3
+
+
+def test_callables_share_incore_artifact_across_case_directories(monkeypatch, tmp_path):
+    _configure_fake_compilation(monkeypatch, tmp_path)
+    shared_dir = tmp_path / "shared_case" / "kernels"
+    shared_dir.mkdir(parents=True)
+    shared_kernel = shared_dir / "kernel.cpp"
+    shared_kernel.write_text('extern "C" void kernel_entry() {}\n')
+
+    specs = []
+    for index in range(2):
+        case_dir = tmp_path / f"case_{index}"
+        case_dir.mkdir()
+        orchestration = case_dir / "orchestration.cpp"
+        orchestration.write_text(f'extern "C" void orchestration_{index}() {{}}\n')
+        specs.append(
+            {
+                "orchestration": {
+                    "source": str(orchestration),
+                    "function_name": f"orchestration_{index}",
+                    "signature": [ArgDirection.IN],
+                },
+                "incores": [
+                    {
+                        "source": str(shared_kernel),
+                        "func_id": index,
+                        "core_type": "aiv",
+                        "signature": [ArgDirection.IN if index == 0 else ArgDirection.OUT],
+                        "extra_include_dirs": [],
+                    }
+                ],
+            }
+        )
+
+    for index, spec in enumerate(specs):
+        cache_key = (f"TestScene{index}", "a2a3sim", "host_build_graph", "pin")
+        _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+
+    assert _FakeKernelCompiler.orchestration_compiles == 2
+    assert _FakeKernelCompiler.incore_compiles == 1
+
+
 def test_compile_cache_invalidates_compiler_schema(monkeypatch, tmp_path):
     _configure_fake_compilation(monkeypatch, tmp_path)
     spec, _header = _cacheable_spec(tmp_path)
@@ -221,7 +376,7 @@ def test_compile_cache_invalidates_compiler_schema(monkeypatch, tmp_path):
     assert _FakeKernelCompiler.incore_compiles == 2
 
 
-def test_compile_cache_rebuilds_incomplete_entry(monkeypatch, tmp_path):
+def test_compile_cache_rebuilds_incomplete_callable_and_reuses_incore(monkeypatch, tmp_path):
     _configure_fake_compilation(monkeypatch, tmp_path)
     spec, _header = _cacheable_spec(tmp_path)
     cache_key = ("TestScene", "a2a3sim", "host_build_graph", "pin")
@@ -233,10 +388,26 @@ def test_compile_cache_rebuilds_incomplete_entry(monkeypatch, tmp_path):
     _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
 
     assert _FakeKernelCompiler.orchestration_compiles == 2
+    assert _FakeKernelCompiler.incore_compiles == 1
+
+
+def test_compile_cache_rebuilds_incomplete_incore_artifact(monkeypatch, tmp_path):
+    _configure_fake_compilation(monkeypatch, tmp_path)
+    spec, _header = _cacheable_spec(tmp_path)
+    cache_key = ("TestScene", "a2a3sim", "host_build_graph", "pin")
+
+    _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+    incore_path = next((tmp_path / "cache" / "incore").glob("*/artifact.bin"))
+    incore_path.write_bytes(b"incomplete")
+    clear_compile_cache()
+    Path(spec["orchestration"]["source"]).write_text('extern "C" void orchestration_changed() {}\n')
+    _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+
+    assert _FakeKernelCompiler.orchestration_compiles == 2
     assert _FakeKernelCompiler.incore_compiles == 2
 
 
-def test_compile_artifact_key_is_independent_of_checkout_path(tmp_path):
+def test_compile_artifact_key_includes_checkout_path_seen_by_compiler(tmp_path):
     keys = []
     for root_name in ("runner-a", "runner-b"):
         root = tmp_path / root_name
@@ -246,7 +417,77 @@ def test_compile_artifact_key_is_independent_of_checkout_path(tmp_path):
         source.write_text('#include "shared.h"\nextern "C" void kernel_entry() {}\n')
         keys.append(scene_test_cache.compile_artifact_key({"platform": "a2a3"}, [(source, [root])]))
 
+    assert keys[0] != keys[1]
+
+
+def test_incore_artifact_key_distinguishes_identical_sources_at_different_paths(tmp_path):
+    keys = []
+    for case_name in ("case-a", "case-b"):
+        case_dir = tmp_path / case_name
+        case_dir.mkdir()
+        source = case_dir / "kernel.cpp"
+        source.write_text('extern "C" const char *source_path() { return __FILE__; }\n')
+        keys.append(scene_test_cache.compile_incore_artifact_key({"platform": "a2a3"}, source, []))
+
+    assert keys[0] != keys[1]
+
+
+def test_incore_artifact_key_reuses_identical_sources_from_different_checkout_roots(monkeypatch, tmp_path):
+    roots = [tmp_path / name for name in ("runner-a", "runner-b")]
+    keys = []
+    for root in roots:
+        root.mkdir()
+        source = root / "kernel.cpp"
+        source.write_text('extern "C" const char *source_path() { return __FILE__; }\n')
+        monkeypatch.setattr(compile_paths, "PROJECT_ROOT", root)
+        keys.append(scene_test_cache.compile_incore_artifact_key({"platform": "a2a3"}, source, []))
+
     assert keys[0] == keys[1]
+
+
+def test_incore_artifact_key_distinguishes_identical_dependencies_at_different_paths(tmp_path):
+    source = tmp_path / "kernel.cpp"
+    source.write_text('#include <shared.h>\nextern "C" void kernel_entry() {}\n')
+    keys = []
+    for include_name in ("include-a", "include-b"):
+        include_dir = tmp_path / include_name
+        include_dir.mkdir()
+        (include_dir / "shared.h").write_text("constexpr const char *HEADER_PATH = __FILE__;\n")
+        keys.append(scene_test_cache.compile_incore_artifact_key({"platform": "a2a3"}, source, [include_dir]))
+
+    assert keys[0] != keys[1]
+
+
+def test_incore_artifact_key_includes_search_paths_used_by_has_include(tmp_path):
+    source = tmp_path / "kernel.cpp"
+    source.write_text(
+        '#if __has_include("feature_flag.h")\n'
+        'extern "C" int kernel_entry() { return 1; }\n'
+        "#else\n"
+        'extern "C" int kernel_entry() { return 0; }\n'
+        "#endif\n"
+    )
+    without_feature = tmp_path / "without-feature"
+    with_feature = tmp_path / "with-feature"
+    without_feature.mkdir()
+    with_feature.mkdir()
+    (with_feature / "feature_flag.h").write_text("// selected by __has_include\n")
+
+    without_key = scene_test_cache.compile_incore_artifact_key({"platform": "a2a3"}, source, [without_feature])
+    with_key = scene_test_cache.compile_incore_artifact_key({"platform": "a2a3"}, source, [with_feature])
+
+    assert without_key != with_key
+
+
+def test_incore_artifact_key_normalizes_relative_source_path(monkeypatch, tmp_path):
+    source = tmp_path / "kernel.cpp"
+    source.write_text('extern "C" const char *source_path() { return __FILE__; }\n')
+    monkeypatch.chdir(tmp_path)
+
+    relative = scene_test_cache.compile_incore_artifact_key({"platform": "a2a3"}, Path("kernel.cpp"), [])
+    absolute = scene_test_cache.compile_incore_artifact_key({"platform": "a2a3"}, source, [])
+
+    assert relative == absolute
 
 
 def test_compile_artifact_key_includes_callable_abi(monkeypatch, tmp_path):
@@ -259,6 +500,18 @@ def test_compile_artifact_key_includes_callable_abi(monkeypatch, tmp_path):
     second = scene_test_cache.compile_artifact_key({}, [(source, [])])
 
     assert first != second
+
+
+def test_incore_artifact_key_is_independent_of_callable_abi(monkeypatch, tmp_path):
+    source = tmp_path / "kernel.cpp"
+    source.write_text('extern "C" void kernel_entry() {}\n')
+
+    monkeypatch.setattr(scene_test_cache, "_chip_callable_abi_token", lambda: "abi-a")
+    first = scene_test_cache.compile_incore_artifact_key({"core_type": "aiv"}, source, [])
+    monkeypatch.setattr(scene_test_cache, "_chip_callable_abi_token", lambda: "abi-b")
+    second = scene_test_cache.compile_incore_artifact_key({"core_type": "aiv"}, source, [])
+
+    assert first == second
 
 
 def test_concurrent_cache_misses_compile_once(monkeypatch, tmp_path):
@@ -284,10 +537,38 @@ def test_concurrent_cache_misses_compile_once(monkeypatch, tmp_path):
     assert [callable_obj.func_name for callable_obj in callables] == ["shared", "shared"]
 
 
+def test_concurrent_incore_cache_misses_compile_once(monkeypatch, tmp_path):
+    monkeypatch.setattr(scene_test_cache, "KERNEL_CACHE_DIR", tmp_path / "cache")
+    start = Barrier(2)
+    count_lock = Lock()
+    compile_count = 0
+
+    def compile_incore():
+        nonlocal compile_count
+        with count_lock:
+            compile_count += 1
+        return b"shared-incore"
+
+    def load_or_compile():
+        start.wait()
+        return scene_test_cache.get_or_compile_incore("f" * 64, compile_incore)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        artifacts = list(executor.map(lambda _: load_or_compile(), range(2)))
+
+    assert compile_count == 1
+    assert artifacts == [b"shared-incore", b"shared-incore"]
+
+
 def test_artifact_logic_token_covers_the_compilation_modules(monkeypatch):
     from simpler_setup import kernel_compiler
 
-    assert set(kernel_compiler._ARTIFACT_LOGIC_MODULES) == {"kernel_compiler.py", "toolchain.py", "elf_parser.py"}
+    assert set(kernel_compiler._ARTIFACT_LOGIC_MODULES) == {
+        "kernel_compiler.py",
+        "toolchain.py",
+        "compile_paths.py",
+        "elf_parser.py",
+    }
 
     def token_over(modules):
         monkeypatch.setattr(kernel_compiler, "_ARTIFACT_LOGIC_MODULES", modules)
@@ -309,16 +590,20 @@ def test_publish_prunes_entries_past_the_retention_window(monkeypatch, tmp_path)
     stale = cache_dir / ("b" * 64)
     stale.mkdir(parents=True)
     (stale / "callable.bin").write_bytes(b"stale")
+    stale_incore = cache_dir / "incore" / ("d" * 64)
+    stale_incore.mkdir(parents=True)
+    (stale_incore / "artifact.bin").write_bytes(b"stale")
     stale_lock = cache_dir / ".locks" / "old.lock"
     stale_lock.parent.mkdir(parents=True)
     stale_lock.write_text("")
     expired = time.time() - scene_test_cache._ENTRY_RETENTION_S - 60
-    for path in (stale, stale_lock):
+    for path in (stale, stale_incore, stale_lock):
         os.utime(path, (expired, expired))
 
     scene_test_cache.get_or_compile("c" * 64, lambda: _build_chip_callable("fresh"))
 
     assert not stale.exists()
+    assert not stale_incore.exists()
     assert not stale_lock.exists()
     assert (cache_dir / ("c" * 64) / "callable.bin").is_file()
 
@@ -347,6 +632,31 @@ def test_unwritable_cache_dir_falls_back_to_plain_compilation(monkeypatch, tmp_p
 
     assert compiled.func_name == "uncached"
     assert not (read_only / "kernels").exists()
+
+
+def test_unwritable_cache_warns_once_for_callable_and_incore(monkeypatch, tmp_path, caplog):
+    _configure_fake_compilation(monkeypatch, tmp_path)
+    spec, _header = _cacheable_spec(tmp_path)
+    cache_dir = tmp_path / "unwritable-cache"
+    monkeypatch.setattr(scene_test_cache, "KERNEL_CACHE_DIR", cache_dir)
+    original_mkdir = Path.mkdir
+
+    def reject_lock_dir(path, *args, **kwargs):
+        if path == cache_dir / ".locks":
+            raise PermissionError("cache directory is read-only")
+        return original_mkdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", reject_lock_dir)
+    cache_key = ("TestScene", "a2a3sim", "host_build_graph", "pin")
+
+    with caplog.at_level("WARNING"):
+        callable_obj = _compile_chip_callable_from_spec(spec, "a2a3sim", "host_build_graph", cache_key)
+
+    disabled_messages = [record.message for record in caplog.records if "[SceneTestCache] disabled:" in record.message]
+    assert callable_obj.func_name == "orchestration"
+    assert _FakeKernelCompiler.orchestration_compiles == 1
+    assert _FakeKernelCompiler.incore_compiles == 1
+    assert len(disabled_messages) == 1
 
 
 def test_source_scan_is_memoized_per_file(monkeypatch, tmp_path):

--- a/tests/ut/py/test_scene_test_compile.py
+++ b/tests/ut/py/test_scene_test_compile.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from threading import Barrier
 
 import pytest
@@ -118,7 +119,28 @@ def test_compile_collected_scene_tests_runs_classes_concurrently():
     )
 
 
-@pytest.mark.parametrize(("max_workers", "expected"), [(None, 1), (8, 8)])
+def test_compile_collected_scene_tests_shares_worker_budget_with_callable_compiles(monkeypatch):
+    captured = []
+
+    @contextmanager
+    def recording_budget(max_workers):
+        captured.append(max_workers)
+        yield
+
+    class Scene:
+        _st_level = 2
+
+        @classmethod
+        def compile_chip_callable(cls, platform):
+            return None
+
+    monkeypatch.setattr(scene_test_compile, "compile_worker_budget", recording_budget)
+
+    assert scene_test_compile.compile_collected_scene_tests([_Item(Scene)], "a2a3", max_workers=3) == (1, [])
+    assert captured == [3]
+
+
+@pytest.mark.parametrize(("max_workers", "expected"), [(None, 3), (8, 8)])
 def test_compile_collected_scene_tests_uses_configured_workers(monkeypatch, max_workers, expected):
     captured = {}
 
@@ -143,6 +165,7 @@ def test_compile_collected_scene_tests_uses_configured_workers(monkeypatch, max_
             return None
 
     monkeypatch.setattr(scene_test_compile, "ThreadPoolExecutor", RecordingExecutor, raising=False)
+    monkeypatch.setattr(scene_test_compile, "default_compile_workers", lambda: 3)
 
     kwargs = {} if max_workers is None else {"max_workers": max_workers}
     assert scene_test_compile.compile_collected_scene_tests([_Item(Scene)], "a2a3", **kwargs) == (1, [])


### PR DESCRIPTION
## Summary
- Add a two-level scene-test cache so unchanged incore artifacts survive callable and orchestration changes.
- Include compiler-visible source, dependency, and include-search paths in cache keys so __FILE__ and __BASE_FILE__ remain correct across CI runners.
- Compile orchestration and missing incore artifacts concurrently while preserving callable assembly order.
- Share a bounded process-wide compiler budget across class-level and per-callable work; the automatic budget reserves two logical CPUs and caps compiler fanout at eight.

## Concurrency scope

The budget is intentionally process-local. It does not coordinate independent worktrees or scene-test processes; those are isolated by CI/job scheduling or can be constrained with --compile-workers.

## Performance

- Qwen3-14B 37-kernel cold compile: 69.620 s -> 19.853 s with 8 workers.
- 3-worker cold compile: 29.214 s; complete callable hit: 8.868 s.

## Testing

- 61 focused compile-pool, cache, scene-compile, and compiler Python UTs passed after the final rebase.
- Ruff check, Ruff format check, and git diff --check passed.
- No NPU access is required for these cache and compiler tests.