### PR TITLE
Fix: give DFX one multi-round contract and re-sync its documentation

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -198,7 +198,7 @@ def pytest_addoption(parser):
         "--enable-dep-gen",
         action="store_true",
         default=False,
-        help="Enable dep_gen capture (SubmitTrace ring, first round only)",
+        help="Enable dep_gen capture (disabled when --rounds > 1)",
     )
     parser.addoption(
         "--enable-pmu",
@@ -214,7 +214,8 @@ def pytest_addoption(parser):
         "--enable-scope-stats",
         action="store_true",
         default=False,
-        help="Enable per-scope peak collection and emit <output_prefix>/scope_stats.jsonl (per-scope ring-fill peaks).",
+        help="Enable per-scope peak collection and emit <output_prefix>/scope_stats/scope_stats.jsonl "
+        "(per-scope ring-fill peaks).",
     )
     parser.addoption(
         "--enable-swimlane-overhead",
@@ -460,6 +461,20 @@ def _configure_sanitizer(config):
         )
 
 
+def _validate_diagnostic_flags(config) -> None:
+    # Imported by full path: `simpler_setup.scene_test` as an attribute is the
+    # @scene_test decorator, not this module.
+    from simpler_setup.scene_test import _validate_diagnostic_flags as validate  # noqa: PLC0415
+
+    try:
+        validate(
+            chip_swimlane=config.getoption("--enable-chip-swimlane", default=0),
+            swimlane_overhead=config.getoption("--enable-swimlane-overhead", default=False),
+        )
+    except ValueError as e:
+        raise pytest.UsageError(str(e)) from e
+
+
 def _validate_level_filters(config) -> None:
     if config.getoption("--level", default=None) is not None and (
         config.getoption("--exclude-level", default=None) is not None
@@ -501,6 +516,7 @@ def pytest_configure(config):
     )
 
     _validate_level_filters(config)
+    _validate_diagnostic_flags(config)
     _configure_sanitizer(config)
 
     # Configure logging unconditionally (not only when --log-level is passed) so

--- a/docs/dfx/chip-swimlane-profiling.md
+++ b/docs/dfx/chip-swimlane-profiling.md
@@ -29,8 +29,8 @@ end-to-end runtime numbers. Two cases dominate the profiler diet:
 
 chip swimlane profiling captures both: per-task `(start, end,
 dispatch, finish)` records on the AICore side, plus per-iteration
-phase records on the AICPU scheduler side and a one-shot
-orchestrator summary. The host writes a Chrome Trace Event JSON
+phase records on the AICPU scheduler side and per-submit orchestrator
+envelopes. The host writes a Chrome Trace Event JSON
 that loads directly in Perfetto, and the same file feeds a
 scheduler-overhead deep-dive report when a device log is
 available.
@@ -139,8 +139,8 @@ The JSON output `"chip_swimlane_level"` field is the captured perf_level:
 `1` = AICore timing only, `2` = +AICPU dispatch/finish,
 `3` = +scheduler phases, `4` = +orchestrator phases.
 
-`--rounds > 1` collects only on the **first** round so warm-up
-runs are not double-counted.
+Chip-swimlane collection is disabled when `--rounds > 1` so benchmark
+runs are not instrumented.
 
 ### 3.2 Output
 
@@ -611,73 +611,84 @@ host publishes for the run. The shared region carries a fixed
 shape on both architectures):
 
 ```text
-ChipSwimlaneDataHeader                                (host init, device R/W)
-├── queues  [MAX_AICPU_THREADS][READYQUEUE_SIZE]
-├── queue_heads / queue_tails (per-thread)
-└── num_cores
+ChipSwimlaneDataHeader                               (host init, device R/W)
+├── queues [MAX_AICPU_THREADS][PROF_READYQUEUE_SIZE]
+├── queue_heads / queue_tails  (per-thread)
+├── num_cores / chip_swimlane_level                   (host writes at init)
+├── num_sched_phase_threads / num_orch_phase_threads  (AICPU writes at phase
+├── num_phase_cores / core_to_thread[]                 init; host gates on
+│                                                      the two counts)
+└── backpressure                (DfxBackpressureHeader)
 
-ChipSwimlaneAicpuTaskPool[num_cores]                    (per-core AICPU pool state)
-├── free_queue {buffer_ptrs[SLOT_COUNT], head, tail}
-├── current_buf_ptr           (AICPU active ChipSwimlaneAicpuTaskBuffer*)
-├── aicore_ring_ptr           (legacy; kept for ABI continuity)
-├── total_record_count
-├── dropped_record_count
-└── mismatch_record_count     (legacy; no longer written)
+Every pool below is the same 192B shape — one ChipSwimlaneActiveHead (64B)
+plus one ChipSwimlaneFreeQueue (128B). Only the buffer payload type differs,
+which is what lets the drain machinery stay polymorphic:
 
-ChipSwimlaneAicoreTaskPool[num_cores]              (per-core AICore pool state)
-├── head {current_buf_ptr, current_buf_seq,     (single 64B cache line;
-│         total_record_count,                    AICPU writes, AICore dcci-
-│         dropped_record_count}                  polls per task; AICPU bumps
-│                                                current_buf_seq on rotation
-│                                                so AICore detects the change)
-└── free_queue {buffer_ptrs[SLOT_COUNT], head, tail}
+head       {current_buf_ptr, current_buf_seq,     single 64B cache line: the
+            total_record_count,                   producer's active buffer
+            dropped_record_count}                 plus its accounting
+free_queue {buffer_ptrs[PROF_SLOT_COUNT],         SPSC ring — host pushes
+            head, tail}                           recycled buffers, AICPU pops
 
-[ChipSwimlaneAicoreTaskBuffer × PLATFORM_AICORE_BUFFERS_PER_CORE per core]
-└── ChipSwimlaneAicoreTaskRecord records[PLATFORM_AICORE_BUFFER_SIZE]  (1024 records, 32B each)
+ChipSwimlaneAicpuTaskPool[num_cores]                    (AICPU writes)
+└── ChipSwimlaneAicpuTaskBuffer × PLATFORM_PROF_BUFFERS_PER_CORE
+    └── ChipSwimlaneAicpuTaskRecord records[PLATFORM_PROF_BUFFER_SIZE]
+                                                        (1000 records, 32B each)
 
-a2a3 layout (post-#942):
-[ChipSwimlaneAicpuSchedPhasePool[num_sched_phase_threads]]  (per-AICPU-thread)
-└── ChipSwimlaneAicpuSchedPhaseBuffer × PROF_BUFFERS_PER_THREAD; alias of TaskPool
+ChipSwimlaneAicoreTaskPool[num_cores]                   (AICore writes; AICPU
+└── ChipSwimlaneAicoreTaskBuffer                         rotates and bumps
+    × PLATFORM_AICORE_BUFFERS_PER_CORE                   current_buf_seq, which
+    └── ChipSwimlaneAicoreTaskRecord                     AICore dcci-polls per
+        records[PLATFORM_AICORE_BUFFER_SIZE]             task to detect)
+                                                        (1024 records, 32B each)
 
-[ChipSwimlaneAicpuOrchPhasePool[num_orch_phase_threads]]    (per-AICPU-thread)
-└── ChipSwimlaneAicpuOrchPhaseBuffer × PROF_BUFFERS_PER_THREAD; alias of TaskPool
+ChipSwimlaneAicpuSchedPhasePool[MAX_AICPU_THREADS]      (one per scheduler
+└── ChipSwimlaneAicpuSchedPhaseBuffer                    thread; buffers only
+    × PLATFORM_PROF_SCHED_BUFFERS_PER_THREAD             for live threads)
+    └── ChipSwimlaneAicpuSchedPhaseRecord
+        records[PLATFORM_PHASE_RECORDS_PER_THREAD]      (16384 records, 64B each)
 
-a5 layout (pre-split; pending port to the a2a3 shape above):
-[ChipSwimlaneAicpuPhasePool[num_phase_threads]]   (single unified pool, gated
-                                                 by ChipSwimlaneAicpuPhaseHeader
-                                                 + CHIP_SWIMLANE_AICPU_PHASE_MAGIC)
-
-(a2a3 phase metadata — num_sched_phase_threads, num_orch_phase_threads,
- num_phase_cores, core_to_thread[] — lives inside ChipSwimlaneDataHeader,
- not a separate cache line; the legacy header + magic gate were removed
- in #941. Host gates on num_{sched,orch}_phase_threads > 0.)
+ChipSwimlaneAicpuOrchPhasePool[MAX_AICPU_THREADS]       (orchestration is
+└── ChipSwimlaneAicpuOrchPhaseBuffer                     single-threaded, so
+    × PLATFORM_PROF_ORCH_BUFFERS_PER_THREAD              only ordinal 0 ever
+    └── ChipSwimlaneAicpuOrchPhaseRecord                 gets a producer)
+        records[PLATFORM_PHASE_RECORDS_PER_THREAD]      (16384 records, 32B each)
 ```
+
+The pool-state array is sized `PLATFORM_MAX_AICPU_THREADS` on both phase
+kinds because AICPU's offset stride is fixed at that width; only the first
+`aicpu_thread_num` states ever get buffers seeded.
 
 Task records are identical across architectures:
 
-- `ChipSwimlaneAicpuTaskRecord` — per-task AICPU-owned fields (task_id, dispatch_time,
-  finish_time, func_id, core_type, reg_task_id), 64-byte aligned.
-  `reg_task_id` is the join key against the matching AICore record.
-- `ChipSwimlaneAicoreTaskRecord` — slim AICore-only record (start, end, task_id),
-  32 bytes; AICore writes one per task into its currently-active
-  per-core buffer.
+- `ChipSwimlaneAicpuTaskRecord` — per-task AICPU-owned fields (dispatch_time,
+  finish_time, reg_task_id); 20 B logical, `aligned(32)` so two records share
+  a cache line. `reg_task_id` is the join key against the matching AICore
+  record. `core_type` comes from the static per-core table
+  `ChipSwimlaneCollector::set_core_types` publishes, and `func_id` is resolved
+  post-process by `swimlane_converter.py` from deps.json's `kernel_ids[]` —
+  neither is carried in the record.
+- `ChipSwimlaneAicoreTaskRecord` — slim AICore-only record (start_time,
+  end_time, task_token_raw, reg_task_id, receive_to_start_cycles), 32 bytes;
+  AICore writes one per task into its currently-active per-core buffer.
+  `reg_task_id` is the join key; `task_token_raw` is identity only.
 
-Phase records diverge — a2a3 split them into two type-tagged streams
-in #942, a5 still uses the legacy unified shape:
+Both architectures use split phase streams:
 
-- a2a3:
-  - `ChipSwimlaneAicpuSchedPhaseRecord` (40 B) — per-iteration scheduler
-    phase; kind ∈ {Complete, Dispatch} + loop_iter + tasks_processed +
-    pop_hit / pop_miss deltas.
-  - `ChipSwimlaneAicpuOrchPhaseRecord` (32 B) — per-submit orchestrator
-    envelope; task_id + submit_idx + start/end.
-- a5:
-  - `ChipSwimlaneAicpuPhaseRecord` (40 B) — single record type carrying
-    both sched and orch via a `phase_id` discriminator; pending port to
-    the split shape.
+- `ChipSwimlaneAicpuSchedPhaseRecord` (64 B) — one record per **emitted
+  phase**, not per scheduler iteration: a single iteration routinely emits
+  several (e.g. Complete, AsyncPoll, Dispatch, Release, plus the Resolve
+  inner phase). `ChipSwimlaneSchedPhaseKind` spans the outer phases
+  (Complete, Dispatch, Release, Dummy, EarlyDispatch, AsyncPoll, Drain,
+  GraphPrepare), the inner ones (Resolve, DrainPrepare, DrainPublish) and
+  the separate-lane markers (DummyTask, PredicatedSkip) — see §3.2 for how
+  each is rendered. Carries loop_iter + tasks_processed + pop_hit /
+  pop_miss deltas and queue-depth snapshots.
+- `ChipSwimlaneAicpuOrchPhaseRecord` (32 B) — per-submit orchestrator
+  envelope; task_id + submit_idx + start/end.
 
-`swimlane_converter` shape-detects per source and produces the same
-output JSON for both. On a2a3 the orch stream replaces the per-sub-step
+`swimlane_converter` consumes the shared shape and produces the same
+output JSON on both architectures. The orch stream replaces the per-sub-step
 records folded into ORCH_SUBMIT; there is no separate shared-memory
 aggregate. The run-window envelope is emitted to device log via
 `LOG_INFO "orch_start=… orch_end=… orch_cost=…"`.
@@ -757,12 +768,12 @@ are single-kind.
 │                          │               │                          │
 │ start(tf)                │               │ AICPU on FIN:            │
 │   ┌────────────────────┐ │ SPSC ready    │   commit AicpuTask       │
-│   │ drain/refill shard │ │ queues        │   record (kind 0); fill  │
-│   │ + replenish thread │ │<──4 kinds────<│   func_id / dispatch /   │
-│   │   poll ready queue │<┼──multiplexed──│   finish; rotate buffer  │
-│   │   refill freeQ     │─┼──free queue──>│   when full              │
+│   │ drain/refill shard │ │ queues        │   record (kind 0):       │
+│   │ + replenish thread │ │<──4 kinds────<│   dispatch / finish /    │
+│   │   poll ready queue │<┼──multiplexed──│   reg_task_id; rotate    │
+│   │   refill freeQ     │─┼──free queue──>│   buffer when full       │
 │   └────────────────────┘ │               │ AICPU scheduler thread:  │
-│   ┌────────────────────┐ │               │   per work iter: write   │
+│   ┌────────────────────┐ │               │   per emitted phase:     │
 │   │ collector shard    │ │               │   SchedPhaseRecord       │
 │   │   reads via host   │ │ shared mem    │   (kind 1). Per submit:  │
 │   │   mapping; copies  │<┼──mapping─────<│   write OrchPhaseRecord  │
@@ -782,17 +793,21 @@ are single-kind.
 ```text
 init_chip_swimlane()
   chip_swimlane_collector_.initialize(num_aicore, ..., output_prefix_)
-  kernel_args_.args.chip_swimlane_data_base = chip_swimlane_collector_.get_chip_swimlane_shm_device_ptr()
+  kernel_args_.args.chip_swimlane_data_base =
+      chip_swimlane_collector_.get_chip_swimlane_setup_device_ptr()
+  kernel_args_.args.chip_swimlane_aicore_rotation_table =
+      chip_swimlane_collector_.get_aicore_ring_addr_table_device_ptr()
 start(tf)                          ← spawn split mgmt + collector shards
 launch AICPU / AICore
 rtStreamSynchronize
 stop()                             ← join mgmt/replenish → join collectors
 read_phase_header_metadata()       ← single-shot read of the
                                      core→thread mapping
-reconcile_counters()               ← three-bucket accounting for both
-                                     PERF and PHASE pools (total /
-                                     collected / dropped); any non-zero
-                                     current_buf_ptr is a flush bug
+reconcile_counters()               ← two-bucket accounting per pool
+                                     (PERF, SCHED_PHASE, ORCH_PHASE):
+                                     collected + dropped == device_total;
+                                     any non-zero current_buf_ptr over a
+                                     non-empty buffer is a flush bug
 export_swimlane_json()             ← writes <output_prefix>/chip_swimlane_records.json
 finalize(unregister, free)
 ```
@@ -829,34 +844,37 @@ behavioral deviation from §5.2 is the **transport channel**: a5 has no
 host-shadow `malloc()` and the mgmt loop synchronizes the two via
 `profiling_copy.h` (`rtMemcpy` onboard, plain `memcpy` in sim).
 
-The AICore-side write target is a per-core, **stable**
-`ChipSwimlaneAicoreRing` (`dual_issue_slots[PLATFORM_L2_AICORE_RING_SIZE]`)
-allocated once by the host and addressed via
-`ChipSwimlaneAicpuTaskPool::aicore_ring_ptr` (AICPU side) and
-`KernelArgs::aicore_chip_swimlane_ring_addrs[block_idx]` forwarded into
-`set_aicore_chip_swimlane_ring()` by `KERNEL_ENTRY` (AICore side). The ring
-address never changes during a run, so AICore's write address is
-decoupled from the AICPU's rotating `ChipSwimlaneAicpuTaskBuffer`. Buffer rotation is
-internal to `chip_swimlane_aicpu_complete_task` when `records[count]` hits
+What is **stable** per core is the *head slot address*, not the buffer. The
+host publishes a `uint64_t[num_aicore]` rotation table through
+`KernelArgs::chip_swimlane_aicore_rotation_table`; `KERNEL_ENTRY` indexes it by
+`block_idx` and hands the slot to `set_chip_swimlane_aicore_head_slot()`. AICPU's
+`chip_swimlane_aicpu_init` fills each slot with the address of that core's
+`ChipSwimlaneAicoreTaskPool::head`. AICore therefore holds one address for the
+whole run, but what it *finds* there rotates: it dcci-polls the head per task
+and re-reads `current_buf_ptr` whenever `current_buf_seq` bumps (§5.1). AICPU
+task-buffer rotation is separately internal to
+`chip_swimlane_aicpu_complete_task` when `records[count]` hits
 `PLATFORM_PROF_BUFFER_SIZE`. The runtime `Handshake` carries no
 profiling fields.
 
 The framework's `MemoryOps` therefore carries five callbacks on
 a5 (`alloc` / `reg` / `free_` / `copy_to_device` /
 `copy_from_device`); the mgmt loop mirrors the entire shm region
-(`ChipSwimlaneDataHeader` + per-core `ChipSwimlaneAicpuTaskPool` +
-`ChipSwimlaneAicpuPhaseHeader` + per-thread `ChipSwimlaneAicpuPhasePool`)
+(`ChipSwimlaneDataHeader` + the per-core task pools + the per-thread
+sched- and orch-phase pools)
 device → host at the top of every tick, then pushes back only the
 fields host actually modified (advanced `queue_heads[q]`, refilled
 `free_queue.tail` and `buffer_ptrs[slot]`) via
 `BufferPoolManager::write_range_to_device`. The bulk
 `mirror_shm_to_device` is deliberately **not** called from the mgmt
 loop: it would race with AICPU writes to device-only fields
-(`current_buf_ptr`, `total/dropped/mismatch` counters, `queue_tails`,
-`free_queue.head`, `ChipSwimlaneAicpuPhaseHeader::magic`,
-`ChipSwimlaneAicpuPhaseHeader::core_to_thread[]`) and roll them back to
+(`head.current_buf_ptr`, `head.current_buf_seq`, `head.total/dropped`
+counters, `queue_tails`, `free_queue.head`, and the header's
+`num_{sched,orch}_phase_threads` / `num_phase_cores` / `core_to_thread[]`)
+and roll them back to
 whatever the host shadow held at the start of the tick. Per-buffer
-payloads (`ChipSwimlaneAicpuTaskBuffer` / `ChipSwimlaneAicpuPhaseBuffer`)
+payloads (`ChipSwimlaneAicpuTaskBuffer` /
+`ChipSwimlaneAicpuSchedPhaseBuffer` / `ChipSwimlaneAicpuOrchPhaseBuffer`)
 are pulled on demand inside `ProfilerAlgorithms::process_entry` after
 a popped ready-entry resolves to its host shadow. `BufferPoolManager`'s
 `release_owned_buffers` canonicalizes carved sub-buffers back to the
@@ -871,14 +889,14 @@ rollback by `release_all_owned()`.
 │   : ProfilerBase<...>    │               │                          │
 │                          │               │                          │
 │ initialize()             │  alloc + reg  │ AICore on task end:      │
-│   rtMalloc shm           │──+ shadow────>│   write timing into      │
-│   per-core ChipSwimlaneAicpuTaskBuffer  │   memset 0    │   per-core ring slot     │
-│   per-core AicoreRing    │   + push 0s   │   dual_issue_slots[      │
-│   per-thread ChipSwimlaneAicpuPhaseBuffer │               │     task_id & 1]         │
-│   register_mapping(s)    │               │                          │
-│   set_memory_context     │               │ AICPU on FIN:            │
-│                          │               │   read ring slot →       │
-│                          │               │   commit into records[]  │
+│   rtMalloc shm           │──+ shadow────>│   dcci the head slot,    │
+│   per-core AicpuTaskBuf  │   memset 0    │   write a slim record    │
+│   per-core AicoreTaskBuf │   + push 0s   │   into the active        │
+│   per-thread Sched/Orch  │               │   AicoreTaskBuffer       │
+│     PhaseBuf             │               │                          │
+│   register_mapping(s)    │               │ AICPU on FIN:            │
+│   set_memory_context     │               │   commit AicpuTask       │
+│                          │               │   record into records[]  │
 │ start(thread_factory)    │               │                          │
 │   mgmt_thread starts     │               │ AICPU per-thread flush   │
 │   poll_thread starts     │               │   on exit: enqueue       │
@@ -907,7 +925,7 @@ rollback by `release_all_owned()`.
 │ read_phase_header_meta   │               │                          │
 │ reconcile_counters       │               │                          │
 │   sanity-check leftovers │               │                          │
-│   + 3-bucket cross-check │               │                          │
+│   + 2-bucket cross-check │               │                          │
 │ export_swimlane_json()   │               │                          │
 │ finalize(free)           │               │                          │
 └──────────────────────────┘               └──────────────────────────┘
@@ -919,14 +937,14 @@ rollback by `release_all_owned()`.
 init_chip_swimlane()
   chip_swimlane_collector_.initialize(num_aicore, ..., output_prefix_)
   kernel_args_.args.chip_swimlane_data_base = chip_swimlane_collector_.get_chip_swimlane_setup_device_ptr()
-  kernel_args_.args.aicore_chip_swimlane_ring_addrs =
-      chip_swimlane_collector_.get_aicore_ring_addrs_device_ptr()
+  kernel_args_.args.chip_swimlane_aicore_rotation_table =
+      chip_swimlane_collector_.get_aicore_ring_addr_table_device_ptr()
 chip_swimlane_collector_.start(thread_factory)   ← mgmt + poll threads
 launch AICPU / AICore
 rtStreamSynchronize
 chip_swimlane_collector_.stop()                  ← join mgmt + poll, drain final batch
 chip_swimlane_collector_.read_phase_header_metadata()
-chip_swimlane_collector_.reconcile_counters()    ← sanity-check + 3-bucket cross-check
+chip_swimlane_collector_.reconcile_counters()    ← sanity-check + 2-bucket cross-check
 chip_swimlane_collector_.export_swimlane_json()
 chip_swimlane_collector_.finalize()
 ```
@@ -936,33 +954,34 @@ on a5 inherits the same CRTP base
 ([`profiling_common::ProfilerBase`](../../src/common/platform/include/host/profiler_base.h))
 as a2a3 and parameterizes
 [`BufferPoolManager`](../../src/common/platform/include/host/buffer_pool_manager.h)
-with `ChipSwimlaneModule` (`kBufferKinds = 2`). The only a5-specific
-glue is the 5-callback `MemoryOps` and the per-tick shm mirror.
+with `ChipSwimlaneModule` (`kBufferKinds = 4`). The collector source is
+shared — `src/common/platform/{include,shared}/host/` — so the only
+a5-specific glue is the 5-callback `MemoryOps` and the per-tick shm mirror.
 
 a5's per-thread AICPU flush hooks (`chip_swimlane_aicpu_flush` /
 `chip_swimlane_aicpu_flush_phase_buffers`) are the only data path on the
 records side — host never reads from `current_buf_ptr` to recover
 records. `reconcile_counters` is purely passive: it logs an error if
 any `current_buf_ptr` is non-zero with a non-empty buffer (a
-device-flush bug), then runs the three-bucket cross-check
-`collected + dropped + mismatch == device_total` per pool (PERF +
-PHASE), same shape as a2a3.
+device-flush bug), then runs the two-bucket cross-check
+`collected + dropped == device_total` per pool (PERF, SCHED_PHASE,
+ORCH_PHASE), same shape as a2a3.
 
 ### 5.4 a2a3 vs a5 at a glance
 
 | Aspect | a2a3 | a5 |
 | ------ | ---- | -- |
-| Task record | `ChipSwimlaneAicpuTaskRecord` (64 B) + `ChipSwimlaneAicoreTaskRecord` (32 B) | identical |
-| Phase record | split: `ChipSwimlaneAicpuSchedPhaseRecord` (40 B) + `ChipSwimlaneAicpuOrchPhaseRecord` (32 B) | unified `ChipSwimlaneAicpuPhaseRecord` (40 B, `phase_id`-tagged); pending port |
-| AICore WIP-slot protocol | identical | |
+| Task record | `ChipSwimlaneAicpuTaskRecord` (32 B) + `ChipSwimlaneAicoreTaskRecord` (32 B) | identical |
+| Phase record | `ChipSwimlaneAicpuSchedPhaseRecord` (64 B) + `ChipSwimlaneAicpuOrchPhaseRecord` (32 B) | identical |
+| AICore head-slot rotation protocol | identical | |
 | AICPU commit on FIN | identical | |
 | Buffer model | rotating pool (free + ready queues) per kind | identical |
-| Ready queue | per-AICPU-thread, multiplexes 4 kinds via `ReadyQueueEntry::kind` | per-AICPU-thread, 2 kinds via `is_phase` |
+| Ready queue | per-AICPU-thread, multiplexes 4 kinds via `ReadyQueueEntry::kind` | identical |
 | Host threads | split mgmt + collector shards, streams during execution | same split mgmt + collector shards (5 = `PLATFORM_MAX_AICPU_THREADS` vs a2a3's 4) |
-| Host-class shape | `ProfilerBase<ChipSwimlaneCollector, ChipSwimlaneModule>` (`kBufferKinds = 4`) | same base, `kBufferKinds = 2` |
+| Host-class shape | `ProfilerBase<ChipSwimlaneCollector, ChipSwimlaneModule>` (`kBufferKinds = 4`) | identical — one shared collector under `src/common/platform/` |
 | Host transport | `halHostRegister` shared memory | host-shadow `malloc` + per-tick `rtMemcpy`/`memcpy` |
 | `MemoryOps` callbacks | 3 (`alloc`, `reg`, `free_`) | 5 (+ `copy_to_device`, `copy_from_device`) |
-| `reconcile_counters` | passive cross-check (collected + dropped + mismatch == device_total) | identical |
+| `reconcile_counters` | passive cross-check (collected + dropped == device_total) | identical |
 | Lifecycle | `initialize` → `start` → `stop` → `read_phase_header_metadata` → `reconcile_counters` → `export_swimlane_json` → `finalize` | identical |
 
 ## 6. Overhead
@@ -978,21 +997,25 @@ When enabled, the dominant per-task overhead is:
 - The AICPU commit on FIN, which copies the WIP record into the
   ring buffer plus a few metadata fields.
 
-Phase-record overhead (only at `--enable-chip-swimlane >= 3`):
+Phase-record overhead, same on both architectures:
 
-- a2a3 — one 40 B `ChipSwimlaneAicpuSchedPhaseRecord` per work-emitting
-  scheduler iteration (Complete + Dispatch, idle iters do not emit),
-  plus one 32 B `ChipSwimlaneAicpuOrchPhaseRecord` per `submit_task()`.
-- a5 — one 40 B `ChipSwimlaneAicpuPhaseRecord` per emitted phase
-  (legacy unified shape).
+- at `--enable-chip-swimlane >= 3` — one 64 B
+  `ChipSwimlaneAicpuSchedPhaseRecord` per **emitted phase**, so a scheduler
+  iteration that does several kinds of work costs several records; idle
+  iterations emit none.
+- at `--enable-chip-swimlane >= 4` only — one 32 B
+  `ChipSwimlaneAicpuOrchPhaseRecord` per `submit_task()`. Level 3 captures
+  no orchestrator records at all (`ChipSwimlaneLevel::ORCH_PHASES` gates
+  both the pool allocation and the device-side write).
 
 Both architectures drain buffers concurrently with execution through the
 ProfilerBase mgmt/collector pipeline; both a2a3 and a5 use split mgmt plus
-collector shards for this profiler (a5 with 7 shards, a2a3 with 4). a5
+collector shards for this profiler, capped at `PLATFORM_MAX_AICPU_THREADS`
+(a5 5, a2a3 4). a5
 additionally pays per-buffer `rtMemcpy`/`memcpy` round-trips to keep the
 host shadow in sync, which overlap with device execution.
 
-`--rounds > 1` collects only on the first round so the steady-state
+`--rounds > 1` disables chip-swimlane collection so the steady-state
 benchmark is not perturbed.
 
 ## 7. Limitations
@@ -1016,19 +1039,26 @@ benchmark is not perturbed.
 
 ### 7.2 a5
 
-- Each per-core `ChipSwimlaneAicpuTaskBuffer` and per-thread `ChipSwimlaneAicpuPhaseBuffer` is
-  fixed-size. Tasks past `PLATFORM_PROF_BUFFER_SIZE` per core (and
-  phases past `PLATFORM_PHASE_RECORDS_PER_THREAD` per thread) are
-  silently dropped via AICPU early return; the host surfaces the
-  count in the finalize log line. Raise the constants in
-  [platform_config.h](../../src/a5/platform/include/common/platform_config.h)
-  for workloads that exceed them.
+- Buffers are fixed-size but **rotated**, so a long run is not bounded by
+  one buffer's capacity. A record is dropped when the producer cannot get a
+  replacement buffer — the pool's free queue is empty because the host has
+  not refilled it yet — or when the ready-queue enqueue fails; AICore
+  additionally drops on its own slot guard when its free queue is empty.
+  Hitting `PLATFORM_PROF_BUFFER_SIZE` / `PLATFORM_PHASE_RECORDS_PER_THREAD`
+  inside a buffer is a defensive path that rotation should have prevented.
+  Every drop bumps `dropped_record_count`, which the host surfaces in the
+  finalize log line. The tuning knobs are therefore **pool depth and
+  replenishment rate** — `PLATFORM_PROF_BUFFERS_PER_CORE`,
+  `PLATFORM_AICORE_BUFFERS_PER_CORE`,
+  `PLATFORM_PROF_{SCHED,ORCH}_BUFFERS_PER_THREAD`, `PLATFORM_PROF_SLOT_COUNT`
+  in [platform_config.h](../../src/a5/platform/include/common/platform_config.h)
+  — not the per-buffer record counts.
 - `a5sim` exercises the export pipeline; the simulated device
   clock is not realistic for absolute-timing analysis.
 
 ### 7.3 Common
 
-- Only the **first** round records when `--rounds > 1` is in use.
+- Chip-swimlane collection is disabled when `--rounds > 1` is in use.
 - The current implementation captures incore-level scope only —
   L3 composition and orchestrator-internal sub-tasks are visible
   through the orchestrator phase summary, not as nested swimlane
@@ -1038,7 +1068,7 @@ benchmark is not perturbed.
 
 **No `chip_swimlane_records.json` produced.** Check that
 `--enable-chip-swimlane` was passed. Verify `<output_prefix>` exists
-in the run log; if `--rounds > 1`, only the first round records.
+in the run log; `--rounds > 1` disables chip-swimlane collection.
 
 **`merged_swimlane.json` is missing.** `swimlane_converter` runs
 automatically after a SceneTest with `--enable-chip-swimlane`; if it

--- a/docs/dfx/pmu-profiling.md
+++ b/docs/dfx/pmu-profiling.md
@@ -65,8 +65,8 @@ SIMPLER_PMU_EVENT_TYPE=4 \
 python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --enable-pmu
 ```
 
-`--rounds > 1` disables PMU collection in the test harness so warm-up
-rounds are not double-counted.
+`--rounds > 1` disables PMU collection in the test harness so benchmark
+rounds stay uninstrumented.
 
 ### 3.2 Output
 

--- a/docs/dfx/profiling-framework.md
+++ b/docs/dfx/profiling-framework.md
@@ -503,9 +503,10 @@ changes capture that:
    pushed back to device with `manager_.write_range_to_device(&field,
    sizeof(field))`. The bulk `mirror_shm_to_device` is deliberately
    **not** called from the mgmt loop — it would race with AICPU writes
-   to device-only fields (`current_buf_ptr`, `total/dropped/mismatch`
-   counters, `queue_tails`, `free_queue.head`,
-   `ChipSwimlaneAicpuPhaseHeader::magic`, `core_to_thread[]`), rolling them
+   to device-only fields (`current_buf_ptr`, `current_buf_seq`,
+   `total/dropped/mismatch` counters, `queue_tails`, `free_queue.head`,
+   and the subsystem's device-written header fields such as
+   `ChipSwimlaneDataHeader::core_to_thread[]`), rolling them
    back to whatever the host shadow had at the start of the tick. Per-buffer
    payloads (`ChipSwimlaneAicpuTaskBuffer` / `PmuBuffer` /
    `DumpMetaBuffer`) are still pulled on demand inside
@@ -538,7 +539,7 @@ per-core ring/reg addresses travel through `KernelArgs`:
 | `KernelArgs` field | Producer | Consumer |
 | ------------------ | -------- | -------- |
 | `enable_profiling_flag` (bitmask) | host (DeviceRunner) | AICPU `kernel.cpp` → `set_chip_swimlane_enabled` / `set_pmu_enabled` / `set_dump_args_enabled`; AICore `KERNEL_ENTRY` → `set_aicore_profiling_flag` |
-| `aicore_chip_swimlane_ring_addrs` (table) | host (`ChipSwimlaneCollector::initialize`) | AICore `KERNEL_ENTRY` indexes `table[block_idx]` → `set_aicore_chip_swimlane_ring` |
+| `chip_swimlane_aicore_rotation_table` (table) | host (`ChipSwimlaneCollector::initialize`) | AICore `KERNEL_ENTRY` indexes `table[block_idx]` → `set_chip_swimlane_aicore_head_slot` |
 | `aicore_pmu_ring_addrs` (table) | host (`PmuCollector::init`) | AICore `KERNEL_ENTRY` → `set_aicore_pmu_ring` |
 | `regs` (per-physical-core register-base table) | host (already required for AICPU MMIO) | AICore `KERNEL_ENTRY` resolves `regs[get_physical_core_id()]` → `set_aicore_pmu_reg_base`; AICore `aicore_execute` caches the value at Phase-3 |
 
@@ -549,19 +550,34 @@ runtime `aicore_execute(runtime, block_idx, core_type)` signature is
 unchanged; adding a new profiling field touches `KernelArgs` and this
 state surface, never the runtime protocol.
 
-### 8.2 Stable AICore staging ring (decouples AICore write from AICPU buffer rotation)
+### 8.2 What AICore holds across an AICPU buffer rotation
 
-ChipSwimlane and PMU on a5 both use the "AICore writes, AICPU commits" model.
-The AICore-side write target is a per-core
-[`ChipSwimlaneAicoreRing`](../../src/common/platform/include/common/chip_swimlane_profiling.h) /
+ChipSwimlane and PMU both hand AICore one per-core address that never
+changes for the whole run, so AICPU can rotate its buffers underneath
+without renegotiating. **What that address points at differs**: for PMU it
+is the staging ring AICore writes into, so AICore's write target really is
+fixed; for ChipSwimlane it is only the head slot AICore reads, and the
+buffer it then writes into rotates.
+
+**PMU (a5)** — AICore writes into a per-core
 [`PmuAicoreRing`](../../src/a5/platform/include/common/pmu_profiling.h) of
-`PLATFORM_{L2,PMU}_AICORE_RING_SIZE` (= 2, dual-issue) slots, allocated
-once by the host and addressed by
-`BufferState::aicore_ring_ptr` (AICPU-visible) and the per-core
-`aicore_*_ring_addrs[block_idx]` (AICore-visible). The address is
-never reassigned, so AICore's write target is stable across AICPU's
-rotating `ChipSwimlaneAicpuTaskBuffer` / `PmuBuffer` flips — flipping is now
-fully internal to `*_complete_record` and never crosses into Handshake.
+`PLATFORM_PMU_AICORE_RING_SIZE` (= 2, dual-issue) slots, allocated once by
+the host and addressed by `PmuBufferState::aicore_ring_ptr` (AICPU-visible)
+and `KernelArgs::aicore_pmu_ring_addrs[block_idx]` (AICore-visible). AICPU
+reads the slot on FIN and commits it into the rotating `PmuBuffer`; the
+staging ring itself is never reassigned.
+
+**ChipSwimlane (both arches)** — AICore is the producer of record and writes
+directly into the rotating `ChipSwimlaneAicoreTaskBuffer`, so there is no
+staging ring. What is fixed is the *head slot*:
+`KernelArgs::chip_swimlane_aicore_rotation_table[block_idx]` points at that
+core's `ChipSwimlaneActiveHead`, and AICore dcci-polls it per task, picking up
+a new `current_buf_ptr` whenever AICPU bumps `current_buf_seq`. See
+[chip-swimlane-profiling.md §5.1](chip-swimlane-profiling.md#51-common-interfaces)
+for the rotation protocol.
+
+Either way, flipping is fully internal to the collector's device-side commit
+path and never crosses into Handshake.
 
 Everything else — Module concept contract, alloc policy
 (drain-shard top-up + proactive replenish), `kIdleTimeoutSec` / `kSubsystemName`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -68,7 +68,7 @@ python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example
 python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py \
     -p a2a3 -d 0 --rounds 100 --skip-golden
 
-# Profiling (first round only)
+# Profiling (single-round only; diagnostics are disabled with --rounds > 1)
 python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py \
     -p a2a3 --enable-chip-swimlane
 
@@ -130,7 +130,7 @@ Scene tests support advanced CLI options for benchmarking, profiling, and runtim
 ```bash
 pytest --platform a2a3sim                                        # default: 1 round + golden
 pytest --platform a2a3 --rounds 100 --skip-golden                # benchmark mode
-pytest --platform a2a3 --enable-chip-swimlane                             # chip swimlane (first round)
+pytest --platform a2a3 --enable-chip-swimlane                             # chip swimlane (single round)
 pytest --platform a2a3 --enable-pmu                              # PMU CSV
 pytest --platform a2a3sim --log-level debug                        # verbose C++ logging
 ```
@@ -140,7 +140,7 @@ pytest --platform a2a3sim --log-level debug                        # verbose C++
 ```bash
 python test_xxx.py -p a2a3sim                                    # default: 1 round + golden
 python test_xxx.py -p a2a3 -d 0 --rounds 100 --skip-golden       # benchmark mode
-python test_xxx.py -p a2a3 --enable-chip-swimlane                         # chip swimlane (first round)
+python test_xxx.py -p a2a3 --enable-chip-swimlane                         # chip swimlane (single round)
 python test_xxx.py -p a2a3 --dump-args                         # dump unified argument artifacts
 python test_xxx.py -p a2a3 --enable-pmu 4                        # PMU CSV (MEMORY)
 python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ logging
@@ -159,13 +159,13 @@ python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ l
 | `--case SEL` | | (all) | Case selector, repeatable: `Foo`, `ClassA::Foo`, `ClassA::` |
 | `--manual` | | `exclude` | `exclude`/`include`/`only` for manual scene-test cases and standalone pytest tests |
 | `--skip-golden` | | false | Skip golden comparison (for benchmarking) |
-| `--enable-chip-swimlane [PERF_LEVEL]` | | `0` | Enable chip swimlane collection on first round only. The flag takes an integer perf_level 0–4 (bare = 4); see [docs/dfx/chip-swimlane-profiling.md](dfx/chip-swimlane-profiling.md#31-enable-chip-swimlane) for the level table. Each test case gets its own `outputs/<case>_<ts>/` directory under which `chip_swimlane_records.json` lands; parallel runs never collide. |
+| `--enable-chip-swimlane [PERF_LEVEL]` | | `0` | Enable chip swimlane collection. The flag takes an integer perf_level 0–4 (bare = 4); see [docs/dfx/chip-swimlane-profiling.md](dfx/chip-swimlane-profiling.md#31-enable-chip-swimlane) for the level table. Each test case gets its own `outputs/<case>_<ts>/` directory under which `chip_swimlane_records.json` lands; parallel runs never collide. Disabled when `--rounds > 1`. |
 | `--dump-args` | | `0` | Dump tensors plus scalar args into unified runtime artifacts (bare flag = `1`; supports `0/1/2/3`) |
 | `--enable-pmu [EVENT_TYPE]` | | `0` | Enable a2a3 PMU CSV collection. Bare flag selects `PIPE_UTILIZATION` (`2`); pass an event type such as `4` for `MEMORY`. |
 | `--exitfirst` | `-x` | false | Stop on first failing test (fail-fast, primarily for CI) |
 | `--log-level LEVEL` | | `timing` | Simpler logger threshold. Accepts `debug` / `info` / `timing` / `warn` / `error` / `null` (case-insensitive). TIMING and NUL/NULL are registered with Python logging before pytest validates the option. The "simpler" Python logger is the single source of truth; `Worker.init()` snapshots it once and pushes the threshold to HostLogger, AICPU, and the onboard CANN mapping. Changing the Python logger afterwards does not affect an existing worker. See [Log levels](#log-levels). |
 
-Profiling is enabled only on the first round to avoid overhead on subsequent iterations. Output tensors are reset to their initial values between rounds.
+Chip swimlane, args dump, PMU, dep-gen, scope stats, and swimlane-overhead analysis are disabled when `--rounds > 1` so benchmark rounds stay uninstrumented. Output tensors are reset to their initial values between rounds.
 
 ## Log levels
 

--- a/docs/user/reference/cli.md
+++ b/docs/user/reference/cli.md
@@ -36,14 +36,17 @@ cases use `"manual": True` or a platform list such as
 All off by default. Each also exists as a `CallConfig` field for direct-`Worker`
 programs — see the [Python API reference](python-api.md).
 
+**Every flag in this table is disabled when `--rounds > 1`**, so benchmark
+rounds stay uninstrumented. The harness warns for each one it switches off.
+
 | Flag | Meaning |
 | ---- | ------- |
 | `--enable-chip-swimlane` | Per-task timing. Bare flag = level 4 (full); `1` AICore timing, `2` + dispatch/fanout, `3` + scheduler phases, `4` + orchestration. **L2 only** |
 | `--enable-swimlane-overhead` | Adds the 8 Overhead Analysis counter tracks. Requires `--enable-chip-swimlane` **and** a `deps.json` — add `--enable-dep-gen` if absent |
 | `--enable-pmu` | AICore hardware counters. Bare flag = `PIPE_UTILIZATION` (2); pass an event type to override, e.g. `--enable-pmu 4` |
 | `--dump-args` | Capture per-task arguments. `0` off; `1` partial; `2` full; `3` hybrid (all metadata plus payload selected via `Arg::dump(...)`) |
-| `--enable-dep-gen` | Capture the dependency graph (first round only) |
-| `--enable-scope-stats` | Per-scope peaks to `<output_prefix>/scope_stats.jsonl` |
+| `--enable-dep-gen` | Capture the dependency graph |
+| `--enable-scope-stats` | Per-scope peaks to `<output_prefix>/scope_stats/scope_stats.jsonl` |
 
 Which flag answers which question is tabulated in
 [How-to: profile a kernel](../how-to/profile-a-kernel.md).

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -42,6 +42,56 @@ logger = logging.getLogger(__name__)
 _compile_cache: dict[tuple, object] = {}
 
 
+class _DiagnosticOptions(NamedTuple):
+    chip_swimlane: int
+    dump_args: int
+    pmu: int
+    dep_gen: bool
+    scope_stats: bool
+    swimlane_overhead: bool
+
+
+def _validate_diagnostic_flags(*, chip_swimlane: int, swimlane_overhead: bool) -> None:
+    """Reject diagnostic combinations that can never produce their artifact.
+
+    Raises ``ValueError``; each CLI front-end translates it into that
+    front-end's own usage error (``parser.error`` standalone,
+    ``pytest.UsageError`` under pytest).
+    """
+    if swimlane_overhead and not chip_swimlane:
+        raise ValueError("--enable-swimlane-overhead requires --enable-chip-swimlane")
+
+
+def _effective_diagnostic_options(
+    rounds: int,
+    *,
+    chip_swimlane: int,
+    dump_args: int,
+    pmu: int,
+    dep_gen: bool,
+    scope_stats: bool,
+    swimlane_overhead: bool,
+    warn: bool = True,
+) -> _DiagnosticOptions:
+    """Return the diagnostics that may run for the requested round count."""
+    _validate_diagnostic_flags(chip_swimlane=chip_swimlane, swimlane_overhead=swimlane_overhead)
+    if rounds <= 1:
+        return _DiagnosticOptions(chip_swimlane, dump_args, pmu, dep_gen, scope_stats, swimlane_overhead)
+
+    disabled = (
+        ("chip swimlane", chip_swimlane),
+        ("args dump", dump_args),
+        ("PMU", pmu),
+        ("dep_gen", dep_gen),
+        ("scope_stats", scope_stats),
+        ("swimlane overhead", swimlane_overhead),
+    )
+    for name, enabled in disabled:
+        if warn and enabled:
+            logger.warning("%s disabled: --rounds > 1", name)
+    return _DiagnosticOptions(0, 0, 0, False, False, False)
+
+
 def _pto_isa_compile_cache_token() -> str:
     """Pin SHA included in session compile-cache keys.
 
@@ -1108,9 +1158,8 @@ def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI
         case_label = f"{cls_name}_{case['name']}"
         # Per-case directory the runtime writes into. Required (non-empty) when
         # any diagnostic flag is on; CallConfig::validate() throws otherwise.
-        # scope_stats now writes <prefix>/scope_stats/scope_stats.jsonl (sibling of
-        # chip_swimlane_records.json / deps.json), so it pulls output_prefix the
-        # same way the other DFX flags do.
+        # scope_stats writes below the per-case output prefix, so it uses the
+        # same output-prefix allocation as the other diagnostics.
         prefix = _build_output_prefix(case_label) if diagnostics_on else Path("")
         try:
             cls_inst._run_and_validate(
@@ -1534,11 +1583,9 @@ class SceneTestCase:
                 for name, initial in initial_outputs.items():
                     getattr(test_args, name).copy_(initial)
 
-            # enable_chip_swimlane / enable_dep_gen are already forced False by
-            # the upstream gate in test_run / run_module when rounds > 1, so an
-            # extra `and round_idx == 0` here is dead code; pass them through
-            # verbatim. (If the upstream gate is ever relaxed, restore the
-            # per-round masking here.)
+            # Every diagnostic reaching this loop is already multi-round-safe:
+            # _effective_diagnostic_options zeroes all of them when rounds > 1,
+            # so no per-round masking belongs here.
             config = self._build_config(
                 config_dict,
                 enable_chip_swimlane=enable_chip_swimlane,
@@ -1656,20 +1703,23 @@ class SceneTestCase:
 
     @staticmethod
     def _effective_enable_dep_gen(request, *, warn: bool = False) -> bool:
-        """``--enable-dep-gen`` CLI value after applying the ``--rounds > 1``
-        disable. Single source of truth so the framework's ``test_run`` loop
-        and any subclass override (e.g. ``TestDepGenCapture``'s post-validate
-        hook) can't drift on the gating rule. Pass ``warn=True`` from the
-        framework's first call — it owns the user-facing "disabled because
-        rounds > 1" message; subclass overrides leave ``warn`` off since
-        ``super().test_run()`` already warned."""
-        if not request.config.getoption("--enable-dep-gen", default=False):
-            return False
-        if request.config.getoption("--rounds", default=1) > 1:
-            if warn:
-                logger.warning("dep_gen disabled: --rounds > 1")
-            return False
-        return True
+        """Return the multi-round-safe dep-gen setting for extension hooks.
+
+        Shares the gating rule with ``test_run`` so a subclass hook (e.g.
+        ``TestDepGenCapture``'s post-validate step) cannot drift from it.
+        ``warn`` stays off by default because ``test_run`` already emitted the
+        user-facing "disabled: --rounds > 1" line before any hook runs.
+        """
+        return _effective_diagnostic_options(
+            request.config.getoption("--rounds", default=1),
+            chip_swimlane=0,
+            dump_args=0,
+            pmu=0,
+            dep_gen=request.config.getoption("--enable-dep-gen", default=False),
+            scope_stats=False,
+            swimlane_overhead=False,
+            warn=warn,
+        ).dep_gen
 
     def test_run(self, st_platform, st_worker, request):
         """Auto test method — runs matching cases for the current platform."""
@@ -1681,22 +1731,24 @@ class SceneTestCase:
         enable_chip_swimlane = request.config.getoption("--enable-chip-swimlane", default=0)
         enable_dump_args = request.config.getoption("--dump-args", default=0)
         enable_pmu = request.config.getoption("--enable-pmu", default=0)
-        enable_dep_gen = self._effective_enable_dep_gen(request, warn=True)
+        enable_dep_gen = request.config.getoption("--enable-dep-gen", default=False)
         enable_scope_stats = request.config.getoption("--enable-scope-stats", default=False)
         enable_swimlane_overhead = request.config.getoption("--enable-swimlane-overhead", default=False)
-        if rounds > 1:
-            if enable_chip_swimlane:
-                logger.warning("Profiling disabled: --rounds > 1")
-                enable_chip_swimlane = 0
-            if enable_dump_args:
-                logger.warning("Dump args disabled: --rounds > 1")
-                enable_dump_args = 0
-            if enable_pmu:
-                logger.warning("PMU disabled: --rounds > 1")
-                enable_pmu = 0
-            if enable_scope_stats:
-                logger.warning("scope_stats disabled: --rounds > 1")
-                enable_scope_stats = False
+        diagnostics = _effective_diagnostic_options(
+            rounds,
+            chip_swimlane=enable_chip_swimlane,
+            dump_args=enable_dump_args,
+            pmu=enable_pmu,
+            dep_gen=enable_dep_gen,
+            scope_stats=enable_scope_stats,
+            swimlane_overhead=enable_swimlane_overhead,
+        )
+        enable_chip_swimlane = diagnostics.chip_swimlane
+        enable_dump_args = diagnostics.dump_args
+        enable_pmu = diagnostics.pmu
+        enable_dep_gen = diagnostics.dep_gen
+        enable_scope_stats = diagnostics.scope_stats
+        enable_swimlane_overhead = diagnostics.swimlane_overhead
 
         cls_name = type(self).__name__
         callable_obj = self.build_callable(st_platform)
@@ -1814,7 +1866,7 @@ class SceneTestCase:
         parser.add_argument(
             "--enable-dep-gen",
             action="store_true",
-            help="Enable dep_gen capture (SubmitTrace ring, first round only)",
+            help="Enable dep_gen capture (disabled when --rounds > 1)",
         )
         parser.add_argument(
             "--enable-pmu",
@@ -1898,22 +1950,30 @@ class SceneTestCase:
                     f"  {_san.preload_command(_san_tokens, args.platform)} python {module_name} ..."
                 )
 
+        # Resolved before the eager PTO-ISA checkout below so a rejected flag
+        # combination costs no clone.
+        try:
+            diagnostics = _effective_diagnostic_options(
+                args.rounds,
+                chip_swimlane=args.enable_chip_swimlane,
+                dump_args=args.dump_args,
+                pmu=args.enable_pmu,
+                dep_gen=args.enable_dep_gen,
+                scope_stats=args.enable_scope_stats,
+                swimlane_overhead=args.enable_swimlane_overhead,
+            )
+        except ValueError as e:
+            parser.error(str(e))
+        args.enable_chip_swimlane = diagnostics.chip_swimlane
+        args.dump_args = diagnostics.dump_args
+        args.enable_pmu = diagnostics.pmu
+        args.enable_dep_gen = diagnostics.dep_gen
+        args.enable_scope_stats = diagnostics.scope_stats
+        args.enable_swimlane_overhead = diagnostics.swimlane_overhead
+
         # Eager pin checkout for kernel/orchestration compiles that pass
         # pto_isa_root explicitly. Do not export PTO_ISA_ROOT (#1403).
         ensure_pto_isa_root(verbose=True)
-
-        if args.rounds > 1 and args.enable_chip_swimlane:
-            logger.warning("Profiling disabled: --rounds > 1")
-            args.enable_chip_swimlane = 0
-        if args.rounds > 1 and args.enable_dep_gen:
-            logger.warning("dep_gen disabled: --rounds > 1")
-            args.enable_dep_gen = False
-        if args.rounds > 1 and args.dump_args:
-            logger.warning("Dump args disabled: --rounds > 1")
-            args.dump_args = 0
-        if args.rounds > 1 and args.enable_scope_stats:
-            logger.warning("scope_stats disabled: --rounds > 1")
-            args.enable_scope_stats = False
 
         from .parallel_scheduler import default_max_parallel, device_range_to_list  # noqa: PLC0415
 
@@ -2084,6 +2144,8 @@ def _dispatch_test_phases_standalone(module_name, selected_by_cls, args):  # noq
         common += ["--enable-chip-swimlane", str(args.enable_chip_swimlane)]
     if args.dump_args:
         common += ["--dump-args", str(args.dump_args)]
+    if args.enable_pmu:
+        common += ["--enable-pmu", str(args.enable_pmu)]
     if args.enable_dep_gen:
         common.append("--enable-dep-gen")
     if args.enable_scope_stats:

--- a/src/a2a3/platform/include/common/kernel_args.h
+++ b/src/a2a3/platform/include/common/kernel_args.h
@@ -108,8 +108,8 @@ struct KernelArgs {
                                         // Allocated by host's ScopeStatsCollector, read+written by AICPU's
                                         // scope_stats_collector via set_platform_scope_stats_base.
     // Device ptr to a uint64_t[num_aicore] table holding each core's
-    // ChipSwimlaneAicoreTaskBuffer address. AICore kernel entry indexes by block_idx
-    // and forwards into platform set/get state. 0 when chip swimlane is off.
+    // ChipSwimlaneActiveHead address (rotation channel). AICore kernel entry indexes
+    // by block_idx and forwards into platform set/get state. 0 when chip swimlane is off.
     uint64_t chip_swimlane_aicore_rotation_table{0};
     // Device pointer to the run-wall buffer the platform AICPU entry writes.
     // Allocated once and kept resident, reset each run. Onboard AICPU receives

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -329,7 +329,7 @@ constexpr int PLATFORM_PMU_RECORDS_PER_BUFFER = 512;
 /**
  * Per-core PMU staging ring depth (AICore-side dual-issue slots).
  *
- * Same constraints as PLATFORM_L2_AICORE_RING_SIZE: ≥ in-flight task
+ * Constraints: ≥ in-flight task
  * depth on a single core, and ideally a power of two so the
  * `task_id % RING_SIZE` slot index compiles to a mask. Decoupled from
  * the rotating PmuBuffer so the AICore write address is stable across

--- a/src/common/platform/include/common/chip_swimlane_profiling.h
+++ b/src/common/platform/include/common/chip_swimlane_profiling.h
@@ -731,7 +731,7 @@ inline const char *host_phase_kind_name(HostPhaseKind kind) {
     return "unknown";
 }
 
-constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 16384;  // ~512KB per sched thread, ~512KB per orch thread
+constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 16384;  // 1 MiB per sched thread, 512 KiB per orch thread
 
 // Fixed-size phase record buffers. Same TypedBuffer template as the task
 // buffers — keeps the drain machinery uniform.

--- a/src/common/platform/include/host/buffer_pool_manager.h
+++ b/src/common/platform/include/host/buffer_pool_manager.h
@@ -42,8 +42,8 @@
  *      narrow `write_range_to_device(field_ptr, sizeof(field))` calls.
  *      A bulk host→device write-back is deliberately avoided — it would
  *      race with AICPU writes to device-only fields (current_buf_ptr,
- *      total/dropped/mismatch counters, queue_tails, free_queue.head, and
- *      on a5 ChipSwimlaneAicpuPhaseHeader::magic).
+ *      current_buf_seq, total/dropped/mismatch counters, queue_tails,
+ *      free_queue.head, and the subsystem's device-written header fields).
  *   2. Pulls each popped buffer's contents from device via
  *      `copy_buffer_from_device` inside ProfilerAlgorithms::process_entry
  *      before delivering it to the collector.

--- a/src/common/platform/include/host/profiler_base.h
+++ b/src/common/platform/include/host/profiler_base.h
@@ -148,9 +148,9 @@
  *     `free_queue.tail` + `buffer_ptrs[]` after refill) back as narrow
  *     `write_range_to_device` writes. A bulk host→device write-back is
  *     intentionally avoided: it would race with AICPU writes to
- *     device-only fields (current_buf_ptr, total/dropped/mismatch
- *     counters, queue_tails, free_queue.head, and on a5
- *     ChipSwimlaneAicpuPhaseHeader::magic) and roll them back to the
+ *     device-only fields (current_buf_ptr, current_buf_seq,
+ *     total/dropped/mismatch counters, queue_tails, free_queue.head, and
+ *     the subsystem's device-written header fields) and roll them back to the
  *     host-shadow values mirrored in at the top of the tick. Buffer
  *     contents are mirrored on demand inside ProfilerAlgorithms.
  *   - On these platforms `reg` always allocates a paired host shadow; the

--- a/tests/ut/py/test_scene_test_cli_contract.py
+++ b/tests/ut/py/test_scene_test_cli_contract.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""CLI contracts shared by pytest and standalone SceneTest execution."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from simpler_setup import parallel_scheduler
+from simpler_setup.scene_test import SceneTestCase, _dispatch_test_phases_standalone, _effective_diagnostic_options
+
+
+def test_multi_rounds_disable_every_diagnostic() -> None:
+    options = _effective_diagnostic_options(
+        2,
+        chip_swimlane=4,
+        dump_args=3,
+        pmu=5,
+        dep_gen=True,
+        scope_stats=True,
+        swimlane_overhead=True,
+    )
+
+    assert options == (0, 0, 0, False, False, False)
+
+
+def test_swimlane_overhead_requires_chip_swimlane() -> None:
+    with pytest.raises(ValueError, match="requires --enable-chip-swimlane"):
+        _effective_diagnostic_options(
+            1,
+            chip_swimlane=0,
+            dump_args=0,
+            pmu=0,
+            dep_gen=False,
+            scope_stats=False,
+            swimlane_overhead=True,
+        )
+
+
+def test_pytest_front_end_reports_a_usage_error_not_a_test_failure() -> None:
+    conftest = importlib.import_module("conftest")
+    options = {"--enable-swimlane-overhead": True, "--enable-chip-swimlane": 0}
+    config = SimpleNamespace(getoption=lambda name, default=None: options.get(name, default))
+
+    with pytest.raises(pytest.UsageError, match="requires --enable-chip-swimlane"):
+        conftest._validate_diagnostic_flags(config)
+
+
+def test_dep_gen_extension_hook_uses_the_shared_multi_round_gate() -> None:
+    options = {"--rounds": 2, "--enable-dep-gen": True}
+    request = SimpleNamespace(config=SimpleNamespace(getoption=lambda name, default=None: options.get(name, default)))
+
+    assert not SceneTestCase._effective_enable_dep_gen(request)
+
+
+def test_standalone_dispatch_forwards_every_diagnostic_flag(monkeypatch) -> None:
+    scene_class = type("StandaloneDiagnosticScene", (), {"_st_level": 2, "_st_runtime": "tensormap_and_ringbuffer"})
+    args = SimpleNamespace(
+        platform="a2a3sim",
+        manual="exclude",
+        log_level="timing",
+        sanitizer="none",
+        rounds=1,
+        skip_golden=False,
+        enable_chip_swimlane=4,
+        dump_args=3,
+        enable_pmu=5,
+        enable_dep_gen=True,
+        enable_scope_stats=True,
+        enable_swimlane_overhead=True,
+        device_ids=[0, 1],
+        max_parallel=1,
+        exitfirst=False,
+        case=None,
+    )
+    commands = []
+
+    def fake_run_jobs(jobs, *_args, **_kwargs):
+        commands.extend(job.build_cmd([0]) for job in jobs)
+        return [SimpleNamespace(returncode=0) for _ in jobs]
+
+    monkeypatch.setattr(parallel_scheduler, "run_jobs", fake_run_jobs)
+
+    assert _dispatch_test_phases_standalone(__name__, {scene_class: [{}]}, args)
+    assert len(commands) == 1
+    command = commands[0]
+    assert command[command.index("--enable-chip-swimlane") + 1] == "4"
+    assert command[command.index("--dump-args") + 1] == "3"
+    assert command[command.index("--enable-pmu") + 1] == "5"
+    assert "--enable-dep-gen" in command
+    assert "--enable-scope-stats" in command
+    assert "--enable-swimlane-overhead" in command
+    assert command[0] == sys.executable


### PR DESCRIPTION
Closes #1796.

## Behavior

The `--rounds > 1` gate was written out three times — in `test_run`, in the standalone `main()`, and in `_effective_enable_dep_gen` — and the three copies disagreed:

- `test_run` never gated `--enable-swimlane-overhead`
- `main()` gated neither that nor `--enable-pmu`
- `_dispatch_test_phases_standalone` did not forward `--enable-pmu` to its children at all, so **PMU silently did nothing** under standalone multi-device dispatch

Both entry points now resolve their diagnostics through one `_effective_diagnostic_options` covering all six flags, so the two paths cannot drift again. This settles the contract the issue asked for: DFX is disabled outright when `--rounds > 1`, for both pytest and standalone.

Neither front-end could reject `--enable-swimlane-overhead` without `--enable-chip-swimlane`, a combination that can never produce the overhead tracks. `_validate_diagnostic_flags` holds that rule once; standalone reports it through `parser.error` and pytest through `pytest.UsageError`, so a usage mistake no longer fails every collected scene test. The standalone check runs before the eager PTO-ISA checkout, so a rejected combination costs no clone.

Everything outside those three files is comment-only: the five touched C++ headers change no code. In `chip_swimlane_profiling.h` the sole non-comment line is `constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 16384;`, whose value is unchanged — only its trailing comment.

## Documentation

Every row below was checked against the implementation, not carried over:

| Documented | Actual |
| --- | --- |
| `ChipSwimlaneAicpuTaskRecord` 64 B with `task_id` / `func_id` / `core_type` | `static_assert(... == 32)`; only `dispatch_time` / `finish_time` / `reg_task_id` |
| §5.2 diagram: AICPU fills `func_id` when committing the record | not in the record at all; resolved post-process by `swimlane_converter.py` from `deps.json`'s `kernel_ids[]` |
| Pool carries `aicore_ring_ptr`, `mismatch_record_count` | `ChipSwimlaneActiveHead` + `ChipSwimlaneFreeQueue`, 192 B; neither field exists |
| a5 "pre-split, pending port" + `ChipSwimlaneAicpuPhasePool` / `PhaseHeader` / `PHASE_MAGIC` | all three symbols removed; both arches use the split streams |
| Sched record: one per iteration, `kind ∈ {Complete, Dispatch}` | one per **emitted phase** — an iteration routinely emits several; `ChipSwimlaneSchedPhaseKind` has 13 values across outer / inner / separate-lane |
| Orch records counted from level 3 | `ChipSwimlaneLevel::ORCH_PHASES` (level 4) gates both the pool allocation and the device-side write; level 3 captures none |
| `collected + dropped + mismatch == device_total` | two-bucket check, per the code's own `Two-bucket invariant` comment |
| a5 `kBufferKinds = 2`, "2 kinds via `is_phase`" | shared collector under `src/common/platform/`, `kBufferKinds = 4` |
| a5 uses 7 collector shards | `kMaxCollectorThreads = PLATFORM_MAX_AICPU_THREADS` — 5 on a5, 4 on a2a3 |
| `get_chip_swimlane_shm_device_ptr` / `aicore_chip_swimlane_ring_addrs` / `get_aicore_ring_addrs_device_ptr` | `get_chip_swimlane_setup_device_ptr` / `chip_swimlane_aicore_rotation_table` / `get_aicore_ring_addr_table_device_ptr` |

Two corrections are worth calling out beyond the table.

**§5.3 contradicted §5.1 of the same document.** It claimed AICore writes into a stable `ChipSwimlaneAicoreRing` that never rotates. What is stable is the *head-slot address* — `chip_swimlane_aicore_rotation_table[block_idx]` holds `&ChipSwimlaneAicoreTaskPool::head` (filled by `chip_swimlane_aicpu_init`), and AICore dcci-polls it, picking up a new buffer whenever `current_buf_seq` bumps. `profiling-framework.md` §8.2 conflated this with PMU's genuine `PmuAicoreRing`; the two are now described separately, and that section is explicit that PMU's fixed address is a write target while ChipSwimlane's is only a read slot.

**§7.2 gave tuning advice that cannot work.** It said a5 drops tasks past `PLATFORM_PROF_BUFFER_SIZE` and told users to raise that constant. Buffers rotate, and the code marks that path unreachable:

```cpp
if (count >= PLATFORM_PROF_BUFFER_SIZE) {
    // Defensive: should not happen because we rotate at end of every commit.
```

Real drops come from an empty pool free queue (host has not refilled yet), a failed ready-queue enqueue, or AICore's own slot guard. The section now names those conditions and points tuning at pool depth and replenishment — `PLATFORM_PROF_BUFFERS_PER_CORE`, `PLATFORM_AICORE_BUFFERS_PER_CORE`, `PLATFORM_PROF_{SCHED,ORCH}_BUFFERS_PER_THREAD`, `PLATFORM_PROF_SLOT_COUNT`.

Smaller items: `PLATFORM_PHASE_RECORDS_PER_THREAD` is 16384 records of 64 B (sched) and 32 B (orch), so the buffers are 1 MiB and 512 KiB — the comment claimed 512 KiB for both. `cli.md` stated the multi-round restriction on only two of six diagnostic rows; it now carries one table-wide note.

The three `aicore_executor.cpp` comments named in the issue were already corrected upstream between `50c06606` and `f4ed1045`; this branch confirms no `set_aicore_chip_swimlane_ring` reference survives anywhere.

## Tests

`tests/ut/py/test_scene_test_cli_contract.py` pins the multi-round gate, the flag validation on both front-ends, and standalone child forwarding of every diagnostic flag — the drift guard the issue asked for. The forwarding case is the one that would have caught the missing `--enable-pmu`.

- Scene-test unit tests: 50 passed (`test_scene_test_cli_contract`, `test_scene_test_dep_gen_hook`, `test_manual_selection`, `test_scene_level_selection`)
- End-to-end: bad combination reports `ERROR: --enable-swimlane-overhead requires --enable-chip-swimlane`; valid combination collects normally
- pre-commit passes on the full change set (clang-format, clang-tidy, cpplint, markdownlint-cli2, ruff check/format, pyright)

Note: the full `tests/ut/py` run on my box has 55 failures + 29 collection errors, all from a stale `_task_interface` extension (built at `24107894789a`, tree at `f4ed1045`) and unrelated to this branch.
