### PR TITLE
Fix: cap nanobind below 3 so a 3.9 build stops resolving a 3.10-only release

### DIFF
--- a/.github/workflows/_packaging.yml
+++ b/.github/workflows/_packaging.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install build + runtime deps in venv
         uses: ./.github/actions/setup-venv
         with:
-          packages: "scikit-build-core>=0.10.0 nanobind>=2.0.0 cmake>=3.15 ninja>=1.11 pytest>=6.0"
+          packages: "scikit-build-core>=0.10.0 nanobind>=2.0.0,<3 cmake>=3.15 ninja>=1.11 pytest>=6.0"
 
       - name: Run packaging matrix
         run: |

--- a/.github/workflows/_profiling-flags-smoke.yml
+++ b/.github/workflows/_profiling-flags-smoke.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
-          build-packages: "scikit-build-core nanobind cmake>=3.15"
+          build-packages: "scikit-build-core nanobind<3 cmake>=3.15"
           packages: "--no-build-isolation --config-settings=build.targets=_task_interface -e .[test]"
 
       - name: Run all profiling flag combos x 2 arches

--- a/.github/workflows/_st-npu-a2a3.yml
+++ b/.github/workflows/_st-npu-a2a3.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
-          build-packages: "scikit-build-core nanobind cmake>=3.15"
+          build-packages: "scikit-build-core nanobind<3 cmake>=3.15"
           packages: "--no-build-isolation --config-settings=build.targets=build_package_a2a3 .[test]"
           install-torch: "false"
           system-site-packages: "true"

--- a/.github/workflows/_st-npu-a5.yml
+++ b/.github/workflows/_st-npu-a5.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
-          build-packages: "scikit-build-core nanobind cmake>=3.15"
+          build-packages: "scikit-build-core nanobind<3 cmake>=3.15"
           packages: "--no-build-isolation --config-settings=build.targets=build_package_a5 .[test]"
           install-torch: "false"
           system-site-packages: "true"

--- a/.github/workflows/_st-sim-a2a3.yml
+++ b/.github/workflows/_st-sim-a2a3.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
-          build-packages: "scikit-build-core nanobind cmake>=3.15"
+          build-packages: "scikit-build-core nanobind<3 cmake>=3.15"
           packages: "--no-build-isolation --config-settings=build.targets=build_package_a2a3sim .[test]"
 
       - name: Run pytest scene tests

--- a/.github/workflows/_st-sim-a5.yml
+++ b/.github/workflows/_st-sim-a5.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
-          build-packages: "scikit-build-core nanobind cmake>=3.15"
+          build-packages: "scikit-build-core nanobind<3 cmake>=3.15"
           packages: "--no-build-isolation --config-settings=build.targets=build_package_a5sim .[test]"
 
       - name: Run pytest scene tests

--- a/.github/workflows/_ut-no-hardware.yml
+++ b/.github/workflows/_ut-no-hardware.yml
@@ -62,7 +62,7 @@ jobs:
         if: inputs.setup_variant == 'github'
         run: |
           pip install torch --index-url https://download.pytorch.org/whl/cpu
-          pip install 'scikit-build-core>=0.10.0' 'nanobind>=2.0.0' 'cmake>=3.15'
+          pip install 'scikit-build-core>=0.10.0' 'nanobind>=2.0.0,<3' 'cmake>=3.15'
           # Worker integration tests exercise both a2a3sim and a5sim.
           pip install --no-build-isolation \
             --config-settings=build.targets=build_package_sim -e '.[test]'

--- a/.github/workflows/_ut-npu-a2a3.yml
+++ b/.github/workflows/_ut-npu-a2a3.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
-          build-packages: "scikit-build-core nanobind cmake>=3.15"
+          build-packages: "scikit-build-core nanobind<3 cmake>=3.15"
           packages: "--no-build-isolation --config-settings=build.targets=build_package_a2a3 .[test]"
           install-torch: "false"
           system-site-packages: "true"

--- a/.github/workflows/_ut-npu-a5.yml
+++ b/.github/workflows/_ut-npu-a5.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-venv
         with:
-          build-packages: "scikit-build-core nanobind cmake>=3.15"
+          build-packages: "scikit-build-core nanobind<3 cmake>=3.15"
           packages: "--no-build-isolation --config-settings=build.targets=build_package_a5 .[test]"
           install-torch: "false"
           system-site-packages: "true"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,7 +108,7 @@ All workflows assume an activated project-local venv (see [`.claude/rules/venv-i
 python3 -m venv --system-site-packages .venv
 source .venv/bin/activate
 pip install --no-build-isolation \
-  'scikit-build-core>=0.10.0' 'nanobind>=2.0.0' 'cmake>=3.15' 'ninja>=1.11' 'pytest>=6.0' 'torch>=2.3'
+  'scikit-build-core>=0.10.0' 'nanobind>=2.0.0,<3' 'cmake>=3.15' 'ninja>=1.11' 'pytest>=6.0' 'torch>=2.3'
 pip install --no-build-isolation -e .
 ```
 

--- a/docs/python-packaging.md
+++ b/docs/python-packaging.md
@@ -123,7 +123,7 @@ For developers who don't want to use pip at all:
 
 ```bash
 . .venv/bin/activate
-pip install 'scikit-build-core>=0.10.0' 'nanobind>=2.0.0' 'cmake>=3.15' 'ninja>=1.11' 'pytest>=6.0' 'torch>=2.3'  # one-time
+pip install 'scikit-build-core>=0.10.0' 'nanobind>=2.0.0,<3' 'cmake>=3.15' 'ninja>=1.11' 'pytest>=6.0' 'torch>=2.3'  # one-time
 cmake -S . -B build/cmake_only -Dnanobind_DIR=$(python -c 'import nanobind; print(nanobind.cmake_dir())')
 cmake --build build/cmake_only
 export PYTHONPATH=$(pwd):$(pwd)/python
@@ -158,7 +158,7 @@ Any change that touches:
 ```bash
 # Locally — same script CI runs.
 source .venv/bin/activate
-pip install 'scikit-build-core>=0.10.0' 'nanobind>=2.0.0' 'cmake>=3.15' 'ninja>=1.11' 'pytest>=6.0' 'torch>=2.3'  # one-time
+pip install 'scikit-build-core>=0.10.0' 'nanobind>=2.0.0,<3' 'cmake>=3.15' 'ninja>=1.11' 'pytest>=6.0' 'torch>=2.3'  # one-time
 bash tools/verify_packaging.sh
 ```
 

--- a/docs/troubleshooting/macos-build.md
+++ b/docs/troubleshooting/macos-build.md
@@ -201,7 +201,7 @@ clang-tidy runs.
 #    are noarch, so this matters only for ABI flags during simpler's
 #    own link step. (See "Why source-install" below.)
 pip uninstall -y simpler nanobind pybind11
-pip install --no-binary nanobind --no-binary pybind11 nanobind pybind11
+pip install --no-binary nanobind --no-binary pybind11 'nanobind<3' pybind11
 
 # 2. Wipe build/ to drop any cached compile_commands.json or .a files
 #    that were produced with the previous compiler.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,12 @@
 # -----------------------------------------------------------------------------------------------------------
 
 [build-system]
-requires = ["scikit-build-core>=0.10.0", "nanobind>=2.0.0", "cmake>=3.15"]
+# nanobind is capped below 3: nanobind 3.x requires Python >= 3.10 in its
+# nanobind-config.cmake, and this project supports >= 3.9 (see requires-python
+# below). nanobind ships no requires-python metadata, so pip installs 3.x onto a
+# 3.9 interpreter happily and the floor only surfaces as a cmake configure
+# error. Raise the cap together with requires-python, never before it.
+requires = ["scikit-build-core>=0.10.0", "nanobind>=2.0.0,<3", "cmake>=3.15"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/tools/verify_packaging.sh
+++ b/tools/verify_packaging.sh
@@ -109,7 +109,7 @@ import torch  # noqa: E402,F401
 
 required = (
     "scikit-build-core>=0.10.0",
-    "nanobind>=2.0.0",
+    "nanobind>=2.0.0,<3",
     "cmake>=3.15",
     "pytest>=6.0",
     "torch>=2.3",
@@ -142,7 +142,7 @@ else:
     print("ninja executable: not found; CMake will select another generator")
 PY
     echo "ERROR: venv missing or has unsupported packaging dependencies. Install with:" >&2
-    echo "  pip install 'scikit-build-core>=0.10.0' 'nanobind>=2.0.0' 'cmake>=3.15' 'ninja>=1.11' 'pytest>=6.0' 'torch>=2.3'" >&2
+    echo "  pip install 'scikit-build-core>=0.10.0' 'nanobind>=2.0.0,<3' 'cmake>=3.15' 'ninja>=1.11' 'pytest>=6.0' 'torch>=2.3'" >&2
     exit 1
 }
 


### PR DESCRIPTION
## Summary

`nanobind 3.0.0` was published to PyPI on **2026-08-22 at 04:23:29Z**. It requires Python ≥ 3.10 in `nanobind-config.cmake`, but its distribution declares **no `requires-python`** (`nanobind-3.0.0-py3-none-any.whl`, `requires_python: null`) — so pip installs it onto a 3.9 interpreter without complaint and the floor only surfaces later, as a cmake configure error. `pyproject.toml` asked for `nanobind>=2.0.0` with **no upper bound**, so from that moment every build resolved it.

This project declares `requires-python = ">=3.9"`, and `st-network1-onboard-a2a3` runs on a **3.9.9** interpreter — in spec. It has failed on every run since the release, including on branches that predate it:

```text
CMake Error at .../nanobind/cmake/nanobind-config.cmake:8 (message):
  nanobind requires Python 3.10 or newer (found Python 3.9.9).
Call Stack (most recent call first):
  CMakeLists.txt:26 (find_package)
```

| when | run | `st-network1-onboard-a2a3` | |
| --- | --- | --- | --- |
| 08-21 20:06 | 32521424184 | pass | |
| 08-22 03:10 | 32547966005 | pass | |
| 08-22 03:34 | 32549082432 | **pass** | last green — 49 min before the upload |
| **08-22 04:23** | — | — | **nanobind 3.0.0 hits PyPI** |
| 08-22 06:25 | 32556569537 | fail | `codex/fix-hbg-null-pending-task-1928` |
| 08-23 02:13 | 32611230014 | fail | #1960 |
| 08-23 02:59 | 32614015493 | fail | #1960 after a force-push |

Not a runner drift: the **passing** runs were on Python 3.9.9 too (`cp39` wheel tags throughout). The interpreter is the pre-condition; the third-party release is the change.

Why only that lane: every other runner happens to sit on 3.10 — `st-onboard-a2a3` on `runner-dev4-7` at 3.10.20, the GitHub-hosted matrix pinned by `setup-python` — so the same nanobind 3.0.0 goes unnoticed there.

## The fix

`nanobind>=2.0.0,<3`, at **every** site that installs or checks nanobind, so no consumer disagrees with the build requirement:

| site | why it matters |
| --- | --- |
| `pyproject.toml` | the build requirement itself |
| 9 workflow strings (`_st-npu-*`, `_ut-npu-*`, `_st-sim-*`, `_ut-no-hardware`, `_packaging`, `_profiling-flags-smoke`) | what CI resolves |
| `tools/verify_packaging.sh` — the `required` tuple **and** the install hint it prints | `_packaging.yml:113` runs it and `docs/getting-started.md:119` calls it *the single source of truth* for an install; a verifier that accepted 3.x would certify a build the requirement then refuses |
| `docs/getting-started.md`, `docs/python-packaging.md` (x2), `docs/troubleshooting/macos-build.md` | a contributor copying these today gets 3.0.0 |

There is no uncapped nanobind install or check left: `grep -rIn "nanobind[>=<!~]" . | grep -v ",<3" | grep -v "nanobind<3"` is empty.

This restores the resolution the tree has always been built against — **2.15.0, whose own cmake floor is `VERSION_LESS "3.9"`**, matching this project's support range exactly:

| | nanobind 2.15.0 | nanobind 3.0.0 |
| --- | --- | --- |
| cmake floor | `>= 3.9` | `>= 3.10` |
| `requires_python` metadata | none | none |
| on Python 3.9.9 | builds | fails at configure |

The cap is the fix rather than a workaround: an unbounded major-version floor lets a third-party release change every lane silently, and nanobind 3.x is a major bump this tree has never been validated against on **any** interpreter.

### Two details worth a reviewer's eye

- **The constraint is bare, not quoted**, in the `build-packages` / `packages` strings. Those reach pip through an unquoted `$VAR` expansion in `setup-venv`, and expansion results are not reparsed for redirection operators — the same reason the neighbouring `cmake>=3.15` already works. Quoting would make pip see a requirement literally named `'nanobind<3'`. Verified by expanding the string in bash and checking the resulting argv (and that no `=3.15`/`3` file appears). `_ut-no-hardware.yml` is a direct `pip install` with its own quoting, so its form keeps the quotes.
- **Lifting the cap is a deliberate two-step, in this order:** raise the runner to Python ≥ 3.10 and `requires-python` with it, *then* allow nanobind 3.x. The other order drops 3.9 support silently.

## Testing

Verified in a fresh worktree whose venv resolves the capped requirement to 2.15.0:

- [x] `pip install --no-build-isolation -e '.[test]'` succeeds
- [x] pyut (`-m "not requires_hardware"`) — 1885 passed, 7 skipped
- [x] `a2a3sim` scene sweep — 59 cases, 0 failures
- [x] the full `tools/verify_packaging.sh` passes end-to-end — all five install paths x two entry points, reporting `nanobind: 2.15.0`
- [x] `pyproject.toml` parses; the specifier admits 2.15.0 and 2.0.0 and excludes 3.0.0 (checked through `packaging`, not by reading the string); all 19 workflow YAMLs parse; `bash -n` clean on the verifier
- [x] the verifier's specifier — read back out of the script so it cannot drift — accepts 2.0.0 / 2.15.0, rejects 3.0.0 / 3.1.0, and equals the one in `pyproject.toml`
- [x] against `--index-url https://pypi.org/simple`, the **uncapped** `nanobind>=2.0.0` resolves to `3.0.0` — the regression this pins shut. (This box's default index is a mirror that has not synced 3.0.0, which is why the capped and uncapped resolutions look identical locally without the explicit index.)

Touching the reusable `_*.yml` workflows means the full matrix runs on this PR, per `.claude/rules/ci-change-detection.md` §2 — including the `st-network1-onboard-a2a3` lane this is meant to unbreak.

Found while triaging the red check on #1960; that PR is unrelated to this failure and needs no change.
