### PR TITLE
host_build_graph: place the big scheduler queues at the arena's tail

### DIFF
--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -1074,15 +1074,12 @@ extern "C" int bind_callable_to_runtime_impl(
 
     // Skip uploading the orchestrator block (fanin_seen_epoch / scope / tensormap,
     // ~8.5 MB): it is host-only dep-computation scratch that the AICPU scheduler
-    // never reads. Ship [0, orch_start) (sm_handle) and [orch_end, arena_size)
-    // (ready queues + runtime header + mailbox) whole; the orch block between them
-    // is not sent. orch_start/orch_end are the first orch and first scheduler
-    // reservations (runtime_reserve_layout order: sm_handle -> orch -> sched); the
-    // ready queues ship in full because graph execution expands a GRAPH task into
-    // on-device nodes that push past the host task count.
-    const auto &sq = layout.sched;
+    // never reads. Ship [0, orch_start) (sm_handle) and
+    // [orch_end, arena_size) (runtime header + mailbox + every scheduler queue)
+    // whole; the orch block between them is not sent. The boundary is the
+    // layout's own, not inferred from a reservation order here.
     const size_t orch_start = layout.orch.off_fanin_seen_epoch;
-    const size_t orch_end = sq.off_ready_queue_slots[0];
+    const size_t orch_end = layout.off_uploaded_tail_begin;
     always_assert(orch_start <= orch_end);
     char *arena_host = static_cast<char *>(host_arena.base());
     char *arena_dev = static_cast<char *>(runtime_arena_dev);

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -117,6 +117,9 @@ struct PTO2RuntimeArenaLayout {
     PTO2SchedulerLayout sched;
     size_t off_runtime{0};
     size_t off_mailbox{0};
+    // First offset past the skipped orchestrator block: the start of the single
+    // contiguous range bind uploads after [0, orch.off_fanin_seen_epoch).
+    size_t off_uploaded_tail_begin{0};
 
     // Cached parameters (re-used by init_data + wire stages).
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]{};

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -106,6 +106,13 @@ PTO2SchedulerLayout PTO2SchedulerState::reserve_layout(DeviceArena &arena) {
     PTO2SchedulerLayout layout{};
     layout.ready_queue_capacity = PTO2_READY_QUEUE_SIZE;
 
+    // Fixed-capacity early-dispatch queues first, then the PTO2_READY_QUEUE_SIZE
+    // ones. The big nine are the arena's last reservations so that the bytes bind
+    // uploads stay one contiguous range no matter how much of them is in use.
+    for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+        layout.off_early_dispatch_queue_slots[i] = ready_queue_reserve_layout(arena, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
+    }
+    layout.off_early_sync_start_queue_slots = ready_queue_reserve_layout(arena, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         layout.off_ready_queue_slots[i] = ready_queue_reserve_layout(arena, PTO2_READY_QUEUE_SIZE);
     }
@@ -115,10 +122,6 @@ PTO2SchedulerLayout PTO2SchedulerState::reserve_layout(DeviceArena &arena) {
     layout.off_dummy_ready_queue_slots = ready_queue_reserve_layout(arena, PTO2_READY_QUEUE_SIZE);
     layout.off_graph_ready_queue_slots = ready_queue_reserve_layout(arena, PTO2_READY_QUEUE_SIZE);
     layout.off_graph_prepare_queue_slots = ready_queue_reserve_layout(arena, PTO2_READY_QUEUE_SIZE);
-    for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        layout.off_early_dispatch_queue_slots[i] = ready_queue_reserve_layout(arena, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
-    }
-    layout.off_early_sync_start_queue_slots = ready_queue_reserve_layout(arena, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
     // Polling: no dep_pool arena region — producer dependencies are inline ids on
     // the payload and readiness is via completion_flags.
     return layout;
@@ -338,11 +341,16 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
         layout.heap_sizes[r] = heap_sizes[r];
     }
 
+    // Reservation order defines the two ranges bind uploads. The orchestrator
+    // block is host-only dep-computation scratch the AICPU never reads, so it is
+    // skipped; everything the device does read is placed after it, which is what
+    // makes [off_uploaded_tail_begin, ...) a single range.
     layout.off_sm_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
     layout.orch = PTO2OrchestratorState::reserve_layout(arena, static_cast<int32_t>(task_window_sizes[0]));
-    layout.sched = PTO2SchedulerState::reserve_layout(arena);
     layout.off_runtime = arena.reserve(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE);
+    layout.off_uploaded_tail_begin = layout.off_runtime;
     layout.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
+    layout.sched = PTO2SchedulerState::reserve_layout(arena);
 
     layout.arena_size = arena.total_size();
     return layout;

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -1136,15 +1136,12 @@ extern "C" int bind_callable_to_runtime_impl(
 
     // Skip uploading the orchestrator block (fanin_seen_epoch / scope / tensormap,
     // ~8.5 MB): it is host-only dep-computation scratch that the AICPU scheduler
-    // never reads. Ship [0, orch_start) (sm_handle) and [orch_end, arena_size)
-    // (ready queues + runtime header + mailbox) whole; the orch block between them
-    // is not sent. orch_start/orch_end are the first orch and first scheduler
-    // reservations (runtime_reserve_layout order: sm_handle -> orch -> sched); the
-    // ready queues ship in full because graph execution expands a GRAPH task into
-    // on-device nodes that push past the host task count.
-    const auto &sq = layout.sched;
+    // never reads. Ship [0, orch_start) (sm_handle) and
+    // [orch_end, arena_size) (runtime header + mailbox + every scheduler queue)
+    // whole; the orch block between them is not sent. The boundary is the
+    // layout's own, not inferred from a reservation order here.
     const size_t orch_start = layout.orch.off_fanin_seen_epoch;
-    const size_t orch_end = sq.off_ready_queue_slots[0];
+    const size_t orch_end = layout.off_uploaded_tail_begin;
     always_assert(orch_start <= orch_end);
     char *arena_host = static_cast<char *>(host_arena.base());
     char *arena_dev = static_cast<char *>(runtime_arena_dev);

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -118,6 +118,9 @@ struct PTO2RuntimeArenaLayout {
     PTO2SchedulerLayout sched;
     size_t off_runtime{0};
     size_t off_mailbox{0};
+    // First offset past the skipped orchestrator block: the start of the single
+    // contiguous range bind uploads after [0, orch.off_fanin_seen_epoch).
+    size_t off_uploaded_tail_begin{0};
 
     // Cached parameters (re-used by init_data + wire stages).
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]{};

--- a/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -106,6 +106,13 @@ PTO2SchedulerLayout PTO2SchedulerState::reserve_layout(DeviceArena &arena) {
     PTO2SchedulerLayout layout{};
     layout.ready_queue_capacity = PTO2_READY_QUEUE_SIZE;
 
+    // Fixed-capacity early-dispatch queues first, then the PTO2_READY_QUEUE_SIZE
+    // ones. The big nine are the arena's last reservations so that the bytes bind
+    // uploads stay one contiguous range no matter how much of them is in use.
+    for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+        layout.off_early_dispatch_queue_slots[i] = ready_queue_reserve_layout(arena, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
+    }
+    layout.off_early_sync_start_queue_slots = ready_queue_reserve_layout(arena, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         layout.off_ready_queue_slots[i] = ready_queue_reserve_layout(arena, PTO2_READY_QUEUE_SIZE);
     }
@@ -115,10 +122,6 @@ PTO2SchedulerLayout PTO2SchedulerState::reserve_layout(DeviceArena &arena) {
     layout.off_dummy_ready_queue_slots = ready_queue_reserve_layout(arena, PTO2_READY_QUEUE_SIZE);
     layout.off_graph_ready_queue_slots = ready_queue_reserve_layout(arena, PTO2_READY_QUEUE_SIZE);
     layout.off_graph_prepare_queue_slots = ready_queue_reserve_layout(arena, PTO2_READY_QUEUE_SIZE);
-    for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        layout.off_early_dispatch_queue_slots[i] = ready_queue_reserve_layout(arena, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
-    }
-    layout.off_early_sync_start_queue_slots = ready_queue_reserve_layout(arena, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
     // Polling: no dep_pool arena region — producer dependencies are inline ids on
     // the payload and readiness is via completion_flags.
     return layout;
@@ -338,11 +341,16 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
         layout.heap_sizes[r] = heap_sizes[r];
     }
 
+    // Reservation order defines the two ranges bind uploads. The orchestrator
+    // block is host-only dep-computation scratch the AICPU never reads, so it is
+    // skipped; everything the device does read is placed after it, which is what
+    // makes [off_uploaded_tail_begin, ...) a single range.
     layout.off_sm_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
     layout.orch = PTO2OrchestratorState::reserve_layout(arena, static_cast<int32_t>(task_window_sizes[0]));
-    layout.sched = PTO2SchedulerState::reserve_layout(arena);
     layout.off_runtime = arena.reserve(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE);
+    layout.off_uploaded_tail_begin = layout.off_runtime;
     layout.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
+    layout.sched = PTO2SchedulerState::reserve_layout(arena);
 
     layout.arena_size = arena.total_size();
     return layout;


### PR DESCRIPTION
## Summary

`bind` uploads the runtime arena as two ranges, skipping the orchestrator block in
between because it is host-only dep-computation scratch the AICPU never reads. The
tail range's start was read as `sq.off_ready_queue_slots[0]` — correct only because
the reservation order happened to be `sm_handle -> orch -> sched`, an assumption
spelled out in a comment at the use site rather than expressed by the layout.

Two changes:

- Reservation order is now `sm_handle -> orch -> runtime -> mailbox -> sched`, and
  the layout carries the boundary as `off_uploaded_tail_begin`, so the upload no
  longer infers it from which region happens to come first.
- Within the scheduler block the four fixed-capacity early-dispatch queues come
  first and the nine `PTO2_READY_QUEUE_SIZE` ones last.

## Why

Both exist to keep the tail range contiguous when those nine stop being uploaded
in full. They hold 1,775,616 of the 2,241,984 bytes `bind` ships, 98.7% of which
is a Vyukov sequence ramp for slots no push ever reaches — measured in #1887 as
peak occupancy 107 against capacity 8192.

Sizing them to what the task population can reach means the used prefix shrinks;
with them last, what shrinks is the *end* of the uploaded range rather than a hole
in the middle of it.

## No behaviour change

Same uploaded byte count (2,241,984), same task count and heap high-water on
qwen3-14b decode, goldens pass.

The count is identical **by construction**, not only by measurement:
`AICoreCompletionMailbox` aligns its members to `PTO2_ALIGN_SIZE` and its size is a
multiple of it, so the arena cursor is cache-line aligned both entering and leaving
the mailbox — the scheduler block therefore needs no padding in its new position,
and `DeviceArena::total_size()` is unchanged. Since `orch_start` and `orch_end`
also do not move, the uploaded byte count cannot shift.

Per-round control-plane times move within their existing run-to-run spread
(`arena_h2d` 0.552 / 0.789 / 0.954 ms across three rounds, against
0.629 / 0.671 / 0.582 before) — this commit changes where bytes sit, not how many
travel.

## Testing

- [x] C++ unit tests: 101/101 pass (`ctest --test-dir tests/ut/cpp/build -LE requires_hardware`)
- [x] Verified no other consumer depends on the old ordering — every user of
      `off_runtime` / `off_mailbox` / the queue offsets goes through the layout,
      and `off_ready_queue_slots[0]` has no remaining out-of-layout reader
- [x] a2a3 and a5 diffs verified identical in content
- [ ] Simulation tests pass (CI)
- [ ] Hardware tests pass (CI)

Builds on #1887.
