### PR TITLE
CI: centralize bounded APT installation

### DIFF
--- a/.github/actions/apt-install/action.yml
+++ b/.github/actions/apt-install/action.yml
@@ -1,0 +1,191 @@
+name: Install APT packages
+description: Install required and optional packages with bounded, recoverable APT operations on Ubuntu runners.
+
+inputs:
+  required-packages:
+    description: Space-separated package names that must be installed.
+    required: false
+    default: ""
+  optional-packages:
+    description: Space-separated package names whose installation may fail without failing the caller.
+    required: false
+    default: ""
+  update-mode:
+    description: "none, system, or source-file. source-file refreshes only the supplied deb822 source."
+    required: false
+    default: none
+  source-file:
+    description: Deb822 .sources file to refresh when update-mode is source-file.
+    required: false
+    default: ""
+  update-attempts:
+    description: Number of bounded update attempts before installation proceeds from the existing indexes.
+    required: false
+    default: "1"
+  update-timeout-seconds:
+    description: Wall-clock bound for each apt-get update attempt.
+    required: false
+    default: "120"
+  install-timeout-seconds:
+    description: Wall-clock bound for each apt-get install invocation.
+    required: false
+    default: "240"
+  install-attempts:
+    description: Number of bounded install attempts before required packages fail.
+    required: false
+    default: "1"
+
+runs:
+  using: composite
+  steps:
+    - name: Install APT packages
+      shell: bash
+      env:
+        REQUIRED_PACKAGES: ${{ inputs.required-packages }}
+        OPTIONAL_PACKAGES: ${{ inputs.optional-packages }}
+        UPDATE_MODE: ${{ inputs.update-mode }}
+        SOURCE_FILE: ${{ inputs.source-file }}
+        UPDATE_ATTEMPTS: ${{ inputs.update-attempts }}
+        UPDATE_TIMEOUT_SECONDS: ${{ inputs.update-timeout-seconds }}
+        INSTALL_ATTEMPTS: ${{ inputs.install-attempts }}
+        INSTALL_TIMEOUT_SECONDS: ${{ inputs.install-timeout-seconds }}
+      run: |
+        set -euo pipefail
+
+        if ! command -v apt-get >/dev/null 2>&1; then
+          echo "::error::apt-install requires an apt-based runner"
+          exit 1
+        fi
+
+        apt_options=(
+          -o Acquire::Retries=0
+          -o Acquire::http::Timeout=20
+          -o Acquire::https::Timeout=20
+        )
+        update_options=()
+        sourceparts_dir=""
+
+        cleanup_sourceparts() {
+          if [[ -n "$sourceparts_dir" ]]; then
+            rm -rf "$sourceparts_dir"
+          fi
+        }
+        trap cleanup_sourceparts EXIT
+
+        is_positive_integer() {
+          [[ "$1" =~ ^[1-9][0-9]*$ ]]
+        }
+
+        for value in "$UPDATE_ATTEMPTS" "$UPDATE_TIMEOUT_SECONDS" "$INSTALL_ATTEMPTS" "$INSTALL_TIMEOUT_SECONDS"; do
+          if ! is_positive_integer "$value"; then
+            echo "::error::APT attempt counts and timeouts must be positive integers"
+            exit 1
+          fi
+        done
+        case "$UPDATE_MODE" in
+          none|system)
+            ;;
+          source-file)
+            if [[ -z "$SOURCE_FILE" || ! -f "$SOURCE_FILE" || "${SOURCE_FILE##*.}" != sources ]]; then
+              echo "::error::source-file update mode requires a readable .sources file"
+              exit 1
+            fi
+            ;;
+          *)
+            echo "::error::unknown update mode: $UPDATE_MODE"
+            exit 1
+            ;;
+        esac
+
+        configure_update() {
+          local mode="$1"
+          update_options=()
+          case "$mode" in
+            none|system)
+              ;;
+            source-file)
+              if [[ -z "$sourceparts_dir" ]]; then
+                sourceparts_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/apt-install-sources.XXXXXX")"
+                install -m 0644 "$SOURCE_FILE" "$sourceparts_dir/${SOURCE_FILE##*/}"
+              fi
+              update_options=(
+                -o Dir::Etc::SourceList=/dev/null
+                -o "Dir::Etc::SourceParts=$sourceparts_dir"
+                -o APT::Get::List-Cleanup=0
+              )
+              ;;
+          esac
+        }
+
+        recover_apt() {
+          sudo rm -rf /var/lib/apt/lists/partial
+          sudo DEBIAN_FRONTEND=noninteractive timeout --kill-after=15s 60s dpkg --configure -a || true
+        }
+
+        run_update() {
+          local mode="$1"
+          local attempts="$2"
+          local attempt
+          local -a update_command
+          update_command=(apt-get "${apt_options[@]}")
+          configure_update "$mode"
+          if [[ "$mode" == none ]]; then
+            return 0
+          fi
+          if [[ "$mode" == source-file ]]; then
+            update_command+=("${update_options[@]}")
+          fi
+          for ((attempt = 1; attempt <= attempts; ++attempt)); do
+            if sudo DEBIAN_FRONTEND=noninteractive timeout --kill-after=15s "${UPDATE_TIMEOUT_SECONDS}s" \
+              "${update_command[@]}" update; then
+              return 0
+            fi
+            recover_apt
+            echo "::warning::apt-get $mode update attempt ${attempt}/${attempts} failed; using existing package indexes"
+          done
+          return 1
+        }
+
+        install_packages_once() {
+          if (( $# == 0 )); then
+            return 0
+          fi
+          sudo DEBIAN_FRONTEND=noninteractive timeout --kill-after=15s "${INSTALL_TIMEOUT_SECONDS}s" \
+            apt-get "${apt_options[@]}" install -y "$@"
+        }
+
+        install_required_packages() {
+          local attempt
+          for ((attempt = 1; attempt <= INSTALL_ATTEMPTS; ++attempt)); do
+            if install_packages_once "$@"; then
+              return 0
+            fi
+            recover_apt
+            echo "::warning::apt required-package install attempt ${attempt}/${INSTALL_ATTEMPTS} failed"
+          done
+          if [[ "$UPDATE_MODE" == none ]]; then
+            echo "::warning::apt install failed on cached indexes; refreshing system indexes once"
+            run_update system 1 || true
+            if install_packages_once "$@"; then
+              return 0
+            fi
+            recover_apt
+          fi
+          echo "::error::apt could not install $*"
+          return 1
+        }
+
+        install_optional_packages() {
+          if install_packages_once "$@"; then
+            return 0
+          fi
+          recover_apt
+          echo "::warning::apt could not install $*"
+          return 1
+        }
+
+        read -r -a required_packages <<<"$REQUIRED_PACKAGES"
+        read -r -a optional_packages <<<"$OPTIONAL_PACKAGES"
+        run_update "$UPDATE_MODE" "$UPDATE_ATTEMPTS" || true
+        install_required_packages "${required_packages[@]}"
+        install_optional_packages "${optional_packages[@]}" || true

--- a/.github/actions/setup-gcc-15/action.yml
+++ b/.github/actions/setup-gcc-15/action.yml
@@ -16,7 +16,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install GCC 15 and build tools
+    - name: Prepare GCC 15 and build tools
+      id: packages
       if: runner.os == 'Linux'
       shell: bash
       env:
@@ -88,14 +89,42 @@ runs:
               sudo tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.sources >/dev/null
           fi
 
-          apt_options=(
-            -o Acquire::Retries=3
-            -o Acquire::http::Timeout=20
-            -o Acquire::https::Timeout=20
-          )
-          sudo apt-get "${apt_options[@]}" update
-          sudo apt-get "${apt_options[@]}" install -y "${packages[@]}"
+          if [[ "$needs_gcc_ppa" == true ]]; then
+            echo "update-mode=source-file" >> "$GITHUB_OUTPUT"
+            echo "source-file=/etc/apt/sources.list.d/ubuntu-toolchain-r-test.sources" >> "$GITHUB_OUTPUT"
+            echo "update-attempts=2" >> "$GITHUB_OUTPUT"
+            echo "install-attempts=2" >> "$GITHUB_OUTPUT"
+          else
+            echo "update-mode=none" >> "$GITHUB_OUTPUT"
+            echo "source-file=" >> "$GITHUB_OUTPUT"
+            echo "update-attempts=1" >> "$GITHUB_OUTPUT"
+            echo "install-attempts=1" >> "$GITHUB_OUTPUT"
+          fi
+          echo "required-packages=${packages[*]}" >> "$GITHUB_OUTPUT"
         fi
+
+    - name: Install GCC 15 and build tools
+      if: runner.os == 'Linux' && steps.packages.outputs.required-packages != ''
+      uses: ./.github/actions/apt-install
+      with:
+        required-packages: ${{ steps.packages.outputs.required-packages }}
+        update-mode: ${{ steps.packages.outputs.update-mode }}
+        source-file: ${{ steps.packages.outputs.source-file }}
+        update-attempts: ${{ steps.packages.outputs.update-attempts }}
+        update-timeout-seconds: "60"
+        install-timeout-seconds: "240"
+        install-attempts: ${{ steps.packages.outputs.install-attempts }}
+
+    - name: Verify GCC 15 and build tools
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        is_version_15() {
+          command -v "$1" >/dev/null 2>&1 &&
+            [[ "$("$1" -dumpversion | cut -d. -f1)" == 15 ]]
+        }
 
         command -v gcc-15
         command -v g++-15

--- a/.github/workflows/_packaging.yml
+++ b/.github/workflows/_packaging.yml
@@ -38,26 +38,40 @@ jobs:
           persist-credentials: false
 
       - name: Set up C++ compiler
+        id: packaging-tools
         if: inputs.setup_variant == 'github'
         run: |
+          # ninja arrives from PyPI with the venv, so the only package a
+          # packaging build cannot proceed without is a host compiler. ccache
+          # merely warms the matrix's later modes and the matrix step already
+          # runs without it, so a package manager that cannot serve it is a
+          # warning, not a failure.
           if [[ "${{ runner.os }}" == "Linux" ]]; then
-            missing_packages=()
-            command -v ninja >/dev/null 2>&1 || missing_packages+=(ninja-build)
-            command -v ccache >/dev/null 2>&1 || missing_packages+=(ccache)
+            required_packages=()
             if ! command -v gcc >/dev/null 2>&1 || ! command -v g++ >/dev/null 2>&1; then
-              missing_packages+=(g++)
+              required_packages+=(g++)
             fi
-            if (( ${#missing_packages[@]} )); then
-              sudo apt-get update
-              sudo apt-get install -y "${missing_packages[@]}"
-            fi
+            optional_packages=()
+            command -v ccache >/dev/null 2>&1 || optional_packages+=(ccache)
+            echo "required-packages=${required_packages[*]}" >> "$GITHUB_OUTPUT"
+            echo "optional-packages=${optional_packages[*]}" >> "$GITHUB_OUTPUT"
           else
-            command -v ninja >/dev/null 2>&1 || brew install ninja
-            command -v ccache >/dev/null 2>&1 || brew install ccache
+            if ! command -v ccache >/dev/null 2>&1; then
+              brew install ccache ||
+                echo "::warning::brew could not install ccache; continuing without it"
+            fi
             if ! command -v gcc-15 >/dev/null 2>&1 || ! command -v g++-15 >/dev/null 2>&1; then
               brew install gcc@15 || brew install gcc
             fi
           fi
+
+      - name: Install Linux C++ compiler tools
+        if: inputs.setup_variant == 'github' && runner.os == 'Linux' && (steps.packaging-tools.outputs.required-packages != '' || steps.packaging-tools.outputs.optional-packages != '')
+        uses: ./.github/actions/apt-install
+        with:
+          required-packages: ${{ steps.packaging-tools.outputs.required-packages }}
+          optional-packages: ${{ steps.packaging-tools.outputs.optional-packages }}
+          install-timeout-seconds: "240"
 
       - name: Set up Python ${{ inputs.python_version }}
         if: inputs.setup_variant == 'github'
@@ -72,7 +86,7 @@ jobs:
       - name: Install build + runtime deps in venv
         uses: ./.github/actions/setup-venv
         with:
-          packages: "scikit-build-core>=0.10.0 nanobind>=2.0.0 cmake>=3.15 pytest>=6.0"
+          packages: "scikit-build-core>=0.10.0 nanobind>=2.0.0 cmake>=3.15 ninja>=1.11 pytest>=6.0"
 
       - name: Run packaging matrix
         run: |

--- a/.github/workflows/_pre-commit.yml
+++ b/.github/workflows/_pre-commit.yml
@@ -84,7 +84,8 @@ jobs:
 
           echo "needs_build=$needs_build" >> "$GITHUB_OUTPUT"
 
-      - name: Install build and lint tools
+      - name: Find missing build and lint tools
+        id: apt-packages
         if: inputs.setup_variant == 'github' && steps.lint-build.outputs.needs_build == 'true'
         run: |
           missing_packages=()
@@ -94,10 +95,14 @@ jobs:
           if ! command -v clang-tidy >/dev/null 2>&1; then
             missing_packages+=(clang-tidy)
           fi
-          if (( ${#missing_packages[@]} )); then
-            sudo apt-get update
-            sudo apt-get install -y "${missing_packages[@]}"
-          fi
+          echo "required-packages=${missing_packages[*]}" >> "$GITHUB_OUTPUT"
+
+      - name: Install build and lint tools
+        if: inputs.setup_variant == 'github' && runner.os == 'Linux' && steps.lint-build.outputs.needs_build == 'true' && steps.apt-packages.outputs.required-packages != ''
+        uses: ./.github/actions/apt-install
+        with:
+          required-packages: ${{ steps.apt-packages.outputs.required-packages }}
+          install-timeout-seconds: "240"
 
       - name: Verify provisioned toolchain
         if: inputs.setup_variant == 'self-cpu' && steps.lint-build.outputs.needs_build == 'true'

--- a/.github/workflows/_ut-no-hardware.yml
+++ b/.github/workflows/_ut-no-hardware.yml
@@ -45,14 +45,15 @@ jobs:
           python-version: ${{ inputs.python_version }}
 
       - name: Install GoogleTest
-        if: inputs.setup_variant == 'github'
-        run: |
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
-            sudo apt-get update
-            sudo apt-get install -y libgtest-dev
-          else
-            brew install googletest
-          fi
+        if: inputs.setup_variant == 'github' && runner.os == 'Linux'
+        uses: ./.github/actions/apt-install
+        with:
+          required-packages: libgtest-dev
+          install-timeout-seconds: "240"
+
+      - name: Install GoogleTest on macOS
+        if: inputs.setup_variant == 'github' && runner.os != 'Linux'
+        run: brew install googletest
 
       - name: Cache pip packages
         uses: ./.github/actions/cache-pip

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -34,13 +34,27 @@ shape. The executable job bodies live in reusable workflows:
 NPU unit-test bodies are split one workflow per architecture so each job
 renders only its own steps. Shared step scaffolding that is safe to run
 after checkout lives in composite actions under `.github/actions/`
-(`cache-pip`, `setup-gcc-15`, `setup-venv`, and the three `network1-*` actions).
+(`apt-install`, `cache-pip`, `setup-gcc-15`, `setup-venv`, and the three `network1-*` actions).
 `setup-gcc-15` accepts a complete, pre-provisioned GCC 15 toolchain on any
 Linux runner; automatic installation of missing Linux tools is Ubuntu-only,
 while macOS installation uses Homebrew. `_packaging.yml` deliberately retains
 its separate compiler setup: Linux packaging accepts the platform compiler and
 also installs ccache, while its macOS fallback is outside the shared action's
-strict GCC 15 contract.
+strict GCC 15 contract. Only the compiler is required there — ninja comes from
+PyPI with the venv, and both the workflow and `tools/verify_packaging.sh` run
+without ccache — so a package manager that cannot serve ccache emits a warning
+and the job continues. `apt-install` gives every apt operation a wall-clock
+bound and attempts to repair an interrupted dpkg transaction before another apt
+operation can run. It uses the runner's existing package indexes by default, avoiding a
+full mirror refresh for ordinary CI dependencies. `setup-gcc-15` is the one
+exception: after installing its pinned Toolchain PPA source, it refreshes only
+that `.sources` file, retrying a failed refresh once with a 60-second bound per
+attempt. That isolated refresh disables list cleanup, preserving the runner's
+Ubuntu indexes for the following install. A failed refresh is a warning; the
+required package install, bounded at four minutes and retried once for this
+PPA workload, decides whether the job can continue. An install from cached
+indexes that fails receives one bounded system-refresh retry. The acquire
+timeouts remain a per-connection safeguard, not a wall-clock guarantee.
 
 ```text
 PullRequest
@@ -284,7 +298,7 @@ queueing entirely:
   where the main CI passes `setup_variant=github` and GitHub-hosted runners.
   Gate outputs still come from the canonical `detect-changes` workflow, executed
   on `[self-hosted, cpu]` in this lane.
-- **cpu runner contract**: dnf-installed `cmake ninja-build gcc-c++ clang-tools-extra graphviz gtest-devel python3-devel`, plus a pip-installable torch aarch64 CPU wheel. When the pre-commit selector requests clang-tidy preparation — for eligible C/C++, `.pre-commit-config.yaml`, or an unknown path — the job creates `g++-15` as a stand-in for the Ubuntu Toolchain PPA compiler. On the agents `g++` resolves to a conda GCC 15 prefix rather than `/usr/bin/g++`, so that diff's sim artifacts are built with GCC 15 and `compile_commands.json` names that prefix's `<triple>-g++`; `tests/lint/clang_tidy.py` drops the triple before replaying a command, without which clang-tidy adopts it as a target and resolves no C++ standard library at all. `ci.yml` lints with clang-tidy 18 and HCE 2.0 packages only LLVM 12, so an agent additionally provides 18 on `PATH` as `clang-tidy-18`, installed together with its clang builtin headers — a clang-tidy whose prefix carries no `lib/clang/<major>/include` resolves no resource dir and fails every `#include <stddef.h>`. The pre-commit job shadows the distro `clang-tidy` only on that build path; Python-only and other lint-only diffs do not build sim artifacts or create either compiler shim.
+- **cpu runner contract**: dnf-installed `cmake ninja-build gcc-c++ clang-tools-extra graphviz gtest-devel python3-devel`, plus a pip-installable torch aarch64 CPU wheel. `setup-venv` installs a PyPI `ninja` into the venv on every lane, which shadows the dnf-provided `ninja-build` on `PATH` whenever the venv is active — deliberately, so CMake's generator selection is identical on this lane and on the github-hosted ones. Same tool, different provenance; the dnf package stays in the contract for builds that run outside the venv. When the pre-commit selector requests clang-tidy preparation — for eligible C/C++, `.pre-commit-config.yaml`, or an unknown path — the job creates `g++-15` as a stand-in for the Ubuntu Toolchain PPA compiler. On the agents `g++` resolves to a conda GCC 15 prefix rather than `/usr/bin/g++`, so that diff's sim artifacts are built with GCC 15 and `compile_commands.json` names that prefix's `<triple>-g++`; `tests/lint/clang_tidy.py` drops the triple before replaying a command, without which clang-tidy adopts it as a target and resolves no C++ standard library at all. `ci.yml` lints with clang-tidy 18 and HCE 2.0 packages only LLVM 12, so an agent additionally provides 18 on `PATH` as `clang-tidy-18`, installed together with its clang builtin headers — a clang-tidy whose prefix carries no `lib/clang/<major>/include` resolves no resource dir and fails every `#include <stddef.h>`. The pre-commit job shadows the distro `clang-tidy` only on that build path; Python-only and other lint-only diffs do not build sim artifacts or create either compiler shim.
 - The lane run is standalone — it attaches no checks to the PR; results are read from the run.
 
 ## Hardware Classification

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,7 +108,7 @@ All workflows assume an activated project-local venv (see [`.claude/rules/venv-i
 python3 -m venv --system-site-packages .venv
 source .venv/bin/activate
 pip install --no-build-isolation \
-  'scikit-build-core>=0.10.0' 'nanobind>=2.0.0' 'cmake>=3.15' 'pytest>=6.0' 'torch>=2.3'
+  'scikit-build-core>=0.10.0' 'nanobind>=2.0.0' 'cmake>=3.15' 'ninja>=1.11' 'pytest>=6.0' 'torch>=2.3'
 pip install --no-build-isolation -e .
 ```
 

--- a/docs/python-packaging.md
+++ b/docs/python-packaging.md
@@ -123,7 +123,7 @@ For developers who don't want to use pip at all:
 
 ```bash
 . .venv/bin/activate
-pip install 'scikit-build-core>=0.10.0' 'nanobind>=2.0.0' 'cmake>=3.15' 'pytest>=6.0' 'torch>=2.3'  # one-time
+pip install 'scikit-build-core>=0.10.0' 'nanobind>=2.0.0' 'cmake>=3.15' 'ninja>=1.11' 'pytest>=6.0' 'torch>=2.3'  # one-time
 cmake -S . -B build/cmake_only -Dnanobind_DIR=$(python -c 'import nanobind; print(nanobind.cmake_dir())')
 cmake --build build/cmake_only
 export PYTHONPATH=$(pwd):$(pwd)/python
@@ -158,7 +158,7 @@ Any change that touches:
 ```bash
 # Locally — same script CI runs.
 source .venv/bin/activate
-pip install 'scikit-build-core>=0.10.0' 'nanobind>=2.0.0' 'cmake>=3.15' 'pytest>=6.0' 'torch>=2.3'  # one-time
+pip install 'scikit-build-core>=0.10.0' 'nanobind>=2.0.0' 'cmake>=3.15' 'ninja>=1.11' 'pytest>=6.0' 'torch>=2.3'  # one-time
 bash tools/verify_packaging.sh
 ```
 

--- a/tests/ut/py/test_gcc_setup_action.py
+++ b/tests/ut/py/test_gcc_setup_action.py
@@ -18,6 +18,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).parents[3]
 ACTION_PATH = REPO_ROOT / ".github/actions/setup-gcc-15/action.yml"
+APT_ACTION_PATH = REPO_ROOT / ".github/actions/apt-install/action.yml"
 PPA_KEY_PATH = REPO_ROOT / ".github/actions/setup-gcc-15/ubuntu-toolchain-r-test.asc"
 SETUP_ACTION = "./.github/actions/setup-gcc-15"
 WORKFLOW_PATHS = (
@@ -56,6 +57,11 @@ def _named_step(path: Path, name: str) -> dict[str, Any]:
 def _action_script(condition: str) -> str:
     action = _load_yaml(ACTION_PATH)
     return next(step["run"] for step in action["runs"]["steps"] if step.get("if") == condition)
+
+
+def _apt_action_script() -> str:
+    action = _load_yaml(APT_ACTION_PATH)
+    return action["runs"]["steps"][0]["run"]
 
 
 def _write_command(path: Path, body: str = "exit 0") -> None:
@@ -132,6 +138,234 @@ def test_linux_branch_installs_only_missing_tools_on_ubuntu_and_pins_the_ppa_key
     assert "${{ github.action_path }}/ubuntu-toolchain-r-test.asc" in script
     assert ': "${VERSION_CODENAME:?Ubuntu /etc/os-release must define VERSION_CODENAME}"' in script
     assert "Signed-By: /etc/apt/keyrings/ubuntu-toolchain-r-test.gpg $EXPECTED_PPA_FINGERPRINT" in script
+
+
+def test_apt_install_preserves_system_indexes_for_ppa_only_refresh_and_recovers_interrupted_installs() -> None:
+    action = _load_yaml(APT_ACTION_PATH)
+    script = action["runs"]["steps"][0]["run"]
+
+    assert action["inputs"]["update-mode"]["default"] == "none"
+    assert "Dir::Etc::SourceList=/dev/null" in script
+    assert "Dir::Etc::SourceParts=$sourceparts_dir" in script
+    assert "APT::Get::List-Cleanup=0" in script
+    assert "timeout --kill-after=15s" in script
+    assert "dpkg --configure -a" in script
+    assert "Acquire::Retries=0" in script
+    assert "sudo DEBIAN_FRONTEND=noninteractive timeout" in script
+    assert "apt install failed on cached indexes; refreshing system indexes once" in script
+    assert "run_update system 1" in script
+    assert "${{ inputs." not in script
+
+
+def test_apt_install_refreshes_the_system_index_after_a_cached_install_failure(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "apt.log"
+    install_marker = tmp_path / "install-attempted"
+    _write_command(
+        bin_dir / "sudo",
+        '''case "$1" in
+  DEBIAN_FRONTEND=*) export "$1"; shift ;;
+esac
+case "$1" in
+  rm|dpkg) exit 0 ;;
+esac
+exec "$@"''',
+    )
+    _write_command(bin_dir / "timeout", 'shift\nshift\nexec "$@"')
+    _write_command(
+        bin_dir / "apt-get",
+        """echo "$*" >> "$APT_LOG"
+if [ ! -e "$APT_INSTALL_MARKER" ]; then
+  : > "$APT_INSTALL_MARKER"
+  exit 1
+fi""",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "APT_INSTALL_MARKER": str(install_marker),
+            "APT_LOG": str(log_path),
+            "INSTALL_ATTEMPTS": "1",
+            "INSTALL_TIMEOUT_SECONDS": "240",
+            "OPTIONAL_PACKAGES": "",
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "REQUIRED_PACKAGES": "libgtest-dev",
+            "RUNNER_TEMP": str(tmp_path),
+            "SOURCE_FILE": "",
+            "UPDATE_ATTEMPTS": "1",
+            "UPDATE_MODE": "none",
+            "UPDATE_TIMEOUT_SECONDS": "120",
+        }
+    )
+    result = subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", _apt_action_script()],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    commands = log_path.read_text().splitlines()
+    assert "install" in commands[0]
+    assert "update" in commands[1]
+    assert "install" in commands[2]
+
+
+def test_apt_install_retries_a_required_install_before_refreshing_indexes(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "apt.log"
+    install_marker = tmp_path / "install-attempted"
+    _write_command(
+        bin_dir / "sudo",
+        '''case "$1" in
+  DEBIAN_FRONTEND=*) export "$1"; shift ;;
+esac
+case "$1" in
+  rm|dpkg) exit 0 ;;
+esac
+exec "$@"''',
+    )
+    _write_command(bin_dir / "timeout", 'shift\nshift\nexec "$@"')
+    _write_command(
+        bin_dir / "apt-get",
+        """echo "$*" >> "$APT_LOG"
+if [ ! -e "$APT_INSTALL_MARKER" ]; then
+  : > "$APT_INSTALL_MARKER"
+  exit 1
+fi""",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "APT_INSTALL_MARKER": str(install_marker),
+            "APT_LOG": str(log_path),
+            "INSTALL_ATTEMPTS": "2",
+            "INSTALL_TIMEOUT_SECONDS": "240",
+            "OPTIONAL_PACKAGES": "",
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "REQUIRED_PACKAGES": "g++-15",
+            "RUNNER_TEMP": str(tmp_path),
+            "SOURCE_FILE": "",
+            "UPDATE_ATTEMPTS": "1",
+            "UPDATE_MODE": "none",
+            "UPDATE_TIMEOUT_SECONDS": "120",
+        }
+    )
+    result = subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", _apt_action_script()],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    commands = log_path.read_text().splitlines()
+    assert len(commands) == 2
+    assert all("install" in command for command in commands)
+
+
+def test_apt_install_rejects_invalid_input_before_running_apt(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    apt_called = tmp_path / "apt-called"
+    _write_command(bin_dir / "apt-get", f': > "{apt_called}"')
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "INSTALL_ATTEMPTS": "1",
+            "INSTALL_TIMEOUT_SECONDS": "240",
+            "OPTIONAL_PACKAGES": "",
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "REQUIRED_PACKAGES": "libgtest-dev",
+            "RUNNER_TEMP": str(tmp_path),
+            "SOURCE_FILE": "",
+            "UPDATE_ATTEMPTS": "zero",
+            "UPDATE_MODE": "none",
+            "UPDATE_TIMEOUT_SECONDS": "120",
+        }
+    )
+    result = subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", _apt_action_script()],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "must be positive integers" in result.stdout + result.stderr
+    assert not apt_called.exists()
+
+
+def test_apt_install_source_file_update_uses_only_the_requested_source(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "apt.log"
+    source_file = tmp_path / "toolchain.sources"
+    source_file.write_text("Types: deb\nURIs: https://example.invalid/apt\nSuites: noble\nComponents: main\n")
+    _write_command(
+        bin_dir / "sudo",
+        '''case "$1" in
+  DEBIAN_FRONTEND=*) export "$1"; shift ;;
+esac
+case "$1" in
+  rm|dpkg) exit 0 ;;
+esac
+exec "$@"''',
+    )
+    _write_command(bin_dir / "timeout", 'shift\nshift\nexec "$@"')
+    _write_command(bin_dir / "apt-get", 'echo "$*" >> "$APT_LOG"')
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "APT_LOG": str(log_path),
+            "INSTALL_ATTEMPTS": "1",
+            "INSTALL_TIMEOUT_SECONDS": "240",
+            "OPTIONAL_PACKAGES": "",
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "REQUIRED_PACKAGES": "",
+            "RUNNER_TEMP": str(tmp_path),
+            "SOURCE_FILE": str(source_file),
+            "UPDATE_ATTEMPTS": "1",
+            "UPDATE_MODE": "source-file",
+            "UPDATE_TIMEOUT_SECONDS": "60",
+        }
+    )
+    result = subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", _apt_action_script()],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    command = log_path.read_text()
+    assert "Dir::Etc::SourceList=/dev/null" in command
+    assert "Dir::Etc::SourceParts=" in command
+    assert "APT::Get::List-Cleanup=0" in command
+    assert command.rstrip().endswith("update")
+
+
+@pytest.mark.parametrize(
+    "workflow_name, step_name",
+    [
+        ("_packaging.yml", "Install Linux C++ compiler tools"),
+        ("_pre-commit.yml", "Install build and lint tools"),
+        ("_ut-no-hardware.yml", "Install GoogleTest"),
+    ],
+)
+def test_workflow_apt_sites_use_the_shared_action(workflow_name: str, step_name: str) -> None:
+    step = _named_step(REPO_ROOT / ".github/workflows" / workflow_name, step_name)
+    assert step["uses"] == "./.github/actions/apt-install"
 
 
 def test_vendored_ppa_key_has_exactly_one_expected_primary_key() -> None:
@@ -291,6 +525,6 @@ def test_self_cpu_scene_tests_preserve_the_preprovisioned_compiler_contract(tmp_
     assert (runner_temp / "bin/g++-15").resolve() == bin_dir / "g++"
 
 
-@pytest.mark.parametrize("path", (ACTION_PATH, *WORKFLOW_PATHS), ids=lambda path: path.name)
+@pytest.mark.parametrize("path", (ACTION_PATH, APT_ACTION_PATH, *WORKFLOW_PATHS), ids=lambda path: path.name)
 def test_changed_action_and_workflows_are_valid_yaml(path: Path) -> None:
     _load_yaml(path)

--- a/tests/ut/py/test_pre_commit_build_selection.py
+++ b/tests/ut/py/test_pre_commit_build_selection.py
@@ -11,7 +11,6 @@ import importlib.util
 import os
 import subprocess
 import sys
-import textwrap
 from pathlib import Path
 
 import pytest
@@ -45,13 +44,9 @@ def _load_clang_tidy_module(monkeypatch):
 
 
 def _selection_script() -> str:
-    workflow = WORKFLOW.read_text()
-    start = "      - name: Select lint build target\n"
-    end = "\n      - name: Install build and lint tools\n"
-    assert workflow.count(start) == 1
-    block = workflow.split(start, 1)[1].split(end, 1)[0]
-    run = block.split("        run: |\n", 1)[1]
-    return textwrap.dedent(run)
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    steps = workflow["jobs"]["run"]["steps"]
+    return next(step["run"] for step in steps if step.get("name") == "Select lint build target")
 
 
 def _commit(repo: Path, relative_path: str, contents: str) -> str:

--- a/tools/verify_packaging.sh
+++ b/tools/verify_packaging.sh
@@ -142,7 +142,7 @@ else:
     print("ninja executable: not found; CMake will select another generator")
 PY
     echo "ERROR: venv missing or has unsupported packaging dependencies. Install with:" >&2
-    echo "  pip install 'scikit-build-core>=0.10.0' 'nanobind>=2.0.0' 'cmake>=3.15' 'pytest>=6.0' 'torch>=2.3'" >&2
+    echo "  pip install 'scikit-build-core>=0.10.0' 'nanobind>=2.0.0' 'cmake>=3.15' 'ninja>=1.11' 'pytest>=6.0' 'torch>=2.3'" >&2
     exit 1
 }
 


### PR DESCRIPTION
## Problem

`packaging-matrix` could remain in **Set up C++ compiler** until the job's
60-minute limit when an Ubuntu package mirror stalled. The mirror instability
predates this change; #1805 did not create it, but its packaging-tool setup
introduced unbounded `apt-get update` and `apt-get install` calls that exposed
the job to it.

Of the OS packages installed there, only the host compiler is required.
`ccache` is an optimization and the packaging matrix already supports running
without it. `ninja` can be installed with the Python build dependencies instead
of requiring another system-package install.

## Changes

- Add a shared `apt-install` composite action for required and optional
  packages. Every update, install, and dpkg recovery operation has a wall-clock
  bound; interrupted state is cleaned up before retrying.
- Reuse the runner's cached package indexes by default in packaging,
  pre-commit, and no-hardware UT. If a required install fails, refresh the
  system indexes once and retry the install.
- Refresh only the Ubuntu Toolchain PPA source in `setup-gcc-15`, preserving
  the runner's existing Ubuntu indexes. The PPA update and required install
  each receive one retry.
- Treat `ccache` as optional in packaging: an APT or Homebrew failure emits a
  warning and the matrix continues without compiler caching.
- Install `ninja>=1.11` with the venv and update the packaging documentation and
  verification hint accordingly.
- Add regression coverage for the shared action and workflow wiring, including
  Bash 3.2 compatibility used by macOS runners.

## Bounds

| Operation | Policy |
| --- | --- |
| APT connection | 20-second HTTP/HTTPS timeout, no internal APT retry |
| Regular required install | 240 seconds; on failure, one 120-second system-index refresh and one final install |
| GCC PPA refresh | Up to two 60-second attempts, limited to the PPA `.sources` file |
| GCC required install | Up to two 240-second attempts |
| dpkg recovery | 60 seconds, then a 15-second kill grace period |

These are per-operation bounds. No job-level `timeout-minutes` value is changed.

## Testing

- All pre-commit hooks passed locally and in CI.
- Focused APT-action regression tests passed on Ubuntu and macOS.
- Packaging and no-hardware UT passed on both Ubuntu and macOS in
  [CI run 32325726639](https://github.com/hw-native-sys/simpler/actions/runs/32325726639).
