### PR TITLE
host_build_graph: remove GraphSubmission from graph execution

### DIFF
--- a/docs/dfx/hbg-bind-phases.md
+++ b/docs/dfx/hbg-bind-phases.md
@@ -28,8 +28,8 @@ line per segment per pass at `LOG_TIMING`:
 | `args` | staging the caller's host tensors and mapping them for host access |
 | `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init` | arena layout, GM heap and shared-memory bring-up |
 | `host_orch` | **all** orchestration: every task submitted, every Graph node recorded, the Definition built |
-| `graph_upload` | uploading the Definition objects, and laying out the replay boundary images the `arena_h2d` copy carries |
-| `arena_h2d` | the one H2D of the pass: the arena's copied zone, the shared-memory image and the Graph submission block |
+| `graph_upload` | uploading the Definition objects and binding every Graph task to the one with its key |
+| `arena_h2d` | the one H2D of the pass: the arena's copied zone and the shared-memory image |
 | `host_view_close` | unmapping the host views taken in `args` |
 
 The **control plane** is `host_orch + graph_upload + relocate + sm_h2d +
@@ -151,13 +151,14 @@ minima taken across passes; that total belongs to no pass and can point the wron
 way (see below).
 
 **A segment's `bytes=` is what that segment itself copied, so no copy is counted
-twice.** `graph_upload` counts the Definition objects it uploads and nothing
-else; `arena_h2d`'s `bytes=` is its single copy, exactly partitioned by the
-`copied=`, `sm=` and `subs=` beside it. The Graph submission block is that
-`subs=` — `graph_upload` lays the block out but copies none of it, so it is
-absent from that segment's `bytes=`. (`shared_mem`'s `bytes=` is the image the
-arena grew to hold, which `arena_h2d` then ships as `sm=`; that is the one figure
-two segments both report, and neither is a copy count of the other.)
+twice.** `graph_upload` counts the Definition objects it uploads, which are all it
+copies; `arena_h2d`'s `bytes=` is its single copy, exactly partitioned by the
+`copied=` and `sm=` beside it. A Graph invocation's boundary values are inside that
+`sm=`: they live in the outer Graph task's ordinary argument pools, so they travel
+with every other task's arguments rather than as a population of their own.
+(`shared_mem`'s `bytes=` is the image the arena grew to hold, which `arena_h2d`
+then ships as `sm=`; that is the one figure two segments both report, and neither
+is a copy count of the other.)
 
 The first pass of each rank is warm-up and belongs in neither statistic; drop it
 explicitly rather than letting a minimum quietly exclude it.
@@ -335,8 +336,9 @@ meant to outlive it.
 upload was restructured: `graph_upload`'s `bytes=` then also counted the Graph
 submission block, `sm_h2d` was still a copy of its own, and `arena_h2d` was the
 copied zone alone. A run today emits no `sm_h2d`, counts only the Definition
-objects in `graph_upload`, and ships all three regions in `arena_h2d` — so the
-same case reports different figures for the same work.
+objects in `graph_upload`, carries no submission block at all, and ships both
+remaining regions in `arena_h2d` — so the same case reports different figures for
+the same work.
 
 Three of these deserve reading together. `host_orch` is the whole story on dsv4 —
 839 `submit_task`, 743 `record_node` and 272 `alloc_tensors` per bind against qwen's

--- a/docs/investigations/2026-08-hbg-graph-definition-single-upload.md
+++ b/docs/investigations/2026-08-hbg-graph-definition-single-upload.md
@@ -15,6 +15,14 @@ dominant costs outside pure orchestration:
 Both trace to one design choice: the Definition travels *inside* every
 submission image.
 
+The follow-up Graph execution layout now removes the per-occurrence
+`GraphSubmission` object entirely. Boundary values use the outer task's existing
+compact payload pools, while `GraphExecution` and node storage are initialized
+in the outer Graph task's heap tail on device. The outer slot's existing
+`graph_context` points first to the shared Definition and then to the localized
+execution. The measurements below describe the earlier shared-Definition step
+and remain its historical baseline.
+
 ## Change
 
 `254f924e` (measured by `4d434174`/`b8095e39`, enabled by `f868ac52`):

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -401,42 +401,21 @@ struct HostOrchEntryPoints {
     OrchestrationBindFunc bind{nullptr};
 };
 
-// One submission's place in the block: where its bytes come from, which outer task
-// reads it, and how far into the block it sits.
-struct StagedSubmission {
-    const std::byte *host_image;
-    PTO2TaskSlotState *outer_slot;
-    size_t bytes;
-    uint64_t offset;
-};
-
 // What the Definition pass copied to the device: the distinct objects, and their
-// bytes. The submission block is in neither — it is laid out here but travels in the
-// single arena H2D, which reports it as that segment's `subs=`.
+// bytes. Both are smaller than the run's Graph task count, which exceeds the object
+// count by the replay factor — one Definition serves every task with its key.
 struct DefinitionUploads {
     size_t count;
     uint64_t bytes;
 };
 
-// Validate every pending submission, bind it to its uploaded Definition, and lay
-// the block out. No device call and no device address: the block lands in the
-// runtime arena's tail, whose base is not known until that region is grown to fit
-// the shared-memory image as well.
-//
-// Submissions sit PTO2_ALIGN_SIZE apart. activation_gate is OR-ed by the outer task
-// and by the node path for the length of the graph, so two submissions sharing a
-// cache line would false-share on that word throughout.
-bool plan_graph_submissions(
-    const HostApi *api, GraphHostState &graph_state, std::vector<StagedSubmission> *staged, uint64_t *block_bytes,
-    DefinitionUploads *uploads
-) {
+// Upload each distinct Definition once, validate every outer Graph task against
+// it, and bind the task's existing graph_context to the device Definition. The
+// device initial classify replaces that pointer with an execution constructed in
+// the outer task's own heap.
+bool bind_graph_definitions(const HostApi *api, GraphHostState &graph_state, DefinitionUploads *uploads) {
     *uploads = DefinitionUploads{};
     const size_t count = graph_host_upload_count(graph_state);
-    // Pass 1: upload each distinct Definition once as a shared device object
-    // ([GraphDefinitionHeader][Definition image]) keyed by content identity.
-    // Submissions reference the object's GM address, so this pass completing
-    // before any submission is uploaded is what makes the reference safe —
-    // the device boots only after both passes.
     GraphHostDefinitionList definitions = graph_host_definitions(graph_state);
     struct UploadedDefinition {
         void *device_object;               // GM address; host must not dereference
@@ -471,63 +450,57 @@ bool plan_graph_submissions(
             LOG_ERROR("host-orch: failed to upload Graph Definition object");
             return false;
         }
-        definition_objects.emplace(definition->content_hash, UploadedDefinition{object, definition});
+        definition_objects.emplace(definition->full_key, UploadedDefinition{object, definition});
         uploads->count++;
         uploads->bytes += object_bytes;
     }
 
-    // Pass 2: validate every submission and lay the block out.
-    staged->reserve(count);
-    *block_bytes = 0;
     for (size_t index = 0; index < count; ++index) {
         std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
-        if (!upload.has_value() || upload->outer_slot == nullptr || upload->data == nullptr ||
-            upload->bytes < sizeof(GraphSubmission) || upload->outer_slot->task_kind != TaskKind::GRAPH ||
-            upload->outer_slot->task == nullptr) {
-            LOG_ERROR("host-orch: invalid pending Graph POD image");
+        if (!upload.has_value() || upload->outer_slot == nullptr || upload->outer_slot->task_kind != TaskKind::GRAPH ||
+            upload->outer_slot->task == nullptr || upload->outer_slot->payload == nullptr) {
+            LOG_ERROR("host-orch: invalid pending Graph task");
             return false;
         }
-        auto *submission = reinterpret_cast<GraphSubmission *>(upload->data);
-        if (!graph_submission_wire_size_valid(*submission, upload->bytes)) {
-            LOG_ERROR("host-orch: Graph submission size does not match its POD image");
+        auto object_it = definition_objects.find(upload->full_key);
+        if (object_it == definition_objects.end() || object_it->second.device_object == nullptr ||
+            object_it->second.host_view == nullptr ||
+            object_it->second.host_view->content_hash != upload->definition_hash) {
+            LOG_ERROR("host-orch: Graph task has no matching uploaded Definition object");
             return false;
         }
-        auto object_it = definition_objects.find(submission->definition_hash);
-        if (object_it == definition_objects.end() || object_it->second.device_object == nullptr) {
-            LOG_ERROR("host-orch: Graph submission has no uploaded Definition object");
-            return false;
-        }
-        // Checked against the host-side Definition image the device object was
-        // built from; the GM object itself is never dereferenced on the host.
-        // Execution storage needs no retained buffer: it is the tail of the
-        // outer task's own heap allocation, which graph_submit_definition sized
-        // to required_heap + execution_storage_bytes.
         const GraphDefinition *definition = object_it->second.host_view;
+        GraphExecutionStorageLayout storage_layout{};
         if (definition->task_count == 0 || definition->task_count > GRAPH_MAX_NODES ||
-            definition->full_key != submission->graph_key || definition->execution_storage_bytes == 0) {
-            LOG_ERROR("host-orch: invalid Graph Definition for submission");
+            definition->full_key != upload->full_key ||
+            !graph_execution_storage_layout(
+                static_cast<int32_t>(definition->task_count), definition->tensor_arg_count,
+                definition->scalar_arg_count, &storage_layout
+            ) ||
+            storage_layout.total_bytes != definition->execution_storage_bytes ||
+            upload->outer_slot->payload->tensor_count != static_cast<int32_t>(definition->boundary_count) ||
+            upload->outer_slot->payload->scalar_count != static_cast<int32_t>(definition->boundary_scalar_count)) {
+            LOG_ERROR("host-orch: invalid Graph Definition for task");
             return false;
         }
-        submission->definition_addr = reinterpret_cast<uint64_t>(object_it->second.device_object);
-        submission->local_execution = 0;
-        submission->activation_gate = 0;
-
-        staged->push_back({upload->data, upload->outer_slot, upload->bytes, *block_bytes});
-        *block_bytes += PTO2_ALIGN_UP(static_cast<uint64_t>(upload->bytes), PTO2_ALIGN_SIZE);
+        const uintptr_t outer_base = reinterpret_cast<uintptr_t>(upload->outer_slot->task->packed_buffer_base);
+        const uintptr_t outer_end = reinterpret_cast<uintptr_t>(upload->outer_slot->task->packed_buffer_end);
+        if (outer_end < outer_base || definition->required_heap > UINTPTR_MAX - outer_base ||
+            storage_layout.total_bytes > outer_end - outer_base ||
+            definition->required_heap > outer_end - outer_base - storage_layout.total_bytes) {
+            LOG_ERROR("host-orch: Graph runtime storage does not fit its outer task heap");
+            return false;
+        }
+        const uintptr_t storage_addr = outer_base + definition->required_heap;
+        if (storage_addr % alignof(GraphExecution) != 0) {
+            LOG_ERROR("host-orch: Graph runtime storage address is misaligned");
+            return false;
+        }
+        upload->outer_slot->graph_context = reinterpret_cast<GraphDefinition *>(
+            reinterpret_cast<uintptr_t>(object_it->second.device_object) + sizeof(GraphDefinitionHeader)
+        );
     }
     return true;
-}
-
-// Copy the planned block into `block_base` and point each outer task at the device
-// address its submission will occupy. The graph_context write lands in the host
-// shared-memory mirror, which has not been compacted or copied yet.
-void stage_graph_submissions(
-    const std::vector<StagedSubmission> &staged, char *block_base, const char *device_block_base
-) {
-    for (const StagedSubmission &entry : staged) {
-        std::memcpy(block_base + entry.offset, entry.host_image, entry.bytes);
-        entry.outer_slot->graph_context = const_cast<char *>(device_block_base) + entry.offset;
-    }
 }
 
 struct GraphHostStateBinding {
@@ -672,21 +645,18 @@ int32_t run_host_orchestration(
     // After the span closes: the reduction walks a few hundred records and emits
     // five markers, which must not be charged to the pass it measures.
 
-    // Uploads each distinct Definition as its own retained device object and lays
-    // out the submission block. The block itself is staged below, into the arena's
-    // second device tail, so nothing here allocates or copies it.
+    // Upload each distinct Definition as its own retained device object and bind
+    // every outer Graph task to it. Per-invocation data already lives in that
+    // task's payload regions and is copied with the shared-memory image below.
     const int64_t t_graph_ns = bind_now_ns();
     DefinitionUploads definition_uploads{};
-    std::vector<StagedSubmission> staged_submissions;
-    uint64_t submission_block_bytes = 0;
-    if (!plan_graph_submissions(api, *graph_state, &staged_submissions, &submission_block_bytes, &definition_uploads)) {
+    if (!bind_graph_definitions(api, *graph_state, &definition_uploads)) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
-        // `bytes` is what this segment copied: the Definition objects alone. The
-        // submission block is laid out here but copied by the arena H2D, which
-        // reports the same bytes as its own `subs=`. `defs` and `submissions` differ
-        // by the replay count — one Definition serves every submission with its key.
+        // `bytes` is what this segment copied: the Definition objects, which are all
+        // it copies. `defs` and `submissions` differ by the replay count — one
+        // Definition serves every Graph task with its key.
         char attrs[96];
         snprintf(
             attrs, sizeof(attrs), "defs=%zu bytes=%" PRIu64 " submissions=%zu", definition_uploads.count,
@@ -737,11 +707,9 @@ int32_t run_host_orchestration(
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         total_heap_size += eff_heap_sizes[r];
     }
-    // Two device tails past off_copied_end, in this order: the shared-memory image,
-    // then the Graph submission block. Both are per-run content of the region the
-    // device already owns, so neither needs an allocation of its own.
-    const uint64_t off_submissions = layout.off_copied_end + image_bytes;
-    const uint64_t device_arena_bytes = off_submissions + submission_block_bytes;
+    // The compact shared-memory image is the only per-run tail in the device
+    // arena. GraphExecution is initialized later in each outer Graph heap.
+    const uint64_t device_arena_bytes = layout.off_copied_end + image_bytes;
     if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, device_arena_bytes) != 0) {
         LOG_ERROR("host-orch: failed to commit %" PRIu64 " bytes of device runtime arena", device_arena_bytes);
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -760,22 +728,18 @@ int32_t run_host_orchestration(
         record_bind_phase(HostPhaseKind::BindSharedMem, t_sm_ns, attrs, image_bytes);
     }
 
-    // One host source for one copy: the copied zone, the shared-memory image, and
-    // the submission block, at exactly the offsets they occupy on the device.
+    // One host source for one copy: the copied zone and shared-memory image at
+    // exactly the offsets they occupy on the device.
     // Over-allocated and rounded up because every segment offset is
     // PTO2_ALIGN_SIZE-aligned and PTO2TaskSlotState is alignas(64), which a byte
     // vector's data() is not.
     const uint64_t copied_bytes = layout.off_copied_end - layout.off_copied_begin;
-    const uint64_t upload_bytes = copied_bytes + image_bytes + submission_block_bytes;
+    const uint64_t upload_bytes = copied_bytes + image_bytes;
     std::vector<std::byte> storage(upload_bytes + PTO2_ALIGN_SIZE, std::byte{0});
     char *upload_base = reinterpret_cast<char *>(
         (reinterpret_cast<uintptr_t>(storage.data()) + PTO2_ALIGN_SIZE - 1) &
         ~static_cast<uintptr_t>(PTO2_ALIGN_SIZE - 1)
     );
-
-    // Before the shared-memory mirror is compacted: this writes each outer task's
-    // graph_context into it, and compaction is what carries those slots.
-    stage_graph_submissions(staged_submissions, upload_base + copied_bytes + image_bytes, arena_dev + off_submissions);
 
     // The copied zone carries no host address: the orchestrator is host-only and
     // no device code may reach host memory through the image. Its work is done, so
@@ -798,10 +762,9 @@ int32_t run_host_orchestration(
         char attrs[224];
         snprintf(
             attrs, sizeof(attrs),
-            "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " subs=%" PRIu64 " args=%" PRIu64
-            "/%" PRIu64 "/%" PRIu64,
-            nt, upload_bytes, copied_bytes, image_bytes, submission_block_bytes, bind_usage.fanin_elems,
-            bind_usage.tensor_elems, bind_usage.scalar_elems
+            "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " args=%" PRIu64 "/%" PRIu64 "/%" PRIu64,
+            nt, upload_bytes, copied_bytes, image_bytes, bind_usage.fanin_elems, bind_usage.tensor_elems,
+            bind_usage.scalar_elems
         );
         record_bind_phase(HostPhaseKind::BindArenaH2d, t_h2d_ns, attrs, upload_bytes);
     }

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -492,7 +492,7 @@ bool bind_graph_definitions(const HostApi *api, GraphHostState &graph_state, Def
             return false;
         }
         const uintptr_t storage_addr = outer_base + definition->required_heap;
-        if (storage_addr % alignof(GraphExecution) != 0) {
+        if (storage_addr % alignof(GraphNodeStorage) != 0) {
             LOG_ERROR("host-orch: Graph runtime storage address is misaligned");
             return false;
         }

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -409,7 +409,8 @@ struct GraphRecording {
 
 struct GraphPendingUpload {
     PTO2TaskSlotState *outer_slot{nullptr};
-    std::vector<std::byte> image;
+    uint64_t full_key{0};
+    uint64_t definition_hash{0};
     bool deferred_heap{false};
 };
 
@@ -913,8 +914,8 @@ size_t graph_host_upload_count(const GraphHostState &state) { return state.pendi
 std::optional<GraphHostUpload> graph_host_upload(GraphHostState &state, size_t index) {
     if (index >= state.pending_uploads.size()) return std::nullopt;
     GraphPendingUpload &upload = state.pending_uploads[index];
-    if (upload.outer_slot == nullptr || upload.image.empty()) return std::nullopt;
-    return GraphHostUpload{upload.outer_slot, upload.image.data(), upload.image.size()};
+    if (upload.outer_slot == nullptr) return std::nullopt;
+    return GraphHostUpload{upload.outer_slot, upload.full_key, upload.definition_hash};
 }
 
 GraphHostDefinitionList graph_host_definitions(GraphHostState &state) {
@@ -1623,45 +1624,6 @@ void graph_reset_outer_payload(PTO2TaskPayload &payload) {
     payload.early_sync_drain_state.store(PTO2_EARLY_SYNC_DRAIN_NONE, std::memory_order_relaxed);
 }
 
-bool graph_prepare_submission_image(
-    uint64_t full_key, const GraphTaskArgs &args, std::vector<std::byte> *submission_image
-) {
-    if (submission_image == nullptr) return false;
-    const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphTensor));
-    const size_t tensor_bytes = static_cast<size_t>(args.tensor_count()) * sizeof(GraphTensor);
-    if (tensors_offset > UINT32_MAX || tensors_offset > UINT32_MAX - tensor_bytes) {
-        return false;
-    }
-    const size_t tensors_end = tensors_offset + tensor_bytes;
-    const size_t scalar_bytes = static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t);
-    const size_t scalars_offset = args.scalar_count() == 0 ? 0 : PTO2_ALIGN_UP(tensors_end, alignof(uint64_t));
-    const size_t total_bytes = args.scalar_count() == 0 ? tensors_end : scalars_offset + scalar_bytes;
-    if ((args.scalar_count() != 0 && (scalars_offset > UINT32_MAX || scalars_offset > UINT32_MAX - scalar_bytes)) ||
-        total_bytes > UINT32_MAX) {
-        return false;
-    }
-    submission_image->assign(total_bytes, std::byte{0});
-    auto *tensors = reinterpret_cast<GraphTensor *>(submission_image->data() + tensors_offset);
-    for (int32_t i = 0; i < args.tensor_count(); ++i)
-        tensors[i] = graph_tensor_pack(args.tensor(i).ref());
-    if (args.scalar_count() != 0) {
-        std::memcpy(
-            submission_image->data() + scalars_offset, args.scalar_data(),
-            static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t)
-        );
-    }
-
-    GraphSubmission submission{};
-    submission.graph_key = full_key;
-    submission.total_bytes = static_cast<uint32_t>(submission_image->size());
-    submission.tensors_offset = static_cast<uint32_t>(tensors_offset);
-    submission.tensor_count = static_cast<uint32_t>(args.tensor_count());
-    submission.scalars_offset = static_cast<uint32_t>(scalars_offset);
-    submission.scalar_count = static_cast<uint32_t>(args.scalar_count());
-    std::memcpy(submission_image->data(), &submission, sizeof(submission));
-    return true;
-}
-
 bool graph_submit_outer(
     PTO2OrchestratorState *orch, GraphHostState *state, uint64_t full_key, uint64_t definition_hash, int32_t owned_heap,
     bool defer_heap, const GraphTaskArgs &args, PTO2TaskId *submitted_id
@@ -1675,8 +1637,8 @@ bool graph_submit_outer(
     }
 
     GraphPendingUpload pending;
-    if (!graph_prepare_submission_image(full_key, args, &pending.image)) return false;
-    reinterpret_cast<GraphSubmission *>(pending.image.data())->definition_hash = definition_hash;
+    pending.full_key = full_key;
+    pending.definition_hash = definition_hash;
     pending.deferred_heap = defer_heap;
 
     DepInputs boundary_inputs{
@@ -1704,10 +1666,21 @@ bool graph_submit_outer(
     ring.completion_flags[allocation.slot].store(0, std::memory_order_relaxed);
 
     slot.bind_buffers(&payload, &task);
-    // An outer GRAPH task holds a real ring slot, so its fanin comes from the pool like
-    // any other task's. It has no tensor or scalar region: its boundary travels inside
-    // the submission image, and graph_reset_outer_payload zeroes both counts below.
-    payload.bind_regions(nullptr, nullptr, orch->fanin_pool + orch->fanin_pool_cursor);
+    // Graph boundaries use the same compact argument pools as ordinary tasks. The
+    // outer payload carries the invocation data; graph_context only names the
+    // shared Definition until device initialization replaces it with GraphExecution.
+    const uint64_t window = ring.task_window_size;
+    const int32_t tensor_slots =
+        static_cast<int32_t>(graph_boundary_tensor_pool_slots(static_cast<uint32_t>(args.tensor_count())));
+    const int32_t scalar_span = PTO2_ALIGN_UP(args.scalar_count(), ARG_POOL_ALIGN / (int32_t)sizeof(uint64_t));
+    debug_assert(static_cast<uint64_t>(orch->tensor_pool_cursor) + tensor_slots <= window * MAX_TENSOR_ARGS);
+    debug_assert(static_cast<uint64_t>(orch->scalar_pool_cursor) + scalar_span <= window * MAX_SCALAR_ARGS);
+    payload.bind_regions(
+        orch->tensor_pool + orch->tensor_pool_cursor, orch->scalar_pool + orch->scalar_pool_cursor,
+        orch->fanin_pool + orch->fanin_pool_cursor
+    );
+    orch->tensor_pool_cursor += tensor_slots;
+    orch->scalar_pool_cursor += scalar_span;
     slot.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
     slot.last_consumer_local_id = static_cast<int32_t>(task_id.local());
     slot.active_mask = ActiveMask{};
@@ -1722,6 +1695,17 @@ bool graph_submit_outer(
     task.packed_buffer_base = allocation.packed_base;
     task.packed_buffer_end = allocation.packed_end;
     graph_reset_outer_payload(payload);
+    payload.tensor_count = args.tensor_count();
+    payload.scalar_count = args.scalar_count();
+    auto *boundary_tensors = reinterpret_cast<GraphTensor *>(payload.tensor_data());
+    for (int32_t i = 0; i < args.tensor_count(); ++i)
+        new (&boundary_tensors[i]) GraphTensor{graph_tensor_pack(args.tensor(i).ref())};
+    if (args.scalar_count() != 0) {
+        std::memcpy(
+            payload.scalar_data(), args.scalar_data(),
+            PTO2_ALIGN_UP(static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t), ARG_POOL_ALIGN)
+        );
+    }
 
     PTO2FaninBuilder fanin_builder(orch, &payload, static_cast<int32_t>(task_id.local()), next_fanin_seen_epoch(orch));
     auto emit = [&](PTO2TaskId producer_id) -> bool {
@@ -1765,7 +1749,7 @@ bool graph_submit_outer(
     orch->fanin_pool_cursor += PTO2_ALIGN_UP(fanin_builder.count, ARG_POOL_ALIGN / (int32_t)sizeof(int32_t));
 
     pending.outer_slot = &slot;
-    state->pending_uploads.push_back(std::move(pending));
+    state->pending_uploads.push_back(pending);
     if (submitted_id != nullptr) *submitted_id = task_id;
 #if SIMPLER_DFX
     orch->tasks_submitted++;
@@ -1801,22 +1785,19 @@ bool graph_submit_pending_definition(
 bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostState *state, uint64_t *failed_key) {
     for (GraphPendingUpload &pending : state->pending_uploads) {
         if (!pending.deferred_heap) continue;
-        if (pending.image.size() < sizeof(GraphSubmission)) return false;
-        auto *submission = reinterpret_cast<GraphSubmission *>(pending.image.data());
-        auto definition_it = state->definitions.find(submission->graph_key);
+        auto definition_it = state->definitions.find(pending.full_key);
         const GraphDefinition *definition =
             definition_it == state->definitions.end() ? nullptr : graph_definition(definition_it->second);
         if (definition == nullptr || definition->execution_storage_bytes == 0 ||
             definition->required_heap > UINT64_MAX - definition->execution_storage_bytes ||
             pending.outer_slot == nullptr || pending.outer_slot->task == nullptr ||
-            pending.outer_slot->task_kind != TaskKind::GRAPH ||
-            !graph_submission_wire_size_valid(*submission, pending.image.size())) {
-            if (failed_key != nullptr) *failed_key = submission->graph_key;
+            pending.outer_slot->task_kind != TaskKind::GRAPH) {
+            if (failed_key != nullptr) *failed_key = pending.full_key;
             return false;
         }
         const uint64_t owned_heap = definition->required_heap + definition->execution_storage_bytes;
         if (owned_heap > static_cast<uint64_t>(INT32_MAX)) {
-            if (failed_key != nullptr) *failed_key = submission->graph_key;
+            if (failed_key != nullptr) *failed_key = pending.full_key;
             return false;
         }
         void *packed_base = nullptr;
@@ -1824,12 +1805,12 @@ bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostSt
         if (!orch->ring.task_allocator.reserve_deferred_heap(
                 static_cast<int32_t>(owned_heap), &packed_base, &packed_end
             )) {
-            if (failed_key != nullptr) *failed_key = submission->graph_key;
+            if (failed_key != nullptr) *failed_key = pending.full_key;
             return false;
         }
         pending.outer_slot->task->packed_buffer_base = packed_base;
         pending.outer_slot->task->packed_buffer_end = packed_end;
-        submission->definition_hash = definition->content_hash;
+        pending.definition_hash = definition->content_hash;
         pending.deferred_heap = false;
     }
     return true;

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -1636,6 +1636,24 @@ bool graph_submit_outer(
         return false;
     }
 
+    // The argument pools hold MAX_TENSOR_ARGS ChipTensors and MAX_SCALAR_ARGS scalars
+    // per window slot, a budget no CoreTaskArgs task can exceed. A Graph boundary is
+    // GraphTaskArgs-wide, so a wide one draws more than the single slot it occupies is
+    // worth — GraphBoundaryPool.WidestBoundaryExceedsOneSlotBudget pins how much. The
+    // cursors bump through a fixed mirror whose last segment is the scalar pool, so an
+    // overdraw writes past that mirror rather than merely exhausting a quota. Test it
+    // ahead of the slot claim and decline the Graph path, which leaves the caller to
+    // replay the block as ordinary tasks.
+    const uint64_t task_window = orch->sm_header->ring.task_window_size;
+    const int32_t tensor_slots =
+        static_cast<int32_t>(graph_boundary_tensor_pool_slots(static_cast<uint32_t>(args.tensor_count())));
+    const int32_t scalar_span = PTO2_ALIGN_UP(args.scalar_count(), ARG_POOL_ALIGN / (int32_t)sizeof(uint64_t));
+    if (static_cast<uint64_t>(orch->tensor_pool_cursor) + tensor_slots > task_window * MAX_TENSOR_ARGS ||
+        static_cast<uint64_t>(orch->scalar_pool_cursor) + scalar_span > task_window * MAX_SCALAR_ARGS) {
+        LOG_WARN("%s", "[GraphExecution] boundary exceeds the argument pools; using ordinary path");
+        return false;
+    }
+
     GraphPendingUpload pending;
     pending.full_key = full_key;
     pending.definition_hash = definition_hash;
@@ -1669,12 +1687,7 @@ bool graph_submit_outer(
     // Graph boundaries use the same compact argument pools as ordinary tasks. The
     // outer payload carries the invocation data; graph_context only names the
     // shared Definition until device initialization replaces it with GraphExecution.
-    const uint64_t window = ring.task_window_size;
-    const int32_t tensor_slots =
-        static_cast<int32_t>(graph_boundary_tensor_pool_slots(static_cast<uint32_t>(args.tensor_count())));
-    const int32_t scalar_span = PTO2_ALIGN_UP(args.scalar_count(), ARG_POOL_ALIGN / (int32_t)sizeof(uint64_t));
-    debug_assert(static_cast<uint64_t>(orch->tensor_pool_cursor) + tensor_slots <= window * MAX_TENSOR_ARGS);
-    debug_assert(static_cast<uint64_t>(orch->scalar_pool_cursor) + scalar_span <= window * MAX_SCALAR_ARGS);
+    // The preflight bounds both spans, so these cursors stay inside their pools.
     payload.bind_regions(
         orch->tensor_pool + orch->tensor_pool_cursor, orch->scalar_pool + orch->scalar_pool_cursor,
         orch->fanin_pool + orch->fanin_pool_cursor

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -410,8 +410,8 @@ struct PTO2TaskPayload {
         scalar_count = args.scalar_count();
 
         // bind_regions must already have run: an unbound region reads back as null and
-        // the stores below would go through it. A count of zero needs no region, which
-        // is how an outer GRAPH task reaches here with both unbound.
+        // the stores below would go through it. A count of zero needs no region, so a
+        // task with neither argument kind may leave both unbound.
         debug_assert(args.tensor_count() == 0 || tensor_data() != nullptr);
         debug_assert(args.scalar_count() == 0 || scalar_data() != nullptr);
 

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_types.h
@@ -690,13 +690,11 @@ using CoreTaskArgs = Arg<MAX_TENSOR_ARGS, MAX_SCALAR_ARGS>;
 inline constexpr uint32_t GRAPH_MAX_TENSOR_ARGS = 128;
 inline constexpr uint32_t GRAPH_MAX_SCALAR_ARGS = 64;
 
-// Boundary arguments of a Graph. Sized independently of CoreTaskArgs because a
-// Graph boundary never becomes a task payload — graph_reset_outer_payload zeroes
-// the outer GRAPH task's tensor_count. The boundary ships to the device inside
-// the submission image; materialize stages each node's own arguments from it,
-// bounded per node by CoreTaskArgs capacity, and bind_graph_topology bounds the
-// pool itself by these constants. Widening them costs orchestration stack and
-// submission-image bytes, not PTO2TaskPayload.
+// Boundary arguments of a Graph. Sized independently of CoreTaskArgs because the
+// outer GRAPH payload carries the whole boundary, while materialize stages only
+// one node's arguments at a time. The compact boundary values live in that
+// payload's argument-pool regions, so widening these caps costs pool bytes only
+// for Graphs that use them; PTO2TaskPayload itself stays fixed-size.
 using GraphTaskArgs = Arg<GRAPH_MAX_TENSOR_ARGS, GRAPH_MAX_SCALAR_ARGS>;
 
 // ChipTaskArgs — chip-level entry-arg holding the orchestration entry's

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -957,17 +957,13 @@ struct PTO2SchedulerState {
     }
 
     // Push every materialized-and-published root that has not been routed yet,
-    // once the outer Graph task's external dependency gate (0x2) has opened.
+    // once the outer Graph task's external dependencies are ready.
     // route_cursor makes this idempotent, so it composes across the per-slice
     // calls during materialization and the final call at the activation meet;
     // each root reaches the ready queue exactly once. Non-roots are never pushed
     // here — they reach the ready queue through their producers' wake list.
     int32_t graph_route_ready_roots(GraphExecution &execution) {
-        if (execution.outer_slot == nullptr) return 0;
-        GraphSubmission *submission = graph_submission_from_slot(*execution.outer_slot);
-        if (submission == nullptr || (__atomic_load_n(&submission->activation_gate, __ATOMIC_ACQUIRE) & 0x2u) == 0) {
-            return 0;
-        }
+        if (execution.outer_slot == nullptr || !graph_execution_external_ready(execution)) return 0;
         const int32_t published = execution.published_nodes.load(std::memory_order_acquire);
         int32_t routed = 0;
         while (true) {
@@ -1010,10 +1006,7 @@ struct PTO2SchedulerState {
     }
 
     int32_t activate_prepared_graph(GraphExecution &execution) {
-        GraphExecutionState expected = GraphExecutionState::PREPARED;
-        if (!execution.state.compare_exchange_strong(
-                expected, GraphExecutionState::ACTIVE, std::memory_order_acq_rel, std::memory_order_acquire
-            )) {
+        if (!graph_execution_transition(execution, GraphExecutionState::PREPARED, GraphExecutionState::ACTIVE)) {
             return 0;
         }
         return graph_route_ready_roots(execution);
@@ -1023,30 +1016,25 @@ struct PTO2SchedulerState {
         PTO2TaskSlotState &outer_slot, int32_t max_nodes = GRAPH_MATERIALIZE_SLICE_NODES,
         int32_t *nodes_materialized = nullptr
     ) {
-        GraphSubmission *submission = graph_submission_from_slot(outer_slot);
-        if (submission == nullptr) return GraphMaterializeResult::INVALID;
-        GraphExecution *execution = graph_execution_localize(outer_slot);
-        if (execution == nullptr) {
-            return graph_submission_execution_initializing(*submission) ? GraphMaterializeResult::BUSY :
-                                                                          GraphMaterializeResult::INVALID;
-        }
+        GraphExecution *execution = graph_execution_from_outer_slot(outer_slot);
+        if (execution == nullptr) return GraphMaterializeResult::INVALID;
         const int32_t before = execution->materialized_nodes;
         const GraphMaterializeResult result =
             graph_execution_materialize_slice(outer_slot, *execution, max_nodes, nodes_materialized);
         if (result == GraphMaterializeResult::PENDING || result == GraphMaterializeResult::PREPARED) {
             graph_incremental_publish(*execution, before, execution->materialized_nodes);
         }
-        if (result == GraphMaterializeResult::PREPARED && graph_submission_signal(*submission, 0x1)) {
+        if (result == GraphMaterializeResult::PREPARED && graph_execution_external_ready(*execution)) {
             activate_prepared_graph(*execution);
         }
         return result;
     }
 
     int32_t activate_graph_task(PTO2TaskSlotState &outer_slot) {
-        GraphSubmission *submission = graph_submission_from_slot(outer_slot);
-        if (submission == nullptr || !graph_submission_signal(*submission, 0x2)) return 0;
-        GraphExecution *execution = graph_submission_local_execution(*submission);
-        return execution == nullptr ? 0 : activate_prepared_graph(*execution);
+        GraphExecution *execution = graph_execution_from_outer_slot(outer_slot);
+        if (execution == nullptr) return 0;
+        graph_execution_signal_external_ready(*execution);
+        return activate_prepared_graph(*execution);
     }
 
     struct TaskCompletionOutcome {
@@ -1081,9 +1069,9 @@ struct PTO2SchedulerState {
         }
         // Incremental activation routes a node before the graph reaches ACTIVE, so a
         // node can legitimately complete while the graph is still MATERIALIZING or
-        // PREPARED. Only SUBMITTED (execution not yet localized) and COMPLETED
+        // PREPARED. Only SUBMITTED (execution not yet bound) and COMPLETED
         // (execution already retired) are invalid states for a node completion.
-        const GraphExecutionState graph_state = execution->state.load(std::memory_order_acquire);
+        const GraphExecutionState graph_state = graph_execution_state(*execution);
         if (graph_state < GraphExecutionState::MATERIALIZING || graph_state > GraphExecutionState::ACTIVE) {
             outcome.error_code = PTO2_ERROR_INVALID_ARGS;
             return outcome;

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -1142,6 +1142,7 @@ void SchedulerContext::classify_partition(int32_t thread_idx, int32_t nthreads) 
         }
         PTO2TaskSlotState &slot = ring.get_slot_state_by_task_id(id);
         if (slot.task_kind == TaskKind::GRAPH) {
+            if (graph_execution_localize(slot) == nullptr) slot.graph_context = nullptr;
             if (!sched_->push_graph_prepare(&slot, slot.task->task_id.raw, thread_idx)) return;
         }
         int32_t state = sched_->classify_fanin_state(&slot);

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -1298,7 +1298,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
         // Graph control work never consumes an AICore. External dependency
         // readiness and bounded definition materialization progress
-        // independently, then meet at GraphSubmission::activation_gate.
+        // independently, then meet in GraphExecution::state.
         //
         // Keep this ahead of dummy/regular dispatch so a ready Graph can expose
         // its root nodes without waiting for an otherwise unrelated dispatch

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -497,7 +497,7 @@ bool bind_graph_definitions(const HostApi *api, GraphHostState &graph_state, Def
             return false;
         }
         const uintptr_t storage_addr = outer_base + definition->required_heap;
-        if (storage_addr % alignof(GraphExecution) != 0) {
+        if (storage_addr % alignof(GraphNodeStorage) != 0) {
             LOG_ERROR("host-orch: Graph runtime storage address is misaligned");
             return false;
         }

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -406,42 +406,21 @@ struct HostOrchEntryPoints {
 // an index from its own block. The bytes the host wrote are therefore the bytes
 // the device schedules, with no on-device or pre-copy pointer fixup.
 
-// One submission's place in the block: where its bytes come from, which outer task
-// reads it, and how far into the block it sits.
-struct StagedSubmission {
-    const std::byte *host_image;
-    PTO2TaskSlotState *outer_slot;
-    size_t bytes;
-    uint64_t offset;
-};
-
 // What the Definition pass copied to the device: the distinct objects, and their
-// bytes. The submission block is in neither — it is laid out here but travels in the
-// single arena H2D, which reports it as that segment's `subs=`.
+// bytes. Both are smaller than the run's Graph task count, which exceeds the object
+// count by the replay factor — one Definition serves every task with its key.
 struct DefinitionUploads {
     size_t count;
     uint64_t bytes;
 };
 
-// Validate every pending submission, bind it to its uploaded Definition, and lay
-// the block out. No device call and no device address: the block lands in the
-// runtime arena's tail, whose base is not known until that region is grown to fit
-// the shared-memory image as well.
-//
-// Submissions sit PTO2_ALIGN_SIZE apart. activation_gate is OR-ed by the outer task
-// and by the node path for the length of the graph, so two submissions sharing a
-// cache line would false-share on that word throughout.
-bool plan_graph_submissions(
-    const HostApi *api, GraphHostState &graph_state, std::vector<StagedSubmission> *staged, uint64_t *block_bytes,
-    DefinitionUploads *uploads
-) {
+// Upload each distinct Definition once, validate every outer Graph task against
+// it, and bind the task's existing graph_context to the device Definition. The
+// device initial classify replaces that pointer with an execution constructed in
+// the outer task's own heap.
+bool bind_graph_definitions(const HostApi *api, GraphHostState &graph_state, DefinitionUploads *uploads) {
     *uploads = DefinitionUploads{};
     const size_t count = graph_host_upload_count(graph_state);
-    // Pass 1: upload each distinct Definition once as a shared device object
-    // ([GraphDefinitionHeader][Definition image]) keyed by content identity.
-    // Submissions reference the object's GM address, so this pass completing
-    // before any submission is uploaded is what makes the reference safe —
-    // the device boots only after both passes.
     GraphHostDefinitionList definitions = graph_host_definitions(graph_state);
     struct UploadedDefinition {
         void *device_object;               // GM address; host must not dereference
@@ -476,63 +455,57 @@ bool plan_graph_submissions(
             LOG_ERROR("host-orch: failed to upload Graph Definition object");
             return false;
         }
-        definition_objects.emplace(definition->content_hash, UploadedDefinition{object, definition});
+        definition_objects.emplace(definition->full_key, UploadedDefinition{object, definition});
         uploads->count++;
         uploads->bytes += object_bytes;
     }
 
-    // Pass 2: validate every submission and lay the block out.
-    staged->reserve(count);
-    *block_bytes = 0;
     for (size_t index = 0; index < count; ++index) {
         std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
-        if (!upload.has_value() || upload->outer_slot == nullptr || upload->data == nullptr ||
-            upload->bytes < sizeof(GraphSubmission) || upload->outer_slot->task_kind != TaskKind::GRAPH ||
-            upload->outer_slot->task == nullptr) {
-            LOG_ERROR("host-orch: invalid pending Graph POD image");
+        if (!upload.has_value() || upload->outer_slot == nullptr || upload->outer_slot->task_kind != TaskKind::GRAPH ||
+            upload->outer_slot->task == nullptr || upload->outer_slot->payload == nullptr) {
+            LOG_ERROR("host-orch: invalid pending Graph task");
             return false;
         }
-        auto *submission = reinterpret_cast<GraphSubmission *>(upload->data);
-        if (!graph_submission_wire_size_valid(*submission, upload->bytes)) {
-            LOG_ERROR("host-orch: Graph submission size does not match its POD image");
+        auto object_it = definition_objects.find(upload->full_key);
+        if (object_it == definition_objects.end() || object_it->second.device_object == nullptr ||
+            object_it->second.host_view == nullptr ||
+            object_it->second.host_view->content_hash != upload->definition_hash) {
+            LOG_ERROR("host-orch: Graph task has no matching uploaded Definition object");
             return false;
         }
-        auto object_it = definition_objects.find(submission->definition_hash);
-        if (object_it == definition_objects.end() || object_it->second.device_object == nullptr) {
-            LOG_ERROR("host-orch: Graph submission has no uploaded Definition object");
-            return false;
-        }
-        // Checked against the host-side Definition image the device object was
-        // built from; the GM object itself is never dereferenced on the host.
-        // Execution storage needs no retained buffer: it is the tail of the
-        // outer task's own heap allocation, which graph_submit_definition sized
-        // to required_heap + execution_storage_bytes.
         const GraphDefinition *definition = object_it->second.host_view;
+        GraphExecutionStorageLayout storage_layout{};
         if (definition->task_count == 0 || definition->task_count > GRAPH_MAX_NODES ||
-            definition->full_key != submission->graph_key || definition->execution_storage_bytes == 0) {
-            LOG_ERROR("host-orch: invalid Graph Definition for submission");
+            definition->full_key != upload->full_key ||
+            !graph_execution_storage_layout(
+                static_cast<int32_t>(definition->task_count), definition->tensor_arg_count,
+                definition->scalar_arg_count, &storage_layout
+            ) ||
+            storage_layout.total_bytes != definition->execution_storage_bytes ||
+            upload->outer_slot->payload->tensor_count != static_cast<int32_t>(definition->boundary_count) ||
+            upload->outer_slot->payload->scalar_count != static_cast<int32_t>(definition->boundary_scalar_count)) {
+            LOG_ERROR("host-orch: invalid Graph Definition for task");
             return false;
         }
-        submission->definition_addr = reinterpret_cast<uint64_t>(object_it->second.device_object);
-        submission->local_execution = 0;
-        submission->activation_gate = 0;
-
-        staged->push_back({upload->data, upload->outer_slot, upload->bytes, *block_bytes});
-        *block_bytes += PTO2_ALIGN_UP(static_cast<uint64_t>(upload->bytes), PTO2_ALIGN_SIZE);
+        const uintptr_t outer_base = reinterpret_cast<uintptr_t>(upload->outer_slot->task->packed_buffer_base);
+        const uintptr_t outer_end = reinterpret_cast<uintptr_t>(upload->outer_slot->task->packed_buffer_end);
+        if (outer_end < outer_base || definition->required_heap > UINTPTR_MAX - outer_base ||
+            storage_layout.total_bytes > outer_end - outer_base ||
+            definition->required_heap > outer_end - outer_base - storage_layout.total_bytes) {
+            LOG_ERROR("host-orch: Graph runtime storage does not fit its outer task heap");
+            return false;
+        }
+        const uintptr_t storage_addr = outer_base + definition->required_heap;
+        if (storage_addr % alignof(GraphExecution) != 0) {
+            LOG_ERROR("host-orch: Graph runtime storage address is misaligned");
+            return false;
+        }
+        upload->outer_slot->graph_context = reinterpret_cast<GraphDefinition *>(
+            reinterpret_cast<uintptr_t>(object_it->second.device_object) + sizeof(GraphDefinitionHeader)
+        );
     }
     return true;
-}
-
-// Copy the planned block into `block_base` and point each outer task at the device
-// address its submission will occupy. The graph_context write lands in the host
-// shared-memory mirror, which has not been compacted or copied yet.
-void stage_graph_submissions(
-    const std::vector<StagedSubmission> &staged, char *block_base, const char *device_block_base
-) {
-    for (const StagedSubmission &entry : staged) {
-        std::memcpy(block_base + entry.offset, entry.host_image, entry.bytes);
-        entry.outer_slot->graph_context = const_cast<char *>(device_block_base) + entry.offset;
-    }
 }
 
 struct GraphHostStateBinding {
@@ -688,21 +661,18 @@ int32_t run_host_orchestration(
     // After the span closes: the reduction walks a few hundred records and emits
     // five markers, which must not be charged to the pass it measures.
 
-    // Uploads each distinct Definition as its own retained device object and lays
-    // out the submission block. The block itself is staged below, into the arena's
-    // second device tail, so nothing here allocates or copies it.
+    // Upload each distinct Definition as its own retained device object and bind
+    // every outer Graph task to it. Per-invocation data already lives in that
+    // task's payload regions and is copied with the shared-memory image below.
     const int64_t t_graph_ns = bind_now_ns();
     DefinitionUploads definition_uploads{};
-    std::vector<StagedSubmission> staged_submissions;
-    uint64_t submission_block_bytes = 0;
-    if (!plan_graph_submissions(api, *graph_state, &staged_submissions, &submission_block_bytes, &definition_uploads)) {
+    if (!bind_graph_definitions(api, *graph_state, &definition_uploads)) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
-        // `bytes` is what this segment copied: the Definition objects alone. The
-        // submission block is laid out here but copied by the arena H2D, which
-        // reports the same bytes as its own `subs=`. `defs` and `submissions` differ
-        // by the replay count — one Definition serves every submission with its key.
+        // `bytes` is what this segment copied: the Definition objects, which are all
+        // it copies. `defs` and `submissions` differ by the replay count — one
+        // Definition serves every Graph task with its key.
         char attrs[96];
         snprintf(
             attrs, sizeof(attrs), "defs=%zu bytes=%" PRIu64 " submissions=%zu", definition_uploads.count,
@@ -753,11 +723,9 @@ int32_t run_host_orchestration(
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         total_heap_size += eff_heap_sizes[r];
     }
-    // Two device tails past off_copied_end, in this order: the shared-memory image,
-    // then the Graph submission block. Both are per-run content of the region the
-    // device already owns, so neither needs an allocation of its own.
-    const uint64_t off_submissions = layout.off_copied_end + image_bytes;
-    const uint64_t device_arena_bytes = off_submissions + submission_block_bytes;
+    // The compact shared-memory image is the only per-run tail in the device
+    // arena. GraphExecution is initialized later in each outer Graph heap.
+    const uint64_t device_arena_bytes = layout.off_copied_end + image_bytes;
     if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, device_arena_bytes) != 0) {
         LOG_ERROR("host-orch: failed to commit %" PRIu64 " bytes of device runtime arena", device_arena_bytes);
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -776,22 +744,18 @@ int32_t run_host_orchestration(
         record_bind_phase(HostPhaseKind::BindSharedMem, t_sm_ns, attrs, image_bytes);
     }
 
-    // One host source for one copy: the copied zone, the shared-memory image, and
-    // the submission block, at exactly the offsets they occupy on the device.
+    // One host source for one copy: the copied zone and shared-memory image at
+    // exactly the offsets they occupy on the device.
     // Over-allocated and rounded up because every segment offset is
     // PTO2_ALIGN_SIZE-aligned and PTO2TaskSlotState is alignas(64), which a byte
     // vector's data() is not.
     const uint64_t copied_bytes = layout.off_copied_end - layout.off_copied_begin;
-    const uint64_t upload_bytes = copied_bytes + image_bytes + submission_block_bytes;
+    const uint64_t upload_bytes = copied_bytes + image_bytes;
     std::vector<std::byte> storage(upload_bytes + PTO2_ALIGN_SIZE, std::byte{0});
     char *upload_base = reinterpret_cast<char *>(
         (reinterpret_cast<uintptr_t>(storage.data()) + PTO2_ALIGN_SIZE - 1) &
         ~static_cast<uintptr_t>(PTO2_ALIGN_SIZE - 1)
     );
-
-    // Before the shared-memory mirror is compacted: this writes each outer task's
-    // graph_context into it, and compaction is what carries those slots.
-    stage_graph_submissions(staged_submissions, upload_base + copied_bytes + image_bytes, arena_dev + off_submissions);
 
     // The copied zone carries no host address: the orchestrator is host-only and
     // no device code may reach host memory through the image. Its work is done, so
@@ -814,10 +778,9 @@ int32_t run_host_orchestration(
         char attrs[224];
         snprintf(
             attrs, sizeof(attrs),
-            "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " subs=%" PRIu64 " args=%" PRIu64
-            "/%" PRIu64 "/%" PRIu64,
-            nt, upload_bytes, copied_bytes, image_bytes, submission_block_bytes, bind_usage.fanin_elems,
-            bind_usage.tensor_elems, bind_usage.scalar_elems
+            "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " args=%" PRIu64 "/%" PRIu64 "/%" PRIu64,
+            nt, upload_bytes, copied_bytes, image_bytes, bind_usage.fanin_elems, bind_usage.tensor_elems,
+            bind_usage.scalar_elems
         );
         record_bind_phase(HostPhaseKind::BindArenaH2d, t_h2d_ns, attrs, upload_bytes);
     }

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -409,7 +409,8 @@ struct GraphRecording {
 
 struct GraphPendingUpload {
     PTO2TaskSlotState *outer_slot{nullptr};
-    std::vector<std::byte> image;
+    uint64_t full_key{0};
+    uint64_t definition_hash{0};
     bool deferred_heap{false};
 };
 
@@ -913,8 +914,8 @@ size_t graph_host_upload_count(const GraphHostState &state) { return state.pendi
 std::optional<GraphHostUpload> graph_host_upload(GraphHostState &state, size_t index) {
     if (index >= state.pending_uploads.size()) return std::nullopt;
     GraphPendingUpload &upload = state.pending_uploads[index];
-    if (upload.outer_slot == nullptr || upload.image.empty()) return std::nullopt;
-    return GraphHostUpload{upload.outer_slot, upload.image.data(), upload.image.size()};
+    if (upload.outer_slot == nullptr) return std::nullopt;
+    return GraphHostUpload{upload.outer_slot, upload.full_key, upload.definition_hash};
 }
 
 GraphHostDefinitionList graph_host_definitions(GraphHostState &state) {
@@ -1623,45 +1624,6 @@ void graph_reset_outer_payload(PTO2TaskPayload &payload) {
     payload.early_sync_drain_state.store(PTO2_EARLY_SYNC_DRAIN_NONE, std::memory_order_relaxed);
 }
 
-bool graph_prepare_submission_image(
-    uint64_t full_key, const GraphTaskArgs &args, std::vector<std::byte> *submission_image
-) {
-    if (submission_image == nullptr) return false;
-    const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphTensor));
-    const size_t tensor_bytes = static_cast<size_t>(args.tensor_count()) * sizeof(GraphTensor);
-    if (tensors_offset > UINT32_MAX || tensors_offset > UINT32_MAX - tensor_bytes) {
-        return false;
-    }
-    const size_t tensors_end = tensors_offset + tensor_bytes;
-    const size_t scalar_bytes = static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t);
-    const size_t scalars_offset = args.scalar_count() == 0 ? 0 : PTO2_ALIGN_UP(tensors_end, alignof(uint64_t));
-    const size_t total_bytes = args.scalar_count() == 0 ? tensors_end : scalars_offset + scalar_bytes;
-    if ((args.scalar_count() != 0 && (scalars_offset > UINT32_MAX || scalars_offset > UINT32_MAX - scalar_bytes)) ||
-        total_bytes > UINT32_MAX) {
-        return false;
-    }
-    submission_image->assign(total_bytes, std::byte{0});
-    auto *tensors = reinterpret_cast<GraphTensor *>(submission_image->data() + tensors_offset);
-    for (int32_t i = 0; i < args.tensor_count(); ++i)
-        tensors[i] = graph_tensor_pack(args.tensor(i).ref());
-    if (args.scalar_count() != 0) {
-        std::memcpy(
-            submission_image->data() + scalars_offset, args.scalar_data(),
-            static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t)
-        );
-    }
-
-    GraphSubmission submission{};
-    submission.graph_key = full_key;
-    submission.total_bytes = static_cast<uint32_t>(submission_image->size());
-    submission.tensors_offset = static_cast<uint32_t>(tensors_offset);
-    submission.tensor_count = static_cast<uint32_t>(args.tensor_count());
-    submission.scalars_offset = static_cast<uint32_t>(scalars_offset);
-    submission.scalar_count = static_cast<uint32_t>(args.scalar_count());
-    std::memcpy(submission_image->data(), &submission, sizeof(submission));
-    return true;
-}
-
 bool graph_submit_outer(
     PTO2OrchestratorState *orch, GraphHostState *state, uint64_t full_key, uint64_t definition_hash, int32_t owned_heap,
     bool defer_heap, const GraphTaskArgs &args, PTO2TaskId *submitted_id
@@ -1675,8 +1637,8 @@ bool graph_submit_outer(
     }
 
     GraphPendingUpload pending;
-    if (!graph_prepare_submission_image(full_key, args, &pending.image)) return false;
-    reinterpret_cast<GraphSubmission *>(pending.image.data())->definition_hash = definition_hash;
+    pending.full_key = full_key;
+    pending.definition_hash = definition_hash;
     pending.deferred_heap = defer_heap;
 
     DepInputs boundary_inputs{
@@ -1704,10 +1666,21 @@ bool graph_submit_outer(
     ring.completion_flags[allocation.slot].store(0, std::memory_order_relaxed);
 
     slot.bind_buffers(&payload, &task);
-    // An outer GRAPH task holds a real ring slot, so its fanin comes from the pool like
-    // any other task's. It has no tensor or scalar region: its boundary travels inside
-    // the submission image, and graph_reset_outer_payload zeroes both counts below.
-    payload.bind_regions(nullptr, nullptr, orch->fanin_pool + orch->fanin_pool_cursor);
+    // Graph boundaries use the same compact argument pools as ordinary tasks. The
+    // outer payload carries the invocation data; graph_context only names the
+    // shared Definition until device initialization replaces it with GraphExecution.
+    const uint64_t window = ring.task_window_size;
+    const int32_t tensor_slots =
+        static_cast<int32_t>(graph_boundary_tensor_pool_slots(static_cast<uint32_t>(args.tensor_count())));
+    const int32_t scalar_span = PTO2_ALIGN_UP(args.scalar_count(), ARG_POOL_ALIGN / (int32_t)sizeof(uint64_t));
+    debug_assert(static_cast<uint64_t>(orch->tensor_pool_cursor) + tensor_slots <= window * MAX_TENSOR_ARGS);
+    debug_assert(static_cast<uint64_t>(orch->scalar_pool_cursor) + scalar_span <= window * MAX_SCALAR_ARGS);
+    payload.bind_regions(
+        orch->tensor_pool + orch->tensor_pool_cursor, orch->scalar_pool + orch->scalar_pool_cursor,
+        orch->fanin_pool + orch->fanin_pool_cursor
+    );
+    orch->tensor_pool_cursor += tensor_slots;
+    orch->scalar_pool_cursor += scalar_span;
     slot.task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
     slot.last_consumer_local_id = static_cast<int32_t>(task_id.local());
     slot.active_mask = ActiveMask{};
@@ -1722,6 +1695,17 @@ bool graph_submit_outer(
     task.packed_buffer_base = allocation.packed_base;
     task.packed_buffer_end = allocation.packed_end;
     graph_reset_outer_payload(payload);
+    payload.tensor_count = args.tensor_count();
+    payload.scalar_count = args.scalar_count();
+    auto *boundary_tensors = reinterpret_cast<GraphTensor *>(payload.tensor_data());
+    for (int32_t i = 0; i < args.tensor_count(); ++i)
+        new (&boundary_tensors[i]) GraphTensor{graph_tensor_pack(args.tensor(i).ref())};
+    if (args.scalar_count() != 0) {
+        std::memcpy(
+            payload.scalar_data(), args.scalar_data(),
+            PTO2_ALIGN_UP(static_cast<size_t>(args.scalar_count()) * sizeof(uint64_t), ARG_POOL_ALIGN)
+        );
+    }
 
     PTO2FaninBuilder fanin_builder(orch, &payload, static_cast<int32_t>(task_id.local()), next_fanin_seen_epoch(orch));
     auto emit = [&](PTO2TaskId producer_id) -> bool {
@@ -1765,7 +1749,7 @@ bool graph_submit_outer(
     orch->fanin_pool_cursor += PTO2_ALIGN_UP(fanin_builder.count, ARG_POOL_ALIGN / (int32_t)sizeof(int32_t));
 
     pending.outer_slot = &slot;
-    state->pending_uploads.push_back(std::move(pending));
+    state->pending_uploads.push_back(pending);
     if (submitted_id != nullptr) *submitted_id = task_id;
 #if SIMPLER_DFX
     orch->tasks_submitted++;
@@ -1801,22 +1785,19 @@ bool graph_submit_pending_definition(
 bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostState *state, uint64_t *failed_key) {
     for (GraphPendingUpload &pending : state->pending_uploads) {
         if (!pending.deferred_heap) continue;
-        if (pending.image.size() < sizeof(GraphSubmission)) return false;
-        auto *submission = reinterpret_cast<GraphSubmission *>(pending.image.data());
-        auto definition_it = state->definitions.find(submission->graph_key);
+        auto definition_it = state->definitions.find(pending.full_key);
         const GraphDefinition *definition =
             definition_it == state->definitions.end() ? nullptr : graph_definition(definition_it->second);
         if (definition == nullptr || definition->execution_storage_bytes == 0 ||
             definition->required_heap > UINT64_MAX - definition->execution_storage_bytes ||
             pending.outer_slot == nullptr || pending.outer_slot->task == nullptr ||
-            pending.outer_slot->task_kind != TaskKind::GRAPH ||
-            !graph_submission_wire_size_valid(*submission, pending.image.size())) {
-            if (failed_key != nullptr) *failed_key = submission->graph_key;
+            pending.outer_slot->task_kind != TaskKind::GRAPH) {
+            if (failed_key != nullptr) *failed_key = pending.full_key;
             return false;
         }
         const uint64_t owned_heap = definition->required_heap + definition->execution_storage_bytes;
         if (owned_heap > static_cast<uint64_t>(INT32_MAX)) {
-            if (failed_key != nullptr) *failed_key = submission->graph_key;
+            if (failed_key != nullptr) *failed_key = pending.full_key;
             return false;
         }
         void *packed_base = nullptr;
@@ -1824,12 +1805,12 @@ bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostSt
         if (!orch->ring.task_allocator.reserve_deferred_heap(
                 static_cast<int32_t>(owned_heap), &packed_base, &packed_end
             )) {
-            if (failed_key != nullptr) *failed_key = submission->graph_key;
+            if (failed_key != nullptr) *failed_key = pending.full_key;
             return false;
         }
         pending.outer_slot->task->packed_buffer_base = packed_base;
         pending.outer_slot->task->packed_buffer_end = packed_end;
-        submission->definition_hash = definition->content_hash;
+        pending.definition_hash = definition->content_hash;
         pending.deferred_heap = false;
     }
     return true;

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -1636,6 +1636,24 @@ bool graph_submit_outer(
         return false;
     }
 
+    // The argument pools hold MAX_TENSOR_ARGS ChipTensors and MAX_SCALAR_ARGS scalars
+    // per window slot, a budget no CoreTaskArgs task can exceed. A Graph boundary is
+    // GraphTaskArgs-wide, so a wide one draws more than the single slot it occupies is
+    // worth — GraphBoundaryPool.WidestBoundaryExceedsOneSlotBudget pins how much. The
+    // cursors bump through a fixed mirror whose last segment is the scalar pool, so an
+    // overdraw writes past that mirror rather than merely exhausting a quota. Test it
+    // ahead of the slot claim and decline the Graph path, which leaves the caller to
+    // replay the block as ordinary tasks.
+    const uint64_t task_window = orch->sm_header->ring.task_window_size;
+    const int32_t tensor_slots =
+        static_cast<int32_t>(graph_boundary_tensor_pool_slots(static_cast<uint32_t>(args.tensor_count())));
+    const int32_t scalar_span = PTO2_ALIGN_UP(args.scalar_count(), ARG_POOL_ALIGN / (int32_t)sizeof(uint64_t));
+    if (static_cast<uint64_t>(orch->tensor_pool_cursor) + tensor_slots > task_window * MAX_TENSOR_ARGS ||
+        static_cast<uint64_t>(orch->scalar_pool_cursor) + scalar_span > task_window * MAX_SCALAR_ARGS) {
+        LOG_WARN("%s", "[GraphExecution] boundary exceeds the argument pools; using ordinary path");
+        return false;
+    }
+
     GraphPendingUpload pending;
     pending.full_key = full_key;
     pending.definition_hash = definition_hash;
@@ -1669,12 +1687,7 @@ bool graph_submit_outer(
     // Graph boundaries use the same compact argument pools as ordinary tasks. The
     // outer payload carries the invocation data; graph_context only names the
     // shared Definition until device initialization replaces it with GraphExecution.
-    const uint64_t window = ring.task_window_size;
-    const int32_t tensor_slots =
-        static_cast<int32_t>(graph_boundary_tensor_pool_slots(static_cast<uint32_t>(args.tensor_count())));
-    const int32_t scalar_span = PTO2_ALIGN_UP(args.scalar_count(), ARG_POOL_ALIGN / (int32_t)sizeof(uint64_t));
-    debug_assert(static_cast<uint64_t>(orch->tensor_pool_cursor) + tensor_slots <= window * MAX_TENSOR_ARGS);
-    debug_assert(static_cast<uint64_t>(orch->scalar_pool_cursor) + scalar_span <= window * MAX_SCALAR_ARGS);
+    // The preflight bounds both spans, so these cursors stay inside their pools.
     payload.bind_regions(
         orch->tensor_pool + orch->tensor_pool_cursor, orch->scalar_pool + orch->scalar_pool_cursor,
         orch->fanin_pool + orch->fanin_pool_cursor

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -410,8 +410,8 @@ struct PTO2TaskPayload {
         scalar_count = args.scalar_count();
 
         // bind_regions must already have run: an unbound region reads back as null and
-        // the stores below would go through it. A count of zero needs no region, which
-        // is how an outer GRAPH task reaches here with both unbound.
+        // the stores below would go through it. A count of zero needs no region, so a
+        // task with neither argument kind may leave both unbound.
         debug_assert(args.tensor_count() == 0 || tensor_data() != nullptr);
         debug_assert(args.scalar_count() == 0 || scalar_data() != nullptr);
 

--- a/src/a5/runtime/host_build_graph/runtime/pto_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_types.h
@@ -689,13 +689,11 @@ using CoreTaskArgs = Arg<MAX_TENSOR_ARGS, MAX_SCALAR_ARGS>;
 inline constexpr uint32_t GRAPH_MAX_TENSOR_ARGS = 128;
 inline constexpr uint32_t GRAPH_MAX_SCALAR_ARGS = 64;
 
-// Boundary arguments of a Graph. Sized independently of CoreTaskArgs because a
-// Graph boundary never becomes a task payload — graph_reset_outer_payload zeroes
-// the outer GRAPH task's tensor_count. The boundary ships to the device inside
-// the submission image; materialize stages each node's own arguments from it,
-// bounded per node by CoreTaskArgs capacity, and bind_graph_topology bounds the
-// pool itself by these constants. Widening them costs orchestration stack and
-// submission-image bytes, not PTO2TaskPayload.
+// Boundary arguments of a Graph. Sized independently of CoreTaskArgs because the
+// outer GRAPH payload carries the whole boundary, while materialize stages only
+// one node's arguments at a time. The compact boundary values live in that
+// payload's argument-pool regions, so widening these caps costs pool bytes only
+// for Graphs that use them; PTO2TaskPayload itself stays fixed-size.
 using GraphTaskArgs = Arg<GRAPH_MAX_TENSOR_ARGS, GRAPH_MAX_SCALAR_ARGS>;
 
 // ChipTaskArgs — chip-level entry-arg holding the orchestration entry's

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/pto_scheduler.h
@@ -957,17 +957,13 @@ struct PTO2SchedulerState {
     }
 
     // Push every materialized-and-published root that has not been routed yet,
-    // once the outer Graph task's external dependency gate (0x2) has opened.
+    // once the outer Graph task's external dependencies are ready.
     // route_cursor makes this idempotent, so it composes across the per-slice
     // calls during materialization and the final call at the activation meet;
     // each root reaches the ready queue exactly once. Non-roots are never pushed
     // here — they reach the ready queue through their producers' wake list.
     int32_t graph_route_ready_roots(GraphExecution &execution) {
-        if (execution.outer_slot == nullptr) return 0;
-        GraphSubmission *submission = graph_submission_from_slot(*execution.outer_slot);
-        if (submission == nullptr || (__atomic_load_n(&submission->activation_gate, __ATOMIC_ACQUIRE) & 0x2u) == 0) {
-            return 0;
-        }
+        if (execution.outer_slot == nullptr || !graph_execution_external_ready(execution)) return 0;
         const int32_t published = execution.published_nodes.load(std::memory_order_acquire);
         int32_t routed = 0;
         while (true) {
@@ -1010,10 +1006,7 @@ struct PTO2SchedulerState {
     }
 
     int32_t activate_prepared_graph(GraphExecution &execution) {
-        GraphExecutionState expected = GraphExecutionState::PREPARED;
-        if (!execution.state.compare_exchange_strong(
-                expected, GraphExecutionState::ACTIVE, std::memory_order_acq_rel, std::memory_order_acquire
-            )) {
+        if (!graph_execution_transition(execution, GraphExecutionState::PREPARED, GraphExecutionState::ACTIVE)) {
             return 0;
         }
         return graph_route_ready_roots(execution);
@@ -1023,30 +1016,25 @@ struct PTO2SchedulerState {
         PTO2TaskSlotState &outer_slot, int32_t max_nodes = GRAPH_MATERIALIZE_SLICE_NODES,
         int32_t *nodes_materialized = nullptr
     ) {
-        GraphSubmission *submission = graph_submission_from_slot(outer_slot);
-        if (submission == nullptr) return GraphMaterializeResult::INVALID;
-        GraphExecution *execution = graph_execution_localize(outer_slot);
-        if (execution == nullptr) {
-            return graph_submission_execution_initializing(*submission) ? GraphMaterializeResult::BUSY :
-                                                                          GraphMaterializeResult::INVALID;
-        }
+        GraphExecution *execution = graph_execution_from_outer_slot(outer_slot);
+        if (execution == nullptr) return GraphMaterializeResult::INVALID;
         const int32_t before = execution->materialized_nodes;
         const GraphMaterializeResult result =
             graph_execution_materialize_slice(outer_slot, *execution, max_nodes, nodes_materialized);
         if (result == GraphMaterializeResult::PENDING || result == GraphMaterializeResult::PREPARED) {
             graph_incremental_publish(*execution, before, execution->materialized_nodes);
         }
-        if (result == GraphMaterializeResult::PREPARED && graph_submission_signal(*submission, 0x1)) {
+        if (result == GraphMaterializeResult::PREPARED && graph_execution_external_ready(*execution)) {
             activate_prepared_graph(*execution);
         }
         return result;
     }
 
     int32_t activate_graph_task(PTO2TaskSlotState &outer_slot) {
-        GraphSubmission *submission = graph_submission_from_slot(outer_slot);
-        if (submission == nullptr || !graph_submission_signal(*submission, 0x2)) return 0;
-        GraphExecution *execution = graph_submission_local_execution(*submission);
-        return execution == nullptr ? 0 : activate_prepared_graph(*execution);
+        GraphExecution *execution = graph_execution_from_outer_slot(outer_slot);
+        if (execution == nullptr) return 0;
+        graph_execution_signal_external_ready(*execution);
+        return activate_prepared_graph(*execution);
     }
 
     struct TaskCompletionOutcome {
@@ -1081,9 +1069,9 @@ struct PTO2SchedulerState {
         }
         // Incremental activation routes a node before the graph reaches ACTIVE, so a
         // node can legitimately complete while the graph is still MATERIALIZING or
-        // PREPARED. Only SUBMITTED (execution not yet localized) and COMPLETED
+        // PREPARED. Only SUBMITTED (execution not yet bound) and COMPLETED
         // (execution already retired) are invalid states for a node completion.
-        const GraphExecutionState graph_state = execution->state.load(std::memory_order_acquire);
+        const GraphExecutionState graph_state = graph_execution_state(*execution);
         if (graph_state < GraphExecutionState::MATERIALIZING || graph_state > GraphExecutionState::ACTIVE) {
             outcome.error_code = PTO2_ERROR_INVALID_ARGS;
             return outcome;

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -1142,6 +1142,7 @@ void SchedulerContext::classify_partition(int32_t thread_idx, int32_t nthreads) 
         }
         PTO2TaskSlotState &slot = ring.get_slot_state_by_task_id(id);
         if (slot.task_kind == TaskKind::GRAPH) {
+            if (graph_execution_localize(slot) == nullptr) slot.graph_context = nullptr;
             if (!sched_->push_graph_prepare(&slot, slot.task->task_id.raw, thread_idx)) return;
         }
         int32_t state = sched_->classify_fanin_state(&slot);

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -1298,7 +1298,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
         // Graph control work never consumes an AICore. External dependency
         // readiness and bounded definition materialization progress
-        // independently, then meet at GraphSubmission::activation_gate.
+        // independently, then meet in GraphExecution::state.
         //
         // Keep this ahead of dummy/regular dispatch so a ready Graph can expose
         // its root nodes without waiting for an otherwise unrelated dispatch

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -356,17 +356,23 @@ For a cache hit, the Host Orchestrator:
 1. validates the fixed boundary contract;
 2. reserves one task-window slot;
 3. reserves one heap block large enough for every internal intermediate, plus
-   the Definition's `execution_storage_bytes` for the execution the device
-   materializes into;
+   the Definition's `execution_storage_bytes` for node storage and its argument
+   pools;
 4. computes only external fanin and boundary tensormap effects;
 5. emits one outer `GRAPH` task;
-6. stages the exact-size POD submission image for upload after orchestration.
+6. stores boundary values in the outer task's ordinary compact argument pools.
+
+The outer Graph's tensor region is counted in `ChipTensor` pool slots but holds
+densely packed `GraphTensor` wire values. Graph scheduling never dispatches the
+outer payload as a kernel payload; device localization reads the compact values
+directly, so boundary metadata does not need to expand to full `ChipTensor`
+records on either side of H2D.
 
 Internal nodes consume no ring task-window slots. Their descriptor, payload, slot
-state, and argument pools live in the tail of the outer `GRAPH` task's own heap
-block, past `required_heap`: one `PTO2TaskAllocator::alloc` covers both halves the
-task owns, so the storage is reclaimed with the task's packed outputs and needs no
-separate device allocation, retention keying or release path.
+state, and argument pools live in the tail of the outer `GRAPH` task's own heap block,
+past `required_heap`: `[GraphExecution][GraphNodeStorage...][tensor pool][scalar pool]`. One
+`PTO2TaskAllocator::alloc` covers both the packed outputs and this execution storage,
+so they are reclaimed together without a separate device allocation or release path.
 
 A node payload holds no argument array of its own — it names each region by a delta,
 like any other payload. Its pools are the last two regions of the execution storage,
@@ -376,24 +382,23 @@ span in the pool as in the Definition's arg table. There is no fanin region: nod
 dependencies come from the Definition's fanin CSR, so a node's `fanin_count` stays 0
 and its fanin delta unbound.
 
-The execution address is therefore not on the wire — both sides compute
-`packed_buffer_base + required_heap` and read the size from the Definition. The
-Scheduler validates that the region lies inside the outer task's allocation and
-then placement-constructs `GraphExecution` there; it never allocates execution
-storage from the AICPU process heap, and it never reads the block's prior
-contents. Every submission materializes from the Definition, so a resubmission
-of the same Graph rebuilds rather than replaying the previous expansion: the
-bytes it starts from are whatever that heap region last held.
+The Host computes the execution-storage size before allocating the outer task's
+heap. It points the outer slot's existing `graph_context` at the shared device
+Definition and compacts the outer payload's tensor/scalar regions with every
+other task's argument pools. The copied arena zone and compact shared-memory
+image travel in one H2D. During the parallel initial classify, the Scheduler
+constructs `GraphExecution` in the outer heap tail, binds it to that Definition
+and the outer payload, and replaces `graph_context` with the execution pointer.
+Node storage remains untouched until bounded materialization begins.
 
 ## Scheduler flow
 
 Host orchestration builds the complete task image before device execution. At
-the end of orchestration, the Host stages each Graph POD image into the runtime
-arena's device region alongside the compacted shared-memory image, copies that
-one bind image to the device, and then launches the resident Scheduler. Nothing
-is patched on the way: a slot state names its payload and descriptor by a delta
-from its own address, so the bytes the Host wrote are the bytes the device
-schedules.
+the end of orchestration, the Host copies one bind image containing the
+compacted shared-memory task window and argument pools, then launches the
+resident Scheduler. Slot task and payload references remain self-relative;
+`graph_context` is the absolute address of the retained Definition object until
+initial classification localizes the execution in the outer heap.
 
 All AICPU threads classify disjoint slices of the completed task window behind
 one startup barrier. A Graph task enters preparation and external-fanin

--- a/src/common/host_build_graph/graph_execution.cpp
+++ b/src/common/host_build_graph/graph_execution.cpp
@@ -19,15 +19,12 @@
 
 namespace {
 
-// The storage is the tail of the outer GRAPH task's heap allocation, so its
-// bytes are whatever that region last held; every field an execution needs is
-// written here or by the materialize pass, never inherited from those bytes.
-GraphExecution *acquire_host_execution_storage(
+GraphExecution *acquire_execution_storage(
     uintptr_t storage_addr, size_t storage_bytes, int32_t node_count, uint32_t tensor_arg_count,
     uint32_t scalar_arg_count
 ) {
     GraphExecutionStorageLayout layout{};
-    if (storage_addr == 0 || storage_addr % alignof(GraphNodeStorage) != 0 ||
+    if (storage_addr == 0 || storage_addr % alignof(GraphExecution) != 0 ||
         !graph_execution_storage_layout(node_count, tensor_arg_count, scalar_arg_count, &layout) ||
         layout.total_bytes > storage_bytes) {
         return nullptr;
@@ -63,7 +60,7 @@ bool bind_graph_topology(GraphExecution &execution) {
     // GRAPH_MAX_SCALAR_ARGS, not MAX_SCALAR_ARGS: this counts the scalars the
     // Graph BOUNDARY carries, which the recorder sizes with
     // GraphTaskArgs = Arg<GRAPH_MAX_TENSOR_ARGS, GRAPH_MAX_SCALAR_ARGS> and the
-    // image hands over as a pointer into the submission, never through a node
+    // outer Graph payload hands it to GraphExecution, never through a node
     // payload. MAX_SCALAR_ARGS is the per-AICore-task cap (16) and applies to
     // GraphNodeDefinition::scalar_count below, which is checked separately; using
     // it here rejected every boundary wider than one kernel call could take.
@@ -170,9 +167,9 @@ bool graph_definition_hash_matches(const GraphDefinition &definition, uint32_t d
     return hash == definition.content_hash;
 }
 
-// One-time integrity gate for a shared Definition object. The first localizer
+// One-time integrity gate for a shared Definition object. The first execution
 // wins the UPLOADED->VERIFYING CAS, hashes the image once, and publishes
-// VERIFIED/INVALID. Localizers of the other submissions sharing this object
+// VERIFIED/INVALID. Other executions sharing this object
 // spin on the state word — never re-hashing, never failing while a peer is
 // mid-verify (the verify is bounded by the image size, so the spin is short).
 GraphDefinition *graph_definition_object_verified(GraphDefinitionHeader &header) {
@@ -313,93 +310,55 @@ bool graph_predicate_resolve(
 }  // namespace
 
 GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
-    GraphSubmission *submission = graph_submission_from_slot(outer_slot);
-    if (submission == nullptr) return nullptr;
-    if (GraphExecution *existing = graph_submission_local_execution(*submission)) return existing;
-    if (graph_submission_execution_initializing(*submission)) return nullptr;
+    if (outer_slot.task_kind != TaskKind::GRAPH || outer_slot.task == nullptr || outer_slot.payload == nullptr ||
+        outer_slot.task->packed_buffer_base == nullptr || outer_slot.task->packed_buffer_end == nullptr ||
+        outer_slot.graph_context == nullptr) {
+        return nullptr;
+    }
 
-    // The Definition lives in its own shared GM object; only its header is
-    // inspected here. The content hash gate runs inside the submission CAS
-    // below, so exactly one localizer verifies a shared object — concurrent
-    // localizers of other submissions see INITIALIZING and retry as BUSY
-    // rather than racing the verify state.
-    if (submission->definition_addr == 0 || submission->definition_addr % alignof(GraphDefinitionHeader) != 0) {
+    const uintptr_t definition_addr = reinterpret_cast<uintptr_t>(outer_slot.graph_context);
+    if (definition_addr < sizeof(GraphDefinitionHeader) ||
+        (definition_addr - sizeof(GraphDefinitionHeader)) % alignof(GraphDefinitionHeader) != 0) {
         return nullptr;
     }
     auto *definition_header =
-        reinterpret_cast<GraphDefinitionHeader *>(static_cast<uintptr_t>(submission->definition_addr));
-    if (definition_header->magic != GRAPH_DEFINITION_OBJECT_MAGIC) return nullptr;
-    const GraphTensor *boundary_tensors = graph_submission_tensors(*submission);
-    const uint64_t *boundary_scalars = graph_submission_scalars(*submission);
-    const size_t boundary_tensor_end = static_cast<size_t>(submission->tensors_offset) +
-                                       static_cast<size_t>(submission->tensor_count) * sizeof(GraphTensor);
-    if (boundary_tensors == nullptr || outer_slot.task == nullptr || outer_slot.task->packed_buffer_base == nullptr ||
-        outer_slot.task->packed_buffer_end == nullptr ||
-        (submission->scalar_count != 0 && boundary_scalars == nullptr) ||
-        (submission->scalar_count != 0 && submission->scalars_offset < boundary_tensor_end)) {
-        return nullptr;
-    }
-    for (uint32_t i = 0; i < submission->tensor_count; ++i) {
-        if (!graph_tensor_wire_valid(boundary_tensors[i])) return nullptr;
-    }
-
-    uint64_t expected = 0;
-    if (!__atomic_compare_exchange_n(
-            &submission->local_execution, &expected, GRAPH_EXECUTION_INITIALIZING, false, __ATOMIC_ACQ_REL,
-            __ATOMIC_ACQUIRE
-        )) {
-        return expected > GRAPH_EXECUTION_INITIALIZING ?
-                   reinterpret_cast<GraphExecution *>(static_cast<uintptr_t>(expected)) :
-                   nullptr;
-    }
-
+        reinterpret_cast<GraphDefinitionHeader *>(definition_addr - sizeof(GraphDefinitionHeader));
     const GraphDefinition *definition = graph_definition_object_verified(*definition_header);
+    PTO2TaskPayload &payload = *outer_slot.payload;
     if (definition == nullptr || definition->total_bytes == 0 || definition->task_count == 0 ||
-        definition->task_count > GRAPH_MAX_NODES || submission->definition_hash != definition->content_hash ||
-        submission->graph_key != definition->full_key || submission->tensor_count != definition->boundary_count ||
-        submission->scalar_count != definition->boundary_scalar_count) {
-        __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
+        definition->task_count > GRAPH_MAX_NODES ||
+        payload.tensor_count != static_cast<int32_t>(definition->boundary_count) ||
+        payload.scalar_count != static_cast<int32_t>(definition->boundary_scalar_count) ||
+        (payload.tensor_count != 0 && payload.tensor_data() == nullptr) ||
+        (payload.scalar_count != 0 && payload.scalar_data() == nullptr)) {
         return nullptr;
     }
+
     const uintptr_t outer_base = reinterpret_cast<uintptr_t>(outer_slot.task->packed_buffer_base);
     const uintptr_t outer_end = reinterpret_cast<uintptr_t>(outer_slot.task->packed_buffer_end);
-    // The outer task's allocation covers the nodes' packed outputs followed by
-    // this execution's storage, so the span must hold both and the execution
-    // starts past required_heap.
-    const uint64_t owned_bytes = definition->required_heap + static_cast<uint64_t>(definition->execution_storage_bytes);
-    if (outer_end < outer_base || definition->execution_storage_bytes == 0 ||
-        definition->required_heap > UINT64_MAX - definition->execution_storage_bytes ||
-        owned_bytes > outer_end - outer_base) {
-        __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
+    if (outer_end < outer_base || definition->required_heap > UINTPTR_MAX - outer_base ||
+        definition->execution_storage_bytes > outer_end - outer_base ||
+        definition->required_heap > outer_end - outer_base - definition->execution_storage_bytes) {
         return nullptr;
     }
-
-    GraphExecution *execution = acquire_host_execution_storage(
+    GraphExecution *execution = acquire_execution_storage(
         outer_base + definition->required_heap, definition->execution_storage_bytes,
         static_cast<int32_t>(definition->task_count), definition->tensor_arg_count, definition->scalar_arg_count
     );
-    if (execution == nullptr) {
-        __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
-        return nullptr;
-    }
+    if (execution == nullptr) return nullptr;
 
-    // The Definition is read in place from the shared GM object; no
-    // per-occurrence copy is taken.
     execution->definition = definition;
+    execution->outer_slot = &outer_slot;
+    execution->boundary_tensors = reinterpret_cast<const GraphTensor *>(payload.tensor_data());
+    execution->boundary_tensor_count = static_cast<uint32_t>(payload.tensor_count);
+    execution->boundary_scalars = payload.scalar_data();
+    execution->boundary_scalar_count = static_cast<uint32_t>(payload.scalar_count);
     if (!bind_graph_topology(*execution)) {
         execution->retired_nodes.store(execution->node_count, std::memory_order_relaxed);
-        execution->state.store(GraphExecutionState::COMPLETED, std::memory_order_release);
-        __atomic_store_n(&submission->local_execution, 0, __ATOMIC_RELEASE);
+        graph_execution_mark_completed(*execution);
         return nullptr;
     }
-    execution->boundary_tensors = boundary_tensors;
-    execution->boundary_tensor_count = submission->tensor_count;
-    execution->boundary_scalars = boundary_scalars;
-    execution->boundary_scalar_count = submission->scalar_count;
-    execution->outer_slot = &outer_slot;
-
-    const uint64_t desired = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(execution));
-    __atomic_store_n(&submission->local_execution, desired, __ATOMIC_RELEASE);
+    outer_slot.graph_context = execution;
     return execution;
 }
 
@@ -413,7 +372,7 @@ GraphMaterializeResult graph_execution_materialize_slice(
         return GraphMaterializeResult::INVALID;
     }
 
-    GraphExecutionState state = execution.state.load(std::memory_order_acquire);
+    GraphExecutionState state = graph_execution_state(execution);
     if (state >= GraphExecutionState::PREPARED) return GraphMaterializeResult::PREPARED;
 
     uint8_t expected_busy = 0;
@@ -423,11 +382,10 @@ GraphMaterializeResult graph_execution_materialize_slice(
         return GraphMaterializeResult::BUSY;
     }
 
-    state = execution.state.load(std::memory_order_acquire);
+    state = graph_execution_state(execution);
     if (state == GraphExecutionState::SUBMITTED) {
-        GraphExecutionState expected = GraphExecutionState::SUBMITTED;
-        if (!execution.state.compare_exchange_strong(
-                expected, GraphExecutionState::MATERIALIZING, std::memory_order_acq_rel, std::memory_order_acquire
+        if (!graph_execution_transition(
+                execution, GraphExecutionState::SUBMITTED, GraphExecutionState::MATERIALIZING
             )) {
             execution.materialize_busy.store(0, std::memory_order_release);
             return GraphMaterializeResult::BUSY;
@@ -610,7 +568,7 @@ GraphMaterializeResult graph_execution_materialize_slice(
         return GraphMaterializeResult::INVALID;
     }
 
-    execution.state.store(GraphExecutionState::PREPARED, std::memory_order_release);
+    graph_execution_set_state(execution, GraphExecutionState::PREPARED);
     execution.materialize_busy.store(0, std::memory_order_release);
     return GraphMaterializeResult::PREPARED;
 }

--- a/src/common/host_build_graph/graph_execution.cpp
+++ b/src/common/host_build_graph/graph_execution.cpp
@@ -24,7 +24,10 @@ GraphExecution *acquire_execution_storage(
     uint32_t scalar_arg_count
 ) {
     GraphExecutionStorageLayout layout{};
-    if (storage_addr == 0 || storage_addr % alignof(GraphExecution) != 0 ||
+    // GraphNodeStorage, not GraphExecution: the node array's alignment is the widest
+    // the storage carries, and nodes_offset only rounds up relative to this base, so
+    // an under-aligned base would leave every alignas(64) node entry misaligned.
+    if (storage_addr == 0 || storage_addr % alignof(GraphNodeStorage) != 0 ||
         !graph_execution_storage_layout(node_count, tensor_arg_count, scalar_arg_count, &layout) ||
         layout.total_bytes > storage_bytes) {
         return nullptr;

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -51,9 +51,9 @@ struct GraphTensor {
     uint8_t reserved[3];
 };
 
-// Everything from GraphTensorSourceRef through GraphSubmission is copied
-// across the host-device boundary. Keep it pointer-free, fixed-width and
-// position-independent: every reference is an offset from its owning header.
+// Definition records are copied across the host-device boundary. Keep them
+// pointer-free, fixed-width and position-independent: every reference is an
+// offset from its owning header.
 struct GraphTensorSourceRef {
     uint8_t source;
     uint8_t reserved;
@@ -159,12 +159,9 @@ struct GraphDefinition {
     uint32_t tensor_arg_count;
     uint32_t scalar_arg_count;
     uint32_t predicate_count;
-    // Bytes an execution of this Definition needs for its GraphExecution header,
-    // node storage and patch arrays. Derived from task_count / tensor_arg_count /
-    // scalar_arg_count, so host and device read one value instead of each
-    // computing it. The outer GRAPH task's heap allocation covers
-    // required_heap + this, and the execution lives at
-    // packed_buffer_base + required_heap.
+    // Bytes the GraphExecution header, node array and node argument pools need in
+    // the outer GRAPH task's heap tail. Invocation boundaries live in the outer
+    // task payload's compact argument-pool regions instead.
     uint32_t execution_storage_bytes;
     uint32_t off_fanout_offsets;
     uint32_t off_fanout_indices;
@@ -181,27 +178,6 @@ struct GraphDefinition {
     uint32_t off_predicates;
 };
 
-// One submission of a Graph. The static Definition is a shared device object
-// this references by address; the execution storage is not referenced at all —
-// it sits at outer_slot.task->packed_buffer_base + definition->required_heap,
-// so both sides derive it from the Definition rather than carrying it on the
-// wire.
-struct GraphSubmission {
-    uint64_t graph_key;
-    uint64_t local_execution;
-    // Device GM address of the shared Definition object this replay references
-    // (an integer-typed absolute address per the wire rules) plus the content
-    // hash the host computed for it.
-    uint64_t definition_addr;
-    uint64_t definition_hash;
-    uint32_t activation_gate;
-    uint32_t total_bytes;
-    uint32_t tensors_offset;
-    uint32_t tensor_count;
-    uint32_t scalars_offset;
-    uint32_t scalar_count;
-};
-
 static_assert(std::is_trivially_copyable_v<GraphTensorSourceRef>);
 static_assert(std::is_standard_layout_v<GraphTensorSourceRef>);
 static_assert(std::is_trivially_copyable_v<GraphTensor>);
@@ -216,8 +192,6 @@ static_assert(std::is_trivially_copyable_v<GraphBoundarySignature>);
 static_assert(std::is_standard_layout_v<GraphBoundarySignature>);
 static_assert(std::is_trivially_copyable_v<GraphDefinition>);
 static_assert(std::is_standard_layout_v<GraphDefinition>);
-static_assert(std::is_trivially_copyable_v<GraphSubmission>);
-static_assert(std::is_standard_layout_v<GraphSubmission>);
 
 inline GraphTensor graph_tensor_pack(const ChipTensor &tensor) {
     GraphTensor packed{};
@@ -297,37 +271,6 @@ inline const T *graph_definition_ptr(const GraphDefinition &definition, uint32_t
     return graph_definition_array<T>(definition, offset, 1);
 }
 
-inline GraphSubmission *graph_submission_from_slot(PTO2TaskSlotState &slot) {
-    return slot.task_kind == TaskKind::GRAPH ? static_cast<GraphSubmission *>(slot.graph_context) : nullptr;
-}
-
-inline bool graph_submission_wire_size_valid(const GraphSubmission &submission, size_t available_bytes) {
-    return available_bytes >= sizeof(GraphSubmission) && submission.total_bytes == available_bytes;
-}
-
-inline const GraphTensor *graph_submission_tensors(const GraphSubmission &submission) {
-    if (submission.tensors_offset == 0 || submission.tensors_offset % alignof(GraphTensor) != 0 ||
-        submission.tensors_offset > submission.total_bytes ||
-        submission.tensor_count > (submission.total_bytes - submission.tensors_offset) / sizeof(GraphTensor)) {
-        return nullptr;
-    }
-    return reinterpret_cast<const GraphTensor *>(
-        reinterpret_cast<const uint8_t *>(&submission) + submission.tensors_offset
-    );
-}
-
-inline const uint64_t *graph_submission_scalars(const GraphSubmission &submission) {
-    if (submission.scalar_count == 0) return nullptr;
-    if (submission.scalars_offset == 0 || submission.scalars_offset % alignof(uint64_t) != 0 ||
-        submission.scalars_offset > submission.total_bytes ||
-        submission.scalar_count > (submission.total_bytes - submission.scalars_offset) / sizeof(uint64_t)) {
-        return nullptr;
-    }
-    return reinterpret_cast<const uint64_t *>(
-        reinterpret_cast<const uint8_t *>(&submission) + submission.scalars_offset
-    );
-}
-
 enum class GraphExecutionState : uint8_t {
     SUBMITTED = 0,
     MATERIALIZING = 1,
@@ -353,10 +296,14 @@ struct alignas(64) GraphNodeStorage {
     PTO2TaskPayload payload;
 };
 
-inline constexpr uint64_t GRAPH_EXECUTION_INITIALIZING = 1;
+inline constexpr uint8_t GRAPH_EXECUTION_STATE_MASK = 0x7;
+inline constexpr uint8_t GRAPH_EXECUTION_EXTERNAL_READY = 0x8;
 
 struct GraphExecution {
-    std::atomic<GraphExecutionState> state{GraphExecutionState::SUBMITTED};
+    // The low bits hold GraphExecutionState. EXTERNAL_READY shares this byte so
+    // dependency readiness can arrive before materialization without a separate
+    // per-submission gate object.
+    std::atomic<uint8_t> state{static_cast<uint8_t>(GraphExecutionState::SUBMITTED)};
     std::atomic<uint8_t> materialize_busy{0};
     std::atomic<int32_t> remaining_nodes{0};
     std::atomic<int32_t> retired_nodes{0};
@@ -391,19 +338,25 @@ struct GraphExecution {
 };
 
 static_assert(std::is_trivially_destructible_v<GraphNodeStorage>);
-// The tensor pool starts right after the node array, so the node stride has to carry
-// ChipTensor's alignment; the scalar pool then starts after a whole number of
-// ChipTensors. Neither holds by construction — both are properties of the two types.
+// The tensor pool starts right after the node array, and the scalar pool starts
+// after a whole number of ChipTensors.
 static_assert(
     alignof(GraphNodeStorage) % alignof(ChipTensor) == 0,
     "a node entry must be at least ChipTensor-aligned: the tensor pool follows the node array"
 );
 static_assert(sizeof(ChipTensor) % alignof(uint64_t) == 0, "the tensor stride must keep the scalar pool aligned");
 static_assert(std::is_trivially_destructible_v<GraphExecution>);
+static_assert(std::is_trivially_copyable_v<GraphExecution>);
+static_assert(sizeof(GraphTensor) <= sizeof(ChipTensor));
 
-// The execution occupies
+inline size_t graph_boundary_tensor_pool_slots(uint32_t tensor_count) {
+    const size_t bytes = static_cast<size_t>(tensor_count) * sizeof(GraphTensor);
+    return (bytes + sizeof(ChipTensor) - 1) / sizeof(ChipTensor);
+}
+
+// The outer GRAPH task's heap tail occupies
 // [GraphExecution][GraphNodeStorage x node_count][ChipTensor x tensor_arg_count]
-// [uint64_t x scalar_arg_count] at the tail of the outer GRAPH task's heap allocation.
+// [uint64_t x scalar_arg_count].
 //
 // The last two regions are the node payloads' argument pools, indexed by the
 // Definition's own tensor_offset / scalar_offset — which is why the Definition's
@@ -453,30 +406,60 @@ inline GraphExecution *graph_execution_from_slot(PTO2TaskSlotState &slot) {
     return slot.task_kind == TaskKind::GRAPH_NODE ? static_cast<GraphExecution *>(slot.graph_context) : nullptr;
 }
 
+inline GraphExecution *graph_execution_from_outer_slot(PTO2TaskSlotState &slot) {
+    return slot.task_kind == TaskKind::GRAPH ? static_cast<GraphExecution *>(slot.graph_context) : nullptr;
+}
+
+inline GraphExecutionState
+graph_execution_state(const GraphExecution &execution, std::memory_order order = std::memory_order_acquire) {
+    return static_cast<GraphExecutionState>(execution.state.load(order) & GRAPH_EXECUTION_STATE_MASK);
+}
+
+inline bool
+graph_execution_external_ready(const GraphExecution &execution, std::memory_order order = std::memory_order_acquire) {
+    return (execution.state.load(order) & GRAPH_EXECUTION_EXTERNAL_READY) != 0;
+}
+
+inline void graph_execution_set_state(
+    GraphExecution &execution, GraphExecutionState next, std::memory_order order = std::memory_order_release
+) {
+    uint8_t observed = execution.state.load(std::memory_order_relaxed);
+    const uint8_t next_state = static_cast<uint8_t>(next);
+    while (!execution.state.compare_exchange_weak(
+        observed, static_cast<uint8_t>((observed & ~GRAPH_EXECUTION_STATE_MASK) | next_state), order,
+        std::memory_order_relaxed
+    )) {}
+}
+
+inline bool graph_execution_transition(
+    GraphExecution &execution, GraphExecutionState expected_state, GraphExecutionState next_state
+) {
+    uint8_t observed = execution.state.load(std::memory_order_acquire);
+    while ((observed & GRAPH_EXECUTION_STATE_MASK) == static_cast<uint8_t>(expected_state)) {
+        const uint8_t desired =
+            static_cast<uint8_t>((observed & ~GRAPH_EXECUTION_STATE_MASK) | static_cast<uint8_t>(next_state));
+        if (execution.state.compare_exchange_weak(
+                observed, desired, std::memory_order_acq_rel, std::memory_order_acquire
+            )) {
+            return true;
+        }
+    }
+    return false;
+}
+
+inline bool graph_execution_signal_external_ready(GraphExecution &execution) {
+    return (execution.state.fetch_or(GRAPH_EXECUTION_EXTERNAL_READY, std::memory_order_acq_rel) &
+            GRAPH_EXECUTION_EXTERNAL_READY) == 0;
+}
+
 inline bool graph_execution_complete_node(GraphExecution &execution) {
     return execution.remaining_nodes.fetch_sub(1, std::memory_order_acq_rel) == 1;
 }
 
 inline void graph_execution_mark_completed(GraphExecution &execution) {
-    execution.state.store(GraphExecutionState::COMPLETED, std::memory_order_release);
+    graph_execution_set_state(execution, GraphExecutionState::COMPLETED);
 }
 
 inline void graph_execution_retire_node(GraphExecution &execution) {
     execution.retired_nodes.fetch_add(1, std::memory_order_release);
-}
-
-inline bool graph_submission_signal(GraphSubmission &submission, uint32_t bit) {
-    constexpr uint32_t BOTH = 0x3;
-    uint32_t observed = __atomic_fetch_or(&submission.activation_gate, bit, __ATOMIC_ACQ_REL);
-    return observed != BOTH && (observed | bit) == BOTH;
-}
-
-inline GraphExecution *graph_submission_local_execution(GraphSubmission &submission) {
-    uint64_t raw = __atomic_load_n(&submission.local_execution, __ATOMIC_ACQUIRE);
-    if (raw <= GRAPH_EXECUTION_INITIALIZING) return nullptr;
-    return reinterpret_cast<GraphExecution *>(static_cast<uintptr_t>(raw));
-}
-
-inline bool graph_submission_execution_initializing(const GraphSubmission &submission) {
-    return __atomic_load_n(&submission.local_execution, __ATOMIC_ACQUIRE) == GRAPH_EXECUTION_INITIALIZING;
 }

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -346,10 +346,15 @@ static_assert(
 );
 static_assert(sizeof(ChipTensor) % alignof(uint64_t) == 0, "the tensor stride must keep the scalar pool aligned");
 static_assert(std::is_trivially_destructible_v<GraphExecution>);
-static_assert(std::is_trivially_copyable_v<GraphExecution>);
+// The whole storage is aligned for its widest member, so one base check covers the
+// header as well as the node array that follows it.
+static_assert(
+    alignof(GraphNodeStorage) % alignof(GraphExecution) == 0,
+    "the node array's alignment must subsume the execution header's"
+);
 static_assert(sizeof(GraphTensor) <= sizeof(ChipTensor));
 
-inline size_t graph_boundary_tensor_pool_slots(uint32_t tensor_count) {
+inline constexpr size_t graph_boundary_tensor_pool_slots(uint32_t tensor_count) {
     const size_t bytes = static_cast<size_t>(tensor_count) * sizeof(GraphTensor);
     return (bytes + sizeof(ChipTensor) - 1) / sizeof(ChipTensor);
 }
@@ -406,6 +411,13 @@ inline GraphExecution *graph_execution_from_slot(PTO2TaskSlotState &slot) {
     return slot.task_kind == TaskKind::GRAPH_NODE ? static_cast<GraphExecution *>(slot.graph_context) : nullptr;
 }
 
+// An outer GRAPH slot's graph_context holds the shared Definition's device address
+// until graph_execution_localize replaces it with the execution, so this cast is only
+// valid after that call. What makes it safe is the boot sequence, not this slot: every
+// AICPU thread localizes a disjoint slice of the task window in classify_partition and
+// all of them barrier before runtime_init_ready_ is published, so no dispatch — and
+// therefore no caller of this function — observes an unlocalized GRAPH slot. A slot
+// whose localization failed carries nullptr.
 inline GraphExecution *graph_execution_from_outer_slot(PTO2TaskSlotState &slot) {
     return slot.task_kind == TaskKind::GRAPH ? static_cast<GraphExecution *>(slot.graph_context) : nullptr;
 }
@@ -424,7 +436,9 @@ inline void graph_execution_set_state(
     GraphExecution &execution, GraphExecutionState next, std::memory_order order = std::memory_order_release
 ) {
     uint8_t observed = execution.state.load(std::memory_order_relaxed);
-    const uint8_t next_state = static_cast<uint8_t>(next);
+    // Masked, so a state added past GRAPH_EXECUTION_STATE_MASK cannot reach the
+    // readiness bit sharing this byte.
+    const uint8_t next_state = static_cast<uint8_t>(static_cast<uint8_t>(next) & GRAPH_EXECUTION_STATE_MASK);
     while (!execution.state.compare_exchange_weak(
         observed, static_cast<uint8_t>((observed & ~GRAPH_EXECUTION_STATE_MASK) | next_state), order,
         std::memory_order_relaxed
@@ -435,9 +449,9 @@ inline bool graph_execution_transition(
     GraphExecution &execution, GraphExecutionState expected_state, GraphExecutionState next_state
 ) {
     uint8_t observed = execution.state.load(std::memory_order_acquire);
+    const uint8_t desired_state = static_cast<uint8_t>(static_cast<uint8_t>(next_state) & GRAPH_EXECUTION_STATE_MASK);
     while ((observed & GRAPH_EXECUTION_STATE_MASK) == static_cast<uint8_t>(expected_state)) {
-        const uint8_t desired =
-            static_cast<uint8_t>((observed & ~GRAPH_EXECUTION_STATE_MASK) | static_cast<uint8_t>(next_state));
+        const uint8_t desired = static_cast<uint8_t>((observed & ~GRAPH_EXECUTION_STATE_MASK) | desired_state);
         if (execution.state.compare_exchange_weak(
                 observed, desired, std::memory_order_acq_rel, std::memory_order_acquire
             )) {

--- a/src/common/host_build_graph/graph_host_state.h
+++ b/src/common/host_build_graph/graph_host_state.h
@@ -30,8 +30,8 @@ using GraphHostStatePtr = std::unique_ptr<GraphHostState, GraphHostStateDeleter>
 
 struct GraphHostUpload {
     PTO2TaskSlotState *outer_slot;
-    std::byte *data;
-    size_t bytes;
+    uint64_t full_key;
+    uint64_t definition_hash;
 };
 
 // The run's distinct Definition images (already deduplicated by the host-side

--- a/tests/ut/cpp/a2a3/test_graph_activation.cpp
+++ b/tests/ut/cpp/a2a3/test_graph_activation.cpp
@@ -128,7 +128,7 @@ TEST_F(GraphActivationTest, IncrementalPublishRoutesCompletedDepsAndWakeChainsPe
 
 // Incremental activation dispatches a node before the graph reaches ACTIVE, so
 // complete_task must accept a node completion while the graph is MATERIALIZING or
-// PREPARED, and reject it only for SUBMITTED (not yet localized) or COMPLETED
+// PREPARED, and reject it only for SUBMITTED (not yet bound) or COMPLETED
 // (already retired).
 TEST_F(GraphActivationTest, CompleteTaskAcceptsCompletionBeforeActive) {
     GraphDefinition definition{};
@@ -146,7 +146,7 @@ TEST_F(GraphActivationTest, CompleteTaskAcceptsCompletionBeforeActive) {
         exec.node_count = 1;
         exec.remaining_nodes.store(1);
         exec.outer_slot = nullptr;
-        exec.state.store(state);
+        graph_execution_set_state(exec, state);
         node[0].slot.graph_context = &exec;
 #if SIMPLER_SCHED_PROFILING
         return sched.complete_task(node[0].slot, 0).error_code;

--- a/tests/ut/cpp/a5/test_graph_activation.cpp
+++ b/tests/ut/cpp/a5/test_graph_activation.cpp
@@ -128,7 +128,7 @@ TEST_F(GraphActivationTest, IncrementalPublishRoutesCompletedDepsAndWakeChainsPe
 
 // Incremental activation dispatches a node before the graph reaches ACTIVE, so
 // complete_task must accept a node completion while the graph is MATERIALIZING or
-// PREPARED, and reject it only for SUBMITTED (not yet localized) or COMPLETED
+// PREPARED, and reject it only for SUBMITTED (not yet bound) or COMPLETED
 // (already retired).
 TEST_F(GraphActivationTest, CompleteTaskAcceptsCompletionBeforeActive) {
     GraphDefinition definition{};
@@ -146,7 +146,7 @@ TEST_F(GraphActivationTest, CompleteTaskAcceptsCompletionBeforeActive) {
         exec.node_count = 1;
         exec.remaining_nodes.store(1);
         exec.outer_slot = nullptr;
-        exec.state.store(state);
+        graph_execution_set_state(exec, state);
         node[0].slot.graph_context = &exec;
 #if SIMPLER_SCHED_PROFILING
         return sched.complete_task(node[0].slot, 0).error_code;

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -125,33 +125,7 @@ make_test_definition(uint64_t graph_key, uint64_t boundary_address, uint32_t bou
     return image;
 }
 
-// The pool holds boundary_scalar_count entries; boundary_scalar lands in the
-// last one, where make_test_definition's BOUNDARY ref reads it.
-std::vector<std::byte> make_test_submission(
-    uint64_t graph_key, uint64_t boundary_address, uint64_t boundary_scalar, uint32_t boundary_scalar_count = 1
-) {
-    const size_t tensors_offset = PTO2_ALIGN_UP(sizeof(GraphSubmission), alignof(GraphTensor));
-    const size_t scalars_offset = PTO2_ALIGN_UP(tensors_offset + sizeof(GraphTensor), alignof(uint64_t));
-    std::vector<std::byte> image(scalars_offset + boundary_scalar_count * sizeof(uint64_t));
-    const GraphTensor boundary = make_test_tensor(boundary_address);
-    std::memcpy(image.data() + tensors_offset, &boundary, sizeof(boundary));
-    std::memcpy(
-        image.data() + scalars_offset + (boundary_scalar_count - 1) * sizeof(uint64_t), &boundary_scalar,
-        sizeof(boundary_scalar)
-    );
-
-    GraphSubmission submission{};
-    submission.graph_key = graph_key;
-    submission.total_bytes = static_cast<uint32_t>(image.size());
-    submission.tensors_offset = static_cast<uint32_t>(tensors_offset);
-    submission.tensor_count = 1;
-    submission.scalars_offset = static_cast<uint32_t>(scalars_offset);
-    submission.scalar_count = boundary_scalar_count;
-    std::memcpy(image.data(), &submission, sizeof(submission));
-    return image;
-}
-
-// A Definition device object exactly as upload_graph_submissions builds it:
+// A Definition device object exactly as upload_graph_executions builds it:
 // [GraphDefinitionHeader][Definition image].
 class TestDefinitionObject {
 public:
@@ -177,6 +151,11 @@ public:
     ~TestDefinitionObject() { ::operator delete(data_, std::align_val_t(alignof(GraphDefinitionHeader))); }
 
     uint64_t address() const { return reinterpret_cast<uint64_t>(data_); }
+    const GraphDefinition *definition() const {
+        return reinterpret_cast<const GraphDefinition *>(
+            static_cast<const uint8_t *>(data_) + sizeof(GraphDefinitionHeader)
+        );
+    }
     uint64_t hash() const { return static_cast<GraphDefinitionHeader *>(data_)->content_hash; }
     GraphDefinitionVerifyState verify_state() const {
         return static_cast<GraphDefinitionVerifyState>(
@@ -207,25 +186,54 @@ private:
     size_t bytes_{0};
 };
 
-// One outer GRAPH task's heap allocation, laid out as graph_submit_definition
-// sizes it: required_heap bytes of node outputs followed by the execution
-// storage. `fill` stands in for whatever the reclaimed heap last held.
+// One outer GRAPH task's heap allocation and payload, laid out as
+// graph_submit_definition sizes them. Device localization constructs the
+// execution in the heap tail and reads invocation boundaries from the payload.
 class OuterHeap {
 public:
     OuterHeap(const std::vector<std::byte> &definition_image, uint8_t fill = 0) {
         const auto *definition = reinterpret_cast<const GraphDefinition *>(definition_image.data());
         heap_bytes_ = static_cast<size_t>(definition->required_heap);
         storage_ = std::make_unique<AlignedStorage>(heap_bytes_ + definition->execution_storage_bytes, fill);
+        task_.packed_buffer_base = base();
+        task_.packed_buffer_end = end();
+        slot_.task_kind = TaskKind::GRAPH;
+        slot_.bind_buffers(&payload_, &task_);
+        payload_.bind_regions(boundary_tensors_.data(), boundary_scalars_.data(), nullptr);
     }
 
     uint8_t *base() const { return storage_->bytes(); }
     uint8_t *end() const { return storage_->bytes() + storage_->size(); }
-    // Where localize places the GraphExecution.
-    void *execution() const { return storage_->bytes() + heap_bytes_; }
+    void *execution() const { return base() + heap_bytes_; }
+
+    GraphExecution *initialize_execution(
+        const TestDefinitionObject &definition_object, uint64_t boundary_address, uint64_t boundary_scalar
+    ) const {
+        const GraphDefinition *definition = definition_object.definition();
+        if (definition->boundary_count > boundary_tensors_.size() ||
+            definition->boundary_scalar_count > boundary_scalars_.size()) {
+            return nullptr;
+        }
+        const GraphTensor boundary = make_test_tensor(boundary_address);
+        new (boundary_tensors_.data()) GraphTensor{boundary};
+        payload_.tensor_count = static_cast<int32_t>(definition->boundary_count);
+        payload_.scalar_count = static_cast<int32_t>(definition->boundary_scalar_count);
+        std::fill_n(boundary_scalars_.data(), definition->boundary_scalar_count, uint64_t{0});
+        if (definition->boundary_scalar_count != 0) {
+            boundary_scalars_[definition->boundary_scalar_count - 1] = boundary_scalar;
+        }
+        slot_.graph_context = const_cast<GraphDefinition *>(definition);
+        return graph_execution_localize(slot_);
+    }
 
 private:
     size_t heap_bytes_{0};
     std::unique_ptr<AlignedStorage> storage_;
+    mutable PTO2TaskDescriptor task_{};
+    mutable PTO2TaskPayload payload_{};
+    mutable PTO2TaskSlotState slot_{};
+    mutable std::array<ChipTensor, GRAPH_MAX_TENSOR_ARGS> boundary_tensors_{};
+    mutable std::array<uint64_t, GRAPH_MAX_SCALAR_ARGS> boundary_scalars_{};
 };
 
 }  // namespace
@@ -295,17 +303,14 @@ TEST(GraphExecutionStorage, ComputesAlignedExactSize) {
     ASSERT_TRUE(graph_execution_storage_layout(NODE_COUNT, TENSOR_ARGS, SCALAR_ARGS, &layout));
     EXPECT_EQ(layout.nodes_offset % alignof(GraphNodeStorage), 0U);
     EXPECT_GE(layout.nodes_offset, sizeof(GraphExecution));
-    // The node array is type-strided now that the payload carries no array of its own,
-    // and the two argument pools follow it.
     EXPECT_EQ(layout.tensors_offset, layout.nodes_offset + NODE_COUNT * sizeof(GraphNodeStorage));
     EXPECT_EQ(layout.tensors_offset % alignof(ChipTensor), 0U);
     EXPECT_EQ(layout.scalars_offset, layout.tensors_offset + TENSOR_ARGS * sizeof(ChipTensor));
     EXPECT_EQ(layout.total_bytes, layout.scalars_offset + SCALAR_ARGS * sizeof(uint64_t));
 }
 
-// The pools are sized by the Definition's arg tables, so a Definition whose nodes
-// declare fewer arguments reserves less — the same property the node stride used to
-// carry, moved to the pools.
+// The pools are sized by the Definition's arg tables, so a Definition whose
+// nodes declare fewer arguments reserves less.
 TEST(GraphExecutionStorage, NarrowerArgTablesReserveLess) {
     constexpr int32_t NODE_COUNT = 4;
     size_t wide = 0;
@@ -326,9 +331,9 @@ TEST(GraphExecutionStorage, RejectsInvalidNodeCount) {
     EXPECT_GE(storage_bytes, sizeof(GraphExecution) + sizeof(GraphNodeStorage));
 }
 
-// A resubmission gets the same heap block back, so the bytes it starts from are
+// A resubmission gets the same heap tail back, so the bytes it starts from are
 // the previous execution's. Every field must come from the Definition or this
-// submission's boundary, never from what the block last held.
+// invocation's payload, never from what the heap last held.
 TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     constexpr uint64_t GRAPH_KEY_VALUE = 0x1234;
     std::array<uint8_t, 64> first_boundary{};
@@ -338,11 +343,9 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
         make_test_definition(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(first_boundary.data()));
     const TestDefinitionObject definition_object(definition);
     OuterHeap heap(definition, 0xAA);
-    std::vector<std::byte> submission_image =
-        make_test_submission(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(first_boundary.data()), 17);
-    auto &submission = *reinterpret_cast<GraphSubmission *>(submission_image.data());
-    submission.definition_addr = definition_object.address();
-    submission.definition_hash = definition_object.hash();
+    GraphExecution *execution =
+        heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(first_boundary.data()), 17);
+    ASSERT_NE(execution, nullptr);
 
     PTO2TaskDescriptor outer_task{};
     outer_task.task_id = PTO2TaskId::make(1, 7);
@@ -351,12 +354,10 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
     outer_slot.task.set(&outer_task);
-    outer_slot.graph_context = &submission;
+    outer_slot.graph_context = execution;
 
-    GraphExecution *execution = graph_execution_localize(outer_slot);
-    ASSERT_NE(execution, nullptr);
-    // Execution storage is the heap allocation's tail: anything lower would
-    // overlap the node outputs occupying the leading required_heap bytes.
+    // The execution and node storage both occupy the outer heap tail after
+    // required_heap.
     EXPECT_EQ(static_cast<void *>(execution), heap.execution());
     EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
     GraphNodeStorage &node = execution->node_at(0);
@@ -371,12 +372,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
 
     graph_execution_mark_completed(*execution);
     execution->retired_nodes.store(2, std::memory_order_release);
-    submission.local_execution = 0;
     outer_task.task_id = PTO2TaskId::make(1, 8);
-    auto *boundary = reinterpret_cast<GraphTensor *>(submission_image.data() + submission.tensors_offset);
-    boundary->buffer_addr = reinterpret_cast<uint64_t>(second_boundary.data());
-    auto *boundary_scalar = reinterpret_cast<uint64_t *>(submission_image.data() + submission.scalars_offset);
-    *boundary_scalar = 99;
 
     // Poison every field the rebuild is responsible for restoring. A replay that
     // preserved any of them would leave the poison observable.
@@ -388,10 +384,10 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     node.slot.completed_subtasks.store(1, std::memory_order_relaxed);
     node.payload.dispatch_fanin.store(1, std::memory_order_relaxed);
 
-    execution = graph_execution_localize(outer_slot);
+    execution = heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(second_boundary.data()), 99);
     ASSERT_NE(execution, nullptr);
-    // Same block: it is this allocation's own tail, so the rebuild lands on the
-    // bytes the previous execution left behind.
+    outer_slot.graph_context = execution;
+    // Same heap block: the rebuild lands on the bytes the previous execution left behind.
     EXPECT_EQ(static_cast<void *>(execution), heap.execution());
 
     EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
@@ -413,7 +409,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
 // (GRAPH_MAX_SCALAR_ARGS), not by a single task payload's MAX_SCALAR_ARGS —
 // a node stages at most MAX_SCALAR_ARGS entries from it, but the pool itself
 // may be wider.
-TEST(GraphExecutionReplay, LocalizesBoundaryScalarPoolWiderThanTaskPayload) {
+TEST(GraphExecutionReplay, MaterializesBoundaryScalarPoolWiderThanTaskPayload) {
     constexpr uint64_t GRAPH_KEY_VALUE = 0x1234;
     constexpr uint32_t POOL = MAX_SCALAR_ARGS + 3;
     static_assert(POOL <= GRAPH_MAX_SCALAR_ARGS);
@@ -423,11 +419,9 @@ TEST(GraphExecutionReplay, LocalizesBoundaryScalarPoolWiderThanTaskPayload) {
         make_test_definition(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()), POOL);
     const TestDefinitionObject definition_object(definition);
     OuterHeap heap(definition);
-    std::vector<std::byte> submission_image =
-        make_test_submission(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()), 21, POOL);
-    auto &submission = *reinterpret_cast<GraphSubmission *>(submission_image.data());
-    submission.definition_addr = definition_object.address();
-    submission.definition_hash = definition_object.hash();
+    GraphExecution *execution =
+        heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(boundary.data()), 21);
+    ASSERT_NE(execution, nullptr);
 
     PTO2TaskDescriptor outer_task{};
     outer_task.task_id = PTO2TaskId::make(1, 7);
@@ -436,10 +430,8 @@ TEST(GraphExecutionReplay, LocalizesBoundaryScalarPoolWiderThanTaskPayload) {
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
     outer_slot.task.set(&outer_task);
-    outer_slot.graph_context = &submission;
+    outer_slot.graph_context = execution;
 
-    GraphExecution *execution = graph_execution_localize(outer_slot);
-    ASSERT_NE(execution, nullptr);
     EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
     EXPECT_EQ(execution->node_storage[0].payload.scalar_data()[0], 21U);
 }
@@ -453,22 +445,7 @@ TEST(GraphExecutionReplay, RejectsBoundaryScalarPoolBeyondContract) {
         make_test_definition(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()), POOL);
     const TestDefinitionObject definition_object(definition);
     OuterHeap heap(definition);
-    std::vector<std::byte> submission_image =
-        make_test_submission(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()), 21, POOL);
-    auto &submission = *reinterpret_cast<GraphSubmission *>(submission_image.data());
-    submission.definition_addr = definition_object.address();
-    submission.definition_hash = definition_object.hash();
-
-    PTO2TaskDescriptor outer_task{};
-    outer_task.task_id = PTO2TaskId::make(1, 7);
-    outer_task.packed_buffer_base = heap.base();
-    outer_task.packed_buffer_end = heap.end();
-    PTO2TaskSlotState outer_slot{};
-    outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task.set(&outer_task);
-    outer_slot.graph_context = &submission;
-
-    EXPECT_EQ(graph_execution_localize(outer_slot), nullptr);
+    EXPECT_EQ(heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(boundary.data()), 21), nullptr);
 }
 
 TEST(GraphDefinitionObject, RejectsDefinitionBeyondRetainedBytes) {
@@ -479,60 +456,71 @@ TEST(GraphDefinitionObject, RejectsDefinitionBeyondRetainedBytes) {
     ASSERT_GT(definition.size(), sizeof(GraphDefinition));
     const TestDefinitionObject definition_object(definition, sizeof(GraphDefinition));
     OuterHeap heap(definition);
-    std::vector<std::byte> submission_image =
-        make_test_submission(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()), 17);
-    auto &submission = *reinterpret_cast<GraphSubmission *>(submission_image.data());
-    submission.definition_addr = definition_object.address();
-    submission.definition_hash = definition_object.hash();
-
-    PTO2TaskDescriptor outer_task{};
-    outer_task.task_id = PTO2TaskId::make(1, 7);
-    outer_task.packed_buffer_base = heap.base();
-    outer_task.packed_buffer_end = heap.end();
-    PTO2TaskSlotState outer_slot{};
-    outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task.set(&outer_task);
-    outer_slot.graph_context = &submission;
-
-    EXPECT_EQ(graph_execution_localize(outer_slot), nullptr);
+    EXPECT_EQ(heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(boundary.data()), 17), nullptr);
     EXPECT_EQ(definition_object.verify_state(), GraphDefinitionVerifyState::INVALID);
 }
 
-TEST(GraphSubmissionWire, RequiresExactAvailableSize) {
-    constexpr uint64_t GRAPH_KEY_VALUE = 0x4567;
-    std::vector<std::byte> image = make_test_submission(GRAPH_KEY_VALUE, 0x1000, 17);
-    const auto &submission = *reinterpret_cast<const GraphSubmission *>(image.data());
-
-    EXPECT_TRUE(graph_submission_wire_size_valid(submission, image.size()));
-    EXPECT_FALSE(graph_submission_wire_size_valid(submission, image.size() - 1));
-    EXPECT_FALSE(graph_submission_wire_size_valid(submission, image.size() + 1));
-}
-
-TEST(GraphSubmissionActivationGate, ActivatesExactlyOnceUnderContention) {
+TEST(GraphExecutionActivationState, ExternalReadySurvivesConcurrentLifecycleTransition) {
     constexpr int ITERATIONS = 1000;
     for (int iteration = 0; iteration < ITERATIONS; ++iteration) {
-        GraphSubmission submission{};
-        std::atomic<int32_t> activations{0};
-        std::thread prepared([&] {
-            if (graph_submission_signal(submission, 0x1)) activations.fetch_add(1, std::memory_order_relaxed);
+        GraphExecution execution{};
+        std::thread materialize([&] {
+            EXPECT_TRUE(graph_execution_transition(
+                execution, GraphExecutionState::SUBMITTED, GraphExecutionState::MATERIALIZING
+            ));
         });
         std::thread ready([&] {
-            if (graph_submission_signal(submission, 0x2)) activations.fetch_add(1, std::memory_order_relaxed);
+            EXPECT_TRUE(graph_execution_signal_external_ready(execution));
         });
-        prepared.join();
+        materialize.join();
         ready.join();
-        EXPECT_EQ(submission.activation_gate, 0x3U);
-        EXPECT_EQ(activations.load(std::memory_order_relaxed), 1);
+        EXPECT_EQ(graph_execution_state(execution), GraphExecutionState::MATERIALIZING);
+        EXPECT_TRUE(graph_execution_external_ready(execution));
     }
 }
 
-TEST(GraphSubmissionActivationGate, RetriesDoNotReactivate) {
-    GraphSubmission submission{};
+TEST(GraphExecutionActivationState, RetriesDoNotClearReadiness) {
+    GraphExecution execution{};
 
-    EXPECT_FALSE(graph_submission_signal(submission, 0x1));
-    EXPECT_TRUE(graph_submission_signal(submission, 0x2));
-    EXPECT_FALSE(graph_submission_signal(submission, 0x1));
-    EXPECT_FALSE(graph_submission_signal(submission, 0x2));
+    EXPECT_TRUE(graph_execution_signal_external_ready(execution));
+    EXPECT_FALSE(graph_execution_signal_external_ready(execution));
+    graph_execution_set_state(execution, GraphExecutionState::PREPARED);
+    EXPECT_TRUE(graph_execution_external_ready(execution));
+    EXPECT_TRUE(graph_execution_transition(execution, GraphExecutionState::PREPARED, GraphExecutionState::ACTIVE));
+    EXPECT_FALSE(graph_execution_transition(execution, GraphExecutionState::PREPARED, GraphExecutionState::ACTIVE));
+}
+
+TEST(GraphExecutionActivationState, ExternalReadyBeforePrepareActivatesAtMeet) {
+    PTO2SchedulerState scheduler{};
+    GraphExecution execution{};
+    PTO2TaskSlotState outer_slot{};
+    outer_slot.task_kind = TaskKind::GRAPH;
+    outer_slot.graph_context = &execution;
+    execution.outer_slot = &outer_slot;
+
+    EXPECT_EQ(scheduler.activate_graph_task(outer_slot), 0);
+    EXPECT_EQ(graph_execution_state(execution), GraphExecutionState::SUBMITTED);
+    EXPECT_TRUE(graph_execution_external_ready(execution));
+
+    graph_execution_set_state(execution, GraphExecutionState::PREPARED);
+    EXPECT_EQ(scheduler.activate_prepared_graph(execution), 0);
+    EXPECT_EQ(graph_execution_state(execution), GraphExecutionState::ACTIVE);
+    EXPECT_EQ(scheduler.activate_prepared_graph(execution), 0);
+}
+
+TEST(GraphExecutionActivationState, PrepareBeforeExternalReadyActivatesAtMeet) {
+    PTO2SchedulerState scheduler{};
+    GraphExecution execution{};
+    PTO2TaskSlotState outer_slot{};
+    outer_slot.task_kind = TaskKind::GRAPH;
+    outer_slot.graph_context = &execution;
+    execution.outer_slot = &outer_slot;
+    graph_execution_set_state(execution, GraphExecutionState::PREPARED);
+
+    EXPECT_EQ(scheduler.activate_graph_task(outer_slot), 0);
+    EXPECT_EQ(graph_execution_state(execution), GraphExecutionState::ACTIVE);
+    EXPECT_TRUE(graph_execution_external_ready(execution));
+    EXPECT_EQ(scheduler.activate_graph_task(outer_slot), 0);
 }
 
 TEST(GraphExecutionErrors, ReadyQueueOverflowHasTriageText) {
@@ -609,7 +597,7 @@ TEST(GraphExecutionProgress, InternalNodeResolutionIsNotAHostCompletion) {
     execution.node_storage = &node;
     execution.node_count = 1;
     execution.remaining_nodes.store(1, std::memory_order_relaxed);
-    execution.state.store(GraphExecutionState::ACTIVE, std::memory_order_relaxed);
+    graph_execution_set_state(execution, GraphExecutionState::ACTIVE, std::memory_order_relaxed);
     node.slot.task_kind = TaskKind::GRAPH_NODE;
     node.slot.graph_context = &execution;
     node.slot.graph_node_index = 0;
@@ -628,7 +616,7 @@ TEST(GraphExecutionProgress, InternalNodeResolutionIsNotAHostCompletion) {
 }
 
 // Device-side execution storage is not guaranteed to be zero-initialized.
-// localize + materialize must produce a fully valid execution from arbitrary
+// Localization plus materialize must produce a valid execution from arbitrary
 // initial bytes.
 TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
     constexpr uint64_t GRAPH_KEY_VALUE = 0x9753;
@@ -638,11 +626,9 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
         make_test_definition(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()));
     const TestDefinitionObject definition_object(definition);
     OuterHeap heap(definition, 0xAA);
-    std::vector<std::byte> submission_image =
-        make_test_submission(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()), 17);
-    auto &submission = *reinterpret_cast<GraphSubmission *>(submission_image.data());
-    submission.definition_addr = definition_object.address();
-    submission.definition_hash = definition_object.hash();
+    GraphExecution *execution =
+        heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(boundary.data()), 17);
+    ASSERT_NE(execution, nullptr);
 
     PTO2TaskDescriptor outer_task{};
     outer_task.task_id = PTO2TaskId::make(1, 5);
@@ -651,10 +637,8 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
     PTO2TaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
     outer_slot.task.set(&outer_task);
-    outer_slot.graph_context = &submission;
+    outer_slot.graph_context = execution;
 
-    GraphExecution *execution = graph_execution_localize(outer_slot);
-    ASSERT_NE(execution, nullptr);
     EXPECT_EQ(static_cast<void *>(execution), heap.execution());
     EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
 

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -125,7 +125,7 @@ make_test_definition(uint64_t graph_key, uint64_t boundary_address, uint32_t bou
     return image;
 }
 
-// A Definition device object exactly as upload_graph_executions builds it:
+// A Definition device object exactly as bind_graph_definitions builds it:
 // [GraphDefinitionHeader][Definition image].
 class TestDefinitionObject {
 public:
@@ -189,8 +189,20 @@ private:
 // One outer GRAPH task's heap allocation and payload, laid out as
 // graph_submit_definition sizes them. Device localization constructs the
 // execution in the heap tail and reads invocation boundaries from the payload.
+//
+// The boundary regions are sized by the same helpers graph_submit_outer reserves
+// with — the ChipTensor slot span that holds GRAPH_MAX_TENSOR_ARGS packed
+// GraphTensors, and the ARG_POOL_ALIGN-rounded scalar span — rather than by the
+// GraphTaskArgs element caps, so the fixture reserves what production reserves for
+// the widest legal boundary. They are members, not separate allocations: a payload
+// names its regions through an int32 SelfRelativePtr delta, which silently binds as
+// unbound past ±2 GiB.
 class OuterHeap {
 public:
+    static constexpr size_t TENSOR_SLOTS = graph_boundary_tensor_pool_slots(GRAPH_MAX_TENSOR_ARGS);
+    static constexpr size_t SCALAR_SPAN =
+        PTO2_ALIGN_UP(static_cast<size_t>(GRAPH_MAX_SCALAR_ARGS), ARG_POOL_ALIGN / sizeof(uint64_t));
+
     OuterHeap(const std::vector<std::byte> &definition_image, uint8_t fill = 0) {
         const auto *definition = reinterpret_cast<const GraphDefinition *>(definition_image.data());
         heap_bytes_ = static_cast<size_t>(definition->required_heap);
@@ -206,14 +218,25 @@ public:
     uint8_t *end() const { return storage_->bytes() + storage_->size(); }
     void *execution() const { return base() + heap_bytes_; }
 
+    // The tensor region past the packed boundary. Production reserves only the packed
+    // span rounded up to a whole slot, so a write anywhere beyond the packed bytes
+    // lands in another task's arguments on a real ring.
+    const std::byte *boundary_tail(uint32_t boundary_count) const {
+        return reinterpret_cast<const std::byte *>(boundary_tensors_.data()) + boundary_count * sizeof(GraphTensor);
+    }
+    size_t boundary_tail_bytes(uint32_t boundary_count) const {
+        return TENSOR_SLOTS * sizeof(ChipTensor) - boundary_count * sizeof(GraphTensor);
+    }
+
     GraphExecution *initialize_execution(
         const TestDefinitionObject &definition_object, uint64_t boundary_address, uint64_t boundary_scalar
-    ) const {
+    ) {
         const GraphDefinition *definition = definition_object.definition();
-        if (definition->boundary_count > boundary_tensors_.size() ||
-            definition->boundary_scalar_count > boundary_scalars_.size()) {
+        if (graph_boundary_tensor_pool_slots(definition->boundary_count) > TENSOR_SLOTS ||
+            definition->boundary_scalar_count > SCALAR_SPAN) {
             return nullptr;
         }
+        std::memset(boundary_tensors_.data(), 0, TENSOR_SLOTS * sizeof(ChipTensor));
         const GraphTensor boundary = make_test_tensor(boundary_address);
         new (boundary_tensors_.data()) GraphTensor{boundary};
         payload_.tensor_count = static_cast<int32_t>(definition->boundary_count);
@@ -229,11 +252,11 @@ public:
 private:
     size_t heap_bytes_{0};
     std::unique_ptr<AlignedStorage> storage_;
-    mutable PTO2TaskDescriptor task_{};
-    mutable PTO2TaskPayload payload_{};
-    mutable PTO2TaskSlotState slot_{};
-    mutable std::array<ChipTensor, GRAPH_MAX_TENSOR_ARGS> boundary_tensors_{};
-    mutable std::array<uint64_t, GRAPH_MAX_SCALAR_ARGS> boundary_scalars_{};
+    PTO2TaskDescriptor task_{};
+    PTO2TaskPayload payload_{};
+    PTO2TaskSlotState slot_{};
+    std::array<ChipTensor, TENSOR_SLOTS> boundary_tensors_{};
+    std::array<uint64_t, SCALAR_SPAN> boundary_scalars_{};
 };
 
 }  // namespace
@@ -307,6 +330,39 @@ TEST(GraphExecutionStorage, ComputesAlignedExactSize) {
     EXPECT_EQ(layout.tensors_offset % alignof(ChipTensor), 0U);
     EXPECT_EQ(layout.scalars_offset, layout.tensors_offset + TENSOR_ARGS * sizeof(ChipTensor));
     EXPECT_EQ(layout.total_bytes, layout.scalars_offset + SCALAR_ARGS * sizeof(uint64_t));
+}
+
+// The outer Graph payload's tensor region is counted in ChipTensor pool slots but
+// holds densely packed GraphTensor values, so the slot count must cover the packed
+// bytes and be the smallest count that does — anything larger silently overdraws the
+// shared pool, anything smaller lets localize read past the region.
+TEST(GraphBoundaryPool, TensorSlotsCoverPackedBytesMinimally) {
+    EXPECT_EQ(graph_boundary_tensor_pool_slots(0), 0U);
+    for (uint32_t count = 1; count <= GRAPH_MAX_TENSOR_ARGS; ++count) {
+        const size_t slots = graph_boundary_tensor_pool_slots(count);
+        const size_t packed = static_cast<size_t>(count) * sizeof(GraphTensor);
+        EXPECT_GE(slots * sizeof(ChipTensor), packed) << "count " << count;
+        EXPECT_LT((slots - 1) * sizeof(ChipTensor), packed) << "count " << count;
+    }
+}
+
+// A Graph boundary is GraphTaskArgs-wide while the pools budget MAX_TENSOR_ARGS /
+// MAX_SCALAR_ARGS per window slot, so the widest legal boundary draws several slots'
+// worth. graph_submit_outer's preflight exists because of that gap; pin the gap itself
+// so a cap or type-size change cannot quietly close or widen it unnoticed.
+TEST(GraphBoundaryPool, WidestBoundaryExceedsOneSlotBudget) {
+    EXPECT_GT(graph_boundary_tensor_pool_slots(GRAPH_MAX_TENSOR_ARGS), static_cast<size_t>(MAX_TENSOR_ARGS));
+    EXPECT_GT(
+        static_cast<size_t>(
+            PTO2_ALIGN_UP(static_cast<int32_t>(GRAPH_MAX_SCALAR_ARGS), ARG_POOL_ALIGN / (int32_t)sizeof(uint64_t))
+        ),
+        static_cast<size_t>(MAX_SCALAR_ARGS)
+    );
+    // The widest boundary that still fits one slot's tensor budget.
+    EXPECT_LE(
+        graph_boundary_tensor_pool_slots(MAX_TENSOR_ARGS * sizeof(ChipTensor) / sizeof(GraphTensor)),
+        static_cast<size_t>(MAX_TENSOR_ARGS)
+    );
 }
 
 // The pools are sized by the Definition's arg tables, so a Definition whose
@@ -662,4 +718,11 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
     }
     EXPECT_EQ(execution->materialized_nodes, execution->node_count);
     EXPECT_EQ(execution->consumed_tensor_args, 2U);
+
+    // Localize and materialize read the boundary and write node arguments; neither may
+    // touch the tensor region past the packed boundary values.
+    const std::byte *tail = heap.boundary_tail(1);
+    for (size_t i = 0; i < heap.boundary_tail_bytes(1); ++i) {
+        ASSERT_EQ(tail[i], std::byte{0}) << "byte " << i << " past the packed boundary";
+    }
 }

--- a/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
@@ -70,7 +70,7 @@ protected:
     }
 };
 
-TEST_F(HbgGraphSubmitFailureTest, InFlightGraphSubmissionsReserveHeapOnlyAtCommit) {
+TEST_F(HbgGraphSubmitFailureTest, InFlightGraphInvocationsReserveHeapOnlyAtCommit) {
     std::array<uint32_t, 16> storage{};
     uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
     ChipTensor boundary = make_tensor_external(storage.data(), shape, 1);
@@ -105,10 +105,8 @@ TEST_F(HbgGraphSubmitFailureTest, InFlightGraphSubmissionsReserveHeapOnlyAtCommi
     const std::optional<GraphHostUpload> second_upload = graph_host_upload(*graph_state, 1);
     ASSERT_TRUE(first_upload.has_value());
     ASSERT_TRUE(second_upload.has_value());
-    const auto *first_submission = reinterpret_cast<const GraphSubmission *>(first_upload->data);
-    const auto *second_submission = reinterpret_cast<const GraphSubmission *>(second_upload->data);
-    EXPECT_NE(first_submission->definition_hash, 0u);
-    EXPECT_EQ(second_submission->definition_hash, first_submission->definition_hash);
+    EXPECT_NE(first_upload->definition_hash, 0u);
+    EXPECT_EQ(second_upload->definition_hash, first_upload->definition_hash);
     // Distinct bases alone would still pass if finalization handed out a wrong
     // extent, so pin the length the Definition asks for and the disjointness two
     // shells of one Graph must have.
@@ -118,7 +116,7 @@ TEST_F(HbgGraphSubmitFailureTest, InFlightGraphSubmissionsReserveHeapOnlyAtCommi
     const auto *second_end = static_cast<const char *>(second_upload->outer_slot->task->packed_buffer_end);
     const GraphHostDefinitionList definitions = graph_host_definitions(*graph_state);
     ASSERT_EQ(definitions.entries.size(), 1u);
-    ASSERT_EQ(definitions.entries[0].full_key, first_submission->graph_key);
+    ASSERT_EQ(definitions.entries[0].full_key, first_upload->full_key);
     const auto *definition = reinterpret_cast<const GraphDefinition *>(definitions.entries[0].data);
     const uint64_t expected_extent =
         PTO2_ALIGN_UP(definition->required_heap + definition->execution_storage_bytes, PTO2_ALIGN_SIZE);
@@ -236,8 +234,7 @@ TEST_F(HbgGraphSubmitFailureTest, WorkerRecordsWhileMainThreadSubmitsSameHashShe
     for (size_t i = 0; i < 3; ++i) {
         const std::optional<GraphHostUpload> upload = graph_host_upload(*graph_state, i);
         ASSERT_TRUE(upload.has_value());
-        const auto *submission = reinterpret_cast<const GraphSubmission *>(upload->data);
-        EXPECT_EQ(submission->definition_hash, definition->content_hash) << "shell " << i;
+        EXPECT_EQ(upload->definition_hash, definition->content_hash) << "shell " << i;
         const auto *base = static_cast<const char *>(upload->outer_slot->task->packed_buffer_base);
         const auto *end = static_cast<const char *>(upload->outer_slot->task->packed_buffer_end);
         EXPECT_EQ(static_cast<uint64_t>(end - base), expected_extent) << "shell " << i;
@@ -620,8 +617,7 @@ TEST_F(HbgGraphSubmitFailureTest, ConcurrentDefinitionsFinalizeInSubmissionOrder
     for (size_t i = 0; i < kGraphCount; ++i) {
         const std::optional<GraphHostUpload> upload = graph_host_upload(*graph_state, i);
         ASSERT_TRUE(upload.has_value()) << "Graph " << i;
-        const auto *submission = reinterpret_cast<const GraphSubmission *>(upload->data);
-        EXPECT_NE(submission->definition_hash, 0u) << "Graph " << i;
+        EXPECT_NE(upload->definition_hash, 0u) << "Graph " << i;
         const auto *base = static_cast<const char *>(upload->outer_slot->task->packed_buffer_base);
         const auto *end = static_cast<const char *>(upload->outer_slot->task->packed_buffer_end);
         ASSERT_NE(base, nullptr) << "Graph " << i;


### PR DESCRIPTION
## Summary

- Remove the device-side `GraphSubmission` wire object for A2A3 and A5 without introducing a replacement submission structure.
- Keep the shared immutable `GraphDefinition` uploaded once per distinct Definition.
- Store each invocation boundary in the existing outer Graph task payload tensor/scalar pool regions.
- Build and initialize `GraphExecution` in the outer Graph task heap tail during the device initial-classification phase; fold external readiness into `GraphExecution::state`.
- Lay out the heap tail as `[GraphExecution][GraphNodeStorage * N][node tensor pool][node scalar pool]` using calculated offsets and sizes.

The implementation is rebased on current `main`. It does not modify `GraphSubmission` into another control structure, add another H2D, or add a new allocation path.

## What the removal buys

`GraphSubmission` carried four things per invocation. Three were derivable or device-local, and one was real:

| Field | Where it lives now |
| --- | --- |
| boundary tensors / scalars | the outer Graph task's ordinary payload argument pools, packed as `GraphTensor` |
| `definition_addr` | the outer slot's existing `graph_context`, host-written to the Definition object |
| `graph_key` / `definition_hash` | validated host-side in `bind_graph_definitions`; never on the wire |
| `local_execution`, `activation_gate` | `GraphExecution::state` — low 3 bits the state, bit 3 `EXTERNAL_READY` |

So the change removes a wire struct, one arena tail, the block-staging pass, and the per-invocation `local_execution` CAS/`INITIALIZING` election with its `BUSY` retry path. Localization now happens once per outer slot in `classify_partition`, whose disjoint slices and pre-`runtime_init_ready_` barrier make the election unnecessary.

## Transfer impact

H2D volume is essentially unchanged; the boundary data moved rather than disappeared.

| Population | main | this PR |
| --- | ---: | ---: |
| Definition objects (`graph_upload`) | 1,007,216 | 1,007,216 |
| arena H2D (`arena_h2d`) | 361,984 | 358,016 |
| **total copied** | **1,369,200** | **1,365,232** |

Net **−3,968 bytes (−0.29%)**: the `GraphSubmission` headers and their per-submission `PTO2_ALIGN_SIZE` padding. The ~292 KB of boundary values that the submission block used to carry now travel inside the same arena copy as the outer tasks' argument pools, so they never left the wire.

An earlier revision of this description claimed an 18.0% / 300,032-byte reduction. That figure double-counted the 296,064-byte submission block, which `graph_upload` reported in its `bytes=` while `arena_h2d` reported the same bytes again as `subs=` — the block was laid out in the first segment but copied by the second. `main@b24092b9` (#1957) fixed that accounting; this PR is rebased past it, and with the block gone `arena_h2d`'s `bytes=` partitions exactly into `copied=` and `sm=`.

## Correctness of the pool move

Putting the boundary in the argument pools crosses a budget: the pools reserve `MAX_TENSOR_ARGS` (32) `ChipTensor` entries and `MAX_SCALAR_ARGS` (16) scalars per window slot, which every task respected because its arguments came from `CoreTaskArgs`. A Graph boundary is `GraphTaskArgs`-wide, so 128 packed `GraphTensor`s span 96 `ChipTensor` entries and 64 boundary scalars span 64 entries — break-even is 42 boundary tensors and 16 boundary scalars.

`graph_submit_outer` therefore tests both spans in its existing preflight, ahead of the slot claim, and declines the Graph path on overdraw exactly as it does for a full task window; the caller replays the block as ordinary tasks. Without that test, enough wide submissions would walk the bump cursors past the end of the shared-memory mirror, whose last segment is the scalar pool.

Execution storage also requires `alignof(GraphNodeStorage)` again rather than `alignof(GraphExecution)`: the latter is 8, `nodes_offset` only rounds up relative to the base, and an 8-aligned base would leave every `alignas(64)` node entry misaligned. No live configuration is affected — the heap bumps in `PTO2_ALIGN_SIZE` units and `required_heap` is a sum of such terms.

## Validation

- Head commit: `faa27c43`, rebased onto `main@adf3764f`.
- C++ unit tests: 115/115 passed.
- Python unit tests: 1894 passed, 14 skipped.
- A2A3 host_build_graph sim, including `host_build_graph_validation` and `host_build_graph_wide_dispatch`: 12 passed, 8 skipped.
- A5 host_build_graph sim: 7 passed.
- A2A3 graph-execution simulator: 2 passed, 1 deselected.
- clang-format and clang-tidy clean over every changed file.
- DSV4 EP2TP2 host-build-graph correctness: 2 rounds passed with device execution skipped, task `task_20260821_111806_176194727055` (measured pre-rebase, on `c8bb4a92`).

## Performance

Locked-device A/B task: `task_20260821_115214_253857727096`, order main -> PR -> main -> PR, six rounds per leg, measured pre-rebase.

| Measurement | main A | PR A | main B | PR B | Result |
| --- | ---: | ---: | ---: | ---: | --- |
| `graph_submit` min | 0.256 ms | 0.250 ms | 0.275 ms | 0.260 ms | -2.3% and -5.5% |
| control-plane min-of-sums | 1.335 ms | 1.328 ms | 1.417 ms | 1.760 ms | -0.5% and +24.2% |

The directly touched `graph_submit` work improves in both repetitions. Aggregate control-plane deltas disagree in sign because unrelated `record_node` / `build_definition` host phases varied substantially under machine contention, so this PR claims no aggregate latency speedup from this run. The stable results are the removal of the submission copy and its staging pass, and no regression in the directly modified submission phase.

Host phase records were disabled and startup rounds were excluded from the steady-state analysis.
