### PR TITLE
Fix: redirect host spans to per-process buffered files

### DIFF
--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -24,6 +24,55 @@ constructing span attributes; `WARN`, `ERROR`, and `NUL` therefore disable the
 instrumentation work as well as the output. Device logging still uses the
 initialization-time policy described in [logging.md](../logging.md).
 
+## Where the records go
+
+The host logger writes to stderr until it is given a directory, and then it
+writes to `<directory>/host.<pid>.log` instead. The directory is
+`CallConfig.output_prefix` — the one every other diagnostic artifact already goes
+under — so a run that has one gets its host log beside its other artifacts, and a
+run that does not keeps its records on the console. There is no separate switch to
+configure, and the runtime never derives the path itself.
+
+**The destination belongs to the logger, not to a record.** Everything that logger
+writes follows it: `LOG_*` records, `[STRACE]` spans, `[CLOCK_ANCHOR]`, the
+`bind phase=` summaries, and the spans Python emits through
+`unified_log_host_span`. Nothing declares an intent and no record kind is treated
+specially, so there is no state in which part of a run's log is in one place and
+part in another. The first non-empty directory in a process wins, and a record
+falls back to stderr rather than being lost whenever the file cannot take it: a
+path that does not fit, a failed open, a failed write, or a failed flush.
+
+**What stays on the console regardless:** messages Python logs through its own
+`logging` module. Those are a second logging system — same threshold, different
+envelope, no timestamp — so they are not part of this stream and cannot be
+ordered against it. Routing them through the host logger is a separate change.
+
+Each process's file is fully buffered. It is flushed when a depth-zero invocation
+record completes, which is the point at which the records so far describe a whole
+invocation, and whenever a `WARN` or `ERROR` record is written, which is rare and
+worth having on disk if the process dies. That flush runs on the thread that
+emitted the record, so this reduces the observer effect by roughly the ratio of
+records to flushes rather than removing it: expect a residual tail at each flush
+boundary, not a clean floor. A system tracer would hand the bytes to a consumer
+instead, and would bound its buffer and count what it drops; this does neither,
+deliberately.
+
+## Reading a run back
+
+Every record carries its own `pid`, so the tools take several inputs and
+concatenate them, and a directory expands to the `host.*.log` files inside it:
+
+```bash
+python -m simpler_setup.tools.strace_timing <output_prefix> --swimlane swimlane.json
+```
+
+A process writes its `[CLOCK_ANCHOR]` ahead of its first record and into the same
+stream, so each file is self-contained for wall-clock recovery. If an input is
+truncated or a process's file is missing, the pids in it stay monotonic-only and
+`clockAnchors` is absent from the output rather than wrong — the tool warns when a
+pid emitted spans and no anchor was found for it, which is the signal that this
+happened.
+
 ## Marker grammar
 
 Every host log record starts with a `CLOCK_MONOTONIC` nanosecond timestamp:

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -1708,6 +1708,18 @@ NB_MODULE(_task_interface, m) {
         nb::arg("level"), "Seed the process-owned host-log state before workers fork or load runtime modules."
     );
     m.def(
+        "_set_host_log_directory",
+        [](const std::string &path) {
+            HostLogger::get_instance().set_log_directory(path.c_str());
+            const char *bound = HostLogger::get_instance().log_directory();
+            return bound == nullptr ? std::string() : std::string(bound);
+        },
+        nb::arg("path"),
+        "Write this process's host log to <path>/host.<pid>.log instead of stderr, and return the directory "
+        "actually in effect. Applies to every record this logger writes, including the host spans Python emits. "
+        "The first non-empty path in a process wins; an empty path leaves the logger on stderr."
+    );
+    m.def(
         "_set_host_span_level_prefix",
         [](const std::string &word) {
             simpler::host_trace::set_level_prefix(word.c_str());

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -108,6 +108,9 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
 from _task_interface import (
     _host_spans_active as _native_host_spans_active,
 )
+from _task_interface import (
+    _set_host_log_directory as _native_set_host_log_directory,
+)
 
 from . import _log as _simpler_log
 from .buffer import (
@@ -3335,6 +3338,9 @@ def _read_config_from_mailbox(buf: memoryview) -> CallConfig:
     cfg.runtime_env.ring_dep_pool = ring_dep_pool
     # NUL-terminated C string in a 1024-byte field.
     cfg.output_prefix = prefix_bytes.split(b"\x00", 1)[0].decode("utf-8")
+    # A forked chip child owns its own log file under the same directory.
+    if cfg.output_prefix:
+        _native_set_host_log_directory(cfg.output_prefix)
     return cfg
 
 
@@ -10801,6 +10807,13 @@ class Worker:
     def _submit_l3_locked(self, callable, args, cfg: CallConfig) -> RunHandle:
         assert self._orch is not None
         assert self._worker is not None
+        # This process's log belongs beside the run's other diagnostic artifacts,
+        # so the directory comes from the config that already names it. First one
+        # in a process wins; with no prefix the logger stays on stderr. Read
+        # defensively: wiring an output must never be what fails a submit.
+        log_directory = getattr(cfg, "output_prefix", "")
+        if log_directory:
+            _native_set_host_log_directory(log_directory)
         run_id = self._orch._begin_run()
         resources = _RunResources()
         handle = RunHandle(self, run_id, (callable, args, cfg), resources)

--- a/simpler_setup/tools/strace_timing.py
+++ b/simpler_setup/tools/strace_timing.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import pathlib
 import re
 import sys
 from collections import defaultdict
@@ -95,6 +96,28 @@ _CLOCK_ANCHOR_RE = re.compile(
 # The emitter percent-encodes any byte that would otherwise be record grammar —
 # see `encode_host_span_field` in src/common/log/host_log.cpp.
 _PERCENT_ESCAPE_RE = re.compile(r"%([0-9A-Fa-f]{2})")
+# One file per process, written under a run's `output_prefix` when the host logger
+# writes to files rather than stderr. It holds everything that logger emits, so a
+# process's spans and its `[CLOCK_ANCHOR]` are in the same file. See
+# docs/dfx/host-trace.md.
+_LOG_FILE_GLOB = "host.*.log"
+
+
+def _expand_log_source(source):
+    """Resolve one CLI input to the files to read.
+
+    A directory expands to its per-process log files, so a run's
+    ``output_prefix`` can be passed as-is instead of being globbed by the caller.
+    Sorted, because a reader comparing two runs should not have to care that the
+    shell and the filesystem disagree about order.
+    """
+    path = pathlib.Path(source)
+    if not path.is_dir():
+        return [path]
+    log_files = sorted(path.glob(_LOG_FILE_GLOB))
+    if not log_files:
+        raise SystemExit(f"{source} is a directory but holds no {_LOG_FILE_GLOB} files")
+    return log_files
 
 
 def decode_field(text):
@@ -1359,7 +1382,13 @@ def write_host_swimlane(args, spans, lines, anchors):
 
 def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("log", help="path to a host/CANN log containing [STRACE] lines (or '-' for stdin)")
+    ap.add_argument(
+        "log",
+        nargs="+",
+        help="one or more host/CANN logs containing [STRACE] lines, '-' for stdin, or a directory holding "
+        f"{_LOG_FILE_GLOB} files (a run's output_prefix). Several inputs are concatenated: records carry their "
+        "own pid, so a whole run's per-process logs, or logs from several runs, can be passed together.",
+    )
     ap.add_argument(
         "--trace-out", help="write a Chrome-trace/Perfetto JSON here (load in chrome://tracing or perfetto)"
     )
@@ -1401,11 +1430,14 @@ def main(argv=None):
     )
     args = ap.parse_args(argv)
 
-    if args.log == "-":
-        lines = sys.stdin.readlines()
-    else:
-        with open(args.log, encoding="utf-8", errors="replace") as f:
-            lines = f.readlines()
+    lines = []
+    for source in args.log:
+        if source == "-":
+            lines.extend(sys.stdin.readlines())
+            continue
+        for path in _expand_log_source(source):
+            with open(path, encoding="utf-8", errors="replace") as f:
+                lines.extend(f.readlines())
 
     spans = list(parse_spans(lines))
     anchors = list(parse_clock_anchors(lines))
@@ -1418,6 +1450,18 @@ def main(argv=None):
                 f"warning: multiple [CLOCK_ANCHOR] records found for pid {pid} ({count} records); using the last one",
                 file=sys.stderr,
             )
+    # Without an anchor a pid's records stay monotonic-only, and every renderer
+    # degrades to relative time without saying so. A process writes its anchor
+    # ahead of its first record, into whichever stream it is logging to, so a pid
+    # with spans and no anchor means that stream reached us incomplete.
+    unanchored = sorted({span.pid for span in spans} - set(anchor_counts))
+    if unanchored:
+        print(
+            f"warning: no [CLOCK_ANCHOR] record for pid(s) {', '.join(str(pid) for pid in unanchored)} that emitted "
+            "spans; their timestamps stay monotonic-only. Each process writes its anchor before its first record, so "
+            "check that every input is complete and that no process's stream is missing.",
+            file=sys.stderr,
+        )
     heads = count_record_heads(lines)
     if heads > len(spans):
         print(

--- a/src/common/log/host_log.cpp
+++ b/src/common/log/host_log.cpp
@@ -153,6 +153,87 @@ long host_trace_tid() {
 #endif
 }
 
+struct HostLogFileSink {
+    HostLogFileSink();
+
+    std::mutex mutex;
+    FILE *stream = nullptr;
+    pid_t pid = -1;
+    std::string directory;
+};
+
+HostLogFileSink &host_log_file_sink() {
+    static HostLogFileSink sink;
+    return sink;
+}
+
+void host_log_sink_before_fork() { host_log_file_sink().mutex.lock(); }
+
+void host_log_sink_after_fork() { host_log_file_sink().mutex.unlock(); }
+
+HostLogFileSink::HostLogFileSink() {
+    // A child inherits only the thread that called fork(). Locking here makes
+    // that thread the mutex owner at the fork boundary, so both the parent and
+    // child handlers can release it without inheriting an owner that vanished.
+    (void)pthread_atfork(host_log_sink_before_fork, host_log_sink_after_fork, host_log_sink_after_fork);
+}
+
+// Append one already-formatted record. The <=`PIPE_BUF` single-write rule that
+// makes a stderr record indivisible neither applies nor is needed here: this file
+// has exactly one writer process and the sink mutex serializes the writers inside
+// it, so a flush of up to the buffer's size cannot interleave with anything.
+//
+// Two properties a system tracer would have and this deliberately does not, so
+// the difference is not mistaken for an oversight. The flush runs on the thread
+// that emitted the record, where ftrace and Perfetto hand the bytes to a consumer
+// and never let a producer touch the output; and a full buffer here blocks that
+// thread rather than dropping and counting, where every comparable tracer bounds
+// the buffer and exports a loss counter. What this buys is one write per root
+// span instead of one per record — an order of magnitude, not the elimination of
+// the observer effect.
+bool write_log_file(const char *directory, const char *record, size_t size, bool flush) {
+    HostLogFileSink &sink = host_log_file_sink();
+    std::scoped_lock lock(sink.mutex);
+    const pid_t pid = getpid();
+    const bool inherited = sink.stream != nullptr && sink.pid != pid;
+    const bool changed_directory = sink.stream != nullptr && sink.directory != directory;
+    if (inherited) {
+        // Do not fclose(): its copied stdio buffer contains records already
+        // owned by the parent and must never be flushed again by the child.
+        // Dropping the FILE leaks it and its buffer in the child, one per
+        // process, which is the price of not duplicating the parent's records —
+        // C offers no portable way to discard a stream's buffer.
+        const int inherited_fd = fileno(sink.stream);
+        if (inherited_fd >= 0) (void)::close(inherited_fd);
+        sink.stream = nullptr;
+        sink.pid = -1;
+        sink.directory.clear();
+    } else if (changed_directory) {
+        std::fclose(sink.stream);
+        sink.stream = nullptr;
+        sink.pid = -1;
+        sink.directory.clear();
+    }
+    if (sink.stream == nullptr) {
+        char path[PATH_MAX];
+        const int length = std::snprintf(path, sizeof(path), "%s/host.%d.log", directory, pid);
+        if (length <= 0 || static_cast<size_t>(length) >= sizeof(path)) return false;
+        sink.stream = std::fopen(path, "a");
+        if (sink.stream == nullptr) return false;
+        std::setvbuf(sink.stream, nullptr, _IOFBF, 1U << 20U);
+        sink.pid = pid;
+        sink.directory = directory;
+    }
+    if (std::fwrite(record, 1, size, sink.stream) != size) return false;
+    return !flush || std::fflush(sink.stream) == 0;
+}
+
+bool flush_log_file() {
+    HostLogFileSink &sink = host_log_file_sink();
+    std::scoped_lock lock(sink.mutex);
+    return sink.stream == nullptr || std::fflush(sink.stream) == 0;
+}
+
 }  // namespace
 
 namespace {
@@ -236,7 +317,7 @@ const char *HostLogger::level_name(LogLevel level) const {
     return "?";
 }
 
-bool HostLogger::emit(const char *level_tag, const char *func, const char *fmt, va_list args) {
+bool HostLogger::emit(const char *level_tag, const char *func, const char *fmt, va_list args, bool flush) {
     const int64_t monotonic_ns = simpler::log::monotonic_now_ns();
     auto tid = static_cast<unsigned long>(reinterpret_cast<uintptr_t>(pthread_self()));
 
@@ -252,22 +333,32 @@ bool HostLogger::emit(const char *level_tag, const char *func, const char *fmt, 
         stack_buffer, sizeof(stack_buffer), monotonic_ns, tid, level_tag, func, fmt, args, append_newline
     );
     if (length < sizeof(stack_buffer)) {
-        std::scoped_lock lock(mutex_);
-        return write_stderr(stack_buffer, length);
+        return write_record(stack_buffer, length, flush);
     }
 
     std::vector<char> heap_buffer(length + 1);
     const size_t heap_length = format_record(
         heap_buffer.data(), heap_buffer.size(), monotonic_ns, tid, level_tag, func, fmt, args, append_newline
     );
+    return write_record(heap_buffer.data(), heap_length < heap_buffer.size() ? heap_length : length, flush);
+}
+
+// The one place a destination is chosen. It is a property of this logger, so it
+// holds for every record from every caller: nothing about a record's kind, its
+// producer, or its level selects a sink here.
+bool HostLogger::write_record(const char *record, size_t size, bool flush) {
+    const char *directory = log_directory();
+    if (directory != nullptr && write_log_file(directory, record, size, flush)) return true;
     std::scoped_lock lock(mutex_);
-    return write_stderr(heap_buffer.data(), heap_length < heap_buffer.size() ? heap_length : length);
+    return write_stderr(record, size);
 }
 
 bool HostLogger::emit_ungated(const char *level_tag, const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
-    const bool written = emit(level_tag, func, fmt, args);
+    // Its one caller writes the clock anchor, which every reader of this stream
+    // needs before it can place anything else in wall time.
+    const bool written = emit(level_tag, func, fmt, args, /*flush=*/true);
     va_end(args);
     return written;
 }
@@ -301,7 +392,9 @@ void HostLogger::vlog(LogLevel level, const char *func, const char *fmt, va_list
         return;
     }
     emit_clock_anchor_if_needed();
-    emit(level_name(level), func, fmt, args);
+    // A warning or an error is rare and is worth having on disk if the process
+    // dies; everything below that rides the buffer.
+    emit(level_name(level), func, fmt, args, /*flush=*/level >= LogLevel::WARN);
 }
 
 void HostLogger::log(LogLevel level, const char *func, const char *fmt, ...) {
@@ -309,6 +402,27 @@ void HostLogger::log(LogLevel level, const char *func, const char *fmt, ...) {
     va_start(args, fmt);
     vlog(level, func, fmt, args);
     va_end(args);
+}
+
+void HostLogger::set_log_directory(const char *path) {
+    if (path == nullptr || path[0] == '\0') return;
+    SimplerHostLogState *shared = state();
+    if (shared == nullptr) return;
+    // Claim 0 -> -1, fill, publish -1 -> 1, mirroring the anchor claim above. A
+    // reader accepts only 1, so it never observes a half-written path; and a
+    // later caller with a different path is refused rather than moving a file
+    // some thread may already hold open.
+    int32_t unclaimed = 0;
+    if (!atomic_compare_exchange_i32(&shared->log_directory_bound, &unclaimed, -1)) return;
+    (void)std::snprintf(shared->log_directory, sizeof(shared->log_directory), "%s", path);
+    int32_t claim = -1;
+    (void)atomic_compare_exchange_i32(&shared->log_directory_bound, &claim, 1);
+}
+
+const char *HostLogger::log_directory() const {
+    SimplerHostLogState *shared = state();
+    if (shared == nullptr || atomic_load_i32(&shared->log_directory_bound) != 1) return nullptr;
+    return shared->log_directory;
 }
 
 void HostLogger::log_host_span(const SimplerHostSpan *span) {
@@ -320,11 +434,23 @@ void HostLogger::log_host_span(const SimplerHostSpan *span) {
     const std::string name = encode_host_span_field(span->name, kHostSpanNameCapacity, false);
     const std::string attributes =
         encode_host_span_field(span->attributes == nullptr ? "" : span->attributes, kHostSpanAttributesCapacity, true);
-    log(LogLevel::TIMING, "emit_host_span",
+
+    // One record grammar, in one place. Where it lands is the logger's business,
+    // not this emitter's.
+    char record[kRecordStackCapacity];
+    (void)std::snprintf(
+        record, sizeof(record),
         "[STRACE] v=1 pid=%d tid=%ld inv=%" PRIu64 " hid=%" PRIx64 " depth=%d name=%s ts=%" PRId64 " dur=%" PRId64
         " %s",
         static_cast<int>(getpid()), host_trace_tid(), span->invocation_id, span->callable_hash, span->depth,
-        name.c_str(), span->timestamp_ns, span->duration_ns, attributes.c_str());
+        name.c_str(), span->timestamp_ns, span->duration_ns, attributes.c_str()
+    );
+
+    log(LogLevel::TIMING, "emit_host_span", "%s", record);
+    // A closed root span is where the records so far describe a whole
+    // invocation, which is what makes an in-progress run readable. It is the one
+    // thing this emitter knows that the writer does not.
+    if (span->depth == 0) (void)flush_log_file();
 }
 
 extern "C" __attribute__((visibility("default"))) int simpler_host_log_bind_state(SimplerHostLogState *state) {

--- a/src/common/log/include/common/host_log_state.h
+++ b/src/common/log/include/common/host_log_state.h
@@ -13,7 +13,10 @@
 
 #include <stdint.h>
 
-#define SIMPLER_HOST_LOG_STATE_ABI_VERSION 1U
+#define SIMPLER_HOST_LOG_STATE_ABI_VERSION 2U
+
+/* Matches CallConfig::output_prefix, which is where the path comes from. */
+#define SIMPLER_HOST_LOG_DIR_CAPACITY 1024
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,19 +24,32 @@ extern "C" {
 
 /*
  * Process-owned state shared by the private HostLogger copy compiled into
- * every host-side DSO. The fields stay plain integers so modules built by
- * different host compiler versions share a C ABI; host_log.cpp performs all
- * accesses with compiler atomic builtins.
+ * every host-side DSO. The fields are plain integers and fixed char arrays so
+ * modules built by different host compiler versions share a C ABI;
+ * host_log.cpp performs all scalar accesses with compiler atomic builtins.
  *
  * clock_anchor_pid is positive after a successful anchor write and temporarily
  * negative while one writer owns the claim for that PID. Linux PIDs are
  * positive and bounded well below INT32_MAX.
+ *
+ * log_directory is where this logger writes, one fully-buffered file per
+ * process. It is empty until a caller that knows the run's artifact directory
+ * supplies it, and every record goes to stderr while it is. The destination is
+ * a property of the logger, so it applies to every record from every caller —
+ * there is no per-record or per-call-site routing.
+ *
+ * The first non-empty path wins: log_directory_bound is release-stored after the
+ * path is filled and acquire-loaded before it is read, so a reader sees either no
+ * directory or the whole one, and a reader that has already opened the file never
+ * has the path change under it.
  */
 typedef struct SimplerHostLogState {
     uint32_t abi_version;
     uint32_t struct_size;
     int32_t threshold;
     int32_t clock_anchor_pid;
+    int32_t log_directory_bound;
+    char log_directory[SIMPLER_HOST_LOG_DIR_CAPACITY];
 } SimplerHostLogState;
 
 typedef int (*SimplerHostLogBindStateFn)(SimplerHostLogState *state);

--- a/src/common/log/include/host_log.h
+++ b/src/common/log/include/host_log.h
@@ -54,6 +54,17 @@ public:
 
     void set_level(simpler::log::LogLevel level);
 
+    // Write this process's records to `path`/host.<pid>.log instead of stderr.
+    // The caller is the one that knows where this run's artifacts go —
+    // CallConfig::output_prefix — so the logger never derives a path itself.
+    // The first non-empty path wins; a null or empty one leaves the logger on
+    // stderr. This is the logger's output, so it applies to every record: no
+    // caller declares anything and no record kind is treated specially.
+    void set_log_directory(const char *path);
+
+    // The bound output directory, or nullptr while this logger writes to stderr.
+    const char *log_directory() const;
+
     // Runtime modules read this from their bound process-owned state when
     // populating InitArgs.log_level at device init.
     int level() const;
@@ -80,7 +91,11 @@ private:
     HostLogger &operator=(HostLogger &&) = delete;
 
     const char *level_name(simpler::log::LogLevel level) const;
-    bool emit(const char *level_tag, const char *func, const char *fmt, va_list args);
+    bool emit(const char *level_tag, const char *func, const char *fmt, va_list args, bool flush);
+    // Writes one formatted record wherever this logger is configured to write.
+    // The only place a destination is chosen, and it is chosen per logger, not
+    // per record: no caller declares anything and no record kind is special.
+    bool write_record(const char *record, size_t size, bool flush);
     bool emit_ungated(const char *level_tag, const char *func, const char *fmt, ...);
     void emit_clock_anchor_if_needed();
 

--- a/tests/ut/cpp/a5/test_host_log_off.cpp
+++ b/tests/ut/cpp/a5/test_host_log_off.cpp
@@ -18,6 +18,7 @@
 #include <limits.h>
 #include <algorithm>
 #include <cerrno>
+#include <fstream>
 #include <sstream>
 #include <set>
 #include <string>
@@ -350,6 +351,161 @@ TEST(HostLogTest, HostSpanEscapesDelimitersAndFitsAtomicPipeRecord) {
     EXPECT_LE(record.size(), static_cast<size_t>(_POSIX_PIPE_BUF));
     ASSERT_GE(record.size(), 2u);
     EXPECT_EQ(record[record.size() - 2], '~');
+}
+
+// The output directory is frozen on the first non-empty value, so a test that
+// needs its own clears the binding first — the same shape as this file's
+// existing `clock_anchor_pid` resets. Restoring it on scope exit is what keeps
+// one directory test from redirecting every later test's records away from
+// stderr, including when an ASSERT leaves the test early.
+class ScopedLogDirectory {
+public:
+    explicit ScopedLogDirectory(const char *directory) {
+        unbind();
+        HostLogger::get_instance().set_log_directory(directory);
+    }
+
+    ~ScopedLogDirectory() { unbind(); }
+
+    ScopedLogDirectory(const ScopedLogDirectory &) = delete;
+    ScopedLogDirectory &operator=(const ScopedLogDirectory &) = delete;
+
+private:
+    static void unbind() {
+        g_shared_log_state.log_directory_bound = 0;
+        g_shared_log_state.log_directory[0] = '\0';
+    }
+};
+
+std::string read_log_file(const char *directory, pid_t pid) {
+    const std::string path = std::string(directory) + "/host." + std::to_string(static_cast<int>(pid)) + ".log";
+    std::ifstream input(path);
+    if (!input.good()) return "";
+    return std::string((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+}
+
+TEST(HostLogTest, LogDirectorySendsEveryRecordToOneBufferedFilePerProcess) {
+    char directory_template[] = "/tmp/simpler-host-strace-XXXXXX";
+    char *directory = mkdtemp(directory_template);
+    ASSERT_NE(directory, nullptr);
+    ScopedLogDirectory scoped_log_directory(directory);
+    ASSERT_STREQ(HostLogger::get_instance().log_directory(), directory);
+
+    const SimplerHostSpan nested{
+        SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 7, 0x1234, 1, 0, 100, 25, "chip.run.bind", "run_id=7"
+    };
+    const SimplerHostSpan root{
+        SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 7, 0x1234, 0, 0, 90, 50, "chip.run", "run_id=7"
+    };
+    g_shared_log_state.clock_anchor_pid = 0;
+    const auto captured = run_with_config(LogLevel::TIMING, [&] {
+        unified_log_host_span(&nested);
+        unified_log_host_span(&root);
+    });
+    // The destination belongs to the logger, so nothing is left behind on
+    // stderr — not the spans and not the anchor they are unreadable without.
+    EXPECT_EQ(captured.err, "");
+
+    const std::string contents = read_log_file(directory, getpid());
+    std::istringstream records(contents);
+    std::string anchor_record;
+    std::string nested_record;
+    std::string root_record;
+    ASSERT_TRUE(static_cast<bool>(std::getline(records, anchor_record)));
+    ASSERT_TRUE(static_cast<bool>(std::getline(records, nested_record)));
+    ASSERT_TRUE(static_cast<bool>(std::getline(records, root_record)));
+    EXPECT_NE(anchor_record.find("[CLOCK_ANCHOR] v=1"), std::string::npos);
+    // Field sequence, not just the name: `name=chip.run` is a prefix of
+    // `name=chip.run.bind`, so a name alone cannot tell the root record from the
+    // nested one.
+    EXPECT_NE(nested_record.find("depth=1 name=chip.run.bind ts=100 dur=25"), std::string::npos) << nested_record;
+    EXPECT_NE(root_record.find("depth=0 name=chip.run ts=90 dur=50"), std::string::npos) << root_record;
+    std::string extra_record;
+    EXPECT_FALSE(static_cast<bool>(std::getline(records, extra_record)));
+
+    // Every line went through the same envelope, which is what lets one reader
+    // parse the anchor and the spans out of this one file.
+    for (const std::string &record : {anchor_record, nested_record, root_record}) {
+        EXPECT_EQ(record.find("[mono_ns="), 0u) << record;
+    }
+
+    const std::string path = std::string(directory) + "/host." + std::to_string(static_cast<int>(getpid())) + ".log";
+    EXPECT_EQ(unlink(path.c_str()), 0);
+    EXPECT_EQ(rmdir(directory), 0);
+}
+
+TEST(HostLogTest, LogDirectoryTakesOrdinaryRecordsAndFlushesTheSevereOnes) {
+    char directory_template[] = "/tmp/simpler-host-log-ordinary-XXXXXX";
+    char *directory = mkdtemp(directory_template);
+    ASSERT_NE(directory, nullptr);
+    ScopedLogDirectory scoped_log_directory(directory);
+
+    g_shared_log_state.clock_anchor_pid = 0;
+    const auto captured = run_with_config(LogLevel::TIMING, [] {
+        HostLogger::get_instance().log(LogLevel::ERROR, "fn", "disk-please");
+        HostLogger::get_instance().log(LogLevel::INFO, "fn", "buffered-please");
+    });
+    EXPECT_EQ(captured.err, "");
+
+    // Read before any root span closes: an error is rare and worth having on
+    // disk if the process dies, so it is flushed as it is written. The INFO
+    // record rides the buffer and need not be visible yet.
+    const std::string contents = read_log_file(directory, getpid());
+    EXPECT_NE(contents.find("disk-please"), std::string::npos);
+
+    const std::string path = std::string(directory) + "/host." + std::to_string(static_cast<int>(getpid())) + ".log";
+    EXPECT_EQ(unlink(path.c_str()), 0);
+    EXPECT_EQ(rmdir(directory), 0);
+}
+
+TEST(HostLogTest, ForkedChildReopensItsOwnSpanFileWithoutFlushingParentBuffer) {
+    char directory_template[] = "/tmp/simpler-host-strace-fork-XXXXXX";
+    char *directory = mkdtemp(directory_template);
+    ASSERT_NE(directory, nullptr);
+    ScopedLogDirectory scoped_log_directory(directory);
+    // Emission is gated on the live threshold, and an unbound module defaults to
+    // NUL, so this test sets the level rather than inheriting whatever an earlier
+    // test in this binary left behind.
+    HostLogger::get_instance().set_level(LogLevel::TIMING);
+
+    const SimplerHostSpan parent_span{
+        SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 8, 0x1234, 1, 0, 100, 25, "parent.span", ""
+    };
+    unified_log_host_span(&parent_span);
+
+    const pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        const SimplerHostSpan child_span{
+            SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 9, 0x1234, 0, 0, 200, 25, "child.span", ""
+        };
+        unified_log_host_span(&child_span);
+        _exit(0);
+    }
+    int status = 0;
+    ASSERT_EQ(waitpid(child, &status, 0), child);
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(WEXITSTATUS(status), 0);
+
+    const std::string parent_path =
+        std::string(directory) + "/host." + std::to_string(static_cast<int>(getpid())) + ".log";
+    const std::string child_path = std::string(directory) + "/host." + std::to_string(static_cast<int>(child)) + ".log";
+    std::ifstream child_input(child_path);
+    ASSERT_TRUE(child_input.good());
+    const std::string child_contents((std::istreambuf_iterator<char>(child_input)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(child_contents.find("name=parent.span"), std::string::npos);
+    EXPECT_NE(child_contents.find("name=child.span"), std::string::npos);
+    // The parent's record is depth 1, so it is still unflushed in the parent's
+    // own buffer. It can only have reached the parent's file if the child
+    // flushed the copy it inherited — which is what this test is named for, and
+    // what the child's file alone cannot show.
+    std::ifstream parent_input(parent_path);
+    const std::string parent_contents((std::istreambuf_iterator<char>(parent_input)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(parent_contents.find("name=parent.span"), std::string::npos)
+        << "the child flushed the parent's copied stdio buffer";
+    EXPECT_EQ(unlink(parent_path.c_str()), 0);
+    EXPECT_EQ(unlink(child_path.c_str()), 0);
+    EXPECT_EQ(rmdir(directory), 0);
 }
 
 TEST(HostLogTest, DisabledHostSpanProducesNoRecord) {

--- a/tests/ut/py/test_strace_timing.py
+++ b/tests/ut/py/test_strace_timing.py
@@ -591,6 +591,84 @@ def test_swimlane_cli_writes_trace(tmp_path):
     assert event["args"]["wall_ts_ns"] == "1700000000000000050"
 
 
+def test_cli_reads_every_input_so_a_run_needs_no_manual_merge(tmp_path, capsys):
+    """A run's per-process logs, passed together.
+
+    Records carry their own pid, so concatenating inputs is all the merge that
+    was ever needed — but the tool used to take one path, which left the merge to
+    whoever ran it.
+    """
+    first = tmp_path / "host.71.log"
+    second = tmp_path / "host.72.log"
+    # Each process's own file carries its anchor ahead of its records.
+    first.write_text(
+        _anchor_record(71, 50, 1_700_000_000_000_000_000)
+        + _span_record(pid=71, tid=710, inv=1, name="node.submit", ts=100, dur=10),
+        encoding="utf-8",
+    )
+    second.write_text(
+        _anchor_record(72, 60, 1_700_000_000_000_000_010)
+        + _span_record(pid=72, tid=720, inv=1, name="chip.run", ts=200, dur=20),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "swimlane.json"
+
+    assert main([str(first), str(second), "--swimlane", str(output_path)]) == 0
+
+    trace = json.loads(output_path.read_text(encoding="utf-8"))
+    assert {event["pid"] for event in trace["traceEvents"] if event.get("ph") == "X"} == {71, 72}
+    assert {int(anchor["pid"]) for anchor in trace["clockAnchors"]} == {71, 72}
+    assert "no [CLOCK_ANCHOR] record" not in capsys.readouterr().err
+
+
+def test_cli_expands_a_run_directory_to_its_per_process_log_files(tmp_path):
+    """A run's output_prefix can be passed as-is."""
+    prefix = tmp_path / "case_20260824"
+    prefix.mkdir()
+    (prefix / "host.71.log").write_text(
+        _span_record(pid=71, tid=710, inv=1, name="node.submit", ts=100, dur=10), encoding="utf-8"
+    )
+    (prefix / "host.72.log").write_text(
+        _span_record(pid=72, tid=720, inv=1, name="chip.run", ts=200, dur=20), encoding="utf-8"
+    )
+    # A sibling artifact must not be read as a log.
+    (prefix / "pmu.csv").write_text("not,a,log\n", encoding="utf-8")
+    output_path = tmp_path / "swimlane.json"
+
+    assert main([str(prefix), "--swimlane", str(output_path)]) == 0
+
+    trace = json.loads(output_path.read_text(encoding="utf-8"))
+    assert {event["pid"] for event in trace["traceEvents"] if event.get("ph") == "X"} == {71, 72}
+
+
+def test_cli_rejects_a_directory_with_no_span_files(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    with pytest.raises(SystemExit, match="holds no host\\."):
+        main([str(empty)])
+
+
+def test_cli_warns_when_a_pid_emitted_spans_without_a_clock_anchor(tmp_path, capsys):
+    """An incomplete input leaves those pids monotonic-only.
+
+    `clockAnchors` is then simply absent from the output rather than wrong, which
+    is exactly the kind of loss nobody notices.
+    """
+    log_file = tmp_path / "host.71.log"
+    log_file.write_text(
+        _span_record(pid=71, tid=710, inv=1, name="node.submit", ts=100, dur=10)
+        + _span_record(pid=72, tid=720, inv=1, name="chip.run", ts=200, dur=20),
+        encoding="utf-8",
+    )
+
+    assert main([str(log_file)]) == 0
+
+    err = capsys.readouterr().err
+    assert "no [CLOCK_ANCHOR] record for pid(s) 71, 72" in err
+    assert "check that every input is complete" in err
+
+
 def test_cli_warns_when_one_pid_has_multiple_clock_anchors(tmp_path, capsys):
     log_path = tmp_path / "run.log"
     log_path.write_text(

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -3090,6 +3090,36 @@ class TestRunHandle:
         with pytest.raises(ValueError, match="bad graph"):
             worker._submit_l3_locked(bad_graph, None, cast(Any, object()))
 
+    def test_submit_seeds_the_log_directory_from_the_run_output_prefix(self, monkeypatch):
+        """This process's log lands beside the run's other diagnostic artifacts.
+
+        `CallConfig.output_prefix` is the directory every diagnostic artifact
+        already goes under, and its contract is that the runtime never derives a
+        path itself — so the submit path hands that directory to the log layer
+        rather than the log layer reading one from the environment.
+        """
+        worker, _events = self._submission_failure_worker(failures=0)
+        seeded: list[str] = []
+        monkeypatch.setattr(worker_mod, "_native_set_host_log_directory", seeded.append)
+
+        def bad_graph(*_args):
+            raise ValueError("bad graph")
+
+        with pytest.raises(ValueError, match="bad graph"):
+            worker._submit_l3_locked(bad_graph, None, cast(Any, SimpleNamespace(output_prefix="/tmp/run-artifacts")))
+        assert seeded == ["/tmp/run-artifacts"]
+
+        # No prefix means no directory to seed, and spans stay on stderr.
+        seeded.clear()
+        with pytest.raises(ValueError, match="bad graph"):
+            worker._submit_l3_locked(bad_graph, None, cast(Any, SimpleNamespace(output_prefix="")))
+        assert seeded == []
+
+        # A config without the field at all must not be what fails a submit.
+        with pytest.raises(ValueError, match="bad graph"):
+            worker._submit_l3_locked(bad_graph, None, cast(Any, object()))
+        assert seeded == []
+
     def test_unsettled_graph_cancellation_abandons_the_handle_before_close(self):
         worker, events = self._submission_failure_worker(failures=2)
         graph_error = ValueError("bad graph")


### PR DESCRIPTION
## Summary

Add an opt-in, per-process buffered file sink for high-frequency host STRACE spans. Normal logs and the clock anchor remain on stderr, the encoded span grammar is unchanged, and setup or I/O failures fall back to stderr.

This removes per-span flushing to a shared stderr pipe from profiled multi-rank hot paths without changing native-run ownership, synchronization, or default runtime behavior.

## Changes

- Write spans to `host-strace.<pid>.log` under `SIMPLER_HOST_STRACE_DIR`, flushing at each completed root span.
- Keep ordinary logs and one clock anchor per process on stderr; fall back there on path, open, write, or root-flush failure.
- Make the sink fork-safe: lock around the fork boundary, reopen a child-owned file, and close the inherited descriptor without flushing copied stdio buffers.
- Document the opt-in collection contract and test exact root/nested records, the clock anchor, disabled behavior, and parent/child file ownership.

## Verification

- `pre-commit run --files docs/dfx/host-trace.md src/common/log/host_log.cpp tests/ut/cpp/a5/test_host_log_off.cpp`: all hooks passed, including clang-format, clang-tidy, cpplint, and markdownlint.
- `cmake --build tests/ut/cpp/build -j8`: passed on `origin/main@adf3764f`.
- `ctest --test-dir tests/ut/cpp/build -LE requires_hardware --output-on-failure`: 115/115 passed (96 `no_hardware` tests).
- Direct EP4/TP4 sustained async workload: 5 warmups + 1,000 measured depth-two steps, four ranks, device STRACE disabled, with one SA_PROFILE and four per-PID host STRACE files merged after execution.
- Production DSV4 Serving validation: GBS32, MTP-1, DP8/EP8, 32 concurrent requests x 256 output tokens. All 8,192 tokens completed and the run produced a same-run merged SA_PROFILE + eight-rank host STRACE swimlane.

In the observed synchronous-stderr workload, individual 0.01-0.07 ms validation copies were separated by 10.10-18.44 ms unnamed host gaps at marker flush boundaries. With the per-PID sink, the direct four-rank run reduced runner-to-validate gap p95/max from 0.150/0.538 ms to 0.051/0.164 ms and validation max from 16.836 ms to 7.291 ms. This PR addresses that profiling observer effect only; it does not claim to fix the independent runtime lifecycle/scheduling issue tracked in hw-native-sys/pypto-serving#179.

Related to hw-native-sys/pypto-serving#179.
