### PR TITLE
host_build_graph: overlap Graph recording with outer submissions

### DIFF
--- a/simpler_setup/tools/strace_timing.py
+++ b/simpler_setup/tools/strace_timing.py
@@ -791,6 +791,12 @@ def _lane_name(entries):
     so an external producer is free to use it for its own meaning; letting one
     reach the loop below would name its lane after one of our roles.
     """
+    phase_threads = {attrs.get("host_phase_thread") for _, attrs in entries}
+    if "graph_record_worker" in phase_threads:
+        return "graph record worker"
+    if "graph_submit_main" in phase_threads:
+        return "graph submit main"
+
     roles = set()
     worker_ids = set()
     external = [(span, attrs) for span, attrs in entries if span_family(span.name) == "external"]
@@ -958,24 +964,40 @@ def host_record_spans(spans, passes):
                 phase = str(record["phase"])
             except (KeyError, TypeError, ValueError):
                 continue
+            raw_tid = record.get("tid", parent.tid)
+            try:
+                record_tid = int(raw_tid)
+            except (TypeError, ValueError):
+                record_tid = parent.tid
+            if record_tid <= 0:
+                record_tid = parent.tid
+            is_record_worker = "tid" in record and record_tid != parent.tid
             if phase in _BIND_PHASE_NAMES:
                 name = f"{_PREPARE_SPAN}.{phase}"
                 depth = parent.depth + 1
+                record_tid = parent.tid
+                phase_thread = "host_main"
                 covered_keys.add(key)
             else:
                 name = f"{_PREPARE_SPAN}.host_orch.{phase}"
                 depth = parent.depth + 2
+                if phase in {"record_node", "build_definition"} and is_record_worker:
+                    phase_thread = "graph_record_worker"
+                elif phase == "graph_submit":
+                    phase_thread = "graph_submit_main"
+                else:
+                    phase_thread = "host_main"
             out.append(
                 Span(
                     pid=parent.pid,
-                    tid=parent.tid,
+                    tid=record_tid,
                     inv=parent.inv,
                     hid=parent.hid,
                     depth=depth,
                     name=name,
                     ts=start,
                     dur=max(0, end - start),
-                    attrs=f"detail={record.get('detail', 0)} src=host_phase_records",
+                    attrs=(f"detail={record.get('detail', 0)} src=host_phase_records host_phase_thread={phase_thread}"),
                 )
             )
     return out, dropped_passes, frozenset(covered_keys)

--- a/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
@@ -281,9 +281,15 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
   variable. One `bind phase=<p> start_ns=<n> dur_ns=<n> <attrs>` line per
   segment, plus one `host-orch phase=<p> total_ns=<n> count=<k> detail_sum=<n>
   dropped=<n>` line per orchestrator kind. They come from per-kind counters, not
-  from the record pool, so a total stays exact even if the pool was never armed or
-  overflowed — that is what makes this the channel for steady state, where
-  `--rounds > 1` switches every artifact collector off.
+  from the record pool. The counters use lock-free atomic additions across the
+  main and recording-worker lanes, with every phase isolated on its own cache
+  line so concurrent `graph_submit` and `record_node` updates do not
+  false-share. The per-event pool is armed when the level-4 artifact is being
+  written (a producer that wants records *and* an output prefix) or whenever the
+  chip swimlane is at `ORCH_PHASES`; a steady-state run satisfies neither, so it
+  pays no pool append and no artifact lock at all. A total stays exact even if
+  the pool was never armed or overflowed — that is what makes this the channel
+  for steady state, where `--rounds > 1` switches every artifact collector off.
 
   Every line is written at the end of the pass, keeping the log write off the path
   being measured. The line therefore carries its own `start_ns`; the log prefix
@@ -293,8 +299,11 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
   has one. One JSON Lines object per pass carrying `pid` / `inv` — the identity
   the `[STRACE]` tree groups by — and one record per operation. This is the
   channel to read for a distribution or a per-event timeline; the summed lines
-  cannot express either. `strace_timing.py --swimlane --host-phase-records <path>`
-  draws each record inside the matching `chip.run.bind`.
+  cannot express either. Every record carries its producer Linux tid.
+  `strace_timing.py --swimlane --host-phase-records <path>` draws each record
+  inside the matching `chip.run.bind`; `record_node` and `build_definition`
+  appear on the `graph record worker` lane, while outer `graph_submit` events
+  appear on the `graph submit main` lane.
 
 - **The host lanes of `chip_swimlane_records.json`**, at level 4 only, joined to
   the device timeline through the clock anchors (see `host/clock_correlation.h`).
@@ -323,12 +332,13 @@ not belong in it.
 
 ### Cost and capacity
 
-A record costs two clock reads, a store and two counter updates — roughly 47 ns
-on an aarch64 host, for ~337 operations in a 40-layer decode pass. Cheap, but it
-sits on the path being measured, which is why neither switch is on by default.
+A record costs two clock reads and a store. Its per-kind counter update is a
+lock-free atomic add; only the per-event pool append is serialized, and only
+when the pool is armed. It sits on the path being measured, which is why neither
+switch is on by default.
 
 The pool holds `PLATFORM_HOST_PHASE_BUFFERS × PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER`
-records (5 × 1024 = 5120, 160 KB) in fixed-size buffers rotated in index order,
+records (5 × 1024 = 5120, 200 KiB) in fixed-size buffers rotated in index order,
 the same shape as the device sched/orch pools with host DDR as its backing.
 Beyond that, records are dropped from the tail and counted: the per-event views
 truncate, the per-kind totals stay exact, and `dropped=` on every `host-orch` line

--- a/src/a2a3/runtime/host_build_graph/host/host_phase_trace.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/host_phase_trace.cpp
@@ -18,8 +18,17 @@
 
 #include <stdio.h>
 
+#include <atomic>
 #include <array>
 #include <cstdlib>
+#include <functional>
+#include <mutex>
+#include <thread>
+
+#if defined(__linux__)
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
 
 #include "common/host_api.h"
 #include "common/log_clock.h"
@@ -35,18 +44,28 @@ namespace {
 // measured path.
 constexpr size_t kBindAttrsCapacity = 96;
 
-struct KindCounter {
-    uint64_t total_ns;
-    uint64_t count;
-    uint64_t payload_sum;
-    uint64_t first_start_ns;
+// record_node and graph_submit are updated concurrently by different cores.
+// Keep phase counters on distinct cache lines so lock-free accounting does not
+// turn that intended overlap into cache-line ownership ping-pong.
+struct alignas(64) KindCounter {
+    std::atomic<uint64_t> total_ns{0};
+    std::atomic<uint64_t> count{0};
+    std::atomic<uint64_t> payload_sum{0};
+    std::atomic<uint64_t> first_start_ns{0};
 };
+static_assert(sizeof(KindCounter) == 64);
 
 struct TraceState {
-    HostPhaseRecordPool *pool;
+    std::atomic<HostPhaseRecordPool *> pool{nullptr};
     const HostApi *api;
-    bool active;
-    uint64_t submitted_tasks;
+    std::atomic<bool> active{false};
+    // Records accepted by `active` but not yet finished with the counters and the
+    // pool. begin/end clear `active` and then drain this to zero, so a record can
+    // never be reported by a pass it does not belong to.
+    std::atomic<int32_t> in_flight{0};
+    std::mutex lifecycle_mutex;
+    std::mutex pool_mutex;
+    std::atomic<uint64_t> submitted_tasks{0};
     std::array<KindCounter, kHostPhaseKindCount> counters;
     std::array<std::array<char, kBindAttrsCapacity>, kHostPhaseKindCount> bind_attrs;
 };
@@ -56,7 +75,80 @@ TraceState &state() {
     return s;
 }
 
+// Publish-then-check against the trace lifecycle's clear-then-drain. Claiming a
+// slot before reading `active` is what makes the pair race-free: a record that
+// got in before the pass closed is waited for, and one that arrives after sees
+// `active` false and withdraws.
+class RecordAdmission {
+public:
+    explicit RecordAdmission(TraceState &s) :
+        s_(s) {
+        s_.in_flight.fetch_add(1, std::memory_order_acq_rel);
+        admitted_ = s_.active.load(std::memory_order_acquire);
+        if (!admitted_) s_.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+    }
+    ~RecordAdmission() {
+        if (admitted_) s_.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+    }
+
+    RecordAdmission(const RecordAdmission &) = delete;
+    RecordAdmission &operator=(const RecordAdmission &) = delete;
+
+    explicit operator bool() const { return admitted_; }
+
+private:
+    TraceState &s_;
+    bool admitted_{false};
+};
+
+// Called with `active` already false, so no new record can be admitted. Only the
+// recording worker can still be inside one, and commit joins it before a pass
+// ends, so in practice this returns without spinning.
+void drain_in_flight_records(TraceState &s) {
+    while (s.in_flight.load(std::memory_order_acquire) != 0) {}
+}
+
 bool is_bind_kind(uint32_t kind) { return kind < static_cast<uint32_t>(HostPhaseKind::OrchSubmitTask); }
+
+uint32_t current_thread_id() {
+    // A thread's identity is fixed for its lifetime, so resolve it once. This
+    // runs per record on the path being measured, where a syscall would inflate
+    // the very durations it is annotating.
+    static thread_local const uint32_t id = []() -> uint32_t {
+#if defined(__linux__) && defined(SYS_gettid)
+        return static_cast<uint32_t>(syscall(SYS_gettid));
+#else
+        return static_cast<uint32_t>(std::hash<std::thread::id>{}(std::this_thread::get_id()));
+#endif
+    }();
+    return id;
+}
+
+void record_counter(TraceState &s, uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload) {
+    KindCounter &counter = s.counters[kind];
+    uint64_t unset = 0;
+    (void)counter.first_start_ns.compare_exchange_strong(unset, start_ns, std::memory_order_relaxed);
+    counter.total_ns.fetch_add(end_ns - start_ns, std::memory_order_relaxed);
+    counter.count.fetch_add(1, std::memory_order_relaxed);
+    counter.payload_sum.fetch_add(payload, std::memory_order_relaxed);
+}
+
+void append_record(TraceState &s, uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload, uint32_t index) {
+    if (s.pool.load(std::memory_order_acquire) == nullptr) return;
+    std::lock_guard<std::mutex> lock(s.pool_mutex);
+    HostPhaseRecordPool *pool = s.pool.load(std::memory_order_relaxed);
+    if (pool == nullptr) return;
+    host_phase_pool_append(
+        pool, static_cast<HostPhaseKind>(kind), start_ns, end_ns, payload, index, current_thread_id()
+    );
+}
+
+void reset_counter(KindCounter &counter) {
+    counter.total_ns.store(0, std::memory_order_relaxed);
+    counter.count.store(0, std::memory_order_relaxed);
+    counter.payload_sum.store(0, std::memory_order_relaxed);
+    counter.first_start_ns.store(0, std::memory_order_relaxed);
+}
 
 }  // namespace
 
@@ -75,7 +167,7 @@ bool host_phase_timing_enabled() {
 // Strong definitions overriding the orchestrator core's weak fallbacks, which
 // exist so builds without this translation unit still link.
 __attribute__((visibility("hidden"))) uint64_t host_phase_now_ns() {
-    if (!state().active) {
+    if (!state().active.load(std::memory_order_acquire)) {
         return 0;
     }
     return static_cast<uint64_t>(simpler::log::monotonic_now_ns());
@@ -84,60 +176,80 @@ __attribute__((visibility("hidden"))) uint64_t host_phase_now_ns() {
 __attribute__((visibility("hidden"))) void
 host_phase_record(uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload, uint32_t index) {
     TraceState &s = state();
-    if (!s.active || kind >= kHostPhaseKindCount || end_ns < start_ns) {
+    if (!s.active.load(std::memory_order_acquire) || kind >= kHostPhaseKindCount || end_ns < start_ns) {
         return;
     }
-    KindCounter &counter = s.counters[kind];
-    if (counter.count == 0) {
-        counter.first_start_ns = start_ns;
+    // ORCH_PHASE_END calls this on every submit-level operation, so the load
+    // above stays the whole cost when tracing is off. Admission then re-checks
+    // under the in-flight claim, which is what actually closes the boundary.
+    RecordAdmission admission(s);
+    if (!admission) {
+        return;
     }
-    counter.total_ns += end_ns - start_ns;
-    counter.count++;
-    counter.payload_sum += payload;
-    host_phase_pool_append(s.pool, static_cast<HostPhaseKind>(kind), start_ns, end_ns, payload, index);
+    record_counter(s, start_ns, end_ns, kind, payload);
+    append_record(s, start_ns, end_ns, kind, payload, index);
 }
 
 void host_phase_record_bind(uint32_t kind, uint64_t start_ns, const char *attrs, uint64_t payload) {
     TraceState &s = state();
-    if (!s.active || !is_bind_kind(kind)) {
+    if (!s.active.load(std::memory_order_acquire) || !is_bind_kind(kind)) {
+        return;
+    }
+    RecordAdmission admission(s);
+    if (!admission) {
         return;
     }
     const uint64_t end_ns = static_cast<uint64_t>(simpler::log::monotonic_now_ns());
     if (attrs != nullptr) {
         snprintf(s.bind_attrs[kind].data(), kBindAttrsCapacity, "%s", attrs);
     }
-    host_phase_record(start_ns, end_ns, kind, payload, 0);
+    record_counter(s, start_ns, end_ns, kind, payload);
+    append_record(s, start_ns, end_ns, kind, payload, 0);
 }
 
 void host_phase_trace_begin(const void *host_api) {
     TraceState &s = state();
+    std::lock_guard<std::mutex> lock(s.lifecycle_mutex);
+    s.active.store(false, std::memory_order_release);
+    drain_in_flight_records(s);
     s.api = static_cast<const HostApi *>(host_api);
-    s.pool = s.api != nullptr ?
-                 static_cast<HostPhaseRecordPool *>(s.api->host_phase_pool_arm(host_phase_timing_enabled())) :
-                 nullptr;
+    HostPhaseRecordPool *pool =
+        s.api != nullptr ? static_cast<HostPhaseRecordPool *>(s.api->host_phase_pool_arm(host_phase_timing_enabled())) :
+                           nullptr;
+    s.pool.store(pool, std::memory_order_release);
     // Timestamps are taken whenever either sink wants them. Gating the clock on
     // the environment variable alone would leave a level-4 run recording zeros.
-    s.active = s.pool != nullptr || host_phase_timing_enabled();
-    s.submitted_tasks = 0;
-    s.counters.fill(KindCounter{});
+    s.submitted_tasks.store(0, std::memory_order_relaxed);
+    for (KindCounter &counter : s.counters)
+        reset_counter(counter);
     for (auto &attrs : s.bind_attrs) {
         attrs[0] = '\0';
     }
+    s.active.store(s.pool != nullptr || host_phase_timing_enabled(), std::memory_order_release);
 }
 
-void host_phase_trace_note_submitted(uint64_t submitted_tasks) { state().submitted_tasks = submitted_tasks; }
+void host_phase_trace_note_submitted(uint64_t submitted_tasks) {
+    state().submitted_tasks.store(submitted_tasks, std::memory_order_relaxed);
+}
 
 void host_phase_trace_end() {
     TraceState &s = state();
-    if (!s.active) {
+    std::lock_guard<std::mutex> lifecycle_lock(s.lifecycle_mutex);
+    if (!s.active.load(std::memory_order_relaxed)) {
         return;
     }
+    s.active.store(false, std::memory_order_release);
+    // Every record already past the `active` check finishes its counter and pool
+    // work before the totals below are read and the pool is handed back.
+    drain_in_flight_records(s);
+    std::lock_guard<std::mutex> pool_lock(s.pool_mutex);
     // Read the pool's own tally before handing it back, and drop the pointer
     // after: the pool belongs to the runner from finish() onward, and the pass is
     // over either way, so nothing here may outlive it. Clearing `active` also
     // makes a second end() without an intervening begin() a no-op rather than a
     // stale read plus a duplicate report.
-    const uint64_t dropped = s.pool != nullptr ? s.pool->head.dropped_record_count : 0;
+    HostPhaseRecordPool *pool = s.pool.load(std::memory_order_relaxed);
+    const uint64_t dropped = pool != nullptr ? pool->head.dropped_record_count : 0;
     if (s.api != nullptr) {
         uint64_t inv = 0;
 #if SIMPLER_HOST_STRACE
@@ -145,10 +257,9 @@ void host_phase_trace_end() {
         // artifact joins to them on (pid, inv).
         inv = simpler::strace::StraceScope::current_inv();
 #endif
-        s.api->host_phase_pool_finish(s.submitted_tasks, inv);
+        s.api->host_phase_pool_finish(s.submitted_tasks.load(std::memory_order_relaxed), inv);
     }
-    s.pool = nullptr;
-    s.active = false;
+    s.pool.store(nullptr, std::memory_order_release);
     if (!host_phase_timing_enabled()) {
         // Records were collected for a per-event reader alone, which has its own
         // report; this breakdown was not asked for.
@@ -157,9 +268,13 @@ void host_phase_trace_end() {
 
     for (uint32_t kind = 0; kind < kHostPhaseKindCount; ++kind) {
         const KindCounter &counter = s.counters[kind];
-        if (counter.count == 0) {
+        const uint64_t count = counter.count.load(std::memory_order_relaxed);
+        if (count == 0) {
             continue;
         }
+        const uint64_t total_ns = counter.total_ns.load(std::memory_order_relaxed);
+        const uint64_t payload_sum = counter.payload_sum.load(std::memory_order_relaxed);
+        const uint64_t first_start_ns = counter.first_start_ns.load(std::memory_order_relaxed);
         const char *name = host_phase_kind_name(static_cast<HostPhaseKind>(kind));
         if (is_bind_kind(kind)) {
             // One occurrence per pass, so the summed time is the segment's own
@@ -168,9 +283,8 @@ void host_phase_trace_end() {
             // the pass, off the path being measured — the write time says nothing
             // about when the segment ran.
             LOG_TIMING(
-                "bind phase=%s start_ns=%llu dur_ns=%llu %s", name,
-                static_cast<unsigned long long>(counter.first_start_ns),
-                static_cast<unsigned long long>(counter.total_ns), s.bind_attrs[kind].data()
+                "bind phase=%s start_ns=%llu dur_ns=%llu %s", name, static_cast<unsigned long long>(first_start_ns),
+                static_cast<unsigned long long>(total_ns), s.bind_attrs[kind].data()
             );
             continue;
         }
@@ -179,8 +293,8 @@ void host_phase_trace_end() {
         // on a timeline. Per-event bars come from the artifact instead.
         LOG_TIMING(
             "host-orch phase=%s total_ns=%llu count=%llu detail_sum=%llu dropped=%llu", name,
-            static_cast<unsigned long long>(counter.total_ns), static_cast<unsigned long long>(counter.count),
-            static_cast<unsigned long long>(counter.payload_sum), static_cast<unsigned long long>(dropped)
+            static_cast<unsigned long long>(total_ns), static_cast<unsigned long long>(count),
+            static_cast<unsigned long long>(payload_sum), static_cast<unsigned long long>(dropped)
         );
     }
 }

--- a/src/a2a3/runtime/host_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/host_build_graph/orchestration/pto_orchestration_api.h
@@ -30,8 +30,16 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <array>
+#include <condition_variable>
 #include <cstring>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <tuple>
 #include <type_traits>
+#include <utility>
 
 // Type headers needed by orchestration
 #include "common.h"              // framework_bind_runtime / framework_current_runtime
@@ -94,6 +102,8 @@ typedef struct PTO2RuntimeOps {
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
     GraphScopeResult (*graph_begin)(PTO2Runtime *rt, uint64_t graph_key, const CoreTaskArgs &args);
+    bool (*graph_prepare)(PTO2Runtime *rt, const CoreTaskArgs &args);
+    void (*graph_abort)(PTO2Runtime *rt);
     bool (*graph_end)(PTO2Runtime *rt);
     void (*graph_commit)(PTO2Runtime *rt);
 
@@ -116,13 +126,175 @@ struct PTO2Runtime {
     PTO2ScopeMode pending_scope_mode;
 };
 
+class GraphOwnedArgs {
+public:
+    // A CoreTaskArgs cannot report more args than its own capacity, so the loops
+    // below need no runtime bound — but only while these arrays are at least as
+    // large as that capacity. GRAPH_MAX_TENSOR_ARGS and MAX_TENSOR_ARGS are
+    // independent constants that merely happen to agree, so shrinking the Graph
+    // one would silently turn the tensor loop into an overflow that a release
+    // build cannot catch.
+    static_assert(
+        GRAPH_MAX_TENSOR_ARGS >= static_cast<uint32_t>(MAX_TENSOR_ARGS),
+        "GraphOwnedArgs must hold every tensor a CoreTaskArgs can carry"
+    );
+
+    explicit GraphOwnedArgs(const CoreTaskArgs &source) {
+        for (int32_t i = 0; i < source.tensor_count(); ++i) {
+            tensors_[static_cast<size_t>(i)].copy(source.tensor(i).ref());
+            switch (source.tag(i)) {
+            case TensorArgType::INPUT:
+                args_.add_input(tensors_[static_cast<size_t>(i)]);
+                break;
+            case TensorArgType::OUTPUT_EXISTING:
+                args_.add_output(tensors_[static_cast<size_t>(i)]);
+                break;
+            case TensorArgType::INOUT:
+                args_.add_inout(tensors_[static_cast<size_t>(i)]);
+                break;
+            case TensorArgType::NO_DEP:
+                args_.add_no_dep(tensors_[static_cast<size_t>(i)]);
+                break;
+            case TensorArgType::OUTPUT:
+                args_.set_error("Runtime-allocated output is not supported at a Graph boundary");
+                break;
+            }
+        }
+        for (int32_t i = 0; i < source.scalar_count(); ++i) {
+            scalars_[static_cast<size_t>(i)] = source.scalar(i);
+            args_.add_scalar(scalars_[static_cast<size_t>(i)]);
+        }
+        args_.launch_spec = source.launch_spec;
+        args_.set_allow_early_resolve(source.allow_early_resolve());
+        if (source.task_timing_slot() != TASK_TIMING_SLOT_NONE) {
+            args_.set_task_timing_slot(source.task_timing_slot());
+        }
+        args_.set_predicate(source.predicate());
+    }
+
+    CoreTaskArgs &args() { return args_; }
+
+private:
+    std::array<ChipTensor, GRAPH_MAX_TENSOR_ARGS> tensors_{};
+    std::array<uint64_t, MAX_SCALAR_ARGS> scalars_{};
+    CoreTaskArgs args_;
+};
+
+class GraphAsyncRecordingState {
+public:
+    GraphAsyncRecordingState() = default;
+    ~GraphAsyncRecordingState() { shutdown(); }
+
+    GraphAsyncRecordingState(const GraphAsyncRecordingState &) = delete;
+    GraphAsyncRecordingState &operator=(const GraphAsyncRecordingState &) = delete;
+
+    template <typename Job>
+    bool start(Job &&job) {
+        std::function<void()> next;
+        try {
+            next = std::forward<Job>(job);
+            ensure_worker();
+        } catch (...) {
+            return false;
+        }
+
+        std::unique_lock<std::mutex> lock(mutex_);
+        debug_assert(done_ && !pending_ && "Only one Graph recording may be in flight");
+        if (!done_ || pending_ || stopping_) return false;
+        job_ = std::move(next);
+        done_ = false;
+        pending_ = true;
+        cv_.notify_one();
+        // graph_begin() has already installed the hash-keyed RECORDING entry
+        // and submitted the zero-heap outer shell. Enqueuing the private job is
+        // therefore the last dependency of the caller; graph_prepare() and all
+        // node recording may start after later same-hash shells are submitted.
+        return true;
+    }
+
+    void wait() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        // Recording invokes the same public task wrappers as the outer
+        // orchestration. Those wrappers call rt_graph_commit() before a
+        // non-Graph operation. The recorder must never wait for its own job.
+        if (worker_.joinable() && worker_.get_id() == std::this_thread::get_id()) return;
+        cv_.wait(lock, [&]() {
+            return done_;
+        });
+    }
+
+private:
+    void ensure_worker() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!worker_.joinable()) {
+            worker_ = std::thread([this]() {
+                run();
+            });
+        }
+    }
+
+    void run() {
+        for (;;) {
+            std::function<void()> current;
+            {
+                std::unique_lock<std::mutex> lock(mutex_);
+                cv_.wait(lock, [&]() {
+                    return pending_ || stopping_;
+                });
+                if (stopping_) return;
+                current = std::move(job_);
+                pending_ = false;
+            }
+            current();
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                done_ = true;
+            }
+            cv_.notify_all();
+        }
+    }
+
+    void shutdown() {
+        wait();
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            stopping_ = true;
+        }
+        cv_.notify_all();
+        if (worker_.joinable()) worker_.join();
+    }
+
+    std::thread worker_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    std::function<void()> job_;
+    bool pending_{false};
+    bool done_{true};
+    bool stopping_{false};
+};
+
+// External linkage on purpose: `static inline` would give every translation
+// unit that submits a Graph its own recorder and its own worker thread, so a
+// commit reached from one TU would not wait for a recording another TU started.
+// Vague linkage keeps one instance — and one worker — per loaded SO.
+inline GraphAsyncRecordingState &rt_graph_async_recording() {
+    // One orchestration SO is invoked serially by its ChipWorker. Keep its
+    // recorder alive across runs so steady-state misses pay only a condition-
+    // variable wakeup, not a fresh pthread create/join. The SO's destructor
+    // stops the idle worker before dlclose unmaps its code.
+    static GraphAsyncRecordingState state;
+    return state;
+}
+
 // =============================================================================
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================
 
 static inline PTO2Runtime *current_runtime() { return framework_current_runtime(); }
+static inline void rt_graph_commit();
 
 static inline TaskOutputTensors alloc_tensors(const CoreTaskArgs &args) {
+    rt_graph_commit();
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -173,6 +345,7 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
 }
 
 static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
+    rt_graph_commit();
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -206,6 +379,7 @@ static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const Core
  * barrier or as a placeholder producer for tests / dep-graph wiring.
  */
 static inline TaskOutputTensors rt_submit_dummy_task(const CoreTaskArgs &args) {
+    rt_graph_commit();
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -221,11 +395,18 @@ static inline GraphScopeResult rt_graph_begin(uint64_t graph_key, const CoreTask
     return rt->ops->graph_begin(rt, graph_key, args);
 }
 
-// Finish the recording pass. Returns true when the recorded sub-DAG was emitted
-// as a single outer GRAPH task (the body must not run again); false when the
-// recording was unsupported and the caller must re-run the body on the ordinary
-// path. A fatal runtime is terminal, so it reports true to suppress a pointless
-// re-run.
+static inline bool rt_graph_prepare(const CoreTaskArgs &args) {
+    PTO2Runtime *rt = current_runtime();
+    return rt->ops->graph_prepare != nullptr && rt->ops->graph_prepare(rt, args);
+}
+
+static inline void rt_graph_abort() {
+    PTO2Runtime *rt = current_runtime();
+    if (rt->ops->graph_abort != nullptr) rt->ops->graph_abort(rt);
+}
+
+// Finish the recording pass and publish its Definition. The calling thread
+// finalizes the already-submitted outer Graph shells in rt_graph_commit.
 static inline bool rt_graph_end() {
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt) || rt->ops->graph_end == nullptr) {
@@ -235,11 +416,11 @@ static inline bool rt_graph_end() {
 }
 
 static inline void rt_graph_commit() {
+    GraphAsyncRecordingState &async = rt_graph_async_recording();
+    async.wait();
+
     PTO2Runtime *rt = current_runtime();
-    if (rt->ops->is_fatal(rt) || rt->ops->graph_commit == nullptr) {
-        return;
-    }
-    rt->ops->graph_commit(rt);
+    if (!rt->ops->is_fatal(rt) && rt->ops->graph_commit != nullptr) rt->ops->graph_commit(rt);
 }
 
 static inline void rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {
@@ -260,6 +441,7 @@ static inline void rt_scope_end() {
 }
 
 static inline void rt_orchestration_done() {
+    rt_graph_commit();
     PTO2Runtime *rt = current_runtime();
     rt->ops->orchestration_done(rt);
 }
@@ -392,6 +574,12 @@ static inline uint64_t rt_graph_function_id(Function function) {
     return function_id;
 }
 
+// `invoke` is copied into the recording job and runs on the recording worker,
+// which outlives this call: the caller returns as soon as the outer shell is
+// submitted, and the body runs until the next rt_graph_commit(). So `invoke` must
+// own everything it needs by value. Capturing caller-frame storage by reference —
+// including the boundary `args` — is a use-after-free; the recorded body receives
+// its own boundary copy as a parameter for exactly that reason.
 template <typename Invoke>
 static inline GraphSubmitResult rt_submit_graph_impl(uint64_t graph_key, const CoreTaskArgs &args, Invoke invoke) {
     debug_assert(!args.has_error && "Graph boundary CoreTaskArgs construction failed");
@@ -408,31 +596,74 @@ static inline GraphSubmitResult rt_submit_graph_impl(uint64_t graph_key, const C
         );
     }
     if (!rt_graph_args_cacheable(args)) {
-        invoke();
         rt_graph_commit();
+        invoke(args);
         return GraphSubmitResult{};
     }
     GraphScopeResult result = rt_graph_begin(graph_key, args);
     if (result.recording) {
-        // First invocation: record the sub-DAG off the ring, then emit one outer
-        // GRAPH task. If the recording hit an unsupported construct, fall back and
-        // run the body on the ordinary path so its work is still submitted.
-        invoke();
-        if (!rt_graph_end()) invoke();
+        GraphAsyncRecordingState &async = rt_graph_async_recording();
+        std::shared_ptr<GraphOwnedArgs> owned_args;
+        try {
+            owned_args = std::make_shared<GraphOwnedArgs>(args);
+        } catch (...) {
+            try {
+                if (!rt_graph_prepare(args)) {
+                    rt_graph_abort();
+                    rt_graph_commit();
+                    return result;
+                }
+                invoke(args);
+                (void)rt_graph_end();
+            } catch (...) {
+                rt_graph_abort();
+                throw;
+            }
+            rt_graph_commit();
+            return result;
+        }
+        auto record = [owned_args, invoke]() mutable {
+            try {
+                if (!rt_graph_prepare(owned_args->args())) {
+                    rt_graph_abort();
+                    return;
+                }
+                invoke(owned_args->args());
+                (void)rt_graph_end();
+            } catch (...) {
+                rt_graph_abort();
+            }
+        };
+        if (!async.start(std::move(record))) {
+            try {
+                if (!rt_graph_prepare(owned_args->args())) {
+                    rt_graph_abort();
+                    rt_graph_commit();
+                    return result;
+                }
+                invoke(owned_args->args());
+                (void)rt_graph_end();
+            } catch (...) {
+                rt_graph_abort();
+                throw;
+            }
+            rt_graph_commit();
+        }
     } else if (result.execute_block) {
         // Un-cacheable at begin, or the Definition cache is full: ordinary path.
-        invoke();
+        rt_graph_commit();
+        if (!current_runtime()->ops->is_fatal(current_runtime())) invoke(args);
     }
-    // Cache hit: execute_block and recording are both false; the body is skipped.
-    rt_graph_commit();
+    // A cache hit or an in-flight hit skips the body. In-flight Graph tasks are
+    // finalized before the next non-Graph operation or orchestration completion.
     return result;
 }
 
 static inline GraphSubmitResult rt_submit_graph(uint64_t graph_id, GraphFunction function, const CoreTaskArgs &args) {
     debug_assert(function != nullptr && "Graph function must not be null");
     if (function == nullptr) return GraphSubmitResult{};
-    return rt_submit_graph_impl(rt_graph_make_key(graph_id), args, [&]() {
-        function(args);
+    return rt_submit_graph_impl(rt_graph_make_key(graph_id), args, [function](const CoreTaskArgs &record_args) {
+        function(record_args);
     });
 }
 
@@ -449,9 +680,17 @@ static inline GraphSubmitResult rt_submit_graph(
 ) {
     debug_assert(function != nullptr && "Graph function must not be null");
     if (function == nullptr) return GraphSubmitResult{};
-    return rt_submit_graph_impl(rt_graph_make_key(graph_id, config...), args, [&]() {
-        function(args, config...);
-    });
+    auto configs = std::make_tuple(config...);
+    return rt_submit_graph_impl(
+        rt_graph_make_key(graph_id, config...), args, [function, configs](const CoreTaskArgs &record_args) {
+            std::apply(
+                [&](auto... values) {
+                    function(record_args, values...);
+                },
+                configs
+            );
+        }
+    );
 }
 
 template <typename... Config>

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -30,10 +30,13 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cstddef>
+#include <condition_variable>
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <new>
 #include <optional>
 #include <unordered_map>
@@ -311,15 +314,12 @@ struct GraphRecordedNode {
 struct GraphRecording {
     uint64_t full_key{0};
     int32_t start_local_task_id{0};
-    // Heap allocation pointer captured at graph_begin. Internal nodes reserve
-    // scratch output buffers past it during the recording pass; graph_end rolls
-    // the heap back here so the outer GRAPH task reclaims the same region.
-    uint64_t heap_watermark{0};
-    // The Graph boundary CoreTaskArgs, owned by the caller for the whole
-    // rt_submit_graph_impl call (recording pass + graph_end). graph_end replays
-    // it through graph_submit_definition to emit the outer GRAPH task with the
-    // current invocation's boundary tensor addresses.
+    uint64_t next_virtual_offset{0};
+    // Worker-owned deep copy of the first Graph boundary. It stays valid from
+    // graph_prepare through graph_end and anchors boundary scalar sources while
+    // the main thread submits outer shells from later invocation arguments.
     const CoreTaskArgs *boundary_args{nullptr};
+    int32_t boundary_scalar_count{0};
     bool unsupported{false};
     std::vector<ChipTensor> boundary_tensors;
     std::vector<TensorArgType> boundary_types;
@@ -329,18 +329,44 @@ struct GraphRecording {
 struct GraphPendingUpload {
     PTO2TaskSlotState *outer_slot{nullptr};
     std::vector<std::byte> image;
+    bool deferred_heap{false};
 };
+
+enum class GraphRecordingStatus : uint8_t { IDLE = 0, RECORDING = 1, READY = 2, FAILED = 3 };
 
 struct GraphHostState {
     std::unordered_map<uint64_t, std::vector<std::byte>> definitions;
     std::unique_ptr<GraphRecording> recording;
     std::vector<GraphPendingUpload> pending_uploads;
+    std::mutex recording_mutex;
+    std::condition_variable recording_cv;
+    // Atomic because graph_prepare reads it on the recording worker without
+    // taking recording_mutex, by design: acquiring the mutex there lets a
+    // main-thread burst of same-hash submissions starve the worker before it can
+    // bind its private recording state. Every other access holds the mutex.
+    std::atomic<GraphRecordingStatus> recording_status{GraphRecordingStatus::IDLE};
+    uint64_t recording_key{0};
+
+    GraphRecordingStatus status() const { return recording_status.load(std::memory_order_acquire); }
+    void set_status(GraphRecordingStatus next) { recording_status.store(next, std::memory_order_release); }
 };
 
 namespace {
 
 GraphHostState *graph_state_from(PTO2OrchestratorState *orch) {
     return orch == nullptr ? nullptr : static_cast<GraphHostState *>(orch->graph_host_state);
+}
+
+thread_local GraphRecording *g_active_graph_recording = nullptr;
+// The recording a thread holds belongs to one GraphHostState. Recording into it
+// from a different orchestrator would silently mix two graphs, so the owner is
+// part of the thread-local identity rather than implied by it.
+thread_local GraphHostState *g_active_graph_owner = nullptr;
+
+GraphRecording *active_graph_recording(PTO2OrchestratorState *orch) {
+    GraphHostState *state = graph_state_from(orch);
+    if (state == nullptr || state != g_active_graph_owner) return nullptr;
+    return g_active_graph_recording;
 }
 
 uint64_t graph_full_key(uint64_t callable_hash, uint64_t graph_key) {
@@ -434,8 +460,9 @@ bool graph_classify_tensor(
 }
 
 void graph_record_mark_unsupported(PTO2OrchestratorState *orch) {
-    GraphHostState *state = graph_state_from(orch);
-    if (state != nullptr && state->recording != nullptr) state->recording->unsupported = true;
+    if (GraphRecording *recording = active_graph_recording(orch); recording != nullptr) {
+        recording->unsupported = true;
+    }
 }
 
 GraphBoundarySignature graph_boundary_signature(const ChipTensor &tensor, TensorArgType type, uint16_t alias_rep) {
@@ -624,7 +651,7 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     definition.edge_count = edge_count;
     definition.root_count = static_cast<uint32_t>(roots.size());
     definition.boundary_count = static_cast<uint32_t>(signatures.size());
-    definition.boundary_scalar_count = static_cast<uint32_t>(recording.boundary_args->scalar_count());
+    definition.boundary_scalar_count = static_cast<uint32_t>(recording.boundary_scalar_count);
     definition.tensor_arg_count = static_cast<uint32_t>(tensors.size());
     definition.scalar_arg_count = static_cast<uint32_t>(scalars.size());
     size_t execution_storage_bytes = 0;
@@ -914,7 +941,7 @@ void PTO2OrchestratorState::begin_scope(PTO2ScopeMode mode) {
     // tasks. Recorded ordering is preserved by the nodes' explicit dependencies
     // and tensor-source classification, so a scope inside a Graph body is a no-op
     // during recording and must not touch the real scope stack.
-    if (GraphHostState *state = graph_state_from(orch); state != nullptr && state->recording != nullptr) {
+    if (active_graph_recording(orch) != nullptr) {
         return;
     }
     assert(orch->scope_stack_top < static_cast<int32_t>(orch->scope_stack_capacity - 1) && "Scope stack overflow");
@@ -955,7 +982,7 @@ void PTO2OrchestratorState::end_scope() {
     }
     // Matches begin_scope: a scope inside a Graph body is a no-op during the
     // shadow-record pass, so it must not touch the scope stack.
-    if (GraphHostState *state = graph_state_from(orch); state != nullptr && state->recording != nullptr) {
+    if (active_graph_recording(orch) != nullptr) {
         return;
     }
     assert(orch->scope_stack_top >= 0 && "Scope stack underflow");
@@ -1291,6 +1318,49 @@ bool graph_boundary_matches(const GraphDefinition &definition, const CoreTaskArg
     return true;
 }
 
+bool graph_recording_boundary_matches(const GraphRecording &recording, const CoreTaskArgs &args) {
+    if (args.scalar_count() != recording.boundary_scalar_count || args.explicit_dep_count() != 0 ||
+        args.tensor_count() != static_cast<int32_t>(recording.boundary_tensors.size()) ||
+        recording.boundary_tensors.size() != recording.boundary_types.size()) {
+        return false;
+    }
+    for (int32_t i = 0; i < args.tensor_count(); ++i) {
+        const ChipTensor &expected = recording.boundary_tensors[static_cast<size_t>(i)];
+        const ChipTensor &actual = args.tensor(i).ref();
+        if (actual.ndims > MAX_TENSOR_DIMS || actual.buffer.size != expected.buffer.size ||
+            actual.ndims != expected.ndims || actual.dtype != expected.dtype ||
+            args.tag(i) != recording.boundary_types[static_cast<size_t>(i)] ||
+            actual.manual_dep != expected.manual_dep || actual.is_contiguous != expected.is_contiguous ||
+            !std::equal(
+                std::begin(actual.shapes), std::begin(actual.shapes) + actual.ndims, std::begin(expected.shapes)
+            ) ||
+            !std::equal(
+                std::begin(actual.strides), std::begin(actual.strides) + actual.ndims, std::begin(expected.strides)
+            )) {
+            return false;
+        }
+        uint16_t expected_alias = static_cast<uint16_t>(i);
+        uint16_t actual_alias = static_cast<uint16_t>(i);
+        for (int32_t j = 0; j < i; ++j) {
+            const ChipTensor &expected_other = recording.boundary_tensors[static_cast<size_t>(j)];
+            if (expected_other.buffer.addr == expected.buffer.addr &&
+                expected_other.buffer.size == expected.buffer.size) {
+                expected_alias = static_cast<uint16_t>(j);
+                break;
+            }
+        }
+        for (int32_t j = 0; j < i; ++j) {
+            const ChipTensor &actual_other = args.tensor(j).ref();
+            if (actual_other.buffer.addr == actual.buffer.addr && actual_other.buffer.size == actual.buffer.size) {
+                actual_alias = static_cast<uint16_t>(j);
+                break;
+            }
+        }
+        if (actual_alias != expected_alias) return false;
+    }
+    return true;
+}
+
 void graph_reset_outer_payload(PTO2TaskPayload &payload) {
     payload.tensor_count = 0;
     payload.scalar_count = 0;
@@ -1307,10 +1377,10 @@ void graph_reset_outer_payload(PTO2TaskPayload &payload) {
     payload.early_sync_drain_state.store(PTO2_EARLY_SYNC_DRAIN_NONE, std::memory_order_relaxed);
 }
 
-bool graph_build_submission_image(
-    const std::vector<std::byte> &definition_image, const CoreTaskArgs &args, std::vector<std::byte> *submission_image
+bool graph_prepare_submission_image(
+    uint64_t full_key, const CoreTaskArgs &args, std::vector<std::byte> *submission_image
 ) {
-    if (submission_image == nullptr || graph_definition(definition_image) == nullptr) return false;
+    if (submission_image == nullptr) return false;
     const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphTensor));
     const size_t tensor_bytes = static_cast<size_t>(args.tensor_count()) * sizeof(GraphTensor);
     if (tensors_offset > UINT32_MAX || tensors_offset > UINT32_MAX - tensor_bytes) {
@@ -1335,10 +1405,8 @@ bool graph_build_submission_image(
         );
     }
 
-    const GraphDefinition &definition = *graph_definition(definition_image);
     GraphSubmission submission{};
-    submission.graph_key = definition.full_key;
-    submission.definition_hash = definition.content_hash;
+    submission.graph_key = full_key;
     submission.total_bytes = static_cast<uint32_t>(submission_image->size());
     submission.tensors_offset = static_cast<uint32_t>(tensors_offset);
     submission.tensor_count = static_cast<uint32_t>(args.tensor_count());
@@ -1348,40 +1416,29 @@ bool graph_build_submission_image(
     return true;
 }
 
-bool graph_submit_definition(
-    PTO2OrchestratorState *orch, GraphHostState *state, const std::vector<std::byte> &definition_image,
-    const CoreTaskArgs &args, PTO2TaskId *submitted_id
+bool graph_submit_outer(
+    PTO2OrchestratorState *orch, GraphHostState *state, uint64_t full_key, uint64_t definition_hash, int32_t owned_heap,
+    bool defer_heap, const CoreTaskArgs &args, PTO2TaskId *submitted_id
 ) {
     always_assert(orch->scope_stack_top >= 0 && "Cannot submit Graph outside a scope");
-    const GraphDefinition *definition = graph_definition(definition_image);
-    if (definition == nullptr || !graph_boundary_matches(*definition, args) ||
-        definition->execution_storage_bytes == 0) {
-        return false;
-    }
-    // One allocation covers both halves the outer task owns: the nodes' packed
-    // outputs, then the execution storage the device materializes into. They
-    // share the task's lifetime, and node_offsets stay relative to the base, so
-    // the execution simply starts past required_heap.
-    const uint64_t owned_heap = definition->required_heap + definition->execution_storage_bytes;
-    if (definition->required_heap > UINT64_MAX - definition->execution_storage_bytes ||
-        owned_heap > static_cast<uint64_t>(INT32_MAX)) {
-        return false;
-    }
     auto &allocator = orch->ring.task_allocator;
-    if (allocator.active_count() >= allocator.window_size() || owned_heap > allocator.heap_available()) {
+    if (allocator.active_count() >= allocator.window_size() ||
+        (!defer_heap && static_cast<uint64_t>(owned_heap) > allocator.heap_available())) {
         LOG_WARN("%s", "[GraphExecution] task-window/heap preflight failed; using ordinary path");
         return false;
     }
 
     GraphPendingUpload pending;
-    if (!graph_build_submission_image(definition_image, args, &pending.image)) return false;
+    if (!graph_prepare_submission_image(full_key, args, &pending.image)) return false;
+    reinterpret_cast<GraphSubmission *>(pending.image.data())->definition_hash = definition_hash;
+    pending.deferred_heap = defer_heap;
 
     DepInputs boundary_inputs{
         args.tensor_count(), args.tensor_data(), args.tag_data(), 0, nullptr,
     };
     const int32_t tensormap_needed = count_registrable_outputs(boundary_inputs, orch->in_manual_scope());
     if (tensormap_needed > 0 && !ensure_tensormap_capacity(orch, tensormap_needed)) return false;
-    const PTO2TaskAllocResult allocation = allocator.alloc(static_cast<int32_t>(owned_heap));
+    const PTO2TaskAllocResult allocation = allocator.alloc(defer_heap ? 0 : owned_heap);
     if (allocation.failed()) {
         orch_mark_fatal(orch, PTO2_ERROR_HEAP_RING_DEADLOCK);
         return false;
@@ -1429,22 +1486,80 @@ bool graph_submit_definition(
     return true;
 }
 
+bool graph_submit_definition(
+    PTO2OrchestratorState *orch, GraphHostState *state, const std::vector<std::byte> &definition_image,
+    const CoreTaskArgs &args, PTO2TaskId *submitted_id
+) {
+    const GraphDefinition *definition = graph_definition(definition_image);
+    if (definition == nullptr || !graph_boundary_matches(*definition, args) ||
+        definition->execution_storage_bytes == 0 ||
+        definition->required_heap > UINT64_MAX - definition->execution_storage_bytes) {
+        return false;
+    }
+    const uint64_t owned_heap = definition->required_heap + definition->execution_storage_bytes;
+    if (owned_heap > static_cast<uint64_t>(INT32_MAX)) return false;
+    return graph_submit_outer(
+        orch, state, definition->full_key, definition->content_hash, static_cast<int32_t>(owned_heap), false, args,
+        submitted_id
+    );
+}
+
+bool graph_submit_pending_definition(
+    PTO2OrchestratorState *orch, GraphHostState *state, uint64_t full_key, const CoreTaskArgs &args,
+    PTO2TaskId *submitted_id
+) {
+    return graph_submit_outer(orch, state, full_key, 0, 0, true, args, submitted_id);
+}
+
+bool graph_finalize_pending_submissions(
+    PTO2OrchestratorState *orch, GraphHostState *state, const GraphDefinition &definition
+) {
+    if (definition.execution_storage_bytes == 0 ||
+        definition.required_heap > UINT64_MAX - definition.execution_storage_bytes) {
+        return false;
+    }
+    const uint64_t owned_heap = definition.required_heap + definition.execution_storage_bytes;
+    if (owned_heap > static_cast<uint64_t>(INT32_MAX)) return false;
+    for (GraphPendingUpload &pending : state->pending_uploads) {
+        if (!pending.deferred_heap || pending.image.size() < sizeof(GraphSubmission)) continue;
+        auto *submission = reinterpret_cast<GraphSubmission *>(pending.image.data());
+        if (submission->graph_key != definition.full_key || pending.outer_slot == nullptr ||
+            pending.outer_slot->task == nullptr || pending.outer_slot->task_kind != TaskKind::GRAPH ||
+            !graph_submission_wire_size_valid(*submission, pending.image.size())) {
+            return false;
+        }
+        void *packed_base = nullptr;
+        void *packed_end = nullptr;
+        if (!orch->ring.task_allocator.reserve_deferred_heap(
+                static_cast<int32_t>(owned_heap), &packed_base, &packed_end
+            )) {
+            return false;
+        }
+        pending.outer_slot->task->packed_buffer_base = packed_base;
+        pending.outer_slot->task->packed_buffer_end = packed_end;
+        submission->definition_hash = definition.content_hash;
+        pending.deferred_heap = false;
+    }
+    return true;
+}
+
 // Record one internal Graph node during the recording pass without consuming a
 // ring task-window slot. Builds the node's metadata and materialized outputs
-// exactly as submit_task_common would, but reserves output buffers from heap
-// scratch (released in graph_end) and derives internal fanins from tensor-source
+// exactly as submit_task_common would, but assigns output buffers from the
+// bit-63 virtual address range and derives internal fanins from tensor-source
 // classification — so no ring slot, tensormap entry, fanin-pool entry, or upload
-// is produced for the node. The whole sub-DAG is later replayed by the single
-// outer GRAPH task graph_end emits. The returned TaskOutputTensors borrow the
-// node's own tensor storage; moving the node into recording.nodes keeps those
-// addresses valid because the inner buffer is transferred, not copied.
+// is produced for the node. The resulting Definition is later attached to the
+// outer GRAPH shells already submitted by the main thread. The returned
+// TaskOutputTensors borrow the node's own tensor storage; moving the node into
+// recording.nodes keeps those addresses valid because the inner buffer is
+// transferred, not copied.
 TaskOutputTensors graph_record_submit_node(
     PTO2OrchestratorState *orch, const CoreTaskArgs &args, ActiveMask active_mask, TaskAttrs task_attrs,
     int32_t aic_kernel_id, int32_t aiv0_kernel_id, int32_t aiv1_kernel_id
 ) {
     ORCH_PHASE_START();
     TaskOutputTensors result;
-    GraphRecording &recording = *graph_state_from(orch)->recording;
+    GraphRecording &recording = *active_graph_recording(orch);
 
     const size_t node_index = recording.nodes.size();
     // A recorded node's index equals its local task id minus the recording
@@ -1459,17 +1574,15 @@ TaskOutputTensors graph_record_submit_node(
     }
 
     const PTO2OutputLayout layout = calculate_output_layout(args);
-    void *packed_base = orch->ring.task_allocator.reserve_heap_scratch(layout.total_output_size);
-    if (layout.total_output_size > 0 && packed_base == nullptr) {
-        // No scratch storage for this node's outputs: the sub-DAG cannot be
-        // recorded, so graph_end falls back and the body runs on the ordinary
-        // path where the same heap pressure is reported through alloc().
-        recording.unsupported = true;
-        return result;
-    }
     const uint64_t aligned_output =
         layout.total_output_size > 0 ? PTO2_ALIGN_UP(static_cast<uint64_t>(layout.total_output_size), PTO2_ALIGN_SIZE) :
                                        0;
+    if (recording.next_virtual_offset > GRAPH_RECORD_VIRTUAL_BASE - aligned_output) {
+        recording.unsupported = true;
+        return result;
+    }
+    const uintptr_t packed_base_addr = GRAPH_RECORD_VIRTUAL_BASE + recording.next_virtual_offset;
+    recording.next_virtual_offset += aligned_output;
 
     GraphRecordedNode node;
     node.kernel_ids[static_cast<int>(PTO2SubtaskSlot::AIC)] = aic_kernel_id;
@@ -1480,11 +1593,10 @@ TaskOutputTensors graph_record_submit_node(
     node.task_attrs.set_early_resolve(false);
     node.logical_block_num = args.launch_spec.block_num();
     // Mirror prepare_task's contract: block_num must be positive and the subtask
-    // count must fit int16_t. An out-of-contract value marks the recording
-    // unsupported so graph_end falls back to the ordinary path, which reports
-    // PTO2_ERROR_INVALID_ARGS, rather than baking a truncated or negative count
-    // into the cached Definition (which the device would expand into a node that
-    // never completes).
+    // count must fit int16_t. An out-of-contract value marks asynchronous
+    // recording unsupported and makes commit fail-fast, rather than baking a
+    // truncated or negative count into the cached Definition (which the device
+    // would expand into a node that never completes).
     const int32_t required_subtasks =
         static_cast<int32_t>(node.logical_block_num) * __builtin_popcount(active_mask.core_mask());
     if (node.logical_block_num <= 0 || required_subtasks > std::numeric_limits<int16_t>::max()) {
@@ -1493,7 +1605,7 @@ TaskOutputTensors graph_record_submit_node(
     } else {
         node.total_required_subtasks = static_cast<int16_t>(required_subtasks);
     }
-    node.record_packed_base = reinterpret_cast<uintptr_t>(packed_base);
+    node.record_packed_base = packed_base_addr;
     node.total_output_size = aligned_output;
 
     // Build the tensor list exactly as PTO2TaskPayload::init: inputs/inouts copy
@@ -1508,8 +1620,7 @@ TaskOutputTensors graph_record_submit_node(
         } else {
             init_tensor_from_create_info(
                 slot_tensor, args.tensor(i).create_info(),
-                reinterpret_cast<void *>(reinterpret_cast<char *>(packed_base) + layout.offsets[i]),
-                layout.buffer_sizes[i]
+                reinterpret_cast<void *>(packed_base_addr + layout.offsets[i]), layout.buffer_sizes[i]
             );
             slot_tensor.owner_task_id = task_id;
         }
@@ -1591,14 +1702,46 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const CoreTaskArgs &args,
         debug_assert(args.explicit_dep_count() == 0 && "Graph boundary explicit dependencies are not supported");
         return result;
     }
-    if (state->recording != nullptr) {
-        state->recording->unsupported = true;
-        debug_assert(state->recording == nullptr && "Nested Graph recording is not supported");
+    if (GraphRecording *active = active_graph_recording(orch); active != nullptr) {
+        active->unsupported = true;
+        debug_assert(active == nullptr && "Nested Graph recording is not supported");
         LOG_WARN("%s", "[GraphExecution] nested Graph recording is not supported");
         return result;
     }
 
     const uint64_t full_key = graph_full_key(callable_hash, graph_key);
+    std::unique_lock<std::mutex> lock(state->recording_mutex);
+    if (state->status() != GraphRecordingStatus::IDLE) {
+        if (state->recording_key != full_key || state->status() == GraphRecordingStatus::FAILED) {
+            return result;
+        }
+        bool boundary_matches = false;
+        if (state->recording != nullptr) {
+            boundary_matches = graph_recording_boundary_matches(*state->recording, args);
+        } else {
+            auto definition_it = state->definitions.find(full_key);
+            boundary_matches = definition_it != state->definitions.end() &&
+                               graph_definition(definition_it->second) != nullptr &&
+                               graph_boundary_matches(*graph_definition(definition_it->second), args);
+        }
+        if (!boundary_matches) return result;
+
+        PTO2TaskId submitted = PTO2TaskId::invalid();
+        ORCH_PHASE_START();
+        if (graph_submit_pending_definition(orch, state, full_key, args, &submitted)) {
+            result.execute_block = false;
+            result.task_id = submitted;
+            ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
+#if SIMPLER_DFX
+            g_orch_submit_idx++;
+#if SIMPLER_ORCH_PROFILING
+            g_orch_submit_count++;
+#endif
+#endif
+        }
+        return result;
+    }
+
     auto definition_it = state->definitions.find(full_key);
     if (definition_it != state->definitions.end()) {
         PTO2TaskId submitted = PTO2TaskId::invalid();
@@ -1630,9 +1773,7 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const CoreTaskArgs &args,
     auto recording = std::make_unique<GraphRecording>();
     recording->full_key = full_key;
     recording->start_local_task_id = orch->ring.task_allocator.active_count();
-    recording->heap_watermark = orch->ring.task_allocator.heap_top();
-    args.anchor_scalar_sources();
-    recording->boundary_args = &args;
+    recording->boundary_scalar_count = args.scalar_count();
     recording->boundary_tensors.reserve(static_cast<size_t>(args.tensor_count()));
     recording->boundary_types.reserve(static_cast<size_t>(args.tensor_count()));
     for (int32_t i = 0; i < args.tensor_count(); ++i) {
@@ -1640,67 +1781,139 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const CoreTaskArgs &args,
         recording->boundary_types.push_back(args.tag(i));
     }
     state->recording = std::move(recording);
-    // The body runs through the shadow-record path, not the ring, so it does not
-    // execute as ordinary tasks.
-    result.execute_block = false;
-    result.recording = true;
+    state->recording_key = full_key;
+    state->set_status(GraphRecordingStatus::RECORDING);
+
+    PTO2TaskId submitted = PTO2TaskId::invalid();
+    ORCH_PHASE_START();
+    if (graph_submit_pending_definition(orch, state, full_key, args, &submitted)) {
+        result.execute_block = false;
+        result.recording = true;
+        result.task_id = submitted;
+        ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
+#if SIMPLER_DFX
+        g_orch_submit_idx++;
+#if SIMPLER_ORCH_PROFILING
+        g_orch_submit_count++;
+#endif
+#endif
+    } else {
+        state->recording.reset();
+        state->recording_key = 0;
+        state->set_status(GraphRecordingStatus::IDLE);
+    }
     return result;
 }
 
-// Finish the recording pass. Returns true when the sub-DAG was compacted into a
-// Definition and emitted as a single outer GRAPH task; false when the recording
-// hit an unsupported construct or the outer task could not be placed, in which
-// case the caller re-runs the body on the ordinary path so its work is still
-// submitted.
+bool PTO2OrchestratorState::graph_prepare(const CoreTaskArgs &args) {
+    GraphHostState *state = graph_state_from(this);
+    if (state == nullptr || g_active_graph_recording != nullptr) return false;
+    // graph_begin publishes this unique recording before the private job is
+    // enqueued; the recording worker's queue acquire observes those writes.
+    // Until this worker calls graph_end/graph_abort, later graph_begin calls
+    // only read the boundary vectors under recording_mutex, and only this worker
+    // writes the fields it binds below. Taking that mutex here lets the main
+    // thread's same-hash submit burst starve prepare and collapse the intended
+    // overlap, so the status read goes through the atomic instead.
+    if (state->status() != GraphRecordingStatus::RECORDING || state->recording == nullptr ||
+        !graph_recording_boundary_matches(*state->recording, args)) {
+        return false;
+    }
+    args.anchor_scalar_sources();
+    state->recording->boundary_args = &args;
+    g_active_graph_recording = state->recording.get();
+    g_active_graph_owner = state;
+    return true;
+}
+
+void PTO2OrchestratorState::graph_abort() {
+    GraphHostState *state = graph_state_from(this);
+    if (state == nullptr) return;
+    {
+        std::lock_guard<std::mutex> lock(state->recording_mutex);
+        state->recording.reset();
+        state->set_status(GraphRecordingStatus::FAILED);
+    }
+    g_active_graph_recording = nullptr;
+    g_active_graph_owner = nullptr;
+    state->recording_cv.notify_all();
+}
+
+// Finish the background recording pass and publish the Definition. The main
+// thread finalizes the already-submitted outer Graph tasks in graph_commit.
 bool PTO2OrchestratorState::graph_end() {
     GraphHostState *state = graph_state_from(this);
-    if (state == nullptr || state->recording == nullptr) return false;
-    std::unique_ptr<GraphRecording> recording = std::move(state->recording);
-    // Release the scratch output buffers the internal nodes reserved; the outer
-    // GRAPH task reclaims the same heap region as one block below (or the
-    // ordinary fallback re-uses it per task).
-    this->ring.task_allocator.restore_heap_top(recording->heap_watermark);
+    GraphRecording *recording = active_graph_recording(this);
+    if (state == nullptr || recording == nullptr) return false;
 
     std::vector<std::byte> definition;
     ORCH_PHASE_START();
-    if (!graph_build_definition(*recording, &definition)) {
+    const bool built = graph_build_definition(*recording, &definition);
+    if (built) {
+        ORCH_PHASE_END(HostOrchPhase::BuildDefinition, recording->nodes.size());
+    }
+    const GraphDefinition *header = built ? graph_definition(definition) : nullptr;
+    if (header == nullptr) {
         debug_assert(false && "The recorded Graph contains a construct that Graph Execution does not support");
-        LOG_WARN("%s", "[GraphExecution] unsupported construct observed; falling back to the ordinary path");
+        LOG_WARN("%s", "[GraphExecution] asynchronous recording produced an unsupported Graph");
+        graph_abort();
         return false;
     }
-    ORCH_PHASE_END(HostOrchPhase::BuildDefinition, recording->nodes.size());
-    const GraphDefinition *header = graph_definition(definition);
-    if (header == nullptr) return false;
     LOG_DEBUG(
         "[GraphExecution] define key=0x%llx nodes=%u bytes=%u", static_cast<unsigned long long>(header->full_key),
         header->task_count, header->total_bytes
     );
-    auto inserted = state->definitions.emplace(header->full_key, std::move(definition));
-    const std::vector<std::byte> &cached = inserted.first->second;
-
-    // Emit the single outer GRAPH task for this first invocation exactly as a
-    // cache hit would, so the recording run occupies one ring slot and one heap
-    // block instead of one per internal node. The Definition stays cached for
-    // subsequent invocations even if this placement fails.
-    PTO2TaskId submitted = PTO2TaskId::invalid();
+    bool ready = false;
     {
-        ORCH_PHASE_START();
-        if (recording->boundary_args == nullptr ||
-            !graph_submit_definition(this, state, cached, *recording->boundary_args, &submitted)) {
-            return false;
+        std::lock_guard<std::mutex> lock(state->recording_mutex);
+        if (state->status() != GraphRecordingStatus::RECORDING || state->recording_key != header->full_key) {
+            state->set_status(GraphRecordingStatus::FAILED);
+        } else {
+            state->definitions.emplace(header->full_key, std::move(definition));
+            state->set_status(GraphRecordingStatus::READY);
         }
-        ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
+        ready = state->status() == GraphRecordingStatus::READY;
+        state->recording.reset();
     }
-#if SIMPLER_DFX
-    g_orch_submit_idx++;
-#if SIMPLER_ORCH_PROFILING
-    g_orch_submit_count++;
-#endif
-#endif
-    return true;
+    g_active_graph_recording = nullptr;
+    g_active_graph_owner = nullptr;
+    state->recording_cv.notify_all();
+    return ready;
 }
 
-void PTO2OrchestratorState::graph_commit() {}
+void PTO2OrchestratorState::graph_commit() {
+    if (active_graph_recording(this) != nullptr) return;
+    GraphHostState *state = graph_state_from(this);
+    if (state == nullptr) return;
+
+    uint64_t full_key = 0;
+    const GraphDefinition *definition = nullptr;
+    bool failed = false;
+    {
+        std::unique_lock<std::mutex> lock(state->recording_mutex);
+        if (state->status() == GraphRecordingStatus::IDLE) return;
+        state->recording_cv.wait(lock, [&]() {
+            return state->status() != GraphRecordingStatus::RECORDING;
+        });
+        full_key = state->recording_key;
+        failed = state->status() != GraphRecordingStatus::READY;
+        auto definition_it = state->definitions.find(full_key);
+        if (!failed && definition_it != state->definitions.end()) definition = graph_definition(definition_it->second);
+    }
+
+    if (definition == nullptr || !graph_finalize_pending_submissions(this, state, *definition)) failed = true;
+    {
+        std::lock_guard<std::mutex> lock(state->recording_mutex);
+        state->set_status(GraphRecordingStatus::IDLE);
+        state->recording_key = 0;
+    }
+    if (failed) {
+        report_fatal(
+            PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "failed to finalize asynchronous Graph key=%#llx",
+            static_cast<unsigned long long>(full_key)
+        );
+    }
+}
 
 TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
     auto *orch = this;
@@ -1776,7 +1989,7 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
         task_attrs.set_predicate();
     }
 
-    if (GraphHostState *state = graph_state_from(orch); state != nullptr && state->recording != nullptr) {
+    if (active_graph_recording(orch) != nullptr) {
         return graph_record_submit_node(
             orch, args, active_mask, task_attrs, normalized.aic_kernel_id, normalized.aiv0_kernel_id,
             normalized.aiv1_kernel_id
@@ -1819,7 +2032,7 @@ TaskOutputTensors PTO2OrchestratorState::submit_dummy_task(const CoreTaskArgs &a
     task_attrs.set_early_resolve(args.allow_early_resolve());
     task_attrs.set_timing_slot(args.task_timing_slot());
 
-    if (GraphHostState *state = graph_state_from(orch); state != nullptr && state->recording != nullptr) {
+    if (active_graph_recording(orch) != nullptr) {
         return graph_record_submit_node(
             orch, args, ActiveMask{}, task_attrs, INVALID_KERNEL_ID, INVALID_KERNEL_ID, INVALID_KERNEL_ID
         );
@@ -1868,9 +2081,9 @@ TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const CoreTaskArgs &args)
 
     // Runtime-allocated outputs cannot be replayed by a Graph, so a Graph body
     // that calls alloc_tensors is unsupported. Still materialize the outputs so
-    // the recording body chains correctly, then poison the recording; graph_end
-    // falls back and the body re-runs on the ordinary path.
-    if (GraphHostState *state = graph_state_from(orch); state != nullptr && state->recording != nullptr) {
+    // the recording body can finish classification, then poison the recording;
+    // commit reports a fatal error because outer shells already exist.
+    if (active_graph_recording(orch) != nullptr) {
         TaskOutputTensors result = graph_record_submit_node(
             orch, args, ActiveMask{}, TaskAttrs{}, INVALID_KERNEL_ID, INVALID_KERNEL_ID, INVALID_KERNEL_ID
         );

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -101,6 +101,14 @@ static GraphScopeResult graph_begin_impl(PTO2Runtime *rt, uint64_t graph_key, co
     return rt->orchestrator.graph_begin(graph_key, args, rt->active_callable_hash);
 }
 
+static bool graph_prepare_impl(PTO2Runtime *rt, const CoreTaskArgs &args) {
+    return rt != nullptr && rt->orchestrator.graph_prepare(args);
+}
+
+static void graph_abort_impl(PTO2Runtime *rt) {
+    if (rt != nullptr) rt->orchestrator.graph_abort();
+}
+
 static bool graph_end_impl(PTO2Runtime *rt) { return rt != nullptr && rt->orchestrator.graph_end(); }
 
 static void graph_commit_impl(PTO2Runtime *rt) {
@@ -115,7 +123,14 @@ void rt_scope_begin(PTO2Runtime *rt) {
 
 void rt_scope_end(PTO2Runtime *rt) { rt->orchestrator.end_scope(); }
 
-void rt_orchestration_done(PTO2Runtime *rt) { rt->orchestrator.mark_done(); }
+void rt_orchestration_done(PTO2Runtime *rt) {
+    // Host orchestration calls this runtime entry directly rather than the
+    // orchestration-SO wrapper. Commit here as well so an all-Graph entry has a
+    // final synchronization point for its asynchronous recording and deferred
+    // outer shells even when no later non-Graph task forced an earlier commit.
+    rt->orchestrator.graph_commit();
+    rt->orchestrator.mark_done();
+}
 
 static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator.fatal; }
 
@@ -379,6 +394,8 @@ static const PTO2RuntimeOps s_runtime_ops = {
     .available_cluster_count = available_cluster_count_impl,
     .available_aiv_count = available_aiv_count_impl,
     .graph_begin = graph_begin_impl,
+    .graph_prepare = graph_prepare_impl,
+    .graph_abort = graph_abort_impl,
     .graph_end = graph_end_impl,
     .graph_commit = graph_commit_impl,
 #if SIMPLER_DFX

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_orchestrator.h
@@ -25,8 +25,7 @@
  * Based on: docs/RUNTIME_LOGIC.md
  */
 
-#ifndef PTO_ORCHESTRATOR_H
-#define PTO_ORCHESTRATOR_H
+#pragma once
 
 #include "common/chip_swimlane_profiling.h"
 #include "utils/device_arena.h"
@@ -159,6 +158,8 @@ struct PTO2OrchestratorState {
     TaskOutputTensors submit_dummy_task(const CoreTaskArgs &args);
     TaskOutputTensors alloc_tensors(const CoreTaskArgs &args);
     GraphScopeResult graph_begin(uint64_t graph_key, const CoreTaskArgs &args, uint64_t callable_hash);
+    bool graph_prepare(const CoreTaskArgs &args);
+    void graph_abort();
     bool graph_end();
     void graph_commit();
     void mark_done();
@@ -186,5 +187,3 @@ struct PTO2OrchProfilingData {
 
 PTO2OrchProfilingData orchestrator_get_profiling();
 #endif
-
-#endif  // PTO_ORCHESTRATOR_H

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_ring_buffer.h
@@ -42,6 +42,14 @@
 #include "pto_shared_memory.h"
 #include "common/unified_log.h"
 
+// Base of the address range Graph recording hands to an internal node's packed
+// outputs. Recorded addresses are never dereferenced: they exist so
+// graph_classify_tensor can tell an internal producer's output from a boundary
+// tensor by address-range containment alone, and the Definition stores them as
+// offsets. That classification is only sound while the range is disjoint from
+// every real heap address, which PTO2TaskAllocator::init() asserts.
+inline constexpr uint64_t GRAPH_RECORD_VIRTUAL_BASE = 1ULL << 63;
+
 // Dep pool spin limit - if exceeded, dep pool capacity too small for workload
 #define PTO2_DEP_POOL_SPIN_LIMIT 100000
 
@@ -92,6 +100,14 @@ public:
         error_code_ptr_ = error_code_ptr;
         local_task_id_ = 0;
         heap_top_ = 0;
+        // Every address this allocator hands out lies in
+        // [heap_base_, heap_base_ + heap_size_), so checking the range once here
+        // keeps it disjoint from GRAPH_RECORD_VIRTUAL_BASE for every allocation.
+        const uint64_t heap_base_addr = reinterpret_cast<uint64_t>(heap_base);
+        always_assert(
+            heap_base_addr < GRAPH_RECORD_VIRTUAL_BASE && heap_size <= GRAPH_RECORD_VIRTUAL_BASE - heap_base_addr &&
+            "Graph heap overlaps the Graph-recording virtual address range"
+        );
     }
 
     /**
@@ -129,6 +145,20 @@ public:
         return {task_id, task_id & window_mask_, heap_ptr, static_cast<char *>(heap_ptr) + aligned_size};
     }
 
+    bool reserve_deferred_heap(int32_t output_size, void **packed_base, void **packed_end) {
+        if (output_size < 0 || packed_base == nullptr || packed_end == nullptr) return false;
+        if (error_code_ptr_ != nullptr && error_code_ptr_->load(std::memory_order_acquire) != PTO2_ERROR_NONE) {
+            return false;
+        }
+        const uint64_t aligned_size =
+            output_size > 0 ? PTO2_ALIGN_UP(static_cast<uint64_t>(output_size), PTO2_ALIGN_SIZE) : 0;
+        void *base = try_bump_heap(aligned_size);
+        if (base == nullptr) return false;
+        *packed_base = base;
+        *packed_end = static_cast<char *>(base) + aligned_size;
+        return true;
+    }
+
     // =========================================================================
     // State queries
     // =========================================================================
@@ -146,28 +176,6 @@ public:
     uint64_t heap_top() const { return heap_top_; }
     uint64_t heap_capacity() const { return heap_size_; }
     uint64_t heap_used_bytes() const { return heap_top_; }
-
-    // Reserve output-buffer bytes without claiming a task-window slot. Graph
-    // recording gives each internal node a disjoint, valid heap address so
-    // tensor-source classification works, then releases the whole range with
-    // restore_heap_top() once the consolidated outer GRAPH task reclaims it as a
-    // single block. On exhaustion it returns nullptr and leaves allocator state
-    // unchanged; graph_record_submit_node treats that as an unsupported
-    // recording and falls back to the ordinary path. A zero size returns the
-    // current position.
-    void *reserve_heap_scratch(int32_t output_size) {
-        uint64_t aligned_size =
-            output_size > 0 ? PTO2_ALIGN_UP(static_cast<uint64_t>(output_size), PTO2_ALIGN_SIZE) : 0;
-        uint64_t top = heap_top_;
-        if (aligned_size == 0) return static_cast<char *>(heap_base_) + top;
-        if (heap_size_ - top < aligned_size) return nullptr;
-        heap_top_ = top + aligned_size;
-        return static_cast<char *>(heap_base_) + top;
-    }
-
-    // Roll the heap allocation pointer back to a value previously returned by
-    // heap_top().
-    void restore_heap_top(uint64_t top) { heap_top_ = top; }
 
 private:
     // --- Task Ring ---

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -96,6 +96,8 @@ struct PTO2RuntimeOps {
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
     GraphScopeResult (*graph_begin)(PTO2Runtime *rt, uint64_t graph_key, const CoreTaskArgs &args);
+    bool (*graph_prepare)(PTO2Runtime *rt, const CoreTaskArgs &args);
+    void (*graph_abort)(PTO2Runtime *rt);
     bool (*graph_end)(PTO2Runtime *rt);
     void (*graph_commit)(PTO2Runtime *rt);
     // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]

--- a/src/a5/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a5/runtime/host_build_graph/docs/profiling_levels.md
@@ -281,9 +281,15 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
   variable. One `bind phase=<p> start_ns=<n> dur_ns=<n> <attrs>` line per
   segment, plus one `host-orch phase=<p> total_ns=<n> count=<k> detail_sum=<n>
   dropped=<n>` line per orchestrator kind. They come from per-kind counters, not
-  from the record pool, so a total stays exact even if the pool was never armed or
-  overflowed — that is what makes this the channel for steady state, where
-  `--rounds > 1` switches every artifact collector off.
+  from the record pool. The counters use lock-free atomic additions across the
+  main and recording-worker lanes, with every phase isolated on its own cache
+  line so concurrent `graph_submit` and `record_node` updates do not
+  false-share. The per-event pool is armed when the level-4 artifact is being
+  written (a producer that wants records *and* an output prefix) or whenever the
+  chip swimlane is at `ORCH_PHASES`; a steady-state run satisfies neither, so it
+  pays no pool append and no artifact lock at all. A total stays exact even if
+  the pool was never armed or overflowed — that is what makes this the channel
+  for steady state, where `--rounds > 1` switches every artifact collector off.
 
   Every line is written at the end of the pass, keeping the log write off the path
   being measured. The line therefore carries its own `start_ns`; the log prefix
@@ -293,8 +299,11 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
   has one. One JSON Lines object per pass carrying `pid` / `inv` — the identity
   the `[STRACE]` tree groups by — and one record per operation. This is the
   channel to read for a distribution or a per-event timeline; the summed lines
-  cannot express either. `strace_timing.py --swimlane --host-phase-records <path>`
-  draws each record inside the matching `chip.run.bind`.
+  cannot express either. Every record carries its producer Linux tid.
+  `strace_timing.py --swimlane --host-phase-records <path>` draws each record
+  inside the matching `chip.run.bind`; `record_node` and `build_definition`
+  appear on the `graph record worker` lane, while outer `graph_submit` events
+  appear on the `graph submit main` lane.
 
 - **The host lanes of `chip_swimlane_records.json`**, at level 4 only, joined to
   the device timeline through the clock anchors (see `host/clock_correlation.h`).
@@ -323,12 +332,13 @@ not belong in it.
 
 ### Cost and capacity
 
-A record costs two clock reads, a store and two counter updates — roughly 47 ns
-on an aarch64 host, for ~337 operations in a 40-layer decode pass. Cheap, but it
-sits on the path being measured, which is why neither switch is on by default.
+A record costs two clock reads and a store. Its per-kind counter update is a
+lock-free atomic add; only the per-event pool append is serialized, and only
+when the pool is armed. It sits on the path being measured, which is why neither
+switch is on by default.
 
 The pool holds `PLATFORM_HOST_PHASE_BUFFERS × PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER`
-records (5 × 1024 = 5120, 160 KB) in fixed-size buffers rotated in index order,
+records (5 × 1024 = 5120, 200 KiB) in fixed-size buffers rotated in index order,
 the same shape as the device sched/orch pools with host DDR as its backing.
 Beyond that, records are dropped from the tail and counted: the per-event views
 truncate, the per-kind totals stay exact, and `dropped=` on every `host-orch` line

--- a/src/a5/runtime/host_build_graph/host/host_phase_trace.cpp
+++ b/src/a5/runtime/host_build_graph/host/host_phase_trace.cpp
@@ -18,8 +18,17 @@
 
 #include <stdio.h>
 
+#include <atomic>
 #include <array>
 #include <cstdlib>
+#include <functional>
+#include <mutex>
+#include <thread>
+
+#if defined(__linux__)
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
 
 #include "common/host_api.h"
 #include "common/log_clock.h"
@@ -35,18 +44,28 @@ namespace {
 // measured path.
 constexpr size_t kBindAttrsCapacity = 96;
 
-struct KindCounter {
-    uint64_t total_ns;
-    uint64_t count;
-    uint64_t payload_sum;
-    uint64_t first_start_ns;
+// record_node and graph_submit are updated concurrently by different cores.
+// Keep phase counters on distinct cache lines so lock-free accounting does not
+// turn that intended overlap into cache-line ownership ping-pong.
+struct alignas(64) KindCounter {
+    std::atomic<uint64_t> total_ns{0};
+    std::atomic<uint64_t> count{0};
+    std::atomic<uint64_t> payload_sum{0};
+    std::atomic<uint64_t> first_start_ns{0};
 };
+static_assert(sizeof(KindCounter) == 64);
 
 struct TraceState {
-    HostPhaseRecordPool *pool;
+    std::atomic<HostPhaseRecordPool *> pool{nullptr};
     const HostApi *api;
-    bool active;
-    uint64_t submitted_tasks;
+    std::atomic<bool> active{false};
+    // Records accepted by `active` but not yet finished with the counters and the
+    // pool. begin/end clear `active` and then drain this to zero, so a record can
+    // never be reported by a pass it does not belong to.
+    std::atomic<int32_t> in_flight{0};
+    std::mutex lifecycle_mutex;
+    std::mutex pool_mutex;
+    std::atomic<uint64_t> submitted_tasks{0};
     std::array<KindCounter, kHostPhaseKindCount> counters;
     std::array<std::array<char, kBindAttrsCapacity>, kHostPhaseKindCount> bind_attrs;
 };
@@ -56,7 +75,80 @@ TraceState &state() {
     return s;
 }
 
+// Publish-then-check against the trace lifecycle's clear-then-drain. Claiming a
+// slot before reading `active` is what makes the pair race-free: a record that
+// got in before the pass closed is waited for, and one that arrives after sees
+// `active` false and withdraws.
+class RecordAdmission {
+public:
+    explicit RecordAdmission(TraceState &s) :
+        s_(s) {
+        s_.in_flight.fetch_add(1, std::memory_order_acq_rel);
+        admitted_ = s_.active.load(std::memory_order_acquire);
+        if (!admitted_) s_.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+    }
+    ~RecordAdmission() {
+        if (admitted_) s_.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+    }
+
+    RecordAdmission(const RecordAdmission &) = delete;
+    RecordAdmission &operator=(const RecordAdmission &) = delete;
+
+    explicit operator bool() const { return admitted_; }
+
+private:
+    TraceState &s_;
+    bool admitted_{false};
+};
+
+// Called with `active` already false, so no new record can be admitted. Only the
+// recording worker can still be inside one, and commit joins it before a pass
+// ends, so in practice this returns without spinning.
+void drain_in_flight_records(TraceState &s) {
+    while (s.in_flight.load(std::memory_order_acquire) != 0) {}
+}
+
 bool is_bind_kind(uint32_t kind) { return kind < static_cast<uint32_t>(HostPhaseKind::OrchSubmitTask); }
+
+uint32_t current_thread_id() {
+    // A thread's identity is fixed for its lifetime, so resolve it once. This
+    // runs per record on the path being measured, where a syscall would inflate
+    // the very durations it is annotating.
+    static thread_local const uint32_t id = []() -> uint32_t {
+#if defined(__linux__) && defined(SYS_gettid)
+        return static_cast<uint32_t>(syscall(SYS_gettid));
+#else
+        return static_cast<uint32_t>(std::hash<std::thread::id>{}(std::this_thread::get_id()));
+#endif
+    }();
+    return id;
+}
+
+void record_counter(TraceState &s, uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload) {
+    KindCounter &counter = s.counters[kind];
+    uint64_t unset = 0;
+    (void)counter.first_start_ns.compare_exchange_strong(unset, start_ns, std::memory_order_relaxed);
+    counter.total_ns.fetch_add(end_ns - start_ns, std::memory_order_relaxed);
+    counter.count.fetch_add(1, std::memory_order_relaxed);
+    counter.payload_sum.fetch_add(payload, std::memory_order_relaxed);
+}
+
+void append_record(TraceState &s, uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload, uint32_t index) {
+    if (s.pool.load(std::memory_order_acquire) == nullptr) return;
+    std::lock_guard<std::mutex> lock(s.pool_mutex);
+    HostPhaseRecordPool *pool = s.pool.load(std::memory_order_relaxed);
+    if (pool == nullptr) return;
+    host_phase_pool_append(
+        pool, static_cast<HostPhaseKind>(kind), start_ns, end_ns, payload, index, current_thread_id()
+    );
+}
+
+void reset_counter(KindCounter &counter) {
+    counter.total_ns.store(0, std::memory_order_relaxed);
+    counter.count.store(0, std::memory_order_relaxed);
+    counter.payload_sum.store(0, std::memory_order_relaxed);
+    counter.first_start_ns.store(0, std::memory_order_relaxed);
+}
 
 }  // namespace
 
@@ -75,7 +167,7 @@ bool host_phase_timing_enabled() {
 // Strong definitions overriding the orchestrator core's weak fallbacks, which
 // exist so builds without this translation unit still link.
 __attribute__((visibility("hidden"))) uint64_t host_phase_now_ns() {
-    if (!state().active) {
+    if (!state().active.load(std::memory_order_acquire)) {
         return 0;
     }
     return static_cast<uint64_t>(simpler::log::monotonic_now_ns());
@@ -84,60 +176,80 @@ __attribute__((visibility("hidden"))) uint64_t host_phase_now_ns() {
 __attribute__((visibility("hidden"))) void
 host_phase_record(uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload, uint32_t index) {
     TraceState &s = state();
-    if (!s.active || kind >= kHostPhaseKindCount || end_ns < start_ns) {
+    if (!s.active.load(std::memory_order_acquire) || kind >= kHostPhaseKindCount || end_ns < start_ns) {
         return;
     }
-    KindCounter &counter = s.counters[kind];
-    if (counter.count == 0) {
-        counter.first_start_ns = start_ns;
+    // ORCH_PHASE_END calls this on every submit-level operation, so the load
+    // above stays the whole cost when tracing is off. Admission then re-checks
+    // under the in-flight claim, which is what actually closes the boundary.
+    RecordAdmission admission(s);
+    if (!admission) {
+        return;
     }
-    counter.total_ns += end_ns - start_ns;
-    counter.count++;
-    counter.payload_sum += payload;
-    host_phase_pool_append(s.pool, static_cast<HostPhaseKind>(kind), start_ns, end_ns, payload, index);
+    record_counter(s, start_ns, end_ns, kind, payload);
+    append_record(s, start_ns, end_ns, kind, payload, index);
 }
 
 void host_phase_record_bind(uint32_t kind, uint64_t start_ns, const char *attrs, uint64_t payload) {
     TraceState &s = state();
-    if (!s.active || !is_bind_kind(kind)) {
+    if (!s.active.load(std::memory_order_acquire) || !is_bind_kind(kind)) {
+        return;
+    }
+    RecordAdmission admission(s);
+    if (!admission) {
         return;
     }
     const uint64_t end_ns = static_cast<uint64_t>(simpler::log::monotonic_now_ns());
     if (attrs != nullptr) {
         snprintf(s.bind_attrs[kind].data(), kBindAttrsCapacity, "%s", attrs);
     }
-    host_phase_record(start_ns, end_ns, kind, payload, 0);
+    record_counter(s, start_ns, end_ns, kind, payload);
+    append_record(s, start_ns, end_ns, kind, payload, 0);
 }
 
 void host_phase_trace_begin(const void *host_api) {
     TraceState &s = state();
+    std::lock_guard<std::mutex> lock(s.lifecycle_mutex);
+    s.active.store(false, std::memory_order_release);
+    drain_in_flight_records(s);
     s.api = static_cast<const HostApi *>(host_api);
-    s.pool = s.api != nullptr ?
-                 static_cast<HostPhaseRecordPool *>(s.api->host_phase_pool_arm(host_phase_timing_enabled())) :
-                 nullptr;
+    HostPhaseRecordPool *pool =
+        s.api != nullptr ? static_cast<HostPhaseRecordPool *>(s.api->host_phase_pool_arm(host_phase_timing_enabled())) :
+                           nullptr;
+    s.pool.store(pool, std::memory_order_release);
     // Timestamps are taken whenever either sink wants them. Gating the clock on
     // the environment variable alone would leave a level-4 run recording zeros.
-    s.active = s.pool != nullptr || host_phase_timing_enabled();
-    s.submitted_tasks = 0;
-    s.counters.fill(KindCounter{});
+    s.submitted_tasks.store(0, std::memory_order_relaxed);
+    for (KindCounter &counter : s.counters)
+        reset_counter(counter);
     for (auto &attrs : s.bind_attrs) {
         attrs[0] = '\0';
     }
+    s.active.store(s.pool != nullptr || host_phase_timing_enabled(), std::memory_order_release);
 }
 
-void host_phase_trace_note_submitted(uint64_t submitted_tasks) { state().submitted_tasks = submitted_tasks; }
+void host_phase_trace_note_submitted(uint64_t submitted_tasks) {
+    state().submitted_tasks.store(submitted_tasks, std::memory_order_relaxed);
+}
 
 void host_phase_trace_end() {
     TraceState &s = state();
-    if (!s.active) {
+    std::lock_guard<std::mutex> lifecycle_lock(s.lifecycle_mutex);
+    if (!s.active.load(std::memory_order_relaxed)) {
         return;
     }
+    s.active.store(false, std::memory_order_release);
+    // Every record already past the `active` check finishes its counter and pool
+    // work before the totals below are read and the pool is handed back.
+    drain_in_flight_records(s);
+    std::lock_guard<std::mutex> pool_lock(s.pool_mutex);
     // Read the pool's own tally before handing it back, and drop the pointer
     // after: the pool belongs to the runner from finish() onward, and the pass is
     // over either way, so nothing here may outlive it. Clearing `active` also
     // makes a second end() without an intervening begin() a no-op rather than a
     // stale read plus a duplicate report.
-    const uint64_t dropped = s.pool != nullptr ? s.pool->head.dropped_record_count : 0;
+    HostPhaseRecordPool *pool = s.pool.load(std::memory_order_relaxed);
+    const uint64_t dropped = pool != nullptr ? pool->head.dropped_record_count : 0;
     if (s.api != nullptr) {
         uint64_t inv = 0;
 #if SIMPLER_HOST_STRACE
@@ -145,10 +257,9 @@ void host_phase_trace_end() {
         // artifact joins to them on (pid, inv).
         inv = simpler::strace::StraceScope::current_inv();
 #endif
-        s.api->host_phase_pool_finish(s.submitted_tasks, inv);
+        s.api->host_phase_pool_finish(s.submitted_tasks.load(std::memory_order_relaxed), inv);
     }
-    s.pool = nullptr;
-    s.active = false;
+    s.pool.store(nullptr, std::memory_order_release);
     if (!host_phase_timing_enabled()) {
         // Records were collected for a per-event reader alone, which has its own
         // report; this breakdown was not asked for.
@@ -157,9 +268,13 @@ void host_phase_trace_end() {
 
     for (uint32_t kind = 0; kind < kHostPhaseKindCount; ++kind) {
         const KindCounter &counter = s.counters[kind];
-        if (counter.count == 0) {
+        const uint64_t count = counter.count.load(std::memory_order_relaxed);
+        if (count == 0) {
             continue;
         }
+        const uint64_t total_ns = counter.total_ns.load(std::memory_order_relaxed);
+        const uint64_t payload_sum = counter.payload_sum.load(std::memory_order_relaxed);
+        const uint64_t first_start_ns = counter.first_start_ns.load(std::memory_order_relaxed);
         const char *name = host_phase_kind_name(static_cast<HostPhaseKind>(kind));
         if (is_bind_kind(kind)) {
             // One occurrence per pass, so the summed time is the segment's own
@@ -168,9 +283,8 @@ void host_phase_trace_end() {
             // the pass, off the path being measured — the write time says nothing
             // about when the segment ran.
             LOG_TIMING(
-                "bind phase=%s start_ns=%llu dur_ns=%llu %s", name,
-                static_cast<unsigned long long>(counter.first_start_ns),
-                static_cast<unsigned long long>(counter.total_ns), s.bind_attrs[kind].data()
+                "bind phase=%s start_ns=%llu dur_ns=%llu %s", name, static_cast<unsigned long long>(first_start_ns),
+                static_cast<unsigned long long>(total_ns), s.bind_attrs[kind].data()
             );
             continue;
         }
@@ -179,8 +293,8 @@ void host_phase_trace_end() {
         // on a timeline. Per-event bars come from the artifact instead.
         LOG_TIMING(
             "host-orch phase=%s total_ns=%llu count=%llu detail_sum=%llu dropped=%llu", name,
-            static_cast<unsigned long long>(counter.total_ns), static_cast<unsigned long long>(counter.count),
-            static_cast<unsigned long long>(counter.payload_sum), static_cast<unsigned long long>(dropped)
+            static_cast<unsigned long long>(total_ns), static_cast<unsigned long long>(count),
+            static_cast<unsigned long long>(payload_sum), static_cast<unsigned long long>(dropped)
         );
     }
 }

--- a/src/a5/runtime/host_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/host_build_graph/orchestration/pto_orchestration_api.h
@@ -30,8 +30,16 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <array>
+#include <condition_variable>
 #include <cstring>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <tuple>
 #include <type_traits>
+#include <utility>
 
 // Type headers needed by orchestration
 #include "common.h"              // framework_bind_runtime / framework_current_runtime
@@ -94,6 +102,8 @@ typedef struct PTO2RuntimeOps {
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
     GraphScopeResult (*graph_begin)(PTO2Runtime *rt, uint64_t graph_key, const CoreTaskArgs &args);
+    bool (*graph_prepare)(PTO2Runtime *rt, const CoreTaskArgs &args);
+    void (*graph_abort)(PTO2Runtime *rt);
     bool (*graph_end)(PTO2Runtime *rt);
     void (*graph_commit)(PTO2Runtime *rt);
 
@@ -116,13 +126,175 @@ struct PTO2Runtime {
     PTO2ScopeMode pending_scope_mode;
 };
 
+class GraphOwnedArgs {
+public:
+    // A CoreTaskArgs cannot report more args than its own capacity, so the loops
+    // below need no runtime bound — but only while these arrays are at least as
+    // large as that capacity. GRAPH_MAX_TENSOR_ARGS and MAX_TENSOR_ARGS are
+    // independent constants that merely happen to agree, so shrinking the Graph
+    // one would silently turn the tensor loop into an overflow that a release
+    // build cannot catch.
+    static_assert(
+        GRAPH_MAX_TENSOR_ARGS >= static_cast<uint32_t>(MAX_TENSOR_ARGS),
+        "GraphOwnedArgs must hold every tensor a CoreTaskArgs can carry"
+    );
+
+    explicit GraphOwnedArgs(const CoreTaskArgs &source) {
+        for (int32_t i = 0; i < source.tensor_count(); ++i) {
+            tensors_[static_cast<size_t>(i)].copy(source.tensor(i).ref());
+            switch (source.tag(i)) {
+            case TensorArgType::INPUT:
+                args_.add_input(tensors_[static_cast<size_t>(i)]);
+                break;
+            case TensorArgType::OUTPUT_EXISTING:
+                args_.add_output(tensors_[static_cast<size_t>(i)]);
+                break;
+            case TensorArgType::INOUT:
+                args_.add_inout(tensors_[static_cast<size_t>(i)]);
+                break;
+            case TensorArgType::NO_DEP:
+                args_.add_no_dep(tensors_[static_cast<size_t>(i)]);
+                break;
+            case TensorArgType::OUTPUT:
+                args_.set_error("Runtime-allocated output is not supported at a Graph boundary");
+                break;
+            }
+        }
+        for (int32_t i = 0; i < source.scalar_count(); ++i) {
+            scalars_[static_cast<size_t>(i)] = source.scalar(i);
+            args_.add_scalar(scalars_[static_cast<size_t>(i)]);
+        }
+        args_.launch_spec = source.launch_spec;
+        args_.set_allow_early_resolve(source.allow_early_resolve());
+        if (source.task_timing_slot() != TASK_TIMING_SLOT_NONE) {
+            args_.set_task_timing_slot(source.task_timing_slot());
+        }
+        args_.set_predicate(source.predicate());
+    }
+
+    CoreTaskArgs &args() { return args_; }
+
+private:
+    std::array<ChipTensor, GRAPH_MAX_TENSOR_ARGS> tensors_{};
+    std::array<uint64_t, MAX_SCALAR_ARGS> scalars_{};
+    CoreTaskArgs args_;
+};
+
+class GraphAsyncRecordingState {
+public:
+    GraphAsyncRecordingState() = default;
+    ~GraphAsyncRecordingState() { shutdown(); }
+
+    GraphAsyncRecordingState(const GraphAsyncRecordingState &) = delete;
+    GraphAsyncRecordingState &operator=(const GraphAsyncRecordingState &) = delete;
+
+    template <typename Job>
+    bool start(Job &&job) {
+        std::function<void()> next;
+        try {
+            next = std::forward<Job>(job);
+            ensure_worker();
+        } catch (...) {
+            return false;
+        }
+
+        std::unique_lock<std::mutex> lock(mutex_);
+        debug_assert(done_ && !pending_ && "Only one Graph recording may be in flight");
+        if (!done_ || pending_ || stopping_) return false;
+        job_ = std::move(next);
+        done_ = false;
+        pending_ = true;
+        cv_.notify_one();
+        // graph_begin() has already installed the hash-keyed RECORDING entry
+        // and submitted the zero-heap outer shell. Enqueuing the private job is
+        // therefore the last dependency of the caller; graph_prepare() and all
+        // node recording may start after later same-hash shells are submitted.
+        return true;
+    }
+
+    void wait() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        // Recording invokes the same public task wrappers as the outer
+        // orchestration. Those wrappers call rt_graph_commit() before a
+        // non-Graph operation. The recorder must never wait for its own job.
+        if (worker_.joinable() && worker_.get_id() == std::this_thread::get_id()) return;
+        cv_.wait(lock, [&]() {
+            return done_;
+        });
+    }
+
+private:
+    void ensure_worker() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!worker_.joinable()) {
+            worker_ = std::thread([this]() {
+                run();
+            });
+        }
+    }
+
+    void run() {
+        for (;;) {
+            std::function<void()> current;
+            {
+                std::unique_lock<std::mutex> lock(mutex_);
+                cv_.wait(lock, [&]() {
+                    return pending_ || stopping_;
+                });
+                if (stopping_) return;
+                current = std::move(job_);
+                pending_ = false;
+            }
+            current();
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                done_ = true;
+            }
+            cv_.notify_all();
+        }
+    }
+
+    void shutdown() {
+        wait();
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            stopping_ = true;
+        }
+        cv_.notify_all();
+        if (worker_.joinable()) worker_.join();
+    }
+
+    std::thread worker_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    std::function<void()> job_;
+    bool pending_{false};
+    bool done_{true};
+    bool stopping_{false};
+};
+
+// External linkage on purpose: `static inline` would give every translation
+// unit that submits a Graph its own recorder and its own worker thread, so a
+// commit reached from one TU would not wait for a recording another TU started.
+// Vague linkage keeps one instance — and one worker — per loaded SO.
+inline GraphAsyncRecordingState &rt_graph_async_recording() {
+    // One orchestration SO is invoked serially by its ChipWorker. Keep its
+    // recorder alive across runs so steady-state misses pay only a condition-
+    // variable wakeup, not a fresh pthread create/join. The SO's destructor
+    // stops the idle worker before dlclose unmaps its code.
+    static GraphAsyncRecordingState state;
+    return state;
+}
+
 // =============================================================================
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================
 
 static inline PTO2Runtime *current_runtime() { return framework_current_runtime(); }
+static inline void rt_graph_commit();
 
 static inline TaskOutputTensors alloc_tensors(const CoreTaskArgs &args) {
+    rt_graph_commit();
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -173,6 +345,7 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
 }
 
 static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
+    rt_graph_commit();
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -206,6 +379,7 @@ static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const Core
  * barrier or as a placeholder producer for tests / dep-graph wiring.
  */
 static inline TaskOutputTensors rt_submit_dummy_task(const CoreTaskArgs &args) {
+    rt_graph_commit();
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -221,11 +395,18 @@ static inline GraphScopeResult rt_graph_begin(uint64_t graph_key, const CoreTask
     return rt->ops->graph_begin(rt, graph_key, args);
 }
 
-// Finish the recording pass. Returns true when the recorded sub-DAG was emitted
-// as a single outer GRAPH task (the body must not run again); false when the
-// recording was unsupported and the caller must re-run the body on the ordinary
-// path. A fatal runtime is terminal, so it reports true to suppress a pointless
-// re-run.
+static inline bool rt_graph_prepare(const CoreTaskArgs &args) {
+    PTO2Runtime *rt = current_runtime();
+    return rt->ops->graph_prepare != nullptr && rt->ops->graph_prepare(rt, args);
+}
+
+static inline void rt_graph_abort() {
+    PTO2Runtime *rt = current_runtime();
+    if (rt->ops->graph_abort != nullptr) rt->ops->graph_abort(rt);
+}
+
+// Finish the recording pass and publish its Definition. The calling thread
+// finalizes the already-submitted outer Graph shells in rt_graph_commit.
 static inline bool rt_graph_end() {
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt) || rt->ops->graph_end == nullptr) {
@@ -235,11 +416,11 @@ static inline bool rt_graph_end() {
 }
 
 static inline void rt_graph_commit() {
+    GraphAsyncRecordingState &async = rt_graph_async_recording();
+    async.wait();
+
     PTO2Runtime *rt = current_runtime();
-    if (rt->ops->is_fatal(rt) || rt->ops->graph_commit == nullptr) {
-        return;
-    }
-    rt->ops->graph_commit(rt);
+    if (!rt->ops->is_fatal(rt) && rt->ops->graph_commit != nullptr) rt->ops->graph_commit(rt);
 }
 
 static inline void rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {
@@ -260,6 +441,7 @@ static inline void rt_scope_end() {
 }
 
 static inline void rt_orchestration_done() {
+    rt_graph_commit();
     PTO2Runtime *rt = current_runtime();
     rt->ops->orchestration_done(rt);
 }
@@ -392,6 +574,12 @@ static inline uint64_t rt_graph_function_id(Function function) {
     return function_id;
 }
 
+// `invoke` is copied into the recording job and runs on the recording worker,
+// which outlives this call: the caller returns as soon as the outer shell is
+// submitted, and the body runs until the next rt_graph_commit(). So `invoke` must
+// own everything it needs by value. Capturing caller-frame storage by reference —
+// including the boundary `args` — is a use-after-free; the recorded body receives
+// its own boundary copy as a parameter for exactly that reason.
 template <typename Invoke>
 static inline GraphSubmitResult rt_submit_graph_impl(uint64_t graph_key, const CoreTaskArgs &args, Invoke invoke) {
     debug_assert(!args.has_error && "Graph boundary CoreTaskArgs construction failed");
@@ -408,31 +596,74 @@ static inline GraphSubmitResult rt_submit_graph_impl(uint64_t graph_key, const C
         );
     }
     if (!rt_graph_args_cacheable(args)) {
-        invoke();
         rt_graph_commit();
+        invoke(args);
         return GraphSubmitResult{};
     }
     GraphScopeResult result = rt_graph_begin(graph_key, args);
     if (result.recording) {
-        // First invocation: record the sub-DAG off the ring, then emit one outer
-        // GRAPH task. If the recording hit an unsupported construct, fall back and
-        // run the body on the ordinary path so its work is still submitted.
-        invoke();
-        if (!rt_graph_end()) invoke();
+        GraphAsyncRecordingState &async = rt_graph_async_recording();
+        std::shared_ptr<GraphOwnedArgs> owned_args;
+        try {
+            owned_args = std::make_shared<GraphOwnedArgs>(args);
+        } catch (...) {
+            try {
+                if (!rt_graph_prepare(args)) {
+                    rt_graph_abort();
+                    rt_graph_commit();
+                    return result;
+                }
+                invoke(args);
+                (void)rt_graph_end();
+            } catch (...) {
+                rt_graph_abort();
+                throw;
+            }
+            rt_graph_commit();
+            return result;
+        }
+        auto record = [owned_args, invoke]() mutable {
+            try {
+                if (!rt_graph_prepare(owned_args->args())) {
+                    rt_graph_abort();
+                    return;
+                }
+                invoke(owned_args->args());
+                (void)rt_graph_end();
+            } catch (...) {
+                rt_graph_abort();
+            }
+        };
+        if (!async.start(std::move(record))) {
+            try {
+                if (!rt_graph_prepare(owned_args->args())) {
+                    rt_graph_abort();
+                    rt_graph_commit();
+                    return result;
+                }
+                invoke(owned_args->args());
+                (void)rt_graph_end();
+            } catch (...) {
+                rt_graph_abort();
+                throw;
+            }
+            rt_graph_commit();
+        }
     } else if (result.execute_block) {
         // Un-cacheable at begin, or the Definition cache is full: ordinary path.
-        invoke();
+        rt_graph_commit();
+        if (!current_runtime()->ops->is_fatal(current_runtime())) invoke(args);
     }
-    // Cache hit: execute_block and recording are both false; the body is skipped.
-    rt_graph_commit();
+    // A cache hit or an in-flight hit skips the body. In-flight Graph tasks are
+    // finalized before the next non-Graph operation or orchestration completion.
     return result;
 }
 
 static inline GraphSubmitResult rt_submit_graph(uint64_t graph_id, GraphFunction function, const CoreTaskArgs &args) {
     debug_assert(function != nullptr && "Graph function must not be null");
     if (function == nullptr) return GraphSubmitResult{};
-    return rt_submit_graph_impl(rt_graph_make_key(graph_id), args, [&]() {
-        function(args);
+    return rt_submit_graph_impl(rt_graph_make_key(graph_id), args, [function](const CoreTaskArgs &record_args) {
+        function(record_args);
     });
 }
 
@@ -449,9 +680,17 @@ static inline GraphSubmitResult rt_submit_graph(
 ) {
     debug_assert(function != nullptr && "Graph function must not be null");
     if (function == nullptr) return GraphSubmitResult{};
-    return rt_submit_graph_impl(rt_graph_make_key(graph_id, config...), args, [&]() {
-        function(args, config...);
-    });
+    auto configs = std::make_tuple(config...);
+    return rt_submit_graph_impl(
+        rt_graph_make_key(graph_id, config...), args, [function, configs](const CoreTaskArgs &record_args) {
+            std::apply(
+                [&](auto... values) {
+                    function(record_args, values...);
+                },
+                configs
+            );
+        }
+    );
 }
 
 template <typename... Config>

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -30,10 +30,13 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cstddef>
+#include <condition_variable>
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <new>
 #include <optional>
 #include <unordered_map>
@@ -311,15 +314,12 @@ struct GraphRecordedNode {
 struct GraphRecording {
     uint64_t full_key{0};
     int32_t start_local_task_id{0};
-    // Heap allocation pointer captured at graph_begin. Internal nodes reserve
-    // scratch output buffers past it during the recording pass; graph_end rolls
-    // the heap back here so the outer GRAPH task reclaims the same region.
-    uint64_t heap_watermark{0};
-    // The Graph boundary CoreTaskArgs, owned by the caller for the whole
-    // rt_submit_graph_impl call (recording pass + graph_end). graph_end replays
-    // it through graph_submit_definition to emit the outer GRAPH task with the
-    // current invocation's boundary tensor addresses.
+    uint64_t next_virtual_offset{0};
+    // Worker-owned deep copy of the first Graph boundary. It stays valid from
+    // graph_prepare through graph_end and anchors boundary scalar sources while
+    // the main thread submits outer shells from later invocation arguments.
     const CoreTaskArgs *boundary_args{nullptr};
+    int32_t boundary_scalar_count{0};
     bool unsupported{false};
     std::vector<ChipTensor> boundary_tensors;
     std::vector<TensorArgType> boundary_types;
@@ -329,18 +329,44 @@ struct GraphRecording {
 struct GraphPendingUpload {
     PTO2TaskSlotState *outer_slot{nullptr};
     std::vector<std::byte> image;
+    bool deferred_heap{false};
 };
+
+enum class GraphRecordingStatus : uint8_t { IDLE = 0, RECORDING = 1, READY = 2, FAILED = 3 };
 
 struct GraphHostState {
     std::unordered_map<uint64_t, std::vector<std::byte>> definitions;
     std::unique_ptr<GraphRecording> recording;
     std::vector<GraphPendingUpload> pending_uploads;
+    std::mutex recording_mutex;
+    std::condition_variable recording_cv;
+    // Atomic because graph_prepare reads it on the recording worker without
+    // taking recording_mutex, by design: acquiring the mutex there lets a
+    // main-thread burst of same-hash submissions starve the worker before it can
+    // bind its private recording state. Every other access holds the mutex.
+    std::atomic<GraphRecordingStatus> recording_status{GraphRecordingStatus::IDLE};
+    uint64_t recording_key{0};
+
+    GraphRecordingStatus status() const { return recording_status.load(std::memory_order_acquire); }
+    void set_status(GraphRecordingStatus next) { recording_status.store(next, std::memory_order_release); }
 };
 
 namespace {
 
 GraphHostState *graph_state_from(PTO2OrchestratorState *orch) {
     return orch == nullptr ? nullptr : static_cast<GraphHostState *>(orch->graph_host_state);
+}
+
+thread_local GraphRecording *g_active_graph_recording = nullptr;
+// The recording a thread holds belongs to one GraphHostState. Recording into it
+// from a different orchestrator would silently mix two graphs, so the owner is
+// part of the thread-local identity rather than implied by it.
+thread_local GraphHostState *g_active_graph_owner = nullptr;
+
+GraphRecording *active_graph_recording(PTO2OrchestratorState *orch) {
+    GraphHostState *state = graph_state_from(orch);
+    if (state == nullptr || state != g_active_graph_owner) return nullptr;
+    return g_active_graph_recording;
 }
 
 uint64_t graph_full_key(uint64_t callable_hash, uint64_t graph_key) {
@@ -434,8 +460,9 @@ bool graph_classify_tensor(
 }
 
 void graph_record_mark_unsupported(PTO2OrchestratorState *orch) {
-    GraphHostState *state = graph_state_from(orch);
-    if (state != nullptr && state->recording != nullptr) state->recording->unsupported = true;
+    if (GraphRecording *recording = active_graph_recording(orch); recording != nullptr) {
+        recording->unsupported = true;
+    }
 }
 
 GraphBoundarySignature graph_boundary_signature(const ChipTensor &tensor, TensorArgType type, uint16_t alias_rep) {
@@ -624,7 +651,7 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     definition.edge_count = edge_count;
     definition.root_count = static_cast<uint32_t>(roots.size());
     definition.boundary_count = static_cast<uint32_t>(signatures.size());
-    definition.boundary_scalar_count = static_cast<uint32_t>(recording.boundary_args->scalar_count());
+    definition.boundary_scalar_count = static_cast<uint32_t>(recording.boundary_scalar_count);
     definition.tensor_arg_count = static_cast<uint32_t>(tensors.size());
     definition.scalar_arg_count = static_cast<uint32_t>(scalars.size());
     size_t execution_storage_bytes = 0;
@@ -914,7 +941,7 @@ void PTO2OrchestratorState::begin_scope(PTO2ScopeMode mode) {
     // tasks. Recorded ordering is preserved by the nodes' explicit dependencies
     // and tensor-source classification, so a scope inside a Graph body is a no-op
     // during recording and must not touch the real scope stack.
-    if (GraphHostState *state = graph_state_from(orch); state != nullptr && state->recording != nullptr) {
+    if (active_graph_recording(orch) != nullptr) {
         return;
     }
     assert(orch->scope_stack_top < static_cast<int32_t>(orch->scope_stack_capacity - 1) && "Scope stack overflow");
@@ -955,7 +982,7 @@ void PTO2OrchestratorState::end_scope() {
     }
     // Matches begin_scope: a scope inside a Graph body is a no-op during the
     // shadow-record pass, so it must not touch the scope stack.
-    if (GraphHostState *state = graph_state_from(orch); state != nullptr && state->recording != nullptr) {
+    if (active_graph_recording(orch) != nullptr) {
         return;
     }
     assert(orch->scope_stack_top >= 0 && "Scope stack underflow");
@@ -1291,6 +1318,49 @@ bool graph_boundary_matches(const GraphDefinition &definition, const CoreTaskArg
     return true;
 }
 
+bool graph_recording_boundary_matches(const GraphRecording &recording, const CoreTaskArgs &args) {
+    if (args.scalar_count() != recording.boundary_scalar_count || args.explicit_dep_count() != 0 ||
+        args.tensor_count() != static_cast<int32_t>(recording.boundary_tensors.size()) ||
+        recording.boundary_tensors.size() != recording.boundary_types.size()) {
+        return false;
+    }
+    for (int32_t i = 0; i < args.tensor_count(); ++i) {
+        const ChipTensor &expected = recording.boundary_tensors[static_cast<size_t>(i)];
+        const ChipTensor &actual = args.tensor(i).ref();
+        if (actual.ndims > MAX_TENSOR_DIMS || actual.buffer.size != expected.buffer.size ||
+            actual.ndims != expected.ndims || actual.dtype != expected.dtype ||
+            args.tag(i) != recording.boundary_types[static_cast<size_t>(i)] ||
+            actual.manual_dep != expected.manual_dep || actual.is_contiguous != expected.is_contiguous ||
+            !std::equal(
+                std::begin(actual.shapes), std::begin(actual.shapes) + actual.ndims, std::begin(expected.shapes)
+            ) ||
+            !std::equal(
+                std::begin(actual.strides), std::begin(actual.strides) + actual.ndims, std::begin(expected.strides)
+            )) {
+            return false;
+        }
+        uint16_t expected_alias = static_cast<uint16_t>(i);
+        uint16_t actual_alias = static_cast<uint16_t>(i);
+        for (int32_t j = 0; j < i; ++j) {
+            const ChipTensor &expected_other = recording.boundary_tensors[static_cast<size_t>(j)];
+            if (expected_other.buffer.addr == expected.buffer.addr &&
+                expected_other.buffer.size == expected.buffer.size) {
+                expected_alias = static_cast<uint16_t>(j);
+                break;
+            }
+        }
+        for (int32_t j = 0; j < i; ++j) {
+            const ChipTensor &actual_other = args.tensor(j).ref();
+            if (actual_other.buffer.addr == actual.buffer.addr && actual_other.buffer.size == actual.buffer.size) {
+                actual_alias = static_cast<uint16_t>(j);
+                break;
+            }
+        }
+        if (actual_alias != expected_alias) return false;
+    }
+    return true;
+}
+
 void graph_reset_outer_payload(PTO2TaskPayload &payload) {
     payload.tensor_count = 0;
     payload.scalar_count = 0;
@@ -1307,10 +1377,10 @@ void graph_reset_outer_payload(PTO2TaskPayload &payload) {
     payload.early_sync_drain_state.store(PTO2_EARLY_SYNC_DRAIN_NONE, std::memory_order_relaxed);
 }
 
-bool graph_build_submission_image(
-    const std::vector<std::byte> &definition_image, const CoreTaskArgs &args, std::vector<std::byte> *submission_image
+bool graph_prepare_submission_image(
+    uint64_t full_key, const CoreTaskArgs &args, std::vector<std::byte> *submission_image
 ) {
-    if (submission_image == nullptr || graph_definition(definition_image) == nullptr) return false;
+    if (submission_image == nullptr) return false;
     const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphTensor));
     const size_t tensor_bytes = static_cast<size_t>(args.tensor_count()) * sizeof(GraphTensor);
     if (tensors_offset > UINT32_MAX || tensors_offset > UINT32_MAX - tensor_bytes) {
@@ -1335,10 +1405,8 @@ bool graph_build_submission_image(
         );
     }
 
-    const GraphDefinition &definition = *graph_definition(definition_image);
     GraphSubmission submission{};
-    submission.graph_key = definition.full_key;
-    submission.definition_hash = definition.content_hash;
+    submission.graph_key = full_key;
     submission.total_bytes = static_cast<uint32_t>(submission_image->size());
     submission.tensors_offset = static_cast<uint32_t>(tensors_offset);
     submission.tensor_count = static_cast<uint32_t>(args.tensor_count());
@@ -1348,40 +1416,29 @@ bool graph_build_submission_image(
     return true;
 }
 
-bool graph_submit_definition(
-    PTO2OrchestratorState *orch, GraphHostState *state, const std::vector<std::byte> &definition_image,
-    const CoreTaskArgs &args, PTO2TaskId *submitted_id
+bool graph_submit_outer(
+    PTO2OrchestratorState *orch, GraphHostState *state, uint64_t full_key, uint64_t definition_hash, int32_t owned_heap,
+    bool defer_heap, const CoreTaskArgs &args, PTO2TaskId *submitted_id
 ) {
     always_assert(orch->scope_stack_top >= 0 && "Cannot submit Graph outside a scope");
-    const GraphDefinition *definition = graph_definition(definition_image);
-    if (definition == nullptr || !graph_boundary_matches(*definition, args) ||
-        definition->execution_storage_bytes == 0) {
-        return false;
-    }
-    // One allocation covers both halves the outer task owns: the nodes' packed
-    // outputs, then the execution storage the device materializes into. They
-    // share the task's lifetime, and node_offsets stay relative to the base, so
-    // the execution simply starts past required_heap.
-    const uint64_t owned_heap = definition->required_heap + definition->execution_storage_bytes;
-    if (definition->required_heap > UINT64_MAX - definition->execution_storage_bytes ||
-        owned_heap > static_cast<uint64_t>(INT32_MAX)) {
-        return false;
-    }
     auto &allocator = orch->ring.task_allocator;
-    if (allocator.active_count() >= allocator.window_size() || owned_heap > allocator.heap_available()) {
+    if (allocator.active_count() >= allocator.window_size() ||
+        (!defer_heap && static_cast<uint64_t>(owned_heap) > allocator.heap_available())) {
         LOG_WARN("%s", "[GraphExecution] task-window/heap preflight failed; using ordinary path");
         return false;
     }
 
     GraphPendingUpload pending;
-    if (!graph_build_submission_image(definition_image, args, &pending.image)) return false;
+    if (!graph_prepare_submission_image(full_key, args, &pending.image)) return false;
+    reinterpret_cast<GraphSubmission *>(pending.image.data())->definition_hash = definition_hash;
+    pending.deferred_heap = defer_heap;
 
     DepInputs boundary_inputs{
         args.tensor_count(), args.tensor_data(), args.tag_data(), 0, nullptr,
     };
     const int32_t tensormap_needed = count_registrable_outputs(boundary_inputs, orch->in_manual_scope());
     if (tensormap_needed > 0 && !ensure_tensormap_capacity(orch, tensormap_needed)) return false;
-    const PTO2TaskAllocResult allocation = allocator.alloc(static_cast<int32_t>(owned_heap));
+    const PTO2TaskAllocResult allocation = allocator.alloc(defer_heap ? 0 : owned_heap);
     if (allocation.failed()) {
         orch_mark_fatal(orch, PTO2_ERROR_HEAP_RING_DEADLOCK);
         return false;
@@ -1429,22 +1486,80 @@ bool graph_submit_definition(
     return true;
 }
 
+bool graph_submit_definition(
+    PTO2OrchestratorState *orch, GraphHostState *state, const std::vector<std::byte> &definition_image,
+    const CoreTaskArgs &args, PTO2TaskId *submitted_id
+) {
+    const GraphDefinition *definition = graph_definition(definition_image);
+    if (definition == nullptr || !graph_boundary_matches(*definition, args) ||
+        definition->execution_storage_bytes == 0 ||
+        definition->required_heap > UINT64_MAX - definition->execution_storage_bytes) {
+        return false;
+    }
+    const uint64_t owned_heap = definition->required_heap + definition->execution_storage_bytes;
+    if (owned_heap > static_cast<uint64_t>(INT32_MAX)) return false;
+    return graph_submit_outer(
+        orch, state, definition->full_key, definition->content_hash, static_cast<int32_t>(owned_heap), false, args,
+        submitted_id
+    );
+}
+
+bool graph_submit_pending_definition(
+    PTO2OrchestratorState *orch, GraphHostState *state, uint64_t full_key, const CoreTaskArgs &args,
+    PTO2TaskId *submitted_id
+) {
+    return graph_submit_outer(orch, state, full_key, 0, 0, true, args, submitted_id);
+}
+
+bool graph_finalize_pending_submissions(
+    PTO2OrchestratorState *orch, GraphHostState *state, const GraphDefinition &definition
+) {
+    if (definition.execution_storage_bytes == 0 ||
+        definition.required_heap > UINT64_MAX - definition.execution_storage_bytes) {
+        return false;
+    }
+    const uint64_t owned_heap = definition.required_heap + definition.execution_storage_bytes;
+    if (owned_heap > static_cast<uint64_t>(INT32_MAX)) return false;
+    for (GraphPendingUpload &pending : state->pending_uploads) {
+        if (!pending.deferred_heap || pending.image.size() < sizeof(GraphSubmission)) continue;
+        auto *submission = reinterpret_cast<GraphSubmission *>(pending.image.data());
+        if (submission->graph_key != definition.full_key || pending.outer_slot == nullptr ||
+            pending.outer_slot->task == nullptr || pending.outer_slot->task_kind != TaskKind::GRAPH ||
+            !graph_submission_wire_size_valid(*submission, pending.image.size())) {
+            return false;
+        }
+        void *packed_base = nullptr;
+        void *packed_end = nullptr;
+        if (!orch->ring.task_allocator.reserve_deferred_heap(
+                static_cast<int32_t>(owned_heap), &packed_base, &packed_end
+            )) {
+            return false;
+        }
+        pending.outer_slot->task->packed_buffer_base = packed_base;
+        pending.outer_slot->task->packed_buffer_end = packed_end;
+        submission->definition_hash = definition.content_hash;
+        pending.deferred_heap = false;
+    }
+    return true;
+}
+
 // Record one internal Graph node during the recording pass without consuming a
 // ring task-window slot. Builds the node's metadata and materialized outputs
-// exactly as submit_task_common would, but reserves output buffers from heap
-// scratch (released in graph_end) and derives internal fanins from tensor-source
+// exactly as submit_task_common would, but assigns output buffers from the
+// bit-63 virtual address range and derives internal fanins from tensor-source
 // classification — so no ring slot, tensormap entry, fanin-pool entry, or upload
-// is produced for the node. The whole sub-DAG is later replayed by the single
-// outer GRAPH task graph_end emits. The returned TaskOutputTensors borrow the
-// node's own tensor storage; moving the node into recording.nodes keeps those
-// addresses valid because the inner buffer is transferred, not copied.
+// is produced for the node. The resulting Definition is later attached to the
+// outer GRAPH shells already submitted by the main thread. The returned
+// TaskOutputTensors borrow the node's own tensor storage; moving the node into
+// recording.nodes keeps those addresses valid because the inner buffer is
+// transferred, not copied.
 TaskOutputTensors graph_record_submit_node(
     PTO2OrchestratorState *orch, const CoreTaskArgs &args, ActiveMask active_mask, TaskAttrs task_attrs,
     int32_t aic_kernel_id, int32_t aiv0_kernel_id, int32_t aiv1_kernel_id
 ) {
     ORCH_PHASE_START();
     TaskOutputTensors result;
-    GraphRecording &recording = *graph_state_from(orch)->recording;
+    GraphRecording &recording = *active_graph_recording(orch);
 
     const size_t node_index = recording.nodes.size();
     // A recorded node's index equals its local task id minus the recording
@@ -1459,17 +1574,15 @@ TaskOutputTensors graph_record_submit_node(
     }
 
     const PTO2OutputLayout layout = calculate_output_layout(args);
-    void *packed_base = orch->ring.task_allocator.reserve_heap_scratch(layout.total_output_size);
-    if (layout.total_output_size > 0 && packed_base == nullptr) {
-        // No scratch storage for this node's outputs: the sub-DAG cannot be
-        // recorded, so graph_end falls back and the body runs on the ordinary
-        // path where the same heap pressure is reported through alloc().
-        recording.unsupported = true;
-        return result;
-    }
     const uint64_t aligned_output =
         layout.total_output_size > 0 ? PTO2_ALIGN_UP(static_cast<uint64_t>(layout.total_output_size), PTO2_ALIGN_SIZE) :
                                        0;
+    if (recording.next_virtual_offset > GRAPH_RECORD_VIRTUAL_BASE - aligned_output) {
+        recording.unsupported = true;
+        return result;
+    }
+    const uintptr_t packed_base_addr = GRAPH_RECORD_VIRTUAL_BASE + recording.next_virtual_offset;
+    recording.next_virtual_offset += aligned_output;
 
     GraphRecordedNode node;
     node.kernel_ids[static_cast<int>(PTO2SubtaskSlot::AIC)] = aic_kernel_id;
@@ -1480,11 +1593,10 @@ TaskOutputTensors graph_record_submit_node(
     node.task_attrs.set_early_resolve(false);
     node.logical_block_num = args.launch_spec.block_num();
     // Mirror prepare_task's contract: block_num must be positive and the subtask
-    // count must fit int16_t. An out-of-contract value marks the recording
-    // unsupported so graph_end falls back to the ordinary path, which reports
-    // PTO2_ERROR_INVALID_ARGS, rather than baking a truncated or negative count
-    // into the cached Definition (which the device would expand into a node that
-    // never completes).
+    // count must fit int16_t. An out-of-contract value marks asynchronous
+    // recording unsupported and makes commit fail-fast, rather than baking a
+    // truncated or negative count into the cached Definition (which the device
+    // would expand into a node that never completes).
     const int32_t required_subtasks =
         static_cast<int32_t>(node.logical_block_num) * __builtin_popcount(active_mask.core_mask());
     if (node.logical_block_num <= 0 || required_subtasks > std::numeric_limits<int16_t>::max()) {
@@ -1493,7 +1605,7 @@ TaskOutputTensors graph_record_submit_node(
     } else {
         node.total_required_subtasks = static_cast<int16_t>(required_subtasks);
     }
-    node.record_packed_base = reinterpret_cast<uintptr_t>(packed_base);
+    node.record_packed_base = packed_base_addr;
     node.total_output_size = aligned_output;
 
     // Build the tensor list exactly as PTO2TaskPayload::init: inputs/inouts copy
@@ -1508,8 +1620,7 @@ TaskOutputTensors graph_record_submit_node(
         } else {
             init_tensor_from_create_info(
                 slot_tensor, args.tensor(i).create_info(),
-                reinterpret_cast<void *>(reinterpret_cast<char *>(packed_base) + layout.offsets[i]),
-                layout.buffer_sizes[i]
+                reinterpret_cast<void *>(packed_base_addr + layout.offsets[i]), layout.buffer_sizes[i]
             );
             slot_tensor.owner_task_id = task_id;
         }
@@ -1591,14 +1702,46 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const CoreTaskArgs &args,
         debug_assert(args.explicit_dep_count() == 0 && "Graph boundary explicit dependencies are not supported");
         return result;
     }
-    if (state->recording != nullptr) {
-        state->recording->unsupported = true;
-        debug_assert(state->recording == nullptr && "Nested Graph recording is not supported");
+    if (GraphRecording *active = active_graph_recording(orch); active != nullptr) {
+        active->unsupported = true;
+        debug_assert(active == nullptr && "Nested Graph recording is not supported");
         LOG_WARN("%s", "[GraphExecution] nested Graph recording is not supported");
         return result;
     }
 
     const uint64_t full_key = graph_full_key(callable_hash, graph_key);
+    std::unique_lock<std::mutex> lock(state->recording_mutex);
+    if (state->status() != GraphRecordingStatus::IDLE) {
+        if (state->recording_key != full_key || state->status() == GraphRecordingStatus::FAILED) {
+            return result;
+        }
+        bool boundary_matches = false;
+        if (state->recording != nullptr) {
+            boundary_matches = graph_recording_boundary_matches(*state->recording, args);
+        } else {
+            auto definition_it = state->definitions.find(full_key);
+            boundary_matches = definition_it != state->definitions.end() &&
+                               graph_definition(definition_it->second) != nullptr &&
+                               graph_boundary_matches(*graph_definition(definition_it->second), args);
+        }
+        if (!boundary_matches) return result;
+
+        PTO2TaskId submitted = PTO2TaskId::invalid();
+        ORCH_PHASE_START();
+        if (graph_submit_pending_definition(orch, state, full_key, args, &submitted)) {
+            result.execute_block = false;
+            result.task_id = submitted;
+            ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
+#if SIMPLER_DFX
+            g_orch_submit_idx++;
+#if SIMPLER_ORCH_PROFILING
+            g_orch_submit_count++;
+#endif
+#endif
+        }
+        return result;
+    }
+
     auto definition_it = state->definitions.find(full_key);
     if (definition_it != state->definitions.end()) {
         PTO2TaskId submitted = PTO2TaskId::invalid();
@@ -1630,9 +1773,7 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const CoreTaskArgs &args,
     auto recording = std::make_unique<GraphRecording>();
     recording->full_key = full_key;
     recording->start_local_task_id = orch->ring.task_allocator.active_count();
-    recording->heap_watermark = orch->ring.task_allocator.heap_top();
-    args.anchor_scalar_sources();
-    recording->boundary_args = &args;
+    recording->boundary_scalar_count = args.scalar_count();
     recording->boundary_tensors.reserve(static_cast<size_t>(args.tensor_count()));
     recording->boundary_types.reserve(static_cast<size_t>(args.tensor_count()));
     for (int32_t i = 0; i < args.tensor_count(); ++i) {
@@ -1640,67 +1781,139 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const CoreTaskArgs &args,
         recording->boundary_types.push_back(args.tag(i));
     }
     state->recording = std::move(recording);
-    // The body runs through the shadow-record path, not the ring, so it does not
-    // execute as ordinary tasks.
-    result.execute_block = false;
-    result.recording = true;
+    state->recording_key = full_key;
+    state->set_status(GraphRecordingStatus::RECORDING);
+
+    PTO2TaskId submitted = PTO2TaskId::invalid();
+    ORCH_PHASE_START();
+    if (graph_submit_pending_definition(orch, state, full_key, args, &submitted)) {
+        result.execute_block = false;
+        result.recording = true;
+        result.task_id = submitted;
+        ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
+#if SIMPLER_DFX
+        g_orch_submit_idx++;
+#if SIMPLER_ORCH_PROFILING
+        g_orch_submit_count++;
+#endif
+#endif
+    } else {
+        state->recording.reset();
+        state->recording_key = 0;
+        state->set_status(GraphRecordingStatus::IDLE);
+    }
     return result;
 }
 
-// Finish the recording pass. Returns true when the sub-DAG was compacted into a
-// Definition and emitted as a single outer GRAPH task; false when the recording
-// hit an unsupported construct or the outer task could not be placed, in which
-// case the caller re-runs the body on the ordinary path so its work is still
-// submitted.
+bool PTO2OrchestratorState::graph_prepare(const CoreTaskArgs &args) {
+    GraphHostState *state = graph_state_from(this);
+    if (state == nullptr || g_active_graph_recording != nullptr) return false;
+    // graph_begin publishes this unique recording before the private job is
+    // enqueued; the recording worker's queue acquire observes those writes.
+    // Until this worker calls graph_end/graph_abort, later graph_begin calls
+    // only read the boundary vectors under recording_mutex, and only this worker
+    // writes the fields it binds below. Taking that mutex here lets the main
+    // thread's same-hash submit burst starve prepare and collapse the intended
+    // overlap, so the status read goes through the atomic instead.
+    if (state->status() != GraphRecordingStatus::RECORDING || state->recording == nullptr ||
+        !graph_recording_boundary_matches(*state->recording, args)) {
+        return false;
+    }
+    args.anchor_scalar_sources();
+    state->recording->boundary_args = &args;
+    g_active_graph_recording = state->recording.get();
+    g_active_graph_owner = state;
+    return true;
+}
+
+void PTO2OrchestratorState::graph_abort() {
+    GraphHostState *state = graph_state_from(this);
+    if (state == nullptr) return;
+    {
+        std::lock_guard<std::mutex> lock(state->recording_mutex);
+        state->recording.reset();
+        state->set_status(GraphRecordingStatus::FAILED);
+    }
+    g_active_graph_recording = nullptr;
+    g_active_graph_owner = nullptr;
+    state->recording_cv.notify_all();
+}
+
+// Finish the background recording pass and publish the Definition. The main
+// thread finalizes the already-submitted outer Graph tasks in graph_commit.
 bool PTO2OrchestratorState::graph_end() {
     GraphHostState *state = graph_state_from(this);
-    if (state == nullptr || state->recording == nullptr) return false;
-    std::unique_ptr<GraphRecording> recording = std::move(state->recording);
-    // Release the scratch output buffers the internal nodes reserved; the outer
-    // GRAPH task reclaims the same heap region as one block below (or the
-    // ordinary fallback re-uses it per task).
-    this->ring.task_allocator.restore_heap_top(recording->heap_watermark);
+    GraphRecording *recording = active_graph_recording(this);
+    if (state == nullptr || recording == nullptr) return false;
 
     std::vector<std::byte> definition;
     ORCH_PHASE_START();
-    if (!graph_build_definition(*recording, &definition)) {
+    const bool built = graph_build_definition(*recording, &definition);
+    if (built) {
+        ORCH_PHASE_END(HostOrchPhase::BuildDefinition, recording->nodes.size());
+    }
+    const GraphDefinition *header = built ? graph_definition(definition) : nullptr;
+    if (header == nullptr) {
         debug_assert(false && "The recorded Graph contains a construct that Graph Execution does not support");
-        LOG_WARN("%s", "[GraphExecution] unsupported construct observed; falling back to the ordinary path");
+        LOG_WARN("%s", "[GraphExecution] asynchronous recording produced an unsupported Graph");
+        graph_abort();
         return false;
     }
-    ORCH_PHASE_END(HostOrchPhase::BuildDefinition, recording->nodes.size());
-    const GraphDefinition *header = graph_definition(definition);
-    if (header == nullptr) return false;
     LOG_DEBUG(
         "[GraphExecution] define key=0x%llx nodes=%u bytes=%u", static_cast<unsigned long long>(header->full_key),
         header->task_count, header->total_bytes
     );
-    auto inserted = state->definitions.emplace(header->full_key, std::move(definition));
-    const std::vector<std::byte> &cached = inserted.first->second;
-
-    // Emit the single outer GRAPH task for this first invocation exactly as a
-    // cache hit would, so the recording run occupies one ring slot and one heap
-    // block instead of one per internal node. The Definition stays cached for
-    // subsequent invocations even if this placement fails.
-    PTO2TaskId submitted = PTO2TaskId::invalid();
+    bool ready = false;
     {
-        ORCH_PHASE_START();
-        if (recording->boundary_args == nullptr ||
-            !graph_submit_definition(this, state, cached, *recording->boundary_args, &submitted)) {
-            return false;
+        std::lock_guard<std::mutex> lock(state->recording_mutex);
+        if (state->status() != GraphRecordingStatus::RECORDING || state->recording_key != header->full_key) {
+            state->set_status(GraphRecordingStatus::FAILED);
+        } else {
+            state->definitions.emplace(header->full_key, std::move(definition));
+            state->set_status(GraphRecordingStatus::READY);
         }
-        ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
+        ready = state->status() == GraphRecordingStatus::READY;
+        state->recording.reset();
     }
-#if SIMPLER_DFX
-    g_orch_submit_idx++;
-#if SIMPLER_ORCH_PROFILING
-    g_orch_submit_count++;
-#endif
-#endif
-    return true;
+    g_active_graph_recording = nullptr;
+    g_active_graph_owner = nullptr;
+    state->recording_cv.notify_all();
+    return ready;
 }
 
-void PTO2OrchestratorState::graph_commit() {}
+void PTO2OrchestratorState::graph_commit() {
+    if (active_graph_recording(this) != nullptr) return;
+    GraphHostState *state = graph_state_from(this);
+    if (state == nullptr) return;
+
+    uint64_t full_key = 0;
+    const GraphDefinition *definition = nullptr;
+    bool failed = false;
+    {
+        std::unique_lock<std::mutex> lock(state->recording_mutex);
+        if (state->status() == GraphRecordingStatus::IDLE) return;
+        state->recording_cv.wait(lock, [&]() {
+            return state->status() != GraphRecordingStatus::RECORDING;
+        });
+        full_key = state->recording_key;
+        failed = state->status() != GraphRecordingStatus::READY;
+        auto definition_it = state->definitions.find(full_key);
+        if (!failed && definition_it != state->definitions.end()) definition = graph_definition(definition_it->second);
+    }
+
+    if (definition == nullptr || !graph_finalize_pending_submissions(this, state, *definition)) failed = true;
+    {
+        std::lock_guard<std::mutex> lock(state->recording_mutex);
+        state->set_status(GraphRecordingStatus::IDLE);
+        state->recording_key = 0;
+    }
+    if (failed) {
+        report_fatal(
+            PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "failed to finalize asynchronous Graph key=%#llx",
+            static_cast<unsigned long long>(full_key)
+        );
+    }
+}
 
 TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
     auto *orch = this;
@@ -1776,7 +1989,7 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
         task_attrs.set_predicate();
     }
 
-    if (GraphHostState *state = graph_state_from(orch); state != nullptr && state->recording != nullptr) {
+    if (active_graph_recording(orch) != nullptr) {
         return graph_record_submit_node(
             orch, args, active_mask, task_attrs, normalized.aic_kernel_id, normalized.aiv0_kernel_id,
             normalized.aiv1_kernel_id
@@ -1819,7 +2032,7 @@ TaskOutputTensors PTO2OrchestratorState::submit_dummy_task(const CoreTaskArgs &a
     task_attrs.set_early_resolve(args.allow_early_resolve());
     task_attrs.set_timing_slot(args.task_timing_slot());
 
-    if (GraphHostState *state = graph_state_from(orch); state != nullptr && state->recording != nullptr) {
+    if (active_graph_recording(orch) != nullptr) {
         return graph_record_submit_node(
             orch, args, ActiveMask{}, task_attrs, INVALID_KERNEL_ID, INVALID_KERNEL_ID, INVALID_KERNEL_ID
         );
@@ -1868,9 +2081,9 @@ TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const CoreTaskArgs &args)
 
     // Runtime-allocated outputs cannot be replayed by a Graph, so a Graph body
     // that calls alloc_tensors is unsupported. Still materialize the outputs so
-    // the recording body chains correctly, then poison the recording; graph_end
-    // falls back and the body re-runs on the ordinary path.
-    if (GraphHostState *state = graph_state_from(orch); state != nullptr && state->recording != nullptr) {
+    // the recording body can finish classification, then poison the recording;
+    // commit reports a fatal error because outer shells already exist.
+    if (active_graph_recording(orch) != nullptr) {
         TaskOutputTensors result = graph_record_submit_node(
             orch, args, ActiveMask{}, TaskAttrs{}, INVALID_KERNEL_ID, INVALID_KERNEL_ID, INVALID_KERNEL_ID
         );

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -101,6 +101,14 @@ static GraphScopeResult graph_begin_impl(PTO2Runtime *rt, uint64_t graph_key, co
     return rt->orchestrator.graph_begin(graph_key, args, rt->active_callable_hash);
 }
 
+static bool graph_prepare_impl(PTO2Runtime *rt, const CoreTaskArgs &args) {
+    return rt != nullptr && rt->orchestrator.graph_prepare(args);
+}
+
+static void graph_abort_impl(PTO2Runtime *rt) {
+    if (rt != nullptr) rt->orchestrator.graph_abort();
+}
+
 static bool graph_end_impl(PTO2Runtime *rt) { return rt != nullptr && rt->orchestrator.graph_end(); }
 
 static void graph_commit_impl(PTO2Runtime *rt) {
@@ -115,7 +123,14 @@ void rt_scope_begin(PTO2Runtime *rt) {
 
 void rt_scope_end(PTO2Runtime *rt) { rt->orchestrator.end_scope(); }
 
-void rt_orchestration_done(PTO2Runtime *rt) { rt->orchestrator.mark_done(); }
+void rt_orchestration_done(PTO2Runtime *rt) {
+    // Host orchestration calls this runtime entry directly rather than the
+    // orchestration-SO wrapper. Commit here as well so an all-Graph entry has a
+    // final synchronization point for its asynchronous recording and deferred
+    // outer shells even when no later non-Graph task forced an earlier commit.
+    rt->orchestrator.graph_commit();
+    rt->orchestrator.mark_done();
+}
 
 static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator.fatal; }
 
@@ -379,6 +394,8 @@ static const PTO2RuntimeOps s_runtime_ops = {
     .available_cluster_count = available_cluster_count_impl,
     .available_aiv_count = available_aiv_count_impl,
     .graph_begin = graph_begin_impl,
+    .graph_prepare = graph_prepare_impl,
+    .graph_abort = graph_abort_impl,
     .graph_end = graph_end_impl,
     .graph_commit = graph_commit_impl,
 #if SIMPLER_DFX

--- a/src/a5/runtime/host_build_graph/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_orchestrator.h
@@ -25,8 +25,7 @@
  * Based on: docs/RUNTIME_LOGIC.md
  */
 
-#ifndef PTO_ORCHESTRATOR_H
-#define PTO_ORCHESTRATOR_H
+#pragma once
 
 #include "common/chip_swimlane_profiling.h"
 #include "utils/device_arena.h"
@@ -158,6 +157,8 @@ struct PTO2OrchestratorState {
     TaskOutputTensors submit_dummy_task(const CoreTaskArgs &args);
     TaskOutputTensors alloc_tensors(const CoreTaskArgs &args);
     GraphScopeResult graph_begin(uint64_t graph_key, const CoreTaskArgs &args, uint64_t callable_hash);
+    bool graph_prepare(const CoreTaskArgs &args);
+    void graph_abort();
     bool graph_end();
     void graph_commit();
     void mark_done();
@@ -185,5 +186,3 @@ struct PTO2OrchProfilingData {
 
 PTO2OrchProfilingData orchestrator_get_profiling();
 #endif
-
-#endif  // PTO_ORCHESTRATOR_H

--- a/src/a5/runtime/host_build_graph/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_ring_buffer.h
@@ -42,6 +42,14 @@
 #include "pto_shared_memory.h"
 #include "common/unified_log.h"
 
+// Base of the address range Graph recording hands to an internal node's packed
+// outputs. Recorded addresses are never dereferenced: they exist so
+// graph_classify_tensor can tell an internal producer's output from a boundary
+// tensor by address-range containment alone, and the Definition stores them as
+// offsets. That classification is only sound while the range is disjoint from
+// every real heap address, which PTO2TaskAllocator::init() asserts.
+inline constexpr uint64_t GRAPH_RECORD_VIRTUAL_BASE = 1ULL << 63;
+
 // Dep pool spin limit - if exceeded, dep pool capacity too small for workload
 #define PTO2_DEP_POOL_SPIN_LIMIT 100000
 
@@ -92,6 +100,14 @@ public:
         error_code_ptr_ = error_code_ptr;
         local_task_id_ = 0;
         heap_top_ = 0;
+        // Every address this allocator hands out lies in
+        // [heap_base_, heap_base_ + heap_size_), so checking the range once here
+        // keeps it disjoint from GRAPH_RECORD_VIRTUAL_BASE for every allocation.
+        const uint64_t heap_base_addr = reinterpret_cast<uint64_t>(heap_base);
+        always_assert(
+            heap_base_addr < GRAPH_RECORD_VIRTUAL_BASE && heap_size <= GRAPH_RECORD_VIRTUAL_BASE - heap_base_addr &&
+            "Graph heap overlaps the Graph-recording virtual address range"
+        );
     }
 
     /**
@@ -129,6 +145,20 @@ public:
         return {task_id, task_id & window_mask_, heap_ptr, static_cast<char *>(heap_ptr) + aligned_size};
     }
 
+    bool reserve_deferred_heap(int32_t output_size, void **packed_base, void **packed_end) {
+        if (output_size < 0 || packed_base == nullptr || packed_end == nullptr) return false;
+        if (error_code_ptr_ != nullptr && error_code_ptr_->load(std::memory_order_acquire) != PTO2_ERROR_NONE) {
+            return false;
+        }
+        const uint64_t aligned_size =
+            output_size > 0 ? PTO2_ALIGN_UP(static_cast<uint64_t>(output_size), PTO2_ALIGN_SIZE) : 0;
+        void *base = try_bump_heap(aligned_size);
+        if (base == nullptr) return false;
+        *packed_base = base;
+        *packed_end = static_cast<char *>(base) + aligned_size;
+        return true;
+    }
+
     // =========================================================================
     // State queries
     // =========================================================================
@@ -146,28 +176,6 @@ public:
     uint64_t heap_top() const { return heap_top_; }
     uint64_t heap_capacity() const { return heap_size_; }
     uint64_t heap_used_bytes() const { return heap_top_; }
-
-    // Reserve output-buffer bytes without claiming a task-window slot. Graph
-    // recording gives each internal node a disjoint, valid heap address so
-    // tensor-source classification works, then releases the whole range with
-    // restore_heap_top() once the consolidated outer GRAPH task reclaims it as a
-    // single block. On exhaustion it returns nullptr and leaves allocator state
-    // unchanged; graph_record_submit_node treats that as an unsupported
-    // recording and falls back to the ordinary path. A zero size returns the
-    // current position.
-    void *reserve_heap_scratch(int32_t output_size) {
-        uint64_t aligned_size =
-            output_size > 0 ? PTO2_ALIGN_UP(static_cast<uint64_t>(output_size), PTO2_ALIGN_SIZE) : 0;
-        uint64_t top = heap_top_;
-        if (aligned_size == 0) return static_cast<char *>(heap_base_) + top;
-        if (heap_size_ - top < aligned_size) return nullptr;
-        heap_top_ = top + aligned_size;
-        return static_cast<char *>(heap_base_) + top;
-    }
-
-    // Roll the heap allocation pointer back to a value previously returned by
-    // heap_top().
-    void restore_heap_top(uint64_t top) { heap_top_ = top; }
 
 private:
     // --- Task Ring ---

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -97,6 +97,8 @@ struct PTO2RuntimeOps {
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
     GraphScopeResult (*graph_begin)(PTO2Runtime *rt, uint64_t graph_key, const CoreTaskArgs &args);
+    bool (*graph_prepare)(PTO2Runtime *rt, const CoreTaskArgs &args);
+    void (*graph_abort)(PTO2Runtime *rt);
     bool (*graph_end)(PTO2Runtime *rt);
     void (*graph_commit)(PTO2Runtime *rt);
     // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -4,18 +4,23 @@ Graph Execution is available only in the `host_build_graph` runtime. A Graph is
 a composite incore task: it is submitted and completed once like an AIC, AIV,
 MIX, or SPMD task, but contains a recorded task DAG.
 
-Every invocation places exactly one `GRAPH` task in the host task window. The
-first invocation records the DAG off the ring — its internal submissions build
-host-only node metadata and reserve scratch output buffers instead of consuming
-task-window slots — then emits the outer `GRAPH` task from the freshly built
-Definition. Later invocations reuse the cached Definition and emit the same one
-`GRAPH` task directly. In both cases the device Scheduler expands the saved
-topology and dispatches the internal nodes; the Host Orchestrator never submits
-those nodes as ring tasks.
+Every invocation places exactly one `GRAPH` task in the host task window. On a
+first miss, the caller immediately submits an outer task shell keyed by Graph
+identity while a worker records the DAG off the ring. Internal submissions
+build host-only node metadata and assign output addresses from a private bit-63
+virtual range instead of consuming task-window slots or heap. Later calls for
+the same in-flight identity submit more shells without waiting for recording.
+Before leaving that consecutive Graph batch, the caller joins the worker and
+fills every shell's heap range and Definition content hash. Cached invocations
+submit the same one `GRAPH` task directly. In both cases the device Scheduler
+expands the saved topology and dispatches the internal nodes; the Host
+Orchestrator never submits those nodes as ring tasks.
 
-A recording that hits an unsupported construct is discarded and the body re-runs
-on the ordinary task-submit path so its work is still submitted; the internal
-nodes then occupy the ring only for that one fallback invocation.
+Boundary contracts are checked before an in-flight shell is accepted. Once a
+shell has entered the task/dependency sequence, an unsupported construct found
+by asynchronous recording is terminal for that orchestration; it cannot be
+replayed as ordinary tasks without rolling back already assigned task IDs and
+TensorMap producers.
 
 ## API
 
@@ -183,11 +188,13 @@ void decode_three_layers(
 }
 ```
 
-All three layers submit one Graph task each: the first records the sub-DAG off
-the ring and emits its Graph task, layers two and three replay the cached
-Definition when their ChipTensor metadata and boundary scalar count match. Each
-invocation patches the current layer's `token_position`; it is a dynamic
-boundary scalar refreshed on every submission and is not part of the Graph key.
+All three layers submit one Graph task each. The first starts background
+recording, while layers two and three immediately submit outer task shells for
+the same in-flight identity. The first following non-Graph operation (or
+orchestration completion) joins recording and finalizes all three shells with
+the new Definition. Each invocation patches the current layer's
+`token_position`; it is a dynamic boundary scalar refreshed on every submission
+and is not part of the Graph key.
 
 ## Definition
 
@@ -195,11 +202,65 @@ Recording uses host-only C++ state:
 
 - `std::vector` for nodes, tensors, scalars, fanins, and pending uploads;
 - `std::unordered_map` for the per-run Definition cache;
-- `std::unique_ptr` for the active recording.
+- `std::unique_ptr` for the active recording, guarded by a mutex and completion
+  condition while the recording worker publishes the Definition.
 
 The cache stores at most 16 Definitions and allocates each entry to its actual
 serialized size. No fixed maximum-size recording array is copied on a cache
 hit.
+
+Recorded output addresses start at `GRAPH_RECORD_VIRTUAL_BASE = 1ULL << 63`.
+They exist only to classify `OWN_OUTPUT` and `INTERNAL` Tensor sources and are
+converted to offsets in the Definition; they are never dereferenced or placed
+on the wire. Classification is by address-range containment alone, so it is only
+sound while no real heap address can fall in that range:
+`PTO2TaskAllocator::init()` asserts the whole configured heap lies below
+`GRAPH_RECORD_VIRTUAL_BASE`, which makes an overlapping device GM heap a loud
+failure at setup instead of a silently misclassified Tensor source. Recording
+therefore leaves the shared task allocator unchanged.
+
+### First-miss host threading
+
+`graph_begin` computes the Graph identity before the body is recorded. On a
+cache miss, the calling thread allocates a zero-heap outer task shell, records
+its boundary dependency edges, and returns. A worker receives a deep copy of
+the boundary arguments, records the internal nodes in the private virtual
+address range, and builds and hashes the Definition. The first call waits only
+until that private job has been installed in the worker queue; it does not wait
+for the operating system to schedule the worker or for `graph_prepare` to bind
+the private recording state. The hash-keyed `RECORDING` entry and zero-heap
+outer shell already exist before the job is enqueued, so later same-identity
+submissions can safely proceed immediately. The worker remains parked on a
+condition variable for the lifetime of the loaded orchestration SO and is
+reused by later runs, so only its first miss pays thread creation. Unloading the
+SO stops and joins the idle worker before its code is unmapped.
+
+The queue handoff publishes the already-created recording to `graph_prepare`.
+Prepare therefore does not reacquire the Definition-state mutex: until the
+worker ends or aborts, later same-identity submissions only read the immutable
+boundary signature under that mutex. Avoiding the redundant acquire prevents
+the short main-thread submit loop from starving the worker before it can enter
+its private recording state.
+
+Calls for the same identity while recording is in flight follow the same shell
+submission path on the calling thread. Their task IDs and TensorMap producers
+therefore enter the ordinary program-order sequence while the worker is still
+executing `record_node` and `build_definition`.
+
+`rt_graph_commit` is a barrier before a non-Graph operation or orchestration
+completion. It waits for the current worker job, reserves each shell's real heap
+block in task order using the Definition's `required_heap`, patches the task
+descriptor and Definition content hash, and then permits ordinary submission to continue. A
+scope transition is deliberately not a barrier: the main thread has already
+submitted the outer Graph shell into that scope, while scopes executed by the
+recording worker are no-ops on the real scope stack. This lets consecutive
+Graph calls in separate outer scopes continue submitting while recording is in
+flight. No unrelated heap allocation can appear between a deferred shell and
+this finalization. Cache-hit submissions after the barrier already know
+`required_heap` and use the ordinary immediate path.
+
+Host phase records therefore show `graph_submit` on the main lane overlapping
+`record_node` and `build_definition` on the recording-worker lane.
 
 At `graph_end`, recording is compacted into one contiguous, pointer-free POD
 Definition. It contains:
@@ -333,21 +394,30 @@ error instead of leaving an already-submitted outer Graph unable to complete.
 
 ## Current unsupported cases
 
-These cases assert in debug builds and execute through the ordinary path in a
-release build:
+Conditions detected before an outer shell is accepted use the ordinary path:
 
 - an empty Graph boundary;
 - variable ChipTensor shape or metadata;
 - changed boundary aliasing;
 - runtime-allocated boundary outputs;
+- more than 32 boundary Tensors;
+- more than 16 Definitions;
+- insufficient task-window or known cache-hit heap capacity.
+
+The following constructs are discovered only while the worker records the
+first Definition. Because its outer shell is already in the task/dependency
+sequence, they assert in debug builds and fail the orchestration in release
+builds:
+
 - nested Graph recording;
 - dispatch predicates;
 - cross-boundary explicit dependencies that are not represented by a boundary
   ChipTensor's creator;
 - an unclassifiable internal ChipTensor source;
 - a boundary-derived scalar accessed through mutable `scalar()`;
-- more than 16 Definitions, 1024 internal nodes, or 32 boundary Tensors;
-- insufficient task-window or heap capacity detected before outer submission.
+- runtime allocation inside the Graph body;
+- more than 1024 internal nodes;
+- insufficient heap capacity while deferred shells are finalized.
 
 An AICPU execution-pool or materialization failure happens after the outer
 Graph has already been submitted. It therefore latches a Scheduler fatal error

--- a/src/common/platform/include/common/chip_swimlane_profiling.h
+++ b/src/common/platform/include/common/chip_swimlane_profiling.h
@@ -614,7 +614,7 @@ struct ChipSwimlaneAicpuOrchPhaseRecord {
 static_assert(sizeof(ChipSwimlaneAicpuOrchPhaseRecord) == 32, "ChipSwimlaneAicpuOrchPhaseRecord layout drift");
 
 /**
- * Host phase record (32 bytes).
+ * Host phase record (40 bytes).
  *
  * One record per timed host operation on host_build_graph's prepare path —
  * both the bind stage's segments and the host orchestrator's submit-level
@@ -630,10 +630,12 @@ struct HostPhaseRecord {
     uint64_t start_ns;
     uint64_t end_ns;
     uint64_t payload;
-    uint32_t kind;   // HostPhaseKind
-    uint32_t index;  // submit_idx for orchestrator operations, 0 for bind segments
+    uint32_t kind;       // HostPhaseKind
+    uint32_t index;      // submit_idx for orchestrator operations, 0 for bind segments
+    uint32_t thread_id;  // OS tid when available, stable producer id otherwise
+    uint32_t _pad;
 };
-static_assert(sizeof(HostPhaseRecord) == 32, "HostPhaseRecord layout drift");
+static_assert(sizeof(HostPhaseRecord) == 40, "HostPhaseRecord layout drift");
 
 /**
  * What one HostPhaseRecord measured.
@@ -747,8 +749,9 @@ using ChipSwimlaneAicpuSchedPhasePool = ChipSwimlaneAicpuTaskPool;
 using ChipSwimlaneAicpuOrchPhasePool = ChipSwimlaneAicpuTaskPool;
 
 // The host phase pool is the same head + free_queue plumbing over host DDR
-// instead of device shared memory: one producer rotates through a fixed set of
-// fixed-size buffers, and a reader walks them in rotation order. Its buffers are
+// instead of device shared memory: producers are serialized by the host trace
+// sink while rotating through a fixed set of fixed-size buffers, and a reader
+// walks them in rotation order. Its buffers are
 // smaller and fewer than a device thread's because its producer emits hundreds
 // of records per pass rather than tens of thousands (see
 // PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER).

--- a/src/common/platform/include/host/host_phase_records.h
+++ b/src/common/platform/include/host/host_phase_records.h
@@ -139,9 +139,11 @@ inline HostPhaseRecordBuffer *host_phase_pool_rotate(HostPhaseRecordPool *pool) 
  * @param start_ns,end_ns  host monotonic nanoseconds
  * @param payload          task id for kinds that submit a task, else a detail count
  * @param index            submit_idx for orchestrator operations, 0 for bind segments
+ * @param thread_id        OS thread identity of the producer
  */
 inline void host_phase_pool_append(
-    HostPhaseRecordPool *pool, HostPhaseKind kind, uint64_t start_ns, uint64_t end_ns, uint64_t payload, uint32_t index
+    HostPhaseRecordPool *pool, HostPhaseKind kind, uint64_t start_ns, uint64_t end_ns, uint64_t payload, uint32_t index,
+    uint32_t thread_id = 0
 ) {
     if (pool == nullptr) return;
     pool->head.total_record_count = pool->head.total_record_count + 1;
@@ -153,6 +155,7 @@ inline void host_phase_pool_append(
             return;
         }
     }
-    active->records[active->count] = HostPhaseRecord{start_ns, end_ns, payload, static_cast<uint32_t>(kind), index};
+    active->records[active->count] =
+        HostPhaseRecord{start_ns, end_ns, payload, static_cast<uint32_t>(kind), index, thread_id, 0};
     active->count = active->count + 1;
 }

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -1060,13 +1060,14 @@ HostPhaseRecordPool *DeviceRunnerBase::host_phase_pool_arm(bool producer_wants_r
         clock_correlation_provider_.reset();
     }
     const bool swimlane_wants_records = chip_swimlane_level_ == ChipSwimlaneLevel::ORCH_PHASES;
+    const bool artifact_wants_records = producer_wants_records && !output_prefix_.empty();
     chip_swimlane_collector_.set_host_orchestrated(swimlane_wants_records);
     // arm() allocates the pool's buffers, so it can throw; this path is noexcept,
     // where an escaping exception is std::terminate. A pass that cannot get its
     // storage collects no records and says so by handing back nullptr.
     HostPhaseRecordPool *pool = nullptr;
     try {
-        pool = host_phase_records_.arm(producer_wants_records || swimlane_wants_records);
+        pool = host_phase_records_.arm(artifact_wants_records || swimlane_wants_records);
     } catch (...) {
         LOG_WARN("Host phase pool could not be armed; this pass collects no per-event records");
     }

--- a/src/common/platform/shared/host/host_phase_records.cpp
+++ b/src/common/platform/shared/host/host_phase_records.cpp
@@ -92,7 +92,7 @@ int HostPhaseRecordStore::write_records_jsonl(const std::string &path) const {
         if (!first) out << ", ";
         out << "{\"phase\": \"" << host_phase_kind_name(static_cast<HostPhaseKind>(record.kind))
             << "\", \"start_ns\": " << record.start_ns << ", \"end_ns\": " << record.end_ns
-            << ", \"detail\": " << record.payload << "}";
+            << ", \"detail\": " << record.payload << ", \"tid\": " << record.thread_id << "}";
         first = false;
     }
     out << "]}\n";

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -677,13 +677,14 @@ HostPhaseRecordPool *SimDeviceRunnerBase::host_phase_pool_arm(bool producer_want
         clock_correlation_provider_.reset();
     }
     const bool swimlane_wants_records = chip_swimlane_level_ == ChipSwimlaneLevel::ORCH_PHASES;
+    const bool artifact_wants_records = producer_wants_records && !output_prefix_.empty();
     chip_swimlane_collector_.set_host_orchestrated(swimlane_wants_records);
     // arm() allocates the pool's buffers, so it can throw; this path is noexcept,
     // where an escaping exception is std::terminate. A pass that cannot get its
     // storage collects no records and says so by handing back nullptr.
     HostPhaseRecordPool *pool = nullptr;
     try {
-        pool = host_phase_records_.arm(producer_wants_records || swimlane_wants_records);
+        pool = host_phase_records_.arm(artifact_wants_records || swimlane_wants_records);
     } catch (...) {
         LOG_WARN("Host phase pool could not be armed; this pass collects no per-event records");
     }

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -877,6 +877,7 @@ target_sources(test_hbg_graph_submit_failure PRIVATE
     ${HBG_RUNTIME_DIR}/shared/runtime.cpp
     ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
 )
+add_a2a3_hbg_runtime_test(test_hbg_graph_async_submit common/test_hbg_graph_async_submit.cpp)
 add_a5_hbg_runtime_test(test_a5_hbg_graph_submit_failure common/test_hbg_graph_submit_failure.cpp)
 target_sources(test_a5_hbg_graph_submit_failure PRIVATE
     ${A5_HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
@@ -887,6 +888,7 @@ target_sources(test_a5_hbg_graph_submit_failure PRIVATE
     ${A5_HBG_RUNTIME_DIR}/shared/runtime.cpp
     ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
 )
+add_a5_hbg_runtime_test(test_a5_hbg_graph_async_submit common/test_hbg_graph_async_submit.cpp)
 add_a5_hbg_runtime_test(test_a5_hbg_core_tracker common/test_hbg_core_tracker.cpp)
 add_a5_hbg_runtime_test(test_a5_hbg_ready_queue_seed common/test_hbg_ready_queue_seed.cpp)
 add_a5_hbg_runtime_test(test_a5_hbg_mailbox_init common/test_hbg_mailbox_init.cpp)

--- a/tests/ut/cpp/a2a3/test_hbg_task_allocator.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_task_allocator.cpp
@@ -36,6 +36,7 @@
 #include <set>
 
 #include "pto_ring_buffer.h"
+#include "task_interface/assert_compat.h"
 
 class HbgTaskAllocatorTest : public ::testing::Test {
 protected:
@@ -224,35 +225,68 @@ TEST_F(HbgTaskAllocatorTest, LatchedFatalShortCircuitsAlloc) {
 }
 
 // =============================================================================
-// Graph-recording scratch reservation
+// Deferred heap reservation
 // =============================================================================
 
-TEST_F(HbgTaskAllocatorTest, ReserveHeapScratchIsRollbackable) {
+// An outer Graph shell is submitted before its Definition exists, so its heap
+// block is carved afterwards. Nothing is reclaimed during a run, so a block
+// handed out after later tasks already took theirs is still sound.
+TEST_F(HbgTaskAllocatorTest, ReserveDeferredHeapCarvesAfterLaterAllocations) {
+    ASSERT_FALSE(allocator.alloc(0).failed());
     ASSERT_FALSE(allocator.alloc(256).failed());
-    uint64_t snapshot = allocator.heap_top();
+    const uint64_t top_before = allocator.heap_top();
 
-    void *scratch = allocator.reserve_heap_scratch(512);
-    ASSERT_NE(scratch, nullptr);
-    EXPECT_EQ(scratch, static_cast<void *>(heap_buf + snapshot));
-    EXPECT_EQ(allocator.heap_top(), snapshot + 512);
-
-    allocator.restore_heap_top(snapshot);
-    EXPECT_EQ(allocator.heap_top(), snapshot);
-    EXPECT_EQ(allocator.heap_available(), HEAP_SIZE - snapshot);
+    void *base = nullptr;
+    void *end = nullptr;
+    ASSERT_TRUE(allocator.reserve_deferred_heap(512, &base, &end));
+    EXPECT_EQ(base, static_cast<void *>(heap_buf + top_before));
+    EXPECT_EQ(end, static_cast<void *>(heap_buf + top_before + 512));
+    EXPECT_EQ(allocator.heap_top(), top_before + 512);
+    EXPECT_EQ(allocator.active_count(), 2) << "A deferred reservation claims no task-window slot";
 }
 
-TEST_F(HbgTaskAllocatorTest, ReserveHeapScratchFailsWithoutMutatingState) {
-    ASSERT_FALSE(allocator.alloc(256).failed());
-    uint64_t top_before = allocator.heap_top();
+TEST_F(HbgTaskAllocatorTest, ReserveDeferredHeapZeroSizeReturnsCurrentTop) {
+    ASSERT_FALSE(allocator.alloc(128).failed());
 
-    EXPECT_EQ(allocator.reserve_heap_scratch(HEAP_SIZE), nullptr);
+    void *base = nullptr;
+    void *end = nullptr;
+    ASSERT_TRUE(allocator.reserve_deferred_heap(0, &base, &end));
+    EXPECT_EQ(base, static_cast<void *>(heap_buf + 128));
+    EXPECT_EQ(base, end);
+    EXPECT_EQ(allocator.heap_top(), 128u);
+}
+
+TEST_F(HbgTaskAllocatorTest, ReserveDeferredHeapFailsWithoutMutatingState) {
+    ASSERT_FALSE(allocator.alloc(256).failed());
+    const uint64_t top_before = allocator.heap_top();
+
+    void *base = nullptr;
+    void *end = nullptr;
+    EXPECT_FALSE(allocator.reserve_deferred_heap(static_cast<int32_t>(HEAP_SIZE), &base, &end));
     EXPECT_EQ(allocator.heap_top(), top_before);
+    EXPECT_EQ(base, nullptr);
     EXPECT_EQ(error_code.load(), PTO2_ERROR_NONE) << "A rejected reservation is not a fatal";
 }
 
-TEST_F(HbgTaskAllocatorTest, ReserveHeapScratchZeroSizeReturnsCurrentTop) {
-    ASSERT_FALSE(allocator.alloc(128).failed());
-    void *p = allocator.reserve_heap_scratch(0);
-    EXPECT_EQ(p, static_cast<void *>(heap_buf + 128));
-    EXPECT_EQ(allocator.heap_top(), 128u);
+TEST_F(HbgTaskAllocatorTest, LatchedFatalShortCircuitsReserveDeferredHeap) {
+    error_code.store(PTO2_ERROR_INVALID_ARGS);
+
+    void *base = nullptr;
+    void *end = nullptr;
+    EXPECT_FALSE(allocator.reserve_deferred_heap(64, &base, &end));
+    EXPECT_EQ(allocator.heap_top(), 0u);
+}
+
+// Graph recording addresses its internal nodes' outputs from
+// GRAPH_RECORD_VIRTUAL_BASE upward and classifies internal vs boundary tensor
+// sources by address-range containment alone. A real heap that reached into that
+// range would silently misclassify, so init() refuses it.
+TEST_F(HbgTaskAllocatorTest, InitRejectsAHeapOverlappingTheRecordingVirtualRange) {
+    PTO2TaskAllocator overlapping{};
+    auto *base = reinterpret_cast<void *>(GRAPH_RECORD_VIRTUAL_BASE);
+    EXPECT_THROW(overlapping.init(WINDOW_SIZE, &current_index, base, HEAP_SIZE, &error_code), AssertionError);
+
+    PTO2TaskAllocator straddling{};
+    auto *just_below = reinterpret_cast<void *>(GRAPH_RECORD_VIRTUAL_BASE - 64);
+    EXPECT_THROW(straddling.init(WINDOW_SIZE, &current_index, just_below, HEAP_SIZE, &error_code), AssertionError);
 }

--- a/tests/ut/cpp/common/test_hbg_graph_async_submit.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_async_submit.cpp
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+
+#include "pto_orchestration_api.h"
+
+namespace {
+
+// The handshakes below wait for an event the peer thread is guaranteed to
+// publish, so this bound only decides how long a genuine failure takes to
+// report. All of this repo's self-hosted CPU runners share one machine, so it is
+// budgeted for a badly loaded host rather than for the expected microseconds.
+constexpr std::chrono::seconds kHandshakeTimeout{5};
+
+PTO2Runtime *g_bound_runtime = nullptr;
+
+extern "C" PTO2Runtime *framework_current_runtime(void) { return g_bound_runtime; }
+extern "C" void framework_bind_runtime(PTO2Runtime *rt) { g_bound_runtime = rt; }
+
+struct FakeRuntime {
+    const PTO2RuntimeOps *ops;
+    PTO2ScopeMode pending_scope_mode{PTO2ScopeMode::AUTO};
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool record_entered{false};
+    bool later_submit_entered{false};
+    bool overlapped{false};
+    int prepare_overlaps{0};
+    int begin_calls{0};
+    int prepare_calls{0};
+    int end_calls{0};
+    int commit_calls{0};
+    int scope_begin_calls{0};
+    int scope_end_calls{0};
+    std::thread::id record_thread;
+    std::thread::id prepare_thread;
+    std::thread::id submit_thread;
+
+    // What graph_prepare actually received, so the deep copy GraphOwnedArgs makes
+    // can be compared against the boundary the caller passed.
+    bool prepare_saw_args{false};
+    int32_t recorded_tensor_count{-1};
+    int32_t recorded_scalar_count{-1};
+    uint64_t recorded_tensor_addr{0};
+    uint64_t recorded_tensor_size{0};
+    uint32_t recorded_ndims{0};
+    uint64_t recorded_scalar{0};
+    TensorArgType recorded_tag{};
+    const void *recorded_args_object{nullptr};
+    const void *recorded_tensor_storage{nullptr};
+};
+
+static_assert(offsetof(FakeRuntime, ops) == 0);
+static_assert(offsetof(FakeRuntime, pending_scope_mode) == offsetof(PTO2Runtime, pending_scope_mode));
+
+FakeRuntime *as_fake(PTO2Runtime *rt) { return reinterpret_cast<FakeRuntime *>(rt); }
+
+bool fake_is_fatal(PTO2Runtime *) { return false; }
+
+GraphScopeResult fake_graph_begin(PTO2Runtime *rt, uint64_t, const CoreTaskArgs &) {
+    FakeRuntime &fake = *as_fake(rt);
+    std::lock_guard<std::mutex> lock(fake.mutex);
+    fake.begin_calls++;
+    GraphScopeResult result;
+    result.execute_block = false;
+    result.recording = fake.begin_calls == 1;
+    if (!result.recording) {
+        fake.later_submit_entered = true;
+        fake.cv.notify_all();
+    }
+    return result;
+}
+
+bool fake_graph_prepare(PTO2Runtime *rt, const CoreTaskArgs &args) {
+    FakeRuntime &fake = *as_fake(rt);
+    std::unique_lock<std::mutex> lock(fake.mutex);
+    fake.prepare_calls++;
+    fake.prepare_thread = std::this_thread::get_id();
+    fake.prepare_saw_args = true;
+    fake.recorded_tensor_count = args.tensor_count();
+    fake.recorded_scalar_count = args.scalar_count();
+    fake.recorded_args_object = &args;
+    if (args.tensor_count() > 0) {
+        const ChipTensor &tensor = args.tensor(0).ref();
+        fake.recorded_tensor_addr = tensor.buffer.addr;
+        fake.recorded_tensor_size = tensor.buffer.size;
+        fake.recorded_ndims = tensor.ndims;
+        fake.recorded_tag = args.tag(0);
+        fake.recorded_tensor_storage = &tensor;
+    }
+    if (args.scalar_count() > 0) {
+        fake.recorded_scalar = args.scalar(0);
+    }
+    // The hash-keyed outer shell is enough for the caller to continue. Hold
+    // prepare until the later same-hash submission proves that start() did not
+    // retain the old worker-ready handshake.
+    const bool saw_later_submit = fake.cv.wait_for(lock, kHandshakeTimeout, [&] {
+        return fake.later_submit_entered;
+    });
+    if (saw_later_submit) fake.prepare_overlaps++;
+    return true;
+}
+
+void fake_graph_abort(PTO2Runtime *) {}
+
+bool fake_graph_end(PTO2Runtime *rt) {
+    FakeRuntime &fake = *as_fake(rt);
+    fake.end_calls++;
+    fake.submit_thread = std::this_thread::get_id();
+    return true;
+}
+
+void fake_graph_commit(PTO2Runtime *rt) { as_fake(rt)->commit_calls++; }
+
+void fake_scope_begin(PTO2Runtime *rt) { as_fake(rt)->scope_begin_calls++; }
+
+void fake_scope_end(PTO2Runtime *rt) { as_fake(rt)->scope_end_calls++; }
+
+const PTO2RuntimeOps kFakeOps = {
+    .scope_begin = fake_scope_begin,
+    .scope_end = fake_scope_end,
+    .is_fatal = fake_is_fatal,
+    .graph_begin = fake_graph_begin,
+    .graph_prepare = fake_graph_prepare,
+    .graph_abort = fake_graph_abort,
+    .graph_end = fake_graph_end,
+    .graph_commit = fake_graph_commit,
+};
+
+}  // namespace
+
+TEST(HbgGraphAsyncSubmit, WorkerRecordsWhileMainSubmitsLaterGraphs) {
+    FakeRuntime fake{};
+    fake.ops = &kFakeOps;
+    framework_bind_runtime(reinterpret_cast<PTO2Runtime *>(&fake));
+
+    uint32_t storage[4]{};
+    uint32_t shape[] = {4};
+    ChipTensor boundary = make_tensor_external(storage, shape, 1);
+    CoreTaskArgs args;
+    args.add_input(boundary);
+
+    int body_calls = 0;
+    const std::thread::id caller = std::this_thread::get_id();
+    GraphSubmitResult first;
+    {
+        PTO2ScopeGuard scope;
+        first = rt_submit_graph_impl(0x1715, args, [&](const CoreTaskArgs &) {
+            // Graph bodies use the ordinary task wrappers, which commit any
+            // preceding outer Graph before submitting. This must not make the
+            // recorder wait for its own in-flight job.
+            rt_graph_commit();
+            std::unique_lock<std::mutex> lock(fake.mutex);
+            body_calls++;
+            fake.record_entered = true;
+            fake.record_thread = std::this_thread::get_id();
+            fake.cv.notify_all();
+            const bool saw_later_submit = fake.cv.wait_for(lock, kHandshakeTimeout, [&] {
+                return fake.later_submit_entered;
+            });
+            fake.overlapped |= saw_later_submit;
+        });
+    }
+    GraphSubmitResult second;
+    {
+        PTO2ScopeGuard scope;
+        second = rt_submit_graph_impl(0x1715, args, [&](const CoreTaskArgs &) {
+            ADD_FAILURE() << "a later submission for an in-flight Graph must not execute the body";
+        });
+    }
+    rt_graph_commit();
+
+    const std::thread::id first_record_thread = fake.record_thread;
+    {
+        std::lock_guard<std::mutex> lock(fake.mutex);
+        fake.begin_calls = 0;
+        fake.record_entered = false;
+        fake.later_submit_entered = false;
+        fake.overlapped = false;
+    }
+    {
+        PTO2ScopeGuard scope;
+        first = rt_submit_graph_impl(0x1715, args, [&](const CoreTaskArgs &) {
+            rt_graph_commit();
+            std::unique_lock<std::mutex> lock(fake.mutex);
+            body_calls++;
+            fake.record_entered = true;
+            fake.record_thread = std::this_thread::get_id();
+            fake.cv.notify_all();
+            const bool saw_later_submit = fake.cv.wait_for(lock, kHandshakeTimeout, [&] {
+                return fake.later_submit_entered;
+            });
+            fake.overlapped |= saw_later_submit;
+        });
+    }
+    {
+        PTO2ScopeGuard scope;
+        second = rt_submit_graph_impl(0x1715, args, [&](const CoreTaskArgs &) {
+            ADD_FAILURE() << "a later submission for an in-flight Graph must not execute the body";
+        });
+    }
+    rt_graph_commit();
+
+    framework_bind_runtime(nullptr);
+    EXPECT_TRUE(first.recording);
+    EXPECT_FALSE(second.recording);
+    EXPECT_EQ(fake.begin_calls, 2);
+    EXPECT_EQ(body_calls, 2);
+    EXPECT_EQ(fake.prepare_calls, 2);
+    EXPECT_EQ(fake.prepare_overlaps, 2) << "main-thread Graph submission must not wait for worker graph_prepare";
+    EXPECT_EQ(fake.end_calls, 2);
+    EXPECT_EQ(fake.commit_calls, 4);
+    EXPECT_EQ(fake.scope_begin_calls, 4);
+    EXPECT_EQ(fake.scope_end_calls, 4);
+    EXPECT_TRUE(fake.overlapped);
+    EXPECT_NE(fake.record_thread, caller);
+    EXPECT_EQ(fake.record_thread, first_record_thread) << "steady-state recording must reuse the worker thread";
+    EXPECT_EQ(fake.prepare_thread, fake.record_thread);
+    EXPECT_EQ(fake.submit_thread, fake.record_thread);
+}
+
+// The recorded body runs on the worker after the caller's frame is free to end,
+// so it must read a boundary the worker owns. GraphOwnedArgs is that copy; this
+// pins both halves of its contract — the values survive, and the storage they
+// live in is not the caller's.
+TEST(HbgGraphAsyncSubmit, RecordingReadsAnOwnedCopyOfTheBoundary) {
+    FakeRuntime fake{};
+    fake.ops = &kFakeOps;
+    framework_bind_runtime(reinterpret_cast<PTO2Runtime *>(&fake));
+
+    uint32_t storage[8]{};
+    uint32_t shape[] = {8};
+    ChipTensor boundary = make_tensor_external(storage, shape, 1);
+    constexpr uint64_t kScalar = 0x5eed1715ULL;
+    CoreTaskArgs args;
+    args.add_input(boundary);
+    args.add_scalar(kScalar);
+
+    const void *caller_args_object = &args;
+    const void *caller_tensor_storage = &args.tensor(0).ref();
+
+    // This case is about the copy, not the overlap: release the gate that
+    // fake_graph_prepare waits on so it returns immediately instead of sitting
+    // out the handshake timeout no later submission is going to satisfy.
+    fake.later_submit_entered = true;
+
+    {
+        PTO2ScopeGuard scope;
+        (void)rt_submit_graph_impl(0x1719, args, [](const CoreTaskArgs &) {});
+    }
+    rt_graph_commit();
+    framework_bind_runtime(nullptr);
+
+    ASSERT_TRUE(fake.prepare_saw_args);
+    EXPECT_EQ(fake.recorded_tensor_count, args.tensor_count());
+    EXPECT_EQ(fake.recorded_scalar_count, args.scalar_count());
+    EXPECT_EQ(fake.recorded_tensor_addr, boundary.buffer.addr);
+    EXPECT_EQ(fake.recorded_tensor_size, boundary.buffer.size);
+    EXPECT_EQ(fake.recorded_ndims, boundary.ndims);
+    EXPECT_EQ(fake.recorded_tag, TensorArgType::INPUT);
+    EXPECT_EQ(fake.recorded_scalar, kScalar);
+
+    EXPECT_NE(fake.recorded_args_object, caller_args_object) << "the worker must not read the caller's CoreTaskArgs";
+    EXPECT_NE(fake.recorded_tensor_storage, caller_tensor_storage)
+        << "the worker must not read ChipTensor storage the caller owns";
+}

--- a/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
@@ -12,12 +12,18 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <condition_variable>
 #include <cstdint>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <utility>
 #include <vector>
 
 #include "graph_host_state.h"
 #include "pto_orchestrator.h"
 #include "pto_shared_memory.h"
+#include "task_interface/assert_compat.h"
 #include "utils/device_arena.h"
 
 class HbgGraphSubmitFailureTest : public ::testing::Test {
@@ -70,6 +76,254 @@ protected:
     }
 };
 
+TEST_F(HbgGraphSubmitFailureTest, InFlightGraphSubmissionsReserveHeapOnlyAtCommit) {
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    ChipTensor boundary = make_tensor_external(storage.data(), shape, 1);
+    CoreTaskArgs boundary_args;
+    boundary_args.add_input(boundary);
+
+    orch.begin_scope();
+    const GraphScopeResult first = orch.graph_begin(0x1715, boundary_args, 0x1736);
+    ASSERT_TRUE(first.recording);
+    ASSERT_TRUE(first.task_id.is_valid());
+    const GraphScopeResult second = orch.graph_begin(0x1715, boundary_args, 0x1736);
+    EXPECT_FALSE(second.recording);
+    EXPECT_FALSE(second.execute_block);
+    ASSERT_TRUE(second.task_id.is_valid());
+    EXPECT_EQ(second.task_id.local(), first.task_id.local() + 1);
+    EXPECT_EQ(orch.ring.task_allocator.heap_top(), 0u);
+    EXPECT_EQ(graph_host_upload_count(*graph_state), 2u);
+
+    ASSERT_TRUE(orch.graph_prepare(boundary_args));
+    CoreTaskArgs node_args;
+    node_args.add_input(boundary);
+    TensorCreateInfo recorded_output(shape, 1, DataType::UINT32);
+    node_args.add_output(recorded_output);
+    ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
+    ASSERT_TRUE(orch.graph_end());
+    EXPECT_EQ(orch.ring.task_allocator.heap_top(), 0u);
+
+    orch.graph_commit();
+    EXPECT_FALSE(orch.fatal);
+    EXPECT_GT(orch.ring.task_allocator.heap_top(), 0u);
+    const std::optional<GraphHostUpload> first_upload = graph_host_upload(*graph_state, 0);
+    const std::optional<GraphHostUpload> second_upload = graph_host_upload(*graph_state, 1);
+    ASSERT_TRUE(first_upload.has_value());
+    ASSERT_TRUE(second_upload.has_value());
+    const auto *first_submission = reinterpret_cast<const GraphSubmission *>(first_upload->data);
+    const auto *second_submission = reinterpret_cast<const GraphSubmission *>(second_upload->data);
+    EXPECT_NE(first_submission->definition_hash, 0u);
+    EXPECT_EQ(second_submission->definition_hash, first_submission->definition_hash);
+    // Distinct bases alone would still pass if finalization handed out a wrong
+    // extent, so pin the length the Definition asks for and the disjointness two
+    // shells of one Graph must have.
+    const auto *first_base = static_cast<const char *>(first_upload->outer_slot->task->packed_buffer_base);
+    const auto *first_end = static_cast<const char *>(first_upload->outer_slot->task->packed_buffer_end);
+    const auto *second_base = static_cast<const char *>(second_upload->outer_slot->task->packed_buffer_base);
+    const auto *second_end = static_cast<const char *>(second_upload->outer_slot->task->packed_buffer_end);
+    const GraphHostDefinitionList definitions = graph_host_definitions(*graph_state);
+    ASSERT_EQ(definitions.entries.size(), 1u);
+    ASSERT_EQ(definitions.entries[0].full_key, first_submission->graph_key);
+    const auto *definition = reinterpret_cast<const GraphDefinition *>(definitions.entries[0].data);
+    const uint64_t expected_extent =
+        PTO2_ALIGN_UP(definition->required_heap + definition->execution_storage_bytes, PTO2_ALIGN_SIZE);
+    EXPECT_EQ(static_cast<uint64_t>(first_end - first_base), expected_extent);
+    EXPECT_EQ(static_cast<uint64_t>(second_end - second_base), expected_extent);
+    EXPECT_TRUE(first_end <= second_base || second_end <= first_base) << "two shells must not share heap bytes";
+}
+
+// The one combination the other two tests miss: real orchestrator state driven
+// by two real threads. test_hbg_graph_async_submit exercises the worker handoff
+// against a fake ops table, and every case here otherwise calls prepare/record/
+// end on the test thread, so nothing covers a worker recording *while* the main
+// thread submits same-hash shells.
+//
+// That overlap is held together only by field partitioning: under
+// recording_mutex the main thread reads boundary_tensors / boundary_types /
+// boundary_scalar_count, while the worker writes boundary_args / nodes /
+// next_virtual_offset / unsupported without it (graph_prepare skips the mutex on
+// purpose, so a submit burst cannot starve it). Nothing enforces that split, so
+// this pins the functional contract that depends on it — and gives TSAN a window
+// to report the split being broken.
+//
+// The handshake is deterministic rather than timing-based: the worker is proven
+// to be between graph_prepare and graph_end while the main thread runs its
+// in-flight graph_begin calls.
+TEST_F(HbgGraphSubmitFailureTest, WorkerRecordsWhileMainThreadSubmitsSameHashShells) {
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    ChipTensor boundary = make_tensor_external(storage.data(), shape, 1);
+    CoreTaskArgs boundary_args;
+    boundary_args.add_input(boundary);
+
+    orch.begin_scope();
+    const GraphScopeResult first = orch.graph_begin(0x171a, boundary_args, 0x1736);
+    ASSERT_TRUE(first.recording);
+    ASSERT_TRUE(first.task_id.is_valid());
+
+    std::mutex gate_mutex;
+    std::condition_variable gate_cv;
+    bool prepared = false;
+    bool main_done_submitting = false;
+    bool prepare_ok = false;
+    bool node_ok = false;
+    bool end_ok = false;
+
+    std::thread worker([&]() {
+        // Worker-owned boundary copy, alive until graph_end: graph_prepare
+        // anchors scalar sources into it and stores its address.
+        CoreTaskArgs worker_args;
+        worker_args.add_input(boundary);
+        prepare_ok = orch.graph_prepare(worker_args);
+        {
+            std::lock_guard<std::mutex> lock(gate_mutex);
+            prepared = true;
+        }
+        gate_cv.notify_all();
+        if (!prepare_ok) return;
+
+        {
+            std::unique_lock<std::mutex> lock(gate_mutex);
+            gate_cv.wait(lock, [&]() {
+                return main_done_submitting;
+            });
+        }
+
+        CoreTaskArgs node_args;
+        node_args.add_input(boundary);
+        TensorCreateInfo recorded_output(shape, 1, DataType::UINT32);
+        node_args.add_output(recorded_output);
+        node_ok = orch.submit_dummy_task(node_args).task_id().is_valid();
+        end_ok = orch.graph_end();
+    });
+
+    {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        gate_cv.wait(lock, [&]() {
+            return prepared;
+        });
+    }
+
+    // The worker is now inside the recording. These two go through the in-flight
+    // branch, which reads the boundary signature under recording_mutex.
+    const GraphScopeResult second = orch.graph_begin(0x171a, boundary_args, 0x1736);
+    const GraphScopeResult third = orch.graph_begin(0x171a, boundary_args, 0x1736);
+    {
+        std::lock_guard<std::mutex> lock(gate_mutex);
+        main_done_submitting = true;
+    }
+    gate_cv.notify_all();
+    worker.join();
+
+    ASSERT_TRUE(prepare_ok);
+    ASSERT_TRUE(node_ok);
+    ASSERT_TRUE(end_ok);
+    EXPECT_FALSE(second.recording);
+    EXPECT_FALSE(second.execute_block);
+    EXPECT_FALSE(third.execute_block);
+    ASSERT_TRUE(second.task_id.is_valid());
+    ASSERT_TRUE(third.task_id.is_valid());
+    EXPECT_EQ(second.task_id.local(), first.task_id.local() + 1);
+    EXPECT_EQ(third.task_id.local(), first.task_id.local() + 2);
+    EXPECT_EQ(orch.ring.task_allocator.heap_top(), 0u) << "no shell may take heap before commit";
+
+    orch.graph_commit();
+    ASSERT_FALSE(orch.fatal);
+    ASSERT_EQ(graph_host_upload_count(*graph_state), 3u);
+
+    const GraphHostDefinitionList definitions = graph_host_definitions(*graph_state);
+    ASSERT_EQ(definitions.entries.size(), 1u);
+    const auto *definition = reinterpret_cast<const GraphDefinition *>(definitions.entries[0].data);
+    const uint64_t expected_extent =
+        PTO2_ALIGN_UP(definition->required_heap + definition->execution_storage_bytes, PTO2_ALIGN_SIZE);
+
+    std::vector<std::pair<const char *, const char *>> ranges;
+    for (size_t i = 0; i < 3; ++i) {
+        const std::optional<GraphHostUpload> upload = graph_host_upload(*graph_state, i);
+        ASSERT_TRUE(upload.has_value());
+        const auto *submission = reinterpret_cast<const GraphSubmission *>(upload->data);
+        EXPECT_EQ(submission->definition_hash, definition->content_hash) << "shell " << i;
+        const auto *base = static_cast<const char *>(upload->outer_slot->task->packed_buffer_base);
+        const auto *end = static_cast<const char *>(upload->outer_slot->task->packed_buffer_end);
+        EXPECT_EQ(static_cast<uint64_t>(end - base), expected_extent) << "shell " << i;
+        ranges.emplace_back(base, end);
+    }
+    for (size_t i = 0; i < ranges.size(); ++i) {
+        for (size_t j = i + 1; j < ranges.size(); ++j) {
+            EXPECT_TRUE(ranges[i].second <= ranges[j].first || ranges[j].second <= ranges[i].first)
+                << "shells " << i << " and " << j << " share heap bytes";
+        }
+    }
+}
+
+// An outer Graph shell enters the task and dependency sequence before the
+// worker has recorded the body, so a construct the recording cannot represent
+// can no longer be answered by re-running the body on the ordinary path — the
+// shell's task id and TensorMap producers are already published. Commit
+// therefore has to latch a fatal rather than leave a shell that can never
+// complete.
+TEST_F(HbgGraphSubmitFailureTest, AbortedRecordingLatchesFatalAtCommit) {
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    ChipTensor boundary = make_tensor_external(storage.data(), shape, 1);
+    CoreTaskArgs boundary_args;
+    boundary_args.add_input(boundary);
+
+    orch.begin_scope();
+    const GraphScopeResult graph = orch.graph_begin(0x1717, boundary_args, 0x1736);
+    ASSERT_TRUE(graph.recording);
+    ASSERT_TRUE(graph.task_id.is_valid());
+    ASSERT_TRUE(orch.graph_prepare(boundary_args));
+
+    CoreTaskArgs node_args;
+    node_args.add_input(boundary);
+    TensorCreateInfo recorded_output(shape, 1, DataType::UINT32);
+    node_args.add_output(recorded_output);
+    ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
+
+    orch.graph_abort();
+    ASSERT_FALSE(orch.fatal) << "Abort alone must not latch; the shell is still finalizable in principle";
+
+    orch.graph_commit();
+    EXPECT_TRUE(orch.fatal) << "A shell whose Definition never arrived cannot be completed";
+}
+
+// A Graph body that allocates at runtime cannot be replayed from a Definition.
+// The recording is poisoned as it happens and graph_end refuses to publish, so
+// the caller reaches the same terminal path as an explicit abort.
+TEST_F(HbgGraphSubmitFailureTest, RuntimeAllocationInsideTheBodyPoisonsTheRecording) {
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    ChipTensor boundary = make_tensor_external(storage.data(), shape, 1);
+    CoreTaskArgs boundary_args;
+    boundary_args.add_input(boundary);
+
+    orch.begin_scope();
+    const GraphScopeResult graph = orch.graph_begin(0x1718, boundary_args, 0x1736);
+    ASSERT_TRUE(graph.recording);
+    ASSERT_TRUE(orch.graph_prepare(boundary_args));
+
+    CoreTaskArgs alloc_args;
+    TensorCreateInfo allocated(shape, 1, DataType::UINT32);
+    alloc_args.add_output(allocated);
+    orch.alloc_tensors(alloc_args);
+
+    // graph_end asserts on an unsupported recording, so a debug build throws
+    // where a release build returns false. rt_submit_graph_impl aborts on either,
+    // which is what the terminal path below depends on.
+    bool published = false;
+    try {
+        published = orch.graph_end();
+    } catch (const AssertionError &) {
+        orch.graph_abort();
+    }
+    EXPECT_FALSE(published);
+
+    orch.graph_commit();
+    EXPECT_TRUE(orch.fatal);
+}
+
 TEST_F(HbgGraphSubmitFailureTest, FaninFailureLatchesFatalWithoutPartialUpload) {
     std::array<uint32_t, 16> storage{};
     uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
@@ -80,11 +334,19 @@ TEST_F(HbgGraphSubmitFailureTest, FaninFailureLatchesFatalWithoutPartialUpload) 
     boundary_args.add_input(boundary);
     const GraphScopeResult graph = orch.graph_begin(0x1715, boundary_args, 0x1736);
     ASSERT_TRUE(graph.recording);
+    ASSERT_TRUE(orch.graph_prepare(boundary_args));
 
     CoreTaskArgs node_args;
     node_args.add_input(boundary);
+    TensorCreateInfo recorded_output(shape, 1, DataType::UINT32);
+    node_args.add_output(recorded_output);
+    const uint64_t heap_top_before_record = orch.ring.task_allocator.heap_top();
     ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
-    orch.graph_end();
+    EXPECT_EQ(orch.ring.task_allocator.heap_top(), heap_top_before_record);
+    ASSERT_TRUE(orch.graph_end());
+    EXPECT_EQ(orch.ring.task_allocator.heap_top(), heap_top_before_record);
+    orch.graph_commit();
+    EXPECT_GT(orch.ring.task_allocator.heap_top(), heap_top_before_record);
     ASSERT_FALSE(orch.fatal);
     const size_t uploads_before_failure = graph_host_upload_count(*graph_state);
 
@@ -114,6 +376,7 @@ TEST_F(HbgGraphSubmitFailureTest, CachedGraphUsesFinalTaskWindowSlot) {
     boundary_args.add_input(boundary);
     const GraphScopeResult graph = orch.graph_begin(0x1716, boundary_args, 0x1736);
     ASSERT_TRUE(graph.recording);
+    ASSERT_TRUE(orch.graph_prepare(boundary_args));
 
     CoreTaskArgs node_args;
     node_args.add_input(boundary);

--- a/tests/ut/cpp/common/test_host_phase_records.cpp
+++ b/tests/ut/cpp/common/test_host_phase_records.cpp
@@ -17,10 +17,12 @@ using simpler::dfx::HostPhaseRecordStore;
 
 namespace {
 
-void record_n(HostPhaseRecordPool *pool, HostPhaseKind kind, uint32_t n, uint64_t first_start = 0) {
+void record_n(
+    HostPhaseRecordPool *pool, HostPhaseKind kind, uint32_t n, uint64_t first_start = 0, uint32_t thread_id = 0
+) {
     for (uint32_t i = 0; i < n; ++i) {
         const uint64_t start = first_start + i;
-        host_phase_pool_append(pool, kind, start, start + 1, i, i);
+        host_phase_pool_append(pool, kind, start, start + 1, i, i, thread_id);
     }
 }
 
@@ -114,6 +116,21 @@ TEST(HostPhaseRecords, ReArmClearsThePreviousPass) {
     record_n(pool, HostPhaseKind::OrchGraphSubmit, 3);
     store.finish(3, /*invocation_id=*/9);
     EXPECT_EQ(store.records().size(), 3u);
+}
+
+TEST(HostPhaseRecords, ProducerThreadIdSurvivesTheArtifactStore) {
+    HostPhaseRecordStore store;
+    HostPhaseRecordPool *pool = store.arm(true);
+    ASSERT_NE(pool, nullptr);
+
+    record_n(pool, HostPhaseKind::OrchRecordNode, 1, /*first_start=*/10, /*thread_id=*/101);
+    record_n(pool, HostPhaseKind::OrchGraphSubmit, 1, /*first_start=*/20, /*thread_id=*/202);
+    store.finish(1, /*invocation_id=*/9);
+
+    const auto records = store.records();
+    ASSERT_EQ(records.size(), 2u);
+    EXPECT_EQ(records[0].thread_id, 101u);
+    EXPECT_EQ(records[1].thread_id, 202u);
 }
 
 TEST(HostPhaseRecords, SubmitProjectionKeepsOnlyTaskSubmittingKinds) {

--- a/tests/ut/py/test_strace_timing.py
+++ b/tests/ut/py/test_strace_timing.py
@@ -867,8 +867,9 @@ def test_host_record_spans_nest_bind_segments_and_orchestrator_operations(tmp_pa
             "pid": 9,
             "inv": 5,
             "records": [
-                {"phase": "args", "start_ns": 1_000, "end_ns": 1_100, "detail": 4096},
-                {"phase": "graph_submit", "start_ns": 1_200, "end_ns": 1_250, "detail": 77},
+                {"phase": "args", "start_ns": 1_000, "end_ns": 1_100, "detail": 4096, "tid": 9},
+                {"phase": "record_node", "start_ns": 1_150, "end_ns": 1_230, "detail": 4, "tid": 42},
+                {"phase": "graph_submit", "start_ns": 1_200, "end_ns": 1_250, "detail": 77, "tid": 9},
             ],
         }
     ]
@@ -883,6 +884,44 @@ def test_host_record_spans_nest_bind_segments_and_orchestrator_operations(tmp_pa
     assert by_name["chip.run.bind.host_orch.graph_submit"].depth == bind_depth + 2
     assert by_name["chip.run.bind.args"].ts == 1_000
     assert by_name["chip.run.bind.args"].dur == 100
+    assert by_name["chip.run.bind.host_orch.record_node"].tid == 42
+    assert by_name["chip.run.bind.host_orch.graph_submit"].tid == 9
+
+    trace = to_host_swimlane(spans + out)
+    lane_names = {
+        event["tid"]: event["args"]["name"]
+        for event in trace["traceEvents"]
+        if event["ph"] == "M" and event["name"] == "thread_name"
+    }
+    assert lane_names[9] == "graph submit main"
+    assert lane_names[42] == "graph record worker"
+
+
+def test_host_record_spans_keep_legacy_recording_on_main_lane():
+    spans = list(parse_spans([_span_record(pid=9, tid=9, inv=5, name="chip.run.bind", ts=900, dur=500)]))
+    passes = [
+        {
+            "pid": 9,
+            "inv": 5,
+            "records": [
+                {"phase": "record_node", "start_ns": 1_000, "end_ns": 1_080, "detail": 4},
+                {"phase": "build_definition", "start_ns": 1_100, "end_ns": 1_180, "detail": 4},
+                {"phase": "graph_submit", "start_ns": 1_200, "end_ns": 1_250, "detail": 77},
+            ],
+        }
+    ]
+
+    out, dropped, _ = host_record_spans(spans, passes)
+
+    assert dropped == 0
+    assert {span.tid for span in out} == {9}
+    trace = to_host_swimlane(spans + out)
+    lane_names = {
+        event["tid"]: event["args"]["name"]
+        for event in trace["traceEvents"]
+        if event["ph"] == "M" and event["name"] == "thread_name"
+    }
+    assert lane_names[9] == "graph submit main"
 
 
 def test_host_record_spans_drop_passes_with_no_matching_bind(tmp_path):


### PR DESCRIPTION
## Summary

- Publish a hash-keyed, zero-heap Graph task shell immediately on a graph miss, while a persistent worker records the node and builds the Definition from an owned argument copy.
- Let subsequent outer `graph_submit` calls continue after the hash is known; finalize deferred heap reservations at the next Graph barrier or orchestration completion.
- Make host phase tracing thread-safe and render `graph submit main` and `graph record worker` on separate Host Swimlane lanes.
- Add coverage for asynchronous overlap, all-Graph entry completion, failure cleanup, and legacy trace parsing on both A2A3 and A5 paths.

This implements the "record on a child thread once the hash is known" step of the Graph roadmap, together with the minimum decoupling of heap allocation from graph building needed to unblock it. The hash→graph table upload, the whole-graph size computation feeding a single `rtMalloc`, lifetime-analysis heap reuse in place of the ring, `task_list`/`dep_pool` compaction, and runtime pre-expansion are **not** in scope here. `reserve_deferred_heap` is deliberately narrow for now — when sizing moves to one pass over all tasks, this Graph-only path should dissolve into it rather than sit beside it.

## Behavior change: an unsupported Graph body is now terminal

Previously a Graph body containing a construct Graph Execution cannot represent was survivable: `graph_end` returned false and the caller re-ran the body on the ordinary task-submit path.

The outer shell is now published *before* the body is recorded, so its task id and TensorMap producers are already in the sequence and the body cannot be replayed. `graph_commit` therefore latches `PTO2_ERROR_INVALID_ARGS` instead. This affects nested Graph recording, dispatch predicates, runtime allocation inside the body (`alloc_tensors`), unclassifiable internal Tensor sources, boundary scalars reached through mutable `scalar()`, non-positive `block_num`, subtask-count overflow, and more than 1024 internal nodes.

Conditions detectable *before* a shell is accepted still fall back to the ordinary path. `GRAPH_EXECUTION.md` carries the full split, and unit tests cover the terminal path through both an explicit abort and runtime allocation inside the body.

## Concurrency contract

The overlap is safe because **recording touches no shared orchestrator state**: `graph_record_submit_node`, `graph_classify_tensor` and `graph_classify_scalar` read and write only the thread-private `GraphRecording`. Internal node outputs are addressed from a private range based at `GRAPH_RECORD_VIRTUAL_BASE = 1ULL << 63` instead of real heap scratch, so the worker never moves the allocator.

That range is load-bearing: tensor-source classification separates an internal producer's output from a boundary tensor by address-range containment alone. `PTO2TaskAllocator::init()` asserts the configured heap lies entirely below the base, so an overlapping device GM heap fails loudly at setup instead of silently misclassifying a Tensor source into a cached Definition.

Where main and worker do meet:

- `recording_mutex` guards Definition publication and the boundary-signature reads that later same-hash submissions perform.
- `recording_status` is `std::atomic` because `graph_prepare` reads it *without* the mutex by design — acquiring it there lets a main-thread burst of same-hash submissions starve the worker before it can bind its recording state.
- `active_graph_recording()` carries the owning `GraphHostState` in a second thread-local, so a thread cannot record into a different orchestrator.
- `rt_graph_async_recording()` has **external** linkage. `static inline` gave every translation unit its own recorder and its own worker thread; the Graph Execution scene test's orchestration is three sources, so a commit reached from one did not wait for a recording another started.

Beyond `graph_record_submit_node`'s isolation, the split between what main reads and what the worker writes is not enforced by a type or a lock, so `WorkerRecordsWhileMainThreadSubmitsSameHashShells` pins the functional contract that depends on it: a real second thread records against real orchestrator state while the main thread submits same-hash shells, asserting consistent `definition_hash`, correct per-shell heap extent, and pairwise disjoint ranges. The handshake is deterministic — the worker is *proven* to sit between `graph_prepare` and `graph_end` during the overlap.

## Also in this PR

- `HostPhaseRecord` grows 32 → 40 bytes for the producer tid, so the pool grows 160 KiB → 200 KiB. Host DDR only; not on the wire. `host_phase_pool_append`'s new parameter is defaulted, and a JSONL without `tid` still parses onto the main lane.
- The per-event pool is armed when the level-4 artifact is being written (producer wants records *and* an output prefix) or whenever the chip swimlane is at `ORCH_PHASES`. A steady-state run satisfies neither, so it pays no pool append.
- Phase counters are lock-free atomic adds on per-kind cache lines; only the pool append is serialized, and only when armed. An in-flight claim keeps a record that passed the `active` check from being attributed to a pass it does not belong to — `begin`/`end` clear `active`, then drain. The cheap `active` load stays in front of the claim because `ORCH_PHASE_END` runs on every submit-level operation.
- `reserve_heap_scratch()` / `restore_heap_top()` lose their last production callers; the deferred reservation that replaced them now has allocator-level coverage, alongside the heap-range invariant.
- `graph_upload` regresses 11.5%: the deferred back-patch moves the shells' heap reservation and content-hash write out of `host_orch` and into upload. The pair is what matters, and it is down 12.7%.

## Performance

Qwen3-14B host-build-Graph decode on device 1, three independent processes with six rounds each, discarding each process's first round (`n=15` steady-state samples):

| Metric | `main` median | This PR median | Change |
| --- | ---: | ---: | ---: |
| `host_orch` | 725.287 us | 569.616 us | -21.46% |
| `graph_upload` | 587.596 us | 655.246 us | +11.51% |
| `host_orch + graph_upload` | 1425.394 us | 1244.922 us | -12.66% |
| `arena_h2d` | 95.401 us | 83.521 us | -12.45% |
| `sm_h2d` | 70.101 us | 70.091 us | ~0% |

The optimized Host Swimlane shows 34 of 40 outer submissions overlapping the record worker, with 77.860 us of exact interval overlap.

## Testing

- Pre-commit checks: passed
- C++ unit tests: **107/107 passed**
- `WorkerRecordsWhileMainThreadSubmitsSameHashShells`: 300 repeats on each arch, zero failures. Note that `sanitizers.yml` scopes ASAN and TSAN to `pytest` scene tests, so `ctest` never sees a sanitizer in CI; TSAN is additionally unusable on the dev box (a thread-free test segfaults before producing output). The test is therefore built to fail on a functional regression without needing a race detector.
- Python unit tests: 1646 passed, 13 skipped. One full-suite-only failure, `test_second_child_failure_reaps_first`, is **pre-existing**: reproduced on an isolated worktree built at this PR's first commit without any of the review fixes (2 failed / 1645 passed there). It is a forked-child close-budget overrun and passes standalone and per-file.
- A2A3 simulator Graph Execution suite: 2 passed, 1 deselected
- A5 simulator Graph Execution suite: 2 passed, 1 deselected
- A2A3 **onboard** Graph Execution suite: 3 passed via `task-submit` on device 1 — this is what exercises the new heap-range assertion against a real GM base
- Qwen3-14B hardware GraphExecutionBatch16Seq3500 on device 1: 6 rounds passed

before
<img width="916" height="84" alt="image" src="https://github.com/user-attachments/assets/3e5a9c85-9e90-4197-ab5e-c322ad00a731" />

after
<img width="492" height="132" alt="image" src="https://github.com/user-attachments/assets/e9487ccf-3ddd-4d7d-b012-aeb6d2390b8b" />