### PR TITLE
host_build_graph: build Definition images in place

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -673,7 +673,7 @@ T *graph_image_section(std::vector<std::byte> *image, uint32_t offset) {
     return offset == 0 ? nullptr : reinterpret_cast<T *>(image->data() + offset);
 }
 
-bool graph_build_definition_in_place(const GraphRecording &recording, std::vector<std::byte> *image) {
+bool graph_build_definition(const GraphRecording &recording, std::vector<std::byte> *image) {
     if (image == nullptr || recording.unsupported || recording.nodes.empty() ||
         recording.nodes.size() > GRAPH_MAX_NODES || recording.boundary_tensors.empty() ||
         recording.boundary_tensors.size() > UINT16_MAX ||
@@ -746,6 +746,11 @@ bool graph_build_definition_in_place(const GraphRecording &recording, std::vecto
         return false;
     }
     definition.total_bytes = static_cast<uint32_t>(image_bytes);
+    // Zero-filled, not merely sized: the alignment slack between sections is inside
+    // the hashed range, so the content hash identifies two structurally identical
+    // Definitions only while that slack is a fixed value. A reserve-and-fill that
+    // left it uninitialized would still verify on the device — same bytes, same
+    // hash — while giving equal Definitions unequal hashes.
     image->assign(image_bytes, std::byte{0});
     auto *fanout_offsets = graph_image_section<uint32_t>(image, definition.off_fanout_offsets);
     auto *fanout_indices = graph_image_section<uint16_t>(image, definition.off_fanout_indices);
@@ -760,7 +765,6 @@ bool graph_build_definition_in_place(const GraphRecording &recording, std::vecto
     auto *scalar_sources = graph_image_section<GraphScalarSourceRef>(image, definition.off_scalar_sources);
     auto *signatures = graph_image_section<GraphBoundarySignature>(image, definition.off_boundary_signatures);
     auto *predicates = graph_image_section<GraphPredicate>(image, definition.off_predicates);
-    std::fill_n(fanout_offsets, recording.nodes.size() + 1, uint32_t{0});
     uint64_t required_heap = 0;
     size_t tensor_cursor = 0;
     size_t scalar_cursor = 0;
@@ -870,10 +874,6 @@ bool graph_build_definition_in_place(const GraphRecording &recording, std::vecto
     definition.content_hash = graph_definition_content_hash(image->data(), image->size());
     std::memcpy(image->data(), &definition, sizeof(definition));
     return true;
-}
-
-bool graph_build_definition(const GraphRecording &recording, std::vector<std::byte> *image) {
-    return graph_build_definition_in_place(recording, image);
 }
 
 const GraphDefinition *graph_definition(const std::vector<std::byte> &image) {

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -617,18 +617,6 @@ GraphBoundarySignature graph_boundary_signature(const ChipTensor &tensor, Tensor
     return signature;
 }
 
-template <typename T>
-uint32_t graph_append_section(std::vector<std::byte> *image, const std::vector<T> &values) {
-    if (values.empty()) return 0;
-    if (image->size() > UINT32_MAX || values.size() > UINT32_MAX / sizeof(T)) return 0;
-    const size_t aligned = PTO2_ALIGN_UP(image->size(), alignof(T));
-    const size_t bytes = values.size() * sizeof(T);
-    if (aligned > UINT32_MAX || bytes > UINT32_MAX - aligned) return 0;
-    image->resize(aligned + bytes);
-    std::memcpy(image->data() + aligned, values.data(), bytes);
-    return static_cast<uint32_t>(aligned);
-}
-
 std::optional<GraphTensorSourceRef> graph_pack_tensor_source(const GraphRecordedTensorSourceRef &source) {
     if (source.source_index > UINT16_MAX) return std::nullopt;
 
@@ -665,59 +653,126 @@ std::optional<GraphScalarSourceRef> graph_pack_scalar_source(const GraphRecorded
     return packed;
 }
 
-bool graph_build_definition(const GraphRecording &recording, std::vector<std::byte> *image) {
+template <typename T>
+bool graph_layout_section(size_t count, size_t *cursor, uint32_t *offset) {
+    if (count == 0) {
+        *offset = 0;
+        return true;
+    }
+    if (*cursor > UINT32_MAX || count > UINT32_MAX / sizeof(T)) return false;
+    const size_t aligned = (*cursor + alignof(T) - 1) & ~(alignof(T) - 1);
+    const size_t bytes = count * sizeof(T);
+    if (aligned > UINT32_MAX || bytes > UINT32_MAX - aligned) return false;
+    *offset = static_cast<uint32_t>(aligned);
+    *cursor = aligned + bytes;
+    return true;
+}
+
+template <typename T>
+T *graph_image_section(std::vector<std::byte> *image, uint32_t offset) {
+    return offset == 0 ? nullptr : reinterpret_cast<T *>(image->data() + offset);
+}
+
+bool graph_build_definition_in_place(const GraphRecording &recording, std::vector<std::byte> *image) {
     if (image == nullptr || recording.unsupported || recording.nodes.empty() ||
-        recording.nodes.size() > GRAPH_MAX_NODES || recording.boundary_tensors.size() > UINT16_MAX ||
-        recording.boundary_tensors.size() != recording.boundary_types.size() || recording.boundary_args == nullptr ||
-        std::any_of(recording.boundary_tensors.begin(), recording.boundary_tensors.end(), [](const ChipTensor &tensor) {
-            return tensor.ndims > MAX_TENSOR_DIMS;
-        })) {
+        recording.nodes.size() > GRAPH_MAX_NODES || recording.boundary_tensors.empty() ||
+        recording.boundary_tensors.size() > UINT16_MAX ||
+        recording.boundary_tensors.size() != recording.boundary_types.size() || recording.boundary_args == nullptr) {
         return false;
     }
 
-    // Every per-node array is grown by push_back below, and the recording
-    // already knows how many entries each node contributes, so size them once
-    // here. Left unreserved, packing 277 nodes' args reallocates each vector a
-    // dozen times and copies its whole contents each time.
     size_t total_tensors = 0;
+    size_t total_scalars = 0;
+    size_t total_fanins = 0;
+    size_t root_count = 0;
+    size_t predicate_count = 0;
     for (const GraphRecordedNode &source : recording.nodes) {
+        if (source.tensors.size() > UINT32_MAX - total_tensors || source.scalar_count > UINT32_MAX - total_scalars ||
+            source.fanin_count > UINT32_MAX - total_fanins ||
+            source.tensor_source_offset > recording.tensor_sources.size() ||
+            source.tensors.size() > recording.tensor_sources.size() - source.tensor_source_offset ||
+            source.scalar_offset > recording.scalars.size() ||
+            source.scalar_count > recording.scalars.size() - source.scalar_offset ||
+            source.scalar_offset > recording.scalar_sources.size() ||
+            source.scalar_count > recording.scalar_sources.size() - source.scalar_offset ||
+            source.fanin_offset > recording.internal_fanins.size() ||
+            source.fanin_count > recording.internal_fanins.size() - source.fanin_offset) {
+            return false;
+        }
         total_tensors += source.tensors.size();
+        total_scalars += source.scalar_count;
+        total_fanins += source.fanin_count;
+        root_count += source.fanin_count == 0 ? 1 : 0;
+        predicate_count += source.predicate_index >= 0 ? 1 : 0;
     }
-    const size_t total_scalars = recording.scalars.size();
-    const size_t total_fanins = recording.internal_fanins.size();
-    std::vector<uint32_t> fanout_counts(recording.nodes.size(), 0);
-    std::vector<uint32_t> fanin_offsets(recording.nodes.size() + 1, 0);
-    std::vector<uint16_t> fanin_indices;
-    std::vector<uint16_t> roots;
-    std::vector<uint64_t> node_offsets(recording.nodes.size(), 0);
-    std::vector<GraphNodeDefinition> nodes(recording.nodes.size());
-    std::vector<GraphTensor> tensors;
-    std::vector<GraphTensorSourceRef> tensor_sources;
-    std::vector<uint64_t> scalars;
-    std::vector<GraphScalarSourceRef> scalar_sources;
-    std::vector<GraphPredicate> predicates;
-    predicates.reserve(recording.predicates.size());
-    fanin_indices.reserve(total_fanins);
-    roots.reserve(recording.nodes.size());
-    tensors.reserve(total_tensors);
-    tensor_sources.reserve(total_tensors);
-    scalars.reserve(total_scalars);
-    scalar_sources.reserve(total_scalars);
+    if (predicate_count > UINT16_MAX) return false;
 
+    GraphDefinition definition{};
+    definition.full_key = recording.full_key;
+    definition.task_count = static_cast<uint32_t>(recording.nodes.size());
+    definition.edge_count = static_cast<uint32_t>(total_fanins);
+    definition.root_count = static_cast<uint32_t>(root_count);
+    definition.boundary_count = static_cast<uint32_t>(recording.boundary_tensors.size());
+    definition.boundary_scalar_count = static_cast<uint32_t>(recording.boundary_scalar_count);
+    definition.tensor_arg_count = static_cast<uint32_t>(total_tensors);
+    definition.scalar_arg_count = static_cast<uint32_t>(total_scalars);
+    definition.predicate_count = static_cast<uint32_t>(predicate_count);
+    size_t execution_storage_bytes = 0;
+    if (!graph_execution_storage_bytes(
+            static_cast<int32_t>(definition.task_count), definition.tensor_arg_count, definition.scalar_arg_count,
+            &execution_storage_bytes
+        ) ||
+        execution_storage_bytes > UINT32_MAX) {
+        return false;
+    }
+    definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
+
+    size_t image_bytes = sizeof(GraphDefinition);
+    if (!graph_layout_section<uint32_t>(recording.nodes.size() + 1, &image_bytes, &definition.off_fanout_offsets) ||
+        !graph_layout_section<uint16_t>(total_fanins, &image_bytes, &definition.off_fanout_indices) ||
+        !graph_layout_section<uint32_t>(recording.nodes.size() + 1, &image_bytes, &definition.off_fanin_offsets) ||
+        !graph_layout_section<uint16_t>(total_fanins, &image_bytes, &definition.off_fanin_indices) ||
+        !graph_layout_section<uint16_t>(root_count, &image_bytes, &definition.off_root_indices) ||
+        !graph_layout_section<uint64_t>(recording.nodes.size(), &image_bytes, &definition.off_node_offsets) ||
+        !graph_layout_section<GraphNodeDefinition>(recording.nodes.size(), &image_bytes, &definition.off_nodes) ||
+        !graph_layout_section<GraphTensor>(total_tensors, &image_bytes, &definition.off_tensors) ||
+        !graph_layout_section<GraphTensorSourceRef>(total_tensors, &image_bytes, &definition.off_tensor_sources) ||
+        !graph_layout_section<uint64_t>(total_scalars, &image_bytes, &definition.off_scalars) ||
+        !graph_layout_section<GraphScalarSourceRef>(total_scalars, &image_bytes, &definition.off_scalar_sources) ||
+        !graph_layout_section<GraphBoundarySignature>(
+            recording.boundary_tensors.size(), &image_bytes, &definition.off_boundary_signatures
+        ) ||
+        !graph_layout_section<GraphPredicate>(predicate_count, &image_bytes, &definition.off_predicates)) {
+        return false;
+    }
+    definition.total_bytes = static_cast<uint32_t>(image_bytes);
+    image->assign(image_bytes, std::byte{0});
+    auto *fanout_offsets = graph_image_section<uint32_t>(image, definition.off_fanout_offsets);
+    auto *fanout_indices = graph_image_section<uint16_t>(image, definition.off_fanout_indices);
+    auto *fanin_offsets = graph_image_section<uint32_t>(image, definition.off_fanin_offsets);
+    auto *fanin_indices = graph_image_section<uint16_t>(image, definition.off_fanin_indices);
+    auto *roots = graph_image_section<uint16_t>(image, definition.off_root_indices);
+    auto *node_offsets = graph_image_section<uint64_t>(image, definition.off_node_offsets);
+    auto *nodes = graph_image_section<GraphNodeDefinition>(image, definition.off_nodes);
+    auto *tensors = graph_image_section<GraphTensor>(image, definition.off_tensors);
+    auto *tensor_sources = graph_image_section<GraphTensorSourceRef>(image, definition.off_tensor_sources);
+    auto *scalars = graph_image_section<uint64_t>(image, definition.off_scalars);
+    auto *scalar_sources = graph_image_section<GraphScalarSourceRef>(image, definition.off_scalar_sources);
+    auto *signatures = graph_image_section<GraphBoundarySignature>(image, definition.off_boundary_signatures);
+    auto *predicates = graph_image_section<GraphPredicate>(image, definition.off_predicates);
+    std::fill_n(fanout_offsets, recording.nodes.size() + 1, uint32_t{0});
     uint64_t required_heap = 0;
-    uint32_t edge_count = 0;
+    size_t tensor_cursor = 0;
+    size_t scalar_cursor = 0;
+    size_t fanin_cursor = 0;
+    size_t root_cursor = 0;
+    size_t predicate_cursor = 0;
+    fanin_offsets[0] = 0;
     for (size_t i = 0; i < recording.nodes.size(); ++i) {
         const GraphRecordedNode &source = recording.nodes[i];
         if (source.total_output_size > static_cast<size_t>(INT32_MAX) ||
             source.tensors.size() > static_cast<size_t>(INT32_MAX) ||
-            source.scalar_count > static_cast<uint32_t>(INT32_MAX) || source.fanin_count > UINT16_MAX ||
-            tensors.size() > UINT32_MAX - source.tensors.size() ||
-            tensor_sources.size() > UINT32_MAX - source.tensors.size() ||
-            scalars.size() > UINT32_MAX - source.scalar_count ||
-            scalar_sources.size() > UINT32_MAX - source.scalar_count ||
-            std::any_of(source.tensors.begin(), source.tensors.end(), [](const ChipTensor &tensor) {
-                return tensor.ndims > MAX_TENSOR_DIMS;
-            })) {
+            source.scalar_count > static_cast<uint32_t>(INT32_MAX) || source.fanin_count > UINT16_MAX) {
             return false;
         }
         node_offsets[i] = required_heap;
@@ -725,15 +780,14 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
         if (required_heap > UINT64_MAX - output_bytes) return false;
         required_heap += output_bytes;
 
-        fanin_offsets[i + 1] = fanin_offsets[i] + source.fanin_count;
-        if (source.fanin_count == 0) roots.push_back(static_cast<uint16_t>(i));
+        if (source.fanin_count == 0) roots[root_cursor++] = static_cast<uint16_t>(i);
         for (uint32_t f = 0; f < source.fanin_count; ++f) {
             const size_t producer = recording.internal_fanins[source.fanin_offset + f];
             if (producer >= i) return false;
-            fanout_counts[producer]++;
-            fanin_indices.push_back(static_cast<uint16_t>(producer));
-            edge_count++;
+            fanin_indices[fanin_cursor++] = static_cast<uint16_t>(producer);
+            fanout_offsets[producer + 1]++;
         }
+        fanin_offsets[i + 1] = static_cast<uint32_t>(fanin_cursor);
 
         GraphNodeDefinition &node = nodes[i];
         std::copy(source.kernel_ids.begin(), source.kernel_ids.end(), std::begin(node.kernel_id));
@@ -744,35 +798,32 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
         node.tensor_count = static_cast<int32_t>(source.tensors.size());
         node.scalar_count = static_cast<int32_t>(source.scalar_count);
         node.total_output_size = static_cast<int32_t>(source.total_output_size);
-        node.tensor_offset = static_cast<uint32_t>(tensors.size());
-        node.scalar_offset = static_cast<uint32_t>(scalars.size());
+        node.tensor_offset = static_cast<uint32_t>(tensor_cursor);
+        node.scalar_offset = static_cast<uint32_t>(scalar_cursor);
         node.dump_metadata = source.dump_metadata;
         node.predicate_slot = 0;
         if (source.predicate_index >= 0) {
-            if (static_cast<size_t>(source.predicate_index) >= recording.predicates.size() ||
-                predicates.size() >= static_cast<size_t>(UINT16_MAX)) {
-                return false;
-            }
+            if (static_cast<size_t>(source.predicate_index) >= recording.predicates.size()) return false;
             const GraphRecordedPredicate &recorded = recording.predicates[source.predicate_index];
             std::optional<GraphTensorSourceRef> packed_source = graph_pack_tensor_source(recorded.source);
             if (!packed_source.has_value() || recorded.operand.ndims > MAX_TENSOR_DIMS) return false;
-            GraphPredicate packed{};
+            GraphPredicate &packed = predicates[predicate_cursor];
             packed.operand = graph_tensor_pack(recorded.operand);
             packed.operand_source = *packed_source;
             packed.elem_offset = recorded.elem_offset;
             packed.target = recorded.target;
             packed.elem_size = recorded.elem_size;
             packed.op = static_cast<uint8_t>(recorded.op);
-            node.predicate_slot = static_cast<uint16_t>(predicates.size() + 1);
-            predicates.push_back(packed);
+            node.predicate_slot = static_cast<uint16_t>(++predicate_cursor);
         }
-        for (const ChipTensor &tensor : source.tensors)
-            tensors.push_back(graph_tensor_pack(tensor));
         for (size_t t = 0; t < source.tensors.size(); ++t) {
+            if (source.tensors[t].ndims > MAX_TENSOR_DIMS) return false;
+            tensors[tensor_cursor] = graph_tensor_pack(source.tensors[t]);
             std::optional<GraphTensorSourceRef> packed_source =
                 graph_pack_tensor_source(recording.tensor_sources[source.tensor_source_offset + t]);
             if (!packed_source.has_value()) return false;
-            tensor_sources.push_back(*packed_source);
+            tensor_sources[tensor_cursor] = *packed_source;
+            tensor_cursor++;
         }
         for (size_t scalar_index = 0; scalar_index < source.scalar_count; ++scalar_index) {
             std::optional<GraphScalarSourceRef> packed_source =
@@ -782,119 +833,47 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
                  packed_source->source_index >= recording.boundary_args->scalar_count())) {
                 return false;
             }
-            scalar_sources.push_back(*packed_source);
-            scalars.push_back(
-                packed_source->source == static_cast<uint8_t>(GraphScalarSource::BOUNDARY) ?
-                    0 :
-                    recording.scalars[source.scalar_offset + scalar_index]
-            );
+            scalar_sources[scalar_cursor] = *packed_source;
+            scalars[scalar_cursor++] = packed_source->source == static_cast<uint8_t>(GraphScalarSource::BOUNDARY) ?
+                                           0 :
+                                           recording.scalars[source.scalar_offset + scalar_index];
         }
     }
-
-    std::vector<uint32_t> fanout_offsets(recording.nodes.size() + 1, 0);
+    if (tensor_cursor != total_tensors || scalar_cursor != total_scalars || fanin_cursor != total_fanins ||
+        root_cursor != root_count || predicate_cursor != predicate_count) {
+        return false;
+    }
+    definition.required_heap = required_heap;
     for (size_t i = 0; i < recording.nodes.size(); ++i)
-        fanout_offsets[i + 1] = fanout_offsets[i] + fanout_counts[i];
-    std::vector<uint16_t> fanout_indices(edge_count);
-    std::vector<uint32_t> cursors(fanout_offsets.begin(), fanout_offsets.end() - 1);
+        fanout_offsets[i + 1] += fanout_offsets[i];
+    std::vector<uint32_t> cursors(fanout_offsets, fanout_offsets + recording.nodes.size());
     for (size_t consumer = 0; consumer < recording.nodes.size(); ++consumer) {
-        const GraphRecordedNode &consumer_node = recording.nodes[consumer];
-        for (uint32_t f = 0; f < consumer_node.fanin_count; ++f) {
-            const size_t producer = recording.internal_fanins[consumer_node.fanin_offset + f];
+        for (uint32_t f = fanin_offsets[consumer]; f < fanin_offsets[consumer + 1]; ++f) {
+            const size_t producer = fanin_indices[f];
             fanout_indices[cursors[producer]++] = static_cast<uint16_t>(consumer);
         }
     }
-
-    std::vector<GraphBoundarySignature> signatures;
-    signatures.reserve(recording.boundary_tensors.size());
     for (size_t i = 0; i < recording.boundary_tensors.size(); ++i) {
+        const ChipTensor &tensor = recording.boundary_tensors[i];
+        if (tensor.ndims > MAX_TENSOR_DIMS) return false;
         uint16_t alias_rep = static_cast<uint16_t>(i);
         for (size_t j = 0; j < i; ++j) {
-            if (recording.boundary_tensors[j].buffer.addr == recording.boundary_tensors[i].buffer.addr &&
-                recording.boundary_tensors[j].buffer.size == recording.boundary_tensors[i].buffer.size) {
+            if (recording.boundary_tensors[j].buffer.addr == tensor.buffer.addr &&
+                recording.boundary_tensors[j].buffer.size == tensor.buffer.size) {
                 alias_rep = static_cast<uint16_t>(j);
                 break;
             }
         }
-        signatures.push_back(
-            graph_boundary_signature(recording.boundary_tensors[i], recording.boundary_types[i], alias_rep)
-        );
+        signatures[i] = graph_boundary_signature(tensor, recording.boundary_types[i], alias_rep);
     }
-
-    image->assign(sizeof(GraphDefinition), std::byte{0});
-    GraphDefinition definition{};
-    definition.full_key = recording.full_key;
-    definition.required_heap = required_heap;
-    definition.task_count = static_cast<uint32_t>(nodes.size());
-    definition.edge_count = edge_count;
-    definition.root_count = static_cast<uint32_t>(roots.size());
-    definition.boundary_count = static_cast<uint32_t>(signatures.size());
-    definition.boundary_scalar_count = static_cast<uint32_t>(recording.boundary_scalar_count);
-    definition.tensor_arg_count = static_cast<uint32_t>(tensors.size());
-    definition.scalar_arg_count = static_cast<uint32_t>(scalars.size());
-    definition.predicate_count = static_cast<uint32_t>(predicates.size());
-    // An execution's storage is the node array plus this Definition's two argument
-    // pools, which the nodes index by their own tensor_offset / scalar_offset — so the
-    // arg-table counts size them, and no per-node scan is needed.
-    size_t execution_storage_bytes = 0;
-    if (!graph_execution_storage_bytes(
-            static_cast<int32_t>(definition.task_count), definition.tensor_arg_count, definition.scalar_arg_count,
-            &execution_storage_bytes
-        ) ||
-        execution_storage_bytes > UINT32_MAX) {
-        return false;
-    }
-    definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
-    // Every section's byte count is known now, so the image grows once instead of
-    // resizing eleven times. Each append aligns its start, hence the per-section
-    // alignment slack.
-    auto section_bytes = [](size_t count, size_t elem_size, size_t align) {
-        return count == 0 ? size_t{0} : (align - 1) + count * elem_size;
-    };
-    image->reserve(
-        image->size() + section_bytes(fanout_offsets.size(), sizeof(uint32_t), alignof(uint32_t)) +
-        section_bytes(fanout_indices.size(), sizeof(uint16_t), alignof(uint16_t)) +
-        section_bytes(fanin_offsets.size(), sizeof(uint32_t), alignof(uint32_t)) +
-        section_bytes(fanin_indices.size(), sizeof(uint16_t), alignof(uint16_t)) +
-        section_bytes(roots.size(), sizeof(uint16_t), alignof(uint16_t)) +
-        section_bytes(node_offsets.size(), sizeof(uint64_t), alignof(uint64_t)) +
-        section_bytes(nodes.size(), sizeof(GraphNodeDefinition), alignof(GraphNodeDefinition)) +
-        section_bytes(tensors.size(), sizeof(GraphTensor), alignof(GraphTensor)) +
-        section_bytes(tensor_sources.size(), sizeof(GraphTensorSourceRef), alignof(GraphTensorSourceRef)) +
-        section_bytes(scalars.size(), sizeof(uint64_t), alignof(uint64_t)) +
-        section_bytes(scalar_sources.size(), sizeof(GraphScalarSourceRef), alignof(GraphScalarSourceRef)) +
-        section_bytes(signatures.size(), sizeof(GraphBoundarySignature), alignof(GraphBoundarySignature)) +
-        section_bytes(predicates.size(), sizeof(GraphPredicate), alignof(GraphPredicate))
-    );
-    definition.off_fanout_offsets = graph_append_section(image, fanout_offsets);
-    definition.off_fanout_indices = graph_append_section(image, fanout_indices);
-    definition.off_fanin_offsets = graph_append_section(image, fanin_offsets);
-    definition.off_fanin_indices = graph_append_section(image, fanin_indices);
-    definition.off_root_indices = graph_append_section(image, roots);
-    definition.off_node_offsets = graph_append_section(image, node_offsets);
-    definition.off_nodes = graph_append_section(image, nodes);
-    definition.off_tensors = graph_append_section(image, tensors);
-    definition.off_tensor_sources = graph_append_section(image, tensor_sources);
-    definition.off_scalars = graph_append_section(image, scalars);
-    definition.off_scalar_sources = graph_append_section(image, scalar_sources);
-    definition.off_boundary_signatures = graph_append_section(image, signatures);
-    definition.off_predicates = graph_append_section(image, predicates);
-    if (definition.off_fanout_offsets == 0 || definition.off_fanin_offsets == 0 || definition.off_node_offsets == 0 ||
-        definition.off_nodes == 0 || definition.off_boundary_signatures == 0 ||
-        (!tensors.empty() && definition.off_tensors == 0) ||
-        (!tensor_sources.empty() && definition.off_tensor_sources == 0) ||
-        (!scalars.empty() && definition.off_scalars == 0) ||
-        (!scalar_sources.empty() && definition.off_scalar_sources == 0) ||
-        (!fanout_indices.empty() && definition.off_fanout_indices == 0) ||
-        (!fanin_indices.empty() && definition.off_fanin_indices == 0) ||
-        (!roots.empty() && definition.off_root_indices == 0) ||
-        (!predicates.empty() && definition.off_predicates == 0)) {
-        return false;
-    }
-    definition.total_bytes = static_cast<uint32_t>(image->size());
     std::memcpy(image->data(), &definition, sizeof(definition));
-    definition.content_hash = graph_hash_bytes(1469598103934665603ULL, image->data(), image->size());
+    definition.content_hash = graph_definition_content_hash(image->data(), image->size());
     std::memcpy(image->data(), &definition, sizeof(definition));
     return true;
+}
+
+bool graph_build_definition(const GraphRecording &recording, std::vector<std::byte> *image) {
+    return graph_build_definition_in_place(recording, image);
 }
 
 const GraphDefinition *graph_definition(const std::vector<std::byte> &image) {

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -673,7 +673,7 @@ T *graph_image_section(std::vector<std::byte> *image, uint32_t offset) {
     return offset == 0 ? nullptr : reinterpret_cast<T *>(image->data() + offset);
 }
 
-bool graph_build_definition_in_place(const GraphRecording &recording, std::vector<std::byte> *image) {
+bool graph_build_definition(const GraphRecording &recording, std::vector<std::byte> *image) {
     if (image == nullptr || recording.unsupported || recording.nodes.empty() ||
         recording.nodes.size() > GRAPH_MAX_NODES || recording.boundary_tensors.empty() ||
         recording.boundary_tensors.size() > UINT16_MAX ||
@@ -746,6 +746,11 @@ bool graph_build_definition_in_place(const GraphRecording &recording, std::vecto
         return false;
     }
     definition.total_bytes = static_cast<uint32_t>(image_bytes);
+    // Zero-filled, not merely sized: the alignment slack between sections is inside
+    // the hashed range, so the content hash identifies two structurally identical
+    // Definitions only while that slack is a fixed value. A reserve-and-fill that
+    // left it uninitialized would still verify on the device — same bytes, same
+    // hash — while giving equal Definitions unequal hashes.
     image->assign(image_bytes, std::byte{0});
     auto *fanout_offsets = graph_image_section<uint32_t>(image, definition.off_fanout_offsets);
     auto *fanout_indices = graph_image_section<uint16_t>(image, definition.off_fanout_indices);
@@ -760,7 +765,6 @@ bool graph_build_definition_in_place(const GraphRecording &recording, std::vecto
     auto *scalar_sources = graph_image_section<GraphScalarSourceRef>(image, definition.off_scalar_sources);
     auto *signatures = graph_image_section<GraphBoundarySignature>(image, definition.off_boundary_signatures);
     auto *predicates = graph_image_section<GraphPredicate>(image, definition.off_predicates);
-    std::fill_n(fanout_offsets, recording.nodes.size() + 1, uint32_t{0});
     uint64_t required_heap = 0;
     size_t tensor_cursor = 0;
     size_t scalar_cursor = 0;
@@ -870,10 +874,6 @@ bool graph_build_definition_in_place(const GraphRecording &recording, std::vecto
     definition.content_hash = graph_definition_content_hash(image->data(), image->size());
     std::memcpy(image->data(), &definition, sizeof(definition));
     return true;
-}
-
-bool graph_build_definition(const GraphRecording &recording, std::vector<std::byte> *image) {
-    return graph_build_definition_in_place(recording, image);
 }
 
 const GraphDefinition *graph_definition(const std::vector<std::byte> &image) {

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -617,18 +617,6 @@ GraphBoundarySignature graph_boundary_signature(const ChipTensor &tensor, Tensor
     return signature;
 }
 
-template <typename T>
-uint32_t graph_append_section(std::vector<std::byte> *image, const std::vector<T> &values) {
-    if (values.empty()) return 0;
-    if (image->size() > UINT32_MAX || values.size() > UINT32_MAX / sizeof(T)) return 0;
-    const size_t aligned = PTO2_ALIGN_UP(image->size(), alignof(T));
-    const size_t bytes = values.size() * sizeof(T);
-    if (aligned > UINT32_MAX || bytes > UINT32_MAX - aligned) return 0;
-    image->resize(aligned + bytes);
-    std::memcpy(image->data() + aligned, values.data(), bytes);
-    return static_cast<uint32_t>(aligned);
-}
-
 std::optional<GraphTensorSourceRef> graph_pack_tensor_source(const GraphRecordedTensorSourceRef &source) {
     if (source.source_index > UINT16_MAX) return std::nullopt;
 
@@ -665,59 +653,126 @@ std::optional<GraphScalarSourceRef> graph_pack_scalar_source(const GraphRecorded
     return packed;
 }
 
-bool graph_build_definition(const GraphRecording &recording, std::vector<std::byte> *image) {
+template <typename T>
+bool graph_layout_section(size_t count, size_t *cursor, uint32_t *offset) {
+    if (count == 0) {
+        *offset = 0;
+        return true;
+    }
+    if (*cursor > UINT32_MAX || count > UINT32_MAX / sizeof(T)) return false;
+    const size_t aligned = (*cursor + alignof(T) - 1) & ~(alignof(T) - 1);
+    const size_t bytes = count * sizeof(T);
+    if (aligned > UINT32_MAX || bytes > UINT32_MAX - aligned) return false;
+    *offset = static_cast<uint32_t>(aligned);
+    *cursor = aligned + bytes;
+    return true;
+}
+
+template <typename T>
+T *graph_image_section(std::vector<std::byte> *image, uint32_t offset) {
+    return offset == 0 ? nullptr : reinterpret_cast<T *>(image->data() + offset);
+}
+
+bool graph_build_definition_in_place(const GraphRecording &recording, std::vector<std::byte> *image) {
     if (image == nullptr || recording.unsupported || recording.nodes.empty() ||
-        recording.nodes.size() > GRAPH_MAX_NODES || recording.boundary_tensors.size() > UINT16_MAX ||
-        recording.boundary_tensors.size() != recording.boundary_types.size() || recording.boundary_args == nullptr ||
-        std::any_of(recording.boundary_tensors.begin(), recording.boundary_tensors.end(), [](const ChipTensor &tensor) {
-            return tensor.ndims > MAX_TENSOR_DIMS;
-        })) {
+        recording.nodes.size() > GRAPH_MAX_NODES || recording.boundary_tensors.empty() ||
+        recording.boundary_tensors.size() > UINT16_MAX ||
+        recording.boundary_tensors.size() != recording.boundary_types.size() || recording.boundary_args == nullptr) {
         return false;
     }
 
-    // Every per-node array is grown by push_back below, and the recording
-    // already knows how many entries each node contributes, so size them once
-    // here. Left unreserved, packing 277 nodes' args reallocates each vector a
-    // dozen times and copies its whole contents each time.
     size_t total_tensors = 0;
+    size_t total_scalars = 0;
+    size_t total_fanins = 0;
+    size_t root_count = 0;
+    size_t predicate_count = 0;
     for (const GraphRecordedNode &source : recording.nodes) {
+        if (source.tensors.size() > UINT32_MAX - total_tensors || source.scalar_count > UINT32_MAX - total_scalars ||
+            source.fanin_count > UINT32_MAX - total_fanins ||
+            source.tensor_source_offset > recording.tensor_sources.size() ||
+            source.tensors.size() > recording.tensor_sources.size() - source.tensor_source_offset ||
+            source.scalar_offset > recording.scalars.size() ||
+            source.scalar_count > recording.scalars.size() - source.scalar_offset ||
+            source.scalar_offset > recording.scalar_sources.size() ||
+            source.scalar_count > recording.scalar_sources.size() - source.scalar_offset ||
+            source.fanin_offset > recording.internal_fanins.size() ||
+            source.fanin_count > recording.internal_fanins.size() - source.fanin_offset) {
+            return false;
+        }
         total_tensors += source.tensors.size();
+        total_scalars += source.scalar_count;
+        total_fanins += source.fanin_count;
+        root_count += source.fanin_count == 0 ? 1 : 0;
+        predicate_count += source.predicate_index >= 0 ? 1 : 0;
     }
-    const size_t total_scalars = recording.scalars.size();
-    const size_t total_fanins = recording.internal_fanins.size();
-    std::vector<uint32_t> fanout_counts(recording.nodes.size(), 0);
-    std::vector<uint32_t> fanin_offsets(recording.nodes.size() + 1, 0);
-    std::vector<uint16_t> fanin_indices;
-    std::vector<uint16_t> roots;
-    std::vector<uint64_t> node_offsets(recording.nodes.size(), 0);
-    std::vector<GraphNodeDefinition> nodes(recording.nodes.size());
-    std::vector<GraphTensor> tensors;
-    std::vector<GraphTensorSourceRef> tensor_sources;
-    std::vector<uint64_t> scalars;
-    std::vector<GraphScalarSourceRef> scalar_sources;
-    std::vector<GraphPredicate> predicates;
-    predicates.reserve(recording.predicates.size());
-    fanin_indices.reserve(total_fanins);
-    roots.reserve(recording.nodes.size());
-    tensors.reserve(total_tensors);
-    tensor_sources.reserve(total_tensors);
-    scalars.reserve(total_scalars);
-    scalar_sources.reserve(total_scalars);
+    if (predicate_count > UINT16_MAX) return false;
 
+    GraphDefinition definition{};
+    definition.full_key = recording.full_key;
+    definition.task_count = static_cast<uint32_t>(recording.nodes.size());
+    definition.edge_count = static_cast<uint32_t>(total_fanins);
+    definition.root_count = static_cast<uint32_t>(root_count);
+    definition.boundary_count = static_cast<uint32_t>(recording.boundary_tensors.size());
+    definition.boundary_scalar_count = static_cast<uint32_t>(recording.boundary_scalar_count);
+    definition.tensor_arg_count = static_cast<uint32_t>(total_tensors);
+    definition.scalar_arg_count = static_cast<uint32_t>(total_scalars);
+    definition.predicate_count = static_cast<uint32_t>(predicate_count);
+    size_t execution_storage_bytes = 0;
+    if (!graph_execution_storage_bytes(
+            static_cast<int32_t>(definition.task_count), definition.tensor_arg_count, definition.scalar_arg_count,
+            &execution_storage_bytes
+        ) ||
+        execution_storage_bytes > UINT32_MAX) {
+        return false;
+    }
+    definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
+
+    size_t image_bytes = sizeof(GraphDefinition);
+    if (!graph_layout_section<uint32_t>(recording.nodes.size() + 1, &image_bytes, &definition.off_fanout_offsets) ||
+        !graph_layout_section<uint16_t>(total_fanins, &image_bytes, &definition.off_fanout_indices) ||
+        !graph_layout_section<uint32_t>(recording.nodes.size() + 1, &image_bytes, &definition.off_fanin_offsets) ||
+        !graph_layout_section<uint16_t>(total_fanins, &image_bytes, &definition.off_fanin_indices) ||
+        !graph_layout_section<uint16_t>(root_count, &image_bytes, &definition.off_root_indices) ||
+        !graph_layout_section<uint64_t>(recording.nodes.size(), &image_bytes, &definition.off_node_offsets) ||
+        !graph_layout_section<GraphNodeDefinition>(recording.nodes.size(), &image_bytes, &definition.off_nodes) ||
+        !graph_layout_section<GraphTensor>(total_tensors, &image_bytes, &definition.off_tensors) ||
+        !graph_layout_section<GraphTensorSourceRef>(total_tensors, &image_bytes, &definition.off_tensor_sources) ||
+        !graph_layout_section<uint64_t>(total_scalars, &image_bytes, &definition.off_scalars) ||
+        !graph_layout_section<GraphScalarSourceRef>(total_scalars, &image_bytes, &definition.off_scalar_sources) ||
+        !graph_layout_section<GraphBoundarySignature>(
+            recording.boundary_tensors.size(), &image_bytes, &definition.off_boundary_signatures
+        ) ||
+        !graph_layout_section<GraphPredicate>(predicate_count, &image_bytes, &definition.off_predicates)) {
+        return false;
+    }
+    definition.total_bytes = static_cast<uint32_t>(image_bytes);
+    image->assign(image_bytes, std::byte{0});
+    auto *fanout_offsets = graph_image_section<uint32_t>(image, definition.off_fanout_offsets);
+    auto *fanout_indices = graph_image_section<uint16_t>(image, definition.off_fanout_indices);
+    auto *fanin_offsets = graph_image_section<uint32_t>(image, definition.off_fanin_offsets);
+    auto *fanin_indices = graph_image_section<uint16_t>(image, definition.off_fanin_indices);
+    auto *roots = graph_image_section<uint16_t>(image, definition.off_root_indices);
+    auto *node_offsets = graph_image_section<uint64_t>(image, definition.off_node_offsets);
+    auto *nodes = graph_image_section<GraphNodeDefinition>(image, definition.off_nodes);
+    auto *tensors = graph_image_section<GraphTensor>(image, definition.off_tensors);
+    auto *tensor_sources = graph_image_section<GraphTensorSourceRef>(image, definition.off_tensor_sources);
+    auto *scalars = graph_image_section<uint64_t>(image, definition.off_scalars);
+    auto *scalar_sources = graph_image_section<GraphScalarSourceRef>(image, definition.off_scalar_sources);
+    auto *signatures = graph_image_section<GraphBoundarySignature>(image, definition.off_boundary_signatures);
+    auto *predicates = graph_image_section<GraphPredicate>(image, definition.off_predicates);
+    std::fill_n(fanout_offsets, recording.nodes.size() + 1, uint32_t{0});
     uint64_t required_heap = 0;
-    uint32_t edge_count = 0;
+    size_t tensor_cursor = 0;
+    size_t scalar_cursor = 0;
+    size_t fanin_cursor = 0;
+    size_t root_cursor = 0;
+    size_t predicate_cursor = 0;
+    fanin_offsets[0] = 0;
     for (size_t i = 0; i < recording.nodes.size(); ++i) {
         const GraphRecordedNode &source = recording.nodes[i];
         if (source.total_output_size > static_cast<size_t>(INT32_MAX) ||
             source.tensors.size() > static_cast<size_t>(INT32_MAX) ||
-            source.scalar_count > static_cast<uint32_t>(INT32_MAX) || source.fanin_count > UINT16_MAX ||
-            tensors.size() > UINT32_MAX - source.tensors.size() ||
-            tensor_sources.size() > UINT32_MAX - source.tensors.size() ||
-            scalars.size() > UINT32_MAX - source.scalar_count ||
-            scalar_sources.size() > UINT32_MAX - source.scalar_count ||
-            std::any_of(source.tensors.begin(), source.tensors.end(), [](const ChipTensor &tensor) {
-                return tensor.ndims > MAX_TENSOR_DIMS;
-            })) {
+            source.scalar_count > static_cast<uint32_t>(INT32_MAX) || source.fanin_count > UINT16_MAX) {
             return false;
         }
         node_offsets[i] = required_heap;
@@ -725,15 +780,14 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
         if (required_heap > UINT64_MAX - output_bytes) return false;
         required_heap += output_bytes;
 
-        fanin_offsets[i + 1] = fanin_offsets[i] + source.fanin_count;
-        if (source.fanin_count == 0) roots.push_back(static_cast<uint16_t>(i));
+        if (source.fanin_count == 0) roots[root_cursor++] = static_cast<uint16_t>(i);
         for (uint32_t f = 0; f < source.fanin_count; ++f) {
             const size_t producer = recording.internal_fanins[source.fanin_offset + f];
             if (producer >= i) return false;
-            fanout_counts[producer]++;
-            fanin_indices.push_back(static_cast<uint16_t>(producer));
-            edge_count++;
+            fanin_indices[fanin_cursor++] = static_cast<uint16_t>(producer);
+            fanout_offsets[producer + 1]++;
         }
+        fanin_offsets[i + 1] = static_cast<uint32_t>(fanin_cursor);
 
         GraphNodeDefinition &node = nodes[i];
         std::copy(source.kernel_ids.begin(), source.kernel_ids.end(), std::begin(node.kernel_id));
@@ -744,35 +798,32 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
         node.tensor_count = static_cast<int32_t>(source.tensors.size());
         node.scalar_count = static_cast<int32_t>(source.scalar_count);
         node.total_output_size = static_cast<int32_t>(source.total_output_size);
-        node.tensor_offset = static_cast<uint32_t>(tensors.size());
-        node.scalar_offset = static_cast<uint32_t>(scalars.size());
+        node.tensor_offset = static_cast<uint32_t>(tensor_cursor);
+        node.scalar_offset = static_cast<uint32_t>(scalar_cursor);
         node.dump_metadata = source.dump_metadata;
         node.predicate_slot = 0;
         if (source.predicate_index >= 0) {
-            if (static_cast<size_t>(source.predicate_index) >= recording.predicates.size() ||
-                predicates.size() >= static_cast<size_t>(UINT16_MAX)) {
-                return false;
-            }
+            if (static_cast<size_t>(source.predicate_index) >= recording.predicates.size()) return false;
             const GraphRecordedPredicate &recorded = recording.predicates[source.predicate_index];
             std::optional<GraphTensorSourceRef> packed_source = graph_pack_tensor_source(recorded.source);
             if (!packed_source.has_value() || recorded.operand.ndims > MAX_TENSOR_DIMS) return false;
-            GraphPredicate packed{};
+            GraphPredicate &packed = predicates[predicate_cursor];
             packed.operand = graph_tensor_pack(recorded.operand);
             packed.operand_source = *packed_source;
             packed.elem_offset = recorded.elem_offset;
             packed.target = recorded.target;
             packed.elem_size = recorded.elem_size;
             packed.op = static_cast<uint8_t>(recorded.op);
-            node.predicate_slot = static_cast<uint16_t>(predicates.size() + 1);
-            predicates.push_back(packed);
+            node.predicate_slot = static_cast<uint16_t>(++predicate_cursor);
         }
-        for (const ChipTensor &tensor : source.tensors)
-            tensors.push_back(graph_tensor_pack(tensor));
         for (size_t t = 0; t < source.tensors.size(); ++t) {
+            if (source.tensors[t].ndims > MAX_TENSOR_DIMS) return false;
+            tensors[tensor_cursor] = graph_tensor_pack(source.tensors[t]);
             std::optional<GraphTensorSourceRef> packed_source =
                 graph_pack_tensor_source(recording.tensor_sources[source.tensor_source_offset + t]);
             if (!packed_source.has_value()) return false;
-            tensor_sources.push_back(*packed_source);
+            tensor_sources[tensor_cursor] = *packed_source;
+            tensor_cursor++;
         }
         for (size_t scalar_index = 0; scalar_index < source.scalar_count; ++scalar_index) {
             std::optional<GraphScalarSourceRef> packed_source =
@@ -782,119 +833,47 @@ bool graph_build_definition(const GraphRecording &recording, std::vector<std::by
                  packed_source->source_index >= recording.boundary_args->scalar_count())) {
                 return false;
             }
-            scalar_sources.push_back(*packed_source);
-            scalars.push_back(
-                packed_source->source == static_cast<uint8_t>(GraphScalarSource::BOUNDARY) ?
-                    0 :
-                    recording.scalars[source.scalar_offset + scalar_index]
-            );
+            scalar_sources[scalar_cursor] = *packed_source;
+            scalars[scalar_cursor++] = packed_source->source == static_cast<uint8_t>(GraphScalarSource::BOUNDARY) ?
+                                           0 :
+                                           recording.scalars[source.scalar_offset + scalar_index];
         }
     }
-
-    std::vector<uint32_t> fanout_offsets(recording.nodes.size() + 1, 0);
+    if (tensor_cursor != total_tensors || scalar_cursor != total_scalars || fanin_cursor != total_fanins ||
+        root_cursor != root_count || predicate_cursor != predicate_count) {
+        return false;
+    }
+    definition.required_heap = required_heap;
     for (size_t i = 0; i < recording.nodes.size(); ++i)
-        fanout_offsets[i + 1] = fanout_offsets[i] + fanout_counts[i];
-    std::vector<uint16_t> fanout_indices(edge_count);
-    std::vector<uint32_t> cursors(fanout_offsets.begin(), fanout_offsets.end() - 1);
+        fanout_offsets[i + 1] += fanout_offsets[i];
+    std::vector<uint32_t> cursors(fanout_offsets, fanout_offsets + recording.nodes.size());
     for (size_t consumer = 0; consumer < recording.nodes.size(); ++consumer) {
-        const GraphRecordedNode &consumer_node = recording.nodes[consumer];
-        for (uint32_t f = 0; f < consumer_node.fanin_count; ++f) {
-            const size_t producer = recording.internal_fanins[consumer_node.fanin_offset + f];
+        for (uint32_t f = fanin_offsets[consumer]; f < fanin_offsets[consumer + 1]; ++f) {
+            const size_t producer = fanin_indices[f];
             fanout_indices[cursors[producer]++] = static_cast<uint16_t>(consumer);
         }
     }
-
-    std::vector<GraphBoundarySignature> signatures;
-    signatures.reserve(recording.boundary_tensors.size());
     for (size_t i = 0; i < recording.boundary_tensors.size(); ++i) {
+        const ChipTensor &tensor = recording.boundary_tensors[i];
+        if (tensor.ndims > MAX_TENSOR_DIMS) return false;
         uint16_t alias_rep = static_cast<uint16_t>(i);
         for (size_t j = 0; j < i; ++j) {
-            if (recording.boundary_tensors[j].buffer.addr == recording.boundary_tensors[i].buffer.addr &&
-                recording.boundary_tensors[j].buffer.size == recording.boundary_tensors[i].buffer.size) {
+            if (recording.boundary_tensors[j].buffer.addr == tensor.buffer.addr &&
+                recording.boundary_tensors[j].buffer.size == tensor.buffer.size) {
                 alias_rep = static_cast<uint16_t>(j);
                 break;
             }
         }
-        signatures.push_back(
-            graph_boundary_signature(recording.boundary_tensors[i], recording.boundary_types[i], alias_rep)
-        );
+        signatures[i] = graph_boundary_signature(tensor, recording.boundary_types[i], alias_rep);
     }
-
-    image->assign(sizeof(GraphDefinition), std::byte{0});
-    GraphDefinition definition{};
-    definition.full_key = recording.full_key;
-    definition.required_heap = required_heap;
-    definition.task_count = static_cast<uint32_t>(nodes.size());
-    definition.edge_count = edge_count;
-    definition.root_count = static_cast<uint32_t>(roots.size());
-    definition.boundary_count = static_cast<uint32_t>(signatures.size());
-    definition.boundary_scalar_count = static_cast<uint32_t>(recording.boundary_scalar_count);
-    definition.tensor_arg_count = static_cast<uint32_t>(tensors.size());
-    definition.scalar_arg_count = static_cast<uint32_t>(scalars.size());
-    definition.predicate_count = static_cast<uint32_t>(predicates.size());
-    // An execution's storage is the node array plus this Definition's two argument
-    // pools, which the nodes index by their own tensor_offset / scalar_offset — so the
-    // arg-table counts size them, and no per-node scan is needed.
-    size_t execution_storage_bytes = 0;
-    if (!graph_execution_storage_bytes(
-            static_cast<int32_t>(definition.task_count), definition.tensor_arg_count, definition.scalar_arg_count,
-            &execution_storage_bytes
-        ) ||
-        execution_storage_bytes > UINT32_MAX) {
-        return false;
-    }
-    definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
-    // Every section's byte count is known now, so the image grows once instead of
-    // resizing eleven times. Each append aligns its start, hence the per-section
-    // alignment slack.
-    auto section_bytes = [](size_t count, size_t elem_size, size_t align) {
-        return count == 0 ? size_t{0} : (align - 1) + count * elem_size;
-    };
-    image->reserve(
-        image->size() + section_bytes(fanout_offsets.size(), sizeof(uint32_t), alignof(uint32_t)) +
-        section_bytes(fanout_indices.size(), sizeof(uint16_t), alignof(uint16_t)) +
-        section_bytes(fanin_offsets.size(), sizeof(uint32_t), alignof(uint32_t)) +
-        section_bytes(fanin_indices.size(), sizeof(uint16_t), alignof(uint16_t)) +
-        section_bytes(roots.size(), sizeof(uint16_t), alignof(uint16_t)) +
-        section_bytes(node_offsets.size(), sizeof(uint64_t), alignof(uint64_t)) +
-        section_bytes(nodes.size(), sizeof(GraphNodeDefinition), alignof(GraphNodeDefinition)) +
-        section_bytes(tensors.size(), sizeof(GraphTensor), alignof(GraphTensor)) +
-        section_bytes(tensor_sources.size(), sizeof(GraphTensorSourceRef), alignof(GraphTensorSourceRef)) +
-        section_bytes(scalars.size(), sizeof(uint64_t), alignof(uint64_t)) +
-        section_bytes(scalar_sources.size(), sizeof(GraphScalarSourceRef), alignof(GraphScalarSourceRef)) +
-        section_bytes(signatures.size(), sizeof(GraphBoundarySignature), alignof(GraphBoundarySignature)) +
-        section_bytes(predicates.size(), sizeof(GraphPredicate), alignof(GraphPredicate))
-    );
-    definition.off_fanout_offsets = graph_append_section(image, fanout_offsets);
-    definition.off_fanout_indices = graph_append_section(image, fanout_indices);
-    definition.off_fanin_offsets = graph_append_section(image, fanin_offsets);
-    definition.off_fanin_indices = graph_append_section(image, fanin_indices);
-    definition.off_root_indices = graph_append_section(image, roots);
-    definition.off_node_offsets = graph_append_section(image, node_offsets);
-    definition.off_nodes = graph_append_section(image, nodes);
-    definition.off_tensors = graph_append_section(image, tensors);
-    definition.off_tensor_sources = graph_append_section(image, tensor_sources);
-    definition.off_scalars = graph_append_section(image, scalars);
-    definition.off_scalar_sources = graph_append_section(image, scalar_sources);
-    definition.off_boundary_signatures = graph_append_section(image, signatures);
-    definition.off_predicates = graph_append_section(image, predicates);
-    if (definition.off_fanout_offsets == 0 || definition.off_fanin_offsets == 0 || definition.off_node_offsets == 0 ||
-        definition.off_nodes == 0 || definition.off_boundary_signatures == 0 ||
-        (!tensors.empty() && definition.off_tensors == 0) ||
-        (!tensor_sources.empty() && definition.off_tensor_sources == 0) ||
-        (!scalars.empty() && definition.off_scalars == 0) ||
-        (!scalar_sources.empty() && definition.off_scalar_sources == 0) ||
-        (!fanout_indices.empty() && definition.off_fanout_indices == 0) ||
-        (!fanin_indices.empty() && definition.off_fanin_indices == 0) ||
-        (!roots.empty() && definition.off_root_indices == 0) ||
-        (!predicates.empty() && definition.off_predicates == 0)) {
-        return false;
-    }
-    definition.total_bytes = static_cast<uint32_t>(image->size());
     std::memcpy(image->data(), &definition, sizeof(definition));
-    definition.content_hash = graph_hash_bytes(1469598103934665603ULL, image->data(), image->size());
+    definition.content_hash = graph_definition_content_hash(image->data(), image->size());
     std::memcpy(image->data(), &definition, sizeof(definition));
     return true;
+}
+
+bool graph_build_definition(const GraphRecording &recording, std::vector<std::byte> *image) {
+    return graph_build_definition_in_place(recording, image);
 }
 
 const GraphDefinition *graph_definition(const std::vector<std::byte> &image) {

--- a/src/common/host_build_graph/graph_execution.cpp
+++ b/src/common/host_build_graph/graph_execution.cpp
@@ -153,21 +153,7 @@ bool graph_definition_hash_matches(const GraphDefinition &definition, uint32_t d
         definition.content_hash == 0) {
         return false;
     }
-    constexpr size_t HASH_OFFSET = offsetof(GraphDefinition, content_hash);
-    constexpr size_t HASH_END = HASH_OFFSET + sizeof(GraphDefinition::content_hash);
-    // graph_hash_bytes mixes eight bytes per step, so a chunked update matches a
-    // single update over the concatenation only when every chunk boundary is a
-    // multiple of eight. The host hashes the whole image in one call; this side
-    // splits it in three to substitute a zeroed content_hash, so both splits have
-    // to land on a word boundary.
-    static_assert(HASH_OFFSET % sizeof(uint64_t) == 0);
-    static_assert(HASH_END % sizeof(uint64_t) == 0);
-    const auto *bytes = reinterpret_cast<const uint8_t *>(&definition);
-    uint64_t hash = graph_hash_bytes(1469598103934665603ULL, bytes, HASH_OFFSET);
-    const uint64_t zero_hash = 0;
-    hash = graph_hash_bytes(hash, &zero_hash, sizeof(zero_hash));
-    hash = graph_hash_bytes(hash, bytes + HASH_END, definition_bytes - HASH_END);
-    return hash == definition.content_hash;
+    return graph_definition_content_hash(&definition, definition_bytes) == definition.content_hash;
 }
 
 // One-time integrity gate for a shared Definition object. The first execution

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -178,6 +178,96 @@ struct GraphDefinition {
     uint32_t off_predicates;
 };
 
+inline uint64_t graph_definition_hash_rotl(uint64_t value, uint32_t shift) {
+    return (value << shift) | (value >> (64U - shift));
+}
+
+inline uint64_t graph_definition_hash_round(uint64_t accumulator, uint64_t input) {
+    constexpr uint64_t PRIME2 = 14029467366897019727ULL;
+    constexpr uint64_t PRIME1 = 11400714785074694791ULL;
+    accumulator += input * PRIME2;
+    accumulator = graph_definition_hash_rotl(accumulator, 31);
+    return accumulator * PRIME1;
+}
+
+inline uint64_t graph_definition_hash_word(const uint8_t *bytes, size_t offset) {
+    constexpr size_t CONTENT_HASH_OFFSET = offsetof(GraphDefinition, content_hash);
+    static_assert(CONTENT_HASH_OFFSET % sizeof(uint64_t) == 0);
+    if (offset == CONTENT_HASH_OFFSET) return 0;
+    uint64_t word = 0;
+    __builtin_memcpy(&word, bytes + offset, sizeof(word));
+    return word;
+}
+
+// The Definition hash follows XXH64's four-lane structure so large images do
+// not serialize one multiply per word. content_hash is treated as zero on both
+// host and device, allowing verification without mutating the uploaded image.
+// Definitions are rebuilt and rehashed by the same runtime version, so this is
+// an integrity checksum rather than a persisted wire-format identifier.
+inline uint64_t graph_definition_content_hash(const void *data, size_t size) {
+    constexpr uint64_t SEED = 1469598103934665603ULL;
+    constexpr uint64_t PRIME1 = 11400714785074694791ULL;
+    constexpr uint64_t PRIME2 = 14029467366897019727ULL;
+    constexpr uint64_t PRIME3 = 1609587929392839161ULL;
+    constexpr uint64_t PRIME4 = 9650029242287828579ULL;
+    constexpr uint64_t PRIME5 = 2870177450012600261ULL;
+    const auto *bytes = static_cast<const uint8_t *>(data);
+    size_t offset = 0;
+    uint64_t hash = 0;
+
+    if (size >= 32) {
+        uint64_t lane1 = SEED + PRIME1 + PRIME2;
+        uint64_t lane2 = SEED + PRIME2;
+        uint64_t lane3 = SEED;
+        uint64_t lane4 = SEED - PRIME1;
+        const size_t stripes_end = size - 32;
+        do {
+            lane1 = graph_definition_hash_round(lane1, graph_definition_hash_word(bytes, offset));
+            lane2 = graph_definition_hash_round(lane2, graph_definition_hash_word(bytes, offset + 8));
+            lane3 = graph_definition_hash_round(lane3, graph_definition_hash_word(bytes, offset + 16));
+            lane4 = graph_definition_hash_round(lane4, graph_definition_hash_word(bytes, offset + 24));
+            offset += 32;
+        } while (offset <= stripes_end);
+        hash = graph_definition_hash_rotl(lane1, 1) + graph_definition_hash_rotl(lane2, 7) +
+               graph_definition_hash_rotl(lane3, 12) + graph_definition_hash_rotl(lane4, 18);
+        hash ^= graph_definition_hash_round(0, lane1);
+        hash = hash * PRIME1 + PRIME4;
+        hash ^= graph_definition_hash_round(0, lane2);
+        hash = hash * PRIME1 + PRIME4;
+        hash ^= graph_definition_hash_round(0, lane3);
+        hash = hash * PRIME1 + PRIME4;
+        hash ^= graph_definition_hash_round(0, lane4);
+        hash = hash * PRIME1 + PRIME4;
+    } else {
+        hash = SEED + PRIME5;
+    }
+
+    hash += size;
+    while (offset + sizeof(uint64_t) <= size) {
+        const uint64_t mixed = graph_definition_hash_round(0, graph_definition_hash_word(bytes, offset));
+        hash ^= mixed;
+        hash = graph_definition_hash_rotl(hash, 27) * PRIME1 + PRIME4;
+        offset += sizeof(uint64_t);
+    }
+    if (offset + sizeof(uint32_t) <= size) {
+        uint32_t word = 0;
+        __builtin_memcpy(&word, bytes + offset, sizeof(word));
+        hash ^= static_cast<uint64_t>(word) * PRIME1;
+        hash = graph_definition_hash_rotl(hash, 23) * PRIME2 + PRIME3;
+        offset += sizeof(uint32_t);
+    }
+    while (offset < size) {
+        hash ^= static_cast<uint64_t>(bytes[offset]) * PRIME5;
+        hash = graph_definition_hash_rotl(hash, 11) * PRIME1;
+        ++offset;
+    }
+    hash ^= hash >> 33;
+    hash *= PRIME2;
+    hash ^= hash >> 29;
+    hash *= PRIME3;
+    hash ^= hash >> 32;
+    return hash;
+}
 static_assert(std::is_trivially_copyable_v<GraphTensorSourceRef>);
 static_assert(std::is_standard_layout_v<GraphTensorSourceRef>);
 static_assert(std::is_trivially_copyable_v<GraphTensor>);

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -15,6 +15,7 @@
 #include <stdint.h>
 
 #include <atomic>
+#include <cstddef>
 #include <type_traits>
 
 #include "pto_runtime2_types.h"
@@ -200,8 +201,15 @@ inline uint64_t graph_definition_hash_word(const uint8_t *bytes, size_t offset) 
 }
 
 // The Definition hash follows XXH64's four-lane structure so large images do
-// not serialize one multiply per word. content_hash is treated as zero on both
-// host and device, allowing verification without mutating the uploaded image.
+// not serialize one multiply per word, and is bit-identical to XXH64 with this
+// seed for any image whose content_hash field is already zero.
+//
+// `data` must be the base of a GraphDefinition image: the word at
+// offsetof(GraphDefinition, content_hash) is read as zero, which is what lets
+// the device verify in place instead of copying the image to clear that field.
+// Hashing any other buffer, or a subrange that does not start at the image base,
+// silently substitutes zero for eight bytes of it.
+//
 // Definitions are rebuilt and rehashed by the same runtime version, so this is
 // an integrity checksum rather than a persisted wire-format identifier.
 inline uint64_t graph_definition_content_hash(const void *data, size_t size) {
@@ -282,6 +290,21 @@ static_assert(std::is_trivially_copyable_v<GraphBoundarySignature>);
 static_assert(std::is_standard_layout_v<GraphBoundarySignature>);
 static_assert(std::is_trivially_copyable_v<GraphDefinition>);
 static_assert(std::is_standard_layout_v<GraphDefinition>);
+
+// Section starts are offsets from the image base, so a section is correctly
+// aligned only if the buffer holding the image is. The builder writes each
+// section through a typed pointer into a std::vector<std::byte>, whose data() is
+// aligned for any type with fundamental alignment and no further — so a section
+// type that asked for more would make every one of those stores undefined, with
+// no diagnostic.
+static_assert(
+    alignof(GraphNodeDefinition) <= alignof(std::max_align_t) && alignof(GraphTensor) <= alignof(std::max_align_t) &&
+        alignof(GraphTensorSourceRef) <= alignof(std::max_align_t) &&
+        alignof(GraphScalarSourceRef) <= alignof(std::max_align_t) &&
+        alignof(GraphBoundarySignature) <= alignof(std::max_align_t) &&
+        alignof(GraphPredicate) <= alignof(std::max_align_t),
+    "a Definition section type must not be over-aligned: its storage is a byte vector"
+);
 
 inline GraphTensor graph_tensor_pack(const ChipTensor &tensor) {
     GraphTensor packed{};

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -120,7 +120,7 @@ make_test_definition(uint64_t graph_key, uint64_t boundary_address, uint32_t bou
     definition.total_bytes = static_cast<uint32_t>(image.size());
     std::memcpy(image.data(), &definition, sizeof(definition));
 
-    definition.content_hash = graph_hash_bytes(1469598103934665603ULL, image.data(), image.size());
+    definition.content_hash = graph_definition_content_hash(image.data(), image.size());
     std::memcpy(image.data(), &definition, sizeof(definition));
     return image;
 }
@@ -260,6 +260,18 @@ private:
 };
 
 }  // namespace
+
+TEST(GraphDefinitionHash, IgnoresOnlyEmbeddedContentHash) {
+    std::vector<std::byte> image = make_test_definition(23, 0x1000);
+    const uint64_t expected = graph_definition_content_hash(image.data(), image.size());
+
+    const uint64_t replacement = 0x0123456789abcdefULL;
+    std::memcpy(image.data() + offsetof(GraphDefinition, content_hash), &replacement, sizeof(replacement));
+    EXPECT_EQ(graph_definition_content_hash(image.data(), image.size()), expected);
+
+    image.back() ^= std::byte{1};
+    EXPECT_NE(graph_definition_content_hash(image.data(), image.size()), expected);
+}
 
 TEST(GraphCache, RejectsEmptyBoundary) {
     GraphTaskArgs args;

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -261,16 +261,53 @@ private:
 
 }  // namespace
 
+// Only the embedded content_hash is excluded — every other word of the image has
+// to reach the digest. Sweeping one bit per 8-byte word is what distinguishes
+// "content_hash is skipped" from "a whole region is skipped": the latter reads as
+// a passing hash test right up until two different Definitions collide.
 TEST(GraphDefinitionHash, IgnoresOnlyEmbeddedContentHash) {
-    std::vector<std::byte> image = make_test_definition(23, 0x1000);
+    const std::vector<std::byte> original = make_test_definition(23, 0x1000);
+    std::vector<std::byte> image = original;
     const uint64_t expected = graph_definition_content_hash(image.data(), image.size());
 
     const uint64_t replacement = 0x0123456789abcdefULL;
     std::memcpy(image.data() + offsetof(GraphDefinition, content_hash), &replacement, sizeof(replacement));
     EXPECT_EQ(graph_definition_content_hash(image.data(), image.size()), expected);
 
+    for (size_t offset = 0; offset + sizeof(uint64_t) <= original.size(); offset += sizeof(uint64_t)) {
+        image = original;
+        image[offset] ^= std::byte{1};
+        const uint64_t hashed = graph_definition_content_hash(image.data(), image.size());
+        if (offset == offsetof(GraphDefinition, content_hash)) {
+            EXPECT_EQ(hashed, expected) << "word at " << offset << " must be excluded";
+        } else {
+            EXPECT_NE(hashed, expected) << "word at " << offset << " must be covered";
+        }
+    }
+
+    image = original;
     image.back() ^= std::byte{1};
     EXPECT_NE(graph_definition_content_hash(image.data(), image.size()), expected);
+}
+
+// The digest is a transcription of XXH64, and a wrong rotate or prime would still
+// agree with itself on both sides of the H2D — host and device share this code, so
+// self-consistency proves nothing about the transcription. Pin it to values taken
+// from a reference XXH64 (python-xxhash 3.8.1) at this seed. Bytes 8..15 are zeroed
+// in the input so the content_hash substitution is a no-op and the two
+// implementations must agree exactly; the three sizes cover the 8-byte, 4-byte and
+// single-byte tail branches, which no real Definition reaches because every image
+// this builder emits is a whole number of 8-byte words.
+TEST(GraphDefinitionHash, MatchesReferenceXxh64) {
+    std::array<uint8_t, 200> buffer{};
+    for (size_t i = 0; i < buffer.size(); ++i) {
+        buffer[i] = static_cast<uint8_t>(i * 7 + 1);
+    }
+    std::fill_n(buffer.begin() + offsetof(GraphDefinition, content_hash), sizeof(uint64_t), uint8_t{0});
+
+    EXPECT_EQ(graph_definition_content_hash(buffer.data(), 120), 0x240ec7f0e9812487ULL);
+    EXPECT_EQ(graph_definition_content_hash(buffer.data(), 124), 0xbccc608fbca2e6c5ULL);
+    EXPECT_EQ(graph_definition_content_hash(buffer.data(), 127), 0x440c5d9a1f5c42e0ULL);
 }
 
 TEST(GraphCache, RejectsEmptyBoundary) {


### PR DESCRIPTION
## Summary

Follow up on #1904 by removing the remaining temporary serialization work from
host-side `GraphDefinition` construction. Previously the builder materialized
thirteen `std::vector`s by `push_back`, then appended each one into the image
with a `resize` + `memcpy` — every byte of the Definition was written twice and
every section allocated twice, and #1904's `reserve` calls removed only the
reallocation, not the copy.

- Lay out the complete packed image up front: `graph_layout_section<T>` walks a
  byte cursor from `sizeof(GraphDefinition)`, aligning each section start and
  recording it into the matching `definition.off_*`, so `total_bytes` is known
  before anything is written. One `assign` allocates; `graph_image_section<T>`
  hands out a typed pointer per section; the fill loop writes each record at its
  final address.
- Build the fan-out CSR without its own vectors: counts accumulate directly into
  `fanout_offsets[producer + 1]`, an in-place prefix sum converts counts to
  offsets, and the second pass reads `fanin_indices` out of the image it just
  built rather than re-walking the recording.
- Write sparse predicates in place, bounding `predicate_count` up front instead
  of re-checking `UINT16_MAX` per node.
- Use one four-lane content hash for host construction and device verification.
  The embedded `content_hash` is read as zero rather than being cleared in a
  copy, so the device verifies in place; the old three-call split and its
  chunk-boundary `static_assert`s go away.
- Keep every Definition self-contained within its Graph. No cross-Graph sharing
  and no cache.

Two things the layout rewrite also gets, beyond the performance goal:

- **Bounds validation the previous builder lacked.** The up-front pass rejects
  `tensor_source_offset + tensors.size()` past `recording.tensor_sources`, and
  the same for `scalar_offset`/`scalar_count` against both `scalars` and
  `scalar_sources`, and `fanin_offset`/`fanin_count` against `internal_fanins`.
  Those four indexings were previously unchecked. A post-pass equality check
  (`tensor_cursor != total_tensors || …`) catches any drift between the layout
  pass and the fill pass.
- **A failed layout is now a hard failure.** `graph_layout_section` returns
  false on overflow, so the whole `off_* == 0` post-hoc check block is gone —
  offsets start past `sizeof(GraphDefinition)`, so the "0 means empty" sentinel
  can no longer collide with a real section.

## Hash integrity

The digest is a hand transcription of XXH64, and host and device share the
function — so a wrong rotate or prime would agree with itself across the H2D and
never surface. It is pinned against a reference implementation
(`python-xxhash` 3.8.1) at this seed, over an input whose bytes 8..15 are zeroed
so the `content_hash` substitution is a no-op and the two implementations must
agree exactly:

| image size | mod 8 | digest |
| ---: | ---: | :-- |
| 120 | 0 | `0x240ec7f0e9812487` |
| 124 | 4 | `0xbccc608fbca2e6c5` |
| 127 | 7 | `0x440c5d9a1f5c42e0` |

Those three sizes cover the 8-byte, 4-byte and single-byte tail branches. No
real Definition reaches the last two: every image this builder emits is a whole
number of 8-byte words, because the last non-empty section is always
`boundary_signatures` (56 B) or `predicates` (136 B) at an 8-aligned start — so
without a deliberately odd-sized buffer those branches are never executed.

`IgnoresOnlyEmbeddedContentHash` flips one bit per 8-byte word across the whole
image and requires the digest to change at every word except `content_hash`,
which separates "one field is excluded" from "a whole region is excluded" — the
second reads as a passing hash test until two Definitions collide. Both tests
fail on a mutant that widens the skip window to include `full_key`.

Three properties the rewrite made load-bearing are now stated where they live:

- `image->assign` zero-fills rather than merely sizing, and the alignment slack
  between sections is inside the hashed range. Leaving that slack uninitialized
  would still verify on the device — it hashes the same bytes — while giving two
  structurally identical Definitions different hashes.
- `graph_definition_content_hash` takes `(const void *, size_t)` but reads the
  word at `offsetof(GraphDefinition, content_hash)` as zero, so it hashes a
  `GraphDefinition` image based at `data` and nothing else. Any other buffer
  silently loses eight bytes.
- Sections are written through typed pointers into a `std::vector<std::byte>`,
  whose `data()` is aligned only for fundamental alignments. Every section type
  is 8-aligned today and a `static_assert` now says so, because an over-aligned
  member added later would make those stores undefined with no diagnostic.

## Performance

Direction is not in doubt: removing thirteen vector materializations plus a full
second write of every byte cannot make `build_definition` slower. **The magnitude
below is not directly comparable and should be re-measured symmetrically before
being quoted.** The hardware A/B ran on `main@1b637ef07` — three merges before
this branch's current base — and the baseline is a single pass against a
three-pass median for the change:

| DSV4 host phase | Baseline (1 pass) | This change (median of 3) |
| --- | ---: | ---: |
| `build_definition` total | 5,487.9 us | 1,689.0 us |
| Max Definition event | 762.9 us | 245.0-303.9 us |
| Definition events over 150 us | 14 / 16 | 3-4 / 16 |

Qwen, three passes: `build_definition` 63.471 us, 69.731 us, 70.710 us, with no
event over 150 us — internally consistent, and the case where the run-to-run
spread is small enough to trust.

Two caveats stated explicitly rather than left for a reader to find:

- **One baseline pass against a three-pass median is asymmetric**, and that is
  how machine contention turns into an apparent win. A three-against-three
  re-run is what would make the percentage quotable.
- **The earlier `graph_submit` figure is withdrawn.** It showed -55.6%, but
  nothing in this diff touches `graph_submit_outer` — Definition construction
  happens in `build_definition`. A large improvement in an untouched phase is
  evidence the baseline pass was contended, not evidence of an effect, so it is
  not claimed here.

`graph_upload` was tracked separately and no transfer-time benefit is claimed.

## Validation

- Head `59b1f5d0`, rebased onto `main@ecd8875b`.
- The rebase over #1955 conflicted in `src/common/host_build_graph/graph_execution.h`:
  #1955 deleted `GraphSubmission` and this branch had added the hash functions
  immediately above it. Resolved by keeping the hash functions and taking the
  deletion. `pto_orchestrator.cpp` auto-merged — the two changes touch disjoint
  functions (`graph_submit_outer` and the pending-upload record vs.
  `graph_build_definition`) — and #1955's argument-pool preflight tests still
  pass alongside.
- C++ unit tests: 115/115.
- Python unit tests: 1894 passed, 14 skipped.
- `host_build_graph` a2a3 simulator, including `host_build_graph_validation` and
  `host_build_graph_wide_dispatch`: 12 passed, 8 skipped. a5 simulator: 7 passed.
- `clang-format` and `clang-tidy` clean over every changed file; the a2a3 and a5
  orchestrator diffs are byte-identical after normalizing the arch path.

## Scope

This PR changes Definition image construction, its integrity hash, and the
tests covering both. It adds no cross-Graph state, moves no work into
submission or upload, and does not change Graph execution lifetime or
allocation. The `GraphDefinition` wire struct is untouched field for field.
