### PR TITLE
Optimize: pack HBG Graph replay data into one arena block

### DIFF
--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -802,20 +802,21 @@ int DeviceRunner::finalize() {
     release_callable_state();
 
     unload_executor_binaries();
-    release_graph_definition_buffers();
 
-    // Release the three per-Worker pooled arenas. Must precede mem_alloc_.finalize()
+    // Release the arena-bank regions. Must precede mem_alloc_.finalize()
     // so the arenas free through the still-live allocator, not after it.
     for (auto &bank : arena_banks_) {
         bank->gm_heap.release();
         bank->gm_sm.release();
         bank->runtime_pool.release();
+        bank->graph_block.release();
     }
     clear_temporary_buffer();
     for (auto &bank : arena_banks_) {
         bank->cached_gm_heap_size = 0;
         bank->cached_gm_sm_size = 0;
         bank->cached_runtime_arena_size = 0;
+        bank->cached_graph_block_size = 0;
     }
     prebuilt_runtime_arena_cache_valid_ = false;
     prebuilt_runtime_arena_cache_key_.clear();

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -417,55 +417,54 @@ static bool relocate_host_orch_image(
     return ok;
 }
 
-bool upload_graph_submissions(
-    Runtime *runtime, const HostApi *api, GraphHostState &graph_state, uint64_t &uploaded_bytes
-) {
+bool upload_graph_block(const HostApi *api, GraphHostState &graph_state, uint64_t &uploaded_bytes) {
     uploaded_bytes = 0;
     const size_t count = graph_host_upload_count(graph_state);
-    // Pass 1: upload each distinct Definition once as a shared device object
-    // ([GraphDefinitionHeader][Definition image]) keyed by content identity.
-    // Submissions reference the object's GM address, so this pass completing
-    // before any submission is uploaded is what makes the reference safe —
-    // the device boots only after both passes.
-    GraphHostDefinitionList definitions = graph_host_definitions(graph_state);
-    struct UploadedDefinition {
-        void *device_object;               // GM address; host must not dereference
-        const GraphDefinition *host_view;  // the host-side image the object was built from
+    struct PackedDefinition {
+        const GraphHostDefinition *entry;
+        const GraphDefinition *definition;
+        size_t offset;
     };
-    std::unordered_map<uint64_t, UploadedDefinition> definition_objects;
+    struct PackedSubmission {
+        PTO2TaskSlotState *outer_slot;
+        const GraphSubmission *submission;
+        size_t definition_index;
+        size_t offset;
+    };
+    auto reserve_region = [](size_t bytes, size_t alignment, size_t *cursor, size_t *offset) -> bool {
+        if (cursor == nullptr || offset == nullptr || alignment == 0 || (alignment & (alignment - 1)) != 0 ||
+            *cursor > SIZE_MAX - (alignment - 1)) {
+            return false;
+        }
+        const size_t aligned = (*cursor + alignment - 1) & ~(alignment - 1);
+        if (bytes > SIZE_MAX - aligned) return false;
+        *offset = aligned;
+        *cursor = aligned + bytes;
+        return true;
+    };
+
+    // Compute and validate the complete layout before asking the arena bank to
+    // allocate. Definitions lead the block; fixed-size submissions follow and
+    // refer to their Definition by device_base + offset.
+    GraphHostDefinitionList definitions = graph_host_definitions(graph_state);
+    std::vector<PackedDefinition> packed_definitions;
+    packed_definitions.reserve(definitions.entries.size());
+    std::unordered_map<uint64_t, size_t> definition_indices;
+    size_t block_bytes = 0;
     for (const GraphHostDefinition &entry : definitions.entries) {
         if (entry.data == nullptr || entry.bytes < sizeof(GraphDefinition)) continue;
         const auto *definition = reinterpret_cast<const GraphDefinition *>(entry.data);
         if (definition->total_bytes != entry.bytes || definition->full_key != entry.full_key) continue;
+        if (entry.bytes > SIZE_MAX - sizeof(GraphDefinitionHeader)) return false;
         const size_t object_bytes = sizeof(GraphDefinitionHeader) + entry.bytes;
-        void *object =
-            api->acquire_graph_definition_buffer(entry.full_key, object_bytes, alignof(GraphDefinitionHeader));
-        if (object == nullptr) {
-            LOG_ERROR(
-                "host-orch: failed to retain %zu bytes for Graph Definition key=%#llx", object_bytes,
-                static_cast<unsigned long long>(entry.full_key)
-            );
-            return false;
-        }
-        std::vector<std::byte> staging(object_bytes, std::byte{0});
-        auto *header = reinterpret_cast<GraphDefinitionHeader *>(staging.data());
-        header->magic = GRAPH_DEFINITION_OBJECT_MAGIC;
-        header->verify_state.store(
-            static_cast<uint32_t>(GraphDefinitionVerifyState::UPLOADED), std::memory_order_relaxed
-        );
-        header->definition_bytes = static_cast<uint32_t>(entry.bytes);
-        header->content_hash = definition->content_hash;
-        header->full_key = definition->full_key;
-        std::memcpy(staging.data() + sizeof(GraphDefinitionHeader), entry.data, entry.bytes);
-        if (api->copy_to_device(object, staging.data(), object_bytes) != 0) {
-            LOG_ERROR("host-orch: failed to upload Graph Definition object");
-            return false;
-        }
-        definition_objects.emplace(definition->content_hash, UploadedDefinition{object, definition});
-        uploaded_bytes += object_bytes;
+        size_t offset = 0;
+        if (!reserve_region(object_bytes, alignof(GraphDefinitionHeader), &block_bytes, &offset)) return false;
+        definition_indices.emplace(definition->content_hash, packed_definitions.size());
+        packed_definitions.push_back(PackedDefinition{&entry, definition, offset});
     }
 
-    // Pass 2: per-submission execution storage + the small reference image.
+    std::vector<PackedSubmission> packed_submissions;
+    packed_submissions.reserve(count);
     for (size_t index = 0; index < count; ++index) {
         std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
         if (!upload.has_value() || upload->outer_slot == nullptr || upload->data == nullptr ||
@@ -474,41 +473,65 @@ bool upload_graph_submissions(
             LOG_ERROR("host-orch: invalid pending Graph POD image");
             return false;
         }
-        auto *submission = reinterpret_cast<GraphSubmission *>(upload->data);
-        auto object_it = definition_objects.find(submission->definition_hash);
-        if (object_it == definition_objects.end() || object_it->second.device_object == nullptr) {
-            LOG_ERROR("host-orch: Graph submission has no uploaded Definition object");
+        const auto *submission = reinterpret_cast<const GraphSubmission *>(upload->data);
+        auto object_it = definition_indices.find(submission->definition_hash);
+        if (object_it == definition_indices.end()) {
+            LOG_ERROR("host-orch: Graph submission has no packed Definition object");
             return false;
         }
-        // Checked against the host-side Definition image the device object was
-        // built from; the GM object itself is never dereferenced on the host.
-        // Execution storage needs no retained buffer: it is the tail of the
-        // outer task's own heap allocation, which graph_submit_definition sized
-        // to required_heap + execution_storage_bytes.
-        const GraphDefinition *definition = object_it->second.host_view;
+        const PackedDefinition &packed_definition = packed_definitions[object_it->second];
+        const GraphDefinition *definition = packed_definition.definition;
         if (definition->task_count == 0 || definition->task_count > GRAPH_MAX_NODES ||
             definition->full_key != submission->graph_key || definition->execution_storage_bytes == 0) {
             LOG_ERROR("host-orch: invalid Graph Definition for submission");
             return false;
         }
-        submission->definition_addr = reinterpret_cast<uint64_t>(object_it->second.device_object);
-        submission->local_execution = 0;
-        submission->activation_gate = 0;
-
-        void *device_submission = api->device_malloc(upload->bytes);
-        if (device_submission == nullptr) {
-            LOG_ERROR("host-orch: failed to allocate %zu bytes for Graph submission", upload->bytes);
-            return false;
-        }
-        if (api->copy_to_device(device_submission, upload->data, upload->bytes) != 0) {
-            LOG_ERROR("host-orch: failed to upload Graph submission POD image");
-            api->device_free(device_submission);
-            return false;
-        }
-        upload->outer_slot->graph_context = device_submission;
-        runtime->tensor_pairs_.push_back({nullptr, device_submission, upload->bytes, false});
-        uploaded_bytes += static_cast<uint64_t>(upload->bytes);
+        size_t offset = 0;
+        if (!reserve_region(sizeof(GraphSubmission), alignof(GraphSubmission), &block_bytes, &offset)) return false;
+        packed_submissions.push_back({upload->outer_slot, submission, object_it->second, offset});
     }
+    if (block_bytes == 0) return true;
+
+    constexpr size_t block_alignment = alignof(GraphDefinitionHeader) > alignof(GraphSubmission) ?
+                                           alignof(GraphDefinitionHeader) :
+                                           alignof(GraphSubmission);
+    void *block = api->acquire_graph_block(block_bytes, block_alignment);
+    if (block == nullptr) {
+        LOG_ERROR("host-orch: failed to acquire %zu bytes for the arena-bank GraphBlock", block_bytes);
+        return false;
+    }
+
+    std::vector<std::byte> staging(block_bytes, std::byte{0});
+    auto *device_base = static_cast<std::byte *>(block);
+    for (const PackedDefinition &packed : packed_definitions) {
+        auto *header = reinterpret_cast<GraphDefinitionHeader *>(staging.data() + packed.offset);
+        header->magic = GRAPH_DEFINITION_OBJECT_MAGIC;
+        header->verify_state.store(
+            static_cast<uint32_t>(GraphDefinitionVerifyState::UPLOADED), std::memory_order_relaxed
+        );
+        header->definition_bytes = static_cast<uint32_t>(packed.entry->bytes);
+        header->content_hash = packed.definition->content_hash;
+        header->full_key = packed.definition->full_key;
+        std::memcpy(
+            staging.data() + packed.offset + sizeof(GraphDefinitionHeader), packed.entry->data, packed.entry->bytes
+        );
+    }
+    for (const PackedSubmission &packed : packed_submissions) {
+        GraphSubmission submission = *packed.submission;
+        submission.definition_addr =
+            reinterpret_cast<uint64_t>(device_base + packed_definitions[packed.definition_index].offset);
+        submission.local_execution = 0;
+        submission.activation_gate = 0;
+        std::memcpy(staging.data() + packed.offset, &submission, sizeof(submission));
+    }
+
+    if (api->copy_to_device(block, staging.data(), block_bytes) != 0) {
+        LOG_ERROR("host-orch: failed to upload the packed GraphBlock");
+        return false;
+    }
+    for (const PackedSubmission &packed : packed_submissions)
+        packed.outer_slot->graph_context = device_base + packed.offset;
+    uploaded_bytes = block_bytes;
     return true;
 }
 
@@ -627,7 +650,7 @@ int32_t run_host_orchestration(
 
     const int64_t t_graph_ns = bind_now_ns();
     uint64_t graph_bytes = 0;
-    if (!upload_graph_submissions(runtime, api, *graph_state, graph_bytes)) return -1;
+    if (!upload_graph_block(api, *graph_state, graph_bytes)) return -1;
     {
         char attrs[96];
         snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, graph_host_upload_count(*graph_state), graph_bytes);

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -410,8 +410,8 @@ static bool relocate_host_orch_image(
         const int32_t count = ring.fc.current_task_index.load(std::memory_order_acquire);
         for (int32_t slot = 0; slot < count; ++slot) {
             PTO2TaskSlotState *state = &ring.slot_states[slot];
+            // payload is relative to its slot and moves with the SM image.
             relocate(state->task);
-            relocate(state->payload);
         }
     }
     return ok;
@@ -684,18 +684,17 @@ int32_t run_host_orchestration(
     }
     record_bind_phase(HostPhaseKind::BindRelocate, t_reloc_ns);
 
-    // Ship only the live prefix of each segment: the device reads no slot past
-    // total_tasks, so upload header + descriptors[0,N), payloads[0,N),
+    // Ship descriptors[0,N), the live TaskPayloadSpace prefix,
     // slot_states[0,N) and completion_flags[0,N) — never the ring-sized tails.
     // header + descriptors[0,N) are contiguous, so that is a single copy.
     const uint64_t nt = static_cast<uint64_t>(total_tasks);
     const uint64_t hdr_desc_bytes = sm_segs.descriptors + nt * sizeof(PTO2TaskDescriptor);
+    const uint64_t payload_bytes = rt->orchestrator.task_payload_space_used_bytes;
     char *host_base = static_cast<char *>(host_sm);
     char *dev_base = static_cast<char *>(device_sm);
     const int64_t t_sm_h2d_ns = bind_now_ns();
     if (api->copy_to_device(dev_base, host_base, hdr_desc_bytes) != 0 ||
-        api->copy_to_device(dev_base + sm_segs.payloads, host_base + sm_segs.payloads, nt * sizeof(PTO2TaskPayload)) !=
-            0 ||
+        api->copy_to_device(dev_base + sm_segs.payloads, host_base + sm_segs.payloads, payload_bytes) != 0 ||
         api->copy_to_device(
             dev_base + sm_segs.slot_states, host_base + sm_segs.slot_states, nt * sizeof(PTO2TaskSlotState)
         ) != 0 ||
@@ -706,8 +705,8 @@ int32_t run_host_orchestration(
         return -1;
     }
     {
-        const uint64_t sm_h2d_bytes = hdr_desc_bytes + nt * sizeof(PTO2TaskPayload) + nt * sizeof(PTO2TaskSlotState) +
-                                      nt * sizeof(std::atomic<uint8_t>);
+        const uint64_t sm_h2d_bytes =
+            hdr_desc_bytes + payload_bytes + nt * sizeof(PTO2TaskSlotState) + nt * sizeof(std::atomic<uint8_t>);
         char attrs[96];
         snprintf(attrs, sizeof(attrs), "nt=%" PRIu64 " bytes=%" PRIu64, nt, sm_h2d_bytes);
         record_bind_phase(HostPhaseKind::BindSmH2d, t_sm_h2d_ns, attrs, sm_h2d_bytes);

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -469,16 +469,12 @@ bool upload_graph_submissions(
     for (size_t index = 0; index < count; ++index) {
         std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
         if (!upload.has_value() || upload->outer_slot == nullptr || upload->data == nullptr ||
-            upload->bytes < sizeof(GraphSubmission) || upload->outer_slot->task_kind != TaskKind::GRAPH ||
+            upload->bytes != sizeof(GraphSubmission) || upload->outer_slot->task_kind != TaskKind::GRAPH ||
             upload->outer_slot->task == nullptr) {
             LOG_ERROR("host-orch: invalid pending Graph POD image");
             return false;
         }
         auto *submission = reinterpret_cast<GraphSubmission *>(upload->data);
-        if (!graph_submission_wire_size_valid(*submission, upload->bytes)) {
-            LOG_ERROR("host-orch: Graph submission size does not match its POD image");
-            return false;
-        }
         auto object_it = definition_objects.find(submission->definition_hash);
         if (object_it == definition_objects.end() || object_it->second.device_object == nullptr) {
             LOG_ERROR("host-orch: Graph submission has no uploaded Definition object");

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -972,6 +972,28 @@ struct PTO2PreparedTask {
     PTO2TaskSlotState *slot_state = nullptr;
 };
 
+static PTO2TaskPayload *allocate_task_payload(PTO2OrchestratorState *orch, size_t requested_bytes) {
+    if (orch == nullptr || orch->sm_header == nullptr || requested_bytes < sizeof(PTO2TaskPayload)) return nullptr;
+    PTO2SharedMemoryRingHeader &ring = orch->sm_header->ring;
+    constexpr uint64_t alignment = alignof(PTO2TaskPayload);
+    const uint64_t capacity = ring.task_window_size * sizeof(PTO2TaskPayload);
+    const uint64_t cursor = orch->task_payload_space_used_bytes;
+    if (cursor > UINT64_MAX - (alignment - 1) || requested_bytes > UINT64_MAX - (alignment - 1)) return nullptr;
+    const uint64_t offset = PTO2_ALIGN_UP(cursor, alignment);
+    const uint64_t bytes = PTO2_ALIGN_UP(static_cast<uint64_t>(requested_bytes), alignment);
+    if (offset > capacity || bytes > capacity - offset) {
+        orch->report_fatal(
+            PTO2_ERROR_FLOW_CONTROL_DEADLOCK, __FUNCTION__,
+            "TaskPayloadSpace exhausted: used=%" PRIu64 " requested=%" PRIu64 " capacity=%" PRIu64, cursor, bytes,
+            capacity
+        );
+        return nullptr;
+    }
+    orch->task_payload_space_used_bytes = offset + bytes;
+    auto *base = reinterpret_cast<std::byte *>(ring.task_payloads);
+    return reinterpret_cast<PTO2TaskPayload *>(base + offset);
+}
+
 static PTO2OutputLayout calculate_output_layout(const CoreTaskArgs &args) {
     PTO2OutputLayout layout;
     for (int32_t i = 0; i < args.tensor_count(); i++) {
@@ -1015,7 +1037,10 @@ static bool prepare_task(
     out->task_id = PTO2TaskId::make(ring_id, static_cast<uint32_t>(out->alloc_result.task_id));
     out->slot_state = &orch->sm_header->ring.get_slot_state_by_slot(out->alloc_result.slot);
     out->task = &orch->sm_header->ring.task_descriptors[out->alloc_result.slot];
-    out->payload = &orch->sm_header->ring.task_payloads[out->alloc_result.slot];
+    out->payload = allocate_task_payload(orch, sizeof(PTO2TaskPayload));
+    if (out->payload == nullptr) {
+        return false;
+    }
 
     // Init-on-write: this slot's dynamic scheduling fields and completion flag are
     // initialized here, as the orchestrator claims the slot. whole-graph-resident
@@ -1027,9 +1052,8 @@ static bool prepare_task(
 
     out->payload->prefetch(args.tensor_count(), args.scalar_count());
 
-    // Re-bind payload/task pointers each submit. Value is per-slot constant
-    // (same as &task_payloads[slot] / &task_descriptors[slot]), but writing
-    // here lets RingSchedState::init() skip the O(window_size) bind loop.
+    // Bind the payload record selected from TaskPayloadSpace. Its relative
+    // reference remains valid when the complete SM image moves to device GM.
     // Both writes hit the same 64B slot_state cache line we're about to
     // dirty below, so the extra cost is two stores on an already-hot line.
     // Must precede the Orch-side wiring publish at the end of
@@ -1563,10 +1587,14 @@ bool graph_submit_outer(
     const PTO2TaskId task_id = PTO2TaskId::make(0, static_cast<uint32_t>(allocation.task_id));
     PTO2SharedMemoryRingHeader &ring = orch->sm_header->ring;
     PTO2TaskDescriptor &task = ring.task_descriptors[allocation.slot];
-    PTO2TaskPayload &payload = ring.task_payloads[allocation.slot];
+    size_t payload_bytes = 0;
+    if (!graph_task_payload_layout(args.tensor_count(), args.scalar_count(), &payload_bytes)) return false;
+    PTO2TaskPayload *payload_ptr = allocate_task_payload(orch, payload_bytes);
+    if (payload_ptr == nullptr) return false;
+    PTO2TaskPayload &payload = *payload_ptr;
     PTO2TaskSlotState &slot = ring.get_slot_state_by_slot(allocation.slot);
 
-    slot.bind_buffers(&payload, &task);
+    slot.bind_buffers(payload_ptr, &task);
     slot.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
     slot.last_consumer_local_id = static_cast<int32_t>(task_id.local());
     slot.active_mask = ActiveMask{};
@@ -1582,14 +1610,17 @@ bool graph_submit_outer(
     task.packed_buffer_base = allocation.packed_base;
     task.packed_buffer_end = allocation.packed_end;
     graph_reset_outer_payload(payload);
-    // The replay's boundary args, in the same place and the same form as any
-    // other task's args. graph_execution_localize reads them from here.
     payload.tensor_count = args.tensor_count();
     payload.scalar_count = args.scalar_count();
-    for (int32_t i = 0; i < args.tensor_count(); ++i)
-        payload.tensors[i] = args.tensor(i).ref();
-    if (args.scalar_count() != 0) {
-        std::memcpy(payload.scalars, args.scalar_data(), static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t));
+    for (int32_t i = 0; i < args.tensor_count(); ++i) {
+        ChipTensor *destination = graph_task_payload_tensor(payload, static_cast<uint32_t>(i));
+        if (destination == nullptr) return false;
+        *destination = args.tensor(i).ref();
+    }
+    for (int32_t i = 0; i < args.scalar_count(); ++i) {
+        uint64_t *destination = graph_task_payload_scalar(payload, static_cast<uint32_t>(i));
+        if (destination == nullptr) return false;
+        *destination = args.scalar_data()[i];
     }
 
     PTO2FaninBuilder fanin_builder(orch, &payload, static_cast<int32_t>(task_id.local()), next_fanin_seen_epoch(orch));

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -1523,40 +1523,13 @@ void graph_reset_outer_payload(PTO2TaskPayload &payload) {
 }
 
 bool graph_prepare_submission_image(
-    uint64_t full_key, const GraphTaskArgs &args, std::vector<std::byte> *submission_image
+    uint64_t full_key, uint64_t definition_hash, std::vector<std::byte> *submission_image
 ) {
     if (submission_image == nullptr) return false;
-    const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphTensor));
-    const size_t tensor_bytes = static_cast<size_t>(args.tensor_count()) * sizeof(GraphTensor);
-    if (tensors_offset > UINT32_MAX || tensors_offset > UINT32_MAX - tensor_bytes) {
-        return false;
-    }
-    const size_t tensors_end = tensors_offset + tensor_bytes;
-    const size_t scalar_bytes = static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t);
-    const size_t scalars_offset = args.scalar_count() == 0 ? 0 : PTO2_ALIGN_UP(tensors_end, alignof(uint64_t));
-    const size_t total_bytes = args.scalar_count() == 0 ? tensors_end : scalars_offset + scalar_bytes;
-    if ((args.scalar_count() != 0 && (scalars_offset > UINT32_MAX || scalars_offset > UINT32_MAX - scalar_bytes)) ||
-        total_bytes > UINT32_MAX) {
-        return false;
-    }
-    submission_image->assign(total_bytes, std::byte{0});
-    auto *tensors = reinterpret_cast<GraphTensor *>(submission_image->data() + tensors_offset);
-    for (int32_t i = 0; i < args.tensor_count(); ++i)
-        tensors[i] = graph_tensor_pack(args.tensor(i).ref());
-    if (args.scalar_count() != 0) {
-        std::memcpy(
-            submission_image->data() + scalars_offset, args.scalar_data(),
-            static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t)
-        );
-    }
-
     GraphSubmission submission{};
     submission.graph_key = full_key;
-    submission.total_bytes = static_cast<uint32_t>(submission_image->size());
-    submission.tensors_offset = static_cast<uint32_t>(tensors_offset);
-    submission.tensor_count = static_cast<uint32_t>(args.tensor_count());
-    submission.scalars_offset = static_cast<uint32_t>(scalars_offset);
-    submission.scalar_count = static_cast<uint32_t>(args.scalar_count());
+    submission.definition_hash = definition_hash;
+    submission_image->assign(sizeof(submission), std::byte{0});
     std::memcpy(submission_image->data(), &submission, sizeof(submission));
     return true;
 }
@@ -1574,8 +1547,7 @@ bool graph_submit_outer(
     }
 
     GraphPendingUpload pending;
-    if (!graph_prepare_submission_image(full_key, args, &pending.image)) return false;
-    reinterpret_cast<GraphSubmission *>(pending.image.data())->definition_hash = definition_hash;
+    if (!graph_prepare_submission_image(full_key, definition_hash, &pending.image)) return false;
     pending.deferred_heap = defer_heap;
 
     DepInputs boundary_inputs{
@@ -1610,6 +1582,15 @@ bool graph_submit_outer(
     task.packed_buffer_base = allocation.packed_base;
     task.packed_buffer_end = allocation.packed_end;
     graph_reset_outer_payload(payload);
+    // The replay's boundary args, in the same place and the same form as any
+    // other task's args. graph_execution_localize reads them from here.
+    payload.tensor_count = args.tensor_count();
+    payload.scalar_count = args.scalar_count();
+    for (int32_t i = 0; i < args.tensor_count(); ++i)
+        payload.tensors[i] = args.tensor(i).ref();
+    if (args.scalar_count() != 0) {
+        std::memcpy(payload.scalars, args.scalar_data(), static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t));
+    }
 
     PTO2FaninBuilder fanin_builder(orch, &payload, static_cast<int32_t>(task_id.local()), next_fanin_seen_epoch(orch));
     auto emit = [&](PTO2TaskId producer_id) -> bool {
@@ -1684,7 +1665,7 @@ bool graph_submit_pending_definition(
 bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostState *state, uint64_t *failed_key) {
     for (GraphPendingUpload &pending : state->pending_uploads) {
         if (!pending.deferred_heap) continue;
-        if (pending.image.size() < sizeof(GraphSubmission)) return false;
+        if (pending.image.size() != sizeof(GraphSubmission)) return false;
         auto *submission = reinterpret_cast<GraphSubmission *>(pending.image.data());
         auto definition_it = state->definitions.find(submission->graph_key);
         const GraphDefinition *definition =
@@ -1692,8 +1673,7 @@ bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostSt
         if (definition == nullptr || definition->execution_storage_bytes == 0 ||
             definition->required_heap > UINT64_MAX - definition->execution_storage_bytes ||
             pending.outer_slot == nullptr || pending.outer_slot->task == nullptr ||
-            pending.outer_slot->task_kind != TaskKind::GRAPH ||
-            !graph_submission_wire_size_valid(*submission, pending.image.size())) {
+            pending.outer_slot->task_kind != TaskKind::GRAPH) {
             if (failed_key != nullptr) *failed_key = submission->graph_key;
             return false;
         }

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_orchestrator.h
@@ -71,6 +71,9 @@ struct PTO2OrchestratorState {
     PTO2RingSet ring;
     uint32_t *fanin_seen_epoch;
     uint32_t fanin_seen_current_epoch{1};
+    // Live bytes in the packed task-payload segment. Payload records are
+    // appended in submission order and may have different lengths.
+    uint64_t task_payload_space_used_bytes{0};
 
     // === TENSOR MAP (Private) ===
     PTO2TensorMap tensor_map;  // Producer lookup

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -450,6 +450,50 @@ static_assert(
     "PTO2TaskPayload size = metadata(576) + predicate cache line(64) + tensors + scalars"
 );
 
+// Position-independent reference used inside relocatable runtime images. The
+// payload and its slot move by the same delta from host DDR to device GM, so a
+// relative offset remains valid without a per-slot relocation pass.
+template <typename T>
+struct PTO2RelativePtr {
+    int64_t offset{0};
+
+    T *get() const {
+        if (offset == 0) return nullptr;
+        const intptr_t self = reinterpret_cast<intptr_t>(this);
+        return reinterpret_cast<T *>(self + offset);
+    }
+
+    void reset(T *pointer = nullptr) {
+        offset = pointer == nullptr ? 0 : reinterpret_cast<intptr_t>(pointer) - reinterpret_cast<intptr_t>(this);
+    }
+
+    PTO2RelativePtr &operator=(T *pointer) {
+        reset(pointer);
+        return *this;
+    }
+
+    operator T *() const { return get(); }
+    T *operator->() const { return get(); }
+    T &operator*() const { return *get(); }
+    explicit operator bool() const { return offset != 0; }
+
+    bool operator==(std::nullptr_t) const { return offset == 0; }
+    bool operator!=(std::nullptr_t) const { return offset != 0; }
+};
+
+template <typename T>
+inline bool operator==(std::nullptr_t, const PTO2RelativePtr<T> &pointer) {
+    return pointer == nullptr;
+}
+
+template <typename T>
+inline bool operator!=(std::nullptr_t, const PTO2RelativePtr<T> &pointer) {
+    return pointer != nullptr;
+}
+
+static_assert(sizeof(PTO2RelativePtr<PTO2TaskPayload>) == sizeof(uint64_t));
+static_assert(std::is_trivially_copyable_v<PTO2RelativePtr<PTO2TaskPayload>>);
+
 /**
  * Per-task slot scheduling state (scheduler-private, NOT in shared memory)
  *
@@ -478,7 +522,7 @@ struct alignas(64) PTO2TaskSlotState {
     std::atomic<PTO2TaskState> task_state;
 
     // --- Per-slot constant, re-bound by orch::prepare_task each submit ---
-    PTO2TaskPayload *payload;
+    PTO2RelativePtr<PTO2TaskPayload> payload;
     PTO2TaskDescriptor *task;
 
     // --- Wake list: last-fanin notification (intrusive, lock-free) ---
@@ -538,7 +582,7 @@ struct alignas(64) PTO2TaskSlotState {
     }
 
     void bind_buffers(PTO2TaskPayload *p, PTO2TaskDescriptor *t) {
-        payload = p;
+        payload.reset(p);
         task = t;
     }
 

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_shared_memory.h
@@ -143,9 +143,11 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
         return task_descriptors[get_slot_by_task_id(local_id)];
     }
 
-    PTO2TaskPayload &get_payload_by_slot(int32_t slot) { return task_payloads[slot]; }
+    PTO2TaskPayload &get_payload_by_slot(int32_t slot) { return *slot_states[slot].payload; }
 
-    PTO2TaskPayload &get_payload_by_task_id(int32_t local_id) { return task_payloads[get_slot_by_task_id(local_id)]; }
+    PTO2TaskPayload &get_payload_by_task_id(int32_t local_id) {
+        return get_payload_by_slot(get_slot_by_task_id(local_id));
+    }
 
     PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -735,18 +735,19 @@ int DeviceRunner::finalize() {
     release_callable_state();
 
     unload_executor_binaries();
-    release_graph_definition_buffers();
 
     for (auto &bank : arena_banks_) {
         bank->gm_heap.release();
         bank->gm_sm.release();
         bank->runtime_pool.release();
+        bank->graph_block.release();
     }
     clear_temporary_buffer();
     for (auto &bank : arena_banks_) {
         bank->cached_gm_heap_size = 0;
         bank->cached_gm_sm_size = 0;
         bank->cached_runtime_arena_size = 0;
+        bank->cached_graph_block_size = 0;
     }
     prebuilt_runtime_arena_cache_valid_ = false;
     prebuilt_runtime_arena_cache_key_.clear();

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -462,55 +462,54 @@ static bool relocate_host_orch_image(
     return ok;
 }
 
-bool upload_graph_submissions(
-    Runtime *runtime, const HostApi *api, GraphHostState &graph_state, uint64_t &uploaded_bytes
-) {
+bool upload_graph_block(const HostApi *api, GraphHostState &graph_state, uint64_t &uploaded_bytes) {
     uploaded_bytes = 0;
     const size_t count = graph_host_upload_count(graph_state);
-    // Pass 1: upload each distinct Definition once as a shared device object
-    // ([GraphDefinitionHeader][Definition image]) keyed by content identity.
-    // Submissions reference the object's GM address, so this pass completing
-    // before any submission is uploaded is what makes the reference safe —
-    // the device boots only after both passes.
-    GraphHostDefinitionList definitions = graph_host_definitions(graph_state);
-    struct UploadedDefinition {
-        void *device_object;               // GM address; host must not dereference
-        const GraphDefinition *host_view;  // the host-side image the object was built from
+    struct PackedDefinition {
+        const GraphHostDefinition *entry;
+        const GraphDefinition *definition;
+        size_t offset;
     };
-    std::unordered_map<uint64_t, UploadedDefinition> definition_objects;
+    struct PackedSubmission {
+        PTO2TaskSlotState *outer_slot;
+        const GraphSubmission *submission;
+        size_t definition_index;
+        size_t offset;
+    };
+    auto reserve_region = [](size_t bytes, size_t alignment, size_t *cursor, size_t *offset) -> bool {
+        if (cursor == nullptr || offset == nullptr || alignment == 0 || (alignment & (alignment - 1)) != 0 ||
+            *cursor > SIZE_MAX - (alignment - 1)) {
+            return false;
+        }
+        const size_t aligned = (*cursor + alignment - 1) & ~(alignment - 1);
+        if (bytes > SIZE_MAX - aligned) return false;
+        *offset = aligned;
+        *cursor = aligned + bytes;
+        return true;
+    };
+
+    // Compute and validate the complete layout before asking the arena bank to
+    // allocate. Definitions lead the block; fixed-size submissions follow and
+    // refer to their Definition by device_base + offset.
+    GraphHostDefinitionList definitions = graph_host_definitions(graph_state);
+    std::vector<PackedDefinition> packed_definitions;
+    packed_definitions.reserve(definitions.entries.size());
+    std::unordered_map<uint64_t, size_t> definition_indices;
+    size_t block_bytes = 0;
     for (const GraphHostDefinition &entry : definitions.entries) {
         if (entry.data == nullptr || entry.bytes < sizeof(GraphDefinition)) continue;
         const auto *definition = reinterpret_cast<const GraphDefinition *>(entry.data);
         if (definition->total_bytes != entry.bytes || definition->full_key != entry.full_key) continue;
+        if (entry.bytes > SIZE_MAX - sizeof(GraphDefinitionHeader)) return false;
         const size_t object_bytes = sizeof(GraphDefinitionHeader) + entry.bytes;
-        void *object =
-            api->acquire_graph_definition_buffer(entry.full_key, object_bytes, alignof(GraphDefinitionHeader));
-        if (object == nullptr) {
-            LOG_ERROR(
-                "host-orch: failed to retain %zu bytes for Graph Definition key=%#llx", object_bytes,
-                static_cast<unsigned long long>(entry.full_key)
-            );
-            return false;
-        }
-        std::vector<std::byte> staging(object_bytes, std::byte{0});
-        auto *header = reinterpret_cast<GraphDefinitionHeader *>(staging.data());
-        header->magic = GRAPH_DEFINITION_OBJECT_MAGIC;
-        header->verify_state.store(
-            static_cast<uint32_t>(GraphDefinitionVerifyState::UPLOADED), std::memory_order_relaxed
-        );
-        header->definition_bytes = static_cast<uint32_t>(entry.bytes);
-        header->content_hash = definition->content_hash;
-        header->full_key = definition->full_key;
-        std::memcpy(staging.data() + sizeof(GraphDefinitionHeader), entry.data, entry.bytes);
-        if (api->copy_to_device(object, staging.data(), object_bytes) != 0) {
-            LOG_ERROR("host-orch: failed to upload Graph Definition object");
-            return false;
-        }
-        definition_objects.emplace(definition->content_hash, UploadedDefinition{object, definition});
-        uploaded_bytes += object_bytes;
+        size_t offset = 0;
+        if (!reserve_region(object_bytes, alignof(GraphDefinitionHeader), &block_bytes, &offset)) return false;
+        definition_indices.emplace(definition->content_hash, packed_definitions.size());
+        packed_definitions.push_back(PackedDefinition{&entry, definition, offset});
     }
 
-    // Pass 2: per-submission execution storage + the small reference image.
+    std::vector<PackedSubmission> packed_submissions;
+    packed_submissions.reserve(count);
     for (size_t index = 0; index < count; ++index) {
         std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
         if (!upload.has_value() || upload->outer_slot == nullptr || upload->data == nullptr ||
@@ -519,41 +518,65 @@ bool upload_graph_submissions(
             LOG_ERROR("host-orch: invalid pending Graph POD image");
             return false;
         }
-        auto *submission = reinterpret_cast<GraphSubmission *>(upload->data);
-        auto object_it = definition_objects.find(submission->definition_hash);
-        if (object_it == definition_objects.end() || object_it->second.device_object == nullptr) {
-            LOG_ERROR("host-orch: Graph submission has no uploaded Definition object");
+        const auto *submission = reinterpret_cast<const GraphSubmission *>(upload->data);
+        auto object_it = definition_indices.find(submission->definition_hash);
+        if (object_it == definition_indices.end()) {
+            LOG_ERROR("host-orch: Graph submission has no packed Definition object");
             return false;
         }
-        // Checked against the host-side Definition image the device object was
-        // built from; the GM object itself is never dereferenced on the host.
-        // Execution storage needs no retained buffer: it is the tail of the
-        // outer task's own heap allocation, which graph_submit_definition sized
-        // to required_heap + execution_storage_bytes.
-        const GraphDefinition *definition = object_it->second.host_view;
+        const PackedDefinition &packed_definition = packed_definitions[object_it->second];
+        const GraphDefinition *definition = packed_definition.definition;
         if (definition->task_count == 0 || definition->task_count > GRAPH_MAX_NODES ||
             definition->full_key != submission->graph_key || definition->execution_storage_bytes == 0) {
             LOG_ERROR("host-orch: invalid Graph Definition for submission");
             return false;
         }
-        submission->definition_addr = reinterpret_cast<uint64_t>(object_it->second.device_object);
-        submission->local_execution = 0;
-        submission->activation_gate = 0;
-
-        void *device_submission = api->device_malloc(upload->bytes);
-        if (device_submission == nullptr) {
-            LOG_ERROR("host-orch: failed to allocate %zu bytes for Graph submission", upload->bytes);
-            return false;
-        }
-        if (api->copy_to_device(device_submission, upload->data, upload->bytes) != 0) {
-            LOG_ERROR("host-orch: failed to upload Graph submission POD image");
-            api->device_free(device_submission);
-            return false;
-        }
-        upload->outer_slot->graph_context = device_submission;
-        runtime->tensor_pairs_.push_back({nullptr, device_submission, upload->bytes, false});
-        uploaded_bytes += static_cast<uint64_t>(upload->bytes);
+        size_t offset = 0;
+        if (!reserve_region(sizeof(GraphSubmission), alignof(GraphSubmission), &block_bytes, &offset)) return false;
+        packed_submissions.push_back({upload->outer_slot, submission, object_it->second, offset});
     }
+    if (block_bytes == 0) return true;
+
+    constexpr size_t block_alignment = alignof(GraphDefinitionHeader) > alignof(GraphSubmission) ?
+                                           alignof(GraphDefinitionHeader) :
+                                           alignof(GraphSubmission);
+    void *block = api->acquire_graph_block(block_bytes, block_alignment);
+    if (block == nullptr) {
+        LOG_ERROR("host-orch: failed to acquire %zu bytes for the arena-bank GraphBlock", block_bytes);
+        return false;
+    }
+
+    std::vector<std::byte> staging(block_bytes, std::byte{0});
+    auto *device_base = static_cast<std::byte *>(block);
+    for (const PackedDefinition &packed : packed_definitions) {
+        auto *header = reinterpret_cast<GraphDefinitionHeader *>(staging.data() + packed.offset);
+        header->magic = GRAPH_DEFINITION_OBJECT_MAGIC;
+        header->verify_state.store(
+            static_cast<uint32_t>(GraphDefinitionVerifyState::UPLOADED), std::memory_order_relaxed
+        );
+        header->definition_bytes = static_cast<uint32_t>(packed.entry->bytes);
+        header->content_hash = packed.definition->content_hash;
+        header->full_key = packed.definition->full_key;
+        std::memcpy(
+            staging.data() + packed.offset + sizeof(GraphDefinitionHeader), packed.entry->data, packed.entry->bytes
+        );
+    }
+    for (const PackedSubmission &packed : packed_submissions) {
+        GraphSubmission submission = *packed.submission;
+        submission.definition_addr =
+            reinterpret_cast<uint64_t>(device_base + packed_definitions[packed.definition_index].offset);
+        submission.local_execution = 0;
+        submission.activation_gate = 0;
+        std::memcpy(staging.data() + packed.offset, &submission, sizeof(submission));
+    }
+
+    if (api->copy_to_device(block, staging.data(), block_bytes) != 0) {
+        LOG_ERROR("host-orch: failed to upload the packed GraphBlock");
+        return false;
+    }
+    for (const PackedSubmission &packed : packed_submissions)
+        packed.outer_slot->graph_context = device_base + packed.offset;
+    uploaded_bytes = block_bytes;
     return true;
 }
 
@@ -683,7 +706,7 @@ int32_t run_host_orchestration(
 
     const int64_t t_graph_ns = bind_now_ns();
     uint64_t graph_bytes = 0;
-    if (!upload_graph_submissions(runtime, api, *graph_state, graph_bytes)) return -1;
+    if (!upload_graph_block(api, *graph_state, graph_bytes)) return -1;
     {
         char attrs[96];
         snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, graph_host_upload_count(*graph_state), graph_bytes);

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -514,16 +514,12 @@ bool upload_graph_submissions(
     for (size_t index = 0; index < count; ++index) {
         std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
         if (!upload.has_value() || upload->outer_slot == nullptr || upload->data == nullptr ||
-            upload->bytes < sizeof(GraphSubmission) || upload->outer_slot->task_kind != TaskKind::GRAPH ||
+            upload->bytes != sizeof(GraphSubmission) || upload->outer_slot->task_kind != TaskKind::GRAPH ||
             upload->outer_slot->task == nullptr) {
             LOG_ERROR("host-orch: invalid pending Graph POD image");
             return false;
         }
         auto *submission = reinterpret_cast<GraphSubmission *>(upload->data);
-        if (!graph_submission_wire_size_valid(*submission, upload->bytes)) {
-            LOG_ERROR("host-orch: Graph submission size does not match its POD image");
-            return false;
-        }
         auto object_it = definition_objects.find(submission->definition_hash);
         if (object_it == definition_objects.end() || object_it->second.device_object == nullptr) {
             LOG_ERROR("host-orch: Graph submission has no uploaded Definition object");

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -450,13 +450,9 @@ static bool relocate_host_orch_image(
         const int32_t count = ring.fc.current_task_index.load(std::memory_order_acquire);
         for (int32_t slot = 0; slot < count; ++slot) {
             PTO2TaskSlotState *state = &ring.slot_states[slot];
-            // Polling: fanin is a flat array of position-independent local-id
-            // integers on the payload, so only the two per-slot arena/SM
-            // pointers need relocating. There is no fanout_head/dep_pool graph
-            // and no host-seeded ready queue (the device boot scan classifies),
-            // so those relocation passes are gone.
+            // Payload is a relative offset and moves with the SM image. The
+            // descriptor is the only absolute per-slot pointer left here.
             relocate(state->task);
-            relocate(state->payload);
         }
     }
     return ok;
@@ -740,18 +736,17 @@ int32_t run_host_orchestration(
     }
     record_bind_phase(HostPhaseKind::BindRelocate, t_reloc_ns);
 
-    // Ship only the live prefix of each segment: the device reads no slot past
-    // total_tasks, so upload header + descriptors[0,N), payloads[0,N),
+    // Ship descriptors[0,N), the live TaskPayloadSpace prefix,
     // slot_states[0,N) and completion_flags[0,N) — never the ring-sized tails.
     // header + descriptors[0,N) are contiguous, so that is a single copy.
     const uint64_t nt = static_cast<uint64_t>(total_tasks);
     const uint64_t hdr_desc_bytes = sm_segs.descriptors + nt * sizeof(PTO2TaskDescriptor);
+    const uint64_t payload_bytes = rt->orchestrator.task_payload_space_used_bytes;
     char *host_base = static_cast<char *>(host_sm);
     char *dev_base = static_cast<char *>(device_sm);
     const int64_t t_sm_h2d_ns = bind_now_ns();
     if (api->copy_to_device(dev_base, host_base, hdr_desc_bytes) != 0 ||
-        api->copy_to_device(dev_base + sm_segs.payloads, host_base + sm_segs.payloads, nt * sizeof(PTO2TaskPayload)) !=
-            0 ||
+        api->copy_to_device(dev_base + sm_segs.payloads, host_base + sm_segs.payloads, payload_bytes) != 0 ||
         api->copy_to_device(
             dev_base + sm_segs.slot_states, host_base + sm_segs.slot_states, nt * sizeof(PTO2TaskSlotState)
         ) != 0 ||
@@ -762,8 +757,8 @@ int32_t run_host_orchestration(
         return -1;
     }
     {
-        const uint64_t sm_h2d_bytes = hdr_desc_bytes + nt * sizeof(PTO2TaskPayload) + nt * sizeof(PTO2TaskSlotState) +
-                                      nt * sizeof(std::atomic<uint8_t>);
+        const uint64_t sm_h2d_bytes =
+            hdr_desc_bytes + payload_bytes + nt * sizeof(PTO2TaskSlotState) + nt * sizeof(std::atomic<uint8_t>);
         char attrs[96];
         snprintf(attrs, sizeof(attrs), "nt=%" PRIu64 " bytes=%" PRIu64, nt, sm_h2d_bytes);
         record_bind_phase(HostPhaseKind::BindSmH2d, t_sm_h2d_ns, attrs, sm_h2d_bytes);

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -972,6 +972,28 @@ struct PTO2PreparedTask {
     PTO2TaskSlotState *slot_state = nullptr;
 };
 
+static PTO2TaskPayload *allocate_task_payload(PTO2OrchestratorState *orch, size_t requested_bytes) {
+    if (orch == nullptr || orch->sm_header == nullptr || requested_bytes < sizeof(PTO2TaskPayload)) return nullptr;
+    PTO2SharedMemoryRingHeader &ring = orch->sm_header->ring;
+    constexpr uint64_t alignment = alignof(PTO2TaskPayload);
+    const uint64_t capacity = ring.task_window_size * sizeof(PTO2TaskPayload);
+    const uint64_t cursor = orch->task_payload_space_used_bytes;
+    if (cursor > UINT64_MAX - (alignment - 1) || requested_bytes > UINT64_MAX - (alignment - 1)) return nullptr;
+    const uint64_t offset = PTO2_ALIGN_UP(cursor, alignment);
+    const uint64_t bytes = PTO2_ALIGN_UP(static_cast<uint64_t>(requested_bytes), alignment);
+    if (offset > capacity || bytes > capacity - offset) {
+        orch->report_fatal(
+            PTO2_ERROR_FLOW_CONTROL_DEADLOCK, __FUNCTION__,
+            "TaskPayloadSpace exhausted: used=%" PRIu64 " requested=%" PRIu64 " capacity=%" PRIu64, cursor, bytes,
+            capacity
+        );
+        return nullptr;
+    }
+    orch->task_payload_space_used_bytes = offset + bytes;
+    auto *base = reinterpret_cast<std::byte *>(ring.task_payloads);
+    return reinterpret_cast<PTO2TaskPayload *>(base + offset);
+}
+
 static PTO2OutputLayout calculate_output_layout(const CoreTaskArgs &args) {
     PTO2OutputLayout layout;
     for (int32_t i = 0; i < args.tensor_count(); i++) {
@@ -1015,7 +1037,10 @@ static bool prepare_task(
     out->task_id = PTO2TaskId::make(ring_id, static_cast<uint32_t>(out->alloc_result.task_id));
     out->slot_state = &orch->sm_header->ring.get_slot_state_by_slot(out->alloc_result.slot);
     out->task = &orch->sm_header->ring.task_descriptors[out->alloc_result.slot];
-    out->payload = &orch->sm_header->ring.task_payloads[out->alloc_result.slot];
+    out->payload = allocate_task_payload(orch, sizeof(PTO2TaskPayload));
+    if (out->payload == nullptr) {
+        return false;
+    }
 
     // Init-on-write: this slot's dynamic scheduling fields and completion flag are
     // initialized here, as the orchestrator claims the slot. whole-graph-resident
@@ -1027,9 +1052,8 @@ static bool prepare_task(
 
     out->payload->prefetch(args.tensor_count(), args.scalar_count());
 
-    // Re-bind payload/task pointers each submit. Value is per-slot constant
-    // (same as &task_payloads[slot] / &task_descriptors[slot]), but writing
-    // here lets RingSchedState::init() skip the O(window_size) bind loop.
+    // Bind the payload record selected from TaskPayloadSpace. Its relative
+    // reference remains valid when the complete SM image moves to device GM.
     // Both writes hit the same 64B slot_state cache line we're about to
     // dirty below, so the extra cost is two stores on an already-hot line.
     // Must precede the Orch-side wiring publish at the end of
@@ -1563,10 +1587,14 @@ bool graph_submit_outer(
     const PTO2TaskId task_id = PTO2TaskId::make(0, static_cast<uint32_t>(allocation.task_id));
     PTO2SharedMemoryRingHeader &ring = orch->sm_header->ring;
     PTO2TaskDescriptor &task = ring.task_descriptors[allocation.slot];
-    PTO2TaskPayload &payload = ring.task_payloads[allocation.slot];
+    size_t payload_bytes = 0;
+    if (!graph_task_payload_layout(args.tensor_count(), args.scalar_count(), &payload_bytes)) return false;
+    PTO2TaskPayload *payload_ptr = allocate_task_payload(orch, payload_bytes);
+    if (payload_ptr == nullptr) return false;
+    PTO2TaskPayload &payload = *payload_ptr;
     PTO2TaskSlotState &slot = ring.get_slot_state_by_slot(allocation.slot);
 
-    slot.bind_buffers(&payload, &task);
+    slot.bind_buffers(payload_ptr, &task);
     slot.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
     slot.last_consumer_local_id = static_cast<int32_t>(task_id.local());
     slot.active_mask = ActiveMask{};
@@ -1582,14 +1610,17 @@ bool graph_submit_outer(
     task.packed_buffer_base = allocation.packed_base;
     task.packed_buffer_end = allocation.packed_end;
     graph_reset_outer_payload(payload);
-    // The replay's boundary args, in the same place and the same form as any
-    // other task's args. graph_execution_localize reads them from here.
     payload.tensor_count = args.tensor_count();
     payload.scalar_count = args.scalar_count();
-    for (int32_t i = 0; i < args.tensor_count(); ++i)
-        payload.tensors[i] = args.tensor(i).ref();
-    if (args.scalar_count() != 0) {
-        std::memcpy(payload.scalars, args.scalar_data(), static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t));
+    for (int32_t i = 0; i < args.tensor_count(); ++i) {
+        ChipTensor *destination = graph_task_payload_tensor(payload, static_cast<uint32_t>(i));
+        if (destination == nullptr) return false;
+        *destination = args.tensor(i).ref();
+    }
+    for (int32_t i = 0; i < args.scalar_count(); ++i) {
+        uint64_t *destination = graph_task_payload_scalar(payload, static_cast<uint32_t>(i));
+        if (destination == nullptr) return false;
+        *destination = args.scalar_data()[i];
     }
 
     PTO2FaninBuilder fanin_builder(orch, &payload, static_cast<int32_t>(task_id.local()), next_fanin_seen_epoch(orch));

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -1523,40 +1523,13 @@ void graph_reset_outer_payload(PTO2TaskPayload &payload) {
 }
 
 bool graph_prepare_submission_image(
-    uint64_t full_key, const GraphTaskArgs &args, std::vector<std::byte> *submission_image
+    uint64_t full_key, uint64_t definition_hash, std::vector<std::byte> *submission_image
 ) {
     if (submission_image == nullptr) return false;
-    const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphTensor));
-    const size_t tensor_bytes = static_cast<size_t>(args.tensor_count()) * sizeof(GraphTensor);
-    if (tensors_offset > UINT32_MAX || tensors_offset > UINT32_MAX - tensor_bytes) {
-        return false;
-    }
-    const size_t tensors_end = tensors_offset + tensor_bytes;
-    const size_t scalar_bytes = static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t);
-    const size_t scalars_offset = args.scalar_count() == 0 ? 0 : PTO2_ALIGN_UP(tensors_end, alignof(uint64_t));
-    const size_t total_bytes = args.scalar_count() == 0 ? tensors_end : scalars_offset + scalar_bytes;
-    if ((args.scalar_count() != 0 && (scalars_offset > UINT32_MAX || scalars_offset > UINT32_MAX - scalar_bytes)) ||
-        total_bytes > UINT32_MAX) {
-        return false;
-    }
-    submission_image->assign(total_bytes, std::byte{0});
-    auto *tensors = reinterpret_cast<GraphTensor *>(submission_image->data() + tensors_offset);
-    for (int32_t i = 0; i < args.tensor_count(); ++i)
-        tensors[i] = graph_tensor_pack(args.tensor(i).ref());
-    if (args.scalar_count() != 0) {
-        std::memcpy(
-            submission_image->data() + scalars_offset, args.scalar_data(),
-            static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t)
-        );
-    }
-
     GraphSubmission submission{};
     submission.graph_key = full_key;
-    submission.total_bytes = static_cast<uint32_t>(submission_image->size());
-    submission.tensors_offset = static_cast<uint32_t>(tensors_offset);
-    submission.tensor_count = static_cast<uint32_t>(args.tensor_count());
-    submission.scalars_offset = static_cast<uint32_t>(scalars_offset);
-    submission.scalar_count = static_cast<uint32_t>(args.scalar_count());
+    submission.definition_hash = definition_hash;
+    submission_image->assign(sizeof(submission), std::byte{0});
     std::memcpy(submission_image->data(), &submission, sizeof(submission));
     return true;
 }
@@ -1574,8 +1547,7 @@ bool graph_submit_outer(
     }
 
     GraphPendingUpload pending;
-    if (!graph_prepare_submission_image(full_key, args, &pending.image)) return false;
-    reinterpret_cast<GraphSubmission *>(pending.image.data())->definition_hash = definition_hash;
+    if (!graph_prepare_submission_image(full_key, definition_hash, &pending.image)) return false;
     pending.deferred_heap = defer_heap;
 
     DepInputs boundary_inputs{
@@ -1610,6 +1582,15 @@ bool graph_submit_outer(
     task.packed_buffer_base = allocation.packed_base;
     task.packed_buffer_end = allocation.packed_end;
     graph_reset_outer_payload(payload);
+    // The replay's boundary args, in the same place and the same form as any
+    // other task's args. graph_execution_localize reads them from here.
+    payload.tensor_count = args.tensor_count();
+    payload.scalar_count = args.scalar_count();
+    for (int32_t i = 0; i < args.tensor_count(); ++i)
+        payload.tensors[i] = args.tensor(i).ref();
+    if (args.scalar_count() != 0) {
+        std::memcpy(payload.scalars, args.scalar_data(), static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t));
+    }
 
     PTO2FaninBuilder fanin_builder(orch, &payload, static_cast<int32_t>(task_id.local()), next_fanin_seen_epoch(orch));
     auto emit = [&](PTO2TaskId producer_id) -> bool {
@@ -1684,7 +1665,7 @@ bool graph_submit_pending_definition(
 bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostState *state, uint64_t *failed_key) {
     for (GraphPendingUpload &pending : state->pending_uploads) {
         if (!pending.deferred_heap) continue;
-        if (pending.image.size() < sizeof(GraphSubmission)) return false;
+        if (pending.image.size() != sizeof(GraphSubmission)) return false;
         auto *submission = reinterpret_cast<GraphSubmission *>(pending.image.data());
         auto definition_it = state->definitions.find(submission->graph_key);
         const GraphDefinition *definition =
@@ -1692,8 +1673,7 @@ bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostSt
         if (definition == nullptr || definition->execution_storage_bytes == 0 ||
             definition->required_heap > UINT64_MAX - definition->execution_storage_bytes ||
             pending.outer_slot == nullptr || pending.outer_slot->task == nullptr ||
-            pending.outer_slot->task_kind != TaskKind::GRAPH ||
-            !graph_submission_wire_size_valid(*submission, pending.image.size())) {
+            pending.outer_slot->task_kind != TaskKind::GRAPH) {
             if (failed_key != nullptr) *failed_key = submission->graph_key;
             return false;
         }

--- a/src/a5/runtime/host_build_graph/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_orchestrator.h
@@ -71,6 +71,9 @@ struct PTO2OrchestratorState {
     PTO2RingSet ring;
     uint32_t *fanin_seen_epoch;
     uint32_t fanin_seen_current_epoch{1};
+    // Live bytes in the packed task-payload segment. Payload records are
+    // appended in submission order and may have different lengths.
+    uint64_t task_payload_space_used_bytes{0};
 
     // === TENSOR MAP (Private) ===
     PTO2TensorMap tensor_map;  // Producer lookup

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -449,6 +449,50 @@ static_assert(
     "PTO2TaskPayload size = metadata(576) + predicate cache line(64) + tensors + scalars"
 );
 
+// Position-independent reference used inside relocatable runtime images. The
+// payload and its slot move by the same delta from host DDR to device GM, so a
+// relative offset remains valid without a per-slot relocation pass.
+template <typename T>
+struct PTO2RelativePtr {
+    int64_t offset{0};
+
+    T *get() const {
+        if (offset == 0) return nullptr;
+        const intptr_t self = reinterpret_cast<intptr_t>(this);
+        return reinterpret_cast<T *>(self + offset);
+    }
+
+    void reset(T *pointer = nullptr) {
+        offset = pointer == nullptr ? 0 : reinterpret_cast<intptr_t>(pointer) - reinterpret_cast<intptr_t>(this);
+    }
+
+    PTO2RelativePtr &operator=(T *pointer) {
+        reset(pointer);
+        return *this;
+    }
+
+    operator T *() const { return get(); }
+    T *operator->() const { return get(); }
+    T &operator*() const { return *get(); }
+    explicit operator bool() const { return offset != 0; }
+
+    bool operator==(std::nullptr_t) const { return offset == 0; }
+    bool operator!=(std::nullptr_t) const { return offset != 0; }
+};
+
+template <typename T>
+inline bool operator==(std::nullptr_t, const PTO2RelativePtr<T> &pointer) {
+    return pointer == nullptr;
+}
+
+template <typename T>
+inline bool operator!=(std::nullptr_t, const PTO2RelativePtr<T> &pointer) {
+    return pointer != nullptr;
+}
+
+static_assert(sizeof(PTO2RelativePtr<PTO2TaskPayload>) == sizeof(uint64_t));
+static_assert(std::is_trivially_copyable_v<PTO2RelativePtr<PTO2TaskPayload>>);
+
 /**
  * Per-task slot scheduling state (scheduler-private, NOT in shared memory)
  *
@@ -477,7 +521,7 @@ struct alignas(64) PTO2TaskSlotState {
     std::atomic<PTO2TaskState> task_state;
 
     // --- Per-slot constant, re-bound by orch::prepare_task each submit ---
-    PTO2TaskPayload *payload;
+    PTO2RelativePtr<PTO2TaskPayload> payload;
     PTO2TaskDescriptor *task;
 
     // --- Wake list: last-fanin notification (intrusive, lock-free) ---
@@ -534,7 +578,7 @@ struct alignas(64) PTO2TaskSlotState {
     }
 
     void bind_buffers(PTO2TaskPayload *p, PTO2TaskDescriptor *t) {
-        payload = p;
+        payload.reset(p);
         task = t;
     }
 

--- a/src/a5/runtime/host_build_graph/runtime/pto_shared_memory.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_shared_memory.h
@@ -143,9 +143,11 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
         return task_descriptors[get_slot_by_task_id(local_id)];
     }
 
-    PTO2TaskPayload &get_payload_by_slot(int32_t slot) { return task_payloads[slot]; }
+    PTO2TaskPayload &get_payload_by_slot(int32_t slot) { return *slot_states[slot].payload; }
 
-    PTO2TaskPayload &get_payload_by_task_id(int32_t local_id) { return task_payloads[get_slot_by_task_id(local_id)]; }
+    PTO2TaskPayload &get_payload_by_task_id(int32_t local_id) {
+        return get_payload_by_slot(get_slot_by_task_id(local_id));
+    }
 
     PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -355,8 +355,19 @@ For a cache hit, the Host Orchestrator:
    the Definition's `execution_storage_bytes` for the execution the device
    materializes into;
 4. computes only external fanin and boundary tensormap effects;
-5. emits one outer `GRAPH` task;
-6. stages the exact-size POD submission image for upload after orchestration.
+5. emits one outer `GRAPH` task, whose payload carries the boundary args exactly
+   as any other task's payload carries its own;
+6. stages a fixed-size POD submission image for upload after orchestration.
+
+The submission image is a Definition reference — key, content hash, device
+address, the activation gate and the word the device CASes to publish its local
+execution — and nothing else. The boundary args are not on it: `sm_h2d` already
+ships every task's payload, so putting them there sends them once instead of
+twice, and the device reads them from `outer_slot.payload` in the same
+`ChipTensor` form the dispatch path uses everywhere else. They arrive through the
+channel that path already trusts, so the Scheduler validates the pairing — their
+counts against the Definition's boundary counts — rather than re-checking each
+tensor.
 
 Internal nodes consume no ring task-window slots. Their descriptor, payload,
 and slot state live in the tail of the outer `GRAPH` task's own heap block,

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -357,7 +357,7 @@ For a cache hit, the Host Orchestrator:
 4. computes only external fanin and boundary tensormap effects;
 5. emits one outer `GRAPH` task, whose payload carries the boundary args exactly
    as any other task's payload carries its own;
-6. stages a fixed-size POD submission image for upload after orchestration.
+6. stages a fixed-size POD submission for the run's GraphBlock.
 
 The submission image is a Definition reference — key, content hash, device
 address, the activation gate and the word the device CASes to publish its local
@@ -368,6 +368,16 @@ twice, and the device reads them from `outer_slot.payload` in the same
 channel that path already trusts, so the Scheduler validates the pairing — their
 counts against the Definition's boundary counts — rather than re-checking each
 tensor.
+
+After orchestration completes, the Host first computes a contiguous GraphBlock
+layout: every distinct `[GraphDefinitionHeader][Definition]` object in order,
+then every fixed-size submission. Submissions store device addresses derived
+from `GraphBlock base + Definition offset`. Only after all sizes and offsets are
+known does the Host acquire the current arena bank's grow-only GraphBlock,
+which reuses an equal-or-larger allocation from that bank. The complete live
+range is overwritten with exactly one H2D copy on every run; there is no
+content-based copy skip and no per-Definition or per-submission device
+allocation.
 
 Internal nodes consume no ring task-window slots. Their descriptor, payload,
 and slot state live in the tail of the outer `GRAPH` task's own heap block,
@@ -387,7 +397,7 @@ bytes it starts from are whatever that heap region last held.
 ## Scheduler flow
 
 Host orchestration builds the complete task image before device execution. At
-the end of orchestration, the Host uploads every exact-size Graph POD image,
+the end of orchestration, the Host uploads the packed GraphBlock once,
 relocates the task and payload pointers in the shared-memory image, copies the
 complete shared-memory/runtime-arena image to the device, and then launches the
 resident Scheduler.

--- a/src/common/host_build_graph/graph_execution.cpp
+++ b/src/common/host_build_graph/graph_execution.cpp
@@ -317,19 +317,18 @@ GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
     auto *definition_header =
         reinterpret_cast<GraphDefinitionHeader *>(static_cast<uintptr_t>(submission->definition_addr));
     if (definition_header->magic != GRAPH_DEFINITION_OBJECT_MAGIC) return nullptr;
-    const GraphTensor *boundary_tensors = graph_submission_tensors(*submission);
-    const uint64_t *boundary_scalars = graph_submission_scalars(*submission);
-    const size_t boundary_tensor_end = static_cast<size_t>(submission->tensors_offset) +
-                                       static_cast<size_t>(submission->tensor_count) * sizeof(GraphTensor);
-    if (boundary_tensors == nullptr || outer_slot.task == nullptr || outer_slot.task->packed_buffer_base == nullptr ||
-        outer_slot.task->packed_buffer_end == nullptr ||
-        (submission->scalar_count != 0 && boundary_scalars == nullptr) ||
-        (submission->scalar_count != 0 && submission->scalars_offset < boundary_tensor_end)) {
+    const ChipTensor *boundary_tensors = graph_submission_boundary_tensors(outer_slot);
+    const uint64_t *boundary_scalars = graph_submission_boundary_scalars(outer_slot);
+    const PTO2TaskPayload *outer_payload = outer_slot.payload;
+    if (boundary_tensors == nullptr || outer_payload == nullptr || outer_slot.task == nullptr ||
+        outer_slot.task->packed_buffer_base == nullptr || outer_slot.task->packed_buffer_end == nullptr ||
+        outer_payload->tensor_count < 0 || outer_payload->tensor_count > MAX_TENSOR_ARGS ||
+        outer_payload->scalar_count < 0 || outer_payload->scalar_count > MAX_SCALAR_ARGS ||
+        (outer_payload->scalar_count != 0 && boundary_scalars == nullptr)) {
         return nullptr;
     }
-    for (uint32_t i = 0; i < submission->tensor_count; ++i) {
-        if (!graph_tensor_wire_valid(boundary_tensors[i])) return nullptr;
-    }
+    const uint32_t boundary_tensor_count = static_cast<uint32_t>(outer_payload->tensor_count);
+    const uint32_t boundary_scalar_count = static_cast<uint32_t>(outer_payload->scalar_count);
 
     uint64_t expected = 0;
     if (!__atomic_compare_exchange_n(
@@ -344,8 +343,8 @@ GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
     const GraphDefinition *definition = graph_definition_object_verified(*definition_header);
     if (definition == nullptr || definition->total_bytes == 0 || definition->task_count == 0 ||
         definition->task_count > GRAPH_MAX_NODES || submission->definition_hash != definition->content_hash ||
-        submission->graph_key != definition->full_key || submission->tensor_count != definition->boundary_count ||
-        submission->scalar_count != definition->boundary_scalar_count) {
+        submission->graph_key != definition->full_key || boundary_tensor_count != definition->boundary_count ||
+        boundary_scalar_count != definition->boundary_scalar_count) {
         __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
         return nullptr;
     }
@@ -381,9 +380,9 @@ GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
         return nullptr;
     }
     execution->boundary_tensors = boundary_tensors;
-    execution->boundary_tensor_count = submission->tensor_count;
+    execution->boundary_tensor_count = boundary_tensor_count;
     execution->boundary_scalars = boundary_scalars;
-    execution->boundary_scalar_count = submission->scalar_count;
+    execution->boundary_scalar_count = boundary_scalar_count;
     execution->outer_slot = &outer_slot;
 
     const uint64_t desired = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(execution));

--- a/src/common/host_build_graph/graph_execution.cpp
+++ b/src/common/host_build_graph/graph_execution.cpp
@@ -55,7 +55,7 @@ void reset_graph_payload(PTO2TaskPayload &payload) {
 bool bind_graph_topology(GraphExecution &execution) {
     if (execution.definition == nullptr) return false;
     const GraphDefinition &definition = *execution.definition;
-    if (definition.boundary_scalar_count > MAX_SCALAR_ARGS) return false;
+    if (definition.boundary_scalar_count > GRAPH_MAX_SCALAR_ARGS) return false;
     const uint32_t *fanin_offsets =
         graph_definition_array<uint32_t>(definition, definition.off_fanin_offsets, definition.task_count + 1);
     const uint16_t *fanin_indices =
@@ -218,18 +218,25 @@ bool graph_rebind_tensor(
     GraphTensor rebound = tensor_template;
     if (!graph_tensor_wire_valid(rebound)) return false;
     if (ref.source == static_cast<uint8_t>(GraphTensorSource::BOUNDARY_EXACT)) {
-        if (ref.source_index >= execution.boundary_tensor_count || ref.packed_offset != 0) return false;
-        rebound = execution.boundary_tensors[ref.source_index];
+        const ChipTensor *boundary = execution.boundary_payload == nullptr ?
+                                         nullptr :
+                                         graph_task_payload_tensor(*execution.boundary_payload, ref.source_index);
+        if (boundary == nullptr || ref.source_index >= execution.boundary_tensor_count || ref.packed_offset != 0) {
+            return false;
+        }
+        rebound = graph_tensor_pack(*boundary);
     } else if (ref.source == static_cast<uint8_t>(GraphTensorSource::BOUNDARY_VIEW)) {
-        if (ref.source_index >= execution.boundary_tensor_count) return false;
-        const GraphTensor &boundary = execution.boundary_tensors[ref.source_index];
-        if (ref.packed_offset > UINT64_MAX - boundary.start_offset) return false;
-        rebound.buffer_addr = boundary.buffer_addr;
-        rebound.buffer_size = boundary.buffer_size;
-        rebound.owner_task_id = boundary.owner_task_id;
-        rebound.start_offset = boundary.start_offset + ref.packed_offset;
-        rebound.version = boundary.version;
-        rebound.address_space = boundary.address_space;
+        const ChipTensor *boundary = execution.boundary_payload == nullptr ?
+                                         nullptr :
+                                         graph_task_payload_tensor(*execution.boundary_payload, ref.source_index);
+        if (boundary == nullptr || ref.source_index >= execution.boundary_tensor_count) return false;
+        if (ref.packed_offset > UINT64_MAX - boundary->start_offset) return false;
+        rebound.buffer_addr = boundary->buffer.addr;
+        rebound.buffer_size = boundary->buffer.size;
+        rebound.owner_task_id = boundary->owner_task_id.raw;
+        rebound.start_offset = boundary->start_offset + ref.packed_offset;
+        rebound.version = boundary->version;
+        rebound.address_space = static_cast<uint8_t>(boundary->address_space);
     } else if (ref.source == static_cast<uint8_t>(GraphTensorSource::INTERNAL) ||
                ref.source == static_cast<uint8_t>(GraphTensorSource::OWN_OUTPUT)) {
         const bool own_output = ref.source == static_cast<uint8_t>(GraphTensorSource::OWN_OUTPUT);
@@ -317,14 +324,12 @@ GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
     auto *definition_header =
         reinterpret_cast<GraphDefinitionHeader *>(static_cast<uintptr_t>(submission->definition_addr));
     if (definition_header->magic != GRAPH_DEFINITION_OBJECT_MAGIC) return nullptr;
-    const ChipTensor *boundary_tensors = graph_submission_boundary_tensors(outer_slot);
-    const uint64_t *boundary_scalars = graph_submission_boundary_scalars(outer_slot);
     const PTO2TaskPayload *outer_payload = outer_slot.payload;
-    if (boundary_tensors == nullptr || outer_payload == nullptr || outer_slot.task == nullptr ||
-        outer_slot.task->packed_buffer_base == nullptr || outer_slot.task->packed_buffer_end == nullptr ||
-        outer_payload->tensor_count < 0 || outer_payload->tensor_count > MAX_TENSOR_ARGS ||
-        outer_payload->scalar_count < 0 || outer_payload->scalar_count > MAX_SCALAR_ARGS ||
-        (outer_payload->scalar_count != 0 && boundary_scalars == nullptr)) {
+    size_t payload_bytes = 0;
+    if (outer_payload == nullptr || outer_slot.task == nullptr || outer_slot.task->packed_buffer_base == nullptr ||
+        outer_slot.task->packed_buffer_end == nullptr ||
+        !graph_task_payload_layout(outer_payload->tensor_count, outer_payload->scalar_count, &payload_bytes) ||
+        payload_bytes < sizeof(PTO2TaskPayload)) {
         return nullptr;
     }
     const uint32_t boundary_tensor_count = static_cast<uint32_t>(outer_payload->tensor_count);
@@ -379,9 +384,8 @@ GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
         __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
         return nullptr;
     }
-    execution->boundary_tensors = boundary_tensors;
+    execution->boundary_payload = outer_payload;
     execution->boundary_tensor_count = boundary_tensor_count;
-    execution->boundary_scalars = boundary_scalars;
     execution->boundary_scalar_count = boundary_scalar_count;
     execution->outer_slot = &outer_slot;
 
@@ -530,11 +534,14 @@ GraphMaterializeResult graph_execution_materialize_slice(
             if (ref.source == static_cast<uint8_t>(GraphScalarSource::STATIC_VALUE)) {
                 payload.scalars[j] = definition_scalars[scalar_index];
             } else if (ref.source == static_cast<uint8_t>(GraphScalarSource::BOUNDARY)) {
-                if (ref.source_index >= execution.boundary_scalar_count || execution.boundary_scalars == nullptr) {
+                const uint64_t *boundary = execution.boundary_payload == nullptr ?
+                                               nullptr :
+                                               graph_task_payload_scalar(*execution.boundary_payload, ref.source_index);
+                if (ref.source_index >= execution.boundary_scalar_count || boundary == nullptr) {
                     execution.materialize_busy.store(0, std::memory_order_release);
                     return GraphMaterializeResult::INVALID;
                 }
-                payload.scalars[j] = execution.boundary_scalars[ref.source_index];
+                payload.scalars[j] = *boundary;
             } else {
                 execution.materialize_busy.store(0, std::memory_order_release);
                 return GraphMaterializeResult::INVALID;

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -195,11 +195,7 @@ struct GraphSubmission {
     uint64_t definition_addr;
     uint64_t definition_hash;
     uint32_t activation_gate;
-    uint32_t total_bytes;
-    uint32_t tensors_offset;
-    uint32_t tensor_count;
-    uint32_t scalars_offset;
-    uint32_t scalar_count;
+    uint32_t reserved;
 };
 
 static_assert(std::is_trivially_copyable_v<GraphTensorSourceRef>);
@@ -301,31 +297,18 @@ inline GraphSubmission *graph_submission_from_slot(PTO2TaskSlotState &slot) {
     return slot.task_kind == TaskKind::GRAPH ? static_cast<GraphSubmission *>(slot.graph_context) : nullptr;
 }
 
-inline bool graph_submission_wire_size_valid(const GraphSubmission &submission, size_t available_bytes) {
-    return available_bytes >= sizeof(GraphSubmission) && submission.total_bytes == available_bytes;
+// A replay's boundary args live in the outer GRAPH task's own payload, the same
+// place every other task's args live, so the submission carries no arg region and
+// the args cross the boundary once, in `sm_h2d`, rather than a second time in
+// their own wire form. They arrive through the channel the dispatch path already
+// trusts for every task's args, so they are not re-validated here; what still is
+// checked is the pairing — their counts against the Definition's boundary counts.
+inline const ChipTensor *graph_submission_boundary_tensors(const PTO2TaskSlotState &outer_slot) {
+    return outer_slot.payload != nullptr ? outer_slot.payload->tensors : nullptr;
 }
 
-inline const GraphTensor *graph_submission_tensors(const GraphSubmission &submission) {
-    if (submission.tensors_offset == 0 || submission.tensors_offset % alignof(GraphTensor) != 0 ||
-        submission.tensors_offset > submission.total_bytes ||
-        submission.tensor_count > (submission.total_bytes - submission.tensors_offset) / sizeof(GraphTensor)) {
-        return nullptr;
-    }
-    return reinterpret_cast<const GraphTensor *>(
-        reinterpret_cast<const uint8_t *>(&submission) + submission.tensors_offset
-    );
-}
-
-inline const uint64_t *graph_submission_scalars(const GraphSubmission &submission) {
-    if (submission.scalar_count == 0) return nullptr;
-    if (submission.scalars_offset == 0 || submission.scalars_offset % alignof(uint64_t) != 0 ||
-        submission.scalars_offset > submission.total_bytes ||
-        submission.scalar_count > (submission.total_bytes - submission.scalars_offset) / sizeof(uint64_t)) {
-        return nullptr;
-    }
-    return reinterpret_cast<const uint64_t *>(
-        reinterpret_cast<const uint8_t *>(&submission) + submission.scalars_offset
-    );
+inline const uint64_t *graph_submission_boundary_scalars(const PTO2TaskSlotState &outer_slot) {
+    return outer_slot.payload != nullptr ? outer_slot.payload->scalars : nullptr;
 }
 
 enum class GraphExecutionState : uint8_t {
@@ -373,7 +356,9 @@ struct GraphExecution {
     const GraphDefinition *definition{nullptr};
     const uint32_t *fanin_offsets{nullptr};
     const uint16_t *fanin_indices{nullptr};
-    const GraphTensor *boundary_tensors{nullptr};
+    // Borrowed from the outer GRAPH task's payload, which owns them for the
+    // replay's whole lifetime.
+    const ChipTensor *boundary_tensors{nullptr};
     uint32_t boundary_tensor_count{0};
     const uint64_t *boundary_scalars{nullptr};
     uint32_t boundary_scalar_count{0};

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -297,18 +297,57 @@ inline GraphSubmission *graph_submission_from_slot(PTO2TaskSlotState &slot) {
     return slot.task_kind == TaskKind::GRAPH ? static_cast<GraphSubmission *>(slot.graph_context) : nullptr;
 }
 
-// A replay's boundary args live in the outer GRAPH task's own payload, the same
-// place every other task's args live, so the submission carries no arg region and
-// the args cross the boundary once, in `sm_h2d`, rather than a second time in
-// their own wire form. They arrive through the channel the dispatch path already
-// trusts for every task's args, so they are not re-validated here; what still is
-// checked is the pairing — their counts against the Definition's boundary counts.
-inline const ChipTensor *graph_submission_boundary_tensors(const PTO2TaskSlotState &outer_slot) {
-    return outer_slot.payload != nullptr ? outer_slot.payload->tensors : nullptr;
+// Graph tasks share the ordinary scheduling payload prefix. Boundary args that
+// exceed the AICore ABI capacities continue in the same TaskPayloadSpace record:
+// [PTO2TaskPayload][extra ChipTensor...][extra uint64_t...], rounded to a cache
+// line. Ordinary kernel payloads remain exactly sizeof(PTO2TaskPayload).
+inline bool graph_task_payload_layout(
+    int32_t tensor_count, int32_t scalar_count, size_t *payload_bytes, size_t *extra_scalars_offset = nullptr
+) {
+    if (payload_bytes == nullptr || tensor_count < 0 || scalar_count < 0 ||
+        tensor_count > static_cast<int32_t>(GRAPH_MAX_TENSOR_ARGS) ||
+        scalar_count > static_cast<int32_t>(GRAPH_MAX_SCALAR_ARGS)) {
+        return false;
+    }
+    const size_t extra_tensors =
+        tensor_count > MAX_TENSOR_ARGS ? static_cast<size_t>(tensor_count - MAX_TENSOR_ARGS) : 0;
+    const size_t extra_scalars =
+        scalar_count > MAX_SCALAR_ARGS ? static_cast<size_t>(scalar_count - MAX_SCALAR_ARGS) : 0;
+    if (extra_tensors > (SIZE_MAX - sizeof(PTO2TaskPayload)) / sizeof(ChipTensor)) return false;
+    const size_t scalars_offset = sizeof(PTO2TaskPayload) + extra_tensors * sizeof(ChipTensor);
+    if (extra_scalars > (SIZE_MAX - scalars_offset) / sizeof(uint64_t)) return false;
+    const size_t end = scalars_offset + extra_scalars * sizeof(uint64_t);
+    if (end > SIZE_MAX - (alignof(PTO2TaskPayload) - 1)) return false;
+    *payload_bytes = PTO2_ALIGN_UP(end, alignof(PTO2TaskPayload));
+    if (extra_scalars_offset != nullptr) *extra_scalars_offset = scalars_offset;
+    return true;
 }
 
-inline const uint64_t *graph_submission_boundary_scalars(const PTO2TaskSlotState &outer_slot) {
-    return outer_slot.payload != nullptr ? outer_slot.payload->scalars : nullptr;
+inline ChipTensor *graph_task_payload_tensor(PTO2TaskPayload &payload, uint32_t index) {
+    if (payload.tensor_count < 0 || index >= static_cast<uint32_t>(payload.tensor_count)) return nullptr;
+    if (index < MAX_TENSOR_ARGS) return &payload.tensors[index];
+    auto *extra = reinterpret_cast<ChipTensor *>(reinterpret_cast<std::byte *>(&payload) + sizeof(payload));
+    return &extra[index - MAX_TENSOR_ARGS];
+}
+
+inline const ChipTensor *graph_task_payload_tensor(const PTO2TaskPayload &payload, uint32_t index) {
+    return graph_task_payload_tensor(const_cast<PTO2TaskPayload &>(payload), index);
+}
+
+inline uint64_t *graph_task_payload_scalar(PTO2TaskPayload &payload, uint32_t index) {
+    if (payload.scalar_count < 0 || index >= static_cast<uint32_t>(payload.scalar_count)) return nullptr;
+    if (index < MAX_SCALAR_ARGS) return &payload.scalars[index];
+    size_t payload_bytes = 0;
+    size_t scalars_offset = 0;
+    if (!graph_task_payload_layout(payload.tensor_count, payload.scalar_count, &payload_bytes, &scalars_offset)) {
+        return nullptr;
+    }
+    auto *extra = reinterpret_cast<uint64_t *>(reinterpret_cast<std::byte *>(&payload) + scalars_offset);
+    return &extra[index - MAX_SCALAR_ARGS];
+}
+
+inline const uint64_t *graph_task_payload_scalar(const PTO2TaskPayload &payload, uint32_t index) {
+    return graph_task_payload_scalar(const_cast<PTO2TaskPayload &>(payload), index);
 }
 
 enum class GraphExecutionState : uint8_t {
@@ -356,11 +395,10 @@ struct GraphExecution {
     const GraphDefinition *definition{nullptr};
     const uint32_t *fanin_offsets{nullptr};
     const uint16_t *fanin_indices{nullptr};
-    // Borrowed from the outer GRAPH task's payload, which owns them for the
-    // replay's whole lifetime.
-    const ChipTensor *boundary_tensors{nullptr};
+    // Borrowed for the replay lifetime; accessors resolve its fixed prefix and
+    // variable overflow tail without requiring the args to be contiguous.
+    const PTO2TaskPayload *boundary_payload{nullptr};
     uint32_t boundary_tensor_count{0};
-    const uint64_t *boundary_scalars{nullptr};
     uint32_t boundary_scalar_count{0};
 };
 

--- a/src/common/platform/include/common/host_api.h
+++ b/src/common/platform/include/common/host_api.h
@@ -51,17 +51,11 @@ struct HostApiOps {
     // {nullptr, 0} when nothing is retained yet.
     void (*get_retained_temp_buffer)(void *runner_ctx, uint32_t pipeline_slot, void **addr, size_t *size);
     void (*set_retained_temp_buffer)(void *runner_ctx, uint32_t pipeline_slot, void *addr, size_t size);
-    // Runner-owned Graph Definition storage, keyed by the Definition's content
-    // identity (full_key, content_hash, total_bytes folded into one key by the
-    // caller). Grow-only retention: one block per key, reused while capacity
-    // fits, a growth request replaces the entry, all blocks released at Worker
-    // finalization. `alignment` must be a power of two. Lets every submission
-    // of one run reference a single device-resident Definition instead of each
-    // carrying a full copy. Execution storage needs no counterpart here — it is
-    // the tail of the outer Graph task's own heap allocation.
-    void *(*acquire_graph_definition_buffer)(
-        void *runner_ctx, uint32_t pipeline_slot, uint64_t key, size_t bytes, size_t alignment
-    );
+    // One grow-only GraphBlock owned by the arena bank selected for this run.
+    // The caller computes the complete packed size before acquiring it, then
+    // overwrites the live range with one H2D copy. Equal-or-smaller requests
+    // reuse the bank's allocation; a larger request replaces it.
+    void *(*acquire_graph_block)(void *runner_ctx, uint32_t arena_bank, size_t bytes, size_t alignment);
     // Commit the three pooled regions (GM heap, runtime shared memory, and
     // prebuilt runtime arena) of the arena bank selected by this run, as three
     // independent device allocations. `runtime_arena_size == 0` skips the
@@ -158,9 +152,9 @@ public:
     void set_retained_temp_buffer(void *addr, size_t size) const {
         ops_->set_retained_temp_buffer(runner_ctx_, pipeline_slot_, addr, size);
     }
-    void *acquire_graph_definition_buffer(uint64_t key, size_t bytes, size_t alignment) const {
-        if (ops_->acquire_graph_definition_buffer == nullptr) return nullptr;
-        return ops_->acquire_graph_definition_buffer(runner_ctx_, pipeline_slot_, key, bytes, alignment);
+    void *acquire_graph_block(size_t bytes, size_t alignment) const {
+        if (ops_->acquire_graph_block == nullptr) return nullptr;
+        return ops_->acquire_graph_block(runner_ctx_, arena_bank_, bytes, alignment);
     }
     int setup_static_arena(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size) const {
         return ops_->setup_static_arena(runner_ctx_, arena_bank_, gm_heap_size, gm_sm_size, runtime_arena_size);

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -156,13 +156,10 @@ static void set_retained_temp_buffer(void *runner_ctx, uint32_t pipeline_slot, v
     } catch (...) {}
 }
 
-static void *acquire_graph_definition_buffer(
-    void *runner_ctx, uint32_t pipeline_slot, uint64_t key, size_t bytes, size_t alignment
-) {
+static void *acquire_graph_block(void *runner_ctx, uint32_t arena_bank, size_t bytes, size_t alignment) {
     if (runner_ctx == nullptr) return nullptr;
     try {
-        return static_cast<DeviceRunnerBase *>(runner_ctx)
-            ->acquire_graph_definition_buffer(pipeline_slot, key, bytes, alignment);
+        return static_cast<DeviceRunnerBase *>(runner_ctx)->acquire_graph_block(arena_bank, bytes, alignment);
     } catch (...) {
         return nullptr;
     }
@@ -281,7 +278,7 @@ static const HostApiOps g_host_api_ops = {
     .device_memset = device_memset,
     .get_retained_temp_buffer = get_retained_temp_buffer,
     .set_retained_temp_buffer = set_retained_temp_buffer,
-    .acquire_graph_definition_buffer = acquire_graph_definition_buffer,
+    .acquire_graph_block = acquire_graph_block,
     .setup_static_arena = setup_static_arena_wrapper,
     .acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper,
     .acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper,

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -173,53 +173,28 @@ void DeviceRunnerBase::set_retained_temp_buffer(uint32_t pipeline_slot, void *ad
     retained_temp_sizes_[pipeline_slot] = size;
 }
 
-void *DeviceRunnerBase::acquire_graph_definition_buffer(
-    uint32_t pipeline_slot, uint64_t key, size_t bytes, size_t alignment
-) {
-    if (pipeline_slot >= graph_definition_buffers_.size() || bytes == 0 || alignment == 0 ||
-        (alignment & (alignment - 1)) != 0 || bytes > SIZE_MAX - (alignment - 1)) {
+void *DeviceRunnerBase::acquire_graph_block(uint32_t arena_bank, size_t bytes, size_t alignment) {
+    if (arena_bank >= arena_banks_.size() || bytes == 0 || alignment == 0 || (alignment & (alignment - 1)) != 0) {
         return nullptr;
     }
-    RetainedGraphBuffer &buffer = graph_definition_buffers_[pipeline_slot][key];
-    if (buffer.aligned_addr != nullptr && buffer.capacity >= bytes &&
-        reinterpret_cast<uintptr_t>(buffer.aligned_addr) % alignment == 0) {
-        return buffer.aligned_addr;
+    const size_t base_alignment =
+        alignment > DeviceArena::kDefaultBaseAlign ? alignment : DeviceArena::kDefaultBaseAlign;
+    if (bytes > SIZE_MAX - (base_alignment - 1)) return nullptr;
+    ArenaBank &bank = this->arena_bank(arena_bank);
+    if (bank.graph_block.is_committed() && bytes <= bank.cached_graph_block_size &&
+        reinterpret_cast<uintptr_t>(bank.graph_block.base()) % alignment == 0) {
+        return bank.graph_block.base();
     }
 
-    const size_t allocation_bytes = bytes + alignment - 1;
-    void *allocation = mem_alloc_.alloc(allocation_bytes);
-    if (allocation == nullptr) return nullptr;
-    const uintptr_t raw = reinterpret_cast<uintptr_t>(allocation);
-    if (raw > UINTPTR_MAX - (alignment - 1)) {
-        mem_alloc_.free(allocation);
+    bank.graph_block.release();
+    bank.cached_graph_block_size = 0;
+    bank.graph_block.reserve(bytes, alignment);
+    if (bank.graph_block.commit(base_alignment) == nullptr) {
+        bank.graph_block.release();
         return nullptr;
     }
-    void *aligned_addr = reinterpret_cast<void *>((raw + alignment - 1) & ~(alignment - 1));
-    if (device_memset(aligned_addr, 0, bytes) != 0) {
-        mem_alloc_.free(allocation);
-        return nullptr;
-    }
-    if (buffer.allocation != nullptr && mem_alloc_.free(buffer.allocation) != 0) {
-        mem_alloc_.free(allocation);
-        return nullptr;
-    }
-    buffer = RetainedGraphBuffer{allocation, aligned_addr, bytes};
-    return aligned_addr;
-}
-
-void DeviceRunnerBase::release_graph_definition_buffers() {
-    for (GraphDefinitionBufferMap &by_key : graph_definition_buffers_) {
-        for (auto &entry : by_key) {
-            if (entry.second.allocation != nullptr) mem_alloc_.free(entry.second.allocation);
-        }
-        by_key.clear();
-    }
-}
-
-void DeviceRunnerBase::abandon_graph_definition_buffers() {
-    for (GraphDefinitionBufferMap &by_key : graph_definition_buffers_) {
-        by_key.clear();
-    }
+    bank.cached_graph_block_size = bytes;
+    return bank.graph_block.base();
 }
 
 void DeviceRunnerBase::clear_temporary_buffer() {
@@ -1424,10 +1399,12 @@ int DeviceRunnerBase::finalize_common_impl(bool abandon_device_resources) {
             bank->gm_heap.abandon_after_device_failure();
             bank->gm_sm.abandon_after_device_failure();
             bank->runtime_pool.abandon_after_device_failure();
+            bank->graph_block.abandon_after_device_failure();
         } else {
             bank->gm_heap.release();
             bank->gm_sm.release();
             bank->runtime_pool.release();
+            bank->graph_block.release();
         }
     }
     prebuilt_runtime_arena_cache_valid_ = false;
@@ -1438,11 +1415,9 @@ int DeviceRunnerBase::finalize_common_impl(bool abandon_device_resources) {
     prebuilt_runtime_arena_cache_image_.clear();
 
     if (abandon_device_resources) {
-        abandon_graph_definition_buffers();
         retained_temp_addrs_.fill(nullptr);
         retained_temp_sizes_.fill(0);
     } else {
-        release_graph_definition_buffers();
         clear_temporary_buffer();
     }
 
@@ -1474,6 +1449,7 @@ int DeviceRunnerBase::finalize_common_impl(bool abandon_device_resources) {
         bank->cached_gm_heap_size = 0;
         bank->cached_gm_sm_size = 0;
         bank->cached_runtime_arena_size = 0;
+        bank->cached_graph_block_size = 0;
     }
     if (abandon_device_resources) {
         LOG_WARN("Fatal teardown: host-side ownership cleared without further device calls");

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -14,8 +14,8 @@
  *
  * This module owns the host-side state and methods that are identical
  * between the two onboard arches today:
- *   - The `MemoryAllocator` and the three `DeviceArena`s (gm heap, PTO2
- *     SM, runtime arena) backing the per-Worker pooled regions.
+ *   - The `MemoryAllocator` and arena-bank-owned `DeviceArena`s backing GM
+ *     heap, PTO2 SM, runtime arena, and the per-run GraphBlock.
  *   - The trivial tensor-memory wrappers (`allocate_tensor`,
  *     `free_tensor`, `copy_*_device`).
  *   - The arena-pool accessors (`acquire_pooled_gm_heap`, etc.).
@@ -144,8 +144,7 @@ public:
     int device_memset(void *dev_ptr, int value, std::size_t bytes);
     void get_retained_temp_buffer(uint32_t pipeline_slot, void **addr, std::size_t *size);
     void set_retained_temp_buffer(uint32_t pipeline_slot, void *addr, std::size_t size);
-    void *
-    acquire_graph_definition_buffer(uint32_t pipeline_slot, uint64_t key, std::size_t bytes, std::size_t alignment);
+    void *acquire_graph_block(uint32_t arena_bank, std::size_t bytes, std::size_t alignment);
     void clear_temporary_buffer();
     /**
      * Map a device buffer into the host address space and return a
@@ -945,7 +944,7 @@ protected:
      *   - aicore_bin_handle_ + binaries_loaded_ reset
      *   - chip_callable_buffers_ free + clear
      *   - callables_ dlclose-on-hbg + clear + aicpu counter reset
-     *   - 3 arenas release + cached size reset
+     *   - arena-bank regions release + cached size reset
      *   - device_wall_dev_ptr_ free (before mem_alloc_.finalize)
      *   - mem_alloc_.finalize
      *   - block_dim_, worker_count_, aicore_kernel_binary_ reset
@@ -959,17 +958,6 @@ protected:
      * @return 0 on success, first nonzero rc encountered otherwise.
      */
     int finalize_common();
-    void release_graph_definition_buffers();
-
-    /**
-     * Drop the retained graph-definition buffers without freeing them.
-     *
-     * The fatal counterpart of release_graph_definition_buffers(): a force reset
-     * has already invalidated every allocation, so only the host-side map is
-     * cleared.
-     */
-    void abandon_graph_definition_buffers();
-
     /**
      * Clear host-side ownership after a fatal device failure without issuing
      * per-resource RTS calls. The caller must first attempt a force reset.
@@ -1124,21 +1112,7 @@ protected:
     // the grow/pack logic lives in trb bind.
     std::array<void *, PTO_PIPELINE_MAX_DEPTH> retained_temp_addrs_{};
     std::array<std::size_t, PTO_PIPELINE_MAX_DEPTH> retained_temp_sizes_{};
-    // One retained device block: the raw allocation plus the aligned address
-    // handed out. Backs the Graph Definition cache below.
-    struct RetainedGraphBuffer {
-        void *allocation{nullptr};
-        void *aligned_addr{nullptr};
-        std::size_t capacity{0};
-    };
-    // Graph Definition storage, one retained block per (pipeline slot,
-    // definition key) — see HostApi acquire_graph_definition_buffer. Keyed by
-    // content identity rather than occurrence: every submission of one run
-    // references the same device-resident Definition.
-    using GraphDefinitionBufferMap = std::unordered_map<uint64_t, RetainedGraphBuffer>;
-    std::array<GraphDefinitionBufferMap, PTO_PIPELINE_MAX_DEPTH> graph_definition_buffers_{};
-
-    // One independently committed set of the three pooled device regions. A
+    // One independently committed set of pooled device regions. A
     // run reaches its set through the arena bank its lease selects, so
     // preparing one bank never mutates a region the active run is executing
     // out of. `cached_*` back `setup_static_arena`'s "fits" check: a later
@@ -1148,14 +1122,17 @@ protected:
         ArenaBank(DeviceArena::AllocFn alloc, DeviceArena::FreeFn free_fn, void *ctx) :
             gm_heap(alloc, free_fn, ctx),
             gm_sm(alloc, free_fn, ctx),
-            runtime_pool(alloc, free_fn, ctx) {}
+            runtime_pool(alloc, free_fn, ctx),
+            graph_block(alloc, free_fn, ctx) {}
 
         DeviceArena gm_heap;
         DeviceArena gm_sm;
         DeviceArena runtime_pool;
+        DeviceArena graph_block;
         size_t cached_gm_heap_size{0};
         size_t cached_gm_sm_size{0};
         size_t cached_runtime_arena_size{0};
+        size_t cached_graph_block_size{0};
     };
     // Held by pointer because DeviceArena is non-copyable and non-movable, so
     // the array cannot be brace-initialised without naming every bank.

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -142,13 +142,10 @@ static void set_retained_temp_buffer(void *runner_ctx, uint32_t pipeline_slot, v
     } catch (...) {}
 }
 
-static void *acquire_graph_definition_buffer(
-    void *runner_ctx, uint32_t pipeline_slot, uint64_t key, size_t bytes, size_t alignment
-) {
+static void *acquire_graph_block(void *runner_ctx, uint32_t arena_bank, size_t bytes, size_t alignment) {
     if (runner_ctx == nullptr) return nullptr;
     try {
-        return static_cast<SimDeviceRunnerBase *>(runner_ctx)
-            ->acquire_graph_definition_buffer(pipeline_slot, key, bytes, alignment);
+        return static_cast<SimDeviceRunnerBase *>(runner_ctx)->acquire_graph_block(arena_bank, bytes, alignment);
     } catch (...) {
         return nullptr;
     }
@@ -268,7 +265,7 @@ static const HostApiOps g_host_api_ops = {
     .device_memset = device_memset,
     .get_retained_temp_buffer = get_retained_temp_buffer,
     .set_retained_temp_buffer = set_retained_temp_buffer,
-    .acquire_graph_definition_buffer = acquire_graph_definition_buffer,
+    .acquire_graph_block = acquire_graph_block,
     .setup_static_arena = setup_static_arena_wrapper,
     .acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper,
     .acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper,

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -374,47 +374,28 @@ void SimDeviceRunnerBase::set_retained_temp_buffer(uint32_t pipeline_slot, void 
     retained_temp_sizes_[pipeline_slot] = size;
 }
 
-void *SimDeviceRunnerBase::acquire_graph_definition_buffer(
-    uint32_t pipeline_slot, uint64_t key, size_t bytes, size_t alignment
-) {
-    if (pipeline_slot >= graph_definition_buffers_.size() || bytes == 0 || alignment == 0 ||
-        (alignment & (alignment - 1)) != 0 || bytes > SIZE_MAX - (alignment - 1)) {
+void *SimDeviceRunnerBase::acquire_graph_block(uint32_t arena_bank, size_t bytes, size_t alignment) {
+    if (arena_bank >= arena_banks_.size() || bytes == 0 || alignment == 0 || (alignment & (alignment - 1)) != 0) {
         return nullptr;
     }
-    RetainedGraphBuffer &buffer = graph_definition_buffers_[pipeline_slot][key];
-    if (buffer.aligned_addr != nullptr && buffer.capacity >= bytes &&
-        reinterpret_cast<uintptr_t>(buffer.aligned_addr) % alignment == 0) {
-        return buffer.aligned_addr;
+    const size_t base_alignment =
+        alignment > DeviceArena::kDefaultBaseAlign ? alignment : DeviceArena::kDefaultBaseAlign;
+    if (bytes > SIZE_MAX - (base_alignment - 1)) return nullptr;
+    ArenaBank &bank = this->arena_bank(arena_bank);
+    if (bank.graph_block.is_committed() && bytes <= bank.cached_graph_block_size &&
+        reinterpret_cast<uintptr_t>(bank.graph_block.base()) % alignment == 0) {
+        return bank.graph_block.base();
     }
 
-    const size_t allocation_bytes = bytes + alignment - 1;
-    void *allocation = mem_alloc_.alloc(allocation_bytes);
-    if (allocation == nullptr) return nullptr;
-    const uintptr_t raw = reinterpret_cast<uintptr_t>(allocation);
-    if (raw > UINTPTR_MAX - (alignment - 1)) {
-        mem_alloc_.free(allocation);
+    bank.graph_block.release();
+    bank.cached_graph_block_size = 0;
+    bank.graph_block.reserve(bytes, alignment);
+    if (bank.graph_block.commit(base_alignment) == nullptr) {
+        bank.graph_block.release();
         return nullptr;
     }
-    void *aligned_addr = reinterpret_cast<void *>((raw + alignment - 1) & ~(alignment - 1));
-    if (device_memset(aligned_addr, 0, bytes) != 0) {
-        mem_alloc_.free(allocation);
-        return nullptr;
-    }
-    if (buffer.allocation != nullptr && mem_alloc_.free(buffer.allocation) != 0) {
-        mem_alloc_.free(allocation);
-        return nullptr;
-    }
-    buffer = RetainedGraphBuffer{allocation, aligned_addr, bytes};
-    return aligned_addr;
-}
-
-void SimDeviceRunnerBase::release_graph_definition_buffers() {
-    for (GraphDefinitionBufferMap &by_key : graph_definition_buffers_) {
-        for (auto &entry : by_key) {
-            if (entry.second.allocation != nullptr) mem_alloc_.free(entry.second.allocation);
-        }
-        by_key.clear();
-    }
+    bank.cached_graph_block_size = bytes;
+    return bank.graph_block.base();
 }
 
 void SimDeviceRunnerBase::clear_temporary_buffer() {

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -194,7 +194,7 @@ public:
     int device_memset(void *dev_ptr, int value, size_t bytes);
     void get_retained_temp_buffer(uint32_t pipeline_slot, void **addr, size_t *size);
     void set_retained_temp_buffer(uint32_t pipeline_slot, void *addr, size_t size);
-    void *acquire_graph_definition_buffer(uint32_t pipeline_slot, uint64_t key, size_t bytes, size_t alignment);
+    void *acquire_graph_block(uint32_t arena_bank, size_t bytes, size_t alignment);
     void clear_temporary_buffer();
 
     // On sim, allocate_tensor returns a plain host pointer, so the "device"
@@ -313,7 +313,6 @@ protected:
     // Bulk-free the shared callable / chip-callable / orch-SO state. Subclass
     // finalize() calls this before mem_alloc_.finalize(). Idempotent.
     void release_callable_state();
-    void release_graph_definition_buffers();
 
     // --- Shared state (protected so subclass execution / init_* / finalize()
     // can read or write directly) ----------------------------------------
@@ -334,20 +333,8 @@ protected:
     MemoryAllocator mem_alloc_;
     std::array<void *, PTO_PIPELINE_MAX_DEPTH> retained_temp_addrs_{};
     std::array<size_t, PTO_PIPELINE_MAX_DEPTH> retained_temp_sizes_{};
-    // One retained device block: the raw allocation plus the aligned address
-    // handed out. Backs the Graph Definition cache below.
-    struct RetainedGraphBuffer {
-        void *allocation{nullptr};
-        void *aligned_addr{nullptr};
-        size_t capacity{0};
-    };
-    // Graph Definition storage, one retained block per (pipeline slot,
-    // definition key) — see HostApi acquire_graph_definition_buffer.
-    using GraphDefinitionBufferMap = std::unordered_map<uint64_t, RetainedGraphBuffer>;
-    std::array<GraphDefinitionBufferMap, PTO_PIPELINE_MAX_DEPTH> graph_definition_buffers_{};
-
-    // Each arena bank backs the three pooled regions (PTO2 GM heap / PTO2
-    // shared memory / trb prebuilt runtime arena) for one pipeline slot. They
+    // Each arena bank backs the pooled regions (PTO2 GM heap / PTO2 shared
+    // memory / trb prebuilt runtime arena / HBG GraphBlock) for one pipeline slot. They
     // are separate allocations because the combined size can exceed the device
     // allocator's largest contiguous block. Released explicitly in finalize()
     // before mem_alloc_.finalize().
@@ -369,14 +356,17 @@ protected:
         ArenaBank(DeviceArena::AllocFn alloc, DeviceArena::FreeFn free_fn, void *ctx) :
             gm_heap(alloc, free_fn, ctx),
             gm_sm(alloc, free_fn, ctx),
-            runtime_pool(alloc, free_fn, ctx) {}
+            runtime_pool(alloc, free_fn, ctx),
+            graph_block(alloc, free_fn, ctx) {}
 
         DeviceArena gm_heap;
         DeviceArena gm_sm;
         DeviceArena runtime_pool;
+        DeviceArena graph_block;
         size_t cached_gm_heap_size{0};
         size_t cached_gm_sm_size{0};
         size_t cached_runtime_arena_size{0};
+        size_t cached_graph_block_size{0};
     };
     std::array<std::unique_ptr<ArenaBank>, PTO_PIPELINE_MAX_DEPTH> arena_banks_;
     ArenaBank &arena_bank(uint32_t bank_id) { return *arena_banks_[bank_id]; }

--- a/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
@@ -142,8 +142,8 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
         SCOPED_TRACE(testing::Message() << "slot local_id=" << local);
         const int32_t slot = ring.get_slot_by_task_id(local);
         const PTO2TaskDescriptor &desc = ring.task_descriptors[slot];
-        const PTO2TaskPayload &pl = ring.task_payloads[slot];
         const PTO2TaskSlotState &st = ring.slot_states[slot];
+        const PTO2TaskPayload &pl = *st.payload;
 
         // Descriptor: the task id is written to this exact local id.
         EXPECT_EQ(desc.task_id.local(), static_cast<uint32_t>(local));
@@ -170,8 +170,9 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     }
 
     // Field-specific coverage on the real task: tensors, scalar, packed output buffer.
-    const PTO2TaskDescriptor &root_desc = ring.task_descriptors[ring.get_slot_by_task_id(root.task_id().local())];
-    const PTO2TaskPayload &root_pl = ring.task_payloads[ring.get_slot_by_task_id(root.task_id().local())];
+    const int32_t root_slot = ring.get_slot_by_task_id(root.task_id().local());
+    const PTO2TaskDescriptor &root_desc = ring.task_descriptors[root_slot];
+    const PTO2TaskPayload &root_pl = *ring.slot_states[root_slot].payload;
     EXPECT_EQ(root_pl.tensor_count, 1);
     EXPECT_EQ(root_pl.scalar_count, 1);
     EXPECT_EQ(root_pl.dump_metadata.dump_arg_mask, (uint64_t{1} << 0) | (uint64_t{1} << 1));
@@ -182,7 +183,8 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     EXPECT_EQ(root_desc.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)], 0);
 
     // The consumer's fanin is written: two duplicate deps dedupe to one.
-    const PTO2TaskPayload &cons_pl = ring.task_payloads[ring.get_slot_by_task_id(consumer.task_id().local())];
+    const int32_t consumer_slot = ring.get_slot_by_task_id(consumer.task_id().local());
+    const PTO2TaskPayload &cons_pl = *ring.slot_states[consumer_slot].payload;
     EXPECT_EQ(cons_pl.fanin_count, 1);
     EXPECT_EQ(cons_pl.fanin_local_ids[0], static_cast<int32_t>(root.task_id().local()));
 }

--- a/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
@@ -142,8 +142,8 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
         SCOPED_TRACE(testing::Message() << "slot local_id=" << local);
         const int32_t slot = ring.get_slot_by_task_id(local);
         const PTO2TaskDescriptor &desc = ring.task_descriptors[slot];
-        const PTO2TaskPayload &pl = ring.task_payloads[slot];
         const PTO2TaskSlotState &st = ring.slot_states[slot];
+        const PTO2TaskPayload &pl = *st.payload;
 
         // Descriptor: the task id is written to this exact local id.
         EXPECT_EQ(desc.task_id.local(), static_cast<uint32_t>(local));
@@ -170,8 +170,9 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     }
 
     // Field-specific coverage on the real task: tensors, scalar, packed output buffer.
-    const PTO2TaskDescriptor &root_desc = ring.task_descriptors[ring.get_slot_by_task_id(root.task_id().local())];
-    const PTO2TaskPayload &root_pl = ring.task_payloads[ring.get_slot_by_task_id(root.task_id().local())];
+    const int32_t root_slot = ring.get_slot_by_task_id(root.task_id().local());
+    const PTO2TaskDescriptor &root_desc = ring.task_descriptors[root_slot];
+    const PTO2TaskPayload &root_pl = *ring.slot_states[root_slot].payload;
     EXPECT_EQ(root_pl.tensor_count, 1);
     EXPECT_EQ(root_pl.scalar_count, 1);
     EXPECT_EQ(root_pl.dump_metadata.dump_arg_mask, (uint64_t{1} << 0) | (uint64_t{1} << 1));
@@ -182,7 +183,8 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     EXPECT_EQ(root_desc.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)], 0);
 
     // The consumer's fanin is written: two duplicate deps dedupe to one.
-    const PTO2TaskPayload &cons_pl = ring.task_payloads[ring.get_slot_by_task_id(consumer.task_id().local())];
+    const int32_t consumer_slot = ring.get_slot_by_task_id(consumer.task_id().local());
+    const PTO2TaskPayload &cons_pl = *ring.slot_states[consumer_slot].payload;
     EXPECT_EQ(cons_pl.fanin_count, 1);
     EXPECT_EQ(cons_pl.fanin_local_ids[0], static_cast<int32_t>(root.task_id().local()));
 }

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -51,7 +51,9 @@ GraphTensor make_test_tensor(uint64_t address) {
     return tensor;
 }
 
-std::vector<std::byte> make_test_definition(uint64_t graph_key, uint64_t boundary_address) {
+std::vector<std::byte> make_test_definition(
+    uint64_t graph_key, uint64_t boundary_address, uint32_t boundary_count = 1, uint32_t boundary_scalar_count = 1
+) {
     std::vector<std::byte> image(sizeof(GraphDefinition));
 
     std::vector<uint32_t> fanin_offsets{0, 0, 1};
@@ -94,8 +96,8 @@ std::vector<std::byte> make_test_definition(uint64_t graph_key, uint64_t boundar
     definition.task_count = 2;
     definition.edge_count = 1;
     definition.root_count = 1;
-    definition.boundary_count = 1;
-    definition.boundary_scalar_count = 1;
+    definition.boundary_count = boundary_count;
+    definition.boundary_scalar_count = boundary_scalar_count;
     definition.tensor_arg_count = 2;
     definition.scalar_arg_count = 2;
     definition.off_fanin_offsets = append_section(image, fanin_offsets);
@@ -215,6 +217,100 @@ private:
 };
 
 }  // namespace
+
+TEST(GraphTaskPayloadSpace, Dsv4BoundaryArgsRoundTrip) {
+    constexpr int32_t TENSOR_COUNT = 118;
+    constexpr int32_t SCALAR_COUNT = 31;
+    size_t payload_bytes = 0;
+    size_t scalars_offset = 0;
+    ASSERT_TRUE(graph_task_payload_layout(TENSOR_COUNT, SCALAR_COUNT, &payload_bytes, &scalars_offset));
+    EXPECT_GT(payload_bytes, sizeof(PTO2TaskPayload));
+    EXPECT_EQ(scalars_offset, sizeof(PTO2TaskPayload) + (TENSOR_COUNT - MAX_TENSOR_ARGS) * sizeof(ChipTensor));
+
+    AlignedStorage storage(payload_bytes);
+    auto &payload = *reinterpret_cast<PTO2TaskPayload *>(storage.data());
+    payload.tensor_count = TENSOR_COUNT;
+    payload.scalar_count = SCALAR_COUNT;
+    for (uint32_t i = 0; i < TENSOR_COUNT; ++i) {
+        ChipTensor *tensor = graph_task_payload_tensor(payload, i);
+        ASSERT_NE(tensor, nullptr);
+        tensor->buffer.addr = 0x1000 + i * 0x100;
+        tensor->start_offset = i * 4;
+    }
+    for (uint32_t i = 0; i < SCALAR_COUNT; ++i) {
+        uint64_t *scalar = graph_task_payload_scalar(payload, i);
+        ASSERT_NE(scalar, nullptr);
+        *scalar = 0xABC000 + i;
+    }
+
+    const PTO2TaskPayload &const_payload = payload;
+    for (uint32_t i = 0; i < TENSOR_COUNT; ++i) {
+        const ChipTensor *tensor = graph_task_payload_tensor(const_payload, i);
+        ASSERT_NE(tensor, nullptr);
+        EXPECT_EQ(tensor->buffer.addr, 0x1000U + i * 0x100U);
+        EXPECT_EQ(tensor->start_offset, i * 4U);
+    }
+    for (uint32_t i = 0; i < SCALAR_COUNT; ++i) {
+        const uint64_t *scalar = graph_task_payload_scalar(const_payload, i);
+        ASSERT_NE(scalar, nullptr);
+        EXPECT_EQ(*scalar, 0xABC000U + i);
+    }
+}
+
+TEST(GraphTaskPayloadSpace, Dsv4BoundaryCountsLocalizeAndMaterialize) {
+    constexpr uint64_t GRAPH_KEY_VALUE = 0xD5F4;
+    constexpr int32_t TENSOR_COUNT = 118;
+    constexpr int32_t SCALAR_COUNT = 31;
+    std::array<uint8_t, 64> boundary{};
+    const std::vector<std::byte> definition =
+        make_test_definition(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()), TENSOR_COUNT, SCALAR_COUNT);
+    const TestDefinitionObject definition_object(definition);
+    OuterHeap heap(definition);
+    std::vector<std::byte> submission_image = make_test_submission(GRAPH_KEY_VALUE);
+    auto &submission = *reinterpret_cast<GraphSubmission *>(submission_image.data());
+    submission.definition_addr = definition_object.address();
+    submission.definition_hash = definition_object.hash();
+
+    size_t payload_bytes = 0;
+    ASSERT_TRUE(graph_task_payload_layout(TENSOR_COUNT, SCALAR_COUNT, &payload_bytes));
+    AlignedStorage payload_storage(payload_bytes);
+    auto &payload = *reinterpret_cast<PTO2TaskPayload *>(payload_storage.data());
+    payload.tensor_count = TENSOR_COUNT;
+    payload.scalar_count = SCALAR_COUNT;
+    graph_tensor_unpack(
+        make_test_tensor(reinterpret_cast<uint64_t>(boundary.data())), graph_task_payload_tensor(payload, 0)
+    );
+    *graph_task_payload_scalar(payload, 0) = 17;
+
+    PTO2TaskDescriptor outer_task{};
+    outer_task.task_id = PTO2TaskId::make(1, 7);
+    outer_task.packed_buffer_base = heap.base();
+    outer_task.packed_buffer_end = heap.end();
+    PTO2TaskSlotState outer_slot{};
+    outer_slot.task_kind = TaskKind::GRAPH;
+    outer_slot.task = &outer_task;
+    outer_slot.payload = &payload;
+    outer_slot.graph_context = &submission;
+
+    GraphExecution *execution = graph_execution_localize(outer_slot);
+    ASSERT_NE(execution, nullptr);
+    EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
+    EXPECT_EQ(execution->node_storage[0].payload.scalars[0], 17U);
+    EXPECT_EQ(execution->node_storage[0].payload.tensors[0].buffer.addr, reinterpret_cast<uint64_t>(boundary.data()));
+}
+
+TEST(GraphTaskPayloadSpace, RelativePayloadReferenceSurvivesWholeImageMove) {
+    struct alignas(64) PayloadImage {
+        PTO2TaskPayload payload{};
+        PTO2TaskSlotState slot{};
+    };
+    PayloadImage source{};
+    source.slot.bind_buffers(&source.payload, nullptr);
+    alignas(PayloadImage) std::array<std::byte, sizeof(PayloadImage)> moved_bytes{};
+    std::memcpy(moved_bytes.data(), &source, sizeof(source));
+    auto *moved = reinterpret_cast<PayloadImage *>(moved_bytes.data());
+    EXPECT_EQ(moved->slot.payload.get(), &moved->payload);
+}
 
 TEST(GraphCache, RejectsEmptyBoundary) {
     GraphTaskArgs args;

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -120,23 +120,21 @@ std::vector<std::byte> make_test_definition(uint64_t graph_key, uint64_t boundar
     return image;
 }
 
-std::vector<std::byte> make_test_submission(uint64_t graph_key, uint64_t boundary_address, uint64_t boundary_scalar) {
-    const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphTensor));
-    const size_t scalars_offset = PTO2_ALIGN_UP(tensors_offset + sizeof(GraphTensor), alignof(uint64_t));
-    std::vector<std::byte> image(scalars_offset + sizeof(uint64_t));
-    const GraphTensor boundary = make_test_tensor(boundary_address);
-    std::memcpy(image.data() + tensors_offset, &boundary, sizeof(boundary));
-    std::memcpy(image.data() + scalars_offset, &boundary_scalar, sizeof(boundary_scalar));
-
+std::vector<std::byte> make_test_submission(uint64_t graph_key) {
+    std::vector<std::byte> image(sizeof(GraphSubmission));
     GraphSubmission submission{};
     submission.graph_key = graph_key;
-    submission.total_bytes = static_cast<uint32_t>(image.size());
-    submission.tensors_offset = static_cast<uint32_t>(tensors_offset);
-    submission.tensor_count = 1;
-    submission.scalars_offset = static_cast<uint32_t>(scalars_offset);
-    submission.scalar_count = 1;
     std::memcpy(image.data(), &submission, sizeof(submission));
     return image;
+}
+
+// The boundary args of a replay, where graph_execution_localize reads them: the
+// outer GRAPH task's own payload, in ChipTensor form like any other task's args.
+void set_test_boundary(PTO2TaskPayload *payload, uint64_t boundary_address, uint64_t boundary_scalar) {
+    payload->tensor_count = 1;
+    payload->scalar_count = 1;
+    graph_tensor_unpack(make_test_tensor(boundary_address), &payload->tensors[0]);
+    payload->scalars[0] = boundary_scalar;
 }
 
 // A Definition device object exactly as upload_graph_submissions builds it:
@@ -305,8 +303,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
         make_test_definition(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(first_boundary.data()));
     const TestDefinitionObject definition_object(definition);
     OuterHeap heap(definition, 0xAA);
-    std::vector<std::byte> submission_image =
-        make_test_submission(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(first_boundary.data()), 17);
+    std::vector<std::byte> submission_image = make_test_submission(GRAPH_KEY_VALUE);
     auto &submission = *reinterpret_cast<GraphSubmission *>(submission_image.data());
     submission.definition_addr = definition_object.address();
     submission.definition_hash = definition_object.hash();
@@ -315,9 +312,12 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     outer_task.task_id = PTO2TaskId::make(1, 7);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
+    auto outer_payload = std::make_unique<PTO2TaskPayload>();
+    set_test_boundary(outer_payload.get(), reinterpret_cast<uint64_t>(first_boundary.data()), 17);
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
     outer_slot.task = &outer_task;
+    outer_slot.payload = outer_payload.get();
     outer_slot.graph_context = &submission;
 
     GraphExecution *execution = graph_execution_localize(outer_slot);
@@ -340,10 +340,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     execution->retired_nodes.store(2, std::memory_order_release);
     submission.local_execution = 0;
     outer_task.task_id = PTO2TaskId::make(1, 8);
-    auto *boundary = reinterpret_cast<GraphTensor *>(submission_image.data() + submission.tensors_offset);
-    boundary->buffer_addr = reinterpret_cast<uint64_t>(second_boundary.data());
-    auto *boundary_scalar = reinterpret_cast<uint64_t *>(submission_image.data() + submission.scalars_offset);
-    *boundary_scalar = 99;
+    set_test_boundary(outer_payload.get(), reinterpret_cast<uint64_t>(second_boundary.data()), 99);
 
     // Poison every field the rebuild is responsible for restoring. A replay that
     // preserved any of them would leave the poison observable.
@@ -384,8 +381,7 @@ TEST(GraphDefinitionObject, RejectsDefinitionBeyondRetainedBytes) {
     ASSERT_GT(definition.size(), sizeof(GraphDefinition));
     const TestDefinitionObject definition_object(definition, sizeof(GraphDefinition));
     OuterHeap heap(definition);
-    std::vector<std::byte> submission_image =
-        make_test_submission(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()), 17);
+    std::vector<std::byte> submission_image = make_test_submission(GRAPH_KEY_VALUE);
     auto &submission = *reinterpret_cast<GraphSubmission *>(submission_image.data());
     submission.definition_addr = definition_object.address();
     submission.definition_hash = definition_object.hash();
@@ -394,23 +390,25 @@ TEST(GraphDefinitionObject, RejectsDefinitionBeyondRetainedBytes) {
     outer_task.task_id = PTO2TaskId::make(1, 7);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
+    auto outer_payload = std::make_unique<PTO2TaskPayload>();
+    set_test_boundary(outer_payload.get(), reinterpret_cast<uint64_t>(boundary.data()), 17);
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
     outer_slot.task = &outer_task;
+    outer_slot.payload = outer_payload.get();
     outer_slot.graph_context = &submission;
 
     EXPECT_EQ(graph_execution_localize(outer_slot), nullptr);
     EXPECT_EQ(definition_object.verify_state(), GraphDefinitionVerifyState::INVALID);
 }
 
-TEST(GraphSubmissionWire, RequiresExactAvailableSize) {
-    constexpr uint64_t GRAPH_KEY_VALUE = 0x4567;
-    std::vector<std::byte> image = make_test_submission(GRAPH_KEY_VALUE, 0x1000, 17);
-    const auto &submission = *reinterpret_cast<const GraphSubmission *>(image.data());
-
-    EXPECT_TRUE(graph_submission_wire_size_valid(submission, image.size()));
-    EXPECT_FALSE(graph_submission_wire_size_valid(submission, image.size() - 1));
-    EXPECT_FALSE(graph_submission_wire_size_valid(submission, image.size() + 1));
+// The submission is a fixed-size Definition reference: it carries no arg region,
+// so its wire size does not depend on the args and nothing indexes into it.
+TEST(GraphSubmissionWire, CarriesNoArgRegion) {
+    std::vector<std::byte> few = make_test_submission(0x4567);
+    std::vector<std::byte> many = make_test_submission(0x89AB);
+    EXPECT_EQ(few.size(), sizeof(GraphSubmission));
+    EXPECT_EQ(few.size(), many.size());
 }
 
 TEST(GraphSubmissionActivationGate, ActivatesExactlyOnceUnderContention) {
@@ -543,8 +541,7 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
         make_test_definition(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()));
     const TestDefinitionObject definition_object(definition);
     OuterHeap heap(definition, 0xAA);
-    std::vector<std::byte> submission_image =
-        make_test_submission(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()), 17);
+    std::vector<std::byte> submission_image = make_test_submission(GRAPH_KEY_VALUE);
     auto &submission = *reinterpret_cast<GraphSubmission *>(submission_image.data());
     submission.definition_addr = definition_object.address();
     submission.definition_hash = definition_object.hash();
@@ -553,9 +550,12 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
     outer_task.task_id = PTO2TaskId::make(1, 5);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
+    auto outer_payload = std::make_unique<PTO2TaskPayload>();
+    set_test_boundary(outer_payload.get(), reinterpret_cast<uint64_t>(boundary.data()), 17);
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
     outer_slot.task = &outer_task;
+    outer_slot.payload = outer_payload.get();
     outer_slot.graph_context = &submission;
 
     GraphExecution *execution = graph_execution_localize(outer_slot);

--- a/tests/ut/cpp/common/test_host_api.cpp
+++ b/tests/ut/cpp/common/test_host_api.cpp
@@ -47,10 +47,16 @@ int setup_static_arena(void *runner_ctx, uint32_t arena_bank, size_t, size_t, si
     return 0;
 }
 
+void *acquire_graph_block(void *runner_ctx, uint32_t arena_bank, size_t, size_t) {
+    static_cast<FakeRunner *>(runner_ctx)->record_arena_bank(arena_bank);
+    return runner_ctx;
+}
+
 const HostApiOps &fake_ops() {
     static const HostApiOps ops = []() {
         HostApiOps result{};
         result.set_retained_temp_buffer = set_retained_temp_buffer;
+        result.acquire_graph_block = acquire_graph_block;
         result.setup_static_arena = setup_static_arena;
         return result;
     }();
@@ -103,6 +109,7 @@ TEST(HostApiTest, BoundRunnerSlotAndBankSurviveConcurrentCrossThreadCalls) {
         for (int i = 0; i < kCallsPerThread; ++i) {
             api_a.set_retained_temp_buffer(nullptr, 0);
             api_b.setup_static_arena(0, 0, 0);
+            (void)api_b.acquire_graph_block(64, 8);
         }
     });
     std::thread second([&]() {
@@ -110,6 +117,7 @@ TEST(HostApiTest, BoundRunnerSlotAndBankSurviveConcurrentCrossThreadCalls) {
         for (int i = 0; i < kCallsPerThread; ++i) {
             api_b.set_retained_temp_buffer(nullptr, 0);
             api_a.setup_static_arena(0, 0, 0);
+            (void)api_a.acquire_graph_block(64, 8);
         }
     });
 
@@ -117,9 +125,9 @@ TEST(HostApiTest, BoundRunnerSlotAndBankSurviveConcurrentCrossThreadCalls) {
     second.join();
 
     EXPECT_EQ(runner_a.pipeline_slots.size(), kCallsPerThread);
-    EXPECT_EQ(runner_a.arena_banks.size(), kCallsPerThread);
+    EXPECT_EQ(runner_a.arena_banks.size(), 2 * kCallsPerThread);
     EXPECT_EQ(runner_b.pipeline_slots.size(), kCallsPerThread);
-    EXPECT_EQ(runner_b.arena_banks.size(), kCallsPerThread);
+    EXPECT_EQ(runner_b.arena_banks.size(), 2 * kCallsPerThread);
     EXPECT_TRUE(all_equal(runner_a.pipeline_slots, kRunnerASlot));
     EXPECT_TRUE(all_equal(runner_a.arena_banks, kRunnerABank));
     EXPECT_TRUE(all_equal(runner_b.pipeline_slots, kRunnerBSlot));


### PR DESCRIPTION
## Summary

Reduce host-side allocation and H2D-copy overhead for host-built Graph replay data.

- Carry replay boundary tensors and scalars in the outer `GRAPH` task payload, leaving `GraphSubmission` as a fixed-size Definition reference plus device replay state.
- Compute and validate the complete `[Definitions][Submissions]` layout, including every size, alignment, and offset, before acquiring device storage.
- Store one grow-only GraphBlock on the arena bank selected for the run. Reuse its allocation when capacity is sufficient and grow it only when required; the block is not Worker-owned.
- Address all internal objects as `GraphBlock base + offset` and overwrite the complete live range with exactly one H2D copy on every run.
- Release or abandon the GraphBlock with its arena bank on normal or fatal teardown for both onboard and simulator runners.

This deliberately does not add content-based copy skipping, Task Window packing, queue sizing, heap sizing, or environment-variable-driven allocation.

## Motivation

Host `rtMalloc` is expensive, and one large `rtMemcpy` is materially cheaper than many small copies. The previous path retained each Definition separately and allocated/uploaded every submission independently. Qwen3 performs 40 Graph replays, producing 41 allocation/H2D operations per run.

The new path computes the whole GraphBlock first, performs at most one allocation/grow operation for the selected arena bank, and then performs one H2D upload.

## Performance

Measured with `GraphExecutionBatch16Seq3500` from the Qwen3-14B decode HBG example on A2A3. Baseline and PR were rebuilt from adjacent runs against current `main` (`93adc386`).

| Metric | main | this PR | Change |
|---|---:|---:|---:|
| Graph upload operations | 41 | 1 | -40 calls |
| Graph upload bytes | 232,312 B | 131,832 B | -43.25% |
| `graph_upload` host span | 1,381.044 us | 243.623 us | -82.36% |
| Device wall | 39.920 ms | 39.925 ms | no regression observed |

The direct `graph_upload` span is the relevant result; end-to-end device execution is expected to remain unchanged because this PR only changes host preparation and upload.

## Validation

- Rebased cleanly onto current `main` (`93adc386`).
- Rebuilt A2A3 and A5 runtime/bindings after the rebase.
- C++ no-hardware suite: 107/107 passed.
- Graph execution simulator coverage passed on both A2A3 and A5:
  - `record_then_replay_1d`
  - `record_then_replay_2d` (multiple Definitions and submissions)
- A2A3 Qwen3 `GraphExecutionBatch16Seq3500` correctness and profiling passed.
- A three-round A2A3 Qwen3 run passed and covered arena-bank rotation followed by reuse of an already provisioned bank.

A5 onboard hardware was not available on the A2A3 validation host; A5 compilation, C++ tests, and A5 simulator coverage passed.
