### PR TITLE
Fix: gate disabled host spans before formatting

### DIFF
--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -18,7 +18,11 @@ children share.
 `src/common/task_interface/profiling_config.h` — separate from the
 `SIMPLER_DFX` gate on the device Orch/Sched markers) and is emitted at
 `LOG_TIMING` (the default threshold) — **no new env var or flag**. In a
-`SIMPLER_HOST_STRACE`-off build the RAII macros compile to nothing.
+`SIMPLER_HOST_STRACE`-off build the RAII macros compile to nothing. In an
+enabled build, Host call sites also read the live process threshold before
+constructing span attributes; `WARN`, `ERROR`, and `NUL` therefore disable the
+instrumentation work as well as the output. Device logging still uses the
+initialization-time policy described in [logging.md](../logging.md).
 
 ## Marker grammar
 
@@ -148,7 +152,7 @@ binding wins**: a `SpanScope` keeps the name pointer it was handed, so a process
 that inits Workers at two levels keeps the first one's word and logs a warning
 rather than relabelling spans that are still open. One process therefore carries
 one vocabulary — which is what makes an L4 run readable, since its own spans say
-`network1.` while each of its L3 children says `host.`.
+`network1.` while each of its L3 children says `node.`.
 
 One process contributes at most two host lanes, because the scheduler runs on
 one thread: the facade thread emits `<level>.graph_build` and `<level>.submit`,
@@ -165,7 +169,8 @@ private logger implementation, then binds it to the
 that state before `fork()`; a chip child re-seeds its inherited copy and passes
 the same pointer to every runtime module it loads. The threshold and one-anchor
 coordination are therefore shared within each process without relying on
-`RTLD_GLOBAL` logger symbols.
+`RTLD_GLOBAL` logger symbols. A private logger is silent before that binding;
+afterward its enabled query follows the shared Host threshold on every span.
 
 ## `ext.` — spans from outside simpler
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -67,6 +67,14 @@ host logger translation units directly. This makes each DSO self-contained:
 loading a runtime can no longer fail because a logger artifact or a global
 logger symbol was missing.
 
+Each bindable private logger starts with a `NUL` fallback threshold and stays
+silent until its loader binds the process-owned state. The `_task_interface`
+owner is seeded with the configured user-facing threshold (`TIMING` by default)
+before it forks workers or loads runtime modules. A missed binding therefore
+appears as an observably silent module instead of output filtered at the wrong
+level. A standalone executable that compiles the logger and has no loader must
+seed its own state before logging; `query_device_hal` does this explicitly.
+
 ## Three-layer ABI
 
 ### Layer 1 — consumer macros
@@ -86,7 +94,9 @@ Each macro injects the source location and passes `__FUNCTION__` separately.
 Host spans use `SimplerHostSpan` and `unified_log_host_span`. Callers supply
 what happened—name, duration, invocation identity, and attributes—while
 `HostLogger::log_host_span` owns the PID, TID, timestamp envelope, escaping,
-and the single `[STRACE]` format string.
+and the single `[STRACE]` format string. Before constructing attributes, hot
+call sites query `unified_log_host_span_enabled`; the logger rechecks the
+TIMING threshold before validating or encoding a record.
 
 ### Layer 2 — unified logging ABI
 
@@ -111,7 +121,10 @@ forwards to its local backend.
 `HostLogger::vlog` is the host-side authority for level gating. It formats a
 complete record and performs one `write(2)` under its module-local mutex.
 `HostLogger::log_host_span` additionally bounds and escapes machine-readable
-fields so a STRACE record fits the portable `PIPE_BUF` floor.
+fields so a STRACE record fits the portable `PIPE_BUF` floor. Its early gate
+keeps direct ABI and legacy STRACE callers from paying those encoding costs
+when TIMING is disabled; `vlog` remains the final check if the threshold changes
+between the caller's query and emission.
 
 The mutex serializes writers only within the DSO that owns it. Writers from
 different DSOs, or from forked processes sharing a pipe, are indivisible only

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -1044,6 +1044,13 @@ NB_MODULE(_task_interface, m) {
     m.attr("HOST_STRACE_ENABLED") = false;
 #endif
     m.def(
+        "_host_spans_active",
+        [] {
+            return simpler::host_trace::enabled();
+        },
+        "Return whether this extension currently emits TIMING-level host spans."
+    );
+    m.def(
         "_initialize_host_log",
         [](int level) {
             if (!simpler::log::is_valid_level(level)) return false;

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -108,6 +108,9 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
     materialize_task_args,
     read_args_from_blob,
 )
+from _task_interface import (
+    _host_spans_active as _native_host_spans_active,
+)
 
 from . import _log as _simpler_log
 from .buffer import (
@@ -268,8 +271,8 @@ _WORKER_CHIP_ENDPOINT_ERROR_REGION_RE = re.compile(r"\bL3-L2 endpoint error\b[^\
 
 
 def _host_spans_active() -> bool:
-    """Whether host-span emission was compiled into this extension."""
-    return HOST_STRACE_ENABLED
+    """Whether host-span emission is compiled in and enabled at runtime."""
+    return HOST_STRACE_ENABLED and _native_host_spans_active()
 
 
 # ---------------------------------------------------------------------------

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -136,7 +136,7 @@ void Orchestrator::finish_run_if_ready(const std::shared_ptr<RunState> &run) {
             return;
         }
         bool failed = run->submission_failed || static_cast<bool>(run->first_error);
-        run->trace_terminal_ns = simpler::host_trace::now_ns();
+        run->trace_terminal_ns = simpler::host_trace::enabled() ? simpler::host_trace::now_ns() : 0;
         run->phase.store(failed ? RunPhase::FAILED : RunPhase::COMPLETED, std::memory_order_release);
         notify = true;
     }
@@ -374,13 +374,15 @@ void Orchestrator::release_run(RunId run_id) {
 
     compact_if_quiescent();
 #if SIMPLER_HOST_STRACE
-    std::ostringstream retire_attrs;
-    retire_attrs << "run_id=" << run_id << " slot_id=" << lease.slot_id << " generation=" << lease.generation
-                 << " role=facade";
-    simpler::host_trace::emit(
-        simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::PostFenceRetirement), run_id, 0, 0,
-        terminal_ns, simpler::host_trace::now_ns() - terminal_ns, retire_attrs.str().c_str()
-    );
+    if (terminal_ns != 0 && simpler::host_trace::enabled()) {
+        std::ostringstream retire_attrs;
+        retire_attrs << "run_id=" << run_id << " slot_id=" << lease.slot_id << " generation=" << lease.generation
+                     << " role=facade";
+        simpler::host_trace::emit(
+            simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::PostFenceRetirement), run_id, 0, 0,
+            terminal_ns, simpler::host_trace::now_ns() - terminal_ns, retire_attrs.str().c_str()
+        );
+    }
 #endif
 }
 
@@ -734,7 +736,7 @@ SubmitResult Orchestrator::submit_impl(
 
 #if SIMPLER_HOST_STRACE
     std::optional<simpler::host_trace::SpanScope> submit_trace;
-    if (worker_type == WorkerType::NEXT_LEVEL) {
+    if (worker_type == WorkerType::NEXT_LEVEL && simpler::host_trace::enabled()) {
         uint64_t trace_callable_hash = 0;
         std::memcpy(&trace_callable_hash, callable.digest.data(), sizeof(trace_callable_hash));
         std::ostringstream trace_attrs;

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -22,6 +22,7 @@
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -442,7 +443,8 @@ void WorkerThread::dispatch_prepared(WorkerDispatch d) {
 WorkerThread::SubmitDispatchResult
 WorkerThread::submit_dispatch(WorkerDispatch d, LaneKind lane_kind, RunId expected_run_id) {
 #if SIMPLER_HOST_STRACE
-    const int64_t trace_start_ns = simpler::host_trace::now_ns();
+    const bool trace_enabled = simpler::host_trace::enabled();
+    const int64_t trace_start_ns = trace_enabled ? simpler::host_trace::now_ns() : 0;
 #endif
     std::unique_lock<std::mutex> admission_lk(admission_mu_);
     if (shutdown_.load(std::memory_order_acquire)) {
@@ -464,9 +466,14 @@ WorkerThread::submit_dispatch(WorkerDispatch d, LaneKind lane_kind, RunId expect
     ++next_dispatch_id_;
     inflight_.fetch_add(1, std::memory_order_release);
 #if SIMPLER_HOST_STRACE
-    const RunId trace_run = trace_run_id(ring_, d.task_slot);
-    const uint64_t trace_hash = trace_callable_hash(ring_, d.task_slot);
-    const std::string trace_lease = trace_lease_attrs(ring_, d.task_slot);
+    RunId trace_run = INVALID_RUN_ID;
+    uint64_t trace_hash = 0;
+    std::string trace_lease;
+    if (trace_enabled) {
+        trace_run = trace_run_id(ring_, d.task_slot);
+        trace_hash = trace_callable_hash(ring_, d.task_slot);
+        trace_lease = trace_lease_attrs(ring_, d.task_slot);
+    }
 #endif
     try {
         endpoint_->submit_progress(ring_, d);
@@ -477,12 +484,15 @@ WorkerThread::submit_dispatch(WorkerDispatch d, LaneKind lane_kind, RunId expect
     }
     admission_lk.unlock();
 #if SIMPLER_HOST_STRACE
-    const int64_t trace_end_ns = simpler::host_trace::now_ns();
-    const std::string trace_attrs = trace_dispatch_attrs(trace_run, d, endpoint_->caps(), "scheduler") + trace_lease;
-    simpler::host_trace::emit(
-        simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::Dispatch), trace_run, trace_hash, 0,
-        trace_start_ns, trace_end_ns - trace_start_ns, trace_attrs.c_str()
-    );
+    if (trace_enabled) {
+        const int64_t trace_end_ns = simpler::host_trace::now_ns();
+        const std::string trace_attrs =
+            trace_dispatch_attrs(trace_run, d, endpoint_->caps(), "scheduler") + trace_lease;
+        simpler::host_trace::emit(
+            simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::Dispatch), trace_run, trace_hash, 0,
+            trace_start_ns, trace_end_ns - trace_start_ns, trace_attrs.c_str()
+        );
+    }
 #endif
     return SubmitDispatchResult::SUBMITTED;
 }
@@ -645,9 +655,15 @@ void WorkerThread::finish_progress_dispatch(const WorkerEndpointProgress &progre
     }
 
 #if SIMPLER_HOST_STRACE
-    const RunId trace_run = trace_run_id(ring_, dispatch.task_slot);
-    const uint64_t trace_hash = trace_callable_hash(ring_, dispatch.task_slot);
-    std::string complete_attrs = trace_dispatch_attrs(trace_run, dispatch, endpoint_->caps(), "worker");
+    const bool trace_enabled = simpler::host_trace::enabled();
+    RunId trace_run = INVALID_RUN_ID;
+    uint64_t trace_hash = 0;
+    std::string complete_attrs;
+    if (trace_enabled) {
+        trace_run = trace_run_id(ring_, dispatch.task_slot);
+        trace_hash = trace_callable_hash(ring_, dispatch.task_slot);
+        complete_attrs = trace_dispatch_attrs(trace_run, dispatch, endpoint_->caps(), "worker");
+    }
 #endif
     WorkerCompletion completion = progress.completion;
     if (accepted_dispatch_ids_.erase(dispatch.dispatch_id) == 0) {
@@ -672,11 +688,14 @@ void WorkerThread::finish_progress_dispatch(const WorkerEndpointProgress &progre
     }
 
 #if SIMPLER_HOST_STRACE
-    complete_attrs += " outcome=" + std::to_string(static_cast<int32_t>(completion.outcome));
-    simpler::host_trace::SpanScope complete_trace(
-        simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::Complete), trace_run, trace_hash, 0,
-        std::move(complete_attrs)
-    );
+    std::optional<simpler::host_trace::SpanScope> complete_trace;
+    if (trace_enabled) {
+        complete_attrs += " outcome=" + std::to_string(static_cast<int32_t>(completion.outcome));
+        complete_trace.emplace(
+            simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::Complete), trace_run, trace_hash, 0,
+            std::move(complete_attrs)
+        );
+    }
 #endif
     on_complete_(std::move(completion));
     {
@@ -722,10 +741,14 @@ void LocalMailboxEndpoint::submit_progress(Ring *ring, const WorkerDispatch &dis
     }
 
 #if SIMPLER_HOST_STRACE
-    simpler::host_trace::SpanScope frame_submit_trace(
-        simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::FrameSubmit), state.run_id,
-        trace_callable_hash(ring, dispatch.task_slot), 0, trace_dispatch_attrs(state.run_id, dispatch, caps_, "worker")
-    );
+    std::optional<simpler::host_trace::SpanScope> frame_submit_trace;
+    if (simpler::host_trace::enabled()) {
+        frame_submit_trace.emplace(
+            simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::FrameSubmit), state.run_id,
+            trace_callable_hash(ring, dispatch.task_slot), 0,
+            trace_dispatch_attrs(state.run_id, dispatch, caps_, "worker")
+        );
+    }
 #endif
 
     // The lease slot id is a native pipeline slot bounded by the runtime's
@@ -986,16 +1009,19 @@ bool LocalMailboxEndpoint::activate_progress(RunId run_id) {
         FrameRecord &record = frames_[index];
         if (!record.occupied || !record.dispatch.prepare_only || record.run_id != run_id) continue;
 #if SIMPLER_HOST_STRACE
-        std::ostringstream activate_attrs;
-        activate_attrs << "run_id=" << run_id << " task_slot=" << record.dispatch.task_slot
-                       << " group_index=" << record.dispatch.group_index << " worker_id=" << caps_.worker_id
-                       << " dispatch_id=" << record.dispatch.dispatch_id
-                       << " endpoint_kind=" << endpoint_kind_name(caps_.kind)
-                       << " prepare_only=" << static_cast<int>(record.dispatch.prepare_only) << " role=worker";
-        simpler::host_trace::SpanScope activate_trace(
-            simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::Activate), run_id, 0, 0,
-            activate_attrs.str()
-        );
+        std::optional<simpler::host_trace::SpanScope> activate_trace;
+        if (simpler::host_trace::enabled()) {
+            std::ostringstream activate_attrs;
+            activate_attrs << "run_id=" << run_id << " task_slot=" << record.dispatch.task_slot
+                           << " group_index=" << record.dispatch.group_index << " worker_id=" << caps_.worker_id
+                           << " dispatch_id=" << record.dispatch.dispatch_id
+                           << " endpoint_kind=" << endpoint_kind_name(caps_.kind)
+                           << " prepare_only=" << static_cast<int>(record.dispatch.prepare_only) << " role=worker";
+            activate_trace.emplace(
+                simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::Activate), run_id, 0, 0,
+                activate_attrs.str()
+            );
+        }
 #endif
         record.activation_requested = true;
         char *frame = task_frame(index);

--- a/src/common/log/host_log.cpp
+++ b/src/common/log/host_log.cpp
@@ -157,10 +157,13 @@ long host_trace_tid() {
 
 namespace {
 
+// A private logger stays silent until its owner seeds this state or its loader
+// binds the process-owned state. Missing binding is therefore observable as an
+// absent module stream rather than output filtered at the wrong threshold.
 SimplerHostLogState g_module_log_state{
     SIMPLER_HOST_LOG_STATE_ABI_VERSION,
     sizeof(SimplerHostLogState),
-    static_cast<int32_t>(LogLevel::TIMING),
+    static_cast<int32_t>(LogLevel::NUL),
     0,
 };
 
@@ -309,6 +312,7 @@ void HostLogger::log(LogLevel level, const char *func, const char *fmt, ...) {
 }
 
 void HostLogger::log_host_span(const SimplerHostSpan *span) {
+    if (!is_enabled(LogLevel::TIMING)) return;
     if (span == nullptr || span->abi_version != SIMPLER_HOST_SPAN_ABI_VERSION ||
         span->struct_size < sizeof(SimplerHostSpan) || span->name == nullptr) {
         return;

--- a/src/common/log/include/common/host_span_scope.h
+++ b/src/common/log/include/common/host_span_scope.h
@@ -33,12 +33,15 @@
 
 namespace simpler::host_trace {
 
+inline bool enabled() noexcept { return unified_log_host_span_enabled() != 0; }
+
 inline int64_t now_ns() noexcept { return simpler::log::monotonic_now_ns(); }
 
 inline void emit(
     const char *name, uint64_t invocation_id, uint64_t callable_hash, int32_t depth, int64_t timestamp_ns,
     int64_t duration_ns, const char *attributes
 ) noexcept {
+    if (!enabled()) return;
     const SimplerHostSpan span{
         SIMPLER_HOST_SPAN_ABI_VERSION,
         sizeof(SimplerHostSpan),
@@ -93,6 +96,7 @@ private:
 
 namespace simpler::host_trace {
 
+inline bool enabled() noexcept { return false; }
 inline int64_t now_ns() noexcept { return 0; }
 inline void emit(const char *, uint64_t, uint64_t, int32_t, int64_t, int64_t, const char *) noexcept {}
 

--- a/src/common/log/unified_log_host.cpp
+++ b/src/common/log/unified_log_host.cpp
@@ -30,6 +30,8 @@ using simpler::log::LogLevel;
 #pragma GCC visibility push(hidden)
 #endif
 
+int unified_log_host_span_enabled() { return HostLogger::get_instance().is_enabled(LogLevel::TIMING) ? 1 : 0; }
+
 void unified_log_host_span(const SimplerHostSpan *span) { HostLogger::get_instance().log_host_span(span); }
 
 void unified_log_error(const char *func, const char *fmt, ...) {

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -989,10 +989,13 @@ add_a5_runtime_test(test_a5_aicore_completion_mailbox a5/test_aicore_completion_
 # Host logger silent/off behavior — no runtime deps, just compile the same
 # self-contained host logger sources used by production consumers.
 set(SIMPLER_LOG_DIR ${CMAKE_SOURCE_DIR}/../../../src/common/log)
-add_executable(test_host_log_off
-    a5/test_host_log_off.cpp
+set(HOST_LOG_TEST_SOURCES
     ${SIMPLER_LOG_DIR}/host_log.cpp
     ${SIMPLER_LOG_DIR}/unified_log_host.cpp
+)
+add_executable(test_host_log_off
+    a5/test_host_log_off.cpp
+    ${HOST_LOG_TEST_SOURCES}
 )
 target_include_directories(test_host_log_off PRIVATE
     ${GTEST_INCLUDE_DIRS}
@@ -1006,6 +1009,25 @@ target_link_libraries(test_host_log_off PRIVATE
     pthread
 )
 add_test(NAME test_host_log_off COMMAND test_host_log_off)
+
+# A separate process verifies the private pre-bind fallback before another
+# test target binds its singleton to process-owned state.
+add_executable(test_host_log_unbound
+    common/test_host_log_unbound.cpp
+    ${HOST_LOG_TEST_SOURCES}
+)
+target_include_directories(test_host_log_unbound PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+    ${SIMPLER_LOG_DIR}
+    ${SIMPLER_LOG_DIR}/include
+)
+target_link_libraries(test_host_log_unbound PRIVATE
+    ${GTEST_MAIN_LIB}
+    ${GTEST_LIB}
+    pthread
+)
+add_test(NAME test_host_log_unbound COMMAND test_host_log_unbound)
 
 set(COMMON_PLATFORM_DIR ${CMAKE_SOURCE_DIR}/../../../src/common/platform)
 function(add_device_phase_capture_test name host_strace device_strace expected)

--- a/tests/ut/cpp/a5/test_host_log_off.cpp
+++ b/tests/ut/cpp/a5/test_host_log_off.cpp
@@ -22,6 +22,7 @@
 #include <set>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -137,6 +138,21 @@ TEST(HostLogTest, NulLevelMutesAllSeverities) {
     });
     EXPECT_EQ(captured.out, "");
     EXPECT_EQ(captured.err, "");
+}
+
+TEST(HostLogTest, HostSpanEnabledFollowsTimingVisibility) {
+    for (const auto &[level, expected] : {
+             std::pair{LogLevel::DEBUG, 1},
+             std::pair{LogLevel::INFO, 1},
+             std::pair{LogLevel::TIMING, 1},
+             std::pair{LogLevel::WARN, 0},
+             std::pair{LogLevel::ERROR, 0},
+             std::pair{LogLevel::NUL, 0},
+         }) {
+        HostLogger::get_instance().set_level(level);
+        EXPECT_EQ(unified_log_host_span_enabled(), expected);
+    }
+    HostLogger::get_instance().set_level(LogLevel::TIMING);
 }
 
 TEST(HostLogTest, ErrorLevelEmitsErrorOnly) {
@@ -334,6 +350,20 @@ TEST(HostLogTest, HostSpanEscapesDelimitersAndFitsAtomicPipeRecord) {
     EXPECT_LE(record.size(), static_cast<size_t>(_POSIX_PIPE_BUF));
     ASSERT_GE(record.size(), 2u);
     EXPECT_EQ(record[record.size() - 2], '~');
+}
+
+TEST(HostLogTest, DisabledHostSpanProducesNoRecord) {
+    const SimplerHostSpan span{
+        SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 7, 0x1234, 0, 0, 100, 25, "host.dispatch",
+        "run_id=7 role=scheduler"
+    };
+
+    auto captured = run_with_config(LogLevel::WARN, [&] {
+        unified_log_host_span(&span);
+    });
+
+    EXPECT_EQ(captured.out, "");
+    EXPECT_EQ(captured.err, "");
 }
 
 TEST(HostLogTest, AllHostSpanEmitPathsPreserve64BitInvocationIds) {

--- a/tests/ut/cpp/common/test_host_log_unbound.cpp
+++ b/tests/ut/cpp/common/test_host_log_unbound.cpp
@@ -9,34 +9,21 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#pragma once
+#include <gtest/gtest.h>
 
-#include <stdint.h>
+#include "common/host_span.h"
+#include "common/log_level.h"
+#include "host_log.h"
 
-#define SIMPLER_HOST_SPAN_ABI_VERSION 1U
+TEST(HostLogUnboundTest, PrivateModuleStateStartsSilent) {
+    EXPECT_EQ(HostLogger::get_instance().level(), static_cast<int>(simpler::log::LogLevel::NUL));
+    EXPECT_EQ(unified_log_host_span_enabled(), 0);
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-typedef struct SimplerHostSpan {
-    uint32_t abi_version;
-    uint32_t struct_size;
-    uint64_t invocation_id;
-    uint64_t callable_hash;
-    int32_t depth;
-    int32_t reserved;
-    int64_t timestamp_ns;
-    int64_t duration_ns;
-    const char *name;
-    const char *attributes;
-} SimplerHostSpan;
-
-/* Link-time adapters used by native Host consumers. The enabled query is the
- * cheap pre-format gate for TIMING-level spans; emission rechecks the level. */
-int unified_log_host_span_enabled(void);
-void unified_log_host_span(const SimplerHostSpan *span);
-
-#ifdef __cplusplus
+    const SimplerHostSpan span{
+        SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 1, 0, 0, 0, 100, 25, "host.dispatch", "run_id=1"
+    };
+    testing::internal::CaptureStderr();
+    HostLogger::get_instance().log(simpler::log::LogLevel::ERROR, "unbound", "must stay silent");
+    unified_log_host_span(&span);
+    EXPECT_EQ(testing::internal::GetCapturedStderr(), "");
 }
-#endif

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -55,16 +55,18 @@ namespace {
 std::mutex captured_host_spans_mu;
 std::vector<std::string> captured_host_span_names;
 std::vector<std::string> captured_host_span_attributes;
+std::atomic<bool> captured_host_spans_enabled{true};
 
 class ScopedHostSpanCapture {
 public:
-    ScopedHostSpanCapture() {
+    explicit ScopedHostSpanCapture(bool enabled = true) {
+        captured_host_spans_enabled.store(enabled, std::memory_order_release);
         std::lock_guard<std::mutex> lk(captured_host_spans_mu);
         captured_host_span_names.clear();
         captured_host_span_attributes.clear();
     }
 
-    ~ScopedHostSpanCapture() = default;
+    ~ScopedHostSpanCapture() { captured_host_spans_enabled.store(true, std::memory_order_release); }
 
     ScopedHostSpanCapture(const ScopedHostSpanCapture &) = delete;
     ScopedHostSpanCapture &operator=(const ScopedHostSpanCapture &) = delete;
@@ -74,6 +76,11 @@ bool captured_host_span(const std::string &name) {
     std::lock_guard<std::mutex> lk(captured_host_spans_mu);
     return std::find(captured_host_span_names.begin(), captured_host_span_names.end(), name) !=
            captured_host_span_names.end();
+}
+
+bool captured_host_spans_empty() {
+    std::lock_guard<std::mutex> lk(captured_host_spans_mu);
+    return captured_host_span_names.empty();
 }
 
 // The attributes of the first span emitted under `name`, or "" if none was.
@@ -86,6 +93,10 @@ std::string captured_host_span_attrs(const std::string &name) {
 }
 
 }  // namespace
+
+extern "C" int unified_log_host_span_enabled() {
+    return captured_host_spans_enabled.load(std::memory_order_acquire) ? 1 : 0;
+}
 
 extern "C" void unified_log_host_span(const SimplerHostSpan *span) {
     if (span == nullptr || span->name == nullptr) return;
@@ -362,7 +373,12 @@ public:
         caps_.supports_frame_staging = true;
     }
 
-    const WorkerEndpointCaps &caps() const override { return caps_; }
+    const WorkerEndpointCaps &caps() const override {
+        caps_call_count_.fetch_add(1, std::memory_order_relaxed);
+        return caps_;
+    }
+
+    size_t caps_call_count() const { return caps_call_count_.load(std::memory_order_relaxed); }
 
     void submit_progress(Ring *ring, const WorkerDispatch &dispatch) override {
         ProgressCall call(*this);
@@ -606,6 +622,7 @@ private:
     }
 
     WorkerEndpointCaps caps_;
+    mutable std::atomic<size_t> caps_call_count_{0};
     mutable std::mutex mu_;
     std::condition_variable cv_;
     std::vector<WorkerDispatch> submitted_;
@@ -1218,6 +1235,45 @@ TEST(WorkerManagerTest, DispatchAndCompletionEmitHostSpans) {
     worker.progress();
     ASSERT_EQ(completed.size(), 1u);
     EXPECT_TRUE(captured_host_span(simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::Complete)));
+
+    worker.stop();
+    allocator.shutdown();
+}
+
+TEST(WorkerManagerTest, DisabledHostSpansSkipDispatchAndCompletionTraceWork) {
+    ScopedHostSpanCapture host_span_capture(/*enabled=*/false);
+
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    TaskSlot slot = make_progress_slot(allocator, /*run_id=*/73, /*pipeline_slot=*/0, /*generation=*/1);
+    ASSERT_NE(slot, INVALID_SLOT);
+
+    WorkerThread worker;
+    auto endpoint = std::make_unique<DeterministicProgressEndpoint>();
+    DeterministicProgressEndpoint *endpoint_ptr = endpoint.get();
+    std::vector<WorkerCompletion> completed;
+    worker.start(
+        &allocator,
+        [&](WorkerCompletion completion) {
+            completed.push_back(std::move(completion));
+        },
+        [](WorkerDispatch) {}, std::move(endpoint)
+    );
+
+    const size_t caps_calls_before_dispatch = endpoint_ptr->caps_call_count();
+    worker.dispatch(WorkerDispatch{slot, 0});
+    ASSERT_TRUE(endpoint_ptr->wait_submitted(1));
+    EXPECT_EQ(endpoint_ptr->caps_call_count(), caps_calls_before_dispatch + 1)
+        << "disabled dispatch should query caps only for admission";
+
+    const WorkerDispatch submitted = endpoint_ptr->submitted().front();
+    endpoint_ptr->emit(WorkerProgressKind::COMPLETED, submitted);
+    const size_t caps_calls_before_completion = endpoint_ptr->caps_call_count();
+    worker.progress();
+    ASSERT_EQ(completed.size(), 1u);
+    EXPECT_EQ(endpoint_ptr->caps_call_count(), caps_calls_before_completion)
+        << "disabled completion should not query caps for trace attributes";
+    EXPECT_TRUE(captured_host_spans_empty());
 
     worker.stop();
     allocator.shutdown();

--- a/tests/ut/cpp/stubs/test_stubs.cpp
+++ b/tests/ut/cpp/stubs/test_stubs.cpp
@@ -34,6 +34,8 @@
 
 extern "C" {
 
+int unified_log_host_span_enabled() { return 0; }
+
 void unified_log_host_span(const struct SimplerHostSpan *) {}
 
 void unified_log_error(const char *func, const char *fmt, ...) {

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -2760,6 +2760,38 @@ class TestRunHandle:
         expected_name = f"{worker._host_span_prefix}.graph_build"
         assert emitted == [(expected_name, 1, 0, 0, 100, 175, "run_id=1 role=facade")]
 
+    def test_host_spans_active_combines_build_and_runtime_gates(self, monkeypatch):
+        monkeypatch.setattr(worker_mod, "HOST_STRACE_ENABLED", True)
+        monkeypatch.setattr(worker_mod, "_native_host_spans_active", lambda: False)
+        assert not worker_mod._host_spans_active()
+
+        monkeypatch.setattr(worker_mod, "_native_host_spans_active", lambda: True)
+        assert worker_mod._host_spans_active()
+
+        monkeypatch.setattr(worker_mod, "HOST_STRACE_ENABLED", False)
+
+        def unexpected_runtime_query():
+            raise AssertionError("a trace-disabled build queried the runtime gate")
+
+        monkeypatch.setattr(worker_mod, "_native_host_spans_active", unexpected_runtime_query)
+        assert not worker_mod._host_spans_active()
+
+    def test_disabled_host_spans_skip_graph_build_instrumentation(self, monkeypatch):
+        worker, _events = self._submission_failure_worker(failures=0)
+        monkeypatch.setattr(worker_mod, "_host_spans_active", lambda: False)
+
+        def unexpected_trace_work(*_args):
+            raise AssertionError("disabled host spans performed trace work")
+
+        monkeypatch.setattr(worker_mod.time, "monotonic_ns", unexpected_trace_work)
+        monkeypatch.setattr(worker_mod, "_emit_host_span", unexpected_trace_work)
+
+        def bad_graph(*_args):
+            raise ValueError("bad graph")
+
+        with pytest.raises(ValueError, match="bad graph"):
+            worker._submit_l3_locked(bad_graph, None, cast(Any, object()))
+
     def test_unsettled_graph_cancellation_abandons_the_handle_before_close(self):
         worker, events = self._submission_failure_worker(failures=2)
         graph_error = ValueError("bad graph")

--- a/tools/cann-examples/aicpu-device-query/host/query_device_hal.cpp
+++ b/tools/cann-examples/aicpu-device-query/host/query_device_hal.cpp
@@ -43,6 +43,7 @@
 #include <runtime/runtime/rts/rts_kernel.h>
 
 #include "aicpu_topology_probe.h"
+#include "host_log.h"
 
 #include <cerrno>
 #include <cstdint>
@@ -314,6 +315,9 @@ int main(int argc, char **argv) {
         std::fprintf(stderr, "usage: %s <device_id> [--json]\n", argv[0]);
         return 1;
     }
+    // This executable owns its logger state; no loader binds it.
+    HostLogger::get_instance().set_level(simpler::log::LogLevel::TIMING);
+
     int device_id = std::atoi(argv[1]);
     const bool json_output = argc == 3;
 


### PR DESCRIPTION
- Query live TIMING visibility before clocks, metadata, and attribute work
- Keep bindable loggers silent until process-state binding
- Seed standalone logger owners before they emit diagnostics
- Preserve level-resolved host-scheduler names across runtime gates and docs
- Cover threshold changes, unbound startup, and disabled scheduler trace work

Addresses items 3 and 7 of [#1792](https://github.com/hw-native-sys/simpler/issues/1792).