### PR TITLE
Add: a switch of its own for the host phase per-event records

### DIFF
--- a/docs/dfx/hbg-bind-measurement.md
+++ b/docs/dfx/hbg-bind-measurement.md
@@ -109,7 +109,7 @@ execution works. One property is load-bearing while it exists:
 A skipped run still writes `host_phase_records.jsonl`, so Recipe B works without
 touching the device. Every phase in that artifact is produced on the host during
 bind, so the skip path writes it exactly as the device-run teardown does; what
-still gates it is `--rounds`, not the device (see Recipe B).
+gates it is Recipe B's three conditions, none of which is the device.
 
 ### Reading the segments out
 
@@ -171,13 +171,16 @@ The summed `bind phase=` lines cannot be placed on a timeline inside
 rotating record pool, written to `outputs/<case>_<ts>/host_phase_records.jsonl` —
 one record per orchestrator operation, each with its own interval.
 
-Two conditions must both hold, and each one silently produces an empty result:
+Three conditions must all hold, and each one silently produces an empty result:
 
-1. **A diagnostic flag must be on**, because that is what makes
+1. **`SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE=1`**, which is what arms the pool.
+   `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` does not: it gates the summed
+   `bind phase=` lines alone, so Recipe A's environment collects no records.
+2. **A diagnostic flag must be on**, because that is what makes
    `CallConfig.output_prefix` non-empty. `--enable-scope-stats` is the cheapest
    for an L3 case; `--enable-chip-swimlane` raises `NotImplementedError` for
    `level=3` (per-chip-process filename collision).
-2. **`--rounds` must be 1.** `rounds > 1` force-disables every diagnostic flag.
+3. **`--rounds` must be 1.** `rounds > 1` force-disables every diagnostic flag.
 
 The device run may be skipped or may fail; neither costs you the artifact. Every
 phase recorded is host work done during bind, so both `SIMPLER_SKIP_DEVICE_RUN`
@@ -187,7 +190,8 @@ swimlane for a case that hangs on device is cheaper to take with the variable se
 than to take by waiting out the stall.
 
 ```bash
-export SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 SIMPLER_LOG_LEVEL=TIMING TORCH_DEVICE_BACKEND_AUTOLOAD=0
+export SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE=1
+export SIMPLER_LOG_LEVEL=TIMING TORCH_DEVICE_BACKEND_AUTOLOAD=0
 
 task-submit --device auto --device-num 1 --timeout 2400 --max-time 2400 --run \
   "python examples/a2a3/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py \
@@ -234,6 +238,7 @@ signal than any duration on a shared box.
 | dsv4 run through the module runner's L3 phase | log has zero `bind phase=` lines, test passes | run the L3 child command directly (Recipe A) |
 | `SIMPLER_SKIP_DEVICE_RUN=0` | run still skips the device, "PASSED" means nothing ran | `unset` the variable |
 | `--rounds 6` with `--enable-scope-stats` | no `outputs/<case>_<ts>/` artifacts | one round for artifacts, many rounds for numbers |
+| Only `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` set for Recipe B | `bind phase=` lines present, no `host_phase_records.jsonl` | the records are a separate switch: also export `SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE=1` |
 | Subtracting timestamps for the control plane | ~300 ms instead of ~3 ms | sum the five segments; `arena_h2d` is not adjacent |
 | Single pass, or comparing across differently-loaded moments | swings of 3.5× | six rounds, compare minima, keep an untouched segment as a control |
 | `base` then `measure`, sequentially | a load drift reads as the branch's effect | interleave the conditions and require the sign to agree per pass |

--- a/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
@@ -235,7 +235,7 @@ Thread X:   overlap checks : XXX, hits=XXX (XX.X%)
 
 `host_build_graph` times its prepare path — the `chip.run.bind` stage's
 segments, and the host orchestrator's submit-level operations inside it. One
-recorder feeds three views, and two independent switches decide which of them
+recorder feeds three views, and three independent switches decide which of them
 appear.
 
 ### What is recorded
@@ -254,22 +254,36 @@ The other two are sub-operations of one of those, which is why a per-kind total
 is a **cost share, not an interval**: a per-event mean is `total_ns / count`, and
 the spread is not recoverable from it.
 
-### The two switches
+### The three switches
 
 | Switch | Turns on |
 | ------ | -------- |
-| `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` (env, off unless it starts with `1`, `t` or `T`) | the `LOG_TIMING` breakdown; needs no rebuild and works at any `--rounds` |
-| `--enable-chip-swimlane 4` (CallConfig `chip_swimlane_level`) | the host lane in `chip_swimlane_records.json`, with its records clock-aligned against the device timeline |
+| `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` (env, off unless it starts with `1`, `t` or `T`) | the `LOG_TIMING` breakdown; needs no records, no rebuild, and works at any `--rounds` |
+| `SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE` (env, same spelling) | per-event collection into the pool, which reaches `host_phase_records.jsonl` when the run has an output directory |
+| `--enable-chip-swimlane 4` (CallConfig `chip_swimlane_level`) | per-event collection *and* the host lane in `chip_swimlane_records.json`, with its records clock-aligned against the device timeline |
 
-Collection is armed by **either** — a level-4 run collects records with the
-variable unset, and the variable collects them with the level at 0. What is
-recorded does not depend on which one armed the pass: the swimlane's share is a
-projection at export, not a branch at record time, so the two configurations
-measure the same overhead and their numbers are comparable.
+The first switch is orthogonal to the other two: it reads the per-kind counters,
+which are exact whether or not records are kept, so a run can take the breakdown
+with no records and records with no breakdown.
+
+Collection is armed by **either** of the other two — a level-4 run collects
+records with the variable unset, and the variable collects them with the level at
+0. What is recorded does not depend on which one armed the pass: the swimlane's
+share is a projection at export, not a branch at record time, so the two
+configurations measure the same overhead and their numbers are comparable.
+
+Collecting and writing are separate questions. A collected pass reaches
+`host_phase_records.jsonl` whenever the run has an output directory, so a level-4
+run produces the artifact too; conversely the variable arms nothing when there is
+no directory to write into, since a pool no reader drains would be pure cost.
 
 ```bash
-# breakdown only, any --rounds, no rebuild
+# breakdown only, any --rounds, no rebuild — no pool, no artifact
 SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 python -m pytest <case> --platform <platform> --device 0
+
+# per-event records; --enable-scope-stats is the cheapest way to get an output directory
+SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE=1 \
+  python -m pytest <case> --platform <platform> --device 0 --enable-scope-stats
 
 # host lane on the chip swimlane, aligned against the device timeline
 python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 4
@@ -277,30 +291,31 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
 
 ### The three views
 
-- **`LOG_TIMING` lines**, at the default log threshold, gated by the env
-  variable. One `bind phase=<p> start_ns=<n> dur_ns=<n> <attrs>` line per
-  segment, plus one `host-orch phase=<p> total_ns=<n> count=<k> detail_sum=<n>
-  dropped=<n>` line per orchestrator kind. They come from per-kind counters, not
-  from the record pool. The counters use lock-free atomic additions across the
-  main and recording-worker lanes, with every phase isolated on its own cache
-  line so concurrent `graph_submit` and `record_node` updates do not
-  false-share. The per-event pool is armed when the level-4 artifact is being
-  written (a producer that wants records *and* an output prefix) or whenever the
-  chip swimlane is at `ORCH_PHASES`; a steady-state run satisfies neither, so it
-  pays no pool append and no artifact lock at all. A total stays exact even if
-  the pool was never armed or overflowed — that is what makes this the channel
-  for steady state, where `--rounds > 1` switches every artifact collector off.
+- **`LOG_TIMING` lines**, at the default log threshold, gated by
+  `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE`. One `bind phase=<p> start_ns=<n>
+  dur_ns=<n> <attrs>` line per segment, plus one `host-orch phase=<p>
+  total_ns=<n> count=<k> detail_sum=<n> dropped=<n>` line per orchestrator kind.
+  They come from per-kind counters, not from the record pool. The counters use
+  lock-free atomic additions across the main and recording-worker lanes, with
+  every phase isolated on its own cache line so concurrent `graph_submit` and
+  `record_node` updates do not false-share. The per-event pool is armed when the
+  artifact is wanted (`SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE` *and* an output
+  prefix) or whenever the chip swimlane is at `ORCH_PHASES`; a steady-state run
+  satisfies neither, so it pays no pool append and no artifact lock at all. A
+  total stays exact even if the pool was never armed or overflowed — that is what
+  makes this the channel for steady state, where `--rounds > 1` switches every
+  artifact collector off.
 
   Every line is written at the end of the pass, keeping the log write off the path
   being measured. The line therefore carries its own `start_ns`; the log prefix
   timestamps the write, not the segment.
 
-- **`host_phase_records.jsonl`** in the per-case output directory, when the run
-  has one. One JSON Lines object per pass carrying `pid` / `inv` — the identity
-  the `[STRACE]` tree groups by — and one record per operation. This is the
-  channel to read for a distribution or a per-event timeline; the summed lines
-  cannot express either. Every record carries its producer Linux tid.
-  `strace_timing.py --swimlane --host-phase-records <path>` draws each record
+- **`host_phase_records.jsonl`** in the per-case output directory, when a
+  collecting pass has one. One JSON Lines object per pass carrying `pid` / `inv`
+  — the identity the `[STRACE]` tree groups by — and one record per operation.
+  This is the channel to read for a distribution or a per-event timeline; the
+  summed lines cannot express either. Every record carries its producer Linux
+  tid. `strace_timing.py --swimlane --host-phase-records <path>` draws each record
   inside the matching `chip.run.bind`; `record_node` and `build_definition`
   appear on the `graph record worker` lane, while outer `graph_submit` events
   appear on the `graph submit main` lane.
@@ -334,7 +349,7 @@ not belong in it.
 
 A record costs two clock reads and a store. Its per-kind counter update is a
 lock-free atomic add; only the per-event pool append is serialized, and only
-when the pool is armed. It sits on the path being measured, which is why neither
+when the pool is armed. It sits on the path being measured, which is why no
 switch is on by default.
 
 The pool holds `PLATFORM_HOST_PHASE_BUFFERS × PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER`

--- a/src/a2a3/runtime/host_build_graph/host/host_phase_trace.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/host_phase_trace.cpp
@@ -110,6 +110,14 @@ void drain_in_flight_records(TraceState &s) {
 
 bool is_bind_kind(uint32_t kind) { return kind < static_cast<uint32_t>(HostPhaseKind::OrchSubmitTask); }
 
+// Opt-in spelling shared by this runtime's switches, matching the runtime's
+// other default-off switch, SIMPLER_TMR_SERIAL_ORCH_SCHED_ENABLE, so that
+// `=false` / `=off` / `=no` read as off rather than as a non-zero string.
+bool env_opt_in(const char *name) {
+    const char *env = std::getenv(name);
+    return env != nullptr && (env[0] == '1' || env[0] == 't' || env[0] == 'T');
+}
+
 uint32_t current_thread_id() {
     // A thread's identity is fixed for its lifetime, so resolve it once. This
     // runs per record on the path being measured, where a syscall would inflate
@@ -152,15 +160,15 @@ void reset_counter(KindCounter &counter) {
 
 }  // namespace
 
-bool host_phase_timing_enabled() {
+bool host_phase_breakdown_enabled() {
     // Read once: the value cannot change within a process, and the orchestrator
-    // asks per submit-level operation. Opt-in spelling matches the runtime's
-    // other default-off switch, SIMPLER_TMR_SERIAL_ORCH_SCHED_ENABLE, so that
-    // `=false` / `=off` / `=no` read as off rather than as a non-zero string.
-    static const bool enabled = [] {
-        const char *env = std::getenv("SIMPLER_HBG_BIND_BREAKDOWN_ENABLE");
-        return env != nullptr && (env[0] == '1' || env[0] == 't' || env[0] == 'T');
-    }();
+    // asks per submit-level operation.
+    static const bool enabled = env_opt_in("SIMPLER_HBG_BIND_BREAKDOWN_ENABLE");
+    return enabled;
+}
+
+bool host_phase_records_enabled() {
+    static const bool enabled = env_opt_in("SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE");
     return enabled;
 }
 
@@ -214,18 +222,19 @@ void host_phase_trace_begin(const void *host_api) {
     drain_in_flight_records(s);
     s.api = static_cast<const HostApi *>(host_api);
     HostPhaseRecordPool *pool =
-        s.api != nullptr ? static_cast<HostPhaseRecordPool *>(s.api->host_phase_pool_arm(host_phase_timing_enabled())) :
-                           nullptr;
+        s.api != nullptr ?
+            static_cast<HostPhaseRecordPool *>(s.api->host_phase_pool_arm(host_phase_records_enabled())) :
+            nullptr;
     s.pool.store(pool, std::memory_order_release);
     // Timestamps are taken whenever either sink wants them. Gating the clock on
-    // the environment variable alone would leave a level-4 run recording zeros.
+    // one switch alone would leave the other sink recording zeros.
     s.submitted_tasks.store(0, std::memory_order_relaxed);
     for (KindCounter &counter : s.counters)
         reset_counter(counter);
     for (auto &attrs : s.bind_attrs) {
         attrs[0] = '\0';
     }
-    s.active.store(s.pool != nullptr || host_phase_timing_enabled(), std::memory_order_release);
+    s.active.store(s.pool != nullptr || host_phase_breakdown_enabled(), std::memory_order_release);
 }
 
 void host_phase_trace_note_submitted(uint64_t submitted_tasks) {
@@ -260,7 +269,7 @@ void host_phase_trace_end() {
         s.api->host_phase_pool_finish(s.submitted_tasks.load(std::memory_order_relaxed), inv);
     }
     s.pool.store(nullptr, std::memory_order_release);
-    if (!host_phase_timing_enabled()) {
+    if (!host_phase_breakdown_enabled()) {
         // Records were collected for a per-event reader alone, which has its own
         // report; this breakdown was not asked for.
         return;

--- a/src/a2a3/runtime/host_build_graph/runtime/host_phase_trace.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/host_phase_trace.h
@@ -37,16 +37,30 @@
  * Whether this runtime asks for its own prepare-path breakdown.
  *
  * True only when `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` starts with `1`, `t` or
- * `T`, read once on first use. This is the producer's own condition; the runner
- * ORs it with the chip-swimlane level when deciding whether to arm the pool, so
- * a level-4 run collects records with the variable unset, and this variable
- * collects them with the level at 0.
+ * `T`, read once on first use. It gates the counters' `LOG_TIMING` lines alone:
+ * the breakdown needs no pool, and the pool has readers that do not want the
+ * lines.
  *
  * "Breakdown" rather than "timing" because the bind stage's *duration* is
  * already published as the `chip.run.bind` `[STRACE]` marker; what this adds
  * is the division of that one number into its parts.
  */
-bool host_phase_timing_enabled();
+bool host_phase_breakdown_enabled();
+
+/**
+ * Whether this runtime asks for per-event records.
+ *
+ * True only when `SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE` starts with `1`, `t`
+ * or `T`, read once on first use. This is the producer's own condition for
+ * collection; the runner ORs it with the chip-swimlane level when deciding
+ * whether to arm the pool, so a level-4 run collects records with the variable
+ * unset, and this variable collects them with the level at 0.
+ *
+ * Collection only. Whether a collected pass also reaches
+ * `host_phase_records.jsonl` is the runner's decision, and it turns on the run
+ * having an output directory.
+ */
+bool host_phase_records_enabled();
 
 /**
  * Host monotonic nanoseconds, or 0 when this pass records nothing — which is

--- a/src/a5/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a5/runtime/host_build_graph/docs/profiling_levels.md
@@ -235,7 +235,7 @@ Thread X:   overlap checks : XXX, hits=XXX (XX.X%)
 
 `host_build_graph` times its prepare path — the `chip.run.bind` stage's
 segments, and the host orchestrator's submit-level operations inside it. One
-recorder feeds three views, and two independent switches decide which of them
+recorder feeds three views, and three independent switches decide which of them
 appear.
 
 ### What is recorded
@@ -254,22 +254,36 @@ The other two are sub-operations of one of those, which is why a per-kind total
 is a **cost share, not an interval**: a per-event mean is `total_ns / count`, and
 the spread is not recoverable from it.
 
-### The two switches
+### The three switches
 
 | Switch | Turns on |
 | ------ | -------- |
-| `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` (env, off unless it starts with `1`, `t` or `T`) | the `LOG_TIMING` breakdown; needs no rebuild and works at any `--rounds` |
-| `--enable-chip-swimlane 4` (CallConfig `chip_swimlane_level`) | the host lane in `chip_swimlane_records.json`, with its records clock-aligned against the device timeline |
+| `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` (env, off unless it starts with `1`, `t` or `T`) | the `LOG_TIMING` breakdown; needs no records, no rebuild, and works at any `--rounds` |
+| `SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE` (env, same spelling) | per-event collection into the pool, which reaches `host_phase_records.jsonl` when the run has an output directory |
+| `--enable-chip-swimlane 4` (CallConfig `chip_swimlane_level`) | per-event collection *and* the host lane in `chip_swimlane_records.json`, with its records clock-aligned against the device timeline |
 
-Collection is armed by **either** — a level-4 run collects records with the
-variable unset, and the variable collects them with the level at 0. What is
-recorded does not depend on which one armed the pass: the swimlane's share is a
-projection at export, not a branch at record time, so the two configurations
-measure the same overhead and their numbers are comparable.
+The first switch is orthogonal to the other two: it reads the per-kind counters,
+which are exact whether or not records are kept, so a run can take the breakdown
+with no records and records with no breakdown.
+
+Collection is armed by **either** of the other two — a level-4 run collects
+records with the variable unset, and the variable collects them with the level at
+0. What is recorded does not depend on which one armed the pass: the swimlane's
+share is a projection at export, not a branch at record time, so the two
+configurations measure the same overhead and their numbers are comparable.
+
+Collecting and writing are separate questions. A collected pass reaches
+`host_phase_records.jsonl` whenever the run has an output directory, so a level-4
+run produces the artifact too; conversely the variable arms nothing when there is
+no directory to write into, since a pool no reader drains would be pure cost.
 
 ```bash
-# breakdown only, any --rounds, no rebuild
+# breakdown only, any --rounds, no rebuild — no pool, no artifact
 SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 python -m pytest <case> --platform <platform> --device 0
+
+# per-event records; --enable-scope-stats is the cheapest way to get an output directory
+SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE=1 \
+  python -m pytest <case> --platform <platform> --device 0 --enable-scope-stats
 
 # host lane on the chip swimlane, aligned against the device timeline
 python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 4
@@ -277,30 +291,31 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
 
 ### The three views
 
-- **`LOG_TIMING` lines**, at the default log threshold, gated by the env
-  variable. One `bind phase=<p> start_ns=<n> dur_ns=<n> <attrs>` line per
-  segment, plus one `host-orch phase=<p> total_ns=<n> count=<k> detail_sum=<n>
-  dropped=<n>` line per orchestrator kind. They come from per-kind counters, not
-  from the record pool. The counters use lock-free atomic additions across the
-  main and recording-worker lanes, with every phase isolated on its own cache
-  line so concurrent `graph_submit` and `record_node` updates do not
-  false-share. The per-event pool is armed when the level-4 artifact is being
-  written (a producer that wants records *and* an output prefix) or whenever the
-  chip swimlane is at `ORCH_PHASES`; a steady-state run satisfies neither, so it
-  pays no pool append and no artifact lock at all. A total stays exact even if
-  the pool was never armed or overflowed — that is what makes this the channel
-  for steady state, where `--rounds > 1` switches every artifact collector off.
+- **`LOG_TIMING` lines**, at the default log threshold, gated by
+  `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE`. One `bind phase=<p> start_ns=<n>
+  dur_ns=<n> <attrs>` line per segment, plus one `host-orch phase=<p>
+  total_ns=<n> count=<k> detail_sum=<n> dropped=<n>` line per orchestrator kind.
+  They come from per-kind counters, not from the record pool. The counters use
+  lock-free atomic additions across the main and recording-worker lanes, with
+  every phase isolated on its own cache line so concurrent `graph_submit` and
+  `record_node` updates do not false-share. The per-event pool is armed when the
+  artifact is wanted (`SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE` *and* an output
+  prefix) or whenever the chip swimlane is at `ORCH_PHASES`; a steady-state run
+  satisfies neither, so it pays no pool append and no artifact lock at all. A
+  total stays exact even if the pool was never armed or overflowed — that is what
+  makes this the channel for steady state, where `--rounds > 1` switches every
+  artifact collector off.
 
   Every line is written at the end of the pass, keeping the log write off the path
   being measured. The line therefore carries its own `start_ns`; the log prefix
   timestamps the write, not the segment.
 
-- **`host_phase_records.jsonl`** in the per-case output directory, when the run
-  has one. One JSON Lines object per pass carrying `pid` / `inv` — the identity
-  the `[STRACE]` tree groups by — and one record per operation. This is the
-  channel to read for a distribution or a per-event timeline; the summed lines
-  cannot express either. Every record carries its producer Linux tid.
-  `strace_timing.py --swimlane --host-phase-records <path>` draws each record
+- **`host_phase_records.jsonl`** in the per-case output directory, when a
+  collecting pass has one. One JSON Lines object per pass carrying `pid` / `inv`
+  — the identity the `[STRACE]` tree groups by — and one record per operation.
+  This is the channel to read for a distribution or a per-event timeline; the
+  summed lines cannot express either. Every record carries its producer Linux
+  tid. `strace_timing.py --swimlane --host-phase-records <path>` draws each record
   inside the matching `chip.run.bind`; `record_node` and `build_definition`
   appear on the `graph record worker` lane, while outer `graph_submit` events
   appear on the `graph submit main` lane.
@@ -334,7 +349,7 @@ not belong in it.
 
 A record costs two clock reads and a store. Its per-kind counter update is a
 lock-free atomic add; only the per-event pool append is serialized, and only
-when the pool is armed. It sits on the path being measured, which is why neither
+when the pool is armed. It sits on the path being measured, which is why no
 switch is on by default.
 
 The pool holds `PLATFORM_HOST_PHASE_BUFFERS × PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER`

--- a/src/a5/runtime/host_build_graph/host/host_phase_trace.cpp
+++ b/src/a5/runtime/host_build_graph/host/host_phase_trace.cpp
@@ -110,6 +110,14 @@ void drain_in_flight_records(TraceState &s) {
 
 bool is_bind_kind(uint32_t kind) { return kind < static_cast<uint32_t>(HostPhaseKind::OrchSubmitTask); }
 
+// Opt-in spelling shared by this runtime's switches, matching the runtime's
+// other default-off switch, SIMPLER_TMR_SERIAL_ORCH_SCHED_ENABLE, so that
+// `=false` / `=off` / `=no` read as off rather than as a non-zero string.
+bool env_opt_in(const char *name) {
+    const char *env = std::getenv(name);
+    return env != nullptr && (env[0] == '1' || env[0] == 't' || env[0] == 'T');
+}
+
 uint32_t current_thread_id() {
     // A thread's identity is fixed for its lifetime, so resolve it once. This
     // runs per record on the path being measured, where a syscall would inflate
@@ -152,15 +160,15 @@ void reset_counter(KindCounter &counter) {
 
 }  // namespace
 
-bool host_phase_timing_enabled() {
+bool host_phase_breakdown_enabled() {
     // Read once: the value cannot change within a process, and the orchestrator
-    // asks per submit-level operation. Opt-in spelling matches the runtime's
-    // other default-off switch, SIMPLER_TMR_SERIAL_ORCH_SCHED_ENABLE, so that
-    // `=false` / `=off` / `=no` read as off rather than as a non-zero string.
-    static const bool enabled = [] {
-        const char *env = std::getenv("SIMPLER_HBG_BIND_BREAKDOWN_ENABLE");
-        return env != nullptr && (env[0] == '1' || env[0] == 't' || env[0] == 'T');
-    }();
+    // asks per submit-level operation.
+    static const bool enabled = env_opt_in("SIMPLER_HBG_BIND_BREAKDOWN_ENABLE");
+    return enabled;
+}
+
+bool host_phase_records_enabled() {
+    static const bool enabled = env_opt_in("SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE");
     return enabled;
 }
 
@@ -214,18 +222,19 @@ void host_phase_trace_begin(const void *host_api) {
     drain_in_flight_records(s);
     s.api = static_cast<const HostApi *>(host_api);
     HostPhaseRecordPool *pool =
-        s.api != nullptr ? static_cast<HostPhaseRecordPool *>(s.api->host_phase_pool_arm(host_phase_timing_enabled())) :
-                           nullptr;
+        s.api != nullptr ?
+            static_cast<HostPhaseRecordPool *>(s.api->host_phase_pool_arm(host_phase_records_enabled())) :
+            nullptr;
     s.pool.store(pool, std::memory_order_release);
     // Timestamps are taken whenever either sink wants them. Gating the clock on
-    // the environment variable alone would leave a level-4 run recording zeros.
+    // one switch alone would leave the other sink recording zeros.
     s.submitted_tasks.store(0, std::memory_order_relaxed);
     for (KindCounter &counter : s.counters)
         reset_counter(counter);
     for (auto &attrs : s.bind_attrs) {
         attrs[0] = '\0';
     }
-    s.active.store(s.pool != nullptr || host_phase_timing_enabled(), std::memory_order_release);
+    s.active.store(s.pool != nullptr || host_phase_breakdown_enabled(), std::memory_order_release);
 }
 
 void host_phase_trace_note_submitted(uint64_t submitted_tasks) {
@@ -260,7 +269,7 @@ void host_phase_trace_end() {
         s.api->host_phase_pool_finish(s.submitted_tasks.load(std::memory_order_relaxed), inv);
     }
     s.pool.store(nullptr, std::memory_order_release);
-    if (!host_phase_timing_enabled()) {
+    if (!host_phase_breakdown_enabled()) {
         // Records were collected for a per-event reader alone, which has its own
         // report; this breakdown was not asked for.
         return;

--- a/src/a5/runtime/host_build_graph/runtime/host_phase_trace.h
+++ b/src/a5/runtime/host_build_graph/runtime/host_phase_trace.h
@@ -37,16 +37,30 @@
  * Whether this runtime asks for its own prepare-path breakdown.
  *
  * True only when `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` starts with `1`, `t` or
- * `T`, read once on first use. This is the producer's own condition; the runner
- * ORs it with the chip-swimlane level when deciding whether to arm the pool, so
- * a level-4 run collects records with the variable unset, and this variable
- * collects them with the level at 0.
+ * `T`, read once on first use. It gates the counters' `LOG_TIMING` lines alone:
+ * the breakdown needs no pool, and the pool has readers that do not want the
+ * lines.
  *
  * "Breakdown" rather than "timing" because the bind stage's *duration* is
  * already published as the `chip.run.bind` `[STRACE]` marker; what this adds
  * is the division of that one number into its parts.
  */
-bool host_phase_timing_enabled();
+bool host_phase_breakdown_enabled();
+
+/**
+ * Whether this runtime asks for per-event records.
+ *
+ * True only when `SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE` starts with `1`, `t`
+ * or `T`, read once on first use. This is the producer's own condition for
+ * collection; the runner ORs it with the chip-swimlane level when deciding
+ * whether to arm the pool, so a level-4 run collects records with the variable
+ * unset, and this variable collects them with the level at 0.
+ *
+ * Collection only. Whether a collected pass also reaches
+ * `host_phase_records.jsonl` is the runner's decision, and it turns on the run
+ * having an output directory.
+ */
+bool host_phase_records_enabled();
 
 /**
  * Host monotonic nanoseconds, or 0 when this pass records nothing — which is


### PR DESCRIPTION
## Summary

`SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` gated two unrelated things: the per-kind
`LOG_TIMING` breakdown, and — as the producer's arming condition — the per-event
record pool behind `host_phase_records.jsonl`. A run that wanted the summed lines
while some other diagnostic flag was on had no way to decline the artifact, and
the per-event path is the one that appends to a pool under a lock on the path
being measured.

- The producer's arming condition becomes its own variable,
  `SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE`, so each of the three views has exactly
  one switch.
- `host_phase_timing_enabled()` → `host_phase_breakdown_enabled()`, which is what
  it now decides alone; the shared `1`/`t`/`T` opt-in parsing moves into one
  helper.
- Collection is still armed by **either** the new variable or a chip-swimlane
  level of `ORCH_PHASES`, and writing the artifact is unchanged — a collected
  pass reaches the JSONL whenever the run has an output directory, so a level-4
  run still produces both. What changes is that the breakdown alone no longer
  arms anything.

| Configuration | `bind phase=` lines | `host_phase_records.jsonl` | swimlane host lane |
| ------------- | ------------------- | -------------------------- | ------------------ |
| neither switch (default) | ✗ | ✗ | ✗ |
| `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1` | ✓ | ✗ *(was ✓)* | ✗ |
| `SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE=1` | ✗ | ✓ | ✗ |
| `--enable-chip-swimlane 4` | ✗ | ✓ | ✓ |

The one behavior change for existing users is the second row: Recipe B in
`docs/dfx/hbg-bind-measurement.md` now exports both variables, and its condition
list and traps table say which switch owns the artifact.

Docs updated in the same commit: both copies of the runtime's
`profiling_levels.md` ("The two switches" → three, and the arming rule) and
`docs/dfx/hbg-bind-measurement.md`.

## Testing

Onboard a2a3, `tests/st/a2a3/host_build_graph/vector_example`, one run per
configuration through `task-submit`, re-run after the rename against the
rebuilt `.so`:

- breakdown variable alone → 12 `bind phase=` lines + 1 `host-orch phase=` line,
  **no** `host_phase_records.jsonl`
- records variable alone → JSONL with 16 records, **no** breakdown lines
- `--enable-chip-swimlane 4`, both variables unset → JSONL **and**
  `chip_swimlane_records.json`
- neither switch, no diagnostic flag → no output directory at all

- [x] Hardware tests pass — hbg scene tests on a2a3: 8 L3 cases, 36 passed /
  1 skipped (L2 `host_build_graph`), 2 passed (L2 `tensormap_and_ringbuffer`)
- [ ] Simulation tests — left to CI
