### PR TITLE
Update: reversing the task wake-up waker

### DIFF
--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -247,7 +247,10 @@ Submit does not push tasks into ready queues. After the graph arrives on device,
 boot classification scans every submitted task exactly once:
 
 - a task whose fanins are all complete is routed to its shape queue;
-- otherwise it registers on the first unmet producer's intrusive wake list; and
+- otherwise it registers on its latest-submitted unmet producer's intrusive
+  wake list -- the producer likeliest to complete last, which minimises how
+  often a waiter is transferred between wake lists and the CAS contention
+  those transfers cause; and
 - producer completion reclassifies every detached waiter.
 
 Completion flags are monotonic, so this consumer-pull scheme cannot miss a

--- a/src/a2a3/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a2a3/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
@@ -80,7 +80,8 @@ must launch as one cohort:
 3. Submit publishes only the finished graph data; it does not push ready tasks.
 4. After H2D, device boot scans every submitted task exactly once.
 5. A task with every fanin complete is routed to its ready queue; otherwise it
-   registers on its first unmet producer's wake list.
+   registers on its latest-submitted unmet producer's wake list, minimising
+   transfers between wake lists and their CAS contention.
 6. Producer completion reclassifies wake-list consumers until they become ready.
 
 Completion flags are monotonic, so a task never needs periodic fanin polling.

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -575,14 +575,19 @@ struct PTO2SchedulerState {
     // set its completion_flags byte. Single-ring: all producers are ring 0, so
     // there is no per-edge ring indirection.
 
-    // First-unmet classification. Returns -1 (all fanins met -> route to ready)
-    // or the index of the first unmet fanin (register on that producer's wake
-    // list). The decision is terminal: tasks are never re-polled; a producer's
+    // Unmet-fanin classification. Returns -1 (all fanins met -> route to ready)
+    // or the index of an unmet fanin (register on that producer's wake list).
+    // Scan direction is load-bearing: the builder fills fanin_local_ids in
+    // submission order, so the last unmet entry is the latest-submitted
+    // producer -- the one likeliest to complete last. Targeting it minimises
+    // wake-list transfers (a consumer re-registered onto a second producer once
+    // its first one completes) and the CAS traffic those transfers put on the
+    // lists. The decision is terminal: tasks are never re-polled; a producer's
     // completion re-scans its waiters via on_mixed_task_complete's wake drain.
     int classify_fanin_state(const PTO2TaskSlotState *s) const {
         const PTO2TaskPayload &p = *s->payload;
         const PTO2SharedMemoryRingHeader &ring = *ring_sched_state.ring;
-        for (int32_t i = 0; i < p.fanin_count; i++) {
+        for (int32_t i = p.fanin_count - 1; i >= 0; i--) {
             if (!ring.is_completion_flag_set(p.fanin_local_ids[i])) return i;
         }
         return -1;

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -247,7 +247,10 @@ Submit does not push tasks into ready queues. After the graph arrives on device,
 boot classification scans every submitted task exactly once:
 
 - a task whose fanins are all complete is routed to its shape queue;
-- otherwise it registers on the first unmet producer's intrusive wake list; and
+- otherwise it registers on its latest-submitted unmet producer's intrusive
+  wake list -- the producer likeliest to complete last, which minimises how
+  often a waiter is transferred between wake lists and the CAS contention
+  those transfers cause; and
 - producer completion reclassifies every detached waiter.
 
 Completion flags are monotonic, so this consumer-pull scheme cannot miss a

--- a/src/a5/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a5/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
@@ -80,7 +80,8 @@ must launch as one cohort:
 3. Submit publishes only the finished graph data; it does not push ready tasks.
 4. After H2D, device boot scans every submitted task exactly once.
 5. A task with every fanin complete is routed to its ready queue; otherwise it
-   registers on its first unmet producer's wake list.
+   registers on its latest-submitted unmet producer's wake list, minimising
+   transfers between wake lists and their CAS contention.
 6. Producer completion reclassifies wake-list consumers until they become ready.
 
 Completion flags are monotonic, so a task never needs periodic fanin polling.

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -575,14 +575,19 @@ struct PTO2SchedulerState {
     // set its completion_flags byte. Single-ring: all producers are ring 0, so
     // there is no per-edge ring indirection.
 
-    // First-unmet classification. Returns -1 (all fanins met -> route to ready)
-    // or the index of the first unmet fanin (register on that producer's wake
-    // list). The decision is terminal: tasks are never re-polled; a producer's
+    // Unmet-fanin classification. Returns -1 (all fanins met -> route to ready)
+    // or the index of an unmet fanin (register on that producer's wake list).
+    // Scan direction is load-bearing: the builder fills fanin_local_ids in
+    // submission order, so the last unmet entry is the latest-submitted
+    // producer -- the one likeliest to complete last. Targeting it minimises
+    // wake-list transfers (a consumer re-registered onto a second producer once
+    // its first one completes) and the CAS traffic those transfers put on the
+    // lists. The decision is terminal: tasks are never re-polled; a producer's
     // completion re-scans its waiters via on_mixed_task_complete's wake drain.
     int classify_fanin_state(const PTO2TaskSlotState *s) const {
         const PTO2TaskPayload &p = *s->payload;
         const PTO2SharedMemoryRingHeader &ring = *ring_sched_state.ring;
-        for (int32_t i = 0; i < p.fanin_count; i++) {
+        for (int32_t i = p.fanin_count - 1; i >= 0; i--) {
             if (!ring.is_completion_flag_set(p.fanin_local_ids[i])) return i;
         }
         return -1;


### PR DESCRIPTION
### Summary

We change the priority of the wakers (producers) in the polling wake-up list mechanism. More precisely, we reverse the order in which the predecessors are checked for completion. The heuristic for this is

- Higher TaskID and TensorId, the later the completion, the fewer bounces around to other wake-up lists

### Benchmarks

We compare the number of calls to `classify_fanin_state` by the `P` thread of the main against this PR and also against the heuristic of largest Task Id. The inversion (this PR) does best.

| Example : case | max fan-in | main | largest task id | this PR |
| --- | ---: | ---: | ---: | ---: |
| paged_attention:Case2 | 4 | 24,497 | 16,312 | **8,202** |
| batch_paged_attention:Case1 | 4 | 3,054 | 2,028 | **1,027** |
| batch_paged_attention:Case2 | 4 | 1,532 | 1,020 | **512** |
| paged_attention_unroll:Case1 | 3 | 512 | 256 | **256** |
| paged_attention_unroll:Case2 | 4 | 299 | 171 | **159** |
| pa_unroll_manual_scope:Case2 | 3 | 98 | 100 | **89** |
| batch_paged_attention:CaseVarSeq4 | 4 | 23 | 15 | **8** |
| pa_unroll_manual_scope:Case1 | 2 | 256 | 256 | 256 |
| qwen3_14b_decode:B16S3500 | 5 | 42 | 41 | **81** |
| benchmark_bgemm:Case0 | 2 | 254 | 494 | **494** |
| bgemm:default | 2 | 49 | 96 | **96** |
| 5 cases with fan-in ≤ 1 | ≤1 | 0 | 0 | 0 |

We also measured overall performance, but it is all within noise.

| Example : case | main (µs) | this PR (µs) | change |
| --- | ---: | ---: | ---: |
| spmd_paged_attention:TwoWay | 65.1 | 63.8 | −2.00% |
| batch_paged_attention:CaseVarSeq4 | 117.7 | 116.5 | −1.06% |
| pa_unroll_manual_scope:Case2 | 572.8 | 568.2 | −0.80% |
| graph_execution:mix_spmd | 85.8 | 85.4 | −0.47% |
| vector_example:default | 53.1 | 52.9 | −0.38% |
| alternating_matmul_add:Case2 | 634.1 | 632.1 | −0.32% |
| paged_attention_unroll:Case1 | 1190.0 | 1186.2 | −0.31% |
| matmul:default | 54.2 | 54.2 | −0.18% |
| qwen3_14b_decode:B16S3500 | 44596.8 | 44553.3 | −0.10% |
| batch_paged_attention:Case2 | 4808.5 | 4805.9 | −0.05% |
| batch_paged_attention:Case1 | 2796.7 | 2796.5 | −0.01% |
| graph_execution:replay_2d | 67.1 | 67.1 | +0.00% |
| paged_attention_unroll:Case2 | 571.3 | 571.8 | +0.08% |
| pa_unroll_manual_scope:Case1 | 1187.2 | 1188.5 | +0.11% |
| alternating_matmul_add:Case1 | 758.7 | 760.0 | +0.17% |
| benchmark_bgemm:Case0 | 619.2 | 621.2 | +0.32% |
| bgemm:default | 102.3 | 102.7 | +0.39% |
| paged_attention:Case2 | 13073.0 | 13175.3 | +0.78% |