### PR TITLE
host_build_graph: drop graph-affine replay of a retained expansion

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -636,10 +636,7 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     definition.tensor_arg_count = static_cast<uint32_t>(tensors.size());
     definition.scalar_arg_count = static_cast<uint32_t>(scalars.size());
     size_t execution_storage_bytes = 0;
-    if (!graph_execution_storage_bytes(
-            static_cast<int32_t>(definition.task_count), definition.tensor_arg_count, definition.scalar_arg_count,
-            &execution_storage_bytes
-        ) ||
+    if (!graph_execution_storage_bytes(static_cast<int32_t>(definition.task_count), &execution_storage_bytes) ||
         execution_storage_bytes > UINT32_MAX) {
         return false;
     }

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -558,25 +558,21 @@ struct alignas(64) PTO2TaskSlotState {
 
     /**
      * Reset dynamic scheduling fields to their pristine values. Called once per
-     * slot as the orchestrator claims it in prepare_task — whole-graph-resident
-     * hbg has no execution-time slot recycle. Skips payload/task (bound once) and
+     * slot as the orchestrator claims it in prepare_task, and again as a Graph
+     * node's storage is materialized — whole-graph-resident hbg has no
+     * execution-time slot recycle. Skips payload/task (bound once) and
      * task_state (the orchestrator sets PENDING when it populates the slot).
      * wake_list_head starts nullptr (open for registration), NOT SENTINEL.
-     * Graph-affine replay passes preserve_graph_binding=true because its node
-     * index, kind, and execution pointer are static properties of the retained
-     * storage block.
      */
-    void reset_for_reuse(bool preserve_graph_binding = false) {
+    void reset_for_reuse() {
         wake_list_head.store(nullptr, std::memory_order_relaxed);
         next_in_wake_list = nullptr;
         any_subtask_deferred.store(false, std::memory_order_relaxed);
         completed_subtasks.store(0, std::memory_order_relaxed);
         next_block_idx.store(0, std::memory_order_relaxed);
-        if (!preserve_graph_binding) {
-            graph_node_index = -1;
-            graph_context = nullptr;
-            task_kind = TaskKind::KERNEL;
-        }
+        graph_node_index = -1;
+        graph_context = nullptr;
+        task_kind = TaskKind::KERNEL;
         // Note: active_mask and task_attrs are per-submit-constant fields
         // rewritten in prepare_task on every reuse, so they are not reset here.
         // last_consumer_local_id is seeded in prepare_task once the id is known.

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -636,10 +636,7 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     definition.tensor_arg_count = static_cast<uint32_t>(tensors.size());
     definition.scalar_arg_count = static_cast<uint32_t>(scalars.size());
     size_t execution_storage_bytes = 0;
-    if (!graph_execution_storage_bytes(
-            static_cast<int32_t>(definition.task_count), definition.tensor_arg_count, definition.scalar_arg_count,
-            &execution_storage_bytes
-        ) ||
+    if (!graph_execution_storage_bytes(static_cast<int32_t>(definition.task_count), &execution_storage_bytes) ||
         execution_storage_bytes > UINT32_MAX) {
         return false;
     }

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -553,25 +553,22 @@ struct alignas(64) PTO2TaskSlotState {
     bool has_any_subtask_deferred() const { return any_subtask_deferred.load(std::memory_order_acquire); }
 
     /**
-     * Reset dynamic scheduling fields to their pristine values. Runs once per
-     * slot at init (pto_shared_memory.cpp) and again during affine Graph replay;
-     * whole-graph-resident hbg has no execution-time slot recycle. Skips
-     * payload/task (bound once) and
+     * Reset dynamic scheduling fields to their pristine values. Called once per
+     * slot as the orchestrator claims it in prepare_task, and again as a Graph
+     * node's storage is materialized — whole-graph-resident hbg has no
+     * execution-time slot recycle. Skips payload/task (bound once) and
      * task_state (the orchestrator sets PENDING when it populates the slot).
      * wake_list_head starts nullptr (open for registration), NOT SENTINEL.
-     * Affine Graph replay preserves the node's retained execution binding.
      */
-    void reset_for_reuse(bool preserve_graph_binding = false) {
+    void reset_for_reuse() {
         wake_list_head.store(nullptr, std::memory_order_relaxed);
         next_in_wake_list = nullptr;
         any_subtask_deferred.store(false, std::memory_order_relaxed);
         completed_subtasks.store(0, std::memory_order_relaxed);
         next_block_idx.store(0, std::memory_order_relaxed);
-        if (!preserve_graph_binding) {
-            graph_node_index = -1;
-            graph_context = nullptr;
-            task_kind = TaskKind::KERNEL;
-        }
+        graph_node_index = -1;
+        graph_context = nullptr;
+        task_kind = TaskKind::KERNEL;
         // Note: active_mask and task_attrs are per-submit-constant fields
         // rewritten in prepare_task on every reuse, so they are not reset here.
         // last_consumer_local_id is seeded in prepare_task once the id is known.

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -252,28 +252,12 @@ needs no separate device allocation, retention keying or release path.
 
 The execution address is therefore not on the wire — both sides compute
 `packed_buffer_base + required_heap` and read the size from the Definition. The
-Scheduler validates that the region lies inside the outer task's allocation
-before placement-constructing `GraphExecution`; it never allocates execution
-storage from the AICPU process heap. Because those bytes are ordinary reclaimed
-heap, a stale `GRAPH_EXECUTION_STORAGE_MAGIC` can appear there; reuse
-additionally requires the recorded Definition key, content hash and node/patch
-counts to match, which only a genuine completed execution of the same Graph
-satisfies, so anything else falls through to a full rebuild.
-
-A block that does match retains the local Definition, static node fields, and
-the Tensor-address and scalar patch tables generated during its first
-materialization. That graph-affine replay skips
-topology binding, per-node count/offset validation, tensor-source
-classification, tensor wire validation, static field stores, and static scalar
-copies. It refreshes only task IDs, packed-buffer bases, boundary/internal
-tensor addresses, boundary scalar bindings, scheduling state, dispatch
-atomics, and wake registrations.
-
-Affinity follows the allocation rather than a retention key: a replay lands on
-the previous execution exactly when the outer task's `packed_buffer_base`
-repeats, which an unchanged task layout produces because the arena base is
-stable across runs and the allocator is a deterministic bump. It does not
-depend on a recycler selecting a recently freed block.
+Scheduler validates that the region lies inside the outer task's allocation and
+then placement-constructs `GraphExecution` there; it never allocates execution
+storage from the AICPU process heap, and it never reads the block's prior
+contents. Every submission materializes from the Definition, so a resubmission
+of the same Graph rebuilds rather than replaying the previous expansion: the
+bytes it starts from are whatever that heap region last held.
 
 ## Scheduler flow
 
@@ -311,9 +295,9 @@ Internal dependency readiness borrows the completion-state polling idea, but
 dependency wiring remains an Orchestrator responsibility:
 
 - recording constructs both fanin and fanout CSR in the immutable Definition;
-- first materialization builds static runnable node state plus compact Tensor
-  address and scalar patch tables; affine replay applies those tables and
-  resets only dynamic runnable state;
+- materialization builds each node's runnable state from the Definition,
+  resolving its Tensor addresses against the boundary image and its producers'
+  packed windows;
 - materialization registers each non-root on one producer selected from its
   saved fanin CSR;
 - a node's release/acquire `task_state` is its Graph-local completion flag, so

--- a/src/common/host_build_graph/graph_execution.cpp
+++ b/src/common/host_build_graph/graph_execution.cpp
@@ -19,126 +19,21 @@
 
 namespace {
 
-void destroy_execution_nodes(GraphExecution *execution) {
-    for (int32_t i = 0; i < execution->constructed_nodes; ++i) {
-        execution->node_storage[i].~GraphNodeStorage();
-    }
-    execution->constructed_nodes = 0;
-}
-
-void reset_execution(
-    GraphExecution *execution, int32_t node_count, uint32_t tensor_patch_count, uint32_t scalar_patch_count,
-    uint64_t graph_key, uint64_t definition_hash
-) {
+// The storage is the tail of the outer GRAPH task's heap allocation, so its
+// bytes are whatever that region last held; every field an execution needs is
+// written here or by the materialize pass, never inherited from those bytes.
+GraphExecution *acquire_host_execution_storage(uintptr_t storage_addr, size_t storage_bytes, int32_t node_count) {
     size_t nodes_offset = 0;
-    size_t tensor_patches_offset = 0;
-    size_t scalar_patches_offset = 0;
-    size_t bytes = 0;
-    if (!graph_execution_storage_layout(
-            execution->node_capacity, execution->tensor_patch_capacity, execution->scalar_patch_capacity, &nodes_offset,
-            &tensor_patches_offset, &scalar_patches_offset, &bytes
-        )) {
-        return;
+    size_t required_bytes = 0;
+    if (storage_addr == 0 || storage_addr % alignof(GraphNodeStorage) != 0 ||
+        !graph_execution_storage_layout(node_count, &nodes_offset, &required_bytes) || required_bytes > storage_bytes) {
+        return nullptr;
     }
-    execution->definition_affine_reuse = graph_key != 0 && execution->materialized_graph_key == graph_key &&
-                                         execution->materialized_definition_hash == definition_hash &&
-                                         execution->materialized_node_count == node_count &&
-                                         execution->materialized_tensor_patch_count == tensor_patch_count &&
-                                         execution->materialized_scalar_patch_count <= scalar_patch_count &&
-                                         execution->constructed_nodes >= node_count;
-    execution->state.store(GraphExecutionState::SUBMITTED, std::memory_order_relaxed);
-    execution->materialize_busy.store(0, std::memory_order_relaxed);
-    execution->remaining_nodes.store(node_count, std::memory_order_relaxed);
-    execution->retired_nodes.store(0, std::memory_order_relaxed);
-    execution->published_nodes.store(0, std::memory_order_relaxed);
-    execution->route_cursor.store(0, std::memory_order_relaxed);
+    auto *execution = new (reinterpret_cast<void *>(storage_addr)) GraphExecution{};
     execution->node_count = node_count;
-    execution->materialized_nodes = 0;
-    execution->materialized_tensor_patches = 0;
-    execution->materialized_scalar_patches = 0;
-    execution->allocation_bytes = bytes;
-    execution->graph_key = graph_key;
-    execution->definition_hash = definition_hash;
-    execution->outer_slot = nullptr;
-    execution->nodes = nullptr;
+    execution->remaining_nodes.store(node_count, std::memory_order_relaxed);
     execution->node_storage =
         reinterpret_cast<GraphNodeStorage *>(reinterpret_cast<uint8_t *>(execution) + nodes_offset);
-    execution->tensor_patches =
-        reinterpret_cast<GraphTensorAddressPatch *>(reinterpret_cast<uint8_t *>(execution) + tensor_patches_offset);
-    execution->scalar_patches =
-        reinterpret_cast<GraphScalarPatch *>(reinterpret_cast<uint8_t *>(execution) + scalar_patches_offset);
-    if (!execution->definition_affine_reuse) {
-        execution->definition = nullptr;
-        execution->fanin_offsets = nullptr;
-        execution->fanin_indices = nullptr;
-    }
-    execution->boundary_tensors = nullptr;
-    execution->boundary_tensor_count = 0;
-    execution->boundary_scalars = nullptr;
-    execution->boundary_scalar_count = 0;
-}
-
-bool reusable_execution_header_valid(const GraphExecution &execution, size_t storage_bytes) {
-    if (execution.storage_magic != GRAPH_EXECUTION_STORAGE_MAGIC || execution.node_capacity <= 0 ||
-        execution.node_capacity > static_cast<int32_t>(GRAPH_MAX_NODES) ||
-        execution.tensor_patch_capacity > GRAPH_MAX_NODES * MAX_TENSOR_ARGS ||
-        execution.scalar_patch_capacity > GRAPH_MAX_NODES * MAX_SCALAR_ARGS ||
-        execution.materialized_tensor_patch_count > execution.tensor_patch_capacity ||
-        execution.materialized_scalar_patch_count > execution.scalar_patch_capacity ||
-        execution.constructed_nodes < 0 || execution.constructed_nodes > execution.node_capacity ||
-        execution.node_count <= 0 || execution.node_count > execution.node_capacity ||
-        execution.state.load(std::memory_order_acquire) != GraphExecutionState::COMPLETED ||
-        execution.retired_nodes.load(std::memory_order_acquire) < execution.node_count) {
-        return false;
-    }
-    size_t expected_bytes = 0;
-    return graph_execution_storage_bytes(
-               execution.node_capacity, execution.tensor_patch_capacity, execution.scalar_patch_capacity,
-               &expected_bytes
-           ) &&
-           execution.allocation_bytes == expected_bytes && expected_bytes <= storage_bytes;
-}
-
-// The storage is the tail of the outer GRAPH task's heap allocation, so its
-// bytes are whatever that region last held. A stale GRAPH_EXECUTION_STORAGE_MAGIC
-// there is harmless: reusing a block additionally requires its recorded
-// materialized_graph_key / materialized_definition_hash / node and patch counts
-// to match this Definition (reset_execution below), which only a genuine
-// completed execution of the same Graph satisfies. Anything else falls through
-// to a full rebuild.
-GraphExecution *acquire_host_execution_storage(
-    uintptr_t storage_addr, size_t storage_bytes, int32_t node_count, uint64_t graph_key, uint64_t definition_hash,
-    uint32_t tensor_patch_count, uint32_t scalar_patch_count
-) {
-    if (node_count <= 0 || node_count > static_cast<int32_t>(GRAPH_MAX_NODES) || storage_addr == 0 ||
-        storage_addr % alignof(GraphNodeStorage) != 0) {
-        return nullptr;
-    }
-    size_t required_bytes = 0;
-    if (!graph_execution_storage_bytes(node_count, tensor_patch_count, scalar_patch_count, &required_bytes) ||
-        required_bytes > storage_bytes) {
-        return nullptr;
-    }
-
-    auto *execution = reinterpret_cast<GraphExecution *>(storage_addr);
-    uint64_t observed_magic = 0;
-    std::memcpy(&observed_magic, execution, sizeof(observed_magic));
-    const bool has_existing_execution = observed_magic == GRAPH_EXECUTION_STORAGE_MAGIC;
-    const bool valid_header = has_existing_execution && reusable_execution_header_valid(*execution, storage_bytes);
-    if (has_existing_execution && !valid_header) return nullptr;
-    const bool capacities_fit = valid_header && execution->node_capacity >= node_count &&
-                                execution->tensor_patch_capacity >= tensor_patch_count &&
-                                execution->scalar_patch_capacity >= scalar_patch_count;
-    if (!capacities_fit) {
-        if (valid_header) destroy_execution_nodes(execution);
-        execution = new (execution) GraphExecution{};
-        execution->node_capacity = node_count;
-        execution->tensor_patch_capacity = tensor_patch_count;
-        execution->scalar_patch_capacity = scalar_patch_count;
-        execution->allocation_bytes = required_bytes;
-    }
-    reset_execution(execution, node_count, tensor_patch_count, scalar_patch_count, graph_key, definition_hash);
-    execution->storage_magic = GRAPH_EXECUTION_STORAGE_MAGIC;
     return execution;
 }
 
@@ -369,24 +264,21 @@ GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
 
     GraphExecution *execution = acquire_host_execution_storage(
         outer_base + definition->required_heap, definition->execution_storage_bytes,
-        static_cast<int32_t>(definition->task_count), submission->graph_key, definition->content_hash,
-        definition->tensor_arg_count, definition->scalar_arg_count
+        static_cast<int32_t>(definition->task_count)
     );
     if (execution == nullptr) {
         __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
         return nullptr;
     }
 
-    if (!execution->definition_affine_reuse) {
-        // The Definition is read in place from the shared GM object; no
-        // per-occurrence copy is taken.
-        execution->definition = definition;
-        if (!bind_graph_topology(*execution)) {
-            execution->retired_nodes.store(execution->node_count, std::memory_order_relaxed);
-            execution->state.store(GraphExecutionState::COMPLETED, std::memory_order_release);
-            __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
-            return nullptr;
-        }
+    // The Definition is read in place from the shared GM object; no
+    // per-occurrence copy is taken.
+    execution->definition = definition;
+    if (!bind_graph_topology(*execution)) {
+        execution->retired_nodes.store(execution->node_count, std::memory_order_relaxed);
+        execution->state.store(GraphExecutionState::COMPLETED, std::memory_order_release);
+        __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
+        return nullptr;
     }
     execution->boundary_tensors = boundary_tensors;
     execution->boundary_tensor_count = submission->tensor_count;
@@ -405,8 +297,7 @@ GraphMaterializeResult graph_execution_materialize_slice(
     if (nodes_materialized != nullptr) *nodes_materialized = 0;
     if (outer_slot.task_kind != TaskKind::GRAPH || outer_slot.task == nullptr ||
         outer_slot.task->packed_buffer_base == nullptr || max_nodes <= 0 || execution.definition == nullptr ||
-        execution.node_storage == nullptr || execution.tensor_patches == nullptr ||
-        execution.scalar_patches == nullptr) {
+        execution.node_storage == nullptr) {
         return GraphMaterializeResult::INVALID;
     }
 
@@ -440,41 +331,34 @@ GraphMaterializeResult graph_execution_materialize_slice(
         return GraphMaterializeResult::INVALID;
     }
 
-    const bool affine_reuse = execution.definition_affine_reuse;
     const GraphDefinition &definition = *execution.definition;
-    const GraphNodeDefinition *nodes = nullptr;
-    const uint64_t *node_offsets = nullptr;
-    const GraphTensor *definition_tensors = nullptr;
-    const GraphTensorSourceRef *tensor_sources = nullptr;
-    const uint64_t *definition_scalars = nullptr;
-    const GraphScalarSourceRef *scalar_sources = nullptr;
-    if (!affine_reuse) {
-        nodes = graph_definition_array<GraphNodeDefinition>(definition, definition.off_nodes, definition.task_count);
-        node_offsets = graph_definition_array<uint64_t>(definition, definition.off_node_offsets, definition.task_count);
-        definition_tensors =
-            definition.tensor_arg_count == 0 ?
-                nullptr :
-                graph_definition_array<GraphTensor>(definition, definition.off_tensors, definition.tensor_arg_count);
-        tensor_sources = definition.tensor_arg_count == 0 ?
-                             nullptr :
-                             graph_definition_array<GraphTensorSourceRef>(
-                                 definition, definition.off_tensor_sources, definition.tensor_arg_count
-                             );
-        definition_scalars =
-            definition.scalar_arg_count == 0 ?
-                nullptr :
-                graph_definition_array<uint64_t>(definition, definition.off_scalars, definition.scalar_arg_count);
-        scalar_sources = definition.scalar_arg_count == 0 ?
-                             nullptr :
-                             graph_definition_array<GraphScalarSourceRef>(
-                                 definition, definition.off_scalar_sources, definition.scalar_arg_count
-                             );
-        if (nodes == nullptr || node_offsets == nullptr ||
-            (definition.tensor_arg_count != 0 && (definition_tensors == nullptr || tensor_sources == nullptr)) ||
-            (definition.scalar_arg_count != 0 && (definition_scalars == nullptr || scalar_sources == nullptr))) {
-            execution.materialize_busy.store(0, std::memory_order_release);
-            return GraphMaterializeResult::INVALID;
-        }
+    const GraphNodeDefinition *nodes =
+        graph_definition_array<GraphNodeDefinition>(definition, definition.off_nodes, definition.task_count);
+    const uint64_t *node_offsets =
+        graph_definition_array<uint64_t>(definition, definition.off_node_offsets, definition.task_count);
+    const GraphTensor *definition_tensors =
+        definition.tensor_arg_count == 0 ?
+            nullptr :
+            graph_definition_array<GraphTensor>(definition, definition.off_tensors, definition.tensor_arg_count);
+    const GraphTensorSourceRef *tensor_sources =
+        definition.tensor_arg_count == 0 ? nullptr :
+                                           graph_definition_array<GraphTensorSourceRef>(
+                                               definition, definition.off_tensor_sources, definition.tensor_arg_count
+                                           );
+    const uint64_t *definition_scalars =
+        definition.scalar_arg_count == 0 ?
+            nullptr :
+            graph_definition_array<uint64_t>(definition, definition.off_scalars, definition.scalar_arg_count);
+    const GraphScalarSourceRef *scalar_sources =
+        definition.scalar_arg_count == 0 ? nullptr :
+                                           graph_definition_array<GraphScalarSourceRef>(
+                                               definition, definition.off_scalar_sources, definition.scalar_arg_count
+                                           );
+    if (nodes == nullptr || node_offsets == nullptr ||
+        (definition.tensor_arg_count != 0 && (definition_tensors == nullptr || tensor_sources == nullptr)) ||
+        (definition.scalar_arg_count != 0 && (definition_scalars == nullptr || scalar_sources == nullptr))) {
+        execution.materialize_busy.store(0, std::memory_order_release);
+        return GraphMaterializeResult::INVALID;
     }
 
     const int32_t first = execution.materialized_nodes;
@@ -493,163 +377,112 @@ GraphMaterializeResult graph_execution_materialize_slice(
         const uint32_t synthetic_local =
             (static_cast<uint32_t>(outer_slot.task->task_id.local()) << 10) | static_cast<uint32_t>(i);
         task.task_id = PTO2TaskId::make(1, synthetic_local);
-        uint64_t node_offset = 0;
-        uint64_t output_bytes = 0;
-        if (affine_reuse) {
-            const uintptr_t previous_base = reinterpret_cast<uintptr_t>(task.packed_buffer_base);
-            const uintptr_t previous_end = reinterpret_cast<uintptr_t>(task.packed_buffer_end);
-            node_offset = previous_base - execution.materialized_outer_base;
-            output_bytes = previous_end - previous_base;
-        } else {
-            const GraphNodeDefinition &source = nodes[i];
-            node_offset = node_offsets[i];
-            output_bytes = PTO2_ALIGN_UP(static_cast<uint64_t>(source.total_output_size), PTO2_ALIGN_SIZE);
-            for (int k = 0; k < PTO2_SUBTASK_SLOT_COUNT; ++k)
-                task.kernel_id[k] = source.kernel_id[k];
-        }
+        const GraphNodeDefinition &source = nodes[i];
+        const uint64_t node_offset = node_offsets[i];
+        const uint64_t output_bytes = PTO2_ALIGN_UP(static_cast<uint64_t>(source.total_output_size), PTO2_ALIGN_SIZE);
+        for (int k = 0; k < PTO2_SUBTASK_SLOT_COUNT; ++k)
+            task.kernel_id[k] = source.kernel_id[k];
         task.packed_buffer_base = reinterpret_cast<void *>(outer_base + node_offset);
         task.packed_buffer_end = reinterpret_cast<void *>(outer_base + node_offset + output_bytes);
 
-        slot.reset_for_reuse(affine_reuse);
+        slot.reset_for_reuse();
         slot.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
-        if (!affine_reuse) {
-            const GraphNodeDefinition &source = nodes[i];
-            slot.bind_buffers(&payload, &task);
-            slot.active_mask = ActiveMask(source.active_mask);
-            slot.task_attrs = TaskAttrs(source.task_attrs);
-            slot.total_required_subtasks = source.total_required_subtasks;
-            slot.logical_block_num = source.logical_block_num;
-            slot.graph_node_index = i;
-            slot.task_kind = TaskKind::GRAPH_NODE;
-            slot.graph_context = &execution;
-            payload.tensor_count = source.tensor_count;
-            payload.scalar_count = source.scalar_count;
-            payload.dump_metadata = source.dump_metadata;
-            if (source.tensor_count < 0 || source.tensor_count > MAX_TENSOR_ARGS || source.scalar_count < 0 ||
-                source.scalar_count > MAX_SCALAR_ARGS ||
-                static_cast<uint32_t>(source.tensor_count) > definition.tensor_arg_count ||
-                static_cast<uint32_t>(source.scalar_count) > definition.scalar_arg_count ||
-                source.tensor_offset > definition.tensor_arg_count - static_cast<uint32_t>(source.tensor_count) ||
-                source.scalar_offset > definition.scalar_arg_count - static_cast<uint32_t>(source.scalar_count)) {
+        slot.bind_buffers(&payload, &task);
+        slot.active_mask = ActiveMask(source.active_mask);
+        slot.task_attrs = TaskAttrs(source.task_attrs);
+        slot.total_required_subtasks = source.total_required_subtasks;
+        slot.logical_block_num = source.logical_block_num;
+        slot.graph_node_index = i;
+        slot.task_kind = TaskKind::GRAPH_NODE;
+        slot.graph_context = &execution;
+        payload.tensor_count = source.tensor_count;
+        payload.scalar_count = source.scalar_count;
+        payload.dump_metadata = source.dump_metadata;
+        if (source.tensor_count < 0 || source.tensor_count > MAX_TENSOR_ARGS || source.scalar_count < 0 ||
+            source.scalar_count > MAX_SCALAR_ARGS ||
+            static_cast<uint32_t>(source.tensor_count) > definition.tensor_arg_count ||
+            static_cast<uint32_t>(source.scalar_count) > definition.scalar_arg_count ||
+            source.tensor_offset > definition.tensor_arg_count - static_cast<uint32_t>(source.tensor_count) ||
+            source.scalar_offset > definition.scalar_arg_count - static_cast<uint32_t>(source.scalar_count)) {
+            execution.materialize_busy.store(0, std::memory_order_release);
+            return GraphMaterializeResult::INVALID;
+        }
+        for (int32_t j = 0; j < source.tensor_count; ++j) {
+            const uint32_t tensor_index = source.tensor_offset + static_cast<uint32_t>(j);
+            ChipTensor &tensor = payload.tensors[j];
+            GraphTensor rebound = definition_tensors[tensor_index];
+            if (!graph_tensor_wire_valid(rebound)) {
                 execution.materialize_busy.store(0, std::memory_order_release);
                 return GraphMaterializeResult::INVALID;
             }
-            for (int32_t j = 0; j < source.tensor_count; ++j) {
-                const uint32_t tensor_index = source.tensor_offset + static_cast<uint32_t>(j);
-                ChipTensor &tensor = payload.tensors[j];
-                GraphTensor rebound = definition_tensors[tensor_index];
-                GraphTensorAddressPatch patch{};
-                if (!graph_tensor_wire_valid(rebound)) {
+            const GraphTensorSourceRef &ref = tensor_sources[tensor_index];
+            if (ref.source == static_cast<uint8_t>(GraphTensorSource::BOUNDARY_EXACT)) {
+                if (ref.source_index >= execution.boundary_tensor_count || ref.packed_offset != 0) {
                     execution.materialize_busy.store(0, std::memory_order_release);
                     return GraphMaterializeResult::INVALID;
                 }
-                const GraphTensorSourceRef &ref = tensor_sources[tensor_index];
-                if (ref.source == static_cast<uint8_t>(GraphTensorSource::BOUNDARY_EXACT)) {
-                    if (ref.source_index >= execution.boundary_tensor_count || ref.packed_offset != 0) {
-                        execution.materialize_busy.store(0, std::memory_order_release);
-                        return GraphMaterializeResult::INVALID;
-                    }
-                    rebound = execution.boundary_tensors[ref.source_index];
-                    patch.source = static_cast<uint8_t>(GraphTensorAddressSource::BOUNDARY);
-                    patch.source_index = ref.source_index;
-                } else if (ref.source == static_cast<uint8_t>(GraphTensorSource::BOUNDARY_VIEW)) {
-                    if (ref.source_index >= execution.boundary_tensor_count) {
-                        execution.materialize_busy.store(0, std::memory_order_release);
-                        return GraphMaterializeResult::INVALID;
-                    }
-                    const GraphTensor &boundary = execution.boundary_tensors[ref.source_index];
-                    if (ref.packed_offset > UINT64_MAX - boundary.start_offset) {
-                        execution.materialize_busy.store(0, std::memory_order_release);
-                        return GraphMaterializeResult::INVALID;
-                    }
-                    rebound.buffer_addr = boundary.buffer_addr;
-                    rebound.buffer_size = boundary.buffer_size;
-                    rebound.owner_task_id = boundary.owner_task_id;
-                    rebound.start_offset = boundary.start_offset + ref.packed_offset;
-                    rebound.version = boundary.version;
-                    rebound.address_space = boundary.address_space;
-                    patch.source = static_cast<uint8_t>(GraphTensorAddressSource::BOUNDARY);
-                    patch.source_index = ref.source_index;
-                } else if (ref.source == static_cast<uint8_t>(GraphTensorSource::INTERNAL) ||
-                           ref.source == static_cast<uint8_t>(GraphTensorSource::OWN_OUTPUT)) {
-                    const bool own_output = ref.source == static_cast<uint8_t>(GraphTensorSource::OWN_OUTPUT);
-                    const int32_t producer_index = own_output ? i : static_cast<int32_t>(ref.source_index);
-                    if (producer_index < 0 || producer_index > i || (own_output && ref.source_index != i) ||
-                        (!own_output && producer_index == i)) {
-                        execution.materialize_busy.store(0, std::memory_order_release);
-                        return GraphMaterializeResult::INVALID;
-                    }
-                    PTO2TaskDescriptor &producer = execution.node_storage[producer_index].task;
-                    const uint64_t producer_bytes = static_cast<uint64_t>(nodes[producer_index].total_output_size);
-                    const uintptr_t producer_base = reinterpret_cast<uintptr_t>(producer.packed_buffer_base);
-                    if (ref.packed_offset > producer_bytes ||
-                        rebound.buffer_size > producer_bytes - ref.packed_offset ||
-                        ref.packed_offset > UINTPTR_MAX - producer_base ||
-                        ref.packed_offset > UINT64_MAX - node_offsets[producer_index]) {
-                        execution.materialize_busy.store(0, std::memory_order_release);
-                        return GraphMaterializeResult::INVALID;
-                    }
-                    rebound.buffer_addr = producer_base + ref.packed_offset;
-                    rebound.owner_task_id = producer.task_id.raw;
-                    patch.source = static_cast<uint8_t>(GraphTensorAddressSource::INTERNAL);
-                    patch.address_offset = node_offsets[producer_index] + ref.packed_offset;
-                } else {
+                rebound = execution.boundary_tensors[ref.source_index];
+            } else if (ref.source == static_cast<uint8_t>(GraphTensorSource::BOUNDARY_VIEW)) {
+                if (ref.source_index >= execution.boundary_tensor_count) {
                     execution.materialize_busy.store(0, std::memory_order_release);
                     return GraphMaterializeResult::INVALID;
                 }
-                if (!graph_tensor_wire_valid(rebound) ||
-                    execution.materialized_tensor_patches >= execution.tensor_patch_capacity) {
+                const GraphTensor &boundary = execution.boundary_tensors[ref.source_index];
+                if (ref.packed_offset > UINT64_MAX - boundary.start_offset) {
                     execution.materialize_busy.store(0, std::memory_order_release);
                     return GraphMaterializeResult::INVALID;
                 }
-                execution.tensor_patches[execution.materialized_tensor_patches++] = patch;
-                graph_tensor_unpack(rebound, &tensor);
+                rebound.buffer_addr = boundary.buffer_addr;
+                rebound.buffer_size = boundary.buffer_size;
+                rebound.owner_task_id = boundary.owner_task_id;
+                rebound.start_offset = boundary.start_offset + ref.packed_offset;
+                rebound.version = boundary.version;
+                rebound.address_space = boundary.address_space;
+            } else if (ref.source == static_cast<uint8_t>(GraphTensorSource::INTERNAL) ||
+                       ref.source == static_cast<uint8_t>(GraphTensorSource::OWN_OUTPUT)) {
+                const bool own_output = ref.source == static_cast<uint8_t>(GraphTensorSource::OWN_OUTPUT);
+                const int32_t producer_index = own_output ? i : static_cast<int32_t>(ref.source_index);
+                if (producer_index < 0 || producer_index > i || (own_output && ref.source_index != i) ||
+                    (!own_output && producer_index == i)) {
+                    execution.materialize_busy.store(0, std::memory_order_release);
+                    return GraphMaterializeResult::INVALID;
+                }
+                PTO2TaskDescriptor &producer = execution.node_storage[producer_index].task;
+                const uint64_t producer_bytes = static_cast<uint64_t>(nodes[producer_index].total_output_size);
+                const uintptr_t producer_base = reinterpret_cast<uintptr_t>(producer.packed_buffer_base);
+                if (ref.packed_offset > producer_bytes || rebound.buffer_size > producer_bytes - ref.packed_offset ||
+                    ref.packed_offset > UINTPTR_MAX - producer_base ||
+                    ref.packed_offset > UINT64_MAX - node_offsets[producer_index]) {
+                    execution.materialize_busy.store(0, std::memory_order_release);
+                    return GraphMaterializeResult::INVALID;
+                }
+                rebound.buffer_addr = producer_base + ref.packed_offset;
+                rebound.owner_task_id = producer.task_id.raw;
+            } else {
+                execution.materialize_busy.store(0, std::memory_order_release);
+                return GraphMaterializeResult::INVALID;
             }
-            for (int32_t j = 0; j < source.scalar_count; ++j) {
-                const uint32_t scalar_index = source.scalar_offset + static_cast<uint32_t>(j);
-                const GraphScalarSourceRef &ref = scalar_sources[scalar_index];
-                if (ref.source == static_cast<uint8_t>(GraphScalarSource::STATIC_VALUE)) {
-                    payload.scalars[j] = definition_scalars[scalar_index];
-                } else if (ref.source == static_cast<uint8_t>(GraphScalarSource::BOUNDARY)) {
-                    if (ref.source_index >= execution.boundary_scalar_count || execution.boundary_scalars == nullptr ||
-                        execution.materialized_scalar_patches >= execution.scalar_patch_capacity) {
-                        execution.materialize_busy.store(0, std::memory_order_release);
-                        return GraphMaterializeResult::INVALID;
-                    }
-                    payload.scalars[j] = execution.boundary_scalars[ref.source_index];
-                    execution.scalar_patches[execution.materialized_scalar_patches++] = GraphScalarPatch{
-                        static_cast<uint16_t>(i), static_cast<uint8_t>(j), static_cast<uint8_t>(ref.source_index)
-                    };
-                } else {
-                    execution.materialize_busy.store(0, std::memory_order_release);
-                    return GraphMaterializeResult::INVALID;
-                }
+            if (!graph_tensor_wire_valid(rebound)) {
+                execution.materialize_busy.store(0, std::memory_order_release);
+                return GraphMaterializeResult::INVALID;
             }
-        } else {
-            for (int32_t j = 0; j < payload.tensor_count; ++j) {
-                if (execution.materialized_tensor_patches >= execution.materialized_tensor_patch_count) {
+            execution.consumed_tensor_args++;
+            graph_tensor_unpack(rebound, &tensor);
+        }
+        for (int32_t j = 0; j < source.scalar_count; ++j) {
+            const uint32_t scalar_index = source.scalar_offset + static_cast<uint32_t>(j);
+            const GraphScalarSourceRef &ref = scalar_sources[scalar_index];
+            if (ref.source == static_cast<uint8_t>(GraphScalarSource::STATIC_VALUE)) {
+                payload.scalars[j] = definition_scalars[scalar_index];
+            } else if (ref.source == static_cast<uint8_t>(GraphScalarSource::BOUNDARY)) {
+                if (ref.source_index >= execution.boundary_scalar_count || execution.boundary_scalars == nullptr) {
                     execution.materialize_busy.store(0, std::memory_order_release);
                     return GraphMaterializeResult::INVALID;
                 }
-                const GraphTensorAddressPatch &patch =
-                    execution.tensor_patches[execution.materialized_tensor_patches++];
-                if (patch.source == static_cast<uint8_t>(GraphTensorAddressSource::BOUNDARY)) {
-                    payload.tensors[j].buffer.addr = execution.boundary_tensors[patch.source_index].buffer_addr;
-                } else {
-                    payload.tensors[j].buffer.addr = outer_base + patch.address_offset;
-                }
-            }
-            while (execution.materialized_scalar_patches < execution.materialized_scalar_patch_count) {
-                const GraphScalarPatch &patch = execution.scalar_patches[execution.materialized_scalar_patches];
-                if (patch.node_index != static_cast<uint16_t>(i)) break;
-                if (patch.node_scalar_index >= payload.scalar_count ||
-                    patch.boundary_scalar_index >= execution.boundary_scalar_count ||
-                    execution.boundary_scalars == nullptr) {
-                    execution.materialize_busy.store(0, std::memory_order_release);
-                    return GraphMaterializeResult::INVALID;
-                }
-                payload.scalars[patch.node_scalar_index] = execution.boundary_scalars[patch.boundary_scalar_index];
-                execution.materialized_scalar_patches++;
+                payload.scalars[j] = execution.boundary_scalars[ref.source_index];
+            } else {
+                execution.materialize_busy.store(0, std::memory_order_release);
+                return GraphMaterializeResult::INVALID;
             }
         }
         reset_graph_payload(payload);
@@ -662,23 +495,15 @@ GraphMaterializeResult graph_execution_materialize_slice(
         return GraphMaterializeResult::PENDING;
     }
 
-    const uint32_t expected_tensor_patches =
-        affine_reuse ? execution.materialized_tensor_patch_count : definition.tensor_arg_count;
-    if (execution.materialized_tensor_patches != expected_tensor_patches) {
-        execution.materialize_busy.store(0, std::memory_order_release);
-        return GraphMaterializeResult::INVALID;
-    }
-    if (affine_reuse && execution.materialized_scalar_patches != execution.materialized_scalar_patch_count) {
+    // Every node's [tensor_offset, tensor_offset + tensor_count) range is bounds-
+    // checked on its own. This total additionally requires the ranges to account
+    // for the whole tensor array, rejecting a Definition that under- or
+    // over-consumes it.
+    if (execution.consumed_tensor_args != definition.tensor_arg_count) {
         execution.materialize_busy.store(0, std::memory_order_release);
         return GraphMaterializeResult::INVALID;
     }
 
-    execution.materialized_graph_key = execution.graph_key;
-    execution.materialized_definition_hash = execution.definition_hash;
-    execution.materialized_node_count = execution.node_count;
-    execution.materialized_tensor_patch_count = execution.materialized_tensor_patches;
-    execution.materialized_scalar_patch_count = execution.materialized_scalar_patches;
-    execution.materialized_outer_base = outer_base;
     execution.state.store(GraphExecutionState::PREPARED, std::memory_order_release);
     execution.materialize_busy.store(0, std::memory_order_release);
     return GraphMaterializeResult::PREPARED;

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -317,48 +317,15 @@ enum class GraphMaterializeResult : uint8_t {
     PREPARED = 3,
 };
 
-enum class GraphTensorAddressSource : uint8_t {
-    BOUNDARY = 0,
-    INTERNAL = 1,
-};
-
-// Precomputed on the first materialization and retained next to the node
-// storage. Affine replay walks this compact POD instead of re-reading and
-// classifying GraphTensorSourceRef entries from the Definition.
-struct GraphTensorAddressPatch {
-    uint64_t address_offset;
-    uint16_t source_index;
-    uint8_t source;
-    uint8_t reserved[5];
-};
-
-static_assert(std::is_trivially_copyable_v<GraphTensorAddressPatch>);
-static_assert(std::is_standard_layout_v<GraphTensorAddressPatch>);
-static_assert(sizeof(GraphTensorAddressPatch) == 16);
-
-struct GraphScalarPatch {
-    uint16_t node_index;
-    uint8_t node_scalar_index;
-    uint8_t boundary_scalar_index;
-};
-
-static_assert(std::is_trivially_copyable_v<GraphScalarPatch>);
-static_assert(std::is_standard_layout_v<GraphScalarPatch>);
-static_assert(sizeof(GraphScalarPatch) == 4);
-static_assert(GRAPH_MAX_NODES <= UINT16_MAX);
-static_assert(MAX_SCALAR_ARGS <= UINT8_MAX);
-
 struct alignas(64) GraphNodeStorage {
     PTO2TaskDescriptor task;
     PTO2TaskPayload payload;
     PTO2TaskSlotState slot;
 };
 
-inline constexpr uint64_t GRAPH_EXECUTION_STORAGE_MAGIC = 0x4752415048455845ULL;
 inline constexpr uint64_t GRAPH_EXECUTION_INITIALIZING = 1;
 
 struct GraphExecution {
-    uint64_t storage_magic{0};
     std::atomic<GraphExecutionState> state{GraphExecutionState::SUBMITTED};
     std::atomic<uint8_t> materialize_busy{0};
     std::atomic<int32_t> remaining_nodes{0};
@@ -371,28 +338,12 @@ struct GraphExecution {
     std::atomic<int32_t> published_nodes{0};
     std::atomic<int32_t> route_cursor{0};
     int32_t node_count{0};
-    int32_t node_capacity{0};
     int32_t materialized_nodes{0};
-    int32_t materialized_node_count{0};
     int32_t constructed_nodes{0};
-    uint32_t tensor_patch_capacity{0};
-    uint32_t materialized_tensor_patches{0};
-    uint32_t materialized_tensor_patch_count{0};
-    uint32_t scalar_patch_capacity{0};
-    uint32_t materialized_scalar_patches{0};
-    uint32_t materialized_scalar_patch_count{0};
-    size_t allocation_bytes{0};
-    uint64_t graph_key{0};
-    uint64_t definition_hash{0};
-    uint64_t materialized_graph_key{0};
-    uint64_t materialized_definition_hash{0};
-    uintptr_t materialized_outer_base{0};
-    bool definition_affine_reuse{false};
+    uint32_t consumed_tensor_args{0};
     PTO2TaskSlotState *outer_slot{nullptr};
     GraphNodeStorage *nodes{nullptr};
     GraphNodeStorage *node_storage{nullptr};
-    GraphTensorAddressPatch *tensor_patches{nullptr};
-    GraphScalarPatch *scalar_patches{nullptr};
     const GraphDefinition *definition{nullptr};
     const uint32_t *fanin_offsets{nullptr};
     const uint16_t *fanin_indices{nullptr};
@@ -402,53 +353,25 @@ struct GraphExecution {
     uint32_t boundary_scalar_count{0};
 };
 
-static_assert(offsetof(GraphExecution, storage_magic) == 0);
-static_assert(sizeof(GraphExecution::storage_magic) == sizeof(uint64_t));
 static_assert(std::is_trivially_destructible_v<GraphNodeStorage>);
 static_assert(std::is_trivially_destructible_v<GraphExecution>);
 
-inline bool graph_execution_storage_layout(
-    int32_t node_capacity, uint32_t tensor_patch_capacity, uint32_t scalar_patch_capacity, size_t *nodes_offset,
-    size_t *tensor_patches_offset, size_t *scalar_patches_offset, size_t *storage_bytes
-) {
-    if (nodes_offset == nullptr || tensor_patches_offset == nullptr || scalar_patches_offset == nullptr ||
-        storage_bytes == nullptr || node_capacity <= 0 ||
-        static_cast<size_t>(node_capacity) > SIZE_MAX / sizeof(GraphNodeStorage) ||
-        tensor_patch_capacity > GRAPH_MAX_NODES * MAX_TENSOR_ARGS ||
-        scalar_patch_capacity > GRAPH_MAX_NODES * MAX_SCALAR_ARGS) {
+// The execution occupies [GraphExecution][GraphNodeStorage x node_count] at the
+// tail of the outer GRAPH task's heap allocation.
+inline bool graph_execution_storage_layout(int32_t node_count, size_t *nodes_offset, size_t *storage_bytes) {
+    if (nodes_offset == nullptr || storage_bytes == nullptr || node_count <= 0 ||
+        node_count > static_cast<int32_t>(GRAPH_MAX_NODES)) {
         return false;
     }
-    auto checked_align_up = [](size_t value, size_t alignment, size_t *result) {
-        if (alignment == 0 || value > SIZE_MAX - (alignment - 1)) return false;
-        *result = (value + alignment - 1) & ~(alignment - 1);
-        return true;
-    };
-    const size_t nodes_bytes = static_cast<size_t>(node_capacity) * sizeof(GraphNodeStorage);
-    const size_t tensor_patches_bytes = static_cast<size_t>(tensor_patch_capacity) * sizeof(GraphTensorAddressPatch);
-    const size_t scalar_patches_bytes = static_cast<size_t>(scalar_patch_capacity) * sizeof(GraphScalarPatch);
-    if (!checked_align_up(sizeof(GraphExecution), alignof(GraphNodeStorage), nodes_offset) ||
-        *nodes_offset > SIZE_MAX - nodes_bytes ||
-        !checked_align_up(*nodes_offset + nodes_bytes, alignof(GraphTensorAddressPatch), tensor_patches_offset) ||
-        *tensor_patches_offset > SIZE_MAX - tensor_patches_bytes ||
-        !checked_align_up(
-            *tensor_patches_offset + tensor_patches_bytes, alignof(GraphScalarPatch), scalar_patches_offset
-        ) ||
-        *scalar_patches_offset > SIZE_MAX - scalar_patches_bytes) {
-        return false;
-    }
-    return checked_align_up(*scalar_patches_offset + scalar_patches_bytes, alignof(GraphNodeStorage), storage_bytes);
+    constexpr size_t ALIGNMENT = alignof(GraphNodeStorage);
+    *nodes_offset = (sizeof(GraphExecution) + ALIGNMENT - 1) & ~(ALIGNMENT - 1);
+    *storage_bytes = *nodes_offset + static_cast<size_t>(node_count) * sizeof(GraphNodeStorage);
+    return true;
 }
 
-inline bool graph_execution_storage_bytes(
-    int32_t node_capacity, uint32_t tensor_patch_capacity, uint32_t scalar_patch_capacity, size_t *storage_bytes
-) {
+inline bool graph_execution_storage_bytes(int32_t node_count, size_t *storage_bytes) {
     size_t nodes_offset = 0;
-    size_t tensor_patches_offset = 0;
-    size_t scalar_patches_offset = 0;
-    return graph_execution_storage_layout(
-        node_capacity, tensor_patch_capacity, scalar_patch_capacity, &nodes_offset, &tensor_patches_offset,
-        &scalar_patches_offset, storage_bytes
-    );
+    return graph_execution_storage_layout(node_count, &nodes_offset, storage_bytes);
 }
 
 GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot);

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -110,10 +110,7 @@ std::vector<std::byte> make_test_definition(uint64_t graph_key, uint64_t boundar
     definition.off_scalars = append_section(image, scalars);
     definition.off_scalar_sources = append_section(image, scalar_sources);
     size_t execution_storage_bytes = 0;
-    graph_execution_storage_bytes(
-        static_cast<int32_t>(definition.task_count), definition.tensor_arg_count, definition.scalar_arg_count,
-        &execution_storage_bytes
-    );
+    graph_execution_storage_bytes(static_cast<int32_t>(definition.task_count), &execution_storage_bytes);
     definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
     definition.total_bytes = static_cast<uint32_t>(image.size());
     std::memcpy(image.data(), &definition, sizeof(definition));
@@ -279,35 +276,27 @@ TEST(GraphScalarProvenance, MutableAccessInvalidatesForwardedSource) {
 
 TEST(GraphExecutionStorage, ComputesAlignedExactSize) {
     constexpr int32_t NODE_COUNT = 7;
-    constexpr uint32_t TENSOR_PATCH_COUNT = 11;
-    constexpr uint32_t SCALAR_PATCH_COUNT = 5;
     size_t nodes_offset = 0;
-    size_t tensor_patches_offset = 0;
-    size_t scalar_patches_offset = 0;
     size_t storage_bytes = 0;
 
-    ASSERT_TRUE(graph_execution_storage_layout(
-        NODE_COUNT, TENSOR_PATCH_COUNT, SCALAR_PATCH_COUNT, &nodes_offset, &tensor_patches_offset,
-        &scalar_patches_offset, &storage_bytes
-    ));
+    ASSERT_TRUE(graph_execution_storage_layout(NODE_COUNT, &nodes_offset, &storage_bytes));
     EXPECT_EQ(nodes_offset % alignof(GraphNodeStorage), 0U);
-    EXPECT_EQ(tensor_patches_offset % alignof(GraphTensorAddressPatch), 0U);
-    EXPECT_EQ(scalar_patches_offset % alignof(GraphScalarPatch), 0U);
-    EXPECT_GE(tensor_patches_offset, nodes_offset + NODE_COUNT * sizeof(GraphNodeStorage));
-    EXPECT_GE(scalar_patches_offset, tensor_patches_offset + TENSOR_PATCH_COUNT * sizeof(GraphTensorAddressPatch));
-    EXPECT_GE(storage_bytes, scalar_patches_offset + SCALAR_PATCH_COUNT * sizeof(GraphScalarPatch));
-    EXPECT_EQ(storage_bytes % alignof(GraphNodeStorage), 0U);
+    EXPECT_GE(nodes_offset, sizeof(GraphExecution));
+    EXPECT_EQ(storage_bytes, nodes_offset + NODE_COUNT * sizeof(GraphNodeStorage));
 }
 
-TEST(GraphExecutionStorage, RejectsInvalidCapacity) {
+TEST(GraphExecutionStorage, RejectsInvalidNodeCount) {
     size_t storage_bytes = 0;
 
-    EXPECT_FALSE(graph_execution_storage_bytes(0, 0, 0, &storage_bytes));
-    EXPECT_FALSE(graph_execution_storage_bytes(-1, 0, 0, &storage_bytes));
-    EXPECT_FALSE(graph_execution_storage_bytes(1, GRAPH_MAX_NODES * MAX_TENSOR_ARGS + 1, 0, &storage_bytes));
+    EXPECT_FALSE(graph_execution_storage_bytes(0, &storage_bytes));
+    EXPECT_FALSE(graph_execution_storage_bytes(-1, &storage_bytes));
+    EXPECT_FALSE(graph_execution_storage_bytes(static_cast<int32_t>(GRAPH_MAX_NODES) + 1, &storage_bytes));
 }
 
-TEST(GraphExecutionReplay, AffineHitRefreshesOnlyDynamicFields) {
+// A resubmission gets the same heap block back, so the bytes it starts from are
+// the previous execution's. Every field must come from the Definition or this
+// submission's boundary, never from what the block last held.
+TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     constexpr uint64_t GRAPH_KEY_VALUE = 0x1234;
     std::array<uint8_t, 64> first_boundary{};
     std::array<uint8_t, 64> second_boundary{};
@@ -315,10 +304,6 @@ TEST(GraphExecutionReplay, AffineHitRefreshesOnlyDynamicFields) {
     const std::vector<std::byte> definition =
         make_test_definition(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(first_boundary.data()));
     const TestDefinitionObject definition_object(definition);
-    // 0xAA fill stands in for whatever the reclaimed heap last held: nothing in
-    // localize/materialize may depend on a zeroed block. Both replays reuse one
-    // allocation so the second sees the first's completed execution, which is
-    // the only state an affine hit accepts.
     OuterHeap heap(definition, 0xAA);
     std::vector<std::byte> submission_image =
         make_test_submission(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(first_boundary.data()), 17);
@@ -355,21 +340,13 @@ TEST(GraphExecutionReplay, AffineHitRefreshesOnlyDynamicFields) {
     execution->retired_nodes.store(2, std::memory_order_release);
     submission.local_execution = 0;
     outer_task.task_id = PTO2TaskId::make(1, 8);
-    // The base cannot move between replays that share an execution block: the
-    // block is that allocation's own tail. Only the boundary is dynamic here.
     auto *boundary = reinterpret_cast<GraphTensor *>(submission_image.data() + submission.tensors_offset);
     boundary->buffer_addr = reinterpret_cast<uint64_t>(second_boundary.data());
     auto *boundary_scalar = reinterpret_cast<uint64_t *>(submission_image.data() + submission.scalars_offset);
     *boundary_scalar = 99;
 
-    execution = graph_execution_localize(outer_slot);
-    ASSERT_NE(execution, nullptr);
-    EXPECT_EQ(static_cast<void *>(execution), heap.execution());
-    ASSERT_TRUE(execution->definition_affine_reuse);
-
-    // Write probes make an otherwise same-valued store observable. An affine
-    // replay must not touch these static fields; only the tensor address and
-    // per-run descriptor/scheduling state below are dynamic.
+    // Poison every field the rebuild is responsible for restoring. A replay that
+    // preserved any of them would leave the poison observable.
     node.task.kernel_id[0] = 314;
     node.slot.active_mask = ActiveMask(3);
     node.payload.scalars[0] = 2718;
@@ -378,12 +355,18 @@ TEST(GraphExecutionReplay, AffineHitRefreshesOnlyDynamicFields) {
     node.slot.completed_subtasks.store(1, std::memory_order_relaxed);
     node.payload.dispatch_fanin.store(1, std::memory_order_relaxed);
 
+    execution = graph_execution_localize(outer_slot);
+    ASSERT_NE(execution, nullptr);
+    // Same block: it is this allocation's own tail, so the rebuild lands on the
+    // bytes the previous execution left behind.
+    EXPECT_EQ(static_cast<void *>(execution), heap.execution());
+
     EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
-    EXPECT_EQ(node.task.kernel_id[0], 314);
-    EXPECT_EQ(node.slot.active_mask.raw(), 3);
+    EXPECT_EQ(node.task.kernel_id[0], 42);
+    EXPECT_EQ(node.slot.active_mask.raw(), 1);
     EXPECT_EQ(node.payload.scalars[0], 99U);
-    EXPECT_EQ(execution->node_storage[1].payload.scalars[0], 31415U);
-    EXPECT_EQ(node.payload.tensors[0].version, 1618);
+    EXPECT_EQ(execution->node_storage[1].payload.scalars[0], 18U);
+    EXPECT_EQ(node.payload.tensors[0].version, 0);
     EXPECT_EQ(node.task.task_id, PTO2TaskId::make(1, (8U << 10U)));
     EXPECT_EQ(node.task.packed_buffer_base, heap.base());
     EXPECT_EQ(node.payload.tensors[0].buffer.addr, reinterpret_cast<uint64_t>(second_boundary.data()));
@@ -391,18 +374,6 @@ TEST(GraphExecutionReplay, AffineHitRefreshesOnlyDynamicFields) {
     EXPECT_EQ(node.slot.completed_subtasks.load(std::memory_order_relaxed), 0);
     EXPECT_EQ(node.payload.dispatch_fanin.load(std::memory_order_relaxed), 0);
     EXPECT_EQ(node.payload.dump_metadata.dump_arg_mask, uint64_t{1} << 0);
-
-    graph_execution_mark_completed(*execution);
-    execution->retired_nodes.store(2, std::memory_order_release);
-    submission.local_execution = 0;
-    execution = graph_execution_localize(outer_slot);
-    ASSERT_NE(execution, nullptr);
-    EXPECT_EQ(static_cast<void *>(execution), heap.execution());
-    ASSERT_TRUE(execution->definition_affine_reuse);
-    execution->materialized_tensor_patch_count = 1;
-
-    EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::INVALID);
-    EXPECT_EQ(execution->materialized_tensor_patches, 1U);
 }
 
 TEST(GraphDefinitionObject, RejectsDefinitionBeyondRetainedBytes) {
@@ -593,8 +564,8 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
     EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
 
     // Every observable scheduling field must be a materialize-written value,
-    // not the 0xAA fill: state machine, counters, atomics, and the patch
-    // tables all start from values only the device side wrote.
+    // not the 0xAA fill: state machine, counters and atomics all start from
+    // values only the device side wrote.
     for (int32_t i = 0; i < execution->node_count; ++i) {
         const GraphNodeStorage &node = execution->node_storage[i];
         ASSERT_EQ(node.slot.task_state.load(std::memory_order_relaxed), PTO2_TASK_PENDING);
@@ -603,14 +574,13 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
         ASSERT_EQ(node.payload.dispatch_fanin.load(std::memory_order_relaxed), 0);
         ASSERT_EQ(node.payload.tensor_count, 1);
         ASSERT_EQ(node.payload.scalar_count, 1);
+        // A tensor address of 0xAAAAAAAAAAAAAAAA would mean the fill leaked
+        // through into a field the scheduler later dereferences.
+        ASSERT_NE(node.payload.tensors[0].buffer.addr, 0xAAAAAAAAAAAAAAAAULL);
         // make_test_definition assigns node i the heap offset 64*i, so the
         // packed window starts at outer_base + 64*i, not at outer_base.
         ASSERT_EQ(node.task.packed_buffer_base, static_cast<void *>(heap.base() + static_cast<size_t>(i) * 64));
     }
     EXPECT_EQ(execution->materialized_nodes, execution->node_count);
-    for (uint32_t i = 0; i < execution->materialized_tensor_patches; ++i) {
-        // A patch address of 0xAAAAAAAAAAAAAAAA would mean the fill leaked
-        // through into a field the scheduler later dereferences.
-        EXPECT_NE(execution->tensor_patches[i].address_offset, 0xAAAAAAAAAAAAAAAAULL);
-    }
+    EXPECT_EQ(execution->consumed_tensor_args, 2U);
 }


### PR DESCRIPTION
## Summary

Deletes the graph-affine replay fast path, which cannot fire.

Materializing a Graph recorded, next to its node storage, a Tensor-address and
scalar patch table plus the Definition key, content hash and node/patch counts
that produced it. A later submission landing on that same storage matched those
and took an affine replay: it skipped topology binding, per-node validation,
tensor-source classification, wire validation and every static field store,
rewriting only 8 bytes of `buffer.addr` per Tensor arg.

That path can only ever fire across binds. A bind's occurrences each get their
own expansion storage and use it once, so a hit requires the previous bind's
expansion to still be in the block — and reusing a previous bind's recorded or
materialized state is not something this runtime permits. The replay is
therefore unreachable by design, and every field it preserved is now written
from the Definition on every submission.

**Removed:** `GraphTensorAddressPatch`, `GraphScalarPatch`,
`GraphTensorAddressSource`; the two patch arrays and their capacities; the six
`materialized_*` fields, `materialized_outer_base` and
`definition_affine_reuse`; `GraphExecution`'s `graph_key`, `definition_hash`,
`node_capacity`, `allocation_bytes` and `storage_magic`; the storage magic
constant, the reuse header validator and the grow-into-a-larger-block path, so
acquiring storage is now an unconditional placement-new. `reset_for_reuse` loses
its `preserve_graph_binding` parameter, whose only non-default caller was the
replay.

**Kept:** the tensor-arg total the replay compared against, as
`consumed_tensor_args`. Each node's `[tensor_offset, tensor_offset +
tensor_count)` range is bounds-checked on its own, and the total additionally
requires the ranges to account for the whole tensor array, rejecting a Definition
that under- or over-consumes it. Being a sum, it does not exclude an overlap
paired with an equal-sized gap; every tensor arg is bounds-checked and
wire-validated before use regardless.

Also aligns the a5 copy of `reset_for_reuse`'s doc comment with the a2a3 one. It
claimed the reset runs at init in `pto_shared_memory.cpp`, but per-slot init is
init-on-write in `orch::prepare_task` in both trees — as that file's own comment
states.

Net −311 lines across 8 files.

## Measurements

Dropping the patch arrays shrinks the expansion storage the outer task's heap
allocation carries. On qwen3-14b decode (40 replays of one 277-node Definition)
the heap high-water falls 128,328,704 → 127,673,344 bytes, 16,384 per expansion.

Device wall time over three rounds is 39.09 / 40.90 / 38.61 ms against
41.27 / 38.65 / 40.70 ms with the replay present: both sets scatter across the
same ~2.7 ms band with no round-over-round trend, so the replay was not paying
for itself on this workload even before it became unreachable.

## Testing

- `AffineHitRefreshesOnlyDynamicFields` becomes
  `ResubmissionRebuildsFromDefinition`, asserting the inverse invariant — poison
  every field the rebuild owns and require the Definition's values back, on the
  same block the previous execution left behind.
- [x] C++ unit tests: 101/101 pass (`ctest --test-dir tests/ut/cpp/build -LE requires_hardware`)
- [x] `clang-format --dry-run --Werror` clean on the changed C++ files
- [x] `markdownlint-cli2 --fix` modifies nothing in `GRAPH_EXECUTION.md`
- [ ] Simulation tests pass (CI)
- [ ] Hardware tests pass (CI)

Builds on #1884.
