### PR TITLE
Fix: write the host phase records artifact when the device run is skipped

### DIFF
--- a/docs/dfx/hbg-bind-measurement.md
+++ b/docs/dfx/hbg-bind-measurement.md
@@ -102,11 +102,14 @@ A 2-rank case emits one pass per rank per round, so six rounds is twelve passes.
 To measure the host path without device execution, set
 `SIMPLER_SKIP_DEVICE_RUN=1`, which returns at `simpler_launch_run`. It is a
 temporary handle from the dsv4 bring-up and is deleted once that case's device
-execution works; two of its properties are load-bearing while it exists:
+execution works. One property is load-bearing while it exists:
 
 - **It is presence-based.** `SIMPLER_SKIP_DEVICE_RUN=0` still skips. `unset` it.
-- **A skipped run writes no `host_phase_records.jsonl`** (see Recipe B), because
-  the artifact is written by the teardown on the device-run path.
+
+A skipped run still writes `host_phase_records.jsonl`, so Recipe B works without
+touching the device. Every phase in that artifact is produced on the host during
+bind, so the skip path writes it exactly as the device-run teardown does; what
+still gates it is `--rounds`, not the device (see Recipe B).
 
 ### Reading the segments out
 
@@ -168,22 +171,23 @@ The summed `bind phase=` lines cannot be placed on a timeline inside
 rotating record pool, written to `outputs/<case>_<ts>/host_phase_records.jsonl` —
 one record per orchestrator operation, each with its own interval.
 
-Three conditions must all hold, and each one silently produces an empty result:
+Two conditions must both hold, and each one silently produces an empty result:
 
 1. **A diagnostic flag must be on**, because that is what makes
    `CallConfig.output_prefix` non-empty. `--enable-scope-stats` is the cheapest
    for an L3 case; `--enable-chip-swimlane` raises `NotImplementedError` for
    `level=3` (per-chip-process filename collision).
 2. **`--rounds` must be 1.** `rounds > 1` force-disables every diagnostic flag.
-3. **The device run must not be skipped.** The artifact is written by
-   `teardown_shared_collectors_after_run()`, which sits on the device-run path.
-   A run that *fails* on device still writes it — that is deliberate, and it is
-   how a case whose device execution does not complete still yields its prepare
-   timing.
+
+The device run may be skipped or may fail; neither costs you the artifact. Every
+phase recorded is host work done during bind, so both `SIMPLER_SKIP_DEVICE_RUN`
+and the device-run teardown write it. That is what lets a case whose device
+execution does not complete still yield its prepare timing — and it is why a
+swimlane for a case that hangs on device is cheaper to take with the variable set
+than to take by waiting out the stall.
 
 ```bash
 export SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 SIMPLER_LOG_LEVEL=TIMING TORCH_DEVICE_BACKEND_AUTOLOAD=0
-unset SIMPLER_SKIP_DEVICE_RUN
 
 task-submit --device auto --device-num 1 --timeout 2400 --max-time 2400 --run \
   "python examples/a2a3/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py \
@@ -230,7 +234,6 @@ signal than any duration on a shared box.
 | dsv4 run through the module runner's L3 phase | log has zero `bind phase=` lines, test passes | run the L3 child command directly (Recipe A) |
 | `SIMPLER_SKIP_DEVICE_RUN=0` | run still skips the device, "PASSED" means nothing ran | `unset` the variable |
 | `--rounds 6` with `--enable-scope-stats` | no `outputs/<case>_<ts>/` artifacts | one round for artifacts, many rounds for numbers |
-| Skipped device run in Recipe B | output directory exists but is empty | let the device run; a failing run writes the artifact too |
 | Subtracting timestamps for the control plane | ~300 ms instead of ~3 ms | sum the five segments; `arena_h2d` is not adjacent |
 | Single pass, or comparing across differently-loaded moments | swings of 3.5× | six rounds, compare minima, keep an untouched segment as a control |
 | `base` then `measure`, sequentially | a load drift reads as the branch's effect | interleave the conditions and require the sign to agree per pass |

--- a/src/common/platform/include/host/host_phase_records.h
+++ b/src/common/platform/include/host/host_phase_records.h
@@ -79,9 +79,13 @@ public:
     /**
      * Append this pass's records to `path` as one JSON Lines object.
      *
+     * At most one line per pass: a second call before the next `arm()` is a no-op,
+     * so paths that both end a run -- a device-run teardown and a run that stops
+     * before launch -- can each write unconditionally without duplicating a pass.
+     *
      * @return 0 on success, -1 when the path cannot be written
      */
-    int write_records_jsonl(const std::string &path) const;
+    int write_records_jsonl(const std::string &path);
 
     /** Records in rotation order. Empty unless a pass was armed with collection. */
     std::vector<HostPhaseRecord> records() const;
@@ -108,6 +112,7 @@ private:
     std::vector<HostPhaseRecordBuffer> buffers_{};
     bool armed_{false};
     bool finished_{false};
+    bool records_written_{false};
     uint64_t submitted_tasks_{0};
     uint64_t invocation_id_{0};
 };

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -813,6 +813,10 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     // produced, so any run under this variable is a timing harness, not a test.
     // Delete this together with the variable once the stall is diagnosed.
     if (std::getenv("SIMPLER_SKIP_DEVICE_RUN") != nullptr) {
+        // The host phase records describe the bind path this variable exists to
+        // measure, so they are written here as well as in the device-run
+        // teardown. Skipping the device must not skip the artifact.
+        state->runner->write_host_phase_records_artifact();
         state->completion_rc = 0;
         state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
         return 0;

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -1814,6 +1814,20 @@ void DeviceRunnerBase::start_shared_collectors_for_run() {
     }
 }
 
+void DeviceRunnerBase::write_host_phase_records_artifact() {
+    // Per-event view of the prepare path. Every phase it records is produced on
+    // the host during bind, and the store is finished before launch, so this
+    // touches no device state and is callable from any point after bind --
+    // including a path that never launches. Keyed on output_prefix_ because it is
+    // non-empty exactly when this run produces diagnostic artifacts, and on the
+    // store having finished a pass, which is what a host-orchestrating runtime
+    // leaves behind. The store writes a pass at most once, so every path that can
+    // end a run calls this unconditionally.
+    if (!output_prefix_.empty() && host_phase_records_.finished()) {
+        (void)host_phase_records_.write_records_jsonl(make_host_phase_records_path(output_prefix_));
+    }
+}
+
 void DeviceRunnerBase::teardown_shared_collectors_after_run(bool device_execution_complete) {
     // Tear down collectors. stop() joins mgmt then collector in the only safe
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
@@ -1828,15 +1842,7 @@ void DeviceRunnerBase::teardown_shared_collectors_after_run(bool device_executio
         chip_swimlane_collector_.export_swimlane_json();
     }
 
-    // Per-event view of the prepare path. Written here rather than in the reap
-    // tail because a device error reaches this teardown but not that tail, and a
-    // failed run is when the prepare timing is worth having. Keyed on
-    // output_prefix_ because it is non-empty exactly when this run produces
-    // diagnostic artifacts, and on the store having finished a pass, which is what
-    // a host-orchestrating runtime leaves behind.
-    if (!output_prefix_.empty() && host_phase_records_.finished()) {
-        (void)host_phase_records_.write_records_jsonl(make_host_phase_records_path(output_prefix_));
-    }
+    write_host_phase_records_artifact();
 
     if (enable_dump_args_) {
         dump_collector_.stop();

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -728,6 +728,15 @@ public:
     const simpler::dfx::HostPhaseRecordStore &host_phase_records() const { return host_phase_records_; }
     /** Hand this pass's records to the swimlane reader, just before its export. */
     void publish_host_phase_records_to_swimlane();
+    /**
+     * Write this pass's per-event host phase records to `output_prefix_`.
+     *
+     * Host-only: every phase recorded is produced on the host during bind and the
+     * store is finished before launch, so a caller that never reaches the device
+     * can still produce the artifact. The store writes a pass at most once, so
+     * every path that can end a run may call this unconditionally.
+     */
+    void write_host_phase_records_artifact();
     void finish_clock_correlation_session(bool capture_device_complete, bool abandon_device_resources) noexcept;
     void set_dump_args_enabled(int level) {
         dump_args_level_ = static_cast<DumpArgsLevel>(level);

--- a/src/common/platform/shared/host/host_phase_records.cpp
+++ b/src/common/platform/shared/host/host_phase_records.cpp
@@ -23,6 +23,7 @@ HostPhaseRecordPool *HostPhaseRecordStore::arm(bool collect_records) {
     pool_ = HostPhaseRecordPool{};
     armed_ = false;
     finished_ = false;
+    records_written_ = false;
     submitted_tasks_ = 0;
     // A pass's identity must not survive into the next one: write_records_jsonl
     // asks only whether the store is armed, so a pass written before finish()
@@ -71,10 +72,11 @@ void HostPhaseRecordStore::finish(uint64_t submitted_tasks, uint64_t invocation_
     }
 }
 
-int HostPhaseRecordStore::write_records_jsonl(const std::string &path) const {
-    if (!armed_) return 0;
+int HostPhaseRecordStore::write_records_jsonl(const std::string &path) {
+    if (!armed_ || records_written_) return 0;
     const std::vector<HostPhaseRecord> all = records();
     if (all.empty() && dropped_records() == 0) return 0;
+    records_written_ = true;
 
     // Appended one object per pass: a --rounds run emits a pass per round, and
     // each object carries the identity needed to join it to that round's spans.

--- a/tests/ut/cpp/common/test_host_phase_records.cpp
+++ b/tests/ut/cpp/common/test_host_phase_records.cpp
@@ -11,11 +11,24 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdio>
+#include <fstream>
+#include <string>
+
 #include "host/host_phase_records.h"
 
 using simpler::dfx::HostPhaseRecordStore;
 
 namespace {
+
+size_t count_lines(const std::string &path) {
+    std::ifstream in(path);
+    size_t n = 0;
+    for (std::string line; std::getline(in, line);) {
+        if (!line.empty()) n++;
+    }
+    return n;
+}
 
 void record_n(
     HostPhaseRecordPool *pool, HostPhaseKind kind, uint32_t n, uint64_t first_start = 0, uint32_t thread_id = 0
@@ -166,6 +179,33 @@ TEST(HostPhaseRecords, EveryKindHasItsOwnName) {
         }
     }
     EXPECT_STREQ(host_phase_kind_name(HostPhaseKind::Count), "unknown");
+}
+
+TEST(HostPhaseRecords, APassIsWrittenAtMostOnceAndTheNextPassAppends) {
+    // Both the device-run teardown and a run that stops before launch write the
+    // artifact unconditionally, so the store -- not its callers -- is what keeps a
+    // pass from appearing twice.
+    const std::string path = std::string(testing::TempDir()) + "/host_phase_records_write_once.jsonl";
+    std::remove(path.c_str());
+
+    HostPhaseRecordStore store;
+    HostPhaseRecordPool *pool = store.arm(true);
+    ASSERT_NE(pool, nullptr);
+    record_n(pool, HostPhaseKind::OrchRecordNode, 4);
+    store.finish(4, /*invocation_id=*/11);
+
+    EXPECT_EQ(store.write_records_jsonl(path), 0);
+    EXPECT_EQ(store.write_records_jsonl(path), 0);
+    EXPECT_EQ(count_lines(path), 1u) << "a second write of the same pass must append nothing";
+
+    pool = store.arm(true);
+    ASSERT_NE(pool, nullptr);
+    record_n(pool, HostPhaseKind::OrchGraphSubmit, 2);
+    store.finish(2, /*invocation_id=*/12);
+    EXPECT_EQ(store.write_records_jsonl(path), 0);
+    EXPECT_EQ(count_lines(path), 2u) << "a --rounds run must still get one line per pass";
+
+    std::remove(path.c_str());
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

`host_phase_records.jsonl` is the per-event view of the bind path — one record
per orchestrator operation, each with its own interval, which is what makes a
host swimlane possible. Every phase in it is host work performed during bind, and
the store is finished before launch. But the only call that wrote it sat in
`teardown_shared_collectors_after_run()`, on the device-run path.

`SIMPLER_SKIP_DEVICE_RUN` exists to measure exactly that host path, and it
produced no artifact. So the one flag that lets a case with a stalling device
yield its prepare timing was also the flag that discarded the richest form of it:
taking a host swimlane for dsv4 meant running the device and waiting out a 45 s
`SCHEDULER_TIMEOUT`.

## What changed

- The write moves into `DeviceRunnerBase::write_host_phase_records_artifact()`,
  and the `SIMPLER_SKIP_DEVICE_RUN` branch in `simpler_launch_run` calls it too.
  Nothing in it touches device state; it was only ever placed on that path.
- Two callers can now end the same run, so the write-once rule moves into the
  store instead of being a property of which path ran. `write_records_jsonl`
  **appends** — one JSON Lines object per pass, which a `--rounds` run relies on
  — so a second call before the next `arm()` would have appended a duplicate
  pass. The store now tracks whether the current pass was written and returns
  early if so, letting every path that can end a run call it unconditionally.
- `docs/dfx/hbg-bind-measurement.md` (#1934) claimed *"A skipped run writes no
  `host_phase_records.jsonl`"* and *"The device run must not be skipped."* Both
  are now false. Recipe B's three preconditions become two, and the doc names the
  gate that actually remains: `--rounds` must be 1, because `rounds > 1`
  force-disables every diagnostic flag and so leaves no output directory.

## Testing

- [x] `ctest -LE requires_hardware` — 107/107
- [x] New cpput case `HostPhaseRecords.APassIsWrittenAtMostOnceAndTheNextPassAppends`,
      confirmed to **fail** against the pre-fix store (a repeated write appended a
      second line for one pass) and pass after.
- [x] a2a3 onboard, dsv4 L3 EP2/TP2 with `SIMPLER_SKIP_DEVICE_RUN=1 --rounds 1
      --enable-pmu 2`: run exits 0 without touching the device, and
      `outputs/<case>_<ts>/host_phase_records.jsonl` lands with 3072 records
      across 2 ranks. `strace_timing --swimlane --host-phase-records` builds the
      swimlane from it — previously only reachable through a device run that
      ended in a 45 s scheduler timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)