### PR TITLE
docs: how to measure the host_build_graph bind path

### DIFF
--- a/docs/dfx/README.md
+++ b/docs/dfx/README.md
@@ -23,6 +23,7 @@ Analysis CLIs that consume these outputs are documented in
 | -------- | -------------- |
 | [L2 Timing](l2-timing.md) | `host_wall` / `device_wall` / Effective / Orch / Sched breakdown from `[STRACE]` |
 | [Host runtime trace markers](host-trace.md) | The `[STRACE]` marker set emitted by the host runtime |
+| [Measuring the host_build_graph bind path](hbg-bind-measurement.md) | How to run the qwen and dsv4 decode cases for bind-segment numbers and a host swimlane |
 | [Device-side phase timing](device-phases.md) | Fixed AICPU phases and the variable-phase plan |
 | [Scheduler-Overhead Model](sched-overhead-model.md) | Is the scheduler the bottleneck, or starved — the model behind `--overhead` |
 

--- a/docs/dfx/hbg-bind-measurement.md
+++ b/docs/dfx/hbg-bind-measurement.md
@@ -1,0 +1,277 @@
+# Measuring the `host_build_graph` bind path
+
+`host_build_graph` builds the whole task graph on the host before the device
+executes anything, so its **bind path** — argument staging, orchestration, the
+Graph Definition, and every H2D copy — is a first-class cost. This page is the
+recipe for measuring it on the two decode networks that exercise it, and for the
+traps that make a measurement wrong rather than merely noisy.
+
+For the marker grammar and the tool's other views, see
+[host-trace.md](host-trace.md). For what the runtime records inside `host_orch`,
+see [host_build_graph's profiling levels](../../src/a2a3/runtime/host_build_graph/docs/profiling_levels.md).
+
+## What the segments are
+
+`SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1` makes the runtime emit one `bind phase=`
+line per segment per pass at `LOG_TIMING`:
+
+| Segment | What it covers |
+| ------- | -------------- |
+| `args` | staging the caller's host tensors and mapping them for host access |
+| `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init` | arena layout, GM heap and shared-memory bring-up |
+| `host_orch` | **all** orchestration: every task submitted, every Graph node recorded, the Definition built |
+| `graph_upload` | the Definition objects and the replay boundary images |
+| `relocate` | pointer relocation inside the shared-memory image |
+| `sm_h2d` | the task descriptors and payloads, host → device |
+| `arena_h2d` | the runtime arena's copied zone |
+| `host_view_close` | unmapping the host views taken in `args` |
+
+The **control plane** is `host_orch + graph_upload + relocate + sm_h2d +
+arena_h2d`: everything between "the caller's data is in place" and "the device
+can start". It is what the < 1 ms target applies to. `args` and
+`host_view_close` are excluded — they scale with the caller's tensor bytes, not
+with the graph.
+
+**The control plane is a sum of costs, not an interval.** `arena_h2d` runs
+*after* `host_view_close`, hundreds of milliseconds later, so the segments do not
+form one contiguous window. Sum the five; do not subtract two timestamps.
+
+## Prerequisites
+
+```bash
+python3 -m venv --system-site-packages .venv     # once per worktree
+source .venv/bin/activate
+pip install --no-build-isolation -e .            # after every source change
+.claude/skills/onboard-arch-precheck/check.sh a2a3   # exit 0 ⇒ this box can run a2a3
+```
+
+Both cases are onboard-only and must run through `task-submit`, which holds the
+device lock for the whole job (see
+[`.claude/rules/running-onboard.md`](../../.claude/rules/running-onboard.md)).
+
+## The two cases
+
+| Property | qwen3-14b decode | DeepSeek-V4 FLASH decode |
+| -------- | ---------------- | ------------------------ |
+| Path | `examples/a2a3/host_build_graph/qwen3_14b_decode/` | `examples/a2a3/host_build_graph/deepseek_v4_flash_decode/` |
+| Devices | 1 | 2 (EP2/TP2) |
+| Host tasks | 47 | 1131 |
+| Graph replays | 40, of a 277-node Definition | 20, of a 743-node Definition |
+| Graph boundary | 26 tensors | 118 tensors, 31 scalars |
+| First-run compile | seconds | **minutes** (369 kernel sources + an 11.6k-line orchestration) |
+| Marked | `manual` | `manual`, `skip_golden` |
+
+Both are `level=3`, which matters for how their output is captured (below).
+
+## Recipe A — stable numbers, many rounds
+
+Six rounds is the working minimum: this box is shared, and a single pass has been
+seen to land 3.5× off its own minimum. Which statistic to read depends on the
+question. For "how long does this path take", take the **minimum of the per-round
+sums** — the quietest pass is the closest this box gets to the machine's own cost.
+For "did a change move it", see [Comparing two branches](#comparing-two-branches)
+below; the answer there is not a minimum.
+
+```bash
+export SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1
+export SIMPLER_LOG_LEVEL=TIMING
+export TORCH_DEVICE_BACKEND_AUTOLOAD=0
+
+# qwen — the module runner prints the child's log to stdout for a 1-device case
+task-submit --device auto --device-num 1 --timeout 2400 --max-time 2400 --run \
+  "python examples/a2a3/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py \
+     -p a2a3 -d \$TASK_DEVICE --manual include --rounds 6" | tee qwen.log
+```
+
+**dsv4 needs the L3 child command run directly.** A case whose
+`device_count > 1` is dispatched by the module runner as one subprocess per
+class, and `run_jobs` captures that subprocess's stdout and prints it only on
+failure — so a passing run yields a log with **no** `bind phase=` lines at all.
+Build the same command the runner would (`scene_test.py`'s L3 phase) and run it
+yourself:
+
+```bash
+task-submit --device auto --device-num 2 --timeout 3600 --max-time 3600 --run \
+  "python examples/a2a3/host_build_graph/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py \
+     -p a2a3 --manual only --rounds 6 -d \$TASK_DEVICE \
+     --case TestDeepseekV4FlashDecodeHostBuildGraph:: --runtime host_build_graph --level 3" | tee dsv4.log
+```
+
+A 2-rank case emits one pass per rank per round, so six rounds is twelve passes.
+
+To measure the host path without device execution, set
+`SIMPLER_SKIP_DEVICE_RUN=1`, which returns at `simpler_launch_run`. It is a
+temporary handle from the dsv4 bring-up and is deleted once that case's device
+execution works; two of its properties are load-bearing while it exists:
+
+- **It is presence-based.** `SIMPLER_SKIP_DEVICE_RUN=0` still skips. `unset` it.
+- **A skipped run writes no `host_phase_records.jsonl`** (see Recipe B), because
+  the artifact is written by the teardown on the device-run path.
+
+### Reading the segments out
+
+```bash
+grep -oE 'bind phase=[a-z_]+ start_ns=[0-9]+ dur_ns=[0-9]+[^[]*' qwen.log
+```
+
+Each line carries `start_ns` (a `CLOCK_MONOTONIC` timestamp) plus the segment's
+own attributes — `tasks=` and `heap_used=` on `host_orch`, `bytes=` on every H2D
+segment, `count=` on `graph_upload`. Group the lines into passes — `arena_h2d` is
+the last segment of a pass, so it closes one — then sum the five control-plane
+segments **within each pass** and take the minimum of those sums. Never sum
+minima taken across passes; that total belongs to no pass and can point the wrong
+way (see below).
+
+The first pass is warm-up on both cases and belongs in neither statistic; drop it
+explicitly rather than letting a minimum quietly exclude it.
+
+Device wall clock for the same rounds comes from the `[STRACE]` markers:
+
+```bash
+grep -oE 'device_wall ts=0 dur=[0-9]+' qwen.log | \
+  awk -F'dur=' '{printf "%.2f\n", $2/1e6}' | sort -n
+```
+
+### Comparing two branches
+
+A branch comparison is a different measurement from a single reading, and two of
+its failure modes have already produced wrong answers on this box.
+
+**Interleave the conditions; never run one after the other.** `base` then
+`measure` attributes every drift in host load to the branch, and the drift is
+larger than most effects worth measuring. Alternate instead —
+`base, measure, base, measure` — and require a per-pass delta that agrees in sign
+across the passes. A pass that disagrees is the signal that the run was
+contended, not that the effect is small: on one dsv4 pass `graph_upload` came out
++0.46 ms against −0.20 ms on the other three, and the same pass carried a bind
+whose `sm_h2d` was 5.93 ms against a 0.6 ms norm.
+
+**A min of sums is not a sum of mins, and they can disagree in sign.** Each
+segment's minimum comes from whichever pass was quietest *for that segment*, so
+summing the per-segment minima produces a total no pass achieved. On one dsv4
+comparison the sum-of-minima moved −0.30 ms while the minimum-of-sums moved
++0.16 ms, from the same log. Decide which question is being asked and use one
+statistic throughout: minimum-of-sums for "what is the best this branch does",
+per-pass medians for "did this branch change anything".
+
+**Judge a segment the diff does not touch.** `host_orch`'s own scatter on dsv4
+spans 2.6–4.9 ms across passes of an unmodified `main` — wider than most changes
+being tested — so a ±0.5 ms difference there is not resolvable by pass medians
+however many rounds are run. When a segment matters and its scatter swamps it,
+instrument the mechanism instead: a sub-counter around the suspected work answers
+in one pass what a duration comparison cannot answer in ten.
+
+## Recipe B — one round with a swimlane
+
+The summed `bind phase=` lines cannot be placed on a timeline inside
+`host_orch`: they are cost shares. The per-event view comes from the runtime's
+rotating record pool, written to `outputs/<case>_<ts>/host_phase_records.jsonl` —
+one record per orchestrator operation, each with its own interval.
+
+Three conditions must all hold, and each one silently produces an empty result:
+
+1. **A diagnostic flag must be on**, because that is what makes
+   `CallConfig.output_prefix` non-empty. `--enable-scope-stats` is the cheapest
+   for an L3 case; `--enable-chip-swimlane` raises `NotImplementedError` for
+   `level=3` (per-chip-process filename collision).
+2. **`--rounds` must be 1.** `rounds > 1` force-disables every diagnostic flag.
+3. **The device run must not be skipped.** The artifact is written by
+   `teardown_shared_collectors_after_run()`, which sits on the device-run path.
+   A run that *fails* on device still writes it — that is deliberate, and it is
+   how a case whose device execution does not complete still yields its prepare
+   timing.
+
+```bash
+export SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 SIMPLER_LOG_LEVEL=TIMING TORCH_DEVICE_BACKEND_AUTOLOAD=0
+unset SIMPLER_SKIP_DEVICE_RUN
+
+task-submit --device auto --device-num 1 --timeout 2400 --max-time 2400 --run \
+  "python examples/a2a3/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py \
+     -p a2a3 -d \$TASK_DEVICE --manual include --rounds 1 --enable-scope-stats" | tee qwen_detail.log
+
+python -m simpler_setup.tools.strace_timing qwen_detail.log \
+    --host-phase-records outputs/<case>_<ts>/host_phase_records.jsonl \
+    --swimlane qwen_host_swimlane.json
+```
+
+Load the JSON in [Perfetto](https://ui.perfetto.dev) or `chrome://tracing`. Each
+rank is its own pid lane, and every record is drawn inside its
+`chip.run.bind`. The same command with the dsv4 log and its records file gives
+the two-rank version; `dropped` in the artifact's header says whether the pool
+truncated anything (it is 0 for both cases: 337 records for qwen, 1887 per rank
+for dsv4).
+
+## Reading the result
+
+**The first round is cold, and not by a little.** On dsv4's first pass
+`static_arena` spends 97.8 ms allocating the 2 GiB ring heap against 0.002 ms on
+later passes, and `host_orch` runs 8% long. Recipe B therefore describes
+*structure* — the order of operations, the per-operation distribution — while
+Recipe A gives the numbers.
+
+**Per-operation records show tails the sums hide.** dsv4's `submit_task` has a
+median of 0.28 µs and a maximum of 54.49 µs, a 195× spread that a
+`total_ns / count` mean reports as 0.68 µs.
+
+**Not all of `host_orch` is instrumented.** The gaps between records — fanin
+computation, tensormap registration, scope bookkeeping — are 22% of `host_orch`
+on qwen and 25–30% on dsv4, and they are the second-largest item inside it.
+Subtract the records' sum from the segment to see them.
+
+**`heap_used=` on `host_orch` is the run's real GM footprint**, so it is the
+metric for any change to allocation or to the Graph expansion pool. It is exact
+and repeatable — byte-identical across runs — which makes it a better regression
+signal than any duration on a shared box.
+
+## Traps
+
+| Trap | Symptom | What to do |
+| ---- | ------- | ---------- |
+| dsv4 run through the module runner's L3 phase | log has zero `bind phase=` lines, test passes | run the L3 child command directly (Recipe A) |
+| `SIMPLER_SKIP_DEVICE_RUN=0` | run still skips the device, "PASSED" means nothing ran | `unset` the variable |
+| `--rounds 6` with `--enable-scope-stats` | no `outputs/<case>_<ts>/` artifacts | one round for artifacts, many rounds for numbers |
+| Skipped device run in Recipe B | output directory exists but is empty | let the device run; a failing run writes the artifact too |
+| Subtracting timestamps for the control plane | ~300 ms instead of ~3 ms | sum the five segments; `arena_h2d` is not adjacent |
+| Single pass, or comparing across differently-loaded moments | swings of 3.5× | six rounds, compare minima, keep an untouched segment as a control |
+| `base` then `measure`, sequentially | a load drift reads as the branch's effect | interleave the conditions and require the sign to agree per pass |
+| Summing per-segment minima | a total no pass achieved; can invert the sign | one statistic throughout — see "Comparing two branches" |
+| Stale build | mass collection errors, or a `launch_aicpu_num (0)` failure | `pip install --no-build-isolation -e .` after every `HEAD` move |
+
+## Reference numbers
+
+Both columns are one measurement session on `main` at **`777d4171`**, host
+`host_build_graph`, on one a2a3 die for qwen and two for dsv4, four rounds each with
+the warm-up pass dropped — 3 steady-state passes for qwen and 7 for dsv4, since a
+2-rank case emits one per rank. Durations are the full **range** across those
+passes; `heap_used`, every `bytes=` and every count are exact and repeat
+byte-identically.
+
+**For orientation, not thresholds, and pinned to a commit for a reason.** The
+machine's other tenants move every duration here, so the range is the point: a
+change smaller than the range beside it cannot be demonstrated by comparing two
+runs. The counts move too — they are properties of the cases, and the cases are
+edited. Re-measure rather than trusting this table; the recipes above are the part
+meant to outlive it.
+
+| Measurement | qwen3-14b decode | dsv4 FLASH decode |
+| ----------- | ---------------- | ----------------- |
+| control plane | 1.11–1.53 ms | 3.63–6.81 ms |
+| `host_orch` | 0.44–0.75 ms (47 tasks) | 2.60–4.91 ms (1131 tasks) |
+| `graph_upload` | 0.56–0.96 ms / 40 uploads, 232,320 B | 0.39–1.14 ms / 20 uploads, 671,144 B |
+| `sm_h2d` | 0.067–0.068 ms / 233,799 B | 0.54–0.98 ms / 5,620,195 B |
+| `arena_h2d` | 0.035–0.039 ms / 632 B | 0.03–0.10 ms / 632 B |
+| `heap_used` | 127,673,344 | 2,038,508,544 |
+| device wall | 39.3 ms | does not complete yet (`sched_error_code=5 INVALID_ARGS`) |
+| `args` (excluded) | 1.37 s / 40.9 GB, 19 of 20 staged | 1.48 s / 45.8 GB, 77 of 92 staged |
+| `host_view_close` (excluded) | 0.25 s / 40.9 GB | 0.28 s / 45.8 GB |
+
+Three of these deserve reading together. `host_orch` is the whole story on dsv4 —
+839 `submit_task`, 743 `record_node` and 272 `alloc_tensors` per bind against qwen's
+5, 277 and 2 — and its 2.3 ms of scatter is why a claim about it needs a
+sub-counter rather than a stopwatch. `args` plus `host_view_close` are two orders of
+magnitude above everything else while being excluded from the control plane: they
+are per-byte costs over the ~41–46 GB of weights each case stages, so they belong
+to getting the weights resident, not to dispatching a graph. And dsv4's device wall
+is absent because the case does not complete on device on this commit — it is a
+`skip_golden` completion case whose host path is what these numbers describe, which
+is also why `SIMPLER_SKIP_DEVICE_RUN` appears in its recipe.

--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -231,7 +231,9 @@ inside its `chip.run.bind`, matched on `(pid, inv)`. Both sides are the same
 still recovers the stage's own segments from the runtime's timing log lines; where
 both are present the artifact wins, so a segment is not drawn twice. See
 [host_build_graph's profiling levels](../../src/a2a3/runtime/host_build_graph/docs/profiling_levels.md)
-for what that runtime records.
+for what that runtime records, and
+[hbg-bind-measurement.md](hbg-bind-measurement.md) for the recipe that produces
+both the log and the artifact on a real decode network.
 
 **One exception, because a K-deep pipeline is not K threads.** The direct-chip
 lane drives prepare(N+1) and finalize(N) from the *same* OS thread, so a 40-run

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,6 +145,7 @@ nav:
       - Log System: logging.md
       - L2 Timing: dfx/l2-timing.md
       - Host trace: dfx/host-trace.md
+      - Measuring the hbg bind path: dfx/hbg-bind-measurement.md
       - Device phases: dfx/device-phases.md
       - Scheduler-overhead model: dfx/sched-overhead-model.md
       - Chip Swimlane: dfx/chip-swimlane-profiling.md


### PR DESCRIPTION
## Summary

`SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1` has itemized the `host_build_graph` bind path
for a while, but nothing recorded which segments make up the number the < 1 ms
control-plane target applies to, how to get the two decode cases to emit the lines at
all, or which readings are *wrong* rather than merely noisy. Every one of those cost a
device job to learn. This adds `docs/dfx/hbg-bind-measurement.md` plus two worked
sample artifacts.

The definition worth writing down: the control plane is
`host_orch + graph_upload + relocate + sm_h2d + arena_h2d`, and it is a **sum of cost
shares, not an interval** — `arena_h2d` runs after `host_view_close`, some 250 ms
later, so subtracting two timestamps overstates it by two orders of magnitude. `args`
and `host_view_close` are excluded because they price the ~41–46 GB of weights each
case stages, not the graph.

## Four traps that have each produced a confidently wrong answer

- A `device_count > 1` case run through the module runner yields a **passing** log
  with zero `bind phase=` lines, because `run_jobs` prints a child's stdout only on
  failure. The L3 child command has to be issued directly.
- `SIMPLER_SKIP_DEVICE_RUN` is presence-based, so `=0` still skips — a run then
  reports PASSED having executed nothing.
- Comparing two branches sequentially attributes a drift in host load to the branch.
  The conditions have to interleave, and the per-pass sign has to agree.
- A sum of per-segment minima is a total no pass achieved, and it can invert the sign
  against the minimum of the per-pass sums — observed at −0.30 ms against +0.16 ms on
  one dsv4 log.

## Reference numbers, pinned to a commit on purpose

The table is `main` at `777d4171`, given as ranges rather than points, because the
range is what tells a reader whether their effect is measurable at all: `host_orch`
alone spans 2.6–4.9 ms on dsv4 across passes of an unmodified build. Where a
segment's scatter swamps the change being tested, the page says to instrument the
mechanism instead of timing the segment.

Re-measuring against current `main` before opening this found three of the table's
numbers already stale, which is itself the argument for the pin:

| | was | is |
| --- | ---: | ---: |
| dsv4 `graph_upload` bytes | 613,424 | 671,144 |
| dsv4 `submit_task` / `alloc_tensors` | 838 / 273 | 839 / 272 |
| dsv4 kernel sources | 367 | 369 |

The first two are #1926's predicated MoE tile loops. Everything structural was
unchanged — task counts, Definition node counts, boundary widths, `heap_used`,
`sm_h2d` bytes — and the page now draws that distinction for the reader, and says to
re-measure rather than trust the table.

## Notes

- Docs only; no code, no build, no test touched. `mkdocs.yml` gains the nav entry —
  the docs build runs `--strict`, so a page under `docs/` that is absent from the nav
  fails the build rather than warning. Both files are in `_detect-changes.yml`'s
  `NON_CODE`, so the PR stays docs-only and every gated job correctly skips.
- Kept as one page at 277 lines and 8 H2 sections, above `doc-consistency.md`'s soft
  trigger. The content is majority tables and command blocks rather than prose, and
  the reference numbers earn their place directly below Recipe A because that is where
  a reader compares a fresh measurement against them. Flagging the call rather than
  making it silently.
