### PR TITLE
Fix: name every unknown attachment enum and cover the adapter-less row

### DIFF
--- a/python/simpler/comm_endpoints.py
+++ b/python/simpler/comm_endpoints.py
@@ -465,6 +465,9 @@ class RegionPartKind(str, Enum):
     COUNTER = "COUNTER"
 
 
+# These three enums are also a wire contract: `global_comm_domain` maps each value to a numeric id
+# for the version-2 `GlobalDomainCommand` attachment records. A new enumerator needs a new id there,
+# and a rename or renumber is a wire break — see that module's `_ATTACHMENT_ROLE_IDS` block.
 class AttachmentRole(str, Enum):
     PROVIDER = "PROVIDER"
     CONSUMER = "CONSUMER"

--- a/python/simpler/global_comm_domain.py
+++ b/python/simpler/global_comm_domain.py
@@ -309,6 +309,12 @@ def validate_member_table(members: tuple[GlobalDomainMember, ...]) -> None:
         raise ValueError("global domain members require unique non-negative global device ranks")
 
 
+# Wire ids for the three ``comm_endpoints`` enums this command carries. They are string enums, so
+# the wire needs its own numbering, and these numbers are part of the version-2 command format: a
+# value's id is fixed for the life of the version, and 0 is reserved for "no adapter". Adding an
+# enumerator means adding an id here; renaming or renumbering one is a wire break. Encoding and
+# decoding both reject an id this table does not name, so an enumerator that is added upstream and
+# not mirrored here fails closed rather than travelling as a wrong value.
 _ATTACHMENT_ROLE_IDS = {
     AttachmentRole.PROVIDER: 1,
     AttachmentRole.CONSUMER: 2,
@@ -392,8 +398,16 @@ def _normalize_attachment(attachment: GlobalDomainAttachment) -> GlobalDomainAtt
         role = AttachmentRole(attachment.role)
     except (TypeError, ValueError) as exc:
         raise ValueError(f"global domain attachment role is unknown: {attachment.role!r}") from exc
-    adapter_kind = None if attachment.adapter_kind is None else AdapterKind(attachment.adapter_kind)
-    adapter_profile = None if attachment.adapter_profile is None else AdapterProfile(attachment.adapter_profile)
+    try:
+        adapter_kind = None if attachment.adapter_kind is None else AdapterKind(attachment.adapter_kind)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"global domain attachment adapter_kind is unknown: {attachment.adapter_kind!r}") from exc
+    try:
+        adapter_profile = None if attachment.adapter_profile is None else AdapterProfile(attachment.adapter_profile)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"global domain attachment adapter_profile is unknown: {attachment.adapter_profile!r}"
+        ) from exc
     if (adapter_kind is None) != (adapter_profile is None):
         raise ValueError("global domain attachment adapter_kind and adapter_profile must be paired")
     if int(attachment.node_worker_id) < 0:

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -9244,7 +9244,9 @@ class Worker:
     ) -> tuple[GlobalDomainDescriptor, ...]:
         if self.level != 3 or self._worker is None:
             raise RuntimeError("Global CommDomain node prepare requires a ready L3 Worker")
-        command.attachments_for_node(node_worker_id)
+        # PREPARE_EXPORT is where the row is stored for IMPORT and COMMIT to reuse, so a table this
+        # node has no row in is rejected here rather than at the first phase that reads one.
+        _ = command.attachments_for_node(node_worker_id)
         prior = self._global_node_domains.get(command.domain_id)
         if prior is not None:
             if self._global_domain_command_identity(prior.command) != self._global_domain_command_identity(command):

--- a/tests/ut/py/test_global_comm_domain.py
+++ b/tests/ut/py/test_global_comm_domain.py
@@ -10,12 +10,15 @@
 from __future__ import annotations
 
 import os
+import re
 import socket
 import subprocess
 import sys
 import threading
 import time
 from collections import Counter
+from dataclasses import replace
+from pathlib import Path
 from typing import cast
 
 import pytest
@@ -104,6 +107,17 @@ def _descriptors() -> tuple[GlobalDomainDescriptor, ...]:
         )
         for rank in range(2)
     )
+
+
+def test_global_domain_version_matches_the_native_header():
+    # The version is spelled twice -- GLOBAL_DOMAIN_VERSION here and COMM_GLOBAL_DOMAIN_VERSION in
+    # the platform header -- and every decoder compares it for strict equality with no negotiation.
+    # Bumping one alone therefore surfaces only as a descriptor-version rejection inside
+    # comm_hccl.cpp / comm_sim.cpp on a real device, which no host-side test would catch.
+    header = Path(__file__).resolve().parents[3] / "src" / "common" / "platform_comm" / "comm.h"
+    match = re.search(r"^#define\s+COMM_GLOBAL_DOMAIN_VERSION\s+(\d+)U?\s*$", header.read_text(), re.MULTILINE)
+    assert match is not None, f"COMM_GLOBAL_DOMAIN_VERSION not found in {header}"
+    assert int(match.group(1)) == GLOBAL_DOMAIN_VERSION
 
 
 @pytest.mark.parametrize(
@@ -255,6 +269,39 @@ def test_global_domain_attachment_table_requires_complete_unique_receiver_rows()
     assert GLOBAL_DOMAIN_MAX_ATTACHMENTS == 64 * 64
 
 
+def test_global_domain_attachment_names_every_unknown_enum_field():
+    # Each of the four enum-typed fields reports which field was wrong. `address_space` and `role`
+    # were already wrapped; `adapter_kind` and `adapter_profile` used to surface the raw enum
+    # ValueError, which names the value but not the field it came from.
+    def make_command(attachment: GlobalDomainAttachment) -> GlobalDomainCommand:
+        row = (attachment, replace(attachment, adapter_kind=None, adapter_profile=None))
+        return GlobalDomainCommand(
+            phase=GlobalDomainPhase.PREPARE_EXPORT,
+            domain_id=12,
+            generation=1,
+            name="attachment-enums",
+            profile="sim",
+            window_size=2048,
+            members=_members(),
+            buffers=(),
+            attachments=row,
+        )
+
+    good = _attachments()[0]
+    for field, bad_value in (
+        ("address_space", 9),
+        ("role", "NOT_A_ROLE"),
+        ("adapter_kind", "NOT_A_KIND"),
+        ("adapter_profile", "NOT_A_PROFILE"),
+    ):
+        with pytest.raises(ValueError, match=f"attachment {field} is unknown"):
+            encode_domain_command(make_command(replace(good, **{field: bad_value})))
+
+    # A None pair stays legal; only a half-set pair is rejected, and by its own message.
+    with pytest.raises(ValueError, match="must be paired"):
+        encode_domain_command(make_command(replace(good, adapter_profile=None)))
+
+
 def test_global_domain_encode_rejects_too_many_buffers():
     command = GlobalDomainCommand(
         phase=GlobalDomainPhase.PREPARE_EXPORT,
@@ -271,21 +318,28 @@ def test_global_domain_encode_rejects_too_many_buffers():
         encode_domain_command(command)
 
 
-def _failure_injection_worker(*, platform: str = "a2a3sim", profile: str = "sim"):
+def _failure_injection_worker(*, platform: str = "a2a3sim", profile: str = "sim", hosts=None):
+    """Two remote L3 nodes under one L4.
+
+    ``hosts`` defaults to both nodes on one host, which is what the failure-injection tests want
+    (they exercise phase rollback, not topology). Endpoint capability is decided per node identity,
+    so a test that cares whether two nodes are on the *same* machine passes distinct hosts.
+    """
     from simpler.worker import RemoteWorkerSpec, Worker, _RunResources  # noqa: PLC0415
 
+    hosts = ("127.0.0.1", "127.0.0.1") if hosts is None else tuple(hosts)
     worker = Worker(level=4, num_sub_workers=0)
     node_ids = tuple(
         worker.add_remote_worker(
             RemoteWorkerSpec(
-                endpoint=f"127.0.0.1:{19073 + index}",
+                endpoint=f"{host}:{19073 + index}",
                 platform=platform,
                 device_ids=(0,),
                 comm_profile=profile,
                 global_device_ranks=(index,),
             )
         )
-        for index in range(2)
+        for index, host in enumerate(hosts)
     )
     resources = _RunResources()
     worker._worker = object()
@@ -462,6 +516,73 @@ def test_allocate_global_domain_builds_one_attachment_row_per_receiver_node(monk
         assert calls
     finally:
         _close_failure_injection_worker(worker, resources)
+
+
+def _attachment_matrix_for_hosts(monkeypatch, hosts):
+    """Allocate one two-rank domain across ``hosts`` and return (node_ids, handle.attachments)."""
+    from simpler.task_interface import CommBufferSpec  # noqa: PLC0415
+
+    worker, resources, node_ids = _failure_injection_worker(hosts=hosts)
+    _install_global_domain_failure_injector(monkeypatch, worker, fail_phase=None, fail_node=-1)
+    try:
+        handle = worker._allocate_global_domain(
+            name="attachment-adapters",
+            members=((node_ids[0], 0), (node_ids[1], 0)),
+            window_size=4096,
+            buffers=[CommBufferSpec("payload", "uint8", 4096, 4096)],
+            retain_after_run=False,
+        )
+        return node_ids, handle.attachments
+    finally:
+        _close_failure_injection_worker(worker, resources)
+
+
+def test_attachment_adapters_come_from_the_endpoint_planner_per_pair(monkeypatch):
+    # The matrix is per (receiver node, rank) because the answer differs per pair, which is the
+    # whole reason a row cannot collapse to one entry per host. Two nodes on one machine reach
+    # every rank window the same way; two nodes on different machines reach only their own.
+    same_ids, same_host = _attachment_matrix_for_hosts(monkeypatch, ("127.0.0.1", "127.0.0.1"))
+    cross_ids, cross_host = _attachment_matrix_for_hosts(monkeypatch, ("10.0.0.1", "10.0.0.2"))
+
+    assert len(same_host) == 4
+    assert all(attachment.adapter_kind is AdapterKind.OWNER_DELEGATED_COPY for attachment in same_host)
+    assert all(attachment.adapter_profile is AdapterProfile.HOST_VMM_COPY for attachment in same_host)
+
+    # Cross-machine: the diagonal (a node reaching the rank it owns) resolves; the off-diagonal
+    # does not, and is carried as an adapter-less host consumer rather than as a usable mapping.
+    assert len(cross_host) == 4
+    resolved = {index for index, attachment in enumerate(cross_host) if attachment.adapter_kind is not None}
+    assert resolved == {0, 3}, cross_host
+    for index in (1, 2):
+        assert cross_host[index].adapter_kind is None
+        assert cross_host[index].adapter_profile is None
+    # An adapter-less row is still a complete, HOST-consumer record on both topologies.
+    for row in (same_host, cross_host):
+        assert all(attachment.address_space is AddressSpace.HOST for attachment in row)
+        assert all(attachment.role is AttachmentRole.CONSUMER for attachment in row)
+    assert same_ids == cross_ids
+
+
+def test_attachment_adapter_pair_survives_a_wire_round_trip_with_and_without_an_adapter(monkeypatch):
+    # The None adapter has to survive encode/decode as None, not as a zero-valued enumerator:
+    # the wire reserves id 0 for "no adapter", and only a round trip proves the two directions
+    # agree on that.
+    _node_ids, cross_host = _attachment_matrix_for_hosts(monkeypatch, ("10.0.0.1", "10.0.0.2"))
+    assert any(attachment.adapter_kind is None for attachment in cross_host)
+    assert any(attachment.adapter_kind is not None for attachment in cross_host)
+
+    command = GlobalDomainCommand(
+        phase=GlobalDomainPhase.PREPARE_EXPORT,
+        domain_id=7,
+        generation=1,
+        name="round-trip",
+        profile="sim",
+        window_size=4096,
+        members=_members(),
+        buffers=(GlobalDomainBuffer("payload", 4096),),
+        attachments=cross_host,
+    )
+    assert decode_domain_command(encode_domain_command(command)).attachments == cross_host
 
 
 def test_global_domain_abort_failure_preserves_primary_error_and_poisons_admission(monkeypatch):


### PR DESCRIPTION
## Summary

Follow-ups to #1879, plus its one unresolved review thread. No wire change.

**The unresolved thread — every unknown enum field now names itself.** `_normalize_attachment` wrapped `address_space` and `role` to report which field was wrong, but converted `adapter_kind` and `adapter_profile` directly, so an invalid value there surfaced `'X' is not a valid AdapterKind` — the value, not the field it arrived in. All four report the same way now. The test drives all four fields plus the half-set adapter pair, and fails against `main` on exactly the two unwrapped ones.

**The adapter-less row had no coverage, and it is the cross-machine common case.** The matrix carries one entry per (receiving node, rank) because the answer differs per pair — but `_failure_injection_worker` puts both nodes on `127.0.0.1`, so endpoint capability resolved identically for all four entries and the `UnsupportedRegionPlan` branch never ran. `#1879`'s matrix test asserts cardinality and `address_space`, never an adapter value, so it could not tell a resolved adapter from a hardcoded one either.

The helper now takes `hosts` (default unchanged, so the rollback tests are untouched — they exercise phase failure, not topology), and a test allocates across two machines and pins the mixed result:

| receiver | rank it reaches | adapter |
| --- | --- | --- |
| node 0 | own | `OWNER_DELEGATED_COPY` / `HOST_VMM_COPY` |
| node 0 | node 1's | none |
| node 1 | node 0's | none |
| node 1 | own | `OWNER_DELEGATED_COPY` / `HOST_VMM_COPY` |

That is the shape that justifies the matrix: one entry per host could not express it. It also demonstrates the planner is the authority rather than a constant, which the same-host topology cannot. A second test round-trips that mixed row through the codec — wire id 0 means "no adapter", and only a round trip shows the encoder and decoder agree that it is `None` and not a zero-valued enumerator.

Both fail against `main` when the `UnsupportedRegionPlan` guard is neutralized, which is what pins the branch.

**One version, spelled twice, with nothing tying them together.** `GLOBAL_DOMAIN_VERSION` and `COMM_GLOBAL_DOMAIN_VERSION` are compared for strict equality with no negotiation, and #1879 bumped both by hand. Nothing asserted they agree: `git grep COMM_GLOBAL_DOMAIN_VERSION -- tests/` was empty against 5 hits under `src/`. Bumping one alone is visible only as a descriptor-version rejection inside `comm_hccl.cpp:1608` / `comm_sim.cpp:829` — on a device, not in CI. A test reads the header and asserts parity; it fails when either side moves alone.

**Two things written down rather than changed.** The three `comm_endpoints` enums are a wire contract — their numeric ids live in `global_comm_domain`, a new enumerator needs an id there, and a renumber is a wire break — so both ends now say so; there was no hint at the enum definitions. And `_prepare_global_domain_node` resolves a row it does not use, purely to reject a table this node has no row in before a later phase reads one; that now reads as deliberate.

Not included: the review body's scaling note (worst case 4096 `resolve_region_spec`/`plan` calls per allocation). It is once per domain allocation, not per task, and caching it would trade a real correctness surface — each pair's answer is genuinely distinct, as the table above shows — for time on a path that runs once. Worth revisiting only with a domain large enough to measure.

## Testing

- [x] `pytest tests/ut/py` — 1538 passed, 13 skipped (rebuilt against this commit)
- [x] Each new test confirmed to fail without its production change: reverting `global_comm_domain.py` reproduces the raw `'NOT_A_KIND' is not a valid AdapterKind`; bumping only `GLOBAL_DOMAIN_VERSION` reddens the parity test; neutralizing the `UnsupportedRegionPlan` guard reddens both cross-machine tests
- [x] `ruff check` / `ruff format --check` clean; `pyright` — 0 errors on the three touched modules
- [ ] Hardware: not run. `pre-commit` is not installed on this box, so its hooks ran as their individual tools. The diff is test coverage, error strings and comments; no device path is reachable from it.
