### PR TITLE
CI: run DeepSeek host smokes per PR

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -15,7 +15,8 @@ description: Testing guide and pre-commit testing strategy for simpler. Use when
 
 **Important**: Always read `.github/workflows/ci.yml` first for the current
 `--pto-session-timeout` values. Quarantines are marker-based, so mirror the
-a2a3 sweep with `-m "not sdma" --exclude-level 4` rather than copying a path
+a2a3 sweep with `-m "not sdma and not deepseek_host_smoke" --exclude-level 4`
+rather than copying a path
 list. PTO-ISA reproducibility comes from the repo-root `pto_isa.pin`.
 
 **CI does not run one flat sweep on a2a3.** Marked tests are quarantined out of
@@ -29,6 +30,7 @@ and will report failures that CI never sees:
 | ------ | ----- | ----------- |
 | `@pytest.mark.manual` / `CASES[*]["manual"]` | Standalone pytest tests / individual scene-test cases; optionally scoped to a platform list | Per-PR main sweep: excluded by default on the selected platforms; dedicated DFX steps: included; `daily.yml`: full sweep with `--manual include` |
 | `@pytest.mark.sdma` | a2a3: `sdma_async_completion_demo`, `prefetch_async_demo`; a5: `sdma_async_completion_demo` | a2a3: the dedicated SDMA step; a5: included in the non-network1 sweep |
+| `@pytest.mark.deepseek_host_smoke` | a2a3 DeepSeek host-preparation smokes for both runtimes | A fresh final pytest process inside the main scene-test device allocation |
 
 The a2a3 SDMA demos provision 48 device-only STARS streams, which makes an
 AICore fault take ~306 s to tear down instead of ~0.3 s — so they must not
@@ -74,7 +76,13 @@ pytest examples tests/st --platform a2a3sim \
 
 # All hardware scene tests — mirror ci.yml: deselect the quarantined marker, or
 # those tests fail here and nowhere else
-pytest examples tests/st -m "not sdma" --exclude-level 4 --platform a2a3 --device <range> \
+pytest examples tests/st -m "not sdma and not deepseek_host_smoke" \
+    --exclude-level 4 --platform a2a3 --device <range> \
+    --pto-session-timeout <timeout>
+
+# Final phase in the same device allocation, but a fresh pytest process.
+pytest examples tests/st -m deepseek_host_smoke \
+    --exclude-level 4 --platform a2a3 --device <range> \
     --pto-session-timeout <timeout>
 
 # The quarantined tests, the way CI runs them — same corpus, selected by the

--- a/.github/workflows/_st-npu-a2a3.yml
+++ b/.github/workflows/_st-npu-a2a3.yml
@@ -87,11 +87,34 @@ jobs:
       - name: Run pytest scene tests (a2a3)
         run: |
           source /usr/local/Ascend/cann/set_env.sh
+          SCENE_TEST_DRIVER="$RUNNER_TEMP/run-a2a3-scene-tests.sh"
+          trap 'rm -f "$SCENE_TEST_DRIVER"' EXIT
+          cat > "$SCENE_TEST_DRIVER" <<'SCENE_TEST_DRIVER'
+          set -euo pipefail
+          device_list=$1
+          manual_mode=$2
+
+          .venv/bin/python -m pytest examples tests/st \
+            -m "not sdma and not deepseek_host_smoke" \
+            --platform a2a3 --exclude-level 4 --device "$device_list" -v \
+            --require-pto-isa --pto-session-timeout 1200 --manual "$manual_mode"
+
+          if [[ "$manual_mode" != "only" ]]; then
+            echo "::group::DeepSeek host-preparation smokes"
+            deepseek_rc=0
+            .venv/bin/python -m pytest examples tests/st \
+              -m deepseek_host_smoke \
+              --platform a2a3 --exclude-level 4 --device "$device_list" -v \
+              --require-pto-isa --pto-session-timeout 1200 --manual "$manual_mode" || deepseek_rc=$?
+            echo "::endgroup::"
+            exit "$deepseek_rc"
+          fi
+          SCENE_TEST_DRIVER
           if [ "$(uname -m)" = "x86_64" ]; then
-            .venv/bin/python -m pytest examples tests/st -m "not sdma" --platform a2a3 --exclude-level 4 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 1200 --manual "$MANUAL_MODE"
+            bash "$SCENE_TEST_DRIVER" "$DEVICE_RANGE" "$MANUAL_MODE"
           else
             task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
-              --run ".venv/bin/python -m pytest examples tests/st -m 'not sdma' --platform a2a3 --exclude-level 4 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 1200 --manual '$MANUAL_MODE'"
+              --run "bash '$SCENE_TEST_DRIVER' \$TASK_DEVICE '$MANUAL_MODE'"
           fi
 
       - name: SDMA pytest (a2a3)

--- a/conftest.py
+++ b/conftest.py
@@ -492,6 +492,11 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
+        "deepseek_host_smoke: a2a3 DeepSeek host-preparation smoke run in the final pytest phase of the "
+        "main scene-test device allocation",
+    )
+    config.addinivalue_line(
+        "markers",
         "network1_remote_device_count(n): number of remote NPU devices needed on the peer machine",
     )
     config.addinivalue_line(

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -78,7 +78,7 @@ PullRequest
 | `st-sim-a2a3` | `ubuntu-latest`, `macos-latest` | `pytest examples tests/st --platform a2a3sim` |
 | `st-sim-a5` | `ubuntu-latest`, `macos-latest` | `pytest examples tests/st --platform a5sim` |
 | `ut-a2a3` | a2a3 self-hosted | `pytest tests/ut --platform a2a3` + `ctest -L "^requires_hardware(_a2a3)?$" --resource-spec-file ...` + build `tools/cann-examples/query` and run `query version` (no device) + build `tools/cann-examples/aicpu-device-query` and `tools/cann-examples/aicpu-kernel-launch` (host + cross-compiled device SO, link smoke only) |
-| `st-onboard-a2a3` | a2a3 self-hosted | `pytest examples tests/st -m "not sdma" --platform a2a3 --exclude-level 4 --device ...`, then a separate `-m sdma` step, then adaptive-parallel DFX feature smokes |
+| `st-onboard-a2a3` | a2a3 self-hosted | The main allocation runs `-m "not sdma and not deepseek_host_smoke"`, then `-m deepseek_host_smoke` in a fresh final pytest process; a separate `-m sdma` step and adaptive-parallel DFX feature smokes follow |
 | `ut-a5` | a5 self-hosted | `pytest tests/ut --platform a5` + build `tools/cann-examples/query` and run `query version` (no device) + build `tools/cann-examples/aicpu-device-query` and `tools/cann-examples/aicpu-kernel-launch` (link smoke only) |
 | `st-onboard-a5` | a5 self-hosted | `pytest examples tests/st --platform a5 --exclude-level 4 --device ...`, including SDMA tests, then adaptive-parallel DFX feature smokes |
 | `st-network1-onboard-a2a3` | a pair of `a2a3pod` machines | `pytest examples tests/st --level 4 --platform a2a3 --device ... --max-parallel 1`, one L3 daemon on the peer |
@@ -189,9 +189,10 @@ benefit — device bin-packing for L3, xdist fanout for L2, and a shared
 `ChipWorker` per `(runtime, device)`:
 
 ```bash
-# Recommended CI invocation — a2a3 deselects SDMA and network1 tests, as the job does,
-# and runs SDMA as a second pass afterwards
-pytest examples tests/st -m "not sdma" --platform a2a3 --exclude-level 4 --device 4-7 -x
+# Recommended CI invocation — a2a3 runs DeepSeek last in the main allocation,
+# then runs SDMA in a separate step
+pytest examples tests/st -m "not sdma and not deepseek_host_smoke" --platform a2a3 --exclude-level 4 --device 4-7 -x
+pytest examples tests/st -m deepseek_host_smoke --platform a2a3 --exclude-level 4 --device 4-7 -x
 pytest examples tests/st -m sdma --platform a2a3 --device 4-5 -x
 
 # A5 runners run the non-network1 corpus, including SDMA tests
@@ -274,7 +275,7 @@ not need `--max-parallel` manually.
 
   The arch flags subtract `NON_CODE` before deciding, so a non-code-only change already makes both `false`. An arch-gated job therefore needs no separate non-code check. See [`.claude/rules/ci-change-detection.md`](../.claude/rules/ci-change-detection.md) for the invariants these gates must keep.
 
-- **SDMA tests run as their own step inside `st-onboard-a2a3`.** The ordinary sweep deselects them with `-m "not sdma"` and `--exclude-level 4`, and a later step runs `-m sdma`. Ordering is what the two SDMA paths share: the SDMA step is always second, so no fault-injection case can land on a device that has already provisioned SDMA. Device acquisition differs by host arch — on aarch64 the SDMA step takes its own `task-submit --device auto --device-num 2`, so the two steps are disjoint in devices as well; on x86_64 there is no `task-submit` and both steps use the same `${DEVICE_RANGE}`, leaving ordering as the only separation. Provisioning the SDMA workspace creates device-only STARS streams that live in the device fault domain, so an AICore fault on a device that has provisioned SDMA costs minutes instead of milliseconds — the sweep's `aicore_op_timeout` fault injection must therefore never share a device with them ([#1425](https://github.com/hw-native-sys/simpler/issues/1425)). Selection for SDMA remains by marker on both sides, so the two cannot drift apart; the split can be dropped once #1425 is fixed. Network1 tests are selected by `--level 4` in `st-network1-onboard-a2a3` and explicitly excluded from ordinary onboard ST lanes.
+- **SDMA tests run as their own step inside `st-onboard-a2a3`.** The ordinary sweep deselects them (and the final-phase DeepSeek smokes) with `-m "not sdma and not deepseek_host_smoke"` and `--exclude-level 4`, and a later step runs `-m sdma`. Ordering is what the two SDMA paths share: the SDMA step is always second, so no fault-injection case can land on a device that has already provisioned SDMA. Device acquisition differs by host arch — on aarch64 the SDMA step takes its own `task-submit --device auto --device-num 2`, so the two steps are disjoint in devices as well; on x86_64 there is no `task-submit` and both steps use the same `${DEVICE_RANGE}`, leaving ordering as the only separation. Provisioning the SDMA workspace creates device-only STARS streams that live in the device fault domain, so an AICore fault on a device that has provisioned SDMA costs minutes instead of milliseconds — the sweep's `aicore_op_timeout` fault injection must therefore never share a device with them ([#1425](https://github.com/hw-native-sys/simpler/issues/1425)). Selection for SDMA remains by marker on both sides, so the two cannot drift apart; the split can be dropped once #1425 is fixed. Network1 tests are selected by `--level 4` in `st-network1-onboard-a2a3` and explicitly excluded from ordinary onboard ST lanes.
 
 ### CPU emergency lane (`ci-self-cpu.yml`) and the `/run-cpu` button
 
@@ -342,6 +343,12 @@ inside a large callable share that budget instead of multiplying it. Without an
 override the automatic budget reserves two logical CPUs and caps at eight. The
 sim jobs run on ephemeral GitHub-hosted runners with no restored cache, so they
 compile cold every time and get no warm-up step.
+
+The a2a3 main allocation runs the two DeepSeek host-preparation smokes last in
+a fresh pytest process. They still initialize devices and prepare both ranks,
+so they remain inside `task-submit`; placing them last avoids handing their
+devices straight back to ordinary scene-test workers, without acquiring a
+second allocation. SDMA and DFX retain their separate steps and allocations.
 
 The DFX smokes reuse the runner's device allocation after the main scene-test
 sweep. The `run-onboard-dfx-smokes` CI action distributes `dep_gen`, chip

--- a/docs/dfx/hbg-bind-measurement.md
+++ b/docs/dfx/hbg-bind-measurement.md
@@ -92,17 +92,16 @@ yourself:
 
 ```bash
 task-submit --device auto --device-num 2 --timeout 3600 --max-time 3600 --run \
-  "python examples/a2a3/host_build_graph/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py \
-     -p a2a3 --manual only --rounds 6 -d \$TASK_DEVICE \
+  "SIMPLER_SKIP_DEVICE_RUN=1 python examples/a2a3/host_build_graph/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py \
+     -p a2a3 --rounds 6 -d \$TASK_DEVICE \
      --case TestDeepseekV4FlashDecodeHostBuildGraph:: --runtime host_build_graph --level 3" | tee dsv4.log
 ```
 
 A 2-rank case emits one pass per rank per round, so six rounds is twelve passes.
 
-To measure the host path without device execution, set
-`SIMPLER_SKIP_DEVICE_RUN=1`, which returns at `simpler_launch_run`. It is a
-temporary handle from the dsv4 bring-up and is deleted once that case's device
-execution works. One property is load-bearing while it exists:
+The dsv4 command sets `SIMPLER_SKIP_DEVICE_RUN=1`, which returns at
+`simpler_launch_run` after prepare-time work and before device execution. One
+property is load-bearing:
 
 - **It is presence-based.** `SIMPLER_SKIP_DEVICE_RUN=0` still skips. `unset` it.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -46,12 +46,13 @@ ctest --test-dir tests/ut/cpp/build -L "^requires_hardware(_a2a3)?$" --output-on
 # Scene tests (pytest, @scene_test classes)
 pytest examples tests/st                          # all sim platforms (auto-parametrized)
 pytest examples tests/st --platform a2a3sim       # specific sim
-pytest examples tests/st -m "not sdma" --platform a2a3 --exclude-level 4          # hardware
-pytest examples tests/st -m "not sdma" --platform a2a3 --exclude-level 4 --device 4-7  # hardware with device pool
+pytest examples tests/st -m "not sdma and not deepseek_host_smoke" --platform a2a3 --exclude-level 4          # hardware
+pytest examples tests/st -m "not sdma and not deepseek_host_smoke" --platform a2a3 --exclude-level 4 --device 4-7  # hardware with device pool
+pytest examples tests/st -m deepseek_host_smoke --platform a2a3 --exclude-level 4 --device 4-7  # final phase, same allocation
 
 # Compile the selected hardware batch without creating a Worker or using an NPU
 python -m simpler_setup.tools.scene_test_compile examples tests/st \
-    -m "not sdma" --platform a2a3 --exclude-level 4 --require-pto-isa --compile-workers 8
+    --platform a2a3 --exclude-level 4 --require-pto-isa --compile-workers 8
 
 # SDMA cases run separately, as they do in CI: they are quarantined by
 # @pytest.mark.sdma so no fault-injection case shares a device with a
@@ -680,8 +681,9 @@ pytest examples tests/st --platform a2a3sim
 # Standalone (single case)
 python test_my_kernel.py -p a2a3sim
 
-# On hardware (SDMA cases quarantined by marker; run them with -m sdma)
-pytest examples tests/st -m "not sdma" --platform a2a3 --exclude-level 4
+# On hardware (run DeepSeek last in the same allocation; SDMA remains separate)
+pytest examples tests/st -m "not sdma and not deepseek_host_smoke" --platform a2a3 --exclude-level 4
+pytest examples tests/st -m deepseek_host_smoke --platform a2a3 --exclude-level 4
 ```
 
 Key fields:

--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/README.md
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/README.md
@@ -7,8 +7,9 @@ comm-window protocol. Only the runtime changes — HBG compiles the orchestratio
 with the host `g++`, runs it on the host CPU instead of the AICPU, and ships the
 built shared-memory image to the device, which then boots scheduler-only.
 
-The case exists to measure **host-side graph construction** and to prove the
-device can execute what the host built. It is deliberately not a numerics test.
+The case exists to measure **host-side graph construction and prepare**. The
+Per-PR smoke does not launch the device body and is deliberately not a numerics
+test.
 
 ## What differs from the TMR case
 
@@ -119,16 +120,17 @@ This gap is independent of the `hc_head_linear` MTE fault:
 
 ```bash
 # standalone (2 dies; wrap in task-submit on a shared box)
-python examples/a2a3/host_build_graph/deepseek_v4_flash_decode/\
-test_deepseek_v4_flash_decode.py -p a2a3 -d <d0>,<d1> --manual only
+SIMPLER_SKIP_DEVICE_RUN=1 python examples/a2a3/host_build_graph/\
+deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py -p a2a3 -d <d0>,<d1>
 
 # pytest
 pytest examples/a2a3/host_build_graph/deepseek_v4_flash_decode \
-    --platform a2a3 --device <d0>,<d1> --manual only
+    --platform a2a3 --device <d0>,<d1>
 ```
 
-`manual` because the 368-kernel compile takes minutes; `skip_golden` because the
-routing is stood in, not computed.
+In Per-PR CI, the case runs in a fresh final pytest process inside the main
+scene-test device allocation. It remains `skip_golden` because no full-network
+torch reference exists upstream.
 
 To exercise only the host side without launching the device body, set
 `SIMPLER_SKIP_DEVICE_RUN=1`. `simpler_launch_run` then completes the run before

--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
@@ -25,22 +25,23 @@ factors travel as kernel tensor inputs read from GM, so the host never writes a
 GM-heap device address and never copies tensor data into task scalars. The
 orchestration source is therefore the TMR one recast as a Graph, with no
 runtime-specific rewrite. ``skip_golden`` is inherited from the TMR case, which
-is itself a completion/smoke case; ``manual`` because the 368-kernel compile
-takes minutes.
+is itself a completion/smoke case.
 
 Host construction and Graph recording complete (129 host submissions). An
 unskipped device run is currently blocked in Graph activation, so the recorded
 bodies never replay. See README.md for the measurements and the remaining
 Graph-runtime limitation.
 
-    python examples/a2a3/host_build_graph/deepseek_v4_flash_decode/\\
-test_deepseek_v4_flash_decode.py -p a2a3 -d <d0>,<d1> --manual only
+    SIMPLER_SKIP_DEVICE_RUN=1 python examples/a2a3/host_build_graph/\
+deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py -p a2a3 -d <d0>,<d1>
 """
 
 import copy
 import importlib.util
 import sys
 from pathlib import Path
+
+import pytest
 
 from simpler_setup import SceneTestCase, scene_test
 from simpler_setup.goldens.deepseek_v4_flash_decode import N_RANKS, generate_inputs
@@ -63,6 +64,11 @@ def _load_tmr_case():
 _TMR = _load_tmr_case()
 
 
+@pytest.fixture(autouse=True)
+def _skip_device_execution(monkeypatch) -> None:
+    monkeypatch.setenv("SIMPLER_SKIP_DEVICE_RUN", "1")
+
+
 def _host_build_graph_callable():
     """Same CALLABLE as the TMR case, with kernel sources re-pointed at the TMR dir
     and the orchestration swapped for the Graph-form variant.
@@ -83,7 +89,8 @@ def _host_build_graph_callable():
     initialization kernels under both runtimes.
 
     The case is ``skip_golden`` because the TMR case it is derived from is: it
-    measures host-side graph construction and device execution, not numerics.
+    measures host-side graph construction and prepare, not numerics or device
+    execution.
     """
     callable_config = copy.deepcopy(_TMR.TestDeepseekV4FlashDecode.CALLABLE)
     chip = callable_config["callables"][0]
@@ -93,6 +100,7 @@ def _host_build_graph_callable():
     return callable_config
 
 
+@pytest.mark.deepseek_host_smoke
 @scene_test(level=3, runtime="host_build_graph")
 class TestDeepseekV4FlashDecodeHostBuildGraph(SceneTestCase):
     """DSv4 FLASH EP2/TP2 decode with the orchestration built on the host."""
@@ -102,7 +110,6 @@ class TestDeepseekV4FlashDecodeHostBuildGraph(SceneTestCase):
         {
             "name": "DecodeFwdEP2TP2",
             "platforms": ["a2a3"],
-            "manual": True,
             "skip_golden": True,
             "config": {
                 "device_count": N_RANKS,

--- a/examples/a2a3/tensormap_and_ringbuffer/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/README.md
@@ -31,7 +31,7 @@ For the `Worker` API underneath the framework, see
 | [`paged_attention_ringbuffer/`](paged_attention_ringbuffer/) | Deliberately undersized rings, driven per case through `config.runtime_env` (`ring_task_window` / `ring_heap` / `ring_dep_pool`) rather than process-global env. A stress test for rotation and reclamation. |
 | [`merge_pipeline_barrier/`](merge_pipeline_barrier/) | Three pipeline stages merged into **one** `block_num=8` SPMD task, ordered by an intra-task cross-core barrier instead of by three scheduled tasks. |
 | [`qwen3_14b_decode/`](qwen3_14b_decode/README.md) | The whole Qwen3-14B 40-layer decode stack as a single fused dispatch, using CANN fused attention. The largest example in the repo. |
-| [`deepseek_v4_flash_decode/`](deepseek_v4_flash_decode/README.md) | The whole DeepSeek-V4 FLASH 43-layer decode network on **2 dies** (EP2 expert-parallel MoE + TP2 LM head through a comm domain). The first pypto-harvested distributed network; `manual` + `skip_golden` (completion smoke, like upstream). |
+| [`deepseek_v4_flash_decode/`](deepseek_v4_flash_decode/README.md) | The whole DeepSeek-V4 FLASH 43-layer decode network on **2 dies** (EP2 expert-parallel MoE + TP2 LM head through a comm domain). The first pypto-harvested distributed network; Per-PR host-preparation smoke with `skip_golden` and no device launch. |
 
 ## Asynchronous completion and cross-card transfer
 

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/README.md
@@ -27,17 +27,17 @@ comm-window views, 1 shared counts vector) plus 13 scalars (rank id + 12
 
 ## Validation semantics
 
-The case is `skip_golden`: it is a completion/smoke test. Upstream pypto-lib
-drives the same fixture with `golden_fn=None` — a full-network torch reference
-does not exist there either; numeric coverage lives with the standalone kernel
-harnesses in pypto-lib (`models/deepseek_v4_flash_mtp/*.py`), and real-weight
-end-to-end accuracy lives in pypto-serving. What this case pins down in simpler
-CI terms: the harvested distributed program compiles, both ranks' graphs
-dispatch, the cross-die window protocol (TPUT/TNOTIFY arrivals, LM-head
-all-gather) drains, and the run terminates cleanly.
-
-It is marked `manual`: compiling 368 incore kernels plus the 7.8k-line chip
-orchestration takes several minutes, so it does not run in the default sweep.
+The case is `skip_golden`: it is a host-preparation smoke test. Upstream
+pypto-lib drives the same fixture with `golden_fn=None` — a full-network torch
+reference does not exist there either; numeric coverage lives with the
+standalone kernel harnesses in pypto-lib
+(`models/deepseek_v4_flash_mtp/*.py`), and real-weight end-to-end accuracy lives
+in pypto-serving. In simpler's Per-PR CI, the harvested distributed program and
+its 368 incore kernels compile, the two-rank run is prepared, and prepare-time
+H2D completes. The device body is not launched, so the case does not validate
+kernel execution, cross-die communication, outputs, or numerical correctness.
+Both DeepSeek runtimes run in a fresh final pytest process inside the main
+scene-test device allocation.
 
 The six buffer initializations formerly expressed as orchestration-side
 `set_initial_value(0)` calls now run on device. Each of the five
@@ -106,13 +106,19 @@ line constants").
 
 ```bash
 # standalone (2 dies; wrap in task-submit on a shared box)
-python examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py \
-    -p a2a3 -d <d0>,<d1> --manual only
+SIMPLER_SKIP_DEVICE_RUN=1 python examples/a2a3/tensormap_and_ringbuffer/\
+deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py \
+    -p a2a3 -d <d0>,<d1>
 
 # pytest
 pytest examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode \
-    --platform a2a3 --device <d0>,<d1> --manual only
+    --platform a2a3 --device <d0>,<d1>
 ```
+
+The pytest module sets `SIMPLER_SKIP_DEVICE_RUN=1` before worker
+initialization. `simpler_launch_run` completes the prepared run before any
+execution claim or device launch, and finalization still releases its
+resources. No outputs are produced.
 
 The fixture materializes on the order of 100 GiB of host tensors (weights for
 both ranks); the machine needs the RAM headroom, and generation takes a few

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
@@ -21,23 +21,24 @@ Regime (fixed at harvest time): batch 4 x 2 token rows per rank (T=8),
 start_pos 8192, paged KV in 128-token blocks, W8A8 INT8 experts, 64 routed
 experts global / 32 per rank at EP2, top-6 + 1 shared.
 
-This is a completion/smoke case (``skip_golden``): upstream pypto-lib runs the
-same fixture with ``golden_fn=None`` (component-level golden checks live with
-the standalone kernels there); a full-network torch reference does not exist
-in either repo. The case validates that the harvested distributed program —
-368 incore kernels plus a 7.8k-line chip orchestration per rank — compiles,
-dispatches across both dies, drives the comm-window protocol to completion,
-and terminates cleanly.
+This is a host-preparation smoke case (``skip_golden``): upstream pypto-lib
+runs the same fixture with ``golden_fn=None`` (component-level golden checks
+live with the standalone kernels there); a full-network torch reference does
+not exist in either repo. The harvested distributed program — 368 incore
+kernels plus a 7.8k-line chip orchestration per rank — is compiled and prepared
+for both dies, but the device body is not launched and no outputs are produced.
 
-The case is marked ``manual`` (compiling 368 kernels takes several minutes);
-run it explicitly:
+In Per-PR CI, the case runs in a fresh final pytest process inside the main
+scene-test device allocation. The standalone command sets the same host-only
+execution boundary as pytest:
 
-    python examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/\
-test_deepseek_v4_flash_decode.py -p a2a3 -d <d0>,<d1> --manual only
+    SIMPLER_SKIP_DEVICE_RUN=1 python examples/a2a3/tensormap_and_ringbuffer/\
+deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py -p a2a3 -d <d0>,<d1>
 
 See README.md for provenance pins and the regeneration recipe.
 """
 
+import pytest
 from simpler.task_interface import ArgDirection as D
 from simpler.task_interface import CommBufferSpec, DataType, TaskArgs, TensorArgType
 
@@ -46,6 +47,11 @@ from simpler_setup.goldens.deepseek_v4_flash_decode import N_RANKS, generate_inp
 from simpler_setup.scene_test import _rehosted_ref
 
 _DIRS = {"i": D.IN, "o": D.OUT, "x": D.INOUT}
+
+
+@pytest.fixture(autouse=True)
+def _skip_device_execution(monkeypatch) -> None:
+    monkeypatch.setenv("SIMPLER_SKIP_DEVICE_RUN", "1")
 
 
 def _sig(encoded):
@@ -580,6 +586,7 @@ def _decode_fwd_orch_fn(orch, callables, task_args, config):
             orch.submit_next_level(callables.decode_fwd, args, config, worker=rank)
 
 
+@pytest.mark.deepseek_host_smoke
 @scene_test(level=3, runtime="tensormap_and_ringbuffer")
 class TestDeepseekV4FlashDecode(SceneTestCase):
     CALLABLE = {
@@ -609,7 +616,6 @@ class TestDeepseekV4FlashDecode(SceneTestCase):
         {
             "name": "DecodeFwdEP2TP2",
             "platforms": ["a2a3"],
-            "manual": True,
             "skip_golden": True,
             "config": {
                 "device_count": N_RANKS,

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -805,13 +805,9 @@ int simpler_prepare_run(
 int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     OnboardNativeRunContext *state = native_run_context(ctx, runtime, "simpler_launch_run");
     if (state == nullptr || state->phase.load(std::memory_order_acquire) != NativeRunPhase::Prepared) return -1;
-    // TEMPORARY (host_build_graph dsv4 bring-up): stop after prepare so the host
-    // side — orchestration, graph construction, image relocation and H2D — can be
-    // measured while the device execution of that graph still stalls. Sitting in
-    // launch (not simpler_run) covers the split prepare/launch/wait entry points
-    // the chip subprocess uses, which never call simpler_run. Outputs are never
-    // produced, so any run under this variable is a timing harness, not a test.
-    // Delete this together with the variable once the stall is diagnosed.
+    // A skipped run completes after prepare-time orchestration, relocation and
+    // H2D. It never claims the runner or produces outputs because no device body
+    // is launched.
     if (std::getenv("SIMPLER_SKIP_DEVICE_RUN") != nullptr) {
         // The host phase records describe the bind path this variable exists to
         // measure, so they are written here as well as in the device-run


### PR DESCRIPTION
## Summary

- Add both A2A3 DeepSeek HBG and TMR cases to the default Per-PR scene-test collection.
- Set `SIMPLER_SKIP_DEVICE_RUN` before worker initialization so prepare-time orchestration, relocation, and H2D run without claiming the runner or launching the device body.
- Update the case and HBG measurement docs for the non-manual, host-only validation boundary.

## Testing

- [x] Per-PR-equivalent `pytest --collect-only` selected both DeepSeek cases under `--platform a2a3 --manual exclude` (inside `task-submit`).
- [x] Touched-files pre-commit suite passed: headers, English-only, platform literals, whitespace, clang-format, clang-tidy, cpplint, markdownlint, Ruff, and Pyright.
- [ ] Full 368-kernel two-die scene execution was not run locally; the cases intentionally stop before device launch.