### PR TITLE
Fix: align diagnostic flags with effective values

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -726,7 +726,7 @@ def pytest_collection_modifyitems(session, config, items):  # noqa: PLR0912
     # that all write chip_swimlane_records_<ts>.json to the same directory with
     # second-precision timestamps, so they trample each other. Block the
     # combination up front; waiting for a proper device-id-in-filename fix.
-    if config.getoption("--enable-chip-swimlane", default=0):
+    if config.getoption("--enable-chip-swimlane", default=0) and config.getoption("--rounds", default=1) <= 1:
         l3_items = [
             i
             for i in items

--- a/docs/user/how-to/profile-a-kernel.md
+++ b/docs/user/how-to/profile-a-kernel.md
@@ -35,11 +35,13 @@ pytest examples/my_example --platform a2a3 --device 4 --dump-args
 `--enable-swimlane-overhead` requires `--enable-chip-swimlane` plus a `deps.json`;
 if it is absent, re-run adding `--enable-dep-gen`.
 
-**`--enable-chip-swimlane` is L2-only.** Asking for it on an L3 test is rejected
-up front — scope to a single chip with `--level 2`, or drop the flag.
+**For single-round runs, `--enable-chip-swimlane` is L2-only.** Asking for it
+on an L3 test is rejected up front — scope to a single chip with `--level 2`,
+or drop the flag.
 
-Use `--rounds N` when you want several iterations, so first-run effects (binary
-load, cold arena) do not dominate what you measure.
+Use `--rounds N` for repeated non-diagnostic timing. All diagnostic flags above
+are disabled when `N > 1`; warm up separately, then collect diagnostics with a
+single round.
 
 ## Enabling from your own code
 

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -1160,7 +1160,14 @@ def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI
     """
     cls_name = type(cls_inst).__name__
     callable_spec = getattr(type(cls_inst), "CALLABLE", None)
-    diagnostics_on = enable_chip_swimlane or enable_dump_args or enable_pmu or enable_dep_gen or enable_scope_stats
+    diagnostics_on = (
+        enable_chip_swimlane
+        or enable_dump_args
+        or enable_pmu
+        or enable_dep_gen
+        or enable_scope_stats
+        or enable_swimlane_overhead
+    )
     for case in cases:
         case_label = f"{cls_name}_{case['name']}"
         # Per-case directory the runtime writes into. Required (non-empty) when
@@ -1746,13 +1753,11 @@ class SceneTestCase:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _effective_enable_dep_gen(request, *, warn: bool = False) -> bool:
+    def _effective_enable_dep_gen(request) -> bool:
         """Return the multi-round-safe dep-gen setting for extension hooks.
 
-        Shares the gating rule with ``test_run`` so a subclass hook (e.g.
-        ``TestDepGenCapture``'s post-validate step) cannot drift from it.
-        ``warn`` stays off by default because ``test_run`` already emitted the
-        user-facing "disabled: --rounds > 1" line before any hook runs.
+        Subclass hooks use the same effective-value rule as the main run path
+        without emitting an additional user-facing warning.
         """
         return _effective_diagnostic_options(
             request.config.getoption("--rounds", default=1),
@@ -1762,7 +1767,7 @@ class SceneTestCase:
             dep_gen=request.config.getoption("--enable-dep-gen", default=False),
             scope_stats=False,
             swimlane_overhead=False,
-            warn=warn,
+            warn=False,
         ).dep_gen
 
     def test_run(self, st_platform, st_worker, request):

--- a/tests/ut/py/test_scene_level_selection.py
+++ b/tests/ut/py/test_scene_level_selection.py
@@ -182,6 +182,49 @@ def test_sorting_uses_function_level_metadata():
     assert [item.nodeid for item in items] == ["tests::host", "tests::l2"]
 
 
+def test_multi_round_chip_swimlane_does_not_reject_l3_items():
+    @scene_level(SceneTestLevel.NODE)
+    def host_fn():
+        return None
+
+    items = [_FakeItem("tests::host", function=host_fn)]
+    config = _FakeConfig(
+        platform="a2a3",
+        level=None,
+        **{
+            "exclude-level": None,
+            "runtime": None,
+            "rounds": 5,
+            "enable-chip-swimlane": 4,
+        },
+    )
+
+    root_conftest.pytest_collection_modifyitems(None, config, items)
+
+    assert [item.nodeid for item in items] == ["tests::host"]
+
+
+def test_single_round_chip_swimlane_rejects_l3_items():
+    @scene_level(SceneTestLevel.NODE)
+    def host_fn():
+        return None
+
+    items = [_FakeItem("tests::host", function=host_fn)]
+    config = _FakeConfig(
+        platform="a2a3",
+        level=None,
+        **{
+            "exclude-level": None,
+            "runtime": None,
+            "rounds": 1,
+            "enable-chip-swimlane": 4,
+        },
+    )
+
+    with pytest.raises(pytest.UsageError, match="not supported for L3 tests"):
+        root_conftest.pytest_collection_modifyitems(None, config, items)
+
+
 def test_level_filters_are_mutually_exclusive():
     config = _FakeConfig(level=4, **{"exclude-level": 4})
 

--- a/tests/ut/py/test_scene_test_cli_contract.py
+++ b/tests/ut/py/test_scene_test_cli_contract.py
@@ -18,7 +18,12 @@ from types import SimpleNamespace
 import pytest
 
 from simpler_setup import parallel_scheduler
-from simpler_setup.scene_test import SceneTestCase, _dispatch_test_phases_standalone, _effective_diagnostic_options
+from simpler_setup.scene_test import (
+    SceneTestCase,
+    _dispatch_test_phases_standalone,
+    _effective_diagnostic_options,
+    run_class_cases,
+)
 
 
 def test_multi_rounds_disable_every_diagnostic() -> None:
@@ -62,6 +67,36 @@ def test_dep_gen_extension_hook_uses_the_shared_multi_round_gate() -> None:
     request = SimpleNamespace(config=SimpleNamespace(getoption=lambda name, default=None: options.get(name, default)))
 
     assert not SceneTestCase._effective_enable_dep_gen(request)
+
+
+def test_swimlane_overhead_allocates_a_diagnostic_output_prefix(monkeypatch) -> None:
+    scene_test_module = importlib.import_module("simpler_setup.scene_test")
+    output_prefix = scene_test_module.Path("diagnostic-output")
+    captured = {}
+
+    class FakeScene:
+        def _run_and_validate(self, *_args, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(scene_test_module, "_build_output_prefix", lambda _case_label: output_prefix)
+
+    run_class_cases(
+        object(),
+        FakeScene(),
+        [{"name": "overhead"}],
+        callable_obj=object(),
+        sub_handles={},
+        rounds=1,
+        skip_golden=False,
+        enable_chip_swimlane=0,
+        enable_dump_args=0,
+        enable_pmu=0,
+        enable_dep_gen=False,
+        enable_scope_stats=False,
+        enable_swimlane_overhead=True,
+    )
+
+    assert captured["output_prefix"] == str(output_prefix)
 
 
 def test_standalone_dispatch_forwards_every_diagnostic_flag(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- Gate the pytest L3 chip-swimlane rejection on single-round runs, matching the effective multi-round behavior used by standalone.
- Clarify that profiling diagnostics are disabled when rounds is greater than one and should be collected in a separate single-round run.
- Treat swimlane overhead as a diagnostic for output-prefix allocation and remove the dead dep-gen warning parameter.
- Add regression coverage for both the single-round rejection and multi-round inert-flag behavior, plus overhead output-prefix allocation.

Follow-up to #1891.

## Scope

The shared diagnostic resolver is the single source of truth for the multi-round gate specifically. The L3 chip-swimlane restriction remains front-end-specific because pytest validates selected items while standalone validates selected classes.

## Testing

- pre-commit run on all changed files
- python -m pytest tests/ut/py -q: 1653 passed, 19 skipped

No hardware test is required because this changes Python CLI collection behavior, unit tests, and documentation only.
