### PR TITLE
Refactor: express the DSv4 MoE tile-loop control flow as dispatch predicates

### DIFF
--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/README.md
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/README.md
@@ -13,24 +13,37 @@ device can execute what the host built. It is deliberately not a numerics test.
 ## What differs from the TMR case
 
 `kernels/orchestration/decode_fwd_graph.cpp` — the file the test points at — is
-the TMR orchestration with one runtime-specific rewrite, additionally recasting
-the 20-iteration decoder layer loop (40 of the 43 layers) as one
-`rt_submit_graph` per iteration: the
+the TMR orchestration recast as a Graph, with **no runtime-specific rewrite left**:
+the 20-iteration decoder layer loop (40 of the 43 layers) becomes one
+`rt_submit_graph` per iteration, so the
 layer's task set becomes the Graph body (a free function reading its per-layer
 views, scales and indices through `GraphTaskArgs`, positionally), and the host
 records a 744-node Definition once instead of submitting the loop's ~15600
 tasks individually. The runtime is untouched.
 
-| Edit | Sites | Why |
-| ---- | ----- | --- |
-| `get_tensor_data(recv_count_out, …)` → `HBG_RECV_ROWS_PER_EXPERT` | 10 | HBG builds the whole graph before the device runs anything, so a read of a **task-produced** tensor has no value to return. The constant holds the per-expert tile loops at their real trip count (`ceil(16/16) == 1`, which is what the `h_i8 [512, 2048]` layout budgets per expert). |
+The read that used to force a rewrite was `recv_count_out[expert][0]`, driving
+the ten MoE per-expert tile loops. HBG builds the whole graph before the device
+runs anything, so a read of a **task-produced** tensor has no value to return
+here, and the ten sites stood a constant in. Both runtimes now express that
+control flow as **dispatch predicates** instead: a static per-expert tile
+grid, with each of a tile's six tasks predicated on
+`recv_count_out[expert][0] > t0`. The scheduler evaluates it at the dispatch
+point, on device, where the value is current — so the same source is correct
+under both runtimes and the HBG copy no longer encodes a routing the fixture
+does not have. The one value the loops computed from the count,
+`valid_rows = min(count - t0, 16)`, moves into the `exp_gate_up_act*` kernels
+the same way the scale reads did: the orchestration passes `recv_count_out` as
+an extra tensor input and each kernel derives the row count from GM in
+`kernel_entry`.
 
-The only other `get_tensor_data` read left is `ext_num_tokens_per_owner`: its
-value feeds tile counts and launch block numbers — orchestration control flow
-that must run where the graph is built. The 30 former `hc_attn_scale_*` /
-`hc_ffn_scale_*` reads moved data, not control flow, and are gone from both
-runtimes: each `split_pre_post*` / `comb_sinkhorn*` kernel now takes the scale
-view as an extra tensor input and reads its elements from GM itself.
+The only `get_tensor_data` read left is `ext_num_tokens_per_owner`. It is an
+**external** tensor, which the runtime stages with a host view, and it feeds
+`set_block_num` — a launch parameter a predicate cannot express, because a
+predicate decides whether a task dispatches, not how wide it is. The 30 former
+`hc_attn_scale_*` / `hc_ffn_scale_*` reads moved data, not control flow, and are
+gone from both runtimes: each `split_pre_post*` / `comb_sinkhorn*` kernel now
+takes the scale view as an extra tensor input and reads its elements from GM
+itself.
 
 The six former orchestration-side initializations are now identical under both
 runtimes. Each `sh_gate_up_act_q*` producer clears its own two padded
@@ -38,17 +51,19 @@ runtimes. Each `sh_gate_up_act_q*` producer clears its own two padded
 split-K `hc_head_linear` AtomicAdds. The host therefore never writes a GM-heap
 device address.
 
-Everything else — submit order, dependencies, scope nesting, and the
-orchestration-side `valid_rows = min(n_rows - t0, 16)` — is byte-identical to
-the TMR source inside the Graph body. The graph keeps the size and shape of the
-real one (the 15971 device-side tasks; 1131 host-submitted with the Graph
-collapse) but not the fixture's routing, hence `skip_golden`.
+Everything else — submit order, dependencies, scope nesting — is
+byte-identical to the TMR source inside the Graph body. The graph keeps the
+size and shape of the real one.
+
+`skip_golden` is inherited from the TMR case, which is itself a
+completion/smoke case: no full-network torch reference exists upstream either,
+and component-level goldens live with the standalone kernels in pypto-lib.
 
 ## Status: the host records the Definition; device replay is blocked in activation
 
 With the Graph form the host records the 744-node Definition and boots with
-**1131 tasks on host** (down from 15991 when every task is submitted
-individually) — this is measured, on both ranks. The device-side replay of a
+**1131 tasks on host**, an order of magnitude below submitting every task
+individually — this is measured, on both ranks. The device-side replay of a
 Definition that large is **not yet exercised**: an unskipped run fails in Graph
 activation (`sched_error_code=5 INVALID_ARGS` from the scheduler's graph
 queues), so the recorded bodies never replay.

--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd_graph.cpp
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd_graph.cpp
@@ -17,16 +17,16 @@
 
 #include "pto_orchestration_api.h"
 
-// Rows this orchestration assumes each expert receives.
+// Rows this orchestration budgets for each expert.
 //
-// The value it replaces is read from recv_count_out, a tensor a task on the
-// device produces. host_build_graph builds the whole graph before the device
-// executes anything, so that read has no value to return here. Standing in a
-// constant keeps the per-expert tile loops at their real trip count
-// (ceil(16/16) == 1, the h_i8 [512, 2048] layout budgets 16 rows per expert),
-// so the graph this builds keeps the size and shape of the real one. The
-// routing it encodes is not the fixture's, which is why the case skips golden.
-constexpr int32_t HBG_RECV_ROWS_PER_EXPERT = 16;
+// The count an expert actually receives is `recv_count_out[expert][0]`, written
+// on the device by `dispatch_meta`. The budget is what the `h_i8 [512, 2048]`
+// layout reserves: 32 experts, 16 rows each, and a tile is 16 rows, so the
+// per-expert tile grid is one tile wide and fixed at build time. Each of a
+// tile's tasks carries a dispatch predicate on that element instead, so the
+// scheduler reads the count at the dispatch point and an expert whose count
+// does not reach the tile's first row has the tile's tasks retired inline.
+constexpr int32_t EXPERT_ROWS_BUDGET = 16;
 
 extern "C" {
 
@@ -1811,20 +1811,21 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                 for (int64_t local_i_inline2779_inline10990 = 0; local_i_inline2779_inline10990 < 32;
                      local_i_inline2779_inline10990 += 1) {
                     int64_t flat_base_inline2774_inline11027 = (local_i_inline2779_inline10990 * 16);
-                    uint32_t indices_n_rows_inline2782_inline11249[2] = {
-                        static_cast<uint32_t>(local_i_inline2779_inline10990), 0
-                    };
-                    int32_t n_rows_inline2782_inline11249 = HBG_RECV_ROWS_PER_EXPERT;
+                    int32_t n_rows_inline2782_inline11249 = EXPERT_ROWS_BUDGET;
                     int64_t n_tiles_inline2780_inline11222 =
                         ((static_cast<int64_t>(n_rows_inline2782_inline11249) + 15) / 16);
                     for (int64_t t_inline2778_inline11250 = 0;
                          t_inline2778_inline11250 < n_tiles_inline2780_inline11222; t_inline2778_inline11250 += 1) {
                         int64_t t0_inline2784_inline11251 = (t_inline2778_inline11250 * 16);
+                        CoreTaskPredicate expert_rows_pred;
+                        expert_rows_pred.operand.tensor = &recv_count_out_inline11145;
+                        expert_rows_pred.operand.ndims = 2;
+                        expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_i_inline2779_inline10990);
+                        expert_rows_pred.operand.indices[1] = 0;
+                        expert_rows_pred.op = PredicateOp::GT;
+                        expert_rows_pred.target = t0_inline2784_inline11251;
                         int64_t flat_t0_inline2786_inline11215 =
                             (flat_base_inline2774_inline11027 + t0_inline2784_inline11251);
-                        int64_t valid_rows_inline2759_inline11253 = std::min<int64_t>(
-                            (static_cast<int64_t>(n_rows_inline2782_inline11249) - t0_inline2784_inline11251), 16
-                        );
                         PTO2_SCOPE() {
                             uint32_t gate_tile_i32_inline2749_inline11102_ci_shapes[2] = {16, 2048};
                             TensorCreateInfo gate_tile_i32_inline2749_inline11102_ci(
@@ -1854,6 +1855,7 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                             params_t188.add_scalar(flat_t0_inline2786_inline11215);
                             params_t188.add_scalar(local_i_inline2779_inline10990);
                             params_t188.launch_spec.set_block_num(2);
+                            params_t188.set_predicate(expert_rows_pred);
                             rt_submit_aic_task(195, params_t188);
 
                             // Spmd exp_up_mm_spmd_1: exp_up_mm_1
@@ -1864,6 +1866,7 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                             params_t189.add_scalar(flat_t0_inline2786_inline11215);
                             params_t189.add_scalar(local_i_inline2779_inline10990);
                             params_t189.launch_spec.set_block_num(2);
+                            params_t189.set_predicate(expert_rows_pred);
                             rt_submit_aic_task(196, params_t189);
 
                             // Spmd exp_gate_up_act_spmd_1: exp_gate_up_act_1
@@ -1874,10 +1877,11 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                             params_t190.add_input(recv_scale_out_inline10979);
                             params_t190.add_input(routed_w1_scale_csa_inline535);
                             params_t190.add_input(routed_w3_scale_csa_inline713);
+                            params_t190.add_input(recv_count_out_inline11145);
                             params_t190.add_scalar(local_i_inline2779_inline10990);
                             params_t190.add_scalar(t0_inline2784_inline11251);
-                            params_t190.add_scalar(valid_rows_inline2759_inline11253);
                             params_t190.launch_spec.set_block_num(4);
+                            params_t190.set_predicate(expert_rows_pred);
                             rt_submit_aiv_task(197, params_t190);
                             uint32_t h_tile_i8_inline2806_inline11087_offsets[2] = {
                                 static_cast<uint32_t>(flat_t0_inline2786_inline11215), 0
@@ -1928,6 +1932,7 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                             params_t191.add_input(h_tile_fp32_inline2744_inline11230);
                             params_t191.add_inout(h_tile_scale_dq_inline2808_inline10968);
                             params_t191.add_inout(h_tile_i8_inline2806_inline11087);
+                            params_t191.set_predicate(expert_rows_pred);
                             rt_submit_aiv_task(198, params_t191);
                         }
                     }
@@ -1936,10 +1941,7 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                     for (int64_t local_e_inline2742_inline11189 = 0; local_e_inline2742_inline11189 < 32;
                          local_e_inline2742_inline11189 += 1) {
                         int64_t e_flat_base_inline2746_inline11067 = (local_e_inline2742_inline11189 * 16);
-                        uint32_t indices_e_rows_inline2760_inline10962[2] = {
-                            static_cast<uint32_t>(local_e_inline2742_inline11189), 0
-                        };
-                        int32_t e_rows_inline2760_inline10962 = HBG_RECV_ROWS_PER_EXPERT;
+                        int32_t e_rows_inline2760_inline10962 = EXPERT_ROWS_BUDGET;
                         int64_t e_tiles_inline2741_inline11191 =
                             ((static_cast<int64_t>(e_rows_inline2760_inline10962) + 15) / 16);
                         for (int64_t tt_inline2776_inline10961 = 0;
@@ -1952,6 +1954,13 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                             TaskOutputTensors alloc_84 = alloc_tensors(y_i32_inline2737_inline11086_ci);
                             const ChipTensor &y_i32_inline2737_inline11086 = alloc_84.get_ref(0);
                             int64_t tt0_inline2740_inline10960 = (tt_inline2776_inline10961 * 16);
+                            CoreTaskPredicate expert_rows_pred;
+                            expert_rows_pred.operand.tensor = &recv_count_out_inline11145;
+                            expert_rows_pred.operand.ndims = 2;
+                            expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_e_inline2742_inline11189);
+                            expert_rows_pred.operand.indices[1] = 0;
+                            expert_rows_pred.op = PredicateOp::GT;
+                            expert_rows_pred.target = tt0_inline2740_inline10960;
                             int64_t flat_tt0_inline2738_inline11157 =
                                 (e_flat_base_inline2746_inline11067 + tt0_inline2740_inline10960);
                             uint32_t h_tile_i8_inline2806_inline11087__ssa_v4_offsets[2] = {
@@ -2010,6 +2019,7 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                             params_t192.add_scalar(local_e_inline2742_inline11189);
                             params_t192.launch_spec.set_block_num(4);
                             params_t192.set_allow_early_resolve(true);
+                            params_t192.set_predicate(expert_rows_pred);
                             TaskOutputTensors task_192_outs = rt_submit_aic_task(199, params_t192);
                             uint32_t recv_y_tile_inline2730_inline10957_offsets[2] = {
                                 static_cast<uint32_t>(flat_tt0_inline2738_inline11157), 0
@@ -2045,6 +2055,7 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                             params_t193.add_scalar(tt0_inline2740_inline10960);
                             params_t193.launch_spec.set_block_num(1);
                             params_t193.set_allow_early_resolve(true);
+                            params_t193.set_predicate(expert_rows_pred);
                             TaskOutputTensors task_193_outs = rt_submit_aiv_task(200, params_t193);
                         }
                     }
@@ -3404,20 +3415,21 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                 for (int64_t local_i_inline2779_inline11869 = 0; local_i_inline2779_inline11869 < 32;
                      local_i_inline2779_inline11869 += 1) {
                     int64_t flat_base_inline2774_inline11906 = (local_i_inline2779_inline11869 * 16);
-                    uint32_t indices_n_rows_inline2782_inline12128[2] = {
-                        static_cast<uint32_t>(local_i_inline2779_inline11869), 0
-                    };
-                    int32_t n_rows_inline2782_inline12128 = HBG_RECV_ROWS_PER_EXPERT;
+                    int32_t n_rows_inline2782_inline12128 = EXPERT_ROWS_BUDGET;
                     int64_t n_tiles_inline2780_inline12101 =
                         ((static_cast<int64_t>(n_rows_inline2782_inline12128) + 15) / 16);
                     for (int64_t t_inline2778_inline12129 = 0;
                          t_inline2778_inline12129 < n_tiles_inline2780_inline12101; t_inline2778_inline12129 += 1) {
                         int64_t t0_inline2784_inline12130 = (t_inline2778_inline12129 * 16);
+                        CoreTaskPredicate expert_rows_pred;
+                        expert_rows_pred.operand.tensor = &recv_count_out_inline12024;
+                        expert_rows_pred.operand.ndims = 2;
+                        expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_i_inline2779_inline11869);
+                        expert_rows_pred.operand.indices[1] = 0;
+                        expert_rows_pred.op = PredicateOp::GT;
+                        expert_rows_pred.target = t0_inline2784_inline12130;
                         int64_t flat_t0_inline2786_inline12094 =
                             (flat_base_inline2774_inline11906 + t0_inline2784_inline12130);
-                        int64_t valid_rows_inline2759_inline12132 = std::min<int64_t>(
-                            (static_cast<int64_t>(n_rows_inline2782_inline12128) - t0_inline2784_inline12130), 16
-                        );
                         PTO2_SCOPE() {
                             uint32_t gate_tile_i32_inline2749_inline11981_ci_shapes[2] = {16, 2048};
                             TensorCreateInfo gate_tile_i32_inline2749_inline11981_ci(
@@ -3447,6 +3459,7 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                             params_t252.add_scalar(flat_t0_inline2786_inline12094);
                             params_t252.add_scalar(local_i_inline2779_inline11869);
                             params_t252.launch_spec.set_block_num(2);
+                            params_t252.set_predicate(expert_rows_pred);
                             rt_submit_aic_task(261, params_t252);
 
                             // Spmd exp_up_mm_spmd_2: exp_up_mm_2
@@ -3457,6 +3470,7 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                             params_t253.add_scalar(flat_t0_inline2786_inline12094);
                             params_t253.add_scalar(local_i_inline2779_inline11869);
                             params_t253.launch_spec.set_block_num(2);
+                            params_t253.set_predicate(expert_rows_pred);
                             rt_submit_aic_task(262, params_t253);
 
                             // Spmd exp_gate_up_act_spmd_2: exp_gate_up_act_2
@@ -3467,10 +3481,11 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                             params_t254.add_input(recv_scale_out_inline11858);
                             params_t254.add_input(routed_w1_scale_hca_inline687);
                             params_t254.add_input(routed_w3_scale_hca_inline513);
+                            params_t254.add_input(recv_count_out_inline12024);
                             params_t254.add_scalar(local_i_inline2779_inline11869);
                             params_t254.add_scalar(t0_inline2784_inline12130);
-                            params_t254.add_scalar(valid_rows_inline2759_inline12132);
                             params_t254.launch_spec.set_block_num(4);
+                            params_t254.set_predicate(expert_rows_pred);
                             rt_submit_aiv_task(263, params_t254);
                             uint32_t h_tile_i8_inline2806_inline11966_offsets[2] = {
                                 static_cast<uint32_t>(flat_t0_inline2786_inline12094), 0
@@ -3521,6 +3536,7 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                             params_t255.add_input(h_tile_fp32_inline2744_inline12109);
                             params_t255.add_inout(h_tile_scale_dq_inline2808_inline11847);
                             params_t255.add_inout(h_tile_i8_inline2806_inline11966);
+                            params_t255.set_predicate(expert_rows_pred);
                             rt_submit_aiv_task(264, params_t255);
                         }
                     }
@@ -3529,10 +3545,7 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                     for (int64_t local_e_inline2742_inline12068 = 0; local_e_inline2742_inline12068 < 32;
                          local_e_inline2742_inline12068 += 1) {
                         int64_t e_flat_base_inline2746_inline11946 = (local_e_inline2742_inline12068 * 16);
-                        uint32_t indices_e_rows_inline2760_inline11841[2] = {
-                            static_cast<uint32_t>(local_e_inline2742_inline12068), 0
-                        };
-                        int32_t e_rows_inline2760_inline11841 = HBG_RECV_ROWS_PER_EXPERT;
+                        int32_t e_rows_inline2760_inline11841 = EXPERT_ROWS_BUDGET;
                         int64_t e_tiles_inline2741_inline12070 =
                             ((static_cast<int64_t>(e_rows_inline2760_inline11841) + 15) / 16);
                         for (int64_t tt_inline2776_inline11840 = 0;
@@ -3545,6 +3558,13 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                             TaskOutputTensors alloc_112 = alloc_tensors(y_i32_inline2737_inline11965_ci);
                             const ChipTensor &y_i32_inline2737_inline11965 = alloc_112.get_ref(0);
                             int64_t tt0_inline2740_inline11839 = (tt_inline2776_inline11840 * 16);
+                            CoreTaskPredicate expert_rows_pred;
+                            expert_rows_pred.operand.tensor = &recv_count_out_inline12024;
+                            expert_rows_pred.operand.ndims = 2;
+                            expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_e_inline2742_inline12068);
+                            expert_rows_pred.operand.indices[1] = 0;
+                            expert_rows_pred.op = PredicateOp::GT;
+                            expert_rows_pred.target = tt0_inline2740_inline11839;
                             int64_t flat_tt0_inline2738_inline12036 =
                                 (e_flat_base_inline2746_inline11946 + tt0_inline2740_inline11839);
                             uint32_t h_tile_i8_inline2806_inline11966__ssa_v4_offsets[2] = {
@@ -3603,6 +3623,7 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                             params_t256.add_scalar(local_e_inline2742_inline12068);
                             params_t256.launch_spec.set_block_num(4);
                             params_t256.set_allow_early_resolve(true);
+                            params_t256.set_predicate(expert_rows_pred);
                             TaskOutputTensors task_256_outs = rt_submit_aic_task(265, params_t256);
                             uint32_t recv_y_tile_inline2730_inline11836_offsets[2] = {
                                 static_cast<uint32_t>(flat_tt0_inline2738_inline12036), 0
@@ -3638,6 +3659,7 @@ void csa_hca_layer(const GraphTaskArgs &args) {
                             params_t257.add_scalar(tt0_inline2740_inline11839);
                             params_t257.launch_spec.set_block_num(1);
                             params_t257.set_allow_early_resolve(true);
+                            params_t257.set_predicate(expert_rows_pred);
                             TaskOutputTensors task_257_outs = rt_submit_aiv_task(266, params_t257);
                         }
                     }
@@ -5844,20 +5866,21 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 for (int64_t local_i_inline2779_inline9183 = 0; local_i_inline2779_inline9183 < 32;
                      local_i_inline2779_inline9183 += 1) {
                     int64_t flat_base_inline2774_inline9220 = (local_i_inline2779_inline9183 * 16);
-                    uint32_t indices_n_rows_inline2782_inline9442[2] = {
-                        static_cast<uint32_t>(local_i_inline2779_inline9183), 0
-                    };
-                    int32_t n_rows_inline2782_inline9442 = HBG_RECV_ROWS_PER_EXPERT;
+                    int32_t n_rows_inline2782_inline9442 = EXPERT_ROWS_BUDGET;
                     int64_t n_tiles_inline2780_inline9415 =
                         ((static_cast<int64_t>(n_rows_inline2782_inline9442) + 15) / 16);
                     for (int64_t t_inline2778_inline9443 = 0; t_inline2778_inline9443 < n_tiles_inline2780_inline9415;
                          t_inline2778_inline9443 += 1) {
                         int64_t t0_inline2784_inline9444 = (t_inline2778_inline9443 * 16);
+                        CoreTaskPredicate expert_rows_pred;
+                        expert_rows_pred.operand.tensor = &recv_count_out_inline9338;
+                        expert_rows_pred.operand.ndims = 2;
+                        expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_i_inline2779_inline9183);
+                        expert_rows_pred.operand.indices[1] = 0;
+                        expert_rows_pred.op = PredicateOp::GT;
+                        expert_rows_pred.target = t0_inline2784_inline9444;
                         int64_t flat_t0_inline2786_inline9408 =
                             (flat_base_inline2774_inline9220 + t0_inline2784_inline9444);
-                        int64_t valid_rows_inline2759_inline9446 = std::min<int64_t>(
-                            (static_cast<int64_t>(n_rows_inline2782_inline9442) - t0_inline2784_inline9444), 16
-                        );
                         PTO2_SCOPE() {
                             uint32_t gate_tile_i32_inline2749_inline9295_ci_shapes[2] = {16, 2048};
                             TensorCreateInfo gate_tile_i32_inline2749_inline9295_ci(
@@ -5887,6 +5910,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t51.add_scalar(flat_t0_inline2786_inline9408);
                             params_t51.add_scalar(local_i_inline2779_inline9183);
                             params_t51.launch_spec.set_block_num(2);
+                            params_t51.set_predicate(expert_rows_pred);
                             rt_submit_aic_task(53, params_t51);
 
                             // Spmd exp_up_mm_spmd: exp_up_mm
@@ -5897,6 +5921,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t52.add_scalar(flat_t0_inline2786_inline9408);
                             params_t52.add_scalar(local_i_inline2779_inline9183);
                             params_t52.launch_spec.set_block_num(2);
+                            params_t52.set_predicate(expert_rows_pred);
                             rt_submit_aic_task(54, params_t52);
 
                             // Spmd exp_gate_up_act_spmd: exp_gate_up_act
@@ -5907,10 +5932,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t53.add_input(recv_scale_out_inline9172);
                             params_t53.add_input(routed_w1_scale_l0_inline654);
                             params_t53.add_input(routed_w3_scale_l0_inline562);
+                            params_t53.add_input(recv_count_out_inline9338);
                             params_t53.add_scalar(local_i_inline2779_inline9183);
                             params_t53.add_scalar(t0_inline2784_inline9444);
-                            params_t53.add_scalar(valid_rows_inline2759_inline9446);
                             params_t53.launch_spec.set_block_num(4);
+                            params_t53.set_predicate(expert_rows_pred);
                             rt_submit_aiv_task(55, params_t53);
                             uint32_t h_tile_i8_inline2806_inline9280_offsets[2] = {
                                 static_cast<uint32_t>(flat_t0_inline2786_inline9408), 0
@@ -5961,6 +5987,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t54.add_input(h_tile_fp32_inline2744_inline9423);
                             params_t54.add_inout(h_tile_scale_dq_inline2808_inline9161);
                             params_t54.add_output(h_tile_i8_inline2806_inline9280);
+                            params_t54.set_predicate(expert_rows_pred);
                             rt_submit_aiv_task(56, params_t54);
                         }
                     }
@@ -5969,10 +5996,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     for (int64_t local_e_inline2742_inline9382 = 0; local_e_inline2742_inline9382 < 32;
                          local_e_inline2742_inline9382 += 1) {
                         int64_t e_flat_base_inline2746_inline9260 = (local_e_inline2742_inline9382 * 16);
-                        uint32_t indices_e_rows_inline2760_inline9155[2] = {
-                            static_cast<uint32_t>(local_e_inline2742_inline9382), 0
-                        };
-                        int32_t e_rows_inline2760_inline9155 = HBG_RECV_ROWS_PER_EXPERT;
+                        int32_t e_rows_inline2760_inline9155 = EXPERT_ROWS_BUDGET;
                         int64_t e_tiles_inline2741_inline9384 =
                             ((static_cast<int64_t>(e_rows_inline2760_inline9155) + 15) / 16);
                         for (int64_t tt_inline2776_inline9154 = 0;
@@ -5984,6 +6008,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             TaskOutputTensors alloc_27 = alloc_tensors(y_i32_inline2737_inline9279_ci);
                             const ChipTensor &y_i32_inline2737_inline9279 = alloc_27.get_ref(0);
                             int64_t tt0_inline2740_inline9153 = (tt_inline2776_inline9154 * 16);
+                            CoreTaskPredicate expert_rows_pred;
+                            expert_rows_pred.operand.tensor = &recv_count_out_inline9338;
+                            expert_rows_pred.operand.ndims = 2;
+                            expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_e_inline2742_inline9382);
+                            expert_rows_pred.operand.indices[1] = 0;
+                            expert_rows_pred.op = PredicateOp::GT;
+                            expert_rows_pred.target = tt0_inline2740_inline9153;
                             int64_t flat_tt0_inline2738_inline9350 =
                                 (e_flat_base_inline2746_inline9260 + tt0_inline2740_inline9153);
                             uint32_t h_tile_i8_inline2806_inline9280__ssa_v4_offsets[2] = {
@@ -6042,6 +6073,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t55.add_scalar(local_e_inline2742_inline9382);
                             params_t55.launch_spec.set_block_num(4);
                             params_t55.set_allow_early_resolve(true);
+                            params_t55.set_predicate(expert_rows_pred);
                             TaskOutputTensors task_55_outs = rt_submit_aic_task(57, params_t55);
                             uint32_t recv_y_tile_inline2730_inline9150_offsets[2] = {
                                 static_cast<uint32_t>(flat_tt0_inline2738_inline9350), 0
@@ -6077,6 +6109,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t56.add_scalar(tt0_inline2740_inline9153);
                             params_t56.launch_spec.set_block_num(1);
                             params_t56.set_allow_early_resolve(true);
+                            params_t56.set_predicate(expert_rows_pred);
                             TaskOutputTensors task_56_outs = rt_submit_aiv_task(58, params_t56);
                         }
                     }
@@ -7261,20 +7294,21 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 for (int64_t local_i_inline2779_inline9945 = 0; local_i_inline2779_inline9945 < 32;
                      local_i_inline2779_inline9945 += 1) {
                     int64_t flat_base_inline2774_inline9982 = (local_i_inline2779_inline9945 * 16);
-                    uint32_t indices_n_rows_inline2782_inline10204[2] = {
-                        static_cast<uint32_t>(local_i_inline2779_inline9945), 0
-                    };
-                    int32_t n_rows_inline2782_inline10204 = HBG_RECV_ROWS_PER_EXPERT;
+                    int32_t n_rows_inline2782_inline10204 = EXPERT_ROWS_BUDGET;
                     int64_t n_tiles_inline2780_inline10177 =
                         ((static_cast<int64_t>(n_rows_inline2782_inline10204) + 15) / 16);
                     for (int64_t t_inline2778_inline10205 = 0;
                          t_inline2778_inline10205 < n_tiles_inline2780_inline10177; t_inline2778_inline10205 += 1) {
                         int64_t t0_inline2784_inline10206 = (t_inline2778_inline10205 * 16);
+                        CoreTaskPredicate expert_rows_pred;
+                        expert_rows_pred.operand.tensor = &recv_count_out_inline10100;
+                        expert_rows_pred.operand.ndims = 2;
+                        expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_i_inline2779_inline9945);
+                        expert_rows_pred.operand.indices[1] = 0;
+                        expert_rows_pred.op = PredicateOp::GT;
+                        expert_rows_pred.target = t0_inline2784_inline10206;
                         int64_t flat_t0_inline2786_inline10170 =
                             (flat_base_inline2774_inline9982 + t0_inline2784_inline10206);
-                        int64_t valid_rows_inline2759_inline10208 = std::min<int64_t>(
-                            (static_cast<int64_t>(n_rows_inline2782_inline10204) - t0_inline2784_inline10206), 16
-                        );
                         PTO2_SCOPE() {
                             uint32_t gate_tile_i32_inline2749_inline10057_ci_shapes[2] = {16, 2048};
                             TensorCreateInfo gate_tile_i32_inline2749_inline10057_ci(
@@ -7304,6 +7338,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t108.add_scalar(flat_t0_inline2786_inline10170);
                             params_t108.add_scalar(local_i_inline2779_inline9945);
                             params_t108.launch_spec.set_block_num(2);
+                            params_t108.set_predicate(expert_rows_pred);
                             rt_submit_aic_task(112, params_t108);
 
                             // Spmd exp_up_mm_spmd_0: exp_up_mm_0
@@ -7314,6 +7349,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t109.add_scalar(flat_t0_inline2786_inline10170);
                             params_t109.add_scalar(local_i_inline2779_inline9945);
                             params_t109.launch_spec.set_block_num(2);
+                            params_t109.set_predicate(expert_rows_pred);
                             rt_submit_aic_task(113, params_t109);
 
                             // Spmd exp_gate_up_act_spmd_0: exp_gate_up_act_0
@@ -7324,10 +7360,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t110.add_input(recv_scale_out_inline9934);
                             params_t110.add_input(routed_w1_scale_l1_inline668);
                             params_t110.add_input(routed_w3_scale_l1_inline689);
+                            params_t110.add_input(recv_count_out_inline10100);
                             params_t110.add_scalar(local_i_inline2779_inline9945);
                             params_t110.add_scalar(t0_inline2784_inline10206);
-                            params_t110.add_scalar(valid_rows_inline2759_inline10208);
                             params_t110.launch_spec.set_block_num(4);
+                            params_t110.set_predicate(expert_rows_pred);
                             rt_submit_aiv_task(114, params_t110);
                             uint32_t h_tile_i8_inline2806_inline10042_offsets[2] = {
                                 static_cast<uint32_t>(flat_t0_inline2786_inline10170), 0
@@ -7378,6 +7415,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t111.add_input(h_tile_fp32_inline2744_inline10185);
                             params_t111.add_inout(h_tile_scale_dq_inline2808_inline9923);
                             params_t111.add_output(h_tile_i8_inline2806_inline10042);
+                            params_t111.set_predicate(expert_rows_pred);
                             rt_submit_aiv_task(115, params_t111);
                         }
                     }
@@ -7386,10 +7424,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     for (int64_t local_e_inline2742_inline10144 = 0; local_e_inline2742_inline10144 < 32;
                          local_e_inline2742_inline10144 += 1) {
                         int64_t e_flat_base_inline2746_inline10022 = (local_e_inline2742_inline10144 * 16);
-                        uint32_t indices_e_rows_inline2760_inline9917[2] = {
-                            static_cast<uint32_t>(local_e_inline2742_inline10144), 0
-                        };
-                        int32_t e_rows_inline2760_inline9917 = HBG_RECV_ROWS_PER_EXPERT;
+                        int32_t e_rows_inline2760_inline9917 = EXPERT_ROWS_BUDGET;
                         int64_t e_tiles_inline2741_inline10146 =
                             ((static_cast<int64_t>(e_rows_inline2760_inline9917) + 15) / 16);
                         for (int64_t tt_inline2776_inline9916 = 0;
@@ -7401,6 +7436,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             TaskOutputTensors alloc_54 = alloc_tensors(y_i32_inline2737_inline10041_ci);
                             const ChipTensor &y_i32_inline2737_inline10041 = alloc_54.get_ref(0);
                             int64_t tt0_inline2740_inline9915 = (tt_inline2776_inline9916 * 16);
+                            CoreTaskPredicate expert_rows_pred;
+                            expert_rows_pred.operand.tensor = &recv_count_out_inline10100;
+                            expert_rows_pred.operand.ndims = 2;
+                            expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_e_inline2742_inline10144);
+                            expert_rows_pred.operand.indices[1] = 0;
+                            expert_rows_pred.op = PredicateOp::GT;
+                            expert_rows_pred.target = tt0_inline2740_inline9915;
                             int64_t flat_tt0_inline2738_inline10112 =
                                 (e_flat_base_inline2746_inline10022 + tt0_inline2740_inline9915);
                             uint32_t h_tile_i8_inline2806_inline10042__ssa_v4_offsets[2] = {
@@ -7459,6 +7501,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t112.add_scalar(local_e_inline2742_inline10144);
                             params_t112.launch_spec.set_block_num(4);
                             params_t112.set_allow_early_resolve(true);
+                            params_t112.set_predicate(expert_rows_pred);
                             TaskOutputTensors task_112_outs = rt_submit_aic_task(116, params_t112);
                             uint32_t recv_y_tile_inline2730_inline9912_offsets[2] = {
                                 static_cast<uint32_t>(flat_tt0_inline2738_inline10112), 0
@@ -7494,6 +7537,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t113.add_scalar(tt0_inline2740_inline9915);
                             params_t113.launch_spec.set_block_num(1);
                             params_t113.set_allow_early_resolve(true);
+                            params_t113.set_predicate(expert_rows_pred);
                             TaskOutputTensors task_113_outs = rt_submit_aiv_task(117, params_t113);
                         }
                     }
@@ -11081,20 +11125,21 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 for (int64_t local_i_inline2779_inline12914 = 0; local_i_inline2779_inline12914 < 32;
                      local_i_inline2779_inline12914 += 1) {
                     int64_t flat_base_inline2774_inline12951 = (local_i_inline2779_inline12914 * 16);
-                    uint32_t indices_n_rows_inline2782_inline13173[2] = {
-                        static_cast<uint32_t>(local_i_inline2779_inline12914), 0
-                    };
-                    int32_t n_rows_inline2782_inline13173 = HBG_RECV_ROWS_PER_EXPERT;
+                    int32_t n_rows_inline2782_inline13173 = EXPERT_ROWS_BUDGET;
                     int64_t n_tiles_inline2780_inline13146 =
                         ((static_cast<int64_t>(n_rows_inline2782_inline13173) + 15) / 16);
                     for (int64_t t_inline2778_inline13174 = 0;
                          t_inline2778_inline13174 < n_tiles_inline2780_inline13146; t_inline2778_inline13174 += 1) {
                         int64_t t0_inline2784_inline13175 = (t_inline2778_inline13174 * 16);
+                        CoreTaskPredicate expert_rows_pred;
+                        expert_rows_pred.operand.tensor = &recv_count_out_inline13069;
+                        expert_rows_pred.operand.ndims = 2;
+                        expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_i_inline2779_inline12914);
+                        expert_rows_pred.operand.indices[1] = 0;
+                        expert_rows_pred.op = PredicateOp::GT;
+                        expert_rows_pred.target = t0_inline2784_inline13175;
                         int64_t flat_t0_inline2786_inline13139 =
                             (flat_base_inline2774_inline12951 + t0_inline2784_inline13175);
-                        int64_t valid_rows_inline2759_inline13177 = std::min<int64_t>(
-                            (static_cast<int64_t>(n_rows_inline2782_inline13173) - t0_inline2784_inline13175), 16
-                        );
                         PTO2_SCOPE() {
                             uint32_t gate_tile_i32_inline2749_inline13026_ci_shapes[2] = {16, 2048};
                             TensorCreateInfo gate_tile_i32_inline2749_inline13026_ci(
@@ -11124,6 +11169,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t331.add_scalar(flat_t0_inline2786_inline13139);
                             params_t331.add_scalar(local_i_inline2779_inline12914);
                             params_t331.launch_spec.set_block_num(2);
+                            params_t331.set_predicate(expert_rows_pred);
                             rt_submit_aic_task(343, params_t331);
 
                             // Spmd exp_up_mm_spmd_3: exp_up_mm_3
@@ -11134,6 +11180,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t332.add_scalar(flat_t0_inline2786_inline13139);
                             params_t332.add_scalar(local_i_inline2779_inline12914);
                             params_t332.launch_spec.set_block_num(2);
+                            params_t332.set_predicate(expert_rows_pred);
                             rt_submit_aic_task(344, params_t332);
 
                             // Spmd exp_gate_up_act_spmd_3: exp_gate_up_act_3
@@ -11144,10 +11191,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t333.add_input(recv_scale_out_inline12903);
                             params_t333.add_input(routed_w1_scale_last_inline490);
                             params_t333.add_input(routed_w3_scale_last_inline673);
+                            params_t333.add_input(recv_count_out_inline13069);
                             params_t333.add_scalar(local_i_inline2779_inline12914);
                             params_t333.add_scalar(t0_inline2784_inline13175);
-                            params_t333.add_scalar(valid_rows_inline2759_inline13177);
                             params_t333.launch_spec.set_block_num(4);
+                            params_t333.set_predicate(expert_rows_pred);
                             rt_submit_aiv_task(345, params_t333);
                             uint32_t h_tile_i8_inline2806_inline13011_offsets[2] = {
                                 static_cast<uint32_t>(flat_t0_inline2786_inline13139), 0
@@ -11198,6 +11246,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t334.add_input(h_tile_fp32_inline2744_inline13154);
                             params_t334.add_inout(h_tile_scale_dq_inline2808_inline12892);
                             params_t334.add_output(h_tile_i8_inline2806_inline13011);
+                            params_t334.set_predicate(expert_rows_pred);
                             rt_submit_aiv_task(346, params_t334);
                         }
                     }
@@ -11206,10 +11255,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     for (int64_t local_e_inline2742_inline13113 = 0; local_e_inline2742_inline13113 < 32;
                          local_e_inline2742_inline13113 += 1) {
                         int64_t e_flat_base_inline2746_inline12991 = (local_e_inline2742_inline13113 * 16);
-                        uint32_t indices_e_rows_inline2760_inline12886[2] = {
-                            static_cast<uint32_t>(local_e_inline2742_inline13113), 0
-                        };
-                        int32_t e_rows_inline2760_inline12886 = HBG_RECV_ROWS_PER_EXPERT;
+                        int32_t e_rows_inline2760_inline12886 = EXPERT_ROWS_BUDGET;
                         int64_t e_tiles_inline2741_inline13115 =
                             ((static_cast<int64_t>(e_rows_inline2760_inline12886) + 15) / 16);
                         for (int64_t tt_inline2776_inline12885 = 0;
@@ -11222,6 +11268,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             TaskOutputTensors alloc_141 = alloc_tensors(y_i32_inline2737_inline13010_ci);
                             const ChipTensor &y_i32_inline2737_inline13010 = alloc_141.get_ref(0);
                             int64_t tt0_inline2740_inline12884 = (tt_inline2776_inline12885 * 16);
+                            CoreTaskPredicate expert_rows_pred;
+                            expert_rows_pred.operand.tensor = &recv_count_out_inline13069;
+                            expert_rows_pred.operand.ndims = 2;
+                            expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_e_inline2742_inline13113);
+                            expert_rows_pred.operand.indices[1] = 0;
+                            expert_rows_pred.op = PredicateOp::GT;
+                            expert_rows_pred.target = tt0_inline2740_inline12884;
                             int64_t flat_tt0_inline2738_inline13081 =
                                 (e_flat_base_inline2746_inline12991 + tt0_inline2740_inline12884);
                             uint32_t h_tile_i8_inline2806_inline13011__ssa_v4_offsets[2] = {
@@ -11280,6 +11333,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t335.add_scalar(local_e_inline2742_inline13113);
                             params_t335.launch_spec.set_block_num(4);
                             params_t335.set_allow_early_resolve(true);
+                            params_t335.set_predicate(expert_rows_pred);
                             TaskOutputTensors task_335_outs = rt_submit_aic_task(347, params_t335);
                             uint32_t recv_y_tile_inline2730_inline12881_offsets[2] = {
                                 static_cast<uint32_t>(flat_tt0_inline2738_inline13081), 0
@@ -11315,6 +11369,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t336.add_scalar(tt0_inline2740_inline12884);
                             params_t336.launch_spec.set_block_num(1);
                             params_t336.set_allow_early_resolve(true);
+                            params_t336.set_predicate(expert_rows_pred);
                             TaskOutputTensors task_336_outs = rt_submit_aiv_task(348, params_t336);
                         }
                     }

--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
@@ -17,15 +17,17 @@ and ships the built SM image to the device, which boots scheduler-only.
 with the runtime untouched, recast as a Graph: the 20-iteration decoder layer
 loop (40 of the 43 layers) submits one ``rt_submit_graph`` per iteration whose
 body is the layer's full task set, so the host records a 744-node Definition
-once and the 15991-task network collapses to 1131 host-submitted tasks. The ten
-``get_tensor_data`` reads of ``recv_count_out`` (a task-produced tensor,
-unreadable while the host builds the graph) stand in a constant. Tensor
-initialization is shared with the TMR case and runs in AIV kernels, and the
-attention/FFN scale factors travel as kernel tensor inputs read from GM, so
-the host never writes a GM-heap device address and never copies tensor data
-into task scalars. The graph therefore keeps the size and
-shape of the real one but not the fixture's routing — hence ``skip_golden``.
-``manual`` because the 368-kernel compile takes minutes.
+once and the full network collapses to 1131 host-submitted tasks. The ten
+``recv_count_out`` reads that drove the MoE per-expert tile loops (a
+task-produced tensor, unreadable while the host builds the graph) are now
+dispatch predicates the scheduler evaluates on device. Tensor initialization is
+shared with the TMR case and runs in AIV kernels, and the attention/FFN scale
+factors travel as kernel tensor inputs read from GM, so the host never writes a
+GM-heap device address and never copies tensor data into task scalars. The
+orchestration source is therefore the TMR one recast as a Graph, with no
+runtime-specific rewrite. ``skip_golden`` is inherited from the TMR case, which
+is itself a completion/smoke case; ``manual`` because the 368-kernel compile
+takes minutes.
 
 Host construction and Graph recording complete (1131 tasks on host). An
 unskipped device run is currently blocked in Graph activation, so the recorded
@@ -67,20 +69,22 @@ def _host_build_graph_callable():
     and the orchestration swapped for the Graph-form variant.
 
     ``decode_fwd_graph.cpp`` is the tensormap_and_ringbuffer orchestration with
-    one runtime-specific rewrite and the runtime untouched. HBG runs the
+    the runtime untouched and no runtime-specific rewrite. HBG runs the
     orchestrator on the host before the device executes anything, so the ten
-    ``get_tensor_data(recv_count_out)`` reads (a task-produced tensor driving the
-    MoE per-expert tile loops) have no value to return; they are replaced by
-    ``HBG_RECV_ROWS_PER_EXPERT``, which holds the tile loops at their real trip
-    count. The one other ``get_tensor_data`` read (``ext_num_tokens_per_owner``)
-    drives tile counts and launch block numbers and stays host-side; the former
-    30 scale reads are gone — the consuming kernels read the scale tensors from
-    GM directly. The shared orchestration submits the same device-side
+    ``get_tensor_data(recv_count_out)`` reads (a task-produced tensor that drove
+    the MoE per-expert tile loops) had no value to return; both runtimes now use
+    a static per-expert tile grid whose tasks carry a dispatch predicate on
+    ``recv_count_out[expert][0]``, read by the scheduler on device, and the
+    ``exp_gate_up_act*`` kernels derive ``valid_rows`` from the count tensor in
+    ``kernel_entry``. The one ``get_tensor_data`` read left
+    (``ext_num_tokens_per_owner``) is an external tensor and drives
+    ``set_block_num``, which a predicate cannot express; the former 30 scale
+    reads are gone — the consuming kernels read the scale tensors from GM
+    directly. The shared orchestration submits the same device-side
     initialization kernels under both runtimes.
 
-    The graph therefore keeps the size and shape of the real one but not the
-    fixture's routing, which is why the case is ``skip_golden``: it measures
-    host-side graph construction and device execution, not numerics.
+    The case is ``skip_golden`` because the TMR case it is derived from is: it
+    measures host-side graph construction and device execution, not numerics.
     """
     callable_config = copy.deepcopy(_TMR.TestDeepseekV4FlashDecode.CALLABLE)
     chip = callable_config["callables"][0]
@@ -104,11 +108,9 @@ class TestDeepseekV4FlashDecodeHostBuildGraph(SceneTestCase):
             "config": {
                 "device_count": N_RANKS,
                 "num_sub_workers": 0,
-                # Ring task window matches the TMR case (HBG_RECV_ROWS_PER_EXPERT
-                # materializes the same per-expert tile count the dynamic loops
-                # produced in-regime). The heap grows 2x: a constant trip count
-                # allocates tile scratch for all 32 experts per MoE layer, while
-                # the dynamic loops allocated only for experts that received rows.
+                # Ring sizing matches the TMR case: both runtimes now build the
+                # same static per-expert tile grid, so both allocate tile scratch
+                # for all 32 experts of every MoE layer.
                 "runtime_env": {
                     "ring_task_window": 16384,
                     "ring_heap": 2 << 30,

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/README.md
@@ -52,9 +52,34 @@ The 30 orchestration-side `get_tensor_data` reads of `hc_attn_scale_*` /
 values went straight into task scalars for the `split_pre_post*` /
 `comb_sinkhorn*` kernels. Each of those kernels now takes the scale view as an
 extra tensor input and reads scale0/scale1 (`split_pre_post*`) or scale2
-(`comb_sinkhorn*`) from GM itself. The remaining reads — `recv_count_out` and
-`ext_num_tokens_per_owner` — feed loop trip counts and launch block numbers,
-i.e. orchestration control flow, and stay on the orchestrator.
+(`comb_sinkhorn*`) from GM itself.
+
+The ten `recv_count_out` reads that drove the MoE per-expert tile loops are gone
+too. `recv_count_out[expert][0]` is written on the device by `dispatch_meta`, so
+reading it in orchestration stalls the orchestrator on a producer wait. The count
+now steers the loops from the device side, split by role:
+
+- **Trip count → dispatch predicate.** The tile grid is static — the
+  `h_i8 [512, 2048]` layout budgets 16 rows per expert and a tile is 16 rows, so
+  one tile per expert — and each of a tile's six tasks carries a **dispatch
+  predicate** on that element (`recv_count_out[expert][0] > t0`). The scheduler
+  evaluates it at the dispatch point, where the task is already ready and the
+  count is therefore current: an expert whose count does not reach the tile's
+  first row has the tile's tasks retired inline, never dispatched to a core.
+  The predicate declares no dependency of its own, and needs none here — every
+  task in the tile consumes a `dispatch_gather` output, and `dispatch_gather`
+  depends on `dispatch_meta`.
+- **`valid_rows` → kernel-side read.** The one value the loops computed from the
+  count, `valid_rows = min(count - t0, 16)`, is a task arg of `exp_gate_up_act*`.
+  The orchestration passes `recv_count_out` as an extra tensor input instead
+  (taking the former first-scalar slot, as the scale views did), and each of the
+  five kernels derives the row count from GM in `kernel_entry`, after a
+  single-line `dcci` on the element.
+
+`ext_num_tokens_per_owner` is the one read left. It is an **external** tensor, so
+it has a value before the network runs, and it feeds `set_block_num` — a launch
+parameter a predicate cannot express, because a predicate decides whether a task
+dispatches, not how wide it is.
 
 ## Status: blocked on the #1644 pto-isa pin bump
 
@@ -63,9 +88,11 @@ commit whose scene-test plumbing can host it) through #1771 — all of which pin
 pto-isa `83d01313`, the commit these kernels were generated against. From
 `7a1b9b11` ("CI: bump pinned pto-isa for PTOAS v0.55", pto-isa -> `0cefc9a5`)
 onward, including current main, both ranks stall mid-network: two kernels spin
-forever on comm-window arrival counters, the AICPU orchestrator times out
-reading `recv_count_out` (`TENSOR_WAIT_TIMEOUT`, "producer not completed"), and
-the scheduler exits `S1:running-stalled`. The stall layer moves with fixture
+forever on comm-window arrival counters and the scheduler exits
+`S1:running-stalled`. (The orchestrator's own `TENSOR_WAIT_TIMEOUT` on
+`recv_count_out` was a consequence of that stall — the read waited on a producer
+the stalled network never ran — and can no longer occur now that the count is
+read by the scheduler at the dispatch point.) The stall layer moves with fixture
 content (a timing-dependent miss, not a fixed logic error), and the identical
 program + content passes under pypto's own runner against pto-isa `83d01313`
 even with every weight streamed as a host tensor. Bisect evidence: PASS at

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/exp_gate_up_act.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/exp_gate_up_act.cpp
@@ -839,12 +839,17 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         reinterpret_cast<__gm__ float *>(routed_w3_scale_l0_inline562__ssa_v0_tensor->buffer.addr) +
         routed_w3_scale_l0_inline562__ssa_v0_tensor->start_offset;
 
+    // Unpack tensor: recv_count_out
+    __gm__ ChipTensor *recv_count_out_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[6]);
+    __gm__ int32_t *recv_count_out =
+        reinterpret_cast<__gm__ int32_t *>(recv_count_out_tensor->buffer.addr) + recv_count_out_tensor->start_offset;
+
     // Unpack scalar: local_i_inline2779_inline9183__idx_v0
     union {
         uint64_t u64;
         int64_t val;
     } local_i_inline2779_inline9183__idx_v0_conv;
-    local_i_inline2779_inline9183__idx_v0_conv.u64 = args[6];
+    local_i_inline2779_inline9183__idx_v0_conv.u64 = args[7];
     int64_t local_i_inline2779_inline9183__idx_v0 = local_i_inline2779_inline9183__idx_v0_conv.val;
 
     // Unpack scalar: t0_inline2784_inline9444__ssa_v0
@@ -852,16 +857,19 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         uint64_t u64;
         int64_t val;
     } t0_inline2784_inline9444__ssa_v0_conv;
-    t0_inline2784_inline9444__ssa_v0_conv.u64 = args[7];
+    t0_inline2784_inline9444__ssa_v0_conv.u64 = args[8];
     int64_t t0_inline2784_inline9444__ssa_v0 = t0_inline2784_inline9444__ssa_v0_conv.val;
 
-    // Unpack scalar: valid_rows_inline2759_inline9446__ssa_v0
-    union {
-        uint64_t u64;
-        int64_t val;
-    } valid_rows_inline2759_inline9446__ssa_v0_conv;
-    valid_rows_inline2759_inline9446__ssa_v0_conv.u64 = args[8];
-    int64_t valid_rows_inline2759_inline9446__ssa_v0 = valid_rows_inline2759_inline9446__ssa_v0_conv.val;
+    // Rows of this tile that carry data. recv_count_out is [32, 1] INT32,
+    // one row per expert, written on the device by dispatch_meta. The line is
+    // invalidated before the load: the count lives in the ring heap, so an
+    // address this core cached under an earlier tensor could otherwise serve
+    // it. The task's dispatch predicate is recv_count_out[expert] > t0, so the
+    // difference is at least 1 whenever this kernel runs.
+    PTOAS__DCCI_SINGLE_CACHE_LINE(&recv_count_out[local_i_inline2779_inline9183__idx_v0]);
+    int64_t valid_rows_inline2759_inline9446__ssa_v0 =
+        static_cast<int64_t>(recv_count_out[local_i_inline2779_inline9183__idx_v0]) - t0_inline2784_inline9444__ssa_v0;
+    if (valid_rows_inline2759_inline9446__ssa_v0 > 16) valid_rows_inline2759_inline9446__ssa_v0 = 16;
 
     // Forward to ptoas-generated function
     exp_gate_up_act(

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/exp_gate_up_act_0.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/exp_gate_up_act_0.cpp
@@ -840,12 +840,17 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         reinterpret_cast<__gm__ float *>(routed_w3_scale_l1_inline689__ssa_v0_tensor->buffer.addr) +
         routed_w3_scale_l1_inline689__ssa_v0_tensor->start_offset;
 
+    // Unpack tensor: recv_count_out
+    __gm__ ChipTensor *recv_count_out_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[6]);
+    __gm__ int32_t *recv_count_out =
+        reinterpret_cast<__gm__ int32_t *>(recv_count_out_tensor->buffer.addr) + recv_count_out_tensor->start_offset;
+
     // Unpack scalar: local_i_inline2779_inline9945__idx_v0
     union {
         uint64_t u64;
         int64_t val;
     } local_i_inline2779_inline9945__idx_v0_conv;
-    local_i_inline2779_inline9945__idx_v0_conv.u64 = args[6];
+    local_i_inline2779_inline9945__idx_v0_conv.u64 = args[7];
     int64_t local_i_inline2779_inline9945__idx_v0 = local_i_inline2779_inline9945__idx_v0_conv.val;
 
     // Unpack scalar: t0_inline2784_inline10206__ssa_v0
@@ -853,16 +858,19 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         uint64_t u64;
         int64_t val;
     } t0_inline2784_inline10206__ssa_v0_conv;
-    t0_inline2784_inline10206__ssa_v0_conv.u64 = args[7];
+    t0_inline2784_inline10206__ssa_v0_conv.u64 = args[8];
     int64_t t0_inline2784_inline10206__ssa_v0 = t0_inline2784_inline10206__ssa_v0_conv.val;
 
-    // Unpack scalar: valid_rows_inline2759_inline10208__ssa_v0
-    union {
-        uint64_t u64;
-        int64_t val;
-    } valid_rows_inline2759_inline10208__ssa_v0_conv;
-    valid_rows_inline2759_inline10208__ssa_v0_conv.u64 = args[8];
-    int64_t valid_rows_inline2759_inline10208__ssa_v0 = valid_rows_inline2759_inline10208__ssa_v0_conv.val;
+    // Rows of this tile that carry data. recv_count_out is [32, 1] INT32,
+    // one row per expert, written on the device by dispatch_meta. The line is
+    // invalidated before the load: the count lives in the ring heap, so an
+    // address this core cached under an earlier tensor could otherwise serve
+    // it. The task's dispatch predicate is recv_count_out[expert] > t0, so the
+    // difference is at least 1 whenever this kernel runs.
+    PTOAS__DCCI_SINGLE_CACHE_LINE(&recv_count_out[local_i_inline2779_inline9945__idx_v0]);
+    int64_t valid_rows_inline2759_inline10208__ssa_v0 =
+        static_cast<int64_t>(recv_count_out[local_i_inline2779_inline9945__idx_v0]) - t0_inline2784_inline10206__ssa_v0;
+    if (valid_rows_inline2759_inline10208__ssa_v0 > 16) valid_rows_inline2759_inline10208__ssa_v0 = 16;
 
     // Forward to ptoas-generated function
     exp_gate_up_act_0(

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/exp_gate_up_act_1.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/exp_gate_up_act_1.cpp
@@ -840,12 +840,17 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         reinterpret_cast<__gm__ float *>(routed_w3_scale_csa_inline713__ssa_v0_tensor->buffer.addr) +
         routed_w3_scale_csa_inline713__ssa_v0_tensor->start_offset;
 
+    // Unpack tensor: recv_count_out
+    __gm__ ChipTensor *recv_count_out_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[6]);
+    __gm__ int32_t *recv_count_out =
+        reinterpret_cast<__gm__ int32_t *>(recv_count_out_tensor->buffer.addr) + recv_count_out_tensor->start_offset;
+
     // Unpack scalar: local_i_inline2779_inline10990__idx_v0
     union {
         uint64_t u64;
         int64_t val;
     } local_i_inline2779_inline10990__idx_v0_conv;
-    local_i_inline2779_inline10990__idx_v0_conv.u64 = args[6];
+    local_i_inline2779_inline10990__idx_v0_conv.u64 = args[7];
     int64_t local_i_inline2779_inline10990__idx_v0 = local_i_inline2779_inline10990__idx_v0_conv.val;
 
     // Unpack scalar: t0_inline2784_inline11251__ssa_v0
@@ -853,16 +858,20 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         uint64_t u64;
         int64_t val;
     } t0_inline2784_inline11251__ssa_v0_conv;
-    t0_inline2784_inline11251__ssa_v0_conv.u64 = args[7];
+    t0_inline2784_inline11251__ssa_v0_conv.u64 = args[8];
     int64_t t0_inline2784_inline11251__ssa_v0 = t0_inline2784_inline11251__ssa_v0_conv.val;
 
-    // Unpack scalar: valid_rows_inline2759_inline11253__ssa_v0
-    union {
-        uint64_t u64;
-        int64_t val;
-    } valid_rows_inline2759_inline11253__ssa_v0_conv;
-    valid_rows_inline2759_inline11253__ssa_v0_conv.u64 = args[8];
-    int64_t valid_rows_inline2759_inline11253__ssa_v0 = valid_rows_inline2759_inline11253__ssa_v0_conv.val;
+    // Rows of this tile that carry data. recv_count_out is [32, 1] INT32,
+    // one row per expert, written on the device by dispatch_meta. The line is
+    // invalidated before the load: the count lives in the ring heap, so an
+    // address this core cached under an earlier tensor could otherwise serve
+    // it. The task's dispatch predicate is recv_count_out[expert] > t0, so the
+    // difference is at least 1 whenever this kernel runs.
+    PTOAS__DCCI_SINGLE_CACHE_LINE(&recv_count_out[local_i_inline2779_inline10990__idx_v0]);
+    int64_t valid_rows_inline2759_inline11253__ssa_v0 =
+        static_cast<int64_t>(recv_count_out[local_i_inline2779_inline10990__idx_v0]) -
+        t0_inline2784_inline11251__ssa_v0;
+    if (valid_rows_inline2759_inline11253__ssa_v0 > 16) valid_rows_inline2759_inline11253__ssa_v0 = 16;
 
     // Forward to ptoas-generated function
     exp_gate_up_act_1(

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/exp_gate_up_act_2.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/exp_gate_up_act_2.cpp
@@ -840,12 +840,17 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         reinterpret_cast<__gm__ float *>(routed_w3_scale_hca_inline513__ssa_v0_tensor->buffer.addr) +
         routed_w3_scale_hca_inline513__ssa_v0_tensor->start_offset;
 
+    // Unpack tensor: recv_count_out
+    __gm__ ChipTensor *recv_count_out_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[6]);
+    __gm__ int32_t *recv_count_out =
+        reinterpret_cast<__gm__ int32_t *>(recv_count_out_tensor->buffer.addr) + recv_count_out_tensor->start_offset;
+
     // Unpack scalar: local_i_inline2779_inline11869__idx_v0
     union {
         uint64_t u64;
         int64_t val;
     } local_i_inline2779_inline11869__idx_v0_conv;
-    local_i_inline2779_inline11869__idx_v0_conv.u64 = args[6];
+    local_i_inline2779_inline11869__idx_v0_conv.u64 = args[7];
     int64_t local_i_inline2779_inline11869__idx_v0 = local_i_inline2779_inline11869__idx_v0_conv.val;
 
     // Unpack scalar: t0_inline2784_inline12130__ssa_v0
@@ -853,16 +858,20 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         uint64_t u64;
         int64_t val;
     } t0_inline2784_inline12130__ssa_v0_conv;
-    t0_inline2784_inline12130__ssa_v0_conv.u64 = args[7];
+    t0_inline2784_inline12130__ssa_v0_conv.u64 = args[8];
     int64_t t0_inline2784_inline12130__ssa_v0 = t0_inline2784_inline12130__ssa_v0_conv.val;
 
-    // Unpack scalar: valid_rows_inline2759_inline12132__ssa_v0
-    union {
-        uint64_t u64;
-        int64_t val;
-    } valid_rows_inline2759_inline12132__ssa_v0_conv;
-    valid_rows_inline2759_inline12132__ssa_v0_conv.u64 = args[8];
-    int64_t valid_rows_inline2759_inline12132__ssa_v0 = valid_rows_inline2759_inline12132__ssa_v0_conv.val;
+    // Rows of this tile that carry data. recv_count_out is [32, 1] INT32,
+    // one row per expert, written on the device by dispatch_meta. The line is
+    // invalidated before the load: the count lives in the ring heap, so an
+    // address this core cached under an earlier tensor could otherwise serve
+    // it. The task's dispatch predicate is recv_count_out[expert] > t0, so the
+    // difference is at least 1 whenever this kernel runs.
+    PTOAS__DCCI_SINGLE_CACHE_LINE(&recv_count_out[local_i_inline2779_inline11869__idx_v0]);
+    int64_t valid_rows_inline2759_inline12132__ssa_v0 =
+        static_cast<int64_t>(recv_count_out[local_i_inline2779_inline11869__idx_v0]) -
+        t0_inline2784_inline12130__ssa_v0;
+    if (valid_rows_inline2759_inline12132__ssa_v0 > 16) valid_rows_inline2759_inline12132__ssa_v0 = 16;
 
     // Forward to ptoas-generated function
     exp_gate_up_act_2(

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/exp_gate_up_act_3.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/aiv/exp_gate_up_act_3.cpp
@@ -840,12 +840,17 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         reinterpret_cast<__gm__ float *>(routed_w3_scale_last_inline673__ssa_v0_tensor->buffer.addr) +
         routed_w3_scale_last_inline673__ssa_v0_tensor->start_offset;
 
+    // Unpack tensor: recv_count_out
+    __gm__ ChipTensor *recv_count_out_tensor = reinterpret_cast<__gm__ ChipTensor *>(args[6]);
+    __gm__ int32_t *recv_count_out =
+        reinterpret_cast<__gm__ int32_t *>(recv_count_out_tensor->buffer.addr) + recv_count_out_tensor->start_offset;
+
     // Unpack scalar: local_i_inline2779_inline12914__idx_v0
     union {
         uint64_t u64;
         int64_t val;
     } local_i_inline2779_inline12914__idx_v0_conv;
-    local_i_inline2779_inline12914__idx_v0_conv.u64 = args[6];
+    local_i_inline2779_inline12914__idx_v0_conv.u64 = args[7];
     int64_t local_i_inline2779_inline12914__idx_v0 = local_i_inline2779_inline12914__idx_v0_conv.val;
 
     // Unpack scalar: t0_inline2784_inline13175__ssa_v0
@@ -853,16 +858,20 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         uint64_t u64;
         int64_t val;
     } t0_inline2784_inline13175__ssa_v0_conv;
-    t0_inline2784_inline13175__ssa_v0_conv.u64 = args[7];
+    t0_inline2784_inline13175__ssa_v0_conv.u64 = args[8];
     int64_t t0_inline2784_inline13175__ssa_v0 = t0_inline2784_inline13175__ssa_v0_conv.val;
 
-    // Unpack scalar: valid_rows_inline2759_inline13177__ssa_v0
-    union {
-        uint64_t u64;
-        int64_t val;
-    } valid_rows_inline2759_inline13177__ssa_v0_conv;
-    valid_rows_inline2759_inline13177__ssa_v0_conv.u64 = args[8];
-    int64_t valid_rows_inline2759_inline13177__ssa_v0 = valid_rows_inline2759_inline13177__ssa_v0_conv.val;
+    // Rows of this tile that carry data. recv_count_out is [32, 1] INT32,
+    // one row per expert, written on the device by dispatch_meta. The line is
+    // invalidated before the load: the count lives in the ring heap, so an
+    // address this core cached under an earlier tensor could otherwise serve
+    // it. The task's dispatch predicate is recv_count_out[expert] > t0, so the
+    // difference is at least 1 whenever this kernel runs.
+    PTOAS__DCCI_SINGLE_CACHE_LINE(&recv_count_out[local_i_inline2779_inline12914__idx_v0]);
+    int64_t valid_rows_inline2759_inline13177__ssa_v0 =
+        static_cast<int64_t>(recv_count_out[local_i_inline2779_inline12914__idx_v0]) -
+        t0_inline2784_inline13175__ssa_v0;
+    if (valid_rows_inline2759_inline13177__ssa_v0 > 16) valid_rows_inline2759_inline13177__ssa_v0 = 16;
 
     // Forward to ptoas-generated function
     exp_gate_up_act_3(

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd.cpp
@@ -17,6 +17,17 @@
 
 #include "pto_orchestration_api.h"
 
+// Rows this orchestration budgets for each expert.
+//
+// The count an expert actually receives is `recv_count_out[expert][0]`, written
+// on the device by `dispatch_meta`. The budget is what the `h_i8 [512, 2048]`
+// layout reserves: 32 experts, 16 rows each, and a tile is 16 rows, so the
+// per-expert tile grid is one tile wide and fixed at build time. Each of a
+// tile's tasks carries a dispatch predicate on that element instead, so the
+// scheduler reads the count at the dispatch point and an expert whose count
+// does not reach the tile's first row has the tile's tasks retired inline.
+constexpr int32_t EXPERT_ROWS_BUDGET = 16;
+
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
@@ -2151,21 +2162,21 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 for (int64_t local_i_inline2779_inline9183 = 0; local_i_inline2779_inline9183 < 32;
                      local_i_inline2779_inline9183 += 1) {
                     int64_t flat_base_inline2774_inline9220 = (local_i_inline2779_inline9183 * 16);
-                    uint32_t indices_n_rows_inline2782_inline9442[2] = {
-                        static_cast<uint32_t>(local_i_inline2779_inline9183), 0
-                    };
-                    int32_t n_rows_inline2782_inline9442 =
-                        get_tensor_data<int32_t>(recv_count_out_inline9338, 2, indices_n_rows_inline2782_inline9442);
+                    int32_t n_rows_inline2782_inline9442 = EXPERT_ROWS_BUDGET;
                     int64_t n_tiles_inline2780_inline9415 =
                         ((static_cast<int64_t>(n_rows_inline2782_inline9442) + 15) / 16);
                     for (int64_t t_inline2778_inline9443 = 0; t_inline2778_inline9443 < n_tiles_inline2780_inline9415;
                          t_inline2778_inline9443 += 1) {
                         int64_t t0_inline2784_inline9444 = (t_inline2778_inline9443 * 16);
+                        CoreTaskPredicate expert_rows_pred;
+                        expert_rows_pred.operand.tensor = &recv_count_out_inline9338;
+                        expert_rows_pred.operand.ndims = 2;
+                        expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_i_inline2779_inline9183);
+                        expert_rows_pred.operand.indices[1] = 0;
+                        expert_rows_pred.op = PredicateOp::GT;
+                        expert_rows_pred.target = t0_inline2784_inline9444;
                         int64_t flat_t0_inline2786_inline9408 =
                             (flat_base_inline2774_inline9220 + t0_inline2784_inline9444);
-                        int64_t valid_rows_inline2759_inline9446 = std::min<int64_t>(
-                            (static_cast<int64_t>(n_rows_inline2782_inline9442) - t0_inline2784_inline9444), 16
-                        );
                         PTO2_SCOPE() {
                             uint32_t gate_tile_i32_inline2749_inline9295_ci_shapes[2] = {16, 2048};
                             TensorCreateInfo gate_tile_i32_inline2749_inline9295_ci(
@@ -2195,6 +2206,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t51.add_scalar(flat_t0_inline2786_inline9408);
                             params_t51.add_scalar(local_i_inline2779_inline9183);
                             params_t51.launch_spec.set_block_num(2);
+                            params_t51.set_predicate(expert_rows_pred);
                             rt_submit_aic_task(53, params_t51);
 
                             // Spmd exp_up_mm_spmd: exp_up_mm
@@ -2205,6 +2217,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t52.add_scalar(flat_t0_inline2786_inline9408);
                             params_t52.add_scalar(local_i_inline2779_inline9183);
                             params_t52.launch_spec.set_block_num(2);
+                            params_t52.set_predicate(expert_rows_pred);
                             rt_submit_aic_task(54, params_t52);
 
                             // Spmd exp_gate_up_act_spmd: exp_gate_up_act
@@ -2215,10 +2228,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t53.add_input(recv_scale_out_inline9172);
                             params_t53.add_input(routed_w1_scale_l0_inline654);
                             params_t53.add_input(routed_w3_scale_l0_inline562);
+                            params_t53.add_input(recv_count_out_inline9338);
                             params_t53.add_scalar(local_i_inline2779_inline9183);
                             params_t53.add_scalar(t0_inline2784_inline9444);
-                            params_t53.add_scalar(valid_rows_inline2759_inline9446);
                             params_t53.launch_spec.set_block_num(4);
+                            params_t53.set_predicate(expert_rows_pred);
                             rt_submit_aiv_task(55, params_t53);
                             uint32_t h_tile_i8_inline2806_inline9280_offsets[2] = {
                                 static_cast<uint32_t>(flat_t0_inline2786_inline9408), 0
@@ -2269,6 +2283,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t54.add_input(h_tile_fp32_inline2744_inline9423);
                             params_t54.add_inout(h_tile_scale_dq_inline2808_inline9161);
                             params_t54.add_output(h_tile_i8_inline2806_inline9280);
+                            params_t54.set_predicate(expert_rows_pred);
                             rt_submit_aiv_task(56, params_t54);
                         }
                     }
@@ -2277,12 +2292,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     for (int64_t local_e_inline2742_inline9382 = 0; local_e_inline2742_inline9382 < 32;
                          local_e_inline2742_inline9382 += 1) {
                         int64_t e_flat_base_inline2746_inline9260 = (local_e_inline2742_inline9382 * 16);
-                        uint32_t indices_e_rows_inline2760_inline9155[2] = {
-                            static_cast<uint32_t>(local_e_inline2742_inline9382), 0
-                        };
-                        int32_t e_rows_inline2760_inline9155 = get_tensor_data<int32_t>(
-                            recv_count_out_inline9338, 2, indices_e_rows_inline2760_inline9155
-                        );
+                        int32_t e_rows_inline2760_inline9155 = EXPERT_ROWS_BUDGET;
                         int64_t e_tiles_inline2741_inline9384 =
                             ((static_cast<int64_t>(e_rows_inline2760_inline9155) + 15) / 16);
                         for (int64_t tt_inline2776_inline9154 = 0;
@@ -2294,6 +2304,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             TaskOutputTensors alloc_27 = alloc_tensors(y_i32_inline2737_inline9279_ci);
                             const ChipTensor &y_i32_inline2737_inline9279 = alloc_27.get_ref(0);
                             int64_t tt0_inline2740_inline9153 = (tt_inline2776_inline9154 * 16);
+                            CoreTaskPredicate expert_rows_pred;
+                            expert_rows_pred.operand.tensor = &recv_count_out_inline9338;
+                            expert_rows_pred.operand.ndims = 2;
+                            expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_e_inline2742_inline9382);
+                            expert_rows_pred.operand.indices[1] = 0;
+                            expert_rows_pred.op = PredicateOp::GT;
+                            expert_rows_pred.target = tt0_inline2740_inline9153;
                             int64_t flat_tt0_inline2738_inline9350 =
                                 (e_flat_base_inline2746_inline9260 + tt0_inline2740_inline9153);
                             uint32_t h_tile_i8_inline2806_inline9280__ssa_v4_offsets[2] = {
@@ -2352,6 +2369,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t55.add_scalar(local_e_inline2742_inline9382);
                             params_t55.launch_spec.set_block_num(4);
                             params_t55.set_allow_early_resolve(true);
+                            params_t55.set_predicate(expert_rows_pred);
                             TaskOutputTensors task_55_outs = rt_submit_aic_task(57, params_t55);
                             uint32_t recv_y_tile_inline2730_inline9150_offsets[2] = {
                                 static_cast<uint32_t>(flat_tt0_inline2738_inline9350), 0
@@ -2387,6 +2405,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t56.add_scalar(tt0_inline2740_inline9153);
                             params_t56.launch_spec.set_block_num(1);
                             params_t56.set_allow_early_resolve(true);
+                            params_t56.set_predicate(expert_rows_pred);
                             TaskOutputTensors task_56_outs = rt_submit_aiv_task(58, params_t56);
                         }
                     }
@@ -3571,21 +3590,21 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 for (int64_t local_i_inline2779_inline9945 = 0; local_i_inline2779_inline9945 < 32;
                      local_i_inline2779_inline9945 += 1) {
                     int64_t flat_base_inline2774_inline9982 = (local_i_inline2779_inline9945 * 16);
-                    uint32_t indices_n_rows_inline2782_inline10204[2] = {
-                        static_cast<uint32_t>(local_i_inline2779_inline9945), 0
-                    };
-                    int32_t n_rows_inline2782_inline10204 =
-                        get_tensor_data<int32_t>(recv_count_out_inline10100, 2, indices_n_rows_inline2782_inline10204);
+                    int32_t n_rows_inline2782_inline10204 = EXPERT_ROWS_BUDGET;
                     int64_t n_tiles_inline2780_inline10177 =
                         ((static_cast<int64_t>(n_rows_inline2782_inline10204) + 15) / 16);
                     for (int64_t t_inline2778_inline10205 = 0;
                          t_inline2778_inline10205 < n_tiles_inline2780_inline10177; t_inline2778_inline10205 += 1) {
                         int64_t t0_inline2784_inline10206 = (t_inline2778_inline10205 * 16);
+                        CoreTaskPredicate expert_rows_pred;
+                        expert_rows_pred.operand.tensor = &recv_count_out_inline10100;
+                        expert_rows_pred.operand.ndims = 2;
+                        expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_i_inline2779_inline9945);
+                        expert_rows_pred.operand.indices[1] = 0;
+                        expert_rows_pred.op = PredicateOp::GT;
+                        expert_rows_pred.target = t0_inline2784_inline10206;
                         int64_t flat_t0_inline2786_inline10170 =
                             (flat_base_inline2774_inline9982 + t0_inline2784_inline10206);
-                        int64_t valid_rows_inline2759_inline10208 = std::min<int64_t>(
-                            (static_cast<int64_t>(n_rows_inline2782_inline10204) - t0_inline2784_inline10206), 16
-                        );
                         PTO2_SCOPE() {
                             uint32_t gate_tile_i32_inline2749_inline10057_ci_shapes[2] = {16, 2048};
                             TensorCreateInfo gate_tile_i32_inline2749_inline10057_ci(
@@ -3615,6 +3634,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t108.add_scalar(flat_t0_inline2786_inline10170);
                             params_t108.add_scalar(local_i_inline2779_inline9945);
                             params_t108.launch_spec.set_block_num(2);
+                            params_t108.set_predicate(expert_rows_pred);
                             rt_submit_aic_task(112, params_t108);
 
                             // Spmd exp_up_mm_spmd_0: exp_up_mm_0
@@ -3625,6 +3645,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t109.add_scalar(flat_t0_inline2786_inline10170);
                             params_t109.add_scalar(local_i_inline2779_inline9945);
                             params_t109.launch_spec.set_block_num(2);
+                            params_t109.set_predicate(expert_rows_pred);
                             rt_submit_aic_task(113, params_t109);
 
                             // Spmd exp_gate_up_act_spmd_0: exp_gate_up_act_0
@@ -3635,10 +3656,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t110.add_input(recv_scale_out_inline9934);
                             params_t110.add_input(routed_w1_scale_l1_inline668);
                             params_t110.add_input(routed_w3_scale_l1_inline689);
+                            params_t110.add_input(recv_count_out_inline10100);
                             params_t110.add_scalar(local_i_inline2779_inline9945);
                             params_t110.add_scalar(t0_inline2784_inline10206);
-                            params_t110.add_scalar(valid_rows_inline2759_inline10208);
                             params_t110.launch_spec.set_block_num(4);
+                            params_t110.set_predicate(expert_rows_pred);
                             rt_submit_aiv_task(114, params_t110);
                             uint32_t h_tile_i8_inline2806_inline10042_offsets[2] = {
                                 static_cast<uint32_t>(flat_t0_inline2786_inline10170), 0
@@ -3689,6 +3711,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t111.add_input(h_tile_fp32_inline2744_inline10185);
                             params_t111.add_inout(h_tile_scale_dq_inline2808_inline9923);
                             params_t111.add_output(h_tile_i8_inline2806_inline10042);
+                            params_t111.set_predicate(expert_rows_pred);
                             rt_submit_aiv_task(115, params_t111);
                         }
                     }
@@ -3697,12 +3720,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     for (int64_t local_e_inline2742_inline10144 = 0; local_e_inline2742_inline10144 < 32;
                          local_e_inline2742_inline10144 += 1) {
                         int64_t e_flat_base_inline2746_inline10022 = (local_e_inline2742_inline10144 * 16);
-                        uint32_t indices_e_rows_inline2760_inline9917[2] = {
-                            static_cast<uint32_t>(local_e_inline2742_inline10144), 0
-                        };
-                        int32_t e_rows_inline2760_inline9917 = get_tensor_data<int32_t>(
-                            recv_count_out_inline10100, 2, indices_e_rows_inline2760_inline9917
-                        );
+                        int32_t e_rows_inline2760_inline9917 = EXPERT_ROWS_BUDGET;
                         int64_t e_tiles_inline2741_inline10146 =
                             ((static_cast<int64_t>(e_rows_inline2760_inline9917) + 15) / 16);
                         for (int64_t tt_inline2776_inline9916 = 0;
@@ -3714,6 +3732,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             TaskOutputTensors alloc_54 = alloc_tensors(y_i32_inline2737_inline10041_ci);
                             const ChipTensor &y_i32_inline2737_inline10041 = alloc_54.get_ref(0);
                             int64_t tt0_inline2740_inline9915 = (tt_inline2776_inline9916 * 16);
+                            CoreTaskPredicate expert_rows_pred;
+                            expert_rows_pred.operand.tensor = &recv_count_out_inline10100;
+                            expert_rows_pred.operand.ndims = 2;
+                            expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_e_inline2742_inline10144);
+                            expert_rows_pred.operand.indices[1] = 0;
+                            expert_rows_pred.op = PredicateOp::GT;
+                            expert_rows_pred.target = tt0_inline2740_inline9915;
                             int64_t flat_tt0_inline2738_inline10112 =
                                 (e_flat_base_inline2746_inline10022 + tt0_inline2740_inline9915);
                             uint32_t h_tile_i8_inline2806_inline10042__ssa_v4_offsets[2] = {
@@ -3772,6 +3797,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t112.add_scalar(local_e_inline2742_inline10144);
                             params_t112.launch_spec.set_block_num(4);
                             params_t112.set_allow_early_resolve(true);
+                            params_t112.set_predicate(expert_rows_pred);
                             TaskOutputTensors task_112_outs = rt_submit_aic_task(116, params_t112);
                             uint32_t recv_y_tile_inline2730_inline9912_offsets[2] = {
                                 static_cast<uint32_t>(flat_tt0_inline2738_inline10112), 0
@@ -3807,6 +3833,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t113.add_scalar(tt0_inline2740_inline9915);
                             params_t113.launch_spec.set_block_num(1);
                             params_t113.set_allow_early_resolve(true);
+                            params_t113.set_predicate(expert_rows_pred);
                             TaskOutputTensors task_113_outs = rt_submit_aiv_task(117, params_t113);
                         }
                     }
@@ -6186,22 +6213,21 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     for (int64_t local_i_inline2779_inline10990 = 0; local_i_inline2779_inline10990 < 32;
                          local_i_inline2779_inline10990 += 1) {
                         int64_t flat_base_inline2774_inline11027 = (local_i_inline2779_inline10990 * 16);
-                        uint32_t indices_n_rows_inline2782_inline11249[2] = {
-                            static_cast<uint32_t>(local_i_inline2779_inline10990), 0
-                        };
-                        int32_t n_rows_inline2782_inline11249 = get_tensor_data<int32_t>(
-                            recv_count_out_inline11145, 2, indices_n_rows_inline2782_inline11249
-                        );
+                        int32_t n_rows_inline2782_inline11249 = EXPERT_ROWS_BUDGET;
                         int64_t n_tiles_inline2780_inline11222 =
                             ((static_cast<int64_t>(n_rows_inline2782_inline11249) + 15) / 16);
                         for (int64_t t_inline2778_inline11250 = 0;
                              t_inline2778_inline11250 < n_tiles_inline2780_inline11222; t_inline2778_inline11250 += 1) {
                             int64_t t0_inline2784_inline11251 = (t_inline2778_inline11250 * 16);
+                            CoreTaskPredicate expert_rows_pred;
+                            expert_rows_pred.operand.tensor = &recv_count_out_inline11145;
+                            expert_rows_pred.operand.ndims = 2;
+                            expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_i_inline2779_inline10990);
+                            expert_rows_pred.operand.indices[1] = 0;
+                            expert_rows_pred.op = PredicateOp::GT;
+                            expert_rows_pred.target = t0_inline2784_inline11251;
                             int64_t flat_t0_inline2786_inline11215 =
                                 (flat_base_inline2774_inline11027 + t0_inline2784_inline11251);
-                            int64_t valid_rows_inline2759_inline11253 = std::min<int64_t>(
-                                (static_cast<int64_t>(n_rows_inline2782_inline11249) - t0_inline2784_inline11251), 16
-                            );
                             PTO2_SCOPE() {
                                 uint32_t gate_tile_i32_inline2749_inline11102_ci_shapes[2] = {16, 2048};
                                 TensorCreateInfo gate_tile_i32_inline2749_inline11102_ci(
@@ -6231,6 +6257,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t188.add_scalar(flat_t0_inline2786_inline11215);
                                 params_t188.add_scalar(local_i_inline2779_inline10990);
                                 params_t188.launch_spec.set_block_num(2);
+                                params_t188.set_predicate(expert_rows_pred);
                                 rt_submit_aic_task(195, params_t188);
 
                                 // Spmd exp_up_mm_spmd_1: exp_up_mm_1
@@ -6241,6 +6268,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t189.add_scalar(flat_t0_inline2786_inline11215);
                                 params_t189.add_scalar(local_i_inline2779_inline10990);
                                 params_t189.launch_spec.set_block_num(2);
+                                params_t189.set_predicate(expert_rows_pred);
                                 rt_submit_aic_task(196, params_t189);
 
                                 // Spmd exp_gate_up_act_spmd_1: exp_gate_up_act_1
@@ -6251,10 +6279,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t190.add_input(recv_scale_out_inline10979);
                                 params_t190.add_input(routed_w1_scale_csa_inline535);
                                 params_t190.add_input(routed_w3_scale_csa_inline713);
+                                params_t190.add_input(recv_count_out_inline11145);
                                 params_t190.add_scalar(local_i_inline2779_inline10990);
                                 params_t190.add_scalar(t0_inline2784_inline11251);
-                                params_t190.add_scalar(valid_rows_inline2759_inline11253);
                                 params_t190.launch_spec.set_block_num(4);
+                                params_t190.set_predicate(expert_rows_pred);
                                 rt_submit_aiv_task(197, params_t190);
                                 uint32_t h_tile_i8_inline2806_inline11087_offsets[2] = {
                                     static_cast<uint32_t>(flat_t0_inline2786_inline11215), 0
@@ -6308,6 +6337,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t191.add_input(h_tile_fp32_inline2744_inline11230);
                                 params_t191.add_inout(h_tile_scale_dq_inline2808_inline10968);
                                 params_t191.add_inout(h_tile_i8_inline2806_inline11087);
+                                params_t191.set_predicate(expert_rows_pred);
                                 rt_submit_aiv_task(198, params_t191);
                             }
                         }
@@ -6316,12 +6346,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         for (int64_t local_e_inline2742_inline11189 = 0; local_e_inline2742_inline11189 < 32;
                              local_e_inline2742_inline11189 += 1) {
                             int64_t e_flat_base_inline2746_inline11067 = (local_e_inline2742_inline11189 * 16);
-                            uint32_t indices_e_rows_inline2760_inline10962[2] = {
-                                static_cast<uint32_t>(local_e_inline2742_inline11189), 0
-                            };
-                            int32_t e_rows_inline2760_inline10962 = get_tensor_data<int32_t>(
-                                recv_count_out_inline11145, 2, indices_e_rows_inline2760_inline10962
-                            );
+                            int32_t e_rows_inline2760_inline10962 = EXPERT_ROWS_BUDGET;
                             int64_t e_tiles_inline2741_inline11191 =
                                 ((static_cast<int64_t>(e_rows_inline2760_inline10962) + 15) / 16);
                             for (int64_t tt_inline2776_inline10961 = 0;
@@ -6334,6 +6359,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 TaskOutputTensors alloc_84 = alloc_tensors(y_i32_inline2737_inline11086_ci);
                                 const ChipTensor &y_i32_inline2737_inline11086 = alloc_84.get_ref(0);
                                 int64_t tt0_inline2740_inline10960 = (tt_inline2776_inline10961 * 16);
+                                CoreTaskPredicate expert_rows_pred;
+                                expert_rows_pred.operand.tensor = &recv_count_out_inline11145;
+                                expert_rows_pred.operand.ndims = 2;
+                                expert_rows_pred.operand.indices[0] =
+                                    static_cast<uint32_t>(local_e_inline2742_inline11189);
+                                expert_rows_pred.operand.indices[1] = 0;
+                                expert_rows_pred.op = PredicateOp::GT;
+                                expert_rows_pred.target = tt0_inline2740_inline10960;
                                 int64_t flat_tt0_inline2738_inline11157 =
                                     (e_flat_base_inline2746_inline11067 + tt0_inline2740_inline10960);
                                 uint32_t h_tile_i8_inline2806_inline11087__ssa_v4_offsets[2] = {
@@ -6392,6 +6425,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t192.add_scalar(local_e_inline2742_inline11189);
                                 params_t192.launch_spec.set_block_num(4);
                                 params_t192.set_allow_early_resolve(true);
+                                params_t192.set_predicate(expert_rows_pred);
                                 TaskOutputTensors task_192_outs = rt_submit_aic_task(199, params_t192);
                                 uint32_t recv_y_tile_inline2730_inline10957_offsets[2] = {
                                     static_cast<uint32_t>(flat_tt0_inline2738_inline11157), 0
@@ -6428,6 +6462,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t193.add_scalar(tt0_inline2740_inline10960);
                                 params_t193.launch_spec.set_block_num(1);
                                 params_t193.set_allow_early_resolve(true);
+                                params_t193.set_predicate(expert_rows_pred);
                                 TaskOutputTensors task_193_outs = rt_submit_aiv_task(200, params_t193);
                             }
                         }
@@ -8306,22 +8341,21 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     for (int64_t local_i_inline2779_inline11869 = 0; local_i_inline2779_inline11869 < 32;
                          local_i_inline2779_inline11869 += 1) {
                         int64_t flat_base_inline2774_inline11906 = (local_i_inline2779_inline11869 * 16);
-                        uint32_t indices_n_rows_inline2782_inline12128[2] = {
-                            static_cast<uint32_t>(local_i_inline2779_inline11869), 0
-                        };
-                        int32_t n_rows_inline2782_inline12128 = get_tensor_data<int32_t>(
-                            recv_count_out_inline12024, 2, indices_n_rows_inline2782_inline12128
-                        );
+                        int32_t n_rows_inline2782_inline12128 = EXPERT_ROWS_BUDGET;
                         int64_t n_tiles_inline2780_inline12101 =
                             ((static_cast<int64_t>(n_rows_inline2782_inline12128) + 15) / 16);
                         for (int64_t t_inline2778_inline12129 = 0;
                              t_inline2778_inline12129 < n_tiles_inline2780_inline12101; t_inline2778_inline12129 += 1) {
                             int64_t t0_inline2784_inline12130 = (t_inline2778_inline12129 * 16);
+                            CoreTaskPredicate expert_rows_pred;
+                            expert_rows_pred.operand.tensor = &recv_count_out_inline12024;
+                            expert_rows_pred.operand.ndims = 2;
+                            expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_i_inline2779_inline11869);
+                            expert_rows_pred.operand.indices[1] = 0;
+                            expert_rows_pred.op = PredicateOp::GT;
+                            expert_rows_pred.target = t0_inline2784_inline12130;
                             int64_t flat_t0_inline2786_inline12094 =
                                 (flat_base_inline2774_inline11906 + t0_inline2784_inline12130);
-                            int64_t valid_rows_inline2759_inline12132 = std::min<int64_t>(
-                                (static_cast<int64_t>(n_rows_inline2782_inline12128) - t0_inline2784_inline12130), 16
-                            );
                             PTO2_SCOPE() {
                                 uint32_t gate_tile_i32_inline2749_inline11981_ci_shapes[2] = {16, 2048};
                                 TensorCreateInfo gate_tile_i32_inline2749_inline11981_ci(
@@ -8351,6 +8385,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t252.add_scalar(flat_t0_inline2786_inline12094);
                                 params_t252.add_scalar(local_i_inline2779_inline11869);
                                 params_t252.launch_spec.set_block_num(2);
+                                params_t252.set_predicate(expert_rows_pred);
                                 rt_submit_aic_task(261, params_t252);
 
                                 // Spmd exp_up_mm_spmd_2: exp_up_mm_2
@@ -8361,6 +8396,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t253.add_scalar(flat_t0_inline2786_inline12094);
                                 params_t253.add_scalar(local_i_inline2779_inline11869);
                                 params_t253.launch_spec.set_block_num(2);
+                                params_t253.set_predicate(expert_rows_pred);
                                 rt_submit_aic_task(262, params_t253);
 
                                 // Spmd exp_gate_up_act_spmd_2: exp_gate_up_act_2
@@ -8371,10 +8407,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t254.add_input(recv_scale_out_inline11858);
                                 params_t254.add_input(routed_w1_scale_hca_inline687);
                                 params_t254.add_input(routed_w3_scale_hca_inline513);
+                                params_t254.add_input(recv_count_out_inline12024);
                                 params_t254.add_scalar(local_i_inline2779_inline11869);
                                 params_t254.add_scalar(t0_inline2784_inline12130);
-                                params_t254.add_scalar(valid_rows_inline2759_inline12132);
                                 params_t254.launch_spec.set_block_num(4);
+                                params_t254.set_predicate(expert_rows_pred);
                                 rt_submit_aiv_task(263, params_t254);
                                 uint32_t h_tile_i8_inline2806_inline11966_offsets[2] = {
                                     static_cast<uint32_t>(flat_t0_inline2786_inline12094), 0
@@ -8428,6 +8465,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t255.add_input(h_tile_fp32_inline2744_inline12109);
                                 params_t255.add_inout(h_tile_scale_dq_inline2808_inline11847);
                                 params_t255.add_inout(h_tile_i8_inline2806_inline11966);
+                                params_t255.set_predicate(expert_rows_pred);
                                 rt_submit_aiv_task(264, params_t255);
                             }
                         }
@@ -8436,12 +8474,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         for (int64_t local_e_inline2742_inline12068 = 0; local_e_inline2742_inline12068 < 32;
                              local_e_inline2742_inline12068 += 1) {
                             int64_t e_flat_base_inline2746_inline11946 = (local_e_inline2742_inline12068 * 16);
-                            uint32_t indices_e_rows_inline2760_inline11841[2] = {
-                                static_cast<uint32_t>(local_e_inline2742_inline12068), 0
-                            };
-                            int32_t e_rows_inline2760_inline11841 = get_tensor_data<int32_t>(
-                                recv_count_out_inline12024, 2, indices_e_rows_inline2760_inline11841
-                            );
+                            int32_t e_rows_inline2760_inline11841 = EXPERT_ROWS_BUDGET;
                             int64_t e_tiles_inline2741_inline12070 =
                                 ((static_cast<int64_t>(e_rows_inline2760_inline11841) + 15) / 16);
                             for (int64_t tt_inline2776_inline11840 = 0;
@@ -8454,6 +8487,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 TaskOutputTensors alloc_112 = alloc_tensors(y_i32_inline2737_inline11965_ci);
                                 const ChipTensor &y_i32_inline2737_inline11965 = alloc_112.get_ref(0);
                                 int64_t tt0_inline2740_inline11839 = (tt_inline2776_inline11840 * 16);
+                                CoreTaskPredicate expert_rows_pred;
+                                expert_rows_pred.operand.tensor = &recv_count_out_inline12024;
+                                expert_rows_pred.operand.ndims = 2;
+                                expert_rows_pred.operand.indices[0] =
+                                    static_cast<uint32_t>(local_e_inline2742_inline12068);
+                                expert_rows_pred.operand.indices[1] = 0;
+                                expert_rows_pred.op = PredicateOp::GT;
+                                expert_rows_pred.target = tt0_inline2740_inline11839;
                                 int64_t flat_tt0_inline2738_inline12036 =
                                     (e_flat_base_inline2746_inline11946 + tt0_inline2740_inline11839);
                                 uint32_t h_tile_i8_inline2806_inline11966__ssa_v4_offsets[2] = {
@@ -8512,6 +8553,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t256.add_scalar(local_e_inline2742_inline12068);
                                 params_t256.launch_spec.set_block_num(4);
                                 params_t256.set_allow_early_resolve(true);
+                                params_t256.set_predicate(expert_rows_pred);
                                 TaskOutputTensors task_256_outs = rt_submit_aic_task(265, params_t256);
                                 uint32_t recv_y_tile_inline2730_inline11836_offsets[2] = {
                                     static_cast<uint32_t>(flat_tt0_inline2738_inline12036), 0
@@ -8548,6 +8590,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t257.add_scalar(tt0_inline2740_inline11839);
                                 params_t257.launch_spec.set_block_num(1);
                                 params_t257.set_allow_early_resolve(true);
+                                params_t257.set_predicate(expert_rows_pred);
                                 TaskOutputTensors task_257_outs = rt_submit_aiv_task(266, params_t257);
                             }
                         }
@@ -10861,21 +10904,21 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 for (int64_t local_i_inline2779_inline12914 = 0; local_i_inline2779_inline12914 < 32;
                      local_i_inline2779_inline12914 += 1) {
                     int64_t flat_base_inline2774_inline12951 = (local_i_inline2779_inline12914 * 16);
-                    uint32_t indices_n_rows_inline2782_inline13173[2] = {
-                        static_cast<uint32_t>(local_i_inline2779_inline12914), 0
-                    };
-                    int32_t n_rows_inline2782_inline13173 =
-                        get_tensor_data<int32_t>(recv_count_out_inline13069, 2, indices_n_rows_inline2782_inline13173);
+                    int32_t n_rows_inline2782_inline13173 = EXPERT_ROWS_BUDGET;
                     int64_t n_tiles_inline2780_inline13146 =
                         ((static_cast<int64_t>(n_rows_inline2782_inline13173) + 15) / 16);
                     for (int64_t t_inline2778_inline13174 = 0;
                          t_inline2778_inline13174 < n_tiles_inline2780_inline13146; t_inline2778_inline13174 += 1) {
                         int64_t t0_inline2784_inline13175 = (t_inline2778_inline13174 * 16);
+                        CoreTaskPredicate expert_rows_pred;
+                        expert_rows_pred.operand.tensor = &recv_count_out_inline13069;
+                        expert_rows_pred.operand.ndims = 2;
+                        expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_i_inline2779_inline12914);
+                        expert_rows_pred.operand.indices[1] = 0;
+                        expert_rows_pred.op = PredicateOp::GT;
+                        expert_rows_pred.target = t0_inline2784_inline13175;
                         int64_t flat_t0_inline2786_inline13139 =
                             (flat_base_inline2774_inline12951 + t0_inline2784_inline13175);
-                        int64_t valid_rows_inline2759_inline13177 = std::min<int64_t>(
-                            (static_cast<int64_t>(n_rows_inline2782_inline13173) - t0_inline2784_inline13175), 16
-                        );
                         PTO2_SCOPE() {
                             uint32_t gate_tile_i32_inline2749_inline13026_ci_shapes[2] = {16, 2048};
                             TensorCreateInfo gate_tile_i32_inline2749_inline13026_ci(
@@ -10905,6 +10948,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t331.add_scalar(flat_t0_inline2786_inline13139);
                             params_t331.add_scalar(local_i_inline2779_inline12914);
                             params_t331.launch_spec.set_block_num(2);
+                            params_t331.set_predicate(expert_rows_pred);
                             rt_submit_aic_task(343, params_t331);
 
                             // Spmd exp_up_mm_spmd_3: exp_up_mm_3
@@ -10915,6 +10959,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t332.add_scalar(flat_t0_inline2786_inline13139);
                             params_t332.add_scalar(local_i_inline2779_inline12914);
                             params_t332.launch_spec.set_block_num(2);
+                            params_t332.set_predicate(expert_rows_pred);
                             rt_submit_aic_task(344, params_t332);
 
                             // Spmd exp_gate_up_act_spmd_3: exp_gate_up_act_3
@@ -10925,10 +10970,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t333.add_input(recv_scale_out_inline12903);
                             params_t333.add_input(routed_w1_scale_last_inline490);
                             params_t333.add_input(routed_w3_scale_last_inline673);
+                            params_t333.add_input(recv_count_out_inline13069);
                             params_t333.add_scalar(local_i_inline2779_inline12914);
                             params_t333.add_scalar(t0_inline2784_inline13175);
-                            params_t333.add_scalar(valid_rows_inline2759_inline13177);
                             params_t333.launch_spec.set_block_num(4);
+                            params_t333.set_predicate(expert_rows_pred);
                             rt_submit_aiv_task(345, params_t333);
                             uint32_t h_tile_i8_inline2806_inline13011_offsets[2] = {
                                 static_cast<uint32_t>(flat_t0_inline2786_inline13139), 0
@@ -10979,6 +11025,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t334.add_input(h_tile_fp32_inline2744_inline13154);
                             params_t334.add_inout(h_tile_scale_dq_inline2808_inline12892);
                             params_t334.add_output(h_tile_i8_inline2806_inline13011);
+                            params_t334.set_predicate(expert_rows_pred);
                             rt_submit_aiv_task(346, params_t334);
                         }
                     }
@@ -10987,12 +11034,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     for (int64_t local_e_inline2742_inline13113 = 0; local_e_inline2742_inline13113 < 32;
                          local_e_inline2742_inline13113 += 1) {
                         int64_t e_flat_base_inline2746_inline12991 = (local_e_inline2742_inline13113 * 16);
-                        uint32_t indices_e_rows_inline2760_inline12886[2] = {
-                            static_cast<uint32_t>(local_e_inline2742_inline13113), 0
-                        };
-                        int32_t e_rows_inline2760_inline12886 = get_tensor_data<int32_t>(
-                            recv_count_out_inline13069, 2, indices_e_rows_inline2760_inline12886
-                        );
+                        int32_t e_rows_inline2760_inline12886 = EXPERT_ROWS_BUDGET;
                         int64_t e_tiles_inline2741_inline13115 =
                             ((static_cast<int64_t>(e_rows_inline2760_inline12886) + 15) / 16);
                         for (int64_t tt_inline2776_inline12885 = 0;
@@ -11005,6 +11047,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             TaskOutputTensors alloc_141 = alloc_tensors(y_i32_inline2737_inline13010_ci);
                             const ChipTensor &y_i32_inline2737_inline13010 = alloc_141.get_ref(0);
                             int64_t tt0_inline2740_inline12884 = (tt_inline2776_inline12885 * 16);
+                            CoreTaskPredicate expert_rows_pred;
+                            expert_rows_pred.operand.tensor = &recv_count_out_inline13069;
+                            expert_rows_pred.operand.ndims = 2;
+                            expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_e_inline2742_inline13113);
+                            expert_rows_pred.operand.indices[1] = 0;
+                            expert_rows_pred.op = PredicateOp::GT;
+                            expert_rows_pred.target = tt0_inline2740_inline12884;
                             int64_t flat_tt0_inline2738_inline13081 =
                                 (e_flat_base_inline2746_inline12991 + tt0_inline2740_inline12884);
                             uint32_t h_tile_i8_inline2806_inline13011__ssa_v4_offsets[2] = {
@@ -11063,6 +11112,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t335.add_scalar(local_e_inline2742_inline13113);
                             params_t335.launch_spec.set_block_num(4);
                             params_t335.set_allow_early_resolve(true);
+                            params_t335.set_predicate(expert_rows_pred);
                             TaskOutputTensors task_335_outs = rt_submit_aic_task(347, params_t335);
                             uint32_t recv_y_tile_inline2730_inline12881_offsets[2] = {
                                 static_cast<uint32_t>(flat_tt0_inline2738_inline13081), 0
@@ -11098,6 +11148,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t336.add_scalar(tt0_inline2740_inline12884);
                             params_t336.launch_spec.set_block_num(1);
                             params_t336.set_allow_early_resolve(true);
+                            params_t336.set_predicate(expert_rows_pred);
                             TaskOutputTensors task_336_outs = rt_submit_aiv_task(348, params_t336);
                         }
                     }

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
@@ -111,7 +111,7 @@ _KERNELS = [
     (52, "dispatch_gather", "aiv", "oiiiooio"),
     (53, "exp_gate_mm", "aic", "oii"),
     (54, "exp_up_mm", "aic", "oii"),
-    (55, "exp_gate_up_act", "aiv", "oiiiii"),
+    (55, "exp_gate_up_act", "aiv", "oiiiiii"),
     (56, "exp_h_q", "aiv", "ixo"),
     (57, "exp_w2_mm", "aic", "oii"),
     (58, "exp_w2_act", "aiv", "iioii"),
@@ -170,7 +170,7 @@ _KERNELS = [
     (111, "dispatch_gather_0", "aiv", "oiiiooio"),
     (112, "exp_gate_mm_0", "aic", "oii"),
     (113, "exp_up_mm_0", "aic", "oii"),
-    (114, "exp_gate_up_act_0", "aiv", "oiiiii"),
+    (114, "exp_gate_up_act_0", "aiv", "oiiiiii"),
     (115, "exp_h_q_0", "aiv", "ixo"),
     (116, "exp_w2_mm_0", "aic", "oii"),
     (117, "exp_w2_act_0", "aiv", "iioii"),
@@ -253,7 +253,7 @@ _KERNELS = [
     (194, "dispatch_gather_1", "aiv", "xiiixxix"),
     (195, "exp_gate_mm_1", "aic", "xii"),
     (196, "exp_up_mm_1", "aic", "xii"),
-    (197, "exp_gate_up_act_1", "aiv", "xiiiii"),
+    (197, "exp_gate_up_act_1", "aiv", "xiiiiii"),
     (198, "exp_h_q_1", "aiv", "ixx"),
     (199, "exp_w2_mm_1", "aic", "xii"),
     (200, "exp_w2_act_1", "aiv", "iixii"),
@@ -319,7 +319,7 @@ _KERNELS = [
     (260, "dispatch_gather_2", "aiv", "xiiixxix"),
     (261, "exp_gate_mm_2", "aic", "xii"),
     (262, "exp_up_mm_2", "aic", "xii"),
-    (263, "exp_gate_up_act_2", "aiv", "xiiiii"),
+    (263, "exp_gate_up_act_2", "aiv", "xiiiiii"),
     (264, "exp_h_q_2", "aiv", "ixx"),
     (265, "exp_w2_mm_2", "aic", "xii"),
     (266, "exp_w2_act_2", "aiv", "iixii"),
@@ -401,7 +401,7 @@ _KERNELS = [
     (342, "dispatch_gather_3", "aiv", "oiiiooio"),
     (343, "exp_gate_mm_3", "aic", "oii"),
     (344, "exp_up_mm_3", "aic", "oii"),
-    (345, "exp_gate_up_act_3", "aiv", "oiiiii"),
+    (345, "exp_gate_up_act_3", "aiv", "oiiiiii"),
     (346, "exp_h_q_3", "aiv", "ixo"),
     (347, "exp_w2_mm_3", "aic", "oii"),
     (348, "exp_w2_act_3", "aiv", "iioii"),
@@ -614,11 +614,15 @@ class TestDeepseekV4FlashDecode(SceneTestCase):
             "config": {
                 "device_count": N_RANKS,
                 "num_sub_workers": 0,
-                # Ring sizing for the 43-layer graph, matching pypto-lib's daily
-                # CI env for this network (PTO2_RING_* 16384 / 16384 / 1 GiB).
+                # Ring sizing for the 43-layer graph. The task window and dep
+                # pool match pypto-lib's daily CI env for this network
+                # (PTO2_RING_* 16384 / 16384). The heap is twice that env's
+                # 1 GiB: the MoE per-expert tile grid is static, so tile scratch
+                # is allocated for all 32 experts of every MoE layer whatever the
+                # routing turns out to be.
                 "runtime_env": {
                     "ring_task_window": 16384,
-                    "ring_heap": 1 << 30,
+                    "ring_heap": 2 << 30,
                     "ring_dep_pool": 16384,
                 },
             },


### PR DESCRIPTION
## What

Follows #1921 (merged) — that PR moved the DSv4 orchestrations' 30 **data** `get_tensor_data` reads (the `hc_*_scale_*` values) into the consuming kernels. This one finishes the job for the reads #1921 left behind: the ten `recv_count_out[expert][0]` reads driving the MoE per-expert tile loops, the last orchestration reads of a **task-produced** tensor.

- on `tensormap_and_ringbuffer` they stall the AICPU orchestrator on a producer wait;
- on `host_build_graph` they have no value to return **at all** — the host builds the whole graph before the device executes anything — so the ten sites stood `HBG_RECV_ROWS_PER_EXPERT = 16` in as a temporary stand-in, and that copy encoded a routing the fixture does not have.

The count now steers the loops from the device side, split by role:

**Trip count → dispatch predicate.** Both runtimes build a static per-expert tile grid — the `h_i8 [512, 2048]` layout budgets 16 rows per expert and a tile is 16 rows, so one tile per expert — and each of a tile's six tasks (`exp_gate_mm`, `exp_up_mm`, `exp_gate_up_act`, `exp_h_q`, `exp_w2_mm`, `exp_w2_act`) carries a dispatch predicate on that element:

```cpp
CoreTaskPredicate expert_rows_pred;                 // recv_count_out[expert][0] > t0
expert_rows_pred.operand.tensor = &recv_count_out_inline9338;
expert_rows_pred.operand.ndims = 2;
expert_rows_pred.operand.indices[0] = static_cast<uint32_t>(local_i_inline2779_inline9183);
expert_rows_pred.operand.indices[1] = 0;
expert_rows_pred.op = PredicateOp::GT;
expert_rows_pred.target = t0_inline2784_inline9444;
```

The scheduler evaluates it at the dispatch point, where the task is already ready and the count is therefore current. An expert whose count does not reach the tile's first row has the tile's tasks retired inline, never dispatched to a core. 10 sites × 2 files, 30 `set_predicate` calls each, symmetric.

**`valid_rows` → kernel-side read.** The one value the loops computed from the count, `valid_rows = min(count - t0, 16)`, was a task scalar of `exp_gate_up_act*`. It moves into the kernels the same way #1921 moved the scales: the orchestrations pass `recv_count_out` as an extra tensor input at the former first-scalar slot, and each of the five kernels derives the row count from GM in `kernel_entry`, after a single-line `dcci` on the element (the count lives in the ring heap, so a line this core cached under an earlier tensor could otherwise serve it). The predicate guarantees `count - t0 >= 1` whenever the kernel runs. The inner ptoas-generated functions are untouched; the five `_KERNELS` signatures grow a trailing input (`oiiiii → oiiiiii`, `xiiiii → xiiiiii`).

## Why no dependency is declared

The predicate declares none on either path, by design — the caller does. None is needed here: every task in a tile consumes a `dispatch_gather` output, and `dispatch_gather` carries an explicit dependency on `dispatch_meta`, which writes `recv_count_out`. Inside the Graph body that edge is recorded as a fanin, so the ordering survives replay; the new tensor input additionally records a direct fanin on the `dispatch_meta` node.

## Consequences

- **`decode_fwd_graph.cpp` carries no runtime-specific rewrite any more.** It is the TMR orchestration recast as a Graph. `HBG_RECV_ROWS_PER_EXPERT` is gone; both files share one `EXPERT_ROWS_BUDGET` that only sizes the static grid.
- **One `get_tensor_data` read left in either file**: `ext_num_tokens_per_owner`. It is an *external* tensor the runtime stages with a host view, and it feeds `set_block_num` — a launch parameter a predicate cannot express, because a predicate decides whether a task dispatches, not how wide it is.
- **The TMR ring heap grows 1 GiB → 2 GiB**, matching what the HBG case already needed: tile scratch is now allocated for all 32 experts of every MoE layer whatever the routing turns out to be.
- The TMR README's stall description drops the orchestrator `TENSOR_WAIT_TIMEOUT` on `recv_count_out` — that read no longer exists, and it was a consequence of the comm-window stall rather than a cause.

## Verification

- The five modified kernels compile clean under ccec (`KernelCompiler.compile_incore`, aiv, pto-isa pin); the two orchestrations compile clean under the host `g++` and (TMR) the aarch64 AICPU cross-`g++`.
- Every rewrite site was produced by scripted transforms with assertions on the site count (5 `n_rows` + 5 `e_rows` per file; 5 `valid_rows` sites per file) and on the number of submits found inside each rewritten loop body (4 and 2), so a site whose shape did not match would have failed the run rather than been silently skipped. Each consumer's `add_input` binds the **nearest preceding** predicate's count tensor, asserted per site — the five MoE blocks each have their own `recv_count_out`.
- Record-time acceptance checked against `graph_record_node`'s predicate refusals: the operand is `[32,1]` INT32 allocated inside the Graph body, so it classifies `INTERNAL` (not `OWN_OUTPUT`), `ndims` matches, and `flat_offset - start_offset` is the expert index, inside `extent_elem_cache == 32`.
- Predicate scene tests pass on `a2a3sim`: `host_build_graph/graph_predicated_dispatch` and `host_build_graph/predicated_dispatch`.
- Full pre-commit clean (clang-format/tidy, cpplint, markdownlint, ruff, pyright).

**Not verified on hardware.** Both DSv4 cases are `manual`, need two dies and a 368-kernel compile; this box is currently 16/16 occupied *and* `npu-smi`/dcmi fails to initialize for new processes (`dcmi module initialize failed. ret is -8005`), so the arch precheck cannot pass. An onboard `SIMPLER_SKIP_DEVICE_RUN=1` HBG run (host orchestration + Graph recording, which is where a rejected predicate operand would surface) is the check still owed; happy to post it once a die frees up.

