### PR TITLE
CI: consolidate DFX, clang-tidy, and cache follow-ups

### DIFF
--- a/.github/workflows/_pre-commit.yml
+++ b/.github/workflows/_pre-commit.yml
@@ -78,35 +78,9 @@ jobs:
             git diff --name-only --no-ext-diff -z "$BASE_SHA".."$HEAD_SHA" > "$changed_files"
           fi
 
-          while IFS= read -r -d '' path; do
-            if [[ ! -e "$path" && ! -L "$path" ]]; then
-              continue
-            fi
-
-            case "$path" in
-              .pre-commit-config.yaml)
-                needs_build=true
-                ;;
-              3rdparty/*)
-                ;;
-              *)
-                shopt -s nocasematch
-                case "$path" in
-                  *.c|*.c++|*.c++m|*.cc|*.ccm|*.cpp|*.cppm|*.cxx|*.cxxm|*.h|*.hh|*.hpp|*.hxx|*.inl|*.ino|*.ipp|*.ixx|*.mm|*.tpp)
-                    case "$path" in
-                      python/bindings/*|*/kernels/*|*/aicore/*) ;;
-                      *) needs_build=true ;;
-                    esac
-                    ;;
-                  *.asc|*.cce|*.gyp|*.gypi|*.py|*.pyi|*.pyt|*.tac|*.wsgi|*.md|*.rst|*.txt|*.yml|*.yaml|*.json|*.toml|*.pin|*.cmake|*.in|*.sh|*.bash|*.zsh|*.fish|*.gitignore|*.clang-format|*.clang-tidy)
-                    ;;
-                  CMakeLists.txt|LICENSE|LICENSE.*) ;;
-                  *) needs_build=true ;;
-                esac
-                shopt -u nocasematch
-                ;;
-            esac
-          done < "$changed_files"
+          needs_build="$(
+            python "$GITHUB_WORKSPACE/tests/lint/clang_tidy_paths.py" --needs-build --null < "$changed_files"
+          )"
 
           echo "needs_build=$needs_build" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/_st-sim-a2a3.yml
+++ b/.github/workflows/_st-sim-a2a3.yml
@@ -108,7 +108,7 @@ jobs:
       - name: dep_gen smoke (a2a3 host_build_graph)
         if: inputs.include_dfx_smokes
         run: |
-          .venv/bin/python -m pytest tests/st/a2a3/host_build_graph/dfx/dep_gen/test_dep_gen.py \
+          .venv/bin/python -m pytest tests/st/a2a3/host_build_graph/dfx/dep_gen/ \
             --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --manual "${{ inputs.manual_mode == 'only' && 'only' || 'include' }}" --enable-dep-gen
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,14 +70,8 @@ repos:
           name: clang-tidy
           entry: python tests/lint/clang_tidy.py
           language: system
-          types_or: [c++, c]
-          exclude: |
-            (?x)^(
-              3rdparty/|
-              python/bindings/|
-              .*/kernels/|
-              .*/aicore/
-            )
+          # clang_tidy_paths.py filters this hook before it imports the project;
+          # the pre-commit workflow uses the same policy to select its build.
 
     - repo: https://github.com/cpplint/cpplint
       rev:  2.0.0

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -121,11 +121,14 @@ same DFX smoke steps used by Per-PR run once in each Daily platform job, and
 the A2/A3 `network1` corpus runs through the existing two-machine workflow. The
 main Per-PR scene-test steps keep the default `--manual exclude`, so moving an
 ordinary case to Daily does not require a second workflow exclusion list.
-Dedicated DFX steps instead use `include` for the normal Per-PR and Daily modes
-because they own the full corpus under their target paths; a `manual_mode` of
-`only` remains `only` in those steps. Marking a DFX case manual therefore
-removes its duplicate execution from the main step without removing its
-dedicated Per-PR coverage.
+The dedicated dep-gen, chip-swimlane, PMU, and args-dump steps instead use
+`include` for the normal Per-PR and Daily modes because they own the full
+corpus under their target paths; a `manual_mode` of `only` remains `only` in
+those steps. Marking a case under one of those paths manual therefore removes
+its duplicate main-step execution without removing its dedicated Per-PR
+coverage. Scope-stats has no dedicated CI smoke: its ordinary scene test stays
+in the main sweep, and artifact validation runs only when
+`--enable-scope-stats` is supplied explicitly.
 
 Use `"manual": True` on an individual `SceneTestCase.CASES` entry and
 `@pytest.mark.manual` on a standalone pytest test. The reusable scene-test
@@ -203,7 +206,9 @@ selection is not a cached CMake variable, so a later ordinary package install
 in the same worktree still uses the default `ALL` target and auto-detects every
 available platform. The network1 stage passes the same target to its peer.
 Pre-commit selects its build from the existing files in the merge-base diff,
-the same file set its hooks inspect. A clang-tidy-eligible C/C++ change builds
+the same file set its hooks inspect. `tests/lint/clang_tidy_paths.py` supplies
+the shared path policy for the clang-tidy hook and this build selection. A
+clang-tidy-eligible C/C++ change builds
 the combined `build_package_sim` target so clang-tidy has both simulator
 compile databases. Files excluded by the clang-tidy hook — vendored
 `3rdparty/`, Python bindings, kernels, and AICore sources — do not trigger that
@@ -347,7 +352,7 @@ partitioned by target architecture, runner OS/architecture, and PTO-ISA pin.
 The callable key covers the contents of its orchestration, incore, and
 transitively included sources, the compiler identities and effective fixed
 flags, a digest of the modules that decide artifact bytes
-(`kernel_compiler.py`, `toolchain.py`, `elf_parser.py`), the binding's
+(`kernel_compiler.py`, `toolchain.py`, `compile_paths.py`, `elf_parser.py`), the binding's
 serialized-callable ABI, a manual schema constant, and the owning test class's
 qualified name. Each incore key covers the source closure, stable
 compiler-visible paths, and the compilation inputs that affect that kernel
@@ -357,6 +362,11 @@ runs on a different runner; paths outside the checkout remain absolute. The key
 excludes orchestration, callable ABI, `func_id`,
 signature, and owning test class, so callables that reference the same kernel
 path can share its artifact.
+
+This cache complements rather than replaces `ccache`: the packaging workflow
+uses `ccache` for supported CMake compiler invocations, while scene-test cache
+entries also retain serialized callables and final incore bytes, including the
+CCEC/linker and ELF-section processing used by onboard builds.
 
 Entries are content-addressed and therefore never overwritten, so a run prunes
 entries whose last use is more than 14 days old before it exits. Without that,

--- a/simpler_setup/compile_pool.py
+++ b/simpler_setup/compile_pool.py
@@ -40,6 +40,7 @@ class _CompileBudget:
 @dataclass
 class _CompilePoolState:
     budget: _CompileBudget
+    override_active: bool = False
 
 
 _budget_guard = threading.Lock()
@@ -54,17 +55,21 @@ def current_compile_workers() -> int:
 
 @contextlib.contextmanager
 def compile_worker_budget(max_workers: int):
-    """Temporarily set the process-wide compiler budget for a complete compile batch."""
+    """Temporarily set the compiler budget; only one process-wide override may be active."""
     if max_workers < 1:
         raise ValueError("max_workers must be at least 1")
     with _budget_guard:
+        if _state.override_active:
+            raise RuntimeError("only one process-wide compile worker budget override may be active")
         previous = _state.budget
         _state.budget = _CompileBudget(max_workers, threading.BoundedSemaphore(max_workers))
+        _state.override_active = True
     try:
         yield
     finally:
         with _budget_guard:
             _state.budget = previous
+            _state.override_active = False
 
 
 @contextlib.contextmanager

--- a/simpler_setup/kernel_compiler.py
+++ b/simpler_setup/kernel_compiler.py
@@ -326,9 +326,6 @@ class KernelCompiler:
         """Describe every compiler and fixed flag that affects kernel artifacts."""
         orchestration = self._orchestration_toolchain(runtime_name)
         incore_tokens = [self.incore_compile_cache_token(core_type) for core_type in sorted(set(core_types))]
-        incore_identity = incore_tokens[0]["identity"] if incore_tokens else None
-        incore_linker = incore_tokens[0]["linker"] if incore_tokens else None
-        incore_entries = [{"core_type": token["core_type"], "flags": token["flags"]} for token in incore_tokens]
         return {
             "schema": _COMPILE_CACHE_SCHEMA,
             "logic": _artifact_logic_token(),
@@ -338,9 +335,7 @@ class KernelCompiler:
                 "link_flags": self._orchestration_link_flags(orchestration),
             },
             "incore": {
-                "identity": incore_identity,
-                "variants": incore_entries,
-                "linker": incore_linker,
+                "variants": incore_tokens,
             },
         }
 

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -1207,8 +1207,6 @@ def _compile_chip_callable_from_spec(spec, platform, runtime, cache_key):
                 include_dirs,
             )
         )
-    if len(resolved_extra_dirs) != len(incores) or len(incore_artifact_keys) != len(incores):
-        raise AssertionError("per-incore cache inputs must match the incore specification")
     compiler_token = kc.compile_cache_token(runtime, [k["core_type"] for k in incores])
     artifact_key = compile_artifact_key(
         {
@@ -1231,7 +1229,7 @@ def _compile_chip_callable_from_spec(spec, platform, runtime, cache_key):
                     "signature": k.get("signature", []),
                     "artifact_key": incore_artifact_key,
                 }
-                for k, incore_artifact_key in zip(incores, incore_artifact_keys)
+                for k, incore_artifact_key in zip(incores, incore_artifact_keys, strict=True)
             ],
         },
         orchestration_units,
@@ -1251,6 +1249,7 @@ def _compile_chip_callable_from_spec(spec, platform, runtime, cache_key):
                         pto_isa_root=pto_isa_root,
                         extra_include_dirs=inc_dirs + extra,
                     )
+                # The cached representation is determined only by platform, which is in the artifact key.
                 return binary if is_sim else extract_text_section(binary)
 
             return get_or_compile_incore(incore_artifact_key, compile_missing_incore)
@@ -1265,7 +1264,9 @@ def _compile_chip_callable_from_spec(spec, platform, runtime, cache_key):
                     extra,
                     incore_artifact_key,
                 )
-                for k, extra, incore_artifact_key in zip(incores, resolved_extra_dirs, incore_artifact_keys)
+                for k, extra, incore_artifact_key in zip(
+                    incores, resolved_extra_dirs, incore_artifact_keys, strict=True
+                )
             ]
             orch_binary = orch_future.result()
             incores_binary = [future.result() for future in incore_futures]
@@ -1719,6 +1720,8 @@ class SceneTestCase:
         matched = self._matching_cases(st_platform, request)
         manual_mode = request.config.getoption("--manual", default="exclude")
         if not matched:
+            # Skip before building and before control returns to subclass
+            # overrides: no case ran, so their post-run validators must not run.
             import pytest  # noqa: PLC0415
 
             pytest.skip(f"No cases matched {type(self).__name__} (platform={st_platform}, manual={manual_mode})")

--- a/tests/lint/clang_tidy.py
+++ b/tests/lint/clang_tidy.py
@@ -26,12 +26,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+from clang_tidy_paths import should_run_clang_tidy
+
 _ROOT = Path(__file__).resolve().parents[2]
 _BUILD_RUNTIMES = _ROOT / "simpler_setup" / "build_runtimes.py"
 _CACHE_DIR = _ROOT / "build" / "cache"
-
-from simpler_setup.platform_info import load_build_config, to_platform  # noqa: E402
-from simpler_setup.runtime_compiler import RuntimeCompiler  # noqa: E402
 
 
 def _macos_isysroot_args() -> list[str]:
@@ -159,6 +158,9 @@ def _parse_db_path(db_file: Path) -> tuple[str, str, str, str]:
 
 def _reconfigure_compile_database(db_file: Path) -> None:
     """Delete the broken target build dir and rerun CMake configure for it."""
+    from simpler_setup.platform_info import load_build_config, to_platform  # noqa: PLC0415
+    from simpler_setup.runtime_compiler import RuntimeCompiler  # noqa: PLC0415
+
     arch, variant, runtime_name, target = _parse_db_path(db_file)
     platform = to_platform(arch, variant)
     config_path = _ROOT / "src" / arch / "runtime" / runtime_name / "build_config.py"
@@ -251,7 +253,7 @@ def _build_file_index() -> dict[str, list[Path]]:
 
 
 def main() -> int:
-    changed = [os.path.abspath(f) for f in sys.argv[1:]]
+    changed = [os.path.abspath(path) for path in sys.argv[1:] if should_run_clang_tidy(path)]
     if not changed:
         return 0
 

--- a/tests/lint/clang_tidy_paths.py
+++ b/tests/lint/clang_tidy_paths.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Classify changed paths for the clang-tidy hook and its CI preparation."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+_CPP_SUFFIXES = frozenset(
+    {
+        ".c",
+        ".c++",
+        ".c++m",
+        ".cc",
+        ".ccm",
+        ".cpp",
+        ".cppm",
+        ".cxx",
+        ".cxxm",
+        ".h",
+        ".hh",
+        ".hpp",
+        ".hxx",
+        ".inl",
+        ".ino",
+        ".ipp",
+        ".ixx",
+        ".mm",
+        ".tpp",
+    }
+)
+_RECOGNIZED_NON_CPP_SUFFIXES = frozenset(
+    {
+        ".asc",
+        ".cce",
+        ".gyp",
+        ".gypi",
+        ".py",
+        ".pyi",
+        ".pyt",
+        ".tac",
+        ".wsgi",
+        ".md",
+        ".rst",
+        ".txt",
+        ".yml",
+        ".yaml",
+        ".json",
+        ".toml",
+        ".pin",
+        ".cmake",
+        ".in",
+        ".sh",
+        ".bash",
+        ".zsh",
+        ".fish",
+        ".gitignore",
+        ".clang-format",
+        ".clang-tidy",
+    }
+)
+
+
+def _relative_path(path: str) -> str:
+    """Normalize a repository-relative or repository-local absolute path."""
+    candidate = Path(path.replace("\\", "/"))
+    if candidate.is_absolute():
+        try:
+            candidate = candidate.relative_to(_ROOT)
+        except ValueError:
+            return candidate.as_posix()
+    return candidate.as_posix().removeprefix("./")
+
+
+def is_cpp_path(path: str) -> bool:
+    """Return whether pre-commit treats a path as C or C++ source."""
+    return Path(_relative_path(path)).suffix.lower() in _CPP_SUFFIXES
+
+
+def is_clang_tidy_excluded(path: str) -> bool:
+    """Return whether the clang-tidy policy excludes a C or C++ path."""
+    normalized = _relative_path(path)
+    return (
+        normalized.startswith("3rdparty/")
+        or normalized.startswith("python/bindings/")
+        or "/kernels/" in normalized
+        or "/aicore/" in normalized
+    )
+
+
+def should_run_clang_tidy(path: str) -> bool:
+    """Return whether clang-tidy should inspect a changed path."""
+    return is_cpp_path(path) and not is_clang_tidy_excluded(path)
+
+
+def needs_pre_commit_build(path: str) -> bool:
+    """Return whether a changed, existing path needs the simulator build."""
+    normalized = _relative_path(path)
+    if normalized == ".pre-commit-config.yaml":
+        return True
+    if should_run_clang_tidy(normalized):
+        return True
+    if is_cpp_path(normalized):
+        return False
+
+    lower_path = normalized.lower()
+    path = Path(lower_path)
+    if path.suffix in _RECOGNIZED_NON_CPP_SUFFIXES or path.name in _RECOGNIZED_NON_CPP_SUFFIXES:
+        return False
+    if path.name == "license" or path.name.startswith("license."):
+        return False
+    return True
+
+
+def _existing_paths(paths: Iterable[str]) -> Iterable[str]:
+    for path in paths:
+        if os.path.exists(path) or os.path.islink(path):
+            yield path
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--needs-build",
+        action="store_true",
+        help="print whether any changed path needs a build",
+    )
+    parser.add_argument(
+        "--null",
+        action="store_true",
+        help="read NUL-delimited paths from standard input",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    if not args.needs_build or not args.null:
+        raise SystemExit("--needs-build and --null are required")
+
+    paths = (os.fsdecode(path) for path in sys.stdin.buffer.read().split(b"\0") if path)
+    print(str(any(needs_pre_commit_build(path) for path in _existing_paths(paths))).lower())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
@@ -107,11 +107,17 @@ class TestArgsDump(SceneTestCase):
         # Marker taken before the run so we bind to this invocation's output dir
         # rather than a stale same-label leftover from a prior run/session.
         run_marker = int(time.time())  # floor to whole seconds: safe if outputs/ ever lands on a coarse-mtime fs
-        super().test_run(st_platform, st_worker, request)
         level = int(request.config.getoption("--dump-args", default=0))
+        if level:
+            matched = self._matching_cases(st_platform, request)
+            assert len(matched) <= 1, (
+                "args-dump artifact assertions describe one case; add a case-specific "
+                "validator before extending TestArgsDump.CASES"
+            )
+        super().test_run(st_platform, st_worker, request)
         if not level:
             return
-        safe_label = _sanitize_for_filename("TestArgsDump_default")
+        safe_label = _sanitize_for_filename(f"TestArgsDump_{matched[0]['name']}")
         matches = [p for p in _outputs_dir().glob(f"{safe_label}_*") if p.stat().st_mtime >= run_marker]
         assert matches, "no args dump output directory created this run"
         out_dir = max(matches, key=lambda p: p.stat().st_mtime)

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/test_chip_swimlane_mixed.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/test_chip_swimlane_mixed.py
@@ -137,8 +137,9 @@ class TestChipSwimlaneMixed(SceneTestCase):
         # invocation's output dir rather than a stale same-label leftover.
         run_marker = int(time.time())  # floor to whole seconds: safe if outputs/ ever lands on a coarse-mtime fs
         super().test_run(st_platform, st_worker, request)
+        matched = self._matching_cases(st_platform, request)
         if request.config.getoption("--enable-chip-swimlane", default=False):
-            for case in self._matching_cases(st_platform, request):
+            for case in matched:
                 # Rely on the differential gate (Pop / Fanout / Fanin) —
                 # the chain produces 3 MIX task_ids × 2 subtask rows = 6
                 # perf rows and 2 deps.json edges, so the dedup branch in
@@ -147,16 +148,17 @@ class TestChipSwimlaneMixed(SceneTestCase):
         # Full-dump modes give the func_id array its regression barrier on the
         # cooperative-mix path (single-kernel coverage lives in test_args_dump).
         if int(request.config.getoption("--dump-args", default=0)) >= 2:
-            self._validate_dump_func_ids(run_marker)
+            for case in matched:
+                self._validate_dump_func_ids(case, run_marker)
 
-    def _validate_dump_func_ids(self, since):
+    def _validate_dump_func_ids(self, case, since):
         """#1181: every chained_mix task is a 2-way cooperative MIX (MATMUL
         func 0 + AIV ADD func 1) sharing one 6-tensor payload, so every dumped
         slot must carry the same active-subtask membership ``func_id == [0, 1]``,
         and each ``(task, slot, stage)`` is emitted exactly once — not
         duplicated per subtask as the pre-#1181 geometry did.
         """
-        safe_label = _sanitize_for_filename("TestChipSwimlaneMixed_default")
+        safe_label = _sanitize_for_filename(f"TestChipSwimlaneMixed_{case['name']}")
         matches = [p for p in _outputs_dir().glob(f"{safe_label}_*") if p.stat().st_mtime >= since]
         assert matches, "no args dump output directory created this run"
         out_dir = max(matches, key=lambda p: p.stat().st_mtime)

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
@@ -91,6 +91,8 @@ class TestDepGenChain(SceneTestCase):
             "config": {"aicpu_thread_num": 2},
             "params": {"n": 64},
         },
+        # Keep one representative boundary in the default Sim sweep; the
+        # dedicated DFX step reruns it with dep-gen capture/replay enabled.
         {
             "name": "n_65_single_overflow",
             "platforms": ["a2a3sim", "a2a3"],

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
@@ -107,11 +107,17 @@ class TestArgsDump(SceneTestCase):
         # Marker taken before the run so we bind to this invocation's output dir
         # rather than a stale same-label leftover from a prior run/session.
         run_marker = int(time.time())  # floor to whole seconds: safe if outputs/ ever lands on a coarse-mtime fs
-        super().test_run(st_platform, st_worker, request)
         level = int(request.config.getoption("--dump-args", default=0))
+        if level:
+            matched = self._matching_cases(st_platform, request)
+            assert len(matched) <= 1, (
+                "args-dump artifact assertions describe one case; add a case-specific "
+                "validator before extending TestArgsDump.CASES"
+            )
+        super().test_run(st_platform, st_worker, request)
         if not level:
             return
-        safe_label = _sanitize_for_filename("TestArgsDump_default")
+        safe_label = _sanitize_for_filename(f"TestArgsDump_{matched[0]['name']}")
         matches = [p for p in _outputs_dir().glob(f"{safe_label}_*") if p.stat().st_mtime >= run_marker]
         assert matches, "no args dump output directory created this run"
         out_dir = max(matches, key=lambda p: p.stat().st_mtime)

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/test_chip_swimlane_mixed.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/test_chip_swimlane_mixed.py
@@ -137,8 +137,9 @@ class TestChipSwimlaneMixed(SceneTestCase):
         # invocation's output dir rather than a stale same-label leftover.
         run_marker = int(time.time())  # floor to whole seconds: safe if outputs/ ever lands on a coarse-mtime fs
         super().test_run(st_platform, st_worker, request)
+        matched = self._matching_cases(st_platform, request)
         if request.config.getoption("--enable-chip-swimlane", default=False):
-            for case in self._matching_cases(st_platform, request):
+            for case in matched:
                 # Rely on the differential gate (Pop / Fanout / Fanin) —
                 # the chain produces 3 MIX task_ids × 2 subtask rows = 6
                 # perf rows and 2 deps.json edges, so the dedup branch in
@@ -151,16 +152,17 @@ class TestChipSwimlaneMixed(SceneTestCase):
         # Full-dump modes give the func_id array its regression barrier on the
         # cooperative-mix path (single-kernel coverage lives in test_args_dump).
         if int(request.config.getoption("--dump-args", default=0)) >= 2:
-            self._validate_dump_func_ids(run_marker)
+            for case in matched:
+                self._validate_dump_func_ids(case, run_marker)
 
-    def _validate_dump_func_ids(self, since):
+    def _validate_dump_func_ids(self, case, since):
         """#1181: every chained_mix task is a 2-way cooperative MIX (MATMUL
         func 0 + AIV ADD func 1) sharing one 6-tensor payload, so every dumped
         slot must carry the same active-subtask membership ``func_id == [0, 1]``,
         and each ``(task, slot, stage)`` is emitted exactly once — not
         duplicated per subtask as the pre-#1181 geometry did.
         """
-        safe_label = _sanitize_for_filename("TestChipSwimlaneMixed_default")
+        safe_label = _sanitize_for_filename(f"TestChipSwimlaneMixed_{case['name']}")
         matches = [p for p in _outputs_dir().glob(f"{safe_label}_*") if p.stat().st_mtime >= since]
         assert matches, "no args dump output directory created this run"
         out_dir = max(matches, key=lambda p: p.stat().st_mtime)

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
@@ -87,6 +87,8 @@ class TestDepGenChain(SceneTestCase):
             "config": {"aicpu_thread_num": 2},
             "params": {"n": 64},
         },
+        # Keep one representative boundary in the default Sim sweep; the
+        # dedicated DFX step reruns it with dep-gen capture/replay enabled.
         {
             "name": "n_65_single_overflow",
             "platforms": ["a5sim", "a5"],

--- a/tests/ut/py/test_compile_pool.py
+++ b/tests/ut/py/test_compile_pool.py
@@ -10,7 +10,9 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
-from threading import Barrier, Event, Lock
+from threading import Barrier, Event, Lock, Thread
+
+import pytest
 
 from simpler_setup import compile_pool
 
@@ -74,3 +76,29 @@ def test_compile_slots_bound_nested_thread_pools():
                 future.result()
 
     assert peak == 2
+
+
+def test_compile_worker_budget_rejects_nested_overrides():
+    with compile_pool.compile_worker_budget(2), pytest.raises(RuntimeError, match="only one process-wide"):
+        with compile_pool.compile_worker_budget(1):
+            pass
+
+
+def test_compile_worker_budget_rejects_concurrent_overrides():
+    entered = Event()
+    release = Event()
+
+    def hold_override():
+        with compile_pool.compile_worker_budget(2):
+            entered.set()
+            assert release.wait(timeout=2)
+
+    worker = Thread(target=hold_override)
+    worker.start()
+    assert entered.wait(timeout=2)
+    with pytest.raises(RuntimeError, match="only one process-wide"):
+        with compile_pool.compile_worker_budget(1):
+            pass
+    release.set()
+    worker.join(timeout=2)
+    assert not worker.is_alive()

--- a/tests/ut/py/test_kernel_compiler.py
+++ b/tests/ut/py/test_kernel_compiler.py
@@ -112,3 +112,22 @@ def test_compiler_subprocess_runs_from_checkout_root(monkeypatch):
     compiler._run_subprocess(["compiler"], "test")
 
     assert captured["cwd"] == PROJECT_ROOT
+
+
+def test_compile_cache_token_preserves_every_incore_toolchain_token(monkeypatch):
+    from simpler_setup import kernel_compiler  # noqa: PLC0415
+
+    compiler = kernel_compiler.KernelCompiler.__new__(kernel_compiler.KernelCompiler)
+    compiler._orchestration_toolchain = lambda _runtime: SimpleNamespace(cxx_path="orch-cxx")
+    compiler._orchestration_compile_flags = lambda _toolchain: ["-orch"]
+    compiler._orchestration_link_flags = lambda _toolchain: ["-link"]
+    tokens = {
+        "aic": {"core_type": "aic", "identity": {"name": "ccec"}, "flags": ["-aic"], "linker": "ld-aic"},
+        "aiv": {"core_type": "aiv", "identity": {"name": "aicore-cc"}, "flags": ["-aiv"], "linker": "ld-aiv"},
+    }
+    compiler.incore_compile_cache_token = lambda core_type: tokens[core_type]
+    monkeypatch.setattr(kernel_compiler, "_executable_cache_identity", lambda _path: {"name": "orch-cxx"})
+
+    token = compiler.compile_cache_token("host_build_graph", ["aiv", "aic"])
+
+    assert token["incore"] == {"variants": [tokens["aic"], tokens["aiv"]]}

--- a/tests/ut/py/test_pre_commit_build_selection.py
+++ b/tests/ut/py/test_pre_commit_build_selection.py
@@ -7,15 +7,41 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
+import importlib.util
 import os
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).parents[3]
 WORKFLOW = REPO_ROOT / ".github/workflows/_pre-commit.yml"
+PATH_HELPER = REPO_ROOT / "tests/lint/clang_tidy_paths.py"
+CLANG_TIDY = REPO_ROOT / "tests/lint/clang_tidy.py"
+PRE_COMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
+
+
+def _load_path_helper():
+    spec = importlib.util.spec_from_file_location("clang_tidy_paths", PATH_HELPER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+PATH_HELPER_MODULE = _load_path_helper()
+
+
+def _load_clang_tidy_module(monkeypatch):
+    monkeypatch.syspath_prepend(str(CLANG_TIDY.parent))
+    spec = importlib.util.spec_from_file_location("clang_tidy_under_test", CLANG_TIDY)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _selection_script() -> str:
@@ -44,7 +70,14 @@ def _commit(repo: Path, relative_path: str, contents: str) -> str:
 
 def _run_selection(repo: Path, base: str, head: str, output: Path) -> dict[str, str]:
     env = os.environ.copy()
-    env.update({"BASE_SHA": base, "HEAD_SHA": head, "GITHUB_OUTPUT": str(output)})
+    env.update(
+        {
+            "BASE_SHA": base,
+            "HEAD_SHA": head,
+            "GITHUB_OUTPUT": str(output),
+            "GITHUB_WORKSPACE": str(REPO_ROOT),
+        }
+    )
     result = subprocess.run(
         ["bash", "-euo", "pipefail", "-c", _selection_script()],
         cwd=repo,
@@ -60,12 +93,66 @@ def _run_selection(repo: Path, base: str, head: str, output: Path) -> dict[str, 
     return dict(line.split("=", 1) for line in output.read_text().splitlines())
 
 
-def test_selection_script_uses_macos_bash_compatible_case_matching() -> None:
+def test_selection_script_delegates_path_matching_to_the_shared_helper() -> None:
     script = _selection_script()
 
-    assert "${path,,}" not in script
-    assert "shopt -s nocasematch" in script
-    assert "shopt -u nocasematch" in script
+    assert 'python "$GITHUB_WORKSPACE/tests/lint/clang_tidy_paths.py" --needs-build --null' in script
+    assert 'case "$path"' not in script
+
+
+def test_clang_tidy_hook_delegates_path_matching_to_the_shared_helper() -> None:
+    config = yaml.safe_load(PRE_COMMIT_CONFIG.read_text())
+    clang_tidy_hook = next(
+        hook
+        for repository in config["repos"]
+        if repository["repo"] == "local"
+        for hook in repository["hooks"]
+        if hook["id"] == "clang-tidy"
+    )
+
+    assert "types_or" not in clang_tidy_hook
+    assert "exclude" not in clang_tidy_hook
+    assert "from clang_tidy_paths import should_run_clang_tidy" in CLANG_TIDY.read_text()
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("src/common/api.cpp", True),
+        ("3rdparty/dependency.cpp", False),
+        ("python/bindings/module.cpp", False),
+        ("examples/a2a3/demo/kernels/aic/kernel.cpp", False),
+        ("src/a2a3/runtime/demo/aicore/kernel.cpp", False),
+        (str(REPO_ROOT / "python/bindings/module.cpp"), False),
+        (str(REPO_ROOT / "examples/a2a3/demo/kernels/aic/kernel.cpp"), False),
+        (str(REPO_ROOT / "src/common/api.cpp"), True),
+        ("Python/Bindings/module.cpp", True),
+        ("src/a2a3/runtime/demo/Kernels/kernel.cpp", True),
+    ],
+)
+def test_clang_tidy_path_selection_has_one_case_sensitive_contract(path: str, expected: bool) -> None:
+    assert PATH_HELPER_MODULE.should_run_clang_tidy(path) is expected
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "3rdparty/dependency.cpp",
+        "python/bindings/module.cpp",
+        "examples/a2a3/demo/kernels/aic/kernel.cpp",
+        "src/a2a3/runtime/demo/aicore/kernel.cpp",
+    ],
+)
+def test_clang_tidy_excluded_paths_exit_before_build_or_compile_database(monkeypatch, path: str) -> None:
+    module = _load_clang_tidy_module(monkeypatch)
+
+    def unexpected_build() -> None:
+        pytest.fail("excluded path reached clang-tidy build/cache handling")
+
+    monkeypatch.setattr(module, "_ensure_sim_cache", unexpected_build)
+    monkeypatch.setattr(sys, "argv", [str(CLANG_TIDY), path])
+
+    assert module.main() == 0
 
 
 def test_self_cpu_uses_the_project_venv_for_lint() -> None:
@@ -108,6 +195,9 @@ def test_only_selected_build_paths_install_the_project() -> None:
         (["docs/readme.md"], {"needs_build": "false"}),
         ([".github/actions/setup-gcc-15/ubuntu-toolchain-r-test.asc"], {"needs_build": "false"}),
         ([".pre-commit-config.yaml"], {"needs_build": "true"}),
+        ([".clang-tidy"], {"needs_build": "false"}),
+        ([".clang-format"], {"needs_build": "false"}),
+        ([".gitignore"], {"needs_build": "false"}),
         (["python/simpler/api.py"], {"needs_build": "false"}),
         (["python/simpler/api.PYI"], {"needs_build": "false"}),
         (["tools/server.wsgi"], {"needs_build": "false"}),


### PR DESCRIPTION
## Summary

This PR combines small post-review follow-ups for #1823, #1829, and #1869.

- DFX selection and artifacts:
  - Run the A2/A3 host-build-graph dep-gen smoke against its complete directory.
  - Keep `n_65_single_overflow` in the default Sim sweep, while the dedicated DFX step reruns it with dep-gen capture/replay enabled.
  - Derive mixed chip-swimlane and args-dump artifact labels from the cases selected for this invocation. Args-dump requires a single selected case only when `--dump-args` artifact validation is enabled.
  - Document why an empty scene selection skips before callable construction and subclass post-validation, and document that scope-stats JSONL validation requires `--enable-scope-stats`.

- clang-tidy path policy:
  - Centralize clang-tidy inclusion/exclusion and the CI simulator-build decision in `tests/lint/clang_tidy_paths.py`.
  - Make both the pre-commit hook and `_pre-commit.yml` use that helper, so excluded paths cannot trigger clang-tidy or create a CI build-selection mismatch.
  - Add tests for the shared policy, repository-local absolute paths, dotfile-only changes, and excluded files exiting before clang-tidy build or compile-database work.

- Persistent scene-test cache follow-ups:
  - Preserve each incore compiler token in the callable cache key.
  - Make compiler-budget overrides process-wide exclusive, with nested and concurrent coverage.
  - Document the artifact-cache module set and why the cache complements `ccache`.

The DFX changes do not alter selected case counts.

## Validation

- `python -m pytest tests/ut/py/test_pre_commit_build_selection.py tests/ut/py/test_scene_level_selection.py -q` — 52 passed.
- Focused DFX Sim scenarios passed on A2/A3 and A5, including args-dump and scope-stats validation.
- Local follow-up validation: `python -m pytest tests/ut/py/test_compile_pool.py tests/ut/py/test_kernel_compiler.py tests/ut/py/test_scene_test_cache.py tests/ut/py/test_pre_commit_build_selection.py` — 101 passed.
- `python -m pre_commit run --files $(git diff --name-only upstream/main...HEAD)` — passed.
- `git diff --check upstream/main...HEAD` — passed.
