### PR TITLE
host_build_graph: capture the outer GRAPH task in the dependency graph

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -72,6 +72,20 @@ __attribute__((weak, visibility("hidden"))) void dep_gen_host_graph_begin_task(
     uint64_t, bool, bool, const int32_t[3], int32_t, int32_t, const TensorRef *, const TensorArgType *
 ) {}
 __attribute__((weak, visibility("hidden"))) void dep_gen_host_graph_end_task() {}
+
+// Raises the two edge kinds compute_task_fanin can discover, for the capture
+// instantiation. Shared by the ordinary submit path and the outer GRAPH task so
+// both describe an edge the same way.
+struct DepGraphAnnotate {
+    void creator(int32_t arg_idx, const ChipTensor &consumer, PTO2TaskId producer) const {
+        dep_gen_host_graph_add_creator_edge(producer.raw, arg_idx, consumer);
+    }
+    void tensormap(
+        int32_t arg_idx, const ChipTensor &consumer, const PTO2TensorMapEntry &entry, OverlapStatus overlap
+    ) const {
+        dep_gen_host_graph_add_tensormap_edge(entry.producer_task_id.raw, arg_idx, consumer, entry, overlap);
+    }
+};
 __attribute__((weak, visibility("hidden"))) void dep_gen_host_graph_add_explicit_edge(uint64_t) {}
 __attribute__((weak, visibility("hidden"))) void
 dep_gen_host_graph_add_creator_edge(uint64_t, int32_t, const ChipTensor &) {}
@@ -1231,16 +1245,6 @@ static TaskOutputTensors submit_task_common(
     // The capture branch instantiates compute_task_fanin with a live Annotate;
     // the plain branch keeps the un-annotated instantiation the hot path had.
     if (capture_dep_graph) {
-        struct DepGraphAnnotate {
-            void creator(int32_t arg_idx, const ChipTensor &consumer, PTO2TaskId producer) const {
-                dep_gen_host_graph_add_creator_edge(producer.raw, arg_idx, consumer);
-            }
-            void tensormap(
-                int32_t arg_idx, const ChipTensor &consumer, const PTO2TensorMapEntry &entry, OverlapStatus overlap
-            ) const {
-                dep_gen_host_graph_add_tensormap_edge(entry.producer_task_id.raw, arg_idx, consumer, entry, overlap);
-            }
-        };
         const bool ok =
             compute_task_fanin(dep_inputs, orch->tensor_map, orch->in_manual_scope(), runtime_emit, DepGraphAnnotate{});
         // STEP 3 is this task's last capture point, so the entry closes here
@@ -1548,7 +1552,32 @@ bool graph_submit_outer(
         PTO2TaskSlotState *producer = &ring.get_slot_state_by_slot(producer_slot);
         return append_fanin_or_fail(orch, producer_id.ring(), producer_slot, producer, producer_id, &fanin_builder);
     };
-    if (!compute_task_fanin(boundary_inputs, orch->tensor_map, orch->in_manual_scope(), emit)) return false;
+    // An outer GRAPH task is a ring task like any other, so the dependency graph
+    // has to carry it: without this the whole Graph — and every edge into it —
+    // is absent from deps.json, leaving a run of 40 replays described by only its
+    // handful of non-Graph tasks. It dispatches no kernel of its own and the
+    // sub-DAG it replays owns no ring slots, so what is captured is its boundary:
+    // the args it consumes and the edges those produce.
+    const bool capture_dep_graph = dep_gen_host_graph_enabled();
+    if (capture_dep_graph) {
+        const std::array<int32_t, PTO2_SUBTASK_SLOT_COUNT> kernel_ids_capture{
+            INVALID_KERNEL_ID,
+            INVALID_KERNEL_ID,
+            INVALID_KERNEL_ID,
+        };
+        dep_gen_host_graph_begin_task(
+            task_id.raw, orch->in_manual_scope(), /*early_dispatch=*/false, kernel_ids_capture.data(),
+            slot.logical_block_num, args.tensor_count(), args.tensor_data(), args.tag_data()
+        );
+        const bool ok =
+            compute_task_fanin(boundary_inputs, orch->tensor_map, orch->in_manual_scope(), emit, DepGraphAnnotate{});
+        // The task's last capture point, so the entry closes whether or not the
+        // fanin computation succeeded.
+        dep_gen_host_graph_end_task();
+        if (!ok) return false;
+    } else if (!compute_task_fanin(boundary_inputs, orch->tensor_map, orch->in_manual_scope(), emit)) {
+        return false;
+    }
     register_task_outputs(boundary_inputs, task_id, orch->tensor_map, orch->in_manual_scope());
     payload.fanin_count = fanin_builder.count;
 

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -72,6 +72,20 @@ __attribute__((weak, visibility("hidden"))) void dep_gen_host_graph_begin_task(
     uint64_t, bool, bool, const int32_t[3], int32_t, int32_t, const TensorRef *, const TensorArgType *
 ) {}
 __attribute__((weak, visibility("hidden"))) void dep_gen_host_graph_end_task() {}
+
+// Raises the two edge kinds compute_task_fanin can discover, for the capture
+// instantiation. Shared by the ordinary submit path and the outer GRAPH task so
+// both describe an edge the same way.
+struct DepGraphAnnotate {
+    void creator(int32_t arg_idx, const ChipTensor &consumer, PTO2TaskId producer) const {
+        dep_gen_host_graph_add_creator_edge(producer.raw, arg_idx, consumer);
+    }
+    void tensormap(
+        int32_t arg_idx, const ChipTensor &consumer, const PTO2TensorMapEntry &entry, OverlapStatus overlap
+    ) const {
+        dep_gen_host_graph_add_tensormap_edge(entry.producer_task_id.raw, arg_idx, consumer, entry, overlap);
+    }
+};
 __attribute__((weak, visibility("hidden"))) void dep_gen_host_graph_add_explicit_edge(uint64_t) {}
 __attribute__((weak, visibility("hidden"))) void
 dep_gen_host_graph_add_creator_edge(uint64_t, int32_t, const ChipTensor &) {}
@@ -1231,16 +1245,6 @@ static TaskOutputTensors submit_task_common(
     // The capture branch instantiates compute_task_fanin with a live Annotate;
     // the plain branch keeps the un-annotated instantiation the hot path had.
     if (capture_dep_graph) {
-        struct DepGraphAnnotate {
-            void creator(int32_t arg_idx, const ChipTensor &consumer, PTO2TaskId producer) const {
-                dep_gen_host_graph_add_creator_edge(producer.raw, arg_idx, consumer);
-            }
-            void tensormap(
-                int32_t arg_idx, const ChipTensor &consumer, const PTO2TensorMapEntry &entry, OverlapStatus overlap
-            ) const {
-                dep_gen_host_graph_add_tensormap_edge(entry.producer_task_id.raw, arg_idx, consumer, entry, overlap);
-            }
-        };
         const bool ok =
             compute_task_fanin(dep_inputs, orch->tensor_map, orch->in_manual_scope(), runtime_emit, DepGraphAnnotate{});
         // STEP 3 is this task's last capture point, so the entry closes here
@@ -1548,7 +1552,32 @@ bool graph_submit_outer(
         PTO2TaskSlotState *producer = &ring.get_slot_state_by_slot(producer_slot);
         return append_fanin_or_fail(orch, producer_id.ring(), producer_slot, producer, producer_id, &fanin_builder);
     };
-    if (!compute_task_fanin(boundary_inputs, orch->tensor_map, orch->in_manual_scope(), emit)) return false;
+    // An outer GRAPH task is a ring task like any other, so the dependency graph
+    // has to carry it: without this the whole Graph — and every edge into it —
+    // is absent from deps.json, leaving a run of 40 replays described by only its
+    // handful of non-Graph tasks. It dispatches no kernel of its own and the
+    // sub-DAG it replays owns no ring slots, so what is captured is its boundary:
+    // the args it consumes and the edges those produce.
+    const bool capture_dep_graph = dep_gen_host_graph_enabled();
+    if (capture_dep_graph) {
+        const std::array<int32_t, PTO2_SUBTASK_SLOT_COUNT> kernel_ids_capture{
+            INVALID_KERNEL_ID,
+            INVALID_KERNEL_ID,
+            INVALID_KERNEL_ID,
+        };
+        dep_gen_host_graph_begin_task(
+            task_id.raw, orch->in_manual_scope(), /*early_dispatch=*/false, kernel_ids_capture.data(),
+            slot.logical_block_num, args.tensor_count(), args.tensor_data(), args.tag_data()
+        );
+        const bool ok =
+            compute_task_fanin(boundary_inputs, orch->tensor_map, orch->in_manual_scope(), emit, DepGraphAnnotate{});
+        // The task's last capture point, so the entry closes whether or not the
+        // fanin computation succeeded.
+        dep_gen_host_graph_end_task();
+        if (!ok) return false;
+    } else if (!compute_task_fanin(boundary_inputs, orch->tensor_map, orch->in_manual_scope(), emit)) {
+        return false;
+    }
     register_task_outputs(boundary_inputs, task_id, orch->tensor_map, orch->in_manual_scope());
     payload.fanin_count = fanin_builder.count;
 


### PR DESCRIPTION
## Summary

- `dep_gen` opens a task's entry in `submit_task_common`, but an outer `GRAPH` task is
  emitted by `graph_submit_definition`, which builds its slot directly and never goes
  through there — so no GRAPH task, and no edge touching one, reached `deps.json`
- `graph_submit_definition` now opens an entry for the task it emits and instantiates
  `compute_task_fanin` with the annotating form, so the boundary edges attach to it
- the `DepGraphAnnotate` that raises those edges moves to file scope and is shared with
  the ordinary path instead of being duplicated
- what is captured is the boundary: an outer GRAPH task dispatches no kernel of its own
  and the sub-DAG it replays owns no ring slots, which the comment now states so the
  coverage claim is not over-read again

Before this, `examples/a2a3/host_build_graph/qwen3_14b_decode` described a 40-layer
decode by its handful of non-Graph tasks alone, while the capture point calls itself
"the sole source of truth for fanout".

## Testing

`tests/st/a2a3/host_build_graph/graph_execution` with `--enable-dep-gen`, on `a2a3sim`,
before and after:

| case | before | after |
| ---- | ------ | ----- |
| `record_then_replay_2d` | 6 tasks / 8 edges | **8 tasks / 10 edges** |
| `record_then_replay_mix_spmd` | **no `deps.json` written** | **3 tasks / 0 edges** |

`mix_spmd` submits nothing but Graphs, so `dep_gen` had no task to open an entry for and
produced no file at all. The 2d case gains its two outer GRAPH tasks and the two edges
into them; its count of tasks whose three kernel ids are all invalid goes 1 → 3 — the
pre-existing dummy fence plus the two GRAPH tasks, which share that signature, so an
all-invalid triple marks "dispatches no kernel", not "is a Graph".

- [x] Simulation: `tests/st/a2a3/host_build_graph` on `a2a3sim` (9 passed, 7 skipped),
      `tests/st/a5/host_build_graph` on `a5sim` (5 passed)
- [x] cpput: 107/107
- [x] Hardware: `qwen3_14b_decode` on a2a3 under `task-submit`

Capture stays gated on `dep_gen_host_graph_enabled()`, whose weak fallback returns
false, so a normal run adds one call per GRAPH submit — the same call the ordinary path
already makes per task. Measured on qwen3-14b decode, twelve rounds after against six
before: `graph_submit` min 0.106 → 0.110 ms, while counters this does not touch move
−0.016 (`arena_h2d`) to +0.007 (`graph_upload`) over the same interval, and the sum of
the scope's minima is flat at 0.660 → 0.661 ms. Below the measurement floor on a shared
box.
