### PR TITLE
host_build_graph: drop the TensorCreateInfo initial-value fill

### DIFF
--- a/src/a2a3/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a2a3/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
@@ -50,6 +50,22 @@ Runtime-created output buffers also live in the graph heap and have no host-view
 registration. Even if their address is nonzero, host orchestration must not
 dereference or modify them.
 
+## No Initial-Value Fill on a Runtime Allocation
+
+`TensorCreateInfo` carries no `set_initial_value` here, unlike its
+`tensormap_and_ringbuffer` counterpart. The fill stores to
+`ChipTensor::buffer.addr` — a GM-heap device address — which the AICPU
+orchestrator can write and the host orchestrator this runtime uses cannot. The
+method is absent rather than failing at run time, so an orchestration that asks
+for it does not compile against this runtime instead of faulting on device.
+
+To give a runtime allocation a defined starting content — a fixed-size tile
+whose producer writes only a prefix, so its consumer reads a known value in the
+remainder — have a task write it. Doing it on device also keeps the buffer
+correct under Graph Execution, where a value written once while recording would
+reach none of the replays: each submission materializes its outputs at addresses
+it derives for itself, from a heap block whose prior contents it never reads.
+
 ## Ownership Validation
 
 Before a wait slot is used, the runtime verifies:

--- a/src/a2a3/runtime/host_build_graph/runtime/tensor_create_info.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/tensor_create_info.h
@@ -14,9 +14,15 @@
  * Runtime-only: this header (and the materialization helpers below) are NOT
  * part of the wire/host-facing ChipTensor in src/common/task_interface/tensor.h.
  * It carries the metadata required to materialize a fresh contiguous output:
- * dtype, ndims, shapes, manual_dep, and an optional initial value fill. Its
- * 64B layout mirrors ChipTensor cache line 1 so init_tensor_from_create_info() can
- * copy the whole line with a single memcpy.
+ * dtype, ndims, shapes, manual_dep. Its 64B layout mirrors ChipTensor cache
+ * line 1 so init_tensor_from_create_info() can copy the whole line with a
+ * single memcpy.
+ *
+ * There is no initial-value fill here, unlike the tensormap_and_ringbuffer
+ * copy of this header. That fill stores to ChipTensor::buffer.addr, which is a
+ * GM-heap device address: the AICPU orchestrator can write it, the host
+ * orchestrator this runtime uses cannot. An orchestration that needs a defined
+ * starting content has a task write it. See docs/SCALAR_DATA_ACCESS.md.
  */
 
 #pragma once
@@ -33,8 +39,7 @@ public:
     TensorCreateInfo(
         const uint32_t shapes_in[], uint32_t ndims_in, DataType dtype_in = DataType::FLOAT32, bool manual_dep_in = false
     ) :
-        initial_value(0),
-        has_initial_value(false),
+        __pad0__{0, 0},
         __pad2__(0),
         start_offset(0),  // mirrors ChipTensor::start_offset; pre-zeroed for create-info outputs
         version(0),
@@ -54,12 +59,6 @@ public:
 
     void copy(const TensorCreateInfo &other) { memcpy(this, &other, sizeof(other)); }
 
-    template <typename T = uint64_t>
-    void set_initial_value(T value) {
-        has_initial_value = true;
-        initial_value = to_u64(value);
-    }
-
     uint64_t buffer_size_bytes() const {
         uint64_t total = 1;
         for (uint32_t i = 0; i < ndims; i++) {
@@ -73,9 +72,7 @@ public:
     // These occupy the same positions as ChipTensor::buffer, ChipTensor::owner_task_id,
     // and ChipTensor::start_offset. The runtime overwrites owner metadata after the
     // memcpy and recomputes start_offset / stride during payload materialization.
-    uint64_t initial_value;
-    bool has_initial_value;
-    uint8_t __pad1__[7];
+    uint64_t __pad0__[2];   // → ChipTensor::buffer (overwritten post-memcpy)
     uint64_t __pad2__;      // → ChipTensor::owner_task_id (overwritten post-memcpy)
     uint64_t start_offset;  // mirrors ChipTensor::start_offset; always 0 for create-info outputs
 
@@ -93,6 +90,7 @@ public:
 
 // TensorCreateInfo layout must match ChipTensor cacheline 1 for memcpy optimization
 static_assert(sizeof(TensorCreateInfo) == 64, "TensorCreateInfo must match ChipTensor cacheline 1 size (64 bytes)");
+static_assert(offsetof(TensorCreateInfo, __pad0__) == offsetof(ChipTensor, buffer));
 static_assert(offsetof(TensorCreateInfo, start_offset) == offsetof(ChipTensor, start_offset));
 static_assert(offsetof(TensorCreateInfo, version) == offsetof(ChipTensor, version));
 static_assert(offsetof(TensorCreateInfo, ndims) == offsetof(ChipTensor, ndims));
@@ -107,24 +105,6 @@ static_assert(offsetof(TensorCreateInfo, shapes) == offsetof(ChipTensor, shapes)
 // Factored out of ChipTensor (which now lives in the wire/host-facing common
 // header) so the create-info dependency stays runtime-only.
 // ============================================================================
-
-/// Fill the entire backing buffer of `t` with `initial_value` (doubling memcpy).
-inline void fill_tensor_initial_value(ChipTensor &t, uint64_t initial_value) {
-    always_assert(reinterpret_cast<char *>(t.buffer.addr) != nullptr);
-    uint64_t elem_size = get_element_size(t.dtype);
-    char *dst = reinterpret_cast<char *>(t.buffer.addr);
-    constexpr uint64_t blk_size = 64;
-    uint64_t blk = (t.buffer.size < blk_size) ? t.buffer.size : blk_size;
-    for (uint64_t b = 0; b < blk; b += elem_size) {
-        memcpy(dst + b, &initial_value, elem_size);
-    }
-    uint64_t filled = blk;
-    while (filled < t.buffer.size) {
-        uint64_t copy_size = ((t.buffer.size - filled) < filled) ? (t.buffer.size - filled) : filled;
-        memcpy(dst + filled, dst, copy_size);
-        filled += copy_size;
-    }
-}
 
 /// Materialize a TensorCreateInfo into `t` (fresh contiguous output).
 /// Single 64B memcpy covers cache line 1; `ci` pre-initialises start_offset (=0)
@@ -141,7 +121,4 @@ inline void init_tensor_from_create_info(ChipTensor &t, const TensorCreateInfo &
         s *= t.shapes[i];
     }
     t.extent_elem_cache = s;
-    if (ci.has_initial_value) {
-        fill_tensor_initial_value(t, ci.initial_value);
-    }
 }

--- a/src/a5/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a5/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
@@ -50,6 +50,22 @@ Runtime-created output buffers also live in the graph heap and have no host-view
 registration. Even if their address is nonzero, host orchestration must not
 dereference or modify them.
 
+## No Initial-Value Fill on a Runtime Allocation
+
+`TensorCreateInfo` carries no `set_initial_value` here, unlike its
+`tensormap_and_ringbuffer` counterpart. The fill stores to
+`ChipTensor::buffer.addr` — a GM-heap device address — which the AICPU
+orchestrator can write and the host orchestrator this runtime uses cannot. The
+method is absent rather than failing at run time, so an orchestration that asks
+for it does not compile against this runtime instead of faulting on device.
+
+To give a runtime allocation a defined starting content — a fixed-size tile
+whose producer writes only a prefix, so its consumer reads a known value in the
+remainder — have a task write it. Doing it on device also keeps the buffer
+correct under Graph Execution, where a value written once while recording would
+reach none of the replays: each submission materializes its outputs at addresses
+it derives for itself, from a heap block whose prior contents it never reads.
+
 ## Ownership Validation
 
 Before a wait slot is used, the runtime verifies:

--- a/src/a5/runtime/host_build_graph/runtime/tensor_create_info.h
+++ b/src/a5/runtime/host_build_graph/runtime/tensor_create_info.h
@@ -14,9 +14,15 @@
  * Runtime-only: this header (and the materialization helpers below) are NOT
  * part of the wire/host-facing ChipTensor in src/common/task_interface/tensor.h.
  * It carries the metadata required to materialize a fresh contiguous output:
- * dtype, ndims, shapes, manual_dep, and an optional initial value fill. Its
- * 64B layout mirrors ChipTensor cache line 1 so init_tensor_from_create_info() can
- * copy the whole line with a single memcpy.
+ * dtype, ndims, shapes, manual_dep. Its 64B layout mirrors ChipTensor cache
+ * line 1 so init_tensor_from_create_info() can copy the whole line with a
+ * single memcpy.
+ *
+ * There is no initial-value fill here, unlike the tensormap_and_ringbuffer
+ * copy of this header. That fill stores to ChipTensor::buffer.addr, which is a
+ * GM-heap device address: the AICPU orchestrator can write it, the host
+ * orchestrator this runtime uses cannot. An orchestration that needs a defined
+ * starting content has a task write it. See docs/SCALAR_DATA_ACCESS.md.
  */
 
 #pragma once
@@ -33,8 +39,7 @@ public:
     TensorCreateInfo(
         const uint32_t shapes_in[], uint32_t ndims_in, DataType dtype_in = DataType::FLOAT32, bool manual_dep_in = false
     ) :
-        initial_value(0),
-        has_initial_value(false),
+        __pad0__{0, 0},
         __pad2__(0),
         start_offset(0),  // mirrors ChipTensor::start_offset; pre-zeroed for create-info outputs
         version(0),
@@ -54,12 +59,6 @@ public:
 
     void copy(const TensorCreateInfo &other) { memcpy(this, &other, sizeof(other)); }
 
-    template <typename T = uint64_t>
-    void set_initial_value(T value) {
-        has_initial_value = true;
-        initial_value = to_u64(value);
-    }
-
     uint64_t buffer_size_bytes() const {
         uint64_t total = 1;
         for (uint32_t i = 0; i < ndims; i++) {
@@ -73,9 +72,7 @@ public:
     // These occupy the same positions as ChipTensor::buffer, ChipTensor::owner_task_id,
     // and ChipTensor::start_offset. The runtime overwrites owner metadata after the
     // memcpy and recomputes start_offset / stride during payload materialization.
-    uint64_t initial_value;
-    bool has_initial_value;
-    uint8_t __pad1__[7];
+    uint64_t __pad0__[2];   // → ChipTensor::buffer (overwritten post-memcpy)
     uint64_t __pad2__;      // → ChipTensor::owner_task_id (overwritten post-memcpy)
     uint64_t start_offset;  // mirrors ChipTensor::start_offset; always 0 for create-info outputs
 
@@ -93,6 +90,7 @@ public:
 
 // TensorCreateInfo layout must match ChipTensor cacheline 1 for memcpy optimization
 static_assert(sizeof(TensorCreateInfo) == 64, "TensorCreateInfo must match ChipTensor cacheline 1 size (64 bytes)");
+static_assert(offsetof(TensorCreateInfo, __pad0__) == offsetof(ChipTensor, buffer));
 static_assert(offsetof(TensorCreateInfo, start_offset) == offsetof(ChipTensor, start_offset));
 static_assert(offsetof(TensorCreateInfo, version) == offsetof(ChipTensor, version));
 static_assert(offsetof(TensorCreateInfo, ndims) == offsetof(ChipTensor, ndims));
@@ -107,24 +105,6 @@ static_assert(offsetof(TensorCreateInfo, shapes) == offsetof(ChipTensor, shapes)
 // Factored out of ChipTensor (which now lives in the wire/host-facing common
 // header) so the create-info dependency stays runtime-only.
 // ============================================================================
-
-/// Fill the entire backing buffer of `t` with `initial_value` (doubling memcpy).
-inline void fill_tensor_initial_value(ChipTensor &t, uint64_t initial_value) {
-    always_assert(reinterpret_cast<char *>(t.buffer.addr) != nullptr);
-    uint64_t elem_size = get_element_size(t.dtype);
-    char *dst = reinterpret_cast<char *>(t.buffer.addr);
-    constexpr uint64_t blk_size = 64;
-    uint64_t blk = (t.buffer.size < blk_size) ? t.buffer.size : blk_size;
-    for (uint64_t b = 0; b < blk; b += elem_size) {
-        memcpy(dst + b, &initial_value, elem_size);
-    }
-    uint64_t filled = blk;
-    while (filled < t.buffer.size) {
-        uint64_t copy_size = ((t.buffer.size - filled) < filled) ? (t.buffer.size - filled) : filled;
-        memcpy(dst + filled, dst, copy_size);
-        filled += copy_size;
-    }
-}
 
 /// Materialize a TensorCreateInfo into `t` (fresh contiguous output).
 /// Single 64B memcpy covers cache line 1; `ci` pre-initialises start_offset (=0)
@@ -141,7 +121,4 @@ inline void init_tensor_from_create_info(ChipTensor &t, const TensorCreateInfo &
         s *= t.shapes[i];
     }
     t.extent_elem_cache = s;
-    if (ci.has_initial_value) {
-        fill_tensor_initial_value(t, ci.initial_value);
-    }
 }

--- a/src/common/task_interface/tensor.h
+++ b/src/common/task_interface/tensor.h
@@ -243,10 +243,12 @@ struct alignas(64) ChipTensor {
     void copy(const ChipTensor &other) { init_from(other); }
 
     // Materialization from a TensorCreateInfo (runtime-allocated outputs) lives
-    // in the runtime tensor_create_info.h as the free functions
-    // init_tensor_from_create_info() / fill_tensor_initial_value(); they operate
-    // on a ChipTensor& through its public members. Kept out of the wire/host-facing
-    // ChipTensor so this header has no dependency on the runtime-only create-info.
+    // in the runtime tensor_create_info.h as init_tensor_from_create_info(), which
+    // operates on a ChipTensor& through its public members. Kept out of the
+    // wire/host-facing ChipTensor so this header has no dependency on the
+    // runtime-only create-info. tensormap_and_ringbuffer additionally has
+    // fill_tensor_initial_value(); host_build_graph does not, because that store
+    // goes to a device address its host orchestrator cannot reach.
 
     // ========================================================================
     // Address / offset computation


### PR DESCRIPTION
## What this does

`TensorCreateInfo::set_initial_value` segfaults the orchestrator on every
`host_build_graph` path. `fill_tensor_initial_value` memcpy's straight to
`ChipTensor::buffer.addr` — a GM-heap **device** address the orchestrating host
cannot load. The file is a verbatim copy of the `tensormap_and_ringbuffer` one,
where the orchestrator runs on the AICPU and that store is correct; the copy
kept the store and lost its premise.

This removes it from `host_build_graph` only.

## Why remove rather than support

- **Nothing left to serve.** #1922 moved the DeepSeek-V4 case — the only caller
  that needed it here — to device-side initialization. The sole remaining caller
  in the tree is the `tensormap_and_ringbuffer` `scalar_data` example, which
  demonstrates the API itself.
- **Supporting it would stop short of the case it was for.** An initial value
  cannot survive Graph Execution: each submission materializes its outputs at
  addresses it derives for itself, from a heap block whose prior contents it
  never reads, so a value written once while recording reaches none of the
  replays. The dsv4 Graph orchestration on `main` could never have used it.

## What is *not* touched

**`tensormap_and_ringbuffer` keeps the fill.** Its orchestrator runs on the
AICPU, which addresses the GM heap directly, so the feature works there. The two
runtimes hold separate copies of this header, so the removal is theirs alone —
`scalar_data` and its golden are untouched.

## Compile-time, not run-time

Dropping the method means an orchestration that asks for it **does not compile**
against `host_build_graph`, rather than building and faulting on device.

## The layout is the delicate part

The two fields occupied bytes `[0, 16)`, aligned with `ChipTensor::buffer` so
`init_tensor_from_create_info` covers cache line 1 in one 64-byte memcpy, and
`start_offset` has to stay at byte 24 for the `offsetof` assertions that follow.
Explicit padding holds the layout, and a new assertion pins its intent:

```cpp
static_assert(offsetof(TensorCreateInfo, __pad0__) == offsetof(ChipTensor, buffer));
```

so the span is verified rather than described — the existing assertions all
started at `start_offset` and left `[0, 16)` uncovered. Those bytes were already
dead: the memcpy is followed immediately by `t.buffer = {addr, buffer_size}`.

## Verification

- **a2a3 hardware** — the `tensormap_and_ringbuffer` `scalar_data` example
  passes. That is the one place in the tree that still sets an initial value,
  and the only regression surface for `src/common/task_interface/tensor.h`,
  the shared header this change touches. Also `tests/st/a2a3/host_build_graph`
  (34 passed, 1 skipped).
- **a2a3sim** — 26 + 10 + 1 passed (L3 excluded; the device pool here has one
  card and that group needs two, unrelated to this change).
- **a5sim** — 25 passed.
- **C++ unit tests** — 107/107, which is where the layout assertions are checked.
