### PR TITLE
Fix: run SPMD paged attention on A5 at the a2a3 shapes

### DIFF
--- a/tests/st/a2a3/host_build_graph/spmd_paged_attention/test_spmd_paged_attention.py
+++ b/tests/st/a2a3/host_build_graph/spmd_paged_attention/test_spmd_paged_attention.py
@@ -26,28 +26,13 @@ class TestSpmdPagedAttentionHbgA2A3(_TmrBase):
     for _incore in CALLABLE["incores"]:
         _incore["source"] = str(_SHARED_DIR / "kernels/mix/paged_attention_parallel.cpp")
 
-    CASES = [
-        {
-            "name": "TwoWayOneBlockZeroQuery",
-            "platforms": ["a2a3sim", "a2a3"],
-            "manual": True,
-            "params": {
-                "batch": 2,
-                "num_heads": 16,
-                "kv_head_num": 1,
-                "head_dim": 128,
-                "block_size": 128,
-                "context_len": 128,
-                "max_model_len": 256,
-                "dtype": "bfloat16",
-            },
-        }
-    ]
-
-    def generate_args(self, params):
-        args = super().generate_args(params)
-        args.query.zero_()
-        return args
+    # The TMR shapes, run through host_build_graph. Deep-copied so the two
+    # classes do not share a params dict. Onboard only: the MIX kernel's
+    # TPUSH/TPOP path does not build for the CPU simulator (PTO-ISA rejects the
+    # ColMajor TMULS in the softmax tail), so a2a3sim is out of scope. See
+    # #1832. Every HBG case stays manual; the Per-PR sweep covers these shapes
+    # on the TMR side.
+    CASES = [{**deepcopy(case), "platforms": ["a2a3"], "manual": True} for case in _TmrBase.CASES]
 
 
 if __name__ == "__main__":

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
@@ -115,9 +115,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     uint32_t oi_fifo_total = static_cast<uint32_t>(SPMD_BLOCK_NUM) * OI_SLOT_SIZE * FIFO_DEPTH;
 
     // Allocate as 1D byte tensors (using INT32 for 4-byte alignment, divide by 4)
-    uint32_t sij_fifo_shapes[1] = {sij_fifo_total / sizeof(int32_t)};
-    uint32_t pij_fifo_shapes[1] = {pij_fifo_total / sizeof(int32_t)};
-    uint32_t oi_fifo_shapes[1] = {oi_fifo_total / sizeof(int32_t)};
+    uint32_t sij_fifo_shapes[1] = {static_cast<uint32_t>(sij_fifo_total / sizeof(int32_t))};
+    uint32_t pij_fifo_shapes[1] = {static_cast<uint32_t>(pij_fifo_total / sizeof(int32_t))};
+    uint32_t oi_fifo_shapes[1] = {static_cast<uint32_t>(oi_fifo_total / sizeof(int32_t))};
 
     TensorCreateInfo sij_fifo_ci(sij_fifo_shapes, 1, DataType::INT32);
     TensorCreateInfo pij_fifo_ci(pij_fifo_shapes, 1, DataType::INT32);

--- a/tests/st/a5/host_build_graph/spmd_paged_attention/test_spmd_paged_attention.py
+++ b/tests/st/a5/host_build_graph/spmd_paged_attention/test_spmd_paged_attention.py
@@ -9,6 +9,8 @@
 # -----------------------------------------------------------------------------------------------------------
 """Manual HBG coverage for the disabled A5 SPMD paged-attention workload."""
 
+from copy import deepcopy
+
 from simpler_setup import scene_test
 from tests.st.a5.tensormap_and_ringbuffer.spmd_paged_attention.test_spmd_paged_attention import (
     TestSpmdPagedAttentionA5 as _TmrBase,
@@ -17,7 +19,13 @@ from tests.st.a5.tensormap_and_ringbuffer.spmd_paged_attention.test_spmd_paged_a
 
 @scene_test(level=2, runtime="host_build_graph")
 class TestSpmdPagedAttentionHbgA5(_TmrBase):
-    CASES = [{**case, "platforms": ["a5sim", "a5"], "manual": True} for case in _TmrBase.CASES]
+    # The TMR shapes, run through host_build_graph. Deep-copied so the two
+    # classes do not share a params dict. Onboard only: the MIX kernel's
+    # TPUSH/TPOP path does not build for the CPU simulator (PTO-ISA rejects the
+    # ColMajor TMULS in the softmax tail), so a5sim is out of scope. See #1832.
+    # Every HBG case stays manual; the Per-PR sweep covers these shapes on the
+    # TMR side.
+    CASES = [{**deepcopy(case), "platforms": ["a5"], "manual": True} for case in _TmrBase.CASES]
 
 
 if __name__ == "__main__":

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/kernels/mix/paged_attention_parallel.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/kernels/mix/paged_attention_parallel.cpp
@@ -120,9 +120,12 @@ struct PAConfig {
     static constexpr uint32_t PIJ_SLOT_SIZE = QT * MAX_BLOCK_SIZE * sizeof(bfloat16_t);
     static constexpr uint32_t OI_SLOT_SIZE = QT * HEAD_DIM * sizeof(float);
 
-    using SijPipeT = TPipe<SIJ_FLAG_ID, Direction::DIR_C2V, SIJ_SLOT_SIZE, FIFO_DEPTH>;
-    using PijPipeT = TPipe<PIJ_FLAG_ID, Direction::DIR_V2C, PIJ_SLOT_SIZE, FIFO_DEPTH>;
-    using OiPipeT = TPipe<OI_FLAG_ID, Direction::DIR_C2V, OI_SLOT_SIZE, FIFO_DEPTH>;
+    // The FIFOs are GM ring buffers the orchestration allocates, so the pipes
+    // take the _GM directions; plain DIR_C2V / DIR_V2C select A5's on-chip
+    // VEC_FIFO path, which ignores the GM base entirely.
+    using SijPipeT = TPipe<SIJ_FLAG_ID, Direction::DIR_C2V_GM, SIJ_SLOT_SIZE, FIFO_DEPTH>;
+    using PijPipeT = TPipe<PIJ_FLAG_ID, Direction::DIR_V2C_GM, PIJ_SLOT_SIZE, FIFO_DEPTH>;
+    using OiPipeT = TPipe<OI_FLAG_ID, Direction::DIR_C2V_GM, OI_SLOT_SIZE, FIFO_DEPTH>;
 
     // AIV UB consumer buffer layout (sized for SUB_QT rows per AIV lane)
     static constexpr uint32_t SIJ_UB_BASE = 0x0;
@@ -194,7 +197,11 @@ static __aicore__ void aic_pv_step(
     GlobalB_PV vjGlobal(val_base + kv_block_id * N * K);
     TLOAD(bMatTile_PV, vjGlobal);
 
-    TPOP<PijPipeT, PijMatTile, TileSplitAxis::TILE_NO_SPLIT>(pij_pipe, pijMatTile);
+    // Cube consumes the whole Q_TILE tile, but the split axis also selects the
+    // two-lane sync: only a non-NO_SPLIT pop waits on, and frees, both AIV
+    // lanes' flag spaces (`flagId + VEC_CORE_ID_OFFSET`). The Mat-from-GM pop
+    // ignores the axis for addressing, so this is a sync-only distinction.
+    TPOP<PijPipeT, PijMatTile, TileSplitAxis::TILE_UP_DOWN>(pij_pipe, pijMatTile);
 
     // PV step uses EVENT_ID1 (QK step uses EVENT_ID0) to avoid flag aliasing
     // when pipe_barrier(PIPE_ALL) is removed between steps.

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
@@ -133,9 +133,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     uint32_t oi_fifo_total = static_cast<uint32_t>(SPMD_BLOCK_NUM) * OI_SLOT_SIZE * FIFO_DEPTH;
 
     // Allocate as 1D byte tensors (using INT32 for 4-byte alignment, divide by 4)
-    uint32_t sij_fifo_shapes[1] = {sij_fifo_total / sizeof(int32_t)};
-    uint32_t pij_fifo_shapes[1] = {pij_fifo_total / sizeof(int32_t)};
-    uint32_t oi_fifo_shapes[1] = {oi_fifo_total / sizeof(int32_t)};
+    uint32_t sij_fifo_shapes[1] = {static_cast<uint32_t>(sij_fifo_total / sizeof(int32_t))};
+    uint32_t pij_fifo_shapes[1] = {static_cast<uint32_t>(pij_fifo_total / sizeof(int32_t))};
+    uint32_t oi_fifo_shapes[1] = {static_cast<uint32_t>(oi_fifo_total / sizeof(int32_t))};
 
     TensorCreateInfo sij_fifo_ci(sij_fifo_shapes, 1, DataType::INT32);
     TensorCreateInfo pij_fifo_ci(pij_fifo_shapes, 1, DataType::INT32);

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py
@@ -50,19 +50,54 @@ class TestSpmdPagedAttentionA5(SceneTestCase):
         ],
     }
 
+    # Same names and shapes as the a2a3 TMR cases. Onboard only: the MIX
+    # kernel's TPUSH/TPOP path does not build for the CPU simulator (PTO-ISA
+    # rejects the ColMajor TMULS in the softmax tail). See #1832.
     CASES = [
         {
-            "name": "TwoWayOneBlockZeroQuery",
-            "platforms": ["a5sim", "a5"],
-            "manual": True,
+            "name": "Case1",
+            "platforms": ["a5"],
             "params": {
-                "batch": 2,
+                "batch": 256,
                 "num_heads": 16,
                 "kv_head_num": 1,
                 "head_dim": 128,
                 "block_size": 128,
-                "context_len": 128,
-                "max_model_len": 256,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            # num_heads == MAX_Q_TILE selects the kernel's q_tile == 64 path.
+            "name": "Case2",
+            "platforms": ["a5"],
+            "manual": True,
+            "params": {
+                "batch": 64,
+                "num_heads": 64,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 64,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            # batch == SPMD_BLOCK_NUM, so every hardware block gets exactly one
+            # logical block.
+            "name": "SmallCase1",
+            "platforms": ["a5"],
+            "manual": True,
+            "params": {
+                "batch": 24,
+                "num_heads": 16,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 128,
+                "context_len": 8192,
+                "max_model_len": 32768,
                 "dtype": "bfloat16",
             },
         },
@@ -71,8 +106,6 @@ class TestSpmdPagedAttentionA5(SceneTestCase):
     def generate_args(self, params):
         specs = []
         for name, value in _pa_generate_inputs(params):
-            if name == "query":
-                value.zero_()
             specs.append(TensorArg(name, value) if isinstance(value, torch.Tensor) else Scalar(name, value))
         return TaskArgsBuilder(*specs)
 


### PR DESCRIPTION
## Summary

The A5 port of the SPMD paged-attention MIX kernel produced wrong results for any
non-zero query, and hung outright once a workload spanned more than `FIFO_DEPTH`
KV blocks. Both are defects in how the kernel drives the PTO-ISA TPUSH/TPOP pipes
on A5. With them fixed, A5 runs the a2a3 shapes at the unchanged `FIFO_DEPTH = 2`,
so the A5 cases become `Case1` / `Case2` / `SmallCase1` with the same parameters
and names as a2a3.

## The two kernel defects

**1. Pipe direction — the GM ring was never used.** The three FIFOs are GM ring
buffers the orchestration allocates, but the pipes were declared with `DIR_C2V` /
`DIR_V2C`. On A5 those select the on-chip VEC_FIFO path, which ignores the GM base
entirely — `popTileFromVecFiFo` only ever reads `C2V_CONSUMER_BUF`. That path also
strides local slots by a full `SLOT_SIZE`, while the kernel budgets its UB at
`2 * SUB_QT * MAX_BLOCK_SIZE * sizeof(float)`. For `q_tile = 16` both are 8192 B,
so slot 1 starts exactly at `OI_UB_BASE` and overlaps the entire oi buffer.

A5 has `DIR_C2V_GM` / `DIR_V2C_GM` for GM-backed rings; they are behind
`#ifdef PTO_NPU_ARCH_A5` and a2a3 has no such distinction, which is how the port
inherited the wrong spelling. `examples/a5/tensormap_and_ringbuffer/bgemm` is the
correct use of the on-chip form — it passes `nullptr` as the GM base.

**2. Split axis on the Cube's pij pop.** The Cube consumes the whole `Q_TILE`
tile, so `TILE_NO_SPLIT` looked right. But the split axis also selects the
two-lane sync: `setIntraBlockBySplit` / `waitIntraBlockBySplit` only touch the
second AIV lane's flag space (`flagId + VEC_CORE_ID_OFFSET`) when the axis is not
`NO_SPLIT`. So `free()` released only lane 0's slot, and `wait()` observed only
lane 0's data-ready — letting the Cube read a pij tile lane 1 had not finished
writing. `popMatTileFromGMFiFo` ignores the axis for addressing, so `TILE_UP_DOWN`
changes synchronization only, not the data path.

That single omission produced both symptoms:

- **The hang.** Lane 1 never saw a slot freed, so it blocked on its third push —
  `shouldWaitFree` returns false while `tileIndex < SlotNum`, which is why the
  boundary sat exactly at `FIFO_DEPTH`. The predicate is cumulative per hardware
  block, since the pipe's `tileIndex` is not reset across the stride loop:
  `(logical blocks on that hw block) * n_blocks > FIFO_DEPTH`. At the stock depth
  of 2 the a2a3 shapes need 704 / 384 / 64 pushes.
- **The wrong values.** The Cube racing lane 1's pij write.

## Coverage changes

- **The A5 cases become the a2a3 shapes and names.** The previous A5 case zeroed
  the query, which makes `sij` zero regardless of how K is loaded, so it exercised
  only the PV path and the final normalization — it passed throughout while every
  non-zero query was wrong. It is replaced rather than kept. `Case1` is
  non-manual, mirroring a2a3; `Case2` and `SmallCase1` stay manual.
- **`host_build_graph` mirrors `tensormap_and_ringbuffer`** on both architectures,
  instead of carrying a single small zero-query case. All HBG cases stay manual.
- **Simulator coverage is dropped for this workload.** The MIX kernel does not
  build for the CPU simulator: PTO-ISA rejects the ColMajor `TMULS` in the softmax
  tail. `a2a3sim` / `a5sim` are removed from the case lists, and the `__CPU_SIM`
  compatibility shim, which only existed to get that build further, goes with it.
- The FIFO tensor shapes in both orchestrations get an explicit cast: the division
  by `sizeof` yields `size_t`, and narrowing it inside a braced initializer is an
  error for Clang.

## Verification

Onboard on a2a3 (`Ascend910 / 9392`, CANN 9.0.0) and a5 (`Ascend950PR / 9579`,
CANN 9.2.0), every run wrapped in `task-submit`. All 12 declared cases pass:

| Platform / runtime | Case1 | Case2 | SmallCase1 |
| --- | --- | --- | --- |
| a2a3 tensormap_and_ringbuffer | pass | pass | pass |
| a2a3 host_build_graph | pass | pass | pass |
| a5 tensormap_and_ringbuffer | pass | pass | pass |
| a5 host_build_graph | pass | pass | pass |

Both selections were exercised on each architecture: `--manual include` (the full
sweep above) and the default Per-PR selection, which collects exactly one node per
architecture — the non-manual `Case1` — and passes.

Because the second defect was a race, the three shapes were re-run individually on
a5: **5/5 pass each, 15/15 total**.

The diagnosis rests on these measurements, all on a5:

- Hang boundary follows `FIFO_DEPTH`. At depth 2, `n_blocks` 1 and 2 passed while
  3 and 4 returned 507014 and 8 returned 507018. At depth 4, `n_blocks` 3 and 4
  passed and 8 returned 507014. At depth 8, `batch = 64` — 6 cumulative pushes —
  stopped hanging. It is not "merely slow": it still stalled under
  `PTO2_SCHEDULER_TIMEOUT_MS=60000`, reported as `sched_error_code=100`,
  `sub_class=S1:running-stalled`, `completed=0/1`.
- The race, measured at depth 8 so nothing hung, `n_blocks = 2`: batch 2 and 4
  passed 5/5; batch 8 passed 2/5; batch 10 passed 1/3; batch 9 failed 3/3; batches
  12, 14, 16, 18, 20, 24 and 64 failed every run, `max_diff` 0.12–0.22. The
  non-monotonic, reproducibly flaky pattern is what identified it as a race rather
  than a size limit.

Ruled out along the way, each by measurement rather than inspection: porting the
a2a3 `setEntryOffset` lane-split fix-up (made it worse, 0.44 → 6.18); passing
`sub_block_id` through the `TPUSH`/`TPOP` overloads (bit-identical output, so A5
already returns the correct lane id); flag-ID overlap between the three pipes (the
`_GM` directions use only `FlagID` and `FlagID + 1`); a missing `TFREE` (the `_GM`
pop paths return `reqFree = true` and `TPOP_IMPL` already frees); `SPMD_BLOCK_NUM`
over-subscribing A5; and per-hardware-block GM FIFO regions overlapping.

Closes #1816
Refs #1832
