### PR TITLE
Fix: assign the graph-cache test's task slot through SelfRelativePtr::set

### DIFF
--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -441,7 +441,7 @@ TEST(GraphExecutionReplay, LocalizesBoundaryScalarPoolWiderThanTaskPayload) {
     outer_task.packed_buffer_end = heap.end();
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task = &outer_task;
+    outer_slot.task.set(&outer_task);
     outer_slot.graph_context = &submission;
 
     GraphExecution *execution = graph_execution_localize(outer_slot);
@@ -471,7 +471,7 @@ TEST(GraphExecutionReplay, RejectsBoundaryScalarPoolBeyondContract) {
     outer_task.packed_buffer_end = heap.end();
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task = &outer_task;
+    outer_slot.task.set(&outer_task);
     outer_slot.graph_context = &submission;
 
     EXPECT_EQ(graph_execution_localize(outer_slot), nullptr);


### PR DESCRIPTION
## Summary

`test_graph_cache` has not compiled on `main` since #1947 merged, so every PR's
`ut` job is red:

```text
tests/ut/cpp/common/test_hbg_graph_cache.cpp:444:24: error: no match for 'operator='
(operand types are 'simpler::hbg::SelfRelativePtr<PTO2TaskDescriptor>' and 'PTO2TaskDescriptor*')
tests/ut/cpp/common/test_hbg_graph_cache.cpp:474:24: error: no match for 'operator=' ...
```

`PTO2TaskSlotState::task` became a `SelfRelativePtr<PTO2TaskDescriptor>` in #1947,
which deletes copy-assignment deliberately — the stored value is a delta from the
field's own address, so assigning it from a raw pointer would silently retarget it.
#1947 converted the three call sites in this file that existed on its base. The two
in `LocalizesBoundaryScalarPoolWiderThanTaskPayload` and
`RejectsBoundaryScalarPoolBeyondContract` came from #1941 while #1947 was in review,
so neither PR's own CI ever compiled both halves together — each was green, and their
merge is not.

Both now use `outer_slot.task.set(&outer_task)`, the form lines 359 / 500 / 659
already use.

## Testing

- [x] `cmake --build tests/ut/cpp/build --target test_graph_cache` — builds (it did not before)
- [x] `--target test_a5_graph_cache` — builds
- [x] `ctest --test-dir tests/ut/cpp/build -R graph_cache -LE requires_hardware` — 2/2 passed

No production code touched; the diff is two lines in one test file.