### PR TITLE
host_build_graph: report ready-queue occupancy high-water at teardown

### DIFF
--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -357,11 +357,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // Destroy the host_build_graph runtime. sm_handle / rt are recreated
         // every run, so always tear them down here.
         if (rt != nullptr) {
+            rt->scheduler.print_queues();
             // Clear g_current_runtime in this DSO before destroying rt.
             framework_bind_runtime(nullptr);
-            // Graph execution blocks are host-owned GM retained by the
-            // DeviceRunner. This run only drops its submission references;
-            // the blocks remain reusable until Worker finalization.
+            // A Graph's expansion storage is the tail of its outer task's heap
+            // allocation, so it retires with that allocation; nothing here owns
+            // a separate block to release.
             runtime_destroy(rt, runtime_arena_);
             rt = nullptr;
         }

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.cpp
@@ -89,14 +89,36 @@ void PTO2SchedulerState::print_stats() {
 
 void PTO2SchedulerState::print_queues() {
     PTO2SchedulerState *sched = this;
-    LOG_DEBUG("=== Ready Queues ===");
-
     const char *shape_names[] = {"AIC", "AIV", "MIX"};
-
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        LOG_DEBUG("  %s: count=%" PRIu64, shape_names[i], sched->ready_queues[i].size());
+        LOG_TIMING(
+            "QPROBE rq[%s] pushes=%llu maxocc=%llu cap=%llu", shape_names[i],
+            (unsigned long long)sched->ready_queues[i].enqueue_pos.load(std::memory_order_relaxed),
+            (unsigned long long)sched->ready_queues[i].max_occupancy.load(std::memory_order_relaxed),
+            (unsigned long long)sched->ready_queues[i].capacity
+        );
+        LOG_TIMING(
+            "QPROBE rsq[%s] pushes=%llu maxocc=%llu", shape_names[i],
+            (unsigned long long)sched->ready_sync_queues[i].enqueue_pos.load(std::memory_order_relaxed),
+            (unsigned long long)sched->ready_sync_queues[i].max_occupancy.load(std::memory_order_relaxed)
+        );
+        LOG_TIMING(
+            "QPROBE edq[%s] pushes=%llu maxocc=%llu cap=%llu", shape_names[i],
+            (unsigned long long)sched->early_dispatch_queues[i].enqueue_pos.load(std::memory_order_relaxed),
+            (unsigned long long)sched->early_dispatch_queues[i].max_occupancy.load(std::memory_order_relaxed),
+            (unsigned long long)sched->early_dispatch_queues[i].capacity
+        );
     }
-    LOG_DEBUG("  DUMMY: count=%" PRIu64, sched->dummy_ready_queue.size());
-
-    LOG_DEBUG("====================");
+    LOG_TIMING(
+        "QPROBE dummy pushes=%llu maxocc=%llu | graph_rq pushes=%llu maxocc=%llu | graph_pq pushes=%llu maxocc=%llu | "
+        "ess pushes=%llu maxocc=%llu",
+        (unsigned long long)sched->dummy_ready_queue.enqueue_pos.load(std::memory_order_relaxed),
+        (unsigned long long)sched->dummy_ready_queue.max_occupancy.load(std::memory_order_relaxed),
+        (unsigned long long)sched->graph_ready_queue.enqueue_pos.load(std::memory_order_relaxed),
+        (unsigned long long)sched->graph_ready_queue.max_occupancy.load(std::memory_order_relaxed),
+        (unsigned long long)sched->graph_prepare_queue.enqueue_pos.load(std::memory_order_relaxed),
+        (unsigned long long)sched->graph_prepare_queue.max_occupancy.load(std::memory_order_relaxed),
+        (unsigned long long)sched->early_sync_start_queue.enqueue_pos.load(std::memory_order_relaxed),
+        (unsigned long long)sched->early_sync_start_queue.max_occupancy.load(std::memory_order_relaxed)
+    );
 }

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -86,12 +86,26 @@ struct alignas(64) PTO2ReadyQueue {
     char _pad1[64 - sizeof(std::atomic<uint64_t>)];  // Own cache line
 
     std::atomic<uint64_t> dequeue_pos;
-    char _pad2[64 - sizeof(std::atomic<uint64_t>)];  // Own cache line
+    // Occupancy high-water, for teardown reporting only. Atomic because pushes
+    // are concurrent; relaxed throughout, so it is ordered against nothing.
+    std::atomic<uint64_t> max_occupancy;
+    char _pad2[64 - 2 * sizeof(std::atomic<uint64_t>)];  // Own cache line
 
     uint64_t size() {
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         return (e >= d) ? (e - d) : 0;
+    }
+
+    // Raise the high-water to the occupancy left by a push that published up to
+    // `published_pos`. Off the fast path it is a load and a compare; the CAS runs
+    // only on a new maximum, so a contended push never pays for it.
+    void note_occupancy(uint64_t published_pos) {
+        const uint64_t occ = published_pos - dequeue_pos.load(std::memory_order_relaxed);
+        uint64_t observed = max_occupancy.load(std::memory_order_relaxed);
+        while (occ > observed && !max_occupancy.compare_exchange_weak(
+                                     observed, occ, std::memory_order_relaxed, std::memory_order_relaxed
+                                 )) {}
     }
 
     bool push(PTO2TaskSlotState *slot_state) { return push_tagged(slot_state, 0); }
@@ -118,6 +132,7 @@ struct alignas(64) PTO2ReadyQueue {
         slot->slot_state = slot_state;
         slot->task_id_snapshot = task_id_snapshot;
         slot->sequence.store(static_cast<int64_t>(pos + 1), std::memory_order_release);
+        note_occupancy(pos + 1);
         return true;
     }
 
@@ -165,6 +180,7 @@ struct alignas(64) PTO2ReadyQueue {
             slot->task_id_snapshot = task_id_snapshots == nullptr ? 0 : task_id_snapshots[i];
             slot->sequence.store(static_cast<int64_t>(pos + i + 1), std::memory_order_release);
         }
+        note_occupancy(pos + static_cast<uint64_t>(count));
         return true;
     }
 

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -63,6 +63,7 @@ bool ready_queue_init_data_from_layout(PTO2ReadyQueue *queue, DeviceArena &arena
     queue->mask = capacity - 1;
     queue->enqueue_pos.store(0, std::memory_order_relaxed);
     queue->dequeue_pos.store(0, std::memory_order_relaxed);
+    queue->max_occupancy.store(0, std::memory_order_relaxed);
 
     for (uint64_t i = 0; i < capacity; i++) {
         slots_arena[i].sequence.store((int64_t)i, std::memory_order_relaxed);

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -364,8 +364,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // Destroy the host_build_graph runtime. sm_handle / rt are recreated
         // every run, so always tear them down here.
         if (rt != nullptr) {
+            rt->scheduler.print_queues();
             // Clear g_current_runtime in this DSO before destroying rt.
             framework_bind_runtime(nullptr);
+            // A Graph's expansion storage is the tail of its outer task's heap
+            // allocation, so it retires with that allocation; nothing here owns
+            // a separate block to release.
             runtime_destroy(rt, runtime_arena_);
             rt = nullptr;
         }

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.cpp
@@ -89,14 +89,36 @@ void PTO2SchedulerState::print_stats() {
 
 void PTO2SchedulerState::print_queues() {
     PTO2SchedulerState *sched = this;
-    LOG_DEBUG("=== Ready Queues ===");
-
     const char *shape_names[] = {"AIC", "AIV", "MIX"};
-
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        LOG_DEBUG("  %s: count=%" PRIu64, shape_names[i], sched->ready_queues[i].size());
+        LOG_TIMING(
+            "QPROBE rq[%s] pushes=%llu maxocc=%llu cap=%llu", shape_names[i],
+            (unsigned long long)sched->ready_queues[i].enqueue_pos.load(std::memory_order_relaxed),
+            (unsigned long long)sched->ready_queues[i].max_occupancy.load(std::memory_order_relaxed),
+            (unsigned long long)sched->ready_queues[i].capacity
+        );
+        LOG_TIMING(
+            "QPROBE rsq[%s] pushes=%llu maxocc=%llu", shape_names[i],
+            (unsigned long long)sched->ready_sync_queues[i].enqueue_pos.load(std::memory_order_relaxed),
+            (unsigned long long)sched->ready_sync_queues[i].max_occupancy.load(std::memory_order_relaxed)
+        );
+        LOG_TIMING(
+            "QPROBE edq[%s] pushes=%llu maxocc=%llu cap=%llu", shape_names[i],
+            (unsigned long long)sched->early_dispatch_queues[i].enqueue_pos.load(std::memory_order_relaxed),
+            (unsigned long long)sched->early_dispatch_queues[i].max_occupancy.load(std::memory_order_relaxed),
+            (unsigned long long)sched->early_dispatch_queues[i].capacity
+        );
     }
-    LOG_DEBUG("  DUMMY: count=%" PRIu64, sched->dummy_ready_queue.size());
-
-    LOG_DEBUG("====================");
+    LOG_TIMING(
+        "QPROBE dummy pushes=%llu maxocc=%llu | graph_rq pushes=%llu maxocc=%llu | graph_pq pushes=%llu maxocc=%llu | "
+        "ess pushes=%llu maxocc=%llu",
+        (unsigned long long)sched->dummy_ready_queue.enqueue_pos.load(std::memory_order_relaxed),
+        (unsigned long long)sched->dummy_ready_queue.max_occupancy.load(std::memory_order_relaxed),
+        (unsigned long long)sched->graph_ready_queue.enqueue_pos.load(std::memory_order_relaxed),
+        (unsigned long long)sched->graph_ready_queue.max_occupancy.load(std::memory_order_relaxed),
+        (unsigned long long)sched->graph_prepare_queue.enqueue_pos.load(std::memory_order_relaxed),
+        (unsigned long long)sched->graph_prepare_queue.max_occupancy.load(std::memory_order_relaxed),
+        (unsigned long long)sched->early_sync_start_queue.enqueue_pos.load(std::memory_order_relaxed),
+        (unsigned long long)sched->early_sync_start_queue.max_occupancy.load(std::memory_order_relaxed)
+    );
 }

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -86,12 +86,26 @@ struct alignas(64) PTO2ReadyQueue {
     char _pad1[64 - sizeof(std::atomic<uint64_t>)];  // Own cache line
 
     std::atomic<uint64_t> dequeue_pos;
-    char _pad2[64 - sizeof(std::atomic<uint64_t>)];  // Own cache line
+    // Occupancy high-water, for teardown reporting only. Atomic because pushes
+    // are concurrent; relaxed throughout, so it is ordered against nothing.
+    std::atomic<uint64_t> max_occupancy;
+    char _pad2[64 - 2 * sizeof(std::atomic<uint64_t>)];  // Own cache line
 
     uint64_t size() {
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         return (e >= d) ? (e - d) : 0;
+    }
+
+    // Raise the high-water to the occupancy left by a push that published up to
+    // `published_pos`. Off the fast path it is a load and a compare; the CAS runs
+    // only on a new maximum, so a contended push never pays for it.
+    void note_occupancy(uint64_t published_pos) {
+        const uint64_t occ = published_pos - dequeue_pos.load(std::memory_order_relaxed);
+        uint64_t observed = max_occupancy.load(std::memory_order_relaxed);
+        while (occ > observed && !max_occupancy.compare_exchange_weak(
+                                     observed, occ, std::memory_order_relaxed, std::memory_order_relaxed
+                                 )) {}
     }
 
     bool push(PTO2TaskSlotState *slot_state) { return push_tagged(slot_state, 0); }
@@ -118,6 +132,7 @@ struct alignas(64) PTO2ReadyQueue {
         slot->slot_state = slot_state;
         slot->task_id_snapshot = task_id_snapshot;
         slot->sequence.store(static_cast<int64_t>(pos + 1), std::memory_order_release);
+        note_occupancy(pos + 1);
         return true;
     }
 
@@ -165,6 +180,7 @@ struct alignas(64) PTO2ReadyQueue {
             slot->task_id_snapshot = task_id_snapshots == nullptr ? 0 : task_id_snapshots[i];
             slot->sequence.store(static_cast<int64_t>(pos + i + 1), std::memory_order_release);
         }
+        note_occupancy(pos + static_cast<uint64_t>(count));
         return true;
     }
 

--- a/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -63,6 +63,7 @@ bool ready_queue_init_data_from_layout(PTO2ReadyQueue *queue, DeviceArena &arena
     queue->mask = capacity - 1;
     queue->enqueue_pos.store(0, std::memory_order_relaxed);
     queue->dequeue_pos.store(0, std::memory_order_relaxed);
+    queue->max_occupancy.store(0, std::memory_order_relaxed);
 
     for (uint64_t i = 0; i < capacity; i++) {
         slots_arena[i].sequence.store((int64_t)i, std::memory_order_relaxed);


### PR DESCRIPTION
## Summary

`PTO2_READY_QUEUE_SIZE` is 8192 and nine queues are sized by it, so the runtime
arena carries 1,775,616 bytes of Vyukov slot array — 79.2% of the 2,241,984 bytes
bind uploads. The upload is bandwidth-bound (measured 3.85 GB/s), so those bytes
are ~0.46 ms of every bind. Whether they can go depends on what occupancy the
queues actually reach, and nothing recorded it: `print_queues()` reported
instantaneous `size()` at `LOG_DEBUG` and had no caller.

Each queue now keeps `max_occupancy`, updated on push, and `print_queues()`
reports per-queue total pushes, occupancy high-water and capacity at
`LOG_TIMING`. The AICPU calls it from the completion gate's finalize, which runs
once per run on the teardown path.

**Cost and correctness of the counter:**

- Off the fast path it is one relaxed load and a compare, on a cache line the
  push already dirtied. No logging on any hot path.
- The queue is MPMC, so the counter is a `std::atomic` raised by a relaxed
  compare-exchange loop in `note_occupancy()`. A plain read-modify-write from
  concurrent producers is a data race; the CAS runs only when a push sets a new
  maximum, so a contended push never pays for it.
- `ready_queue_init_data_from_layout()` zeroes it alongside the positions it
  already initializes — arena bytes are not guaranteed zero and the first push
  reads the counter before writing it.
- `std::atomic<uint64_t>` occupies the same 8 bytes a plain field would, inside
  the padding that already isolated `dequeue_pos`, so `PTO2ReadyQueue` keeps its
  cache-line layout and the arena layout is unchanged.

## What the numbers say

qwen3-14b decode (40 layers × 277 nodes, batch 16 / seq 3500) reports:

```text
  queue        pushes   high-water   capacity
  rq[AIC]      11,646          107       8192
  rq[AIV]       1,164            6       8192
  rq[MIX]           0            0       8192
  rsq[MIX]         40            1       8192
  rsq[AIC/AIV]      0            0       8192
  dummy           481            8       8192
  graph_rq         40            1       8192
  graph_pq      2,800           40       8192
  edq[*], ess       0            0         64
```

Peak occupancy across every 8192-slot queue is 107, so 98.7% of the ramp is never
read.

**Capacity cannot simply shrink**, because a failed push latches
`READY_QUEUE_OVERFLOW` rather than retrying: capacity is a correctness bound. The
provable bound per queue is the population that can route to it, and for
`rq[AIC]` that is one node per graph node — about 11,080 — whose next power of two
is 16384, *larger* than today's 8192. So the current constant is not worst-case
safe either; it rests on the same empirical headroom these numbers now quantify,
and shrinking it requires making a full queue recoverable first.

## Also

Drops a stale claim next to the finalize call: Graph expansion storage is no
longer a DeviceRunner-retained block, it is the tail of the outer task's heap
allocation and retires with it. The a5 tree carried no such claim, so it gains the
corrected wording rather than keeping a teardown block the a2a3 copy explains and
it does not.

## Testing

- [x] C++ unit tests: 101/101 pass (`ctest --test-dir tests/ut/cpp/build -LE requires_hardware`)
- [x] `clang-format` clean on all seven changed C++ files
- [x] a2a3 and a5 edits verified identical (diff of the two per-tree diffs)
- [ ] Simulation tests pass (CI)
- [ ] Hardware tests pass (CI)

Builds on #1885.
