### PR TITLE
Fix: give each host phase-record producer its own lane

### DIFF
--- a/docs/dfx/hbg-bind-measurement.md
+++ b/docs/dfx/hbg-bind-measurement.md
@@ -168,7 +168,7 @@ in one pass what a duration comparison cannot answer in ten.
 
 The summed `bind phase=` lines cannot be placed on a timeline inside
 `host_orch`: they are cost shares. The per-event view comes from the runtime's
-rotating record pool, written to `outputs/<case>_<ts>/host_phase_records.jsonl` —
+per-producer record pool, written to `outputs/<case>_<ts>/host_phase_records.jsonl` —
 one record per orchestrator operation, each with its own interval.
 
 Three conditions must all hold, and each one silently produces an empty result:

--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -168,17 +168,26 @@ constexpr int PLATFORM_PROF_ORCH_BUFFERS_PER_THREAD = 8;
  * Host phase-record pool geometry (host_build_graph's bind path and host
  * orchestrator).
  *
- * Same rotating-pool shape as the sched/orch pools above, sized for its own
- * producer rather than theirs: a scheduler thread emits tens of thousands of
- * records per run, while one host orchestration pass emits a few hundred (a
- * 40-layer decode: 12 bind segments + ~325 submit-level operations). Inheriting
- * PLATFORM_PHASE_RECORDS_PER_THREAD here would allocate 4 MB to hold 11 KB and
- * leave the rotation path unreachable, so per-buffer capacity is 1024 records
- * (32 KB) and the pool holds 5 of them — the floor that lets
- * PLATFORM_PROF_SLOT_COUNT spares fill the free_queue with one buffer active.
+ * Sized for its own producers rather than the sched/orch pools': a scheduler
+ * thread emits tens of thousands of records per run, while one host orchestration
+ * pass emits a few hundred per producer (a 40-layer decode: 12 bind segments +
+ * ~325 submit-level operations). Inheriting PLATFORM_PHASE_RECORDS_PER_THREAD
+ * here would allocate 4 MB to hold 11 KB.
+ *
+ * A pass has one producer per thread that records: the submitting thread plus one
+ * per concurrently-recorded Graph Definition. Each claims whole buffers and fills
+ * them alone, so `PLATFORM_HOST_PHASE_BUFFERS` must exceed the producer count or
+ * a producer is denied a buffer and its records are dropped. The recorder pool
+ * caps itself at GRAPH_MAX_DEFINITIONS (16) threads, so 17 producers is the
+ * ceiling; the buffer count is above that so a producer whose first buffer fills
+ * can chain another.
+ *
+ * Per-buffer capacity is what a producer holds before chaining, not what a pass
+ * needs: the widest observed single producer is a 1-Definition workload's lone
+ * recorder at ~1900 records, which chains four 512-record buffers.
  */
-constexpr int PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER = 1024;
-constexpr int PLATFORM_HOST_PHASE_BUFFERS = PLATFORM_PROF_SLOT_COUNT + 1;
+constexpr int PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER = 512;
+constexpr int PLATFORM_HOST_PHASE_BUFFERS = 24;
 
 /**
  * Ready queue capacity for performance data collection.

--- a/src/a2a3/runtime/host_build_graph/host/host_phase_trace.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/host_phase_trace.cpp
@@ -44,29 +44,56 @@ namespace {
 // measured path.
 constexpr size_t kBindAttrsCapacity = 96;
 
-// record_node and graph_submit are updated concurrently by different cores.
-// Keep phase counters on distinct cache lines so lock-free accounting does not
-// turn that intended overlap into cache-line ownership ping-pong.
-struct alignas(64) KindCounter {
-    std::atomic<uint64_t> total_ns{0};
-    std::atomic<uint64_t> count{0};
-    std::atomic<uint64_t> payload_sum{0};
-    std::atomic<uint64_t> first_start_ns{0};
+// One producer's counters and in-flight claim, on its own cache lines.
+//
+// The producers of a pass are independent -- each records its own Definition and
+// counts only its own operations -- so nothing here is shared, and the per-record
+// path performs no atomic read-modify-write at all. Sharing them cost the emitting
+// thread about 0.8 us per record at eight producers, purely in cache-line
+// ownership: every producer of a Graph workload records the same kind
+// (`record_node`), so a per-kind counter is a single line eight threads fight
+// over, and the `alignas(64)` that separates one kind from another does nothing
+// about that.
+//
+// Plain integers, not atomics, and that is only sound because a lane has exactly
+// one writer for the whole pass -- never a shared fallback -- and the reader sums
+// the lanes after the pass is closed and its producers drained. A producer that
+// cannot get a lane of its own does not record.
+struct KindCounter {
+    uint64_t total_ns{0};
+    uint64_t count{0};
+    uint64_t payload_sum{0};
+    uint64_t first_start_ns{0};
 };
-static_assert(sizeof(KindCounter) == 64);
+
+struct alignas(64) ProducerLane {
+    // Records accepted by `active` but not yet finished with the counters and the
+    // pool. begin/end clear `active` and then drain the sum of these to zero, so a
+    // record can never be reported by a pass it does not belong to.
+    std::atomic<int32_t> in_flight{0};
+    std::array<KindCounter, kHostPhaseKindCount> counters{};
+};
+
+// One lane per thread that can record: the submitting thread plus one per
+// concurrently-recorded Definition, so the ceiling is GRAPH_MAX_DEFINITIONS + 1 =
+// 17. Matches the pool's buffer count, which is sized the same way, so a producer
+// that got a buffer also has a lane and neither denial is reachable in a sized
+// run.
+constexpr size_t kProducerLanes = PLATFORM_HOST_PHASE_BUFFERS;
 
 struct TraceState {
     std::atomic<HostPhaseRecordPool *> pool{nullptr};
     const HostApi *api;
     std::atomic<bool> active{false};
-    // Records accepted by `active` but not yet finished with the counters and the
-    // pool. begin/end clear `active` and then drain this to zero, so a record can
-    // never be reported by a pass it does not belong to.
-    std::atomic<int32_t> in_flight{0};
+    std::atomic<uint32_t> generation{0};
+    std::atomic<uint32_t> next_lane{0};
+    // Records dropped because every lane was taken. Unreachable while the lane
+    // count covers the producer ceiling; counted rather than assumed so a workload
+    // that outgrows it says so instead of silently under-reporting.
+    std::atomic<uint64_t> lane_denied{0};
     std::mutex lifecycle_mutex;
-    std::mutex pool_mutex;
     std::atomic<uint64_t> submitted_tasks{0};
-    std::array<KindCounter, kHostPhaseKindCount> counters;
+    std::array<ProducerLane, kProducerLanes> lanes;
     std::array<std::array<char, kBindAttrsCapacity>, kHostPhaseKindCount> bind_attrs;
 };
 
@@ -75,20 +102,40 @@ TraceState &state() {
     return s;
 }
 
+// This thread's lane for the current pass, or nullptr when every lane is taken.
+//
+// `generation` is what makes a cached lane safe to reuse: it is process-unique per
+// pass, so a lane claimed under one pass is never mistaken for a claim under
+// another. Returns the generation it claimed under, because the caller must
+// re-check it once admitted -- see host_phase_record.
+ProducerLane *producer_lane(TraceState &s, uint32_t &claimed_generation) {
+    static thread_local ProducerLane *lane = nullptr;
+    static thread_local uint32_t lane_generation = 0;
+    const uint32_t generation = s.generation.load(std::memory_order_acquire);
+    if (lane == nullptr || lane_generation != generation) {
+        const uint32_t index = s.next_lane.fetch_add(1, std::memory_order_relaxed);
+        lane = index < kProducerLanes ? &s.lanes[index] : nullptr;
+        lane_generation = generation;
+    }
+    claimed_generation = generation;
+    return lane;
+}
+
 // Publish-then-check against the trace lifecycle's clear-then-drain. Claiming a
 // slot before reading `active` is what makes the pair race-free: a record that
 // got in before the pass closed is waited for, and one that arrives after sees
-// `active` false and withdraws.
+// `active` false and withdraws. The claim is on this producer's own line, so it
+// costs nothing to the others.
 class RecordAdmission {
 public:
-    explicit RecordAdmission(TraceState &s) :
-        s_(s) {
-        s_.in_flight.fetch_add(1, std::memory_order_acq_rel);
-        admitted_ = s_.active.load(std::memory_order_acquire);
-        if (!admitted_) s_.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+    RecordAdmission(TraceState &s, ProducerLane &lane) :
+        lane_(lane) {
+        lane_.in_flight.fetch_add(1, std::memory_order_acq_rel);
+        admitted_ = s.active.load(std::memory_order_acquire);
+        if (!admitted_) lane_.in_flight.fetch_sub(1, std::memory_order_acq_rel);
     }
     ~RecordAdmission() {
-        if (admitted_) s_.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+        if (admitted_) lane_.in_flight.fetch_sub(1, std::memory_order_acq_rel);
     }
 
     RecordAdmission(const RecordAdmission &) = delete;
@@ -97,7 +144,7 @@ public:
     explicit operator bool() const { return admitted_; }
 
 private:
-    TraceState &s_;
+    ProducerLane &lane_;
     bool admitted_{false};
 };
 
@@ -105,7 +152,9 @@ private:
 // recording worker can still be inside one, and commit joins it before a pass
 // ends, so in practice this returns without spinning.
 void drain_in_flight_records(TraceState &s) {
-    while (s.in_flight.load(std::memory_order_acquire) != 0) {}
+    for (ProducerLane &lane : s.lanes) {
+        while (lane.in_flight.load(std::memory_order_acquire) != 0) {}
+    }
 }
 
 bool is_bind_kind(uint32_t kind) { return kind < static_cast<uint32_t>(HostPhaseKind::OrchSubmitTask); }
@@ -132,30 +181,46 @@ uint32_t current_thread_id() {
     return id;
 }
 
-void record_counter(TraceState &s, uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload) {
-    KindCounter &counter = s.counters[kind];
-    uint64_t unset = 0;
-    (void)counter.first_start_ns.compare_exchange_strong(unset, start_ns, std::memory_order_relaxed);
-    counter.total_ns.fetch_add(end_ns - start_ns, std::memory_order_relaxed);
-    counter.count.fetch_add(1, std::memory_order_relaxed);
-    counter.payload_sum.fetch_add(payload, std::memory_order_relaxed);
+void record_counter(ProducerLane &lane, uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload) {
+    KindCounter &counter = lane.counters[kind];
+    if (counter.first_start_ns == 0) counter.first_start_ns = start_ns;
+    counter.total_ns += end_ns - start_ns;
+    counter.count++;
+    counter.payload_sum += payload;
 }
 
 void append_record(TraceState &s, uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload, uint32_t index) {
-    if (s.pool.load(std::memory_order_acquire) == nullptr) return;
-    std::lock_guard<std::mutex> lock(s.pool_mutex);
-    HostPhaseRecordPool *pool = s.pool.load(std::memory_order_relaxed);
+    // No lock: the pool claims a slot per record with one atomic increment, so
+    // concurrent recording threads do not serialize here. `pool` is republished
+    // only by begin/end, which bracket every record via the admission drain.
+    HostPhaseRecordPool *pool = s.pool.load(std::memory_order_acquire);
     if (pool == nullptr) return;
     host_phase_pool_append(
         pool, static_cast<HostPhaseKind>(kind), start_ns, end_ns, payload, index, current_thread_id()
     );
 }
 
-void reset_counter(KindCounter &counter) {
-    counter.total_ns.store(0, std::memory_order_relaxed);
-    counter.count.store(0, std::memory_order_relaxed);
-    counter.payload_sum.store(0, std::memory_order_relaxed);
-    counter.first_start_ns.store(0, std::memory_order_relaxed);
+// A pass's totals for one kind, summed across the producers that recorded it.
+// Valid only after the lanes are drained.
+KindCounter merged_counter(const TraceState &s, uint32_t kind) {
+    KindCounter merged{};
+    for (const ProducerLane &lane : s.lanes) {
+        const KindCounter &counter = lane.counters[kind];
+        merged.total_ns += counter.total_ns;
+        merged.count += counter.count;
+        merged.payload_sum += counter.payload_sum;
+        if (counter.first_start_ns != 0 &&
+            (merged.first_start_ns == 0 || counter.first_start_ns < merged.first_start_ns)) {
+            merged.first_start_ns = counter.first_start_ns;
+        }
+    }
+    return merged;
+}
+
+void reset_lanes(TraceState &s) {
+    for (ProducerLane &lane : s.lanes) {
+        lane.counters = {};
+    }
 }
 
 }  // namespace
@@ -190,11 +255,24 @@ host_phase_record(uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t pa
     // ORCH_PHASE_END calls this on every submit-level operation, so the load
     // above stays the whole cost when tracing is off. Admission then re-checks
     // under the in-flight claim, which is what actually closes the boundary.
-    RecordAdmission admission(s);
+    uint32_t claimed_generation = 0;
+    ProducerLane *lane = producer_lane(s, claimed_generation);
+    if (lane == nullptr) {
+        s.lane_denied.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    RecordAdmission admission(s, *lane);
     if (!admission) {
         return;
     }
-    record_counter(s, start_ns, end_ns, kind, payload);
+    // A pass can have closed and a new one opened between claiming the lane and
+    // being admitted here, and the new pass resets the lane hand-out -- so a lane
+    // claimed for the old pass may already belong to another producer, and writing
+    // its plain-integer counters would be a race. A stale claim withdraws instead.
+    if (s.generation.load(std::memory_order_acquire) != claimed_generation) {
+        return;
+    }
+    record_counter(*lane, start_ns, end_ns, kind, payload);
     append_record(s, start_ns, end_ns, kind, payload, index);
 }
 
@@ -203,15 +281,24 @@ void host_phase_record_bind(uint32_t kind, uint64_t start_ns, const char *attrs,
     if (!s.active.load(std::memory_order_acquire) || !is_bind_kind(kind)) {
         return;
     }
-    RecordAdmission admission(s);
+    uint32_t claimed_generation = 0;
+    ProducerLane *lane = producer_lane(s, claimed_generation);
+    if (lane == nullptr) {
+        s.lane_denied.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    RecordAdmission admission(s, *lane);
     if (!admission) {
+        return;
+    }
+    if (s.generation.load(std::memory_order_acquire) != claimed_generation) {
         return;
     }
     const uint64_t end_ns = static_cast<uint64_t>(simpler::log::monotonic_now_ns());
     if (attrs != nullptr) {
         snprintf(s.bind_attrs[kind].data(), kBindAttrsCapacity, "%s", attrs);
     }
-    record_counter(s, start_ns, end_ns, kind, payload);
+    record_counter(*lane, start_ns, end_ns, kind, payload);
     append_record(s, start_ns, end_ns, kind, payload, 0);
 }
 
@@ -229,11 +316,18 @@ void host_phase_trace_begin(const void *host_api) {
     // Timestamps are taken whenever either sink wants them. Gating the clock on
     // one switch alone would leave the other sink recording zeros.
     s.submitted_tasks.store(0, std::memory_order_relaxed);
-    for (KindCounter &counter : s.counters)
-        reset_counter(counter);
+    s.lane_denied.store(0, std::memory_order_relaxed);
+    reset_lanes(s);
     for (auto &attrs : s.bind_attrs) {
         attrs[0] = '\0';
     }
+    // Retires the producers' cached lanes, so a thread that recorded in the last
+    // pass claims afresh rather than keeping a lane whose counters were just
+    // cleared under it. Published before `active`, so no record can see the new
+    // pass with a stale lane. The counter is process-wide monotonic rather than
+    // per-pass-reset, so no two passes ever share an identity.
+    s.next_lane.store(0, std::memory_order_relaxed);
+    s.generation.fetch_add(1, std::memory_order_release);
     s.active.store(s.pool != nullptr || host_phase_breakdown_enabled(), std::memory_order_release);
 }
 
@@ -249,16 +343,21 @@ void host_phase_trace_end() {
     }
     s.active.store(false, std::memory_order_release);
     // Every record already past the `active` check finishes its counter and pool
-    // work before the totals below are read and the pool is handed back.
+    // work before the totals below are read and the pool is handed back, so no
+    // lock is needed here either: the drain, not a mutex, is what makes the pool
+    // quiescent.
     drain_in_flight_records(s);
-    std::lock_guard<std::mutex> pool_lock(s.pool_mutex);
     // Read the pool's own tally before handing it back, and drop the pointer
     // after: the pool belongs to the runner from finish() onward, and the pass is
     // over either way, so nothing here may outlive it. Clearing `active` also
     // makes a second end() without an intervening begin() a no-op rather than a
     // stale read plus a duplicate report.
     HostPhaseRecordPool *pool = s.pool.load(std::memory_order_relaxed);
-    const uint64_t dropped = pool != nullptr ? pool->head.dropped_record_count : 0;
+    // Both ways a record can be lost: no buffer left in the pool, or no lane left
+    // to count it in. The second is unreachable while the lane count covers the
+    // producer ceiling, and is summed in rather than assumed away.
+    const uint64_t dropped = (pool != nullptr ? pool->dropped.load(std::memory_order_relaxed) : 0) +
+                             s.lane_denied.load(std::memory_order_relaxed);
     if (s.api != nullptr) {
         uint64_t inv = 0;
 #if SIMPLER_HOST_STRACE
@@ -276,14 +375,14 @@ void host_phase_trace_end() {
     }
 
     for (uint32_t kind = 0; kind < kHostPhaseKindCount; ++kind) {
-        const KindCounter &counter = s.counters[kind];
-        const uint64_t count = counter.count.load(std::memory_order_relaxed);
+        const KindCounter counter = merged_counter(s, kind);
+        const uint64_t count = counter.count;
         if (count == 0) {
             continue;
         }
-        const uint64_t total_ns = counter.total_ns.load(std::memory_order_relaxed);
-        const uint64_t payload_sum = counter.payload_sum.load(std::memory_order_relaxed);
-        const uint64_t first_start_ns = counter.first_start_ns.load(std::memory_order_relaxed);
+        const uint64_t total_ns = counter.total_ns;
+        const uint64_t payload_sum = counter.payload_sum;
+        const uint64_t first_start_ns = counter.first_start_ns;
         const char *name = host_phase_kind_name(static_cast<HostPhaseKind>(kind));
         if (is_bind_kind(kind)) {
             // One occurrence per pass, so the summed time is the segment's own

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -187,17 +187,26 @@ constexpr int PLATFORM_PROF_ORCH_BUFFERS_PER_THREAD = 8;
  * Host phase-record pool geometry (host_build_graph's bind path and host
  * orchestrator).
  *
- * Same rotating-pool shape as the sched/orch pools above, sized for its own
- * producer rather than theirs: a scheduler thread emits tens of thousands of
- * records per run, while one host orchestration pass emits a few hundred (a
- * 40-layer decode: 12 bind segments + ~325 submit-level operations). Inheriting
- * PLATFORM_PHASE_RECORDS_PER_THREAD here would allocate 4 MB to hold 11 KB and
- * leave the rotation path unreachable, so per-buffer capacity is 1024 records
- * (32 KB) and the pool holds 5 of them — the floor that lets
- * PLATFORM_PROF_SLOT_COUNT spares fill the free_queue with one buffer active.
+ * Sized for its own producers rather than the sched/orch pools': a scheduler
+ * thread emits tens of thousands of records per run, while one host orchestration
+ * pass emits a few hundred per producer (a 40-layer decode: 12 bind segments +
+ * ~325 submit-level operations). Inheriting PLATFORM_PHASE_RECORDS_PER_THREAD
+ * here would allocate 4 MB to hold 11 KB.
+ *
+ * A pass has one producer per thread that records: the submitting thread plus one
+ * per concurrently-recorded Graph Definition. Each claims whole buffers and fills
+ * them alone, so `PLATFORM_HOST_PHASE_BUFFERS` must exceed the producer count or
+ * a producer is denied a buffer and its records are dropped. The recorder pool
+ * caps itself at GRAPH_MAX_DEFINITIONS (16) threads, so 17 producers is the
+ * ceiling; the buffer count is above that so a producer whose first buffer fills
+ * can chain another.
+ *
+ * Per-buffer capacity is what a producer holds before chaining, not what a pass
+ * needs: the widest observed single producer is a 1-Definition workload's lone
+ * recorder at ~1900 records, which chains four 512-record buffers.
  */
-constexpr int PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER = 1024;
-constexpr int PLATFORM_HOST_PHASE_BUFFERS = PLATFORM_PROF_SLOT_COUNT + 1;
+constexpr int PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER = 512;
+constexpr int PLATFORM_HOST_PHASE_BUFFERS = 24;
 
 /**
  * Per-core ChipSwimlaneAicoreTaskBuffer pre-allocation count.

--- a/src/a5/runtime/host_build_graph/host/host_phase_trace.cpp
+++ b/src/a5/runtime/host_build_graph/host/host_phase_trace.cpp
@@ -44,29 +44,56 @@ namespace {
 // measured path.
 constexpr size_t kBindAttrsCapacity = 96;
 
-// record_node and graph_submit are updated concurrently by different cores.
-// Keep phase counters on distinct cache lines so lock-free accounting does not
-// turn that intended overlap into cache-line ownership ping-pong.
-struct alignas(64) KindCounter {
-    std::atomic<uint64_t> total_ns{0};
-    std::atomic<uint64_t> count{0};
-    std::atomic<uint64_t> payload_sum{0};
-    std::atomic<uint64_t> first_start_ns{0};
+// One producer's counters and in-flight claim, on its own cache lines.
+//
+// The producers of a pass are independent -- each records its own Definition and
+// counts only its own operations -- so nothing here is shared, and the per-record
+// path performs no atomic read-modify-write at all. Sharing them cost the emitting
+// thread about 0.8 us per record at eight producers, purely in cache-line
+// ownership: every producer of a Graph workload records the same kind
+// (`record_node`), so a per-kind counter is a single line eight threads fight
+// over, and the `alignas(64)` that separates one kind from another does nothing
+// about that.
+//
+// Plain integers, not atomics, and that is only sound because a lane has exactly
+// one writer for the whole pass -- never a shared fallback -- and the reader sums
+// the lanes after the pass is closed and its producers drained. A producer that
+// cannot get a lane of its own does not record.
+struct KindCounter {
+    uint64_t total_ns{0};
+    uint64_t count{0};
+    uint64_t payload_sum{0};
+    uint64_t first_start_ns{0};
 };
-static_assert(sizeof(KindCounter) == 64);
+
+struct alignas(64) ProducerLane {
+    // Records accepted by `active` but not yet finished with the counters and the
+    // pool. begin/end clear `active` and then drain the sum of these to zero, so a
+    // record can never be reported by a pass it does not belong to.
+    std::atomic<int32_t> in_flight{0};
+    std::array<KindCounter, kHostPhaseKindCount> counters{};
+};
+
+// One lane per thread that can record: the submitting thread plus one per
+// concurrently-recorded Definition, so the ceiling is GRAPH_MAX_DEFINITIONS + 1 =
+// 17. Matches the pool's buffer count, which is sized the same way, so a producer
+// that got a buffer also has a lane and neither denial is reachable in a sized
+// run.
+constexpr size_t kProducerLanes = PLATFORM_HOST_PHASE_BUFFERS;
 
 struct TraceState {
     std::atomic<HostPhaseRecordPool *> pool{nullptr};
     const HostApi *api;
     std::atomic<bool> active{false};
-    // Records accepted by `active` but not yet finished with the counters and the
-    // pool. begin/end clear `active` and then drain this to zero, so a record can
-    // never be reported by a pass it does not belong to.
-    std::atomic<int32_t> in_flight{0};
+    std::atomic<uint32_t> generation{0};
+    std::atomic<uint32_t> next_lane{0};
+    // Records dropped because every lane was taken. Unreachable while the lane
+    // count covers the producer ceiling; counted rather than assumed so a workload
+    // that outgrows it says so instead of silently under-reporting.
+    std::atomic<uint64_t> lane_denied{0};
     std::mutex lifecycle_mutex;
-    std::mutex pool_mutex;
     std::atomic<uint64_t> submitted_tasks{0};
-    std::array<KindCounter, kHostPhaseKindCount> counters;
+    std::array<ProducerLane, kProducerLanes> lanes;
     std::array<std::array<char, kBindAttrsCapacity>, kHostPhaseKindCount> bind_attrs;
 };
 
@@ -75,20 +102,40 @@ TraceState &state() {
     return s;
 }
 
+// This thread's lane for the current pass, or nullptr when every lane is taken.
+//
+// `generation` is what makes a cached lane safe to reuse: it is process-unique per
+// pass, so a lane claimed under one pass is never mistaken for a claim under
+// another. Returns the generation it claimed under, because the caller must
+// re-check it once admitted -- see host_phase_record.
+ProducerLane *producer_lane(TraceState &s, uint32_t &claimed_generation) {
+    static thread_local ProducerLane *lane = nullptr;
+    static thread_local uint32_t lane_generation = 0;
+    const uint32_t generation = s.generation.load(std::memory_order_acquire);
+    if (lane == nullptr || lane_generation != generation) {
+        const uint32_t index = s.next_lane.fetch_add(1, std::memory_order_relaxed);
+        lane = index < kProducerLanes ? &s.lanes[index] : nullptr;
+        lane_generation = generation;
+    }
+    claimed_generation = generation;
+    return lane;
+}
+
 // Publish-then-check against the trace lifecycle's clear-then-drain. Claiming a
 // slot before reading `active` is what makes the pair race-free: a record that
 // got in before the pass closed is waited for, and one that arrives after sees
-// `active` false and withdraws.
+// `active` false and withdraws. The claim is on this producer's own line, so it
+// costs nothing to the others.
 class RecordAdmission {
 public:
-    explicit RecordAdmission(TraceState &s) :
-        s_(s) {
-        s_.in_flight.fetch_add(1, std::memory_order_acq_rel);
-        admitted_ = s_.active.load(std::memory_order_acquire);
-        if (!admitted_) s_.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+    RecordAdmission(TraceState &s, ProducerLane &lane) :
+        lane_(lane) {
+        lane_.in_flight.fetch_add(1, std::memory_order_acq_rel);
+        admitted_ = s.active.load(std::memory_order_acquire);
+        if (!admitted_) lane_.in_flight.fetch_sub(1, std::memory_order_acq_rel);
     }
     ~RecordAdmission() {
-        if (admitted_) s_.in_flight.fetch_sub(1, std::memory_order_acq_rel);
+        if (admitted_) lane_.in_flight.fetch_sub(1, std::memory_order_acq_rel);
     }
 
     RecordAdmission(const RecordAdmission &) = delete;
@@ -97,7 +144,7 @@ public:
     explicit operator bool() const { return admitted_; }
 
 private:
-    TraceState &s_;
+    ProducerLane &lane_;
     bool admitted_{false};
 };
 
@@ -105,7 +152,9 @@ private:
 // recording worker can still be inside one, and commit joins it before a pass
 // ends, so in practice this returns without spinning.
 void drain_in_flight_records(TraceState &s) {
-    while (s.in_flight.load(std::memory_order_acquire) != 0) {}
+    for (ProducerLane &lane : s.lanes) {
+        while (lane.in_flight.load(std::memory_order_acquire) != 0) {}
+    }
 }
 
 bool is_bind_kind(uint32_t kind) { return kind < static_cast<uint32_t>(HostPhaseKind::OrchSubmitTask); }
@@ -132,30 +181,46 @@ uint32_t current_thread_id() {
     return id;
 }
 
-void record_counter(TraceState &s, uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload) {
-    KindCounter &counter = s.counters[kind];
-    uint64_t unset = 0;
-    (void)counter.first_start_ns.compare_exchange_strong(unset, start_ns, std::memory_order_relaxed);
-    counter.total_ns.fetch_add(end_ns - start_ns, std::memory_order_relaxed);
-    counter.count.fetch_add(1, std::memory_order_relaxed);
-    counter.payload_sum.fetch_add(payload, std::memory_order_relaxed);
+void record_counter(ProducerLane &lane, uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload) {
+    KindCounter &counter = lane.counters[kind];
+    if (counter.first_start_ns == 0) counter.first_start_ns = start_ns;
+    counter.total_ns += end_ns - start_ns;
+    counter.count++;
+    counter.payload_sum += payload;
 }
 
 void append_record(TraceState &s, uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload, uint32_t index) {
-    if (s.pool.load(std::memory_order_acquire) == nullptr) return;
-    std::lock_guard<std::mutex> lock(s.pool_mutex);
-    HostPhaseRecordPool *pool = s.pool.load(std::memory_order_relaxed);
+    // No lock: the pool claims a slot per record with one atomic increment, so
+    // concurrent recording threads do not serialize here. `pool` is republished
+    // only by begin/end, which bracket every record via the admission drain.
+    HostPhaseRecordPool *pool = s.pool.load(std::memory_order_acquire);
     if (pool == nullptr) return;
     host_phase_pool_append(
         pool, static_cast<HostPhaseKind>(kind), start_ns, end_ns, payload, index, current_thread_id()
     );
 }
 
-void reset_counter(KindCounter &counter) {
-    counter.total_ns.store(0, std::memory_order_relaxed);
-    counter.count.store(0, std::memory_order_relaxed);
-    counter.payload_sum.store(0, std::memory_order_relaxed);
-    counter.first_start_ns.store(0, std::memory_order_relaxed);
+// A pass's totals for one kind, summed across the producers that recorded it.
+// Valid only after the lanes are drained.
+KindCounter merged_counter(const TraceState &s, uint32_t kind) {
+    KindCounter merged{};
+    for (const ProducerLane &lane : s.lanes) {
+        const KindCounter &counter = lane.counters[kind];
+        merged.total_ns += counter.total_ns;
+        merged.count += counter.count;
+        merged.payload_sum += counter.payload_sum;
+        if (counter.first_start_ns != 0 &&
+            (merged.first_start_ns == 0 || counter.first_start_ns < merged.first_start_ns)) {
+            merged.first_start_ns = counter.first_start_ns;
+        }
+    }
+    return merged;
+}
+
+void reset_lanes(TraceState &s) {
+    for (ProducerLane &lane : s.lanes) {
+        lane.counters = {};
+    }
 }
 
 }  // namespace
@@ -190,11 +255,24 @@ host_phase_record(uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t pa
     // ORCH_PHASE_END calls this on every submit-level operation, so the load
     // above stays the whole cost when tracing is off. Admission then re-checks
     // under the in-flight claim, which is what actually closes the boundary.
-    RecordAdmission admission(s);
+    uint32_t claimed_generation = 0;
+    ProducerLane *lane = producer_lane(s, claimed_generation);
+    if (lane == nullptr) {
+        s.lane_denied.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    RecordAdmission admission(s, *lane);
     if (!admission) {
         return;
     }
-    record_counter(s, start_ns, end_ns, kind, payload);
+    // A pass can have closed and a new one opened between claiming the lane and
+    // being admitted here, and the new pass resets the lane hand-out -- so a lane
+    // claimed for the old pass may already belong to another producer, and writing
+    // its plain-integer counters would be a race. A stale claim withdraws instead.
+    if (s.generation.load(std::memory_order_acquire) != claimed_generation) {
+        return;
+    }
+    record_counter(*lane, start_ns, end_ns, kind, payload);
     append_record(s, start_ns, end_ns, kind, payload, index);
 }
 
@@ -203,15 +281,24 @@ void host_phase_record_bind(uint32_t kind, uint64_t start_ns, const char *attrs,
     if (!s.active.load(std::memory_order_acquire) || !is_bind_kind(kind)) {
         return;
     }
-    RecordAdmission admission(s);
+    uint32_t claimed_generation = 0;
+    ProducerLane *lane = producer_lane(s, claimed_generation);
+    if (lane == nullptr) {
+        s.lane_denied.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    RecordAdmission admission(s, *lane);
     if (!admission) {
+        return;
+    }
+    if (s.generation.load(std::memory_order_acquire) != claimed_generation) {
         return;
     }
     const uint64_t end_ns = static_cast<uint64_t>(simpler::log::monotonic_now_ns());
     if (attrs != nullptr) {
         snprintf(s.bind_attrs[kind].data(), kBindAttrsCapacity, "%s", attrs);
     }
-    record_counter(s, start_ns, end_ns, kind, payload);
+    record_counter(*lane, start_ns, end_ns, kind, payload);
     append_record(s, start_ns, end_ns, kind, payload, 0);
 }
 
@@ -229,11 +316,18 @@ void host_phase_trace_begin(const void *host_api) {
     // Timestamps are taken whenever either sink wants them. Gating the clock on
     // one switch alone would leave the other sink recording zeros.
     s.submitted_tasks.store(0, std::memory_order_relaxed);
-    for (KindCounter &counter : s.counters)
-        reset_counter(counter);
+    s.lane_denied.store(0, std::memory_order_relaxed);
+    reset_lanes(s);
     for (auto &attrs : s.bind_attrs) {
         attrs[0] = '\0';
     }
+    // Retires the producers' cached lanes, so a thread that recorded in the last
+    // pass claims afresh rather than keeping a lane whose counters were just
+    // cleared under it. Published before `active`, so no record can see the new
+    // pass with a stale lane. The counter is process-wide monotonic rather than
+    // per-pass-reset, so no two passes ever share an identity.
+    s.next_lane.store(0, std::memory_order_relaxed);
+    s.generation.fetch_add(1, std::memory_order_release);
     s.active.store(s.pool != nullptr || host_phase_breakdown_enabled(), std::memory_order_release);
 }
 
@@ -249,16 +343,21 @@ void host_phase_trace_end() {
     }
     s.active.store(false, std::memory_order_release);
     // Every record already past the `active` check finishes its counter and pool
-    // work before the totals below are read and the pool is handed back.
+    // work before the totals below are read and the pool is handed back, so no
+    // lock is needed here either: the drain, not a mutex, is what makes the pool
+    // quiescent.
     drain_in_flight_records(s);
-    std::lock_guard<std::mutex> pool_lock(s.pool_mutex);
     // Read the pool's own tally before handing it back, and drop the pointer
     // after: the pool belongs to the runner from finish() onward, and the pass is
     // over either way, so nothing here may outlive it. Clearing `active` also
     // makes a second end() without an intervening begin() a no-op rather than a
     // stale read plus a duplicate report.
     HostPhaseRecordPool *pool = s.pool.load(std::memory_order_relaxed);
-    const uint64_t dropped = pool != nullptr ? pool->head.dropped_record_count : 0;
+    // Both ways a record can be lost: no buffer left in the pool, or no lane left
+    // to count it in. The second is unreachable while the lane count covers the
+    // producer ceiling, and is summed in rather than assumed away.
+    const uint64_t dropped = (pool != nullptr ? pool->dropped.load(std::memory_order_relaxed) : 0) +
+                             s.lane_denied.load(std::memory_order_relaxed);
     if (s.api != nullptr) {
         uint64_t inv = 0;
 #if SIMPLER_HOST_STRACE
@@ -276,14 +375,14 @@ void host_phase_trace_end() {
     }
 
     for (uint32_t kind = 0; kind < kHostPhaseKindCount; ++kind) {
-        const KindCounter &counter = s.counters[kind];
-        const uint64_t count = counter.count.load(std::memory_order_relaxed);
+        const KindCounter counter = merged_counter(s, kind);
+        const uint64_t count = counter.count;
         if (count == 0) {
             continue;
         }
-        const uint64_t total_ns = counter.total_ns.load(std::memory_order_relaxed);
-        const uint64_t payload_sum = counter.payload_sum.load(std::memory_order_relaxed);
-        const uint64_t first_start_ns = counter.first_start_ns.load(std::memory_order_relaxed);
+        const uint64_t total_ns = counter.total_ns;
+        const uint64_t payload_sum = counter.payload_sum;
+        const uint64_t first_start_ns = counter.first_start_ns;
         const char *name = host_phase_kind_name(static_cast<HostPhaseKind>(kind));
         if (is_bind_kind(kind)) {
             // One occurrence per pass, so the summed time is the segment's own

--- a/src/common/platform/include/common/chip_swimlane_profiling.h
+++ b/src/common/platform/include/common/chip_swimlane_profiling.h
@@ -748,15 +748,16 @@ using ChipSwimlaneAicpuOrchPhaseBuffer =
 using ChipSwimlaneAicpuSchedPhasePool = ChipSwimlaneAicpuTaskPool;
 using ChipSwimlaneAicpuOrchPhasePool = ChipSwimlaneAicpuTaskPool;
 
-// The host phase pool is the same head + free_queue plumbing over host DDR
-// instead of device shared memory: producers are serialized by the host trace
-// sink while rotating through a fixed set of fixed-size buffers, and a reader
-// walks them in rotation order. Its buffers are
-// smaller and fewer than a device thread's because its producer emits hundreds
-// of records per pass rather than tens of thousands (see
+// The host phase pool holds the same fixed-size record buffers over host DDR
+// instead of device shared memory, but not the head + free_queue plumbing: those
+// exist so a single device producer can hand filled buffers to a host reader
+// mid-run, and the host pool has many concurrent producers and one reader that
+// only ever looks after the pass is closed. It is defined in
+// host/host_phase_records.h, which owns that host-only shape; the buffers are
+// smaller and fewer than a device thread's because a producer emits hundreds of
+// records per pass rather than tens of thousands (see
 // PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER).
 using HostPhaseRecordBuffer = TypedBuffer<HostPhaseRecord, PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER>;
-using HostPhaseRecordPool = ChipSwimlaneAicpuTaskPool;
 
 // =============================================================================
 // Helper Functions - Memory Layout

--- a/src/common/platform/include/host/host_phase_records.h
+++ b/src/common/platform/include/host/host_phase_records.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -20,21 +21,89 @@
 #include "common/platform_config.h"
 
 /**
- * Rotating pool of host phase records, written on host_build_graph's prepare
- * path and read by whichever diagnostics are enabled for the run.
+ * Pool of host phase records, written on host_build_graph's prepare path and read
+ * by whichever diagnostics are enabled for the run.
  *
  * The pool is a platform resource with two independently gated readers — the
  * chip-swimlane export at level 4, and the per-event artifact the host trace
  * tooling consumes — so it belongs to neither of them. Storage and lifetime are
- * the platform's; the write cursor lives in the pool head, exactly as the
- * device sched/orch pools put it in shared memory for the AICPU to advance.
+ * the platform's.
  *
  * Recording is a header-inline store into platform-allocated memory rather than
  * a call through HostApi: a pass performs a few hundred operations a few
  * microseconds apart on the very path whose budget is under measurement, so the
- * per-event cost must stay at two clock reads and a store. HostApi carries only
- * the once-per-pass arm and finish.
+ * per-event cost must stay at two clock reads, one slot claim and a store.
+ * HostApi carries only the once-per-pass arm and finish.
+ *
+ * Every producer thread of a pass writes concurrently — a Graph workload records
+ * one thread per concurrent Definition alongside the submitting thread — so the
+ * pool is a flat array of slots claimed by one atomic increment, not a rotating
+ * active buffer. See `host_phase_pool_append` for what that replaced and why.
  */
+
+/**
+ * Record storage for one pass, written by every producer thread concurrently.
+ *
+ * A producer claims a whole buffer and fills it alone, so its records are
+ * contiguous and no cache line is ever shared with another producer's record.
+ * That is the whole design: the producers are independent — each records its own
+ * Definition and counts only its own operations — so nothing about a record needs
+ * coordination, and the per-record path has no shared write at all.
+ *
+ * `generation` invalidates a producer's cached buffer when a new pass is armed;
+ * without it a producer left over from the previous pass would append at its old
+ * offset into a buffer `arm()` has already cleared.
+ *
+ * At namespace scope alongside `HostPhaseRecord` and `HostPhaseRecordBuffer`, so
+ * the header-inline producer below and its callers name all three the same way.
+ */
+struct HostPhaseRecordPool {
+    std::atomic<uint32_t> next_buffer{0};
+    std::atomic<uint32_t> generation{0};
+    // Only touched when a producer is denied a buffer, i.e. never in a sized run.
+    std::atomic<uint64_t> dropped{0};
+    HostPhaseRecordBuffer *buffers{nullptr};
+    uint32_t buffer_count{0};
+};
+
+/**
+ * One producer's place in the pool: which buffer it owns and how much of it is
+ * used. Thread-local, so reading and advancing it is private to that thread.
+ */
+struct HostPhaseProducerLane {
+    const HostPhaseRecordPool *pool{nullptr};
+    uint32_t generation{0};
+    uint32_t buffer{0};
+    uint32_t used{0};
+    bool denied{false};
+};
+
+inline HostPhaseProducerLane &host_phase_producer_lane() {
+    static thread_local HostPhaseProducerLane lane;
+    return lane;
+}
+
+/**
+ * Take the next unclaimed buffer as this producer's own.
+ *
+ * Cold path: once per PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER records, plus once
+ * per pass per producer. Returns false when every buffer is claimed, which is the
+ * pool's only lossy outcome; the lane remembers it so a denied producer does not
+ * retry the atomic on every later record.
+ */
+inline bool host_phase_lane_claim_buffer(HostPhaseRecordPool *pool, HostPhaseProducerLane &lane, uint32_t generation) {
+    const uint32_t buffer = pool->next_buffer.fetch_add(1, std::memory_order_relaxed);
+    lane.pool = pool;
+    lane.generation = generation;
+    if (buffer >= pool->buffer_count) {
+        lane.denied = true;
+        return false;
+    }
+    lane.buffer = buffer;
+    lane.used = 0;
+    lane.denied = false;
+    return true;
+}
 
 namespace simpler::dfx {
 
@@ -87,27 +156,31 @@ public:
      */
     int write_records_jsonl(const std::string &path);
 
-    /** Records in rotation order. Empty unless a pass was armed with collection. */
+    /** Records in start-time order. Empty unless a pass was armed with collection. */
     std::vector<HostPhaseRecord> records() const;
 
-    /** Records whose kind submits a task, in rotation order. */
+    /** Records whose kind submits a task, in start-time order. */
     std::vector<HostPhaseRecord> submit_records() const;
 
-    /** Records whose kind is a host-to-device transfer, in rotation order. */
+    /** Records whose kind is a host-to-device transfer, in start-time order. */
     std::vector<HostPhaseRecord> device_upload_records() const;
 
     bool armed() const { return armed_; }
     bool finished() const { return finished_; }
     uint64_t submitted_tasks() const { return submitted_tasks_; }
     uint64_t invocation_id() const { return invocation_id_; }
-    uint64_t total_records() const { return pool_.head.total_record_count; }
-    uint64_t dropped_records() const { return pool_.head.dropped_record_count; }
+    /** Records the producers emitted, whether or not each one found a buffer. */
+    uint64_t total_records() const { return stored_records() + dropped_records(); }
+    uint64_t dropped_records() const { return pool_.dropped.load(std::memory_order_relaxed); }
     /** Capacity in records, i.e. how many fit before any is dropped. */
     static constexpr size_t capacity() {
         return static_cast<size_t>(PLATFORM_HOST_PHASE_BUFFERS) * PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER;
     }
 
 private:
+    /** Records that reached a buffer, summed across the buffers producers filled. */
+    uint64_t stored_records() const;
+
     HostPhaseRecordPool pool_{};
     std::vector<HostPhaseRecordBuffer> buffers_{};
     bool armed_{false};
@@ -120,26 +193,27 @@ private:
 }  // namespace simpler::dfx
 
 /**
- * Take the next free buffer as the active one.
- *
- * Cold path: reached once per PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER records, and
- * on the pass's first record. Returns nullptr when the free queue is exhausted,
- * which is the pool's only lossy outcome and is counted in the head.
- */
-inline HostPhaseRecordBuffer *host_phase_pool_rotate(HostPhaseRecordPool *pool) {
-    ChipSwimlaneFreeQueue &free_queue = pool->free_queue;
-    if (free_queue.head == free_queue.tail) return nullptr;
-    const uint32_t slot = free_queue.head % PLATFORM_PROF_SLOT_COUNT;
-    auto *next = reinterpret_cast<HostPhaseRecordBuffer *>(free_queue.buffer_ptrs[slot]);
-    free_queue.head = free_queue.head + 1;
-    pool->head.current_buf_ptr = reinterpret_cast<uint64_t>(next);
-    pool->head.current_buf_seq = pool->head.current_buf_seq + 1;
-    return next;
-}
-
-/**
  * Append one record. A null pool means this pass collects no records, which is
  * the common case and costs one branch.
+ *
+ * No shared write: the record goes into the buffer this thread owns, at the offset
+ * this thread tracks, and `count` is published on that same private line. The one
+ * atomic is a buffer claim, taken once per PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER
+ * records, and it measures as free.
+ *
+ * That matters because all of this runs after the record's own end timestamp, so
+ * whatever it costs is invisible except as a gap between two records. The
+ * predecessor -- a global mutex over one shared active buffer -- cost the emitting
+ * thread 3.3 us per record at eight producers against 0.1 us at one, and a flat
+ * per-record slot claim still cost 1.1 us because a 40-byte record leaves adjacent
+ * slots, owned by different threads, sharing a cache line. Per-producer buffers
+ * are flat at ~50 ns from one producer to sixteen, which is what two
+ * `clock_gettime` calls cost on their own.
+ *
+ * A written record is visible to a reader only after that producer stops, so a
+ * reader must not read a pass before its producers are done.
+ * `host_phase_trace_end()` guarantees that: it clears `active` and drains the
+ * in-flight count to zero before `finish()`.
  *
  * @param start_ns,end_ns  host monotonic nanoseconds
  * @param payload          task id for kinds that submit a task, else a detail count
@@ -151,16 +225,23 @@ inline void host_phase_pool_append(
     uint32_t thread_id = 0
 ) {
     if (pool == nullptr) return;
-    pool->head.total_record_count = pool->head.total_record_count + 1;
-    auto *active = reinterpret_cast<HostPhaseRecordBuffer *>(pool->head.current_buf_ptr);
-    if (active == nullptr || active->count >= PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER) {
-        active = host_phase_pool_rotate(pool);
-        if (active == nullptr) {
-            pool->head.dropped_record_count = pool->head.dropped_record_count + 1;
+    HostPhaseProducerLane &lane = host_phase_producer_lane();
+    const uint32_t generation = pool->generation.load(std::memory_order_acquire);
+    const bool fresh_pass = lane.pool != pool || lane.generation != generation;
+    if (fresh_pass || (!lane.denied && lane.used >= PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER)) {
+        if (!host_phase_lane_claim_buffer(pool, lane, generation)) {
+            pool->dropped.fetch_add(1, std::memory_order_relaxed);
             return;
         }
+    } else if (lane.denied) {
+        pool->dropped.fetch_add(1, std::memory_order_relaxed);
+        return;
     }
-    active->records[active->count] =
+    HostPhaseRecordBuffer &buffer = pool->buffers[lane.buffer];
+    buffer.records[lane.used] =
         HostPhaseRecord{start_ns, end_ns, payload, static_cast<uint32_t>(kind), index, thread_id, 0};
-    active->count = active->count + 1;
+    lane.used++;
+    // This producer is the only writer of this buffer's count, and the reader
+    // needs it to know how far the buffer is filled.
+    buffer.count = lane.used;
 }

--- a/src/common/platform/shared/host/host_phase_records.cpp
+++ b/src/common/platform/shared/host/host_phase_records.cpp
@@ -13,14 +13,37 @@
 
 #include <unistd.h>
 
+#include <algorithm>
+#include <atomic>
 #include <fstream>
 
 #include "common/unified_log.h"
 
 namespace simpler::dfx {
+namespace {
+
+// A pass identity must be unique across every pool in the process, not merely
+// within one. A producer caches its lane against the identity of the pass it
+// claimed it for, and a store is per DeviceRunner: a freshly constructed store can
+// occupy a destroyed one's address with a per-pool counter that has reached the
+// same value, at which point a stale cached lane looks valid for a pass it never
+// claimed and appends at an offset into a buffer this pass has cleared.
+uint32_t next_pass_generation() {
+    static std::atomic<uint32_t> generation{0};
+    return generation.fetch_add(1, std::memory_order_relaxed) + 1;
+}
+
+}  // namespace
 
 HostPhaseRecordPool *HostPhaseRecordStore::arm(bool collect_records) {
-    pool_ = HostPhaseRecordPool{};
+    // Publishing a new generation is what retires the previous pass's producer
+    // lanes: a thread that recorded then still holds a buffer index and an offset,
+    // and must not append at that offset into a buffer cleared below.
+    pool_.generation.store(next_pass_generation(), std::memory_order_release);
+    pool_.next_buffer.store(0, std::memory_order_relaxed);
+    pool_.dropped.store(0, std::memory_order_relaxed);
+    pool_.buffers = nullptr;
+    pool_.buffer_count = 0;
     armed_ = false;
     finished_ = false;
     records_written_ = false;
@@ -41,20 +64,20 @@ HostPhaseRecordPool *HostPhaseRecordStore::arm(bool collect_records) {
     for (auto &buffer : buffers_) {
         buffer.count = 0;
     }
-
-    // Buffer 0 is active and the rest fill the free queue in index order, so the
-    // reader recovers fill order from the buffer index alone — the free queue
-    // holds exactly PLATFORM_PROF_SLOT_COUNT spares, which is why the pool is
-    // one buffer larger than that.
-    pool_.head.current_buf_ptr = reinterpret_cast<uint64_t>(&buffers_[0]);
-    pool_.head.current_buf_seq = 1;
-    for (size_t i = 1; i < buffers_.size(); ++i) {
-        pool_.free_queue.buffer_ptrs[(i - 1) % PLATFORM_PROF_SLOT_COUNT] = reinterpret_cast<uint64_t>(&buffers_[i]);
-    }
-    pool_.free_queue.head = 0;
-    pool_.free_queue.tail = static_cast<uint32_t>(buffers_.size() - 1);
+    pool_.buffers = buffers_.data();
+    pool_.buffer_count = static_cast<uint32_t>(buffers_.size());
     armed_ = true;
     return &pool_;
+}
+
+uint64_t HostPhaseRecordStore::stored_records() const {
+    uint64_t total = 0;
+    for (const auto &buffer : buffers_) {
+        total += buffer.count < PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER ?
+                     buffer.count :
+                     static_cast<uint32_t>(PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER);
+    }
+    return total;
 }
 
 void HostPhaseRecordStore::finish(uint64_t submitted_tasks, uint64_t invocation_id) {
@@ -62,12 +85,12 @@ void HostPhaseRecordStore::finish(uint64_t submitted_tasks, uint64_t invocation_
     submitted_tasks_ = submitted_tasks;
     invocation_id_ = invocation_id;
     finished_ = true;
-    if (pool_.head.dropped_record_count > 0) {
+    if (dropped_records() > 0) {
         LOG_WARN(
-            "Host phase pool dropped %u of %u records (capacity %zu); the per-event views are truncated while the "
-            "per-kind totals stay exact",
-            static_cast<unsigned>(pool_.head.dropped_record_count),
-            static_cast<unsigned>(pool_.head.total_record_count), capacity()
+            "Host phase pool dropped %llu of %llu records (%d buffers of %d); the per-event views are truncated while "
+            "the per-kind totals stay exact",
+            static_cast<unsigned long long>(dropped_records()), static_cast<unsigned long long>(total_records()),
+            PLATFORM_HOST_PHASE_BUFFERS, PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER
         );
     }
 }
@@ -110,7 +133,7 @@ int HostPhaseRecordStore::write_records_jsonl(const std::string &path) {
 std::vector<HostPhaseRecord> HostPhaseRecordStore::records() const {
     std::vector<HostPhaseRecord> out;
     if (!armed_) return out;
-    out.reserve(pool_.head.total_record_count);
+    out.reserve(static_cast<size_t>(stored_records()));
     for (const auto &buffer : buffers_) {
         const uint32_t count = buffer.count < PLATFORM_HOST_PHASE_RECORDS_PER_BUFFER ?
                                    buffer.count :
@@ -119,6 +142,12 @@ std::vector<HostPhaseRecord> HostPhaseRecordStore::records() const {
             out.push_back(buffer.records[i]);
         }
     }
+    // A buffer holds one producer's records, so concatenating the buffers groups
+    // by producer rather than ordering by time. Sorting here is off any measured
+    // path and gives every reader one well-defined order.
+    std::stable_sort(out.begin(), out.end(), [](const HostPhaseRecord &a, const HostPhaseRecord &b) {
+        return a.start_ns < b.start_ns;
+    });
     return out;
 }
 

--- a/tests/ut/cpp/common/test_host_phase_records.cpp
+++ b/tests/ut/cpp/common/test_host_phase_records.cpp
@@ -11,9 +11,14 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <cstddef>
 #include <cstdio>
 #include <fstream>
+#include <new>
 #include <string>
+#include <thread>
+#include <vector>
 
 #include "host/host_phase_records.h"
 
@@ -72,13 +77,13 @@ TEST(HostPhaseRecords, RecordsSurviveInOrderWithinOneBuffer) {
     }
 }
 
-TEST(HostPhaseRecords, RotationSpansEveryBufferInOrder) {
+TEST(HostPhaseRecords, SlotsSpanEveryBufferInOrder) {
     HostPhaseRecordStore store;
     HostPhaseRecordPool *pool = store.arm(true);
     ASSERT_NE(pool, nullptr);
 
-    // Exactly fills the pool: one active buffer plus PLATFORM_PROF_SLOT_COUNT
-    // spares, so the last record lands without a drop.
+    // Exactly fills the pool, so the last record lands without a drop and every
+    // buffer reports itself full.
     const uint32_t capacity = static_cast<uint32_t>(HostPhaseRecordStore::capacity());
     record_n(pool, HostPhaseKind::OrchGraphSubmit, capacity, /*first_start=*/1);
     store.finish(0, /*invocation_id=*/9);
@@ -86,9 +91,49 @@ TEST(HostPhaseRecords, RotationSpansEveryBufferInOrder) {
     const auto records = store.records();
     ASSERT_EQ(records.size(), capacity);
     EXPECT_EQ(store.dropped_records(), 0u);
-    EXPECT_EQ(pool->head.current_buf_seq, static_cast<uint32_t>(PLATFORM_HOST_PHASE_BUFFERS));
+    EXPECT_EQ(store.total_records(), capacity);
     for (uint32_t i = 0; i < capacity; ++i) {
-        EXPECT_EQ(records[i].start_ns, 1u + i) << "record " << i << " out of rotation order";
+        EXPECT_EQ(records[i].start_ns, 1u + i) << "record " << i << " out of start-time order";
+    }
+}
+
+TEST(HostPhaseRecords, ConcurrentProducersLoseNothingAndDoNotOverlapSlots) {
+    // The pool has one writer per producer thread of a pass -- a Graph workload
+    // records one thread per concurrent Definition plus the submitting one. Each
+    // record must land exactly once, which is what makes the slot claim, rather
+    // than a lock, sufficient.
+    constexpr uint32_t kThreads = 8;
+    constexpr uint32_t kPerThread = 500;
+    HostPhaseRecordStore store;
+    HostPhaseRecordPool *pool = store.arm(true);
+    ASSERT_NE(pool, nullptr);
+    ASSERT_GE(HostPhaseRecordStore::capacity(), static_cast<size_t>(kThreads) * kPerThread);
+
+    std::atomic<bool> go{false};
+    std::vector<std::thread> producers;
+    for (uint32_t t = 0; t < kThreads; ++t) {
+        producers.emplace_back([&, t]() {
+            while (!go.load(std::memory_order_acquire)) {}
+            // Disjoint start_ns ranges, so a lost or duplicated record is visible
+            // as a hole or a repeat rather than needing per-thread bookkeeping.
+            record_n(pool, HostPhaseKind::OrchRecordNode, kPerThread, /*first_start=*/1 + t * kPerThread, t);
+        });
+    }
+    go.store(true, std::memory_order_release);
+    for (auto &producer : producers)
+        producer.join();
+    store.finish(0, /*invocation_id=*/9);
+
+    const auto records = store.records();
+    ASSERT_EQ(records.size(), static_cast<size_t>(kThreads) * kPerThread);
+    EXPECT_EQ(store.dropped_records(), 0u);
+    std::vector<uint64_t> starts;
+    starts.reserve(records.size());
+    for (const auto &record : records)
+        starts.push_back(record.start_ns);
+    // records() sorts, so every value in the union must appear exactly once.
+    for (size_t i = 0; i < starts.size(); ++i) {
+        EXPECT_EQ(starts[i], 1u + i) << "record " << i << " lost, duplicated, or out of order";
     }
 }
 
@@ -110,6 +155,44 @@ TEST(HostPhaseRecords, OverflowDropsAndCountsWithoutLosingEarlierRecords) {
     ASSERT_FALSE(records.empty());
     EXPECT_EQ(records.front().start_ns, 1u);
     EXPECT_EQ(records.back().start_ns, static_cast<uint64_t>(capacity));
+}
+
+TEST(HostPhaseRecords, AStoreReusingAnAddressDoesNotInheritACachedLane) {
+    // A producer caches its buffer and offset against the identity of the pass it
+    // claimed them for. That identity must be unique across the process, not
+    // counted per pool: there is a store per DeviceRunner, so a new store can
+    // occupy a destroyed one's address, and a per-pool counter would then hand it
+    // an identity the cached lane already matches. The producer would resume the
+    // dead store's offset -- appending past the records it wrote, or, once that
+    // offset is at a buffer boundary, dropping everything.
+    //
+    // Placement-new over one buffer is what makes the address reuse certain rather
+    // than left to the stack allocator, which is why this reproduced only in CI.
+    alignas(HostPhaseRecordStore) static std::byte storage[sizeof(HostPhaseRecordStore)];
+    auto *at_address = reinterpret_cast<HostPhaseRecordStore *>(storage);
+
+    new (at_address) HostPhaseRecordStore();
+    HostPhaseRecordPool *pool = at_address->arm(true);
+    ASSERT_NE(pool, nullptr);
+    record_n(pool, HostPhaseKind::OrchRecordNode, 100, /*first_start=*/1);
+    at_address->finish(0, /*invocation_id=*/9);
+    ASSERT_EQ(at_address->records().size(), 100u);
+    at_address->~HostPhaseRecordStore();
+
+    // Same address, brand-new store, its first pass.
+    new (at_address) HostPhaseRecordStore();
+    pool = at_address->arm(true);
+    ASSERT_NE(pool, nullptr);
+    record_n(pool, HostPhaseKind::OrchRecordNode, 100, /*first_start=*/1000);
+    at_address->finish(0, /*invocation_id=*/9);
+
+    const auto records = at_address->records();
+    EXPECT_EQ(records.size(), 100u) << "the new store inherited the dead one's producer lane";
+    EXPECT_EQ(at_address->dropped_records(), 0u);
+    for (size_t i = 0; i < records.size(); ++i) {
+        EXPECT_EQ(records[i].start_ns, 1000u + i) << "record " << i << " is not from this store's pass";
+    }
+    at_address->~HostPhaseRecordStore();
 }
 
 TEST(HostPhaseRecords, ReArmClearsThePreviousPass) {


### PR DESCRIPTION
## Summary

The host phase pool was built for **one** writer — it is the device pool's shape,
where the AICPU alone advances a cursor and the host reads — and host recording
became multi-threaded under it. A global mutex made that safe: every producer
serialized on one lock to append into one active buffer, and every producer's
counter update landed on one cache line per kind.

But the producers are independent. A recording thread records its own Definition
and counts only its own operations; nothing about a record needs coordination. The
lock and the shared counters bought nothing, and they cost the emitting thread
**3.3 µs per record at eight producers against 0.1 µs at one**.

All of that runs *after* the record's own end timestamp, so it was invisible as
anything except a gap between two consecutive records — which is exactly how it
presented: a swimlane whose recording lanes looked 45–66% idle, with the idle time
attributed to the workload. The 2 µs gap between two `record_node` records was
the instrument, not the orchestration; for scale, the codegen's actual per-node
argument construction in that gap measures **11 ns**.

## What changed

Each producer claims a whole buffer and fills it alone, so its records are
contiguous and no cache line is shared; its counters and in-flight claim are its
own lines. The per-record path has no shared write left — the one atomic is a
buffer claim taken once per 512 records.

Measured on a 320-core aarch64 host, 20k records per thread:

| producers | mutex + shared counters | per-producer lanes |
| --------- | ----------------------- | ------------------ |
| 1         | 122 ns                  | 48 ns              |
| 4         | 1718 ns                 | 50 ns              |
| 8         | 3233 ns                 | 49 ns              |
| 16        | 7321 ns                 | 49 ns              |

Flat rather than merely lower, and 48 ns is what the two `clock_gettime` calls
cost on their own — the record itself is now free.

An intermediate form is worth recording because it looks like the obvious fix and
is not enough: **one atomic slot claim per record into a flat array still cost
1.1 µs at eight producers**, because a 40-byte `HostPhaseRecord` leaves adjacent
slots owned by different threads sharing a 64-byte line. That is why the buffers
are per producer rather than merely lock-free.

## Effect on a real workload

dsv4's seven-Definition Graph form, a2a3, `--rounds 5` with the device run
skipped, minimum over the 8 warm passes:

| | before | after | |
| --- | --- | --- | --- |
| `host_orch` | 1.291 ms | 0.828 ms | −36% |
| control-plane total | 2.998 ms | 2.379 ms | −21% |

and in the per-event view the gap between two `record_node` records falls from
1.96–2.30 µs to 0.25–0.68 µs on every lane. The orchestration is unchanged; this
is the instrument getting out of the way of what it was measuring.

This also removes the reason #1937 gives for wanting the per-event pool separately
switchable — that path no longer appends under a lock — though one switch per view
is worth keeping on its own terms.

## Two consequences worth naming

- The pool is no longer the device pool's shape, so it is defined where it is used
  rather than aliased from the device header.
- `records()` sorts. A buffer holds one producer's records, so concatenating
  buffers groups by producer; sorting at read time (off any measured path) gives
  every reader one well-defined order. No current consumer depended on the old
  order — the swimlane exporter scans for a minimum `start_ns` and emits explicit
  timestamps — but a future one might.

The buffer count must exceed the producer count or a producer is denied a lane, so
it is 24 (the recorder pool caps at `GRAPH_MAX_DEFINITIONS` = 16 threads, plus the
submitting thread, plus headroom for chaining) with 512 records each.

## Testing

- [x] `ctest -LE requires_hardware` — 107/107
- [x] New cpput case `HostPhaseRecords.ConcurrentProducersLoseNothingAndDoNotOverlapSlots`
      — 8 threads × 500 records over disjoint `start_ns` ranges, every value present
      exactly once. Confirmed to **fail** when the buffer claim is made non-atomic.
- [x] `SlotsSpanEveryBufferInOrder` / `OverflowDropsAndCounts...` updated for the
      new pool: a single producer chains all 24 buffers, and overshoot is counted
      rather than corrupting the retained prefix.
- [x] a2a3 onboard, dsv4 L3 EP2/TP2, device run skipped: exits 0, artifact lands,
      7 producer lanes, per-node gap 0.42–0.68 µs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)