### PR TITLE
Fix: validate HBG single-ring boundaries

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -1337,9 +1337,9 @@ static TaskOutputTensors submit_task_common(
 
     for (uint32_t i = 0; i < args.explicit_dep_count(); i++) {
         TaskId dep_task_id = args.explicit_dep(i);
-        if (!dep_task_id.is_valid()) {
+        if (!dep_task_id.is_valid() || dep_task_id.ring() != 0) {
             orch->report_fatal(
-                SIMPLER_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.set_dependencies(...) requires valid task ids"
+                SIMPLER_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.set_dependencies(...) requires valid ring-zero task ids"
             );
             return result;
         }

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/shared_memory.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/shared_memory.cpp
@@ -23,6 +23,15 @@
 #include <string.h>
 #include "common/unified_log.h"
 
+namespace {
+
+bool is_valid_task_window_size(uint64_t task_window_size) {
+    return task_window_size >= 4 && task_window_size <= static_cast<uint64_t>(INT32_MAX) &&
+           (task_window_size & (task_window_size - 1)) == 0;
+}
+
+}  // namespace
+
 // =============================================================================
 // Size Calculation
 // =============================================================================
@@ -60,6 +69,7 @@ void PTO2SharedMemoryHandle::setup_pointers(uint64_t pitch) {
 bool PTO2SharedMemoryHandle::init(
     void *sm_base_arg, uint64_t sm_size_arg, uint64_t task_window_size, uint64_t heap_size
 ) {
+    if (!is_valid_task_window_size(task_window_size)) return false;
     if (!sm_base_arg || sm_size_arg == 0) return false;
     const uint64_t mirror_bytes = calculate_size(task_window_size);
     // The mirror has to stay inside an int32 delta's reach: a payload names its
@@ -83,6 +93,7 @@ bool PTO2SharedMemoryHandle::init(
 bool PTO2SharedMemoryHandle::attach_populated(
     void *sm_base_arg, uint64_t sm_size_arg, uint64_t task_window_size, uint64_t live_slots, uint64_t image_bytes
 ) {
+    if (!is_valid_task_window_size(task_window_size)) return false;
     if (!sm_base_arg || sm_size_arg == 0) return false;
     // A pitch above the capacity would name a slot the ring cannot address, and one
     // below what the host used would place every segment past the descriptors

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -1337,9 +1337,9 @@ static TaskOutputTensors submit_task_common(
 
     for (uint32_t i = 0; i < args.explicit_dep_count(); i++) {
         TaskId dep_task_id = args.explicit_dep(i);
-        if (!dep_task_id.is_valid()) {
+        if (!dep_task_id.is_valid() || dep_task_id.ring() != 0) {
             orch->report_fatal(
-                SIMPLER_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.set_dependencies(...) requires valid task ids"
+                SIMPLER_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.set_dependencies(...) requires valid ring-zero task ids"
             );
             return result;
         }

--- a/src/a5/runtime/host_build_graph/runtime/shared/shared_memory.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/shared_memory.cpp
@@ -23,6 +23,15 @@
 #include <string.h>
 #include "common/unified_log.h"
 
+namespace {
+
+bool is_valid_task_window_size(uint64_t task_window_size) {
+    return task_window_size >= 4 && task_window_size <= static_cast<uint64_t>(INT32_MAX) &&
+           (task_window_size & (task_window_size - 1)) == 0;
+}
+
+}  // namespace
+
 // =============================================================================
 // Size Calculation
 // =============================================================================
@@ -60,6 +69,7 @@ void PTO2SharedMemoryHandle::setup_pointers(uint64_t pitch) {
 bool PTO2SharedMemoryHandle::init(
     void *sm_base_arg, uint64_t sm_size_arg, uint64_t task_window_size, uint64_t heap_size
 ) {
+    if (!is_valid_task_window_size(task_window_size)) return false;
     if (!sm_base_arg || sm_size_arg == 0) return false;
     const uint64_t mirror_bytes = calculate_size(task_window_size);
     // The mirror has to stay inside an int32 delta's reach: a payload names its
@@ -83,6 +93,7 @@ bool PTO2SharedMemoryHandle::init(
 bool PTO2SharedMemoryHandle::attach_populated(
     void *sm_base_arg, uint64_t sm_size_arg, uint64_t task_window_size, uint64_t live_slots, uint64_t image_bytes
 ) {
+    if (!is_valid_task_window_size(task_window_size)) return false;
     if (!sm_base_arg || sm_size_arg == 0) return false;
     // A pitch above the capacity would name a slot the ring cannot address, and one
     // below what the host used would place every segment past the descriptors

--- a/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
@@ -13,6 +13,7 @@
 
 #include <array>
 #include <condition_variable>
+#include <cstddef>
 #include <cstdint>
 #include <mutex>
 #include <optional>
@@ -25,6 +26,20 @@
 #include "shared_memory.h"
 #include "task_interface/assert_compat.h"
 #include "utils/device_arena.h"
+
+TEST(HbgRuntimeBoundaryTest, SharedMemoryRejectsInvalidTaskWindowBeforePointerSetup) {
+    alignas(PTO2_ALIGN_SIZE) std::array<std::byte, 4096> storage{};
+    constexpr std::array<uint64_t, 3> kInvalidTaskWindows{0, 3, 5};
+
+    for (uint64_t task_window_size : kInvalidTaskWindows) {
+        SCOPED_TRACE(task_window_size);
+        PTO2SharedMemoryHandle handle{};
+        EXPECT_FALSE(handle.init(storage.data(), storage.size(), task_window_size, 4096));
+        EXPECT_EQ(handle.sm_base, nullptr);
+        EXPECT_FALSE(handle.attach_populated(storage.data(), storage.size(), task_window_size, 1, storage.size()));
+        EXPECT_EQ(handle.sm_base, nullptr);
+    }
+}
 
 class HbgGraphSubmitFailureTest : public ::testing::Test {
 protected:
@@ -69,6 +84,28 @@ protected:
         sm_arena.release();
     }
 };
+
+TEST_F(HbgGraphSubmitFailureTest, ExplicitDependencyRejectsNonzeroRingId) {
+    orch.begin_scope();
+
+    CoreTaskArgs producer_args;
+    const TaskOutputTensors producer = orch.submit_dummy_task(producer_args);
+    ASSERT_TRUE(producer.task_id().is_valid());
+
+    const TaskId invalid_dep = TaskId::make(1, producer.task_id().local());
+    CoreTaskArgs consumer_args;
+    consumer_args.set_dependencies(&invalid_dep, 1);
+    orch.submit_dummy_task(consumer_args);
+
+    EXPECT_TRUE(orch.fatal);
+    EXPECT_EQ(
+        sm_handle->header->orch_error_code.load(std::memory_order_acquire),
+        static_cast<int32_t>(SIMPLER_ERROR_INVALID_ARGS)
+    );
+    const auto &producer_slot =
+        sm_handle->header->ring.get_slot_state_by_task_id(static_cast<int32_t>(producer.task_id().local()));
+    EXPECT_EQ(producer_slot.last_consumer_local_id, static_cast<int32_t>(producer.task_id().local()));
+}
 
 TEST_F(HbgGraphSubmitFailureTest, InFlightGraphInvocationsReserveHeapOnlyAtCommit) {
     std::array<uint32_t, 16> storage{};


### PR DESCRIPTION
## Summary

- Rebase onto current `main`, where #1965 and #1968 now contain the structural HBG single-ring and scope collapse originally carried by this PR.
- Retain the boundary hardening not yet present upstream: reject invalid task-window capacities before shared-memory pointer setup and reject nonzero-ring explicit dependencies before slot lookup.
- Apply both guards to a2a3 and a5 and cover them through the shared HBG regression target.

## Testing

- [x] `pre-commit run --from-ref upstream/main --to-ref HEAD`
- [x] `test_hbg_graph_submit_failure`
- [x] `test_a5_hbg_graph_submit_failure`

Related to #1721
