### PR TITLE
Name L3 by its topology position, not by the processor it runs on

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -714,7 +714,7 @@ def pytest_collection_modifyitems(session, config, items):  # noqa: PLR0912
         l3_items = [
             i
             for i in items
-            if _item_scene_level(i) == SceneTestLevel.HOST and not any(m.name == "skip" for m in i.iter_markers())
+            if _item_scene_level(i) == SceneTestLevel.NODE and not any(m.name == "skip" for m in i.iter_markers())
         ]
         if l3_items:
             sample = ", ".join(sorted({i.nodeid for i in l3_items})[:3])
@@ -1137,7 +1137,7 @@ def pytest_runtestloop(session):
     # levels the dispatcher itself uses for children, it wants direct control.
     if runtime_filter is not None:
         return
-    if _normalize_cli_scene_level(level_filter) in (SceneTestLevel.CHIP, SceneTestLevel.HOST):
+    if _normalize_cli_scene_level(level_filter) in (SceneTestLevel.CHIP, SceneTestLevel.NODE):
         return
 
     # User explicitly asked for collect-only / scoped-run — don't orchestrate.

--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -123,13 +123,14 @@ including time the caller spends polling or doing other host work; blocking
 Every hierarchical worker that drives next-level children emits these spans
 through the logger compiled into `_task_interface`, since the orchestrator and
 scheduler code they run is the same at every level above the chip. **The leading
-word names the level that emitted them**, so `<level>` below is one of `host`
+word names the level that emitted them**, so `<level>` below is one of `node`
 (L3), `network1` (L4), `network2` (L5) or `network3` (L6) — see
 [`python/simpler/worker_level.py`](../../python/simpler/worker_level.py) for the
-ladder:
+ladder. It is never `host`: that names the *processor* this span ABI belongs to,
+which every one of those levels runs on:
 
-| Span | Host decision point |
-| ---- | ------------------- |
+| Span | Decision point |
+| ---- | -------------- |
 | `<level>.graph_build` | serialized Python graph callback |
 | `<level>.submit` | next-level task publication after slot allocation |
 | `<level>.dispatch` | scheduler handoff to a worker thread |
@@ -268,7 +269,7 @@ tree, and the root span already carries the identity that tells two runs apart.
 
 Only `claim_release` was added for this: it wraps `release_native_run` inside
 finalize, the point a successor's launch becomes admissible, and no other span
-marks that boundary. `host.post_fence_retirement` covers the L3 orchestrator's
+marks that boundary. `node.post_fence_retirement` covers the L3 orchestrator's
 `release_run` tail for the same reason.
 
 The identity is `run_id / dispatch_id / run_epoch / slot_id / generation`. Each

--- a/docs/hierarchical-level-runtime.md
+++ b/docs/hierarchical-level-runtime.md
@@ -35,16 +35,23 @@ NPU clusters:
 L6  network3  / CLOS2 / Cluster    ── full cluster (N6 super-nodes)
 L5  network2  / CLOS1 / SuperNode  ── super-node (N5 pods)
 L4  network1  / POD   / Pod        ── pod (4 hosts)
-L3  host      / HOST  / Node       ── single host machine (16 chips + M SubWorkers)
+L3  node      / HOST  / Node       ── single host machine (16 chips + M SubWorkers)
 L2  chip      / CHIP  / Processor  ── one NPU chip (shared device memory)
 L1  —         / DIE   / L2Cache    ── chip die (hardware-managed)
 L0  core      / CORE  / AIV, AIC   ── individual compute core (hardware-managed)
 ```
 
-The first column is the level word the code uses — `WorkerLevel` in
+The first column is the level word **this code** uses — `WorkerLevel` in
 [`python/simpler/worker_level.py`](../python/simpler/worker_level.py), the
 `[STRACE]` span prefix, and `SceneTestLevel`. L1 has no word because no Worker
-sits there.
+sits there. The second column is the **Ascend architecture documentation's** code
+for the same level, and the third is the physical entity it denotes.
+
+L3 is where the three disagree, and that is worth reading closely: we call it
+`node`, the architecture docs call it `HOST`, and the entity is a Node. `host` is
+the *processor* name in this repository — `HostLogger`, the `host_span` ABI,
+`host_runtime.so` — so reusing it as a level word made one word mean both "which
+processor" and "which level".
 
 **L2 is the boundary** between two worlds:
 
@@ -62,20 +69,27 @@ sits there.
 
 | Level | Workers it contains | Status |
 | ----- | ------------------- | ------ |
-| L3 (`host`) | `ChipWorker` ×N + `SubWorker` ×M | Implemented |
+| L3 (`node`) | `ChipWorker` ×N + `SubWorker` ×M | Implemented |
 | L4 (`network1`) | `Worker(level=3)` ×N + `SubWorker` ×M | Local implemented; remote sim implemented; HCOMM profiles pending |
 | L5 (`network2`) | `Worker(level=4)` ×N | Local L4 code path, untested; remote proposed |
 | L6 (`network3`) | `Worker(level=5)` ×N | Local L4 code path, untested; remote proposed |
 
 **This table is the one place the level words are mapped to physical entities.**
-A level above `host` is named for how many network hops separate it from the
-host, not for the hardware that implements it: `network1` is the layer commonly
-deployed as a **pod**, `network2` as a **supernode**, `network3` as a
+Every word names a **topology position**, never a processor and never a
+deployment fact. A level above `node` is named for how many network hops separate
+it from the node, not for the hardware that implements it: `network1` is the layer
+commonly deployed as a **pod**, `network2` as a **supernode**, `network3` as a
 **cluster**. The words count hops because that correspondence is not fixed —
-sometimes a host sits under a pod, sometimes directly under a supernode — and
+sometimes a node sits under a pod, sometimes directly under a supernode — and
 naming a level after an interconnect does not work either, since it is mostly SU
 and sometimes RoCE. Note the digit counts hops rather than the level number:
-`network1` is L4. The ladder is defined once, in
+`network1` is L4.
+
+L3 is `node` for the same reason, and **not** `host`: `host` names the *processor*
+that `HostLogger`, the `host_span` ABI and `host_runtime.so` belong to, and L3
+merely happens to run there. So does L4, and so does part of the chip runtime —
+a level word taken from a deployment location cannot be exclusive. The ladder is
+defined once, in
 [`python/simpler/worker_level.py`](../python/simpler/worker_level.py); everything
 else in the tree uses the level word alone.
 

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -4399,7 +4399,7 @@ class Worker:
         self.level = level
         # Rebound from the level in `init()`; the default matches the C++ table's
         # so a span emitted before init names L3 rather than nothing.
-        self._host_span_prefix = _span_prefix(WorkerLevel.host)
+        self._host_span_prefix = _span_prefix(WorkerLevel.node)
         self._config = config
         self._callable_registry: dict[int, Any] = {}
         self._identity_registry: dict[bytes, _CallableIdentityState] = {}

--- a/python/simpler/worker_level.py
+++ b/python/simpler/worker_level.py
@@ -10,18 +10,25 @@
 """One word per level of the worker hierarchy, and the trace prefix derived from it.
 
 `[STRACE]` span names lead with the level that emitted them, so a reader can tell
-a chip-runtime span from a host-scheduler one without consulting the tree. The
+a chip-runtime span from a node-scheduler one without consulting the tree. The
 words live here because the emitting code cannot supply them: `Orchestrator` and
 `WorkerThread` are level-agnostic — the same code runs at every level above the
 chip — so the word is a property of the process, resolved once from its Worker's
 level.
 
-Above `host` the physical layer is not fixed: sometimes a host sits under a pod,
-sometimes directly under a supernode. Naming those levels after a specific
-interconnect does not work either (mostly SU, sometimes RoCE). So they are named
-by how many network hops separate them from the host — `network1` is one hop up,
-whatever hardware implements it. The digit counts hops, not the level number:
+**Every word names a topology position, never a processor or a deployment fact.**
+`node` is one machine's orchestration; above it the physical layer is not fixed —
+sometimes a node sits under a pod, sometimes directly under a supernode — and
+naming those levels after an interconnect does not work either (mostly SU,
+sometimes RoCE). So they count network hops from the node: `network1` is one hop
+up, whatever hardware implements it. The digit counts hops, not the level number:
 `network1` is L4.
+
+`host` is deliberately absent. It names a *processor* — the CPU that `HostLogger`,
+`host_span` and `host_runtime.so` all belong to — and L3 merely happens to run
+there. So does L4, and so does part of the chip runtime, which is why a level word
+taken from a deployment location cannot be exclusive. That is the same reason L4
+is not called `pod`.
 
 `docs/hierarchical-level-runtime.md` is the one place that maps these words onto
 physical entities; this module deliberately does not repeat that mapping, so the
@@ -49,14 +56,14 @@ class WorkerLevel(IntEnum):
 
     core = 0
     chip = 2
-    host = 3
+    node = 3
     network1 = 4
     network2 = 5
     network3 = 6
 
 
 def span_prefix(level: int) -> str:
-    """Return the `[STRACE]` name prefix for `level`, e.g. 3 -> ``"host"``.
+    """Return the `[STRACE]` name prefix for `level`, e.g. 3 -> ``"node"``.
 
     Raises `ValueError` for a level the ladder does not name, rather than
     inventing a word. L5 and L6 run what
@@ -67,7 +74,7 @@ def span_prefix(level: int) -> str:
 
     Note `WorkerLevel(level).name`, not `str(WorkerLevel(level))`: this project
     targets Python 3.10, where `enum.StrEnum` does not exist and `str()` on any
-    `Enum` yields ``"WorkerLevel.host"``.
+    `Enum` yields ``"WorkerLevel.node"``.
     """
     try:
         return WorkerLevel(level).name

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -151,7 +151,7 @@ def _golden_thread_cap():
 
 class SceneTestLevel(IntEnum):
     CHIP = 2
-    HOST = 3
+    NODE = 3
     NETWORK1 = 4
 
 

--- a/simpler_setup/tools/strace_timing.py
+++ b/simpler_setup/tools/strace_timing.py
@@ -262,7 +262,7 @@ def _trace_document(events, anchors_by_pid, **extra):
 # invocation grouping instead of excluding them.
 _CHIP_WORD = "chip"
 _CORE_WORD = "core"
-_HOST_WORDS = ("host", "network1", "network2", "network3")
+_NODE_WORDS = ("node", "network1", "network2", "network3")
 
 # Reserved for producers outside simpler: `ext.<producer>.<span>`. Without a
 # reserved word a caller's span called `host.foo` would parse as one of ours.
@@ -272,10 +272,10 @@ _EXTERNAL_WORD = "ext"
 def span_family(name):
     """Classify `name` by the producer its leading word names.
 
-    Returns ``"chip"``, ``"core"``, ``"host"``, ``"external"``, or ``"unknown"``.
-    Every level at or above L3 answers ``"host"``: they run the same
-    orchestrator and scheduler code, so they form one family whichever word a
-    given process resolved to.
+    Returns ``"chip"``, ``"core"``, ``"node"``, ``"external"``, or ``"unknown"``.
+    Every level at or above L3 answers ``"node"`` — the family takes its lowest
+    member's name — because they run the same orchestrator and scheduler code and
+    so form one family whichever word a given process resolved to.
     """
     head = name.split(".", 1)[0]
     if head == _EXTERNAL_WORD:
@@ -284,19 +284,19 @@ def span_family(name):
         return "chip"
     if head == _CORE_WORD:
         return "core"
-    if head in _HOST_WORDS:
-        return "host"
+    if head in _NODE_WORDS:
+        return "node"
     return "unknown"
 
 
-def host_span_leaf(name):
-    """The part of a host-family span name after its level word, else ``None``.
+def node_span_leaf(name):
+    """The part of a node-family span name after its level word, else ``None``.
 
     Call sites match on the leaf rather than the whole name because the level
-    word varies by the process that emitted it — ``host.submit`` from an L3 and
+    word varies by the process that emitted it — ``node.submit`` from an L3 and
     ``network1.submit`` from an L4 are the same decision point.
     """
-    if span_family(name) != "host":
+    if span_family(name) != "node":
         return None
     _, _, leaf = name.partition(".")
     return leaf
@@ -305,9 +305,10 @@ def host_span_leaf(name):
 def external_producer(name):
     """The producer segment of an ``ext.<producer>.<span>`` name, else ``None``.
 
-    All three segments are required: ``ext.pypto.decode_layer`` attributes to
-    ``pypto``, while ``ext.foo`` names no span of its own and ``ext..foo`` names
-    no producer. Neither resolves, so a malformed name lands in an unattributed
+    All three segments must be present and non-empty: ``ext.pypto.decode_layer``
+    attributes to ``pypto``, while ``ext.foo`` names no span of its own,
+    ``ext..foo`` names no producer, and ``ext.pypto.`` names a producer but no
+    span. None of those resolve, so a malformed name lands in an unattributed
     lane instead of another producer's.
 
     Attribution is separate from :func:`span_family`, which answers only whether
@@ -316,9 +317,9 @@ def external_producer(name):
     if span_family(name) != "external":
         return None
     parts = name.split(".")
-    if len(parts) < 3:
+    if len(parts) < 3 or not parts[1] or not parts[2]:
         return None
-    return parts[1] or None
+    return parts[1]
 
 
 def invocation_spans(spans):
@@ -326,14 +327,14 @@ def invocation_spans(spans):
 
     Those views key on ``(pid, inv)``, and ``inv`` is a native run epoch. Two
     families carry none, so admitting either would group all of its spans into
-    one forged invocation: the per-task ``host``/``network*`` scheduler family,
+    one forged invocation: the per-task ``node``/``network*`` scheduler family,
     and anything an external producer emitted under ``ext.``.
 
     Everything else is kept, **including a name this parser does not recognize**.
     Dropping an unfamiliar family silently is how ``chip.prewarm.build`` once
     vanished from the tables.
     """
-    return [span for span in spans if span_family(span.name) not in ("host", "external")]
+    return [span for span in spans if span_family(span.name) not in ("node", "external")]
 
 
 def group_invocations(spans):
@@ -528,7 +529,7 @@ def print_tpot_table(buckets, label_for_hid=None, stream=sys.stdout):
 
 
 _ROUNDS_TABLE_NAMES = {
-    "host": "chip.run",
+    "run": "chip.run",
     "device": "chip.run.runner_run.device_wall",
     "orch": "chip.run.runner_run.device_wall.orch",
     "sched": "chip.run.runner_run.device_wall.sched",
@@ -565,7 +566,7 @@ def _round_metrics(inv):
     else:
         effective = 0.0
 
-    return (_dur("host"), _dur("device"), effective, _dur("orch"), _dur("sched"))
+    return (_dur("run"), _dur("device"), effective, _dur("orch"), _dur("sched"))
 
 
 def print_rounds_table(buckets, stream=sys.stdout):
@@ -727,8 +728,8 @@ def _parsed_attrs(span):
 
 # Highest-precedence match wins. One OS thread emits spans of several roles: the
 # scheduler loop is the sole caller of both `dispatch_ready` and
-# `manager->progress`, so it emits `host.dispatch` (role=scheduler) alongside
-# `host.frame_submit` / `host.activate` / `host.complete`, whose `role=worker` names
+# `manager->progress`, so it emits `node.dispatch` (role=scheduler) alongside
+# `node.frame_submit` / `node.activate` / `node.complete`, whose `role=worker` names
 # the worker a dispatch targets rather than the thread doing the work.
 _HOST_THREAD_ROLES = ("facade", "scheduler", "worker")
 
@@ -781,7 +782,7 @@ def _slot_lanes(entries, slot_by_invocation):
     return dict(sorted(by_slot.items()))
 
 
-def _host_thread_name(entries):
+def _lane_name(entries):
     """Name one OS thread's lane from every span it emitted.
 
     `entries` are that thread's (span, parsed attributes) pairs.
@@ -797,7 +798,7 @@ def _host_thread_name(entries):
         if span_family(span.name) == "external":
             continue
         role = attrs.get("role")
-        leaf = host_span_leaf(span.name)
+        leaf = node_span_leaf(span.name)
         if role == "facade" or leaf in {"graph_build", "submit"}:
             roles.add("facade")
         elif role in ("scheduler", "worker"):
@@ -834,7 +835,7 @@ def _flow_key(span, attrs):
     return span.pid, run_id, task_slot
 
 
-def _assign_lanes(host_entries, host_threads):
+def _assign_lanes(non_device_entries, non_device_threads):
     """Choose a lane per span, and a name per lane.
 
     A thread that interleaved runs is split by pipeline slot (see
@@ -849,21 +850,21 @@ def _assign_lanes(host_entries, host_threads):
     """
     lane_of = {}
     lane_names = {}
-    next_synthetic_tid = max(tid for _, tid in host_threads) + 1
-    ours = [entry for entry in host_entries if span_family(entry[0].name) != "external"]
+    next_synthetic_tid = max(tid for _, tid in non_device_threads) + 1
+    ours = [entry for entry in non_device_entries if span_family(entry[0].name) != "external"]
     slot_by_invocation = _slot_by_invocation(ours)
-    for pid, tid in host_threads:
-        on_thread = [entry for entry in host_entries if entry[0].pid == pid and entry[0].tid == tid]
+    for pid, tid in non_device_threads:
+        on_thread = [entry for entry in non_device_entries if entry[0].pid == pid and entry[0].tid == tid]
         ours_on_thread = [entry for entry in on_thread if span_family(entry[0].name) != "external"]
         slot_lanes = _slot_lanes(ours_on_thread, slot_by_invocation)
         if slot_lanes is None:
-            lane_names[(pid, tid)] = _host_thread_name(on_thread)
+            lane_names[(pid, tid)] = _lane_name(on_thread)
             for span, _ in on_thread:
                 lane_of[id(span)] = tid
             continue
         external_on_thread = [entry for entry in on_thread if span_family(entry[0].name) == "external"]
         if external_on_thread:
-            lane_names[(pid, tid)] = _host_thread_name(external_on_thread)
+            lane_names[(pid, tid)] = _lane_name(external_on_thread)
             for span, _ in external_on_thread:
                 lane_of[id(span)] = tid
         for slot_id, group in slot_lanes.items():
@@ -1037,8 +1038,8 @@ def _process_label(pid, process_spans):
     and then the label carries no `simpler` prefix — it is not our process.
     """
     families = {span_family(span.name) for span in process_spans}
-    if "host" in families:
-        return f"simpler host (pid={pid})"
+    if "node" in families:
+        return f"simpler node (pid={pid})"
     if families == {"external"}:
         producers = sorted({producer for span in process_spans if (producer := external_producer(span.name))})
         named = "/".join(producers) if producers else "unattributed"
@@ -1063,15 +1064,18 @@ def to_host_swimlane(spans, anchors=None):
     entries = [(span, _parsed_attrs(span)) for span in spans]
     events = []
 
-    host_entries = [entry for entry in entries if not entry[0].is_device]
+    non_device_entries = [entry for entry in entries if not entry[0].is_device]
     device_entries = [entry for entry in entries if entry[0].is_device]
-    host_pids = sorted({span.pid for span, _ in host_entries})
-    host_threads = sorted({(span.pid, span.tid) for span, _ in host_entries})
+    non_device_pids = sorted({span.pid for span, _ in non_device_entries})
+    non_device_threads = sorted({(span.pid, span.tid) for span, _ in non_device_entries})
 
-    lane_of, lane_names = _assign_lanes(host_entries, host_threads)
+    lane_of, lane_names = _assign_lanes(non_device_entries, non_device_threads)
 
-    for pid in host_pids:
-        process_spans = [span for span, _ in host_entries if span.pid == pid]
+    for pid in non_device_pids:
+        # Every span the process emitted, device-clock ones included: a `clk=dev`
+        # span is ours too, so it is evidence about whose process this is even
+        # though it never reaches the visible timeline.
+        process_spans = [span for span in spans if span.pid == pid]
         events.append(
             {
                 "ph": "M",
@@ -1091,7 +1095,9 @@ def to_host_swimlane(spans, anchors=None):
                 "args": {"name": name},
             }
         )
-    for span, parsed in sorted(host_entries, key=lambda item: (item[0].ts, item[0].pid, item[0].tid, item[0].name)):
+    for span, parsed in sorted(
+        non_device_entries, key=lambda item: (item[0].ts, item[0].pid, item[0].tid, item[0].name)
+    ):
         event_args = {
             "inv": span.inv,
             "hid": span.hid,
@@ -1114,8 +1120,8 @@ def to_host_swimlane(spans, anchors=None):
         )
 
     submits = defaultdict(list)
-    for span, attrs in host_entries:
-        if host_span_leaf(span.name) != "submit":
+    for span, attrs in non_device_entries:
+        if node_span_leaf(span.name) != "submit":
             continue
         key = _flow_key(span, attrs)
         if key is not None:
@@ -1124,8 +1130,8 @@ def to_host_swimlane(spans, anchors=None):
         candidates.sort(key=lambda item: item.ts)
 
     dispatches = []
-    for span, attrs in host_entries:
-        if host_span_leaf(span.name) != "dispatch":
+    for span, attrs in non_device_entries:
+        if node_span_leaf(span.name) != "dispatch":
             continue
         key = _flow_key(span, attrs)
         source = None

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -157,9 +157,9 @@ struct RunState {
     bool submission_closed{false};
     bool submission_failed{false};
     bool lease_released{false};
-    // When this run reached a terminal phase. `host.post_fence_retirement`
-    // measures from here to the end of release_run, which is the only host cost
-    // that falls outside every other span.
+    // When this run reached a terminal phase. `node.post_fence_retirement`
+    // measures from here to the end of release_run, the only work this process
+    // does outside every other span.
     int64_t trace_terminal_ns{0};
 };
 

--- a/src/common/log/include/common/host_span_names.h
+++ b/src/common/log/include/common/host_span_names.h
@@ -56,11 +56,13 @@ inline constexpr std::array<const char *, static_cast<size_t>(HostSpan::kCount)>
     ".graph_build", ".submit", ".dispatch", ".frame_submit", ".activate", ".complete", ".post_fence_retirement",
 };
 
-/// The bound level word. Defaults to `host`: L3 is the only level that has ever
+/// The bound level word. Defaults to `node`: L3 is the only level that has ever
 /// driven this code in a shipped configuration, so an unset prefix names the
-/// truth rather than an arbitrary placeholder.
+/// truth rather than an arbitrary placeholder. The word names a topology
+/// position, so it is never the processor name `host` — that belongs to the
+/// `host_span` ABI this file implements, which every level above the chip uses.
 inline std::string &level_word() {
-    static std::string word = "host";
+    static std::string word = "node";
     return word;
 }
 
@@ -87,7 +89,7 @@ inline bool &prefix_bound() {
 }  // namespace detail
 
 /**
- * Bind this process's level word, e.g. `"host"` or `"network1"`.
+ * Bind this process's level word, e.g. `"node"` or `"network1"`.
  *
  * **The first non-empty word wins; every later one is refused.** Two reasons,
  * and neither is enforceable by documentation alone:

--- a/tests/ut/cpp/a5/test_host_log_off.cpp
+++ b/tests/ut/cpp/a5/test_host_log_off.cpp
@@ -384,7 +384,7 @@ TEST(HostLogTest, HostSpanTruncationDropsAWholeEscapeRatherThanItsLastByte) {
                                0,
                                100,
                                25,
-                               "host.dispatch",
+                               "node.dispatch",
                                attributes.c_str()};
 
     auto captured = run_with_config(LogLevel::TIMING, [&] {

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -1210,13 +1210,13 @@ TEST(WorkerManagerTest, DispatchAndCompletionEmitHostSpans) {
 
     worker.dispatch(WorkerDispatch{slot, 0});
     ASSERT_TRUE(endpoint_ptr->wait_submitted(1));
-    EXPECT_TRUE(captured_host_span("host.dispatch"));
+    EXPECT_TRUE(captured_host_span("node.dispatch"));
 
     const WorkerDispatch submitted = endpoint_ptr->submitted().front();
     endpoint_ptr->emit(WorkerProgressKind::COMPLETED, submitted);
     worker.progress();
     ASSERT_EQ(completed.size(), 1u);
-    EXPECT_TRUE(captured_host_span("host.complete"));
+    EXPECT_TRUE(captured_host_span("node.complete"));
 
     worker.stop();
     allocator.shutdown();
@@ -1474,8 +1474,8 @@ TEST(WorkerManagerTest, TwoFrameLeaseSlotsDoNotDefineFifoOrAcceptance) {
     ASSERT_TRUE(endpoint.poll_progress(progress));
     EXPECT_EQ(progress.kind, WorkerProgressKind::ACCEPTED);
     EXPECT_EQ(progress.dispatch.dispatch_id, 42u);
-    EXPECT_TRUE(captured_host_span("host.frame_submit"));
-    EXPECT_TRUE(captured_host_span("host.activate"));
+    EXPECT_TRUE(captured_host_span("node.frame_submit"));
+    EXPECT_TRUE(captured_host_span("node.activate"));
     allocator.shutdown();
 }
 
@@ -2042,10 +2042,10 @@ TEST_F(ProgressSchedulerFixture, GroupSubmitReportsNoSingleWorkerAndNoSingleInde
     );
     orchestrator.close_run_submission(run);
 
-    ASSERT_TRUE(captured_host_span("host.submit"));
+    ASSERT_TRUE(captured_host_span("node.submit"));
     std::ostringstream expected;
     expected << "run_id=" << run << " task_slot=" << group.task_slot << " group_index=-1 group_size=2 role=facade";
-    EXPECT_EQ(captured_host_span_attrs("host.submit"), expected.str());
+    EXPECT_EQ(captured_host_span_attrs("node.submit"), expected.str());
 }
 
 TEST_F(ProgressSchedulerFixture, SuccessorStagesButActivatesOnlyAfterFifoPromotion) {
@@ -2506,7 +2506,7 @@ TEST_F(SchedulerFixture, ACancellationThatWinsTheClaimStopsTheDispatch) {
     }
 }
 
-// `host.submit` is what a dispatch arrow is drawn back to, so the swimlane can
+// `node.submit` is what a dispatch arrow is drawn back to, so the swimlane can
 // only pair the two if these attributes carry the same run/slot the dispatch
 // reports. A SUB submission is deliberately silent: it has no NEXT_LEVEL worker
 // to hand off to.
@@ -2515,11 +2515,11 @@ TEST_F(SchedulerFixture, NextLevelSubmitEmitsAPairableHostSpan) {
 
     auto submitted = orch.submit_next_level(C(0x42), single_tensor_args(0xCAFE, TensorArgType::OUTPUT), cfg, 0);
 
-    ASSERT_TRUE(captured_host_span("host.submit"));
+    ASSERT_TRUE(captured_host_span("node.submit"));
     std::ostringstream expected;
     expected << "run_id=" << run_id << " task_slot=" << submitted.task_slot
              << " group_index=0 group_size=1 worker_id=0 role=facade";
-    EXPECT_EQ(captured_host_span_attrs("host.submit"), expected.str());
+    EXPECT_EQ(captured_host_span_attrs("node.submit"), expected.str());
 
     mock_worker.wait_running();
     mock_worker.complete();

--- a/tests/ut/py/test_scene_level_selection.py
+++ b/tests/ut/py/test_scene_level_selection.py
@@ -158,7 +158,7 @@ def test_exclude_level4_keeps_unlevelled_functions():
 
 
 def test_sorting_uses_function_level_metadata():
-    @scene_level(SceneTestLevel.HOST)
+    @scene_level(SceneTestLevel.NODE)
     def host_fn():
         return None
 

--- a/tests/ut/py/test_strace_timing.py
+++ b/tests/ut/py/test_strace_timing.py
@@ -18,7 +18,7 @@ from simpler.worker_level import WorkerLevel
 from simpler_setup.tools.strace_timing import (
     _CHIP_WORD,
     _CORE_WORD,
-    _HOST_WORDS,
+    _NODE_WORDS,
     NativeOverlapError,
     assert_native_overlap,
     bucket_by_hid,
@@ -26,10 +26,10 @@ from simpler_setup.tools.strace_timing import (
     external_producer,
     group_invocations,
     host_record_spans,
-    host_span_leaf,
     invocation_spans,
     load_host_phase_records,
     main,
+    node_span_leaf,
     parse_clock_anchors,
     parse_spans,
     print_rounds_table,
@@ -219,10 +219,10 @@ def test_wall_time_uses_the_matching_anchor_for_each_pid():
     spans = list(
         parse_spans(
             [
-                _span_record(pid=41, tid=410, inv=1, name="host.submit", ts=1_500, dur=10),
-                _span_record(pid=52, tid=520, inv=1, name="host.submit", ts=1_500, dur=10),
-                _span_record(pid=63, tid=630, inv=1, name="host.submit", ts=1_500, dur=10),
-                _span_record(pid=64, tid=640, inv=1, name="host.submit", ts=1_500, dur=10),
+                _span_record(pid=41, tid=410, inv=1, name="node.submit", ts=1_500, dur=10),
+                _span_record(pid=52, tid=520, inv=1, name="node.submit", ts=1_500, dur=10),
+                _span_record(pid=63, tid=630, inv=1, name="node.submit", ts=1_500, dur=10),
+                _span_record(pid=64, tid=640, inv=1, name="node.submit", ts=1_500, dur=10),
             ]
         )
     )
@@ -253,7 +253,7 @@ def test_host_swimlane_keeps_real_host_lanes_and_builds_dispatch_flow():
             pid=41,
             tid=410,
             inv=7,
-            name="host.graph_build",
+            name="node.graph_build",
             ts=1_000,
             dur=900,
             attrs="run_id=7 role=facade",
@@ -262,7 +262,7 @@ def test_host_swimlane_keeps_real_host_lanes_and_builds_dispatch_flow():
             pid=41,
             tid=410,
             inv=7,
-            name="host.submit",
+            name="node.submit",
             ts=1_100,
             dur=100,
             attrs="run_id=7 task_slot=12 group_index=0 worker_id=3 role=facade",
@@ -271,7 +271,7 @@ def test_host_swimlane_keeps_real_host_lanes_and_builds_dispatch_flow():
             pid=41,
             tid=411,
             inv=7,
-            name="host.dispatch",
+            name="node.dispatch",
             ts=1_400,
             dur=80,
             attrs=(
@@ -306,8 +306,8 @@ def test_host_swimlane_names_the_scheduler_lane_from_every_role_it_emits():
     """The scheduler thread emits `role=worker` spans before its first `role=scheduler` one.
 
     `scheduler.cpp`'s loop is the only caller of both `dispatch_ready()` and
-    `manager->progress()`, and inside `submit_dispatch` the `host.frame_submit`
-    scope closes within `submit_progress` — before the `host.dispatch` record
+    `manager->progress()`, and inside `submit_dispatch` the `node.frame_submit`
+    scope closes within `submit_progress` — before the `node.dispatch` record
     emitted after the admission lock is released. Naming the lane from the
     first span it emitted therefore labels the scheduler `worker 3`.
     """
@@ -316,7 +316,7 @@ def test_host_swimlane_names_the_scheduler_lane_from_every_role_it_emits():
             pid=41,
             tid=411,
             inv=7,
-            name="host.frame_submit",
+            name="node.frame_submit",
             ts=1_410,
             dur=40,
             attrs="run_id=7 task_slot=12 group_index=0 worker_id=3 dispatch_id=1 role=worker",
@@ -325,7 +325,7 @@ def test_host_swimlane_names_the_scheduler_lane_from_every_role_it_emits():
             pid=41,
             tid=411,
             inv=7,
-            name="host.dispatch",
+            name="node.dispatch",
             ts=1_400,
             dur=80,
             attrs="run_id=7 task_slot=12 group_index=0 worker_id=3 dispatch_id=1 role=scheduler",
@@ -334,7 +334,7 @@ def test_host_swimlane_names_the_scheduler_lane_from_every_role_it_emits():
             pid=41,
             tid=411,
             inv=7,
-            name="host.complete",
+            name="node.complete",
             ts=2_000,
             dur=30,
             attrs="run_id=7 task_slot=12 group_index=0 worker_id=3 dispatch_id=1 role=worker",
@@ -381,7 +381,7 @@ def test_host_swimlane_pairs_dispatch_with_latest_preceding_submit():
             pid=41,
             tid=410,
             inv=7,
-            name="host.submit",
+            name="node.submit",
             ts=100,
             dur=20,
             attrs="run_id=7 task_slot=12 group_index=0 worker_id=3 role=facade",
@@ -390,7 +390,7 @@ def test_host_swimlane_pairs_dispatch_with_latest_preceding_submit():
             pid=41,
             tid=411,
             inv=7,
-            name="host.dispatch",
+            name="node.dispatch",
             ts=200,
             dur=10,
             attrs="run_id=7 task_slot=12 group_index=0 worker_id=3 dispatch_id=1 role=scheduler",
@@ -399,7 +399,7 @@ def test_host_swimlane_pairs_dispatch_with_latest_preceding_submit():
             pid=41,
             tid=410,
             inv=7,
-            name="host.submit",
+            name="node.submit",
             ts=300,
             dur=20,
             attrs="run_id=7 task_slot=12 group_index=0 worker_id=3 role=facade",
@@ -408,7 +408,7 @@ def test_host_swimlane_pairs_dispatch_with_latest_preceding_submit():
             pid=41,
             tid=411,
             inv=7,
-            name="host.dispatch",
+            name="node.dispatch",
             ts=400,
             dur=10,
             attrs="run_id=7 task_slot=12 group_index=0 worker_id=3 dispatch_id=2 role=scheduler",
@@ -436,7 +436,7 @@ def test_host_swimlane_keeps_unaligned_device_clock_out_of_visible_timeline():
                     pid=41,
                     tid=410,
                     inv=7,
-                    name="host.graph_build",
+                    name="node.graph_build",
                     ts=1_000_000_000,
                     dur=900,
                     attrs="run_id=7 role=facade",
@@ -458,7 +458,7 @@ def test_host_swimlane_keeps_unaligned_device_clock_out_of_visible_timeline():
     visible_slices = [event for event in trace["traceEvents"] if event.get("ph") == "X"]
 
     assert [(event["name"], event["ts"], event["dur"]) for event in visible_slices] == [
-        ("host.graph_build", 1_000_000.0, 0.9)
+        ("node.graph_build", 1_000_000.0, 0.9)
     ]
     assert trace["unalignedDeviceSpans"] == [
         {
@@ -493,7 +493,7 @@ def test_invocation_views_ignore_host_swimlane_markers():
                     pid=61,
                     tid=611,
                     inv=9,
-                    name="host.dispatch",
+                    name="node.dispatch",
                     ts=900,
                     dur=20,
                     attrs="run_id=9 task_slot=4 group_index=0 worker_id=0 dispatch_id=1",
@@ -522,16 +522,16 @@ def test_span_family_classifies_the_level_words_and_reserves_ext():
     # Every level at or above L3 runs the same orchestrator and scheduler code,
     # so they answer as one family whichever word the process resolved to.
     for level in WorkerLevel:
-        if level.value >= WorkerLevel.host.value:
-            assert span_family(f"{level.name}.dispatch") == "host"
+        if level.value >= WorkerLevel.node.value:
+            assert span_family(f"{level.name}.dispatch") == "node"
     # A caller cannot land in ours, which is what `ext.` is reserved for.
     assert span_family("ext.pypto.decode_layer") == "external"
     assert span_family("something_else.foo") == "unknown"
     # The leaf is what the swimlane's flow pairing matches on, so it resolves for
     # every host level word and for nothing else.
-    assert host_span_leaf("host.dispatch") == "dispatch"
-    assert host_span_leaf("network1.submit") == "submit"
-    assert host_span_leaf("chip.run") is None
+    assert node_span_leaf("node.dispatch") == "dispatch"
+    assert node_span_leaf("network1.submit") == "submit"
+    assert node_span_leaf("chip.run") is None
 
 
 def test_every_level_word_the_ladder_names_is_a_word_this_parser_knows():
@@ -545,7 +545,7 @@ def test_every_level_word_the_ladder_names_is_a_word_this_parser_knows():
     under a forged ``(pid, 0)`` key. No error anywhere, just wrong tables.
     """
     ladder = {level.name for level in WorkerLevel}
-    parser = set(_HOST_WORDS) | {_CHIP_WORD, _CORE_WORD}
+    parser = set(_NODE_WORDS) | {_CHIP_WORD, _CORE_WORD}
 
     assert ladder == parser, (
         f"the ladder and this parser disagree: ladder-only={sorted(ladder - parser)}, "
@@ -554,7 +554,7 @@ def test_every_level_word_the_ladder_names_is_a_word_this_parser_knows():
     # Each word also has to reach the family the ladder position implies, not
     # merely be present in some list.
     for level in WorkerLevel:
-        expected = "host" if level.value >= WorkerLevel.host.value else level.name
+        expected = "node" if level.value >= WorkerLevel.node.value else level.name
         assert span_family(f"{level.name}.something") == expected
         # A level word is never mistaken for the external namespace.
         assert external_producer(f"{level.name}.something") is None
@@ -580,14 +580,14 @@ def test_swimlane_cli_writes_trace(tmp_path):
     output_path = tmp_path / "host_swimlane.json"
     log_path.write_text(
         _anchor_record(71, 50, 1_700_000_000_000_000_000)
-        + _span_record(pid=71, tid=710, inv=2, name="host.graph_build", ts=100, dur=25, attrs="run_id=2 role=facade"),
+        + _span_record(pid=71, tid=710, inv=2, name="node.graph_build", ts=100, dur=25, attrs="run_id=2 role=facade"),
         encoding="utf-8",
     )
 
     assert main([str(log_path), "--swimlane", str(output_path)]) == 0
 
     trace = json.loads(output_path.read_text(encoding="utf-8"))
-    event = next(event for event in trace["traceEvents"] if event.get("name") == "host.graph_build")
+    event = next(event for event in trace["traceEvents"] if event.get("name") == "node.graph_build")
     assert event["args"]["wall_ts_ns"] == "1700000000000000050"
 
 
@@ -909,35 +909,39 @@ def test_host_record_spans_drop_passes_with_no_matching_bind(tmp_path):
 
 
 def test_ext_name_attributes_a_producer_and_refuses_a_malformed_one():
-    """``ext.<producer>.<span>`` — all three segments are required for attribution.
+    """``ext.<producer>.<span>`` — three present, non-empty segments to attribute.
 
     Family and attribution answer different questions. A name under ``ext.`` is
     never ours whatever follows it, so a malformed one still classifies as
     external; it simply lands in an unattributed lane rather than another
-    producer's.
+    producer's. A present-but-empty segment counts as malformed either side of
+    the producer: ``ext..foo`` names nobody, and ``ext.pypto.`` names a producer
+    with no span of its own.
     """
     assert external_producer("ext.pypto.decode_layer") == "pypto"
     assert external_producer("ext.pypto.attention.qk") == "pypto"
 
-    for malformed in ("ext.pypto", "ext.", "ext..decode_layer"):
+    for malformed in ("ext.pypto", "ext.", "ext..decode_layer", "ext.pypto.", "ext.pypto..detail"):
         assert span_family(malformed) == "external"
         assert external_producer(malformed) is None
 
     # Not external at all, so no producer.
-    assert external_producer("host.dispatch") is None
+    assert external_producer("node.dispatch") is None
     assert external_producer("chip.run") is None
 
 
 def test_ext_name_cannot_impersonate_one_of_our_level_words():
-    """The reason the namespace exists: a caller's ``host.foo`` must not parse as ours.
+    """The reason the namespace exists: a caller's ``node.foo`` must not parse as ours.
 
     Every level word is reachable as a producer segment, and none of them
-    promotes the span into our family.
+    promotes the span into our family. ``host`` is included precisely because it
+    is *not* a level word — it names a processor, so a producer may legitimately
+    be called that, and it must be treated as any other producer name.
     """
-    for word in ("core", "chip", "host", "network1", "network2", "network3"):
+    for word in [level.name for level in WorkerLevel] + ["host"]:
         assert span_family(f"ext.{word}.foo") == "external"
         assert external_producer(f"ext.{word}.foo") == word
-        assert host_span_leaf(f"ext.{word}.foo") is None
+        assert node_span_leaf(f"ext.{word}.foo") is None
 
 
 def test_ext_spans_stay_out_of_the_invocation_keyed_views():
@@ -991,14 +995,35 @@ def test_a_shared_process_stays_ours_when_a_producer_emits_into_it():
     keeps the process labelled as ours.
     """
     lines = [
-        _span_record(pid=41, tid=410, inv=7, name="host.graph_build", ts=100, dur=200, attrs="run_id=7 role=facade"),
+        _span_record(pid=41, tid=410, inv=7, name="node.graph_build", ts=100, dur=200, attrs="run_id=7 role=facade"),
         _span_record(pid=41, tid=411, inv=0, name="ext.pypto.decode_layer", ts=120, dur=60),
     ]
 
     trace = to_host_swimlane(list(parse_spans(lines)))
 
-    assert _metadata(trace, "process_name") == ["simpler host (pid=41)"]
+    assert _metadata(trace, "process_name") == ["simpler node (pid=41)"]
     assert _lanes(trace) == {410: "orchestrator / facade", 411: "ext pypto"}
+
+
+def test_a_device_clock_span_still_proves_the_process_is_ours():
+    """A `clk=dev` span never reaches the visible timeline, but it is still ours.
+
+    So it is evidence about whose process this is. Classifying from the visible
+    spans alone would label a process that emitted one of our device spans and
+    one external host span as the producer's.
+    """
+    lines = [
+        _span_record(pid=41, tid=410, inv=0, name="ext.pypto.decode_layer", ts=120, dur=60),
+        _span_record(
+            pid=41, tid=410, inv=7, name="chip.run.runner_run.device_wall", ts=300, dur=40, attrs="clk=dev", depth=1
+        ),
+    ]
+
+    trace = to_host_swimlane(list(parse_spans(lines)))
+
+    assert _metadata(trace, "process_name") == ["simpler chip child (pid=41)"]
+    # The device span stays off the visible timeline all the same.
+    assert {event["name"] for event in trace["traceEvents"] if event["ph"] == "X"} == {"ext.pypto.decode_layer"}
 
 
 def test_ext_attributes_cannot_take_over_one_of_our_lane_names():

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -2755,7 +2755,7 @@ class TestRunHandle:
         with pytest.raises(ValueError, match="bad graph"):
             worker._submit_l3_locked(bad_graph, None, cast(Any, object()))
 
-        assert emitted == [("host.graph_build", 1, 0, 0, 100, 175, "run_id=1 role=facade")]
+        assert emitted == [("node.graph_build", 1, 0, 0, 100, 175, "run_id=1 role=facade")]
 
     def test_unsettled_graph_cancellation_abandons_the_handle_before_close(self):
         worker, events = self._submission_failure_worker(failures=2)


### PR DESCRIPTION
## Summary

`host` meant two things at once:

| Axis | Question it answers | Words |
| --- | --- | --- |
| **processor** | which CPU does this run on | host / AICPU / AICore |
| **topology** | where in the orchestration tree | core / chip / **?** / network1 / network2 / network3 |

It occupied a cell in each. The ambiguity had **already produced a misread inside the tracer**:

```python
host_entries = [entry for entry in entries if not entry[0].is_device]
```

That `host` is the processor sense, so `host_entries` **includes `chip.run`** — the same function later returns `"chip child"` for one of those lanes. A reader who takes the name at face value expects the host *family*.

## Which side moves is not a free choice

| Sense | Occurrences | |
| --- | --- | --- |
| processor | **450+** — `HostLogger` 105, `host_span` 104, `host_log` 103, `host_runtime` 121, `SIMPLER_HOST_STRACE` 26 | `host`/`device` is the CUDA/CANN convention every Ascend reader arrives with |
| topology (L3) | **~60**, behind a single source of truth | |

So the level word moves. It is **`node`**, which is not a new coinage — `python/simpler/global_comm_domain.py` already calls L3 that (`node_worker_id`, *"one receiving L3 node"*, *"receiver-node by rank attachment matrix"*), and it does so in the communication code, where `network1/2/3` are the neighbouring coordinates.

```
core(0)  chip(2)  node(3)  network1(4)  network2(5)  network3(6)
```

**Every word is now a topology position; none is a processor or a deployment fact.** That is the same reason L4 is not called `pod`: a node sometimes sits under a pod and sometimes directly under a supernode, so the level counts hops instead. L3 running on a host CPU is a deployment fact of exactly that kind — L4 runs there too, and so does part of the chip runtime, which is why a level word taken from a deployment location can never be exclusive.

## What moved

Each occurrence needed one judgement: **does this `host` name a level or a processor?**

- `WorkerLevel.host` → `node`, `SceneTestLevel.HOST` → `NODE`
- the parser's copy of the ladder: `_HOST_WORDS` → `_NODE_WORDS`, the family `span_family` answers → `"node"`, `host_span_leaf` → `node_span_leaf` (the family still takes its lowest member's name)
- `host_span_names.h`'s pre-bind default word — the only level-word literal in C++, since the prefix is bound at runtime from Python
- 41 `host.<leaf>` span literals across docs and tests

Two names that were **products of the same ambiguity** move with it, because fixing one sense and leaving these would only half-resolve it:

- `_ROUNDS_TABLE_NAMES` keyed `chip.run` under `"host"` — a level word pointing at another level's span, 270 lines from the tuple defining `host` as L3. The key is `"run"`, which is what the value is. It is an **internal dict key**; the printed column header lives in `_ROUNDS_TABLE_COLUMNS` and is untouched, so `tools/benchmark_rounds.sh` parses exactly what it did before.
- `host_entries`/`host_pids`/`host_threads` → `non_device_*`, `_host_thread_name` → `_lane_name`

## What deliberately did not move

- **Every processor-sense identifier**, all 450+, including `to_host_swimlane` (its subject is non-device spans) and the `--trace-out` lane label `"host"` sitting directly beside `"device (clk=dev)"` — the single occurrence a mechanical sweep would most likely have broken.
- **`docs/hierarchical-level-runtime.md`'s second column.** It is the *Ascend architecture documentation's* code for each level, not an identifier of ours, and `HOST` there is correct. L3 is now the row where all three columns differ — `node` / `HOST` / Node — so the doc states what each column is, which it never did and L3 is exactly where that mattered.

## Two findings from #1886's review

That PR merged first and both live in the code this one renames:

1. **`external_producer`** documented *"all three segments are required"* and checked two of them, so `ext.pypto.` — a producer with no span of its own — attributed to `pypto`. It now requires all three present **and** non-empty, which also rejects `ext.pypto..detail`.
2. **`_process_label`** was handed only the non-device spans, so a process emitting one of our `clk=dev` spans alongside an external host span was labelled as the producer's. A device span never reaches the visible timeline, but it is still ours and therefore still evidence about whose process this is; classification now reads every span the pid emitted. The visible timeline is unchanged.

## Testing

- [x] `pytest tests/ut/py` — **1646 passed, 0 failed** (45 in the strace file)
- [x] `ctest -LE requires_hardware` — **101/101**. `test_scheduler.cpp` asserting `node.dispatch` is what proves the C++ side emits it: that name is built from the bound prefix, so a green run **is** the end-to-end check for the level word.
- [x] Python→C++ level-word handoff measured directly: `span_prefix(3)` → `node`, `_set_host_span_level_prefix` returns `node`
- [x] Both #1886 findings have a negative control — restoring either the two-segment check or the non-device-only classification turns exactly its own test red
- [x] `git grep` for `host_span_leaf`, `_HOST_WORDS`, `WorkerLevel.host`, `SceneTestLevel.HOST` returns nothing; every surviving `` `host` `` in prose is a sentence explaining that it names the processor
- [x] End to end through the real emitter: `_emit_host_span` via `HostLogger::log_host_span`, external span on the swimlane and absent from the invocation views
- [x] ruff, ruff format clean

The ladder-to-parser pin added in #1886 fails if the two lists ever disagree again, so this rename cannot half-land.