### PR TITLE
Fix: report failing SceneTest case context

### DIFF
--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -1155,7 +1155,8 @@ def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI
     """Execute a pre-filtered list of cases for one class (layers 5-6).
 
     Caller is responsible for platform/selector/manual filtering. Profiling
-    snapshots wrap each case. Validation failures propagate; caller decides
+    snapshots wrap each case. Execution failures carry the class and case name,
+    with the original exception preserved as their cause; the caller decides
     fail-fast vs collect semantics.
     """
     cls_name = type(cls_inst).__name__
@@ -1190,6 +1191,8 @@ def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI
                 enable_scope_stats=enable_scope_stats,
                 output_prefix=str(prefix) if diagnostics_on else "",
             )
+        except Exception as exc:
+            raise RuntimeError(f"SceneTest case failed: {cls_name}::{case['name']}: {exc}") from exc
         finally:
             if enable_chip_swimlane:
                 _convert_case_swimlane(

--- a/tests/ut/py/test_scene_test_cli_contract.py
+++ b/tests/ut/py/test_scene_test_cli_contract.py
@@ -99,6 +99,63 @@ def test_swimlane_overhead_allocates_a_diagnostic_output_prefix(monkeypatch) -> 
     assert captured["output_prefix"] == str(output_prefix)
 
 
+def test_run_class_cases_reports_the_failing_case_name() -> None:
+    class FailingScene:
+        def _run_and_validate(self, *_args, **_kwargs):
+            raise ValueError("device run failed")
+
+    case = {"name": "large_bf16", "params": {"batch": 64, "dtype": "bfloat16"}}
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"SceneTest case failed: FailingScene::large_bf16: device run failed$",
+    ) as failure:
+        run_class_cases(
+            object(),
+            FailingScene(),
+            [case],
+            callable_obj=object(),
+            sub_handles={},
+            rounds=1,
+            skip_golden=False,
+            enable_chip_swimlane=0,
+            enable_dump_args=0,
+            enable_pmu=0,
+            enable_dep_gen=False,
+            enable_scope_stats=False,
+        )
+
+    assert isinstance(failure.value.__cause__, ValueError)
+    assert str(failure.value.__cause__) == "device run failed"
+
+
+def test_run_class_cases_keeps_device_error_visible_to_poison_classifier() -> None:
+    conftest = importlib.import_module("conftest")
+
+    class FailingScene:
+        def _run_and_validate(self, *_args, **_kwargs):
+            raise RuntimeError("run_prepared failed with code 507018")
+
+    with pytest.raises(RuntimeError) as failure:
+        run_class_cases(
+            object(),
+            FailingScene(),
+            [{"name": "device_error"}],
+            callable_obj=object(),
+            sub_handles={},
+            rounds=1,
+            skip_golden=False,
+            enable_chip_swimlane=0,
+            enable_dump_args=0,
+            enable_pmu=0,
+            enable_dep_gen=False,
+            enable_scope_stats=False,
+        )
+
+    excinfo = SimpleNamespace(type=type(failure.value), value=failure.value)
+    assert conftest._is_device_runtime_error(excinfo)
+
+
 def test_standalone_dispatch_forwards_every_diagnostic_flag(monkeypatch) -> None:
     scene_class = type("StandaloneDiagnosticScene", (), {"_st_level": 2, "_st_runtime": "tensormap_and_ringbuffer"})
     args = SimpleNamespace(


### PR DESCRIPTION
## Summary
- report a failing SceneTest entry as its class-qualified case name
- retain the original exception message and cause so device poison markers remain detectable
- cover ordinary failures and pooled Worker poison classification with regression tests

## Testing
- `python -m pytest tests/ut/py/test_scene_test_cli_contract.py -q` (8 passed)
- Ruff check and format check on the changed files
- Pyright on the changed files
- Full `tests/ut` reached 1667 passed and 19 skipped; the unrelated `test_second_child_failure_reaps_first` suite-load teardown flake failed and passed when rerun alone

Closes #1832