### PR TITLE
tools: ship the host_build_graph bind-phase statistics as a wheel CLI

### DIFF
--- a/.claude/skills/hbg-bind-phases/SKILL.md
+++ b/.claude/skills/hbg-bind-phases/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: hbg-bind-phases
+description: Measure host_build_graph's `bind` phases — the host-side stage between "caller data in place" and "device can start" (orchestration, Definition upload, H2D), also called the bind path or control plane — on the dsv4 and qwen decode cases, and compare two branches. Use when the user asks how long bind or the control plane takes, whether a change moved host_orch / graph_upload / sm_h2d / arena_h2d, or to A/B a host-side change. This is the HOST stage with the device run skipped — for on-device latency use `benchmark` or `perf-example-device` instead.
+---
+
+# Measuring the `host_build_graph` bind phases
+
+What the phases are, why each switch is there, and the reference numbers:
+[`docs/dfx/hbg-bind-phases.md`](../../../docs/dfx/hbg-bind-phases.md).
+Read it before interpreting any number. This file is the invocation.
+
+The device run is skipped, so a case whose device execution does not complete
+still yields its whole host picture.
+
+## The recipe
+
+Fill in `ENVS`, `CASE`, `TAIL` from the two tables below, then run it verbatim.
+`pip install --no-build-isolation -e .` first, and again after every `HEAD` move.
+
+```bash
+HEAD_SHA=$(git rev-parse --short HEAD)
+LOG="outputs/bind_${HEAD_SHA}.log"; mkdir -p outputs
+MARK="outputs/.bind_start"; : >"$MARK"   # fixed mtime; "$LOG" keeps being appended to
+
+ENVS="SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 SIMPLER_LOG_LEVEL=TIMING \
+TORCH_DEVICE_BACKEND_AUTOLOAD=0 SIMPLER_SKIP_DEVICE_RUN=1"          # + mode delta
+CASE="examples/.../test_<case>.py -p a2a3 --manual only \
+--case <Class>:: --skip-golden"                                      # + level, per case
+TAIL="--rounds 6"                                                    # per mode
+
+.claude/skills/onboard-arch-precheck/check.sh a2a3 || exit 1
+echo "[stamp] $HEAD_SHA env $ENVS python $CASE $TAIL" >"$LOG"
+task-submit --device auto --device-num <N> --timeout 3600 --max-time 3600 \
+  --run "env $ENVS python $CASE $TAIL -d \$TASK_DEVICE" >>"$LOG" 2>&1
+grep -c 'bind phase=' "$LOG"          # must be > 0
+```
+
+`env` prefixes the assignments so they survive coming from a variable, and the
+`[stamp]` line is the same string that runs — which is what makes two logs
+comparable. Never hand-edit one arm's command without the other's.
+
+## The two cases
+
+| Property | dsv4 FLASH decode | qwen3-14b decode |
+| -------- | ----------------- | ---------------- |
+| `--device-num` | 2 | 1 |
+| `CASE` example | `examples/a2a3/host_build_graph/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py` | `examples/a2a3/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py` |
+| `--case` | `TestDeepseekV4FlashDecodeHostBuildGraph::` | `TestQwen314BDecodeHostBuildGraph::` |
+| level | `level=3`, so **add** `--runtime host_build_graph --level 3` | `level=2`, add nothing |
+| timeout | 3600 (cold compile is minutes) | 2400 |
+
+The `--level 3` addition is not optional for dsv4: without it the module runner
+captures the child's stdout and the log ends up with zero `bind phase=` lines
+while the run still passes.
+
+## The two modes
+
+| Field | numbers | timeline |
+| ----- | ------- | -------- |
+| `ENVS` delta | none | `+ SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE=1` |
+| `TAIL` | `--rounds 6` | `--rounds 1 --enable-pmu 2` |
+| finish with | the parser, below | `strace_timing`, below |
+
+`--rounds > 1` force-disables every diagnostic (it warns per flag), so one run
+gives statistics or a timeline, never both. The diagnostic flag in timeline mode
+is there to make `CallConfig.output_prefix` non-empty, which is what gives the
+per-event artifact a directory; `--enable-chip-swimlane` raises
+`NotImplementedError` at level 3.
+
+```bash
+# numbers
+python -m simpler_setup.tools.hbg_bind_phases "$LOG" --rounds 6
+
+# timeline — only an artifact newer than this run's own marker counts
+RECORDS=$(find outputs -name host_phase_records.jsonl -newer "$MARK")
+echo "$RECORDS"          # must name exactly one file; empty ⇒ this run wrote none,
+                         # so stop rather than reading a previous run's artifact
+python -m simpler_setup.tools.strace_timing "$LOG" --host-phase-records "$RECORDS" \
+  --swimlane "$(dirname "$RECORDS")/host_swimlane.json"      # load in ui.perfetto.dev
+```
+
+## Before reporting a number
+
+- `grep -c 'bind phase='` was `> 0`, and the table shows a `[stamp]` line.
+- Quote the stamp with the number. A number without the command and commit that
+  produced it cannot be compared to anything.
+- Comparing two branches has three more rules, all of them learned the hard way —
+  follow **Comparing two branches** in the doc rather than reasoning it out here.
+
+For on-device latency instead, use [`benchmark`](../benchmark/SKILL.md) or
+[`perf-example-device`](../perf-example-device/SKILL.md).

--- a/docs/dfx/README.md
+++ b/docs/dfx/README.md
@@ -23,7 +23,7 @@ Analysis CLIs that consume these outputs are documented in
 | -------- | -------------- |
 | [L2 Timing](l2-timing.md) | `host_wall` / `device_wall` / Effective / Orch / Sched breakdown from `[STRACE]` |
 | [Host runtime trace markers](host-trace.md) | The `[STRACE]` marker set emitted by the host runtime |
-| [Measuring the host_build_graph bind path](hbg-bind-measurement.md) | How to run the qwen and dsv4 decode cases for bind-segment numbers and a host swimlane |
+| [The host_build_graph bind phases](hbg-bind-phases.md) | What the bind segments are, the switches that expose them, and how to compare two branches on the qwen and dsv4 decode cases |
 | [Device-side phase timing](device-phases.md) | Fixed AICPU phases and the variable-phase plan |
 | [Scheduler-Overhead Model](sched-overhead-model.md) | Is the scheduler the bottleneck, or starved — the model behind `--overhead` |
 

--- a/docs/dfx/hbg-bind-phases.md
+++ b/docs/dfx/hbg-bind-phases.md
@@ -1,14 +1,22 @@
-# Measuring the `host_build_graph` bind path
+# The `host_build_graph` bind phases
 
 `host_build_graph` builds the whole task graph on the host before the device
-executes anything, so its **bind path** — argument staging, orchestration, the
-Graph Definition, and every H2D copy — is a first-class cost. This page is the
-recipe for measuring it on the two decode networks that exercise it, and for the
-traps that make a measurement wrong rather than merely noisy.
+executes anything, so the host-side **`bind` stage** — argument staging,
+orchestration, the Graph Definition, and every H2D copy — is a first-class cost.
+`bind` is the `chip.run.bind` `[STRACE]` span both runtimes emit; only this one
+subdivides it into **phases**, one `bind phase=<p>` line each. This page is what
+those phases are, how to measure them on the two decode networks that exercise
+them, and the traps that make a measurement wrong rather than merely noisy.
 
 For the marker grammar and the tool's other views, see
 [host-trace.md](host-trace.md). For what the runtime records inside `host_orch`,
 see [host_build_graph's profiling levels](../../src/a2a3/runtime/host_build_graph/docs/profiling_levels.md).
+
+**A new lesson about measuring these phases belongs on this page.** The
+[`hbg-bind-phases`](../../.claude/skills/hbg-bind-phases/SKILL.md) skill holds the
+invocation and nothing else — it is loaded into context on every use — and
+[`hbg_bind_phases`](../../simpler_setup/tools/hbg_bind_phases.py) gets a comment
+only once the lesson is an invariant its code depends on.
 
 ## What the segments are
 
@@ -55,15 +63,23 @@ device lock for the whole job (see
 | -------- | ---------------- | ------------------------ |
 | Path | `examples/a2a3/host_build_graph/qwen3_14b_decode/` | `examples/a2a3/host_build_graph/deepseek_v4_flash_decode/` |
 | Devices | 1 | 2 (EP2/TP2) |
+| Level | 2 | 3 |
 | Host tasks | 47 | 1131 |
 | Graph replays | 40, of a 277-node Definition | 20, of a 743-node Definition |
 | Graph boundary | 26 tensors | 118 tensors, 31 scalars |
 | First-run compile | seconds | **minutes** (369 kernel sources + an 11.6k-line orchestration) |
 | Marked | `manual` | `manual`, `skip_golden` |
 
-Both are `level=3`, which matters for how their output is captured (below).
+The level decides how a case's output is captured, which is what the recipe below
+has to work around.
 
 ## Recipe A — stable numbers, many rounds
+
+The ready-made invocation for either case lives in the
+[`hbg-bind-phases`](../../.claude/skills/hbg-bind-phases/SKILL.md) skill;
+`python -m simpler_setup.tools.hbg_bind_phases <log> --rounds N` turns its log into
+per-phase statistics. This section is what the switches mean and why the traps
+below exist.
 
 Six rounds is the working minimum: this box is shared, and a single pass has been
 seen to land 3.5× off its own minimum. Which statistic to read depends on the
@@ -72,39 +88,30 @@ sums** — the quietest pass is the closest this box gets to the machine's own c
 For "did a change move it", see [Comparing two branches](#comparing-two-branches)
 below; the answer there is not a minimum.
 
-```bash
-export SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1
-export SIMPLER_LOG_LEVEL=TIMING
-export TORCH_DEVICE_BACKEND_AUTOLOAD=0
+Four switches and one flag make the measurement, and each is load-bearing:
 
-# qwen — the module runner prints the child's log to stdout for a 1-device case
-task-submit --device auto --device-num 1 --timeout 2400 --max-time 2400 --run \
-  "python examples/a2a3/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py \
-     -p a2a3 -d \$TASK_DEVICE --manual include --rounds 6" | tee qwen.log
-```
+| Switch | Why |
+| ------ | --- |
+| `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1` | emits the `bind phase=` lines at all |
+| `SIMPLER_LOG_LEVEL=TIMING` | the level they are emitted at |
+| `TORCH_DEVICE_BACKEND_AUTOLOAD=0` | otherwise `torch_npu` grabs a device on import, which a host-only measurement does not want — and nothing in the log records whether it was set |
+| `SIMPLER_SKIP_DEVICE_RUN=1` | returns at `simpler_launch_run`, so the host path is measured without a working device run |
+| `--skip-golden` | with the device skipped the outputs a golden check compares are never produced, so a checking case such as qwen otherwise fails at validation with the whole measurement already complete in the log |
 
-**dsv4 needs the L3 child command run directly.** A case whose
-`device_count > 1` is dispatched by the module runner as one subprocess per
-class, and `run_jobs` captures that subprocess's stdout and prints it only on
-failure — so a passing run yields a log with **no** `bind phase=` lines at all.
-Build the same command the runner would (`scene_test.py`'s L3 phase) and run it
-yourself:
+**`SIMPLER_SKIP_DEVICE_RUN` is presence-based.** `SIMPLER_SKIP_DEVICE_RUN=0` still
+skips; `unset` it. It is a temporary handle from the dsv4 bring-up and is deleted
+once that case's device execution works.
 
-```bash
-task-submit --device auto --device-num 2 --timeout 3600 --max-time 3600 --run \
-  "python examples/a2a3/host_build_graph/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py \
-     -p a2a3 --manual only --rounds 6 -d \$TASK_DEVICE \
-     --case TestDeepseekV4FlashDecodeHostBuildGraph:: --runtime host_build_graph --level 3" | tee dsv4.log
-```
+**A multi-device case must be invoked as its own L3 child command**
+(`--runtime host_build_graph --level 3`). A case whose `device_count > 1` is
+otherwise dispatched by the module runner as one subprocess per class, and
+`run_jobs` captures that subprocess's stdout and prints it only on failure — so a
+passing run yields a log with **no** `bind phase=` lines at all. qwen is
+`level=2` and needs no child command.
 
 A 2-rank case emits one pass per rank per round, so six rounds is twelve passes.
-
-To measure the host path without device execution, set
-`SIMPLER_SKIP_DEVICE_RUN=1`, which returns at `simpler_launch_run`. It is a
-temporary handle from the dsv4 bring-up and is deleted once that case's device
-execution works. One property is load-bearing while it exists:
-
-- **It is presence-based.** `SIMPLER_SKIP_DEVICE_RUN=0` still skips. `unset` it.
+Pass `--rounds` to the parser so it infers the rank count and drops one cold pass
+*per rank* rather than one in total.
 
 A skipped run still writes `host_phase_records.jsonl`, so Recipe B works without
 touching the device. Every phase in that artifact is produced on the host during
@@ -113,8 +120,12 @@ gates it is Recipe B's three conditions, none of which is the device.
 
 ### Reading the segments out
 
+The parser does this grouping; read it out by hand only to check something it does
+not report. The log lands in `outputs/hbg_bind_stats_<sha>.log` unless `-o` names
+it:
+
 ```bash
-grep -oE 'bind phase=[a-z_]+ start_ns=[0-9]+ dur_ns=[0-9]+[^[]*' qwen.log
+grep -oE 'bind phase=[a-z_]+ start_ns=[0-9]+ dur_ns=[0-9]+[^[]*' outputs/hbg_bind_stats_<sha>.log
 ```
 
 Each line carries `start_ns` (a `CLOCK_MONOTONIC` timestamp) plus the segment's
@@ -125,13 +136,14 @@ segments **within each pass** and take the minimum of those sums. Never sum
 minima taken across passes; that total belongs to no pass and can point the wrong
 way (see below).
 
-The first pass is warm-up on both cases and belongs in neither statistic; drop it
+The first pass of each rank is warm-up and belongs in neither statistic; drop it
 explicitly rather than letting a minimum quietly exclude it.
 
-Device wall clock for the same rounds comes from the `[STRACE]` markers:
+Device wall clock for the same rounds comes from the `[STRACE]` markers, on a run
+that did not skip the device:
 
 ```bash
-grep -oE 'device_wall ts=0 dur=[0-9]+' qwen.log | \
+grep -oE 'device_wall ts=0 dur=[0-9]+' <log> | \
   awk -F'dur=' '{printf "%.2f\n", $2/1e6}' | sort -n
 ```
 
@@ -140,29 +152,51 @@ grep -oE 'device_wall ts=0 dur=[0-9]+' qwen.log | \
 A branch comparison is a different measurement from a single reading, and two of
 its failure modes have already produced wrong answers on this box.
 
+**Both arms must be the same ruler, and the log is the only witness you get.** A
+baseline missing `TORCH_DEVICE_BACKEND_AUTOLOAD=0` produced a wrong number once:
+it alone paid for `torch_npu` grabbing a device on import, and the difference was
+attributed to the branch. Nothing in this repo reads that variable — it is
+`torch_npu`'s own — so no log line records whether it was set. The recipe
+therefore echoes the command it is about to run, verbatim, as the log's first
+line, and `hbg_bind_phases` prints that line above the table:
+
+```bash
+diff <(head -1 base.log) <(head -1 measure.log)   # must differ only in the commit
+```
+
+An arm with no `[stamp]` line cannot take part in a comparison.
+
 **Interleave the conditions; never run one after the other.** `base` then
 `measure` attributes every drift in host load to the branch, and the drift is
 larger than most effects worth measuring. Alternate instead —
-`base, measure, base, measure` — and require a per-pass delta that agrees in sign
-across the passes. A pass that disagrees is the signal that the run was
-contended, not that the effect is small: on one dsv4 pass `graph_upload` came out
-+0.46 ms against −0.20 ms on the other three, and the same pass carried a bind
-whose `sm_h2d` was 5.93 ms against a 0.6 ms norm.
+`base, measure, base, measure` — which gives one minimum-of-sums per arm per
+repetition, and require the delta between them to **agree in sign across the
+repetitions**. A repetition that disagrees says the run was contended, not that
+the effect is small: on one dsv4 pass `graph_upload` came out +0.46 ms against
+−0.20 ms on the other three, and the same pass carried a bind whose `sm_h2d` was
+5.93 ms against a 0.6 ms norm.
 
-**A min of sums is not a sum of mins, and they can disagree in sign.** Each
-segment's minimum comes from whichever pass was quietest *for that segment*, so
-summing the per-segment minima produces a total no pass achieved. On one dsv4
-comparison the sum-of-minima moved −0.30 ms while the minimum-of-sums moved
-+0.16 ms, from the same log. Decide which question is being asked and use one
-statistic throughout: minimum-of-sums for "what is the best this branch does",
-per-pass medians for "did this branch change anything".
+**One statistic decides: the minimum of the per-pass sums.** Sum the five
+control-plane segments *within* each pass, take the minimum across the warm
+passes, and compare those. A min of sums is not a sum of mins and the two can
+disagree in sign — each segment's minimum comes from whichever pass was quietest
+*for that segment*, so summing per-segment minima produces a total no pass
+achieved. On one dsv4 comparison the sum-of-minima moved −0.30 ms while the
+minimum-of-sums moved +0.16 ms, from the same log. `hbg_phase_stats` reports the
+minimum-of-sums as its `total` row; never assemble a total by hand from the
+per-phase `min` column.
+
+The median and the max in that table are **not** a second decision rule. Read
+them for one thing only: a change that lowers the minimum while widening the
+range has made the cost less predictable, which is a cost of its own and worth
+reporting alongside the minimum.
 
 **Judge a segment the diff does not touch.** `host_orch`'s own scatter on dsv4
 spans 2.6–4.9 ms across passes of an unmodified `main` — wider than most changes
-being tested — so a ±0.5 ms difference there is not resolvable by pass medians
-however many rounds are run. When a segment matters and its scatter swamps it,
-instrument the mechanism instead: a sub-counter around the suspected work answers
-in one pass what a duration comparison cannot answer in ten.
+being tested — so a ±0.5 ms difference there is not resolvable by comparing
+durations however many rounds are run. When a segment matters and its scatter
+swamps it, instrument the mechanism instead: a sub-counter around the suspected
+work answers in one pass what a duration comparison cannot answer in ten.
 
 ## Recipe B — one round with a swimlane
 
@@ -171,7 +205,8 @@ The summed `bind phase=` lines cannot be placed on a timeline inside
 per-producer record pool, written to `outputs/<case>_<ts>/host_phase_records.jsonl` —
 one record per orchestrator operation, each with its own interval.
 
-Three conditions must all hold, and each one silently produces an empty result:
+Three conditions must all hold, and the first two produce an empty result
+silently:
 
 1. **`SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE=1`**, which is what arms the pool.
    `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` does not: it gates the summed
@@ -180,7 +215,10 @@ Three conditions must all hold, and each one silently produces an empty result:
    `CallConfig.output_prefix` non-empty. `--enable-scope-stats` is the cheapest
    for an L3 case; `--enable-chip-swimlane` raises `NotImplementedError` for
    `level=3` (per-chip-process filename collision).
-3. **`--rounds` must be 1.** `rounds > 1` force-disables every diagnostic flag.
+3. **`--rounds` must be 1.** `rounds > 1` force-disables every diagnostic flag —
+   this one does warn, `<flag> disabled: --rounds > 1` per flag
+   ([`simpler_setup/scene_test.py`](../../simpler_setup/scene_test.py)), but the
+   warning sits in a log whose run otherwise passed.
 
 The device run may be skipped or may fail; neither costs you the artifact. Every
 phase recorded is host work done during bind, so both `SIMPLER_SKIP_DEVICE_RUN`
@@ -189,17 +227,12 @@ execution does not complete still yield its prepare timing — and it is why a
 swimlane for a case that hangs on device is cheaper to take with the variable set
 than to take by waiting out the stall.
 
+The skill's timeline mode is this recipe; it finishes with
+
 ```bash
-export SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE=1
-export SIMPLER_LOG_LEVEL=TIMING TORCH_DEVICE_BACKEND_AUTOLOAD=0
-
-task-submit --device auto --device-num 1 --timeout 2400 --max-time 2400 --run \
-  "python examples/a2a3/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py \
-     -p a2a3 -d \$TASK_DEVICE --manual include --rounds 1 --enable-scope-stats" | tee qwen_detail.log
-
-python -m simpler_setup.tools.strace_timing qwen_detail.log \
+python -m simpler_setup.tools.strace_timing <log> \
     --host-phase-records outputs/<case>_<ts>/host_phase_records.jsonl \
-    --swimlane qwen_host_swimlane.json
+    --swimlane host_swimlane.json
 ```
 
 Load the JSON in [Perfetto](https://ui.perfetto.dev) or `chrome://tracing`. Each
@@ -237,12 +270,14 @@ signal than any duration on a shared box.
 | ---- | ------- | ---------- |
 | dsv4 run through the module runner's L3 phase | log has zero `bind phase=` lines, test passes | run the L3 child command directly (Recipe A) |
 | `SIMPLER_SKIP_DEVICE_RUN=0` | run still skips the device, "PASSED" means nothing ran | `unset` the variable |
-| `--rounds 6` with `--enable-scope-stats` | no `outputs/<case>_<ts>/` artifacts | one round for artifacts, many rounds for numbers |
+| `--rounds 6` with `--enable-scope-stats` | no `outputs/<case>_<ts>/` artifacts, plus a `disabled: --rounds > 1` warning | one round for artifacts, many rounds for numbers |
 | Only `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` set for Recipe B | `bind phase=` lines present, no `host_phase_records.jsonl` | the records are a separate switch: also export `SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE=1` |
+| Comparing a log with no `[stamp]` first line | the parser says so above the table | re-run it through the recipe; conditions cannot be recovered from memory |
 | Subtracting timestamps for the control plane | ~300 ms instead of ~3 ms | sum the five segments; `arena_h2d` is not adjacent |
+| Summing per-segment minima by hand | a total no pass achieved; can invert the sign | read the tool's `total` row — the minimum of the per-pass sums |
+| `--rounds 1` for numbers | the tool refuses: every pass is a rank's warm-up | six rounds; `--keep-first` only to look at the cold pass deliberately |
 | Single pass, or comparing across differently-loaded moments | swings of 3.5× | six rounds, compare minima, keep an untouched segment as a control |
-| `base` then `measure`, sequentially | a load drift reads as the branch's effect | interleave the conditions and require the sign to agree per pass |
-| Summing per-segment minima | a total no pass achieved; can invert the sign | one statistic throughout — see "Comparing two branches" |
+| `base` then `measure`, sequentially | a load drift reads as the branch's effect | interleave the arms and require the sign to agree per repetition |
 | Stale build | mass collection errors, or a `launch_aicpu_num (0)` failure | `pip install --no-build-isolation -e .` after every `HEAD` move |
 
 ## Reference numbers

--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -237,8 +237,8 @@ still recovers the stage's own segments from the runtime's timing log lines; whe
 both are present the artifact wins, so a segment is not drawn twice. See
 [host_build_graph's profiling levels](../../src/a2a3/runtime/host_build_graph/docs/profiling_levels.md)
 for what that runtime records, and
-[hbg-bind-measurement.md](hbg-bind-measurement.md) for the recipe that produces
-both the log and the artifact on a real decode network.
+[hbg-bind-phases.md](hbg-bind-phases.md) for what those segments are and
+what produces both the log and the artifact on a real decode network.
 
 **One exception, because a K-deep pipeline is not K threads.** The direct-chip
 lane drives prepare(N+1) and finalize(N) from the *same* OS thread, so a 40-run

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,7 +145,7 @@ nav:
       - Log System: logging.md
       - L2 Timing: dfx/l2-timing.md
       - Host trace: dfx/host-trace.md
-      - Measuring the hbg bind path: dfx/hbg-bind-measurement.md
+      - hbg bind phases: dfx/hbg-bind-phases.md
       - Device phases: dfx/device-phases.md
       - Scheduler-overhead model: dfx/sched-overhead-model.md
       - Chip Swimlane: dfx/chip-swimlane-profiling.md

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -14,6 +14,7 @@ no repo checkout required.
 - **[sched_overhead_analysis](#sched_overhead_analysis)** — scheduler overhead / Tail OH breakdown
 - **[critical_path](#critical_path)** — chip swimlane critical-path compute/stall analysis
 - **[strace_timing](#strace_timing)** — per-stage `chip.run` breakdown (host + AICPU phases) from `[STRACE]` log markers → TPOT table, per-round table (`--rounds-table`), nested tree (`--tree`), or Perfetto JSON
+- **[hbg_bind_phases](#hbg_bind_phases)** — `host_build_graph` `bind`-stage phases from `bind phase=` log markers → per-phase min/median/max plus the control-plane total
 - **[dump_viewer](#dump_viewer)** — inspect / export args dumps (see [docs/args-dump.md](../../docs/dfx/args-dump.md) for full workflow)
 - **[deps_viewer](#deps_viewer)** — `deps.json` (dep_gen) → text or pan/zoom HTML dependency graph
 
@@ -380,6 +381,39 @@ view.
 The swimlane is the only view that renders `ext.` spans: every table and
 `--trace-out` keys on `(pid, inv)`, which no external producer has. See
 [docs/dfx/host-trace.md](../../docs/dfx/host-trace.md) for that contract.
+
+---
+
+## hbg_bind_phases
+
+Per-phase statistics for `host_build_graph`'s **`bind` stage** from the
+`bind phase=` markers a run emits under `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1` at
+`LOG_TIMING`. One line per segment per bind pass; see
+[docs/dfx/hbg-bind-phases.md](../../docs/dfx/hbg-bind-phases.md) for
+what the segments are, the invocation that produces them, and how to compare two
+runs.
+
+```bash
+# min / median / max per phase over the warm passes, plus the control-plane total
+python -m simpler_setup.tools.hbg_bind_phases path/to/log --rounds 6
+```
+
+Passing `--rounds` is what lets it infer the rank count, so it drops one cold
+warm-up pass **per rank** rather than one in total; `--ranks` sets that directly
+and `--keep-first` keeps the cold passes. A run whose every pass is a rank's
+warm-up — `--rounds 1` — is refused rather than reported, since the one number it
+could print is the cold one. Three grouping rules are encoded rather than left to
+the caller, because each silently produces a wrong number: `arena_h2d` closes a
+pass (the segments are not contiguous in time, so timestamp order does not group
+them), the control-plane total is summed **within** a pass before any minimum is
+taken, and the first pass of each rank is warm-up.
+
+A run whose control plane is missing a phase entirely — a change can retire one —
+is still totalled, over the phases it has, with the absent ones named. A phase
+missing from only *some* passes is a truncated log instead, and those passes are
+excluded with a warning. If the log's first line is a `[stamp]` line naming the
+command and commit, it is echoed above the table; without one, the conditions
+behind the numbers have to be established by hand.
 
 ---
 

--- a/simpler_setup/tools/__init__.py
+++ b/simpler_setup/tools/__init__.py
@@ -16,4 +16,5 @@ Invoke via ``python -m simpler_setup.tools.<name>``:
 - ``deps_viewer``           : deps.json -> text or pan/zoom HTML dependency graph
 - ``dump_viewer``           : inspect args dumps
 - ``strace_timing``         : per-stage / per-round timing from [STRACE] log markers
+- ``hbg_bind_phases``       : per-phase host_build_graph bind statistics from `bind phase=` markers
 """

--- a/simpler_setup/tools/hbg_bind_phases.py
+++ b/simpler_setup/tools/hbg_bind_phases.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Per-phase statistics from a `bind phase=` LOG_TIMING breakdown.
+
+Reads the log a `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 --rounds N` run leaves
+behind and reports each bind phase's minimum, median and maximum across the warm
+passes, plus the control-plane total.
+
+What the phases are, and how to compare two runs:
+docs/dfx/hbg-bind-phases.md.
+"""
+
+import argparse
+import re
+import statistics
+import sys
+
+PHASE_LINE = re.compile(r"bind phase=(\w+) start_ns=(\d+) dur_ns=(\d+)")
+# The recipe's first log line, recording the command and the commit the run used.
+# Two runs are comparable only if it matches, so it is echoed above the table.
+STAMP_LINE = re.compile(r"^\[stamp\] (.*)$")
+
+# The segments between "the caller's data is in place" and "the device can run".
+# `args` and `host_view_close` are per-byte costs over the weights the case
+# stages, so they belong to getting the weights resident, not to dispatch.
+CONTROL_PLANE = ("host_orch", "graph_upload", "relocate", "sm_h2d", "arena_h2d")
+
+# Display order: the bind stage's own sequence, so a reader can follow it down.
+PHASE_ORDER = (
+    "args",
+    "arena_build",
+    "static_arena",
+    "gm_heap",
+    "shared_mem",
+    "runtime_init",
+    "host_orch",
+    "graph_upload",
+    "relocate",
+    "sm_h2d",
+    "arena_h2d",
+    "host_view_close",
+)
+
+# The last segment of a pass, and so what closes one: the segments are not
+# contiguous in time, so timestamp order does not group them.
+PASS_CLOSING_PHASE = "arena_h2d"
+
+
+def parse_passes(path: str) -> list[dict[str, float]]:
+    """Group `bind phase=` lines into passes, in milliseconds."""
+    passes: list[dict[str, float]] = []
+    current: dict[str, float] = {}
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            match = PHASE_LINE.search(line)
+            if match is None:
+                continue
+            phase, _start_ns, dur_ns = match.group(1), int(match.group(2)), int(match.group(3))
+            current[phase] = dur_ns / 1e6
+            if phase == PASS_CLOSING_PHASE:
+                passes.append(current)
+                current = {}
+    if current:
+        passes.append(current)
+    # A group without `host_orch` is not a bind pass.
+    return [p for p in passes if "host_orch" in p]
+
+
+def parse_stamp(path: str) -> str:
+    """The run's environment stamp, or "" for a log this script did not produce."""
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            match = STAMP_LINE.match(line.rstrip("\n"))
+            if match is not None:
+                return match.group(1)
+    return ""
+
+
+def spread(values: list[float]) -> tuple[float, float, float]:
+    """Minimum, median and maximum. The median averages the two central values."""
+    return min(values), statistics.median(values), max(values)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("log", help="run log carrying the `bind phase=` lines")
+    parser.add_argument(
+        "--ranks",
+        type=int,
+        default=None,
+        help="ranks in the run; the first pass of each is warm-up and is dropped. "
+        "Default: inferred as the number of passes divided by the round count when "
+        "--rounds is given, else 1.",
+    )
+    parser.add_argument("--rounds", type=int, default=None, help="rounds the run was given, to infer --ranks")
+    parser.add_argument("--keep-first", action="store_true", help="keep the cold pass in the statistics")
+    args = parser.parse_args()
+
+    passes = parse_passes(args.log)
+    if not passes:
+        print(
+            f"{args.log}: no `bind phase=` lines. SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 and "
+            "SIMPLER_LOG_LEVEL=TIMING must both be set, and a multi-device case must be "
+            "invoked as its own child command -- see docs/dfx/hbg-bind-phases.md.",
+            file=sys.stderr,
+        )
+        return 1
+
+    ranks = args.ranks
+    if ranks is None:
+        ranks = max(1, len(passes) // args.rounds) if args.rounds else 1
+    dropped = 0 if args.keep_first else min(ranks, len(passes))
+    warm = passes[dropped:]
+    if not warm:
+        print(
+            f"{args.log}: {len(passes)} pass(es) over {ranks} rank(s), all of them cold. The first "
+            "pass of each rank is warm-up, so a warm pass needs --rounds 2 or more; --keep-first "
+            "reports the cold passes instead.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"{args.log}")
+    stamp = parse_stamp(args.log)
+    if stamp:
+        print(f"  {stamp}")
+    else:
+        print("  (no `[stamp]` line: the command and commit behind these numbers have")
+        print("   to be established by hand before comparing them to anything)")
+    print(f"  {len(passes)} passes, {len(warm)} warm ({dropped} cold dropped, ranks={ranks})\n")
+    print(f"  {'phase':<18}{'min':>10}{'median':>10}{'max':>10}   n")
+    for phase in PHASE_ORDER:
+        values = [p[phase] for p in warm if phase in p]
+        if not values:
+            continue
+        low, mid, high = spread(values)
+        mark = "*" if phase in CONTROL_PLANE else " "
+        print(f" {mark}{phase:<18}{low:>10.3f}{mid:>10.3f}{high:>10.3f}  {len(values):3d}")
+
+    unknown = sorted({k for p in warm for k in p} - set(PHASE_ORDER))
+    if unknown:
+        print(f"\n  phases this tool does not know about: {', '.join(unknown)}")
+        print("  (add them to PHASE_ORDER, and to CONTROL_PLANE if a dispatch change can move them)")
+
+    # The control-plane set is not fixed: a change can retire a phase outright, so
+    # the total covers the phases this run has and names the ones absent from every
+    # pass. Absent from only some passes is a truncated log rather than a retired
+    # phase, and would understate a pass, so those passes are excluded and warned
+    # about.
+    present = [k for k in CONTROL_PLANE if any(k in p for k in [k] for p in warm)]
+    partial = [k for k in present if not all(k in p for p in warm)]
+    retired = [k for k in CONTROL_PLANE if k not in present]
+    complete = [p for p in warm if all(k in p for k in present)]
+    if complete:
+        totals = [sum(p[k] for k in present) for p in complete]
+        low, mid, high = spread(totals)
+        print("\n  * = control plane, summed within each pass and then:")
+        print(f"    total{'':<13}{low:>10.3f}{mid:>10.3f}{high:>10.3f}  {len(totals):3d}   (ms)")
+        if retired:
+            print(f"    over {len(present)} of {len(CONTROL_PLANE)} phases; absent from every")
+            print(f"    pass: {', '.join(retired)}")
+        if partial:
+            print(f"    WARNING: {', '.join(partial)} is missing from some passes but not all;")
+            print("    those passes are excluded, and the total may not describe the run")
+        print("\n  Compare by min, over the same phase set, against a log with the same")
+        print("  stamp; see docs/dfx/hbg-bind-phases.md 'Comparing two branches'.")
+    else:
+        print(f"\n  no pass carries any of {CONTROL_PLANE}; the control-plane total is not computable")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Every number in the recent `host_build_graph` work came from assembling the same
handful of switches by hand, and two of the ways to get that wrong are quiet:

- a multi-device case run through the module runner has its child output captured,
  so the log holds zero `bind phase=` lines and the run still **passes**;
- summing per-phase minima produces a total no pass achieved, and it can invert the
  sign of a branch comparison.

Only the second needs code. This PR ships that as a wheel CLI and leaves the
invocation as prose.

## `simpler_setup/tools/hbg_bind_phases.py`

```bash
python -m simpler_setup.tools.hbg_bind_phases path/to/log --rounds 6
```

Groups the `bind phase=` markers into passes and reports each phase's min / median
/ max plus the control-plane total. Three rules are encoded rather than left to the
caller: `arena_h2d` closes a pass (the segments are not contiguous in time, so
timestamp order does not group them), the total is summed **within** a pass before
any minimum is taken, and the first pass of each rank is warm-up — which is what
`--rounds` is for, since it lets the tool infer the rank count and drop one cold
pass *per rank* rather than one in total.

The control-plane set is not fixed: a change can retire a phase outright, so the
total covers the phases a run has and names the ones absent from every pass. Absent
from only *some* passes is a truncated log instead, and those passes are excluded
with a warning.

**Why the wheel and not `tools/`:** the switch that produces its input already ships
— `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` is a documented runtime knob in
`src/{arch}/runtime/host_build_graph/docs/profiling_levels.md`, so anyone with an
installed wheel can produce these logs. The tool is pure stdlib and reads nothing
but the log, so `tools/` — whose contents "assume a full source checkout" — was the
wrong home. It now sits next to `strace_timing`, indexed in
`simpler_setup/tools/README.md`.

## The invocation stays prose

Four environment variables, `--skip-golden`, and one `--level` decision.
`.claude/skills/hbg-bind-phases/` carries it as one skeleton plus a table per case
and per mode. Two things keep that from being hand-assembly again:

- `env` prefixes the variable-expanded assignments, so they cannot silently degrade
  into a command name;
- the recipe echoes the exact command it is about to run as the log's first
  `[stamp]` line, and the tool prints that line above the table.

That check exists because a baseline lacking `TORCH_DEVICE_BACKEND_AUTOLOAD=0` once
paid for `torch_npu` grabbing a device on import and the gap was credited to the
branch. Nothing in this repo reads that variable — it is `torch_npu`'s own — so the
log is the only witness available, and an arm with no `[stamp]` line cannot take
part in a comparison.

## One fact, one home

| Surface | Owns |
| ------- | ---- |
| `docs/dfx/hbg-bind-phases.md` | what the phases are, why each switch is load-bearing, the comparison methodology, the reference numbers |
| `.claude/skills/hbg-bind-phases/SKILL.md` | the invocation and the pre-report checks — nothing else, since it enters context on every use |
| `simpler_setup/tools/hbg_bind_phases.py` | the grouping and statistics; a comment only where a rule is an invariant the code depends on |
| `simpler_setup/tools/README.md` | the CLI's index entry and flags |

Recipe A's per-case command blocks become a switch table plus a pointer at the
skill, and the doc names where a new lesson goes so the next one does not grow on
four surfaces at once. `tools/` is untouched by this PR and still lists only the two
scripts that genuinely need a checkout.

**One stem names all three surfaces**, following `core-swimlane` /
`core-swimlane-profiling.md` / `core_swimlane.py`. "Bind path" was never an
identifier — it appears only in prose and comments, so it carried no contract and
nothing to grep — while the code names both halves: `chip.run.bind` is the
`[STRACE]` span, emitted by **both** runtimes, and `bind phase=<p>` is the
subdivision only `host_build_graph/host/host_phase_trace.cpp` emits. So the doc
moves `hbg-bind-measurement.md` → `hbg-bind-phases.md` (beside its device-side
counterpart `device-phases.md`), the skill `measure-bind-path` → `hbg-bind-phases`,
and the tool `hbg_phase_stats` → `hbg_bind_phases`; `docs/dfx/README.md`,
`host-trace.md` and the `mkdocs.yml` nav move with the file, and the doc's first
paragraph now defines both words against those two code names.

## Three corrections to the recipe as documented

- `--rounds > 1` does **not** disable the diagnostics silently: `scene_test.py:96-98`
  warns `<flag> disabled: --rounds > 1` per flag. The trap is a warning buried in a
  passing run, not an absence — the doc said otherwise.
- `level=3` was claimed for **both** cases. qwen is `level=2`
  (`test_qwen3_14b_decode.py:45`), and the level is exactly what decides whether the
  L3 child command has to be built.
- The doc calls six rounds the working minimum, so six is the count in every example.

## Testing

- [x] `ruff check` / `ruff format` / `pyright` clean on the moved module; it runs
      standalone (stdlib only) and fails under `python -m` only for the pre-existing
      reason every sibling tool does (`simpler_setup/__init__.py` needs the `simpler`
      package installed — `strace_timing` behaves identically).
- [x] Exercised end-to-end on a synthetic 4-pass 2-rank log: one cold pass dropped
      per rank, control-plane total summed within each pass, `[stamp]` line echoed.
- [x] The recipe's two invocations were run onboard on this branch before being
      written down (dsv4 2×a2a3 L3, qwen 1×a2a3 L2).
- [ ] No product code: the only shipped addition is a read-only CLI module.
