### PR TITLE
Fix: support existing 64x256x64 paged attention Case3

### DIFF
--- a/examples/a2a3/host_build_graph/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
+++ b/examples/a2a3/host_build_graph/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
@@ -62,8 +62,6 @@ class TestPagedAttentionUnrollManualScopeHostBuildGraph(SceneTestCase):
         ],
     }
 
-    # The shared head_dim=256 kernels fail golden on both runtimes, so Case3
-    # is not a valid cross-runtime benchmark.
     CASES = [
         {
             "name": "Case1",
@@ -88,6 +86,21 @@ class TestPagedAttentionUnrollManualScopeHostBuildGraph(SceneTestCase):
                 "num_heads": 64,
                 "kv_head_num": 1,
                 "head_dim": 128,
+                "block_size": 64,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            "name": "Case3",
+            "platforms": ["a2a3"],
+            "manual": True,
+            "params": {
+                "batch": 64,
+                "num_heads": 64,
+                "kv_head_num": 1,
+                "head_dim": 256,
                 "block_size": 64,
                 "context_len": 8192,
                 "max_model_len": 32768,

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -10,9 +10,10 @@
  */
 // PV Matmul Kernel: pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128) -> (16, 128)
 //   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
+//   Case3: (64,  64) @ ( 64, 256) -> (64, 256)
 //
 // pij is bfloat16 (converted from fp32 in softmax_prepare via TCVT).
 // vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
@@ -103,11 +104,14 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ ChipTensor *vj = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
     __gm__ ChipTensor *oi_new = reinterpret_cast<__gm__ ChipTensor *>(args[2]);
     uint64_t q_tile_size = static_cast<uint64_t>(pij->shapes[0]);
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[1]);
 
     if (q_tile_size == 16 && pij->shapes[1] <= 16) {
         pv_matmul_impl<16, 16, 16>(pij, vj, oi_new);
     } else if (q_tile_size == 16) {
         pv_matmul_impl<16, 128, 128>(pij, vj, oi_new);
+    } else if (head_dim == 256) {
+        pv_matmul_impl<64, 64, 256>(pij, vj, oi_new);
     } else {
         pv_matmul_impl<64, 64, 128>(pij, vj, oi_new);
     }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -10,9 +10,10 @@
  */
 // QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128).T -> (16, 128)
 //   Case2: (64, 128) @ (128,  64).T -> (64,  64)
+//   Case3: (64, 256) @ (256,  64).T -> (64,  64)
 //
 // kj is stored as (N, K) = (block_size, head_dim) in row-major memory.
 // This is equivalent to (K, N) in column-major (DN) layout.
@@ -104,11 +105,14 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ ChipTensor *kj = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
     __gm__ ChipTensor *sij = reinterpret_cast<__gm__ ChipTensor *>(args[2]);
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
+    uint64_t head_dim = static_cast<uint64_t>(qi->shapes[1]);
 
-    if (q_tile_size == 16 && qi->shapes[1] <= 16) {
+    if (q_tile_size == 16 && head_dim <= 16) {
         qk_matmul_impl<16, 16, 16>(qi, kj, sij);
     } else if (q_tile_size == 16) {
         qk_matmul_impl<16, 128, 128>(qi, kj, sij);
+    } else if (head_dim == 256) {
+        qk_matmul_impl<64, 256, 64>(qi, kj, sij);
     } else {
         qk_matmul_impl<64, 128, 64>(qi, kj, sij);
     }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -10,9 +10,10 @@
  */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
-// Operates on full tiles where M=q_tile_size, N=head_dim (128):
+// Operates on full tiles where M=q_tile_size and N=head_dim:
 //   Case1: oi/oi_new are (16, 128), mij/lij/mi/li are 16-element vectors
 //   Case2: oi/oi_new are (64, 128), mij/lij/mi/li are 64-element vectors
+//   Case3: oi/oi_new are (64, 256), mij/lij/mi/li are 64-element vectors
 //
 // Scalar layout strategy using TRESHAPE (zero-copy UB reshape):
 //   Scalars loaded as DN ColMajor (M, 1) for TROWEXPANDMUL/TROWEXPANDDIV.
@@ -245,11 +246,14 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[0]);
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[1]);
 
-    if (q_tile_size == 16 && oi_new->shapes[1] <= 16) {
+    if (q_tile_size == 16 && head_dim <= 16) {
         online_update_impl<16, 16>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     } else if (q_tile_size == 16) {
         online_update_impl<16, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    } else if (head_dim == 256) {
+        online_update_impl<64, 256>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     } else {
         online_update_impl<64, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/aic/aic_pv_matmul.cpp
@@ -10,9 +10,10 @@
  */
 // PV Matmul Kernel: pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128) -> (16, 128)
 //   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
+//   Case3: (64,  64) @ ( 64, 256) -> (64, 256)
 //
 // pij is bfloat16 (converted from fp32 in softmax_prepare via TCVT).
 // vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
@@ -103,11 +104,14 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ ChipTensor *vj = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
     __gm__ ChipTensor *oi_new = reinterpret_cast<__gm__ ChipTensor *>(args[2]);
     uint64_t q_tile_size = static_cast<uint64_t>(pij->shapes[0]);
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[1]);
 
     if (q_tile_size == 16 && pij->shapes[1] <= 16) {
         pv_matmul_impl<16, 16, 16>(pij, vj, oi_new);
     } else if (q_tile_size == 16) {
         pv_matmul_impl<16, 128, 128>(pij, vj, oi_new);
+    } else if (head_dim == 256) {
+        pv_matmul_impl<64, 64, 256>(pij, vj, oi_new);
     } else {
         pv_matmul_impl<64, 64, 128>(pij, vj, oi_new);
     }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/aic/aic_qk_matmul.cpp
@@ -10,9 +10,10 @@
  */
 // QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128).T -> (16, 128)
 //   Case2: (64, 128) @ (128,  64).T -> (64,  64)
+//   Case3: (64, 256) @ (256,  64).T -> (64,  64)
 //
 // kj is stored as (N, K) = (block_size, head_dim) in row-major memory.
 // This is equivalent to (K, N) in column-major (DN) layout.
@@ -104,11 +105,14 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ ChipTensor *kj = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
     __gm__ ChipTensor *sij = reinterpret_cast<__gm__ ChipTensor *>(args[2]);
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
+    uint64_t head_dim = static_cast<uint64_t>(qi->shapes[1]);
 
-    if (q_tile_size == 16 && qi->shapes[1] <= 16) {
+    if (q_tile_size == 16 && head_dim <= 16) {
         qk_matmul_impl<16, 16, 16>(qi, kj, sij);
     } else if (q_tile_size == 16) {
         qk_matmul_impl<16, 128, 128>(qi, kj, sij);
+    } else if (head_dim == 256) {
+        qk_matmul_impl<64, 256, 64>(qi, kj, sij);
     } else {
         qk_matmul_impl<64, 128, 64>(qi, kj, sij);
     }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/aiv/aiv_online_update.cpp
@@ -10,9 +10,10 @@
  */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
-// Operates on full tiles where M=q_tile_size, N=head_dim (128):
+// Operates on full tiles where M=q_tile_size and N=head_dim:
 //   Case1: oi/oi_new are (16, 128), mij/lij/mi/li are 16-element vectors
 //   Case2: oi/oi_new are (64, 128), mij/lij/mi/li are 64-element vectors
+//   Case3: oi/oi_new are (64, 256), mij/lij/mi/li are 64-element vectors
 //
 // Scalar layout strategy using TRESHAPE (zero-copy UB reshape):
 //   Scalars loaded as DN ColMajor (M, 1) for TROWEXPANDMUL/TROWEXPANDDIV.
@@ -245,11 +246,14 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[0]);
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[1]);
 
-    if (q_tile_size == 16 && oi_new->shapes[1] <= 16) {
+    if (q_tile_size == 16 && head_dim <= 16) {
         online_update_impl<16, 16>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     } else if (q_tile_size == 16) {
         online_update_impl<16, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    } else if (head_dim == 256) {
+        online_update_impl<64, 256>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     } else {
         online_update_impl<64, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/aic/aic_pv_matmul.cpp
@@ -26,9 +26,10 @@
 //   - Canonical 3-stage pipeline: TLOAD(MTE2) → TMOV(MTE1) → TMATMUL(M)
 //   - Reverse-dependency events ensure buffer safety across iterations
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128) -> (16, 128)
 //   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
+//   Case3: (64,  64) @ ( 64, 256) -> (64, 256)
 //
 // pij is bfloat16 (from softmax_prepare TCVT).
 // vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
@@ -158,9 +159,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr);
 
     uint64_t q_tile_size = static_cast<uint64_t>(pij_buf->shapes[0]);
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[1]);
 
     if (q_tile_size == 16) {
         pv_matmul_n_impl<16, 128, 128>(pij_base, val_base, oi_base, n_blocks, bt, bt_offset);
+    } else if (head_dim == 256) {
+        pv_matmul_n_impl<64, 64, 256>(pij_base, val_base, oi_base, n_blocks, bt, bt_offset);
     } else {
         pv_matmul_n_impl<64, 64, 128>(pij_base, val_base, oi_base, n_blocks, bt, bt_offset);
     }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/aic/aic_qk_matmul.cpp
@@ -22,9 +22,10 @@
 //   - qi TLOAD hoisted before the loop (constant across all iterations)
 //   - Double-buffered L1 B tiles: prefetch next kj during current TMATMUL+TSTORE
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128).T -> (16, 128)
 //   Case2: (64, 128) @ (128,  64).T -> (64,  64)
+//   Case3: (64, 256) @ (256,  64).T -> (64,  64)
 //
 // Template: M=q_tile, K=head_dim, N=block_size
 
@@ -146,9 +147,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr);
 
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
+    uint64_t head_dim = static_cast<uint64_t>(qi->shapes[1]);
 
     if (q_tile_size == 16) {
         qk_matmul_n_impl<16, 128, 128>(qi_base, key_base, sij_base, n_blocks, bt, bt_offset);
+    } else if (head_dim == 256) {
+        qk_matmul_n_impl<64, 256, 64>(qi_base, key_base, sij_base, n_blocks, bt, bt_offset);
     } else {
         qk_matmul_n_impl<64, 128, 64>(qi_base, key_base, sij_base, n_blocks, bt, bt_offset);
     }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/aiv/aiv_online_update.cpp
@@ -10,9 +10,10 @@
  */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
-// Operates on full tiles where M=q_tile_size, N=head_dim (128):
+// Operates on full tiles where M=q_tile_size and N=head_dim:
 //   Case1: oi/oi_new are (16, 128), mij/lij/mi/li are 16-element vectors
 //   Case2: oi/oi_new are (64, 128), mij/lij/mi/li are 64-element vectors
+//   Case3: oi/oi_new are (64, 256), mij/lij/mi/li are 64-element vectors
 //
 // Scalar layout strategy using TRESHAPE (zero-copy UB reshape):
 //   Scalars loaded as DN ColMajor (M, 1) for TROWEXPANDMUL/TROWEXPANDDIV.
@@ -245,10 +246,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[0]);
-    // args[10] = head_dim (128)
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[1]);
 
     if (q_tile_size == 16) {
         online_update_impl<16, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    } else if (head_dim == 256) {
+        online_update_impl<64, 256>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     } else {
         online_update_impl<64, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     }

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -10,9 +10,10 @@
  */
 // PV Matmul Kernel: pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128) -> (16, 128)
 //   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
+//   Case3: (64,  64) @ ( 64, 256) -> (64, 256)
 //
 // pij is bfloat16 (converted from fp32 in softmax_prepare via TCVT).
 // vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
@@ -103,12 +104,14 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ ChipTensor *vj = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
     __gm__ ChipTensor *oi_new = reinterpret_cast<__gm__ ChipTensor *>(args[2]);
     uint64_t q_tile_size = static_cast<uint64_t>(pij->shapes[0]);
-    // args[4] = block_size, args[5] = head_dim
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[1]);
 
     if (q_tile_size == 16 && pij->shapes[1] <= 16) {
         pv_matmul_impl<16, 16, 16>(pij, vj, oi_new);
     } else if (q_tile_size == 16) {
         pv_matmul_impl<16, 128, 128>(pij, vj, oi_new);
+    } else if (head_dim == 256) {
+        pv_matmul_impl<64, 64, 256>(pij, vj, oi_new);
     } else {
         pv_matmul_impl<64, 64, 128>(pij, vj, oi_new);
     }

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -10,9 +10,10 @@
  */
 // QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128).T -> (16, 128)
 //   Case2: (64, 128) @ (128,  64).T -> (64,  64)
+//   Case3: (64, 256) @ (256,  64).T -> (64,  64)
 //
 // kj is stored as (N, K) = (block_size, head_dim) in row-major memory.
 // This is equivalent to (K, N) in column-major (DN) layout.
@@ -104,12 +105,14 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ ChipTensor *kj = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
     __gm__ ChipTensor *sij = reinterpret_cast<__gm__ ChipTensor *>(args[2]);
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
-    // args[4] = head_dim (128), args[5] = block_size
+    uint64_t head_dim = static_cast<uint64_t>(qi->shapes[1]);
 
-    if (q_tile_size == 16 && qi->shapes[1] <= 16) {
+    if (q_tile_size == 16 && head_dim <= 16) {
         qk_matmul_impl<16, 16, 16>(qi, kj, sij);
     } else if (q_tile_size == 16) {
         qk_matmul_impl<16, 128, 128>(qi, kj, sij);
+    } else if (head_dim == 256) {
+        qk_matmul_impl<64, 256, 64>(qi, kj, sij);
     } else {
         qk_matmul_impl<64, 128, 64>(qi, kj, sij);
     }

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -10,9 +10,10 @@
  */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
-// Operates on full tiles where M=q_tile_size, N=head_dim (128):
+// Operates on full tiles where M=q_tile_size and N=head_dim:
 //   Case1: oi/oi_new are (16, 128), mij/lij/mi/li are 16-element vectors
 //   Case2: oi/oi_new are (64, 128), mij/lij/mi/li are 64-element vectors
+//   Case3: oi/oi_new are (64, 256), mij/lij/mi/li are 64-element vectors
 //
 // Scalar layout strategy using TRESHAPE (zero-copy UB reshape):
 //   Scalars loaded as DN ColMajor (M, 1) for TROWEXPANDMUL/TROWEXPANDDIV.
@@ -237,12 +238,14 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[0]);
-    // args[10] = head_dim (128)
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[1]);
 
-    if (q_tile_size == 16 && oi_new->shapes[1] <= 16) {
+    if (q_tile_size == 16 && head_dim <= 16) {
         online_update_impl<16, 16>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     } else if (q_tile_size == 16) {
         online_update_impl<16, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    } else if (head_dim == 256) {
+        online_update_impl<64, 256>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     } else {
         online_update_impl<64, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     }

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/aic/aic_pv_matmul.cpp
@@ -25,9 +25,10 @@
 //   - Canonical 3-stage pipeline: TLOAD(MTE2) → TMOV(MTE1) → TMATMUL(M)
 //   - Reverse-dependency events ensure buffer safety across iterations
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128) -> (16, 128)
 //   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
+//   Case3: (64,  64) @ ( 64, 256) -> (64, 256)
 //
 // pij is bfloat16 (from softmax_prepare TCVT).
 // vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
@@ -158,9 +159,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr);
 
     uint64_t q_tile_size = static_cast<uint64_t>(pij_buf->shapes[0]);
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[1]);
 
     if (q_tile_size == 16) {
         pv_matmul_n_impl<16, 128, 128>(pij_base, val_base, oi_base, n_blocks, bt, bt_offset);
+    } else if (head_dim == 256) {
+        pv_matmul_n_impl<64, 64, 256>(pij_base, val_base, oi_base, n_blocks, bt, bt_offset);
     } else {
         pv_matmul_n_impl<64, 64, 128>(pij_base, val_base, oi_base, n_blocks, bt, bt_offset);
     }

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/aic/aic_qk_matmul.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/aic/aic_qk_matmul.cpp
@@ -20,9 +20,10 @@
 // Optimizations:
 //   - qi TLOAD hoisted before the loop (constant across all iterations)
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128).T -> (16, 128)
 //   Case2: (64, 128) @ (128,  64).T -> (64,  64)
+//   Case3: (64, 256) @ (256,  64).T -> (64,  64)
 //
 // Template: M=q_tile, K=head_dim, N=block_size
 
@@ -123,9 +124,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr);
 
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
+    uint64_t head_dim = static_cast<uint64_t>(qi->shapes[1]);
 
     if (q_tile_size == 16) {
         qk_matmul_n_impl<16, 128, 128>(qi_base, key_base, sij_base, n_blocks, bt, bt_offset);
+    } else if (head_dim == 256) {
+        qk_matmul_n_impl<64, 256, 64>(qi_base, key_base, sij_base, n_blocks, bt, bt_offset);
     } else {
         qk_matmul_n_impl<64, 128, 64>(qi_base, key_base, sij_base, n_blocks, bt, bt_offset);
     }

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/aiv/aiv_online_update.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/aiv/aiv_online_update.cpp
@@ -10,9 +10,10 @@
  */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
-// Operates on full tiles where M=q_tile_size, N=head_dim (128):
+// Operates on full tiles where M=q_tile_size and N=head_dim:
 //   Case1: oi/oi_new are (16, 128), mij/lij/mi/li are 16-element vectors
 //   Case2: oi/oi_new are (64, 128), mij/lij/mi/li are 64-element vectors
+//   Case3: oi/oi_new are (64, 256), mij/lij/mi/li are 64-element vectors
 //
 // Scalar layout strategy using TRESHAPE (zero-copy UB reshape):
 //   Scalars loaded as DN ColMajor (M, 1) for TROWEXPANDMUL/TROWEXPANDDIV.
@@ -237,10 +238,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[0]);
-    // args[10] = head_dim (128)
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[1]);
 
     if (q_tile_size == 16) {
         online_update_impl<16, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    } else if (head_dim == 256) {
+        online_update_impl<64, 256>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     } else {
         online_update_impl<64, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     }

--- a/tests/st/a2a3/host_build_graph/batch_paged_attention/test_batch_paged_attention.py
+++ b/tests/st/a2a3/host_build_graph/batch_paged_attention/test_batch_paged_attention.py
@@ -62,8 +62,6 @@ class TestBatchPagedAttentionHostBuildGraph(SceneTestCase):
         ],
     }
 
-    # The shared head_dim=256 kernels fail golden on both runtimes, so Case3
-    # is not a valid cross-runtime benchmark.
     CASES = [
         {
             "name": "Case1",
@@ -91,6 +89,22 @@ class TestBatchPagedAttentionHostBuildGraph(SceneTestCase):
                 "num_heads": 64,
                 "kv_head_num": 1,
                 "head_dim": 128,
+                "block_size": 64,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            "name": "Case3",
+            "platforms": ["a2a3"],
+            "manual": True,
+            "config": {"runtime_env": {"ring_heap": 1024 * 1024 * 1024}},
+            "params": {
+                "batch": 64,
+                "num_heads": 64,
+                "kv_head_num": 1,
+                "head_dim": 256,
                 "block_size": 64,
                 "context_len": 8192,
                 "max_model_len": 32768,

--- a/tests/st/a2a3/host_build_graph/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a2a3/host_build_graph/paged_attention_unroll/test_paged_attention_unroll.py
@@ -62,8 +62,6 @@ class TestPagedAttentionUnrollHostBuildGraph(SceneTestCase):
         ],
     }
 
-    # The shared head_dim=256 kernels fail golden on both runtimes, so Case3
-    # is not a valid cross-runtime benchmark.
     CASES = [
         {
             "name": "Case1",
@@ -88,6 +86,21 @@ class TestPagedAttentionUnrollHostBuildGraph(SceneTestCase):
                 "num_heads": 64,
                 "kv_head_num": 1,
                 "head_dim": 128,
+                "block_size": 64,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            "name": "Case3",
+            "platforms": ["a2a3"],
+            "manual": True,
+            "params": {
+                "batch": 64,
+                "num_heads": 64,
+                "kv_head_num": 1,
+                "head_dim": 256,
                 "block_size": 64,
                 "context_len": 8192,
                 "max_model_len": 32768,

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -14,9 +14,10 @@
 // Processes batch_count batches in a single kernel invocation.
 // Per-batch addresses are computed from global tensor bases + block_table lookup.
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128) -> (16, 128)
 //   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
+//   Case3: (64,  64) @ ( 64, 256) -> (64, 256)
 //
 // Template: M=q_tile, K=block_size, N=head_dim
 
@@ -120,6 +121,7 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
 
     uint64_t q_tile_size = static_cast<uint64_t>(pij_batch->shapes[0] / batch_count);
     uint64_t block_size = static_cast<uint64_t>(pij_batch->shapes[1]);
+    uint64_t head_dim = static_cast<uint64_t>(oi_new_batch->shapes[1]);
 
     if (q_tile_size == 16 && block_size <= 16) {
         pv_matmul_batch_impl<16, 16, 16>(
@@ -127,6 +129,10 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
         );
     } else if (q_tile_size == 16) {
         pv_matmul_batch_impl<16, 128, 128>(
+            pij_batch, value_cache, block_table_t, oi_new_batch, batch_count, block_idx, block_num, batch_start
+        );
+    } else if (head_dim == 256) {
+        pv_matmul_batch_impl<64, 64, 256>(
             pij_batch, value_cache, block_table_t, oi_new_batch, batch_count, block_idx, block_num, batch_start
         );
     } else {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -14,9 +14,10 @@
 // Processes batch_count batches in a single kernel invocation.
 // Per-batch addresses are computed from global tensor bases + block_table lookup.
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128).T -> (16, 128)
 //   Case2: (64, 128) @ (128,  64).T -> (64,  64)
+//   Case3: (64, 256) @ (256,  64).T -> (64,  64)
 //
 // Template: M=q_tile, K=head_dim, N=block_size
 
@@ -124,6 +125,7 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
 
     uint64_t q_tile_size = static_cast<uint64_t>(sij_batch->shapes[0] / batch_count);
     uint64_t block_size = static_cast<uint64_t>(sij_batch->shapes[1]);
+    uint64_t head_dim = static_cast<uint64_t>(query->shapes[1]);
 
     if (q_tile_size == 16 && block_size <= 16) {
         qk_matmul_batch_impl<16, 16, 16>(
@@ -132,6 +134,11 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
         );
     } else if (q_tile_size == 16) {
         qk_matmul_batch_impl<16, 128, 128>(
+            query, key_cache, block_table_t, sij_batch, batch_count, block_idx, q_offset, block_num, num_heads,
+            batch_start
+        );
+    } else if (head_dim == 256) {
+        qk_matmul_batch_impl<64, 256, 64>(
             query, key_cache, block_table_t, sij_batch, batch_count, block_idx, q_offset, block_num, num_heads,
             batch_start
         );

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -14,9 +14,10 @@
 // For each batch b, updates accumulators mi/li/oi with new block's mij/lij/oi_new.
 // On is_last, normalizes and writes to the output tensor at the correct batch offset.
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) -- q_tile=16, head_dim=128
 //   Case2: (64, 128) -- q_tile=64, head_dim=128
+//   Case3: (64, 256) -- q_tile=64, head_dim=256
 //
 // Scalar layout strategy:
 //   M scalar floats stored contiguously in GM can be loaded as either:
@@ -219,6 +220,11 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
         );
     } else if (q_tile_size == 16) {
         online_update_batch_impl<16, 128>(
+            mij_batch, lij_batch, oi_new_batch, mi_batch, li_batch, oi_batch, out, is_first, is_last, batch_count,
+            q_offset, num_heads, batch_start
+        );
+    } else if (head_dim == 256) {
+        online_update_batch_impl<64, 256>(
             mij_batch, lij_batch, oi_new_batch, mi_batch, li_batch, oi_batch, out, is_first, is_last, batch_count,
             q_offset, num_heads, batch_start
         );

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -26,9 +26,10 @@
 //   - Canonical 3-stage pipeline: TLOAD(MTE2) → TMOV(MTE1) → TMATMUL(M)
 //   - Reverse-dependency events ensure buffer safety across iterations
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128) -> (16, 128)
 //   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
+//   Case3: (64,  64) @ ( 64, 256) -> (64, 256)
 //
 // pij is bfloat16 (from softmax_prepare TCVT).
 // vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
@@ -159,9 +160,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr);
 
     uint64_t q_tile_size = static_cast<uint64_t>(pij_buf->shapes[0]);
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[1]);
 
     if (q_tile_size == 16) {
         pv_matmul_n_impl<16, 128, 128>(pij_base, val_base, oi_base, n_blocks, bt, bt_offset);
+    } else if (head_dim == 256) {
+        pv_matmul_n_impl<64, 64, 256>(pij_base, val_base, oi_base, n_blocks, bt, bt_offset);
     } else {
         pv_matmul_n_impl<64, 64, 128>(pij_base, val_base, oi_base, n_blocks, bt, bt_offset);
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -22,9 +22,10 @@
 //   - qi TLOAD hoisted before the loop (constant across all iterations)
 //   - Double-buffered L1 B tiles: prefetch next kj during current TMATMUL+TSTORE
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128).T -> (16, 128)
 //   Case2: (64, 128) @ (128,  64).T -> (64,  64)
+//   Case3: (64, 256) @ (256,  64).T -> (64,  64)
 //
 // Template: M=q_tile, K=head_dim, N=block_size
 
@@ -147,9 +148,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr);
 
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
+    uint64_t head_dim = static_cast<uint64_t>(qi->shapes[1]);
 
     if (q_tile_size == 16) {
         qk_matmul_n_impl<16, 128, 128>(qi_base, key_base, sij_base, n_blocks, bt, bt_offset);
+    } else if (head_dim == 256) {
+        qk_matmul_n_impl<64, 256, 64>(qi_base, key_base, sij_base, n_blocks, bt, bt_offset);
     } else {
         qk_matmul_n_impl<64, 128, 64>(qi_base, key_base, sij_base, n_blocks, bt, bt_offset);
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -10,9 +10,10 @@
  */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
-// Operates on full tiles where M=q_tile_size, N=head_dim (128):
+// Operates on full tiles where M=q_tile_size and N=head_dim:
 //   Case1: oi/oi_new are (16, 128), mij/lij/mi/li are 16-element vectors
 //   Case2: oi/oi_new are (64, 128), mij/lij/mi/li are 64-element vectors
+//   Case3: oi/oi_new are (64, 256), mij/lij/mi/li are 64-element vectors
 //
 // Scalar layout strategy using TRESHAPE (zero-copy UB reshape):
 //   Scalars loaded as DN ColMajor (M, 1) for TROWEXPANDMUL/TROWEXPANDDIV.
@@ -246,10 +247,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[0]);
-    // args[10] = head_dim (128)
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[1]);
 
     if (q_tile_size == 16) {
         online_update_impl<16, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    } else if (head_dim == 256) {
+        online_update_impl<64, 256>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     } else {
         online_update_impl<64, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aic/aic_pv_matmul.cpp
@@ -26,9 +26,10 @@
 //   - Canonical 3-stage pipeline: TLOAD(MTE2) → TMOV(MTE1) → TMATMUL(M)
 //   - Reverse-dependency events ensure buffer safety across iterations
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128) -> (16, 128)
 //   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
+//   Case3: (64,  64) @ ( 64, 256) -> (64, 256)
 //
 // pij is bfloat16 (from softmax_prepare TCVT).
 // vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
@@ -162,9 +163,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
 
     // pij_buf is 4D (1, 1, q_tile, n_blocks*block_size) to match qk's 4D output.
     uint64_t q_tile_size = static_cast<uint64_t>(pij_buf->shapes[2]);
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[3]);
 
     if (q_tile_size == 16) {
         pv_matmul_n_impl<16, 128, 128>(pij_buf, value_cache, block_table_t, oi_new, n_blocks, bt_offset);
+    } else if (head_dim == 256) {
+        pv_matmul_n_impl<64, 64, 256>(pij_buf, value_cache, block_table_t, oi_new, n_blocks, bt_offset);
     } else {
         pv_matmul_n_impl<64, 64, 128>(pij_buf, value_cache, block_table_t, oi_new, n_blocks, bt_offset);
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aic/aic_qk_matmul.cpp
@@ -21,9 +21,10 @@
 // Optimizations:
 //   - qi TLOAD hoisted before the loop (constant across all iterations)
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128).T -> (16, 128)
 //   Case2: (64, 128) @ (128,  64).T -> (64,  64)
+//   Case3: (64, 256) @ (256,  64).T -> (64,  64)
 //
 // Template: M=q_tile, K=head_dim, N=block_size
 
@@ -126,9 +127,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
 
     // qi is a 4D view (batch, q_len, num_heads_tile, head_dim); decode fixes batch=q_len=1.
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[2]);
+    uint64_t head_dim = static_cast<uint64_t>(qi->shapes[3]);
 
     if (q_tile_size == 16) {
         qk_matmul_n_impl<16, 128, 128>(qi, key_cache, block_table_t, sij_buf, n_blocks, bt_offset);
+    } else if (head_dim == 256) {
+        qk_matmul_n_impl<64, 256, 64>(qi, key_cache, block_table_t, sij_buf, n_blocks, bt_offset);
     } else {
         qk_matmul_n_impl<64, 128, 64>(qi, key_cache, block_table_t, sij_buf, n_blocks, bt_offset);
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aiv/aiv_online_update.cpp
@@ -11,9 +11,10 @@
 
 // Online Softmax Update + Normalize Kernel (AIV)
 //
-// Operates on full tiles where M=q_tile_size, N=head_dim (128):
+// Operates on full tiles where M=q_tile_size and N=head_dim:
 //   Case1: oi/oi_new are (16, 128), mij/lij/mi/li are 16-element vectors
 //   Case2: oi/oi_new are (64, 128), mij/lij/mi/li are 64-element vectors
+//   Case3: oi/oi_new are (64, 256), mij/lij/mi/li are 64-element vectors
 //
 // Scalar layout strategy using TRESHAPE (zero-copy UB reshape):
 //   Scalars loaded as DN ColMajor (M, 1) for TROWEXPANDMUL/TROWEXPANDDIV.
@@ -253,9 +254,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     // mij is 3D (1, 1, q_tile) to match softmax's 3D scalar output.
     uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[2]);
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[3]);
 
     if (q_tile_size == 16) {
         online_update_impl<16, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    } else if (head_dim == 256) {
+        online_update_impl<64, 256>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     } else {
         online_update_impl<64, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     }

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -10,9 +10,10 @@
  */
 // PV Matmul Kernel: pij(M, K) @ vj(K, N) -> oi_new(M, N)
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128) -> (16, 128)
 //   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
+//   Case3: (64,  64) @ ( 64, 256) -> (64, 256)
 //
 // pij is bfloat16 (converted from fp32 in softmax_prepare via TCVT).
 // vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
@@ -103,12 +104,14 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ ChipTensor *vj = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
     __gm__ ChipTensor *oi_new = reinterpret_cast<__gm__ ChipTensor *>(args[2]);
     uint64_t q_tile_size = static_cast<uint64_t>(pij->shapes[0]);
-    // args[4] = block_size, args[5] = head_dim
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[1]);
 
     if (q_tile_size == 16 && pij->shapes[1] <= 16) {
         pv_matmul_impl<16, 16, 16>(pij, vj, oi_new);
     } else if (q_tile_size == 16) {
         pv_matmul_impl<16, 128, 128>(pij, vj, oi_new);
+    } else if (head_dim == 256) {
+        pv_matmul_impl<64, 64, 256>(pij, vj, oi_new);
     } else {
         pv_matmul_impl<64, 64, 128>(pij, vj, oi_new);
     }

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -10,9 +10,10 @@
  */
 // QK Matmul Kernel: qi(M, K) @ kj.T(K, N) -> sij(M, N)
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128).T -> (16, 128)
 //   Case2: (64, 128) @ (128,  64).T -> (64,  64)
+//   Case3: (64, 256) @ (256,  64).T -> (64,  64)
 //
 // kj is stored as (N, K) = (block_size, head_dim) in row-major memory.
 // This is equivalent to (K, N) in column-major (DN) layout.
@@ -104,12 +105,14 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ ChipTensor *kj = reinterpret_cast<__gm__ ChipTensor *>(args[1]);
     __gm__ ChipTensor *sij = reinterpret_cast<__gm__ ChipTensor *>(args[2]);
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
-    // args[4] = head_dim (128), args[5] = block_size
+    uint64_t head_dim = static_cast<uint64_t>(qi->shapes[1]);
 
-    if (q_tile_size == 16 && qi->shapes[1] <= 16) {
+    if (q_tile_size == 16 && head_dim <= 16) {
         qk_matmul_impl<16, 16, 16>(qi, kj, sij);
     } else if (q_tile_size == 16) {
         qk_matmul_impl<16, 128, 128>(qi, kj, sij);
+    } else if (head_dim == 256) {
+        qk_matmul_impl<64, 256, 64>(qi, kj, sij);
     } else {
         qk_matmul_impl<64, 128, 64>(qi, kj, sij);
     }

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -10,9 +10,10 @@
  */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
-// Operates on full tiles where M=q_tile_size, N=head_dim (128):
+// Operates on full tiles where M=q_tile_size and N=head_dim:
 //   Case1: oi/oi_new are (16, 128), mij/lij/mi/li are 16-element vectors
 //   Case2: oi/oi_new are (64, 128), mij/lij/mi/li are 64-element vectors
+//   Case3: oi/oi_new are (64, 256), mij/lij/mi/li are 64-element vectors
 //
 // Scalar layout strategy using TRESHAPE (zero-copy UB reshape):
 //   Scalars loaded as DN ColMajor (M, 1) for TROWEXPANDMUL/TROWEXPANDDIV.
@@ -237,12 +238,14 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[0]);
-    // args[10] = head_dim (128)
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[1]);
 
-    if (q_tile_size == 16 && oi_new->shapes[1] <= 16) {
+    if (q_tile_size == 16 && head_dim <= 16) {
         online_update_impl<16, 16>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     } else if (q_tile_size == 16) {
         online_update_impl<16, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    } else if (head_dim == 256) {
+        online_update_impl<64, 256>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     } else {
         online_update_impl<64, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     }

--- a/tests/st/a5/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_pv_matmul.cpp
@@ -14,9 +14,10 @@
 // Processes batch_count batches in a single kernel invocation.
 // Per-batch addresses are computed from global tensor bases + block_table lookup.
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128) -> (16, 128)
 //   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
+//   Case3: (64,  64) @ ( 64, 256) -> (64, 256)
 //
 // Template: M=q_tile, K=block_size, N=head_dim
 
@@ -119,6 +120,7 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
 
     uint64_t q_tile_size = static_cast<uint64_t>(pij_batch->shapes[0] / batch_count);
     uint64_t block_size = static_cast<uint64_t>(pij_batch->shapes[1]);
+    uint64_t head_dim = static_cast<uint64_t>(oi_new_batch->shapes[1]);
 
     if (q_tile_size == 16 && block_size <= 16) {
         pv_matmul_batch_impl<16, 16, 16>(
@@ -126,6 +128,10 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
         );
     } else if (q_tile_size == 16) {
         pv_matmul_batch_impl<16, 128, 128>(
+            pij_batch, value_cache, block_table_t, oi_new_batch, batch_count, block_idx, block_num, batch_start
+        );
+    } else if (head_dim == 256) {
+        pv_matmul_batch_impl<64, 64, 256>(
             pij_batch, value_cache, block_table_t, oi_new_batch, batch_count, block_idx, block_num, batch_start
         );
     } else {

--- a/tests/st/a5/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/batch_paged_attention/kernels/aic/aic_qk_matmul.cpp
@@ -14,9 +14,10 @@
 // Processes batch_count batches in a single kernel invocation.
 // Per-batch addresses are computed from global tensor bases + block_table lookup.
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128).T -> (16, 128)
 //   Case2: (64, 128) @ (128,  64).T -> (64,  64)
+//   Case3: (64, 256) @ (256,  64).T -> (64,  64)
 //
 // Template: M=q_tile, K=head_dim, N=block_size
 
@@ -124,6 +125,7 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
 
     uint64_t q_tile_size = static_cast<uint64_t>(sij_batch->shapes[0] / batch_count);
     uint64_t block_size = static_cast<uint64_t>(sij_batch->shapes[1]);
+    uint64_t head_dim = static_cast<uint64_t>(query->shapes[1]);
 
     if (q_tile_size == 16 && block_size <= 16) {
         qk_matmul_batch_impl<16, 16, 16>(
@@ -132,6 +134,11 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
         );
     } else if (q_tile_size == 16) {
         qk_matmul_batch_impl<16, 128, 128>(
+            query, key_cache, block_table_t, sij_batch, batch_count, block_idx, q_offset, block_num, num_heads,
+            batch_start
+        );
+    } else if (head_dim == 256) {
+        qk_matmul_batch_impl<64, 256, 64>(
             query, key_cache, block_table_t, sij_batch, batch_count, block_idx, q_offset, block_num, num_heads,
             batch_start
         );

--- a/tests/st/a5/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/batch_paged_attention/kernels/aiv/aiv_online_update.cpp
@@ -14,9 +14,10 @@
 // For each batch b, updates accumulators mi/li/oi with new block's mij/lij/oi_new.
 // On is_last, normalizes and writes to the output tensor at the correct batch offset.
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) -- q_tile=16, head_dim=128
 //   Case2: (64, 128) -- q_tile=64, head_dim=128
+//   Case3: (64, 256) -- q_tile=64, head_dim=256
 //
 // Scalar layout strategy:
 //   M scalar floats stored contiguously in GM can be loaded as either:
@@ -208,6 +209,11 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
         );
     } else if (q_tile_size == 16) {
         online_update_batch_impl<16, 128>(
+            mij_batch, lij_batch, oi_new_batch, mi_batch, li_batch, oi_batch, out, is_first, is_last, batch_count,
+            q_offset, num_heads, batch_start
+        );
+    } else if (head_dim == 256) {
+        online_update_batch_impl<64, 256>(
             mij_batch, lij_batch, oi_new_batch, mi_batch, li_batch, oi_batch, out, is_first, is_last, batch_count,
             q_offset, num_heads, batch_start
         );

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -25,9 +25,10 @@
 //   - Canonical 3-stage pipeline: TLOAD(MTE2) → TMOV(MTE1) → TMATMUL(M)
 //   - Reverse-dependency events ensure buffer safety across iterations
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128) -> (16, 128)
 //   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
+//   Case3: (64,  64) @ ( 64, 256) -> (64, 256)
 //
 // pij is bfloat16 (from softmax_prepare TCVT).
 // vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
@@ -158,9 +159,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr);
 
     uint64_t q_tile_size = static_cast<uint64_t>(pij_buf->shapes[0]);
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[1]);
 
     if (q_tile_size == 16) {
         pv_matmul_n_impl<16, 128, 128>(pij_base, val_base, oi_base, n_blocks, bt, bt_offset);
+    } else if (head_dim == 256) {
+        pv_matmul_n_impl<64, 64, 256>(pij_base, val_base, oi_base, n_blocks, bt, bt_offset);
     } else {
         pv_matmul_n_impl<64, 64, 128>(pij_base, val_base, oi_base, n_blocks, bt, bt_offset);
     }

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_qk_matmul.cpp
@@ -21,9 +21,10 @@
 //   - qi TLOAD hoisted before the loop (constant across all iterations)
 //   - Double-buffered L1 B tiles: prefetch next kj during current TMATMUL+TSTORE
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128).T -> (16, 128)
 //   Case2: (64, 128) @ (128,  64).T -> (64,  64)
+//   Case3: (64, 256) @ (256,  64).T -> (64,  64)
 //
 // Template: M=q_tile, K=head_dim, N=block_size
 
@@ -146,9 +147,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     __gm__ int32_t *bt = reinterpret_cast<__gm__ int32_t *>(block_table_t->buffer.addr);
 
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[0]);
+    uint64_t head_dim = static_cast<uint64_t>(qi->shapes[1]);
 
     if (q_tile_size == 16) {
         qk_matmul_n_impl<16, 128, 128>(qi_base, key_base, sij_base, n_blocks, bt, bt_offset);
+    } else if (head_dim == 256) {
+        qk_matmul_n_impl<64, 256, 64>(qi_base, key_base, sij_base, n_blocks, bt, bt_offset);
     } else {
         qk_matmul_n_impl<64, 128, 64>(qi_base, key_base, sij_base, n_blocks, bt, bt_offset);
     }

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aiv/aiv_online_update.cpp
@@ -10,9 +10,10 @@
  */
 // Online Softmax Update + Normalize Kernel (AIV)
 //
-// Operates on full tiles where M=q_tile_size, N=head_dim (128):
+// Operates on full tiles where M=q_tile_size and N=head_dim:
 //   Case1: oi/oi_new are (16, 128), mij/lij/mi/li are 16-element vectors
 //   Case2: oi/oi_new are (64, 128), mij/lij/mi/li are 64-element vectors
+//   Case3: oi/oi_new are (64, 256), mij/lij/mi/li are 64-element vectors
 //
 // Scalar layout strategy using TRESHAPE (zero-copy UB reshape):
 //   Scalars loaded as DN ColMajor (M, 1) for TROWEXPANDMUL/TROWEXPANDDIV.
@@ -240,10 +241,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     uint64_t is_first = static_cast<uint64_t>(args[7]);
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[0]);
-    // args[10] = head_dim (128)
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[1]);
 
     if (q_tile_size == 16) {
         online_update_impl<16, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    } else if (head_dim == 256) {
+        online_update_impl<64, 256>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     } else {
         online_update_impl<64, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     }

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aic/aic_pv_matmul.cpp
@@ -26,9 +26,10 @@
 //   - Canonical 3-stage pipeline: TLOAD(MTE2) → TMOV(MTE1) → TMATMUL(M)
 //   - Reverse-dependency events ensure buffer safety across iterations
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128) -> (16, 128)
 //   Case2: (64,  64) @ ( 64, 128) -> (64, 128)
+//   Case3: (64,  64) @ ( 64, 256) -> (64, 256)
 //
 // pij is bfloat16 (from softmax_prepare TCVT).
 // vj is stored as (K, N) = (block_size, head_dim) in row-major (ND) layout.
@@ -163,9 +164,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
 
     // pij_buf is 4D (1, 1, q_tile, n_blocks*block_size) to match qk's 4D output.
     uint64_t q_tile_size = static_cast<uint64_t>(pij_buf->shapes[2]);
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[3]);
 
     if (q_tile_size == 16) {
         pv_matmul_n_impl<16, 128, 128>(pij_buf, value_cache, block_table_t, oi_new, n_blocks, bt_offset);
+    } else if (head_dim == 256) {
+        pv_matmul_n_impl<64, 64, 256>(pij_buf, value_cache, block_table_t, oi_new, n_blocks, bt_offset);
     } else {
         pv_matmul_n_impl<64, 64, 128>(pij_buf, value_cache, block_table_t, oi_new, n_blocks, bt_offset);
     }

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aic/aic_qk_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aic/aic_qk_matmul.cpp
@@ -21,9 +21,10 @@
 // Optimizations:
 //   - qi TLOAD hoisted before the loop (constant across all iterations)
 //
-// Supports two tile configurations via runtime dispatch:
+// Supports three tile configurations via runtime dispatch:
 //   Case1: (16, 128) @ (128, 128).T -> (16, 128)
 //   Case2: (64, 128) @ (128,  64).T -> (64,  64)
+//   Case3: (64, 256) @ (256,  64).T -> (64,  64)
 //
 // Template: M=q_tile, K=head_dim, N=block_size
 
@@ -128,9 +129,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
 
     // qi is a 4D view (batch, q_len, num_heads_tile, head_dim); decode fixes batch=q_len=1.
     uint64_t q_tile_size = static_cast<uint64_t>(qi->shapes[2]);
+    uint64_t head_dim = static_cast<uint64_t>(qi->shapes[3]);
 
     if (q_tile_size == 16) {
         qk_matmul_n_impl<16, 128, 128>(qi, key_cache, block_table_t, sij_buf, n_blocks, bt_offset);
+    } else if (head_dim == 256) {
+        qk_matmul_n_impl<64, 256, 64>(qi, key_cache, block_table_t, sij_buf, n_blocks, bt_offset);
     } else {
         qk_matmul_n_impl<64, 128, 64>(qi, key_cache, block_table_t, sij_buf, n_blocks, bt_offset);
     }

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aiv/aiv_online_update.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aiv/aiv_online_update.cpp
@@ -11,9 +11,10 @@
 
 // Online Softmax Update + Normalize Kernel (AIV)
 //
-// Operates on full tiles where M=q_tile_size, N=head_dim (128):
+// Operates on full tiles where M=q_tile_size and N=head_dim:
 //   Case1: oi/oi_new are (16, 128), mij/lij/mi/li are 16-element vectors
 //   Case2: oi/oi_new are (64, 128), mij/lij/mi/li are 64-element vectors
+//   Case3: oi/oi_new are (64, 256), mij/lij/mi/li are 64-element vectors
 //
 // Scalar layout strategy using TRESHAPE (zero-copy UB reshape):
 //   Scalars loaded as DN ColMajor (M, 1) for TROWEXPANDMUL/TROWEXPANDDIV.
@@ -242,9 +243,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     uint64_t is_last = static_cast<uint64_t>(args[8]);
     // mij is 3D (1, 1, q_tile) to match softmax's 3D scalar output.
     uint64_t q_tile_size = static_cast<uint64_t>(mij->shapes[2]);
+    uint64_t head_dim = static_cast<uint64_t>(oi_new->shapes[3]);
 
     if (q_tile_size == 16) {
         online_update_impl<16, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
+    } else if (head_dim == 256) {
+        online_update_impl<64, 256>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     } else {
         online_update_impl<64, 128>(mij, lij, oi_new, mi, li, oi, is_first, is_last, dst);
     }


### PR DESCRIPTION
## Summary

- Support the paged-attention `Case3` tuple `(q_tile, head_dim, block_size) = (64, 256, 64)` in the 11 affected TMR variants and the standalone A5 host-build-graph kernel copies.
- Restore `Case3` in the three A2/A3 host-build-graph wrappers that share the corrected TMR kernels.
- Preserve the existing small-shape and 128-wide dispatch paths, including the batched two-dimensional query layout.
- Keep the task ABI unchanged.

## Scope

These scene kernels dispatch the shapes exercised by their cases; they are not a general paged-attention shape dispatcher. This PR does not claim support for every `head_dim=256` combination. In particular, no current case uses `q_tile=16, head_dim=256`, and the existing fallback behavior for unsupported shapes is unchanged.

## Root cause

The `Case3` workloads use `head_dim=256`, while the affected kernels dispatched the QK, PV, and online-update operations to templates whose head-dimension axis was fixed at 128. As a result, QK reduced only the first 128 elements, and PV/online-update produced or normalized only the first 128 output elements.

The A5 `host_build_graph/paged_attention` scene carries independent kernel copies rather than referencing `TMR_CASE`, so those copies require the same dispatch fix for its existing `Case3`.

Three A2/A3 host-build-graph wrappers omitted `Case3` when they were introduced because these shared kernels failed golden at 256 width. They now reuse the corrected kernels, so the matching case definitions are restored.

## Fix

Select the existing small/128-wide templates or the new 256-wide template instantiations from the runtime tensor shapes:

- QK uses the query tensor's head dimension for the reduction width.
- PV and online-update use the output tensor's head dimension for the output width.
- Other dispatch behavior and the kernel argument layout remain unchanged.

The restored batched HBG `Case3` uses a case-local 1 GiB graph heap. Its 256-wide graph exhausts the 512 MiB setting used by the existing 128-wide cases.

## Case3 resource budget

- QK L0A/L0B: 32 + 32 KiB.
- PV L0C `AccTile`: 64 KiB.
- Online-update UB: approximately 130 KiB.

These budgets are specific to the supported 256-wide Case3 and are one reason this change should not be read as allowing arbitrary wider shapes.

## Case3 validation

| Platform | Area | Variant | Case | Result |
| --- | --- | --- | --- | --- |
| A2/A3 | example | `paged_attention` | existing `Case3` | Passed on A2 onboard |
| A2/A3 | example | `paged_attention_manual_scope` | existing `Case3` | Passed on A2 onboard |
| A2/A3 | example | `paged_attention_unroll_manual_scope` | existing `Case3` | Passed on A2 onboard |
| A2/A3 | ST | `batch_paged_attention` | existing `Case3` | Passed on A2 onboard |
| A2/A3 | ST | `paged_attention_unroll` | existing `Case3` | Passed on A2 onboard |
| A2/A3 | ST | `paged_attention_unroll_4dims` | existing `Case3` | Passed on A2 onboard |
| A2/A3 | HBG example | `paged_attention_unroll_manual_scope` | restored `Case3` | Passed on A2 onboard |
| A2/A3 | HBG ST | `batch_paged_attention` | restored `Case3`, 1 GiB heap | Passed on A2 onboard |
| A2/A3 | HBG ST | `paged_attention_unroll` | restored `Case3` | Passed on A2 onboard |
| A5 | example | `paged_attention` | existing `Case3` | Passed on A5 onboard |
| A5 | example | `paged_attention_unroll_manual_scope` | existing `Case3` | Passed on A5 onboard |
| A5 | ST | `batch_paged_attention` | existing `Case3` | Passed on A5 onboard |
| A5 | ST | `paged_attention_unroll` | existing `Case3` | Passed on A5 onboard |
| A5 | ST | `paged_attention_unroll_4dims` | existing `Case3` | Passed on A5 onboard |
| A5 | HBG ST | `paged_attention` | existing `Case3` | Requires A5 onboard; A5sim `SmallCase1` compile/smoke passed |

Per-PR CI excludes these manual onboard-only `Case3` cases, so the green CI checks the existing small/128-wide paths rather than the 256-wide runtime result.

## Additional checks

- All pre-commit hooks passed after rebasing onto the latest `main`.
- All three restored A2/A3 HBG `Case3` workloads passed standalone golden validation inside an allocated `task-submit` job.

Part of #1832.
