### PR TITLE
host_build_graph: prewarm concurrent Graph recording

### DIFF
--- a/src/a2a3/runtime/host_build_graph/build_config.py
+++ b/src/a2a3/runtime/host_build_graph/build_config.py
@@ -21,6 +21,8 @@
 # The "orchestration" directory contains source files compiled into both
 # runtime targets AND the orchestration .so (e.g., tensor methods needed
 # by the ChipTensor constructor's validation logic).
+# "host_orchestration_support" is linked only into that host-loaded .so; its
+# recorder prewarm entry must not instantiate host threads in runtime targets.
 
 BUILD_CONFIG = {
     "aicore": {"include_dirs": ["runtime", "common", ".."], "source_dirs": ["aicore", "orchestration"]},
@@ -32,5 +34,8 @@ BUILD_CONFIG = {
         "include_dirs": ["runtime", "common", ".."],
         "source_dirs": ["host", "runtime/orchestrator_core", "runtime/shared", "orchestration"],
     },
-    "orchestration": {"include_dirs": ["runtime", "orchestration", "common", ".."], "source_dirs": ["orchestration"]},
+    "orchestration": {
+        "include_dirs": ["runtime", "orchestration", "common", ".."],
+        "source_dirs": ["orchestration", "host_orchestration_support"],
+    },
 }

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -361,6 +361,7 @@ bool create_orch_so_tempfile(const uint8_t *data, size_t size, std::string *out_
 // The orchestration .so exports these (PTO2 submit_task form).
 typedef void (*OrchestrationEntryFunc)(const ChipTaskArgs &);
 typedef void (*OrchestrationBindFunc)(PTO2Runtime *);
+typedef void (*OrchestrationPrewarmFunc)();
 
 // Resolved orchestration .so entry points. register_callable_impl allocates one
 // of these (the entry, plus the .so's own framework_bind_runtime, which sets
@@ -793,6 +794,13 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
             dlclose(handle);
             return -1;
         }
+        void *prewarm_sym = dlsym(handle, "framework_prewarm_graph_recorders");
+        if (prewarm_sym == nullptr) {
+            LOG_ERROR("host-orch: orch .so does not export framework_prewarm_graph_recorders: %s", dlerror());
+            dlclose(handle);
+            return -1;
+        }
+        reinterpret_cast<OrchestrationPrewarmFunc>(prewarm_sym)();
         // Safe to unlink now: the handle keeps the .so mapped regardless of path.
         unlink(so_path.c_str());
         auto *eps = new HostOrchEntryPoints{};

--- a/src/a2a3/runtime/host_build_graph/host_orchestration_support/graph_recorder_prewarm.cpp
+++ b/src/a2a3/runtime/host_build_graph/host_orchestration_support/graph_recorder_prewarm.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#include "pto_orchestration_api.h"
+
+extern "C" __attribute__((visibility("default"))) void framework_prewarm_graph_recorders() {
+    (void)rt_graph_async_recording().prewarm();
+}

--- a/src/a2a3/runtime/host_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/host_build_graph/orchestration/pto_orchestration_api.h
@@ -31,19 +31,21 @@
 #include <stdint.h>
 
 #include <array>
+#include <algorithm>
 #include <condition_variable>
 #include <cstring>
 #include <functional>
-#include <memory>
 #include <mutex>
 #include <thread>
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 // Type headers needed by orchestration
 #include "common.h"              // framework_bind_runtime / framework_current_runtime
 #include "graph_cache.h"         // Graph Execution key and result helpers
+#include "graph_host_state.h"    // GRAPH_MAX_DEFINITIONS
 #include "pto_runtime2_types.h"  // PTO2_ERROR_*
 #include "pto_submit_types.h"    // MixedKernels, INVALID_KERNEL_ID, subtask slots
 #include "pto_types.h"           // Arg, TaskOutputTensors, TensorArgType
@@ -102,8 +104,8 @@ typedef struct PTO2RuntimeOps {
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
     GraphScopeResult (*graph_begin)(PTO2Runtime *rt, uint64_t graph_key, const GraphTaskArgs &args);
-    bool (*graph_prepare)(PTO2Runtime *rt, const GraphTaskArgs &args);
-    void (*graph_abort)(PTO2Runtime *rt);
+    bool (*graph_prepare)(PTO2Runtime *rt, void *recording_handle, const GraphTaskArgs &args);
+    void (*graph_abort)(PTO2Runtime *rt, void *recording_handle);
     bool (*graph_end)(PTO2Runtime *rt);
     void (*graph_commit)(PTO2Runtime *rt);
 
@@ -128,10 +130,13 @@ struct PTO2Runtime {
 
 class GraphOwnedArgs {
 public:
+    GraphOwnedArgs() { std::memset(tensors_.data(), 0, sizeof(tensors_)); }
+
     // The arrays below are sized to the Graph boundary's own capacity, so a
     // source GraphTaskArgs cannot report more args than they hold and the copy
     // loops need no runtime bound.
-    explicit GraphOwnedArgs(const GraphTaskArgs &source) {
+    void assign(const GraphTaskArgs &source) {
+        args_.reset();
         for (int32_t i = 0; i < source.tensor_count(); ++i) {
             tensors_[static_cast<size_t>(i)].copy(source.tensor(i).ref());
             switch (source.tag(i)) {
@@ -174,73 +179,150 @@ private:
 
 class GraphAsyncRecordingState {
 public:
-    GraphAsyncRecordingState() = default;
+    GraphAsyncRecordingState() {
+        for (size_t i = 0; i < kJobCapacity; ++i) {
+            free_owned_args_[i] = kJobCapacity - i - 1;
+        }
+    }
     ~GraphAsyncRecordingState() { shutdown(); }
 
     GraphAsyncRecordingState(const GraphAsyncRecordingState &) = delete;
     GraphAsyncRecordingState &operator=(const GraphAsyncRecordingState &) = delete;
 
+    // The common four-Definition case should not create pthreads between outer
+    // shell submissions. Callable registration parks those workers before the
+    // first run; start() can still grow to the Definition limit if a workload
+    // records more identities concurrently.
+    bool prewarm() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        if (stopping_) return false;
+        while (workers_.size() < kPrewarmedWorkerCount) {
+            if (!create_worker_locked()) break;
+        }
+        const size_t target = workers_.size();
+        cv_.wait(lock, [&]() {
+            return ready_workers_ >= target || stopping_;
+        });
+        return !stopping_ && target == kPrewarmedWorkerCount;
+    }
+
     template <typename Job>
-    bool start(Job &&job) {
-        std::function<void()> next;
+    bool start(const GraphTaskArgs &args, Job &&job) {
+        std::function<void(GraphTaskArgs &)> next;
         try {
             next = std::forward<Job>(job);
-            ensure_worker();
         } catch (...) {
             return false;
         }
 
+        size_t owned_args_index;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (stopping_ || free_owned_args_count_ == 0 || job_count_ == kJobCapacity) return false;
+            owned_args_index = free_owned_args_[--free_owned_args_count_];
+        }
+        owned_args_[owned_args_index].assign(args);
+
         std::unique_lock<std::mutex> lock(mutex_);
-        debug_assert(done_ && !pending_ && "Only one Graph recording may be in flight");
-        if (!done_ || pending_ || stopping_) return false;
-        job_ = std::move(next);
-        done_ = false;
-        pending_ = true;
+        if (stopping_) {
+            free_owned_args_[free_owned_args_count_++] = owned_args_index;
+            return false;
+        }
+        PendingJob &pending = jobs_[job_tail_];
+        pending.function = std::move(next);
+        pending.owned_args_index = owned_args_index;
+        job_tail_ = (job_tail_ + 1) % kJobCapacity;
+        job_count_++;
+        const size_t desired_workers = std::min(kMaxWorkerCount, job_count_ + active_jobs_);
+        while (workers_.size() < desired_workers) {
+            if (!create_worker_locked()) break;
+        }
+        if (workers_.empty()) {
+            job_tail_ = (job_tail_ + kJobCapacity - 1) % kJobCapacity;
+            PendingJob &rollback = jobs_[job_tail_];
+            rollback.function = {};
+            job_count_--;
+            free_owned_args_[free_owned_args_count_++] = rollback.owned_args_index;
+            return false;
+        }
+        lock.unlock();
         cv_.notify_one();
-        // graph_begin() has already installed the hash-keyed RECORDING entry
-        // and submitted the zero-heap outer shell. Enqueuing the private job is
+        // graph_begin() has already installed the keyed in-flight entry and
+        // submitted the zero-heap outer shell. Enqueuing the private job is
         // therefore the last dependency of the caller; graph_prepare() and all
-        // node recording may start after later same-hash shells are submitted.
+        // node recording may start after later shells are submitted.
         return true;
     }
 
+    // Wait for every queued and running recording. A recording thread returns
+    // immediately: it may reach this through rt_orchestration_done in a Graph body
+    // and must never wait for its own job, nor for a sibling's — the sibling makes
+    // progress independently and waiting on it would trade a recording thread for
+    // nothing.
     void wait() {
         std::unique_lock<std::mutex> lock(mutex_);
-        // Recording invokes the same public task wrappers as the outer
-        // orchestration. Those wrappers call rt_graph_commit() before a
-        // non-Graph operation. The recorder must never wait for its own job.
-        if (worker_.joinable() && worker_.get_id() == std::this_thread::get_id()) return;
+        if (is_worker_thread_locked(std::this_thread::get_id())) return;
         cv_.wait(lock, [&]() {
-            return done_;
+            return job_count_ == 0 && active_jobs_ == 0;
         });
     }
 
 private:
-    void ensure_worker() {
-        std::lock_guard<std::mutex> lock(mutex_);
-        if (!worker_.joinable()) {
-            worker_ = std::thread([this]() {
+    static constexpr size_t kPrewarmedWorkerCount = 4;
+    static constexpr size_t kMaxWorkerCount = GRAPH_MAX_DEFINITIONS;
+    static constexpr size_t kJobCapacity = GRAPH_MAX_DEFINITIONS;
+
+    struct PendingJob {
+        std::function<void(GraphTaskArgs &)> function;
+        size_t owned_args_index{0};
+    };
+
+    bool is_worker_thread_locked(std::thread::id id) const {
+        for (const std::thread &worker : workers_) {
+            if (worker.get_id() == id) return true;
+        }
+        return false;
+    }
+
+    bool create_worker_locked() {
+        if (stopping_ || workers_.size() >= kMaxWorkerCount) return false;
+        try {
+            workers_.emplace_back([this]() {
                 run();
             });
+            return true;
+        } catch (...) {
+            return false;
         }
     }
 
     void run() {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            ready_workers_++;
+        }
+        cv_.notify_all();
         for (;;) {
-            std::function<void()> current;
+            PendingJob current;
             {
                 std::unique_lock<std::mutex> lock(mutex_);
                 cv_.wait(lock, [&]() {
-                    return pending_ || stopping_;
+                    return job_count_ != 0 || stopping_;
                 });
-                if (stopping_) return;
-                current = std::move(job_);
-                pending_ = false;
+                if (stopping_ && job_count_ == 0) return;
+                PendingJob &pending = jobs_[job_head_];
+                current.function = std::move(pending.function);
+                current.owned_args_index = pending.owned_args_index;
+                job_head_ = (job_head_ + 1) % kJobCapacity;
+                job_count_--;
+                active_jobs_++;
             }
-            current();
+            current.function(owned_args_[current.owned_args_index].args());
+            current.function = {};
             {
                 std::lock_guard<std::mutex> lock(mutex_);
-                done_ = true;
+                free_owned_args_[free_owned_args_count_++] = current.owned_args_index;
+                active_jobs_--;
             }
             cv_.notify_all();
         }
@@ -253,27 +335,33 @@ private:
             stopping_ = true;
         }
         cv_.notify_all();
-        if (worker_.joinable()) worker_.join();
+        for (std::thread &worker : workers_) {
+            if (worker.joinable()) worker.join();
+        }
     }
 
-    std::thread worker_;
+    std::vector<std::thread> workers_;
     std::mutex mutex_;
     std::condition_variable cv_;
-    std::function<void()> job_;
-    bool pending_{false};
-    bool done_{true};
+    std::array<GraphOwnedArgs, kJobCapacity> owned_args_;
+    std::array<size_t, kJobCapacity> free_owned_args_{};
+    std::array<PendingJob, kJobCapacity> jobs_;
+    size_t free_owned_args_count_{kJobCapacity};
+    size_t job_head_{0};
+    size_t job_tail_{0};
+    size_t job_count_{0};
+    size_t ready_workers_{0};
+    size_t active_jobs_{0};
     bool stopping_{false};
 };
 
 // External linkage on purpose: `static inline` would give every translation
-// unit that submits a Graph its own recorder and its own worker thread, so a
+// unit that submits a Graph its own recorder and its own worker threads, so a
 // commit reached from one TU would not wait for a recording another TU started.
-// Vague linkage keeps one instance — and one worker — per loaded SO.
+// Vague linkage keeps one instance — and one pool — per loaded SO.
 inline GraphAsyncRecordingState &rt_graph_async_recording() {
-    // One orchestration SO is invoked serially by its ChipWorker. Keep its
-    // recorder alive across runs so steady-state misses pay only a condition-
-    // variable wakeup, not a fresh pthread create/join. The SO's destructor
-    // stops the idle worker before dlclose unmaps its code.
+    // Keep the bounded pool alive across runs so steady-state misses pay only a
+    // condition-variable wakeup. The SO's destructor joins it before dlclose.
     static GraphAsyncRecordingState state;
     return state;
 }
@@ -285,8 +373,15 @@ inline GraphAsyncRecordingState &rt_graph_async_recording() {
 static inline PTO2Runtime *current_runtime() { return framework_current_runtime(); }
 static inline void rt_graph_commit();
 
+// An ordinary submission depends on nothing a recording produces. The outer
+// Graph shell entered the task sequence and registered its TensorMap producers
+// at graph_begin, so fanin against it is already correct; the recording only
+// builds the Definition image, and the deferred heap block a shell still needs is
+// an independent bump allocation that orchestration completion reserves. So none
+// of the three wrappers below joins the recorders — a barrier here stalls the
+// submitting thread for the rest of every recording in flight, which on the
+// four-Definition DeepSeek-V4 decode was a third of the orchestration window.
 static inline TaskOutputTensors alloc_tensors(const CoreTaskArgs &args) {
-    rt_graph_commit();
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -337,7 +432,6 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
 }
 
 static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
-    rt_graph_commit();
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -371,7 +465,6 @@ static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const Core
  * barrier or as a placeholder producer for tests / dep-graph wiring.
  */
 static inline TaskOutputTensors rt_submit_dummy_task(const CoreTaskArgs &args) {
-    rt_graph_commit();
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -387,14 +480,17 @@ static inline GraphScopeResult rt_graph_begin(uint64_t graph_key, const GraphTas
     return rt->ops->graph_begin(rt, graph_key, args);
 }
 
-static inline bool rt_graph_prepare(const GraphTaskArgs &args) {
+// Bind the calling thread to the recording `graph_key` opened. The handle comes
+// from the GraphScopeResult that opened it, so a thread can only ever record
+// into the recording it was handed.
+static inline bool rt_graph_prepare(void *recording_handle, const GraphTaskArgs &args) {
     PTO2Runtime *rt = current_runtime();
-    return rt->ops->graph_prepare != nullptr && rt->ops->graph_prepare(rt, args);
+    return rt->ops->graph_prepare != nullptr && rt->ops->graph_prepare(rt, recording_handle, args);
 }
 
-static inline void rt_graph_abort() {
+static inline void rt_graph_abort(void *recording_handle) {
     PTO2Runtime *rt = current_runtime();
-    if (rt->ops->graph_abort != nullptr) rt->ops->graph_abort(rt);
+    if (rt->ops->graph_abort != nullptr) rt->ops->graph_abort(rt, recording_handle);
 }
 
 // Finish the recording pass and publish its Definition. The calling thread
@@ -566,10 +662,10 @@ static inline uint64_t rt_graph_function_id(Function function) {
     return function_id;
 }
 
-// `invoke` is copied into the recording job and runs on the recording worker,
-// which outlives this call: the caller returns as soon as the outer shell is
-// submitted, and the body runs until the next rt_graph_commit(). So `invoke` must
-// own everything it needs by value. Capturing caller-frame storage by reference —
+// `invoke` is copied into the recording job and runs on a recording thread, which
+// outlives this call: the caller returns as soon as the outer shell is submitted,
+// and the body runs until orchestration completion joins it. So `invoke` must own
+// everything it needs by value. Capturing caller-frame storage by reference —
 // including the boundary `args` — is a use-after-free; the recorded body receives
 // its own boundary copy as a parameter for exactly that reason.
 template <typename Invoke>
@@ -588,66 +684,44 @@ static inline GraphSubmitResult rt_submit_graph_impl(uint64_t graph_key, const G
         );
     }
     if (!rt_graph_args_cacheable(args)) {
-        rt_graph_commit();
         invoke(args);
         return GraphSubmitResult{};
     }
     GraphScopeResult result = rt_graph_begin(graph_key, args);
     if (result.recording) {
         GraphAsyncRecordingState &async = rt_graph_async_recording();
-        std::shared_ptr<GraphOwnedArgs> owned_args;
-        try {
-            owned_args = std::make_shared<GraphOwnedArgs>(args);
-        } catch (...) {
+        void *handle = result.recording_handle;
+        auto record = [invoke, handle](GraphTaskArgs &record_args) mutable {
             try {
-                if (!rt_graph_prepare(args)) {
-                    rt_graph_abort();
-                    rt_graph_commit();
+                if (!rt_graph_prepare(handle, record_args)) {
+                    rt_graph_abort(handle);
+                    return;
+                }
+                invoke(record_args);
+                (void)rt_graph_end();
+            } catch (...) {
+                rt_graph_abort(handle);
+            }
+        };
+        if (!async.start(args, std::move(record))) {
+            try {
+                if (!rt_graph_prepare(handle, args)) {
+                    rt_graph_abort(handle);
                     return result;
                 }
                 invoke(args);
                 (void)rt_graph_end();
             } catch (...) {
-                rt_graph_abort();
+                rt_graph_abort(handle);
                 throw;
             }
-            rt_graph_commit();
-            return result;
-        }
-        auto record = [owned_args, invoke]() mutable {
-            try {
-                if (!rt_graph_prepare(owned_args->args())) {
-                    rt_graph_abort();
-                    return;
-                }
-                invoke(owned_args->args());
-                (void)rt_graph_end();
-            } catch (...) {
-                rt_graph_abort();
-            }
-        };
-        if (!async.start(std::move(record))) {
-            try {
-                if (!rt_graph_prepare(owned_args->args())) {
-                    rt_graph_abort();
-                    rt_graph_commit();
-                    return result;
-                }
-                invoke(owned_args->args());
-                (void)rt_graph_end();
-            } catch (...) {
-                rt_graph_abort();
-                throw;
-            }
-            rt_graph_commit();
         }
     } else if (result.execute_block) {
         // Un-cacheable at begin, or the Definition cache is full: ordinary path.
-        rt_graph_commit();
         if (!current_runtime()->ops->is_fatal(current_runtime())) invoke(args);
     }
-    // A cache hit or an in-flight hit skips the body. In-flight Graph tasks are
-    // finalized before the next non-Graph operation or orchestration completion.
+    // A cache hit or an in-flight hit skips the body. Every in-flight Graph task
+    // is finalized at orchestration completion.
     return result;
 }
 

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -389,23 +389,46 @@ struct GraphPendingUpload {
     bool deferred_heap{false};
 };
 
-enum class GraphRecordingStatus : uint8_t { IDLE = 0, RECORDING = 1, READY = 2, FAILED = 3 };
+enum class GraphRecordingStatus : uint8_t { RECORDING = 0, READY = 1, FAILED = 2 };
 
-struct GraphHostState {
-    std::unordered_map<uint64_t, std::vector<std::byte>> definitions;
+// One Definition being recorded. Entries are keyed by Graph key and held by
+// unique_ptr, so a rehash of the owning map never moves one: the recording
+// thread is handed this address at graph_begin and dereferences it without
+// taking recording_mutex.
+struct GraphInflightRecording {
+    uint64_t full_key{0};
     std::unique_ptr<GraphRecording> recording;
-    std::vector<GraphPendingUpload> pending_uploads;
-    std::mutex recording_mutex;
-    std::condition_variable recording_cv;
-    // Atomic because graph_prepare reads it on the recording worker without
+    // Atomic because graph_prepare reads it on the recording thread without
     // taking recording_mutex, by design: acquiring the mutex there lets a
-    // main-thread burst of same-hash submissions starve the worker before it can
+    // main-thread burst of same-key submissions starve the thread before it can
     // bind its private recording state. Every other access holds the mutex.
-    std::atomic<GraphRecordingStatus> recording_status{GraphRecordingStatus::IDLE};
-    uint64_t recording_key{0};
+    std::atomic<GraphRecordingStatus> recording_status{GraphRecordingStatus::RECORDING};
 
     GraphRecordingStatus status() const { return recording_status.load(std::memory_order_acquire); }
     void set_status(GraphRecordingStatus next) { recording_status.store(next, std::memory_order_release); }
+};
+
+struct GraphHostState {
+    std::unordered_map<uint64_t, std::vector<std::byte>> definitions;
+    // Recordings in flight, at most one per Graph key. Several record at once,
+    // each on its own thread; graph_commit drains and finalizes all of them.
+    std::unordered_map<uint64_t, std::unique_ptr<GraphInflightRecording>> inflight;
+    std::vector<GraphPendingUpload> pending_uploads;
+    std::mutex recording_mutex;
+    std::condition_variable recording_cv;
+    // Mirrors inflight.size() so orchestration completion answers the common
+    // "nothing is recording" case without taking recording_mutex.
+    std::atomic<size_t> inflight_count{0};
+
+    // Definitions this run can still admit: published plus in flight, against
+    // the per-worker cache limit.
+    size_t claimed_definitions() const { return definitions.size() + inflight.size(); }
+    bool any_recording() const {
+        for (const auto &entry : inflight) {
+            if (entry.second->status() == GraphRecordingStatus::RECORDING) return true;
+        }
+        return false;
+    }
 };
 
 namespace {
@@ -414,6 +437,9 @@ GraphHostState *graph_state_from(PTO2OrchestratorState *orch) {
     return orch == nullptr ? nullptr : static_cast<GraphHostState *>(orch->graph_host_state);
 }
 
+// The in-flight entry this thread is recording into, bound by graph_prepare and
+// cleared by graph_end / graph_abort.
+thread_local GraphInflightRecording *g_active_graph_entry = nullptr;
 thread_local GraphRecording *g_active_graph_recording = nullptr;
 // The recording a thread holds belongs to one GraphHostState. Recording into it
 // from a different orchestrator would silently mix two graphs, so the owner is
@@ -1655,21 +1681,25 @@ bool graph_submit_pending_definition(
     return graph_submit_outer(orch, state, full_key, 0, 0, true, args, submitted_id);
 }
 
-bool graph_finalize_pending_submissions(
-    PTO2OrchestratorState *orch, GraphHostState *state, const GraphDefinition &definition
-) {
-    if (definition.execution_storage_bytes == 0 ||
-        definition.required_heap > UINT64_MAX - definition.execution_storage_bytes) {
-        return false;
-    }
-    const uint64_t owned_heap = definition.required_heap + definition.execution_storage_bytes;
-    if (owned_heap > static_cast<uint64_t>(INT32_MAX)) return false;
+bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostState *state, uint64_t *failed_key) {
     for (GraphPendingUpload &pending : state->pending_uploads) {
-        if (!pending.deferred_heap || pending.image.size() < sizeof(GraphSubmission)) continue;
+        if (!pending.deferred_heap) continue;
+        if (pending.image.size() < sizeof(GraphSubmission)) return false;
         auto *submission = reinterpret_cast<GraphSubmission *>(pending.image.data());
-        if (submission->graph_key != definition.full_key || pending.outer_slot == nullptr ||
-            pending.outer_slot->task == nullptr || pending.outer_slot->task_kind != TaskKind::GRAPH ||
+        auto definition_it = state->definitions.find(submission->graph_key);
+        const GraphDefinition *definition =
+            definition_it == state->definitions.end() ? nullptr : graph_definition(definition_it->second);
+        if (definition == nullptr || definition->execution_storage_bytes == 0 ||
+            definition->required_heap > UINT64_MAX - definition->execution_storage_bytes ||
+            pending.outer_slot == nullptr || pending.outer_slot->task == nullptr ||
+            pending.outer_slot->task_kind != TaskKind::GRAPH ||
             !graph_submission_wire_size_valid(*submission, pending.image.size())) {
+            if (failed_key != nullptr) *failed_key = submission->graph_key;
+            return false;
+        }
+        const uint64_t owned_heap = definition->required_heap + definition->execution_storage_bytes;
+        if (owned_heap > static_cast<uint64_t>(INT32_MAX)) {
+            if (failed_key != nullptr) *failed_key = submission->graph_key;
             return false;
         }
         void *packed_base = nullptr;
@@ -1677,11 +1707,12 @@ bool graph_finalize_pending_submissions(
         if (!orch->ring.task_allocator.reserve_deferred_heap(
                 static_cast<int32_t>(owned_heap), &packed_base, &packed_end
             )) {
+            if (failed_key != nullptr) *failed_key = submission->graph_key;
             return false;
         }
         pending.outer_slot->task->packed_buffer_base = packed_base;
         pending.outer_slot->task->packed_buffer_end = packed_end;
-        submission->definition_hash = definition.content_hash;
+        submission->definition_hash = definition->content_hash;
         pending.deferred_heap = false;
     }
     return true;
@@ -1914,37 +1945,10 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
 
     const uint64_t full_key = graph_full_key(callable_hash, graph_key);
     std::unique_lock<std::mutex> lock(state->recording_mutex);
-    if (state->status() != GraphRecordingStatus::IDLE) {
-        if (state->recording_key != full_key || state->status() == GraphRecordingStatus::FAILED) {
-            return result;
-        }
-        bool boundary_matches = false;
-        if (state->recording != nullptr) {
-            boundary_matches = graph_recording_boundary_matches(*state->recording, args);
-        } else {
-            auto definition_it = state->definitions.find(full_key);
-            boundary_matches = definition_it != state->definitions.end() &&
-                               graph_definition(definition_it->second) != nullptr &&
-                               graph_boundary_matches(*graph_definition(definition_it->second), args);
-        }
-        if (!boundary_matches) return result;
 
-        PTO2TaskId submitted = PTO2TaskId::invalid();
-        ORCH_PHASE_START();
-        if (graph_submit_pending_definition(orch, state, full_key, args, &submitted)) {
-            result.execute_block = false;
-            result.task_id = submitted;
-            ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
-#if SIMPLER_DFX
-            g_orch_submit_idx++;
-#if SIMPLER_ORCH_PROFILING
-            g_orch_submit_count++;
-#endif
-#endif
-        }
-        return result;
-    }
-
+    // A published Definition is immutable, so the cache lookup comes first and
+    // answers regardless of what else is recording. Gating it on an idle recorder
+    // would make an already-built Definition wait for an unrelated one.
     auto definition_it = state->definitions.find(full_key);
     if (definition_it != state->definitions.end()) {
         PTO2TaskId submitted = PTO2TaskId::invalid();
@@ -1962,13 +1966,41 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
         }
         return result;
     }
-    if (state->definitions.size() >= GRAPH_MAX_DEFINITIONS) {
+
+    // This key is already recording: publish another zero-heap shell against it.
+    // A recording that ended has its Definition in the cache, so reaching here
+    // with no recording object means the pass failed and this key is spent.
+    auto inflight_it = state->inflight.find(full_key);
+    if (inflight_it != state->inflight.end()) {
+        GraphInflightRecording &entry = *inflight_it->second;
+        if (entry.status() != GraphRecordingStatus::RECORDING || entry.recording == nullptr ||
+            !graph_recording_boundary_matches(*entry.recording, args)) {
+            return result;
+        }
+        PTO2TaskId submitted = PTO2TaskId::invalid();
+        ORCH_PHASE_START();
+        if (graph_submit_pending_definition(orch, state, full_key, args, &submitted)) {
+            result.execute_block = false;
+            result.task_id = submitted;
+            ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
+#if SIMPLER_DFX
+            g_orch_submit_idx++;
+#if SIMPLER_ORCH_PROFILING
+            g_orch_submit_count++;
+#endif
+#endif
+        }
+        return result;
+    }
+
+    if (state->claimed_definitions() >= GRAPH_MAX_DEFINITIONS) {
         debug_assert(
-            state->definitions.size() < GRAPH_MAX_DEFINITIONS &&
+            state->claimed_definitions() < GRAPH_MAX_DEFINITIONS &&
             "Graph Definition cache exceeds the supported per-worker limit"
         );
         LOG_WARN(
-            "[GraphExecution] Definition cache is full (%zu entries); using ordinary path", state->definitions.size()
+            "[GraphExecution] Definition cache is full (%zu published, %zu in flight); using ordinary path",
+            state->definitions.size(), state->inflight.size()
         );
         return result;
     }
@@ -1983,15 +2015,19 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
         recording->boundary_tensors.push_back(args.tensor(i).ref());
         recording->boundary_types.push_back(args.tag(i));
     }
-    state->recording = std::move(recording);
-    state->recording_key = full_key;
-    state->set_status(GraphRecordingStatus::RECORDING);
+    auto entry = std::make_unique<GraphInflightRecording>();
+    entry->full_key = full_key;
+    entry->recording = std::move(recording);
+    GraphInflightRecording *entry_ptr = entry.get();
+    state->inflight.emplace(full_key, std::move(entry));
+    state->inflight_count.store(state->inflight.size(), std::memory_order_release);
 
     PTO2TaskId submitted = PTO2TaskId::invalid();
     ORCH_PHASE_START();
     if (graph_submit_pending_definition(orch, state, full_key, args, &submitted)) {
         result.execute_block = false;
         result.recording = true;
+        result.recording_handle = entry_ptr;
         result.task_id = submitted;
         ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
 #if SIMPLER_DFX
@@ -2001,42 +2037,46 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
 #endif
 #endif
     } else {
-        state->recording.reset();
-        state->recording_key = 0;
-        state->set_status(GraphRecordingStatus::IDLE);
+        state->inflight.erase(full_key);
+        state->inflight_count.store(state->inflight.size(), std::memory_order_release);
     }
     return result;
 }
 
-bool PTO2OrchestratorState::graph_prepare(const GraphTaskArgs &args) {
+bool PTO2OrchestratorState::graph_prepare(void *recording_handle, const GraphTaskArgs &args) {
     GraphHostState *state = graph_state_from(this);
-    if (state == nullptr || g_active_graph_recording != nullptr) return false;
-    // graph_begin publishes this unique recording before the private job is
-    // enqueued; the recording worker's queue acquire observes those writes.
-    // Until this worker calls graph_end/graph_abort, later graph_begin calls
-    // only read the boundary vectors under recording_mutex, and only this worker
-    // writes the fields it binds below. Taking that mutex here lets the main
-    // thread's same-hash submit burst starve prepare and collapse the intended
-    // overlap, so the status read goes through the atomic instead.
-    if (state->status() != GraphRecordingStatus::RECORDING || state->recording == nullptr ||
-        !graph_recording_boundary_matches(*state->recording, args)) {
+    if (state == nullptr || recording_handle == nullptr || g_active_graph_recording != nullptr) return false;
+    auto *entry = static_cast<GraphInflightRecording *>(recording_handle);
+    // graph_begin published this entry before the private job was enqueued, and
+    // the entry's address is stable for as long as the recording lives, so the
+    // recording thread reaches its own state without searching for it. Until this
+    // thread calls graph_end/graph_abort, later graph_begin calls only read the
+    // boundary vectors under recording_mutex, and only this thread writes the
+    // fields it binds below. Taking that mutex here lets the main thread's
+    // same-key submit burst starve prepare and collapse the intended overlap, so
+    // the status read goes through the atomic instead.
+    if (entry->status() != GraphRecordingStatus::RECORDING || entry->recording == nullptr ||
+        !graph_recording_boundary_matches(*entry->recording, args)) {
         return false;
     }
     args.anchor_scalar_sources();
-    state->recording->boundary_args = &args;
-    g_active_graph_recording = state->recording.get();
+    entry->recording->boundary_args = &args;
+    g_active_graph_entry = entry;
+    g_active_graph_recording = entry->recording.get();
     g_active_graph_owner = state;
     return true;
 }
 
-void PTO2OrchestratorState::graph_abort() {
+void PTO2OrchestratorState::graph_abort(void *recording_handle) {
     GraphHostState *state = graph_state_from(this);
-    if (state == nullptr) return;
+    auto *entry = static_cast<GraphInflightRecording *>(recording_handle);
+    if (state == nullptr || entry == nullptr) return;
     {
         std::lock_guard<std::mutex> lock(state->recording_mutex);
-        state->recording.reset();
-        state->set_status(GraphRecordingStatus::FAILED);
+        entry->recording.reset();
+        entry->set_status(GraphRecordingStatus::FAILED);
     }
+    g_active_graph_entry = nullptr;
     g_active_graph_recording = nullptr;
     g_active_graph_owner = nullptr;
     state->recording_cv.notify_all();
@@ -2047,7 +2087,8 @@ void PTO2OrchestratorState::graph_abort() {
 bool PTO2OrchestratorState::graph_end() {
     GraphHostState *state = graph_state_from(this);
     GraphRecording *recording = active_graph_recording(this);
-    if (state == nullptr || recording == nullptr) return false;
+    GraphInflightRecording *entry = g_active_graph_entry;
+    if (state == nullptr || recording == nullptr || entry == nullptr) return false;
 
     std::vector<std::byte> definition;
     ORCH_PHASE_START();
@@ -2059,7 +2100,7 @@ bool PTO2OrchestratorState::graph_end() {
     if (header == nullptr) {
         debug_assert(false && "The recorded Graph contains a construct that Graph Execution does not support");
         LOG_WARN("%s", "[GraphExecution] asynchronous recording produced an unsupported Graph");
-        graph_abort();
+        graph_abort(entry);
         return false;
     }
     LOG_DEBUG(
@@ -2069,51 +2110,56 @@ bool PTO2OrchestratorState::graph_end() {
     bool ready = false;
     {
         std::lock_guard<std::mutex> lock(state->recording_mutex);
-        if (state->status() != GraphRecordingStatus::RECORDING || state->recording_key != header->full_key) {
-            state->set_status(GraphRecordingStatus::FAILED);
+        if (entry->status() != GraphRecordingStatus::RECORDING || entry->full_key != header->full_key) {
+            entry->set_status(GraphRecordingStatus::FAILED);
         } else {
             state->definitions.emplace(header->full_key, std::move(definition));
-            state->set_status(GraphRecordingStatus::READY);
+            entry->set_status(GraphRecordingStatus::READY);
         }
-        ready = state->status() == GraphRecordingStatus::READY;
-        state->recording.reset();
+        ready = entry->status() == GraphRecordingStatus::READY;
+        entry->recording.reset();
     }
+    g_active_graph_entry = nullptr;
     g_active_graph_recording = nullptr;
     g_active_graph_owner = nullptr;
     state->recording_cv.notify_all();
     return ready;
 }
 
+// Join every recording in flight and back-patch all deferred shells in submit
+// order. Orchestration completion is the only normal-path barrier.
 void PTO2OrchestratorState::graph_commit() {
     if (active_graph_recording(this) != nullptr) return;
     GraphHostState *state = graph_state_from(this);
-    if (state == nullptr) return;
+    if (state == nullptr || state->inflight_count.load(std::memory_order_acquire) == 0) return;
 
-    uint64_t full_key = 0;
-    const GraphDefinition *definition = nullptr;
-    bool failed = false;
+    std::unordered_map<uint64_t, std::unique_ptr<GraphInflightRecording>> drained;
     {
         std::unique_lock<std::mutex> lock(state->recording_mutex);
-        if (state->status() == GraphRecordingStatus::IDLE) return;
+        if (state->inflight.empty()) return;
         state->recording_cv.wait(lock, [&]() {
-            return state->status() != GraphRecordingStatus::RECORDING;
+            return !state->any_recording();
         });
-        full_key = state->recording_key;
-        failed = state->status() != GraphRecordingStatus::READY;
-        auto definition_it = state->definitions.find(full_key);
-        if (!failed && definition_it != state->definitions.end()) definition = graph_definition(definition_it->second);
+        drained.swap(state->inflight);
+        state->inflight_count.store(0, std::memory_order_release);
     }
 
-    if (definition == nullptr || !graph_finalize_pending_submissions(this, state, *definition)) failed = true;
-    {
-        std::lock_guard<std::mutex> lock(state->recording_mutex);
-        state->set_status(GraphRecordingStatus::IDLE);
-        state->recording_key = 0;
+    uint64_t failed_key = 0;
+    bool failed = false;
+    for (const auto &[key, entry] : drained) {
+        auto definition_it = state->definitions.find(key);
+        if (entry->status() == GraphRecordingStatus::READY && definition_it != state->definitions.end() &&
+            graph_definition(definition_it->second) != nullptr) {
+            continue;
+        }
+        if (!failed) failed_key = key;
+        failed = true;
     }
+    if (!failed && !graph_finalize_pending_submissions(this, state, &failed_key)) failed = true;
     if (failed) {
         report_fatal(
             PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "failed to finalize asynchronous Graph key=%#llx",
-            static_cast<unsigned long long>(full_key)
+            static_cast<unsigned long long>(failed_key)
         );
     }
 }

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -101,12 +101,12 @@ static GraphScopeResult graph_begin_impl(PTO2Runtime *rt, uint64_t graph_key, co
     return rt->orchestrator.graph_begin(graph_key, args, rt->active_callable_hash);
 }
 
-static bool graph_prepare_impl(PTO2Runtime *rt, const GraphTaskArgs &args) {
-    return rt != nullptr && rt->orchestrator.graph_prepare(args);
+static bool graph_prepare_impl(PTO2Runtime *rt, void *recording_handle, const GraphTaskArgs &args) {
+    return rt != nullptr && rt->orchestrator.graph_prepare(recording_handle, args);
 }
 
-static void graph_abort_impl(PTO2Runtime *rt) {
-    if (rt != nullptr) rt->orchestrator.graph_abort();
+static void graph_abort_impl(PTO2Runtime *rt, void *recording_handle) {
+    if (rt != nullptr) rt->orchestrator.graph_abort(recording_handle);
 }
 
 static bool graph_end_impl(PTO2Runtime *rt) { return rt != nullptr && rt->orchestrator.graph_end(); }

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_orchestrator.h
@@ -158,8 +158,8 @@ struct PTO2OrchestratorState {
     TaskOutputTensors submit_dummy_task(const CoreTaskArgs &args);
     TaskOutputTensors alloc_tensors(const CoreTaskArgs &args);
     GraphScopeResult graph_begin(uint64_t graph_key, const GraphTaskArgs &args, uint64_t callable_hash);
-    bool graph_prepare(const GraphTaskArgs &args);
-    void graph_abort();
+    bool graph_prepare(void *recording_handle, const GraphTaskArgs &args);
+    void graph_abort(void *recording_handle);
     bool graph_end();
     void graph_commit();
     void mark_done();

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -96,8 +96,8 @@ struct PTO2RuntimeOps {
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
     GraphScopeResult (*graph_begin)(PTO2Runtime *rt, uint64_t graph_key, const GraphTaskArgs &args);
-    bool (*graph_prepare)(PTO2Runtime *rt, const GraphTaskArgs &args);
-    void (*graph_abort)(PTO2Runtime *rt);
+    bool (*graph_prepare)(PTO2Runtime *rt, void *recording_handle, const GraphTaskArgs &args);
+    void (*graph_abort)(PTO2Runtime *rt, void *recording_handle);
     bool (*graph_end)(PTO2Runtime *rt);
     void (*graph_commit)(PTO2Runtime *rt);
     // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]

--- a/src/a5/runtime/host_build_graph/build_config.py
+++ b/src/a5/runtime/host_build_graph/build_config.py
@@ -21,6 +21,8 @@
 # The "orchestration" directory contains source files compiled into both
 # runtime targets AND the orchestration .so (e.g., tensor methods needed
 # by the ChipTensor constructor's validation logic).
+# "host_orchestration_support" is linked only into that host-loaded .so; its
+# recorder prewarm entry must not instantiate host threads in runtime targets.
 
 BUILD_CONFIG = {
     "aicore": {"include_dirs": ["runtime", "common", ".."], "source_dirs": ["aicore", "orchestration"]},
@@ -32,5 +34,8 @@ BUILD_CONFIG = {
         "include_dirs": ["runtime", "common", ".."],
         "source_dirs": ["host", "runtime/orchestrator_core", "runtime/shared", "orchestration"],
     },
-    "orchestration": {"include_dirs": ["runtime", "orchestration", "common", ".."], "source_dirs": ["orchestration"]},
+    "orchestration": {
+        "include_dirs": ["runtime", "orchestration", "common", ".."],
+        "source_dirs": ["orchestration", "host_orchestration_support"],
+    },
 }

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -364,6 +364,7 @@ bool create_orch_so_tempfile(const uint8_t *data, size_t size, std::string *out_
 // The orchestration .so exports these (PTO2 submit_task form).
 typedef void (*OrchestrationEntryFunc)(const ChipTaskArgs &);
 typedef void (*OrchestrationBindFunc)(PTO2Runtime *);
+typedef void (*OrchestrationPrewarmFunc)();
 
 // Resolved orchestration .so entry points. register_callable_impl allocates one
 // of these (the entry, plus the .so's own framework_bind_runtime, which sets
@@ -849,6 +850,13 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
             dlclose(handle);
             return -1;
         }
+        void *prewarm_sym = dlsym(handle, "framework_prewarm_graph_recorders");
+        if (prewarm_sym == nullptr) {
+            LOG_ERROR("host-orch: orch .so does not export framework_prewarm_graph_recorders: %s", dlerror());
+            dlclose(handle);
+            return -1;
+        }
+        reinterpret_cast<OrchestrationPrewarmFunc>(prewarm_sym)();
         // Safe to unlink now: the handle keeps the .so mapped regardless of path.
         unlink(so_path.c_str());
         auto *eps = new HostOrchEntryPoints{};

--- a/src/a5/runtime/host_build_graph/host_orchestration_support/graph_recorder_prewarm.cpp
+++ b/src/a5/runtime/host_build_graph/host_orchestration_support/graph_recorder_prewarm.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#include "pto_orchestration_api.h"
+
+extern "C" __attribute__((visibility("default"))) void framework_prewarm_graph_recorders() {
+    (void)rt_graph_async_recording().prewarm();
+}

--- a/src/a5/runtime/host_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/host_build_graph/orchestration/pto_orchestration_api.h
@@ -31,19 +31,21 @@
 #include <stdint.h>
 
 #include <array>
+#include <algorithm>
 #include <condition_variable>
 #include <cstring>
 #include <functional>
-#include <memory>
 #include <mutex>
 #include <thread>
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 // Type headers needed by orchestration
 #include "common.h"              // framework_bind_runtime / framework_current_runtime
 #include "graph_cache.h"         // Graph Execution key and result helpers
+#include "graph_host_state.h"    // GRAPH_MAX_DEFINITIONS
 #include "pto_runtime2_types.h"  // PTO2_ERROR_*
 #include "pto_submit_types.h"    // MixedKernels, INVALID_KERNEL_ID, subtask slots
 #include "pto_types.h"           // Arg, TaskOutputTensors, TensorArgType
@@ -102,8 +104,8 @@ typedef struct PTO2RuntimeOps {
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
     GraphScopeResult (*graph_begin)(PTO2Runtime *rt, uint64_t graph_key, const GraphTaskArgs &args);
-    bool (*graph_prepare)(PTO2Runtime *rt, const GraphTaskArgs &args);
-    void (*graph_abort)(PTO2Runtime *rt);
+    bool (*graph_prepare)(PTO2Runtime *rt, void *recording_handle, const GraphTaskArgs &args);
+    void (*graph_abort)(PTO2Runtime *rt, void *recording_handle);
     bool (*graph_end)(PTO2Runtime *rt);
     void (*graph_commit)(PTO2Runtime *rt);
 
@@ -128,10 +130,13 @@ struct PTO2Runtime {
 
 class GraphOwnedArgs {
 public:
+    GraphOwnedArgs() { std::memset(tensors_.data(), 0, sizeof(tensors_)); }
+
     // The arrays below are sized to the Graph boundary's own capacity, so a
     // source GraphTaskArgs cannot report more args than they hold and the copy
     // loops need no runtime bound.
-    explicit GraphOwnedArgs(const GraphTaskArgs &source) {
+    void assign(const GraphTaskArgs &source) {
+        args_.reset();
         for (int32_t i = 0; i < source.tensor_count(); ++i) {
             tensors_[static_cast<size_t>(i)].copy(source.tensor(i).ref());
             switch (source.tag(i)) {
@@ -174,73 +179,150 @@ private:
 
 class GraphAsyncRecordingState {
 public:
-    GraphAsyncRecordingState() = default;
+    GraphAsyncRecordingState() {
+        for (size_t i = 0; i < kJobCapacity; ++i) {
+            free_owned_args_[i] = kJobCapacity - i - 1;
+        }
+    }
     ~GraphAsyncRecordingState() { shutdown(); }
 
     GraphAsyncRecordingState(const GraphAsyncRecordingState &) = delete;
     GraphAsyncRecordingState &operator=(const GraphAsyncRecordingState &) = delete;
 
+    // The common four-Definition case should not create pthreads between outer
+    // shell submissions. Callable registration parks those workers before the
+    // first run; start() can still grow to the Definition limit if a workload
+    // records more identities concurrently.
+    bool prewarm() {
+        std::unique_lock<std::mutex> lock(mutex_);
+        if (stopping_) return false;
+        while (workers_.size() < kPrewarmedWorkerCount) {
+            if (!create_worker_locked()) break;
+        }
+        const size_t target = workers_.size();
+        cv_.wait(lock, [&]() {
+            return ready_workers_ >= target || stopping_;
+        });
+        return !stopping_ && target == kPrewarmedWorkerCount;
+    }
+
     template <typename Job>
-    bool start(Job &&job) {
-        std::function<void()> next;
+    bool start(const GraphTaskArgs &args, Job &&job) {
+        std::function<void(GraphTaskArgs &)> next;
         try {
             next = std::forward<Job>(job);
-            ensure_worker();
         } catch (...) {
             return false;
         }
 
+        size_t owned_args_index;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (stopping_ || free_owned_args_count_ == 0 || job_count_ == kJobCapacity) return false;
+            owned_args_index = free_owned_args_[--free_owned_args_count_];
+        }
+        owned_args_[owned_args_index].assign(args);
+
         std::unique_lock<std::mutex> lock(mutex_);
-        debug_assert(done_ && !pending_ && "Only one Graph recording may be in flight");
-        if (!done_ || pending_ || stopping_) return false;
-        job_ = std::move(next);
-        done_ = false;
-        pending_ = true;
+        if (stopping_) {
+            free_owned_args_[free_owned_args_count_++] = owned_args_index;
+            return false;
+        }
+        PendingJob &pending = jobs_[job_tail_];
+        pending.function = std::move(next);
+        pending.owned_args_index = owned_args_index;
+        job_tail_ = (job_tail_ + 1) % kJobCapacity;
+        job_count_++;
+        const size_t desired_workers = std::min(kMaxWorkerCount, job_count_ + active_jobs_);
+        while (workers_.size() < desired_workers) {
+            if (!create_worker_locked()) break;
+        }
+        if (workers_.empty()) {
+            job_tail_ = (job_tail_ + kJobCapacity - 1) % kJobCapacity;
+            PendingJob &rollback = jobs_[job_tail_];
+            rollback.function = {};
+            job_count_--;
+            free_owned_args_[free_owned_args_count_++] = rollback.owned_args_index;
+            return false;
+        }
+        lock.unlock();
         cv_.notify_one();
-        // graph_begin() has already installed the hash-keyed RECORDING entry
-        // and submitted the zero-heap outer shell. Enqueuing the private job is
+        // graph_begin() has already installed the keyed in-flight entry and
+        // submitted the zero-heap outer shell. Enqueuing the private job is
         // therefore the last dependency of the caller; graph_prepare() and all
-        // node recording may start after later same-hash shells are submitted.
+        // node recording may start after later shells are submitted.
         return true;
     }
 
+    // Wait for every queued and running recording. A recording thread returns
+    // immediately: it may reach this through rt_orchestration_done in a Graph body
+    // and must never wait for its own job, nor for a sibling's — the sibling makes
+    // progress independently and waiting on it would trade a recording thread for
+    // nothing.
     void wait() {
         std::unique_lock<std::mutex> lock(mutex_);
-        // Recording invokes the same public task wrappers as the outer
-        // orchestration. Those wrappers call rt_graph_commit() before a
-        // non-Graph operation. The recorder must never wait for its own job.
-        if (worker_.joinable() && worker_.get_id() == std::this_thread::get_id()) return;
+        if (is_worker_thread_locked(std::this_thread::get_id())) return;
         cv_.wait(lock, [&]() {
-            return done_;
+            return job_count_ == 0 && active_jobs_ == 0;
         });
     }
 
 private:
-    void ensure_worker() {
-        std::lock_guard<std::mutex> lock(mutex_);
-        if (!worker_.joinable()) {
-            worker_ = std::thread([this]() {
+    static constexpr size_t kPrewarmedWorkerCount = 4;
+    static constexpr size_t kMaxWorkerCount = GRAPH_MAX_DEFINITIONS;
+    static constexpr size_t kJobCapacity = GRAPH_MAX_DEFINITIONS;
+
+    struct PendingJob {
+        std::function<void(GraphTaskArgs &)> function;
+        size_t owned_args_index{0};
+    };
+
+    bool is_worker_thread_locked(std::thread::id id) const {
+        for (const std::thread &worker : workers_) {
+            if (worker.get_id() == id) return true;
+        }
+        return false;
+    }
+
+    bool create_worker_locked() {
+        if (stopping_ || workers_.size() >= kMaxWorkerCount) return false;
+        try {
+            workers_.emplace_back([this]() {
                 run();
             });
+            return true;
+        } catch (...) {
+            return false;
         }
     }
 
     void run() {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            ready_workers_++;
+        }
+        cv_.notify_all();
         for (;;) {
-            std::function<void()> current;
+            PendingJob current;
             {
                 std::unique_lock<std::mutex> lock(mutex_);
                 cv_.wait(lock, [&]() {
-                    return pending_ || stopping_;
+                    return job_count_ != 0 || stopping_;
                 });
-                if (stopping_) return;
-                current = std::move(job_);
-                pending_ = false;
+                if (stopping_ && job_count_ == 0) return;
+                PendingJob &pending = jobs_[job_head_];
+                current.function = std::move(pending.function);
+                current.owned_args_index = pending.owned_args_index;
+                job_head_ = (job_head_ + 1) % kJobCapacity;
+                job_count_--;
+                active_jobs_++;
             }
-            current();
+            current.function(owned_args_[current.owned_args_index].args());
+            current.function = {};
             {
                 std::lock_guard<std::mutex> lock(mutex_);
-                done_ = true;
+                free_owned_args_[free_owned_args_count_++] = current.owned_args_index;
+                active_jobs_--;
             }
             cv_.notify_all();
         }
@@ -253,27 +335,33 @@ private:
             stopping_ = true;
         }
         cv_.notify_all();
-        if (worker_.joinable()) worker_.join();
+        for (std::thread &worker : workers_) {
+            if (worker.joinable()) worker.join();
+        }
     }
 
-    std::thread worker_;
+    std::vector<std::thread> workers_;
     std::mutex mutex_;
     std::condition_variable cv_;
-    std::function<void()> job_;
-    bool pending_{false};
-    bool done_{true};
+    std::array<GraphOwnedArgs, kJobCapacity> owned_args_;
+    std::array<size_t, kJobCapacity> free_owned_args_{};
+    std::array<PendingJob, kJobCapacity> jobs_;
+    size_t free_owned_args_count_{kJobCapacity};
+    size_t job_head_{0};
+    size_t job_tail_{0};
+    size_t job_count_{0};
+    size_t ready_workers_{0};
+    size_t active_jobs_{0};
     bool stopping_{false};
 };
 
 // External linkage on purpose: `static inline` would give every translation
-// unit that submits a Graph its own recorder and its own worker thread, so a
+// unit that submits a Graph its own recorder and its own worker threads, so a
 // commit reached from one TU would not wait for a recording another TU started.
-// Vague linkage keeps one instance — and one worker — per loaded SO.
+// Vague linkage keeps one instance — and one pool — per loaded SO.
 inline GraphAsyncRecordingState &rt_graph_async_recording() {
-    // One orchestration SO is invoked serially by its ChipWorker. Keep its
-    // recorder alive across runs so steady-state misses pay only a condition-
-    // variable wakeup, not a fresh pthread create/join. The SO's destructor
-    // stops the idle worker before dlclose unmaps its code.
+    // Keep the bounded pool alive across runs so steady-state misses pay only a
+    // condition-variable wakeup. The SO's destructor joins it before dlclose.
     static GraphAsyncRecordingState state;
     return state;
 }
@@ -285,8 +373,15 @@ inline GraphAsyncRecordingState &rt_graph_async_recording() {
 static inline PTO2Runtime *current_runtime() { return framework_current_runtime(); }
 static inline void rt_graph_commit();
 
+// An ordinary submission depends on nothing a recording produces. The outer
+// Graph shell entered the task sequence and registered its TensorMap producers
+// at graph_begin, so fanin against it is already correct; the recording only
+// builds the Definition image, and the deferred heap block a shell still needs is
+// an independent bump allocation that orchestration completion reserves. So none
+// of the three wrappers below joins the recorders — a barrier here stalls the
+// submitting thread for the rest of every recording in flight, which on the
+// four-Definition DeepSeek-V4 decode was a third of the orchestration window.
 static inline TaskOutputTensors alloc_tensors(const CoreTaskArgs &args) {
-    rt_graph_commit();
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -337,7 +432,6 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
 }
 
 static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
-    rt_graph_commit();
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -371,7 +465,6 @@ static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const Core
  * barrier or as a placeholder producer for tests / dep-graph wiring.
  */
 static inline TaskOutputTensors rt_submit_dummy_task(const CoreTaskArgs &args) {
-    rt_graph_commit();
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -387,14 +480,17 @@ static inline GraphScopeResult rt_graph_begin(uint64_t graph_key, const GraphTas
     return rt->ops->graph_begin(rt, graph_key, args);
 }
 
-static inline bool rt_graph_prepare(const GraphTaskArgs &args) {
+// Bind the calling thread to the recording `graph_key` opened. The handle comes
+// from the GraphScopeResult that opened it, so a thread can only ever record
+// into the recording it was handed.
+static inline bool rt_graph_prepare(void *recording_handle, const GraphTaskArgs &args) {
     PTO2Runtime *rt = current_runtime();
-    return rt->ops->graph_prepare != nullptr && rt->ops->graph_prepare(rt, args);
+    return rt->ops->graph_prepare != nullptr && rt->ops->graph_prepare(rt, recording_handle, args);
 }
 
-static inline void rt_graph_abort() {
+static inline void rt_graph_abort(void *recording_handle) {
     PTO2Runtime *rt = current_runtime();
-    if (rt->ops->graph_abort != nullptr) rt->ops->graph_abort(rt);
+    if (rt->ops->graph_abort != nullptr) rt->ops->graph_abort(rt, recording_handle);
 }
 
 // Finish the recording pass and publish its Definition. The calling thread
@@ -566,10 +662,10 @@ static inline uint64_t rt_graph_function_id(Function function) {
     return function_id;
 }
 
-// `invoke` is copied into the recording job and runs on the recording worker,
-// which outlives this call: the caller returns as soon as the outer shell is
-// submitted, and the body runs until the next rt_graph_commit(). So `invoke` must
-// own everything it needs by value. Capturing caller-frame storage by reference —
+// `invoke` is copied into the recording job and runs on a recording thread, which
+// outlives this call: the caller returns as soon as the outer shell is submitted,
+// and the body runs until orchestration completion joins it. So `invoke` must own
+// everything it needs by value. Capturing caller-frame storage by reference —
 // including the boundary `args` — is a use-after-free; the recorded body receives
 // its own boundary copy as a parameter for exactly that reason.
 template <typename Invoke>
@@ -588,66 +684,44 @@ static inline GraphSubmitResult rt_submit_graph_impl(uint64_t graph_key, const G
         );
     }
     if (!rt_graph_args_cacheable(args)) {
-        rt_graph_commit();
         invoke(args);
         return GraphSubmitResult{};
     }
     GraphScopeResult result = rt_graph_begin(graph_key, args);
     if (result.recording) {
         GraphAsyncRecordingState &async = rt_graph_async_recording();
-        std::shared_ptr<GraphOwnedArgs> owned_args;
-        try {
-            owned_args = std::make_shared<GraphOwnedArgs>(args);
-        } catch (...) {
+        void *handle = result.recording_handle;
+        auto record = [invoke, handle](GraphTaskArgs &record_args) mutable {
             try {
-                if (!rt_graph_prepare(args)) {
-                    rt_graph_abort();
-                    rt_graph_commit();
+                if (!rt_graph_prepare(handle, record_args)) {
+                    rt_graph_abort(handle);
+                    return;
+                }
+                invoke(record_args);
+                (void)rt_graph_end();
+            } catch (...) {
+                rt_graph_abort(handle);
+            }
+        };
+        if (!async.start(args, std::move(record))) {
+            try {
+                if (!rt_graph_prepare(handle, args)) {
+                    rt_graph_abort(handle);
                     return result;
                 }
                 invoke(args);
                 (void)rt_graph_end();
             } catch (...) {
-                rt_graph_abort();
+                rt_graph_abort(handle);
                 throw;
             }
-            rt_graph_commit();
-            return result;
-        }
-        auto record = [owned_args, invoke]() mutable {
-            try {
-                if (!rt_graph_prepare(owned_args->args())) {
-                    rt_graph_abort();
-                    return;
-                }
-                invoke(owned_args->args());
-                (void)rt_graph_end();
-            } catch (...) {
-                rt_graph_abort();
-            }
-        };
-        if (!async.start(std::move(record))) {
-            try {
-                if (!rt_graph_prepare(owned_args->args())) {
-                    rt_graph_abort();
-                    rt_graph_commit();
-                    return result;
-                }
-                invoke(owned_args->args());
-                (void)rt_graph_end();
-            } catch (...) {
-                rt_graph_abort();
-                throw;
-            }
-            rt_graph_commit();
         }
     } else if (result.execute_block) {
         // Un-cacheable at begin, or the Definition cache is full: ordinary path.
-        rt_graph_commit();
         if (!current_runtime()->ops->is_fatal(current_runtime())) invoke(args);
     }
-    // A cache hit or an in-flight hit skips the body. In-flight Graph tasks are
-    // finalized before the next non-Graph operation or orchestration completion.
+    // A cache hit or an in-flight hit skips the body. Every in-flight Graph task
+    // is finalized at orchestration completion.
     return result;
 }
 

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -389,23 +389,46 @@ struct GraphPendingUpload {
     bool deferred_heap{false};
 };
 
-enum class GraphRecordingStatus : uint8_t { IDLE = 0, RECORDING = 1, READY = 2, FAILED = 3 };
+enum class GraphRecordingStatus : uint8_t { RECORDING = 0, READY = 1, FAILED = 2 };
 
-struct GraphHostState {
-    std::unordered_map<uint64_t, std::vector<std::byte>> definitions;
+// One Definition being recorded. Entries are keyed by Graph key and held by
+// unique_ptr, so a rehash of the owning map never moves one: the recording
+// thread is handed this address at graph_begin and dereferences it without
+// taking recording_mutex.
+struct GraphInflightRecording {
+    uint64_t full_key{0};
     std::unique_ptr<GraphRecording> recording;
-    std::vector<GraphPendingUpload> pending_uploads;
-    std::mutex recording_mutex;
-    std::condition_variable recording_cv;
-    // Atomic because graph_prepare reads it on the recording worker without
+    // Atomic because graph_prepare reads it on the recording thread without
     // taking recording_mutex, by design: acquiring the mutex there lets a
-    // main-thread burst of same-hash submissions starve the worker before it can
+    // main-thread burst of same-key submissions starve the thread before it can
     // bind its private recording state. Every other access holds the mutex.
-    std::atomic<GraphRecordingStatus> recording_status{GraphRecordingStatus::IDLE};
-    uint64_t recording_key{0};
+    std::atomic<GraphRecordingStatus> recording_status{GraphRecordingStatus::RECORDING};
 
     GraphRecordingStatus status() const { return recording_status.load(std::memory_order_acquire); }
     void set_status(GraphRecordingStatus next) { recording_status.store(next, std::memory_order_release); }
+};
+
+struct GraphHostState {
+    std::unordered_map<uint64_t, std::vector<std::byte>> definitions;
+    // Recordings in flight, at most one per Graph key. Several record at once,
+    // each on its own thread; graph_commit drains and finalizes all of them.
+    std::unordered_map<uint64_t, std::unique_ptr<GraphInflightRecording>> inflight;
+    std::vector<GraphPendingUpload> pending_uploads;
+    std::mutex recording_mutex;
+    std::condition_variable recording_cv;
+    // Mirrors inflight.size() so orchestration completion answers the common
+    // "nothing is recording" case without taking recording_mutex.
+    std::atomic<size_t> inflight_count{0};
+
+    // Definitions this run can still admit: published plus in flight, against
+    // the per-worker cache limit.
+    size_t claimed_definitions() const { return definitions.size() + inflight.size(); }
+    bool any_recording() const {
+        for (const auto &entry : inflight) {
+            if (entry.second->status() == GraphRecordingStatus::RECORDING) return true;
+        }
+        return false;
+    }
 };
 
 namespace {
@@ -414,6 +437,9 @@ GraphHostState *graph_state_from(PTO2OrchestratorState *orch) {
     return orch == nullptr ? nullptr : static_cast<GraphHostState *>(orch->graph_host_state);
 }
 
+// The in-flight entry this thread is recording into, bound by graph_prepare and
+// cleared by graph_end / graph_abort.
+thread_local GraphInflightRecording *g_active_graph_entry = nullptr;
 thread_local GraphRecording *g_active_graph_recording = nullptr;
 // The recording a thread holds belongs to one GraphHostState. Recording into it
 // from a different orchestrator would silently mix two graphs, so the owner is
@@ -1655,21 +1681,25 @@ bool graph_submit_pending_definition(
     return graph_submit_outer(orch, state, full_key, 0, 0, true, args, submitted_id);
 }
 
-bool graph_finalize_pending_submissions(
-    PTO2OrchestratorState *orch, GraphHostState *state, const GraphDefinition &definition
-) {
-    if (definition.execution_storage_bytes == 0 ||
-        definition.required_heap > UINT64_MAX - definition.execution_storage_bytes) {
-        return false;
-    }
-    const uint64_t owned_heap = definition.required_heap + definition.execution_storage_bytes;
-    if (owned_heap > static_cast<uint64_t>(INT32_MAX)) return false;
+bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostState *state, uint64_t *failed_key) {
     for (GraphPendingUpload &pending : state->pending_uploads) {
-        if (!pending.deferred_heap || pending.image.size() < sizeof(GraphSubmission)) continue;
+        if (!pending.deferred_heap) continue;
+        if (pending.image.size() < sizeof(GraphSubmission)) return false;
         auto *submission = reinterpret_cast<GraphSubmission *>(pending.image.data());
-        if (submission->graph_key != definition.full_key || pending.outer_slot == nullptr ||
-            pending.outer_slot->task == nullptr || pending.outer_slot->task_kind != TaskKind::GRAPH ||
+        auto definition_it = state->definitions.find(submission->graph_key);
+        const GraphDefinition *definition =
+            definition_it == state->definitions.end() ? nullptr : graph_definition(definition_it->second);
+        if (definition == nullptr || definition->execution_storage_bytes == 0 ||
+            definition->required_heap > UINT64_MAX - definition->execution_storage_bytes ||
+            pending.outer_slot == nullptr || pending.outer_slot->task == nullptr ||
+            pending.outer_slot->task_kind != TaskKind::GRAPH ||
             !graph_submission_wire_size_valid(*submission, pending.image.size())) {
+            if (failed_key != nullptr) *failed_key = submission->graph_key;
+            return false;
+        }
+        const uint64_t owned_heap = definition->required_heap + definition->execution_storage_bytes;
+        if (owned_heap > static_cast<uint64_t>(INT32_MAX)) {
+            if (failed_key != nullptr) *failed_key = submission->graph_key;
             return false;
         }
         void *packed_base = nullptr;
@@ -1677,11 +1707,12 @@ bool graph_finalize_pending_submissions(
         if (!orch->ring.task_allocator.reserve_deferred_heap(
                 static_cast<int32_t>(owned_heap), &packed_base, &packed_end
             )) {
+            if (failed_key != nullptr) *failed_key = submission->graph_key;
             return false;
         }
         pending.outer_slot->task->packed_buffer_base = packed_base;
         pending.outer_slot->task->packed_buffer_end = packed_end;
-        submission->definition_hash = definition.content_hash;
+        submission->definition_hash = definition->content_hash;
         pending.deferred_heap = false;
     }
     return true;
@@ -1914,37 +1945,10 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
 
     const uint64_t full_key = graph_full_key(callable_hash, graph_key);
     std::unique_lock<std::mutex> lock(state->recording_mutex);
-    if (state->status() != GraphRecordingStatus::IDLE) {
-        if (state->recording_key != full_key || state->status() == GraphRecordingStatus::FAILED) {
-            return result;
-        }
-        bool boundary_matches = false;
-        if (state->recording != nullptr) {
-            boundary_matches = graph_recording_boundary_matches(*state->recording, args);
-        } else {
-            auto definition_it = state->definitions.find(full_key);
-            boundary_matches = definition_it != state->definitions.end() &&
-                               graph_definition(definition_it->second) != nullptr &&
-                               graph_boundary_matches(*graph_definition(definition_it->second), args);
-        }
-        if (!boundary_matches) return result;
 
-        PTO2TaskId submitted = PTO2TaskId::invalid();
-        ORCH_PHASE_START();
-        if (graph_submit_pending_definition(orch, state, full_key, args, &submitted)) {
-            result.execute_block = false;
-            result.task_id = submitted;
-            ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
-#if SIMPLER_DFX
-            g_orch_submit_idx++;
-#if SIMPLER_ORCH_PROFILING
-            g_orch_submit_count++;
-#endif
-#endif
-        }
-        return result;
-    }
-
+    // A published Definition is immutable, so the cache lookup comes first and
+    // answers regardless of what else is recording. Gating it on an idle recorder
+    // would make an already-built Definition wait for an unrelated one.
     auto definition_it = state->definitions.find(full_key);
     if (definition_it != state->definitions.end()) {
         PTO2TaskId submitted = PTO2TaskId::invalid();
@@ -1962,13 +1966,41 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
         }
         return result;
     }
-    if (state->definitions.size() >= GRAPH_MAX_DEFINITIONS) {
+
+    // This key is already recording: publish another zero-heap shell against it.
+    // A recording that ended has its Definition in the cache, so reaching here
+    // with no recording object means the pass failed and this key is spent.
+    auto inflight_it = state->inflight.find(full_key);
+    if (inflight_it != state->inflight.end()) {
+        GraphInflightRecording &entry = *inflight_it->second;
+        if (entry.status() != GraphRecordingStatus::RECORDING || entry.recording == nullptr ||
+            !graph_recording_boundary_matches(*entry.recording, args)) {
+            return result;
+        }
+        PTO2TaskId submitted = PTO2TaskId::invalid();
+        ORCH_PHASE_START();
+        if (graph_submit_pending_definition(orch, state, full_key, args, &submitted)) {
+            result.execute_block = false;
+            result.task_id = submitted;
+            ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
+#if SIMPLER_DFX
+            g_orch_submit_idx++;
+#if SIMPLER_ORCH_PROFILING
+            g_orch_submit_count++;
+#endif
+#endif
+        }
+        return result;
+    }
+
+    if (state->claimed_definitions() >= GRAPH_MAX_DEFINITIONS) {
         debug_assert(
-            state->definitions.size() < GRAPH_MAX_DEFINITIONS &&
+            state->claimed_definitions() < GRAPH_MAX_DEFINITIONS &&
             "Graph Definition cache exceeds the supported per-worker limit"
         );
         LOG_WARN(
-            "[GraphExecution] Definition cache is full (%zu entries); using ordinary path", state->definitions.size()
+            "[GraphExecution] Definition cache is full (%zu published, %zu in flight); using ordinary path",
+            state->definitions.size(), state->inflight.size()
         );
         return result;
     }
@@ -1983,15 +2015,19 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
         recording->boundary_tensors.push_back(args.tensor(i).ref());
         recording->boundary_types.push_back(args.tag(i));
     }
-    state->recording = std::move(recording);
-    state->recording_key = full_key;
-    state->set_status(GraphRecordingStatus::RECORDING);
+    auto entry = std::make_unique<GraphInflightRecording>();
+    entry->full_key = full_key;
+    entry->recording = std::move(recording);
+    GraphInflightRecording *entry_ptr = entry.get();
+    state->inflight.emplace(full_key, std::move(entry));
+    state->inflight_count.store(state->inflight.size(), std::memory_order_release);
 
     PTO2TaskId submitted = PTO2TaskId::invalid();
     ORCH_PHASE_START();
     if (graph_submit_pending_definition(orch, state, full_key, args, &submitted)) {
         result.execute_block = false;
         result.recording = true;
+        result.recording_handle = entry_ptr;
         result.task_id = submitted;
         ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
 #if SIMPLER_DFX
@@ -2001,42 +2037,46 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
 #endif
 #endif
     } else {
-        state->recording.reset();
-        state->recording_key = 0;
-        state->set_status(GraphRecordingStatus::IDLE);
+        state->inflight.erase(full_key);
+        state->inflight_count.store(state->inflight.size(), std::memory_order_release);
     }
     return result;
 }
 
-bool PTO2OrchestratorState::graph_prepare(const GraphTaskArgs &args) {
+bool PTO2OrchestratorState::graph_prepare(void *recording_handle, const GraphTaskArgs &args) {
     GraphHostState *state = graph_state_from(this);
-    if (state == nullptr || g_active_graph_recording != nullptr) return false;
-    // graph_begin publishes this unique recording before the private job is
-    // enqueued; the recording worker's queue acquire observes those writes.
-    // Until this worker calls graph_end/graph_abort, later graph_begin calls
-    // only read the boundary vectors under recording_mutex, and only this worker
-    // writes the fields it binds below. Taking that mutex here lets the main
-    // thread's same-hash submit burst starve prepare and collapse the intended
-    // overlap, so the status read goes through the atomic instead.
-    if (state->status() != GraphRecordingStatus::RECORDING || state->recording == nullptr ||
-        !graph_recording_boundary_matches(*state->recording, args)) {
+    if (state == nullptr || recording_handle == nullptr || g_active_graph_recording != nullptr) return false;
+    auto *entry = static_cast<GraphInflightRecording *>(recording_handle);
+    // graph_begin published this entry before the private job was enqueued, and
+    // the entry's address is stable for as long as the recording lives, so the
+    // recording thread reaches its own state without searching for it. Until this
+    // thread calls graph_end/graph_abort, later graph_begin calls only read the
+    // boundary vectors under recording_mutex, and only this thread writes the
+    // fields it binds below. Taking that mutex here lets the main thread's
+    // same-key submit burst starve prepare and collapse the intended overlap, so
+    // the status read goes through the atomic instead.
+    if (entry->status() != GraphRecordingStatus::RECORDING || entry->recording == nullptr ||
+        !graph_recording_boundary_matches(*entry->recording, args)) {
         return false;
     }
     args.anchor_scalar_sources();
-    state->recording->boundary_args = &args;
-    g_active_graph_recording = state->recording.get();
+    entry->recording->boundary_args = &args;
+    g_active_graph_entry = entry;
+    g_active_graph_recording = entry->recording.get();
     g_active_graph_owner = state;
     return true;
 }
 
-void PTO2OrchestratorState::graph_abort() {
+void PTO2OrchestratorState::graph_abort(void *recording_handle) {
     GraphHostState *state = graph_state_from(this);
-    if (state == nullptr) return;
+    auto *entry = static_cast<GraphInflightRecording *>(recording_handle);
+    if (state == nullptr || entry == nullptr) return;
     {
         std::lock_guard<std::mutex> lock(state->recording_mutex);
-        state->recording.reset();
-        state->set_status(GraphRecordingStatus::FAILED);
+        entry->recording.reset();
+        entry->set_status(GraphRecordingStatus::FAILED);
     }
+    g_active_graph_entry = nullptr;
     g_active_graph_recording = nullptr;
     g_active_graph_owner = nullptr;
     state->recording_cv.notify_all();
@@ -2047,7 +2087,8 @@ void PTO2OrchestratorState::graph_abort() {
 bool PTO2OrchestratorState::graph_end() {
     GraphHostState *state = graph_state_from(this);
     GraphRecording *recording = active_graph_recording(this);
-    if (state == nullptr || recording == nullptr) return false;
+    GraphInflightRecording *entry = g_active_graph_entry;
+    if (state == nullptr || recording == nullptr || entry == nullptr) return false;
 
     std::vector<std::byte> definition;
     ORCH_PHASE_START();
@@ -2059,7 +2100,7 @@ bool PTO2OrchestratorState::graph_end() {
     if (header == nullptr) {
         debug_assert(false && "The recorded Graph contains a construct that Graph Execution does not support");
         LOG_WARN("%s", "[GraphExecution] asynchronous recording produced an unsupported Graph");
-        graph_abort();
+        graph_abort(entry);
         return false;
     }
     LOG_DEBUG(
@@ -2069,51 +2110,56 @@ bool PTO2OrchestratorState::graph_end() {
     bool ready = false;
     {
         std::lock_guard<std::mutex> lock(state->recording_mutex);
-        if (state->status() != GraphRecordingStatus::RECORDING || state->recording_key != header->full_key) {
-            state->set_status(GraphRecordingStatus::FAILED);
+        if (entry->status() != GraphRecordingStatus::RECORDING || entry->full_key != header->full_key) {
+            entry->set_status(GraphRecordingStatus::FAILED);
         } else {
             state->definitions.emplace(header->full_key, std::move(definition));
-            state->set_status(GraphRecordingStatus::READY);
+            entry->set_status(GraphRecordingStatus::READY);
         }
-        ready = state->status() == GraphRecordingStatus::READY;
-        state->recording.reset();
+        ready = entry->status() == GraphRecordingStatus::READY;
+        entry->recording.reset();
     }
+    g_active_graph_entry = nullptr;
     g_active_graph_recording = nullptr;
     g_active_graph_owner = nullptr;
     state->recording_cv.notify_all();
     return ready;
 }
 
+// Join every recording in flight and back-patch all deferred shells in submit
+// order. Orchestration completion is the only normal-path barrier.
 void PTO2OrchestratorState::graph_commit() {
     if (active_graph_recording(this) != nullptr) return;
     GraphHostState *state = graph_state_from(this);
-    if (state == nullptr) return;
+    if (state == nullptr || state->inflight_count.load(std::memory_order_acquire) == 0) return;
 
-    uint64_t full_key = 0;
-    const GraphDefinition *definition = nullptr;
-    bool failed = false;
+    std::unordered_map<uint64_t, std::unique_ptr<GraphInflightRecording>> drained;
     {
         std::unique_lock<std::mutex> lock(state->recording_mutex);
-        if (state->status() == GraphRecordingStatus::IDLE) return;
+        if (state->inflight.empty()) return;
         state->recording_cv.wait(lock, [&]() {
-            return state->status() != GraphRecordingStatus::RECORDING;
+            return !state->any_recording();
         });
-        full_key = state->recording_key;
-        failed = state->status() != GraphRecordingStatus::READY;
-        auto definition_it = state->definitions.find(full_key);
-        if (!failed && definition_it != state->definitions.end()) definition = graph_definition(definition_it->second);
+        drained.swap(state->inflight);
+        state->inflight_count.store(0, std::memory_order_release);
     }
 
-    if (definition == nullptr || !graph_finalize_pending_submissions(this, state, *definition)) failed = true;
-    {
-        std::lock_guard<std::mutex> lock(state->recording_mutex);
-        state->set_status(GraphRecordingStatus::IDLE);
-        state->recording_key = 0;
+    uint64_t failed_key = 0;
+    bool failed = false;
+    for (const auto &[key, entry] : drained) {
+        auto definition_it = state->definitions.find(key);
+        if (entry->status() == GraphRecordingStatus::READY && definition_it != state->definitions.end() &&
+            graph_definition(definition_it->second) != nullptr) {
+            continue;
+        }
+        if (!failed) failed_key = key;
+        failed = true;
     }
+    if (!failed && !graph_finalize_pending_submissions(this, state, &failed_key)) failed = true;
     if (failed) {
         report_fatal(
             PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "failed to finalize asynchronous Graph key=%#llx",
-            static_cast<unsigned long long>(full_key)
+            static_cast<unsigned long long>(failed_key)
         );
     }
 }

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -101,12 +101,12 @@ static GraphScopeResult graph_begin_impl(PTO2Runtime *rt, uint64_t graph_key, co
     return rt->orchestrator.graph_begin(graph_key, args, rt->active_callable_hash);
 }
 
-static bool graph_prepare_impl(PTO2Runtime *rt, const GraphTaskArgs &args) {
-    return rt != nullptr && rt->orchestrator.graph_prepare(args);
+static bool graph_prepare_impl(PTO2Runtime *rt, void *recording_handle, const GraphTaskArgs &args) {
+    return rt != nullptr && rt->orchestrator.graph_prepare(recording_handle, args);
 }
 
-static void graph_abort_impl(PTO2Runtime *rt) {
-    if (rt != nullptr) rt->orchestrator.graph_abort();
+static void graph_abort_impl(PTO2Runtime *rt, void *recording_handle) {
+    if (rt != nullptr) rt->orchestrator.graph_abort(recording_handle);
 }
 
 static bool graph_end_impl(PTO2Runtime *rt) { return rt != nullptr && rt->orchestrator.graph_end(); }

--- a/src/a5/runtime/host_build_graph/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_orchestrator.h
@@ -157,8 +157,8 @@ struct PTO2OrchestratorState {
     TaskOutputTensors submit_dummy_task(const CoreTaskArgs &args);
     TaskOutputTensors alloc_tensors(const CoreTaskArgs &args);
     GraphScopeResult graph_begin(uint64_t graph_key, const GraphTaskArgs &args, uint64_t callable_hash);
-    bool graph_prepare(const GraphTaskArgs &args);
-    void graph_abort();
+    bool graph_prepare(void *recording_handle, const GraphTaskArgs &args);
+    void graph_abort(void *recording_handle);
     bool graph_end();
     void graph_commit();
     void mark_done();

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -97,8 +97,8 @@ struct PTO2RuntimeOps {
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
     GraphScopeResult (*graph_begin)(PTO2Runtime *rt, uint64_t graph_key, const GraphTaskArgs &args);
-    bool (*graph_prepare)(PTO2Runtime *rt, const GraphTaskArgs &args);
-    void (*graph_abort)(PTO2Runtime *rt);
+    bool (*graph_prepare)(PTO2Runtime *rt, void *recording_handle, const GraphTaskArgs &args);
+    void (*graph_abort)(PTO2Runtime *rt, void *recording_handle);
     bool (*graph_end)(PTO2Runtime *rt);
     void (*graph_commit)(PTO2Runtime *rt);
     // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -6,15 +6,17 @@ MIX, or SPMD task, but contains a recorded task DAG.
 
 Every invocation places exactly one `GRAPH` task in the host task window. On a
 first miss, the caller immediately submits an outer task shell keyed by Graph
-identity while a worker records the DAG off the ring. Internal submissions
-build host-only node metadata and assign output addresses from a private bit-63
-virtual range instead of consuming task-window slots or heap. Later calls for
-the same in-flight identity submit more shells without waiting for recording.
-Before leaving that consecutive Graph batch, the caller joins the worker and
-fills every shell's heap range and Definition content hash. Cached invocations
-submit the same one `GRAPH` task directly. In both cases the device Scheduler
-expands the saved topology and dispatches the internal nodes; the Host
-Orchestrator never submits those nodes as ring tasks.
+identity while a recording thread records the DAG off the ring. Internal
+submissions build host-only node metadata and assign output addresses from a
+private bit-63 virtual range instead of consuming task-window slots or heap.
+Later calls for the same in-flight identity submit more shells without waiting
+for recording, and a call for a *different* identity opens its own recording on
+its own thread rather than waiting. At orchestration completion, the caller joins
+every recording and fills each shell's heap range and Definition content hash.
+Cached invocations submit the same one `GRAPH` task directly — a cache hit never
+waits on a recording. In both cases the device Scheduler expands the saved
+topology and dispatches the internal nodes; the Host Orchestrator never submits
+those nodes as ring tasks.
 
 Boundary contracts are checked before an in-flight shell is accepted. Once a
 shell has entered the task/dependency sequence, an unsupported construct found
@@ -209,12 +211,14 @@ Recording uses host-only C++ state:
 
 - `std::vector` for nodes, tensors, scalars, fanins, and pending uploads;
 - `std::unordered_map` for the per-run Definition cache;
-- `std::unique_ptr` for the active recording, guarded by a mutex and completion
-  condition while the recording worker publishes the Definition.
+- `std::unordered_map` for the recordings in flight, keyed by Graph identity and
+  holding each entry by `std::unique_ptr`, guarded by a mutex and completion
+  condition while the recording threads publish their Definitions.
 
 The cache stores at most 16 Definitions and allocates each entry to its actual
-serialized size. No fixed maximum-size recording array is copied on a cache
-hit.
+serialized size. Published and in-flight entries count against the same limit,
+since an in-flight one has already claimed its identity. No fixed maximum-size
+recording array is copied on a cache hit.
 
 Recorded output addresses start at `GRAPH_RECORD_VIRTUAL_BASE = 1ULL << 63`.
 They exist only to classify `OWN_OUTPUT` and `INTERNAL` Tensor sources and are
@@ -230,44 +234,86 @@ therefore leaves the shared task allocator unchanged.
 
 `graph_begin` computes the Graph identity before the body is recorded. On a
 cache miss, the calling thread allocates a zero-heap outer task shell, records
-its boundary dependency edges, and returns. A worker receives a deep copy of
-the boundary arguments, records the internal nodes in the private virtual
+its boundary dependency edges, and returns. A recording thread receives a deep
+copy of the boundary arguments, records the internal nodes in the private virtual
 address range, and builds and hashes the Definition. The first call waits only
-until that private job has been installed in the worker queue; it does not wait
-for the operating system to schedule the worker or for `graph_prepare` to bind
-the private recording state. The hash-keyed `RECORDING` entry and zero-heap
-outer shell already exist before the job is enqueued, so later same-identity
-submissions can safely proceed immediately. The worker remains parked on a
-condition variable for the lifetime of the loaded orchestration SO and is
-reused by later runs, so only its first miss pays thread creation. Unloading the
-SO stops and joins the idle worker before its code is unmapped.
+until that private job has been installed in the recorder queue; it does not wait
+for the operating system to schedule the thread or for `graph_prepare` to bind
+the private recording state. The keyed in-flight entry and zero-heap outer shell
+already exist before the job is enqueued, so later same-identity submissions can
+safely proceed immediately. Threads remain parked on a condition variable for
+the lifetime of the loaded orchestration SO and are reused by later runs. Four
+workers are created when the callable's orchestration SO is loaded, before any
+`host_orch` run; unloading the SO stops and joins them before their code is
+unmapped.
 
-The queue handoff publishes the already-created recording to `graph_prepare`.
-Prepare therefore does not reacquire the Definition-state mutex: until the
-worker ends or aborts, later same-identity submissions only read the immutable
-boundary signature under that mutex. Avoiding the redundant acquire prevents
-the short main-thread submit loop from starving the worker before it can enter
-its private recording state.
+**Distinct identities record concurrently.** The recorder owns a fixed 16-slot
+job queue and 16 reusable boundary snapshots. The four prewarmed workers cover
+the common four-Definition case without creating threads or allocating boundary
+storage between shell submissions. A fifth or later concurrent miss grows one
+worker per additional job, up to the 16-Definition limit, so the prewarm does not
+turn into a four-recording concurrency cap. Recording touches no shared allocator
+state and each recording classifies Tensor sources only against its own nodes and
+its own boundary, so two recordings sharing the `GRAPH_RECORD_VIRTUAL_BASE`
+range cannot see each other's addresses. What serializes is only the per-identity
+rule: at most one recording per Graph key, which the keyed in-flight map enforces.
+
+`graph_begin` answers a **cache hit before consulting anything in flight**. A
+published Definition is immutable, so replaying it depends on no recording; the
+lookup order is what keeps an already-built Graph from waiting on an unrelated
+Definition. An identity that is neither published nor in flight opens its own
+recording rather than falling back to the ordinary path.
+
+The queue handoff hands `graph_prepare` the in-flight entry's own address,
+carried through `GraphScopeResult::recording_handle`. Prepare therefore neither
+searches for its recording nor reacquires the Definition-state mutex: until its
+thread ends or aborts, later same-identity submissions only read the immutable
+boundary signature under that mutex. Avoiding the redundant acquire prevents the
+short main-thread submit loop from starving a recording thread before it can
+enter its private state, and the handle makes recording into another identity's
+state unrepresentable rather than merely unlikely.
 
 Calls for the same identity while recording is in flight follow the same shell
 submission path on the calling thread. Their task IDs and TensorMap producers
-therefore enter the ordinary program-order sequence while the worker is still
+therefore enter the ordinary program-order sequence while its recording thread is
 executing `record_node` and `build_definition`.
 
-`rt_graph_commit` is a barrier before a non-Graph operation or orchestration
-completion. It waits for the current worker job, reserves each shell's real heap
-block in task order using the Definition's `required_heap`, patches the task
-descriptor and Definition content hash, and then permits ordinary submission to continue. A
-scope transition is deliberately not a barrier: the main thread has already
-submitted the outer Graph shell into that scope, while scopes executed by the
-recording worker are no-ops on the real scope stack. This lets consecutive
-Graph calls in separate outer scopes continue submitting while recording is in
-flight. No unrelated heap allocation can appear between a deferred shell and
-this finalization. Cache-hit submissions after the barrier already know
-`required_heap` and use the ordinary immediate path.
+**Ordinary submissions do not join the recorders either.** `rt_submit_task`,
+`rt_submit_dummy_task` and `alloc_tensors` proceed while any number of Definitions
+are recording, because an ordinary task depends on nothing a recording produces:
+the outer shell entered the task sequence and registered its TensorMap producers
+at `graph_begin`, so fanin against it is already correct, and the deferred heap
+block the shell still needs is an independent bump reservation. The consequence is
+that heap-address order stops matching task-id order — an ordinary task submitted
+during a recording takes its block first — and nothing depends on that
+correspondence: reservations are independent bumps, relocation is
+address-window-based rather than order-based, and `host_build_graph` retires
+nothing during a run.
 
-Host phase records therefore show `graph_submit` on the main lane overlapping
-`record_node` and `build_definition` on the recording-worker lane.
+`rt_graph_commit` is therefore a barrier at exactly one point, orchestration
+completion. It waits for **every** recording in flight, then walks deferred
+shells in original submission order, reserves each shell's real heap block using
+its Definition's `required_heap`, patches the task descriptor and Definition
+content hash, and lets the image be uploaded. A scope transition is deliberately
+not a barrier either: the main thread has already submitted the outer Graph shell
+into that scope, while scopes executed by a recording thread are no-ops on the
+real scope stack.
+
+Making a barrier out of every ordinary submission is what a single-slot recorder
+needed and what this design does not. What it costs depends on how an orchestration
+interleaves: a loop whose body is nothing but Graph submissions drains only once,
+after the loop, by which time the recording has had every later submission to
+overlap with. A loop that allocates a cross-block tensor per iteration drains on
+its *second* iteration instead, with the recordings just started. In a decode
+measured in that second shape — four Definitions, one `alloc_tensors` per iteration
+— the drain cost a third of the orchestration window, with the submitting thread
+stopped and four recording threads running. With the barrier only at completion,
+14% of that pass's submissions land inside the recording span instead of 0.2%, and
+the recorders rather than the submitter become the tail.
+
+Host phase records therefore show `graph_submit`, `submit_task` and
+`alloc_tensors` on the main lane overlapping `record_node` and
+`build_definition` on the recording lanes.
 
 At `graph_end`, recording is compacted into one contiguous, pointer-free POD
 Definition. It contains:
@@ -411,7 +457,7 @@ Conditions detected before an outer shell is accepted use the ordinary path:
 - more than 16 Definitions;
 - insufficient task-window or known cache-hit heap capacity.
 
-The following constructs are discovered only while the worker records the
+The following constructs are discovered only while a thread records the
 first Definition. Because its outer shell is already in the task/dependency
 sequence, they assert in debug builds and fail the orchestration in release
 builds:

--- a/src/common/host_build_graph/graph_cache.h
+++ b/src/common/host_build_graph/graph_cache.h
@@ -23,6 +23,12 @@ struct GraphScopeResult {
     bool execute_block{true};
     bool recording{false};
     PTO2TaskId task_id{PTO2TaskId::invalid()};
+    // The recording this call opened, non-null exactly when `recording` is set.
+    // The recording thread hands it back to graph_prepare so binding needs no
+    // lookup: several Definitions record at once, and finding one by key would
+    // mean traversing the in-flight map under its mutex on a path whose whole
+    // purpose is to not contend with the submitting thread.
+    void *recording_handle{nullptr};
 };
 
 using GraphSubmitResult = GraphScopeResult;

--- a/tests/ut/cpp/common/test_hbg_graph_async_submit.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_async_submit.cpp
@@ -15,6 +15,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <mutex>
+#include <set>
 #include <thread>
 
 #include "pto_orchestration_api.h"
@@ -40,6 +41,9 @@ struct FakeRuntime {
     bool record_entered{false};
     bool later_submit_entered{false};
     bool overlapped{false};
+    bool record_every_begin{false};
+    bool gate_four_prepares{false};
+    int four_prepare_overlaps{0};
     int prepare_overlaps{0};
     int begin_calls{0};
     int prepare_calls{0};
@@ -54,6 +58,7 @@ struct FakeRuntime {
     // What graph_prepare actually received, so the deep copy GraphOwnedArgs makes
     // can be compared against the boundary the caller passed.
     bool prepare_saw_args{false};
+    const void *prepare_handle{nullptr};
     int32_t recorded_tensor_count{-1};
     int32_t recorded_scalar_count{-1};
     uint64_t recorded_tensor_addr{0};
@@ -78,7 +83,9 @@ GraphScopeResult fake_graph_begin(PTO2Runtime *rt, uint64_t, const GraphTaskArgs
     fake.begin_calls++;
     GraphScopeResult result;
     result.execute_block = false;
-    result.recording = fake.begin_calls == 1;
+    result.recording = fake.record_every_begin || fake.begin_calls == 1;
+    // The handle the recording thread must hand back to graph_prepare.
+    if (result.recording) result.recording_handle = &fake;
     if (!result.recording) {
         fake.later_submit_entered = true;
         fake.cv.notify_all();
@@ -86,10 +93,11 @@ GraphScopeResult fake_graph_begin(PTO2Runtime *rt, uint64_t, const GraphTaskArgs
     return result;
 }
 
-bool fake_graph_prepare(PTO2Runtime *rt, const GraphTaskArgs &args) {
+bool fake_graph_prepare(PTO2Runtime *rt, void *recording_handle, const GraphTaskArgs &args) {
     FakeRuntime &fake = *as_fake(rt);
     std::unique_lock<std::mutex> lock(fake.mutex);
     fake.prepare_calls++;
+    fake.prepare_handle = recording_handle;
     fake.prepare_thread = std::this_thread::get_id();
     fake.prepare_saw_args = true;
     fake.recorded_tensor_count = args.tensor_count();
@@ -106,6 +114,14 @@ bool fake_graph_prepare(PTO2Runtime *rt, const GraphTaskArgs &args) {
     if (args.scalar_count() > 0) {
         fake.recorded_scalar = args.scalar(0);
     }
+    if (fake.gate_four_prepares) {
+        fake.cv.notify_all();
+        const bool all_prepared = fake.cv.wait_for(lock, kHandshakeTimeout, [&] {
+            return fake.prepare_calls == 4;
+        });
+        if (all_prepared) fake.four_prepare_overlaps++;
+        return true;
+    }
     // The hash-keyed outer shell is enough for the caller to continue. Hold
     // prepare until the later same-hash submission proves that start() did not
     // retain the old worker-ready handshake.
@@ -116,10 +132,11 @@ bool fake_graph_prepare(PTO2Runtime *rt, const GraphTaskArgs &args) {
     return true;
 }
 
-void fake_graph_abort(PTO2Runtime *) {}
+void fake_graph_abort(PTO2Runtime *, void *) {}
 
 bool fake_graph_end(PTO2Runtime *rt) {
     FakeRuntime &fake = *as_fake(rt);
+    std::lock_guard<std::mutex> lock(fake.mutex);
     fake.end_calls++;
     fake.submit_thread = std::this_thread::get_id();
     return true;
@@ -144,6 +161,78 @@ const PTO2RuntimeOps kFakeOps = {
 
 }  // namespace
 
+TEST(HbgGraphAsyncSubmit, PrewarmedRecorderPoolGrowsForFiveConcurrentGraphs) {
+    constexpr int kGraphCount = 5;
+    GraphAsyncRecordingState pool;
+    ASSERT_TRUE(pool.prewarm());
+    std::mutex gate_mutex;
+    std::condition_variable gate_cv;
+    int entered = 0;
+    bool release = false;
+    std::set<std::thread::id> worker_ids;
+    GraphTaskArgs empty_args;
+
+    for (int i = 0; i < kGraphCount; ++i) {
+        ASSERT_TRUE(pool.start(empty_args, [&](GraphTaskArgs &) {
+            std::unique_lock<std::mutex> lock(gate_mutex);
+            worker_ids.insert(std::this_thread::get_id());
+            entered++;
+            gate_cv.notify_all();
+            gate_cv.wait(lock, [&]() {
+                return release;
+            });
+        }));
+    }
+
+    bool all_entered = false;
+    {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        all_entered = gate_cv.wait_for(lock, kHandshakeTimeout, [&]() {
+            return entered == kGraphCount;
+        });
+        release = true;
+    }
+    gate_cv.notify_all();
+    pool.wait();
+
+    EXPECT_TRUE(all_entered) << "every Graph recording must start before any one of them finishes";
+    EXPECT_EQ(worker_ids.size(), static_cast<size_t>(kGraphCount))
+        << "a fifth Graph must grow the four-worker prewarmed pool instead of queueing";
+}
+
+TEST(HbgGraphAsyncSubmit, FourDistinctGraphMissesDoNotInsertAnIntermediateCommit) {
+    FakeRuntime fake{};
+    fake.ops = &kFakeOps;
+    fake.record_every_begin = true;
+    fake.gate_four_prepares = true;
+    framework_bind_runtime(reinterpret_cast<PTO2Runtime *>(&fake));
+
+    uint32_t storage[4]{};
+    uint32_t shape[] = {4};
+    ChipTensor boundary = make_tensor_external(storage, shape, 1);
+    GraphTaskArgs args;
+    args.add_input(boundary);
+
+    int body_calls = 0;
+    for (uint64_t graph_key = 0x1800; graph_key < 0x1804; ++graph_key) {
+        PTO2ScopeGuard scope;
+        const GraphSubmitResult result = rt_submit_graph_impl(graph_key, args, [&](const GraphTaskArgs &) {
+            std::lock_guard<std::mutex> lock(fake.mutex);
+            body_calls++;
+        });
+        EXPECT_TRUE(result.recording);
+    }
+    rt_graph_commit();
+    framework_bind_runtime(nullptr);
+
+    EXPECT_EQ(fake.begin_calls, 4);
+    EXPECT_EQ(fake.prepare_calls, 4);
+    EXPECT_EQ(fake.four_prepare_overlaps, 4) << "all four recorders must enter before commit waits for any Definition";
+    EXPECT_EQ(fake.end_calls, 4);
+    EXPECT_EQ(fake.commit_calls, 1) << "only the explicit final commit may wait for the recorder pool";
+    EXPECT_EQ(body_calls, 4);
+}
+
 TEST(HbgGraphAsyncSubmit, WorkerRecordsWhileMainSubmitsLaterGraphs) {
     FakeRuntime fake{};
     fake.ops = &kFakeOps;
@@ -161,8 +250,7 @@ TEST(HbgGraphAsyncSubmit, WorkerRecordsWhileMainSubmitsLaterGraphs) {
     {
         PTO2ScopeGuard scope;
         first = rt_submit_graph_impl(0x1715, args, [&](const GraphTaskArgs &) {
-            // Graph bodies use the ordinary task wrappers, which commit any
-            // preceding outer Graph before submitting. This must not make the
+            // An explicit commit reached from a Graph body must not make the
             // recorder wait for its own in-flight job.
             rt_graph_commit();
             std::unique_lock<std::mutex> lock(fake.mutex);
@@ -185,7 +273,6 @@ TEST(HbgGraphAsyncSubmit, WorkerRecordsWhileMainSubmitsLaterGraphs) {
     }
     rt_graph_commit();
 
-    const std::thread::id first_record_thread = fake.record_thread;
     {
         std::lock_guard<std::mutex> lock(fake.mutex);
         fake.begin_calls = 0;
@@ -223,13 +310,13 @@ TEST(HbgGraphAsyncSubmit, WorkerRecordsWhileMainSubmitsLaterGraphs) {
     EXPECT_EQ(body_calls, 2);
     EXPECT_EQ(fake.prepare_calls, 2);
     EXPECT_EQ(fake.prepare_overlaps, 2) << "main-thread Graph submission must not wait for worker graph_prepare";
+    EXPECT_EQ(fake.prepare_handle, &fake) << "the recording thread must bind through the handle graph_begin returned";
     EXPECT_EQ(fake.end_calls, 2);
     EXPECT_EQ(fake.commit_calls, 4);
     EXPECT_EQ(fake.scope_begin_calls, 4);
     EXPECT_EQ(fake.scope_end_calls, 4);
     EXPECT_TRUE(fake.overlapped);
     EXPECT_NE(fake.record_thread, caller);
-    EXPECT_EQ(fake.record_thread, first_record_thread) << "steady-state recording must reuse the worker thread";
     EXPECT_EQ(fake.prepare_thread, fake.record_thread);
     EXPECT_EQ(fake.submit_thread, fake.record_thread);
 }

--- a/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
@@ -95,7 +95,7 @@ TEST_F(HbgGraphSubmitFailureTest, InFlightGraphSubmissionsReserveHeapOnlyAtCommi
     EXPECT_EQ(orch.ring.task_allocator.heap_top(), 0u);
     EXPECT_EQ(graph_host_upload_count(*graph_state), 2u);
 
-    ASSERT_TRUE(orch.graph_prepare(boundary_args));
+    ASSERT_TRUE(orch.graph_prepare(first.recording_handle, boundary_args));
     CoreTaskArgs node_args;
     node_args.add_input(boundary);
     TensorCreateInfo recorded_output(shape, 1, DataType::UINT32);
@@ -175,7 +175,7 @@ TEST_F(HbgGraphSubmitFailureTest, WorkerRecordsWhileMainThreadSubmitsSameHashShe
         // anchors scalar sources into it and stores its address.
         GraphTaskArgs worker_args;
         worker_args.add_input(boundary);
-        prepare_ok = orch.graph_prepare(worker_args);
+        prepare_ok = orch.graph_prepare(first.recording_handle, worker_args);
         {
             std::lock_guard<std::mutex> lock(gate_mutex);
             prepared = true;
@@ -274,7 +274,7 @@ TEST_F(HbgGraphSubmitFailureTest, AbortedRecordingLatchesFatalAtCommit) {
     const GraphScopeResult graph = orch.graph_begin(0x1717, boundary_args, 0x1736);
     ASSERT_TRUE(graph.recording);
     ASSERT_TRUE(graph.task_id.is_valid());
-    ASSERT_TRUE(orch.graph_prepare(boundary_args));
+    ASSERT_TRUE(orch.graph_prepare(graph.recording_handle, boundary_args));
 
     CoreTaskArgs node_args;
     node_args.add_input(boundary);
@@ -282,7 +282,7 @@ TEST_F(HbgGraphSubmitFailureTest, AbortedRecordingLatchesFatalAtCommit) {
     node_args.add_output(recorded_output);
     ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
 
-    orch.graph_abort();
+    orch.graph_abort(graph.recording_handle);
     ASSERT_FALSE(orch.fatal) << "Abort alone must not latch; the shell is still finalizable in principle";
 
     orch.graph_commit();
@@ -302,7 +302,7 @@ TEST_F(HbgGraphSubmitFailureTest, RuntimeAllocationInsideTheBodyRecordsAKernelle
     orch.begin_scope();
     const GraphScopeResult graph = orch.graph_begin(0x1718, boundary_args, 0x1736);
     ASSERT_TRUE(graph.recording);
-    ASSERT_TRUE(orch.graph_prepare(boundary_args));
+    ASSERT_TRUE(orch.graph_prepare(graph.recording_handle, boundary_args));
 
     CoreTaskArgs alloc_args;
     TensorCreateInfo allocated(shape, 1, DataType::UINT32);
@@ -326,7 +326,7 @@ TEST_F(HbgGraphSubmitFailureTest, FaninFailureLatchesFatalWithoutPartialUpload) 
     boundary_args.add_input(boundary);
     const GraphScopeResult graph = orch.graph_begin(0x1715, boundary_args, 0x1736);
     ASSERT_TRUE(graph.recording);
-    ASSERT_TRUE(orch.graph_prepare(boundary_args));
+    ASSERT_TRUE(orch.graph_prepare(graph.recording_handle, boundary_args));
 
     CoreTaskArgs node_args;
     node_args.add_input(boundary);
@@ -368,7 +368,7 @@ TEST_F(HbgGraphSubmitFailureTest, CachedGraphUsesFinalTaskWindowSlot) {
     boundary_args.add_input(boundary);
     const GraphScopeResult graph = orch.graph_begin(0x1716, boundary_args, 0x1736);
     ASSERT_TRUE(graph.recording);
-    ASSERT_TRUE(orch.graph_prepare(boundary_args));
+    ASSERT_TRUE(orch.graph_prepare(graph.recording_handle, boundary_args));
 
     CoreTaskArgs node_args;
     node_args.add_input(boundary);
@@ -417,7 +417,7 @@ protected:
         orch.begin_scope();
         const GraphScopeResult graph = orch.graph_begin(graph_key, boundary_args, 0x1736);
         EXPECT_TRUE(graph.recording);
-        EXPECT_TRUE(orch.graph_prepare(boundary_args));
+        EXPECT_TRUE(orch.graph_prepare(graph.recording_handle, boundary_args));
 
         CoreTaskArgs node_args;
         node_args.add_input(boundary);
@@ -429,7 +429,7 @@ protected:
         EXPECT_TRUE(orch.submit_task(mixed, node_args).task_id().is_valid());
 
         EXPECT_THROW(orch.graph_end(), AssertionError) << "an unrecordable predicate must not publish";
-        orch.graph_abort();
+        orch.graph_abort(graph.recording_handle);
         orch.graph_commit();
         EXPECT_TRUE(orch.fatal) << "a shell whose Definition never arrived cannot be completed";
     }
@@ -479,7 +479,7 @@ TEST_F(HbgGraphPredicateRejectionTest, PredicateOnAKernellessNodeIsNotRecorded) 
     orch.begin_scope();
     const GraphScopeResult graph = orch.graph_begin(0x2003, boundary_args, 0x1736);
     ASSERT_TRUE(graph.recording);
-    ASSERT_TRUE(orch.graph_prepare(boundary_args));
+    ASSERT_TRUE(orch.graph_prepare(graph.recording_handle, boundary_args));
 
     CoreTaskArgs node_args;
     node_args.add_input(boundary);
@@ -493,4 +493,212 @@ TEST_F(HbgGraphPredicateRejectionTest, PredicateOnAKernellessNodeIsNotRecorded) 
     EXPECT_TRUE(orch.graph_end()) << "a dropped predicate must not make the body unrecordable";
     orch.graph_commit();
     EXPECT_FALSE(orch.fatal);
+}
+
+// Distinct Graph keys record concurrently. A Definition the run has not seen
+// before must open its own recording even while another is in flight — the
+// alternative is that it is turned away, replays nothing for the rest of the run,
+// and every occurrence of it submits its whole body as ordinary tasks.
+TEST_F(HbgGraphSubmitFailureTest, ASecondKeyRecordsAlongsideTheFirst) {
+    std::array<uint32_t, 16> storage_a{};
+    std::array<uint32_t, 16> storage_b{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage_a.size())};
+    ChipTensor boundary_a = make_tensor_external(storage_a.data(), shape, 1);
+    ChipTensor boundary_b = make_tensor_external(storage_b.data(), shape, 1);
+    GraphTaskArgs args_a;
+    args_a.add_input(boundary_a);
+    GraphTaskArgs args_b;
+    args_b.add_input(boundary_b);
+
+    orch.begin_scope();
+    const GraphScopeResult first = orch.graph_begin(0x1901, args_a, 0x1736);
+    ASSERT_TRUE(first.recording);
+    ASSERT_NE(first.recording_handle, nullptr);
+
+    const GraphScopeResult second = orch.graph_begin(0x1902, args_b, 0x1736);
+    EXPECT_TRUE(second.recording) << "a distinct key must not be demoted by a busy recorder";
+    EXPECT_FALSE(second.execute_block);
+    ASSERT_NE(second.recording_handle, nullptr);
+    EXPECT_NE(second.recording_handle, first.recording_handle);
+
+    // Record both from this thread; concurrency of the threads is the pool's
+    // concern, and interleaving the two recordings is what the runtime must
+    // tolerate. Each bind goes through its own handle.
+    TensorCreateInfo recorded_output(shape, 1, DataType::UINT32);
+
+    ASSERT_TRUE(orch.graph_prepare(first.recording_handle, args_a));
+    CoreTaskArgs node_a;
+    node_a.add_input(boundary_a);
+    node_a.add_output(recorded_output);
+    ASSERT_TRUE(orch.submit_dummy_task(node_a).task_id().is_valid());
+    ASSERT_TRUE(orch.graph_end());
+
+    ASSERT_TRUE(orch.graph_prepare(second.recording_handle, args_b));
+    CoreTaskArgs node_b;
+    node_b.add_input(boundary_b);
+    node_b.add_output(recorded_output);
+    ASSERT_TRUE(orch.submit_dummy_task(node_b).task_id().is_valid());
+    ASSERT_TRUE(orch.graph_end());
+
+    // One commit drains and back-patches both keys' deferred shells.
+    orch.graph_commit();
+    EXPECT_FALSE(orch.fatal);
+
+    const GraphScopeResult replay_a = orch.graph_begin(0x1901, args_a, 0x1736);
+    EXPECT_FALSE(replay_a.execute_block) << "the first key's Definition must be cached";
+    EXPECT_FALSE(replay_a.recording);
+    const GraphScopeResult replay_b = orch.graph_begin(0x1902, args_b, 0x1736);
+    EXPECT_FALSE(replay_b.execute_block) << "the second key's Definition must be cached";
+    EXPECT_FALSE(replay_b.recording);
+}
+
+// Recording completion order belongs to the worker pool; heap reservation order
+// belongs to the main-thread program. Finalizing one Definition at a time walks
+// an unordered key map and makes the heap layout depend on hash iteration, so
+// finish these four recordings in reverse and require commit to preserve the
+// original shell order.
+TEST_F(HbgGraphSubmitFailureTest, ConcurrentDefinitionsFinalizeInSubmissionOrder) {
+    constexpr size_t kGraphCount = 4;
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    ChipTensor boundary = make_tensor_external(storage.data(), shape, 1);
+    GraphTaskArgs args;
+    args.add_input(boundary);
+    TensorCreateInfo recorded_output(shape, 1, DataType::UINT32);
+
+    orch.begin_scope();
+    std::array<GraphScopeResult, kGraphCount> graphs;
+    for (size_t i = 0; i < kGraphCount; ++i) {
+        graphs[i] = orch.graph_begin(0x1910 + i, args, 0x1736);
+        ASSERT_TRUE(graphs[i].recording) << "Graph " << i;
+        ASSERT_TRUE(graphs[i].task_id.is_valid()) << "Graph " << i;
+    }
+
+    for (size_t i = kGraphCount; i-- > 0;) {
+        ASSERT_TRUE(orch.graph_prepare(graphs[i].recording_handle, args)) << "Graph " << i;
+        CoreTaskArgs node_args;
+        node_args.add_input(boundary);
+        node_args.add_output(recorded_output);
+        ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid()) << "Graph " << i;
+        ASSERT_TRUE(orch.graph_end()) << "Graph " << i;
+    }
+
+    orch.graph_commit();
+    ASSERT_FALSE(orch.fatal);
+    ASSERT_EQ(graph_host_upload_count(*graph_state), kGraphCount);
+
+    const char *previous_end = nullptr;
+    for (size_t i = 0; i < kGraphCount; ++i) {
+        const std::optional<GraphHostUpload> upload = graph_host_upload(*graph_state, i);
+        ASSERT_TRUE(upload.has_value()) << "Graph " << i;
+        const auto *submission = reinterpret_cast<const GraphSubmission *>(upload->data);
+        EXPECT_NE(submission->definition_hash, 0u) << "Graph " << i;
+        const auto *base = static_cast<const char *>(upload->outer_slot->task->packed_buffer_base);
+        const auto *end = static_cast<const char *>(upload->outer_slot->task->packed_buffer_end);
+        ASSERT_NE(base, nullptr) << "Graph " << i;
+        ASSERT_GT(end, base) << "Graph " << i;
+        if (previous_end != nullptr) {
+            EXPECT_LE(previous_end, base) << "Graph " << i << " was finalized ahead of an earlier shell";
+        }
+        previous_end = end;
+    }
+}
+
+// A published Definition is immutable, so replaying it needs nothing from an
+// unrelated recording. Gating the cache lookup on an idle recorder made an
+// already-built Graph wait for a Definition it has no relationship with.
+TEST_F(HbgGraphSubmitFailureTest, ACachedGraphReplaysWhileAnotherKeyRecords) {
+    std::array<uint32_t, 16> storage_a{};
+    std::array<uint32_t, 16> storage_b{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage_a.size())};
+    ChipTensor boundary_a = make_tensor_external(storage_a.data(), shape, 1);
+    ChipTensor boundary_b = make_tensor_external(storage_b.data(), shape, 1);
+    GraphTaskArgs args_a;
+    args_a.add_input(boundary_a);
+    GraphTaskArgs args_b;
+    args_b.add_input(boundary_b);
+    TensorCreateInfo recorded_output(shape, 1, DataType::UINT32);
+
+    orch.begin_scope();
+    const GraphScopeResult first = orch.graph_begin(0x1903, args_a, 0x1736);
+    ASSERT_TRUE(first.recording);
+    ASSERT_TRUE(orch.graph_prepare(first.recording_handle, args_a));
+    CoreTaskArgs node_a;
+    node_a.add_input(boundary_a);
+    node_a.add_output(recorded_output);
+    ASSERT_TRUE(orch.submit_dummy_task(node_a).task_id().is_valid());
+    ASSERT_TRUE(orch.graph_end());
+    orch.graph_commit();
+    ASSERT_FALSE(orch.fatal);
+
+    // Key B is now recording and stays that way for the rest of the test.
+    const GraphScopeResult second = orch.graph_begin(0x1904, args_b, 0x1736);
+    ASSERT_TRUE(second.recording);
+
+    const GraphScopeResult replay = orch.graph_begin(0x1903, args_a, 0x1736);
+    EXPECT_FALSE(replay.execute_block) << "a cache hit must not wait for an unrelated recording";
+    EXPECT_FALSE(replay.recording);
+    ASSERT_TRUE(replay.task_id.is_valid());
+    // A replay off the cache carries its own heap, unlike the zero-heap shells
+    // key B is still deferring.
+    EXPECT_GT(orch.ring.task_allocator.heap_top(), 0u);
+
+    ASSERT_TRUE(orch.graph_prepare(second.recording_handle, args_b));
+    CoreTaskArgs node_b;
+    node_b.add_input(boundary_b);
+    node_b.add_output(recorded_output);
+    ASSERT_TRUE(orch.submit_dummy_task(node_b).task_id().is_valid());
+    ASSERT_TRUE(orch.graph_end());
+    orch.graph_commit();
+    EXPECT_FALSE(orch.fatal);
+}
+
+// An ordinary task submitted while a recording is in flight takes its heap
+// immediately, so the shell's deferred block lands after it and heap-address order
+// stops matching task-id order. Nothing depends on that correspondence — each
+// reservation is an independent bump and HBG retires nothing during a run — which
+// is what lets an ordinary submission proceed without joining the recorders.
+TEST_F(HbgGraphSubmitFailureTest, AnOrdinaryAllocationInterleavesWithADeferredShell) {
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    ChipTensor boundary = make_tensor_external(storage.data(), shape, 1);
+    GraphTaskArgs boundary_args;
+    boundary_args.add_input(boundary);
+    TensorCreateInfo recorded_output(shape, 1, DataType::UINT32);
+
+    orch.begin_scope();
+    const GraphScopeResult graph = orch.graph_begin(0x1905, boundary_args, 0x1736);
+    ASSERT_TRUE(graph.recording);
+    EXPECT_EQ(orch.ring.task_allocator.heap_top(), 0u) << "the shell defers its heap";
+
+    // The ordinary task goes first, from the base of the heap.
+    CoreTaskArgs ordinary_args;
+    TensorCreateInfo ordinary_output(shape, 1, DataType::UINT32);
+    ordinary_args.add_output(ordinary_output);
+    const TaskOutputTensors ordinary = orch.alloc_tensors(ordinary_args);
+    ASSERT_TRUE(ordinary.task_id().is_valid());
+    const uint64_t heap_after_ordinary = orch.ring.task_allocator.heap_top();
+    EXPECT_GT(heap_after_ordinary, 0u);
+
+    // Only then does the recording finish and the shell claim its block.
+    ASSERT_TRUE(orch.graph_prepare(graph.recording_handle, boundary_args));
+    CoreTaskArgs node_args;
+    node_args.add_input(boundary);
+    node_args.add_output(recorded_output);
+    ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
+    ASSERT_TRUE(orch.graph_end());
+    orch.graph_commit();
+
+    EXPECT_FALSE(orch.fatal);
+    EXPECT_GT(orch.ring.task_allocator.heap_top(), heap_after_ordinary)
+        << "the shell's block sits above the ordinary task's, not before it";
+    PTO2SharedMemoryRingHeader &ring = sm_handle->header->ring;
+    const int32_t shell_slot = ring.get_slot_by_task_id(static_cast<int32_t>(graph.task_id.local()));
+    const PTO2TaskDescriptor *shell = ring.slot_states[shell_slot].task;
+    ASSERT_NE(shell, nullptr);
+    ASSERT_NE(shell->packed_buffer_base, nullptr);
+    EXPECT_GE(
+        reinterpret_cast<uintptr_t>(shell->packed_buffer_base),
+        reinterpret_cast<uintptr_t>(gm_heap.data()) + heap_after_ordinary
+    ) << "the two reservations must be disjoint";
 }

--- a/tests/ut/py/test_kernel_compiler.py
+++ b/tests/ut/py/test_kernel_compiler.py
@@ -35,20 +35,20 @@ def test_host_orchestration_matches_runtime_sanitizer_toolchain(monkeypatch, pla
 
 
 @pytest.mark.parametrize(
-    ("target_platform", "target_runtime", "expects_host_logger"),
+    ("target_platform", "target_runtime", "expects_host_logger", "expects_graph_recorder_prewarm"),
     [
-        ("a2a3sim", "host_build_graph", True),
-        ("a2a3sim", "tensormap_and_ringbuffer", True),
-        ("a2a3", "host_build_graph", True),
-        ("a2a3", "tensormap_and_ringbuffer", False),
-        ("a5sim", "host_build_graph", True),
-        ("a5sim", "tensormap_and_ringbuffer", True),
-        ("a5", "host_build_graph", True),
-        ("a5", "tensormap_and_ringbuffer", False),
+        ("a2a3sim", "host_build_graph", True, True),
+        ("a2a3sim", "tensormap_and_ringbuffer", True, False),
+        ("a2a3", "host_build_graph", True, True),
+        ("a2a3", "tensormap_and_ringbuffer", False, False),
+        ("a5sim", "host_build_graph", True, True),
+        ("a5sim", "tensormap_and_ringbuffer", True, False),
+        ("a5", "host_build_graph", True, True),
+        ("a5", "tensormap_and_ringbuffer", False, False),
     ],
 )
 def test_host_orchestration_is_a_self_contained_log_consumer(
-    monkeypatch, target_platform, target_runtime, expects_host_logger
+    monkeypatch, target_platform, target_runtime, expects_host_logger, expects_graph_recorder_prewarm
 ):
     from simpler_setup import kernel_compiler, toolchain  # noqa: PLC0415
 
@@ -75,6 +75,8 @@ def test_host_orchestration_is_a_self_contained_log_consumer(
         assert "host_log.cpp" not in source_names
         assert "unified_log_host.cpp" not in source_names
         assert "-pthread" not in compiler._orchestration_link_flags(compiler._orchestration_toolchain(target_runtime))
+
+    assert ("graph_recorder_prewarm.cpp" in source_names) is expects_graph_recorder_prewarm
 
 
 def test_direct_compiler_command_uses_checkout_relative_paths(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Builds on #1916 by @ChaoWao and combines its flexible per-Graph concurrency model with the low-overhead prewarmed recording path developed in #1897:

- keep the Definition cache lookup ahead of in-flight state, key all in-flight recordings by Graph identity, and pass a stable `recording_handle` into `graph_prepare`;
- allow distinct Graph identities to record concurrently while Graph shells and ordinary outer tasks continue to submit, with the only global recording barrier at orchestration completion;
- prewarm four recorder threads when the host orchestration SO loads, outside `host_orch`, while retaining growth up to the 16-Definition cache limit;
- replace per-miss `shared_ptr`/`deque` allocation with 16 reusable owned-argument snapshots and a fixed 16-slot job ring;
- finalize deferred Graph shells once, in main-thread submission order rather than unordered Definition-map order.

The result keeps #1916's flexibility beyond four concurrent Graph identities, while removing thread creation and job-allocation work from the common four-Graph miss path.

## Why

The old single recorder serialized distinct Graph misses. A later workaround could retry after a commit, but that still waited for the occupied recorder and also let the final `graph_submit` inherit an unrelated recording barrier.

With this change, the hash-keyed zero-heap shell is submitted immediately. Its body records on the worker associated with that identity, and later shells or ordinary tasks continue on the main submission thread. Only final Definition publication and shell heap materialization are deferred to the completion barrier.

## DSV4 four-Graph validation

The four-Definition DeepSeek-V4 fixture is used only for validation and is not part of this runtime PR.

A host-phase swimlane captured on two chip ranks shows, per rank:

- one `graph submit main` lane and four distinct `graph record worker` lanes;
- 742 `record_node` events and four `build_definition` events distributed across all four workers;
- 60 / 40 `graph_submit` events landing inside the recording window on the two ranks;
- the recording tail only 2.96 us after / 1.68 us before the last overlapping submission, with no long final-submit bubble.

Every pass submitted 835 host tasks, so no Graph identity was silently demoted.

## Performance

Same host and device pair, pure #1916 versus this integrated version, two opposite-order passes. Each pass ran four invocations on two ranks; invocation 1 of each rank was excluded, leaving 12 steady samples per version. The comparison was recorded on main `72a5fa7e`; this branch is rebased to current main `aac09a61`.

| phase | #1916 median | integrated median | change |
| --- | ---: | ---: | ---: |
| `host_orch` | 2.443 ms | 2.126 ms | **-13.0%** |
| `graph_submit` total | 0.358 ms | 0.273 ms | **-23.8%** |
| `graph_upload` | 1.235 ms | 1.208 ms | -2.2% |
| `arena_h2d` | 0.053 ms | 0.062 ms | +0.009 ms |
| `sm_h2d` | 0.556 ms | 0.642 ms | +0.086 ms |

The H2D values reversed by rank/pass and are outside the recording implementation; the stable gain is in `host_orch` and its `graph_submit` share.

## Testing

- [x] pre-commit on all changed files (clang-format, clang-tidy, cpplint, pyright, markdown, and repository checks)
- [x] `ctest -LE requires_hardware`: 107/107 passed
- [x] `tests/ut/py/test_kernel_compiler.py`: 19 passed
- [x] a2a3sim host-build-graph Graph execution: 2 passed
- [x] a5sim host-build-graph Graph execution: 2 passed
- [x] DeepSeek-V4 four-Graph host prepare, two ranks, four rounds per version: passed
- [x] DeepSeek-V4 four-Graph host-phase diagnostic capture: passed
