### PR TITLE
CI: run DeepSeek device smokes per PR

### DIFF
--- a/.claude/skills/hbg-bind-phases/SKILL.md
+++ b/.claude/skills/hbg-bind-phases/SKILL.md
@@ -24,8 +24,8 @@ MARK="outputs/.bind_start"; : >"$MARK"   # fixed mtime; "$LOG" keeps being appen
 
 ENVS="SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 SIMPLER_LOG_LEVEL=TIMING \
 TORCH_DEVICE_BACKEND_AUTOLOAD=0 SIMPLER_SKIP_DEVICE_RUN=1"          # + mode delta
-CASE="examples/.../test_<case>.py -p a2a3 --manual only \
---case <Class>:: --skip-golden"                                      # + level, per case
+CASE="examples/.../test_<case>.py -p a2a3 \
+--case <Class>:: --skip-golden"                       # + manual mode and level, per case
 TAIL="--rounds 6"                                                    # per mode
 
 .claude/skills/onboard-arch-precheck/check.sh a2a3 || exit 1
@@ -46,6 +46,7 @@ comparable. Never hand-edit one arm's command without the other's.
 | `--device-num` | 2 | 1 |
 | `CASE` example | `examples/a2a3/host_build_graph/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py` | `examples/a2a3/host_build_graph/qwen3_14b_decode/test_qwen3_14b_decode.py` |
 | `--case` | `TestDeepseekV4FlashDecodeHostBuildGraph::` | `TestQwen314BDecodeHostBuildGraph::` |
+| manual mode | none | **add** `--manual only` |
 | level | `level=3`, so **add** `--runtime host_build_graph --level 3` | `level=2`, add nothing |
 | timeout | 3600 (cold compile is minutes) | 2400 |
 

--- a/conftest.py
+++ b/conftest.py
@@ -511,6 +511,10 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
+        "resource_last: run this test in the final Resource subphase after L2",
+    )
+    config.addinivalue_line(
+        "markers",
         "runtime(name): runtime this standalone test targets; used by runtime-isolation subprocess "
         "filtering so non-@scene_test tests only run under their matching runtime",
     )
@@ -765,6 +769,7 @@ class _ResourceJob(typing.NamedTuple):
     label: str  # class name for "l3", function name for "standalone"
     runtime: str
     device_count: int
+    run_last: bool
 
 
 def _collect_st_runtimes(items, level=None):
@@ -822,7 +827,12 @@ def _collect_resource_jobs(items, platform, manual_mode="exclude"):
             max_dev = max(max_dev, int(case.get("config", {}).get("device_count", 1)))
         if saw_case:
             l3_by_nodeid[item.nodeid] = _ResourceJob(
-                kind="l3", nodeid=item.nodeid, label=cls.__name__, runtime=rt, device_count=max_dev
+                kind="l3",
+                nodeid=item.nodeid,
+                label=cls.__name__,
+                runtime=rt,
+                device_count=max_dev,
+                run_last=item.get_closest_marker("resource_last") is not None,
             )
     jobs.extend(l3_by_nodeid.values())
 
@@ -849,6 +859,7 @@ def _collect_resource_jobs(items, platform, manual_mode="exclude"):
             label=item.name,
             runtime=rt_marker.args[0],
             device_count=dev_count,
+            run_last=item.get_closest_marker("resource_last") is not None,
         )
     jobs.extend(standalone_by_nodeid.values())
 
@@ -960,14 +971,60 @@ def _emit_resource_failure_summary(
         print("  full output is in the Resource child group above", flush=True)
 
 
+def _run_resource_phase(resource_specs, device_ids, max_parallel, fail_fast, platform, manual_mode, cwd, heading):
+    jobs = []
+    for spec in resource_specs:
+        label = f"{spec.kind} {spec.label} (rt={spec.runtime}, dev={spec.device_count})"
+
+        def _build(ids, _spec=spec):
+            return _resource_child_command(_spec, ids, platform, manual_mode)
+
+        jobs.append(
+            _ps.Job(
+                label=label,
+                device_count=spec.device_count,
+                build_cmd=_build,
+                cwd=str(cwd),
+                nodeid=spec.nodeid,
+            )
+        )
+
+    def _on_done(res):
+        tag = "PASS" if res.returncode == 0 else f"FAIL rc={res.returncode}"
+        nodeid = res.nodeid or "<unknown>"
+        header = f"{res.label} nodeid={nodeid} [{tag} {res.duration_s:.1f}s, devices={res.device_ids}]"
+        _emit_group(header, res.output)
+        if res.returncode != 0:
+            print(
+                f"*** FAIL: {nodeid} ({res.label}, devices={res.device_ids}) — expand group above ***",
+                flush=True,
+            )
+
+    print(
+        f"\n{heading}: {len(jobs)} case(s), pool={device_ids}, max_parallel={max_parallel}",
+        flush=True,
+    )
+    results = _ps.run_jobs(
+        jobs,
+        device_ids,
+        max_parallel=max_parallel,
+        fail_fast=fail_fast,
+        on_job_done=_on_done,
+    )
+    if any(r.returncode == TIMEOUT_EXIT_CODE for r in results):
+        print(f"\n*** {heading}: TIMED OUT ***\n", flush=True)
+        os._exit(TIMEOUT_EXIT_CODE)
+    return results
+
+
 def _dispatch_test_phases(session, resource_specs):  # noqa: PLR0912
-    """Run Resource → L2 phases.
+    """Run Resource → L2 → final Resource phases.
 
     The Resource phase dispatches every item that needs a dedicated
     device-allocating subprocess — L3 ``SceneTestCase`` classes *and*
     standalone functions marked with ``@pytest.mark.device_count`` +
-    ``@pytest.mark.runtime``. They share the same ``run_jobs`` bin-pack
-    and fail-fast gate, so they are one phase, not two.
+    ``@pytest.mark.runtime``. Items marked ``resource_last`` run after L2 in
+    the same pytest invocation and enclosing device allocation.
 
     ``resource_specs`` is pre-collected by ``pytest_runtestloop`` (which
     already has to inspect the list to decide whether to dispatch) so
@@ -984,58 +1041,23 @@ def _dispatch_test_phases(session, resource_specs):  # noqa: PLR0912
 
     base_args = _base_pytest_argv(session, strip_options=("--exclude-level",))
     cwd = session.config.invocation_params.dir
+    ordinary_resource_specs = [spec for spec in resource_specs if not spec.run_last]
+    final_resource_specs = [spec for spec in resource_specs if spec.run_last]
 
     # ----- Phase 1: Resource (L3 classes + standalone resource functions) -----
     resource_failed = False
     resource_results: list[_ps.JobResult] = []
-    if resource_specs:
-        jobs = []
-        for spec in resource_specs:
-            label = f"{spec.kind} {spec.label} (rt={spec.runtime}, dev={spec.device_count})"
-
-            def _build(ids, _spec=spec):
-                # Narrow the child to the specific nodeid, not the inherited
-                # directory args (examples tests/st). Passing the directories
-                # would re-collect every SceneTestCase and run them alongside
-                # this job in the same subprocess, which has only this job's
-                # allocated devices — e.g. TestL3Group (needs 2) would fail
-                # inside TestL3ChildMemory's 1-device subprocess.
-                return _resource_child_command(_spec, ids, platform, manual_mode)
-
-            jobs.append(
-                _ps.Job(
-                    label=label,
-                    device_count=spec.device_count,
-                    build_cmd=_build,
-                    cwd=str(cwd),
-                    nodeid=spec.nodeid,
-                )
-            )
-
-        def _on_done(res):
-            tag = "PASS" if res.returncode == 0 else f"FAIL rc={res.returncode}"
-            nodeid = res.nodeid or "<unknown>"
-            header = f"{res.label} nodeid={nodeid} [{tag} {res.duration_s:.1f}s, devices={res.device_ids}]"
-            _emit_group(header, res.output)
-            if res.returncode != 0:
-                # Out-of-group summary so a reviewer scanning the collapsed
-                # log still sees the failure without having to expand.
-                print(
-                    f"*** FAIL: {nodeid} ({res.label}, devices={res.device_ids}) — expand group above ***",
-                    flush=True,
-                )
-
-        print(
-            f"\nResource phase: {len(jobs)} case(s), pool={device_ids}, max_parallel={max_parallel}",
-            flush=True,
-        )
+    if ordinary_resource_specs:
         try:
-            results = _ps.run_jobs(
-                jobs,
+            results = _run_resource_phase(
+                ordinary_resource_specs,
                 device_ids,
-                max_parallel=max_parallel,
-                fail_fast=fail_fast,
-                on_job_done=_on_done,
+                max_parallel,
+                fail_fast,
+                platform,
+                manual_mode,
+                cwd,
+                "Resource phase",
             )
         except ValueError as e:
             print(f"\n*** Resource phase ABORTED: {e} ***\n", flush=True)
@@ -1045,9 +1067,6 @@ def _dispatch_test_phases(session, resource_specs):  # noqa: PLR0912
         resource_failed = any(r.returncode != 0 for r in results)
         if resource_failed:
             _emit_resource_failure_summary(results)
-        if any(r.returncode == TIMEOUT_EXIT_CODE for r in results):
-            print("\n*** Resource phase: TIMED OUT ***\n", flush=True)
-            os._exit(TIMEOUT_EXIT_CODE)
 
         # Fail-fast: stop before L2 phase if any Resource job failed.
         if resource_failed and fail_fast:
@@ -1124,6 +1143,29 @@ def _dispatch_test_phases(session, resource_specs):  # noqa: PLR0912
             print(f"*** FAIL: L2 {rt} — expand group above ***", flush=True)
             if fail_fast:
                 break
+
+    # ----- Phase 3: Resource jobs that must leave no ordinary ST successor -----
+    if final_resource_specs and not (l2_failed and fail_fast):
+        try:
+            results = _run_resource_phase(
+                final_resource_specs,
+                device_ids,
+                max_parallel,
+                fail_fast,
+                platform,
+                manual_mode,
+                cwd,
+                "Final Resource phase",
+            )
+        except ValueError as e:
+            print(f"\n*** Final Resource phase ABORTED: {e} ***\n", flush=True)
+            session.testsfailed = 1
+            return True
+        resource_results.extend(results)
+        final_resource_failed = any(r.returncode != 0 for r in results)
+        resource_failed = resource_failed or final_resource_failed
+        if final_resource_failed:
+            _emit_resource_failure_summary(results, heading="Final Resource phase failed")
 
     if resource_failed:
         _emit_resource_failure_summary(

--- a/docs/dfx/hbg-bind-phases.md
+++ b/docs/dfx/hbg-bind-phases.md
@@ -68,7 +68,7 @@ device lock for the whole job (see
 | Graph replays | 40, of a 277-node Definition | 20, of a 743-node Definition |
 | Graph boundary | 26 tensors | 118 tensors, 31 scalars |
 | First-run compile | seconds | **minutes** (369 kernel sources + an 11.6k-line orchestration) |
-| Marked | `manual` | `manual`, `skip_golden` |
+| Marked | `manual` | `skip_golden` |
 
 The level decides how a case's output is captured, which is what the recipe below
 has to work around.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -371,6 +371,14 @@ This matters on CPU-constrained CI runners. Example: an L3 case needs `device_co
 
 A single file can declare both L2 and L3 classes; they're grouped by `(runtime, level)` internally. L3 classes run in the Resource phase (subprocess-per-case, alongside standalone resource-marked functions), L2 classes run in the L2 phase (shared Worker per device).
 
+### Resource-phase tail ordering
+
+Mark an L3 class or standalone resource test with
+`@pytest.mark.resource_last` when it must run after every ordinary Resource and
+L2 job. The dispatcher runs marked jobs in a final Resource subphase inside the
+same pytest invocation, so the enclosing `task-submit` allocation remains held
+and no second queue submission is needed.
+
 ### Profiling under parallelism
 
 Each test case sets its own `CallConfig.output_prefix` (chosen by `scene_test.py::_build_output_prefix` as `outputs/<ClassName>_<case>_<YYYYMMDD_HHMMSS>/`). The C++ runtime writes all diagnostic artifacts under that prefix with fixed filenames:

--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/README.md
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/README.md
@@ -153,15 +153,15 @@ This gap is independent of the `hc_head_linear` MTE fault:
 ```bash
 # standalone (2 dies; wrap in task-submit on a shared box)
 python examples/a2a3/host_build_graph/deepseek_v4_flash_decode/\
-test_deepseek_v4_flash_decode.py -p a2a3 -d <d0>,<d1> --manual only
+test_deepseek_v4_flash_decode.py -p a2a3 -d <d0>,<d1>
 
 # pytest
 pytest examples/a2a3/host_build_graph/deepseek_v4_flash_decode \
-    --platform a2a3 --device <d0>,<d1> --manual only
+    --platform a2a3 --device <d0>,<d1>
 ```
 
-`manual` because the 368-kernel compile takes minutes; `skip_golden` because the
-routing is stood in, not computed.
+The case participates in the default Per-PR collection. It remains
+`skip_golden` because no full-network torch reference exists upstream.
 
 To exercise only the host side without launching the device body, set
 `SIMPLER_SKIP_DEVICE_RUN=1`. `simpler_launch_run` then completes the run before

--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
@@ -25,21 +25,22 @@ factors travel as kernel tensor inputs read from GM, so the host never writes a
 GM-heap device address and never copies tensor data into task scalars. The
 orchestration source is therefore the TMR one recast as a Graph, with no
 runtime-specific rewrite. ``skip_golden`` is inherited from the TMR case, which
-is itself a completion/smoke case; ``manual`` because the 368-kernel compile
-takes minutes.
+is itself a completion/smoke case.
 
 Host construction, Graph recording (129 host submissions) and device replay all
 complete, both ranks ``outcome=0``. See README.md for the measurements and for
 the fixes that got the replay running.
 
     python examples/a2a3/host_build_graph/deepseek_v4_flash_decode/\\
-test_deepseek_v4_flash_decode.py -p a2a3 -d <d0>,<d1> --manual only
+test_deepseek_v4_flash_decode.py -p a2a3 -d <d0>,<d1>
 """
 
 import copy
 import importlib.util
 import sys
 from pathlib import Path
+
+import pytest
 
 from simpler_setup import SceneTestCase, scene_test
 from simpler_setup.goldens.deepseek_v4_flash_decode import N_RANKS, generate_inputs
@@ -92,6 +93,7 @@ def _host_build_graph_callable():
     return callable_config
 
 
+@pytest.mark.resource_last
 @scene_test(level=3, runtime="host_build_graph")
 class TestDeepseekV4FlashDecodeHostBuildGraph(SceneTestCase):
     """DSv4 FLASH EP2/TP2 decode with the orchestration built on the host."""
@@ -101,7 +103,6 @@ class TestDeepseekV4FlashDecodeHostBuildGraph(SceneTestCase):
         {
             "name": "DecodeFwdEP2TP2",
             "platforms": ["a2a3"],
-            "manual": True,
             "skip_golden": True,
             "config": {
                 "device_count": N_RANKS,

--- a/examples/a2a3/tensormap_and_ringbuffer/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/README.md
@@ -31,7 +31,7 @@ For the `Worker` API underneath the framework, see
 | [`paged_attention_ringbuffer/`](paged_attention_ringbuffer/) | Deliberately undersized rings, driven per case through `config.runtime_env` (`ring_task_window` / `ring_heap` / `ring_dep_pool`) rather than process-global env. A stress test for rotation and reclamation. |
 | [`merge_pipeline_barrier/`](merge_pipeline_barrier/) | Three pipeline stages merged into **one** `block_num=8` SPMD task, ordered by an intra-task cross-core barrier instead of by three scheduled tasks. |
 | [`qwen3_14b_decode/`](qwen3_14b_decode/README.md) | The whole Qwen3-14B 40-layer decode stack as a single fused dispatch, using CANN fused attention. The largest example in the repo. |
-| [`deepseek_v4_flash_decode/`](deepseek_v4_flash_decode/README.md) | The whole DeepSeek-V4 FLASH 43-layer decode network on **2 dies** (EP2 expert-parallel MoE + TP2 LM head through a comm domain). The first pypto-harvested distributed network; `manual` + `skip_golden` (completion smoke, like upstream). |
+| [`deepseek_v4_flash_decode/`](deepseek_v4_flash_decode/README.md) | The whole DeepSeek-V4 FLASH 43-layer decode network on **2 dies** (EP2 expert-parallel MoE + TP2 LM head through a comm domain). The first pypto-harvested distributed network; Per-PR `skip_golden` completion smoke, like upstream. |
 
 ## Asynchronous completion and cross-card transfer
 

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/README.md
@@ -36,8 +36,8 @@ CI terms: the harvested distributed program compiles, both ranks' graphs
 dispatch, the cross-die window protocol (TPUT/TNOTIFY arrivals, LM-head
 all-gather) drains, and the run terminates cleanly.
 
-It is marked `manual`: compiling 368 incore kernels plus the 7.8k-line chip
-orchestration takes several minutes, so it does not run in the default sweep.
+The case participates in the default Per-PR collection; compiling its 368
+incore kernels plus the 7.8k-line chip orchestration takes several minutes.
 
 The six buffer initializations formerly expressed as orchestration-side
 `set_initial_value(0)` calls now run on device. Each of the five
@@ -81,37 +81,25 @@ it has a value before the network runs, and it feeds `set_block_num` — a launc
 parameter a predicate cannot express, because a predicate decides whether a task
 dispatches, not how wide it is.
 
-## Status: blocked on the #1644 pto-isa pin bump
+## Status: full-device completion on the current pin
 
-The case PASSES on every runtime from the wire-ABI cutover (#1729, the earliest
-commit whose scene-test plumbing can host it) through #1771 — all of which pin
-pto-isa `83d01313`, the commit these kernels were generated against. From
-`7a1b9b11` ("CI: bump pinned pto-isa for PTOAS v0.55", pto-isa -> `0cefc9a5`)
-onward, including current main, both ranks stall mid-network: two kernels spin
-forever on comm-window arrival counters and the scheduler exits
-`S1:running-stalled`. (The orchestrator's own `TENSOR_WAIT_TIMEOUT` on
-`recv_count_out` was a consequence of that stall — the read waited on a producer
-the stalled network never ran — and can no longer occur now that the count is
-read by the scheduler at the dispatch point.) The stall layer moves with fixture
-content (a timing-dependent miss, not a fixed logic error), and the identical
-program + content passes under pypto's own runner against pto-isa `83d01313`
-even with every weight streamed as a host tensor. Bisect evidence: PASS at
-PR #1771 and FAIL at PR #1644 on otherwise identical simpler code. Candidate
-pto-isa changes in `83d01313..0cefc9a5` touch exactly the GM-polling path
-these kernels spin on
-(`6ffe3221` "Qualify dcci cache line arguments", `2d9d4288` "normalize cache
-line constants").
+The original bring-up recorded a timing-dependent mid-network stall after the
+pto-isa pin bump in #1644. That status is historical: the current case completes
+on the repository pin `cd4a3d3f7a1a27fcfe536f617e9bca3008929664`. The device
+verification in #1939 passed both the TMR and HBG variants on two A2A3 dies. The
+Per-PR run for #1949 then exercised both full device bodies in the ordinary
+scene-test sweep: TMR passed in 299.25 seconds and HBG in 303.09 seconds.
 
 ## Running
 
 ```bash
 # standalone (2 dies; wrap in task-submit on a shared box)
 python examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py \
-    -p a2a3 -d <d0>,<d1> --manual only
+    -p a2a3 -d <d0>,<d1>
 
 # pytest
 pytest examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode \
-    --platform a2a3 --device <d0>,<d1> --manual only
+    --platform a2a3 --device <d0>,<d1>
 ```
 
 The fixture materializes on the order of 100 GiB of host tensors (weights for

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/test_deepseek_v4_flash_decode.py
@@ -29,15 +29,15 @@ in either repo. The case validates that the harvested distributed program —
 dispatches across both dies, drives the comm-window protocol to completion,
 and terminates cleanly.
 
-The case is marked ``manual`` (compiling 368 kernels takes several minutes);
-run it explicitly:
+The case participates in the default Per-PR collection. To run it explicitly:
 
     python examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/\
-test_deepseek_v4_flash_decode.py -p a2a3 -d <d0>,<d1> --manual only
+test_deepseek_v4_flash_decode.py -p a2a3 -d <d0>,<d1>
 
 See README.md for provenance pins and the regeneration recipe.
 """
 
+import pytest
 from simpler.task_interface import ArgDirection as D
 from simpler.task_interface import CommBufferSpec, DataType, TaskArgs, TensorArgType
 
@@ -580,6 +580,7 @@ def _decode_fwd_orch_fn(orch, callables, task_args, config):
             orch.submit_next_level(callables.decode_fwd, args, config, worker=rank)
 
 
+@pytest.mark.resource_last
 @scene_test(level=3, runtime="tensormap_and_ringbuffer")
 class TestDeepseekV4FlashDecode(SceneTestCase):
     CALLABLE = {
@@ -609,7 +610,6 @@ class TestDeepseekV4FlashDecode(SceneTestCase):
         {
             "name": "DecodeFwdEP2TP2",
             "platforms": ["a2a3"],
-            "manual": True,
             "skip_golden": True,
             "config": {
                 "device_count": N_RANKS,

--- a/tests/ut/py/test_scene_level_selection.py
+++ b/tests/ut/py/test_scene_level_selection.py
@@ -17,6 +17,7 @@ import pytest
 from _pytest.outcomes import Failed
 
 from simpler_setup import SceneTestCase, SceneTestLevel, scene_level, scene_test
+from simpler_setup.parallel_scheduler import JobResult
 from simpler_setup.scene_test import _discover_module_test_classes
 
 _ROOT = Path(__file__).resolve().parents[3]
@@ -180,6 +181,70 @@ def test_sorting_uses_function_level_metadata():
     root_conftest.pytest_collection_modifyitems(None, config, items)
 
     assert [item.nodeid for item in items] == ["tests::host", "tests::l2"]
+
+
+def test_resource_jobs_record_resource_last():
+    class NormalL3:
+        _st_level = SceneTestLevel.NODE
+        _st_runtime = "host_build_graph"
+        CASES = [{"platforms": ["a2a3"]}]
+
+    class LastL3:
+        _st_level = SceneTestLevel.NODE
+        _st_runtime = "host_build_graph"
+        CASES = [{"platforms": ["a2a3"]}]
+
+    items = [
+        _FakeItem("tests::last", cls=LastL3, markers=[_FakeMarker("resource_last")]),
+        _FakeItem("tests::normal", cls=NormalL3),
+    ]
+
+    jobs = root_conftest._collect_resource_jobs(items, "a2a3")
+
+    assert [(job.nodeid, job.run_last) for job in jobs] == [
+        ("tests::last", True),
+        ("tests::normal", False),
+    ]
+
+
+def test_resource_last_jobs_run_after_l2(monkeypatch, tmp_path):
+    class L2:
+        _st_level = SceneTestLevel.CHIP
+        _st_runtime = "host_build_graph"
+
+    config = _FakeConfig(
+        device="0",
+        exitfirst=False,
+        platform="a2a3",
+        manual="exclude",
+    )
+    config.invocation_params = SimpleNamespace(dir=tmp_path)
+    session = SimpleNamespace(config=config, items=[_FakeItem("tests::l2", cls=L2)], testsfailed=0)
+    specs = [
+        root_conftest._ResourceJob("l3", "tests::normal", "Normal", "host_build_graph", 1, 0),
+        root_conftest._ResourceJob("l3", "tests::last", "Last", "host_build_graph", 1, 1),
+    ]
+    events = []
+
+    def fake_run_jobs(jobs, *_args, **_kwargs):
+        events.append(("resource", tuple(job.nodeid for job in jobs)))
+        return [JobResult(label=job.label, returncode=0, device_ids=[0], nodeid=job.nodeid) for job in jobs]
+
+    def fake_subprocess_run(*_args, **_kwargs):
+        events.append(("l2", "host_build_graph"))
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(root_conftest, "_base_pytest_argv", lambda *_args, **_kwargs: ["pytest"])
+    monkeypatch.setattr(root_conftest, "_resolve_max_parallel", lambda *_args, **_kwargs: 1)
+    monkeypatch.setattr(root_conftest._ps, "run_jobs", fake_run_jobs)
+    monkeypatch.setattr(root_conftest.subprocess, "run", fake_subprocess_run)
+
+    assert root_conftest._dispatch_test_phases(session, specs)
+    assert events == [
+        ("resource", ("tests::normal",)),
+        ("l2", "host_build_graph"),
+        ("resource", ("tests::last",)),
+    ]
 
 
 def test_multi_round_chip_swimlane_does_not_reject_l3_items():


### PR DESCRIPTION
## Summary

- Remove `manual` from the A2A3 host-build-graph and tensormap-and-ringbuffer DeepSeek cases.
- Run both two-rank device completion smokes in the default Per-PR scene sweep.
- Defer both long-running cases to the final Resource subphase, after ordinary Resource and L2 work.
- Update the directly related case, measurement, and testing documentation.

This branch is based on main after #1939, which fixed and verified full device replay for both runtimes. Both cases launch and wait for their complete device bodies; there is no device-skip monkeypatch.

## Resource handoff isolation

Two earlier Per-PR runs exposed an existing `halMemCtl(AIC_CTRL)` initialization race after the TMR DeepSeek case had passed and released both of its devices:

- [run 32439970394](https://github.com/hw-native-sys/simpler/actions/runs/32439970394/job/96649067282): DeepSeek passed on devices `[10,11]`; immediately started successor workers reused both devices, and the worker on device 11 exhausted the bounded `halMemCtl` EACCES retries.
- [run 32442207474](https://github.com/hw-native-sys/simpler/actions/runs/32442207474/job/96655962665): DeepSeek passed on devices `[14,15]`; immediate successor reuse produced the same failure on device 14.

The failing nodeids were successor `worker_async_fifo` tests, not either DeepSeek test. The signature is consistent with the concurrent `chip_process` bring-up race documented in #925: releasing a two-device job lets the scheduler start two independent workers together, and one driver-side `halMemCtl(ADDR_MAP_TYPE_REG_AIC_CTRL)` request can lose the serialization window. A complete DeepSeek device run proves model completion but does not make immediate concurrent bring-up in later processes safe.

Both DeepSeek classes therefore carry `@pytest.mark.resource_last`. The dispatcher runs ordinary Resource jobs, then L2, then a final Resource subphase inside the same pytest invocation and the same enclosing `task-submit` allocation. DeepSeek still executes its complete device body, but no ordinary ST worker is launched after it. This is CI containment for the resource-handoff race; it is not presented as a fix to the driver/HAL serialization behavior.

## Testing

- `python -m py_compile` for both changed test modules
- repository header, English-only, platform-literal, Ruff, formatting, and Markdown checks
- dispatcher unit coverage verifies that `resource_last` jobs run after L2
- full A2A3 execution for both runtimes was verified by #1939
- [current-head Per-PR CI](https://github.com/hw-native-sys/simpler/actions/runs/32480588229) passed, including `st-onboard-a2a3`
