### PR TITLE
host_build_graph: carry dispatch predicates through Graph Execution

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -309,6 +309,18 @@ struct GraphRecordedScalarSourceRef {
     size_t source_index{0};
 };
 
+// A node's dispatch predicate, held as the operand tensor plus the element index
+// within it rather than the absolute address submit would resolve. The tensor is
+// copied because the caller only lends it for the duration of the submit call.
+struct GraphRecordedPredicate {
+    ChipTensor operand;
+    GraphRecordedTensorSourceRef source;
+    uint64_t elem_offset{0};
+    int64_t target{0};
+    uint8_t elem_size{0};
+    PredicateOp op{PredicateOp::NONE};
+};
+
 struct GraphRecordedNode {
     std::array<int32_t, PTO2_SUBTASK_SLOT_COUNT> kernel_ids{};
     ActiveMask active_mask{};
@@ -329,6 +341,8 @@ struct GraphRecordedNode {
     uint32_t scalar_count{0};
     uint32_t fanin_offset{0};
     uint32_t fanin_count{0};
+    // Index into the recording's predicates, or -1 when the node carries none.
+    int32_t predicate_index{-1};
     ArgsDumpTaskMetadata dump_metadata;
 };
 
@@ -364,6 +378,9 @@ struct GraphRecording {
     std::vector<GraphRecordedScalarSourceRef> scalar_sources;
     std::vector<size_t> internal_fanins;
     std::vector<GraphRecordedOutputRange> output_ranges;
+    // Indexed by GraphRecordedNode::predicate_index; only predicated nodes
+    // contribute an entry.
+    std::vector<GraphRecordedPredicate> predicates;
 };
 
 struct GraphPendingUpload {
@@ -606,6 +623,8 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     std::vector<GraphTensorSourceRef> tensor_sources;
     std::vector<uint64_t> scalars;
     std::vector<GraphScalarSourceRef> scalar_sources;
+    std::vector<GraphPredicate> predicates;
+    predicates.reserve(recording.predicates.size());
     fanin_indices.reserve(total_fanins);
     roots.reserve(recording.nodes.size());
     tensors.reserve(total_tensors);
@@ -656,6 +675,25 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
         node.tensor_offset = static_cast<uint32_t>(tensors.size());
         node.scalar_offset = static_cast<uint32_t>(scalars.size());
         node.dump_metadata = source.dump_metadata;
+        node.predicate_slot = 0;
+        if (source.predicate_index >= 0) {
+            if (static_cast<size_t>(source.predicate_index) >= recording.predicates.size() ||
+                predicates.size() >= static_cast<size_t>(UINT16_MAX)) {
+                return false;
+            }
+            const GraphRecordedPredicate &recorded = recording.predicates[source.predicate_index];
+            std::optional<GraphTensorSourceRef> packed_source = graph_pack_tensor_source(recorded.source);
+            if (!packed_source.has_value() || recorded.operand.ndims > MAX_TENSOR_DIMS) return false;
+            GraphPredicate packed{};
+            packed.operand = graph_tensor_pack(recorded.operand);
+            packed.operand_source = *packed_source;
+            packed.elem_offset = recorded.elem_offset;
+            packed.target = recorded.target;
+            packed.elem_size = recorded.elem_size;
+            packed.op = static_cast<uint8_t>(recorded.op);
+            node.predicate_slot = static_cast<uint16_t>(predicates.size() + 1);
+            predicates.push_back(packed);
+        }
         for (const ChipTensor &tensor : source.tensors)
             tensors.push_back(graph_tensor_pack(tensor));
         for (size_t t = 0; t < source.tensors.size(); ++t) {
@@ -721,6 +759,7 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     definition.boundary_scalar_count = static_cast<uint32_t>(recording.boundary_scalar_count);
     definition.tensor_arg_count = static_cast<uint32_t>(tensors.size());
     definition.scalar_arg_count = static_cast<uint32_t>(scalars.size());
+    definition.predicate_count = static_cast<uint32_t>(predicates.size());
     size_t execution_storage_bytes = 0;
     if (!graph_execution_storage_bytes(static_cast<int32_t>(definition.task_count), &execution_storage_bytes) ||
         execution_storage_bytes > UINT32_MAX) {
@@ -745,7 +784,8 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
         section_bytes(tensor_sources.size(), sizeof(GraphTensorSourceRef), alignof(GraphTensorSourceRef)) +
         section_bytes(scalars.size(), sizeof(uint64_t), alignof(uint64_t)) +
         section_bytes(scalar_sources.size(), sizeof(GraphScalarSourceRef), alignof(GraphScalarSourceRef)) +
-        section_bytes(signatures.size(), sizeof(GraphBoundarySignature), alignof(GraphBoundarySignature))
+        section_bytes(signatures.size(), sizeof(GraphBoundarySignature), alignof(GraphBoundarySignature)) +
+        section_bytes(predicates.size(), sizeof(GraphPredicate), alignof(GraphPredicate))
     );
     definition.off_fanout_offsets = graph_append_section(image, fanout_offsets);
     definition.off_fanout_indices = graph_append_section(image, fanout_indices);
@@ -759,6 +799,7 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     definition.off_scalars = graph_append_section(image, scalars);
     definition.off_scalar_sources = graph_append_section(image, scalar_sources);
     definition.off_boundary_signatures = graph_append_section(image, signatures);
+    definition.off_predicates = graph_append_section(image, predicates);
     if (definition.off_fanout_offsets == 0 || definition.off_fanin_offsets == 0 || definition.off_node_offsets == 0 ||
         definition.off_nodes == 0 || definition.off_boundary_signatures == 0 ||
         (!tensors.empty() && definition.off_tensors == 0) ||
@@ -767,7 +808,8 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
         (!scalar_sources.empty() && definition.off_scalar_sources == 0) ||
         (!fanout_indices.empty() && definition.off_fanout_indices == 0) ||
         (!fanin_indices.empty() && definition.off_fanin_indices == 0) ||
-        (!roots.empty() && definition.off_root_indices == 0)) {
+        (!roots.empty() && definition.off_root_indices == 0) ||
+        (!predicates.empty() && definition.off_predicates == 0)) {
         return false;
     }
     definition.total_bytes = static_cast<uint32_t>(image->size());
@@ -1671,7 +1713,7 @@ TaskOutputTensors graph_record_submit_node(
         PTO2TaskId::make(0, static_cast<uint32_t>(recording.start_local_task_id) + static_cast<uint32_t>(node_index));
     result.set_task_id(task_id);
 
-    if (node_index >= GRAPH_MAX_NODES || args.has_error || args.predicate().op != PredicateOp::NONE) {
+    if (node_index >= GRAPH_MAX_NODES || args.has_error) {
         recording.unsupported = true;
     }
 
@@ -1765,6 +1807,45 @@ TaskOutputTensors graph_record_submit_node(
             recording.unsupported = true;
         }
     }
+    // A dispatch predicate resolves to an absolute GM address at submit, which a
+    // Definition replayed against fresh buffers cannot carry. Record the operand
+    // the same way a tensor arg is recorded — classified source plus the element
+    // index within that tensor — and let materialize resolve the pair. The
+    // predicate creates no dependency here any more than it does on the ordinary
+    // path: the caller declares one, and the explicit-dep loop below records it.
+    //
+    // Gated on the recorded attribute, not on args: a kernel-less node never
+    // dispatches, so submit_dummy_task and alloc_tensors drop the predicate the
+    // caller set. Reading args here instead would record a predicate the node's
+    // own attribute denies, and materialize rejects a Definition whose two halves
+    // disagree.
+    if (node.task_attrs.has_predicate()) {
+        const CoreTaskPredicate &pred = args.predicate();
+        GraphRecordedPredicate recorded;
+        recorded.op = pred.op;
+        recorded.target = pred.target;
+        const ChipTensor *operand = pred.operand.tensor;
+        // OWN_OUTPUT would read the node's own output before the node runs, so it
+        // names no value the predicate could be evaluating. An index vector that
+        // leaves the operand's extent is caught here too: materialize would
+        // otherwise reject the baked offset on the device, where the failure is a
+        // Scheduler fatal rather than a named unsupported construct.
+        const uint64_t flat_offset =
+            operand == nullptr ? 0 : operand->compute_flat_offset(pred.operand.indices, pred.operand.ndims);
+        if (operand == nullptr || operand->ndims > MAX_TENSOR_DIMS || pred.operand.ndims > operand->ndims ||
+            flat_offset < operand->start_offset || flat_offset - operand->start_offset >= operand->extent_elem_cache ||
+            !graph_classify_tensor(recording, node, static_cast<int32_t>(node_index), *operand, &recorded.source) ||
+            recorded.source.source == GraphRecordedTensorSource::OWN_OUTPUT) {
+            recording.unsupported = true;
+        } else {
+            recorded.operand.copy(*operand);
+            recorded.elem_offset = flat_offset - operand->start_offset;
+            recorded.elem_size = static_cast<uint8_t>(get_element_size(operand->dtype));
+        }
+        node.predicate_index = static_cast<int32_t>(recording.predicates.size());
+        recording.predicates.push_back(recorded);
+    }
+
     node.fanin_offset = static_cast<uint32_t>(recording.internal_fanins.size());
     // Dedup within this node's own range: the flat array's earlier entries belong
     // to earlier nodes.

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -309,6 +309,18 @@ struct GraphRecordedScalarSourceRef {
     size_t source_index{0};
 };
 
+// A node's dispatch predicate, held as the operand tensor plus the element index
+// within it rather than the absolute address submit would resolve. The tensor is
+// copied because the caller only lends it for the duration of the submit call.
+struct GraphRecordedPredicate {
+    ChipTensor operand;
+    GraphRecordedTensorSourceRef source;
+    uint64_t elem_offset{0};
+    int64_t target{0};
+    uint8_t elem_size{0};
+    PredicateOp op{PredicateOp::NONE};
+};
+
 struct GraphRecordedNode {
     std::array<int32_t, PTO2_SUBTASK_SLOT_COUNT> kernel_ids{};
     ActiveMask active_mask{};
@@ -329,6 +341,8 @@ struct GraphRecordedNode {
     uint32_t scalar_count{0};
     uint32_t fanin_offset{0};
     uint32_t fanin_count{0};
+    // Index into the recording's predicates, or -1 when the node carries none.
+    int32_t predicate_index{-1};
     ArgsDumpTaskMetadata dump_metadata;
 };
 
@@ -364,6 +378,9 @@ struct GraphRecording {
     std::vector<GraphRecordedScalarSourceRef> scalar_sources;
     std::vector<size_t> internal_fanins;
     std::vector<GraphRecordedOutputRange> output_ranges;
+    // Indexed by GraphRecordedNode::predicate_index; only predicated nodes
+    // contribute an entry.
+    std::vector<GraphRecordedPredicate> predicates;
 };
 
 struct GraphPendingUpload {
@@ -606,6 +623,8 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     std::vector<GraphTensorSourceRef> tensor_sources;
     std::vector<uint64_t> scalars;
     std::vector<GraphScalarSourceRef> scalar_sources;
+    std::vector<GraphPredicate> predicates;
+    predicates.reserve(recording.predicates.size());
     fanin_indices.reserve(total_fanins);
     roots.reserve(recording.nodes.size());
     tensors.reserve(total_tensors);
@@ -656,6 +675,25 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
         node.tensor_offset = static_cast<uint32_t>(tensors.size());
         node.scalar_offset = static_cast<uint32_t>(scalars.size());
         node.dump_metadata = source.dump_metadata;
+        node.predicate_slot = 0;
+        if (source.predicate_index >= 0) {
+            if (static_cast<size_t>(source.predicate_index) >= recording.predicates.size() ||
+                predicates.size() >= static_cast<size_t>(UINT16_MAX)) {
+                return false;
+            }
+            const GraphRecordedPredicate &recorded = recording.predicates[source.predicate_index];
+            std::optional<GraphTensorSourceRef> packed_source = graph_pack_tensor_source(recorded.source);
+            if (!packed_source.has_value() || recorded.operand.ndims > MAX_TENSOR_DIMS) return false;
+            GraphPredicate packed{};
+            packed.operand = graph_tensor_pack(recorded.operand);
+            packed.operand_source = *packed_source;
+            packed.elem_offset = recorded.elem_offset;
+            packed.target = recorded.target;
+            packed.elem_size = recorded.elem_size;
+            packed.op = static_cast<uint8_t>(recorded.op);
+            node.predicate_slot = static_cast<uint16_t>(predicates.size() + 1);
+            predicates.push_back(packed);
+        }
         for (const ChipTensor &tensor : source.tensors)
             tensors.push_back(graph_tensor_pack(tensor));
         for (size_t t = 0; t < source.tensors.size(); ++t) {
@@ -721,6 +759,7 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     definition.boundary_scalar_count = static_cast<uint32_t>(recording.boundary_scalar_count);
     definition.tensor_arg_count = static_cast<uint32_t>(tensors.size());
     definition.scalar_arg_count = static_cast<uint32_t>(scalars.size());
+    definition.predicate_count = static_cast<uint32_t>(predicates.size());
     size_t execution_storage_bytes = 0;
     if (!graph_execution_storage_bytes(static_cast<int32_t>(definition.task_count), &execution_storage_bytes) ||
         execution_storage_bytes > UINT32_MAX) {
@@ -745,7 +784,8 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
         section_bytes(tensor_sources.size(), sizeof(GraphTensorSourceRef), alignof(GraphTensorSourceRef)) +
         section_bytes(scalars.size(), sizeof(uint64_t), alignof(uint64_t)) +
         section_bytes(scalar_sources.size(), sizeof(GraphScalarSourceRef), alignof(GraphScalarSourceRef)) +
-        section_bytes(signatures.size(), sizeof(GraphBoundarySignature), alignof(GraphBoundarySignature))
+        section_bytes(signatures.size(), sizeof(GraphBoundarySignature), alignof(GraphBoundarySignature)) +
+        section_bytes(predicates.size(), sizeof(GraphPredicate), alignof(GraphPredicate))
     );
     definition.off_fanout_offsets = graph_append_section(image, fanout_offsets);
     definition.off_fanout_indices = graph_append_section(image, fanout_indices);
@@ -759,6 +799,7 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     definition.off_scalars = graph_append_section(image, scalars);
     definition.off_scalar_sources = graph_append_section(image, scalar_sources);
     definition.off_boundary_signatures = graph_append_section(image, signatures);
+    definition.off_predicates = graph_append_section(image, predicates);
     if (definition.off_fanout_offsets == 0 || definition.off_fanin_offsets == 0 || definition.off_node_offsets == 0 ||
         definition.off_nodes == 0 || definition.off_boundary_signatures == 0 ||
         (!tensors.empty() && definition.off_tensors == 0) ||
@@ -767,7 +808,8 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
         (!scalar_sources.empty() && definition.off_scalar_sources == 0) ||
         (!fanout_indices.empty() && definition.off_fanout_indices == 0) ||
         (!fanin_indices.empty() && definition.off_fanin_indices == 0) ||
-        (!roots.empty() && definition.off_root_indices == 0)) {
+        (!roots.empty() && definition.off_root_indices == 0) ||
+        (!predicates.empty() && definition.off_predicates == 0)) {
         return false;
     }
     definition.total_bytes = static_cast<uint32_t>(image->size());
@@ -1671,7 +1713,7 @@ TaskOutputTensors graph_record_submit_node(
         PTO2TaskId::make(0, static_cast<uint32_t>(recording.start_local_task_id) + static_cast<uint32_t>(node_index));
     result.set_task_id(task_id);
 
-    if (node_index >= GRAPH_MAX_NODES || args.has_error || args.predicate().op != PredicateOp::NONE) {
+    if (node_index >= GRAPH_MAX_NODES || args.has_error) {
         recording.unsupported = true;
     }
 
@@ -1765,6 +1807,45 @@ TaskOutputTensors graph_record_submit_node(
             recording.unsupported = true;
         }
     }
+    // A dispatch predicate resolves to an absolute GM address at submit, which a
+    // Definition replayed against fresh buffers cannot carry. Record the operand
+    // the same way a tensor arg is recorded — classified source plus the element
+    // index within that tensor — and let materialize resolve the pair. The
+    // predicate creates no dependency here any more than it does on the ordinary
+    // path: the caller declares one, and the explicit-dep loop below records it.
+    //
+    // Gated on the recorded attribute, not on args: a kernel-less node never
+    // dispatches, so submit_dummy_task and alloc_tensors drop the predicate the
+    // caller set. Reading args here instead would record a predicate the node's
+    // own attribute denies, and materialize rejects a Definition whose two halves
+    // disagree.
+    if (node.task_attrs.has_predicate()) {
+        const CoreTaskPredicate &pred = args.predicate();
+        GraphRecordedPredicate recorded;
+        recorded.op = pred.op;
+        recorded.target = pred.target;
+        const ChipTensor *operand = pred.operand.tensor;
+        // OWN_OUTPUT would read the node's own output before the node runs, so it
+        // names no value the predicate could be evaluating. An index vector that
+        // leaves the operand's extent is caught here too: materialize would
+        // otherwise reject the baked offset on the device, where the failure is a
+        // Scheduler fatal rather than a named unsupported construct.
+        const uint64_t flat_offset =
+            operand == nullptr ? 0 : operand->compute_flat_offset(pred.operand.indices, pred.operand.ndims);
+        if (operand == nullptr || operand->ndims > MAX_TENSOR_DIMS || pred.operand.ndims > operand->ndims ||
+            flat_offset < operand->start_offset || flat_offset - operand->start_offset >= operand->extent_elem_cache ||
+            !graph_classify_tensor(recording, node, static_cast<int32_t>(node_index), *operand, &recorded.source) ||
+            recorded.source.source == GraphRecordedTensorSource::OWN_OUTPUT) {
+            recording.unsupported = true;
+        } else {
+            recorded.operand.copy(*operand);
+            recorded.elem_offset = flat_offset - operand->start_offset;
+            recorded.elem_size = static_cast<uint8_t>(get_element_size(operand->dtype));
+        }
+        node.predicate_index = static_cast<int32_t>(recording.predicates.size());
+        recording.predicates.push_back(recorded);
+    }
+
     node.fanin_offset = static_cast<uint32_t>(recording.internal_fanins.size());
     // Dedup within this node's own range: the flat array's earlier entries belong
     // to earlier nodes.

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -122,6 +122,13 @@ with the unmodified boundary value.
 - A recorded task may depend on a Graph-external producer when that producer
   is the creator of a boundary ChipTensor. The outer Graph owns that dependency on
   replay; arbitrary cross-boundary explicit dependencies remain unsupported.
+- A recorded task may carry a dispatch predicate. Submit resolves a predicate
+  into an absolute GM address, which no Definition can hold, so the Definition
+  stores the operand tensor's classified source plus the element index within
+  it and materialize resolves the pair per execution. The operand may be a
+  boundary ChipTensor or another node's output; the predicate itself creates no
+  dependency, exactly as on the ordinary path, so the caller still declares one
+  on the operand's producer.
 
 Structural or alias mismatch logs a warning and executes the Graph function
 normally for that invocation. It never reuses heap offsets recorded for a
@@ -410,10 +417,12 @@ sequence, they assert in debug builds and fail the orchestration in release
 builds:
 
 - nested Graph recording;
-- dispatch predicates;
 - cross-boundary explicit dependencies that are not represented by a boundary
   ChipTensor's creator;
-- an unclassifiable internal ChipTensor source;
+- an unclassifiable internal ChipTensor source, including a dispatch
+  predicate's operand tensor;
+- a dispatch predicate whose operand is the predicated node's own output;
+- a dispatch predicate whose index vector leaves the operand tensor's extent;
 - a boundary-derived scalar accessed through mutable `scalar()`;
 - runtime allocation inside the Graph body;
 - more than 1024 internal nodes;
@@ -443,3 +452,7 @@ Graph three times: one recording execution followed by two outer-Graph
 submissions. The full-model example at
 `examples/a2a3/host_build_graph/qwen3_14b_decode` records one Qwen3-14B decoder
 layer and replays its Definition for the remaining 39 layers.
+`tests/st/{a2a3,a5}/host_build_graph/graph_predicated_dispatch` covers dispatch
+predicates on both operand sources, giving each invocation its own gate buffer
+and gate scalar so a replay that reused the recorded operand address would read
+the recording invocation's gates.

--- a/src/common/host_build_graph/graph_execution.cpp
+++ b/src/common/host_build_graph/graph_execution.cpp
@@ -205,6 +205,99 @@ GraphDefinition *graph_definition_object_verified(GraphDefinitionHeader &header)
     return matched ? definition : nullptr;
 }
 
+// Rebind one Definition tensor template onto this execution. A BOUNDARY_* ref
+// takes the invocation's boundary tensor; an INTERNAL / OWN_OUTPUT ref takes the
+// producer node's materialized output base. `node_index` is the consuming node,
+// which bounds a producer reference to a node that is already constructed.
+// Returns false when the ref addresses no valid source — the Definition is then
+// invalid, since every ref is written by the recorder from a classified source.
+bool graph_rebind_tensor(
+    const GraphExecution &execution, const GraphNodeDefinition *nodes, const uint64_t *node_offsets,
+    const GraphTensor &tensor_template, const GraphTensorSourceRef &ref, int32_t node_index, GraphTensor *rebound_out
+) {
+    GraphTensor rebound = tensor_template;
+    if (!graph_tensor_wire_valid(rebound)) return false;
+    if (ref.source == static_cast<uint8_t>(GraphTensorSource::BOUNDARY_EXACT)) {
+        if (ref.source_index >= execution.boundary_tensor_count || ref.packed_offset != 0) return false;
+        rebound = execution.boundary_tensors[ref.source_index];
+    } else if (ref.source == static_cast<uint8_t>(GraphTensorSource::BOUNDARY_VIEW)) {
+        if (ref.source_index >= execution.boundary_tensor_count) return false;
+        const GraphTensor &boundary = execution.boundary_tensors[ref.source_index];
+        if (ref.packed_offset > UINT64_MAX - boundary.start_offset) return false;
+        rebound.buffer_addr = boundary.buffer_addr;
+        rebound.buffer_size = boundary.buffer_size;
+        rebound.owner_task_id = boundary.owner_task_id;
+        rebound.start_offset = boundary.start_offset + ref.packed_offset;
+        rebound.version = boundary.version;
+        rebound.address_space = boundary.address_space;
+    } else if (ref.source == static_cast<uint8_t>(GraphTensorSource::INTERNAL) ||
+               ref.source == static_cast<uint8_t>(GraphTensorSource::OWN_OUTPUT)) {
+        const bool own_output = ref.source == static_cast<uint8_t>(GraphTensorSource::OWN_OUTPUT);
+        const int32_t producer_index = own_output ? node_index : static_cast<int32_t>(ref.source_index);
+        if (producer_index < 0 || producer_index > node_index || (own_output && ref.source_index != node_index) ||
+            (!own_output && producer_index == node_index)) {
+            return false;
+        }
+        PTO2TaskDescriptor &producer = execution.node_storage[producer_index].task;
+        const uint64_t producer_bytes = static_cast<uint64_t>(nodes[producer_index].total_output_size);
+        const uintptr_t producer_base = reinterpret_cast<uintptr_t>(producer.packed_buffer_base);
+        if (ref.packed_offset > producer_bytes || rebound.buffer_size > producer_bytes - ref.packed_offset ||
+            ref.packed_offset > UINTPTR_MAX - producer_base ||
+            ref.packed_offset > UINT64_MAX - node_offsets[producer_index]) {
+            return false;
+        }
+        rebound.buffer_addr = producer_base + ref.packed_offset;
+        rebound.owner_task_id = producer.task_id.raw;
+    } else {
+        return false;
+    }
+    if (!graph_tensor_wire_valid(rebound)) return false;
+    *rebound_out = rebound;
+    return true;
+}
+
+// Turn a Definition predicate plus its rebound operand tensor into the address
+// the scheduler reads at the dispatch point. start_offset and elem_offset are
+// element counts, so the byte offset is their sum scaled by the element width —
+// the same arithmetic the ordinary submit path runs on ChipTensor.
+// The Definition crossed the host boundary, so every field it contributes is
+// range-checked here: pass() memcpys elem_size bytes into an int64_t, and the
+// address must land inside the operand's own buffer.
+bool graph_predicate_resolve(
+    const GraphTensor &operand, const GraphPredicate &predicate, DispatchPredicate *resolved_out
+) {
+    // pass() treats an operator it does not recognize as "always dispatch", so an
+    // unknown code from the image must not reach it. Enumerating the operators
+    // without a default makes a newly added one a build warning here rather than
+    // a silent pass.
+    bool operator_known = false;
+    switch (static_cast<PredicateOp>(predicate.op)) {
+    case PredicateOp::EQ:
+    case PredicateOp::NE:
+    case PredicateOp::GT:
+    case PredicateOp::LT:
+    case PredicateOp::GE:
+    case PredicateOp::LE:
+        operator_known = true;
+        break;
+    case PredicateOp::NONE:
+        break;
+    }
+    if (!operator_known) return false;
+    const uint64_t element_size = get_element_size(static_cast<DataType>(operand.dtype));
+    if (element_size != 1 && element_size != 2 && element_size != 4 && element_size != 8) return false;
+    if (predicate.elem_size != element_size || predicate.elem_offset >= operand.extent_elem) return false;
+    // graph_tensor_wire_valid bounds start_offset + extent_elem by the buffer's
+    // element count, so the scaled sum cannot leave the buffer.
+    const uint64_t byte_offset = (operand.start_offset + predicate.elem_offset) * element_size;
+
+    resolved_out->addr = operand.buffer_addr + byte_offset;
+    resolved_out->target = predicate.target;
+    resolved_out->elem_size = predicate.elem_size;
+    resolved_out->op = static_cast<PredicateOp>(predicate.op);
+    return true;
+}
+
 }  // namespace
 
 GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
@@ -361,9 +454,14 @@ GraphMaterializeResult graph_execution_materialize_slice(
                                            graph_definition_array<GraphScalarSourceRef>(
                                                definition, definition.off_scalar_sources, definition.scalar_arg_count
                                            );
+    const GraphPredicate *predicates =
+        definition.predicate_count == 0 ?
+            nullptr :
+            graph_definition_array<GraphPredicate>(definition, definition.off_predicates, definition.predicate_count);
     if (nodes == nullptr || node_offsets == nullptr ||
         (definition.tensor_arg_count != 0 && (definition_tensors == nullptr || tensor_sources == nullptr)) ||
-        (definition.scalar_arg_count != 0 && (definition_scalars == nullptr || scalar_sources == nullptr))) {
+        (definition.scalar_arg_count != 0 && (definition_scalars == nullptr || scalar_sources == nullptr)) ||
+        (definition.predicate_count != 0 && predicates == nullptr)) {
         execution.materialize_busy.store(0, std::memory_order_release);
         return GraphMaterializeResult::INVALID;
     }
@@ -416,65 +514,16 @@ GraphMaterializeResult graph_execution_materialize_slice(
         }
         for (int32_t j = 0; j < source.tensor_count; ++j) {
             const uint32_t tensor_index = source.tensor_offset + static_cast<uint32_t>(j);
-            ChipTensor &tensor = payload.tensors[j];
-            GraphTensor rebound = definition_tensors[tensor_index];
-            if (!graph_tensor_wire_valid(rebound)) {
-                execution.materialize_busy.store(0, std::memory_order_release);
-                return GraphMaterializeResult::INVALID;
-            }
-            const GraphTensorSourceRef &ref = tensor_sources[tensor_index];
-            if (ref.source == static_cast<uint8_t>(GraphTensorSource::BOUNDARY_EXACT)) {
-                if (ref.source_index >= execution.boundary_tensor_count || ref.packed_offset != 0) {
-                    execution.materialize_busy.store(0, std::memory_order_release);
-                    return GraphMaterializeResult::INVALID;
-                }
-                rebound = execution.boundary_tensors[ref.source_index];
-            } else if (ref.source == static_cast<uint8_t>(GraphTensorSource::BOUNDARY_VIEW)) {
-                if (ref.source_index >= execution.boundary_tensor_count) {
-                    execution.materialize_busy.store(0, std::memory_order_release);
-                    return GraphMaterializeResult::INVALID;
-                }
-                const GraphTensor &boundary = execution.boundary_tensors[ref.source_index];
-                if (ref.packed_offset > UINT64_MAX - boundary.start_offset) {
-                    execution.materialize_busy.store(0, std::memory_order_release);
-                    return GraphMaterializeResult::INVALID;
-                }
-                rebound.buffer_addr = boundary.buffer_addr;
-                rebound.buffer_size = boundary.buffer_size;
-                rebound.owner_task_id = boundary.owner_task_id;
-                rebound.start_offset = boundary.start_offset + ref.packed_offset;
-                rebound.version = boundary.version;
-                rebound.address_space = boundary.address_space;
-            } else if (ref.source == static_cast<uint8_t>(GraphTensorSource::INTERNAL) ||
-                       ref.source == static_cast<uint8_t>(GraphTensorSource::OWN_OUTPUT)) {
-                const bool own_output = ref.source == static_cast<uint8_t>(GraphTensorSource::OWN_OUTPUT);
-                const int32_t producer_index = own_output ? i : static_cast<int32_t>(ref.source_index);
-                if (producer_index < 0 || producer_index > i || (own_output && ref.source_index != i) ||
-                    (!own_output && producer_index == i)) {
-                    execution.materialize_busy.store(0, std::memory_order_release);
-                    return GraphMaterializeResult::INVALID;
-                }
-                PTO2TaskDescriptor &producer = execution.node_storage[producer_index].task;
-                const uint64_t producer_bytes = static_cast<uint64_t>(nodes[producer_index].total_output_size);
-                const uintptr_t producer_base = reinterpret_cast<uintptr_t>(producer.packed_buffer_base);
-                if (ref.packed_offset > producer_bytes || rebound.buffer_size > producer_bytes - ref.packed_offset ||
-                    ref.packed_offset > UINTPTR_MAX - producer_base ||
-                    ref.packed_offset > UINT64_MAX - node_offsets[producer_index]) {
-                    execution.materialize_busy.store(0, std::memory_order_release);
-                    return GraphMaterializeResult::INVALID;
-                }
-                rebound.buffer_addr = producer_base + ref.packed_offset;
-                rebound.owner_task_id = producer.task_id.raw;
-            } else {
-                execution.materialize_busy.store(0, std::memory_order_release);
-                return GraphMaterializeResult::INVALID;
-            }
-            if (!graph_tensor_wire_valid(rebound)) {
+            GraphTensor rebound;
+            if (!graph_rebind_tensor(
+                    execution, nodes, node_offsets, definition_tensors[tensor_index], tensor_sources[tensor_index], i,
+                    &rebound
+                )) {
                 execution.materialize_busy.store(0, std::memory_order_release);
                 return GraphMaterializeResult::INVALID;
             }
             execution.consumed_tensor_args++;
-            graph_tensor_unpack(rebound, &tensor);
+            graph_tensor_unpack(rebound, &payload.tensors[j]);
         }
         for (int32_t j = 0; j < source.scalar_count; ++j) {
             const uint32_t scalar_index = source.scalar_offset + static_cast<uint32_t>(j);
@@ -493,6 +542,34 @@ GraphMaterializeResult graph_execution_materialize_slice(
             }
         }
         reset_graph_payload(payload);
+        // The attribute bit and the predicate slot are written together by the
+        // recorder. A Definition where they disagree would either route the node
+        // through a predicate the scheduler never reads, or leave a resolved
+        // predicate that no dispatch consults.
+        if (slot.task_attrs.has_predicate() != (source.predicate_slot != 0)) {
+            execution.materialize_busy.store(0, std::memory_order_release);
+            return GraphMaterializeResult::INVALID;
+        }
+        // Resolved after the reset, which clears the predicate every node starts from.
+        if (source.predicate_slot != 0) {
+            const uint32_t predicate_index = static_cast<uint32_t>(source.predicate_slot) - 1;
+            GraphTensor operand;
+            // OWN_OUTPUT is a valid source for a tensor arg but never for an
+            // operand: it would bind the predicate to the buffer this node has
+            // yet to write, so the dispatch decision would read whatever the heap
+            // last held. The recorder refuses it; so does the image reader.
+            if (predicate_index >= definition.predicate_count ||
+                predicates[predicate_index].operand_source.source ==
+                    static_cast<uint8_t>(GraphTensorSource::OWN_OUTPUT) ||
+                !graph_rebind_tensor(
+                    execution, nodes, node_offsets, predicates[predicate_index].operand,
+                    predicates[predicate_index].operand_source, i, &operand
+                ) ||
+                !graph_predicate_resolve(operand, predicates[predicate_index], &payload.predicate)) {
+                execution.materialize_busy.store(0, std::memory_order_release);
+                return GraphMaterializeResult::INVALID;
+            }
+        }
     }
     execution.materialized_nodes = last;
     if (nodes_materialized != nullptr) *nodes_materialized = last - first;

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -73,13 +73,35 @@ struct GraphScalarSourceRef {
     uint8_t reserved;
 };
 
+// Wire representation of a node's dispatch predicate. The operand's absolute GM
+// address is not replay-invariant, so the Definition names the tensor the
+// operand element sits in plus its element offset within that tensor;
+// materialize rebinds the tensor for the execution and resolves the pair into
+// the address the scheduler reads at the dispatch point.
+struct GraphPredicate {
+    GraphTensor operand;
+    GraphTensorSourceRef operand_source;
+    // Element index into the rebound operand tensor, added to its start_offset.
+    // Fixed at record time: a Graph with a variable ChipTensor shape is rejected
+    // before recording, so the operand's strides cannot change across replays.
+    uint64_t elem_offset;
+    int64_t target;
+    uint8_t elem_size;
+    uint8_t op;
+    uint8_t reserved[6];
+};
+
 struct GraphNodeDefinition {
     int32_t kernel_id[PTO2_SUBTASK_SLOT_COUNT];
     uint8_t active_mask;
     uint8_t task_attrs;
     int16_t logical_block_num;
     int16_t total_required_subtasks;
-    uint16_t reserved;
+    // One-based index into the Definition's predicate array; 0 means the node
+    // carries no dispatch predicate. Biased so that a zeroed GraphNodeDefinition
+    // is a valid predicate-free node. Predicated nodes are rare, so the
+    // predicates live in their own array rather than inline.
+    uint16_t predicate_slot;
     int32_t tensor_count;
     int32_t scalar_count;
     int32_t total_output_size;
@@ -136,6 +158,7 @@ struct GraphDefinition {
     uint32_t boundary_scalar_count;
     uint32_t tensor_arg_count;
     uint32_t scalar_arg_count;
+    uint32_t predicate_count;
     // Bytes an execution of this Definition needs for its GraphExecution header,
     // node storage and patch arrays. Derived from task_count / tensor_arg_count /
     // scalar_arg_count, so host and device read one value instead of each
@@ -155,6 +178,7 @@ struct GraphDefinition {
     uint32_t off_scalars;
     uint32_t off_scalar_sources;
     uint32_t off_boundary_signatures;
+    uint32_t off_predicates;
 };
 
 // One submission of a Graph. The static Definition is a shared device object
@@ -186,6 +210,8 @@ static_assert(std::is_trivially_copyable_v<GraphScalarSourceRef>);
 static_assert(std::is_standard_layout_v<GraphScalarSourceRef>);
 static_assert(std::is_trivially_copyable_v<GraphNodeDefinition>);
 static_assert(std::is_standard_layout_v<GraphNodeDefinition>);
+static_assert(std::is_trivially_copyable_v<GraphPredicate>);
+static_assert(std::is_standard_layout_v<GraphPredicate>);
 static_assert(std::is_trivially_copyable_v<GraphBoundarySignature>);
 static_assert(std::is_standard_layout_v<GraphBoundarySignature>);
 static_assert(std::is_trivially_copyable_v<GraphDefinition>);

--- a/tests/st/a2a3/host_build_graph/graph_predicated_dispatch/kernels/aic/kernel_clobber_alt.cpp
+++ b/tests/st/a2a3/host_build_graph/graph_predicated_dispatch/kernels/aic/kernel_clobber_alt.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Second clobber kernel for the graph_predicated_dispatch scene: overwrites
+ * args[0][0] with 555.0f. It is the body of the task predicated on a
+ * Graph-internal operand, while kernel_clobber (999.0f) is predicated on a
+ * boundary operand. Distinct poison values let one output tell which of the two
+ * predicates dispatched.
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ ChipTensor *out_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    out[0] = 555.0f;
+    dcci(&out[0], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/tests/st/a2a3/host_build_graph/graph_predicated_dispatch/kernels/orchestration/graph_predicated_dispatch_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/graph_predicated_dispatch/kernels/orchestration/graph_predicated_dispatch_orch.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * graph_predicated_dispatch orchestration: dispatch predicates inside a Graph.
+ *
+ * One fixed Graph body is invoked four times with its own boundary tensors and
+ * its own boundary scalar. Invocation 0 records the Definition; the rest replay
+ * it as outer Graph tasks.
+ *
+ * The body holds three predicated tasks, one per operand source, so a single
+ * Definition covers every rebind kind materialize can take:
+ *
+ *   gate_producer (WRITE_GATE)   internal INT32 tensor := boundary scalar
+ *   sentinel      (WRITE_CONST)  X[0] := 42.0
+ *   clobber_b     (CLOBBER)      X[0] := 999.0,  predicate gate[0] > 0
+ *                                                (BOUNDARY_EXACT)
+ *   clobber_i     (CLOBBER_ALT)  X[0] := 555.0,  predicate internal_gate[0] > 0
+ *                                                (INTERNAL)
+ *   consumer      (COPY_FIRST)   Y[0] := X[0],   predicate gate_view[1] > 0
+ *                                                (BOUNDARY_VIEW)
+ *
+ * The X tasks chain through X, so the last clobber to dispatch decides what the
+ * consumer copies; a suppressed consumer leaves Y at the caller's fill value.
+ *
+ * gate_view is gate[GATE_VIEW_BASE ..] and the predicate indexes element 1 of
+ * it, so its address is the boundary's base plus a view offset plus an element
+ * offset — three offsets no other branch stacks. gate[GATE_VIEW_BASE + 1] is the
+ * only element that drives it, and gate[0] drives clobber_b, so dropping any one
+ * of the three reads an element that is zero in every invocation and suppresses
+ * the consumer where it must run.
+ *
+ * Per invocation, (gate[0], internal scalar, gate[GATE_VIEW_BASE + 1]) is
+ * (0,0,1) / (1,0,1) / (0,1,1) / (0,0,0), giving four distinct outcomes. Each
+ * invocation passes its own gate buffer and scalar, so an operand address frozen
+ * at record time would replay invocation 0's gates and collapse them all.
+ */
+
+#include <stdint.h>
+
+#include <array>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+#define FUNC_WRITE_CONST 0
+#define FUNC_COPY_FIRST 1
+#define FUNC_CLOBBER 2
+#define FUNC_WRITE_GATE 3
+#define FUNC_CLOBBER_ALT 4
+
+#define GRAPH_INVOCATIONS 4
+#define GATE_ELEMS 16
+#define GATE_VIEW_BASE 4
+#define GATE_VIEW_ELEMS 4
+
+namespace {
+
+CoreTaskPredicate gate_predicate(const ChipTensor &gate, uint32_t index) {
+    CoreTaskPredicate pred;
+    pred.operand.tensor = &gate;
+    pred.operand.ndims = 1;
+    pred.operand.indices[0] = index;
+    pred.op = PredicateOp::GT;
+    pred.target = 0;
+    return pred;
+}
+
+void layer(const GraphTaskArgs &args, int variant) {
+    (void)variant;
+    const ChipTensor &x = args.tensor(0).ref();
+    const ChipTensor &y = args.tensor(1).ref();
+    const ChipTensor &boundary_gate = args.tensor(2).ref();
+
+    // A view of the boundary gate: same buffer, shifted start_offset, so the
+    // recorder classifies it BOUNDARY_VIEW rather than BOUNDARY_EXACT.
+    const std::array<uint32_t, 1> view_shape{GATE_VIEW_ELEMS};
+    const std::array<uint32_t, 1> view_offset{GATE_VIEW_BASE};
+    const ChipTensor gate_view = boundary_gate.view(view_shape.data(), view_offset.data());
+
+    // Graph-internal predicate operand: its address is the recording's virtual
+    // one, so replay can only read it once materialize has rebound the node.
+    const std::array<uint32_t, 1> gate_shape{GATE_ELEMS};
+    TensorCreateInfo gate_info(gate_shape.data(), static_cast<uint32_t>(gate_shape.size()), DataType::INT32);
+    CoreTaskArgs gate_args;
+    gate_args.add_output(gate_info);
+    gate_args.add_scalar(args.scalar(0));
+    TaskOutputTensors gate_outputs = rt_submit_aic_task(FUNC_WRITE_GATE, gate_args);
+    ChipTensor internal_gate = gate_outputs.get_ref(0);
+    PTO2TaskId gate_tid = gate_outputs.task_id();
+
+    // X is a boundary tensor, so the four tasks below share no Graph-internal
+    // tensor and the recorder derives no edge between them. Their write-then-read
+    // order is stated explicitly, which is what a recorded Graph preserves.
+    PTO2TaskId sentinel_tid;
+    {
+        CoreTaskArgs sentinel_args;
+        sentinel_args.add_inout(x);
+        sentinel_tid = rt_submit_aic_task(FUNC_WRITE_CONST, sentinel_args).task_id();
+    }
+
+    PTO2TaskId clobber_tid;
+    {
+        CoreTaskArgs clobber_args;
+        clobber_args.add_inout(x);
+        const std::array<PTO2TaskId, 1> deps{sentinel_tid};
+        clobber_args.set_dependencies(deps.data(), static_cast<uint32_t>(deps.size()));
+        clobber_args.set_predicate(gate_predicate(boundary_gate, 0));
+        clobber_tid = rt_submit_aic_task(FUNC_CLOBBER, clobber_args).task_id();
+    }
+
+    PTO2TaskId clobber_alt_tid;
+    {
+        CoreTaskArgs clobber_args;
+        clobber_args.add_inout(x);
+        // The predicate is a condition, not a dependency: the operand's producer
+        // is named here so the value is written by the time this task is ready.
+        const std::array<PTO2TaskId, 2> deps{clobber_tid, gate_tid};
+        clobber_args.set_dependencies(deps.data(), static_cast<uint32_t>(deps.size()));
+        clobber_args.set_predicate(gate_predicate(internal_gate, 0));
+        clobber_alt_tid = rt_submit_aic_task(FUNC_CLOBBER_ALT, clobber_args).task_id();
+    }
+
+    {
+        CoreTaskArgs consumer_args;
+        consumer_args.add_input(x);
+        consumer_args.add_inout(y);
+        const std::array<PTO2TaskId, 1> deps{clobber_alt_tid};
+        consumer_args.set_dependencies(deps.data(), static_cast<uint32_t>(deps.size()));
+        consumer_args.set_predicate(gate_predicate(gate_view, 1));
+        rt_submit_aic_task(FUNC_COPY_FIRST, consumer_args);
+    }
+}
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+    (void)args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 3 * GRAPH_INVOCATIONS + GRAPH_INVOCATIONS,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
+    for (int32_t i = 0; i < GRAPH_INVOCATIONS; ++i) {
+        GraphTaskArgs layer_args;
+        layer_args.add_inout(orch_args.tensor(i).ref());
+        layer_args.add_inout(orch_args.tensor(GRAPH_INVOCATIONS + i).ref());
+        layer_args.add_input(orch_args.tensor(2 * GRAPH_INVOCATIONS + i).ref());
+        layer_args.add_scalar(orch_args.scalar(i));
+        rt_submit_graph(&layer, layer_args, 0);
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a2a3/host_build_graph/graph_predicated_dispatch/test_graph_predicated_dispatch.py
+++ b/tests/st/a2a3/host_build_graph/graph_predicated_dispatch/test_graph_predicated_dispatch.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""graph_predicated_dispatch: a Graph carries dispatch predicates across replays.
+
+One fixed Graph body holds three predicated tasks, one per operand source
+(boundary tensor, Graph-internal tensor, view of a boundary tensor). The body is
+invoked four times: invocation 0 records the Definition, the rest replay it as
+outer Graph tasks.
+
+Each invocation supplies its own gate buffer and its own gate scalar:
+
+  invocation | gate[0] | internal | gate[view] | dispatched         | X     | Y
+  0          | 0       | 0        | 1          | consumer           | 42.0  | 42.0
+  1          | 1       | 0        | 1          | clobber + consumer | 999.0 | 999.0
+  2          | 0       | 1        | 1          | alt + consumer     | 555.0 | 555.0
+  3          | 0       | 0        | 0          | none               | 42.0  | INIT
+
+An operand address frozen at record time would replay invocation 0's gates, so
+every invocation would take invocation 0's branch.
+
+The consumer's operand is a view of the gate starting at GATE_VIEW_BASE, indexed
+at element 1 — the only case where the address stacks a boundary base, a view
+offset and an element offset. Only gate[GATE_VIEW_BASE + 1] carries its value, so
+dropping any one of the three reads an element that is 0 everywhere and leaves Y
+unwritten where the table says it must be copied.
+"""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+
+ELEMS = 16
+GATE_ELEMS = 16
+GATE_VIEW_BASE = 4  # must match the orchestration
+GATE_VIEW_INDEX = GATE_VIEW_BASE + 1
+SENTINEL = 42.0
+POISON = 999.0  # written by the task predicated on the boundary gate
+POISON_ALT = 555.0  # written by the task predicated on the Graph-internal gate
+INIT_VAL = -1.0
+
+# Per invocation: (boundary gate[0], internal gate scalar, gate[GATE_VIEW_INDEX]).
+GATES = ((0, 0, 1), (1, 0, 1), (0, 1, 1), (0, 0, 0))
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestGraphPredicatedDispatch(SceneTestCase):
+    """graph_predicated_dispatch: predicates recorded into a Graph resolve per replay."""
+
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/graph_predicated_dispatch_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            # x0..x3, y0..y3, gate0..gate3
+            "signature": [D.INOUT] * 8 + [D.IN] * 4,
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "WRITE_CONST",
+                "source": "../predicated_dispatch/kernels/aic/kernel_write_const.cpp",
+                "core_type": "aic",
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 1,
+                "name": "COPY_FIRST",
+                "source": "../predicated_dispatch/kernels/aic/kernel_copy_first.cpp",
+                "core_type": "aic",
+                # Predicated on a view of the boundary gate.
+                "signature": [D.IN, D.INOUT],
+            },
+            {
+                "func_id": 2,
+                "name": "CLOBBER",
+                "source": "../predicated_dispatch/kernels/aic/kernel_clobber.cpp",
+                "core_type": "aic",
+                # Predicated on the boundary gate.
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 3,
+                "name": "WRITE_GATE",
+                "source": "../predicated_dispatch/kernels/aic/kernel_write_gate.cpp",
+                "core_type": "aic",
+                # Produces the Graph-internal gate; the value rides as a trailing scalar.
+                "signature": [D.OUT],
+            },
+            {
+                "func_id": 4,
+                "name": "CLOBBER_ALT",
+                "source": "kernels/aic/kernel_clobber_alt.cpp",
+                "core_type": "aic",
+                # Predicated on the Graph-internal gate.
+                "signature": [D.INOUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "PredicateAcrossGraphReplays",
+            "platforms": ["a2a3sim", "a2a3"],
+            "config": {"aicpu_thread_num": 4},
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        del params
+        args = []
+        for i in range(len(GATES)):
+            args.append(TensorArg(f"x{i}", torch.full((ELEMS,), INIT_VAL, dtype=torch.float32)))
+        for i in range(len(GATES)):
+            args.append(TensorArg(f"y{i}", torch.full((ELEMS,), INIT_VAL, dtype=torch.float32)))
+        for i, (boundary_gate, _, view_gate) in enumerate(GATES):
+            gate = torch.zeros((GATE_ELEMS,), dtype=torch.int32)
+            gate[0] = boundary_gate
+            gate[GATE_VIEW_INDEX] = view_gate
+            args.append(TensorArg(f"gate{i}", gate))
+        args.extend(Scalar(f"internal_gate{i}", internal) for i, (_, internal, _) in enumerate(GATES))
+        return TaskArgsBuilder(*args)
+
+    def compute_golden(self, args, params):
+        del params
+        for i, (boundary_gate, internal_gate, view_gate) in enumerate(GATES):
+            if internal_gate > 0:
+                x_final = POISON_ALT
+            elif boundary_gate > 0:
+                x_final = POISON
+            else:
+                x_final = SENTINEL
+            getattr(args, f"x{i}")[0] = x_final
+            # The consumer is itself predicated: suppressed, it never copies.
+            if view_gate > 0:
+                getattr(args, f"y{i}")[0] = x_final
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a5/host_build_graph/graph_predicated_dispatch/kernels/aic/kernel_clobber_alt.cpp
+++ b/tests/st/a5/host_build_graph/graph_predicated_dispatch/kernels/aic/kernel_clobber_alt.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Second clobber kernel for the graph_predicated_dispatch scene: overwrites
+ * args[0][0] with 555.0f. It is the body of the task predicated on a
+ * Graph-internal operand, while kernel_clobber (999.0f) is predicated on a
+ * boundary operand. Distinct poison values let one output tell which of the two
+ * predicates dispatched.
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ ChipTensor *out_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    out[0] = 555.0f;
+    dcci(&out[0], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/tests/st/a5/host_build_graph/graph_predicated_dispatch/kernels/orchestration/graph_predicated_dispatch_orch.cpp
+++ b/tests/st/a5/host_build_graph/graph_predicated_dispatch/kernels/orchestration/graph_predicated_dispatch_orch.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * graph_predicated_dispatch orchestration: dispatch predicates inside a Graph.
+ *
+ * One fixed Graph body is invoked four times with its own boundary tensors and
+ * its own boundary scalar. Invocation 0 records the Definition; the rest replay
+ * it as outer Graph tasks.
+ *
+ * The body holds three predicated tasks, one per operand source, so a single
+ * Definition covers every rebind kind materialize can take:
+ *
+ *   gate_producer (WRITE_GATE)   internal INT32 tensor := boundary scalar
+ *   sentinel      (WRITE_CONST)  X[0] := 42.0
+ *   clobber_b     (CLOBBER)      X[0] := 999.0,  predicate gate[0] > 0
+ *                                                (BOUNDARY_EXACT)
+ *   clobber_i     (CLOBBER_ALT)  X[0] := 555.0,  predicate internal_gate[0] > 0
+ *                                                (INTERNAL)
+ *   consumer      (COPY_FIRST)   Y[0] := X[0],   predicate gate_view[1] > 0
+ *                                                (BOUNDARY_VIEW)
+ *
+ * The X tasks chain through X, so the last clobber to dispatch decides what the
+ * consumer copies; a suppressed consumer leaves Y at the caller's fill value.
+ *
+ * gate_view is gate[GATE_VIEW_BASE ..] and the predicate indexes element 1 of
+ * it, so its address is the boundary's base plus a view offset plus an element
+ * offset — three offsets no other branch stacks. gate[GATE_VIEW_BASE + 1] is the
+ * only element that drives it, and gate[0] drives clobber_b, so dropping any one
+ * of the three reads an element that is zero in every invocation and suppresses
+ * the consumer where it must run.
+ *
+ * Per invocation, (gate[0], internal scalar, gate[GATE_VIEW_BASE + 1]) is
+ * (0,0,1) / (1,0,1) / (0,1,1) / (0,0,0), giving four distinct outcomes. Each
+ * invocation passes its own gate buffer and scalar, so an operand address frozen
+ * at record time would replay invocation 0's gates and collapse them all.
+ */
+
+#include <stdint.h>
+
+#include <array>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+#define FUNC_WRITE_CONST 0
+#define FUNC_COPY_FIRST 1
+#define FUNC_CLOBBER 2
+#define FUNC_WRITE_GATE 3
+#define FUNC_CLOBBER_ALT 4
+
+#define GRAPH_INVOCATIONS 4
+#define GATE_ELEMS 16
+#define GATE_VIEW_BASE 4
+#define GATE_VIEW_ELEMS 4
+
+namespace {
+
+CoreTaskPredicate gate_predicate(const ChipTensor &gate, uint32_t index) {
+    CoreTaskPredicate pred;
+    pred.operand.tensor = &gate;
+    pred.operand.ndims = 1;
+    pred.operand.indices[0] = index;
+    pred.op = PredicateOp::GT;
+    pred.target = 0;
+    return pred;
+}
+
+void layer(const GraphTaskArgs &args, int variant) {
+    (void)variant;
+    const ChipTensor &x = args.tensor(0).ref();
+    const ChipTensor &y = args.tensor(1).ref();
+    const ChipTensor &boundary_gate = args.tensor(2).ref();
+
+    // A view of the boundary gate: same buffer, shifted start_offset, so the
+    // recorder classifies it BOUNDARY_VIEW rather than BOUNDARY_EXACT.
+    const std::array<uint32_t, 1> view_shape{GATE_VIEW_ELEMS};
+    const std::array<uint32_t, 1> view_offset{GATE_VIEW_BASE};
+    const ChipTensor gate_view = boundary_gate.view(view_shape.data(), view_offset.data());
+
+    // Graph-internal predicate operand: its address is the recording's virtual
+    // one, so replay can only read it once materialize has rebound the node.
+    const std::array<uint32_t, 1> gate_shape{GATE_ELEMS};
+    TensorCreateInfo gate_info(gate_shape.data(), static_cast<uint32_t>(gate_shape.size()), DataType::INT32);
+    CoreTaskArgs gate_args;
+    gate_args.add_output(gate_info);
+    gate_args.add_scalar(args.scalar(0));
+    TaskOutputTensors gate_outputs = rt_submit_aic_task(FUNC_WRITE_GATE, gate_args);
+    ChipTensor internal_gate = gate_outputs.get_ref(0);
+    PTO2TaskId gate_tid = gate_outputs.task_id();
+
+    // X is a boundary tensor, so the four tasks below share no Graph-internal
+    // tensor and the recorder derives no edge between them. Their write-then-read
+    // order is stated explicitly, which is what a recorded Graph preserves.
+    PTO2TaskId sentinel_tid;
+    {
+        CoreTaskArgs sentinel_args;
+        sentinel_args.add_inout(x);
+        sentinel_tid = rt_submit_aic_task(FUNC_WRITE_CONST, sentinel_args).task_id();
+    }
+
+    PTO2TaskId clobber_tid;
+    {
+        CoreTaskArgs clobber_args;
+        clobber_args.add_inout(x);
+        const std::array<PTO2TaskId, 1> deps{sentinel_tid};
+        clobber_args.set_dependencies(deps.data(), static_cast<uint32_t>(deps.size()));
+        clobber_args.set_predicate(gate_predicate(boundary_gate, 0));
+        clobber_tid = rt_submit_aic_task(FUNC_CLOBBER, clobber_args).task_id();
+    }
+
+    PTO2TaskId clobber_alt_tid;
+    {
+        CoreTaskArgs clobber_args;
+        clobber_args.add_inout(x);
+        // The predicate is a condition, not a dependency: the operand's producer
+        // is named here so the value is written by the time this task is ready.
+        const std::array<PTO2TaskId, 2> deps{clobber_tid, gate_tid};
+        clobber_args.set_dependencies(deps.data(), static_cast<uint32_t>(deps.size()));
+        clobber_args.set_predicate(gate_predicate(internal_gate, 0));
+        clobber_alt_tid = rt_submit_aic_task(FUNC_CLOBBER_ALT, clobber_args).task_id();
+    }
+
+    {
+        CoreTaskArgs consumer_args;
+        consumer_args.add_input(x);
+        consumer_args.add_inout(y);
+        const std::array<PTO2TaskId, 1> deps{clobber_alt_tid};
+        consumer_args.set_dependencies(deps.data(), static_cast<uint32_t>(deps.size()));
+        consumer_args.set_predicate(gate_predicate(gate_view, 1));
+        rt_submit_aic_task(FUNC_COPY_FIRST, consumer_args);
+    }
+}
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+    (void)args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 3 * GRAPH_INVOCATIONS + GRAPH_INVOCATIONS,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
+    for (int32_t i = 0; i < GRAPH_INVOCATIONS; ++i) {
+        GraphTaskArgs layer_args;
+        layer_args.add_inout(orch_args.tensor(i).ref());
+        layer_args.add_inout(orch_args.tensor(GRAPH_INVOCATIONS + i).ref());
+        layer_args.add_input(orch_args.tensor(2 * GRAPH_INVOCATIONS + i).ref());
+        layer_args.add_scalar(orch_args.scalar(i));
+        rt_submit_graph(&layer, layer_args, 0);
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a5/host_build_graph/graph_predicated_dispatch/test_graph_predicated_dispatch.py
+++ b/tests/st/a5/host_build_graph/graph_predicated_dispatch/test_graph_predicated_dispatch.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""graph_predicated_dispatch: a Graph carries dispatch predicates across replays.
+
+One fixed Graph body holds three predicated tasks, one per operand source
+(boundary tensor, Graph-internal tensor, view of a boundary tensor). The body is
+invoked four times: invocation 0 records the Definition, the rest replay it as
+outer Graph tasks.
+
+Each invocation supplies its own gate buffer and its own gate scalar:
+
+  invocation | gate[0] | internal | gate[view] | dispatched         | X     | Y
+  0          | 0       | 0        | 1          | consumer           | 42.0  | 42.0
+  1          | 1       | 0        | 1          | clobber + consumer | 999.0 | 999.0
+  2          | 0       | 1        | 1          | alt + consumer     | 555.0 | 555.0
+  3          | 0       | 0        | 0          | none               | 42.0  | INIT
+
+An operand address frozen at record time would replay invocation 0's gates, so
+every invocation would take invocation 0's branch.
+
+The consumer's operand is a view of the gate starting at GATE_VIEW_BASE, indexed
+at element 1 — the only case where the address stacks a boundary base, a view
+offset and an element offset. Only gate[GATE_VIEW_BASE + 1] carries its value, so
+dropping any one of the three reads an element that is 0 everywhere and leaves Y
+unwritten where the table says it must be copied.
+"""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+
+ELEMS = 16
+GATE_ELEMS = 16
+GATE_VIEW_BASE = 4  # must match the orchestration
+GATE_VIEW_INDEX = GATE_VIEW_BASE + 1
+SENTINEL = 42.0
+POISON = 999.0  # written by the task predicated on the boundary gate
+POISON_ALT = 555.0  # written by the task predicated on the Graph-internal gate
+INIT_VAL = -1.0
+
+# Per invocation: (boundary gate[0], internal gate scalar, gate[GATE_VIEW_INDEX]).
+GATES = ((0, 0, 1), (1, 0, 1), (0, 1, 1), (0, 0, 0))
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestGraphPredicatedDispatchA5(SceneTestCase):
+    """graph_predicated_dispatch: predicates recorded into a Graph resolve per replay."""
+
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/graph_predicated_dispatch_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            # x0..x3, y0..y3, gate0..gate3
+            "signature": [D.INOUT] * 8 + [D.IN] * 4,
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "WRITE_CONST",
+                "source": "../predicated_dispatch/kernels/aic/kernel_write_const.cpp",
+                "core_type": "aic",
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 1,
+                "name": "COPY_FIRST",
+                "source": "../predicated_dispatch/kernels/aic/kernel_copy_first.cpp",
+                "core_type": "aic",
+                # Predicated on a view of the boundary gate.
+                "signature": [D.IN, D.INOUT],
+            },
+            {
+                "func_id": 2,
+                "name": "CLOBBER",
+                "source": "../predicated_dispatch/kernels/aic/kernel_clobber.cpp",
+                "core_type": "aic",
+                # Predicated on the boundary gate.
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 3,
+                "name": "WRITE_GATE",
+                "source": "../predicated_dispatch/kernels/aic/kernel_write_gate.cpp",
+                "core_type": "aic",
+                # Produces the Graph-internal gate; the value rides as a trailing scalar.
+                "signature": [D.OUT],
+            },
+            {
+                "func_id": 4,
+                "name": "CLOBBER_ALT",
+                "source": "kernels/aic/kernel_clobber_alt.cpp",
+                "core_type": "aic",
+                # Predicated on the Graph-internal gate.
+                "signature": [D.INOUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "PredicateAcrossGraphReplays",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 4},
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        del params
+        args = []
+        for i in range(len(GATES)):
+            args.append(TensorArg(f"x{i}", torch.full((ELEMS,), INIT_VAL, dtype=torch.float32)))
+        for i in range(len(GATES)):
+            args.append(TensorArg(f"y{i}", torch.full((ELEMS,), INIT_VAL, dtype=torch.float32)))
+        for i, (boundary_gate, _, view_gate) in enumerate(GATES):
+            gate = torch.zeros((GATE_ELEMS,), dtype=torch.int32)
+            gate[0] = boundary_gate
+            gate[GATE_VIEW_INDEX] = view_gate
+            args.append(TensorArg(f"gate{i}", gate))
+        args.extend(Scalar(f"internal_gate{i}", internal) for i, (_, internal, _) in enumerate(GATES))
+        return TaskArgsBuilder(*args)
+
+    def compute_golden(self, args, params):
+        del params
+        for i, (boundary_gate, internal_gate, view_gate) in enumerate(GATES):
+            if internal_gate > 0:
+                x_final = POISON_ALT
+            elif boundary_gate > 0:
+                x_final = POISON
+            else:
+                x_final = SENTINEL
+            getattr(args, f"x{i}")[0] = x_final
+            # The consumer is itself predicated: suppressed, it never copies.
+            if view_gate > 0:
+                getattr(args, f"y{i}")[0] = x_final
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a5/host_build_graph/predicated_dispatch/kernels/aic/kernel_clobber.cpp
+++ b/tests/st/a5/host_build_graph/predicated_dispatch/kernels/aic/kernel_clobber.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Clobber kernel for the predicated_dispatch scene tests: overwrites args[0][0]
+ * with a poison value (999.0f). It is the body of the predicated task — if the
+ * predicate correctly suppresses dispatch, this kernel never runs and the
+ * producer's sentinel (42.0f) survives; if it ever runs, the downstream copy
+ * reads 999.0f and the test fails.
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ ChipTensor *out_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    out[0] = 999.0f;
+    dcci(&out[0], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/tests/st/a5/host_build_graph/predicated_dispatch/kernels/aic/kernel_copy_first.cpp
+++ b/tests/st/a5/host_build_graph/predicated_dispatch/kernels/aic/kernel_copy_first.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Consumer kernel for the predicated_dispatch scene tests: copies args[0][0] -> args[1][0].
+ *
+ * The producer writes the sentinel (42.0f) to args[0]; a predicated clobber sits
+ * between the producer and this consumer. When the predicate suppresses the
+ * clobber's dispatch, args[0] is untouched and args[1][0] equals 42.0f; when the
+ * clobber dispatches, args[1][0] is the poison value instead.
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ ChipTensor *in_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+    __gm__ ChipTensor *out_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
+
+    __gm__ float *in = reinterpret_cast<__gm__ float *>(in_tensor->buffer.addr) + in_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    out[0] = in[0];
+    dcci(&out[0], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/tests/st/a5/host_build_graph/predicated_dispatch/kernels/aic/kernel_write_const.cpp
+++ b/tests/st/a5/host_build_graph/predicated_dispatch/kernels/aic/kernel_write_const.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Writes a fixed sentinel (42.0f) to args[0][0]. The producer in the
+ * predicated_dispatch scene tests; a downstream consumer verifies the dependency
+ * chain (producer -> predicated clobber -> consumer) propagates the value intact.
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ ChipTensor *out_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    out[0] = 42.0f;
+    dcci(&out[0], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/tests/st/a5/host_build_graph/predicated_dispatch/kernels/aic/kernel_write_gate.cpp
+++ b/tests/st/a5/host_build_graph/predicated_dispatch/kernels/aic/kernel_write_gate.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Producer of the predicate value for the predicated_dispatch scene tests.
+ * Writes the scalar arg into gate[0] (INT32). A downstream task carries a
+ * dispatch predicate on gate[0]; the scheduler reads this value at the dispatch
+ * point (after this producer has completed) to decide whether to dispatch.
+ *
+ * args[0] = gate tensor (INOUT, INT32); args[1] = scalar gate value.
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ ChipTensor *out_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[0]);
+    int64_t gate_value = args[1];  // scalar arg follows the tensor args
+
+    __gm__ int32_t *out = reinterpret_cast<__gm__ int32_t *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+    out[0] = static_cast<int32_t>(gate_value);
+    dcci(&out[0], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/tests/st/a5/host_build_graph/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
+++ b/tests/st/a5/host_build_graph/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * predicated_dispatch orchestration: delayed-evaluation dispatch predicate.
+ *
+ * The predicate value is produced by a prior task and read by the scheduler at
+ * the dispatch point — never in orchestration — so the orchestrator does not
+ * stall on it:
+ *
+ *   gate_producer (WRITE_GATE)  writes gate[0] = gate_value   (INT32)
+ *   x_producer    (WRITE_CONST) writes X[0]   = 42.0
+ *   clobber       (CLOBBER)     would write X[0] = 999.0, but carries
+ *                               set_predicate(gate[0] > 0) and depends on
+ *                               gate_producer. The scheduler reads gate[0] when
+ *                               the clobber becomes ready (gate already written)
+ *                               and dispatches only if gate[0] > 0; otherwise the
+ *                               task is retired inline without dispatch.
+ *   consumer      (COPY_FIRST)  copies X[0] -> Y[0]
+ *
+ *   case=1: gate_value = 0 -> predicate FALSE -> clobber not dispatched ->
+ *           X stays 42.0 -> Y = 42.0. Proves non-dispatch + consumer still unlocks.
+ *   case=2: gate_value = 1 -> predicate TRUE  -> clobber dispatched ->
+ *           X = 999.0 -> Y = 999.0. Proves the dispatch path is taken.
+ *
+ * Args layout: [X, Y, gate] + case scalar.
+ */
+
+#include <cstdint>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+#define FUNC_WRITE_CONST 0
+#define FUNC_COPY_FIRST 1
+#define FUNC_CLOBBER 2
+#define FUNC_WRITE_GATE 3
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 4,  // 3 tensors + 1 case scalar
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
+    const ChipTensor &ext_X = orch_args.tensor(0).ref();
+    const ChipTensor &ext_Y = orch_args.tensor(1).ref();
+    const ChipTensor &ext_gate = orch_args.tensor(2).ref();
+
+    uint64_t case_id = orch_args.scalar(0);
+    if (case_id != 1 && case_id != 2) {
+        rt_report_fatal(PTO2_ERROR_INVALID_ARGS, "unsupported case_id=%llu", static_cast<unsigned long long>(case_id));
+        return;
+    }
+    // case 1 => gate 0 (predicate FALSE, skip); case 2 => gate 1 (predicate TRUE, dispatch).
+    int64_t gate_value = (case_id == 1) ? 0 : 1;
+
+    // gate producer: gate[0] = gate_value
+    PTO2TaskId gate_tid;
+    {
+        CoreTaskArgs args;
+        args.add_inout(ext_gate);
+        args.add_scalar(gate_value);
+        gate_tid = rt_submit_aic_task(FUNC_WRITE_GATE, args).task_id();
+    }
+
+    // x producer: X[0] = 42.0
+    {
+        CoreTaskArgs args;
+        args.add_inout(ext_X);
+        rt_submit_aic_task(FUNC_WRITE_CONST, args);
+    }
+
+    // predicated clobber: would write X[0] = 999.0 if dispatched. Depends on the
+    // gate producer so gate[0] is written by the time this task is ready; the
+    // scheduler reads gate[0] at the dispatch point and dispatches only if > 0.
+    {
+        CoreTaskArgs args;
+        args.add_inout(ext_X);
+        PTO2TaskId deps[] = {gate_tid};
+        args.set_dependencies(deps, 1);
+        // predicate: gate[0] > 0  (operand op target), built level by level.
+        CoreTaskPredicate pred;
+        pred.operand.tensor = &ext_gate;
+        pred.operand.ndims = 1;
+        pred.operand.indices[0] = 0;
+        pred.op = PredicateOp::GT;
+        pred.target = 0;
+        args.set_predicate(pred);
+        rt_submit_aic_task(FUNC_CLOBBER, args);
+    }
+
+    // consumer: Y[0] = X[0]
+    {
+        CoreTaskArgs args;
+        args.add_input(ext_X);
+        args.add_inout(ext_Y);
+        rt_submit_aic_task(FUNC_COPY_FIRST, args);
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a5/host_build_graph/predicated_dispatch/test_predicated_dispatch.py
+++ b/tests/st/a5/host_build_graph/predicated_dispatch/test_predicated_dispatch.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""predicated_dispatch: a dispatch predicate is evaluated by the scheduler at the
+dispatch point (delayed evaluation), not in orchestration.
+
+The predicate value is produced by a prior task; the scheduler reads it only
+when the predicated task becomes ready (its producer done), so orchestration
+never stalls on it. Chain:
+
+  gate_producer writes gate[0] = gate_value (INT32)
+  x_producer    writes X[0]   = 42.0
+  clobber       would write X[0] = 999.0, but carries set_predicate(gate[0] > 0)
+                and depends on gate_producer; the scheduler reads gate[0] at the
+                dispatch point and dispatches only if gate[0] > 0.
+  consumer      copies X[0] -> Y[0]
+
+  case=1 (gate_value = 0): predicate FALSE -> clobber NOT dispatched -> X stays
+         42.0 -> Y = 42.0. Proves non-dispatch AND that the retired task still
+         unlocks the consumer.
+  case=2 (gate_value = 1): predicate TRUE -> clobber dispatched -> X = 999.0 ->
+         Y = 999.0. Proves the dispatch path is taken when the predicate holds.
+"""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+
+SENTINEL = 42.0
+POISON = 999.0  # what the clobber writes if the predicate lets it dispatch
+INIT_VAL = -1.0
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestPredicatedDispatchA5(SceneTestCase):
+    """predicated_dispatch: scheduler evaluates the dispatch predicate at dispatch time."""
+
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/predicated_dispatch_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT, D.INOUT, D.INOUT],  # X, Y, gate
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "WRITE_CONST",
+                "source": "kernels/aic/kernel_write_const.cpp",
+                "core_type": "aic",
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 1,
+                "name": "COPY_FIRST",
+                "source": "kernels/aic/kernel_copy_first.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.INOUT],
+            },
+            {
+                "func_id": 2,
+                "name": "CLOBBER",
+                "source": "kernels/aic/kernel_clobber.cpp",
+                "core_type": "aic",
+                # Body of the predicated task; runs only if the predicate holds.
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 3,
+                "name": "WRITE_GATE",
+                "source": "kernels/aic/kernel_write_gate.cpp",
+                "core_type": "aic",
+                # One INOUT tensor (gate); the gate value rides as a trailing scalar.
+                "signature": [D.INOUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "PredicateFalseSkips",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 2},
+            "params": {"case": 1},
+        },
+        {
+            "name": "PredicateTrueDispatches",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 2},
+            "params": {"case": 2},
+        },
+    ]
+
+    def generate_args(self, params):
+        x = torch.full((16,), INIT_VAL, dtype=torch.float32)
+        y = torch.full((16,), INIT_VAL, dtype=torch.float32)
+        gate = torch.full((16,), -1, dtype=torch.int32)
+        return TaskArgsBuilder(
+            TensorArg("x", x),
+            TensorArg("y", y),
+            TensorArg("gate", gate),
+            Scalar("case", int(params["case"])),
+        )
+
+    def compute_golden(self, args, params):
+        gate_value = 0 if params["case"] == 1 else 1
+        args.gate[0] = gate_value
+        # x_producer writes 42.0; the clobber (X = 999.0) runs only if gate > 0.
+        x_final = SENTINEL if gate_value == 0 else POISON
+        args.x[0] = x_final
+        args.y[0] = x_final
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
@@ -390,3 +390,107 @@ TEST_F(HbgGraphSubmitFailureTest, CachedGraphUsesFinalTaskWindowSlot) {
     EXPECT_EQ(sm_handle->header->ring.fc.current_task_index.load(std::memory_order_acquire), allocator.window_size());
     EXPECT_EQ(sm_handle->header->orch_error_code.load(std::memory_order_acquire), PTO2_ERROR_NONE);
 }
+
+// The constructs a predicate can present that no Definition can express. Each is
+// discovered while recording, after the outer shell is already in the task
+// sequence, so the contract is the one AbortedRecordingLatchesFatalAtCommit
+// states: the recording cannot be published and the commit latches a fatal.
+// There is no re-run on the ordinary path to fall back to.
+//
+// This build keeps assertions enabled, so the unsupported construct surfaces as
+// the throwing debug_assert graph_end() fires on its way out. That assert
+// precedes graph_end()'s own abort, so the abort has to be issued here instead —
+// otherwise this thread's recording stays bound and the next test records into
+// it.
+class HbgGraphPredicateRejectionTest : public HbgGraphSubmitFailureTest {
+protected:
+    // Records one predicated node into a fresh Graph and asserts the recording
+    // refused it. `build_predicate` receives the boundary tensor.
+    template <typename BuildPredicate>
+    void expect_recording_refused(uint64_t graph_key, BuildPredicate build_predicate) {
+        std::array<uint32_t, 16> storage{};
+        uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+        ChipTensor boundary = make_tensor_external(storage.data(), shape, 1, DataType::INT32);
+        GraphTaskArgs boundary_args;
+        boundary_args.add_input(boundary);
+
+        orch.begin_scope();
+        const GraphScopeResult graph = orch.graph_begin(graph_key, boundary_args, 0x1736);
+        EXPECT_TRUE(graph.recording);
+        EXPECT_TRUE(orch.graph_prepare(boundary_args));
+
+        CoreTaskArgs node_args;
+        node_args.add_input(boundary);
+        TensorCreateInfo recorded_output(shape, 1, DataType::INT32);
+        node_args.add_output(recorded_output);
+        MixedKernels mixed{};
+        mixed.aiv0_kernel_id = 0;
+        node_args.set_predicate(build_predicate(boundary));
+        EXPECT_TRUE(orch.submit_task(mixed, node_args).task_id().is_valid());
+
+        EXPECT_THROW(orch.graph_end(), AssertionError) << "an unrecordable predicate must not publish";
+        orch.graph_abort();
+        orch.graph_commit();
+        EXPECT_TRUE(orch.fatal) << "a shell whose Definition never arrived cannot be completed";
+    }
+
+    static CoreTaskPredicate predicate_on(const ChipTensor &operand, uint32_t index) {
+        CoreTaskPredicate pred;
+        pred.operand.tensor = &operand;
+        pred.operand.ndims = 1;
+        pred.operand.indices[0] = index;
+        pred.op = PredicateOp::GT;
+        pred.target = 0;
+        return pred;
+    }
+};
+
+TEST_F(HbgGraphPredicateRejectionTest, OperandIndexOutsideTheExtentAbortsTheRecording) {
+    // Index 16 on a 16-element operand: the flat offset is one element past the
+    // extent, so the address it names belongs to whatever follows the buffer.
+    expect_recording_refused(0x2001, [](const ChipTensor &boundary) {
+        return predicate_on(boundary, 16);
+    });
+}
+
+TEST_F(HbgGraphPredicateRejectionTest, OperandOnAnUnclassifiableTensorAbortsTheRecording) {
+    // Neither a boundary tensor nor any recorded node's output, so the recorder
+    // cannot name a base the replay could rebind against.
+    std::array<uint32_t, 16> foreign_storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(foreign_storage.size())};
+    const ChipTensor foreign = make_tensor_external(foreign_storage.data(), shape, 1, DataType::INT32);
+    expect_recording_refused(0x2002, [&foreign](const ChipTensor &) {
+        return predicate_on(foreign, 0);
+    });
+}
+
+// A kernel-less node never dispatches, so submit_dummy_task and alloc_tensors
+// drop the caller's predicate exactly as they do on the ordinary path. Recording
+// must drop it too: a node whose Definition claimed a predicate its own attribute
+// denies is rejected by materialize, on the device, for a value the scheduler was
+// never going to read.
+TEST_F(HbgGraphPredicateRejectionTest, PredicateOnAKernellessNodeIsNotRecorded) {
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    ChipTensor boundary = make_tensor_external(storage.data(), shape, 1, DataType::INT32);
+    GraphTaskArgs boundary_args;
+    boundary_args.add_input(boundary);
+
+    orch.begin_scope();
+    const GraphScopeResult graph = orch.graph_begin(0x2003, boundary_args, 0x1736);
+    ASSERT_TRUE(graph.recording);
+    ASSERT_TRUE(orch.graph_prepare(boundary_args));
+
+    CoreTaskArgs node_args;
+    node_args.add_input(boundary);
+    TensorCreateInfo recorded_output(shape, 1, DataType::INT32);
+    node_args.add_output(recorded_output);
+    // Out of extent, which a recorded predicate would reject — proving the
+    // predicate never reached the recorder rather than merely passing its checks.
+    node_args.set_predicate(predicate_on(boundary, 16));
+    ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
+
+    EXPECT_TRUE(orch.graph_end()) << "a dropped predicate must not make the body unrecordable";
+    orch.graph_commit();
+    EXPECT_FALSE(orch.fatal);
+}


### PR DESCRIPTION
## Summary

A task carrying `set_predicate()` recorded into a Graph marked the whole recording unsupported (`graph_record_submit_node`), which fails the orchestration because the outer shell is already in the task/dependency sequence by then.

The blocker was representational, not semantic: submit resolves a predicate into an **absolute GM address** (`operand.tensor->buffer.addr + flat_offset * elem_size`), and a Definition is replayed against buffers that move every invocation.

**Fix:** record the operand the way a tensor arg is recorded — its classified source plus the element index within it — and let materialize rebind the tensor for the execution and scale the pair into an address.

| Layer | Change |
| ----- | ------ |
| Record (`pto_orchestrator.cpp`, both arches) | Drop the unsupported gate; classify the operand tensor and pre-compute `Σ idx·stride`; reject an unclassifiable operand or one that resolves to the node's own output |
| Definition wire (`graph_execution.h`) | New `GraphPredicate` section + `predicate_count` / `off_predicates`. `GraphNodeDefinition` points at it through the two bytes it was already padding with, as a **one-based slot** so a zeroed node definition stays predicate-free |
| Materialize (`graph_execution.cpp`) | Replace the unconditional `payload.predicate = DispatchPredicate{}` with a per-execution resolve, fully range-checked (`pass()` memcpys `elem_size` bytes, so the address must land inside the operand's own buffer) |
| Dispatch / completion | **No change.** An expanded node routes through `push_ready_routed` like any other task, so a failed predicate lands in the dummy queue, retires inline, and still resolves its fanout |

The four-way rebind that the materialize loop ran inline for tensor args is extracted into `graph_rebind_tensor()`, so the predicate operand resolves through the same checks instead of a second copy of them.

**The predicate creates no dependency**, exactly as on the ordinary path — `DepInputs` only ever consumed arg tensors and explicit deps, and predicate resolution runs after fanin computation. Classification here exists only to name the address' base. The caller still declares the dependency on the operand's producer, and the recorder captures it through the existing explicit-dep path.

## Testing

- [x] `graph_predicated_dispatch` (new): one Graph invoked three times, each invocation with its own gate buffer and gate scalar, holding two predicated tasks whose operands come from the two different sources (boundary tensor / Graph-internal tensor). The three invocations land on three distinct output values, so a replay reusing the recorded operand address would read the recording invocation's gates and fail. Verified failing on the parent commit.
- [x] `predicated_dispatch` ported to a5 — the scene existed only under `tests/st/a2a3`, so a5's predicate evaluation had no coverage at all.
- [x] a2a3sim / a5sim: new and existing `host_build_graph` scenes pass.
- [x] a2a3 onboard (via `task-submit`): both predicate scenes pass.
- [x] ut-cpp: 107/107, including the graph cache / activation / submit-failure suites — unchanged, and passing without editing any UT (that is what the one-based slot buys).

## Notes

`GRAPH_EXECUTION.md` moves dispatch predicates out of the unsupported list, documents how the operand is carried, and records the two new rejection cases. `sizeof(GraphNodeDefinition)` is unchanged at 72 B, so the Definition size and heap arithmetic in the Graph design notes do not move.

While writing the scene I hit a **pre-existing, unrelated gap**: `graph_record_submit_node` derives fanin only from `INTERNAL`-classified tensor sources plus explicit deps and never consults the TensorMap, so two nodes inside one Graph body that both `add_inout()` the *same boundary* tensor get no edge — while the ordinary path builds one via `compute_task_fanin`. The scene declares those edges explicitly. Worth its own issue.