### PR TITLE
Fix: initialize DSv4 decode buffers on device instead of the orchestrator

### DIFF
--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/README.md
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/README.md
@@ -2,7 +2,7 @@
 
 The `tensormap_and_ringbuffer` DeepSeek-V4 case
 (`examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/`) run under
-`host_build_graph`: same 43-layer network, same 367 kernels, same fixture, same
+`host_build_graph`: same 43-layer network, same 368 kernels, same fixture, same
 comm-window protocol. Only the runtime changes — HBG compiles the orchestration
 with the host `g++`, runs it on the host CPU instead of the AICPU, and ships the
 built shared-memory image to the device, which then boots scheduler-only.
@@ -13,9 +13,9 @@ device can execute what the host built. It is deliberately not a numerics test.
 ## What differs from the TMR case
 
 `kernels/orchestration/decode_fwd_hostbuild.cpp` is the TMR orchestration with
-two edits, **51 lines in all**, kept as the non-Graph baseline.
+one runtime-specific rewrite, kept as the non-Graph baseline.
 `kernels/orchestration/decode_fwd_graph.cpp` — the file the test points at —
-carries the same two edits and additionally recasts the 20-iteration decoder
+carries the same rewrite and additionally recasts the 20-iteration decoder
 layer loop (40 of the 43 layers) as one `rt_submit_graph` per iteration: the
 layer's task set becomes the Graph body (a free function reading its per-layer
 views, scales and indices through `GraphTaskArgs`, positionally), and the host
@@ -25,11 +25,15 @@ tasks individually. The runtime is untouched.
 | Edit | Sites | Why |
 | ---- | ----- | --- |
 | `get_tensor_data(recv_count_out, …)` → `HBG_RECV_ROWS_PER_EXPERT` | 10 | HBG builds the whole graph before the device runs anything, so a read of a **task-produced** tensor has no value to return. The constant holds the per-expert tile loops at their real trip count (`ceil(16/16) == 1`, which is what the `h_i8 [512, 2048]` layout budgets per expert). |
-| `set_initial_value(0)` dropped | 6 | The fill target is a GM-heap **device** address and the host orchestrator cannot store to it. Leaving the call in place segfaults the chip subprocess; dropping it leaves the `mixes_raw` AtomicAdd destination uninitialized — see "Runtime gaps" below. |
-
 The other **31** `get_tensor_data` reads are left alone: they read external
 tensors (`ext_num_tokens_per_owner`, `hc_attn_scale_*`, `hc_ffn_scale_*`), which
 the runtime stages with a host view and which therefore return real values.
+
+The six former orchestration-side initializations are now identical under both
+runtimes. Each `sh_gate_up_act_q*` producer clears its own two padded
+`h_tile_i8` rows, while a dedicated AIV seed task clears `mixes_raw` before the
+split-K `hc_head_linear` AtomicAdds. The host therefore never writes a GM-heap
+device address.
 
 Everything else — submit order, dependencies, scope nesting, and the
 orchestration-side `valid_rows = min(n_rows - t0, 16)` — is byte-identical to
@@ -90,7 +94,7 @@ network on hardware. The failure reproduced at the identical task and
 | --------- | --- |
 | pto-isa version | Stalls identically on `83d01313`, `0cefc9a5` and `f51c92f6`. (The *earlier* stall at task 2307 — issue #1839 — is a genuine ISA regression and **is** fixed by `f51c92f6`; it is a different stall.) |
 | The orchestration edits above | An earlier variant that instead used dispatch predicates and a static tile grid stalls at the same task. So does one with the predicate rewrite removed. |
-| `set_initial_value` | Present and absent both fail identically. It is not the MTE cause, but its removal remains a separate numerical-correctness gap. |
+| `set_initial_value` | Present and absent both fail identically, so it was not the MTE cause. The calls have since been replaced with device-side initialization kernels. |
 | Runtime modifications | A `host_tensor_fill` seam was written to support `set_initial_value` on HBG and later reverted; the stall is identical with it, without it, and on a pristine tree. |
 | A different TMR kernel binary | The HBG and TMR `hc_head_linear` binaries are byte-identical. TMR completing this kernel was an allocation-layout mask, not evidence that its memory accesses were valid. |
 | Kernel-internal spin | In the failing binary all loop bounds are compile-time constants and `t_dim`/`t_linear` are unused in the body. `ptoas_auto_sync_tail(kBarrierAll)` expands to `pipe_barrier(PIPE_ALL)` — intra-core, not cross-core. There is no cross-block synchronization to deadlock on. |
@@ -119,16 +123,10 @@ The two `x_flat` views and TLOAD tiles, dependent matmul/accumulator tiles, and
 the `mixes_raw` AtomicAdd store now all use `valid_rows`. It is eight for this
 invocation, so no instruction addresses a non-existent input row.
 
-## Runtime gaps this case exposed
+## Runtime gap this case exposed
 
-These gaps are independent of the `hc_head_linear` MTE fault:
+This gap is independent of the `hc_head_linear` MTE fault:
 
-- **AtomicAdd destinations cannot currently be initialized correctly by HBG.**
-  TMR calls `set_initial_value(0)` for `mixes_raw`, whose final TSTORE uses
-  `AtomicAdd`. HBG drops that call because its host `memcpy` cannot write the GM
-  device address, so the accumulation target remains undefined. This did not
-  cause the MTE fault, but HBG needs a device-side zero before it can validate
-  numerical results.
 - **`get_tensor_data` on a task-produced tensor burns its full timeout.** The
   wait can never be satisfied in this runtime — the device does not execute until
   orchestration finishes — yet `wait_for_tensor_ready` spins the whole 15 s before
@@ -146,7 +144,7 @@ pytest examples/a2a3/host_build_graph/deepseek_v4_flash_decode \
     --platform a2a3 --device <d0>,<d1> --manual only
 ```
 
-`manual` because the 367-kernel compile takes minutes; `skip_golden` because the
+`manual` because the 368-kernel compile takes minutes; `skip_golden` because the
 routing is stood in, not computed.
 
 To exercise only the host side without launching the device body, set
@@ -174,7 +172,7 @@ Kernels, fixture and orchestration come from the TMR case; see its
 [README](../../tensormap_and_ringbuffer/deepseek_v4_flash_decode/README.md) for
 network shape, regeneration steps and cost. Two orchestration files are specific
 to this case: `kernels/orchestration/decode_fwd_hostbuild.cpp` (the TMR
-orchestration with the two edits in the table above — the host-orchestration
+orchestration with the rewrite in the table above — the host-orchestration
 baseline the investigation was run against) and
 `kernels/orchestration/decode_fwd_graph.cpp` (the same program recast as a
 Graph, which the test points at). The Graph variant is derivable from the

--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd_graph.cpp
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd_graph.cpp
@@ -11528,8 +11528,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         rt_submit_aiv_task(354, params_t342);
         uint32_t mixes_raw_inline13234_ci_shapes[2] = {static_cast<uint32_t>(t_linear_inline13230), 16};
         TensorCreateInfo mixes_raw_inline13234_ci(mixes_raw_inline13234_ci_shapes, 2, DataType::FLOAT32);
-        TaskOutputTensors alloc_144 = alloc_tensors(mixes_raw_inline13234_ci);
-        const ChipTensor &mixes_raw_inline13234 = alloc_144.get_ref(0);
+
+        // Seed the split-K AtomicAdd destination on device before any contributor runs.
+        CoreTaskArgs params_hc_head_mixes_zero;
+        params_hc_head_mixes_zero.add_output(mixes_raw_inline13234_ci);
+        params_hc_head_mixes_zero.launch_spec.set_block_num(((t_linear_inline13230 + 15) / 16));
+        TaskOutputTensors hc_head_mixes_zero_outs = rt_submit_aiv_task(367, params_hc_head_mixes_zero);
+        const ChipTensor &mixes_raw_inline13234 = hc_head_mixes_zero_outs.get_ref(0);
+        PTO2TaskId hc_head_mixes_zero_tid = hc_head_mixes_zero_outs.task_id();
 
         // Spmd hc_head_linear_spmd: hc_head_linear
         CoreTaskArgs params_t343;
@@ -11537,6 +11543,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t343.add_input(ext_hc_head_fn);
         params_t343.add_inout(mixes_raw_inline13234);
         params_t343.launch_spec.set_block_num(((t_linear_inline13230 / 16) * 16));
+        PTO2TaskId params_t343_deps[1];
+        params_t343_deps[0] = hc_head_mixes_zero_tid;
+        params_t343.set_dependencies(params_t343_deps, 1);
         rt_submit_aic_task(355, params_t343);
 
         // Spmd hc_head_reduce_spmd: hc_head_reduce

--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd_hostbuild.cpp
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd_hostbuild.cpp
@@ -11302,8 +11302,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         rt_submit_aiv_task(354, params_t342);
         uint32_t mixes_raw_inline13234_ci_shapes[2] = {static_cast<uint32_t>(t_linear_inline13230), 16};
         TensorCreateInfo mixes_raw_inline13234_ci(mixes_raw_inline13234_ci_shapes, 2, DataType::FLOAT32);
-        TaskOutputTensors alloc_144 = alloc_tensors(mixes_raw_inline13234_ci);
-        const ChipTensor &mixes_raw_inline13234 = alloc_144.get_ref(0);
+
+        // Seed the split-K AtomicAdd destination on device before any contributor runs.
+        CoreTaskArgs params_hc_head_mixes_zero;
+        params_hc_head_mixes_zero.add_output(mixes_raw_inline13234_ci);
+        params_hc_head_mixes_zero.launch_spec.set_block_num(((t_linear_inline13230 + 15) / 16));
+        TaskOutputTensors hc_head_mixes_zero_outs = rt_submit_aiv_task(367, params_hc_head_mixes_zero);
+        const ChipTensor &mixes_raw_inline13234 = hc_head_mixes_zero_outs.get_ref(0);
+        PTO2TaskId hc_head_mixes_zero_tid = hc_head_mixes_zero_outs.task_id();
 
         // Spmd hc_head_linear_spmd: hc_head_linear
         CoreTaskArgs params_t343;
@@ -11311,6 +11317,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t343.add_input(ext_hc_head_fn);
         params_t343.add_inout(mixes_raw_inline13234);
         params_t343.launch_spec.set_block_num(((t_linear_inline13230 / 16) * 16));
+        PTO2TaskId params_t343_deps[1];
+        params_t343_deps[0] = hc_head_mixes_zero_tid;
+        params_t343.set_dependencies(params_t343_deps, 1);
         rt_submit_aic_task(355, params_t343);
 
         // Spmd hc_head_reduce_spmd: hc_head_reduce

--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
@@ -8,7 +8,7 @@
 # -----------------------------------------------------------------------------------------------------------
 """DeepSeek-V4 FLASH decode on host_build_graph: same program, host-run orchestration.
 
-The 43-layer network, its 367 kernels and its fixture come from the
+The 43-layer network, its 368 kernels and its fixture come from the
 ``tensormap_and_ringbuffer`` case; only the runtime changes. HBG compiles the
 orchestration with the host g++, runs it on the host CPU instead of the AICPU,
 and ships the built SM image to the device, which boots scheduler-only.
@@ -19,16 +19,16 @@ loop (40 of the 43 layers) submits one ``rt_submit_graph`` per iteration whose
 body is the layer's full task set, so the host records a 744-node Definition
 once and the 15991-task network collapses to 1131 host-submitted tasks. The ten
 ``get_tensor_data`` reads of ``recv_count_out`` (a task-produced tensor,
-unreadable while the host builds the graph) stand in a constant, and the six
-``set_initial_value`` calls are dropped because their target is a GM-heap
-device address. The graph therefore keeps the size and shape of the real one
-but not the fixture's routing — hence ``skip_golden``. ``manual`` because the
-367-kernel compile takes minutes.
+unreadable while the host builds the graph) stand in a constant. Tensor
+initialization is shared with the TMR case and runs in AIV kernels, so the host
+never writes a GM-heap device address. The graph therefore keeps the size and
+shape of the real one but not the fixture's routing — hence ``skip_golden``.
+``manual`` because the 368-kernel compile takes minutes.
 
-Host construction and Graph recording complete (1131 tasks on host); device
-execution of the non-graph remainder currently stalls 12 tasks from the end.
-See README.md for the measurement, what has been ruled out, and what is still
-open.
+Host construction and Graph recording complete (1131 tasks on host). An
+unskipped Graph-form device run is currently blocked earlier, during Graph
+activation; the non-Graph baseline completes its device body. See README.md for
+the measurements and remaining Graph-runtime limitation.
 
     python examples/a2a3/host_build_graph/deepseek_v4_flash_decode/\\
 test_deepseek_v4_flash_decode.py -p a2a3 -d <d0>,<d1> --manual only
@@ -65,15 +65,14 @@ def _host_build_graph_callable():
     and the orchestration swapped for the predicated-dispatch variant.
 
     ``decode_fwd_hostbuild.cpp`` is the tensormap_and_ringbuffer orchestration
-    with two edits, 51 lines in all, and the runtime untouched. HBG runs the
+    with one runtime-specific rewrite and the runtime untouched. HBG runs the
     orchestrator on the host before the device executes anything, so the ten
     ``get_tensor_data(recv_count_out)`` reads (a task-produced tensor driving the
     MoE per-expert tile loops) have no value to return; they are replaced by
     ``HBG_RECV_ROWS_PER_EXPERT``, which holds the tile loops at their real trip
-    count. The six ``set_initial_value`` calls are dropped because the host
-    cannot store to the GM-heap address they target. The other 31
-    ``get_tensor_data`` reads are external tensors the runtime stages with a host
-    view, and are left alone.
+    count. The other 31 ``get_tensor_data`` reads are external tensors the
+    runtime stages with a host view, and are left alone. The shared orchestration
+    submits the same device-side initialization kernels under both runtimes.
 
     The graph therefore keeps the size and shape of the real one but not the
     fixture's routing, which is why the case is ``skip_golden``: it measures

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/README.md
@@ -1,7 +1,7 @@
 # DeepSeek-V4 FLASH full decode network (EP2 / TP2, 2 dies)
 
 The complete DeepSeek-V4 FLASH 43-layer decode forward as one scene test:
-pypto-generated chip orchestration + 367 incore kernels per rank, dispatched to
+pypto-generated chip orchestration + 368 incore kernels per rank, dispatched to
 two dies that cooperate through a communication domain (expert-parallel MoE
 dispatch/combine and a TP-sharded LM head). This is the first pypto-harvested
 **distributed** network in the repo — the single-chip counterpart is
@@ -36,16 +36,25 @@ CI terms: the harvested distributed program compiles, both ranks' graphs
 dispatch, the cross-die window protocol (TPUT/TNOTIFY arrivals, LM-head
 all-gather) drains, and the run terminates cleanly.
 
-It is marked `manual`: compiling 367 incore kernels plus the 7.8k-line chip
+It is marked `manual`: compiling 368 incore kernels plus the 7.8k-line chip
 orchestration takes several minutes, so it does not run in the default sweep.
 
-## Status: blocked on the #1644 pto-isa pin bump
+The six buffer initializations formerly expressed as orchestration-side
+`set_initial_value(0)` calls now run on device. Each of the five
+`sh_gate_up_act_q*` kernels clears the two padded `h_tile_i8` rows owned by its
+logical block. The dedicated `hc_head_mixes_zero` seed kernel clears one
+up-to-16-row chunk of the dynamic `mixes_raw` split-K destination per logical
+block; an explicit task dependency orders all `hc_head_linear` `AtomicAdd`
+stores after it.
+
+## Status: blocked on this branch's pto-isa pin
 
 The case PASSES on every runtime from the wire-ABI cutover (#1729, the earliest
 commit whose scene-test plumbing can host it) through #1771 — all of which pin
 pto-isa `83d01313`, the commit these kernels were generated against. From
 `7a1b9b11` ("CI: bump pinned pto-isa for PTOAS v0.55", pto-isa -> `0cefc9a5`)
-onward, including current main, both ranks stall mid-network: two kernels spin
+onward, including this branch's `0cefc9a5` pin, both ranks stall mid-network:
+two kernels spin
 forever on comm-window arrival counters, the AICPU orchestrator times out
 reading `recv_count_out` (`TENSOR_WAIT_TIMEOUT`, "producer not completed"), and
 the scheduler exits `S1:running-stalled`. The stall layer moves with fixture
@@ -85,14 +94,16 @@ Harvested with `RunConfig` defaults (`--start-pos 8192`, `--num-tokens 8`,
 | pypto | `289290e6` |
 | simpler (pypto `runtime/` pin at harvest) | `3165cc89` |
 | ptoas | `v0.57` |
-| pto-isa | `83d01313d9bfc247c4b7c8bcf969d1019f0d106f` (= `pto_isa.pin`) |
+| pto-isa used for generation | `83d01313d9bfc247c4b7c8bcf969d1019f0d106f` |
 
-There are no hand-edits: every `kernels/**/*.cpp` is the pypto codegen output
-plus three mechanical, reproducible transforms — the license header, the repo's
-`clang-format`, and the whole-word renames `L2TaskArgs -> ChipTaskArgs`,
-`L0TaskArgs -> CoreTaskArgs`, `Tensor -> ChipTensor` (pypto's codegen still
-emits the pre-rename identifiers of its pinned runtime `3165cc89`; simpler
-renamed them on main per the role-based naming rule, with no compat alias). `test_deepseek_v4_flash_decode.py`'s
+The harvested files start from pypto codegen output plus three mechanical,
+reproducible transforms — the license header, the repo's `clang-format`, and
+the whole-word renames `L2TaskArgs -> ChipTaskArgs`, `L0TaskArgs -> CoreTaskArgs`,
+`Tensor -> ChipTensor` (pypto's codegen still emits the pre-rename identifiers
+of its pinned runtime `3165cc89`; simpler renamed them on main per the role-based
+naming rule, with no compat alias). The intentional post-harvest edits are the
+`hc_head_linear` row-tail bound and the device-side initialization described
+above; regeneration must reapply both. `test_deepseek_v4_flash_decode.py`'s
 `_KERNELS` / `_ORCH_SIG` tables are transcribed from the harvest's
 `kernel_config.py`, and `_ARG_STEPS` / the comm-domain layout from its
 generated `host_orch.py` (per-rank stacked slices become the `_r0`/`_r1` host

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/hc_head_mixes_zero.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/hc_head_mixes_zero.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+// Kernel Function: hc_head_mixes_zero
+
+#include <cstdint>
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#if defined(__CPU_SIM)
+#define __aicore__
+#else
+#define __aicore__ [aicore]
+#endif
+#endif
+
+#include <pto/pto-inst.hpp>
+#include "tensor.h"
+#include "intrinsic.h"
+
+using namespace pto;
+
+enum class PTOAutoSyncTailMode : int {
+    kBarrierAll = 0,
+    kSetWaitMte3ToSEvent0 = 1,
+};
+
+static __aicore__ inline void ptoas_auto_sync_tail(PTOAutoSyncTailMode mode = PTOAutoSyncTailMode::kBarrierAll) {
+    switch (mode) {
+    case PTOAutoSyncTailMode::kSetWaitMte3ToSEvent0:
+        set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+        wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+        break;
+    case PTOAutoSyncTailMode::kBarrierAll:
+    default:
+        pipe_barrier(PIPE_ALL);
+        break;
+    }
+}
+
+static __aicore__ void hc_head_mixes_zero(__gm__ float *mixes_raw, int64_t total_rows, int32_t block_idx) {
+    constexpr float zero = 0.0f;
+    constexpr int64_t rows_per_block = 16;
+    constexpr int64_t cols = 16;
+    int64_t row_base = static_cast<int64_t>(block_idx) * rows_per_block;
+    int64_t remaining_rows = total_rows - row_base;
+    int64_t valid_rows = remaining_rows < rows_per_block ? remaining_rows : rows_per_block;
+
+#if defined(__DAV_VEC__)
+    set_mask_norm();
+    set_vector_mask(-1, -1);
+
+    Tile<
+        TileType::Vec, float, 16, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null,
+        CompactMode::Null>
+        zero_tile = Tile<
+            TileType::Vec, float, 16, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null,
+            CompactMode::Null>(valid_rows, cols);
+    TASSIGN(zero_tile, 0);
+    TEXPANDS(zero_tile, zero);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+    pto::Shape<1, 1, 1, -1, 16> shape = pto::Shape<1, 1, 1, -1, 16>(1, 1, 1, valid_rows, cols);
+    pto::Stride<256, 256, 256, 16, 1> stride = pto::Stride<256, 256, 256, 16, 1>();
+    GlobalTensor<float, pto::Shape<1, 1, 1, -1, 16>, pto::Stride<256, 256, 256, 16, 1>, pto::Layout::ND> output =
+        GlobalTensor<float, pto::Shape<1, 1, 1, -1, 16>, pto::Stride<256, 256, 256, 16, 1>, pto::Layout::ND>(
+            mixes_raw + row_base * cols, shape, stride
+        );
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(output, zero_tile);
+#endif  // __DAV_VEC__
+
+    ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    int32_t block_idx = get_block_idx(args);
+    __gm__ ChipTensor *mixes_raw_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+    __gm__ float *mixes_raw =
+        reinterpret_cast<__gm__ float *>(mixes_raw_tensor->buffer.addr) + mixes_raw_tensor->start_offset;
+    int64_t total_rows = static_cast<int64_t>(mixes_raw_tensor->shapes[0]);
+    hc_head_mixes_zero(mixes_raw, total_rows, block_idx);
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/sh_gate_up_act_q.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/sh_gate_up_act_q.cpp
@@ -98,6 +98,35 @@ static __aicore__ inline void PTOAS__DCCI_SINGLE_CACHE_LINE(Ptr ptr) {
     dcci((__gm__ void *)ptr, cache_line_t::SINGLE_CACHE_LINE);
 }
 
+static __aicore__ inline void zero_h_tile_i8_padding(__gm__ int8_t *h_tile_i8, int32_t block_idx, int32_t block_num) {
+#if defined(__DAV_VEC__)
+    constexpr int8_t zero = 0;
+    constexpr int64_t rows_per_block = 2;
+    constexpr int64_t cols = 2048;
+    const int64_t padding_row = static_cast<int64_t>(block_num + block_idx) * rows_per_block;
+
+    Tile<
+        TileType::Vec, int8_t, 2, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null,
+        CompactMode::Null>
+        zero_tile = Tile<
+            TileType::Vec, int8_t, 2, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null,
+            CompactMode::Null>(rows_per_block, cols);
+    TASSIGN(zero_tile, 0);
+    TEXPANDS(zero_tile, zero);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+    pto::Shape<1, 1, 1, 2, 2048> shape = pto::Shape<1, 1, 1, 2, 2048>();
+    pto::Stride<4096, 4096, 4096, 2048, 1> stride = pto::Stride<4096, 4096, 4096, 2048, 1>();
+    GlobalTensor<int8_t, pto::Shape<1, 1, 1, 2, 2048>, pto::Stride<4096, 4096, 4096, 2048, 1>, pto::Layout::ND> output =
+        GlobalTensor<int8_t, pto::Shape<1, 1, 1, 2, 2048>, pto::Stride<4096, 4096, 4096, 2048, 1>, pto::Layout::ND>(
+            h_tile_i8 + padding_row * cols, shape, stride
+        );
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(output, zero_tile);
+    pipe_barrier(PIPE_MTE3);
+#endif  // __DAV_VEC__
+}
+
 static __aicore__ void sh_gate_up_act_q(
     __gm__ float *v1, __gm__ float *v2, __gm__ int32_t *v3, __gm__ int32_t *v4, __gm__ float *v5, __gm__ float *v6,
     __gm__ float *v7, __gm__ int8_t *v8, int64_t v9, int64_t v10, int32_t v11, int32_t v12
@@ -130,6 +159,7 @@ static __aicore__ void sh_gate_up_act_q(
 #if defined(__DAV_VEC__)
     set_mask_norm();
     set_vector_mask(-1, -1);
+    zero_h_tile_i8_padding(v8, v11, v12);
     // pto: %row_block_inline2664_inline9171__ssa_v0, %20
     int64_t v36 = (int64_t)((uint64_t)((int64_t)v11) * (uint64_t)v25);
     // pto: %x_scale_inline2668_inline9349__tile

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/sh_gate_up_act_q_0.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/sh_gate_up_act_q_0.cpp
@@ -98,6 +98,35 @@ static __aicore__ inline void PTOAS__DCCI_SINGLE_CACHE_LINE(Ptr ptr) {
     dcci((__gm__ void *)ptr, cache_line_t::SINGLE_CACHE_LINE);
 }
 
+static __aicore__ inline void zero_h_tile_i8_padding(__gm__ int8_t *h_tile_i8, int32_t block_idx, int32_t block_num) {
+#if defined(__DAV_VEC__)
+    constexpr int8_t zero = 0;
+    constexpr int64_t rows_per_block = 2;
+    constexpr int64_t cols = 2048;
+    const int64_t padding_row = static_cast<int64_t>(block_num + block_idx) * rows_per_block;
+
+    Tile<
+        TileType::Vec, int8_t, 2, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null,
+        CompactMode::Null>
+        zero_tile = Tile<
+            TileType::Vec, int8_t, 2, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null,
+            CompactMode::Null>(rows_per_block, cols);
+    TASSIGN(zero_tile, 0);
+    TEXPANDS(zero_tile, zero);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+    pto::Shape<1, 1, 1, 2, 2048> shape = pto::Shape<1, 1, 1, 2, 2048>();
+    pto::Stride<4096, 4096, 4096, 2048, 1> stride = pto::Stride<4096, 4096, 4096, 2048, 1>();
+    GlobalTensor<int8_t, pto::Shape<1, 1, 1, 2, 2048>, pto::Stride<4096, 4096, 4096, 2048, 1>, pto::Layout::ND> output =
+        GlobalTensor<int8_t, pto::Shape<1, 1, 1, 2, 2048>, pto::Stride<4096, 4096, 4096, 2048, 1>, pto::Layout::ND>(
+            h_tile_i8 + padding_row * cols, shape, stride
+        );
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(output, zero_tile);
+    pipe_barrier(PIPE_MTE3);
+#endif  // __DAV_VEC__
+}
+
 static __aicore__ void sh_gate_up_act_q_0(
     __gm__ float *v1, __gm__ float *v2, __gm__ int32_t *v3, __gm__ int32_t *v4, __gm__ float *v5, __gm__ float *v6,
     __gm__ float *v7, __gm__ int8_t *v8, int64_t v9, int64_t v10, int32_t v11, int32_t v12
@@ -130,6 +159,7 @@ static __aicore__ void sh_gate_up_act_q_0(
 #if defined(__DAV_VEC__)
     set_mask_norm();
     set_vector_mask(-1, -1);
+    zero_h_tile_i8_padding(v8, v11, v12);
     // pto: %row_block_inline2664_inline9933__ssa_v0, %20
     int64_t v36 = (int64_t)((uint64_t)((int64_t)v11) * (uint64_t)v25);
     // pto: %x_scale_inline2668_inline10111__tile

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/sh_gate_up_act_q_1.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/sh_gate_up_act_q_1.cpp
@@ -98,6 +98,35 @@ static __aicore__ inline void PTOAS__DCCI_SINGLE_CACHE_LINE(Ptr ptr) {
     dcci((__gm__ void *)ptr, cache_line_t::SINGLE_CACHE_LINE);
 }
 
+static __aicore__ inline void zero_h_tile_i8_padding(__gm__ int8_t *h_tile_i8, int32_t block_idx, int32_t block_num) {
+#if defined(__DAV_VEC__)
+    constexpr int8_t zero = 0;
+    constexpr int64_t rows_per_block = 2;
+    constexpr int64_t cols = 2048;
+    const int64_t padding_row = static_cast<int64_t>(block_num + block_idx) * rows_per_block;
+
+    Tile<
+        TileType::Vec, int8_t, 2, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null,
+        CompactMode::Null>
+        zero_tile = Tile<
+            TileType::Vec, int8_t, 2, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null,
+            CompactMode::Null>(rows_per_block, cols);
+    TASSIGN(zero_tile, 0);
+    TEXPANDS(zero_tile, zero);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+    pto::Shape<1, 1, 1, 2, 2048> shape = pto::Shape<1, 1, 1, 2, 2048>();
+    pto::Stride<4096, 4096, 4096, 2048, 1> stride = pto::Stride<4096, 4096, 4096, 2048, 1>();
+    GlobalTensor<int8_t, pto::Shape<1, 1, 1, 2, 2048>, pto::Stride<4096, 4096, 4096, 2048, 1>, pto::Layout::ND> output =
+        GlobalTensor<int8_t, pto::Shape<1, 1, 1, 2, 2048>, pto::Stride<4096, 4096, 4096, 2048, 1>, pto::Layout::ND>(
+            h_tile_i8 + padding_row * cols, shape, stride
+        );
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(output, zero_tile);
+    pipe_barrier(PIPE_MTE3);
+#endif  // __DAV_VEC__
+}
+
 static __aicore__ void sh_gate_up_act_q_1(
     __gm__ float *v1, __gm__ float *v2, __gm__ int32_t *v3, __gm__ int32_t *v4, __gm__ float *v5, __gm__ float *v6,
     __gm__ float *v7, __gm__ int8_t *v8, int64_t v9, int64_t v10, int32_t v11, int32_t v12
@@ -130,6 +159,7 @@ static __aicore__ void sh_gate_up_act_q_1(
 #if defined(__DAV_VEC__)
     set_mask_norm();
     set_vector_mask(-1, -1);
+    zero_h_tile_i8_padding(v8, v11, v12);
     // pto: %row_block_inline2664_inline10978__ssa_v0, %20
     int64_t v36 = (int64_t)((uint64_t)((int64_t)v11) * (uint64_t)v25);
     // pto: %x_scale_inline2668_inline11156__tile

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/sh_gate_up_act_q_2.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/sh_gate_up_act_q_2.cpp
@@ -98,6 +98,35 @@ static __aicore__ inline void PTOAS__DCCI_SINGLE_CACHE_LINE(Ptr ptr) {
     dcci((__gm__ void *)ptr, cache_line_t::SINGLE_CACHE_LINE);
 }
 
+static __aicore__ inline void zero_h_tile_i8_padding(__gm__ int8_t *h_tile_i8, int32_t block_idx, int32_t block_num) {
+#if defined(__DAV_VEC__)
+    constexpr int8_t zero = 0;
+    constexpr int64_t rows_per_block = 2;
+    constexpr int64_t cols = 2048;
+    const int64_t padding_row = static_cast<int64_t>(block_num + block_idx) * rows_per_block;
+
+    Tile<
+        TileType::Vec, int8_t, 2, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null,
+        CompactMode::Null>
+        zero_tile = Tile<
+            TileType::Vec, int8_t, 2, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null,
+            CompactMode::Null>(rows_per_block, cols);
+    TASSIGN(zero_tile, 0);
+    TEXPANDS(zero_tile, zero);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+    pto::Shape<1, 1, 1, 2, 2048> shape = pto::Shape<1, 1, 1, 2, 2048>();
+    pto::Stride<4096, 4096, 4096, 2048, 1> stride = pto::Stride<4096, 4096, 4096, 2048, 1>();
+    GlobalTensor<int8_t, pto::Shape<1, 1, 1, 2, 2048>, pto::Stride<4096, 4096, 4096, 2048, 1>, pto::Layout::ND> output =
+        GlobalTensor<int8_t, pto::Shape<1, 1, 1, 2, 2048>, pto::Stride<4096, 4096, 4096, 2048, 1>, pto::Layout::ND>(
+            h_tile_i8 + padding_row * cols, shape, stride
+        );
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(output, zero_tile);
+    pipe_barrier(PIPE_MTE3);
+#endif  // __DAV_VEC__
+}
+
 static __aicore__ void sh_gate_up_act_q_2(
     __gm__ float *v1, __gm__ float *v2, __gm__ int32_t *v3, __gm__ int32_t *v4, __gm__ float *v5, __gm__ float *v6,
     __gm__ float *v7, __gm__ int8_t *v8, int64_t v9, int64_t v10, int32_t v11, int32_t v12
@@ -130,6 +159,7 @@ static __aicore__ void sh_gate_up_act_q_2(
 #if defined(__DAV_VEC__)
     set_mask_norm();
     set_vector_mask(-1, -1);
+    zero_h_tile_i8_padding(v8, v11, v12);
     // pto: %row_block_inline2664_inline11857__ssa_v0, %20
     int64_t v36 = (int64_t)((uint64_t)((int64_t)v11) * (uint64_t)v25);
     // pto: %x_scale_inline2668_inline12035__tile

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/sh_gate_up_act_q_3.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/sh_gate_up_act_q_3.cpp
@@ -98,6 +98,35 @@ static __aicore__ inline void PTOAS__DCCI_SINGLE_CACHE_LINE(Ptr ptr) {
     dcci((__gm__ void *)ptr, cache_line_t::SINGLE_CACHE_LINE);
 }
 
+static __aicore__ inline void zero_h_tile_i8_padding(__gm__ int8_t *h_tile_i8, int32_t block_idx, int32_t block_num) {
+#if defined(__DAV_VEC__)
+    constexpr int8_t zero = 0;
+    constexpr int64_t rows_per_block = 2;
+    constexpr int64_t cols = 2048;
+    const int64_t padding_row = static_cast<int64_t>(block_num + block_idx) * rows_per_block;
+
+    Tile<
+        TileType::Vec, int8_t, 2, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null,
+        CompactMode::Null>
+        zero_tile = Tile<
+            TileType::Vec, int8_t, 2, 2048, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null,
+            CompactMode::Null>(rows_per_block, cols);
+    TASSIGN(zero_tile, 0);
+    TEXPANDS(zero_tile, zero);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+    pto::Shape<1, 1, 1, 2, 2048> shape = pto::Shape<1, 1, 1, 2, 2048>();
+    pto::Stride<4096, 4096, 4096, 2048, 1> stride = pto::Stride<4096, 4096, 4096, 2048, 1>();
+    GlobalTensor<int8_t, pto::Shape<1, 1, 1, 2, 2048>, pto::Stride<4096, 4096, 4096, 2048, 1>, pto::Layout::ND> output =
+        GlobalTensor<int8_t, pto::Shape<1, 1, 1, 2, 2048>, pto::Stride<4096, 4096, 4096, 2048, 1>, pto::Layout::ND>(
+            h_tile_i8 + padding_row * cols, shape, stride
+        );
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(output, zero_tile);
+    pipe_barrier(PIPE_MTE3);
+#endif  // __DAV_VEC__
+}
+
 static __aicore__ void sh_gate_up_act_q_3(
     __gm__ float *v1, __gm__ float *v2, __gm__ int32_t *v3, __gm__ int32_t *v4, __gm__ float *v5, __gm__ float *v6,
     __gm__ float *v7, __gm__ int8_t *v8, int64_t v9, int64_t v10, int32_t v11, int32_t v12
@@ -130,6 +159,7 @@ static __aicore__ void sh_gate_up_act_q_3(
 #if defined(__DAV_VEC__)
     set_mask_norm();
     set_vector_mask(-1, -1);
+    zero_h_tile_i8_padding(v8, v11, v12);
     // pto: %row_block_inline2664_inline12902__ssa_v0, %20
     int64_t v36 = (int64_t)((uint64_t)((int64_t)v11) * (uint64_t)v25);
     // pto: %x_scale_inline2668_inline13080__tile

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd.cpp
@@ -1986,7 +1986,6 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             TensorCreateInfo h_tile_i8_inline2663_inline9173_ci(
                 h_tile_i8_inline2663_inline9173_ci_shapes, 2, DataType::INT8
             );
-            h_tile_i8_inline2663_inline9173_ci.set_initial_value(0);
             uint32_t h_tile_scale_dq_inline2676_inline9243_ci_shapes[2] = {16, 8};
             TensorCreateInfo h_tile_scale_dq_inline2676_inline9243_ci(
                 h_tile_scale_dq_inline2676_inline9243_ci_shapes, 2, DataType::FLOAT32, /*manual_dep=*/true
@@ -3417,7 +3416,6 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             TensorCreateInfo h_tile_i8_inline2663_inline9935_ci(
                 h_tile_i8_inline2663_inline9935_ci_shapes, 2, DataType::INT8
             );
-            h_tile_i8_inline2663_inline9935_ci.set_initial_value(0);
             uint32_t h_tile_scale_dq_inline2676_inline10005_ci_shapes[2] = {16, 8};
             TensorCreateInfo h_tile_scale_dq_inline2676_inline10005_ci(
                 h_tile_scale_dq_inline2676_inline10005_ci_shapes, 2, DataType::FLOAT32, /*manual_dep=*/true
@@ -6051,7 +6049,6 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 TensorCreateInfo h_tile_i8_inline2663_inline10980_ci(
                     h_tile_i8_inline2663_inline10980_ci_shapes, 2, DataType::INT8
                 );
-                h_tile_i8_inline2663_inline10980_ci.set_initial_value(0);
                 uint32_t h_tile_scale_dq_inline2676_inline11050_ci_shapes[2] = {16, 8};
                 TensorCreateInfo h_tile_scale_dq_inline2676_inline11050_ci(
                     h_tile_scale_dq_inline2676_inline11050_ci_shapes, 2, DataType::FLOAT32, /*manual_dep=*/true
@@ -8192,7 +8189,6 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 TensorCreateInfo h_tile_i8_inline2663_inline11859_ci(
                     h_tile_i8_inline2663_inline11859_ci_shapes, 2, DataType::INT8
                 );
-                h_tile_i8_inline2663_inline11859_ci.set_initial_value(0);
                 uint32_t h_tile_scale_dq_inline2676_inline11929_ci_shapes[2] = {16, 8};
                 TensorCreateInfo h_tile_scale_dq_inline2676_inline11929_ci(
                     h_tile_scale_dq_inline2676_inline11929_ci_shapes, 2, DataType::FLOAT32, /*manual_dep=*/true
@@ -10762,7 +10758,6 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             TensorCreateInfo h_tile_i8_inline2663_inline12904_ci(
                 h_tile_i8_inline2663_inline12904_ci_shapes, 2, DataType::INT8
             );
-            h_tile_i8_inline2663_inline12904_ci.set_initial_value(0);
             uint32_t h_tile_scale_dq_inline2676_inline12974_ci_shapes[2] = {16, 8};
             TensorCreateInfo h_tile_scale_dq_inline2676_inline12974_ci(
                 h_tile_scale_dq_inline2676_inline12974_ci_shapes, 2, DataType::FLOAT32, /*manual_dep=*/true
@@ -11313,9 +11308,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         rt_submit_aiv_task(354, params_t342);
         uint32_t mixes_raw_inline13234_ci_shapes[2] = {static_cast<uint32_t>(t_linear_inline13230), 16};
         TensorCreateInfo mixes_raw_inline13234_ci(mixes_raw_inline13234_ci_shapes, 2, DataType::FLOAT32);
-        mixes_raw_inline13234_ci.set_initial_value(0);
-        TaskOutputTensors alloc_144 = alloc_tensors(mixes_raw_inline13234_ci);
-        const ChipTensor &mixes_raw_inline13234 = alloc_144.get_ref(0);
+
+        // Seed the split-K AtomicAdd destination on device before any contributor runs.
+        CoreTaskArgs params_hc_head_mixes_zero;
+        params_hc_head_mixes_zero.add_output(mixes_raw_inline13234_ci);
+        params_hc_head_mixes_zero.launch_spec.set_block_num(((t_linear_inline13230 + 15) / 16));
+        TaskOutputTensors hc_head_mixes_zero_outs = rt_submit_aiv_task(367, params_hc_head_mixes_zero);
+        const ChipTensor &mixes_raw_inline13234 = hc_head_mixes_zero_outs.get_ref(0);
+        PTO2TaskId hc_head_mixes_zero_tid = hc_head_mixes_zero_outs.task_id();
 
         // Spmd hc_head_linear_spmd: hc_head_linear
         CoreTaskArgs params_t343;
@@ -11323,6 +11323,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t343.add_input(ext_hc_head_fn);
         params_t343.add_inout(mixes_raw_inline13234);
         params_t343.launch_spec.set_block_num(((t_linear_inline13230 / 16) * 16));
+        PTO2TaskId params_t343_deps[1];
+        params_t343_deps[0] = hc_head_mixes_zero_tid;
+        params_t343.set_dependencies(params_t343_deps, 1);
         rt_submit_aic_task(355, params_t343);
 
         // Spmd hc_head_reduce_spmd: hc_head_reduce

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
@@ -25,11 +25,11 @@ This is a completion/smoke case (``skip_golden``): upstream pypto-lib runs the
 same fixture with ``golden_fn=None`` (component-level golden checks live with
 the standalone kernels there); a full-network torch reference does not exist
 in either repo. The case validates that the harvested distributed program —
-367 incore kernels plus a 7.8k-line chip orchestration per rank — compiles,
+368 incore kernels plus a 7.8k-line chip orchestration per rank — compiles,
 dispatches across both dies, drives the comm-window protocol to completion,
 and terminates cleanly.
 
-The case is marked ``manual`` (compiling 367 kernels takes several minutes);
+The case is marked ``manual`` (compiling 368 kernels takes several minutes);
 run it explicitly:
 
     python examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/\
@@ -423,6 +423,7 @@ _KERNELS = [
     (364, "lm_head_combine_gather", "aiv", "oi"),
     (365, "lm_head_signal_clear", "aiv", "ioo"),
     (366, "lm_head_greedy_sample", "aiv", "ix"),
+    (367, "hc_head_mixes_zero", "aiv", "o"),
 ]
 
 # Chip orchestration tensor-argument directions (scalars excluded), from kernel_config.py.


### PR DESCRIPTION
## What

Replaces the six orchestration-side `set_initial_value(0)` calls in the DeepSeek-V4 FLASH decode cases with device-side initialization, so the TMR and HBG orchestrations are now identical here and the host never writes a GM-heap device address (previously a segfault under HBG, worked around by dropping the calls and leaving `mixes_raw` undefined).

- **`h_tile_i8` padding rows**: each of the five `sh_gate_up_act_q*` AIV kernels now clears the two padded rows owned by its logical block (`zero_h_tile_i8_padding`) before producing its output.
- **`mixes_raw` split-K destination**: a new `hc_head_mixes_zero` AIV kernel (func_id 367) clears one up-to-16-row chunk per logical block; an explicit task dependency orders every `hc_head_linear` `AtomicAdd` store after the seed task. All three orchestrations (`decode_fwd.cpp`, `decode_fwd_hostbuild.cpp`, `decode_fwd_graph.cpp`) submit it in place of the plain `alloc_tensors` + `set_initial_value`.

This closes the "AtomicAdd destinations cannot currently be initialized correctly by HBG" runtime gap recorded in the HBG README.

Both full-network cases remain `manual` (368-kernel compile); READMEs and docstrings are updated for the new kernel count and status.
