### PR TITLE
Fix: publish the host phase pool's buffers before its generation

### DIFF
--- a/src/common/platform/shared/host/host_phase_records.cpp
+++ b/src/common/platform/shared/host/host_phase_records.cpp
@@ -36,10 +36,12 @@ uint32_t next_pass_generation() {
 }  // namespace
 
 HostPhaseRecordPool *HostPhaseRecordStore::arm(bool collect_records) {
-    // Publishing a new generation is what retires the previous pass's producer
-    // lanes: a thread that recorded then still holds a buffer index and an offset,
-    // and must not append at that offset into a buffer cleared below.
-    pool_.generation.store(next_pass_generation(), std::memory_order_release);
+    // Everything a producer reads about this pass is written before the generation
+    // is published, and the generation is published last with a release. That store
+    // is the pass's only publication point: a producer acquires the generation and
+    // is then guaranteed to see the buffer pointer and count that go with it.
+    // Publishing the generation first would let a producer pair a new generation
+    // with the null pointer below and dereference it.
     pool_.next_buffer.store(0, std::memory_order_relaxed);
     pool_.dropped.store(0, std::memory_order_relaxed);
     pool_.buffers = nullptr;
@@ -55,6 +57,10 @@ HostPhaseRecordPool *HostPhaseRecordStore::arm(bool collect_records) {
     if (!collect_records) {
         buffers_.clear();
         buffers_.shrink_to_fit();
+        // Still a new pass, and publishing it is what retires the producer lanes a
+        // previous pass handed out — a producer holding one must not append into
+        // storage this call just released.
+        pool_.generation.store(next_pass_generation(), std::memory_order_release);
         return nullptr;
     }
 
@@ -67,6 +73,8 @@ HostPhaseRecordPool *HostPhaseRecordStore::arm(bool collect_records) {
     pool_.buffers = buffers_.data();
     pool_.buffer_count = static_cast<uint32_t>(buffers_.size());
     armed_ = true;
+    // Last, and with a release: see the top of this function.
+    pool_.generation.store(next_pass_generation(), std::memory_order_release);
     return &pool_;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1940, which merged before this landed. CodeRabbit raised it there as
an "outside diff range" comment on the review body — a surface with no
`isResolved` flag, so it went unanswered while the PR merged.

`arm()` released the new pass generation **first** and wrote `buffers` and
`buffer_count` **after**, so the release/acquire pair on `generation` published
neither. A producer that acquired the new generation was not guaranteed to see the
storage that goes with it, and could pair it with the null pointer the same
function had just written and dereference that.

```cpp
pool_.generation.store(next_pass_generation(), std::memory_order_release);  // published first
...
pool_.buffers = buffers_.data();          // written after — not covered by the release
pool_.buffer_count = ...;
```

## Why it did not bite

A producer only records while `active` is set, and `host_phase_trace_begin`
publishes `active` with a release **after** `arm()` returns — so that store carried
the buffers, and the acquire in `RecordAdmission` is what actually made the read
safe.

That is a fine reason for it not to have crashed, and a bad reason to leave it: the
release on `generation` reads as the publication point, which is exactly what made
the order look correct on review, and resting on `active` means the argument is no
longer local to the pool. Anything that later reads the pool outside the `active`
gate inherits a latent bug.

## What changed

The buffer pointer and count are written first and the generation released last, on
both the collecting and the `collect_records == false` early-return path, so the
generation store is the pass's single publication point and an acquiring producer
sees the storage by construction.

## Testing

- [x] `ctest -LE requires_hardware` — 108/108

No new test: this is a reordering of stores whose incorrect form is unobservable
without a memory-model checker, and the existing pool tests already cover the
publication contract's observable behaviour. The guarantee is stated in a comment
at the top of `arm()` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)