### PR TITLE
host_build_graph: partition the runtime arena into copy and no-copy zones

### DIFF
--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -265,12 +265,27 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
             void *sm_ptr = runtime->get_gm_sm_ptr();
             uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(rt->prebuilt_layout.task_window_sizes);
+            // sm_handle and the scheduler state are the device-only zone: their
+            // bytes never travel, so they start as whatever the pooled arena last
+            // held. Zeroing the handle first is what makes attach_populated's
+            // assignment of every field checkable here rather than by inspecting
+            // attach_populated.
             memset(rt->sm_handle, 0, sizeof(*rt->sm_handle));
             if (!rt->sm_handle->attach_populated(sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes)) {
                 LOG_ERROR("Thread %d: host-orch: sm_handle->attach_populated failed", thread_idx);
                 rt = nullptr;
                 run_rc = -1;
                 boot_ok = false;
+            } else if (!rt->scheduler->init_data_from_layout(rt->prebuilt_layout.sched, runtime_arena_, sm_ptr)) {
+                LOG_ERROR("Thread %d: host-orch: scheduler init_data_from_layout failed", thread_idx);
+                rt = nullptr;
+                run_rc = -1;
+                boot_ok = false;
+            } else {
+                // Queue headers are set, so the slot arrays can take their ramp.
+                // Both precede runtime_init_ready_, which is what releases the peer
+                // threads into the dispatch loop, so no push sees either unset.
+                rt->scheduler->seed_queue_slots();
             }
         }
 
@@ -357,7 +372,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // Destroy the host_build_graph runtime. sm_handle / rt are recreated
         // every run, so always tear them down here.
         if (rt != nullptr) {
-            rt->scheduler.print_queues();
+            rt->scheduler->print_queues();
             // Clear g_current_runtime in this DSO before destroying rt.
             framework_bind_runtime(nullptr);
             // A Graph's expansion storage is the tail of its outer task's heap

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -81,32 +81,85 @@ The host/device boundary is POD and position-independent. Fanins are integer
 producer IDs, not pointers. The only per-slot pointers are rebound to their final
 device addresses before H2D.
 
-### 3.1 Bounded H2D Upload
+### 3.1 What Ships: the Arena's Three Zones
+
+Three rules decide every byte of the runtime arena:
+
+1. **Whoever generates a value writes it.** Content the host generates is written
+   on the host and copied down. Content that is a function of the *layout* rather
+   than of the *run* is written by the side that reads it.
+2. **A copy carries per-run content, never an initialization pattern.** Shipping
+   bytes the device could derive from the layout spends link bandwidth
+   transporting a constant.
+3. **Initialize once.** A region whose content does not differ between runs is
+   established once, not re-established per bind.
+
+They partition the arena into three contiguous zones, and `runtime_reserve_layout`
+reserves them in this order:
+
+| Zone | Regions | Copied | Written by |
+| ---- | ------- | ------ | ---------- |
+| host-only | orchestrator block: `fanin_seen_epoch` / `scope_tasks` / TensorMap, ~8.5 MB | never | host, during graph construction |
+| copied | `[off_copied_begin, off_copied_end)`: runtime header, completion mailbox | whole zone, one copy | host |
+| device-only | `sm_handle`, `PTO2SchedulerState` and its thirteen queue slot arrays | never | AICPU at boot |
+
+Putting the copied zone **between** the two zones that are never copied is what
+makes `bind` a single contiguous `copy_to_device`. Both bounds are layout fields,
+so no consumer infers a boundary from which region happens to be reserved first —
+`bind_callable_to_runtime_impl` asserts only that they are ordered and in range.
+
+**Why the scheduler state is device-written.** `PTO2SchedulerState` holds no
+per-run content: `sm_header` and the ring pointer derive from a pooled SM base,
+queue capacities are compile-time constants, and hbg never advances
+`last_task_alive`. Its one host-side entry point, `on_scope_end`, is an empty stub
+here. So the host would only be writing an initialization pattern — 203,392 bytes
+of it, dominated by `AsyncWaitList::entries` — for the device to receive and never
+read. `PTO2Runtime` therefore holds a *pointer* to it, wired from
+`off_scheduler` on each side, and the AICPU calls `init_data_from_layout` at boot.
+
+**Why the queue slots are device-written.** `push` claims `slots[pos & mask]` only
+when that slot's `sequence` already equals `pos`, so an empty queue is a
+`0..capacity-1` ramp, not zeroed memory: on zeroed slots position 0 happens to
+match and every later position reads a lower sequence, which is the full-queue
+signal, so such a queue accepts one push and then reports full. The ramp is
+mandatory but it is a function of `capacity` alone, so
+`PTO2SchedulerState::seed_queue_slots()` writes it on the device rather than `bind`
+shipping 1,775,616 bytes of it. The ready queues are still *not* bounded to
+`total_tasks`: graph execution expands a GRAPH task into on-device nodes that push
+past the host task count, so every slot must carry a valid sequence.
+
+Both run before the boot thread publishes `runtime_init_ready_`, which is what
+releases the peer threads into the dispatch loop, so no push can observe an
+uninitialized queue.
+
+**Boot cost, not per-run cost.** The sequence invariant is lap-relative: a free
+slot's sequence tracks the position it serves, and `pop` releases a slot with
+exactly the value the next lap's `push` expects. A drained queue is therefore
+already an empty queue, which is why `tensormap_and_ringbuffer` can leave
+`PTO2ReadyQueue::reset_for_reuse()` empty and never touch the positions. hbg
+re-establishes both on every attach today because the queue *headers* are reset
+per bind; the combination to avoid is resetting the positions while leaving the
+sequences mid-lap, which makes `push` read a sequence above its position and spin
+as if a peer were mid-publish.
+
+**Known gap.** The completion mailbox is still in the copied zone, but nothing
+reads its 4096 message slots before writing them (`try_push` CASes `head` and then
+writes the claimed slot), so 262,272 of the copied zone's 262,976 bytes are a
+`memset` the device does not need. By rule 2 it belongs in the device-only zone
+with its two cursors zeroed at boot.
+
+### 3.2 Bounded H2D Upload
 
 The shared-memory mirror is sized to ring capacity (task window) but a run only
 writes `[0, total_tasks)`, and the device boots scheduler-only and reads no SM slot
 past `total_tasks`. So the SM H2D shipped each run is bounded, not capacity-sized —
 the contract that keeps `bind` proportional to the workload.
 
-- **Shared memory** — the header is zeroed on the host; `descriptors`, `payloads`,
-  `slot_states` and `completion_flags` are each written per task at submit and
-  H2D-uploaded bounded to `[0, total_tasks)`. Per-slot reset is init-on-write in
-  `orch::prepare_task` as each slot is claimed — there is no window-wide reset.
-
-- **Runtime arena** — the **orchestrator block** (`fanin_seen_epoch` /
-  `scope_tasks` / TensorMap, ~8.5 MB) is **not shipped at all**: it is host-only
-  dep-computation scratch, and the AICPU scheduler holds zero references to it. (The
-  scalar `inline_completed_tasks` the scheduler does read lives in the runtime
-  header, inside the region that still ships whole.) Everything from the scheduler
-  block onward — the ready-queue slot pools, runtime header, and completion mailbox
-  — ships **whole**. The ready queues are *not* bounded to `total_tasks`: graph
-  execution replays a cached GRAPH task that the device Scheduler expands into
-  on-device nodes, and those nodes push into the ready queues past the host task
-  count, so the queue slots must all carry a valid Vyukov sequence on the device.
-
-`bind_callable_to_runtime_impl` `always_assert`s `orch_start <= orch_end` before
-uploading, so a future `runtime_reserve_layout` reorder that moved the scheduler
-block ahead of the orchestrator block faults instead of shipping a misaligned image.
+The header is zeroed on the host; `descriptors`, `payloads`, `slot_states` and
+`completion_flags` are each written per task at submit and H2D-uploaded bounded to
+`[0, total_tasks)`. Per-slot reset is init-on-write in `orch::prepare_task` as each
+slot is claimed — there is no window-wide reset. The four segments travel as four
+copies rather than one because ring-sized tails separate their live prefixes.
 
 ## 4. Whole-Graph Capacity
 

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -551,7 +551,7 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: orchestrator re-init against host SM failed");
         return -1;
     }
-    rt->orchestrator.wire_arena_pointers(layout.orch, host_arena, &rt->scheduler);
+    rt->orchestrator.wire_arena_pointers(layout.orch, host_arena, rt->scheduler);
 
     PTO2SharedMemoryHandle host_sm_handle;
     if (!host_sm_handle.init_per_ring(host_sm, sm_size, eff_task_window_sizes, eff_heap_sizes)) {
@@ -1072,29 +1072,25 @@ extern "C" int bind_callable_to_runtime_impl(
     // *before* it can dereference the image.
     rt->prebuilt_layout = layout;
 
-    // Skip uploading the orchestrator block (fanin_seen_epoch / scope / tensormap,
-    // ~8.5 MB): it is host-only dep-computation scratch that the AICPU scheduler
-    // never reads. Ship [0, orch_start) (sm_handle) and
-    // [orch_end, arena_size) (runtime header + mailbox + every scheduler queue)
-    // whole; the orch block between them is not sent. The boundary is the
-    // layout's own, not inferred from a reservation order here.
-    const size_t orch_start = layout.orch.off_fanin_seen_epoch;
-    const size_t orch_end = layout.off_uploaded_tail_begin;
-    always_assert(orch_start <= orch_end);
+    // The arena is partitioned into three zones (see PTO2RuntimeArenaLayout) and
+    // only the middle one is copied: the host-only orchestrator block sits before
+    // it, and the regions the device initializes itself (sm_handle, scheduler
+    // state, queue slot arrays) sit after it. So bind is one copy of one range,
+    // with both bounds taken from the layout rather than inferred from a
+    // reservation order here.
+    const size_t copied_begin = layout.off_copied_begin;
+    const size_t copied_end = layout.off_copied_end;
+    always_assert(copied_begin <= copied_end && copied_end <= layout.arena_size);
     char *arena_host = static_cast<char *>(host_arena.base());
     char *arena_dev = static_cast<char *>(runtime_arena_dev);
     const int64_t t_arena_h2d_ns = bind_now_ns();
-    int rc_upload = api->copy_to_device(arena_dev, arena_host, orch_start);
-    if (rc_upload == 0) {
-        rc_upload = api->copy_to_device(arena_dev + orch_end, arena_host + orch_end, layout.arena_size - orch_end);
-    }
+    int rc_upload = api->copy_to_device(arena_dev + copied_begin, arena_host + copied_begin, copied_end - copied_begin);
     if (rc_upload != 0) {
         LOG_ERROR("Failed to rtMemcpy prebuilt runtime arena to device (rc=%d)", rc_upload);
         return -1;
     }
     {
-        const uint64_t arena_h2d_bytes =
-            static_cast<uint64_t>(orch_start) + static_cast<uint64_t>(layout.arena_size - orch_end);
+        const uint64_t arena_h2d_bytes = static_cast<uint64_t>(copied_end - copied_begin);
         char attrs[96];
         snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, arena_h2d_bytes);
         record_bind_phase(HostPhaseKind::BindArenaH2d, t_arena_h2d_ns, attrs, arena_h2d_bytes);

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -115,11 +115,26 @@ struct PTO2RuntimeArenaLayout {
     size_t off_sm_handle{0};
     PTO2OrchestratorLayout orch;
     PTO2SchedulerLayout sched;
+    size_t off_scheduler{0};
     size_t off_runtime{0};
     size_t off_mailbox{0};
-    // First offset past the skipped orchestrator block: the start of the single
-    // contiguous range bind uploads after [0, orch.off_fanin_seen_epoch).
-    size_t off_uploaded_tail_begin{0};
+    // The arena is reserved in three zones and the offsets above land in exactly
+    // one of them:
+    //
+    //   host-only    the orchestrator block. Dep-computation scratch the AICPU
+    //                never reads, so it is never copied.
+    //   copied       [off_copied_begin, off_copied_end). Every byte carries this
+    //                run's own content, so bind ships the whole zone as one
+    //                contiguous range.
+    //   device-only  sm_handle, the scheduler state and its queue slot arrays.
+    //                Reachable storage whose content is a function of the layout,
+    //                not of the run, so the device writes it at boot instead of
+    //                receiving an initialization pattern over PCIe.
+    //
+    // Placing the copied zone in the middle is what keeps the upload a single
+    // range: the two zones that are not copied sit on either side of it.
+    size_t off_copied_begin{0};
+    size_t off_copied_end{0};
 
     // Cached parameters (re-used by init_data + wire stages).
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]{};
@@ -144,7 +159,9 @@ struct PTO2Runtime {
     // Components
     PTO2SharedMemoryHandle *sm_handle;
     PTO2OrchestratorState orchestrator;
-    PTO2SchedulerState scheduler;
+    // Device-only zone: the scheduler state holds no per-run content, so it is
+    // addressed through the arena rather than carried inside this header.
+    PTO2SchedulerState *scheduler;
     AICoreCompletionMailbox *aicore_mailbox;
 
     // GM Heap for output buffers

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -91,6 +91,18 @@ struct alignas(64) PTO2ReadyQueue {
     std::atomic<uint64_t> max_occupancy;
     char _pad2[64 - 2 * sizeof(std::atomic<uint64_t>)];  // Own cache line
 
+    // Bring the slots[] array to its empty state: slot i's sequence must equal i
+    // for push_tagged's `diff == 0` claim test to accept the first pass, so an
+    // empty queue is a 0..capacity-1 ramp rather than zeroed memory. Runs on the
+    // device after wire_arena_pointers, before any push — the region is reserved
+    // past the uploaded range, so nothing seeds it on the host.
+    void seed_slots() {
+        for (uint64_t i = 0; i < capacity; i++) {
+            slots[i].sequence.store(static_cast<int64_t>(i), std::memory_order_relaxed);
+            slots[i].slot_state = nullptr;
+        }
+    }
+
     uint64_t size() {
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
@@ -411,16 +423,15 @@ struct alignas(64) PTO2ReadyQueue {
 // as non-member so PTO2ReadyQueue stays a POD-like struct with cache-line
 // alignment. Storage is owned by the caller-supplied arena.
 //   reserve_layout: declare the slots[] region on the arena (must precede commit)
-//   init_from_layout: bind slots pointer from arena.region_ptr(off) and
-//                     initialize sequence counters
+//   init_from_layout: initialize the queue header (capacity, mask, positions)
+//   seed_slots: establish the slot array's empty ramp, on the device only
 //   destroy: forget the slots pointer (arena owns the buffer)
 size_t ready_queue_reserve_layout(DeviceArena &arena, uint64_t capacity);
-// Writes everything *except* the arena-internal `slots` pointer field
-// (sequences/positions on the slot array, capacity, mask). Uses
-// arena.region_ptr(slots_off) only to address the slot array for writes;
-// does NOT store the pointer in `queue->slots`. Call
-// `ready_queue_wire_arena_pointers` afterwards to set the field itself.
-bool ready_queue_init_data_from_layout(PTO2ReadyQueue *queue, DeviceArena &arena, size_t slots_off, uint64_t capacity);
+// Writes the header fields only: capacity, mask, positions, occupancy counter.
+// The slot array is neither addressed nor written — it lives past the uploaded
+// range and PTO2ReadyQueue::seed_slots() fills it on the device. Call
+// `ready_queue_wire_arena_pointers` to set the `slots` pointer itself.
+void ready_queue_init_data_from_layout(PTO2ReadyQueue *queue, uint64_t capacity);
 // Stores queue->slots = arena.region_ptr(slots_off). Idempotent.
 void ready_queue_wire_arena_pointers(PTO2ReadyQueue *queue, DeviceArena &arena, size_t slots_off);
 void ready_queue_destroy(PTO2ReadyQueue *queue);
@@ -1182,6 +1193,13 @@ struct PTO2SchedulerState {
     // (ready_queues[].slots, dummy_ready_queue.slots, dep_pool.base for each
     // ring). Called on both host and device sides.
     void wire_arena_pointers(const PTO2SchedulerLayout &layout, DeviceArena &arena);
+
+    // Phase 3c, device only: bring every queue's slots[] to its empty ramp. The
+    // slot arrays sit past the uploaded range, so this is the only thing that
+    // establishes the sequence values push compares against. Runs once per arena
+    // after wire_arena_pointers and before any push; a drained queue needs no
+    // repeat, since a free slot's sequence tracks the position it serves.
+    void seed_queue_slots();
 
     // Forget per-region pointers; arena owns the backing memory.
     void destroy();

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -1042,7 +1042,7 @@ void SchedulerContext::deinit() {
 
 void SchedulerContext::bind_runtime(PTO2Runtime *rt) {
     rt_ = rt;
-    sched_ = &rt->scheduler;
+    sched_ = rt->scheduler;
 }
 
 // =============================================================================
@@ -1086,7 +1086,7 @@ void SchedulerContext::on_orchestration_done(
     if (inline_completed > 0) {
         completed_tasks_.fetch_add(inline_completed, std::memory_order_relaxed);
 #if SIMPLER_SCHED_PROFILING
-        rt->scheduler.tasks_completed.fetch_add(inline_completed, std::memory_order_relaxed);
+        rt->scheduler->tasks_completed.fetch_add(inline_completed, std::memory_order_relaxed);
 #endif
     }
 

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -55,22 +55,15 @@ size_t ready_queue_reserve_layout(DeviceArena &arena, uint64_t capacity) {
     return arena.reserve(capacity * sizeof(PTO2ReadyQueueSlot), PTO2_ALIGN_SIZE);
 }
 
-bool ready_queue_init_data_from_layout(PTO2ReadyQueue *queue, DeviceArena &arena, size_t slots_off, uint64_t capacity) {
-    // Address the slots region for data writes without storing the pointer in
-    // queue->slots — that field is set by ready_queue_wire_arena_pointers.
-    auto *slots_arena = static_cast<PTO2ReadyQueueSlot *>(arena.region_ptr(slots_off));
+// Initialize the queue header only. slots[] carries the sequence ramp push
+// compares against, but it lives past the uploaded range and is seeded on the
+// device by PTO2SchedulerState::seed_queue_slots(), so nothing writes it here.
+void ready_queue_init_data_from_layout(PTO2ReadyQueue *queue, uint64_t capacity) {
     queue->capacity = capacity;
     queue->mask = capacity - 1;
     queue->enqueue_pos.store(0, std::memory_order_relaxed);
     queue->dequeue_pos.store(0, std::memory_order_relaxed);
     queue->max_occupancy.store(0, std::memory_order_relaxed);
-
-    for (uint64_t i = 0; i < capacity; i++) {
-        slots_arena[i].sequence.store((int64_t)i, std::memory_order_relaxed);
-        slots_arena[i].slot_state = nullptr;
-    }
-
-    return true;
 }
 
 void ready_queue_wire_arena_pointers(PTO2ReadyQueue *queue, DeviceArena &arena, size_t slots_off) {
@@ -142,49 +135,44 @@ bool PTO2SchedulerState::init_data_from_layout(
     }
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        if (!ready_queue_init_data_from_layout(
-                &sched->ready_queues[i], arena, layout.off_ready_queue_slots[i], layout.ready_queue_capacity
-            )) {
-            return false;
-        }
+        ready_queue_init_data_from_layout(&sched->ready_queues[i], layout.ready_queue_capacity);
     }
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        if (!ready_queue_init_data_from_layout(
-                &sched->ready_sync_queues[i], arena, layout.off_ready_sync_queue_slots[i], layout.ready_queue_capacity
-            )) {
-            return false;
-        }
+        ready_queue_init_data_from_layout(&sched->ready_sync_queues[i], layout.ready_queue_capacity);
     }
-    if (!ready_queue_init_data_from_layout(
-            &sched->dummy_ready_queue, arena, layout.off_dummy_ready_queue_slots, layout.ready_queue_capacity
-        )) {
-        return false;
-    }
-    if (!ready_queue_init_data_from_layout(
-            &sched->graph_ready_queue, arena, layout.off_graph_ready_queue_slots, layout.ready_queue_capacity
-        ) ||
-        !ready_queue_init_data_from_layout(
-            &sched->graph_prepare_queue, arena, layout.off_graph_prepare_queue_slots, layout.ready_queue_capacity
-        )) {
-        return false;
-    }
+    ready_queue_init_data_from_layout(&sched->dummy_ready_queue, layout.ready_queue_capacity);
+    ready_queue_init_data_from_layout(&sched->graph_ready_queue, layout.ready_queue_capacity);
+    ready_queue_init_data_from_layout(&sched->graph_prepare_queue, layout.ready_queue_capacity);
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        if (!ready_queue_init_data_from_layout(
-                &sched->early_dispatch_queues[i], arena, layout.off_early_dispatch_queue_slots[i],
-                PTO2_EARLY_DISPATCH_QUEUE_SIZE
-            )) {
-            return false;
-        }
+        ready_queue_init_data_from_layout(&sched->early_dispatch_queues[i], PTO2_EARLY_DISPATCH_QUEUE_SIZE);
     }
-    if (!ready_queue_init_data_from_layout(
-            &sched->early_sync_start_queue, arena, layout.off_early_sync_start_queue_slots,
-            PTO2_EARLY_DISPATCH_QUEUE_SIZE
-        )) {
-        return false;
-    }
+    ready_queue_init_data_from_layout(&sched->early_sync_start_queue, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
 
     // Polling: no dep_pool arena region to initialize.
+    (void)arena;
+    (void)layout;
     return true;
+}
+
+// Device-only: establish every queue's empty ramp. Mirrors the enumeration in
+// wire_arena_pointers / destroy — a queue whose slots[] is never seeded accepts
+// one push and then reports full, since push claims a slot only when its
+// sequence already equals the position being claimed.
+void PTO2SchedulerState::seed_queue_slots() {
+    PTO2SchedulerState *sched = this;
+    for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+        sched->ready_queues[i].seed_slots();
+    }
+    for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+        sched->ready_sync_queues[i].seed_slots();
+    }
+    sched->dummy_ready_queue.seed_slots();
+    sched->graph_ready_queue.seed_slots();
+    sched->graph_prepare_queue.seed_slots();
+    for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+        sched->early_dispatch_queues[i].seed_slots();
+    }
+    sched->early_sync_start_queue.seed_slots();
 }
 
 void PTO2SchedulerState::wire_arena_pointers(const PTO2SchedulerLayout &layout, DeviceArena &arena) {
@@ -341,15 +329,20 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
         layout.heap_sizes[r] = heap_sizes[r];
     }
 
-    // Reservation order defines the two ranges bind uploads. The orchestrator
-    // block is host-only dep-computation scratch the AICPU never reads, so it is
-    // skipped; everything the device does read is placed after it, which is what
-    // makes [off_uploaded_tail_begin, ...) a single range.
-    layout.off_sm_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
+    // Reservation order is the zone partition (see PTO2RuntimeArenaLayout): the
+    // host-only orchestrator block, then the one copied range, then everything
+    // the device initializes itself. Each zone is contiguous, so bind is a single
+    // copy and no consumer has to infer a boundary from what happens to come
+    // first.
     layout.orch = PTO2OrchestratorState::reserve_layout(arena, static_cast<int32_t>(task_window_sizes[0]));
+
+    layout.off_copied_begin = arena.total_size();
     layout.off_runtime = arena.reserve(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE);
-    layout.off_uploaded_tail_begin = layout.off_runtime;
     layout.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
+    layout.off_copied_end = arena.total_size();
+
+    layout.off_sm_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
+    layout.off_scheduler = arena.reserve(sizeof(PTO2SchedulerState), alignof(PTO2SchedulerState));
     layout.sched = PTO2SchedulerState::reserve_layout(arena);
 
     layout.arena_size = arena.total_size();
@@ -387,9 +380,6 @@ PTO2Runtime *runtime_init_data_from_layout(
     PTO2Runtime *rt = static_cast<PTO2Runtime *>(arena.region_ptr(layout.off_runtime));
     memset(rt, 0, sizeof(*rt));
 
-    auto *sm_wrap = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(layout.off_sm_handle));
-    memset(sm_wrap, 0, sizeof(*sm_wrap));
-
     // rt->ops is filled by the AICPU at boot.
     rt->mode = mode;
     rt->gm_heap = gm_heap_dev_base;
@@ -402,16 +392,18 @@ PTO2Runtime *runtime_init_data_from_layout(
     rt->total_cycles = 0;
     rt->active_callable_hash = 0;
 
+    // Two components are deliberately not initialized here.
+    //
     // The orchestrator is initialized by the host-orch path
     // (run_host_orchestration) against the host SM once it is allocated, then
-    // relocated for the device. Initializing it here would be dead work: its
-    // arena content (tensormap + seen_epoch memset) is immediately overwritten by
-    // that re-init, and the orchestrator arena block is not uploaded to the device
-    // (the scheduler boots without it). So only the scheduler is initialized here;
-    // rt->orchestrator stays zeroed (from the memset above) until run_host_orchestration.
-    if (!rt->scheduler.init_data_from_layout(layout.sched, arena, sm_dev_base)) {
-        return nullptr;
-    }
+    // relocated for the device. Doing it here would be dead work: its arena
+    // content (tensormap + seen_epoch memset) is immediately overwritten by that
+    // re-init, and the orchestrator block is host-only anyway.
+    //
+    // The scheduler and sm_handle live in the device-only zone, so their bytes
+    // never travel; the AICPU initializes them at boot. Writing them here would
+    // be writing an initialization pattern that nothing reads.
+    (void)sm_dev_base;
 
     auto *mailbox = static_cast<AICoreCompletionMailbox *>(arena.region_ptr(layout.off_mailbox));
     memset(mailbox, 0, sizeof(*mailbox));
@@ -422,14 +414,15 @@ PTO2Runtime *runtime_init_data_from_layout(
 void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt) {
     rt->sm_handle = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(layout.off_sm_handle));
     rt->aicore_mailbox = static_cast<AICoreCompletionMailbox *>(arena.region_ptr(layout.off_mailbox));
-    rt->orchestrator.wire_arena_pointers(layout.orch, arena, &rt->scheduler);
-    rt->scheduler.wire_arena_pointers(layout.sched, arena);
+    rt->scheduler = static_cast<PTO2SchedulerState *>(arena.region_ptr(layout.off_scheduler));
+    rt->orchestrator.wire_arena_pointers(layout.orch, arena, rt->scheduler);
+    rt->scheduler->wire_arena_pointers(layout.sched, arena);
 }
 
 void runtime_destroy(PTO2Runtime *rt, DeviceArena & /*arena*/) {
     // Arena buffer is pooled across runs by DeviceRunner — never freed here.
     if (!rt) return;
-    rt->scheduler.destroy();
+    rt->scheduler->destroy();
     rt->orchestrator.destroy();
     rt->aicore_mailbox = nullptr;
     rt->sm_handle = nullptr;

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -265,12 +265,27 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
             void *sm_ptr = runtime->get_gm_sm_ptr();
             uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(rt->prebuilt_layout.task_window_sizes);
+            // sm_handle and the scheduler state are the device-only zone: their
+            // bytes never travel, so they start as whatever the pooled arena last
+            // held. Zeroing the handle first is what makes attach_populated's
+            // assignment of every field checkable here rather than by inspecting
+            // attach_populated.
             memset(rt->sm_handle, 0, sizeof(*rt->sm_handle));
             if (!rt->sm_handle->attach_populated(sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes)) {
                 LOG_ERROR("Thread %d: host-orch: sm_handle->attach_populated failed", thread_idx);
                 rt = nullptr;
                 run_rc = -1;
                 boot_ok = false;
+            } else if (!rt->scheduler->init_data_from_layout(rt->prebuilt_layout.sched, runtime_arena_, sm_ptr)) {
+                LOG_ERROR("Thread %d: host-orch: scheduler init_data_from_layout failed", thread_idx);
+                rt = nullptr;
+                run_rc = -1;
+                boot_ok = false;
+            } else {
+                // Queue headers are set, so the slot arrays can take their ramp.
+                // Both precede runtime_init_ready_, which is what releases the peer
+                // threads into the dispatch loop, so no push sees either unset.
+                rt->scheduler->seed_queue_slots();
             }
         }
 
@@ -364,7 +379,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // Destroy the host_build_graph runtime. sm_handle / rt are recreated
         // every run, so always tear them down here.
         if (rt != nullptr) {
-            rt->scheduler.print_queues();
+            rt->scheduler->print_queues();
             // Clear g_current_runtime in this DSO before destroying rt.
             framework_bind_runtime(nullptr);
             // A Graph's expansion storage is the tail of its outer task's heap

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -81,32 +81,85 @@ The host/device boundary is POD and position-independent. Fanins are integer
 producer IDs, not pointers. The only per-slot pointers are rebound to their final
 device addresses before H2D.
 
-### 3.1 Bounded H2D Upload
+### 3.1 What Ships: the Arena's Three Zones
+
+Three rules decide every byte of the runtime arena:
+
+1. **Whoever generates a value writes it.** Content the host generates is written
+   on the host and copied down. Content that is a function of the *layout* rather
+   than of the *run* is written by the side that reads it.
+2. **A copy carries per-run content, never an initialization pattern.** Shipping
+   bytes the device could derive from the layout spends link bandwidth
+   transporting a constant.
+3. **Initialize once.** A region whose content does not differ between runs is
+   established once, not re-established per bind.
+
+They partition the arena into three contiguous zones, and `runtime_reserve_layout`
+reserves them in this order:
+
+| Zone | Regions | Copied | Written by |
+| ---- | ------- | ------ | ---------- |
+| host-only | orchestrator block: `fanin_seen_epoch` / `scope_tasks` / TensorMap, ~8.5 MB | never | host, during graph construction |
+| copied | `[off_copied_begin, off_copied_end)`: runtime header, completion mailbox | whole zone, one copy | host |
+| device-only | `sm_handle`, `PTO2SchedulerState` and its thirteen queue slot arrays | never | AICPU at boot |
+
+Putting the copied zone **between** the two zones that are never copied is what
+makes `bind` a single contiguous `copy_to_device`. Both bounds are layout fields,
+so no consumer infers a boundary from which region happens to be reserved first —
+`bind_callable_to_runtime_impl` asserts only that they are ordered and in range.
+
+**Why the scheduler state is device-written.** `PTO2SchedulerState` holds no
+per-run content: `sm_header` and the ring pointer derive from a pooled SM base,
+queue capacities are compile-time constants, and hbg never advances
+`last_task_alive`. Its one host-side entry point, `on_scope_end`, is an empty stub
+here. So the host would only be writing an initialization pattern — 203,392 bytes
+of it, dominated by `AsyncWaitList::entries` — for the device to receive and never
+read. `PTO2Runtime` therefore holds a *pointer* to it, wired from
+`off_scheduler` on each side, and the AICPU calls `init_data_from_layout` at boot.
+
+**Why the queue slots are device-written.** `push` claims `slots[pos & mask]` only
+when that slot's `sequence` already equals `pos`, so an empty queue is a
+`0..capacity-1` ramp, not zeroed memory: on zeroed slots position 0 happens to
+match and every later position reads a lower sequence, which is the full-queue
+signal, so such a queue accepts one push and then reports full. The ramp is
+mandatory but it is a function of `capacity` alone, so
+`PTO2SchedulerState::seed_queue_slots()` writes it on the device rather than `bind`
+shipping 1,775,616 bytes of it. The ready queues are still *not* bounded to
+`total_tasks`: graph execution expands a GRAPH task into on-device nodes that push
+past the host task count, so every slot must carry a valid sequence.
+
+Both run before the boot thread publishes `runtime_init_ready_`, which is what
+releases the peer threads into the dispatch loop, so no push can observe an
+uninitialized queue.
+
+**Boot cost, not per-run cost.** The sequence invariant is lap-relative: a free
+slot's sequence tracks the position it serves, and `pop` releases a slot with
+exactly the value the next lap's `push` expects. A drained queue is therefore
+already an empty queue, which is why `tensormap_and_ringbuffer` can leave
+`PTO2ReadyQueue::reset_for_reuse()` empty and never touch the positions. hbg
+re-establishes both on every attach today because the queue *headers* are reset
+per bind; the combination to avoid is resetting the positions while leaving the
+sequences mid-lap, which makes `push` read a sequence above its position and spin
+as if a peer were mid-publish.
+
+**Known gap.** The completion mailbox is still in the copied zone, but nothing
+reads its 4096 message slots before writing them (`try_push` CASes `head` and then
+writes the claimed slot), so 262,272 of the copied zone's 262,976 bytes are a
+`memset` the device does not need. By rule 2 it belongs in the device-only zone
+with its two cursors zeroed at boot.
+
+### 3.2 Bounded H2D Upload
 
 The shared-memory mirror is sized to ring capacity (task window) but a run only
 writes `[0, total_tasks)`, and the device boots scheduler-only and reads no SM slot
 past `total_tasks`. So the SM H2D shipped each run is bounded, not capacity-sized —
 the contract that keeps `bind` proportional to the workload.
 
-- **Shared memory** — the header is zeroed on the host; `descriptors`, `payloads`,
-  `slot_states` and `completion_flags` are each written per task at submit and
-  H2D-uploaded bounded to `[0, total_tasks)`. Per-slot reset is init-on-write in
-  `orch::prepare_task` as each slot is claimed — there is no window-wide reset.
-
-- **Runtime arena** — the **orchestrator block** (`fanin_seen_epoch` /
-  `scope_tasks` / TensorMap, ~8.5 MB) is **not shipped at all**: it is host-only
-  dep-computation scratch, and the AICPU scheduler holds zero references to it. (The
-  scalar `inline_completed_tasks` the scheduler does read lives in the runtime
-  header, inside the region that still ships whole.) Everything from the scheduler
-  block onward — the ready-queue slot pools, runtime header, and completion mailbox
-  — ships **whole**. The ready queues are *not* bounded to `total_tasks`: graph
-  execution replays a cached GRAPH task that the device Scheduler expands into
-  on-device nodes, and those nodes push into the ready queues past the host task
-  count, so the queue slots must all carry a valid Vyukov sequence on the device.
-
-`bind_callable_to_runtime_impl` `always_assert`s `orch_start <= orch_end` before
-uploading, so a future `runtime_reserve_layout` reorder that moved the scheduler
-block ahead of the orchestrator block faults instead of shipping a misaligned image.
+The header is zeroed on the host; `descriptors`, `payloads`, `slot_states` and
+`completion_flags` are each written per task at submit and H2D-uploaded bounded to
+`[0, total_tasks)`. Per-slot reset is init-on-write in `orch::prepare_task` as each
+slot is claimed — there is no window-wide reset. The four segments travel as four
+copies rather than one because ring-sized tails separate their live prefixes.
 
 ## 4. Whole-Graph Capacity
 

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -597,7 +597,7 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: orchestrator re-init against host SM failed");
         return -1;
     }
-    rt->orchestrator.wire_arena_pointers(layout.orch, host_arena, &rt->scheduler);
+    rt->orchestrator.wire_arena_pointers(layout.orch, host_arena, rt->scheduler);
 
     // Initialize the host SM header (ring flow control) so submit_task can run.
     PTO2SharedMemoryHandle host_sm_handle;
@@ -1134,29 +1134,25 @@ extern "C" int bind_callable_to_runtime_impl(
     // *before* it can dereference the image.
     rt->prebuilt_layout = layout;
 
-    // Skip uploading the orchestrator block (fanin_seen_epoch / scope / tensormap,
-    // ~8.5 MB): it is host-only dep-computation scratch that the AICPU scheduler
-    // never reads. Ship [0, orch_start) (sm_handle) and
-    // [orch_end, arena_size) (runtime header + mailbox + every scheduler queue)
-    // whole; the orch block between them is not sent. The boundary is the
-    // layout's own, not inferred from a reservation order here.
-    const size_t orch_start = layout.orch.off_fanin_seen_epoch;
-    const size_t orch_end = layout.off_uploaded_tail_begin;
-    always_assert(orch_start <= orch_end);
+    // The arena is partitioned into three zones (see PTO2RuntimeArenaLayout) and
+    // only the middle one is copied: the host-only orchestrator block sits before
+    // it, and the regions the device initializes itself (sm_handle, scheduler
+    // state, queue slot arrays) sit after it. So bind is one copy of one range,
+    // with both bounds taken from the layout rather than inferred from a
+    // reservation order here.
+    const size_t copied_begin = layout.off_copied_begin;
+    const size_t copied_end = layout.off_copied_end;
+    always_assert(copied_begin <= copied_end && copied_end <= layout.arena_size);
     char *arena_host = static_cast<char *>(host_arena.base());
     char *arena_dev = static_cast<char *>(runtime_arena_dev);
     const int64_t t_arena_h2d_ns = bind_now_ns();
-    int rc_upload = api->copy_to_device(arena_dev, arena_host, orch_start);
-    if (rc_upload == 0) {
-        rc_upload = api->copy_to_device(arena_dev + orch_end, arena_host + orch_end, layout.arena_size - orch_end);
-    }
+    int rc_upload = api->copy_to_device(arena_dev + copied_begin, arena_host + copied_begin, copied_end - copied_begin);
     if (rc_upload != 0) {
         LOG_ERROR("Failed to rtMemcpy prebuilt runtime arena to device (rc=%d)", rc_upload);
         return -1;
     }
     {
-        const uint64_t arena_h2d_bytes =
-            static_cast<uint64_t>(orch_start) + static_cast<uint64_t>(layout.arena_size - orch_end);
+        const uint64_t arena_h2d_bytes = static_cast<uint64_t>(copied_end - copied_begin);
         char attrs[96];
         snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, arena_h2d_bytes);
         record_bind_phase(HostPhaseKind::BindArenaH2d, t_arena_h2d_ns, attrs, arena_h2d_bytes);

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -116,11 +116,26 @@ struct PTO2RuntimeArenaLayout {
     size_t off_sm_handle{0};
     PTO2OrchestratorLayout orch;
     PTO2SchedulerLayout sched;
+    size_t off_scheduler{0};
     size_t off_runtime{0};
     size_t off_mailbox{0};
-    // First offset past the skipped orchestrator block: the start of the single
-    // contiguous range bind uploads after [0, orch.off_fanin_seen_epoch).
-    size_t off_uploaded_tail_begin{0};
+    // The arena is reserved in three zones and the offsets above land in exactly
+    // one of them:
+    //
+    //   host-only    the orchestrator block. Dep-computation scratch the AICPU
+    //                never reads, so it is never copied.
+    //   copied       [off_copied_begin, off_copied_end). Every byte carries this
+    //                run's own content, so bind ships the whole zone as one
+    //                contiguous range.
+    //   device-only  sm_handle, the scheduler state and its queue slot arrays.
+    //                Reachable storage whose content is a function of the layout,
+    //                not of the run, so the device writes it at boot instead of
+    //                receiving an initialization pattern over PCIe.
+    //
+    // Placing the copied zone in the middle is what keeps the upload a single
+    // range: the two zones that are not copied sit on either side of it.
+    size_t off_copied_begin{0};
+    size_t off_copied_end{0};
 
     // Cached parameters (re-used by init_data + wire stages).
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]{};
@@ -145,7 +160,9 @@ struct PTO2Runtime {
     // Components
     PTO2SharedMemoryHandle *sm_handle;
     PTO2OrchestratorState orchestrator;
-    PTO2SchedulerState scheduler;
+    // Device-only zone: the scheduler state holds no per-run content, so it is
+    // addressed through the arena rather than carried inside this header.
+    PTO2SchedulerState *scheduler;
     AICoreCompletionMailbox *aicore_mailbox;
 
     // GM Heap for output buffers

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -91,6 +91,18 @@ struct alignas(64) PTO2ReadyQueue {
     std::atomic<uint64_t> max_occupancy;
     char _pad2[64 - 2 * sizeof(std::atomic<uint64_t>)];  // Own cache line
 
+    // Bring the slots[] array to its empty state: slot i's sequence must equal i
+    // for push_tagged's `diff == 0` claim test to accept the first pass, so an
+    // empty queue is a 0..capacity-1 ramp rather than zeroed memory. Runs on the
+    // device after wire_arena_pointers, before any push — the region is reserved
+    // past the uploaded range, so nothing seeds it on the host.
+    void seed_slots() {
+        for (uint64_t i = 0; i < capacity; i++) {
+            slots[i].sequence.store(static_cast<int64_t>(i), std::memory_order_relaxed);
+            slots[i].slot_state = nullptr;
+        }
+    }
+
     uint64_t size() {
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
@@ -411,16 +423,15 @@ struct alignas(64) PTO2ReadyQueue {
 // as non-member so PTO2ReadyQueue stays a POD-like struct with cache-line
 // alignment. Storage is owned by the caller-supplied arena.
 //   reserve_layout: declare the slots[] region on the arena (must precede commit)
-//   init_from_layout: bind slots pointer from arena.region_ptr(off) and
-//                     initialize sequence counters
+//   init_from_layout: initialize the queue header (capacity, mask, positions)
+//   seed_slots: establish the slot array's empty ramp, on the device only
 //   destroy: forget the slots pointer (arena owns the buffer)
 size_t ready_queue_reserve_layout(DeviceArena &arena, uint64_t capacity);
-// Writes everything *except* the arena-internal `slots` pointer field
-// (sequences/positions on the slot array, capacity, mask). Uses
-// arena.region_ptr(slots_off) only to address the slot array for writes;
-// does NOT store the pointer in `queue->slots`. Call
-// `ready_queue_wire_arena_pointers` afterwards to set the field itself.
-bool ready_queue_init_data_from_layout(PTO2ReadyQueue *queue, DeviceArena &arena, size_t slots_off, uint64_t capacity);
+// Writes the header fields only: capacity, mask, positions, occupancy counter.
+// The slot array is neither addressed nor written — it lives past the uploaded
+// range and PTO2ReadyQueue::seed_slots() fills it on the device. Call
+// `ready_queue_wire_arena_pointers` to set the `slots` pointer itself.
+void ready_queue_init_data_from_layout(PTO2ReadyQueue *queue, uint64_t capacity);
 // Stores queue->slots = arena.region_ptr(slots_off). Idempotent.
 void ready_queue_wire_arena_pointers(PTO2ReadyQueue *queue, DeviceArena &arena, size_t slots_off);
 void ready_queue_destroy(PTO2ReadyQueue *queue);
@@ -1182,6 +1193,13 @@ struct PTO2SchedulerState {
     // (ready_queues[].slots, dummy_ready_queue.slots, dep_pool.base for each
     // ring). Called on both host and device sides.
     void wire_arena_pointers(const PTO2SchedulerLayout &layout, DeviceArena &arena);
+
+    // Phase 3c, device only: bring every queue's slots[] to its empty ramp. The
+    // slot arrays sit past the uploaded range, so this is the only thing that
+    // establishes the sequence values push compares against. Runs once per arena
+    // after wire_arena_pointers and before any push; a drained queue needs no
+    // repeat, since a free slot's sequence tracks the position it serves.
+    void seed_queue_slots();
 
     // Forget per-region pointers; arena owns the backing memory.
     void destroy();

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -1042,7 +1042,7 @@ void SchedulerContext::deinit() {
 
 void SchedulerContext::bind_runtime(PTO2Runtime *rt) {
     rt_ = rt;
-    sched_ = &rt->scheduler;
+    sched_ = rt->scheduler;
 }
 
 // =============================================================================
@@ -1086,7 +1086,7 @@ void SchedulerContext::on_orchestration_done(
     if (inline_completed > 0) {
         completed_tasks_.fetch_add(inline_completed, std::memory_order_relaxed);
 #if SIMPLER_SCHED_PROFILING
-        rt->scheduler.tasks_completed.fetch_add(inline_completed, std::memory_order_relaxed);
+        rt->scheduler->tasks_completed.fetch_add(inline_completed, std::memory_order_relaxed);
 #endif
     }
 

--- a/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -55,22 +55,15 @@ size_t ready_queue_reserve_layout(DeviceArena &arena, uint64_t capacity) {
     return arena.reserve(capacity * sizeof(PTO2ReadyQueueSlot), PTO2_ALIGN_SIZE);
 }
 
-bool ready_queue_init_data_from_layout(PTO2ReadyQueue *queue, DeviceArena &arena, size_t slots_off, uint64_t capacity) {
-    // Address the slots region for data writes without storing the pointer in
-    // queue->slots — that field is set by ready_queue_wire_arena_pointers.
-    auto *slots_arena = static_cast<PTO2ReadyQueueSlot *>(arena.region_ptr(slots_off));
+// Initialize the queue header only. slots[] carries the sequence ramp push
+// compares against, but it lives past the uploaded range and is seeded on the
+// device by PTO2SchedulerState::seed_queue_slots(), so nothing writes it here.
+void ready_queue_init_data_from_layout(PTO2ReadyQueue *queue, uint64_t capacity) {
     queue->capacity = capacity;
     queue->mask = capacity - 1;
     queue->enqueue_pos.store(0, std::memory_order_relaxed);
     queue->dequeue_pos.store(0, std::memory_order_relaxed);
     queue->max_occupancy.store(0, std::memory_order_relaxed);
-
-    for (uint64_t i = 0; i < capacity; i++) {
-        slots_arena[i].sequence.store((int64_t)i, std::memory_order_relaxed);
-        slots_arena[i].slot_state = nullptr;
-    }
-
-    return true;
 }
 
 void ready_queue_wire_arena_pointers(PTO2ReadyQueue *queue, DeviceArena &arena, size_t slots_off) {
@@ -142,49 +135,44 @@ bool PTO2SchedulerState::init_data_from_layout(
     }
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        if (!ready_queue_init_data_from_layout(
-                &sched->ready_queues[i], arena, layout.off_ready_queue_slots[i], layout.ready_queue_capacity
-            )) {
-            return false;
-        }
+        ready_queue_init_data_from_layout(&sched->ready_queues[i], layout.ready_queue_capacity);
     }
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        if (!ready_queue_init_data_from_layout(
-                &sched->ready_sync_queues[i], arena, layout.off_ready_sync_queue_slots[i], layout.ready_queue_capacity
-            )) {
-            return false;
-        }
+        ready_queue_init_data_from_layout(&sched->ready_sync_queues[i], layout.ready_queue_capacity);
     }
-    if (!ready_queue_init_data_from_layout(
-            &sched->dummy_ready_queue, arena, layout.off_dummy_ready_queue_slots, layout.ready_queue_capacity
-        )) {
-        return false;
-    }
-    if (!ready_queue_init_data_from_layout(
-            &sched->graph_ready_queue, arena, layout.off_graph_ready_queue_slots, layout.ready_queue_capacity
-        ) ||
-        !ready_queue_init_data_from_layout(
-            &sched->graph_prepare_queue, arena, layout.off_graph_prepare_queue_slots, layout.ready_queue_capacity
-        )) {
-        return false;
-    }
+    ready_queue_init_data_from_layout(&sched->dummy_ready_queue, layout.ready_queue_capacity);
+    ready_queue_init_data_from_layout(&sched->graph_ready_queue, layout.ready_queue_capacity);
+    ready_queue_init_data_from_layout(&sched->graph_prepare_queue, layout.ready_queue_capacity);
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        if (!ready_queue_init_data_from_layout(
-                &sched->early_dispatch_queues[i], arena, layout.off_early_dispatch_queue_slots[i],
-                PTO2_EARLY_DISPATCH_QUEUE_SIZE
-            )) {
-            return false;
-        }
+        ready_queue_init_data_from_layout(&sched->early_dispatch_queues[i], PTO2_EARLY_DISPATCH_QUEUE_SIZE);
     }
-    if (!ready_queue_init_data_from_layout(
-            &sched->early_sync_start_queue, arena, layout.off_early_sync_start_queue_slots,
-            PTO2_EARLY_DISPATCH_QUEUE_SIZE
-        )) {
-        return false;
-    }
+    ready_queue_init_data_from_layout(&sched->early_sync_start_queue, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
 
     // Polling: no dep_pool arena region to initialize.
+    (void)arena;
+    (void)layout;
     return true;
+}
+
+// Device-only: establish every queue's empty ramp. Mirrors the enumeration in
+// wire_arena_pointers / destroy — a queue whose slots[] is never seeded accepts
+// one push and then reports full, since push claims a slot only when its
+// sequence already equals the position being claimed.
+void PTO2SchedulerState::seed_queue_slots() {
+    PTO2SchedulerState *sched = this;
+    for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+        sched->ready_queues[i].seed_slots();
+    }
+    for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+        sched->ready_sync_queues[i].seed_slots();
+    }
+    sched->dummy_ready_queue.seed_slots();
+    sched->graph_ready_queue.seed_slots();
+    sched->graph_prepare_queue.seed_slots();
+    for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+        sched->early_dispatch_queues[i].seed_slots();
+    }
+    sched->early_sync_start_queue.seed_slots();
 }
 
 void PTO2SchedulerState::wire_arena_pointers(const PTO2SchedulerLayout &layout, DeviceArena &arena) {
@@ -341,15 +329,20 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
         layout.heap_sizes[r] = heap_sizes[r];
     }
 
-    // Reservation order defines the two ranges bind uploads. The orchestrator
-    // block is host-only dep-computation scratch the AICPU never reads, so it is
-    // skipped; everything the device does read is placed after it, which is what
-    // makes [off_uploaded_tail_begin, ...) a single range.
-    layout.off_sm_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
+    // Reservation order is the zone partition (see PTO2RuntimeArenaLayout): the
+    // host-only orchestrator block, then the one copied range, then everything
+    // the device initializes itself. Each zone is contiguous, so bind is a single
+    // copy and no consumer has to infer a boundary from what happens to come
+    // first.
     layout.orch = PTO2OrchestratorState::reserve_layout(arena, static_cast<int32_t>(task_window_sizes[0]));
+
+    layout.off_copied_begin = arena.total_size();
     layout.off_runtime = arena.reserve(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE);
-    layout.off_uploaded_tail_begin = layout.off_runtime;
     layout.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
+    layout.off_copied_end = arena.total_size();
+
+    layout.off_sm_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
+    layout.off_scheduler = arena.reserve(sizeof(PTO2SchedulerState), alignof(PTO2SchedulerState));
     layout.sched = PTO2SchedulerState::reserve_layout(arena);
 
     layout.arena_size = arena.total_size();
@@ -387,9 +380,6 @@ PTO2Runtime *runtime_init_data_from_layout(
     PTO2Runtime *rt = static_cast<PTO2Runtime *>(arena.region_ptr(layout.off_runtime));
     memset(rt, 0, sizeof(*rt));
 
-    auto *sm_wrap = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(layout.off_sm_handle));
-    memset(sm_wrap, 0, sizeof(*sm_wrap));
-
     // rt->ops is filled by the AICPU at boot.
     rt->mode = mode;
     rt->gm_heap = gm_heap_dev_base;
@@ -402,16 +392,18 @@ PTO2Runtime *runtime_init_data_from_layout(
     rt->total_cycles = 0;
     rt->active_callable_hash = 0;
 
+    // Two components are deliberately not initialized here.
+    //
     // The orchestrator is initialized by the host-orch path
     // (run_host_orchestration) against the host SM once it is allocated, then
-    // relocated for the device. Initializing it here would be dead work: its
-    // arena content (tensormap + seen_epoch memset) is immediately overwritten by
-    // that re-init, and the orchestrator arena block is not uploaded to the device
-    // (the scheduler boots without it). So only the scheduler is initialized here;
-    // rt->orchestrator stays zeroed (from the memset above) until run_host_orchestration.
-    if (!rt->scheduler.init_data_from_layout(layout.sched, arena, sm_dev_base)) {
-        return nullptr;
-    }
+    // relocated for the device. Doing it here would be dead work: its arena
+    // content (tensormap + seen_epoch memset) is immediately overwritten by that
+    // re-init, and the orchestrator block is host-only anyway.
+    //
+    // The scheduler and sm_handle live in the device-only zone, so their bytes
+    // never travel; the AICPU initializes them at boot. Writing them here would
+    // be writing an initialization pattern that nothing reads.
+    (void)sm_dev_base;
 
     auto *mailbox = static_cast<AICoreCompletionMailbox *>(arena.region_ptr(layout.off_mailbox));
     memset(mailbox, 0, sizeof(*mailbox));
@@ -422,14 +414,15 @@ PTO2Runtime *runtime_init_data_from_layout(
 void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt) {
     rt->sm_handle = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(layout.off_sm_handle));
     rt->aicore_mailbox = static_cast<AICoreCompletionMailbox *>(arena.region_ptr(layout.off_mailbox));
-    rt->orchestrator.wire_arena_pointers(layout.orch, arena, &rt->scheduler);
-    rt->scheduler.wire_arena_pointers(layout.sched, arena);
+    rt->scheduler = static_cast<PTO2SchedulerState *>(arena.region_ptr(layout.off_scheduler));
+    rt->orchestrator.wire_arena_pointers(layout.orch, arena, rt->scheduler);
+    rt->scheduler->wire_arena_pointers(layout.sched, arena);
 }
 
 void runtime_destroy(PTO2Runtime *rt, DeviceArena & /*arena*/) {
     // Arena buffer is pooled across runs by DeviceRunner — never freed here.
     if (!rt) return;
-    rt->scheduler.destroy();
+    rt->scheduler->destroy();
     rt->orchestrator.destroy();
     rt->aicore_mailbox = nullptr;
     rt->sm_handle = nullptr;

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -842,6 +842,18 @@ add_a2a3_hbg_runtime_test(test_hbg_tensor_access a2a3/test_hbg_tensor_access.cpp
 add_a2a3_hbg_runtime_test(test_dispatch_table a2a3/test_dispatch_table.cpp
     ${HBG_RUNTIME_DIR}/shared/runtime.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_core_tracker common/test_hbg_core_tracker.cpp)
+# The seed test calls the real ready_queue_init_data_from_layout, so it links the
+# shared init TU (and the orchestrator/SM members that TU refers to).
+add_a2a3_hbg_runtime_test(test_hbg_ready_queue_seed common/test_hbg_ready_queue_seed.cpp)
+target_sources(test_hbg_ready_queue_seed PRIVATE
+    ${HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
+    ${HBG_RUNTIME_DIR}/orchestrator_core/pto_ring_buffer.cpp
+    ${HBG_RUNTIME_DIR}/shared/pto_shared_memory.cpp
+    ${HBG_RUNTIME_DIR}/shared/pto_tensormap.cpp
+    ${HBG_RUNTIME_DIR}/shared/pto_runtime2_init.cpp
+    ${HBG_RUNTIME_DIR}/shared/runtime.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+)
 # The submit-poison test drives the real orchestrator submit path, so it links the
 # orchestrator + shared runtime out-of-line members (mirrors a2a3_rt_objs for hbg).
 add_a2a3_hbg_runtime_test(test_hbg_submit_poison a2a3/test_hbg_submit_poison.cpp)
@@ -875,6 +887,16 @@ target_sources(test_a5_hbg_graph_submit_failure PRIVATE
     ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
 )
 add_a5_hbg_runtime_test(test_a5_hbg_core_tracker common/test_hbg_core_tracker.cpp)
+add_a5_hbg_runtime_test(test_a5_hbg_ready_queue_seed common/test_hbg_ready_queue_seed.cpp)
+target_sources(test_a5_hbg_ready_queue_seed PRIVATE
+    ${A5_HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
+    ${A5_HBG_RUNTIME_DIR}/orchestrator_core/pto_ring_buffer.cpp
+    ${A5_HBG_RUNTIME_DIR}/shared/pto_shared_memory.cpp
+    ${A5_HBG_RUNTIME_DIR}/shared/pto_tensormap.cpp
+    ${A5_HBG_RUNTIME_DIR}/shared/pto_runtime2_init.cpp
+    ${A5_HBG_RUNTIME_DIR}/shared/runtime.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+)
 add_a5_hbg_runtime_test(test_a5_hbg_aicore_completion_mailbox a5/test_aicore_completion_mailbox.cpp)
 set(HBG_A5_RUNTIME_DIR ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/host_build_graph/runtime)
 # The submit-poison test drives the real orchestrator submit path, so it links the

--- a/tests/ut/cpp/a2a3/test_graph_activation.cpp
+++ b/tests/ut/cpp/a2a3/test_graph_activation.cpp
@@ -44,6 +44,9 @@ protected:
         ASSERT_NE(runtime_arena.commit(), nullptr);
         ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
         sched.wire_arena_pointers(sched_layout, runtime_arena);
+        // Same order the AICPU boots in: the slot arrays are not part of the
+        // uploaded image, so nothing can push until they carry their ramp.
+        sched.seed_queue_slots();
     }
 
     void TearDown() override {

--- a/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
@@ -67,6 +67,9 @@ protected:
         ));
         ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
         sched.wire_arena_pointers(sched_layout, runtime_arena);
+        // Same order the AICPU boots in: the slot arrays are not part of the
+        // uploaded image, so nothing can push until they carry their ramp.
+        sched.seed_queue_slots();
         orch.wire_arena_pointers(orch_layout, runtime_arena, &sched);
     }
 

--- a/tests/ut/cpp/a5/test_graph_activation.cpp
+++ b/tests/ut/cpp/a5/test_graph_activation.cpp
@@ -44,6 +44,9 @@ protected:
         ASSERT_NE(runtime_arena.commit(), nullptr);
         ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
         sched.wire_arena_pointers(sched_layout, runtime_arena);
+        // Same order the AICPU boots in: the slot arrays are not part of the
+        // uploaded image, so nothing can push until they carry their ramp.
+        sched.seed_queue_slots();
     }
 
     void TearDown() override {

--- a/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
@@ -67,6 +67,9 @@ protected:
         ));
         ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
         sched.wire_arena_pointers(sched_layout, runtime_arena);
+        // Same order the AICPU boots in: the slot arrays are not part of the
+        // uploaded image, so nothing can push until they carry their ramp.
+        sched.seed_queue_slots();
         orch.wire_arena_pointers(orch_layout, runtime_arena, &sched);
     }
 

--- a/tests/ut/cpp/common/test_hbg_ready_queue_seed.cpp
+++ b/tests/ut/cpp/common/test_hbg_ready_queue_seed.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The slot array of a host_build_graph ready queue is reserved past the uploaded
+ * range, so it reaches the device holding whatever the pooled allocation last
+ * had. seed_slots() is what makes it an empty queue.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "scheduler/pto_scheduler.h"
+
+namespace {
+
+constexpr uint64_t CAPACITY = 8;
+
+// A slots region under the test's control, filled with a pattern standing in for
+// unseeded device memory. 0 is deliberate for one case: zeroed memory is the
+// tempting assumption, and it is the one that silently behaves like a full queue.
+class SlotsRegion {
+public:
+    explicit SlotsRegion(uint8_t fill) :
+        storage_(CAPACITY * sizeof(PTO2ReadyQueueSlot)) {
+        std::memset(storage_.data(), fill, storage_.size());
+    }
+
+    PTO2ReadyQueueSlot *slots() { return reinterpret_cast<PTO2ReadyQueueSlot *>(storage_.data()); }
+
+private:
+    std::vector<std::byte> storage_;
+};
+
+// PTO2ReadyQueue holds atomics and so is neither copyable nor movable: the caller
+// owns the storage and this only fills it, exactly as the arena path does.
+void make_queue(PTO2ReadyQueue *queue, SlotsRegion &region) {
+    ready_queue_init_data_from_layout(queue, CAPACITY);
+    queue->slots = region.slots();
+}
+
+// Distinct non-null slot_state values; the queue only moves the pointer around.
+PTO2TaskSlotState *fake_slot_state(size_t i) {
+    static PTO2TaskSlotState states[CAPACITY * 2];
+    return &states[i];
+}
+
+}  // namespace
+
+// The header alone does not make a usable queue: push claims slots[pos] only when
+// its sequence already equals pos, so on zeroed memory position 0 happens to
+// match and every later position reads a lower sequence, which is the full-queue
+// signal. One push then succeeds and the rest report full.
+TEST(HbgReadyQueueSeed, ZeroedSlotsReportFullAfterOnePush) {
+    SlotsRegion region(0x00);
+    PTO2ReadyQueue queue{};
+    make_queue(&queue, region);
+
+    EXPECT_TRUE(queue.push(fake_slot_state(0)));
+    EXPECT_FALSE(queue.push(fake_slot_state(1)));
+    EXPECT_FALSE(queue.push(fake_slot_state(2)));
+}
+
+TEST(HbgReadyQueueSeed, SeededSlotsAcceptCapacityPushes) {
+    SlotsRegion region(0xAA);
+    PTO2ReadyQueue queue{};
+    make_queue(&queue, region);
+
+    queue.seed_slots();
+
+    for (uint64_t i = 0; i < CAPACITY; i++) {
+        EXPECT_TRUE(queue.push(fake_slot_state(i))) << "push " << i;
+    }
+    // Capacity is a hard bound: a full queue rejects rather than overwrites.
+    EXPECT_FALSE(queue.push(fake_slot_state(CAPACITY)));
+
+    for (uint64_t i = 0; i < CAPACITY; i++) {
+        EXPECT_EQ(queue.pop(), fake_slot_state(i)) << "pop " << i;
+    }
+    EXPECT_EQ(queue.pop(), nullptr);
+}
+
+// The ramp is a once-per-region cost, not a per-run one: pop releases a slot with
+// the sequence the next lap's push expects, so a drained queue keeps accepting
+// work across laps with no re-seed.
+TEST(HbgReadyQueueSeed, DrainedQueueWrapsWithoutReseeding) {
+    SlotsRegion region(0xAA);
+    PTO2ReadyQueue queue{};
+    make_queue(&queue, region);
+    queue.seed_slots();
+
+    for (uint64_t lap = 0; lap < 4; lap++) {
+        for (uint64_t i = 0; i < CAPACITY; i++) {
+            ASSERT_TRUE(queue.push(fake_slot_state(i))) << "lap " << lap << " push " << i;
+        }
+        for (uint64_t i = 0; i < CAPACITY; i++) {
+            ASSERT_EQ(queue.pop(), fake_slot_state(i)) << "lap " << lap << " pop " << i;
+        }
+    }
+
+    EXPECT_EQ(queue.max_occupancy.load(std::memory_order_relaxed), CAPACITY);
+}
+
+// Seeding is unconditional on attach, so it must also recover a region left
+// mid-lap by an earlier run rather than assuming a drained predecessor.
+TEST(HbgReadyQueueSeed, ReseedRecoversAPartiallyUsedRegion) {
+    SlotsRegion region(0xAA);
+    PTO2ReadyQueue queue{};
+    make_queue(&queue, region);
+    queue.seed_slots();
+    ASSERT_TRUE(queue.push(fake_slot_state(0)));
+    ASSERT_TRUE(queue.push(fake_slot_state(1)));
+
+    // What a fresh bind does: the uploaded header returns to zeroed positions and
+    // the device re-establishes the lap-0 ramp underneath it.
+    ready_queue_init_data_from_layout(&queue, CAPACITY);
+    queue.seed_slots();
+
+    for (uint64_t i = 0; i < CAPACITY; i++) {
+        EXPECT_TRUE(queue.push(fake_slot_state(i))) << "push " << i;
+    }
+    EXPECT_EQ(queue.pop(), fake_slot_state(0));
+}


### PR DESCRIPTION
## Summary

`bind` uploaded **2,242,048** bytes of runtime arena per bind, and **1,979,072** of
them were an initialization pattern:

| bytes | region | what the device did with it |
| --- | --- | --- |
| 1,775,616 | thirteen queue slot arrays | read a `0..capacity-1` ramp derived from `capacity` |
| 203,392 | `PTO2SchedulerState` | read state with no per-run content |
| 32 | `PTO2SharedMemoryHandle` | `memset` it and rebuild all four fields |

The reservation order interleaved regions the device reads with regions it does not,
so the upload was two ranges around a skipped orchestrator block, with the tail's
start inferred from whichever region happened to come first.

## Three zones

`runtime_reserve_layout` now reserves in this order:

| Zone | Regions | Copied | Written by |
| ---- | ------- | ------ | ---------- |
| host-only | orchestrator block (`fanin_seen_epoch` / `scope_tasks` / TensorMap, ~8.5 MB) | never | host, during graph construction |
| copied | `[off_copied_begin, off_copied_end)`: runtime header, completion mailbox | whole zone, one copy | host |
| device-only | `sm_handle`, `PTO2SchedulerState` and its thirteen slot arrays | never | AICPU at boot |

Putting the copied zone **between** the two zones that are never copied makes `bind`
a single `copy_to_device` of a single range whose bounds are layout fields — no
consumer infers a boundary from a reservation order. `off_uploaded_tail_begin/end`
go away with the two-range form.

```text
arena_h2d bytes   2,242,048 -> 262,976   (-88.3%)
```

## Why each region moved

**`PTO2SchedulerState` holds no per-run content.** `sm_header` and the ring pointer
derive from a pooled SM base; queue capacities are compile-time constants; hbg never
advances `last_task_alive`; and its one host-side entry point, `on_scope_end`, is an
empty stub here. Nothing outside `runtime/scheduler/` pushes, and `build_config.py`
does not put that directory in the host `.so`. So `PTO2Runtime` holds a pointer wired
from `off_scheduler`, and the AICPU calls `init_data_from_layout` at boot.
`PTO2Runtime` drops **204,072 → 680 bytes**, which also shrinks the `memset` opening
`runtime_init_data_from_layout` by the same amount.

**The queue slots have a sharper edge.** `push` claims `slots[pos & mask]` only when
that slot's `sequence` already equals `pos`, so an empty queue is a ramp, not zeroed
memory: on zeroed slots position 0 happens to match and every later position reads a
lower sequence — the full-queue signal — so the queue takes one push and then reports
full. The ramp is mandatory *and* a pure function of `capacity`, so
`seed_queue_slots()` writes it on the device.

Both the scheduler init and the seeding run before the boot thread publishes
`runtime_init_ready_`, which is what releases the peer threads into the dispatch
loop, so no push can observe either unset.

## Documentation

`RUNTIME_LOGIC.md` §3.1 documented the superseded behaviour ("everything from the
scheduler block onward ships whole") and the assert guarding the two-range form. It
is rewritten as the zone partition plus the three rules that decide membership:

1. Whoever generates a value writes it.
2. A copy carries per-run content, never an initialization pattern.
3. A region that does not differ between runs is initialized once.

It also records why the ramp is a boot cost rather than a per-run one — the sequence
invariant is lap-relative, so a drained queue is already empty, which is why
`tensormap_and_ringbuffer` leaves `PTO2ReadyQueue::reset_for_reuse()` empty and never
touches the positions — and the combination that hangs (positions reset while
sequences stay mid-lap).

## Known gap, recorded in the doc

262,272 of the remaining 262,976 copied bytes are the completion mailbox, whose 4096
message slots are a host `memset` that nothing reads before writing (`try_push` CASes
`head`, then writes the claimed slot). By rule 2 it belongs in the device-only zone
with its two cursors zeroed at boot.

## Testing

- [x] C++ unit tests: 103/103 pass (`ctest --test-dir tests/ut/cpp/build -LE requires_hardware`)
- [x] New `test_hbg_ready_queue_seed` (both trees) covers the queue contract from both
      sides: zeroed slots accept one push then report full; seeded slots take exactly
      `capacity` pushes and pop in order; a drained queue wraps four laps with no
      re-seed; a re-seed recovers a region left mid-lap
- [x] The four hbg fixtures that drive the scheduler from a host test seed in the same
      order the AICPU boots in
- [x] `clang-format` clean; `markdownlint-cli2 --fix` modifies nothing
- [x] a2a3 and a5 changed lines verified identical
- [x] Byte figures computed from measured `sizeof`s, not estimated
- [ ] Simulation tests pass (CI)
- [ ] Hardware tests pass (CI)

Builds on #1889.
