### PR TITLE
host_build_graph: move payload arguments into pools named by delta

### DIFF
--- a/docs/dfx/args-dump.md
+++ b/docs/dfx/args-dump.md
@@ -348,7 +348,7 @@ dump skips `SCALAR` entries (they do not consume a positional tensor slot).
 
 Both `host_build_graph` and `tensormap_and_ringbuffer` share the
 same code path: the AICPU dump-collector reads geometry directly from
-`PTO2TaskPayload::tensors[]`, which carries shape and offset info
+the payload's tensor region, which carries shape and offset info
 alongside the device-packed arguments. For allocated output tensors,
 `alloc_tensors` supplies a `TensorCreateInfo` at orchestration time
 that is embedded in the payload by submit. For tensors that already
@@ -496,7 +496,7 @@ AICPU has device addresses and sizes — the logical shape, dtype,
 and view geometry come from the runtime. Both `host_build_graph`
 and `tensormap_and_ringbuffer` share the same code path: the
 AICPU dump-collector reads geometry directly from
-`PTO2TaskPayload::tensors[]`, which carries shape and offset info
+the payload's tensor region, which carries shape and offset info
 alongside the device-packed arguments. For allocated output tensors,
 `alloc_tensors` supplies a `TensorCreateInfo` at orchestration time
 that is embedded in the payload by submit. For tensors that already

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -194,13 +194,18 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
                 __gm__ char *src = reinterpret_cast<__gm__ char *>(exec_payload->src_payload);
                 int32_t tensor_count = *reinterpret_cast<__gm__ int32_t *>(src + PTO2_TASKPAYLOAD_TENSOR_COUNT_OFFSET);
                 int32_t scalar_count = *reinterpret_cast<__gm__ int32_t *>(src + PTO2_TASKPAYLOAD_SCALAR_COUNT_OFFSET);
-                __gm__ uint64_t *src_scalars =
-                    reinterpret_cast<__gm__ uint64_t *>(src + PTO2_TASKPAYLOAD_SCALARS_OFFSET);
+                // Each region is named by an int32 delta from the naming field's own
+                // address, so resolve the field, then add what it holds.
+                __gm__ char *tensors_field = src + PTO2_TASKPAYLOAD_TENSORS_DELTA_OFFSET;
+                __gm__ char *src_tensors = tensors_field + *reinterpret_cast<__gm__ int32_t *>(tensors_field);
+                __gm__ char *scalars_field = src + PTO2_TASKPAYLOAD_SCALARS_DELTA_OFFSET;
+                __gm__ uint64_t *src_scalars = reinterpret_cast<__gm__ uint64_t *>(
+                    scalars_field + *reinterpret_cast<__gm__ int32_t *>(scalars_field)
+                );
                 int n = 0;
                 for (int32_t i = 0; i < tensor_count; i++) {
-                    exec_payload->args[n++] = reinterpret_cast<uint64_t>(
-                        src + PTO2_TASKPAYLOAD_TENSORS_OFFSET + i * PTO2_TASKPAYLOAD_TENSOR_STRIDE
-                    );
+                    exec_payload->args[n++] =
+                        reinterpret_cast<uint64_t>(src_tensors + i * PTO2_TASKPAYLOAD_TENSOR_STRIDE);
                 }
                 for (int32_t i = 0; i < scalar_count; i++) {
                     exec_payload->args[n++] = src_scalars[i];

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -270,8 +270,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // rejects a pitch outside (0, capacity] and a region too small for it.
             const uint64_t live_slots =
                 pto2_sm_layout::live_slot_pitch(static_cast<uint64_t>(runtime->host_total_tasks));
-            const uint64_t payload_stride = runtime->sm_payload_stride;
-            const uint64_t sm_size = pto2_sm_layout::ring_segment_offsets(live_slots, payload_stride).end;
+            const uint64_t sm_size = runtime->sm_image_bytes;
             // sm_handle and the scheduler state are the device-only zone: their
             // bytes never travel, so they start as whatever the pooled arena last
             // held. Zeroing the handle first is what makes attach_populated's
@@ -279,7 +278,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // attach_populated.
             memset(rt->sm_handle, 0, sizeof(*rt->sm_handle));
             if (!rt->sm_handle->attach_populated(
-                    sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes, live_slots, payload_stride
+                    sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes, live_slots, runtime->sm_image_bytes
                 )) {
                 LOG_ERROR("Thread %d: host-orch: sm_handle->attach_populated failed", thread_idx);
                 rt = nullptr;

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -73,13 +73,16 @@ The shared image uses three per-slot structures:
 | Structure | Purpose |
 | --------- | ------- |
 | `PTO2TaskDescriptor` | Full task ID, kernel IDs, packed-buffer addresses |
-| `PTO2TaskPayload` | Tensors, scalars, predicate, local-ID fanins, dispatch metadata |
+| `PTO2TaskPayload` | Argument counts, predicate, dispatch metadata, and a delta naming each of its tensor, scalar and fanin regions — the arguments themselves live in the pool segments, so the payload is a fixed three cache lines regardless of the argument caps |
 | `PTO2TaskSlotState` | Active mask, attributes, block/subtask counters, completion state, task/payload bindings |
 
 The host/device boundary is POD and position-independent. Fanins are integer
-producer IDs, not pointers, and a slot state names its payload and descriptor by a
-delta from its own address — so the image needs no fixup on either side of the
-copy.
+producer IDs, not pointers, and a slot state names its payload and descriptor — and
+a payload names its three argument regions — by a delta from the naming field's own
+address, so the image needs no fixup on either side of the copy. A delta is only
+correct for the layout it was taken in, so `compact_live_image` re-takes every one
+of them against the shipped image; the copy to the device moves a field and its
+target together and leaves them all correct.
 
 ### 3.1 What Ships: the Arena's Three Zones
 
@@ -242,8 +245,8 @@ AIC/MIX tasks use the available cluster count.
 TensorMap maps tensor regions to producer task IDs. For every task:
 
 1. INPUT/INOUT regions look up overlapping producers.
-2. Explicit and discovered producers are deduplicated into
-   `fanin_local_ids[]`.
+2. Explicit and discovered producers are deduplicated into the payload's fanin
+   region.
 3. OUTPUT/INOUT regions register the new task as producer.
 4. Each producer tracks its highest consumer local ID for completion metadata.
 

--- a/src/a2a3/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a2a3/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
@@ -28,8 +28,9 @@ The shared graph image separates stable task identity from scheduling state:
 
 - `PTO2TaskDescriptor` contains the task ID, kernel IDs, and packed-buffer
   addresses.
-- `PTO2TaskPayload` contains tensors, scalars, predicates, and position-
-  independent `fanin_local_ids[]`.
+- `PTO2TaskPayload` contains the argument counts, predicate, and a delta naming
+  each of its tensor, scalar and position-independent fanin-id regions. The
+  arguments live in the pool segments, not in the payload.
 - `PTO2TaskSlotState` contains the active mask, task attributes, logical block
   count, subtask counters, completion state, and descriptor/payload bindings.
 
@@ -76,8 +77,8 @@ must launch as one cohort:
 ## Dependency and Readiness Flow
 
 1. Host orchestration allocates a task slot and builds its payload.
-2. TensorMap and explicit dependencies append producer local IDs to
-   `fanin_local_ids[]`.
+2. TensorMap and explicit dependencies append producer local IDs to the payload's
+   fanin region.
 3. Submit publishes only the finished graph data; it does not push ready tasks.
 4. After H2D, device boot scans every submitted task exactly once.
 5. A task with every fanin complete is routed to its ready queue; otherwise it

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -683,22 +683,18 @@ int32_t run_host_orchestration(
     // with the same pitch. The ring capacity and mask are untouched: `local_id &
     // mask` is `local_id`, which is below the pitch for every ring task.
     const uint64_t nt = static_cast<uint64_t>(total_tasks);
-    // The widest task in this bind sets the stride every payload in the image gets.
-    // Read from the mirror, which orchestration has finished writing.
-    int32_t widest_tensor_count = 0;
-    {
-        const auto *mirror_payloads =
-            reinterpret_cast<const PTO2TaskPayload *>(static_cast<const char *>(host_sm) + sm_segs.payloads);
-        for (uint64_t i = 0; i < nt; ++i) {
-            if (mirror_payloads[i].tensor_count > widest_tensor_count) {
-                widest_tensor_count = mirror_payloads[i].tensor_count;
-            }
-        }
-    }
-    const uint64_t payload_stride = pto2_sm_layout::shipped_payload_stride(widest_tensor_count);
-    runtime->sm_payload_stride = payload_stride;
-    const uint64_t image_bytes =
-        pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::live_slot_pitch(nt), payload_stride).end;
+    // What this bind actually put in the pools. The orchestrator's cursors are the
+    // exact populated extent of each one — no scan of the mirror is needed, and the
+    // image ships that much rather than the worst case the mirror is dimensioned for.
+    const PTO2OrchestratorState &orch_state = rt->orchestrator;
+    const pto2_sm_layout::BindUsage bind_usage{
+        nt,
+        static_cast<uint64_t>(orch_state.fanin_pool_cursor),
+        static_cast<uint64_t>(orch_state.tensor_pool_cursor),
+        static_cast<uint64_t>(orch_state.scalar_pool_cursor),
+    };
+    const uint64_t image_bytes = pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::image_extents(bind_usage)).end;
+    runtime->sm_image_bytes = image_bytes;
 
     // Only now is the size known, so this is where the device region grows to cover
     // its shared-memory tail. setup_static_arena grows per region and
@@ -756,7 +752,7 @@ int32_t run_host_orchestration(
     runtime_clear_host_only_pointers(rt);
     std::memcpy(upload_base, static_cast<const char *>(host_arena.base()) + layout.off_copied_begin, copied_bytes);
     const uint64_t compacted = pto2_sm_layout::compact_live_image(
-        static_cast<const char *>(host_sm), eff_task_window_sizes[0], nt, payload_stride, upload_base + copied_bytes
+        static_cast<const char *>(host_sm), eff_task_window_sizes[0], bind_usage, upload_base + copied_bytes
     );
     always_assert(compacted == image_bytes);
 
@@ -766,11 +762,15 @@ int32_t run_host_orchestration(
         return -1;
     }
     {
-        char attrs[96];
+        // Eight uint64 fields plus their labels; 96 would truncate the trailing
+        // `args=` counts on a large bind, which are the ones this marker exists for.
+        char attrs[224];
         snprintf(
             attrs, sizeof(attrs),
-            "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " subs=%" PRIu64 " pstride=%" PRIu64, nt,
-            upload_bytes, copied_bytes, image_bytes, submission_block_bytes, payload_stride
+            "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " subs=%" PRIu64 " args=%" PRIu64
+            "/%" PRIu64 "/%" PRIu64,
+            nt, upload_bytes, copied_bytes, image_bytes, submission_block_bytes, bind_usage.fanin_elems,
+            bind_usage.tensor_elems, bind_usage.scalar_elems
         );
         record_bind_phase(HostPhaseKind::BindArenaH2d, t_h2d_ns, attrs, upload_bytes);
     }

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -2222,7 +2222,7 @@ void PTO2OrchestratorState::graph_abort(void *recording_handle) {
     auto *entry = static_cast<GraphInflightRecording *>(recording_handle);
     if (state == nullptr || entry == nullptr) return;
     {
-        std::lock_guard<std::mutex> lock(state->recording_mutex);
+        std::scoped_lock lock(state->recording_mutex);
         entry->recording.reset();
         entry->set_status(GraphRecordingStatus::FAILED);
     }
@@ -2259,7 +2259,7 @@ bool PTO2OrchestratorState::graph_end() {
     );
     bool ready = false;
     {
-        std::lock_guard<std::mutex> lock(state->recording_mutex);
+        std::scoped_lock lock(state->recording_mutex);
         if (entry->status() != GraphRecordingStatus::RECORDING || entry->full_key != header->full_key) {
             entry->set_status(GraphRecordingStatus::FAILED);
         } else {

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -838,22 +838,17 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     definition.tensor_arg_count = static_cast<uint32_t>(tensors.size());
     definition.scalar_arg_count = static_cast<uint32_t>(scalars.size());
     definition.predicate_count = static_cast<uint32_t>(predicates.size());
-    // The widest node sets the stride every entry of this Definition's execution
-    // storage gets; nodes[] carries each node's declared tensor count.
-    int32_t widest_node_tensor_count = 0;
-    for (const GraphNodeDefinition &node : nodes) {
-        if (node.tensor_count > widest_node_tensor_count) widest_node_tensor_count = node.tensor_count;
-    }
-    const size_t node_stride = graph_node_stride(widest_node_tensor_count);
+    // An execution's storage is the node array plus this Definition's two argument
+    // pools, which the nodes index by their own tensor_offset / scalar_offset — so the
+    // arg-table counts size them, and no per-node scan is needed.
     size_t execution_storage_bytes = 0;
-    if (node_stride > UINT32_MAX ||
-        !graph_execution_storage_bytes(
-            static_cast<int32_t>(definition.task_count), node_stride, &execution_storage_bytes
+    if (!graph_execution_storage_bytes(
+            static_cast<int32_t>(definition.task_count), definition.tensor_arg_count, definition.scalar_arg_count,
+            &execution_storage_bytes
         ) ||
         execution_storage_bytes > UINT32_MAX) {
         return false;
     }
-    definition.node_stride = static_cast<uint32_t>(node_stride);
     definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
     // Every section's byte count is known now, so the image grows once instead of
     // resizing eleven times. Each append aligns its start, hence the per-section
@@ -955,7 +950,7 @@ static uint32_t next_fanin_seen_epoch(PTO2OrchestratorState *orch) {
 
 // Polling: fanin is a flat array of position-independent producer local ids on
 // the payload (no dep-pool spill, no producer pointers). The builder writes them
-// directly into payload->fanin_local_ids as producers are appended, deduping by
+// directly into the payload's fanin region as producers are appended, deduping by
 // slot and hard-capping at PTO2_MAX_FANIN. self_local is this task's own local id
 // (the consumer), used to bump each producer's last_consumer_local_id (the
 // reclaim gate the host wait_for_consumers polls via completed_watermark).
@@ -965,12 +960,16 @@ struct PTO2FaninBuilder {
         orch(orch),
         seen_epoch(seen_epoch),
         self_local(self_local),
-        payload(payload) {}
+        payload(payload),
+        slots(payload->fanin_data()) {}
     int32_t count{0};
     PTO2OrchestratorState *orch{nullptr};
     uint32_t seen_epoch{0};
     int32_t self_local{0};
     PTO2TaskPayload *payload{nullptr};
+    // The payload's fanin region, resolved once: the appends below would otherwise
+    // re-resolve the delta per producer. Requires the regions bound before construction.
+    int32_t *slots{nullptr};
 
     bool mark_seen(uint8_t prod_ring, int32_t prod_slot) {
         if (prod_ring >= PTO2_MAX_RING_DEPTH || prod_slot < 0) {
@@ -1005,7 +1004,7 @@ static bool append_fanin_or_fail(
         LOG_ERROR("========================================");
         LOG_ERROR("FATAL: Fanin Capacity Exhausted!");
         LOG_ERROR("========================================");
-        LOG_ERROR("HBG stores every producer dependency inline on the consumer task.");
+        LOG_ERROR("HBG stores every producer dependency in the consumer task's fanin region.");
         LOG_ERROR("  Fanin:     used=%d/%d", fanin_builder->count, PTO2_MAX_FANIN);
         LOG_ERROR("  Requested: at least %d distinct producer dependencies", fanin_builder->count + 1);
         LOG_ERROR("Solution:");
@@ -1015,7 +1014,7 @@ static bool append_fanin_or_fail(
         orch_mark_fatal(orch, PTO2_ERROR_DEP_POOL_OVERFLOW);
         return false;
     }
-    fanin_builder->payload->fanin_local_ids[fanin_builder->count++] = static_cast<int32_t>(producer_task_id.local());
+    fanin_builder->slots[fanin_builder->count++] = static_cast<int32_t>(producer_task_id.local());
 
     // Reclaim gate: record this task as a consumer of the producer. The producer
     // slot retires once the per-ring completed_watermark reaches this consumer id.
@@ -1079,6 +1078,24 @@ static bool prepare_task(
     out->slot_state = &orch->sm_header->ring.get_slot_state_by_slot(out->alloc_result.slot);
     out->task = &orch->sm_header->ring.task_descriptors[out->alloc_result.slot];
     out->payload = &orch->sm_header->ring.task_payloads[out->alloc_result.slot];
+
+    // Bind the three argument regions before prefetch() and init(), both of which
+    // dereference them. The scalar cursor advances in whole cache lines because init()
+    // rounds its scalar memcpy up to one; a packed advance would let that rounding
+    // write into the next task's region. A tensor region is aligned for any count,
+    // ChipTensor being two cache lines. The fanin cursor advances at publish, not
+    // here — see the comment where it does.
+    const uint64_t window = orch->sm_header->ring.task_window_size;
+    const int32_t scalar_span = PTO2_ALIGN_UP(args.scalar_count(), ARG_POOL_ALIGN / (int32_t)sizeof(uint64_t));
+    debug_assert(static_cast<uint64_t>(orch->tensor_pool_cursor) + args.tensor_count() <= window * MAX_TENSOR_ARGS);
+    debug_assert(static_cast<uint64_t>(orch->scalar_pool_cursor) + scalar_span <= window * MAX_SCALAR_ARGS);
+    debug_assert(static_cast<uint64_t>(orch->fanin_pool_cursor) + PTO2_MAX_FANIN <= window * PTO2_MAX_FANIN);
+    out->payload->bind_regions(
+        orch->tensor_pool + orch->tensor_pool_cursor, orch->scalar_pool + orch->scalar_pool_cursor,
+        orch->fanin_pool + orch->fanin_pool_cursor
+    );
+    orch->tensor_pool_cursor += args.tensor_count();
+    orch->scalar_pool_cursor += scalar_span;
 
     // Init-on-write: this slot's dynamic scheduling fields and completion flag are
     // initialized here, as the orchestrator claims the slot. whole-graph-resident
@@ -1437,7 +1454,7 @@ static TaskOutputTensors submit_task_common(
     task.packed_buffer_end = prepared.alloc_result.packed_end;
 
     // append_fanin_or_fail wrote each producer's local id straight into
-    // payload.fanin_local_ids and bumped its last_consumer_local_id; the count is
+    // the payload's fanin region and bumped its last_consumer_local_id; the count is
     // published in STEP 6 below. payload.init does not touch the fanin region.
     payload.init(args, result, prepared.alloc_result, layout);
 
@@ -1463,7 +1480,7 @@ static TaskOutputTensors submit_task_common(
 
     // === STEP 6: publish the inline fanin count (device boot classifies) ===
     // Polling + host-orch: append_fanin_or_fail already wrote each producer's
-    // local id into payload.fanin_local_ids and bumped its last_consumer_local_id.
+    // local id into the payload's fanin region and bumped its last_consumer_local_id.
     // All that remains is to record how many. There is NO fanout adjacency, NO
     // dep_pool, and NO ready routing here — the initial device boot scan classifies
     // each task once. A -1 result from classify_fanin_state routes the task through
@@ -1474,6 +1491,12 @@ static TaskOutputTensors submit_task_common(
     // a flat array of position-independent integers, so it crosses to the device
     // unchanged.
     payload.fanin_count = fanin_builder.count;
+    // The region's length is settled, so the cursor closes it at the real count. The
+    // equality holds only while nothing between the bind and here bound another fanin
+    // region, which is what makes the deferred advance safe.
+    debug_assert(orch->fanin_pool_cursor == static_cast<int32_t>(payload.fanin_data() - orch->fanin_pool));
+    orch->fanin_pool_cursor += PTO2_ALIGN_UP(fanin_builder.count, ARG_POOL_ALIGN / (int32_t)sizeof(int32_t));
+
     (void)sched;
 
     CYCLE_COUNT_LAP(g_orch_fanin_cycle);
@@ -1689,6 +1712,10 @@ bool graph_submit_outer(
     ring.completion_flags[allocation.slot].store(0, std::memory_order_relaxed);
 
     slot.bind_buffers(&payload, &task);
+    // An outer GRAPH task holds a real ring slot, so its fanin comes from the pool like
+    // any other task's. It has no tensor or scalar region: its boundary travels inside
+    // the submission image, and graph_reset_outer_payload zeroes both counts below.
+    payload.bind_regions(nullptr, nullptr, orch->fanin_pool + orch->fanin_pool_cursor);
     slot.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
     slot.last_consumer_local_id = static_cast<int32_t>(task_id.local());
     slot.active_mask = ActiveMask{};
@@ -1739,6 +1766,11 @@ bool graph_submit_outer(
     }
     register_task_outputs(boundary_inputs, task_id, orch->tensor_map, orch->in_manual_scope());
     payload.fanin_count = fanin_builder.count;
+    // The region's length is settled, so the cursor closes it at the real count. The
+    // equality holds only while nothing between the bind and here bound another fanin
+    // region, which is what makes the deferred advance safe.
+    debug_assert(orch->fanin_pool_cursor == static_cast<int32_t>(payload.fanin_data() - orch->fanin_pool));
+    orch->fanin_pool_cursor += PTO2_ALIGN_UP(fanin_builder.count, ARG_POOL_ALIGN / (int32_t)sizeof(int32_t));
 
     pending.outer_slot = &slot;
     state->pending_uploads.push_back(std::move(pending));

--- a/src/a2a3/runtime/host_build_graph/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto2_dispatch_payload.h
@@ -67,11 +67,13 @@ static_assert(
 // PTO2TaskPayload layout drift fails the build rather than corrupting args[].
 constexpr uint32_t PTO2_TASKPAYLOAD_TENSOR_COUNT_OFFSET = 0;
 constexpr uint32_t PTO2_TASKPAYLOAD_SCALAR_COUNT_OFFSET = 4;
+// Offsets of the fields that NAME the argument regions, not of the regions themselves:
+// a region's address is (src + <field offset>) + <the int32 delta stored there>.
+constexpr uint32_t PTO2_TASKPAYLOAD_TENSORS_DELTA_OFFSET = 12;
+constexpr uint32_t PTO2_TASKPAYLOAD_SCALARS_DELTA_OFFSET = 16;
 // Cache line 9 (byte 576) holds the AICPU-only DispatchPredicate. Scalars follow it,
 // then tensors — the tensor array is last because it is the only region whose used
 // extent varies per task, so a task's read set is a contiguous prefix.
-constexpr uint32_t PTO2_TASKPAYLOAD_SCALARS_OFFSET = 640;
-constexpr uint32_t PTO2_TASKPAYLOAD_TENSORS_OFFSET = 768;
 constexpr uint32_t PTO2_TASKPAYLOAD_TENSOR_STRIDE = 128;  // sizeof(ChipTensor)
 
 /**

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_orchestrator.h
@@ -115,6 +115,24 @@ struct PTO2OrchestratorState {
     // crosses to the device.
     GraphHostState *graph_host_state{nullptr};
 
+    // === ARGUMENT POOLS (host-only) ===
+    // The mirror's three argument pools and the next free element in each. A submit
+    // binds its region at the cursor and advances it by what the task uses, so the
+    // pools stay packed and the bind path reads the cursors as the image's pool
+    // extents. Nothing is ever returned, and the pools are dimensioned for the worst
+    // case (task_window tasks each at their full cap), so a bump cannot overflow.
+    // The bases live here, not in the ring header: nothing on the device resolves one.
+    //
+    // The fanin cursor does not advance at bind time. PTO2FaninBuilder appends and
+    // dedups producers afterwards, so the region's length is known only when the count
+    // is published, and it advances there.
+    int32_t *fanin_pool{nullptr};
+    ChipTensor *tensor_pool{nullptr};
+    uint64_t *scalar_pool{nullptr};
+    int32_t fanin_pool_cursor{0};
+    int32_t tensor_pool_cursor{0};
+    int32_t scalar_pool_cursor{0};
+
     // === STATISTICS ===
 #if SIMPLER_DFX
     int64_t tasks_submitted;
@@ -143,8 +161,8 @@ struct PTO2OrchestratorState {
     );
 
     // Phase 3b: write the arena-internal pointer fields (scope_tasks,
-    // scope_begins, ring.fanin_pool.base, tensor_map.{buckets,entry_pool,
-    // free_entry_list,task_entry_heads}, scheduler reference).
+    // scope_begins, tensor_map.{buckets,entry_pool,free_entry_list,
+    // task_entry_heads}, scheduler reference).
     // Idempotent — host runs once on the image, AICPU runs once after attach.
     void wire_arena_pointers(const PTO2OrchestratorLayout &layout, DeviceArena &arena, PTO2SchedulerState *scheduler);
 

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -266,8 +266,7 @@ void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayou
 
 /**
  * Phase 3b — wire the orchestrator's pointers into the host-only zone
- * (orchestrator.{scope_tasks, scope_begins, scheduler, tensor_map.*,
- * ring.fanin_pool.base}).
+ * (orchestrator.{scope_tasks, scope_begins, scheduler, tensor_map.*}).
  *
  * Host-only by construction: that zone is past layout.device_bytes and so is not
  * allocated on the device, which makes the addresses this writes unrepresentable

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -30,6 +30,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <type_traits>
 
 #include "profiling_config.h"
 #include "pto_constants.h"
@@ -110,11 +111,17 @@
 // Fanin storage
 #define PTO2_FANIN_INLINE_CAP 64
 
-// Polling-scheduler inline fanin cap. The polling model stores producer
-// dependencies as flat position-independent local-id integers on the payload
-// (no dep-pool spill), so a task's fanin degree is hard-capped here. Must cover
-// the worst-case fanin of any workload (paged_attention is the densest).
+// Polling-scheduler fanin cap. The polling model stores producer dependencies as
+// flat position-independent local-id integers in the fanin pool (no dep-pool
+// spill), so a task's fanin degree is hard-capped here. Must cover the worst-case
+// fanin of any workload (paged_attention is the densest).
 #define PTO2_MAX_FANIN 128
+
+// Alignment of every per-task region inside an argument pool. Each region starts
+// and ends on a cache line so PTO2TaskPayload::init's round-up scalar memcpy stays
+// inside the task's own region — see its comment. ChipTensor is already 2 cache
+// lines, so only the fanin and scalar regions need the round-up.
+inline constexpr int32_t ARG_POOL_ALIGN = 64;
 
 // Dependency-degree diagnostic: warn once when a task's fanin or a producer's
 // fanout first exceeds this degree, so dense dependency graphs surface without
@@ -260,35 +267,42 @@ enum PTO2EarlySyncDrainState : uint8_t {
 inline constexpr int PTO2_EARLY_DISPATCH_CORE_MASK_WORDS = 2;
 
 struct PTO2TaskPayload {
-    // === Cache lines 0-8 (576B) — metadata + inline fanin ===
+    // === Cache line 0 (64B) — the dispatch path's own line ===
+    // sizeof is independent of PTO2_MAX_FANIN / MAX_TENSOR_ARGS / MAX_SCALAR_ARGS:
+    // widening a cap costs pool bytes for the tasks that need them, not a control
+    // block on every task.
     int32_t tensor_count{0};
     int32_t scalar_count{0};
     int32_t fanin_count{0};  // Producer dependency count (raw, no +1 redundance)
-    // Producer dependencies as position-independent local task ids. Single-ring
-    // hbg: every producer is ring 0, so no per-edge ring id is stored. Scanned
-    // by classify_fanin_state against the ring completion_flags. A -1 result
-    // means every fanin is complete; otherwise it is the first unmet
-    // fanin index. Hard-capped at PTO2_MAX_FANIN (no dep-pool spill).
-    int32_t fanin_local_ids[PTO2_MAX_FANIN];
-    // Reserved: preserves the early-dispatch block and tensors[] offsets. tensors
-    // must stay at byte 576 (AICore arg-materialization contract), so this fanin
-    // region keeps its original 528-byte footprint.
-    int32_t _fanin_reserved[3];
-    // Early-dispatch metadata (AICPU-side only). Ordered by descending
-    // alignment (8B mask, 4B fanin, then 2B/1B counters and flags) so the block packs with no
-    // internal padding. Kept here after the fanin array (not moved up front): on
-    // cache line 8 it shares only with the rarely-touched fanin tail, whereas in
-    // line 0 the early-dispatch atomics (written during staging) would false-share with
-    // tensor_count/scalar_count (read by build_payload at dispatch). Fits in the 40B
-    // between the fanin array (offset 536) and the 64B-aligned tensors[] (offset
-    // 576), so sizeof and tensors[] are unchanged.
+
+    // This task's three argument regions, each in a pool outside this struct and
+    // named by a delta from the naming field's own address. A delta holds only for
+    // the layout it was taken in, so every one is bound twice on the host: against
+    // the mirror when the slot is claimed, and against the image in
+    // compact_live_image, which re-pitches the segments.
+    //
+    // fanin holds flat position-independent producer local task ids. Single-ring
+    // hbg: every producer is ring 0, so no per-edge ring id is stored. Scanned by
+    // classify_fanin_state against the ring completion_flags. Hard-capped at
+    // PTO2_MAX_FANIN (no dep-pool spill). Unbound on a Graph node, whose
+    // dependencies live in the Definition's fanin CSR instead.
+    simpler::hbg::SelfRelativePtr<ChipTensor> tensors;
+    simpler::hbg::SelfRelativePtr<uint64_t> scalars;
+    simpler::hbg::SelfRelativePtr<int32_t> fanin;
+
+    // === Cache line 1 — early-dispatch metadata (AICPU-side only) ===
+    // Ordered by descending alignment (8B mask, 4B fanin, then 2B/1B counters and
+    // flags) so the block packs with no internal padding. On its own line rather
+    // than line 0: these atomics are written during staging while line 0's counts
+    // and region deltas are read by build_payload at dispatch, so sharing a line
+    // would false-share.
     //
     // Bitmask of global core_ids this consumer is pre-staged (gated) on. Concurrent
     // stagers publish bits with atomic fetch_or. A regular consumer destructively
     // splits them between release and late-stager owners; a sync_start cohort keeps
     // the completed mask stable for its single launch owner, whether staging is local
     // or uses the global drain fallback.
-    std::atomic<uint64_t> staged_core_mask[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS]{};
+    alignas(64) std::atomic<uint64_t> staged_core_mask[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS]{};
     // Early-dispatch CANDIDATE detection (event-driven, dual of fanin_refcount):
     // seeded at wiring with producers already complete, then a flagged producer
     // bumps each consumer after all of its logical blocks are published.
@@ -326,49 +340,57 @@ struct PTO2TaskPayload {
     // reinitialization. READY records that producer release observed OWNER;
     // only cancellation clears OWNER during the current task lifetime.
     std::atomic<uint8_t> early_sync_drain_state{PTO2_EARLY_SYNC_DRAIN_NONE};
-    // === Cache line 9 (byte 576) — dispatch predicate (AICPU-only) ===
-    // Offset is a fixed 576, independent of MAX_TENSOR_ARGS / MAX_SCALAR_ARGS.
-    // AICore never reads it — args are materialized from the tensor_count / tensors
-    // / scalars offsets only. Resolved at submit; evaluated by the scheduler at
-    // dispatch.
+    // === Cache line 2 — dispatch predicate + dump metadata (AICPU-only) ===
+    // AICore never reads either — args are materialized from line 0's counts and
+    // region deltas. Resolved at submit; evaluated by the scheduler at dispatch.
     alignas(64) DispatchPredicate predicate;
     ArgsDumpTaskMetadata dump_metadata;
-    // === Cache lines 10-11 (128B) — scalars ===
-    // alignas is load-bearing: the AICore reads this at a compile-time offset, and
-    // uint64_t alone would let it start right after dump_metadata instead of on the
-    // next cache line. tensors got its 640 for free from ChipTensor's own alignment.
-    alignas(64) uint64_t scalars[MAX_SCALAR_ARGS];
-    // === Cache lines 12-75 (4096B) — tensors (alignas(64) forces alignment) ===
-    //
-    // Last on purpose. This is the only region whose used extent varies per task —
-    // one to seventeen entries of thirty-two on a measured decode — so putting it at
-    // the end makes everything a task reads a contiguous prefix, which is what lets
-    // the shipped image carry less than the whole array.
-    ChipTensor tensors[MAX_TENSOR_ARGS];
 
-    // Layout verification (size checks that don't need offsetof).
-    static_assert(sizeof(ChipTensor) == 128, "ChipTensor must be 2 cache lines");
-    static_assert(MAX_SCALAR_ARGS * sizeof(uint64_t) == 128, "scalar region must be 128B (2 cache lines)");
+    // --- Argument region access ---
+    // Each accessor resolves its delta once and hands back the region's first
+    // element, so a caller indexes the region directly. Deliberately no per-element
+    // accessor: one inside a loop would re-resolve the delta on every iteration, and
+    // a store through an unrelated pointer in the loop body is enough to stop the
+    // compiler hoisting that load — build_payload's args[] writes are exactly that.
+    ChipTensor *tensor_data() { return tensors.get(); }
+    const ChipTensor *tensor_data() const { return tensors.get(); }
+    uint64_t *scalar_data() { return scalars.get(); }
+    const uint64_t *scalar_data() const { return scalars.get(); }
+    int32_t *fanin_data() { return fanin.get(); }
+    const int32_t *fanin_data() const { return fanin.get(); }
+
+    /**
+     * Point this payload's three argument regions at pool-resident storage. Must run
+     * before prefetch() and init(), which dereference them.
+     *
+     * A Graph node passes nullptr for fanin: its dependencies come from the
+     * Definition's CSR, so the region does not exist and fanin_count stays 0.
+     */
+    void bind_regions(ChipTensor *tensor_region, uint64_t *scalar_region, int32_t *fanin_region) {
+        tensors.set(tensor_region);
+        scalars.set(scalar_region);
+        fanin.set(fanin_region);
+    }
 
     /**
      * Prefetch (for write) the regions init() is about to fill so the stores land
      * in warm cache. tensor_count/scalar_count come from the Arg — the payload's
-     * own counts are not set until init(). Warms the early-dispatch block at
-     * offset 536 (cache line 8) too. A member fn lowers to the same prefetch
+     * own counts are not set until init(). A member fn lowers to the same prefetch
      * instructions as a free function (`this` is just a register), no cache impact.
      */
     void prefetch(int32_t tensor_count, int32_t scalar_count) const {
+        const ChipTensor *t = tensor_data();
         for (int32_t i = 0; i < tensor_count; i++) {
-            __builtin_prefetch(&tensors[i], 1, 3);
-            __builtin_prefetch(reinterpret_cast<const char *>(&tensors[i]) + 64, 1, 3);
+            __builtin_prefetch(&t[i], 1, 3);
+            __builtin_prefetch(reinterpret_cast<const char *>(&t[i]) + 64, 1, 3);
         }
+        const uint64_t *s = scalar_data();
         for (int32_t i = 0; i < scalar_count; i += 8) {
-            __builtin_prefetch(&scalars[i], 1, 3);
+            __builtin_prefetch(&s[i], 1, 3);
         }
         __builtin_prefetch(this, 1, 3);
         __builtin_prefetch(reinterpret_cast<const char *>(this) + 64, 1, 3);
         __builtin_prefetch(reinterpret_cast<const char *>(this) + 128, 1, 3);
-        __builtin_prefetch(reinterpret_cast<const char *>(this) + 512, 1, 3);  // early-dispatch fields (cache line 8)
     }
 
     /**
@@ -387,23 +409,31 @@ struct PTO2TaskPayload {
         tensor_count = args.tensor_count();
         scalar_count = args.scalar_count();
 
-        // int32_t out_idx = 0;
+        // bind_regions must already have run: an unbound region reads back as null and
+        // the stores below would go through it. A count of zero needs no region, which
+        // is how an outer GRAPH task reaches here with both unbound.
+        debug_assert(args.tensor_count() == 0 || tensor_data() != nullptr);
+        debug_assert(args.scalar_count() == 0 || scalar_data() != nullptr);
+
+        ChipTensor *dst = tensor_data();
         for (int32_t i = 0; i < args.tensor_count(); i++) {
             if (args.tag(i) != TensorArgType::OUTPUT) {
-                tensors[i].copy(args.tensor(i).ref());
+                dst[i].copy(args.tensor(i).ref());
             } else {
                 init_tensor_from_create_info(
-                    tensors[i], args.tensor(i).create_info(),
+                    dst[i], args.tensor(i).create_info(),
                     reinterpret_cast<void *>(reinterpret_cast<char *>(alloc_result.packed_base) + layout.offsets[i]),
                     layout.buffer_sizes[i]
                 );
-                tensors[i].owner_task_id = result.task_id();
-                result.materialize_output(tensors[i]);
+                dst[i].owner_task_id = result.task_id();
+                result.materialize_output(dst[i]);
             }
         }
-        // Round up to cache line boundary. Both arrays are 128B so no overrun.
-        // Eliminates branches; extra bytes within the same CL have zero additional cost.
-        memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
+        // Round up to cache line boundary. Every scalar region is a whole number of
+        // cache lines (ARG_POOL_ALIGN), so the rounded copy stays inside this
+        // task's own region. Eliminates branches; extra bytes within the same CL have
+        // zero additional cost.
+        memcpy(scalar_data(), args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
 
         dump_metadata = {};
 #if SIMPLER_DFX
@@ -416,7 +446,7 @@ struct PTO2TaskPayload {
         // fields. reset_for_reuse MUST NOT touch the payload (it runs at slot
         // init and would pull this cold cache line across structures);
         // prepare_task only allocates/binds. prefetch() warms this
-        // line (offset 512) so these writes land in warm cache.
+        // line (cache line 1) so these writes land in warm cache.
         //
         // early_dispatch_state / staged_core_mask / dispatch_fanin are all CONSUMER-side: a
         // task whose own allow_early_resolve is false still has them touched when
@@ -437,28 +467,36 @@ struct PTO2TaskPayload {
     }
 };
 
-// PTO2TaskPayload layout verification (offsetof requires complete type).
-static_assert(offsetof(PTO2TaskPayload, fanin_local_ids) == 12, "inline fanin id array must follow fanin_count");
+// PTO2TaskPayload layout verification (offsetof requires complete type). The counts
+// and region deltas share the first cache line, the early-dispatch atomics own the
+// second, and the AICPU-only predicate + dump metadata own the third.
+static_assert(offsetof(PTO2TaskPayload, tensors) == 12, "region deltas must follow the three counts");
 static_assert(
-    offsetof(PTO2TaskPayload, predicate) == 576,
-    "dispatch predicate occupies cache line 9 at fixed byte 576 (before the arg arrays, never moves)"
+    offsetof(PTO2TaskPayload, fanin) + sizeof(simpler::hbg::SelfRelativePtr<int32_t>) <= 64,
+    "counts + region deltas must fit the first cache line"
 );
 static_assert(
-    offsetof(PTO2TaskPayload, dump_metadata) + sizeof(ArgsDumpTaskMetadata) <= 640,
-    "dump metadata must fit in the AICPU-only cache line before the arg arrays"
+    offsetof(PTO2TaskPayload, staged_core_mask) == 64,
+    "the early-dispatch atomics own cache line 1: they are written during staging while "
+    "line 0's counts and deltas are read at dispatch, so sharing a line would false-share"
+);
+static_assert(offsetof(PTO2TaskPayload, predicate) == 128, "dispatch predicate owns cache line 2");
+static_assert(
+    offsetof(PTO2TaskPayload, dump_metadata) + sizeof(ArgsDumpTaskMetadata) <= 192,
+    "dump metadata must fit the predicate's cache line"
 );
 static_assert(
-    offsetof(PTO2TaskPayload, scalars) == 640, "scalars must start at byte 640 (cache line 10, after predicate)"
+    sizeof(PTO2TaskPayload) == 192, "PTO2TaskPayload is three cache lines and independent of every argument cap"
 );
+// compact_live_image restacks the payload segment with one memcpy and the device
+// copy moves the whole image, so the payload has to be a POD wire struct. Deleting
+// SelfRelativePtr's copy operations does not cost it that — a deleted special member
+// is trivial — but only an assertion keeps a future member from doing so silently.
 static_assert(
-    offsetof(PTO2TaskPayload, tensors) == 640 + MAX_SCALAR_ARGS * sizeof(uint64_t),
-    "tensors must immediately follow scalars, and must be the last region: the shipped "
-    "image carries only as much of the array as a task uses, so nothing may sit past it"
+    std::is_trivially_copyable_v<PTO2TaskPayload> && std::is_standard_layout_v<PTO2TaskPayload>,
+    "PTO2TaskPayload crosses to the device by memcpy"
 );
-static_assert(
-    sizeof(PTO2TaskPayload) == 640 + MAX_SCALAR_ARGS * sizeof(uint64_t) + MAX_TENSOR_ARGS * sizeof(ChipTensor),
-    "PTO2TaskPayload size = metadata(576) + predicate cache line(64) + scalars + tensors"
-);
+static_assert(sizeof(ChipTensor) == 128, "ChipTensor must be 2 cache lines");
 
 /**
  * Per-task slot scheduling state (scheduler-private, NOT in shared memory)

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -44,6 +44,7 @@
 // need it include it via runtime.h directly.
 #include "aicore_completion_mailbox.h"
 #include "common/args_dump_task_metadata.h"
+#include "host_build_graph/self_relative_ptr.h"
 #include "pto_submit_types.h"
 #include "pto_task_id.h"
 #include "pto_types.h"
@@ -458,75 +459,6 @@ static_assert(
     sizeof(PTO2TaskPayload) == 640 + MAX_SCALAR_ARGS * sizeof(uint64_t) + MAX_TENSOR_ARGS * sizeof(ChipTensor),
     "PTO2TaskPayload size = metadata(576) + predicate cache line(64) + scalars + tensors"
 );
-
-/**
- * A pointer to a sibling in the same contiguous block, stored as a byte delta
- * from the field's own address.
- *
- * The block is `memcpy`'d to the device as one image, so a delta between two
- * addresses inside it is invariant under the move while a raw pointer is not.
- * Both users below satisfy that precondition: a ring task's payload and
- * descriptor live in the same shared-memory image as its slot state, and a Graph
- * node's live in the same GraphNodeStorage.
- *
- * A zero delta means unbound — a field can never coincide with its own target.
- * Zeroed memory therefore reads as null, which is what the slot's pristine state
- * is.
- *
- * int32_t bounds the distance at 2 GiB. Both blocks are far below it — a
- * GraphNodeStorage is a fixed struct, and the shared-memory image's end is
- * rejected above the bound in attach_populated — and set() leaves the field
- * unbound rather than storing a truncated delta, so an out-of-range target
- * reads back as null instead of as unrelated memory.
- */
-namespace simpler::hbg {
-
-template <typename T>
-class SelfRelativePtr {
-public:
-    SelfRelativePtr() = default;
-
-    // The stored value means something only relative to where it is stored, so
-    // copying it from another field would silently retarget it. Every write goes
-    // through set(), which takes the destination's own address into account. A
-    // whole-block memcpy is unaffected: it moves the field and its target
-    // together, which is the case this representation exists for.
-    SelfRelativePtr(const SelfRelativePtr &) = delete;
-    SelfRelativePtr &operator=(const SelfRelativePtr &) = delete;
-
-    T *get() const {
-        if (delta_ == 0) return nullptr;
-        return reinterpret_cast<T *>(reinterpret_cast<uintptr_t>(this) + static_cast<intptr_t>(delta_));
-    }
-
-    void set(T *target) {
-        if (target == nullptr) {
-            delta_ = 0;
-            return;
-        }
-        const intptr_t delta = reinterpret_cast<intptr_t>(target) - reinterpret_cast<intptr_t>(this);
-        // Narrowing a delta this large would name unrelated memory that a consumer
-        // would then dereference. Unbound is the one value every consumer already
-        // tests for.
-        if (delta < INT32_MIN || delta > INT32_MAX) {
-            delta_ = 0;
-            return;
-        }
-        delta_ = static_cast<int32_t>(delta);
-    }
-
-    T *operator->() const { return get(); }
-    T &operator*() const { return *get(); }
-    explicit operator bool() const { return delta_ != 0; }
-
-    friend bool operator==(const SelfRelativePtr &lhs, std::nullptr_t) { return lhs.delta_ == 0; }
-    friend bool operator!=(const SelfRelativePtr &lhs, std::nullptr_t) { return lhs.delta_ != 0; }
-
-private:
-    int32_t delta_{0};
-};
-
-}  // namespace simpler::hbg
 
 /**
  * Per-task slot scheduling state (scheduler-private, NOT in shared memory)

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_shared_memory.h
@@ -251,9 +251,15 @@ struct PTO2SharedMemoryHandle {
     // the wrong address, so both sides derive it from the same submitted count.
     // The capacity and mask in the header are unchanged, and `local_id & mask`
     // yields `local_id`, which is below `live_slots` for every ring task.
+    //
+    // `image_bytes` is what the host shipped, pools included. The device cannot
+    // recompute it — the pool extents are the bind's cursors, which only the host saw
+    // — and it does not need to: a payload names its argument regions by delta, so no
+    // pool base is resolved here. The value bounds the region and checks the int32
+    // delta reach.
     bool attach_populated(
         void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t live_slots,
-        uint64_t payload_stride
+        uint64_t image_bytes
     );
 
     void destroy();
@@ -266,13 +272,10 @@ private:
         const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
     );
     void setup_pointers(uint64_t task_window_size);
-    // `pitch` is the slot count the arrays are dimensioned for. init_per_ring
-    // passes the ring capacity (the mirror the orchestrator writes into);
-    // attach_populated passes the submitted count (the compacted image that
-    // shipped).
-    void setup_pointers_per_ring(
-        const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch, uint64_t payload_stride
-    );
+    // `pitch` is the slot count the arrays are dimensioned for. init_per_ring passes
+    // the ring capacity (the mirror the orchestrator writes into); attach_populated
+    // passes the submitted count (the compacted image that shipped).
+    void setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch);
 };
 
 // =============================================================================
@@ -310,49 +313,87 @@ inline std::atomic<int32_t> *ring_current_task_index_addr(void *sm_dev_base) noe
     );
 }
 
-// Byte offsets (from the SM base) of the ring's three segments. The layout is:
-// header, then descriptors -> payloads -> slot_states, every segment
-// PTO2_ALIGN_UP-padded.
+// Byte offsets (from the SM base) of the ring's segments. The layout is: header, then
+// descriptors -> payloads -> slot_states -> completion_flags -> the three argument
+// pools, every segment PTO2_ALIGN_UP-padded. RingImageExtents dimensions them: the
+// mirror for the worst case the API allows, the image for what this bind holds, which
+// is what makes the live prefixes contiguous and the upload one copy.
 //
-// Two parameters, and the host mirror and the shipped image differ in both.
-//
-// The *pitch* is how many slots the arrays are dimensioned for: the mirror uses the
-// ring capacity, the image uses the submitted count, which is what makes the four
-// live prefixes contiguous and the upload one copy.
-//
-// The *payload stride* is how far apart consecutive payloads sit. The mirror uses
-// sizeof(PTO2TaskPayload), whose tensor array is dimensioned for the widest task the
-// API allows. The image uses the widest task in this bind — the array is the last
-// field, so anything past that task's entries is read by nobody.
+// The pools sit last because nothing on the device resolves a segment past
+// completion_flags: a payload names its argument regions by delta, so the four
+// slot-pitched offsets are all the attach path computes.
 struct PTO2RingSegmentOffsets {
     uint64_t descriptors;
     uint64_t payloads;
     uint64_t slot_states;
     uint64_t completion_flags;  // polling-completion byte array (1 byte/slot)
-    uint64_t end;               // offset just past completion_flags (total SM size)
+    uint64_t fanin_pool;
+    uint64_t tensor_pool;
+    uint64_t scalar_pool;
+    uint64_t end;  // offset just past the last segment (total image size)
 };
 
-// Single source of truth for the SM segment layout. Returns offsets (not
-// pointers), so it serves BOTH the host-side pointer setup (`setup_pointers`,
-// which adds `sm_base`) and the device-address helpers below (which add
-// `sm_dev_base`). Adding or reordering a segment is a one-line edit here; every
-// consumer follows automatically, so the layout walk can never silently
-// disagree across call sites.
-inline PTO2RingSegmentOffsets
-ring_segment_offsets(uint64_t task_window_size, uint64_t payload_stride = sizeof(PTO2TaskPayload)) noexcept {
+// How many slots and how many pool elements a layout is dimensioned for.
+struct RingImageExtents {
+    uint64_t slots;
+    uint64_t fanin_elems;
+    uint64_t tensor_elems;
+    uint64_t scalar_elems;
+};
+
+// The mirror the orchestrator writes into: the ring capacity, every pool sized so the
+// worst case cannot overflow a bump — task_window tasks each at their full cap. That
+// bound is what lets prepare_task advance a cursor with no capacity check.
+inline RingImageExtents mirror_extents(uint64_t task_window_size) noexcept {
+    return RingImageExtents{
+        task_window_size,
+        task_window_size * PTO2_MAX_FANIN,
+        task_window_size * MAX_TENSOR_ARGS,
+        task_window_size * MAX_SCALAR_ARGS,
+    };
+}
+
+// Single source of truth for the SM segment layout. Returns offsets (not pointers),
+// so it serves BOTH the host-side pointer setup (`setup_pointers`, which adds
+// `sm_base`) and the device-address helpers below (which add `sm_dev_base`). Adding
+// or reordering a segment is a one-line edit here; every consumer follows
+// automatically, so the layout walk can never silently disagree across call sites.
+inline PTO2RingSegmentOffsets ring_segment_offsets(const RingImageExtents &e) noexcept {
     uint64_t off = PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
     PTO2RingSegmentOffsets o{};
     o.descriptors = off;
-    off += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
+    off += PTO2_ALIGN_UP(e.slots * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
     o.payloads = off;
-    off += PTO2_ALIGN_UP(task_window_size * payload_stride, PTO2_ALIGN_SIZE);
+    off += PTO2_ALIGN_UP(e.slots * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
     o.slot_states = off;
-    off += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
+    off += PTO2_ALIGN_UP(e.slots * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
     o.completion_flags = off;
-    off += PTO2_ALIGN_UP(task_window_size * sizeof(std::atomic<uint8_t>), PTO2_ALIGN_SIZE);
+    off += PTO2_ALIGN_UP(e.slots * sizeof(std::atomic<uint8_t>), PTO2_ALIGN_SIZE);
+    o.fanin_pool = off;
+    off += PTO2_ALIGN_UP(e.fanin_elems * sizeof(int32_t), PTO2_ALIGN_SIZE);
+    o.tensor_pool = off;
+    off += PTO2_ALIGN_UP(e.tensor_elems * sizeof(ChipTensor), PTO2_ALIGN_SIZE);
+    o.scalar_pool = off;
+    off += PTO2_ALIGN_UP(e.scalar_elems * sizeof(uint64_t), PTO2_ALIGN_SIZE);
     o.end = off;
     return o;
 }
+
+inline PTO2RingSegmentOffsets ring_segment_offsets(uint64_t task_window_size) noexcept {
+    return ring_segment_offsets(mirror_extents(task_window_size));
+}
+
+// Every per-task region starts on a cache line, which PTO2TaskPayload::init's
+// round-up scalar memcpy relies on. ChipTensor is 2 cache lines, so a tensor region
+// is aligned for any count; the fanin and scalar strides need it stated.
+static_assert(
+    (PTO2_MAX_FANIN * sizeof(int32_t)) % ARG_POOL_ALIGN == 0,
+    "the fanin region's cap must be a whole number of cache lines"
+);
+static_assert(
+    (MAX_SCALAR_ARGS * sizeof(uint64_t)) % ARG_POOL_ALIGN == 0,
+    "the scalar region's cap must be a whole number of cache lines"
+);
 
 // The pitch the shipped image uses for a given submitted task count. A bind that
 // submits nothing still ships its header and still attaches, and a zero-length
@@ -361,47 +402,54 @@ inline uint64_t live_slot_pitch(uint64_t submitted_tasks) noexcept {
     return submitted_tasks == 0 ? 1 : submitted_tasks;
 }
 
-// The stride a shipped payload array uses for a given widest task. The tensor array
-// is the payload's last field, so a task reads nothing past its own entries and the
-// stride need only cover them — but every payload in the image shares one stride, so
-// it is the widest task that sets it.
-//
-// Rounded up to PTO2_ALIGN_SIZE because PTO2TaskPayload's own alignment is 64 and the
-// image places consecutive payloads at multiples of the stride.
-inline uint64_t shipped_payload_stride(int32_t widest_tensor_count) noexcept {
-    constexpr uint64_t kTensorsOffset = offsetof(PTO2TaskPayload, tensors);
-    const uint64_t used = static_cast<uint64_t>(widest_tensor_count < 0 ? 0 : widest_tensor_count) * sizeof(ChipTensor);
-    const uint64_t stride = PTO2_ALIGN_UP(kTensorsOffset + used, PTO2_ALIGN_SIZE);
-    return stride > sizeof(PTO2TaskPayload) ? sizeof(PTO2TaskPayload) : stride;
+// What a bind actually holds, for the shipped image's extents. Each pool ships only the
+// prefix its cursor reached, which is why a run of narrow tasks ships a small fraction
+// of the mirror's pools.
+struct BindUsage {
+    uint64_t submitted_tasks;
+    uint64_t fanin_elems;
+    uint64_t tensor_elems;
+    uint64_t scalar_elems;
+};
+
+inline RingImageExtents image_extents(const BindUsage &used) noexcept {
+    return RingImageExtents{
+        live_slot_pitch(used.submitted_tasks),
+        used.fanin_elems,
+        used.tensor_elems,
+        used.scalar_elems,
+    };
 }
 
 // Restack the live prefix of every ring segment from the ring-pitched mirror the
-// orchestrator wrote into an image pitched to `submitted_tasks`, where the four
+// orchestrator wrote into an image dimensioned for what this bind holds, where the
 // prefixes are contiguous and can travel as one copy.
 //
 // `out_base` must be PTO2_ALIGN_SIZE-aligned and hold
-// `ring_segment_offsets(live_slot_pitch(submitted_tasks)).end` bytes. Returns that
-// byte count.
+// `ring_segment_offsets(image_extents(used)).end` bytes. Returns that byte count.
 //
 // Two things the restack has to fix up, both because the image is not the mirror:
 //
 //   - the ring header's data pointers name the mirror's arrays, so they leave as
 //     null rather than carrying host addresses into device memory (the device
 //     resolves them in attach_populated);
-//   - a slot state names its payload and descriptor by a delta from its own
-//     address, and the restack changed those distances, so each binding is
-//     re-taken against the image.
-inline uint64_t compact_live_image(
-    const char *mirror_base, uint64_t task_window_size, uint64_t submitted_tasks, uint64_t payload_stride,
-    char *out_base
-) noexcept {
-    // The mirror is pitched to the capacity and to the type, so a larger live count
-    // or a wider stride reads past the segment it is copying from and ships a corrupt
-    // image. attach_populated tests the same two bounds on the device side.
-    always_assert(submitted_tasks <= task_window_size);
-    always_assert(payload_stride <= sizeof(PTO2TaskPayload));
-    const PTO2RingSegmentOffsets from = ring_segment_offsets(task_window_size);
-    const PTO2RingSegmentOffsets to = ring_segment_offsets(live_slot_pitch(submitted_tasks), payload_stride);
+//   - a slot state names its payload and descriptor, and a payload names its three
+//     argument regions, by a delta from the naming field's own address; the restack
+//     changed those distances, so every one is re-taken against the image. A region
+//     keeps its position within its pool, so the re-take is the same arithmetic with
+//     the image's bases.
+inline uint64_t
+compact_live_image(const char *mirror_base, uint64_t task_window_size, const BindUsage &used, char *out_base) noexcept {
+    // The mirror is dimensioned for the worst case, so a live count or a cursor past
+    // it reads beyond the segment it is copying from and ships a corrupt image.
+    // attach_populated tests the slot bound again on the device side.
+    const RingImageExtents mirror = mirror_extents(task_window_size);
+    always_assert(used.submitted_tasks <= mirror.slots);
+    always_assert(used.fanin_elems <= mirror.fanin_elems);
+    always_assert(used.tensor_elems <= mirror.tensor_elems);
+    always_assert(used.scalar_elems <= mirror.scalar_elems);
+    const PTO2RingSegmentOffsets from = ring_segment_offsets(mirror);
+    const PTO2RingSegmentOffsets to = ring_segment_offsets(image_extents(used));
 
     // The header and the descriptors offset are pitch-independent, so the header
     // lands where it already was.
@@ -412,24 +460,54 @@ inline uint64_t compact_live_image(
     out_ring.slot_states = nullptr;
     out_ring.completion_flags = nullptr;
 
-    const uint64_t nt = submitted_tasks;
+    const uint64_t nt = used.submitted_tasks;
     std::memcpy(out_base + to.descriptors, mirror_base + from.descriptors, nt * sizeof(PTO2TaskDescriptor));
-    // Per payload, because the source and destination strides differ: the mirror is
-    // pitched to the type, the image to the widest task in this bind.
-    for (uint64_t i = 0; i < nt; ++i) {
-        std::memcpy(
-            out_base + to.payloads + i * payload_stride, mirror_base + from.payloads + i * sizeof(PTO2TaskPayload),
-            payload_stride
-        );
-    }
+    // One copy, not one per payload: PTO2TaskPayload is fixed-size, so the mirror and
+    // the image share a stride. Each pool is likewise one copy of its own prefix.
+    std::memcpy(out_base + to.payloads, mirror_base + from.payloads, nt * sizeof(PTO2TaskPayload));
     std::memcpy(out_base + to.slot_states, mirror_base + from.slot_states, nt * sizeof(PTO2TaskSlotState));
     std::memcpy(out_base + to.completion_flags, mirror_base + from.completion_flags, nt * sizeof(std::atomic<uint8_t>));
+    std::memcpy(out_base + to.fanin_pool, mirror_base + from.fanin_pool, used.fanin_elems * sizeof(int32_t));
+    std::memcpy(out_base + to.tensor_pool, mirror_base + from.tensor_pool, used.tensor_elems * sizeof(ChipTensor));
+    std::memcpy(out_base + to.scalar_pool, mirror_base + from.scalar_pool, used.scalar_elems * sizeof(uint64_t));
 
     auto *out_slots = reinterpret_cast<PTO2TaskSlotState *>(out_base + to.slot_states);
     auto *out_descriptors = reinterpret_cast<PTO2TaskDescriptor *>(out_base + to.descriptors);
+    auto *out_payloads = reinterpret_cast<PTO2TaskPayload *>(out_base + to.payloads);
+    const auto *mirror_payloads = reinterpret_cast<const PTO2TaskPayload *>(mirror_base + from.payloads);
+    auto *out_fanin = reinterpret_cast<int32_t *>(out_base + to.fanin_pool);
+    auto *out_tensors = reinterpret_cast<ChipTensor *>(out_base + to.tensor_pool);
+    auto *out_scalars = reinterpret_cast<uint64_t *>(out_base + to.scalar_pool);
+    const auto *mirror_fanin = reinterpret_cast<const int32_t *>(mirror_base + from.fanin_pool);
+    const auto *mirror_tensors = reinterpret_cast<const ChipTensor *>(mirror_base + from.tensor_pool);
+    const auto *mirror_scalars = reinterpret_cast<const uint64_t *>(mirror_base + from.scalar_pool);
+    // An unbound region stays unbound: a Graph node's payload never gets a fanin
+    // region, and its count is 0, so no consumer resolves it. A bound one is inside
+    // its own mirror pool by construction — the only binder is a bump cursor on that
+    // pool — and the translation below depends on it, so it is asserted rather than
+    // re-derived.
     for (uint64_t i = 0; i < nt; ++i) {
-        auto *out_payload = reinterpret_cast<PTO2TaskPayload *>(out_base + to.payloads + i * payload_stride);
-        out_slots[i].bind_buffers(out_payload, &out_descriptors[i]);
+        out_slots[i].bind_buffers(&out_payloads[i], &out_descriptors[i]);
+        const PTO2TaskPayload &src = mirror_payloads[i];
+        const ChipTensor *src_tensors = src.tensor_data();
+        const uint64_t *src_scalars = src.scalar_data();
+        const int32_t *src_fanin = src.fanin_data();
+        debug_assert(
+            src_tensors == nullptr ||
+            (src_tensors >= mirror_tensors && src_tensors <= mirror_tensors + used.tensor_elems)
+        );
+        debug_assert(
+            src_scalars == nullptr ||
+            (src_scalars >= mirror_scalars && src_scalars <= mirror_scalars + used.scalar_elems)
+        );
+        debug_assert(
+            src_fanin == nullptr || (src_fanin >= mirror_fanin && src_fanin <= mirror_fanin + used.fanin_elems)
+        );
+        out_payloads[i].bind_regions(
+            src_tensors == nullptr ? nullptr : out_tensors + (src_tensors - mirror_tensors),
+            src_scalars == nullptr ? nullptr : out_scalars + (src_scalars - mirror_scalars),
+            src_fanin == nullptr ? nullptr : out_fanin + (src_fanin - mirror_fanin)
+        );
     }
     return to.end;
 }

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -174,12 +174,12 @@ public:
     // the boot thread reads this instead of counting SM ring heads.
     int32_t host_total_tasks;
 
-    // Distance between consecutive payloads in the shipped shared-memory image.
-    // Smaller than sizeof(PTO2TaskPayload) whenever the bind's widest task uses
-    // fewer tensors than the array holds, which is the usual case. Set by the host
-    // before the image is copied; the AICPU needs it at attach to place every
-    // segment that follows the payload array.
-    uint64_t sm_payload_stride;
+    // Size of the shipped shared-memory image, argument pools included. Set by the
+    // host before the image is copied; the AICPU cannot recompute it because the pool
+    // extents are the bind's cursors, which only the host saw. It bounds the region at
+    // attach and checks the int32 delta reach — it places no segment, since a payload
+    // names its argument regions by delta.
+    uint64_t sm_image_bytes;
 
 private:
     // Kernel binary tracking for cleanup

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -577,7 +577,7 @@ struct PTO2SchedulerState {
 
     // Unmet-fanin classification. Returns -1 (all fanins met -> route to ready)
     // or the index of an unmet fanin (register on that producer's wake list).
-    // Scan direction is load-bearing: the builder fills fanin_local_ids in
+    // Scan direction is load-bearing: the builder fills the fanin region in
     // submission order, so the last unmet entry is the latest-submitted
     // producer -- the one likeliest to complete last. Targeting it minimises
     // wake-list transfers (a consumer re-registered onto a second producer once
@@ -587,8 +587,9 @@ struct PTO2SchedulerState {
     int classify_fanin_state(const PTO2TaskSlotState *s) const {
         const PTO2TaskPayload &p = *s->payload;
         const PTO2SharedMemoryRingHeader &ring = *ring_sched_state.ring;
+        const int32_t *fanin = p.fanin_data();
         for (int32_t i = p.fanin_count - 1; i >= 0; i--) {
-            if (!ring.is_completion_flag_set(p.fanin_local_ids[i])) return i;
+            if (!ring.is_completion_flag_set(fanin[i])) return i;
         }
         return -1;
     }
@@ -614,7 +615,7 @@ struct PTO2SchedulerState {
                 push_ready_routed(consumer);
                 return;
             }
-            producer = &ring.get_slot_state_by_task_id(consumer->payload->fanin_local_ids[state]);
+            producer = &ring.get_slot_state_by_task_id(consumer->payload->fanin_data()[state]);
         }
     }
 
@@ -643,7 +644,7 @@ struct PTO2SchedulerState {
             if (state < 0) {
                 push_ready_routed(waiter);
             } else {
-                register_wake(&ring.get_slot_state_by_task_id(waiter->payload->fanin_local_ids[state]), waiter);
+                register_wake(&ring.get_slot_state_by_task_id(waiter->payload->fanin_data()[state]), waiter);
             }
             waiter = next;
         }

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -245,9 +245,9 @@ void SchedulerContext::log_stall_diagnostics(
                 int32_t fi = slot_state.payload != nullptr ? slot_state.payload->fanin_count : 0;
                 int32_t rc = 0;
                 if (slot_state.payload != nullptr) {
+                    const int32_t *fanin = slot_state.payload->fanin_data();
                     for (int32_t k = 0; k < fi; k++) {
-                        int32_t pid = slot_state.payload->fanin_local_ids[k];
-                        if (ring.is_completion_flag_set(pid, std::memory_order_relaxed)) rc++;
+                        if (ring.is_completion_flag_set(fanin[k], std::memory_order_relaxed)) rc++;
                     }
                 }
                 int32_t kid_aic = slot_state.task->kernel_id[0];
@@ -1148,7 +1148,7 @@ void SchedulerContext::classify_partition(int32_t thread_idx, int32_t nthreads) 
         if (state < 0) {
             sched_->push_ready_routed(&slot);
         } else {
-            int32_t prod_local = slot.payload->fanin_local_ids[state];
+            int32_t prod_local = slot.payload->fanin_data()[state];
             sched_->register_wake(&ring.get_slot_state_by_task_id(prod_local), &slot);
         }
     }

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -42,8 +42,8 @@
 // Pin those constants to the real layout here, where the struct is fully visible.
 static_assert(offsetof(PTO2TaskPayload, tensor_count) == PTO2_TASKPAYLOAD_TENSOR_COUNT_OFFSET);
 static_assert(offsetof(PTO2TaskPayload, scalar_count) == PTO2_TASKPAYLOAD_SCALAR_COUNT_OFFSET);
-static_assert(offsetof(PTO2TaskPayload, tensors) == PTO2_TASKPAYLOAD_TENSORS_OFFSET);
-static_assert(offsetof(PTO2TaskPayload, scalars) == PTO2_TASKPAYLOAD_SCALARS_OFFSET);
+static_assert(offsetof(PTO2TaskPayload, tensors) == PTO2_TASKPAYLOAD_TENSORS_DELTA_OFFSET);
+static_assert(offsetof(PTO2TaskPayload, scalars) == PTO2_TASKPAYLOAD_SCALARS_DELTA_OFFSET);
 static_assert(sizeof(ChipTensor) == PTO2_TASKPAYLOAD_TENSOR_STRIDE);
 
 // =============================================================================
@@ -143,11 +143,18 @@ void SchedulerContext::build_payload(
         // Ready task: fill args here; src_payload = 0 signals AICore to run on pickup.
         dispatch_payload.src_payload = 0;
         int n = 0;
-        for (int32_t i = 0; i < payload.tensor_count; i++) {
-            dispatch_payload.args[n++] = reinterpret_cast<uint64_t>(&payload.tensors[i]);
+        // Both regions are resolved once: the args[] stores below could alias the
+        // payload as far as the compiler knows, so re-resolving a delta per element
+        // would reload it on every iteration.
+        const ChipTensor *tensors = payload.tensor_data();
+        const int32_t tensor_count = payload.tensor_count;
+        for (int32_t i = 0; i < tensor_count; i++) {
+            dispatch_payload.args[n++] = reinterpret_cast<uint64_t>(&tensors[i]);
         }
-        for (int32_t i = 0; i < payload.scalar_count; i++) {
-            dispatch_payload.args[n++] = payload.scalars[i];
+        const uint64_t *scalars = payload.scalar_data();
+        const int32_t scalar_count = payload.scalar_count;
+        for (int32_t i = 0; i < scalar_count; i++) {
+            dispatch_payload.args[n++] = scalars[i];
         }
     }
     dispatch_payload.local_context.block_idx = block_idx;

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -257,6 +257,16 @@ bool PTO2OrchestratorState::init_data_from_layout(
 
     orch->ring.task_allocator.init(static_cast<int32_t>(task_window_size), cur_idx_dev, gm_heap, heap_size, orch_err);
 
+    // The mirror's argument pools. Offset arithmetic on the same base as sm_header,
+    // so it holds for whichever SM this orchestrator was pointed at — the host-orch
+    // path re-inits against the host mirror before orchestration. The cursors reset
+    // with the rest of the state above.
+    auto *sm_bytes = static_cast<char *>(sm_dev_base);
+    const auto pools = pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::mirror_extents(task_window_size));
+    orch->fanin_pool = reinterpret_cast<int32_t *>(sm_bytes + pools.fanin_pool);
+    orch->tensor_pool = reinterpret_cast<ChipTensor *>(sm_bytes + pools.tensor_pool);
+    orch->scalar_pool = reinterpret_cast<uint64_t *>(sm_bytes + pools.scalar_pool);
+
     const size_t seen_epoch_bytes =
         PTO2_ALIGN_UP(static_cast<size_t>(layout.tensor_map.task_window_size) * sizeof(uint32_t), PTO2_ALIGN_SIZE);
     auto *seen_epoch = static_cast<uint32_t *>(arena.region_ptr(layout.off_fanin_seen_epoch));

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
@@ -46,16 +46,21 @@ uint64_t PTO2SharedMemoryHandle::calculate_size_per_ring(const uint64_t task_win
 // =============================================================================
 
 void PTO2SharedMemoryHandle::setup_pointers_per_ring(
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch, uint64_t payload_stride
+    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch
 ) {
     (void)task_window_sizes;
     char *base = (char *)sm_base;
     header = (PTO2SharedMemoryHeader *)base;
 
-    // Per-ring descriptors / payloads / slot_states — offsets from the single
-    // source of truth (pto2_sm_layout::ring_segment_offsets), so this setup and
-    // the device-address helpers cannot drift.
-    auto off = pto2_sm_layout::ring_segment_offsets(pitch, payload_stride);
+    // Per-ring descriptors / payloads / slot_states — offsets from the single source
+    // of truth (pto2_sm_layout::ring_segment_offsets), so this setup and the
+    // device-address helpers cannot drift.
+    //
+    // Only the four slot-pitched segments, and no argument pool: the pool extents
+    // differ between the mirror and the image, while these four depend on the pitch
+    // alone. The orchestrator holds the mirror's pool bases; the device resolves an
+    // argument region through the payload's delta and needs no base at all.
+    auto off = pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::image_extents({pitch, 0, 0, 0}));
     auto &ring = header->ring;
     ring.task_descriptors = (PTO2TaskDescriptor *)(base + off.descriptors);
     ring.task_payloads = (PTO2TaskPayload *)(base + off.payloads);
@@ -68,7 +73,7 @@ void PTO2SharedMemoryHandle::setup_pointers(uint64_t task_window_size) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
     }
-    setup_pointers_per_ring(task_window_sizes, task_window_size, sizeof(PTO2TaskPayload));
+    setup_pointers_per_ring(task_window_sizes, task_window_size);
 }
 
 bool PTO2SharedMemoryHandle::init(
@@ -88,19 +93,28 @@ bool PTO2SharedMemoryHandle::init_per_ring(
     const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
 ) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
-    if (sm_size_arg < calculate_size_per_ring(task_window_sizes)) return false;
+    const uint64_t mirror_bytes = calculate_size_per_ring(task_window_sizes);
+    // The mirror has to stay inside an int32 delta's reach: a payload names its
+    // argument regions that way, and set() leaves a field unbound rather than
+    // truncating, so a pool out of reach would read back as null and be dereferenced
+    // as one. attach_populated makes the same check on the shipped image.
+    //
+    // Tested before the region's own size, because this rejects the ring capacity
+    // itself: no region, however large, makes such a window usable.
+    if (mirror_bytes > static_cast<uint64_t>(INT32_MAX)) return false;
+    if (sm_size_arg < mirror_bytes) return false;
 
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers_per_ring(task_window_sizes, task_window_sizes[0], sizeof(PTO2TaskPayload));
+    setup_pointers_per_ring(task_window_sizes, task_window_sizes[0]);
     init_header_per_ring(task_window_sizes, heap_sizes);
     return true;
 }
 
 bool PTO2SharedMemoryHandle::attach_populated(
     void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t live_slots,
-    uint64_t payload_stride
+    uint64_t image_bytes
 ) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
     // A pitch above the capacity would name a slot the ring cannot address, and one
@@ -108,21 +122,24 @@ bool PTO2SharedMemoryHandle::attach_populated(
     // short. This is the whole contract between the two sides, checked once at
     // attach rather than trusted.
     if (live_slots == 0 || live_slots > task_window_sizes[0]) return false;
-    // A stride past the type's size would read between payloads; one below the
-    // tensor array's own offset could not hold a payload's fixed head at all.
-    if (payload_stride > sizeof(PTO2TaskPayload) || payload_stride < offsetof(PTO2TaskPayload, tensors)) return false;
+    // The image must at least hold the four slot-pitched segments; anything beyond
+    // that is its argument pools, whose extents are the bind's cursors and are not
+    // recomputable here. The first pool's offset is exactly where those four end.
+    const uint64_t slots_end =
+        pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::image_extents({live_slots, 0, 0, 0})).fanin_pool;
+    if (image_bytes < slots_end) return false;
     // The region holds the compacted image, so that is what has to fit — the ring
     // capacity is no longer its size.
-    const uint64_t image_end = pto2_sm_layout::ring_segment_offsets(live_slots, payload_stride).end;
-    if (sm_size_arg < image_end) return false;
+    if (sm_size_arg < image_bytes) return false;
     // A slot state names its payload and descriptor by an int32 delta from its own
-    // address, so no two positions in the image may be further apart than that.
-    if (image_end > static_cast<uint64_t>(INT32_MAX)) return false;
+    // address, and a payload names its argument regions the same way, so no two
+    // positions in the image may be further apart than that.
+    if (image_bytes > static_cast<uint64_t>(INT32_MAX)) return false;
 
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers_per_ring(task_window_sizes, live_slots, payload_stride);
+    setup_pointers_per_ring(task_window_sizes, live_slots);
     // Deliberately NO init_header_per_ring: the SM already holds the host
     // orchestrator's task graph (descriptors, slot states, ring counters).
     return true;

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/runtime.cpp
@@ -35,7 +35,7 @@ Runtime::Runtime() {
     aicpu_allowed_cpu_count = 0;
     aicpu_launch_count = 0;
     host_total_tasks = 0;
-    sm_payload_stride = sizeof(PTO2TaskPayload);
+    sm_image_bytes = 0;
 
     // Initialize shared-memory / orchestration argument plumbing
     gm_sm_ptr_ = nullptr;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -337,6 +337,14 @@ struct PTO2TaskPayload {
     static_assert(sizeof(ChipTensor) == 128, "ChipTensor must be 2 cache lines");
     static_assert(MAX_SCALAR_ARGS * sizeof(uint64_t) == 128, "scalar region must be 128B (2 cache lines)");
 
+    // Argument region access. Shared AICPU code (args_dump_aicpu.h) reads a payload's
+    // arguments through these, so both runtimes offer them whether the arguments sit
+    // inline as they do here or in a pool.
+    ChipTensor *tensor_data() { return tensors; }
+    const ChipTensor *tensor_data() const { return tensors; }
+    uint64_t *scalar_data() { return scalars; }
+    const uint64_t *scalar_data() const { return scalars; }
+
     /**
      * Prefetch for write the regions init() fills. tensor_count/scalar_count
      * come from the argument because the payload counts are not initialized

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -194,13 +194,18 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
                 __gm__ char *src = reinterpret_cast<__gm__ char *>(exec_payload->src_payload);
                 int32_t tensor_count = *reinterpret_cast<__gm__ int32_t *>(src + PTO2_TASKPAYLOAD_TENSOR_COUNT_OFFSET);
                 int32_t scalar_count = *reinterpret_cast<__gm__ int32_t *>(src + PTO2_TASKPAYLOAD_SCALAR_COUNT_OFFSET);
-                __gm__ uint64_t *src_scalars =
-                    reinterpret_cast<__gm__ uint64_t *>(src + PTO2_TASKPAYLOAD_SCALARS_OFFSET);
+                // Each region is named by an int32 delta from the naming field's own
+                // address, so resolve the field, then add what it holds.
+                __gm__ char *tensors_field = src + PTO2_TASKPAYLOAD_TENSORS_DELTA_OFFSET;
+                __gm__ char *src_tensors = tensors_field + *reinterpret_cast<__gm__ int32_t *>(tensors_field);
+                __gm__ char *scalars_field = src + PTO2_TASKPAYLOAD_SCALARS_DELTA_OFFSET;
+                __gm__ uint64_t *src_scalars = reinterpret_cast<__gm__ uint64_t *>(
+                    scalars_field + *reinterpret_cast<__gm__ int32_t *>(scalars_field)
+                );
                 int n = 0;
                 for (int32_t i = 0; i < tensor_count; i++) {
-                    exec_payload->args[n++] = reinterpret_cast<uint64_t>(
-                        src + PTO2_TASKPAYLOAD_TENSORS_OFFSET + i * PTO2_TASKPAYLOAD_TENSOR_STRIDE
-                    );
+                    exec_payload->args[n++] =
+                        reinterpret_cast<uint64_t>(src_tensors + i * PTO2_TASKPAYLOAD_TENSOR_STRIDE);
                 }
                 for (int32_t i = 0; i < scalar_count; i++) {
                     exec_payload->args[n++] = src_scalars[i];

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -270,8 +270,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // rejects a pitch outside (0, capacity] and a region too small for it.
             const uint64_t live_slots =
                 pto2_sm_layout::live_slot_pitch(static_cast<uint64_t>(runtime->host_total_tasks));
-            const uint64_t payload_stride = runtime->sm_payload_stride;
-            const uint64_t sm_size = pto2_sm_layout::ring_segment_offsets(live_slots, payload_stride).end;
+            const uint64_t sm_size = runtime->sm_image_bytes;
             // sm_handle and the scheduler state are the device-only zone: their
             // bytes never travel, so they start as whatever the pooled arena last
             // held. Zeroing the handle first is what makes attach_populated's
@@ -279,7 +278,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // attach_populated.
             memset(rt->sm_handle, 0, sizeof(*rt->sm_handle));
             if (!rt->sm_handle->attach_populated(
-                    sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes, live_slots, payload_stride
+                    sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes, live_slots, runtime->sm_image_bytes
                 )) {
                 LOG_ERROR("Thread %d: host-orch: sm_handle->attach_populated failed", thread_idx);
                 rt = nullptr;

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -73,13 +73,16 @@ The shared image uses three per-slot structures:
 | Structure | Purpose |
 | --------- | ------- |
 | `PTO2TaskDescriptor` | Full task ID, kernel IDs, packed-buffer addresses |
-| `PTO2TaskPayload` | Tensors, scalars, predicate, local-ID fanins, dispatch metadata |
+| `PTO2TaskPayload` | Argument counts, predicate, dispatch metadata, and a delta naming each of its tensor, scalar and fanin regions — the arguments themselves live in the pool segments, so the payload is a fixed three cache lines regardless of the argument caps |
 | `PTO2TaskSlotState` | Active mask, attributes, block/subtask counters, completion state, task/payload bindings |
 
 The host/device boundary is POD and position-independent. Fanins are integer
-producer IDs, not pointers, and a slot state names its payload and descriptor by a
-delta from its own address — so the image needs no fixup on either side of the
-copy.
+producer IDs, not pointers, and a slot state names its payload and descriptor — and
+a payload names its three argument regions — by a delta from the naming field's own
+address, so the image needs no fixup on either side of the copy. A delta is only
+correct for the layout it was taken in, so `compact_live_image` re-takes every one
+of them against the shipped image; the copy to the device moves a field and its
+target together and leaves them all correct.
 
 ### 3.1 What Ships: the Arena's Three Zones
 
@@ -242,8 +245,8 @@ AIC/MIX tasks use the available cluster count.
 TensorMap maps tensor regions to producer task IDs. For every task:
 
 1. INPUT/INOUT regions look up overlapping producers.
-2. Explicit and discovered producers are deduplicated into
-   `fanin_local_ids[]`.
+2. Explicit and discovered producers are deduplicated into the payload's fanin
+   region.
 3. OUTPUT/INOUT regions register the new task as producer.
 4. Each producer tracks its highest consumer local ID for completion metadata.
 

--- a/src/a5/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a5/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
@@ -28,8 +28,9 @@ The shared graph image separates stable task identity from scheduling state:
 
 - `PTO2TaskDescriptor` contains the task ID, kernel IDs, and packed-buffer
   addresses.
-- `PTO2TaskPayload` contains tensors, scalars, predicates, and position-
-  independent `fanin_local_ids[]`.
+- `PTO2TaskPayload` contains the argument counts, predicate, and a delta naming
+  each of its tensor, scalar and position-independent fanin-id regions. The
+  arguments live in the pool segments, not in the payload.
 - `PTO2TaskSlotState` contains the active mask, task attributes, logical block
   count, subtask counters, completion state, and descriptor/payload bindings.
 
@@ -76,8 +77,8 @@ must launch as one cohort:
 ## Dependency and Readiness Flow
 
 1. Host orchestration allocates a task slot and builds its payload.
-2. TensorMap and explicit dependencies append producer local IDs to
-   `fanin_local_ids[]`.
+2. TensorMap and explicit dependencies append producer local IDs to the payload's
+   fanin region.
 3. Submit publishes only the finished graph data; it does not push ready tasks.
 4. After H2D, device boot scans every submitted task exactly once.
 5. A task with every fanin complete is routed to its ready queue; otherwise it

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -699,22 +699,18 @@ int32_t run_host_orchestration(
     // with the same pitch. The ring capacity and mask are untouched: `local_id &
     // mask` is `local_id`, which is below the pitch for every ring task.
     const uint64_t nt = static_cast<uint64_t>(total_tasks);
-    // The widest task in this bind sets the stride every payload in the image gets.
-    // Read from the mirror, which orchestration has finished writing.
-    int32_t widest_tensor_count = 0;
-    {
-        const auto *mirror_payloads =
-            reinterpret_cast<const PTO2TaskPayload *>(static_cast<const char *>(host_sm) + sm_segs.payloads);
-        for (uint64_t i = 0; i < nt; ++i) {
-            if (mirror_payloads[i].tensor_count > widest_tensor_count) {
-                widest_tensor_count = mirror_payloads[i].tensor_count;
-            }
-        }
-    }
-    const uint64_t payload_stride = pto2_sm_layout::shipped_payload_stride(widest_tensor_count);
-    runtime->sm_payload_stride = payload_stride;
-    const uint64_t image_bytes =
-        pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::live_slot_pitch(nt), payload_stride).end;
+    // What this bind actually put in the pools. The orchestrator's cursors are the
+    // exact populated extent of each one — no scan of the mirror is needed, and the
+    // image ships that much rather than the worst case the mirror is dimensioned for.
+    const PTO2OrchestratorState &orch_state = rt->orchestrator;
+    const pto2_sm_layout::BindUsage bind_usage{
+        nt,
+        static_cast<uint64_t>(orch_state.fanin_pool_cursor),
+        static_cast<uint64_t>(orch_state.tensor_pool_cursor),
+        static_cast<uint64_t>(orch_state.scalar_pool_cursor),
+    };
+    const uint64_t image_bytes = pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::image_extents(bind_usage)).end;
+    runtime->sm_image_bytes = image_bytes;
 
     // Only now is the size known, so this is where the device region grows to cover
     // its shared-memory tail. setup_static_arena grows per region and
@@ -772,7 +768,7 @@ int32_t run_host_orchestration(
     runtime_clear_host_only_pointers(rt);
     std::memcpy(upload_base, static_cast<const char *>(host_arena.base()) + layout.off_copied_begin, copied_bytes);
     const uint64_t compacted = pto2_sm_layout::compact_live_image(
-        static_cast<const char *>(host_sm), eff_task_window_sizes[0], nt, payload_stride, upload_base + copied_bytes
+        static_cast<const char *>(host_sm), eff_task_window_sizes[0], bind_usage, upload_base + copied_bytes
     );
     always_assert(compacted == image_bytes);
 
@@ -782,11 +778,15 @@ int32_t run_host_orchestration(
         return -1;
     }
     {
-        char attrs[96];
+        // Eight uint64 fields plus their labels; 96 would truncate the trailing
+        // `args=` counts on a large bind, which are the ones this marker exists for.
+        char attrs[224];
         snprintf(
             attrs, sizeof(attrs),
-            "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " subs=%" PRIu64 " pstride=%" PRIu64, nt,
-            upload_bytes, copied_bytes, image_bytes, submission_block_bytes, payload_stride
+            "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " subs=%" PRIu64 " args=%" PRIu64
+            "/%" PRIu64 "/%" PRIu64,
+            nt, upload_bytes, copied_bytes, image_bytes, submission_block_bytes, bind_usage.fanin_elems,
+            bind_usage.tensor_elems, bind_usage.scalar_elems
         );
         record_bind_phase(HostPhaseKind::BindArenaH2d, t_h2d_ns, attrs, upload_bytes);
     }

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -2222,7 +2222,7 @@ void PTO2OrchestratorState::graph_abort(void *recording_handle) {
     auto *entry = static_cast<GraphInflightRecording *>(recording_handle);
     if (state == nullptr || entry == nullptr) return;
     {
-        std::lock_guard<std::mutex> lock(state->recording_mutex);
+        std::scoped_lock lock(state->recording_mutex);
         entry->recording.reset();
         entry->set_status(GraphRecordingStatus::FAILED);
     }
@@ -2259,7 +2259,7 @@ bool PTO2OrchestratorState::graph_end() {
     );
     bool ready = false;
     {
-        std::lock_guard<std::mutex> lock(state->recording_mutex);
+        std::scoped_lock lock(state->recording_mutex);
         if (entry->status() != GraphRecordingStatus::RECORDING || entry->full_key != header->full_key) {
             entry->set_status(GraphRecordingStatus::FAILED);
         } else {

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -838,22 +838,17 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
     definition.tensor_arg_count = static_cast<uint32_t>(tensors.size());
     definition.scalar_arg_count = static_cast<uint32_t>(scalars.size());
     definition.predicate_count = static_cast<uint32_t>(predicates.size());
-    // The widest node sets the stride every entry of this Definition's execution
-    // storage gets; nodes[] carries each node's declared tensor count.
-    int32_t widest_node_tensor_count = 0;
-    for (const GraphNodeDefinition &node : nodes) {
-        if (node.tensor_count > widest_node_tensor_count) widest_node_tensor_count = node.tensor_count;
-    }
-    const size_t node_stride = graph_node_stride(widest_node_tensor_count);
+    // An execution's storage is the node array plus this Definition's two argument
+    // pools, which the nodes index by their own tensor_offset / scalar_offset — so the
+    // arg-table counts size them, and no per-node scan is needed.
     size_t execution_storage_bytes = 0;
-    if (node_stride > UINT32_MAX ||
-        !graph_execution_storage_bytes(
-            static_cast<int32_t>(definition.task_count), node_stride, &execution_storage_bytes
+    if (!graph_execution_storage_bytes(
+            static_cast<int32_t>(definition.task_count), definition.tensor_arg_count, definition.scalar_arg_count,
+            &execution_storage_bytes
         ) ||
         execution_storage_bytes > UINT32_MAX) {
         return false;
     }
-    definition.node_stride = static_cast<uint32_t>(node_stride);
     definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
     // Every section's byte count is known now, so the image grows once instead of
     // resizing eleven times. Each append aligns its start, hence the per-section
@@ -955,7 +950,7 @@ static uint32_t next_fanin_seen_epoch(PTO2OrchestratorState *orch) {
 
 // Polling: fanin is a flat array of position-independent producer local ids on
 // the payload (no dep-pool spill, no producer pointers). The builder writes them
-// directly into payload->fanin_local_ids as producers are appended, deduping by
+// directly into the payload's fanin region as producers are appended, deduping by
 // slot and hard-capping at PTO2_MAX_FANIN. self_local is this task's own local id
 // (the consumer), used to bump each producer's last_consumer_local_id (the
 // reclaim gate the host wait_for_consumers polls via completed_watermark).
@@ -965,12 +960,16 @@ struct PTO2FaninBuilder {
         orch(orch),
         seen_epoch(seen_epoch),
         self_local(self_local),
-        payload(payload) {}
+        payload(payload),
+        slots(payload->fanin_data()) {}
     int32_t count{0};
     PTO2OrchestratorState *orch{nullptr};
     uint32_t seen_epoch{0};
     int32_t self_local{0};
     PTO2TaskPayload *payload{nullptr};
+    // The payload's fanin region, resolved once: the appends below would otherwise
+    // re-resolve the delta per producer. Requires the regions bound before construction.
+    int32_t *slots{nullptr};
 
     bool mark_seen(uint8_t prod_ring, int32_t prod_slot) {
         if (prod_ring >= PTO2_MAX_RING_DEPTH || prod_slot < 0) {
@@ -1005,7 +1004,7 @@ static bool append_fanin_or_fail(
         LOG_ERROR("========================================");
         LOG_ERROR("FATAL: Fanin Capacity Exhausted!");
         LOG_ERROR("========================================");
-        LOG_ERROR("HBG stores every producer dependency inline on the consumer task.");
+        LOG_ERROR("HBG stores every producer dependency in the consumer task's fanin region.");
         LOG_ERROR("  Fanin:     used=%d/%d", fanin_builder->count, PTO2_MAX_FANIN);
         LOG_ERROR("  Requested: at least %d distinct producer dependencies", fanin_builder->count + 1);
         LOG_ERROR("Solution:");
@@ -1015,7 +1014,7 @@ static bool append_fanin_or_fail(
         orch_mark_fatal(orch, PTO2_ERROR_DEP_POOL_OVERFLOW);
         return false;
     }
-    fanin_builder->payload->fanin_local_ids[fanin_builder->count++] = static_cast<int32_t>(producer_task_id.local());
+    fanin_builder->slots[fanin_builder->count++] = static_cast<int32_t>(producer_task_id.local());
 
     // Reclaim gate: record this task as a consumer of the producer. The producer
     // slot retires once the per-ring completed_watermark reaches this consumer id.
@@ -1079,6 +1078,24 @@ static bool prepare_task(
     out->slot_state = &orch->sm_header->ring.get_slot_state_by_slot(out->alloc_result.slot);
     out->task = &orch->sm_header->ring.task_descriptors[out->alloc_result.slot];
     out->payload = &orch->sm_header->ring.task_payloads[out->alloc_result.slot];
+
+    // Bind the three argument regions before prefetch() and init(), both of which
+    // dereference them. The scalar cursor advances in whole cache lines because init()
+    // rounds its scalar memcpy up to one; a packed advance would let that rounding
+    // write into the next task's region. A tensor region is aligned for any count,
+    // ChipTensor being two cache lines. The fanin cursor advances at publish, not
+    // here — see the comment where it does.
+    const uint64_t window = orch->sm_header->ring.task_window_size;
+    const int32_t scalar_span = PTO2_ALIGN_UP(args.scalar_count(), ARG_POOL_ALIGN / (int32_t)sizeof(uint64_t));
+    debug_assert(static_cast<uint64_t>(orch->tensor_pool_cursor) + args.tensor_count() <= window * MAX_TENSOR_ARGS);
+    debug_assert(static_cast<uint64_t>(orch->scalar_pool_cursor) + scalar_span <= window * MAX_SCALAR_ARGS);
+    debug_assert(static_cast<uint64_t>(orch->fanin_pool_cursor) + PTO2_MAX_FANIN <= window * PTO2_MAX_FANIN);
+    out->payload->bind_regions(
+        orch->tensor_pool + orch->tensor_pool_cursor, orch->scalar_pool + orch->scalar_pool_cursor,
+        orch->fanin_pool + orch->fanin_pool_cursor
+    );
+    orch->tensor_pool_cursor += args.tensor_count();
+    orch->scalar_pool_cursor += scalar_span;
 
     // Init-on-write: this slot's dynamic scheduling fields and completion flag are
     // initialized here, as the orchestrator claims the slot. whole-graph-resident
@@ -1437,7 +1454,7 @@ static TaskOutputTensors submit_task_common(
     task.packed_buffer_end = prepared.alloc_result.packed_end;
 
     // append_fanin_or_fail wrote each producer's local id straight into
-    // payload.fanin_local_ids and bumped its last_consumer_local_id; the count is
+    // the payload's fanin region and bumped its last_consumer_local_id; the count is
     // published in STEP 6 below. payload.init does not touch the fanin region.
     payload.init(args, result, prepared.alloc_result, layout);
 
@@ -1463,7 +1480,7 @@ static TaskOutputTensors submit_task_common(
 
     // === STEP 6: publish the inline fanin count (device boot classifies) ===
     // Polling + host-orch: append_fanin_or_fail already wrote each producer's
-    // local id into payload.fanin_local_ids and bumped its last_consumer_local_id.
+    // local id into the payload's fanin region and bumped its last_consumer_local_id.
     // All that remains is to record how many. There is NO fanout adjacency, NO
     // dep_pool, and NO ready routing here — the initial device boot scan classifies
     // each task once. A -1 result from classify_fanin_state routes the task through
@@ -1474,6 +1491,12 @@ static TaskOutputTensors submit_task_common(
     // a flat array of position-independent integers, so it crosses to the device
     // unchanged.
     payload.fanin_count = fanin_builder.count;
+    // The region's length is settled, so the cursor closes it at the real count. The
+    // equality holds only while nothing between the bind and here bound another fanin
+    // region, which is what makes the deferred advance safe.
+    debug_assert(orch->fanin_pool_cursor == static_cast<int32_t>(payload.fanin_data() - orch->fanin_pool));
+    orch->fanin_pool_cursor += PTO2_ALIGN_UP(fanin_builder.count, ARG_POOL_ALIGN / (int32_t)sizeof(int32_t));
+
     (void)sched;
 
     CYCLE_COUNT_LAP(g_orch_fanin_cycle);
@@ -1689,6 +1712,10 @@ bool graph_submit_outer(
     ring.completion_flags[allocation.slot].store(0, std::memory_order_relaxed);
 
     slot.bind_buffers(&payload, &task);
+    // An outer GRAPH task holds a real ring slot, so its fanin comes from the pool like
+    // any other task's. It has no tensor or scalar region: its boundary travels inside
+    // the submission image, and graph_reset_outer_payload zeroes both counts below.
+    payload.bind_regions(nullptr, nullptr, orch->fanin_pool + orch->fanin_pool_cursor);
     slot.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
     slot.last_consumer_local_id = static_cast<int32_t>(task_id.local());
     slot.active_mask = ActiveMask{};
@@ -1739,6 +1766,11 @@ bool graph_submit_outer(
     }
     register_task_outputs(boundary_inputs, task_id, orch->tensor_map, orch->in_manual_scope());
     payload.fanin_count = fanin_builder.count;
+    // The region's length is settled, so the cursor closes it at the real count. The
+    // equality holds only while nothing between the bind and here bound another fanin
+    // region, which is what makes the deferred advance safe.
+    debug_assert(orch->fanin_pool_cursor == static_cast<int32_t>(payload.fanin_data() - orch->fanin_pool));
+    orch->fanin_pool_cursor += PTO2_ALIGN_UP(fanin_builder.count, ARG_POOL_ALIGN / (int32_t)sizeof(int32_t));
 
     pending.outer_slot = &slot;
     state->pending_uploads.push_back(std::move(pending));

--- a/src/a5/runtime/host_build_graph/runtime/pto2_dispatch_payload.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto2_dispatch_payload.h
@@ -67,11 +67,13 @@ static_assert(
 // PTO2TaskPayload layout drift fails the build rather than corrupting args[].
 constexpr uint32_t PTO2_TASKPAYLOAD_TENSOR_COUNT_OFFSET = 0;
 constexpr uint32_t PTO2_TASKPAYLOAD_SCALAR_COUNT_OFFSET = 4;
+// Offsets of the fields that NAME the argument regions, not of the regions themselves:
+// a region's address is (src + <field offset>) + <the int32 delta stored there>.
+constexpr uint32_t PTO2_TASKPAYLOAD_TENSORS_DELTA_OFFSET = 12;
+constexpr uint32_t PTO2_TASKPAYLOAD_SCALARS_DELTA_OFFSET = 16;
 // Cache line 9 (byte 576) holds the AICPU-only DispatchPredicate. Scalars follow it,
 // then tensors — the tensor array is last because it is the only region whose used
 // extent varies per task, so a task's read set is a contiguous prefix.
-constexpr uint32_t PTO2_TASKPAYLOAD_SCALARS_OFFSET = 640;
-constexpr uint32_t PTO2_TASKPAYLOAD_TENSORS_OFFSET = 768;
 constexpr uint32_t PTO2_TASKPAYLOAD_TENSOR_STRIDE = 128;  // sizeof(ChipTensor)
 
 /**

--- a/src/a5/runtime/host_build_graph/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_orchestrator.h
@@ -115,6 +115,24 @@ struct PTO2OrchestratorState {
     // crosses to the device.
     GraphHostState *graph_host_state{nullptr};
 
+    // === ARGUMENT POOLS (host-only) ===
+    // The mirror's three argument pools and the next free element in each. A submit
+    // binds its region at the cursor and advances it by what the task uses, so the
+    // pools stay packed and the bind path reads the cursors as the image's pool
+    // extents. Nothing is ever returned, and the pools are dimensioned for the worst
+    // case (task_window tasks each at their full cap), so a bump cannot overflow.
+    // The bases live here, not in the ring header: nothing on the device resolves one.
+    //
+    // The fanin cursor does not advance at bind time. PTO2FaninBuilder appends and
+    // dedups producers afterwards, so the region's length is known only when the count
+    // is published, and it advances there.
+    int32_t *fanin_pool{nullptr};
+    ChipTensor *tensor_pool{nullptr};
+    uint64_t *scalar_pool{nullptr};
+    int32_t fanin_pool_cursor{0};
+    int32_t tensor_pool_cursor{0};
+    int32_t scalar_pool_cursor{0};
+
     // === STATISTICS ===
 #if SIMPLER_DFX
     int64_t tasks_submitted;
@@ -142,8 +160,8 @@ struct PTO2OrchestratorState {
     );
 
     // Phase 3b: write the arena-internal pointer fields (scope_tasks,
-    // scope_begins, ring.fanin_pool.base, tensor_map.{buckets,entry_pool,
-    // free_entry_list,task_entry_heads}, scheduler reference).
+    // scope_begins, tensor_map.{buckets,entry_pool,free_entry_list,
+    // task_entry_heads}, scheduler reference).
     // Idempotent — host runs once on the image, AICPU runs once after attach.
     void wire_arena_pointers(const PTO2OrchestratorLayout &layout, DeviceArena &arena, PTO2SchedulerState *scheduler);
 

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -267,8 +267,7 @@ void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayou
 
 /**
  * Phase 3b — wire the orchestrator's pointers into the host-only zone
- * (orchestrator.{scope_tasks, scope_begins, scheduler, tensor_map.*,
- * ring.fanin_pool.base}).
+ * (orchestrator.{scope_tasks, scope_begins, scheduler, tensor_map.*}).
  *
  * Host-only by construction: that zone is past layout.device_bytes and so is not
  * allocated on the device, which makes the addresses this writes unrepresentable

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -30,6 +30,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <type_traits>
 
 #include "profiling_config.h"
 #include "pto_constants.h"
@@ -110,11 +111,17 @@
 // Fanin storage
 #define PTO2_FANIN_INLINE_CAP 64
 
-// Polling-scheduler inline fanin cap. The polling model stores producer
-// dependencies as flat position-independent local-id integers on the payload
-// (no dep-pool spill), so a task's fanin degree is hard-capped here. Must cover
-// the worst-case fanin of any workload (paged_attention is the densest).
+// Polling-scheduler fanin cap. The polling model stores producer dependencies as
+// flat position-independent local-id integers in the fanin pool (no dep-pool
+// spill), so a task's fanin degree is hard-capped here. Must cover the worst-case
+// fanin of any workload (paged_attention is the densest).
 #define PTO2_MAX_FANIN 128
+
+// Alignment of every per-task region inside an argument pool. Each region starts
+// and ends on a cache line so PTO2TaskPayload::init's round-up scalar memcpy stays
+// inside the task's own region — see its comment. ChipTensor is already 2 cache
+// lines, so only the fanin and scalar regions need the round-up.
+inline constexpr int32_t ARG_POOL_ALIGN = 64;
 
 // Dependency-degree diagnostic: warn once when a task's fanin or a producer's
 // fanout first exceeds this degree, so dense dependency graphs surface without
@@ -260,35 +267,42 @@ enum PTO2EarlySyncDrainState : uint8_t {
 inline constexpr int PTO2_EARLY_DISPATCH_CORE_MASK_WORDS = 2;
 
 struct PTO2TaskPayload {
-    // === Cache lines 0-8 (576B) — metadata + inline fanin ===
+    // === Cache line 0 (64B) — the dispatch path's own line ===
+    // sizeof is independent of PTO2_MAX_FANIN / MAX_TENSOR_ARGS / MAX_SCALAR_ARGS:
+    // widening a cap costs pool bytes for the tasks that need them, not a control
+    // block on every task.
     int32_t tensor_count{0};
     int32_t scalar_count{0};
     int32_t fanin_count{0};  // Producer dependency count (raw, no +1 redundance)
-    // Producer dependencies as position-independent local task ids. Single-ring
-    // hbg: every producer is ring 0, so no per-edge ring id is stored. Scanned
-    // by classify_fanin_state against the ring completion_flags. A -1 result
-    // means every fanin is complete; otherwise it is the first unmet
-    // fanin index. Hard-capped at PTO2_MAX_FANIN (no dep-pool spill).
-    int32_t fanin_local_ids[PTO2_MAX_FANIN];
-    // Reserved: preserves the early-dispatch block and tensors[] offsets. tensors
-    // must stay at byte 576 (AICore arg-materialization contract), so this fanin
-    // region keeps its original 528-byte footprint.
-    int32_t _fanin_reserved[3];
-    // Early-dispatch metadata (AICPU-side only). Ordered by descending
-    // alignment (8B mask, 4B fanin, then 2B/1B counters and flags) so the block packs with no
-    // internal padding. Kept here after the fanin array (not moved up front): on
-    // cache line 8 it shares only with the rarely-touched fanin tail, whereas in
-    // line 0 the early-dispatch atomics (written during staging) would false-share with
-    // tensor_count/scalar_count (read by build_payload at dispatch). Fits in the 40B
-    // between the fanin array (offset 536) and the 64B-aligned tensors[] (offset
-    // 576), so sizeof and tensors[] are unchanged.
+
+    // This task's three argument regions, each in a pool outside this struct and
+    // named by a delta from the naming field's own address. A delta holds only for
+    // the layout it was taken in, so every one is bound twice on the host: against
+    // the mirror when the slot is claimed, and against the image in
+    // compact_live_image, which re-pitches the segments.
+    //
+    // fanin holds flat position-independent producer local task ids. Single-ring
+    // hbg: every producer is ring 0, so no per-edge ring id is stored. Scanned by
+    // classify_fanin_state against the ring completion_flags. Hard-capped at
+    // PTO2_MAX_FANIN (no dep-pool spill). Unbound on a Graph node, whose
+    // dependencies live in the Definition's fanin CSR instead.
+    simpler::hbg::SelfRelativePtr<ChipTensor> tensors;
+    simpler::hbg::SelfRelativePtr<uint64_t> scalars;
+    simpler::hbg::SelfRelativePtr<int32_t> fanin;
+
+    // === Cache line 1 — early-dispatch metadata (AICPU-side only) ===
+    // Ordered by descending alignment (8B mask, 4B fanin, then 2B/1B counters and
+    // flags) so the block packs with no internal padding. On its own line rather
+    // than line 0: these atomics are written during staging while line 0's counts
+    // and region deltas are read by build_payload at dispatch, so sharing a line
+    // would false-share.
     //
     // Bitmask of global core_ids this consumer is pre-staged (gated) on. Concurrent
     // stagers publish bits with atomic fetch_or. A regular consumer destructively
     // splits them between release and late-stager owners; a sync_start cohort keeps
     // the completed mask stable for its single launch owner, whether staging is local
     // or uses the global drain fallback.
-    std::atomic<uint64_t> staged_core_mask[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS]{};
+    alignas(64) std::atomic<uint64_t> staged_core_mask[PTO2_EARLY_DISPATCH_CORE_MASK_WORDS]{};
     // Early-dispatch CANDIDATE detection (event-driven, dual of fanin_refcount):
     // seeded at wiring with producers already complete, then a flagged producer
     // bumps each consumer after all of its logical blocks are published.
@@ -326,49 +340,57 @@ struct PTO2TaskPayload {
     // reinitialization. READY records that producer release observed OWNER;
     // only cancellation clears OWNER during the current task lifetime.
     std::atomic<uint8_t> early_sync_drain_state{PTO2_EARLY_SYNC_DRAIN_NONE};
-    // === Cache line 9 (byte 576) — dispatch predicate (AICPU-only) ===
-    // Offset is a fixed 576, independent of MAX_TENSOR_ARGS / MAX_SCALAR_ARGS.
-    // AICore never reads it — args are materialized from the tensor_count / tensors
-    // / scalars offsets only. Resolved at submit; evaluated by the scheduler at
-    // dispatch.
+    // === Cache line 2 — dispatch predicate + dump metadata (AICPU-only) ===
+    // AICore never reads either — args are materialized from line 0's counts and
+    // region deltas. Resolved at submit; evaluated by the scheduler at dispatch.
     alignas(64) DispatchPredicate predicate;
     ArgsDumpTaskMetadata dump_metadata;
-    // === Cache lines 10-11 (128B) — scalars ===
-    // alignas is load-bearing: the AICore reads this at a compile-time offset, and
-    // uint64_t alone would let it start right after dump_metadata instead of on the
-    // next cache line. tensors got its 640 for free from ChipTensor's own alignment.
-    alignas(64) uint64_t scalars[MAX_SCALAR_ARGS];
-    // === Cache lines 12-75 (4096B) — tensors (alignas(64) forces alignment) ===
-    //
-    // Last on purpose. This is the only region whose used extent varies per task —
-    // one to seventeen entries of thirty-two on a measured decode — so putting it at
-    // the end makes everything a task reads a contiguous prefix, which is what lets
-    // the shipped image carry less than the whole array.
-    ChipTensor tensors[MAX_TENSOR_ARGS];
 
-    // Layout verification (size checks that don't need offsetof).
-    static_assert(sizeof(ChipTensor) == 128, "ChipTensor must be 2 cache lines");
-    static_assert(MAX_SCALAR_ARGS * sizeof(uint64_t) == 128, "scalar region must be 128B (2 cache lines)");
+    // --- Argument region access ---
+    // Each accessor resolves its delta once and hands back the region's first
+    // element, so a caller indexes the region directly. Deliberately no per-element
+    // accessor: one inside a loop would re-resolve the delta on every iteration, and
+    // a store through an unrelated pointer in the loop body is enough to stop the
+    // compiler hoisting that load — build_payload's args[] writes are exactly that.
+    ChipTensor *tensor_data() { return tensors.get(); }
+    const ChipTensor *tensor_data() const { return tensors.get(); }
+    uint64_t *scalar_data() { return scalars.get(); }
+    const uint64_t *scalar_data() const { return scalars.get(); }
+    int32_t *fanin_data() { return fanin.get(); }
+    const int32_t *fanin_data() const { return fanin.get(); }
+
+    /**
+     * Point this payload's three argument regions at pool-resident storage. Must run
+     * before prefetch() and init(), which dereference them.
+     *
+     * A Graph node passes nullptr for fanin: its dependencies come from the
+     * Definition's CSR, so the region does not exist and fanin_count stays 0.
+     */
+    void bind_regions(ChipTensor *tensor_region, uint64_t *scalar_region, int32_t *fanin_region) {
+        tensors.set(tensor_region);
+        scalars.set(scalar_region);
+        fanin.set(fanin_region);
+    }
 
     /**
      * Prefetch (for write) the regions init() is about to fill so the stores land
      * in warm cache. tensor_count/scalar_count come from the Arg — the payload's
-     * own counts are not set until init(). Warms the early-dispatch block at
-     * offset 536 (cache line 8) too. A member fn lowers to the same prefetch
+     * own counts are not set until init(). A member fn lowers to the same prefetch
      * instructions as a free function (`this` is just a register), no cache impact.
      */
     void prefetch(int32_t tensor_count, int32_t scalar_count) const {
+        const ChipTensor *t = tensor_data();
         for (int32_t i = 0; i < tensor_count; i++) {
-            __builtin_prefetch(&tensors[i], 1, 3);
-            __builtin_prefetch(reinterpret_cast<const char *>(&tensors[i]) + 64, 1, 3);
+            __builtin_prefetch(&t[i], 1, 3);
+            __builtin_prefetch(reinterpret_cast<const char *>(&t[i]) + 64, 1, 3);
         }
+        const uint64_t *s = scalar_data();
         for (int32_t i = 0; i < scalar_count; i += 8) {
-            __builtin_prefetch(&scalars[i], 1, 3);
+            __builtin_prefetch(&s[i], 1, 3);
         }
         __builtin_prefetch(this, 1, 3);
         __builtin_prefetch(reinterpret_cast<const char *>(this) + 64, 1, 3);
         __builtin_prefetch(reinterpret_cast<const char *>(this) + 128, 1, 3);
-        __builtin_prefetch(reinterpret_cast<const char *>(this) + 512, 1, 3);  // early-dispatch fields (cache line 8)
     }
 
     /**
@@ -387,23 +409,31 @@ struct PTO2TaskPayload {
         tensor_count = args.tensor_count();
         scalar_count = args.scalar_count();
 
-        // int32_t out_idx = 0;
+        // bind_regions must already have run: an unbound region reads back as null and
+        // the stores below would go through it. A count of zero needs no region, which
+        // is how an outer GRAPH task reaches here with both unbound.
+        debug_assert(args.tensor_count() == 0 || tensor_data() != nullptr);
+        debug_assert(args.scalar_count() == 0 || scalar_data() != nullptr);
+
+        ChipTensor *dst = tensor_data();
         for (int32_t i = 0; i < args.tensor_count(); i++) {
             if (args.tag(i) != TensorArgType::OUTPUT) {
-                tensors[i].copy(args.tensor(i).ref());
+                dst[i].copy(args.tensor(i).ref());
             } else {
                 init_tensor_from_create_info(
-                    tensors[i], args.tensor(i).create_info(),
+                    dst[i], args.tensor(i).create_info(),
                     reinterpret_cast<void *>(reinterpret_cast<char *>(alloc_result.packed_base) + layout.offsets[i]),
                     layout.buffer_sizes[i]
                 );
-                tensors[i].owner_task_id = result.task_id();
-                result.materialize_output(tensors[i]);
+                dst[i].owner_task_id = result.task_id();
+                result.materialize_output(dst[i]);
             }
         }
-        // Round up to cache line boundary. Both arrays are 128B so no overrun.
-        // Eliminates branches; extra bytes within the same CL have zero additional cost.
-        memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
+        // Round up to cache line boundary. Every scalar region is a whole number of
+        // cache lines (ARG_POOL_ALIGN), so the rounded copy stays inside this
+        // task's own region. Eliminates branches; extra bytes within the same CL have
+        // zero additional cost.
+        memcpy(scalar_data(), args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
 
         dump_metadata = {};
 #if SIMPLER_DFX
@@ -416,7 +446,7 @@ struct PTO2TaskPayload {
         // fields. reset_for_reuse MUST NOT touch the payload (it runs at slot
         // init and would pull this cold cache line across structures);
         // prepare_task only allocates/binds. prefetch() warms this
-        // line (offset 512) so these writes land in warm cache.
+        // line (cache line 1) so these writes land in warm cache.
         //
         // early_dispatch_state / staged_core_mask / dispatch_fanin are all CONSUMER-side: a
         // task whose own allow_early_resolve is false still has them touched when
@@ -437,28 +467,36 @@ struct PTO2TaskPayload {
     }
 };
 
-// PTO2TaskPayload layout verification (offsetof requires complete type).
-static_assert(offsetof(PTO2TaskPayload, fanin_local_ids) == 12, "inline fanin id array must follow fanin_count");
+// PTO2TaskPayload layout verification (offsetof requires complete type). The counts
+// and region deltas share the first cache line, the early-dispatch atomics own the
+// second, and the AICPU-only predicate + dump metadata own the third.
+static_assert(offsetof(PTO2TaskPayload, tensors) == 12, "region deltas must follow the three counts");
 static_assert(
-    offsetof(PTO2TaskPayload, predicate) == 576,
-    "dispatch predicate occupies cache line 9 at fixed byte 576 (before the arg arrays, never moves)"
+    offsetof(PTO2TaskPayload, fanin) + sizeof(simpler::hbg::SelfRelativePtr<int32_t>) <= 64,
+    "counts + region deltas must fit the first cache line"
 );
 static_assert(
-    offsetof(PTO2TaskPayload, dump_metadata) + sizeof(ArgsDumpTaskMetadata) <= 640,
-    "dump metadata must fit in the AICPU-only cache line before the arg arrays"
+    offsetof(PTO2TaskPayload, staged_core_mask) == 64,
+    "the early-dispatch atomics own cache line 1: they are written during staging while "
+    "line 0's counts and deltas are read at dispatch, so sharing a line would false-share"
+);
+static_assert(offsetof(PTO2TaskPayload, predicate) == 128, "dispatch predicate owns cache line 2");
+static_assert(
+    offsetof(PTO2TaskPayload, dump_metadata) + sizeof(ArgsDumpTaskMetadata) <= 192,
+    "dump metadata must fit the predicate's cache line"
 );
 static_assert(
-    offsetof(PTO2TaskPayload, scalars) == 640, "scalars must start at byte 640 (cache line 10, after predicate)"
+    sizeof(PTO2TaskPayload) == 192, "PTO2TaskPayload is three cache lines and independent of every argument cap"
 );
+// compact_live_image restacks the payload segment with one memcpy and the device
+// copy moves the whole image, so the payload has to be a POD wire struct. Deleting
+// SelfRelativePtr's copy operations does not cost it that — a deleted special member
+// is trivial — but only an assertion keeps a future member from doing so silently.
 static_assert(
-    offsetof(PTO2TaskPayload, tensors) == 640 + MAX_SCALAR_ARGS * sizeof(uint64_t),
-    "tensors must immediately follow scalars, and must be the last region: the shipped "
-    "image carries only as much of the array as a task uses, so nothing may sit past it"
+    std::is_trivially_copyable_v<PTO2TaskPayload> && std::is_standard_layout_v<PTO2TaskPayload>,
+    "PTO2TaskPayload crosses to the device by memcpy"
 );
-static_assert(
-    sizeof(PTO2TaskPayload) == 640 + MAX_SCALAR_ARGS * sizeof(uint64_t) + MAX_TENSOR_ARGS * sizeof(ChipTensor),
-    "PTO2TaskPayload size = metadata(576) + predicate cache line(64) + scalars + tensors"
-);
+static_assert(sizeof(ChipTensor) == 128, "ChipTensor must be 2 cache lines");
 
 /**
  * Per-task slot scheduling state (scheduler-private, NOT in shared memory)

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -44,6 +44,7 @@
 // need it include it via runtime.h directly.
 #include "aicore_completion_mailbox.h"
 #include "common/args_dump_task_metadata.h"
+#include "host_build_graph/self_relative_ptr.h"
 #include "pto_submit_types.h"
 #include "pto_task_id.h"
 #include "pto_types.h"
@@ -458,75 +459,6 @@ static_assert(
     sizeof(PTO2TaskPayload) == 640 + MAX_SCALAR_ARGS * sizeof(uint64_t) + MAX_TENSOR_ARGS * sizeof(ChipTensor),
     "PTO2TaskPayload size = metadata(576) + predicate cache line(64) + scalars + tensors"
 );
-
-/**
- * A pointer to a sibling in the same contiguous block, stored as a byte delta
- * from the field's own address.
- *
- * The block is `memcpy`'d to the device as one image, so a delta between two
- * addresses inside it is invariant under the move while a raw pointer is not.
- * Both users below satisfy that precondition: a ring task's payload and
- * descriptor live in the same shared-memory image as its slot state, and a Graph
- * node's live in the same GraphNodeStorage.
- *
- * A zero delta means unbound — a field can never coincide with its own target.
- * Zeroed memory therefore reads as null, which is what the slot's pristine state
- * is.
- *
- * int32_t bounds the distance at 2 GiB. Both blocks are far below it — a
- * GraphNodeStorage is a fixed struct, and the shared-memory image's end is
- * rejected above the bound in attach_populated — and set() leaves the field
- * unbound rather than storing a truncated delta, so an out-of-range target
- * reads back as null instead of as unrelated memory.
- */
-namespace simpler::hbg {
-
-template <typename T>
-class SelfRelativePtr {
-public:
-    SelfRelativePtr() = default;
-
-    // The stored value means something only relative to where it is stored, so
-    // copying it from another field would silently retarget it. Every write goes
-    // through set(), which takes the destination's own address into account. A
-    // whole-block memcpy is unaffected: it moves the field and its target
-    // together, which is the case this representation exists for.
-    SelfRelativePtr(const SelfRelativePtr &) = delete;
-    SelfRelativePtr &operator=(const SelfRelativePtr &) = delete;
-
-    T *get() const {
-        if (delta_ == 0) return nullptr;
-        return reinterpret_cast<T *>(reinterpret_cast<uintptr_t>(this) + static_cast<intptr_t>(delta_));
-    }
-
-    void set(T *target) {
-        if (target == nullptr) {
-            delta_ = 0;
-            return;
-        }
-        const intptr_t delta = reinterpret_cast<intptr_t>(target) - reinterpret_cast<intptr_t>(this);
-        // Narrowing a delta this large would name unrelated memory that a consumer
-        // would then dereference. Unbound is the one value every consumer already
-        // tests for.
-        if (delta < INT32_MIN || delta > INT32_MAX) {
-            delta_ = 0;
-            return;
-        }
-        delta_ = static_cast<int32_t>(delta);
-    }
-
-    T *operator->() const { return get(); }
-    T &operator*() const { return *get(); }
-    explicit operator bool() const { return delta_ != 0; }
-
-    friend bool operator==(const SelfRelativePtr &lhs, std::nullptr_t) { return lhs.delta_ == 0; }
-    friend bool operator!=(const SelfRelativePtr &lhs, std::nullptr_t) { return lhs.delta_ != 0; }
-
-private:
-    int32_t delta_{0};
-};
-
-}  // namespace simpler::hbg
 
 /**
  * Per-task slot scheduling state (scheduler-private, NOT in shared memory)

--- a/src/a5/runtime/host_build_graph/runtime/pto_shared_memory.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_shared_memory.h
@@ -251,9 +251,15 @@ struct PTO2SharedMemoryHandle {
     // the wrong address, so both sides derive it from the same submitted count.
     // The capacity and mask in the header are unchanged, and `local_id & mask`
     // yields `local_id`, which is below `live_slots` for every ring task.
+    //
+    // `image_bytes` is what the host shipped, pools included. The device cannot
+    // recompute it — the pool extents are the bind's cursors, which only the host saw
+    // — and it does not need to: a payload names its argument regions by delta, so no
+    // pool base is resolved here. The value bounds the region and checks the int32
+    // delta reach.
     bool attach_populated(
         void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t live_slots,
-        uint64_t payload_stride
+        uint64_t image_bytes
     );
 
     void destroy();
@@ -266,13 +272,10 @@ private:
         const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
     );
     void setup_pointers(uint64_t task_window_size);
-    // `pitch` is the slot count the arrays are dimensioned for. init_per_ring
-    // passes the ring capacity (the mirror the orchestrator writes into);
-    // attach_populated passes the submitted count (the compacted image that
-    // shipped).
-    void setup_pointers_per_ring(
-        const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch, uint64_t payload_stride
-    );
+    // `pitch` is the slot count the arrays are dimensioned for. init_per_ring passes
+    // the ring capacity (the mirror the orchestrator writes into); attach_populated
+    // passes the submitted count (the compacted image that shipped).
+    void setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch);
 };
 
 // =============================================================================
@@ -310,49 +313,87 @@ inline std::atomic<int32_t> *ring_current_task_index_addr(void *sm_dev_base) noe
     );
 }
 
-// Byte offsets (from the SM base) of the ring's three segments. The layout is:
-// header, then descriptors -> payloads -> slot_states, every segment
-// PTO2_ALIGN_UP-padded.
+// Byte offsets (from the SM base) of the ring's segments. The layout is: header, then
+// descriptors -> payloads -> slot_states -> completion_flags -> the three argument
+// pools, every segment PTO2_ALIGN_UP-padded. RingImageExtents dimensions them: the
+// mirror for the worst case the API allows, the image for what this bind holds, which
+// is what makes the live prefixes contiguous and the upload one copy.
 //
-// Two parameters, and the host mirror and the shipped image differ in both.
-//
-// The *pitch* is how many slots the arrays are dimensioned for: the mirror uses the
-// ring capacity, the image uses the submitted count, which is what makes the four
-// live prefixes contiguous and the upload one copy.
-//
-// The *payload stride* is how far apart consecutive payloads sit. The mirror uses
-// sizeof(PTO2TaskPayload), whose tensor array is dimensioned for the widest task the
-// API allows. The image uses the widest task in this bind — the array is the last
-// field, so anything past that task's entries is read by nobody.
+// The pools sit last because nothing on the device resolves a segment past
+// completion_flags: a payload names its argument regions by delta, so the four
+// slot-pitched offsets are all the attach path computes.
 struct PTO2RingSegmentOffsets {
     uint64_t descriptors;
     uint64_t payloads;
     uint64_t slot_states;
     uint64_t completion_flags;  // polling-completion byte array (1 byte/slot)
-    uint64_t end;               // offset just past completion_flags (total SM size)
+    uint64_t fanin_pool;
+    uint64_t tensor_pool;
+    uint64_t scalar_pool;
+    uint64_t end;  // offset just past the last segment (total image size)
 };
 
-// Single source of truth for the SM segment layout. Returns offsets (not
-// pointers), so it serves BOTH the host-side pointer setup (`setup_pointers`,
-// which adds `sm_base`) and the device-address helpers below (which add
-// `sm_dev_base`). Adding or reordering a segment is a one-line edit here; every
-// consumer follows automatically, so the layout walk can never silently
-// disagree across call sites.
-inline PTO2RingSegmentOffsets
-ring_segment_offsets(uint64_t task_window_size, uint64_t payload_stride = sizeof(PTO2TaskPayload)) noexcept {
+// How many slots and how many pool elements a layout is dimensioned for.
+struct RingImageExtents {
+    uint64_t slots;
+    uint64_t fanin_elems;
+    uint64_t tensor_elems;
+    uint64_t scalar_elems;
+};
+
+// The mirror the orchestrator writes into: the ring capacity, every pool sized so the
+// worst case cannot overflow a bump — task_window tasks each at their full cap. That
+// bound is what lets prepare_task advance a cursor with no capacity check.
+inline RingImageExtents mirror_extents(uint64_t task_window_size) noexcept {
+    return RingImageExtents{
+        task_window_size,
+        task_window_size * PTO2_MAX_FANIN,
+        task_window_size * MAX_TENSOR_ARGS,
+        task_window_size * MAX_SCALAR_ARGS,
+    };
+}
+
+// Single source of truth for the SM segment layout. Returns offsets (not pointers),
+// so it serves BOTH the host-side pointer setup (`setup_pointers`, which adds
+// `sm_base`) and the device-address helpers below (which add `sm_dev_base`). Adding
+// or reordering a segment is a one-line edit here; every consumer follows
+// automatically, so the layout walk can never silently disagree across call sites.
+inline PTO2RingSegmentOffsets ring_segment_offsets(const RingImageExtents &e) noexcept {
     uint64_t off = PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
     PTO2RingSegmentOffsets o{};
     o.descriptors = off;
-    off += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
+    off += PTO2_ALIGN_UP(e.slots * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
     o.payloads = off;
-    off += PTO2_ALIGN_UP(task_window_size * payload_stride, PTO2_ALIGN_SIZE);
+    off += PTO2_ALIGN_UP(e.slots * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
     o.slot_states = off;
-    off += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
+    off += PTO2_ALIGN_UP(e.slots * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
     o.completion_flags = off;
-    off += PTO2_ALIGN_UP(task_window_size * sizeof(std::atomic<uint8_t>), PTO2_ALIGN_SIZE);
+    off += PTO2_ALIGN_UP(e.slots * sizeof(std::atomic<uint8_t>), PTO2_ALIGN_SIZE);
+    o.fanin_pool = off;
+    off += PTO2_ALIGN_UP(e.fanin_elems * sizeof(int32_t), PTO2_ALIGN_SIZE);
+    o.tensor_pool = off;
+    off += PTO2_ALIGN_UP(e.tensor_elems * sizeof(ChipTensor), PTO2_ALIGN_SIZE);
+    o.scalar_pool = off;
+    off += PTO2_ALIGN_UP(e.scalar_elems * sizeof(uint64_t), PTO2_ALIGN_SIZE);
     o.end = off;
     return o;
 }
+
+inline PTO2RingSegmentOffsets ring_segment_offsets(uint64_t task_window_size) noexcept {
+    return ring_segment_offsets(mirror_extents(task_window_size));
+}
+
+// Every per-task region starts on a cache line, which PTO2TaskPayload::init's
+// round-up scalar memcpy relies on. ChipTensor is 2 cache lines, so a tensor region
+// is aligned for any count; the fanin and scalar strides need it stated.
+static_assert(
+    (PTO2_MAX_FANIN * sizeof(int32_t)) % ARG_POOL_ALIGN == 0,
+    "the fanin region's cap must be a whole number of cache lines"
+);
+static_assert(
+    (MAX_SCALAR_ARGS * sizeof(uint64_t)) % ARG_POOL_ALIGN == 0,
+    "the scalar region's cap must be a whole number of cache lines"
+);
 
 // The pitch the shipped image uses for a given submitted task count. A bind that
 // submits nothing still ships its header and still attaches, and a zero-length
@@ -361,47 +402,54 @@ inline uint64_t live_slot_pitch(uint64_t submitted_tasks) noexcept {
     return submitted_tasks == 0 ? 1 : submitted_tasks;
 }
 
-// The stride a shipped payload array uses for a given widest task. The tensor array
-// is the payload's last field, so a task reads nothing past its own entries and the
-// stride need only cover them — but every payload in the image shares one stride, so
-// it is the widest task that sets it.
-//
-// Rounded up to PTO2_ALIGN_SIZE because PTO2TaskPayload's own alignment is 64 and the
-// image places consecutive payloads at multiples of the stride.
-inline uint64_t shipped_payload_stride(int32_t widest_tensor_count) noexcept {
-    constexpr uint64_t kTensorsOffset = offsetof(PTO2TaskPayload, tensors);
-    const uint64_t used = static_cast<uint64_t>(widest_tensor_count < 0 ? 0 : widest_tensor_count) * sizeof(ChipTensor);
-    const uint64_t stride = PTO2_ALIGN_UP(kTensorsOffset + used, PTO2_ALIGN_SIZE);
-    return stride > sizeof(PTO2TaskPayload) ? sizeof(PTO2TaskPayload) : stride;
+// What a bind actually holds, for the shipped image's extents. Each pool ships only the
+// prefix its cursor reached, which is why a run of narrow tasks ships a small fraction
+// of the mirror's pools.
+struct BindUsage {
+    uint64_t submitted_tasks;
+    uint64_t fanin_elems;
+    uint64_t tensor_elems;
+    uint64_t scalar_elems;
+};
+
+inline RingImageExtents image_extents(const BindUsage &used) noexcept {
+    return RingImageExtents{
+        live_slot_pitch(used.submitted_tasks),
+        used.fanin_elems,
+        used.tensor_elems,
+        used.scalar_elems,
+    };
 }
 
 // Restack the live prefix of every ring segment from the ring-pitched mirror the
-// orchestrator wrote into an image pitched to `submitted_tasks`, where the four
+// orchestrator wrote into an image dimensioned for what this bind holds, where the
 // prefixes are contiguous and can travel as one copy.
 //
 // `out_base` must be PTO2_ALIGN_SIZE-aligned and hold
-// `ring_segment_offsets(live_slot_pitch(submitted_tasks)).end` bytes. Returns that
-// byte count.
+// `ring_segment_offsets(image_extents(used)).end` bytes. Returns that byte count.
 //
 // Two things the restack has to fix up, both because the image is not the mirror:
 //
 //   - the ring header's data pointers name the mirror's arrays, so they leave as
 //     null rather than carrying host addresses into device memory (the device
 //     resolves them in attach_populated);
-//   - a slot state names its payload and descriptor by a delta from its own
-//     address, and the restack changed those distances, so each binding is
-//     re-taken against the image.
-inline uint64_t compact_live_image(
-    const char *mirror_base, uint64_t task_window_size, uint64_t submitted_tasks, uint64_t payload_stride,
-    char *out_base
-) noexcept {
-    // The mirror is pitched to the capacity and to the type, so a larger live count
-    // or a wider stride reads past the segment it is copying from and ships a corrupt
-    // image. attach_populated tests the same two bounds on the device side.
-    always_assert(submitted_tasks <= task_window_size);
-    always_assert(payload_stride <= sizeof(PTO2TaskPayload));
-    const PTO2RingSegmentOffsets from = ring_segment_offsets(task_window_size);
-    const PTO2RingSegmentOffsets to = ring_segment_offsets(live_slot_pitch(submitted_tasks), payload_stride);
+//   - a slot state names its payload and descriptor, and a payload names its three
+//     argument regions, by a delta from the naming field's own address; the restack
+//     changed those distances, so every one is re-taken against the image. A region
+//     keeps its position within its pool, so the re-take is the same arithmetic with
+//     the image's bases.
+inline uint64_t
+compact_live_image(const char *mirror_base, uint64_t task_window_size, const BindUsage &used, char *out_base) noexcept {
+    // The mirror is dimensioned for the worst case, so a live count or a cursor past
+    // it reads beyond the segment it is copying from and ships a corrupt image.
+    // attach_populated tests the slot bound again on the device side.
+    const RingImageExtents mirror = mirror_extents(task_window_size);
+    always_assert(used.submitted_tasks <= mirror.slots);
+    always_assert(used.fanin_elems <= mirror.fanin_elems);
+    always_assert(used.tensor_elems <= mirror.tensor_elems);
+    always_assert(used.scalar_elems <= mirror.scalar_elems);
+    const PTO2RingSegmentOffsets from = ring_segment_offsets(mirror);
+    const PTO2RingSegmentOffsets to = ring_segment_offsets(image_extents(used));
 
     // The header and the descriptors offset are pitch-independent, so the header
     // lands where it already was.
@@ -412,24 +460,54 @@ inline uint64_t compact_live_image(
     out_ring.slot_states = nullptr;
     out_ring.completion_flags = nullptr;
 
-    const uint64_t nt = submitted_tasks;
+    const uint64_t nt = used.submitted_tasks;
     std::memcpy(out_base + to.descriptors, mirror_base + from.descriptors, nt * sizeof(PTO2TaskDescriptor));
-    // Per payload, because the source and destination strides differ: the mirror is
-    // pitched to the type, the image to the widest task in this bind.
-    for (uint64_t i = 0; i < nt; ++i) {
-        std::memcpy(
-            out_base + to.payloads + i * payload_stride, mirror_base + from.payloads + i * sizeof(PTO2TaskPayload),
-            payload_stride
-        );
-    }
+    // One copy, not one per payload: PTO2TaskPayload is fixed-size, so the mirror and
+    // the image share a stride. Each pool is likewise one copy of its own prefix.
+    std::memcpy(out_base + to.payloads, mirror_base + from.payloads, nt * sizeof(PTO2TaskPayload));
     std::memcpy(out_base + to.slot_states, mirror_base + from.slot_states, nt * sizeof(PTO2TaskSlotState));
     std::memcpy(out_base + to.completion_flags, mirror_base + from.completion_flags, nt * sizeof(std::atomic<uint8_t>));
+    std::memcpy(out_base + to.fanin_pool, mirror_base + from.fanin_pool, used.fanin_elems * sizeof(int32_t));
+    std::memcpy(out_base + to.tensor_pool, mirror_base + from.tensor_pool, used.tensor_elems * sizeof(ChipTensor));
+    std::memcpy(out_base + to.scalar_pool, mirror_base + from.scalar_pool, used.scalar_elems * sizeof(uint64_t));
 
     auto *out_slots = reinterpret_cast<PTO2TaskSlotState *>(out_base + to.slot_states);
     auto *out_descriptors = reinterpret_cast<PTO2TaskDescriptor *>(out_base + to.descriptors);
+    auto *out_payloads = reinterpret_cast<PTO2TaskPayload *>(out_base + to.payloads);
+    const auto *mirror_payloads = reinterpret_cast<const PTO2TaskPayload *>(mirror_base + from.payloads);
+    auto *out_fanin = reinterpret_cast<int32_t *>(out_base + to.fanin_pool);
+    auto *out_tensors = reinterpret_cast<ChipTensor *>(out_base + to.tensor_pool);
+    auto *out_scalars = reinterpret_cast<uint64_t *>(out_base + to.scalar_pool);
+    const auto *mirror_fanin = reinterpret_cast<const int32_t *>(mirror_base + from.fanin_pool);
+    const auto *mirror_tensors = reinterpret_cast<const ChipTensor *>(mirror_base + from.tensor_pool);
+    const auto *mirror_scalars = reinterpret_cast<const uint64_t *>(mirror_base + from.scalar_pool);
+    // An unbound region stays unbound: a Graph node's payload never gets a fanin
+    // region, and its count is 0, so no consumer resolves it. A bound one is inside
+    // its own mirror pool by construction — the only binder is a bump cursor on that
+    // pool — and the translation below depends on it, so it is asserted rather than
+    // re-derived.
     for (uint64_t i = 0; i < nt; ++i) {
-        auto *out_payload = reinterpret_cast<PTO2TaskPayload *>(out_base + to.payloads + i * payload_stride);
-        out_slots[i].bind_buffers(out_payload, &out_descriptors[i]);
+        out_slots[i].bind_buffers(&out_payloads[i], &out_descriptors[i]);
+        const PTO2TaskPayload &src = mirror_payloads[i];
+        const ChipTensor *src_tensors = src.tensor_data();
+        const uint64_t *src_scalars = src.scalar_data();
+        const int32_t *src_fanin = src.fanin_data();
+        debug_assert(
+            src_tensors == nullptr ||
+            (src_tensors >= mirror_tensors && src_tensors <= mirror_tensors + used.tensor_elems)
+        );
+        debug_assert(
+            src_scalars == nullptr ||
+            (src_scalars >= mirror_scalars && src_scalars <= mirror_scalars + used.scalar_elems)
+        );
+        debug_assert(
+            src_fanin == nullptr || (src_fanin >= mirror_fanin && src_fanin <= mirror_fanin + used.fanin_elems)
+        );
+        out_payloads[i].bind_regions(
+            src_tensors == nullptr ? nullptr : out_tensors + (src_tensors - mirror_tensors),
+            src_scalars == nullptr ? nullptr : out_scalars + (src_scalars - mirror_scalars),
+            src_fanin == nullptr ? nullptr : out_fanin + (src_fanin - mirror_fanin)
+        );
     }
     return to.end;
 }

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -173,12 +173,12 @@ public:
     // the boot thread reads this instead of counting SM ring heads.
     int32_t host_total_tasks;
 
-    // Distance between consecutive payloads in the shipped shared-memory image.
-    // Smaller than sizeof(PTO2TaskPayload) whenever the bind's widest task uses
-    // fewer tensors than the array holds, which is the usual case. Set by the host
-    // before the image is copied; the AICPU needs it at attach to place every
-    // segment that follows the payload array.
-    uint64_t sm_payload_stride;
+    // Size of the shipped shared-memory image, argument pools included. Set by the
+    // host before the image is copied; the AICPU cannot recompute it because the pool
+    // extents are the bind's cursors, which only the host saw. It bounds the region at
+    // attach and checks the int32 delta reach — it places no segment, since a payload
+    // names its argument regions by delta.
+    uint64_t sm_image_bytes;
 
 private:
     // Kernel binary tracking for cleanup

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -577,7 +577,7 @@ struct PTO2SchedulerState {
 
     // Unmet-fanin classification. Returns -1 (all fanins met -> route to ready)
     // or the index of an unmet fanin (register on that producer's wake list).
-    // Scan direction is load-bearing: the builder fills fanin_local_ids in
+    // Scan direction is load-bearing: the builder fills the fanin region in
     // submission order, so the last unmet entry is the latest-submitted
     // producer -- the one likeliest to complete last. Targeting it minimises
     // wake-list transfers (a consumer re-registered onto a second producer once
@@ -587,8 +587,9 @@ struct PTO2SchedulerState {
     int classify_fanin_state(const PTO2TaskSlotState *s) const {
         const PTO2TaskPayload &p = *s->payload;
         const PTO2SharedMemoryRingHeader &ring = *ring_sched_state.ring;
+        const int32_t *fanin = p.fanin_data();
         for (int32_t i = p.fanin_count - 1; i >= 0; i--) {
-            if (!ring.is_completion_flag_set(p.fanin_local_ids[i])) return i;
+            if (!ring.is_completion_flag_set(fanin[i])) return i;
         }
         return -1;
     }
@@ -614,7 +615,7 @@ struct PTO2SchedulerState {
                 push_ready_routed(consumer);
                 return;
             }
-            producer = &ring.get_slot_state_by_task_id(consumer->payload->fanin_local_ids[state]);
+            producer = &ring.get_slot_state_by_task_id(consumer->payload->fanin_data()[state]);
         }
     }
 
@@ -643,7 +644,7 @@ struct PTO2SchedulerState {
             if (state < 0) {
                 push_ready_routed(waiter);
             } else {
-                register_wake(&ring.get_slot_state_by_task_id(waiter->payload->fanin_local_ids[state]), waiter);
+                register_wake(&ring.get_slot_state_by_task_id(waiter->payload->fanin_data()[state]), waiter);
             }
             waiter = next;
         }

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -245,9 +245,9 @@ void SchedulerContext::log_stall_diagnostics(
                 int32_t fi = slot_state.payload != nullptr ? slot_state.payload->fanin_count : 0;
                 int32_t rc = 0;
                 if (slot_state.payload != nullptr) {
+                    const int32_t *fanin = slot_state.payload->fanin_data();
                     for (int32_t k = 0; k < fi; k++) {
-                        int32_t pid = slot_state.payload->fanin_local_ids[k];
-                        if (ring.is_completion_flag_set(pid, std::memory_order_relaxed)) rc++;
+                        if (ring.is_completion_flag_set(fanin[k], std::memory_order_relaxed)) rc++;
                     }
                 }
                 int32_t kid_aic = slot_state.task->kernel_id[0];
@@ -1148,7 +1148,7 @@ void SchedulerContext::classify_partition(int32_t thread_idx, int32_t nthreads) 
         if (state < 0) {
             sched_->push_ready_routed(&slot);
         } else {
-            int32_t prod_local = slot.payload->fanin_local_ids[state];
+            int32_t prod_local = slot.payload->fanin_data()[state];
             sched_->register_wake(&ring.get_slot_state_by_task_id(prod_local), &slot);
         }
     }

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -42,8 +42,8 @@
 // Pin those constants to the real layout here, where the struct is fully visible.
 static_assert(offsetof(PTO2TaskPayload, tensor_count) == PTO2_TASKPAYLOAD_TENSOR_COUNT_OFFSET);
 static_assert(offsetof(PTO2TaskPayload, scalar_count) == PTO2_TASKPAYLOAD_SCALAR_COUNT_OFFSET);
-static_assert(offsetof(PTO2TaskPayload, tensors) == PTO2_TASKPAYLOAD_TENSORS_OFFSET);
-static_assert(offsetof(PTO2TaskPayload, scalars) == PTO2_TASKPAYLOAD_SCALARS_OFFSET);
+static_assert(offsetof(PTO2TaskPayload, tensors) == PTO2_TASKPAYLOAD_TENSORS_DELTA_OFFSET);
+static_assert(offsetof(PTO2TaskPayload, scalars) == PTO2_TASKPAYLOAD_SCALARS_DELTA_OFFSET);
 static_assert(sizeof(ChipTensor) == PTO2_TASKPAYLOAD_TENSOR_STRIDE);
 
 // =============================================================================
@@ -143,11 +143,18 @@ void SchedulerContext::build_payload(
         // Ready task: fill args here; src_payload = 0 signals AICore to run on pickup.
         dispatch_payload.src_payload = 0;
         int n = 0;
-        for (int32_t i = 0; i < payload.tensor_count; i++) {
-            dispatch_payload.args[n++] = reinterpret_cast<uint64_t>(&payload.tensors[i]);
+        // Both regions are resolved once: the args[] stores below could alias the
+        // payload as far as the compiler knows, so re-resolving a delta per element
+        // would reload it on every iteration.
+        const ChipTensor *tensors = payload.tensor_data();
+        const int32_t tensor_count = payload.tensor_count;
+        for (int32_t i = 0; i < tensor_count; i++) {
+            dispatch_payload.args[n++] = reinterpret_cast<uint64_t>(&tensors[i]);
         }
-        for (int32_t i = 0; i < payload.scalar_count; i++) {
-            dispatch_payload.args[n++] = payload.scalars[i];
+        const uint64_t *scalars = payload.scalar_data();
+        const int32_t scalar_count = payload.scalar_count;
+        for (int32_t i = 0; i < scalar_count; i++) {
+            dispatch_payload.args[n++] = scalars[i];
         }
     }
     dispatch_payload.local_context.block_idx = block_idx;

--- a/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -257,6 +257,16 @@ bool PTO2OrchestratorState::init_data_from_layout(
 
     orch->ring.task_allocator.init(static_cast<int32_t>(task_window_size), cur_idx_dev, gm_heap, heap_size, orch_err);
 
+    // The mirror's argument pools. Offset arithmetic on the same base as sm_header,
+    // so it holds for whichever SM this orchestrator was pointed at — the host-orch
+    // path re-inits against the host mirror before orchestration. The cursors reset
+    // with the rest of the state above.
+    auto *sm_bytes = static_cast<char *>(sm_dev_base);
+    const auto pools = pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::mirror_extents(task_window_size));
+    orch->fanin_pool = reinterpret_cast<int32_t *>(sm_bytes + pools.fanin_pool);
+    orch->tensor_pool = reinterpret_cast<ChipTensor *>(sm_bytes + pools.tensor_pool);
+    orch->scalar_pool = reinterpret_cast<uint64_t *>(sm_bytes + pools.scalar_pool);
+
     const size_t seen_epoch_bytes =
         PTO2_ALIGN_UP(static_cast<size_t>(layout.tensor_map.task_window_size) * sizeof(uint32_t), PTO2_ALIGN_SIZE);
     auto *seen_epoch = static_cast<uint32_t *>(arena.region_ptr(layout.off_fanin_seen_epoch));

--- a/src/a5/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/pto_shared_memory.cpp
@@ -46,16 +46,21 @@ uint64_t PTO2SharedMemoryHandle::calculate_size_per_ring(const uint64_t task_win
 // =============================================================================
 
 void PTO2SharedMemoryHandle::setup_pointers_per_ring(
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch, uint64_t payload_stride
+    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch
 ) {
     (void)task_window_sizes;
     char *base = (char *)sm_base;
     header = (PTO2SharedMemoryHeader *)base;
 
-    // Per-ring descriptors / payloads / slot_states — offsets from the single
-    // source of truth (pto2_sm_layout::ring_segment_offsets), so this setup and
-    // the device-address helpers cannot drift.
-    auto off = pto2_sm_layout::ring_segment_offsets(pitch, payload_stride);
+    // Per-ring descriptors / payloads / slot_states — offsets from the single source
+    // of truth (pto2_sm_layout::ring_segment_offsets), so this setup and the
+    // device-address helpers cannot drift.
+    //
+    // Only the four slot-pitched segments, and no argument pool: the pool extents
+    // differ between the mirror and the image, while these four depend on the pitch
+    // alone. The orchestrator holds the mirror's pool bases; the device resolves an
+    // argument region through the payload's delta and needs no base at all.
+    auto off = pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::image_extents({pitch, 0, 0, 0}));
     auto &ring = header->ring;
     ring.task_descriptors = (PTO2TaskDescriptor *)(base + off.descriptors);
     ring.task_payloads = (PTO2TaskPayload *)(base + off.payloads);
@@ -68,7 +73,7 @@ void PTO2SharedMemoryHandle::setup_pointers(uint64_t task_window_size) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
     }
-    setup_pointers_per_ring(task_window_sizes, task_window_size, sizeof(PTO2TaskPayload));
+    setup_pointers_per_ring(task_window_sizes, task_window_size);
 }
 
 bool PTO2SharedMemoryHandle::init(
@@ -88,19 +93,28 @@ bool PTO2SharedMemoryHandle::init_per_ring(
     const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
 ) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
-    if (sm_size_arg < calculate_size_per_ring(task_window_sizes)) return false;
+    const uint64_t mirror_bytes = calculate_size_per_ring(task_window_sizes);
+    // The mirror has to stay inside an int32 delta's reach: a payload names its
+    // argument regions that way, and set() leaves a field unbound rather than
+    // truncating, so a pool out of reach would read back as null and be dereferenced
+    // as one. attach_populated makes the same check on the shipped image.
+    //
+    // Tested before the region's own size, because this rejects the ring capacity
+    // itself: no region, however large, makes such a window usable.
+    if (mirror_bytes > static_cast<uint64_t>(INT32_MAX)) return false;
+    if (sm_size_arg < mirror_bytes) return false;
 
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers_per_ring(task_window_sizes, task_window_sizes[0], sizeof(PTO2TaskPayload));
+    setup_pointers_per_ring(task_window_sizes, task_window_sizes[0]);
     init_header_per_ring(task_window_sizes, heap_sizes);
     return true;
 }
 
 bool PTO2SharedMemoryHandle::attach_populated(
     void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t live_slots,
-    uint64_t payload_stride
+    uint64_t image_bytes
 ) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
     // A pitch above the capacity would name a slot the ring cannot address, and one
@@ -108,21 +122,24 @@ bool PTO2SharedMemoryHandle::attach_populated(
     // short. This is the whole contract between the two sides, checked once at
     // attach rather than trusted.
     if (live_slots == 0 || live_slots > task_window_sizes[0]) return false;
-    // A stride past the type's size would read between payloads; one below the tensor
-    // array's own offset could not hold a payload's fixed head at all.
-    if (payload_stride > sizeof(PTO2TaskPayload) || payload_stride < offsetof(PTO2TaskPayload, tensors)) return false;
+    // The image must at least hold the four slot-pitched segments; anything beyond
+    // that is its argument pools, whose extents are the bind's cursors and are not
+    // recomputable here. The first pool's offset is exactly where those four end.
+    const uint64_t slots_end =
+        pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::image_extents({live_slots, 0, 0, 0})).fanin_pool;
+    if (image_bytes < slots_end) return false;
     // The region holds the compacted image, so that is what has to fit — the ring
     // capacity is no longer its size.
-    const uint64_t image_end = pto2_sm_layout::ring_segment_offsets(live_slots, payload_stride).end;
-    if (sm_size_arg < image_end) return false;
+    if (sm_size_arg < image_bytes) return false;
     // A slot state names its payload and descriptor by an int32 delta from its own
-    // address, so no two positions in the image may be further apart than that.
-    if (image_end > static_cast<uint64_t>(INT32_MAX)) return false;
+    // address, and a payload names its argument regions the same way, so no two
+    // positions in the image may be further apart than that.
+    if (image_bytes > static_cast<uint64_t>(INT32_MAX)) return false;
 
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers_per_ring(task_window_sizes, live_slots, payload_stride);
+    setup_pointers_per_ring(task_window_sizes, live_slots);
     // Deliberately NO init_header_per_ring: the SM already holds the host
     // orchestrator's task graph (descriptors, slot states, ring counters).
     return true;

--- a/src/a5/runtime/host_build_graph/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/runtime.cpp
@@ -35,7 +35,7 @@ Runtime::Runtime() {
     aicpu_allowed_cpu_count = 0;
     aicpu_launch_count = 0;
     host_total_tasks = 0;
-    sm_payload_stride = sizeof(PTO2TaskPayload);
+    sm_image_bytes = 0;
 
     // Initialize shared-memory / orchestration argument plumbing
     gm_sm_ptr_ = nullptr;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -337,6 +337,14 @@ struct PTO2TaskPayload {
     static_assert(sizeof(ChipTensor) == 128, "ChipTensor must be 2 cache lines");
     static_assert(MAX_SCALAR_ARGS * sizeof(uint64_t) == 128, "scalar region must be 128B (2 cache lines)");
 
+    // Argument region access. Shared AICPU code (args_dump_aicpu.h) reads a payload's
+    // arguments through these, so both runtimes offer them whether the arguments sit
+    // inline as they do here or in a pool.
+    ChipTensor *tensor_data() { return tensors; }
+    const ChipTensor *tensor_data() const { return tensors; }
+    uint64_t *scalar_data() { return scalars; }
+    const uint64_t *scalar_data() const { return scalars; }
+
     /**
      * Prefetch for write the regions init() fills. tensor_count/scalar_count
      * come from the argument because the payload counts are not initialized

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -362,11 +362,19 @@ For a cache hit, the Host Orchestrator:
 5. emits one outer `GRAPH` task;
 6. stages the exact-size POD submission image for upload after orchestration.
 
-Internal nodes consume no ring task-window slots. Their descriptor, payload,
-and slot state live in the tail of the outer `GRAPH` task's own heap block,
-past `required_heap`: one `PTO2TaskAllocator::alloc` covers both halves the
-task owns, so the storage is reclaimed with the task's packed outputs and
-needs no separate device allocation, retention keying or release path.
+Internal nodes consume no ring task-window slots. Their descriptor, payload, slot
+state, and argument pools live in the tail of the outer `GRAPH` task's own heap
+block, past `required_heap`: one `PTO2TaskAllocator::alloc` covers both halves the
+task owns, so the storage is reclaimed with the task's packed outputs and needs no
+separate device allocation, retention keying or release path.
+
+A node payload holds no argument array of its own — it names each region by a delta,
+like any other payload. Its pools are the last two regions of the execution storage,
+sized by the Definition's `tensor_arg_count` / `scalar_arg_count` and indexed by the
+node's own `tensor_offset` / `scalar_offset`, so a node's arguments occupy the same
+span in the pool as in the Definition's arg table. There is no fanin region: node
+dependencies come from the Definition's fanin CSR, so a node's `fanin_count` stays 0
+and its fanin delta unbound.
 
 The execution address is therefore not on the wire — both sides compute
 `packed_buffer_base + required_heap` and read the size from the Definition. The

--- a/src/common/host_build_graph/graph_execution.cpp
+++ b/src/common/host_build_graph/graph_execution.cpp
@@ -22,21 +22,23 @@ namespace {
 // The storage is the tail of the outer GRAPH task's heap allocation, so its
 // bytes are whatever that region last held; every field an execution needs is
 // written here or by the materialize pass, never inherited from those bytes.
-GraphExecution *
-acquire_host_execution_storage(uintptr_t storage_addr, size_t storage_bytes, int32_t node_count, size_t node_stride) {
-    size_t nodes_offset = 0;
-    size_t required_bytes = 0;
+GraphExecution *acquire_host_execution_storage(
+    uintptr_t storage_addr, size_t storage_bytes, int32_t node_count, uint32_t tensor_arg_count,
+    uint32_t scalar_arg_count
+) {
+    GraphExecutionStorageLayout layout{};
     if (storage_addr == 0 || storage_addr % alignof(GraphNodeStorage) != 0 ||
-        !graph_execution_storage_layout(node_count, node_stride, &nodes_offset, &required_bytes) ||
-        required_bytes > storage_bytes) {
+        !graph_execution_storage_layout(node_count, tensor_arg_count, scalar_arg_count, &layout) ||
+        layout.total_bytes > storage_bytes) {
         return nullptr;
     }
     auto *execution = new (reinterpret_cast<void *>(storage_addr)) GraphExecution{};
     execution->node_count = node_count;
-    execution->node_stride = node_stride;
     execution->remaining_nodes.store(node_count, std::memory_order_relaxed);
-    execution->node_storage =
-        reinterpret_cast<GraphNodeStorage *>(reinterpret_cast<uint8_t *>(execution) + nodes_offset);
+    auto *base = reinterpret_cast<uint8_t *>(execution);
+    execution->node_storage = reinterpret_cast<GraphNodeStorage *>(base + layout.nodes_offset);
+    execution->node_tensor_pool = reinterpret_cast<ChipTensor *>(base + layout.tensors_offset);
+    execution->node_scalar_pool = reinterpret_cast<uint64_t *>(base + layout.scalars_offset);
     return execution;
 }
 
@@ -374,7 +376,7 @@ GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
 
     GraphExecution *execution = acquire_host_execution_storage(
         outer_base + definition->required_heap, definition->execution_storage_bytes,
-        static_cast<int32_t>(definition->task_count), definition->node_stride
+        static_cast<int32_t>(definition->task_count), definition->tensor_arg_count, definition->scalar_arg_count
     );
     if (execution == nullptr) {
         __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
@@ -522,6 +524,15 @@ GraphMaterializeResult graph_execution_materialize_slice(
             execution.materialize_busy.store(0, std::memory_order_release);
             return GraphMaterializeResult::INVALID;
         }
+        // A node's arguments occupy the same span in this execution's pools as in the
+        // Definition's arg tables, so the region starts at the node's own offset. No
+        // fanin region: its dependencies come from the Definition's CSR, and
+        // reset_graph_payload below keeps fanin_count at 0.
+        payload.bind_regions(
+            execution.node_tensor_pool + source.tensor_offset, execution.node_scalar_pool + source.scalar_offset,
+            nullptr
+        );
+        ChipTensor *node_tensors = payload.tensor_data();
         for (int32_t j = 0; j < source.tensor_count; ++j) {
             const uint32_t tensor_index = source.tensor_offset + static_cast<uint32_t>(j);
             GraphTensor rebound;
@@ -533,19 +544,20 @@ GraphMaterializeResult graph_execution_materialize_slice(
                 return GraphMaterializeResult::INVALID;
             }
             execution.consumed_tensor_args++;
-            graph_tensor_unpack(rebound, &payload.tensors[j]);
+            graph_tensor_unpack(rebound, &node_tensors[j]);
         }
+        uint64_t *node_scalars = payload.scalar_data();
         for (int32_t j = 0; j < source.scalar_count; ++j) {
             const uint32_t scalar_index = source.scalar_offset + static_cast<uint32_t>(j);
             const GraphScalarSourceRef &ref = scalar_sources[scalar_index];
             if (ref.source == static_cast<uint8_t>(GraphScalarSource::STATIC_VALUE)) {
-                payload.scalars[j] = definition_scalars[scalar_index];
+                node_scalars[j] = definition_scalars[scalar_index];
             } else if (ref.source == static_cast<uint8_t>(GraphScalarSource::BOUNDARY)) {
                 if (ref.source_index >= execution.boundary_scalar_count || execution.boundary_scalars == nullptr) {
                     execution.materialize_busy.store(0, std::memory_order_release);
                     return GraphMaterializeResult::INVALID;
                 }
-                payload.scalars[j] = execution.boundary_scalars[ref.source_index];
+                node_scalars[j] = execution.boundary_scalars[ref.source_index];
             } else {
                 execution.materialize_busy.store(0, std::memory_order_release);
                 return GraphMaterializeResult::INVALID;

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -166,11 +166,6 @@ struct GraphDefinition {
     // required_heap + this, and the execution lives at
     // packed_buffer_base + required_heap.
     uint32_t execution_storage_bytes;
-    // Distance between consecutive GraphNodeStorage entries in an execution of this
-    // Definition. The payload is the last field of both the storage and the payload
-    // itself, so a node reads only as much of its tensor array as it declares — this
-    // is sized to the widest node here rather than to sizeof(GraphNodeStorage).
-    uint32_t node_stride;
     uint32_t off_fanout_offsets;
     uint32_t off_fanout_indices;
     uint32_t off_fanin_offsets;
@@ -380,10 +375,11 @@ struct GraphExecution {
     PTO2TaskSlotState *outer_slot{nullptr};
     GraphNodeStorage *nodes{nullptr};
     GraphNodeStorage *node_storage{nullptr};
-    // Entries sit this far apart, which is at most sizeof(GraphNodeStorage) and usually
-    // less. Reach one through node_at(); indexing node_storage as an array of the type
-    // would land between entries.
-    size_t node_stride{sizeof(GraphNodeStorage)};
+    // This execution's node argument pools, in the storage tail past node_storage.
+    // Every node payload's tensor and scalar deltas point here; its pool position is
+    // the Definition's tensor_offset / scalar_offset.
+    ChipTensor *node_tensor_pool{nullptr};
+    uint64_t *node_scalar_pool{nullptr};
     const GraphDefinition *definition{nullptr};
     const uint32_t *fanin_offsets{nullptr};
     const uint16_t *fanin_indices{nullptr};
@@ -392,64 +388,61 @@ struct GraphExecution {
     const uint64_t *boundary_scalars{nullptr};
     uint32_t boundary_scalar_count{0};
 
-    // One multiply — the same one the compiler already emitted for node_storage[i],
-    // since sizeof(GraphNodeStorage) is not a power of two and the scale was never a
-    // shift. Callers on the dispatch path pay nothing for the stride becoming a
-    // runtime value.
-    GraphNodeStorage &node_at(int32_t index) const {
-        return *reinterpret_cast<GraphNodeStorage *>(
-            reinterpret_cast<uint8_t *>(node_storage) + static_cast<size_t>(index) * node_stride
-        );
-    }
+    GraphNodeStorage &node_at(int32_t index) const { return node_storage[index]; }
 };
 
 static_assert(std::is_trivially_destructible_v<GraphNodeStorage>);
+// The tensor pool starts right after the node array, so the node stride has to carry
+// ChipTensor's alignment; the scalar pool then starts after a whole number of
+// ChipTensors. Neither holds by construction — both are properties of the two types.
 static_assert(
-    offsetof(GraphNodeStorage, payload) + sizeof(PTO2TaskPayload) == sizeof(GraphNodeStorage),
-    "the payload must be GraphNodeStorage's last field: the execution storage is strided by how much "
-    "of it a node uses, so anything placed after it would be cut off"
+    alignof(GraphNodeStorage) % alignof(ChipTensor) == 0,
+    "a node entry must be at least ChipTensor-aligned: the tensor pool follows the node array"
 );
+static_assert(sizeof(ChipTensor) % alignof(uint64_t) == 0, "the tensor stride must keep the scalar pool aligned");
 static_assert(std::is_trivially_destructible_v<GraphExecution>);
 
-// The execution occupies [GraphExecution][GraphNodeStorage x node_count] at the
-// tail of the outer GRAPH task's heap allocation.
-// The smallest stride that still holds a node's payload head. A node reads that head
-// plus as many tensor entries as it declares, and the tensor array is the last field of
-// the payload, which is in turn the last field of the storage.
-inline constexpr size_t graph_node_stride_floor() noexcept {
-    return offsetof(GraphNodeStorage, payload) + offsetof(PTO2TaskPayload, tensors);
-}
+// The execution occupies
+// [GraphExecution][GraphNodeStorage x node_count][ChipTensor x tensor_arg_count]
+// [uint64_t x scalar_arg_count] at the tail of the outer GRAPH task's heap allocation.
+//
+// The last two regions are the node payloads' argument pools, indexed by the
+// Definition's own tensor_offset / scalar_offset — which is why the Definition's
+// arg-table counts size them rather than a per-node sum: node i's arguments occupy
+// [offset, offset + count) in both the table and the pool. There is no fanin region:
+// node dependencies live in the Definition's fanin CSR, so a node's fanin_count stays
+// 0 and its fanin delta unbound.
+struct GraphExecutionStorageLayout {
+    size_t nodes_offset;
+    size_t tensors_offset;
+    size_t scalars_offset;
+    size_t total_bytes;
+};
 
-// The stride an execution uses for a given widest node. Rounded up to
-// GraphNodeStorage's own alignment, since the array places consecutive entries at
-// multiples of the stride, and clamped to the type: that is the widest an execution can
-// ever need.
-inline size_t graph_node_stride(int32_t widest_tensor_count) noexcept {
-    constexpr size_t ALIGNMENT = alignof(GraphNodeStorage);
-    const size_t used = static_cast<size_t>(widest_tensor_count < 0 ? 0 : widest_tensor_count) * sizeof(ChipTensor);
-    const size_t stride = (graph_node_stride_floor() + used + ALIGNMENT - 1) & ~(ALIGNMENT - 1);
-    return stride > sizeof(GraphNodeStorage) ? sizeof(GraphNodeStorage) : stride;
-}
-
-inline bool
-graph_execution_storage_layout(int32_t node_count, size_t node_stride, size_t *nodes_offset, size_t *storage_bytes) {
-    if (nodes_offset == nullptr || storage_bytes == nullptr || node_count <= 0 ||
-        node_count > static_cast<int32_t>(GRAPH_MAX_NODES) || node_stride > sizeof(GraphNodeStorage) ||
-        node_stride < graph_node_stride_floor() || node_stride % alignof(GraphNodeStorage) != 0) {
+inline bool graph_execution_storage_layout(
+    int32_t node_count, uint32_t tensor_arg_count, uint32_t scalar_arg_count, GraphExecutionStorageLayout *out
+) {
+    if (out == nullptr || node_count <= 0 || node_count > static_cast<int32_t>(GRAPH_MAX_NODES)) {
         return false;
     }
     constexpr size_t ALIGNMENT = alignof(GraphNodeStorage);
-    *nodes_offset = (sizeof(GraphExecution) + ALIGNMENT - 1) & ~(ALIGNMENT - 1);
-    // Entries sit node_stride apart, but each one is created by placement-new of a
-    // whole GraphNodeStorage, so the last entry's object has to fit: the reservation
-    // ends at its full size rather than at its stride.
-    *storage_bytes = *nodes_offset + static_cast<size_t>(node_count - 1) * node_stride + sizeof(GraphNodeStorage);
+    out->nodes_offset = (sizeof(GraphExecution) + ALIGNMENT - 1) & ~(ALIGNMENT - 1);
+    out->tensors_offset = out->nodes_offset + static_cast<size_t>(node_count) * sizeof(GraphNodeStorage);
+    out->scalars_offset = out->tensors_offset + static_cast<size_t>(tensor_arg_count) * sizeof(ChipTensor);
+    out->total_bytes = out->scalars_offset + static_cast<size_t>(scalar_arg_count) * sizeof(uint64_t);
     return true;
 }
 
-inline bool graph_execution_storage_bytes(int32_t node_count, size_t node_stride, size_t *storage_bytes) {
-    size_t nodes_offset = 0;
-    return graph_execution_storage_layout(node_count, node_stride, &nodes_offset, storage_bytes);
+inline bool graph_execution_storage_bytes(
+    int32_t node_count, uint32_t tensor_arg_count, uint32_t scalar_arg_count, size_t *storage_bytes
+) {
+    GraphExecutionStorageLayout layout{};
+    if (storage_bytes == nullptr ||
+        !graph_execution_storage_layout(node_count, tensor_arg_count, scalar_arg_count, &layout)) {
+        return false;
+    }
+    *storage_bytes = layout.total_bytes;
+    return true;
 }
 
 GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot);

--- a/src/common/host_build_graph/self_relative_ptr.h
+++ b/src/common/host_build_graph/self_relative_ptr.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <cstddef>
+
+/**
+ * A pointer to a sibling in the same contiguous block, stored as a byte delta
+ * from the field's own address.
+ *
+ * The block is `memcpy`'d to the device as one image, so a delta between two
+ * addresses inside it is invariant under the move while a raw pointer is not.
+ * Every user has to satisfy that precondition: a ring task's payload and
+ * descriptor live in the same shared-memory image as its slot state, and a Graph
+ * node's live in the same GraphNodeStorage.
+ *
+ * A zero delta means unbound — a field can never coincide with its own target.
+ * Zeroed memory therefore reads as null, which is what the slot's pristine state
+ * is.
+ *
+ * int32_t bounds the distance at 2 GiB, and set() leaves the field unbound rather
+ * than storing a truncated delta, so an out-of-range target reads back as null
+ * instead of as unrelated memory. A block whose extent can approach the bound
+ * therefore has to reject it up front: attach_populated does so for the shipped
+ * shared-memory image.
+ */
+namespace simpler::hbg {
+
+template <typename T>
+class SelfRelativePtr {
+public:
+    SelfRelativePtr() = default;
+
+    // The stored value means something only relative to where it is stored, so
+    // copying it from another field would silently retarget it. Every write goes
+    // through set(), which takes the destination's own address into account. A
+    // whole-block memcpy is unaffected: it moves the field and its target
+    // together, which is the case this representation exists for.
+    SelfRelativePtr(const SelfRelativePtr &) = delete;
+    SelfRelativePtr &operator=(const SelfRelativePtr &) = delete;
+
+    T *get() const {
+        if (delta_ == 0) return nullptr;
+        return reinterpret_cast<T *>(reinterpret_cast<uintptr_t>(this) + static_cast<intptr_t>(delta_));
+    }
+
+    void set(T *target) {
+        if (target == nullptr) {
+            delta_ = 0;
+            return;
+        }
+        const intptr_t delta = reinterpret_cast<intptr_t>(target) - reinterpret_cast<intptr_t>(this);
+        // Narrowing a delta this large would name unrelated memory that a consumer
+        // would then dereference. Unbound is the one value every consumer already
+        // tests for.
+        if (delta < INT32_MIN || delta > INT32_MAX) {
+            delta_ = 0;
+            return;
+        }
+        delta_ = static_cast<int32_t>(delta);
+    }
+
+    T *operator->() const { return get(); }
+    T &operator*() const { return *get(); }
+    explicit operator bool() const { return delta_ != 0; }
+
+    friend bool operator==(const SelfRelativePtr &lhs, std::nullptr_t) { return lhs.delta_ == 0; }
+    friend bool operator!=(const SelfRelativePtr &lhs, std::nullptr_t) { return lhs.delta_ != 0; }
+
+private:
+    int32_t delta_{0};
+};
+
+}  // namespace simpler::hbg

--- a/src/common/platform/include/aicpu/args_dump_aicpu.h
+++ b/src/common/platform/include/aicpu/args_dump_aicpu.h
@@ -158,6 +158,7 @@ inline void dump_args_for_task(
     int32_t covered_count = 0;
     const CoreCallable &sig = *sig_src;
 
+    const auto *pl_tensors = pl.tensor_data();
     for (int32_t sig_idx = 0; sig_idx < sig.sig_count(); sig_idx++) {
         ArgDirection dir = sig.sig(sig_idx);
         if (dir == ArgDirection::SCALAR) {
@@ -178,7 +179,7 @@ inline void dump_args_for_task(
             !should_dump_arg(dump_arg_mask, slot)) {
             continue;
         }
-        const auto &t = pl.tensors[slot];
+        const auto &t = pl_tensors[slot];
         ArgsDumpInfo info = {};
         info.buffer_addr = t.buffer.addr;
         info.dtype = static_cast<uint8_t>(t.dtype);
@@ -226,6 +227,7 @@ inline void dump_args_for_task(
             has_scalar_dtypes =
                 get_dump_args_task_scalar_dtypes(slot_state.task->task_id.raw, &dtype_scalar_count, scalar_dtypes);
         }
+        const uint64_t *pl_scalars = pl.scalar_data();
         for (int32_t scalar_index = 0; scalar_index < pl.scalar_count; scalar_index++) {
             int32_t scalar_arg_index = pl.tensor_count + scalar_index;
             if (!should_dump_arg(dump_arg_mask, scalar_arg_index)) {
@@ -245,7 +247,7 @@ inline void dump_args_for_task(
             for (int32_t i = 0; i < active_count; i++) {
                 info.func_ids[i] = active_fids[i];
             }
-            info.scalar_value = pl.scalars[scalar_index];
+            info.scalar_value = pl_scalars[scalar_index];
             if (has_dump_arg_flag(dump_arg_flags, scalar_arg_index)) {
                 info.flags = ARGS_DUMP_RECORD_FLAG_ARG_INDEX_AMBIGUOUS;
             }

--- a/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
@@ -184,5 +184,5 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     // The consumer's fanin is written: two duplicate deps dedupe to one.
     const PTO2TaskPayload &cons_pl = ring.task_payloads[ring.get_slot_by_task_id(consumer.task_id().local())];
     EXPECT_EQ(cons_pl.fanin_count, 1);
-    EXPECT_EQ(cons_pl.fanin_local_ids[0], static_cast<int32_t>(root.task_id().local()));
+    EXPECT_EQ(cons_pl.fanin_data()[0], static_cast<int32_t>(root.task_id().local()));
 }

--- a/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
@@ -184,5 +184,5 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     // The consumer's fanin is written: two duplicate deps dedupe to one.
     const PTO2TaskPayload &cons_pl = ring.task_payloads[ring.get_slot_by_task_id(consumer.task_id().local())];
     EXPECT_EQ(cons_pl.fanin_count, 1);
-    EXPECT_EQ(cons_pl.fanin_local_ids[0], static_cast<int32_t>(root.task_id().local()));
+    EXPECT_EQ(cons_pl.fanin_data()[0], static_cast<int32_t>(root.task_id().local()));
 }

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -441,7 +441,7 @@ TEST(GraphExecutionReplay, LocalizesBoundaryScalarPoolWiderThanTaskPayload) {
     outer_task.packed_buffer_end = heap.end();
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task = &outer_task;
+    outer_slot.task.set(&outer_task);
     outer_slot.graph_context = &submission;
 
     GraphExecution *execution = graph_execution_localize(outer_slot);
@@ -471,7 +471,7 @@ TEST(GraphExecutionReplay, RejectsBoundaryScalarPoolBeyondContract) {
     outer_task.packed_buffer_end = heap.end();
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task = &outer_task;
+    outer_slot.task.set(&outer_task);
     outer_slot.graph_context = &submission;
 
     EXPECT_EQ(graph_execution_localize(outer_slot), nullptr);

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -111,12 +111,11 @@ make_test_definition(uint64_t graph_key, uint64_t boundary_address, uint32_t bou
     definition.off_tensor_sources = append_section(image, tensor_sources);
     definition.off_scalars = append_section(image, scalars);
     definition.off_scalar_sources = append_section(image, scalar_sources);
-    // Widest node here declares one tensor, so the storage strides well below the
-    // type; the fixture exercises the compacted stride rather than the identity case.
-    const size_t node_stride = graph_node_stride(1);
     size_t execution_storage_bytes = 0;
-    graph_execution_storage_bytes(static_cast<int32_t>(definition.task_count), node_stride, &execution_storage_bytes);
-    definition.node_stride = static_cast<uint32_t>(node_stride);
+    graph_execution_storage_bytes(
+        static_cast<int32_t>(definition.task_count), definition.tensor_arg_count, definition.scalar_arg_count,
+        &execution_storage_bytes
+    );
     definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
     definition.total_bytes = static_cast<uint32_t>(image.size());
     std::memcpy(image.data(), &definition, sizeof(definition));
@@ -289,47 +288,42 @@ TEST(GraphScalarProvenance, MutableAccessInvalidatesForwardedSource) {
 
 TEST(GraphExecutionStorage, ComputesAlignedExactSize) {
     constexpr int32_t NODE_COUNT = 7;
-    size_t nodes_offset = 0;
-    size_t storage_bytes = 0;
+    constexpr uint32_t TENSOR_ARGS = 11;
+    constexpr uint32_t SCALAR_ARGS = 5;
+    GraphExecutionStorageLayout layout{};
 
-    // Identity stride first: the layout must still describe a full-width execution.
-    ASSERT_TRUE(graph_execution_storage_layout(NODE_COUNT, sizeof(GraphNodeStorage), &nodes_offset, &storage_bytes));
-    EXPECT_EQ(nodes_offset % alignof(GraphNodeStorage), 0U);
-    EXPECT_GE(nodes_offset, sizeof(GraphExecution));
-    EXPECT_EQ(storage_bytes, nodes_offset + NODE_COUNT * sizeof(GraphNodeStorage));
+    ASSERT_TRUE(graph_execution_storage_layout(NODE_COUNT, TENSOR_ARGS, SCALAR_ARGS, &layout));
+    EXPECT_EQ(layout.nodes_offset % alignof(GraphNodeStorage), 0U);
+    EXPECT_GE(layout.nodes_offset, sizeof(GraphExecution));
+    // The node array is type-strided now that the payload carries no array of its own,
+    // and the two argument pools follow it.
+    EXPECT_EQ(layout.tensors_offset, layout.nodes_offset + NODE_COUNT * sizeof(GraphNodeStorage));
+    EXPECT_EQ(layout.tensors_offset % alignof(ChipTensor), 0U);
+    EXPECT_EQ(layout.scalars_offset, layout.tensors_offset + TENSOR_ARGS * sizeof(ChipTensor));
+    EXPECT_EQ(layout.total_bytes, layout.scalars_offset + SCALAR_ARGS * sizeof(uint64_t));
+}
 
-    // A compacted stride shortens only the array; the header offset is stride-free.
-    // The last entry keeps room for a whole GraphNodeStorage, because that is what
-    // materialization placement-news into it.
-    const size_t narrow = graph_node_stride(1);
-    size_t narrow_offset = 0;
-    size_t narrow_bytes = 0;
-    ASSERT_TRUE(graph_execution_storage_layout(NODE_COUNT, narrow, &narrow_offset, &narrow_bytes));
-    EXPECT_EQ(narrow_offset, nodes_offset);
-    EXPECT_EQ(narrow_bytes, nodes_offset + (NODE_COUNT - 1) * narrow + sizeof(GraphNodeStorage));
-    EXPECT_GE(narrow_bytes - (narrow_offset + (NODE_COUNT - 1) * narrow), sizeof(GraphNodeStorage));
+// The pools are sized by the Definition's arg tables, so a Definition whose nodes
+// declare fewer arguments reserves less — the same property the node stride used to
+// carry, moved to the pools.
+TEST(GraphExecutionStorage, NarrowerArgTablesReserveLess) {
+    constexpr int32_t NODE_COUNT = 4;
+    size_t wide = 0;
+    size_t narrow = 0;
+    ASSERT_TRUE(graph_execution_storage_bytes(NODE_COUNT, 32, 16, &wide));
+    ASSERT_TRUE(graph_execution_storage_bytes(NODE_COUNT, 4, 2, &narrow));
+    EXPECT_LT(narrow, wide);
 }
 
 TEST(GraphExecutionStorage, RejectsInvalidNodeCount) {
     size_t storage_bytes = 0;
 
-    const size_t full = sizeof(GraphNodeStorage);
-    EXPECT_FALSE(graph_execution_storage_bytes(0, full, &storage_bytes));
-    EXPECT_FALSE(graph_execution_storage_bytes(-1, full, &storage_bytes));
-    EXPECT_FALSE(graph_execution_storage_bytes(static_cast<int32_t>(GRAPH_MAX_NODES) + 1, full, &storage_bytes));
-    // A stride the layout cannot honour is rejected the same way a bad node count is:
-    // past the type there is nothing to read, and below the payload head an entry
-    // cannot hold its own fixed fields.
-    EXPECT_FALSE(graph_execution_storage_bytes(1, full + alignof(GraphNodeStorage), &storage_bytes));
-    EXPECT_FALSE(
-        graph_execution_storage_bytes(1, graph_node_stride_floor() - alignof(GraphNodeStorage), &storage_bytes)
-    );
-    EXPECT_FALSE(graph_execution_storage_bytes(1, full - 1, &storage_bytes));
-    // The compacted stride the widest node implies is honoured, and is smaller.
-    EXPECT_TRUE(graph_execution_storage_bytes(4, graph_node_stride(1), &storage_bytes));
-    size_t full_bytes = 0;
-    EXPECT_TRUE(graph_execution_storage_bytes(4, full, &full_bytes));
-    EXPECT_LT(storage_bytes, full_bytes);
+    EXPECT_FALSE(graph_execution_storage_bytes(0, 1, 1, &storage_bytes));
+    EXPECT_FALSE(graph_execution_storage_bytes(-1, 1, 1, &storage_bytes));
+    EXPECT_FALSE(graph_execution_storage_bytes(static_cast<int32_t>(GRAPH_MAX_NODES) + 1, 1, 1, &storage_bytes));
+    // A Definition with no arguments at all still needs its node array.
+    EXPECT_TRUE(graph_execution_storage_bytes(1, 0, 0, &storage_bytes));
+    EXPECT_GE(storage_bytes, sizeof(GraphExecution) + sizeof(GraphNodeStorage));
 }
 
 // A resubmission gets the same heap block back, so the bytes it starts from are
@@ -368,8 +362,8 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     GraphNodeStorage &node = execution->node_at(0);
     ASSERT_EQ(node.payload.scalar_count, 1);
     ASSERT_EQ(node.payload.tensor_count, 1);
-    EXPECT_EQ(node.payload.scalars[0], 17U);
-    EXPECT_EQ(execution->node_at(1).payload.scalars[0], 18U);
+    EXPECT_EQ(node.payload.scalar_data()[0], 17U);
+    EXPECT_EQ(execution->node_at(1).payload.scalar_data()[0], 18U);
     EXPECT_EQ(node.payload.dump_metadata.dump_arg_mask, uint64_t{1} << 0);
     EXPECT_EQ(node.payload.dump_metadata.scalar_dtypes[0], static_cast<uint8_t>(DataType::FLOAT32));
     EXPECT_EQ(execution->node_at(1).payload.dump_metadata.dump_arg_mask, uint64_t{1} << 1);
@@ -388,9 +382,9 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     // preserved any of them would leave the poison observable.
     node.task.kernel_id[0] = 314;
     node.slot.active_mask = ActiveMask(3);
-    node.payload.scalars[0] = 2718;
-    execution->node_at(1).payload.scalars[0] = 31415;
-    node.payload.tensors[0].version = 1618;
+    node.payload.scalar_data()[0] = 2718;
+    execution->node_at(1).payload.scalar_data()[0] = 31415;
+    node.payload.tensor_data()[0].version = 1618;
     node.slot.completed_subtasks.store(1, std::memory_order_relaxed);
     node.payload.dispatch_fanin.store(1, std::memory_order_relaxed);
 
@@ -403,13 +397,13 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
     EXPECT_EQ(node.task.kernel_id[0], 42);
     EXPECT_EQ(node.slot.active_mask.raw(), 1);
-    EXPECT_EQ(node.payload.scalars[0], 99U);
-    EXPECT_EQ(execution->node_at(1).payload.scalars[0], 18U);
-    EXPECT_EQ(node.payload.tensors[0].version, 0);
+    EXPECT_EQ(node.payload.scalar_data()[0], 99U);
+    EXPECT_EQ(execution->node_at(1).payload.scalar_data()[0], 18U);
+    EXPECT_EQ(node.payload.tensor_data()[0].version, 0);
     EXPECT_EQ(node.task.task_id, PTO2TaskId::make(1, (8U << 10U)));
     EXPECT_EQ(node.task.packed_buffer_base, heap.base());
-    EXPECT_EQ(node.payload.tensors[0].buffer.addr, reinterpret_cast<uint64_t>(second_boundary.data()));
-    EXPECT_EQ(execution->node_at(1).payload.tensors[0].buffer.addr, reinterpret_cast<uint64_t>(heap.base() + 16));
+    EXPECT_EQ(node.payload.tensor_data()[0].buffer.addr, reinterpret_cast<uint64_t>(second_boundary.data()));
+    EXPECT_EQ(execution->node_at(1).payload.tensor_data()[0].buffer.addr, reinterpret_cast<uint64_t>(heap.base() + 16));
     EXPECT_EQ(node.slot.completed_subtasks.load(std::memory_order_relaxed), 0);
     EXPECT_EQ(node.payload.dispatch_fanin.load(std::memory_order_relaxed), 0);
     EXPECT_EQ(node.payload.dump_metadata.dump_arg_mask, uint64_t{1} << 0);
@@ -447,7 +441,7 @@ TEST(GraphExecutionReplay, LocalizesBoundaryScalarPoolWiderThanTaskPayload) {
     GraphExecution *execution = graph_execution_localize(outer_slot);
     ASSERT_NE(execution, nullptr);
     EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
-    EXPECT_EQ(execution->node_storage[0].payload.scalars[0], 21U);
+    EXPECT_EQ(execution->node_storage[0].payload.scalar_data()[0], 21U);
 }
 
 TEST(GraphExecutionReplay, RejectsBoundaryScalarPoolBeyondContract) {
@@ -677,7 +671,7 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
         ASSERT_EQ(node.payload.scalar_count, 1);
         // A tensor address of 0xAAAAAAAAAAAAAAAA would mean the fill leaked
         // through into a field the scheduler later dereferences.
-        ASSERT_NE(node.payload.tensors[0].buffer.addr, 0xAAAAAAAAAAAAAAAAULL);
+        ASSERT_NE(node.payload.tensor_data()[0].buffer.addr, 0xAAAAAAAAAAAAAAAAULL);
         // make_test_definition assigns node i the heap offset 64*i, so the
         // packed window starts at outer_base + 64*i, not at outer_base.
         ASSERT_EQ(node.task.packed_buffer_base, static_cast<void *>(heap.base() + static_cast<size_t>(i) * 64));

--- a/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
+++ b/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
@@ -31,6 +31,15 @@ namespace {
 constexpr uint64_t WINDOW = 64;  // stands in for the ring capacity
 constexpr uint64_t SUBMITTED = 5;
 
+// The per-task argument shape these tests write. Deliberately far below every cap, so
+// the compacted pools are a small fraction of the mirror's and the difference is
+// visible in the shipped byte count. The fanin stride is what the orchestrator
+// advances by — a whole number of cache lines, since a region has to start on one.
+constexpr int32_t TENSORS_PER_TASK = 2;
+constexpr int32_t SCALARS_PER_TASK = 3;
+constexpr int32_t FANIN_PER_TASK = 4;
+constexpr int32_t FANIN_STRIDE = static_cast<int32_t>(ARG_POOL_ALIGN / sizeof(int32_t));
+
 // A buffer aligned the way both the arena mirror and the device SM base are;
 // PTO2TaskSlotState is alignas(64) and every segment offset is a multiple of
 // PTO2_ALIGN_SIZE.
@@ -72,9 +81,27 @@ public:
         ring.completion_flags = completion_flags();
         (void)off;
 
+        // Each live slot takes a packed region in each pool, exactly as the
+        // orchestrator's bump cursors hand them out, and gets content that identifies
+        // the slot so the compaction can be checked element by element.
         for (uint64_t i = 0; i < SUBMITTED; ++i) {
             descriptors()[i].task_id = PTO2TaskId::make(0, static_cast<uint32_t>(i));
-            payloads()[i].tensor_count = static_cast<int32_t>(100 + i);
+            payloads()[i].tensor_count = TENSORS_PER_TASK;
+            payloads()[i].scalar_count = SCALARS_PER_TASK;
+            payloads()[i].fanin_count = FANIN_PER_TASK;
+            payloads()[i].bind_regions(
+                tensor_pool() + i * TENSORS_PER_TASK, scalar_pool() + i * SCALARS_PER_TASK,
+                fanin_pool() + i * FANIN_STRIDE
+            );
+            for (int32_t j = 0; j < TENSORS_PER_TASK; ++j) {
+                payloads()[i].tensor_data()[j].buffer.addr = 0x1000 + i * 0x10 + j;
+            }
+            for (int32_t j = 0; j < SCALARS_PER_TASK; ++j) {
+                payloads()[i].scalar_data()[j] = 0x3000 + i * 0x10 + j;
+            }
+            for (int32_t j = 0; j < FANIN_PER_TASK; ++j) {
+                payloads()[i].fanin_data()[j] = static_cast<int32_t>(0x50 + i * 0x10 + j);
+            }
             slot_states()[i].last_consumer_local_id = static_cast<int32_t>(i);
             slot_states()[i].graph_node_index = static_cast<int32_t>(200 + i);
             slot_states()[i].bind_buffers(&payloads()[i], &descriptors()[i]);
@@ -96,6 +123,15 @@ public:
             image_.base() + pto2_sm_layout::ring_segment_offsets(WINDOW).payloads
         );
     }
+    ChipTensor *tensor_pool() {
+        return reinterpret_cast<ChipTensor *>(image_.base() + pto2_sm_layout::ring_segment_offsets(WINDOW).tensor_pool);
+    }
+    uint64_t *scalar_pool() {
+        return reinterpret_cast<uint64_t *>(image_.base() + pto2_sm_layout::ring_segment_offsets(WINDOW).scalar_pool);
+    }
+    int32_t *fanin_pool() {
+        return reinterpret_cast<int32_t *>(image_.base() + pto2_sm_layout::ring_segment_offsets(WINDOW).fanin_pool);
+    }
     PTO2TaskSlotState *slot_states() {
         return reinterpret_cast<PTO2TaskSlotState *>(
             image_.base() + pto2_sm_layout::ring_segment_offsets(WINDOW).slot_states
@@ -111,28 +147,35 @@ private:
     AlignedImage image_;
 };
 
+// What a bind of `submitted` tasks put in the pools, given the per-task shape the
+// Mirror writes. This is the same arithmetic the orchestrator's cursors perform.
+inline pto2_sm_layout::BindUsage usage_for(uint64_t submitted) {
+    return pto2_sm_layout::BindUsage{
+        submitted,
+        submitted * static_cast<uint64_t>(FANIN_STRIDE),
+        submitted * static_cast<uint64_t>(TENSORS_PER_TASK),
+        submitted * static_cast<uint64_t>(SCALARS_PER_TASK),
+    };
+}
+
 struct Compacted {
     AlignedImage image;
     uint64_t bytes;
-    uint64_t stride;
+    pto2_sm_layout::BindUsage used;
 
-    explicit Compacted(
-        Mirror &mirror, uint64_t submitted = SUBMITTED, uint64_t payload_stride = sizeof(PTO2TaskPayload)
-    ) :
-        image(
-            pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::live_slot_pitch(submitted), payload_stride).end, 0xAA
-        ),
+    explicit Compacted(Mirror &mirror, uint64_t submitted = SUBMITTED) :
+        image(pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::image_extents(usage_for(submitted))).end, 0xAA),
         bytes(0),
-        stride(payload_stride) {
-        bytes = pto2_sm_layout::compact_live_image(mirror.base(), WINDOW, submitted, payload_stride, image.base());
+        used(usage_for(submitted)) {
+        bytes = pto2_sm_layout::compact_live_image(mirror.base(), WINDOW, used, image.base());
     }
 
     pto2_sm_layout::PTO2RingSegmentOffsets off(uint64_t submitted = SUBMITTED) const {
-        return pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::live_slot_pitch(submitted), stride);
+        return pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::image_extents(usage_for(submitted)));
     }
 
     PTO2TaskPayload *payload_at(uint64_t i) {
-        return reinterpret_cast<PTO2TaskPayload *>(image.base() + off().payloads + i * stride);
+        return reinterpret_cast<PTO2TaskPayload *>(image.base() + off().payloads) + i;
     }
     PTO2TaskDescriptor *descriptors() {
         return reinterpret_cast<PTO2TaskDescriptor *>(image.base() + off().descriptors);
@@ -152,7 +195,7 @@ TEST(HbgSmCompaction, ShipsOnlyTheLivePrefix) {
     Mirror mirror;
     Compacted compacted(mirror);
 
-    EXPECT_EQ(compacted.bytes, pto2_sm_layout::ring_segment_offsets(SUBMITTED).end);
+    EXPECT_EQ(compacted.bytes, compacted.off().end);
     EXPECT_LT(compacted.bytes, pto2_sm_layout::ring_segment_offsets(WINDOW).end);
 }
 
@@ -162,7 +205,8 @@ TEST(HbgSmCompaction, CarriesEveryLiveSlotsContent) {
 
     for (uint64_t i = 0; i < SUBMITTED; ++i) {
         EXPECT_EQ(compacted.descriptors()[i].task_id.local(), i) << "slot " << i;
-        EXPECT_EQ(compacted.payload_at(i)->tensor_count, static_cast<int32_t>(100 + i)) << "slot " << i;
+        EXPECT_EQ(compacted.payload_at(i)->tensor_count, TENSORS_PER_TASK) << "slot " << i;
+        EXPECT_EQ(compacted.payload_at(i)->tensor_data()[0].buffer.addr, 0x1000 + i * 0x10) << "slot " << i;
         EXPECT_EQ(compacted.slot_states()[i].last_consumer_local_id, static_cast<int32_t>(i)) << "slot " << i;
         EXPECT_EQ(compacted.slot_states()[i].graph_node_index, static_cast<int32_t>(200 + i)) << "slot " << i;
         EXPECT_EQ(compacted.completion_flags()[i].load(std::memory_order_relaxed), static_cast<uint8_t>(i & 1))
@@ -196,7 +240,10 @@ TEST(HbgSmCompaction, BindingsSurviveTheCopyToTheDevice) {
 
     AlignedImage landed(compacted.bytes);
     std::memcpy(landed.base(), compacted.image.base(), compacted.bytes);
-    const auto off = pto2_sm_layout::ring_segment_offsets(SUBMITTED);
+    // The image's own layout, not the mirror's. The four slot-pitched offsets happen
+    // to agree between the two, but reading them off the mirror overload here would
+    // stop being true the moment a pool moved ahead of them.
+    const auto off = compacted.off();
     auto *slots = reinterpret_cast<PTO2TaskSlotState *>(landed.base() + off.slot_states);
     auto *payloads = reinterpret_cast<PTO2TaskPayload *>(landed.base() + off.payloads);
     auto *descriptors = reinterpret_cast<PTO2TaskDescriptor *>(landed.base() + off.descriptors);
@@ -221,54 +268,131 @@ TEST(HbgSmCompaction, LeavesNoHostPointerInTheHeader) {
     EXPECT_EQ(ring.completion_flags, nullptr);
 }
 
-// A bind that submits nothing still ships its header and still attaches.
+// A bind that submits nothing still ships its header and still attaches. Its pools
+// are empty, so what travels is the header plus one slot's worth of pitch — far below
+// the mirror, whose pools are dimensioned for the whole window.
 TEST(HbgSmCompaction, ZeroSubmittedShipsTheHeaderAlone) {
     Mirror mirror;
     Compacted compacted(mirror, /*submitted=*/0);
 
-    EXPECT_EQ(compacted.bytes, pto2_sm_layout::ring_segment_offsets(1).end);
+    EXPECT_EQ(compacted.bytes, compacted.off(0).end);
+    EXPECT_LT(compacted.bytes, pto2_sm_layout::ring_segment_offsets(1).end);
     auto &ring = reinterpret_cast<const PTO2SharedMemoryHeader *>(compacted.image.base())->ring;
     EXPECT_EQ(ring.task_window_size, WINDOW);
     EXPECT_EQ(ring.task_descriptors, nullptr);
 }
 
-// The image strides its payload array by the widest task in the bind, not by the
-// type. Everything a task reads is a prefix of its payload, so a narrower stride
-// carries the same information in fewer bytes.
-TEST(HbgSmCompaction, CompactedStrideShipsFewerBytesAndStillResolves) {
+// The pools ship what the bind used, not what the mirror is dimensioned for. That
+// is the same property the payload stride used to carry, moved to the pools: fewer
+// bytes, and every argument still resolves.
+TEST(HbgSmCompaction, PackedPoolsShipFewerBytesAndStillResolve) {
     Mirror mirror;
-    for (uint64_t i = 0; i < SUBMITTED; ++i) {
-        mirror.payloads()[i].tensor_count = 2;
-        mirror.payloads()[i].scalar_count = 1;
-        mirror.payloads()[i].tensors[0].buffer.addr = 0x1000 + i;
-        mirror.payloads()[i].tensors[1].buffer.addr = 0x2000 + i;
-        mirror.payloads()[i].scalars[0] = 0x3000 + i;
-    }
+    Compacted compacted(mirror);
 
-    const uint64_t stride = pto2_sm_layout::shipped_payload_stride(2);
-    ASSERT_LT(stride, sizeof(PTO2TaskPayload));
-    ASSERT_EQ(stride % PTO2_ALIGN_SIZE, 0u);
-
-    Compacted compacted(mirror, SUBMITTED, stride);
-    EXPECT_LT(compacted.bytes, pto2_sm_layout::ring_segment_offsets(SUBMITTED).end);
+    // The mirror's pools cover WINDOW tasks at their full caps; the image's cover
+    // SUBMITTED tasks at the shape they actually used.
+    EXPECT_LT(compacted.bytes, pto2_sm_layout::ring_segment_offsets(WINDOW).end);
 
     for (uint64_t i = 0; i < SUBMITTED; ++i) {
         PTO2TaskPayload *shipped = compacted.payload_at(i);
-        EXPECT_EQ(shipped->tensor_count, 2) << "slot " << i;
-        EXPECT_EQ(shipped->scalar_count, 1) << "slot " << i;
-        EXPECT_EQ(shipped->tensors[0].buffer.addr, 0x1000 + i) << "slot " << i;
-        EXPECT_EQ(shipped->tensors[1].buffer.addr, 0x2000 + i) << "slot " << i;
-        EXPECT_EQ(shipped->scalars[0], 0x3000 + i) << "slot " << i;
-        // The binding has to follow the compacted stride, not the type's.
+        EXPECT_EQ(shipped->tensor_count, TENSORS_PER_TASK) << "slot " << i;
+        EXPECT_EQ(shipped->scalar_count, SCALARS_PER_TASK) << "slot " << i;
+        EXPECT_EQ(shipped->fanin_count, FANIN_PER_TASK) << "slot " << i;
+        // Every element resolves through the re-taken delta, and lands on this slot's
+        // own region rather than a neighbour's.
+        for (int32_t j = 0; j < TENSORS_PER_TASK; ++j) {
+            EXPECT_EQ(shipped->tensor_data()[j].buffer.addr, 0x1000 + i * 0x10 + j) << "slot " << i << " arg " << j;
+        }
+        for (int32_t j = 0; j < SCALARS_PER_TASK; ++j) {
+            EXPECT_EQ(shipped->scalar_data()[j], 0x3000 + i * 0x10 + j) << "slot " << i << " arg " << j;
+        }
+        for (int32_t j = 0; j < FANIN_PER_TASK; ++j) {
+            EXPECT_EQ(shipped->fanin_data()[j], static_cast<int32_t>(0x50 + i * 0x10 + j))
+                << "slot " << i << " arg " << j;
+        }
         EXPECT_EQ(compacted.slot_states()[i].payload.get(), shipped) << "slot " << i;
     }
 }
 
-// A stride covering the whole array is the identity case, and must not be exceeded:
-// the type is the widest an image can ever be.
-TEST(HbgSmCompaction, StrideNeverExceedsTheType) {
-    EXPECT_EQ(pto2_sm_layout::shipped_payload_stride(MAX_TENSOR_ARGS), sizeof(PTO2TaskPayload));
-    EXPECT_EQ(pto2_sm_layout::shipped_payload_stride(MAX_TENSOR_ARGS * 4), sizeof(PTO2TaskPayload));
-    EXPECT_EQ(pto2_sm_layout::shipped_payload_stride(0), offsetof(PTO2TaskPayload, tensors));
-    EXPECT_EQ(pto2_sm_layout::shipped_payload_stride(-1), offsetof(PTO2TaskPayload, tensors));
+// A region's delta is only correct for the layout it was taken in, so the restack has
+// to re-take it. Proof: every shipped region lies inside the image's own pools, which
+// the mirror's addresses could not satisfy.
+TEST(HbgSmCompaction, RebindsEveryArgumentRegionInsideTheImage) {
+    Mirror mirror;
+    Compacted compacted(mirror);
+
+    const auto off = compacted.off();
+    const char *base = compacted.image.base();
+    const char *tensor_begin = base + off.tensor_pool;
+    const char *tensor_end = tensor_begin + compacted.used.tensor_elems * sizeof(ChipTensor);
+    const char *scalar_begin = base + off.scalar_pool;
+    const char *scalar_end = scalar_begin + compacted.used.scalar_elems * sizeof(uint64_t);
+    const char *fanin_begin = base + off.fanin_pool;
+    const char *fanin_end = fanin_begin + compacted.used.fanin_elems * sizeof(int32_t);
+
+    for (uint64_t i = 0; i < SUBMITTED; ++i) {
+        PTO2TaskPayload *shipped = compacted.payload_at(i);
+        const char *t = reinterpret_cast<const char *>(shipped->tensor_data());
+        const char *s = reinterpret_cast<const char *>(shipped->scalar_data());
+        const char *f = reinterpret_cast<const char *>(shipped->fanin_data());
+        EXPECT_GE(t, tensor_begin) << "slot " << i;
+        EXPECT_LT(t, tensor_end) << "slot " << i;
+        EXPECT_GE(s, scalar_begin) << "slot " << i;
+        EXPECT_LT(s, scalar_end) << "slot " << i;
+        EXPECT_GE(f, fanin_begin) << "slot " << i;
+        EXPECT_LT(f, fanin_end) << "slot " << i;
+    }
+}
+
+// An outer GRAPH task binds only a fanin region: its boundary arguments travel inside
+// the submission image and both argument counts are 0. The restack must carry that
+// unbound state through rather than resolving it to the pool base, which is what the
+// consumers' count guards assume.
+TEST(HbgSmCompaction, UnboundRegionsStayUnbound) {
+    Mirror mirror;
+    // Slot 2 stands in for the outer GRAPH task.
+    constexpr uint64_t GRAPH_SLOT = 2;
+    mirror.payloads()[GRAPH_SLOT].tensor_count = 0;
+    mirror.payloads()[GRAPH_SLOT].scalar_count = 0;
+    mirror.payloads()[GRAPH_SLOT].bind_regions(nullptr, nullptr, mirror.fanin_pool() + GRAPH_SLOT * FANIN_STRIDE);
+
+    Compacted compacted(mirror);
+
+    PTO2TaskPayload *shipped = compacted.payload_at(GRAPH_SLOT);
+    EXPECT_EQ(shipped->tensor_data(), nullptr);
+    EXPECT_EQ(shipped->scalar_data(), nullptr);
+    // Its fanin region still resolves, and still inside the image.
+    const char *f = reinterpret_cast<const char *>(shipped->fanin_data());
+    EXPECT_GE(f, compacted.image.base() + compacted.off().fanin_pool);
+    EXPECT_LT(f, compacted.image.base() + compacted.off().tensor_pool);
+    for (int32_t j = 0; j < FANIN_PER_TASK; ++j) {
+        EXPECT_EQ(shipped->fanin_data()[j], static_cast<int32_t>(0x50 + GRAPH_SLOT * 0x10 + j)) << "arg " << j;
+    }
+    // Its neighbours are untouched by the unbound slot.
+    EXPECT_EQ(compacted.payload_at(1)->tensor_data()[0].buffer.addr, 0x1000 + 1 * 0x10);
+    EXPECT_EQ(compacted.payload_at(3)->tensor_data()[0].buffer.addr, 0x1000 + 3 * 0x10);
+}
+
+// A slot names its payload, and a payload names its regions, by an int32 delta, so
+// neither the mirror nor the image may span more than that reach. `init_per_ring` and
+// `attach_populated` each reject a layout that does; what is checked here is the
+// arithmetic they test — that the default capacity is comfortably inside the bound, and
+// that the layout is what decides where the bound falls. Growing a segment enough to
+// put the default capacity out of reach fails here.
+TEST(HbgSmCompaction, LayoutStaysWithinDeltaReach) {
+    Mirror mirror;
+    Compacted compacted(mirror);
+    EXPECT_LT(compacted.bytes, static_cast<uint64_t>(INT32_MAX));
+
+    constexpr uint64_t REACH = static_cast<uint64_t>(INT32_MAX);
+    EXPECT_LE(pto2_sm_layout::ring_segment_offsets(PTO2_TASK_WINDOW_SIZE).end, REACH);
+
+    // The bound is a property of the layout, not of the capacity alone: there is a
+    // capacity past which the mirror no longer fits, and it is above the default.
+    uint64_t window = PTO2_TASK_WINDOW_SIZE;
+    while (window <= (UINT64_MAX / 2) && pto2_sm_layout::ring_segment_offsets(window).end <= REACH) {
+        window *= 2;
+    }
+    EXPECT_GT(window, static_cast<uint64_t>(PTO2_TASK_WINDOW_SIZE));
+    EXPECT_GT(pto2_sm_layout::ring_segment_offsets(window).end, REACH);
 }


### PR DESCRIPTION
## Summary

`PTO2TaskPayload` carried three fixed-capacity arrays sized by the argument caps —
`fanin_local_ids[PTO2_MAX_FANIN]`, `scalars[MAX_SCALAR_ARGS]`, `tensors[MAX_TENSOR_ARGS]`,
4864 bytes. #1947 made the tensor array shippable at less than its width by moving it last
and striding the image by the bind's **widest** task. Two costs remained: a narrow task
still paid the widest task's stride, and the fanin array did not participate at all.

The arrays move into pool segments, and a payload names each region by a `SelfRelativePtr`
— the same int32 delta representation #1947 introduced for a slot's payload and descriptor.
`sizeof(PTO2TaskPayload)` becomes a fixed **192 bytes**, independent of all three caps, and
the image carries what a bind actually used rather than what its widest task implies.

## Review order

Three commits, smallest first. The first is independent of the rest and can be cherry-picked.

| | churn | |
| --- | ---: | --- |
| `a9c4b9c7` | 12 | **Fixes ut-cpp on `main`**, which is currently red — see below |
| `510c5271` | 224 | `SelfRelativePtr` gets its own header; the two arches stop carrying a copy each. Class body unchanged |
| `7c1fabb5` | 1896 | The payload pools. a2a3 and a5 are mirrors, so ~940 lines of it is duplication |

## Measured, DeepSeek-V4 flash decode (a2a3, 129 tasks / 86 GRAPH tasks)

| | reserved by a per-task-cap layout | this bind actually uses |
| --- | ---: | ---: |
| fanin ids | 16,512 | **1,664** |
| tensors | 4,128 | **151** |
| scalars | 2,064 | **72** |

The 151-against-4,128 spread is why striding by the widest task leaves most of the
reservation unused: the tasks average 1.17 tensors.

> These numbers, and the earlier `arena_h2d` timings, were measured on the pre-restructure
> revision (`ec49b166`). The byte accounting is unchanged by the restructure — the pool
> extents are the same cursors — but the onboard run has not been repeated on this head.
> See **Testing**.

## What this retires

- **`payload_stride` / `shipped_payload_stride`**. A fixed-size payload makes the image's
  payload segment one `memcpy` instead of one per task — that loop existed only because the
  payload was variable-length. On dsv4 the restack goes from 133 `memcpy` calls to 8.
- **`node_stride` / `graph_node_stride`**. `GraphNodeStorage` goes back to being
  type-strided, and `node_at()` back to indexing. A Graph node's regions live in its
  execution storage, sized by the Definition's arg-table counts and indexed by each node's
  own `tensor_offset` / `scalar_offset`.
- **`runtime->sm_payload_stride` → `sm_image_bytes`**. The device cannot recompute an image
  whose pool extents are the bind's cursors, and needs no pool base either: a payload
  resolves its own regions. Same one `uint64` across the boundary, more direct meaning.

H2D stays at one copy. The pools are segments of the image, so they are filled by host-side
`memcpy` into the same upload buffer and ride the existing arena copy. The ring header that
crosses to the device keeps its 192 bytes: the pool bases are orchestrator state, because
nothing on the device resolves one.

## Load-bearing details

- **Deltas are re-taken in `compact_live_image`**, which re-pitches the segments and
  therefore changes those distances — exactly as it already re-takes the slot bindings. Only
  the device copy is delta-invariant, because it moves a field and its target together.
- **The fanin cursor advances when the count is published**, not at bind: `PTO2FaninBuilder`
  appends and dedups producers after the region is bound. The cursor equality asserted there
  doubles as a re-entrancy check on that window.
- **Every region is cache-line aligned** so `init()`'s round-up scalar memcpy stays inside
  the task's own region and keeps its branch-free form.
- **Regions are exposed first-element-first**, not per element: a store through an unrelated
  pointer in a loop body defeats hoisting of the delta load, and `build_payload`'s `args[]`
  writes are exactly that.
- **An outer GRAPH task binds only a fanin region.** Its boundary arguments travel inside the
  submission image and `graph_reset_outer_payload` zeroes both argument counts, so it needs
  no tensor or scalar region. An unbound region survives the restack unbound, which every
  consumer's count guard assumes; a UT holds that.
- **`init_per_ring` rejects a ring capacity whose mirror is past an int32 delta's reach**,
  before it considers the region's own size — no region makes such a capacity usable. Image
  extents never exceed mirror extents, so that one check also bounds the shipped image;
  `attach_populated` re-tests it device-side. `set()` leaves a field unbound rather than
  truncating, so an out-of-reach pool would otherwise read back as null and be dereferenced.
- **The payload is asserted trivially copyable and standard layout**, per the wire-struct
  rule. A deleted special member is still trivial, so `SelfRelativePtr` costs the payload
  neither property — but without the assertion a future member could, while
  `compact_live_image` kept `memcpy`ing it.

## Two pre-existing breakages fixed

- `tests/ut/cpp/common/test_hbg_graph_cache.cpp` assigns a raw pointer to a
  `SelfRelativePtr` at two of five sites, which has not compiled since #1947 deleted that
  operator. Reproduced on a clean `a5c6093d`, so **ut-cpp is currently red on `main`** — the
  two affected tests are #1941's boundary-scalar-pool regressions, so #1941 and #1947 likely
  missed each other on rebase. This is commit `a9c4b9c7`, deliberately separable.
- Two `std::lock_guard` uses become `std::scoped_lock`; clang-tidy checks a modified file in
  full and `modernize-use-scoped-lock` rejects them.

## Also fixed while here

- `prefetch()` warmed `this + 512`, the early-dispatch block's old home, which is past the
  end of a 192-byte payload. Removed, and `init`'s comment naming that offset corrected.
- `GraphNodeStorage`'s two new layout assertions were `sizeof % alignof`, which every type
  satisfies. They now state what the pools need: a node entry at least `ChipTensor`-aligned,
  and a tensor stride that keeps the scalar pool aligned.
- `BindArenaH2d`'s 96-byte attribute buffer would truncate the three added pool counts on a
  large bind.

## Testing

- 8 variants build (a2a3/a5 × sim/onboard × hbg/tmrb), including ccec for the AICore gated path
- C++ UT **114/114**. The compaction UT is rewritten for pools: packed-pool shipping,
  per-region rebinding inside the image, unbound regions surviving unbound, layout delta
  reach. The unbound-region case was confirmed to fail with its guard removed
- a2a3/a5 byte-for-byte arch parity verified against the merge base, per file
- **Not re-run on this head:** the a2a3 onboard suite and the dsv4 host-construction path.
  Both passed on `ec49b166` (34 + 2 onboard, 3 rounds × 2 ranks) before the restructure,
  which removed the boundary pools and moved the pool bases out of the ring header. Worth a
  hardware pass before merge.
