### PR TITLE
Fix: charge graph_upload only the bytes it copies

### DIFF
--- a/docs/dfx/hbg-bind-phases.md
+++ b/docs/dfx/hbg-bind-phases.md
@@ -28,10 +28,8 @@ line per segment per pass at `LOG_TIMING`:
 | `args` | staging the caller's host tensors and mapping them for host access |
 | `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init` | arena layout, GM heap and shared-memory bring-up |
 | `host_orch` | **all** orchestration: every task submitted, every Graph node recorded, the Definition built |
-| `graph_upload` | the Definition objects and the replay boundary images |
-| `relocate` | pointer relocation inside the shared-memory image |
-| `sm_h2d` | the task descriptors and payloads, host → device |
-| `arena_h2d` | the runtime arena's copied zone |
+| `graph_upload` | uploading the Definition objects, and laying out the replay boundary images the `arena_h2d` copy carries |
+| `arena_h2d` | the one H2D of the pass: the arena's copied zone, the shared-memory image and the Graph submission block |
 | `host_view_close` | unmapping the host views taken in `args` |
 
 The **control plane** is `host_orch + graph_upload + relocate + sm_h2d +
@@ -40,9 +38,18 @@ can start". It is what the < 1 ms target applies to. `args` and
 `host_view_close` are excluded — they scale with the caller's tensor bytes, not
 with the graph.
 
+**Two of those five are retired kinds a current run does not emit.** `relocate`
+and `sm_h2d` date from when the shared-memory image was relocated and copied on
+its own; it now travels inside the single `arena_h2d` copy as that segment's
+`sm=`. `hbg_bind_phases` keeps both in its control-plane set so a log that
+predates the change still totals correctly, and names them under its `total` row
+as absent from every pass. The table above is what a current run emits: ten
+segments, three of them control plane.
+
 **The control plane is a sum of costs, not an interval.** `arena_h2d` runs
 *after* `host_view_close`, hundreds of milliseconds later, so the segments do not
-form one contiguous window. Sum the five; do not subtract two timestamps.
+form one contiguous window. Sum the ones the pass has; do not subtract two
+timestamps.
 
 ## Prerequisites
 
@@ -125,16 +132,32 @@ not report. The log lands in `outputs/hbg_bind_stats_<sha>.log` unless `-o` name
 it:
 
 ```bash
-grep -oE 'bind phase=[a-z_]+ start_ns=[0-9]+ dur_ns=[0-9]+[^[]*' outputs/hbg_bind_stats_<sha>.log
+grep -oE 'bind phase=[a-z0-9_]+ start_ns=[0-9]+ dur_ns=[0-9]+[^[]*' outputs/hbg_bind_stats_<sha>.log
 ```
 
+The character class has to admit digits. `[a-z_]+` matches no segment whose name
+carries one, so it silently drops every `arena_h2d` line — the pass-closing
+segment, the only H2D left, and the one that itemizes the whole upload. On a
+two-pass log that is 18 lines where 20 exist, with nothing to say a segment went
+missing.
+
 Each line carries `start_ns` (a `CLOCK_MONOTONIC` timestamp) plus the segment's
-own attributes — `tasks=` and `heap_used=` on `host_orch`, `bytes=` on every H2D
-segment, `count=` on `graph_upload`. Group the lines into passes — `arena_h2d` is
-the last segment of a pass, so it closes one — then sum the five control-plane
-segments **within each pass** and take the minimum of those sums. Never sum
+own attributes — `tasks=` and `heap_used=` on `host_orch`, `defs=`, `bytes=` and
+`submissions=` on `graph_upload`, and `arena_h2d`'s itemized upload. Group the
+lines into passes — `arena_h2d` is the last segment of a pass, so it closes one —
+then sum the control-plane segments **within each pass** and take the minimum of
+those sums. Never sum
 minima taken across passes; that total belongs to no pass and can point the wrong
 way (see below).
+
+**A segment's `bytes=` is what that segment itself copied, so no copy is counted
+twice.** `graph_upload` counts the Definition objects it uploads and nothing
+else; `arena_h2d`'s `bytes=` is its single copy, exactly partitioned by the
+`copied=`, `sm=` and `subs=` beside it. The Graph submission block is that
+`subs=` — `graph_upload` lays the block out but copies none of it, so it is
+absent from that segment's `bytes=`. (`shared_mem`'s `bytes=` is the image the
+arena grew to hold, which `arena_h2d` then ships as `sm=`; that is the one figure
+two segments both report, and neither is a copy count of the other.)
 
 The first pass of each rank is warm-up and belongs in neither statistic; drop it
 explicitly rather than letting a minimum quietly exclude it.
@@ -176,7 +199,7 @@ the effect is small: on one dsv4 pass `graph_upload` came out +0.46 ms against
 −0.20 ms on the other three, and the same pass carried a bind whose `sm_h2d` was
 5.93 ms against a 0.6 ms norm.
 
-**One statistic decides: the minimum of the per-pass sums.** Sum the five
+**One statistic decides: the minimum of the per-pass sums.** Sum the
 control-plane segments *within* each pass, take the minimum across the warm
 passes, and compare those. A min of sums is not a sum of mins and the two can
 disagree in sign — each segment's minimum comes from whichever pass was quietest
@@ -273,7 +296,7 @@ signal than any duration on a shared box.
 | `--rounds 6` with `--enable-scope-stats` | no `outputs/<case>_<ts>/` artifacts, plus a `disabled: --rounds > 1` warning | one round for artifacts, many rounds for numbers |
 | Only `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` set for Recipe B | `bind phase=` lines present, no `host_phase_records.jsonl` | the records are a separate switch: also export `SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE=1` |
 | Comparing a log with no `[stamp]` first line | the parser says so above the table | re-run it through the recipe; conditions cannot be recovered from memory |
-| Subtracting timestamps for the control plane | ~300 ms instead of ~3 ms | sum the five segments; `arena_h2d` is not adjacent |
+| Subtracting timestamps for the control plane | ~300 ms instead of ~3 ms | sum the segments; `arena_h2d` is not adjacent |
 | Summing per-segment minima by hand | a total no pass achieved; can invert the sign | read the tool's `total` row — the minimum of the per-pass sums |
 | `--rounds 1` for numbers | the tool refuses: every pass is a rank's warm-up | six rounds; `--keep-first` only to look at the cold pass deliberately |
 | Single pass, or comparing across differently-loaded moments | swings of 3.5× | six rounds, compare minima, keep an untouched segment as a control |
@@ -300,13 +323,20 @@ meant to outlive it.
 | ----------- | ---------------- | ----------------- |
 | control plane | 1.11–1.53 ms | 3.63–6.81 ms |
 | `host_orch` | 0.44–0.75 ms (47 tasks) | 2.60–4.91 ms (1131 tasks) |
-| `graph_upload` | 0.56–0.96 ms / 40 uploads, 232,320 B | 0.39–1.14 ms / 20 uploads, 671,144 B |
-| `sm_h2d` | 0.067–0.068 ms / 233,799 B | 0.54–0.98 ms / 5,620,195 B |
-| `arena_h2d` | 0.035–0.039 ms / 632 B | 0.03–0.10 ms / 632 B |
+| `graph_upload` | 0.56–0.96 ms / 40 submissions, 232,320 B † | 0.39–1.14 ms / 20 submissions, 671,144 B † |
+| `sm_h2d` † | 0.067–0.068 ms / 233,799 B | 0.54–0.98 ms / 5,620,195 B |
+| `arena_h2d` † | 0.035–0.039 ms / 632 B | 0.03–0.10 ms / 632 B |
 | `heap_used` | 127,673,344 | 2,038,508,544 |
 | device wall | 39.3 ms | does not complete yet (`sched_error_code=5 INVALID_ARGS`) |
 | `args` (excluded) | 1.37 s / 40.9 GB, 19 of 20 staged | 1.48 s / 45.8 GB, 77 of 92 staged |
 | `host_view_close` (excluded) | 0.25 s / 40.9 GB | 0.28 s / 45.8 GB |
+
+† The three upload rows are the markers as they read at that commit, before the
+upload was restructured: `graph_upload`'s `bytes=` then also counted the Graph
+submission block, `sm_h2d` was still a copy of its own, and `arena_h2d` was the
+copied zone alone. A run today emits no `sm_h2d`, counts only the Definition
+objects in `graph_upload`, and ships all three regions in `arena_h2d` — so the
+same case reports different figures for the same work.
 
 Three of these deserve reading together. `host_orch` is the whole story on dsv4 —
 839 `submit_task`, 743 `record_node` and 272 `alloc_tensors` per bind against qwen's

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -295,13 +295,19 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 // All of it precedes runtime_init_ready_, which is what releases
                 // the peer threads into the dispatch loop, so neither a push nor a
                 // completion message sees an uninitialized region.
+                //
+                // Both regions sit in the device-only zone, so their bytes are
+                // whatever the pooled arena last held, and each one's empty state is
+                // whatever its own initializer writes — a ready queue's is a
+                // sequence ramp (slot i holds i), the mailbox's is zeroed cursors
+                // and publication gates. Zeroing the region is a substitute for
+                // neither call.
                 rt->scheduler->seed_queue_slots();
                 rt->aicore_mailbox->init_empty();
             }
         }
 
         if (boot_ok) {
-            memset(rt->aicore_mailbox, 0, sizeof(*rt->aicore_mailbox));
             runtime_finalize_after_wire(rt, sched_ctx_.aic_count(), sched_ctx_.aiv_count());
             runtime->set_slot_states_ptr(nullptr);
 

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -398,6 +398,14 @@ struct StagedSubmission {
     uint64_t offset;
 };
 
+// What the Definition pass copied to the device: the distinct objects, and their
+// bytes. The submission block is in neither — it is laid out here but travels in the
+// single arena H2D, which reports it as that segment's `subs=`.
+struct DefinitionUploads {
+    size_t count;
+    uint64_t bytes;
+};
+
 // Validate every pending submission, bind it to its uploaded Definition, and lay
 // the block out. No device call and no device address: the block lands in the
 // runtime arena's tail, whose base is not known until that region is grown to fit
@@ -408,9 +416,9 @@ struct StagedSubmission {
 // cache line would false-share on that word throughout.
 bool plan_graph_submissions(
     const HostApi *api, GraphHostState &graph_state, std::vector<StagedSubmission> *staged, uint64_t *block_bytes,
-    uint64_t &uploaded_bytes
+    DefinitionUploads *uploads
 ) {
-    uploaded_bytes = 0;
+    *uploads = DefinitionUploads{};
     const size_t count = graph_host_upload_count(graph_state);
     // Pass 1: upload each distinct Definition once as a shared device object
     // ([GraphDefinitionHeader][Definition image]) keyed by content identity.
@@ -452,7 +460,8 @@ bool plan_graph_submissions(
             return false;
         }
         definition_objects.emplace(definition->content_hash, UploadedDefinition{object, definition});
-        uploaded_bytes += object_bytes;
+        uploads->count++;
+        uploads->bytes += object_bytes;
     }
 
     // Pass 2: validate every submission and lay the block out.
@@ -494,7 +503,6 @@ bool plan_graph_submissions(
         staged->push_back({upload->data, upload->outer_slot, upload->bytes, *block_bytes});
         *block_bytes += PTO2_ALIGN_UP(static_cast<uint64_t>(upload->bytes), PTO2_ALIGN_SIZE);
     }
-    uploaded_bytes += *block_bytes;
     return true;
 }
 
@@ -652,16 +660,23 @@ int32_t run_host_orchestration(
     // out the submission block. The block itself is staged below, into the arena's
     // second device tail, so nothing here allocates or copies it.
     const int64_t t_graph_ns = bind_now_ns();
-    uint64_t graph_bytes = 0;
+    DefinitionUploads definition_uploads{};
     std::vector<StagedSubmission> staged_submissions;
     uint64_t submission_block_bytes = 0;
-    if (!plan_graph_submissions(api, *graph_state, &staged_submissions, &submission_block_bytes, graph_bytes)) {
+    if (!plan_graph_submissions(api, *graph_state, &staged_submissions, &submission_block_bytes, &definition_uploads)) {
         return -1;
     }
     {
+        // `bytes` is what this segment copied: the Definition objects alone. The
+        // submission block is laid out here but copied by the arena H2D, which
+        // reports the same bytes as its own `subs=`. `defs` and `submissions` differ
+        // by the replay count — one Definition serves every submission with its key.
         char attrs[96];
-        snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, graph_host_upload_count(*graph_state), graph_bytes);
-        record_bind_phase(HostPhaseKind::BindGraphUpload, t_graph_ns, attrs, graph_bytes);
+        snprintf(
+            attrs, sizeof(attrs), "defs=%zu bytes=%" PRIu64 " submissions=%zu", definition_uploads.count,
+            definition_uploads.bytes, graph_host_upload_count(*graph_state)
+        );
+        record_bind_phase(HostPhaseKind::BindGraphUpload, t_graph_ns, attrs, definition_uploads.bytes);
     }
 
     // total_tasks sizes the bounded per-segment H2D copies below; a value outside

--- a/src/a2a3/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
@@ -9,8 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_H_
-#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_H_
+#pragma once
 
 #include <atomic>
 #include <cstdint>
@@ -100,6 +99,30 @@ struct AICoreCompletionMailbox {
     // consumer lock; a stale answer only over/under-triggers a drain attempt.
     bool has_pending() { return tail.load(std::memory_order_acquire) < head.load(std::memory_order_acquire); }
 
+    // Bring the ring to its empty state on arena memory whose prior contents are
+    // unknown. head and tail are the cursors try_pop's bounds check reads, and
+    // each slot's seq is its publication gate: try_pop accepts entries[t] only
+    // when seq == t + 1, and a producer bumps head before it stores seq, so a
+    // residual seq that happens to equal t + 1 would let the consumer read a slot
+    // the producer has not written yet. Zeroing seq closes that window; the rest
+    // of a message is written before its seq and never read ahead of head, so it
+    // needs nothing.
+    //
+    // This is the ring's only initializer, so it is also where the empty state is
+    // defined: a caller that zeroes the region instead happens to land on the same
+    // state, and would silently drop anything non-zero added here.
+    //
+    // Once head and tail persist across binds this collapses to tail := head:
+    // positions never repeat, so a residual seq is always below t + 1 and only
+    // the undrained-messages case is left to discard.
+    void init_empty() {
+        head.store(0, std::memory_order_relaxed);
+        tail.store(0, std::memory_order_relaxed);
+        for (uint64_t i = 0; i < AICORE_COMPLETION_MAILBOX_CAPACITY; i++) {
+            entries[i].seq.store(0, std::memory_order_relaxed);
+        }
+    }
+
     // MPSC push for a CONDITION message. Returns false when the ring is full
     // (head - tail >= CAPACITY); caller should SPIN_WAIT_HINT and retry.
     // Lock-free: CAS the shared head to claim a slot, write the fields, then
@@ -115,26 +138,6 @@ struct AICoreCompletionMailbox {
     //
     // Safe to call concurrently from any number of producers; structurally
     // independent of the AsyncWaitList::busy lock.
-    // Bring the ring to its empty state on arena memory whose prior contents are
-    // unknown. head and tail are the cursors try_pop's bounds check reads, and
-    // each slot's seq is its publication gate: try_pop accepts entries[t] only
-    // when seq == t + 1, and a producer bumps head before it stores seq, so a
-    // residual seq that happens to equal t + 1 would let the consumer read a slot
-    // the producer has not written yet. Zeroing seq closes that window; the rest
-    // of a message is written before its seq and never read ahead of head, so it
-    // needs nothing.
-    //
-    // Once head and tail persist across binds this collapses to tail := head:
-    // positions never repeat, so a residual seq is always below t + 1 and only
-    // the undrained-messages case is left to discard.
-    void init_empty() {
-        head.store(0, std::memory_order_relaxed);
-        tail.store(0, std::memory_order_relaxed);
-        for (uint64_t i = 0; i < AICORE_COMPLETION_MAILBOX_CAPACITY; i++) {
-            entries[i].seq.store(0, std::memory_order_relaxed);
-        }
-    }
-
     bool try_push_condition(
         PTO2TaskId task_token, uint64_t addr, uint32_t expected_value, uint32_t engine, int32_t completion_type
     ) {
@@ -217,5 +220,3 @@ struct AICoreCompletionMailbox {
 static_assert(
     sizeof(AICoreCompletionMailbox) % PTO2_ALIGN_SIZE == 0, "AICoreCompletionMailbox size must be cache-line aligned"
 );
-
-#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_H_

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_shared_memory.h
@@ -145,11 +145,9 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
         return task_descriptors[get_slot_by_task_id(local_id)];
     }
 
-    // No get_payload_by_slot / get_payload_by_task_id here on purpose: the shipped
-    // image strides its payload array by the widest task in the bind, not by
-    // sizeof(PTO2TaskPayload), so indexing it as an array of the type would land
-    // between payloads. A payload is reached through its slot state's `payload`,
-    // which the image's restack rebinds to the real address.
+    // No get_payload_by_slot / get_payload_by_task_id here: a payload is reached
+    // through its slot state's `payload` delta, which the image's restack rebinds to
+    // the real address.
 
     PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -295,13 +295,19 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 // All of it precedes runtime_init_ready_, which is what releases
                 // the peer threads into the dispatch loop, so neither a push nor a
                 // completion message sees an uninitialized region.
+                //
+                // Both regions sit in the device-only zone, so their bytes are
+                // whatever the pooled arena last held, and each one's empty state is
+                // whatever its own initializer writes — a ready queue's is a
+                // sequence ramp (slot i holds i), the mailbox's is zeroed cursors
+                // and publication gates. Zeroing the region is a substitute for
+                // neither call.
                 rt->scheduler->seed_queue_slots();
                 rt->aicore_mailbox->init_empty();
             }
         }
 
         if (boot_ok) {
-            memset(rt->aicore_mailbox, 0, sizeof(*rt->aicore_mailbox));
             runtime_finalize_after_wire(rt, sched_ctx_.aic_count(), sched_ctx_.aiv_count());
             runtime->set_slot_states_ptr(nullptr);
 

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -403,6 +403,14 @@ struct StagedSubmission {
     uint64_t offset;
 };
 
+// What the Definition pass copied to the device: the distinct objects, and their
+// bytes. The submission block is in neither — it is laid out here but travels in the
+// single arena H2D, which reports it as that segment's `subs=`.
+struct DefinitionUploads {
+    size_t count;
+    uint64_t bytes;
+};
+
 // Validate every pending submission, bind it to its uploaded Definition, and lay
 // the block out. No device call and no device address: the block lands in the
 // runtime arena's tail, whose base is not known until that region is grown to fit
@@ -413,9 +421,9 @@ struct StagedSubmission {
 // cache line would false-share on that word throughout.
 bool plan_graph_submissions(
     const HostApi *api, GraphHostState &graph_state, std::vector<StagedSubmission> *staged, uint64_t *block_bytes,
-    uint64_t &uploaded_bytes
+    DefinitionUploads *uploads
 ) {
-    uploaded_bytes = 0;
+    *uploads = DefinitionUploads{};
     const size_t count = graph_host_upload_count(graph_state);
     // Pass 1: upload each distinct Definition once as a shared device object
     // ([GraphDefinitionHeader][Definition image]) keyed by content identity.
@@ -457,7 +465,8 @@ bool plan_graph_submissions(
             return false;
         }
         definition_objects.emplace(definition->content_hash, UploadedDefinition{object, definition});
-        uploaded_bytes += object_bytes;
+        uploads->count++;
+        uploads->bytes += object_bytes;
     }
 
     // Pass 2: validate every submission and lay the block out.
@@ -499,7 +508,6 @@ bool plan_graph_submissions(
         staged->push_back({upload->data, upload->outer_slot, upload->bytes, *block_bytes});
         *block_bytes += PTO2_ALIGN_UP(static_cast<uint64_t>(upload->bytes), PTO2_ALIGN_SIZE);
     }
-    uploaded_bytes += *block_bytes;
     return true;
 }
 
@@ -668,16 +676,23 @@ int32_t run_host_orchestration(
     // out the submission block. The block itself is staged below, into the arena's
     // second device tail, so nothing here allocates or copies it.
     const int64_t t_graph_ns = bind_now_ns();
-    uint64_t graph_bytes = 0;
+    DefinitionUploads definition_uploads{};
     std::vector<StagedSubmission> staged_submissions;
     uint64_t submission_block_bytes = 0;
-    if (!plan_graph_submissions(api, *graph_state, &staged_submissions, &submission_block_bytes, graph_bytes)) {
+    if (!plan_graph_submissions(api, *graph_state, &staged_submissions, &submission_block_bytes, &definition_uploads)) {
         return -1;
     }
     {
+        // `bytes` is what this segment copied: the Definition objects alone. The
+        // submission block is laid out here but copied by the arena H2D, which
+        // reports the same bytes as its own `subs=`. `defs` and `submissions` differ
+        // by the replay count — one Definition serves every submission with its key.
         char attrs[96];
-        snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, graph_host_upload_count(*graph_state), graph_bytes);
-        record_bind_phase(HostPhaseKind::BindGraphUpload, t_graph_ns, attrs, graph_bytes);
+        snprintf(
+            attrs, sizeof(attrs), "defs=%zu bytes=%" PRIu64 " submissions=%zu", definition_uploads.count,
+            definition_uploads.bytes, graph_host_upload_count(*graph_state)
+        );
+        record_bind_phase(HostPhaseKind::BindGraphUpload, t_graph_ns, attrs, definition_uploads.bytes);
     }
 
     // total_tasks sizes the bounded per-segment H2D copies below; a value outside

--- a/src/a5/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
+++ b/src/a5/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
@@ -99,6 +99,30 @@ struct AICoreCompletionMailbox {
     // consumer lock; a stale answer only over/under-triggers a drain attempt.
     bool has_pending() { return tail.load(std::memory_order_acquire) < head.load(std::memory_order_acquire); }
 
+    // Bring the ring to its empty state on arena memory whose prior contents are
+    // unknown. head and tail are the cursors try_pop's bounds check reads, and
+    // each slot's seq is its publication gate: try_pop accepts entries[t] only
+    // when seq == t + 1, and a producer bumps head before it stores seq, so a
+    // residual seq that happens to equal t + 1 would let the consumer read a slot
+    // the producer has not written yet. Zeroing seq closes that window; the rest
+    // of a message is written before its seq and never read ahead of head, so it
+    // needs nothing.
+    //
+    // This is the ring's only initializer, so it is also where the empty state is
+    // defined: a caller that zeroes the region instead happens to land on the same
+    // state, and would silently drop anything non-zero added here.
+    //
+    // Once head and tail persist across binds this collapses to tail := head:
+    // positions never repeat, so a residual seq is always below t + 1 and only
+    // the undrained-messages case is left to discard.
+    void init_empty() {
+        head.store(0, std::memory_order_relaxed);
+        tail.store(0, std::memory_order_relaxed);
+        for (uint64_t i = 0; i < AICORE_COMPLETION_MAILBOX_CAPACITY; i++) {
+            entries[i].seq.store(0, std::memory_order_relaxed);
+        }
+    }
+
     // MPSC push for a CONDITION message. Returns false when the ring is full
     // (head - tail >= CAPACITY); caller should SPIN_WAIT_HINT and retry.
     // Lock-free: CAS the shared head to claim a slot, write the fields, then
@@ -114,26 +138,6 @@ struct AICoreCompletionMailbox {
     //
     // Safe to call concurrently from any number of producers; structurally
     // independent of the AsyncWaitList::busy lock.
-    // Bring the ring to its empty state on arena memory whose prior contents are
-    // unknown. head and tail are the cursors try_pop's bounds check reads, and
-    // each slot's seq is its publication gate: try_pop accepts entries[t] only
-    // when seq == t + 1, and a producer bumps head before it stores seq, so a
-    // residual seq that happens to equal t + 1 would let the consumer read a slot
-    // the producer has not written yet. Zeroing seq closes that window; the rest
-    // of a message is written before its seq and never read ahead of head, so it
-    // needs nothing.
-    //
-    // Once head and tail persist across binds this collapses to tail := head:
-    // positions never repeat, so a residual seq is always below t + 1 and only
-    // the undrained-messages case is left to discard.
-    void init_empty() {
-        head.store(0, std::memory_order_relaxed);
-        tail.store(0, std::memory_order_relaxed);
-        for (uint64_t i = 0; i < AICORE_COMPLETION_MAILBOX_CAPACITY; i++) {
-            entries[i].seq.store(0, std::memory_order_relaxed);
-        }
-    }
-
     bool try_push_condition(
         PTO2TaskId task_token, uint64_t addr, uint32_t expected_value, uint32_t engine, int32_t completion_type
     ) {

--- a/src/a5/runtime/host_build_graph/runtime/pto_shared_memory.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_shared_memory.h
@@ -145,11 +145,9 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
         return task_descriptors[get_slot_by_task_id(local_id)];
     }
 
-    // No get_payload_by_slot / get_payload_by_task_id here on purpose: the shipped
-    // image strides its payload array by the widest task in the bind, not by
-    // sizeof(PTO2TaskPayload), so indexing it as an array of the type would land
-    // between payloads. A payload is reached through its slot state's `payload`,
-    // which the image's restack rebinds to the real address.
+    // No get_payload_by_slot / get_payload_by_task_id here: a payload is reached
+    // through its slot state's `payload` delta, which the image's restack rebinds to
+    // the real address.
 
     PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -346,11 +346,10 @@ enum class GraphMaterializeResult : uint8_t {
 struct alignas(64) GraphNodeStorage {
     PTO2TaskDescriptor task;
     PTO2TaskSlotState slot;
-    // Last on purpose, and it must stay last: the payload's own tensor array is its
-    // final field, so a node reads only a prefix of this struct, and the execution
-    // storage can be strided by the widest node in the graph instead of by the type.
-    // The slot reaches it by a delta from the slot's own address, so the order is
-    // free.
+    // The payload carries its argument regions as deltas into pools past the node
+    // array, so its size is the same for every node and the slot names it by a delta
+    // from the slot's own address. Field order here therefore constrains nothing, and
+    // node_at strides the storage by this type.
     PTO2TaskPayload payload;
 };
 


### PR DESCRIPTION
## Summary

`bytes=` on the `graph_upload` bind segment counted the Graph submission block on
top of the Definition objects, while the arena H2D counts that same block again as
its `subs=`. The block is laid out in `graph_upload`, which copies none of it, and
travels in the single arena copy — so one population of bytes was reported by two
segments. On qwen3-14b decode the segment reported **232,640 B** where the
Definition copy is **130,240 B**; the remaining 102,400 B is the block
`arena_h2d` already reports.

The segment now counts the Definition objects alone, and names its two
populations apart — `defs=` objects uploaded, `submissions=` replays planned.
The old `count=` was the submission count sitting beside a byte figure it did not
describe: the two differ by the replay factor, since one Definition serves every
submission sharing its key. #1946 made these numbers a shipped CLI's output, so
the wrong one was being presented by a supported tool.

Four claims that the argument-pool (#1952) and single-upload (#1947) changes
falsified:

- `GraphNodeStorage`'s payload comment described a struct read as a prefix and
  strided by the widest node in the graph. Payload arguments live in delta-named
  pools, so every node is the same size and `node_at` indexes by type. (The
  comment also said "it must stay last" and "the order is free" three lines
  apart.)
- The shared-memory ring header said the shipped image strides its payload array
  by the widest task rather than by `sizeof(PTO2TaskPayload)`.
  `ring_segment_offsets` pitches that segment by exactly the type.
- `docs/dfx/hbg-bind-phases.md`'s by-hand grep used `[a-z_]+`, which matches no
  segment whose name carries a digit, so it dropped every `arena_h2d` line — the
  pass-closing segment and the only H2D left. Measured on a two-pass log: 18
  lines returned where 20 exist, with nothing to say a segment went missing. The
  page also still described `relocate` and `sm_h2d`, which no run has emitted
  since the image moved into the arena copy, and told the reader to sum five
  control-plane segments where three exist. The pinned reference table keeps its
  numbers with a footnote naming which markers have since changed meaning.
- The AICPU boot path zeroed the completion mailbox immediately after
  `init_empty()`, whose writes are all zero, leaving that call dead while the
  comment above it presented the call as load-bearing. The mailbox has one
  initializer again, and the boot comment records the conventions the `memset`
  silently coupled: a ready queue's empty state is a **non-zero** sequence ramp
  (`slots[i].sequence = i`; an unseeded queue accepts one push then reports
  full), the mailbox's is zeroed cursors and publication gates, and zeroing the
  region substitutes for neither. A non-zero ramp added to `init_empty()` would
  have been silently erased.

The `memset` was a superset of `init_empty()`, so its removal changes no
behavior. The rest is comments, one doc, and a marker's attributes — no
dispatch-path or wire-format change.

## Testing

Onboard a2a3, under a `task-submit` device lock, with the runtimes rebuilt for
a2a3 / a5 / a2a3sim / a5sim:

- [x] Marker arithmetic observed directly — `graph_upload` reports
      `defs=2 bytes=4112 submissions=3` where `arena_h2d` reports
      `bytes=3904 copied=704 sm=2048 subs=1152`. 704 + 2048 + 1152 = 3904, so
      the upload partitions exactly and `subs=` appears once. Pre-fix,
      `graph_upload` would have read 5264.
- [x] `host_build_graph` onboard sweep (`-m "not sdma" --exclude-level 4`) —
      42 passed, 1 skipped
- [x] `pytest tests/ut -m "not requires_hardware"` — 1671 passed, 7 skipped
- [x] cpput `ctest -LE requires_hardware` — 114 of 114
- [x] `markdownlint-cli2`, `clang-format --dry-run --Werror` — clean

No regression test accompanies the byte fix: the attributes exist only in a full
onboard bind's log, so the observation above is the evidence. The mailbox change
is behavior-preserving by construction, so no failing repro precedes it.
