### PR TITLE
Rename span families to the level that emits them

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -304,8 +304,8 @@ runtime-inapplicable columns are not zero measurements and must not be printed.
 
 | Metric | Source | What it captures |
 | ------ | ------ | ---------------- |
-| Host | `[STRACE]` `run_prepared` span | steady_clock around dispatch (Python overhead included); rendered from markers by `strace_timing --rounds-table` |
-| Device | `[STRACE]` `run_prepared.runner_run.device_wall` span | full on-NPU AICPU run wall (`AicpuPhase::RunWall`, `max(end) − min(start)` across threads); on TMR this whole run + teardown is strictly larger than the windows below |
+| Host | `[STRACE]` `chip.run` span | steady_clock around dispatch (Python overhead included); rendered from markers by `strace_timing --rounds-table` |
+| Device | `[STRACE]` `chip.run.runner_run.device_wall` span | full on-NPU AICPU run wall (`AicpuPhase::RunWall`, `max(end) − min(start)` across threads); on TMR this whole run + teardown is strictly larger than the windows below |
 | Effective | TMR orch/sched markers' device-domain `ts`+`dur` | TMR only: `max(orch_end,sched_end) − min(orch_start,sched_start)` — the orch∪sched merged window |
 | Orch | `[STRACE]` `…device_wall.orch` span (`--rounds-table`) | TMR only: device orchestrator (graph-build) window |
 | Sched | `[STRACE]` `…device_wall.sched` span (`--rounds-table`) | TMR only: scheduler dispatch/execution window |

--- a/.claude/skills/multi-repo-qwen-setup/SKILL.md
+++ b/.claude/skills/multi-repo-qwen-setup/SKILL.md
@@ -126,8 +126,8 @@ task-submit --timeout 2400 --max-time 2400 --device auto --device-num 1 --run "\
   host wall, per-step layer breakdown) plus `strace_timing --rounds-table`
   (§2–§5).
 - Decode dispatches through the **L3 `DistributedWorker`**, which forks a
-  **chip-child (L2)** that runs `run_prepared`. The per-step timing lives at
-  **L2**: `run_prepared` computes both host (`host_wall`) and device
+  **chip-child (L2)** that runs `simpler_run`. The per-step timing lives at
+  **L2**: `simpler_run` computes both host (`host_wall`) and device
   (`device_wall` = the fused-decode orchestrator wall, ~40 ms at 3.5k context —
   nonzero) plus the device orch/sched markers. The L3 parent's `Worker.run`
   returns `RunTiming(python_wall, 0)` — its `device_wall=0` is **expected** (L3
@@ -237,14 +237,14 @@ The full per-token decomposition (what each layer means / how to get it):
 | ④ attach+bind+validate | `host_wall − runner_run` | `strace_timing` (`bind`/`validate` spans) |
 | ⑤ python/executor wrap | `end-to-end − host_wall` | `npu_generate --profile` |
 
-②③④ come from the **L2 chip-child** `run_prepared`'s `host_wall` /
+②③④ come from the **L2 chip-child** `simpler_run`'s `host_wall` /
 `runner_run` / `device_wall`. `host_wall` and `device_wall` are already
 computed there (and `device_wall` is nonzero, ~40 ms at 3.5k context — it is the
 L2 orchestrator wall, *not* the L3 parent's `RunTiming.device_wall=0`); the L3
 parent drops the child's `RunTiming`, so they never reach a return value.
 
 Simpler surfaces them instead as **`[STRACE]` host-trace markers** — one
-line per `run_prepared` stage
+line per `chip.run` stage
 (`bind`/`bind.args`/`bind.prebuilt`/`runner_run`/`validate`) plus the AICPU
 device-phase subdivision (`preamble`/`so_load`/`graph_build` — with
 `config_validate`/`arena_wire`/`sm_reset` prep sub-phases — /`post_orch`,

--- a/docs/dfx/device-phases.md
+++ b/docs/dfx/device-phases.md
@@ -72,7 +72,7 @@ deep-dive — see [l2-timing.md](l2-timing.md).
   It copies the larger task-timing tail only when the header says at least one
   tagged task was dispatched. It caches per-phase ns
   (`last_device_phase_ns`), and emits each non-zero phase as a `clk=dev`
-  `[STRACE]` marker nested under `simpler_run.runner_run.device_wall`
+  `[STRACE]` marker nested under `chip.run.runner_run.device_wall`
   (see [host-trace.md](host-trace.md)).
 
 ### Gating device-domain markers
@@ -87,7 +87,7 @@ deployment can profile the two domains separately:
   controls buffer setup/reset, AICPU stamping, D2H readback, and marker
   emission. A disabled predicate leaves the device base null, so stamping
   no-ops and the marker-only H2D/D2H transfers are skipped.
-* **Host** (`simpler_run` / `bind` / `runner_run` / `validate` spans): no new
+* **Host** (`chip.run` / `bind` / `runner_run` / `validate` spans): no new
   knob — they ride the compile-time `SIMPLER_HOST_STRACE` macro and the log level
   (`LOG_TIMING`), so raising the log threshold drops them.
 
@@ -95,7 +95,7 @@ The simulator still applies `SIMPLER_DEVICE_STRACE_ENABLE` at emission time;
 the transfer optimization above is specific to the onboard device buffer.
 
 `RunWall` is the whole on-NPU wall (the former `RunTiming.device_wall`); it is
-emitted as the `simpler_run.runner_run.device_wall` marker, not returned.
+emitted as the `chip.run.runner_run.device_wall` marker, not returned.
 
 ### Reading the phases — they nest and overlap, don't sum them
 
@@ -213,7 +213,7 @@ threads, no per-task AICore records, works in `SIMPLER_DFX=0`. See
   completeness check still decides what is emitted. Every complete slot
   (dispatch set, finish > dispatch) is
   emitted as a stable `clk=dev` span
-  `simpler_run.runner_run.device_wall.task_slot_<N>`, retaining start and
+  `chip.run.runner_run.device_wall.task_slot_<N>`, retaining start and
   duration so cross-slot intervals are recoverable; `Worker.run()` still returns
   `None`. All slots are reset every run, so a failed/short run cannot leak stale
   data; unset or incomplete slots are skipped. Slots share the phase timeline's

--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -76,15 +76,15 @@ output sees the original text; a consumer reading the raw log does not.
 ## Span tree
 
 ```text
-simpler_run                                   (= host_wall)
-├─ simpler_run.bind
-│  ├─ simpler_run.bind.args        (ntensor=N: per-tensor device_malloc + H2D)
-│  └─ simpler_run.bind.prebuilt    (prebuilt runtime-arena cache hit or build + upload)
-├─ simpler_run.runner_run          (device enqueue + completion drain)
-│  └─ simpler_run.runner_run.device_wall      (whole on-NPU AICPU wall)
+chip.run                                      (= host_wall)
+├─ chip.run.bind
+│  ├─ chip.run.bind.args        (ntensor=N: per-tensor device_malloc + H2D)
+│  └─ chip.run.bind.prebuilt    (prebuilt runtime-arena cache hit or build + upload)
+├─ chip.run.runner_run          (device enqueue + completion drain)
+│  └─ chip.run.runner_run.device_wall      (whole on-NPU AICPU wall)
 │     └─ .{preamble,so_load,graph_build,config_validate,arena_wire,sm_reset,post_orch,orch,sched}
 │           TMR device-domain (clk=dev): AICPU subdivision of the on-NPU wall
-└─ simpler_run.validate
+└─ chip.run.validate
 ```
 
 The `device_wall` span exists for both runtimes. Its
@@ -103,7 +103,7 @@ The phased native-run interface preserves this same marker contract. Prepare
 allocates one `inv` and records the host-wall start; prepare, the child progress
 path's launch/drain lifecycle, and finalize bind that `(inv, hid)` while
 emitting their spans. Finalize releases the runner claim, destroys the per-run
-state, and then emits the stored `simpler_run` wall, so the root includes that
+state, and then emits the stored `chip.run` wall, so the root includes that
 cleanup tail.
 No trace scope or synthetic nesting remains active between C API calls. For
 direct phased use the host wall is the full prepare-to-finalize lifetime,
@@ -112,10 +112,10 @@ including time the caller spends polling or doing other host work; blocking
 
 | Depth | Span names |
 | ----- | ---------- |
-| 0 | `simpler_run` |
-| 1 | `simpler_run.bind`, `simpler_run.runner_run`, `simpler_run.claim_release`, `simpler_run.validate` |
-| 2 | `simpler_run.bind.args`, `simpler_run.bind.prebuilt`, `simpler_run.runner_run.device_wall` |
-| 3 | TMR phase spans `simpler_run.runner_run.device_wall.{preamble,so_load,graph_build,config_validate,arena_wire,sm_reset,post_orch,orch,sched}` and optional `task_slot_*` spans |
+| 0 | `chip.run` |
+| 1 | `chip.run.bind`, `chip.run.runner_run`, `chip.run.claim_release`, `chip.run.validate` |
+| 2 | `chip.run.bind.args`, `chip.run.bind.prebuilt`, `chip.run.runner_run.device_wall` |
+| 3 | TMR phase spans `chip.run.runner_run.device_wall.{preamble,so_load,graph_build,config_validate,arena_wire,sm_reset,post_orch,orch,sched}` and optional `task_slot_*` spans |
 
 ## L3/L4 host scheduler spans
 
@@ -125,13 +125,13 @@ L4 pod alike, since the orchestrator and scheduler code they run is the same:
 
 | Span | Host decision point |
 | ---- | ------------------- |
-| `l3.graph_build` | serialized Python graph callback |
-| `l3.submit` | next-level task publication after slot allocation |
-| `l3.dispatch` | scheduler handoff to a worker thread |
-| `l3.frame_submit` | local child mailbox-frame publication |
-| `l3.activate` | prepared-frame activation |
-| `l3.complete` | terminal child progress handling |
-| `l3.post_fence_retirement` | run erase + quiescent compaction, after the completion fence |
+| `host.graph_build` | serialized Python graph callback |
+| `host.submit` | next-level task publication after slot allocation |
+| `host.dispatch` | scheduler handoff to a worker thread |
+| `host.frame_submit` | local child mailbox-frame publication |
+| `host.activate` | prepared-frame activation |
+| `host.complete` | terminal child progress handling |
+| `host.post_fence_retirement` | run erase + quiescent compaction, after the completion fence |
 
 Their attributes carry the available `run_id`, `task_slot`, `group_index`,
 `worker_id`, `dispatch_id`, endpoint kind, and the dispatch's pipeline lease
@@ -143,9 +143,9 @@ per-level vocabulary that resolves this is tracked in
 [#1793](https://github.com/hw-native-sys/simpler/issues/1793).
 
 One process contributes at most two host lanes, because the scheduler runs on
-one thread: the facade thread emits `l3.graph_build` and `l3.submit`, and the
-scheduler thread emits the other four. `role=worker` on `l3.frame_submit`,
-`l3.activate` and `l3.complete` names the worker a dispatch targets, not the
+one thread: the facade thread emits `host.graph_build` and `host.submit`, and the
+scheduler thread emits the other four. `role=worker` on `host.frame_submit`,
+`host.activate` and `host.complete` names the worker a dispatch targets, not the
 thread that ran it.
 
 The spans reach the logger over the fixed POD `SimplerHostSpan` ABI in
@@ -177,7 +177,7 @@ python -m simpler_setup.tools.strace_timing path/to/log --swimlane host_swimlane
 ```
 
 The tool groups by `(pid, inv)`, rebuilds each invocation's tree from `depth`,
-buckets by `hid`, and prints each callable's mean `simpler_run` plus per-stage
+buckets by `hid`, and prints each callable's mean `chip.run` plus per-stage
 means. With `--trace-out` it writes one `ph:"X"` event per span on a synthetic
 per-invocation lane, so each call renders as an isolated nested tree in
 [Perfetto](https://ui.perfetto.dev) / `chrome://tracing`.
@@ -189,7 +189,7 @@ A runtime may subdivide a stage it owns, which the markers deliberately do not
 describe — the marker grammar is a fixed per-run-stage contract, and a runtime's
 internal breakdown of one stage does not belong in it. `--host-phase-records`
 takes such a breakdown from the artifact the runtime wrote and draws each record
-inside its `simpler_run.bind`, matched on `(pid, inv)`. Both sides are the same
+inside its `chip.run.bind`, matched on `(pid, inv)`. Both sides are the same
 `CLOCK_MONOTONIC` axis, so nothing is converted. Without the artifact the tool
 still recovers the stage's own segments from the runtime's timing log lines; where
 both are present the artifact wins, so a segment is not drawn twice. See
@@ -220,19 +220,19 @@ the device-phase timing views.
 
 The phased native lane claims that run N+1's preparation runs *concurrently*
 with run N's device execution. That claim is checkable from a captured log
-without any new marker family: the windows are already in the `simpler_run`
+without any new marker family: the windows are already in the `chip.run`
 tree, and the root span already carries the identity that tells two runs apart.
 
 | Property | Read from |
 | -------- | --------- |
-| successor's preparation | `simpler_run.bind` — its arena build + host orchestration |
-| predecessor's device work | `simpler_run.runner_run` |
-| when a successor may launch | `simpler_run.claim_release` |
-| which run each belongs to | root `simpler_run` attrs, joined by `(pid, inv)` |
+| successor's preparation | `chip.run.bind` — its arena build + host orchestration |
+| predecessor's device work | `chip.run.runner_run` |
+| when a successor may launch | `chip.run.claim_release` |
+| which run each belongs to | root `chip.run` attrs, joined by `(pid, inv)` |
 
 Only `claim_release` was added for this: it wraps `release_native_run` inside
 finalize, the point a successor's launch becomes admissible, and no other span
-marks that boundary. `l3.post_fence_retirement` covers the L3 orchestrator's
+marks that boundary. `host.post_fence_retirement` covers the L3 orchestrator's
 `release_run` tail for the same reason.
 
 The identity is `run_id / dispatch_id / run_epoch / slot_id / generation`. Each

--- a/docs/dfx/l2-timing.md
+++ b/docs/dfx/l2-timing.md
@@ -21,8 +21,8 @@ opt-in (`--enable-chip-swimlane`) and documented separately in
 
 | Span | What it measures | Source |
 | ---- | ---------------- | ------ |
-| **`simpler_run`** (host_wall) | Host `steady_clock` delta wrapping the dispatch call — includes Python/host overhead. | host side, around the C-ABI run call |
-| **`simpler_run.runner_run.device_wall`** | **Full on-NPU kernel wall**: earliest `simpler_aicpu_exec` start to latest end across launched threads — i.e. **the whole run + teardown**. | Each `simpler_aicpu_exec` thread stamps its own `AicpuPhase::RunWall` slot in the per-thread `AicpuPhaseRecord` buffer (`KernelArgs.device_wall_data_base`, see `src/{arch}/platform/onboard/aicpu/kernel.cpp`); host reduces `max(end) - min(start)` each run |
+| **`chip.run`** (host_wall) | Host `steady_clock` delta wrapping the dispatch call — includes Python/host overhead. | host side, around the C-ABI run call |
+| **`chip.run.runner_run.device_wall`** | **Full on-NPU kernel wall**: earliest `simpler_aicpu_exec` start to latest end across launched threads — i.e. **the whole run + teardown**. | Each `simpler_aicpu_exec` thread stamps its own `AicpuPhase::RunWall` slot in the per-thread `AicpuPhaseRecord` buffer (`KernelArgs.device_wall_data_base`, see `src/{arch}/platform/onboard/aicpu/kernel.cpp`); host reduces `max(end) - min(start)` each run |
 
 Both are emitted whenever the runtime was built with `SIMPLER_HOST_STRACE` (the
 default) — **independent of `--enable-chip-swimlane`**. The `device_wall` marker is
@@ -81,7 +81,7 @@ invocation).
 
 | Column | Definition |
 | ------ | ---------- |
-| **Host** | `simpler_run` span — host wall incl. Python/dispatch overhead. |
+| **Host** | `chip.run` span — host wall incl. Python/dispatch overhead. |
 | **Device** | `device_wall` span — full on-NPU wall incl. init/teardown. |
 | **Effective** | TMR only: `max(orch_end, sched_end) − min(orch_start, sched_start)` — the orch∪sched merged window (the effective on-device execution window). Computed from the orch/sched markers' **device-domain** `ts`+`dur` (the device spans carry a device-clock start offset, not the host emit time). This is the old device-log "Total", now derived purely from the markers — no device log needed. |
 | **Orch** | TMR only: `…device_wall.orch` span — device orchestrator (graph-build) window. |

--- a/docs/dfx/profiling-framework.md
+++ b/docs/dfx/profiling-framework.md
@@ -24,7 +24,7 @@ For everyday per-run timing (no collector, always on under `SIMPLER_HOST_STRACE`
 [l2-timing.md](l2-timing.md) covers host_wall / device_wall (`[STRACE]` markers) +
 device-log Orch/Sched/Total, and [host-trace.md](host-trace.md) +
 [device-phases.md](device-phases.md) cover the `[STRACE]` per-stage
-breakdown of `simpler_run` (host stages + AICPU phase subdivision).
+breakdown of `chip.run` (host stages + AICPU phase subdivision).
 
 ## 1. Why a shared framework
 

--- a/examples/workers/l2/vector_add/test_run_timing.py
+++ b/examples/workers/l2/vector_add/test_run_timing.py
@@ -6,18 +6,18 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Hardware ST asserting simpler_run emits ``[STRACE]`` host-trace markers.
+"""Hardware ST asserting chip.run emits ``[STRACE]`` host-trace markers.
 
 ``Worker.run`` no longer returns a RunTiming — per-stage timing is emitted by
 the platform as ``[STRACE]`` log markers (see docs/dfx/host-trace.md). Reuses
 the vector_add example's kernel + ChipCallable build so this test doesn't drag
 in its own kernel sources. The contract being verified:
 
-    * a real dispatch emits an ``[STRACE] ... name=simpler_run ... dur=<ns>``
+    * a real dispatch emits an ``[STRACE] ... name=chip.run ... dur=<ns>``
       marker (the host wall around the dispatch) with a strictly positive
       duration — there's no way a real run took zero steady-clock time;
     * the device-domain wall marker
-      (``name=simpler_run.runner_run.device_wall``) is present with a positive
+      (``name=chip.run.runner_run.device_wall``) is present with a positive
       duration on the default SIMPLER_HOST_STRACE build.
 
 Markers go to stderr via the unified host logger, captured here with ``capfd``.
@@ -107,17 +107,17 @@ def test_simpler_run_emits_strace_markers(st_platform, st_device_ids, capfd):
     _drive_one_run(st_platform, int(st_device_ids[0]))
     err = capfd.readouterr().err
 
-    # Host wall: the simpler_run root span. A real dispatch can't take 0 ns.
-    host_durs = _strace_durs(err, "simpler_run")
+    # Host wall: the chip.run root span. A real dispatch can't take 0 ns.
+    host_durs = _strace_durs(err, "chip.run")
     assert host_durs, (
-        "no `[STRACE] ... name=simpler_run` marker found on stderr; "
-        "simpler_run stopped emitting host-trace markers (SIMPLER_HOST_STRACE off, "
+        "no `[STRACE] ... name=chip.run` marker found on stderr; "
+        "chip.run stopped emitting host-trace markers (SIMPLER_HOST_STRACE off, "
         "or the host logger TIMING level was suppressed)."
     )
-    assert max(host_durs) > 0, f"simpler_run marker dur must be > 0 ns, got {host_durs}"
+    assert max(host_durs) > 0, f"chip.run marker dur must be > 0 ns, got {host_durs}"
 
     # Device-domain wall: the on-NPU AICPU wall, emitted after readback.
-    dev_durs = _strace_durs(err, "simpler_run.runner_run.device_wall")
+    dev_durs = _strace_durs(err, "chip.run.runner_run.device_wall")
     assert dev_durs, (
         "no device_wall [STRACE] marker found; the AICPU phase buffer readback "
         "or marker emission regressed on the default SIMPLER_HOST_STRACE build."

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -56,6 +56,7 @@
 #include "callable_protocol.h"
 #include "chip_run_lane.h"
 #include "chip_worker.h"
+#include "common/host_span_names.h"
 #include "common/host_span_scope.h"
 #include "host_log.h"
 #include "data_type.h"
@@ -1050,6 +1051,21 @@ NB_MODULE(_task_interface, m) {
             return true;
         },
         nb::arg("level"), "Seed the process-owned host-log state before workers fork or load runtime modules."
+    );
+    m.def(
+        "_set_host_span_level_prefix",
+        [](const std::string &word) {
+            simpler::host_trace::set_level_prefix(word.c_str());
+#if SIMPLER_HOST_STRACE
+            return std::string(simpler::host_trace::level_prefix());
+#else
+            return word;
+#endif
+        },
+        nb::arg("word"),
+        "Bind this process's level word for host-scheduler span names, and return what is now bound. "
+        "Python owns the level -> word mapping (simpler.worker_level); this pushes the resolved word so "
+        "the C++ emit sites and Python agree on one derivation."
     );
     m.def(
         "_emit_host_span",

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -97,6 +97,7 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
     _mailbox_load_i32,
     _mailbox_store_i32,
     _read_control_copy_request,
+    _set_host_span_level_prefix,
     _worker_host_mapped_region_ack_cleanup_error,
     _worker_host_mapped_region_close,
     _worker_host_mapped_region_import_onboard,
@@ -245,6 +246,8 @@ from .worker_chip_orch_comm import (
     peek_region_create_reply_region_id,
     validate_region_create_reply,
 )
+from .worker_level import WorkerLevel
+from .worker_level import span_prefix as _span_prefix
 
 # Upper bound on how long the parent waits for every chip's bootstrap mailbox
 # to leave IDLE.  Well above a realistic HCCL init (seconds) but short enough
@@ -4388,6 +4391,9 @@ class Worker:
         **config,
     ) -> None:
         self.level = level
+        # Rebound from the level in `init()`; the default matches the C++ table's
+        # so a span emitted before init names L3 rather than nothing.
+        self._host_span_prefix = _span_prefix(WorkerLevel.host)
         self._config = config
         self._callable_registry: dict[int, Any] = {}
         self._identity_registry: dict[bytes, _CallableIdentityState] = {}
@@ -7763,6 +7769,13 @@ class Worker:
         chip_log_level = _simpler_log.get_current_config()
         _initialize_host_log(chip_log_level)
 
+        # Bind the level word this process's host-scheduler spans lead with. The
+        # C++ emit sites in Orchestrator / WorkerThread are level-agnostic — the
+        # same code drives next-level children at every level above the chip — so
+        # the word is a property of the process. Resolved once here and pushed, so
+        # there is a single derivation rather than one on each side.
+        self._host_span_prefix = _set_host_span_level_prefix(_span_prefix(self.level))
+
         self._startup_reaped_pids = set()
         self._startup_ready_pids = set()
         self._startup_group_leader_pids = set()
@@ -10918,7 +10931,7 @@ class Worker:
                     finally:
                         graph_end_ns = time.monotonic_ns()
                         _emit_host_span(
-                            "l3.graph_build",
+                            f"{self._host_span_prefix}.graph_build",
                             run_id,
                             0,
                             0,

--- a/python/simpler/worker_level.py
+++ b/python/simpler/worker_level.py
@@ -1,0 +1,72 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""One word per level of the worker hierarchy, and the trace prefix derived from it.
+
+`[STRACE]` span names lead with the level that emitted them, so a reader can tell
+a chip-runtime span from a host-scheduler one without consulting the tree. The
+words live here because the emitting code cannot supply them: `Orchestrator` and
+`WorkerThread` are level-agnostic — the same code runs at every level above the
+chip — so the word is a property of the process, resolved once from its Worker's
+level.
+
+Above `host` the physical layer is not fixed: sometimes a host sits under a pod,
+sometimes directly under a supernode. Naming those levels after a specific
+interconnect does not work either (mostly SU, sometimes RoCE). So they are named
+by how many network hops separate them from the host — `network1` is one hop up,
+whatever hardware implements it. The digit counts hops, not the level number:
+`network1` is L4.
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+__all__ = ["WorkerLevel", "span_prefix"]
+
+
+class WorkerLevel(IntEnum):
+    """A level in the worker hierarchy, named by the role it plays.
+
+    `IntEnum` because `level` is an integer everywhere it is compared
+    (`worker.py` gates on `level >= 3` and `level >= 4`) and is serialized as
+    one. Membership is therefore additive: naming a level here does not
+    constrain any of those comparisons.
+
+    `L1` is absent because no such level exists; the ladder skips from the
+    in-core `core` to the whole-chip `chip`.
+    """
+
+    core = 0
+    chip = 2
+    host = 3
+    network1 = 4
+    network2 = 5
+    network3 = 6
+
+
+def span_prefix(level: int) -> str:
+    """Return the `[STRACE]` name prefix for `level`, e.g. 3 -> ``"host"``.
+
+    Raises `ValueError` for a level the ladder does not name, rather than
+    inventing a word. L5 and L6 run what
+    `docs/hierarchical-level-runtime.md` calls "the local L4 code path" and are
+    untested; when one is first exercised, a missing word should surface as a
+    failure here rather than as spans quietly labelled with the wrong level —
+    which is the defect this prefix exists to fix.
+
+    Note `WorkerLevel(level).name`, not `str(WorkerLevel(level))`: this project
+    targets Python 3.10, where `enum.StrEnum` does not exist and `str()` on any
+    `Enum` yields ``"WorkerLevel.host"``.
+    """
+    try:
+        return WorkerLevel(level).name
+    except ValueError:
+        named = ", ".join(f"{member.value}={member.name}" for member in WorkerLevel)
+        raise ValueError(f"no span prefix for worker level {level}; the ladder names {named}") from None

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -13,7 +13,7 @@ no repo checkout required.
 - **[swimlane_converter](#swimlane_converter)** — perf JSON → Chrome Trace Event (Perfetto)
 - **[sched_overhead_analysis](#sched_overhead_analysis)** — scheduler overhead / Tail OH breakdown
 - **[critical_path](#critical_path)** — chip swimlane critical-path compute/stall analysis
-- **[strace_timing](#strace_timing)** — per-stage `simpler_run` breakdown (host + AICPU phases) from `[STRACE]` log markers → TPOT table, per-round table (`--rounds-table`), nested tree (`--tree`), or Perfetto JSON
+- **[strace_timing](#strace_timing)** — per-stage `chip.run` breakdown (host + AICPU phases) from `[STRACE]` log markers → TPOT table, per-round table (`--rounds-table`), nested tree (`--tree`), or Perfetto JSON
 - **[dump_viewer](#dump_viewer)** — inspect / export args dumps (see [docs/args-dump.md](../../docs/dfx/args-dump.md) for full workflow)
 - **[deps_viewer](#deps_viewer)** — `deps.json` (dep_gen) → text or pan/zoom HTML dependency graph
 
@@ -321,7 +321,7 @@ python -m simpler_setup.tools.strace_timing path/to/log
 # Per-round Host/Device/Orch/Sched table (the benchmark/--rounds N view)
 python -m simpler_setup.tools.strace_timing path/to/log --rounds-table
 
-# Indented nested span tree per callable (simpler_run → bind / runner_run →
+# Indented nested span tree per callable (chip.run → bind / runner_run →
 # device_wall → preamble/config_validate/arena_wire/sm_reset/orch/sched/post_orch)
 python -m simpler_setup.tools.strace_timing path/to/log --tree
 
@@ -334,7 +334,7 @@ python -m simpler_setup.tools.strace_timing path/to/log --swimlane host_swimlane
 ```
 
 Groups spans by `(pid, inv)`, rebuilds each invocation's tree from `depth`,
-buckets by callable hash `hid`, and reports each callable's mean `simpler_run`
+buckets by callable hash `hid`, and reports each callable's mean `chip.run`
 plus per-stage means. It reads the host-emitted `[STRACE]` lines and shows the
 host stages (`bind`/`runner_run`/`validate`) alongside the AICPU phases.
 
@@ -358,7 +358,7 @@ here. Because grouping is per `(pid, inv)`, this captures **L3 multi-round**
 (every chip-child invocation), not just round 0.
 
 `--swimlane` consumes both the `l3.*` scheduler markers and child
-`simpler_run` markers. Host lanes retain their OS pid/tid. Because Chrome Trace
+`chip.run` markers. Host lanes retain their OS pid/tid. Because Chrome Trace
 JSON has one visible timestamp axis, raw device-domain `clk=dev` slices are
 stored in the top-level `unalignedDeviceSpans` array rather than placed beside
 the unrelated host clock and stretching Perfetto into an empty-looking

--- a/simpler_setup/tools/strace_timing.py
+++ b/simpler_setup/tools/strace_timing.py
@@ -14,7 +14,7 @@ markers in ``src/common/log/include/common/strace.h``), gated by the
 compile-time ``SIMPLER_HOST_STRACE`` macro (on by default) and emitted at
 ``LOG_TIMING``. Device-domain phases (AICPU subdivision of the on-NPU wall)
 are emitted by the host after readback as ``clk=dev`` spans nested under
-``simpler_run.runner_run.device_wall``.
+``chip.run.runner_run.device_wall``.
 
 Runtimes emit only the device spans they implement. Both current runtimes emit
 ``device_wall``; the finer orch/sched phase subdivision is TMR-specific.
@@ -35,7 +35,7 @@ Grouping:
       guessing): a span at depth d is a child of the most recent span at d-1.
 
 Outputs:
-    * a per-callable TPOT table (each invocation's simpler_run dur + the mean
+    * a per-callable TPOT table (each invocation's chip.run dur + the mean
       of each sub-stage across invocations), and
     * optionally a Chrome-trace / Perfetto JSON (``--trace-out``): one ``ph:"X"``
       event per span on a synthetic per-invocation lane, so each host call tree
@@ -172,7 +172,7 @@ class Invocation:
     spans: list = field(default_factory=list)
 
     def root(self):
-        """The depth-0 span (simpler_run), or None if absent."""
+        """The depth-0 span (chip.run), or None if absent."""
         for s in self.spans:
             if s.depth == 0:
                 return s
@@ -251,18 +251,75 @@ def _trace_document(events, anchors_by_pid, **extra):
     return document
 
 
-def legacy_spans(spans):
-    """Return spans belonging to the established ``simpler_run`` views.
+# A span name leads with the word for the level that produced it. The words come
+# from `simpler.worker_level.WorkerLevel`; this parser cannot import the runtime
+# package, so it carries the list and the unit tests pin the two together.
+_CHIP_WORD = "chip"
+_CORE_WORD = "core"
+_HOST_WORDS = ("host", "network1", "network2", "network3")
 
-    Other marker families share the STRACE grammar but answer a different
-    question, and the invocation views are keyed on ``(pid, inv)`` — a family
-    that carries no invocation id would group into one bogus lane. Keeping them
-    out here preserves the TPOT, rounds, tree, and ``--trace-out`` contracts for
-    every consumer at once; filtering downstream covers only the view that
-    filters. Existing families such as ``simpler_prewarm`` keep their old
-    behavior.
+# Reserved for producers outside simpler: `ext.<producer>.<span>`. Without a
+# reserved word a caller's span called `host.foo` would parse as one of ours.
+_EXTERNAL_WORD = "ext"
+
+# Spellings simpler no longer emits, mapped to the family they used to name.
+# Kept so an archived log stays readable — the same reason `_STRACE_RE` still
+# accepts the wall-clock record prefix. Note this restores the tree, swimlane and
+# invocation views on an old log, not `_ROUNDS_TABLE_NAMES`: that table is a
+# single-spelling contract with pypto.
+_RETIRED_WORDS = {"simpler_run": _CHIP_WORD, "simpler_prewarm": _CHIP_WORD, "l3": _HOST_WORDS[0]}
+
+
+def span_family(name):
+    """Classify `name` by the producer its leading word names.
+
+    Returns ``"chip"``, ``"core"``, ``"host"``, ``"external"``, or ``"unknown"``.
+    Every level at or above L3 answers ``"host"``: they run the same
+    orchestrator and scheduler code, so they form one family whichever word a
+    given process resolved to.
     """
-    return [span for span in spans if not span.name.startswith("l3.")]
+    head = name.split(".", 1)[0]
+    head = _RETIRED_WORDS.get(head, head)
+    if head == _EXTERNAL_WORD:
+        return "external"
+    if head == _CHIP_WORD:
+        return "chip"
+    if head == _CORE_WORD:
+        return "core"
+    if head in _HOST_WORDS:
+        return "host"
+    return "unknown"
+
+
+def host_span_leaf(name):
+    """The part of a host-family span name after its level word, else ``None``.
+
+    Call sites match on the leaf rather than the whole name because the level
+    word varies by the process that emitted it — ``host.submit`` from an L3 and
+    ``network1.submit`` from an L4 are the same decision point.
+    """
+    if span_family(name) != "host":
+        return None
+    _, _, leaf = name.partition(".")
+    return leaf
+
+
+def legacy_spans(spans):
+    """Return the spans the invocation-keyed views may consume.
+
+    The invocation views key on ``(pid, inv)``, so a family carrying no
+    invocation id would group into one bogus lane. Excluded: the per-task
+    ``host``/``network*`` scheduler family, and anything an external producer
+    emitted under ``ext.``. Everything else is kept, including a name this
+    parser does not recognize — dropping an unfamiliar family silently is how
+    ``chip.prewarm.build`` once vanished from the tables.
+
+    The name is retained deliberately. pypto calls this through
+    ``hasattr(_strace_timing, "legacy_spans")`` and falls back to its own
+    ``l3.``-prefix filter when it is absent, so renaming it would silently
+    re-arm that stale fallback in a downstream repository.
+    """
+    return [span for span in spans if span_family(span.name) not in ("host", "external")]
 
 
 def group_invocations(spans):
@@ -290,10 +347,10 @@ def bucket_by_hid(invocations):
 
 
 # The spans one native run contributes to the overlap proof. All three already
-# exist in the `simpler_run` tree; only `claim_release` was added for it.
-_PREPARE_SPAN = "simpler_run.bind"
-_DEVICE_SPAN = "simpler_run.runner_run"
-_RELEASE_SPAN = "simpler_run.claim_release"
+# exist in the `chip.run` tree; only `claim_release` was added for it.
+_PREPARE_SPAN = "chip.run.bind"
+_DEVICE_SPAN = "chip.run.runner_run"
+_RELEASE_SPAN = "chip.run.claim_release"
 _NATIVE_REQUIRED_SPANS = (_PREPARE_SPAN, _DEVICE_SPAN, _RELEASE_SPAN)
 _PIPELINE_IDENTITY_FIELDS = ("run_id", "dispatch_id", "run_epoch", "slot_id", "generation")
 
@@ -301,7 +358,7 @@ _PIPELINE_IDENTITY_FIELDS = ("run_id", "dispatch_id", "run_epoch", "slot_id", "g
 def _native_dispatches(invocations):
     """Map each native run's identity to its ``{span name: span}``.
 
-    The identity rides on the root ``simpler_run`` span, and every sub-span of
+    The identity rides on the root ``chip.run`` span, and every sub-span of
     that run shares its ``(pid, inv)`` — so grouping by invocation is what joins
     the windows to the identity. An invocation whose root carries no identity is
     not a phased native run and is skipped.
@@ -438,8 +495,7 @@ def print_tpot_table(buckets, label_for_hid=None, stream=sys.stdout):
         durs = [r.dur for r in roots]
         if durs:
             print(
-                f"  simpler_run: mean={_fmt_us(int(_mean(durs)))}us "
-                f"min={_fmt_us(min(durs))}us max={_fmt_us(max(durs))}us",
+                f"  chip.run: mean={_fmt_us(int(_mean(durs)))}us min={_fmt_us(min(durs))}us max={_fmt_us(max(durs))}us",
                 file=stream,
             )
 
@@ -458,10 +514,10 @@ def print_tpot_table(buckets, label_for_hid=None, stream=sys.stdout):
 
 
 _ROUNDS_TABLE_NAMES = {
-    "host": "simpler_run",
-    "device": "simpler_run.runner_run.device_wall",
-    "orch": "simpler_run.runner_run.device_wall.orch",
-    "sched": "simpler_run.runner_run.device_wall.sched",
+    "host": "chip.run",
+    "device": "chip.run.runner_run.device_wall",
+    "orch": "chip.run.runner_run.device_wall.orch",
+    "sched": "chip.run.runner_run.device_wall.sched",
 }
 
 # Per-round table columns, in print order. "Effective" is the orch∪sched merged
@@ -657,8 +713,8 @@ def _parsed_attrs(span):
 
 # Highest-precedence match wins. One OS thread emits spans of several roles: the
 # scheduler loop is the sole caller of both `dispatch_ready` and
-# `manager->progress`, so it emits `l3.dispatch` (role=scheduler) alongside
-# `l3.frame_submit` / `l3.activate` / `l3.complete`, whose `role=worker` names
+# `manager->progress`, so it emits `host.dispatch` (role=scheduler) alongside
+# `host.frame_submit` / `host.activate` / `host.complete`, whose `role=worker` names
 # the worker a dispatch targets rather than the thread doing the work.
 _HOST_THREAD_ROLES = ("facade", "scheduler", "worker")
 
@@ -720,11 +776,12 @@ def _host_thread_name(entries):
     worker_ids = set()
     for span, attrs in entries:
         role = attrs.get("role")
-        if role == "facade" or span.name in {"l3.graph_build", "l3.submit"}:
+        leaf = host_span_leaf(span.name)
+        if role == "facade" or leaf in {"graph_build", "submit"}:
             roles.add("facade")
         elif role in ("scheduler", "worker"):
             roles.add(role)
-        elif span.name.startswith("l3."):
+        elif leaf is not None:
             roles.add("worker")
         if role == "worker":
             worker_ids.add(attrs.get("worker_id"))
@@ -739,7 +796,7 @@ def _host_thread_name(entries):
         worker_id = worker_ids.pop() if len(worker_ids) == 1 else None
         return f"worker {worker_id}" if worker_id is not None else "worker"
 
-    if any(span.name == "simpler_run" or span.name.startswith("simpler_run.") for span, _ in entries):
+    if any(span_family(span.name) == "chip" for span, _ in entries):
         return "chip child"
     return f"tid {entries[0][0].tid}"
 
@@ -832,7 +889,7 @@ def host_record_spans(spans, passes):
     """Turn phase records into spans nested under their pass's ``bind``.
 
     A record carries only ``(pid, inv)`` and a host-clock interval; the thread and
-    the tree position come from the ``simpler_run.bind`` span of the same
+    the tree position come from the ``chip.run.bind`` span of the same
     invocation, which is the stage the records subdivide. Records whose pass has
     no such span are dropped — without it there is no lane to draw them on and no
     parent to nest them under.
@@ -846,9 +903,7 @@ def host_record_spans(spans, passes):
     the ``(pid, inv)`` keys the artifact covered — a caller uses the last to avoid
     drawing the same segment twice from the log lines as well.
     """
-    bind_by_key = {
-        (span.pid, span.inv): span for span in spans if span.name == "simpler_run.bind" and not span.is_device
-    }
+    bind_by_key = {(span.pid, span.inv): span for span in spans if span.name == _PREPARE_SPAN and not span.is_device}
     out = []
     dropped_passes = 0
     covered_keys = set()
@@ -866,11 +921,11 @@ def host_record_spans(spans, passes):
             except (KeyError, TypeError, ValueError):
                 continue
             if phase in _BIND_PHASE_NAMES:
-                name = f"simpler_run.bind.{phase}"
+                name = f"{_PREPARE_SPAN}.{phase}"
                 depth = parent.depth + 1
                 covered_keys.add(key)
             else:
-                name = f"simpler_run.bind.host_orch.{phase}"
+                name = f"{_PREPARE_SPAN}.host_orch.{phase}"
                 depth = parent.depth + 2
             out.append(
                 Span(
@@ -891,20 +946,20 @@ def host_record_spans(spans, passes):
 def bind_phase_spans(text, spans, skip_keys=frozenset()):
     """Recover `bind phase=` timing lines as spans nested under their ``bind``.
 
-    Without these the swimlane draws ``simpler_run.bind`` as one empty bar, which
+    Without these the swimlane draws ``chip.run.bind`` as one empty bar, which
     for a runtime with a host prepare path is most of the trace: on a 40-layer
     qwen decode the stage is seconds of tensor staging and host-view teardown,
     while the orchestration inside it is around a millisecond. The per-event
     records then land in well under a pixel with nothing to indicate where to zoom.
 
     The line carries its own ``start_ns``. The owning invocation is whichever
-    ``simpler_run.bind`` of that thread contains the interval; a phase outside
+    ``chip.run.bind`` of that thread contains the interval; a phase outside
     every bind is dropped rather than guessed at.
 
     ``skip_keys`` holds the ``(pid, inv)`` a record artifact already covered, so
     the same segment is not drawn twice when both channels are present.
     """
-    binds = [span for span in spans if span.name == "simpler_run.bind" and not span.is_device]
+    binds = [span for span in spans if span.name == _PREPARE_SPAN and not span.is_device]
     out = []
     for match in _BIND_PHASE_RE.finditer(text):
         start = int(match["start"])
@@ -925,7 +980,7 @@ def bind_phase_spans(text, spans, skip_keys=frozenset()):
                 inv=parent.inv,
                 hid=parent.hid,
                 depth=parent.depth + 1,
-                name=f"simpler_run.bind.{match['phase']}",
+                name=f"{_PREPARE_SPAN}.{match['phase']}",
                 ts=start,
                 dur=dur,
                 attrs=f"{match['attrs'].strip()} log_thread=0x{match['tid_hex']} src=bind_phase".strip(),
@@ -960,7 +1015,7 @@ def to_host_swimlane(spans, anchors=None):
 
     for pid in host_pids:
         process_spans = [span for span, _ in host_entries if span.pid == pid]
-        role = "host" if any(span.name.startswith("l3.") for span in process_spans) else "chip child"
+        role = "host" if any(span_family(span.name) == "host" for span in process_spans) else "chip child"
         events.append(
             {
                 "ph": "M",
@@ -1004,7 +1059,7 @@ def to_host_swimlane(spans, anchors=None):
 
     submits = defaultdict(list)
     for span, attrs in host_entries:
-        if span.name != "l3.submit":
+        if host_span_leaf(span.name) != "submit":
             continue
         key = _flow_key(span, attrs)
         if key is not None:
@@ -1014,7 +1069,7 @@ def to_host_swimlane(spans, anchors=None):
 
     dispatches = []
     for span, attrs in host_entries:
-        if span.name != "l3.dispatch":
+        if host_span_leaf(span.name) != "dispatch":
             continue
         key = _flow_key(span, attrs)
         source = None
@@ -1086,7 +1141,7 @@ def to_host_swimlane(spans, anchors=None):
 
 def _print_agg_tree(invs, stream=sys.stdout):
     """Print a callable's spans as a nested tree built from the dotted span
-    names (so e.g. ``simpler_run.bind.args`` nests under ``simpler_run.bind``),
+    names (so e.g. ``chip.run.bind.args`` nests under ``chip.run.bind``),
     NOT from depth+ts — host (steady_clock) and device (``clk=dev``) spans live
     on different clocks, so timestamp containment across domains is meaningless;
     the dotted name is the unambiguous parent link. Device spans are tagged
@@ -1196,7 +1251,7 @@ def write_host_swimlane(args, spans, lines, anchors):
         record_count = len(extra)
         if orphaned:
             print(
-                f"warning: {orphaned} phase-record pass(es) had no matching simpler_run.bind span "
+                f"warning: {orphaned} phase-record pass(es) had no matching chip.run.bind span "
                 "in this log and were dropped — is the log from the same run as the artifact?",
                 file=sys.stderr,
             )
@@ -1233,7 +1288,7 @@ def main(argv=None):
         action="append",
         metavar="PATH",
         help="a host_phase_records.jsonl from the same run; its per-event bind segments and "
-        "orchestrator operations are drawn inside the matching simpler_run.bind. Repeatable. Only "
+        "orchestrator operations are drawn inside the matching chip.run.bind. Repeatable. Only "
         "affects --swimlane, because the summed host-orch timing lines are cost shares and cannot "
         "be placed on a timeline",
     )

--- a/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
@@ -234,7 +234,7 @@ Thread X:   overlap checks : XXX, hits=XXX (XX.X%)
 
 ## Prepare-Path Timing: One Pool, Three Views
 
-`host_build_graph` times its prepare path — the `simpler_run.bind` stage's
+`host_build_graph` times its prepare path — the `chip.run.bind` stage's
 segments, and the host orchestrator's submit-level operations inside it. One
 recorder feeds three views, and two independent switches decide which of them
 appear.
@@ -295,7 +295,7 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
   the `[STRACE]` tree groups by — and one record per operation. This is the
   channel to read for a distribution or a per-event timeline; the summed lines
   cannot express either. `strace_timing.py --swimlane --host-phase-records <path>`
-  draws each record inside the matching `simpler_run.bind`.
+  draws each record inside the matching `chip.run.bind`.
 
 - **The host lanes of `chip_swimlane_records.json`**, at level 4 only, joined to
   the device timeline through the clock anchors (see `host/clock_correlation.h`).
@@ -314,7 +314,7 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
   against `recorded_records` (the submit projection), plus `pool_records` for the
   whole population — a pool count above the projection is normal, not incomplete.
 
-The stage's *duration* is already published as the `simpler_run.bind` `[STRACE]`
+The stage's *duration* is already published as the `chip.run.bind` `[STRACE]`
 marker, so the marker and this breakdown are a total and its parts rather than two
 spellings of one number. The parts are not markers themselves: the marker grammar
 is the platform's public per-run-stage contract (see `pto_runtime_c_api.h` and

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -775,7 +775,7 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
  * is already populated by register_callable_impl.
  *
  * Splitting this from register_callable_impl matches the per-callable_id
- * design: register/run_prepared invokes this every call, while the prep
+ * design: register/simpler_run invokes this every call, while the prep
  * half runs only once per callable_id.
  *
  * @param runtime    Pointer to the per-run Runtime

--- a/src/a2a3/runtime/host_build_graph/runtime/host_phase_trace.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/host_phase_trace.h
@@ -29,7 +29,7 @@
  *     host/host_phase_records.h); this runtime holds only the pool pointer.
  *
  * Timestamps are host monotonic nanoseconds — the clock the `[STRACE]` host
- * spans use — so records nest inside `simpler_run.bind` with no alignment step
+ * spans use — so records nest inside `chip.run.bind` with no alignment step
  * and share the enclosing run's (pid, inv) identity.
  */
 
@@ -43,7 +43,7 @@
  * collects them with the level at 0.
  *
  * "Breakdown" rather than "timing" because the bind stage's *duration* is
- * already published as the `simpler_run.bind` `[STRACE]` marker; what this adds
+ * already published as the `chip.run.bind` `[STRACE]` marker; what this adds
  * is the division of that one number into its parts.
  */
 bool host_phase_timing_enabled();

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -192,7 +192,7 @@ static uint32_t g_orch_submit_idx = 0;
 __attribute__((weak, visibility("hidden"))) void host_phase_record(uint64_t, uint64_t, uint32_t, uint64_t, uint32_t) {}
 
 // Host monotonic clock shared with the `[STRACE]` span tree, so a record nests
-// under simpler_run.bind.host_orch without any clock conversion. The host build
+// under chip.run.bind.host_orch without any clock conversion. The host build
 // links the strong definition in host_phase_trace.cpp; this fallback keeps
 // non-host builds linking, where the recorder above is a no-op anyway.
 __attribute__((weak, visibility("hidden"))) uint64_t host_phase_now_ns() { return 0; }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -580,7 +580,7 @@ static bool stage_device_args(
     int scalar_count = orch_args->scalar_count();
 
     int64_t t_args_start = _now_ms();
-    STRACE_A("simpler_run.bind.args", "");
+    STRACE_A("chip.run.bind.args", "");
     for (int i = 0; i < tensor_count; i++) {
         ChipTensor t = orch_args->tensor(i);
 
@@ -911,7 +911,7 @@ extern "C" int bind_callable_to_runtime_impl(
 
     int64_t t_prebuilt_start = _now_ms();
     {
-        STRACE("simpler_run.bind.prebuilt");
+        STRACE("chip.run.bind.prebuilt");
         PrebuiltRuntimeArenaCacheProbe cache_probe = make_prebuilt_runtime_arena_cache_probe(sizing);
         int cache_rc = bind_cached_runtime_image(runtime, api, cache_probe, device_args);
         if (cache_rc < 0) {
@@ -968,7 +968,7 @@ extern "C" int prewarm_config_impl(
         return -1;
     }
 
-    STRACE("simpler_prewarm.build");
+    STRACE("chip.prewarm.build");
     return build_and_cache_prebuilt_arena(api, sizing) ? 0 : -1;
 }
 

--- a/src/a5/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a5/runtime/host_build_graph/docs/profiling_levels.md
@@ -234,7 +234,7 @@ Thread X:   overlap checks : XXX, hits=XXX (XX.X%)
 
 ## Prepare-Path Timing: One Pool, Three Views
 
-`host_build_graph` times its prepare path — the `simpler_run.bind` stage's
+`host_build_graph` times its prepare path — the `chip.run.bind` stage's
 segments, and the host orchestrator's submit-level operations inside it. One
 recorder feeds three views, and two independent switches decide which of them
 appear.
@@ -295,7 +295,7 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
   the `[STRACE]` tree groups by — and one record per operation. This is the
   channel to read for a distribution or a per-event timeline; the summed lines
   cannot express either. `strace_timing.py --swimlane --host-phase-records <path>`
-  draws each record inside the matching `simpler_run.bind`.
+  draws each record inside the matching `chip.run.bind`.
 
 - **The host lanes of `chip_swimlane_records.json`**, at level 4 only, joined to
   the device timeline through the clock anchors (see `host/clock_correlation.h`).
@@ -314,7 +314,7 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
   against `recorded_records` (the submit projection), plus `pool_records` for the
   whole population — a pool count above the projection is normal, not incomplete.
 
-The stage's *duration* is already published as the `simpler_run.bind` `[STRACE]`
+The stage's *duration* is already published as the `chip.run.bind` `[STRACE]`
 marker, so the marker and this breakdown are a total and its parts rather than two
 spellings of one number. The parts are not markers themselves: the marker grammar
 is the platform's public per-run-stage contract (see `pto_runtime_c_api.h` and

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -831,7 +831,7 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
  * is already populated by register_callable_impl.
  *
  * Splitting this from register_callable_impl matches the per-callable_id
- * design: register/run_prepared invokes this every call, while the prep
+ * design: register/simpler_run invokes this every call, while the prep
  * half runs only once per callable_id.
  *
  * @param runtime    Pointer to the per-run Runtime

--- a/src/a5/runtime/host_build_graph/runtime/host_phase_trace.h
+++ b/src/a5/runtime/host_build_graph/runtime/host_phase_trace.h
@@ -29,7 +29,7 @@
  *     host/host_phase_records.h); this runtime holds only the pool pointer.
  *
  * Timestamps are host monotonic nanoseconds — the clock the `[STRACE]` host
- * spans use — so records nest inside `simpler_run.bind` with no alignment step
+ * spans use — so records nest inside `chip.run.bind` with no alignment step
  * and share the enclosing run's (pid, inv) identity.
  */
 
@@ -43,7 +43,7 @@
  * collects them with the level at 0.
  *
  * "Breakdown" rather than "timing" because the bind stage's *duration* is
- * already published as the `simpler_run.bind` `[STRACE]` marker; what this adds
+ * already published as the `chip.run.bind` `[STRACE]` marker; what this adds
  * is the division of that one number into its parts.
  */
 bool host_phase_timing_enabled();

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -192,7 +192,7 @@ static uint32_t g_orch_submit_idx = 0;
 __attribute__((weak, visibility("hidden"))) void host_phase_record(uint64_t, uint64_t, uint32_t, uint64_t, uint32_t) {}
 
 // Host monotonic clock shared with the `[STRACE]` span tree, so a record nests
-// under simpler_run.bind.host_orch without any clock conversion. The host build
+// under chip.run.bind.host_orch without any clock conversion. The host build
 // links the strong definition in host_phase_trace.cpp; this fallback keeps
 // non-host builds linking, where the recorder above is a no-op anyway.
 __attribute__((weak, visibility("hidden"))) uint64_t host_phase_now_ns() { return 0; }

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -580,7 +580,7 @@ static bool stage_device_args(
     int scalar_count = orch_args->scalar_count();
 
     int64_t t_args_start = _now_ms();
-    STRACE_A("simpler_run.bind.args", "");
+    STRACE_A("chip.run.bind.args", "");
     for (int i = 0; i < tensor_count; i++) {
         ChipTensor t = orch_args->tensor(i);
 
@@ -911,7 +911,7 @@ extern "C" int bind_callable_to_runtime_impl(
 
     int64_t t_prebuilt_start = _now_ms();
     {
-        STRACE("simpler_run.bind.prebuilt");
+        STRACE("chip.run.bind.prebuilt");
         PrebuiltRuntimeArenaCacheProbe cache_probe = make_prebuilt_runtime_arena_cache_probe(sizing);
         int cache_rc = bind_cached_runtime_image(runtime, api, cache_probe, device_args);
         if (cache_rc < 0) {
@@ -968,7 +968,7 @@ extern "C" int prewarm_config_impl(
         return -1;
     }
 
-    STRACE("simpler_prewarm.build");
+    STRACE("chip.prewarm.build");
     return build_and_cache_prebuilt_arena(api, sizing) ? 0 : -1;
 }
 

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -21,6 +21,7 @@
 #include <stdexcept>
 #include <unordered_set>
 
+#include "common/host_span_names.h"
 #include "common/host_span_scope.h"
 #include "worker_manager.h"
 
@@ -377,8 +378,8 @@ void Orchestrator::release_run(RunId run_id) {
     retire_attrs << "run_id=" << run_id << " slot_id=" << lease.slot_id << " generation=" << lease.generation
                  << " role=facade";
     simpler::host_trace::emit(
-        "l3.post_fence_retirement", run_id, 0, 0, terminal_ns, simpler::host_trace::now_ns() - terminal_ns,
-        retire_attrs.str().c_str()
+        simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::PostFenceRetirement), run_id, 0, 0,
+        terminal_ns, simpler::host_trace::now_ns() - terminal_ns, retire_attrs.str().c_str()
     );
 #endif
 }
@@ -739,7 +740,10 @@ SubmitResult Orchestrator::submit_impl(
                     << " group_index=" << (args_list.size() == 1 ? 0 : -1) << " group_size=" << args_list.size();
         if (target_worker_ids.size() == 1) trace_attrs << " worker_id=" << target_worker_ids.front();
         trace_attrs << " role=facade";
-        submit_trace.emplace("l3.submit", run->id, trace_callable_hash, 0, trace_attrs.str());
+        submit_trace.emplace(
+            simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::Submit), run->id, trace_callable_hash, 0,
+            trace_attrs.str()
+        );
     }
 #endif
 

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -157,7 +157,7 @@ struct RunState {
     bool submission_closed{false};
     bool submission_failed{false};
     bool lease_released{false};
-    // When this run reached a terminal phase. `l3.post_fence_retirement`
+    // When this run reached a terminal phase. `host.post_fence_retirement`
     // measures from here to the end of release_run, which is the only host cost
     // that falls outside every other span.
     int64_t trace_terminal_ns{0};

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -29,6 +29,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/host_span_names.h"
 #include "common/host_span_scope.h"
 #include "ring.h"
 
@@ -479,7 +480,8 @@ WorkerThread::submit_dispatch(WorkerDispatch d, LaneKind lane_kind, RunId expect
     const int64_t trace_end_ns = simpler::host_trace::now_ns();
     const std::string trace_attrs = trace_dispatch_attrs(trace_run, d, endpoint_->caps(), "scheduler") + trace_lease;
     simpler::host_trace::emit(
-        "l3.dispatch", trace_run, trace_hash, 0, trace_start_ns, trace_end_ns - trace_start_ns, trace_attrs.c_str()
+        simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::Dispatch), trace_run, trace_hash, 0,
+        trace_start_ns, trace_end_ns - trace_start_ns, trace_attrs.c_str()
     );
 #endif
     return SubmitDispatchResult::SUBMITTED;
@@ -671,7 +673,10 @@ void WorkerThread::finish_progress_dispatch(const WorkerEndpointProgress &progre
 
 #if SIMPLER_HOST_STRACE
     complete_attrs += " outcome=" + std::to_string(static_cast<int32_t>(completion.outcome));
-    simpler::host_trace::SpanScope complete_trace("l3.complete", trace_run, trace_hash, 0, std::move(complete_attrs));
+    simpler::host_trace::SpanScope complete_trace(
+        simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::Complete), trace_run, trace_hash, 0,
+        std::move(complete_attrs)
+    );
 #endif
     on_complete_(std::move(completion));
     {
@@ -718,8 +723,8 @@ void LocalMailboxEndpoint::submit_progress(Ring *ring, const WorkerDispatch &dis
 
 #if SIMPLER_HOST_STRACE
     simpler::host_trace::SpanScope frame_submit_trace(
-        "l3.frame_submit", state.run_id, trace_callable_hash(ring, dispatch.task_slot), 0,
-        trace_dispatch_attrs(state.run_id, dispatch, caps_, "worker")
+        simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::FrameSubmit), state.run_id,
+        trace_callable_hash(ring, dispatch.task_slot), 0, trace_dispatch_attrs(state.run_id, dispatch, caps_, "worker")
     );
 #endif
 
@@ -987,7 +992,10 @@ bool LocalMailboxEndpoint::activate_progress(RunId run_id) {
                        << " dispatch_id=" << record.dispatch.dispatch_id
                        << " endpoint_kind=" << endpoint_kind_name(caps_.kind)
                        << " prepare_only=" << static_cast<int>(record.dispatch.prepare_only) << " role=worker";
-        simpler::host_trace::SpanScope activate_trace("l3.activate", run_id, 0, 0, activate_attrs.str());
+        simpler::host_trace::SpanScope activate_trace(
+            simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::Activate), run_id, 0, 0,
+            activate_attrs.str()
+        );
 #endif
         record.activation_requested = true;
         char *frame = task_frame(index);

--- a/src/common/log/include/common/host_span_names.h
+++ b/src/common/log/include/common/host_span_names.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file host_span_names.h
+ * @brief Full `[STRACE]` names for the host-scheduler span family.
+ *
+ * `Orchestrator` and `WorkerThread` are level-agnostic — the same code drives
+ * next-level children at every level above the chip — so the level word in
+ * their span names is a property of the process, not of the call site. Python
+ * resolves it once from the Worker's level (`simpler.worker_level.span_prefix`)
+ * and pushes it here during init.
+ *
+ * The names are materialized at that point rather than per span: `SpanScope`
+ * keeps the `const char *` it was given and dereferences it in its destructor,
+ * so a name must outlive every scope that uses it, and building one per span
+ * would allocate on the dispatch path.
+ */
+
+#pragma once
+
+#include "profiling_config.h"
+
+#if SIMPLER_HOST_STRACE
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+namespace simpler::host_trace {
+
+/// The host-scheduler family. One entry per span the orchestrator or a worker
+/// thread emits; `kCount` sizes the resolved table.
+enum class HostSpan : size_t {
+    GraphBuild = 0,
+    Submit,
+    Dispatch,
+    FrameSubmit,
+    Activate,
+    Complete,
+    PostFenceRetirement,
+    kCount,
+};
+
+namespace detail {
+
+inline constexpr std::array<const char *, static_cast<size_t>(HostSpan::kCount)> kHostSpanSuffixes = {
+    ".graph_build", ".submit", ".dispatch", ".frame_submit", ".activate", ".complete", ".post_fence_retirement",
+};
+
+/// The bound level word. Defaults to `host`: L3 is the only level that has ever
+/// driven this code in a shipped configuration, so an unset prefix names the
+/// truth rather than an arbitrary placeholder.
+inline std::string &level_word() {
+    static std::string word = "host";
+    return word;
+}
+
+/// Resolved names, owned for the process's lifetime so `c_str()` outlives every
+/// `SpanScope`.
+inline std::array<std::string, static_cast<size_t>(HostSpan::kCount)> &host_span_table() {
+    static std::array<std::string, static_cast<size_t>(HostSpan::kCount)> table = [] {
+        std::array<std::string, static_cast<size_t>(HostSpan::kCount)> initial;
+        for (size_t i = 0; i < initial.size(); ++i) {
+            initial[i] = level_word() + kHostSpanSuffixes[i];
+        }
+        return initial;
+    }();
+    return table;
+}
+
+}  // namespace detail
+
+/**
+ * Bind this process's level word, e.g. `"host"` or `"network1"`.
+ *
+ * Called once during Worker init, before any worker thread starts and before
+ * the first span — the table is then read-only, which is why it needs no lock.
+ * A null or empty word leaves the default in place.
+ */
+inline void set_level_prefix(const char *word) {
+    if (word == nullptr || *word == '\0') return;
+    detail::level_word() = word;
+    auto &table = detail::host_span_table();
+    for (size_t i = 0; i < table.size(); ++i) {
+        table[i] = detail::level_word() + detail::kHostSpanSuffixes[i];
+    }
+}
+
+/// The level word currently bound, for a caller that must agree with it.
+inline const char *level_prefix() { return detail::level_word().c_str(); }
+
+/// Full dotted name for `which`, stable for the process's lifetime.
+inline const char *host_span_name(HostSpan which) {
+    return detail::host_span_table()[static_cast<size_t>(which)].c_str();
+}
+
+}  // namespace simpler::host_trace
+
+#else
+
+namespace simpler::host_trace {
+
+inline void set_level_prefix(const char *) noexcept {}
+
+}  // namespace simpler::host_trace
+
+#endif  // SIMPLER_HOST_STRACE

--- a/src/common/platform/include/common/chip_swimlane_profiling.h
+++ b/src/common/platform/include/common/chip_swimlane_profiling.h
@@ -639,7 +639,7 @@ static_assert(sizeof(HostPhaseRecord) == 32, "HostPhaseRecord layout drift");
  * What one HostPhaseRecord measured.
  *
  * The bind kinds partition the bind stage: their durations sum to the
- * `simpler_run.bind` span. The orchestrator kinds are nested inside BindHostOrch
+ * `chip.run.bind` span. The orchestrator kinds are nested inside BindHostOrch
  * and do not partition it — some are sub-operations of others.
  */
 enum class HostPhaseKind : uint32_t {

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -528,22 +528,22 @@ static void emit_device_phase_markers(DeviceRunnerBase *runner) {
     if (!device_phase_capture_enabled()) return;
     const uint64_t run_wall_ns = runner->last_device_phase_ns(AicpuPhase::RunWall);
     if (run_wall_ns != 0) {
-        STRACE_DEV_SPAN_AT("simpler_run.runner_run.device_wall", 0, static_cast<long long>(run_wall_ns), 2);
+        STRACE_DEV_SPAN_AT("chip.run.runner_run.device_wall", 0, static_cast<long long>(run_wall_ns), 2);
     }
     struct PhaseName {
         AicpuPhase phase;
         const char *name;
     };
     static const PhaseName kPhases[] = {
-        {AicpuPhase::Preamble, "simpler_run.runner_run.device_wall.preamble"},
-        {AicpuPhase::SoLoad, "simpler_run.runner_run.device_wall.so_load"},
-        {AicpuPhase::GraphBuild, "simpler_run.runner_run.device_wall.graph_build"},
-        {AicpuPhase::ConfigValidate, "simpler_run.runner_run.device_wall.config_validate"},
-        {AicpuPhase::ArenaWire, "simpler_run.runner_run.device_wall.arena_wire"},
-        {AicpuPhase::SmReset, "simpler_run.runner_run.device_wall.sm_reset"},
-        {AicpuPhase::PostOrch, "simpler_run.runner_run.device_wall.post_orch"},
-        {AicpuPhase::OrchWindow, "simpler_run.runner_run.device_wall.orch"},
-        {AicpuPhase::SchedWindow, "simpler_run.runner_run.device_wall.sched"},
+        {AicpuPhase::Preamble, "chip.run.runner_run.device_wall.preamble"},
+        {AicpuPhase::SoLoad, "chip.run.runner_run.device_wall.so_load"},
+        {AicpuPhase::GraphBuild, "chip.run.runner_run.device_wall.graph_build"},
+        {AicpuPhase::ConfigValidate, "chip.run.runner_run.device_wall.config_validate"},
+        {AicpuPhase::ArenaWire, "chip.run.runner_run.device_wall.arena_wire"},
+        {AicpuPhase::SmReset, "chip.run.runner_run.device_wall.sm_reset"},
+        {AicpuPhase::PostOrch, "chip.run.runner_run.device_wall.post_orch"},
+        {AicpuPhase::OrchWindow, "chip.run.runner_run.device_wall.orch"},
+        {AicpuPhase::SchedWindow, "chip.run.runner_run.device_wall.sched"},
     };
     // RunWall is emitted above as device_wall; every other phase is in the table.
     static_assert(
@@ -565,14 +565,14 @@ static void emit_device_phase_markers(DeviceRunnerBase *runner) {
     // intervals (e.g. finish(slot_1) - dispatch(slot_0)) stay recoverable.
     // Untagged / incomplete slots read back 0/0 and are skipped.
     static const char *const kTaskSlotNames[NUM_TASK_TIMING_SLOTS] = {
-        "simpler_run.runner_run.device_wall.task_slot_0",  "simpler_run.runner_run.device_wall.task_slot_1",
-        "simpler_run.runner_run.device_wall.task_slot_2",  "simpler_run.runner_run.device_wall.task_slot_3",
-        "simpler_run.runner_run.device_wall.task_slot_4",  "simpler_run.runner_run.device_wall.task_slot_5",
-        "simpler_run.runner_run.device_wall.task_slot_6",  "simpler_run.runner_run.device_wall.task_slot_7",
-        "simpler_run.runner_run.device_wall.task_slot_8",  "simpler_run.runner_run.device_wall.task_slot_9",
-        "simpler_run.runner_run.device_wall.task_slot_10", "simpler_run.runner_run.device_wall.task_slot_11",
-        "simpler_run.runner_run.device_wall.task_slot_12", "simpler_run.runner_run.device_wall.task_slot_13",
-        "simpler_run.runner_run.device_wall.task_slot_14", "simpler_run.runner_run.device_wall.task_slot_15",
+        "chip.run.runner_run.device_wall.task_slot_0",  "chip.run.runner_run.device_wall.task_slot_1",
+        "chip.run.runner_run.device_wall.task_slot_2",  "chip.run.runner_run.device_wall.task_slot_3",
+        "chip.run.runner_run.device_wall.task_slot_4",  "chip.run.runner_run.device_wall.task_slot_5",
+        "chip.run.runner_run.device_wall.task_slot_6",  "chip.run.runner_run.device_wall.task_slot_7",
+        "chip.run.runner_run.device_wall.task_slot_8",  "chip.run.runner_run.device_wall.task_slot_9",
+        "chip.run.runner_run.device_wall.task_slot_10", "chip.run.runner_run.device_wall.task_slot_11",
+        "chip.run.runner_run.device_wall.task_slot_12", "chip.run.runner_run.device_wall.task_slot_13",
+        "chip.run.runner_run.device_wall.task_slot_14", "chip.run.runner_run.device_wall.task_slot_15",
     };
     for (int s = 0; s < NUM_TASK_TIMING_SLOTS; ++s) {
         const uint64_t dispatch_ns = runner->last_task_slot_dispatch_ns(s);
@@ -607,16 +607,14 @@ static void
 emit_native_run_host_wall(uint64_t trace_inv, uint64_t trace_hid, long long trace_start_ns, const char *trace_attrs) {
     const long long end_ns = STRACE_NOW_NS();
     STRACE_CONTEXT(trace_inv, trace_hid, 0);
-    STRACE_HOST_SPAN_AT_A("simpler_run", trace_start_ns, end_ns - trace_start_ns, 0, trace_attrs);
+    STRACE_HOST_SPAN_AT_A("chip.run", trace_start_ns, end_ns - trace_start_ns, 0, trace_attrs);
 }
 
 static void emit_native_run_runner_wall(OnboardNativeRunContext *state) {
     if (state->runner_trace_start_ns == 0) return;
     const long long end_ns = STRACE_NOW_NS();
     STRACE_CONTEXT(state->trace_inv, state->trace_hid, 1);
-    STRACE_HOST_SPAN_AT(
-        "simpler_run.runner_run", state->runner_trace_start_ns, end_ns - state->runner_trace_start_ns, 1
-    );
+    STRACE_HOST_SPAN_AT("chip.run.runner_run", state->runner_trace_start_ns, end_ns - state->runner_trace_start_ns, 1);
     state->runner_trace_start_ns = 0;
 }
 
@@ -741,7 +739,7 @@ int simpler_prepare_run(
         if (overlaps_active_run) {
             int compatibility_rc = 0;
             {
-                STRACE("simpler_run.bind.compatibility");
+                STRACE("chip.run.bind.compatibility");
                 compatibility_rc = prepared_run_config_compatible_impl(
                     &state->host_api, config->runtime_env.ring_task_window, config->runtime_env.ring_heap,
                     config->runtime_env.ring_dep_pool
@@ -784,7 +782,7 @@ int simpler_prepare_run(
         if (!overlaps_active_run) runner->apply_call_config(state->config);
 
         {
-            STRACE("simpler_run.bind");
+            STRACE("chip.run.bind");
             rc = runner->bind_callable_to_runtime(
                 state->runtime, callable_id, &state->host_api, args, state->config.runtime_env.ring_task_window,
                 state->config.runtime_env.ring_heap, state->config.runtime_env.ring_dep_pool
@@ -950,7 +948,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         if (!launched) state->runtime.set_gm_sm_ptr(nullptr);
         if (attach_rc == 0) {
             {
-                STRACE("simpler_run.validate");
+                STRACE("chip.run.validate");
                 validation_rc = validate_runtime_impl(&state->runtime, &state->host_api, launched ? execution_rc : -1);
             }
             if (launched && execution_rc == 0) emit_device_phase_markers(state->runner);
@@ -987,7 +985,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         // The point a successor's launch becomes admissible. Ordering a
         // successor's device work against this boundary is what separates a
         // pipelined launch from a reordered one, and no other span marks it.
-        STRACE("simpler_run.claim_release");
+        STRACE("chip.run.claim_release");
         state->runner->release_native_run(state);
         state->runner_claimed = false;
     }

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -498,22 +498,22 @@ static void emit_device_phase_markers(SimDeviceRunnerBase *runner) {
     if (!device_profiling_enabled()) return;
     const uint64_t run_wall_ns = runner->last_device_phase_ns(AicpuPhase::RunWall);
     if (run_wall_ns != 0) {
-        STRACE_DEV_SPAN_AT("simpler_run.runner_run.device_wall", 0, static_cast<long long>(run_wall_ns), 2);
+        STRACE_DEV_SPAN_AT("chip.run.runner_run.device_wall", 0, static_cast<long long>(run_wall_ns), 2);
     }
     struct PhaseName {
         AicpuPhase phase;
         const char *name;
     };
     static const PhaseName kPhases[] = {
-        {AicpuPhase::Preamble, "simpler_run.runner_run.device_wall.preamble"},
-        {AicpuPhase::SoLoad, "simpler_run.runner_run.device_wall.so_load"},
-        {AicpuPhase::GraphBuild, "simpler_run.runner_run.device_wall.graph_build"},
-        {AicpuPhase::ConfigValidate, "simpler_run.runner_run.device_wall.config_validate"},
-        {AicpuPhase::ArenaWire, "simpler_run.runner_run.device_wall.arena_wire"},
-        {AicpuPhase::SmReset, "simpler_run.runner_run.device_wall.sm_reset"},
-        {AicpuPhase::PostOrch, "simpler_run.runner_run.device_wall.post_orch"},
-        {AicpuPhase::OrchWindow, "simpler_run.runner_run.device_wall.orch"},
-        {AicpuPhase::SchedWindow, "simpler_run.runner_run.device_wall.sched"},
+        {AicpuPhase::Preamble, "chip.run.runner_run.device_wall.preamble"},
+        {AicpuPhase::SoLoad, "chip.run.runner_run.device_wall.so_load"},
+        {AicpuPhase::GraphBuild, "chip.run.runner_run.device_wall.graph_build"},
+        {AicpuPhase::ConfigValidate, "chip.run.runner_run.device_wall.config_validate"},
+        {AicpuPhase::ArenaWire, "chip.run.runner_run.device_wall.arena_wire"},
+        {AicpuPhase::SmReset, "chip.run.runner_run.device_wall.sm_reset"},
+        {AicpuPhase::PostOrch, "chip.run.runner_run.device_wall.post_orch"},
+        {AicpuPhase::OrchWindow, "chip.run.runner_run.device_wall.orch"},
+        {AicpuPhase::SchedWindow, "chip.run.runner_run.device_wall.sched"},
     };
     // RunWall is emitted above as device_wall; every other phase is in the table.
     static_assert(
@@ -535,14 +535,14 @@ static void emit_device_phase_markers(SimDeviceRunnerBase *runner) {
     // intervals (e.g. finish(slot_1) - dispatch(slot_0)) stay recoverable.
     // Untagged / incomplete slots read back 0/0 and are skipped.
     static const char *const kTaskSlotNames[NUM_TASK_TIMING_SLOTS] = {
-        "simpler_run.runner_run.device_wall.task_slot_0",  "simpler_run.runner_run.device_wall.task_slot_1",
-        "simpler_run.runner_run.device_wall.task_slot_2",  "simpler_run.runner_run.device_wall.task_slot_3",
-        "simpler_run.runner_run.device_wall.task_slot_4",  "simpler_run.runner_run.device_wall.task_slot_5",
-        "simpler_run.runner_run.device_wall.task_slot_6",  "simpler_run.runner_run.device_wall.task_slot_7",
-        "simpler_run.runner_run.device_wall.task_slot_8",  "simpler_run.runner_run.device_wall.task_slot_9",
-        "simpler_run.runner_run.device_wall.task_slot_10", "simpler_run.runner_run.device_wall.task_slot_11",
-        "simpler_run.runner_run.device_wall.task_slot_12", "simpler_run.runner_run.device_wall.task_slot_13",
-        "simpler_run.runner_run.device_wall.task_slot_14", "simpler_run.runner_run.device_wall.task_slot_15",
+        "chip.run.runner_run.device_wall.task_slot_0",  "chip.run.runner_run.device_wall.task_slot_1",
+        "chip.run.runner_run.device_wall.task_slot_2",  "chip.run.runner_run.device_wall.task_slot_3",
+        "chip.run.runner_run.device_wall.task_slot_4",  "chip.run.runner_run.device_wall.task_slot_5",
+        "chip.run.runner_run.device_wall.task_slot_6",  "chip.run.runner_run.device_wall.task_slot_7",
+        "chip.run.runner_run.device_wall.task_slot_8",  "chip.run.runner_run.device_wall.task_slot_9",
+        "chip.run.runner_run.device_wall.task_slot_10", "chip.run.runner_run.device_wall.task_slot_11",
+        "chip.run.runner_run.device_wall.task_slot_12", "chip.run.runner_run.device_wall.task_slot_13",
+        "chip.run.runner_run.device_wall.task_slot_14", "chip.run.runner_run.device_wall.task_slot_15",
     };
     for (int s = 0; s < NUM_TASK_TIMING_SLOTS; ++s) {
         const uint64_t dispatch_ns = runner->last_task_slot_dispatch_ns(s);
@@ -575,16 +575,14 @@ static SimNativeRunContext *native_run_context(DeviceContextHandle ctx, RuntimeH
 static void emit_native_run_host_wall(uint64_t trace_inv, uint64_t trace_hid, long long trace_start_ns) {
     const long long end_ns = STRACE_NOW_NS();
     STRACE_CONTEXT(trace_inv, trace_hid, 0);
-    STRACE_HOST_SPAN_AT("simpler_run", trace_start_ns, end_ns - trace_start_ns, 0);
+    STRACE_HOST_SPAN_AT("chip.run", trace_start_ns, end_ns - trace_start_ns, 0);
 }
 
 static void emit_native_run_runner_wall(SimNativeRunContext *state) {
     if (state->runner_trace_start_ns == 0) return;
     const long long end_ns = STRACE_NOW_NS();
     STRACE_CONTEXT(state->trace_inv, state->trace_hid, 1);
-    STRACE_HOST_SPAN_AT(
-        "simpler_run.runner_run", state->runner_trace_start_ns, end_ns - state->runner_trace_start_ns, 1
-    );
+    STRACE_HOST_SPAN_AT("chip.run.runner_run", state->runner_trace_start_ns, end_ns - state->runner_trace_start_ns, 1);
     state->runner_trace_start_ns = 0;
 }
 
@@ -673,7 +671,7 @@ int simpler_prepare_run(
         runner->apply_call_config(state->config);
 
         {
-            STRACE("simpler_run.bind");
+            STRACE("chip.run.bind");
             rc = runner->bind_callable_to_runtime(
                 state->runtime, callable_id, &state->host_api, args, state->config.runtime_env.ring_task_window,
                 state->config.runtime_env.ring_heap, state->config.runtime_env.ring_dep_pool
@@ -819,7 +817,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         if (!launched) state->runtime.set_gm_sm_ptr(nullptr);
         if (attach_rc == 0) {
             {
-                STRACE("simpler_run.validate");
+                STRACE("chip.run.validate");
                 validation_rc = validate_runtime_impl(&state->runtime, &state->host_api, launched ? execution_rc : -1);
             }
             if (launched && execution_rc == 0) emit_device_phase_markers(state->runner);

--- a/tests/st/a2a3/host_build_graph/native_run_lifecycle/test_native_run_lifecycle.py
+++ b/tests/st/a2a3/host_build_graph/native_run_lifecycle/test_native_run_lifecycle.py
@@ -73,42 +73,42 @@ class TestNativeRunLifecycle(SceneTestCase):
         super().test_run(st_platform, st_worker, request)
 
         spans = list(parse_spans(capfd.readouterr().err.splitlines()))
-        invocations = [inv for inv in group_invocations(spans) if "simpler_run" in inv.by_name()]
+        invocations = [inv for inv in group_invocations(spans) if "chip.run" in inv.by_name()]
         # Two of these are the abandoned diagnostic prepares below, which record a
-        # simpler_run invocation without ever reaching simpler_run.runner_run.
+        # chip.run invocation without ever reaching chip.run.runner_run.
         expected_invocations = 5 if st_platform.endswith("sim") else 9
         assert len(invocations) == expected_invocations
 
         common_depths = {
-            "simpler_run": 0,
-            "simpler_run.bind": 1,
-            "simpler_run.validate": 1,
+            "chip.run": 0,
+            "chip.run.bind": 1,
+            "chip.run.validate": 1,
         }
         launched_depths = {
             **common_depths,
-            "simpler_run.runner_run": 1,
-            "simpler_run.runner_run.device_wall": 2,
+            "chip.run.runner_run": 1,
+            "chip.run.runner_run.device_wall": 2,
         }
         launched_count = 0
         for invocation in invocations:
             by_name = invocation.by_name()
-            expected_depths = launched_depths if "simpler_run.runner_run" in by_name else common_depths
-            launched_count += "simpler_run.runner_run" in by_name
+            expected_depths = launched_depths if "chip.run.runner_run" in by_name else common_depths
+            launched_count += "chip.run.runner_run" in by_name
             assert expected_depths.keys() <= by_name.keys()
             assert len({span.hid for span in invocation.spans}) == 1
-            assert sum(span.name == "simpler_run" for span in invocation.spans) == 1
+            assert sum(span.name == "chip.run" for span in invocation.spans) == 1
             for name, depth in expected_depths.items():
                 assert by_name[name].depth == depth
 
-            root = by_name["simpler_run"]
+            root = by_name["chip.run"]
             root_end = root.ts + root.dur
-            for name in expected_depths.keys() - {"simpler_run", "simpler_run.runner_run.device_wall"}:
+            for name in expected_depths.keys() - {"chip.run", "chip.run.runner_run.device_wall"}:
                 stage = by_name[name]
                 assert root.ts <= stage.ts <= stage.ts + stage.dur <= root_end
         expected_launched = 2 if st_platform.endswith("sim") else 6
         assert launched_count == expected_launched
         if not st_platform.endswith("sim"):
-            root_attrs = [inv.by_name()["simpler_run"].attrs for inv in invocations]
+            root_attrs = [inv.by_name()["chip.run"].attrs for inv in invocations]
             assert all(
                 key in attrs
                 for attrs in root_attrs

--- a/tests/st/a5/tensormap_and_ringbuffer/bench_prewarm_timing.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/bench_prewarm_timing.py
@@ -39,8 +39,8 @@ _CASE_NAME = "SingleDummyAutoDep"
 _RING = 64
 
 _TIMING_RE = re.compile(r"TIMING: prebuilt_runtime_arena = (\d+)ms")
-_STRACE_BIND_RE = re.compile(r"\[STRACE\].*name=simpler_run\.bind\.prebuilt\s+ts=\d+\s+dur=(\d+)")
-_STRACE_PREWARM_RE = re.compile(r"\[STRACE\].*name=simpler_prewarm\.build\s+ts=\d+\s+dur=(\d+)")
+_STRACE_BIND_RE = re.compile(r"\[STRACE\].*name=chip\.run\.bind\.prebuilt\s+ts=\d+\s+dur=(\d+)")
+_STRACE_PREWARM_RE = re.compile(r"\[STRACE\].*name=chip\.prewarm\.build\s+ts=\d+\s+dur=(\d+)")
 
 
 def _last_ms_from_ns(values: list[int]) -> float | None:
@@ -157,8 +157,8 @@ def main() -> None:
                 token in line
                 for token in (
                     "TIMING: prebuilt_runtime_arena",
-                    "name=simpler_prewarm.build",
-                    "name=simpler_run.bind.prebuilt",
+                    "name=chip.prewarm.build",
+                    "name=chip.run.bind.prebuilt",
                 )
             ):
                 print(line)
@@ -173,7 +173,7 @@ def main() -> None:
         print("\n=== SUMMARY ===")
         print(f"cold first-run bind.prebuilt (STRACE) : {_fmt_ms(cold)}")
         print(f"hot  first-run bind.prebuilt (STRACE) : {_fmt_ms(hot)}")
-        print(f"hot  init simpler_prewarm.build        : {_fmt_ms(prewarm_ms)}")
+        print(f"hot  init chip.prewarm.build        : {_fmt_ms(prewarm_ms)}")
         if cold is not None and hot is not None:
             print(f"first-run savings (cold - hot)         : {cold - hot:.2f} ms")
             if prewarm_ms is not None:

--- a/tests/st/task_timing/task_timing_slots/kernels/orchestration/task_timing_orch.cpp
+++ b/tests/st/task_timing/task_timing_slots/kernels/orchestration/task_timing_orch.cpp
@@ -19,7 +19,7 @@
  *
  * t1 consumes t0's output, so t1's Scheduler-observed FIN necessarily follows
  * t0's dispatch. The host reads back both slots and emits
- * `simpler_run.runner_run.device_wall.task_slot_0` / `_1` on the [STRACE]
+ * `chip.run.runner_run.device_wall.task_slot_0` / `_1` on the [STRACE]
  * timeline; tooling recovers the whole-chain interval as
  * finish(slot_1) - dispatch(slot_0).
  *

--- a/tests/st/task_timing/task_timing_slots/test_task_timing_e2e.py
+++ b/tests/st/task_timing/task_timing_slots/test_task_timing_e2e.py
@@ -11,7 +11,7 @@
 A two-task chain (`c = a + b` tagged slot 0, `out = c + b` tagged slot 1) is
 run with chip swimlane OFF. The contract being verified:
 
-    * both `simpler_run.runner_run.device_wall.task_slot_0` and `..._1`
+    * both `chip.run.runner_run.device_wall.task_slot_0` and `..._1`
       [STRACE] markers are present with strictly positive duration — proving
       the whole path (Arg tag -> descriptor pad -> Scheduler dispatch/finish
       fold -> host H2D reset / D2H readback -> marker emit) works with the
@@ -60,7 +60,7 @@ _STRACE_RE = re.compile(r"\[STRACE\] .*\bname=(?P<name>\S+)\b.*\bts=(?P<ts>\d+)\
 
 def _slot_spans(captured: str, slot: int) -> list:
     """Return (ts, dur) for every task_slot_<slot> [STRACE] marker."""
-    name = f"simpler_run.runner_run.device_wall.task_slot_{slot}"
+    name = f"chip.run.runner_run.device_wall.task_slot_{slot}"
     out = []
     for line in captured.splitlines():
         m = _STRACE_RE.search(line)

--- a/tests/ut/cpp/a5/test_host_log_off.cpp
+++ b/tests/ut/cpp/a5/test_host_log_off.cpp
@@ -384,7 +384,7 @@ TEST(HostLogTest, HostSpanTruncationDropsAWholeEscapeRatherThanItsLastByte) {
                                0,
                                100,
                                25,
-                               "l3.dispatch",
+                               "host.dispatch",
                                attributes.c_str()};
 
     auto captured = run_with_config(LogLevel::TIMING, [&] {

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -1210,13 +1210,13 @@ TEST(WorkerManagerTest, DispatchAndCompletionEmitHostSpans) {
 
     worker.dispatch(WorkerDispatch{slot, 0});
     ASSERT_TRUE(endpoint_ptr->wait_submitted(1));
-    EXPECT_TRUE(captured_host_span("l3.dispatch"));
+    EXPECT_TRUE(captured_host_span("host.dispatch"));
 
     const WorkerDispatch submitted = endpoint_ptr->submitted().front();
     endpoint_ptr->emit(WorkerProgressKind::COMPLETED, submitted);
     worker.progress();
     ASSERT_EQ(completed.size(), 1u);
-    EXPECT_TRUE(captured_host_span("l3.complete"));
+    EXPECT_TRUE(captured_host_span("host.complete"));
 
     worker.stop();
     allocator.shutdown();
@@ -1474,8 +1474,8 @@ TEST(WorkerManagerTest, TwoFrameLeaseSlotsDoNotDefineFifoOrAcceptance) {
     ASSERT_TRUE(endpoint.poll_progress(progress));
     EXPECT_EQ(progress.kind, WorkerProgressKind::ACCEPTED);
     EXPECT_EQ(progress.dispatch.dispatch_id, 42u);
-    EXPECT_TRUE(captured_host_span("l3.frame_submit"));
-    EXPECT_TRUE(captured_host_span("l3.activate"));
+    EXPECT_TRUE(captured_host_span("host.frame_submit"));
+    EXPECT_TRUE(captured_host_span("host.activate"));
     allocator.shutdown();
 }
 
@@ -2042,10 +2042,10 @@ TEST_F(ProgressSchedulerFixture, GroupSubmitReportsNoSingleWorkerAndNoSingleInde
     );
     orchestrator.close_run_submission(run);
 
-    ASSERT_TRUE(captured_host_span("l3.submit"));
+    ASSERT_TRUE(captured_host_span("host.submit"));
     std::ostringstream expected;
     expected << "run_id=" << run << " task_slot=" << group.task_slot << " group_index=-1 group_size=2 role=facade";
-    EXPECT_EQ(captured_host_span_attrs("l3.submit"), expected.str());
+    EXPECT_EQ(captured_host_span_attrs("host.submit"), expected.str());
 }
 
 TEST_F(ProgressSchedulerFixture, SuccessorStagesButActivatesOnlyAfterFifoPromotion) {
@@ -2506,7 +2506,7 @@ TEST_F(SchedulerFixture, ACancellationThatWinsTheClaimStopsTheDispatch) {
     }
 }
 
-// `l3.submit` is what a dispatch arrow is drawn back to, so the swimlane can
+// `host.submit` is what a dispatch arrow is drawn back to, so the swimlane can
 // only pair the two if these attributes carry the same run/slot the dispatch
 // reports. A SUB submission is deliberately silent: it has no NEXT_LEVEL worker
 // to hand off to.
@@ -2515,11 +2515,11 @@ TEST_F(SchedulerFixture, NextLevelSubmitEmitsAPairableHostSpan) {
 
     auto submitted = orch.submit_next_level(C(0x42), single_tensor_args(0xCAFE, TensorArgType::OUTPUT), cfg, 0);
 
-    ASSERT_TRUE(captured_host_span("l3.submit"));
+    ASSERT_TRUE(captured_host_span("host.submit"));
     std::ostringstream expected;
     expected << "run_id=" << run_id << " task_slot=" << submitted.task_slot
              << " group_index=0 group_size=1 worker_id=0 role=facade";
-    EXPECT_EQ(captured_host_span_attrs("l3.submit"), expected.str());
+    EXPECT_EQ(captured_host_span_attrs("host.submit"), expected.str());
 
     mock_worker.wait_running();
     mock_worker.complete();

--- a/tests/ut/py/test_strace_timing.py
+++ b/tests/ut/py/test_strace_timing.py
@@ -72,29 +72,27 @@ def _span_record(
 
 def test_parse_spans_finds_adjacent_records_on_one_physical_line():
     line = (
-        _record(1, 1, "simpler_run", "rank=0")
-        + _record(2, 2, "simpler_run.runner_run.device_wall", "clk=dev rank=1")
-        + "\n"
+        _record(1, 1, "chip.run", "rank=0") + _record(2, 2, "chip.run.runner_run.device_wall", "clk=dev rank=1") + "\n"
     )
 
     spans = list(parse_spans([line]))
 
     assert [(span.pid, span.inv, span.name) for span in spans] == [
-        (1, 1, "simpler_run"),
-        (2, 2, "simpler_run.runner_run.device_wall"),
+        (1, 1, "chip.run"),
+        (2, 2, "chip.run.runner_run.device_wall"),
     ]
     assert spans[0].attrs == "rank=0"
     assert spans[1].attrs == "clk=dev rank=1"
 
 
 def test_parse_spans_keeps_every_record_of_a_multi_line_blob():
-    blob = _legacy_record(1, 1, "simpler_run", "rank=0") + "\n" + _record(2, 2, "simpler_run.bind", "rank=1") + "\n"
+    blob = _legacy_record(1, 1, "chip.run", "rank=0") + "\n" + _record(2, 2, "chip.run.bind", "rank=1") + "\n"
 
     spans = list(parse_spans([blob]))
 
     assert [(span.pid, span.inv, span.name) for span in spans] == [
-        (1, 1, "simpler_run"),
-        (2, 2, "simpler_run.bind"),
+        (1, 1, "chip.run"),
+        (2, 2, "chip.run.bind"),
     ]
     assert spans[0].attrs == "rank=0"
     assert spans[1].attrs == "rank=1"
@@ -103,7 +101,7 @@ def test_parse_spans_keeps_every_record_of_a_multi_line_blob():
 def test_parse_spans_preserves_64_bit_invocation_id():
     invocation_id = 2**32 + 7
 
-    spans = list(parse_spans([_record(41, invocation_id, "simpler_run")]))
+    spans = list(parse_spans([_record(41, invocation_id, "chip.run")]))
 
     assert len(spans) == 1
     assert spans[0].inv == invocation_id
@@ -141,12 +139,12 @@ def test_trace_renderers_add_wall_time_without_replacing_monotonic_timestamps():
     spans = list(
         parse_spans(
             [
-                _span_record(pid=41, tid=410, inv=7, name="simpler_run", ts=1_250, dur=20),
+                _span_record(pid=41, tid=410, inv=7, name="chip.run", ts=1_250, dur=20),
                 _span_record(
                     pid=41,
                     tid=410,
                     inv=7,
-                    name="simpler_run.runner_run.device_wall",
+                    name="chip.run.runner_run.device_wall",
                     ts=300,
                     dur=40,
                     attrs="clk=dev",
@@ -161,7 +159,7 @@ def test_trace_renderers_add_wall_time_without_replacing_monotonic_timestamps():
     host_swimlane = to_host_swimlane(spans, anchors=anchors)
 
     for trace in (chrome_trace, host_swimlane):
-        host_event = next(event for event in trace["traceEvents"] if event.get("name") == "simpler_run")
+        host_event = next(event for event in trace["traceEvents"] if event.get("name") == "chip.run")
         assert host_event["ts"] == 1.25
         assert host_event["args"]["wall_ts_ns"] == "1700000000000000250"
         assert host_event["args"]["wall_time"] == "2023-11-14T22:13:20.000000250Z"
@@ -185,10 +183,10 @@ def test_wall_time_uses_the_matching_anchor_for_each_pid():
     spans = list(
         parse_spans(
             [
-                _span_record(pid=41, tid=410, inv=1, name="l3.submit", ts=1_500, dur=10),
-                _span_record(pid=52, tid=520, inv=1, name="l3.submit", ts=1_500, dur=10),
-                _span_record(pid=63, tid=630, inv=1, name="l3.submit", ts=1_500, dur=10),
-                _span_record(pid=64, tid=640, inv=1, name="l3.submit", ts=1_500, dur=10),
+                _span_record(pid=41, tid=410, inv=1, name="host.submit", ts=1_500, dur=10),
+                _span_record(pid=52, tid=520, inv=1, name="host.submit", ts=1_500, dur=10),
+                _span_record(pid=63, tid=630, inv=1, name="host.submit", ts=1_500, dur=10),
+                _span_record(pid=64, tid=640, inv=1, name="host.submit", ts=1_500, dur=10),
             ]
         )
     )
@@ -205,7 +203,7 @@ def test_wall_time_uses_the_matching_anchor_for_each_pid():
 
 
 def test_count_record_heads_sees_a_torn_record_that_parse_spans_drops():
-    intact = _record(1, 1, "simpler_run", "rank=0")
+    intact = _record(1, 1, "chip.run", "rank=0")
     torn = intact[: intact.index(" ts=")]
     lines = [intact + "\n", torn + "\n"]
 
@@ -219,7 +217,7 @@ def test_host_swimlane_keeps_real_host_lanes_and_builds_dispatch_flow():
             pid=41,
             tid=410,
             inv=7,
-            name="l3.graph_build",
+            name="host.graph_build",
             ts=1_000,
             dur=900,
             attrs="run_id=7 role=facade",
@@ -228,7 +226,7 @@ def test_host_swimlane_keeps_real_host_lanes_and_builds_dispatch_flow():
             pid=41,
             tid=410,
             inv=7,
-            name="l3.submit",
+            name="host.submit",
             ts=1_100,
             dur=100,
             attrs="run_id=7 task_slot=12 group_index=0 worker_id=3 role=facade",
@@ -237,7 +235,7 @@ def test_host_swimlane_keeps_real_host_lanes_and_builds_dispatch_flow():
             pid=41,
             tid=411,
             inv=7,
-            name="l3.dispatch",
+            name="host.dispatch",
             ts=1_400,
             dur=80,
             attrs=(
@@ -272,8 +270,8 @@ def test_host_swimlane_names_the_scheduler_lane_from_every_role_it_emits():
     """The scheduler thread emits `role=worker` spans before its first `role=scheduler` one.
 
     `scheduler.cpp`'s loop is the only caller of both `dispatch_ready()` and
-    `manager->progress()`, and inside `submit_dispatch` the `l3.frame_submit`
-    scope closes within `submit_progress` — before the `l3.dispatch` record
+    `manager->progress()`, and inside `submit_dispatch` the `host.frame_submit`
+    scope closes within `submit_progress` — before the `host.dispatch` record
     emitted after the admission lock is released. Naming the lane from the
     first span it emitted therefore labels the scheduler `worker 3`.
     """
@@ -282,7 +280,7 @@ def test_host_swimlane_names_the_scheduler_lane_from_every_role_it_emits():
             pid=41,
             tid=411,
             inv=7,
-            name="l3.frame_submit",
+            name="host.frame_submit",
             ts=1_410,
             dur=40,
             attrs="run_id=7 task_slot=12 group_index=0 worker_id=3 dispatch_id=1 role=worker",
@@ -291,7 +289,7 @@ def test_host_swimlane_names_the_scheduler_lane_from_every_role_it_emits():
             pid=41,
             tid=411,
             inv=7,
-            name="l3.dispatch",
+            name="host.dispatch",
             ts=1_400,
             dur=80,
             attrs="run_id=7 task_slot=12 group_index=0 worker_id=3 dispatch_id=1 role=scheduler",
@@ -300,7 +298,7 @@ def test_host_swimlane_names_the_scheduler_lane_from_every_role_it_emits():
             pid=41,
             tid=411,
             inv=7,
-            name="l3.complete",
+            name="host.complete",
             ts=2_000,
             dur=30,
             attrs="run_id=7 task_slot=12 group_index=0 worker_id=3 dispatch_id=1 role=worker",
@@ -324,7 +322,7 @@ def test_parse_spans_decodes_percent_escaped_name_and_attribute_values():
             pid=41,
             tid=410,
             inv=7,
-            name="l3.odd%20name",
+            name="host.odd%20name",
             ts=100,
             dur=10,
             attrs="run_id=7 reason=submit%20failed%3A%20%5Bfatal%5D role=facade",
@@ -332,7 +330,7 @@ def test_parse_spans_decodes_percent_escaped_name_and_attribute_values():
     ]
 
     span = next(iter(parse_spans(lines)))
-    assert span.name == "l3.odd name"
+    assert span.name == "host.odd name"
 
     trace = to_host_swimlane([span])
     args = next(event["args"] for event in trace["traceEvents"] if event["ph"] == "X")
@@ -347,7 +345,7 @@ def test_host_swimlane_pairs_dispatch_with_latest_preceding_submit():
             pid=41,
             tid=410,
             inv=7,
-            name="l3.submit",
+            name="host.submit",
             ts=100,
             dur=20,
             attrs="run_id=7 task_slot=12 group_index=0 worker_id=3 role=facade",
@@ -356,7 +354,7 @@ def test_host_swimlane_pairs_dispatch_with_latest_preceding_submit():
             pid=41,
             tid=411,
             inv=7,
-            name="l3.dispatch",
+            name="host.dispatch",
             ts=200,
             dur=10,
             attrs="run_id=7 task_slot=12 group_index=0 worker_id=3 dispatch_id=1 role=scheduler",
@@ -365,7 +363,7 @@ def test_host_swimlane_pairs_dispatch_with_latest_preceding_submit():
             pid=41,
             tid=410,
             inv=7,
-            name="l3.submit",
+            name="host.submit",
             ts=300,
             dur=20,
             attrs="run_id=7 task_slot=12 group_index=0 worker_id=3 role=facade",
@@ -374,7 +372,7 @@ def test_host_swimlane_pairs_dispatch_with_latest_preceding_submit():
             pid=41,
             tid=411,
             inv=7,
-            name="l3.dispatch",
+            name="host.dispatch",
             ts=400,
             dur=10,
             attrs="run_id=7 task_slot=12 group_index=0 worker_id=3 dispatch_id=2 role=scheduler",
@@ -402,7 +400,7 @@ def test_host_swimlane_keeps_unaligned_device_clock_out_of_visible_timeline():
                     pid=41,
                     tid=410,
                     inv=7,
-                    name="l3.graph_build",
+                    name="host.graph_build",
                     ts=1_000_000_000,
                     dur=900,
                     attrs="run_id=7 role=facade",
@@ -411,7 +409,7 @@ def test_host_swimlane_keeps_unaligned_device_clock_out_of_visible_timeline():
                     pid=52,
                     tid=520,
                     inv=8,
-                    name="simpler_run.runner_run.device_wall",
+                    name="chip.run.runner_run.device_wall",
                     ts=300,
                     dur=40,
                     attrs="clk=dev rank=1",
@@ -424,11 +422,11 @@ def test_host_swimlane_keeps_unaligned_device_clock_out_of_visible_timeline():
     visible_slices = [event for event in trace["traceEvents"] if event.get("ph") == "X"]
 
     assert [(event["name"], event["ts"], event["dur"]) for event in visible_slices] == [
-        ("l3.graph_build", 1_000_000.0, 0.9)
+        ("host.graph_build", 1_000_000.0, 0.9)
     ]
     assert trace["unalignedDeviceSpans"] == [
         {
-            "name": "simpler_run.runner_run.device_wall",
+            "name": "chip.run.runner_run.device_wall",
             "ts_ns": 300,
             "dur_ns": 40,
             "pid": 52,
@@ -445,9 +443,9 @@ def test_legacy_trace_output_ignores_host_swimlane_markers():
     old = list(
         parse_spans(
             [
-                _span_record(pid=61, tid=610, inv=3, name="simpler_run", ts=1_000, dur=500),
-                _span_record(pid=61, tid=610, inv=3, name="simpler_run.bind", ts=1_100, dur=50, depth=1),
-                _span_record(pid=61, tid=610, inv=4, name="simpler_prewarm.build", ts=1_200, dur=75),
+                _span_record(pid=61, tid=610, inv=3, name="chip.run", ts=1_000, dur=500),
+                _span_record(pid=61, tid=610, inv=3, name="chip.run.bind", ts=1_100, dur=50, depth=1),
+                _span_record(pid=61, tid=610, inv=4, name="chip.prewarm.build", ts=1_200, dur=75),
             ]
         )
     )
@@ -458,7 +456,7 @@ def test_legacy_trace_output_ignores_host_swimlane_markers():
                     pid=61,
                     tid=611,
                     inv=9,
-                    name="l3.dispatch",
+                    name="host.dispatch",
                     ts=900,
                     dur=20,
                     attrs="run_id=9 task_slot=4 group_index=0 worker_id=0 dispatch_id=1",
@@ -471,9 +469,9 @@ def test_legacy_trace_output_ignores_host_swimlane_markers():
     mixed_invocations = group_invocations(legacy_spans(mixed))
 
     assert [span.name for span in legacy_spans(mixed)] == [
-        "simpler_run",
-        "simpler_run.bind",
-        "simpler_prewarm.build",
+        "chip.run",
+        "chip.run.bind",
+        "chip.prewarm.build",
     ]
     assert to_chrome_trace(old_invocations, bucket_by_hid(old_invocations)) == to_chrome_trace(
         mixed_invocations, bucket_by_hid(mixed_invocations)
@@ -484,15 +482,15 @@ def test_invocation_by_name_uses_earliest_timestamp_not_input_order():
     spans = list(
         parse_spans(
             [
-                _span_record(pid=61, tid=610, inv=3, name="simpler_run.bind", ts=1_200, dur=20, depth=1),
-                _span_record(pid=61, tid=611, inv=3, name="simpler_run.bind", ts=1_100, dur=30, depth=1),
+                _span_record(pid=61, tid=610, inv=3, name="chip.run.bind", ts=1_200, dur=20, depth=1),
+                _span_record(pid=61, tid=611, inv=3, name="chip.run.bind", ts=1_100, dur=30, depth=1),
             ]
         )
     )
 
     invocation = group_invocations(spans)[0]
 
-    assert invocation.by_name()["simpler_run.bind"].ts == 1_100
+    assert invocation.by_name()["chip.run.bind"].ts == 1_100
 
 
 def test_swimlane_cli_writes_trace(tmp_path):
@@ -500,14 +498,14 @@ def test_swimlane_cli_writes_trace(tmp_path):
     output_path = tmp_path / "host_swimlane.json"
     log_path.write_text(
         _anchor_record(71, 50, 1_700_000_000_000_000_000)
-        + _span_record(pid=71, tid=710, inv=2, name="l3.graph_build", ts=100, dur=25, attrs="run_id=2 role=facade"),
+        + _span_record(pid=71, tid=710, inv=2, name="host.graph_build", ts=100, dur=25, attrs="run_id=2 role=facade"),
         encoding="utf-8",
     )
 
     assert main([str(log_path), "--swimlane", str(output_path)]) == 0
 
     trace = json.loads(output_path.read_text(encoding="utf-8"))
-    event = next(event for event in trace["traceEvents"] if event.get("name") == "l3.graph_build")
+    event = next(event for event in trace["traceEvents"] if event.get("name") == "host.graph_build")
     assert event["args"]["wall_ts_ns"] == "1700000000000000050"
 
 
@@ -516,7 +514,7 @@ def test_cli_warns_when_one_pid_has_multiple_clock_anchors(tmp_path, capsys):
     log_path.write_text(
         _anchor_record(71, 50, 1_700_000_000_000_000_000)
         + _anchor_record(71, 75, 1_700_000_000_000_000_025)
-        + _span_record(pid=71, tid=710, inv=2, name="simpler_run", ts=100, dur=25),
+        + _span_record(pid=71, tid=710, inv=2, name="chip.run", ts=100, dur=25),
         encoding="utf-8",
     )
 
@@ -529,11 +527,11 @@ def test_rounds_table_omits_tmr_only_columns_when_only_host_and_device_exist():
     lines = []
     for inv, host_dur, device_dur in ((1, 100_000, 20_000), (2, 120_000, 24_000)):
         lines.append(
-            _record(1, inv, "simpler_run", dur=host_dur)
+            _record(1, inv, "chip.run", dur=host_dur)
             + _record(
                 1,
                 inv,
-                "simpler_run.runner_run.device_wall",
+                "chip.run.runner_run.device_wall",
                 "clk=dev",
                 depth=2,
                 dur=device_dur,
@@ -556,7 +554,7 @@ def test_rounds_table_omits_tmr_only_columns_when_only_host_and_device_exist():
 
 
 def _run_records(*, run_epoch, prepare, device, release, run_id=0, dispatch_id=0, slot_id=0, pid=7, inv=None):
-    """One phased native run's spans, as the `simpler_run` tree carries them.
+    """One phased native run's spans, as the `chip.run` tree carries them.
 
     `prepare` and `device` are (ts, dur). The root span carries the identity and
     spans the whole lifetime, so it must enclose the children.
@@ -565,10 +563,10 @@ def _run_records(*, run_epoch, prepare, device, release, run_id=0, dispatch_id=0
     identity = f"run_id={run_id} dispatch_id={dispatch_id} slot_id={slot_id} generation=1 run_epoch={run_epoch}"
     root_end = release + 10
     return [
-        _record(pid, invocation, "simpler_run.bind", depth=1, ts=prepare[0], dur=prepare[1]),
-        _record(pid, invocation, "simpler_run.runner_run", depth=1, ts=device[0], dur=device[1]),
-        _record(pid, invocation, "simpler_run.claim_release", depth=1, ts=release, dur=5),
-        _record(pid, invocation, "simpler_run", identity, depth=0, ts=prepare[0], dur=root_end - prepare[0]),
+        _record(pid, invocation, "chip.run.bind", depth=1, ts=prepare[0], dur=prepare[1]),
+        _record(pid, invocation, "chip.run.runner_run", depth=1, ts=device[0], dur=device[1]),
+        _record(pid, invocation, "chip.run.claim_release", depth=1, ts=release, dur=5),
+        _record(pid, invocation, "chip.run", identity, depth=0, ts=prepare[0], dur=root_end - prepare[0]),
     ]
 
 
@@ -644,10 +642,10 @@ def test_native_overlap_orders_by_dispatch_id_when_the_scheduler_allocates_one()
 
 
 def test_native_overlap_skips_an_invocation_that_is_not_a_phased_run():
-    """A lexical `simpler_run` carries no identity attrs, so it orders nothing."""
+    """A lexical `chip.run` carries no identity attrs, so it orders nothing."""
     lines = _run_records(run_epoch=1, prepare=(50, 20), device=(100, 100), release=200)
     lines += _run_records(run_epoch=2, prepare=(150, 30), device=(240, 100), release=340)
-    lines += [_record(7, 99, "simpler_run", "", depth=0, ts=10, dur=5)]
+    lines += [_record(7, 99, "chip.run", "", depth=0, ts=10, dur=5)]
 
     assert len(assert_native_overlap(parse_spans(lines))) == 1
 
@@ -660,7 +658,7 @@ def test_native_overlap_needs_two_runs_on_one_lane():
 
 
 def test_claim_release_span_stays_inside_the_invocation_tree():
-    """It is a `simpler_run` child, so the existing views absorb it.
+    """It is a `chip.run` child, so the existing views absorb it.
 
     A separate family would have to be filtered out of every view; a depth-1
     child of the root is what the tree already knows how to render — and it
@@ -670,8 +668,8 @@ def test_claim_release_span_stays_inside_the_invocation_tree():
 
     invocation = group_invocations(legacy_spans(list(parse_spans(lines))))[0]
 
-    assert invocation.root().name == "simpler_run"
-    assert invocation.by_name()["simpler_run.claim_release"].depth == 1
+    assert invocation.root().name == "chip.run"
+    assert invocation.by_name()["chip.run.claim_release"].depth == 1
     # The root still reports the whole lifetime, not a sub-stage's duration.
     assert invocation.root().dur == 210 - 50
 
@@ -734,14 +732,14 @@ def test_chrome_trace_cli_writes_wall_time(tmp_path):
     output_path = tmp_path / "strace.json"
     log_path.write_text(
         _anchor_record(71, 50, 1_700_000_000_000_000_000)
-        + _span_record(pid=71, tid=710, inv=2, name="simpler_run", ts=100, dur=25),
+        + _span_record(pid=71, tid=710, inv=2, name="chip.run", ts=100, dur=25),
         encoding="utf-8",
     )
 
     assert main([str(log_path), "--trace-out", str(output_path)]) == 0
 
     trace = json.loads(output_path.read_text(encoding="utf-8"))
-    event = next(event for event in trace["traceEvents"] if event.get("name") == "simpler_run")
+    event = next(event for event in trace["traceEvents"] if event.get("name") == "chip.run")
     assert event["ts"] == 0.1
     assert event["args"]["wall_ts_ns"] == "1700000000000000050"
 
@@ -781,7 +779,7 @@ def test_host_phase_records_loader_keeps_only_well_formed_passes(tmp_path):
 def test_host_record_spans_nest_bind_segments_and_orchestrator_operations(tmp_path):
     """A record's kind decides its depth: a bind segment sits under the stage, an
     orchestrator operation one level further in, under the segment it ran inside."""
-    spans = list(parse_spans([_span_record(pid=9, tid=9, inv=5, name="simpler_run.bind", ts=1_000, dur=500)]))
+    spans = list(parse_spans([_span_record(pid=9, tid=9, inv=5, name="chip.run.bind", ts=1_000, dur=500)]))
     passes = [
         {
             "pid": 9,
@@ -799,14 +797,14 @@ def test_host_record_spans_nest_bind_segments_and_orchestrator_operations(tmp_pa
     assert covered == frozenset({(9, 5)})
     by_name = {span.name: span for span in out}
     bind_depth = spans[0].depth
-    assert by_name["simpler_run.bind.args"].depth == bind_depth + 1
-    assert by_name["simpler_run.bind.host_orch.graph_submit"].depth == bind_depth + 2
-    assert by_name["simpler_run.bind.args"].ts == 1_000
-    assert by_name["simpler_run.bind.args"].dur == 100
+    assert by_name["chip.run.bind.args"].depth == bind_depth + 1
+    assert by_name["chip.run.bind.host_orch.graph_submit"].depth == bind_depth + 2
+    assert by_name["chip.run.bind.args"].ts == 1_000
+    assert by_name["chip.run.bind.args"].dur == 100
 
 
 def test_host_record_spans_drop_passes_with_no_matching_bind(tmp_path):
-    spans = list(parse_spans([_span_record(pid=9, tid=9, inv=5, name="simpler_run.bind", ts=1_000, dur=500)]))
+    spans = list(parse_spans([_span_record(pid=9, tid=9, inv=5, name="chip.run.bind", ts=1_000, dur=500)]))
     passes = [{"pid": 9, "inv": 999, "records": [{"phase": "args", "start_ns": 1_000, "end_ns": 1_100}]}]
 
     out, orphaned, covered = host_record_spans(spans, passes)

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -2755,7 +2755,7 @@ class TestRunHandle:
         with pytest.raises(ValueError, match="bad graph"):
             worker._submit_l3_locked(bad_graph, None, cast(Any, object()))
 
-        assert emitted == [("l3.graph_build", 1, 0, 0, 100, 175, "run_id=1 role=facade")]
+        assert emitted == [("host.graph_build", 1, 0, 0, 100, 175, "run_id=1 role=facade")]
 
     def test_unsettled_graph_cancellation_abandons_the_handle_before_close(self):
         worker, events = self._submission_failure_worker(failures=2)

--- a/tools/benchmark_rounds.sh
+++ b/tools/benchmark_rounds.sh
@@ -10,12 +10,12 @@
 # Benchmark wrapper: run examples on hardware and report per-round latency.
 # All columns come from the `[STRACE]` markers the run emits to stderr, parsed
 # by `strace_timing --rounds-table` (no CANN device log is read):
-#   - Host      run_prepared span (host wall, incl. Python)
-#   - Device    run_prepared.runner_run.device_wall span (full on-NPU AICPU wall)
+#   - Host      chip.run span (host wall, incl. Python)
+#   - Device    chip.run.runner_run.device_wall span (full on-NPU AICPU wall)
 #   - Effective orch∪sched merged window, from the TMR orch/sched markers'
 #               device-domain ts+dur (the old device-log "Total", now pure-marker)
-#   - Orch      TMR run_prepared.runner_run.device_wall.orch span
-#   - Sched     TMR run_prepared.runner_run.device_wall.sched span
+#   - Orch      TMR chip.run.runner_run.device_wall.orch span
+#   - Sched     TMR chip.run.runner_run.device_wall.sched span
 #
 # Usage:
 #   ./tools/benchmark_rounds.sh [-p <platform>] [-d <device>] [-n <rounds>] [-r <runtime>] [--serial-orch-sched]
@@ -221,7 +221,7 @@ fi
 #   Render per-round timing from the [STRACE] markers the run teed into
 #   $fw_stdout_file (host stderr, via 2>&1). All columns come from one source —
 #   the markers, parsed by `strace_timing --rounds-table`:
-#     - Host (us)      [STRACE] run_prepared span (host wall, incl. Python)
+#     - Host (us)      [STRACE] chip.run span (host wall, incl. Python)
 #     - Device (us)    [STRACE] device_wall span (full on-NPU AICPU wall)
 #     - Effective (us) orch∪sched merged window, from orch/sched device-domain ts+dur
 #     - Orch (us)      [STRACE] device_wall.orch span


### PR DESCRIPTION
Fixes #1793.

## Problem

`[STRACE]` span names came in two unrelated prefixes, and one of them was **wrong**:

- `l3.*` is emitted from `Orchestrator`, `WorkerThread` and `worker.py` — and all three are **level-agnostic**, the same code driving next-level children at every level above the chip. So an L4 process labelled its spans `l3.` too. That is the defect; the naming is the symptom.
- `simpler_run*` / `simpler_prewarm.*` named no level at all.

Both families now lead with the level that produced them.

## One word per level

`python/simpler/worker_level.py` is the source of truth:

| level | word | | level | word |
| ---: | --- | --- | ---: | --- |
| 0 | `core` | | 4 | `network1` |
| 2 | `chip` | | 5 | `network2` |
| 3 | `host` | | 6 | `network3` |

`network<N>` rather than `pod` / `supernode` / `cluster`: above `host` the physical layer is not fixed — sometimes a host sits under a pod, sometimes directly under a supernode — and naming those levels after an interconnect does not work either (mostly SU, sometimes RoCE). They count **network hops** instead. The digit counts hops, not the level: `network1` is L4.

An unmapped level **raises** rather than inventing a word, so when L5 or L6 is first exercised the gap surfaces as a failure instead of spans quietly carrying the wrong level. The enum is `IntEnum` and names no policy, so the `level >= 3` / `level >= 4` gates throughout `worker.py` are untouched.

Note `level.name`, not `str(level)`: this project targets Python 3.10, where `enum.StrEnum` does not exist and `str()` on any `Enum` yields `"WorkerLevel.host"`.

## The host family resolves once per process

`SpanScope` keeps the `const char *` it is given and dereferences it in its destructor, so a name must outlive every scope and building one per span would allocate on the dispatch path. Python resolves the word at `Worker.init` and pushes it through the new `_set_host_span_level_prefix`; `common/host_span_names.h` materializes the seven full names at that point and holds them for the process lifetime. Python reads the bound word back for its own `graph_build` span, so there is **one derivation** rather than one on each side.

The chip family needs none of that — a chip process is always L2, so the rename is static and the tree shape is preserved:

```text
simpler_run                    -> chip.run
simpler_run.bind[.args|...]    -> chip.run.bind[...]
simpler_run.runner_run[...]    -> chip.run.runner_run[...]
simpler_prewarm.build          -> chip.prewarm.build
```

## The parser splits by family — and keeps its function name

`legacy_spans()` filtered on the `l3.` prefix. It now classifies by the leading word (`chip` / `core` / `host` / `external` / `unknown`) and excludes the per-task host family plus anything an external producer emitted. An **unrecognized name is kept**: silently dropping an unfamiliar family is how `simpler_prewarm.build` once vanished from the tables.

**The name `legacy_spans` is retained deliberately.** pypto reaches it through `hasattr(_strace_timing, "legacy_spans")` and falls back to its own `l3.`-prefix filter when absent — so renaming the function would silently re-arm a stale filter in another repository. Call sites that matched `l3.submit` now match on the leaf via `host_span_leaf()`, because the word varies by level while the decision point does not.

`ext.<producer>.` is reserved for external producers (#1793's C2b): without it a caller's span named `host.foo` would parse as one of ours. #1794 depends on this.

`_ROUNDS_TABLE_NAMES` keeps its four **keys** — `host` / `device` / `orch` / `sched` — and changes only their values. pypto reads that mapping, so the keys are a contract even though `host` now points at a `chip.` span.

Retired spellings still classify into their families so an **archived log stays readable** — the same reason the record regex still accepts the old wall-clock prefix.

## `simpler_run` is three different things

The token is the span root, the **C API function**, and the text of a **runtime error message**. A sweep across it renamed a `dlsym` lookup, two function definitions and several error-message quotes before the build and then a sim scene test caught it:

```text
error: expected initializer before '.' token      // int chip.run(
RuntimeError: dlsym failed for 'chip.run': undefined symbol
```

Every occurrence was judged individually instead. Under `src/` the bare token is **always** the function and is untouched (47 occurrences kept). `l3.register` / `l3.init` are local-variable attribute access in the worker tests and are likewise untouched (30 kept).

`run_prepared` — which simpler #1210 retired and nothing updated — is resolved the same way while the names are in hand: span references become `chip.run`, function and error-message references become `simpler_run`. It survived in three agent-facing skills and `tools/benchmark_rounds.sh`, which is exactly the "runbook fails silently" case #1793 describes.

## Verification

**Negative control** — none of the 27 retired span names remains outside the parser's deliberate retired-spelling map. **Positive control** — `chip.run` 195, `chip.prewarm` 7, `host.*` leaves 47. Walked per name rather than by one pattern: a root-name-only grep is what hid three `.claude/skills/` consumers that reference `runner_run` / `device_wall` *without* the root.

**End to end on a2a3sim**, reading a real trace back through the parser rather than trusting a fixture:

```text
chip (13): chip.run · chip.run.bind{,.args,.prebuilt} · chip.run.runner_run
           · chip.run.runner_run.device_wall{,.orch,.sched,.arena_wire,
             .config_validate,.post_orch,.sm_reset} · chip.run.validate
host  (9): host.submit · host.dispatch · host.frame_submit · host.complete
           · host.graph_build · host.post_fence_retirement

legacy_spans keeps 13/22 · --rounds-table renders all five columns
· both renderers pair their cross-thread flow events
```

`host.` there is **resolved from the process level** (L3 ⇒ `host`), not hardcoded — which is the defect this fixes.

| Suite | Result |
| ----- | ------ |
| `pytest tests/ut/py/test_strace_timing.py` | **33/33** |
| `ctest -LE requires_hardware --timeout 300` | **101/101** |
| `pytest tests/ut/py -m "not requires_hardware"` | 1503 passed, 15 failed |
| `pre-commit` | clean except `clang-tidy` |

The 15 failures **reproduce identically on unmodified `main`** — I stashed the work and re-ran the same subset to check. All are sim cases under CPU oversubscription, the mode `docs/ci.md` records. `clang-tidy`'s hook venv cannot `import simpler` and fails the same way on untouched files.

Both suites were re-run after the rebase onto `348a8cb3`.

## Downstream is not updated here

Per the decision to let downstream adapt on its own, and because I have read-only access to both repositories (`gh api repos/… --jq .permissions` ⇒ `push: false`). Recorded as a **known consequence, not a verified one** — this PR cannot prove pypto's grouping is unaffected:

- **pypto-serving** `.agents/skills/profile-dsv4-serving-strace/scripts/render_8lane.py:118,196,200-202,220-221,231` hardcodes the old literals and imports nothing from simpler ⇒ **fails loudly**. Better fix than updating eight literals: read `_ROUNDS_TABLE_NAMES`, so the next rename cannot break it.
- **pypto** `python/pypto/runtime/bench.py:1182` has an `l3.`-prefix fallback that is **dormant** while `legacy_spans` exists — which this PR preserves, so pypto needs no change today. It becomes live only if that function is ever renamed.

Unaffected and needing no edit, so nobody wastes time on them: pypto `bench.py:284-313` already imports `_ROUNDS_TABLE_NAMES` (its hardcoded names are only a pre-#1210 fallback); pypto-serving `analyze_profile.py:33,59` imports from `simpler_setup.tools.strace_timing`; pypto-lib `golden/runner.py:869-873` takes its parser from pypto and never touches span names. Full survey in [#1793](https://github.com/hw-native-sys/simpler/issues/1793#issuecomment-5323837030).

## Follow-ups, deliberately not here

- **`pod` → `network1`** across the rest of the tree: 88 files by word boundary, including `.github/actions/pod-{stage,run-pytest,teardown}/`, `_st-pod.yml`, the `tests/st/.../l4_pod/` directory and `docs/ci.md` (26 hits). Larger than this rename; this PR *defines* `network1`, that one converges the prose.
- **#1842** is a draft adding ten new `simpler_run.bind.*` spans and will need rebasing onto this vocabulary.
