### PR TITLE
Fix: guard reopened HBG drain followers

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -662,6 +662,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     bool coordinator = thread_idx == 0;
 
     PTO2TaskSlotState *slot_state = drain_state_.pending_task.load(std::memory_order_acquire);
+    if (slot_state == nullptr) return;
     // OWNER is acquired before the drain is published and persists through
     // completion, so every staging thread makes the same gate decision even if
     // producer release changes early_dispatch_state during the barrier.

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -662,6 +662,17 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     bool coordinator = thread_idx == 0;
 
     PTO2TaskSlotState *slot_state = drain_state_.pending_task.load(std::memory_order_acquire);
+    // Null means this thread arrived after the drain it entered for had already
+    // reopened, and no check above rejects it: the reopen below clears pending_task
+    // before sync_start_pending, so a thread entering on a stale non-zero snapshot of
+    // that gate lands here; drain_attempt still names this round and every ack token
+    // is already published, so the reduction and the follower barrier both pass
+    // immediately. It never acked for this round -- the coordinator collected every
+    // ack before clearing -- so there is nothing to stage and nothing to unwind.
+    //
+    // Not the converse case: a thread already past this load cannot see the clear,
+    // because the coordinator waits on drain_stage_done_mask for every thread and a
+    // thread sets its bit only after staging, which is after this load.
     if (slot_state == nullptr) return;
     // OWNER is acquired before the drain is published and persists through
     // completion, so every staging thread makes the same gate decision even if

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -87,6 +87,8 @@ struct CompletedTaskQueue {
     uint64_t size() const { return tail.load(std::memory_order_acquire) - head.load(std::memory_order_acquire); }
 };
 
+class SchedulerContextTestPeer;
+
 /**
  * SchedulerContext: owns all scheduler-side state and methods.
  *
@@ -177,6 +179,8 @@ public:
     int32_t aiv_count() const { return aiv_count_; }
     bool is_completed() const { return completed_.load(std::memory_order_acquire); }
     int32_t completed_tasks_count() const { return completed_tasks_.load(std::memory_order_acquire); }
+
+    friend class SchedulerContextTestPeer;
 
 private:
     // =========================================================================

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -667,6 +667,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     bool coordinator = thread_idx == 0;
 
     PTO2TaskSlotState *slot_state = drain_state_.pending_task.load(std::memory_order_acquire);
+    if (slot_state == nullptr) return;
     // OWNER is acquired before the drain is published and persists through
     // completion, so every staging thread makes the same gate decision even if
     // producer release changes early_dispatch_state during the barrier.

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -667,6 +667,17 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     bool coordinator = thread_idx == 0;
 
     PTO2TaskSlotState *slot_state = drain_state_.pending_task.load(std::memory_order_acquire);
+    // Null means this thread arrived after the drain it entered for had already
+    // reopened, and no check above rejects it: the reopen below clears pending_task
+    // before sync_start_pending, so a thread entering on a stale non-zero snapshot of
+    // that gate lands here; drain_attempt still names this round and every ack token
+    // is already published, so the reduction and the follower barrier both pass
+    // immediately. It never acked for this round -- the coordinator collected every
+    // ack before clearing -- so there is nothing to stage and nothing to unwind.
+    //
+    // Not the converse case: a thread already past this load cannot see the clear,
+    // because the coordinator waits on drain_stage_done_mask for every thread and a
+    // thread sets its bit only after staging, which is after this load.
     if (slot_state == nullptr) return;
     // OWNER is acquired before the drain is published and persists through
     // completion, so every staging thread makes the same gate decision even if

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -87,6 +87,8 @@ struct CompletedTaskQueue {
     uint64_t size() const { return tail.load(std::memory_order_acquire) - head.load(std::memory_order_acquire); }
 };
 
+class SchedulerContextTestPeer;
+
 /**
  * SchedulerContext: owns all scheduler-side state and methods.
  *
@@ -177,6 +179,8 @@ public:
     int32_t aiv_count() const { return aiv_count_; }
     bool is_completed() const { return completed_.load(std::memory_order_acquire); }
     int32_t completed_tasks_count() const { return completed_tasks_.load(std::memory_order_acquire); }
+
+    friend class SchedulerContextTestPeer;
 
 private:
     // =========================================================================

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -865,6 +865,24 @@ add_a2a3_hbg_runtime_test(test_hbg_ready_queue_seed common/test_hbg_ready_queue_
 add_a2a3_hbg_runtime_test(test_hbg_mailbox_init common/test_hbg_mailbox_init.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_self_relative_ptr common/test_hbg_self_relative_ptr.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_sm_compaction common/test_hbg_sm_compaction.cpp)
+add_a2a3_hbg_runtime_test(test_hbg_scheduler_drain common/test_hbg_scheduler_drain.cpp)
+target_sources(test_hbg_scheduler_drain PRIVATE
+    ${HBG_RUNTIME_DIR}/scheduler/scheduler_completion.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/shared/aicpu/pmu_collector_aicpu.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/sim/aicpu/inner_platform_regs.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/chip_swimlane_collector_aicpu.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/device_phase_aicpu.cpp
+)
+add_a5_hbg_runtime_test(test_a5_hbg_scheduler_drain common/test_hbg_scheduler_drain.cpp)
+target_sources(test_a5_hbg_scheduler_drain PRIVATE
+    common/test_hbg_scheduler_drain_a5_stubs.cpp
+    ${A5_HBG_RUNTIME_DIR}/scheduler/scheduler_completion.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/platform/shared/aicpu/pmu_collector_aicpu.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/chip_swimlane_collector_aicpu.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/device_phase_aicpu.cpp
+)
 target_sources(test_hbg_ready_queue_seed PRIVATE
     ${HBG_RUNTIME_DIR}/orchestrator_core/pto_orchestrator.cpp
     ${HBG_RUNTIME_DIR}/orchestrator_core/pto_ring_buffer.cpp

--- a/tests/ut/cpp/common/test_hbg_scheduler_drain.cpp
+++ b/tests/ut/cpp/common/test_hbg_scheduler_drain.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include "scheduler/scheduler_context.h"
+
+uint64_t __attribute__((weak)) read_reg(uint64_t, RegId) { return 0; }
+
+void __attribute__((weak)) reg_store_release(volatile uint32_t *, uint32_t) {}
+
+extern "C" uint64_t get_platform_pmu_reg_addrs() { return 0; }
+
+extern "C" uint64_t get_platform_regs() { return 0; }
+
+int SchedulerContext::prepare_block_for_dispatch(
+    int32_t, int32_t, PTO2TaskSlotState &, PTO2ResourceShape, bool, int32_t, PublishHandle *, bool
+) {
+    return 0;
+}
+
+class SchedulerContextTestPeer {
+public:
+    static void leave_ack_barrier_after_reopen(SchedulerContext &context) {
+        constexpr int32_t kActiveThreads = 2;
+        constexpr int32_t kFollowerThread = 1;
+        constexpr uint64_t kAttempt = 41;
+        const uint64_t subtree_token = sync_start_drain_ack_subtree_token(kAttempt);
+
+        context.active_sched_threads_ = kActiveThreads;
+        context.completed_.store(false, std::memory_order_relaxed);
+        context.drain_state_.sync_start_pending.store(1, std::memory_order_relaxed);
+        context.drain_state_.drain_attempt.store(kAttempt, std::memory_order_relaxed);
+
+        context.drain_ack_tokens_[0].store(subtree_token, std::memory_order_release);
+        context.drain_state_.pending_task.store(nullptr, std::memory_order_release);
+
+        context.handle_drain_mode(kFollowerThread);
+    }
+};
+
+TEST(SchedulerDrainTest, FollowerReturnsWhenCoordinatorReopenedAfterAckPublication) {
+    SchedulerContext context;
+
+    SchedulerContextTestPeer::leave_ack_barrier_after_reopen(context);
+}

--- a/tests/ut/cpp/common/test_hbg_scheduler_drain.cpp
+++ b/tests/ut/cpp/common/test_hbg_scheduler_drain.cpp
@@ -15,6 +15,10 @@
 
 #include "scheduler/scheduler_context.h"
 
+// Weak, because the a2a3 target also links sim/aicpu/inner_platform_regs.cpp, which
+// defines these strongly and overrides the definitions here. The a5 target links no
+// equivalent, so it supplies its own strong stubs in
+// test_hbg_scheduler_drain_a5_stubs.cpp. Both targets compile this file.
 uint64_t __attribute__((weak)) read_reg(uint64_t, RegId) { return 0; }
 
 void __attribute__((weak)) reg_store_release(volatile uint32_t *, uint32_t) {}
@@ -31,6 +35,13 @@ int SchedulerContext::prepare_block_for_dispatch(
 
 class SchedulerContextTestPeer {
 public:
+    // The state a thread finds when it enters handle_drain_mode after the drain it
+    // entered for has already reopened: the ack token for this round is published, so
+    // the reduction and the follower barrier both pass without spinning, while
+    // pending_task is already cleared. sync_start_pending stays non-zero because the
+    // reopen clears it after pending_task -- that ordering is what lets a thread get
+    // this far -- and drain_attempt still names this round, so neither barrier
+    // early-exit fires.
     static void leave_ack_barrier_after_reopen(SchedulerContext &context) {
         constexpr int32_t kActiveThreads = 2;
         constexpr int32_t kFollowerThread = 1;
@@ -41,16 +52,38 @@ public:
         context.completed_.store(false, std::memory_order_relaxed);
         context.drain_state_.sync_start_pending.store(1, std::memory_order_relaxed);
         context.drain_state_.drain_attempt.store(kAttempt, std::memory_order_relaxed);
+        context.drain_state_.drain_stage_go.store(0, std::memory_order_relaxed);
+        context.drain_state_.drain_stage_done_mask.store(0, std::memory_order_relaxed);
 
         context.drain_ack_tokens_[0].store(subtree_token, std::memory_order_release);
         context.drain_state_.pending_task.store(nullptr, std::memory_order_release);
 
         context.handle_drain_mode(kFollowerThread);
     }
+
+    static uint32_t stage_done_mask(const SchedulerContext &context) {
+        return context.drain_state_.drain_stage_done_mask.load(std::memory_order_relaxed);
+    }
+    static int32_t sync_start_pending(const SchedulerContext &context) {
+        return context.drain_state_.sync_start_pending.load(std::memory_order_relaxed);
+    }
+    static uint32_t drain_stage_go(const SchedulerContext &context) {
+        return context.drain_state_.drain_stage_go.load(std::memory_order_relaxed);
+    }
 };
 
+// Surviving the call only proves the load is no longer dereferenced. What the guard
+// owes is that the late arrival does nothing: it must not stage, must not ack for a
+// round whose acks were already collected, and must not reopen a gate it does not own.
+// Asserting that is what separates an early return from a fallback that keeps going.
 TEST(SchedulerDrainTest, FollowerReturnsWhenCoordinatorReopenedAfterAckPublication) {
     SchedulerContext context;
 
     SchedulerContextTestPeer::leave_ack_barrier_after_reopen(context);
+
+    EXPECT_EQ(SchedulerContextTestPeer::stage_done_mask(context), 0u)
+        << "a thread that arrived after reopen must not report staging";
+    EXPECT_EQ(SchedulerContextTestPeer::drain_stage_go(context), 0u)
+        << "only the coordinator of a live round releases staging";
+    EXPECT_EQ(SchedulerContextTestPeer::sync_start_pending(context), 1) << "the late arrival must not reopen the gate";
 }

--- a/tests/ut/cpp/common/test_hbg_scheduler_drain_a5_stubs.cpp
+++ b/tests/ut/cpp/common/test_hbg_scheduler_drain_a5_stubs.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#include "aicpu/platform_regs.h"
+
+void write_reg(uint64_t, RegId, uint64_t) {}

--- a/tests/ut/cpp/common/test_hbg_scheduler_drain_a5_stubs.cpp
+++ b/tests/ut/cpp/common/test_hbg_scheduler_drain_a5_stubs.cpp
@@ -13,4 +13,7 @@
 
 #include "aicpu/platform_regs.h"
 
+// The a5 drain target links no platform-regs implementation, so the symbols its
+// aicpu sources reference are defined here. Strong, not weak: nothing else in that
+// link supplies them, unlike a2a3 where inner_platform_regs.cpp does.
 void write_reg(uint64_t, RegId, uint64_t) {}


### PR DESCRIPTION
## Summary
- Return from drain handling when a late follower observes that the coordinator has cleared `pending_task` after publishing the drain acknowledgment token.
- Add deterministic a2a3 and a5 regression coverage for the post-ack reopen state.
- The regression exits with `SIGSEGV` on the unfixed code and passes with the null guard.

## Testing
- Pre-commit hooks: passed
- No-hardware C++ unit tests: 116/116 passed
- a2a3sim `host_build_graph`: 14 passed, 7 skipped
- a5sim `host_build_graph`: 11 passed
- a2a3 onboard `host_build_graph`: 42 passed, 1 skipped
- a5 onboard: not run locally because the validation host is a2a3; covered by matching-silicon CI

Fixes #1928