### PR TITLE
test(a5): classify the deadlock head without racing the publication window

### DIFF
--- a/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
+++ b/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
@@ -13,7 +13,6 @@
 
 #include <cstdint>
 #include <string>
-#include <thread>
 #include <vector>
 
 #include "utils/device_arena.h"
@@ -60,14 +59,16 @@ protected:
         sm_arena.release();
     }
 
-    std::thread service_reclaim_publication_once(uint8_t ring_id) {
-        return std::thread([this, ring_id]() {
-            uint32_t bit = PTO2SchedulerState::ring_advance_pending_bit(ring_id);
-            while ((sched.publication_request_mask.load(std::memory_order_acquire) & bit) == 0) {
-                std::this_thread::yield();
-            }
-            sched.drain_publication_requests();
-        });
+    // Detach every reclaim consumer on this orchestrator from the scheduler's
+    // batched-publication handshake. With no publisher to ask, the watermark in
+    // shared memory is the only one there is, so a blocked reclaim spin treats it
+    // as exact from its first check and classifies the head without waiting for
+    // an acknowledgment.
+    void unwire_reclaim_publication() {
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            orch.rings[r].task_allocator.set_reclaim_publication_request(nullptr, nullptr);
+            orch.rings[r].fanin_pool.set_reclaim_publication_request(nullptr, nullptr, static_cast<uint8_t>(r));
+        }
     }
 };
 
@@ -269,11 +270,10 @@ TEST_F(OrchestratorFaninTest, SubmitPathHeapDeadlockLogReportsRingAndRealHeapSta
 
     CoreTaskArgs blocked_args;
     add_runtime_output_arg(blocked_args, create_infos, 1);
-    std::thread scheduler = service_reclaim_publication_once(1);
+    unwire_reclaim_publication();
     testing::internal::CaptureStderr();
     TaskOutputTensors blocked = orch.submit_dummy_task(blocked_args);
     std::string log = testing::internal::GetCapturedStderr();
-    scheduler.join();
 
     EXPECT_FALSE(blocked.task_id().is_valid());
     EXPECT_TRUE(orch.fatal);
@@ -305,11 +305,10 @@ TEST_F(OrchestratorFaninTest, StructuralCheckRejectsOpenAncestorWhenNestedScopes
 
     CoreTaskArgs child_args;
     add_runtime_output_arg(child_args, create_infos, 1);
-    std::thread scheduler = service_reclaim_publication_once(PTO2_MAX_RING_DEPTH - 1);
+    unwire_reclaim_publication();
     testing::internal::CaptureStderr();
     TaskOutputTensors child = orch.submit_dummy_task(child_args);
     std::string log = testing::internal::GetCapturedStderr();
-    scheduler.join();
 
     EXPECT_FALSE(child.task_id().is_valid());
     EXPECT_TRUE(orch.fatal);


### PR DESCRIPTION
## Why

Two cases in `tests/ut/cpp/a5/test_orchestrator_fanin.cpp` asserted a **classification that is only reachable inside a timing window**, and raced a thread to get there:

```cpp
std::thread scheduler = service_reclaim_publication_once(PTO2_MAX_RING_DEPTH - 1);
testing::internal::CaptureStderr();
TaskOutputTensors child = orch.submit_dummy_task(child_args);   // blocks in alloc()
...
EXPECT_NE(log.find("oldest task owned by an open scope on this ring"), std::string::npos);
```

A5 reports a *provable* head-of-line deadlock only with an **acknowledged exact watermark**. The reclaim spin asks for one after 10 ms without progress and abandons at its 500 ms backstop, so the assertion held only if the servicing thread was scheduled inside that ~490 ms window. On a 3-core `macos-latest` runner under `ctest -j` it is not: the allocator falls to the timeout classification — exactly what it is specified to do without an acknowledgment — and the message assertion fails while `orch_error_code` in the same case still reads `PTO2_ERROR_HEAP_RING_DEADLOCK`.

Observed on an unrelated PR ([red](https://github.com/hw-native-sys/simpler/actions/runs/32215976079/job/95957942810), then [green on re-run of the same commit](https://github.com/hw-native-sys/simpler/actions/runs/32217241910/job/95961348628)).

## What changes

Neither case is about the handshake — both are about **which classification a head gets once the watermark is exact**. `ReclaimPublicationRequest` already answers that an unwired request counts as synchronized: with no publisher to ask, the watermark in shared memory is the only one there is. So detaching the orchestrator's reclaim consumers from the scheduler's masks arms the structural check at the spin's **first** classification pass:

```cpp
void unwire_reclaim_publication() {
    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
        orch.rings[r].task_allocator.set_reclaim_publication_request(nullptr, nullptr);
        orch.rings[r].fanin_pool.set_reclaim_publication_request(nullptr, nullptr, static_cast<uint8_t>(r));
    }
}
```

No thread, no window, no preemption sensitivity. This is also the shape the **a2a3 siblings of both cases already have** — that allocator has no batched publication to wire, which is why only a5 ever flaked here. The change restores parity rather than inventing a test idiom.

## What still covers the wired path

`ClosedChildHeadUsesTimeoutWithOpenParentOnSharedRing`, untouched: it stays wired, is never serviced, and asserts that the structural claim is **withheld** and the report falls to the timeout. Preemption cannot invalidate it — the deciding condition is an absolute-time comparison that becomes true regardless of scheduling, and no other exit can reach it first. It costs 500 ms, which is what asserting the absence of the other exit costs.

## Testing

- [x] `test_a5_orchestrator_fanin` — **9/9**. Both cases drop from a 10–526 ms race to **22 ms**, which is fixture setup; only the timeout case still spends 500 ms
- [x] `ctest -LE requires_hardware` — **107/107**
- [x] **Negative control** — making `reclaim_head_matches_open_task` always return false reddens exactly the two cases, each after falling through to the 500 ms timeout, and leaves `ClosedChildHeadUsesTimeoutWithOpenParentOnSharedRing` green, since it wants that branch

## Relation to #1913

Same defect class — a unit test whose verdict depends on thread scheduling rather than on the code being correct — found in the same triage, fixed by the same move: assert the correctness property, not the duration. Independent commit on `main`; the two do not overlap in files and can land in either order.
