### PR TITLE
Fix: fail Worker init when the SDMA warmup faults the card

### DIFF
--- a/docs/comm-domain.md
+++ b/docs/comm-domain.md
@@ -236,6 +236,20 @@ the resident `KernelArgs`, and injects it into every run's kernel
 `GlobalContext` (`get_dma_workspace`). A Worker without `enable_sdma` creates no
 SDMA streams and its kernels read a zero workspace address. The workspace is
 released at Worker finalize by ordinary stream/manager teardown.
+
+Provisioning also warms the SDMA control path once, in the same call: a
+vector-only AICore ELF (`sdma_warmup_kernel.o`, staged per arch under
+`build/lib/<arch>/sdma_warmup/`) walks every channel so the first
+`TPREFETCH_ASYNC` of a run does not pay the cold STARS submit-queue publication
+(~92 µs per channel, ~4.4 ms of init for all 48). Either way the Worker comes
+up; the two ways of not having the ELF differ only in what says so. An arch that
+carries no `sdma_warmup_kernel.cpp` builds none by design and reports nothing —
+a5 is that case, so its first `TPREFETCH_ASYNC` still pays the cold path. An arch
+that carries the source but staged no object is a build or staging regression,
+and is warned about twice: by the runtime builder and again at Worker init. A
+warmup whose device launch or sync *fails* is not in this category at all — it
+fails Worker init, because the card it faulted on must not reach the first run.
+
 Communication-domain allocation does not create SDMA streams or carry the
 workspace through `CommContext`. Because an SDMA-enabled Worker's 48 STARS
 streams sit in the device fault/sync domain, a fault on that Worker slows its

--- a/simpler_setup/runtime_builder.py
+++ b/simpler_setup/runtime_builder.py
@@ -463,11 +463,25 @@ class RuntimeBuilder:
         without it the first TPREFETCH_ASYNC pays the cold SDMA control path
         (~4.4 ms) but nothing breaks, so this is deliberately not validated the
         way ``_resolve_dispatcher_path`` is.
+
+        A missing ELF for an arch that *does* carry the source is a build or
+        staging regression, and every consumer of it degrades silently, so it is
+        warned about here rather than left to be noticed as lost performance.
         """
         if self._variant == "sim":
             return None
         path = self._LIB_DIR / self._arch / "sdma_warmup" / "sdma_warmup_kernel.o"
-        return path if path.is_file() else None
+        if path.is_file():
+            return path
+        source = PROJECT_ROOT / "src" / self._arch / "platform" / "onboard" / "aicore" / "sdma_warmup_kernel.cpp"
+        if source.is_file():
+            logger.warning(
+                "SDMA warmup ELF not staged at %s though %s carries its source; "
+                "an enable_sdma Worker will pay the cold SDMA control path on its first TPREFETCH_ASYNC",
+                path,
+                self._arch,
+            )
+        return None
 
     def _resolve_dispatcher_path(self) -> Optional[Path]:
         """Return path to libsimpler_aicpu_dispatcher.so for onboard variants.

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -263,7 +263,7 @@ private:
     // enqueue on the same DeviceRunner can recover in place; if the drain itself
     // errors the context is unrecoverable without a full reset, so flip
     // device_unusable_ and let admission/enqueue fail fast.
-    void recover_device_or_mark_unusable(int aicore_rc);
+    void recover_device_or_mark_unusable(int aicore_rc) override;
 
     // Force-reset the card via aclrtResetDeviceForce to clear an op-timeout
     // sticky-error that the soft rtDeviceReset cannot (a soft reset + fresh

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -224,7 +224,7 @@ private:
     // enqueue on the same DeviceRunner can recover in place; if the drain itself
     // errors the context is unrecoverable without a full reset, so flip
     // device_unusable_ and let admission/enqueue fail fast.
-    void recover_device_or_mark_unusable(int aicore_rc);
+    void recover_device_or_mark_unusable(int aicore_rc) override;
 
     // Force-reset the card via aclrtResetDeviceForce to clear an op-timeout
     // sticky-error that the soft rtDeviceReset cannot (verified: a soft reset

--- a/src/common/platform/include/common/sdma_warmup_layout.h
+++ b/src/common/platform/include/common/sdma_warmup_layout.h
@@ -14,8 +14,7 @@
  * launcher (DeviceRunnerBase::launch_sdma_warmup_kernel).
  */
 
-#ifndef SRC_COMMON_PLATFORM_INCLUDE_COMMON_SDMA_WARMUP_LAYOUT_H_
-#define SRC_COMMON_PLATFORM_INCLUDE_COMMON_SDMA_WARMUP_LAYOUT_H_
+#pragma once
 
 #include <cstdint>
 
@@ -27,8 +26,8 @@
 constexpr uint32_t kSdmaWarmupStatusStrideBytes = 64U;
 
 // Slot values. 0 (the host-side zero fill) therefore means "no core reached this
-// channel", which is a distinct failure from the warmup declining its
-// preconditions.
+// channel", which the launcher reports separately from the warmup declining its
+// preconditions on a channel it did reach.
 constexpr uint32_t kSdmaWarmupStatusOk = 1U;
 constexpr uint32_t kSdmaWarmupStatusFailed = 2U;
 
@@ -39,5 +38,3 @@ constexpr uint32_t kSdmaWarmupStatusFailed = 2U;
 // copies serialize behind the engine instead of overlapping it. 8 clears that
 // cliff and, unlike a channel-count-derived value, stays valid on any AIV count.
 constexpr uint32_t kSdmaWarmupBlockDim = 8U;
-
-#endif  // SRC_COMMON_PLATFORM_INCLUDE_COMMON_SDMA_WARMUP_LAYOUT_H_

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -971,9 +971,19 @@ int DeviceRunnerBase::provision_dma_workspace(
         return rc;
     }
 
-    // Best-effort, and deliberately after the re-latch: warming needs the live
-    // workspace, and its outcome must not gate provisioning.
-    (void)launch_sdma_warmup_kernel(sdma_warmup_binary, sdma_warmup_size);
+    // Deliberately after the re-latch: warming needs the live workspace. An
+    // unavailable warmup leaves provisioning successful, because the only cost is
+    // first-call latency. A device error does not: the card the warmup just faulted
+    // on would otherwise reach the first run. No dma_workspace_release() on that
+    // path — launch_sdma_warmup_kernel() has marked the runner unusable, and
+    // per-resource release on a faulted card is exactly what finalize()'s fatal
+    // path exists to avoid. The workspace handle stays set so that path still sees
+    // an SDMA generation and applies its handoff delay.
+    rc = launch_sdma_warmup_kernel(sdma_warmup_binary, sdma_warmup_size);
+    if (rc != 0) {
+        LOG_ERROR("provision_dma_workspace: sdma warmup left the device unusable: %d", rc);
+        return rc;
+    }
     return 0;
 }
 
@@ -1054,9 +1064,13 @@ int DeviceRunnerBase::launch_sdma_warmup_kernel(const void *binary, size_t size)
     const double elapsed_ms =
         std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - started).count();
     if (rc != 0) {
-        LOG_WARN("sdma warmup: launch/sync failed: %d; first TPREFETCH_ASYNC will pay the cold path", rc);
-        free_tensor(status_dev);
-        return 0;
+        LOG_ERROR("sdma warmup: launch/sync failed: %d; the card is left poisoned", rc);
+        // No free_tensor(status_dev): rtFree on a card that just failed an AICore
+        // operation can block in DEV_RUNNING_DOWN. The allocation stays tracked by
+        // mem_alloc_ and is forgotten wholesale by the fatal teardown the mark
+        // below routes finalize() into.
+        recover_device_or_mark_unusable(rc);
+        return rc;
     }
 
     report_sdma_warmup_status(status_dev, channel_count, elapsed_ms);
@@ -1074,12 +1088,17 @@ void DeviceRunnerBase::report_sdma_warmup_status(void *status_dev, uint32_t chan
     }
 
     uint32_t warmed = 0;
+    uint32_t declined = 0;
     for (uint32_t channel = 0; channel < channel_count; ++channel) {
         uint32_t slot = 0;
         std::memcpy(
             &slot, status_host.data() + static_cast<size_t>(channel) * kSdmaWarmupStatusStrideBytes, sizeof(slot)
         );
-        if (slot == kSdmaWarmupStatusOk) ++warmed;
+        if (slot == kSdmaWarmupStatusOk) {
+            ++warmed;
+        } else if (slot == kSdmaWarmupStatusFailed) {
+            ++declined;
+        }
     }
     // TIMING, not INFO: this is a one-off multi-millisecond init cost paid to
     // remove the same cost from the first run, so it belongs with the other
@@ -1087,9 +1106,13 @@ void DeviceRunnerBase::report_sdma_warmup_status(void *status_dev, uint32_t chan
     if (warmed == channel_count) {
         LOG_TIMING("sdma warmup: %u/%u channels warmed in %.2f ms", warmed, channel_count, elapsed_ms);
     } else {
+        // The two shortfalls have different causes: a declined channel was reached
+        // but failed the warmup's preconditions (unpopulated SQ, non-empty queue),
+        // while an unreached one means the walk itself did not cover the channel.
         LOG_WARN(
-            "sdma warmup: only %u/%u channels warmed in %.2f ms; the rest keep their cold-start cost", warmed,
-            channel_count, elapsed_ms
+            "sdma warmup: only %u/%u channels warmed in %.2f ms (%u declined, %u unreached); "
+            "the rest keep their cold-start cost",
+            warmed, channel_count, elapsed_ms, declined, channel_count - warmed - declined
         );
     }
 }

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -402,8 +402,9 @@ public:
      * by finalize_common().
      *
      * `sdma_warmup_binary` / `sdma_warmup_size`, when non-empty, are handed to
-     * launch_sdma_warmup_kernel() once the workspace is live. A failed or absent
-     * warmup does NOT fail provisioning.
+     * launch_sdma_warmup_kernel() once the workspace is live. An absent or
+     * unrunnable warmup does NOT fail provisioning; a warmup whose device launch or
+     * sync fails does, and leaves the runner marked unusable.
      *
      * @return 0 on success, negative on unsupported/failed provisioning.
      */
@@ -516,11 +517,20 @@ public:
 
     /**
      * Whether this runner may start another run without first being finalized.
-     * The shared c_api checks this before attaching the thread or provisioning
-     * optional resources, so a poisoned runner cannot create SDMA streams on
-     * its way to the arch-specific enqueue fail-fast guard.
+     * The shared c_api checks this at every run boundary (prepare / launch /
+     * finalize), so a poisoned runner fails admission ahead of the arch-specific
+     * enqueue fail-fast guard.
      */
     virtual bool can_accept_run() const = 0;
+
+    /**
+     * An AICore launch or stream sync failed outside the per-run path. The arch
+     * runner drains what it can and flips its device-unusable flag, so the next
+     * admission fails fast and finalize() takes its fatal teardown path instead of
+     * per-resource release on a faulted card. The base default is a no-op for
+     * runners that track no such state.
+     */
+    virtual void recover_device_or_mark_unusable(int /*aicore_rc*/) {}
 
     /** Invalidate retained run streams after new AICore code is published. */
     virtual void mark_run_streams_stale() {}
@@ -677,19 +687,24 @@ public:
      * (`RT_DEV_BINARY_MAGIC_ELF_AIVEC`, its own handle) because the executor is a
      * resident loop launched per run with a `block_dim_` that is still 0 here.
      *
-     * Best-effort by design: an absent binary, a launch failure or a channel that
-     * declines to warm are all logged and swallowed, since the only consequence is
-     * first-call latency.
+     * Unavailability is best-effort and returns 0: an absent binary, no channels,
+     * a failed registration or allocation, and a channel that declines to warm all
+     * cost only first-call latency. A failed launch or stream sync is not, because
+     * it means an AICore operation faulted on this card; that marks the runner
+     * unusable and returns the error so the caller does not hand a poisoned device
+     * to the first run.
      *
-     * @return 0 always.
+     * @return 0 when the warmup ran or was unavailable, the device error otherwise.
      */
     int launch_sdma_warmup_kernel(const void *binary, size_t size);
 
     /**
      * Read back the warmup kernel's per-channel status slots and report how many
-     * channels came up warm. Takes ownership of `status_dev` and frees it.
-     * `elapsed_ms` is the launch-to-sync wall time, reported alongside the count
-     * because it is the init-time cost being traded for first-run latency.
+     * channels came up warm, splitting the remainder into channels that declined
+     * the warmup's preconditions and channels no core reached. Takes ownership of
+     * `status_dev` and frees it. `elapsed_ms` is the launch-to-sync wall time,
+     * reported alongside the count because it is the init-time cost being traded
+     * for first-run latency.
      */
     void report_sdma_warmup_status(void *status_dev, uint32_t channel_count, double elapsed_ms);
 

--- a/src/common/platform_comm/comm.h
+++ b/src/common/platform_comm/comm.h
@@ -86,7 +86,8 @@ uint32_t dma_workspace_supported_mask(void);
 /**
  * Number of SDMA channels the provisioned workspace describes, i.e. how many
  * channels the control-path warmup must walk. Exposed through the comm seam
- * because it comes from a PTO constant (kSdmaMaxChannel) and src/common must
+ * because it comes from a PTO constant (kSdmaMaxChannelGroups, the count
+ * SdmaWorkspaceManager::Init actually creates streams for) and src/common must
  * not include PTO headers.
  */
 uint32_t dma_workspace_channel_count(void);

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -468,9 +468,10 @@ size_t get_run_stream_set_create_count(DeviceContextHandle ctx);
  *
  * `sdma_warmup_binary` / `sdma_warmup_size` carry the vector-only ELF that walks
  * the SDMA control path once per channel against the workspace just provisioned,
- * so the first TPREFETCH_ASYNC does not pay that cold start. Optional: a
- * null/empty buffer skips the warmup, and a warmup that fails does not fail
- * provisioning — it only costs first-call latency.
+ * so the first TPREFETCH_ASYNC does not pay that cold start. A null/empty buffer,
+ * or a warmup the platform cannot run, skips it and still provisions
+ * successfully — the only cost is first-call latency. A warmup whose device launch
+ * or sync fails does fail provisioning, because that card is then poisoned.
  */
 int simpler_provision_dma_workspace(
     DeviceContextHandle ctx, uint32_t required_mask, const void *sdma_warmup_binary, uint64_t sdma_warmup_size

--- a/tests/ut/py/test_runtime_builder.py
+++ b/tests/ut/py/test_runtime_builder.py
@@ -8,6 +8,7 @@
 # -----------------------------------------------------------------------------------------------------------
 """Tests for RuntimeBuilder class."""
 
+import logging
 import textwrap
 from pathlib import Path
 from unittest.mock import patch
@@ -295,6 +296,41 @@ class TestRuntimeBuilderGetBinaries:
         builder, _ = self._isolated_builder(MockCompiler, tmp_path, monkeypatch, "a2a3")
 
         assert builder.get_binaries("test_rt", build=True).sdma_warmup_path is None
+
+    def _make_warmup_source(self, tmp_path, arch):
+        """Create the arch's warmup kernel source, the 'this arch builds one' marker."""
+        source = tmp_path / "src" / arch / "platform" / "onboard" / "aicore" / "sdma_warmup_kernel.cpp"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text("// fake warmup kernel\n")
+        return source
+
+    @patch("simpler_setup.runtime_builder.RuntimeCompiler")
+    def test_warns_when_an_arch_with_warmup_source_staged_nothing(self, MockCompiler, tmp_path, monkeypatch, caplog):
+        """A build/staging regression must be visible, not just slower.
+
+        Every consumer of the warmup ELF degrades silently when it is missing, so
+        an arch that carries the source but staged no object is the one case that
+        has to say something.
+        """
+        self._make_runtime(tmp_path, "a2a3")
+        self._make_warmup_source(tmp_path, "a2a3")
+        builder, _ = self._isolated_builder(MockCompiler, tmp_path, monkeypatch, "a2a3")
+
+        with caplog.at_level(logging.WARNING, logger="simpler_setup.runtime_builder"):
+            assert builder.get_binaries("test_rt", build=True).sdma_warmup_path is None
+
+        assert "SDMA warmup ELF not staged" in caplog.text
+
+    @patch("simpler_setup.runtime_builder.RuntimeCompiler")
+    def test_no_warning_for_an_arch_that_builds_no_warmup(self, MockCompiler, tmp_path, monkeypatch, caplog):
+        """Absent source means the arch never builds one, which is not a regression."""
+        self._make_runtime(tmp_path, "a5")
+        builder, _ = self._isolated_builder(MockCompiler, tmp_path, monkeypatch, "a5")
+
+        with caplog.at_level(logging.WARNING, logger="simpler_setup.runtime_builder"):
+            assert builder.get_binaries("test_rt", build=True).sdma_warmup_path is None
+
+        assert "SDMA warmup ELF not staged" not in caplog.text
 
     @patch("simpler_setup.runtime_builder.RuntimeCompiler")
     def test_resolves_staged_sdma_warmup_elf(self, MockCompiler, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Follow-up to #1896. The warmup launcher treated every outcome as best-effort, including the one that is not: a `rtKernelLaunchWithHandleV2` / `rtStreamSynchronize` failure means an AICore operation faulted on this card, and swallowing it reported `provision_dma_workspace` success and handed the poisoned device to the first run. The same path called `free_tensor` on the status buffer — the per-resource `rtFree` that blocks in `DEV_RUNNING_DOWN` and that #1664's fatal teardown was written to avoid.

- Split *unavailable* from *failed*. An absent ELF, zero channels, a failed `rtRegisterAllKernel` or allocation still provision successfully — the only cost is first-call latency. A failed launch or sync marks the runner unusable and fails provisioning.
- Promote `recover_device_or_mark_unusable` to a `DeviceRunnerBase` virtual (default no-op) so the shared launcher can reach each arch's `device_unusable_` flag. Its doc comment already described exactly this trigger ("on an AICore launch/sync error").
- Do not free the status buffer on the failed path; the allocation stays tracked and is abandoned wholesale by the fatal teardown the mark routes `finalize()` into.
- Report `declined` and `unreached` channels separately. `sdma_warmup_layout.h` already encoded the distinction (slot 0 vs 2) and nothing surfaced it.
- Warn at build time when an arch carries `sdma_warmup_kernel.cpp` but staged no object. Every consumer of a missing ELF degrades silently, so a staging regression was invisible in both the build and the run.
- Comment/doc corrections in the same subsystem: the comm seam named `kSdmaMaxChannel` where the implementation deliberately returns `kSdmaMaxChannelGroups`; `docs/comm-domain.md` did not mention that provisioning now warms 48 channels or what happens when that fails; the new layout header used an `#ifndef` guard where codestyle §12 asks for `#pragma once`.

## Why this ordering is safe

`provision_dma_workspace` does **not** call `dma_workspace_release()` on the failed path, deliberately: the runner is already marked unusable, and per-resource release on a faulted card is what the fatal path exists to skip. Leaving `dma_workspace_handle_` set is also load-bearing — `DeviceRunner::finalize()` reads it to decide that this Worker holds the 48 CP-process SDMA streams and therefore needs the handoff delay and the single-attempt reset budget (see [docs/investigations/2026-07-a2a3-sdma-fault-teardown.md](docs/investigations/2026-07-a2a3-sdma-fault-teardown.md), #1425).

## Validation

Onboard a2a3, all runs under `task-submit`.

**Happy path unchanged** — `prefetch_async_demo` standalone with `--log-level timing`:

```text
[TIMING] report_sdma_warmup_status: sdma warmup: 48/48 channels warmed in 10.07 ms
  TestPrefetchAsyncDemo::prefetch_copy PASSED
```

**New failure path, by temporary fault injection** (illegal `block_dim` at the launch site, reverted before commit). The whole chain fires in order, and Worker init now refuses instead of continuing:

```text
[ERROR] launch_sdma_warmup_kernel: sdma warmup: launch/sync failed: 507034; the card is left poisoned
[ERROR] recover_device_or_mark_unusable: AICore error 507034: bounded device drain failed: 507034 (force reset will follow in finalize)
[ERROR] provision_dma_workspace: sdma warmup left the device unusable: 507034
[WARN]  finalize: SDMA fatal teardown workaround (CANN 9.0.0/driver 26.0.rc1): waiting 50000 ms before force reset
[WARN]  finalize_common_impl: Fatal teardown: force reset/quarantine finished; skipping per-resource RTS destroy/free calls
RuntimeError: async-DMA workspace provisioning (mask=1) failed with code 507034
```

That last line is the point: previously this run continued onto a poisoned card. Teardown stayed bounded at ~56 s, which is #1664's contract, not a regression.

**Suites** — `pytest examples tests/st -m sdma --platform a2a3` 3/3 passed (`prefetch_async_demo`, `sdma_async_completion_demo`, `test_sdma_worker_aicore_fault_teardown_is_bounded`); `pytest tests/ut/py` 1653 passed / 13 skipped; `ruff`, `pyright`, `clang-format -n --Werror` clean on every touched file.

## Not addressed

- `kSdmaWarmupBlockDim` is still launched unclamped by `max_vector_cores_`, so the header's "stays valid on any AIV count" claim is enforced by a2a3 having 48 AIVs rather than by the code. One line if you want it here.
- The `recover_device_or_mark_unusable` declaration comments in both arch headers say the flag is flipped "if the drain itself errors", while the implementation flips it unconditionally (the `.cpp` explains why). Pre-existing; left alone rather than rewritten in a change that only adds `override`.
- `simpler_provision_dma_workspace` remains an unversioned dlsym'd C symbol, so a stale `_task_interface` against a fresh `host_runtime.so` reads uninitialized argument registers for the warmup pointer. The pipeline-contract UT pins `ChipWorker::init` but nothing pins the C API.
- #1425 itself is untouched and still open — this only stops one new way of entering its window unnoticed.
