### PR TITLE
host_build_graph: move the completion mailbox into the device-only zone

### DIFF
--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -282,10 +282,13 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 run_rc = -1;
                 boot_ok = false;
             } else {
-                // Queue headers are set, so the slot arrays can take their ramp.
-                // Both precede runtime_init_ready_, which is what releases the peer
-                // threads into the dispatch loop, so no push sees either unset.
+                // Queue headers are set, so the slot arrays can take their ramp,
+                // and the mailbox ring gets its cursors and publication gates.
+                // All of it precedes runtime_init_ready_, which is what releases
+                // the peer threads into the dispatch loop, so neither a push nor a
+                // completion message sees an uninitialized region.
                 rt->scheduler->seed_queue_slots();
+                rt->aicore_mailbox->init_empty();
             }
         }
 

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -100,8 +100,8 @@ reserves them in this order:
 | Zone | Regions | Copied | Written by |
 | ---- | ------- | ------ | ---------- |
 | host-only | orchestrator block: `fanin_seen_epoch` / `scope_tasks` / TensorMap, ~8.5 MB | never | host, during graph construction |
-| copied | `[off_copied_begin, off_copied_end)`: runtime header, completion mailbox | whole zone, one copy | host |
-| device-only | `sm_handle`, `PTO2SchedulerState` and its thirteen queue slot arrays | never | AICPU at boot |
+| copied | `[off_copied_begin, off_copied_end)`: the runtime header | whole zone, one copy | host |
+| device-only | `sm_handle`, `PTO2SchedulerState` and its thirteen queue slot arrays, the completion mailbox | never | AICPU at boot |
 
 Putting the copied zone **between** the two zones that are never copied is what
 makes `bind` a single contiguous `copy_to_device`. Both bounds are layout fields,
@@ -142,11 +142,19 @@ per bind; the combination to avoid is resetting the positions while leaving the
 sequences mid-lap, which makes `push` read a sequence above its position and spin
 as if a peer were mid-publish.
 
-**Known gap.** The completion mailbox is still in the copied zone, but nothing
-reads its 4096 message slots before writing them (`try_push` CASes `head` and then
-writes the claimed slot), so 262,272 of the copied zone's 262,976 bytes are a
-`memset` the device does not need. By rule 2 it belongs in the device-only zone
-with its two cursors zeroed at boot.
+**Why the mailbox is device-written, and why zeroing `seq` is not optional.**
+`try_pop` bounds its scan with `head` and gates publication on
+`entries[t].seq == t + 1`, while a producer bumps `head` *before* it stores `seq`.
+So between those two a consumer already sees `t < head` and reads that slot: a
+residual `seq` equal to `t + 1` would hand out a message the producer has not
+written. `init_empty()` therefore zeroes `head`, `tail` and every slot's `seq`; the
+remaining message fields are written before their `seq` and never read ahead of
+`head`, so they need nothing. This is the one region whose device-side
+initialization is *not* O(1), and only because the cursors restart at zero every
+bind — once they persist, positions never repeat, a residual `seq` is always below
+`t + 1`, and the whole thing collapses to `tail := head`, which also discards what
+an error-aborted run left undrained. `MonotonicSeqSurvivesCapacityWrapWithoutZeroing`
+pins the invariant that makes that safe.
 
 ### 3.2 Bounded H2D Upload
 

--- a/src/a2a3/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
@@ -115,6 +115,26 @@ struct AICoreCompletionMailbox {
     //
     // Safe to call concurrently from any number of producers; structurally
     // independent of the AsyncWaitList::busy lock.
+    // Bring the ring to its empty state on arena memory whose prior contents are
+    // unknown. head and tail are the cursors try_pop's bounds check reads, and
+    // each slot's seq is its publication gate: try_pop accepts entries[t] only
+    // when seq == t + 1, and a producer bumps head before it stores seq, so a
+    // residual seq that happens to equal t + 1 would let the consumer read a slot
+    // the producer has not written yet. Zeroing seq closes that window; the rest
+    // of a message is written before its seq and never read ahead of head, so it
+    // needs nothing.
+    //
+    // Once head and tail persist across binds this collapses to tail := head:
+    // positions never repeat, so a residual seq is always below t + 1 and only
+    // the undrained-messages case is left to discard.
+    void init_empty() {
+        head.store(0, std::memory_order_relaxed);
+        tail.store(0, std::memory_order_relaxed);
+        for (uint64_t i = 0; i < AICORE_COMPLETION_MAILBOX_CAPACITY; i++) {
+            entries[i].seq.store(0, std::memory_order_relaxed);
+        }
+    }
+
     bool try_push_condition(
         PTO2TaskId task_token, uint64_t addr, uint32_t expected_value, uint32_t engine, int32_t completion_type
     ) {

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -338,10 +338,10 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
 
     layout.off_copied_begin = arena.total_size();
     layout.off_runtime = arena.reserve(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE);
-    layout.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
     layout.off_copied_end = arena.total_size();
 
     layout.off_sm_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
+    layout.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
     layout.off_scheduler = arena.reserve(sizeof(PTO2SchedulerState), alignof(PTO2SchedulerState));
     layout.sched = PTO2SchedulerState::reserve_layout(arena);
 
@@ -404,9 +404,6 @@ PTO2Runtime *runtime_init_data_from_layout(
     // never travel; the AICPU initializes them at boot. Writing them here would
     // be writing an initialization pattern that nothing reads.
     (void)sm_dev_base;
-
-    auto *mailbox = static_cast<AICoreCompletionMailbox *>(arena.region_ptr(layout.off_mailbox));
-    memset(mailbox, 0, sizeof(*mailbox));
 
     return rt;
 }

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -282,10 +282,13 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 run_rc = -1;
                 boot_ok = false;
             } else {
-                // Queue headers are set, so the slot arrays can take their ramp.
-                // Both precede runtime_init_ready_, which is what releases the peer
-                // threads into the dispatch loop, so no push sees either unset.
+                // Queue headers are set, so the slot arrays can take their ramp,
+                // and the mailbox ring gets its cursors and publication gates.
+                // All of it precedes runtime_init_ready_, which is what releases
+                // the peer threads into the dispatch loop, so neither a push nor a
+                // completion message sees an uninitialized region.
                 rt->scheduler->seed_queue_slots();
+                rt->aicore_mailbox->init_empty();
             }
         }
 

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -100,8 +100,8 @@ reserves them in this order:
 | Zone | Regions | Copied | Written by |
 | ---- | ------- | ------ | ---------- |
 | host-only | orchestrator block: `fanin_seen_epoch` / `scope_tasks` / TensorMap, ~8.5 MB | never | host, during graph construction |
-| copied | `[off_copied_begin, off_copied_end)`: runtime header, completion mailbox | whole zone, one copy | host |
-| device-only | `sm_handle`, `PTO2SchedulerState` and its thirteen queue slot arrays | never | AICPU at boot |
+| copied | `[off_copied_begin, off_copied_end)`: the runtime header | whole zone, one copy | host |
+| device-only | `sm_handle`, `PTO2SchedulerState` and its thirteen queue slot arrays, the completion mailbox | never | AICPU at boot |
 
 Putting the copied zone **between** the two zones that are never copied is what
 makes `bind` a single contiguous `copy_to_device`. Both bounds are layout fields,
@@ -142,11 +142,19 @@ per bind; the combination to avoid is resetting the positions while leaving the
 sequences mid-lap, which makes `push` read a sequence above its position and spin
 as if a peer were mid-publish.
 
-**Known gap.** The completion mailbox is still in the copied zone, but nothing
-reads its 4096 message slots before writing them (`try_push` CASes `head` and then
-writes the claimed slot), so 262,272 of the copied zone's 262,976 bytes are a
-`memset` the device does not need. By rule 2 it belongs in the device-only zone
-with its two cursors zeroed at boot.
+**Why the mailbox is device-written, and why zeroing `seq` is not optional.**
+`try_pop` bounds its scan with `head` and gates publication on
+`entries[t].seq == t + 1`, while a producer bumps `head` *before* it stores `seq`.
+So between those two a consumer already sees `t < head` and reads that slot: a
+residual `seq` equal to `t + 1` would hand out a message the producer has not
+written. `init_empty()` therefore zeroes `head`, `tail` and every slot's `seq`; the
+remaining message fields are written before their `seq` and never read ahead of
+`head`, so they need nothing. This is the one region whose device-side
+initialization is *not* O(1), and only because the cursors restart at zero every
+bind — once they persist, positions never repeat, a residual `seq` is always below
+`t + 1`, and the whole thing collapses to `tail := head`, which also discards what
+an error-aborted run left undrained. `MonotonicSeqSurvivesCapacityWrapWithoutZeroing`
+pins the invariant that makes that safe.
 
 ### 3.2 Bounded H2D Upload
 

--- a/src/a5/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
+++ b/src/a5/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
@@ -114,6 +114,26 @@ struct AICoreCompletionMailbox {
     //
     // Safe to call concurrently from any number of producers; structurally
     // independent of the AsyncWaitList::busy lock.
+    // Bring the ring to its empty state on arena memory whose prior contents are
+    // unknown. head and tail are the cursors try_pop's bounds check reads, and
+    // each slot's seq is its publication gate: try_pop accepts entries[t] only
+    // when seq == t + 1, and a producer bumps head before it stores seq, so a
+    // residual seq that happens to equal t + 1 would let the consumer read a slot
+    // the producer has not written yet. Zeroing seq closes that window; the rest
+    // of a message is written before its seq and never read ahead of head, so it
+    // needs nothing.
+    //
+    // Once head and tail persist across binds this collapses to tail := head:
+    // positions never repeat, so a residual seq is always below t + 1 and only
+    // the undrained-messages case is left to discard.
+    void init_empty() {
+        head.store(0, std::memory_order_relaxed);
+        tail.store(0, std::memory_order_relaxed);
+        for (uint64_t i = 0; i < AICORE_COMPLETION_MAILBOX_CAPACITY; i++) {
+            entries[i].seq.store(0, std::memory_order_relaxed);
+        }
+    }
+
     bool try_push_condition(
         PTO2TaskId task_token, uint64_t addr, uint32_t expected_value, uint32_t engine, int32_t completion_type
     ) {

--- a/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -338,10 +338,10 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
 
     layout.off_copied_begin = arena.total_size();
     layout.off_runtime = arena.reserve(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE);
-    layout.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
     layout.off_copied_end = arena.total_size();
 
     layout.off_sm_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
+    layout.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
     layout.off_scheduler = arena.reserve(sizeof(PTO2SchedulerState), alignof(PTO2SchedulerState));
     layout.sched = PTO2SchedulerState::reserve_layout(arena);
 
@@ -404,9 +404,6 @@ PTO2Runtime *runtime_init_data_from_layout(
     // never travel; the AICPU initializes them at boot. Writing them here would
     // be writing an initialization pattern that nothing reads.
     (void)sm_dev_base;
-
-    auto *mailbox = static_cast<AICoreCompletionMailbox *>(arena.region_ptr(layout.off_mailbox));
-    memset(mailbox, 0, sizeof(*mailbox));
 
     return rt;
 }

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -845,6 +845,7 @@ add_a2a3_hbg_runtime_test(test_hbg_core_tracker common/test_hbg_core_tracker.cpp
 # The seed test calls the real ready_queue_init_data_from_layout, so it links the
 # shared init TU (and the orchestrator/SM members that TU refers to).
 add_a2a3_hbg_runtime_test(test_hbg_ready_queue_seed common/test_hbg_ready_queue_seed.cpp)
+add_a2a3_hbg_runtime_test(test_hbg_mailbox_init common/test_hbg_mailbox_init.cpp)
 target_sources(test_hbg_ready_queue_seed PRIVATE
     ${HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
     ${HBG_RUNTIME_DIR}/orchestrator_core/pto_ring_buffer.cpp
@@ -888,6 +889,7 @@ target_sources(test_a5_hbg_graph_submit_failure PRIVATE
 )
 add_a5_hbg_runtime_test(test_a5_hbg_core_tracker common/test_hbg_core_tracker.cpp)
 add_a5_hbg_runtime_test(test_a5_hbg_ready_queue_seed common/test_hbg_ready_queue_seed.cpp)
+add_a5_hbg_runtime_test(test_a5_hbg_mailbox_init common/test_hbg_mailbox_init.cpp)
 target_sources(test_a5_hbg_ready_queue_seed PRIVATE
     ${A5_HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
     ${A5_HBG_RUNTIME_DIR}/orchestrator_core/pto_ring_buffer.cpp

--- a/tests/ut/cpp/common/test_hbg_mailbox_init.cpp
+++ b/tests/ut/cpp/common/test_hbg_mailbox_init.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The completion mailbox is reserved in the arena's device-only zone, so it
+ * reaches the AICPU holding whatever the pooled allocation last had.
+ * init_empty() is what makes it an empty ring.
+ *
+ * host_build_graph only: the tensormap_and_ringbuffer mailbox is uploaded with
+ * the rest of its image and has no such entry point.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <new>
+
+#include "aicore_completion_mailbox.h"
+
+namespace {
+
+PTO2TaskId make_token(uint32_t local) { return PTO2TaskId::make(/*ring=*/0, local); }
+
+// A mailbox on memory holding a prior generation's bytes, which is what the
+// pooled arena hands the AICPU: the region is never uploaded, so nothing zeroes
+// it on the way in.
+AICoreCompletionMailbox *dirty_mailbox(uint8_t fill) {
+    void *raw = ::operator new(sizeof(AICoreCompletionMailbox));
+    std::memset(raw, fill, sizeof(AICoreCompletionMailbox));
+    return new (raw) AICoreCompletionMailbox{};
+}
+
+void destroy_mailbox(AICoreCompletionMailbox *mb) {
+    mb->~AICoreCompletionMailbox();
+    ::operator delete(mb);
+}
+
+}  // namespace
+
+// The window init_empty() closes: a producer bumps head before it stores seq, so
+// between those two a consumer already sees t < head and reads entries[t].seq. A
+// residual seq equal to t + 1 passes the publication gate and hands out a message
+// the producer has not written. Seeding entries[0].seq = 1 is exactly the value
+// the gate accepts for the first pop.
+TEST(HbgMailboxInit, ClosesThePrePublicationWindowOnDirtyMemory) {
+    AICoreCompletionMailbox *mb = dirty_mailbox(0xAA);
+    mb->entries[0].seq.store(1, std::memory_order_relaxed);
+
+    mb->init_empty();
+
+    // Stand in for a producer that has claimed slot 0 but not yet published.
+    mb->head.store(1, std::memory_order_relaxed);
+    AICoreCompletionMsgView out{};
+    EXPECT_FALSE(mb->try_pop(out)) << "a residual seq must not pass the publication gate";
+
+    // The producer's own release-store is still observed.
+    mb->entries[0].seq.store(1, std::memory_order_release);
+    EXPECT_TRUE(mb->try_pop(out));
+
+    destroy_mailbox(mb);
+}
+
+TEST(HbgMailboxInit, DirtyMemoryStartsEmpty) {
+    AICoreCompletionMailbox *mb = dirty_mailbox(0xAA);
+
+    mb->init_empty();
+
+    EXPECT_FALSE(mb->has_pending());
+    AICoreCompletionMsgView out{};
+    EXPECT_FALSE(mb->try_pop(out));
+
+    destroy_mailbox(mb);
+}
+
+// A full round trip on dirty memory, so the fields try_pop copies out are proven
+// to come from the producer rather than from the fill.
+TEST(HbgMailboxInit, DirtyMemoryYieldsAUsableRing) {
+    AICoreCompletionMailbox *mb = dirty_mailbox(0xAA);
+    mb->init_empty();
+
+    const PTO2TaskId token = make_token(11);
+    ASSERT_TRUE(
+        mb->try_push_condition(token, /*addr=*/0x4000, /*expected_value=*/7, /*engine=*/1, /*completion_type=*/0)
+    );
+    ASSERT_TRUE(mb->has_pending());
+
+    AICoreCompletionMsgView out{};
+    ASSERT_TRUE(mb->try_pop(out));
+    EXPECT_EQ(out.task_token.raw, token.raw);
+    EXPECT_EQ(out.addr, 0x4000ULL);
+    EXPECT_EQ(out.expected_value, 7U);
+    EXPECT_FALSE(mb->try_pop(out));
+
+    destroy_mailbox(mb);
+}


### PR DESCRIPTION
## Summary

After #1894 the arena's copied zone was 262,976 bytes — and **262,272 of them were
the completion mailbox**: `memset` on the host and shipped so the device could
receive 4096 zeroed message slots. Rule 2 of the zone partition puts it in the
device-only zone, since its content is a function of the layout rather than of the
run.

```text
arena_h2d bytes   262,976 -> 704   (the runtime header, 680 bytes, aligned)
```

## Zeroing the cursors is not enough

There is a window between two stores that makes this more than a region move.
`try_pop` bounds its scan with `head` and gates publication on
`entries[t].seq == t + 1`, while `try_push_condition` bumps `head` **before** it
stores `seq`:

```cpp
// producer                        // consumer
head.CAS(h, h+1)                   t = tail; h = head;
                                   if (t >= h) return false;   // passes: t < h
                                   slot = &entries[t & MASK];
                                   if (slot->seq != t + 1) ...  // reads the slot
slot->...= ...;
slot->seq.store(t+1, release)
```

So between those two the consumer already reads that slot, and a residual `seq`
equal to `t + 1` hands out a message the producer has not written — a stale
`task_token`/`addr` surfacing as a live completion. **The host's per-bind `memset`
is what closes that today**, so dropping it without a replacement would turn a
cross-run leftover into a false publication.

`AICoreCompletionMailbox::init_empty()` therefore zeroes `head`, `tail` and every
slot's `seq`. The remaining message fields are written before their `seq` and never
read ahead of `head`, so they need nothing. The AICPU calls it at boot beside the
queue seeding, before `runtime_init_ready_` releases the peer threads.

## The O(1) form, and why it is not this PR

This is the one device-side initialization that is not O(1), and only because the
cursors restart at zero every bind. Once they persist across binds, positions never
repeat, a residual `seq` is always below `t + 1`, and `init_empty()` collapses to
`tail := head` — which also discards what an error-aborted run left undrained.

`MonotonicSeqSurvivesCapacityWrapWithoutZeroing` already pins the invariant that
makes that safe. `RUNTIME_LOGIC.md` records the dependency so nobody attempts the
collapse before the cursors are allowed to persist.

## Testing

- [x] C++ unit tests: 105/105 pass (`ctest --test-dir tests/ut/cpp/build -LE requires_hardware`)
- [x] New `test_hbg_mailbox_init` (both trees) exercises `init_empty()` against arena
      bytes rather than a zeroed image: a mailbox whose slot 0 carries the exact `seq`
      the gate accepts must not pop before the producer publishes; an all-`0xAA`
      region must start empty; a full push/drain round trip must return the
      producer's fields rather than the fill
- [x] **Mutation-checked**: removing the `seq` loop from `init_empty()` fails
      `ClosesThePrePublicationWindowOnDirtyMemory`, so the assertion is load-bearing
- [x] `clang-format` clean; `markdownlint-cli2 --fix` modifies nothing
- [x] a2a3 and a5 changed lines verified identical
- [ ] Simulation tests pass (CI)
- [ ] Hardware tests pass (CI)

The tests live in an hbg-only file because a5's `test_aicore_completion_mailbox`
also builds against the `tensormap_and_ringbuffer` mailbox, which is uploaded with
the rest of its image and has no such entry point.

Builds on #1894.
