### PR TITLE
Refactor: version the domain command wire apart from the descriptor

### DIFF
--- a/python/simpler/global_comm_domain.py
+++ b/python/simpler/global_comm_domain.py
@@ -18,7 +18,15 @@ from _task_interface import AddressSpace  # pyright: ignore[reportMissingImports
 
 from .comm_endpoints import AdapterKind, AdapterProfile, AttachmentRole
 
+#: Descriptor layout. Paired with ``COMM_GLOBAL_DOMAIN_VERSION`` in
+#: ``src/common/platform_comm/comm.h``: the platform backend stamps this number into every
+#: descriptor it exports and ``_validate_descriptor`` checks it on decode, so advancing one
+#: without the other fails every allocation at PREPARE. The ``LOCAL_*`` L3->L2 mailbox structs
+#: in ``worker.py`` also carry it; producer and consumer there are the same build.
 GLOBAL_DOMAIN_VERSION = 2
+#: L4<->L3 control-command layout: COMM_INIT, ALLOC_DOMAIN, RELEASE and COPY. Python owns both
+#: ends, so this advances on its own -- a command-layout change needs no C++ rebuild.
+GLOBAL_DOMAIN_COMMAND_VERSION = 2
 GLOBAL_DOMAIN_MAX_RANKS = 64
 GLOBAL_DOMAIN_MAX_BUFFERS = 64
 GLOBAL_DOMAIN_MAX_ATTACHMENT_ROWS = GLOBAL_DOMAIN_MAX_RANKS
@@ -532,7 +540,7 @@ def encode_comm_init(command: GlobalCommInitCommand) -> bytes:
         raise ValueError(f"unsupported global domain profile {command.profile!r}")
     if command.node_rank < 0 or command.node_count <= 0 or command.node_rank >= command.node_count:
         raise ValueError("global comm init node identity is invalid")
-    out = bytearray(struct.pack("<III", GLOBAL_DOMAIN_VERSION, command.node_rank, command.node_count))
+    out = bytearray(struct.pack("<III", GLOBAL_DOMAIN_COMMAND_VERSION, command.node_rank, command.node_count))
     _put_string(out, command.cluster_id, "cluster_id")
     _put_string(out, command.topology_hash, "topology_hash")
     _put_string(out, command.profile, "profile")
@@ -545,7 +553,7 @@ def encode_comm_init(command: GlobalCommInitCommand) -> bytes:
 def decode_comm_init(data: bytes) -> GlobalCommInitCommand:
     reader = _Reader(data)
     version = reader.u32()
-    if version != GLOBAL_DOMAIN_VERSION:
+    if version != GLOBAL_DOMAIN_COMMAND_VERSION:
         raise ValueError("global comm init version mismatch")
     node_rank = reader.u32()
     node_count = reader.u32()
@@ -629,7 +637,7 @@ def encode_domain_command(command: GlobalDomainCommand) -> bytes:  # noqa: PLR09
     out = bytearray(
         struct.pack(
             "<IIQQQ",
-            GLOBAL_DOMAIN_VERSION,
+            GLOBAL_DOMAIN_COMMAND_VERSION,
             int(command.phase),
             int(command.domain_id),
             int(command.generation),
@@ -657,7 +665,7 @@ def encode_domain_command(command: GlobalDomainCommand) -> bytes:  # noqa: PLR09
 def decode_domain_command(data: bytes) -> GlobalDomainCommand:
     reader = _Reader(data)
     version = reader.u32()
-    if version != GLOBAL_DOMAIN_VERSION:
+    if version != GLOBAL_DOMAIN_COMMAND_VERSION:
         raise ValueError("global domain command version mismatch")
     try:
         phase = GlobalDomainPhase(reader.u32())
@@ -725,14 +733,14 @@ def decode_descriptor_table(data: bytes) -> tuple[GlobalDomainDescriptor, ...]:
 def encode_release_command(command: GlobalDomainReleaseCommand) -> bytes:
     if command.domain_id == 0 or command.generation == 0:
         raise ValueError("global domain release identity must be positive")
-    return struct.pack("<IQQ", GLOBAL_DOMAIN_VERSION, int(command.domain_id), int(command.generation))
+    return struct.pack("<IQQ", GLOBAL_DOMAIN_COMMAND_VERSION, int(command.domain_id), int(command.generation))
 
 
 def decode_release_command(data: bytes) -> GlobalDomainReleaseCommand:
     if len(data) != struct.calcsize("<IQQ"):
         raise ValueError("global domain release size mismatch")
     version, domain_id, generation = struct.unpack("<IQQ", data)
-    if version != GLOBAL_DOMAIN_VERSION or domain_id == 0 or generation == 0:
+    if version != GLOBAL_DOMAIN_COMMAND_VERSION or domain_id == 0 or generation == 0:
         raise ValueError("global domain release identity or version is invalid")
     return GlobalDomainReleaseCommand(int(domain_id), int(generation))
 
@@ -754,7 +762,7 @@ def encode_copy_command(command: GlobalDomainCopyCommand, *, include_data: bool)
     out = bytearray(
         struct.pack(
             "<IQQIQQ",
-            GLOBAL_DOMAIN_VERSION,
+            GLOBAL_DOMAIN_COMMAND_VERSION,
             int(command.domain_id),
             int(command.generation),
             int(command.domain_rank),
@@ -781,7 +789,7 @@ def decode_copy_command(data: bytes, *, include_data: bool) -> GlobalDomainCopyC
         nbytes=int(nbytes),
         data=bytes(payload),
     )
-    if version != GLOBAL_DOMAIN_VERSION:
+    if version != GLOBAL_DOMAIN_COMMAND_VERSION:
         raise ValueError("global domain copy version mismatch")
     encode_copy_command(command, include_data=include_data)
     return command

--- a/tests/ut/py/test_global_comm_domain.py
+++ b/tests/ut/py/test_global_comm_domain.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import cast
 
 import pytest
-import simpler.global_comm_domain as codec_mod
+import simpler.global_comm_domain as domain_mod
 from simpler.buffer import AddressSpace
 from simpler.comm_endpoints import AdapterKind, AdapterProfile, AttachmentRole
 from simpler.global_comm_domain import (
@@ -119,10 +119,17 @@ def _descriptors() -> tuple[GlobalDomainDescriptor, ...]:
 def test_global_domain_version_matches_the_native_header():
     # The version is spelled twice -- GLOBAL_DOMAIN_VERSION here and COMM_GLOBAL_DOMAIN_VERSION in
     # the platform header -- and every decoder compares it for strict equality with no negotiation.
-    # Bumping one alone therefore surfaces only as a descriptor-version rejection inside
-    # comm_hccl.cpp / comm_sim.cpp on a real device, which no host-side test would catch.
+    # Bumping one alone is rejected by comm_hccl.cpp / comm_sim.cpp as a descriptor-version
+    # mismatch, which names the descriptor rather than the edit that caused it. This pins the
+    # pairing at the edit.
     header = Path(__file__).resolve().parents[3] / "src" / "common" / "platform_comm" / "comm.h"
-    match = re.search(r"^#define\s+COMM_GLOBAL_DOMAIN_VERSION\s+(\d+)U?\s*$", header.read_text(), re.MULTILINE)
+    if not header.is_file():
+        pytest.skip("platform_comm sources are not present in this installation")
+    match = re.search(
+        r"^#define\s+COMM_GLOBAL_DOMAIN_VERSION\s+(\d+)U?\s*$",
+        header.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
     assert match is not None, f"COMM_GLOBAL_DOMAIN_VERSION not found in {header}"
     assert int(match.group(1)) == GLOBAL_DOMAIN_VERSION
 
@@ -309,22 +316,6 @@ def test_global_domain_attachment_names_every_unknown_enum_field():
         encode_domain_command(make_command(replace(good, adapter_profile=None)))
 
 
-def test_descriptor_version_matches_the_platform_backend_macro():
-    """`GLOBAL_DOMAIN_VERSION` is stamped into each descriptor by the platform backend, not by
-    Python, so the two definitions are one contract. Advancing the Python side alone fails every
-    allocation at PREPARE with `global domain descriptor version mismatch` -- a message that
-    points at the descriptor rather than at the edit that caused it. Pin the pairing where the
-    bump is made instead of where it surfaces.
-    """
-    header = Path(__file__).resolve().parents[3] / "src" / "common" / "platform_comm" / "comm.h"
-    if not header.is_file():
-        pytest.skip("platform_comm sources are not present in this installation")
-    match = re.search(r"#define\s+COMM_GLOBAL_DOMAIN_VERSION\s+(\d+)U?", header.read_text(encoding="utf-8"))
-
-    assert match is not None, f"COMM_GLOBAL_DOMAIN_VERSION not found in {header}"
-    assert int(match.group(1)) == GLOBAL_DOMAIN_VERSION
-
-
 def test_l4_l3_commands_version_independently_of_the_descriptor(monkeypatch):
     """Python owns both ends of the L4<->L3 commands, so their layout versions separately from the
     backend-stamped descriptor. Both constants hold the same number today, which would let a codec
@@ -334,7 +325,7 @@ def test_l4_l3_commands_version_independently_of_the_descriptor(monkeypatch):
     """
     members = _members()
     command_version = GLOBAL_DOMAIN_VERSION + 1
-    monkeypatch.setattr(codec_mod, "GLOBAL_DOMAIN_COMMAND_VERSION", command_version)
+    monkeypatch.setattr(domain_mod, "GLOBAL_DOMAIN_COMMAND_VERSION", command_version)
     encoded = {
         "comm_init": encode_comm_init(GlobalCommInitCommand("cluster", "topology", "sim", 0, 2, members)),
         "domain": encode_domain_command(

--- a/tests/ut/py/test_global_comm_domain.py
+++ b/tests/ut/py/test_global_comm_domain.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import os
 import re
 import socket
+import struct
 import subprocess
 import sys
 import threading
@@ -22,6 +23,7 @@ from pathlib import Path
 from typing import cast
 
 import pytest
+import simpler.global_comm_domain as codec_mod
 from simpler.buffer import AddressSpace
 from simpler.comm_endpoints import AdapterKind, AdapterProfile, AttachmentRole
 from simpler.global_comm_domain import (
@@ -39,17 +41,22 @@ from simpler.global_comm_domain import (
     GlobalDomainAttachment,
     GlobalDomainBuffer,
     GlobalDomainCommand,
+    GlobalDomainCopyCommand,
     GlobalDomainDescriptor,
     GlobalDomainMember,
     GlobalDomainPhase,
     GlobalDomainReleaseCommand,
     decode_comm_init,
+    decode_copy_command,
     decode_descriptor_table,
     decode_domain_command,
+    decode_release_command,
     encode_comm_init,
     encode_comm_init_result,
+    encode_copy_command,
     encode_descriptor_table,
     encode_domain_command,
+    encode_release_command,
     resolve_global_comm_capability,
     validate_descriptor_table,
 )
@@ -300,6 +307,64 @@ def test_global_domain_attachment_names_every_unknown_enum_field():
     # A None pair stays legal; only a half-set pair is rejected, and by its own message.
     with pytest.raises(ValueError, match="must be paired"):
         encode_domain_command(make_command(replace(good, adapter_profile=None)))
+
+
+def test_descriptor_version_matches_the_platform_backend_macro():
+    """`GLOBAL_DOMAIN_VERSION` is stamped into each descriptor by the platform backend, not by
+    Python, so the two definitions are one contract. Advancing the Python side alone fails every
+    allocation at PREPARE with `global domain descriptor version mismatch` -- a message that
+    points at the descriptor rather than at the edit that caused it. Pin the pairing where the
+    bump is made instead of where it surfaces.
+    """
+    header = Path(__file__).resolve().parents[3] / "src" / "common" / "platform_comm" / "comm.h"
+    if not header.is_file():
+        pytest.skip("platform_comm sources are not present in this installation")
+    match = re.search(r"#define\s+COMM_GLOBAL_DOMAIN_VERSION\s+(\d+)U?", header.read_text(encoding="utf-8"))
+
+    assert match is not None, f"COMM_GLOBAL_DOMAIN_VERSION not found in {header}"
+    assert int(match.group(1)) == GLOBAL_DOMAIN_VERSION
+
+
+def test_l4_l3_commands_version_independently_of_the_descriptor(monkeypatch):
+    """Python owns both ends of the L4<->L3 commands, so their layout versions separately from the
+    backend-stamped descriptor. Both constants hold the same number today, which would let a codec
+    that still read `GLOBAL_DOMAIN_VERSION` pass unnoticed -- so drive the command version to a
+    distinct value first. Under that override a descriptor-versioned encoder stamps the wrong
+    header, and a descriptor-versioned decoder rejects a payload it should accept.
+    """
+    members = _members()
+    command_version = GLOBAL_DOMAIN_VERSION + 1
+    monkeypatch.setattr(codec_mod, "GLOBAL_DOMAIN_COMMAND_VERSION", command_version)
+    encoded = {
+        "comm_init": encode_comm_init(GlobalCommInitCommand("cluster", "topology", "sim", 0, 2, members)),
+        "domain": encode_domain_command(
+            GlobalDomainCommand(
+                phase=GlobalDomainPhase.PREPARE_EXPORT,
+                domain_id=11,
+                generation=1,
+                name="tp",
+                profile="sim",
+                window_size=2048,
+                members=members,
+                buffers=(GlobalDomainBuffer("payload", 128),),
+            )
+        ),
+        "release": encode_release_command(GlobalDomainReleaseCommand(11, 1)),
+        "copy": encode_copy_command(GlobalDomainCopyCommand(11, 1, 0, 0, 4, b"abcd"), include_data=True),
+    }
+    decoders = {
+        "comm_init": decode_comm_init,
+        "domain": decode_domain_command,
+        "release": decode_release_command,
+        "copy": lambda data: decode_copy_command(data, include_data=True),
+    }
+
+    for name, blob in encoded.items():
+        assert struct.unpack_from("<I", blob)[0] == command_version, name
+        decoders[name](blob)
+        foreign = struct.pack("<I", command_version + 1) + blob[4:]
+        with pytest.raises(ValueError, match="version"):
+            decoders[name](foreign)
 
 
 def test_global_domain_encode_rejects_too_many_buffers():


### PR DESCRIPTION
## Summary

`GLOBAL_DOMAIN_VERSION` guarded three unrelated layouts at once — the descriptor, the four L4↔L3 control commands, and the `LOCAL_*` L3→L2 mailbox structs. Only one of those is a cross-language contract: the platform backend stamps the descriptor from `COMM_GLOBAL_DOMAIN_VERSION` in `src/common/platform_comm/comm.h`, and `_validate_descriptor` checks it on decode.

The consequence is that a Python-only command-layout change cannot advance its own version. Bumping the shared constant fails **every allocation at PREPARE** with `global domain descriptor version mismatch` unless the C++ macro moves in lockstep and every runtime is rebuilt — and the error names the descriptor, not the command that changed.

**This already cost us a version number.** #1879 needed a command-wire change and bumped `comm.h` alongside the Python constant, which was the only correct move available. But that bump was its *entire* C++ diff:

```
$ git show 5cb8110d -- src/common/platform_comm/comm.h
-#define COMM_GLOBAL_DOMAIN_VERSION 1U
+#define COMM_GLOBAL_DOMAIN_VERSION 2U
```

`CommGlobalDomainDescriptor` and `COMM_GLOBAL_DOMAIN_DESCRIPTOR_BYTES 288U` are byte-identical across that commit. So a descriptor version was retired, and every `libhost_runtime.so` rebuilt, for a change no C++ reader could observe.

- `GLOBAL_DOMAIN_COMMAND_VERSION` now guards `COMM_INIT`, `ALLOC_DOMAIN`, `RELEASE` and `COPY`, where Python owns both ends
- `GLOBAL_DOMAIN_VERSION` keeps the descriptor and the mailbox structs, and its comment names the C++ macro it is paired with
- **Both hold 2, so no wire layout changes** — this separates two namespaces that were sharing one name, nothing more

Per-layer versioning is already the shape here rather than a new idea: `remote_l3_protocol.PROTOCOL_VERSION` sits at 3, independent of comm's 2.

## One new test, and the existing pin kept

**The independence test drives the constants apart first.** Both hold 2 today, so asserting that a command stamps `GLOBAL_DOMAIN_COMMAND_VERSION` and rejects an adjacent value would prove nothing — a codec still reading `GLOBAL_DOMAIN_VERSION` satisfies the same assertions. That was confirmed by experiment: reverting only the four decoder checks left the first draft of this test passing. It now overrides the command version to a distinct value, encodes every command under it, **decodes each unmodified payload**, and only then corrupts the header and requires rejection. Verified across four states:

| state | expected | result |
| --- | --- | --- |
| unmodified | pass | pass |
| decoders reverted to `GLOBAL_DOMAIN_VERSION` | fail | fail (`global comm init version mismatch`) |
| encoders reverted to `GLOBAL_DOMAIN_VERSION` | fail | fail (`assert 2 == 3`) |
| restored | pass | pass |

**The descriptor↔`comm.h` pairing needed no new test.** #1882 landed `test_global_domain_version_matches_the_native_header` in this same file, so a desynced Python bump already fails at the edit. An earlier revision of this PR added a second, near-identical pin ~190 lines below it; that duplicate is removed, and the two improvements it carried moved onto the surviving test — skip when `src/` is absent, so a wheel-only installation does not error, and read the header as UTF-8 explicitly. Its comment claimed no host-side test would catch a desync, which the two sim end-to-end cases in this file disprove, so it now states what the rejection actually costs: it names the descriptor rather than the edit.

Desyncing `GLOBAL_DOMAIN_VERSION` from `comm.h` fails the pin plus both sim end-to-end cases.

## Scope

The `LOCAL_*` L3→L2 mailbox structs stay on `GLOBAL_DOMAIN_VERSION`, and that is deliberate rather than a residue. Those frames **transport descriptors verbatim**: the prepare path sizes its buffer as `LOCAL_PREPARE_REPLY.size + GLOBAL_DOMAIN_DESCRIPTOR_BYTES` and the import path splices `descriptor_bytes` in after the header. They sit downstream of the descriptor layout, so a descriptor bump legitimately invalidates them, and a third constant would have to move together with the descriptor's in most real changes — re-creating exactly the coupling this change removes. The one shape that would genuinely want its own version is a `LOCAL_*` frame carrying no descriptor, `LOCAL_RELEASE_REQUEST` being the only such case today; splitting three ways can wait until that bites.

No behavior changes, no C++ changes, no new wire format.

## Testing

Based on `7fa3f543`, which included resolving a conflict with #1869 — both its new attachment test and the one added here are kept. Validated on an Ascend910 V1 host.

- [x] `pytest tests/ut -m "not requires_hardware"` — **1629 passed**, 7 skipped
- [x] Negative checks — the four-state table above, plus desyncing `GLOBAL_DOMAIN_VERSION` from `comm.h` to confirm the pin fails
- [x] Lint — ruff check/format, pyright, check-headers, check-english-only

Split out of #1876, whose other half was retired: that PR's `deployment` field was aimed at a premise the design ruling overturned, and #1879 has since landed the attachment axis that actually covers it. This half was reviewed there and asked to survive on its own.
