### PR TITLE
Fix: keep host-side C API statuses out of the device-latched code band

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1260,14 +1260,22 @@ def pytest_runtest_makereport(item, call):
 #   507018 ACL_ERROR_RT_AICPU_EXCEPTION
 #   507046 ACL_ERROR_RT_STREAM_SYNC_TIMEOUT
 #   507899 sticky-error rtMalloc / rtStreamCreate on the poisoned context
-#       -1 a5 DeviceRunner fail-fast sentinel ("marked unusable; refusing to run")
+#    -1000 PTO_RUNTIME_ERR_INTERNAL — the host-side generic failure, which the a5
+#          DeviceRunner fail-fast ("marked unusable; refusing to run") reports and
+#          which also catches a poisoned card whose CANN code an intermediate
+#          layer flattened. It is the whole host band's floor, so it is the one
+#          entry here that is deliberately wider than a single mechanism.
 # The names above are CANN's own (acl/error_codes/rt_error_codes.h); what each one
 # means and how to chase it is in docs/troubleshooting/device-error-codes.md, and the
-# host log now prints that meaning next to the code.
+# host log now prints that meaning next to the code. -1000 and below is the
+# host-side band (PTO_RUNTIME_ERR_* in src/common/worker/pto_runtime_c_api.h);
+# -1..-999 are device-latched codes and must NOT be listed here — a latched
+# SCOPE_DEADLOCK (-1) is an orchestration bug, not a poisoned device, and
+# treating it as poison is exactly the spurious rebuild this filter avoids.
 # Worker surfaces these as "run/run_prepared/prepare_callable/simpler_init
 # failed with code <N>" — never as an AssertionError, so golden mismatches are
 # already excluded.
-_DEVICE_POISON_CODES = frozenset({207001, 507000, 507015, 507018, 507046, 507899, -1})
+_DEVICE_POISON_CODES = frozenset({207001, 507000, 507015, 507018, 507046, 507899, -1000})
 _DEVICE_ERROR_CODE_RE = re.compile(r"\b(?:run|run_prepared|prepare_callable|simpler_init) failed with code (-?\d+)\b")
 _DEVICE_QUARANTINE_MARKERS = (
     "device is quarantined after a prior Worker could not confirm reset",

--- a/docs/troubleshooting/a2a3-507899-aicpu-shared-so-fault.md
+++ b/docs/troubleshooting/a2a3-507899-aicpu-shared-so-fault.md
@@ -8,7 +8,7 @@ phase reports ~10 failed + ~23 errors at once. The surfaced Python errors are
 
 ```text
 RuntimeError: simpler_init failed with code 507899
-RuntimeError: register_callable failed with code -1
+RuntimeError: register_callable failed with code -1000
 RuntimeError: simpler_run failed with code 507018 / 507046 / 507901
 [ERROR] rtMalloc failed: 507899 (size=...)
 [ERROR] Failed to allocate device GM for ChipCallable buffer

--- a/docs/troubleshooting/device-error-codes.md
+++ b/docs/troubleshooting/device-error-codes.md
@@ -47,6 +47,31 @@ the same number:
 | **sim** (`a5sim` / `a2a3sim`) | `-N`, where `N` is the latched code. `-1` is SCOPE_DEADLOCK, `-100` is SCHEDULER_TIMEOUT. |
 | **onboard** | Usually a CANN watchdog fires first and masks the code as a generic `507018`. **Do not read `<rc>` as the error code here.** |
 
+### A code at or below -1000 is not a device code at all
+
+The tables on this page cover the codes the *device* latches, which reach you as
+`-1..-999`. A failure raised by the **host runtime** — a null argument, an
+allocation that failed, an H2D that did not complete, a `dlopen` that found
+nothing — never borrows a number from that range: it reports
+`PTO_RUNTIME_ERR_INTERNAL` (`-1000`) or another `PTO_RUNTIME_ERR_*` code below it
+(`src/common/worker/pto_runtime_c_api.h`).
+
+So `failed with code -1000` means **look for the preceding host log line**, not
+for a mechanism on this page — nothing was latched on the device, and no
+`error detail:` line accompanies it. Conversely `-1` really is SCOPE_DEADLOCK,
+and `-3` really is FLOW_CONTROL_DEADLOCK; neither doubles as "something in the
+host runtime went wrong."
+
+**One exception, and it is the reverse direction.** The AICPU executor still uses
+`-1` as its own generic failure, and that value travels out as the run's `rc`
+(most visibly the sim deinit-timeout cascade in
+[sim-oversubscription-hang.md](sim-oversubscription-hang.md)). So a `-1` on
+screen is *either* a latched SCOPE_DEADLOCK *or* an unlatched AICPU-executor
+failure. Tell them apart by the pair: a latched code always brings its
+`orch_error_code=` / `error detail:` lines with it; the executor's `-1` arrives
+bare. The `-1000`-and-below rule above is unaffected either way — it is about
+which numbers the host band uses, and no device-side code ever enters it.
+
 So on hardware the exception code is the *least* informative thing on screen. The
 `error detail:` / `error hint:` pair is printed either way — start there.
 

--- a/docs/troubleshooting/sim-oversubscription-hang.md
+++ b/docs/troubleshooting/sim-oversubscription-hang.md
@@ -35,6 +35,15 @@ Two distinct signatures, both only on sim and only under load:
    RuntimeError: chip_process dev=N: simpler_run failed with code -1
    ```
 
+   The `-1` here comes from the **AICPU executor**, which still uses `-1` as its
+   own generic failure — it is the one producer that sits outside the
+   `PTO_RUNTIME_ERR_*` band, so this signature is not covered by the
+   "`-1000` and below" rule for host-runtime failures in
+   [device-error-codes.md](device-error-codes.md). Nor is it the latched
+   `SCOPE_DEADLOCK` that page assigns to `-1`: the giveaway is that no
+   `orch_error_code=` / `error detail:` pair accompanies it. A failure raised by
+   the host runtime would report `-1000` or below.
+
 Both appear intermittently in `st-sim-*` on `ubuntu-latest` (≈4 vCPU) and are
 easy to trip on any box running concurrent sim tests.
 

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -145,7 +145,7 @@ DeviceRunner::~DeviceRunner() { finalize(); }
 int DeviceRunner::ensure_acl_ready(int device_id) {
     if (device_id < 0) {
         LOG_ERROR("ensure_acl_ready: invalid device_id %d", device_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // aclInit is process-wide; CANN returns ACL_ERROR_REPEAT_INITIALIZE if it
@@ -221,7 +221,7 @@ int DeviceRunner::prepare_execution(
     Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot, const NativeRunIdentity &identity,
     std::unique_ptr<PreparedExecution> *prepared
 ) {
-    if (prepared == nullptr || *prepared != nullptr) return -1;
+    if (prepared == nullptr || *prepared != nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
     execution->resources_owned = true;
     auto prepare_rollback = RAIIScopeGuard([this, &execution]() {
@@ -244,9 +244,9 @@ int DeviceRunner::prepare_execution(
             "A soft reset does not clear the poison; finalize() will force-reset "
             "the card so the next Worker on it inits clean."
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
-    if (validate_launch_aicpu_num(launch_aicpu_num) != 0) return -1;
+    if (validate_launch_aicpu_num(launch_aicpu_num) != 0) return PTO_RUNTIME_ERR_INTERNAL;
 
     int rc = ensure_device_initialized();
     if (rc != 0) {
@@ -258,7 +258,7 @@ int DeviceRunner::prepare_execution(
 
     if (block_dim < 1) {
         LOG_ERROR("prepare_execution computed block_dim < 1 from worker_count=%d", runtime.get_worker_count());
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     int num_aicore = block_dim * cores_per_blockdim_;
 
@@ -309,24 +309,24 @@ int DeviceRunner::prepare_execution(
         runtime.set_aicpu_launch_count(0);
         if (!pto::a2a3::probe_aicpu_topology(static_cast<uint32_t>(device_id_), user_cpus)) {
             LOG_ERROR("A2A3 AICPU topology probe failed; cannot configure affinity gate");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         int resolved_aicpu = resolve_aicpu_thread_num(
             runtime.get_aicpu_thread_num(), static_cast<int>(user_cpus.size()), PLATFORM_DEFAULT_AICPU_THREAD_NUM
         );
-        if (resolved_aicpu < 0) return -1;
+        if (resolved_aicpu < 0) return PTO_RUNTIME_ERR_INTERNAL;
         if (!pto::a2a3::compute_allowed_cpus(user_cpus, resolved_aicpu, allowed)) {
             LOG_ERROR(
                 "A2A3 AICPU topology has %zu user cpus, cannot fit %d active threads", user_cpus.size(), resolved_aicpu
             );
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         runtime.set_aicpu_thread_num(resolved_aicpu);
         launch_aicpu_num = resolved_aicpu;
         const size_t cap = runtime.aicpu_allowed_cpus_capacity();
         if (allowed.size() > cap) {
             LOG_ERROR("A2A3 compute_allowed_cpus returned %zu > cap %zu", allowed.size(), cap);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         int32_t *allowed_cpus = runtime.get_aicpu_allowed_cpus();
         for (size_t i = 0; i < allowed.size(); ++i)
@@ -437,7 +437,7 @@ int DeviceRunner::poll_execution(const ActiveExecution &active) {
 }
 
 int DeviceRunner::drain_execution(ActiveExecution &active) {
-    if (active.prepared == nullptr || !active.prepared->resources_owned) return -1;
+    if (active.prepared == nullptr || !active.prepared->resources_owned) return PTO_RUNTIME_ERR_INTERNAL;
     PreparedExecution &prepared = *active.prepared;
     auto drain_cleanup = RAIIScopeGuard([this, &prepared]() {
         cleanup_execution(prepared, /*retire_aicore=*/true);
@@ -502,7 +502,7 @@ void DeviceRunner::abandon_prepared_execution(PreparedExecution &prepared) noexc
 }
 
 int DeviceRunner::create_run_stream(void **out) {
-    if (out == nullptr) return -1;
+    if (out == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     *out = nullptr;
 
     rtStream_t stream = nullptr;
@@ -596,7 +596,7 @@ LaunchTransactionResult DeviceRunner::launch_run(PreparedExecution &prepared, La
     RunStreamSet streams{static_cast<rtStream_t>(run_streams_.aicpu()), static_cast<rtStream_t>(run_streams_.aicore())};
     LaunchTransactionResult result = exact_launch_transaction(
         prepared.identity, std::move(permit),
-        [&]() {
+        [&]() -> int {
             // Arming precedes any execution-visible submission, so its failures —
             // including a thread-spawn or allocation throw — are reported as an rc
             // and leave the run safely rollback-able.
@@ -638,7 +638,7 @@ LaunchTransactionResult DeviceRunner::launch_run(PreparedExecution &prepared, La
                     workers[i].aicore_done = 0;
             } catch (...) {
                 LOG_ERROR("launch_run: arming failed before any stream submission");
-                return -1;
+                return PTO_RUNTIME_ERR_INTERNAL;
             }
 
             // Publishing query/drain ownership is a state change, so it sits past
@@ -657,7 +657,7 @@ LaunchTransactionResult DeviceRunner::launch_run(PreparedExecution &prepared, La
             }
             return launch_rc;
         },
-        [&]() {
+        [&]() -> int {
             LOG_INFO("=== launch_aicpu_kernel %s ===", host::KernelNames::RunName);
             int aicpu_launch_n =
                 (runtime.get_aicpu_launch_count() > 0) ? runtime.get_aicpu_launch_count() : launch_aicpu_num;
@@ -676,7 +676,7 @@ LaunchTransactionResult DeviceRunner::launch_run(PreparedExecution &prepared, La
 int DeviceRunner::reap_run() {
     if (!run_streams_.ready()) {
         LOG_ERROR("reap_run: the run stream pair is not ready");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     int rc = sync_stream_pair(run_streams_.aicpu(), run_streams_.aicore());
     if (rc != 0) {
@@ -843,7 +843,7 @@ private:
 
 int DeviceRunner::force_reset_device() {
     if (device_id_ < 0) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     // aclrtResetDeviceForce is an ACL API; bring ACL up for the whole sequence,
     // released on scope exit so a repeated poison-then-reset cycle in a
@@ -851,7 +851,7 @@ int DeviceRunner::force_reset_device() {
     AclInitGuard acl_guard;
     if (!acl_guard.ok()) {
         LOG_ERROR("force_reset_device: ACL init failed; cannot reset device %d", device_id_);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
         // Reset phase. Bind the device, best-effort drain (the op-timeout
@@ -863,7 +863,7 @@ int DeviceRunner::force_reset_device() {
         DeviceBindGuard bind_guard(device_id_);
         if (!bind_guard.bound()) {
             LOG_ERROR("force_reset_device: could not bind device %d; reset skipped", device_id_);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         (void)aclrtSynchronizeDeviceWithTimeout(timeout_config_.stream_sync_timeout_ms);
         aclError rc = aclrtResetDeviceForce(device_id_);
@@ -883,7 +883,7 @@ int DeviceRunner::force_reset_device() {
     DeviceBindGuard probe_bind(device_id_);
     if (!probe_bind.bound()) {
         LOG_ERROR("force_reset_device: post-reset DeviceBindGuard failed for device %d", device_id_);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     aclrtStream probe_stream = nullptr;
     aclError stream_rc = aclrtCreateStream(&probe_stream);
@@ -1137,12 +1137,12 @@ int DeviceRunner::init_chip_swimlane(
     auto register_cb = [](void *dev_ptr, size_t size, int device_id, void **host_ptr) -> int {
         if (load_hal_if_needed() != 0) {
             LOG_ERROR("Failed to load ascend_hal for profiling: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         HalHostRegisterFn fn = get_halHostRegister();
         if (fn == nullptr) {
             LOG_ERROR("halHostRegister symbol not found: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
     };
@@ -1175,12 +1175,12 @@ int DeviceRunner::init_args_dump(Runtime &runtime, int device_id, KernelArgsHelp
     auto register_cb = [](void *dev_ptr, size_t size, int device_id, void **host_ptr) -> int {
         if (load_hal_if_needed() != 0) {
             LOG_ERROR("Failed to load ascend_hal for args dump: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         HalHostRegisterFn fn = get_halHostRegister();
         if (fn == nullptr) {
             LOG_ERROR("halHostRegister symbol not found: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
     };
@@ -1211,12 +1211,12 @@ int DeviceRunner::init_pmu(
     auto register_cb = [](void *dev_ptr, size_t size, int device_id, void **host_ptr) -> int {
         if (load_hal_if_needed() != 0) {
             LOG_ERROR("Failed to load ascend_hal for PMU: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         HalHostRegisterFn fn = get_halHostRegister();
         if (fn == nullptr) {
             LOG_ERROR("halHostRegister symbol not found: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
     };
@@ -1243,12 +1243,12 @@ int DeviceRunner::init_dep_gen(int num_threads, int device_id, KernelArgsHelper 
     auto register_cb = [](void *dev_ptr, size_t size, int device_id, void **host_ptr) -> int {
         if (load_hal_if_needed() != 0) {
             LOG_ERROR("Failed to load ascend_hal for dep_gen: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         HalHostRegisterFn fn = get_halHostRegister();
         if (fn == nullptr) {
             LOG_ERROR("halHostRegister symbol not found: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
     };
@@ -1274,12 +1274,12 @@ int DeviceRunner::init_scope_stats(int num_threads, int device_id, KernelArgsHel
     auto register_cb = +[](void *dev_ptr, size_t size, int device_id, void **host_ptr) -> int {
         if (load_hal_if_needed() != 0) {
             LOG_ERROR("Failed to load ascend_hal for scope_stats: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         HalHostRegisterFn fn = get_halHostRegister();
         if (fn == nullptr) {
             LOG_ERROR("halHostRegister symbol not found: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
     };

--- a/src/a2a3/platform/onboard/host/host_regs.cpp
+++ b/src/a2a3/platform/onboard/host/host_regs.cpp
@@ -18,6 +18,7 @@
 #include "common/unified_log.h"
 #include "common/platform_config.h"
 #include "common/acl_hal_device.h"
+#include "pto_runtime_c_api.h"
 #include "runtime/rt.h"
 #include "ascend_hal.h"  // CANN HAL API definitions (MODULE_TYPE_AICORE, INFO_TYPE_OCCUPY, etc.)
 #include <chrono>
@@ -99,7 +100,7 @@ get_aicore_reg_info(std::vector<int64_t> &aic, std::vector<int64_t> &aiv, const 
 
     if (halFunc == nullptr) {
         LOG_ERROR("halMemCtl not found in symbol table");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     struct AddrMapInPara in_map_para;
@@ -187,7 +188,7 @@ int init_aicore_register_addresses(
 ) {
     if (runtime_regs_ptr == nullptr) {
         LOG_ERROR("init_aicore_register_addresses(%s): Invalid parameters", kind_to_name(kind));
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     std::vector<int64_t> host_regs;
@@ -197,21 +198,21 @@ int init_aicore_register_addresses(
     }
     if (host_regs.empty()) {
         LOG_ERROR("init_aicore_register_addresses(%s): Empty address array", kind_to_name(kind));
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     size_t regs_size = host_regs.size() * sizeof(int64_t);
     void *reg_ptr = allocator.alloc(regs_size);
     if (reg_ptr == nullptr) {
         LOG_ERROR("Failed to allocate device memory for %s register addresses", kind_to_name(kind));
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     int ret = rtMemcpy(reg_ptr, regs_size, host_regs.data(), regs_size, RT_MEMCPY_HOST_TO_DEVICE);
     if (ret != 0) {
         LOG_ERROR("Failed to copy %s register addresses to device (rc=%d)", kind_to_name(kind), ret);
         allocator.free(reg_ptr);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     *runtime_regs_ptr = reinterpret_cast<uint64_t>(reg_ptr);

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -33,11 +33,11 @@ DeviceContextHandle create_device_context(void) {
 }
 
 int ensure_acl_ready_ctx(DeviceContextHandle ctx, int device_id) {
-    if (ctx == NULL) return -1;
+    if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<DeviceRunner *>(ctx)->ensure_acl_ready(device_id);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
@@ -57,11 +57,11 @@ void *create_comm_stream_ctx(DeviceContextHandle ctx) {
 }
 
 int destroy_comm_stream_ctx(DeviceContextHandle ctx, void *stream) {
-    if (ctx == NULL) return -1;
+    if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<DeviceRunner *>(ctx)->destroy_comm_stream(stream);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 

--- a/src/a2a3/platform/shared/host/pmu_collector.cpp
+++ b/src/a2a3/platform/shared/host/pmu_collector.cpp
@@ -31,6 +31,7 @@
 
 #include "common/memory_barrier.h"
 #include "common/unified_log.h"
+#include "../../../../common/worker/pto_runtime_c_api.h"
 
 namespace {
 
@@ -73,14 +74,14 @@ int PmuCollector::init(
 ) {
     if (num_cores <= 0 || num_threads <= 0 || alloc_cb == nullptr || free_cb == nullptr) {
         LOG_ERROR("PmuCollector::init: invalid arguments");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (num_cores > PLATFORM_MAX_CORES || num_threads > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR(
             "PmuCollector::init: dimensions out of range (cores=%d/%d threads=%d/%d)", num_cores, PLATFORM_MAX_CORES,
             num_threads, PLATFORM_MAX_AICPU_THREADS
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Must precede the recycled-lane seeding below: push_recycled() folds its
@@ -104,7 +105,7 @@ int PmuCollector::init(
     if (!recycled_seed_capacity_is_sufficient(
             num_cores, num_threads, kPmuSurplusPerCore, decltype(manager_)::kRecycledQueueCapacity
         )) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // ---- Allocate shared header + buffer-state region ----
@@ -112,7 +113,7 @@ int PmuCollector::init(
     shm_dev_ = alloc_cb(shm_size_);
     if (shm_dev_ == nullptr) {
         LOG_ERROR("PmuCollector: failed to allocate PMU shared memory (%zu bytes)", shm_size_);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     if (register_cb != nullptr) {
@@ -143,7 +144,7 @@ int PmuCollector::init(
             void *dev_ptr = alloc_cb(buf_size);
             if (dev_ptr == nullptr) {
                 LOG_ERROR("PmuCollector: failed to allocate PmuBuffer c=%d b=%d", c, b);
-                return -1;
+                return PTO_RUNTIME_ERR_INTERNAL;
             }
 
             void *host_ptr = dev_ptr;

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -129,13 +129,13 @@ int DeviceRunner::ensure_binaries_loaded() {
                 "/tmp/aicpu_sim_XXXXXX", aicpu_so_binary_.data(), aicpu_so_binary_.size(), &aicpu_so_path_
             )) {
             LOG_ERROR("Failed to create temp file for AICPU SO");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         aicpu_so_handle_ = dlopen(aicpu_so_path_.c_str(), RTLD_NOW | RTLD_LOCAL);
         if (aicpu_so_handle_ == nullptr) {
             LOG_ERROR("dlopen failed for AICPU SO: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         auto load_sym = [this](const char *name, void **out) -> bool {
@@ -153,9 +153,11 @@ int DeviceRunner::ensure_binaries_loaded() {
             *out = sym;
         };
 
-        if (!load_sym("aicpu_execute", reinterpret_cast<void **>(&aicpu_execute_func_))) return -1;
+        if (!load_sym("aicpu_execute", reinterpret_cast<void **>(&aicpu_execute_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
         load_optional_sym("simpler_aicpu_register_callable", reinterpret_cast<void **>(&aicpu_register_callable_func_));
-        if (!load_sym("set_platform_regs", reinterpret_cast<void **>(&set_platform_regs_func_))) return -1;
+        if (!load_sym("set_platform_regs", reinterpret_cast<void **>(&set_platform_regs_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
         load_optional_sym("set_orch_device_id", reinterpret_cast<void **>(&set_orch_device_id_func_));
         load_optional_sym("set_scheduler_timeout_ms", reinterpret_cast<void **>(&set_scheduler_timeout_ms_func_));
         if (set_scheduler_timeout_ms_func_ != nullptr) {
@@ -170,40 +172,48 @@ int DeviceRunner::ensure_binaries_loaded() {
                 (sched_status.scheduler_env_set && sched_status.scheduler_valid) ? sched_cfg.scheduler_timeout_ms : 0
             );
         }
-        if (!load_sym("set_platform_dump_base", reinterpret_cast<void **>(&set_platform_dump_base_func_))) return -1;
-        if (!load_sym("set_platform_phase_base", reinterpret_cast<void **>(&set_platform_phase_base_func_))) return -1;
-        if (!load_sym("set_dump_args_enabled", reinterpret_cast<void **>(&set_dump_args_enabled_func_))) return -1;
+        if (!load_sym("set_platform_dump_base", reinterpret_cast<void **>(&set_platform_dump_base_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
+        if (!load_sym("set_platform_phase_base", reinterpret_cast<void **>(&set_platform_phase_base_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
+        if (!load_sym("set_dump_args_enabled", reinterpret_cast<void **>(&set_dump_args_enabled_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
         if (!load_sym(
                 "set_platform_chip_swimlane_base", reinterpret_cast<void **>(&set_platform_chip_swimlane_base_func_)
             ))
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         if (!load_sym(
                 "set_platform_chip_swimlane_aicore_rotation_table",
                 reinterpret_cast<void **>(&set_platform_chip_swimlane_aicore_rotation_table_func_)
             ))
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         if (!load_sym("set_chip_swimlane_enabled", reinterpret_cast<void **>(&set_chip_swimlane_enabled_func_)))
-            return -1;
-        if (!load_sym("set_platform_pmu_base", reinterpret_cast<void **>(&set_platform_pmu_base_func_))) return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
+        if (!load_sym("set_platform_pmu_base", reinterpret_cast<void **>(&set_platform_pmu_base_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
         if (!load_sym("set_platform_pmu_reg_addrs", reinterpret_cast<void **>(&set_platform_pmu_reg_addrs_func_)))
-            return -1;
-        if (!load_sym("set_pmu_enabled", reinterpret_cast<void **>(&set_pmu_enabled_func_))) return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
+        if (!load_sym("set_pmu_enabled", reinterpret_cast<void **>(&set_pmu_enabled_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
         if (!load_sym("set_platform_dep_gen_base", reinterpret_cast<void **>(&set_platform_dep_gen_base_func_)))
-            return -1;
-        if (!load_sym("set_dep_gen_enabled", reinterpret_cast<void **>(&set_dep_gen_enabled_func_))) return -1;
-        if (!load_sym("set_scope_stats_enabled", reinterpret_cast<void **>(&set_scope_stats_enabled_func_))) return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
+        if (!load_sym("set_dep_gen_enabled", reinterpret_cast<void **>(&set_dep_gen_enabled_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
+        if (!load_sym("set_scope_stats_enabled", reinterpret_cast<void **>(&set_scope_stats_enabled_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
         if (!load_sym("set_platform_scope_stats_base", reinterpret_cast<void **>(&set_platform_scope_stats_base_func_)))
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
 
         // The AICPU sim SO owns its level flags because it is RTLD_LOCAL.
         // Forward the process-wide HostLogger threshold explicitly.
         using SetLogLevelFunc = void (*)(int);
         SetLogLevelFunc set_log_level_func = nullptr;
-        if (!load_sym("set_log_level", reinterpret_cast<void **>(&set_log_level_func))) return -1;
+        if (!load_sym("set_log_level", reinterpret_cast<void **>(&set_log_level_func))) return PTO_RUNTIME_ERR_INTERNAL;
         set_log_level_func(HostLogger::get_instance().level());
         using SetHostLogStateFunc = void (*)(SimplerHostLogState *);
         SetHostLogStateFunc set_host_log_state_func = nullptr;
-        if (!load_sym("set_host_log_state", reinterpret_cast<void **>(&set_host_log_state_func))) return -1;
+        if (!load_sym("set_host_log_state", reinterpret_cast<void **>(&set_host_log_state_func)))
+            return PTO_RUNTIME_ERR_INTERNAL;
         set_host_log_state_func(HostLogger::get_instance().state());
 
         aicpu_so_loaded_ = true;
@@ -227,13 +237,13 @@ int DeviceRunner::ensure_binaries_loaded() {
                 "/tmp/aicore_sim_XXXXXX", aicore_kernel_binary_.data(), aicore_kernel_binary_.size(), &aicore_so_path_
             )) {
             LOG_ERROR("Failed to create temp file for AICore SO");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         aicore_so_handle_ = dlopen(aicore_so_path_.c_str(), RTLD_NOW | RTLD_LOCAL);
         if (aicore_so_handle_ == nullptr) {
             LOG_ERROR("dlopen failed for AICore SO: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         const char *bind_log_error = nullptr;
@@ -246,7 +256,7 @@ int DeviceRunner::ensure_binaries_loaded() {
             );
             dlclose(aicore_so_handle_);
             aicore_so_handle_ = nullptr;
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         aicore_execute_func_ =
@@ -255,7 +265,7 @@ int DeviceRunner::ensure_binaries_loaded() {
             );
         if (aicore_execute_func_ == nullptr) {
             LOG_ERROR("dlsym failed for aicore_execute_wrapper: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         LOG_INFO("DeviceRunner(sim): Loaded aicore_execute_wrapper from %s", aicore_so_path_.c_str());
 
@@ -277,7 +287,7 @@ int DeviceRunner::ensure_binaries_loaded() {
 int DeviceRunner::invoke_device_register(const RegisterCallableArgs &reg_args) {
     if (aicpu_register_callable_func_ == nullptr || set_orch_device_id_func_ == nullptr) {
         LOG_ERROR("Register-callable functions not loaded. Call ensure_binaries_loaded first.");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     set_orch_device_id_func_(device_id_);
     // The descriptor was assembled from CallableState by the base
@@ -299,10 +309,10 @@ int DeviceRunner::prepare_execution(
     Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot, const NativeRunIdentity &identity,
     std::unique_ptr<PreparedExecution> *prepared
 ) {
-    if (prepared == nullptr || *prepared != nullptr) return -1;
+    if (prepared == nullptr || *prepared != nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     if (active_run_ != nullptr) {
         LOG_ERROR("prepare_execution called while another simulated run still owns execution state");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
     active_run_ = std::make_unique<ActiveRun>();
@@ -324,7 +334,7 @@ int DeviceRunner::prepare_execution(
     runtime.set_aicpu_thread_num(launch_aicpu_num);
     if (block_dim < 1) {
         LOG_ERROR("prepare_execution computed block_dim < 1 from worker_count=%d", runtime.get_worker_count());
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     int rc = ensure_device_initialized();
@@ -438,7 +448,7 @@ int DeviceRunner::prepare_execution(
     active_run_->reg_blocks = mem_alloc_.alloc(total_reg_size);
     if (active_run_->reg_blocks == nullptr) {
         LOG_ERROR("Failed to allocate simulated register memory (%zu bytes)", total_reg_size);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     std::memset(active_run_->reg_blocks, 0, total_reg_size);
 
@@ -446,7 +456,7 @@ int DeviceRunner::prepare_execution(
     uint64_t *regs_array = reinterpret_cast<uint64_t *>(mem_alloc_.alloc(regs_array_size));
     if (regs_array == nullptr) {
         LOG_ERROR("Failed to allocate register address array");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     for (int i = 0; i < num_aicore; i++) {
         regs_array[i] =
@@ -462,7 +472,7 @@ int DeviceRunner::prepare_execution(
     active_run_->pmu_reg_blocks = mem_alloc_.alloc(total_pmu_reg_size);
     if (active_run_->pmu_reg_blocks == nullptr) {
         LOG_ERROR("Failed to allocate simulated PMU register memory (%zu bytes)", total_pmu_reg_size);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     std::memset(active_run_->pmu_reg_blocks, 0, total_pmu_reg_size);
 
@@ -470,7 +480,7 @@ int DeviceRunner::prepare_execution(
     uint64_t *pmu_regs_array = reinterpret_cast<uint64_t *>(mem_alloc_.alloc(pmu_regs_array_size));
     if (pmu_regs_array == nullptr) {
         LOG_ERROR("Failed to allocate PMU register address array");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     for (int i = 0; i < num_aicore; i++) {
         pmu_regs_array[i] =
@@ -488,7 +498,7 @@ int DeviceRunner::prepare_execution(
         set_platform_chip_swimlane_aicore_rotation_table_func_ == nullptr ||
         set_chip_swimlane_enabled_func_ == nullptr) {
         LOG_ERROR("Executor functions not loaded. Call ensure_binaries_loaded first.");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
@@ -519,7 +529,7 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
 
     LaunchTransactionResult result = exact_launch_transaction(
         prepared->identity, std::move(permit),
-        [&]() {
+        [&]() -> int {
             // Arming precedes any simulated-core thread, so its failures — including
             // a thread-spawn or allocation throw — are reported as an rc and leave
             // the run safely rollback-able.
@@ -559,7 +569,7 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
                 run_completion_.reset(static_cast<size_t>(over_launch) + static_cast<size_t>(num_aicore));
             } catch (...) {
                 LOG_ERROR("launch_execution: arming failed before any simulated core started");
-                return -1;
+                return PTO_RUNTIME_ERR_INTERNAL;
             }
 
             LOG_INFO("Launching %d AICore thread(s)", num_aicore);
@@ -576,7 +586,7 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
             }
             return 0;
         },
-        [&]() {
+        [&]() -> int {
             LOG_INFO("Launching %d AICPU threads (logical=%d)", over_launch, launch_aicpu_num);
             for (int i = 0; i < over_launch; i++) {
                 run->aicpu_threads.push_back(create_thread([this, run, launch_aicpu_num, over_launch, sim_t0]() {
@@ -614,7 +624,7 @@ int DeviceRunner::poll_execution(const ActiveExecution &) { return run_completio
 int DeviceRunner::drain_execution(ActiveExecution &) {
     if (active_run_ == nullptr) {
         LOG_ERROR("drain_execution called without a launched simulated run");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     auto run_cleanup = RAIIScopeGuard([this]() {
         cleanup_active_run();

--- a/src/a2a3/runtime/host_build_graph/common/pto_runtime_status.h
+++ b/src/a2a3/runtime/host_build_graph/common/pto_runtime_status.h
@@ -12,13 +12,18 @@
 /**
  * PTO2 Runtime Status Helpers
  *
- * Shared error-code contract used inside the tensormap_and_ringbuffer runtime.
+ * Shared error-code contract used inside the host_build_graph runtime.
  */
 
-#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_COMMON_PTO_RUNTIME_STATUS_H_
-#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_COMMON_PTO_RUNTIME_STATUS_H_
+#pragma once
 
 #include <stdint.h>
+
+// A latched code reaches the host as its own value negated, so the two families
+// below land in -1..-99 and -100..-PTO_RUNTIME_LATCHED_CODE_MAX there. That
+// ceiling lives in src/common/worker/pto_runtime_c_api.h, and the host-side C
+// API band begins below its negation — so the latched range is bounded, not
+// open-ended downwards.
 
 // Orchestrator errors (1-99): detected in orchestrator thread
 #define PTO2_ERROR_NONE 0  // Explicitly means "no error"; it is not an "unknown/unspecified" error code.
@@ -50,5 +55,3 @@ static inline int32_t runtime_status_from_error_codes(int32_t orch_error_code, i
     }
     return 0;
 }
-
-#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_COMMON_PTO_RUNTIME_STATUS_H_

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -76,6 +76,18 @@
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
+// This file returns both kinds of negative status — a latched device code
+// negated, and PTO_RUNTIME_ERR_* for a host-side failure — so a caller can
+// attribute one to a mechanism only while the two bands stay disjoint. The
+// second conjunct is the structural half and holds for any latched code; the
+// first is a spot check on the highest one this runtime defines, so a new
+// four-digit latched code needs the ceiling raised here as well.
+static_assert(
+    PTO2_ERROR_READY_QUEUE_OVERFLOW <= PTO_RUNTIME_LATCHED_CODE_MAX &&
+        PTO_RUNTIME_ERR_BASE < -PTO_RUNTIME_LATCHED_CODE_MAX,
+    "host-side C API codes must stay below the negation of every latched device code"
+);
+
 extern "C" const PipelineContract *get_pipeline_contract(void) {
     // Host orchestration materializes this run's own graph into the image it
     // uploads, so every device-resident region carries per-run content.
@@ -558,27 +570,27 @@ int32_t run_host_orchestration(
             layout.orch, host_arena, host_sm, gm_heap, eff_heap_sizes[0], eff_task_window_sizes[0]
         )) {
         LOG_ERROR("host-orch: orchestrator re-init against host SM failed");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     rt->orchestrator.wire_arena_pointers(layout.orch, host_arena, rt->scheduler);
 
     PTO2SharedMemoryHandle host_sm_handle;
     if (!host_sm_handle.init_per_ring(host_sm, sm_size, eff_task_window_sizes, eff_heap_sizes)) {
         LOG_ERROR("host-orch: host SM init_per_ring failed");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     GraphHostStatePtr graph_state = make_graph_host_state();
     if (!graph_state) {
         LOG_ERROR("host-orch: failed to allocate Graph host state");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     GraphHostStateBinding graph_binding(rt->orchestrator, graph_state.get());
 
     const int32_t block_dim = runtime->get_worker_count() / PLATFORM_CORES_PER_BLOCKDIM;
     if (block_dim < 1) {
         LOG_ERROR("host-orch: worker_count %d yields no clusters", runtime->get_worker_count());
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     runtime_finalize_after_wire(
         rt, block_dim * PLATFORM_AIC_CORES_PER_BLOCKDIM, block_dim * PLATFORM_AIV_CORES_PER_BLOCKDIM
@@ -588,7 +600,7 @@ int32_t run_host_orchestration(
     const auto *entry_points = reinterpret_cast<const HostOrchEntryPoints *>(host_orch_func_ptr);
     if (entry_points->bind == nullptr) {
         LOG_ERROR("host-orch: orch .so framework_bind_runtime was not resolved");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     rt->active_callable_hash = reinterpret_cast<uint64_t>(entry_points->entry);
     rt->tensor_access = &tensor_access;
@@ -634,8 +646,9 @@ int32_t run_host_orchestration(
         // The latched code is the diagnosis, so it is what the caller sees — through the
         // same mapping the run path uses, since a caller cannot tell which of the two
         // noticed. A fatal with no code left to read is the only generic failure.
-        const int32_t status =
-            orch_error != PTO2_ERROR_NONE ? runtime_status_from_error_codes(orch_error, PTO2_ERROR_NONE) : -1;
+        const int32_t status = orch_error != PTO2_ERROR_NONE ?
+                                   runtime_status_from_error_codes(orch_error, PTO2_ERROR_NONE) :
+                                   PTO_RUNTIME_ERR_INTERNAL;
         LOG_RUNTIME_FAILURE(orch_error, PTO2_ERROR_NONE, status);
         LOG_ERROR(
             "host-orch: refusing to upload an incomplete graph after %" PRIu64 " heap bytes",
@@ -664,7 +677,7 @@ int32_t run_host_orchestration(
     std::vector<StagedSubmission> staged_submissions;
     uint64_t submission_block_bytes = 0;
     if (!plan_graph_submissions(api, *graph_state, &staged_submissions, &submission_block_bytes, &definition_uploads)) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
         // `bytes` is what this segment copied: the Definition objects alone. The
@@ -683,7 +696,7 @@ int32_t run_host_orchestration(
     // [0, task_window] would make those copies read/write out of bounds.
     if (total_tasks < 0 || static_cast<uint64_t>(total_tasks) > eff_task_window_sizes[0]) {
         LOG_ERROR("host-orch: total_tasks %d out of range [0, %" PRIu64 "]", total_tasks, eff_task_window_sizes[0]);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     host_phase_trace_note_submitted(static_cast<uint64_t>(total_tasks));
 
@@ -728,12 +741,12 @@ int32_t run_host_orchestration(
     const uint64_t device_arena_bytes = off_submissions + submission_block_bytes;
     if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, device_arena_bytes) != 0) {
         LOG_ERROR("host-orch: failed to commit %" PRIu64 " bytes of device runtime arena", device_arena_bytes);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     device_arena = api->acquire_pooled_runtime_arena();
     if (device_arena == nullptr) {
         LOG_ERROR("%s", "host-orch: failed to re-acquire the pooled runtime arena");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     char *arena_dev = static_cast<char *>(device_arena);
     void *device_sm = arena_dev + layout.off_copied_end;
@@ -774,7 +787,7 @@ int32_t run_host_orchestration(
     const int64_t t_h2d_ns = bind_now_ns();
     if (api->copy_to_device(arena_dev + layout.off_copied_begin, upload_base, upload_bytes) != 0) {
         LOG_ERROR("host-orch: H2D of the runtime image failed");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
         // Eight uint64 fields plus their labels; 96 would truncate the trailing
@@ -807,11 +820,11 @@ int32_t run_host_orchestration(
 extern "C" int register_callable_impl(const ChipCallable *callable, const HostApi *api, CallableArtifacts *out) {
     if (callable == nullptr) {
         LOG_ERROR("Callable pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (api == nullptr || out == nullptr) {
         LOG_ERROR("HostApi or out is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     *out = CallableArtifacts{};
     out->signature.assign(callable->signature_, callable->signature_ + callable->sig_count());
@@ -821,12 +834,12 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
             callable, api, &out->kernel_addrs, &out->chip_buffer_dev, &out->chip_buffer_hash, &out->aicore_image_hash
         ) != 0) {
         LOG_ERROR("Failed to upload ChipCallable buffer");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     for (const ChildKernelAddr &c : out->kernel_addrs) {
         if (c.func_id < 0 || c.func_id >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("func_id=%d is out of range [0, %d)", c.func_id, RUNTIME_MAX_FUNC_ID);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
     }
 
@@ -835,7 +848,7 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
 
     if (orch_so_binary == nullptr || orch_so_size == 0) {
         LOG_ERROR("Orchestration SO binary is required for host orchestration");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     out->orch_so_data = orch_so_binary;
@@ -853,17 +866,17 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
         const char *orch_func_name = callable->func_name();
         if (orch_func_name == nullptr || orch_func_name[0] == '\0') {
             LOG_ERROR("host-orch: orchestration function name is empty");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         std::string so_path;
         if (!create_orch_so_tempfile(orch_so_binary, orch_so_size, &so_path)) {
             LOG_ERROR("host-orch: failed to materialize orchestration .so");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         void *handle = dlopen(so_path.c_str(), RTLD_NOW | RTLD_LOCAL);
         if (handle == nullptr) {
             LOG_ERROR("host-orch: dlopen failed: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         const char *bind_log_error = nullptr;
         if (simpler::log::bind_loaded_host_log_state(handle, HostLogger::get_instance().state(), &bind_log_error) !=
@@ -873,13 +886,13 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
                 bind_log_error != nullptr ? bind_log_error : "unknown error"
             );
             dlclose(handle);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         void *entry = dlsym(handle, orch_func_name);
         if (entry == nullptr) {
             LOG_ERROR("host-orch: dlsym('%s') failed: %s", orch_func_name, dlerror());
             dlclose(handle);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         // The orch .so has its own framework_bind_runtime / g_current_runtime
         // (orchestration/common.cpp is compiled into it); resolve it now so the
@@ -888,13 +901,13 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
         if (bind_sym == nullptr) {
             LOG_ERROR("host-orch: orch .so does not export framework_bind_runtime: %s", dlerror());
             dlclose(handle);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         void *prewarm_sym = dlsym(handle, "framework_prewarm_graph_recorders");
         if (prewarm_sym == nullptr) {
             LOG_ERROR("host-orch: orch .so does not export framework_prewarm_graph_recorders: %s", dlerror());
             dlclose(handle);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         reinterpret_cast<OrchestrationPrewarmFunc>(prewarm_sym)();
         // Safe to unlink now: the handle keeps the .so mapped regardless of path.
@@ -932,15 +945,15 @@ extern "C" int bind_callable_to_runtime_impl(
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (api == nullptr) {
         LOG_ERROR("HostApi pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (orch_args == nullptr) {
         LOG_ERROR("orch_args pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     // host_build_graph host-orch: register_callable_impl resolved the
     // orchestration entry on the host and passed it here as host_orch_func_ptr;
@@ -962,7 +975,7 @@ extern "C" int bind_callable_to_runtime_impl(
     uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH];
     uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH];
     if (!resolve_ring_config(ring_task_window, ring_heap, eff_task_window_sizes, eff_heap_sizes)) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     const std::string task_window_log = format_ring_array(eff_task_window_sizes);
     const std::string heap_log = format_ring_array(eff_heap_sizes);
@@ -994,7 +1007,7 @@ extern "C" int bind_callable_to_runtime_impl(
         void *dev_ptr = api->device_malloc(size);
         if (dev_ptr == nullptr) {
             LOG_ERROR("Failed to allocate device memory for tensor %d", i);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         // Pure write-only OUTPUT buffers are never read by the kernel and hold
@@ -1007,7 +1020,7 @@ extern "C" int bind_callable_to_runtime_impl(
             if (rc != 0) {
                 LOG_ERROR("Failed to stage tensor %d to device", i);
                 api->device_free(dev_ptr);
-                return -1;
+                return PTO_RUNTIME_ERR_INTERNAL;
             }
             staged_bytes += static_cast<uint64_t>(size);
             ++staged_tensors;
@@ -1034,7 +1047,7 @@ extern "C" int bind_callable_to_runtime_impl(
         // device address.
         if (!tensor_access.add(reinterpret_cast<uint64_t>(dev_ptr), size, host_ptr)) {
             LOG_ERROR("host-orch: no host view for tensor %d (dev_ptr %p, %zu bytes)", i, dev_ptr, size);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         t.buffer.addr = reinterpret_cast<uint64_t>(dev_ptr);
@@ -1061,7 +1074,7 @@ extern "C" int bind_callable_to_runtime_impl(
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         if (eff_heap_sizes[r] > std::numeric_limits<uint64_t>::max() - total_heap_size) {
             LOG_ERROR("Total ring heap size overflows uint64_t");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         total_heap_size += eff_heap_sizes[r];
     }
@@ -1072,7 +1085,7 @@ extern "C" int bind_callable_to_runtime_impl(
     PTO2RuntimeArenaLayout layout = runtime_reserve_layout(host_arena, eff_task_window_sizes, eff_heap_sizes);
     if (host_arena.commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
         LOG_ERROR("Failed to commit host arena for prebuilt runtime image");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
         char attrs[64];
@@ -1098,7 +1111,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // places tasks.
     if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, layout.device_bytes) != 0) {
         LOG_ERROR("Failed to setup pooled static arena");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
         char attrs[96];
@@ -1111,7 +1124,7 @@ extern "C" int bind_callable_to_runtime_impl(
     record_bind_phase(HostPhaseKind::BindGmHeap, t_heap_ns);
     if (gm_heap == nullptr) {
         LOG_ERROR("Failed to acquire pooled GM heap");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     runtime->set_gm_heap(gm_heap);
     // The shared memory is placed at the end of orchestration, so until then this
@@ -1122,7 +1135,7 @@ extern "C" int bind_callable_to_runtime_impl(
     void *runtime_arena_dev = api->acquire_pooled_runtime_arena();
     if (runtime_arena_dev == nullptr) {
         LOG_ERROR("Failed to acquire pooled runtime arena");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Set up orchestration state (consumed by the host orchestrator below)
@@ -1146,7 +1159,7 @@ extern "C" int bind_callable_to_runtime_impl(
     );
     if (rt == nullptr) {
         LOG_ERROR("runtime_init_data_from_layout failed");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     runtime_wire_arena_pointers(host_arena, layout, rt);
     runtime_wire_host_only_pointers(host_arena, layout, rt);
@@ -1161,7 +1174,7 @@ extern "C" int bind_callable_to_runtime_impl(
 
     if (host_orch_func_ptr == nullptr) {
         LOG_ERROR("host-orch: orchestration entry points were not resolved");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
         ChipTaskArgs orch_l2;
@@ -1195,7 +1208,7 @@ extern "C" int bind_callable_to_runtime_impl(
     runtime_arena_dev = api->acquire_pooled_runtime_arena();
     if (runtime_arena_dev == nullptr) {
         LOG_ERROR("%s", "Failed to re-acquire the pooled runtime arena after orchestration");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     runtime->set_prebuilt_arena(runtime_arena_dev, layout.off_runtime);
 
@@ -1220,11 +1233,11 @@ extern "C" int bind_callable_to_runtime_impl(
 extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (api == nullptr) {
         LOG_ERROR("HostApi pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     int rc = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h
@@ -15,10 +15,15 @@
  * Shared error-code contract used inside the tensormap_and_ringbuffer runtime.
  */
 
-#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_COMMON_PTO_RUNTIME_STATUS_H_
-#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_COMMON_PTO_RUNTIME_STATUS_H_
+#pragma once
 
 #include <stdint.h>
+
+// A latched code reaches the host as its own value negated, so the two families
+// below land in -1..-99 and -100..-PTO_RUNTIME_LATCHED_CODE_MAX there. That
+// ceiling lives in src/common/worker/pto_runtime_c_api.h, and the host-side C
+// API band begins below its negation — so the latched range is bounded, not
+// open-ended downwards.
 
 // Orchestrator errors (1-99): detected in orchestrator thread
 #define PTO2_ERROR_NONE 0  // Explicitly means "no error"; it is not an "unknown/unspecified" error code.
@@ -92,5 +97,3 @@ static inline int32_t runtime_status_from_error_codes(int32_t orch_error_code, i
     }
     return 0;
 }
-
-#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_COMMON_PTO_RUNTIME_STATUS_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -58,6 +58,18 @@
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
+// This file returns both kinds of negative status — a latched device code
+// negated, and PTO_RUNTIME_ERR_* for a host-side failure — so a caller can
+// attribute one to a mechanism only while the two bands stay disjoint. The
+// second conjunct is the structural half and holds for any latched code; the
+// first is a spot check on the highest one this runtime defines, so a new
+// four-digit latched code needs the ceiling raised here as well.
+static_assert(
+    PTO2_ERROR_ASYNC_REGISTRATION_FAILED <= PTO_RUNTIME_LATCHED_CODE_MAX &&
+        PTO_RUNTIME_ERR_BASE < -PTO_RUNTIME_LATCHED_CODE_MAX,
+    "host-side C API codes must stay below the negation of every latched device code"
+);
+
 extern "C" const PipelineContract *get_pipeline_contract(void) {
     // Orchestration runs on the device, so this run's own content is confined to
     // its task args. The three pooled regions are built and uploaded once per
@@ -405,11 +417,11 @@ private:
 extern "C" int register_callable_impl(const ChipCallable *callable, const HostApi *api, CallableArtifacts *out) {
     if (callable == nullptr) {
         LOG_ERROR("Callable pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (api == nullptr || out == nullptr) {
         LOG_ERROR("HostApi or out is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     *out = CallableArtifacts{};
     out->signature.assign(callable->signature_, callable->signature_ + callable->sig_count());
@@ -419,12 +431,12 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
             callable, api, &out->kernel_addrs, &out->chip_buffer_dev, &out->chip_buffer_hash, &out->aicore_image_hash
         ) != 0) {
         LOG_ERROR("Failed to upload ChipCallable buffer");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     for (const ChildKernelAddr &c : out->kernel_addrs) {
         if (c.func_id < 0 || c.func_id >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("func_id=%d is out of range [0, %d)", c.func_id, RUNTIME_MAX_FUNC_ID);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
     }
 
@@ -433,7 +445,7 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
 
     if (orch_so_binary == nullptr || orch_so_size == 0) {
         LOG_ERROR("Orchestration SO binary is required for device orchestration");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     out->orch_so_data = orch_so_binary;
@@ -508,10 +520,10 @@ static bool resolve_arena_sizing(
 extern "C" int prepared_run_config_compatible_impl(
     const HostApi *api, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
 ) {
-    if (api == nullptr) return -1;
+    if (api == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
 
     ArenaSizingConfig sizing;
-    if (!resolve_arena_sizing(ring_task_window, ring_heap, ring_dep_pool, &sizing)) return -1;
+    if (!resolve_arena_sizing(ring_task_window, ring_heap, ring_dep_pool, &sizing)) return PTO_RUNTIME_ERR_INTERNAL;
 
     PrebuiltRuntimeArenaCacheProbe probe = make_prebuilt_runtime_arena_cache_probe(sizing);
     void *gm_heap = nullptr;
@@ -858,22 +870,22 @@ extern "C" int bind_callable_to_runtime_impl(
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (api == nullptr) {
         LOG_ERROR("HostApi pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (orch_args == nullptr) {
         LOG_ERROR("orch_args pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     // trb runs orchestration on the device — there is no host-side orch
     // function pointer to invoke. The c_api signature accepts one for
     // symmetry with hbg; assert the trb-side invariant here.
     if (host_orch_func_ptr != nullptr) {
         LOG_ERROR("bind_callable_to_runtime_impl: trb does not accept a host_orch_func_ptr");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     int tensor_count = orch_args->tensor_count();
@@ -885,7 +897,7 @@ extern "C" int bind_callable_to_runtime_impl(
 
     ArenaSizingConfig sizing;
     if (!resolve_arena_sizing(ring_task_window, ring_heap, ring_dep_pool, &sizing)) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // The retained temporary buffer is always used on the trb path — it is an
@@ -895,7 +907,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // bump-slice from it.
     RetainedTempBump bump;
     if (!bump.begin(api, orch_args)) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     auto bind_cleanup = RAIIScopeGuard([&]() {
@@ -904,7 +916,7 @@ extern "C" int bind_callable_to_runtime_impl(
 
     ChipStorageTaskArgs device_args;
     if (!stage_device_args(runtime, api, orch_args, signature, sig_count, &bump, &device_args)) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     apply_orch_sched_env_flags(runtime);
@@ -915,7 +927,7 @@ extern "C" int bind_callable_to_runtime_impl(
         PrebuiltRuntimeArenaCacheProbe cache_probe = make_prebuilt_runtime_arena_cache_probe(sizing);
         int cache_rc = bind_cached_runtime_image(runtime, api, cache_probe, device_args);
         if (cache_rc < 0) {
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         if (cache_rc != 0) {
             // Miss: build + upload the arena image, then wire the runtime
@@ -927,7 +939,7 @@ extern "C" int bind_callable_to_runtime_impl(
             StaticArenaPtrs ptrs;
             PTO2RuntimeArenaLayout layout;
             if (!build_and_cache_prebuilt_arena(api, sizing, &ptrs, &layout)) {
-                return -1;
+                return PTO_RUNTIME_ERR_INTERNAL;
             }
             runtime->set_orch_args(device_args);
             runtime->set_gm_sm_ptr(ptrs.gm_sm);
@@ -960,16 +972,16 @@ extern "C" int prewarm_config_impl(
 ) {
     if (api == nullptr) {
         LOG_ERROR("HostApi pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     ArenaSizingConfig sizing;
     if (!resolve_arena_sizing(ring_task_window, ring_heap, ring_dep_pool, &sizing)) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     STRACE("chip.prewarm.build");
-    return build_and_cache_prebuilt_arena(api, sizing) ? 0 : -1;
+    return build_and_cache_prebuilt_arena(api, sizing) ? 0 : PTO_RUNTIME_ERR_INTERNAL;
 }
 
 /**
@@ -988,11 +1000,11 @@ extern "C" int prewarm_config_impl(
 extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (api == nullptr) {
         LOG_ERROR("HostApi pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     int rc = 0;

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -82,7 +82,7 @@ DeviceRunner::~DeviceRunner() { finalize(); }
 int DeviceRunner::ensure_acl_ready(int device_id) {
     if (device_id < 0) {
         LOG_ERROR("ensure_acl_ready: invalid device_id %d", device_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // aclInit is process-wide; CANN returns 100002 if it has already been
@@ -151,7 +151,7 @@ int DeviceRunner::query_aicpu_device_occupancy(pto::a5::AicpuDeviceOccupancy &ou
     void *device_result = mem_alloc_.alloc(sizeof(AicpuTopologyQueryResult));
     if (device_result == nullptr) {
         LOG_ERROR("AICPU topology query result allocation failed");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     auto result_cleanup = RAIIScopeGuard([&]() {
         mem_alloc_.free(device_result);
@@ -187,7 +187,7 @@ int DeviceRunner::query_aicpu_device_occupancy(pto::a5::AicpuDeviceOccupancy &ou
             "device-side AICPU OCCUPY query failed: rc=%d mask=0x%llx", result.occupy_rc,
             static_cast<unsigned long long>(result.occupy)
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     aicpu_device_occupancy_.occupy = result.occupy;
     aicpu_device_occupancy_.pf_occupy = result.pf_occupy;
@@ -211,7 +211,8 @@ int DeviceRunner::query_aicpu_topology(pto::a5::AicpuTopology &out) {
     if (rc != 0) return rc;
 
     pto::a5::AicpuTopology topology;
-    if (!pto::a5::probe_aicpu_topology(static_cast<uint32_t>(device_id_), occupancy, topology)) return -1;
+    if (!pto::a5::probe_aicpu_topology(static_cast<uint32_t>(device_id_), occupancy, topology))
+        return PTO_RUNTIME_ERR_INTERNAL;
 
     aicpu_topology_ = std::move(topology);
     aicpu_topology_cached_ = true;
@@ -230,7 +231,7 @@ int DeviceRunner::prepare_execution(
     Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot, const NativeRunIdentity &identity,
     std::unique_ptr<PreparedExecution> *prepared
 ) {
-    if (prepared == nullptr || *prepared != nullptr) return -1;
+    if (prepared == nullptr || *prepared != nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
     execution->resources_owned = true;
     auto prepare_rollback = RAIIScopeGuard([this, &execution]() {
@@ -254,9 +255,9 @@ int DeviceRunner::prepare_execution(
             "A soft reset does not clear the poison on a5; finalize() will force-reset "
             "the card so the next Worker on it inits clean."
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
-    if (validate_launch_aicpu_num(requested_aicpu_num) != 0) return -1;
+    if (validate_launch_aicpu_num(requested_aicpu_num) != 0) return PTO_RUNTIME_ERR_INTERNAL;
     int active_aicpu_num = automatic_aicpu_num ? PLATFORM_DEFAULT_AICPU_THREAD_NUM : requested_aicpu_num;
     runtime.set_aicpu_thread_num(active_aicpu_num);
 
@@ -270,7 +271,7 @@ int DeviceRunner::prepare_execution(
 
     if (block_dim < 1) {
         LOG_ERROR("prepare_execution computed block_dim < 1 from worker_count=%d", runtime.get_worker_count());
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     int num_aicore = block_dim * cores_per_blockdim_;
 
@@ -305,7 +306,7 @@ int DeviceRunner::prepare_execution(
         runtime.set_aicpu_allowed_cpu_count(0);
         if (query_aicpu_topology(topology) != 0) {
             LOG_ERROR("AICPU topology probe failed; affinity gate will not launch");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         pto::a5::AicpuLaunchPlan launch_plan;
         std::string plan_error;
@@ -316,7 +317,7 @@ int DeviceRunner::prepare_execution(
                 pto::a5::aicpu_scenario_name(topology.scenario_type),
                 static_cast<unsigned long long>(topology.device_occupancy.occupy), plan_error.c_str()
             );
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         const auto &allowed = launch_plan.allowed_cpus;
         active_aicpu_num = launch_plan.effective_active_count;
@@ -325,7 +326,7 @@ int DeviceRunner::prepare_execution(
             const size_t cap = runtime.aicpu_allowed_cpus_capacity();
             if (allowed.size() > cap) {
                 LOG_ERROR("AICPU selection returned %zu > cap %zu", allowed.size(), cap);
-                return -1;
+                return PTO_RUNTIME_ERR_INTERNAL;
             }
             int32_t *allowed_cpus = runtime.get_aicpu_allowed_cpus();
             for (size_t i = 0; i < allowed.size(); ++i)
@@ -446,7 +447,7 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
 
     LaunchTransactionResult transaction = exact_launch_transaction(
         prepared->identity, std::move(permit),
-        [&]() {
+        [&]() -> int {
             // Arming precedes any execution-visible submission, so its failures —
             // including a thread-spawn or allocation throw — are reported as an rc
             // and leave the run safely rollback-able.
@@ -494,7 +495,7 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
                     workers[i].aicore_done = 0;
             } catch (...) {
                 LOG_ERROR("launch_execution: arming failed before any stream submission");
-                return -1;
+                return PTO_RUNTIME_ERR_INTERNAL;
             }
 
             run_poll_slot_.store(prepared->pipeline_slot, std::memory_order_relaxed);
@@ -508,7 +509,7 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
             }
             return launch_rc;
         },
-        [&]() {
+        [&]() -> int {
             LOG_INFO("=== launch_aicpu_kernel %s ===", host::KernelNames::RunName);
             // launch_count = popcount(OCCUPY) from the topology probe — one thread
             // per user-schedulable cpu_id. The filter gate barriers exactly this
@@ -562,7 +563,7 @@ int DeviceRunner::poll_execution(const ActiveExecution &active) {
 }
 
 int DeviceRunner::drain_execution(ActiveExecution &active) {
-    if (active.prepared == nullptr) return -1;
+    if (active.prepared == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     PreparedExecution &prepared = *active.prepared;
     const uint32_t pipeline_slot = prepared.pipeline_slot;
     if (!prepared.resources_owned || run_poll_slot_.load(std::memory_order_relaxed) != pipeline_slot) {
@@ -570,7 +571,7 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
             "drain_execution slot mismatch: requested=%u active=%u owns=%d", pipeline_slot,
             run_poll_slot_.load(std::memory_order_relaxed), static_cast<int>(prepared.resources_owned)
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     auto drain_cleanup = RAIIScopeGuard([this, &prepared]() {
         cleanup_execution(prepared, /*launched=*/true);
@@ -746,7 +747,7 @@ private:
 int DeviceRunner::force_reset_device() {
     clear_aicpu_topology_cache();
     if (device_id_ < 0) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     // aclrtResetDeviceForce is an ACL API; bring ACL up for the whole sequence,
     // released on scope exit so a repeated poison-then-reset cycle in a
@@ -754,7 +755,7 @@ int DeviceRunner::force_reset_device() {
     AclInitGuard acl_guard;
     if (!acl_guard.ok()) {
         LOG_ERROR("force_reset_device: ACL init failed; cannot reset device %d", device_id_);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
         // Reset phase. Bind the device, best-effort drain (the op-timeout
@@ -766,7 +767,7 @@ int DeviceRunner::force_reset_device() {
         DeviceBindGuard bind_guard(device_id_);
         if (!bind_guard.bound()) {
             LOG_ERROR("force_reset_device: could not bind device %d; reset skipped", device_id_);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         (void)aclrtSynchronizeDeviceWithTimeout(timeout_config_.stream_sync_timeout_ms);
         aclError rc = aclrtResetDeviceForce(device_id_);
@@ -787,7 +788,7 @@ int DeviceRunner::force_reset_device() {
     DeviceBindGuard probe_bind(device_id_);
     if (!probe_bind.bound()) {
         LOG_ERROR("force_reset_device: post-reset DeviceBindGuard failed for device %d", device_id_);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     aclrtStream probe_stream = nullptr;
     aclError stream_rc = aclrtCreateStream(&probe_stream);

--- a/src/a5/platform/onboard/host/host_regs.cpp
+++ b/src/a5/platform/onboard/host/host_regs.cpp
@@ -18,6 +18,7 @@
 #include "common/unified_log.h"
 #include "common/platform_config.h"
 #include "common/acl_hal_device.h"
+#include "pto_runtime_c_api.h"
 #include "runtime/rt.h"
 #include "ascend_hal.h"  // CANN HAL API definitions
 #include <dlfcn.h>
@@ -37,7 +38,7 @@ static int get_aicore_reg_info(std::vector<int64_t> &regs, int64_t device_id) {
 
     if (halFunc == nullptr) {
         LOG_ERROR("halResMap not found in symbol table");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     const int64_t phys_device_id = pto::acl_to_hal_device_id(device_id);
@@ -106,7 +107,7 @@ static int get_aicore_regs(std::vector<int64_t> &regs, uint64_t device_id) {
 int init_aicore_register_addresses(uint64_t *runtime_regs_ptr, uint64_t device_id, MemoryAllocator &allocator) {
     if (runtime_regs_ptr == nullptr) {
         LOG_ERROR("init_aicore_register_addresses: Invalid parameters");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Step 1: Get register addresses from HAL
@@ -122,7 +123,7 @@ int init_aicore_register_addresses(uint64_t *runtime_regs_ptr, uint64_t device_i
     void *reg_ptr = allocator.alloc(regs_size);
     if (reg_ptr == nullptr) {
         LOG_ERROR("Failed to allocate device memory for register addresses");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Step 3: Copy register addresses to device memory
@@ -130,7 +131,7 @@ int init_aicore_register_addresses(uint64_t *runtime_regs_ptr, uint64_t device_i
     if (ret != 0) {
         LOG_ERROR("Failed to copy register addresses to device (rc=%d)", ret);
         allocator.free(reg_ptr);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Step 4: Store device pointer in output regs field

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -33,11 +33,11 @@ DeviceContextHandle create_device_context(void) {
 }
 
 int ensure_acl_ready_ctx(DeviceContextHandle ctx, int device_id) {
-    if (ctx == NULL) return -1;
+    if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<DeviceRunner *>(ctx)->ensure_acl_ready(device_id);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
@@ -57,11 +57,11 @@ void *create_comm_stream_ctx(DeviceContextHandle ctx) {
 }
 
 int destroy_comm_stream_ctx(DeviceContextHandle ctx, void *stream) {
-    if (ctx == NULL) return -1;
+    if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<DeviceRunner *>(ctx)->destroy_comm_stream(stream);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 

--- a/src/a5/platform/shared/host/pmu_collector.cpp
+++ b/src/a5/platform/shared/host/pmu_collector.cpp
@@ -37,6 +37,7 @@
 #include "common/memory_barrier.h"
 #include "common/unified_log.h"
 #include "host/profiling_copy.h"
+#include "../../../../common/worker/pto_runtime_c_api.h"
 
 namespace {
 
@@ -79,18 +80,18 @@ int PmuCollector::init(
 ) {
     if (num_cores <= 0 || num_threads <= 0 || alloc_cb == nullptr || free_cb == nullptr) {
         LOG_ERROR("PmuCollector::init: invalid arguments");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (num_cores > PLATFORM_MAX_CORES || num_threads > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR(
             "PmuCollector::init: dimensions out of range (cores=%d/%d threads=%d/%d)", num_cores, PLATFORM_MAX_CORES,
             num_threads, PLATFORM_MAX_AICPU_THREADS
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (initialized_) {
         LOG_ERROR("PmuCollector already initialized");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Must precede the recycled-lane seeding below: push_recycled() folds its
@@ -112,7 +113,7 @@ int PmuCollector::init(
     if (!recycled_seed_capacity_is_sufficient(
             num_cores, num_threads, kPmuSurplusPerCore, decltype(manager_)::kRecycledQueueCapacity
         )) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Stash callbacks on the base up-front so alloc_paired_buffer sees
@@ -137,7 +138,7 @@ int PmuCollector::init(
     void *shm_dev_local = alloc_paired_buffer(shm_size, &shm_host_local);
     if (shm_dev_local == nullptr) {
         LOG_ERROR("PmuCollector: failed to allocate PMU shared memory (%zu bytes)", shm_size);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     std::memset(shm_host_local, 0, shm_size);
@@ -160,7 +161,7 @@ int PmuCollector::init(
     void *ring_addrs_dev_local = alloc_paired_buffer(table_size, &ring_addrs_host_local);
     if (ring_addrs_dev_local == nullptr) {
         LOG_ERROR("PmuCollector: failed to allocate aicore ring address table (%zu bytes)", table_size);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     std::memset(ring_addrs_host_local, 0, table_size);
 
@@ -174,7 +175,7 @@ int PmuCollector::init(
         void *ring_dev = alloc_cb(sizeof(PmuAicoreRing));
         if (ring_dev == nullptr) {
             LOG_ERROR("PmuCollector: failed to allocate PmuAicoreRing for core %d", c);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         aicore_rings_dev_local[c] = ring_dev;
         guard.add_direct_ptr(ring_dev);
@@ -186,7 +187,7 @@ int PmuCollector::init(
             void *dev_ptr = alloc_paired_buffer(buf_size, &host_ptr);
             if (dev_ptr == nullptr) {
                 LOG_ERROR("PmuCollector: failed to allocate PmuBuffer c=%d b=%d", c, b);
-                return -1;
+                return PTO_RUNTIME_ERR_INTERNAL;
             }
 
             if (b < PLATFORM_PMU_SLOT_COUNT) {

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -117,13 +117,13 @@ int DeviceRunner::ensure_binaries_loaded() {
                 "/tmp/aicpu_sim_XXXXXX", aicpu_so_binary_.data(), aicpu_so_binary_.size(), &aicpu_so_path_
             )) {
             LOG_ERROR("Failed to create temp file for AICPU SO");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         aicpu_so_handle_ = dlopen(aicpu_so_path_.c_str(), RTLD_NOW | RTLD_LOCAL);
         if (aicpu_so_handle_ == nullptr) {
             LOG_ERROR("dlopen failed for AICPU SO: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         auto load_sym = [this](const char *name, void **out) -> bool {
@@ -141,9 +141,11 @@ int DeviceRunner::ensure_binaries_loaded() {
             *out = sym;
         };
 
-        if (!load_sym("aicpu_execute", reinterpret_cast<void **>(&aicpu_execute_func_))) return -1;
+        if (!load_sym("aicpu_execute", reinterpret_cast<void **>(&aicpu_execute_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
         load_optional_sym("simpler_aicpu_register_callable", reinterpret_cast<void **>(&aicpu_register_callable_func_));
-        if (!load_sym("set_platform_regs", reinterpret_cast<void **>(&set_platform_regs_func_))) return -1;
+        if (!load_sym("set_platform_regs", reinterpret_cast<void **>(&set_platform_regs_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
         load_optional_sym("set_orch_device_id", reinterpret_cast<void **>(&set_orch_device_id_func_));
         load_optional_sym("set_scheduler_timeout_ms", reinterpret_cast<void **>(&set_scheduler_timeout_ms_func_));
         if (set_scheduler_timeout_ms_func_ != nullptr) {
@@ -158,38 +160,46 @@ int DeviceRunner::ensure_binaries_loaded() {
                 (sched_status.scheduler_env_set && sched_status.scheduler_valid) ? sched_cfg.scheduler_timeout_ms : 0
             );
         }
-        if (!load_sym("set_platform_dump_base", reinterpret_cast<void **>(&set_platform_dump_base_func_))) return -1;
-        if (!load_sym("set_platform_phase_base", reinterpret_cast<void **>(&set_platform_phase_base_func_))) return -1;
-        if (!load_sym("set_dump_args_enabled", reinterpret_cast<void **>(&set_dump_args_enabled_func_))) return -1;
+        if (!load_sym("set_platform_dump_base", reinterpret_cast<void **>(&set_platform_dump_base_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
+        if (!load_sym("set_platform_phase_base", reinterpret_cast<void **>(&set_platform_phase_base_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
+        if (!load_sym("set_dump_args_enabled", reinterpret_cast<void **>(&set_dump_args_enabled_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
         if (!load_sym(
                 "set_platform_chip_swimlane_base", reinterpret_cast<void **>(&set_platform_chip_swimlane_base_func_)
             ))
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         if (!load_sym(
                 "set_platform_chip_swimlane_aicore_rotation_table",
                 reinterpret_cast<void **>(&set_platform_chip_swimlane_aicore_rotation_table_func_)
             ))
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         if (!load_sym("set_chip_swimlane_enabled", reinterpret_cast<void **>(&set_chip_swimlane_enabled_func_)))
-            return -1;
-        if (!load_sym("set_platform_pmu_base", reinterpret_cast<void **>(&set_platform_pmu_base_func_))) return -1;
-        if (!load_sym("set_pmu_enabled", reinterpret_cast<void **>(&set_pmu_enabled_func_))) return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
+        if (!load_sym("set_platform_pmu_base", reinterpret_cast<void **>(&set_platform_pmu_base_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
+        if (!load_sym("set_pmu_enabled", reinterpret_cast<void **>(&set_pmu_enabled_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
         if (!load_sym("set_platform_dep_gen_base", reinterpret_cast<void **>(&set_platform_dep_gen_base_func_)))
-            return -1;
-        if (!load_sym("set_dep_gen_enabled", reinterpret_cast<void **>(&set_dep_gen_enabled_func_))) return -1;
-        if (!load_sym("set_scope_stats_enabled", reinterpret_cast<void **>(&set_scope_stats_enabled_func_))) return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
+        if (!load_sym("set_dep_gen_enabled", reinterpret_cast<void **>(&set_dep_gen_enabled_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
+        if (!load_sym("set_scope_stats_enabled", reinterpret_cast<void **>(&set_scope_stats_enabled_func_)))
+            return PTO_RUNTIME_ERR_INTERNAL;
         if (!load_sym("set_platform_scope_stats_base", reinterpret_cast<void **>(&set_platform_scope_stats_base_func_)))
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
 
         // The AICPU sim SO owns its level flags because it is RTLD_LOCAL.
         // Forward the process-wide HostLogger threshold explicitly.
         using SetLogLevelFunc = void (*)(int);
         SetLogLevelFunc set_log_level_func = nullptr;
-        if (!load_sym("set_log_level", reinterpret_cast<void **>(&set_log_level_func))) return -1;
+        if (!load_sym("set_log_level", reinterpret_cast<void **>(&set_log_level_func))) return PTO_RUNTIME_ERR_INTERNAL;
         set_log_level_func(HostLogger::get_instance().level());
         using SetHostLogStateFunc = void (*)(SimplerHostLogState *);
         SetHostLogStateFunc set_host_log_state_func = nullptr;
-        if (!load_sym("set_host_log_state", reinterpret_cast<void **>(&set_host_log_state_func))) return -1;
+        if (!load_sym("set_host_log_state", reinterpret_cast<void **>(&set_host_log_state_func)))
+            return PTO_RUNTIME_ERR_INTERNAL;
         set_host_log_state_func(HostLogger::get_instance().state());
 
         aicpu_so_loaded_ = true;
@@ -212,13 +222,13 @@ int DeviceRunner::ensure_binaries_loaded() {
                 "/tmp/aicore_sim_XXXXXX", aicore_kernel_binary_.data(), aicore_kernel_binary_.size(), &aicore_so_path_
             )) {
             LOG_ERROR("Failed to create temp file for AICore SO");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         aicore_so_handle_ = dlopen(aicore_so_path_.c_str(), RTLD_NOW | RTLD_LOCAL);
         if (aicore_so_handle_ == nullptr) {
             LOG_ERROR("dlopen failed for AICore SO: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         const char *bind_log_error = nullptr;
@@ -231,7 +241,7 @@ int DeviceRunner::ensure_binaries_loaded() {
             );
             dlclose(aicore_so_handle_);
             aicore_so_handle_ = nullptr;
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         aicore_execute_func_ =
@@ -240,7 +250,7 @@ int DeviceRunner::ensure_binaries_loaded() {
             );
         if (aicore_execute_func_ == nullptr) {
             LOG_ERROR("dlsym failed for aicore_execute_wrapper: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         LOG_INFO("DeviceRunner(sim): Loaded aicore_execute_wrapper from %s", aicore_so_path_.c_str());
 
@@ -260,7 +270,7 @@ int DeviceRunner::ensure_binaries_loaded() {
 int DeviceRunner::invoke_device_register(const RegisterCallableArgs &reg_args) {
     if (aicpu_register_callable_func_ == nullptr || set_orch_device_id_func_ == nullptr) {
         LOG_ERROR("Register-callable functions not loaded. Call ensure_binaries_loaded first.");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     set_orch_device_id_func_(device_id_);
     // The descriptor was assembled from CallableState by the base
@@ -274,10 +284,10 @@ int DeviceRunner::prepare_execution(
     Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot, const NativeRunIdentity &identity,
     std::unique_ptr<PreparedExecution> *prepared
 ) {
-    if (prepared == nullptr || *prepared != nullptr) return -1;
+    if (prepared == nullptr || *prepared != nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     if (active_run_ != nullptr) {
         LOG_ERROR("prepare_execution called while another simulated run still owns execution state");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
     active_run_ = std::make_unique<ActiveRun>();
@@ -299,7 +309,7 @@ int DeviceRunner::prepare_execution(
     runtime.set_aicpu_thread_num(launch_aicpu_num);
     if (block_dim < 1) {
         LOG_ERROR("prepare_execution computed block_dim < 1 from worker_count=%d", runtime.get_worker_count());
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     int rc = ensure_device_initialized();
@@ -409,7 +419,7 @@ int DeviceRunner::prepare_execution(
     active_run_->reg_blocks = mem_alloc_.alloc(total_reg_size);
     if (active_run_->reg_blocks == nullptr) {
         LOG_ERROR("Failed to allocate simulated register memory (%zu bytes)", total_reg_size);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     std::memset(active_run_->reg_blocks, 0, total_reg_size);
 
@@ -417,7 +427,7 @@ int DeviceRunner::prepare_execution(
     uint64_t *regs_array = reinterpret_cast<uint64_t *>(mem_alloc_.alloc(regs_array_size));
     if (regs_array == nullptr) {
         LOG_ERROR("Failed to allocate register address array");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     for (int i = 0; i < num_aicore; i++) {
         regs_array[i] =
@@ -434,7 +444,7 @@ int DeviceRunner::prepare_execution(
         set_platform_chip_swimlane_aicore_rotation_table_func_ == nullptr ||
         set_chip_swimlane_enabled_func_ == nullptr) {
         LOG_ERROR("Executor functions not loaded. Call ensure_binaries_loaded first.");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
@@ -465,7 +475,7 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
 
     LaunchTransactionResult result = exact_launch_transaction(
         prepared->identity, std::move(permit),
-        [&]() {
+        [&]() -> int {
             // Arming precedes any simulated-core thread, so its failures — including
             // a thread-spawn or allocation throw — are reported as an rc and leave
             // the run safely rollback-able.
@@ -504,7 +514,7 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
                 run_completion_.reset(static_cast<size_t>(over_launch) + static_cast<size_t>(num_aicore));
             } catch (...) {
                 LOG_ERROR("launch_execution: arming failed before any simulated core started");
-                return -1;
+                return PTO_RUNTIME_ERR_INTERNAL;
             }
 
             LOG_INFO("Launching %d AICore thread(s)", num_aicore);
@@ -522,7 +532,7 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
             }
             return 0;
         },
-        [&]() {
+        [&]() -> int {
             LOG_INFO("Launching %d AICPU threads (logical=%d)", over_launch, launch_aicpu_num);
             for (int i = 0; i < over_launch; i++) {
                 run->aicpu_threads.push_back(create_thread([this, run, launch_aicpu_num, over_launch, sim_t0]() {
@@ -560,7 +570,7 @@ int DeviceRunner::poll_execution(const ActiveExecution &) { return run_completio
 int DeviceRunner::drain_execution(ActiveExecution &) {
     if (active_run_ == nullptr) {
         LOG_ERROR("drain_execution called without a launched simulated run");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     auto run_cleanup = RAIIScopeGuard([this]() {
         cleanup_active_run();

--- a/src/a5/runtime/host_build_graph/common/pto_runtime_status.h
+++ b/src/a5/runtime/host_build_graph/common/pto_runtime_status.h
@@ -12,12 +12,18 @@
 /**
  * PTO2 Runtime Status Helpers
  *
- * Shared error-code contract used inside the tensormap_and_ringbuffer runtime.
+ * Shared error-code contract used inside the host_build_graph runtime.
  */
 
 #pragma once
 
 #include <stdint.h>
+
+// A latched code reaches the host as its own value negated, so the two families
+// below land in -1..-99 and -100..-PTO_RUNTIME_LATCHED_CODE_MAX there. That
+// ceiling lives in src/common/worker/pto_runtime_c_api.h, and the host-side C
+// API band begins below its negation — so the latched range is bounded, not
+// open-ended downwards.
 
 // Orchestrator errors (1-99): detected in orchestrator thread
 #define PTO2_ERROR_NONE 0  // Explicitly means "no error"; it is not an "unknown/unspecified" error code.

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -76,6 +76,18 @@
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
+// This file returns both kinds of negative status — a latched device code
+// negated, and PTO_RUNTIME_ERR_* for a host-side failure — so a caller can
+// attribute one to a mechanism only while the two bands stay disjoint. The
+// second conjunct is the structural half and holds for any latched code; the
+// first is a spot check on the highest one this runtime defines, so a new
+// four-digit latched code needs the ceiling raised here as well.
+static_assert(
+    PTO2_ERROR_READY_QUEUE_OVERFLOW <= PTO_RUNTIME_LATCHED_CODE_MAX &&
+        PTO_RUNTIME_ERR_BASE < -PTO_RUNTIME_LATCHED_CODE_MAX,
+    "host-side C API codes must stay below the negation of every latched device code"
+);
+
 extern "C" const PipelineContract *get_pipeline_contract(void) {
     // Host orchestration materializes this run's own graph into the image it
     // uploads, so every device-resident region carries per-run content.
@@ -564,7 +576,7 @@ int32_t run_host_orchestration(
             layout.orch, host_arena, host_sm, gm_heap, eff_heap_sizes[0], eff_task_window_sizes[0]
         )) {
         LOG_ERROR("host-orch: orchestrator re-init against host SM failed");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     rt->orchestrator.wire_arena_pointers(layout.orch, host_arena, rt->scheduler);
 
@@ -572,13 +584,13 @@ int32_t run_host_orchestration(
     PTO2SharedMemoryHandle host_sm_handle;
     if (!host_sm_handle.init_per_ring(host_sm, sm_size, eff_task_window_sizes, eff_heap_sizes)) {
         LOG_ERROR("host-orch: host SM init_per_ring failed");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     GraphHostStatePtr graph_state = make_graph_host_state();
     if (!graph_state) {
         LOG_ERROR("host-orch: failed to allocate Graph host state");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     GraphHostStateBinding graph_binding(rt->orchestrator, graph_state.get());
 
@@ -589,7 +601,7 @@ int32_t run_host_orchestration(
     const int32_t block_dim = runtime->get_worker_count() / PLATFORM_CORES_PER_BLOCKDIM;
     if (block_dim < 1) {
         LOG_ERROR("host-orch: worker_count %d yields no clusters", runtime->get_worker_count());
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     runtime_finalize_after_wire(
         rt, block_dim * PLATFORM_AIC_CORES_PER_BLOCKDIM, block_dim * PLATFORM_AIV_CORES_PER_BLOCKDIM
@@ -604,7 +616,7 @@ int32_t run_host_orchestration(
     const auto *entry_points = reinterpret_cast<const HostOrchEntryPoints *>(host_orch_func_ptr);
     if (entry_points->bind == nullptr) {
         LOG_ERROR("host-orch: orch .so framework_bind_runtime was not resolved");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     rt->active_callable_hash = reinterpret_cast<uint64_t>(entry_points->entry);
     rt->tensor_access = &tensor_access;
@@ -650,8 +662,9 @@ int32_t run_host_orchestration(
         // The latched code is the diagnosis, so it is what the caller sees — through the
         // same mapping the run path uses, since a caller cannot tell which of the two
         // noticed. A fatal with no code left to read is the only generic failure.
-        const int32_t status =
-            orch_error != PTO2_ERROR_NONE ? runtime_status_from_error_codes(orch_error, PTO2_ERROR_NONE) : -1;
+        const int32_t status = orch_error != PTO2_ERROR_NONE ?
+                                   runtime_status_from_error_codes(orch_error, PTO2_ERROR_NONE) :
+                                   PTO_RUNTIME_ERR_INTERNAL;
         LOG_RUNTIME_FAILURE(orch_error, PTO2_ERROR_NONE, status);
         LOG_ERROR(
             "host-orch: refusing to upload an incomplete graph after %" PRIu64 " heap bytes",
@@ -680,7 +693,7 @@ int32_t run_host_orchestration(
     std::vector<StagedSubmission> staged_submissions;
     uint64_t submission_block_bytes = 0;
     if (!plan_graph_submissions(api, *graph_state, &staged_submissions, &submission_block_bytes, &definition_uploads)) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
         // `bytes` is what this segment copied: the Definition objects alone. The
@@ -699,7 +712,7 @@ int32_t run_host_orchestration(
     // [0, task_window] would make those copies read/write out of bounds.
     if (total_tasks < 0 || static_cast<uint64_t>(total_tasks) > eff_task_window_sizes[0]) {
         LOG_ERROR("host-orch: total_tasks %d out of range [0, %" PRIu64 "]", total_tasks, eff_task_window_sizes[0]);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     host_phase_trace_note_submitted(static_cast<uint64_t>(total_tasks));
 
@@ -744,12 +757,12 @@ int32_t run_host_orchestration(
     const uint64_t device_arena_bytes = off_submissions + submission_block_bytes;
     if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, device_arena_bytes) != 0) {
         LOG_ERROR("host-orch: failed to commit %" PRIu64 " bytes of device runtime arena", device_arena_bytes);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     device_arena = api->acquire_pooled_runtime_arena();
     if (device_arena == nullptr) {
         LOG_ERROR("%s", "host-orch: failed to re-acquire the pooled runtime arena");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     char *arena_dev = static_cast<char *>(device_arena);
     void *device_sm = arena_dev + layout.off_copied_end;
@@ -790,7 +803,7 @@ int32_t run_host_orchestration(
     const int64_t t_h2d_ns = bind_now_ns();
     if (api->copy_to_device(arena_dev + layout.off_copied_begin, upload_base, upload_bytes) != 0) {
         LOG_ERROR("host-orch: H2D of the runtime image failed");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
         // Eight uint64 fields plus their labels; 96 would truncate the trailing
@@ -823,11 +836,11 @@ int32_t run_host_orchestration(
 extern "C" int register_callable_impl(const ChipCallable *callable, const HostApi *api, CallableArtifacts *out) {
     if (callable == nullptr) {
         LOG_ERROR("Callable pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (api == nullptr || out == nullptr) {
         LOG_ERROR("HostApi or out is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     *out = CallableArtifacts{};
     out->signature.assign(callable->signature_, callable->signature_ + callable->sig_count());
@@ -837,12 +850,12 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
             callable, api, &out->kernel_addrs, &out->chip_buffer_dev, &out->chip_buffer_hash, &out->aicore_image_hash
         ) != 0) {
         LOG_ERROR("Failed to upload ChipCallable buffer");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     for (const ChildKernelAddr &c : out->kernel_addrs) {
         if (c.func_id < 0 || c.func_id >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("func_id=%d is out of range [0, %d)", c.func_id, RUNTIME_MAX_FUNC_ID);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
     }
 
@@ -851,7 +864,7 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
 
     if (orch_so_binary == nullptr || orch_so_size == 0) {
         LOG_ERROR("Orchestration SO binary is required for host orchestration");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     out->orch_so_data = orch_so_binary;
@@ -869,17 +882,17 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
         const char *orch_func_name = callable->func_name();
         if (orch_func_name == nullptr || orch_func_name[0] == '\0') {
             LOG_ERROR("host-orch: orchestration function name is empty");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         std::string so_path;
         if (!create_orch_so_tempfile(orch_so_binary, orch_so_size, &so_path)) {
             LOG_ERROR("host-orch: failed to materialize orchestration .so");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         void *handle = dlopen(so_path.c_str(), RTLD_NOW | RTLD_LOCAL);
         if (handle == nullptr) {
             LOG_ERROR("host-orch: dlopen failed: %s", dlerror());
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         const char *bind_log_error = nullptr;
         if (simpler::log::bind_loaded_host_log_state(handle, HostLogger::get_instance().state(), &bind_log_error) !=
@@ -889,13 +902,13 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
                 bind_log_error != nullptr ? bind_log_error : "unknown error"
             );
             dlclose(handle);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         void *entry = dlsym(handle, orch_func_name);
         if (entry == nullptr) {
             LOG_ERROR("host-orch: dlsym('%s') failed: %s", orch_func_name, dlerror());
             dlclose(handle);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         // The orch .so has its own framework_bind_runtime / g_current_runtime
         // (orchestration/common.cpp is compiled into it); resolve it now so the
@@ -904,13 +917,13 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
         if (bind_sym == nullptr) {
             LOG_ERROR("host-orch: orch .so does not export framework_bind_runtime: %s", dlerror());
             dlclose(handle);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         void *prewarm_sym = dlsym(handle, "framework_prewarm_graph_recorders");
         if (prewarm_sym == nullptr) {
             LOG_ERROR("host-orch: orch .so does not export framework_prewarm_graph_recorders: %s", dlerror());
             dlclose(handle);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         reinterpret_cast<OrchestrationPrewarmFunc>(prewarm_sym)();
         // Safe to unlink now: the handle keeps the .so mapped regardless of path.
@@ -948,15 +961,15 @@ extern "C" int bind_callable_to_runtime_impl(
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (api == nullptr) {
         LOG_ERROR("HostApi pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (orch_args == nullptr) {
         LOG_ERROR("orch_args pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     // host_build_graph host-orch: register_callable_impl resolved the
     // orchestration entry on the host and passed it here as host_orch_func_ptr;
@@ -978,7 +991,7 @@ extern "C" int bind_callable_to_runtime_impl(
     uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH];
     uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH];
     if (!resolve_ring_config(ring_task_window, ring_heap, eff_task_window_sizes, eff_heap_sizes)) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     const std::string task_window_log = format_ring_array(eff_task_window_sizes);
     const std::string heap_log = format_ring_array(eff_heap_sizes);
@@ -1010,7 +1023,7 @@ extern "C" int bind_callable_to_runtime_impl(
         void *dev_ptr = api->device_malloc(size);
         if (dev_ptr == nullptr) {
             LOG_ERROR("Failed to allocate device memory for tensor %d", i);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         // Pure write-only OUTPUT buffers are never read by the kernel and hold
@@ -1023,7 +1036,7 @@ extern "C" int bind_callable_to_runtime_impl(
             if (rc != 0) {
                 LOG_ERROR("Failed to stage tensor %d to device", i);
                 api->device_free(dev_ptr);
-                return -1;
+                return PTO_RUNTIME_ERR_INTERNAL;
             }
             staged_bytes += static_cast<uint64_t>(size);
             ++staged_tensors;
@@ -1050,7 +1063,7 @@ extern "C" int bind_callable_to_runtime_impl(
         // device address.
         if (!tensor_access.add(reinterpret_cast<uint64_t>(dev_ptr), size, host_ptr)) {
             LOG_ERROR("host-orch: no host view for tensor %d (dev_ptr %p, %zu bytes)", i, dev_ptr, size);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         t.buffer.addr = reinterpret_cast<uint64_t>(dev_ptr);
@@ -1077,7 +1090,7 @@ extern "C" int bind_callable_to_runtime_impl(
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         if (eff_heap_sizes[r] > std::numeric_limits<uint64_t>::max() - total_heap_size) {
             LOG_ERROR("Total ring heap size overflows uint64_t");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         total_heap_size += eff_heap_sizes[r];
     }
@@ -1088,7 +1101,7 @@ extern "C" int bind_callable_to_runtime_impl(
     PTO2RuntimeArenaLayout layout = runtime_reserve_layout(host_arena, eff_task_window_sizes, eff_heap_sizes);
     if (host_arena.commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
         LOG_ERROR("Failed to commit host arena for prebuilt runtime image");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
         char attrs[64];
@@ -1114,7 +1127,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // places tasks.
     if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, layout.device_bytes) != 0) {
         LOG_ERROR("Failed to setup pooled static arena");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
         char attrs[96];
@@ -1127,7 +1140,7 @@ extern "C" int bind_callable_to_runtime_impl(
     record_bind_phase(HostPhaseKind::BindGmHeap, t_heap_ns);
     if (gm_heap == nullptr) {
         LOG_ERROR("Failed to acquire pooled GM heap");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     runtime->set_gm_heap(gm_heap);
     // The shared memory is placed at the end of orchestration, so until then this
@@ -1138,7 +1151,7 @@ extern "C" int bind_callable_to_runtime_impl(
     void *runtime_arena_dev = api->acquire_pooled_runtime_arena();
     if (runtime_arena_dev == nullptr) {
         LOG_ERROR("Failed to acquire pooled runtime arena");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Set up orchestration state (consumed by the host orchestrator below)
@@ -1162,7 +1175,7 @@ extern "C" int bind_callable_to_runtime_impl(
     );
     if (rt == nullptr) {
         LOG_ERROR("runtime_init_data_from_layout failed");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     runtime_wire_arena_pointers(host_arena, layout, rt);
     runtime_wire_host_only_pointers(host_arena, layout, rt);
@@ -1183,7 +1196,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // otherwise), so this is an assertion-style guard, not a fallback path.
     if (host_orch_func_ptr == nullptr) {
         LOG_ERROR("host-orch: orchestration entry points were not resolved");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
         ChipTaskArgs orch_l2;
@@ -1217,7 +1230,7 @@ extern "C" int bind_callable_to_runtime_impl(
     runtime_arena_dev = api->acquire_pooled_runtime_arena();
     if (runtime_arena_dev == nullptr) {
         LOG_ERROR("%s", "Failed to re-acquire the pooled runtime arena after orchestration");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     runtime->set_prebuilt_arena(runtime_arena_dev, layout.off_runtime);
 
@@ -1242,11 +1255,11 @@ extern "C" int bind_callable_to_runtime_impl(
 extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (api == nullptr) {
         LOG_ERROR("HostApi pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     int rc = 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h
@@ -15,10 +15,15 @@
  * Shared error-code contract used inside the tensormap_and_ringbuffer runtime.
  */
 
-#ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_COMMON_PTO_RUNTIME_STATUS_H_
-#define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_COMMON_PTO_RUNTIME_STATUS_H_
+#pragma once
 
 #include <stdint.h>
+
+// A latched code reaches the host as its own value negated, so the two families
+// below land in -1..-99 and -100..-PTO_RUNTIME_LATCHED_CODE_MAX there. That
+// ceiling lives in src/common/worker/pto_runtime_c_api.h, and the host-side C
+// API band begins below its negation — so the latched range is bounded, not
+// open-ended downwards.
 
 // Orchestrator errors (1-99): detected in orchestrator thread
 #define PTO2_ERROR_NONE 0  // Explicitly means "no error"; it is not an "unknown/unspecified" error code.
@@ -92,5 +97,3 @@ static inline int32_t runtime_status_from_error_codes(int32_t orch_error_code, i
     }
     return 0;
 }
-
-#endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_COMMON_PTO_RUNTIME_STATUS_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -62,6 +62,18 @@ static_assert(
     RUNTIME_ENV_RING_COUNT == PTO2_MAX_RING_DEPTH, "RuntimeEnv ring count must match PTO2 runtime ring depth"
 );
 
+// This file returns both kinds of negative status — a latched device code
+// negated, and PTO_RUNTIME_ERR_* for a host-side failure — so a caller can
+// attribute one to a mechanism only while the two bands stay disjoint. The
+// second conjunct is the structural half and holds for any latched code; the
+// first is a spot check on the highest one this runtime defines, so a new
+// four-digit latched code needs the ceiling raised here as well.
+static_assert(
+    PTO2_ERROR_ASYNC_REGISTRATION_FAILED <= PTO_RUNTIME_LATCHED_CODE_MAX &&
+        PTO_RUNTIME_ERR_BASE < -PTO_RUNTIME_LATCHED_CODE_MAX,
+    "host-side C API codes must stay below the negation of every latched device code"
+);
+
 extern "C" const PipelineContract *get_pipeline_contract(void) {
     // Orchestration runs on the device, so this run's own content is confined to
     // its task args. The three pooled regions are built and uploaded once per
@@ -405,11 +417,11 @@ private:
 extern "C" int register_callable_impl(const ChipCallable *callable, const HostApi *api, CallableArtifacts *out) {
     if (callable == nullptr) {
         LOG_ERROR("Callable pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (api == nullptr || out == nullptr) {
         LOG_ERROR("HostApi or out is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     *out = CallableArtifacts{};
     out->signature.assign(callable->signature_, callable->signature_ + callable->sig_count());
@@ -419,12 +431,12 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
             callable, api, &out->kernel_addrs, &out->chip_buffer_dev, &out->chip_buffer_hash, &out->aicore_image_hash
         ) != 0) {
         LOG_ERROR("Failed to upload ChipCallable buffer");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     for (const ChildKernelAddr &c : out->kernel_addrs) {
         if (c.func_id < 0 || c.func_id >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("func_id=%d is out of range [0, %d)", c.func_id, RUNTIME_MAX_FUNC_ID);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
     }
 
@@ -433,7 +445,7 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
 
     if (orch_so_binary == nullptr || orch_so_size == 0) {
         LOG_ERROR("Orchestration SO binary is required for device orchestration");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     out->orch_so_data = orch_so_binary;
@@ -508,10 +520,10 @@ static bool resolve_arena_sizing(
 extern "C" int prepared_run_config_compatible_impl(
     const HostApi *api, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
 ) {
-    if (api == nullptr) return -1;
+    if (api == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
 
     ArenaSizingConfig sizing;
-    if (!resolve_arena_sizing(ring_task_window, ring_heap, ring_dep_pool, &sizing)) return -1;
+    if (!resolve_arena_sizing(ring_task_window, ring_heap, ring_dep_pool, &sizing)) return PTO_RUNTIME_ERR_INTERNAL;
 
     PrebuiltRuntimeArenaCacheProbe probe = make_prebuilt_runtime_arena_cache_probe(sizing);
     void *gm_heap = nullptr;
@@ -858,22 +870,22 @@ extern "C" int bind_callable_to_runtime_impl(
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (api == nullptr) {
         LOG_ERROR("HostApi pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (orch_args == nullptr) {
         LOG_ERROR("orch_args pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     // trb runs orchestration on the device — there is no host-side orch
     // function pointer to invoke. The c_api signature accepts one for
     // symmetry with hbg; assert the trb-side invariant here.
     if (host_orch_func_ptr != nullptr) {
         LOG_ERROR("bind_callable_to_runtime_impl: trb does not accept a host_orch_func_ptr");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     int tensor_count = orch_args->tensor_count();
@@ -885,7 +897,7 @@ extern "C" int bind_callable_to_runtime_impl(
 
     ArenaSizingConfig sizing;
     if (!resolve_arena_sizing(ring_task_window, ring_heap, ring_dep_pool, &sizing)) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // The retained temporary buffer is always used on the trb path — it is an
@@ -895,7 +907,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // bump-slice from it.
     RetainedTempBump bump;
     if (!bump.begin(api, orch_args)) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     auto bind_cleanup = RAIIScopeGuard([&]() {
@@ -904,7 +916,7 @@ extern "C" int bind_callable_to_runtime_impl(
 
     ChipStorageTaskArgs device_args;
     if (!stage_device_args(runtime, api, orch_args, signature, sig_count, &bump, &device_args)) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     apply_orch_sched_env_flags(runtime);
@@ -915,7 +927,7 @@ extern "C" int bind_callable_to_runtime_impl(
         PrebuiltRuntimeArenaCacheProbe cache_probe = make_prebuilt_runtime_arena_cache_probe(sizing);
         int cache_rc = bind_cached_runtime_image(runtime, api, cache_probe, device_args);
         if (cache_rc < 0) {
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         if (cache_rc != 0) {
             // Miss: build + upload the arena image, then wire the runtime
@@ -927,7 +939,7 @@ extern "C" int bind_callable_to_runtime_impl(
             StaticArenaPtrs ptrs;
             PTO2RuntimeArenaLayout layout;
             if (!build_and_cache_prebuilt_arena(api, sizing, &ptrs, &layout)) {
-                return -1;
+                return PTO_RUNTIME_ERR_INTERNAL;
             }
             runtime->set_orch_args(device_args);
             runtime->set_gm_sm_ptr(ptrs.gm_sm);
@@ -960,16 +972,16 @@ extern "C" int prewarm_config_impl(
 ) {
     if (api == nullptr) {
         LOG_ERROR("HostApi pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     ArenaSizingConfig sizing;
     if (!resolve_arena_sizing(ring_task_window, ring_heap, ring_dep_pool, &sizing)) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     STRACE("chip.prewarm.build");
-    return build_and_cache_prebuilt_arena(api, sizing) ? 0 : -1;
+    return build_and_cache_prebuilt_arena(api, sizing) ? 0 : PTO_RUNTIME_ERR_INTERNAL;
 }
 
 /**
@@ -988,11 +1000,11 @@ extern "C" int prewarm_config_impl(
 extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int execution_rc) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (api == nullptr) {
         LOG_ERROR("HostApi pointer is null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     int rc = 0;

--- a/src/common/aicpu_loader/host/load_aicpu_op.cpp
+++ b/src/common/aicpu_loader/host/load_aicpu_op.cpp
@@ -30,6 +30,7 @@
 #include "common/unified_log.h"
 #include "runtime/rt.h"
 #include "utils/elf_build_id.h"
+#include "pto_runtime_c_api.h"
 
 namespace host {
 
@@ -94,11 +95,11 @@ int LoadAicpuOp::BootstrapDispatcher(
 ) {
     if (dispatcher_so_data == nullptr || dispatcher_so_len == 0) {
         LOG_ERROR("BootstrapDispatcher: empty dispatcher SO bytes");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (inner_so_data == nullptr || inner_so_len == 0) {
         LOG_ERROR("BootstrapDispatcher: empty inner SO bytes");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     device_id_ = device_id;
     inner_fp_ = FingerprintBytes(inner_so_data, inner_so_len);
@@ -301,7 +302,7 @@ bool LoadAicpuOp::GenerateAicpuOpJson(const std::string &json_path, const std::s
 int LoadAicpuOp::Init(const std::vector<std::string> &extra_symbols) {
     if (inner_fp_ == 0) {
         LOG_ERROR("LoadAicpuOp::Init: BootstrapDispatcher must be called first");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Base entries are exported by every runtime; the runtime reports any extra
@@ -319,7 +320,7 @@ int LoadAicpuOp::Init(const std::vector<std::string> &extra_symbols) {
 
     if (!GenerateAicpuOpJson(json_file_path_, inner_so_basename_)) {
         json_file_path_.clear();
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // RAII cleanups: any non-zero return path below unwinds via these guards.
@@ -395,7 +396,7 @@ int LoadAicpuOp::AicpuKernelLaunch(
 ) {
     if (args == nullptr || args_size == 0) {
         LOG_ERROR("AicpuKernelLaunch: invalid arguments (args is null or args_size is 0)");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     rtCpuKernelArgs_t cpu_args = {};
     cpu_args.baseArgs.args = args;
@@ -420,7 +421,7 @@ int LoadAicpuOp::LaunchBuiltInOp(
     auto it = func_handles_.find(func_name);
     if (it == func_handles_.end()) {
         LOG_ERROR("Function not found: %s", func_name.c_str());
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     return AicpuKernelLaunch(it->second, stream, args, args_size, aicpu_num);
 }

--- a/src/common/platform/include/host/buffer_pool_manager.h
+++ b/src/common/platform/include/host/buffer_pool_manager.h
@@ -91,6 +91,7 @@
 #include <vector>
 
 #include "common/unified_log.h"
+#include "../../../worker/pto_runtime_c_api.h"
 
 namespace profiling_common {
 
@@ -535,7 +536,7 @@ public:
                 static_cast<const void *>(host_field), static_cast<const void *>(host_field + size),
                 static_cast<const void *>(host_base), static_cast<const void *>(host_base + shm_size_)
             );
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         size_t offset = static_cast<size_t>(host_field - host_base);
         void *dev_field = static_cast<char *>(shared_mem_dev_) + offset;
@@ -570,7 +571,7 @@ public:
                 static_cast<const void *>(host_field), static_cast<const void *>(host_field + size),
                 static_cast<const void *>(host_base), static_cast<const void *>(host_base + shm_size_)
             );
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         size_t offset = static_cast<size_t>(host_field - host_base);
         const void *dev_field = static_cast<const char *>(shared_mem_dev_) + offset;

--- a/src/common/platform/include/host/profiler_base.h
+++ b/src/common/platform/include/host/profiler_base.h
@@ -207,6 +207,7 @@
 #include "common/unified_log.h"
 #include "host/buffer_pool_manager.h"
 #include "host/profiling_copy.h"
+#include "../../../worker/pto_runtime_c_api.h"
 
 namespace profiling_common {
 
@@ -257,7 +258,7 @@ using ProfFreeCallback = std::function<int(void *dev_ptr)>;
  *       set_memory_context(...);
  *       InitRollbackGuard<Manager> guard(manager_, free_cb);
  *       void *dev_ptr = alloc_paired_buffer(size, &host_ptr);
- *       if (dev_ptr == nullptr) return -1;       // guard runs, frees nothing yet
+ *       if (dev_ptr == nullptr) return PTO_RUNTIME_ERR_INTERNAL;       // guard runs, frees nothing yet
  *       ...
  *       void *direct = alloc_cb(...);
  *       guard.add_direct_ptr(direct);            // ensure it's freed on abort
@@ -890,12 +891,13 @@ public:
             // Capture `this` so the malloc'd shadow can be registered as
             // framework-owned via the manager.
             auto copy_to_device = copy_to_device_;
-            ops.reg = [this, copy_to_device](void *dev_ptr, size_t size, int /*device_id*/, void **host_ptr_out) {
-                if (host_ptr_out == nullptr) return -1;
+            ops.reg = [this,
+                       copy_to_device](void *dev_ptr, size_t size, int /*device_id*/, void **host_ptr_out) -> int {
+                if (host_ptr_out == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
                 void *host_ptr = std::malloc(size);
                 if (host_ptr == nullptr) {
                     *host_ptr_out = nullptr;
-                    return -1;
+                    return PTO_RUNTIME_ERR_INTERNAL;
                 }
                 std::memset(host_ptr, 0, size);
                 int rc = copy_to_device(dev_ptr, host_ptr, size);

--- a/src/common/platform/include/host/run_stream_pair.h
+++ b/src/common/platform/include/host/run_stream_pair.h
@@ -78,7 +78,7 @@ public:
             // A run that has not retired still owns the pair: a device-complete
             // poll is not a finalized run, and replacing the stream under it
             // would strand a live submission.
-            if (owner_ != nullptr) return -1;
+            if (owner_ != nullptr) return PTO_RUNTIME_ERR_INTERNAL;
             if (!stale_) {
                 submitted_ = false;
                 complete_ = false;
@@ -108,9 +108,9 @@ public:
 
     /** Make the pair visible to non-blocking poll and record its submitter. */
     int mark_submitted(const void *owner) {
-        if (owner == nullptr) return -1;
+        if (owner == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
         std::lock_guard<std::mutex> lock(mutex_);
-        if (aicpu_ == nullptr || aicore_ == nullptr) return -1;
+        if (aicpu_ == nullptr || aicore_ == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
         owner_ = owner;
         submitted_ = true;
         complete_ = false;

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -93,20 +93,20 @@ static void device_free(void *runner_ctx, void *dev_ptr) {
 }
 
 static int copy_to_device(void *runner_ctx, void *dev_ptr, const void *host_ptr, size_t size) {
-    if (runner_ctx == nullptr || dev_ptr == nullptr || host_ptr == nullptr) return -1;
+    if (runner_ctx == nullptr || dev_ptr == nullptr || host_ptr == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<DeviceRunnerBase *>(runner_ctx)->copy_to_device(dev_ptr, host_ptr, size);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
 static int copy_from_device(void *runner_ctx, void *host_ptr, const void *dev_ptr, size_t size) {
-    if (runner_ctx == nullptr || host_ptr == nullptr || dev_ptr == nullptr) return -1;
+    if (runner_ctx == nullptr || host_ptr == nullptr || dev_ptr == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<DeviceRunnerBase *>(runner_ctx)->copy_from_device(host_ptr, dev_ptr, size);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
@@ -127,11 +127,11 @@ static void unregister_device_memory_from_host(void *runner_ctx, void *dev_ptr) 
 }
 
 static int device_memset(void *runner_ctx, void *dev_ptr, int value, size_t size) {
-    if (runner_ctx == nullptr || dev_ptr == nullptr) return -1;
+    if (runner_ctx == nullptr || dev_ptr == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<DeviceRunnerBase *>(runner_ctx)->device_memset(dev_ptr, value, size);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
@@ -196,12 +196,12 @@ static void host_phase_pool_finish(void *runner_ctx, uint64_t submitted_tasks, u
 static int setup_static_arena_wrapper(
     void *runner_ctx, uint32_t arena_bank, size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size
 ) {
-    if (runner_ctx == nullptr) return -1;
+    if (runner_ctx == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<DeviceRunnerBase *>(runner_ctx)
             ->setup_static_arena(arena_bank, gm_heap_size, gm_sm_size, runtime_arena_size);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
@@ -332,34 +332,34 @@ void device_free_ctx(DeviceContextHandle ctx, void *dev_ptr) {
 }
 
 int copy_to_device_ctx(DeviceContextHandle ctx, void *dev_ptr, const void *host_ptr, size_t size) {
-    if (ctx == NULL || dev_ptr == NULL || host_ptr == NULL) return -1;
+    if (ctx == NULL || dev_ptr == NULL || host_ptr == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<DeviceRunnerBase *>(ctx)->copy_to_device(dev_ptr, host_ptr, size);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
 int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *dev_ptr, size_t size) {
-    if (ctx == NULL || host_ptr == NULL || dev_ptr == NULL) return -1;
+    if (ctx == NULL || host_ptr == NULL || dev_ptr == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<DeviceRunnerBase *>(ctx)->copy_from_device(host_ptr, dev_ptr, size);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
 int finalize_device(DeviceContextHandle ctx) {
-    if (ctx == NULL) return -1;
+    if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
         if (runner->native_runs_outstanding()) {
             LOG_ERROR("finalize_device: native run must be finalized first");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         return runner->finalize();
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
@@ -368,7 +368,7 @@ int simpler_init(
     const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
     const CallConfig *prewarm_config
 ) {
-    if (ctx == NULL) return -1;
+    if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
 
     DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
 
@@ -384,7 +384,7 @@ int simpler_init(
     try {
         rc = runner->attach_current_thread(device_id);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (rc != 0) return rc;
 
@@ -406,7 +406,7 @@ int simpler_init(
             runner->set_dispatcher_binary(std::move(dispatcher_vec));
         }
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Eagerly run the one-shot device setup: create persistent AICPU/AICore
@@ -418,7 +418,7 @@ int simpler_init(
     try {
         rc = runner->ensure_device_initialized();
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (rc != 0) return rc;
 
@@ -434,7 +434,7 @@ int simpler_init(
                 prewarm_config->runtime_env.ring_dep_pool
             );
         } catch (...) {
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         if (rc != 0) return rc;
     }
@@ -446,11 +446,11 @@ int simpler_init(
  * =========================================================================== */
 
 int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, const void *callable) {
-    if (ctx == NULL || callable == NULL) return -1;
+    if (ctx == NULL || callable == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
     if (runner->native_runs_outstanding()) {
         LOG_ERROR("simpler_register_callable: native run must be finalized before mutating the callable registry");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     try {
@@ -514,7 +514,7 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
         }
         return 0;
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
@@ -630,18 +630,18 @@ static int cleanup_failed_prepare(OnboardNativeRunContext *state, int execution_
     std::memcpy(trace_attrs, state->trace_attrs, sizeof(trace_attrs));
     if (clear_gm_sm) state->runtime.set_gm_sm_ptr(nullptr);
     state->runner->finish_clock_correlation_session(false, !state->runner->can_accept_run());
-    int validation_rc = -1;
+    int validation_rc = PTO_RUNTIME_ERR_INTERNAL;
     try {
         validation_rc = validate_runtime_impl(&state->runtime, &state->host_api, execution_rc);
     } catch (...) {
-        validation_rc = -1;
+        validation_rc = PTO_RUNTIME_ERR_INTERNAL;
     }
     int resources_rc = 0;
     if (state->prepared_execution != nullptr) {
         try {
             state->runner->abandon_prepared_execution(*state->prepared_execution);
         } catch (...) {
-            resources_rc = -1;
+            resources_rc = PTO_RUNTIME_ERR_INTERNAL;
         }
     }
     if (state->runner_resources_owned) {
@@ -649,7 +649,7 @@ static int cleanup_failed_prepare(OnboardNativeRunContext *state, int execution_
             int abandon_rc = state->runner->abandon_native_run_resources(state->descriptor.pipeline_slot);
             if (resources_rc == 0) resources_rc = abandon_rc;
         } catch (...) {
-            resources_rc = -1;
+            resources_rc = PTO_RUNTIME_ERR_INTERNAL;
         }
         state->runner_resources_owned = false;
     }
@@ -672,36 +672,37 @@ int simpler_prepare_run(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config,
     const NativeRunDescriptor *descriptor
 ) {
-    if (ctx == nullptr || runtime == nullptr || config == nullptr || descriptor == nullptr) return -1;
+    if (ctx == nullptr || runtime == nullptr || config == nullptr || descriptor == nullptr)
+        return PTO_RUNTIME_ERR_INTERNAL;
     if (descriptor->pipeline_slot >= PTO_PIPELINE_MAX_DEPTH || descriptor->arena_bank >= PTO_PIPELINE_MAX_DEPTH) {
         LOG_ERROR(
             "simpler_prepare_run: descriptor selects slot=%u bank=%u outside [0, %u)", descriptor->pipeline_slot,
             descriptor->arena_bank, PTO_PIPELINE_MAX_DEPTH
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (reinterpret_cast<uintptr_t>(runtime) % alignof(OnboardNativeRunContext) != 0) {
         LOG_ERROR("simpler_prepare_run: runtime storage does not satisfy get_runtime_alignment()");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
     if (!runner->has_callable(callable_id)) {
         LOG_ERROR("simpler_prepare_run: callable_id=%d not registered", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (!runner->can_accept_run()) {
         LOG_ERROR("simpler_prepare_run: runner is unusable after a prior device failure");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     uint64_t magic = 0;
     std::memcpy(&magic, runtime, sizeof(magic));
     if (magic == OnboardNativeRunContext::kMagic) {
         LOG_ERROR("simpler_prepare_run: runtime already contains a prepared run; finalize it before reuse");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (magic != 0) {
         LOG_ERROR("simpler_prepare_run: runtime storage was not zero-initialized before its first use");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     OnboardNativeRunContext *state = nullptr;
@@ -725,7 +726,7 @@ int simpler_prepare_run(
             )) {
             LOG_ERROR("simpler_prepare_run: native-run admission is occupied (%s)", state->trace_attrs);
             destroy_native_run_context(state);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         state->runner_reserved = true;
         const bool overlaps_active_run = allow_prepared_successor && runner->native_run_active();
@@ -797,14 +798,15 @@ int simpler_prepare_run(
         state->runner_resources_owned = false;
         return 0;
     } catch (...) {
-        if (state != nullptr) return cleanup_failed_prepare(state, -1, true);
-        return -1;
+        if (state != nullptr) return cleanup_failed_prepare(state, PTO_RUNTIME_ERR_INTERNAL, true);
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
 int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     OnboardNativeRunContext *state = native_run_context(ctx, runtime, "simpler_launch_run");
-    if (state == nullptr || state->phase.load(std::memory_order_acquire) != NativeRunPhase::Prepared) return -1;
+    if (state == nullptr || state->phase.load(std::memory_order_acquire) != NativeRunPhase::Prepared)
+        return PTO_RUNTIME_ERR_INTERNAL;
     // TEMPORARY (host_build_graph dsv4 bring-up): stop after prepare so the host
     // side — orchestration, graph construction, image relocation and H2D — can be
     // measured while the device execution of that graph still stalls. Sitting in
@@ -821,11 +823,11 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
         return 0;
     }
-    if (!state->runner->can_accept_run() || !state->runner_reserved) return -1;
+    if (!state->runner->can_accept_run() || !state->runner_reserved) return PTO_RUNTIME_ERR_INTERNAL;
     if (state->prepared_execution == nullptr ||
         !state->runner->try_acquire_native_run(state, state->identity(), &state->launch_permit)) {
         LOG_ERROR("simpler_launch_run: execution claim is occupied (%s)", state->trace_attrs);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     state->runner_claimed = true;
     // The active predecessor may poison the device after this successor was
@@ -833,11 +835,11 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     if (!state->runner->can_accept_run()) {
         state->runner->release_native_run(state);
         state->runner_claimed = false;
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     state->runner_trace_start_ns = STRACE_NOW_NS();
-    int rc = -1;
+    int rc = PTO_RUNTIME_ERR_INTERNAL;
     try {
         rc = state->runner->attach_current_thread(state->runner->device_id());
         if (rc == 0) {
@@ -848,11 +850,11 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
             state->active_execution = std::move(launch.active);
             if (launch.progress == LaunchProgress::Complete && !state->publish_acceptance(launch.receipt)) {
                 LOG_ERROR("simpler_launch_run: launch receipt identity mismatch (%s)", state->trace_attrs);
-                rc = -1;
+                rc = PTO_RUNTIME_ERR_INTERNAL;
             }
         }
     } catch (...) {
-        rc = -1;
+        rc = PTO_RUNTIME_ERR_INTERNAL;
     }
     if (rc != 0) {
         state->completion_rc = rc;
@@ -883,26 +885,26 @@ int simpler_poll_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
 
 int simpler_wait_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     OnboardNativeRunContext *state = native_run_context(ctx, runtime, "simpler_wait_run");
-    if (state == nullptr) return -1;
+    if (state == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     NativeRunPhase phase = state->phase.load(std::memory_order_acquire);
-    if (phase == NativeRunPhase::Prepared) return -1;
+    if (phase == NativeRunPhase::Prepared) return PTO_RUNTIME_ERR_INTERNAL;
     if (phase == NativeRunPhase::Complete) return state->completion_rc;
     // drain_execution() synchronizes and destroys streams, reads device memory
     // and frees device allocations, all of which need this thread's CANN
     // device context. rtSetDevice is idempotent on an already-attached thread.
-    int drain_rc = -1;
+    int drain_rc = PTO_RUNTIME_ERR_INTERNAL;
     try {
         drain_rc = state->runner->attach_current_thread(state->runner->device_id());
         if (drain_rc != 0) {
             LOG_ERROR("simpler_wait_run: attach_current_thread failed: %d (%s)", drain_rc, state->trace_attrs);
         } else {
-            drain_rc = -1;
+            drain_rc = PTO_RUNTIME_ERR_INTERNAL;
             if (state->active_execution != nullptr) {
                 drain_rc = state->runner->drain_execution(*state->active_execution);
             }
         }
     } catch (...) {
-        drain_rc = -1;
+        drain_rc = PTO_RUNTIME_ERR_INTERNAL;
         LOG_ERROR("simpler_wait_run: drain threw (%s)", state->trace_attrs);
     }
     if (state->completion_rc == 0) state->completion_rc = drain_rc;
@@ -913,7 +915,7 @@ int simpler_wait_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
 
 int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     OnboardNativeRunContext *state = native_run_context(ctx, runtime, "simpler_finalize_run");
-    if (state == nullptr) return -1;
+    if (state == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     NativeRunPhase phase = state->phase.load(std::memory_order_acquire);
     const uint64_t trace_inv = state->trace_inv;
     const uint64_t trace_hid = state->trace_hid;
@@ -934,11 +936,11 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     // Both drain_execution() and validate_runtime_impl() touch the device, so
     // the attach covers each of them. rtSetDevice is idempotent on an
     // already-attached thread.
-    int attach_rc = -1;
+    int attach_rc = PTO_RUNTIME_ERR_INTERNAL;
     try {
         attach_rc = state->runner->attach_current_thread(state->runner->device_id());
     } catch (...) {
-        attach_rc = -1;
+        attach_rc = PTO_RUNTIME_ERR_INTERNAL;
     }
     if (attach_rc != 0) {
         LOG_ERROR("simpler_finalize_run: attach_current_thread failed: %d (%s)", attach_rc, state->trace_attrs);
@@ -946,7 +948,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     if (phase == NativeRunPhase::Running && launched) {
         int drain_rc = attach_rc;
         if (attach_rc == 0) {
-            drain_rc = -1;
+            drain_rc = PTO_RUNTIME_ERR_INTERNAL;
             try {
                 drain_rc = state->runner->drain_execution(*state->active_execution);
             } catch (...) {
@@ -959,20 +961,22 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     }
     emit_native_run_runner_wall(state);
 
-    int validation_rc = -1;
+    int validation_rc = PTO_RUNTIME_ERR_INTERNAL;
     try {
         if (!launched) state->runtime.set_gm_sm_ptr(nullptr);
         if (attach_rc == 0) {
             {
                 STRACE("chip.run.validate");
-                validation_rc = validate_runtime_impl(&state->runtime, &state->host_api, launched ? execution_rc : -1);
+                validation_rc = validate_runtime_impl(
+                    &state->runtime, &state->host_api, launched ? execution_rc : PTO_RUNTIME_ERR_INTERNAL
+                );
             }
             if (launched && execution_rc == 0) emit_device_phase_markers(state->runner);
         } else {
             validation_rc = attach_rc;
         }
     } catch (...) {
-        validation_rc = -1;
+        validation_rc = PTO_RUNTIME_ERR_INTERNAL;
     }
 
     int resources_rc = 0;
@@ -980,7 +984,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         try {
             state->runner->abandon_prepared_execution(*state->prepared_execution);
         } catch (...) {
-            resources_rc = -1;
+            resources_rc = PTO_RUNTIME_ERR_INTERNAL;
         }
     }
     if (state->runner_resources_owned) {
@@ -988,7 +992,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
             int abandon_rc = state->runner->abandon_native_run_resources(state->descriptor.pipeline_slot);
             if (resources_rc == 0) resources_rc = abandon_rc;
         } catch (...) {
-            resources_rc = -1;
+            resources_rc = PTO_RUNTIME_ERR_INTERNAL;
         }
         state->runner_resources_owned = false;
     }
@@ -1047,18 +1051,18 @@ uint64_t get_retained_temp_addr_ctx(DeviceContextHandle ctx, uint32_t slot_id) {
 }
 
 int simpler_unregister_callable(DeviceContextHandle ctx, int32_t callable_id) {
-    if (ctx == NULL) return -1;
+    if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
         if (runner->native_runs_outstanding()) {
             LOG_ERROR(
                 "simpler_unregister_callable: native run must be finalized before mutating the callable registry"
             );
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         return runner->unregister_callable(callable_id);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
@@ -1101,13 +1105,13 @@ size_t committed_device_memory_ctx(DeviceContextHandle ctx) {
 int simpler_provision_dma_workspace(
     DeviceContextHandle ctx, uint32_t required_mask, const void *sdma_warmup_binary, uint64_t sdma_warmup_size
 ) {
-    if (ctx == NULL) return -1;
+    if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<DeviceRunnerBase *>(ctx)->provision_dma_workspace(
             required_mask, sdma_warmup_binary, static_cast<size_t>(sdma_warmup_size)
         );
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -305,7 +305,7 @@ int DeviceRunnerBase::setup_static_arena(
 ) {
     if (arena_bank >= arena_banks_.size()) {
         LOG_ERROR("arena bank %u is outside [0, %zu)", arena_bank, arena_banks_.size());
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     // Three independent device_malloc'd buffers: GM heap, PTO2 SM, prebuilt
     // runtime arena. Split out from a single large allocation because the
@@ -344,7 +344,7 @@ int DeviceRunnerBase::setup_static_arena(
             // is_committed() guard skips the release branch. release() is
             // idempotent on a never-committed arena (zeroes cursor_).
             arena.release();
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         cached_size = requested_size;
         return 0;
@@ -374,7 +374,7 @@ int DeviceRunnerBase::setup_static_arena(
             prebuilt_runtime_arena_cache_runtime_arena_base_ = nullptr;
             prebuilt_runtime_arena_cache_image_.clear();
         }
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (arena_changed && arena_bank == 0) {
         prebuilt_runtime_arena_cache_valid_ = false;
@@ -398,14 +398,14 @@ std::thread DeviceRunnerBase::create_thread(std::function<void()> fn) {
 int DeviceRunnerBase::attach_current_thread(int device_id) {
     if (device_id < 0) {
         LOG_ERROR("Invalid device_id: %d", device_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (device_id_ != -1 && device_id_ != device_id) {
         LOG_ERROR(
             "DeviceRunner already initialized on device %d; reset/finalize before switching to device %d", device_id_,
             device_id
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // CANN device context is per-thread, so every caller must attach explicitly.
@@ -546,7 +546,7 @@ int DeviceRunnerBase::ensure_binaries_loaded() {
     // Device must be set first
     if (stream_aicpu_ == nullptr) {
         LOG_ERROR("Device not set before loading binaries");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     if (dispatcher_so_binary_.empty()) {
@@ -554,7 +554,7 @@ int DeviceRunnerBase::ensure_binaries_loaded() {
             "DeviceRunner: dispatcher SO bytes not provided; pass dispatcher_path through ChipWorker.init "
             "(RuntimeBinaries.dispatcher_path)"
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // One-shot bootstrap: libaicpu_extend_kernels invokes our dispatcher,
@@ -732,12 +732,12 @@ int DeviceRunnerBase::stamp_orch_so(Runtime &runtime, int32_t cid) {
     // slot to dispatch — the active callable_id.
     if (cid < 0) {
         LOG_ERROR("stamp_orch_so: invalid callable_id=%d", cid);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     auto it = callables_.find(cid);
     if (it == callables_.end()) {
         LOG_ERROR("stamp_orch_so: callable_id=%d not registered", cid);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     runtime.set_active_callable_id(cid);
     return 0;
@@ -747,7 +747,7 @@ int DeviceRunnerBase::prepare_orch_so(Runtime &runtime) {
     const int32_t cid = runtime.get_active_callable_id();
     if (cid < 0) {
         LOG_ERROR("prepare_orch_so: no active callable_id; registered-callable flow required");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     return stamp_orch_so(runtime, cid);
 }
@@ -756,7 +756,7 @@ int DeviceRunnerBase::commit_device_register(int32_t cid) {
     auto it = callables_.find(cid);
     if (it == callables_.end()) {
         LOG_ERROR("commit_device_register: callable_id=%d not registered", cid);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     const auto &state = it->second;
     if (state.host_dlopen_handle != nullptr) {
@@ -774,7 +774,7 @@ int DeviceRunnerBase::launch_device_register(int32_t callable_id) {
     auto it = callables_.find(callable_id);
     if (it == callables_.end()) {
         LOG_ERROR("launch_device_register: callable_id=%d not registered", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (it->second.host_dlopen_handle != nullptr) {
         return 0;
@@ -838,19 +838,19 @@ int DeviceRunnerBase::record_device_orch_callable(
         LOG_ERROR(
             "record_device_orch_callable: callable_id=%d out of range [0, %d)", callable_id, MAX_REGISTERED_CALLABLE_IDS
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (orch_so_data == nullptr || orch_so_size == 0) {
         LOG_ERROR("record_device_orch_callable: empty orch SO for callable_id=%d", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (chip_buffer_hash == 0 || chip_dev == 0) {
         LOG_ERROR("record_device_orch_callable: missing chip buffer for callable_id=%d", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (callables_.count(callable_id) != 0) {
         LOG_ERROR("record_device_orch_callable: callable_id=%d already registered", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     const uint64_t hash = simpler::common::utils::elf_build_id_64(orch_so_data, orch_so_size);
@@ -881,19 +881,19 @@ int DeviceRunnerBase::record_host_orch_callable(
         LOG_ERROR(
             "record_host_orch_callable: callable_id=%d out of range [0, %d)", callable_id, MAX_REGISTERED_CALLABLE_IDS
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (host_dlopen_handle == nullptr || host_orch_func_ptr == nullptr) {
         LOG_ERROR("record_host_orch_callable: null handle/fn for callable_id=%d", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (chip_buffer_hash == 0) {
         LOG_ERROR("record_host_orch_callable: missing chip buffer for callable_id=%d", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (callables_.count(callable_id) != 0) {
         LOG_ERROR("record_host_orch_callable: callable_id=%d already registered", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     CallableState state;
@@ -935,11 +935,11 @@ int DeviceRunnerBase::provision_dma_workspace(
     const uint32_t supported = dma_workspace_supported_mask();
     if ((required_mask & ~supported) != 0) {
         LOG_ERROR("provision_dma_workspace: unsupported mask=0x%x (supported=0x%x)", required_mask, supported);
-        return -1;
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
     }
     if (dma_workspace_handle_ != nullptr) {
         LOG_ERROR("provision_dma_workspace: workspace already provisioned");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     for (int kind = 0; kind < DMA_WORKSPACE_KIND_COUNT; ++kind)
@@ -1140,7 +1140,7 @@ int DeviceRunnerBase::bind_callable_to_runtime(
     auto it = callables_.find(callable_id);
     if (it == callables_.end()) {
         LOG_ERROR("bind_callable_to_runtime: callable_id=%d not registered", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     const auto &state = it->second;
 
@@ -1158,7 +1158,7 @@ int DeviceRunnerBase::bind_callable_to_runtime(
     for (const auto &kv : state.kernel_addrs) {
         if (kv.first < 0 || kv.first >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("bind_callable_to_runtime: func_id=%d out of range", kv.first);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
@@ -1490,7 +1490,7 @@ int DeviceRunnerBase::launch_aicore_kernel(rtStream_t stream, KernelArgs *k_args
     if (aicore_bin_handle_ == nullptr) {
         if (aicore_kernel_binary_.empty()) {
             LOG_ERROR("AICore kernel binary is empty");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         rtDevBinary_t binary;
         std::memset(&binary, 0, sizeof(binary));
@@ -1538,7 +1538,7 @@ int DeviceRunnerBase::validate_launch_aicpu_num(int launch_aicpu_num) {
         LOG_ERROR(
             "launch_aicpu_num (%d) must be 0 (auto) or in range [2, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     return 0;
 }
@@ -1619,17 +1619,17 @@ int DeviceRunnerBase::resolve_block_dim() {
 
 int DeviceRunnerBase::prepare_launch_shape(Runtime &runtime, const CallConfig &config) {
     if (validate_launch_aicpu_num(config.aicpu_thread_num) != 0) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     int block_dim = resolve_block_dim();
     if (block_dim < 0) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     int num_aicore = block_dim * cores_per_blockdim_;
     if (num_aicore > RUNTIME_MAX_WORKER) {
         LOG_ERROR("block_dim (%d) exceeds RUNTIME_MAX_WORKER (%d)", block_dim, RUNTIME_MAX_WORKER);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     runtime.set_worker_count(num_aicore);

--- a/src/common/platform/onboard/host/device_runner_helpers.cpp
+++ b/src/common/platform/onboard/host/device_runner_helpers.cpp
@@ -69,7 +69,7 @@ int KernelArgsHelper::init_runtime_args(const Runtime &host_runtime, MemoryAlloc
         void *runtime_dev = allocator_->alloc(runtime_size);
         if (runtime_dev == nullptr) {
             LOG_ERROR("Alloc for runtime_args failed");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         args.runtime_args = reinterpret_cast<Runtime *>(runtime_dev);
     }
@@ -98,7 +98,7 @@ int KernelArgsHelper::init_device_kernel_args(MemoryAllocator &allocator) {
         void *dev_ptr = allocator_->alloc(sizeof(KernelArgs));
         if (dev_ptr == nullptr) {
             LOG_ERROR("Alloc for device KernelArgs failed");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         device_k_args_ = reinterpret_cast<KernelArgs *>(dev_ptr);
     }

--- a/src/common/platform/shared/host/args_dump_collector.cpp
+++ b/src/common/platform/shared/host/args_dump_collector.cpp
@@ -40,6 +40,7 @@
 
 #include "common/memory_barrier.h"
 #include "common/unified_log.h"
+#include "../../../worker/pto_runtime_c_api.h"
 
 // =============================================================================
 // ArgsDumpCollector
@@ -94,14 +95,14 @@ int ArgsDumpCollector::initialize(
 ) {
     if (shm_host_ != nullptr) {
         LOG_ERROR("ArgsDumpCollector already initialized");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (num_dump_threads <= 0 || num_dump_threads > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR(
             "ArgsDumpCollector::initialize: invalid num_dump_threads=%d (valid range: 1-%d)", num_dump_threads,
             PLATFORM_MAX_AICPU_THREADS
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Must precede the recycled-lane seeding below: push_recycled() folds its
@@ -142,7 +143,7 @@ int ArgsDumpCollector::initialize(
     void *shm_dev_local = alloc_paired_buffer(shm_size, &shm_host_local);
     if (shm_dev_local == nullptr) {
         LOG_ERROR("Failed to allocate dump shared memory (%zu bytes)", shm_size);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Initialize header on host shadow
@@ -165,7 +166,7 @@ int ArgsDumpCollector::initialize(
         ai.dev_ptr = alloc_paired_buffer(arena_size, &ai.host_ptr);
         if (ai.dev_ptr == nullptr) {
             LOG_ERROR("Failed to allocate dump arena for thread %d (%lu bytes)", t, arena_size);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         DumpBufferState *state = get_dump_buffer_state(shm_host_local, t);
@@ -191,7 +192,7 @@ int ArgsDumpCollector::initialize(
             void *dev_ptr = alloc_paired_buffer(sizeof(DumpMetaBuffer), &host_ptr);
             if (dev_ptr == nullptr) {
                 LOG_ERROR("Failed to allocate dump meta buffer %d for thread %d", b, t);
-                return -1;
+                return PTO_RUNTIME_ERR_INTERNAL;
             }
             // alloc_paired_buffer already registered dev→host via the manager.
 

--- a/src/common/platform/shared/host/chip_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/chip_swimlane_collector.cpp
@@ -35,6 +35,7 @@
 #include "common/memory_barrier.h"
 #include "common/unified_log.h"
 #include "host/profiling_copy.h"
+#include "../../../worker/pto_runtime_c_api.h"
 
 // =============================================================================
 // ChipSwimlaneCollector Implementation
@@ -89,27 +90,27 @@ int ChipSwimlaneCollector::initialize(
 ) {
     if (shm_host_ != nullptr) {
         LOG_ERROR("ChipSwimlaneCollector already initialized");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // register_cb may legitimately be null on simulation / non-SVM platforms;
     // alloc and free callbacks are mandatory. Matches dep_gen / pmu / scope_stats.
     if (alloc_cb == nullptr || free_cb == nullptr) {
         LOG_ERROR("ChipSwimlaneCollector::initialize: alloc_cb/free_cb must be non-null");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     LOG_INFO("Initializing performance profiling");
 
     if (num_aicore <= 0 || num_aicore > PLATFORM_MAX_CORES) {
         LOG_ERROR("Invalid number of AICores: %d (max=%d)", num_aicore, PLATFORM_MAX_CORES);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (aicpu_thread_num <= 0 || aicpu_thread_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR(
             "Invalid number of AICPU threads: %d (valid range: 1-%d)", aicpu_thread_num, PLATFORM_MAX_AICPU_THREADS
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Must precede the recycled-lane seeding below: push_recycled() folds its
@@ -171,7 +172,7 @@ int ChipSwimlaneCollector::initialize(
     void *perf_dev_ptr = alloc_paired_buffer(total_size, &perf_host_ptr);
     if (perf_dev_ptr == nullptr) {
         LOG_ERROR("Failed to allocate shared memory (%zu bytes)", total_size);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     LOG_DEBUG("Allocated shared memory: dev=%p host=%p", perf_dev_ptr, perf_host_ptr);
 
@@ -228,7 +229,7 @@ int ChipSwimlaneCollector::initialize(
             "ChipSwimlaneAicpuTask", num_aicore, aicpu_thread_num, kAicpuSurplusPerCore,
             decltype(manager_)::kRecycledQueueCapacity
         )) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     for (int i = 0; i < num_aicore; i++) {
         ChipSwimlaneAicpuTaskPool *state = get_perf_buffer_state(perf_host_ptr, i);
@@ -245,7 +246,7 @@ int ChipSwimlaneCollector::initialize(
             void *dev_buf_ptr = alloc_paired_buffer(sizeof(ChipSwimlaneAicpuTaskBuffer), &host_buf_ptr);
             if (dev_buf_ptr == nullptr) {
                 LOG_ERROR("Failed to allocate ChipSwimlaneAicpuTaskBuffer for core %d, buffer %d", i, s);
-                return -1;
+                return PTO_RUNTIME_ERR_INTERNAL;
             }
             ChipSwimlaneAicpuTaskBuffer *buf = reinterpret_cast<ChipSwimlaneAicpuTaskBuffer *>(host_buf_ptr);
             memset(buf, 0, sizeof(ChipSwimlaneAicpuTaskBuffer));
@@ -276,7 +277,7 @@ int ChipSwimlaneCollector::initialize(
             "ChipSwimlaneAicoreTask", num_aicore, aicpu_thread_num, kAicoreSurplusPerCore,
             decltype(manager_)::kRecycledQueueCapacity
         )) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     for (int i = 0; i < num_aicore; i++) {
         ChipSwimlaneAicoreTaskPool *ac_state = get_aicore_buffer_state(perf_host_ptr, num_aicore, i);
@@ -288,7 +289,7 @@ int ChipSwimlaneCollector::initialize(
             void *dev_buf_ptr = alloc_paired_buffer(sizeof(ChipSwimlaneAicoreTaskBuffer), &host_buf_ptr);
             if (dev_buf_ptr == nullptr) {
                 LOG_ERROR("Failed to allocate ChipSwimlaneAicoreTaskBuffer for core %d, buffer %d", i, s);
-                return -1;
+                return PTO_RUNTIME_ERR_INTERNAL;
             }
             ChipSwimlaneAicoreTaskBuffer *buf = reinterpret_cast<ChipSwimlaneAicoreTaskBuffer *>(host_buf_ptr);
             memset(buf, 0, sizeof(ChipSwimlaneAicoreTaskBuffer));
@@ -334,7 +335,7 @@ int ChipSwimlaneCollector::initialize(
             LOG_ERROR(
                 "Failed to allocate chip_swimlane_aicore_rotation_table (rotation) table (%zu bytes)", table_bytes
             );
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
     }
 
@@ -367,7 +368,7 @@ int ChipSwimlaneCollector::initialize(
                 void *dev_buf_ptr = alloc_paired_buffer(buffer_bytes, &host_buf_ptr);
                 if (dev_buf_ptr == nullptr) {
                     LOG_ERROR("Failed to allocate %s phase buffer for thread %d, slot %d", kind_label, t, s);
-                    return -1;
+                    return PTO_RUNTIME_ERR_INTERNAL;
                 }
                 // Zero only the `count` word at the buffer's tail, using the
                 // matching Buffer type. The records payload is overwritten by
@@ -406,7 +407,7 @@ int ChipSwimlaneCollector::initialize(
             /*state_count=*/num_phase_threads, /*buffer_count=*/aicpu_thread_num,
             /*buffers_per_thread=*/PLATFORM_PROF_SCHED_BUFFERS_PER_THREAD, ProfBufferType::AICPU_SCHED_PHASE, "sched"
         ) != 0) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     auto orch_get_state = [](void *base, int n_cores, int t) {
         return get_orch_phase_buffer_state(base, n_cores, t);
@@ -417,7 +418,7 @@ int ChipSwimlaneCollector::initialize(
             /*state_count=*/num_phase_threads, /*buffer_count=*/orch_buffer_count,
             /*buffers_per_thread=*/PLATFORM_PROF_ORCH_BUFFERS_PER_THREAD, ProfBufferType::AICPU_ORCH_PHASE, "orch"
         ) != 0) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     LOG_DEBUG(
         "Initialized %d sched (%d buf/thread) + %d orch (%d buf/thread) PhaseBufferStates", num_phase_threads,
@@ -930,7 +931,7 @@ void ChipSwimlaneCollector::finish_clock_correlation_session() { clock_correlati
 // rebuild, and shrinks this file to a pure dump.
 int ChipSwimlaneCollector::export_swimlane_json() {
     if (shm_host_ == nullptr) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     merge_collector_shards();
 
@@ -963,25 +964,25 @@ int ChipSwimlaneCollector::export_swimlane_json() {
     has_any_records = has_any_records || any_phase_records(collected_sched_phase_records_) || has_aicpu_orch_phases;
     if (!has_any_records) {
         LOG_WARN("Warning: No performance data to export.");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (has_aicpu_orch_phases && host_orchestrated_) {
         LOG_ERROR("Both host and AICPU orchestrator records are present; refusing mixed clock-domain export");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     std::error_code ec;
     std::filesystem::create_directories(output_prefix_, ec);
     if (ec) {
         LOG_ERROR("Error: Failed to create output directory %s: %s", output_prefix_.c_str(), ec.message().c_str());
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     std::string filepath = output_prefix_ + "/chip_swimlane_records.json";
     std::ofstream outfile(filepath);
     if (!outfile.is_open()) {
         LOG_ERROR("Error: Failed to open file: %s", filepath.c_str());
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     int chip_swimlane_level = static_cast<int>(chip_swimlane_level_);
@@ -1269,7 +1270,7 @@ int ChipSwimlaneCollector::export_swimlane_json() {
 
     if (!outfile) {
         LOG_ERROR("Failed to write JSON file (stream error): %s", filepath.c_str());
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     LOG_INFO("=== JSON Export Complete ===");

--- a/src/common/platform/shared/host/dep_gen_collector.cpp
+++ b/src/common/platform/shared/host/dep_gen_collector.cpp
@@ -34,6 +34,7 @@
 #include "common/memory_barrier.h"
 #include "common/unified_log.h"
 #include "host/profiling_copy.h"
+#include "../../../worker/pto_runtime_c_api.h"
 
 DepGenCollector::~DepGenCollector() { stop(); }
 
@@ -47,14 +48,14 @@ int DepGenCollector::init(
 ) {
     if (initialized_) {
         LOG_ERROR("DepGenCollector already initialized");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (num_threads <= 0 || num_threads > PLATFORM_MAX_AICPU_THREADS || alloc_cb == nullptr || free_cb == nullptr) {
         LOG_ERROR(
             "DepGenCollector::init: invalid arguments (num_threads=%d, valid range: 1-%d)", num_threads,
             PLATFORM_MAX_AICPU_THREADS
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Must precede the recycled-lane seeding below: push_recycled() folds its
@@ -87,7 +88,7 @@ int DepGenCollector::init(
     void *shm_dev_local = alloc_paired_buffer(shm_size, &shm_host_local);
     if (shm_dev_local == nullptr) {
         LOG_ERROR("DepGenCollector: failed to allocate dep_gen shared memory (%zu bytes)", shm_size);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     std::memset(shm_host_local, 0, shm_size);
@@ -104,7 +105,7 @@ int DepGenCollector::init(
         void *dev_ptr = alloc_paired_buffer(buf_size, &host_ptr);
         if (dev_ptr == nullptr) {
             LOG_ERROR("DepGenCollector: failed to allocate DepGenBuffer b=%d", b);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         if (b < PLATFORM_DEP_GEN_SLOT_COUNT) {

--- a/src/common/platform/shared/host/scope_stats_collector.cpp
+++ b/src/common/platform/shared/host/scope_stats_collector.cpp
@@ -40,6 +40,7 @@
 #include "common/memory_barrier.h"
 #include "common/unified_log.h"
 #include "host/profiling_copy.h"
+#include "../../../worker/pto_runtime_c_api.h"
 
 ScopeStatsCollector::~ScopeStatsCollector() { stop(); }
 
@@ -56,11 +57,11 @@ int ScopeStatsCollector::init(
             "ScopeStatsCollector::init: invalid arguments (num_threads=%d, valid range: 1-%d)", num_threads,
             PLATFORM_MAX_AICPU_THREADS
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (initialized_) {
         LOG_ERROR("ScopeStatsCollector already initialized");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Must precede the recycled-lane seeding below: push_recycled() folds its
@@ -93,7 +94,7 @@ int ScopeStatsCollector::init(
     void *shm_dev_local = alloc_paired_buffer(shm_size, &shm_host_local);
     if (shm_dev_local == nullptr) {
         LOG_ERROR("ScopeStatsCollector: failed to allocate scope_stats shared memory (%zu bytes)", shm_size);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     std::memset(shm_host_local, 0, shm_size);
@@ -109,7 +110,7 @@ int ScopeStatsCollector::init(
         void *dev_ptr = alloc_paired_buffer(buf_size, &host_ptr);
         if (dev_ptr == nullptr) {
             LOG_ERROR("ScopeStatsCollector: failed to allocate ScopeStatsBuffer b=%d", b);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
 
         if (b < PLATFORM_SCOPE_STATS_SLOT_COUNT) {
@@ -265,7 +266,7 @@ int ScopeStatsCollector::write_jsonl(const std::string &output_dir) {
     std::FILE *fp = std::fopen(path.c_str(), "w");
     if (fp == nullptr) {
         LOG_ERROR("scope_stats: failed to open %s", path.c_str());
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     const ScopeStatsDataHeader *hdr = scope_stats_header();

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -79,20 +79,20 @@ static void device_free(void *runner_ctx, void *dev_ptr) {
 }
 
 static int copy_to_device(void *runner_ctx, void *dev_ptr, const void *host_ptr, size_t size) {
-    if (runner_ctx == nullptr || dev_ptr == nullptr || host_ptr == nullptr) return -1;
+    if (runner_ctx == nullptr || dev_ptr == nullptr || host_ptr == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<SimDeviceRunnerBase *>(runner_ctx)->copy_to_device(dev_ptr, host_ptr, size);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
 static int copy_from_device(void *runner_ctx, void *host_ptr, const void *dev_ptr, size_t size) {
-    if (runner_ctx == nullptr || host_ptr == nullptr || dev_ptr == nullptr) return -1;
+    if (runner_ctx == nullptr || host_ptr == nullptr || dev_ptr == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<SimDeviceRunnerBase *>(runner_ctx)->copy_from_device(host_ptr, dev_ptr, size);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
@@ -113,11 +113,11 @@ static void unregister_device_memory_from_host(void *runner_ctx, void *dev_ptr) 
 }
 
 static int device_memset(void *runner_ctx, void *dev_ptr, int value, size_t size) {
-    if (runner_ctx == nullptr || dev_ptr == nullptr) return -1;
+    if (runner_ctx == nullptr || dev_ptr == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<SimDeviceRunnerBase *>(runner_ctx)->device_memset(dev_ptr, value, size);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
@@ -182,12 +182,12 @@ static void host_phase_pool_finish(void *runner_ctx, uint64_t submitted_tasks, u
 static int setup_static_arena_wrapper(
     void *runner_ctx, uint32_t arena_bank, size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size
 ) {
-    if (runner_ctx == nullptr) return -1;
+    if (runner_ctx == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<SimDeviceRunnerBase *>(runner_ctx)
             ->setup_static_arena(arena_bank, gm_heap_size, gm_sm_size, runtime_arena_size);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
@@ -315,30 +315,30 @@ void device_free_ctx(DeviceContextHandle ctx, void *dev_ptr) {
 }
 
 int copy_to_device_ctx(DeviceContextHandle ctx, void *dev_ptr, const void *host_ptr, size_t size) {
-    if (ctx == NULL || dev_ptr == NULL || host_ptr == NULL) return -1;
+    if (ctx == NULL || dev_ptr == NULL || host_ptr == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<SimDeviceRunnerBase *>(ctx)->copy_to_device(dev_ptr, host_ptr, size);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
 int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *dev_ptr, size_t size) {
-    if (ctx == NULL || host_ptr == NULL || dev_ptr == NULL) return -1;
+    if (ctx == NULL || host_ptr == NULL || dev_ptr == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         return static_cast<SimDeviceRunnerBase *>(ctx)->copy_from_device(host_ptr, dev_ptr, size);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
 int finalize_device(DeviceContextHandle ctx) {
-    if (ctx == NULL) return -1;
+    if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         SimDeviceRunnerBase *runner = static_cast<SimDeviceRunnerBase *>(ctx);
         if (runner->native_run_active()) {
             LOG_ERROR("finalize_device: native run must be finalized first");
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         int rc = runner->finalize();
         int dev = pto_cpu_sim_get_bound_device();
@@ -347,7 +347,7 @@ int finalize_device(DeviceContextHandle ctx) {
         }
         return rc;
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
@@ -363,7 +363,7 @@ int simpler_init(
     (void)dispatcher_binary;
     (void)dispatcher_size;
 
-    if (ctx == NULL) return -1;
+    if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
 
     SimDeviceRunnerBase *runner = static_cast<SimDeviceRunnerBase *>(ctx);
 
@@ -371,7 +371,7 @@ int simpler_init(
     try {
         rc = runner->attach_current_thread(device_id);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (rc != 0) return rc;
 
@@ -386,7 +386,7 @@ int simpler_init(
         }
         runner->set_executors(std::move(aicpu_vec), std::move(aicore_vec));
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     // No CANN dlog on sim. ChipWorker bound this module's logger to the
     // process-owned state before calling simpler_init.
@@ -402,7 +402,7 @@ int simpler_init(
                 prewarm_config->runtime_env.ring_dep_pool
             );
         } catch (...) {
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         if (rc != 0) return rc;
     }
@@ -414,11 +414,11 @@ int simpler_init(
  * =========================================================================== */
 
 int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, const void *callable) {
-    if (ctx == NULL || callable == NULL) return -1;
+    if (ctx == NULL || callable == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     SimDeviceRunnerBase *runner = static_cast<SimDeviceRunnerBase *>(ctx);
     if (runner->native_run_active()) {
         LOG_ERROR("simpler_register_callable: native run must be finalized before mutating the callable registry");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     try {
@@ -474,7 +474,7 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
         }
         return rc;
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
@@ -592,11 +592,11 @@ static int cleanup_failed_prepare(SimNativeRunContext *state, int execution_rc, 
     const long long trace_start_ns = state->trace_start_ns;
     if (clear_gm_sm) state->runtime.set_gm_sm_ptr(nullptr);
     state->runner->finish_clock_correlation_session(false);
-    int validation_rc = -1;
+    int validation_rc = PTO_RUNTIME_ERR_INTERNAL;
     try {
         validation_rc = validate_runtime_impl(&state->runtime, &state->host_api, execution_rc);
     } catch (...) {
-        validation_rc = -1;
+        validation_rc = PTO_RUNTIME_ERR_INTERNAL;
     }
     if (state->prepared_execution != nullptr) {
         state->runner->abandon_prepared_execution(*state->prepared_execution);
@@ -614,36 +614,37 @@ int simpler_prepare_run(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config,
     const NativeRunDescriptor *descriptor
 ) {
-    if (ctx == nullptr || runtime == nullptr || config == nullptr || descriptor == nullptr) return -1;
+    if (ctx == nullptr || runtime == nullptr || config == nullptr || descriptor == nullptr)
+        return PTO_RUNTIME_ERR_INTERNAL;
     if (descriptor->pipeline_slot >= PTO_PIPELINE_MAX_DEPTH || descriptor->arena_bank >= PTO_PIPELINE_MAX_DEPTH) {
         LOG_ERROR(
             "simpler_prepare_run: descriptor selects slot=%u bank=%u outside [0, %u)", descriptor->pipeline_slot,
             descriptor->arena_bank, PTO_PIPELINE_MAX_DEPTH
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (reinterpret_cast<uintptr_t>(runtime) % alignof(SimNativeRunContext) != 0) {
         LOG_ERROR("simpler_prepare_run: runtime storage does not satisfy get_runtime_alignment()");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     SimDeviceRunnerBase *runner = static_cast<SimDeviceRunnerBase *>(ctx);
     if (!runner->has_callable(callable_id)) {
         LOG_ERROR("simpler_prepare_run: callable_id=%d not registered", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (!runner->can_accept_run()) {
         LOG_ERROR("simpler_prepare_run: runner is poisoned by an uncertain partial launch");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     uint64_t magic = 0;
     std::memcpy(&magic, runtime, sizeof(magic));
     if (magic == SimNativeRunContext::kMagic) {
         LOG_ERROR("simpler_prepare_run: runtime already contains a prepared run; finalize it before reuse");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (magic != 0) {
         LOG_ERROR("simpler_prepare_run: runtime storage was not zero-initialized before its first use");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     SimNativeRunContext *state = nullptr;
@@ -655,7 +656,7 @@ int simpler_prepare_run(
         if (!runner->try_acquire_native_run(state, state->identity(), &state->launch_permit)) {
             LOG_ERROR("simpler_prepare_run: another native run is active on this device context");
             destroy_native_run_context(state);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         state->runner_claimed = true;
         state->trace_inv = trace_inv;
@@ -685,18 +686,19 @@ int simpler_prepare_run(
         if (rc != 0) return cleanup_failed_prepare(state, rc, true);
         return 0;
     } catch (...) {
-        if (state != nullptr) return cleanup_failed_prepare(state, -1, true);
-        return -1;
+        if (state != nullptr) return cleanup_failed_prepare(state, PTO_RUNTIME_ERR_INTERNAL, true);
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
 int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     SimNativeRunContext *state = native_run_context(ctx, runtime, "simpler_launch_run");
-    if (state == nullptr || state->phase.load(std::memory_order_acquire) != NativeRunPhase::Prepared) return -1;
-    if (!state->runner_claimed || !state->runner->native_run_owned_by(state)) return -1;
+    if (state == nullptr || state->phase.load(std::memory_order_acquire) != NativeRunPhase::Prepared)
+        return PTO_RUNTIME_ERR_INTERNAL;
+    if (!state->runner_claimed || !state->runner->native_run_owned_by(state)) return PTO_RUNTIME_ERR_INTERNAL;
 
     state->runner_trace_start_ns = STRACE_NOW_NS();
-    int rc = -1;
+    int rc = PTO_RUNTIME_ERR_INTERNAL;
     try {
         rc = state->runner->attach_current_thread(state->runner->device_id());
         if (rc == 0) {
@@ -705,10 +707,11 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
             rc = launch.rc;
             state->prepared_execution = std::move(launch.prepared);
             state->active_execution = std::move(launch.active);
-            if (launch.progress == LaunchProgress::Complete && !state->publish_acceptance(launch.receipt)) rc = -1;
+            if (launch.progress == LaunchProgress::Complete && !state->publish_acceptance(launch.receipt))
+                rc = PTO_RUNTIME_ERR_INTERNAL;
         }
     } catch (...) {
-        rc = -1;
+        rc = PTO_RUNTIME_ERR_INTERNAL;
     }
     if (rc != 0) {
         state->completion_rc = rc;
@@ -737,27 +740,27 @@ int simpler_poll_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
 
 int simpler_wait_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     SimNativeRunContext *state = native_run_context(ctx, runtime, "simpler_wait_run");
-    if (state == nullptr) return -1;
+    if (state == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     NativeRunPhase phase = state->phase.load(std::memory_order_acquire);
-    if (phase == NativeRunPhase::Prepared) return -1;
+    if (phase == NativeRunPhase::Prepared) return PTO_RUNTIME_ERR_INTERNAL;
     if (phase == NativeRunPhase::Complete) return state->completion_rc;
     // Bind the calling thread to this runner's simulated device before the
     // drain, so sim's lifecycle entry points carry the same contract as
     // onboard's. attach_current_thread() is idempotent for a thread already
     // bound to this device.
-    int drain_rc = -1;
+    int drain_rc = PTO_RUNTIME_ERR_INTERNAL;
     try {
         drain_rc = state->runner->attach_current_thread(state->runner->device_id());
         if (drain_rc != 0) {
             LOG_ERROR("simpler_wait_run: attach_current_thread failed: %d (%s)", drain_rc, state->trace_attrs);
         } else {
-            drain_rc = -1;
+            drain_rc = PTO_RUNTIME_ERR_INTERNAL;
             if (state->active_execution != nullptr) {
                 drain_rc = state->runner->drain_execution(*state->active_execution);
             }
         }
     } catch (...) {
-        drain_rc = -1;
+        drain_rc = PTO_RUNTIME_ERR_INTERNAL;
         LOG_ERROR("simpler_wait_run: drain threw (%s)", state->trace_attrs);
     }
     if (state->completion_rc == 0) state->completion_rc = drain_rc;
@@ -768,7 +771,7 @@ int simpler_wait_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
 
 int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     SimNativeRunContext *state = native_run_context(ctx, runtime, "simpler_finalize_run");
-    if (state == nullptr) return -1;
+    if (state == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     NativeRunPhase phase = state->phase.load(std::memory_order_acquire);
     const uint64_t trace_inv = state->trace_inv;
     const uint64_t trace_hid = state->trace_hid;
@@ -787,11 +790,11 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     // Bind the calling thread to this runner's simulated device before the
     // drain and the validation below. attach_current_thread() is idempotent
     // for a thread already bound to this device.
-    int attach_rc = -1;
+    int attach_rc = PTO_RUNTIME_ERR_INTERNAL;
     try {
         attach_rc = state->runner->attach_current_thread(state->runner->device_id());
     } catch (...) {
-        attach_rc = -1;
+        attach_rc = PTO_RUNTIME_ERR_INTERNAL;
     }
     if (attach_rc != 0) {
         LOG_ERROR("simpler_finalize_run: attach_current_thread failed: %d (%s)", attach_rc, state->trace_attrs);
@@ -799,7 +802,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     if (phase == NativeRunPhase::Running && launched) {
         int drain_rc = attach_rc;
         if (attach_rc == 0) {
-            drain_rc = -1;
+            drain_rc = PTO_RUNTIME_ERR_INTERNAL;
             try {
                 drain_rc = state->runner->drain_execution(*state->active_execution);
             } catch (...) {
@@ -812,20 +815,22 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     }
     emit_native_run_runner_wall(state);
 
-    int validation_rc = -1;
+    int validation_rc = PTO_RUNTIME_ERR_INTERNAL;
     try {
         if (!launched) state->runtime.set_gm_sm_ptr(nullptr);
         if (attach_rc == 0) {
             {
                 STRACE("chip.run.validate");
-                validation_rc = validate_runtime_impl(&state->runtime, &state->host_api, launched ? execution_rc : -1);
+                validation_rc = validate_runtime_impl(
+                    &state->runtime, &state->host_api, launched ? execution_rc : PTO_RUNTIME_ERR_INTERNAL
+                );
             }
             if (launched && execution_rc == 0) emit_device_phase_markers(state->runner);
         } else {
             validation_rc = attach_rc;
         }
     } catch (...) {
-        validation_rc = -1;
+        validation_rc = PTO_RUNTIME_ERR_INTERNAL;
     }
 
     if (state->prepared_execution != nullptr) {
@@ -874,18 +879,18 @@ uint64_t get_retained_temp_addr_ctx(DeviceContextHandle ctx, uint32_t slot_id) {
 }
 
 int simpler_unregister_callable(DeviceContextHandle ctx, int32_t callable_id) {
-    if (ctx == NULL) return -1;
+    if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         SimDeviceRunnerBase *runner = static_cast<SimDeviceRunnerBase *>(ctx);
         if (runner->native_run_active()) {
             LOG_ERROR(
                 "simpler_unregister_callable: native run must be finalized before mutating the callable registry"
             );
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         return runner->unregister_callable(callable_id);
     } catch (...) {
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 
@@ -931,7 +936,7 @@ int simpler_provision_dma_workspace(
     (void)ctx;
     (void)sdma_warmup_binary;
     (void)sdma_warmup_size;
-    return required_mask == 0 ? 0 : -1;
+    return required_mask == 0 ? 0 : PTO_RUNTIME_ERR_UNSUPPORTED;
 }
 
 }  // extern "C"

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -126,7 +126,7 @@ uint64_t SimDeviceRunnerBase::retained_temp_addr(uint32_t slot_id) const {
 int SimDeviceRunnerBase::setup_static_arena(
     uint32_t arena_bank, size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size
 ) {
-    if (arena_bank >= arena_banks_.size()) return -1;
+    if (arena_bank >= arena_banks_.size()) return PTO_RUNTIME_ERR_INTERNAL;
     ArenaBank &bank = this->arena_bank(arena_bank);
     // Three independent device_malloc'd buffers: GM heap, PTO2 SM, prebuilt
     // runtime arena. Split out from a single large allocation because the
@@ -156,7 +156,7 @@ int SimDeviceRunnerBase::setup_static_arena(
         arena.reserve(requested_size, DeviceArena::kDefaultBaseAlign);
         if (arena.commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
             arena.release();
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         cached_size = requested_size;
         return 0;
@@ -181,7 +181,7 @@ int SimDeviceRunnerBase::setup_static_arena(
         prebuilt_runtime_arena_cache_sm_base_ = nullptr;
         prebuilt_runtime_arena_cache_runtime_arena_base_ = nullptr;
         prebuilt_runtime_arena_cache_image_.clear();
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (arena_changed) {
         prebuilt_runtime_arena_cache_valid_ = false;
@@ -273,14 +273,14 @@ std::thread SimDeviceRunnerBase::create_thread(std::function<void()> fn) {
 int SimDeviceRunnerBase::attach_current_thread(int device_id) {
     if (device_id < 0) {
         LOG_ERROR("Invalid device_id: %d", device_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (device_id_ != -1 && device_id_ != device_id) {
         LOG_ERROR(
             "DeviceRunner already initialized on device %d; finalize before switching to device %d", device_id_,
             device_id
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Per-thread bind so sim hooks (TPUSH/TPOP, identity helpers) route through
@@ -306,7 +306,7 @@ int SimDeviceRunnerBase::prepare_launch_shape(Runtime &runtime, const CallConfig
             "launch_aicpu_num (%d) must be 0 (auto) or in range [2, %d]", config.aicpu_thread_num,
             PLATFORM_MAX_AICPU_THREADS
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     // A run always takes the whole simulated device; orchestration sizes its
     // cohorts from rt_available_cluster_count() rather than a per-call width.
@@ -316,7 +316,7 @@ int SimDeviceRunnerBase::prepare_launch_shape(Runtime &runtime, const CallConfig
     int num_aicore = block_dim * cores_per_blockdim_;
     if (num_aicore > RUNTIME_MAX_WORKER) {
         LOG_ERROR("num_aicore (%d) exceeds RUNTIME_MAX_WORKER (%d)", num_aicore, RUNTIME_MAX_WORKER);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     block_dim_ = block_dim;
@@ -432,12 +432,12 @@ int SimDeviceRunnerBase::stamp_orch_so(Runtime &runtime, int32_t cid) {
     // callable_id so the AICPU dispatches the right orch_so_table_ slot.
     if (cid < 0) {
         LOG_ERROR("stamp_orch_so: invalid callable_id=%d", cid);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     auto it = callables_.find(cid);
     if (it == callables_.end()) {
         LOG_ERROR("stamp_orch_so: callable_id=%d not registered", cid);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     runtime.set_active_callable_id(cid);
     return 0;
@@ -447,7 +447,7 @@ int SimDeviceRunnerBase::prepare_orch_so(Runtime &runtime) {
     const int32_t cid = runtime.get_active_callable_id();
     if (cid < 0) {
         LOG_ERROR("prepare_orch_so: no active callable_id; prepared-callable flow required");
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     return stamp_orch_so(runtime, cid);
 }
@@ -456,7 +456,7 @@ int SimDeviceRunnerBase::commit_device_register(int32_t cid) {
     auto it = callables_.find(cid);
     if (it == callables_.end()) {
         LOG_ERROR("commit_device_register: callable_id=%d not registered", cid);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (it->second.host_dlopen_handle != nullptr) {
         return 0;
@@ -473,7 +473,7 @@ int SimDeviceRunnerBase::launch_device_register(int32_t callable_id) {
     auto it = callables_.find(callable_id);
     if (it == callables_.end()) {
         LOG_ERROR("launch_device_register: callable_id=%d not registered", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (it->second.host_dlopen_handle != nullptr) {
         return 0;
@@ -519,19 +519,19 @@ int SimDeviceRunnerBase::record_device_orch_callable(
         LOG_ERROR(
             "record_device_orch_callable: callable_id=%d out of range [0, %d)", callable_id, MAX_REGISTERED_CALLABLE_IDS
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (orch_so_data == nullptr || orch_so_size == 0) {
         LOG_ERROR("record_device_orch_callable: empty orch SO for callable_id=%d", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (chip_buffer_hash == 0 || chip_dev == 0) {
         LOG_ERROR("record_device_orch_callable: missing chip buffer for callable_id=%d", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (callables_.count(callable_id) != 0) {
         LOG_ERROR("record_device_orch_callable: callable_id=%d already registered", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     const uint64_t hash = simpler::common::utils::elf_build_id_64(orch_so_data, orch_so_size);
@@ -561,19 +561,19 @@ int SimDeviceRunnerBase::record_host_orch_callable(
         LOG_ERROR(
             "record_host_orch_callable: callable_id=%d out of range [0, %d)", callable_id, MAX_REGISTERED_CALLABLE_IDS
         );
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (host_dlopen_handle == nullptr || host_orch_func_ptr == nullptr) {
         LOG_ERROR("record_host_orch_callable: null handle/fn for callable_id=%d", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (chip_buffer_hash == 0) {
         LOG_ERROR("record_host_orch_callable: missing chip buffer for callable_id=%d", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (callables_.count(callable_id) != 0) {
         LOG_ERROR("record_host_orch_callable: callable_id=%d already registered", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     CallableState state;
@@ -626,13 +626,13 @@ int SimDeviceRunnerBase::bind_callable_to_runtime(
     auto it = callables_.find(callable_id);
     if (it == callables_.end()) {
         LOG_ERROR("bind_callable_to_runtime: callable_id=%d not registered", callable_id);
-        return -1;
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
     const auto &state = it->second;
     for (const auto &kv : state.kernel_addrs) {
         if (kv.first < 0 || kv.first >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("bind_callable_to_runtime: func_id=%d out of range", kv.first);
-            return -1;
+            return PTO_RUNTIME_ERR_INTERNAL;
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -47,7 +47,8 @@
  * copied, or used for overlapping runs while it contains a prepared run. The
  * caller must serialize phase functions for a given context/storage pair;
  * poll/wait/finalize are not concurrent operations on the same run.
- * Error codes: 0 = success, negative = error.
+ * Error codes: 0 = success, negative = error — see the two disjoint negative
+ * bands documented on the PTO_RUNTIME_ERR_* enum below.
  */
 
 #pragma once
@@ -70,14 +71,41 @@ extern "C" {
 typedef void *RuntimeHandle;
 typedef void *DeviceContextHandle;
 
+/**
+ * Host-side status codes, and the band they are confined to.
+ *
+ * A negative return from any entry point below names one of two mechanisms, and
+ * a caller must be able to tell which from the number alone:
+ *
+ *   - a **device-latched** runtime code, reported as its own value negated.
+ *     Orchestration codes occupy 1..99 and scheduler codes 100 upwards, so the
+ *     latched band is -1..-PTO_RUNTIME_LATCHED_CODE_MAX (the codes themselves
+ *     are PTO2_ERROR_* in src/{arch}/runtime/{runtime}/common/pto_runtime_status.h;
+ *     the per-code triage tables are in
+ *     docs/troubleshooting/device-error-codes.md).
+ *   - a **host-side** code from this enum, at or below PTO_RUNTIME_ERR_BASE.
+ *
+ * The two bands are disjoint, and a static_assert in each runtime's
+ * runtime_maker.cpp holds them apart. So a host-side failure never reports -1
+ * (which is SCOPE_DEADLOCK) or -3 (FLOW_CONTROL_DEADLOCK): it reports
+ * PTO_RUNTIME_ERR_INTERNAL, or a more specific code from this band.
+ */
 enum {
-    PTO_RUNTIME_ERR_UNSUPPORTED = -2,
-    PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE = -3,
+    /* Ceiling on a device-latched code, and therefore the floor of the latched
+       band once negated. */
+    PTO_RUNTIME_LATCHED_CODE_MAX = 999,
+    /* Highest host-side code; the band descends from here. */
+    PTO_RUNTIME_ERR_BASE = -(PTO_RUNTIME_LATCHED_CODE_MAX + 1),
+    /* A host-side failure whose diagnosis is the log line that preceded it. */
+    PTO_RUNTIME_ERR_INTERNAL = PTO_RUNTIME_ERR_BASE,
+    /* The request names a capability this platform/runtime does not implement. */
+    PTO_RUNTIME_ERR_UNSUPPORTED = PTO_RUNTIME_ERR_BASE - 1,
+    PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE = PTO_RUNTIME_ERR_BASE - 2,
 };
 
 /** Return values from simpler_poll_run(). */
 enum {
-    SIMPLER_NATIVE_RUN_POLL_ERROR = -1,
+    SIMPLER_NATIVE_RUN_POLL_ERROR = PTO_RUNTIME_ERR_INTERNAL,
     SIMPLER_NATIVE_RUN_POLL_NOT_READY = 0,
     SIMPLER_NATIVE_RUN_POLL_COMPLETE = 1,
 };

--- a/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
+++ b/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
@@ -34,6 +34,7 @@
 #include "pto_shared_memory.h"
 #include "runtime.h"
 #include "task_args.h"
+#include "worker/pto_runtime_c_api.h"
 
 extern "C" int bind_callable_to_runtime_impl(
     Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
@@ -439,7 +440,7 @@ TEST_F(TrbRuntimeTempBufferTest, GrowAllocationFailureFailsBindWithoutLeak) {
     ChipStorageTaskArgs args = make_args(input, output);
     ArgDirection signature[2] = {ArgDirection::IN, ArgDirection::OUT};
 
-    EXPECT_EQ(bind_runtime(runtime, api_, args, signature, 2), -1);
+    EXPECT_EQ(bind_runtime(runtime, api_, args, signature, 2), PTO_RUNTIME_ERR_INTERNAL);
     EXPECT_EQ(fake_.retained_addr, nullptr);
     EXPECT_EQ(fake_.retained_size, 0u);
     EXPECT_TRUE(fake_.live_mallocs.empty());
@@ -455,7 +456,7 @@ TEST_F(TrbRuntimeTempBufferTest, FailedCopyOnTemporaryPathDoesNotFreeRetainedBuf
     args.add_tensor(make_tensor(input));
     ArgDirection signature[1] = {ArgDirection::IN};
 
-    EXPECT_EQ(bind_runtime(runtime, api_, args, signature, 1), -1);
+    EXPECT_EQ(bind_runtime(runtime, api_, args, signature, 1), PTO_RUNTIME_ERR_INTERNAL);
     // Retained buffer was allocated once for the grow and is NOT freed on the
     // error path (it lives on the slot for the next run); the slice lease is a
     // no-op, so no device_free happens here.

--- a/tests/ut/cpp/hierarchical/test_chip_run_lane.cpp
+++ b/tests/ut/cpp/hierarchical/test_chip_run_lane.cpp
@@ -69,7 +69,7 @@ int prepare_run(
     g_events.push_back("prepare" + std::to_string(descriptor->pipeline_slot));
     ++g_prepare_count[descriptor->pipeline_slot];
     if (g_reject_first_prepare[descriptor->pipeline_slot] && g_prepare_count[descriptor->pipeline_slot] == 1) {
-        return -3;
+        return PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE;
     }
     return g_prepare_rc[descriptor->pipeline_slot];
 }
@@ -379,6 +379,38 @@ TEST(ChipRunLaneTest, DirectIncompatibleSuccessorRetriesAfterPredecessorFence) {
     EXPECT_EQ(g_prepare_count[1], 2u);
     g_complete[1] = true;
     EXPECT_TRUE(second.done());
+    lane.close();
+    worker.finalize();
+}
+
+// PTO2_ERROR_FLOW_CONTROL_DEADLOCK (3) negated — the status a device latches for
+// a flow-control deadlock. Spelled out rather than included: the PTO2_ERROR_*
+// macros live in each runtime's private pto_runtime_status.h, which this
+// worker-level test does not compile against.
+constexpr int kLatchedFlowControlDeadlock = -3;
+
+// A latched deadlock is terminal. PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE once held
+// this same value, so the lane read the deadlock as "prepare at depth one instead"
+// and retried it — reporting a successful run over a device that had wedged.
+TEST(ChipRunLaneTest, LatchedFlowControlDeadlockIsTerminalRatherThanRetried) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    ChipStorageTaskArgs args{};
+
+    // A live predecessor is what puts the successor's prepare on the overlapping
+    // path, where the incompatible-prepare retry lives.
+    ChipRun first = lane.submit(1, args, CallConfig{});
+    g_prepare_rc[1] = kLatchedFlowControlDeadlock;
+    ChipRun second = lane.submit(1, args, CallConfig{});
+
+    EXPECT_TRUE(second.done());
+    EXPECT_THROW(second.wait_until(ChipRunLane::Deadline::max()), std::runtime_error);
+    EXPECT_EQ(g_prepare_count[1], 1u) << "latched deadlock was retried as an incompatible prepare";
+    EXPECT_FALSE(lane.poisoned());
+
+    g_complete[0] = true;
+    EXPECT_TRUE(first.done());
     lane.close();
     worker.finalize();
 }

--- a/tests/ut/py/test_resource_failure_summary.py
+++ b/tests/ut/py/test_resource_failure_summary.py
@@ -6,7 +6,8 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Tests for Resource phase failure summaries emitted by the root conftest."""
+"""Tests for root-conftest behavior: Resource phase failure summaries and
+device-poison classification."""
 
 from __future__ import annotations
 
@@ -99,3 +100,28 @@ def test_emit_resource_failure_summary_can_emit_compact_recap(capsys):
     assert "rc=2 devices=[7] duration=3.0s" in out
     assert "full output is in the Resource child group above" in out
     assert "hidden tail" not in out
+
+
+def test_device_poison_codes_key_on_the_host_band_not_the_latched_one():
+    """Poison classification reads host-band codes only.
+
+    The a5 DeviceRunner fail-fast ("marked unusable") and a poisoned card whose
+    CANN code an intermediate layer flattened both report the host-side generic
+    code, and both must trigger the worker rebuild. A device-latched code must
+    not: SCOPE_DEADLOCK is an orchestration bug, and treating it as a poisoned
+    context turns one red test into a misleading runtime-wide skip.
+
+    The two bands are defined in src/common/worker/pto_runtime_c_api.h; the set
+    here has to move with them, which is what this test pins.
+    """
+    cf = _load_root_conftest()
+
+    # Host band: PTO_RUNTIME_ERR_INTERNAL, plus the CANN sticky-error codes.
+    assert cf._is_device_runtime_error_msg("run failed with code -1000")
+    assert cf._is_device_runtime_error_msg("simpler_init failed with code 507899")
+
+    # Device-latched band (-1..-999): never poison, whatever the mechanism.
+    assert not cf._is_device_runtime_error_msg("run failed with code -1")  # SCOPE_DEADLOCK
+    assert not cf._is_device_runtime_error_msg("run failed with code -3")  # FLOW_CONTROL_DEADLOCK
+    assert not cf._is_device_runtime_error_msg("run failed with code -100")  # SCHEDULER_TIMEOUT
+    assert not any(-999 <= code <= -1 for code in cf._DEVICE_POISON_CODES)


### PR DESCRIPTION
## Summary

`docs/troubleshooting/device-error-codes.md` publishes the negative-status contract as "`runtime_status` is just the latched code negated", which reserves `-1..-11` for orchestration codes and `-100` downwards for scheduler codes. Three other meanings lived inside that reservation:

| Value | Contract meaning | Also occupied by | Consequence |
| ----- | ---------------- | ---------------- | ----------- |
| `-1` | SCOPE_DEADLOCK | every generic host-side failure | `failed with code -1` did not say whether a scope deadlocked on the device or an allocation failed on the host |
| `-2` | HEAP_RING_DEADLOCK | `PTO_RUNTIME_ERR_UNSUPPORTED` | mislabel only — the code had no producer |
| `-3` | FLOW_CONTROL_DEADLOCK | `PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE` | **harmful**: `chip_worker.cpp` turns that value into `PreparedRunIncompatible` and drives the depth-one fallback, so a flow-control deadlock was reported as "this prepared run is incompatible" and then silently retried |

`SIMPLER_NATIVE_RUN_POLL_ERROR` was `-1` as well.

The C API side moves, not the mapping. The doc's rule is published, and `tests/st/host_build_graph_validation` asserts `failed with code -5`, so the latched codes keep their numbers.

- `PTO_RUNTIME_ERR_*` now descends from `PTO_RUNTIME_ERR_BASE = -(PTO_RUNTIME_LATCHED_CODE_MAX + 1)` = `-1000`: `INTERNAL` `-1000`, `UNSUPPORTED` `-1001`, `PREPARED_INCOMPATIBLE` `-1002`. The band is derived from the ceiling, so one number moves both sides together.
- A host-side generic failure on the run path reports the new `PTO_RUNTIME_ERR_INTERNAL` instead of `-1`. The sweep covers what can leave as a run's rc: the exported C API entries, `DeviceRunner` / `DeviceRunnerBase`, the four runtime makers, the DFX collectors and their shared pool/profiler headers, and the AICPU loader.
- Each `runtime_maker.cpp` `static_assert`s the two bands apart — it is the file that produces both kinds of status, and the only one that includes both headers. The four `pto_runtime_status.h` copies bound the latched range as `-100..-PTO_RUNTIME_LATCHED_CODE_MAX` rather than "downwards". The assert's structural half holds for any latched code; its per-code half is a spot check on the highest one, which the comment now says.
- `PTO_RUNTIME_ERR_UNSUPPORTED` gains its first two producers, both SDMA-mask rejections (sim `simpler_provision_dma_workspace`, `DeviceRunnerBase::provision_dma_workspace`). It was previously dead.

The two in-tree C++ consumers already used the symbolic names. Three numeric consumers did not, and all three move here: a cpput stub that hardcoded `-3`, two `-1` expectations in `test_trb_runtime_temp_buffer`, and — the one that mattered — `conftest.py::_DEVICE_POISON_CODES`, which keyed on `-1` for the a5 `DeviceRunner` fail-fast. Leaving that would have stopped the rebuild-then-skip containment from firing on a poisoned card *and* started classifying a latched `SCOPE_DEADLOCK` as a poisoned device — the spurious-rebuild case the comment above that set warns about.

`PTO_RUNTIME_ERR_INTERNAL` replaces `-1` as a `return` **and** as a value: initializers, `catch (...)` assignments, and the `cleanup_failed_prepare(state, -1, true)` arguments (32 sites across the two `c_api_shared.cpp` files). Without that half, an exception inside prepare / launch / wait / finalize still reported itself as a scope deadlock.

### Regression barriers

Both fail before the fix and pass after — verified by temporarily restoring the old value, not by inspection:

| Test | Pins |
| --- | --- |
| `ChipRunLaneTest.LatchedFlowControlDeadlockIsTerminalRatherThanRetried` | a latched `-3` on a successor's prepare behind a live predecessor stays terminal. Under the collision the lane read it as `PREPARED_INCOMPATIBLE` and retried at depth one, reporting success over a wedged device. Pre-fix failure message: `latched deadlock was retried as an incompatible prepare`. |
| `test_device_poison_codes_key_on_the_host_band_not_the_latched_one` | the poison set keys on the host band and never on `-1..-999`. Nothing covered this classifier before, which is why the stale `-1` was silent. |

### Deliberately left on the private `-1` convention

The comm plane; dep_gen's own `{-1,-2,-3}` space and the weak fallbacks that must match it; helpers whose negative is a sentinel rather than a status (`resolve_block_dim`, `resolve_aicpu_thread_num`, `get_current_device_id`).

And one that is **not** closed: the **AICPU executor** still returns `-1` when a thread fails with nothing latched, and that value reaches the host rc — the `simpler_run failed with code -1` cascade documented in `sim-oversubscription-hang.md`. Closing it needs a device-side status contract rather than a host sweep, so that doc now carries the way to tell the two apart (a latched `-1` is always accompanied by an `orch_error_code=` / `error detail:` pair; the AICPU one is not).

### Incidental

Three of the four `pto_runtime_status.h` copies lose their `#ifndef` guards for `#pragma once`: the `host_build_graph` copies carried the `tensormap_and_ringbuffer` guard name verbatim, so a translation unit including both would have silently skipped the second. Their file comment named the wrong runtime for the same reason.

## Testing

Run on an a2a3 box (`onboard-arch-precheck` exit 0), hardware work through `task-submit`:

- [x] `a2a3sim` scene sweep — 59 passed, 8 skipped
- [x] `a5sim` scene sweep — 52 passed, 1 skipped
- [x] `runtime_fatal_codes` + `host_build_graph_validation` with `--manual include` on both sims — 15/15. Per-PR only 2 of 11 latched codes assert `code -N`; the rest are `@pytest.mark.manual`, so this run is what actually proves `-1` SCOPE_DEADLOCK / `-2` HEAP_RING / `-3` FLOW_CONTROL / `-5` INVALID_ARGS still surface unchanged
- [x] `a2a3` onboard sweep (`-m "not sdma" --exclude-level 4`) — 149 passed, 1 skipped
- [x] `a2a3` onboard sdma-marked scene tests — 3 passed
- [x] cpput — 115/115 non-hardware, plus the `requires_hardware_a2a3` label 1/1
- [x] pyut (`-m "not requires_hardware"`) — 1886 passed, 7 skipped; `requires_hardware` on a2a3 1/1
- [x] `clang-format`, `markdownlint-cli2` clean
