### PR TITLE
Add: carry an endpoint deployment on Global CommDomain members

### DIFF
--- a/docs/comm-domain.md
+++ b/docs/comm-domain.md
@@ -70,6 +70,18 @@ domain ranks. A remote node reads `comm_profile` and `global_device_ranks`
 from `RemoteWorkerSpec`; a local L3 reads the same fields from its `Worker`
 configuration. All participating nodes must use the same profile.
 
+A member is an **endpoint with a deployment**, not a position in the worker
+tree: `GlobalDomainMember` carries an `EndpointDeployment` alongside its
+address, and that deployment is what selects the backing its window is carved
+from (`comm_endpoints._backend_kind_for_provider`). The window lives in device
+memory, so every member is a `DEVICE_AICORE` endpoint and the member table
+rejects any other value. The restriction is about backing, not about level: a
+`HOST_CPU` participant needs a host-mappable window, and no platform path
+allocates one — `halHostRegister` refuses a VMM VA, so one backing cannot be
+both peer-imported by a device and mapped by a host. `Worker` resolves the
+deployment from the registered L3 node, so `allocate_global_domain` takes the
+same `(l3_worker_id, local_l2_worker_id)` members it always has.
+
 An MPI-launched group registered with `add_mpirun_worker_group` uses the same
 member contract. Rank 0 writes the group manifest before launch, every MPI rank
 must publish READY before the L4 parent exposes the returned worker ids, and

--- a/python/simpler/global_comm_domain.py
+++ b/python/simpler/global_comm_domain.py
@@ -14,7 +14,16 @@ import enum
 import struct
 from dataclasses import dataclass
 
+from .comm_endpoints import DEVICE_AICORE, EndpointDeployment
+
+#: Descriptor and L3->L2 mailbox layout. Paired with ``COMM_GLOBAL_DOMAIN_VERSION`` in
+#: ``src/common/platform_comm/comm.h``: the platform backend stamps this number into every
+#: descriptor it exports and Python checks it on decode, so the two constants move together
+#: or not at all.
 GLOBAL_DOMAIN_VERSION = 1
+#: L4<->L3 control-command layout. Python owns both ends of these commands, so it advances
+#: independently of the backend-stamped descriptor version above.
+GLOBAL_DOMAIN_COMMAND_VERSION = 2
 GLOBAL_DOMAIN_MAX_RANKS = 64
 GLOBAL_DOMAIN_MAX_BUFFERS = 64
 GLOBAL_DOMAIN_HANDLE_BYTES = 256
@@ -26,6 +35,15 @@ GLOBAL_DOMAIN_PROFILE_IDS = {
     GLOBAL_DOMAIN_PROFILE_SIM: 1,
     GLOBAL_DOMAIN_PROFILE_A3_FABRIC: 2,
 }
+#: Wire ordinal per deployment, mirroring ``GLOBAL_DOMAIN_PROFILE_IDS``: ``EndpointDeployment``
+#: carries string values, and enum declaration order is not a wire contract, so the mapping is
+#: stated here rather than derived.
+GLOBAL_DOMAIN_DEPLOYMENT_IDS = {
+    EndpointDeployment.HOST_CPU: 1,
+    EndpointDeployment.DEVICE_AICORE: 2,
+    EndpointDeployment.DEVICE_AICPU: 3,
+}
+GLOBAL_DOMAIN_DEPLOYMENTS_BY_ID = {value: key for key, value in GLOBAL_DOMAIN_DEPLOYMENT_IDS.items()}
 GLOBAL_DOMAIN_MAX_STRING_BYTES = 1024
 GLOBAL_DOMAIN_MAX_COPY_BYTES = 8 * 1024 * 1024
 
@@ -54,10 +72,22 @@ class GlobalDomainPhase(enum.IntEnum):
 
 @dataclass(frozen=True)
 class GlobalDomainMember:
+    """One endpoint of a Global CommDomain: where it sits, and what it is deployed on.
+
+    ``node_worker_id`` / ``local_worker_id`` address the endpoint, ``global_device_rank``
+    is its cluster-wide device identity and ``domain_rank`` its dense rank in this domain.
+    ``deployment`` states the kind of endpoint, which is what selects the backing its window
+    is carved from; ``validate_member_table`` admits only ``DEVICE_AICORE`` today.
+    """
+
     node_worker_id: int
     local_worker_id: int
     global_device_rank: int
     domain_rank: int
+    deployment: EndpointDeployment = DEVICE_AICORE
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "deployment", EndpointDeployment(self.deployment))
 
 
 @dataclass(frozen=True)
@@ -264,6 +294,14 @@ def validate_member_table(members: tuple[GlobalDomainMember, ...]) -> None:
     global_ranks = [member.global_device_rank for member in members]
     if len(set(global_ranks)) != len(global_ranks) or any(rank < 0 for rank in global_ranks):
         raise ValueError("global domain members require unique non-negative global device ranks")
+    if any(member.deployment is not DEVICE_AICORE for member in members):
+        # The restriction is about backing, not about level: a member's window is carved by
+        # the platform backend as a device VMM window, and no host-mappable backing exists to
+        # place one anywhere else -- `halHostRegister` refuses a VMM VA.
+        raise ValueError(
+            f"global domain members must be {DEVICE_AICORE.value} endpoints: "
+            "no host-mappable window backing is implemented"
+        )
 
 
 def validate_descriptor_table(
@@ -292,23 +330,36 @@ def validate_descriptor_table(
 
 
 def _put_member(out: bytearray, member: GlobalDomainMember) -> None:
+    deployment_id = GLOBAL_DOMAIN_DEPLOYMENT_IDS.get(member.deployment)
+    if deployment_id is None:
+        raise ValueError(f"global domain member deployment {member.deployment!r} has no wire id")
     out.extend(
         struct.pack(
-            "<iIII",
+            "<iIIII",
             int(member.node_worker_id),
             int(member.local_worker_id),
             int(member.global_device_rank),
             int(member.domain_rank),
+            deployment_id,
         )
     )
 
 
 def _read_member(reader: _Reader) -> GlobalDomainMember:
+    node_worker_id = reader.i32()
+    local_worker_id = reader.u32()
+    global_device_rank = reader.u32()
+    domain_rank = reader.u32()
+    deployment_id = reader.u32()
+    deployment = GLOBAL_DOMAIN_DEPLOYMENTS_BY_ID.get(deployment_id)
+    if deployment is None:
+        raise ValueError(f"global domain member deployment id {deployment_id} is unknown")
     return GlobalDomainMember(
-        node_worker_id=reader.i32(),
-        local_worker_id=reader.u32(),
-        global_device_rank=reader.u32(),
-        domain_rank=reader.u32(),
+        node_worker_id=node_worker_id,
+        local_worker_id=local_worker_id,
+        global_device_rank=global_device_rank,
+        domain_rank=domain_rank,
+        deployment=deployment,
     )
 
 
@@ -320,7 +371,7 @@ def encode_comm_init(command: GlobalCommInitCommand) -> bytes:
         raise ValueError(f"unsupported global domain profile {command.profile!r}")
     if command.node_rank < 0 or command.node_count <= 0 or command.node_rank >= command.node_count:
         raise ValueError("global comm init node identity is invalid")
-    out = bytearray(struct.pack("<III", GLOBAL_DOMAIN_VERSION, command.node_rank, command.node_count))
+    out = bytearray(struct.pack("<III", GLOBAL_DOMAIN_COMMAND_VERSION, command.node_rank, command.node_count))
     _put_string(out, command.cluster_id, "cluster_id")
     _put_string(out, command.topology_hash, "topology_hash")
     _put_string(out, command.profile, "profile")
@@ -333,7 +384,7 @@ def encode_comm_init(command: GlobalCommInitCommand) -> bytes:
 def decode_comm_init(data: bytes) -> GlobalCommInitCommand:
     reader = _Reader(data)
     version = reader.u32()
-    if version != GLOBAL_DOMAIN_VERSION:
+    if version != GLOBAL_DOMAIN_COMMAND_VERSION:
         raise ValueError("global comm init version mismatch")
     node_rank = reader.u32()
     node_count = reader.u32()
@@ -414,7 +465,7 @@ def encode_domain_command(command: GlobalDomainCommand) -> bytes:
     out = bytearray(
         struct.pack(
             "<IIQQQ",
-            GLOBAL_DOMAIN_VERSION,
+            GLOBAL_DOMAIN_COMMAND_VERSION,
             int(command.phase),
             int(command.domain_id),
             int(command.generation),
@@ -439,7 +490,7 @@ def encode_domain_command(command: GlobalDomainCommand) -> bytes:
 def decode_domain_command(data: bytes) -> GlobalDomainCommand:
     reader = _Reader(data)
     version = reader.u32()
-    if version != GLOBAL_DOMAIN_VERSION:
+    if version != GLOBAL_DOMAIN_COMMAND_VERSION:
         raise ValueError("global domain command version mismatch")
     try:
         phase = GlobalDomainPhase(reader.u32())
@@ -502,14 +553,14 @@ def decode_descriptor_table(data: bytes) -> tuple[GlobalDomainDescriptor, ...]:
 def encode_release_command(command: GlobalDomainReleaseCommand) -> bytes:
     if command.domain_id == 0 or command.generation == 0:
         raise ValueError("global domain release identity must be positive")
-    return struct.pack("<IQQ", GLOBAL_DOMAIN_VERSION, int(command.domain_id), int(command.generation))
+    return struct.pack("<IQQ", GLOBAL_DOMAIN_COMMAND_VERSION, int(command.domain_id), int(command.generation))
 
 
 def decode_release_command(data: bytes) -> GlobalDomainReleaseCommand:
     if len(data) != struct.calcsize("<IQQ"):
         raise ValueError("global domain release size mismatch")
     version, domain_id, generation = struct.unpack("<IQQ", data)
-    if version != GLOBAL_DOMAIN_VERSION or domain_id == 0 or generation == 0:
+    if version != GLOBAL_DOMAIN_COMMAND_VERSION or domain_id == 0 or generation == 0:
         raise ValueError("global domain release identity or version is invalid")
     return GlobalDomainReleaseCommand(int(domain_id), int(generation))
 
@@ -531,7 +582,7 @@ def encode_copy_command(command: GlobalDomainCopyCommand, *, include_data: bool)
     out = bytearray(
         struct.pack(
             "<IQQIQQ",
-            GLOBAL_DOMAIN_VERSION,
+            GLOBAL_DOMAIN_COMMAND_VERSION,
             int(command.domain_id),
             int(command.generation),
             int(command.domain_rank),
@@ -558,7 +609,7 @@ def decode_copy_command(data: bytes, *, include_data: bool) -> GlobalDomainCopyC
         nbytes=int(nbytes),
         data=bytes(payload),
     )
-    if version != GLOBAL_DOMAIN_VERSION:
+    if version != GLOBAL_DOMAIN_COMMAND_VERSION:
         raise ValueError("global domain copy version mismatch")
     encode_copy_command(command, include_data=include_data)
     return command

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -145,6 +145,7 @@ from .comm_endpoints import (
     BackendPlan,
     BackendResolver,
     DefaultRegionAccessService,
+    EndpointDeployment,
     EndpointRegistry,
     RegionAccessService,
     RegionLayoutSpec,
@@ -903,6 +904,10 @@ class _GlobalNodeRuntime:
     node_count: int
     cluster_id: str
     is_remote: bool
+    #: Deployment every Global CommDomain member on this node carries. A node contributes its
+    #: chips' device windows, and no launch path registers a host participant, so this is the
+    #: one value the member table admits.
+    deployment: EndpointDeployment = DEVICE_AICORE
 
 
 _IdentitySnapshotEntry = tuple[bytes, Any, int, str, str]
@@ -9566,6 +9571,7 @@ class Worker:
                     local_worker_id=int(local_worker_id),
                     global_device_rank=node.global_device_ranks[int(local_worker_id)],
                     domain_rank=domain_rank,
+                    deployment=node.deployment,
                 )
             )
         if len(profiles) != 1:
@@ -9591,6 +9597,7 @@ class Worker:
                         member.local_worker_id,
                         member.global_device_rank,
                         member.domain_rank,
+                        member.deployment.value,
                     )
                     for member in domain_members_tuple
                 ),

--- a/tests/ut/py/test_global_comm_domain.py
+++ b/tests/ut/py/test_global_comm_domain.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 import socket
+import struct
 import subprocess
 import sys
 import threading
@@ -19,12 +20,15 @@ from collections import Counter
 from typing import cast
 
 import pytest
+from simpler.comm_endpoints import DEVICE_AICORE, HOST_CPU, EndpointDeployment
 from simpler.global_comm_domain import (
     CTRL_GLOBAL_DOMAIN_COPY_FROM,
     CTRL_GLOBAL_DOMAIN_COPY_TO,
     CTRL_GLOBAL_DOMAIN_IMPORT,
     CTRL_GLOBAL_DOMAIN_PREPARE,
     CTRL_GLOBAL_DOMAIN_RELEASE,
+    GLOBAL_DOMAIN_COMMAND_VERSION,
+    GLOBAL_DOMAIN_DEPLOYMENT_IDS,
     GLOBAL_DOMAIN_DESCRIPTOR_BYTES,
     GLOBAL_DOMAIN_MAX_BUFFERS,
     GLOBAL_DOMAIN_PROFILE_IDS,
@@ -45,6 +49,7 @@ from simpler.global_comm_domain import (
     encode_domain_command,
     resolve_global_comm_capability,
     validate_descriptor_table,
+    validate_member_table,
 )
 
 
@@ -159,6 +164,58 @@ def test_global_domain_wire_round_trips_topology_and_descriptor_table():
     assert decode_domain_command(encode_domain_command(command)) == command
     assert decode_descriptor_table(encode_descriptor_table(_descriptors())) == _descriptors()
     assert GLOBAL_DOMAIN_DESCRIPTOR_BYTES == 288
+
+
+def test_global_domain_member_normalizes_its_deployment_to_the_enum_member():
+    """`EndpointDeployment` subclasses `str`, so an un-normalized value would encode (the wire-id
+    dict matches it by value) yet fail `validate_member_table`'s identity check. Normalizing at
+    construction keeps the two in agreement.
+    """
+    member = GlobalDomainMember(0, 0, 3, 0)
+    bare_string = cast(EndpointDeployment, str(DEVICE_AICORE.value))
+
+    assert member.deployment is DEVICE_AICORE
+    assert GlobalDomainMember(0, 0, 3, 0, bare_string).deployment is DEVICE_AICORE
+    assert GlobalDomainMember(0, 0, 3, 0, bare_string) == member
+
+
+def test_global_domain_wire_round_trips_the_member_deployment():
+    init = GlobalCommInitCommand("cluster", "topology", "sim", 0, 2, _members())
+
+    decoded = decode_comm_init(encode_comm_init(init))
+
+    assert decoded == init
+    assert [member.deployment for member in decoded.members] == [DEVICE_AICORE, DEVICE_AICORE]
+
+
+def test_global_domain_member_table_rejects_a_non_device_deployment():
+    members = (GlobalDomainMember(0, 0, 0, 0, HOST_CPU),)
+
+    with pytest.raises(ValueError, match="no host-mappable window backing is implemented"):
+        validate_member_table(members)
+
+
+def test_global_domain_wire_rejects_an_unknown_member_deployment_id():
+    encoded = bytearray(encode_comm_init(GlobalCommInitCommand("cluster", "topology", "sim", 0, 2, _members())))
+    unknown = max(GLOBAL_DOMAIN_DEPLOYMENT_IDS.values()) + 1
+    deployment_offset = encoded.rindex(struct.pack("<I", GLOBAL_DOMAIN_DEPLOYMENT_IDS[DEVICE_AICORE]))
+    encoded[deployment_offset : deployment_offset + 4] = struct.pack("<I", unknown)
+
+    with pytest.raises(ValueError, match=f"deployment id {unknown} is unknown"):
+        decode_comm_init(bytes(encoded))
+
+
+def test_global_domain_command_version_is_independent_of_the_backend_descriptor_version():
+    """The descriptor version is stamped by the platform backend (`COMM_GLOBAL_DOMAIN_VERSION`
+    in `src/common/platform_comm/comm.h`), so the L4<->L3 command layout carries its own.
+    """
+    encoded = encode_comm_init(GlobalCommInitCommand("cluster", "topology", "sim", 0, 2, _members()))
+    stale = struct.pack("<I", GLOBAL_DOMAIN_VERSION) + encoded[4:]
+
+    assert GLOBAL_DOMAIN_COMMAND_VERSION != GLOBAL_DOMAIN_VERSION
+    assert struct.unpack_from("<I", encoded)[0] == GLOBAL_DOMAIN_COMMAND_VERSION
+    with pytest.raises(ValueError, match="global comm init version mismatch"):
+        decode_comm_init(stale)
 
 
 def test_global_domain_encode_rejects_too_many_buffers():


### PR DESCRIPTION
## Summary

A `GlobalDomainMember` was four tree positions — node and local worker ids, global device rank, domain rank — none of which said what the endpoint is deployed on. The backing a member's window is carved from is derived from its deployment (`comm_endpoints._backend_kind_for_provider`), so without the field a member's semantics are welded to one tree level, and a `HOST_CPU` participant or the two deployment views of one chip have no spelling at all.

Placeholder-only, as the issue specifies: the dimension is added, exactly one value is accepted, behavior does not change.

- `GlobalDomainMember` gains an `EndpointDeployment`, imported from `comm_endpoints` rather than redefined. It is normalized at construction because `EndpointDeployment` subclasses `str` — an un-normalized value would be found by the wire-id table yet rejected by `validate_member_table`'s identity check, so the encoder and the validator would disagree about the same value.
- The member wire carries it as a `u32` ordinal from an explicit table, mirroring `GLOBAL_DOMAIN_PROFILE_IDS`. Enum declaration order is not a wire contract, so the mapping is stated rather than derived.
- `validate_member_table` admits only `DEVICE_AICORE`, and says so in terms of backing rather than level: no host-mappable window backing is implemented, because `halHostRegister` refuses a VMM VA.
- `Worker` resolves the deployment from the registered L3 node rather than the caller, so `allocate_global_domain(members=[(l3_id, l2_index), ...])` keeps its signature and no example changes.
- `docs/comm-domain.md` states the invariant instead of leaving a reader to infer member semantics from the tuple shape.

### Why a second version constant

`GLOBAL_DOMAIN_VERSION` guarded four unrelated layouts at once: the L4↔L3 commands, the `LOCAL_*` L3→L2 mailbox structs, the release/copy commands, and the descriptor — which the platform backend stamps with `COMM_GLOBAL_DOMAIN_VERSION` in `src/common/platform_comm/comm.h` and Python checks on decode. Advancing that constant for a Python-only field addition would have failed every allocation at PREPARE with `global domain descriptor version mismatch`, unless the C++ macro moved in lockstep and every runtime was rebuilt.

The L4↔L3 commands now carry their own `GLOBAL_DOMAIN_COMMAND_VERSION = 2`, so a stale peer reports a version mismatch instead of a confusing truncated-wire error, and the backend-paired constant stays at 1. **No C++ changes** — `src/` is untouched, and the member table never reaches the device (the L3→L2 `LOCAL_PREPARE_REQUEST` carries only `domain_rank` and `rank_count`).

## Testing

Validated on an Ascend910 V1 host; onboard runs went through `task-submit`.

- [x] Unit tests — `pytest tests/ut -m "not requires_hardware"`: **1486 passed**
- [x] Cross-process end-to-end — 8 cases spawning real `simpler.remote_l3_worker` daemons over TCP, plus the mixed local/remote and MPI-group paths
- [x] Simulation tests — full `tests/st --platform a2a3sim`: **64 passed, 0 failed**
- [x] Hardware tests — `pytest tests/ut -m requires_hardware --platform a2a3`: **6/6 passed**, including `test_two_rank_comm_lifecycle` and `test_two_rank_allocate_release_round_trip`
- [x] Hardware scene tests — `tests/st/worker --platform a2a3`: **12/12 PASS**, including `TestAsyncNotifyDemo`, which declares no sim variant
- [x] Lint — ruff check/format, pyright, check-headers, check-english-only, markdownlint

New unit cases cover the deployment round-tripping on the wire, construction-time normalization, rejection of a non-`DEVICE_AICORE` member, rejection of an unknown deployment id arriving on the wire, and the command version being independent of the backend-stamped descriptor version.

## Scope

Deliberately excluded, per the issue: no `EndpointId` / `session_id` / `worker_path`, no member selector, no capability computation. The two follow-ups that share this root cause — `CommBufferSpec` being an offset slice of one window rather than an independent Buffer, and `comm_profile` being one node-level string — are breaking changes that need the endpoint registry to be load-bearing first.

Fixes #1836