### PR TITLE
host_build_graph: upload the bind image once, and only the bytes the device reads

### DIFF
--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -802,9 +802,8 @@ int DeviceRunner::finalize() {
     release_callable_state();
 
     unload_executor_binaries();
-    release_graph_definition_buffers();
 
-    // Release the three per-Worker pooled arenas. Must precede mem_alloc_.finalize()
+    // Release the arena-bank regions. Must precede mem_alloc_.finalize()
     // so the arenas free through the still-live allocator, not after it.
     for (auto &bank : arena_banks_) {
         bank->gm_heap.release();

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -229,9 +229,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
     // Boot: the last AICPU thread (aicpu_thread_num_ - 1) performs the one-time
     // host-orch attach. host_build_graph's orchestrator already ran on the host,
-    // which also relocated every cross-task pointer to its final device address
-    // before H2D — so the SM/arena this thread sees are already fully
-    // device-addressed. This thread attaches the prebuilt arena, points the SM
+    // and every cross-task reference it wrote is an offset from its own block, so
+    // the SM/arena this thread sees need no address fixup. This thread attaches
+    // the prebuilt arena, points the SM
     // handle's ring-header pointers at the device SM WITHOUT resetting the
     // host-populated data, hands the host-computed task count to the scheduler,
     // and releases the other threads. It then falls through and schedules its own
@@ -264,14 +264,24 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             runtime_wire_arena_pointers(runtime_arena_, rt->prebuilt_layout, rt);
 
             void *sm_ptr = runtime->get_gm_sm_ptr();
-            uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(rt->prebuilt_layout.task_window_sizes);
+            // The image the host shipped is pitched to the submitted task count,
+            // not to the ring capacity, and the device region holds exactly that
+            // image — so its size comes from the same pitch. attach_populated
+            // rejects a pitch outside (0, capacity] and a region too small for it.
+            const uint64_t live_slots =
+                pto2_sm_layout::live_slot_pitch(static_cast<uint64_t>(runtime->host_total_tasks));
+            const uint64_t payload_bytes = runtime->sm_payload_bytes;
+            const uint64_t sm_size =
+                pto2_sm_layout::ring_segment_offsets_with_payload_bytes(live_slots, payload_bytes).end;
             // sm_handle and the scheduler state are the device-only zone: their
             // bytes never travel, so they start as whatever the pooled arena last
             // held. Zeroing the handle first is what makes attach_populated's
             // assignment of every field checkable here rather than by inspecting
             // attach_populated.
             memset(rt->sm_handle, 0, sizeof(*rt->sm_handle));
-            if (!rt->sm_handle->attach_populated(sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes)) {
+            if (!rt->sm_handle->attach_populated(
+                    sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes, live_slots, payload_bytes
+                )) {
                 LOG_ERROR("Thread %d: host-orch: sm_handle->attach_populated failed", thread_idx);
                 rt = nullptr;
                 run_rc = -1;
@@ -306,8 +316,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // to keep them alive).
             // NOTE: do NOT call rt_orchestration_done(rt) here. The HOST already
             // called it in run_host_orchestration; the orchestrator's own
-            // task-allocator pointers are intentionally NOT relocated, so they
-            // still hold host addresses and mark_done() would fault the AICPU.
+            // task-allocator pointers name host memory the device never reads, so
+            // mark_done() would fault the AICPU.
             sched_ctx_.on_orchestration_done(runtime, rt, thread_idx, runtime->host_total_tasks);
             LOG_INFO("Thread %d: host-orch boot complete (%d tasks)", thread_idx, runtime->host_total_tasks);
         }

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -9,7 +9,7 @@ host register: materialize + dlopen orchestration SO
         ↓
 host run/bind: stage external tensors, execute orchestration to completion
         ↓
-host: relocate the prebuilt graph image and copy it to device memory
+host: copy the prebuilt graph image to device memory
         ↓
 device: attach the image, classify tasks, dispatch with AICPU schedulers
         ↓
@@ -49,9 +49,8 @@ For each run, the host:
 2. reserves one backing arena for runtime/shared-memory subregions;
 3. binds the runtime to the orchestration DSO;
 4. calls the orchestration entry synchronously;
-5. finalizes task counts and the graph image;
-6. rewrites per-slot task/payload pointers to device addresses; and
-7. copies the shared-memory image and arena to the device.
+5. finalizes task counts and the graph image; and
+6. copies the shared-memory image and the arena's copied zone to the device.
 
 An orchestration fatal stops this sequence and is propagated through
 `orch_error_code`.
@@ -78,8 +77,9 @@ The shared image uses three per-slot structures:
 | `PTO2TaskSlotState` | Active mask, attributes, block/subtask counters, completion state, task/payload bindings |
 
 The host/device boundary is POD and position-independent. Fanins are integer
-producer IDs, not pointers. The only per-slot pointers are rebound to their final
-device addresses before H2D.
+producer IDs, not pointers, and a slot state names its payload and descriptor by a
+delta from its own address — so the image needs no fixup on either side of the
+copy.
 
 ### 3.1 What Ships: the Arena's Three Zones
 
@@ -97,16 +97,25 @@ Three rules decide every byte of the runtime arena:
 They partition the arena into three contiguous zones, and `runtime_reserve_layout`
 reserves them in this order:
 
-| Zone | Regions | Copied | Written by |
-| ---- | ------- | ------ | ---------- |
-| host-only | orchestrator block: `fanin_seen_epoch` / `scope_tasks` / TensorMap, ~8.5 MB | never | host, during graph construction |
-| copied | `[off_copied_begin, off_copied_end)`: the runtime header | whole zone, one copy | host |
-| device-only | `sm_handle`, `PTO2SchedulerState` and its thirteen queue slot arrays, the completion mailbox | never | AICPU at boot |
+| Zone | Regions | Copied | Allocated on device | Written by |
+| ---- | ------- | ------ | ------------------- | ---------- |
+| device-only | `sm_handle`, the completion mailbox, `PTO2SchedulerState` and its thirteen queue slot arrays | never | yes | AICPU at boot |
+| copied | `[off_copied_begin, off_copied_end)`: the runtime header | whole zone, one copy | yes | host |
+| host-only | orchestrator block: `fanin_seen_epoch` / `scope_tasks` / TensorMap, ~9.3 MB | never | **no** | host, during graph construction |
 
-Putting the copied zone **between** the two zones that are never copied is what
-makes `bind` a single contiguous `copy_to_device`. Both bounds are layout fields,
-so no consumer infers a boundary from which region happens to be reserved first —
-`bind_callable_to_runtime_impl` asserts only that they are ordered and in range.
+The copied zone is the fixed device prefix's final zone. After orchestration, its
+end is followed by the compact shared-memory image and then the Graph Definitions
+and submissions. `bind` stages those three run-generated regions contiguously and
+uses one `copy_to_device` starting at `off_copied_begin`.
+
+**Why the host-only zone comes last.** No device code dereferences a pointer into
+the orchestrator block — hbg has no device-side orchestrator, and the one
+orchestrator field the scheduler reads, `inline_completed_tasks`, is a scalar in
+the runtime header. Putting the block at the tail lets `setup_static_arena` request
+only `layout.device_bytes`, the copied + device-only prefix, so those ~9.3 MB are
+never reserved on the device at all. `runtime_wire_host_only_pointers` is therefore
+host-only, and `runtime_clear_host_only_pointers` drops those pointers before the
+copied zone is uploaded so no host address crosses the boundary.
 
 **Why the scheduler state is device-written.** `PTO2SchedulerState` holds no
 per-run content: `sm_header` and the ring pointer derive from a pooled SM base,
@@ -163,11 +172,24 @@ writes `[0, total_tasks)`, and the device boots scheduler-only and reads no SM s
 past `total_tasks`. So the SM H2D shipped each run is bounded, not capacity-sized —
 the contract that keeps `bind` proportional to the workload.
 
-The header is zeroed on the host; `descriptors`, `payloads`, `slot_states` and
-`completion_flags` are each written per task at submit and H2D-uploaded bounded to
-`[0, total_tasks)`. Per-slot reset is init-on-write in `orch::prepare_task` as each
-slot is claimed — there is no window-wide reset. The four segments travel as four
-copies rather than one because ring-sized tails separate their live prefixes.
+The header is zeroed on the host; `descriptors`, `slot_states` and
+`completion_flags` are each written per task at submit. Payloads come from one
+`TaskPayloadSpace`: every slot stores a self-relative reference to its record, so
+Graph tasks can carry more tensors or scalars than an ordinary fixed payload.
+Per-slot reset is init-on-write in `orch::prepare_task` as each slot is claimed —
+there is no window-wide reset.
+
+At the end of orchestration, compaction restacks the descriptor prefix, the exact
+live TaskPayloadSpace byte range, the slot-state prefix, and the completion flags.
+It preserves each slot's payload offset while rebinding its relative references.
+That compact SM image follows the copied runtime header and precedes the Graph
+block in one staging buffer, so all host-generated runtime data travels in one
+H2D copy.
+
+The heap is committed first because host construction needs its device addresses.
+The runtime arena is not committed until the compact SM and Graph block sizes are
+known; the arena bank then allocates it once or reuses a prior allocation whose
+capacity is sufficient.
 
 ## 4. Whole-Graph Capacity
 

--- a/src/a2a3/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a2a3/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
@@ -38,7 +38,7 @@ The execution order is:
 
 1. The host loads and calls the orchestration shared object.
 2. Orchestration builds the entire task graph and returns.
-3. The host relocates and copies the graph image to device memory.
+3. The host copies the graph image to device memory.
 4. AICPU schedulers boot and dispatch the graph.
 
 A producer submitted in step 1 cannot become `COMPLETED` until step 4. Waiting

--- a/src/a2a3/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a2a3/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
@@ -33,8 +33,9 @@ The shared graph image separates stable task identity from scheduling state:
 - `PTO2TaskSlotState` contains the active mask, task attributes, logical block
   count, subtask counters, completion state, and descriptor/payload bindings.
 
-This image is built on the host, relocated once, and copied to the device. It
-contains no fanout adjacency or dependency-pool pointers.
+This image is built on the host and copied to the device verbatim. It contains
+no fanout adjacency or dependency-pool pointers, and its descriptor/payload
+bindings are deltas from the slot state's own address rather than pointers.
 
 ## Resource Shapes
 

--- a/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
@@ -240,12 +240,12 @@ appear.
 
 ### What is recorded
 
-Seventeen kinds, all on the host monotonic clock the `[STRACE]` host spans use,
+Sixteen kinds, all on the host monotonic clock the `[STRACE]` host spans use,
 so records and spans read against each other with no alignment step.
 
 | Group | Kinds |
 | ----- | ----- |
-| Bind segments (partition the stage) | `args`, `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init`, `host_orch`, `graph_upload`, `relocate`, `sm_h2d`, `arena_h2d`, `host_view_close` |
+| Bind segments (partition the stage) | `args`, `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init`, `host_orch`, `graph_upload`, `arena_h2d`, `host_view_close` |
 | Orchestrator operations (inside `host_orch`) | `submit_task`, `alloc_tensors`, `record_node`, `graph_submit`, `build_definition` |
 
 Three of the orchestrator kinds end with a task submitted — `submit_task`,
@@ -312,7 +312,7 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
   | Key | Kinds | Rendered as |
   | --- | ----- | ----------- |
   | `host_orchestrator_phases` | the task-submitting kinds | `Host Orchestrator` process |
-  | `host_device_uploads` | `graph_upload`, `sm_h2d`, `arena_h2d`, with byte counts | `Host Prepare` / `H2D` lane |
+  | `host_device_uploads` | `arena_h2d`, with the complete runtime-image byte count | `Host Prepare` / `H2D` lane |
 
   The upload lane is the one place the whole question — orchestration plus H2D
   inside a millisecond — is visible against the device execution it precedes; the

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -79,13 +79,16 @@
 extern "C" const PipelineContract *get_pipeline_contract(void) {
     // Host orchestration materializes this run's own graph into the image it
     // uploads, so every device-resident region carries per-run content.
+    //
+    // PTO_PIPELINE_GM_SM is absent because hbg has no separate shared-memory
+    // region: the image is the tail of the runtime-image region, so it shares that
+    // region's classification. The arena-topology check skips an absent kind.
     static const PipelineContract contract = {
         PTO_PIPELINE_CONTRACT_ABI_VERSION,
-        5,
+        4,
         2,
         {
             {PTO_PIPELINE_GM_HEAP, PTO_PIPELINE_HOST_PER_RUN, 0},
-            {PTO_PIPELINE_GM_SM, PTO_PIPELINE_HOST_PER_RUN, 0},
             {PTO_PIPELINE_RUNTIME_IMAGE, PTO_PIPELINE_HOST_PER_RUN, 0},
             {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
             {PTO_PIPELINE_AICORE_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
@@ -288,6 +291,18 @@ static bool resolve_ring_config(
             LOG_ERROR("ring_heap[%d]=%" PRIu64 " must be >= 1024", r, eff_heap_sizes[r]);
             return false;
         }
+        // A slot state reaches its payload and descriptor through a 32-bit
+        // self-relative delta, so every pair of addresses in the shared-memory
+        // image must be within INT32_MAX of each other.
+        const uint64_t sm_bytes = pto2_sm_layout::ring_segment_offsets(eff_task_window_sizes[r]).end;
+        if (sm_bytes > static_cast<uint64_t>(INT32_MAX)) {
+            LOG_ERROR(
+                "ring_task_window[%d]=%" PRIu64 " needs a %" PRIu64 "-byte shared memory image, past the %d-byte limit "
+                "a slot state's self-relative payload/descriptor delta can span",
+                r, eff_task_window_sizes[r], sm_bytes, INT32_MAX
+            );
+            return false;
+        }
     }
 
     return true;
@@ -317,9 +332,10 @@ static int32_t pto2_read_runtime_status(Runtime *runtime, const HostApi *api, PT
 namespace {
 
 // host_build_graph is host-orchestration-first: the HOST dlopens the
-// orchestration .so and runs it to completion. The shared memory + arena carry
-// host-DDR cross-task pointers; the host relocates them to their final device
-// addresses before the H2D copy, so the device schedules a complete image.
+// orchestration .so and runs it to completion. Every cross-task reference the
+// shared memory and arena carry is an offset or an index from its own block, so
+// the image the device schedules is the bytes the host wrote — there is nothing
+// to fix up after the H2D copy.
 
 bool write_all_bytes(int fd, const uint8_t *data, size_t size) {
     size_t total = 0;
@@ -373,147 +389,110 @@ struct HostOrchEntryPoints {
     OrchestrationBindFunc bind{nullptr};
 };
 
-static bool relocate_host_orch_image(
-    PTO2SharedMemoryHandle &host_sm_handle, uint64_t host_sm, uint64_t sm_size, int64_t sm_delta, uint64_t host_arena,
-    uint64_t arena_size, int64_t arena_delta
-) {
-    static_assert(PTO2_MAX_RING_DEPTH == 1, "relocate_host_orch_image assumes a single ring");
+struct StagedDefinition {
+    const std::byte *host_image;
+    size_t bytes;
+    const GraphDefinition *definition;
+    size_t offset;
+};
 
-    if (!(host_sm + sm_size <= host_arena || host_arena + arena_size <= host_sm)) {
-        LOG_ERROR(
-            "host-orch: SM window [%#lx,+%#lx) overlaps arena window [%#lx,+%#lx); cannot relocate", host_sm, sm_size,
-            host_arena, arena_size
-        );
+struct StagedSubmission {
+    const GraphSubmission *host_image;
+    PTO2TaskSlotState *outer_slot;
+    size_t definition_offset;
+    size_t offset;
+};
+
+struct GraphBlockPlan {
+    std::vector<StagedDefinition> definitions;
+    std::vector<StagedSubmission> submissions;
+    size_t bytes{0};
+};
+
+bool reserve_graph_region(size_t bytes, size_t alignment, size_t *cursor, size_t *offset) {
+    if (cursor == nullptr || offset == nullptr || alignment == 0 || (alignment & (alignment - 1)) != 0 ||
+        *cursor > SIZE_MAX - (alignment - 1)) {
         return false;
     }
-
-    bool ok = true;
-    auto relocate = [&](auto *&pointer) {
-        using Pointer = std::remove_reference_t<decltype(pointer)>;
-        const uint64_t address = reinterpret_cast<uint64_t>(pointer);
-        if (address == 0) return;
-        if (address >= host_sm && address < host_sm + sm_size) {
-            pointer = reinterpret_cast<Pointer>(static_cast<uintptr_t>(address + sm_delta));
-        } else if (address >= host_arena && address < host_arena + arena_size) {
-            pointer = reinterpret_cast<Pointer>(static_cast<uintptr_t>(address + arena_delta));
-        } else {
-            LOG_ERROR(
-                "host-orch: pointer %#lx is outside both SM and arena windows; cannot relocate for device", address
-            );
-            ok = false;
-        }
-    };
-
-    PTO2SharedMemoryHeader *header = host_sm_handle.header;
-    if (header != nullptr) {
-        PTO2SharedMemoryRingHeader &ring = header->ring;
-        const int32_t count = ring.fc.current_task_index.load(std::memory_order_acquire);
-        for (int32_t slot = 0; slot < count; ++slot) {
-            PTO2TaskSlotState *state = &ring.slot_states[slot];
-            relocate(state->task);
-            relocate(state->payload);
-        }
-    }
-    return ok;
+    const size_t aligned = (*cursor + alignment - 1) & ~(alignment - 1);
+    if (bytes > SIZE_MAX - aligned) return false;
+    *offset = aligned;
+    *cursor = aligned + bytes;
+    return true;
 }
 
-bool upload_graph_submissions(
-    Runtime *runtime, const HostApi *api, GraphHostState &graph_state, uint64_t &uploaded_bytes
-) {
-    uploaded_bytes = 0;
-    const size_t count = graph_host_upload_count(graph_state);
-    // Pass 1: upload each distinct Definition once as a shared device object
-    // ([GraphDefinitionHeader][Definition image]) keyed by content identity.
-    // Submissions reference the object's GM address, so this pass completing
-    // before any submission is uploaded is what makes the reference safe —
-    // the device boots only after both passes.
+bool plan_graph_block(GraphHostState &graph_state, GraphBlockPlan *plan, uint64_t &uploaded_bytes) {
+    if (plan == nullptr) return false;
+    std::unordered_map<uint64_t, std::pair<size_t, const GraphDefinition *>> definition_offsets;
     GraphHostDefinitionList definitions = graph_host_definitions(graph_state);
-    struct UploadedDefinition {
-        void *device_object;               // GM address; host must not dereference
-        const GraphDefinition *host_view;  // the host-side image the object was built from
-    };
-    std::unordered_map<uint64_t, UploadedDefinition> definition_objects;
+    plan->definitions.reserve(definitions.entries.size());
     for (const GraphHostDefinition &entry : definitions.entries) {
         if (entry.data == nullptr || entry.bytes < sizeof(GraphDefinition)) continue;
         const auto *definition = reinterpret_cast<const GraphDefinition *>(entry.data);
-        if (definition->total_bytes != entry.bytes || definition->full_key != entry.full_key) continue;
-        const size_t object_bytes = sizeof(GraphDefinitionHeader) + entry.bytes;
-        void *object =
-            api->acquire_graph_definition_buffer(entry.full_key, object_bytes, alignof(GraphDefinitionHeader));
-        if (object == nullptr) {
-            LOG_ERROR(
-                "host-orch: failed to retain %zu bytes for Graph Definition key=%#llx", object_bytes,
-                static_cast<unsigned long long>(entry.full_key)
-            );
+        if (definition->total_bytes != entry.bytes || definition->full_key != entry.full_key ||
+            entry.bytes > SIZE_MAX - sizeof(GraphDefinitionHeader)) {
             return false;
         }
-        std::vector<std::byte> staging(object_bytes, std::byte{0});
-        auto *header = reinterpret_cast<GraphDefinitionHeader *>(staging.data());
-        header->magic = GRAPH_DEFINITION_OBJECT_MAGIC;
-        header->verify_state.store(
-            static_cast<uint32_t>(GraphDefinitionVerifyState::UPLOADED), std::memory_order_relaxed
-        );
-        header->definition_bytes = static_cast<uint32_t>(entry.bytes);
-        header->content_hash = definition->content_hash;
-        header->full_key = definition->full_key;
-        std::memcpy(staging.data() + sizeof(GraphDefinitionHeader), entry.data, entry.bytes);
-        if (api->copy_to_device(object, staging.data(), object_bytes) != 0) {
-            LOG_ERROR("host-orch: failed to upload Graph Definition object");
+        size_t offset = 0;
+        if (!reserve_graph_region(
+                sizeof(GraphDefinitionHeader) + entry.bytes, alignof(GraphDefinitionHeader), &plan->bytes, &offset
+            )) {
             return false;
         }
-        definition_objects.emplace(definition->content_hash, UploadedDefinition{object, definition});
-        uploaded_bytes += object_bytes;
+        definition_offsets.emplace(definition->content_hash, std::make_pair(offset, definition));
+        plan->definitions.push_back({entry.data, entry.bytes, definition, offset});
     }
 
-    // Pass 2: per-submission execution storage + the small reference image.
+    const size_t count = graph_host_upload_count(graph_state);
+    plan->submissions.reserve(count);
     for (size_t index = 0; index < count; ++index) {
         std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
         if (!upload.has_value() || upload->outer_slot == nullptr || upload->data == nullptr ||
-            upload->bytes < sizeof(GraphSubmission) || upload->outer_slot->task_kind != TaskKind::GRAPH ||
+            upload->bytes != sizeof(GraphSubmission) || upload->outer_slot->task_kind != TaskKind::GRAPH ||
             upload->outer_slot->task == nullptr) {
             LOG_ERROR("host-orch: invalid pending Graph POD image");
             return false;
         }
-        auto *submission = reinterpret_cast<GraphSubmission *>(upload->data);
-        if (!graph_submission_wire_size_valid(*submission, upload->bytes)) {
-            LOG_ERROR("host-orch: Graph submission size does not match its POD image");
+        const auto *submission = reinterpret_cast<const GraphSubmission *>(upload->data);
+        auto definition_it = definition_offsets.find(submission->definition_hash);
+        if (definition_it == definition_offsets.end()) {
+            LOG_ERROR("host-orch: Graph submission has no packed Definition object");
             return false;
         }
-        auto object_it = definition_objects.find(submission->definition_hash);
-        if (object_it == definition_objects.end() || object_it->second.device_object == nullptr) {
-            LOG_ERROR("host-orch: Graph submission has no uploaded Definition object");
-            return false;
-        }
-        // Checked against the host-side Definition image the device object was
-        // built from; the GM object itself is never dereferenced on the host.
-        // Execution storage needs no retained buffer: it is the tail of the
-        // outer task's own heap allocation, which graph_submit_definition sized
-        // to required_heap + execution_storage_bytes.
-        const GraphDefinition *definition = object_it->second.host_view;
+        const GraphDefinition *definition = definition_it->second.second;
         if (definition->task_count == 0 || definition->task_count > GRAPH_MAX_NODES ||
             definition->full_key != submission->graph_key || definition->execution_storage_bytes == 0) {
             LOG_ERROR("host-orch: invalid Graph Definition for submission");
             return false;
         }
-        submission->definition_addr = reinterpret_cast<uint64_t>(object_it->second.device_object);
-        submission->local_execution = 0;
-        submission->activation_gate = 0;
-
-        void *device_submission = api->device_malloc(upload->bytes);
-        if (device_submission == nullptr) {
-            LOG_ERROR("host-orch: failed to allocate %zu bytes for Graph submission", upload->bytes);
-            return false;
-        }
-        if (api->copy_to_device(device_submission, upload->data, upload->bytes) != 0) {
-            LOG_ERROR("host-orch: failed to upload Graph submission POD image");
-            api->device_free(device_submission);
-            return false;
-        }
-        upload->outer_slot->graph_context = device_submission;
-        runtime->tensor_pairs_.push_back({nullptr, device_submission, upload->bytes, false});
-        uploaded_bytes += static_cast<uint64_t>(upload->bytes);
+        size_t offset = 0;
+        if (!reserve_graph_region(sizeof(GraphSubmission), PTO2_ALIGN_SIZE, &plan->bytes, &offset)) return false;
+        plan->submissions.push_back({submission, upload->outer_slot, definition_it->second.first, offset});
     }
+    uploaded_bytes = plan->bytes;
     return true;
+}
+
+void stage_graph_block(const GraphBlockPlan &plan, char *block_base, char *device_block_base) {
+    for (const StagedDefinition &entry : plan.definitions) {
+        auto *header = reinterpret_cast<GraphDefinitionHeader *>(block_base + entry.offset);
+        header->magic = GRAPH_DEFINITION_OBJECT_MAGIC;
+        header->verify_state.store(
+            static_cast<uint32_t>(GraphDefinitionVerifyState::UPLOADED), std::memory_order_relaxed
+        );
+        header->definition_bytes = static_cast<uint32_t>(entry.bytes);
+        header->content_hash = entry.definition->content_hash;
+        header->full_key = entry.definition->full_key;
+        std::memcpy(block_base + entry.offset + sizeof(GraphDefinitionHeader), entry.host_image, entry.bytes);
+    }
+    for (const StagedSubmission &entry : plan.submissions) {
+        GraphSubmission submission = *entry.host_image;
+        submission.definition_addr = reinterpret_cast<uint64_t>(device_block_base + entry.definition_offset);
+        submission.local_execution = 0;
+        submission.activation_gate = 0;
+        std::memcpy(block_base + entry.offset, &submission, sizeof(submission));
+        entry.outer_slot->graph_context = device_block_base + entry.offset;
+    }
 }
 
 struct GraphHostStateBinding {
@@ -528,7 +507,7 @@ struct GraphHostStateBinding {
 
 int32_t run_host_orchestration(
     Runtime *runtime, const HostApi *api, HostTensorAccessor &tensor_access, PTO2Runtime *rt, DeviceArena &host_arena,
-    const PTO2RuntimeArenaLayout &layout, void *device_sm, uint64_t sm_size, void *device_arena, void *gm_heap,
+    const PTO2RuntimeArenaLayout &layout, uint64_t sm_size, void *gm_heap,
     const uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH],
     void *host_orch_func_ptr, const ChipTaskArgs &orch_l2
 ) {
@@ -540,8 +519,14 @@ int32_t run_host_orchestration(
     // orch::prepare_task and shipped bounded to total_tasks below.
     const pto2_sm_layout::PTO2RingSegmentOffsets sm_segs =
         pto2_sm_layout::ring_segment_offsets(eff_task_window_sizes[0]);
-    std::unique_ptr<uint8_t[]> host_sm_buf(new uint8_t[sm_size]);
-    void *host_sm = host_sm_buf.get();
+    // Over-allocated and rounded up: every segment offset is a multiple of
+    // PTO2_ALIGN_SIZE and PTO2TaskSlotState is alignas(64), which a plain
+    // new uint8_t[] does not guarantee.
+    std::unique_ptr<uint8_t[]> host_sm_buf(new uint8_t[sm_size + PTO2_ALIGN_SIZE]);
+    void *host_sm = reinterpret_cast<void *>(
+        (reinterpret_cast<uintptr_t>(host_sm_buf.get()) + PTO2_ALIGN_SIZE - 1) &
+        ~static_cast<uintptr_t>(PTO2_ALIGN_SIZE - 1)
+    );
     std::memset(host_sm, 0, sm_segs.descriptors);
 
     // Re-point the orchestrator half at the host SM (scheduler keeps device SM).
@@ -617,6 +602,25 @@ int32_t run_host_orchestration(
     }
 #endif
 
+    // A latched fatal means the graph in the mirror is not the graph the orchestration
+    // described — a heap or tensormap exhaustion drops tasks, a fanin overflow drops
+    // edges. Uploading it would launch the device on an incomplete graph and surface
+    // the cause as whatever the device notices second, usually a scheduler timeout.
+    const int32_t orch_error = pto2_sm_layout::orch_error_code_addr(host_sm)->load(std::memory_order_acquire);
+    if (orch_error != PTO2_ERROR_NONE || rt->orchestrator.fatal) {
+        // The latched code is the diagnosis, so it is what the caller sees — through the
+        // same mapping the run path uses, since a caller cannot tell which of the two
+        // noticed. A fatal with no code left to read is the only generic failure.
+        const int32_t status =
+            orch_error != PTO2_ERROR_NONE ? runtime_status_from_error_codes(orch_error, PTO2_ERROR_NONE) : -1;
+        LOG_RUNTIME_FAILURE(orch_error, PTO2_ERROR_NONE, status);
+        LOG_ERROR(
+            "host-orch: refusing to upload an incomplete graph after %" PRIu64 " heap bytes",
+            rt->orchestrator.ring.task_allocator.heap_used_bytes()
+        );
+        return status;
+    }
+
     const int32_t total_tasks = pto2_sm_layout::ring_current_task_index_addr(host_sm)->load(std::memory_order_acquire);
     {
         char attrs[96];
@@ -629,9 +633,12 @@ int32_t run_host_orchestration(
     // After the span closes: the reduction walks a few hundred records and emits
     // five markers, which must not be charged to the pass it measures.
 
+    // Plan the Definition and submission tail before growing the arena. No device
+    // allocation or copy occurs until every byte count is known.
     const int64_t t_graph_ns = bind_now_ns();
     uint64_t graph_bytes = 0;
-    if (!upload_graph_submissions(runtime, api, *graph_state, graph_bytes)) return -1;
+    GraphBlockPlan graph_plan;
+    if (!plan_graph_block(*graph_state, &graph_plan, graph_bytes)) return -1;
     {
         char attrs[96];
         snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, graph_host_upload_count(*graph_state), graph_bytes);
@@ -646,52 +653,85 @@ int32_t run_host_orchestration(
     }
     host_phase_trace_note_submitted(static_cast<uint64_t>(total_tasks));
 
-    // Relocate the host-DDR cross-task pointers to their final DEVICE addresses
-    // on the host, before the SM and arena leave for the device. Pointers into
-    // the SM shift by sm_delta; pointers into the arena (fanout adjacency, wiring
-    // queue) shift by arena_delta. After this both the SM and arena carry device
-    // addresses, so the device boots scheduler-only.
-    const int64_t sm_delta = static_cast<int64_t>(reinterpret_cast<uint64_t>(device_sm)) -
-                             static_cast<int64_t>(reinterpret_cast<uint64_t>(host_sm));
-    const int64_t arena_delta = static_cast<int64_t>(reinterpret_cast<uint64_t>(device_arena)) -
-                                static_cast<int64_t>(reinterpret_cast<uint64_t>(host_arena.base()));
-    const int64_t t_reloc_ns = bind_now_ns();
-    if (!relocate_host_orch_image(
-            host_sm_handle, reinterpret_cast<uint64_t>(host_sm), sm_size, sm_delta,
-            reinterpret_cast<uint64_t>(host_arena.base()), layout.arena_size, arena_delta
-        )) {
-        LOG_ERROR("host-orch: relocation failed; refusing to H2D an image with unrelocated host pointers");
+    // Restack the live prefixes into one contiguous image. TaskPayloadSpace keeps
+    // variable-sized records in submission order, so its exact live byte count is
+    // copied as one segment and each slot is rebound by its payload offset.
+    const uint64_t nt = static_cast<uint64_t>(total_tasks);
+    const uint64_t payload_bytes = rt->orchestrator.task_payload_space_used_bytes;
+    runtime->sm_payload_bytes = payload_bytes;
+    const uint64_t image_bytes =
+        pto2_sm_layout::ring_segment_offsets_with_payload_bytes(pto2_sm_layout::live_slot_pitch(nt), payload_bytes).end;
+
+    // Only now is the size known, so this is where the device runtime region is
+    // committed. setup_static_arena grows per region and short-circuits a request
+    // it already covers, so the heap is untouched and repeated workloads reuse a
+    // sufficiently large runtime arena.
+    const int64_t t_sm_ns = bind_now_ns();
+    uint64_t total_heap_size = 0;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        total_heap_size += eff_heap_sizes[r];
+    }
+    // Device tails follow in order: shared memory, then Definitions and submissions.
+    const uint64_t off_graph_block = layout.off_copied_end + image_bytes;
+    const uint64_t device_arena_bytes = off_graph_block + graph_plan.bytes;
+    if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, device_arena_bytes) != 0) {
+        LOG_ERROR("host-orch: failed to commit %" PRIu64 " bytes of device runtime arena", device_arena_bytes);
         return -1;
     }
-    record_bind_phase(HostPhaseKind::BindRelocate, t_reloc_ns);
+    void *device_arena = api->acquire_pooled_runtime_arena();
+    if (device_arena == nullptr) {
+        LOG_ERROR("%s", "host-orch: failed to re-acquire the pooled runtime arena");
+        return -1;
+    }
+    char *arena_dev = static_cast<char *>(device_arena);
+    void *device_sm = arena_dev + layout.off_copied_end;
+    runtime->set_gm_sm_ptr(device_sm);
+    {
+        char attrs[96];
+        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, image_bytes);
+        record_bind_phase(HostPhaseKind::BindSharedMem, t_sm_ns, attrs, image_bytes);
+    }
 
-    // Ship only the live prefix of each segment: the device reads no slot past
-    // total_tasks, so upload header + descriptors[0,N), payloads[0,N),
-    // slot_states[0,N) and completion_flags[0,N) — never the ring-sized tails.
-    // header + descriptors[0,N) are contiguous, so that is a single copy.
-    const uint64_t nt = static_cast<uint64_t>(total_tasks);
-    const uint64_t hdr_desc_bytes = sm_segs.descriptors + nt * sizeof(PTO2TaskDescriptor);
-    char *host_base = static_cast<char *>(host_sm);
-    char *dev_base = static_cast<char *>(device_sm);
-    const int64_t t_sm_h2d_ns = bind_now_ns();
-    if (api->copy_to_device(dev_base, host_base, hdr_desc_bytes) != 0 ||
-        api->copy_to_device(dev_base + sm_segs.payloads, host_base + sm_segs.payloads, nt * sizeof(PTO2TaskPayload)) !=
-            0 ||
-        api->copy_to_device(
-            dev_base + sm_segs.slot_states, host_base + sm_segs.slot_states, nt * sizeof(PTO2TaskSlotState)
-        ) != 0 ||
-        api->copy_to_device(
-            dev_base + sm_segs.completion_flags, host_base + sm_segs.completion_flags, nt * sizeof(std::atomic<uint8_t>)
-        ) != 0) {
-        LOG_ERROR("host-orch: H2D of populated SM failed");
+    // One host source for one copy: the copied zone, the shared-memory image, and
+    // the submission block, at exactly the offsets they occupy on the device.
+    // Over-allocated and rounded up because every segment offset is
+    // PTO2_ALIGN_SIZE-aligned and PTO2TaskSlotState is alignas(64), which a byte
+    // vector's data() is not.
+    const uint64_t copied_bytes = layout.off_copied_end - layout.off_copied_begin;
+    const uint64_t upload_bytes = copied_bytes + image_bytes + graph_plan.bytes;
+    std::vector<std::byte> storage(upload_bytes + PTO2_ALIGN_SIZE, std::byte{0});
+    char *upload_base = reinterpret_cast<char *>(
+        (reinterpret_cast<uintptr_t>(storage.data()) + PTO2_ALIGN_SIZE - 1) &
+        ~static_cast<uintptr_t>(PTO2_ALIGN_SIZE - 1)
+    );
+
+    // Before the shared-memory mirror is compacted: this writes each outer task's
+    // graph_context into it, and compaction carries those slot updates.
+    stage_graph_block(graph_plan, upload_base + copied_bytes + image_bytes, arena_dev + off_graph_block);
+
+    // The orchestrator has finished, so its pointers into the host-only tail have
+    // no further reader on either side — and this header is about to be copied, so
+    // leaving them would carry host addresses to the device.
+    runtime_clear_host_only_pointers(rt);
+    std::memcpy(upload_base, static_cast<const char *>(host_arena.base()) + layout.off_copied_begin, copied_bytes);
+    const uint64_t compacted = pto2_sm_layout::compact_live_image(
+        static_cast<const char *>(host_sm), eff_task_window_sizes[0], nt, payload_bytes, upload_base + copied_bytes
+    );
+    always_assert(compacted == image_bytes);
+
+    const int64_t t_h2d_ns = bind_now_ns();
+    if (api->copy_to_device(arena_dev + layout.off_copied_begin, upload_base, upload_bytes) != 0) {
+        LOG_ERROR("host-orch: H2D of the runtime image failed");
         return -1;
     }
     {
-        const uint64_t sm_h2d_bytes = hdr_desc_bytes + nt * sizeof(PTO2TaskPayload) + nt * sizeof(PTO2TaskSlotState) +
-                                      nt * sizeof(std::atomic<uint8_t>);
         char attrs[96];
-        snprintf(attrs, sizeof(attrs), "nt=%" PRIu64 " bytes=%" PRIu64, nt, sm_h2d_bytes);
-        record_bind_phase(HostPhaseKind::BindSmH2d, t_sm_h2d_ns, attrs, sm_h2d_bytes);
+        snprintf(
+            attrs, sizeof(attrs),
+            "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " graph=%zu pbytes=%" PRIu64, nt,
+            upload_bytes, copied_bytes, image_bytes, graph_plan.bytes, payload_bytes
+        );
+        record_bind_phase(HostPhaseKind::BindArenaH2d, t_h2d_ns, attrs, upload_bytes);
     }
     return total_tasks;
 }
@@ -980,18 +1020,25 @@ extern "C" int bind_callable_to_runtime_impl(
     }
     {
         char attrs[64];
-        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, static_cast<uint64_t>(layout.arena_size));
+        snprintf(
+            attrs, sizeof(attrs), "bytes=%" PRIu64 " device=%" PRIu64, static_cast<uint64_t>(layout.arena_size),
+            static_cast<uint64_t>(layout.device_bytes)
+        );
         record_bind_phase(HostPhaseKind::BindArenaBuild, t_arena_build_ns, attrs);
     }
 
     const int64_t t_static_arena_ns = bind_now_ns();
-    if (api->setup_static_arena(total_heap_size, sm_size, layout.arena_size) != 0) {
+    // Commit only the heap now: the host orchestrator needs its device addresses
+    // while building tasks. Shared memory belongs to the runtime-arena image, and
+    // that arena stays uncommitted until orchestration has calculated its exact
+    // SM, payload, Definition, and submission sizes.
+    if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, /*runtime_arena_size=*/0) != 0) {
         LOG_ERROR("Failed to setup pooled static arena");
         return -1;
     }
     {
         char attrs[96];
-        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " sm=%" PRIu64, total_heap_size, sm_size);
+        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " arena=deferred", total_heap_size);
         record_bind_phase(HostPhaseKind::BindStaticArena, t_static_arena_ns, attrs);
     }
 
@@ -1003,21 +1050,10 @@ extern "C" int bind_callable_to_runtime_impl(
         return -1;
     }
     runtime->set_gm_heap(gm_heap);
-
-    const int64_t t_sm_ns = bind_now_ns();
-    void *sm_ptr = api->acquire_pooled_gm_sm();
-    record_bind_phase(HostPhaseKind::BindSharedMem, t_sm_ns);
-    if (sm_ptr == nullptr) {
-        LOG_ERROR("Failed to acquire pooled PTO2 shared memory");
-        return -1;
-    }
-    runtime->set_gm_sm_ptr(sm_ptr);
-
-    void *runtime_arena_dev = api->acquire_pooled_runtime_arena();
-    if (runtime_arena_dev == nullptr) {
-        LOG_ERROR("Failed to acquire pooled runtime arena");
-        return -1;
-    }
+    // The shared memory is placed at the end of orchestration, so until then this
+    // bind has no SM. Clearing it keeps a failure before that point from leaving the
+    // previous bind's address for the error-code read to follow.
+    runtime->set_gm_sm_ptr(nullptr);
 
     // Set up orchestration state (consumed by the host orchestrator below)
     runtime->set_orch_args(device_args);
@@ -1033,13 +1069,24 @@ extern "C" int bind_callable_to_runtime_impl(
     // reset) + a handful of device-only field fixups.
     // -------------------------------------------------------------------------
     const int64_t t_runtime_init_ns = bind_now_ns();
-    PTO2Runtime *rt =
-        runtime_init_data_from_layout(host_arena, layout, PTO2_MODE_EXECUTE, sm_ptr, sm_size, gm_heap, eff_heap_sizes);
+    // No SM base: the scheduler and sm_handle are device-written now, so nothing
+    // here stores one, and the region is not even committed yet.
+    PTO2Runtime *rt = runtime_init_data_from_layout(
+        host_arena, layout, PTO2_MODE_EXECUTE, /*sm_dev_base=*/nullptr, sm_size, gm_heap, eff_heap_sizes
+    );
     if (rt == nullptr) {
         LOG_ERROR("runtime_init_data_from_layout failed");
         return -1;
     }
     runtime_wire_arena_pointers(host_arena, layout, rt);
+    runtime_wire_host_only_pointers(host_arena, layout, rt);
+    // Stash the layout inside the PTO2Runtime image so the AICPU can recover every
+    // arena-internal offset after the copy. It is written before orchestration
+    // because orchestration is what performs that copy, and the runtime header is
+    // part of what travels. The runtime arena's device base does NOT travel — it is
+    // on the host Runtime (set_prebuilt_arena below), since the AICPU needs that
+    // pointer before it can dereference the image.
+    rt->prebuilt_layout = layout;
     record_bind_phase(HostPhaseKind::BindRuntimeInit, t_runtime_init_ns);
 
     if (host_orch_func_ptr == nullptr) {
@@ -1050,8 +1097,8 @@ extern "C" int bind_callable_to_runtime_impl(
         ChipTaskArgs orch_l2;
         orch_l2.create_from_chip_args(device_args);
         int32_t total_tasks = run_host_orchestration(
-            runtime, api, tensor_access, rt, host_arena, layout, sm_ptr, sm_size, runtime_arena_dev, gm_heap,
-            eff_heap_sizes, eff_task_window_sizes, host_orch_func_ptr, orch_l2
+            runtime, api, tensor_access, rt, host_arena, layout, sm_size, gm_heap, eff_heap_sizes,
+            eff_task_window_sizes, host_orch_func_ptr, orch_l2
         );
         // The orchestrator is the only host-view reader; from here the device
         // owns these buffers, so drop the window on both exits.
@@ -1066,41 +1113,19 @@ extern "C" int bind_callable_to_runtime_impl(
         }
         if (total_tasks < 0) {
             LOG_ERROR("host-orch: orchestration run failed");
-            return -1;
+            return total_tasks;
         }
         runtime->host_total_tasks = total_tasks;
         LOG_INFO("host-orch: submitted %d tasks on host", total_tasks);
     }
 
-    // Stash the layout inside the PTO2Runtime image so the AICPU can recover
-    // every arena-internal offset after rtMemcpy. The runtime arena's device
-    // base does NOT travel in this image — it's on the host Runtime
-    // (set_prebuilt_arena below), since the AICPU needs that pointer
-    // *before* it can dereference the image.
-    rt->prebuilt_layout = layout;
-
-    // The arena is partitioned into three zones (see PTO2RuntimeArenaLayout) and
-    // only the middle one is copied: the host-only orchestrator block sits before
-    // it, and the regions the device initializes itself (sm_handle, scheduler
-    // state, queue slot arrays) sit after it. So bind is one copy of one range,
-    // with both bounds taken from the layout rather than inferred from a
-    // reservation order here.
-    const size_t copied_begin = layout.off_copied_begin;
-    const size_t copied_end = layout.off_copied_end;
-    always_assert(copied_begin <= copied_end && copied_end <= layout.arena_size);
-    char *arena_host = static_cast<char *>(host_arena.base());
-    char *arena_dev = static_cast<char *>(runtime_arena_dev);
-    const int64_t t_arena_h2d_ns = bind_now_ns();
-    int rc_upload = api->copy_to_device(arena_dev + copied_begin, arena_host + copied_begin, copied_end - copied_begin);
-    if (rc_upload != 0) {
-        LOG_ERROR("Failed to rtMemcpy prebuilt runtime arena to device (rc=%d)", rc_upload);
+    // Orchestration grew the device region to cover its shared-memory tail, which
+    // reallocates, so the base acquired before it may no longer be the one the
+    // image was copied into.
+    void *runtime_arena_dev = api->acquire_pooled_runtime_arena();
+    if (runtime_arena_dev == nullptr) {
+        LOG_ERROR("%s", "Failed to re-acquire the pooled runtime arena after orchestration");
         return -1;
-    }
-    {
-        const uint64_t arena_h2d_bytes = static_cast<uint64_t>(copied_end - copied_begin);
-        char attrs[96];
-        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, arena_h2d_bytes);
-        record_bind_phase(HostPhaseKind::BindArenaH2d, t_arena_h2d_ns, attrs, arena_h2d_bytes);
     }
     runtime->set_prebuilt_arena(runtime_arena_dev, layout.off_runtime);
 

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -786,11 +786,16 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     definition.tensor_arg_count = static_cast<uint32_t>(tensors.size());
     definition.scalar_arg_count = static_cast<uint32_t>(scalars.size());
     definition.predicate_count = static_cast<uint32_t>(predicates.size());
+    const size_t node_stride = sizeof(GraphNodeStorage);
     size_t execution_storage_bytes = 0;
-    if (!graph_execution_storage_bytes(static_cast<int32_t>(definition.task_count), &execution_storage_bytes) ||
+    if (node_stride > UINT32_MAX ||
+        !graph_execution_storage_bytes(
+            static_cast<int32_t>(definition.task_count), node_stride, &execution_storage_bytes
+        ) ||
         execution_storage_bytes > UINT32_MAX) {
         return false;
     }
+    definition.node_stride = static_cast<uint32_t>(node_stride);
     definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
     // Every section's byte count is known now, so the image grows once instead of
     // resizing eleven times. Each append aligns its start, hence the per-section
@@ -972,6 +977,28 @@ struct PTO2PreparedTask {
     PTO2TaskSlotState *slot_state = nullptr;
 };
 
+static PTO2TaskPayload *allocate_task_payload(PTO2OrchestratorState *orch, size_t requested_bytes) {
+    if (orch == nullptr || orch->sm_header == nullptr || requested_bytes < sizeof(PTO2TaskPayload)) return nullptr;
+    PTO2SharedMemoryRingHeader &ring = orch->sm_header->ring;
+    constexpr uint64_t alignment = alignof(PTO2TaskPayload);
+    const uint64_t capacity = ring.task_window_size * sizeof(PTO2TaskPayload);
+    const uint64_t cursor = orch->task_payload_space_used_bytes;
+    if (cursor > UINT64_MAX - (alignment - 1) || requested_bytes > UINT64_MAX - (alignment - 1)) return nullptr;
+    const uint64_t offset = PTO2_ALIGN_UP(cursor, alignment);
+    const uint64_t bytes = PTO2_ALIGN_UP(static_cast<uint64_t>(requested_bytes), alignment);
+    if (offset > capacity || bytes > capacity - offset) {
+        orch->report_fatal(
+            PTO2_ERROR_FLOW_CONTROL_DEADLOCK, __FUNCTION__,
+            "TaskPayloadSpace exhausted: used=%" PRIu64 " requested=%" PRIu64 " capacity=%" PRIu64, cursor, bytes,
+            capacity
+        );
+        return nullptr;
+    }
+    orch->task_payload_space_used_bytes = offset + bytes;
+    auto *base = reinterpret_cast<std::byte *>(ring.task_payloads);
+    return reinterpret_cast<PTO2TaskPayload *>(base + offset);
+}
+
 static PTO2OutputLayout calculate_output_layout(const CoreTaskArgs &args) {
     PTO2OutputLayout layout;
     for (int32_t i = 0; i < args.tensor_count(); i++) {
@@ -1015,7 +1042,10 @@ static bool prepare_task(
     out->task_id = PTO2TaskId::make(ring_id, static_cast<uint32_t>(out->alloc_result.task_id));
     out->slot_state = &orch->sm_header->ring.get_slot_state_by_slot(out->alloc_result.slot);
     out->task = &orch->sm_header->ring.task_descriptors[out->alloc_result.slot];
-    out->payload = &orch->sm_header->ring.task_payloads[out->alloc_result.slot];
+    out->payload = allocate_task_payload(orch, sizeof(PTO2TaskPayload));
+    if (out->payload == nullptr) {
+        return false;
+    }
 
     // Init-on-write: this slot's dynamic scheduling fields and completion flag are
     // initialized here, as the orchestrator claims the slot. whole-graph-resident
@@ -1027,9 +1057,8 @@ static bool prepare_task(
 
     out->payload->prefetch(args.tensor_count(), args.scalar_count());
 
-    // Re-bind payload/task pointers each submit. Value is per-slot constant
-    // (same as &task_payloads[slot] / &task_descriptors[slot]), but writing
-    // here lets RingSchedState::init() skip the O(window_size) bind loop.
+    // Bind the payload record selected from TaskPayloadSpace. Its relative
+    // reference remains valid when the complete SM image moves to device GM.
     // Both writes hit the same 64B slot_state cache line we're about to
     // dirty below, so the extra cost is two stores on an already-hot line.
     // Must precede the Orch-side wiring publish at the end of
@@ -1384,9 +1413,9 @@ static TaskOutputTensors submit_task_common(
     // push_ready_routed; otherwise the returned index selects the producer passed
     // to register_wake. Wake retargeting in register_wake may reclassify a task
     // when the selected producer is already complete.
-    // The initial scan happens before the scheduler dispatch loop starts. Because
-    // fanin is a flat array of position-independent integers, none of this needs
-    // host->device pointer relocation.
+    // The initial scan happens before the scheduler dispatch loop starts. Fanin is
+    // a flat array of position-independent integers, so it crosses to the device
+    // unchanged.
     payload.fanin_count = fanin_builder.count;
     (void)sched;
 
@@ -1523,40 +1552,13 @@ void graph_reset_outer_payload(PTO2TaskPayload &payload) {
 }
 
 bool graph_prepare_submission_image(
-    uint64_t full_key, const GraphTaskArgs &args, std::vector<std::byte> *submission_image
+    uint64_t full_key, uint64_t definition_hash, std::vector<std::byte> *submission_image
 ) {
     if (submission_image == nullptr) return false;
-    const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphTensor));
-    const size_t tensor_bytes = static_cast<size_t>(args.tensor_count()) * sizeof(GraphTensor);
-    if (tensors_offset > UINT32_MAX || tensors_offset > UINT32_MAX - tensor_bytes) {
-        return false;
-    }
-    const size_t tensors_end = tensors_offset + tensor_bytes;
-    const size_t scalar_bytes = static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t);
-    const size_t scalars_offset = args.scalar_count() == 0 ? 0 : PTO2_ALIGN_UP(tensors_end, alignof(uint64_t));
-    const size_t total_bytes = args.scalar_count() == 0 ? tensors_end : scalars_offset + scalar_bytes;
-    if ((args.scalar_count() != 0 && (scalars_offset > UINT32_MAX || scalars_offset > UINT32_MAX - scalar_bytes)) ||
-        total_bytes > UINT32_MAX) {
-        return false;
-    }
-    submission_image->assign(total_bytes, std::byte{0});
-    auto *tensors = reinterpret_cast<GraphTensor *>(submission_image->data() + tensors_offset);
-    for (int32_t i = 0; i < args.tensor_count(); ++i)
-        tensors[i] = graph_tensor_pack(args.tensor(i).ref());
-    if (args.scalar_count() != 0) {
-        std::memcpy(
-            submission_image->data() + scalars_offset, args.scalar_data(),
-            static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t)
-        );
-    }
-
     GraphSubmission submission{};
     submission.graph_key = full_key;
-    submission.total_bytes = static_cast<uint32_t>(submission_image->size());
-    submission.tensors_offset = static_cast<uint32_t>(tensors_offset);
-    submission.tensor_count = static_cast<uint32_t>(args.tensor_count());
-    submission.scalars_offset = static_cast<uint32_t>(scalars_offset);
-    submission.scalar_count = static_cast<uint32_t>(args.scalar_count());
+    submission.definition_hash = definition_hash;
+    submission_image->assign(sizeof(submission), std::byte{0});
     std::memcpy(submission_image->data(), &submission, sizeof(submission));
     return true;
 }
@@ -1574,8 +1576,7 @@ bool graph_submit_outer(
     }
 
     GraphPendingUpload pending;
-    if (!graph_prepare_submission_image(full_key, args, &pending.image)) return false;
-    reinterpret_cast<GraphSubmission *>(pending.image.data())->definition_hash = definition_hash;
+    if (!graph_prepare_submission_image(full_key, definition_hash, &pending.image)) return false;
     pending.deferred_heap = defer_heap;
 
     DepInputs boundary_inputs{
@@ -1591,10 +1592,22 @@ bool graph_submit_outer(
     const PTO2TaskId task_id = PTO2TaskId::make(0, static_cast<uint32_t>(allocation.task_id));
     PTO2SharedMemoryRingHeader &ring = orch->sm_header->ring;
     PTO2TaskDescriptor &task = ring.task_descriptors[allocation.slot];
-    PTO2TaskPayload &payload = ring.task_payloads[allocation.slot];
+    size_t payload_bytes = 0;
+    if (!graph_task_payload_layout(args.tensor_count(), args.scalar_count(), &payload_bytes)) return false;
+    PTO2TaskPayload *payload_ptr = allocate_task_payload(orch, payload_bytes);
+    if (payload_ptr == nullptr) return false;
+    PTO2TaskPayload &payload = *payload_ptr;
     PTO2TaskSlotState &slot = ring.get_slot_state_by_slot(allocation.slot);
 
-    slot.bind_buffers(&payload, &task);
+    // Init-on-write, as in prepare_task: this slot's dynamic scheduling fields and
+    // completion flag are established here, at the claim, because nothing else
+    // writes them. A stale wake_list_head of WAKE_LIST_SENTINEL would close the
+    // list against every consumer, and a stale completion flag would report the
+    // Graph done before it ran.
+    slot.reset_for_reuse();
+    ring.completion_flags[allocation.slot].store(0, std::memory_order_relaxed);
+
+    slot.bind_buffers(payload_ptr, &task);
     slot.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
     slot.last_consumer_local_id = static_cast<int32_t>(task_id.local());
     slot.active_mask = ActiveMask{};
@@ -1602,7 +1615,6 @@ bool graph_submit_outer(
     slot.total_required_subtasks = 0;
     slot.logical_block_num = 1;
     slot.task_kind = TaskKind::GRAPH;
-    slot.graph_context = nullptr;
     scope_tasks_push(orch, &slot);
 
     task.task_id = task_id;
@@ -1610,6 +1622,18 @@ bool graph_submit_outer(
     task.packed_buffer_base = allocation.packed_base;
     task.packed_buffer_end = allocation.packed_end;
     graph_reset_outer_payload(payload);
+    payload.tensor_count = args.tensor_count();
+    payload.scalar_count = args.scalar_count();
+    for (int32_t i = 0; i < args.tensor_count(); ++i) {
+        ChipTensor *destination = graph_task_payload_tensor(payload, static_cast<uint32_t>(i));
+        if (destination == nullptr) return false;
+        *destination = args.tensor(i).ref();
+    }
+    for (int32_t i = 0; i < args.scalar_count(); ++i) {
+        uint64_t *destination = graph_task_payload_scalar(payload, static_cast<uint32_t>(i));
+        if (destination == nullptr) return false;
+        *destination = args.scalar_data()[i];
+    }
 
     PTO2FaninBuilder fanin_builder(orch, &payload, static_cast<int32_t>(task_id.local()), next_fanin_seen_epoch(orch));
     auto emit = [&](PTO2TaskId producer_id) -> bool {
@@ -1684,7 +1708,7 @@ bool graph_submit_pending_definition(
 bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostState *state, uint64_t *failed_key) {
     for (GraphPendingUpload &pending : state->pending_uploads) {
         if (!pending.deferred_heap) continue;
-        if (pending.image.size() < sizeof(GraphSubmission)) return false;
+        if (pending.image.size() != sizeof(GraphSubmission)) return false;
         auto *submission = reinterpret_cast<GraphSubmission *>(pending.image.data());
         auto definition_it = state->definitions.find(submission->graph_key);
         const GraphDefinition *definition =
@@ -1692,8 +1716,7 @@ bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostSt
         if (definition == nullptr || definition->execution_storage_bytes == 0 ||
             definition->required_heap > UINT64_MAX - definition->execution_storage_bytes ||
             pending.outer_slot == nullptr || pending.outer_slot->task == nullptr ||
-            pending.outer_slot->task_kind != TaskKind::GRAPH ||
-            !graph_submission_wire_size_valid(*submission, pending.image.size())) {
+            pending.outer_slot->task_kind != TaskKind::GRAPH) {
             if (failed_key != nullptr) *failed_key = submission->graph_key;
             return false;
         }
@@ -2072,7 +2095,7 @@ void PTO2OrchestratorState::graph_abort(void *recording_handle) {
     auto *entry = static_cast<GraphInflightRecording *>(recording_handle);
     if (state == nullptr || entry == nullptr) return;
     {
-        std::lock_guard<std::mutex> lock(state->recording_mutex);
+        std::scoped_lock lock(state->recording_mutex);
         entry->recording.reset();
         entry->set_status(GraphRecordingStatus::FAILED);
     }
@@ -2109,7 +2132,7 @@ bool PTO2OrchestratorState::graph_end() {
     );
     bool ready = false;
     {
-        std::lock_guard<std::mutex> lock(state->recording_mutex);
+        std::scoped_lock lock(state->recording_mutex);
         if (entry->status() != GraphRecordingStatus::RECORDING || entry->full_key != header->full_key) {
             entry->set_status(GraphRecordingStatus::FAILED);
         } else {

--- a/src/a2a3/runtime/host_build_graph/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto2_dispatch_payload.h
@@ -67,7 +67,6 @@ static_assert(
 // PTO2TaskPayload layout drift fails the build rather than corrupting args[].
 constexpr uint32_t PTO2_TASKPAYLOAD_TENSOR_COUNT_OFFSET = 0;
 constexpr uint32_t PTO2_TASKPAYLOAD_SCALAR_COUNT_OFFSET = 4;
-// Cache line 9 (byte 576) holds the AICPU-only DispatchPredicate; tensors follow it.
 constexpr uint32_t PTO2_TASKPAYLOAD_TENSORS_OFFSET = 640;
 constexpr uint32_t PTO2_TASKPAYLOAD_SCALARS_OFFSET = 4736;
 constexpr uint32_t PTO2_TASKPAYLOAD_TENSOR_STRIDE = 128;  // sizeof(ChipTensor)

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_orchestrator.h
@@ -71,6 +71,9 @@ struct PTO2OrchestratorState {
     PTO2RingSet ring;
     uint32_t *fanin_seen_epoch;
     uint32_t fanin_seen_current_epoch{1};
+    // Live bytes in the packed task-payload segment. Payload records are
+    // appended in submission order and may have different lengths.
+    uint64_t task_payload_space_used_bytes{0};
 
     // === TENSOR MAP (Private) ===
     PTO2TensorMap tensor_map;  // Producer lookup

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -120,23 +120,36 @@ struct PTO2RuntimeArenaLayout {
     size_t off_scheduler{0};
     size_t off_runtime{0};
     size_t off_mailbox{0};
-    // The arena is reserved in three zones and the offsets above land in exactly
-    // one of them:
+    // The arena is reserved in zones, in this order, and the offsets above land in
+    // exactly one of them:
     //
-    //   host-only    the orchestrator block. Dep-computation scratch the AICPU
-    //                never reads, so it is never copied.
+    //   device-only  sm_handle, the AICore mailbox, the scheduler state and its
+    //                queue slot arrays. Reachable storage whose content is a
+    //                function of the layout, not of the run, so the device writes
+    //                it at boot instead of receiving an initialization pattern
+    //                over PCIe.
     //   copied       [off_copied_begin, off_copied_end). Every byte carries this
     //                run's own content, so bind ships the whole zone as one
     //                contiguous range.
-    //   device-only  sm_handle, the scheduler state and its queue slot arrays.
-    //                Reachable storage whose content is a function of the layout,
-    //                not of the run, so the device writes it at boot instead of
-    //                receiving an initialization pattern over PCIe.
     //
-    // Placing the copied zone in the middle is what keeps the upload a single
-    // range: the two zones that are not copied sit on either side of it.
+    // off_copied_end is where the shared part of the layout stops. Past it the two
+    // sides carry different tails, and neither reads the other's:
+    //
+    //   host tail    the orchestrator block. Dep-computation scratch no device code
+    //                reads, so it is neither copied nor allocated on the device.
+    //   device tail  the compact shared-memory image followed by Graph Definitions
+    //                and submissions. Their sizes are not known until orchestration
+    //                ends, so bind commits the device region only after planning them.
+    //
+    // The copied zone is padded to a PTO2_ALIGN_SIZE boundary, so the device tail
+    // begins exactly at off_copied_end: the copied zone, shared-memory image, and
+    // Graph block are adjacent on the device and travel as one copy.
     size_t off_copied_begin{0};
     size_t off_copied_end{0};
+
+    // Byte length of the device region before its shared-memory tail. The host
+    // arena is arena_size, which instead covers the orchestrator block there.
+    size_t device_bytes{0};
 
     // Cached parameters (re-used by init_data + wire stages).
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]{};
@@ -243,15 +256,33 @@ PTO2Runtime *runtime_init_data_from_layout(
 );
 
 /**
- * Phase 3 — wire every arena-internal pointer field (rt->sm_handle,
- * rt->aicore_mailbox, orchestrator.{scope_tasks, scope_begins, scheduler,
- * tensor_map.*, ring.fanin_pool.base}, scheduler.{ready_queues,
- * ready_sync_queues, early_dispatch_queues, dep_pool}) so each holds
- * arena.base() + offset. Idempotent — runs on
- * both host (writing host-mirror addresses) and AICPU (writing device
- * addresses) sides.
+ * Phase 3 — wire the arena-internal pointer fields that exist on both sides
+ * (rt->sm_handle, rt->aicore_mailbox, rt->scheduler and
+ * scheduler.{ready_queues, ready_sync_queues, early_dispatch_queues}) so each
+ * holds arena.base() + offset. Idempotent — runs on both host (writing
+ * host-mirror addresses) and AICPU (writing device addresses) sides.
  */
 void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
+
+/**
+ * Phase 3b — wire the orchestrator's pointers into the host-only zone
+ * (orchestrator.{scope_tasks, scope_begins, scheduler, tensor_map.*,
+ * ring.fanin_pool.base}).
+ *
+ * Host-only by construction: that zone is past layout.device_bytes and so is not
+ * allocated on the device, which makes the addresses this writes unrepresentable
+ * there. Requires rt->scheduler, so it follows runtime_wire_arena_pointers.
+ */
+void runtime_wire_host_only_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
+
+/**
+ * Drop the pointers Phase 3b wrote, so the runtime header can be copied to the
+ * device without carrying host addresses into it. The device reads one
+ * orchestrator field, inline_completed_tasks, which this leaves alone.
+ *
+ * Call after orchestration finishes and before the copied zone is uploaded.
+ */
+void runtime_clear_host_only_pointers(PTO2Runtime *rt);
 
 /**
  * AICPU-only Phase 4 — fill in the few fields the host could not know at

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -22,14 +22,14 @@
  * Based on: docs/RUNTIME_LOGIC.md
  */
 
-#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_RUNTIME2_TYPES_H_
-#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_RUNTIME2_TYPES_H_
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #include <atomic>
+#include <cstddef>
 
 #include "profiling_config.h"
 #include "pto_constants.h"
@@ -332,10 +332,10 @@ struct PTO2TaskPayload {
     // dispatch.
     alignas(64) DispatchPredicate predicate;
     ArgsDumpTaskMetadata dump_metadata;
-    // === Cache lines 10-73 (4096B) — tensors (alignas(64) forces alignment) ===
+    // === Cache lines 10-73 (4096B) — tensors ===
     ChipTensor tensors[MAX_TENSOR_ARGS];
     // === Cache lines 74-75 (128B) — scalars ===
-    uint64_t scalars[MAX_SCALAR_ARGS];
+    alignas(64) uint64_t scalars[MAX_SCALAR_ARGS];
 
     // Layout verification (size checks that don't need offsetof).
     static_assert(sizeof(ChipTensor) == 128, "ChipTensor must be 2 cache lines");
@@ -432,7 +432,7 @@ struct PTO2TaskPayload {
 static_assert(offsetof(PTO2TaskPayload, fanin_local_ids) == 12, "inline fanin id array must follow fanin_count");
 static_assert(
     offsetof(PTO2TaskPayload, predicate) == 576,
-    "dispatch predicate occupies cache line 9 at fixed byte 576 (before tensors, never moves)"
+    "dispatch predicate occupies cache line 9 at fixed byte 576 (before the arg arrays, never moves)"
 );
 static_assert(
     offsetof(PTO2TaskPayload, dump_metadata) + sizeof(ArgsDumpTaskMetadata) <= 640,
@@ -449,6 +449,50 @@ static_assert(
     sizeof(PTO2TaskPayload) == 640 + MAX_TENSOR_ARGS * sizeof(ChipTensor) + MAX_SCALAR_ARGS * sizeof(uint64_t),
     "PTO2TaskPayload size = metadata(576) + predicate cache line(64) + tensors + scalars"
 );
+
+// Position-independent reference used inside relocatable runtime images. The
+// payload and its slot move by the same delta from host DDR to device GM, so a
+// relative offset remains valid without a per-slot relocation pass.
+template <typename T>
+struct PTO2RelativePtr {
+    int64_t offset{0};
+
+    T *get() const {
+        if (offset == 0) return nullptr;
+        const intptr_t self = reinterpret_cast<intptr_t>(this);
+        return reinterpret_cast<T *>(self + offset);
+    }
+
+    void reset(T *pointer = nullptr) {
+        offset = pointer == nullptr ? 0 : reinterpret_cast<intptr_t>(pointer) - reinterpret_cast<intptr_t>(this);
+    }
+
+    PTO2RelativePtr &operator=(T *pointer) {
+        reset(pointer);
+        return *this;
+    }
+
+    operator T *() const { return get(); }
+    T *operator->() const { return get(); }
+    T &operator*() const { return *get(); }
+    explicit operator bool() const { return offset != 0; }
+
+    bool operator==(std::nullptr_t) const { return offset == 0; }
+    bool operator!=(std::nullptr_t) const { return offset != 0; }
+};
+
+template <typename T>
+inline bool operator==(std::nullptr_t, const PTO2RelativePtr<T> &pointer) {
+    return pointer == nullptr;
+}
+
+template <typename T>
+inline bool operator!=(std::nullptr_t, const PTO2RelativePtr<T> &pointer) {
+    return pointer != nullptr;
+}
+
+static_assert(sizeof(PTO2RelativePtr<PTO2TaskPayload>) == sizeof(uint64_t));
+static_assert(std::is_trivially_copyable_v<PTO2RelativePtr<PTO2TaskPayload>>);
 
 /**
  * Per-task slot scheduling state (scheduler-private, NOT in shared memory)
@@ -478,8 +522,10 @@ struct alignas(64) PTO2TaskSlotState {
     std::atomic<PTO2TaskState> task_state;
 
     // --- Per-slot constant, re-bound by orch::prepare_task each submit ---
-    PTO2TaskPayload *payload;
-    PTO2TaskDescriptor *task;
+    // Self-relative, so the SM image needs no pointer fix-up on its way to the
+    // device: both targets sit in the same block as this field.
+    PTO2RelativePtr<PTO2TaskPayload> payload;
+    PTO2RelativePtr<PTO2TaskDescriptor> task;
 
     // --- Wake list: last-fanin notification (intrusive, lock-free) ---
     // A pending consumer whose fanin scan finds an unmet producer registers on
@@ -538,8 +584,8 @@ struct alignas(64) PTO2TaskSlotState {
     }
 
     void bind_buffers(PTO2TaskPayload *p, PTO2TaskDescriptor *t) {
-        payload = p;
-        task = t;
+        payload.reset(p);
+        task.reset(t);
     }
 
     // Host-visible completion mirror. The device readiness truth
@@ -582,5 +628,3 @@ static_assert(sizeof(PTO2TaskSlotState) == 64);
 // Sentinel marking a wake list as "owner already completed; no more
 // registrations accepted". Distinct from any real slot_state pointer.
 inline PTO2TaskSlotState *const WAKE_LIST_SENTINEL = reinterpret_cast<PTO2TaskSlotState *>(static_cast<uintptr_t>(0x1));
-
-#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_RUNTIME2_TYPES_H_

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_shared_memory.h
@@ -34,6 +34,8 @@
 
 #include <stddef.h>
 
+#include <cstring>
+
 #include "utils/device_arena.h"
 #include "pto_runtime2_types.h"
 
@@ -143,9 +145,11 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
         return task_descriptors[get_slot_by_task_id(local_id)];
     }
 
-    PTO2TaskPayload &get_payload_by_slot(int32_t slot) { return task_payloads[slot]; }
+    PTO2TaskPayload &get_payload_by_slot(int32_t slot) { return *slot_states[slot].payload; }
 
-    PTO2TaskPayload &get_payload_by_task_id(int32_t local_id) { return task_payloads[get_slot_by_task_id(local_id)]; }
+    PTO2TaskPayload &get_payload_by_task_id(int32_t local_id) {
+        return get_payload_by_slot(get_slot_by_task_id(local_id));
+    }
 
     PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
@@ -240,7 +244,17 @@ struct PTO2SharedMemoryHandle {
     // Used by host_build_graph host-orch, where the host orchestrator populated
     // the SM and H2D'd it; the device must re-point at its own SM base without
     // wiping the contents (unlike init_per_ring, which also resets the header).
-    bool attach_populated(void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
+    //
+    // `live_slots` is the pitch the uploaded arrays were laid out with — the
+    // number of slots the host actually submitted, not the ring capacity. It must
+    // match what the host used or every segment past the descriptors resolves to
+    // the wrong address, so both sides derive it from the same submitted count.
+    // The capacity and mask in the header are unchanged, and `local_id & mask`
+    // yields `local_id`, which is below `live_slots` for every ring task.
+    bool attach_populated(
+        void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t live_slots,
+        uint64_t payload_bytes
+    );
 
     void destroy();
     void print_layout();
@@ -252,7 +266,13 @@ private:
         const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
     );
     void setup_pointers(uint64_t task_window_size);
-    void setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
+    // `pitch` is the slot count the arrays are dimensioned for. init_per_ring
+    // passes the ring capacity (the mirror the orchestrator writes into);
+    // attach_populated passes the submitted count (the compacted image that
+    // shipped).
+    void setup_pointers_per_ring(
+        const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch, uint64_t payload_bytes
+    );
 };
 
 // =============================================================================
@@ -293,6 +313,17 @@ inline std::atomic<int32_t> *ring_current_task_index_addr(void *sm_dev_base) noe
 // Byte offsets (from the SM base) of the ring's three segments. The layout is:
 // header, then descriptors -> payloads -> slot_states, every segment
 // PTO2_ALIGN_UP-padded.
+//
+// Two parameters, and the host mirror and the shipped image differ in both.
+//
+// The *pitch* is how many slots the arrays are dimensioned for: the mirror uses the
+// ring capacity, the image uses the submitted count, which is what makes the four
+// live prefixes contiguous and the upload one copy.
+//
+// The *payload stride* is how far apart consecutive payloads sit. The mirror uses
+// sizeof(PTO2TaskPayload), whose tensor array is dimensioned for the widest task the
+// API allows. The image uses the widest task in this bind — the array is the last
+// field, so anything past that task's entries is read by nobody.
 struct PTO2RingSegmentOffsets {
     uint64_t descriptors;
     uint64_t payloads;
@@ -307,13 +338,14 @@ struct PTO2RingSegmentOffsets {
 // `sm_dev_base`). Adding or reordering a segment is a one-line edit here; every
 // consumer follows automatically, so the layout walk can never silently
 // disagree across call sites.
-inline PTO2RingSegmentOffsets ring_segment_offsets(uint64_t task_window_size) noexcept {
+inline PTO2RingSegmentOffsets
+ring_segment_offsets_with_payload_bytes(uint64_t task_window_size, uint64_t payload_bytes) noexcept {
     uint64_t off = PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
     PTO2RingSegmentOffsets o{};
     o.descriptors = off;
     off += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
     o.payloads = off;
-    off += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
+    off += PTO2_ALIGN_UP(payload_bytes, PTO2_ALIGN_SIZE);
     o.slot_states = off;
     off += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
     o.completion_flags = off;
@@ -322,25 +354,70 @@ inline PTO2RingSegmentOffsets ring_segment_offsets(uint64_t task_window_size) no
     return o;
 }
 
-// Device address of the task_descriptors array.
-inline PTO2TaskDescriptor *ring_task_descriptors_addr(void *sm_dev_base, uint64_t task_window_size) noexcept {
-    return reinterpret_cast<PTO2TaskDescriptor *>(
-        static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_size).descriptors
-    );
+inline PTO2RingSegmentOffsets ring_segment_offsets(uint64_t task_window_size) noexcept {
+    return ring_segment_offsets_with_payload_bytes(task_window_size, task_window_size * sizeof(PTO2TaskPayload));
 }
 
-// Device address of the slot_states array used by host/device pointer wiring.
-inline PTO2TaskSlotState *ring_slot_states_addr(void *sm_dev_base, uint64_t task_window_size) noexcept {
-    return reinterpret_cast<PTO2TaskSlotState *>(
-        static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_size).slot_states
-    );
+// The pitch the shipped image uses for a given submitted task count. A bind that
+// submits nothing still ships its header and still attaches, and a zero-length
+// array has no layout, so the pitch never drops below one slot.
+inline uint64_t live_slot_pitch(uint64_t submitted_tasks) noexcept {
+    return submitted_tasks == 0 ? 1 : submitted_tasks;
 }
 
-// Device address of the polling completion_flags byte array.
-inline std::atomic<uint8_t> *ring_completion_flags_addr(void *sm_dev_base, uint64_t task_window_size) noexcept {
-    return reinterpret_cast<std::atomic<uint8_t> *>(
-        static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_size).completion_flags
-    );
+// Restack the live prefix of every ring segment from the ring-pitched mirror the
+// orchestrator wrote into an image pitched to `submitted_tasks`, where the four
+// prefixes are contiguous and can travel as one copy.
+//
+// `out_base` must be PTO2_ALIGN_SIZE-aligned and hold
+// `ring_segment_offsets_with_payload_bytes(live_slot_pitch(submitted_tasks),
+// payload_bytes).end` bytes. Returns that byte count.
+//
+// Two things the restack has to fix up, both because the image is not the mirror:
+//
+//   - the ring header's data pointers name the mirror's arrays, so they leave as
+//     null rather than carrying host addresses into device memory (the device
+//     resolves them in attach_populated);
+//   - a slot state names its payload and descriptor by a delta from its own
+//     address, and the restack changed those distances, so each binding is
+//     re-taken against the image.
+inline uint64_t compact_live_image(
+    const char *mirror_base, uint64_t task_window_size, uint64_t submitted_tasks, uint64_t payload_bytes, char *out_base
+) noexcept {
+    always_assert(submitted_tasks <= task_window_size);
+    always_assert(payload_bytes <= task_window_size * sizeof(PTO2TaskPayload));
+    const PTO2RingSegmentOffsets from = ring_segment_offsets(task_window_size);
+    const PTO2RingSegmentOffsets to =
+        ring_segment_offsets_with_payload_bytes(live_slot_pitch(submitted_tasks), payload_bytes);
+
+    // The header and the descriptors offset are pitch-independent, so the header
+    // lands where it already was.
+    std::memcpy(out_base, mirror_base, to.descriptors);
+    auto &out_ring = reinterpret_cast<PTO2SharedMemoryHeader *>(out_base)->ring;
+    out_ring.task_descriptors = nullptr;
+    out_ring.task_payloads = nullptr;
+    out_ring.slot_states = nullptr;
+    out_ring.completion_flags = nullptr;
+
+    const uint64_t nt = submitted_tasks;
+    std::memcpy(out_base + to.descriptors, mirror_base + from.descriptors, nt * sizeof(PTO2TaskDescriptor));
+    std::memcpy(out_base + to.payloads, mirror_base + from.payloads, payload_bytes);
+    std::memcpy(out_base + to.slot_states, mirror_base + from.slot_states, nt * sizeof(PTO2TaskSlotState));
+    std::memcpy(out_base + to.completion_flags, mirror_base + from.completion_flags, nt * sizeof(std::atomic<uint8_t>));
+
+    auto *out_slots = reinterpret_cast<PTO2TaskSlotState *>(out_base + to.slot_states);
+    auto *out_descriptors = reinterpret_cast<PTO2TaskDescriptor *>(out_base + to.descriptors);
+    const auto *source_slots = reinterpret_cast<const PTO2TaskSlotState *>(mirror_base + from.slot_states);
+    const char *source_payload_base = mirror_base + from.payloads;
+    for (uint64_t i = 0; i < nt; ++i) {
+        const char *source_payload = reinterpret_cast<const char *>(source_slots[i].payload.get());
+        always_assert(source_payload >= source_payload_base);
+        const uint64_t payload_offset = static_cast<uint64_t>(source_payload - source_payload_base);
+        always_assert(payload_offset + sizeof(PTO2TaskPayload) <= payload_bytes);
+        auto *out_payload = reinterpret_cast<PTO2TaskPayload *>(out_base + to.payloads + payload_offset);
+        out_slots[i].bind_buffers(out_payload, &out_descriptors[i]);
+    }
+    return to.end;
 }
 
 }  // namespace pto2_sm_layout

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -174,6 +174,9 @@ public:
     // the boot thread reads this instead of counting SM ring heads.
     int32_t host_total_tasks;
 
+    // Live TaskPayloadSpace byte count in the shipped shared-memory image.
+    uint64_t sm_payload_bytes;
+
 private:
     // Kernel binary tracking for cleanup
 

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -906,7 +906,7 @@ struct PTO2SchedulerState {
         const uint32_t end = execution.fanin_offsets[node_index + 1];
         for (uint32_t edge = begin; edge < end; ++edge) {
             const uint16_t producer_index = execution.fanin_indices[edge];
-            const PTO2TaskSlotState &producer = execution.nodes[producer_index].slot;
+            const PTO2TaskSlotState &producer = execution.node_at(producer_index).slot;
             if (producer.task_state.load(std::memory_order_acquire) != PTO2_TASK_COMPLETED) {
                 return static_cast<int32_t>(producer_index);
             }
@@ -934,7 +934,7 @@ struct PTO2SchedulerState {
                 push_ready_routed(consumer);
                 return;
             }
-            producer = &execution.nodes[unmet_producer].slot;
+            producer = &execution.node_at(unmet_producer).slot;
         }
     }
 
@@ -947,7 +947,7 @@ struct PTO2SchedulerState {
             if (unmet_producer < 0) {
                 push_ready_routed(waiter);
             } else {
-                register_graph_wake(execution, &execution.nodes[unmet_producer].slot, waiter);
+                register_graph_wake(execution, &execution.node_at(unmet_producer).slot, waiter);
             }
             consumers_rescanned++;
             waiter = next;
@@ -978,7 +978,7 @@ struct PTO2SchedulerState {
                 continue;
             }
             if (execution.fanin_offsets[i] == execution.fanin_offsets[i + 1]) {
-                push_ready_routed(&execution.node_storage[i].slot);
+                push_ready_routed(&execution.node_at(i).slot);
                 routed++;
             }
         }
@@ -996,12 +996,12 @@ struct PTO2SchedulerState {
     void graph_incremental_publish(GraphExecution &execution, int32_t first, int32_t last) {
         for (int32_t i = first; i < last; ++i) {
             if (execution.fanin_offsets[i] == execution.fanin_offsets[i + 1]) continue;  // root
-            PTO2TaskSlotState &node = execution.node_storage[i].slot;
+            PTO2TaskSlotState &node = execution.node_at(i).slot;
             const int32_t unmet = graph_first_unmet_producer(execution, node);
             if (unmet < 0) {
                 push_ready_routed(&node);
             } else {
-                register_graph_wake(execution, &execution.nodes[unmet].slot, &node);
+                register_graph_wake(execution, &execution.node_at(unmet).slot, &node);
             }
         }
         execution.published_nodes.store(last, std::memory_order_release);

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -322,21 +322,26 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
         layout.heap_sizes[r] = heap_sizes[r];
     }
 
-    // Reservation order is the zone partition (see PTO2RuntimeArenaLayout): the
-    // host-only orchestrator block, then the one copied range, then everything
-    // the device initializes itself. Each zone is contiguous, so bind is a single
-    // copy and no consumer has to infer a boundary from what happens to come
-    // first.
-    layout.orch = PTO2OrchestratorState::reserve_layout(arena, static_cast<int32_t>(task_window_sizes[0]));
-
-    layout.off_copied_begin = arena.total_size();
-    layout.off_runtime = arena.reserve(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE);
-    layout.off_copied_end = arena.total_size();
-
+    // Reservation order is the zone partition (see PTO2RuntimeArenaLayout):
+    // everything the device initializes itself, then the one copied range. Each
+    // zone is contiguous, so bind is a single copy and no consumer has to infer a
+    // boundary from what happens to come first.
+    //
+    // The copied zone comes last of the two so the device's shared-memory tail can
+    // begin where it ends, making the two adjacent and the upload one copy.
     layout.off_sm_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
     layout.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
     layout.off_scheduler = arena.reserve(sizeof(PTO2SchedulerState), alignof(PTO2SchedulerState));
     layout.sched = PTO2SchedulerState::reserve_layout(arena);
+
+    layout.off_copied_begin = arena.total_size();
+    // Padded to a PTO2_ALIGN_SIZE boundary: the shared-memory image starts at
+    // off_copied_end on the device and its segment offsets are aligned from there.
+    layout.off_runtime = arena.reserve(PTO2_ALIGN_UP(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE), PTO2_ALIGN_SIZE);
+    layout.off_copied_end = arena.total_size();
+
+    layout.device_bytes = arena.total_size();
+    layout.orch = PTO2OrchestratorState::reserve_layout(arena, static_cast<int32_t>(task_window_sizes[0]));
 
     layout.arena_size = arena.total_size();
     return layout;
@@ -360,9 +365,8 @@ PTO2Runtime *runtime_init_data_from_layout(
  * and initializes the scheduler (ready / sync / dummy / graph queues) against
  * the device SM. The orchestrator is deliberately left zeroed: the host-orch
  * path (run_host_orchestration) initializes it against the host SM once that
- * buffer exists, then relocates it for the device. Initializing it here would
- * be dead work — overwritten by that re-init, and the orchestrator arena block
- * is never uploaded to the device. Caller must follow up with
+ * buffer exists. Initializing it here would be dead work — overwritten by that
+ * re-init, and the orchestrator arena block is never uploaded to the device. Caller must follow up with
  * runtime_wire_arena_pointers. Returns the arena-resident PTO2Runtime*, or
  * nullptr on failure.
  */
@@ -388,10 +392,10 @@ PTO2Runtime *runtime_init_data_from_layout(
     // Two components are deliberately not initialized here.
     //
     // The orchestrator is initialized by the host-orch path
-    // (run_host_orchestration) against the host SM once it is allocated, then
-    // relocated for the device. Doing it here would be dead work: its arena
-    // content (tensormap + seen_epoch memset) is immediately overwritten by that
-    // re-init, and the orchestrator block is host-only anyway.
+    // (run_host_orchestration) against the host SM once it is allocated. Doing it
+    // here would be dead work: its arena content (tensormap + seen_epoch memset)
+    // is immediately overwritten by that re-init, and the orchestrator block is
+    // host-only anyway.
     //
     // The scheduler and sm_handle live in the device-only zone, so their bytes
     // never travel; the AICPU initializes them at boot. Writing them here would
@@ -405,9 +409,14 @@ void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayou
     rt->sm_handle = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(layout.off_sm_handle));
     rt->aicore_mailbox = static_cast<AICoreCompletionMailbox *>(arena.region_ptr(layout.off_mailbox));
     rt->scheduler = static_cast<PTO2SchedulerState *>(arena.region_ptr(layout.off_scheduler));
-    rt->orchestrator.wire_arena_pointers(layout.orch, arena, rt->scheduler);
     rt->scheduler->wire_arena_pointers(layout.sched, arena);
 }
+
+void runtime_wire_host_only_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt) {
+    rt->orchestrator.wire_arena_pointers(layout.orch, arena, rt->scheduler);
+}
+
+void runtime_clear_host_only_pointers(PTO2Runtime *rt) { rt->orchestrator.destroy(); }
 
 void runtime_destroy(PTO2Runtime *rt, DeviceArena & /*arena*/) {
     // Arena buffer is pooled across runs by DeviceRunner — never freed here.

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
@@ -45,14 +45,17 @@ uint64_t PTO2SharedMemoryHandle::calculate_size_per_ring(const uint64_t task_win
 // Creation and Destruction
 // =============================================================================
 
-void PTO2SharedMemoryHandle::setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+void PTO2SharedMemoryHandle::setup_pointers_per_ring(
+    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch, uint64_t payload_bytes
+) {
+    (void)task_window_sizes;
     char *base = (char *)sm_base;
     header = (PTO2SharedMemoryHeader *)base;
 
     // Per-ring descriptors / payloads / slot_states — offsets from the single
     // source of truth (pto2_sm_layout::ring_segment_offsets), so this setup and
     // the device-address helpers cannot drift.
-    auto off = pto2_sm_layout::ring_segment_offsets(task_window_sizes[0]);
+    auto off = pto2_sm_layout::ring_segment_offsets_with_payload_bytes(pitch, payload_bytes);
     auto &ring = header->ring;
     ring.task_descriptors = (PTO2TaskDescriptor *)(base + off.descriptors);
     ring.task_payloads = (PTO2TaskPayload *)(base + off.payloads);
@@ -65,7 +68,7 @@ void PTO2SharedMemoryHandle::setup_pointers(uint64_t task_window_size) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
     }
-    setup_pointers_per_ring(task_window_sizes);
+    setup_pointers_per_ring(task_window_sizes, task_window_size, task_window_size * sizeof(PTO2TaskPayload));
 }
 
 bool PTO2SharedMemoryHandle::init(
@@ -90,21 +93,30 @@ bool PTO2SharedMemoryHandle::init_per_ring(
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers_per_ring(task_window_sizes);
+    setup_pointers_per_ring(task_window_sizes, task_window_sizes[0], task_window_sizes[0] * sizeof(PTO2TaskPayload));
     init_header_per_ring(task_window_sizes, heap_sizes);
     return true;
 }
 
 bool PTO2SharedMemoryHandle::attach_populated(
-    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t live_slots,
+    uint64_t payload_bytes
 ) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
-    if (sm_size_arg < calculate_size_per_ring(task_window_sizes)) return false;
-
+    // A pitch above the capacity would name a slot the ring cannot address, and one
+    // below what the host used would place every segment past the descriptors
+    // short. This is the whole contract between the two sides, checked once at
+    // attach rather than trusted.
+    if (live_slots == 0 || live_slots > task_window_sizes[0]) return false;
+    if (payload_bytes > task_window_sizes[0] * sizeof(PTO2TaskPayload)) return false;
+    // The region holds the compacted image, so that is what has to fit — the ring
+    // capacity is no longer its size.
+    const uint64_t image_end = pto2_sm_layout::ring_segment_offsets_with_payload_bytes(live_slots, payload_bytes).end;
+    if (sm_size_arg < image_end) return false;
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers_per_ring(task_window_sizes);
+    setup_pointers_per_ring(task_window_sizes, live_slots, payload_bytes);
     // Deliberately NO init_header_per_ring: the SM already holds the host
     // orchestrator's task graph (descriptors, slot states, ring counters).
     return true;

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/runtime.cpp
@@ -35,6 +35,7 @@ Runtime::Runtime() {
     aicpu_allowed_cpu_count = 0;
     aicpu_launch_count = 0;
     host_total_tasks = 0;
+    sm_payload_bytes = 0;
 
     // Initialize shared-memory / orchestration argument plumbing
     gm_sm_ptr_ = nullptr;

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -735,7 +735,6 @@ int DeviceRunner::finalize() {
     release_callable_state();
 
     unload_executor_binaries();
-    release_graph_definition_buffers();
 
     for (auto &bank : arena_banks_) {
         bank->gm_heap.release();

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -229,9 +229,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
     // Boot: the last AICPU thread (aicpu_thread_num_ - 1) performs the one-time
     // host-orch attach. host_build_graph's orchestrator already ran on the host,
-    // which also relocated every cross-task pointer to its final device address
-    // before H2D — so the SM/arena this thread sees are already fully
-    // device-addressed. This thread attaches the prebuilt arena, points the SM
+    // and every cross-task reference it wrote is an offset from its own block, so
+    // the SM/arena this thread sees need no address fixup. This thread attaches
+    // the prebuilt arena, points the SM
     // handle's ring-header pointers at the device SM WITHOUT resetting the
     // host-populated data, hands the host-computed task count to the scheduler,
     // and releases the other threads. It then falls through and schedules its own
@@ -264,14 +264,24 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             runtime_wire_arena_pointers(runtime_arena_, rt->prebuilt_layout, rt);
 
             void *sm_ptr = runtime->get_gm_sm_ptr();
-            uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(rt->prebuilt_layout.task_window_sizes);
+            // The image the host shipped is pitched to the submitted task count,
+            // not to the ring capacity, and the device region holds exactly that
+            // image — so its size comes from the same pitch. attach_populated
+            // rejects a pitch outside (0, capacity] and a region too small for it.
+            const uint64_t live_slots =
+                pto2_sm_layout::live_slot_pitch(static_cast<uint64_t>(runtime->host_total_tasks));
+            const uint64_t payload_bytes = runtime->sm_payload_bytes;
+            const uint64_t sm_size =
+                pto2_sm_layout::ring_segment_offsets_with_payload_bytes(live_slots, payload_bytes).end;
             // sm_handle and the scheduler state are the device-only zone: their
             // bytes never travel, so they start as whatever the pooled arena last
             // held. Zeroing the handle first is what makes attach_populated's
             // assignment of every field checkable here rather than by inspecting
             // attach_populated.
             memset(rt->sm_handle, 0, sizeof(*rt->sm_handle));
-            if (!rt->sm_handle->attach_populated(sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes)) {
+            if (!rt->sm_handle->attach_populated(
+                    sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes, live_slots, payload_bytes
+                )) {
                 LOG_ERROR("Thread %d: host-orch: sm_handle->attach_populated failed", thread_idx);
                 rt = nullptr;
                 run_rc = -1;
@@ -307,12 +317,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // to keep them alive).
             // NOTE: do NOT call rt_orchestration_done(rt) here. The HOST already
             // called it in run_host_orchestration; the orchestrator's own
-            // task-allocator pointers are intentionally NOT relocated (only the
-            // SM cross-task pointers and the host-built fanout adjacency —
-            // dep_pool / ready queues / fanout_head — were), so they still hold
-            // host addresses and mark_done()'s active_count() read would
-            // dereference host memory and fault the AICPU. on_orchestration_done
-            // only needs total_tasks and the scalar
+            // task-allocator pointers name host memory the device never reads, so
+            // mark_done()'s active_count() read would dereference it and fault the
+            // AICPU. on_orchestration_done only needs total_tasks and the scalar
             // orchestrator.inline_completed_tasks, both already valid.
             sched_ctx_.on_orchestration_done(runtime, rt, thread_idx, runtime->host_total_tasks);
             LOG_INFO("Thread %d: host-orch boot complete (%d tasks)", thread_idx, runtime->host_total_tasks);

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -9,7 +9,7 @@ host register: materialize + dlopen orchestration SO
         ↓
 host run/bind: stage external tensors, execute orchestration to completion
         ↓
-host: relocate the prebuilt graph image and copy it to device memory
+host: copy the prebuilt graph image to device memory
         ↓
 device: attach the image, classify tasks, dispatch with AICPU schedulers
         ↓
@@ -49,9 +49,8 @@ For each run, the host:
 2. reserves one backing arena for runtime/shared-memory subregions;
 3. binds the runtime to the orchestration DSO;
 4. calls the orchestration entry synchronously;
-5. finalizes task counts and the graph image;
-6. rewrites per-slot task/payload pointers to device addresses; and
-7. copies the shared-memory image and arena to the device.
+5. finalizes task counts and the graph image; and
+6. copies the shared-memory image and the arena's copied zone to the device.
 
 An orchestration fatal stops this sequence and is propagated through
 `orch_error_code`.
@@ -78,8 +77,9 @@ The shared image uses three per-slot structures:
 | `PTO2TaskSlotState` | Active mask, attributes, block/subtask counters, completion state, task/payload bindings |
 
 The host/device boundary is POD and position-independent. Fanins are integer
-producer IDs, not pointers. The only per-slot pointers are rebound to their final
-device addresses before H2D.
+producer IDs, not pointers, and a slot state names its payload and descriptor by a
+delta from its own address — so the image needs no fixup on either side of the
+copy.
 
 ### 3.1 What Ships: the Arena's Three Zones
 
@@ -97,16 +97,25 @@ Three rules decide every byte of the runtime arena:
 They partition the arena into three contiguous zones, and `runtime_reserve_layout`
 reserves them in this order:
 
-| Zone | Regions | Copied | Written by |
-| ---- | ------- | ------ | ---------- |
-| host-only | orchestrator block: `fanin_seen_epoch` / `scope_tasks` / TensorMap, ~8.5 MB | never | host, during graph construction |
-| copied | `[off_copied_begin, off_copied_end)`: the runtime header | whole zone, one copy | host |
-| device-only | `sm_handle`, `PTO2SchedulerState` and its thirteen queue slot arrays, the completion mailbox | never | AICPU at boot |
+| Zone | Regions | Copied | Allocated on device | Written by |
+| ---- | ------- | ------ | ------------------- | ---------- |
+| device-only | `sm_handle`, the completion mailbox, `PTO2SchedulerState` and its thirteen queue slot arrays | never | yes | AICPU at boot |
+| copied | `[off_copied_begin, off_copied_end)`: the runtime header | whole zone, one copy | yes | host |
+| host-only | orchestrator block: `fanin_seen_epoch` / `scope_tasks` / TensorMap, ~9.3 MB | never | **no** | host, during graph construction |
 
-Putting the copied zone **between** the two zones that are never copied is what
-makes `bind` a single contiguous `copy_to_device`. Both bounds are layout fields,
-so no consumer infers a boundary from which region happens to be reserved first —
-`bind_callable_to_runtime_impl` asserts only that they are ordered and in range.
+The copied zone is the fixed device prefix's final zone. After orchestration, its
+end is followed by the compact shared-memory image and then the Graph Definitions
+and submissions. `bind` stages those three run-generated regions contiguously and
+uses one `copy_to_device` starting at `off_copied_begin`.
+
+**Why the host-only zone comes last.** No device code dereferences a pointer into
+the orchestrator block — hbg has no device-side orchestrator, and the one
+orchestrator field the scheduler reads, `inline_completed_tasks`, is a scalar in
+the runtime header. Putting the block at the tail lets `setup_static_arena` request
+only `layout.device_bytes`, the copied + device-only prefix, so those ~9.3 MB are
+never reserved on the device at all. `runtime_wire_host_only_pointers` is therefore
+host-only, and `runtime_clear_host_only_pointers` drops those pointers before the
+copied zone is uploaded so no host address crosses the boundary.
 
 **Why the scheduler state is device-written.** `PTO2SchedulerState` holds no
 per-run content: `sm_header` and the ring pointer derive from a pooled SM base,
@@ -163,11 +172,24 @@ writes `[0, total_tasks)`, and the device boots scheduler-only and reads no SM s
 past `total_tasks`. So the SM H2D shipped each run is bounded, not capacity-sized —
 the contract that keeps `bind` proportional to the workload.
 
-The header is zeroed on the host; `descriptors`, `payloads`, `slot_states` and
-`completion_flags` are each written per task at submit and H2D-uploaded bounded to
-`[0, total_tasks)`. Per-slot reset is init-on-write in `orch::prepare_task` as each
-slot is claimed — there is no window-wide reset. The four segments travel as four
-copies rather than one because ring-sized tails separate their live prefixes.
+The header is zeroed on the host; `descriptors`, `slot_states` and
+`completion_flags` are each written per task at submit. Payloads come from one
+`TaskPayloadSpace`: every slot stores a self-relative reference to its record, so
+Graph tasks can carry more tensors or scalars than an ordinary fixed payload.
+Per-slot reset is init-on-write in `orch::prepare_task` as each slot is claimed —
+there is no window-wide reset.
+
+At the end of orchestration, compaction restacks the descriptor prefix, the exact
+live TaskPayloadSpace byte range, the slot-state prefix, and the completion flags.
+It preserves each slot's payload offset while rebinding its relative references.
+That compact SM image follows the copied runtime header and precedes the Graph
+block in one staging buffer, so all host-generated runtime data travels in one
+H2D copy.
+
+The heap is committed first because host construction needs its device addresses.
+The runtime arena is not committed until the compact SM and Graph block sizes are
+known; the arena bank then allocates it once or reuses a prior allocation whose
+capacity is sufficient.
 
 ## 4. Whole-Graph Capacity
 

--- a/src/a5/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a5/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
@@ -38,7 +38,7 @@ The execution order is:
 
 1. The host loads and calls the orchestration shared object.
 2. Orchestration builds the entire task graph and returns.
-3. The host relocates and copies the graph image to device memory.
+3. The host copies the graph image to device memory.
 4. AICPU schedulers boot and dispatch the graph.
 
 A producer submitted in step 1 cannot become `COMPLETED` until step 4. Waiting

--- a/src/a5/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a5/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
@@ -33,8 +33,9 @@ The shared graph image separates stable task identity from scheduling state:
 - `PTO2TaskSlotState` contains the active mask, task attributes, logical block
   count, subtask counters, completion state, and descriptor/payload bindings.
 
-This image is built on the host, relocated once, and copied to the device. It
-contains no fanout adjacency or dependency-pool pointers.
+This image is built on the host and copied to the device verbatim. It contains
+no fanout adjacency or dependency-pool pointers, and its descriptor/payload
+bindings are deltas from the slot state's own address rather than pointers.
 
 ## Resource Shapes
 

--- a/src/a5/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a5/runtime/host_build_graph/docs/profiling_levels.md
@@ -240,12 +240,12 @@ appear.
 
 ### What is recorded
 
-Seventeen kinds, all on the host monotonic clock the `[STRACE]` host spans use,
+Sixteen kinds, all on the host monotonic clock the `[STRACE]` host spans use,
 so records and spans read against each other with no alignment step.
 
 | Group | Kinds |
 | ----- | ----- |
-| Bind segments (partition the stage) | `args`, `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init`, `host_orch`, `graph_upload`, `relocate`, `sm_h2d`, `arena_h2d`, `host_view_close` |
+| Bind segments (partition the stage) | `args`, `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init`, `host_orch`, `graph_upload`, `arena_h2d`, `host_view_close` |
 | Orchestrator operations (inside `host_orch`) | `submit_task`, `alloc_tensors`, `record_node`, `graph_submit`, `build_definition` |
 
 Three of the orchestrator kinds end with a task submitted — `submit_task`,
@@ -312,7 +312,7 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
   | Key | Kinds | Rendered as |
   | --- | ----- | ----------- |
   | `host_orchestrator_phases` | the task-submitting kinds | `Host Orchestrator` process |
-  | `host_device_uploads` | `graph_upload`, `sm_h2d`, `arena_h2d`, with byte counts | `Host Prepare` / `H2D` lane |
+  | `host_device_uploads` | `arena_h2d`, with the complete runtime-image byte count | `Host Prepare` / `H2D` lane |
 
   The upload lane is the one place the whole question — orchestration plus H2D
   inside a millisecond — is visible against the device execution it precedes; the

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -79,13 +79,16 @@
 extern "C" const PipelineContract *get_pipeline_contract(void) {
     // Host orchestration materializes this run's own graph into the image it
     // uploads, so every device-resident region carries per-run content.
+    //
+    // PTO_PIPELINE_GM_SM is absent because hbg has no separate shared-memory
+    // region: the image is the tail of the runtime-image region, so it shares that
+    // region's classification. The arena-topology check skips an absent kind.
     static const PipelineContract contract = {
         PTO_PIPELINE_CONTRACT_ABI_VERSION,
-        5,
+        4,
         2,
         {
             {PTO_PIPELINE_GM_HEAP, PTO_PIPELINE_HOST_PER_RUN, 0},
-            {PTO_PIPELINE_GM_SM, PTO_PIPELINE_HOST_PER_RUN, 0},
             {PTO_PIPELINE_RUNTIME_IMAGE, PTO_PIPELINE_HOST_PER_RUN, 0},
             {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
             {PTO_PIPELINE_AICORE_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
@@ -288,6 +291,18 @@ static bool resolve_ring_config(
             LOG_ERROR("ring_heap[%d]=%" PRIu64 " must be >= 1024", r, eff_heap_sizes[r]);
             return false;
         }
+        // A slot state reaches its payload and descriptor through a 32-bit
+        // self-relative delta, so every pair of addresses in the shared-memory
+        // image must be within INT32_MAX of each other.
+        const uint64_t sm_bytes = pto2_sm_layout::ring_segment_offsets(eff_task_window_sizes[r]).end;
+        if (sm_bytes > static_cast<uint64_t>(INT32_MAX)) {
+            LOG_ERROR(
+                "ring_task_window[%d]=%" PRIu64 " needs a %" PRIu64 "-byte shared memory image, past the %d-byte limit "
+                "a slot state's self-relative payload/descriptor delta can span",
+                r, eff_task_window_sizes[r], sm_bytes, INT32_MAX
+            );
+            return false;
+        }
     }
 
     return true;
@@ -317,12 +332,10 @@ static int32_t pto2_read_runtime_status(Runtime *runtime, const HostApi *api, PT
 namespace {
 
 // host_build_graph is host-orchestration-first: the HOST dlopens the
-// orchestration .so and runs it to completion. The shared memory + arena carry
-// host-DDR cross-task pointers (slot_state.task/payload,
-// payload.fanin_local_ids[], dep_pool/ready queues); the host relocates them to
-// their final device addresses (relocate_host_orch_image, below) BEFORE the H2D
-// copy, so the device receives a fully device-addressed image and schedules
-// only — no on-device pointer fixup.
+// orchestration .so and runs it to completion. Every cross-task reference the
+// shared memory and arena carry is an offset or an index from its own block, so
+// the image the device schedules is the bytes the host wrote — there is nothing
+// to fix up after the H2D copy.
 
 bool write_all_bytes(int fd, const uint8_t *data, size_t size) {
     size_t total = 0;
@@ -376,189 +389,117 @@ struct HostOrchEntryPoints {
     OrchestrationBindFunc bind{nullptr};
 };
 
-// Run the orchestrator on the host. `rt` was built with its scheduler half
-// pointing at the device SM; here we re-point ONLY the orchestrator half at a
-// host SM mirror, run the orchestration entry against it, latch the submitted
-// task count, and H2D the populated SM to the device (the device scheduler
-// reads task descriptors from there). The device never dereferences the
-// orchestrator's SM pointers, so leaving them host-side is safe. Returns the
-// total task count (>= 0) on success, or -1 on failure.
-// host_build_graph host-orch: the orchestrator built the task graph in a host
-// SM mirror and (when wiring is folded into submit) the fanout adjacency in the
-// host arena, storing host-DDR addresses into the cross-task pointers. Relocate
-// them to their FINAL device addresses here on the host, BEFORE the SM/arena are
-// copied to the device — so the device receives a fully device-addressed image
-// and boots scheduler-only with no on-device pointer fixup.
-//
-// Relocated pointers span TWO regions with DIFFERENT deltas: the SM block
-// (slot_state.task/.payload, fanin_local_ids[], dep-entry.slot_state,
-// ready-queue slot.slot_state) and the arena block (slot_state.fanout_head,
-// dep-entry.next point into the SM but live in the arena).
-// Rather than track which delta each field needs, relocate() classifies every
-// pointer by the region it points INTO and applies that region's delta; foreign
-// and null pointers pass through untouched. The fanout adjacency is wired inline
-// during host submit, so dep_pool/ready are already populated here.
-//
-// The orchestrator's own task-allocator pointers are intentionally NOT relocated
-// (the device runs scheduler-only and never dereferences them, and must not call
-// rt_orchestration_done — the host already did). Multi-fanin spill is not yet
-// relocated; a task exceeding PTO2_FANIN_INLINE_CAP producers latches fatal here
-// (returns false) rather than shipping un-relocated host pointers to the device.
-// Returns false on any unrelocatable pointer so the caller can fail the prepare.
-static bool relocate_host_orch_image(
-    PTO2SharedMemoryHandle &host_sm_handle, uint64_t host_sm, uint64_t sm_size, int64_t sm_delta, uint64_t host_arena,
-    uint64_t arena_size, int64_t arena_delta
-) {
-    static_assert(PTO2_MAX_RING_DEPTH == 1, "relocate_host_orch_image assumes a single ring");
+// host_build_graph host-orch: the orchestrator builds the task graph in a host
+// shared-memory mirror, and every cross-task reference it stores is an offset or
+// an index from its own block. The bytes the host wrote are therefore the bytes
+// the device schedules, with no on-device or pre-copy pointer fixup.
 
-    // SM and arena windows must not overlap — relocate classifies a pointer by
-    // which window it falls in, so an overlap would misclassify and apply the
-    // wrong delta. Both are independent malloc-backed host buffers in practice;
-    // assert it so a future shared-buffer layout can't silently corrupt.
-    if (!(host_sm + sm_size <= host_arena || host_arena + arena_size <= host_sm)) {
-        LOG_ERROR(
-            "host-orch: SM window [%#lx,+%#lx) overlaps arena window [%#lx,+%#lx); cannot relocate", host_sm, sm_size,
-            host_arena, arena_size
-        );
+struct StagedDefinition {
+    const std::byte *host_image;
+    size_t bytes;
+    const GraphDefinition *definition;
+    size_t offset;
+};
+
+struct StagedSubmission {
+    const GraphSubmission *host_image;
+    PTO2TaskSlotState *outer_slot;
+    size_t definition_offset;
+    size_t offset;
+};
+
+struct GraphBlockPlan {
+    std::vector<StagedDefinition> definitions;
+    std::vector<StagedSubmission> submissions;
+    size_t bytes{0};
+};
+
+bool reserve_graph_region(size_t bytes, size_t alignment, size_t *cursor, size_t *offset) {
+    if (cursor == nullptr || offset == nullptr || alignment == 0 || (alignment & (alignment - 1)) != 0 ||
+        *cursor > SIZE_MAX - (alignment - 1)) {
         return false;
     }
-
-    bool ok = true;
-    auto relocate = [&](auto *&pointer) {
-        using Pointer = std::remove_reference_t<decltype(pointer)>;
-        const uint64_t address = reinterpret_cast<uint64_t>(pointer);
-        if (address == 0) return;
-        if (address >= host_sm && address < host_sm + sm_size) {
-            pointer = reinterpret_cast<Pointer>(static_cast<uintptr_t>(address + sm_delta));
-        } else if (address >= host_arena && address < host_arena + arena_size) {
-            pointer = reinterpret_cast<Pointer>(static_cast<uintptr_t>(address + arena_delta));
-        } else {
-            // A non-null pointer in neither window is an external/host address
-            // the device would dereference verbatim after H2D. No field should
-            // legitimately carry one; latch fatal rather than ship a host VA to
-            // the device (silent AICPU corruption otherwise).
-            LOG_ERROR(
-                "host-orch: pointer %#lx is outside both SM and arena windows; cannot relocate for device", address
-            );
-            ok = false;
-        }
-    };
-
-    PTO2SharedMemoryHeader *header = host_sm_handle.header;
-    if (header != nullptr) {
-        PTO2SharedMemoryRingHeader &ring = header->ring;
-        const int32_t count = ring.fc.current_task_index.load(std::memory_order_acquire);
-        for (int32_t slot = 0; slot < count; ++slot) {
-            PTO2TaskSlotState *state = &ring.slot_states[slot];
-            // Polling: fanin is a flat array of position-independent local-id
-            // integers on the payload, so only the two per-slot arena/SM
-            // pointers need relocating. There is no fanout_head/dep_pool graph
-            // and no host-seeded ready queue (the device boot scan classifies),
-            // so those relocation passes are gone.
-            relocate(state->task);
-            relocate(state->payload);
-        }
-    }
-    return ok;
+    const size_t aligned = (*cursor + alignment - 1) & ~(alignment - 1);
+    if (bytes > SIZE_MAX - aligned) return false;
+    *offset = aligned;
+    *cursor = aligned + bytes;
+    return true;
 }
 
-bool upload_graph_submissions(
-    Runtime *runtime, const HostApi *api, GraphHostState &graph_state, uint64_t &uploaded_bytes
-) {
-    uploaded_bytes = 0;
-    const size_t count = graph_host_upload_count(graph_state);
-    // Pass 1: upload each distinct Definition once as a shared device object
-    // ([GraphDefinitionHeader][Definition image]) keyed by content identity.
-    // Submissions reference the object's GM address, so this pass completing
-    // before any submission is uploaded is what makes the reference safe —
-    // the device boots only after both passes.
+bool plan_graph_block(GraphHostState &graph_state, GraphBlockPlan *plan, uint64_t &uploaded_bytes) {
+    if (plan == nullptr) return false;
+
+    // Compute and validate the complete layout before asking the arena bank to
+    // allocate. Definitions lead the block; fixed-size submissions follow and
+    // refer to their Definition by device_base + offset.
     GraphHostDefinitionList definitions = graph_host_definitions(graph_state);
-    struct UploadedDefinition {
-        void *device_object;               // GM address; host must not dereference
-        const GraphDefinition *host_view;  // the host-side image the object was built from
-    };
-    std::unordered_map<uint64_t, UploadedDefinition> definition_objects;
+    plan->definitions.reserve(definitions.entries.size());
+    std::unordered_map<uint64_t, std::pair<size_t, const GraphDefinition *>> definition_offsets;
     for (const GraphHostDefinition &entry : definitions.entries) {
         if (entry.data == nullptr || entry.bytes < sizeof(GraphDefinition)) continue;
         const auto *definition = reinterpret_cast<const GraphDefinition *>(entry.data);
-        if (definition->total_bytes != entry.bytes || definition->full_key != entry.full_key) continue;
-        const size_t object_bytes = sizeof(GraphDefinitionHeader) + entry.bytes;
-        void *object =
-            api->acquire_graph_definition_buffer(entry.full_key, object_bytes, alignof(GraphDefinitionHeader));
-        if (object == nullptr) {
-            LOG_ERROR(
-                "host-orch: failed to retain %zu bytes for Graph Definition key=%#llx", object_bytes,
-                static_cast<unsigned long long>(entry.full_key)
-            );
+        if (definition->total_bytes != entry.bytes || definition->full_key != entry.full_key) return false;
+        if (entry.bytes > SIZE_MAX - sizeof(GraphDefinitionHeader)) return false;
+        size_t offset = 0;
+        if (!reserve_graph_region(
+                sizeof(GraphDefinitionHeader) + entry.bytes, alignof(GraphDefinitionHeader), &plan->bytes, &offset
+            )) {
             return false;
         }
-        std::vector<std::byte> staging(object_bytes, std::byte{0});
-        auto *header = reinterpret_cast<GraphDefinitionHeader *>(staging.data());
-        header->magic = GRAPH_DEFINITION_OBJECT_MAGIC;
-        header->verify_state.store(
-            static_cast<uint32_t>(GraphDefinitionVerifyState::UPLOADED), std::memory_order_relaxed
-        );
-        header->definition_bytes = static_cast<uint32_t>(entry.bytes);
-        header->content_hash = definition->content_hash;
-        header->full_key = definition->full_key;
-        std::memcpy(staging.data() + sizeof(GraphDefinitionHeader), entry.data, entry.bytes);
-        if (api->copy_to_device(object, staging.data(), object_bytes) != 0) {
-            LOG_ERROR("host-orch: failed to upload Graph Definition object");
-            return false;
-        }
-        definition_objects.emplace(definition->content_hash, UploadedDefinition{object, definition});
-        uploaded_bytes += object_bytes;
+        definition_offsets.emplace(definition->content_hash, std::make_pair(offset, definition));
+        plan->definitions.push_back({entry.data, entry.bytes, definition, offset});
     }
 
-    // Pass 2: per-submission execution storage + the small reference image.
+    const size_t count = graph_host_upload_count(graph_state);
+    plan->submissions.reserve(count);
     for (size_t index = 0; index < count; ++index) {
         std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
         if (!upload.has_value() || upload->outer_slot == nullptr || upload->data == nullptr ||
-            upload->bytes < sizeof(GraphSubmission) || upload->outer_slot->task_kind != TaskKind::GRAPH ||
+            upload->bytes != sizeof(GraphSubmission) || upload->outer_slot->task_kind != TaskKind::GRAPH ||
             upload->outer_slot->task == nullptr) {
             LOG_ERROR("host-orch: invalid pending Graph POD image");
             return false;
         }
-        auto *submission = reinterpret_cast<GraphSubmission *>(upload->data);
-        if (!graph_submission_wire_size_valid(*submission, upload->bytes)) {
-            LOG_ERROR("host-orch: Graph submission size does not match its POD image");
+        const auto *submission = reinterpret_cast<const GraphSubmission *>(upload->data);
+        auto definition_it = definition_offsets.find(submission->definition_hash);
+        if (definition_it == definition_offsets.end()) {
+            LOG_ERROR("host-orch: Graph submission has no packed Definition object");
             return false;
         }
-        auto object_it = definition_objects.find(submission->definition_hash);
-        if (object_it == definition_objects.end() || object_it->second.device_object == nullptr) {
-            LOG_ERROR("host-orch: Graph submission has no uploaded Definition object");
-            return false;
-        }
-        // Checked against the host-side Definition image the device object was
-        // built from; the GM object itself is never dereferenced on the host.
-        // Execution storage needs no retained buffer: it is the tail of the
-        // outer task's own heap allocation, which graph_submit_definition sized
-        // to required_heap + execution_storage_bytes.
-        const GraphDefinition *definition = object_it->second.host_view;
+        const GraphDefinition *definition = definition_it->second.second;
         if (definition->task_count == 0 || definition->task_count > GRAPH_MAX_NODES ||
             definition->full_key != submission->graph_key || definition->execution_storage_bytes == 0) {
             LOG_ERROR("host-orch: invalid Graph Definition for submission");
             return false;
         }
-        submission->definition_addr = reinterpret_cast<uint64_t>(object_it->second.device_object);
-        submission->local_execution = 0;
-        submission->activation_gate = 0;
-
-        void *device_submission = api->device_malloc(upload->bytes);
-        if (device_submission == nullptr) {
-            LOG_ERROR("host-orch: failed to allocate %zu bytes for Graph submission", upload->bytes);
-            return false;
-        }
-        if (api->copy_to_device(device_submission, upload->data, upload->bytes) != 0) {
-            LOG_ERROR("host-orch: failed to upload Graph submission POD image");
-            api->device_free(device_submission);
-            return false;
-        }
-        upload->outer_slot->graph_context = device_submission;
-        runtime->tensor_pairs_.push_back({nullptr, device_submission, upload->bytes, false});
-        uploaded_bytes += static_cast<uint64_t>(upload->bytes);
+        size_t offset = 0;
+        if (!reserve_graph_region(sizeof(GraphSubmission), PTO2_ALIGN_SIZE, &plan->bytes, &offset)) return false;
+        plan->submissions.push_back({submission, upload->outer_slot, definition_it->second.first, offset});
     }
+    uploaded_bytes = plan->bytes;
     return true;
+}
+
+void stage_graph_block(const GraphBlockPlan &plan, char *block_base, char *device_block_base) {
+    for (const StagedDefinition &entry : plan.definitions) {
+        auto *header = reinterpret_cast<GraphDefinitionHeader *>(block_base + entry.offset);
+        header->magic = GRAPH_DEFINITION_OBJECT_MAGIC;
+        header->verify_state.store(
+            static_cast<uint32_t>(GraphDefinitionVerifyState::UPLOADED), std::memory_order_relaxed
+        );
+        header->definition_bytes = static_cast<uint32_t>(entry.bytes);
+        header->content_hash = entry.definition->content_hash;
+        header->full_key = entry.definition->full_key;
+        std::memcpy(block_base + entry.offset + sizeof(GraphDefinitionHeader), entry.host_image, entry.bytes);
+    }
+    for (const StagedSubmission &entry : plan.submissions) {
+        GraphSubmission submission = *entry.host_image;
+        submission.definition_addr = reinterpret_cast<uint64_t>(device_block_base + entry.definition_offset);
+        submission.local_execution = 0;
+        submission.activation_gate = 0;
+        std::memcpy(block_base + entry.offset, &submission, sizeof(submission));
+        entry.outer_slot->graph_context = device_block_base + entry.offset;
+    }
 }
 
 struct GraphHostStateBinding {
@@ -573,7 +514,7 @@ struct GraphHostStateBinding {
 
 int32_t run_host_orchestration(
     Runtime *runtime, const HostApi *api, HostTensorAccessor &tensor_access, PTO2Runtime *rt, DeviceArena &host_arena,
-    const PTO2RuntimeArenaLayout &layout, void *device_sm, uint64_t sm_size, void *device_arena, void *gm_heap,
+    const PTO2RuntimeArenaLayout &layout, uint64_t sm_size, void *gm_heap,
     const uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH],
     void *host_orch_func_ptr, const ChipTaskArgs &orch_l2
 ) {
@@ -586,8 +527,14 @@ int32_t run_host_orchestration(
     // orch::prepare_task and shipped bounded to total_tasks below.
     const pto2_sm_layout::PTO2RingSegmentOffsets sm_segs =
         pto2_sm_layout::ring_segment_offsets(eff_task_window_sizes[0]);
-    std::unique_ptr<uint8_t[]> host_sm_buf(new uint8_t[sm_size]);
-    void *host_sm = host_sm_buf.get();
+    // Over-allocated and rounded up: every segment offset is a multiple of
+    // PTO2_ALIGN_SIZE and PTO2TaskSlotState is alignas(64), which a plain
+    // new uint8_t[] does not guarantee.
+    std::unique_ptr<uint8_t[]> host_sm_buf(new uint8_t[sm_size + PTO2_ALIGN_SIZE]);
+    void *host_sm = reinterpret_cast<void *>(
+        (reinterpret_cast<uintptr_t>(host_sm_buf.get()) + PTO2_ALIGN_SIZE - 1) &
+        ~static_cast<uintptr_t>(PTO2_ALIGN_SIZE - 1)
+    );
     std::memset(host_sm, 0, sm_segs.descriptors);
 
     // Re-point the orchestrator half at the host SM (scheduler keeps device SM).
@@ -673,6 +620,25 @@ int32_t run_host_orchestration(
     }
 #endif
 
+    // A latched fatal means the graph in the mirror is not the graph the orchestration
+    // described — a heap or tensormap exhaustion drops tasks, a fanin overflow drops
+    // edges. Uploading it would launch the device on an incomplete graph and surface
+    // the cause as whatever the device notices second, usually a scheduler timeout.
+    const int32_t orch_error = pto2_sm_layout::orch_error_code_addr(host_sm)->load(std::memory_order_acquire);
+    if (orch_error != PTO2_ERROR_NONE || rt->orchestrator.fatal) {
+        // The latched code is the diagnosis, so it is what the caller sees — through the
+        // same mapping the run path uses, since a caller cannot tell which of the two
+        // noticed. A fatal with no code left to read is the only generic failure.
+        const int32_t status =
+            orch_error != PTO2_ERROR_NONE ? runtime_status_from_error_codes(orch_error, PTO2_ERROR_NONE) : -1;
+        LOG_RUNTIME_FAILURE(orch_error, PTO2_ERROR_NONE, status);
+        LOG_ERROR(
+            "host-orch: refusing to upload an incomplete graph after %" PRIu64 " heap bytes",
+            rt->orchestrator.ring.task_allocator.heap_used_bytes()
+        );
+        return status;
+    }
+
     const int32_t total_tasks = pto2_sm_layout::ring_current_task_index_addr(host_sm)->load(std::memory_order_acquire);
     {
         char attrs[96];
@@ -685,9 +651,12 @@ int32_t run_host_orchestration(
     // After the span closes: the reduction walks a few hundred records and emits
     // five markers, which must not be charged to the pass it measures.
 
+    // Plan the Definition and submission tail before growing the arena. No device
+    // allocation or copy occurs until every byte count is known.
     const int64_t t_graph_ns = bind_now_ns();
     uint64_t graph_bytes = 0;
-    if (!upload_graph_submissions(runtime, api, *graph_state, graph_bytes)) return -1;
+    GraphBlockPlan graph_plan;
+    if (!plan_graph_block(*graph_state, &graph_plan, graph_bytes)) return -1;
     {
         char attrs[96];
         snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, graph_host_upload_count(*graph_state), graph_bytes);
@@ -702,52 +671,85 @@ int32_t run_host_orchestration(
     }
     host_phase_trace_note_submitted(static_cast<uint64_t>(total_tasks));
 
-    // Relocate the host-DDR cross-task pointers to their final DEVICE addresses
-    // on the host, before the SM and arena leave for the device. Pointers into
-    // the SM shift by sm_delta; pointers into the arena (fanout adjacency, wiring
-    // queue) shift by arena_delta. After this both the SM and arena carry device
-    // addresses, so the device boots scheduler-only.
-    const int64_t sm_delta = static_cast<int64_t>(reinterpret_cast<uint64_t>(device_sm)) -
-                             static_cast<int64_t>(reinterpret_cast<uint64_t>(host_sm));
-    const int64_t arena_delta = static_cast<int64_t>(reinterpret_cast<uint64_t>(device_arena)) -
-                                static_cast<int64_t>(reinterpret_cast<uint64_t>(host_arena.base()));
-    const int64_t t_reloc_ns = bind_now_ns();
-    if (!relocate_host_orch_image(
-            host_sm_handle, reinterpret_cast<uint64_t>(host_sm), sm_size, sm_delta,
-            reinterpret_cast<uint64_t>(host_arena.base()), layout.arena_size, arena_delta
-        )) {
-        LOG_ERROR("host-orch: relocation failed; refusing to H2D an image with unrelocated host pointers");
+    // Restack the live prefixes into one contiguous image. TaskPayloadSpace keeps
+    // variable-sized records in submission order, so its exact live byte count is
+    // copied as one segment and each slot is rebound by its payload offset.
+    const uint64_t nt = static_cast<uint64_t>(total_tasks);
+    const uint64_t payload_bytes = rt->orchestrator.task_payload_space_used_bytes;
+    runtime->sm_payload_bytes = payload_bytes;
+    const uint64_t image_bytes =
+        pto2_sm_layout::ring_segment_offsets_with_payload_bytes(pto2_sm_layout::live_slot_pitch(nt), payload_bytes).end;
+
+    // Only now is the size known, so this is where the device runtime region is
+    // committed. setup_static_arena grows per region and short-circuits a request
+    // it already covers, so the heap is untouched and repeated workloads reuse a
+    // sufficiently large runtime arena.
+    const int64_t t_sm_ns = bind_now_ns();
+    uint64_t total_heap_size = 0;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        total_heap_size += eff_heap_sizes[r];
+    }
+    // Device tails follow in order: shared memory, then Definitions and submissions.
+    const uint64_t off_graph_block = layout.off_copied_end + image_bytes;
+    const uint64_t device_arena_bytes = off_graph_block + graph_plan.bytes;
+    if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, device_arena_bytes) != 0) {
+        LOG_ERROR("host-orch: failed to commit %" PRIu64 " bytes of device runtime arena", device_arena_bytes);
         return -1;
     }
-    record_bind_phase(HostPhaseKind::BindRelocate, t_reloc_ns);
+    void *device_arena = api->acquire_pooled_runtime_arena();
+    if (device_arena == nullptr) {
+        LOG_ERROR("%s", "host-orch: failed to re-acquire the pooled runtime arena");
+        return -1;
+    }
+    char *arena_dev = static_cast<char *>(device_arena);
+    void *device_sm = arena_dev + layout.off_copied_end;
+    runtime->set_gm_sm_ptr(device_sm);
+    {
+        char attrs[96];
+        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, image_bytes);
+        record_bind_phase(HostPhaseKind::BindSharedMem, t_sm_ns, attrs, image_bytes);
+    }
 
-    // Ship only the live prefix of each segment: the device reads no slot past
-    // total_tasks, so upload header + descriptors[0,N), payloads[0,N),
-    // slot_states[0,N) and completion_flags[0,N) — never the ring-sized tails.
-    // header + descriptors[0,N) are contiguous, so that is a single copy.
-    const uint64_t nt = static_cast<uint64_t>(total_tasks);
-    const uint64_t hdr_desc_bytes = sm_segs.descriptors + nt * sizeof(PTO2TaskDescriptor);
-    char *host_base = static_cast<char *>(host_sm);
-    char *dev_base = static_cast<char *>(device_sm);
-    const int64_t t_sm_h2d_ns = bind_now_ns();
-    if (api->copy_to_device(dev_base, host_base, hdr_desc_bytes) != 0 ||
-        api->copy_to_device(dev_base + sm_segs.payloads, host_base + sm_segs.payloads, nt * sizeof(PTO2TaskPayload)) !=
-            0 ||
-        api->copy_to_device(
-            dev_base + sm_segs.slot_states, host_base + sm_segs.slot_states, nt * sizeof(PTO2TaskSlotState)
-        ) != 0 ||
-        api->copy_to_device(
-            dev_base + sm_segs.completion_flags, host_base + sm_segs.completion_flags, nt * sizeof(std::atomic<uint8_t>)
-        ) != 0) {
-        LOG_ERROR("host-orch: H2D of populated SM failed");
+    // One host source for one copy: the copied zone, the shared-memory image, and
+    // the submission block, at exactly the offsets they occupy on the device.
+    // Over-allocated and rounded up because every segment offset is
+    // PTO2_ALIGN_SIZE-aligned and PTO2TaskSlotState is alignas(64), which a byte
+    // vector's data() is not.
+    const uint64_t copied_bytes = layout.off_copied_end - layout.off_copied_begin;
+    const uint64_t upload_bytes = copied_bytes + image_bytes + graph_plan.bytes;
+    std::vector<std::byte> storage(upload_bytes + PTO2_ALIGN_SIZE, std::byte{0});
+    char *upload_base = reinterpret_cast<char *>(
+        (reinterpret_cast<uintptr_t>(storage.data()) + PTO2_ALIGN_SIZE - 1) &
+        ~static_cast<uintptr_t>(PTO2_ALIGN_SIZE - 1)
+    );
+
+    // Before the shared-memory mirror is compacted: this writes each outer task's
+    // graph_context into it, and compaction carries those slot updates.
+    stage_graph_block(graph_plan, upload_base + copied_bytes + image_bytes, arena_dev + off_graph_block);
+
+    // The orchestrator has finished, so its pointers into the host-only tail have
+    // no further reader on either side — and this header is about to be copied, so
+    // leaving them would carry host addresses to the device.
+    runtime_clear_host_only_pointers(rt);
+    std::memcpy(upload_base, static_cast<const char *>(host_arena.base()) + layout.off_copied_begin, copied_bytes);
+    const uint64_t compacted = pto2_sm_layout::compact_live_image(
+        static_cast<const char *>(host_sm), eff_task_window_sizes[0], nt, payload_bytes, upload_base + copied_bytes
+    );
+    always_assert(compacted == image_bytes);
+
+    const int64_t t_h2d_ns = bind_now_ns();
+    if (api->copy_to_device(arena_dev + layout.off_copied_begin, upload_base, upload_bytes) != 0) {
+        LOG_ERROR("host-orch: H2D of the runtime image failed");
         return -1;
     }
     {
-        const uint64_t sm_h2d_bytes = hdr_desc_bytes + nt * sizeof(PTO2TaskPayload) + nt * sizeof(PTO2TaskSlotState) +
-                                      nt * sizeof(std::atomic<uint8_t>);
         char attrs[96];
-        snprintf(attrs, sizeof(attrs), "nt=%" PRIu64 " bytes=%" PRIu64, nt, sm_h2d_bytes);
-        record_bind_phase(HostPhaseKind::BindSmH2d, t_sm_h2d_ns, attrs, sm_h2d_bytes);
+        snprintf(
+            attrs, sizeof(attrs),
+            "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " graph=%zu pbytes=%" PRIu64, nt,
+            upload_bytes, copied_bytes, image_bytes, graph_plan.bytes, payload_bytes
+        );
+        record_bind_phase(HostPhaseKind::BindArenaH2d, t_h2d_ns, attrs, upload_bytes);
     }
     return total_tasks;
 }
@@ -1036,18 +1038,25 @@ extern "C" int bind_callable_to_runtime_impl(
     }
     {
         char attrs[64];
-        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, static_cast<uint64_t>(layout.arena_size));
+        snprintf(
+            attrs, sizeof(attrs), "bytes=%" PRIu64 " device=%" PRIu64, static_cast<uint64_t>(layout.arena_size),
+            static_cast<uint64_t>(layout.device_bytes)
+        );
         record_bind_phase(HostPhaseKind::BindArenaBuild, t_arena_build_ns, attrs);
     }
 
     const int64_t t_static_arena_ns = bind_now_ns();
-    if (api->setup_static_arena(total_heap_size, sm_size, layout.arena_size) != 0) {
+    // Commit only the heap now: the host orchestrator needs its device addresses
+    // while building tasks. Shared memory belongs to the runtime-arena image, and
+    // that arena stays uncommitted until orchestration has calculated its exact
+    // SM, payload, Definition, and submission sizes.
+    if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, /*runtime_arena_size=*/0) != 0) {
         LOG_ERROR("Failed to setup pooled static arena");
         return -1;
     }
     {
         char attrs[96];
-        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " sm=%" PRIu64, total_heap_size, sm_size);
+        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " arena=deferred", total_heap_size);
         record_bind_phase(HostPhaseKind::BindStaticArena, t_static_arena_ns, attrs);
     }
 
@@ -1059,21 +1068,10 @@ extern "C" int bind_callable_to_runtime_impl(
         return -1;
     }
     runtime->set_gm_heap(gm_heap);
-
-    const int64_t t_sm_ns = bind_now_ns();
-    void *sm_ptr = api->acquire_pooled_gm_sm();
-    record_bind_phase(HostPhaseKind::BindSharedMem, t_sm_ns);
-    if (sm_ptr == nullptr) {
-        LOG_ERROR("Failed to acquire pooled PTO2 shared memory");
-        return -1;
-    }
-    runtime->set_gm_sm_ptr(sm_ptr);
-
-    void *runtime_arena_dev = api->acquire_pooled_runtime_arena();
-    if (runtime_arena_dev == nullptr) {
-        LOG_ERROR("Failed to acquire pooled runtime arena");
-        return -1;
-    }
+    // The shared memory is placed at the end of orchestration, so until then this
+    // bind has no SM. Clearing it keeps a failure before that point from leaving the
+    // previous bind's address for the error-code read to follow.
+    runtime->set_gm_sm_ptr(nullptr);
 
     // Set up orchestration state (consumed by the host orchestrator below)
     runtime->set_orch_args(device_args);
@@ -1089,13 +1087,24 @@ extern "C" int bind_callable_to_runtime_impl(
     // reset) + a handful of device-only field fixups.
     // -------------------------------------------------------------------------
     const int64_t t_runtime_init_ns = bind_now_ns();
-    PTO2Runtime *rt =
-        runtime_init_data_from_layout(host_arena, layout, PTO2_MODE_EXECUTE, sm_ptr, sm_size, gm_heap, eff_heap_sizes);
+    // No SM base: the scheduler and sm_handle are device-written now, so nothing
+    // here stores one, and the region is not even committed yet.
+    PTO2Runtime *rt = runtime_init_data_from_layout(
+        host_arena, layout, PTO2_MODE_EXECUTE, /*sm_dev_base=*/nullptr, sm_size, gm_heap, eff_heap_sizes
+    );
     if (rt == nullptr) {
         LOG_ERROR("runtime_init_data_from_layout failed");
         return -1;
     }
     runtime_wire_arena_pointers(host_arena, layout, rt);
+    runtime_wire_host_only_pointers(host_arena, layout, rt);
+    // Stash the layout inside the PTO2Runtime image so the AICPU can recover every
+    // arena-internal offset after the copy. It is written before orchestration
+    // because orchestration is what performs that copy, and the runtime header is
+    // part of what travels. The runtime arena's device base does NOT travel — it is
+    // on the host Runtime (set_prebuilt_arena below), since the AICPU needs that
+    // pointer before it can dereference the image.
+    rt->prebuilt_layout = layout;
     record_bind_phase(HostPhaseKind::BindRuntimeInit, t_runtime_init_ns);
 
     // host_build_graph host-orch: run the orchestrator on the host now, against
@@ -1112,8 +1121,8 @@ extern "C" int bind_callable_to_runtime_impl(
         ChipTaskArgs orch_l2;
         orch_l2.create_from_chip_args(device_args);
         int32_t total_tasks = run_host_orchestration(
-            runtime, api, tensor_access, rt, host_arena, layout, sm_ptr, sm_size, runtime_arena_dev, gm_heap,
-            eff_heap_sizes, eff_task_window_sizes, host_orch_func_ptr, orch_l2
+            runtime, api, tensor_access, rt, host_arena, layout, sm_size, gm_heap, eff_heap_sizes,
+            eff_task_window_sizes, host_orch_func_ptr, orch_l2
         );
         // The orchestrator is the only host-view reader; from here the device
         // owns these buffers, so drop the window on both exits.
@@ -1128,41 +1137,19 @@ extern "C" int bind_callable_to_runtime_impl(
         }
         if (total_tasks < 0) {
             LOG_ERROR("host-orch: orchestration run failed");
-            return -1;
+            return total_tasks;
         }
         runtime->host_total_tasks = total_tasks;
         LOG_INFO("host-orch: submitted %d tasks on host", total_tasks);
     }
 
-    // Stash the layout inside the PTO2Runtime image so the AICPU can recover
-    // every arena-internal offset after rtMemcpy. The runtime arena's device
-    // base does NOT travel in this image — it's on the host Runtime
-    // (set_prebuilt_arena below), since the AICPU needs that pointer
-    // *before* it can dereference the image.
-    rt->prebuilt_layout = layout;
-
-    // The arena is partitioned into three zones (see PTO2RuntimeArenaLayout) and
-    // only the middle one is copied: the host-only orchestrator block sits before
-    // it, and the regions the device initializes itself (sm_handle, scheduler
-    // state, queue slot arrays) sit after it. So bind is one copy of one range,
-    // with both bounds taken from the layout rather than inferred from a
-    // reservation order here.
-    const size_t copied_begin = layout.off_copied_begin;
-    const size_t copied_end = layout.off_copied_end;
-    always_assert(copied_begin <= copied_end && copied_end <= layout.arena_size);
-    char *arena_host = static_cast<char *>(host_arena.base());
-    char *arena_dev = static_cast<char *>(runtime_arena_dev);
-    const int64_t t_arena_h2d_ns = bind_now_ns();
-    int rc_upload = api->copy_to_device(arena_dev + copied_begin, arena_host + copied_begin, copied_end - copied_begin);
-    if (rc_upload != 0) {
-        LOG_ERROR("Failed to rtMemcpy prebuilt runtime arena to device (rc=%d)", rc_upload);
+    // Orchestration grew the device region to cover its shared-memory tail, which
+    // reallocates, so the base acquired before it may no longer be the one the
+    // image was copied into.
+    void *runtime_arena_dev = api->acquire_pooled_runtime_arena();
+    if (runtime_arena_dev == nullptr) {
+        LOG_ERROR("%s", "Failed to re-acquire the pooled runtime arena after orchestration");
         return -1;
-    }
-    {
-        const uint64_t arena_h2d_bytes = static_cast<uint64_t>(copied_end - copied_begin);
-        char attrs[96];
-        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, arena_h2d_bytes);
-        record_bind_phase(HostPhaseKind::BindArenaH2d, t_arena_h2d_ns, attrs, arena_h2d_bytes);
     }
     runtime->set_prebuilt_arena(runtime_arena_dev, layout.off_runtime);
 

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -786,11 +786,16 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     definition.tensor_arg_count = static_cast<uint32_t>(tensors.size());
     definition.scalar_arg_count = static_cast<uint32_t>(scalars.size());
     definition.predicate_count = static_cast<uint32_t>(predicates.size());
+    const size_t node_stride = sizeof(GraphNodeStorage);
     size_t execution_storage_bytes = 0;
-    if (!graph_execution_storage_bytes(static_cast<int32_t>(definition.task_count), &execution_storage_bytes) ||
+    if (node_stride > UINT32_MAX ||
+        !graph_execution_storage_bytes(
+            static_cast<int32_t>(definition.task_count), node_stride, &execution_storage_bytes
+        ) ||
         execution_storage_bytes > UINT32_MAX) {
         return false;
     }
+    definition.node_stride = static_cast<uint32_t>(node_stride);
     definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
     // Every section's byte count is known now, so the image grows once instead of
     // resizing eleven times. Each append aligns its start, hence the per-section
@@ -972,6 +977,28 @@ struct PTO2PreparedTask {
     PTO2TaskSlotState *slot_state = nullptr;
 };
 
+static PTO2TaskPayload *allocate_task_payload(PTO2OrchestratorState *orch, size_t requested_bytes) {
+    if (orch == nullptr || orch->sm_header == nullptr || requested_bytes < sizeof(PTO2TaskPayload)) return nullptr;
+    PTO2SharedMemoryRingHeader &ring = orch->sm_header->ring;
+    constexpr uint64_t alignment = alignof(PTO2TaskPayload);
+    const uint64_t capacity = ring.task_window_size * sizeof(PTO2TaskPayload);
+    const uint64_t cursor = orch->task_payload_space_used_bytes;
+    if (cursor > UINT64_MAX - (alignment - 1) || requested_bytes > UINT64_MAX - (alignment - 1)) return nullptr;
+    const uint64_t offset = PTO2_ALIGN_UP(cursor, alignment);
+    const uint64_t bytes = PTO2_ALIGN_UP(static_cast<uint64_t>(requested_bytes), alignment);
+    if (offset > capacity || bytes > capacity - offset) {
+        orch->report_fatal(
+            PTO2_ERROR_FLOW_CONTROL_DEADLOCK, __FUNCTION__,
+            "TaskPayloadSpace exhausted: used=%" PRIu64 " requested=%" PRIu64 " capacity=%" PRIu64, cursor, bytes,
+            capacity
+        );
+        return nullptr;
+    }
+    orch->task_payload_space_used_bytes = offset + bytes;
+    auto *base = reinterpret_cast<std::byte *>(ring.task_payloads);
+    return reinterpret_cast<PTO2TaskPayload *>(base + offset);
+}
+
 static PTO2OutputLayout calculate_output_layout(const CoreTaskArgs &args) {
     PTO2OutputLayout layout;
     for (int32_t i = 0; i < args.tensor_count(); i++) {
@@ -1015,7 +1042,10 @@ static bool prepare_task(
     out->task_id = PTO2TaskId::make(ring_id, static_cast<uint32_t>(out->alloc_result.task_id));
     out->slot_state = &orch->sm_header->ring.get_slot_state_by_slot(out->alloc_result.slot);
     out->task = &orch->sm_header->ring.task_descriptors[out->alloc_result.slot];
-    out->payload = &orch->sm_header->ring.task_payloads[out->alloc_result.slot];
+    out->payload = allocate_task_payload(orch, sizeof(PTO2TaskPayload));
+    if (out->payload == nullptr) {
+        return false;
+    }
 
     // Init-on-write: this slot's dynamic scheduling fields and completion flag are
     // initialized here, as the orchestrator claims the slot. whole-graph-resident
@@ -1027,9 +1057,8 @@ static bool prepare_task(
 
     out->payload->prefetch(args.tensor_count(), args.scalar_count());
 
-    // Re-bind payload/task pointers each submit. Value is per-slot constant
-    // (same as &task_payloads[slot] / &task_descriptors[slot]), but writing
-    // here lets RingSchedState::init() skip the O(window_size) bind loop.
+    // Bind the payload record selected from TaskPayloadSpace. Its relative
+    // reference remains valid when the complete SM image moves to device GM.
     // Both writes hit the same 64B slot_state cache line we're about to
     // dirty below, so the extra cost is two stores on an already-hot line.
     // Must precede the Orch-side wiring publish at the end of
@@ -1384,9 +1413,9 @@ static TaskOutputTensors submit_task_common(
     // push_ready_routed; otherwise the returned index selects the producer passed
     // to register_wake. Wake retargeting in register_wake may reclassify a task
     // when the selected producer is already complete.
-    // The initial scan happens before the scheduler dispatch loop starts. Because
-    // fanin is a flat array of position-independent integers, none of this needs
-    // host->device pointer relocation.
+    // The initial scan happens before the scheduler dispatch loop starts. Fanin is
+    // a flat array of position-independent integers, so it crosses to the device
+    // unchanged.
     payload.fanin_count = fanin_builder.count;
     (void)sched;
 
@@ -1523,40 +1552,13 @@ void graph_reset_outer_payload(PTO2TaskPayload &payload) {
 }
 
 bool graph_prepare_submission_image(
-    uint64_t full_key, const GraphTaskArgs &args, std::vector<std::byte> *submission_image
+    uint64_t full_key, uint64_t definition_hash, std::vector<std::byte> *submission_image
 ) {
     if (submission_image == nullptr) return false;
-    const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphTensor));
-    const size_t tensor_bytes = static_cast<size_t>(args.tensor_count()) * sizeof(GraphTensor);
-    if (tensors_offset > UINT32_MAX || tensors_offset > UINT32_MAX - tensor_bytes) {
-        return false;
-    }
-    const size_t tensors_end = tensors_offset + tensor_bytes;
-    const size_t scalar_bytes = static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t);
-    const size_t scalars_offset = args.scalar_count() == 0 ? 0 : PTO2_ALIGN_UP(tensors_end, alignof(uint64_t));
-    const size_t total_bytes = args.scalar_count() == 0 ? tensors_end : scalars_offset + scalar_bytes;
-    if ((args.scalar_count() != 0 && (scalars_offset > UINT32_MAX || scalars_offset > UINT32_MAX - scalar_bytes)) ||
-        total_bytes > UINT32_MAX) {
-        return false;
-    }
-    submission_image->assign(total_bytes, std::byte{0});
-    auto *tensors = reinterpret_cast<GraphTensor *>(submission_image->data() + tensors_offset);
-    for (int32_t i = 0; i < args.tensor_count(); ++i)
-        tensors[i] = graph_tensor_pack(args.tensor(i).ref());
-    if (args.scalar_count() != 0) {
-        std::memcpy(
-            submission_image->data() + scalars_offset, args.scalar_data(),
-            static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t)
-        );
-    }
-
     GraphSubmission submission{};
     submission.graph_key = full_key;
-    submission.total_bytes = static_cast<uint32_t>(submission_image->size());
-    submission.tensors_offset = static_cast<uint32_t>(tensors_offset);
-    submission.tensor_count = static_cast<uint32_t>(args.tensor_count());
-    submission.scalars_offset = static_cast<uint32_t>(scalars_offset);
-    submission.scalar_count = static_cast<uint32_t>(args.scalar_count());
+    submission.definition_hash = definition_hash;
+    submission_image->assign(sizeof(submission), std::byte{0});
     std::memcpy(submission_image->data(), &submission, sizeof(submission));
     return true;
 }
@@ -1574,8 +1576,7 @@ bool graph_submit_outer(
     }
 
     GraphPendingUpload pending;
-    if (!graph_prepare_submission_image(full_key, args, &pending.image)) return false;
-    reinterpret_cast<GraphSubmission *>(pending.image.data())->definition_hash = definition_hash;
+    if (!graph_prepare_submission_image(full_key, definition_hash, &pending.image)) return false;
     pending.deferred_heap = defer_heap;
 
     DepInputs boundary_inputs{
@@ -1591,10 +1592,22 @@ bool graph_submit_outer(
     const PTO2TaskId task_id = PTO2TaskId::make(0, static_cast<uint32_t>(allocation.task_id));
     PTO2SharedMemoryRingHeader &ring = orch->sm_header->ring;
     PTO2TaskDescriptor &task = ring.task_descriptors[allocation.slot];
-    PTO2TaskPayload &payload = ring.task_payloads[allocation.slot];
+    size_t payload_bytes = 0;
+    if (!graph_task_payload_layout(args.tensor_count(), args.scalar_count(), &payload_bytes)) return false;
+    PTO2TaskPayload *payload_ptr = allocate_task_payload(orch, payload_bytes);
+    if (payload_ptr == nullptr) return false;
+    PTO2TaskPayload &payload = *payload_ptr;
     PTO2TaskSlotState &slot = ring.get_slot_state_by_slot(allocation.slot);
 
-    slot.bind_buffers(&payload, &task);
+    // Init-on-write, as in prepare_task: this slot's dynamic scheduling fields and
+    // completion flag are established here, at the claim, because nothing else
+    // writes them. A stale wake_list_head of WAKE_LIST_SENTINEL would close the
+    // list against every consumer, and a stale completion flag would report the
+    // Graph done before it ran.
+    slot.reset_for_reuse();
+    ring.completion_flags[allocation.slot].store(0, std::memory_order_relaxed);
+
+    slot.bind_buffers(payload_ptr, &task);
     slot.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
     slot.last_consumer_local_id = static_cast<int32_t>(task_id.local());
     slot.active_mask = ActiveMask{};
@@ -1602,7 +1615,6 @@ bool graph_submit_outer(
     slot.total_required_subtasks = 0;
     slot.logical_block_num = 1;
     slot.task_kind = TaskKind::GRAPH;
-    slot.graph_context = nullptr;
     scope_tasks_push(orch, &slot);
 
     task.task_id = task_id;
@@ -1610,6 +1622,18 @@ bool graph_submit_outer(
     task.packed_buffer_base = allocation.packed_base;
     task.packed_buffer_end = allocation.packed_end;
     graph_reset_outer_payload(payload);
+    payload.tensor_count = args.tensor_count();
+    payload.scalar_count = args.scalar_count();
+    for (int32_t i = 0; i < args.tensor_count(); ++i) {
+        ChipTensor *destination = graph_task_payload_tensor(payload, static_cast<uint32_t>(i));
+        if (destination == nullptr) return false;
+        *destination = args.tensor(i).ref();
+    }
+    for (int32_t i = 0; i < args.scalar_count(); ++i) {
+        uint64_t *destination = graph_task_payload_scalar(payload, static_cast<uint32_t>(i));
+        if (destination == nullptr) return false;
+        *destination = args.scalar_data()[i];
+    }
 
     PTO2FaninBuilder fanin_builder(orch, &payload, static_cast<int32_t>(task_id.local()), next_fanin_seen_epoch(orch));
     auto emit = [&](PTO2TaskId producer_id) -> bool {
@@ -1684,7 +1708,7 @@ bool graph_submit_pending_definition(
 bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostState *state, uint64_t *failed_key) {
     for (GraphPendingUpload &pending : state->pending_uploads) {
         if (!pending.deferred_heap) continue;
-        if (pending.image.size() < sizeof(GraphSubmission)) return false;
+        if (pending.image.size() != sizeof(GraphSubmission)) return false;
         auto *submission = reinterpret_cast<GraphSubmission *>(pending.image.data());
         auto definition_it = state->definitions.find(submission->graph_key);
         const GraphDefinition *definition =
@@ -1692,8 +1716,7 @@ bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostSt
         if (definition == nullptr || definition->execution_storage_bytes == 0 ||
             definition->required_heap > UINT64_MAX - definition->execution_storage_bytes ||
             pending.outer_slot == nullptr || pending.outer_slot->task == nullptr ||
-            pending.outer_slot->task_kind != TaskKind::GRAPH ||
-            !graph_submission_wire_size_valid(*submission, pending.image.size())) {
+            pending.outer_slot->task_kind != TaskKind::GRAPH) {
             if (failed_key != nullptr) *failed_key = submission->graph_key;
             return false;
         }
@@ -2072,7 +2095,7 @@ void PTO2OrchestratorState::graph_abort(void *recording_handle) {
     auto *entry = static_cast<GraphInflightRecording *>(recording_handle);
     if (state == nullptr || entry == nullptr) return;
     {
-        std::lock_guard<std::mutex> lock(state->recording_mutex);
+        std::scoped_lock lock(state->recording_mutex);
         entry->recording.reset();
         entry->set_status(GraphRecordingStatus::FAILED);
     }
@@ -2109,7 +2132,7 @@ bool PTO2OrchestratorState::graph_end() {
     );
     bool ready = false;
     {
-        std::lock_guard<std::mutex> lock(state->recording_mutex);
+        std::scoped_lock lock(state->recording_mutex);
         if (entry->status() != GraphRecordingStatus::RECORDING || entry->full_key != header->full_key) {
             entry->set_status(GraphRecordingStatus::FAILED);
         } else {

--- a/src/a5/runtime/host_build_graph/runtime/pto2_dispatch_payload.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto2_dispatch_payload.h
@@ -67,7 +67,6 @@ static_assert(
 // PTO2TaskPayload layout drift fails the build rather than corrupting args[].
 constexpr uint32_t PTO2_TASKPAYLOAD_TENSOR_COUNT_OFFSET = 0;
 constexpr uint32_t PTO2_TASKPAYLOAD_SCALAR_COUNT_OFFSET = 4;
-// Cache line 9 (byte 576) holds the AICPU-only DispatchPredicate; tensors follow it.
 constexpr uint32_t PTO2_TASKPAYLOAD_TENSORS_OFFSET = 640;
 constexpr uint32_t PTO2_TASKPAYLOAD_SCALARS_OFFSET = 4736;
 constexpr uint32_t PTO2_TASKPAYLOAD_TENSOR_STRIDE = 128;  // sizeof(ChipTensor)

--- a/src/a5/runtime/host_build_graph/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_orchestrator.h
@@ -71,6 +71,9 @@ struct PTO2OrchestratorState {
     PTO2RingSet ring;
     uint32_t *fanin_seen_epoch;
     uint32_t fanin_seen_current_epoch{1};
+    // Live bytes in the packed task-payload segment. Payload records are
+    // appended in submission order and may have different lengths.
+    uint64_t task_payload_space_used_bytes{0};
 
     // === TENSOR MAP (Private) ===
     PTO2TensorMap tensor_map;  // Producer lookup

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -121,23 +121,36 @@ struct PTO2RuntimeArenaLayout {
     size_t off_scheduler{0};
     size_t off_runtime{0};
     size_t off_mailbox{0};
-    // The arena is reserved in three zones and the offsets above land in exactly
-    // one of them:
+    // The arena is reserved in zones, in this order, and the offsets above land in
+    // exactly one of them:
     //
-    //   host-only    the orchestrator block. Dep-computation scratch the AICPU
-    //                never reads, so it is never copied.
+    //   device-only  sm_handle, the AICore mailbox, the scheduler state and its
+    //                queue slot arrays. Reachable storage whose content is a
+    //                function of the layout, not of the run, so the device writes
+    //                it at boot instead of receiving an initialization pattern
+    //                over PCIe.
     //   copied       [off_copied_begin, off_copied_end). Every byte carries this
     //                run's own content, so bind ships the whole zone as one
     //                contiguous range.
-    //   device-only  sm_handle, the scheduler state and its queue slot arrays.
-    //                Reachable storage whose content is a function of the layout,
-    //                not of the run, so the device writes it at boot instead of
-    //                receiving an initialization pattern over PCIe.
     //
-    // Placing the copied zone in the middle is what keeps the upload a single
-    // range: the two zones that are not copied sit on either side of it.
+    // off_copied_end is where the shared part of the layout stops. Past it the two
+    // sides carry different tails, and neither reads the other's:
+    //
+    //   host tail    the orchestrator block. Dep-computation scratch no device code
+    //                reads, so it is neither copied nor allocated on the device.
+    //   device tail  the compact shared-memory image followed by Graph Definitions
+    //                and submissions. Their sizes are not known until orchestration
+    //                ends, so bind commits the device region only after planning them.
+    //
+    // The copied zone is padded to a PTO2_ALIGN_SIZE boundary, so the device tail
+    // begins exactly at off_copied_end: the copied zone, shared-memory image, and
+    // Graph block are adjacent on the device and travel as one copy.
     size_t off_copied_begin{0};
     size_t off_copied_end{0};
+
+    // Byte length of the device region before its shared-memory tail. The host
+    // arena is arena_size, which instead covers the orchestrator block there.
+    size_t device_bytes{0};
 
     // Cached parameters (re-used by init_data + wire stages).
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]{};
@@ -244,15 +257,33 @@ PTO2Runtime *runtime_init_data_from_layout(
 );
 
 /**
- * Phase 3 — wire every arena-internal pointer field (rt->sm_handle,
- * rt->aicore_mailbox, orchestrator.{scope_tasks, scope_begins, scheduler,
- * tensor_map.*, ring.fanin_pool.base}, scheduler.{ready_queues,
- * ready_sync_queues, early_dispatch_queues, dep_pool}) so each holds
- * arena.base() + offset. Idempotent — runs on
- * both host (writing host-mirror addresses) and AICPU (writing device
- * addresses) sides.
+ * Phase 3 — wire the arena-internal pointer fields that exist on both sides
+ * (rt->sm_handle, rt->aicore_mailbox, rt->scheduler and
+ * scheduler.{ready_queues, ready_sync_queues, early_dispatch_queues}) so each
+ * holds arena.base() + offset. Idempotent — runs on both host (writing
+ * host-mirror addresses) and AICPU (writing device addresses) sides.
  */
 void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
+
+/**
+ * Phase 3b — wire the orchestrator's pointers into the host-only zone
+ * (orchestrator.{scope_tasks, scope_begins, scheduler, tensor_map.*,
+ * ring.fanin_pool.base}).
+ *
+ * Host-only by construction: that zone is past layout.device_bytes and so is not
+ * allocated on the device, which makes the addresses this writes unrepresentable
+ * there. Requires rt->scheduler, so it follows runtime_wire_arena_pointers.
+ */
+void runtime_wire_host_only_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
+
+/**
+ * Drop the pointers Phase 3b wrote, so the runtime header can be copied to the
+ * device without carrying host addresses into it. The device reads one
+ * orchestrator field, inline_completed_tasks, which this leaves alone.
+ *
+ * Call after orchestration finishes and before the copied zone is uploaded.
+ */
+void runtime_clear_host_only_pointers(PTO2Runtime *rt);
 
 /**
  * AICPU-only Phase 4 — fill in the few fields the host could not know at

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 #include <atomic>
+#include <cstddef>
 
 #include "profiling_config.h"
 #include "pto_constants.h"
@@ -331,10 +332,10 @@ struct PTO2TaskPayload {
     // dispatch.
     alignas(64) DispatchPredicate predicate;
     ArgsDumpTaskMetadata dump_metadata;
-    // === Cache lines 10-73 (4096B) — tensors (alignas(64) forces alignment) ===
+    // === Cache lines 10-73 (4096B) — tensors ===
     ChipTensor tensors[MAX_TENSOR_ARGS];
     // === Cache lines 74-75 (128B) — scalars ===
-    uint64_t scalars[MAX_SCALAR_ARGS];
+    alignas(64) uint64_t scalars[MAX_SCALAR_ARGS];
 
     // Layout verification (size checks that don't need offsetof).
     static_assert(sizeof(ChipTensor) == 128, "ChipTensor must be 2 cache lines");
@@ -431,7 +432,7 @@ struct PTO2TaskPayload {
 static_assert(offsetof(PTO2TaskPayload, fanin_local_ids) == 12, "inline fanin id array must follow fanin_count");
 static_assert(
     offsetof(PTO2TaskPayload, predicate) == 576,
-    "dispatch predicate occupies cache line 9 at fixed byte 576 (before tensors, never moves)"
+    "dispatch predicate occupies cache line 9 at fixed byte 576 (before the arg arrays, never moves)"
 );
 static_assert(
     offsetof(PTO2TaskPayload, dump_metadata) + sizeof(ArgsDumpTaskMetadata) <= 640,
@@ -448,6 +449,50 @@ static_assert(
     sizeof(PTO2TaskPayload) == 640 + MAX_TENSOR_ARGS * sizeof(ChipTensor) + MAX_SCALAR_ARGS * sizeof(uint64_t),
     "PTO2TaskPayload size = metadata(576) + predicate cache line(64) + tensors + scalars"
 );
+
+// Position-independent reference used inside relocatable runtime images. The
+// payload and its slot move by the same delta from host DDR to device GM, so a
+// relative offset remains valid without a per-slot relocation pass.
+template <typename T>
+struct PTO2RelativePtr {
+    int64_t offset{0};
+
+    T *get() const {
+        if (offset == 0) return nullptr;
+        const intptr_t self = reinterpret_cast<intptr_t>(this);
+        return reinterpret_cast<T *>(self + offset);
+    }
+
+    void reset(T *pointer = nullptr) {
+        offset = pointer == nullptr ? 0 : reinterpret_cast<intptr_t>(pointer) - reinterpret_cast<intptr_t>(this);
+    }
+
+    PTO2RelativePtr &operator=(T *pointer) {
+        reset(pointer);
+        return *this;
+    }
+
+    operator T *() const { return get(); }
+    T *operator->() const { return get(); }
+    T &operator*() const { return *get(); }
+    explicit operator bool() const { return offset != 0; }
+
+    bool operator==(std::nullptr_t) const { return offset == 0; }
+    bool operator!=(std::nullptr_t) const { return offset != 0; }
+};
+
+template <typename T>
+inline bool operator==(std::nullptr_t, const PTO2RelativePtr<T> &pointer) {
+    return pointer == nullptr;
+}
+
+template <typename T>
+inline bool operator!=(std::nullptr_t, const PTO2RelativePtr<T> &pointer) {
+    return pointer != nullptr;
+}
+
+static_assert(sizeof(PTO2RelativePtr<PTO2TaskPayload>) == sizeof(uint64_t));
+static_assert(std::is_trivially_copyable_v<PTO2RelativePtr<PTO2TaskPayload>>);
 
 /**
  * Per-task slot scheduling state (scheduler-private, NOT in shared memory)
@@ -477,8 +522,10 @@ struct alignas(64) PTO2TaskSlotState {
     std::atomic<PTO2TaskState> task_state;
 
     // --- Per-slot constant, re-bound by orch::prepare_task each submit ---
-    PTO2TaskPayload *payload;
-    PTO2TaskDescriptor *task;
+    // Self-relative, so the SM image needs no pointer fix-up on its way to the
+    // device: both targets sit in the same block as this field.
+    PTO2RelativePtr<PTO2TaskPayload> payload;
+    PTO2RelativePtr<PTO2TaskDescriptor> task;
 
     // --- Wake list: last-fanin notification (intrusive, lock-free) ---
     // A pending consumer whose fanin scan finds an unmet producer registers on
@@ -534,8 +581,8 @@ struct alignas(64) PTO2TaskSlotState {
     }
 
     void bind_buffers(PTO2TaskPayload *p, PTO2TaskDescriptor *t) {
-        payload = p;
-        task = t;
+        payload.reset(p);
+        task.reset(t);
     }
 
     // Host-visible completion mirror. The device readiness truth

--- a/src/a5/runtime/host_build_graph/runtime/pto_shared_memory.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_shared_memory.h
@@ -34,6 +34,8 @@
 
 #include <stddef.h>
 
+#include <cstring>
+
 #include "utils/device_arena.h"
 #include "pto_runtime2_types.h"
 
@@ -143,9 +145,11 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
         return task_descriptors[get_slot_by_task_id(local_id)];
     }
 
-    PTO2TaskPayload &get_payload_by_slot(int32_t slot) { return task_payloads[slot]; }
+    PTO2TaskPayload &get_payload_by_slot(int32_t slot) { return *slot_states[slot].payload; }
 
-    PTO2TaskPayload &get_payload_by_task_id(int32_t local_id) { return task_payloads[get_slot_by_task_id(local_id)]; }
+    PTO2TaskPayload &get_payload_by_task_id(int32_t local_id) {
+        return get_payload_by_slot(get_slot_by_task_id(local_id));
+    }
 
     PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
@@ -240,7 +244,17 @@ struct PTO2SharedMemoryHandle {
     // Used by host_build_graph host-orch, where the host orchestrator populated
     // the SM and H2D'd it; the device must re-point at its own SM base without
     // wiping the contents (unlike init_per_ring, which also resets the header).
-    bool attach_populated(void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
+    //
+    // `live_slots` is the pitch the uploaded arrays were laid out with — the
+    // number of slots the host actually submitted, not the ring capacity. It must
+    // match what the host used or every segment past the descriptors resolves to
+    // the wrong address, so both sides derive it from the same submitted count.
+    // The capacity and mask in the header are unchanged, and `local_id & mask`
+    // yields `local_id`, which is below `live_slots` for every ring task.
+    bool attach_populated(
+        void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t live_slots,
+        uint64_t payload_bytes
+    );
 
     void destroy();
     void print_layout();
@@ -252,7 +266,13 @@ private:
         const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
     );
     void setup_pointers(uint64_t task_window_size);
-    void setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
+    // `pitch` is the slot count the arrays are dimensioned for. init_per_ring
+    // passes the ring capacity (the mirror the orchestrator writes into);
+    // attach_populated passes the submitted count (the compacted image that
+    // shipped).
+    void setup_pointers_per_ring(
+        const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch, uint64_t payload_bytes
+    );
 };
 
 // =============================================================================
@@ -293,6 +313,17 @@ inline std::atomic<int32_t> *ring_current_task_index_addr(void *sm_dev_base) noe
 // Byte offsets (from the SM base) of the ring's three segments. The layout is:
 // header, then descriptors -> payloads -> slot_states, every segment
 // PTO2_ALIGN_UP-padded.
+//
+// Two parameters, and the host mirror and the shipped image differ in both.
+//
+// The *pitch* is how many slots the arrays are dimensioned for: the mirror uses the
+// ring capacity, the image uses the submitted count, which is what makes the four
+// live prefixes contiguous and the upload one copy.
+//
+// The *payload stride* is how far apart consecutive payloads sit. The mirror uses
+// sizeof(PTO2TaskPayload), whose tensor array is dimensioned for the widest task the
+// API allows. The image uses the widest task in this bind — the array is the last
+// field, so anything past that task's entries is read by nobody.
 struct PTO2RingSegmentOffsets {
     uint64_t descriptors;
     uint64_t payloads;
@@ -307,13 +338,14 @@ struct PTO2RingSegmentOffsets {
 // `sm_dev_base`). Adding or reordering a segment is a one-line edit here; every
 // consumer follows automatically, so the layout walk can never silently
 // disagree across call sites.
-inline PTO2RingSegmentOffsets ring_segment_offsets(uint64_t task_window_size) noexcept {
+inline PTO2RingSegmentOffsets
+ring_segment_offsets_with_payload_bytes(uint64_t task_window_size, uint64_t payload_bytes) noexcept {
     uint64_t off = PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
     PTO2RingSegmentOffsets o{};
     o.descriptors = off;
     off += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
     o.payloads = off;
-    off += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
+    off += PTO2_ALIGN_UP(payload_bytes, PTO2_ALIGN_SIZE);
     o.slot_states = off;
     off += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
     o.completion_flags = off;
@@ -322,25 +354,82 @@ inline PTO2RingSegmentOffsets ring_segment_offsets(uint64_t task_window_size) no
     return o;
 }
 
-// Device address of the task_descriptors array.
-inline PTO2TaskDescriptor *ring_task_descriptors_addr(void *sm_dev_base, uint64_t task_window_size) noexcept {
-    return reinterpret_cast<PTO2TaskDescriptor *>(
-        static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_size).descriptors
-    );
+inline PTO2RingSegmentOffsets ring_segment_offsets(uint64_t task_window_size) noexcept {
+    return ring_segment_offsets_with_payload_bytes(task_window_size, task_window_size * sizeof(PTO2TaskPayload));
 }
 
-// Device address of the slot_states array used by host/device pointer wiring.
-inline PTO2TaskSlotState *ring_slot_states_addr(void *sm_dev_base, uint64_t task_window_size) noexcept {
-    return reinterpret_cast<PTO2TaskSlotState *>(
-        static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_size).slot_states
-    );
+// The pitch the shipped image uses for a given submitted task count. A bind that
+// submits nothing still ships its header and still attaches, and a zero-length
+// array has no layout, so the pitch never drops below one slot.
+inline uint64_t live_slot_pitch(uint64_t submitted_tasks) noexcept {
+    return submitted_tasks == 0 ? 1 : submitted_tasks;
 }
 
-// Device address of the polling completion_flags byte array.
-inline std::atomic<uint8_t> *ring_completion_flags_addr(void *sm_dev_base, uint64_t task_window_size) noexcept {
-    return reinterpret_cast<std::atomic<uint8_t> *>(
-        static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_size).completion_flags
-    );
+// The stride a shipped payload array uses for a given widest task. The tensor array
+// is the payload's last field, so a task reads nothing past its own entries and the
+// stride need only cover them — but every payload in the image shares one stride, so
+// it is the widest task that sets it.
+//
+// Rounded up to PTO2_ALIGN_SIZE because PTO2TaskPayload's own alignment is 64 and the
+// image places consecutive payloads at multiples of the stride.
+// Restack the live prefix of every ring segment from the ring-pitched mirror the
+// orchestrator wrote into an image pitched to `submitted_tasks`, where the four
+// prefixes are contiguous and can travel as one copy.
+//
+// `out_base` must be PTO2_ALIGN_SIZE-aligned and hold
+// `ring_segment_offsets_with_payload_bytes(live_slot_pitch(submitted_tasks),
+// payload_bytes).end` bytes. Returns that byte count.
+//
+// Two things the restack has to fix up, both because the image is not the mirror:
+//
+//   - the ring header's data pointers name the mirror's arrays, so they leave as
+//     null rather than carrying host addresses into device memory (the device
+//     resolves them in attach_populated);
+//   - a slot state names its payload and descriptor by a delta from its own
+//     address, and the restack changed those distances, so each binding is
+//     re-taken against the image.
+inline uint64_t compact_live_image(
+    const char *mirror_base, uint64_t task_window_size, uint64_t submitted_tasks, uint64_t payload_bytes, char *out_base
+) noexcept {
+    // The mirror is pitched to the capacity and to the type, so a larger live count
+    // or a wider stride reads past the segment it is copying from and ships a corrupt
+    // image. attach_populated tests the same two bounds on the device side.
+    always_assert(submitted_tasks <= task_window_size);
+    always_assert(payload_bytes <= task_window_size * sizeof(PTO2TaskPayload));
+    const PTO2RingSegmentOffsets from = ring_segment_offsets(task_window_size);
+    const PTO2RingSegmentOffsets to =
+        ring_segment_offsets_with_payload_bytes(live_slot_pitch(submitted_tasks), payload_bytes);
+
+    // The header and the descriptors offset are pitch-independent, so the header
+    // lands where it already was.
+    std::memcpy(out_base, mirror_base, to.descriptors);
+    auto &out_ring = reinterpret_cast<PTO2SharedMemoryHeader *>(out_base)->ring;
+    out_ring.task_descriptors = nullptr;
+    out_ring.task_payloads = nullptr;
+    out_ring.slot_states = nullptr;
+    out_ring.completion_flags = nullptr;
+
+    const uint64_t nt = submitted_tasks;
+    std::memcpy(out_base + to.descriptors, mirror_base + from.descriptors, nt * sizeof(PTO2TaskDescriptor));
+    // Per payload, because the source and destination strides differ: the mirror is
+    // pitched to the type, the image to the widest task in this bind.
+    std::memcpy(out_base + to.payloads, mirror_base + from.payloads, payload_bytes);
+    std::memcpy(out_base + to.slot_states, mirror_base + from.slot_states, nt * sizeof(PTO2TaskSlotState));
+    std::memcpy(out_base + to.completion_flags, mirror_base + from.completion_flags, nt * sizeof(std::atomic<uint8_t>));
+
+    auto *out_slots = reinterpret_cast<PTO2TaskSlotState *>(out_base + to.slot_states);
+    auto *out_descriptors = reinterpret_cast<PTO2TaskDescriptor *>(out_base + to.descriptors);
+    const auto *source_slots = reinterpret_cast<const PTO2TaskSlotState *>(mirror_base + from.slot_states);
+    const char *source_payload_base = mirror_base + from.payloads;
+    for (uint64_t i = 0; i < nt; ++i) {
+        const char *source_payload = reinterpret_cast<const char *>(source_slots[i].payload.get());
+        always_assert(source_payload >= source_payload_base);
+        const uint64_t payload_offset = static_cast<uint64_t>(source_payload - source_payload_base);
+        always_assert(payload_offset + sizeof(PTO2TaskPayload) <= payload_bytes);
+        auto *out_payload = reinterpret_cast<PTO2TaskPayload *>(out_base + to.payloads + payload_offset);
+        out_slots[i].bind_buffers(out_payload, &out_descriptors[i]);
+    }
+    return to.end;
 }
 
 }  // namespace pto2_sm_layout

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -173,6 +173,9 @@ public:
     // the boot thread reads this instead of counting SM ring heads.
     int32_t host_total_tasks;
 
+    // Live TaskPayloadSpace byte count in the shipped shared-memory image.
+    uint64_t sm_payload_bytes;
+
 private:
     // Kernel binary tracking for cleanup
 

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -906,7 +906,7 @@ struct PTO2SchedulerState {
         const uint32_t end = execution.fanin_offsets[node_index + 1];
         for (uint32_t edge = begin; edge < end; ++edge) {
             const uint16_t producer_index = execution.fanin_indices[edge];
-            const PTO2TaskSlotState &producer = execution.nodes[producer_index].slot;
+            const PTO2TaskSlotState &producer = execution.node_at(producer_index).slot;
             if (producer.task_state.load(std::memory_order_acquire) != PTO2_TASK_COMPLETED) {
                 return static_cast<int32_t>(producer_index);
             }
@@ -934,7 +934,7 @@ struct PTO2SchedulerState {
                 push_ready_routed(consumer);
                 return;
             }
-            producer = &execution.nodes[unmet_producer].slot;
+            producer = &execution.node_at(unmet_producer).slot;
         }
     }
 
@@ -947,7 +947,7 @@ struct PTO2SchedulerState {
             if (unmet_producer < 0) {
                 push_ready_routed(waiter);
             } else {
-                register_graph_wake(execution, &execution.nodes[unmet_producer].slot, waiter);
+                register_graph_wake(execution, &execution.node_at(unmet_producer).slot, waiter);
             }
             consumers_rescanned++;
             waiter = next;
@@ -978,7 +978,7 @@ struct PTO2SchedulerState {
                 continue;
             }
             if (execution.fanin_offsets[i] == execution.fanin_offsets[i + 1]) {
-                push_ready_routed(&execution.node_storage[i].slot);
+                push_ready_routed(&execution.node_at(i).slot);
                 routed++;
             }
         }
@@ -996,12 +996,12 @@ struct PTO2SchedulerState {
     void graph_incremental_publish(GraphExecution &execution, int32_t first, int32_t last) {
         for (int32_t i = first; i < last; ++i) {
             if (execution.fanin_offsets[i] == execution.fanin_offsets[i + 1]) continue;  // root
-            PTO2TaskSlotState &node = execution.node_storage[i].slot;
+            PTO2TaskSlotState &node = execution.node_at(i).slot;
             const int32_t unmet = graph_first_unmet_producer(execution, node);
             if (unmet < 0) {
                 push_ready_routed(&node);
             } else {
-                register_graph_wake(execution, &execution.nodes[unmet].slot, &node);
+                register_graph_wake(execution, &execution.node_at(unmet).slot, &node);
             }
         }
         execution.published_nodes.store(last, std::memory_order_release);

--- a/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -322,21 +322,26 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
         layout.heap_sizes[r] = heap_sizes[r];
     }
 
-    // Reservation order is the zone partition (see PTO2RuntimeArenaLayout): the
-    // host-only orchestrator block, then the one copied range, then everything
-    // the device initializes itself. Each zone is contiguous, so bind is a single
-    // copy and no consumer has to infer a boundary from what happens to come
-    // first.
-    layout.orch = PTO2OrchestratorState::reserve_layout(arena, static_cast<int32_t>(task_window_sizes[0]));
-
-    layout.off_copied_begin = arena.total_size();
-    layout.off_runtime = arena.reserve(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE);
-    layout.off_copied_end = arena.total_size();
-
+    // Reservation order is the zone partition (see PTO2RuntimeArenaLayout):
+    // everything the device initializes itself, then the one copied range. Each
+    // zone is contiguous, so bind is a single copy and no consumer has to infer a
+    // boundary from what happens to come first.
+    //
+    // The copied zone comes last of the two so the device's shared-memory tail can
+    // begin where it ends, making the two adjacent and the upload one copy.
     layout.off_sm_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
     layout.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
     layout.off_scheduler = arena.reserve(sizeof(PTO2SchedulerState), alignof(PTO2SchedulerState));
     layout.sched = PTO2SchedulerState::reserve_layout(arena);
+
+    layout.off_copied_begin = arena.total_size();
+    // Padded to a PTO2_ALIGN_SIZE boundary: the shared-memory image starts at
+    // off_copied_end on the device and its segment offsets are aligned from there.
+    layout.off_runtime = arena.reserve(PTO2_ALIGN_UP(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE), PTO2_ALIGN_SIZE);
+    layout.off_copied_end = arena.total_size();
+
+    layout.device_bytes = arena.total_size();
+    layout.orch = PTO2OrchestratorState::reserve_layout(arena, static_cast<int32_t>(task_window_sizes[0]));
 
     layout.arena_size = arena.total_size();
     return layout;
@@ -360,9 +365,8 @@ PTO2Runtime *runtime_init_data_from_layout(
  * and initializes the scheduler (ready / sync / dummy / graph queues) against
  * the device SM. The orchestrator is deliberately left zeroed: the host-orch
  * path (run_host_orchestration) initializes it against the host SM once that
- * buffer exists, then relocates it for the device. Initializing it here would
- * be dead work — overwritten by that re-init, and the orchestrator arena block
- * is never uploaded to the device. Caller must follow up with
+ * buffer exists. Initializing it here would be dead work — overwritten by that
+ * re-init, and the orchestrator arena block is never uploaded to the device. Caller must follow up with
  * runtime_wire_arena_pointers. Returns the arena-resident PTO2Runtime*, or
  * nullptr on failure.
  */
@@ -388,10 +392,10 @@ PTO2Runtime *runtime_init_data_from_layout(
     // Two components are deliberately not initialized here.
     //
     // The orchestrator is initialized by the host-orch path
-    // (run_host_orchestration) against the host SM once it is allocated, then
-    // relocated for the device. Doing it here would be dead work: its arena
-    // content (tensormap + seen_epoch memset) is immediately overwritten by that
-    // re-init, and the orchestrator block is host-only anyway.
+    // (run_host_orchestration) against the host SM once it is allocated. Doing it
+    // here would be dead work: its arena content (tensormap + seen_epoch memset)
+    // is immediately overwritten by that re-init, and the orchestrator block is
+    // host-only anyway.
     //
     // The scheduler and sm_handle live in the device-only zone, so their bytes
     // never travel; the AICPU initializes them at boot. Writing them here would
@@ -405,9 +409,14 @@ void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayou
     rt->sm_handle = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(layout.off_sm_handle));
     rt->aicore_mailbox = static_cast<AICoreCompletionMailbox *>(arena.region_ptr(layout.off_mailbox));
     rt->scheduler = static_cast<PTO2SchedulerState *>(arena.region_ptr(layout.off_scheduler));
-    rt->orchestrator.wire_arena_pointers(layout.orch, arena, rt->scheduler);
     rt->scheduler->wire_arena_pointers(layout.sched, arena);
 }
+
+void runtime_wire_host_only_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt) {
+    rt->orchestrator.wire_arena_pointers(layout.orch, arena, rt->scheduler);
+}
+
+void runtime_clear_host_only_pointers(PTO2Runtime *rt) { rt->orchestrator.destroy(); }
 
 void runtime_destroy(PTO2Runtime *rt, DeviceArena & /*arena*/) {
     // Arena buffer is pooled across runs by DeviceRunner — never freed here.

--- a/src/a5/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
@@ -45,14 +45,17 @@ uint64_t PTO2SharedMemoryHandle::calculate_size_per_ring(const uint64_t task_win
 // Creation and Destruction
 // =============================================================================
 
-void PTO2SharedMemoryHandle::setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+void PTO2SharedMemoryHandle::setup_pointers_per_ring(
+    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch, uint64_t payload_bytes
+) {
+    (void)task_window_sizes;
     char *base = (char *)sm_base;
     header = (PTO2SharedMemoryHeader *)base;
 
     // Per-ring descriptors / payloads / slot_states — offsets from the single
     // source of truth (pto2_sm_layout::ring_segment_offsets), so this setup and
     // the device-address helpers cannot drift.
-    auto off = pto2_sm_layout::ring_segment_offsets(task_window_sizes[0]);
+    auto off = pto2_sm_layout::ring_segment_offsets_with_payload_bytes(pitch, payload_bytes);
     auto &ring = header->ring;
     ring.task_descriptors = (PTO2TaskDescriptor *)(base + off.descriptors);
     ring.task_payloads = (PTO2TaskPayload *)(base + off.payloads);
@@ -65,7 +68,7 @@ void PTO2SharedMemoryHandle::setup_pointers(uint64_t task_window_size) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
     }
-    setup_pointers_per_ring(task_window_sizes);
+    setup_pointers_per_ring(task_window_sizes, task_window_size, task_window_size * sizeof(PTO2TaskPayload));
 }
 
 bool PTO2SharedMemoryHandle::init(
@@ -90,21 +93,30 @@ bool PTO2SharedMemoryHandle::init_per_ring(
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers_per_ring(task_window_sizes);
+    setup_pointers_per_ring(task_window_sizes, task_window_sizes[0], task_window_sizes[0] * sizeof(PTO2TaskPayload));
     init_header_per_ring(task_window_sizes, heap_sizes);
     return true;
 }
 
 bool PTO2SharedMemoryHandle::attach_populated(
-    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t live_slots,
+    uint64_t payload_bytes
 ) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
-    if (sm_size_arg < calculate_size_per_ring(task_window_sizes)) return false;
-
+    // A pitch above the capacity would name a slot the ring cannot address, and one
+    // below what the host used would place every segment past the descriptors
+    // short. This is the whole contract between the two sides, checked once at
+    // attach rather than trusted.
+    if (live_slots == 0 || live_slots > task_window_sizes[0]) return false;
+    if (payload_bytes > task_window_sizes[0] * sizeof(PTO2TaskPayload)) return false;
+    // The region holds the compacted image, so that is what has to fit — the ring
+    // capacity is no longer its size.
+    const uint64_t image_end = pto2_sm_layout::ring_segment_offsets_with_payload_bytes(live_slots, payload_bytes).end;
+    if (sm_size_arg < image_end) return false;
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers_per_ring(task_window_sizes);
+    setup_pointers_per_ring(task_window_sizes, live_slots, payload_bytes);
     // Deliberately NO init_header_per_ring: the SM already holds the host
     // orchestrator's task graph (descriptors, slot states, ring counters).
     return true;

--- a/src/a5/runtime/host_build_graph/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/runtime.cpp
@@ -35,6 +35,7 @@ Runtime::Runtime() {
     aicpu_allowed_cpu_count = 0;
     aicpu_launch_count = 0;
     host_total_tasks = 0;
+    sm_payload_bytes = 0;
 
     // Initialize shared-memory / orchestration argument plumbing
     gm_sm_ptr_ = nullptr;

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -355,8 +355,29 @@ For a cache hit, the Host Orchestrator:
    the Definition's `execution_storage_bytes` for the execution the device
    materializes into;
 4. computes only external fanin and boundary tensormap effects;
-5. emits one outer `GRAPH` task;
-6. stages the exact-size POD submission image for upload after orchestration.
+5. emits one outer `GRAPH` task, whose payload carries the boundary args exactly
+   as any other task's payload carries its own;
+6. stages a fixed-size POD submission for the run's GraphBlock.
+
+The submission image is a Definition reference — key, content hash, device
+address, the activation gate and the word the device CASes to publish its local
+execution — and nothing else. The boundary args are not on it: the compact SM segment already
+ships every task's payload, so putting them there sends them once instead of
+twice, and the device reads them from `outer_slot.payload` in the same
+`ChipTensor` form the dispatch path uses everywhere else. They arrive through the
+channel that path already trusts, so the Scheduler validates the pairing — their
+counts against the Definition's boundary counts — rather than re-checking each
+tensor.
+
+After orchestration completes, the Host first computes a contiguous GraphBlock
+layout: every distinct `[GraphDefinitionHeader][Definition]` object in order,
+then every fixed-size submission. Submissions store device addresses derived
+from `GraphBlock base + Definition offset`. Only after all sizes and offsets are
+known does the Host append that block to the current arena bank's runtime
+region, which reuses an equal-or-larger allocation from that bank. The complete
+bind image is overwritten with exactly one H2D copy on every run; there is no
+content-based copy skip and no per-Definition or per-submission device
+allocation.
 
 Internal nodes consume no ring task-window slots. Their descriptor, payload,
 and slot state live in the tail of the outer `GRAPH` task's own heap block,
@@ -376,10 +397,11 @@ bytes it starts from are whatever that heap region last held.
 ## Scheduler flow
 
 Host orchestration builds the complete task image before device execution. At
-the end of orchestration, the Host uploads every exact-size Graph POD image,
-relocates the task and payload pointers in the shared-memory image, copies the
-complete shared-memory/runtime-arena image to the device, and then launches the
-resident Scheduler.
+the end of orchestration, the Host stages the copied runtime zone, the compacted
+shared-memory image, Graph Definitions, and submissions into one arena-owned
+bind image and uploads it once before launching the resident Scheduler. Slot
+states name their TaskPayloadSpace record and descriptor by self-relative
+offsets, so compaction rebinds them without shipping host pointers.
 
 All AICPU threads classify disjoint slices of the completed task window behind
 one startup barrier. A Graph task enters preparation and external-fanin

--- a/src/common/host_build_graph/graph_execution.cpp
+++ b/src/common/host_build_graph/graph_execution.cpp
@@ -22,15 +22,18 @@ namespace {
 // The storage is the tail of the outer GRAPH task's heap allocation, so its
 // bytes are whatever that region last held; every field an execution needs is
 // written here or by the materialize pass, never inherited from those bytes.
-GraphExecution *acquire_host_execution_storage(uintptr_t storage_addr, size_t storage_bytes, int32_t node_count) {
+GraphExecution *
+acquire_host_execution_storage(uintptr_t storage_addr, size_t storage_bytes, int32_t node_count, size_t node_stride) {
     size_t nodes_offset = 0;
     size_t required_bytes = 0;
     if (storage_addr == 0 || storage_addr % alignof(GraphNodeStorage) != 0 ||
-        !graph_execution_storage_layout(node_count, &nodes_offset, &required_bytes) || required_bytes > storage_bytes) {
+        !graph_execution_storage_layout(node_count, node_stride, &nodes_offset, &required_bytes) ||
+        required_bytes > storage_bytes) {
         return nullptr;
     }
     auto *execution = new (reinterpret_cast<void *>(storage_addr)) GraphExecution{};
     execution->node_count = node_count;
+    execution->node_stride = node_stride;
     execution->remaining_nodes.store(node_count, std::memory_order_relaxed);
     execution->node_storage =
         reinterpret_cast<GraphNodeStorage *>(reinterpret_cast<uint8_t *>(execution) + nodes_offset);
@@ -55,7 +58,7 @@ void reset_graph_payload(PTO2TaskPayload &payload) {
 bool bind_graph_topology(GraphExecution &execution) {
     if (execution.definition == nullptr) return false;
     const GraphDefinition &definition = *execution.definition;
-    if (definition.boundary_scalar_count > MAX_SCALAR_ARGS) return false;
+    if (definition.boundary_scalar_count > GRAPH_MAX_SCALAR_ARGS) return false;
     const uint32_t *fanin_offsets =
         graph_definition_array<uint32_t>(definition, definition.off_fanin_offsets, definition.task_count + 1);
     const uint16_t *fanin_indices =
@@ -218,18 +221,25 @@ bool graph_rebind_tensor(
     GraphTensor rebound = tensor_template;
     if (!graph_tensor_wire_valid(rebound)) return false;
     if (ref.source == static_cast<uint8_t>(GraphTensorSource::BOUNDARY_EXACT)) {
-        if (ref.source_index >= execution.boundary_tensor_count || ref.packed_offset != 0) return false;
-        rebound = execution.boundary_tensors[ref.source_index];
+        const ChipTensor *boundary = execution.boundary_payload == nullptr ?
+                                         nullptr :
+                                         graph_task_payload_tensor(*execution.boundary_payload, ref.source_index);
+        if (boundary == nullptr || ref.source_index >= execution.boundary_tensor_count || ref.packed_offset != 0) {
+            return false;
+        }
+        rebound = graph_tensor_pack(*boundary);
     } else if (ref.source == static_cast<uint8_t>(GraphTensorSource::BOUNDARY_VIEW)) {
-        if (ref.source_index >= execution.boundary_tensor_count) return false;
-        const GraphTensor &boundary = execution.boundary_tensors[ref.source_index];
-        if (ref.packed_offset > UINT64_MAX - boundary.start_offset) return false;
-        rebound.buffer_addr = boundary.buffer_addr;
-        rebound.buffer_size = boundary.buffer_size;
-        rebound.owner_task_id = boundary.owner_task_id;
-        rebound.start_offset = boundary.start_offset + ref.packed_offset;
-        rebound.version = boundary.version;
-        rebound.address_space = boundary.address_space;
+        const ChipTensor *boundary = execution.boundary_payload == nullptr ?
+                                         nullptr :
+                                         graph_task_payload_tensor(*execution.boundary_payload, ref.source_index);
+        if (boundary == nullptr || ref.source_index >= execution.boundary_tensor_count) return false;
+        if (ref.packed_offset > UINT64_MAX - boundary->start_offset) return false;
+        rebound.buffer_addr = boundary->buffer.addr;
+        rebound.buffer_size = boundary->buffer.size;
+        rebound.owner_task_id = boundary->owner_task_id.raw;
+        rebound.start_offset = boundary->start_offset + ref.packed_offset;
+        rebound.version = boundary->version;
+        rebound.address_space = static_cast<uint8_t>(boundary->address_space);
     } else if (ref.source == static_cast<uint8_t>(GraphTensorSource::INTERNAL) ||
                ref.source == static_cast<uint8_t>(GraphTensorSource::OWN_OUTPUT)) {
         const bool own_output = ref.source == static_cast<uint8_t>(GraphTensorSource::OWN_OUTPUT);
@@ -238,7 +248,7 @@ bool graph_rebind_tensor(
             (!own_output && producer_index == node_index)) {
             return false;
         }
-        PTO2TaskDescriptor &producer = execution.node_storage[producer_index].task;
+        PTO2TaskDescriptor &producer = execution.node_at(producer_index).task;
         const uint64_t producer_bytes = static_cast<uint64_t>(nodes[producer_index].total_output_size);
         const uintptr_t producer_base = reinterpret_cast<uintptr_t>(producer.packed_buffer_base);
         if (ref.packed_offset > producer_bytes || rebound.buffer_size > producer_bytes - ref.packed_offset ||
@@ -317,19 +327,16 @@ GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
     auto *definition_header =
         reinterpret_cast<GraphDefinitionHeader *>(static_cast<uintptr_t>(submission->definition_addr));
     if (definition_header->magic != GRAPH_DEFINITION_OBJECT_MAGIC) return nullptr;
-    const GraphTensor *boundary_tensors = graph_submission_tensors(*submission);
-    const uint64_t *boundary_scalars = graph_submission_scalars(*submission);
-    const size_t boundary_tensor_end = static_cast<size_t>(submission->tensors_offset) +
-                                       static_cast<size_t>(submission->tensor_count) * sizeof(GraphTensor);
-    if (boundary_tensors == nullptr || outer_slot.task == nullptr || outer_slot.task->packed_buffer_base == nullptr ||
+    const PTO2TaskPayload *outer_payload = outer_slot.payload;
+    size_t payload_bytes = 0;
+    if (outer_payload == nullptr || outer_slot.task == nullptr || outer_slot.task->packed_buffer_base == nullptr ||
         outer_slot.task->packed_buffer_end == nullptr ||
-        (submission->scalar_count != 0 && boundary_scalars == nullptr) ||
-        (submission->scalar_count != 0 && submission->scalars_offset < boundary_tensor_end)) {
+        !graph_task_payload_layout(outer_payload->tensor_count, outer_payload->scalar_count, &payload_bytes) ||
+        payload_bytes < sizeof(PTO2TaskPayload)) {
         return nullptr;
     }
-    for (uint32_t i = 0; i < submission->tensor_count; ++i) {
-        if (!graph_tensor_wire_valid(boundary_tensors[i])) return nullptr;
-    }
+    const uint32_t boundary_tensor_count = static_cast<uint32_t>(outer_payload->tensor_count);
+    const uint32_t boundary_scalar_count = static_cast<uint32_t>(outer_payload->scalar_count);
 
     uint64_t expected = 0;
     if (!__atomic_compare_exchange_n(
@@ -344,8 +351,8 @@ GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
     const GraphDefinition *definition = graph_definition_object_verified(*definition_header);
     if (definition == nullptr || definition->total_bytes == 0 || definition->task_count == 0 ||
         definition->task_count > GRAPH_MAX_NODES || submission->definition_hash != definition->content_hash ||
-        submission->graph_key != definition->full_key || submission->tensor_count != definition->boundary_count ||
-        submission->scalar_count != definition->boundary_scalar_count) {
+        submission->graph_key != definition->full_key || boundary_tensor_count != definition->boundary_count ||
+        boundary_scalar_count != definition->boundary_scalar_count) {
         __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
         return nullptr;
     }
@@ -364,7 +371,7 @@ GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
 
     GraphExecution *execution = acquire_host_execution_storage(
         outer_base + definition->required_heap, definition->execution_storage_bytes,
-        static_cast<int32_t>(definition->task_count)
+        static_cast<int32_t>(definition->task_count), definition->node_stride
     );
     if (execution == nullptr) {
         __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
@@ -380,10 +387,9 @@ GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
         __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
         return nullptr;
     }
-    execution->boundary_tensors = boundary_tensors;
-    execution->boundary_tensor_count = submission->tensor_count;
-    execution->boundary_scalars = boundary_scalars;
-    execution->boundary_scalar_count = submission->scalar_count;
+    execution->boundary_payload = outer_payload;
+    execution->boundary_tensor_count = boundary_tensor_count;
+    execution->boundary_scalar_count = boundary_scalar_count;
     execution->outer_slot = &outer_slot;
 
     const uint64_t desired = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(execution));
@@ -470,7 +476,7 @@ GraphMaterializeResult graph_execution_materialize_slice(
     const int32_t last = std::min(execution.node_count, first + max_nodes);
     const uintptr_t outer_base = reinterpret_cast<uintptr_t>(outer_slot.task->packed_buffer_base);
     for (int32_t i = first; i < last; ++i) {
-        GraphNodeStorage *storage = &execution.node_storage[i];
+        GraphNodeStorage *storage = &execution.node_at(i);
         if (i >= execution.constructed_nodes) {
             storage = new (storage) GraphNodeStorage;
             execution.constructed_nodes++;
@@ -531,11 +537,14 @@ GraphMaterializeResult graph_execution_materialize_slice(
             if (ref.source == static_cast<uint8_t>(GraphScalarSource::STATIC_VALUE)) {
                 payload.scalars[j] = definition_scalars[scalar_index];
             } else if (ref.source == static_cast<uint8_t>(GraphScalarSource::BOUNDARY)) {
-                if (ref.source_index >= execution.boundary_scalar_count || execution.boundary_scalars == nullptr) {
+                const uint64_t *boundary = execution.boundary_payload == nullptr ?
+                                               nullptr :
+                                               graph_task_payload_scalar(*execution.boundary_payload, ref.source_index);
+                if (ref.source_index >= execution.boundary_scalar_count || boundary == nullptr) {
                     execution.materialize_busy.store(0, std::memory_order_release);
                     return GraphMaterializeResult::INVALID;
                 }
-                payload.scalars[j] = execution.boundary_scalars[ref.source_index];
+                payload.scalars[j] = *boundary;
             } else {
                 execution.materialize_busy.store(0, std::memory_order_release);
                 return GraphMaterializeResult::INVALID;

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -166,6 +166,9 @@ struct GraphDefinition {
     // required_heap + this, and the execution lives at
     // packed_buffer_base + required_heap.
     uint32_t execution_storage_bytes;
+    // Distance between consecutive GraphNodeStorage entries. Every entry is a
+    // complete C++ object, so valid Definitions carry sizeof(GraphNodeStorage).
+    uint32_t node_stride;
     uint32_t off_fanout_offsets;
     uint32_t off_fanout_indices;
     uint32_t off_fanin_offsets;
@@ -195,11 +198,7 @@ struct GraphSubmission {
     uint64_t definition_addr;
     uint64_t definition_hash;
     uint32_t activation_gate;
-    uint32_t total_bytes;
-    uint32_t tensors_offset;
-    uint32_t tensor_count;
-    uint32_t scalars_offset;
-    uint32_t scalar_count;
+    uint32_t reserved;
 };
 
 static_assert(std::is_trivially_copyable_v<GraphTensorSourceRef>);
@@ -301,31 +300,57 @@ inline GraphSubmission *graph_submission_from_slot(PTO2TaskSlotState &slot) {
     return slot.task_kind == TaskKind::GRAPH ? static_cast<GraphSubmission *>(slot.graph_context) : nullptr;
 }
 
-inline bool graph_submission_wire_size_valid(const GraphSubmission &submission, size_t available_bytes) {
-    return available_bytes >= sizeof(GraphSubmission) && submission.total_bytes == available_bytes;
+// Graph tasks share the ordinary scheduling payload prefix. Boundary args that
+// exceed the AICore ABI capacities continue in the same TaskPayloadSpace record:
+// [PTO2TaskPayload][extra ChipTensor...][extra uint64_t...], rounded to a cache
+// line. Ordinary kernel payloads remain exactly sizeof(PTO2TaskPayload).
+inline bool graph_task_payload_layout(
+    int32_t tensor_count, int32_t scalar_count, size_t *payload_bytes, size_t *extra_scalars_offset = nullptr
+) {
+    if (payload_bytes == nullptr || tensor_count < 0 || scalar_count < 0 ||
+        tensor_count > static_cast<int32_t>(GRAPH_MAX_TENSOR_ARGS) ||
+        scalar_count > static_cast<int32_t>(GRAPH_MAX_SCALAR_ARGS)) {
+        return false;
+    }
+    const size_t extra_tensors =
+        tensor_count > MAX_TENSOR_ARGS ? static_cast<size_t>(tensor_count - MAX_TENSOR_ARGS) : 0;
+    const size_t extra_scalars =
+        scalar_count > MAX_SCALAR_ARGS ? static_cast<size_t>(scalar_count - MAX_SCALAR_ARGS) : 0;
+    if (extra_tensors > (SIZE_MAX - sizeof(PTO2TaskPayload)) / sizeof(ChipTensor)) return false;
+    const size_t scalars_offset = sizeof(PTO2TaskPayload) + extra_tensors * sizeof(ChipTensor);
+    if (extra_scalars > (SIZE_MAX - scalars_offset) / sizeof(uint64_t)) return false;
+    const size_t end = scalars_offset + extra_scalars * sizeof(uint64_t);
+    if (end > SIZE_MAX - (alignof(PTO2TaskPayload) - 1)) return false;
+    *payload_bytes = PTO2_ALIGN_UP(end, alignof(PTO2TaskPayload));
+    if (extra_scalars_offset != nullptr) *extra_scalars_offset = scalars_offset;
+    return true;
 }
 
-inline const GraphTensor *graph_submission_tensors(const GraphSubmission &submission) {
-    if (submission.tensors_offset == 0 || submission.tensors_offset % alignof(GraphTensor) != 0 ||
-        submission.tensors_offset > submission.total_bytes ||
-        submission.tensor_count > (submission.total_bytes - submission.tensors_offset) / sizeof(GraphTensor)) {
-        return nullptr;
-    }
-    return reinterpret_cast<const GraphTensor *>(
-        reinterpret_cast<const uint8_t *>(&submission) + submission.tensors_offset
-    );
+inline ChipTensor *graph_task_payload_tensor(PTO2TaskPayload &payload, uint32_t index) {
+    if (payload.tensor_count < 0 || index >= static_cast<uint32_t>(payload.tensor_count)) return nullptr;
+    if (index < MAX_TENSOR_ARGS) return &payload.tensors[index];
+    auto *extra = reinterpret_cast<ChipTensor *>(reinterpret_cast<std::byte *>(&payload) + sizeof(payload));
+    return &extra[index - MAX_TENSOR_ARGS];
 }
 
-inline const uint64_t *graph_submission_scalars(const GraphSubmission &submission) {
-    if (submission.scalar_count == 0) return nullptr;
-    if (submission.scalars_offset == 0 || submission.scalars_offset % alignof(uint64_t) != 0 ||
-        submission.scalars_offset > submission.total_bytes ||
-        submission.scalar_count > (submission.total_bytes - submission.scalars_offset) / sizeof(uint64_t)) {
+inline const ChipTensor *graph_task_payload_tensor(const PTO2TaskPayload &payload, uint32_t index) {
+    return graph_task_payload_tensor(const_cast<PTO2TaskPayload &>(payload), index);
+}
+
+inline uint64_t *graph_task_payload_scalar(PTO2TaskPayload &payload, uint32_t index) {
+    if (payload.scalar_count < 0 || index >= static_cast<uint32_t>(payload.scalar_count)) return nullptr;
+    if (index < MAX_SCALAR_ARGS) return &payload.scalars[index];
+    size_t payload_bytes = 0;
+    size_t scalars_offset = 0;
+    if (!graph_task_payload_layout(payload.tensor_count, payload.scalar_count, &payload_bytes, &scalars_offset)) {
         return nullptr;
     }
-    return reinterpret_cast<const uint64_t *>(
-        reinterpret_cast<const uint8_t *>(&submission) + submission.scalars_offset
-    );
+    auto *extra = reinterpret_cast<uint64_t *>(reinterpret_cast<std::byte *>(&payload) + scalars_offset);
+    return &extra[index - MAX_SCALAR_ARGS];
+}
+
+inline const uint64_t *graph_task_payload_scalar(const PTO2TaskPayload &payload, uint32_t index) {
+    return graph_task_payload_scalar(const_cast<PTO2TaskPayload &>(payload), index);
 }
 
 enum class GraphExecutionState : uint8_t {
@@ -345,8 +370,8 @@ enum class GraphMaterializeResult : uint8_t {
 
 struct alignas(64) GraphNodeStorage {
     PTO2TaskDescriptor task;
-    PTO2TaskPayload payload;
     PTO2TaskSlotState slot;
+    PTO2TaskPayload payload;
 };
 
 inline constexpr uint64_t GRAPH_EXECUTION_INITIALIZING = 1;
@@ -370,13 +395,23 @@ struct GraphExecution {
     PTO2TaskSlotState *outer_slot{nullptr};
     GraphNodeStorage *nodes{nullptr};
     GraphNodeStorage *node_storage{nullptr};
+    // Kept in the wire Definition for validation; every entry is one complete
+    // GraphNodeStorage object.
+    size_t node_stride{sizeof(GraphNodeStorage)};
     const GraphDefinition *definition{nullptr};
     const uint32_t *fanin_offsets{nullptr};
     const uint16_t *fanin_indices{nullptr};
-    const GraphTensor *boundary_tensors{nullptr};
+    // Borrowed for the replay lifetime; accessors resolve its fixed prefix and
+    // variable overflow tail without requiring the args to be contiguous.
+    const PTO2TaskPayload *boundary_payload{nullptr};
     uint32_t boundary_tensor_count{0};
-    const uint64_t *boundary_scalars{nullptr};
     uint32_t boundary_scalar_count{0};
+
+    GraphNodeStorage &node_at(int32_t index) const {
+        return *reinterpret_cast<GraphNodeStorage *>(
+            reinterpret_cast<uint8_t *>(node_storage) + static_cast<size_t>(index) * node_stride
+        );
+    }
 };
 
 static_assert(std::is_trivially_destructible_v<GraphNodeStorage>);
@@ -384,9 +419,14 @@ static_assert(std::is_trivially_destructible_v<GraphExecution>);
 
 // The execution occupies [GraphExecution][GraphNodeStorage x node_count] at the
 // tail of the outer GRAPH task's heap allocation.
-inline bool graph_execution_storage_layout(int32_t node_count, size_t *nodes_offset, size_t *storage_bytes) {
+inline constexpr size_t graph_node_stride_floor() noexcept { return sizeof(GraphNodeStorage); }
+
+inline size_t graph_node_stride(int32_t) noexcept { return sizeof(GraphNodeStorage); }
+
+inline bool
+graph_execution_storage_layout(int32_t node_count, size_t node_stride, size_t *nodes_offset, size_t *storage_bytes) {
     if (nodes_offset == nullptr || storage_bytes == nullptr || node_count <= 0 ||
-        node_count > static_cast<int32_t>(GRAPH_MAX_NODES)) {
+        node_count > static_cast<int32_t>(GRAPH_MAX_NODES) || node_stride != sizeof(GraphNodeStorage)) {
         return false;
     }
     constexpr size_t ALIGNMENT = alignof(GraphNodeStorage);
@@ -395,9 +435,9 @@ inline bool graph_execution_storage_layout(int32_t node_count, size_t *nodes_off
     return true;
 }
 
-inline bool graph_execution_storage_bytes(int32_t node_count, size_t *storage_bytes) {
+inline bool graph_execution_storage_bytes(int32_t node_count, size_t node_stride, size_t *storage_bytes) {
     size_t nodes_offset = 0;
-    return graph_execution_storage_layout(node_count, &nodes_offset, storage_bytes);
+    return graph_execution_storage_layout(node_count, node_stride, &nodes_offset, storage_bytes);
 }
 
 GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot);

--- a/src/common/platform/include/common/host_api.h
+++ b/src/common/platform/include/common/host_api.h
@@ -51,17 +51,6 @@ struct HostApiOps {
     // {nullptr, 0} when nothing is retained yet.
     void (*get_retained_temp_buffer)(void *runner_ctx, uint32_t pipeline_slot, void **addr, size_t *size);
     void (*set_retained_temp_buffer)(void *runner_ctx, uint32_t pipeline_slot, void *addr, size_t size);
-    // Runner-owned Graph Definition storage, keyed by the Definition's content
-    // identity (full_key, content_hash, total_bytes folded into one key by the
-    // caller). Grow-only retention: one block per key, reused while capacity
-    // fits, a growth request replaces the entry, all blocks released at Worker
-    // finalization. `alignment` must be a power of two. Lets every submission
-    // of one run reference a single device-resident Definition instead of each
-    // carrying a full copy. Execution storage needs no counterpart here — it is
-    // the tail of the outer Graph task's own heap allocation.
-    void *(*acquire_graph_definition_buffer)(
-        void *runner_ctx, uint32_t pipeline_slot, uint64_t key, size_t bytes, size_t alignment
-    );
     // Commit the three pooled regions (GM heap, runtime shared memory, and
     // prebuilt runtime arena) of the arena bank selected by this run, as three
     // independent device allocations. `runtime_arena_size == 0` skips the
@@ -157,10 +146,6 @@ public:
     }
     void set_retained_temp_buffer(void *addr, size_t size) const {
         ops_->set_retained_temp_buffer(runner_ctx_, pipeline_slot_, addr, size);
-    }
-    void *acquire_graph_definition_buffer(uint64_t key, size_t bytes, size_t alignment) const {
-        if (ops_->acquire_graph_definition_buffer == nullptr) return nullptr;
-        return ops_->acquire_graph_definition_buffer(runner_ctx_, pipeline_slot_, key, bytes, alignment);
     }
     int setup_static_arena(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size) const {
         return ops_->setup_static_arena(runner_ctx_, arena_bank_, gm_heap_size, gm_sm_size, runtime_arena_size);

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -156,18 +156,6 @@ static void set_retained_temp_buffer(void *runner_ctx, uint32_t pipeline_slot, v
     } catch (...) {}
 }
 
-static void *acquire_graph_definition_buffer(
-    void *runner_ctx, uint32_t pipeline_slot, uint64_t key, size_t bytes, size_t alignment
-) {
-    if (runner_ctx == nullptr) return nullptr;
-    try {
-        return static_cast<DeviceRunnerBase *>(runner_ctx)
-            ->acquire_graph_definition_buffer(pipeline_slot, key, bytes, alignment);
-    } catch (...) {
-        return nullptr;
-    }
-}
-
 static uint64_t upload_chip_callable_buffer_wrapper(void *runner_ctx, const void *callable) {
     if (runner_ctx == nullptr) return 0;
     try {
@@ -281,7 +269,6 @@ static const HostApiOps g_host_api_ops = {
     .device_memset = device_memset,
     .get_retained_temp_buffer = get_retained_temp_buffer,
     .set_retained_temp_buffer = set_retained_temp_buffer,
-    .acquire_graph_definition_buffer = acquire_graph_definition_buffer,
     .setup_static_arena = setup_static_arena_wrapper,
     .acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper,
     .acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper,

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -173,55 +173,6 @@ void DeviceRunnerBase::set_retained_temp_buffer(uint32_t pipeline_slot, void *ad
     retained_temp_sizes_[pipeline_slot] = size;
 }
 
-void *DeviceRunnerBase::acquire_graph_definition_buffer(
-    uint32_t pipeline_slot, uint64_t key, size_t bytes, size_t alignment
-) {
-    if (pipeline_slot >= graph_definition_buffers_.size() || bytes == 0 || alignment == 0 ||
-        (alignment & (alignment - 1)) != 0 || bytes > SIZE_MAX - (alignment - 1)) {
-        return nullptr;
-    }
-    RetainedGraphBuffer &buffer = graph_definition_buffers_[pipeline_slot][key];
-    if (buffer.aligned_addr != nullptr && buffer.capacity >= bytes &&
-        reinterpret_cast<uintptr_t>(buffer.aligned_addr) % alignment == 0) {
-        return buffer.aligned_addr;
-    }
-
-    const size_t allocation_bytes = bytes + alignment - 1;
-    void *allocation = mem_alloc_.alloc(allocation_bytes);
-    if (allocation == nullptr) return nullptr;
-    const uintptr_t raw = reinterpret_cast<uintptr_t>(allocation);
-    if (raw > UINTPTR_MAX - (alignment - 1)) {
-        mem_alloc_.free(allocation);
-        return nullptr;
-    }
-    void *aligned_addr = reinterpret_cast<void *>((raw + alignment - 1) & ~(alignment - 1));
-    if (device_memset(aligned_addr, 0, bytes) != 0) {
-        mem_alloc_.free(allocation);
-        return nullptr;
-    }
-    if (buffer.allocation != nullptr && mem_alloc_.free(buffer.allocation) != 0) {
-        mem_alloc_.free(allocation);
-        return nullptr;
-    }
-    buffer = RetainedGraphBuffer{allocation, aligned_addr, bytes};
-    return aligned_addr;
-}
-
-void DeviceRunnerBase::release_graph_definition_buffers() {
-    for (GraphDefinitionBufferMap &by_key : graph_definition_buffers_) {
-        for (auto &entry : by_key) {
-            if (entry.second.allocation != nullptr) mem_alloc_.free(entry.second.allocation);
-        }
-        by_key.clear();
-    }
-}
-
-void DeviceRunnerBase::abandon_graph_definition_buffers() {
-    for (GraphDefinitionBufferMap &by_key : graph_definition_buffers_) {
-        by_key.clear();
-    }
-}
-
 void DeviceRunnerBase::clear_temporary_buffer() {
     for (size_t slot = 0; slot < retained_temp_addrs_.size(); ++slot) {
         if (retained_temp_addrs_[slot] == nullptr) continue;
@@ -1438,11 +1389,9 @@ int DeviceRunnerBase::finalize_common_impl(bool abandon_device_resources) {
     prebuilt_runtime_arena_cache_image_.clear();
 
     if (abandon_device_resources) {
-        abandon_graph_definition_buffers();
         retained_temp_addrs_.fill(nullptr);
         retained_temp_sizes_.fill(0);
     } else {
-        release_graph_definition_buffers();
         clear_temporary_buffer();
     }
 

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -14,8 +14,8 @@
  *
  * This module owns the host-side state and methods that are identical
  * between the two onboard arches today:
- *   - The `MemoryAllocator` and the three `DeviceArena`s (gm heap, PTO2
- *     SM, runtime arena) backing the per-Worker pooled regions.
+ *   - The `MemoryAllocator` and arena-bank-owned `DeviceArena`s backing GM
+ *     heap, PTO2 SM, and the runtime arena.
  *   - The trivial tensor-memory wrappers (`allocate_tensor`,
  *     `free_tensor`, `copy_*_device`).
  *   - The arena-pool accessors (`acquire_pooled_gm_heap`, etc.).
@@ -144,8 +144,6 @@ public:
     int device_memset(void *dev_ptr, int value, std::size_t bytes);
     void get_retained_temp_buffer(uint32_t pipeline_slot, void **addr, std::size_t *size);
     void set_retained_temp_buffer(uint32_t pipeline_slot, void *addr, std::size_t size);
-    void *
-    acquire_graph_definition_buffer(uint32_t pipeline_slot, uint64_t key, std::size_t bytes, std::size_t alignment);
     void clear_temporary_buffer();
     /**
      * Map a device buffer into the host address space and return a
@@ -954,7 +952,7 @@ protected:
      *   - aicore_bin_handle_ + binaries_loaded_ reset
      *   - chip_callable_buffers_ free + clear
      *   - callables_ dlclose-on-hbg + clear + aicpu counter reset
-     *   - 3 arenas release + cached size reset
+     *   - arena-bank regions release + cached size reset
      *   - device_wall_dev_ptr_ free (before mem_alloc_.finalize)
      *   - mem_alloc_.finalize
      *   - block_dim_, worker_count_, aicore_kernel_binary_ reset
@@ -968,17 +966,6 @@ protected:
      * @return 0 on success, first nonzero rc encountered otherwise.
      */
     int finalize_common();
-    void release_graph_definition_buffers();
-
-    /**
-     * Drop the retained graph-definition buffers without freeing them.
-     *
-     * The fatal counterpart of release_graph_definition_buffers(): a force reset
-     * has already invalidated every allocation, so only the host-side map is
-     * cleared.
-     */
-    void abandon_graph_definition_buffers();
-
     /**
      * Clear host-side ownership after a fatal device failure without issuing
      * per-resource RTS calls. The caller must first attempt a force reset.
@@ -1133,21 +1120,7 @@ protected:
     // the grow/pack logic lives in trb bind.
     std::array<void *, PTO_PIPELINE_MAX_DEPTH> retained_temp_addrs_{};
     std::array<std::size_t, PTO_PIPELINE_MAX_DEPTH> retained_temp_sizes_{};
-    // One retained device block: the raw allocation plus the aligned address
-    // handed out. Backs the Graph Definition cache below.
-    struct RetainedGraphBuffer {
-        void *allocation{nullptr};
-        void *aligned_addr{nullptr};
-        std::size_t capacity{0};
-    };
-    // Graph Definition storage, one retained block per (pipeline slot,
-    // definition key) — see HostApi acquire_graph_definition_buffer. Keyed by
-    // content identity rather than occurrence: every submission of one run
-    // references the same device-resident Definition.
-    using GraphDefinitionBufferMap = std::unordered_map<uint64_t, RetainedGraphBuffer>;
-    std::array<GraphDefinitionBufferMap, PTO_PIPELINE_MAX_DEPTH> graph_definition_buffers_{};
-
-    // One independently committed set of the three pooled device regions. A
+    // One independently committed set of pooled device regions. A
     // run reaches its set through the arena bank its lease selects, so
     // preparing one bank never mutates a region the active run is executing
     // out of. `cached_*` back `setup_static_arena`'s "fits" check: a later

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -142,18 +142,6 @@ static void set_retained_temp_buffer(void *runner_ctx, uint32_t pipeline_slot, v
     } catch (...) {}
 }
 
-static void *acquire_graph_definition_buffer(
-    void *runner_ctx, uint32_t pipeline_slot, uint64_t key, size_t bytes, size_t alignment
-) {
-    if (runner_ctx == nullptr) return nullptr;
-    try {
-        return static_cast<SimDeviceRunnerBase *>(runner_ctx)
-            ->acquire_graph_definition_buffer(pipeline_slot, key, bytes, alignment);
-    } catch (...) {
-        return nullptr;
-    }
-}
-
 static uint64_t upload_chip_callable_buffer_wrapper(void *runner_ctx, const void *callable) {
     if (runner_ctx == nullptr) return 0;
     try {
@@ -268,7 +256,6 @@ static const HostApiOps g_host_api_ops = {
     .device_memset = device_memset,
     .get_retained_temp_buffer = get_retained_temp_buffer,
     .set_retained_temp_buffer = set_retained_temp_buffer,
-    .acquire_graph_definition_buffer = acquire_graph_definition_buffer,
     .setup_static_arena = setup_static_arena_wrapper,
     .acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper,
     .acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper,

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -374,49 +374,6 @@ void SimDeviceRunnerBase::set_retained_temp_buffer(uint32_t pipeline_slot, void 
     retained_temp_sizes_[pipeline_slot] = size;
 }
 
-void *SimDeviceRunnerBase::acquire_graph_definition_buffer(
-    uint32_t pipeline_slot, uint64_t key, size_t bytes, size_t alignment
-) {
-    if (pipeline_slot >= graph_definition_buffers_.size() || bytes == 0 || alignment == 0 ||
-        (alignment & (alignment - 1)) != 0 || bytes > SIZE_MAX - (alignment - 1)) {
-        return nullptr;
-    }
-    RetainedGraphBuffer &buffer = graph_definition_buffers_[pipeline_slot][key];
-    if (buffer.aligned_addr != nullptr && buffer.capacity >= bytes &&
-        reinterpret_cast<uintptr_t>(buffer.aligned_addr) % alignment == 0) {
-        return buffer.aligned_addr;
-    }
-
-    const size_t allocation_bytes = bytes + alignment - 1;
-    void *allocation = mem_alloc_.alloc(allocation_bytes);
-    if (allocation == nullptr) return nullptr;
-    const uintptr_t raw = reinterpret_cast<uintptr_t>(allocation);
-    if (raw > UINTPTR_MAX - (alignment - 1)) {
-        mem_alloc_.free(allocation);
-        return nullptr;
-    }
-    void *aligned_addr = reinterpret_cast<void *>((raw + alignment - 1) & ~(alignment - 1));
-    if (device_memset(aligned_addr, 0, bytes) != 0) {
-        mem_alloc_.free(allocation);
-        return nullptr;
-    }
-    if (buffer.allocation != nullptr && mem_alloc_.free(buffer.allocation) != 0) {
-        mem_alloc_.free(allocation);
-        return nullptr;
-    }
-    buffer = RetainedGraphBuffer{allocation, aligned_addr, bytes};
-    return aligned_addr;
-}
-
-void SimDeviceRunnerBase::release_graph_definition_buffers() {
-    for (GraphDefinitionBufferMap &by_key : graph_definition_buffers_) {
-        for (auto &entry : by_key) {
-            if (entry.second.allocation != nullptr) mem_alloc_.free(entry.second.allocation);
-        }
-        by_key.clear();
-    }
-}
-
 void SimDeviceRunnerBase::clear_temporary_buffer() {
     for (size_t slot = 0; slot < retained_temp_addrs_.size(); ++slot) {
         if (retained_temp_addrs_[slot] == nullptr) continue;

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -194,7 +194,6 @@ public:
     int device_memset(void *dev_ptr, int value, size_t bytes);
     void get_retained_temp_buffer(uint32_t pipeline_slot, void **addr, size_t *size);
     void set_retained_temp_buffer(uint32_t pipeline_slot, void *addr, size_t size);
-    void *acquire_graph_definition_buffer(uint32_t pipeline_slot, uint64_t key, size_t bytes, size_t alignment);
     void clear_temporary_buffer();
 
     // On sim, allocate_tensor returns a plain host pointer, so the "device"
@@ -313,7 +312,6 @@ protected:
     // Bulk-free the shared callable / chip-callable / orch-SO state. Subclass
     // finalize() calls this before mem_alloc_.finalize(). Idempotent.
     void release_callable_state();
-    void release_graph_definition_buffers();
 
     // --- Shared state (protected so subclass execution / init_* / finalize()
     // can read or write directly) ----------------------------------------
@@ -334,20 +332,8 @@ protected:
     MemoryAllocator mem_alloc_;
     std::array<void *, PTO_PIPELINE_MAX_DEPTH> retained_temp_addrs_{};
     std::array<size_t, PTO_PIPELINE_MAX_DEPTH> retained_temp_sizes_{};
-    // One retained device block: the raw allocation plus the aligned address
-    // handed out. Backs the Graph Definition cache below.
-    struct RetainedGraphBuffer {
-        void *allocation{nullptr};
-        void *aligned_addr{nullptr};
-        size_t capacity{0};
-    };
-    // Graph Definition storage, one retained block per (pipeline slot,
-    // definition key) — see HostApi acquire_graph_definition_buffer.
-    using GraphDefinitionBufferMap = std::unordered_map<uint64_t, RetainedGraphBuffer>;
-    std::array<GraphDefinitionBufferMap, PTO_PIPELINE_MAX_DEPTH> graph_definition_buffers_{};
-
-    // Each arena bank backs the three pooled regions (PTO2 GM heap / PTO2
-    // shared memory / trb prebuilt runtime arena) for one pipeline slot. They
+    // Each arena bank backs the pooled regions (PTO2 GM heap / PTO2 shared
+    // memory / prebuilt runtime arena) for one pipeline slot. They
     // are separate allocations because the combined size can exceed the device
     // allocator's largest contiguous block. Released explicitly in finalize()
     // before mem_alloc_.finalize().

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -846,6 +846,8 @@ add_a2a3_hbg_runtime_test(test_hbg_core_tracker common/test_hbg_core_tracker.cpp
 # shared init TU (and the orchestrator/SM members that TU refers to).
 add_a2a3_hbg_runtime_test(test_hbg_ready_queue_seed common/test_hbg_ready_queue_seed.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_mailbox_init common/test_hbg_mailbox_init.cpp)
+add_a2a3_hbg_runtime_test(test_hbg_self_relative_ptr common/test_hbg_self_relative_ptr.cpp)
+add_a2a3_hbg_runtime_test(test_hbg_sm_compaction common/test_hbg_sm_compaction.cpp)
 target_sources(test_hbg_ready_queue_seed PRIVATE
     ${HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
     ${HBG_RUNTIME_DIR}/orchestrator_core/pto_ring_buffer.cpp
@@ -878,6 +880,18 @@ target_sources(test_hbg_graph_submit_failure PRIVATE
     ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
 )
 add_a2a3_hbg_runtime_test(test_hbg_graph_async_submit common/test_hbg_graph_async_submit.cpp)
+# Drives the real orchestrator submit and Graph placement paths, so it links the
+# same out-of-line members as the graph-submit test.
+add_a2a3_hbg_runtime_test(test_hbg_slot_claim common/test_hbg_slot_claim.cpp)
+target_sources(test_hbg_slot_claim PRIVATE
+    ${HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
+    ${HBG_RUNTIME_DIR}/orchestrator_core/pto_ring_buffer.cpp
+    ${HBG_RUNTIME_DIR}/shared/pto_shared_memory.cpp
+    ${HBG_RUNTIME_DIR}/shared/pto_tensormap.cpp
+    ${HBG_RUNTIME_DIR}/shared/pto_runtime2_init.cpp
+    ${HBG_RUNTIME_DIR}/shared/runtime.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+)
 add_a5_hbg_runtime_test(test_a5_hbg_graph_submit_failure common/test_hbg_graph_submit_failure.cpp)
 target_sources(test_a5_hbg_graph_submit_failure PRIVATE
     ${A5_HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
@@ -889,9 +903,21 @@ target_sources(test_a5_hbg_graph_submit_failure PRIVATE
     ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
 )
 add_a5_hbg_runtime_test(test_a5_hbg_graph_async_submit common/test_hbg_graph_async_submit.cpp)
+add_a5_hbg_runtime_test(test_a5_hbg_slot_claim common/test_hbg_slot_claim.cpp)
+target_sources(test_a5_hbg_slot_claim PRIVATE
+    ${A5_HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
+    ${A5_HBG_RUNTIME_DIR}/orchestrator_core/pto_ring_buffer.cpp
+    ${A5_HBG_RUNTIME_DIR}/shared/pto_shared_memory.cpp
+    ${A5_HBG_RUNTIME_DIR}/shared/pto_tensormap.cpp
+    ${A5_HBG_RUNTIME_DIR}/shared/pto_runtime2_init.cpp
+    ${A5_HBG_RUNTIME_DIR}/shared/runtime.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+)
 add_a5_hbg_runtime_test(test_a5_hbg_core_tracker common/test_hbg_core_tracker.cpp)
 add_a5_hbg_runtime_test(test_a5_hbg_ready_queue_seed common/test_hbg_ready_queue_seed.cpp)
 add_a5_hbg_runtime_test(test_a5_hbg_mailbox_init common/test_hbg_mailbox_init.cpp)
+add_a5_hbg_runtime_test(test_a5_hbg_self_relative_ptr common/test_hbg_self_relative_ptr.cpp)
+add_a5_hbg_runtime_test(test_a5_hbg_sm_compaction common/test_hbg_sm_compaction.cpp)
 target_sources(test_a5_hbg_ready_queue_seed PRIVATE
     ${A5_HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
     ${A5_HBG_RUNTIME_DIR}/orchestrator_core/pto_ring_buffer.cpp

--- a/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
@@ -142,8 +142,8 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
         SCOPED_TRACE(testing::Message() << "slot local_id=" << local);
         const int32_t slot = ring.get_slot_by_task_id(local);
         const PTO2TaskDescriptor &desc = ring.task_descriptors[slot];
-        const PTO2TaskPayload &pl = ring.task_payloads[slot];
         const PTO2TaskSlotState &st = ring.slot_states[slot];
+        const PTO2TaskPayload &pl = *st.payload;
 
         // Descriptor: the task id is written to this exact local id.
         EXPECT_EQ(desc.task_id.local(), static_cast<uint32_t>(local));
@@ -170,8 +170,9 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     }
 
     // Field-specific coverage on the real task: tensors, scalar, packed output buffer.
-    const PTO2TaskDescriptor &root_desc = ring.task_descriptors[ring.get_slot_by_task_id(root.task_id().local())];
-    const PTO2TaskPayload &root_pl = ring.task_payloads[ring.get_slot_by_task_id(root.task_id().local())];
+    const int32_t root_slot = ring.get_slot_by_task_id(root.task_id().local());
+    const PTO2TaskDescriptor &root_desc = ring.task_descriptors[root_slot];
+    const PTO2TaskPayload &root_pl = *ring.slot_states[root_slot].payload;
     EXPECT_EQ(root_pl.tensor_count, 1);
     EXPECT_EQ(root_pl.scalar_count, 1);
     EXPECT_EQ(root_pl.dump_metadata.dump_arg_mask, (uint64_t{1} << 0) | (uint64_t{1} << 1));
@@ -182,7 +183,8 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     EXPECT_EQ(root_desc.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)], 0);
 
     // The consumer's fanin is written: two duplicate deps dedupe to one.
-    const PTO2TaskPayload &cons_pl = ring.task_payloads[ring.get_slot_by_task_id(consumer.task_id().local())];
+    const int32_t consumer_slot = ring.get_slot_by_task_id(consumer.task_id().local());
+    const PTO2TaskPayload &cons_pl = *ring.slot_states[consumer_slot].payload;
     EXPECT_EQ(cons_pl.fanin_count, 1);
     EXPECT_EQ(cons_pl.fanin_local_ids[0], static_cast<int32_t>(root.task_id().local()));
 }

--- a/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
@@ -142,8 +142,8 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
         SCOPED_TRACE(testing::Message() << "slot local_id=" << local);
         const int32_t slot = ring.get_slot_by_task_id(local);
         const PTO2TaskDescriptor &desc = ring.task_descriptors[slot];
-        const PTO2TaskPayload &pl = ring.task_payloads[slot];
         const PTO2TaskSlotState &st = ring.slot_states[slot];
+        const PTO2TaskPayload &pl = *st.payload;
 
         // Descriptor: the task id is written to this exact local id.
         EXPECT_EQ(desc.task_id.local(), static_cast<uint32_t>(local));
@@ -170,8 +170,9 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     }
 
     // Field-specific coverage on the real task: tensors, scalar, packed output buffer.
-    const PTO2TaskDescriptor &root_desc = ring.task_descriptors[ring.get_slot_by_task_id(root.task_id().local())];
-    const PTO2TaskPayload &root_pl = ring.task_payloads[ring.get_slot_by_task_id(root.task_id().local())];
+    const int32_t root_slot = ring.get_slot_by_task_id(root.task_id().local());
+    const PTO2TaskDescriptor &root_desc = ring.task_descriptors[root_slot];
+    const PTO2TaskPayload &root_pl = *ring.slot_states[root_slot].payload;
     EXPECT_EQ(root_pl.tensor_count, 1);
     EXPECT_EQ(root_pl.scalar_count, 1);
     EXPECT_EQ(root_pl.dump_metadata.dump_arg_mask, (uint64_t{1} << 0) | (uint64_t{1} << 1));
@@ -182,7 +183,8 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     EXPECT_EQ(root_desc.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)], 0);
 
     // The consumer's fanin is written: two duplicate deps dedupe to one.
-    const PTO2TaskPayload &cons_pl = ring.task_payloads[ring.get_slot_by_task_id(consumer.task_id().local())];
+    const int32_t consumer_slot = ring.get_slot_by_task_id(consumer.task_id().local());
+    const PTO2TaskPayload &cons_pl = *ring.slot_states[consumer_slot].payload;
     EXPECT_EQ(cons_pl.fanin_count, 1);
     EXPECT_EQ(cons_pl.fanin_local_ids[0], static_cast<int32_t>(root.task_id().local()));
 }

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -51,7 +51,9 @@ GraphTensor make_test_tensor(uint64_t address) {
     return tensor;
 }
 
-std::vector<std::byte> make_test_definition(uint64_t graph_key, uint64_t boundary_address) {
+std::vector<std::byte> make_test_definition(
+    uint64_t graph_key, uint64_t boundary_address, uint32_t boundary_count = 1, uint32_t boundary_scalar_count = 1
+) {
     std::vector<std::byte> image(sizeof(GraphDefinition));
 
     std::vector<uint32_t> fanin_offsets{0, 0, 1};
@@ -94,8 +96,8 @@ std::vector<std::byte> make_test_definition(uint64_t graph_key, uint64_t boundar
     definition.task_count = 2;
     definition.edge_count = 1;
     definition.root_count = 1;
-    definition.boundary_count = 1;
-    definition.boundary_scalar_count = 1;
+    definition.boundary_count = boundary_count;
+    definition.boundary_scalar_count = boundary_scalar_count;
     definition.tensor_arg_count = 2;
     definition.scalar_arg_count = 2;
     definition.off_fanin_offsets = append_section(image, fanin_offsets);
@@ -109,8 +111,12 @@ std::vector<std::byte> make_test_definition(uint64_t graph_key, uint64_t boundar
     definition.off_tensor_sources = append_section(image, tensor_sources);
     definition.off_scalars = append_section(image, scalars);
     definition.off_scalar_sources = append_section(image, scalar_sources);
+    // Widest node here declares one tensor, so the storage strides well below the
+    // type; the fixture exercises the compacted stride rather than the identity case.
+    const size_t node_stride = graph_node_stride(1);
     size_t execution_storage_bytes = 0;
-    graph_execution_storage_bytes(static_cast<int32_t>(definition.task_count), &execution_storage_bytes);
+    graph_execution_storage_bytes(static_cast<int32_t>(definition.task_count), node_stride, &execution_storage_bytes);
+    definition.node_stride = static_cast<uint32_t>(node_stride);
     definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
     definition.total_bytes = static_cast<uint32_t>(image.size());
     std::memcpy(image.data(), &definition, sizeof(definition));
@@ -120,23 +126,21 @@ std::vector<std::byte> make_test_definition(uint64_t graph_key, uint64_t boundar
     return image;
 }
 
-std::vector<std::byte> make_test_submission(uint64_t graph_key, uint64_t boundary_address, uint64_t boundary_scalar) {
-    const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphTensor));
-    const size_t scalars_offset = PTO2_ALIGN_UP(tensors_offset + sizeof(GraphTensor), alignof(uint64_t));
-    std::vector<std::byte> image(scalars_offset + sizeof(uint64_t));
-    const GraphTensor boundary = make_test_tensor(boundary_address);
-    std::memcpy(image.data() + tensors_offset, &boundary, sizeof(boundary));
-    std::memcpy(image.data() + scalars_offset, &boundary_scalar, sizeof(boundary_scalar));
-
+std::vector<std::byte> make_test_submission(uint64_t graph_key) {
+    std::vector<std::byte> image(sizeof(GraphSubmission));
     GraphSubmission submission{};
     submission.graph_key = graph_key;
-    submission.total_bytes = static_cast<uint32_t>(image.size());
-    submission.tensors_offset = static_cast<uint32_t>(tensors_offset);
-    submission.tensor_count = 1;
-    submission.scalars_offset = static_cast<uint32_t>(scalars_offset);
-    submission.scalar_count = 1;
     std::memcpy(image.data(), &submission, sizeof(submission));
     return image;
+}
+
+// The boundary args of a replay, where graph_execution_localize reads them: the
+// outer GRAPH task's own payload, in ChipTensor form like any other task's args.
+void set_test_boundary(PTO2TaskPayload *payload, uint64_t boundary_address, uint64_t boundary_scalar) {
+    payload->tensor_count = 1;
+    payload->scalar_count = 1;
+    graph_tensor_unpack(make_test_tensor(boundary_address), &payload->tensors[0]);
+    payload->scalars[0] = boundary_scalar;
 }
 
 // A Definition device object exactly as upload_graph_submissions builds it:
@@ -218,6 +222,100 @@ private:
 
 }  // namespace
 
+TEST(GraphTaskPayloadSpace, Dsv4BoundaryArgsRoundTrip) {
+    constexpr int32_t TENSOR_COUNT = 118;
+    constexpr int32_t SCALAR_COUNT = 31;
+    size_t payload_bytes = 0;
+    size_t scalars_offset = 0;
+    ASSERT_TRUE(graph_task_payload_layout(TENSOR_COUNT, SCALAR_COUNT, &payload_bytes, &scalars_offset));
+    EXPECT_GT(payload_bytes, sizeof(PTO2TaskPayload));
+    EXPECT_EQ(scalars_offset, sizeof(PTO2TaskPayload) + (TENSOR_COUNT - MAX_TENSOR_ARGS) * sizeof(ChipTensor));
+
+    AlignedStorage storage(payload_bytes);
+    auto &payload = *reinterpret_cast<PTO2TaskPayload *>(storage.data());
+    payload.tensor_count = TENSOR_COUNT;
+    payload.scalar_count = SCALAR_COUNT;
+    for (uint32_t i = 0; i < TENSOR_COUNT; ++i) {
+        ChipTensor *tensor = graph_task_payload_tensor(payload, i);
+        ASSERT_NE(tensor, nullptr);
+        tensor->buffer.addr = 0x1000 + i * 0x100;
+        tensor->start_offset = i * 4;
+    }
+    for (uint32_t i = 0; i < SCALAR_COUNT; ++i) {
+        uint64_t *scalar = graph_task_payload_scalar(payload, i);
+        ASSERT_NE(scalar, nullptr);
+        *scalar = 0xABC000 + i;
+    }
+
+    const PTO2TaskPayload &const_payload = payload;
+    for (uint32_t i = 0; i < TENSOR_COUNT; ++i) {
+        const ChipTensor *tensor = graph_task_payload_tensor(const_payload, i);
+        ASSERT_NE(tensor, nullptr);
+        EXPECT_EQ(tensor->buffer.addr, 0x1000U + i * 0x100U);
+        EXPECT_EQ(tensor->start_offset, i * 4U);
+    }
+    for (uint32_t i = 0; i < SCALAR_COUNT; ++i) {
+        const uint64_t *scalar = graph_task_payload_scalar(const_payload, i);
+        ASSERT_NE(scalar, nullptr);
+        EXPECT_EQ(*scalar, 0xABC000U + i);
+    }
+}
+
+TEST(GraphTaskPayloadSpace, Dsv4BoundaryCountsLocalizeAndMaterialize) {
+    constexpr uint64_t GRAPH_KEY_VALUE = 0xD5F4;
+    constexpr int32_t TENSOR_COUNT = 118;
+    constexpr int32_t SCALAR_COUNT = 31;
+    std::array<uint8_t, 64> boundary{};
+    const std::vector<std::byte> definition =
+        make_test_definition(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()), TENSOR_COUNT, SCALAR_COUNT);
+    const TestDefinitionObject definition_object(definition);
+    OuterHeap heap(definition);
+    std::vector<std::byte> submission_image = make_test_submission(GRAPH_KEY_VALUE);
+    auto &submission = *reinterpret_cast<GraphSubmission *>(submission_image.data());
+    submission.definition_addr = definition_object.address();
+    submission.definition_hash = definition_object.hash();
+
+    size_t payload_bytes = 0;
+    ASSERT_TRUE(graph_task_payload_layout(TENSOR_COUNT, SCALAR_COUNT, &payload_bytes));
+    AlignedStorage payload_storage(payload_bytes);
+    auto &payload = *reinterpret_cast<PTO2TaskPayload *>(payload_storage.data());
+    payload.tensor_count = TENSOR_COUNT;
+    payload.scalar_count = SCALAR_COUNT;
+    graph_tensor_unpack(
+        make_test_tensor(reinterpret_cast<uint64_t>(boundary.data())), graph_task_payload_tensor(payload, 0)
+    );
+    *graph_task_payload_scalar(payload, 0) = 17;
+
+    PTO2TaskDescriptor outer_task{};
+    outer_task.task_id = PTO2TaskId::make(1, 7);
+    outer_task.packed_buffer_base = heap.base();
+    outer_task.packed_buffer_end = heap.end();
+    PTO2TaskSlotState outer_slot{};
+    outer_slot.task_kind = TaskKind::GRAPH;
+    outer_slot.task = &outer_task;
+    outer_slot.payload = &payload;
+    outer_slot.graph_context = &submission;
+
+    GraphExecution *execution = graph_execution_localize(outer_slot);
+    ASSERT_NE(execution, nullptr);
+    EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
+    EXPECT_EQ(execution->node_storage[0].payload.scalars[0], 17U);
+    EXPECT_EQ(execution->node_storage[0].payload.tensors[0].buffer.addr, reinterpret_cast<uint64_t>(boundary.data()));
+}
+
+TEST(GraphTaskPayloadSpace, RelativePayloadReferenceSurvivesWholeImageMove) {
+    struct alignas(64) PayloadImage {
+        PTO2TaskPayload payload{};
+        PTO2TaskSlotState slot{};
+    };
+    PayloadImage source{};
+    source.slot.bind_buffers(&source.payload, nullptr);
+    alignas(PayloadImage) std::array<std::byte, sizeof(PayloadImage)> moved_bytes{};
+    std::memcpy(moved_bytes.data(), &source, sizeof(source));
+    auto *moved = reinterpret_cast<PayloadImage *>(moved_bytes.data());
+    EXPECT_EQ(moved->slot.payload.get(), &moved->payload);
+}
+
 TEST(GraphCache, RejectsEmptyBoundary) {
     GraphTaskArgs args;
 
@@ -279,18 +377,34 @@ TEST(GraphExecutionStorage, ComputesAlignedExactSize) {
     size_t nodes_offset = 0;
     size_t storage_bytes = 0;
 
-    ASSERT_TRUE(graph_execution_storage_layout(NODE_COUNT, &nodes_offset, &storage_bytes));
+    // Identity stride first: the layout must still describe a full-width execution.
+    ASSERT_TRUE(graph_execution_storage_layout(NODE_COUNT, sizeof(GraphNodeStorage), &nodes_offset, &storage_bytes));
     EXPECT_EQ(nodes_offset % alignof(GraphNodeStorage), 0U);
     EXPECT_GE(nodes_offset, sizeof(GraphExecution));
     EXPECT_EQ(storage_bytes, nodes_offset + NODE_COUNT * sizeof(GraphNodeStorage));
+
+    EXPECT_EQ(graph_node_stride(1), sizeof(GraphNodeStorage));
+    EXPECT_EQ(graph_node_stride(MAX_TENSOR_ARGS), sizeof(GraphNodeStorage));
 }
 
 TEST(GraphExecutionStorage, RejectsInvalidNodeCount) {
     size_t storage_bytes = 0;
 
-    EXPECT_FALSE(graph_execution_storage_bytes(0, &storage_bytes));
-    EXPECT_FALSE(graph_execution_storage_bytes(-1, &storage_bytes));
-    EXPECT_FALSE(graph_execution_storage_bytes(static_cast<int32_t>(GRAPH_MAX_NODES) + 1, &storage_bytes));
+    const size_t full = sizeof(GraphNodeStorage);
+    EXPECT_FALSE(graph_execution_storage_bytes(0, full, &storage_bytes));
+    EXPECT_FALSE(graph_execution_storage_bytes(-1, full, &storage_bytes));
+    EXPECT_FALSE(graph_execution_storage_bytes(static_cast<int32_t>(GRAPH_MAX_NODES) + 1, full, &storage_bytes));
+    // Every entry is placement-constructed as GraphNodeStorage, so only the full
+    // object stride is valid.
+    EXPECT_FALSE(graph_execution_storage_bytes(1, full + alignof(GraphNodeStorage), &storage_bytes));
+    EXPECT_FALSE(
+        graph_execution_storage_bytes(1, graph_node_stride_floor() - alignof(GraphNodeStorage), &storage_bytes)
+    );
+    EXPECT_FALSE(graph_execution_storage_bytes(1, full - 1, &storage_bytes));
+    EXPECT_TRUE(graph_execution_storage_bytes(4, graph_node_stride(1), &storage_bytes));
+    size_t full_bytes = 0;
+    EXPECT_TRUE(graph_execution_storage_bytes(4, full, &full_bytes));
+    EXPECT_EQ(storage_bytes, full_bytes);
 }
 
 // A resubmission gets the same heap block back, so the bytes it starts from are
@@ -305,8 +419,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
         make_test_definition(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(first_boundary.data()));
     const TestDefinitionObject definition_object(definition);
     OuterHeap heap(definition, 0xAA);
-    std::vector<std::byte> submission_image =
-        make_test_submission(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(first_boundary.data()), 17);
+    std::vector<std::byte> submission_image = make_test_submission(GRAPH_KEY_VALUE);
     auto &submission = *reinterpret_cast<GraphSubmission *>(submission_image.data());
     submission.definition_addr = definition_object.address();
     submission.definition_hash = definition_object.hash();
@@ -315,9 +428,11 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     outer_task.task_id = PTO2TaskId::make(1, 7);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
+    auto outer_payload = std::make_unique<PTO2TaskPayload>();
+    set_test_boundary(outer_payload.get(), reinterpret_cast<uint64_t>(first_boundary.data()), 17);
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task = &outer_task;
+    outer_slot.bind_buffers(outer_payload.get(), &outer_task);
     outer_slot.graph_context = &submission;
 
     GraphExecution *execution = graph_execution_localize(outer_slot);
@@ -326,31 +441,28 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     // overlap the node outputs occupying the leading required_heap bytes.
     EXPECT_EQ(static_cast<void *>(execution), heap.execution());
     EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
-    GraphNodeStorage &node = execution->node_storage[0];
+    GraphNodeStorage &node = execution->node_at(0);
     ASSERT_EQ(node.payload.scalar_count, 1);
     ASSERT_EQ(node.payload.tensor_count, 1);
     EXPECT_EQ(node.payload.scalars[0], 17U);
-    EXPECT_EQ(execution->node_storage[1].payload.scalars[0], 18U);
+    EXPECT_EQ(execution->node_at(1).payload.scalars[0], 18U);
     EXPECT_EQ(node.payload.dump_metadata.dump_arg_mask, uint64_t{1} << 0);
     EXPECT_EQ(node.payload.dump_metadata.scalar_dtypes[0], static_cast<uint8_t>(DataType::FLOAT32));
-    EXPECT_EQ(execution->node_storage[1].payload.dump_metadata.dump_arg_mask, uint64_t{1} << 1);
-    EXPECT_EQ(execution->node_storage[1].payload.dump_metadata.scalar_dtypes[0], static_cast<uint8_t>(DataType::INT32));
+    EXPECT_EQ(execution->node_at(1).payload.dump_metadata.dump_arg_mask, uint64_t{1} << 1);
+    EXPECT_EQ(execution->node_at(1).payload.dump_metadata.scalar_dtypes[0], static_cast<uint8_t>(DataType::INT32));
 
     graph_execution_mark_completed(*execution);
     execution->retired_nodes.store(2, std::memory_order_release);
     submission.local_execution = 0;
     outer_task.task_id = PTO2TaskId::make(1, 8);
-    auto *boundary = reinterpret_cast<GraphTensor *>(submission_image.data() + submission.tensors_offset);
-    boundary->buffer_addr = reinterpret_cast<uint64_t>(second_boundary.data());
-    auto *boundary_scalar = reinterpret_cast<uint64_t *>(submission_image.data() + submission.scalars_offset);
-    *boundary_scalar = 99;
+    set_test_boundary(outer_payload.get(), reinterpret_cast<uint64_t>(second_boundary.data()), 99);
 
     // Poison every field the rebuild is responsible for restoring. A replay that
     // preserved any of them would leave the poison observable.
     node.task.kernel_id[0] = 314;
     node.slot.active_mask = ActiveMask(3);
     node.payload.scalars[0] = 2718;
-    execution->node_storage[1].payload.scalars[0] = 31415;
+    execution->node_at(1).payload.scalars[0] = 31415;
     node.payload.tensors[0].version = 1618;
     node.slot.completed_subtasks.store(1, std::memory_order_relaxed);
     node.payload.dispatch_fanin.store(1, std::memory_order_relaxed);
@@ -365,12 +477,12 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     EXPECT_EQ(node.task.kernel_id[0], 42);
     EXPECT_EQ(node.slot.active_mask.raw(), 1);
     EXPECT_EQ(node.payload.scalars[0], 99U);
-    EXPECT_EQ(execution->node_storage[1].payload.scalars[0], 18U);
+    EXPECT_EQ(execution->node_at(1).payload.scalars[0], 18U);
     EXPECT_EQ(node.payload.tensors[0].version, 0);
     EXPECT_EQ(node.task.task_id, PTO2TaskId::make(1, (8U << 10U)));
     EXPECT_EQ(node.task.packed_buffer_base, heap.base());
     EXPECT_EQ(node.payload.tensors[0].buffer.addr, reinterpret_cast<uint64_t>(second_boundary.data()));
-    EXPECT_EQ(execution->node_storage[1].payload.tensors[0].buffer.addr, reinterpret_cast<uint64_t>(heap.base() + 16));
+    EXPECT_EQ(execution->node_at(1).payload.tensors[0].buffer.addr, reinterpret_cast<uint64_t>(heap.base() + 16));
     EXPECT_EQ(node.slot.completed_subtasks.load(std::memory_order_relaxed), 0);
     EXPECT_EQ(node.payload.dispatch_fanin.load(std::memory_order_relaxed), 0);
     EXPECT_EQ(node.payload.dump_metadata.dump_arg_mask, uint64_t{1} << 0);
@@ -384,8 +496,7 @@ TEST(GraphDefinitionObject, RejectsDefinitionBeyondRetainedBytes) {
     ASSERT_GT(definition.size(), sizeof(GraphDefinition));
     const TestDefinitionObject definition_object(definition, sizeof(GraphDefinition));
     OuterHeap heap(definition);
-    std::vector<std::byte> submission_image =
-        make_test_submission(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()), 17);
+    std::vector<std::byte> submission_image = make_test_submission(GRAPH_KEY_VALUE);
     auto &submission = *reinterpret_cast<GraphSubmission *>(submission_image.data());
     submission.definition_addr = definition_object.address();
     submission.definition_hash = definition_object.hash();
@@ -394,23 +505,24 @@ TEST(GraphDefinitionObject, RejectsDefinitionBeyondRetainedBytes) {
     outer_task.task_id = PTO2TaskId::make(1, 7);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
+    auto outer_payload = std::make_unique<PTO2TaskPayload>();
+    set_test_boundary(outer_payload.get(), reinterpret_cast<uint64_t>(boundary.data()), 17);
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task = &outer_task;
+    outer_slot.bind_buffers(outer_payload.get(), &outer_task);
     outer_slot.graph_context = &submission;
 
     EXPECT_EQ(graph_execution_localize(outer_slot), nullptr);
     EXPECT_EQ(definition_object.verify_state(), GraphDefinitionVerifyState::INVALID);
 }
 
-TEST(GraphSubmissionWire, RequiresExactAvailableSize) {
-    constexpr uint64_t GRAPH_KEY_VALUE = 0x4567;
-    std::vector<std::byte> image = make_test_submission(GRAPH_KEY_VALUE, 0x1000, 17);
-    const auto &submission = *reinterpret_cast<const GraphSubmission *>(image.data());
-
-    EXPECT_TRUE(graph_submission_wire_size_valid(submission, image.size()));
-    EXPECT_FALSE(graph_submission_wire_size_valid(submission, image.size() - 1));
-    EXPECT_FALSE(graph_submission_wire_size_valid(submission, image.size() + 1));
+// The submission is a fixed-size Definition reference: it carries no arg region,
+// so its wire size does not depend on the args and nothing indexes into it.
+TEST(GraphSubmissionWire, CarriesNoArgRegion) {
+    std::vector<std::byte> few = make_test_submission(0x4567);
+    std::vector<std::byte> many = make_test_submission(0x89AB);
+    EXPECT_EQ(few.size(), sizeof(GraphSubmission));
+    EXPECT_EQ(few.size(), many.size());
 }
 
 TEST(GraphSubmissionActivationGate, ActivatesExactlyOnceUnderContention) {
@@ -543,8 +655,7 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
         make_test_definition(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()));
     const TestDefinitionObject definition_object(definition);
     OuterHeap heap(definition, 0xAA);
-    std::vector<std::byte> submission_image =
-        make_test_submission(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()), 17);
+    std::vector<std::byte> submission_image = make_test_submission(GRAPH_KEY_VALUE);
     auto &submission = *reinterpret_cast<GraphSubmission *>(submission_image.data());
     submission.definition_addr = definition_object.address();
     submission.definition_hash = definition_object.hash();
@@ -553,9 +664,11 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
     outer_task.task_id = PTO2TaskId::make(1, 5);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
+    auto outer_payload = std::make_unique<PTO2TaskPayload>();
+    set_test_boundary(outer_payload.get(), reinterpret_cast<uint64_t>(boundary.data()), 17);
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task = &outer_task;
+    outer_slot.bind_buffers(outer_payload.get(), &outer_task);
     outer_slot.graph_context = &submission;
 
     GraphExecution *execution = graph_execution_localize(outer_slot);
@@ -567,7 +680,7 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
     // not the 0xAA fill: state machine, counters and atomics all start from
     // values only the device side wrote.
     for (int32_t i = 0; i < execution->node_count; ++i) {
-        const GraphNodeStorage &node = execution->node_storage[i];
+        const GraphNodeStorage &node = execution->node_at(i);
         ASSERT_EQ(node.slot.task_state.load(std::memory_order_relaxed), PTO2_TASK_PENDING);
         ASSERT_EQ(node.slot.task_kind, TaskKind::GRAPH_NODE);
         ASSERT_EQ(node.slot.completed_subtasks.load(std::memory_order_relaxed), 0);

--- a/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
@@ -694,7 +694,7 @@ TEST_F(HbgGraphSubmitFailureTest, AnOrdinaryAllocationInterleavesWithADeferredSh
         << "the shell's block sits above the ordinary task's, not before it";
     PTO2SharedMemoryRingHeader &ring = sm_handle->header->ring;
     const int32_t shell_slot = ring.get_slot_by_task_id(static_cast<int32_t>(graph.task_id.local()));
-    const PTO2TaskDescriptor *shell = ring.slot_states[shell_slot].task;
+    const PTO2TaskDescriptor *shell = ring.slot_states[shell_slot].task.get();
     ASSERT_NE(shell, nullptr);
     ASSERT_NE(shell->packed_buffer_base, nullptr);
     EXPECT_GE(

--- a/tests/ut/cpp/common/test_hbg_self_relative_ptr.cpp
+++ b/tests/ut/cpp/common/test_hbg_self_relative_ptr.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * A slot state reaches its payload and descriptor through a delta from its own
+ * address, which is what lets the shared-memory image be copied to the device
+ * verbatim. The property the copy depends on is that the delta still resolves
+ * after the whole block moves — that is what these tests pin.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "pto_runtime2_types.h"
+
+namespace {
+
+// A block laid out the way the shared-memory image is: the referring field and
+// its targets in one contiguous span, with a target on each side of the field so
+// both delta signs are covered.
+struct Block {
+    PTO2TaskPayload before_payload;
+    PTO2RelativePtr<PTO2TaskPayload> to_before;
+    PTO2RelativePtr<PTO2TaskPayload> to_after;
+    PTO2TaskPayload after_payload;
+};
+
+}  // namespace
+
+TEST(HbgSelfRelativePtr, ZeroedMemoryReadsAsUnbound) {
+    PTO2RelativePtr<PTO2TaskPayload> pointer{};
+
+    EXPECT_EQ(pointer.get(), nullptr);
+    EXPECT_TRUE(pointer == nullptr);
+    EXPECT_FALSE(static_cast<bool>(pointer));
+}
+
+TEST(HbgSelfRelativePtr, ResolvesTargetsOnBothSides) {
+    Block block{};
+    block.to_before.reset(&block.before_payload);
+    block.to_after.reset(&block.after_payload);
+
+    EXPECT_EQ(block.to_before.get(), &block.before_payload);
+    EXPECT_EQ(block.to_after.get(), &block.after_payload);
+    EXPECT_TRUE(block.to_before != nullptr);
+    EXPECT_TRUE(static_cast<bool>(block.to_after));
+}
+
+TEST(HbgSelfRelativePtr, SetNullRebindsToUnbound) {
+    Block block{};
+    block.to_after.reset(&block.after_payload);
+    ASSERT_NE(block.to_after.get(), nullptr);
+
+    block.to_after.reset(nullptr);
+
+    EXPECT_EQ(block.to_after.get(), nullptr);
+    EXPECT_TRUE(block.to_after == nullptr);
+}
+
+// The reason the relocation pass is gone: a raw pointer written on the host names
+// a host address the device would dereference verbatim, while a delta names the
+// same *relative* position in whichever copy is being read.
+TEST(HbgSelfRelativePtr, SurvivesABlockCopyToAnotherAddress) {
+    // Two real objects rather than raw byte buffers: PTO2TaskSlotState is
+    // alignas(64), which std::vector<std::byte>::data() does not promise, and a
+    // memcpy into untyped storage would not begin the object's lifetime.
+    Block source{};
+    Block destination{};
+    Block *origin = &source;
+    origin->to_before.reset(&origin->before_payload);
+    origin->to_after.reset(&origin->after_payload);
+
+    // A separate object, so the copy lands at an unrelated address the way the
+    // device image does.
+    std::memcpy(&destination, &source, sizeof(Block));
+    Block *moved = &destination;
+    ASSERT_NE(reinterpret_cast<void *>(moved), reinterpret_cast<void *>(origin));
+
+    EXPECT_EQ(moved->to_before.get(), &moved->before_payload);
+    EXPECT_EQ(moved->to_after.get(), &moved->after_payload);
+}
+
+// bind_buffers is the only writer, and the slot state it writes into is copied as
+// part of the same image as its payload and descriptor.
+TEST(HbgSelfRelativePtr, SlotStateBindingSurvivesTheImageCopy) {
+    struct Image {
+        PTO2TaskDescriptor descriptor;
+        PTO2TaskPayload payload;
+        PTO2TaskSlotState slot;
+    };
+
+    // Real objects, not byte buffers: the slot state is alignas(64), which
+    // std::vector<std::byte>::data() does not promise.
+    Image source{};
+    Image destination{};
+    Image *origin = &source;
+    origin->slot.bind_buffers(&origin->payload, &origin->descriptor);
+    ASSERT_EQ(origin->slot.payload.get(), &origin->payload);
+    ASSERT_EQ(origin->slot.task.get(), &origin->descriptor);
+
+    std::memcpy(&destination, &source, sizeof(Image));
+    Image *moved = &destination;
+    ASSERT_NE(reinterpret_cast<void *>(moved), reinterpret_cast<void *>(origin));
+
+    EXPECT_EQ(moved->slot.payload.get(), &moved->payload);
+    EXPECT_EQ(moved->slot.task.get(), &moved->descriptor);
+}
+
+// The descriptor ABI AICore consumes and the one-cache-line slot state are both
+// unchanged by the representation: the eight bytes the two deltas save become
+// tail padding inside the same 64.
+TEST(HbgSelfRelativePtr, KeepsTheSharedMemoryAbiSizes) {
+    EXPECT_EQ(sizeof(PTO2TaskSlotState), 64u);
+    EXPECT_EQ(sizeof(PTO2TaskDescriptor), 40u);
+    EXPECT_EQ(sizeof(PTO2RelativePtr<PTO2TaskPayload>), 8u);
+    EXPECT_EQ(offsetof(PTO2TaskDescriptor, packed_buffer_base), 24u);
+}

--- a/tests/ut/cpp/common/test_hbg_slot_claim.cpp
+++ b/tests/ut/cpp/common/test_hbg_slot_claim.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The shared-memory slot segments are init-on-write: nothing zeroes them, and a
+ * slot's dynamic scheduling fields are established as the orchestrator claims it.
+ * That makes the claim the only place the pristine state comes from, for every
+ * kind of task — an ordinary submit and the outer task of a recorded Graph alike.
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#include "graph_host_state.h"
+#include "pto_orchestrator.h"
+#include "pto_shared_memory.h"
+#include "utils/device_arena.h"
+
+class HbgSlotClaimTest : public ::testing::Test {
+protected:
+    DeviceArena sm_arena;
+    DeviceArena runtime_arena;
+    PTO2SharedMemoryHandle *sm_handle = nullptr;
+    PTO2OrchestratorState orch{};
+    PTO2SchedulerState sched{};
+    PTO2OrchestratorLayout orch_layout{};
+    PTO2SchedulerLayout sched_layout{};
+    GraphHostStatePtr graph_state;
+    std::vector<char> gm_heap;
+
+    static constexpr size_t HEAP_BYTES = 64 * 1024;
+
+    void SetUp() override {
+        sm_handle = PTO2SharedMemoryHandle::create_and_init_default(sm_arena);
+        ASSERT_NE(sm_handle, nullptr);
+        gm_heap.resize(HEAP_BYTES * PTO2_MAX_RING_DEPTH);
+
+        orch_layout = PTO2OrchestratorState::reserve_layout(runtime_arena, static_cast<int32_t>(PTO2_TASK_WINDOW_SIZE));
+        sched_layout = PTO2SchedulerState::reserve_layout(runtime_arena);
+        ASSERT_NE(runtime_arena.commit(), nullptr);
+
+        ASSERT_TRUE(orch.init_data_from_layout(
+            orch_layout, runtime_arena, sm_handle->sm_base, gm_heap.data(), HEAP_BYTES, PTO2_TASK_WINDOW_SIZE
+        ));
+        ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
+        sched.wire_arena_pointers(sched_layout, runtime_arena);
+        orch.wire_arena_pointers(orch_layout, runtime_arena, &sched);
+
+        graph_state = make_graph_host_state();
+        ASSERT_NE(graph_state, nullptr);
+        orch.graph_host_state = graph_state.get();
+    }
+
+    void TearDown() override {
+        orch.graph_host_state = nullptr;
+        graph_state.reset();
+        orch.destroy();
+        sched.destroy();
+        runtime_arena.release();
+        sm_arena.release();
+    }
+
+    // The state a slot is in before it is claimed when the shared memory outlives
+    // one pass. Nothing writes these bytes on the way in, so whatever the previous
+    // pass left is what the claim has to overwrite. Every value here is one a
+    // completed task really leaves behind.
+    void poison_slot(int32_t slot) {
+        PTO2TaskSlotState &state = sm_handle->header->ring.get_slot_state_by_slot(slot);
+        state.wake_list_head.store(WAKE_LIST_SENTINEL, std::memory_order_relaxed);
+        state.next_in_wake_list = &sm_handle->header->ring.get_slot_state_by_slot(slot + 1);
+        state.any_subtask_deferred.store(true, std::memory_order_relaxed);
+        state.completed_subtasks.store(7, std::memory_order_relaxed);
+        state.next_block_idx.store(3, std::memory_order_relaxed);
+        state.graph_node_index = 11;
+        sm_handle->header->ring.completion_flags[slot].store(1, std::memory_order_relaxed);
+    }
+
+    void expect_slot_pristine(int32_t slot) {
+        PTO2TaskSlotState &state = sm_handle->header->ring.get_slot_state_by_slot(slot);
+        EXPECT_EQ(state.wake_list_head.load(std::memory_order_relaxed), nullptr)
+            << "a stale SENTINEL closes the wake list, so no consumer can register on this producer";
+        EXPECT_EQ(state.next_in_wake_list, nullptr);
+        EXPECT_FALSE(state.has_any_subtask_deferred());
+        EXPECT_EQ(state.completed_subtasks.load(std::memory_order_relaxed), 0);
+        EXPECT_EQ(state.next_block_idx.load(std::memory_order_relaxed), 0);
+        EXPECT_EQ(sm_handle->header->ring.completion_flags[slot].load(std::memory_order_relaxed), 0)
+            << "a stale completion flag reports this task done before it has run";
+    }
+};
+
+TEST_F(HbgSlotClaimTest, OrdinarySubmitClaimsAPoisonedSlot) {
+    poison_slot(0);
+
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    ChipTensor boundary = make_tensor_external(storage.data(), shape, 1);
+
+    orch.begin_scope();
+    CoreTaskArgs args;
+    args.add_input(boundary);
+    ASSERT_TRUE(orch.submit_dummy_task(args).task_id().is_valid());
+
+    expect_slot_pristine(0);
+}
+
+// The outer task of a recorded Graph takes a ring slot like any other task, and
+// takes it through its own placement rather than through prepare_task — so it
+// needs the same claim-time reset. It occupies one heap block and one slot for a
+// whole sub-DAG, which is exactly why it is easy to overlook.
+TEST_F(HbgSlotClaimTest, GraphOuterTaskClaimsAPoisonedSlot) {
+    poison_slot(0);
+
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    ChipTensor boundary = make_tensor_external(storage.data(), shape, 1);
+
+    orch.begin_scope();
+    // A Graph boundary carries the wider arg type: graph_begin deep-copies it for the
+    // recording, which the ordinary CoreTaskArgs cannot hold.
+    GraphTaskArgs boundary_args;
+    boundary_args.add_input(boundary);
+    const GraphScopeResult graph = orch.graph_begin(0x51ADC1A1, boundary_args, 0x1736);
+    ASSERT_TRUE(graph.recording);
+    // graph_begin publishes the outer shell and creates the recording, handing back the
+    // handle graph_prepare binds to the thread that will submit the body. The recorder is
+    // normally a worker, so this test plays both roles on one thread.
+    ASSERT_NE(graph.recording_handle, nullptr);
+    ASSERT_TRUE(orch.graph_prepare(graph.recording_handle, boundary_args));
+
+    CoreTaskArgs node_args;
+    node_args.add_input(boundary);
+    ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
+    ASSERT_TRUE(orch.graph_end());
+    ASSERT_EQ(orch.ring.task_allocator.active_count(), 1);
+
+    PTO2TaskSlotState &outer = sm_handle->header->ring.get_slot_state_by_slot(0);
+    ASSERT_EQ(outer.task_kind, TaskKind::GRAPH);
+    expect_slot_pristine(0);
+}
+
+// A cached replay places its outer task the same way the recording pass did, so
+// the second slot has to come out just as clean.
+TEST_F(HbgSlotClaimTest, CachedGraphReplayClaimsAPoisonedSlot) {
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    ChipTensor boundary = make_tensor_external(storage.data(), shape, 1);
+
+    orch.begin_scope();
+    // A Graph boundary carries the wider arg type: graph_begin deep-copies it for the
+    // recording, which the ordinary CoreTaskArgs cannot hold.
+    GraphTaskArgs boundary_args;
+    boundary_args.add_input(boundary);
+    const GraphScopeResult recorded = orch.graph_begin(0x51ADC1A2, boundary_args, 0x1736);
+    ASSERT_TRUE(recorded.recording);
+    ASSERT_TRUE(orch.graph_prepare(recorded.recording_handle, boundary_args));
+    CoreTaskArgs node_args;
+    node_args.add_input(boundary);
+    ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
+    ASSERT_TRUE(orch.graph_end());
+
+    poison_slot(1);
+    const GraphScopeResult replay = orch.graph_begin(0x51ADC1A2, boundary_args, 0x1736);
+    ASSERT_TRUE(replay.task_id.is_valid());
+    ASSERT_EQ(replay.task_id.local(), 1u);
+
+    expect_slot_pristine(1);
+}

--- a/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
+++ b/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The orchestrator writes a ring-pitched shared-memory mirror; the image that
+ * ships is pitched to the submitted count so its four live prefixes are
+ * contiguous and travel as one copy. compact_live_image is the restack, and it
+ * owes the device three things: the live payloads, a header carrying no host
+ * addresses, and slot-state bindings that resolve inside the image rather than
+ * back into the mirror.
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "pto_shared_memory.h"
+
+namespace {
+
+constexpr uint64_t WINDOW = 64;  // stands in for the ring capacity
+constexpr uint64_t SUBMITTED = 5;
+
+// A buffer aligned the way both the arena mirror and the device SM base are;
+// PTO2TaskSlotState is alignas(64) and every segment offset is a multiple of
+// PTO2_ALIGN_SIZE.
+class AlignedImage {
+public:
+    explicit AlignedImage(uint64_t bytes, uint8_t fill = 0) :
+        storage_(bytes + PTO2_ALIGN_SIZE, std::byte{0}) {
+        base_ = reinterpret_cast<char *>(
+            (reinterpret_cast<uintptr_t>(storage_.data()) + PTO2_ALIGN_SIZE - 1) &
+            ~static_cast<uintptr_t>(PTO2_ALIGN_SIZE - 1)
+        );
+        if (fill != 0) std::memset(base_, fill, bytes);
+    }
+
+    char *base() { return base_; }
+    const char *base() const { return base_; }
+
+private:
+    std::vector<std::byte> storage_;
+    char *base_{nullptr};
+};
+
+// A mirror in the state the orchestrator leaves it: SUBMITTED slots bound to
+// their own payload and descriptor, distinguishable per-slot content, and header
+// pointers naming the mirror's own arrays.
+class Mirror {
+public:
+    Mirror() :
+        image_(pto2_sm_layout::ring_segment_offsets(WINDOW).end) {
+        const auto off = pto2_sm_layout::ring_segment_offsets(WINDOW);
+        auto *header = reinterpret_cast<PTO2SharedMemoryHeader *>(image_.base());
+        auto &ring = header->ring;
+        ring.task_window_size = WINDOW;
+        ring.task_window_mask = static_cast<int32_t>(WINDOW - 1);
+        ring.fc.current_task_index.store(static_cast<int32_t>(SUBMITTED), std::memory_order_relaxed);
+        ring.task_descriptors = descriptors();
+        ring.task_payloads = payloads();
+        ring.slot_states = slot_states();
+        ring.completion_flags = completion_flags();
+        (void)off;
+
+        const std::array<uint64_t, SUBMITTED> record_bytes = {
+            sizeof(PTO2TaskPayload), sizeof(PTO2TaskPayload) + 128, sizeof(PTO2TaskPayload),
+            sizeof(PTO2TaskPayload) + 256, sizeof(PTO2TaskPayload)
+        };
+        for (uint64_t i = 0; i < SUBMITTED; ++i) {
+            payload_offsets_[i] = payload_bytes_;
+            payload_bytes_ += record_bytes[i];
+            descriptors()[i].task_id = PTO2TaskId::make(0, static_cast<uint32_t>(i));
+            payload_at(i)->tensor_count = static_cast<int32_t>(100 + i);
+            slot_states()[i].last_consumer_local_id = static_cast<int32_t>(i);
+            slot_states()[i].graph_node_index = static_cast<int32_t>(200 + i);
+            slot_states()[i].bind_buffers(payload_at(i), &descriptors()[i]);
+            completion_flags()[i].store(static_cast<uint8_t>(i & 1), std::memory_order_relaxed);
+            if (record_bytes[i] > sizeof(PTO2TaskPayload)) {
+                *reinterpret_cast<uint64_t *>(reinterpret_cast<char *>(payload_at(i)) + sizeof(PTO2TaskPayload)) =
+                    0xA500 + i;
+            }
+        }
+        // A slot past the submitted prefix, to prove it does not travel.
+        descriptors()[SUBMITTED].task_id = PTO2TaskId::make(0, 0xBEEF);
+    }
+
+    const char *base() const { return image_.base(); }
+    uint64_t payload_bytes() const { return payload_bytes_; }
+    uint64_t payload_offset(uint64_t index) const { return payload_offsets_[index]; }
+
+    PTO2TaskDescriptor *descriptors() {
+        return reinterpret_cast<PTO2TaskDescriptor *>(
+            image_.base() + pto2_sm_layout::ring_segment_offsets(WINDOW).descriptors
+        );
+    }
+    PTO2TaskPayload *payloads() {
+        return reinterpret_cast<PTO2TaskPayload *>(
+            image_.base() + pto2_sm_layout::ring_segment_offsets(WINDOW).payloads
+        );
+    }
+    PTO2TaskPayload *payload_at(uint64_t index) {
+        return reinterpret_cast<PTO2TaskPayload *>(reinterpret_cast<char *>(payloads()) + payload_offsets_[index]);
+    }
+    PTO2TaskSlotState *slot_states() {
+        return reinterpret_cast<PTO2TaskSlotState *>(
+            image_.base() + pto2_sm_layout::ring_segment_offsets(WINDOW).slot_states
+        );
+    }
+    std::atomic<uint8_t> *completion_flags() {
+        return reinterpret_cast<std::atomic<uint8_t> *>(
+            image_.base() + pto2_sm_layout::ring_segment_offsets(WINDOW).completion_flags
+        );
+    }
+
+private:
+    AlignedImage image_;
+    std::array<uint64_t, SUBMITTED> payload_offsets_{};
+    uint64_t payload_bytes_{0};
+};
+
+struct Compacted {
+    AlignedImage image;
+    uint64_t bytes;
+    uint64_t payload_bytes;
+    std::array<uint64_t, SUBMITTED> payload_offsets;
+
+    explicit Compacted(Mirror &mirror, uint64_t submitted = SUBMITTED) :
+        image(
+            pto2_sm_layout::ring_segment_offsets_with_payload_bytes(
+                pto2_sm_layout::live_slot_pitch(submitted), submitted == 0 ? 0 : mirror.payload_bytes()
+            )
+                .end,
+            0xAA
+        ),
+        bytes(0),
+        payload_bytes(submitted == 0 ? 0 : mirror.payload_bytes()) {
+        for (uint64_t i = 0; i < SUBMITTED; ++i)
+            payload_offsets[i] = mirror.payload_offset(i);
+        bytes = pto2_sm_layout::compact_live_image(mirror.base(), WINDOW, submitted, payload_bytes, image.base());
+    }
+
+    pto2_sm_layout::PTO2RingSegmentOffsets off(uint64_t submitted = SUBMITTED) const {
+        return pto2_sm_layout::ring_segment_offsets_with_payload_bytes(
+            pto2_sm_layout::live_slot_pitch(submitted), payload_bytes
+        );
+    }
+
+    PTO2TaskPayload *payload_at(uint64_t i) {
+        return reinterpret_cast<PTO2TaskPayload *>(image.base() + off().payloads + payload_offsets[i]);
+    }
+    PTO2TaskDescriptor *descriptors() {
+        return reinterpret_cast<PTO2TaskDescriptor *>(image.base() + off().descriptors);
+    }
+    PTO2TaskPayload *payloads() { return payload_at(0); }
+    PTO2TaskSlotState *slot_states() { return reinterpret_cast<PTO2TaskSlotState *>(image.base() + off().slot_states); }
+    std::atomic<uint8_t> *completion_flags() {
+        return reinterpret_cast<std::atomic<uint8_t> *>(image.base() + off().completion_flags);
+    }
+};
+
+}  // namespace
+
+// The point of the restack: the whole image is one range, and it is far smaller
+// than the mirror it came from.
+TEST(HbgSmCompaction, ShipsOnlyTheLivePrefix) {
+    Mirror mirror;
+    Compacted compacted(mirror);
+
+    EXPECT_EQ(
+        compacted.bytes, pto2_sm_layout::ring_segment_offsets_with_payload_bytes(SUBMITTED, mirror.payload_bytes()).end
+    );
+    EXPECT_LT(compacted.bytes, pto2_sm_layout::ring_segment_offsets(WINDOW).end);
+}
+
+TEST(HbgSmCompaction, CarriesEveryLiveSlotsContent) {
+    Mirror mirror;
+    Compacted compacted(mirror);
+
+    for (uint64_t i = 0; i < SUBMITTED; ++i) {
+        EXPECT_EQ(compacted.descriptors()[i].task_id.local(), i) << "slot " << i;
+        EXPECT_EQ(compacted.payload_at(i)->tensor_count, static_cast<int32_t>(100 + i)) << "slot " << i;
+        EXPECT_EQ(compacted.slot_states()[i].last_consumer_local_id, static_cast<int32_t>(i)) << "slot " << i;
+        EXPECT_EQ(compacted.slot_states()[i].graph_node_index, static_cast<int32_t>(200 + i)) << "slot " << i;
+        EXPECT_EQ(compacted.completion_flags()[i].load(std::memory_order_relaxed), static_cast<uint8_t>(i & 1))
+            << "slot " << i;
+    }
+    // The header's pitch-independent fields come across; the mirror slot past the
+    // prefix does not.
+    auto &ring = reinterpret_cast<const PTO2SharedMemoryHeader *>(compacted.image.base())->ring;
+    EXPECT_EQ(ring.task_window_size, WINDOW);
+    EXPECT_EQ(ring.fc.current_task_index.load(std::memory_order_relaxed), static_cast<int32_t>(SUBMITTED));
+}
+
+// The load-bearing one. Restacking changes the distance between a slot state and
+// its payload, so a binding copied verbatim would resolve to the mirror — a host
+// address, in device memory.
+TEST(HbgSmCompaction, RebindsEverySlotInsideTheImage) {
+    Mirror mirror;
+    Compacted compacted(mirror);
+
+    for (uint64_t i = 0; i < SUBMITTED; ++i) {
+        EXPECT_EQ(compacted.slot_states()[i].payload.get(), compacted.payload_at(i)) << "slot " << i;
+        EXPECT_EQ(compacted.slot_states()[i].task.get(), &compacted.descriptors()[i]) << "slot " << i;
+    }
+}
+
+// A delta is invariant under a whole-image move, which is what makes the single
+// copy to the device safe.
+TEST(HbgSmCompaction, BindingsSurviveTheCopyToTheDevice) {
+    Mirror mirror;
+    Compacted compacted(mirror);
+
+    AlignedImage landed(compacted.bytes);
+    std::memcpy(landed.base(), compacted.image.base(), compacted.bytes);
+    const auto off = pto2_sm_layout::ring_segment_offsets_with_payload_bytes(SUBMITTED, mirror.payload_bytes());
+    auto *slots = reinterpret_cast<PTO2TaskSlotState *>(landed.base() + off.slot_states);
+    char *payloads = landed.base() + off.payloads;
+    auto *descriptors = reinterpret_cast<PTO2TaskDescriptor *>(landed.base() + off.descriptors);
+
+    for (uint64_t i = 0; i < SUBMITTED; ++i) {
+        EXPECT_EQ(slots[i].payload.get(), reinterpret_cast<PTO2TaskPayload *>(payloads + mirror.payload_offset(i)))
+            << "slot " << i;
+        EXPECT_EQ(slots[i].task.get(), &descriptors[i]) << "slot " << i;
+    }
+}
+
+// The header's data pointers name the mirror. The device resolves its own in
+// attach_populated, so shipping them would only put host addresses in device
+// memory.
+TEST(HbgSmCompaction, LeavesNoHostPointerInTheHeader) {
+    Mirror mirror;
+    Compacted compacted(mirror);
+
+    auto &ring = reinterpret_cast<const PTO2SharedMemoryHeader *>(compacted.image.base())->ring;
+    EXPECT_EQ(ring.task_descriptors, nullptr);
+    EXPECT_EQ(ring.task_payloads, nullptr);
+    EXPECT_EQ(ring.slot_states, nullptr);
+    EXPECT_EQ(ring.completion_flags, nullptr);
+}
+
+// A bind that submits nothing still ships its header and still attaches.
+TEST(HbgSmCompaction, ZeroSubmittedShipsTheHeaderAlone) {
+    Mirror mirror;
+    Compacted compacted(mirror, /*submitted=*/0);
+
+    EXPECT_EQ(compacted.bytes, pto2_sm_layout::ring_segment_offsets_with_payload_bytes(1, 0).end);
+    auto &ring = reinterpret_cast<const PTO2SharedMemoryHeader *>(compacted.image.base())->ring;
+    EXPECT_EQ(ring.task_window_size, WINDOW);
+    EXPECT_EQ(ring.task_descriptors, nullptr);
+}
+
+TEST(HbgSmCompaction, PreservesVariableLengthPayloadRecords) {
+    Mirror mirror;
+    Compacted compacted(mirror);
+
+    for (uint64_t i = 0; i < SUBMITTED; ++i) {
+        PTO2TaskPayload *shipped = compacted.payload_at(i);
+        EXPECT_EQ(shipped->tensor_count, static_cast<int32_t>(100 + i)) << "slot " << i;
+        EXPECT_EQ(compacted.slot_states()[i].payload.get(), shipped) << "slot " << i;
+    }
+    EXPECT_EQ(
+        *reinterpret_cast<uint64_t *>(reinterpret_cast<char *>(compacted.payload_at(1)) + sizeof(PTO2TaskPayload)),
+        0xA501u
+    );
+    EXPECT_EQ(
+        *reinterpret_cast<uint64_t *>(reinterpret_cast<char *>(compacted.payload_at(3)) + sizeof(PTO2TaskPayload)),
+        0xA503u
+    );
+}


### PR DESCRIPTION
## Summary

The bind stage made **46 host-to-device transfers per bind** and reserved **361 MB of device
memory**, most of it for data the device never reads. Both come from the same habit: every
structure was shipped at the width of its type, and copied on its own.

**One copy instead of forty-six.** A slot's payload and descriptor are named by a
self-relative offset (an `int32` delta from the field's own address), so the ring image
survives a single `memcpy` with no pointer fix-up — which retires the host-to-device
relocation pass. Graph submissions go up as one block rather than one allocation and one copy
each, and both the shared-memory image and that submission block become tails of the runtime
arena's own region, so they ride the arena's copy. What remains is one arena copy plus one
retained Definition object.

**Only the bytes the device reads.** The arena's host-only zone is dep-computation scratch no
device code touches, so it is no longer reserved on the device. The shared-memory image ships
pitched to the submitted task count rather than the ring capacity — 47 slots of 16,384 on
qwen3-14b decode — and the device reservation follows the same pitch.

**Strided by what a bind holds, not by the type.** `PTO2TaskPayload`'s tensor array and
`GraphNodeStorage`'s payload move last so each can be truncated; the shipped payload array and
the Graph execution storage are then strided by the widest task and the widest node in the
bind. `sizeof(GraphNodeStorage)` is not a power of two, so indexing already compiled to a
multiply — a runtime stride changes the operand from an immediate to a register and adds no
indirection on the dispatch path.

The `int32` delta carries two bounds with it. `set()` leaves the field **unbound** rather than
storing a truncated delta — unbound is the value every consumer already tests for, while a
truncated one names unrelated memory — and `attach_populated` rejects an image whose end
exceeds the bound, next to the live-count and stride bounds it already checks. On the host side
`compact_live_image` asserts those same two bounds, where exceeding them would read past the
mirror's segments and ship a corrupt image with nothing to say so.

### Three defects, not optimizations

- **A Graph outer task's slot was not reset as it was claimed.** It was only accidentally
  correct: the host mirror is a fresh `new uint8_t[]`, which the kernel hands back
  zero-filled, so a stale slot never surfaced. A reused slot or reused mirror would have read
  the previous run's state. Covered by a test that fails without the reset.
- **A latched orchestration fatal did not stop the upload.** A heap or tensormap exhaustion
  drops tasks and a fanin overflow drops edges; the truncated graph was shipped anyway, and
  the error code only reached the host after the device had launched and timed out — so the
  reported failure was a scheduler timeout with the real cause behind it. Checking the same
  word before the upload costs one relaxed load.
- **The execution storage reserved one stride per entry**, while materialization
  placement-news a whole `GraphNodeStorage` into each, so the last entry's object ended past
  the allocation. Nothing in the truncated tail has a default initializer, so it corrupted
  nothing — but adding one would have made it a heap overrun. The reservation now ends at the
  last entry's full size.

## Measurements

qwen3-14b decode, 7 binds, minimum over the run:

| | before | after |
| --- | --- | --- |
| bind-stage H2D | 642,987 ns | **65,441 ns (−90%)** |
| upload shape | 46 copies, ~467 KB | **1 arena copy of 180,480 B** + 1 Definition object |
| PTO2 shared memory reserved | 81,412,352 | **77,440** |
| graph heap high-water consumed | 127,673,344 | **106,399,744** |
| **total device memory reserved** | **361,363,392** | **270,857,280 (−86.3 MiB, −25%)** |

The graph heap's *reservation* is deliberately untouched and still `PTO2_HEAP_SIZE`. Sizing it
from the measured requirement is separate work that depends on how heap positions are
represented, and #1897 has since made that a design question rather than a mechanical one.

## Testing

- [x] `cpput` 113/113
- [x] a2a3 `host_build_graph` scene tests: 34 passed + 1 skipped, every L3 resource child green
- [x] Review round 1 (CodeRabbit, 7 items): 6 fixed, 1 skipped as a false positive — the
      payload offset constants *are* asserted, in `scheduler_dispatch.cpp:45-46` on both arches
- [x] Rebased onto current `main` (#1912/#1929/#1930/#1924/#1926 landed while this was open);
      the conflict with #1912's new
      `graph_rebind_tensor()` helper was resolved in favour of the helper, with the runtime
      stride moved inside it (it indexed `node_storage[]` by the type's size, which lands
      between entries once the storage is pitched)
- [ ] a5 onboard — built for both arches, but only a2a3 silicon was available here

One flake seen and not caused by this change: a full-directory run once failed the L3 child
`worker_async_fifo::test_incompatible_runtime_env_falls_back_to_depth_one` on its
concurrency-overlap assertion during a 216.9 s run (usual ~140 s). That child runs
`rt=tensormap_and_ringbuffer`, while every file here is under `host_build_graph/` or its unit
tests — no tmr source, no platform code, no worker code. It passes alone 2/2 and the whole file
passes; a re-run of the full gate was clean.

