### PR TITLE
Fix: record Graph dependencies from the writer, not the allocator

### DIFF
--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/README.md
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/README.md
@@ -20,11 +20,15 @@ through `GraphTaskArgs`, positionally) and the host records it once per identity
 instead of submitting the pass's ~15600 tasks individually. The runtime is
 untouched.
 
-Seven Definitions cover all 43 layers:
+Eight Definitions cover all 43 layers:
 
 - `csa_attn_block` (50 nodes) / `csa_moe_block` (32) and `hca_attn_block` (35) /
   `hca_moe_block` (31) — the decoder loop's two alternating layer shapes, layers
   2..41, plus layer 42 replaying `csa_attn_block` and `hca_moe_block`.
+  `csa_moe_block` records two Definitions: its routing kernel is `route_hash_1`
+  at layer 2 and `route_sort` from layer 4 on, and a body is recorded once per
+  key, so the predicate is a Graph config value rather than a host-side `if` the
+  first recorded layer would settle for every replay.
 - `swa_attn_block` (28) — the two peeled sliding-window attentions of layers 0
   and 1. Their nodes are pairwise alpha-equivalent, so layer 1 replays what layer
   0 recorded.
@@ -71,17 +75,46 @@ size and shape of the real one.
 completion/smoke case: no full-network torch reference exists upstream either,
 and component-level goldens live with the standalone kernels in pypto-lib.
 
-## Status: the host records the Definitions; device replay is blocked in activation
+## Status: the host records the Definitions and the device replays them
 
-With the Graph form the host records the seven Definitions and boots with **129
+With the Graph form the host records the eight Definitions and boots with **129
 submissions from the submitting thread**, two orders of magnitude below
-submitting every task individually — this is measured, on both ranks. The
-device-side replay is **not yet exercised**: an unskipped run fails in Graph
-activation (`sched_error_code=5 INVALID_ARGS` from the scheduler's graph
-queues), so the recorded bodies never replay.
+submitting every task individually — this is measured, on both ranks. The device
+replays all of them and both ranks reach `outcome=0`.
 
-`skip_golden` therefore establishes host-side construction, not numerical
-correctness.
+`skip_golden` still means this establishes completion, not numbers.
+
+Getting the replay running took three fixes. Each is a way a Graph can differ
+from the same body submitted task by task, so they are worth keeping written
+down:
+
+1. **The recorder inferred dependencies from the allocation site, not the last
+   writer.** A recorded node's fanin came only from tensor args classified
+   `INTERNAL` — which names whichever node's packed window holds the bytes, i.e.
+   the allocator — plus explicit `set_dependencies`. Every write-then-read
+   through an `alloc_tensors` buffer or a boundary view was therefore unordered,
+   and a Definition replayed a DAG the body does not have when its tasks are
+   submitted individually. Measured on the pre-split single-Definition form of
+   this body: 1348 edges against the 2143 the ordinary path computes for the same
+   tasks, 543 of 561 comparable nodes short. On device that ran
+   `csa_slots_build_valid_qk_plan` before the `topk` that fills its input, so
+   `qk_pv_1` gathered KV pages at addresses the bus rejected. The recorder now
+   runs the same `compute_task_fanin` / `register_task_outputs` the ring path
+   runs, against a tensor map owned by the recording.
+2. **Two bodies read 64-bit comm handles back as `int32_t`.** `csa_moe_block` and
+   `hca_moe_block` bound `recv_*_ctx`, `*_arrived_ctx` and `routed_y_buf_ctx` as
+   `int32_t` while the entry passes `uint64_t`; the peeled `hash_moe_l*_block`
+   bodies already had it right. The MoE all-to-all pushed to a truncated window
+   address, which surfaces as an AIV MTE bus fault rather than a wrong number.
+3. **A host-side branch inside a body was settled at record time** — the
+   `route_hash_1` / `route_sort` choice described above.
+
+The `sched_error_code=5 INVALID_ARGS` this section used to report came from a
+fourth, separate defect: `bind_graph_topology` bounded the Graph *boundary*
+scalar count by `MAX_SCALAR_ARGS`, the per-AICore-task cap (16), rather than the
+`GRAPH_MAX_SCALAR_ARGS` (64) the recorder's boundary is built with. Cutting the
+pass into blocks brought every boundary under 16 and hid it; it is fixed in the
+runtime, so a wider boundary is legal again.
 
 ### Why `hc_head_linear` carries a row-tail bound
 
@@ -156,6 +189,6 @@ Kernels, fixture and orchestration come from the TMR case; see its
 network shape, regeneration steps and cost. One orchestration file is specific
 to this case: `kernels/orchestration/decode_fwd_graph.cpp`, the TMR
 orchestration carrying the rewrite in the table above and recast as a Graph —
-the forward pass is cut into the seven Definitions listed above, each layer's
+the forward pass is cut into the eight Definitions listed above, each layer's
 task set forming a Graph body whose per-layer views, scales and indices cross
 the boundary positionally.

--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd_graph.cpp
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd_graph.cpp
@@ -1222,7 +1222,7 @@ void csa_attn_block(const GraphTaskArgs &args) {
     }
 }
 
-void csa_moe_block(const GraphTaskArgs &args) {
+void csa_moe_block(const GraphTaskArgs &args, bool route_by_hash) {
     const ChipTensor &hc_ffn_fn_csa_inline547 = args.tensor(0).ref();
     const ChipTensor &hc_ffn_scale_csa_inline543 = args.tensor(1).ref();
     const ChipTensor &hc_ffn_base_csa_inline542 = args.tensor(2).ref();
@@ -1253,18 +1253,23 @@ void csa_moe_block(const GraphTaskArgs &args) {
     const ChipTensor &ext_routed_y_buf = args.tensor(27).ref();
     const ChipTensor &x_attn_csa_inline721 = args.tensor(28).ref();
     const ChipTensor &hidden_mid_inline726 = args.tensor(29).ref();
+    // Each binding keeps the type its submit site passes. The comm-window handles
+    // are 64-bit device contexts; read one back as int32_t and the MoE all-to-all
+    // pushes to a truncated window address — an MTE bus fault on the AIV, not a
+    // wrong number. The peeled hash_moe_l*_block bodies below already bind them
+    // this way.
     int32_t csa_layer_inline714 = static_cast<int32_t>(args.scalar(0));
     int32_t csa_moe_epoch_inline715 = static_cast<int32_t>(args.scalar(1));
-    int32_t arrived_ctx = static_cast<int32_t>(args.scalar(2));
-    int32_t combine_arrived_ctx = static_cast<int32_t>(args.scalar(3));
-    int32_t data_arrived_ctx = static_cast<int32_t>(args.scalar(4));
-    int64_t my_rank = static_cast<int64_t>(args.scalar(5));
-    int64_t nt_inline677__rv_v2 = static_cast<int64_t>(args.scalar(6));
-    int32_t recv_meta_ctx = static_cast<int32_t>(args.scalar(7));
-    int32_t recv_x_ctx = static_cast<int32_t>(args.scalar(8));
-    int32_t recv_aux_ctx = static_cast<int32_t>(args.scalar(9));
-    int32_t recv_route_ctx = static_cast<int32_t>(args.scalar(10));
-    int32_t routed_y_buf_ctx = static_cast<int32_t>(args.scalar(11));
+    uint64_t arrived_ctx = args.scalar(2);
+    uint64_t combine_arrived_ctx = args.scalar(3);
+    uint64_t data_arrived_ctx = args.scalar(4);
+    int32_t my_rank = static_cast<int32_t>(args.scalar(5));
+    int32_t nt_inline677__rv_v2 = static_cast<int32_t>(args.scalar(6));
+    uint64_t recv_meta_ctx = args.scalar(7);
+    uint64_t recv_x_ctx = args.scalar(8);
+    uint64_t recv_aux_ctx = args.scalar(9);
+    uint64_t recv_route_ctx = args.scalar(10);
+    uint64_t routed_y_buf_ctx = args.scalar(11);
     PTO2_SCOPE() {
         uint32_t x_mixed_inline11049_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline11049_ci(x_mixed_inline11049_ci_shapes, 2, DataType::BFLOAT16);
@@ -1528,7 +1533,14 @@ void csa_moe_block(const GraphTaskArgs &args) {
         params_t176.set_allow_early_resolve(true);
         TaskOutputTensors task_176_outs = rt_submit_task(mixed_176, params_t176);
         int64_t active_route_tiles_inline2579_inline11064 = ((active_tokens_inline2578_inline11042__phi_v4 + 7) / 8);
-        if ((static_cast<int64_t>(csa_layer_inline714) < 3)) {
+        // A body is recorded once per Definition key, so a host-side branch on a
+        // per-layer boundary scalar would bake the first recorded layer's arm into
+        // every replay — layer 2 takes route_hash_1, layers 4..40 must take
+        // route_sort. `route_by_hash` carries the predicate as a Graph config
+        // value, which rt_submit_graph folds into the key: two Definitions, each
+        // layer replaying its own. (Eight in total for the pass, which is what the
+        // recorder pool prewarms.)
+        if (route_by_hash) {
             // Spmd route_hash_spmd_1: route_hash_1
             CoreTaskArgs params_t177;
             params_t177.add_input(ext_input_ids);
@@ -2950,17 +2962,22 @@ void hca_moe_block(const GraphTaskArgs &args) {
     const ChipTensor &ext_routed_y_buf = args.tensor(25).ref();
     const ChipTensor &hidden_inline709 = args.tensor(26).ref();
     const ChipTensor &x_attn_hca_inline723 = args.tensor(27).ref();
+    // Each binding keeps the type its submit site passes. The comm-window handles
+    // are 64-bit device contexts; read one back as int32_t and the MoE all-to-all
+    // pushes to a truncated window address — an MTE bus fault on the AIV, not a
+    // wrong number. The peeled hash_moe_l*_block bodies below already bind them
+    // this way.
     int32_t hca_moe_epoch_inline716 = static_cast<int32_t>(args.scalar(0));
-    int32_t arrived_ctx = static_cast<int32_t>(args.scalar(1));
-    int32_t combine_arrived_ctx = static_cast<int32_t>(args.scalar(2));
-    int32_t data_arrived_ctx = static_cast<int32_t>(args.scalar(3));
-    int64_t my_rank = static_cast<int64_t>(args.scalar(4));
-    int64_t nt_inline677__rv_v2 = static_cast<int64_t>(args.scalar(5));
-    int32_t recv_meta_ctx = static_cast<int32_t>(args.scalar(6));
-    int32_t recv_x_ctx = static_cast<int32_t>(args.scalar(7));
-    int32_t recv_aux_ctx = static_cast<int32_t>(args.scalar(8));
-    int32_t recv_route_ctx = static_cast<int32_t>(args.scalar(9));
-    int32_t routed_y_buf_ctx = static_cast<int32_t>(args.scalar(10));
+    uint64_t arrived_ctx = args.scalar(1);
+    uint64_t combine_arrived_ctx = args.scalar(2);
+    uint64_t data_arrived_ctx = args.scalar(3);
+    int32_t my_rank = static_cast<int32_t>(args.scalar(4));
+    int32_t nt_inline677__rv_v2 = static_cast<int32_t>(args.scalar(5));
+    uint64_t recv_meta_ctx = args.scalar(6);
+    uint64_t recv_x_ctx = args.scalar(7);
+    uint64_t recv_aux_ctx = args.scalar(8);
+    uint64_t recv_route_ctx = args.scalar(9);
+    uint64_t routed_y_buf_ctx = args.scalar(10);
     PTO2_SCOPE() {
         uint32_t x_mixed_inline11928_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline11928_ci(x_mixed_inline11928_ci_shapes, 2, DataType::BFLOAT16);
@@ -7963,7 +7980,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         csa_moe_block_args.add_scalar(csa_layer_inline714, csa_moe_epoch_inline715, arrived_ctx, combine_arrived_ctx);
         csa_moe_block_args.add_scalar(data_arrived_ctx, my_rank, nt_inline677__rv_v2, recv_meta_ctx);
         csa_moe_block_args.add_scalar(recv_x_ctx, recv_aux_ctx, recv_route_ctx, routed_y_buf_ctx);
-        rt_submit_graph(&csa_moe_block, csa_moe_block_args);
+        rt_submit_graph(&csa_moe_block, csa_moe_block_args, static_cast<int64_t>(csa_layer_inline714) < 3);
     };
     auto submit_hca_attn_block = [&](int32_t hca_layer_inline704, int64_t loop_i_inline712,
                                      const ChipTensor &x_attn_hca_inline723, const ChipTensor &hidden_mid_inline726) {

--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
@@ -15,7 +15,7 @@ and ships the built SM image to the device, which boots scheduler-only.
 
 ``kernels/orchestration/decode_fwd_graph.cpp`` is that case's orchestration
 with the runtime untouched, recast as a Graph: the whole forward pass is cut
-into seven Graph blocks covering all 43 layers, so the host records seven
+into Graph blocks covering all 43 layers, so the host records eight
 Definitions and submits 129 tasks itself, the rest being built on the recording
 threads. The ten ``recv_count_out`` reads that drove the MoE per-expert tile
 loops (a task-produced tensor, unreadable while the host builds the graph) are
@@ -28,10 +28,9 @@ runtime-specific rewrite. ``skip_golden`` is inherited from the TMR case, which
 is itself a completion/smoke case; ``manual`` because the 368-kernel compile
 takes minutes.
 
-Host construction and Graph recording complete (129 host submissions). An
-unskipped device run is currently blocked in Graph activation, so the recorded
-bodies never replay. See README.md for the measurements and the remaining
-Graph-runtime limitation.
+Host construction, Graph recording (129 host submissions) and device replay all
+complete, both ranks ``outcome=0``. See README.md for the measurements and for
+the fixes that got the replay running.
 
     python examples/a2a3/host_build_graph/deepseek_v4_flash_decode/\\
 test_deepseek_v4_flash_decode.py -p a2a3 -d <d0>,<d1> --manual only

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -381,6 +381,32 @@ struct GraphRecording {
     // Indexed by GraphRecordedNode::predicate_index; only predicated nodes
     // contribute an entry.
     std::vector<GraphRecordedPredicate> predicates;
+    // Hazard state for the recorded body, owned per recording because several
+    // graphs record at once, each on its own thread.
+    //
+    // The ordinary submit path reads a task's producers out of orch->tensor_map
+    // (compute_task_fanin, STEP 3) and publishes the task's writes back into it
+    // (register_task_outputs, STEP 4). The shadow-record path replaces
+    // submit_task_common wholesale, so without a map of its own the recorder
+    // can only see the edges tensor-source classification yields — and that
+    // classification answers "which node's packed window holds these bytes",
+    // i.e. who ALLOCATED the buffer, never who wrote it last. A body that
+    // allocates once with alloc_tensors and then writes in place with add_inout
+    // (the shape every generated orchestration uses) would therefore record a
+    // node with no edge to its actual producer, and the Definition would replay
+    // a DAG the same body never had when submitted task by task.
+    DeviceArena tensor_map_arena;
+    PTO2TensorMapLayout tensor_map_layout{};
+    PTO2TensorMap tensor_map{};
+    bool tensor_map_ready{false};
+    // Scope depth as the body sees it. begin_scope/end_scope leave the real
+    // orchestrator stack untouched while recording (a Graph replays flat), but
+    // the manual-scope flag still has to follow the body: a manual scope
+    // suppresses inference on the ring, so it must suppress it here too.
+    int32_t scope_stack_top{-1};
+    int32_t manual_begin_depth{PTO2_MAX_SCOPE_DEPTH};
+
+    bool in_manual_scope() const { return scope_stack_top >= manual_begin_depth; }
 };
 
 struct GraphPendingUpload {
@@ -519,6 +545,32 @@ graph_classify_scalar(const GraphRecording &recording, const ArgT &args, int32_t
         }
     }
     return {};
+}
+
+// Entry capacity for one recorded body's hazard map. A Definition is capped at
+// GRAPH_MAX_NODES nodes and each node registers at most its INOUT/OUTPUT_EXISTING
+// args, so this bounds the worst realistic body while staying a small fraction of
+// the ring path's whole-orchestration pool (PTO2_TENSORMAP_POOL_SIZE). Exhausting
+// it marks the recording unsupported, which graph_commit reports as
+// PTO2_ERROR_INVALID_ARGS -- the outer shell is already submitted by then, so there
+// is no ordinary-path fallback left to take.
+constexpr int32_t GRAPH_RECORD_TENSORMAP_POOL_SIZE = 16384;
+
+// Stand the recording's hazard map up on its own host allocation. Failure is
+// reported to the caller, which is still before the outer shell is submitted and
+// so can still take the ordinary path, rather than producing a Definition with
+// inferred edges missing.
+bool graph_recording_init_tensor_map(GraphRecording &recording) {
+    recording.tensor_map_layout = PTO2TensorMap::reserve_layout(
+        recording.tensor_map_arena, PTO2_TENSORMAP_NUM_BUCKETS, GRAPH_RECORD_TENSORMAP_POOL_SIZE, GRAPH_MAX_NODES
+    );
+    if (recording.tensor_map_arena.commit() == nullptr) return false;
+    if (!recording.tensor_map.init_data_from_layout(recording.tensor_map_layout, recording.tensor_map_arena)) {
+        return false;
+    }
+    recording.tensor_map.wire_arena_pointers(recording.tensor_map_layout, recording.tensor_map_arena);
+    recording.tensor_map_ready = true;
+    return true;
 }
 
 bool graph_classify_tensor(
@@ -1093,10 +1145,27 @@ void PTO2OrchestratorState::begin_scope(PTO2ScopeMode mode) {
     }
     // A Graph replays as a flat DAG with no scope structure: scope boundaries only
     // shape scheduling on the ring, and the shadow-record path submits no ring
-    // tasks. Recorded ordering is preserved by the nodes' explicit dependencies
-    // and tensor-source classification, so a scope inside a Graph body is a no-op
-    // during recording and must not touch the real scope stack.
-    if (active_graph_recording(orch) != nullptr) {
+    // tasks. So a scope inside a Graph body must not touch the real scope stack.
+    // Its manual/auto mode still matters, though — the recorder infers a node's
+    // producers with the same compute_task_fanin the ring path uses, and that
+    // inference is suppressed inside a manual scope — so the depth is tracked on
+    // the recording instead.
+    if (GraphRecording *recording = active_graph_recording(orch); recording != nullptr) {
+        // Reject what the ring rejects. An auto scope inside a manual one is a
+        // fatal below; accepting it here would let a Graph record and replay a
+        // body that ordinary submission refuses. The push still happens so
+        // end_scope stays balanced -- the recording is doomed either way, since
+        // graph_commit turns an unsupported recording into PTO2_ERROR_INVALID_ARGS.
+        if (recording->scope_stack_top >= PTO2_MAX_SCOPE_DEPTH - 1 ||
+            (mode == PTO2ScopeMode::AUTO && recording->in_manual_scope())) {
+            recording->unsupported = true;
+        }
+        if (recording->scope_stack_top < PTO2_MAX_SCOPE_DEPTH - 1) {
+            ++recording->scope_stack_top;
+            if (mode == PTO2ScopeMode::MANUAL && !recording->in_manual_scope()) {
+                recording->manual_begin_depth = recording->scope_stack_top;
+            }
+        }
         return;
     }
     assert(orch->scope_stack_top < static_cast<int32_t>(orch->scope_stack_capacity - 1) && "Scope stack overflow");
@@ -1135,9 +1204,15 @@ void PTO2OrchestratorState::end_scope() {
     if (orch->fatal) {
         return;
     }
-    // Matches begin_scope: a scope inside a Graph body is a no-op during the
-    // shadow-record pass, so it must not touch the scope stack.
-    if (active_graph_recording(orch) != nullptr) {
+    // Matches begin_scope: a scope inside a Graph body never touches the real
+    // scope stack, only the recording's own manual-scope depth.
+    if (GraphRecording *recording = active_graph_recording(orch); recording != nullptr) {
+        if (recording->scope_stack_top >= 0) {
+            if (recording->manual_begin_depth == recording->scope_stack_top) {
+                recording->manual_begin_depth = PTO2_MAX_SCOPE_DEPTH;
+            }
+            --recording->scope_stack_top;
+        }
         return;
     }
     assert(orch->scope_stack_top >= 0 && "Scope stack underflow");
@@ -1890,6 +1965,50 @@ TaskOutputTensors graph_record_submit_node(
         const GraphRecordedTensorSourceRef &source = recording.tensor_sources[node.tensor_source_offset + i];
         if (source.source == GraphRecordedTensorSource::INTERNAL) add_fanin(source.source_index);
     }
+
+    // Inferred hazards, on the same terms as the ring path. The loop above only
+    // names the node that ALLOCATED each buffer; every write-then-read through a
+    // buffer someone else allocated — an alloc_tensors output written in place
+    // with add_inout, or a view of a boundary tensor — needs the last-writer
+    // lookup compute_task_fanin performs. Running the very same function against
+    // the recording's own map is what keeps a Definition's edge set equal to the
+    // one the body gets when its tasks are submitted individually.
+    //
+    // Producers outside the recording window are dropped: they are reached
+    // through boundary tensors, and the outer Graph shell already carries those
+    // args, so the shell's own fanin orders the whole body behind them.
+    {
+        const DepInputs dep_inputs{
+            tensor_count,
+            args.tensor_data(),
+            args.tag_data(),
+            static_cast<int32_t>(args.explicit_dep_count()),
+            args.explicit_deps_data(),
+        };
+        const bool manual_scope = recording.in_manual_scope();
+        if (!recording.tensor_map_ready) {
+            recording.unsupported = true;
+        } else if (recording.tensor_map.free_entries() < count_registrable_outputs(dep_inputs, manual_scope)) {
+            // Recording one more node would assert inside new_entry(). Abandon the
+            // Definition instead, so the run fails by name at graph_commit rather
+            // than on a hard assert here.
+            LOG_WARN(
+                "[GraphExecution] recording hazard map exhausted at node %zu (%d entries); Graph abandoned", node_index,
+                GRAPH_RECORD_TENSORMAP_POOL_SIZE
+            );
+            recording.unsupported = true;
+        } else {
+            auto emit_inferred = [&recording, &add_fanin, node_index](PTO2TaskId producer) -> bool {
+                const int32_t producer_index = static_cast<int32_t>(producer.local()) - recording.start_local_task_id;
+                if (producer.ring() == 0 && producer_index >= 0 && producer_index < static_cast<int32_t>(node_index)) {
+                    add_fanin(static_cast<size_t>(producer_index));
+                }
+                return true;
+            };
+            (void)compute_task_fanin(dep_inputs, recording.tensor_map, manual_scope, emit_inferred);
+            register_task_outputs(dep_inputs, task_id, recording.tensor_map, manual_scope);
+        }
+    }
     for (uint32_t i = 0; i < args.explicit_dep_count(); ++i) {
         const PTO2TaskId dep = args.explicit_dep(i);
         const int32_t dep_index = static_cast<int32_t>(dep.local()) - recording.start_local_task_id;
@@ -2008,6 +2127,10 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
     auto recording = std::make_unique<GraphRecording>();
     recording->full_key = full_key;
     recording->start_local_task_id = orch->ring.task_allocator.active_count();
+    if (!graph_recording_init_tensor_map(*recording)) {
+        LOG_WARN("[GraphExecution] recording hazard map allocation failed; using ordinary path");
+        return result;
+    }
     recording->boundary_scalar_count = args.scalar_count();
     recording->boundary_tensors.reserve(static_cast<size_t>(args.tensor_count()));
     recording->boundary_types.reserve(static_cast<size_t>(args.tensor_count()));

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -381,6 +381,32 @@ struct GraphRecording {
     // Indexed by GraphRecordedNode::predicate_index; only predicated nodes
     // contribute an entry.
     std::vector<GraphRecordedPredicate> predicates;
+    // Hazard state for the recorded body, owned per recording because several
+    // graphs record at once, each on its own thread.
+    //
+    // The ordinary submit path reads a task's producers out of orch->tensor_map
+    // (compute_task_fanin, STEP 3) and publishes the task's writes back into it
+    // (register_task_outputs, STEP 4). The shadow-record path replaces
+    // submit_task_common wholesale, so without a map of its own the recorder
+    // can only see the edges tensor-source classification yields — and that
+    // classification answers "which node's packed window holds these bytes",
+    // i.e. who ALLOCATED the buffer, never who wrote it last. A body that
+    // allocates once with alloc_tensors and then writes in place with add_inout
+    // (the shape every generated orchestration uses) would therefore record a
+    // node with no edge to its actual producer, and the Definition would replay
+    // a DAG the same body never had when submitted task by task.
+    DeviceArena tensor_map_arena;
+    PTO2TensorMapLayout tensor_map_layout{};
+    PTO2TensorMap tensor_map{};
+    bool tensor_map_ready{false};
+    // Scope depth as the body sees it. begin_scope/end_scope leave the real
+    // orchestrator stack untouched while recording (a Graph replays flat), but
+    // the manual-scope flag still has to follow the body: a manual scope
+    // suppresses inference on the ring, so it must suppress it here too.
+    int32_t scope_stack_top{-1};
+    int32_t manual_begin_depth{PTO2_MAX_SCOPE_DEPTH};
+
+    bool in_manual_scope() const { return scope_stack_top >= manual_begin_depth; }
 };
 
 struct GraphPendingUpload {
@@ -519,6 +545,32 @@ graph_classify_scalar(const GraphRecording &recording, const ArgT &args, int32_t
         }
     }
     return {};
+}
+
+// Entry capacity for one recorded body's hazard map. A Definition is capped at
+// GRAPH_MAX_NODES nodes and each node registers at most its INOUT/OUTPUT_EXISTING
+// args, so this bounds the worst realistic body while staying a small fraction of
+// the ring path's whole-orchestration pool (PTO2_TENSORMAP_POOL_SIZE). Exhausting
+// it marks the recording unsupported, which graph_commit reports as
+// PTO2_ERROR_INVALID_ARGS -- the outer shell is already submitted by then, so there
+// is no ordinary-path fallback left to take.
+constexpr int32_t GRAPH_RECORD_TENSORMAP_POOL_SIZE = 16384;
+
+// Stand the recording's hazard map up on its own host allocation. Failure is
+// reported to the caller, which is still before the outer shell is submitted and
+// so can still take the ordinary path, rather than producing a Definition with
+// inferred edges missing.
+bool graph_recording_init_tensor_map(GraphRecording &recording) {
+    recording.tensor_map_layout = PTO2TensorMap::reserve_layout(
+        recording.tensor_map_arena, PTO2_TENSORMAP_NUM_BUCKETS, GRAPH_RECORD_TENSORMAP_POOL_SIZE, GRAPH_MAX_NODES
+    );
+    if (recording.tensor_map_arena.commit() == nullptr) return false;
+    if (!recording.tensor_map.init_data_from_layout(recording.tensor_map_layout, recording.tensor_map_arena)) {
+        return false;
+    }
+    recording.tensor_map.wire_arena_pointers(recording.tensor_map_layout, recording.tensor_map_arena);
+    recording.tensor_map_ready = true;
+    return true;
 }
 
 bool graph_classify_tensor(
@@ -1093,10 +1145,27 @@ void PTO2OrchestratorState::begin_scope(PTO2ScopeMode mode) {
     }
     // A Graph replays as a flat DAG with no scope structure: scope boundaries only
     // shape scheduling on the ring, and the shadow-record path submits no ring
-    // tasks. Recorded ordering is preserved by the nodes' explicit dependencies
-    // and tensor-source classification, so a scope inside a Graph body is a no-op
-    // during recording and must not touch the real scope stack.
-    if (active_graph_recording(orch) != nullptr) {
+    // tasks. So a scope inside a Graph body must not touch the real scope stack.
+    // Its manual/auto mode still matters, though — the recorder infers a node's
+    // producers with the same compute_task_fanin the ring path uses, and that
+    // inference is suppressed inside a manual scope — so the depth is tracked on
+    // the recording instead.
+    if (GraphRecording *recording = active_graph_recording(orch); recording != nullptr) {
+        // Reject what the ring rejects. An auto scope inside a manual one is a
+        // fatal below; accepting it here would let a Graph record and replay a
+        // body that ordinary submission refuses. The push still happens so
+        // end_scope stays balanced -- the recording is doomed either way, since
+        // graph_commit turns an unsupported recording into PTO2_ERROR_INVALID_ARGS.
+        if (recording->scope_stack_top >= PTO2_MAX_SCOPE_DEPTH - 1 ||
+            (mode == PTO2ScopeMode::AUTO && recording->in_manual_scope())) {
+            recording->unsupported = true;
+        }
+        if (recording->scope_stack_top < PTO2_MAX_SCOPE_DEPTH - 1) {
+            ++recording->scope_stack_top;
+            if (mode == PTO2ScopeMode::MANUAL && !recording->in_manual_scope()) {
+                recording->manual_begin_depth = recording->scope_stack_top;
+            }
+        }
         return;
     }
     assert(orch->scope_stack_top < static_cast<int32_t>(orch->scope_stack_capacity - 1) && "Scope stack overflow");
@@ -1135,9 +1204,15 @@ void PTO2OrchestratorState::end_scope() {
     if (orch->fatal) {
         return;
     }
-    // Matches begin_scope: a scope inside a Graph body is a no-op during the
-    // shadow-record pass, so it must not touch the scope stack.
-    if (active_graph_recording(orch) != nullptr) {
+    // Matches begin_scope: a scope inside a Graph body never touches the real
+    // scope stack, only the recording's own manual-scope depth.
+    if (GraphRecording *recording = active_graph_recording(orch); recording != nullptr) {
+        if (recording->scope_stack_top >= 0) {
+            if (recording->manual_begin_depth == recording->scope_stack_top) {
+                recording->manual_begin_depth = PTO2_MAX_SCOPE_DEPTH;
+            }
+            --recording->scope_stack_top;
+        }
         return;
     }
     assert(orch->scope_stack_top >= 0 && "Scope stack underflow");
@@ -1890,6 +1965,50 @@ TaskOutputTensors graph_record_submit_node(
         const GraphRecordedTensorSourceRef &source = recording.tensor_sources[node.tensor_source_offset + i];
         if (source.source == GraphRecordedTensorSource::INTERNAL) add_fanin(source.source_index);
     }
+
+    // Inferred hazards, on the same terms as the ring path. The loop above only
+    // names the node that ALLOCATED each buffer; every write-then-read through a
+    // buffer someone else allocated — an alloc_tensors output written in place
+    // with add_inout, or a view of a boundary tensor — needs the last-writer
+    // lookup compute_task_fanin performs. Running the very same function against
+    // the recording's own map is what keeps a Definition's edge set equal to the
+    // one the body gets when its tasks are submitted individually.
+    //
+    // Producers outside the recording window are dropped: they are reached
+    // through boundary tensors, and the outer Graph shell already carries those
+    // args, so the shell's own fanin orders the whole body behind them.
+    {
+        const DepInputs dep_inputs{
+            tensor_count,
+            args.tensor_data(),
+            args.tag_data(),
+            static_cast<int32_t>(args.explicit_dep_count()),
+            args.explicit_deps_data(),
+        };
+        const bool manual_scope = recording.in_manual_scope();
+        if (!recording.tensor_map_ready) {
+            recording.unsupported = true;
+        } else if (recording.tensor_map.free_entries() < count_registrable_outputs(dep_inputs, manual_scope)) {
+            // Recording one more node would assert inside new_entry(). Abandon the
+            // Definition instead, so the run fails by name at graph_commit rather
+            // than on a hard assert here.
+            LOG_WARN(
+                "[GraphExecution] recording hazard map exhausted at node %zu (%d entries); Graph abandoned", node_index,
+                GRAPH_RECORD_TENSORMAP_POOL_SIZE
+            );
+            recording.unsupported = true;
+        } else {
+            auto emit_inferred = [&recording, &add_fanin, node_index](PTO2TaskId producer) -> bool {
+                const int32_t producer_index = static_cast<int32_t>(producer.local()) - recording.start_local_task_id;
+                if (producer.ring() == 0 && producer_index >= 0 && producer_index < static_cast<int32_t>(node_index)) {
+                    add_fanin(static_cast<size_t>(producer_index));
+                }
+                return true;
+            };
+            (void)compute_task_fanin(dep_inputs, recording.tensor_map, manual_scope, emit_inferred);
+            register_task_outputs(dep_inputs, task_id, recording.tensor_map, manual_scope);
+        }
+    }
     for (uint32_t i = 0; i < args.explicit_dep_count(); ++i) {
         const PTO2TaskId dep = args.explicit_dep(i);
         const int32_t dep_index = static_cast<int32_t>(dep.local()) - recording.start_local_task_id;
@@ -2008,6 +2127,10 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
     auto recording = std::make_unique<GraphRecording>();
     recording->full_key = full_key;
     recording->start_local_task_id = orch->ring.task_allocator.active_count();
+    if (!graph_recording_init_tensor_map(*recording)) {
+        LOG_WARN("[GraphExecution] recording hazard map allocation failed; using ordinary path");
+        return result;
+    }
     recording->boundary_scalar_count = args.scalar_count();
     recording->boundary_tensors.reserve(static_cast<size_t>(args.tensor_count()));
     recording->boundary_types.reserve(static_cast<size_t>(args.tensor_count()));

--- a/src/common/host_build_graph/graph_execution.cpp
+++ b/src/common/host_build_graph/graph_execution.cpp
@@ -55,7 +55,14 @@ void reset_graph_payload(PTO2TaskPayload &payload) {
 bool bind_graph_topology(GraphExecution &execution) {
     if (execution.definition == nullptr) return false;
     const GraphDefinition &definition = *execution.definition;
-    if (definition.boundary_scalar_count > MAX_SCALAR_ARGS) return false;
+    // GRAPH_MAX_SCALAR_ARGS, not MAX_SCALAR_ARGS: this counts the scalars the
+    // Graph BOUNDARY carries, which the recorder sizes with
+    // GraphTaskArgs = Arg<GRAPH_MAX_TENSOR_ARGS, GRAPH_MAX_SCALAR_ARGS> and the
+    // image hands over as a pointer into the submission, never through a node
+    // payload. MAX_SCALAR_ARGS is the per-AICore-task cap (16) and applies to
+    // GraphNodeDefinition::scalar_count below, which is checked separately; using
+    // it here rejected every boundary wider than one kernel call could take.
+    if (definition.boundary_scalar_count > GRAPH_MAX_SCALAR_ARGS) return false;
     const uint32_t *fanin_offsets =
         graph_definition_array<uint32_t>(definition, definition.off_fanin_offsets, definition.task_count + 1);
     const uint16_t *fanin_indices =

--- a/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
@@ -289,6 +289,41 @@ TEST_F(HbgGraphSubmitFailureTest, AbortedRecordingLatchesFatalAtCommit) {
     EXPECT_TRUE(orch.fatal) << "A shell whose Definition never arrived cannot be completed";
 }
 
+// The ordinary path reports PTO2_ERROR_INVALID_ARGS for an auto scope opened
+// inside a manual one. The recording pass keeps a scope depth of its own — the
+// manual flag has to reach compute_task_fanin, which suppresses inference inside
+// a manual scope — so it has to refuse the same nesting. Accepting it would let a
+// Graph record and replay a body ordinary submission rejects outright.
+TEST_F(HbgGraphSubmitFailureTest, AutoScopeNestedInManualScopeRefusesTheRecording) {
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    ChipTensor boundary = make_tensor_external(storage.data(), shape, 1);
+    GraphTaskArgs boundary_args;
+    boundary_args.add_input(boundary);
+
+    orch.begin_scope();
+    const GraphScopeResult graph = orch.graph_begin(0x171d, boundary_args, 0x1736);
+    ASSERT_TRUE(graph.recording);
+    ASSERT_TRUE(orch.graph_prepare(graph.recording_handle, boundary_args));
+
+    orch.begin_scope(PTO2ScopeMode::MANUAL);
+    orch.begin_scope(PTO2ScopeMode::AUTO);
+
+    CoreTaskArgs node_args;
+    node_args.add_input(boundary);
+    TensorCreateInfo recorded_output(shape, 1, DataType::UINT32);
+    node_args.add_output(recorded_output);
+    ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
+
+    orch.end_scope();
+    orch.end_scope();
+
+    EXPECT_THROW(orch.graph_end(), AssertionError) << "an auto scope inside a manual one must not publish";
+    orch.graph_abort(graph.recording_handle);
+    orch.graph_commit();
+    EXPECT_TRUE(orch.fatal) << "a shell whose Definition never arrived cannot be completed";
+}
+
 // A Graph body may allocate. The allocation records as a kernel-less node, the
 // same shape submit_dummy_task records, so the recording stays publishable and
 // the commit latches no fatal.


### PR DESCRIPTION
> Rebased onto `main` after #1936 (`record DSv4's 43 layers as seven Graph
> Definitions`). That rewrite changed which of the original defects are still
> reachable — the findings below are re-derived against the seven-block layout,
> and the case diff is much smaller than it was.

The DeepSeek-V4 FLASH 43-layer decode scene test passes under
`tensormap_and_ringbuffer`. On current `main` an unskipped `host_build_graph`
run fails on device with `sched_error_code=100 SCHEDULER_TIMEOUT`, behind an AIV
MTE bus fault. (The case README still says `sched_error_code=5 INVALID_ARGS`;
that was the pre-split symptom — see the last section.)

## Recorder: a node's fanin named the allocator, not the writer

`graph_record_submit_node` built fanin from two sources only: tensor args
classified `INTERNAL`, and explicit `set_dependencies`. `INTERNAL` answers *which
node's packed window holds these bytes* — i.e. who **allocated** the buffer — and
the recorder consulted no tensor map, so the whole of Step B of
`compute_task_fanin` was absent inside a Graph body. A buffer allocated once with
`alloc_tensors` and then written in place with `add_inout` produced, for both
writer and reader, a single edge to the *alloc* node; a write to a boundary-rooted
view produced no edge at all.

Only bodies that hand-declare nearly every edge escaped it, which is why the
qwen3 HBG graph case never showed it — 42 `set_dependencies` over 49 submits, and
no `alloc_tensors`.

Measured on the single-Definition form of this body (before #1936), against the
same tasks submitted individually:

| | edges | nodes short |
| --- | --- | --- |
| ordinary submit path | 2143 | — |
| Definition, before | 1348 | 543 of 561 |
| Definition, after | 2157 | 0 |

(The 14 extra afterwards are the allocation-site edges the `INTERNAL`
classification still contributes; each points at an alloc node that has already
retired.)

What it cost on device: the replay ran `csa_slots_build_valid_qk_plan` before the
`topk` that fills its input, built the sparse-attention plan out of heap nobody
had written, and `qk_pv_1` then gathered KV pages at `base + garbage_index *
stride`. The AIV reported `fftsplus aivector error … the response value returned
by the bus is a non-zero value` and never completed, so the run ended in
`SCHEDULER_TIMEOUT` with all 24 clusters parked on that task.

The recorder now runs the same `compute_task_fanin` / `register_task_outputs` the
ring path runs, against a `PTO2TensorMap` owned by the recording (one per
recording, since several record concurrently). Reusing those two functions rather
than reimplementing the hazard walk is what makes the edge sets equal by
construction. `begin_scope` / `end_scope` keep the body's own manual-scope depth
so a manual scope suppresses inference here exactly as it does on the ring — they
still never touch the real scope stack. Because that depth is now load-bearing,
the recording also refuses an auto scope opened inside a manual one, which the
ordinary path reports as `PTO2_ERROR_INVALID_ARGS`; otherwise a Graph could
record and replay a body ordinary submission rejects outright. Covered by
`HbgGraphSubmitFailureTest.AutoScopeNestedInManualScopeRefusesTheRecording`,
which fails with the guard removed. Pool exhaustion or a failed allocation
marks the recording unsupported, so the body falls back to the ordinary submit
path rather than publishing a Definition with edges missing.

## Case: two defects, both in the loop's MoE bodies

- **64-bit comm handles read back as `int32_t`.** `csa_moe_block` and
  `hca_moe_block` bound `recv_*_ctx`, `*_arrived_ctx` and `routed_y_buf_ctx` as
  `int32_t` while the entry passes `uint64_t`, so the MoE all-to-all pushed to a
  truncated window address — an AIV MTE bus fault, not a wrong number. The peeled
  `hash_moe_l0_block` / `hash_moe_l1_block` bodies #1936 added already bind them
  as `uint64_t`; the two loop bodies now match.
- **A host-side branch settled at record time.** `csa_moe_block` picked its
  routing kernel with `if (csa_layer < 3)` on a per-layer boundary scalar. A body
  is recorded once per Definition key, so every replay would have taken layer 2's
  `route_hash_1` where layers 4..40 need `route_sort`. The predicate travels as a
  Graph config value now, which `rt_submit_graph` folds into the key. That makes
  the pass **eight** Definitions rather than seven — still within the eight the
  recorder pool prewarms after #1936, and the README/docstring counts are updated.

The `add_input`-on-a-written-boundary-tensor defect the first revision of this PR
fixed is gone on its own: #1936's blocks tag every written boundary tensor
`add_inout` already. Re-checked mechanically — 8 submit sites, 0 mis-tagged.

## Runtime, separately: the boundary was capped by the per-task scalar limit

`bind_graph_topology` rejected a Definition whose `boundary_scalar_count` exceeded
`MAX_SCALAR_ARGS` — which is `CORE_MAX_SCALAR_ARGS` (16), the number of scalars
**one AICore task** may take. A Graph boundary is not a node payload: the recorder
builds it with `Arg<GRAPH_MAX_TENSOR_ARGS, GRAPH_MAX_SCALAR_ARGS>` (128/64) and
the image hands it to the device as a pointer into the submission. Nothing on the
host capped it either — `rt_graph_args_cacheable` checks tensors only.

The single-Definition body passed 19 scalars and was refused on the device's
first prepare pass; that is the `INVALID_ARGS` the README still reports. #1936
cut the pass into blocks whose boundaries are all ≤ 12 scalars, which hides the
bug rather than fixing it. Bounded by `GRAPH_MAX_SCALAR_ARGS` here, so a wider
boundary is legal again. The per-node cap is checked separately and unchanged.

## Verification

Two a2a3 dies, via `task-submit`:

- `TestDeepseekV4FlashDecode::DecodeFwdEP2TP2` (tensormap_and_ringbuffer) — PASS
- `TestDeepseekV4FlashDecodeHostBuildGraph::DecodeFwdEP2TP2` (host_build_graph) — PASS
- unmodified `main` at `27bc3eea`, same box, same command — `SCHEDULER_TIMEOUT`
- `pytest tests/st/a2a3/host_build_graph examples/a2a3/host_build_graph --platform a2a3 --exclude-level 4` — 36 passed, 1 skipped, including `graph_execution`, `graph_predicated_dispatch`, `concurrent_prepare_stress` and `paged_attention_unroll_manual_scope`
- `ctest --test-dir tests/ut/cpp/build` — 108/108

Isolating the layer: the same orchestration in submit-every-task form (the TMR
source run with `runtime="host_build_graph"`) passes on device. The HBG runtime
and the 368 kernels were never the problem — the Graph recast was.

`--manual only` additionally surfaces a pre-existing failure in
`tests/st/a2a3/host_build_graph/paged_attention` (`Task Window Exhausted,
used=16384/16384`); it reproduces identically on unmodified `main` and is what
that case's own comment documents ("exceeds the default ring window … run it
explicitly with a large `PTO2_RING_TASK_WINDOW`").

a5 shares `pto_orchestrator.cpp` byte-for-byte and is updated identically, but
there is no a5 silicon on the box this was developed on — CI covers it.
