### PR TITLE
Close the ext. reserved namespace against our own inference

### DIFF
--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -46,8 +46,9 @@ The visible Perfetto axis remains monotonic; each mapped host event exposes the
 exact decimal `wall_ts_ns` and a UTC `wall_time` in its arguments, while the JSON
 top level retains the source mappings in `clockAnchors`. Nanosecond epoch values
 are strings because JSON consumers commonly use IEEE-754 numbers, which cannot
-represent current epoch nanoseconds exactly. Old logs without an anchor retain
-their existing output, and `clk=dev` records never receive host wall time.
+represent current epoch nanoseconds exactly. A log with no anchor for a pid gets
+no wall time for that pid's events and is otherwise unaffected, and `clk=dev`
+records never receive host wall time.
 
 One line per span, emitted on scope exit
 (`src/common/log/include/common/strace.h`):
@@ -164,6 +165,35 @@ that state before `fork()`; a chip child re-seeds its inherited copy and passes
 the same pointer to every runtime module it loads. The threshold and one-anchor
 coordination are therefore shared within each process without relying on
 `RTLD_GLOBAL` logger symbols.
+
+## `ext.` — spans from outside simpler
+
+Every level word above belongs to simpler, so a span from any other producer
+leads with the reserved word `ext.` and names itself:
+
+```text
+ext.<producer>.<span>          e.g. ext.pypto.decode_layer
+```
+
+All three segments are required. `ext.foo` names no span of its own and
+`ext..foo` names no producer, so neither attributes to anyone — such a span is
+still recognized as external (it can never be mistaken for ours) but renders in
+an unattributed lane. A producer segment may itself be one of our level words:
+`ext.host.foo` attributes to a producer called `host` and remains external.
+
+What the namespace guarantees, in both directions:
+
+| Guarantee | What holds |
+| --------- | ---------- |
+| **Visible in** | `--swimlane`, on the emitting pid/tid. This is the only view that renders external spans. |
+| **Excluded from** | the TPOT, rounds and `--tree` tables and `--trace-out`, all of which key on `(pid, inv)`. `inv` is our native run epoch and no public surface exposes it, so admitting external spans would collapse every one of them into a single forged invocation. |
+| **Cannot affect** | lane naming, lane splitting, or dispatch-flow pairing. Our views infer those only from our own spans, so `role`, `slot_id`, `run_id` and `depth` on an external span carry whatever meaning its producer wants. |
+| **Process label** | a process that emitted only external spans is labelled `external producer <name> (pid=N)`, with no `simpler` prefix. A producer emitting into one of our processes — the common case for a caller of the public API — leaves that process labelled as ours. |
+
+The contract is executable: `tests/ut/py/test_strace_timing.py` asserts each row
+above under the `ext.` heading near the end of the file. A repository adapting to
+this namespace can read those tests as the specification and mirror them against
+its own emitter.
 
 ## Reading the markers — `strace_timing.py`
 

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -366,14 +366,20 @@ to a file (`python test_*.py … --rounds N > run.log 2>&1`) and pass `run.log`
 here. Because grouping is per `(pid, inv)`, this captures **L3 multi-round**
 (every chip-child invocation), not just round 0.
 
-`--swimlane` consumes both the `l3.*` scheduler markers and child
-`chip.run` markers. Host lanes retain their OS pid/tid. Because Chrome Trace
+`--swimlane` consumes the `<level>.*` host-scheduler markers (`host.`,
+`network1.`, `network2.`, `network3.`) and child `chip.run` markers, plus any
+`ext.<producer>.*` spans a producer outside simpler emitted. Host lanes retain
+their OS pid/tid. Because Chrome Trace
 JSON has one visible timestamp axis, raw device-domain `clk=dev` slices are
 stored in the top-level `unalignedDeviceSpans` array rather than placed beside
 the unrelated host clock and stretching Perfetto into an empty-looking
 multi-day viewport. Their ns timestamps remain unchanged; no clock offset is
 invented. This does not alter the established per-invocation `--trace-out`
 view.
+
+The swimlane is the only view that renders `ext.` spans: every table and
+`--trace-out` keys on `(pid, inv)`, which no external producer has. See
+[docs/dfx/host-trace.md](../../docs/dfx/host-trace.md) for that contract.
 
 ---
 

--- a/simpler_setup/tools/strace_timing.py
+++ b/simpler_setup/tools/strace_timing.py
@@ -57,11 +57,13 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
-# The monotonic prefix is current; the wall-clock form keeps archived logs
-# parseable. The func segment excludes ':' because `LOG_TIMING` passes
+# A record's attribute list runs to the end of its line, so what bounds it is the
+# lookahead for the next record's log prefix — which is why this pattern exists at
+# all. Two complete records do share one physical line: ranks forked by an L3
+# share the capture fd. The func segment excludes ':' because `LOG_TIMING` passes
 # `__FUNCTION__`, an unqualified name. A qualified name containing '::' stops
 # this alternative from matching, leaving `[STRACE]` to bound the record.
-_HOST_LOG_TIME = r"(?:\[mono_ns=\d+\]|\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6}\])"
+_HOST_LOG_TIME = r"\[mono_ns=\d+\]"
 _HOST_LOG_PREFIX = _HOST_LOG_TIME + r"\[T0x[0-9a-fA-F]+\]\[[A-Z]+\]\s+[^:\r\n]+:\s+"
 # MULTILINE anchors the `$` alternative at every line end, so a caller passing a
 # multi-line blob rather than one line per item keeps every record but the last.
@@ -252,8 +254,12 @@ def _trace_document(events, anchors_by_pid, **extra):
 
 
 # A span name leads with the word for the level that produced it. The words come
-# from `simpler.worker_level.WorkerLevel`; this parser cannot import the runtime
-# package, so it carries the list and the unit tests pin the two together.
+# from `simpler.worker_level.WorkerLevel`, and this parser cannot import the
+# runtime package, so this is a second copy of that ladder.
+# `test_every_level_word_the_ladder_names_is_a_word_this_parser_knows` compares
+# the two as sets: a level added there and not here makes `span_family` answer
+# `unknown` for a word the runtime emits, which puts per-task spans into
+# invocation grouping instead of excluding them.
 _CHIP_WORD = "chip"
 _CORE_WORD = "core"
 _HOST_WORDS = ("host", "network1", "network2", "network3")
@@ -261,13 +267,6 @@ _HOST_WORDS = ("host", "network1", "network2", "network3")
 # Reserved for producers outside simpler: `ext.<producer>.<span>`. Without a
 # reserved word a caller's span called `host.foo` would parse as one of ours.
 _EXTERNAL_WORD = "ext"
-
-# Spellings simpler no longer emits, mapped to the family they used to name.
-# Kept so an archived log stays readable — the same reason `_STRACE_RE` still
-# accepts the wall-clock record prefix. Note this restores the tree, swimlane and
-# invocation views on an old log, not `_ROUNDS_TABLE_NAMES`: that table is a
-# single-spelling contract with pypto.
-_RETIRED_WORDS = {"simpler_run": _CHIP_WORD, "simpler_prewarm": _CHIP_WORD, "l3": _HOST_WORDS[0]}
 
 
 def span_family(name):
@@ -279,7 +278,6 @@ def span_family(name):
     given process resolved to.
     """
     head = name.split(".", 1)[0]
-    head = _RETIRED_WORDS.get(head, head)
     if head == _EXTERNAL_WORD:
         return "external"
     if head == _CHIP_WORD:
@@ -304,20 +302,36 @@ def host_span_leaf(name):
     return leaf
 
 
-def legacy_spans(spans):
+def external_producer(name):
+    """The producer segment of an ``ext.<producer>.<span>`` name, else ``None``.
+
+    All three segments are required: ``ext.pypto.decode_layer`` attributes to
+    ``pypto``, while ``ext.foo`` names no span of its own and ``ext..foo`` names
+    no producer. Neither resolves, so a malformed name lands in an unattributed
+    lane instead of another producer's.
+
+    Attribution is separate from :func:`span_family`, which answers only whether
+    a name is ours. A name under ``ext.`` is never ours whatever follows it.
+    """
+    if span_family(name) != "external":
+        return None
+    parts = name.split(".")
+    if len(parts) < 3:
+        return None
+    return parts[1] or None
+
+
+def invocation_spans(spans):
     """Return the spans the invocation-keyed views may consume.
 
-    The invocation views key on ``(pid, inv)``, so a family carrying no
-    invocation id would group into one bogus lane. Excluded: the per-task
-    ``host``/``network*`` scheduler family, and anything an external producer
-    emitted under ``ext.``. Everything else is kept, including a name this
-    parser does not recognize — dropping an unfamiliar family silently is how
-    ``chip.prewarm.build`` once vanished from the tables.
+    Those views key on ``(pid, inv)``, and ``inv`` is a native run epoch. Two
+    families carry none, so admitting either would group all of its spans into
+    one forged invocation: the per-task ``host``/``network*`` scheduler family,
+    and anything an external producer emitted under ``ext.``.
 
-    The name is retained deliberately. pypto calls this through
-    ``hasattr(_strace_timing, "legacy_spans")`` and falls back to its own
-    ``l3.``-prefix filter when it is absent, so renaming it would silently
-    re-arm that stale fallback in a downstream repository.
+    Everything else is kept, **including a name this parser does not recognize**.
+    Dropping an unfamiliar family silently is how ``chip.prewarm.build`` once
+    vanished from the tables.
     """
     return [span for span in spans if span_family(span.name) not in ("host", "external")]
 
@@ -415,7 +429,7 @@ def assert_native_overlap(spans, *, require_hidden=False):
     scheduling, so it is opt-in: a bind that runs long on a contended machine
     still overlaps.
     """
-    dispatches = _native_dispatches(group_invocations(legacy_spans(spans)))
+    dispatches = _native_dispatches(group_invocations(invocation_spans(spans)))
     by_pid = defaultdict(list)
     for identity, by_name in dispatches.items():
         missing = [name for name in _NATIVE_REQUIRED_SPANS if name not in by_name]
@@ -771,10 +785,17 @@ def _host_thread_name(entries):
     """Name one OS thread's lane from every span it emitted.
 
     `entries` are that thread's (span, parsed attributes) pairs.
+
+    Role inference reads only our own spans. `role` is an ordinary attribute key,
+    so an external producer is free to use it for its own meaning; letting one
+    reach the loop below would name its lane after one of our roles.
     """
     roles = set()
     worker_ids = set()
+    external = [(span, attrs) for span, attrs in entries if span_family(span.name) == "external"]
     for span, attrs in entries:
+        if span_family(span.name) == "external":
+            continue
         role = attrs.get("role")
         leaf = host_span_leaf(span.name)
         if role == "facade" or leaf in {"graph_build", "submit"}:
@@ -798,6 +819,10 @@ def _host_thread_name(entries):
 
     if any(span_family(span.name) == "chip" for span, _ in entries):
         return "chip child"
+    if len(external) == len(entries):
+        producers = sorted({producer for span, _ in external if (producer := external_producer(span.name))})
+        if producers:
+            return f"ext {'/'.join(producers)}"
     return f"tid {entries[0][0].tid}"
 
 
@@ -816,19 +841,31 @@ def _assign_lanes(host_entries, host_threads):
     :func:`_slot_lanes`); every other thread keeps its real tid. Synthetic lane
     ids start past the observed tid space so a split lane cannot collide with a
     real thread's.
+
+    Only our own spans shape the split. A pipeline slot is our concept and
+    `slot_id` / `depth` are ordinary record fields, so an external producer that
+    writes them would otherwise decide whether one of our threads is split and
+    into how many lanes. Its spans stay on the thread's real tid.
     """
     lane_of = {}
     lane_names = {}
     next_synthetic_tid = max(tid for _, tid in host_threads) + 1
-    slot_by_invocation = _slot_by_invocation(host_entries)
+    ours = [entry for entry in host_entries if span_family(entry[0].name) != "external"]
+    slot_by_invocation = _slot_by_invocation(ours)
     for pid, tid in host_threads:
         on_thread = [entry for entry in host_entries if entry[0].pid == pid and entry[0].tid == tid]
-        slot_lanes = _slot_lanes(on_thread, slot_by_invocation)
+        ours_on_thread = [entry for entry in on_thread if span_family(entry[0].name) != "external"]
+        slot_lanes = _slot_lanes(ours_on_thread, slot_by_invocation)
         if slot_lanes is None:
             lane_names[(pid, tid)] = _host_thread_name(on_thread)
             for span, _ in on_thread:
                 lane_of[id(span)] = tid
             continue
+        external_on_thread = [entry for entry in on_thread if span_family(entry[0].name) == "external"]
+        if external_on_thread:
+            lane_names[(pid, tid)] = _host_thread_name(external_on_thread)
+            for span, _ in external_on_thread:
+                lane_of[id(span)] = tid
         for slot_id, group in slot_lanes.items():
             lane_tid = next_synthetic_tid
             next_synthetic_tid += 1
@@ -989,6 +1026,26 @@ def bind_phase_spans(text, spans, skip_keys=frozenset()):
     return out
 
 
+def _process_label(pid, process_spans):
+    """Name one process from the families of the spans it emitted.
+
+    Any span of ours makes the process ours, and the host family wins over the
+    chip one. Sharing is the common case rather than the exception: a producer
+    calling the public tracing API emits from inside our own host process, so
+    `ext.` spans alongside ours say nothing about whose process it is. Only a
+    process that emitted external spans and nothing else belongs to a producer,
+    and then the label carries no `simpler` prefix — it is not our process.
+    """
+    families = {span_family(span.name) for span in process_spans}
+    if "host" in families:
+        return f"simpler host (pid={pid})"
+    if families == {"external"}:
+        producers = sorted({producer for span in process_spans if (producer := external_producer(span.name))})
+        named = "/".join(producers) if producers else "unattributed"
+        return f"external producer {named} (pid={pid})"
+    return f"simpler chip child (pid={pid})"
+
+
 def to_host_swimlane(spans, anchors=None):
     """Build a real-pid/tid host scheduling timeline for Perfetto.
 
@@ -1015,14 +1072,13 @@ def to_host_swimlane(spans, anchors=None):
 
     for pid in host_pids:
         process_spans = [span for span, _ in host_entries if span.pid == pid]
-        role = "host" if any(span_family(span.name) == "host" for span in process_spans) else "chip child"
         events.append(
             {
                 "ph": "M",
                 "name": "process_name",
                 "pid": pid,
                 "tid": 0,
-                "args": {"name": f"simpler {role} (pid={pid})"},
+                "args": {"name": _process_label(pid, process_spans)},
             }
         )
     for (pid, lane_tid), name in sorted(lane_names.items()):
@@ -1341,8 +1397,8 @@ def main(argv=None):
             "excluded from the timing below",
             file=sys.stderr,
         )
-    legacy = legacy_spans(spans)
-    invocations = group_invocations(legacy)
+    keyed = invocation_spans(spans)
+    invocations = group_invocations(keyed)
     buckets = bucket_by_hid(invocations)
 
     if args.assert_native_overlap:
@@ -1362,7 +1418,7 @@ def main(argv=None):
     if args.trace_out:
         with open(args.trace_out, "w", encoding="utf-8") as f:
             json.dump(to_chrome_trace(invocations, buckets, anchors=anchors), f)
-        print(f"Wrote Chrome trace: {args.trace_out} ({len(legacy)} spans)")
+        print(f"Wrote Chrome trace: {args.trace_out} ({len(keyed)} spans)")
 
     if args.swimlane:
         write_host_swimlane(args, spans, lines, anchors)

--- a/tests/ut/py/test_strace_timing.py
+++ b/tests/ut/py/test_strace_timing.py
@@ -13,16 +13,21 @@ from collections import defaultdict
 from io import StringIO
 
 import pytest
+from simpler.worker_level import WorkerLevel
 
 from simpler_setup.tools.strace_timing import (
+    _CHIP_WORD,
+    _CORE_WORD,
+    _HOST_WORDS,
     NativeOverlapError,
     assert_native_overlap,
     bucket_by_hid,
     count_record_heads,
+    external_producer,
     group_invocations,
     host_record_spans,
     host_span_leaf,
-    legacy_spans,
+    invocation_spans,
     load_host_phase_records,
     main,
     parse_clock_anchors,
@@ -34,19 +39,26 @@ from simpler_setup.tools.strace_timing import (
 )
 
 
+def _metadata(trace, kind):
+    """The `args.name` of every `kind` metadata event, in lane order."""
+    return [event["args"]["name"] for event in trace["traceEvents"] if event["ph"] == "M" and event["name"] == kind]
+
+
+def _lanes(trace):
+    """Lane tid -> lane name."""
+    return {
+        event["tid"]: event["args"]["name"]
+        for event in trace["traceEvents"]
+        if event["ph"] == "M" and event["name"] == "thread_name"
+    }
+
+
 def _record(pid, inv, name, attrs="", *, depth=0, ts=100, dur=20):
     """One current host-log record in the shape `HostLogger::emit` writes it."""
     return (
         f"[mono_ns={1_000_000 + pid}][T0x{pid}][TIMING] emit_host_span: "
         f"[STRACE] v=1 pid={pid} tid={pid} inv={inv} hid=abc depth={depth} "
         f"name={name} ts={ts} dur={dur} {attrs}"
-    )
-
-
-def _legacy_record(pid, inv, name, attrs=""):
-    return (
-        f"[2026-08-04 10:00:00.00000{pid}][T0x{pid}][TIMING] emit_span: [strace.h:132] "
-        f"[STRACE] v=1 pid={pid} tid={pid} inv={inv} hid=abc depth=0 name={name} ts=100 dur=20 {attrs}"
     )
 
 
@@ -88,7 +100,29 @@ def test_parse_spans_finds_adjacent_records_on_one_physical_line():
 
 
 def test_parse_spans_keeps_every_record_of_a_multi_line_blob():
-    blob = _legacy_record(1, 1, "chip.run", "rank=0") + "\n" + _record(2, 2, "chip.run.bind", "rank=1") + "\n"
+    blob = _record(1, 1, "chip.run", "rank=0") + "\n" + _record(2, 2, "chip.run.bind", "rank=1") + "\n"
+
+    spans = list(parse_spans([blob]))
+
+    assert [(span.pid, span.inv, span.name) for span in spans] == [
+        (1, 1, "chip.run"),
+        (2, 2, "chip.run.bind"),
+    ]
+    assert spans[0].attrs == "rank=0"
+    assert spans[1].attrs == "rank=1"
+
+
+def test_parse_spans_splits_two_records_sharing_one_physical_line():
+    """The log prefix has to bound a record, not just precede one.
+
+    Ranks forked by an L3 share the capture fd, so two complete records land on
+    one physical line often enough that pypto's reader re-splits on ``[STRACE]``
+    before parsing. A record's attribute list runs to the end of the line, so
+    what stops it is the lookahead for the *next* record's log prefix — remove
+    that lookahead and the first record's ``attrs`` silently absorbs the
+    second's whole prefix rather than failing to match.
+    """
+    blob = _record(1, 1, "chip.run", "rank=0") + _record(2, 2, "chip.run.bind", "rank=1")
 
     spans = list(parse_spans([blob]))
 
@@ -441,7 +475,7 @@ def test_host_swimlane_keeps_unaligned_device_clock_out_of_visible_timeline():
     ]
 
 
-def test_legacy_trace_output_ignores_host_swimlane_markers():
+def test_invocation_views_ignore_host_swimlane_markers():
     """The current vocabulary: the host family stays out of the invocation views."""
     old = list(
         parse_spans(
@@ -468,10 +502,10 @@ def test_legacy_trace_output_ignores_host_swimlane_markers():
         )
     )
 
-    old_invocations = group_invocations(legacy_spans(old))
-    mixed_invocations = group_invocations(legacy_spans(mixed))
+    old_invocations = group_invocations(invocation_spans(old))
+    mixed_invocations = group_invocations(invocation_spans(mixed))
 
-    assert [span.name for span in legacy_spans(mixed)] == [
+    assert [span.name for span in invocation_spans(mixed)] == [
         "chip.run",
         "chip.run.bind",
         "chip.prewarm.build",
@@ -487,51 +521,43 @@ def test_span_family_classifies_the_level_words_and_reserves_ext():
     assert span_family("core.pipe") == "core"
     # Every level at or above L3 runs the same orchestrator and scheduler code,
     # so they answer as one family whichever word the process resolved to.
-    for word in ("host", "network1", "network2", "network3"):
-        assert span_family(f"{word}.dispatch") == "host"
+    for level in WorkerLevel:
+        if level.value >= WorkerLevel.host.value:
+            assert span_family(f"{level.name}.dispatch") == "host"
     # A caller cannot land in ours, which is what `ext.` is reserved for.
     assert span_family("ext.pypto.decode_layer") == "external"
     assert span_family("something_else.foo") == "unknown"
-
-
-def test_retired_span_names_still_classify_so_archived_logs_stay_readable():
-    """An archived log predates the rename; its spans must still land in a family.
-
-    The retired-spelling map exists for exactly this, so it needs a test that
-    fails if someone removes it. Note the *chip* retired names survive
-    `legacy_spans()` while the retired *host* name is excluded, matching how the
-    current names behave.
-    """
-    retired = list(
-        parse_spans(
-            [
-                _span_record(pid=61, tid=610, inv=3, name="simpler_run", ts=1_000, dur=500),
-                _span_record(pid=61, tid=610, inv=3, name="simpler_run.bind", ts=1_100, dur=50, depth=1),
-                _span_record(pid=61, tid=610, inv=4, name="simpler_prewarm.build", ts=1_200, dur=75),
-                _span_record(
-                    pid=61,
-                    tid=611,
-                    inv=9,
-                    name="l3.dispatch",
-                    ts=900,
-                    dur=20,
-                    attrs="run_id=9 task_slot=4 group_index=0 worker_id=0 dispatch_id=1",
-                ),
-            ]
-        )
-    )
-
-    assert [span_family(span.name) for span in retired] == ["chip", "chip", "chip", "host"]
-    assert [span.name for span in legacy_spans(retired)] == [
-        "simpler_run",
-        "simpler_run.bind",
-        "simpler_prewarm.build",
-    ]
-    # `host_span_leaf` reads the decision point out of either spelling, which is
-    # what keeps the swimlane's flow pairing working on an old log.
-    assert host_span_leaf("l3.dispatch") == "dispatch"
+    # The leaf is what the swimlane's flow pairing matches on, so it resolves for
+    # every host level word and for nothing else.
+    assert host_span_leaf("host.dispatch") == "dispatch"
     assert host_span_leaf("network1.submit") == "submit"
     assert host_span_leaf("chip.run") is None
+
+
+def test_every_level_word_the_ladder_names_is_a_word_this_parser_knows():
+    """`WorkerLevel` is the source of truth; the parser carries a second copy.
+
+    The parser cannot import the runtime package, so the two lists are written
+    twice and only a test can hold them together. Nothing else would: a level
+    added to the ladder makes the runtime emit a word the parser does not know,
+    `span_family` answers ``unknown``, and — because unknown is deliberately
+    kept rather than dropped — those per-task spans enter invocation grouping
+    under a forged ``(pid, 0)`` key. No error anywhere, just wrong tables.
+    """
+    ladder = {level.name for level in WorkerLevel}
+    parser = set(_HOST_WORDS) | {_CHIP_WORD, _CORE_WORD}
+
+    assert ladder == parser, (
+        f"the ladder and this parser disagree: ladder-only={sorted(ladder - parser)}, "
+        f"parser-only={sorted(parser - ladder)}"
+    )
+    # Each word also has to reach the family the ladder position implies, not
+    # merely be present in some list.
+    for level in WorkerLevel:
+        expected = "host" if level.value >= WorkerLevel.host.value else level.name
+        assert span_family(f"{level.name}.something") == expected
+        # A level word is never mistaken for the external namespace.
+        assert external_producer(f"{level.name}.something") is None
 
 
 def test_invocation_by_name_uses_earliest_timestamp_not_input_order():
@@ -722,7 +748,7 @@ def test_claim_release_span_stays_inside_the_invocation_tree():
     """
     lines = _run_records(run_epoch=1, prepare=(50, 20), device=(100, 100), release=200)
 
-    invocation = group_invocations(legacy_spans(list(parse_spans(lines))))[0]
+    invocation = group_invocations(invocation_spans(list(parse_spans(lines))))[0]
 
     assert invocation.root().name == "chip.run"
     assert invocation.by_name()["chip.run.claim_release"].depth == 1
@@ -868,3 +894,183 @@ def test_host_record_spans_drop_passes_with_no_matching_bind(tmp_path):
     assert out == []
     assert orphaned == 1
     assert covered == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# The `ext.` reserved namespace — the contract an external producer codes to.
+#
+# Every level word belongs to simpler, so a producer outside this repo emits
+# under `ext.<producer>.<span>`. The tests below are the executable form of that
+# contract: what a well-formed name looks like, which views the spans reach, and
+# what a producer provably cannot do to our views. A repository adapting to it
+# (pypto, pypto-serving, a user script) can read these as the specification and
+# mirror the assertions against its own emitter.
+# ---------------------------------------------------------------------------
+
+
+def test_ext_name_attributes_a_producer_and_refuses_a_malformed_one():
+    """``ext.<producer>.<span>`` — all three segments are required for attribution.
+
+    Family and attribution answer different questions. A name under ``ext.`` is
+    never ours whatever follows it, so a malformed one still classifies as
+    external; it simply lands in an unattributed lane rather than another
+    producer's.
+    """
+    assert external_producer("ext.pypto.decode_layer") == "pypto"
+    assert external_producer("ext.pypto.attention.qk") == "pypto"
+
+    for malformed in ("ext.pypto", "ext.", "ext..decode_layer"):
+        assert span_family(malformed) == "external"
+        assert external_producer(malformed) is None
+
+    # Not external at all, so no producer.
+    assert external_producer("host.dispatch") is None
+    assert external_producer("chip.run") is None
+
+
+def test_ext_name_cannot_impersonate_one_of_our_level_words():
+    """The reason the namespace exists: a caller's ``host.foo`` must not parse as ours.
+
+    Every level word is reachable as a producer segment, and none of them
+    promotes the span into our family.
+    """
+    for word in ("core", "chip", "host", "network1", "network2", "network3"):
+        assert span_family(f"ext.{word}.foo") == "external"
+        assert external_producer(f"ext.{word}.foo") == word
+        assert host_span_leaf(f"ext.{word}.foo") is None
+
+
+def test_ext_spans_stay_out_of_the_invocation_keyed_views():
+    """A producer has no ``inv``, so admitting its spans would forge one lane for all of them.
+
+    ``inv`` is our correlation key (a native run epoch) and the public surface
+    does not expose it, so every external record carries 0. Grouping on
+    ``(pid, inv)`` would collapse unrelated producer spans into a single
+    invocation and contaminate the rounds and TPOT tables computed from it.
+    """
+    lines = [
+        _span_record(pid=41, tid=410, inv=7, name="chip.run", ts=100, dur=500, attrs="run_id=7 slot_id=0"),
+        _span_record(pid=41, tid=410, inv=0, name="ext.pypto.decode_layer", ts=120, dur=80),
+        _span_record(pid=41, tid=410, inv=0, name="ext.pypto.attention", ts=140, dur=20),
+    ]
+    spans = list(parse_spans(lines))
+
+    assert [span.name for span in invocation_spans(spans)] == ["chip.run"]
+    invocations = group_invocations(invocation_spans(spans))
+    assert [(inv.pid, inv.inv) for inv in invocations] == [(41, 7)]
+
+    trace = to_chrome_trace(invocations, bucket_by_hid(invocations))
+    assert "ext.pypto.decode_layer" not in {event.get("name") for event in trace["traceEvents"]}
+
+
+def test_ext_spans_appear_on_the_swimlane_attributed_to_their_producer():
+    """The swimlane is where an external span is visible, and the only such view.
+
+    A process that emitted nothing but external spans is not ours, so its label
+    carries no ``simpler`` prefix.
+    """
+    lines = [
+        _span_record(pid=90, tid=900, inv=0, name="ext.pypto.decode_layer", ts=100, dur=80),
+        _span_record(pid=90, tid=900, inv=0, name="ext.pypto.attention", ts=110, dur=20),
+    ]
+
+    trace = to_host_swimlane(list(parse_spans(lines)))
+
+    assert {event["name"] for event in trace["traceEvents"] if event["ph"] == "X"} == {
+        "ext.pypto.decode_layer",
+        "ext.pypto.attention",
+    }
+    assert _metadata(trace, "process_name") == ["external producer pypto (pid=90)"]
+    assert _metadata(trace, "thread_name") == ["ext pypto"]
+
+
+def test_a_shared_process_stays_ours_when_a_producer_emits_into_it():
+    """The common case: a producer calls the public API from inside our host process.
+
+    Sharing therefore says nothing about whose process it is, so any span of ours
+    keeps the process labelled as ours.
+    """
+    lines = [
+        _span_record(pid=41, tid=410, inv=7, name="host.graph_build", ts=100, dur=200, attrs="run_id=7 role=facade"),
+        _span_record(pid=41, tid=411, inv=0, name="ext.pypto.decode_layer", ts=120, dur=60),
+    ]
+
+    trace = to_host_swimlane(list(parse_spans(lines)))
+
+    assert _metadata(trace, "process_name") == ["simpler host (pid=41)"]
+    assert _lanes(trace) == {410: "orchestrator / facade", 411: "ext pypto"}
+
+
+def test_ext_attributes_cannot_take_over_one_of_our_lane_names():
+    """``role`` is an ordinary attribute key, so a producer may use it for its own meaning.
+
+    Lane naming infers our roles, so it must read only our spans — otherwise a
+    producer writing ``role=facade`` renames its lane to one of ours.
+    """
+    lines = [
+        _span_record(pid=90, tid=900, inv=0, name="ext.pypto.decode_layer", ts=100, dur=80, attrs="role=facade"),
+        _span_record(pid=90, tid=901, inv=0, name="ext.pypto.step", ts=100, dur=80, attrs="role=scheduler worker_id=3"),
+    ]
+
+    trace = to_host_swimlane(list(parse_spans(lines)))
+
+    assert _lanes(trace) == {900: "ext pypto", 901: "ext pypto"}
+
+
+def test_ext_spans_cannot_reshape_our_lanes_or_our_dispatch_flow():
+    """A pipeline slot is ours, and ``slot_id`` / ``depth`` / ``run_id`` are plain fields.
+
+    An interleaved thread splits into one lane per slot. A producer emitting on
+    that same thread must not decide whether the split happens, into how many
+    lanes, or which spans a dispatch flow arrow connects.
+    """
+    lines = _run_records(run_epoch=1, slot_id=0, prepare=(50, 20), device=(100, 100), release=200)
+    lines += _run_records(run_epoch=2, slot_id=1, prepare=(150, 30), device=(240, 100), release=340)
+    lines += _run_records(run_epoch=3, slot_id=0, prepare=(300, 30), device=(380, 100), release=480)
+    baseline = to_host_swimlane(list(parse_spans(lines)))
+
+    # The same log, plus a producer on that thread claiming a slot of its own, a
+    # root-looking depth, and the run/slot pair the flow pairing keys on.
+    lines += [
+        _span_record(
+            pid=7,
+            tid=7,
+            inv=0,
+            name="ext.pypto.decode_layer",
+            ts=60,
+            dur=400,
+            attrs="run_id=0 task_slot=12 slot_id=99 role=facade",
+        )
+    ]
+    mixed = to_host_swimlane(list(parse_spans(lines)))
+
+    def flows(trace):
+        return [event for event in trace["traceEvents"] if event["ph"] in ("s", "f")]
+
+    assert _metadata(baseline, "thread_name") == ["pipeline slot 0 (tid 7)", "pipeline slot 1 (tid 7)"]
+    assert _metadata(mixed, "thread_name") == ["ext pypto", *_metadata(baseline, "thread_name")]
+    assert flows(mixed) == flows(baseline)
+    # The producer's span is still on the timeline, on the thread's real tid.
+    external = next(event for event in mixed["traceEvents"] if event.get("name") == "ext.pypto.decode_layer")
+    assert external["tid"] == 7
+
+
+def test_ext_spans_reach_the_swimlane_but_not_the_tables_through_the_cli(tmp_path, capsys):
+    """End to end: one log carrying both, through the same CLI a downstream repo runs."""
+    log_path = tmp_path / "run.log"
+    swimlane_path = tmp_path / "host_swimlane.json"
+    trace_path = tmp_path / "strace.json"
+    log_path.write_text(
+        _span_record(pid=41, tid=410, inv=7, name="chip.run", ts=100, dur=500, attrs="run_id=7 slot_id=0")
+        + _span_record(pid=41, tid=411, inv=0, name="ext.pypto.decode_layer", ts=120, dur=80),
+        encoding="utf-8",
+    )
+
+    assert main([str(log_path), "--swimlane", str(swimlane_path), "--trace-out", str(trace_path)]) == 0
+    capsys.readouterr()
+
+    swimlane = json.loads(swimlane_path.read_text(encoding="utf-8"))
+    trace = json.loads(trace_path.read_text(encoding="utf-8"))
+
+    assert "ext.pypto.decode_layer" in {event.get("name") for event in swimlane["traceEvents"]}
+    assert "ext.pypto.decode_layer" not in {event.get("name") for event in trace["traceEvents"]}


### PR DESCRIPTION
## Summary

#1793 C2b reserved `ext.<producer>.<span>` so a caller outside simpler cannot land a span in one of our level words. #1877 added the guard that makes the classification hold. What it did not do is make the **rest of the parser** stop treating an external span as a source of truth about *our* structure — and nothing stated what a producer may expect in return.

Three places read a producer's record and answered questions about us with it:

| Where | What a producer could do |
| --- | --- |
| swimlane process label | a process emitting only `ext.*` spans was announced as `simpler chip child` |
| lane naming (`_host_thread_name`) | `role` is an ordinary attribute key; `role=facade` renamed the producer's lane to `orchestrator / facade` |
| lane splitting (`_assign_lanes`) | a pipeline slot is ours, so `slot_id` + `depth` on an external span decided whether one of **our** threads split into per-slot lanes, and into how many |

The invariant behind all three is one sentence: **our views infer our structure only from our own spans.** Role inference and lane splitting now filter the family out; the process label gains a third arm that carries no `simpler` prefix, because such a process is not ours. Dispatch-flow pairing needed no change — it keys on `host_span_leaf`, which is `None` for anything not ours — and a test now holds that.

`external_producer()` names the second segment and requires all three: a malformed `ext.foo` is still *external* (it can never be mistaken for ours) but attributes to nobody. A producer segment may itself be one of our level words — `ext.host.foo` is a producer called `host` and stays external, which is the case the namespace was reserved for.

## The contract is the deliverable, so it is executable

`tests/ut/py/test_strace_timing.py` gains **8 tests** under an `ext.` heading, one per row of the table now in `docs/dfx/host-trace.md`:

- name shape and malformed-name attribution
- the impersonation attempt (every level word as a producer segment)
- exclusion from the invocation-keyed views, **and why**: `inv` is our native run epoch and no public surface exposes it, so admitting external spans forges one invocation holding all of them
- presence on the swimlane, attributed to the producer — the only view that renders them
- the shared-process case (a producer calling from inside our host process leaves the process ours)
- the three takeover attempts above

**Another repository adapting to this namespace can read those tests as the specification and mirror them against its own emitter.** That is the point of the shape they are written in.

## `legacy_spans` -> `invocation_spans`

The name never described what it does. #1730 introduced it as *"spans belonging to the established `simpler_run` views"* — so **legacy** qualified the *views*, the ones that predated the swimlane, while the name reads as though the spans were obsolete. Its body has since stopped resembling that intent altogether: it was `not name.startswith("l3.")` and is now a family exclusion, so the word matches nothing in it.

⚠️ **Known consequence, taken deliberately.** pypto probes this name with `hasattr(_strace_timing, "legacy_spans")` and falls back to a `startswith("l3.")` filter when it is absent. That filter is inert for logs from this tree, so a pypto that has not adopted the new name will admit host-family spans into its per-launch grouping and its numbers will be wrong **without an error**. Recorded here so the answer is findable from the symptom. Nothing in this repository reads the old name.

## Reading archived logs is dropped

Two facilities existed only so a log this tree can no longer produce stays parseable. The tool is held to one standard instead — the current code is clean and self-consistent:

- `_HOST_LOG_TIME` accepted the wall-clock record prefix #1824 replaced.
- `_RETIRED_WORDS` mapped `simpler_run` / `simpler_prewarm` / `l3` onto the families they used to name. Its own comment tied the two together — *"the same reason `_STRACE_RE` still accepts the wall-clock record prefix"* — so keeping one and dropping the other would have left the tool inconsistent with itself.

Both are gone, with the test that guarded the retired spellings and the helper that built the retired prefix.

**What that costs, measured rather than assumed, is asymmetric.** A retired *chip* name now answers `unknown`, which `invocation_spans` keeps, so it groups exactly as before. A retired *host* name also answers `unknown` — and `unknown` is kept — so on a log predating #1877 the `l3.*` scheduler spans now **enter** invocation grouping instead of being excluded from it, which is the pollution the family split exists to prevent. That is the concrete meaning of no longer reading archived logs.

Removing the wall-clock arm exposed one invariant worth a test, and it is not about old logs. A record's attribute list runs to the end of its line, so what bounds it is the lookahead for the *next* record's prefix — and two complete records do share one physical line, because ranks forked by an L3 share the capture fd (which is why pypto's reader re-splits on `[STRACE]` first). With that lookahead gone the earlier record's `attrs` absorbs the later one's whole prefix rather than failing to match:

```
rank=0[mono_ns=1000002][T0x2][TIMING] emit_host_span:
```

No error, just a wrong value, and nothing covered it. A test now does, against the current prefix.

## The level ladder was written three times and pinned nowhere

Dropping the retired map put weight on what `span_family` does with a word it does not know, which turned up a defect of my own from #1877. `_HOST_WORDS` carried the comment *"this parser cannot import the runtime package, so it carries the list and the unit tests pin the two together"* — and **no test referenced `WorkerLevel` at all**. The level words lived in three independent hand-written copies:

| Copy | Where |
| --- | --- |
| the ladder (source of truth) | `python/simpler/worker_level.py::WorkerLevel` |
| the parser's tuple | `strace_timing.py::_HOST_WORDS` |
| a literal loop in the test that was supposed to be the pin | `for word in ("host", "network1", …)` |

So adding a level to the ladder would make the runtime emit a word the parser does not know, `span_family` would answer `unknown`, and — because unknown is deliberately *kept* rather than dropped, so an unfamiliar family is never silently lost — those per-task spans would enter invocation grouping under a forged `(pid, 0)` key. **Wrong tables, no error, and none of the three copies would have complained.** That is the real source of an unrecognized span name; a typo is the unlikely one.

`test_every_level_word_the_ladder_names_is_a_word_this_parser_knows` now compares the two as sets and checks each word reaches the family its ladder position implies. The parser cannot import the runtime package, but the test can — which is what makes the pin possible at all. Adding `network4 = 7` to the ladder alone now fails it with

```
AssertionError: the ladder and this parser disagree: ladder-only=['network4'], parser-only=[]
```

and fails the level-word test too, since its loop walks `WorkerLevel` instead of a fourth copy. The comment that claimed a pin now names the test that is one.

## Testing

- [x] `pytest tests/ut/py` — **1624 passed, 0 failed** (44 in the strace file). Two earlier full runs on this tree failed on `test_second_child_failure_reaps_first` and later ones did not — the forked-child reaping flake recorded locally on 2026-08-16. It passes 4/4 in isolation and this change touches no file under `tests/ut/py/test_worker/` nor anything in worker startup.
- [x] **Negative control per behaviour** — reverting the process label, the role-inference filter, the lane-structure filter, the producer well-formedness check, the record-bounding prefix lookahead, or the ladder-to-parser pin each turns exactly the corresponding test red and nothing else.
- [x] **End to end through the real emitter**, not a hand-built string: `_emit_host_span` writes `chip.run` and `ext.pypto.decode_layer` on one thread via `HostLogger::log_host_span`; the CLI puts the external span on the swimlane, keeps it out of `--trace-out` and the TPOT table, and ignores its `role=facade slot_id=99`.
- [x] `ctest -LE requires_hardware` — 101/101 (no C++ in this change)
- [x] ruff, ruff format, pyright, markdownlint clean

## Also

`simpler_setup/tools/README.md` described `--swimlane` as consuming `l3.*` markers — a spelling #1877 retired. It is in the paragraph this change rewrites, and the grep that found the rest of that rename returns it among a dozen legitimate `l3` variable names (`l3.register`, `examples.workers.l3.`), which is how it survived. Other `legacy` mentions in the tree name genuinely old capture formats and ABI fields and are left alone.

Closes the C2b item of #1793. Unblocks part of #1794, which names `trace.enabled()` and this namespace as its prerequisites.
