### PR TITLE
Fix: remove redundant scene run configuration

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -182,8 +182,9 @@ git diff --name-only
    - Examples: `examples/{arch}/<runtime>/<name>/`
    - Device-only scene tests: `tests/st/{arch}/<runtime>/<name>/`
 2. Add `test_<name>.py` with a `@scene_test`-decorated class (see [docs/testing.md](../../docs/testing.md) for the full template: `CALLABLE`, `CASES`, `generate_args`, `compute_golden`). End with `if __name__ == "__main__": SceneTestCase.run_module(__name__)` so the file runs standalone.
-3. Add kernel source files under `kernels/aic/`, `kernels/aiv/`, and/or `kernels/orchestration/` — referenced by `CALLABLE["orchestration"]["source"]` / `CALLABLE["incores"][*]["source"]` as paths relative to the test file.
-4. Pytest auto-discovers any `test_*.py` under `examples/` and `tests/st/`; no registration needed.
+3. Omit `CASES[*]["config"]["aicpu_thread_num"]` unless the test specifically exercises a thread-count or scheduler-topology behavior. The default automatically selects the correct count for each architecture; do not copy or pin that default. When an override is necessary, add a nearby comment explaining the test dependency. The framework rejects unknown `config` keys at import time; the accepted keys are `aicpu_thread_num`, `runtime_env`, `device_count`, and `num_sub_workers`, with `ring_task_window`, `ring_heap`, and `ring_dep_pool` under `runtime_env`.
+4. Add kernel source files under `kernels/aic/`, `kernels/aiv/`, and/or `kernels/orchestration/` — referenced by `CALLABLE["orchestration"]["source"]` / `CALLABLE["incores"][*]["source"]` as paths relative to the test file.
+5. Pytest auto-discovers any `test_*.py` under `examples/` and `tests/st/`; no registration needed.
 
 ## Related Skills
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -210,14 +210,21 @@ In `src/{arch}/runtime/host_build_graph/runtime/runtime.h`:
 
 ### Runtime Configuration
 
-Runtime behavior is configured via `kernel_config.py` in each example:
+Scene tests select their runtime with `@scene_test` and keep optional per-case
+overrides under `CASES[*]["config"]`:
 
 ```python
-RUNTIME_CONFIG = {
-    "runtime": "host_build_graph",    # Runtime to use
-    "aicpu_thread_num": 0,            # Auto-select AICPU threads
-}
+@scene_test(level=2, runtime="host_build_graph")
+class TestVectorExample(SceneTestCase):
+    CASES = [
+        {"name": "default", "platforms": ["a2a3sim", "a2a3"], "params": {}},
+    ]
 ```
+
+Omitting `aicpu_thread_num` selects the architecture default. Set it only when
+the workload intentionally requires a particular AICPU thread topology.
+Programmatic users select the runtime when constructing `Worker` and may pass a
+`CallConfig` to `worker.run()` for the same per-run overrides.
 
 Device selection is done via CLI flag:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -653,7 +653,6 @@ class TestMyKernel(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]
@@ -701,6 +700,14 @@ Key fields:
   where nothing survived (that means the SDK is missing). Used by
   [`qwen3_14b_decode`](../examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/)
   for its CANN attention extern.
+- `CASES[].config` is optional. Ordinary cases should omit `aicpu_thread_num`
+  and use the architecture default; set it only when the test specifically
+  exercises a thread-count or scheduler-topology behavior.
+- The framework owns the `config` namespace. Its keys are
+  `aicpu_thread_num`, `runtime_env`, `device_count`, and `num_sub_workers`;
+  `runtime_env` accepts `ring_task_window`, `ring_heap`, and `ring_dep_pool`.
+  Unknown keys fail when the `@scene_test` class is imported instead of being
+  silently ignored. Case-level extension keys outside `config` remain allowed.
 
 ### Output Validation
 

--- a/docs/user/how-to/write-and-run-a-kernel.md
+++ b/docs/user/how-to/write-and-run-a-kernel.md
@@ -55,7 +55,6 @@ class TestMyExample(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],                # sim needs no hardware
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]
@@ -91,8 +90,10 @@ python examples/my_example/test_my_example.py -p a2a3sim
 ```
 
 `level` and `runtime` are decorator arguments; **platforms are declared per case
-in `CASES`**, not on the decorator. Per-case knobs go under `"config"` —
-`aicpu_thread_num`, and `runtime_env` for ring sizing on
+in `CASES`**, not on the decorator. Ordinary cases should omit `"config"` and
+use the architecture's automatic AICPU thread count. Add `aicpu_thread_num`
+only when a test specifically depends on a thread-count or scheduler-topology
+behavior; `runtime_env` holds ring-sizing overrides for
 `tensormap_and_ringbuffer`. See the [Python API reference](../reference/python-api.md)
 for the full `CallConfig` field list.
 

--- a/examples/a2a3/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py
+++ b/examples/a2a3/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py
@@ -53,7 +53,6 @@ class TestQwen314BDecodeHostBuildGraph(SceneTestCase):
             "name": "GraphExecutionBatch16Seq3500",
             "platforms": ["a2a3"],
             "manual": True,
-            "config": {"aicpu_thread_num": 4, "block_dim": 0},
             "params": {"seed": 1234, "seq_len": 3500},
         },
     ]

--- a/examples/workers/l4/vector_add_mixed_l3/main.py
+++ b/examples/workers/l4/vector_add_mixed_l3/main.py
@@ -327,7 +327,6 @@ def run(
             orch.submit_next_level(remote_handle, remote_args, cfg, worker=remote_worker)
 
         config = CallConfig()
-        config.aicpu_thread_num = 4
         worker.run(parent_orch, args=None, config=config)
 
         worker.remote_copy_from(remote_handles[2], remote_outputs["f0"][0], TENSOR_NBYTES)

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -28,6 +28,7 @@ import logging
 import os
 import platform as host_platform
 import sys
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from enum import IntEnum
@@ -47,6 +48,9 @@ from .scene_test_cache import (
 logger = logging.getLogger(__name__)
 
 _compile_cache: dict[tuple, object] = {}
+
+_CASE_CONFIG_KEYS = frozenset({"aicpu_thread_num", "runtime_env", "device_count", "num_sub_workers"})
+_RUNTIME_ENV_KEYS = frozenset({"ring_task_window", "ring_heap", "ring_dep_pool"})
 
 
 class _DiagnosticOptions(NamedTuple):
@@ -1356,6 +1360,41 @@ def _compile_chip_callable_from_spec(spec, platform, runtime, cache_key):
 # ---------------------------------------------------------------------------
 
 
+def _validate_case_configs(cls: type) -> None:
+    """Validate the framework-owned configuration mappings on a scene-test class."""
+    for index, case in enumerate(getattr(cls, "CASES", ())):
+        if not isinstance(case, Mapping):
+            raise TypeError(f"{cls.__name__}.CASES[{index}] must be a mapping, got {type(case).__name__}")
+
+        case_name = case.get("name", f"index {index}")
+        config = case.get("config", {})
+        if not isinstance(config, Mapping):
+            raise TypeError(
+                f"{cls.__name__}.CASES[{index}] ({case_name!r}) config must be a mapping, got {type(config).__name__}"
+            )
+
+        unknown_config = sorted(set(config) - _CASE_CONFIG_KEYS)
+        if unknown_config:
+            raise ValueError(
+                f"{cls.__name__}.CASES[{index}] ({case_name!r}) config has unknown keys: "
+                f"{', '.join(unknown_config)}; allowed keys: {', '.join(sorted(_CASE_CONFIG_KEYS))}"
+            )
+
+        runtime_env = config.get("runtime_env", {})
+        if not isinstance(runtime_env, Mapping):
+            raise TypeError(
+                f"{cls.__name__}.CASES[{index}] ({case_name!r}) config.runtime_env must be a mapping, "
+                f"got {type(runtime_env).__name__}"
+            )
+
+        unknown_runtime_env = sorted(set(runtime_env) - _RUNTIME_ENV_KEYS)
+        if unknown_runtime_env:
+            raise ValueError(
+                f"{cls.__name__}.CASES[{index}] ({case_name!r}) config.runtime_env has unknown keys: "
+                f"{', '.join(unknown_runtime_env)}; allowed keys: {', '.join(sorted(_RUNTIME_ENV_KEYS))}"
+            )
+
+
 def scene_test(level: int | SceneTestLevel, runtime: str):
     """Decorator marking a SceneTestCase with level and runtime.
 
@@ -1364,6 +1403,7 @@ def scene_test(level: int | SceneTestLevel, runtime: str):
     level_decorator = scene_level(level)
 
     def decorator(cls):
+        _validate_case_configs(cls)
         level_decorator(cls)
         cls._st_runtime = runtime
         cls_dir = Path(inspect.getfile(cls)).parent

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -45,7 +45,7 @@ The host builds the complete task graph before launching device execution. The o
 - **Scheduling**: AICPU receives the pre-built graph and dispatches tasks by traversing dependencies
 - **Use case**: development and debugging; no device-side orchestration overhead
 
-### 1.2 tensormap_and_ringbuffer (PTO2)
+### 1.2 tensormap_and_ringbuffer
 
 The primary production runtime. Uses ring buffers for task slots and output memory, with a TensorMap for automatic dependency tracking.
 
@@ -53,7 +53,7 @@ The primary production runtime. Uses ring buffers for task slots and output memo
 - **Memory**: GM Heap ring for output buffer allocation
 - **Dependencies**: automatically derived from tensor read/write patterns via TensorMap
 - **Thread model**: `aicpu_thread_num - 1` scheduler threads + 1 orchestrator
-  thread on AICPU; the common four-thread configuration uses 3 schedulers
+  thread on AICPU; the default five-thread configuration uses 4 schedulers
 - **Multi-ring**: HeapRing, TaskRing, and DepPool are split into `PTO2_MAX_RING_DEPTH` (4) independent instances for nested scope isolation. See [MULTI_RING.md](MULTI_RING.md) for details.
 - **Use case**: production workloads; supports streaming, flow control, and large batch sizes
 
@@ -542,19 +542,20 @@ verified by review.
 
 ### 8.1 Thread Model
 
-With `aicpu_thread_num=4`, the AICPU runs 4 threads. The core counts below
+With the default `aicpu_thread_num=5`, the AICPU runs 5 threads. The core counts below
 describe the 36-cluster target in §2.3; the runtime partitions the detected
 cores across the scheduler threads, so smaller SKUs use proportionally smaller
 slices.
 
 | Thread | Role | Cores |
 | ------ | ---- | ----- |
-| 0 | Scheduler | 12 AIC + 24 AIV |
-| 1 | Scheduler | 12 AIC + 24 AIV |
-| 2 | Scheduler | 12 AIC + 24 AIV |
-| 3 | Orchestrator | none |
+| 0 | Scheduler | 9 AIC + 18 AIV |
+| 1 | Scheduler | 9 AIC + 18 AIV |
+| 2 | Scheduler | 9 AIC + 18 AIV |
+| 3 | Scheduler | 9 AIC + 18 AIV |
+| 4 | Orchestrator | none |
 
-Core assignment: AICs and AIVs are divided equally among the 3 scheduler threads.
+Core assignment: AICs and AIVs are divided equally among the 4 scheduler threads.
 
 ### 8.2 Scheduler Main Loop
 
@@ -890,7 +891,7 @@ extern "C" void aicpu_orchestration_entry(uint64_t* args, int arg_count);
 
 ## 12. Example: Batch Paged Attention
 
-### 12.1 Kernel Configuration (`kernel_config.py`)
+### 12.1 Scene-test Configuration
 
 ```python
 KERNELS = [
@@ -906,12 +907,17 @@ ORCHESTRATION = {
     "function_name": "aicpu_orchestration_entry",
 }
 
-RUNTIME_CONFIG = {
-    "runtime": "tensormap_and_ringbuffer",
-    "aicpu_thread_num": 4,
-    "block_dim": 24,
-}
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestBatchPagedAttention(SceneTestCase):
+    CALLABLE = {"orchestration": ORCHESTRATION, "incores": KERNELS}
+    CASES = [
+        {"name": "default", "platforms": ["a5sim", "a5"], "params": {}},
+    ]
 ```
+
+The omitted config selects the A5 default of five AICPU threads. Every run uses
+the detected device width, up to 36 clusters; there is no per-run `block_dim`
+knob.
 
 ### 12.2 Orchestration Structure
 

--- a/src/common/task_interface/call_config.h
+++ b/src/common/task_interface/call_config.h
@@ -56,8 +56,8 @@ inline constexpr int RUNTIME_ENV_UINT64_FIELD_COUNT = RUNTIME_ENV_FIELD_GROUPS *
 #pragma pack(push, 1)
 // Per-task runtime-environment overrides — the programmatic equivalent of the
 // `PTO2_RING_*` env vars, grouped under their own sub-struct so they read as a
-// distinct configuration tier from the top-level execution knobs (block_dim,
-// aicpu_thread_num). Consumed by tensormap_and_ringbuffer only; other runtimes
+// distinct configuration tier from the top-level `aicpu_thread_num` knob.
+// Consumed by tensormap_and_ringbuffer only; other runtimes
 // ignore them.
 //
 // Each resource is a per-scope-depth-ring array (index 0..3). A 0 entry is

--- a/tests/st/a2a3/host_build_graph/dfx/dep_gen/test_dep_gen.py
+++ b/tests/st/a2a3/host_build_graph/dfx/dep_gen/test_dep_gen.py
@@ -232,6 +232,8 @@ class TestDepGenHostBuildGraphEdgeSources(SceneTestCase):
         ],
     }
 
+    # One scheduler owns every core, so the captured graph exercises the
+    # predicate and explicit-dependency hooks without cross-shard merging.
     CASES = [
         {
             "name": "gate_open",

--- a/tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution.py
+++ b/tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution.py
@@ -56,13 +56,11 @@ class TestGraphExecutionHostBuildGraph(SceneTestCase):
             "name": "record_then_replay_1d",
             "platforms": ["a2a3sim", "a2a3"],
             "manual": ["a2a3sim"],
-            "config": {"aicpu_thread_num": 4, "block_dim": 3},
             "params": {"shape": (128 * 128,)},
         },
         {
             "name": "record_then_replay_2d",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4, "block_dim": 3},
             "params": {"shape": (128 * 128, 1)},
         },
     ]

--- a/tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution_aic_aiv.py
+++ b/tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution_aic_aiv.py
@@ -53,7 +53,6 @@ class TestGraphExecutionAicAivHostBuildGraph(SceneTestCase):
             "name": "record_then_replay_aic_aiv",
             "platforms": ["a2a3sim", "a2a3"],
             "manual": ["a2a3sim"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution_mix_spmd.py
+++ b/tests/st/a2a3/host_build_graph/graph_execution/test_graph_execution_mix_spmd.py
@@ -60,7 +60,6 @@ class TestGraphExecutionMixSpmdHostBuildGraph(SceneTestCase):
         {
             "name": "record_then_replay_mix_spmd",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/host_build_graph/graph_predicated_dispatch/test_graph_predicated_dispatch.py
+++ b/tests/st/a2a3/host_build_graph/graph_predicated_dispatch/test_graph_predicated_dispatch.py
@@ -111,7 +111,6 @@ class TestGraphPredicatedDispatch(SceneTestCase):
         {
             "name": "PredicateAcrossGraphReplays",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/host_build_graph/native_run_lifecycle/test_native_run_lifecycle.py
+++ b/tests/st/a2a3/host_build_graph/native_run_lifecycle/test_native_run_lifecycle.py
@@ -54,7 +54,6 @@ class TestNativeRunLifecycle(SceneTestCase):
         {
             "name": "phase_split_preserves_blocking_compatibility",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"aicpu_thread_num": 4},
             "params": {"a": 2.0, "b": 3.0},
         }
     ]
@@ -132,7 +131,7 @@ class TestNativeRunLifecycle(SceneTestCase):
     ):
         del rounds, skip_golden, enable_chip_swimlane, enable_dump_args
         del enable_pmu, enable_dep_gen, enable_scope_stats, output_prefix
-        config = self._build_config(case["config"])
+        config = self._build_config(case.get("config", {}))
         chip_worker = worker._chip_worker
         assert chip_worker is not None
         supports_concurrent_prepare = bool(chip_worker._impl.supports_concurrent_native_prepare)
@@ -176,7 +175,7 @@ class TestNativeRunLifecycle(SceneTestCase):
             # while its shared memory is still mapped, so a collector retained by
             # an abandoned run makes the next prepare on this runner fail.
             with tempfile.TemporaryDirectory(prefix="simpler-abandon-diagnostics-") as abandon_dir:
-                abandon_config = self._build_config(case["config"])
+                abandon_config = self._build_config(case.get("config", {}))
                 abandon_config.enable_scope_stats = True
                 abandon_config.output_prefix = abandon_dir
                 abandon_args = self.generate_args(case["params"])
@@ -273,7 +272,7 @@ class TestNativeRunLifecycle(SceneTestCase):
                 _compare_outputs(successor_args, successor_golden, successor_outputs, self.RTOL, self.ATOL)
 
                 with tempfile.TemporaryDirectory(prefix="simpler-native-diagnostics-") as output_dir:
-                    diagnostic_config = self._build_config(case["config"])
+                    diagnostic_config = self._build_config(case.get("config", {}))
                     diagnostic_config.enable_dep_gen = True
                     diagnostic_config.output_prefix = output_dir
 

--- a/tests/st/a2a3/host_build_graph/predicated_dispatch/test_predicated_dispatch.py
+++ b/tests/st/a2a3/host_build_graph/predicated_dispatch/test_predicated_dispatch.py
@@ -85,6 +85,8 @@ class TestPredicatedDispatch(SceneTestCase):
         ],
     }
 
+    # One scheduler owns every core, so both cases isolate predicate evaluation
+    # and task retirement from cross-scheduler routing.
     CASES = [
         {
             "name": "PredicateFalseSkips",

--- a/tests/st/a2a3/host_build_graph/run_stream_reuse/test_run_stream_reuse.py
+++ b/tests/st/a2a3/host_build_graph/run_stream_reuse/test_run_stream_reuse.py
@@ -107,7 +107,6 @@ class TestRunStreamReuseHbg(SceneTestCase):
         {
             "name": "repeated_runs",
             "platforms": ["a2a3", "a2a3sim"],
-            "config": {"block_dim": 3},
             "params": {},
         },
     ]
@@ -181,7 +180,7 @@ class TestRunStreamReuseHbg(SceneTestCase):
         args, output_names = _build_l2_ref_args(test_args, self.CALLABLE["orchestration"]["signature"], worker)
         golden_args = test_args.clone()
         self.compute_golden(golden_args, params, subtract=subtract)
-        worker.run(handle, args, config=self._build_config(self.CASES[0]["config"]))
+        worker.run(handle, args, config=self._build_config(self.CASES[0].get("config", {})))
         _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
     # The st_worker fixture is shared by every test in this class, and so is the
@@ -205,7 +204,7 @@ class TestRunStreamReuseHbg(SceneTestCase):
             chip_args,
             slot_id,
             generation,
-            config=self._build_config(self.CASES[0]["config"]),
+            config=self._build_config(self.CASES[0].get("config", {})),
         )
         _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 

--- a/tests/st/a2a3/host_build_graph/worker_async_endpoint/test_worker_async_endpoint.py
+++ b/tests/st/a2a3/host_build_graph/worker_async_endpoint/test_worker_async_endpoint.py
@@ -125,7 +125,7 @@ class TestWorkerAsyncEndpoint(SceneTestCase):
         {
             "name": "two_frame_sequential_execution",
             "platforms": ["a2a3"],
-            "config": {"device_count": 1, "num_sub_workers": 1, "aicpu_thread_num": 4},
+            "config": {"device_count": 1, "num_sub_workers": 1},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/host_build_graph/worker_async_fifo/test_worker_async_fifo.py
+++ b/tests/st/a2a3/host_build_graph/worker_async_fifo/test_worker_async_fifo.py
@@ -169,7 +169,7 @@ class TestWorkerAsyncWholeRunFifo(SceneTestCase):
         {
             "name": "whole_run_fifo",
             "platforms": ["a2a3"],
-            "config": {"device_count": 1, "num_sub_workers": 1, "aicpu_thread_num": 4},
+            "config": {"device_count": 1, "num_sub_workers": 1},
             "params": {},
         },
     ]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
@@ -83,6 +83,8 @@ class TestDepGenChain(SceneTestCase):
     SENTINEL = 42.0
     INIT_VAL = -1.0
 
+    # One scheduler owns every core, keeping the capture shard topology fixed
+    # while the explicit-dependency count crosses overflow boundaries.
     CASES = [
         {
             "name": "n_64_no_chain",

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
@@ -75,6 +75,8 @@ class TestDummyTask(SceneTestCase):
         ],
     }
 
+    # One scheduler owns every core, so these cases isolate dummy-ready-queue
+    # ordering and retirement from cross-scheduler routing.
     CASES = [
         {
             "name": "SingleDummyAutoDep",

--- a/tests/st/a2a3/tensormap_and_ringbuffer/heap_empty_ring_rebase/test_heap_empty_ring_rebase.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/heap_empty_ring_rebase/test_heap_empty_ring_rebase.py
@@ -54,6 +54,8 @@ class TestHeapEmptyRingRebase(SceneTestCase):
         ],
     }
 
+    # One scheduler owns every core, so both scopes drain under the same
+    # scheduler topology while only the ring-1 heap capacity forces the rebase.
     CASES = [
         {
             "name": "EmptyRingRebase",

--- a/tests/st/a2a3/tensormap_and_ringbuffer/pipeline_slots/test_pipeline_slots.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/pipeline_slots/test_pipeline_slots.py
@@ -67,7 +67,6 @@ class TestPipelineSlotsTmr(SceneTestCase):
         {
             "name": "slot_topology",
             "platforms": ["a2a3", "a2a3sim"],
-            "config": {"aicpu_thread_num": 4, "block_dim": 3},
             "params": {},
         },
     ]
@@ -99,7 +98,7 @@ class TestPipelineSlotsTmr(SceneTestCase):
         golden = test_args.clone()
         self.compute_golden(golden, {})
         signature = self.CALLABLE["orchestration"]["signature"]
-        config = self._build_config(self.CASES[0]["config"])
+        config = self._build_config(self.CASES[0].get("config", {}))
         if slot_id is None:
             args, output_names = _build_l2_ref_args(test_args, signature, worker)
             worker.run(handle, args, config=config)

--- a/tests/st/a2a3/tensormap_and_ringbuffer/predicated_dispatch/test_predicated_dispatch.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/predicated_dispatch/test_predicated_dispatch.py
@@ -85,6 +85,8 @@ class TestPredicatedDispatch(SceneTestCase):
         ],
     }
 
+    # One scheduler owns every core, so both cases isolate predicate routing
+    # and retirement from cross-scheduler ownership changes.
     CASES = [
         {
             "name": "PredicateFalseSkips",

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/test_spmd_sync_start_mix_spill.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/test_spmd_sync_start_mix_spill.py
@@ -78,6 +78,8 @@ class TestSpmdSyncStartMixSpill(SceneTestCase):
         ],
     }
 
+    # Three AICPU threads provide two schedulers. The full-device cohorts span
+    # both ownership partitions, covering cross-scheduler pending-slot staging.
     CASES = [
         {
             "name": "Case1",

--- a/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_launch_acceptance.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/test_l3_launch_acceptance.py
@@ -84,7 +84,7 @@ class TestL3LaunchAcceptance(SceneTestCase):
         {
             "name": "default",
             "platforms": ["a2a3sim", "a2a3"],
-            "config": {"device_count": 1, "num_sub_workers": 0, "aicpu_thread_num": 4},
+            "config": {"device_count": 1, "num_sub_workers": 0},
             "params": {},
         },
     ]

--- a/tests/st/a5/host_build_graph/graph_execution/test_graph_execution.py
+++ b/tests/st/a5/host_build_graph/graph_execution/test_graph_execution.py
@@ -53,13 +53,11 @@ class TestGraphExecutionHostBuildGraphA5(SceneTestCase):
             "name": "record_then_replay_1d",
             "platforms": ["a5sim", "a5"],
             "manual": ["a5sim"],
-            "config": {"aicpu_thread_num": 4, "block_dim": 3},
             "params": {"shape": (128 * 128,)},
         },
         {
             "name": "record_then_replay_2d",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4, "block_dim": 3},
             "params": {"shape": (128 * 128, 1)},
         },
     ]

--- a/tests/st/a5/host_build_graph/graph_execution/test_graph_execution_aic_aiv.py
+++ b/tests/st/a5/host_build_graph/graph_execution/test_graph_execution_aic_aiv.py
@@ -47,7 +47,6 @@ class TestGraphExecutionAicAivHostBuildGraphA5(SceneTestCase):
             "name": "record_then_replay_aic_aiv",
             "platforms": ["a5sim", "a5"],
             "manual": ["a5sim"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a5/host_build_graph/graph_execution/test_graph_execution_mix_spmd.py
+++ b/tests/st/a5/host_build_graph/graph_execution/test_graph_execution_mix_spmd.py
@@ -57,7 +57,6 @@ class TestGraphExecutionMixSpmdHostBuildGraphA5(SceneTestCase):
         {
             "name": "record_then_replay_mix_spmd",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a5/host_build_graph/graph_predicated_dispatch/test_graph_predicated_dispatch.py
+++ b/tests/st/a5/host_build_graph/graph_predicated_dispatch/test_graph_predicated_dispatch.py
@@ -111,7 +111,6 @@ class TestGraphPredicatedDispatchA5(SceneTestCase):
         {
             "name": "PredicateAcrossGraphReplays",
             "platforms": ["a5sim", "a5"],
-            "config": {"aicpu_thread_num": 4},
             "params": {},
         },
     ]

--- a/tests/st/a5/host_build_graph/predicated_dispatch/test_predicated_dispatch.py
+++ b/tests/st/a5/host_build_graph/predicated_dispatch/test_predicated_dispatch.py
@@ -85,6 +85,8 @@ class TestPredicatedDispatchA5(SceneTestCase):
         ],
     }
 
+    # One scheduler owns every core, so both cases isolate predicate evaluation
+    # and task retirement from cross-scheduler routing.
     CASES = [
         {
             "name": "PredicateFalseSkips",

--- a/tests/st/a5/tensormap_and_ringbuffer/bench_prewarm_timing.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/bench_prewarm_timing.py
@@ -96,7 +96,6 @@ def _run_scenario(*, device_id: int, platform: str, prewarm: bool) -> None:
         args, _output_names = _build_l2_ref_args(test_args, orch_sig, worker)
 
         run_cfg = CallConfig()
-        run_cfg.block_dim = config_dict.get("block_dim", 1)
         run_cfg.aicpu_thread_num = config_dict.get("aicpu_thread_num", 2)
         run_cfg.runtime_env.ring_task_window = _RING
 

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/test_chip_swimlane.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/test_chip_swimlane.py
@@ -69,7 +69,7 @@ class TestChipSwimlane(SceneTestCase):
     }
 
     # The host's drain/collector thread count follows aicpu_thread_num, so the
-    # low-thread cases exercise a shard layout the 4-thread default never
+    # low-thread cases exercise a shard layout the 5-thread default never
     # reaches. The task-count assertions below are exact, so a record lost to a
     # mis-sharded buffer fails the run rather than degrading it silently.
     CASES = [

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
@@ -79,6 +79,8 @@ class TestDepGenChain(SceneTestCase):
     SENTINEL = 42.0
     INIT_VAL = -1.0
 
+    # One scheduler owns every core, keeping the capture shard topology fixed
+    # while the explicit-dependency count crosses overflow boundaries.
     CASES = [
         {
             "name": "n_64_no_chain",

--- a/tests/st/a5/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
@@ -71,6 +71,8 @@ class TestDummyTask(SceneTestCase):
         ],
     }
 
+    # One scheduler owns every core, so these cases isolate dummy-ready-queue
+    # ordering and retirement from cross-scheduler routing.
     CASES = [
         {
             "name": "SingleDummyAutoDep",

--- a/tests/st/a5/tensormap_and_ringbuffer/mx_fp_gemm/test_mx_fp_gemm.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/mx_fp_gemm/test_mx_fp_gemm.py
@@ -37,7 +37,6 @@ def _cases():
             {
                 "name": "MXFP8_TMATMUL_MX",
                 "platforms": ["a5"],
-                "config": {"aicpu_thread_num": 2, "block_dim": 1},
                 "params": {"mode": 0},
             }
         )
@@ -46,7 +45,6 @@ def _cases():
             {
                 "name": "MXFP4_TMATMUL_MX",
                 "platforms": ["a5"],
-                "config": {"aicpu_thread_num": 2, "block_dim": 1},
                 "params": {"mode": 1},
             }
         )

--- a/tests/st/a5/tensormap_and_ringbuffer/pipeline_slots/test_pipeline_slots.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/pipeline_slots/test_pipeline_slots.py
@@ -64,7 +64,6 @@ class TestPipelineSlotsTmr(SceneTestCase):
         {
             "name": "slot_topology",
             "platforms": ["a5", "a5sim"],
-            "config": {"aicpu_thread_num": 4, "block_dim": 3},
             "params": {},
         },
     ]
@@ -96,7 +95,7 @@ class TestPipelineSlotsTmr(SceneTestCase):
         golden = test_args.clone()
         self.compute_golden(golden, {})
         signature = self.CALLABLE["orchestration"]["signature"]
-        config = self._build_config(self.CASES[0]["config"])
+        config = self._build_config(self.CASES[0].get("config", {}))
         if slot_id is None:
             args, output_names = _build_l2_ref_args(test_args, signature, worker)
             worker.run(handle, args, config=config)

--- a/tests/st/a5/tensormap_and_ringbuffer/predicated_dispatch/test_predicated_dispatch.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/predicated_dispatch/test_predicated_dispatch.py
@@ -85,6 +85,8 @@ class TestPredicatedDispatch(SceneTestCase):
         ],
     }
 
+    # One scheduler owns every core, so both cases isolate predicate routing
+    # and retirement from cross-scheduler ownership changes.
     CASES = [
         {
             "name": "PredicateFalseSkips",

--- a/tests/st/host_build_graph_wide_dispatch/test_host_build_graph_wide_dispatch.py
+++ b/tests/st/host_build_graph_wide_dispatch/test_host_build_graph_wide_dispatch.py
@@ -84,6 +84,8 @@ class TestHostBuildGraphWideDispatch(SceneTestCase):
         ],
     }
 
+    # Two AICPU threads leave one scheduler, which owns every cluster used by
+    # the AIV and MIX placement assertions.
     CASES = [
         {
             "name": "TwoThreads",

--- a/tests/ut/py/test_scene_test_config_validation.py
+++ b/tests/ut/py/test_scene_test_config_validation.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Validation contracts for framework-owned scene-test configuration."""
+
+import pytest
+
+from simpler_setup import scene_test
+
+
+def _decorate(cases):
+    class ConfigScene:
+        CASES = cases
+
+    return scene_test(level=2, runtime="host_build_graph")(ConfigScene)
+
+
+def test_scene_test_accepts_all_config_keys_and_custom_case_keys() -> None:
+    decorated = _decorate(
+        [
+            {
+                "name": "valid",
+                "platforms": ["a2a3sim"],
+                "config": {
+                    "aicpu_thread_num": 2,
+                    "runtime_env": {
+                        "ring_task_window": 64,
+                        "ring_heap": 1024,
+                        "ring_dep_pool": 32,
+                    },
+                    "device_count": 2,
+                    "num_sub_workers": 1,
+                },
+                "required_sched_phases": ("release",),
+            },
+            {"name": "no_config", "platforms": ["a2a3sim"]},
+        ]
+    )
+
+    assert decorated.CASES[0]["required_sched_phases"] == ("release",)
+
+
+def test_scene_test_rejects_unknown_config_key() -> None:
+    with pytest.raises(ValueError, match=r"ConfigScene\.CASES\[0\].*block_dim.*allowed keys"):
+        _decorate([{"name": "bad", "config": {"block_dim": 24}}])
+
+
+def test_scene_test_rejects_unknown_runtime_env_key() -> None:
+    with pytest.raises(ValueError, match=r"ConfigScene\.CASES\[0\].*runtime_env.*ring_heep.*allowed keys"):
+        _decorate([{"name": "bad", "config": {"runtime_env": {"ring_heep": 1024}}}])
+
+
+@pytest.mark.parametrize(
+    ("config", "match"),
+    [
+        (None, "config must be a mapping"),
+        ({"runtime_env": None}, "config.runtime_env must be a mapping"),
+    ],
+)
+def test_scene_test_rejects_non_mapping_config_layers(config, match) -> None:
+    with pytest.raises(TypeError, match=match):
+        _decorate([{"name": "bad", "config": config}])


### PR DESCRIPTION
## Summary
- Remove redundant default `aicpu_thread_num` and obsolete top-level `block_dim` from ordinary HBG/TMR scene cases, examples, and the prewarm benchmark
- Keep explicit thread counts only where tests depend on scheduler/DFX topology, with a nearby explanation for every retained override
- Reject unknown `CASES[*]["config"]` and nested `runtime_env` keys when scene-test classes are imported
- Fix whitebox helpers that assumed `CASES[*]["config"]` always existed after config cleanup
- Update scene-test guidance and the A5 runtime documentation to match the current five-thread/four-scheduler topology

## Test plan
- [x] Pre-commit hooks pass on all changed files
- [x] Config-validation unit tests (`5 passed`)
- [x] A2/A3 and A5 full scene-test collection
- [x] A2/A3 sim resource, HBG, and TMR suites
- [x] A5 sim resource, HBG, and TMR suites
- [x] A5 cold prewarm benchmark runs through `worker.run()` without `AttributeError`
- [x] Full Python unit suite: `1681 passed, 6 skipped`; two GCC setup tests are incompatible with the locally installed `/usr/bin/g++-15`, and one worker child-reaping case passed on isolated rerun
- [ ] Onboard-only cases (Qwen decode, async worker) — not run; `npu-smi` is unavailable on this machine
