### PR TITLE
host_build_graph: upload the bind image once, and only the bytes the device reads

### DIFF
--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -229,9 +229,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
     // Boot: the last AICPU thread (aicpu_thread_num_ - 1) performs the one-time
     // host-orch attach. host_build_graph's orchestrator already ran on the host,
-    // which also relocated every cross-task pointer to its final device address
-    // before H2D — so the SM/arena this thread sees are already fully
-    // device-addressed. This thread attaches the prebuilt arena, points the SM
+    // and every cross-task reference it wrote is an offset from its own block, so
+    // the SM/arena this thread sees need no address fixup. This thread attaches
+    // the prebuilt arena, points the SM
     // handle's ring-header pointers at the device SM WITHOUT resetting the
     // host-populated data, hands the host-computed task count to the scheduler,
     // and releases the other threads. It then falls through and schedules its own
@@ -264,14 +264,23 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             runtime_wire_arena_pointers(runtime_arena_, rt->prebuilt_layout, rt);
 
             void *sm_ptr = runtime->get_gm_sm_ptr();
-            uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(rt->prebuilt_layout.task_window_sizes);
+            // The image the host shipped is pitched to the submitted task count,
+            // not to the ring capacity, and the device region holds exactly that
+            // image — so its size comes from the same pitch. attach_populated
+            // rejects a pitch outside (0, capacity] and a region too small for it.
+            const uint64_t live_slots =
+                pto2_sm_layout::live_slot_pitch(static_cast<uint64_t>(runtime->host_total_tasks));
+            const uint64_t payload_stride = runtime->sm_payload_stride;
+            const uint64_t sm_size = pto2_sm_layout::ring_segment_offsets(live_slots, payload_stride).end;
             // sm_handle and the scheduler state are the device-only zone: their
             // bytes never travel, so they start as whatever the pooled arena last
             // held. Zeroing the handle first is what makes attach_populated's
             // assignment of every field checkable here rather than by inspecting
             // attach_populated.
             memset(rt->sm_handle, 0, sizeof(*rt->sm_handle));
-            if (!rt->sm_handle->attach_populated(sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes)) {
+            if (!rt->sm_handle->attach_populated(
+                    sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes, live_slots, payload_stride
+                )) {
                 LOG_ERROR("Thread %d: host-orch: sm_handle->attach_populated failed", thread_idx);
                 rt = nullptr;
                 run_rc = -1;
@@ -306,8 +315,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // to keep them alive).
             // NOTE: do NOT call rt_orchestration_done(rt) here. The HOST already
             // called it in run_host_orchestration; the orchestrator's own
-            // task-allocator pointers are intentionally NOT relocated, so they
-            // still hold host addresses and mark_done() would fault the AICPU.
+            // task-allocator pointers name host memory the device never reads, so
+            // mark_done() would fault the AICPU.
             sched_ctx_.on_orchestration_done(runtime, rt, thread_idx, runtime->host_total_tasks);
             LOG_INFO("Thread %d: host-orch boot complete (%d tasks)", thread_idx, runtime->host_total_tasks);
         }

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -9,7 +9,7 @@ host register: materialize + dlopen orchestration SO
         ↓
 host run/bind: stage external tensors, execute orchestration to completion
         ↓
-host: relocate the prebuilt graph image and copy it to device memory
+host: copy the prebuilt graph image to device memory
         ↓
 device: attach the image, classify tasks, dispatch with AICPU schedulers
         ↓
@@ -49,9 +49,8 @@ For each run, the host:
 2. reserves one backing arena for runtime/shared-memory subregions;
 3. binds the runtime to the orchestration DSO;
 4. calls the orchestration entry synchronously;
-5. finalizes task counts and the graph image;
-6. rewrites per-slot task/payload pointers to device addresses; and
-7. copies the shared-memory image and arena to the device.
+5. finalizes task counts and the graph image; and
+6. copies the shared-memory image and the arena's copied zone to the device.
 
 An orchestration fatal stops this sequence and is propagated through
 `orch_error_code`.
@@ -78,8 +77,9 @@ The shared image uses three per-slot structures:
 | `PTO2TaskSlotState` | Active mask, attributes, block/subtask counters, completion state, task/payload bindings |
 
 The host/device boundary is POD and position-independent. Fanins are integer
-producer IDs, not pointers. The only per-slot pointers are rebound to their final
-device addresses before H2D.
+producer IDs, not pointers, and a slot state names its payload and descriptor by a
+delta from its own address — so the image needs no fixup on either side of the
+copy.
 
 ### 3.1 What Ships: the Arena's Three Zones
 
@@ -97,16 +97,25 @@ Three rules decide every byte of the runtime arena:
 They partition the arena into three contiguous zones, and `runtime_reserve_layout`
 reserves them in this order:
 
-| Zone | Regions | Copied | Written by |
-| ---- | ------- | ------ | ---------- |
-| host-only | orchestrator block: `fanin_seen_epoch` / `scope_tasks` / TensorMap, ~8.5 MB | never | host, during graph construction |
-| copied | `[off_copied_begin, off_copied_end)`: the runtime header | whole zone, one copy | host |
-| device-only | `sm_handle`, `PTO2SchedulerState` and its thirteen queue slot arrays, the completion mailbox | never | AICPU at boot |
+| Zone | Regions | Copied | Allocated on device | Written by |
+| ---- | ------- | ------ | ------------------- | ---------- |
+| copied | `[off_copied_begin, off_copied_end)`: the runtime header | whole zone, one copy | yes | host |
+| device-only | `sm_handle`, the completion mailbox, `PTO2SchedulerState` and its thirteen queue slot arrays | never | yes | AICPU at boot |
+| host-only | orchestrator block: `fanin_seen_epoch` / `scope_tasks` / TensorMap, ~9.3 MB | never | **no** | host, during graph construction |
 
-Putting the copied zone **between** the two zones that are never copied is what
-makes `bind` a single contiguous `copy_to_device`. Both bounds are layout fields,
-so no consumer infers a boundary from which region happens to be reserved first —
-`bind_callable_to_runtime_impl` asserts only that they are ordered and in range.
+The copied zone leads, so `bind` is a single contiguous `copy_to_device` starting
+at the arena base. Both bounds are layout fields, so no consumer infers a boundary
+from which region happens to be reserved first — `bind_callable_to_runtime_impl`
+asserts only that they are ordered and in range.
+
+**Why the host-only zone comes last.** No device code dereferences a pointer into
+the orchestrator block — hbg has no device-side orchestrator, and the one
+orchestrator field the scheduler reads, `inline_completed_tasks`, is a scalar in
+the runtime header. Putting the block at the tail lets `setup_static_arena` request
+only `layout.device_bytes`, the copied + device-only prefix, so those ~9.3 MB are
+never reserved on the device at all. `runtime_wire_host_only_pointers` is therefore
+host-only, and `runtime_clear_host_only_pointers` drops those pointers before the
+copied zone is uploaded so no host address crosses the boundary.
 
 **Why the scheduler state is device-written.** `PTO2SchedulerState` holds no
 per-run content: `sm_header` and the ring pointer derive from a pooled SM base,

--- a/src/a2a3/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a2a3/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
@@ -38,7 +38,7 @@ The execution order is:
 
 1. The host loads and calls the orchestration shared object.
 2. Orchestration builds the entire task graph and returns.
-3. The host relocates and copies the graph image to device memory.
+3. The host copies the graph image to device memory.
 4. AICPU schedulers boot and dispatch the graph.
 
 A producer submitted in step 1 cannot become `COMPLETED` until step 4. Waiting

--- a/src/a2a3/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a2a3/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
@@ -33,8 +33,9 @@ The shared graph image separates stable task identity from scheduling state:
 - `PTO2TaskSlotState` contains the active mask, task attributes, logical block
   count, subtask counters, completion state, and descriptor/payload bindings.
 
-This image is built on the host, relocated once, and copied to the device. It
-contains no fanout adjacency or dependency-pool pointers.
+This image is built on the host and copied to the device verbatim. It contains
+no fanout adjacency or dependency-pool pointers, and its descriptor/payload
+bindings are deltas from the slot state's own address rather than pointers.
 
 ## Resource Shapes
 

--- a/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
@@ -240,12 +240,12 @@ appear.
 
 ### What is recorded
 
-Seventeen kinds, all on the host monotonic clock the `[STRACE]` host spans use,
+Sixteen kinds, all on the host monotonic clock the `[STRACE]` host spans use,
 so records and spans read against each other with no alignment step.
 
 | Group | Kinds |
 | ----- | ----- |
-| Bind segments (partition the stage) | `args`, `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init`, `host_orch`, `graph_upload`, `relocate`, `sm_h2d`, `arena_h2d`, `host_view_close` |
+| Bind segments (partition the stage) | `args`, `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init`, `host_orch`, `graph_upload`, `sm_h2d`, `arena_h2d`, `host_view_close` |
 | Orchestrator operations (inside `host_orch`) | `submit_task`, `alloc_tensors`, `record_node`, `graph_submit`, `build_definition` |
 
 Three of the orchestrator kinds end with a task submitted — `submit_task`,

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -79,13 +79,16 @@
 extern "C" const PipelineContract *get_pipeline_contract(void) {
     // Host orchestration materializes this run's own graph into the image it
     // uploads, so every device-resident region carries per-run content.
+    //
+    // PTO_PIPELINE_GM_SM is absent because hbg has no separate shared-memory
+    // region: the image is the tail of the runtime-image region, so it shares that
+    // region's classification. The arena-topology check skips an absent kind.
     static const PipelineContract contract = {
         PTO_PIPELINE_CONTRACT_ABI_VERSION,
-        5,
+        4,
         2,
         {
             {PTO_PIPELINE_GM_HEAP, PTO_PIPELINE_HOST_PER_RUN, 0},
-            {PTO_PIPELINE_GM_SM, PTO_PIPELINE_HOST_PER_RUN, 0},
             {PTO_PIPELINE_RUNTIME_IMAGE, PTO_PIPELINE_HOST_PER_RUN, 0},
             {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
             {PTO_PIPELINE_AICORE_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
@@ -288,6 +291,18 @@ static bool resolve_ring_config(
             LOG_ERROR("ring_heap[%d]=%" PRIu64 " must be >= 1024", r, eff_heap_sizes[r]);
             return false;
         }
+        // A slot state reaches its payload and descriptor through a 32-bit
+        // self-relative delta, so every pair of addresses in the shared-memory
+        // image must be within INT32_MAX of each other.
+        const uint64_t sm_bytes = pto2_sm_layout::ring_segment_offsets(eff_task_window_sizes[r]).end;
+        if (sm_bytes > static_cast<uint64_t>(INT32_MAX)) {
+            LOG_ERROR(
+                "ring_task_window[%d]=%" PRIu64 " needs a %" PRIu64 "-byte shared memory image, past the %d-byte limit "
+                "a slot state's self-relative payload/descriptor delta can span",
+                r, eff_task_window_sizes[r], sm_bytes, INT32_MAX
+            );
+            return false;
+        }
     }
 
     return true;
@@ -317,9 +332,10 @@ static int32_t pto2_read_runtime_status(Runtime *runtime, const HostApi *api, PT
 namespace {
 
 // host_build_graph is host-orchestration-first: the HOST dlopens the
-// orchestration .so and runs it to completion. The shared memory + arena carry
-// host-DDR cross-task pointers; the host relocates them to their final device
-// addresses before the H2D copy, so the device schedules a complete image.
+// orchestration .so and runs it to completion. Every cross-task reference the
+// shared memory and arena carry is an offset or an index from its own block, so
+// the image the device schedules is the bytes the host wrote — there is nothing
+// to fix up after the H2D copy.
 
 bool write_all_bytes(int fd, const uint8_t *data, size_t size) {
     size_t total = 0;
@@ -373,52 +389,26 @@ struct HostOrchEntryPoints {
     OrchestrationBindFunc bind{nullptr};
 };
 
-static bool relocate_host_orch_image(
-    PTO2SharedMemoryHandle &host_sm_handle, uint64_t host_sm, uint64_t sm_size, int64_t sm_delta, uint64_t host_arena,
-    uint64_t arena_size, int64_t arena_delta
-) {
-    static_assert(PTO2_MAX_RING_DEPTH == 1, "relocate_host_orch_image assumes a single ring");
+// One submission's place in the block: where its bytes come from, which outer task
+// reads it, and how far into the block it sits.
+struct StagedSubmission {
+    const std::byte *host_image;
+    PTO2TaskSlotState *outer_slot;
+    size_t bytes;
+    uint64_t offset;
+};
 
-    if (!(host_sm + sm_size <= host_arena || host_arena + arena_size <= host_sm)) {
-        LOG_ERROR(
-            "host-orch: SM window [%#lx,+%#lx) overlaps arena window [%#lx,+%#lx); cannot relocate", host_sm, sm_size,
-            host_arena, arena_size
-        );
-        return false;
-    }
-
-    bool ok = true;
-    auto relocate = [&](auto *&pointer) {
-        using Pointer = std::remove_reference_t<decltype(pointer)>;
-        const uint64_t address = reinterpret_cast<uint64_t>(pointer);
-        if (address == 0) return;
-        if (address >= host_sm && address < host_sm + sm_size) {
-            pointer = reinterpret_cast<Pointer>(static_cast<uintptr_t>(address + sm_delta));
-        } else if (address >= host_arena && address < host_arena + arena_size) {
-            pointer = reinterpret_cast<Pointer>(static_cast<uintptr_t>(address + arena_delta));
-        } else {
-            LOG_ERROR(
-                "host-orch: pointer %#lx is outside both SM and arena windows; cannot relocate for device", address
-            );
-            ok = false;
-        }
-    };
-
-    PTO2SharedMemoryHeader *header = host_sm_handle.header;
-    if (header != nullptr) {
-        PTO2SharedMemoryRingHeader &ring = header->ring;
-        const int32_t count = ring.fc.current_task_index.load(std::memory_order_acquire);
-        for (int32_t slot = 0; slot < count; ++slot) {
-            PTO2TaskSlotState *state = &ring.slot_states[slot];
-            relocate(state->task);
-            relocate(state->payload);
-        }
-    }
-    return ok;
-}
-
-bool upload_graph_submissions(
-    Runtime *runtime, const HostApi *api, GraphHostState &graph_state, uint64_t &uploaded_bytes
+// Validate every pending submission, bind it to its uploaded Definition, and lay
+// the block out. No device call and no device address: the block lands in the
+// runtime arena's tail, whose base is not known until that region is grown to fit
+// the shared-memory image as well.
+//
+// Submissions sit PTO2_ALIGN_SIZE apart. activation_gate is OR-ed by the outer task
+// and by the node path for the length of the graph, so two submissions sharing a
+// cache line would false-share on that word throughout.
+bool plan_graph_submissions(
+    const HostApi *api, GraphHostState &graph_state, std::vector<StagedSubmission> *staged, uint64_t *block_bytes,
+    uint64_t &uploaded_bytes
 ) {
     uploaded_bytes = 0;
     const size_t count = graph_host_upload_count(graph_state);
@@ -465,7 +455,9 @@ bool upload_graph_submissions(
         uploaded_bytes += object_bytes;
     }
 
-    // Pass 2: per-submission execution storage + the small reference image.
+    // Pass 2: validate every submission and lay the block out.
+    staged->reserve(count);
+    *block_bytes = 0;
     for (size_t index = 0; index < count; ++index) {
         std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
         if (!upload.has_value() || upload->outer_slot == nullptr || upload->data == nullptr ||
@@ -499,21 +491,23 @@ bool upload_graph_submissions(
         submission->local_execution = 0;
         submission->activation_gate = 0;
 
-        void *device_submission = api->device_malloc(upload->bytes);
-        if (device_submission == nullptr) {
-            LOG_ERROR("host-orch: failed to allocate %zu bytes for Graph submission", upload->bytes);
-            return false;
-        }
-        if (api->copy_to_device(device_submission, upload->data, upload->bytes) != 0) {
-            LOG_ERROR("host-orch: failed to upload Graph submission POD image");
-            api->device_free(device_submission);
-            return false;
-        }
-        upload->outer_slot->graph_context = device_submission;
-        runtime->tensor_pairs_.push_back({nullptr, device_submission, upload->bytes, false});
-        uploaded_bytes += static_cast<uint64_t>(upload->bytes);
+        staged->push_back({upload->data, upload->outer_slot, upload->bytes, *block_bytes});
+        *block_bytes += PTO2_ALIGN_UP(static_cast<uint64_t>(upload->bytes), PTO2_ALIGN_SIZE);
     }
+    uploaded_bytes += *block_bytes;
     return true;
+}
+
+// Copy the planned block into `block_base` and point each outer task at the device
+// address its submission will occupy. The graph_context write lands in the host
+// shared-memory mirror, which has not been compacted or copied yet.
+void stage_graph_submissions(
+    const std::vector<StagedSubmission> &staged, char *block_base, const char *device_block_base
+) {
+    for (const StagedSubmission &entry : staged) {
+        std::memcpy(block_base + entry.offset, entry.host_image, entry.bytes);
+        entry.outer_slot->graph_context = const_cast<char *>(device_block_base) + entry.offset;
+    }
 }
 
 struct GraphHostStateBinding {
@@ -528,7 +522,7 @@ struct GraphHostStateBinding {
 
 int32_t run_host_orchestration(
     Runtime *runtime, const HostApi *api, HostTensorAccessor &tensor_access, PTO2Runtime *rt, DeviceArena &host_arena,
-    const PTO2RuntimeArenaLayout &layout, void *device_sm, uint64_t sm_size, void *device_arena, void *gm_heap,
+    const PTO2RuntimeArenaLayout &layout, uint64_t sm_size, void *device_arena, void *gm_heap,
     const uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH],
     void *host_orch_func_ptr, const ChipTaskArgs &orch_l2
 ) {
@@ -540,8 +534,14 @@ int32_t run_host_orchestration(
     // orch::prepare_task and shipped bounded to total_tasks below.
     const pto2_sm_layout::PTO2RingSegmentOffsets sm_segs =
         pto2_sm_layout::ring_segment_offsets(eff_task_window_sizes[0]);
-    std::unique_ptr<uint8_t[]> host_sm_buf(new uint8_t[sm_size]);
-    void *host_sm = host_sm_buf.get();
+    // Over-allocated and rounded up: every segment offset is a multiple of
+    // PTO2_ALIGN_SIZE and PTO2TaskSlotState is alignas(64), which a plain
+    // new uint8_t[] does not guarantee.
+    std::unique_ptr<uint8_t[]> host_sm_buf(new uint8_t[sm_size + PTO2_ALIGN_SIZE]);
+    void *host_sm = reinterpret_cast<void *>(
+        (reinterpret_cast<uintptr_t>(host_sm_buf.get()) + PTO2_ALIGN_SIZE - 1) &
+        ~static_cast<uintptr_t>(PTO2_ALIGN_SIZE - 1)
+    );
     std::memset(host_sm, 0, sm_segs.descriptors);
 
     // Re-point the orchestrator half at the host SM (scheduler keeps device SM).
@@ -617,6 +617,25 @@ int32_t run_host_orchestration(
     }
 #endif
 
+    // A latched fatal means the graph in the mirror is not the graph the orchestration
+    // described — a heap or tensormap exhaustion drops tasks, a fanin overflow drops
+    // edges. Uploading it would launch the device on an incomplete graph and surface
+    // the cause as whatever the device notices second, usually a scheduler timeout.
+    const int32_t orch_error = pto2_sm_layout::orch_error_code_addr(host_sm)->load(std::memory_order_acquire);
+    if (orch_error != PTO2_ERROR_NONE || rt->orchestrator.fatal) {
+        // The latched code is the diagnosis, so it is what the caller sees — through the
+        // same mapping the run path uses, since a caller cannot tell which of the two
+        // noticed. A fatal with no code left to read is the only generic failure.
+        const int32_t status =
+            orch_error != PTO2_ERROR_NONE ? runtime_status_from_error_codes(orch_error, PTO2_ERROR_NONE) : -1;
+        LOG_RUNTIME_FAILURE(orch_error, PTO2_ERROR_NONE, status);
+        LOG_ERROR(
+            "host-orch: refusing to upload an incomplete graph after %" PRIu64 " heap bytes",
+            rt->orchestrator.ring.task_allocator.heap_used_bytes()
+        );
+        return status;
+    }
+
     const int32_t total_tasks = pto2_sm_layout::ring_current_task_index_addr(host_sm)->load(std::memory_order_acquire);
     {
         char attrs[96];
@@ -629,9 +648,16 @@ int32_t run_host_orchestration(
     // After the span closes: the reduction walks a few hundred records and emits
     // five markers, which must not be charged to the pass it measures.
 
+    // Uploads each distinct Definition as its own retained device object and lays
+    // out the submission block. The block itself is staged below, into the arena's
+    // second device tail, so nothing here allocates or copies it.
     const int64_t t_graph_ns = bind_now_ns();
     uint64_t graph_bytes = 0;
-    if (!upload_graph_submissions(runtime, api, *graph_state, graph_bytes)) return -1;
+    std::vector<StagedSubmission> staged_submissions;
+    uint64_t submission_block_bytes = 0;
+    if (!plan_graph_submissions(api, *graph_state, &staged_submissions, &submission_block_bytes, graph_bytes)) {
+        return -1;
+    }
     {
         char attrs[96];
         snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, graph_host_upload_count(*graph_state), graph_bytes);
@@ -646,52 +672,107 @@ int32_t run_host_orchestration(
     }
     host_phase_trace_note_submitted(static_cast<uint64_t>(total_tasks));
 
-    // Relocate the host-DDR cross-task pointers to their final DEVICE addresses
-    // on the host, before the SM and arena leave for the device. Pointers into
-    // the SM shift by sm_delta; pointers into the arena (fanout adjacency, wiring
-    // queue) shift by arena_delta. After this both the SM and arena carry device
-    // addresses, so the device boots scheduler-only.
-    const int64_t sm_delta = static_cast<int64_t>(reinterpret_cast<uint64_t>(device_sm)) -
-                             static_cast<int64_t>(reinterpret_cast<uint64_t>(host_sm));
-    const int64_t arena_delta = static_cast<int64_t>(reinterpret_cast<uint64_t>(device_arena)) -
-                                static_cast<int64_t>(reinterpret_cast<uint64_t>(host_arena.base()));
-    const int64_t t_reloc_ns = bind_now_ns();
-    if (!relocate_host_orch_image(
-            host_sm_handle, reinterpret_cast<uint64_t>(host_sm), sm_size, sm_delta,
-            reinterpret_cast<uint64_t>(host_arena.base()), layout.arena_size, arena_delta
-        )) {
-        LOG_ERROR("host-orch: relocation failed; refusing to H2D an image with unrelocated host pointers");
+    // The device reads no ring slot past total_tasks, so only that prefix of each
+    // segment has to travel. In the mirror the orchestrator wrote, the four
+    // prefixes are a ring capacity apart, which would make the upload four copies
+    // of a few hundred kilobytes each — and at these sizes a copy_to_device is
+    // priced by the call, not by the bytes.
+    //
+    // So the prefixes are restacked into an image pitched to total_tasks, where
+    // they are contiguous, and that image goes up as one copy. The device attaches
+    // with the same pitch. The ring capacity and mask are untouched: `local_id &
+    // mask` is `local_id`, which is below the pitch for every ring task.
+    const uint64_t nt = static_cast<uint64_t>(total_tasks);
+    // The widest task in this bind sets the stride every payload in the image gets.
+    // Read from the mirror, which orchestration has finished writing.
+    int32_t widest_tensor_count = 0;
+    {
+        const auto *mirror_payloads =
+            reinterpret_cast<const PTO2TaskPayload *>(static_cast<const char *>(host_sm) + sm_segs.payloads);
+        for (uint64_t i = 0; i < nt; ++i) {
+            if (mirror_payloads[i].tensor_count > widest_tensor_count) {
+                widest_tensor_count = mirror_payloads[i].tensor_count;
+            }
+        }
+    }
+    const uint64_t payload_stride = pto2_sm_layout::shipped_payload_stride(widest_tensor_count);
+    runtime->sm_payload_stride = payload_stride;
+    const uint64_t image_bytes =
+        pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::live_slot_pitch(nt), payload_stride).end;
+
+    // Only now is the size known, so this is where the device region grows to cover
+    // its shared-memory tail. setup_static_arena grows per region and
+    // short-circuits a request it already covers, so the heap is untouched and a
+    // repeated workload grows the arena once. Growing reallocates, so the base is
+    // re-acquired rather than reused.
+    const int64_t t_sm_ns = bind_now_ns();
+    uint64_t total_heap_size = 0;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        total_heap_size += eff_heap_sizes[r];
+    }
+    // Two device tails past off_copied_end, in this order: the shared-memory image,
+    // then the Graph submission block. Both are per-run content of the region the
+    // device already owns, so neither needs an allocation of its own.
+    const uint64_t off_submissions = layout.off_copied_end + image_bytes;
+    const uint64_t device_arena_bytes = off_submissions + submission_block_bytes;
+    if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, device_arena_bytes) != 0) {
+        LOG_ERROR("host-orch: failed to commit %" PRIu64 " bytes of device runtime arena", device_arena_bytes);
         return -1;
     }
-    record_bind_phase(HostPhaseKind::BindRelocate, t_reloc_ns);
+    device_arena = api->acquire_pooled_runtime_arena();
+    if (device_arena == nullptr) {
+        LOG_ERROR("%s", "host-orch: failed to re-acquire the pooled runtime arena");
+        return -1;
+    }
+    char *arena_dev = static_cast<char *>(device_arena);
+    void *device_sm = arena_dev + layout.off_copied_end;
+    runtime->set_gm_sm_ptr(device_sm);
+    {
+        char attrs[96];
+        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, image_bytes);
+        record_bind_phase(HostPhaseKind::BindSharedMem, t_sm_ns, attrs, image_bytes);
+    }
 
-    // Ship only the live prefix of each segment: the device reads no slot past
-    // total_tasks, so upload header + descriptors[0,N), payloads[0,N),
-    // slot_states[0,N) and completion_flags[0,N) — never the ring-sized tails.
-    // header + descriptors[0,N) are contiguous, so that is a single copy.
-    const uint64_t nt = static_cast<uint64_t>(total_tasks);
-    const uint64_t hdr_desc_bytes = sm_segs.descriptors + nt * sizeof(PTO2TaskDescriptor);
-    char *host_base = static_cast<char *>(host_sm);
-    char *dev_base = static_cast<char *>(device_sm);
-    const int64_t t_sm_h2d_ns = bind_now_ns();
-    if (api->copy_to_device(dev_base, host_base, hdr_desc_bytes) != 0 ||
-        api->copy_to_device(dev_base + sm_segs.payloads, host_base + sm_segs.payloads, nt * sizeof(PTO2TaskPayload)) !=
-            0 ||
-        api->copy_to_device(
-            dev_base + sm_segs.slot_states, host_base + sm_segs.slot_states, nt * sizeof(PTO2TaskSlotState)
-        ) != 0 ||
-        api->copy_to_device(
-            dev_base + sm_segs.completion_flags, host_base + sm_segs.completion_flags, nt * sizeof(std::atomic<uint8_t>)
-        ) != 0) {
-        LOG_ERROR("host-orch: H2D of populated SM failed");
+    // One host source for one copy: the copied zone, the shared-memory image, and
+    // the submission block, at exactly the offsets they occupy on the device.
+    // Over-allocated and rounded up because every segment offset is
+    // PTO2_ALIGN_SIZE-aligned and PTO2TaskSlotState is alignas(64), which a byte
+    // vector's data() is not.
+    const uint64_t copied_bytes = layout.off_copied_end - layout.off_copied_begin;
+    const uint64_t upload_bytes = copied_bytes + image_bytes + submission_block_bytes;
+    std::vector<std::byte> storage(upload_bytes + PTO2_ALIGN_SIZE, std::byte{0});
+    char *upload_base = reinterpret_cast<char *>(
+        (reinterpret_cast<uintptr_t>(storage.data()) + PTO2_ALIGN_SIZE - 1) &
+        ~static_cast<uintptr_t>(PTO2_ALIGN_SIZE - 1)
+    );
+
+    // Before the shared-memory mirror is compacted: this writes each outer task's
+    // graph_context into it, and compaction is what carries those slots.
+    stage_graph_submissions(staged_submissions, upload_base + copied_bytes + image_bytes, arena_dev + off_submissions);
+
+    // The orchestrator has finished, so its pointers into the host-only tail have
+    // no further reader on either side — and this header is about to be copied, so
+    // leaving them would carry host addresses to the device.
+    runtime_clear_host_only_pointers(rt);
+    std::memcpy(upload_base, static_cast<const char *>(host_arena.base()) + layout.off_copied_begin, copied_bytes);
+    const uint64_t compacted = pto2_sm_layout::compact_live_image(
+        static_cast<const char *>(host_sm), eff_task_window_sizes[0], nt, payload_stride, upload_base + copied_bytes
+    );
+    always_assert(compacted == image_bytes);
+
+    const int64_t t_h2d_ns = bind_now_ns();
+    if (api->copy_to_device(arena_dev + layout.off_copied_begin, upload_base, upload_bytes) != 0) {
+        LOG_ERROR("host-orch: H2D of the runtime image failed");
         return -1;
     }
     {
-        const uint64_t sm_h2d_bytes = hdr_desc_bytes + nt * sizeof(PTO2TaskPayload) + nt * sizeof(PTO2TaskSlotState) +
-                                      nt * sizeof(std::atomic<uint8_t>);
         char attrs[96];
-        snprintf(attrs, sizeof(attrs), "nt=%" PRIu64 " bytes=%" PRIu64, nt, sm_h2d_bytes);
-        record_bind_phase(HostPhaseKind::BindSmH2d, t_sm_h2d_ns, attrs, sm_h2d_bytes);
+        snprintf(
+            attrs, sizeof(attrs),
+            "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " subs=%" PRIu64 " pstride=%" PRIu64, nt,
+            upload_bytes, copied_bytes, image_bytes, submission_block_bytes, payload_stride
+        );
+        record_bind_phase(HostPhaseKind::BindArenaH2d, t_h2d_ns, attrs, upload_bytes);
     }
     return total_tasks;
 }
@@ -980,18 +1061,33 @@ extern "C" int bind_callable_to_runtime_impl(
     }
     {
         char attrs[64];
-        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, static_cast<uint64_t>(layout.arena_size));
+        snprintf(
+            attrs, sizeof(attrs), "bytes=%" PRIu64 " device=%" PRIu64, static_cast<uint64_t>(layout.arena_size),
+            static_cast<uint64_t>(layout.device_bytes)
+        );
         record_bind_phase(HostPhaseKind::BindArenaBuild, t_arena_build_ns, attrs);
     }
 
     const int64_t t_static_arena_ns = bind_now_ns();
-    if (api->setup_static_arena(total_heap_size, sm_size, layout.arena_size) != 0) {
+    // Two things this call does not ask for at full size.
+    //
+    // device_bytes, not arena_size: the host-only zone at the arena's tail is
+    // dep-computation scratch no device code reads, so reserving device memory for
+    // it would be dead space for the length of the run.
+    //
+    // No pooled shared memory: hbg's shared-memory image is the tail of its own
+    // runtime-arena region, so this asks for 0 and leaves that pool uncommitted.
+    // The arena is asked for only up to that tail, whose size is the submitted task
+    // count — run_host_orchestration grows it once it knows. The heap must exist
+    // first either way: the orchestrator hands out device heap addresses as it
+    // places tasks.
+    if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, layout.device_bytes) != 0) {
         LOG_ERROR("Failed to setup pooled static arena");
         return -1;
     }
     {
         char attrs[96];
-        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " sm=%" PRIu64, total_heap_size, sm_size);
+        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " arena=%" PRIu64, total_heap_size, layout.device_bytes);
         record_bind_phase(HostPhaseKind::BindStaticArena, t_static_arena_ns, attrs);
     }
 
@@ -1003,15 +1099,10 @@ extern "C" int bind_callable_to_runtime_impl(
         return -1;
     }
     runtime->set_gm_heap(gm_heap);
-
-    const int64_t t_sm_ns = bind_now_ns();
-    void *sm_ptr = api->acquire_pooled_gm_sm();
-    record_bind_phase(HostPhaseKind::BindSharedMem, t_sm_ns);
-    if (sm_ptr == nullptr) {
-        LOG_ERROR("Failed to acquire pooled PTO2 shared memory");
-        return -1;
-    }
-    runtime->set_gm_sm_ptr(sm_ptr);
+    // The shared memory is placed at the end of orchestration, so until then this
+    // bind has no SM. Clearing it keeps a failure before that point from leaving the
+    // previous bind's address for the error-code read to follow.
+    runtime->set_gm_sm_ptr(nullptr);
 
     void *runtime_arena_dev = api->acquire_pooled_runtime_arena();
     if (runtime_arena_dev == nullptr) {
@@ -1033,13 +1124,24 @@ extern "C" int bind_callable_to_runtime_impl(
     // reset) + a handful of device-only field fixups.
     // -------------------------------------------------------------------------
     const int64_t t_runtime_init_ns = bind_now_ns();
-    PTO2Runtime *rt =
-        runtime_init_data_from_layout(host_arena, layout, PTO2_MODE_EXECUTE, sm_ptr, sm_size, gm_heap, eff_heap_sizes);
+    // No SM base: the scheduler and sm_handle are device-written now, so nothing
+    // here stores one, and the region is not even committed yet.
+    PTO2Runtime *rt = runtime_init_data_from_layout(
+        host_arena, layout, PTO2_MODE_EXECUTE, /*sm_dev_base=*/nullptr, sm_size, gm_heap, eff_heap_sizes
+    );
     if (rt == nullptr) {
         LOG_ERROR("runtime_init_data_from_layout failed");
         return -1;
     }
     runtime_wire_arena_pointers(host_arena, layout, rt);
+    runtime_wire_host_only_pointers(host_arena, layout, rt);
+    // Stash the layout inside the PTO2Runtime image so the AICPU can recover every
+    // arena-internal offset after the copy. It is written before orchestration
+    // because orchestration is what performs that copy, and the runtime header is
+    // part of what travels. The runtime arena's device base does NOT travel — it is
+    // on the host Runtime (set_prebuilt_arena below), since the AICPU needs that
+    // pointer before it can dereference the image.
+    rt->prebuilt_layout = layout;
     record_bind_phase(HostPhaseKind::BindRuntimeInit, t_runtime_init_ns);
 
     if (host_orch_func_ptr == nullptr) {
@@ -1050,8 +1152,8 @@ extern "C" int bind_callable_to_runtime_impl(
         ChipTaskArgs orch_l2;
         orch_l2.create_from_chip_args(device_args);
         int32_t total_tasks = run_host_orchestration(
-            runtime, api, tensor_access, rt, host_arena, layout, sm_ptr, sm_size, runtime_arena_dev, gm_heap,
-            eff_heap_sizes, eff_task_window_sizes, host_orch_func_ptr, orch_l2
+            runtime, api, tensor_access, rt, host_arena, layout, sm_size, runtime_arena_dev, gm_heap, eff_heap_sizes,
+            eff_task_window_sizes, host_orch_func_ptr, orch_l2
         );
         // The orchestrator is the only host-view reader; from here the device
         // owns these buffers, so drop the window on both exits.
@@ -1066,41 +1168,19 @@ extern "C" int bind_callable_to_runtime_impl(
         }
         if (total_tasks < 0) {
             LOG_ERROR("host-orch: orchestration run failed");
-            return -1;
+            return total_tasks;
         }
         runtime->host_total_tasks = total_tasks;
         LOG_INFO("host-orch: submitted %d tasks on host", total_tasks);
     }
 
-    // Stash the layout inside the PTO2Runtime image so the AICPU can recover
-    // every arena-internal offset after rtMemcpy. The runtime arena's device
-    // base does NOT travel in this image — it's on the host Runtime
-    // (set_prebuilt_arena below), since the AICPU needs that pointer
-    // *before* it can dereference the image.
-    rt->prebuilt_layout = layout;
-
-    // The arena is partitioned into three zones (see PTO2RuntimeArenaLayout) and
-    // only the middle one is copied: the host-only orchestrator block sits before
-    // it, and the regions the device initializes itself (sm_handle, scheduler
-    // state, queue slot arrays) sit after it. So bind is one copy of one range,
-    // with both bounds taken from the layout rather than inferred from a
-    // reservation order here.
-    const size_t copied_begin = layout.off_copied_begin;
-    const size_t copied_end = layout.off_copied_end;
-    always_assert(copied_begin <= copied_end && copied_end <= layout.arena_size);
-    char *arena_host = static_cast<char *>(host_arena.base());
-    char *arena_dev = static_cast<char *>(runtime_arena_dev);
-    const int64_t t_arena_h2d_ns = bind_now_ns();
-    int rc_upload = api->copy_to_device(arena_dev + copied_begin, arena_host + copied_begin, copied_end - copied_begin);
-    if (rc_upload != 0) {
-        LOG_ERROR("Failed to rtMemcpy prebuilt runtime arena to device (rc=%d)", rc_upload);
+    // Orchestration grew the device region to cover its shared-memory tail, which
+    // reallocates, so the base acquired before it may no longer be the one the
+    // image was copied into.
+    runtime_arena_dev = api->acquire_pooled_runtime_arena();
+    if (runtime_arena_dev == nullptr) {
+        LOG_ERROR("%s", "Failed to re-acquire the pooled runtime arena after orchestration");
         return -1;
-    }
-    {
-        const uint64_t arena_h2d_bytes = static_cast<uint64_t>(copied_end - copied_begin);
-        char attrs[96];
-        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, arena_h2d_bytes);
-        record_bind_phase(HostPhaseKind::BindArenaH2d, t_arena_h2d_ns, attrs, arena_h2d_bytes);
     }
     runtime->set_prebuilt_arena(runtime_arena_dev, layout.off_runtime);
 

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -786,11 +786,22 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     definition.tensor_arg_count = static_cast<uint32_t>(tensors.size());
     definition.scalar_arg_count = static_cast<uint32_t>(scalars.size());
     definition.predicate_count = static_cast<uint32_t>(predicates.size());
+    // The widest node sets the stride every entry of this Definition's execution
+    // storage gets; nodes[] carries each node's declared tensor count.
+    int32_t widest_node_tensor_count = 0;
+    for (const GraphNodeDefinition &node : nodes) {
+        if (node.tensor_count > widest_node_tensor_count) widest_node_tensor_count = node.tensor_count;
+    }
+    const size_t node_stride = graph_node_stride(widest_node_tensor_count);
     size_t execution_storage_bytes = 0;
-    if (!graph_execution_storage_bytes(static_cast<int32_t>(definition.task_count), &execution_storage_bytes) ||
+    if (node_stride > UINT32_MAX ||
+        !graph_execution_storage_bytes(
+            static_cast<int32_t>(definition.task_count), node_stride, &execution_storage_bytes
+        ) ||
         execution_storage_bytes > UINT32_MAX) {
         return false;
     }
+    definition.node_stride = static_cast<uint32_t>(node_stride);
     definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
     // Every section's byte count is known now, so the image grows once instead of
     // resizing eleven times. Each append aligns its start, hence the per-section
@@ -1384,9 +1395,9 @@ static TaskOutputTensors submit_task_common(
     // push_ready_routed; otherwise the returned index selects the producer passed
     // to register_wake. Wake retargeting in register_wake may reclassify a task
     // when the selected producer is already complete.
-    // The initial scan happens before the scheduler dispatch loop starts. Because
-    // fanin is a flat array of position-independent integers, none of this needs
-    // host->device pointer relocation.
+    // The initial scan happens before the scheduler dispatch loop starts. Fanin is
+    // a flat array of position-independent integers, so it crosses to the device
+    // unchanged.
     payload.fanin_count = fanin_builder.count;
     (void)sched;
 
@@ -1594,6 +1605,14 @@ bool graph_submit_outer(
     PTO2TaskPayload &payload = ring.task_payloads[allocation.slot];
     PTO2TaskSlotState &slot = ring.get_slot_state_by_slot(allocation.slot);
 
+    // Init-on-write, as in prepare_task: this slot's dynamic scheduling fields and
+    // completion flag are established here, at the claim, because nothing else
+    // writes them. A stale wake_list_head of WAKE_LIST_SENTINEL would close the
+    // list against every consumer, and a stale completion flag would report the
+    // Graph done before it ran.
+    slot.reset_for_reuse();
+    ring.completion_flags[allocation.slot].store(0, std::memory_order_relaxed);
+
     slot.bind_buffers(&payload, &task);
     slot.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
     slot.last_consumer_local_id = static_cast<int32_t>(task_id.local());
@@ -1602,7 +1621,6 @@ bool graph_submit_outer(
     slot.total_required_subtasks = 0;
     slot.logical_block_num = 1;
     slot.task_kind = TaskKind::GRAPH;
-    slot.graph_context = nullptr;
     scope_tasks_push(orch, &slot);
 
     task.task_id = task_id;

--- a/src/a2a3/runtime/host_build_graph/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto2_dispatch_payload.h
@@ -67,9 +67,11 @@ static_assert(
 // PTO2TaskPayload layout drift fails the build rather than corrupting args[].
 constexpr uint32_t PTO2_TASKPAYLOAD_TENSOR_COUNT_OFFSET = 0;
 constexpr uint32_t PTO2_TASKPAYLOAD_SCALAR_COUNT_OFFSET = 4;
-// Cache line 9 (byte 576) holds the AICPU-only DispatchPredicate; tensors follow it.
-constexpr uint32_t PTO2_TASKPAYLOAD_TENSORS_OFFSET = 640;
-constexpr uint32_t PTO2_TASKPAYLOAD_SCALARS_OFFSET = 4736;
+// Cache line 9 (byte 576) holds the AICPU-only DispatchPredicate. Scalars follow it,
+// then tensors — the tensor array is last because it is the only region whose used
+// extent varies per task, so a task's read set is a contiguous prefix.
+constexpr uint32_t PTO2_TASKPAYLOAD_SCALARS_OFFSET = 640;
+constexpr uint32_t PTO2_TASKPAYLOAD_TENSORS_OFFSET = 768;
 constexpr uint32_t PTO2_TASKPAYLOAD_TENSOR_STRIDE = 128;  // sizeof(ChipTensor)
 
 /**

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -120,23 +120,36 @@ struct PTO2RuntimeArenaLayout {
     size_t off_scheduler{0};
     size_t off_runtime{0};
     size_t off_mailbox{0};
-    // The arena is reserved in three zones and the offsets above land in exactly
-    // one of them:
+    // The arena is reserved in zones, in this order, and the offsets above land in
+    // exactly one of them:
     //
-    //   host-only    the orchestrator block. Dep-computation scratch the AICPU
-    //                never reads, so it is never copied.
+    //   device-only  sm_handle, the AICore mailbox, the scheduler state and its
+    //                queue slot arrays. Reachable storage whose content is a
+    //                function of the layout, not of the run, so the device writes
+    //                it at boot instead of receiving an initialization pattern
+    //                over PCIe.
     //   copied       [off_copied_begin, off_copied_end). Every byte carries this
     //                run's own content, so bind ships the whole zone as one
     //                contiguous range.
-    //   device-only  sm_handle, the scheduler state and its queue slot arrays.
-    //                Reachable storage whose content is a function of the layout,
-    //                not of the run, so the device writes it at boot instead of
-    //                receiving an initialization pattern over PCIe.
     //
-    // Placing the copied zone in the middle is what keeps the upload a single
-    // range: the two zones that are not copied sit on either side of it.
+    // off_copied_end is where the shared part of the layout stops. Past it the two
+    // sides carry different tails, and neither reads the other's:
+    //
+    //   host tail    the orchestrator block. Dep-computation scratch no device code
+    //                reads, so it is neither copied nor allocated on the device.
+    //   device tail  the shared-memory image, whose size is the submitted task
+    //                count and therefore not known when this layout is built. bind
+    //                grows the device region to cover it once orchestration ends.
+    //
+    // The copied zone is padded to a PTO2_ALIGN_SIZE boundary, so the device tail
+    // begins exactly at off_copied_end: the copied zone and the shared-memory image
+    // are adjacent on the device and travel as one copy.
     size_t off_copied_begin{0};
     size_t off_copied_end{0};
+
+    // Byte length of the device region before its shared-memory tail. The host
+    // arena is arena_size, which instead covers the orchestrator block there.
+    size_t device_bytes{0};
 
     // Cached parameters (re-used by init_data + wire stages).
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]{};
@@ -243,15 +256,33 @@ PTO2Runtime *runtime_init_data_from_layout(
 );
 
 /**
- * Phase 3 — wire every arena-internal pointer field (rt->sm_handle,
- * rt->aicore_mailbox, orchestrator.{scope_tasks, scope_begins, scheduler,
- * tensor_map.*, ring.fanin_pool.base}, scheduler.{ready_queues,
- * ready_sync_queues, early_dispatch_queues, dep_pool}) so each holds
- * arena.base() + offset. Idempotent — runs on
- * both host (writing host-mirror addresses) and AICPU (writing device
- * addresses) sides.
+ * Phase 3 — wire the arena-internal pointer fields that exist on both sides
+ * (rt->sm_handle, rt->aicore_mailbox, rt->scheduler and
+ * scheduler.{ready_queues, ready_sync_queues, early_dispatch_queues}) so each
+ * holds arena.base() + offset. Idempotent — runs on both host (writing
+ * host-mirror addresses) and AICPU (writing device addresses) sides.
  */
 void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
+
+/**
+ * Phase 3b — wire the orchestrator's pointers into the host-only zone
+ * (orchestrator.{scope_tasks, scope_begins, scheduler, tensor_map.*,
+ * ring.fanin_pool.base}).
+ *
+ * Host-only by construction: that zone is past layout.device_bytes and so is not
+ * allocated on the device, which makes the addresses this writes unrepresentable
+ * there. Requires rt->scheduler, so it follows runtime_wire_arena_pointers.
+ */
+void runtime_wire_host_only_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
+
+/**
+ * Drop the pointers Phase 3b wrote, so the runtime header can be copied to the
+ * device without carrying host addresses into it. The device reads one
+ * orchestrator field, inline_completed_tasks, which this leaves alone.
+ *
+ * Call after orchestration finishes and before the copied zone is uploaded.
+ */
+void runtime_clear_host_only_pointers(PTO2Runtime *rt);
 
 /**
  * AICPU-only Phase 4 — fill in the few fields the host could not know at

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -22,14 +22,14 @@
  * Based on: docs/RUNTIME_LOGIC.md
  */
 
-#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_RUNTIME2_TYPES_H_
-#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_RUNTIME2_TYPES_H_
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #include <atomic>
+#include <cstddef>
 
 #include "profiling_config.h"
 #include "pto_constants.h"
@@ -332,10 +332,18 @@ struct PTO2TaskPayload {
     // dispatch.
     alignas(64) DispatchPredicate predicate;
     ArgsDumpTaskMetadata dump_metadata;
-    // === Cache lines 10-73 (4096B) — tensors (alignas(64) forces alignment) ===
+    // === Cache lines 10-11 (128B) — scalars ===
+    // alignas is load-bearing: the AICore reads this at a compile-time offset, and
+    // uint64_t alone would let it start right after dump_metadata instead of on the
+    // next cache line. tensors got its 640 for free from ChipTensor's own alignment.
+    alignas(64) uint64_t scalars[MAX_SCALAR_ARGS];
+    // === Cache lines 12-75 (4096B) — tensors (alignas(64) forces alignment) ===
+    //
+    // Last on purpose. This is the only region whose used extent varies per task —
+    // one to seventeen entries of thirty-two on a measured decode — so putting it at
+    // the end makes everything a task reads a contiguous prefix, which is what lets
+    // the shipped image carry less than the whole array.
     ChipTensor tensors[MAX_TENSOR_ARGS];
-    // === Cache lines 74-75 (128B) — scalars ===
-    uint64_t scalars[MAX_SCALAR_ARGS];
 
     // Layout verification (size checks that don't need offsetof).
     static_assert(sizeof(ChipTensor) == 128, "ChipTensor must be 2 cache lines");
@@ -432,23 +440,93 @@ struct PTO2TaskPayload {
 static_assert(offsetof(PTO2TaskPayload, fanin_local_ids) == 12, "inline fanin id array must follow fanin_count");
 static_assert(
     offsetof(PTO2TaskPayload, predicate) == 576,
-    "dispatch predicate occupies cache line 9 at fixed byte 576 (before tensors, never moves)"
+    "dispatch predicate occupies cache line 9 at fixed byte 576 (before the arg arrays, never moves)"
 );
 static_assert(
     offsetof(PTO2TaskPayload, dump_metadata) + sizeof(ArgsDumpTaskMetadata) <= 640,
-    "dump metadata must fit in the AICPU-only cache line before tensors"
+    "dump metadata must fit in the AICPU-only cache line before the arg arrays"
 );
 static_assert(
-    offsetof(PTO2TaskPayload, tensors) == 640, "tensors must start at byte 640 (cache line 10, after predicate)"
+    offsetof(PTO2TaskPayload, scalars) == 640, "scalars must start at byte 640 (cache line 10, after predicate)"
 );
 static_assert(
-    offsetof(PTO2TaskPayload, scalars) == 640 + MAX_TENSOR_ARGS * sizeof(ChipTensor),
-    "scalars must immediately follow tensors"
+    offsetof(PTO2TaskPayload, tensors) == 640 + MAX_SCALAR_ARGS * sizeof(uint64_t),
+    "tensors must immediately follow scalars, and must be the last region: the shipped "
+    "image carries only as much of the array as a task uses, so nothing may sit past it"
 );
 static_assert(
-    sizeof(PTO2TaskPayload) == 640 + MAX_TENSOR_ARGS * sizeof(ChipTensor) + MAX_SCALAR_ARGS * sizeof(uint64_t),
-    "PTO2TaskPayload size = metadata(576) + predicate cache line(64) + tensors + scalars"
+    sizeof(PTO2TaskPayload) == 640 + MAX_SCALAR_ARGS * sizeof(uint64_t) + MAX_TENSOR_ARGS * sizeof(ChipTensor),
+    "PTO2TaskPayload size = metadata(576) + predicate cache line(64) + scalars + tensors"
 );
+
+/**
+ * A pointer to a sibling in the same contiguous block, stored as a byte delta
+ * from the field's own address.
+ *
+ * The block is `memcpy`'d to the device as one image, so a delta between two
+ * addresses inside it is invariant under the move while a raw pointer is not.
+ * Both users below satisfy that precondition: a ring task's payload and
+ * descriptor live in the same shared-memory image as its slot state, and a Graph
+ * node's live in the same GraphNodeStorage.
+ *
+ * A zero delta means unbound — a field can never coincide with its own target.
+ * Zeroed memory therefore reads as null, which is what the slot's pristine state
+ * is.
+ *
+ * int32_t bounds the distance at 2 GiB. Both blocks are far below it — a
+ * GraphNodeStorage is a fixed struct, and the shared-memory image's end is
+ * rejected above the bound in attach_populated — and set() leaves the field
+ * unbound rather than storing a truncated delta, so an out-of-range target
+ * reads back as null instead of as unrelated memory.
+ */
+namespace simpler::hbg {
+
+template <typename T>
+class SelfRelativePtr {
+public:
+    SelfRelativePtr() = default;
+
+    // The stored value means something only relative to where it is stored, so
+    // copying it from another field would silently retarget it. Every write goes
+    // through set(), which takes the destination's own address into account. A
+    // whole-block memcpy is unaffected: it moves the field and its target
+    // together, which is the case this representation exists for.
+    SelfRelativePtr(const SelfRelativePtr &) = delete;
+    SelfRelativePtr &operator=(const SelfRelativePtr &) = delete;
+
+    T *get() const {
+        if (delta_ == 0) return nullptr;
+        return reinterpret_cast<T *>(reinterpret_cast<uintptr_t>(this) + static_cast<intptr_t>(delta_));
+    }
+
+    void set(T *target) {
+        if (target == nullptr) {
+            delta_ = 0;
+            return;
+        }
+        const intptr_t delta = reinterpret_cast<intptr_t>(target) - reinterpret_cast<intptr_t>(this);
+        // Narrowing a delta this large would name unrelated memory that a consumer
+        // would then dereference. Unbound is the one value every consumer already
+        // tests for.
+        if (delta < INT32_MIN || delta > INT32_MAX) {
+            delta_ = 0;
+            return;
+        }
+        delta_ = static_cast<int32_t>(delta);
+    }
+
+    T *operator->() const { return get(); }
+    T &operator*() const { return *get(); }
+    explicit operator bool() const { return delta_ != 0; }
+
+    friend bool operator==(const SelfRelativePtr &lhs, std::nullptr_t) { return lhs.delta_ == 0; }
+    friend bool operator!=(const SelfRelativePtr &lhs, std::nullptr_t) { return lhs.delta_ != 0; }
+
+private:
+    int32_t delta_{0};
+};
+
+}  // namespace simpler::hbg
 
 /**
  * Per-task slot scheduling state (scheduler-private, NOT in shared memory)
@@ -478,8 +556,10 @@ struct alignas(64) PTO2TaskSlotState {
     std::atomic<PTO2TaskState> task_state;
 
     // --- Per-slot constant, re-bound by orch::prepare_task each submit ---
-    PTO2TaskPayload *payload;
-    PTO2TaskDescriptor *task;
+    // Self-relative, so the SM image needs no pointer fix-up on its way to the
+    // device: both targets sit in the same block as this field.
+    simpler::hbg::SelfRelativePtr<PTO2TaskPayload> payload;
+    simpler::hbg::SelfRelativePtr<PTO2TaskDescriptor> task;
 
     // --- Wake list: last-fanin notification (intrusive, lock-free) ---
     // A pending consumer whose fanin scan finds an unmet producer registers on
@@ -538,8 +618,8 @@ struct alignas(64) PTO2TaskSlotState {
     }
 
     void bind_buffers(PTO2TaskPayload *p, PTO2TaskDescriptor *t) {
-        payload = p;
-        task = t;
+        payload.set(p);
+        task.set(t);
     }
 
     // Host-visible completion mirror. The device readiness truth
@@ -582,5 +662,3 @@ static_assert(sizeof(PTO2TaskSlotState) == 64);
 // Sentinel marking a wake list as "owner already completed; no more
 // registrations accepted". Distinct from any real slot_state pointer.
 inline PTO2TaskSlotState *const WAKE_LIST_SENTINEL = reinterpret_cast<PTO2TaskSlotState *>(static_cast<uintptr_t>(0x1));
-
-#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_RUNTIME2_TYPES_H_

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_shared_memory.h
@@ -34,6 +34,8 @@
 
 #include <stddef.h>
 
+#include <cstring>
+
 #include "utils/device_arena.h"
 #include "pto_runtime2_types.h"
 
@@ -143,9 +145,11 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
         return task_descriptors[get_slot_by_task_id(local_id)];
     }
 
-    PTO2TaskPayload &get_payload_by_slot(int32_t slot) { return task_payloads[slot]; }
-
-    PTO2TaskPayload &get_payload_by_task_id(int32_t local_id) { return task_payloads[get_slot_by_task_id(local_id)]; }
+    // No get_payload_by_slot / get_payload_by_task_id here on purpose: the shipped
+    // image strides its payload array by the widest task in the bind, not by
+    // sizeof(PTO2TaskPayload), so indexing it as an array of the type would land
+    // between payloads. A payload is reached through its slot state's `payload`,
+    // which the image's restack rebinds to the real address.
 
     PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
@@ -240,7 +244,17 @@ struct PTO2SharedMemoryHandle {
     // Used by host_build_graph host-orch, where the host orchestrator populated
     // the SM and H2D'd it; the device must re-point at its own SM base without
     // wiping the contents (unlike init_per_ring, which also resets the header).
-    bool attach_populated(void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
+    //
+    // `live_slots` is the pitch the uploaded arrays were laid out with — the
+    // number of slots the host actually submitted, not the ring capacity. It must
+    // match what the host used or every segment past the descriptors resolves to
+    // the wrong address, so both sides derive it from the same submitted count.
+    // The capacity and mask in the header are unchanged, and `local_id & mask`
+    // yields `local_id`, which is below `live_slots` for every ring task.
+    bool attach_populated(
+        void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t live_slots,
+        uint64_t payload_stride
+    );
 
     void destroy();
     void print_layout();
@@ -252,7 +266,13 @@ private:
         const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
     );
     void setup_pointers(uint64_t task_window_size);
-    void setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
+    // `pitch` is the slot count the arrays are dimensioned for. init_per_ring
+    // passes the ring capacity (the mirror the orchestrator writes into);
+    // attach_populated passes the submitted count (the compacted image that
+    // shipped).
+    void setup_pointers_per_ring(
+        const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch, uint64_t payload_stride
+    );
 };
 
 // =============================================================================
@@ -293,6 +313,17 @@ inline std::atomic<int32_t> *ring_current_task_index_addr(void *sm_dev_base) noe
 // Byte offsets (from the SM base) of the ring's three segments. The layout is:
 // header, then descriptors -> payloads -> slot_states, every segment
 // PTO2_ALIGN_UP-padded.
+//
+// Two parameters, and the host mirror and the shipped image differ in both.
+//
+// The *pitch* is how many slots the arrays are dimensioned for: the mirror uses the
+// ring capacity, the image uses the submitted count, which is what makes the four
+// live prefixes contiguous and the upload one copy.
+//
+// The *payload stride* is how far apart consecutive payloads sit. The mirror uses
+// sizeof(PTO2TaskPayload), whose tensor array is dimensioned for the widest task the
+// API allows. The image uses the widest task in this bind — the array is the last
+// field, so anything past that task's entries is read by nobody.
 struct PTO2RingSegmentOffsets {
     uint64_t descriptors;
     uint64_t payloads;
@@ -307,13 +338,14 @@ struct PTO2RingSegmentOffsets {
 // `sm_dev_base`). Adding or reordering a segment is a one-line edit here; every
 // consumer follows automatically, so the layout walk can never silently
 // disagree across call sites.
-inline PTO2RingSegmentOffsets ring_segment_offsets(uint64_t task_window_size) noexcept {
+inline PTO2RingSegmentOffsets
+ring_segment_offsets(uint64_t task_window_size, uint64_t payload_stride = sizeof(PTO2TaskPayload)) noexcept {
     uint64_t off = PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
     PTO2RingSegmentOffsets o{};
     o.descriptors = off;
     off += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
     o.payloads = off;
-    off += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
+    off += PTO2_ALIGN_UP(task_window_size * payload_stride, PTO2_ALIGN_SIZE);
     o.slot_states = off;
     off += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
     o.completion_flags = off;
@@ -322,25 +354,84 @@ inline PTO2RingSegmentOffsets ring_segment_offsets(uint64_t task_window_size) no
     return o;
 }
 
-// Device address of the task_descriptors array.
-inline PTO2TaskDescriptor *ring_task_descriptors_addr(void *sm_dev_base, uint64_t task_window_size) noexcept {
-    return reinterpret_cast<PTO2TaskDescriptor *>(
-        static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_size).descriptors
-    );
+// The pitch the shipped image uses for a given submitted task count. A bind that
+// submits nothing still ships its header and still attaches, and a zero-length
+// array has no layout, so the pitch never drops below one slot.
+inline uint64_t live_slot_pitch(uint64_t submitted_tasks) noexcept {
+    return submitted_tasks == 0 ? 1 : submitted_tasks;
 }
 
-// Device address of the slot_states array used by host/device pointer wiring.
-inline PTO2TaskSlotState *ring_slot_states_addr(void *sm_dev_base, uint64_t task_window_size) noexcept {
-    return reinterpret_cast<PTO2TaskSlotState *>(
-        static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_size).slot_states
-    );
+// The stride a shipped payload array uses for a given widest task. The tensor array
+// is the payload's last field, so a task reads nothing past its own entries and the
+// stride need only cover them — but every payload in the image shares one stride, so
+// it is the widest task that sets it.
+//
+// Rounded up to PTO2_ALIGN_SIZE because PTO2TaskPayload's own alignment is 64 and the
+// image places consecutive payloads at multiples of the stride.
+inline uint64_t shipped_payload_stride(int32_t widest_tensor_count) noexcept {
+    constexpr uint64_t kTensorsOffset = offsetof(PTO2TaskPayload, tensors);
+    const uint64_t used = static_cast<uint64_t>(widest_tensor_count < 0 ? 0 : widest_tensor_count) * sizeof(ChipTensor);
+    const uint64_t stride = PTO2_ALIGN_UP(kTensorsOffset + used, PTO2_ALIGN_SIZE);
+    return stride > sizeof(PTO2TaskPayload) ? sizeof(PTO2TaskPayload) : stride;
 }
 
-// Device address of the polling completion_flags byte array.
-inline std::atomic<uint8_t> *ring_completion_flags_addr(void *sm_dev_base, uint64_t task_window_size) noexcept {
-    return reinterpret_cast<std::atomic<uint8_t> *>(
-        static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_size).completion_flags
-    );
+// Restack the live prefix of every ring segment from the ring-pitched mirror the
+// orchestrator wrote into an image pitched to `submitted_tasks`, where the four
+// prefixes are contiguous and can travel as one copy.
+//
+// `out_base` must be PTO2_ALIGN_SIZE-aligned and hold
+// `ring_segment_offsets(live_slot_pitch(submitted_tasks)).end` bytes. Returns that
+// byte count.
+//
+// Two things the restack has to fix up, both because the image is not the mirror:
+//
+//   - the ring header's data pointers name the mirror's arrays, so they leave as
+//     null rather than carrying host addresses into device memory (the device
+//     resolves them in attach_populated);
+//   - a slot state names its payload and descriptor by a delta from its own
+//     address, and the restack changed those distances, so each binding is
+//     re-taken against the image.
+inline uint64_t compact_live_image(
+    const char *mirror_base, uint64_t task_window_size, uint64_t submitted_tasks, uint64_t payload_stride,
+    char *out_base
+) noexcept {
+    // The mirror is pitched to the capacity and to the type, so a larger live count
+    // or a wider stride reads past the segment it is copying from and ships a corrupt
+    // image. attach_populated tests the same two bounds on the device side.
+    always_assert(submitted_tasks <= task_window_size);
+    always_assert(payload_stride <= sizeof(PTO2TaskPayload));
+    const PTO2RingSegmentOffsets from = ring_segment_offsets(task_window_size);
+    const PTO2RingSegmentOffsets to = ring_segment_offsets(live_slot_pitch(submitted_tasks), payload_stride);
+
+    // The header and the descriptors offset are pitch-independent, so the header
+    // lands where it already was.
+    std::memcpy(out_base, mirror_base, to.descriptors);
+    auto &out_ring = reinterpret_cast<PTO2SharedMemoryHeader *>(out_base)->ring;
+    out_ring.task_descriptors = nullptr;
+    out_ring.task_payloads = nullptr;
+    out_ring.slot_states = nullptr;
+    out_ring.completion_flags = nullptr;
+
+    const uint64_t nt = submitted_tasks;
+    std::memcpy(out_base + to.descriptors, mirror_base + from.descriptors, nt * sizeof(PTO2TaskDescriptor));
+    // Per payload, because the source and destination strides differ: the mirror is
+    // pitched to the type, the image to the widest task in this bind.
+    for (uint64_t i = 0; i < nt; ++i) {
+        std::memcpy(
+            out_base + to.payloads + i * payload_stride, mirror_base + from.payloads + i * sizeof(PTO2TaskPayload),
+            payload_stride
+        );
+    }
+    std::memcpy(out_base + to.slot_states, mirror_base + from.slot_states, nt * sizeof(PTO2TaskSlotState));
+    std::memcpy(out_base + to.completion_flags, mirror_base + from.completion_flags, nt * sizeof(std::atomic<uint8_t>));
+
+    auto *out_slots = reinterpret_cast<PTO2TaskSlotState *>(out_base + to.slot_states);
+    auto *out_descriptors = reinterpret_cast<PTO2TaskDescriptor *>(out_base + to.descriptors);
+    for (uint64_t i = 0; i < nt; ++i) {
+        auto *out_payload = reinterpret_cast<PTO2TaskPayload *>(out_base + to.payloads + i * payload_stride);
+        out_slots[i].bind_buffers(out_payload, &out_descriptors[i]);
+    }
+    return to.end;
 }
 
 }  // namespace pto2_sm_layout

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -174,6 +174,13 @@ public:
     // the boot thread reads this instead of counting SM ring heads.
     int32_t host_total_tasks;
 
+    // Distance between consecutive payloads in the shipped shared-memory image.
+    // Smaller than sizeof(PTO2TaskPayload) whenever the bind's widest task uses
+    // fewer tensors than the array holds, which is the usual case. Set by the host
+    // before the image is copied; the AICPU needs it at attach to place every
+    // segment that follows the payload array.
+    uint64_t sm_payload_stride;
+
 private:
     // Kernel binary tracking for cleanup
 

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -906,7 +906,7 @@ struct PTO2SchedulerState {
         const uint32_t end = execution.fanin_offsets[node_index + 1];
         for (uint32_t edge = begin; edge < end; ++edge) {
             const uint16_t producer_index = execution.fanin_indices[edge];
-            const PTO2TaskSlotState &producer = execution.nodes[producer_index].slot;
+            const PTO2TaskSlotState &producer = execution.node_at(producer_index).slot;
             if (producer.task_state.load(std::memory_order_acquire) != PTO2_TASK_COMPLETED) {
                 return static_cast<int32_t>(producer_index);
             }
@@ -934,7 +934,7 @@ struct PTO2SchedulerState {
                 push_ready_routed(consumer);
                 return;
             }
-            producer = &execution.nodes[unmet_producer].slot;
+            producer = &execution.node_at(unmet_producer).slot;
         }
     }
 
@@ -947,7 +947,7 @@ struct PTO2SchedulerState {
             if (unmet_producer < 0) {
                 push_ready_routed(waiter);
             } else {
-                register_graph_wake(execution, &execution.nodes[unmet_producer].slot, waiter);
+                register_graph_wake(execution, &execution.node_at(unmet_producer).slot, waiter);
             }
             consumers_rescanned++;
             waiter = next;
@@ -978,7 +978,7 @@ struct PTO2SchedulerState {
                 continue;
             }
             if (execution.fanin_offsets[i] == execution.fanin_offsets[i + 1]) {
-                push_ready_routed(&execution.node_storage[i].slot);
+                push_ready_routed(&execution.node_at(i).slot);
                 routed++;
             }
         }
@@ -996,12 +996,12 @@ struct PTO2SchedulerState {
     void graph_incremental_publish(GraphExecution &execution, int32_t first, int32_t last) {
         for (int32_t i = first; i < last; ++i) {
             if (execution.fanin_offsets[i] == execution.fanin_offsets[i + 1]) continue;  // root
-            PTO2TaskSlotState &node = execution.node_storage[i].slot;
+            PTO2TaskSlotState &node = execution.node_at(i).slot;
             const int32_t unmet = graph_first_unmet_producer(execution, node);
             if (unmet < 0) {
                 push_ready_routed(&node);
             } else {
-                register_graph_wake(execution, &execution.nodes[unmet].slot, &node);
+                register_graph_wake(execution, &execution.node_at(unmet).slot, &node);
             }
         }
         execution.published_nodes.store(last, std::memory_order_release);

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -322,21 +322,26 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
         layout.heap_sizes[r] = heap_sizes[r];
     }
 
-    // Reservation order is the zone partition (see PTO2RuntimeArenaLayout): the
-    // host-only orchestrator block, then the one copied range, then everything
-    // the device initializes itself. Each zone is contiguous, so bind is a single
-    // copy and no consumer has to infer a boundary from what happens to come
-    // first.
-    layout.orch = PTO2OrchestratorState::reserve_layout(arena, static_cast<int32_t>(task_window_sizes[0]));
-
-    layout.off_copied_begin = arena.total_size();
-    layout.off_runtime = arena.reserve(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE);
-    layout.off_copied_end = arena.total_size();
-
+    // Reservation order is the zone partition (see PTO2RuntimeArenaLayout):
+    // everything the device initializes itself, then the one copied range. Each
+    // zone is contiguous, so bind is a single copy and no consumer has to infer a
+    // boundary from what happens to come first.
+    //
+    // The copied zone comes last of the two so the device's shared-memory tail can
+    // begin where it ends, making the two adjacent and the upload one copy.
     layout.off_sm_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
     layout.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
     layout.off_scheduler = arena.reserve(sizeof(PTO2SchedulerState), alignof(PTO2SchedulerState));
     layout.sched = PTO2SchedulerState::reserve_layout(arena);
+
+    layout.off_copied_begin = arena.total_size();
+    // Padded to a PTO2_ALIGN_SIZE boundary: the shared-memory image starts at
+    // off_copied_end on the device and its segment offsets are aligned from there.
+    layout.off_runtime = arena.reserve(PTO2_ALIGN_UP(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE), PTO2_ALIGN_SIZE);
+    layout.off_copied_end = arena.total_size();
+
+    layout.device_bytes = arena.total_size();
+    layout.orch = PTO2OrchestratorState::reserve_layout(arena, static_cast<int32_t>(task_window_sizes[0]));
 
     layout.arena_size = arena.total_size();
     return layout;
@@ -360,9 +365,8 @@ PTO2Runtime *runtime_init_data_from_layout(
  * and initializes the scheduler (ready / sync / dummy / graph queues) against
  * the device SM. The orchestrator is deliberately left zeroed: the host-orch
  * path (run_host_orchestration) initializes it against the host SM once that
- * buffer exists, then relocates it for the device. Initializing it here would
- * be dead work — overwritten by that re-init, and the orchestrator arena block
- * is never uploaded to the device. Caller must follow up with
+ * buffer exists. Initializing it here would be dead work — overwritten by that
+ * re-init, and the orchestrator arena block is never uploaded to the device. Caller must follow up with
  * runtime_wire_arena_pointers. Returns the arena-resident PTO2Runtime*, or
  * nullptr on failure.
  */
@@ -388,10 +392,10 @@ PTO2Runtime *runtime_init_data_from_layout(
     // Two components are deliberately not initialized here.
     //
     // The orchestrator is initialized by the host-orch path
-    // (run_host_orchestration) against the host SM once it is allocated, then
-    // relocated for the device. Doing it here would be dead work: its arena
-    // content (tensormap + seen_epoch memset) is immediately overwritten by that
-    // re-init, and the orchestrator block is host-only anyway.
+    // (run_host_orchestration) against the host SM once it is allocated. Doing it
+    // here would be dead work: its arena content (tensormap + seen_epoch memset)
+    // is immediately overwritten by that re-init, and the orchestrator block is
+    // host-only anyway.
     //
     // The scheduler and sm_handle live in the device-only zone, so their bytes
     // never travel; the AICPU initializes them at boot. Writing them here would
@@ -405,9 +409,14 @@ void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayou
     rt->sm_handle = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(layout.off_sm_handle));
     rt->aicore_mailbox = static_cast<AICoreCompletionMailbox *>(arena.region_ptr(layout.off_mailbox));
     rt->scheduler = static_cast<PTO2SchedulerState *>(arena.region_ptr(layout.off_scheduler));
-    rt->orchestrator.wire_arena_pointers(layout.orch, arena, rt->scheduler);
     rt->scheduler->wire_arena_pointers(layout.sched, arena);
 }
+
+void runtime_wire_host_only_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt) {
+    rt->orchestrator.wire_arena_pointers(layout.orch, arena, rt->scheduler);
+}
+
+void runtime_clear_host_only_pointers(PTO2Runtime *rt) { rt->orchestrator.destroy(); }
 
 void runtime_destroy(PTO2Runtime *rt, DeviceArena & /*arena*/) {
     // Arena buffer is pooled across runs by DeviceRunner — never freed here.

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
@@ -45,14 +45,17 @@ uint64_t PTO2SharedMemoryHandle::calculate_size_per_ring(const uint64_t task_win
 // Creation and Destruction
 // =============================================================================
 
-void PTO2SharedMemoryHandle::setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+void PTO2SharedMemoryHandle::setup_pointers_per_ring(
+    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch, uint64_t payload_stride
+) {
+    (void)task_window_sizes;
     char *base = (char *)sm_base;
     header = (PTO2SharedMemoryHeader *)base;
 
     // Per-ring descriptors / payloads / slot_states — offsets from the single
     // source of truth (pto2_sm_layout::ring_segment_offsets), so this setup and
     // the device-address helpers cannot drift.
-    auto off = pto2_sm_layout::ring_segment_offsets(task_window_sizes[0]);
+    auto off = pto2_sm_layout::ring_segment_offsets(pitch, payload_stride);
     auto &ring = header->ring;
     ring.task_descriptors = (PTO2TaskDescriptor *)(base + off.descriptors);
     ring.task_payloads = (PTO2TaskPayload *)(base + off.payloads);
@@ -65,7 +68,7 @@ void PTO2SharedMemoryHandle::setup_pointers(uint64_t task_window_size) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
     }
-    setup_pointers_per_ring(task_window_sizes);
+    setup_pointers_per_ring(task_window_sizes, task_window_size, sizeof(PTO2TaskPayload));
 }
 
 bool PTO2SharedMemoryHandle::init(
@@ -90,21 +93,36 @@ bool PTO2SharedMemoryHandle::init_per_ring(
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers_per_ring(task_window_sizes);
+    setup_pointers_per_ring(task_window_sizes, task_window_sizes[0], sizeof(PTO2TaskPayload));
     init_header_per_ring(task_window_sizes, heap_sizes);
     return true;
 }
 
 bool PTO2SharedMemoryHandle::attach_populated(
-    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t live_slots,
+    uint64_t payload_stride
 ) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
-    if (sm_size_arg < calculate_size_per_ring(task_window_sizes)) return false;
+    // A pitch above the capacity would name a slot the ring cannot address, and one
+    // below what the host used would place every segment past the descriptors
+    // short. This is the whole contract between the two sides, checked once at
+    // attach rather than trusted.
+    if (live_slots == 0 || live_slots > task_window_sizes[0]) return false;
+    // A stride past the type's size would read between payloads; one below the
+    // tensor array's own offset could not hold a payload's fixed head at all.
+    if (payload_stride > sizeof(PTO2TaskPayload) || payload_stride < offsetof(PTO2TaskPayload, tensors)) return false;
+    // The region holds the compacted image, so that is what has to fit — the ring
+    // capacity is no longer its size.
+    const uint64_t image_end = pto2_sm_layout::ring_segment_offsets(live_slots, payload_stride).end;
+    if (sm_size_arg < image_end) return false;
+    // A slot state names its payload and descriptor by an int32 delta from its own
+    // address, so no two positions in the image may be further apart than that.
+    if (image_end > static_cast<uint64_t>(INT32_MAX)) return false;
 
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers_per_ring(task_window_sizes);
+    setup_pointers_per_ring(task_window_sizes, live_slots, payload_stride);
     // Deliberately NO init_header_per_ring: the SM already holds the host
     // orchestrator's task graph (descriptors, slot states, ring counters).
     return true;

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/runtime.cpp
@@ -35,6 +35,7 @@ Runtime::Runtime() {
     aicpu_allowed_cpu_count = 0;
     aicpu_launch_count = 0;
     host_total_tasks = 0;
+    sm_payload_stride = sizeof(PTO2TaskPayload);
 
     // Initialize shared-memory / orchestration argument plumbing
     gm_sm_ptr_ = nullptr;

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -229,9 +229,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
     // Boot: the last AICPU thread (aicpu_thread_num_ - 1) performs the one-time
     // host-orch attach. host_build_graph's orchestrator already ran on the host,
-    // which also relocated every cross-task pointer to its final device address
-    // before H2D — so the SM/arena this thread sees are already fully
-    // device-addressed. This thread attaches the prebuilt arena, points the SM
+    // and every cross-task reference it wrote is an offset from its own block, so
+    // the SM/arena this thread sees need no address fixup. This thread attaches
+    // the prebuilt arena, points the SM
     // handle's ring-header pointers at the device SM WITHOUT resetting the
     // host-populated data, hands the host-computed task count to the scheduler,
     // and releases the other threads. It then falls through and schedules its own
@@ -264,14 +264,23 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             runtime_wire_arena_pointers(runtime_arena_, rt->prebuilt_layout, rt);
 
             void *sm_ptr = runtime->get_gm_sm_ptr();
-            uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(rt->prebuilt_layout.task_window_sizes);
+            // The image the host shipped is pitched to the submitted task count,
+            // not to the ring capacity, and the device region holds exactly that
+            // image — so its size comes from the same pitch. attach_populated
+            // rejects a pitch outside (0, capacity] and a region too small for it.
+            const uint64_t live_slots =
+                pto2_sm_layout::live_slot_pitch(static_cast<uint64_t>(runtime->host_total_tasks));
+            const uint64_t payload_stride = runtime->sm_payload_stride;
+            const uint64_t sm_size = pto2_sm_layout::ring_segment_offsets(live_slots, payload_stride).end;
             // sm_handle and the scheduler state are the device-only zone: their
             // bytes never travel, so they start as whatever the pooled arena last
             // held. Zeroing the handle first is what makes attach_populated's
             // assignment of every field checkable here rather than by inspecting
             // attach_populated.
             memset(rt->sm_handle, 0, sizeof(*rt->sm_handle));
-            if (!rt->sm_handle->attach_populated(sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes)) {
+            if (!rt->sm_handle->attach_populated(
+                    sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes, live_slots, payload_stride
+                )) {
                 LOG_ERROR("Thread %d: host-orch: sm_handle->attach_populated failed", thread_idx);
                 rt = nullptr;
                 run_rc = -1;
@@ -307,12 +316,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // to keep them alive).
             // NOTE: do NOT call rt_orchestration_done(rt) here. The HOST already
             // called it in run_host_orchestration; the orchestrator's own
-            // task-allocator pointers are intentionally NOT relocated (only the
-            // SM cross-task pointers and the host-built fanout adjacency —
-            // dep_pool / ready queues / fanout_head — were), so they still hold
-            // host addresses and mark_done()'s active_count() read would
-            // dereference host memory and fault the AICPU. on_orchestration_done
-            // only needs total_tasks and the scalar
+            // task-allocator pointers name host memory the device never reads, so
+            // mark_done()'s active_count() read would dereference it and fault the
+            // AICPU. on_orchestration_done only needs total_tasks and the scalar
             // orchestrator.inline_completed_tasks, both already valid.
             sched_ctx_.on_orchestration_done(runtime, rt, thread_idx, runtime->host_total_tasks);
             LOG_INFO("Thread %d: host-orch boot complete (%d tasks)", thread_idx, runtime->host_total_tasks);

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -9,7 +9,7 @@ host register: materialize + dlopen orchestration SO
         ↓
 host run/bind: stage external tensors, execute orchestration to completion
         ↓
-host: relocate the prebuilt graph image and copy it to device memory
+host: copy the prebuilt graph image to device memory
         ↓
 device: attach the image, classify tasks, dispatch with AICPU schedulers
         ↓
@@ -49,9 +49,8 @@ For each run, the host:
 2. reserves one backing arena for runtime/shared-memory subregions;
 3. binds the runtime to the orchestration DSO;
 4. calls the orchestration entry synchronously;
-5. finalizes task counts and the graph image;
-6. rewrites per-slot task/payload pointers to device addresses; and
-7. copies the shared-memory image and arena to the device.
+5. finalizes task counts and the graph image; and
+6. copies the shared-memory image and the arena's copied zone to the device.
 
 An orchestration fatal stops this sequence and is propagated through
 `orch_error_code`.
@@ -78,8 +77,9 @@ The shared image uses three per-slot structures:
 | `PTO2TaskSlotState` | Active mask, attributes, block/subtask counters, completion state, task/payload bindings |
 
 The host/device boundary is POD and position-independent. Fanins are integer
-producer IDs, not pointers. The only per-slot pointers are rebound to their final
-device addresses before H2D.
+producer IDs, not pointers, and a slot state names its payload and descriptor by a
+delta from its own address — so the image needs no fixup on either side of the
+copy.
 
 ### 3.1 What Ships: the Arena's Three Zones
 
@@ -97,16 +97,25 @@ Three rules decide every byte of the runtime arena:
 They partition the arena into three contiguous zones, and `runtime_reserve_layout`
 reserves them in this order:
 
-| Zone | Regions | Copied | Written by |
-| ---- | ------- | ------ | ---------- |
-| host-only | orchestrator block: `fanin_seen_epoch` / `scope_tasks` / TensorMap, ~8.5 MB | never | host, during graph construction |
-| copied | `[off_copied_begin, off_copied_end)`: the runtime header | whole zone, one copy | host |
-| device-only | `sm_handle`, `PTO2SchedulerState` and its thirteen queue slot arrays, the completion mailbox | never | AICPU at boot |
+| Zone | Regions | Copied | Allocated on device | Written by |
+| ---- | ------- | ------ | ------------------- | ---------- |
+| copied | `[off_copied_begin, off_copied_end)`: the runtime header | whole zone, one copy | yes | host |
+| device-only | `sm_handle`, the completion mailbox, `PTO2SchedulerState` and its thirteen queue slot arrays | never | yes | AICPU at boot |
+| host-only | orchestrator block: `fanin_seen_epoch` / `scope_tasks` / TensorMap, ~9.3 MB | never | **no** | host, during graph construction |
 
-Putting the copied zone **between** the two zones that are never copied is what
-makes `bind` a single contiguous `copy_to_device`. Both bounds are layout fields,
-so no consumer infers a boundary from which region happens to be reserved first —
-`bind_callable_to_runtime_impl` asserts only that they are ordered and in range.
+The copied zone leads, so `bind` is a single contiguous `copy_to_device` starting
+at the arena base. Both bounds are layout fields, so no consumer infers a boundary
+from which region happens to be reserved first — `bind_callable_to_runtime_impl`
+asserts only that they are ordered and in range.
+
+**Why the host-only zone comes last.** No device code dereferences a pointer into
+the orchestrator block — hbg has no device-side orchestrator, and the one
+orchestrator field the scheduler reads, `inline_completed_tasks`, is a scalar in
+the runtime header. Putting the block at the tail lets `setup_static_arena` request
+only `layout.device_bytes`, the copied + device-only prefix, so those ~9.3 MB are
+never reserved on the device at all. `runtime_wire_host_only_pointers` is therefore
+host-only, and `runtime_clear_host_only_pointers` drops those pointers before the
+copied zone is uploaded so no host address crosses the boundary.
 
 **Why the scheduler state is device-written.** `PTO2SchedulerState` holds no
 per-run content: `sm_header` and the ring pointer derive from a pooled SM base,

--- a/src/a5/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a5/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
@@ -38,7 +38,7 @@ The execution order is:
 
 1. The host loads and calls the orchestration shared object.
 2. Orchestration builds the entire task graph and returns.
-3. The host relocates and copies the graph image to device memory.
+3. The host copies the graph image to device memory.
 4. AICPU schedulers boot and dispatch the graph.
 
 A producer submitted in step 1 cannot become `COMPLETED` until step 4. Waiting

--- a/src/a5/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a5/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
@@ -33,8 +33,9 @@ The shared graph image separates stable task identity from scheduling state:
 - `PTO2TaskSlotState` contains the active mask, task attributes, logical block
   count, subtask counters, completion state, and descriptor/payload bindings.
 
-This image is built on the host, relocated once, and copied to the device. It
-contains no fanout adjacency or dependency-pool pointers.
+This image is built on the host and copied to the device verbatim. It contains
+no fanout adjacency or dependency-pool pointers, and its descriptor/payload
+bindings are deltas from the slot state's own address rather than pointers.
 
 ## Resource Shapes
 

--- a/src/a5/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a5/runtime/host_build_graph/docs/profiling_levels.md
@@ -240,12 +240,12 @@ appear.
 
 ### What is recorded
 
-Seventeen kinds, all on the host monotonic clock the `[STRACE]` host spans use,
+Sixteen kinds, all on the host monotonic clock the `[STRACE]` host spans use,
 so records and spans read against each other with no alignment step.
 
 | Group | Kinds |
 | ----- | ----- |
-| Bind segments (partition the stage) | `args`, `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init`, `host_orch`, `graph_upload`, `relocate`, `sm_h2d`, `arena_h2d`, `host_view_close` |
+| Bind segments (partition the stage) | `args`, `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init`, `host_orch`, `graph_upload`, `sm_h2d`, `arena_h2d`, `host_view_close` |
 | Orchestrator operations (inside `host_orch`) | `submit_task`, `alloc_tensors`, `record_node`, `graph_submit`, `build_definition` |
 
 Three of the orchestrator kinds end with a task submitted — `submit_task`,

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -79,13 +79,16 @@
 extern "C" const PipelineContract *get_pipeline_contract(void) {
     // Host orchestration materializes this run's own graph into the image it
     // uploads, so every device-resident region carries per-run content.
+    //
+    // PTO_PIPELINE_GM_SM is absent because hbg has no separate shared-memory
+    // region: the image is the tail of the runtime-image region, so it shares that
+    // region's classification. The arena-topology check skips an absent kind.
     static const PipelineContract contract = {
         PTO_PIPELINE_CONTRACT_ABI_VERSION,
-        5,
+        4,
         2,
         {
             {PTO_PIPELINE_GM_HEAP, PTO_PIPELINE_HOST_PER_RUN, 0},
-            {PTO_PIPELINE_GM_SM, PTO_PIPELINE_HOST_PER_RUN, 0},
             {PTO_PIPELINE_RUNTIME_IMAGE, PTO_PIPELINE_HOST_PER_RUN, 0},
             {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
             {PTO_PIPELINE_AICORE_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
@@ -288,6 +291,18 @@ static bool resolve_ring_config(
             LOG_ERROR("ring_heap[%d]=%" PRIu64 " must be >= 1024", r, eff_heap_sizes[r]);
             return false;
         }
+        // A slot state reaches its payload and descriptor through a 32-bit
+        // self-relative delta, so every pair of addresses in the shared-memory
+        // image must be within INT32_MAX of each other.
+        const uint64_t sm_bytes = pto2_sm_layout::ring_segment_offsets(eff_task_window_sizes[r]).end;
+        if (sm_bytes > static_cast<uint64_t>(INT32_MAX)) {
+            LOG_ERROR(
+                "ring_task_window[%d]=%" PRIu64 " needs a %" PRIu64 "-byte shared memory image, past the %d-byte limit "
+                "a slot state's self-relative payload/descriptor delta can span",
+                r, eff_task_window_sizes[r], sm_bytes, INT32_MAX
+            );
+            return false;
+        }
     }
 
     return true;
@@ -317,12 +332,10 @@ static int32_t pto2_read_runtime_status(Runtime *runtime, const HostApi *api, PT
 namespace {
 
 // host_build_graph is host-orchestration-first: the HOST dlopens the
-// orchestration .so and runs it to completion. The shared memory + arena carry
-// host-DDR cross-task pointers (slot_state.task/payload,
-// payload.fanin_local_ids[], dep_pool/ready queues); the host relocates them to
-// their final device addresses (relocate_host_orch_image, below) BEFORE the H2D
-// copy, so the device receives a fully device-addressed image and schedules
-// only — no on-device pointer fixup.
+// orchestration .so and runs it to completion. Every cross-task reference the
+// shared memory and arena carry is an offset or an index from its own block, so
+// the image the device schedules is the bytes the host wrote — there is nothing
+// to fix up after the H2D copy.
 
 bool write_all_bytes(int fd, const uint8_t *data, size_t size) {
     size_t total = 0;
@@ -376,94 +389,31 @@ struct HostOrchEntryPoints {
     OrchestrationBindFunc bind{nullptr};
 };
 
-// Run the orchestrator on the host. `rt` was built with its scheduler half
-// pointing at the device SM; here we re-point ONLY the orchestrator half at a
-// host SM mirror, run the orchestration entry against it, latch the submitted
-// task count, and H2D the populated SM to the device (the device scheduler
-// reads task descriptors from there). The device never dereferences the
-// orchestrator's SM pointers, so leaving them host-side is safe. Returns the
-// total task count (>= 0) on success, or -1 on failure.
-// host_build_graph host-orch: the orchestrator built the task graph in a host
-// SM mirror and (when wiring is folded into submit) the fanout adjacency in the
-// host arena, storing host-DDR addresses into the cross-task pointers. Relocate
-// them to their FINAL device addresses here on the host, BEFORE the SM/arena are
-// copied to the device — so the device receives a fully device-addressed image
-// and boots scheduler-only with no on-device pointer fixup.
+// host_build_graph host-orch: the orchestrator builds the task graph in a host
+// shared-memory mirror, and every cross-task reference it stores is an offset or
+// an index from its own block. The bytes the host wrote are therefore the bytes
+// the device schedules, with no on-device or pre-copy pointer fixup.
+
+// One submission's place in the block: where its bytes come from, which outer task
+// reads it, and how far into the block it sits.
+struct StagedSubmission {
+    const std::byte *host_image;
+    PTO2TaskSlotState *outer_slot;
+    size_t bytes;
+    uint64_t offset;
+};
+
+// Validate every pending submission, bind it to its uploaded Definition, and lay
+// the block out. No device call and no device address: the block lands in the
+// runtime arena's tail, whose base is not known until that region is grown to fit
+// the shared-memory image as well.
 //
-// Relocated pointers span TWO regions with DIFFERENT deltas: the SM block
-// (slot_state.task/.payload, fanin_local_ids[], dep-entry.slot_state,
-// ready-queue slot.slot_state) and the arena block (slot_state.fanout_head,
-// dep-entry.next point into the SM but live in the arena).
-// Rather than track which delta each field needs, relocate() classifies every
-// pointer by the region it points INTO and applies that region's delta; foreign
-// and null pointers pass through untouched. The fanout adjacency is wired inline
-// during host submit, so dep_pool/ready are already populated here.
-//
-// The orchestrator's own task-allocator pointers are intentionally NOT relocated
-// (the device runs scheduler-only and never dereferences them, and must not call
-// rt_orchestration_done — the host already did). Multi-fanin spill is not yet
-// relocated; a task exceeding PTO2_FANIN_INLINE_CAP producers latches fatal here
-// (returns false) rather than shipping un-relocated host pointers to the device.
-// Returns false on any unrelocatable pointer so the caller can fail the prepare.
-static bool relocate_host_orch_image(
-    PTO2SharedMemoryHandle &host_sm_handle, uint64_t host_sm, uint64_t sm_size, int64_t sm_delta, uint64_t host_arena,
-    uint64_t arena_size, int64_t arena_delta
-) {
-    static_assert(PTO2_MAX_RING_DEPTH == 1, "relocate_host_orch_image assumes a single ring");
-
-    // SM and arena windows must not overlap — relocate classifies a pointer by
-    // which window it falls in, so an overlap would misclassify and apply the
-    // wrong delta. Both are independent malloc-backed host buffers in practice;
-    // assert it so a future shared-buffer layout can't silently corrupt.
-    if (!(host_sm + sm_size <= host_arena || host_arena + arena_size <= host_sm)) {
-        LOG_ERROR(
-            "host-orch: SM window [%#lx,+%#lx) overlaps arena window [%#lx,+%#lx); cannot relocate", host_sm, sm_size,
-            host_arena, arena_size
-        );
-        return false;
-    }
-
-    bool ok = true;
-    auto relocate = [&](auto *&pointer) {
-        using Pointer = std::remove_reference_t<decltype(pointer)>;
-        const uint64_t address = reinterpret_cast<uint64_t>(pointer);
-        if (address == 0) return;
-        if (address >= host_sm && address < host_sm + sm_size) {
-            pointer = reinterpret_cast<Pointer>(static_cast<uintptr_t>(address + sm_delta));
-        } else if (address >= host_arena && address < host_arena + arena_size) {
-            pointer = reinterpret_cast<Pointer>(static_cast<uintptr_t>(address + arena_delta));
-        } else {
-            // A non-null pointer in neither window is an external/host address
-            // the device would dereference verbatim after H2D. No field should
-            // legitimately carry one; latch fatal rather than ship a host VA to
-            // the device (silent AICPU corruption otherwise).
-            LOG_ERROR(
-                "host-orch: pointer %#lx is outside both SM and arena windows; cannot relocate for device", address
-            );
-            ok = false;
-        }
-    };
-
-    PTO2SharedMemoryHeader *header = host_sm_handle.header;
-    if (header != nullptr) {
-        PTO2SharedMemoryRingHeader &ring = header->ring;
-        const int32_t count = ring.fc.current_task_index.load(std::memory_order_acquire);
-        for (int32_t slot = 0; slot < count; ++slot) {
-            PTO2TaskSlotState *state = &ring.slot_states[slot];
-            // Polling: fanin is a flat array of position-independent local-id
-            // integers on the payload, so only the two per-slot arena/SM
-            // pointers need relocating. There is no fanout_head/dep_pool graph
-            // and no host-seeded ready queue (the device boot scan classifies),
-            // so those relocation passes are gone.
-            relocate(state->task);
-            relocate(state->payload);
-        }
-    }
-    return ok;
-}
-
-bool upload_graph_submissions(
-    Runtime *runtime, const HostApi *api, GraphHostState &graph_state, uint64_t &uploaded_bytes
+// Submissions sit PTO2_ALIGN_SIZE apart. activation_gate is OR-ed by the outer task
+// and by the node path for the length of the graph, so two submissions sharing a
+// cache line would false-share on that word throughout.
+bool plan_graph_submissions(
+    const HostApi *api, GraphHostState &graph_state, std::vector<StagedSubmission> *staged, uint64_t *block_bytes,
+    uint64_t &uploaded_bytes
 ) {
     uploaded_bytes = 0;
     const size_t count = graph_host_upload_count(graph_state);
@@ -510,7 +460,9 @@ bool upload_graph_submissions(
         uploaded_bytes += object_bytes;
     }
 
-    // Pass 2: per-submission execution storage + the small reference image.
+    // Pass 2: validate every submission and lay the block out.
+    staged->reserve(count);
+    *block_bytes = 0;
     for (size_t index = 0; index < count; ++index) {
         std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
         if (!upload.has_value() || upload->outer_slot == nullptr || upload->data == nullptr ||
@@ -544,21 +496,23 @@ bool upload_graph_submissions(
         submission->local_execution = 0;
         submission->activation_gate = 0;
 
-        void *device_submission = api->device_malloc(upload->bytes);
-        if (device_submission == nullptr) {
-            LOG_ERROR("host-orch: failed to allocate %zu bytes for Graph submission", upload->bytes);
-            return false;
-        }
-        if (api->copy_to_device(device_submission, upload->data, upload->bytes) != 0) {
-            LOG_ERROR("host-orch: failed to upload Graph submission POD image");
-            api->device_free(device_submission);
-            return false;
-        }
-        upload->outer_slot->graph_context = device_submission;
-        runtime->tensor_pairs_.push_back({nullptr, device_submission, upload->bytes, false});
-        uploaded_bytes += static_cast<uint64_t>(upload->bytes);
+        staged->push_back({upload->data, upload->outer_slot, upload->bytes, *block_bytes});
+        *block_bytes += PTO2_ALIGN_UP(static_cast<uint64_t>(upload->bytes), PTO2_ALIGN_SIZE);
     }
+    uploaded_bytes += *block_bytes;
     return true;
+}
+
+// Copy the planned block into `block_base` and point each outer task at the device
+// address its submission will occupy. The graph_context write lands in the host
+// shared-memory mirror, which has not been compacted or copied yet.
+void stage_graph_submissions(
+    const std::vector<StagedSubmission> &staged, char *block_base, const char *device_block_base
+) {
+    for (const StagedSubmission &entry : staged) {
+        std::memcpy(block_base + entry.offset, entry.host_image, entry.bytes);
+        entry.outer_slot->graph_context = const_cast<char *>(device_block_base) + entry.offset;
+    }
 }
 
 struct GraphHostStateBinding {
@@ -573,7 +527,7 @@ struct GraphHostStateBinding {
 
 int32_t run_host_orchestration(
     Runtime *runtime, const HostApi *api, HostTensorAccessor &tensor_access, PTO2Runtime *rt, DeviceArena &host_arena,
-    const PTO2RuntimeArenaLayout &layout, void *device_sm, uint64_t sm_size, void *device_arena, void *gm_heap,
+    const PTO2RuntimeArenaLayout &layout, uint64_t sm_size, void *device_arena, void *gm_heap,
     const uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH],
     void *host_orch_func_ptr, const ChipTaskArgs &orch_l2
 ) {
@@ -586,8 +540,14 @@ int32_t run_host_orchestration(
     // orch::prepare_task and shipped bounded to total_tasks below.
     const pto2_sm_layout::PTO2RingSegmentOffsets sm_segs =
         pto2_sm_layout::ring_segment_offsets(eff_task_window_sizes[0]);
-    std::unique_ptr<uint8_t[]> host_sm_buf(new uint8_t[sm_size]);
-    void *host_sm = host_sm_buf.get();
+    // Over-allocated and rounded up: every segment offset is a multiple of
+    // PTO2_ALIGN_SIZE and PTO2TaskSlotState is alignas(64), which a plain
+    // new uint8_t[] does not guarantee.
+    std::unique_ptr<uint8_t[]> host_sm_buf(new uint8_t[sm_size + PTO2_ALIGN_SIZE]);
+    void *host_sm = reinterpret_cast<void *>(
+        (reinterpret_cast<uintptr_t>(host_sm_buf.get()) + PTO2_ALIGN_SIZE - 1) &
+        ~static_cast<uintptr_t>(PTO2_ALIGN_SIZE - 1)
+    );
     std::memset(host_sm, 0, sm_segs.descriptors);
 
     // Re-point the orchestrator half at the host SM (scheduler keeps device SM).
@@ -673,6 +633,25 @@ int32_t run_host_orchestration(
     }
 #endif
 
+    // A latched fatal means the graph in the mirror is not the graph the orchestration
+    // described — a heap or tensormap exhaustion drops tasks, a fanin overflow drops
+    // edges. Uploading it would launch the device on an incomplete graph and surface
+    // the cause as whatever the device notices second, usually a scheduler timeout.
+    const int32_t orch_error = pto2_sm_layout::orch_error_code_addr(host_sm)->load(std::memory_order_acquire);
+    if (orch_error != PTO2_ERROR_NONE || rt->orchestrator.fatal) {
+        // The latched code is the diagnosis, so it is what the caller sees — through the
+        // same mapping the run path uses, since a caller cannot tell which of the two
+        // noticed. A fatal with no code left to read is the only generic failure.
+        const int32_t status =
+            orch_error != PTO2_ERROR_NONE ? runtime_status_from_error_codes(orch_error, PTO2_ERROR_NONE) : -1;
+        LOG_RUNTIME_FAILURE(orch_error, PTO2_ERROR_NONE, status);
+        LOG_ERROR(
+            "host-orch: refusing to upload an incomplete graph after %" PRIu64 " heap bytes",
+            rt->orchestrator.ring.task_allocator.heap_used_bytes()
+        );
+        return status;
+    }
+
     const int32_t total_tasks = pto2_sm_layout::ring_current_task_index_addr(host_sm)->load(std::memory_order_acquire);
     {
         char attrs[96];
@@ -685,9 +664,16 @@ int32_t run_host_orchestration(
     // After the span closes: the reduction walks a few hundred records and emits
     // five markers, which must not be charged to the pass it measures.
 
+    // Uploads each distinct Definition as its own retained device object and lays
+    // out the submission block. The block itself is staged below, into the arena's
+    // second device tail, so nothing here allocates or copies it.
     const int64_t t_graph_ns = bind_now_ns();
     uint64_t graph_bytes = 0;
-    if (!upload_graph_submissions(runtime, api, *graph_state, graph_bytes)) return -1;
+    std::vector<StagedSubmission> staged_submissions;
+    uint64_t submission_block_bytes = 0;
+    if (!plan_graph_submissions(api, *graph_state, &staged_submissions, &submission_block_bytes, graph_bytes)) {
+        return -1;
+    }
     {
         char attrs[96];
         snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, graph_host_upload_count(*graph_state), graph_bytes);
@@ -702,52 +688,107 @@ int32_t run_host_orchestration(
     }
     host_phase_trace_note_submitted(static_cast<uint64_t>(total_tasks));
 
-    // Relocate the host-DDR cross-task pointers to their final DEVICE addresses
-    // on the host, before the SM and arena leave for the device. Pointers into
-    // the SM shift by sm_delta; pointers into the arena (fanout adjacency, wiring
-    // queue) shift by arena_delta. After this both the SM and arena carry device
-    // addresses, so the device boots scheduler-only.
-    const int64_t sm_delta = static_cast<int64_t>(reinterpret_cast<uint64_t>(device_sm)) -
-                             static_cast<int64_t>(reinterpret_cast<uint64_t>(host_sm));
-    const int64_t arena_delta = static_cast<int64_t>(reinterpret_cast<uint64_t>(device_arena)) -
-                                static_cast<int64_t>(reinterpret_cast<uint64_t>(host_arena.base()));
-    const int64_t t_reloc_ns = bind_now_ns();
-    if (!relocate_host_orch_image(
-            host_sm_handle, reinterpret_cast<uint64_t>(host_sm), sm_size, sm_delta,
-            reinterpret_cast<uint64_t>(host_arena.base()), layout.arena_size, arena_delta
-        )) {
-        LOG_ERROR("host-orch: relocation failed; refusing to H2D an image with unrelocated host pointers");
+    // The device reads no ring slot past total_tasks, so only that prefix of each
+    // segment has to travel. In the mirror the orchestrator wrote, the four
+    // prefixes are a ring capacity apart, which would make the upload four copies
+    // of a few hundred kilobytes each — and at these sizes a copy_to_device is
+    // priced by the call, not by the bytes.
+    //
+    // So the prefixes are restacked into an image pitched to total_tasks, where
+    // they are contiguous, and that image goes up as one copy. The device attaches
+    // with the same pitch. The ring capacity and mask are untouched: `local_id &
+    // mask` is `local_id`, which is below the pitch for every ring task.
+    const uint64_t nt = static_cast<uint64_t>(total_tasks);
+    // The widest task in this bind sets the stride every payload in the image gets.
+    // Read from the mirror, which orchestration has finished writing.
+    int32_t widest_tensor_count = 0;
+    {
+        const auto *mirror_payloads =
+            reinterpret_cast<const PTO2TaskPayload *>(static_cast<const char *>(host_sm) + sm_segs.payloads);
+        for (uint64_t i = 0; i < nt; ++i) {
+            if (mirror_payloads[i].tensor_count > widest_tensor_count) {
+                widest_tensor_count = mirror_payloads[i].tensor_count;
+            }
+        }
+    }
+    const uint64_t payload_stride = pto2_sm_layout::shipped_payload_stride(widest_tensor_count);
+    runtime->sm_payload_stride = payload_stride;
+    const uint64_t image_bytes =
+        pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::live_slot_pitch(nt), payload_stride).end;
+
+    // Only now is the size known, so this is where the device region grows to cover
+    // its shared-memory tail. setup_static_arena grows per region and
+    // short-circuits a request it already covers, so the heap is untouched and a
+    // repeated workload grows the arena once. Growing reallocates, so the base is
+    // re-acquired rather than reused.
+    const int64_t t_sm_ns = bind_now_ns();
+    uint64_t total_heap_size = 0;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        total_heap_size += eff_heap_sizes[r];
+    }
+    // Two device tails past off_copied_end, in this order: the shared-memory image,
+    // then the Graph submission block. Both are per-run content of the region the
+    // device already owns, so neither needs an allocation of its own.
+    const uint64_t off_submissions = layout.off_copied_end + image_bytes;
+    const uint64_t device_arena_bytes = off_submissions + submission_block_bytes;
+    if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, device_arena_bytes) != 0) {
+        LOG_ERROR("host-orch: failed to commit %" PRIu64 " bytes of device runtime arena", device_arena_bytes);
         return -1;
     }
-    record_bind_phase(HostPhaseKind::BindRelocate, t_reloc_ns);
+    device_arena = api->acquire_pooled_runtime_arena();
+    if (device_arena == nullptr) {
+        LOG_ERROR("%s", "host-orch: failed to re-acquire the pooled runtime arena");
+        return -1;
+    }
+    char *arena_dev = static_cast<char *>(device_arena);
+    void *device_sm = arena_dev + layout.off_copied_end;
+    runtime->set_gm_sm_ptr(device_sm);
+    {
+        char attrs[96];
+        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, image_bytes);
+        record_bind_phase(HostPhaseKind::BindSharedMem, t_sm_ns, attrs, image_bytes);
+    }
 
-    // Ship only the live prefix of each segment: the device reads no slot past
-    // total_tasks, so upload header + descriptors[0,N), payloads[0,N),
-    // slot_states[0,N) and completion_flags[0,N) — never the ring-sized tails.
-    // header + descriptors[0,N) are contiguous, so that is a single copy.
-    const uint64_t nt = static_cast<uint64_t>(total_tasks);
-    const uint64_t hdr_desc_bytes = sm_segs.descriptors + nt * sizeof(PTO2TaskDescriptor);
-    char *host_base = static_cast<char *>(host_sm);
-    char *dev_base = static_cast<char *>(device_sm);
-    const int64_t t_sm_h2d_ns = bind_now_ns();
-    if (api->copy_to_device(dev_base, host_base, hdr_desc_bytes) != 0 ||
-        api->copy_to_device(dev_base + sm_segs.payloads, host_base + sm_segs.payloads, nt * sizeof(PTO2TaskPayload)) !=
-            0 ||
-        api->copy_to_device(
-            dev_base + sm_segs.slot_states, host_base + sm_segs.slot_states, nt * sizeof(PTO2TaskSlotState)
-        ) != 0 ||
-        api->copy_to_device(
-            dev_base + sm_segs.completion_flags, host_base + sm_segs.completion_flags, nt * sizeof(std::atomic<uint8_t>)
-        ) != 0) {
-        LOG_ERROR("host-orch: H2D of populated SM failed");
+    // One host source for one copy: the copied zone, the shared-memory image, and
+    // the submission block, at exactly the offsets they occupy on the device.
+    // Over-allocated and rounded up because every segment offset is
+    // PTO2_ALIGN_SIZE-aligned and PTO2TaskSlotState is alignas(64), which a byte
+    // vector's data() is not.
+    const uint64_t copied_bytes = layout.off_copied_end - layout.off_copied_begin;
+    const uint64_t upload_bytes = copied_bytes + image_bytes + submission_block_bytes;
+    std::vector<std::byte> storage(upload_bytes + PTO2_ALIGN_SIZE, std::byte{0});
+    char *upload_base = reinterpret_cast<char *>(
+        (reinterpret_cast<uintptr_t>(storage.data()) + PTO2_ALIGN_SIZE - 1) &
+        ~static_cast<uintptr_t>(PTO2_ALIGN_SIZE - 1)
+    );
+
+    // Before the shared-memory mirror is compacted: this writes each outer task's
+    // graph_context into it, and compaction is what carries those slots.
+    stage_graph_submissions(staged_submissions, upload_base + copied_bytes + image_bytes, arena_dev + off_submissions);
+
+    // The orchestrator has finished, so its pointers into the host-only tail have
+    // no further reader on either side — and this header is about to be copied, so
+    // leaving them would carry host addresses to the device.
+    runtime_clear_host_only_pointers(rt);
+    std::memcpy(upload_base, static_cast<const char *>(host_arena.base()) + layout.off_copied_begin, copied_bytes);
+    const uint64_t compacted = pto2_sm_layout::compact_live_image(
+        static_cast<const char *>(host_sm), eff_task_window_sizes[0], nt, payload_stride, upload_base + copied_bytes
+    );
+    always_assert(compacted == image_bytes);
+
+    const int64_t t_h2d_ns = bind_now_ns();
+    if (api->copy_to_device(arena_dev + layout.off_copied_begin, upload_base, upload_bytes) != 0) {
+        LOG_ERROR("host-orch: H2D of the runtime image failed");
         return -1;
     }
     {
-        const uint64_t sm_h2d_bytes = hdr_desc_bytes + nt * sizeof(PTO2TaskPayload) + nt * sizeof(PTO2TaskSlotState) +
-                                      nt * sizeof(std::atomic<uint8_t>);
         char attrs[96];
-        snprintf(attrs, sizeof(attrs), "nt=%" PRIu64 " bytes=%" PRIu64, nt, sm_h2d_bytes);
-        record_bind_phase(HostPhaseKind::BindSmH2d, t_sm_h2d_ns, attrs, sm_h2d_bytes);
+        snprintf(
+            attrs, sizeof(attrs),
+            "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " subs=%" PRIu64 " pstride=%" PRIu64, nt,
+            upload_bytes, copied_bytes, image_bytes, submission_block_bytes, payload_stride
+        );
+        record_bind_phase(HostPhaseKind::BindArenaH2d, t_h2d_ns, attrs, upload_bytes);
     }
     return total_tasks;
 }
@@ -1036,18 +1077,33 @@ extern "C" int bind_callable_to_runtime_impl(
     }
     {
         char attrs[64];
-        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, static_cast<uint64_t>(layout.arena_size));
+        snprintf(
+            attrs, sizeof(attrs), "bytes=%" PRIu64 " device=%" PRIu64, static_cast<uint64_t>(layout.arena_size),
+            static_cast<uint64_t>(layout.device_bytes)
+        );
         record_bind_phase(HostPhaseKind::BindArenaBuild, t_arena_build_ns, attrs);
     }
 
     const int64_t t_static_arena_ns = bind_now_ns();
-    if (api->setup_static_arena(total_heap_size, sm_size, layout.arena_size) != 0) {
+    // Two things this call does not ask for at full size.
+    //
+    // device_bytes, not arena_size: the host-only zone at the arena's tail is
+    // dep-computation scratch no device code reads, so reserving device memory for
+    // it would be dead space for the length of the run.
+    //
+    // No pooled shared memory: hbg's shared-memory image is the tail of its own
+    // runtime-arena region, so this asks for 0 and leaves that pool uncommitted.
+    // The arena is asked for only up to that tail, whose size is the submitted task
+    // count — run_host_orchestration grows it once it knows. The heap must exist
+    // first either way: the orchestrator hands out device heap addresses as it
+    // places tasks.
+    if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, layout.device_bytes) != 0) {
         LOG_ERROR("Failed to setup pooled static arena");
         return -1;
     }
     {
         char attrs[96];
-        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " sm=%" PRIu64, total_heap_size, sm_size);
+        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " arena=%" PRIu64, total_heap_size, layout.device_bytes);
         record_bind_phase(HostPhaseKind::BindStaticArena, t_static_arena_ns, attrs);
     }
 
@@ -1059,15 +1115,10 @@ extern "C" int bind_callable_to_runtime_impl(
         return -1;
     }
     runtime->set_gm_heap(gm_heap);
-
-    const int64_t t_sm_ns = bind_now_ns();
-    void *sm_ptr = api->acquire_pooled_gm_sm();
-    record_bind_phase(HostPhaseKind::BindSharedMem, t_sm_ns);
-    if (sm_ptr == nullptr) {
-        LOG_ERROR("Failed to acquire pooled PTO2 shared memory");
-        return -1;
-    }
-    runtime->set_gm_sm_ptr(sm_ptr);
+    // The shared memory is placed at the end of orchestration, so until then this
+    // bind has no SM. Clearing it keeps a failure before that point from leaving the
+    // previous bind's address for the error-code read to follow.
+    runtime->set_gm_sm_ptr(nullptr);
 
     void *runtime_arena_dev = api->acquire_pooled_runtime_arena();
     if (runtime_arena_dev == nullptr) {
@@ -1089,13 +1140,24 @@ extern "C" int bind_callable_to_runtime_impl(
     // reset) + a handful of device-only field fixups.
     // -------------------------------------------------------------------------
     const int64_t t_runtime_init_ns = bind_now_ns();
-    PTO2Runtime *rt =
-        runtime_init_data_from_layout(host_arena, layout, PTO2_MODE_EXECUTE, sm_ptr, sm_size, gm_heap, eff_heap_sizes);
+    // No SM base: the scheduler and sm_handle are device-written now, so nothing
+    // here stores one, and the region is not even committed yet.
+    PTO2Runtime *rt = runtime_init_data_from_layout(
+        host_arena, layout, PTO2_MODE_EXECUTE, /*sm_dev_base=*/nullptr, sm_size, gm_heap, eff_heap_sizes
+    );
     if (rt == nullptr) {
         LOG_ERROR("runtime_init_data_from_layout failed");
         return -1;
     }
     runtime_wire_arena_pointers(host_arena, layout, rt);
+    runtime_wire_host_only_pointers(host_arena, layout, rt);
+    // Stash the layout inside the PTO2Runtime image so the AICPU can recover every
+    // arena-internal offset after the copy. It is written before orchestration
+    // because orchestration is what performs that copy, and the runtime header is
+    // part of what travels. The runtime arena's device base does NOT travel — it is
+    // on the host Runtime (set_prebuilt_arena below), since the AICPU needs that
+    // pointer before it can dereference the image.
+    rt->prebuilt_layout = layout;
     record_bind_phase(HostPhaseKind::BindRuntimeInit, t_runtime_init_ns);
 
     // host_build_graph host-orch: run the orchestrator on the host now, against
@@ -1112,8 +1174,8 @@ extern "C" int bind_callable_to_runtime_impl(
         ChipTaskArgs orch_l2;
         orch_l2.create_from_chip_args(device_args);
         int32_t total_tasks = run_host_orchestration(
-            runtime, api, tensor_access, rt, host_arena, layout, sm_ptr, sm_size, runtime_arena_dev, gm_heap,
-            eff_heap_sizes, eff_task_window_sizes, host_orch_func_ptr, orch_l2
+            runtime, api, tensor_access, rt, host_arena, layout, sm_size, runtime_arena_dev, gm_heap, eff_heap_sizes,
+            eff_task_window_sizes, host_orch_func_ptr, orch_l2
         );
         // The orchestrator is the only host-view reader; from here the device
         // owns these buffers, so drop the window on both exits.
@@ -1128,41 +1190,19 @@ extern "C" int bind_callable_to_runtime_impl(
         }
         if (total_tasks < 0) {
             LOG_ERROR("host-orch: orchestration run failed");
-            return -1;
+            return total_tasks;
         }
         runtime->host_total_tasks = total_tasks;
         LOG_INFO("host-orch: submitted %d tasks on host", total_tasks);
     }
 
-    // Stash the layout inside the PTO2Runtime image so the AICPU can recover
-    // every arena-internal offset after rtMemcpy. The runtime arena's device
-    // base does NOT travel in this image — it's on the host Runtime
-    // (set_prebuilt_arena below), since the AICPU needs that pointer
-    // *before* it can dereference the image.
-    rt->prebuilt_layout = layout;
-
-    // The arena is partitioned into three zones (see PTO2RuntimeArenaLayout) and
-    // only the middle one is copied: the host-only orchestrator block sits before
-    // it, and the regions the device initializes itself (sm_handle, scheduler
-    // state, queue slot arrays) sit after it. So bind is one copy of one range,
-    // with both bounds taken from the layout rather than inferred from a
-    // reservation order here.
-    const size_t copied_begin = layout.off_copied_begin;
-    const size_t copied_end = layout.off_copied_end;
-    always_assert(copied_begin <= copied_end && copied_end <= layout.arena_size);
-    char *arena_host = static_cast<char *>(host_arena.base());
-    char *arena_dev = static_cast<char *>(runtime_arena_dev);
-    const int64_t t_arena_h2d_ns = bind_now_ns();
-    int rc_upload = api->copy_to_device(arena_dev + copied_begin, arena_host + copied_begin, copied_end - copied_begin);
-    if (rc_upload != 0) {
-        LOG_ERROR("Failed to rtMemcpy prebuilt runtime arena to device (rc=%d)", rc_upload);
+    // Orchestration grew the device region to cover its shared-memory tail, which
+    // reallocates, so the base acquired before it may no longer be the one the
+    // image was copied into.
+    runtime_arena_dev = api->acquire_pooled_runtime_arena();
+    if (runtime_arena_dev == nullptr) {
+        LOG_ERROR("%s", "Failed to re-acquire the pooled runtime arena after orchestration");
         return -1;
-    }
-    {
-        const uint64_t arena_h2d_bytes = static_cast<uint64_t>(copied_end - copied_begin);
-        char attrs[96];
-        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, arena_h2d_bytes);
-        record_bind_phase(HostPhaseKind::BindArenaH2d, t_arena_h2d_ns, attrs, arena_h2d_bytes);
     }
     runtime->set_prebuilt_arena(runtime_arena_dev, layout.off_runtime);
 

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -786,11 +786,22 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     definition.tensor_arg_count = static_cast<uint32_t>(tensors.size());
     definition.scalar_arg_count = static_cast<uint32_t>(scalars.size());
     definition.predicate_count = static_cast<uint32_t>(predicates.size());
+    // The widest node sets the stride every entry of this Definition's execution
+    // storage gets; nodes[] carries each node's declared tensor count.
+    int32_t widest_node_tensor_count = 0;
+    for (const GraphNodeDefinition &node : nodes) {
+        if (node.tensor_count > widest_node_tensor_count) widest_node_tensor_count = node.tensor_count;
+    }
+    const size_t node_stride = graph_node_stride(widest_node_tensor_count);
     size_t execution_storage_bytes = 0;
-    if (!graph_execution_storage_bytes(static_cast<int32_t>(definition.task_count), &execution_storage_bytes) ||
+    if (node_stride > UINT32_MAX ||
+        !graph_execution_storage_bytes(
+            static_cast<int32_t>(definition.task_count), node_stride, &execution_storage_bytes
+        ) ||
         execution_storage_bytes > UINT32_MAX) {
         return false;
     }
+    definition.node_stride = static_cast<uint32_t>(node_stride);
     definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
     // Every section's byte count is known now, so the image grows once instead of
     // resizing eleven times. Each append aligns its start, hence the per-section
@@ -1384,9 +1395,9 @@ static TaskOutputTensors submit_task_common(
     // push_ready_routed; otherwise the returned index selects the producer passed
     // to register_wake. Wake retargeting in register_wake may reclassify a task
     // when the selected producer is already complete.
-    // The initial scan happens before the scheduler dispatch loop starts. Because
-    // fanin is a flat array of position-independent integers, none of this needs
-    // host->device pointer relocation.
+    // The initial scan happens before the scheduler dispatch loop starts. Fanin is
+    // a flat array of position-independent integers, so it crosses to the device
+    // unchanged.
     payload.fanin_count = fanin_builder.count;
     (void)sched;
 
@@ -1594,6 +1605,14 @@ bool graph_submit_outer(
     PTO2TaskPayload &payload = ring.task_payloads[allocation.slot];
     PTO2TaskSlotState &slot = ring.get_slot_state_by_slot(allocation.slot);
 
+    // Init-on-write, as in prepare_task: this slot's dynamic scheduling fields and
+    // completion flag are established here, at the claim, because nothing else
+    // writes them. A stale wake_list_head of WAKE_LIST_SENTINEL would close the
+    // list against every consumer, and a stale completion flag would report the
+    // Graph done before it ran.
+    slot.reset_for_reuse();
+    ring.completion_flags[allocation.slot].store(0, std::memory_order_relaxed);
+
     slot.bind_buffers(&payload, &task);
     slot.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
     slot.last_consumer_local_id = static_cast<int32_t>(task_id.local());
@@ -1602,7 +1621,6 @@ bool graph_submit_outer(
     slot.total_required_subtasks = 0;
     slot.logical_block_num = 1;
     slot.task_kind = TaskKind::GRAPH;
-    slot.graph_context = nullptr;
     scope_tasks_push(orch, &slot);
 
     task.task_id = task_id;

--- a/src/a5/runtime/host_build_graph/runtime/pto2_dispatch_payload.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto2_dispatch_payload.h
@@ -67,9 +67,11 @@ static_assert(
 // PTO2TaskPayload layout drift fails the build rather than corrupting args[].
 constexpr uint32_t PTO2_TASKPAYLOAD_TENSOR_COUNT_OFFSET = 0;
 constexpr uint32_t PTO2_TASKPAYLOAD_SCALAR_COUNT_OFFSET = 4;
-// Cache line 9 (byte 576) holds the AICPU-only DispatchPredicate; tensors follow it.
-constexpr uint32_t PTO2_TASKPAYLOAD_TENSORS_OFFSET = 640;
-constexpr uint32_t PTO2_TASKPAYLOAD_SCALARS_OFFSET = 4736;
+// Cache line 9 (byte 576) holds the AICPU-only DispatchPredicate. Scalars follow it,
+// then tensors — the tensor array is last because it is the only region whose used
+// extent varies per task, so a task's read set is a contiguous prefix.
+constexpr uint32_t PTO2_TASKPAYLOAD_SCALARS_OFFSET = 640;
+constexpr uint32_t PTO2_TASKPAYLOAD_TENSORS_OFFSET = 768;
 constexpr uint32_t PTO2_TASKPAYLOAD_TENSOR_STRIDE = 128;  // sizeof(ChipTensor)
 
 /**

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -121,23 +121,36 @@ struct PTO2RuntimeArenaLayout {
     size_t off_scheduler{0};
     size_t off_runtime{0};
     size_t off_mailbox{0};
-    // The arena is reserved in three zones and the offsets above land in exactly
-    // one of them:
+    // The arena is reserved in zones, in this order, and the offsets above land in
+    // exactly one of them:
     //
-    //   host-only    the orchestrator block. Dep-computation scratch the AICPU
-    //                never reads, so it is never copied.
+    //   device-only  sm_handle, the AICore mailbox, the scheduler state and its
+    //                queue slot arrays. Reachable storage whose content is a
+    //                function of the layout, not of the run, so the device writes
+    //                it at boot instead of receiving an initialization pattern
+    //                over PCIe.
     //   copied       [off_copied_begin, off_copied_end). Every byte carries this
     //                run's own content, so bind ships the whole zone as one
     //                contiguous range.
-    //   device-only  sm_handle, the scheduler state and its queue slot arrays.
-    //                Reachable storage whose content is a function of the layout,
-    //                not of the run, so the device writes it at boot instead of
-    //                receiving an initialization pattern over PCIe.
     //
-    // Placing the copied zone in the middle is what keeps the upload a single
-    // range: the two zones that are not copied sit on either side of it.
+    // off_copied_end is where the shared part of the layout stops. Past it the two
+    // sides carry different tails, and neither reads the other's:
+    //
+    //   host tail    the orchestrator block. Dep-computation scratch no device code
+    //                reads, so it is neither copied nor allocated on the device.
+    //   device tail  the shared-memory image, whose size is the submitted task
+    //                count and therefore not known when this layout is built. bind
+    //                grows the device region to cover it once orchestration ends.
+    //
+    // The copied zone is padded to a PTO2_ALIGN_SIZE boundary, so the device tail
+    // begins exactly at off_copied_end: the copied zone and the shared-memory image
+    // are adjacent on the device and travel as one copy.
     size_t off_copied_begin{0};
     size_t off_copied_end{0};
+
+    // Byte length of the device region before its shared-memory tail. The host
+    // arena is arena_size, which instead covers the orchestrator block there.
+    size_t device_bytes{0};
 
     // Cached parameters (re-used by init_data + wire stages).
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]{};
@@ -244,15 +257,33 @@ PTO2Runtime *runtime_init_data_from_layout(
 );
 
 /**
- * Phase 3 — wire every arena-internal pointer field (rt->sm_handle,
- * rt->aicore_mailbox, orchestrator.{scope_tasks, scope_begins, scheduler,
- * tensor_map.*, ring.fanin_pool.base}, scheduler.{ready_queues,
- * ready_sync_queues, early_dispatch_queues, dep_pool}) so each holds
- * arena.base() + offset. Idempotent — runs on
- * both host (writing host-mirror addresses) and AICPU (writing device
- * addresses) sides.
+ * Phase 3 — wire the arena-internal pointer fields that exist on both sides
+ * (rt->sm_handle, rt->aicore_mailbox, rt->scheduler and
+ * scheduler.{ready_queues, ready_sync_queues, early_dispatch_queues}) so each
+ * holds arena.base() + offset. Idempotent — runs on both host (writing
+ * host-mirror addresses) and AICPU (writing device addresses) sides.
  */
 void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
+
+/**
+ * Phase 3b — wire the orchestrator's pointers into the host-only zone
+ * (orchestrator.{scope_tasks, scope_begins, scheduler, tensor_map.*,
+ * ring.fanin_pool.base}).
+ *
+ * Host-only by construction: that zone is past layout.device_bytes and so is not
+ * allocated on the device, which makes the addresses this writes unrepresentable
+ * there. Requires rt->scheduler, so it follows runtime_wire_arena_pointers.
+ */
+void runtime_wire_host_only_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
+
+/**
+ * Drop the pointers Phase 3b wrote, so the runtime header can be copied to the
+ * device without carrying host addresses into it. The device reads one
+ * orchestrator field, inline_completed_tasks, which this leaves alone.
+ *
+ * Call after orchestration finishes and before the copied zone is uploaded.
+ */
+void runtime_clear_host_only_pointers(PTO2Runtime *rt);
 
 /**
  * AICPU-only Phase 4 — fill in the few fields the host could not know at

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -29,6 +29,7 @@
 #include <stdint.h>
 
 #include <atomic>
+#include <cstddef>
 
 #include "profiling_config.h"
 #include "pto_constants.h"
@@ -331,10 +332,18 @@ struct PTO2TaskPayload {
     // dispatch.
     alignas(64) DispatchPredicate predicate;
     ArgsDumpTaskMetadata dump_metadata;
-    // === Cache lines 10-73 (4096B) — tensors (alignas(64) forces alignment) ===
+    // === Cache lines 10-11 (128B) — scalars ===
+    // alignas is load-bearing: the AICore reads this at a compile-time offset, and
+    // uint64_t alone would let it start right after dump_metadata instead of on the
+    // next cache line. tensors got its 640 for free from ChipTensor's own alignment.
+    alignas(64) uint64_t scalars[MAX_SCALAR_ARGS];
+    // === Cache lines 12-75 (4096B) — tensors (alignas(64) forces alignment) ===
+    //
+    // Last on purpose. This is the only region whose used extent varies per task —
+    // one to seventeen entries of thirty-two on a measured decode — so putting it at
+    // the end makes everything a task reads a contiguous prefix, which is what lets
+    // the shipped image carry less than the whole array.
     ChipTensor tensors[MAX_TENSOR_ARGS];
-    // === Cache lines 74-75 (128B) — scalars ===
-    uint64_t scalars[MAX_SCALAR_ARGS];
 
     // Layout verification (size checks that don't need offsetof).
     static_assert(sizeof(ChipTensor) == 128, "ChipTensor must be 2 cache lines");
@@ -431,23 +440,93 @@ struct PTO2TaskPayload {
 static_assert(offsetof(PTO2TaskPayload, fanin_local_ids) == 12, "inline fanin id array must follow fanin_count");
 static_assert(
     offsetof(PTO2TaskPayload, predicate) == 576,
-    "dispatch predicate occupies cache line 9 at fixed byte 576 (before tensors, never moves)"
+    "dispatch predicate occupies cache line 9 at fixed byte 576 (before the arg arrays, never moves)"
 );
 static_assert(
     offsetof(PTO2TaskPayload, dump_metadata) + sizeof(ArgsDumpTaskMetadata) <= 640,
-    "dump metadata must fit in the AICPU-only cache line before tensors"
+    "dump metadata must fit in the AICPU-only cache line before the arg arrays"
 );
 static_assert(
-    offsetof(PTO2TaskPayload, tensors) == 640, "tensors must start at byte 640 (cache line 10, after predicate)"
+    offsetof(PTO2TaskPayload, scalars) == 640, "scalars must start at byte 640 (cache line 10, after predicate)"
 );
 static_assert(
-    offsetof(PTO2TaskPayload, scalars) == 640 + MAX_TENSOR_ARGS * sizeof(ChipTensor),
-    "scalars must immediately follow tensors"
+    offsetof(PTO2TaskPayload, tensors) == 640 + MAX_SCALAR_ARGS * sizeof(uint64_t),
+    "tensors must immediately follow scalars, and must be the last region: the shipped "
+    "image carries only as much of the array as a task uses, so nothing may sit past it"
 );
 static_assert(
-    sizeof(PTO2TaskPayload) == 640 + MAX_TENSOR_ARGS * sizeof(ChipTensor) + MAX_SCALAR_ARGS * sizeof(uint64_t),
-    "PTO2TaskPayload size = metadata(576) + predicate cache line(64) + tensors + scalars"
+    sizeof(PTO2TaskPayload) == 640 + MAX_SCALAR_ARGS * sizeof(uint64_t) + MAX_TENSOR_ARGS * sizeof(ChipTensor),
+    "PTO2TaskPayload size = metadata(576) + predicate cache line(64) + scalars + tensors"
 );
+
+/**
+ * A pointer to a sibling in the same contiguous block, stored as a byte delta
+ * from the field's own address.
+ *
+ * The block is `memcpy`'d to the device as one image, so a delta between two
+ * addresses inside it is invariant under the move while a raw pointer is not.
+ * Both users below satisfy that precondition: a ring task's payload and
+ * descriptor live in the same shared-memory image as its slot state, and a Graph
+ * node's live in the same GraphNodeStorage.
+ *
+ * A zero delta means unbound — a field can never coincide with its own target.
+ * Zeroed memory therefore reads as null, which is what the slot's pristine state
+ * is.
+ *
+ * int32_t bounds the distance at 2 GiB. Both blocks are far below it — a
+ * GraphNodeStorage is a fixed struct, and the shared-memory image's end is
+ * rejected above the bound in attach_populated — and set() leaves the field
+ * unbound rather than storing a truncated delta, so an out-of-range target
+ * reads back as null instead of as unrelated memory.
+ */
+namespace simpler::hbg {
+
+template <typename T>
+class SelfRelativePtr {
+public:
+    SelfRelativePtr() = default;
+
+    // The stored value means something only relative to where it is stored, so
+    // copying it from another field would silently retarget it. Every write goes
+    // through set(), which takes the destination's own address into account. A
+    // whole-block memcpy is unaffected: it moves the field and its target
+    // together, which is the case this representation exists for.
+    SelfRelativePtr(const SelfRelativePtr &) = delete;
+    SelfRelativePtr &operator=(const SelfRelativePtr &) = delete;
+
+    T *get() const {
+        if (delta_ == 0) return nullptr;
+        return reinterpret_cast<T *>(reinterpret_cast<uintptr_t>(this) + static_cast<intptr_t>(delta_));
+    }
+
+    void set(T *target) {
+        if (target == nullptr) {
+            delta_ = 0;
+            return;
+        }
+        const intptr_t delta = reinterpret_cast<intptr_t>(target) - reinterpret_cast<intptr_t>(this);
+        // Narrowing a delta this large would name unrelated memory that a consumer
+        // would then dereference. Unbound is the one value every consumer already
+        // tests for.
+        if (delta < INT32_MIN || delta > INT32_MAX) {
+            delta_ = 0;
+            return;
+        }
+        delta_ = static_cast<int32_t>(delta);
+    }
+
+    T *operator->() const { return get(); }
+    T &operator*() const { return *get(); }
+    explicit operator bool() const { return delta_ != 0; }
+
+    friend bool operator==(const SelfRelativePtr &lhs, std::nullptr_t) { return lhs.delta_ == 0; }
+    friend bool operator!=(const SelfRelativePtr &lhs, std::nullptr_t) { return lhs.delta_ != 0; }
+
+private:
+    int32_t delta_{0};
+};
+
+}  // namespace simpler::hbg
 
 /**
  * Per-task slot scheduling state (scheduler-private, NOT in shared memory)
@@ -477,8 +556,10 @@ struct alignas(64) PTO2TaskSlotState {
     std::atomic<PTO2TaskState> task_state;
 
     // --- Per-slot constant, re-bound by orch::prepare_task each submit ---
-    PTO2TaskPayload *payload;
-    PTO2TaskDescriptor *task;
+    // Self-relative, so the SM image needs no pointer fix-up on its way to the
+    // device: both targets sit in the same block as this field.
+    simpler::hbg::SelfRelativePtr<PTO2TaskPayload> payload;
+    simpler::hbg::SelfRelativePtr<PTO2TaskDescriptor> task;
 
     // --- Wake list: last-fanin notification (intrusive, lock-free) ---
     // A pending consumer whose fanin scan finds an unmet producer registers on
@@ -534,8 +615,8 @@ struct alignas(64) PTO2TaskSlotState {
     }
 
     void bind_buffers(PTO2TaskPayload *p, PTO2TaskDescriptor *t) {
-        payload = p;
-        task = t;
+        payload.set(p);
+        task.set(t);
     }
 
     // Host-visible completion mirror. The device readiness truth

--- a/src/a5/runtime/host_build_graph/runtime/pto_shared_memory.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_shared_memory.h
@@ -34,6 +34,8 @@
 
 #include <stddef.h>
 
+#include <cstring>
+
 #include "utils/device_arena.h"
 #include "pto_runtime2_types.h"
 
@@ -143,9 +145,11 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
         return task_descriptors[get_slot_by_task_id(local_id)];
     }
 
-    PTO2TaskPayload &get_payload_by_slot(int32_t slot) { return task_payloads[slot]; }
-
-    PTO2TaskPayload &get_payload_by_task_id(int32_t local_id) { return task_payloads[get_slot_by_task_id(local_id)]; }
+    // No get_payload_by_slot / get_payload_by_task_id here on purpose: the shipped
+    // image strides its payload array by the widest task in the bind, not by
+    // sizeof(PTO2TaskPayload), so indexing it as an array of the type would land
+    // between payloads. A payload is reached through its slot state's `payload`,
+    // which the image's restack rebinds to the real address.
 
     PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
@@ -240,7 +244,17 @@ struct PTO2SharedMemoryHandle {
     // Used by host_build_graph host-orch, where the host orchestrator populated
     // the SM and H2D'd it; the device must re-point at its own SM base without
     // wiping the contents (unlike init_per_ring, which also resets the header).
-    bool attach_populated(void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
+    //
+    // `live_slots` is the pitch the uploaded arrays were laid out with — the
+    // number of slots the host actually submitted, not the ring capacity. It must
+    // match what the host used or every segment past the descriptors resolves to
+    // the wrong address, so both sides derive it from the same submitted count.
+    // The capacity and mask in the header are unchanged, and `local_id & mask`
+    // yields `local_id`, which is below `live_slots` for every ring task.
+    bool attach_populated(
+        void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t live_slots,
+        uint64_t payload_stride
+    );
 
     void destroy();
     void print_layout();
@@ -252,7 +266,13 @@ private:
         const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
     );
     void setup_pointers(uint64_t task_window_size);
-    void setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
+    // `pitch` is the slot count the arrays are dimensioned for. init_per_ring
+    // passes the ring capacity (the mirror the orchestrator writes into);
+    // attach_populated passes the submitted count (the compacted image that
+    // shipped).
+    void setup_pointers_per_ring(
+        const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch, uint64_t payload_stride
+    );
 };
 
 // =============================================================================
@@ -293,6 +313,17 @@ inline std::atomic<int32_t> *ring_current_task_index_addr(void *sm_dev_base) noe
 // Byte offsets (from the SM base) of the ring's three segments. The layout is:
 // header, then descriptors -> payloads -> slot_states, every segment
 // PTO2_ALIGN_UP-padded.
+//
+// Two parameters, and the host mirror and the shipped image differ in both.
+//
+// The *pitch* is how many slots the arrays are dimensioned for: the mirror uses the
+// ring capacity, the image uses the submitted count, which is what makes the four
+// live prefixes contiguous and the upload one copy.
+//
+// The *payload stride* is how far apart consecutive payloads sit. The mirror uses
+// sizeof(PTO2TaskPayload), whose tensor array is dimensioned for the widest task the
+// API allows. The image uses the widest task in this bind — the array is the last
+// field, so anything past that task's entries is read by nobody.
 struct PTO2RingSegmentOffsets {
     uint64_t descriptors;
     uint64_t payloads;
@@ -307,13 +338,14 @@ struct PTO2RingSegmentOffsets {
 // `sm_dev_base`). Adding or reordering a segment is a one-line edit here; every
 // consumer follows automatically, so the layout walk can never silently
 // disagree across call sites.
-inline PTO2RingSegmentOffsets ring_segment_offsets(uint64_t task_window_size) noexcept {
+inline PTO2RingSegmentOffsets
+ring_segment_offsets(uint64_t task_window_size, uint64_t payload_stride = sizeof(PTO2TaskPayload)) noexcept {
     uint64_t off = PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
     PTO2RingSegmentOffsets o{};
     o.descriptors = off;
     off += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
     o.payloads = off;
-    off += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
+    off += PTO2_ALIGN_UP(task_window_size * payload_stride, PTO2_ALIGN_SIZE);
     o.slot_states = off;
     off += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
     o.completion_flags = off;
@@ -322,25 +354,84 @@ inline PTO2RingSegmentOffsets ring_segment_offsets(uint64_t task_window_size) no
     return o;
 }
 
-// Device address of the task_descriptors array.
-inline PTO2TaskDescriptor *ring_task_descriptors_addr(void *sm_dev_base, uint64_t task_window_size) noexcept {
-    return reinterpret_cast<PTO2TaskDescriptor *>(
-        static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_size).descriptors
-    );
+// The pitch the shipped image uses for a given submitted task count. A bind that
+// submits nothing still ships its header and still attaches, and a zero-length
+// array has no layout, so the pitch never drops below one slot.
+inline uint64_t live_slot_pitch(uint64_t submitted_tasks) noexcept {
+    return submitted_tasks == 0 ? 1 : submitted_tasks;
 }
 
-// Device address of the slot_states array used by host/device pointer wiring.
-inline PTO2TaskSlotState *ring_slot_states_addr(void *sm_dev_base, uint64_t task_window_size) noexcept {
-    return reinterpret_cast<PTO2TaskSlotState *>(
-        static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_size).slot_states
-    );
+// The stride a shipped payload array uses for a given widest task. The tensor array
+// is the payload's last field, so a task reads nothing past its own entries and the
+// stride need only cover them — but every payload in the image shares one stride, so
+// it is the widest task that sets it.
+//
+// Rounded up to PTO2_ALIGN_SIZE because PTO2TaskPayload's own alignment is 64 and the
+// image places consecutive payloads at multiples of the stride.
+inline uint64_t shipped_payload_stride(int32_t widest_tensor_count) noexcept {
+    constexpr uint64_t kTensorsOffset = offsetof(PTO2TaskPayload, tensors);
+    const uint64_t used = static_cast<uint64_t>(widest_tensor_count < 0 ? 0 : widest_tensor_count) * sizeof(ChipTensor);
+    const uint64_t stride = PTO2_ALIGN_UP(kTensorsOffset + used, PTO2_ALIGN_SIZE);
+    return stride > sizeof(PTO2TaskPayload) ? sizeof(PTO2TaskPayload) : stride;
 }
 
-// Device address of the polling completion_flags byte array.
-inline std::atomic<uint8_t> *ring_completion_flags_addr(void *sm_dev_base, uint64_t task_window_size) noexcept {
-    return reinterpret_cast<std::atomic<uint8_t> *>(
-        static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_size).completion_flags
-    );
+// Restack the live prefix of every ring segment from the ring-pitched mirror the
+// orchestrator wrote into an image pitched to `submitted_tasks`, where the four
+// prefixes are contiguous and can travel as one copy.
+//
+// `out_base` must be PTO2_ALIGN_SIZE-aligned and hold
+// `ring_segment_offsets(live_slot_pitch(submitted_tasks)).end` bytes. Returns that
+// byte count.
+//
+// Two things the restack has to fix up, both because the image is not the mirror:
+//
+//   - the ring header's data pointers name the mirror's arrays, so they leave as
+//     null rather than carrying host addresses into device memory (the device
+//     resolves them in attach_populated);
+//   - a slot state names its payload and descriptor by a delta from its own
+//     address, and the restack changed those distances, so each binding is
+//     re-taken against the image.
+inline uint64_t compact_live_image(
+    const char *mirror_base, uint64_t task_window_size, uint64_t submitted_tasks, uint64_t payload_stride,
+    char *out_base
+) noexcept {
+    // The mirror is pitched to the capacity and to the type, so a larger live count
+    // or a wider stride reads past the segment it is copying from and ships a corrupt
+    // image. attach_populated tests the same two bounds on the device side.
+    always_assert(submitted_tasks <= task_window_size);
+    always_assert(payload_stride <= sizeof(PTO2TaskPayload));
+    const PTO2RingSegmentOffsets from = ring_segment_offsets(task_window_size);
+    const PTO2RingSegmentOffsets to = ring_segment_offsets(live_slot_pitch(submitted_tasks), payload_stride);
+
+    // The header and the descriptors offset are pitch-independent, so the header
+    // lands where it already was.
+    std::memcpy(out_base, mirror_base, to.descriptors);
+    auto &out_ring = reinterpret_cast<PTO2SharedMemoryHeader *>(out_base)->ring;
+    out_ring.task_descriptors = nullptr;
+    out_ring.task_payloads = nullptr;
+    out_ring.slot_states = nullptr;
+    out_ring.completion_flags = nullptr;
+
+    const uint64_t nt = submitted_tasks;
+    std::memcpy(out_base + to.descriptors, mirror_base + from.descriptors, nt * sizeof(PTO2TaskDescriptor));
+    // Per payload, because the source and destination strides differ: the mirror is
+    // pitched to the type, the image to the widest task in this bind.
+    for (uint64_t i = 0; i < nt; ++i) {
+        std::memcpy(
+            out_base + to.payloads + i * payload_stride, mirror_base + from.payloads + i * sizeof(PTO2TaskPayload),
+            payload_stride
+        );
+    }
+    std::memcpy(out_base + to.slot_states, mirror_base + from.slot_states, nt * sizeof(PTO2TaskSlotState));
+    std::memcpy(out_base + to.completion_flags, mirror_base + from.completion_flags, nt * sizeof(std::atomic<uint8_t>));
+
+    auto *out_slots = reinterpret_cast<PTO2TaskSlotState *>(out_base + to.slot_states);
+    auto *out_descriptors = reinterpret_cast<PTO2TaskDescriptor *>(out_base + to.descriptors);
+    for (uint64_t i = 0; i < nt; ++i) {
+        auto *out_payload = reinterpret_cast<PTO2TaskPayload *>(out_base + to.payloads + i * payload_stride);
+        out_slots[i].bind_buffers(out_payload, &out_descriptors[i]);
+    }
+    return to.end;
 }
 
 }  // namespace pto2_sm_layout

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -173,6 +173,13 @@ public:
     // the boot thread reads this instead of counting SM ring heads.
     int32_t host_total_tasks;
 
+    // Distance between consecutive payloads in the shipped shared-memory image.
+    // Smaller than sizeof(PTO2TaskPayload) whenever the bind's widest task uses
+    // fewer tensors than the array holds, which is the usual case. Set by the host
+    // before the image is copied; the AICPU needs it at attach to place every
+    // segment that follows the payload array.
+    uint64_t sm_payload_stride;
+
 private:
     // Kernel binary tracking for cleanup
 

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -906,7 +906,7 @@ struct PTO2SchedulerState {
         const uint32_t end = execution.fanin_offsets[node_index + 1];
         for (uint32_t edge = begin; edge < end; ++edge) {
             const uint16_t producer_index = execution.fanin_indices[edge];
-            const PTO2TaskSlotState &producer = execution.nodes[producer_index].slot;
+            const PTO2TaskSlotState &producer = execution.node_at(producer_index).slot;
             if (producer.task_state.load(std::memory_order_acquire) != PTO2_TASK_COMPLETED) {
                 return static_cast<int32_t>(producer_index);
             }
@@ -934,7 +934,7 @@ struct PTO2SchedulerState {
                 push_ready_routed(consumer);
                 return;
             }
-            producer = &execution.nodes[unmet_producer].slot;
+            producer = &execution.node_at(unmet_producer).slot;
         }
     }
 
@@ -947,7 +947,7 @@ struct PTO2SchedulerState {
             if (unmet_producer < 0) {
                 push_ready_routed(waiter);
             } else {
-                register_graph_wake(execution, &execution.nodes[unmet_producer].slot, waiter);
+                register_graph_wake(execution, &execution.node_at(unmet_producer).slot, waiter);
             }
             consumers_rescanned++;
             waiter = next;
@@ -978,7 +978,7 @@ struct PTO2SchedulerState {
                 continue;
             }
             if (execution.fanin_offsets[i] == execution.fanin_offsets[i + 1]) {
-                push_ready_routed(&execution.node_storage[i].slot);
+                push_ready_routed(&execution.node_at(i).slot);
                 routed++;
             }
         }
@@ -996,12 +996,12 @@ struct PTO2SchedulerState {
     void graph_incremental_publish(GraphExecution &execution, int32_t first, int32_t last) {
         for (int32_t i = first; i < last; ++i) {
             if (execution.fanin_offsets[i] == execution.fanin_offsets[i + 1]) continue;  // root
-            PTO2TaskSlotState &node = execution.node_storage[i].slot;
+            PTO2TaskSlotState &node = execution.node_at(i).slot;
             const int32_t unmet = graph_first_unmet_producer(execution, node);
             if (unmet < 0) {
                 push_ready_routed(&node);
             } else {
-                register_graph_wake(execution, &execution.nodes[unmet].slot, &node);
+                register_graph_wake(execution, &execution.node_at(unmet).slot, &node);
             }
         }
         execution.published_nodes.store(last, std::memory_order_release);

--- a/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -322,21 +322,26 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
         layout.heap_sizes[r] = heap_sizes[r];
     }
 
-    // Reservation order is the zone partition (see PTO2RuntimeArenaLayout): the
-    // host-only orchestrator block, then the one copied range, then everything
-    // the device initializes itself. Each zone is contiguous, so bind is a single
-    // copy and no consumer has to infer a boundary from what happens to come
-    // first.
-    layout.orch = PTO2OrchestratorState::reserve_layout(arena, static_cast<int32_t>(task_window_sizes[0]));
-
-    layout.off_copied_begin = arena.total_size();
-    layout.off_runtime = arena.reserve(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE);
-    layout.off_copied_end = arena.total_size();
-
+    // Reservation order is the zone partition (see PTO2RuntimeArenaLayout):
+    // everything the device initializes itself, then the one copied range. Each
+    // zone is contiguous, so bind is a single copy and no consumer has to infer a
+    // boundary from what happens to come first.
+    //
+    // The copied zone comes last of the two so the device's shared-memory tail can
+    // begin where it ends, making the two adjacent and the upload one copy.
     layout.off_sm_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
     layout.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
     layout.off_scheduler = arena.reserve(sizeof(PTO2SchedulerState), alignof(PTO2SchedulerState));
     layout.sched = PTO2SchedulerState::reserve_layout(arena);
+
+    layout.off_copied_begin = arena.total_size();
+    // Padded to a PTO2_ALIGN_SIZE boundary: the shared-memory image starts at
+    // off_copied_end on the device and its segment offsets are aligned from there.
+    layout.off_runtime = arena.reserve(PTO2_ALIGN_UP(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE), PTO2_ALIGN_SIZE);
+    layout.off_copied_end = arena.total_size();
+
+    layout.device_bytes = arena.total_size();
+    layout.orch = PTO2OrchestratorState::reserve_layout(arena, static_cast<int32_t>(task_window_sizes[0]));
 
     layout.arena_size = arena.total_size();
     return layout;
@@ -360,9 +365,8 @@ PTO2Runtime *runtime_init_data_from_layout(
  * and initializes the scheduler (ready / sync / dummy / graph queues) against
  * the device SM. The orchestrator is deliberately left zeroed: the host-orch
  * path (run_host_orchestration) initializes it against the host SM once that
- * buffer exists, then relocates it for the device. Initializing it here would
- * be dead work — overwritten by that re-init, and the orchestrator arena block
- * is never uploaded to the device. Caller must follow up with
+ * buffer exists. Initializing it here would be dead work — overwritten by that
+ * re-init, and the orchestrator arena block is never uploaded to the device. Caller must follow up with
  * runtime_wire_arena_pointers. Returns the arena-resident PTO2Runtime*, or
  * nullptr on failure.
  */
@@ -388,10 +392,10 @@ PTO2Runtime *runtime_init_data_from_layout(
     // Two components are deliberately not initialized here.
     //
     // The orchestrator is initialized by the host-orch path
-    // (run_host_orchestration) against the host SM once it is allocated, then
-    // relocated for the device. Doing it here would be dead work: its arena
-    // content (tensormap + seen_epoch memset) is immediately overwritten by that
-    // re-init, and the orchestrator block is host-only anyway.
+    // (run_host_orchestration) against the host SM once it is allocated. Doing it
+    // here would be dead work: its arena content (tensormap + seen_epoch memset)
+    // is immediately overwritten by that re-init, and the orchestrator block is
+    // host-only anyway.
     //
     // The scheduler and sm_handle live in the device-only zone, so their bytes
     // never travel; the AICPU initializes them at boot. Writing them here would
@@ -405,9 +409,14 @@ void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayou
     rt->sm_handle = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(layout.off_sm_handle));
     rt->aicore_mailbox = static_cast<AICoreCompletionMailbox *>(arena.region_ptr(layout.off_mailbox));
     rt->scheduler = static_cast<PTO2SchedulerState *>(arena.region_ptr(layout.off_scheduler));
-    rt->orchestrator.wire_arena_pointers(layout.orch, arena, rt->scheduler);
     rt->scheduler->wire_arena_pointers(layout.sched, arena);
 }
+
+void runtime_wire_host_only_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt) {
+    rt->orchestrator.wire_arena_pointers(layout.orch, arena, rt->scheduler);
+}
+
+void runtime_clear_host_only_pointers(PTO2Runtime *rt) { rt->orchestrator.destroy(); }
 
 void runtime_destroy(PTO2Runtime *rt, DeviceArena & /*arena*/) {
     // Arena buffer is pooled across runs by DeviceRunner — never freed here.

--- a/src/a5/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
@@ -45,14 +45,17 @@ uint64_t PTO2SharedMemoryHandle::calculate_size_per_ring(const uint64_t task_win
 // Creation and Destruction
 // =============================================================================
 
-void PTO2SharedMemoryHandle::setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+void PTO2SharedMemoryHandle::setup_pointers_per_ring(
+    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch, uint64_t payload_stride
+) {
+    (void)task_window_sizes;
     char *base = (char *)sm_base;
     header = (PTO2SharedMemoryHeader *)base;
 
     // Per-ring descriptors / payloads / slot_states — offsets from the single
     // source of truth (pto2_sm_layout::ring_segment_offsets), so this setup and
     // the device-address helpers cannot drift.
-    auto off = pto2_sm_layout::ring_segment_offsets(task_window_sizes[0]);
+    auto off = pto2_sm_layout::ring_segment_offsets(pitch, payload_stride);
     auto &ring = header->ring;
     ring.task_descriptors = (PTO2TaskDescriptor *)(base + off.descriptors);
     ring.task_payloads = (PTO2TaskPayload *)(base + off.payloads);
@@ -65,7 +68,7 @@ void PTO2SharedMemoryHandle::setup_pointers(uint64_t task_window_size) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
     }
-    setup_pointers_per_ring(task_window_sizes);
+    setup_pointers_per_ring(task_window_sizes, task_window_size, sizeof(PTO2TaskPayload));
 }
 
 bool PTO2SharedMemoryHandle::init(
@@ -90,21 +93,36 @@ bool PTO2SharedMemoryHandle::init_per_ring(
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers_per_ring(task_window_sizes);
+    setup_pointers_per_ring(task_window_sizes, task_window_sizes[0], sizeof(PTO2TaskPayload));
     init_header_per_ring(task_window_sizes, heap_sizes);
     return true;
 }
 
 bool PTO2SharedMemoryHandle::attach_populated(
-    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t live_slots,
+    uint64_t payload_stride
 ) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
-    if (sm_size_arg < calculate_size_per_ring(task_window_sizes)) return false;
+    // A pitch above the capacity would name a slot the ring cannot address, and one
+    // below what the host used would place every segment past the descriptors
+    // short. This is the whole contract between the two sides, checked once at
+    // attach rather than trusted.
+    if (live_slots == 0 || live_slots > task_window_sizes[0]) return false;
+    // A stride past the type's size would read between payloads; one below the tensor
+    // array's own offset could not hold a payload's fixed head at all.
+    if (payload_stride > sizeof(PTO2TaskPayload) || payload_stride < offsetof(PTO2TaskPayload, tensors)) return false;
+    // The region holds the compacted image, so that is what has to fit — the ring
+    // capacity is no longer its size.
+    const uint64_t image_end = pto2_sm_layout::ring_segment_offsets(live_slots, payload_stride).end;
+    if (sm_size_arg < image_end) return false;
+    // A slot state names its payload and descriptor by an int32 delta from its own
+    // address, so no two positions in the image may be further apart than that.
+    if (image_end > static_cast<uint64_t>(INT32_MAX)) return false;
 
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers_per_ring(task_window_sizes);
+    setup_pointers_per_ring(task_window_sizes, live_slots, payload_stride);
     // Deliberately NO init_header_per_ring: the SM already holds the host
     // orchestrator's task graph (descriptors, slot states, ring counters).
     return true;

--- a/src/a5/runtime/host_build_graph/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/runtime.cpp
@@ -35,6 +35,7 @@ Runtime::Runtime() {
     aicpu_allowed_cpu_count = 0;
     aicpu_launch_count = 0;
     host_total_tasks = 0;
+    sm_payload_stride = sizeof(PTO2TaskPayload);
 
     // Initialize shared-memory / orchestration argument plumbing
     gm_sm_ptr_ = nullptr;

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -380,10 +380,12 @@ bytes it starts from are whatever that heap region last held.
 ## Scheduler flow
 
 Host orchestration builds the complete task image before device execution. At
-the end of orchestration, the Host uploads every exact-size Graph POD image,
-relocates the task and payload pointers in the shared-memory image, copies the
-complete shared-memory/runtime-arena image to the device, and then launches the
-resident Scheduler.
+the end of orchestration, the Host stages each Graph POD image into the runtime
+arena's device region alongside the compacted shared-memory image, copies that
+one bind image to the device, and then launches the resident Scheduler. Nothing
+is patched on the way: a slot state names its payload and descriptor by a delta
+from its own address, so the bytes the Host wrote are the bytes the device
+schedules.
 
 All AICPU threads classify disjoint slices of the completed task window behind
 one startup barrier. A Graph task enters preparation and external-fanin

--- a/src/common/host_build_graph/graph_execution.cpp
+++ b/src/common/host_build_graph/graph_execution.cpp
@@ -22,15 +22,18 @@ namespace {
 // The storage is the tail of the outer GRAPH task's heap allocation, so its
 // bytes are whatever that region last held; every field an execution needs is
 // written here or by the materialize pass, never inherited from those bytes.
-GraphExecution *acquire_host_execution_storage(uintptr_t storage_addr, size_t storage_bytes, int32_t node_count) {
+GraphExecution *
+acquire_host_execution_storage(uintptr_t storage_addr, size_t storage_bytes, int32_t node_count, size_t node_stride) {
     size_t nodes_offset = 0;
     size_t required_bytes = 0;
     if (storage_addr == 0 || storage_addr % alignof(GraphNodeStorage) != 0 ||
-        !graph_execution_storage_layout(node_count, &nodes_offset, &required_bytes) || required_bytes > storage_bytes) {
+        !graph_execution_storage_layout(node_count, node_stride, &nodes_offset, &required_bytes) ||
+        required_bytes > storage_bytes) {
         return nullptr;
     }
     auto *execution = new (reinterpret_cast<void *>(storage_addr)) GraphExecution{};
     execution->node_count = node_count;
+    execution->node_stride = node_stride;
     execution->remaining_nodes.store(node_count, std::memory_order_relaxed);
     execution->node_storage =
         reinterpret_cast<GraphNodeStorage *>(reinterpret_cast<uint8_t *>(execution) + nodes_offset);
@@ -238,7 +241,7 @@ bool graph_rebind_tensor(
             (!own_output && producer_index == node_index)) {
             return false;
         }
-        PTO2TaskDescriptor &producer = execution.node_storage[producer_index].task;
+        PTO2TaskDescriptor &producer = execution.node_at(producer_index).task;
         const uint64_t producer_bytes = static_cast<uint64_t>(nodes[producer_index].total_output_size);
         const uintptr_t producer_base = reinterpret_cast<uintptr_t>(producer.packed_buffer_base);
         if (ref.packed_offset > producer_bytes || rebound.buffer_size > producer_bytes - ref.packed_offset ||
@@ -364,7 +367,7 @@ GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
 
     GraphExecution *execution = acquire_host_execution_storage(
         outer_base + definition->required_heap, definition->execution_storage_bytes,
-        static_cast<int32_t>(definition->task_count)
+        static_cast<int32_t>(definition->task_count), definition->node_stride
     );
     if (execution == nullptr) {
         __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
@@ -470,7 +473,7 @@ GraphMaterializeResult graph_execution_materialize_slice(
     const int32_t last = std::min(execution.node_count, first + max_nodes);
     const uintptr_t outer_base = reinterpret_cast<uintptr_t>(outer_slot.task->packed_buffer_base);
     for (int32_t i = first; i < last; ++i) {
-        GraphNodeStorage *storage = &execution.node_storage[i];
+        GraphNodeStorage *storage = &execution.node_at(i);
         if (i >= execution.constructed_nodes) {
             storage = new (storage) GraphNodeStorage;
             execution.constructed_nodes++;

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -166,6 +166,11 @@ struct GraphDefinition {
     // required_heap + this, and the execution lives at
     // packed_buffer_base + required_heap.
     uint32_t execution_storage_bytes;
+    // Distance between consecutive GraphNodeStorage entries in an execution of this
+    // Definition. The payload is the last field of both the storage and the payload
+    // itself, so a node reads only as much of its tensor array as it declares — this
+    // is sized to the widest node here rather than to sizeof(GraphNodeStorage).
+    uint32_t node_stride;
     uint32_t off_fanout_offsets;
     uint32_t off_fanout_indices;
     uint32_t off_fanin_offsets;
@@ -345,8 +350,13 @@ enum class GraphMaterializeResult : uint8_t {
 
 struct alignas(64) GraphNodeStorage {
     PTO2TaskDescriptor task;
-    PTO2TaskPayload payload;
     PTO2TaskSlotState slot;
+    // Last on purpose, and it must stay last: the payload's own tensor array is its
+    // final field, so a node reads only a prefix of this struct, and the execution
+    // storage can be strided by the widest node in the graph instead of by the type.
+    // The slot reaches it by a delta from the slot's own address, so the order is
+    // free.
+    PTO2TaskPayload payload;
 };
 
 inline constexpr uint64_t GRAPH_EXECUTION_INITIALIZING = 1;
@@ -370,6 +380,10 @@ struct GraphExecution {
     PTO2TaskSlotState *outer_slot{nullptr};
     GraphNodeStorage *nodes{nullptr};
     GraphNodeStorage *node_storage{nullptr};
+    // Entries sit this far apart, which is at most sizeof(GraphNodeStorage) and usually
+    // less. Reach one through node_at(); indexing node_storage as an array of the type
+    // would land between entries.
+    size_t node_stride{sizeof(GraphNodeStorage)};
     const GraphDefinition *definition{nullptr};
     const uint32_t *fanin_offsets{nullptr};
     const uint16_t *fanin_indices{nullptr};
@@ -377,27 +391,65 @@ struct GraphExecution {
     uint32_t boundary_tensor_count{0};
     const uint64_t *boundary_scalars{nullptr};
     uint32_t boundary_scalar_count{0};
+
+    // One multiply — the same one the compiler already emitted for node_storage[i],
+    // since sizeof(GraphNodeStorage) is not a power of two and the scale was never a
+    // shift. Callers on the dispatch path pay nothing for the stride becoming a
+    // runtime value.
+    GraphNodeStorage &node_at(int32_t index) const {
+        return *reinterpret_cast<GraphNodeStorage *>(
+            reinterpret_cast<uint8_t *>(node_storage) + static_cast<size_t>(index) * node_stride
+        );
+    }
 };
 
 static_assert(std::is_trivially_destructible_v<GraphNodeStorage>);
+static_assert(
+    offsetof(GraphNodeStorage, payload) + sizeof(PTO2TaskPayload) == sizeof(GraphNodeStorage),
+    "the payload must be GraphNodeStorage's last field: the execution storage is strided by how much "
+    "of it a node uses, so anything placed after it would be cut off"
+);
 static_assert(std::is_trivially_destructible_v<GraphExecution>);
 
 // The execution occupies [GraphExecution][GraphNodeStorage x node_count] at the
 // tail of the outer GRAPH task's heap allocation.
-inline bool graph_execution_storage_layout(int32_t node_count, size_t *nodes_offset, size_t *storage_bytes) {
+// The smallest stride that still holds a node's payload head. A node reads that head
+// plus as many tensor entries as it declares, and the tensor array is the last field of
+// the payload, which is in turn the last field of the storage.
+inline constexpr size_t graph_node_stride_floor() noexcept {
+    return offsetof(GraphNodeStorage, payload) + offsetof(PTO2TaskPayload, tensors);
+}
+
+// The stride an execution uses for a given widest node. Rounded up to
+// GraphNodeStorage's own alignment, since the array places consecutive entries at
+// multiples of the stride, and clamped to the type: that is the widest an execution can
+// ever need.
+inline size_t graph_node_stride(int32_t widest_tensor_count) noexcept {
+    constexpr size_t ALIGNMENT = alignof(GraphNodeStorage);
+    const size_t used = static_cast<size_t>(widest_tensor_count < 0 ? 0 : widest_tensor_count) * sizeof(ChipTensor);
+    const size_t stride = (graph_node_stride_floor() + used + ALIGNMENT - 1) & ~(ALIGNMENT - 1);
+    return stride > sizeof(GraphNodeStorage) ? sizeof(GraphNodeStorage) : stride;
+}
+
+inline bool
+graph_execution_storage_layout(int32_t node_count, size_t node_stride, size_t *nodes_offset, size_t *storage_bytes) {
     if (nodes_offset == nullptr || storage_bytes == nullptr || node_count <= 0 ||
-        node_count > static_cast<int32_t>(GRAPH_MAX_NODES)) {
+        node_count > static_cast<int32_t>(GRAPH_MAX_NODES) || node_stride > sizeof(GraphNodeStorage) ||
+        node_stride < graph_node_stride_floor() || node_stride % alignof(GraphNodeStorage) != 0) {
         return false;
     }
     constexpr size_t ALIGNMENT = alignof(GraphNodeStorage);
     *nodes_offset = (sizeof(GraphExecution) + ALIGNMENT - 1) & ~(ALIGNMENT - 1);
-    *storage_bytes = *nodes_offset + static_cast<size_t>(node_count) * sizeof(GraphNodeStorage);
+    // Entries sit node_stride apart, but each one is created by placement-new of a
+    // whole GraphNodeStorage, so the last entry's object has to fit: the reservation
+    // ends at its full size rather than at its stride.
+    *storage_bytes = *nodes_offset + static_cast<size_t>(node_count - 1) * node_stride + sizeof(GraphNodeStorage);
     return true;
 }
 
-inline bool graph_execution_storage_bytes(int32_t node_count, size_t *storage_bytes) {
+inline bool graph_execution_storage_bytes(int32_t node_count, size_t node_stride, size_t *storage_bytes) {
     size_t nodes_offset = 0;
-    return graph_execution_storage_layout(node_count, &nodes_offset, storage_bytes);
+    return graph_execution_storage_layout(node_count, node_stride, &nodes_offset, storage_bytes);
 }
 
 GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot);

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -846,6 +846,8 @@ add_a2a3_hbg_runtime_test(test_hbg_core_tracker common/test_hbg_core_tracker.cpp
 # shared init TU (and the orchestrator/SM members that TU refers to).
 add_a2a3_hbg_runtime_test(test_hbg_ready_queue_seed common/test_hbg_ready_queue_seed.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_mailbox_init common/test_hbg_mailbox_init.cpp)
+add_a2a3_hbg_runtime_test(test_hbg_self_relative_ptr common/test_hbg_self_relative_ptr.cpp)
+add_a2a3_hbg_runtime_test(test_hbg_sm_compaction common/test_hbg_sm_compaction.cpp)
 target_sources(test_hbg_ready_queue_seed PRIVATE
     ${HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
     ${HBG_RUNTIME_DIR}/orchestrator_core/pto_ring_buffer.cpp
@@ -878,6 +880,18 @@ target_sources(test_hbg_graph_submit_failure PRIVATE
     ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
 )
 add_a2a3_hbg_runtime_test(test_hbg_graph_async_submit common/test_hbg_graph_async_submit.cpp)
+# Drives the real orchestrator submit and Graph placement paths, so it links the
+# same out-of-line members as the graph-submit test.
+add_a2a3_hbg_runtime_test(test_hbg_slot_claim common/test_hbg_slot_claim.cpp)
+target_sources(test_hbg_slot_claim PRIVATE
+    ${HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
+    ${HBG_RUNTIME_DIR}/orchestrator_core/pto_ring_buffer.cpp
+    ${HBG_RUNTIME_DIR}/shared/pto_shared_memory.cpp
+    ${HBG_RUNTIME_DIR}/shared/pto_tensormap.cpp
+    ${HBG_RUNTIME_DIR}/shared/pto_runtime2_init.cpp
+    ${HBG_RUNTIME_DIR}/shared/runtime.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+)
 add_a5_hbg_runtime_test(test_a5_hbg_graph_submit_failure common/test_hbg_graph_submit_failure.cpp)
 target_sources(test_a5_hbg_graph_submit_failure PRIVATE
     ${A5_HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
@@ -889,9 +903,21 @@ target_sources(test_a5_hbg_graph_submit_failure PRIVATE
     ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
 )
 add_a5_hbg_runtime_test(test_a5_hbg_graph_async_submit common/test_hbg_graph_async_submit.cpp)
+add_a5_hbg_runtime_test(test_a5_hbg_slot_claim common/test_hbg_slot_claim.cpp)
+target_sources(test_a5_hbg_slot_claim PRIVATE
+    ${A5_HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
+    ${A5_HBG_RUNTIME_DIR}/orchestrator_core/pto_ring_buffer.cpp
+    ${A5_HBG_RUNTIME_DIR}/shared/pto_shared_memory.cpp
+    ${A5_HBG_RUNTIME_DIR}/shared/pto_tensormap.cpp
+    ${A5_HBG_RUNTIME_DIR}/shared/pto_runtime2_init.cpp
+    ${A5_HBG_RUNTIME_DIR}/shared/runtime.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+)
 add_a5_hbg_runtime_test(test_a5_hbg_core_tracker common/test_hbg_core_tracker.cpp)
 add_a5_hbg_runtime_test(test_a5_hbg_ready_queue_seed common/test_hbg_ready_queue_seed.cpp)
 add_a5_hbg_runtime_test(test_a5_hbg_mailbox_init common/test_hbg_mailbox_init.cpp)
+add_a5_hbg_runtime_test(test_a5_hbg_self_relative_ptr common/test_hbg_self_relative_ptr.cpp)
+add_a5_hbg_runtime_test(test_a5_hbg_sm_compaction common/test_hbg_sm_compaction.cpp)
 target_sources(test_a5_hbg_ready_queue_seed PRIVATE
     ${A5_HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
     ${A5_HBG_RUNTIME_DIR}/orchestrator_core/pto_ring_buffer.cpp

--- a/tests/ut/cpp/a2a3/test_graph_activation.cpp
+++ b/tests/ut/cpp/a2a3/test_graph_activation.cpp
@@ -66,7 +66,7 @@ protected:
         node.slot.task_kind = TaskKind::KERNEL;
         node.slot.total_required_subtasks = 1;
         node.slot.logical_block_num = 1;
-        node.slot.payload = &node.payload;
+        node.slot.payload.set(&node.payload);
     }
 };
 
@@ -138,7 +138,7 @@ TEST_F(GraphActivationTest, CompleteTaskAcceptsCompletionBeforeActive) {
         node[0].slot.task_kind = TaskKind::GRAPH_NODE;
         node[0].slot.graph_node_index = 0;
         node[0].slot.total_required_subtasks = 1;
-        node[0].slot.payload = &node[0].payload;
+        node[0].slot.payload.set(&node[0].payload);
 
         GraphExecution exec{};
         exec.definition = &definition;

--- a/tests/ut/cpp/a5/test_graph_activation.cpp
+++ b/tests/ut/cpp/a5/test_graph_activation.cpp
@@ -66,7 +66,7 @@ protected:
         node.slot.task_kind = TaskKind::KERNEL;
         node.slot.total_required_subtasks = 1;
         node.slot.logical_block_num = 1;
-        node.slot.payload = &node.payload;
+        node.slot.payload.set(&node.payload);
     }
 };
 
@@ -138,7 +138,7 @@ TEST_F(GraphActivationTest, CompleteTaskAcceptsCompletionBeforeActive) {
         node[0].slot.task_kind = TaskKind::GRAPH_NODE;
         node[0].slot.graph_node_index = 0;
         node[0].slot.total_required_subtasks = 1;
-        node[0].slot.payload = &node[0].payload;
+        node[0].slot.payload.set(&node[0].payload);
 
         GraphExecution exec{};
         exec.definition = &definition;

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -109,8 +109,12 @@ std::vector<std::byte> make_test_definition(uint64_t graph_key, uint64_t boundar
     definition.off_tensor_sources = append_section(image, tensor_sources);
     definition.off_scalars = append_section(image, scalars);
     definition.off_scalar_sources = append_section(image, scalar_sources);
+    // Widest node here declares one tensor, so the storage strides well below the
+    // type; the fixture exercises the compacted stride rather than the identity case.
+    const size_t node_stride = graph_node_stride(1);
     size_t execution_storage_bytes = 0;
-    graph_execution_storage_bytes(static_cast<int32_t>(definition.task_count), &execution_storage_bytes);
+    graph_execution_storage_bytes(static_cast<int32_t>(definition.task_count), node_stride, &execution_storage_bytes);
+    definition.node_stride = static_cast<uint32_t>(node_stride);
     definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
     definition.total_bytes = static_cast<uint32_t>(image.size());
     std::memcpy(image.data(), &definition, sizeof(definition));
@@ -279,18 +283,44 @@ TEST(GraphExecutionStorage, ComputesAlignedExactSize) {
     size_t nodes_offset = 0;
     size_t storage_bytes = 0;
 
-    ASSERT_TRUE(graph_execution_storage_layout(NODE_COUNT, &nodes_offset, &storage_bytes));
+    // Identity stride first: the layout must still describe a full-width execution.
+    ASSERT_TRUE(graph_execution_storage_layout(NODE_COUNT, sizeof(GraphNodeStorage), &nodes_offset, &storage_bytes));
     EXPECT_EQ(nodes_offset % alignof(GraphNodeStorage), 0U);
     EXPECT_GE(nodes_offset, sizeof(GraphExecution));
     EXPECT_EQ(storage_bytes, nodes_offset + NODE_COUNT * sizeof(GraphNodeStorage));
+
+    // A compacted stride shortens only the array; the header offset is stride-free.
+    // The last entry keeps room for a whole GraphNodeStorage, because that is what
+    // materialization placement-news into it.
+    const size_t narrow = graph_node_stride(1);
+    size_t narrow_offset = 0;
+    size_t narrow_bytes = 0;
+    ASSERT_TRUE(graph_execution_storage_layout(NODE_COUNT, narrow, &narrow_offset, &narrow_bytes));
+    EXPECT_EQ(narrow_offset, nodes_offset);
+    EXPECT_EQ(narrow_bytes, nodes_offset + (NODE_COUNT - 1) * narrow + sizeof(GraphNodeStorage));
+    EXPECT_GE(narrow_bytes - (narrow_offset + (NODE_COUNT - 1) * narrow), sizeof(GraphNodeStorage));
 }
 
 TEST(GraphExecutionStorage, RejectsInvalidNodeCount) {
     size_t storage_bytes = 0;
 
-    EXPECT_FALSE(graph_execution_storage_bytes(0, &storage_bytes));
-    EXPECT_FALSE(graph_execution_storage_bytes(-1, &storage_bytes));
-    EXPECT_FALSE(graph_execution_storage_bytes(static_cast<int32_t>(GRAPH_MAX_NODES) + 1, &storage_bytes));
+    const size_t full = sizeof(GraphNodeStorage);
+    EXPECT_FALSE(graph_execution_storage_bytes(0, full, &storage_bytes));
+    EXPECT_FALSE(graph_execution_storage_bytes(-1, full, &storage_bytes));
+    EXPECT_FALSE(graph_execution_storage_bytes(static_cast<int32_t>(GRAPH_MAX_NODES) + 1, full, &storage_bytes));
+    // A stride the layout cannot honour is rejected the same way a bad node count is:
+    // past the type there is nothing to read, and below the payload head an entry
+    // cannot hold its own fixed fields.
+    EXPECT_FALSE(graph_execution_storage_bytes(1, full + alignof(GraphNodeStorage), &storage_bytes));
+    EXPECT_FALSE(
+        graph_execution_storage_bytes(1, graph_node_stride_floor() - alignof(GraphNodeStorage), &storage_bytes)
+    );
+    EXPECT_FALSE(graph_execution_storage_bytes(1, full - 1, &storage_bytes));
+    // The compacted stride the widest node implies is honoured, and is smaller.
+    EXPECT_TRUE(graph_execution_storage_bytes(4, graph_node_stride(1), &storage_bytes));
+    size_t full_bytes = 0;
+    EXPECT_TRUE(graph_execution_storage_bytes(4, full, &full_bytes));
+    EXPECT_LT(storage_bytes, full_bytes);
 }
 
 // A resubmission gets the same heap block back, so the bytes it starts from are
@@ -317,7 +347,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     outer_task.packed_buffer_end = heap.end();
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task = &outer_task;
+    outer_slot.task.set(&outer_task);
     outer_slot.graph_context = &submission;
 
     GraphExecution *execution = graph_execution_localize(outer_slot);
@@ -326,15 +356,15 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     // overlap the node outputs occupying the leading required_heap bytes.
     EXPECT_EQ(static_cast<void *>(execution), heap.execution());
     EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
-    GraphNodeStorage &node = execution->node_storage[0];
+    GraphNodeStorage &node = execution->node_at(0);
     ASSERT_EQ(node.payload.scalar_count, 1);
     ASSERT_EQ(node.payload.tensor_count, 1);
     EXPECT_EQ(node.payload.scalars[0], 17U);
-    EXPECT_EQ(execution->node_storage[1].payload.scalars[0], 18U);
+    EXPECT_EQ(execution->node_at(1).payload.scalars[0], 18U);
     EXPECT_EQ(node.payload.dump_metadata.dump_arg_mask, uint64_t{1} << 0);
     EXPECT_EQ(node.payload.dump_metadata.scalar_dtypes[0], static_cast<uint8_t>(DataType::FLOAT32));
-    EXPECT_EQ(execution->node_storage[1].payload.dump_metadata.dump_arg_mask, uint64_t{1} << 1);
-    EXPECT_EQ(execution->node_storage[1].payload.dump_metadata.scalar_dtypes[0], static_cast<uint8_t>(DataType::INT32));
+    EXPECT_EQ(execution->node_at(1).payload.dump_metadata.dump_arg_mask, uint64_t{1} << 1);
+    EXPECT_EQ(execution->node_at(1).payload.dump_metadata.scalar_dtypes[0], static_cast<uint8_t>(DataType::INT32));
 
     graph_execution_mark_completed(*execution);
     execution->retired_nodes.store(2, std::memory_order_release);
@@ -350,7 +380,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     node.task.kernel_id[0] = 314;
     node.slot.active_mask = ActiveMask(3);
     node.payload.scalars[0] = 2718;
-    execution->node_storage[1].payload.scalars[0] = 31415;
+    execution->node_at(1).payload.scalars[0] = 31415;
     node.payload.tensors[0].version = 1618;
     node.slot.completed_subtasks.store(1, std::memory_order_relaxed);
     node.payload.dispatch_fanin.store(1, std::memory_order_relaxed);
@@ -365,12 +395,12 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     EXPECT_EQ(node.task.kernel_id[0], 42);
     EXPECT_EQ(node.slot.active_mask.raw(), 1);
     EXPECT_EQ(node.payload.scalars[0], 99U);
-    EXPECT_EQ(execution->node_storage[1].payload.scalars[0], 18U);
+    EXPECT_EQ(execution->node_at(1).payload.scalars[0], 18U);
     EXPECT_EQ(node.payload.tensors[0].version, 0);
     EXPECT_EQ(node.task.task_id, PTO2TaskId::make(1, (8U << 10U)));
     EXPECT_EQ(node.task.packed_buffer_base, heap.base());
     EXPECT_EQ(node.payload.tensors[0].buffer.addr, reinterpret_cast<uint64_t>(second_boundary.data()));
-    EXPECT_EQ(execution->node_storage[1].payload.tensors[0].buffer.addr, reinterpret_cast<uint64_t>(heap.base() + 16));
+    EXPECT_EQ(execution->node_at(1).payload.tensors[0].buffer.addr, reinterpret_cast<uint64_t>(heap.base() + 16));
     EXPECT_EQ(node.slot.completed_subtasks.load(std::memory_order_relaxed), 0);
     EXPECT_EQ(node.payload.dispatch_fanin.load(std::memory_order_relaxed), 0);
     EXPECT_EQ(node.payload.dump_metadata.dump_arg_mask, uint64_t{1} << 0);
@@ -396,7 +426,7 @@ TEST(GraphDefinitionObject, RejectsDefinitionBeyondRetainedBytes) {
     outer_task.packed_buffer_end = heap.end();
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task = &outer_task;
+    outer_slot.task.set(&outer_task);
     outer_slot.graph_context = &submission;
 
     EXPECT_EQ(graph_execution_localize(outer_slot), nullptr);
@@ -555,7 +585,7 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
     outer_task.packed_buffer_end = heap.end();
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task = &outer_task;
+    outer_slot.task.set(&outer_task);
     outer_slot.graph_context = &submission;
 
     GraphExecution *execution = graph_execution_localize(outer_slot);
@@ -567,7 +597,7 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
     // not the 0xAA fill: state machine, counters and atomics all start from
     // values only the device side wrote.
     for (int32_t i = 0; i < execution->node_count; ++i) {
-        const GraphNodeStorage &node = execution->node_storage[i];
+        const GraphNodeStorage &node = execution->node_at(i);
         ASSERT_EQ(node.slot.task_state.load(std::memory_order_relaxed), PTO2_TASK_PENDING);
         ASSERT_EQ(node.slot.task_kind, TaskKind::GRAPH_NODE);
         ASSERT_EQ(node.slot.completed_subtasks.load(std::memory_order_relaxed), 0);

--- a/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
@@ -694,7 +694,7 @@ TEST_F(HbgGraphSubmitFailureTest, AnOrdinaryAllocationInterleavesWithADeferredSh
         << "the shell's block sits above the ordinary task's, not before it";
     PTO2SharedMemoryRingHeader &ring = sm_handle->header->ring;
     const int32_t shell_slot = ring.get_slot_by_task_id(static_cast<int32_t>(graph.task_id.local()));
-    const PTO2TaskDescriptor *shell = ring.slot_states[shell_slot].task;
+    const PTO2TaskDescriptor *shell = ring.slot_states[shell_slot].task.get();
     ASSERT_NE(shell, nullptr);
     ASSERT_NE(shell->packed_buffer_base, nullptr);
     EXPECT_GE(

--- a/tests/ut/cpp/common/test_hbg_self_relative_ptr.cpp
+++ b/tests/ut/cpp/common/test_hbg_self_relative_ptr.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * A slot state reaches its payload and descriptor through a delta from its own
+ * address, which is what lets the shared-memory image be copied to the device
+ * verbatim. The property the copy depends on is that the delta still resolves
+ * after the whole block moves — that is what these tests pin.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "pto_runtime2_types.h"
+
+namespace {
+
+using simpler::hbg::SelfRelativePtr;
+
+// A block laid out the way the shared-memory image is: the referring field and
+// its targets in one contiguous span, with a target on each side of the field so
+// both delta signs are covered.
+struct Block {
+    PTO2TaskPayload before_payload;
+    SelfRelativePtr<PTO2TaskPayload> to_before;
+    SelfRelativePtr<PTO2TaskPayload> to_after;
+    PTO2TaskPayload after_payload;
+};
+
+}  // namespace
+
+TEST(HbgSelfRelativePtr, ZeroedMemoryReadsAsUnbound) {
+    std::vector<std::byte> storage(sizeof(SelfRelativePtr<PTO2TaskPayload>), std::byte{0});
+    auto *pointer = reinterpret_cast<SelfRelativePtr<PTO2TaskPayload> *>(storage.data());
+
+    EXPECT_EQ(pointer->get(), nullptr);
+    EXPECT_TRUE(*pointer == nullptr);
+    EXPECT_FALSE(static_cast<bool>(*pointer));
+}
+
+TEST(HbgSelfRelativePtr, ResolvesTargetsOnBothSides) {
+    Block block{};
+    block.to_before.set(&block.before_payload);
+    block.to_after.set(&block.after_payload);
+
+    EXPECT_EQ(block.to_before.get(), &block.before_payload);
+    EXPECT_EQ(block.to_after.get(), &block.after_payload);
+    EXPECT_TRUE(block.to_before != nullptr);
+    EXPECT_TRUE(static_cast<bool>(block.to_after));
+}
+
+TEST(HbgSelfRelativePtr, SetNullRebindsToUnbound) {
+    Block block{};
+    block.to_after.set(&block.after_payload);
+    ASSERT_NE(block.to_after.get(), nullptr);
+
+    block.to_after.set(nullptr);
+
+    EXPECT_EQ(block.to_after.get(), nullptr);
+    EXPECT_TRUE(block.to_after == nullptr);
+}
+
+// The reason the relocation pass is gone: a raw pointer written on the host names
+// a host address the device would dereference verbatim, while a delta names the
+// same *relative* position in whichever copy is being read.
+TEST(HbgSelfRelativePtr, SurvivesABlockCopyToAnotherAddress) {
+    // Two real objects rather than raw byte buffers: PTO2TaskSlotState is
+    // alignas(64), which std::vector<std::byte>::data() does not promise, and a
+    // memcpy into untyped storage would not begin the object's lifetime.
+    Block source{};
+    Block destination{};
+    Block *origin = &source;
+    origin->to_before.set(&origin->before_payload);
+    origin->to_after.set(&origin->after_payload);
+
+    // A separate object, so the copy lands at an unrelated address the way the
+    // device image does.
+    std::memcpy(&destination, &source, sizeof(Block));
+    Block *moved = &destination;
+    ASSERT_NE(reinterpret_cast<void *>(moved), reinterpret_cast<void *>(origin));
+
+    EXPECT_EQ(moved->to_before.get(), &moved->before_payload);
+    EXPECT_EQ(moved->to_after.get(), &moved->after_payload);
+}
+
+// bind_buffers is the only writer, and the slot state it writes into is copied as
+// part of the same image as its payload and descriptor.
+TEST(HbgSelfRelativePtr, SlotStateBindingSurvivesTheImageCopy) {
+    struct Image {
+        PTO2TaskDescriptor descriptor;
+        PTO2TaskPayload payload;
+        PTO2TaskSlotState slot;
+    };
+
+    // Real objects, not byte buffers: the slot state is alignas(64), which
+    // std::vector<std::byte>::data() does not promise.
+    Image source{};
+    Image destination{};
+    Image *origin = &source;
+    origin->slot.bind_buffers(&origin->payload, &origin->descriptor);
+    ASSERT_EQ(origin->slot.payload.get(), &origin->payload);
+    ASSERT_EQ(origin->slot.task.get(), &origin->descriptor);
+
+    std::memcpy(&destination, &source, sizeof(Image));
+    Image *moved = &destination;
+    ASSERT_NE(reinterpret_cast<void *>(moved), reinterpret_cast<void *>(origin));
+
+    EXPECT_EQ(moved->slot.payload.get(), &moved->payload);
+    EXPECT_EQ(moved->slot.task.get(), &moved->descriptor);
+}
+
+// The descriptor ABI AICore consumes and the one-cache-line slot state are both
+// unchanged by the representation: the eight bytes the two deltas save become
+// tail padding inside the same 64.
+TEST(HbgSelfRelativePtr, KeepsTheSharedMemoryAbiSizes) {
+    EXPECT_EQ(sizeof(PTO2TaskSlotState), 64u);
+    EXPECT_EQ(sizeof(PTO2TaskDescriptor), 40u);
+    EXPECT_EQ(sizeof(SelfRelativePtr<PTO2TaskPayload>), 4u);
+    EXPECT_EQ(offsetof(PTO2TaskDescriptor, packed_buffer_base), 24u);
+}

--- a/tests/ut/cpp/common/test_hbg_slot_claim.cpp
+++ b/tests/ut/cpp/common/test_hbg_slot_claim.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The shared-memory slot segments are init-on-write: nothing zeroes them, and a
+ * slot's dynamic scheduling fields are established as the orchestrator claims it.
+ * That makes the claim the only place the pristine state comes from, for every
+ * kind of task — an ordinary submit and the outer task of a recorded Graph alike.
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#include "graph_host_state.h"
+#include "pto_orchestrator.h"
+#include "pto_shared_memory.h"
+#include "utils/device_arena.h"
+
+class HbgSlotClaimTest : public ::testing::Test {
+protected:
+    DeviceArena sm_arena;
+    DeviceArena runtime_arena;
+    PTO2SharedMemoryHandle *sm_handle = nullptr;
+    PTO2OrchestratorState orch{};
+    PTO2SchedulerState sched{};
+    PTO2OrchestratorLayout orch_layout{};
+    PTO2SchedulerLayout sched_layout{};
+    GraphHostStatePtr graph_state;
+    std::vector<char> gm_heap;
+
+    static constexpr size_t HEAP_BYTES = 64 * 1024;
+
+    void SetUp() override {
+        sm_handle = PTO2SharedMemoryHandle::create_and_init_default(sm_arena);
+        ASSERT_NE(sm_handle, nullptr);
+        gm_heap.resize(HEAP_BYTES * PTO2_MAX_RING_DEPTH);
+
+        orch_layout = PTO2OrchestratorState::reserve_layout(runtime_arena, static_cast<int32_t>(PTO2_TASK_WINDOW_SIZE));
+        sched_layout = PTO2SchedulerState::reserve_layout(runtime_arena);
+        ASSERT_NE(runtime_arena.commit(), nullptr);
+
+        ASSERT_TRUE(orch.init_data_from_layout(
+            orch_layout, runtime_arena, sm_handle->sm_base, gm_heap.data(), HEAP_BYTES, PTO2_TASK_WINDOW_SIZE
+        ));
+        ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
+        sched.wire_arena_pointers(sched_layout, runtime_arena);
+        orch.wire_arena_pointers(orch_layout, runtime_arena, &sched);
+
+        graph_state = make_graph_host_state();
+        ASSERT_NE(graph_state, nullptr);
+        orch.graph_host_state = graph_state.get();
+    }
+
+    void TearDown() override {
+        orch.graph_host_state = nullptr;
+        graph_state.reset();
+        orch.destroy();
+        sched.destroy();
+        runtime_arena.release();
+        sm_arena.release();
+    }
+
+    // The state a slot is in before it is claimed when the shared memory outlives
+    // one pass. Nothing writes these bytes on the way in, so whatever the previous
+    // pass left is what the claim has to overwrite. Every value here is one a
+    // completed task really leaves behind.
+    void poison_slot(int32_t slot) {
+        PTO2TaskSlotState &state = sm_handle->header->ring.get_slot_state_by_slot(slot);
+        state.wake_list_head.store(WAKE_LIST_SENTINEL, std::memory_order_relaxed);
+        state.next_in_wake_list = &sm_handle->header->ring.get_slot_state_by_slot(slot + 1);
+        state.any_subtask_deferred.store(true, std::memory_order_relaxed);
+        state.completed_subtasks.store(7, std::memory_order_relaxed);
+        state.next_block_idx.store(3, std::memory_order_relaxed);
+        state.graph_node_index = 11;
+        sm_handle->header->ring.completion_flags[slot].store(1, std::memory_order_relaxed);
+    }
+
+    void expect_slot_pristine(int32_t slot) {
+        PTO2TaskSlotState &state = sm_handle->header->ring.get_slot_state_by_slot(slot);
+        EXPECT_EQ(state.wake_list_head.load(std::memory_order_relaxed), nullptr)
+            << "a stale SENTINEL closes the wake list, so no consumer can register on this producer";
+        EXPECT_EQ(state.next_in_wake_list, nullptr);
+        EXPECT_FALSE(state.has_any_subtask_deferred());
+        EXPECT_EQ(state.completed_subtasks.load(std::memory_order_relaxed), 0);
+        EXPECT_EQ(state.next_block_idx.load(std::memory_order_relaxed), 0);
+        EXPECT_EQ(sm_handle->header->ring.completion_flags[slot].load(std::memory_order_relaxed), 0)
+            << "a stale completion flag reports this task done before it has run";
+    }
+};
+
+TEST_F(HbgSlotClaimTest, OrdinarySubmitClaimsAPoisonedSlot) {
+    poison_slot(0);
+
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    ChipTensor boundary = make_tensor_external(storage.data(), shape, 1);
+
+    orch.begin_scope();
+    CoreTaskArgs args;
+    args.add_input(boundary);
+    ASSERT_TRUE(orch.submit_dummy_task(args).task_id().is_valid());
+
+    expect_slot_pristine(0);
+}
+
+// The outer task of a recorded Graph takes a ring slot like any other task, and
+// takes it through its own placement rather than through prepare_task — so it
+// needs the same claim-time reset. It occupies one heap block and one slot for a
+// whole sub-DAG, which is exactly why it is easy to overlook.
+TEST_F(HbgSlotClaimTest, GraphOuterTaskClaimsAPoisonedSlot) {
+    poison_slot(0);
+
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    ChipTensor boundary = make_tensor_external(storage.data(), shape, 1);
+
+    orch.begin_scope();
+    // A Graph boundary carries the wider arg type: graph_begin deep-copies it for the
+    // recording, which the ordinary CoreTaskArgs cannot hold.
+    GraphTaskArgs boundary_args;
+    boundary_args.add_input(boundary);
+    const GraphScopeResult graph = orch.graph_begin(0x51ADC1A1, boundary_args, 0x1736);
+    ASSERT_TRUE(graph.recording);
+    // graph_begin publishes the outer shell and creates the recording, handing back the
+    // handle graph_prepare binds to the thread that will submit the body. The recorder is
+    // normally a worker, so this test plays both roles on one thread.
+    ASSERT_NE(graph.recording_handle, nullptr);
+    ASSERT_TRUE(orch.graph_prepare(graph.recording_handle, boundary_args));
+
+    CoreTaskArgs node_args;
+    node_args.add_input(boundary);
+    ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
+    ASSERT_TRUE(orch.graph_end());
+    ASSERT_EQ(orch.ring.task_allocator.active_count(), 1);
+
+    PTO2TaskSlotState &outer = sm_handle->header->ring.get_slot_state_by_slot(0);
+    ASSERT_EQ(outer.task_kind, TaskKind::GRAPH);
+    expect_slot_pristine(0);
+}
+
+// A cached replay places its outer task the same way the recording pass did, so
+// the second slot has to come out just as clean.
+TEST_F(HbgSlotClaimTest, CachedGraphReplayClaimsAPoisonedSlot) {
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    ChipTensor boundary = make_tensor_external(storage.data(), shape, 1);
+
+    orch.begin_scope();
+    // A Graph boundary carries the wider arg type: graph_begin deep-copies it for the
+    // recording, which the ordinary CoreTaskArgs cannot hold.
+    GraphTaskArgs boundary_args;
+    boundary_args.add_input(boundary);
+    const GraphScopeResult recorded = orch.graph_begin(0x51ADC1A2, boundary_args, 0x1736);
+    ASSERT_TRUE(recorded.recording);
+    ASSERT_TRUE(orch.graph_prepare(recorded.recording_handle, boundary_args));
+    CoreTaskArgs node_args;
+    node_args.add_input(boundary);
+    ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
+    ASSERT_TRUE(orch.graph_end());
+
+    poison_slot(1);
+    const GraphScopeResult replay = orch.graph_begin(0x51ADC1A2, boundary_args, 0x1736);
+    ASSERT_TRUE(replay.task_id.is_valid());
+    ASSERT_EQ(replay.task_id.local(), 1u);
+
+    expect_slot_pristine(1);
+}

--- a/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
+++ b/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The orchestrator writes a ring-pitched shared-memory mirror; the image that
+ * ships is pitched to the submitted count so its four live prefixes are
+ * contiguous and travel as one copy. compact_live_image is the restack, and it
+ * owes the device three things: the live payloads, a header carrying no host
+ * addresses, and slot-state bindings that resolve inside the image rather than
+ * back into the mirror.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "pto_shared_memory.h"
+
+namespace {
+
+constexpr uint64_t WINDOW = 64;  // stands in for the ring capacity
+constexpr uint64_t SUBMITTED = 5;
+
+// A buffer aligned the way both the arena mirror and the device SM base are;
+// PTO2TaskSlotState is alignas(64) and every segment offset is a multiple of
+// PTO2_ALIGN_SIZE.
+class AlignedImage {
+public:
+    explicit AlignedImage(uint64_t bytes, uint8_t fill = 0) :
+        storage_(bytes + PTO2_ALIGN_SIZE, std::byte{0}) {
+        base_ = reinterpret_cast<char *>(
+            (reinterpret_cast<uintptr_t>(storage_.data()) + PTO2_ALIGN_SIZE - 1) &
+            ~static_cast<uintptr_t>(PTO2_ALIGN_SIZE - 1)
+        );
+        if (fill != 0) std::memset(base_, fill, bytes);
+    }
+
+    char *base() { return base_; }
+    const char *base() const { return base_; }
+
+private:
+    std::vector<std::byte> storage_;
+    char *base_{nullptr};
+};
+
+// A mirror in the state the orchestrator leaves it: SUBMITTED slots bound to
+// their own payload and descriptor, distinguishable per-slot content, and header
+// pointers naming the mirror's own arrays.
+class Mirror {
+public:
+    Mirror() :
+        image_(pto2_sm_layout::ring_segment_offsets(WINDOW).end) {
+        const auto off = pto2_sm_layout::ring_segment_offsets(WINDOW);
+        auto *header = reinterpret_cast<PTO2SharedMemoryHeader *>(image_.base());
+        auto &ring = header->ring;
+        ring.task_window_size = WINDOW;
+        ring.task_window_mask = static_cast<int32_t>(WINDOW - 1);
+        ring.fc.current_task_index.store(static_cast<int32_t>(SUBMITTED), std::memory_order_relaxed);
+        ring.task_descriptors = descriptors();
+        ring.task_payloads = payloads();
+        ring.slot_states = slot_states();
+        ring.completion_flags = completion_flags();
+        (void)off;
+
+        for (uint64_t i = 0; i < SUBMITTED; ++i) {
+            descriptors()[i].task_id = PTO2TaskId::make(0, static_cast<uint32_t>(i));
+            payloads()[i].tensor_count = static_cast<int32_t>(100 + i);
+            slot_states()[i].last_consumer_local_id = static_cast<int32_t>(i);
+            slot_states()[i].graph_node_index = static_cast<int32_t>(200 + i);
+            slot_states()[i].bind_buffers(&payloads()[i], &descriptors()[i]);
+            completion_flags()[i].store(static_cast<uint8_t>(i & 1), std::memory_order_relaxed);
+        }
+        // A slot past the submitted prefix, to prove it does not travel.
+        descriptors()[SUBMITTED].task_id = PTO2TaskId::make(0, 0xBEEF);
+    }
+
+    const char *base() const { return image_.base(); }
+
+    PTO2TaskDescriptor *descriptors() {
+        return reinterpret_cast<PTO2TaskDescriptor *>(
+            image_.base() + pto2_sm_layout::ring_segment_offsets(WINDOW).descriptors
+        );
+    }
+    PTO2TaskPayload *payloads() {
+        return reinterpret_cast<PTO2TaskPayload *>(
+            image_.base() + pto2_sm_layout::ring_segment_offsets(WINDOW).payloads
+        );
+    }
+    PTO2TaskSlotState *slot_states() {
+        return reinterpret_cast<PTO2TaskSlotState *>(
+            image_.base() + pto2_sm_layout::ring_segment_offsets(WINDOW).slot_states
+        );
+    }
+    std::atomic<uint8_t> *completion_flags() {
+        return reinterpret_cast<std::atomic<uint8_t> *>(
+            image_.base() + pto2_sm_layout::ring_segment_offsets(WINDOW).completion_flags
+        );
+    }
+
+private:
+    AlignedImage image_;
+};
+
+struct Compacted {
+    AlignedImage image;
+    uint64_t bytes;
+    uint64_t stride;
+
+    explicit Compacted(
+        Mirror &mirror, uint64_t submitted = SUBMITTED, uint64_t payload_stride = sizeof(PTO2TaskPayload)
+    ) :
+        image(
+            pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::live_slot_pitch(submitted), payload_stride).end, 0xAA
+        ),
+        bytes(0),
+        stride(payload_stride) {
+        bytes = pto2_sm_layout::compact_live_image(mirror.base(), WINDOW, submitted, payload_stride, image.base());
+    }
+
+    pto2_sm_layout::PTO2RingSegmentOffsets off(uint64_t submitted = SUBMITTED) const {
+        return pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::live_slot_pitch(submitted), stride);
+    }
+
+    PTO2TaskPayload *payload_at(uint64_t i) {
+        return reinterpret_cast<PTO2TaskPayload *>(image.base() + off().payloads + i * stride);
+    }
+    PTO2TaskDescriptor *descriptors() {
+        return reinterpret_cast<PTO2TaskDescriptor *>(image.base() + off().descriptors);
+    }
+    PTO2TaskPayload *payloads() { return payload_at(0); }
+    PTO2TaskSlotState *slot_states() { return reinterpret_cast<PTO2TaskSlotState *>(image.base() + off().slot_states); }
+    std::atomic<uint8_t> *completion_flags() {
+        return reinterpret_cast<std::atomic<uint8_t> *>(image.base() + off().completion_flags);
+    }
+};
+
+}  // namespace
+
+// The point of the restack: the whole image is one range, and it is far smaller
+// than the mirror it came from.
+TEST(HbgSmCompaction, ShipsOnlyTheLivePrefix) {
+    Mirror mirror;
+    Compacted compacted(mirror);
+
+    EXPECT_EQ(compacted.bytes, pto2_sm_layout::ring_segment_offsets(SUBMITTED).end);
+    EXPECT_LT(compacted.bytes, pto2_sm_layout::ring_segment_offsets(WINDOW).end);
+}
+
+TEST(HbgSmCompaction, CarriesEveryLiveSlotsContent) {
+    Mirror mirror;
+    Compacted compacted(mirror);
+
+    for (uint64_t i = 0; i < SUBMITTED; ++i) {
+        EXPECT_EQ(compacted.descriptors()[i].task_id.local(), i) << "slot " << i;
+        EXPECT_EQ(compacted.payload_at(i)->tensor_count, static_cast<int32_t>(100 + i)) << "slot " << i;
+        EXPECT_EQ(compacted.slot_states()[i].last_consumer_local_id, static_cast<int32_t>(i)) << "slot " << i;
+        EXPECT_EQ(compacted.slot_states()[i].graph_node_index, static_cast<int32_t>(200 + i)) << "slot " << i;
+        EXPECT_EQ(compacted.completion_flags()[i].load(std::memory_order_relaxed), static_cast<uint8_t>(i & 1))
+            << "slot " << i;
+    }
+    // The header's pitch-independent fields come across; the mirror slot past the
+    // prefix does not.
+    auto &ring = reinterpret_cast<const PTO2SharedMemoryHeader *>(compacted.image.base())->ring;
+    EXPECT_EQ(ring.task_window_size, WINDOW);
+    EXPECT_EQ(ring.fc.current_task_index.load(std::memory_order_relaxed), static_cast<int32_t>(SUBMITTED));
+}
+
+// The load-bearing one. Restacking changes the distance between a slot state and
+// its payload, so a binding copied verbatim would resolve to the mirror — a host
+// address, in device memory.
+TEST(HbgSmCompaction, RebindsEverySlotInsideTheImage) {
+    Mirror mirror;
+    Compacted compacted(mirror);
+
+    for (uint64_t i = 0; i < SUBMITTED; ++i) {
+        EXPECT_EQ(compacted.slot_states()[i].payload.get(), compacted.payload_at(i)) << "slot " << i;
+        EXPECT_EQ(compacted.slot_states()[i].task.get(), &compacted.descriptors()[i]) << "slot " << i;
+    }
+}
+
+// A delta is invariant under a whole-image move, which is what makes the single
+// copy to the device safe.
+TEST(HbgSmCompaction, BindingsSurviveTheCopyToTheDevice) {
+    Mirror mirror;
+    Compacted compacted(mirror);
+
+    AlignedImage landed(compacted.bytes);
+    std::memcpy(landed.base(), compacted.image.base(), compacted.bytes);
+    const auto off = pto2_sm_layout::ring_segment_offsets(SUBMITTED);
+    auto *slots = reinterpret_cast<PTO2TaskSlotState *>(landed.base() + off.slot_states);
+    auto *payloads = reinterpret_cast<PTO2TaskPayload *>(landed.base() + off.payloads);
+    auto *descriptors = reinterpret_cast<PTO2TaskDescriptor *>(landed.base() + off.descriptors);
+
+    for (uint64_t i = 0; i < SUBMITTED; ++i) {
+        EXPECT_EQ(slots[i].payload.get(), &payloads[i]) << "slot " << i;
+        EXPECT_EQ(slots[i].task.get(), &descriptors[i]) << "slot " << i;
+    }
+}
+
+// The header's data pointers name the mirror. The device resolves its own in
+// attach_populated, so shipping them would only put host addresses in device
+// memory.
+TEST(HbgSmCompaction, LeavesNoHostPointerInTheHeader) {
+    Mirror mirror;
+    Compacted compacted(mirror);
+
+    auto &ring = reinterpret_cast<const PTO2SharedMemoryHeader *>(compacted.image.base())->ring;
+    EXPECT_EQ(ring.task_descriptors, nullptr);
+    EXPECT_EQ(ring.task_payloads, nullptr);
+    EXPECT_EQ(ring.slot_states, nullptr);
+    EXPECT_EQ(ring.completion_flags, nullptr);
+}
+
+// A bind that submits nothing still ships its header and still attaches.
+TEST(HbgSmCompaction, ZeroSubmittedShipsTheHeaderAlone) {
+    Mirror mirror;
+    Compacted compacted(mirror, /*submitted=*/0);
+
+    EXPECT_EQ(compacted.bytes, pto2_sm_layout::ring_segment_offsets(1).end);
+    auto &ring = reinterpret_cast<const PTO2SharedMemoryHeader *>(compacted.image.base())->ring;
+    EXPECT_EQ(ring.task_window_size, WINDOW);
+    EXPECT_EQ(ring.task_descriptors, nullptr);
+}
+
+// The image strides its payload array by the widest task in the bind, not by the
+// type. Everything a task reads is a prefix of its payload, so a narrower stride
+// carries the same information in fewer bytes.
+TEST(HbgSmCompaction, CompactedStrideShipsFewerBytesAndStillResolves) {
+    Mirror mirror;
+    for (uint64_t i = 0; i < SUBMITTED; ++i) {
+        mirror.payloads()[i].tensor_count = 2;
+        mirror.payloads()[i].scalar_count = 1;
+        mirror.payloads()[i].tensors[0].buffer.addr = 0x1000 + i;
+        mirror.payloads()[i].tensors[1].buffer.addr = 0x2000 + i;
+        mirror.payloads()[i].scalars[0] = 0x3000 + i;
+    }
+
+    const uint64_t stride = pto2_sm_layout::shipped_payload_stride(2);
+    ASSERT_LT(stride, sizeof(PTO2TaskPayload));
+    ASSERT_EQ(stride % PTO2_ALIGN_SIZE, 0u);
+
+    Compacted compacted(mirror, SUBMITTED, stride);
+    EXPECT_LT(compacted.bytes, pto2_sm_layout::ring_segment_offsets(SUBMITTED).end);
+
+    for (uint64_t i = 0; i < SUBMITTED; ++i) {
+        PTO2TaskPayload *shipped = compacted.payload_at(i);
+        EXPECT_EQ(shipped->tensor_count, 2) << "slot " << i;
+        EXPECT_EQ(shipped->scalar_count, 1) << "slot " << i;
+        EXPECT_EQ(shipped->tensors[0].buffer.addr, 0x1000 + i) << "slot " << i;
+        EXPECT_EQ(shipped->tensors[1].buffer.addr, 0x2000 + i) << "slot " << i;
+        EXPECT_EQ(shipped->scalars[0], 0x3000 + i) << "slot " << i;
+        // The binding has to follow the compacted stride, not the type's.
+        EXPECT_EQ(compacted.slot_states()[i].payload.get(), shipped) << "slot " << i;
+    }
+}
+
+// A stride covering the whole array is the identity case, and must not be exceeded:
+// the type is the widest an image can ever be.
+TEST(HbgSmCompaction, StrideNeverExceedsTheType) {
+    EXPECT_EQ(pto2_sm_layout::shipped_payload_stride(MAX_TENSOR_ARGS), sizeof(PTO2TaskPayload));
+    EXPECT_EQ(pto2_sm_layout::shipped_payload_stride(MAX_TENSOR_ARGS * 4), sizeof(PTO2TaskPayload));
+    EXPECT_EQ(pto2_sm_layout::shipped_payload_stride(0), offsetof(PTO2TaskPayload, tensors));
+    EXPECT_EQ(pto2_sm_layout::shipped_payload_stride(-1), offsetof(PTO2TaskPayload, tensors));
+}


### PR DESCRIPTION
## Summary

The bind stage made **46 host-to-device transfers per bind** and reserved **361 MB**
of device memory, most of it for data the device never reads. Both come from the
same habit: every structure was shipped at the width of its type and copied on its
own.

**One copy instead of forty-six.** A slot's payload and descriptor are named by a
self-relative offset — an int32 delta from the field's own address — so the whole
ring image survives a single `memcpy` with no pointer fix-up, which retires the
host-to-device relocation pass. The Graph submissions go up as one block rather
than one allocation and one copy each, and both the shared-memory image and that
submission block become tails of the runtime arena's own region, so they ride the
arena's copy. What is left is one arena copy plus one retained Definition object.

**Only the bytes the device reads.** The arena's host-only zone is dep-computation
scratch no device code touches, so it is no longer reserved on the device at all.
The shared-memory image ships pitched to the submitted task count rather than the
ring capacity, and the device-side reservation follows the same pitch — on qwen3-14b
decode, from 81,412,352 bytes to 77,440.

**Strided by what a bind actually holds, not by the type.** `PTO2TaskPayload`'s
tensor array and `GraphNodeStorage`'s payload move last so each can be truncated,
and the shipped arrays are then strided by the widest task and the widest node in
the bind. `sizeof(GraphNodeStorage)` is not a power of two, so indexing already
compiled to a multiply; a runtime stride changes the operand from an immediate to a
register and adds no indirection on the dispatch path.

The int32 delta carries two bounds with it. `set()` leaves the field unbound rather
than storing a truncated delta, since unbound is the value every consumer already
tests for and a truncated one names unrelated memory; `attach_populated` rejects an
image whose end exceeds the bound. On the host side `compact_live_image` asserts the
same two bounds, where exceeding them would read past the mirror's segments and ship
a corrupt image with nothing to say so.

**Three defects fall out of the same reading, and none is an optimization** — see
the commit message for each, including a Graph outer task's slot that was not reset
as it was claimed and was only accidentally correct (a fresh `new uint8_t[]` comes
back zero-filled, so a stale slot never appeared; a reused slot or mirror would have
read the previous run's state). Each is covered by a test that fails without the fix.

## Relationship to #1932

This is the same change as #1932's original commit (`0f84de55`), **rebased onto
current `main`** — #1932's base is `102df3d5`, now five commits behind (missing
#1936, #1937, #1875, #1940, #1942). The rebase changed nothing: both commits'
own diffstats are identical at 43 files, +1998/−635.

#1932 has since been rewritten into a different shape (`17115ed1`, "Fix: pack HBG
payloads into the runtime arena", 54 files), so **the two are no longer the same
change** and one of them should be closed rather than both merged. Flagging that
rather than assuming which.

## Measured effect

a2a3, dsv4 seven-Definition decode, `--rounds 5` with the device run skipped,
per-phase minima over the 8 warm passes, **interleaved** `A, B, A, B` with both arms
driven by the same harness and the same environment stamp:

| phase | A1 | B1 | Δ1 | A2 | B2 | Δ2 | sign |
| ----- | -- | -- | -- | -- | -- | -- | ---- |
| `host_orch` | 1.119 | 0.940 | −0.179 | 0.882 | 0.853 | −0.029 | agree |
| `graph_upload` | 1.323 | 0.217 | −1.106 | 1.401 | 0.185 | −1.216 | agree |
| `relocate` | 0.001 | — | −0.001 | 0.001 | — | −0.001 | agree |
| `sm_h2d` | 0.104 | — | −0.104 | 0.104 | — | −0.104 | agree |
| `arena_h2d` | 0.052 | 0.071 | **+0.019** | 0.036 | 0.067 | **+0.031** | agree |
| **control-plane total** | **2.795** | **1.323** | **−1.472** | **2.575** | **1.105** | **−1.470** | agree |

The two repetitions' totals agree to 2 µs. `relocate` and `sm_h2d` are retired
outright, and `arena_h2d` grows because their work now rides the arena copy — 0.03 ms
in exchange for 0.105 ms. `host_orch` agrees in sign but the magnitudes differ 6× and
both sit inside their own spread; **I do not claim a real effect there**, and this
change has no reason to touch orchestration.

## Testing

- [x] `ctest -LE requires_hardware` — 114/114 (6 new cases from this change)
- [x] a2a3 onboard, dsv4 L3 EP2/TP2 and qwen3-14b L2, bind measurement completes on
      both

🤖 Generated with [Claude Code](https://claude.com/claude-code)