### PR TITLE
Fix: separate disjoint views of one backing in L3 dependency inference

### DIFF
--- a/docs/buffer-abi.md
+++ b/docs/buffer-abi.md
@@ -194,9 +194,35 @@ orch.submit_next_level(chip_handle, ta, cfg, worker=0)
 ```
 
 `TaskArgs` carries `Tensor`s. Tags drive dependency inference, which keys on
-the **canonical identity** (buffer granularity, the successor of the former
-buffer-address key); byte-range overlap between same-buffer views is refined by
-the L2 OverlapMap on the materialized tensors, not by the L3 key.
+the **canonical identity** — buffer granularity, the successor of the former
+buffer-address key, so every view of one backing lands on one key and no real
+dependency hides behind a differing offset. Which of those candidates actually
+conflict is then decided by their **view geometry**, in two stages:
+
+1. **Bounding range.** `[byte_offset, byte_offset + extent)` on each side.
+   Disjoint boxes are disjoint views, answered in O(1).
+2. **Per-dimension intersection**, when the boxes do overlap. Each origin is
+   decomposed into per-axis coordinates and the axes are intersected one by
+   one; disjoint on any single axis makes the views disjoint.
+
+So two disjoint slices of one buffer carry no edge and run concurrently —
+`x[0]` and `x[1]` of a rank-major tensor by stage 1, and `x[:, 0:4]` versus
+`x[:, 8:12]` of a matrix by stage 2, whose bounding boxes interleave because
+every row of one sits between two rows of the other.
+
+This is the host-side counterpart of the L2 OverlapMap cascade, and carries the
+same limits. Stage 2 models only pairs sharing one canonical row-major layout —
+same dtype and `ndims`, identical `strides` descending as exact multiples down
+to 1, origins on that layout's lattice. A transposed pair, a stepped slice, or
+two views of different rank over one backing fall through as *overlapping*, as
+does a producer a later write only partly covers. Every fallback is in that one
+direction: an extra edge is possible where the truth is subtler, and a real
+dependency is never dropped.
+
+An extra edge is normally just lost concurrency. It is not always: where two
+tasks rendezvous with each other, a spurious edge holds back the dispatch that
+would release the other, and the run deadlocks. That is why the disjointness
+above is answered precisely rather than conservatively.
 
 ## Reading and writing data — torch only at the boundaries
 
@@ -298,7 +324,9 @@ values are final, at submit:
   so there is no order between them to express, and a device-staged copy of a
   host backing does not even alias on the device for the L2 overlap map to
   notice. Disjoint slices of one buffer stay legal — that is what `byte_offset`
-  is for.
+  is for, and this check runs the same two-stage comparison dependency
+  inference does, so a tiled write of one buffer passes rather than tripping on
+  bounding boxes that merely interleave.
 
 Group members are not compared against each other: a group is one node, and
 naming one buffer as every member's output is how it publishes a single

--- a/docs/remote-l3-worker-design.md
+++ b/docs/remote-l3-worker-design.md
@@ -506,14 +506,20 @@ Parent-side slots therefore store existing `TaskArgs`, an optional
 `RemoteTaskArgsView`, eligible worker ids, and captured remote-buffer refs.
 
 `Orchestrator::infer_deps()` builds `TensorKey` from remote handle metadata
-when a sidecar exists. The first implementation intentionally preserves the
-current exact-start TensorMap semantics: local fork/shm keys use
-`(ptr, worker_id)`, while remote keys use
-`(address_kind, owner_worker_id, buffer_id, generation, offset)`. The tensor
-byte length is bounds-checked by the descriptor but does not participate in
-dependency lookup. This means two remote tensors that reference overlapping
-byte ranges with different offsets are not automatically ordered, matching the
-current local pointer-key behavior.
+when a sidecar exists. Remote keys keep the exact-start semantics the first
+implementation chose — `(address_kind, owner_worker_id, buffer_id, generation,
+offset)` — so the tensor byte length is bounds-checked by the descriptor but
+does not participate in dependency lookup. Two remote tensors over overlapping
+byte ranges with different offsets are therefore not automatically ordered.
+
+The local path no longer works this way. A local key names the backing alone,
+and the view's geometry decides which same-key args conflict, so overlap there
+is caught and disjointness there is respected. Bringing the remote path onto
+the same model means dropping `offset` from the key and giving each entry
+`[offset, offset + nbytes)` as its footprint — `RemoteTensorDesc` already
+carries both. `HOST_INLINE` is the case that needs care: it pins `buffer_id` and
+`generation` to zero, so `offset` is the only thing separating two inline
+payloads today.
 
 ## Failure Semantics
 

--- a/docs/remote-l3-worker-design/buffers-and-transports.md
+++ b/docs/remote-l3-worker-design/buffers-and-transports.md
@@ -313,15 +313,16 @@ local child memory:  (LOCAL_CHILD, worker_id, ptr)
 Known limitation: two remote tensors that reference overlapping byte ranges
 with different `offset_begin` values do not automatically depend on each other.
 For example, a producer writing `[0, 4096)` and a consumer reading
-`[1024, 2048)` map to different dependency keys. This matches the current local
-`ptr`-based TensorMap behavior, where a subview at `base + offset` is a
-different key from `base`.
+`[1024, 2048)` map to different dependency keys.
 
-The first implementation chooses this route to keep remote scheduling behavior
-compatible with local fork/shm semantics and to avoid changing TensorMap into a
-range index as part of the transport bring-up. `offset_end`/`nbytes` remains in
-`RemoteTensorDesc` for bounds checks and for a future range-overlap TensorMap
-upgrade, but it is not part of the first dependency key.
+Local keys no longer share this limitation. A local key names the backing alone
+and each TensorMap entry carries the view's geometry, so an overlapping pair is
+ordered and a disjoint pair is not. The remote path is now the only one that
+folds an offset into the key. `offset_end`/`nbytes` remains in
+`RemoteTensorDesc` for bounds checks and is what an upgrade would turn into the
+entry's footprint once `offset` leaves the key — noting that `HOST_INLINE` pins
+`buffer_id` and `generation` to zero, so `offset` is currently the only thing
+separating two inline payloads.
 
 ## HCOMM Adapter Contract
 

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -10553,7 +10553,8 @@ class Worker:
         tensor is MAP_SHARED — read-write across the fork, so usable as an OUTPUT the parent reads back;
         a plain tensor is COW read-only (input only). The handle is memoized by the tensor's storage
         base, so every ref over the same storage shares one canonical identity and dependencies key on
-        it. At L2 (no fork) any host tensor works. ``dtype`` is the ``DataType`` int value.
+        it; the ``byte_offset`` this computes is what then separates two views that do not intersect.
+        At L2 (no fork) any host tensor works. ``dtype`` is the ``DataType`` int value.
         """
         untyped_storage = getattr(tensor, "untyped_storage", None)
         if callable(untyped_storage):
@@ -10564,7 +10565,9 @@ class Worker:
             base, nbytes = host_ptr_nbytes(tensor)
             byte_offset = 0
         # Memoized per storage base so every view of one storage shares an identity and their
-        # dependencies key together. The allocator reuses addresses, though, so a hit whose size no
+        # dependencies key together — a real dependency between two views cannot then hide behind a
+        # differing offset, and the byte ranges tell the intersecting pairs from the disjoint ones
+        # under that one key. The allocator reuses addresses, though, so a hit whose size no
         # longer matches is a *different* storage that happens to sit where the last one did: it must
         # get a fresh identity, or the two would fuse into one node in the dependency graph.
         handle = self._fork_tensor_handles.get(base)

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -647,7 +647,9 @@ uint64_t Orchestrator::alloc(const std::vector<uint32_t> &shape, DataType dtype,
         // can erase; the reverse order can leak an unjournaled producer entry.
         s.output_keys.push_back(key);
         if (test_hook_) test_hook_(OrchestratorTestPoint::ALLOC_OUTPUT_KEY_PREPARED);
-        tensormap_->insert(run->id, key, ar.slot);
+        // The allocation covers its whole backing, which is what a default TensorFootprint
+        // spans — so every view a consumer later takes of it resolves back to this slot.
+        tensormap_->insert(run->id, key, TensorFootprint{}, ar.slot);
     }
 
     // Simulate the self try_consume that on_task_complete would normally
@@ -1179,6 +1181,17 @@ void Orchestrator::infer_deps(
         }
     };
 
+    // One key can resolve to several producers, one per live view under it that this arg's own
+    // view reaches. `overlapping` is scratch reused across args.
+    std::vector<TaskSlot> overlapping;
+    auto take_producers = [&](TensorKey key, const TensorFootprint &view) {
+        overlapping.clear();
+        tensormap_->lookup_overlapping(run_id, key, view, overlapping);
+        for (TaskSlot prod : overlapping) {
+            add_unique_producer(prod);
+        }
+    };
+
     // Tag-driven dependency inference — mirrors L2
     // (src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
     //  steps B and 4):
@@ -1196,6 +1209,11 @@ void Orchestrator::infer_deps(
         for (int32_t i = 0; i < a.tensor_count(); ++i) {
             const Tensor &r = a.tensor(i);
             TensorKey key{};
+            // The bytes this arg touches inside the backing its key names. Two args under one
+            // key conflict only where their views intersect, which is what keeps two disjoint
+            // slices of one buffer — `x[0]` and `x[1]` of a rank-major tensor, or two column
+            // blocks whose bounding boxes interleave — independent.
+            TensorFootprint view{};
             bool has_key = false;
             if (!remote_sidecars.empty()) {
                 const auto &sidecar = remote_sidecars[g];
@@ -1205,6 +1223,9 @@ void Orchestrator::infer_deps(
                     TensorAddressKind kind = desc.address_space == RemoteAddressSpace::HOST_INLINE ?
                                                  TensorAddressKind::HOST_INLINE :
                                                  TensorAddressKind::REMOTE_BUFFER;
+                    // A remote key already carries the view's offset, so every entry under one
+                    // of them denotes the same origin and a footprint adds nothing; the default
+                    // whole-backing one keeps this path's behaviour exactly as it was.
                     key = TensorKey::remote_buffer(
                         kind, desc.owner_worker_id, desc.buffer_id, desc.generation, desc.offset
                     );
@@ -1213,39 +1234,35 @@ void Orchestrator::infer_deps(
             }
             if (!has_key) {
                 if (r.buffer.nbytes == 0) continue;  // placeholder / null ref — nothing to track
-                // Key a local Tensor by its canonical identity alone (buffer granularity) — the
-                // successor of the former buffer-address key now that Tensor carries identity, not
-                // an address. Any two refs to the same buffer collide (a candidate dependency); the
-                // byte_offset/footprint overlap that would refine this to only *conflicting* sub-views
-                // is a future precision pass, not part of the key (folding it in would split
-                // same-buffer refs into distinct keys and miss real dependencies).
+                // Key a local Tensor by its canonical identity alone, so every view of one backing
+                // lands on one key and no real dependency can hide behind a differing offset. The
+                // view geometry decides which of those candidates actually conflict.
                 CanonicalIdentityHash idh;
                 uint64_t k = idh(r.buffer.identity);
                 key = r.buffer.address_space == static_cast<uint8_t>(AddressSpace::DEVICE) ?
                           TensorKey::local_child(k, worker_id) :
                           TensorKey::local_host(k);
+                view = tensor_footprint(r);
                 has_key = true;
             }
             TensorArgType tag = a.tag(i);
             switch (tag) {
             case TensorArgType::INPUT: {
-                TaskSlot prod = tensormap_->lookup(run_id, key);
-                if (prod != INVALID_SLOT) add_unique_producer(prod);
+                take_producers(key, view);
                 break;
             }
             case TensorArgType::INOUT: {
-                TaskSlot prod = tensormap_->lookup(run_id, key);
-                if (prod != INVALID_SLOT) add_unique_producer(prod);
+                take_producers(key, view);
                 output_keys.push_back(key);
                 if (test_hook_) test_hook_(OrchestratorTestPoint::SUBMIT_OUTPUT_KEY_PREPARED);
-                tensormap_->insert(run_id, key, slot);
+                tensormap_->insert(run_id, key, view, slot);
                 break;
             }
             case TensorArgType::OUTPUT:
             case TensorArgType::OUTPUT_EXISTING: {
                 output_keys.push_back(key);
                 if (test_hook_) test_hook_(OrchestratorTestPoint::SUBMIT_OUTPUT_KEY_PREPARED);
-                tensormap_->insert(run_id, key, slot);
+                tensormap_->insert(run_id, key, view, slot);
                 break;
             }
             case TensorArgType::NO_DEP:

--- a/src/common/hierarchical/tensormap.cpp
+++ b/src/common/hierarchical/tensormap.cpp
@@ -11,27 +11,53 @@
 
 #include "tensormap.h"
 
-TaskSlot TensorMap::lookup(RunId run_id, TensorKey key) const {
+void TensorMap::lookup_overlapping(
+    RunId run_id, TensorKey key, const TensorFootprint &view, std::vector<TaskSlot> &out
+) const {
     std::lock_guard<std::mutex> lk(mu_);
     auto it = map_.find(RunTensorKey{run_id, key});
-    if (it == map_.end()) return INVALID_SLOT;
-    return it->second;
+    if (it == map_.end()) return;
+    for (const Entry &entry : it->second) {
+        if (tensor_overlap(view, entry.view) != TensorOverlap::NONE) out.push_back(entry.producer);
+    }
 }
 
-void TensorMap::insert(RunId run_id, TensorKey key, TaskSlot producer) {
+void TensorMap::insert(RunId run_id, TensorKey key, const TensorFootprint &view, TaskSlot producer) {
     std::lock_guard<std::mutex> lk(mu_);
-    map_[RunTensorKey{run_id, key}] = producer;
+    std::vector<Entry> &entries = map_[RunTensorKey{run_id, key}];
+    // A write leaves an earlier producer standing only for the bytes it does not reach, so an
+    // entry it covers whole is dead and one it only reaches into is not. Dropping the latter too
+    // would lose the dependency a consumer of those outside bytes must still take.
+    size_t kept = 0;
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (tensor_overlap(view, entries[i].view) == TensorOverlap::COVERED) continue;
+        entries[kept++] = entries[i];
+    }
+    entries.resize(kept);
+    entries.push_back(Entry{view, producer});
 }
 
 void TensorMap::erase_task_outputs(RunId run_id, TaskSlot owner, const std::vector<TensorKey> &keys) {
     std::lock_guard<std::mutex> lk(mu_);
     for (const auto &key : keys) {
         auto it = map_.find(RunTensorKey{run_id, key});
-        if (it != map_.end() && it->second == owner) map_.erase(it);
+        if (it == map_.end()) continue;
+        std::vector<Entry> &entries = it->second;
+        size_t kept = 0;
+        for (size_t i = 0; i < entries.size(); ++i) {
+            if (entries[i].producer == owner) continue;
+            entries[kept++] = entries[i];
+        }
+        entries.resize(kept);
+        if (entries.empty()) map_.erase(it);
     }
 }
 
 int32_t TensorMap::size() const {
     std::lock_guard<std::mutex> lk(mu_);
-    return static_cast<int32_t>(map_.size());
+    size_t total = 0;
+    for (const auto &bucket : map_) {
+        total += bucket.second.size();
+    }
+    return static_cast<int32_t>(total);
 }

--- a/src/common/hierarchical/tensormap.h
+++ b/src/common/hierarchical/tensormap.h
@@ -10,21 +10,29 @@
  */
 
 /**
- * TensorMap — (RunId, TensorKey) → producer task slot mapping.
+ * TensorMap — (RunId, TensorKey) → the live producers of a backing's byte ranges.
  *
- * At the hierarchical host level, every tensor is identified by a TensorKey
- * consisting of (ptr, worker_id). Host tensors (HeapRing) use
- * worker_id=-1 because their addresses are globally unique; child_memory
- * tensors use the owning NEXT_LEVEL worker id to disambiguate identical
- * device addresses across different children.
+ * A TensorKey names a whole backing: the canonical identity of a local buffer, scoped by the
+ * owning NEXT_LEVEL worker id for device memory (identical device addresses recur across
+ * children), or the exported (owner, buffer_id, generation, offset) of a remote one. Two views
+ * of one backing therefore land on one key by construction, and the key alone cannot tell a
+ * pair that conflicts from a pair that does not.
+ *
+ * `TensorFootprint` is what tells them apart. Each key holds every producer whose written view is
+ * still the last word on some byte of the backing, so `x[0]` and `x[1]` coexist under one key and
+ * neither resolves as the other's producer. This mirrors the L2 PTO2TensorMap, which hashes by
+ * base address only and walks the chain running the same overlap cascade — a bounding-range
+ * reject, then a per-dimension hyper-rectangle test that separates two column blocks whose
+ * bounding boxes interleave.
+ *
+ * Conservative in one direction only: a pair the cascade cannot model exactly counts as
+ * overlapping, and a producer a later write only partly covers stays live. So an extra edge is
+ * possible where the truth is subtler, and a real dependency is never dropped.
  *
  * Unlike the L2 PTO2TensorMap, this implementation:
  *   - Uses std::unordered_map (no ring buffer entry pool)
- *   - Does not perform overlap detection (each key maps to one producer)
- *   - Cleans up a task's entries when it is CONSUMED, skipping the keys a
+ *   - Cleans up a task's entries when it is CONSUMED, skipping the views a
  *     newer same-run producer has taken over
- *
- * Owned exclusively by the Orchestrator (main thread); no locking required.
  */
 
 #pragma once
@@ -37,21 +45,24 @@
 
 class TensorMap {
 public:
-    // Look up the producer for a tensor key.
-    // Returns INVALID_SLOT when not found.
-    TaskSlot lookup(RunId run_id, TensorKey key) const;
+    // Append every live producer under `key` whose written view overlaps `view`. Views that do
+    // not intersect are the disjoint slices of one backing, and are not dependencies.
+    // `out` is appended to, not cleared: one task accumulates producers across all its args.
+    void lookup_overlapping(RunId run_id, TensorKey key, const TensorFootprint &view, std::vector<TaskSlot> &out) const;
 
-    // Register key → producer mapping.
-    // Overwrites any existing entry (re-use of the same buffer by a new producer).
-    void insert(RunId run_id, TensorKey key, TaskSlot producer);
+    // Register `producer` as the writer of `view` under `key`. Entries this write covers whole
+    // are superseded and dropped; one that reaches outside it stays, because it is still the
+    // last writer of the bytes this write does not reach.
+    void insert(RunId run_id, TensorKey key, const TensorFootprint &view, TaskSlot producer);
 
-    // Remove the entries in 'keys' that still map to 'owner'.
-    // Called when a producer task transitions to CONSUMED. A key that a newer
-    // same-run producer has since re-registered belongs to that producer and
-    // is left intact.
+    // Remove the entries under 'keys' still owned by 'owner'.
+    // Called when a producer task transitions to CONSUMED. A view that a newer same-run
+    // producer has since superseded is already gone; one it left standing belongs to nobody
+    // else and is dropped here.
     void erase_task_outputs(RunId run_id, TaskSlot owner, const std::vector<TensorKey> &keys);
 
-    // Number of entries currently tracked.
+    // Number of (key, view) producer entries currently tracked. A key holding two disjoint
+    // live writers counts twice.
     int32_t size() const;
 
 private:
@@ -71,6 +82,11 @@ private:
         }
     };
 
+    struct Entry {
+        TensorFootprint view{};
+        TaskSlot producer{INVALID_SLOT};
+    };
+
     mutable std::mutex mu_;
-    std::unordered_map<RunTensorKey, TaskSlot, RunTensorKeyHash> map_;
+    std::unordered_map<RunTensorKey, std::vector<Entry>, RunTensorKeyHash> map_;
 };

--- a/src/common/task_interface/buffer.h
+++ b/src/common/task_interface/buffer.h
@@ -252,16 +252,20 @@ inline constexpr uint64_t TENSOR_EXTENT_UNREPRESENTABLE = UINT64_MAX;
 // Byte extent of a (possibly strided) view: the last addressable element, plus one element.
 // Saturates at TENSOR_EXTENT_UNREPRESENTABLE rather than wrapping, so an extent a hostile
 // shape/stride cannot express is rejected instead of comparing as a small, in-bounds value.
-// Callers that have not yet validated `r` must not trust the result for anything but a bound.
-inline uint64_t tensor_extent_bytes(const Tensor &r) {
+// Callers that have not yet validated the view must not trust the result for anything but a bound.
+inline uint64_t view_extent_bytes(const uint32_t *shapes, const uint32_t *strides, uint32_t ndims, DataType dtype) {
     uint64_t last_elem = 0;
-    for (uint32_t i = 0; i < r.ndims && i < static_cast<uint32_t>(MAX_TENSOR_DIMS); ++i) {
-        if (r.shapes[i] == 0) continue;
+    for (uint32_t i = 0; i < ndims && i < static_cast<uint32_t>(MAX_TENSOR_DIMS); ++i) {
+        if (shapes[i] == 0) continue;
         last_elem = tensor_add_sat(
-            last_elem, tensor_mul_sat(static_cast<uint64_t>(r.shapes[i] - 1), static_cast<uint64_t>(r.strides[i]))
+            last_elem, tensor_mul_sat(static_cast<uint64_t>(shapes[i] - 1), static_cast<uint64_t>(strides[i]))
         );
     }
-    return tensor_mul_sat(tensor_add_sat(last_elem, 1), get_element_size(r.dtype));
+    return tensor_mul_sat(tensor_add_sat(last_elem, 1), get_element_size(dtype));
+}
+
+inline uint64_t tensor_extent_bytes(const Tensor &r) {
+    return view_extent_bytes(r.shapes, r.strides, r.ndims, r.dtype);
 }
 
 /**
@@ -407,15 +411,187 @@ inline void validate_tensor(const Tensor &r) {
     }
 }
 
-// Do two views of the SAME backing touch a common byte? Compared as bounding ranges
-// [byte_offset, byte_offset + extent): a strided view's gaps are treated as occupied, so this is
-// conservative — it never misses a real overlap, and may report one for two interleaved views.
-// The end offsets saturate, so an unvalidated extent cannot wrap a range into a false "disjoint".
+/**
+ * Half-open byte range [begin, end) within one backing — a view's bounding box.
+ *
+ * A strided view's gaps count as occupied, so this is only a bound: `x[0:4, 0:4]` and
+ * `x[0:4, 8:12]` of one 16x16 matrix are disjoint yet their bounding ranges intersect. It is the
+ * O(1) reject stage of `tensor_overlap` below, which refines an intersection per dimension.
+ *
+ * `end` saturates at UINT64_MAX, so an extent that does not fit 64 bits cannot wrap a range into
+ * a false "disjoint". A default-constructed range spans the whole backing.
+ */
+struct TensorByteRange {
+    uint64_t begin{0};
+    uint64_t end{UINT64_MAX};
+
+    bool overlaps(const TensorByteRange &o) const { return begin < o.end && o.begin < end; }
+    bool covers(const TensorByteRange &o) const { return begin <= o.begin && o.end <= end; }
+};
+
+// The bounding range a view occupies in its backing.
+inline TensorByteRange tensor_byte_range(const Tensor &r) {
+    return TensorByteRange{r.byte_offset, tensor_add_sat(r.byte_offset, tensor_extent_bytes(r))};
+}
+
+/**
+ * How one view (`probe`) stands to another (`entry`) over the same backing.
+ *
+ * `PARTIAL` is also the answer when the pair cannot be compared exactly, so a caller may only
+ * read `NONE` as proof of disjointness — never `PARTIAL` as proof of a shared byte.
+ */
+enum class TensorOverlap : uint8_t {
+    NONE,     // provably no common byte
+    PARTIAL,  // they share a byte, or the pair is not exactly comparable
+    COVERED,  // every byte of `entry` is also a byte of `probe`
+};
+
+/**
+ * The geometry of a view inside its backing — what decides whether two views touch a common byte.
+ *
+ * `ndims == 0` is the whole-backing footprint: what a caller registers when it knows a buffer is
+ * touched but not which bytes (an allocation; a remote argument whose key already carries the
+ * offset). No valid Tensor has `ndims == 0`, so a default-constructed footprint means exactly
+ * that, and overlaps everything.
+ *
+ * The backing's identity is deliberately absent: a footprint is only ever compared against
+ * another over the SAME backing, which the caller establishes — a shared dependency key, or the
+ * identity check in `tensors_overlap`.
+ */
+struct TensorFootprint {
+    uint64_t byte_offset{0};
+    uint64_t backing_nbytes{0};
+    uint32_t shapes[MAX_TENSOR_DIMS]{};
+    uint32_t strides[MAX_TENSOR_DIMS]{};  // in elements, as on Tensor
+    uint32_t ndims{0};
+    DataType dtype{};
+
+    bool is_whole_backing() const { return ndims == 0; }
+    TensorByteRange range() const {
+        if (is_whole_backing()) return TensorByteRange{};
+        const uint64_t extent = view_extent_bytes(shapes, strides, ndims, dtype);
+        return TensorByteRange{byte_offset, tensor_add_sat(byte_offset, extent)};
+    }
+};
+
+inline TensorFootprint tensor_footprint(const Tensor &r) {
+    TensorFootprint f{};
+    f.byte_offset = r.byte_offset;
+    f.backing_nbytes = r.buffer.nbytes;
+    f.ndims = r.ndims;
+    f.dtype = r.dtype;
+    for (uint32_t i = 0; i < MAX_TENSOR_DIMS; ++i) {
+        f.shapes[i] = r.shapes[i];
+        f.strides[i] = r.strides[i];
+    }
+    return f;
+}
+
+/**
+ * Do two views of the same backing touch a common byte, and does `probe` swallow `entry` whole?
+ *
+ * Three stages, mirroring the L2 `PTO2TensorMap::check_overlap` this is the host-side counterpart
+ * of (`src/{arch}/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h`):
+ *
+ *   1. Bounding-range intersection. O(1), and the only stage a whole-backing footprint reaches.
+ *      Disjoint bounding boxes are disjoint views, so this alone can answer `NONE`.
+ *   2. Per-dimension hyper-rectangle intersection, once the bounding boxes do intersect. Eligible
+ *      only when both sides share one canonical row-major axis layout — same dtype and ndims,
+ *      identical strides, `strides` descending as exact integer multiples down to 1, and each
+ *      origin decomposing cleanly under the shape that layout implies. Disjoint on any single
+ *      axis makes the views disjoint, which is what separates two column blocks whose bounding
+ *      boxes interleave.
+ *   3. Anything stage 2 cannot model — a transposed pair, a stepped slice, mismatched dtypes —
+ *      falls out as `PARTIAL`. Exact enumeration of those is not attempted.
+ *
+ * Every rejection path in stage 2 yields `PARTIAL`, never `NONE`: an unmodelled pair is assumed
+ * to conflict. So a false edge is possible where the truth is subtler; a real one is never lost.
+ */
+inline TensorOverlap tensor_overlap(const TensorFootprint &probe, const TensorFootprint &entry) {
+    // ---- Stage 1: bounding-range intersection (O(1) reject) ----
+    const TensorByteRange probe_range = probe.range();
+    const TensorByteRange entry_range = entry.range();
+    if (!probe_range.overlaps(entry_range)) return TensorOverlap::NONE;
+    if (probe.is_whole_backing()) {
+        return entry_range.begin >= probe_range.begin && entry_range.end <= probe_range.end ? TensorOverlap::COVERED :
+                                                                                              TensorOverlap::PARTIAL;
+    }
+    if (entry.is_whole_backing()) return TensorOverlap::PARTIAL;
+
+    // ---- Stage 2 prerequisites: one shared canonical row-major axis layout ----
+    if (probe.dtype != entry.dtype || probe.ndims != entry.ndims) return TensorOverlap::PARTIAL;
+    const uint32_t ndims = probe.ndims;
+    if (ndims > static_cast<uint32_t>(MAX_TENSOR_DIMS)) return TensorOverlap::PARTIAL;
+    for (uint32_t i = 0; i < ndims; ++i) {
+        if (probe.strides[i] != entry.strides[i]) return TensorOverlap::PARTIAL;
+        if (probe.strides[i] == 0) return TensorOverlap::PARTIAL;
+    }
+    // The reference-shape derivation below reads `strides[i] == prod(shape[i+1..])`. Requiring the
+    // innermost stride to be 1 and each outer one to be an exact multiple of its inner neighbour is
+    // what makes that true; it rejects stepped slices and any view chain that reorders the axes.
+    if (probe.strides[ndims - 1] != 1) return TensorOverlap::PARTIAL;
+    for (uint32_t i = 1; i < ndims; ++i) {
+        if (probe.strides[i - 1] % probe.strides[i] != 0) return TensorOverlap::PARTIAL;
+    }
+
+    const uint64_t elem = get_element_size(probe.dtype);
+    if (elem == 0) return TensorOverlap::PARTIAL;
+    if (probe.byte_offset % elem != 0 || entry.byte_offset % elem != 0) return TensorOverlap::PARTIAL;
+
+    // Reference shape A of the backing, recovered from the stride vector: A[i] = strides[i-1] /
+    // strides[i], and A[0] from however many elements the backing holds. An allocator that rounded
+    // the backing up leaves A[0] larger than the truth, which only loosens the bounds check below —
+    // A[0] is never used as anything but an upper bound, so it can produce neither a false NONE nor
+    // a false COVERED.
+    uint32_t ref_shapes[MAX_TENSOR_DIMS] = {};
+    for (uint32_t i = 1; i < ndims; ++i) {
+        ref_shapes[i] = probe.strides[i - 1] / probe.strides[i];
+    }
+    const uint64_t numel_storage = probe.backing_nbytes / elem;
+    const uint32_t stride0 = probe.strides[0];
+    if (numel_storage % stride0 != 0) return TensorOverlap::PARTIAL;
+    const uint64_t ref_shape0 = numel_storage / stride0;
+    if (ref_shape0 > UINT32_MAX) return TensorOverlap::PARTIAL;
+    ref_shapes[0] = static_cast<uint32_t>(ref_shape0);
+
+    // Decompose each origin into per-axis coordinates. `strides[i] == prod(A[i+1..])`, so dividing
+    // the remainder by strides[i] yields axis i directly. A non-zero final remainder means the
+    // origin does not sit on a lattice point of this layout — not modellable, so PARTIAL.
+    uint64_t probe_off[MAX_TENSOR_DIMS] = {};
+    uint64_t entry_off[MAX_TENSOR_DIMS] = {};
+    uint64_t probe_remain = probe.byte_offset / elem;
+    uint64_t entry_remain = entry.byte_offset / elem;
+    for (uint32_t i = 0; i < ndims; ++i) {
+        const uint64_t s = probe.strides[i];
+        probe_off[i] = probe_remain / s;
+        entry_off[i] = entry_remain / s;
+        probe_remain %= s;
+        entry_remain %= s;
+    }
+    if (probe_remain != 0 || entry_remain != 0) return TensorOverlap::PARTIAL;
+
+    for (uint32_t i = 0; i < ndims; ++i) {
+        if (probe_off[i] + probe.shapes[i] > ref_shapes[i]) return TensorOverlap::PARTIAL;
+        if (entry_off[i] + entry.shapes[i] > ref_shapes[i]) return TensorOverlap::PARTIAL;
+    }
+
+    // ---- Stage 2 core: per-axis line-segment intersection ----
+    bool probe_contains_entry = true;
+    for (uint32_t i = 0; i < ndims; ++i) {
+        const uint64_t p_begin = probe_off[i];
+        const uint64_t p_end = p_begin + probe.shapes[i];
+        const uint64_t e_begin = entry_off[i];
+        const uint64_t e_end = e_begin + entry.shapes[i];
+        if (!(p_begin < e_end && e_begin < p_end)) return TensorOverlap::NONE;
+        if (!(p_begin <= e_begin && e_end <= p_end)) probe_contains_entry = false;
+    }
+    return probe_contains_entry ? TensorOverlap::COVERED : TensorOverlap::PARTIAL;
+}
+
+// Do two views of the SAME backing touch a common byte?
 inline bool tensors_overlap(const Tensor &a, const Tensor &b) {
     if (!(a.buffer.identity == b.buffer.identity)) return false;
-    const uint64_t a_end = tensor_add_sat(a.byte_offset, tensor_extent_bytes(a));
-    const uint64_t b_end = tensor_add_sat(b.byte_offset, tensor_extent_bytes(b));
-    return a.byte_offset < b_end && b.byte_offset < a_end;
+    return tensor_overlap(tensor_footprint(a), tensor_footprint(b)) != TensorOverlap::NONE;
 }
 
 static_assert(std::is_trivially_copyable_v<Tensor>, "Tensor must be trivially copyable for blob memcpy");

--- a/tests/ut/cpp/hierarchical/test_orchestrator.cpp
+++ b/tests/ut/cpp/hierarchical/test_orchestrator.cpp
@@ -25,6 +25,33 @@
 #include "types.h"
 #include "task_args.h"
 
+// Producers under `key` whose written view overlaps `view`, in registration order.
+static std::vector<TaskSlot> map_hits(const TensorMap &tm, RunId run_id, TensorKey key, const TensorFootprint &view) {
+    std::vector<TaskSlot> out;
+    tm.lookup_overlapping(run_id, key, view, out);
+    return out;
+}
+
+// The single producer covering the whole backing under `key`, or INVALID_SLOT when there is
+// none. Asserts there is at most one: a caller states the key holds one live writer.
+static TaskSlot map_producer(const TensorMap &tm, RunId run_id, TensorKey key) {
+    std::vector<TaskSlot> out = map_hits(tm, run_id, key, TensorFootprint{});
+    EXPECT_LE(out.size(), 1u);
+    return out.empty() ? INVALID_SLOT : out[0];
+}
+
+// The footprint of byte `row` of a `rows`-byte backing — what `row_view_args` names.
+static TensorFootprint row_fp(uint64_t row, uint64_t rows) {
+    TensorFootprint f{};
+    f.byte_offset = row;
+    f.backing_nbytes = rows;
+    f.ndims = 1;
+    f.shapes[0] = 1;
+    f.strides[0] = 1;
+    f.dtype = DataType::UINT8;
+    return f;
+}
+
 // ---------------------------------------------------------------------------
 // Fixture: wires the Orchestrator components together (no Scheduler thread)
 // ---------------------------------------------------------------------------
@@ -68,7 +95,8 @@ struct OrchestratorFixture : public ::testing::Test {
     }
 
     // A canonical identity keyed by `buffer_id` (fixed owner nonce/path), so two args with the same
-    // buffer_id collide into one dependency — the successor of the former buffer-address key.
+    // buffer_id land on one dependency key — the successor of the former buffer-address key. Whether
+    // they carry an edge is then their byte ranges' business.
     static CanonicalIdentity identity_for(uint64_t buffer_id) {
         CanonicalIdentity id{};
         id.buffer_id = buffer_id;
@@ -91,6 +119,49 @@ struct OrchestratorFixture : public ::testing::Test {
         r.ndims = 1;
         r.shapes[0] = 1;
         r.strides[0] = 1;
+        r.dtype = DataType::UINT8;
+        a.add_tensor(r, tag);
+        return a;
+    }
+
+    // Helper: a TaskArgs holding row `row` of a `rows`-row backing keyed by `buffer_id` — one
+    // UINT8 element per row, so row r is exactly byte r. The rank-major slice `x[r]` that
+    // distributed codegen hands each worker.
+    static TaskArgs row_view_args(uint64_t buffer_id, uint64_t row, uint64_t rows, TensorArgType tag) {
+        TaskArgs a;
+        Tensor r{};
+        r.buffer.backend_kind = static_cast<uint8_t>(BackendKind::POSIX_SHM);
+        r.buffer.access = static_cast<uint8_t>(AccessMode::READWRITE);
+        r.buffer.nbytes = rows;
+        r.buffer.identity = identity_for(buffer_id);
+        r.byte_offset = row;
+        r.ndims = 1;
+        r.shapes[0] = 1;
+        r.strides[0] = 1;
+        r.dtype = DataType::UINT8;
+        a.add_tensor(r, tag);
+        return a;
+    }
+
+    // Helper: a TaskArgs holding rows [r0, r0+rows) x cols [c0, c0+cols) of a `R`x`C` UINT8 matrix
+    // keyed by `buffer_id`. Two of these can be disjoint while their bounding boxes interleave,
+    // which is what makes the per-dimension stage of the overlap cascade load-bearing.
+    static TaskArgs tile_view_args(
+        uint64_t buffer_id, uint32_t r0, uint32_t rows, uint32_t c0, uint32_t cols, uint32_t R, uint32_t C,
+        TensorArgType tag
+    ) {
+        TaskArgs a;
+        Tensor r{};
+        r.buffer.backend_kind = static_cast<uint8_t>(BackendKind::POSIX_SHM);
+        r.buffer.access = static_cast<uint8_t>(AccessMode::READWRITE);
+        r.buffer.nbytes = static_cast<uint64_t>(R) * C;
+        r.buffer.identity = identity_for(buffer_id);
+        r.byte_offset = static_cast<uint64_t>(r0) * C + c0;
+        r.ndims = 2;
+        r.shapes[0] = rows;
+        r.shapes[1] = cols;
+        r.strides[0] = C;
+        r.strides[1] = 1;
         r.dtype = DataType::UINT8;
         a.add_tensor(r, tag);
         return a;
@@ -266,7 +337,7 @@ TEST_F(OrchestratorFixture, TensorMapTracksProducer) {
     TaskSlot drain_slot;
     rq.try_pop(drain_slot);
 
-    EXPECT_EQ(tm.lookup(run_id, ref_key(0x1234)), a.task_slot);
+    EXPECT_EQ(map_producer(tm, run_id, ref_key(0x1234)), a.task_slot);
 }
 
 TEST_F(OrchestratorFixture, OnConsumedCleansUpTensorMap) {
@@ -275,12 +346,12 @@ TEST_F(OrchestratorFixture, OnConsumedCleansUpTensorMap) {
     TaskSlot slot;
     rq.try_pop(slot);
 
-    EXPECT_EQ(tm.lookup(run_id, ref_key(0x42)), slot);
+    EXPECT_EQ(map_producer(tm, run_id, ref_key(0x42)), slot);
 
     S(slot).state.store(TaskState::COMPLETED, std::memory_order_relaxed);
     orch.on_consumed(slot);
 
-    EXPECT_EQ(tm.lookup(run_id, ref_key(0x42)), INVALID_SLOT);
+    EXPECT_EQ(map_producer(tm, run_id, ref_key(0x42)), INVALID_SLOT);
     EXPECT_EQ(S(slot).state.load(), TaskState::CONSUMED);
 }
 
@@ -299,12 +370,12 @@ TEST_F(OrchestratorFixture, ConsumingASupersededProducerKeepsTheNewerMapping) {
     auto args_b = single_tensor_args(0x5150, TensorArgType::OUTPUT);
     auto b = orch.submit_next_level(C(43), args_b, cfg, 0);
     ASSERT_TRUE(rq.try_pop(drain));
-    ASSERT_EQ(tm.lookup(run_id, ref_key(0x5150)), b.task_slot);
+    ASSERT_EQ(map_producer(tm, run_id, ref_key(0x5150)), b.task_slot);
 
     S(a.task_slot).state.store(TaskState::COMPLETED, std::memory_order_relaxed);
     ASSERT_TRUE(orch.on_consumed(a.task_slot));
 
-    EXPECT_EQ(tm.lookup(run_id, ref_key(0x5150)), b.task_slot);
+    EXPECT_EQ(map_producer(tm, run_id, ref_key(0x5150)), b.task_slot);
 
     auto args_c = single_tensor_args(0x5150, TensorArgType::INPUT);
     auto c = orch.submit_next_level(C(44), args_c, cfg, 0);
@@ -312,6 +383,150 @@ TEST_F(OrchestratorFixture, ConsumingASupersededProducerKeepsTheNewerMapping) {
     EXPECT_EQ(S(c.task_slot).fanin_count, 1);
     ASSERT_EQ(S(c.task_slot).fanin_producers.size(), 1u);
     EXPECT_EQ(S(c.task_slot).fanin_producers[0], b.task_slot);
+}
+
+TEST_F(OrchestratorFixture, DisjointViewsOfOneHostBackingDoNotSerialize) {
+    // Distributed codegen gives each rank an INOUT view of one rank-major host tensor. The two
+    // views share a key -- a host key carries no worker id to separate them -- so without the
+    // byte-range check rank 1's lookup resolves rank 0's slot and the two dispatches serialize.
+    // Each rank's kernel is meanwhile spinning on the other's cross-rank notify, so the edge
+    // deadlocks the run rather than merely slowing it (pypto#2448).
+    auto rank0 = row_view_args(0xBEEF, /*row=*/0, /*rows=*/2, TensorArgType::INOUT);
+    auto a = orch.submit_next_level(C(42), rank0, cfg, 0);
+    TaskSlot ready;
+    ASSERT_TRUE(rq.try_pop(ready));
+    ASSERT_EQ(ready, a.task_slot);
+
+    auto rank1 = row_view_args(0xBEEF, /*row=*/1, /*rows=*/2, TensorArgType::INOUT);
+    auto b = orch.submit_next_level(C(42), rank1, cfg, 0);
+
+    EXPECT_EQ(S(b.task_slot).state.load(), TaskState::READY);
+    EXPECT_EQ(S(b.task_slot).fanin_count, 0);
+    EXPECT_TRUE(S(b.task_slot).fanin_producers.empty());
+
+    // Both writers stay live under the one key, each owning its own row.
+    EXPECT_EQ(map_hits(tm, run_id, ref_key(0xBEEF), row_fp(0, 2)), (std::vector<TaskSlot>{a.task_slot}));
+    EXPECT_EQ(map_hits(tm, run_id, ref_key(0xBEEF), row_fp(1, 2)), (std::vector<TaskSlot>{b.task_slot}));
+}
+
+TEST_F(OrchestratorFixture, DisjointColumnBlocksOfOneHostBackingDoNotSerialize) {
+    // The same INOUT dispatch as above, sliced on a non-leading axis. `x[:, 0:4]` and
+    // `x[:, 8:12]` of a 16x16 matrix put every row of one between two rows of the other, so
+    // their bounding ranges interleave -- [0, 244) and [8, 252) -- and the O(1) stage alone
+    // would wire the same false edge. Only the per-dimension stage separates them, and it has
+    // to do so on the footprint infer_deps builds from the Tensor, not a hand-made one.
+    auto west = tile_view_args(0xBEEF, 0, 16, 0, 4, 16, 16, TensorArgType::INOUT);
+    auto a = orch.submit_next_level(C(42), west, cfg, 0);
+    TaskSlot ready;
+    ASSERT_TRUE(rq.try_pop(ready));
+    ASSERT_EQ(ready, a.task_slot);
+
+    auto east = tile_view_args(0xBEEF, 0, 16, 8, 4, 16, 16, TensorArgType::INOUT);
+    auto b = orch.submit_next_level(C(42), east, cfg, 0);
+
+    EXPECT_EQ(S(b.task_slot).state.load(), TaskState::READY);
+    EXPECT_EQ(S(b.task_slot).fanin_count, 0);
+    EXPECT_TRUE(S(b.task_slot).fanin_producers.empty());
+}
+
+TEST_F(OrchestratorFixture, DisjointTilesOfOneHostBackingDoNotSerialize) {
+    // A 2x2 grid of 8x8 tiles, every one INOUT: four dispatches, no edge between any pair.
+    struct {
+        uint32_t r0, c0;
+    } quads[] = {{0, 0}, {0, 8}, {8, 0}, {8, 8}};
+    for (const auto &q : quads) {
+        auto args = tile_view_args(0xBEEF, q.r0, 8, q.c0, 8, 16, 16, TensorArgType::INOUT);
+        auto res = orch.submit_next_level(C(42), args, cfg, 0);
+        EXPECT_EQ(S(res.task_slot).state.load(), TaskState::READY);
+        EXPECT_EQ(S(res.task_slot).fanin_count, 0) << "tile (" << q.r0 << ", " << q.c0 << ") took an edge";
+        TaskSlot ready;
+        ASSERT_TRUE(rq.try_pop(ready));
+        ASSERT_EQ(ready, res.task_slot);
+    }
+    // All four remain live under the one key, each owning its quadrant.
+    EXPECT_EQ(tm.size(), 4);
+}
+
+TEST_F(OrchestratorFixture, IntersectingTilesOfOneHostBackingStillSerialize) {
+    // The converse of the two above: tiles that do share elements keep their edge, so the
+    // refinement is not simply switching dependency inference off for 2-D views.
+    auto first = tile_view_args(0xBEEF, 0, 8, 0, 8, 16, 16, TensorArgType::INOUT);
+    auto a = orch.submit_next_level(C(42), first, cfg, 0);
+    TaskSlot ready;
+    ASSERT_TRUE(rq.try_pop(ready));
+
+    auto straddling = tile_view_args(0xBEEF, 4, 8, 4, 8, 16, 16, TensorArgType::INOUT);
+    auto b = orch.submit_next_level(C(43), straddling, cfg, 0);
+
+    EXPECT_EQ(S(b.task_slot).state.load(), TaskState::PENDING);
+    ASSERT_EQ(S(b.task_slot).fanin_producers.size(), 1u);
+    EXPECT_EQ(S(b.task_slot).fanin_producers[0], a.task_slot);
+}
+
+TEST_F(OrchestratorFixture, OverlappingViewsOfOneHostBackingStillSerialize) {
+    // The converse of the disjoint case: same key, ranges that share a byte, so the edge is real
+    // and must survive the refinement.
+    auto writer = row_view_args(0xBEEF, /*row=*/1, /*rows=*/4, TensorArgType::INOUT);
+    auto a = orch.submit_next_level(C(42), writer, cfg, 0);
+    TaskSlot ready;
+    ASSERT_TRUE(rq.try_pop(ready));
+
+    auto reader = row_view_args(0xBEEF, /*row=*/1, /*rows=*/4, TensorArgType::INPUT);
+    auto b = orch.submit_next_level(C(43), reader, cfg, 0);
+
+    EXPECT_EQ(S(b.task_slot).state.load(), TaskState::PENDING);
+    ASSERT_EQ(S(b.task_slot).fanin_producers.size(), 1u);
+    EXPECT_EQ(S(b.task_slot).fanin_producers[0], a.task_slot);
+}
+
+TEST_F(OrchestratorFixture, AReaderOfTheWholeBackingDependsOnEveryDisjointWriter) {
+    // A whole-backing view overlaps both rows, so it takes both edges -- the case that makes
+    // dropping a superseded-but-not-covered producer unsound.
+    auto rank0 = row_view_args(0xBEEF, /*row=*/0, /*rows=*/2, TensorArgType::OUTPUT_EXISTING);
+    auto a = orch.submit_next_level(C(42), rank0, cfg, 0);
+    TaskSlot ready;
+    ASSERT_TRUE(rq.try_pop(ready));
+
+    auto rank1 = row_view_args(0xBEEF, /*row=*/1, /*rows=*/2, TensorArgType::OUTPUT_EXISTING);
+    auto b = orch.submit_next_level(C(42), rank1, cfg, 0);
+    ASSERT_TRUE(rq.try_pop(ready));
+
+    TaskArgs full;
+    Tensor r{};
+    r.buffer.backend_kind = static_cast<uint8_t>(BackendKind::POSIX_SHM);
+    r.buffer.access = static_cast<uint8_t>(AccessMode::READWRITE);
+    r.buffer.nbytes = 2;
+    r.buffer.identity = identity_for(0xBEEF);
+    r.ndims = 1;
+    r.shapes[0] = 2;
+    r.strides[0] = 1;
+    r.dtype = DataType::UINT8;
+    full.add_tensor(r, TensorArgType::INPUT);
+
+    auto c = orch.submit_next_level(C(43), full, cfg, 0);
+    EXPECT_EQ(S(c.task_slot).state.load(), TaskState::PENDING);
+    EXPECT_EQ(S(c.task_slot).fanin_count, 2);
+    ASSERT_EQ(S(c.task_slot).fanin_producers.size(), 2u);
+    EXPECT_EQ(S(c.task_slot).fanin_producers[0], a.task_slot);
+    EXPECT_EQ(S(c.task_slot).fanin_producers[1], b.task_slot);
+}
+
+TEST_F(OrchestratorFixture, ConsumingOneDisjointWriterLeavesTheOther) {
+    auto rank0 = row_view_args(0xBEEF, /*row=*/0, /*rows=*/2, TensorArgType::INOUT);
+    auto a = orch.submit_next_level(C(42), rank0, cfg, 0);
+    TaskSlot ready;
+    ASSERT_TRUE(rq.try_pop(ready));
+
+    auto rank1 = row_view_args(0xBEEF, /*row=*/1, /*rows=*/2, TensorArgType::INOUT);
+    auto b = orch.submit_next_level(C(42), rank1, cfg, 0);
+    ASSERT_TRUE(rq.try_pop(ready));
+
+    S(a.task_slot).state.store(TaskState::COMPLETED, std::memory_order_relaxed);
+    ASSERT_TRUE(orch.on_consumed(a.task_slot));
+
+    // Cleanup is keyed by (key, owner), so it must not take the row it does not own with it.
+    EXPECT_TRUE(map_hits(tm, run_id, ref_key(0xBEEF), row_fp(0, 2)).empty());
+    EXPECT_EQ(map_hits(tm, run_id, ref_key(0xBEEF), row_fp(1, 2)), (std::vector<TaskSlot>{b.task_slot}));
 }
 
 TEST_F(OrchestratorFixture, ScopeRegistersAndReleasesRef) {
@@ -367,8 +582,8 @@ TEST_F(OrchestratorFixture, GroupTaskStoresArgsListPerMember) {
     EXPECT_EQ(S(res.task_slot).args(1).tensor(0).buffer.identity.buffer_id, 0xA1u);
 
     // Both keys registered as producers for the group slot.
-    EXPECT_EQ(tm.lookup(run_id, ref_key(0xA0)), res.task_slot);
-    EXPECT_EQ(tm.lookup(run_id, ref_key(0xA1)), res.task_slot);
+    EXPECT_EQ(map_producer(tm, run_id, ref_key(0xA0)), res.task_slot);
+    EXPECT_EQ(map_producer(tm, run_id, ref_key(0xA1)), res.task_slot);
 }
 
 TEST_F(OrchestratorFixture, SingleTaskStoresTaskArgsDirectly) {
@@ -402,7 +617,7 @@ TEST_F(OrchestratorFixture, RemoteOutputSidecarRegistersRemoteKey) {
     );
 
     TensorKey key = TensorKey::remote_buffer(TensorAddressKind::REMOTE_BUFFER, 3, 9, 2, 64);
-    EXPECT_EQ(tm.lookup(run_id, key), res.task_slot);
+    EXPECT_EQ(map_producer(tm, run_id, key), res.task_slot);
 }
 
 TEST_F(OrchestratorFixture, RemoteBarePayloadFailsBeforeSlotCommit) {
@@ -475,7 +690,7 @@ TEST_F(OrchestratorFixture, InoutWiresCreatorAsFanin) {
     rq.try_pop(writer_slot);
 
     // TensorMap now points at the new writer.
-    EXPECT_EQ(tm.lookup(run_id, ref_key(0xFEED)), writer.task_slot);
+    EXPECT_EQ(map_producer(tm, run_id, ref_key(0xFEED)), writer.task_slot);
     // Writer has the creator recorded as a fanin producer (via INOUT
     // lookup) but no *live* fanin since the creator is already COMPLETED.
     EXPECT_EQ(S(writer.task_slot).fanin_count, 0);
@@ -509,7 +724,7 @@ TEST_F(OrchestratorFixture, OutputAndOutputExistingAreInsertOnly) {
         auto writer_args = single_tensor_args(c.key, c.tag);
         auto writer = orch.submit_next_level(C(42), writer_args, cfg, 0);
 
-        EXPECT_EQ(tm.lookup(run_id, ref_key(c.key)), writer.task_slot);
+        EXPECT_EQ(map_producer(tm, run_id, ref_key(c.key)), writer.task_slot);
         EXPECT_EQ(S(writer.task_slot).fanin_count, 0);
         EXPECT_TRUE(S(writer.task_slot).fanin_producers.empty()) << "tag=" << static_cast<int>(c.tag);
         {
@@ -1312,9 +1527,9 @@ TEST_F(OrchestratorFixture, SubmitOutputJournalFailurePreservesThePreviousOwnerA
     ASSERT_NE(failed_slot, previous.task_slot);
     EXPECT_EQ(S(failed_slot).state.load(std::memory_order_acquire), TaskState::BUILDING);
     ASSERT_EQ(S(failed_slot).output_keys.size(), 2u);
-    EXPECT_EQ(tm.lookup(run_id, first_key), failed_slot)
+    EXPECT_EQ(map_producer(tm, run_id, first_key), failed_slot)
         << "the first fully-published output is needed to exercise cancellation cleanup";
-    EXPECT_EQ(tm.lookup(run_id, previous_key), previous.task_slot)
+    EXPECT_EQ(map_producer(tm, run_id, previous_key), previous.task_slot)
         << "a failed second insert displaced the prior owner before publication";
 
     orch.set_test_hook({});
@@ -1322,15 +1537,15 @@ TEST_F(OrchestratorFixture, SubmitOutputJournalFailurePreservesThePreviousOwnerA
         orch.fail_run_submission(run_id, std::make_exception_ptr(std::runtime_error("output publication failed")))
     );
     EXPECT_EQ(S(failed_slot).state.load(std::memory_order_acquire), TaskState::CONSUMED);
-    EXPECT_EQ(tm.lookup(run_id, first_key), INVALID_SLOT);
-    EXPECT_EQ(tm.lookup(run_id, previous_key), previous.task_slot)
+    EXPECT_EQ(map_producer(tm, run_id, first_key), INVALID_SLOT);
+    EXPECT_EQ(map_producer(tm, run_id, previous_key), previous.task_slot)
         << "failed-slot cleanup erased a TensorMap entry still owned by the running producer";
     EXPECT_FALSE(orch.run_done(run_id));
 
     S(previous.task_slot).state.store(TaskState::COMPLETED, std::memory_order_release);
     EXPECT_TRUE(orch.on_consumed(previous.task_slot));
     EXPECT_TRUE(orch.run_done(run_id));
-    EXPECT_EQ(tm.lookup(run_id, previous_key), INVALID_SLOT);
+    EXPECT_EQ(map_producer(tm, run_id, previous_key), INVALID_SLOT);
     EXPECT_EQ(allocator.active_count(), 0);
     EXPECT_THROW(orch.wait_run(run_id), std::runtime_error);
     orch.release_run(run_id);

--- a/tests/ut/cpp/hierarchical/test_tensormap.cpp
+++ b/tests/ut/cpp/hierarchical/test_tensormap.cpp
@@ -21,112 +21,301 @@ static TensorKey ck(uint64_t ptr, int32_t worker_id) { return TensorKey::local_c
 static constexpr RunId RUN1 = 1;
 static constexpr RunId RUN2 = 2;
 
+// Helper: a contiguous UINT8 view spanning [begin, end) of a `backing`-byte buffer — the simplest
+// footprint whose bytes are exactly the range named.
+static TensorFootprint br(uint64_t begin, uint64_t end, uint64_t backing = 4096) {
+    TensorFootprint f{};
+    f.byte_offset = begin;
+    f.backing_nbytes = backing;
+    f.ndims = 1;
+    f.shapes[0] = static_cast<uint32_t>(end - begin);
+    f.strides[0] = 1;
+    f.dtype = DataType::UINT8;
+    return f;
+}
+
+// Helper: rows [r0, r0+rows) x cols [c0, c0+cols) of a `R`x`C` UINT8 matrix. Two of these can be
+// disjoint while their bounding boxes intersect, which is what the per-dimension stage is for.
+static TensorFootprint tile(uint32_t r0, uint32_t rows, uint32_t c0, uint32_t cols, uint32_t R, uint32_t C) {
+    TensorFootprint f{};
+    f.byte_offset = static_cast<uint64_t>(r0) * C + c0;
+    f.backing_nbytes = static_cast<uint64_t>(R) * C;
+    f.ndims = 2;
+    f.shapes[0] = rows;
+    f.shapes[1] = cols;
+    f.strides[0] = C;
+    f.strides[1] = 1;
+    f.dtype = DataType::UINT8;
+    return f;
+}
+
+// Helper: the whole backing — what an arg with no narrower footprint claims.
+static TensorFootprint whole() { return TensorFootprint{}; }
+
+// Helper: producers overlapping `view`, in insertion order.
+static std::vector<TaskSlot> hits(const TensorMap &tm, RunId run_id, TensorKey key, const TensorFootprint &view) {
+    std::vector<TaskSlot> out;
+    tm.lookup_overlapping(run_id, key, view, out);
+    return out;
+}
+
+// Helper: the single producer of the whole backing, or INVALID_SLOT when there is none. Asserts
+// there is at most one — a test that uses this is stating the key holds one live writer.
+static TaskSlot sole(const TensorMap &tm, RunId run_id, TensorKey key) {
+    std::vector<TaskSlot> out = hits(tm, run_id, key, whole());
+    EXPECT_LE(out.size(), 1u);
+    return out.empty() ? INVALID_SLOT : out[0];
+}
+
 TEST(TensorMap, LookupEmptyReturnsInvalid) {
     TensorMap tm;
-    EXPECT_EQ(tm.lookup(RUN1, hk(0xDEADBEEF)), INVALID_SLOT);
+    EXPECT_EQ(sole(tm, RUN1, hk(0xDEADBEEF)), INVALID_SLOT);
 }
 
 TEST(TensorMap, InsertAndLookup) {
     TensorMap tm;
-    tm.insert(RUN1, hk(0x1000), 5);
-    EXPECT_EQ(tm.lookup(RUN1, hk(0x1000)), 5);
-    EXPECT_EQ(tm.lookup(RUN1, hk(0x2000)), INVALID_SLOT);
+    tm.insert(RUN1, hk(0x1000), whole(), 5);
+    EXPECT_EQ(sole(tm, RUN1, hk(0x1000)), 5);
+    EXPECT_EQ(sole(tm, RUN1, hk(0x2000)), INVALID_SLOT);
     EXPECT_EQ(tm.size(), 1);
 }
 
 TEST(TensorMap, OverwriteExistingEntry) {
     TensorMap tm;
-    tm.insert(RUN1, hk(0x1000), 3);
-    tm.insert(RUN1, hk(0x1000), 7);  // new producer reuses same buffer
-    EXPECT_EQ(tm.lookup(RUN1, hk(0x1000)), 7);
+    tm.insert(RUN1, hk(0x1000), whole(), 3);
+    tm.insert(RUN1, hk(0x1000), whole(), 7);  // new producer reuses same buffer
+    EXPECT_EQ(sole(tm, RUN1, hk(0x1000)), 7);
     EXPECT_EQ(tm.size(), 1);
 }
 
 TEST(TensorMap, EraseTaskOutputs) {
     TensorMap tm;
-    tm.insert(RUN1, hk(0x1000), 0);
-    tm.insert(RUN1, hk(0x2000), 0);
-    tm.insert(RUN1, hk(0x3000), 1);
+    tm.insert(RUN1, hk(0x1000), whole(), 0);
+    tm.insert(RUN1, hk(0x2000), whole(), 0);
+    tm.insert(RUN1, hk(0x3000), whole(), 1);
 
     tm.erase_task_outputs(RUN1, 0, {hk(0x1000), hk(0x2000)});
 
-    EXPECT_EQ(tm.lookup(RUN1, hk(0x1000)), INVALID_SLOT);
-    EXPECT_EQ(tm.lookup(RUN1, hk(0x2000)), INVALID_SLOT);
-    EXPECT_EQ(tm.lookup(RUN1, hk(0x3000)), 1);
+    EXPECT_EQ(sole(tm, RUN1, hk(0x1000)), INVALID_SLOT);
+    EXPECT_EQ(sole(tm, RUN1, hk(0x2000)), INVALID_SLOT);
+    EXPECT_EQ(sole(tm, RUN1, hk(0x3000)), 1);
     EXPECT_EQ(tm.size(), 1);
 }
 
 TEST(TensorMap, EraseWithEmptyKeyList) {
     TensorMap tm;
-    tm.insert(RUN1, hk(0x1000), 2);
+    tm.insert(RUN1, hk(0x1000), whole(), 2);
     tm.erase_task_outputs(RUN1, 2, {});
-    EXPECT_EQ(tm.lookup(RUN1, hk(0x1000)), 2);
+    EXPECT_EQ(sole(tm, RUN1, hk(0x1000)), 2);
 }
 
 TEST(TensorMap, MultipleEntries) {
     TensorMap tm;
     for (int i = 0; i < 100; ++i)
-        tm.insert(RUN1, hk(static_cast<uint64_t>(i) * 0x1000), i % 16);
+        tm.insert(RUN1, hk(static_cast<uint64_t>(i) * 0x1000), whole(), i % 16);
     EXPECT_EQ(tm.size(), 100);
     for (int i = 0; i < 100; ++i)
-        EXPECT_EQ(tm.lookup(RUN1, hk(static_cast<uint64_t>(i) * 0x1000)), i % 16);
+        EXPECT_EQ(sole(tm, RUN1, hk(static_cast<uint64_t>(i) * 0x1000)), i % 16);
 }
 
 // --- TensorKey compound key tests ---
 
 TEST(TensorMap, SamePtrDifferentEndpointAreDistinct) {
     TensorMap tm;
-    tm.insert(RUN1, ck(0xABC, 0), 10);
-    tm.insert(RUN1, ck(0xABC, 1), 20);
-    EXPECT_EQ(tm.lookup(RUN1, ck(0xABC, 0)), 10);
-    EXPECT_EQ(tm.lookup(RUN1, ck(0xABC, 1)), 20);
+    tm.insert(RUN1, ck(0xABC, 0), whole(), 10);
+    tm.insert(RUN1, ck(0xABC, 1), whole(), 20);
+    EXPECT_EQ(sole(tm, RUN1, ck(0xABC, 0)), 10);
+    EXPECT_EQ(sole(tm, RUN1, ck(0xABC, 1)), 20);
     EXPECT_EQ(tm.size(), 2);
 }
 
 TEST(TensorMap, HostAndChildKeyAreDistinct) {
     TensorMap tm;
-    tm.insert(RUN1, hk(0x1000), 5);
-    tm.insert(RUN1, ck(0x1000, 0), 6);
-    EXPECT_EQ(tm.lookup(RUN1, hk(0x1000)), 5);
-    EXPECT_EQ(tm.lookup(RUN1, ck(0x1000, 0)), 6);
+    tm.insert(RUN1, hk(0x1000), whole(), 5);
+    tm.insert(RUN1, ck(0x1000, 0), whole(), 6);
+    EXPECT_EQ(sole(tm, RUN1, hk(0x1000)), 5);
+    EXPECT_EQ(sole(tm, RUN1, ck(0x1000, 0)), 6);
     EXPECT_EQ(tm.size(), 2);
 }
 
 TEST(TensorMap, EraseChildKeyLeavesHostKey) {
     TensorMap tm;
-    tm.insert(RUN1, hk(0x1000), 5);
-    tm.insert(RUN1, ck(0x1000, 0), 6);
+    tm.insert(RUN1, hk(0x1000), whole(), 5);
+    tm.insert(RUN1, ck(0x1000, 0), whole(), 6);
     tm.erase_task_outputs(RUN1, 6, {ck(0x1000, 0)});
-    EXPECT_EQ(tm.lookup(RUN1, hk(0x1000)), 5);
-    EXPECT_EQ(tm.lookup(RUN1, ck(0x1000, 0)), INVALID_SLOT);
+    EXPECT_EQ(sole(tm, RUN1, hk(0x1000)), 5);
+    EXPECT_EQ(sole(tm, RUN1, ck(0x1000, 0)), INVALID_SLOT);
     EXPECT_EQ(tm.size(), 1);
 }
 
 TEST(TensorMap, SameAddressIsNamespacedByRun) {
     TensorMap tm;
-    tm.insert(RUN1, hk(0x1000), 5);
-    tm.insert(RUN2, hk(0x1000), 9);
+    tm.insert(RUN1, hk(0x1000), whole(), 5);
+    tm.insert(RUN2, hk(0x1000), whole(), 9);
 
-    EXPECT_EQ(tm.lookup(RUN1, hk(0x1000)), 5);
-    EXPECT_EQ(tm.lookup(RUN2, hk(0x1000)), 9);
+    EXPECT_EQ(sole(tm, RUN1, hk(0x1000)), 5);
+    EXPECT_EQ(sole(tm, RUN2, hk(0x1000)), 9);
     EXPECT_EQ(tm.size(), 2);
 
     tm.erase_task_outputs(RUN1, 5, {hk(0x1000)});
-    EXPECT_EQ(tm.lookup(RUN1, hk(0x1000)), INVALID_SLOT);
-    EXPECT_EQ(tm.lookup(RUN2, hk(0x1000)), 9);
+    EXPECT_EQ(sole(tm, RUN1, hk(0x1000)), INVALID_SLOT);
+    EXPECT_EQ(sole(tm, RUN2, hk(0x1000)), 9);
 }
 
 TEST(TensorMap, EraseKeepsNewerSameRunProducer) {
     TensorMap tm;
-    tm.insert(RUN1, hk(0x1000), 3);
-    tm.insert(RUN1, hk(0x1000), 7);  // unordered second writer of the same key
+    tm.insert(RUN1, hk(0x1000), whole(), 3);
+    tm.insert(RUN1, hk(0x1000), whole(), 7);  // unordered second writer of the same key
 
     // Slot 3 no longer owns the key; its cleanup must not evict slot 7.
     tm.erase_task_outputs(RUN1, 3, {hk(0x1000)});
-    EXPECT_EQ(tm.lookup(RUN1, hk(0x1000)), 7);
+    EXPECT_EQ(sole(tm, RUN1, hk(0x1000)), 7);
     EXPECT_EQ(tm.size(), 1);
 
     tm.erase_task_outputs(RUN1, 7, {hk(0x1000)});
-    EXPECT_EQ(tm.lookup(RUN1, hk(0x1000)), INVALID_SLOT);
+    EXPECT_EQ(sole(tm, RUN1, hk(0x1000)), INVALID_SLOT);
     EXPECT_EQ(tm.size(), 0);
+}
+
+// --- Byte-range overlap: which same-key entries actually conflict ---
+
+TEST(TensorMap, DisjointRangesUnderOneKeyAreIndependentProducers) {
+    // The rank-major case: two workers write `x[0]` and `x[1]` of one backing. They share a key
+    // by construction, and neither may resolve as the other's producer.
+    TensorMap tm;
+    tm.insert(RUN1, hk(0x1000), br(0, 64), 1);
+    tm.insert(RUN1, hk(0x1000), br(64, 128), 2);
+
+    EXPECT_EQ(tm.size(), 2);
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), br(0, 64)), (std::vector<TaskSlot>{1}));
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), br(64, 128)), (std::vector<TaskSlot>{2}));
+}
+
+TEST(TensorMap, OverlappingRangeResolvesEveryProducerItTouches) {
+    TensorMap tm;
+    tm.insert(RUN1, hk(0x1000), br(0, 64), 1);
+    tm.insert(RUN1, hk(0x1000), br(64, 128), 2);
+
+    // A reader of the whole backing depends on both half-writers.
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), whole()), (std::vector<TaskSlot>{1, 2}));
+    // A reader straddling the boundary depends on both; one strictly inside, on one.
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), br(32, 96)), (std::vector<TaskSlot>{1, 2}));
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), br(8, 16)), (std::vector<TaskSlot>{1}));
+}
+
+TEST(TensorMap, TouchingRangesDoNotOverlap) {
+    // Ranges are half-open, so `end == begin` of the next is adjacency, not a shared byte.
+    TensorMap tm;
+    tm.insert(RUN1, hk(0x1000), br(0, 64), 1);
+    EXPECT_TRUE(hits(tm, RUN1, hk(0x1000), br(64, 128)).empty());
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), br(63, 128)), (std::vector<TaskSlot>{1}));
+}
+
+TEST(TensorMap, CoveringWriteSupersedesTheEntriesUnderIt) {
+    TensorMap tm;
+    tm.insert(RUN1, hk(0x1000), br(0, 64), 1);
+    tm.insert(RUN1, hk(0x1000), br(64, 128), 2);
+    tm.insert(RUN1, hk(0x1000), br(0, 128), 3);
+
+    // Neither half-writer is the last word on any byte any more.
+    EXPECT_EQ(tm.size(), 1);
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), whole()), (std::vector<TaskSlot>{3}));
+}
+
+TEST(TensorMap, PartiallyCoveredProducerSurvivesForItsOwnBytes) {
+    TensorMap tm;
+    tm.insert(RUN1, hk(0x1000), br(0, 128), 1);
+    tm.insert(RUN1, hk(0x1000), br(0, 64), 2);  // rewrites only the first half
+
+    EXPECT_EQ(tm.size(), 2);
+    // Slot 1 still owns [64, 128), so a reader of that half must not lose the edge to it.
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), br(64, 128)), (std::vector<TaskSlot>{1}));
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), br(0, 64)), (std::vector<TaskSlot>{1, 2}));
+}
+
+TEST(TensorMap, EraseDropsEveryRangeATaskStillOwns) {
+    TensorMap tm;
+    tm.insert(RUN1, hk(0x1000), br(0, 64), 1);
+    tm.insert(RUN1, hk(0x1000), br(64, 128), 1);  // one task writing two disjoint views
+    tm.insert(RUN1, hk(0x1000), br(128, 192), 2);
+
+    // output_keys records the key once per arg, so cleanup replays it twice; both of slot 1's
+    // ranges go, and the unrelated writer stays.
+    tm.erase_task_outputs(RUN1, 1, {hk(0x1000), hk(0x1000)});
+    EXPECT_EQ(tm.size(), 1);
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), whole()), (std::vector<TaskSlot>{2}));
+}
+
+TEST(TensorMap, AWholeBackingWriteSupersedesEveryRangeUnderIt) {
+    // What Orchestrator::alloc registers: no narrower footprint, so it owns the whole backing.
+    TensorMap tm;
+    tm.insert(RUN1, hk(0x1000), br(0, 64), 1);
+    tm.insert(RUN1, hk(0x1000), whole(), 2);
+    EXPECT_EQ(tm.size(), 1);
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), br(0, 8)), (std::vector<TaskSlot>{2}));
+}
+
+// --- Per-dimension refinement: bounding boxes intersect, the views do not ---
+
+TEST(TensorMap, DisjointColumnBlocksAreIndependentProducers) {
+    // `x[:, 0:4]` and `x[:, 8:12]` of a 16x16 matrix. Every row of the first sits between two rows
+    // of the second, so their bounding ranges interleave -- [0, 244) and [8, 252) -- and stage 1
+    // alone would wire an edge. The per-axis test rejects on the column axis.
+    TensorMap tm;
+    tm.insert(RUN1, hk(0x1000), tile(0, 16, 0, 4, 16, 16), 1);
+    tm.insert(RUN1, hk(0x1000), tile(0, 16, 8, 4, 16, 16), 2);
+
+    EXPECT_EQ(tm.size(), 2);
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), tile(0, 16, 0, 4, 16, 16)), (std::vector<TaskSlot>{1}));
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), tile(0, 16, 8, 4, 16, 16)), (std::vector<TaskSlot>{2}));
+}
+
+TEST(TensorMap, DisjointTilesAreIndependentProducers) {
+    // A 2x2 grid of 8x8 tiles over one 16x16 matrix: four writers, no edge between any pair.
+    TensorMap tm;
+    tm.insert(RUN1, hk(0x1000), tile(0, 8, 0, 8, 16, 16), 1);
+    tm.insert(RUN1, hk(0x1000), tile(0, 8, 8, 8, 16, 16), 2);
+    tm.insert(RUN1, hk(0x1000), tile(8, 8, 0, 8, 16, 16), 3);
+    tm.insert(RUN1, hk(0x1000), tile(8, 8, 8, 8, 16, 16), 4);
+
+    EXPECT_EQ(tm.size(), 4);
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), tile(0, 8, 0, 8, 16, 16)), (std::vector<TaskSlot>{1}));
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), tile(8, 8, 8, 8, 16, 16)), (std::vector<TaskSlot>{4}));
+}
+
+TEST(TensorMap, TilesSharingABlockStillDepend) {
+    // The converse: tiles that do share elements keep their edge.
+    TensorMap tm;
+    tm.insert(RUN1, hk(0x1000), tile(0, 8, 0, 8, 16, 16), 1);
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), tile(4, 8, 4, 8, 16, 16)), (std::vector<TaskSlot>{1}));
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), tile(0, 16, 0, 16, 16, 16)), (std::vector<TaskSlot>{1}));
+}
+
+TEST(TensorMap, ATileWriteSupersedesOnlyTheTilesItContains) {
+    TensorMap tm;
+    tm.insert(RUN1, hk(0x1000), tile(0, 4, 0, 4, 16, 16), 1);
+    tm.insert(RUN1, hk(0x1000), tile(0, 4, 8, 4, 16, 16), 2);
+    // Rewrites the top-left quadrant: covers slot 1 whole, does not touch slot 2's columns.
+    tm.insert(RUN1, hk(0x1000), tile(0, 8, 0, 8, 16, 16), 3);
+
+    EXPECT_EQ(tm.size(), 2);
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), tile(0, 4, 0, 4, 16, 16)), (std::vector<TaskSlot>{3}));
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), tile(0, 4, 8, 4, 16, 16)), (std::vector<TaskSlot>{2}));
+}
+
+TEST(TensorMap, ARowBlockAndAColumnBlockCross) {
+    // A row block and a column block of one matrix always share a corner, whatever their offsets.
+    TensorMap tm;
+    tm.insert(RUN1, hk(0x1000), tile(0, 4, 0, 16, 16, 16), 1);
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), tile(0, 16, 12, 4, 16, 16)), (std::vector<TaskSlot>{1}));
+}
+
+TEST(TensorMap, MismatchedAxisLayoutsFallBackToConservative) {
+    // Stage 2 models only pairs sharing one canonical row-major layout. A 16x16 view and a flat
+    // 256-element view of the same backing do not, so they are assumed to conflict even where a
+    // per-element answer would say otherwise.
+    TensorMap tm;
+    tm.insert(RUN1, hk(0x1000), tile(0, 4, 0, 4, 16, 16), 1);
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), br(0, 256, 256)), (std::vector<TaskSlot>{1}));
+    EXPECT_EQ(hits(tm, RUN1, hk(0x1000), br(200, 256, 256)), (std::vector<TaskSlot>{}));
 }


### PR DESCRIPTION
## Summary

`Orchestrator::infer_deps` keyed a local `Tensor` on `hash(buffer.identity)` alone and dropped the view's offset, so every view of one backing resolved as every other's producer. A host key carries no worker id, so nothing else separated them: two workers handed `x[0]` and `x[1]` of one rank-major host tensor took a `rank0 -> rank1` edge and serialized. Each rank's kernel is meanwhile spinning on the other's cross-rank notify, so the dispatch that would release it is the one held back — the run deadlocks rather than merely slowing down.

The key was buffer-granular on purpose; the source comment recorded the offset refinement as "a future precision pass". This is that pass.

- **`TensorMap` holds every live producer per key**, not one slot, and a lookup returns only the ones whose view the querying view actually touches. Multi-entry is what makes the refinement sound rather than merely permissive: with one slot per key, rank 1's `insert` evicts rank 0 and a later reader of `x[0]` infers no dependency at all.
- **The overlap cascade is ported from L2's `PTO2TensorMap::check_overlap`**, which already hashes by base address and walks the chain:
  1. Bounding range `[byte_offset, byte_offset + extent)`. O(1), and enough for a leading-axis slice, which is contiguous.
  2. Per-dimension intersection where the boxes do overlap. A bounding box cannot answer `x[:, 0:4]` versus `x[:, 8:12]` — every row of one sits between two rows of the other, so the boxes interleave (`[0, 244)` and `[8, 252)` for a 16x16 matrix) while the views are disjoint. The reference shape is recovered from the stride vector, each origin decomposes into per-axis coordinates, and the axes intersect one at a time.
- **An `insert` drops only the entries it covers whole.** One it reaches into but not past stays live, because it remains the last writer of the bytes outside. That also closes a false *negative* the single-slot map had: a sub-view write used to displace a whole-buffer producer outright, leaving a reader of the untouched part with no edge to it.
- **`tensors_overlap` runs the same comparison**, so the submit-time check is fixed in the same shape — two arguments of one task naming disjoint tiles of one buffer were being rejected as overlapping writes.

### Precision limits, and why they matter here

Stage 2 models only pairs sharing one canonical row-major layout: same dtype and `ndims`, identical `strides` descending as exact multiples down to 1, origins on that layout's lattice. A transposed pair, a stepped slice, or two views of different rank over one backing fall through as overlapping, as does a producer a later write only partly covers.

Every fallback is in that one direction — an extra edge is possible where the truth is subtler, a real dependency is never dropped. But an extra edge is not free here: between two tasks that rendezvous with each other it holds back the dispatch that would release the other, which is exactly this bug. Precision is a correctness property on this path, not a performance one.

### Out of scope

The remote-sidecar path is unchanged. Its key already folds `offset` in, so every entry under one denotes the same origin; it takes the default whole-backing footprint and behaves bit-identically. Moving it onto the same model means dropping `offset` from the key, which `HOST_INLINE` is not ready for — it pins `buffer_id` and `generation` to zero, so `offset` is the only thing separating two inline payloads today. What that upgrade needs is written down in the two remote design docs rather than half-done here.

## Testing

- [x] C++ unit tests — 105/105 pass.
  - `Orchestrator`, end to end through `infer_deps`: two `INOUT` rank slices dispatch with no dependency; two `INOUT` column blocks and a 2x2 grid of four `INOUT` tiles likewise; intersecting tiles still take their edge; a whole-backing reader depends on every disjoint writer; consuming one disjoint writer leaves the other.
  - `TensorMap`, on the cascade directly: disjoint column blocks, a tile grid, tiles sharing a block, partial supersede, a row block crossing a column block, and the conservative fallback for a mismatched axis layout.
- [x] Python unit tests — 1653 passed, 6 skipped.
- [x] Simulation tests — full `pytest examples tests/st --platform a2a3sim`: 21 scene tests + both L2 batches pass.
- [ ] Hardware tests — not run locally; the deadlock repro lives in pypto-lib.

Red-checked in both layers. Reverting the footprint to buffer-granular fails the rank-slice cases. Short-circuiting stage 2 to the bounding box alone leaves the rank-slice case passing (it is contiguous) and fails exactly the column-block and tile cases — at both the `Orchestrator` and `TensorMap` levels — while the intersecting-tile case keeps passing throughout.

Fixes hw-native-sys/pypto#2448