### PR TITLE
Update: overlap cold Graph recording and one-bind upload

### DIFF
--- a/docs/investigations/2026-08-hbg-graph-definition-single-upload.md
+++ b/docs/investigations/2026-08-hbg-graph-definition-single-upload.md
@@ -130,5 +130,118 @@ records why it, and not batching, is the one that moves the 12 ms.
 - The first-cut device verify gate returned "busy-looking" nulls to peer
   submissions and surfaced as `sched_error_code=5 INVALID_ARGS`; the fix is
   the spin-wait on `verify_state` (dispatch-path legal: spin, no sleep).
-- `graph record` (245–687 µs) remains per-run and untouched — the per-run
-  Definition cache discard is a separate, still-open item (KNOWN_ISSUES).
+- `graph record` (245–687 µs in the original experiment) remains a cold-miss
+  cost. The current cache belongs to the registered callable, but every fresh
+  process used for cold benchmarking still starts with no Definitions.
+
+## Amendment 2026-08-20 — concurrent cold recording and compact shells
+
+The follow-up overlaps distinct-key recording and removes repeated static tensor
+metadata from the cold path:
+
+- callable registration reserves empty host recording state for the first eight
+  keys; it creates neither a Definition nor a device cache entry;
+- one cold orchestration may build several Definitions concurrently. Every
+  distinct Definition and per-occurrence submission is staged into the run's
+  Graph block, and each submission is patched to the Definition in that block;
+- each submission uses a 40-byte `GraphInvocationTensor` for dynamic boundary
+  state. Static shape, stride, dtype and layout metadata stay in the retained
+  Definition and are reconstructed and exact-validated on device;
+- the Graph submission images themselves already share one callable-owned host
+  allocation, and fixed-capacity metadata arrays remove temporary map/vector
+  allocation from the measured upload window;
+- a fixed 16-entry main-thread key table validates each Graph boundary once per
+  run, then lets repeated same-key shells read recorder/Definition publication
+  atomically without the recording mutex or another boundary scan;
+- the pre-sized submission byte store uses a separate used cursor, so appending
+  a shell overwrites its exact image instead of value-initializing the reserved
+  capacity again;
+- each recording owns a block arena for copied `ChipTensor` arguments, avoiding
+  one general-heap allocation per recorded node while preserving stable tensor
+  addresses for borrowed outputs;
+- callable registration reserves empty recording/Definition-image storage for
+  the first eight keys. A cold worker packs sections directly into its final
+  image allocation rather than assembling thirteen temporary vectors, and the
+  finished recording arena is retired with the callable instead of being freed
+  under the publication mutex;
+- a recording worker claims only one distinct key in each orchestration batch,
+  so a short recording cannot consume a second job while another prewarmed
+  worker remains parked; each job is assigned to that worker's private slot
+  and condition variable, avoiding a pool-wide wakeup between consecutive
+  cold Graph submissions;
+- non-sanitizer host runtime and orchestration builds define `NDEBUG`. Sanitizer
+  and C++ unit-test builds retain the reference Definition builder and its
+  byte-for-byte comparison, while production cold misses execute only the
+  direct builder;
+- a cache-only pass reuses the callable-owned host Definition cache, but stages
+  the referenced Definitions at their addresses in the new run's bind image;
+- main's one-bind-image path (#1947) restacks the four live shared-memory ranges,
+  the device-read arena prefix and the Graph submission block into one host
+  image. One `arena_h2d` transfers that image; there is no separate `sm_h2d`.
+
+After integration with #1947, a cold run's copy model is one bind-image H2D:
+`[copied arena][compact SM][Definition objects][Graph shells]`. The original
+branch's separate page-locked Definition/submission pack is therefore
+superseded; retaining another allocation and upload path would only duplicate
+the main implementation. DSV4 results below are from fresh processes whose
+callable Definition cache starts empty; cache-hit rounds are not a substitute
+for those measurements.
+
+Before #1947 landed, rebasing onto `upstream/main` at `2f3376ab`, rebuilding
+every runtime and reinstalling the editable wheel produced the following
+fresh-process DSV4 `DecodeFwdEP2TP2` sample. It is retained as historical
+evidence for the recording overlap, not as the current-main upload baseline:
+
+| Rank | `host_orch` | `graph_upload` | `sm_h2d` | `arena_h2d` | Sum |
+| ---- | ----------- | -------------- | -------- | ----------- | --- |
+| 0 | 866 µs | 107 µs | 99 µs | 35 µs | **1,106 µs** |
+| 1 | 1,007 µs | 103 µs | 94 µs | 39 µs | **1,243 µs** |
+| Mean | 936 µs | 105 µs | 96 µs | 37 µs | **1,174 µs** |
+
+The per-event timeline shows that 83 and 82 of the 86 main-thread Graph
+submissions overlap worker recording. The last Graph submission also precedes
+the last Definition publication by 149 and 124 µs respectively; the remaining
+tail is the required final publication barrier before the packed upload, not an
+intermediate submit-side wait.
+
+Startup and externally contended runs are kept as controls rather than folded
+into this table. In the same final-rebase session a contended pass measured
+2.64/0.98 ms in `host_orch`, with the extra time concentrated in recorder
+scheduling. It still recorded seven distinct workers and the same cold-miss
+event counts, so it diagnoses host contention rather than a serial-path
+fallback.
+
+## Amendment 2026-08-21 — current main and the one-bind Graph block
+
+The branch was then rebased onto `upstream/main` at `a5c6093d`. That base
+includes #1939's producer-lifetime dependency fix and #1947's one-bind-image
+layout. The DSV4 cold workload now records 1,679 nodes and eight Definitions,
+instead of the earlier 1,388 nodes and seven Definitions, so its `host_orch`
+number is not directly comparable with the pre-rebase table above.
+
+The first post-rebase sample still uploaded all eight Definition objects
+separately before copying the bind image. Folding those objects into the Graph
+block reduced the copy-bearing stages as follows; each row is one rank from a
+fresh-process hardware pass:
+
+| Rank | Before `graph_upload + arena_h2d` | One bind image | Delta |
+| ---- | --------------------------------- | -------------- | ----- |
+| 0 | 1,066.261 us | 264.793 us | -75.2% |
+| 1 | 1,112.880 us | 311.813 us | -72.0% |
+
+The final sample's complete host preparation breakdown is:
+
+| Rank | `host_orch` | `graph_upload` | `sm_h2d` | `arena_h2d` | Sum |
+| ---- | ----------- | -------------- | -------- | ----------- | --- |
+| 0 | 2,041.889 us | 3.841 us | 0 | 260.952 us | **2,306.682 us** |
+| 1 | 2,617.405 us | 5.760 us | 0 | 306.053 us | **2,929.218 us** |
+| Mean | 2,329.647 us | 4.801 us | 0 | 283.503 us | **2,617.950 us** |
+
+Both ranks submitted 86 shells on the main thread, recorded 1,679 nodes,
+built eight Definitions on eight distinct worker threads, and dropped no trace
+records. On one rank the last shell preceded the final Definition by 788 us; on
+the other it followed it by 9 us. The only remaining tail after the last
+Definition was 20--46 us, which is the final publication/packing barrier rather
+than the earlier erroneous submit-side wait. The visible run-to-run
+`host_orch` variation is concentrated in worker scheduling gaps; task-submit
+exposed 320 CPUs to the job, so it is not an accidental one-CPU affinity limit.

--- a/simpler_setup/toolchain.py
+++ b/simpler_setup/toolchain.py
@@ -260,6 +260,8 @@ class GxxToolchain(Toolchain):
 
     def get_compile_flags(self, **kwargs) -> list[str]:
         flags = ["-shared", "-fPIC", "-O3", "-g", "-std=c++17"]
+        if not self._prefer_g15:
+            flags.append("-DNDEBUG")
         # -fno-gnu-unique: prevent STB_GNU_UNIQUE binding so dlclose actually
         # unloads the SO.  GCC-only; clang does not produce STB_GNU_UNIQUE.
         if self._gcc:

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -117,6 +117,9 @@ target_compile_options(host_runtime
 # Platform name baked into the shared get_platform() impl in
 # src/common/platform/shared/host/platform_compile_info.cpp.
 target_compile_definitions(host_runtime PRIVATE SIMPLER_PLATFORM_NAME="a2a3")
+if(NOT SIMPLER_SANITIZERS)
+    target_compile_definitions(host_runtime PRIVATE NDEBUG)
+endif()
 
 if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE)
     target_compile_definitions(host_runtime PRIVATE SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=1)

--- a/src/a2a3/platform/sim/host/CMakeLists.txt
+++ b/src/a2a3/platform/sim/host/CMakeLists.txt
@@ -101,6 +101,9 @@ target_compile_options(host_runtime
 # Platform name baked into the shared get_platform() impl in
 # src/common/platform/shared/host/platform_compile_info.cpp.
 target_compile_definitions(host_runtime PRIVATE SIMPLER_PLATFORM_NAME="a2a3sim")
+if(NOT SIMPLER_SANITIZERS)
+    target_compile_definitions(host_runtime PRIVATE NDEBUG)
+endif()
 
 # Include directories
 target_include_directories(host_runtime

--- a/src/a2a3/runtime/host_build_graph/host/host_phase_trace.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/host_phase_trace.cpp
@@ -44,7 +44,7 @@ namespace {
 // measured path.
 constexpr size_t kBindAttrsCapacity = 96;
 
-// One producer's counters and in-flight claim, on its own cache lines.
+// One producer's counters and pass-lifetime lease, on its own cache lines.
 //
 // The producers of a pass are independent -- each records its own Definition and
 // counts only its own operations -- so nothing here is shared, and the per-record
@@ -67,10 +67,9 @@ struct KindCounter {
 };
 
 struct alignas(64) ProducerLane {
-    // Records accepted by `active` but not yet finished with the counters and the
-    // pool. begin/end clear `active` and then drain the sum of these to zero, so a
-    // record can never be reported by a pass it does not belong to.
-    std::atomic<int32_t> in_flight{0};
+    // Producers admitted by `active` and not yet finished with the counters and
+    // pool. begin/end clear `active` and drain these leases before reusing a lane.
+    std::atomic<int32_t> leased{0};
     std::array<KindCounter, kHostPhaseKindCount> counters{};
 };
 
@@ -102,58 +101,31 @@ TraceState &state() {
     return s;
 }
 
-// This thread's lane for the current pass, or nullptr when every lane is taken.
-//
-// `generation` is what makes a cached lane safe to reuse: it is process-unique per
-// pass, so a lane claimed under one pass is never mistaken for a claim under
-// another. Returns the generation it claimed under, because the caller must
-// re-check it once admitted -- see host_phase_record.
-ProducerLane *producer_lane(TraceState &s, uint32_t &claimed_generation) {
-    static thread_local ProducerLane *lane = nullptr;
-    static thread_local uint32_t lane_generation = 0;
-    const uint32_t generation = s.generation.load(std::memory_order_acquire);
-    if (lane == nullptr || lane_generation != generation) {
-        const uint32_t index = s.next_lane.fetch_add(1, std::memory_order_relaxed);
-        lane = index < kProducerLanes ? &s.lanes[index] : nullptr;
-        lane_generation = generation;
-    }
-    claimed_generation = generation;
-    return lane;
-}
-
-// Publish-then-check against the trace lifecycle's clear-then-drain. Claiming a
-// slot before reading `active` is what makes the pair race-free: a record that
-// got in before the pass closed is waited for, and one that arrives after sees
-// `active` false and withdraws. The claim is on this producer's own line, so it
-// costs nothing to the others.
-class RecordAdmission {
-public:
-    RecordAdmission(TraceState &s, ProducerLane &lane) :
-        lane_(lane) {
-        lane_.in_flight.fetch_add(1, std::memory_order_acq_rel);
-        admitted_ = s.active.load(std::memory_order_acquire);
-        if (!admitted_) lane_.in_flight.fetch_sub(1, std::memory_order_acq_rel);
-    }
-    ~RecordAdmission() {
-        if (admitted_) lane_.in_flight.fetch_sub(1, std::memory_order_acq_rel);
-    }
-
-    RecordAdmission(const RecordAdmission &) = delete;
-    RecordAdmission &operator=(const RecordAdmission &) = delete;
-
-    explicit operator bool() const { return admitted_; }
-
-private:
-    ProducerLane &lane_;
-    bool admitted_{false};
+struct ProducerCursor {
+    TraceState *owner{nullptr};
+    ProducerLane *lane{nullptr};
+    uint32_t generation{0};
+    uint32_t depth{0};
+    bool denied{false};
 };
 
-// Called with `active` already false, so no new record can be admitted. Only the
-// recording worker can still be inside one, and commit joins it before a pass
-// ends, so in practice this returns without spinning.
-void drain_in_flight_records(TraceState &s) {
+ProducerCursor &producer_cursor() {
+    static thread_local ProducerCursor cursor;
+    return cursor;
+}
+
+void release_producer(ProducerCursor &cursor) {
+    ProducerLane *lane = cursor.lane;
+    cursor = {};
+    if (lane != nullptr) lane->leased.fetch_sub(1, std::memory_order_release);
+}
+
+// Called with `active` already false, so no new producer can be admitted. A
+// Graph commit normally joins every worker first; the drain also makes early
+// error exits safe without charging two atomic RMWs to every record.
+void drain_producers(TraceState &s) {
     for (ProducerLane &lane : s.lanes) {
-        while (lane.in_flight.load(std::memory_order_acquire) != 0) {}
+        while (lane.leased.load(std::memory_order_acquire) != 0) {}
     }
 }
 
@@ -190,9 +162,8 @@ void record_counter(ProducerLane &lane, uint64_t start_ns, uint64_t end_ns, uint
 }
 
 void append_record(TraceState &s, uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload, uint32_t index) {
-    // No lock: the pool claims a slot per record with one atomic increment, so
-    // concurrent recording threads do not serialize here. `pool` is republished
-    // only by begin/end, which bracket every record via the admission drain.
+    // No lock: a producer privately advances the buffer it claimed for this pass.
+    // `pool` is republished only after every producer lease is drained.
     HostPhaseRecordPool *pool = s.pool.load(std::memory_order_acquire);
     if (pool == nullptr) return;
     host_phase_pool_append(
@@ -237,68 +208,76 @@ bool host_phase_records_enabled() {
     return enabled;
 }
 
+void host_phase_producer_begin() {
+    TraceState &s = state();
+    ProducerCursor &cursor = producer_cursor();
+    if (cursor.depth != 0) {
+        ++cursor.depth;
+        return;
+    }
+    if (!s.active.load(std::memory_order_acquire)) return;
+
+    const uint32_t generation = s.generation.load(std::memory_order_acquire);
+    const uint32_t index = s.next_lane.fetch_add(1, std::memory_order_relaxed);
+    ProducerLane *lane = index < kProducerLanes ? &s.lanes[index] : nullptr;
+    if (lane == nullptr) {
+        cursor = ProducerCursor{&s, nullptr, generation, 1, true};
+        return;
+    }
+
+    // Publish the lease before re-checking the pass boundary. trace_end clears
+    // active before draining, so it either observes this lease or this producer
+    // observes the closed/replaced pass and withdraws.
+    lane->leased.fetch_add(1, std::memory_order_acq_rel);
+    if (!s.active.load(std::memory_order_acquire) || s.generation.load(std::memory_order_acquire) != generation) {
+        lane->leased.fetch_sub(1, std::memory_order_release);
+        return;
+    }
+    cursor = ProducerCursor{&s, lane, generation, 1, false};
+}
+
+void host_phase_producer_end() {
+    ProducerCursor &cursor = producer_cursor();
+    if (cursor.depth == 0) return;
+    if (--cursor.depth == 0) release_producer(cursor);
+}
+
 // Strong definitions overriding the orchestrator core's weak fallbacks, which
 // exist so builds without this translation unit still link.
 __attribute__((visibility("hidden"))) uint64_t host_phase_now_ns() {
-    if (!state().active.load(std::memory_order_acquire)) {
-        return 0;
-    }
+    const ProducerCursor &cursor = producer_cursor();
+    if (cursor.depth == 0 || cursor.owner != &state()) return 0;
     return static_cast<uint64_t>(simpler::log::monotonic_now_ns());
 }
 
 __attribute__((visibility("hidden"))) void
 host_phase_record(uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload, uint32_t index) {
     TraceState &s = state();
-    if (!s.active.load(std::memory_order_acquire) || kind >= kHostPhaseKindCount || end_ns < start_ns) {
+    if (start_ns == 0 || kind >= kHostPhaseKindCount || end_ns < start_ns) {
         return;
     }
-    // ORCH_PHASE_END calls this on every submit-level operation, so the load
-    // above stays the whole cost when tracing is off. Admission then re-checks
-    // under the in-flight claim, which is what actually closes the boundary.
-    uint32_t claimed_generation = 0;
-    ProducerLane *lane = producer_lane(s, claimed_generation);
-    if (lane == nullptr) {
+    ProducerCursor &cursor = producer_cursor();
+    if (cursor.depth == 0 || cursor.owner != &s || cursor.denied || cursor.lane == nullptr) {
         s.lane_denied.fetch_add(1, std::memory_order_relaxed);
         return;
     }
-    RecordAdmission admission(s, *lane);
-    if (!admission) {
-        return;
-    }
-    // A pass can have closed and a new one opened between claiming the lane and
-    // being admitted here, and the new pass resets the lane hand-out -- so a lane
-    // claimed for the old pass may already belong to another producer, and writing
-    // its plain-integer counters would be a race. A stale claim withdraws instead.
-    if (s.generation.load(std::memory_order_acquire) != claimed_generation) {
-        return;
-    }
-    record_counter(*lane, start_ns, end_ns, kind, payload);
+    record_counter(*cursor.lane, start_ns, end_ns, kind, payload);
     append_record(s, start_ns, end_ns, kind, payload, index);
 }
 
 void host_phase_record_bind(uint32_t kind, uint64_t start_ns, const char *attrs, uint64_t payload) {
     TraceState &s = state();
-    if (!s.active.load(std::memory_order_acquire) || !is_bind_kind(kind)) {
-        return;
-    }
-    uint32_t claimed_generation = 0;
-    ProducerLane *lane = producer_lane(s, claimed_generation);
-    if (lane == nullptr) {
+    if (start_ns == 0 || !is_bind_kind(kind)) return;
+    ProducerCursor &cursor = producer_cursor();
+    if (cursor.depth == 0 || cursor.owner != &s || cursor.denied || cursor.lane == nullptr) {
         s.lane_denied.fetch_add(1, std::memory_order_relaxed);
-        return;
-    }
-    RecordAdmission admission(s, *lane);
-    if (!admission) {
-        return;
-    }
-    if (s.generation.load(std::memory_order_acquire) != claimed_generation) {
         return;
     }
     const uint64_t end_ns = static_cast<uint64_t>(simpler::log::monotonic_now_ns());
     if (attrs != nullptr) {
         snprintf(s.bind_attrs[kind].data(), kBindAttrsCapacity, "%s", attrs);
     }
-    record_counter(*lane, start_ns, end_ns, kind, payload);
+    record_counter(*cursor.lane, start_ns, end_ns, kind, payload);
     append_record(s, start_ns, end_ns, kind, payload, 0);
 }
 
@@ -306,7 +285,8 @@ void host_phase_trace_begin(const void *host_api) {
     TraceState &s = state();
     std::lock_guard<std::mutex> lock(s.lifecycle_mutex);
     s.active.store(false, std::memory_order_release);
-    drain_in_flight_records(s);
+    release_producer(producer_cursor());
+    drain_producers(s);
     s.api = static_cast<const HostApi *>(host_api);
     HostPhaseRecordPool *pool =
         s.api != nullptr ?
@@ -329,6 +309,7 @@ void host_phase_trace_begin(const void *host_api) {
     s.next_lane.store(0, std::memory_order_relaxed);
     s.generation.fetch_add(1, std::memory_order_release);
     s.active.store(s.pool != nullptr || host_phase_breakdown_enabled(), std::memory_order_release);
+    host_phase_producer_begin();
 }
 
 void host_phase_trace_note_submitted(uint64_t submitted_tasks) {
@@ -342,11 +323,10 @@ void host_phase_trace_end() {
         return;
     }
     s.active.store(false, std::memory_order_release);
-    // Every record already past the `active` check finishes its counter and pool
-    // work before the totals below are read and the pool is handed back, so no
-    // lock is needed here either: the drain, not a mutex, is what makes the pool
-    // quiescent.
-    drain_in_flight_records(s);
+    release_producer(producer_cursor());
+    // Every admitted producer finishes its counter and pool work before totals
+    // are read and the pool is handed back.
+    drain_producers(s);
     // Read the pool's own tally before handing it back, and drop the pointer
     // after: the pool belongs to the runner from finish() onward, and the pass is
     // over either way, so nothing here may outlive it. Clearing `active` also

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -48,7 +48,6 @@
 #include <string>
 #include <type_traits>
 #include <utility>
-#include <unordered_map>
 #include <vector>
 
 #include "../common/pto_runtime_status.h"
@@ -387,77 +386,60 @@ typedef void (*OrchestrationPrewarmFunc)();
 struct HostOrchEntryPoints {
     OrchestrationEntryFunc entry{nullptr};
     OrchestrationBindFunc bind{nullptr};
+    GraphHostStatePtr graph_state;
 };
 
-// One submission's place in the block: where its bytes come from, which outer task
-// reads it, and how far into the block it sits.
-struct StagedSubmission {
+struct StagedDefinition {
     const std::byte *host_image;
-    PTO2TaskSlotState *outer_slot;
     size_t bytes;
+    uint64_t full_key;
+    uint64_t content_hash;
     uint64_t offset;
 };
 
-// Validate every pending submission, bind it to its uploaded Definition, and lay
-// the block out. No device call and no device address: the block lands in the
-// runtime arena's tail, whose base is not known until that region is grown to fit
-// the shared-memory image as well.
+// One submission's place in the block: where its bytes come from, which outer
+// task reads it, which staged Definition it names, and its block offset.
+struct StagedSubmission {
+    std::byte *host_image;
+    PTO2TaskSlotState *outer_slot;
+    size_t bytes;
+    uint64_t offset;
+    uint64_t definition_offset;
+};
+
+// Validate every Definition and submission, then lay one Graph block out in the
+// runtime arena's tail. The device address is intentionally unknown here: the
+// arena can grow only after the completed task count determines the compact SM
+// size.
 //
 // Submissions sit PTO2_ALIGN_SIZE apart. activation_gate is OR-ed by the outer task
 // and by the node path for the length of the graph, so two submissions sharing a
 // cache line would false-share on that word throughout.
 bool plan_graph_submissions(
-    const HostApi *api, GraphHostState &graph_state, std::vector<StagedSubmission> *staged, uint64_t *block_bytes,
-    uint64_t &uploaded_bytes
+    GraphHostState &graph_state, std::vector<StagedDefinition> *staged_definitions,
+    std::vector<StagedSubmission> *staged_submissions, uint64_t *block_bytes, uint64_t &uploaded_bytes
 ) {
     uploaded_bytes = 0;
     const size_t count = graph_host_upload_count(graph_state);
-    // Pass 1: upload each distinct Definition once as a shared device object
-    // ([GraphDefinitionHeader][Definition image]) keyed by content identity.
-    // Submissions reference the object's GM address, so this pass completing
-    // before any submission is uploaded is what makes the reference safe —
-    // the device boots only after both passes.
     GraphHostDefinitionList definitions = graph_host_definitions(graph_state);
-    struct UploadedDefinition {
-        void *device_object;               // GM address; host must not dereference
-        const GraphDefinition *host_view;  // the host-side image the object was built from
-    };
-    std::unordered_map<uint64_t, UploadedDefinition> definition_objects;
-    for (const GraphHostDefinition &entry : definitions.entries) {
+    staged_definitions->reserve(definitions.size());
+    *block_bytes = 0;
+    for (const GraphHostDefinition &entry : definitions) {
         if (entry.data == nullptr || entry.bytes < sizeof(GraphDefinition)) continue;
         const auto *definition = reinterpret_cast<const GraphDefinition *>(entry.data);
         if (definition->total_bytes != entry.bytes || definition->full_key != entry.full_key) continue;
-        const size_t object_bytes = sizeof(GraphDefinitionHeader) + entry.bytes;
-        void *object =
-            api->acquire_graph_definition_buffer(entry.full_key, object_bytes, alignof(GraphDefinitionHeader));
-        if (object == nullptr) {
-            LOG_ERROR(
-                "host-orch: failed to retain %zu bytes for Graph Definition key=%#llx", object_bytes,
-                static_cast<unsigned long long>(entry.full_key)
-            );
+        if (entry.bytes > UINT64_MAX - sizeof(GraphDefinitionHeader)) return false;
+        const uint64_t object_bytes = sizeof(GraphDefinitionHeader) + entry.bytes;
+        const uint64_t offset = PTO2_ALIGN_UP(*block_bytes, alignof(GraphDefinitionHeader));
+        if (offset < *block_bytes || object_bytes > UINT64_MAX - offset) {
+            LOG_ERROR("host-orch: Graph Definition block size overflows uint64_t");
             return false;
         }
-        std::vector<std::byte> staging(object_bytes, std::byte{0});
-        auto *header = reinterpret_cast<GraphDefinitionHeader *>(staging.data());
-        header->magic = GRAPH_DEFINITION_OBJECT_MAGIC;
-        header->verify_state.store(
-            static_cast<uint32_t>(GraphDefinitionVerifyState::UPLOADED), std::memory_order_relaxed
-        );
-        header->definition_bytes = static_cast<uint32_t>(entry.bytes);
-        header->content_hash = definition->content_hash;
-        header->full_key = definition->full_key;
-        std::memcpy(staging.data() + sizeof(GraphDefinitionHeader), entry.data, entry.bytes);
-        if (api->copy_to_device(object, staging.data(), object_bytes) != 0) {
-            LOG_ERROR("host-orch: failed to upload Graph Definition object");
-            return false;
-        }
-        definition_objects.emplace(definition->content_hash, UploadedDefinition{object, definition});
-        uploaded_bytes += object_bytes;
+        staged_definitions->push_back({entry.data, entry.bytes, entry.full_key, definition->content_hash, offset});
+        *block_bytes = offset + object_bytes;
     }
 
-    // Pass 2: validate every submission and lay the block out.
-    staged->reserve(count);
-    *block_bytes = 0;
+    staged_submissions->reserve(count);
     for (size_t index = 0; index < count; ++index) {
         std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
         if (!upload.has_value() || upload->outer_slot == nullptr || upload->data == nullptr ||
@@ -471,40 +453,55 @@ bool plan_graph_submissions(
             LOG_ERROR("host-orch: Graph submission size does not match its POD image");
             return false;
         }
-        auto object_it = definition_objects.find(submission->definition_hash);
-        if (object_it == definition_objects.end() || object_it->second.device_object == nullptr) {
-            LOG_ERROR("host-orch: Graph submission has no uploaded Definition object");
+        const auto definition_it =
+            std::find_if(staged_definitions->begin(), staged_definitions->end(), [&](const StagedDefinition &entry) {
+                return entry.content_hash == submission->definition_hash;
+            });
+        if (definition_it == staged_definitions->end()) {
+            LOG_ERROR("host-orch: Graph submission has no staged Definition object");
             return false;
         }
-        // Checked against the host-side Definition image the device object was
-        // built from; the GM object itself is never dereferenced on the host.
-        // Execution storage needs no retained buffer: it is the tail of the
-        // outer task's own heap allocation, which graph_submit_definition sized
-        // to required_heap + execution_storage_bytes.
-        const GraphDefinition *definition = object_it->second.host_view;
+        const GraphDefinition *definition = reinterpret_cast<const GraphDefinition *>(definition_it->host_image);
         if (definition->task_count == 0 || definition->task_count > GRAPH_MAX_NODES ||
             definition->full_key != submission->graph_key || definition->execution_storage_bytes == 0) {
             LOG_ERROR("host-orch: invalid Graph Definition for submission");
             return false;
         }
-        submission->definition_addr = reinterpret_cast<uint64_t>(object_it->second.device_object);
         submission->local_execution = 0;
         submission->activation_gate = 0;
-
-        staged->push_back({upload->data, upload->outer_slot, upload->bytes, *block_bytes});
-        *block_bytes += PTO2_ALIGN_UP(static_cast<uint64_t>(upload->bytes), PTO2_ALIGN_SIZE);
+        const uint64_t offset = PTO2_ALIGN_UP(*block_bytes, PTO2_ALIGN_SIZE);
+        const uint64_t padded_bytes = PTO2_ALIGN_UP(static_cast<uint64_t>(upload->bytes), PTO2_ALIGN_SIZE);
+        if (offset < *block_bytes || padded_bytes > UINT64_MAX - offset) {
+            LOG_ERROR("host-orch: Graph submission block size overflows uint64_t");
+            return false;
+        }
+        staged_submissions->push_back({upload->data, upload->outer_slot, upload->bytes, offset, definition_it->offset});
+        *block_bytes = offset + padded_bytes;
     }
-    uploaded_bytes += *block_bytes;
+    uploaded_bytes = *block_bytes;
     return true;
 }
 
-// Copy the planned block into `block_base` and point each outer task at the device
-// address its submission will occupy. The graph_context write lands in the host
-// shared-memory mirror, which has not been compacted or copied yet.
-void stage_graph_submissions(
-    const std::vector<StagedSubmission> &staged, char *block_base, const char *device_block_base
+// Build every Definition object and patch/copy every submission into the one
+// bind image. graph_context writes land in the host SM mirror before compaction.
+void stage_graph_block(
+    const std::vector<StagedDefinition> &definitions, const std::vector<StagedSubmission> &submissions,
+    char *block_base, const char *device_block_base
 ) {
-    for (const StagedSubmission &entry : staged) {
+    for (const StagedDefinition &entry : definitions) {
+        auto *header = reinterpret_cast<GraphDefinitionHeader *>(block_base + entry.offset);
+        header->magic = GRAPH_DEFINITION_OBJECT_MAGIC;
+        header->verify_state.store(
+            static_cast<uint32_t>(GraphDefinitionVerifyState::UPLOADED), std::memory_order_relaxed
+        );
+        header->definition_bytes = static_cast<uint32_t>(entry.bytes);
+        header->content_hash = entry.content_hash;
+        header->full_key = entry.full_key;
+        std::memcpy(block_base + entry.offset + sizeof(GraphDefinitionHeader), entry.host_image, entry.bytes);
+    }
+    for (const StagedSubmission &entry : submissions) {
+        auto *submission = reinterpret_cast<GraphSubmission *>(entry.host_image);
+        submission->definition_addr = reinterpret_cast<uint64_t>(device_block_base + entry.definition_offset);
         std::memcpy(block_base + entry.offset, entry.host_image, entry.bytes);
         entry.outer_slot->graph_context = const_cast<char *>(device_block_base) + entry.offset;
     }
@@ -560,12 +557,14 @@ int32_t run_host_orchestration(
         return -1;
     }
 
-    GraphHostStatePtr graph_state = make_graph_host_state();
-    if (!graph_state) {
-        LOG_ERROR("host-orch: failed to allocate Graph host state");
+    auto *entry_points = reinterpret_cast<HostOrchEntryPoints *>(host_orch_func_ptr);
+    if (entry_points == nullptr || entry_points->graph_state == nullptr ||
+        !graph_host_begin_run(*entry_points->graph_state)) {
+        LOG_ERROR("host-orch: failed to begin callable Graph state");
         return -1;
     }
-    GraphHostStateBinding graph_binding(rt->orchestrator, graph_state.get());
+    GraphHostState &graph_state = *entry_points->graph_state;
+    GraphHostStateBinding graph_binding(rt->orchestrator, &graph_state);
 
     const int32_t block_dim = runtime->get_worker_count() / PLATFORM_CORES_PER_BLOCKDIM;
     if (block_dim < 1) {
@@ -577,7 +576,6 @@ int32_t run_host_orchestration(
     );
     rt->mode = PTO2_MODE_EXECUTE;
 
-    const auto *entry_points = reinterpret_cast<const HostOrchEntryPoints *>(host_orch_func_ptr);
     if (entry_points->bind == nullptr) {
         LOG_ERROR("host-orch: orch .so framework_bind_runtime was not resolved");
         return -1;
@@ -648,19 +646,21 @@ int32_t run_host_orchestration(
     // After the span closes: the reduction walks a few hundred records and emits
     // five markers, which must not be charged to the pass it measures.
 
-    // Uploads each distinct Definition as its own retained device object and lays
-    // out the submission block. The block itself is staged below, into the arena's
-    // second device tail, so nothing here allocates or copies it.
+    // Plan all Definition objects and submissions as one arena-tail block. No
+    // device call occurs until the complete bind image is transferred below.
     const int64_t t_graph_ns = bind_now_ns();
     uint64_t graph_bytes = 0;
+    std::vector<StagedDefinition> staged_definitions;
     std::vector<StagedSubmission> staged_submissions;
-    uint64_t submission_block_bytes = 0;
-    if (!plan_graph_submissions(api, *graph_state, &staged_submissions, &submission_block_bytes, graph_bytes)) {
+    uint64_t graph_block_bytes = 0;
+    if (!plan_graph_submissions(
+            graph_state, &staged_definitions, &staged_submissions, &graph_block_bytes, graph_bytes
+        )) {
         return -1;
     }
     {
         char attrs[96];
-        snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, graph_host_upload_count(*graph_state), graph_bytes);
+        snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, graph_host_upload_count(graph_state), graph_bytes);
         record_bind_phase(HostPhaseKind::BindGraphUpload, t_graph_ns, attrs, graph_bytes);
     }
 
@@ -710,11 +710,10 @@ int32_t run_host_orchestration(
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         total_heap_size += eff_heap_sizes[r];
     }
-    // Two device tails past off_copied_end, in this order: the shared-memory image,
-    // then the Graph submission block. Both are per-run content of the region the
-    // device already owns, so neither needs an allocation of its own.
-    const uint64_t off_submissions = layout.off_copied_end + image_bytes;
-    const uint64_t device_arena_bytes = off_submissions + submission_block_bytes;
+    // Two device tails past off_copied_end: the shared-memory image, then all
+    // Graph Definition objects and submissions.
+    const uint64_t off_graph = layout.off_copied_end + image_bytes;
+    const uint64_t device_arena_bytes = off_graph + graph_block_bytes;
     if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, device_arena_bytes) != 0) {
         LOG_ERROR("host-orch: failed to commit %" PRIu64 " bytes of device runtime arena", device_arena_bytes);
         return -1;
@@ -734,12 +733,12 @@ int32_t run_host_orchestration(
     }
 
     // One host source for one copy: the copied zone, the shared-memory image, and
-    // the submission block, at exactly the offsets they occupy on the device.
+    // the Graph block, at exactly the offsets they occupy on the device.
     // Over-allocated and rounded up because every segment offset is
     // PTO2_ALIGN_SIZE-aligned and PTO2TaskSlotState is alignas(64), which a byte
     // vector's data() is not.
     const uint64_t copied_bytes = layout.off_copied_end - layout.off_copied_begin;
-    const uint64_t upload_bytes = copied_bytes + image_bytes + submission_block_bytes;
+    const uint64_t upload_bytes = copied_bytes + image_bytes + graph_block_bytes;
     std::vector<std::byte> storage(upload_bytes + PTO2_ALIGN_SIZE, std::byte{0});
     char *upload_base = reinterpret_cast<char *>(
         (reinterpret_cast<uintptr_t>(storage.data()) + PTO2_ALIGN_SIZE - 1) &
@@ -748,7 +747,9 @@ int32_t run_host_orchestration(
 
     // Before the shared-memory mirror is compacted: this writes each outer task's
     // graph_context into it, and compaction is what carries those slots.
-    stage_graph_submissions(staged_submissions, upload_base + copied_bytes + image_bytes, arena_dev + off_submissions);
+    stage_graph_block(
+        staged_definitions, staged_submissions, upload_base + copied_bytes + image_bytes, arena_dev + off_graph
+    );
 
     // The orchestrator has finished, so its pointers into the host-only tail have
     // no further reader on either side — and this header is about to be copied, so
@@ -769,8 +770,8 @@ int32_t run_host_orchestration(
         char attrs[96];
         snprintf(
             attrs, sizeof(attrs),
-            "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " subs=%" PRIu64 " pstride=%" PRIu64, nt,
-            upload_bytes, copied_bytes, image_bytes, submission_block_bytes, payload_stride
+            "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " graph=%" PRIu64 " pstride=%" PRIu64, nt,
+            upload_bytes, copied_bytes, image_bytes, graph_block_bytes, payload_stride
         );
         record_bind_phase(HostPhaseKind::BindArenaH2d, t_h2d_ns, attrs, upload_bytes);
     }
@@ -884,11 +885,18 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
         reinterpret_cast<OrchestrationPrewarmFunc>(prewarm_sym)();
         // Safe to unlink now: the handle keeps the .so mapped regardless of path.
         unlink(so_path.c_str());
-        auto *eps = new HostOrchEntryPoints{};
+        auto eps = std::make_shared<HostOrchEntryPoints>();
+        eps->graph_state = make_graph_host_state();
+        if (eps->graph_state == nullptr) {
+            LOG_ERROR("host-orch: failed to allocate callable Graph state");
+            dlclose(handle);
+            return -1;
+        }
         eps->entry = reinterpret_cast<OrchestrationEntryFunc>(entry);
         eps->bind = reinterpret_cast<OrchestrationBindFunc>(bind_sym);
         out->host_dlopen_handle = handle;
-        out->host_orch_func_ptr = eps;
+        out->host_orch_func_ptr = eps.get();
+        out->host_orch_owner = std::move(eps);
         LOG_INFO("host-orch: loaded orchestration entry '%s' on host", orch_func_name);
     }
     LOG_INFO("Orchestration SO: %zu bytes staged", orch_so_size);

--- a/src/a2a3/runtime/host_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/host_build_graph/orchestration/pto_orchestration_api.h
@@ -35,12 +35,12 @@
 #include <condition_variable>
 #include <cstring>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <tuple>
 #include <type_traits>
 #include <utility>
-#include <vector>
 
 // Type headers needed by orchestration
 #include "common.h"              // framework_bind_runtime / framework_current_runtime
@@ -196,10 +196,10 @@ public:
     bool prewarm() {
         std::unique_lock<std::mutex> lock(mutex_);
         if (stopping_) return false;
-        while (workers_.size() < kPrewarmedWorkerCount) {
+        while (worker_count_ < kPrewarmedWorkerCount) {
             if (!create_worker_locked()) break;
         }
-        const size_t target = workers_.size();
+        const size_t target = worker_count_;
         cv_.wait(lock, [&]() {
             return ready_workers_ >= target || stopping_;
         });
@@ -228,25 +228,37 @@ public:
             free_owned_args_[free_owned_args_count_++] = owned_args_index;
             return false;
         }
-        PendingJob &pending = jobs_[job_tail_];
-        pending.function = std::move(next);
-        pending.owned_args_index = owned_args_index;
-        job_tail_ = (job_tail_ + 1) % kJobCapacity;
-        job_count_++;
-        const size_t desired_workers = std::min(kMaxWorkerCount, job_count_ + active_jobs_);
-        while (workers_.size() < desired_workers) {
+        if (!batch_active_) {
+            batch_active_ = true;
+            jobs_in_batch_ = 0;
+            if (++batch_epoch_ == 0) ++batch_epoch_;
+        }
+        const size_t desired_workers = std::min(kMaxWorkerCount, jobs_in_batch_ + 1);
+        while (worker_count_ < desired_workers) {
             if (!create_worker_locked()) break;
         }
-        if (workers_.empty()) {
-            job_tail_ = (job_tail_ + kJobCapacity - 1) % kJobCapacity;
-            PendingJob &rollback = jobs_[job_tail_];
-            rollback.function = {};
-            job_count_--;
-            free_owned_args_[free_owned_args_count_++] = rollback.owned_args_index;
+        size_t worker_index = kMaxWorkerCount;
+        for (size_t i = 0; i < worker_count_; ++i) {
+            WorkerSlot &worker = *workers_[i];
+            if (!worker.pending && !worker.active && worker.claimed_epoch != batch_epoch_) {
+                worker_index = i;
+                break;
+            }
+        }
+        if (worker_count_ < desired_workers || worker_index == kMaxWorkerCount) {
+            if (jobs_in_batch_ == 0) batch_active_ = false;
+            free_owned_args_[free_owned_args_count_++] = owned_args_index;
             return false;
         }
+        WorkerSlot &worker = *workers_[worker_index];
+        worker.job.function = std::move(next);
+        worker.job.owned_args_index = owned_args_index;
+        worker.pending = true;
+        worker.claimed_epoch = batch_epoch_;
+        job_count_++;
+        jobs_in_batch_++;
         lock.unlock();
-        cv_.notify_one();
+        worker.cv.notify_one();
         // graph_begin() has already installed the keyed in-flight entry and
         // submitted the zero-heap outer shell. Enqueuing the private job is
         // therefore the last dependency of the caller; graph_prepare() and all
@@ -265,6 +277,8 @@ public:
         cv_.wait(lock, [&]() {
             return job_count_ == 0 && active_jobs_ == 0;
         });
+        batch_active_ = false;
+        jobs_in_batch_ = 0;
     }
 
 private:
@@ -277,26 +291,40 @@ private:
         size_t owned_args_index{0};
     };
 
+    struct WorkerSlot {
+        std::condition_variable cv;
+        std::thread thread;
+        PendingJob job;
+        uint64_t claimed_epoch{0};
+        bool pending{false};
+        bool active{false};
+    };
+
     bool is_worker_thread_locked(std::thread::id id) const {
-        for (const std::thread &worker : workers_) {
-            if (worker.get_id() == id) return true;
+        for (size_t i = 0; i < worker_count_; ++i) {
+            if (workers_[i]->thread.get_id() == id) return true;
         }
         return false;
     }
 
     bool create_worker_locked() {
-        if (stopping_ || workers_.size() >= kMaxWorkerCount) return false;
+        if (stopping_ || worker_count_ >= kMaxWorkerCount) return false;
+        const size_t worker_index = worker_count_;
         try {
-            workers_.emplace_back([this]() {
-                run();
+            workers_[worker_index] = std::make_unique<WorkerSlot>();
+            workers_[worker_index]->thread = std::thread([this, worker_index]() {
+                run(worker_index);
             });
+            worker_count_++;
             return true;
         } catch (...) {
+            workers_[worker_index].reset();
             return false;
         }
     }
 
-    void run() {
+    void run(size_t worker_index) {
+        WorkerSlot &worker = *workers_[worker_index];
         {
             std::lock_guard<std::mutex> lock(mutex_);
             ready_workers_++;
@@ -306,14 +334,14 @@ private:
             PendingJob current;
             {
                 std::unique_lock<std::mutex> lock(mutex_);
-                cv_.wait(lock, [&]() {
-                    return job_count_ != 0 || stopping_;
+                worker.cv.wait(lock, [&]() {
+                    return worker.pending || stopping_;
                 });
-                if (stopping_ && job_count_ == 0) return;
-                PendingJob &pending = jobs_[job_head_];
-                current.function = std::move(pending.function);
-                current.owned_args_index = pending.owned_args_index;
-                job_head_ = (job_head_ + 1) % kJobCapacity;
+                if (stopping_ && !worker.pending) return;
+                current.function = std::move(worker.job.function);
+                current.owned_args_index = worker.job.owned_args_index;
+                worker.pending = false;
+                worker.active = true;
                 job_count_--;
                 active_jobs_++;
             }
@@ -323,6 +351,7 @@ private:
                 std::lock_guard<std::mutex> lock(mutex_);
                 free_owned_args_[free_owned_args_count_++] = current.owned_args_index;
                 active_jobs_--;
+                worker.active = false;
             }
             cv_.notify_all();
         }
@@ -334,24 +363,28 @@ private:
             std::lock_guard<std::mutex> lock(mutex_);
             stopping_ = true;
         }
-        cv_.notify_all();
-        for (std::thread &worker : workers_) {
+        for (size_t i = 0; i < worker_count_; ++i) {
+            workers_[i]->cv.notify_one();
+        }
+        for (size_t i = 0; i < worker_count_; ++i) {
+            std::thread &worker = workers_[i]->thread;
             if (worker.joinable()) worker.join();
         }
     }
 
-    std::vector<std::thread> workers_;
+    std::array<std::unique_ptr<WorkerSlot>, kMaxWorkerCount> workers_;
     std::mutex mutex_;
     std::condition_variable cv_;
     std::array<GraphOwnedArgs, kJobCapacity> owned_args_;
     std::array<size_t, kJobCapacity> free_owned_args_{};
-    std::array<PendingJob, kJobCapacity> jobs_;
     size_t free_owned_args_count_{kJobCapacity};
-    size_t job_head_{0};
-    size_t job_tail_{0};
     size_t job_count_{0};
+    size_t jobs_in_batch_{0};
+    size_t worker_count_{0};
     size_t ready_workers_{0};
     size_t active_jobs_{0};
+    uint64_t batch_epoch_{0};
+    bool batch_active_{false};
     bool stopping_{false};
 };
 

--- a/src/a2a3/runtime/host_build_graph/runtime/host_phase_trace.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/host_phase_trace.h
@@ -63,6 +63,18 @@ bool host_phase_breakdown_enabled();
 bool host_phase_records_enabled();
 
 /**
+ * Hold one trace-lifetime lease for the calling producer.
+ *
+ * The main submitting thread holds a lease for the whole bind pass. A Graph
+ * recording worker holds one from graph_prepare through graph_end/graph_abort.
+ * Calls may nest when a recording falls back to the submitting thread.
+ */
+void host_phase_producer_begin();
+
+/** Release one nesting level of the calling producer's trace lease. */
+void host_phase_producer_end();
+
+/**
  * Host monotonic nanoseconds, or 0 when this pass records nothing — which is
  * what keeps the orchestrator's per-operation hooks down to two calls returning
  * a constant.

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -199,6 +199,8 @@ static uint32_t g_orch_submit_idx = 0;
 // plain integer because this file is also compiled for the AICPU, where the
 // platform's host headers are absent.
 __attribute__((weak, visibility("hidden"))) void host_phase_record(uint64_t, uint64_t, uint32_t, uint64_t, uint32_t) {}
+__attribute__((weak, visibility("hidden"))) void host_phase_producer_begin() {}
+__attribute__((weak, visibility("hidden"))) void host_phase_producer_end() {}
 
 // Host monotonic clock shared with the `[STRACE]` span tree, so a record nests
 // under chip.run.bind.host_orch without any clock conversion. The host build
@@ -321,6 +323,67 @@ struct GraphRecordedPredicate {
     PredicateOp op{PredicateOp::NONE};
 };
 
+// Predicate groups commonly reuse one operand for many nodes. Its source is a
+// property of the tensor, not of the element/target, so classify it once rather
+// than rescan every Graph boundary for each node in the group.
+struct GraphPredicateOperandCache {
+    ChipTensor operand;
+    GraphRecordedTensorSourceRef source;
+    bool valid{false};
+};
+
+struct GraphRecordedTensors {
+    ChipTensor *data{nullptr};
+    size_t count{0};
+
+    size_t size() const { return count; }
+    ChipTensor *begin() const { return data; }
+    ChipTensor *end() const { return count == 0 ? data : data + count; }
+    ChipTensor &operator[](size_t index) const { return data[index]; }
+};
+
+class GraphRecordedTensorArena {
+public:
+    bool reserve_initial() {
+        if (!blocks_.empty()) return true;
+        std::unique_ptr<ChipTensor[]> storage{new (std::nothrow) ChipTensor[kInitialBlockTensors]};
+        if (storage == nullptr) return false;
+        try {
+            blocks_.push_back(Block{std::move(storage), kInitialBlockTensors, 0});
+        } catch (...) {
+            return false;
+        }
+        return true;
+    }
+
+    ChipTensor *allocate(size_t count) {
+        if (count == 0) return nullptr;
+        if (blocks_.empty() || count > blocks_.back().capacity - blocks_.back().used) {
+            const size_t capacity = std::max(kInitialBlockTensors, count);
+            std::unique_ptr<ChipTensor[]> storage{new (std::nothrow) ChipTensor[capacity]};
+            if (storage == nullptr) return nullptr;
+            try {
+                blocks_.push_back(Block{std::move(storage), capacity, 0});
+            } catch (...) {
+                return nullptr;
+            }
+        }
+        Block &block = blocks_.back();
+        ChipTensor *result = block.storage.get() + block.used;
+        block.used += count;
+        return result;
+    }
+
+private:
+    static constexpr size_t kInitialBlockTensors = 2048;
+    struct Block {
+        std::unique_ptr<ChipTensor[]> storage;
+        size_t capacity;
+        size_t used;
+    };
+    std::vector<Block> blocks_;
+};
+
 struct GraphRecordedNode {
     std::array<int32_t, PTO2_SUBTASK_SLOT_COUNT> kernel_ids{};
     ActiveMask active_mask{};
@@ -333,7 +396,7 @@ struct GraphRecordedNode {
     // this one stays per node: its heap buffer has to outlive every later node's
     // recording. The arrays whose addresses are never borrowed live flat on the
     // recording instead — see GraphRecording.
-    std::vector<ChipTensor> tensors;
+    GraphRecordedTensors tensors;
     // Ranges into the recording's flat arrays. tensor_sources has one entry per
     // tensor, so tensors.size() is its count.
     uint32_t tensor_source_offset{0};
@@ -369,6 +432,15 @@ struct GraphRecording {
     bool unsupported{false};
     std::vector<ChipTensor> boundary_tensors;
     std::vector<TensorArgType> boundary_types;
+    // First index carrying each boundary tensor's exact (address, size) pair.
+    // Computing this once keeps later same-key submits on an O(N) exact
+    // contract check instead of rediscovering both alias partitions in O(N^2).
+    std::vector<uint16_t> boundary_alias_reps;
+    // Every node needs a contiguous tensor array because TaskOutputTensors
+    // borrows its outputs until the recording ends. A private monotonic arena
+    // preserves that ownership contract while replacing one general-heap
+    // allocation per node with a handful of worker-local bump-allocator chunks.
+    GraphRecordedTensorArena tensor_storage;
     std::vector<GraphRecordedNode> nodes;
     // Flat per-node arrays, indexed by the ranges on GraphRecordedNode. Held
     // here rather than on each node so recording a graph pays a handful of
@@ -381,6 +453,7 @@ struct GraphRecording {
     // Indexed by GraphRecordedNode::predicate_index; only predicated nodes
     // contribute an entry.
     std::vector<GraphRecordedPredicate> predicates;
+    GraphPredicateOperandCache predicate_operand_cache;
     // Hazard state for the recorded body, owned per recording because several
     // graphs record at once, each on its own thread.
     //
@@ -411,11 +484,35 @@ struct GraphRecording {
 
 struct GraphPendingUpload {
     PTO2TaskSlotState *outer_slot{nullptr};
-    std::vector<std::byte> image;
+    size_t image_offset{0};
+    size_t image_bytes{0};
     bool deferred_heap{false};
 };
 
 enum class GraphRecordingStatus : uint8_t { RECORDING = 0, READY = 1, FAILED = 2 };
+
+constexpr size_t GRAPH_INITIAL_SUBMISSION_COUNT = 128;
+constexpr size_t GRAPH_INITIAL_SUBMISSION_BYTES = 512U << 10;
+constexpr size_t GRAPH_INITIAL_RECORDED_NODES = 320;
+constexpr size_t GRAPH_PREDICATE_INTERN_WINDOW = 64;
+constexpr size_t GRAPH_INITIAL_RECORDED_TENSORS = 4096;
+constexpr size_t GRAPH_INITIAL_RECORDED_SCALARS = 2048;
+constexpr size_t GRAPH_INITIAL_RECORDED_FANINS = 2048;
+constexpr size_t GRAPH_INITIAL_DEFINITION_BYTES = 256U << 10;
+constexpr size_t GRAPH_PREWARM_DEFINITIONS = 8;
+
+// Main-thread lookup for the common repeated-key path. A run validates a key's
+// fixed boundary contract once, then later submissions need only this immutable
+// key plus the atomically published recording state. This keeps the recording
+// mutex off the path that is meant to overlap with recorder publication.
+struct GraphFastEntry {
+    uint64_t full_key{0};
+    uint32_t boundary_count{0};
+    uint32_t boundary_scalar_count{0};
+    uint64_t validated_run_epoch{0};
+    std::atomic<GraphRecordingStatus> recording_status{GraphRecordingStatus::FAILED};
+    std::atomic<const std::vector<std::byte> *> definition{nullptr};
+};
 
 // One Definition being recorded. Entries are keyed by Graph key and held by
 // unique_ptr, so a rehash of the owning map never moves one: the recording
@@ -429,9 +526,14 @@ struct GraphInflightRecording {
     // main-thread burst of same-key submissions starve the thread before it can
     // bind its private recording state. Every other access holds the mutex.
     std::atomic<GraphRecordingStatus> recording_status{GraphRecordingStatus::RECORDING};
+    GraphFastEntry *fast_entry{nullptr};
+    std::vector<std::byte> definition_scratch;
 
     GraphRecordingStatus status() const { return recording_status.load(std::memory_order_acquire); }
-    void set_status(GraphRecordingStatus next) { recording_status.store(next, std::memory_order_release); }
+    void set_status(GraphRecordingStatus next) {
+        recording_status.store(next, std::memory_order_release);
+        if (fast_entry != nullptr) fast_entry->recording_status.store(next, std::memory_order_release);
+    }
 };
 
 struct GraphHostState {
@@ -439,16 +541,31 @@ struct GraphHostState {
     // Recordings in flight, at most one per Graph key. Several record at once,
     // each on its own thread; graph_commit drains and finalizes all of them.
     std::unordered_map<uint64_t, std::unique_ptr<GraphInflightRecording>> inflight;
+    // Completed cold recordings retain their worker-local arenas until the
+    // callable is destroyed. Releasing several large recording trees while
+    // holding recording_mutex serialized allocator work in graph_commit.
+    std::vector<std::unique_ptr<GraphInflightRecording>> retired_recordings;
     std::vector<GraphPendingUpload> pending_uploads;
+    // All per-occurrence submission images share one callable-owned allocation.
+    // begin_run clears its size but retains capacity, so steady-state replay
+    // performs no per-Graph host allocation and is already laid out as the H2D
+    // batch consumed by runtime_maker.
+    std::vector<std::byte> pending_image_storage;
+    size_t pending_image_bytes{0};
     std::mutex recording_mutex;
     std::condition_variable recording_cv;
     // Mirrors inflight.size() so orchestration completion answers the common
     // "nothing is recording" case without taking recording_mutex.
     std::atomic<size_t> inflight_count{0};
+    std::array<GraphFastEntry, GRAPH_MAX_DEFINITIONS> fast_entries{};
+    size_t fast_entry_count{0};
+    uint64_t run_epoch{0};
+    std::array<std::unique_ptr<GraphInflightRecording>, GRAPH_MAX_DEFINITIONS> prewarmed_recordings{};
+    size_t next_prewarmed_recording{0};
 
     // Definitions this run can still admit: published plus in flight, against
     // the per-worker cache limit.
-    size_t claimed_definitions() const { return definitions.size() + inflight.size(); }
+    size_t claimed_definitions() const { return fast_entry_count; }
     bool any_recording() const {
         for (const auto &entry : inflight) {
             if (entry.second->status() == GraphRecordingStatus::RECORDING) return true;
@@ -493,6 +610,25 @@ bool graph_tensor_exact(const ChipTensor &lhs, const ChipTensor &rhs) {
     }
     return std::equal(std::begin(lhs.shapes), std::begin(lhs.shapes) + lhs.ndims, std::begin(rhs.shapes)) &&
            std::equal(std::begin(lhs.strides), std::begin(lhs.strides) + lhs.ndims, std::begin(rhs.strides));
+}
+
+bool graph_predicate_replay_equivalent(
+    const GraphRecordedPredicate &recorded, const GraphRecordedTensorSourceRef &source, uint64_t operand_start_offset,
+    uint64_t elem_offset, int64_t target, uint8_t elem_size, PredicateOp op
+) {
+    if (recorded.source.source != source.source || recorded.source.source_index != source.source_index ||
+        recorded.source.packed_offset != source.packed_offset || recorded.elem_offset != elem_offset ||
+        recorded.target != target || recorded.elem_size != elem_size || recorded.op != op) {
+        return false;
+    }
+    // A boundary tensor's invocation fields replace the recorded template at
+    // materialize time. For an internal tensor, rebind replaces its base but
+    // preserves the view's element start, which therefore remains part of the
+    // address identity. OWN_OUTPUT predicates are rejected before this point.
+    if (recorded.source.source == GraphRecordedTensorSource::INTERNAL) {
+        return recorded.operand.start_offset == operand_start_offset;
+    }
+    return recorded.source.source != GraphRecordedTensorSource::OWN_OUTPUT;
 }
 
 bool graph_tensor_from_boundary(
@@ -623,6 +759,76 @@ GraphBoundarySignature graph_boundary_signature(const ChipTensor &tensor, Tensor
     return signature;
 }
 
+class GraphBoundaryAliasTable {
+public:
+    static constexpr size_t kCapacity = static_cast<size_t>(GRAPH_MAX_TENSOR_ARGS) * 2;
+    static_assert(kCapacity != 0 && (kCapacity & (kCapacity - 1)) == 0);
+
+    void begin() {
+        ++generation_;
+        if (generation_ == 0) {
+            for (Slot &slot : slots_)
+                slot.generation = 0;
+            generation_ = 1;
+        }
+    }
+
+    bool representative(const ChipTensor &tensor, uint16_t index, uint16_t *representative) {
+        if (representative == nullptr) return false;
+        const uint64_t address = tensor.buffer.addr;
+        const uint64_t size = tensor.buffer.size;
+        size_t slot_index = hash_pair(address, size) & (kCapacity - 1);
+        for (size_t probe = 0; probe < kCapacity; ++probe) {
+            Slot &slot = slots_[slot_index];
+            if (slot.generation != generation_) {
+                slot = Slot{address, size, index, generation_};
+                *representative = index;
+                return true;
+            }
+            if (slot.address == address && slot.size == size) {
+                *representative = slot.representative;
+                return true;
+            }
+            slot_index = (slot_index + 1) & (kCapacity - 1);
+        }
+        return false;
+    }
+
+private:
+    struct Slot {
+        uint64_t address{0};
+        uint64_t size{0};
+        uint16_t representative{0};
+        uint32_t generation{0};
+    };
+
+    static uint64_t hash_pair(uint64_t address, uint64_t size) {
+        uint64_t value = address ^ (size + 0x9e3779b97f4a7c15ULL + (address << 6) + (address >> 2));
+        value ^= value >> 33;
+        value *= 0xff51afd7ed558ccdULL;
+        value ^= value >> 33;
+        return value;
+    }
+
+    uint32_t generation_{0};
+    std::array<Slot, kCapacity> slots_{};
+};
+
+bool graph_boundary_alias_representatives(const GraphTaskArgs &args, uint16_t *representatives) {
+    if (representatives == nullptr || args.tensor_count() < 0 ||
+        args.tensor_count() > static_cast<int32_t>(GRAPH_MAX_TENSOR_ARGS)) {
+        return false;
+    }
+    static thread_local GraphBoundaryAliasTable aliases;
+    aliases.begin();
+    for (int32_t i = 0; i < args.tensor_count(); ++i) {
+        if (!aliases.representative(args.tensor(i).ref(), static_cast<uint16_t>(i), &representatives[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
 template <typename T>
 uint32_t graph_append_section(std::vector<std::byte> *image, const std::vector<T> &values) {
     if (values.empty()) return 0;
@@ -675,6 +881,7 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     if (image == nullptr || recording.unsupported || recording.nodes.empty() ||
         recording.nodes.size() > GRAPH_MAX_NODES || recording.boundary_tensors.size() > UINT16_MAX ||
         recording.boundary_tensors.size() != recording.boundary_types.size() || recording.boundary_args == nullptr ||
+        recording.predicates.size() > UINT16_MAX ||
         std::any_of(recording.boundary_tensors.begin(), recording.boundary_tensors.end(), [](const ChipTensor &tensor) {
             return tensor.ndims > MAX_TENSOR_DIMS;
         })) {
@@ -701,14 +908,26 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     std::vector<GraphTensorSourceRef> tensor_sources;
     std::vector<uint64_t> scalars;
     std::vector<GraphScalarSourceRef> scalar_sources;
-    std::vector<GraphPredicate> predicates;
-    predicates.reserve(recording.predicates.size());
+    std::vector<GraphPredicate> predicates(recording.predicates.size());
     fanin_indices.reserve(total_fanins);
     roots.reserve(recording.nodes.size());
     tensors.reserve(total_tensors);
     tensor_sources.reserve(total_tensors);
     scalars.reserve(total_scalars);
     scalar_sources.reserve(total_scalars);
+
+    for (size_t i = 0; i < recording.predicates.size(); ++i) {
+        const GraphRecordedPredicate &recorded = recording.predicates[i];
+        std::optional<GraphTensorSourceRef> packed_source = graph_pack_tensor_source(recorded.source);
+        if (!packed_source.has_value() || recorded.operand.ndims > MAX_TENSOR_DIMS) return false;
+        GraphPredicate &packed = predicates[i];
+        packed.operand = graph_tensor_pack(recorded.operand);
+        packed.operand_source = *packed_source;
+        packed.elem_offset = recorded.elem_offset;
+        packed.target = recorded.target;
+        packed.elem_size = recorded.elem_size;
+        packed.op = static_cast<uint8_t>(recorded.op);
+    }
 
     uint64_t required_heap = 0;
     uint32_t edge_count = 0;
@@ -755,22 +974,8 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
         node.dump_metadata = source.dump_metadata;
         node.predicate_slot = 0;
         if (source.predicate_index >= 0) {
-            if (static_cast<size_t>(source.predicate_index) >= recording.predicates.size() ||
-                predicates.size() >= static_cast<size_t>(UINT16_MAX)) {
-                return false;
-            }
-            const GraphRecordedPredicate &recorded = recording.predicates[source.predicate_index];
-            std::optional<GraphTensorSourceRef> packed_source = graph_pack_tensor_source(recorded.source);
-            if (!packed_source.has_value() || recorded.operand.ndims > MAX_TENSOR_DIMS) return false;
-            GraphPredicate packed{};
-            packed.operand = graph_tensor_pack(recorded.operand);
-            packed.operand_source = *packed_source;
-            packed.elem_offset = recorded.elem_offset;
-            packed.target = recorded.target;
-            packed.elem_size = recorded.elem_size;
-            packed.op = static_cast<uint8_t>(recorded.op);
-            node.predicate_slot = static_cast<uint16_t>(predicates.size() + 1);
-            predicates.push_back(packed);
+            if (static_cast<size_t>(source.predicate_index) >= recording.predicates.size()) return false;
+            node.predicate_slot = static_cast<uint16_t>(source.predicate_index + 1);
         }
         for (const ChipTensor &tensor : source.tensors)
             tensors.push_back(graph_tensor_pack(tensor));
@@ -812,18 +1017,11 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
 
     std::vector<GraphBoundarySignature> signatures;
     signatures.reserve(recording.boundary_tensors.size());
+    if (recording.boundary_alias_reps.size() != recording.boundary_tensors.size()) return false;
     for (size_t i = 0; i < recording.boundary_tensors.size(); ++i) {
-        uint16_t alias_rep = static_cast<uint16_t>(i);
-        for (size_t j = 0; j < i; ++j) {
-            if (recording.boundary_tensors[j].buffer.addr == recording.boundary_tensors[i].buffer.addr &&
-                recording.boundary_tensors[j].buffer.size == recording.boundary_tensors[i].buffer.size) {
-                alias_rep = static_cast<uint16_t>(j);
-                break;
-            }
-        }
-        signatures.push_back(
-            graph_boundary_signature(recording.boundary_tensors[i], recording.boundary_types[i], alias_rep)
-        );
+        signatures.push_back(graph_boundary_signature(
+            recording.boundary_tensors[i], recording.boundary_types[i], recording.boundary_alias_reps[i]
+        ));
     }
 
     image->assign(sizeof(GraphDefinition), std::byte{0});
@@ -908,6 +1106,232 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     return true;
 }
 
+// Cold misses used to build thirteen temporary section vectors and then copy
+// all of them into the Definition image. The recording already contains every
+// exact count, so lay out the final image first and pack directly into it. The
+// only remaining scratch allocation is the per-node fanout cursor array.
+bool graph_build_definition_direct(const GraphRecording &recording, std::vector<std::byte> *image) {
+    const size_t node_count = recording.nodes.size();
+    if (image == nullptr || recording.unsupported || node_count == 0 || node_count > GRAPH_MAX_NODES ||
+        recording.boundary_tensors.empty() || recording.boundary_tensors.size() > UINT16_MAX ||
+        recording.boundary_tensors.size() != recording.boundary_types.size() ||
+        recording.boundary_tensors.size() != recording.boundary_alias_reps.size() ||
+        recording.boundary_args == nullptr || recording.predicates.size() > UINT16_MAX) {
+        return false;
+    }
+
+    size_t total_tensors = 0;
+    const size_t total_scalars = recording.scalars.size();
+    const size_t total_fanins = recording.internal_fanins.size();
+    size_t root_count = 0;
+    int32_t widest_node_tensor_count = 0;
+    uint64_t required_heap = 0;
+    std::vector<uint32_t> fanout_cursors(node_count, 0);
+    for (size_t i = 0; i < node_count; ++i) {
+        const GraphRecordedNode &source = recording.nodes[i];
+        if (source.total_output_size > static_cast<size_t>(INT32_MAX) ||
+            source.tensors.size() > static_cast<size_t>(INT32_MAX) ||
+            source.scalar_count > static_cast<uint32_t>(INT32_MAX) || source.fanin_count > UINT16_MAX ||
+            source.tensor_source_offset > recording.tensor_sources.size() ||
+            source.tensors.size() > recording.tensor_sources.size() - source.tensor_source_offset ||
+            source.scalar_offset > recording.scalars.size() ||
+            source.scalar_count > recording.scalars.size() - source.scalar_offset ||
+            source.scalar_offset > recording.scalar_sources.size() ||
+            source.scalar_count > recording.scalar_sources.size() - source.scalar_offset ||
+            source.fanin_offset > recording.internal_fanins.size() ||
+            source.fanin_count > recording.internal_fanins.size() - source.fanin_offset ||
+            total_tensors > UINT32_MAX - source.tensors.size() ||
+            std::any_of(source.tensors.begin(), source.tensors.end(), [](const ChipTensor &tensor) {
+                return tensor.ndims > MAX_TENSOR_DIMS;
+            })) {
+            return false;
+        }
+        total_tensors += source.tensors.size();
+        widest_node_tensor_count = std::max(widest_node_tensor_count, static_cast<int32_t>(source.tensors.size()));
+        if (source.fanin_count == 0) ++root_count;
+        for (uint32_t f = 0; f < source.fanin_count; ++f) {
+            const size_t producer = recording.internal_fanins[source.fanin_offset + f];
+            if (producer >= i || fanout_cursors[producer] == UINT32_MAX) return false;
+            ++fanout_cursors[producer];
+        }
+        const uint64_t output_bytes = PTO2_ALIGN_UP(source.total_output_size, PTO2_ALIGN_SIZE);
+        if (required_heap > UINT64_MAX - output_bytes) return false;
+        required_heap += output_bytes;
+    }
+    if (total_tensors > UINT32_MAX || total_scalars > UINT32_MAX || total_fanins > UINT32_MAX ||
+        root_count > UINT32_MAX) {
+        return false;
+    }
+    for (const ChipTensor &tensor : recording.boundary_tensors) {
+        if (tensor.ndims > MAX_TENSOR_DIMS) return false;
+    }
+
+    GraphDefinition definition{};
+    definition.full_key = recording.full_key;
+    definition.required_heap = required_heap;
+    definition.task_count = static_cast<uint32_t>(node_count);
+    definition.edge_count = static_cast<uint32_t>(total_fanins);
+    definition.root_count = static_cast<uint32_t>(root_count);
+    definition.boundary_count = static_cast<uint32_t>(recording.boundary_tensors.size());
+    definition.boundary_scalar_count = static_cast<uint32_t>(recording.boundary_scalar_count);
+    definition.tensor_arg_count = static_cast<uint32_t>(total_tensors);
+    definition.scalar_arg_count = static_cast<uint32_t>(total_scalars);
+    definition.predicate_count = static_cast<uint32_t>(recording.predicates.size());
+    const size_t node_stride = graph_node_stride(widest_node_tensor_count);
+    size_t execution_storage_bytes = 0;
+    if (node_stride > UINT32_MAX ||
+        !graph_execution_storage_bytes(static_cast<int32_t>(node_count), node_stride, &execution_storage_bytes) ||
+        execution_storage_bytes > UINT32_MAX) {
+        return false;
+    }
+    definition.node_stride = static_cast<uint32_t>(node_stride);
+    definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
+
+    size_t cursor = sizeof(GraphDefinition);
+    auto layout = [&cursor](size_t count, size_t element_bytes, size_t alignment, uint32_t *offset) {
+        *offset = 0;
+        if (count == 0) return true;
+        if (alignment == 0 || (alignment & (alignment - 1)) != 0 || cursor > SIZE_MAX - (alignment - 1) ||
+            count > SIZE_MAX / element_bytes) {
+            return false;
+        }
+        const size_t aligned = (cursor + alignment - 1) & ~(alignment - 1);
+        const size_t bytes = count * element_bytes;
+        if (aligned > UINT32_MAX || bytes > UINT32_MAX - aligned) return false;
+        *offset = static_cast<uint32_t>(aligned);
+        cursor = aligned + bytes;
+        return true;
+    };
+#define GRAPH_LAYOUT_FIELD(field, type, count) layout((count), sizeof(type), alignof(type), &definition.field)
+    if (!GRAPH_LAYOUT_FIELD(off_fanout_offsets, uint32_t, node_count + 1) ||
+        !GRAPH_LAYOUT_FIELD(off_fanout_indices, uint16_t, total_fanins) ||
+        !GRAPH_LAYOUT_FIELD(off_fanin_offsets, uint32_t, node_count + 1) ||
+        !GRAPH_LAYOUT_FIELD(off_fanin_indices, uint16_t, total_fanins) ||
+        !GRAPH_LAYOUT_FIELD(off_root_indices, uint16_t, root_count) ||
+        !GRAPH_LAYOUT_FIELD(off_node_offsets, uint64_t, node_count) ||
+        !GRAPH_LAYOUT_FIELD(off_nodes, GraphNodeDefinition, node_count) ||
+        !GRAPH_LAYOUT_FIELD(off_tensors, GraphTensor, total_tensors) ||
+        !GRAPH_LAYOUT_FIELD(off_tensor_sources, GraphTensorSourceRef, total_tensors) ||
+        !GRAPH_LAYOUT_FIELD(off_scalars, uint64_t, total_scalars) ||
+        !GRAPH_LAYOUT_FIELD(off_scalar_sources, GraphScalarSourceRef, total_scalars) ||
+        !GRAPH_LAYOUT_FIELD(off_boundary_signatures, GraphBoundarySignature, recording.boundary_tensors.size()) ||
+        !GRAPH_LAYOUT_FIELD(off_predicates, GraphPredicate, recording.predicates.size())) {
+#undef GRAPH_LAYOUT_FIELD
+        return false;
+    }
+#undef GRAPH_LAYOUT_FIELD
+    if (cursor > UINT32_MAX) return false;
+    image->assign(cursor, std::byte{0});
+    definition.total_bytes = static_cast<uint32_t>(cursor);
+
+    auto section = [&image](uint32_t offset) -> std::byte * {
+        return offset == 0 ? nullptr : image->data() + offset;
+    };
+    auto *fanout_offsets = reinterpret_cast<uint32_t *>(section(definition.off_fanout_offsets));
+    auto *fanout_indices = reinterpret_cast<uint16_t *>(section(definition.off_fanout_indices));
+    auto *fanin_offsets = reinterpret_cast<uint32_t *>(section(definition.off_fanin_offsets));
+    auto *fanin_indices = reinterpret_cast<uint16_t *>(section(definition.off_fanin_indices));
+    auto *roots = reinterpret_cast<uint16_t *>(section(definition.off_root_indices));
+    auto *node_offsets = reinterpret_cast<uint64_t *>(section(definition.off_node_offsets));
+    auto *nodes = reinterpret_cast<GraphNodeDefinition *>(section(definition.off_nodes));
+    auto *tensors = reinterpret_cast<GraphTensor *>(section(definition.off_tensors));
+    auto *tensor_sources = reinterpret_cast<GraphTensorSourceRef *>(section(definition.off_tensor_sources));
+    auto *scalars = reinterpret_cast<uint64_t *>(section(definition.off_scalars));
+    auto *scalar_sources = reinterpret_cast<GraphScalarSourceRef *>(section(definition.off_scalar_sources));
+    auto *signatures = reinterpret_cast<GraphBoundarySignature *>(section(definition.off_boundary_signatures));
+    auto *predicates = reinterpret_cast<GraphPredicate *>(section(definition.off_predicates));
+
+    uint32_t tensor_cursor = 0;
+    uint32_t scalar_cursor = 0;
+    uint32_t fanin_cursor = 0;
+    uint32_t root_cursor = 0;
+    uint64_t heap_cursor = 0;
+    fanin_offsets[0] = 0;
+    for (size_t i = 0; i < node_count; ++i) {
+        const GraphRecordedNode &source = recording.nodes[i];
+        node_offsets[i] = heap_cursor;
+        heap_cursor += PTO2_ALIGN_UP(source.total_output_size, PTO2_ALIGN_SIZE);
+        if (source.fanin_count == 0) roots[root_cursor++] = static_cast<uint16_t>(i);
+        for (uint32_t f = 0; f < source.fanin_count; ++f) {
+            fanin_indices[fanin_cursor++] = static_cast<uint16_t>(recording.internal_fanins[source.fanin_offset + f]);
+        }
+        fanin_offsets[i + 1] = fanin_cursor;
+
+        GraphNodeDefinition &node = nodes[i];
+        std::copy(source.kernel_ids.begin(), source.kernel_ids.end(), std::begin(node.kernel_id));
+        node.active_mask = source.active_mask.raw();
+        node.task_attrs = source.task_attrs.raw();
+        node.logical_block_num = source.logical_block_num;
+        node.total_required_subtasks = source.total_required_subtasks;
+        node.tensor_count = static_cast<int32_t>(source.tensors.size());
+        node.scalar_count = static_cast<int32_t>(source.scalar_count);
+        node.total_output_size = static_cast<int32_t>(source.total_output_size);
+        node.tensor_offset = tensor_cursor;
+        node.scalar_offset = scalar_cursor;
+        node.dump_metadata = source.dump_metadata;
+        if (source.predicate_index >= 0) {
+            if (static_cast<size_t>(source.predicate_index) >= recording.predicates.size()) return false;
+            const GraphRecordedPredicate &recorded = recording.predicates[source.predicate_index];
+            std::optional<GraphTensorSourceRef> packed_source = graph_pack_tensor_source(recorded.source);
+            if (!packed_source.has_value() || recorded.operand.ndims > MAX_TENSOR_DIMS) return false;
+            GraphPredicate &packed = predicates[source.predicate_index];
+            packed.operand = graph_tensor_pack(recorded.operand);
+            packed.operand_source = *packed_source;
+            packed.elem_offset = recorded.elem_offset;
+            packed.target = recorded.target;
+            packed.elem_size = recorded.elem_size;
+            packed.op = static_cast<uint8_t>(recorded.op);
+            node.predicate_slot = static_cast<uint16_t>(source.predicate_index + 1);
+        }
+        for (size_t t = 0; t < source.tensors.size(); ++t) {
+            tensors[tensor_cursor] = graph_tensor_pack(source.tensors[t]);
+            std::optional<GraphTensorSourceRef> packed_source =
+                graph_pack_tensor_source(recording.tensor_sources[source.tensor_source_offset + t]);
+            if (!packed_source.has_value()) return false;
+            tensor_sources[tensor_cursor++] = *packed_source;
+        }
+        for (size_t s = 0; s < source.scalar_count; ++s) {
+            std::optional<GraphScalarSourceRef> packed_source =
+                graph_pack_scalar_source(recording.scalar_sources[source.scalar_offset + s]);
+            if (!packed_source.has_value() ||
+                (packed_source->source == static_cast<uint8_t>(GraphScalarSource::BOUNDARY) &&
+                 packed_source->source_index >= recording.boundary_args->scalar_count())) {
+                return false;
+            }
+            scalar_sources[scalar_cursor] = *packed_source;
+            scalars[scalar_cursor++] = packed_source->source == static_cast<uint8_t>(GraphScalarSource::BOUNDARY) ?
+                                           0 :
+                                           recording.scalars[source.scalar_offset + s];
+        }
+    }
+
+    fanout_offsets[0] = 0;
+    for (size_t i = 0; i < node_count; ++i) {
+        fanout_offsets[i + 1] = fanout_offsets[i] + fanout_cursors[i];
+        fanout_cursors[i] = fanout_offsets[i];
+    }
+    for (size_t consumer = 0; consumer < node_count; ++consumer) {
+        const GraphRecordedNode &node = recording.nodes[consumer];
+        for (uint32_t f = 0; f < node.fanin_count; ++f) {
+            const size_t producer = recording.internal_fanins[node.fanin_offset + f];
+            fanout_indices[fanout_cursors[producer]++] = static_cast<uint16_t>(consumer);
+        }
+    }
+    for (size_t i = 0; i < recording.boundary_tensors.size(); ++i) {
+        signatures[i] = graph_boundary_signature(
+            recording.boundary_tensors[i], recording.boundary_types[i], recording.boundary_alias_reps[i]
+        );
+    }
+    if (tensor_cursor != total_tensors || scalar_cursor != total_scalars || fanin_cursor != total_fanins ||
+        root_cursor != root_count || heap_cursor != required_heap) {
+        return false;
+    }
+    std::memcpy(image->data(), &definition, sizeof(definition));
+    definition.content_hash = graph_hash_bytes(1469598103934665603ULL, image->data(), image->size());
+    std::memcpy(image->data(), &definition, sizeof(definition));
+    return true;
+}
+
 const GraphDefinition *graph_definition(const std::vector<std::byte> &image) {
     if (image.size() < sizeof(GraphDefinition)) return nullptr;
     const auto *definition = reinterpret_cast<const GraphDefinition *>(image.data());
@@ -916,26 +1340,79 @@ const GraphDefinition *graph_definition(const std::vector<std::byte> &image) {
 
 }  // namespace
 
-GraphHostStatePtr make_graph_host_state() { return GraphHostStatePtr{new (std::nothrow) GraphHostState{}}; }
+GraphHostStatePtr make_graph_host_state() {
+    GraphHostStatePtr state{new (std::nothrow) GraphHostState{}};
+    if (state == nullptr) return {};
+    try {
+        state->definitions.reserve(GRAPH_MAX_DEFINITIONS);
+        state->inflight.reserve(GRAPH_MAX_DEFINITIONS);
+        state->retired_recordings.reserve(GRAPH_MAX_DEFINITIONS);
+        state->pending_uploads.reserve(GRAPH_INITIAL_SUBMISSION_COUNT);
+        state->pending_image_storage.resize(GRAPH_INITIAL_SUBMISSION_BYTES);
+        for (size_t i = 0; i < state->prewarmed_recordings.size(); ++i) {
+            auto &slot = state->prewarmed_recordings[i];
+            slot = std::make_unique<GraphInflightRecording>();
+            slot->recording = std::make_unique<GraphRecording>();
+            if (i >= GRAPH_PREWARM_DEFINITIONS) continue;
+            GraphRecording &recording = *slot->recording;
+            recording.boundary_tensors.reserve(GRAPH_MAX_TENSOR_ARGS);
+            recording.boundary_types.reserve(GRAPH_MAX_TENSOR_ARGS);
+            recording.boundary_alias_reps.reserve(GRAPH_MAX_TENSOR_ARGS);
+            recording.nodes.reserve(GRAPH_INITIAL_RECORDED_NODES);
+            recording.tensor_sources.reserve(GRAPH_INITIAL_RECORDED_TENSORS);
+            recording.scalars.reserve(GRAPH_INITIAL_RECORDED_SCALARS);
+            recording.scalar_sources.reserve(GRAPH_INITIAL_RECORDED_SCALARS);
+            recording.internal_fanins.reserve(GRAPH_INITIAL_RECORDED_FANINS);
+            recording.output_ranges.reserve(GRAPH_INITIAL_RECORDED_NODES);
+            recording.predicates.reserve(GRAPH_INITIAL_RECORDED_NODES);
+            if (!recording.tensor_storage.reserve_initial()) return {};
+            slot->definition_scratch.reserve(GRAPH_INITIAL_DEFINITION_BYTES);
+        }
+    } catch (...) {
+        return {};
+    }
+    return state;
+}
 
 void GraphHostStateDeleter::operator()(GraphHostState *state) const noexcept { delete state; }
+
+bool graph_host_begin_run(GraphHostState &state) {
+    std::lock_guard<std::mutex> lock(state.recording_mutex);
+    if (!state.inflight.empty() || state.inflight_count.load(std::memory_order_acquire) != 0) return false;
+    state.pending_uploads.clear();
+    state.pending_image_bytes = 0;
+    if (++state.run_epoch == 0) {
+        state.run_epoch = 1;
+        for (size_t i = 0; i < state.fast_entry_count; ++i)
+            state.fast_entries[i].validated_run_epoch = 0;
+    }
+    return true;
+}
 
 size_t graph_host_upload_count(const GraphHostState &state) { return state.pending_uploads.size(); }
 
 std::optional<GraphHostUpload> graph_host_upload(GraphHostState &state, size_t index) {
     if (index >= state.pending_uploads.size()) return std::nullopt;
     GraphPendingUpload &upload = state.pending_uploads[index];
-    if (upload.outer_slot == nullptr || upload.image.empty()) return std::nullopt;
-    return GraphHostUpload{upload.outer_slot, upload.image.data(), upload.image.size()};
+    if (upload.outer_slot == nullptr || upload.image_bytes == 0 || upload.image_offset > state.pending_image_bytes ||
+        upload.image_bytes > state.pending_image_bytes - upload.image_offset) {
+        return std::nullopt;
+    }
+    return GraphHostUpload{
+        upload.outer_slot, state.pending_image_storage.data() + upload.image_offset, upload.image_bytes
+    };
+}
+
+GraphHostUploadBatch graph_host_upload_batch(GraphHostState &state) {
+    return GraphHostUploadBatch{state.pending_image_storage.data(), state.pending_image_bytes};
 }
 
 GraphHostDefinitionList graph_host_definitions(GraphHostState &state) {
     GraphHostDefinitionList list;
-    list.entries.reserve(state.definitions.size());
     for (auto &[key, image] : state.definitions) {
         const GraphDefinition *header = graph_definition(image);
-        if (header != nullptr && header->total_bytes == image.size()) {
-            list.entries.push_back(GraphHostDefinition{key, image.data(), image.size()});
+        if (header != nullptr && header->total_bytes == image.size() && list.count < list.entries.size()) {
+            list.entries[list.count++] = GraphHostDefinition{key, image.data(), image.size()};
         }
     }
     return list;
@@ -1506,6 +1983,9 @@ bool graph_boundary_matches(const GraphDefinition &definition, const GraphTaskAr
     );
     if (signatures == nullptr) return false;
 
+    std::array<uint16_t, GRAPH_MAX_TENSOR_ARGS> alias_reps{};
+    if (!graph_boundary_alias_representatives(args, alias_reps.data())) return false;
+
     bool alias_mismatch = false;
     for (int32_t i = 0; i < args.tensor_count(); ++i) {
         const ChipTensor &tensor = args.tensor(i).ref();
@@ -1531,15 +2011,7 @@ bool graph_boundary_matches(const GraphDefinition &definition, const GraphTaskAr
             );
             return false;
         }
-        uint16_t alias_rep = static_cast<uint16_t>(i);
-        for (int32_t j = 0; j < i; ++j) {
-            const ChipTensor &other = args.tensor(j).ref();
-            if (other.buffer.addr == tensor.buffer.addr && other.buffer.size == tensor.buffer.size) {
-                alias_rep = static_cast<uint16_t>(j);
-                break;
-            }
-        }
-        alias_mismatch |= alias_rep != signature.alias_rep;
+        alias_mismatch |= alias_reps[static_cast<size_t>(i)] != signature.alias_rep;
     }
     if (alias_mismatch) {
         debug_assert(!alias_mismatch && "Changing the Graph boundary alias partition is not supported");
@@ -1552,9 +2024,12 @@ bool graph_boundary_matches(const GraphDefinition &definition, const GraphTaskAr
 bool graph_recording_boundary_matches(const GraphRecording &recording, const GraphTaskArgs &args) {
     if (args.scalar_count() != recording.boundary_scalar_count || args.explicit_dep_count() != 0 ||
         args.tensor_count() != static_cast<int32_t>(recording.boundary_tensors.size()) ||
-        recording.boundary_tensors.size() != recording.boundary_types.size()) {
+        recording.boundary_tensors.size() != recording.boundary_types.size() ||
+        recording.boundary_tensors.size() != recording.boundary_alias_reps.size()) {
         return false;
     }
+    std::array<uint16_t, GRAPH_MAX_TENSOR_ARGS> actual_alias_reps{};
+    if (!graph_boundary_alias_representatives(args, actual_alias_reps.data())) return false;
     for (int32_t i = 0; i < args.tensor_count(); ++i) {
         const ChipTensor &expected = recording.boundary_tensors[static_cast<size_t>(i)];
         const ChipTensor &actual = args.tensor(i).ref();
@@ -1570,24 +2045,9 @@ bool graph_recording_boundary_matches(const GraphRecording &recording, const Gra
             )) {
             return false;
         }
-        uint16_t expected_alias = static_cast<uint16_t>(i);
-        uint16_t actual_alias = static_cast<uint16_t>(i);
-        for (int32_t j = 0; j < i; ++j) {
-            const ChipTensor &expected_other = recording.boundary_tensors[static_cast<size_t>(j)];
-            if (expected_other.buffer.addr == expected.buffer.addr &&
-                expected_other.buffer.size == expected.buffer.size) {
-                expected_alias = static_cast<uint16_t>(j);
-                break;
-            }
+        if (actual_alias_reps[static_cast<size_t>(i)] != recording.boundary_alias_reps[static_cast<size_t>(i)]) {
+            return false;
         }
-        for (int32_t j = 0; j < i; ++j) {
-            const ChipTensor &actual_other = args.tensor(j).ref();
-            if (actual_other.buffer.addr == actual.buffer.addr && actual_other.buffer.size == actual.buffer.size) {
-                actual_alias = static_cast<uint16_t>(j);
-                break;
-            }
-        }
-        if (actual_alias != expected_alias) return false;
     }
     return true;
 }
@@ -1609,11 +2069,14 @@ void graph_reset_outer_payload(PTO2TaskPayload &payload) {
 }
 
 bool graph_prepare_submission_image(
-    uint64_t full_key, const GraphTaskArgs &args, std::vector<std::byte> *submission_image
+    uint64_t full_key, const GraphTaskArgs &args, std::vector<std::byte> *storage, size_t *storage_bytes,
+    size_t *image_offset, size_t *image_bytes
 ) {
-    if (submission_image == nullptr) return false;
-    const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphTensor));
-    const size_t tensor_bytes = static_cast<size_t>(args.tensor_count()) * sizeof(GraphTensor);
+    if (storage == nullptr || storage_bytes == nullptr || image_offset == nullptr || image_bytes == nullptr) {
+        return false;
+    }
+    const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphInvocationTensor));
+    const size_t tensor_bytes = static_cast<size_t>(args.tensor_count()) * sizeof(GraphInvocationTensor);
     if (tensors_offset > UINT32_MAX || tensors_offset > UINT32_MAX - tensor_bytes) {
         return false;
     }
@@ -1625,25 +2088,32 @@ bool graph_prepare_submission_image(
         total_bytes > UINT32_MAX) {
         return false;
     }
-    submission_image->assign(total_bytes, std::byte{0});
-    auto *tensors = reinterpret_cast<GraphTensor *>(submission_image->data() + tensors_offset);
+    constexpr size_t kImageAlignment = alignof(GraphSubmission);
+    if (*storage_bytes > SIZE_MAX - (kImageAlignment - 1)) return false;
+    const size_t offset = (*storage_bytes + kImageAlignment - 1) & ~(kImageAlignment - 1);
+    if (total_bytes > SIZE_MAX - offset) return false;
+    if (offset + total_bytes > storage->size()) storage->resize(offset + total_bytes);
+    std::byte *image = storage->data() + offset;
+    auto *tensors = reinterpret_cast<GraphInvocationTensor *>(image + tensors_offset);
     for (int32_t i = 0; i < args.tensor_count(); ++i)
-        tensors[i] = graph_tensor_pack(args.tensor(i).ref());
+        tensors[i] = graph_invocation_tensor_pack(args.tensor(i).ref());
     if (args.scalar_count() != 0) {
         std::memcpy(
-            submission_image->data() + scalars_offset, args.scalar_data(),
-            static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t)
+            image + scalars_offset, args.scalar_data(), static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t)
         );
     }
 
     GraphSubmission submission{};
     submission.graph_key = full_key;
-    submission.total_bytes = static_cast<uint32_t>(submission_image->size());
+    submission.total_bytes = static_cast<uint32_t>(total_bytes);
     submission.tensors_offset = static_cast<uint32_t>(tensors_offset);
     submission.tensor_count = static_cast<uint32_t>(args.tensor_count());
     submission.scalars_offset = static_cast<uint32_t>(scalars_offset);
     submission.scalar_count = static_cast<uint32_t>(args.scalar_count());
-    std::memcpy(submission_image->data(), &submission, sizeof(submission));
+    std::memcpy(image, &submission, sizeof(submission));
+    *storage_bytes = offset + total_bytes;
+    *image_offset = offset;
+    *image_bytes = total_bytes;
     return true;
 }
 
@@ -1660,8 +2130,14 @@ bool graph_submit_outer(
     }
 
     GraphPendingUpload pending;
-    if (!graph_prepare_submission_image(full_key, args, &pending.image)) return false;
-    reinterpret_cast<GraphSubmission *>(pending.image.data())->definition_hash = definition_hash;
+    if (!graph_prepare_submission_image(
+            full_key, args, &state->pending_image_storage, &state->pending_image_bytes, &pending.image_offset,
+            &pending.image_bytes
+        )) {
+        return false;
+    }
+    reinterpret_cast<GraphSubmission *>(state->pending_image_storage.data() + pending.image_offset)->definition_hash =
+        definition_hash;
     pending.deferred_heap = defer_heap;
 
     DepInputs boundary_inputs{
@@ -1741,7 +2217,7 @@ bool graph_submit_outer(
     payload.fanin_count = fanin_builder.count;
 
     pending.outer_slot = &slot;
-    state->pending_uploads.push_back(std::move(pending));
+    state->pending_uploads.push_back(pending);
     if (submitted_id != nullptr) *submitted_id = task_id;
 #if SIMPLER_DFX
     orch->tasks_submitted++;
@@ -1751,10 +2227,10 @@ bool graph_submit_outer(
 
 bool graph_submit_definition(
     PTO2OrchestratorState *orch, GraphHostState *state, const std::vector<std::byte> &definition_image,
-    const GraphTaskArgs &args, PTO2TaskId *submitted_id
+    const GraphTaskArgs &args, PTO2TaskId *submitted_id, bool boundary_checked = false
 ) {
     const GraphDefinition *definition = graph_definition(definition_image);
-    if (definition == nullptr || !graph_boundary_matches(*definition, args) ||
+    if (definition == nullptr || (!boundary_checked && !graph_boundary_matches(*definition, args)) ||
         definition->execution_storage_bytes == 0 ||
         definition->required_heap > UINT64_MAX - definition->execution_storage_bytes) {
         return false;
@@ -1777,8 +2253,12 @@ bool graph_submit_pending_definition(
 bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostState *state, uint64_t *failed_key) {
     for (GraphPendingUpload &pending : state->pending_uploads) {
         if (!pending.deferred_heap) continue;
-        if (pending.image.size() < sizeof(GraphSubmission)) return false;
-        auto *submission = reinterpret_cast<GraphSubmission *>(pending.image.data());
+        if (pending.image_bytes < sizeof(GraphSubmission) || pending.image_offset > state->pending_image_bytes ||
+            pending.image_bytes > state->pending_image_bytes - pending.image_offset) {
+            return false;
+        }
+        auto *submission =
+            reinterpret_cast<GraphSubmission *>(state->pending_image_storage.data() + pending.image_offset);
         auto definition_it = state->definitions.find(submission->graph_key);
         const GraphDefinition *definition =
             definition_it == state->definitions.end() ? nullptr : graph_definition(definition_it->second);
@@ -1786,7 +2266,7 @@ bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostSt
             definition->required_heap > UINT64_MAX - definition->execution_storage_bytes ||
             pending.outer_slot == nullptr || pending.outer_slot->task == nullptr ||
             pending.outer_slot->task_kind != TaskKind::GRAPH ||
-            !graph_submission_wire_size_valid(*submission, pending.image.size())) {
+            !graph_submission_wire_size_valid(*submission, pending.image_bytes)) {
             if (failed_key != nullptr) *failed_key = submission->graph_key;
             return false;
         }
@@ -1880,7 +2360,12 @@ TaskOutputTensors graph_record_submit_node(
     // the caller's ChipTensor; outputs materialize from the create-info onto the
     // scratch buffer and carry this node's owner id.
     const int32_t tensor_count = args.tensor_count();
-    node.tensors.resize(static_cast<size_t>(tensor_count));
+    node.tensors.count = static_cast<size_t>(tensor_count);
+    node.tensors.data = recording.tensor_storage.allocate(node.tensors.count);
+    if (tensor_count != 0 && node.tensors.data == nullptr) {
+        recording.unsupported = true;
+        return result;
+    }
     for (int32_t i = 0; i < tensor_count; ++i) {
         ChipTensor &slot_tensor = node.tensors[static_cast<size_t>(i)];
         if (args.tag(i) != TensorArgType::OUTPUT) {
@@ -1945,9 +2430,6 @@ TaskOutputTensors graph_record_submit_node(
     // disagree.
     if (node.task_attrs.has_predicate()) {
         const CoreTaskPredicate &pred = args.predicate();
-        GraphRecordedPredicate recorded;
-        recorded.op = pred.op;
-        recorded.target = pred.target;
         const ChipTensor *operand = pred.operand.tensor;
         // OWN_OUTPUT would read the node's own output before the node runs, so it
         // names no value the predicate could be evaluating. An index vector that
@@ -1956,18 +2438,56 @@ TaskOutputTensors graph_record_submit_node(
         // Scheduler fatal rather than a named unsupported construct.
         const uint64_t flat_offset =
             operand == nullptr ? 0 : operand->compute_flat_offset(pred.operand.indices, pred.operand.ndims);
-        if (operand == nullptr || operand->ndims > MAX_TENSOR_DIMS || pred.operand.ndims > operand->ndims ||
-            flat_offset < operand->start_offset || flat_offset - operand->start_offset >= operand->extent_elem_cache ||
-            !graph_classify_tensor(recording, node, static_cast<int32_t>(node_index), *operand, &recorded.source) ||
-            recorded.source.source == GraphRecordedTensorSource::OWN_OUTPUT) {
+        const bool operand_valid = operand != nullptr && operand->ndims <= MAX_TENSOR_DIMS &&
+                                   pred.operand.ndims <= operand->ndims && flat_offset >= operand->start_offset &&
+                                   flat_offset - operand->start_offset < operand->extent_elem_cache;
+        GraphRecordedTensorSourceRef source;
+        bool source_classified = false;
+        if (operand_valid && recording.predicate_operand_cache.valid &&
+            graph_tensor_exact(*operand, recording.predicate_operand_cache.operand)) {
+            source = recording.predicate_operand_cache.source;
+            source_classified = true;
+        } else if (operand_valid &&
+                   graph_classify_tensor(recording, node, static_cast<int32_t>(node_index), *operand, &source)) {
+            // OWN_OUTPUT is relative to the node being recorded; the same
+            // address becomes INTERNAL for a later node, so never cache it.
+            if (source.source != GraphRecordedTensorSource::OWN_OUTPUT) {
+                recording.predicate_operand_cache.operand.copy(*operand);
+                recording.predicate_operand_cache.source = source;
+                recording.predicate_operand_cache.valid = true;
+            }
+            source_classified = true;
+        }
+        if (!operand_valid || !source_classified || source.source == GraphRecordedTensorSource::OWN_OUTPUT) {
             recording.unsupported = true;
         } else {
-            recorded.operand.copy(*operand);
-            recorded.elem_offset = flat_offset - operand->start_offset;
-            recorded.elem_size = static_cast<uint8_t>(get_element_size(operand->dtype));
+            const uint64_t elem_offset = flat_offset - operand->start_offset;
+            const uint8_t elem_size = static_cast<uint8_t>(get_element_size(operand->dtype));
+            const uint64_t operand_start_offset = operand->start_offset;
+            const size_t predicate_begin = recording.predicates.size() > GRAPH_PREDICATE_INTERN_WINDOW ?
+                                               recording.predicates.size() - GRAPH_PREDICATE_INTERN_WINDOW :
+                                               0;
+            for (size_t i = recording.predicates.size(); i > predicate_begin; --i) {
+                if (graph_predicate_replay_equivalent(
+                        recording.predicates[i - 1], source, operand_start_offset, elem_offset, pred.target, elem_size,
+                        pred.op
+                    )) {
+                    node.predicate_index = static_cast<int32_t>(i - 1);
+                    break;
+                }
+            }
+            if (node.predicate_index < 0) {
+                GraphRecordedPredicate recorded;
+                recorded.operand.copy(*operand);
+                recorded.source = source;
+                recorded.elem_offset = elem_offset;
+                recorded.target = pred.target;
+                recorded.elem_size = elem_size;
+                recorded.op = pred.op;
+                node.predicate_index = static_cast<int32_t>(recording.predicates.size());
+                recording.predicates.push_back(recorded);
+            }
         }
-        node.predicate_index = static_cast<int32_t>(recording.predicates.size());
-        recording.predicates.push_back(recorded);
     }
 
     node.fanin_offset = static_cast<uint32_t>(recording.internal_fanins.size());
@@ -2057,7 +2577,7 @@ TaskOutputTensors graph_record_submit_node(
         always_assert(recording.output_ranges.empty() || recording.output_ranges.back().end <= begin);
         recording.output_ranges.push_back({begin, end, static_cast<uint32_t>(node_index)});
     }
-    recording.nodes.push_back(std::move(node));
+    recording.nodes.push_back(node);
     ORCH_PHASE_END(HostOrchPhase::RecordNode, task_id.raw);
     return result;
 }
@@ -2081,6 +2601,48 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
     }
 
     const uint64_t full_key = graph_full_key(callable_hash, graph_key);
+
+    // One orchestration SO invokes graph_begin serially on its main thread.
+    // Recorder threads only publish `definition` and `recording_status`, so the
+    // fixed table itself needs no mutex. The first occurrence of a key in each
+    // run still performs the exact boundary/alias check; repeated occurrences
+    // are identified solely by the already-validated hash key.
+    for (size_t i = 0; i < state->fast_entry_count; ++i) {
+        GraphFastEntry &fast = state->fast_entries[i];
+        if (fast.full_key != full_key) continue;
+        if (fast.boundary_count != static_cast<uint32_t>(args.tensor_count()) ||
+            fast.boundary_scalar_count != static_cast<uint32_t>(args.scalar_count())) {
+            return result;
+        }
+        const GraphRecordingStatus status = fast.recording_status.load(std::memory_order_acquire);
+        const std::vector<std::byte> *definition = fast.definition.load(std::memory_order_acquire);
+        if (fast.validated_run_epoch != state->run_epoch) {
+            if (status != GraphRecordingStatus::READY || definition == nullptr) return result;
+            const GraphDefinition *header = graph_definition(*definition);
+            if (header == nullptr || !graph_boundary_matches(*header, args)) return result;
+            fast.validated_run_epoch = state->run_epoch;
+        }
+        PTO2TaskId submitted = PTO2TaskId::invalid();
+        ORCH_PHASE_START();
+        const bool submitted_ok = status == GraphRecordingStatus::READY && definition != nullptr ?
+                                      graph_submit_definition(orch, state, *definition, args, &submitted, true) :
+                                  status == GraphRecordingStatus::RECORDING ?
+                                      graph_submit_pending_definition(orch, state, full_key, args, &submitted) :
+                                      false;
+        if (submitted_ok) {
+            result.execute_block = false;
+            result.task_id = submitted;
+            ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
+#if SIMPLER_DFX
+            g_orch_submit_idx++;
+#if SIMPLER_ORCH_PROFILING
+            g_orch_submit_count++;
+#endif
+#endif
+        }
+        return result;
+    }
+
     std::unique_lock<std::mutex> lock(state->recording_mutex);
 
     // A published Definition is immutable, so the cache lookup comes first and
@@ -2088,9 +2650,11 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
     // would make an already-built Definition wait for an unrelated one.
     auto definition_it = state->definitions.find(full_key);
     if (definition_it != state->definitions.end()) {
+        const std::vector<std::byte> *definition = &definition_it->second;
+        lock.unlock();
         PTO2TaskId submitted = PTO2TaskId::invalid();
         ORCH_PHASE_START();
-        if (graph_submit_definition(orch, state, definition_it->second, args, &submitted)) {
+        if (graph_submit_definition(orch, state, *definition, args, &submitted)) {
             result.execute_block = false;
             result.task_id = submitted;
             ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
@@ -2114,6 +2678,7 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
             !graph_recording_boundary_matches(*entry.recording, args)) {
             return result;
         }
+        lock.unlock();
         PTO2TaskId submitted = PTO2TaskId::invalid();
         ORCH_PHASE_START();
         if (graph_submit_pending_definition(orch, state, full_key, args, &submitted)) {
@@ -2142,7 +2707,10 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
         return result;
     }
 
-    auto recording = std::make_unique<GraphRecording>();
+    if (state->next_prewarmed_recording >= state->prewarmed_recordings.size()) return result;
+    auto entry = std::move(state->prewarmed_recordings[state->next_prewarmed_recording++]);
+    if (entry == nullptr || entry->recording == nullptr) return result;
+    GraphRecording *recording = entry->recording.get();
     recording->full_key = full_key;
     recording->start_local_task_id = orch->ring.task_allocator.active_count();
     if (!graph_recording_init_tensor_map(*recording)) {
@@ -2152,16 +2720,25 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
     recording->boundary_scalar_count = args.scalar_count();
     recording->boundary_tensors.reserve(static_cast<size_t>(args.tensor_count()));
     recording->boundary_types.reserve(static_cast<size_t>(args.tensor_count()));
+    recording->boundary_alias_reps.resize(static_cast<size_t>(args.tensor_count()));
+    if (!graph_boundary_alias_representatives(args, recording->boundary_alias_reps.data())) return result;
     for (int32_t i = 0; i < args.tensor_count(); ++i) {
         recording->boundary_tensors.push_back(args.tensor(i).ref());
         recording->boundary_types.push_back(args.tag(i));
     }
-    auto entry = std::make_unique<GraphInflightRecording>();
     entry->full_key = full_key;
-    entry->recording = std::move(recording);
     GraphInflightRecording *entry_ptr = entry.get();
     state->inflight.emplace(full_key, std::move(entry));
+    GraphFastEntry &fast = state->fast_entries[state->fast_entry_count++];
+    fast.full_key = full_key;
+    fast.boundary_count = static_cast<uint32_t>(args.tensor_count());
+    fast.boundary_scalar_count = static_cast<uint32_t>(args.scalar_count());
+    fast.validated_run_epoch = state->run_epoch;
+    fast.definition.store(nullptr, std::memory_order_relaxed);
+    fast.recording_status.store(GraphRecordingStatus::RECORDING, std::memory_order_release);
+    entry_ptr->fast_entry = &fast;
     state->inflight_count.store(state->inflight.size(), std::memory_order_release);
+    lock.unlock();
 
     PTO2TaskId submitted = PTO2TaskId::invalid();
     ORCH_PHASE_START();
@@ -2178,8 +2755,12 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
 #endif
 #endif
     } else {
-        state->inflight.erase(full_key);
+        lock.lock();
+        auto failed = state->inflight.find(full_key);
+        if (failed != state->inflight.end() && failed->second.get() == entry_ptr) state->inflight.erase(failed);
         state->inflight_count.store(state->inflight.size(), std::memory_order_release);
+        always_assert(state->fast_entry_count != 0 && &state->fast_entries[state->fast_entry_count - 1] == &fast);
+        --state->fast_entry_count;
     }
     return result;
 }
@@ -2209,15 +2790,28 @@ bool PTO2OrchestratorState::graph_prepare(void *recording_handle, const GraphTas
         graph_recording_boundary_matches(*entry->recording, args) &&
         "the recording thread's boundary copy must match the boundary graph_begin recorded"
     );
+    try {
+        entry->recording->nodes.reserve(GRAPH_INITIAL_RECORDED_NODES);
+        entry->recording->tensor_sources.reserve(GRAPH_INITIAL_RECORDED_TENSORS);
+        entry->recording->scalars.reserve(GRAPH_INITIAL_RECORDED_SCALARS);
+        entry->recording->scalar_sources.reserve(GRAPH_INITIAL_RECORDED_SCALARS);
+        entry->recording->internal_fanins.reserve(GRAPH_INITIAL_RECORDED_FANINS);
+        entry->recording->output_ranges.reserve(GRAPH_INITIAL_RECORDED_NODES);
+    } catch (...) {
+        entry->recording->unsupported = true;
+        return false;
+    }
     args.anchor_scalar_sources();
     entry->recording->boundary_args = &args;
     g_active_graph_entry = entry;
     g_active_graph_recording = entry->recording.get();
     g_active_graph_owner = state;
+    host_phase_producer_begin();
     return true;
 }
 
 void PTO2OrchestratorState::graph_abort(void *recording_handle) {
+    host_phase_producer_end();
     GraphHostState *state = graph_state_from(this);
     auto *entry = static_cast<GraphInflightRecording *>(recording_handle);
     if (state == nullptr || entry == nullptr) return;
@@ -2240,9 +2834,15 @@ bool PTO2OrchestratorState::graph_end() {
     GraphInflightRecording *entry = g_active_graph_entry;
     if (state == nullptr || recording == nullptr || entry == nullptr) return false;
 
-    std::vector<std::byte> definition;
+    std::vector<std::byte> &definition = entry->definition_scratch;
+    definition.clear();
     ORCH_PHASE_START();
-    const bool built = graph_build_definition(*recording, &definition);
+    const bool built = graph_build_definition_direct(*recording, &definition);
+#ifndef NDEBUG
+    std::vector<std::byte> reference_definition;
+    const bool reference_built = graph_build_definition(*recording, &reference_definition);
+    debug_assert(reference_built == built && (!built || reference_definition == definition));
+#endif
     if (built) {
         ORCH_PHASE_END(HostOrchPhase::BuildDefinition, recording->nodes.size());
     }
@@ -2263,16 +2863,25 @@ bool PTO2OrchestratorState::graph_end() {
         if (entry->status() != GraphRecordingStatus::RECORDING || entry->full_key != header->full_key) {
             entry->set_status(GraphRecordingStatus::FAILED);
         } else {
-            state->definitions.emplace(header->full_key, std::move(definition));
-            entry->set_status(GraphRecordingStatus::READY);
+            auto [definition_it, inserted] = state->definitions.emplace(header->full_key, std::move(definition));
+            if (!inserted) {
+                entry->set_status(GraphRecordingStatus::FAILED);
+            } else if (entry->fast_entry != nullptr) {
+                entry->fast_entry->definition.store(&definition_it->second, std::memory_order_release);
+            }
+            if (!inserted) {
+                ready = false;
+            } else {
+                entry->set_status(GraphRecordingStatus::READY);
+            }
         }
         ready = entry->status() == GraphRecordingStatus::READY;
-        entry->recording.reset();
     }
     g_active_graph_entry = nullptr;
     g_active_graph_recording = nullptr;
     g_active_graph_owner = nullptr;
     state->recording_cv.notify_all();
+    host_phase_producer_end();
     return ready;
 }
 
@@ -2306,6 +2915,10 @@ void PTO2OrchestratorState::graph_commit() {
         failed = true;
     }
     if (!failed && !graph_finalize_pending_submissions(this, state, &failed_key)) failed = true;
+    for (auto &[key, entry] : drained) {
+        (void)key;
+        state->retired_recordings.push_back(std::move(entry));
+    }
     if (failed) {
         report_fatal(
             PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "failed to finalize asynchronous Graph key=%#llx",

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -127,6 +127,9 @@ target_compile_options(host_runtime
 # Platform name baked into the shared get_platform() impl in
 # src/common/platform/shared/host/platform_compile_info.cpp.
 target_compile_definitions(host_runtime PRIVATE SIMPLER_PLATFORM_NAME="a5")
+if(NOT SIMPLER_SANITIZERS)
+    target_compile_definitions(host_runtime PRIVATE NDEBUG)
+endif()
 
 if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE)
     target_compile_definitions(host_runtime PRIVATE SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=1)

--- a/src/a5/platform/sim/host/CMakeLists.txt
+++ b/src/a5/platform/sim/host/CMakeLists.txt
@@ -102,6 +102,9 @@ target_compile_options(host_runtime
 # Platform name baked into the shared get_platform() impl in
 # src/common/platform/shared/host/platform_compile_info.cpp.
 target_compile_definitions(host_runtime PRIVATE SIMPLER_PLATFORM_NAME="a5sim")
+if(NOT SIMPLER_SANITIZERS)
+    target_compile_definitions(host_runtime PRIVATE NDEBUG)
+endif()
 
 # Include directories
 target_include_directories(host_runtime

--- a/src/a5/runtime/host_build_graph/host/host_phase_trace.cpp
+++ b/src/a5/runtime/host_build_graph/host/host_phase_trace.cpp
@@ -44,7 +44,7 @@ namespace {
 // measured path.
 constexpr size_t kBindAttrsCapacity = 96;
 
-// One producer's counters and in-flight claim, on its own cache lines.
+// One producer's counters and pass-lifetime lease, on its own cache lines.
 //
 // The producers of a pass are independent -- each records its own Definition and
 // counts only its own operations -- so nothing here is shared, and the per-record
@@ -67,10 +67,9 @@ struct KindCounter {
 };
 
 struct alignas(64) ProducerLane {
-    // Records accepted by `active` but not yet finished with the counters and the
-    // pool. begin/end clear `active` and then drain the sum of these to zero, so a
-    // record can never be reported by a pass it does not belong to.
-    std::atomic<int32_t> in_flight{0};
+    // Producers admitted by `active` and not yet finished with the counters and
+    // pool. begin/end clear `active` and drain these leases before reusing a lane.
+    std::atomic<int32_t> leased{0};
     std::array<KindCounter, kHostPhaseKindCount> counters{};
 };
 
@@ -102,58 +101,31 @@ TraceState &state() {
     return s;
 }
 
-// This thread's lane for the current pass, or nullptr when every lane is taken.
-//
-// `generation` is what makes a cached lane safe to reuse: it is process-unique per
-// pass, so a lane claimed under one pass is never mistaken for a claim under
-// another. Returns the generation it claimed under, because the caller must
-// re-check it once admitted -- see host_phase_record.
-ProducerLane *producer_lane(TraceState &s, uint32_t &claimed_generation) {
-    static thread_local ProducerLane *lane = nullptr;
-    static thread_local uint32_t lane_generation = 0;
-    const uint32_t generation = s.generation.load(std::memory_order_acquire);
-    if (lane == nullptr || lane_generation != generation) {
-        const uint32_t index = s.next_lane.fetch_add(1, std::memory_order_relaxed);
-        lane = index < kProducerLanes ? &s.lanes[index] : nullptr;
-        lane_generation = generation;
-    }
-    claimed_generation = generation;
-    return lane;
-}
-
-// Publish-then-check against the trace lifecycle's clear-then-drain. Claiming a
-// slot before reading `active` is what makes the pair race-free: a record that
-// got in before the pass closed is waited for, and one that arrives after sees
-// `active` false and withdraws. The claim is on this producer's own line, so it
-// costs nothing to the others.
-class RecordAdmission {
-public:
-    RecordAdmission(TraceState &s, ProducerLane &lane) :
-        lane_(lane) {
-        lane_.in_flight.fetch_add(1, std::memory_order_acq_rel);
-        admitted_ = s.active.load(std::memory_order_acquire);
-        if (!admitted_) lane_.in_flight.fetch_sub(1, std::memory_order_acq_rel);
-    }
-    ~RecordAdmission() {
-        if (admitted_) lane_.in_flight.fetch_sub(1, std::memory_order_acq_rel);
-    }
-
-    RecordAdmission(const RecordAdmission &) = delete;
-    RecordAdmission &operator=(const RecordAdmission &) = delete;
-
-    explicit operator bool() const { return admitted_; }
-
-private:
-    ProducerLane &lane_;
-    bool admitted_{false};
+struct ProducerCursor {
+    TraceState *owner{nullptr};
+    ProducerLane *lane{nullptr};
+    uint32_t generation{0};
+    uint32_t depth{0};
+    bool denied{false};
 };
 
-// Called with `active` already false, so no new record can be admitted. Only the
-// recording worker can still be inside one, and commit joins it before a pass
-// ends, so in practice this returns without spinning.
-void drain_in_flight_records(TraceState &s) {
+ProducerCursor &producer_cursor() {
+    static thread_local ProducerCursor cursor;
+    return cursor;
+}
+
+void release_producer(ProducerCursor &cursor) {
+    ProducerLane *lane = cursor.lane;
+    cursor = {};
+    if (lane != nullptr) lane->leased.fetch_sub(1, std::memory_order_release);
+}
+
+// Called with `active` already false, so no new producer can be admitted. A
+// Graph commit normally joins every worker first; the drain also makes early
+// error exits safe without charging two atomic RMWs to every record.
+void drain_producers(TraceState &s) {
     for (ProducerLane &lane : s.lanes) {
-        while (lane.in_flight.load(std::memory_order_acquire) != 0) {}
+        while (lane.leased.load(std::memory_order_acquire) != 0) {}
     }
 }
 
@@ -190,9 +162,8 @@ void record_counter(ProducerLane &lane, uint64_t start_ns, uint64_t end_ns, uint
 }
 
 void append_record(TraceState &s, uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload, uint32_t index) {
-    // No lock: the pool claims a slot per record with one atomic increment, so
-    // concurrent recording threads do not serialize here. `pool` is republished
-    // only by begin/end, which bracket every record via the admission drain.
+    // No lock: a producer privately advances the buffer it claimed for this pass.
+    // `pool` is republished only after every producer lease is drained.
     HostPhaseRecordPool *pool = s.pool.load(std::memory_order_acquire);
     if (pool == nullptr) return;
     host_phase_pool_append(
@@ -237,68 +208,76 @@ bool host_phase_records_enabled() {
     return enabled;
 }
 
+void host_phase_producer_begin() {
+    TraceState &s = state();
+    ProducerCursor &cursor = producer_cursor();
+    if (cursor.depth != 0) {
+        ++cursor.depth;
+        return;
+    }
+    if (!s.active.load(std::memory_order_acquire)) return;
+
+    const uint32_t generation = s.generation.load(std::memory_order_acquire);
+    const uint32_t index = s.next_lane.fetch_add(1, std::memory_order_relaxed);
+    ProducerLane *lane = index < kProducerLanes ? &s.lanes[index] : nullptr;
+    if (lane == nullptr) {
+        cursor = ProducerCursor{&s, nullptr, generation, 1, true};
+        return;
+    }
+
+    // Publish the lease before re-checking the pass boundary. trace_end clears
+    // active before draining, so it either observes this lease or this producer
+    // observes the closed/replaced pass and withdraws.
+    lane->leased.fetch_add(1, std::memory_order_acq_rel);
+    if (!s.active.load(std::memory_order_acquire) || s.generation.load(std::memory_order_acquire) != generation) {
+        lane->leased.fetch_sub(1, std::memory_order_release);
+        return;
+    }
+    cursor = ProducerCursor{&s, lane, generation, 1, false};
+}
+
+void host_phase_producer_end() {
+    ProducerCursor &cursor = producer_cursor();
+    if (cursor.depth == 0) return;
+    if (--cursor.depth == 0) release_producer(cursor);
+}
+
 // Strong definitions overriding the orchestrator core's weak fallbacks, which
 // exist so builds without this translation unit still link.
 __attribute__((visibility("hidden"))) uint64_t host_phase_now_ns() {
-    if (!state().active.load(std::memory_order_acquire)) {
-        return 0;
-    }
+    const ProducerCursor &cursor = producer_cursor();
+    if (cursor.depth == 0 || cursor.owner != &state()) return 0;
     return static_cast<uint64_t>(simpler::log::monotonic_now_ns());
 }
 
 __attribute__((visibility("hidden"))) void
 host_phase_record(uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload, uint32_t index) {
     TraceState &s = state();
-    if (!s.active.load(std::memory_order_acquire) || kind >= kHostPhaseKindCount || end_ns < start_ns) {
+    if (start_ns == 0 || kind >= kHostPhaseKindCount || end_ns < start_ns) {
         return;
     }
-    // ORCH_PHASE_END calls this on every submit-level operation, so the load
-    // above stays the whole cost when tracing is off. Admission then re-checks
-    // under the in-flight claim, which is what actually closes the boundary.
-    uint32_t claimed_generation = 0;
-    ProducerLane *lane = producer_lane(s, claimed_generation);
-    if (lane == nullptr) {
+    ProducerCursor &cursor = producer_cursor();
+    if (cursor.depth == 0 || cursor.owner != &s || cursor.denied || cursor.lane == nullptr) {
         s.lane_denied.fetch_add(1, std::memory_order_relaxed);
         return;
     }
-    RecordAdmission admission(s, *lane);
-    if (!admission) {
-        return;
-    }
-    // A pass can have closed and a new one opened between claiming the lane and
-    // being admitted here, and the new pass resets the lane hand-out -- so a lane
-    // claimed for the old pass may already belong to another producer, and writing
-    // its plain-integer counters would be a race. A stale claim withdraws instead.
-    if (s.generation.load(std::memory_order_acquire) != claimed_generation) {
-        return;
-    }
-    record_counter(*lane, start_ns, end_ns, kind, payload);
+    record_counter(*cursor.lane, start_ns, end_ns, kind, payload);
     append_record(s, start_ns, end_ns, kind, payload, index);
 }
 
 void host_phase_record_bind(uint32_t kind, uint64_t start_ns, const char *attrs, uint64_t payload) {
     TraceState &s = state();
-    if (!s.active.load(std::memory_order_acquire) || !is_bind_kind(kind)) {
-        return;
-    }
-    uint32_t claimed_generation = 0;
-    ProducerLane *lane = producer_lane(s, claimed_generation);
-    if (lane == nullptr) {
+    if (start_ns == 0 || !is_bind_kind(kind)) return;
+    ProducerCursor &cursor = producer_cursor();
+    if (cursor.depth == 0 || cursor.owner != &s || cursor.denied || cursor.lane == nullptr) {
         s.lane_denied.fetch_add(1, std::memory_order_relaxed);
-        return;
-    }
-    RecordAdmission admission(s, *lane);
-    if (!admission) {
-        return;
-    }
-    if (s.generation.load(std::memory_order_acquire) != claimed_generation) {
         return;
     }
     const uint64_t end_ns = static_cast<uint64_t>(simpler::log::monotonic_now_ns());
     if (attrs != nullptr) {
         snprintf(s.bind_attrs[kind].data(), kBindAttrsCapacity, "%s", attrs);
     }
-    record_counter(*lane, start_ns, end_ns, kind, payload);
+    record_counter(*cursor.lane, start_ns, end_ns, kind, payload);
     append_record(s, start_ns, end_ns, kind, payload, 0);
 }
 
@@ -306,7 +285,8 @@ void host_phase_trace_begin(const void *host_api) {
     TraceState &s = state();
     std::lock_guard<std::mutex> lock(s.lifecycle_mutex);
     s.active.store(false, std::memory_order_release);
-    drain_in_flight_records(s);
+    release_producer(producer_cursor());
+    drain_producers(s);
     s.api = static_cast<const HostApi *>(host_api);
     HostPhaseRecordPool *pool =
         s.api != nullptr ?
@@ -329,6 +309,7 @@ void host_phase_trace_begin(const void *host_api) {
     s.next_lane.store(0, std::memory_order_relaxed);
     s.generation.fetch_add(1, std::memory_order_release);
     s.active.store(s.pool != nullptr || host_phase_breakdown_enabled(), std::memory_order_release);
+    host_phase_producer_begin();
 }
 
 void host_phase_trace_note_submitted(uint64_t submitted_tasks) {
@@ -342,11 +323,10 @@ void host_phase_trace_end() {
         return;
     }
     s.active.store(false, std::memory_order_release);
-    // Every record already past the `active` check finishes its counter and pool
-    // work before the totals below are read and the pool is handed back, so no
-    // lock is needed here either: the drain, not a mutex, is what makes the pool
-    // quiescent.
-    drain_in_flight_records(s);
+    release_producer(producer_cursor());
+    // Every admitted producer finishes its counter and pool work before totals
+    // are read and the pool is handed back.
+    drain_producers(s);
     // Read the pool's own tally before handing it back, and drop the pointer
     // after: the pool belongs to the runner from finish() onward, and the pass is
     // over either way, so nothing here may outlive it. Clearing `active` also

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -48,7 +48,6 @@
 #include <string>
 #include <type_traits>
 #include <utility>
-#include <unordered_map>
 #include <vector>
 
 #include "../common/pto_runtime_status.h"
@@ -387,6 +386,7 @@ typedef void (*OrchestrationPrewarmFunc)();
 struct HostOrchEntryPoints {
     OrchestrationEntryFunc entry{nullptr};
     OrchestrationBindFunc bind{nullptr};
+    GraphHostStatePtr graph_state;
 };
 
 // host_build_graph host-orch: the orchestrator builds the task graph in a host
@@ -394,75 +394,57 @@ struct HostOrchEntryPoints {
 // an index from its own block. The bytes the host wrote are therefore the bytes
 // the device schedules, with no on-device or pre-copy pointer fixup.
 
-// One submission's place in the block: where its bytes come from, which outer task
-// reads it, and how far into the block it sits.
-struct StagedSubmission {
+struct StagedDefinition {
     const std::byte *host_image;
-    PTO2TaskSlotState *outer_slot;
     size_t bytes;
+    uint64_t full_key;
+    uint64_t content_hash;
     uint64_t offset;
 };
 
-// Validate every pending submission, bind it to its uploaded Definition, and lay
-// the block out. No device call and no device address: the block lands in the
-// runtime arena's tail, whose base is not known until that region is grown to fit
-// the shared-memory image as well.
+// One submission's place in the block: where its bytes come from, which outer
+// task reads it, which staged Definition it names, and its block offset.
+struct StagedSubmission {
+    std::byte *host_image;
+    PTO2TaskSlotState *outer_slot;
+    size_t bytes;
+    uint64_t offset;
+    uint64_t definition_offset;
+};
+
+// Validate every Definition and submission, then lay one Graph block out in the
+// runtime arena's tail. The device address is intentionally unknown here: the
+// arena can grow only after the completed task count determines the compact SM
+// size.
 //
 // Submissions sit PTO2_ALIGN_SIZE apart. activation_gate is OR-ed by the outer task
 // and by the node path for the length of the graph, so two submissions sharing a
 // cache line would false-share on that word throughout.
 bool plan_graph_submissions(
-    const HostApi *api, GraphHostState &graph_state, std::vector<StagedSubmission> *staged, uint64_t *block_bytes,
-    uint64_t &uploaded_bytes
+    GraphHostState &graph_state, std::vector<StagedDefinition> *staged_definitions,
+    std::vector<StagedSubmission> *staged_submissions, uint64_t *block_bytes, uint64_t &uploaded_bytes
 ) {
     uploaded_bytes = 0;
     const size_t count = graph_host_upload_count(graph_state);
-    // Pass 1: upload each distinct Definition once as a shared device object
-    // ([GraphDefinitionHeader][Definition image]) keyed by content identity.
-    // Submissions reference the object's GM address, so this pass completing
-    // before any submission is uploaded is what makes the reference safe —
-    // the device boots only after both passes.
     GraphHostDefinitionList definitions = graph_host_definitions(graph_state);
-    struct UploadedDefinition {
-        void *device_object;               // GM address; host must not dereference
-        const GraphDefinition *host_view;  // the host-side image the object was built from
-    };
-    std::unordered_map<uint64_t, UploadedDefinition> definition_objects;
-    for (const GraphHostDefinition &entry : definitions.entries) {
+    staged_definitions->reserve(definitions.size());
+    *block_bytes = 0;
+    for (const GraphHostDefinition &entry : definitions) {
         if (entry.data == nullptr || entry.bytes < sizeof(GraphDefinition)) continue;
         const auto *definition = reinterpret_cast<const GraphDefinition *>(entry.data);
         if (definition->total_bytes != entry.bytes || definition->full_key != entry.full_key) continue;
-        const size_t object_bytes = sizeof(GraphDefinitionHeader) + entry.bytes;
-        void *object =
-            api->acquire_graph_definition_buffer(entry.full_key, object_bytes, alignof(GraphDefinitionHeader));
-        if (object == nullptr) {
-            LOG_ERROR(
-                "host-orch: failed to retain %zu bytes for Graph Definition key=%#llx", object_bytes,
-                static_cast<unsigned long long>(entry.full_key)
-            );
+        if (entry.bytes > UINT64_MAX - sizeof(GraphDefinitionHeader)) return false;
+        const uint64_t object_bytes = sizeof(GraphDefinitionHeader) + entry.bytes;
+        const uint64_t offset = PTO2_ALIGN_UP(*block_bytes, alignof(GraphDefinitionHeader));
+        if (offset < *block_bytes || object_bytes > UINT64_MAX - offset) {
+            LOG_ERROR("host-orch: Graph Definition block size overflows uint64_t");
             return false;
         }
-        std::vector<std::byte> staging(object_bytes, std::byte{0});
-        auto *header = reinterpret_cast<GraphDefinitionHeader *>(staging.data());
-        header->magic = GRAPH_DEFINITION_OBJECT_MAGIC;
-        header->verify_state.store(
-            static_cast<uint32_t>(GraphDefinitionVerifyState::UPLOADED), std::memory_order_relaxed
-        );
-        header->definition_bytes = static_cast<uint32_t>(entry.bytes);
-        header->content_hash = definition->content_hash;
-        header->full_key = definition->full_key;
-        std::memcpy(staging.data() + sizeof(GraphDefinitionHeader), entry.data, entry.bytes);
-        if (api->copy_to_device(object, staging.data(), object_bytes) != 0) {
-            LOG_ERROR("host-orch: failed to upload Graph Definition object");
-            return false;
-        }
-        definition_objects.emplace(definition->content_hash, UploadedDefinition{object, definition});
-        uploaded_bytes += object_bytes;
+        staged_definitions->push_back({entry.data, entry.bytes, entry.full_key, definition->content_hash, offset});
+        *block_bytes = offset + object_bytes;
     }
 
-    // Pass 2: validate every submission and lay the block out.
-    staged->reserve(count);
-    *block_bytes = 0;
+    staged_submissions->reserve(count);
     for (size_t index = 0; index < count; ++index) {
         std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
         if (!upload.has_value() || upload->outer_slot == nullptr || upload->data == nullptr ||
@@ -476,40 +458,55 @@ bool plan_graph_submissions(
             LOG_ERROR("host-orch: Graph submission size does not match its POD image");
             return false;
         }
-        auto object_it = definition_objects.find(submission->definition_hash);
-        if (object_it == definition_objects.end() || object_it->second.device_object == nullptr) {
-            LOG_ERROR("host-orch: Graph submission has no uploaded Definition object");
+        const auto definition_it =
+            std::find_if(staged_definitions->begin(), staged_definitions->end(), [&](const StagedDefinition &entry) {
+                return entry.content_hash == submission->definition_hash;
+            });
+        if (definition_it == staged_definitions->end()) {
+            LOG_ERROR("host-orch: Graph submission has no staged Definition object");
             return false;
         }
-        // Checked against the host-side Definition image the device object was
-        // built from; the GM object itself is never dereferenced on the host.
-        // Execution storage needs no retained buffer: it is the tail of the
-        // outer task's own heap allocation, which graph_submit_definition sized
-        // to required_heap + execution_storage_bytes.
-        const GraphDefinition *definition = object_it->second.host_view;
+        const GraphDefinition *definition = reinterpret_cast<const GraphDefinition *>(definition_it->host_image);
         if (definition->task_count == 0 || definition->task_count > GRAPH_MAX_NODES ||
             definition->full_key != submission->graph_key || definition->execution_storage_bytes == 0) {
             LOG_ERROR("host-orch: invalid Graph Definition for submission");
             return false;
         }
-        submission->definition_addr = reinterpret_cast<uint64_t>(object_it->second.device_object);
         submission->local_execution = 0;
         submission->activation_gate = 0;
-
-        staged->push_back({upload->data, upload->outer_slot, upload->bytes, *block_bytes});
-        *block_bytes += PTO2_ALIGN_UP(static_cast<uint64_t>(upload->bytes), PTO2_ALIGN_SIZE);
+        const uint64_t offset = PTO2_ALIGN_UP(*block_bytes, PTO2_ALIGN_SIZE);
+        const uint64_t padded_bytes = PTO2_ALIGN_UP(static_cast<uint64_t>(upload->bytes), PTO2_ALIGN_SIZE);
+        if (offset < *block_bytes || padded_bytes > UINT64_MAX - offset) {
+            LOG_ERROR("host-orch: Graph submission block size overflows uint64_t");
+            return false;
+        }
+        staged_submissions->push_back({upload->data, upload->outer_slot, upload->bytes, offset, definition_it->offset});
+        *block_bytes = offset + padded_bytes;
     }
-    uploaded_bytes += *block_bytes;
+    uploaded_bytes = *block_bytes;
     return true;
 }
 
-// Copy the planned block into `block_base` and point each outer task at the device
-// address its submission will occupy. The graph_context write lands in the host
-// shared-memory mirror, which has not been compacted or copied yet.
-void stage_graph_submissions(
-    const std::vector<StagedSubmission> &staged, char *block_base, const char *device_block_base
+// Build every Definition object and patch/copy every submission into the one
+// bind image. graph_context writes land in the host SM mirror before compaction.
+void stage_graph_block(
+    const std::vector<StagedDefinition> &definitions, const std::vector<StagedSubmission> &submissions,
+    char *block_base, const char *device_block_base
 ) {
-    for (const StagedSubmission &entry : staged) {
+    for (const StagedDefinition &entry : definitions) {
+        auto *header = reinterpret_cast<GraphDefinitionHeader *>(block_base + entry.offset);
+        header->magic = GRAPH_DEFINITION_OBJECT_MAGIC;
+        header->verify_state.store(
+            static_cast<uint32_t>(GraphDefinitionVerifyState::UPLOADED), std::memory_order_relaxed
+        );
+        header->definition_bytes = static_cast<uint32_t>(entry.bytes);
+        header->content_hash = entry.content_hash;
+        header->full_key = entry.full_key;
+        std::memcpy(block_base + entry.offset + sizeof(GraphDefinitionHeader), entry.host_image, entry.bytes);
+    }
+    for (const StagedSubmission &entry : submissions) {
+        auto *submission = reinterpret_cast<GraphSubmission *>(entry.host_image);
+        submission->definition_addr = reinterpret_cast<uint64_t>(device_block_base + entry.definition_offset);
         std::memcpy(block_base + entry.offset, entry.host_image, entry.bytes);
         entry.outer_slot->graph_context = const_cast<char *>(device_block_base) + entry.offset;
     }
@@ -567,12 +564,14 @@ int32_t run_host_orchestration(
         return -1;
     }
 
-    GraphHostStatePtr graph_state = make_graph_host_state();
-    if (!graph_state) {
-        LOG_ERROR("host-orch: failed to allocate Graph host state");
+    auto *entry_points = reinterpret_cast<HostOrchEntryPoints *>(host_orch_func_ptr);
+    if (entry_points == nullptr || entry_points->graph_state == nullptr ||
+        !graph_host_begin_run(*entry_points->graph_state)) {
+        LOG_ERROR("host-orch: failed to begin callable Graph state");
         return -1;
     }
-    GraphHostStateBinding graph_binding(rt->orchestrator, graph_state.get());
+    GraphHostState &graph_state = *entry_points->graph_state;
+    GraphHostStateBinding graph_binding(rt->orchestrator, &graph_state);
 
     // Install the ops table (host s_runtime_ops) and latch this run's cluster
     // counts. worker_count is published by DeviceRunner::prepare_launch_shape
@@ -593,7 +592,6 @@ int32_t run_host_orchestration(
     // context_lens/block_table) whether or not the platform maps device memory
     // into the host address space.
 
-    const auto *entry_points = reinterpret_cast<const HostOrchEntryPoints *>(host_orch_func_ptr);
     if (entry_points->bind == nullptr) {
         LOG_ERROR("host-orch: orch .so framework_bind_runtime was not resolved");
         return -1;
@@ -664,19 +662,21 @@ int32_t run_host_orchestration(
     // After the span closes: the reduction walks a few hundred records and emits
     // five markers, which must not be charged to the pass it measures.
 
-    // Uploads each distinct Definition as its own retained device object and lays
-    // out the submission block. The block itself is staged below, into the arena's
-    // second device tail, so nothing here allocates or copies it.
+    // Plan all Definition objects and submissions as one arena-tail block. No
+    // device call occurs until the complete bind image is transferred below.
     const int64_t t_graph_ns = bind_now_ns();
     uint64_t graph_bytes = 0;
+    std::vector<StagedDefinition> staged_definitions;
     std::vector<StagedSubmission> staged_submissions;
-    uint64_t submission_block_bytes = 0;
-    if (!plan_graph_submissions(api, *graph_state, &staged_submissions, &submission_block_bytes, graph_bytes)) {
+    uint64_t graph_block_bytes = 0;
+    if (!plan_graph_submissions(
+            graph_state, &staged_definitions, &staged_submissions, &graph_block_bytes, graph_bytes
+        )) {
         return -1;
     }
     {
         char attrs[96];
-        snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, graph_host_upload_count(*graph_state), graph_bytes);
+        snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, graph_host_upload_count(graph_state), graph_bytes);
         record_bind_phase(HostPhaseKind::BindGraphUpload, t_graph_ns, attrs, graph_bytes);
     }
 
@@ -726,11 +726,10 @@ int32_t run_host_orchestration(
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         total_heap_size += eff_heap_sizes[r];
     }
-    // Two device tails past off_copied_end, in this order: the shared-memory image,
-    // then the Graph submission block. Both are per-run content of the region the
-    // device already owns, so neither needs an allocation of its own.
-    const uint64_t off_submissions = layout.off_copied_end + image_bytes;
-    const uint64_t device_arena_bytes = off_submissions + submission_block_bytes;
+    // Two device tails past off_copied_end: the shared-memory image, then all
+    // Graph Definition objects and submissions.
+    const uint64_t off_graph = layout.off_copied_end + image_bytes;
+    const uint64_t device_arena_bytes = off_graph + graph_block_bytes;
     if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, device_arena_bytes) != 0) {
         LOG_ERROR("host-orch: failed to commit %" PRIu64 " bytes of device runtime arena", device_arena_bytes);
         return -1;
@@ -750,12 +749,12 @@ int32_t run_host_orchestration(
     }
 
     // One host source for one copy: the copied zone, the shared-memory image, and
-    // the submission block, at exactly the offsets they occupy on the device.
+    // the Graph block, at exactly the offsets they occupy on the device.
     // Over-allocated and rounded up because every segment offset is
     // PTO2_ALIGN_SIZE-aligned and PTO2TaskSlotState is alignas(64), which a byte
     // vector's data() is not.
     const uint64_t copied_bytes = layout.off_copied_end - layout.off_copied_begin;
-    const uint64_t upload_bytes = copied_bytes + image_bytes + submission_block_bytes;
+    const uint64_t upload_bytes = copied_bytes + image_bytes + graph_block_bytes;
     std::vector<std::byte> storage(upload_bytes + PTO2_ALIGN_SIZE, std::byte{0});
     char *upload_base = reinterpret_cast<char *>(
         (reinterpret_cast<uintptr_t>(storage.data()) + PTO2_ALIGN_SIZE - 1) &
@@ -764,7 +763,9 @@ int32_t run_host_orchestration(
 
     // Before the shared-memory mirror is compacted: this writes each outer task's
     // graph_context into it, and compaction is what carries those slots.
-    stage_graph_submissions(staged_submissions, upload_base + copied_bytes + image_bytes, arena_dev + off_submissions);
+    stage_graph_block(
+        staged_definitions, staged_submissions, upload_base + copied_bytes + image_bytes, arena_dev + off_graph
+    );
 
     // The orchestrator has finished, so its pointers into the host-only tail have
     // no further reader on either side — and this header is about to be copied, so
@@ -785,8 +786,8 @@ int32_t run_host_orchestration(
         char attrs[96];
         snprintf(
             attrs, sizeof(attrs),
-            "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " subs=%" PRIu64 " pstride=%" PRIu64, nt,
-            upload_bytes, copied_bytes, image_bytes, submission_block_bytes, payload_stride
+            "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " graph=%" PRIu64 " pstride=%" PRIu64, nt,
+            upload_bytes, copied_bytes, image_bytes, graph_block_bytes, payload_stride
         );
         record_bind_phase(HostPhaseKind::BindArenaH2d, t_h2d_ns, attrs, upload_bytes);
     }
@@ -900,11 +901,18 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
         reinterpret_cast<OrchestrationPrewarmFunc>(prewarm_sym)();
         // Safe to unlink now: the handle keeps the .so mapped regardless of path.
         unlink(so_path.c_str());
-        auto *eps = new HostOrchEntryPoints{};
+        auto eps = std::make_shared<HostOrchEntryPoints>();
+        eps->graph_state = make_graph_host_state();
+        if (eps->graph_state == nullptr) {
+            LOG_ERROR("host-orch: failed to allocate callable Graph state");
+            dlclose(handle);
+            return -1;
+        }
         eps->entry = reinterpret_cast<OrchestrationEntryFunc>(entry);
         eps->bind = reinterpret_cast<OrchestrationBindFunc>(bind_sym);
         out->host_dlopen_handle = handle;
-        out->host_orch_func_ptr = eps;
+        out->host_orch_func_ptr = eps.get();
+        out->host_orch_owner = std::move(eps);
         LOG_INFO("host-orch: loaded orchestration entry '%s' on host", orch_func_name);
     }
     LOG_INFO("Orchestration SO: %zu bytes staged", orch_so_size);

--- a/src/a5/runtime/host_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/host_build_graph/orchestration/pto_orchestration_api.h
@@ -35,12 +35,12 @@
 #include <condition_variable>
 #include <cstring>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <tuple>
 #include <type_traits>
 #include <utility>
-#include <vector>
 
 // Type headers needed by orchestration
 #include "common.h"              // framework_bind_runtime / framework_current_runtime
@@ -196,10 +196,10 @@ public:
     bool prewarm() {
         std::unique_lock<std::mutex> lock(mutex_);
         if (stopping_) return false;
-        while (workers_.size() < kPrewarmedWorkerCount) {
+        while (worker_count_ < kPrewarmedWorkerCount) {
             if (!create_worker_locked()) break;
         }
-        const size_t target = workers_.size();
+        const size_t target = worker_count_;
         cv_.wait(lock, [&]() {
             return ready_workers_ >= target || stopping_;
         });
@@ -228,25 +228,37 @@ public:
             free_owned_args_[free_owned_args_count_++] = owned_args_index;
             return false;
         }
-        PendingJob &pending = jobs_[job_tail_];
-        pending.function = std::move(next);
-        pending.owned_args_index = owned_args_index;
-        job_tail_ = (job_tail_ + 1) % kJobCapacity;
-        job_count_++;
-        const size_t desired_workers = std::min(kMaxWorkerCount, job_count_ + active_jobs_);
-        while (workers_.size() < desired_workers) {
+        if (!batch_active_) {
+            batch_active_ = true;
+            jobs_in_batch_ = 0;
+            if (++batch_epoch_ == 0) ++batch_epoch_;
+        }
+        const size_t desired_workers = std::min(kMaxWorkerCount, jobs_in_batch_ + 1);
+        while (worker_count_ < desired_workers) {
             if (!create_worker_locked()) break;
         }
-        if (workers_.empty()) {
-            job_tail_ = (job_tail_ + kJobCapacity - 1) % kJobCapacity;
-            PendingJob &rollback = jobs_[job_tail_];
-            rollback.function = {};
-            job_count_--;
-            free_owned_args_[free_owned_args_count_++] = rollback.owned_args_index;
+        size_t worker_index = kMaxWorkerCount;
+        for (size_t i = 0; i < worker_count_; ++i) {
+            WorkerSlot &worker = *workers_[i];
+            if (!worker.pending && !worker.active && worker.claimed_epoch != batch_epoch_) {
+                worker_index = i;
+                break;
+            }
+        }
+        if (worker_count_ < desired_workers || worker_index == kMaxWorkerCount) {
+            if (jobs_in_batch_ == 0) batch_active_ = false;
+            free_owned_args_[free_owned_args_count_++] = owned_args_index;
             return false;
         }
+        WorkerSlot &worker = *workers_[worker_index];
+        worker.job.function = std::move(next);
+        worker.job.owned_args_index = owned_args_index;
+        worker.pending = true;
+        worker.claimed_epoch = batch_epoch_;
+        job_count_++;
+        jobs_in_batch_++;
         lock.unlock();
-        cv_.notify_one();
+        worker.cv.notify_one();
         // graph_begin() has already installed the keyed in-flight entry and
         // submitted the zero-heap outer shell. Enqueuing the private job is
         // therefore the last dependency of the caller; graph_prepare() and all
@@ -265,6 +277,8 @@ public:
         cv_.wait(lock, [&]() {
             return job_count_ == 0 && active_jobs_ == 0;
         });
+        batch_active_ = false;
+        jobs_in_batch_ = 0;
     }
 
 private:
@@ -277,26 +291,40 @@ private:
         size_t owned_args_index{0};
     };
 
+    struct WorkerSlot {
+        std::condition_variable cv;
+        std::thread thread;
+        PendingJob job;
+        uint64_t claimed_epoch{0};
+        bool pending{false};
+        bool active{false};
+    };
+
     bool is_worker_thread_locked(std::thread::id id) const {
-        for (const std::thread &worker : workers_) {
-            if (worker.get_id() == id) return true;
+        for (size_t i = 0; i < worker_count_; ++i) {
+            if (workers_[i]->thread.get_id() == id) return true;
         }
         return false;
     }
 
     bool create_worker_locked() {
-        if (stopping_ || workers_.size() >= kMaxWorkerCount) return false;
+        if (stopping_ || worker_count_ >= kMaxWorkerCount) return false;
+        const size_t worker_index = worker_count_;
         try {
-            workers_.emplace_back([this]() {
-                run();
+            workers_[worker_index] = std::make_unique<WorkerSlot>();
+            workers_[worker_index]->thread = std::thread([this, worker_index]() {
+                run(worker_index);
             });
+            worker_count_++;
             return true;
         } catch (...) {
+            workers_[worker_index].reset();
             return false;
         }
     }
 
-    void run() {
+    void run(size_t worker_index) {
+        WorkerSlot &worker = *workers_[worker_index];
         {
             std::lock_guard<std::mutex> lock(mutex_);
             ready_workers_++;
@@ -306,14 +334,14 @@ private:
             PendingJob current;
             {
                 std::unique_lock<std::mutex> lock(mutex_);
-                cv_.wait(lock, [&]() {
-                    return job_count_ != 0 || stopping_;
+                worker.cv.wait(lock, [&]() {
+                    return worker.pending || stopping_;
                 });
-                if (stopping_ && job_count_ == 0) return;
-                PendingJob &pending = jobs_[job_head_];
-                current.function = std::move(pending.function);
-                current.owned_args_index = pending.owned_args_index;
-                job_head_ = (job_head_ + 1) % kJobCapacity;
+                if (stopping_ && !worker.pending) return;
+                current.function = std::move(worker.job.function);
+                current.owned_args_index = worker.job.owned_args_index;
+                worker.pending = false;
+                worker.active = true;
                 job_count_--;
                 active_jobs_++;
             }
@@ -323,6 +351,7 @@ private:
                 std::lock_guard<std::mutex> lock(mutex_);
                 free_owned_args_[free_owned_args_count_++] = current.owned_args_index;
                 active_jobs_--;
+                worker.active = false;
             }
             cv_.notify_all();
         }
@@ -334,24 +363,28 @@ private:
             std::lock_guard<std::mutex> lock(mutex_);
             stopping_ = true;
         }
-        cv_.notify_all();
-        for (std::thread &worker : workers_) {
+        for (size_t i = 0; i < worker_count_; ++i) {
+            workers_[i]->cv.notify_one();
+        }
+        for (size_t i = 0; i < worker_count_; ++i) {
+            std::thread &worker = workers_[i]->thread;
             if (worker.joinable()) worker.join();
         }
     }
 
-    std::vector<std::thread> workers_;
+    std::array<std::unique_ptr<WorkerSlot>, kMaxWorkerCount> workers_;
     std::mutex mutex_;
     std::condition_variable cv_;
     std::array<GraphOwnedArgs, kJobCapacity> owned_args_;
     std::array<size_t, kJobCapacity> free_owned_args_{};
-    std::array<PendingJob, kJobCapacity> jobs_;
     size_t free_owned_args_count_{kJobCapacity};
-    size_t job_head_{0};
-    size_t job_tail_{0};
     size_t job_count_{0};
+    size_t jobs_in_batch_{0};
+    size_t worker_count_{0};
     size_t ready_workers_{0};
     size_t active_jobs_{0};
+    uint64_t batch_epoch_{0};
+    bool batch_active_{false};
     bool stopping_{false};
 };
 

--- a/src/a5/runtime/host_build_graph/runtime/host_phase_trace.h
+++ b/src/a5/runtime/host_build_graph/runtime/host_phase_trace.h
@@ -63,6 +63,18 @@ bool host_phase_breakdown_enabled();
 bool host_phase_records_enabled();
 
 /**
+ * Hold one trace-lifetime lease for the calling producer.
+ *
+ * The main submitting thread holds a lease for the whole bind pass. A Graph
+ * recording worker holds one from graph_prepare through graph_end/graph_abort.
+ * Calls may nest when a recording falls back to the submitting thread.
+ */
+void host_phase_producer_begin();
+
+/** Release one nesting level of the calling producer's trace lease. */
+void host_phase_producer_end();
+
+/**
  * Host monotonic nanoseconds, or 0 when this pass records nothing — which is
  * what keeps the orchestrator's per-operation hooks down to two calls returning
  * a constant.

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -199,6 +199,8 @@ static uint32_t g_orch_submit_idx = 0;
 // plain integer because this file is also compiled for the AICPU, where the
 // platform's host headers are absent.
 __attribute__((weak, visibility("hidden"))) void host_phase_record(uint64_t, uint64_t, uint32_t, uint64_t, uint32_t) {}
+__attribute__((weak, visibility("hidden"))) void host_phase_producer_begin() {}
+__attribute__((weak, visibility("hidden"))) void host_phase_producer_end() {}
 
 // Host monotonic clock shared with the `[STRACE]` span tree, so a record nests
 // under chip.run.bind.host_orch without any clock conversion. The host build
@@ -321,6 +323,67 @@ struct GraphRecordedPredicate {
     PredicateOp op{PredicateOp::NONE};
 };
 
+// Predicate groups commonly reuse one operand for many nodes. Its source is a
+// property of the tensor, not of the element/target, so classify it once rather
+// than rescan every Graph boundary for each node in the group.
+struct GraphPredicateOperandCache {
+    ChipTensor operand;
+    GraphRecordedTensorSourceRef source;
+    bool valid{false};
+};
+
+struct GraphRecordedTensors {
+    ChipTensor *data{nullptr};
+    size_t count{0};
+
+    size_t size() const { return count; }
+    ChipTensor *begin() const { return data; }
+    ChipTensor *end() const { return count == 0 ? data : data + count; }
+    ChipTensor &operator[](size_t index) const { return data[index]; }
+};
+
+class GraphRecordedTensorArena {
+public:
+    bool reserve_initial() {
+        if (!blocks_.empty()) return true;
+        std::unique_ptr<ChipTensor[]> storage{new (std::nothrow) ChipTensor[kInitialBlockTensors]};
+        if (storage == nullptr) return false;
+        try {
+            blocks_.push_back(Block{std::move(storage), kInitialBlockTensors, 0});
+        } catch (...) {
+            return false;
+        }
+        return true;
+    }
+
+    ChipTensor *allocate(size_t count) {
+        if (count == 0) return nullptr;
+        if (blocks_.empty() || count > blocks_.back().capacity - blocks_.back().used) {
+            const size_t capacity = std::max(kInitialBlockTensors, count);
+            std::unique_ptr<ChipTensor[]> storage{new (std::nothrow) ChipTensor[capacity]};
+            if (storage == nullptr) return nullptr;
+            try {
+                blocks_.push_back(Block{std::move(storage), capacity, 0});
+            } catch (...) {
+                return nullptr;
+            }
+        }
+        Block &block = blocks_.back();
+        ChipTensor *result = block.storage.get() + block.used;
+        block.used += count;
+        return result;
+    }
+
+private:
+    static constexpr size_t kInitialBlockTensors = 2048;
+    struct Block {
+        std::unique_ptr<ChipTensor[]> storage;
+        size_t capacity;
+        size_t used;
+    };
+    std::vector<Block> blocks_;
+};
+
 struct GraphRecordedNode {
     std::array<int32_t, PTO2_SUBTASK_SLOT_COUNT> kernel_ids{};
     ActiveMask active_mask{};
@@ -333,7 +396,7 @@ struct GraphRecordedNode {
     // this one stays per node: its heap buffer has to outlive every later node's
     // recording. The arrays whose addresses are never borrowed live flat on the
     // recording instead — see GraphRecording.
-    std::vector<ChipTensor> tensors;
+    GraphRecordedTensors tensors;
     // Ranges into the recording's flat arrays. tensor_sources has one entry per
     // tensor, so tensors.size() is its count.
     uint32_t tensor_source_offset{0};
@@ -369,6 +432,15 @@ struct GraphRecording {
     bool unsupported{false};
     std::vector<ChipTensor> boundary_tensors;
     std::vector<TensorArgType> boundary_types;
+    // First index carrying each boundary tensor's exact (address, size) pair.
+    // Computing this once keeps later same-key submits on an O(N) exact
+    // contract check instead of rediscovering both alias partitions in O(N^2).
+    std::vector<uint16_t> boundary_alias_reps;
+    // Every node needs a contiguous tensor array because TaskOutputTensors
+    // borrows its outputs until the recording ends. A private monotonic arena
+    // preserves that ownership contract while replacing one general-heap
+    // allocation per node with a handful of worker-local bump-allocator chunks.
+    GraphRecordedTensorArena tensor_storage;
     std::vector<GraphRecordedNode> nodes;
     // Flat per-node arrays, indexed by the ranges on GraphRecordedNode. Held
     // here rather than on each node so recording a graph pays a handful of
@@ -381,6 +453,7 @@ struct GraphRecording {
     // Indexed by GraphRecordedNode::predicate_index; only predicated nodes
     // contribute an entry.
     std::vector<GraphRecordedPredicate> predicates;
+    GraphPredicateOperandCache predicate_operand_cache;
     // Hazard state for the recorded body, owned per recording because several
     // graphs record at once, each on its own thread.
     //
@@ -411,11 +484,35 @@ struct GraphRecording {
 
 struct GraphPendingUpload {
     PTO2TaskSlotState *outer_slot{nullptr};
-    std::vector<std::byte> image;
+    size_t image_offset{0};
+    size_t image_bytes{0};
     bool deferred_heap{false};
 };
 
 enum class GraphRecordingStatus : uint8_t { RECORDING = 0, READY = 1, FAILED = 2 };
+
+constexpr size_t GRAPH_INITIAL_SUBMISSION_COUNT = 128;
+constexpr size_t GRAPH_INITIAL_SUBMISSION_BYTES = 512U << 10;
+constexpr size_t GRAPH_INITIAL_RECORDED_NODES = 320;
+constexpr size_t GRAPH_PREDICATE_INTERN_WINDOW = 64;
+constexpr size_t GRAPH_INITIAL_RECORDED_TENSORS = 4096;
+constexpr size_t GRAPH_INITIAL_RECORDED_SCALARS = 2048;
+constexpr size_t GRAPH_INITIAL_RECORDED_FANINS = 2048;
+constexpr size_t GRAPH_INITIAL_DEFINITION_BYTES = 256U << 10;
+constexpr size_t GRAPH_PREWARM_DEFINITIONS = 8;
+
+// Main-thread lookup for the common repeated-key path. A run validates a key's
+// fixed boundary contract once, then later submissions need only this immutable
+// key plus the atomically published recording state. This keeps the recording
+// mutex off the path that is meant to overlap with recorder publication.
+struct GraphFastEntry {
+    uint64_t full_key{0};
+    uint32_t boundary_count{0};
+    uint32_t boundary_scalar_count{0};
+    uint64_t validated_run_epoch{0};
+    std::atomic<GraphRecordingStatus> recording_status{GraphRecordingStatus::FAILED};
+    std::atomic<const std::vector<std::byte> *> definition{nullptr};
+};
 
 // One Definition being recorded. Entries are keyed by Graph key and held by
 // unique_ptr, so a rehash of the owning map never moves one: the recording
@@ -429,9 +526,14 @@ struct GraphInflightRecording {
     // main-thread burst of same-key submissions starve the thread before it can
     // bind its private recording state. Every other access holds the mutex.
     std::atomic<GraphRecordingStatus> recording_status{GraphRecordingStatus::RECORDING};
+    GraphFastEntry *fast_entry{nullptr};
+    std::vector<std::byte> definition_scratch;
 
     GraphRecordingStatus status() const { return recording_status.load(std::memory_order_acquire); }
-    void set_status(GraphRecordingStatus next) { recording_status.store(next, std::memory_order_release); }
+    void set_status(GraphRecordingStatus next) {
+        recording_status.store(next, std::memory_order_release);
+        if (fast_entry != nullptr) fast_entry->recording_status.store(next, std::memory_order_release);
+    }
 };
 
 struct GraphHostState {
@@ -439,16 +541,31 @@ struct GraphHostState {
     // Recordings in flight, at most one per Graph key. Several record at once,
     // each on its own thread; graph_commit drains and finalizes all of them.
     std::unordered_map<uint64_t, std::unique_ptr<GraphInflightRecording>> inflight;
+    // Completed cold recordings retain their worker-local arenas until the
+    // callable is destroyed. Releasing several large recording trees while
+    // holding recording_mutex serialized allocator work in graph_commit.
+    std::vector<std::unique_ptr<GraphInflightRecording>> retired_recordings;
     std::vector<GraphPendingUpload> pending_uploads;
+    // All per-occurrence submission images share one callable-owned allocation.
+    // begin_run clears its size but retains capacity, so steady-state replay
+    // performs no per-Graph host allocation and is already laid out as the H2D
+    // batch consumed by runtime_maker.
+    std::vector<std::byte> pending_image_storage;
+    size_t pending_image_bytes{0};
     std::mutex recording_mutex;
     std::condition_variable recording_cv;
     // Mirrors inflight.size() so orchestration completion answers the common
     // "nothing is recording" case without taking recording_mutex.
     std::atomic<size_t> inflight_count{0};
+    std::array<GraphFastEntry, GRAPH_MAX_DEFINITIONS> fast_entries{};
+    size_t fast_entry_count{0};
+    uint64_t run_epoch{0};
+    std::array<std::unique_ptr<GraphInflightRecording>, GRAPH_MAX_DEFINITIONS> prewarmed_recordings{};
+    size_t next_prewarmed_recording{0};
 
     // Definitions this run can still admit: published plus in flight, against
     // the per-worker cache limit.
-    size_t claimed_definitions() const { return definitions.size() + inflight.size(); }
+    size_t claimed_definitions() const { return fast_entry_count; }
     bool any_recording() const {
         for (const auto &entry : inflight) {
             if (entry.second->status() == GraphRecordingStatus::RECORDING) return true;
@@ -493,6 +610,25 @@ bool graph_tensor_exact(const ChipTensor &lhs, const ChipTensor &rhs) {
     }
     return std::equal(std::begin(lhs.shapes), std::begin(lhs.shapes) + lhs.ndims, std::begin(rhs.shapes)) &&
            std::equal(std::begin(lhs.strides), std::begin(lhs.strides) + lhs.ndims, std::begin(rhs.strides));
+}
+
+bool graph_predicate_replay_equivalent(
+    const GraphRecordedPredicate &recorded, const GraphRecordedTensorSourceRef &source, uint64_t operand_start_offset,
+    uint64_t elem_offset, int64_t target, uint8_t elem_size, PredicateOp op
+) {
+    if (recorded.source.source != source.source || recorded.source.source_index != source.source_index ||
+        recorded.source.packed_offset != source.packed_offset || recorded.elem_offset != elem_offset ||
+        recorded.target != target || recorded.elem_size != elem_size || recorded.op != op) {
+        return false;
+    }
+    // A boundary tensor's invocation fields replace the recorded template at
+    // materialize time. For an internal tensor, rebind replaces its base but
+    // preserves the view's element start, which therefore remains part of the
+    // address identity. OWN_OUTPUT predicates are rejected before this point.
+    if (recorded.source.source == GraphRecordedTensorSource::INTERNAL) {
+        return recorded.operand.start_offset == operand_start_offset;
+    }
+    return recorded.source.source != GraphRecordedTensorSource::OWN_OUTPUT;
 }
 
 bool graph_tensor_from_boundary(
@@ -623,6 +759,76 @@ GraphBoundarySignature graph_boundary_signature(const ChipTensor &tensor, Tensor
     return signature;
 }
 
+class GraphBoundaryAliasTable {
+public:
+    static constexpr size_t kCapacity = static_cast<size_t>(GRAPH_MAX_TENSOR_ARGS) * 2;
+    static_assert(kCapacity != 0 && (kCapacity & (kCapacity - 1)) == 0);
+
+    void begin() {
+        ++generation_;
+        if (generation_ == 0) {
+            for (Slot &slot : slots_)
+                slot.generation = 0;
+            generation_ = 1;
+        }
+    }
+
+    bool representative(const ChipTensor &tensor, uint16_t index, uint16_t *representative) {
+        if (representative == nullptr) return false;
+        const uint64_t address = tensor.buffer.addr;
+        const uint64_t size = tensor.buffer.size;
+        size_t slot_index = hash_pair(address, size) & (kCapacity - 1);
+        for (size_t probe = 0; probe < kCapacity; ++probe) {
+            Slot &slot = slots_[slot_index];
+            if (slot.generation != generation_) {
+                slot = Slot{address, size, index, generation_};
+                *representative = index;
+                return true;
+            }
+            if (slot.address == address && slot.size == size) {
+                *representative = slot.representative;
+                return true;
+            }
+            slot_index = (slot_index + 1) & (kCapacity - 1);
+        }
+        return false;
+    }
+
+private:
+    struct Slot {
+        uint64_t address{0};
+        uint64_t size{0};
+        uint16_t representative{0};
+        uint32_t generation{0};
+    };
+
+    static uint64_t hash_pair(uint64_t address, uint64_t size) {
+        uint64_t value = address ^ (size + 0x9e3779b97f4a7c15ULL + (address << 6) + (address >> 2));
+        value ^= value >> 33;
+        value *= 0xff51afd7ed558ccdULL;
+        value ^= value >> 33;
+        return value;
+    }
+
+    uint32_t generation_{0};
+    std::array<Slot, kCapacity> slots_{};
+};
+
+bool graph_boundary_alias_representatives(const GraphTaskArgs &args, uint16_t *representatives) {
+    if (representatives == nullptr || args.tensor_count() < 0 ||
+        args.tensor_count() > static_cast<int32_t>(GRAPH_MAX_TENSOR_ARGS)) {
+        return false;
+    }
+    static thread_local GraphBoundaryAliasTable aliases;
+    aliases.begin();
+    for (int32_t i = 0; i < args.tensor_count(); ++i) {
+        if (!aliases.representative(args.tensor(i).ref(), static_cast<uint16_t>(i), &representatives[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
 template <typename T>
 uint32_t graph_append_section(std::vector<std::byte> *image, const std::vector<T> &values) {
     if (values.empty()) return 0;
@@ -675,6 +881,7 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     if (image == nullptr || recording.unsupported || recording.nodes.empty() ||
         recording.nodes.size() > GRAPH_MAX_NODES || recording.boundary_tensors.size() > UINT16_MAX ||
         recording.boundary_tensors.size() != recording.boundary_types.size() || recording.boundary_args == nullptr ||
+        recording.predicates.size() > UINT16_MAX ||
         std::any_of(recording.boundary_tensors.begin(), recording.boundary_tensors.end(), [](const ChipTensor &tensor) {
             return tensor.ndims > MAX_TENSOR_DIMS;
         })) {
@@ -701,14 +908,26 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     std::vector<GraphTensorSourceRef> tensor_sources;
     std::vector<uint64_t> scalars;
     std::vector<GraphScalarSourceRef> scalar_sources;
-    std::vector<GraphPredicate> predicates;
-    predicates.reserve(recording.predicates.size());
+    std::vector<GraphPredicate> predicates(recording.predicates.size());
     fanin_indices.reserve(total_fanins);
     roots.reserve(recording.nodes.size());
     tensors.reserve(total_tensors);
     tensor_sources.reserve(total_tensors);
     scalars.reserve(total_scalars);
     scalar_sources.reserve(total_scalars);
+
+    for (size_t i = 0; i < recording.predicates.size(); ++i) {
+        const GraphRecordedPredicate &recorded = recording.predicates[i];
+        std::optional<GraphTensorSourceRef> packed_source = graph_pack_tensor_source(recorded.source);
+        if (!packed_source.has_value() || recorded.operand.ndims > MAX_TENSOR_DIMS) return false;
+        GraphPredicate &packed = predicates[i];
+        packed.operand = graph_tensor_pack(recorded.operand);
+        packed.operand_source = *packed_source;
+        packed.elem_offset = recorded.elem_offset;
+        packed.target = recorded.target;
+        packed.elem_size = recorded.elem_size;
+        packed.op = static_cast<uint8_t>(recorded.op);
+    }
 
     uint64_t required_heap = 0;
     uint32_t edge_count = 0;
@@ -755,22 +974,8 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
         node.dump_metadata = source.dump_metadata;
         node.predicate_slot = 0;
         if (source.predicate_index >= 0) {
-            if (static_cast<size_t>(source.predicate_index) >= recording.predicates.size() ||
-                predicates.size() >= static_cast<size_t>(UINT16_MAX)) {
-                return false;
-            }
-            const GraphRecordedPredicate &recorded = recording.predicates[source.predicate_index];
-            std::optional<GraphTensorSourceRef> packed_source = graph_pack_tensor_source(recorded.source);
-            if (!packed_source.has_value() || recorded.operand.ndims > MAX_TENSOR_DIMS) return false;
-            GraphPredicate packed{};
-            packed.operand = graph_tensor_pack(recorded.operand);
-            packed.operand_source = *packed_source;
-            packed.elem_offset = recorded.elem_offset;
-            packed.target = recorded.target;
-            packed.elem_size = recorded.elem_size;
-            packed.op = static_cast<uint8_t>(recorded.op);
-            node.predicate_slot = static_cast<uint16_t>(predicates.size() + 1);
-            predicates.push_back(packed);
+            if (static_cast<size_t>(source.predicate_index) >= recording.predicates.size()) return false;
+            node.predicate_slot = static_cast<uint16_t>(source.predicate_index + 1);
         }
         for (const ChipTensor &tensor : source.tensors)
             tensors.push_back(graph_tensor_pack(tensor));
@@ -812,18 +1017,11 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
 
     std::vector<GraphBoundarySignature> signatures;
     signatures.reserve(recording.boundary_tensors.size());
+    if (recording.boundary_alias_reps.size() != recording.boundary_tensors.size()) return false;
     for (size_t i = 0; i < recording.boundary_tensors.size(); ++i) {
-        uint16_t alias_rep = static_cast<uint16_t>(i);
-        for (size_t j = 0; j < i; ++j) {
-            if (recording.boundary_tensors[j].buffer.addr == recording.boundary_tensors[i].buffer.addr &&
-                recording.boundary_tensors[j].buffer.size == recording.boundary_tensors[i].buffer.size) {
-                alias_rep = static_cast<uint16_t>(j);
-                break;
-            }
-        }
-        signatures.push_back(
-            graph_boundary_signature(recording.boundary_tensors[i], recording.boundary_types[i], alias_rep)
-        );
+        signatures.push_back(graph_boundary_signature(
+            recording.boundary_tensors[i], recording.boundary_types[i], recording.boundary_alias_reps[i]
+        ));
     }
 
     image->assign(sizeof(GraphDefinition), std::byte{0});
@@ -908,6 +1106,232 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     return true;
 }
 
+// Cold misses used to build thirteen temporary section vectors and then copy
+// all of them into the Definition image. The recording already contains every
+// exact count, so lay out the final image first and pack directly into it. The
+// only remaining scratch allocation is the per-node fanout cursor array.
+bool graph_build_definition_direct(const GraphRecording &recording, std::vector<std::byte> *image) {
+    const size_t node_count = recording.nodes.size();
+    if (image == nullptr || recording.unsupported || node_count == 0 || node_count > GRAPH_MAX_NODES ||
+        recording.boundary_tensors.empty() || recording.boundary_tensors.size() > UINT16_MAX ||
+        recording.boundary_tensors.size() != recording.boundary_types.size() ||
+        recording.boundary_tensors.size() != recording.boundary_alias_reps.size() ||
+        recording.boundary_args == nullptr || recording.predicates.size() > UINT16_MAX) {
+        return false;
+    }
+
+    size_t total_tensors = 0;
+    const size_t total_scalars = recording.scalars.size();
+    const size_t total_fanins = recording.internal_fanins.size();
+    size_t root_count = 0;
+    int32_t widest_node_tensor_count = 0;
+    uint64_t required_heap = 0;
+    std::vector<uint32_t> fanout_cursors(node_count, 0);
+    for (size_t i = 0; i < node_count; ++i) {
+        const GraphRecordedNode &source = recording.nodes[i];
+        if (source.total_output_size > static_cast<size_t>(INT32_MAX) ||
+            source.tensors.size() > static_cast<size_t>(INT32_MAX) ||
+            source.scalar_count > static_cast<uint32_t>(INT32_MAX) || source.fanin_count > UINT16_MAX ||
+            source.tensor_source_offset > recording.tensor_sources.size() ||
+            source.tensors.size() > recording.tensor_sources.size() - source.tensor_source_offset ||
+            source.scalar_offset > recording.scalars.size() ||
+            source.scalar_count > recording.scalars.size() - source.scalar_offset ||
+            source.scalar_offset > recording.scalar_sources.size() ||
+            source.scalar_count > recording.scalar_sources.size() - source.scalar_offset ||
+            source.fanin_offset > recording.internal_fanins.size() ||
+            source.fanin_count > recording.internal_fanins.size() - source.fanin_offset ||
+            total_tensors > UINT32_MAX - source.tensors.size() ||
+            std::any_of(source.tensors.begin(), source.tensors.end(), [](const ChipTensor &tensor) {
+                return tensor.ndims > MAX_TENSOR_DIMS;
+            })) {
+            return false;
+        }
+        total_tensors += source.tensors.size();
+        widest_node_tensor_count = std::max(widest_node_tensor_count, static_cast<int32_t>(source.tensors.size()));
+        if (source.fanin_count == 0) ++root_count;
+        for (uint32_t f = 0; f < source.fanin_count; ++f) {
+            const size_t producer = recording.internal_fanins[source.fanin_offset + f];
+            if (producer >= i || fanout_cursors[producer] == UINT32_MAX) return false;
+            ++fanout_cursors[producer];
+        }
+        const uint64_t output_bytes = PTO2_ALIGN_UP(source.total_output_size, PTO2_ALIGN_SIZE);
+        if (required_heap > UINT64_MAX - output_bytes) return false;
+        required_heap += output_bytes;
+    }
+    if (total_tensors > UINT32_MAX || total_scalars > UINT32_MAX || total_fanins > UINT32_MAX ||
+        root_count > UINT32_MAX) {
+        return false;
+    }
+    for (const ChipTensor &tensor : recording.boundary_tensors) {
+        if (tensor.ndims > MAX_TENSOR_DIMS) return false;
+    }
+
+    GraphDefinition definition{};
+    definition.full_key = recording.full_key;
+    definition.required_heap = required_heap;
+    definition.task_count = static_cast<uint32_t>(node_count);
+    definition.edge_count = static_cast<uint32_t>(total_fanins);
+    definition.root_count = static_cast<uint32_t>(root_count);
+    definition.boundary_count = static_cast<uint32_t>(recording.boundary_tensors.size());
+    definition.boundary_scalar_count = static_cast<uint32_t>(recording.boundary_scalar_count);
+    definition.tensor_arg_count = static_cast<uint32_t>(total_tensors);
+    definition.scalar_arg_count = static_cast<uint32_t>(total_scalars);
+    definition.predicate_count = static_cast<uint32_t>(recording.predicates.size());
+    const size_t node_stride = graph_node_stride(widest_node_tensor_count);
+    size_t execution_storage_bytes = 0;
+    if (node_stride > UINT32_MAX ||
+        !graph_execution_storage_bytes(static_cast<int32_t>(node_count), node_stride, &execution_storage_bytes) ||
+        execution_storage_bytes > UINT32_MAX) {
+        return false;
+    }
+    definition.node_stride = static_cast<uint32_t>(node_stride);
+    definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
+
+    size_t cursor = sizeof(GraphDefinition);
+    auto layout = [&cursor](size_t count, size_t element_bytes, size_t alignment, uint32_t *offset) {
+        *offset = 0;
+        if (count == 0) return true;
+        if (alignment == 0 || (alignment & (alignment - 1)) != 0 || cursor > SIZE_MAX - (alignment - 1) ||
+            count > SIZE_MAX / element_bytes) {
+            return false;
+        }
+        const size_t aligned = (cursor + alignment - 1) & ~(alignment - 1);
+        const size_t bytes = count * element_bytes;
+        if (aligned > UINT32_MAX || bytes > UINT32_MAX - aligned) return false;
+        *offset = static_cast<uint32_t>(aligned);
+        cursor = aligned + bytes;
+        return true;
+    };
+#define GRAPH_LAYOUT_FIELD(field, type, count) layout((count), sizeof(type), alignof(type), &definition.field)
+    if (!GRAPH_LAYOUT_FIELD(off_fanout_offsets, uint32_t, node_count + 1) ||
+        !GRAPH_LAYOUT_FIELD(off_fanout_indices, uint16_t, total_fanins) ||
+        !GRAPH_LAYOUT_FIELD(off_fanin_offsets, uint32_t, node_count + 1) ||
+        !GRAPH_LAYOUT_FIELD(off_fanin_indices, uint16_t, total_fanins) ||
+        !GRAPH_LAYOUT_FIELD(off_root_indices, uint16_t, root_count) ||
+        !GRAPH_LAYOUT_FIELD(off_node_offsets, uint64_t, node_count) ||
+        !GRAPH_LAYOUT_FIELD(off_nodes, GraphNodeDefinition, node_count) ||
+        !GRAPH_LAYOUT_FIELD(off_tensors, GraphTensor, total_tensors) ||
+        !GRAPH_LAYOUT_FIELD(off_tensor_sources, GraphTensorSourceRef, total_tensors) ||
+        !GRAPH_LAYOUT_FIELD(off_scalars, uint64_t, total_scalars) ||
+        !GRAPH_LAYOUT_FIELD(off_scalar_sources, GraphScalarSourceRef, total_scalars) ||
+        !GRAPH_LAYOUT_FIELD(off_boundary_signatures, GraphBoundarySignature, recording.boundary_tensors.size()) ||
+        !GRAPH_LAYOUT_FIELD(off_predicates, GraphPredicate, recording.predicates.size())) {
+#undef GRAPH_LAYOUT_FIELD
+        return false;
+    }
+#undef GRAPH_LAYOUT_FIELD
+    if (cursor > UINT32_MAX) return false;
+    image->assign(cursor, std::byte{0});
+    definition.total_bytes = static_cast<uint32_t>(cursor);
+
+    auto section = [&image](uint32_t offset) -> std::byte * {
+        return offset == 0 ? nullptr : image->data() + offset;
+    };
+    auto *fanout_offsets = reinterpret_cast<uint32_t *>(section(definition.off_fanout_offsets));
+    auto *fanout_indices = reinterpret_cast<uint16_t *>(section(definition.off_fanout_indices));
+    auto *fanin_offsets = reinterpret_cast<uint32_t *>(section(definition.off_fanin_offsets));
+    auto *fanin_indices = reinterpret_cast<uint16_t *>(section(definition.off_fanin_indices));
+    auto *roots = reinterpret_cast<uint16_t *>(section(definition.off_root_indices));
+    auto *node_offsets = reinterpret_cast<uint64_t *>(section(definition.off_node_offsets));
+    auto *nodes = reinterpret_cast<GraphNodeDefinition *>(section(definition.off_nodes));
+    auto *tensors = reinterpret_cast<GraphTensor *>(section(definition.off_tensors));
+    auto *tensor_sources = reinterpret_cast<GraphTensorSourceRef *>(section(definition.off_tensor_sources));
+    auto *scalars = reinterpret_cast<uint64_t *>(section(definition.off_scalars));
+    auto *scalar_sources = reinterpret_cast<GraphScalarSourceRef *>(section(definition.off_scalar_sources));
+    auto *signatures = reinterpret_cast<GraphBoundarySignature *>(section(definition.off_boundary_signatures));
+    auto *predicates = reinterpret_cast<GraphPredicate *>(section(definition.off_predicates));
+
+    uint32_t tensor_cursor = 0;
+    uint32_t scalar_cursor = 0;
+    uint32_t fanin_cursor = 0;
+    uint32_t root_cursor = 0;
+    uint64_t heap_cursor = 0;
+    fanin_offsets[0] = 0;
+    for (size_t i = 0; i < node_count; ++i) {
+        const GraphRecordedNode &source = recording.nodes[i];
+        node_offsets[i] = heap_cursor;
+        heap_cursor += PTO2_ALIGN_UP(source.total_output_size, PTO2_ALIGN_SIZE);
+        if (source.fanin_count == 0) roots[root_cursor++] = static_cast<uint16_t>(i);
+        for (uint32_t f = 0; f < source.fanin_count; ++f) {
+            fanin_indices[fanin_cursor++] = static_cast<uint16_t>(recording.internal_fanins[source.fanin_offset + f]);
+        }
+        fanin_offsets[i + 1] = fanin_cursor;
+
+        GraphNodeDefinition &node = nodes[i];
+        std::copy(source.kernel_ids.begin(), source.kernel_ids.end(), std::begin(node.kernel_id));
+        node.active_mask = source.active_mask.raw();
+        node.task_attrs = source.task_attrs.raw();
+        node.logical_block_num = source.logical_block_num;
+        node.total_required_subtasks = source.total_required_subtasks;
+        node.tensor_count = static_cast<int32_t>(source.tensors.size());
+        node.scalar_count = static_cast<int32_t>(source.scalar_count);
+        node.total_output_size = static_cast<int32_t>(source.total_output_size);
+        node.tensor_offset = tensor_cursor;
+        node.scalar_offset = scalar_cursor;
+        node.dump_metadata = source.dump_metadata;
+        if (source.predicate_index >= 0) {
+            if (static_cast<size_t>(source.predicate_index) >= recording.predicates.size()) return false;
+            const GraphRecordedPredicate &recorded = recording.predicates[source.predicate_index];
+            std::optional<GraphTensorSourceRef> packed_source = graph_pack_tensor_source(recorded.source);
+            if (!packed_source.has_value() || recorded.operand.ndims > MAX_TENSOR_DIMS) return false;
+            GraphPredicate &packed = predicates[source.predicate_index];
+            packed.operand = graph_tensor_pack(recorded.operand);
+            packed.operand_source = *packed_source;
+            packed.elem_offset = recorded.elem_offset;
+            packed.target = recorded.target;
+            packed.elem_size = recorded.elem_size;
+            packed.op = static_cast<uint8_t>(recorded.op);
+            node.predicate_slot = static_cast<uint16_t>(source.predicate_index + 1);
+        }
+        for (size_t t = 0; t < source.tensors.size(); ++t) {
+            tensors[tensor_cursor] = graph_tensor_pack(source.tensors[t]);
+            std::optional<GraphTensorSourceRef> packed_source =
+                graph_pack_tensor_source(recording.tensor_sources[source.tensor_source_offset + t]);
+            if (!packed_source.has_value()) return false;
+            tensor_sources[tensor_cursor++] = *packed_source;
+        }
+        for (size_t s = 0; s < source.scalar_count; ++s) {
+            std::optional<GraphScalarSourceRef> packed_source =
+                graph_pack_scalar_source(recording.scalar_sources[source.scalar_offset + s]);
+            if (!packed_source.has_value() ||
+                (packed_source->source == static_cast<uint8_t>(GraphScalarSource::BOUNDARY) &&
+                 packed_source->source_index >= recording.boundary_args->scalar_count())) {
+                return false;
+            }
+            scalar_sources[scalar_cursor] = *packed_source;
+            scalars[scalar_cursor++] = packed_source->source == static_cast<uint8_t>(GraphScalarSource::BOUNDARY) ?
+                                           0 :
+                                           recording.scalars[source.scalar_offset + s];
+        }
+    }
+
+    fanout_offsets[0] = 0;
+    for (size_t i = 0; i < node_count; ++i) {
+        fanout_offsets[i + 1] = fanout_offsets[i] + fanout_cursors[i];
+        fanout_cursors[i] = fanout_offsets[i];
+    }
+    for (size_t consumer = 0; consumer < node_count; ++consumer) {
+        const GraphRecordedNode &node = recording.nodes[consumer];
+        for (uint32_t f = 0; f < node.fanin_count; ++f) {
+            const size_t producer = recording.internal_fanins[node.fanin_offset + f];
+            fanout_indices[fanout_cursors[producer]++] = static_cast<uint16_t>(consumer);
+        }
+    }
+    for (size_t i = 0; i < recording.boundary_tensors.size(); ++i) {
+        signatures[i] = graph_boundary_signature(
+            recording.boundary_tensors[i], recording.boundary_types[i], recording.boundary_alias_reps[i]
+        );
+    }
+    if (tensor_cursor != total_tensors || scalar_cursor != total_scalars || fanin_cursor != total_fanins ||
+        root_cursor != root_count || heap_cursor != required_heap) {
+        return false;
+    }
+    std::memcpy(image->data(), &definition, sizeof(definition));
+    definition.content_hash = graph_hash_bytes(1469598103934665603ULL, image->data(), image->size());
+    std::memcpy(image->data(), &definition, sizeof(definition));
+    return true;
+}
+
 const GraphDefinition *graph_definition(const std::vector<std::byte> &image) {
     if (image.size() < sizeof(GraphDefinition)) return nullptr;
     const auto *definition = reinterpret_cast<const GraphDefinition *>(image.data());
@@ -916,26 +1340,79 @@ const GraphDefinition *graph_definition(const std::vector<std::byte> &image) {
 
 }  // namespace
 
-GraphHostStatePtr make_graph_host_state() { return GraphHostStatePtr{new (std::nothrow) GraphHostState{}}; }
+GraphHostStatePtr make_graph_host_state() {
+    GraphHostStatePtr state{new (std::nothrow) GraphHostState{}};
+    if (state == nullptr) return {};
+    try {
+        state->definitions.reserve(GRAPH_MAX_DEFINITIONS);
+        state->inflight.reserve(GRAPH_MAX_DEFINITIONS);
+        state->retired_recordings.reserve(GRAPH_MAX_DEFINITIONS);
+        state->pending_uploads.reserve(GRAPH_INITIAL_SUBMISSION_COUNT);
+        state->pending_image_storage.resize(GRAPH_INITIAL_SUBMISSION_BYTES);
+        for (size_t i = 0; i < state->prewarmed_recordings.size(); ++i) {
+            auto &slot = state->prewarmed_recordings[i];
+            slot = std::make_unique<GraphInflightRecording>();
+            slot->recording = std::make_unique<GraphRecording>();
+            if (i >= GRAPH_PREWARM_DEFINITIONS) continue;
+            GraphRecording &recording = *slot->recording;
+            recording.boundary_tensors.reserve(GRAPH_MAX_TENSOR_ARGS);
+            recording.boundary_types.reserve(GRAPH_MAX_TENSOR_ARGS);
+            recording.boundary_alias_reps.reserve(GRAPH_MAX_TENSOR_ARGS);
+            recording.nodes.reserve(GRAPH_INITIAL_RECORDED_NODES);
+            recording.tensor_sources.reserve(GRAPH_INITIAL_RECORDED_TENSORS);
+            recording.scalars.reserve(GRAPH_INITIAL_RECORDED_SCALARS);
+            recording.scalar_sources.reserve(GRAPH_INITIAL_RECORDED_SCALARS);
+            recording.internal_fanins.reserve(GRAPH_INITIAL_RECORDED_FANINS);
+            recording.output_ranges.reserve(GRAPH_INITIAL_RECORDED_NODES);
+            recording.predicates.reserve(GRAPH_INITIAL_RECORDED_NODES);
+            if (!recording.tensor_storage.reserve_initial()) return {};
+            slot->definition_scratch.reserve(GRAPH_INITIAL_DEFINITION_BYTES);
+        }
+    } catch (...) {
+        return {};
+    }
+    return state;
+}
 
 void GraphHostStateDeleter::operator()(GraphHostState *state) const noexcept { delete state; }
+
+bool graph_host_begin_run(GraphHostState &state) {
+    std::lock_guard<std::mutex> lock(state.recording_mutex);
+    if (!state.inflight.empty() || state.inflight_count.load(std::memory_order_acquire) != 0) return false;
+    state.pending_uploads.clear();
+    state.pending_image_bytes = 0;
+    if (++state.run_epoch == 0) {
+        state.run_epoch = 1;
+        for (size_t i = 0; i < state.fast_entry_count; ++i)
+            state.fast_entries[i].validated_run_epoch = 0;
+    }
+    return true;
+}
 
 size_t graph_host_upload_count(const GraphHostState &state) { return state.pending_uploads.size(); }
 
 std::optional<GraphHostUpload> graph_host_upload(GraphHostState &state, size_t index) {
     if (index >= state.pending_uploads.size()) return std::nullopt;
     GraphPendingUpload &upload = state.pending_uploads[index];
-    if (upload.outer_slot == nullptr || upload.image.empty()) return std::nullopt;
-    return GraphHostUpload{upload.outer_slot, upload.image.data(), upload.image.size()};
+    if (upload.outer_slot == nullptr || upload.image_bytes == 0 || upload.image_offset > state.pending_image_bytes ||
+        upload.image_bytes > state.pending_image_bytes - upload.image_offset) {
+        return std::nullopt;
+    }
+    return GraphHostUpload{
+        upload.outer_slot, state.pending_image_storage.data() + upload.image_offset, upload.image_bytes
+    };
+}
+
+GraphHostUploadBatch graph_host_upload_batch(GraphHostState &state) {
+    return GraphHostUploadBatch{state.pending_image_storage.data(), state.pending_image_bytes};
 }
 
 GraphHostDefinitionList graph_host_definitions(GraphHostState &state) {
     GraphHostDefinitionList list;
-    list.entries.reserve(state.definitions.size());
     for (auto &[key, image] : state.definitions) {
         const GraphDefinition *header = graph_definition(image);
-        if (header != nullptr && header->total_bytes == image.size()) {
-            list.entries.push_back(GraphHostDefinition{key, image.data(), image.size()});
+        if (header != nullptr && header->total_bytes == image.size() && list.count < list.entries.size()) {
+            list.entries[list.count++] = GraphHostDefinition{key, image.data(), image.size()};
         }
     }
     return list;
@@ -1506,6 +1983,9 @@ bool graph_boundary_matches(const GraphDefinition &definition, const GraphTaskAr
     );
     if (signatures == nullptr) return false;
 
+    std::array<uint16_t, GRAPH_MAX_TENSOR_ARGS> alias_reps{};
+    if (!graph_boundary_alias_representatives(args, alias_reps.data())) return false;
+
     bool alias_mismatch = false;
     for (int32_t i = 0; i < args.tensor_count(); ++i) {
         const ChipTensor &tensor = args.tensor(i).ref();
@@ -1531,15 +2011,7 @@ bool graph_boundary_matches(const GraphDefinition &definition, const GraphTaskAr
             );
             return false;
         }
-        uint16_t alias_rep = static_cast<uint16_t>(i);
-        for (int32_t j = 0; j < i; ++j) {
-            const ChipTensor &other = args.tensor(j).ref();
-            if (other.buffer.addr == tensor.buffer.addr && other.buffer.size == tensor.buffer.size) {
-                alias_rep = static_cast<uint16_t>(j);
-                break;
-            }
-        }
-        alias_mismatch |= alias_rep != signature.alias_rep;
+        alias_mismatch |= alias_reps[static_cast<size_t>(i)] != signature.alias_rep;
     }
     if (alias_mismatch) {
         debug_assert(!alias_mismatch && "Changing the Graph boundary alias partition is not supported");
@@ -1552,9 +2024,12 @@ bool graph_boundary_matches(const GraphDefinition &definition, const GraphTaskAr
 bool graph_recording_boundary_matches(const GraphRecording &recording, const GraphTaskArgs &args) {
     if (args.scalar_count() != recording.boundary_scalar_count || args.explicit_dep_count() != 0 ||
         args.tensor_count() != static_cast<int32_t>(recording.boundary_tensors.size()) ||
-        recording.boundary_tensors.size() != recording.boundary_types.size()) {
+        recording.boundary_tensors.size() != recording.boundary_types.size() ||
+        recording.boundary_tensors.size() != recording.boundary_alias_reps.size()) {
         return false;
     }
+    std::array<uint16_t, GRAPH_MAX_TENSOR_ARGS> actual_alias_reps{};
+    if (!graph_boundary_alias_representatives(args, actual_alias_reps.data())) return false;
     for (int32_t i = 0; i < args.tensor_count(); ++i) {
         const ChipTensor &expected = recording.boundary_tensors[static_cast<size_t>(i)];
         const ChipTensor &actual = args.tensor(i).ref();
@@ -1570,24 +2045,9 @@ bool graph_recording_boundary_matches(const GraphRecording &recording, const Gra
             )) {
             return false;
         }
-        uint16_t expected_alias = static_cast<uint16_t>(i);
-        uint16_t actual_alias = static_cast<uint16_t>(i);
-        for (int32_t j = 0; j < i; ++j) {
-            const ChipTensor &expected_other = recording.boundary_tensors[static_cast<size_t>(j)];
-            if (expected_other.buffer.addr == expected.buffer.addr &&
-                expected_other.buffer.size == expected.buffer.size) {
-                expected_alias = static_cast<uint16_t>(j);
-                break;
-            }
+        if (actual_alias_reps[static_cast<size_t>(i)] != recording.boundary_alias_reps[static_cast<size_t>(i)]) {
+            return false;
         }
-        for (int32_t j = 0; j < i; ++j) {
-            const ChipTensor &actual_other = args.tensor(j).ref();
-            if (actual_other.buffer.addr == actual.buffer.addr && actual_other.buffer.size == actual.buffer.size) {
-                actual_alias = static_cast<uint16_t>(j);
-                break;
-            }
-        }
-        if (actual_alias != expected_alias) return false;
     }
     return true;
 }
@@ -1609,11 +2069,14 @@ void graph_reset_outer_payload(PTO2TaskPayload &payload) {
 }
 
 bool graph_prepare_submission_image(
-    uint64_t full_key, const GraphTaskArgs &args, std::vector<std::byte> *submission_image
+    uint64_t full_key, const GraphTaskArgs &args, std::vector<std::byte> *storage, size_t *storage_bytes,
+    size_t *image_offset, size_t *image_bytes
 ) {
-    if (submission_image == nullptr) return false;
-    const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphTensor));
-    const size_t tensor_bytes = static_cast<size_t>(args.tensor_count()) * sizeof(GraphTensor);
+    if (storage == nullptr || storage_bytes == nullptr || image_offset == nullptr || image_bytes == nullptr) {
+        return false;
+    }
+    const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphInvocationTensor));
+    const size_t tensor_bytes = static_cast<size_t>(args.tensor_count()) * sizeof(GraphInvocationTensor);
     if (tensors_offset > UINT32_MAX || tensors_offset > UINT32_MAX - tensor_bytes) {
         return false;
     }
@@ -1625,25 +2088,32 @@ bool graph_prepare_submission_image(
         total_bytes > UINT32_MAX) {
         return false;
     }
-    submission_image->assign(total_bytes, std::byte{0});
-    auto *tensors = reinterpret_cast<GraphTensor *>(submission_image->data() + tensors_offset);
+    constexpr size_t kImageAlignment = alignof(GraphSubmission);
+    if (*storage_bytes > SIZE_MAX - (kImageAlignment - 1)) return false;
+    const size_t offset = (*storage_bytes + kImageAlignment - 1) & ~(kImageAlignment - 1);
+    if (total_bytes > SIZE_MAX - offset) return false;
+    if (offset + total_bytes > storage->size()) storage->resize(offset + total_bytes);
+    std::byte *image = storage->data() + offset;
+    auto *tensors = reinterpret_cast<GraphInvocationTensor *>(image + tensors_offset);
     for (int32_t i = 0; i < args.tensor_count(); ++i)
-        tensors[i] = graph_tensor_pack(args.tensor(i).ref());
+        tensors[i] = graph_invocation_tensor_pack(args.tensor(i).ref());
     if (args.scalar_count() != 0) {
         std::memcpy(
-            submission_image->data() + scalars_offset, args.scalar_data(),
-            static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t)
+            image + scalars_offset, args.scalar_data(), static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t)
         );
     }
 
     GraphSubmission submission{};
     submission.graph_key = full_key;
-    submission.total_bytes = static_cast<uint32_t>(submission_image->size());
+    submission.total_bytes = static_cast<uint32_t>(total_bytes);
     submission.tensors_offset = static_cast<uint32_t>(tensors_offset);
     submission.tensor_count = static_cast<uint32_t>(args.tensor_count());
     submission.scalars_offset = static_cast<uint32_t>(scalars_offset);
     submission.scalar_count = static_cast<uint32_t>(args.scalar_count());
-    std::memcpy(submission_image->data(), &submission, sizeof(submission));
+    std::memcpy(image, &submission, sizeof(submission));
+    *storage_bytes = offset + total_bytes;
+    *image_offset = offset;
+    *image_bytes = total_bytes;
     return true;
 }
 
@@ -1660,8 +2130,14 @@ bool graph_submit_outer(
     }
 
     GraphPendingUpload pending;
-    if (!graph_prepare_submission_image(full_key, args, &pending.image)) return false;
-    reinterpret_cast<GraphSubmission *>(pending.image.data())->definition_hash = definition_hash;
+    if (!graph_prepare_submission_image(
+            full_key, args, &state->pending_image_storage, &state->pending_image_bytes, &pending.image_offset,
+            &pending.image_bytes
+        )) {
+        return false;
+    }
+    reinterpret_cast<GraphSubmission *>(state->pending_image_storage.data() + pending.image_offset)->definition_hash =
+        definition_hash;
     pending.deferred_heap = defer_heap;
 
     DepInputs boundary_inputs{
@@ -1741,7 +2217,7 @@ bool graph_submit_outer(
     payload.fanin_count = fanin_builder.count;
 
     pending.outer_slot = &slot;
-    state->pending_uploads.push_back(std::move(pending));
+    state->pending_uploads.push_back(pending);
     if (submitted_id != nullptr) *submitted_id = task_id;
 #if SIMPLER_DFX
     orch->tasks_submitted++;
@@ -1751,10 +2227,10 @@ bool graph_submit_outer(
 
 bool graph_submit_definition(
     PTO2OrchestratorState *orch, GraphHostState *state, const std::vector<std::byte> &definition_image,
-    const GraphTaskArgs &args, PTO2TaskId *submitted_id
+    const GraphTaskArgs &args, PTO2TaskId *submitted_id, bool boundary_checked = false
 ) {
     const GraphDefinition *definition = graph_definition(definition_image);
-    if (definition == nullptr || !graph_boundary_matches(*definition, args) ||
+    if (definition == nullptr || (!boundary_checked && !graph_boundary_matches(*definition, args)) ||
         definition->execution_storage_bytes == 0 ||
         definition->required_heap > UINT64_MAX - definition->execution_storage_bytes) {
         return false;
@@ -1777,8 +2253,12 @@ bool graph_submit_pending_definition(
 bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostState *state, uint64_t *failed_key) {
     for (GraphPendingUpload &pending : state->pending_uploads) {
         if (!pending.deferred_heap) continue;
-        if (pending.image.size() < sizeof(GraphSubmission)) return false;
-        auto *submission = reinterpret_cast<GraphSubmission *>(pending.image.data());
+        if (pending.image_bytes < sizeof(GraphSubmission) || pending.image_offset > state->pending_image_bytes ||
+            pending.image_bytes > state->pending_image_bytes - pending.image_offset) {
+            return false;
+        }
+        auto *submission =
+            reinterpret_cast<GraphSubmission *>(state->pending_image_storage.data() + pending.image_offset);
         auto definition_it = state->definitions.find(submission->graph_key);
         const GraphDefinition *definition =
             definition_it == state->definitions.end() ? nullptr : graph_definition(definition_it->second);
@@ -1786,7 +2266,7 @@ bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostSt
             definition->required_heap > UINT64_MAX - definition->execution_storage_bytes ||
             pending.outer_slot == nullptr || pending.outer_slot->task == nullptr ||
             pending.outer_slot->task_kind != TaskKind::GRAPH ||
-            !graph_submission_wire_size_valid(*submission, pending.image.size())) {
+            !graph_submission_wire_size_valid(*submission, pending.image_bytes)) {
             if (failed_key != nullptr) *failed_key = submission->graph_key;
             return false;
         }
@@ -1880,7 +2360,12 @@ TaskOutputTensors graph_record_submit_node(
     // the caller's ChipTensor; outputs materialize from the create-info onto the
     // scratch buffer and carry this node's owner id.
     const int32_t tensor_count = args.tensor_count();
-    node.tensors.resize(static_cast<size_t>(tensor_count));
+    node.tensors.count = static_cast<size_t>(tensor_count);
+    node.tensors.data = recording.tensor_storage.allocate(node.tensors.count);
+    if (tensor_count != 0 && node.tensors.data == nullptr) {
+        recording.unsupported = true;
+        return result;
+    }
     for (int32_t i = 0; i < tensor_count; ++i) {
         ChipTensor &slot_tensor = node.tensors[static_cast<size_t>(i)];
         if (args.tag(i) != TensorArgType::OUTPUT) {
@@ -1945,9 +2430,6 @@ TaskOutputTensors graph_record_submit_node(
     // disagree.
     if (node.task_attrs.has_predicate()) {
         const CoreTaskPredicate &pred = args.predicate();
-        GraphRecordedPredicate recorded;
-        recorded.op = pred.op;
-        recorded.target = pred.target;
         const ChipTensor *operand = pred.operand.tensor;
         // OWN_OUTPUT would read the node's own output before the node runs, so it
         // names no value the predicate could be evaluating. An index vector that
@@ -1956,18 +2438,56 @@ TaskOutputTensors graph_record_submit_node(
         // Scheduler fatal rather than a named unsupported construct.
         const uint64_t flat_offset =
             operand == nullptr ? 0 : operand->compute_flat_offset(pred.operand.indices, pred.operand.ndims);
-        if (operand == nullptr || operand->ndims > MAX_TENSOR_DIMS || pred.operand.ndims > operand->ndims ||
-            flat_offset < operand->start_offset || flat_offset - operand->start_offset >= operand->extent_elem_cache ||
-            !graph_classify_tensor(recording, node, static_cast<int32_t>(node_index), *operand, &recorded.source) ||
-            recorded.source.source == GraphRecordedTensorSource::OWN_OUTPUT) {
+        const bool operand_valid = operand != nullptr && operand->ndims <= MAX_TENSOR_DIMS &&
+                                   pred.operand.ndims <= operand->ndims && flat_offset >= operand->start_offset &&
+                                   flat_offset - operand->start_offset < operand->extent_elem_cache;
+        GraphRecordedTensorSourceRef source;
+        bool source_classified = false;
+        if (operand_valid && recording.predicate_operand_cache.valid &&
+            graph_tensor_exact(*operand, recording.predicate_operand_cache.operand)) {
+            source = recording.predicate_operand_cache.source;
+            source_classified = true;
+        } else if (operand_valid &&
+                   graph_classify_tensor(recording, node, static_cast<int32_t>(node_index), *operand, &source)) {
+            // OWN_OUTPUT is relative to the node being recorded; the same
+            // address becomes INTERNAL for a later node, so never cache it.
+            if (source.source != GraphRecordedTensorSource::OWN_OUTPUT) {
+                recording.predicate_operand_cache.operand.copy(*operand);
+                recording.predicate_operand_cache.source = source;
+                recording.predicate_operand_cache.valid = true;
+            }
+            source_classified = true;
+        }
+        if (!operand_valid || !source_classified || source.source == GraphRecordedTensorSource::OWN_OUTPUT) {
             recording.unsupported = true;
         } else {
-            recorded.operand.copy(*operand);
-            recorded.elem_offset = flat_offset - operand->start_offset;
-            recorded.elem_size = static_cast<uint8_t>(get_element_size(operand->dtype));
+            const uint64_t elem_offset = flat_offset - operand->start_offset;
+            const uint8_t elem_size = static_cast<uint8_t>(get_element_size(operand->dtype));
+            const uint64_t operand_start_offset = operand->start_offset;
+            const size_t predicate_begin = recording.predicates.size() > GRAPH_PREDICATE_INTERN_WINDOW ?
+                                               recording.predicates.size() - GRAPH_PREDICATE_INTERN_WINDOW :
+                                               0;
+            for (size_t i = recording.predicates.size(); i > predicate_begin; --i) {
+                if (graph_predicate_replay_equivalent(
+                        recording.predicates[i - 1], source, operand_start_offset, elem_offset, pred.target, elem_size,
+                        pred.op
+                    )) {
+                    node.predicate_index = static_cast<int32_t>(i - 1);
+                    break;
+                }
+            }
+            if (node.predicate_index < 0) {
+                GraphRecordedPredicate recorded;
+                recorded.operand.copy(*operand);
+                recorded.source = source;
+                recorded.elem_offset = elem_offset;
+                recorded.target = pred.target;
+                recorded.elem_size = elem_size;
+                recorded.op = pred.op;
+                node.predicate_index = static_cast<int32_t>(recording.predicates.size());
+                recording.predicates.push_back(recorded);
+            }
         }
-        node.predicate_index = static_cast<int32_t>(recording.predicates.size());
-        recording.predicates.push_back(recorded);
     }
 
     node.fanin_offset = static_cast<uint32_t>(recording.internal_fanins.size());
@@ -2057,7 +2577,7 @@ TaskOutputTensors graph_record_submit_node(
         always_assert(recording.output_ranges.empty() || recording.output_ranges.back().end <= begin);
         recording.output_ranges.push_back({begin, end, static_cast<uint32_t>(node_index)});
     }
-    recording.nodes.push_back(std::move(node));
+    recording.nodes.push_back(node);
     ORCH_PHASE_END(HostOrchPhase::RecordNode, task_id.raw);
     return result;
 }
@@ -2081,6 +2601,48 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
     }
 
     const uint64_t full_key = graph_full_key(callable_hash, graph_key);
+
+    // One orchestration SO invokes graph_begin serially on its main thread.
+    // Recorder threads only publish `definition` and `recording_status`, so the
+    // fixed table itself needs no mutex. The first occurrence of a key in each
+    // run still performs the exact boundary/alias check; repeated occurrences
+    // are identified solely by the already-validated hash key.
+    for (size_t i = 0; i < state->fast_entry_count; ++i) {
+        GraphFastEntry &fast = state->fast_entries[i];
+        if (fast.full_key != full_key) continue;
+        if (fast.boundary_count != static_cast<uint32_t>(args.tensor_count()) ||
+            fast.boundary_scalar_count != static_cast<uint32_t>(args.scalar_count())) {
+            return result;
+        }
+        const GraphRecordingStatus status = fast.recording_status.load(std::memory_order_acquire);
+        const std::vector<std::byte> *definition = fast.definition.load(std::memory_order_acquire);
+        if (fast.validated_run_epoch != state->run_epoch) {
+            if (status != GraphRecordingStatus::READY || definition == nullptr) return result;
+            const GraphDefinition *header = graph_definition(*definition);
+            if (header == nullptr || !graph_boundary_matches(*header, args)) return result;
+            fast.validated_run_epoch = state->run_epoch;
+        }
+        PTO2TaskId submitted = PTO2TaskId::invalid();
+        ORCH_PHASE_START();
+        const bool submitted_ok = status == GraphRecordingStatus::READY && definition != nullptr ?
+                                      graph_submit_definition(orch, state, *definition, args, &submitted, true) :
+                                  status == GraphRecordingStatus::RECORDING ?
+                                      graph_submit_pending_definition(orch, state, full_key, args, &submitted) :
+                                      false;
+        if (submitted_ok) {
+            result.execute_block = false;
+            result.task_id = submitted;
+            ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
+#if SIMPLER_DFX
+            g_orch_submit_idx++;
+#if SIMPLER_ORCH_PROFILING
+            g_orch_submit_count++;
+#endif
+#endif
+        }
+        return result;
+    }
+
     std::unique_lock<std::mutex> lock(state->recording_mutex);
 
     // A published Definition is immutable, so the cache lookup comes first and
@@ -2088,9 +2650,11 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
     // would make an already-built Definition wait for an unrelated one.
     auto definition_it = state->definitions.find(full_key);
     if (definition_it != state->definitions.end()) {
+        const std::vector<std::byte> *definition = &definition_it->second;
+        lock.unlock();
         PTO2TaskId submitted = PTO2TaskId::invalid();
         ORCH_PHASE_START();
-        if (graph_submit_definition(orch, state, definition_it->second, args, &submitted)) {
+        if (graph_submit_definition(orch, state, *definition, args, &submitted)) {
             result.execute_block = false;
             result.task_id = submitted;
             ORCH_PHASE_END(HostOrchPhase::GraphSubmit, submitted.raw);
@@ -2114,6 +2678,7 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
             !graph_recording_boundary_matches(*entry.recording, args)) {
             return result;
         }
+        lock.unlock();
         PTO2TaskId submitted = PTO2TaskId::invalid();
         ORCH_PHASE_START();
         if (graph_submit_pending_definition(orch, state, full_key, args, &submitted)) {
@@ -2142,7 +2707,10 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
         return result;
     }
 
-    auto recording = std::make_unique<GraphRecording>();
+    if (state->next_prewarmed_recording >= state->prewarmed_recordings.size()) return result;
+    auto entry = std::move(state->prewarmed_recordings[state->next_prewarmed_recording++]);
+    if (entry == nullptr || entry->recording == nullptr) return result;
+    GraphRecording *recording = entry->recording.get();
     recording->full_key = full_key;
     recording->start_local_task_id = orch->ring.task_allocator.active_count();
     if (!graph_recording_init_tensor_map(*recording)) {
@@ -2152,16 +2720,25 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
     recording->boundary_scalar_count = args.scalar_count();
     recording->boundary_tensors.reserve(static_cast<size_t>(args.tensor_count()));
     recording->boundary_types.reserve(static_cast<size_t>(args.tensor_count()));
+    recording->boundary_alias_reps.resize(static_cast<size_t>(args.tensor_count()));
+    if (!graph_boundary_alias_representatives(args, recording->boundary_alias_reps.data())) return result;
     for (int32_t i = 0; i < args.tensor_count(); ++i) {
         recording->boundary_tensors.push_back(args.tensor(i).ref());
         recording->boundary_types.push_back(args.tag(i));
     }
-    auto entry = std::make_unique<GraphInflightRecording>();
     entry->full_key = full_key;
-    entry->recording = std::move(recording);
     GraphInflightRecording *entry_ptr = entry.get();
     state->inflight.emplace(full_key, std::move(entry));
+    GraphFastEntry &fast = state->fast_entries[state->fast_entry_count++];
+    fast.full_key = full_key;
+    fast.boundary_count = static_cast<uint32_t>(args.tensor_count());
+    fast.boundary_scalar_count = static_cast<uint32_t>(args.scalar_count());
+    fast.validated_run_epoch = state->run_epoch;
+    fast.definition.store(nullptr, std::memory_order_relaxed);
+    fast.recording_status.store(GraphRecordingStatus::RECORDING, std::memory_order_release);
+    entry_ptr->fast_entry = &fast;
     state->inflight_count.store(state->inflight.size(), std::memory_order_release);
+    lock.unlock();
 
     PTO2TaskId submitted = PTO2TaskId::invalid();
     ORCH_PHASE_START();
@@ -2178,8 +2755,12 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
 #endif
 #endif
     } else {
-        state->inflight.erase(full_key);
+        lock.lock();
+        auto failed = state->inflight.find(full_key);
+        if (failed != state->inflight.end() && failed->second.get() == entry_ptr) state->inflight.erase(failed);
         state->inflight_count.store(state->inflight.size(), std::memory_order_release);
+        always_assert(state->fast_entry_count != 0 && &state->fast_entries[state->fast_entry_count - 1] == &fast);
+        --state->fast_entry_count;
     }
     return result;
 }
@@ -2209,15 +2790,28 @@ bool PTO2OrchestratorState::graph_prepare(void *recording_handle, const GraphTas
         graph_recording_boundary_matches(*entry->recording, args) &&
         "the recording thread's boundary copy must match the boundary graph_begin recorded"
     );
+    try {
+        entry->recording->nodes.reserve(GRAPH_INITIAL_RECORDED_NODES);
+        entry->recording->tensor_sources.reserve(GRAPH_INITIAL_RECORDED_TENSORS);
+        entry->recording->scalars.reserve(GRAPH_INITIAL_RECORDED_SCALARS);
+        entry->recording->scalar_sources.reserve(GRAPH_INITIAL_RECORDED_SCALARS);
+        entry->recording->internal_fanins.reserve(GRAPH_INITIAL_RECORDED_FANINS);
+        entry->recording->output_ranges.reserve(GRAPH_INITIAL_RECORDED_NODES);
+    } catch (...) {
+        entry->recording->unsupported = true;
+        return false;
+    }
     args.anchor_scalar_sources();
     entry->recording->boundary_args = &args;
     g_active_graph_entry = entry;
     g_active_graph_recording = entry->recording.get();
     g_active_graph_owner = state;
+    host_phase_producer_begin();
     return true;
 }
 
 void PTO2OrchestratorState::graph_abort(void *recording_handle) {
+    host_phase_producer_end();
     GraphHostState *state = graph_state_from(this);
     auto *entry = static_cast<GraphInflightRecording *>(recording_handle);
     if (state == nullptr || entry == nullptr) return;
@@ -2240,9 +2834,15 @@ bool PTO2OrchestratorState::graph_end() {
     GraphInflightRecording *entry = g_active_graph_entry;
     if (state == nullptr || recording == nullptr || entry == nullptr) return false;
 
-    std::vector<std::byte> definition;
+    std::vector<std::byte> &definition = entry->definition_scratch;
+    definition.clear();
     ORCH_PHASE_START();
-    const bool built = graph_build_definition(*recording, &definition);
+    const bool built = graph_build_definition_direct(*recording, &definition);
+#ifndef NDEBUG
+    std::vector<std::byte> reference_definition;
+    const bool reference_built = graph_build_definition(*recording, &reference_definition);
+    debug_assert(reference_built == built && (!built || reference_definition == definition));
+#endif
     if (built) {
         ORCH_PHASE_END(HostOrchPhase::BuildDefinition, recording->nodes.size());
     }
@@ -2263,16 +2863,25 @@ bool PTO2OrchestratorState::graph_end() {
         if (entry->status() != GraphRecordingStatus::RECORDING || entry->full_key != header->full_key) {
             entry->set_status(GraphRecordingStatus::FAILED);
         } else {
-            state->definitions.emplace(header->full_key, std::move(definition));
-            entry->set_status(GraphRecordingStatus::READY);
+            auto [definition_it, inserted] = state->definitions.emplace(header->full_key, std::move(definition));
+            if (!inserted) {
+                entry->set_status(GraphRecordingStatus::FAILED);
+            } else if (entry->fast_entry != nullptr) {
+                entry->fast_entry->definition.store(&definition_it->second, std::memory_order_release);
+            }
+            if (!inserted) {
+                ready = false;
+            } else {
+                entry->set_status(GraphRecordingStatus::READY);
+            }
         }
         ready = entry->status() == GraphRecordingStatus::READY;
-        entry->recording.reset();
     }
     g_active_graph_entry = nullptr;
     g_active_graph_recording = nullptr;
     g_active_graph_owner = nullptr;
     state->recording_cv.notify_all();
+    host_phase_producer_end();
     return ready;
 }
 
@@ -2306,6 +2915,10 @@ void PTO2OrchestratorState::graph_commit() {
         failed = true;
     }
     if (!failed && !graph_finalize_pending_submissions(this, state, &failed_key)) failed = true;
+    for (auto &[key, entry] : drained) {
+        (void)key;
+        state->retired_recordings.push_back(std::move(entry));
+    }
     if (failed) {
         report_fatal(
             PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "failed to finalize asynchronous Graph key=%#llx",

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -132,11 +132,14 @@ with the unmodified boundary value.
   dependency, exactly as on the ordinary path, so the caller still declares one
   on the operand's producer.
 
-Structural or alias mismatch logs a warning and executes the Graph function
-normally for that invocation. It never reuses heap offsets recorded for a
-different shape. Debug builds also assert at these unsupported boundaries so
-development catches a violated fixed-shape contract immediately; the ordinary
-path remains the defensive release-build behavior.
+The first occurrence of each Graph key in a new orchestration run validates its
+structural and alias contract. A mismatch logs a warning and executes the Graph
+function normally; debug builds also assert. Later occurrences of that key in
+the same run use the already-validated key and an atomic Definition state, so
+they neither rescan the boundary nor contend with recorder publication. Fixed
+shape and alias metadata are therefore a per-key API contract within one run;
+the device exact-validates every reconstructed submission before materializing
+it.
 
 ## Qwen decoder-layer example
 
@@ -199,9 +202,9 @@ void decode_three_layers(
 
 All three layers submit one Graph task each. The first starts background
 recording, while layers two and three immediately submit outer task shells for
-the same in-flight identity. The first following non-Graph operation (or
-orchestration completion) joins recording and finalizes all three shells with
-the new Definition. Each invocation patches the current layer's
+the same in-flight identity. Orchestration completion joins recording and
+finalizes all three shells with the new Definition; intervening non-Graph
+operations are not barriers. Each invocation patches the current layer's
 `token_position`; it is a dynamic boundary scalar refreshed on every submission
 and is not part of the Graph key.
 
@@ -210,10 +213,17 @@ and is not part of the Graph key.
 Recording uses host-only C++ state:
 
 - `std::vector` for nodes, tensors, scalars, fanins, and pending uploads;
-- `std::unordered_map` for the per-run Definition cache;
+- `std::unordered_map` for the registered callable's Definition cache;
 - `std::unordered_map` for the recordings in flight, keyed by Graph identity and
   holding each entry by `std::unique_ptr`, guarded by a mutex and completion
   condition while the recording threads publish their Definitions.
+
+Callable registration preallocates empty recording storage for the first eight
+distinct keys. This reserves vectors, tensor-arena blocks and Definition image
+capacity only; it neither executes a Graph body nor creates a cached Definition.
+After a cold recording publishes its Definition, that temporary storage remains
+owned by the callable instead of being freed under the publication mutex on the
+`host_orch` critical path.
 
 The cache stores at most 16 Definitions and allocates each entry to its actual
 serialized size. Published and in-flight entries count against the same limit,
@@ -253,6 +263,10 @@ a workload that cuts a forward pass into up to eight Definitions without creatin
 threads or allocating boundary storage between shell submissions. A ninth or later
 concurrent miss grows one worker per additional job, up to the 16-Definition
 limit, so the prewarm does not turn into an eight-recording concurrency cap.
+Between two commits, one worker claims at most one distinct-key recording. A
+short Definition therefore cannot re-enter the shared queue and take a later
+key while a prewarmed worker remains parked; the pool sizes against all jobs in
+the current batch rather than only the jobs that happen to still be active.
 Growth happens inside the submission that needs it, so it lands on the submitting
 thread: a workload whose Definition count exceeds the prewarmed count pays a
 `pthread_create` (measured 32-74 us each) in the middle of its submission burst.
@@ -336,24 +350,30 @@ device execution pool requires this hash, the Graph key, and the node count to
 all match before reusing a resident Definition. A new run may record different
 metadata under the same function identity, so key-only reuse is not safe.
 
-All references are 32-bit offsets from the Definition base. Cross-boundary
-Tensors use the fixed-width `GraphTensor` wire POD rather than the
-64-byte-aligned C++ `ChipTensor` object. The upload is therefore one contiguous
-copy with no raw Host pointers and no relocation pass.
+All references are 32-bit offsets from the Definition base. Definition tensor
+templates use the fixed-width `GraphTensor` wire POD rather than the
+64-byte-aligned C++ `ChipTensor` object. Per-occurrence submissions carry only a
+40-byte `GraphInvocationTensor`: address, owner, offset/extent, version and
+address space. The device reconstructs its full boundary tensor from that
+dynamic half plus the Definition's fixed boundary signature. This avoids
+resending shape, stride, dtype and layout metadata on every shell while keeping
+the image pointer-free and exact-validated.
 
 Before materialization, the Scheduler recomputes the Definition content hash
 and validates section ranges, topology indices, node heap offsets, the outer
 heap extent, ChipTensor metadata, and ChipTensor-source bounds. Invalid wire data is
 rejected before an offset participates in pointer arithmetic.
 
-There is no cache schema version. The cache is per run and starts empty, so a
-persistent-format version would currently have no effect.
+There is no cache schema version. The cache is process-local, is owned by one
+registered callable, and is destroyed before that callable's orchestration SO
+is unloaded. It is not a persistent on-disk format.
 
 ## Cache hit and memory
 
 For a cache hit, the Host Orchestrator:
 
-1. validates the fixed boundary contract;
+1. validates the fixed boundary contract on the key's first occurrence in this
+   run; later occurrences use the hash-keyed fast entry;
 2. reserves one task-window slot;
 3. reserves one heap block large enough for every internal intermediate, plus
    the Definition's `execution_storage_bytes` for the execution the device
@@ -380,12 +400,13 @@ bytes it starts from are whatever that heap region last held.
 ## Scheduler flow
 
 Host orchestration builds the complete task image before device execution. At
-the end of orchestration, the Host stages each Graph POD image into the runtime
-arena's device region alongside the compacted shared-memory image, copies that
-one bind image to the device, and then launches the resident Scheduler. Nothing
-is patched on the way: a slot state names its payload and descriptor by a delta
-from its own address, so the bytes the Host wrote are the bytes the device
-schedules.
+the end of orchestration, the Host stages each distinct Definition object and
+each Graph POD submission into a Graph block in the runtime arena, alongside
+the compacted shared-memory image. Each submission's `definition_addr` is
+patched to the corresponding object in that same block. The Host then copies
+the complete bind image to the device and launches the resident Scheduler. A
+slot state names its payload and descriptor by a delta from its own address, so
+no other task-image relocation is needed.
 
 All AICPU threads classify disjoint slices of the completed task window behind
 one startup barrier. A Graph task enters preparation and external-fanin

--- a/src/common/host_build_graph/graph_execution.cpp
+++ b/src/common/host_build_graph/graph_execution.cpp
@@ -221,6 +221,15 @@ GraphDefinition *graph_definition_object_verified(GraphDefinitionHeader &header)
 // which bounds a producer reference to a node that is already constructed.
 // Returns false when the ref addresses no valid source — the Definition is then
 // invalid, since every ref is written by the recorder from a classified source.
+bool graph_execution_boundary_tensor(const GraphExecution &execution, uint16_t index, GraphTensor *tensor) {
+    if (tensor == nullptr || index >= execution.boundary_tensor_count || execution.boundary_tensors == nullptr ||
+        execution.boundary_signatures == nullptr) {
+        return false;
+    }
+    *tensor = graph_invocation_tensor_unpack(execution.boundary_tensors[index], execution.boundary_signatures[index]);
+    return graph_tensor_wire_valid(*tensor);
+}
+
 bool graph_rebind_tensor(
     const GraphExecution &execution, const GraphNodeDefinition *nodes, const uint64_t *node_offsets,
     const GraphTensor &tensor_template, const GraphTensorSourceRef &ref, int32_t node_index, GraphTensor *rebound_out
@@ -228,11 +237,12 @@ bool graph_rebind_tensor(
     GraphTensor rebound = tensor_template;
     if (!graph_tensor_wire_valid(rebound)) return false;
     if (ref.source == static_cast<uint8_t>(GraphTensorSource::BOUNDARY_EXACT)) {
-        if (ref.source_index >= execution.boundary_tensor_count || ref.packed_offset != 0) return false;
-        rebound = execution.boundary_tensors[ref.source_index];
+        if (ref.packed_offset != 0 || !graph_execution_boundary_tensor(execution, ref.source_index, &rebound)) {
+            return false;
+        }
     } else if (ref.source == static_cast<uint8_t>(GraphTensorSource::BOUNDARY_VIEW)) {
-        if (ref.source_index >= execution.boundary_tensor_count) return false;
-        const GraphTensor &boundary = execution.boundary_tensors[ref.source_index];
+        GraphTensor boundary;
+        if (!graph_execution_boundary_tensor(execution, ref.source_index, &boundary)) return false;
         if (ref.packed_offset > UINT64_MAX - boundary.start_offset) return false;
         rebound.buffer_addr = boundary.buffer_addr;
         rebound.buffer_size = boundary.buffer_size;
@@ -327,20 +337,16 @@ GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
     auto *definition_header =
         reinterpret_cast<GraphDefinitionHeader *>(static_cast<uintptr_t>(submission->definition_addr));
     if (definition_header->magic != GRAPH_DEFINITION_OBJECT_MAGIC) return nullptr;
-    const GraphTensor *boundary_tensors = graph_submission_tensors(*submission);
+    const GraphInvocationTensor *boundary_tensors = graph_submission_tensors(*submission);
     const uint64_t *boundary_scalars = graph_submission_scalars(*submission);
     const size_t boundary_tensor_end = static_cast<size_t>(submission->tensors_offset) +
-                                       static_cast<size_t>(submission->tensor_count) * sizeof(GraphTensor);
+                                       static_cast<size_t>(submission->tensor_count) * sizeof(GraphInvocationTensor);
     if (boundary_tensors == nullptr || outer_slot.task == nullptr || outer_slot.task->packed_buffer_base == nullptr ||
         outer_slot.task->packed_buffer_end == nullptr ||
         (submission->scalar_count != 0 && boundary_scalars == nullptr) ||
         (submission->scalar_count != 0 && submission->scalars_offset < boundary_tensor_end)) {
         return nullptr;
     }
-    for (uint32_t i = 0; i < submission->tensor_count; ++i) {
-        if (!graph_tensor_wire_valid(boundary_tensors[i])) return nullptr;
-    }
-
     uint64_t expected = 0;
     if (!__atomic_compare_exchange_n(
             &submission->local_execution, &expected, GRAPH_EXECUTION_INITIALIZING, false, __ATOMIC_ACQ_REL,
@@ -358,6 +364,20 @@ GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
         submission->scalar_count != definition->boundary_scalar_count) {
         __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
         return nullptr;
+    }
+    const GraphBoundarySignature *boundary_signatures = graph_definition_array<GraphBoundarySignature>(
+        *definition, definition->off_boundary_signatures, definition->boundary_count
+    );
+    if (boundary_signatures == nullptr) {
+        __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
+        return nullptr;
+    }
+    for (uint32_t i = 0; i < submission->tensor_count; ++i) {
+        const GraphTensor tensor = graph_invocation_tensor_unpack(boundary_tensors[i], boundary_signatures[i]);
+        if (!graph_tensor_wire_valid(tensor)) {
+            __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
+            return nullptr;
+        }
     }
     const uintptr_t outer_base = reinterpret_cast<uintptr_t>(outer_slot.task->packed_buffer_base);
     const uintptr_t outer_end = reinterpret_cast<uintptr_t>(outer_slot.task->packed_buffer_end);
@@ -391,6 +411,7 @@ GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
         return nullptr;
     }
     execution->boundary_tensors = boundary_tensors;
+    execution->boundary_signatures = boundary_signatures;
     execution->boundary_tensor_count = submission->tensor_count;
     execution->boundary_scalars = boundary_scalars;
     execution->boundary_scalar_count = submission->scalar_count;

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -51,6 +51,21 @@ struct GraphTensor {
     uint8_t reserved[3];
 };
 
+// Per-invocation half of one Graph boundary tensor. Shape, strides, dtype,
+// buffer size and layout flags are fixed by the Definition's boundary
+// signature, so sending them again in every outer shell wastes both main-thread
+// packing work and H2D bytes. These are exactly the fields allowed to vary
+// between submissions of the same Definition.
+struct GraphInvocationTensor {
+    uint64_t buffer_addr;
+    uint64_t owner_task_id;
+    uint64_t start_offset;
+    uint64_t extent_elem;
+    int32_t version;
+    uint8_t address_space;
+    uint8_t reserved[3];
+};
+
 // Everything from GraphTensorSourceRef through GraphSubmission is copied
 // across the host-device boundary. Keep it pointer-free, fixed-width and
 // position-independent: every reference is an offset from its owning header.
@@ -122,6 +137,49 @@ struct GraphBoundarySignature {
     uint8_t is_contiguous;
     uint8_t reserved;
 };
+
+inline GraphInvocationTensor graph_invocation_tensor_pack(const ChipTensor &tensor) {
+    GraphInvocationTensor packed{};
+    packed.buffer_addr = tensor.buffer.addr;
+    packed.owner_task_id = tensor.owner_task_id.raw;
+    packed.start_offset = tensor.start_offset;
+    packed.extent_elem = tensor.extent_elem_cache;
+    packed.version = tensor.version;
+    packed.address_space = static_cast<uint8_t>(tensor.address_space);
+    return packed;
+}
+
+inline GraphInvocationTensor graph_invocation_tensor_pack(const GraphTensor &tensor) {
+    GraphInvocationTensor packed{};
+    packed.buffer_addr = tensor.buffer_addr;
+    packed.owner_task_id = tensor.owner_task_id;
+    packed.start_offset = tensor.start_offset;
+    packed.extent_elem = tensor.extent_elem;
+    packed.version = tensor.version;
+    packed.address_space = tensor.address_space;
+    return packed;
+}
+
+inline GraphTensor
+graph_invocation_tensor_unpack(const GraphInvocationTensor &invocation, const GraphBoundarySignature &signature) {
+    GraphTensor tensor{};
+    tensor.buffer_addr = invocation.buffer_addr;
+    tensor.buffer_size = signature.buffer_size;
+    tensor.owner_task_id = invocation.owner_task_id;
+    tensor.start_offset = invocation.start_offset;
+    tensor.extent_elem = invocation.extent_elem;
+    tensor.version = invocation.version;
+    for (uint32_t i = 0; i < MAX_TENSOR_DIMS; ++i) {
+        tensor.shapes[i] = signature.shapes[i];
+        tensor.strides[i] = signature.strides[i];
+    }
+    tensor.ndims = signature.ndims;
+    tensor.dtype = signature.dtype;
+    tensor.manual_dep = signature.manual_dep;
+    tensor.is_contiguous = signature.is_contiguous;
+    tensor.address_space = invocation.address_space;
+    return tensor;
+}
 
 // Header prefixing each device-resident Definition object. The definition
 // buffer uploaded by the host is [GraphDefinitionHeader][GraphDefinition image];
@@ -211,6 +269,9 @@ static_assert(std::is_trivially_copyable_v<GraphTensorSourceRef>);
 static_assert(std::is_standard_layout_v<GraphTensorSourceRef>);
 static_assert(std::is_trivially_copyable_v<GraphTensor>);
 static_assert(std::is_standard_layout_v<GraphTensor>);
+static_assert(std::is_trivially_copyable_v<GraphInvocationTensor>);
+static_assert(std::is_standard_layout_v<GraphInvocationTensor>);
+static_assert(sizeof(GraphInvocationTensor) == 40);
 static_assert(std::is_trivially_copyable_v<GraphScalarSourceRef>);
 static_assert(std::is_standard_layout_v<GraphScalarSourceRef>);
 static_assert(std::is_trivially_copyable_v<GraphNodeDefinition>);
@@ -310,13 +371,14 @@ inline bool graph_submission_wire_size_valid(const GraphSubmission &submission, 
     return available_bytes >= sizeof(GraphSubmission) && submission.total_bytes == available_bytes;
 }
 
-inline const GraphTensor *graph_submission_tensors(const GraphSubmission &submission) {
-    if (submission.tensors_offset == 0 || submission.tensors_offset % alignof(GraphTensor) != 0 ||
+inline const GraphInvocationTensor *graph_submission_tensors(const GraphSubmission &submission) {
+    if (submission.tensors_offset == 0 || submission.tensors_offset % alignof(GraphInvocationTensor) != 0 ||
         submission.tensors_offset > submission.total_bytes ||
-        submission.tensor_count > (submission.total_bytes - submission.tensors_offset) / sizeof(GraphTensor)) {
+        submission.tensor_count >
+            (submission.total_bytes - submission.tensors_offset) / sizeof(GraphInvocationTensor)) {
         return nullptr;
     }
-    return reinterpret_cast<const GraphTensor *>(
+    return reinterpret_cast<const GraphInvocationTensor *>(
         reinterpret_cast<const uint8_t *>(&submission) + submission.tensors_offset
     );
 }
@@ -387,7 +449,8 @@ struct GraphExecution {
     const GraphDefinition *definition{nullptr};
     const uint32_t *fanin_offsets{nullptr};
     const uint16_t *fanin_indices{nullptr};
-    const GraphTensor *boundary_tensors{nullptr};
+    const GraphInvocationTensor *boundary_tensors{nullptr};
+    const GraphBoundarySignature *boundary_signatures{nullptr};
     uint32_t boundary_tensor_count{0};
     const uint64_t *boundary_scalars{nullptr};
     uint32_t boundary_scalar_count{0};

--- a/src/common/host_build_graph/graph_host_state.h
+++ b/src/common/host_build_graph/graph_host_state.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -34,6 +35,11 @@ struct GraphHostUpload {
     size_t bytes;
 };
 
+struct GraphHostUploadBatch {
+    std::byte *data;
+    size_t bytes;
+};
+
 // The run's distinct Definition images (already deduplicated by the host-side
 // Definition cache), for upload as shared device objects ahead of submissions.
 struct GraphHostDefinition {
@@ -43,10 +49,20 @@ struct GraphHostDefinition {
 };
 
 struct GraphHostDefinitionList {
-    std::vector<GraphHostDefinition> entries;
+    std::array<GraphHostDefinition, GRAPH_MAX_DEFINITIONS> entries{};
+    size_t count{0};
+
+    size_t size() const { return count; }
+    const GraphHostDefinition &operator[](size_t index) const { return entries[index]; }
+    const GraphHostDefinition *begin() const { return entries.data(); }
+    const GraphHostDefinition *end() const { return entries.data() + count; }
 };
 
 GraphHostStatePtr make_graph_host_state();
+// Start another orchestration pass against a callable-owned state. Completed
+// Definitions remain reusable; per-run submission images are discarded.
+bool graph_host_begin_run(GraphHostState &state);
 size_t graph_host_upload_count(const GraphHostState &state);
 std::optional<GraphHostUpload> graph_host_upload(GraphHostState &state, size_t index);
+GraphHostUploadBatch graph_host_upload_batch(GraphHostState &state);
 GraphHostDefinitionList graph_host_definitions(GraphHostState &state);

--- a/src/common/platform/include/host/host_phase_records.h
+++ b/src/common/platform/include/host/host_phase_records.h
@@ -212,8 +212,8 @@ private:
  *
  * A written record is visible to a reader only after that producer stops, so a
  * reader must not read a pass before its producers are done.
- * `host_phase_trace_end()` guarantees that: it clears `active` and drains the
- * in-flight count to zero before `finish()`.
+ * `host_phase_trace_end()` guarantees that: it clears `active` and drains every
+ * producer's pass-lifetime lease before `finish()`.
  *
  * @param start_ns,end_ns  host monotonic nanoseconds
  * @param payload          task id for kinds that submit a task, else a detail count

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -490,7 +490,8 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
         if (artifacts.host_dlopen_handle != nullptr) {
             rc = runner->record_host_orch_callable(
                 callable_id, artifacts.chip_buffer_hash, artifacts.aicore_image_hash, artifacts.host_dlopen_handle,
-                artifacts.host_orch_func_ptr, std::move(kernel_addrs), std::move(artifacts.signature)
+                artifacts.host_orch_func_ptr, std::move(artifacts.host_orch_owner), std::move(kernel_addrs),
+                std::move(artifacts.signature)
             );
             if (rc != 0) return rc;
             host_dlopen_guard.dismiss();

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -875,7 +875,8 @@ int DeviceRunnerBase::record_device_orch_callable(
 
 int DeviceRunnerBase::record_host_orch_callable(
     int32_t callable_id, uint64_t chip_buffer_hash, uint64_t aicore_image_hash, void *host_dlopen_handle,
-    void *host_orch_func_ptr, std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
+    void *host_orch_func_ptr, std::shared_ptr<void> host_orch_owner, std::vector<std::pair<int, uint64_t>> kernel_addrs,
+    std::vector<ArgDirection> signature
 ) {
     if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
         LOG_ERROR(
@@ -901,6 +902,7 @@ int DeviceRunnerBase::record_host_orch_callable(
     state.aicore_image_hash = aicore_image_hash;
     state.host_dlopen_handle = host_dlopen_handle;
     state.host_orch_func_ptr = host_orch_func_ptr;
+    state.host_orch_owner = std::move(host_orch_owner);
     state.kernel_addrs = std::move(kernel_addrs);
     state.signature = std::move(signature);
     callables_.emplace(callable_id, std::move(state));
@@ -921,6 +923,7 @@ int DeviceRunnerBase::unregister_callable(int32_t callable_id) {
 
     if (state.host_dlopen_handle != nullptr) {
         // hbg path: no device-side orch SO handle, just dlclose the host handle.
+        state.host_orch_owner.reset();
         dlclose(state.host_dlopen_handle);
         return 0;
     }
@@ -1408,6 +1411,7 @@ int DeviceRunnerBase::finalize_common_impl(bool abandon_device_resources) {
     // pytest sessions.
     for (auto &kv : callables_) {
         if (kv.second.host_dlopen_handle != nullptr) {
+            kv.second.host_orch_owner.reset();
             dlclose(kv.second.host_dlopen_handle);
         }
     }

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -372,8 +372,8 @@ public:
      */
     int record_host_orch_callable(
         int32_t callable_id, uint64_t chip_buffer_hash, uint64_t aicore_image_hash, void *host_dlopen_handle,
-        void *host_orch_func_ptr, std::vector<std::pair<int, uint64_t>> kernel_addrs,
-        std::vector<ArgDirection> signature
+        void *host_orch_func_ptr, std::shared_ptr<void> host_orch_owner,
+        std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
     );
 
     /**
@@ -1037,6 +1037,7 @@ protected:
         // hbg path (host already dlopen'd the orch SO)
         void *host_dlopen_handle{nullptr};
         void *host_orch_func_ptr{nullptr};
+        std::shared_ptr<void> host_orch_owner;
     };
     std::unordered_map<int32_t, CallableState> callables_;
     // Opaque provider handle from dma_workspace_provision(), owned for the

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -449,7 +449,7 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
         if (artifacts.host_dlopen_handle != nullptr) {
             rc = runner->record_host_orch_callable(
                 callable_id, artifacts.chip_buffer_hash, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr,
-                std::move(kernel_addrs), std::move(artifacts.signature)
+                std::move(artifacts.host_orch_owner), std::move(kernel_addrs), std::move(artifacts.signature)
             );
             if (rc == 0) {
                 host_dlopen_guard.dismiss();

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -555,7 +555,8 @@ int SimDeviceRunnerBase::record_device_orch_callable(
 
 int SimDeviceRunnerBase::record_host_orch_callable(
     int32_t callable_id, uint64_t chip_buffer_hash, void *host_dlopen_handle, void *host_orch_func_ptr,
-    std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
+    std::shared_ptr<void> host_orch_owner, std::vector<std::pair<int, uint64_t>> kernel_addrs,
+    std::vector<ArgDirection> signature
 ) {
     if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
         LOG_ERROR(
@@ -580,6 +581,7 @@ int SimDeviceRunnerBase::record_host_orch_callable(
     state.chip_buffer_hash = chip_buffer_hash;
     state.host_dlopen_handle = host_dlopen_handle;
     state.host_orch_func_ptr = host_orch_func_ptr;
+    state.host_orch_owner = std::move(host_orch_owner);
     state.kernel_addrs = std::move(kernel_addrs);
     state.signature = std::move(signature);
     callables_.emplace(callable_id, std::move(state));
@@ -600,6 +602,7 @@ int SimDeviceRunnerBase::unregister_callable(int32_t callable_id) {
 
     if (state.host_dlopen_handle != nullptr) {
         // hbg: dlclose the host handle; no device-side orch SO handle.
+        state.host_orch_owner.reset();
         dlclose(state.host_dlopen_handle);
         return 0;
     }
@@ -889,6 +892,7 @@ void SimDeviceRunnerBase::release_callable_state() {
     // pytest sessions.
     for (auto &kv : callables_) {
         if (kv.second.host_dlopen_handle != nullptr) {
+            kv.second.host_orch_owner.reset();
             dlclose(kv.second.host_dlopen_handle);
         }
     }

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -213,7 +213,8 @@ public:
     );
     int record_host_orch_callable(
         int32_t callable_id, uint64_t chip_buffer_hash, void *host_dlopen_handle, void *host_orch_func_ptr,
-        std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
+        std::shared_ptr<void> host_orch_owner, std::vector<std::pair<int, uint64_t>> kernel_addrs,
+        std::vector<ArgDirection> signature
     );
     int unregister_callable(int32_t callable_id);
     bool has_callable(int32_t callable_id) const;
@@ -438,6 +439,7 @@ protected:
         // hbg path
         void *host_dlopen_handle{nullptr};
         void *host_orch_func_ptr{nullptr};
+        std::shared_ptr<void> host_orch_owner;
     };
     std::unordered_map<int32_t, CallableState> callables_;
     std::unordered_set<int32_t> aicpu_seen_callable_ids_;

--- a/src/common/task_interface/prepare_callable_common.h
+++ b/src/common/task_interface/prepare_callable_common.h
@@ -24,6 +24,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -65,13 +66,17 @@ struct CallableArtifacts {
     std::vector<ArgDirection> signature;
     void *host_dlopen_handle{nullptr};  // hbg only
     void *host_orch_func_ptr{nullptr};  // hbg only
-    uint64_t chip_buffer_hash{0};       // FNV-1a hash for the whole ChipCallable buffer
-    uint64_t aicore_image_hash{0};      // FNV-1a hash for func ids and AICore child binaries
-    uint64_t chip_buffer_dev{0};        // device address of the ChipCallable header
-    const void *orch_so_data{nullptr};  // trb only; host view used for validation/hash only
-    size_t orch_so_size{0};             // trb only
-    std::string func_name;              // trb only (orch entry symbol)
-    std::string config_name;            // trb only (orch config symbol)
+    // Owns the runtime-specific object behind host_orch_func_ptr. Keeping the
+    // owner in CallableState gives host_build_graph callable-lifetime caches a
+    // precise unregister/finalize lifetime without exposing their type here.
+    std::shared_ptr<void> host_orch_owner;  // hbg only
+    uint64_t chip_buffer_hash{0};           // FNV-1a hash for the whole ChipCallable buffer
+    uint64_t aicore_image_hash{0};          // FNV-1a hash for func ids and AICore child binaries
+    uint64_t chip_buffer_dev{0};            // device address of the ChipCallable header
+    const void *orch_so_data{nullptr};      // trb only; host view used for validation/hash only
+    size_t orch_so_size{0};                 // trb only
+    std::string func_name;                  // trb only (orch entry symbol)
+    std::string config_name;                // trb only (orch config symbol)
 };
 
 /**

--- a/tests/ut/cpp/common/test_hbg_graph_async_submit.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_async_submit.cpp
@@ -202,6 +202,41 @@ TEST(HbgGraphAsyncSubmit, PrewarmedRecorderPoolGrowsPastThePrewarmedCount) {
         << "a concurrent miss past the prewarmed count must grow the pool instead of queueing";
 }
 
+TEST(HbgGraphAsyncSubmit, CompletedRecorderDoesNotClaimAnotherKeyInTheSameBatch) {
+    GraphAsyncRecordingState pool;
+    ASSERT_TRUE(pool.prewarm());
+    GraphTaskArgs empty_args;
+    std::mutex mutex;
+    std::condition_variable cv;
+    int completed = 0;
+    std::thread::id first_worker;
+    std::thread::id second_worker;
+
+    ASSERT_TRUE(pool.start(empty_args, [&](GraphTaskArgs &) {
+        std::lock_guard<std::mutex> lock(mutex);
+        first_worker = std::this_thread::get_id();
+        completed++;
+        cv.notify_all();
+    }));
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        ASSERT_TRUE(cv.wait_for(lock, kHandshakeTimeout, [&]() {
+            return completed == 1;
+        }));
+    }
+    ASSERT_TRUE(pool.start(empty_args, [&](GraphTaskArgs &) {
+        std::lock_guard<std::mutex> lock(mutex);
+        second_worker = std::this_thread::get_id();
+        completed++;
+        cv.notify_all();
+    }));
+    pool.wait();
+
+    EXPECT_EQ(completed, 2);
+    EXPECT_NE(first_worker, second_worker)
+        << "a fast recording must leave the next key for another prewarmed worker until commit";
+}
+
 TEST(HbgGraphAsyncSubmit, FourDistinctGraphMissesDoNotInsertAnIntermediateCommit) {
     FakeRuntime fake{};
     fake.ops = &kFakeOps;

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -51,6 +51,19 @@ GraphTensor make_test_tensor(uint64_t address) {
     return tensor;
 }
 
+GraphBoundarySignature make_test_boundary_signature(const GraphTensor &tensor) {
+    GraphBoundarySignature signature{};
+    signature.buffer_size = tensor.buffer_size;
+    std::copy(std::begin(tensor.shapes), std::end(tensor.shapes), std::begin(signature.shapes));
+    std::copy(std::begin(tensor.strides), std::end(tensor.strides), std::begin(signature.strides));
+    signature.ndims = tensor.ndims;
+    signature.dtype = tensor.dtype;
+    signature.tag = static_cast<uint8_t>(TensorArgType::INPUT);
+    signature.manual_dep = tensor.manual_dep;
+    signature.is_contiguous = tensor.is_contiguous;
+    return signature;
+}
+
 std::vector<std::byte>
 make_test_definition(uint64_t graph_key, uint64_t boundary_address, uint32_t boundary_scalar_count = 1) {
     std::vector<std::byte> image(sizeof(GraphDefinition));
@@ -89,6 +102,7 @@ make_test_definition(uint64_t graph_key, uint64_t boundary_address, uint32_t bou
     scalar_sources[0].source = static_cast<uint8_t>(GraphScalarSource::BOUNDARY);
     scalar_sources[0].source_index = boundary_scalar_count - 1;
     scalar_sources[1].source = static_cast<uint8_t>(GraphScalarSource::STATIC_VALUE);
+    std::vector<GraphBoundarySignature> boundary_signatures{make_test_boundary_signature(tensors[0])};
 
     GraphDefinition definition{};
     definition.full_key = graph_key;
@@ -111,6 +125,7 @@ make_test_definition(uint64_t graph_key, uint64_t boundary_address, uint32_t bou
     definition.off_tensor_sources = append_section(image, tensor_sources);
     definition.off_scalars = append_section(image, scalars);
     definition.off_scalar_sources = append_section(image, scalar_sources);
+    definition.off_boundary_signatures = append_section(image, boundary_signatures);
     // Widest node here declares one tensor, so the storage strides well below the
     // type; the fixture exercises the compacted stride rather than the identity case.
     const size_t node_stride = graph_node_stride(1);
@@ -131,11 +146,12 @@ make_test_definition(uint64_t graph_key, uint64_t boundary_address, uint32_t bou
 std::vector<std::byte> make_test_submission(
     uint64_t graph_key, uint64_t boundary_address, uint64_t boundary_scalar, uint32_t boundary_scalar_count = 1
 ) {
-    const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphTensor));
-    const size_t scalars_offset = PTO2_ALIGN_UP(tensors_offset + sizeof(GraphTensor), alignof(uint64_t));
+    const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphInvocationTensor));
+    const size_t scalars_offset = PTO2_ALIGN_UP(tensors_offset + sizeof(GraphInvocationTensor), alignof(uint64_t));
     std::vector<std::byte> image(scalars_offset + boundary_scalar_count * sizeof(uint64_t));
     const GraphTensor boundary = make_test_tensor(boundary_address);
-    std::memcpy(image.data() + tensors_offset, &boundary, sizeof(boundary));
+    const GraphInvocationTensor invocation = graph_invocation_tensor_pack(boundary);
+    std::memcpy(image.data() + tensors_offset, &invocation, sizeof(invocation));
     std::memcpy(
         image.data() + scalars_offset + (boundary_scalar_count - 1) * sizeof(uint64_t), &boundary_scalar,
         sizeof(boundary_scalar)
@@ -379,7 +395,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     execution->retired_nodes.store(2, std::memory_order_release);
     submission.local_execution = 0;
     outer_task.task_id = PTO2TaskId::make(1, 8);
-    auto *boundary = reinterpret_cast<GraphTensor *>(submission_image.data() + submission.tensors_offset);
+    auto *boundary = reinterpret_cast<GraphInvocationTensor *>(submission_image.data() + submission.tensors_offset);
     boundary->buffer_addr = reinterpret_cast<uint64_t>(second_boundary.data());
     auto *boundary_scalar = reinterpret_cast<uint64_t *>(submission_image.data() + submission.scalars_offset);
     *boundary_scalar = 99;
@@ -441,7 +457,7 @@ TEST(GraphExecutionReplay, LocalizesBoundaryScalarPoolWiderThanTaskPayload) {
     outer_task.packed_buffer_end = heap.end();
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task = &outer_task;
+    outer_slot.task.set(&outer_task);
     outer_slot.graph_context = &submission;
 
     GraphExecution *execution = graph_execution_localize(outer_slot);
@@ -471,7 +487,7 @@ TEST(GraphExecutionReplay, RejectsBoundaryScalarPoolBeyondContract) {
     outer_task.packed_buffer_end = heap.end();
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task = &outer_task;
+    outer_slot.task.set(&outer_task);
     outer_slot.graph_context = &submission;
 
     EXPECT_EQ(graph_execution_localize(outer_slot), nullptr);

--- a/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
@@ -123,14 +123,98 @@ TEST_F(HbgGraphSubmitFailureTest, InFlightGraphSubmissionsReserveHeapOnlyAtCommi
     const auto *second_base = static_cast<const char *>(second_upload->outer_slot->task->packed_buffer_base);
     const auto *second_end = static_cast<const char *>(second_upload->outer_slot->task->packed_buffer_end);
     const GraphHostDefinitionList definitions = graph_host_definitions(*graph_state);
-    ASSERT_EQ(definitions.entries.size(), 1u);
-    ASSERT_EQ(definitions.entries[0].full_key, first_submission->graph_key);
-    const auto *definition = reinterpret_cast<const GraphDefinition *>(definitions.entries[0].data);
+    ASSERT_EQ(definitions.size(), 1u);
+    ASSERT_EQ(definitions[0].full_key, first_submission->graph_key);
+    const auto *definition = reinterpret_cast<const GraphDefinition *>(definitions[0].data);
     const uint64_t expected_extent =
         PTO2_ALIGN_UP(definition->required_heap + definition->execution_storage_bytes, PTO2_ALIGN_SIZE);
     EXPECT_EQ(static_cast<uint64_t>(first_end - first_base), expected_extent);
     EXPECT_EQ(static_cast<uint64_t>(second_end - second_base), expected_extent);
     EXPECT_TRUE(first_end <= second_base || second_end <= first_base) << "two shells must not share heap bytes";
+}
+
+TEST_F(HbgGraphSubmitFailureTest, ANewRunRetainsDefinitionsAndDropsOldSubmissions) {
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    ChipTensor boundary = make_tensor_external(storage.data(), shape, 1);
+    GraphTaskArgs boundary_args;
+    boundary_args.add_input(boundary);
+
+    orch.begin_scope();
+    const GraphScopeResult first = orch.graph_begin(0x1716, boundary_args, 0x1736);
+    ASSERT_TRUE(first.recording);
+    ASSERT_TRUE(orch.graph_prepare(first.recording_handle, boundary_args));
+    CoreTaskArgs node_args;
+    node_args.add_input(boundary);
+    TensorCreateInfo recorded_output(shape, 1, DataType::UINT32);
+    node_args.add_output(recorded_output);
+    ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
+    ASSERT_TRUE(orch.graph_end());
+    orch.graph_commit();
+    ASSERT_FALSE(orch.fatal);
+    ASSERT_EQ(graph_host_upload_count(*graph_state), 1u);
+    ASSERT_EQ(graph_host_definitions(*graph_state).size(), 1u);
+    const std::optional<GraphHostUpload> first_upload = graph_host_upload(*graph_state, 0);
+    const GraphHostUploadBatch first_batch = graph_host_upload_batch(*graph_state);
+    ASSERT_TRUE(first_upload.has_value());
+    ASSERT_NE(first_batch.data, nullptr);
+    EXPECT_EQ(first_upload->data, first_batch.data);
+    EXPECT_EQ(first_upload->bytes, first_batch.bytes);
+
+    ASSERT_TRUE(graph_host_begin_run(*graph_state));
+    EXPECT_EQ(graph_host_upload_count(*graph_state), 0u);
+    EXPECT_EQ(graph_host_definitions(*graph_state).size(), 1u);
+    EXPECT_EQ(graph_host_upload_batch(*graph_state).bytes, 0u);
+
+    const GraphScopeResult replay = orch.graph_begin(0x1716, boundary_args, 0x1736);
+    EXPECT_FALSE(replay.recording);
+    EXPECT_FALSE(replay.execute_block);
+    EXPECT_TRUE(replay.task_id.is_valid());
+    EXPECT_EQ(graph_host_upload_count(*graph_state), 1u);
+    EXPECT_EQ(graph_host_upload_batch(*graph_state).bytes, first_batch.bytes);
+}
+
+TEST_F(HbgGraphSubmitFailureTest, BoundaryAliasPartitionIsCheckedOnTheFirstSubmissionOfEachRun) {
+    std::array<uint32_t, 16> first_storage{};
+    std::array<uint32_t, 16> second_storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(first_storage.size())};
+    ChipTensor first = make_tensor_external(first_storage.data(), shape, 1);
+    ChipTensor second = make_tensor_external(second_storage.data(), shape, 1);
+
+    GraphTaskArgs recorded_args;
+    recorded_args.add_input(first);
+    recorded_args.add_input(first);
+    GraphTaskArgs same_partition_args;
+    same_partition_args.add_input(second);
+    same_partition_args.add_input(second);
+    GraphTaskArgs different_partition_args;
+    different_partition_args.add_input(first);
+    different_partition_args.add_input(second);
+
+    orch.begin_scope();
+    const GraphScopeResult recording = orch.graph_begin(0x171b, recorded_args, 0x1736);
+    ASSERT_TRUE(recording.recording);
+    const GraphScopeResult inflight_match = orch.graph_begin(0x171b, same_partition_args, 0x1736);
+    EXPECT_FALSE(inflight_match.execute_block);
+    EXPECT_TRUE(inflight_match.task_id.is_valid());
+    ASSERT_TRUE(orch.graph_prepare(recording.recording_handle, recorded_args));
+    CoreTaskArgs node_args;
+    node_args.add_input(first);
+    TensorCreateInfo recorded_output(shape, 1, DataType::UINT32);
+    node_args.add_output(recorded_output);
+    ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
+    ASSERT_TRUE(orch.graph_end());
+    orch.graph_commit();
+    ASSERT_FALSE(orch.fatal);
+
+    ASSERT_TRUE(graph_host_begin_run(*graph_state));
+    // The first occurrence of a key in a new run revalidates the fixed boundary
+    // contract. Later same-key submissions use the hash-keyed fast path and do
+    // not serialize with the recording mutex.
+    EXPECT_ANY_THROW((void)orch.graph_begin(0x171b, different_partition_args, 0x1736));
+    const GraphScopeResult cached_match = orch.graph_begin(0x171b, same_partition_args, 0x1736);
+    EXPECT_FALSE(cached_match.execute_block);
+    EXPECT_TRUE(cached_match.task_id.is_valid());
 }
 
 // The one combination the other two tests miss: real orchestrator state driven
@@ -233,8 +317,8 @@ TEST_F(HbgGraphSubmitFailureTest, WorkerRecordsWhileMainThreadSubmitsSameHashShe
     ASSERT_EQ(graph_host_upload_count(*graph_state), 3u);
 
     const GraphHostDefinitionList definitions = graph_host_definitions(*graph_state);
-    ASSERT_EQ(definitions.entries.size(), 1u);
-    const auto *definition = reinterpret_cast<const GraphDefinition *>(definitions.entries[0].data);
+    ASSERT_EQ(definitions.size(), 1u);
+    const auto *definition = reinterpret_cast<const GraphDefinition *>(definitions[0].data);
     const uint64_t expected_extent =
         PTO2_ALIGN_UP(definition->required_heap + definition->execution_storage_bytes, PTO2_ALIGN_SIZE);
 
@@ -526,6 +610,60 @@ TEST_F(HbgGraphPredicateRejectionTest, PredicateOnAKernellessNodeIsNotRecorded) 
     ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
 
     EXPECT_TRUE(orch.graph_end()) << "a dropped predicate must not make the body unrecordable";
+    orch.graph_commit();
+    EXPECT_FALSE(orch.fatal);
+}
+
+TEST_F(HbgGraphSubmitFailureTest, RepeatedReplayEquivalentPredicatesShareOneDefinitionSlot) {
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    ChipTensor boundary = make_tensor_external(storage.data(), shape, 1, DataType::INT32);
+    GraphTaskArgs boundary_args;
+    boundary_args.add_input(boundary);
+
+    orch.begin_scope();
+    const GraphScopeResult graph = orch.graph_begin(0x2004, boundary_args, 0x1736);
+    ASSERT_TRUE(graph.recording);
+    ASSERT_TRUE(orch.graph_prepare(graph.recording_handle, boundary_args));
+
+    std::array<ChipTensor, 3> predicate_operands{boundary, boundary, boundary};
+    // Both are the same boundary view at replay. Their recorded versions differ,
+    // but materialize replaces that invocation field before resolving either
+    // predicate, so storing two Definition slots would preserve no information.
+    predicate_operands[0].version = boundary.version + 1;
+    predicate_operands[1].version = boundary.version + 2;
+    predicate_operands[2].version = boundary.version + 3;
+
+    MixedKernels mixed{};
+    mixed.aiv0_kernel_id = 0;
+    for (int i = 0; i < 3; ++i) {
+        CoreTaskArgs node_args;
+        node_args.add_input(boundary);
+        TensorCreateInfo recorded_output(shape, 1, DataType::INT32);
+        node_args.add_output(recorded_output);
+        CoreTaskPredicate predicate;
+        predicate.operand.tensor = &predicate_operands[static_cast<size_t>(i)];
+        predicate.operand.ndims = 1;
+        predicate.operand.indices[0] = i == 1 ? 1 : 0;
+        predicate.op = PredicateOp::GT;
+        predicate.target = 0;
+        node_args.set_predicate(predicate);
+        ASSERT_TRUE(orch.submit_task(mixed, node_args).task_id().is_valid());
+    }
+
+    ASSERT_TRUE(orch.graph_end());
+    const GraphHostDefinitionList definitions = graph_host_definitions(*graph_state);
+    ASSERT_EQ(definitions.size(), 1u);
+    const auto *definition = reinterpret_cast<const GraphDefinition *>(definitions[0].data);
+    ASSERT_EQ(definition->task_count, 3u);
+    EXPECT_EQ(definition->predicate_count, 2u);
+    const auto *nodes = reinterpret_cast<const GraphNodeDefinition *>(
+        static_cast<const std::byte *>(definitions[0].data) + definition->off_nodes
+    );
+    EXPECT_EQ(nodes[0].predicate_slot, 1u);
+    EXPECT_EQ(nodes[1].predicate_slot, 2u);
+    EXPECT_EQ(nodes[2].predicate_slot, 1u);
+
     orch.graph_commit();
     EXPECT_FALSE(orch.fatal);
 }

--- a/tests/ut/py/test_toolchain.py
+++ b/tests/ut/py/test_toolchain.py
@@ -80,6 +80,9 @@ class TestGxxToolchainCmakeArgs:
         assert "-DCMAKE_C_FLAGS=-pthread -B /data/envs/lyf/compiler_compat" in args
         assert "-DCMAKE_CXX_FLAGS=-pthread -B /data/envs/lyf/compiler_compat" in args
 
+    def test_direct_host_builds_disable_debug_assertions(self, toolchain):
+        assert "-DNDEBUG" in toolchain.get_compile_flags()
+
 
 class TestGxxToolchainPreferG15Pins:
     """Under a sanitizer, prefer_g15 ABI-pins the host compiler to g++-15 so its
@@ -103,6 +106,9 @@ class TestGxxToolchainPreferG15Pins:
         args = toolchain.get_cmake_args()
         assert "-DCMAKE_C_COMPILER=gcc-15" in args
         assert "-DCMAKE_CXX_COMPILER=g++-15" in args
+
+    def test_sanitizer_host_builds_keep_debug_assertions(self, toolchain):
+        assert "-DNDEBUG" not in toolchain.get_compile_flags()
 
     def test_conda_flags_preserved_but_compiler_pinned(self, toolchain, monkeypatch):
         # Conda's injected -B compiler_compat flags must survive, but the


### PR DESCRIPTION
## Summary

- Submit hash-keyed zero-heap Graph shells immediately on the main thread while distinct cold Graph bodies record concurrently on dedicated, prewarmed workers. Same-key submissions use the published/in-flight key state and do not wait for Definition construction.
- Keep completed Definitions in callable-owned host state, use compact dynamic invocation tensors, and defer each shell heap reservation until the required Definition is available at the final commit barrier.
- Integrate with main PR #1947 by staging all Definition objects and Graph submissions in the compact runtime arena image. The device receives one bind-image H2D and no separate `sm_h2d` or per-Definition H2Ds.
- Preserve separate main/worker host-phase lanes and add A2/A5 coverage for concurrent misses, same-key replay, boundary contracts, predicate reuse, and failure paths.

## Current-main DSV4 result

Rebased onto main `a5c6093d` and rebuilt all four runtime variants. The table is one fresh-process A2/A3 DSV4 `DecodeFwdEP2TP2` hardware pass after the final one-bind integration.

| Rank | `host_orch` | `graph_upload` | `sm_h2d` | `arena_h2d` | Four-part sum |
| --- | ---: | ---: | ---: | ---: | ---: |
| 0 | 2.041889 ms | 0.003841 ms | 0 | 0.260952 ms | **2.306682 ms** |
| 1 | 2.617405 ms | 0.005760 ms | 0 | 0.306053 ms | **2.929218 ms** |
| Mean | **2.329647 ms** | **0.004801 ms** | **0** | **0.283503 ms** | **2.617950 ms** |

Each rank submits 86 Graph shells on the main thread, records 1,679 nodes, builds eight Definitions on eight distinct worker threads, and drops no host-phase records. The last Definition leaves only a 20-46 us final publication/packing tail. On one rank the last `graph_submit` precedes the final Definition by 788 us; on the other it follows it by 9 us, so the former erroneous submit-side wait is absent.

The generated host swimlane contains two `graph submit main` lanes and sixteen `graph record worker` lanes, with 172 `graph_submit`, 3,358 `record_node`, and sixteen `build_definition` events across both ranks.

## One-bind upload A/B

The first post-rebase sample still copied eight Definition objects separately before the bind image. Folding them into the Graph block changes the copy-bearing stages as follows:

| Rank | Before `graph_upload + arena_h2d` | One bind image | Delta |
| --- | ---: | ---: | ---: |
| 0 | 1.066261 ms | 0.264793 ms | **-75.2%** |
| 1 | 1.112880 ms | 0.311813 ms | **-72.0%** |

Main #1939 changes the DSV4 dependency coverage from the earlier seven Definitions/1,388 recorded nodes to eight Definitions/1,679 nodes. Therefore the older 0.689/0.646 ms `host_orch` samples are not an apples-to-apples performance target after rebase; current host time also shows worker scheduling jitter, while the upload reduction is directly attributable and repeatable. task-submit exposed 320 CPUs, so this is not a one-CPU affinity artifact.

## Validation

- Latest-main merge base: `a5c6093d`; branch is exactly one commit ahead
- Editable A2/A3 onboard, A2/A3 sim, A5 onboard, and A5 sim runtime build: passed
- Non-hardware C++ unit tests: **114/114 passed**
- Toolchain Python unit tests: **17/17 passed**
- C++ formatting, header/English checks, cpplint, ruff, and pyright: passed
- Fresh-process DSV4 hardware execution and host-phase event-structure validation: passed

Detailed design, historical comparison, and current-main evidence are in `docs/investigations/2026-08-hbg-graph-definition-single-upload.md`.