### PR TITLE
Refactor: hbg's orchestrator and TensorMap are host-owned, not arena regions

### DIFF
--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -308,7 +308,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         }
 
         if (boot_ok) {
-            runtime_finalize_after_wire(rt, sched_ctx_.aic_count(), sched_ctx_.aiv_count());
+            runtime_bind_ops(rt);
             runtime->set_slot_states_ptr(nullptr);
 
             sched_ctx_.bind_runtime(rt);

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -84,7 +84,7 @@ correct for the layout it was taken in, so `compact_live_image` re-takes every o
 of them against the shipped image; the copy to the device moves a field and its
 target together and leaves them all correct.
 
-### 3.1 What Ships: the Arena's Three Zones
+### 3.1 What Ships: the Arena's Two Zones
 
 Three rules decide every byte of the runtime arena:
 
@@ -97,28 +97,30 @@ Three rules decide every byte of the runtime arena:
 3. **Initialize once.** A region whose content does not differ between runs is
    established once, not re-established per bind.
 
-They partition the arena into three contiguous zones, and `runtime_reserve_layout`
+They partition the arena into two contiguous zones, and `runtime_reserve_layout`
 reserves them in this order:
 
 | Zone | Regions | Copied | Allocated on device | Written by |
 | ---- | ------- | ------ | ------------------- | ---------- |
-| copied | `[off_copied_begin, off_copied_end)`: the runtime header | whole zone, one copy | yes | host |
 | device-only | `sm_handle`, the completion mailbox, `PTO2SchedulerState` and its thirteen queue slot arrays | never | yes | AICPU at boot |
-| host-only | orchestrator block: `fanin_seen_epoch` / `scope_tasks` / TensorMap, ~9.3 MB | never | **no** | host, during graph construction |
+| copied | `[off_copied_begin, off_copied_end)`: the runtime header | whole zone, one copy | yes | host |
 
-The copied zone leads, so `bind` is a single contiguous `copy_to_device` starting
-at the arena base. Both bounds are layout fields, so no consumer infers a boundary
-from which region happens to be reserved first — `bind_callable_to_runtime_impl`
-asserts only that they are ordered and in range.
+The copied zone comes last, so `bind` is a single contiguous `copy_to_device`
+starting at `off_copied_begin` — and the device's shared-memory tail begins
+exactly where that zone ends. Both bounds are layout fields, so no consumer infers
+a boundary from which region happens to be reserved first —
+`bind_callable_to_runtime_impl` asserts only that they are ordered and in range.
 
-**Why the host-only zone comes last.** No device code dereferences a pointer into
-the orchestrator block — hbg has no device-side orchestrator, and the one
-orchestrator field the scheduler reads, `inline_completed_tasks`, is a scalar in
-the runtime header. Putting the block at the tail lets `setup_static_arena` request
-only `layout.device_bytes`, the copied + device-only prefix, so those ~9.3 MB are
-never reserved on the device at all. `runtime_wire_host_only_pointers` is therefore
-host-only, and `runtime_clear_host_only_pointers` drops those pointers before the
-copied zone is uploaded so no host address crosses the boundary.
+**Why the orchestrator is not in the arena at all.** hbg has no device-side
+orchestrator, so nothing on the device reads its state: not the `fanin_seen_epoch`
+table, not the scope arrays, not the TensorMap (~9.3 MB between them). It is
+therefore a plain host object that owns those arrays — `PTO2OrchestratorState::init`
+allocates them — and `PTO2Runtime` reaches it through a pointer that `bind` drops
+before the copied zone is uploaded, so no host address crosses the boundary. A
+`static_assert` keeps `PTO2Runtime` trivially copyable, which is what forbids
+putting an owning member back inside it. The one orchestrator value the device-side
+scheduler reads, the count of tasks completed inline during orchestration, is a
+scalar `rt_orchestration_done` publishes into the runtime header.
 
 **Why the scheduler state is device-written.** `PTO2SchedulerState` holds no
 per-run content: `sm_header` and the ring pointer derive from a pooled SM base,

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -565,14 +565,17 @@ int32_t run_host_orchestration(
     std::memset(host_sm, 0, sm_segs.descriptors);
 
     // Re-point the orchestrator half at the host SM (scheduler keeps device SM).
-    // init_data_from_layout resets the orchestrator state, so this is safe.
-    if (!rt->orchestrator.init_data_from_layout(
-            layout.orch, host_arena, host_sm, gm_heap, eff_heap_sizes[0], eff_task_window_sizes[0]
-        )) {
-        LOG_ERROR("host-orch: orchestrator re-init against host SM failed");
+    // Host-owned and destroyed with this frame, so rt->orchestrator is dropped on
+    // every exit — it must never outlive the object it names.
+    PTO2OrchestratorState orchestrator;
+    rt->orchestrator = &orchestrator;
+    RAIIScopeGuard orchestrator_binding([rt]() {
+        rt->orchestrator = nullptr;
+    });
+    if (!orchestrator.init(host_sm, gm_heap, eff_heap_sizes[0], eff_task_window_sizes[0], rt->scheduler)) {
+        LOG_ERROR("host-orch: orchestrator init against host SM failed");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
-    rt->orchestrator.wire_arena_pointers(layout.orch, host_arena, rt->scheduler);
 
     PTO2SharedMemoryHandle host_sm_handle;
     if (!host_sm_handle.init_per_ring(host_sm, sm_size, eff_task_window_sizes, eff_heap_sizes)) {
@@ -585,16 +588,16 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: failed to allocate Graph host state");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
-    GraphHostStateBinding graph_binding(rt->orchestrator, graph_state.get());
+    GraphHostStateBinding graph_binding(orchestrator, graph_state.get());
 
     const int32_t block_dim = runtime->get_worker_count() / PLATFORM_CORES_PER_BLOCKDIM;
     if (block_dim < 1) {
         LOG_ERROR("host-orch: worker_count %d yields no clusters", runtime->get_worker_count());
         return PTO_RUNTIME_ERR_INTERNAL;
     }
-    runtime_finalize_after_wire(
-        rt, block_dim * PLATFORM_AIC_CORES_PER_BLOCKDIM, block_dim * PLATFORM_AIV_CORES_PER_BLOCKDIM
-    );
+    runtime_bind_ops(rt);
+    orchestrator.total_cluster_count = block_dim * PLATFORM_AIC_CORES_PER_BLOCKDIM;
+    orchestrator.total_aiv_count = block_dim * PLATFORM_AIV_CORES_PER_BLOCKDIM;
     rt->mode = PTO2_MODE_EXECUTE;
 
     const auto *entry_points = reinterpret_cast<const HostOrchEntryPoints *>(host_orch_func_ptr);
@@ -642,7 +645,7 @@ int32_t run_host_orchestration(
     // edges. Uploading it would launch the device on an incomplete graph and surface
     // the cause as whatever the device notices second, usually a scheduler timeout.
     const int32_t orch_error = pto2_sm_layout::orch_error_code_addr(host_sm)->load(std::memory_order_acquire);
-    if (orch_error != PTO2_ERROR_NONE || rt->orchestrator.fatal) {
+    if (orch_error != PTO2_ERROR_NONE || orchestrator.fatal) {
         // The latched code is the diagnosis, so it is what the caller sees — through the
         // same mapping the run path uses, since a caller cannot tell which of the two
         // noticed. A fatal with no code left to read is the only generic failure.
@@ -652,7 +655,7 @@ int32_t run_host_orchestration(
         LOG_RUNTIME_FAILURE(orch_error, PTO2_ERROR_NONE, status);
         LOG_ERROR(
             "host-orch: refusing to upload an incomplete graph after %" PRIu64 " heap bytes",
-            rt->orchestrator.ring.task_allocator.heap_used_bytes()
+            orchestrator.ring.task_allocator.heap_used_bytes()
         );
         return status;
     }
@@ -662,7 +665,7 @@ int32_t run_host_orchestration(
         char attrs[96];
         snprintf(
             attrs, sizeof(attrs), "tasks=%" PRId32 " heap_used=%" PRIu64, total_tasks,
-            rt->orchestrator.ring.task_allocator.heap_used_bytes()
+            orchestrator.ring.task_allocator.heap_used_bytes()
         );
         record_bind_phase(HostPhaseKind::BindHostOrch, t_orch_ns, attrs);
     }
@@ -714,7 +717,7 @@ int32_t run_host_orchestration(
     // What this bind actually put in the pools. The orchestrator's cursors are the
     // exact populated extent of each one — no scan of the mirror is needed, and the
     // image ships that much rather than the worst case the mirror is dimensioned for.
-    const PTO2OrchestratorState &orch_state = rt->orchestrator;
+    const PTO2OrchestratorState &orch_state = orchestrator;
     const pto2_sm_layout::BindUsage bind_usage{
         nt,
         static_cast<uint64_t>(orch_state.fanin_pool_cursor),
@@ -774,10 +777,10 @@ int32_t run_host_orchestration(
     // graph_context into it, and compaction is what carries those slots.
     stage_graph_submissions(staged_submissions, upload_base + copied_bytes + image_bytes, arena_dev + off_submissions);
 
-    // The orchestrator has finished, so its pointers into the host-only tail have
-    // no further reader on either side — and this header is about to be copied, so
-    // leaving them would carry host addresses to the device.
-    runtime_clear_host_only_pointers(rt);
+    // The copied zone carries no host address: the orchestrator is host-only and
+    // no device code may reach host memory through the image. Its work is done, so
+    // the pointer goes early rather than at the guard's scope exit.
+    rt->orchestrator = nullptr;
     std::memcpy(upload_base, static_cast<const char *>(host_arena.base()) + layout.off_copied_begin, copied_bytes);
     const uint64_t compacted = pto2_sm_layout::compact_live_image(
         static_cast<const char *>(host_sm), eff_task_window_sizes[0], bind_usage, upload_base + copied_bytes
@@ -1089,33 +1092,24 @@ extern "C" int bind_callable_to_runtime_impl(
     }
     {
         char attrs[64];
-        snprintf(
-            attrs, sizeof(attrs), "bytes=%" PRIu64 " device=%" PRIu64, static_cast<uint64_t>(layout.arena_size),
-            static_cast<uint64_t>(layout.device_bytes)
-        );
+        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, static_cast<uint64_t>(layout.arena_size));
         record_bind_phase(HostPhaseKind::BindArenaBuild, t_arena_build_ns, attrs);
     }
 
     const int64_t t_static_arena_ns = bind_now_ns();
-    // Two things this call does not ask for at full size.
-    //
-    // device_bytes, not arena_size: the host-only zone at the arena's tail is
-    // dep-computation scratch no device code reads, so reserving device memory for
-    // it would be dead space for the length of the run.
-    //
     // No pooled shared memory: hbg's shared-memory image is the tail of its own
     // runtime-arena region, so this asks for 0 and leaves that pool uncommitted.
     // The arena is asked for only up to that tail, whose size is the submitted task
     // count — run_host_orchestration grows it once it knows. The heap must exist
     // first either way: the orchestrator hands out device heap addresses as it
     // places tasks.
-    if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, layout.device_bytes) != 0) {
+    if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, layout.arena_size) != 0) {
         LOG_ERROR("Failed to setup pooled static arena");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
         char attrs[96];
-        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " arena=%" PRIu64, total_heap_size, layout.device_bytes);
+        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " arena=%" PRIu64, total_heap_size, layout.arena_size);
         record_bind_phase(HostPhaseKind::BindStaticArena, t_static_arena_ns, attrs);
     }
 
@@ -1162,7 +1156,6 @@ extern "C" int bind_callable_to_runtime_impl(
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     runtime_wire_arena_pointers(host_arena, layout, rt);
-    runtime_wire_host_only_pointers(host_arena, layout, rt);
     // Stash the layout inside the PTO2Runtime image so the AICPU can recover every
     // arena-internal offset after the copy. It is written before orchestration
     // because orchestration is what performs that copy, and the runtime header is

--- a/src/a2a3/runtime/host_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/host_build_graph/orchestration/pto_orchestration_api.h
@@ -99,7 +99,7 @@ typedef struct PTO2RuntimeOps {
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const CoreTaskArgs &args);
     TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const CoreTaskArgs &args);
 
-    // This-run core geometry from runtime_finalize_after_wire: MIX clusters
+    // This-run core geometry latched by the host bind: MIX clusters
     // (one AIC each) and standalone AIV cores.
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -395,8 +395,6 @@ struct GraphRecording {
     // (the shape every generated orchestration uses) would therefore record a
     // node with no edge to its actual producer, and the Definition would replay
     // a DAG the same body never had when submitted task by task.
-    DeviceArena tensor_map_arena;
-    PTO2TensorMapLayout tensor_map_layout{};
     PTO2TensorMap tensor_map{};
     bool tensor_map_ready{false};
     // Scope depth as the body sees it. begin_scope/end_scope leave the real
@@ -556,19 +554,14 @@ graph_classify_scalar(const GraphRecording &recording, const ArgT &args, int32_t
 // is no ordinary-path fallback left to take.
 constexpr int32_t GRAPH_RECORD_TENSORMAP_POOL_SIZE = 16384;
 
-// Stand the recording's hazard map up on its own host allocation. Failure is
+// Stand the recording's hazard map up on its own allocation. Failure is
 // reported to the caller, which is still before the outer shell is submitted and
 // so can still take the ordinary path, rather than producing a Definition with
 // inferred edges missing.
 bool graph_recording_init_tensor_map(GraphRecording &recording) {
-    recording.tensor_map_layout = PTO2TensorMap::reserve_layout(
-        recording.tensor_map_arena, PTO2_TENSORMAP_NUM_BUCKETS, GRAPH_RECORD_TENSORMAP_POOL_SIZE, GRAPH_MAX_NODES
-    );
-    if (recording.tensor_map_arena.commit() == nullptr) return false;
-    if (!recording.tensor_map.init_data_from_layout(recording.tensor_map_layout, recording.tensor_map_arena)) {
+    if (!recording.tensor_map.init(PTO2_TENSORMAP_NUM_BUCKETS, GRAPH_RECORD_TENSORMAP_POOL_SIZE, GRAPH_MAX_NODES)) {
         return false;
     }
-    recording.tensor_map.wire_arena_pointers(recording.tensor_map_layout, recording.tensor_map_arena);
     recording.tensor_map_ready = true;
     return true;
 }
@@ -940,7 +933,8 @@ static uint32_t next_fanin_seen_epoch(PTO2OrchestratorState *orch) {
     uint32_t next = orch->fanin_seen_current_epoch + 1;
     if (next == 0) {
         memset(
-            orch->fanin_seen_epoch, 0, static_cast<size_t>(orch->sm_header->ring.task_window_size) * sizeof(uint32_t)
+            orch->fanin_seen_epoch.get(), 0,
+            static_cast<size_t>(orch->sm_header->ring.task_window_size) * sizeof(uint32_t)
         );
         next = 1;
     }
@@ -975,7 +969,7 @@ struct PTO2FaninBuilder {
         if (prod_ring >= PTO2_MAX_RING_DEPTH || prod_slot < 0) {
             return false;
         }
-        uint32_t *seen = orch->fanin_seen_epoch;
+        uint32_t *seen = orch->fanin_seen_epoch.get();
         uint32_t slot = static_cast<uint32_t>(prod_slot);
         if (seen[slot] == seen_epoch) {
             return true;
@@ -1152,11 +1146,9 @@ static bool prepare_task(
 
 static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state) {
     if (orch->scope_tasks_size >= orch->scope_tasks_capacity) {
-        // scope_tasks lives in the per-Worker arena (single backing allocation),
-        // so realloc is not legal. Capacity is the total in-flight slot budget
-        // (the runtime task window; see reserve_layout) — hitting it means the
-        // ring is saturated, so no further push could succeed regardless of
-        // buffer growth.
+        // Capacity is the total in-flight slot budget (the runtime task window;
+        // see PTO2OrchestratorState::init) — hitting it means the ring is
+        // saturated, so no further push could succeed regardless of buffer growth.
         orch->report_fatal(
             PTO2_ERROR_SCOPE_TASKS_OVERFLOW, __FUNCTION__,
             "scope_tasks buffer saturated at %d entries (all rings full)", orch->scope_tasks_capacity

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -85,64 +85,67 @@ static constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_CYCLES =
 
 static TaskOutputTensors
 submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
-    return rt->orchestrator.submit_task(mixed_kernels, args);
+    return rt->orchestrator->submit_task(mixed_kernels, args);
 }
 
 static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const CoreTaskArgs &args) {
-    return rt->orchestrator.alloc_tensors(args);
+    return rt->orchestrator->alloc_tensors(args);
 }
 
 static TaskOutputTensors submit_dummy_task_impl(PTO2Runtime *rt, const CoreTaskArgs &args) {
-    return rt->orchestrator.submit_dummy_task(args);
+    return rt->orchestrator->submit_dummy_task(args);
 }
 
 static GraphScopeResult graph_begin_impl(PTO2Runtime *rt, uint64_t graph_key, const GraphTaskArgs &args) {
     if (rt == nullptr) return GraphScopeResult{};
-    return rt->orchestrator.graph_begin(graph_key, args, rt->active_callable_hash);
+    return rt->orchestrator->graph_begin(graph_key, args, rt->active_callable_hash);
 }
 
 static bool graph_prepare_impl(PTO2Runtime *rt, void *recording_handle, const GraphTaskArgs &args) {
-    return rt != nullptr && rt->orchestrator.graph_prepare(recording_handle, args);
+    return rt != nullptr && rt->orchestrator->graph_prepare(recording_handle, args);
 }
 
 static void graph_abort_impl(PTO2Runtime *rt, void *recording_handle) {
-    if (rt != nullptr) rt->orchestrator.graph_abort(recording_handle);
+    if (rt != nullptr) rt->orchestrator->graph_abort(recording_handle);
 }
 
-static bool graph_end_impl(PTO2Runtime *rt) { return rt != nullptr && rt->orchestrator.graph_end(); }
+static bool graph_end_impl(PTO2Runtime *rt) { return rt != nullptr && rt->orchestrator->graph_end(); }
 
 static void graph_commit_impl(PTO2Runtime *rt) {
-    if (rt != nullptr) rt->orchestrator.graph_commit();
+    if (rt != nullptr) rt->orchestrator->graph_commit();
 }
 
 void rt_scope_begin(PTO2Runtime *rt) {
     PTO2ScopeMode mode = rt->pending_scope_mode;
     rt->pending_scope_mode = PTO2ScopeMode::AUTO;
-    rt->orchestrator.begin_scope(mode);
+    rt->orchestrator->begin_scope(mode);
 }
 
-void rt_scope_end(PTO2Runtime *rt) { rt->orchestrator.end_scope(); }
+void rt_scope_end(PTO2Runtime *rt) { rt->orchestrator->end_scope(); }
 
 void rt_orchestration_done(PTO2Runtime *rt) {
     // Host orchestration calls this runtime entry directly rather than the
     // orchestration-SO wrapper. Commit here as well so an all-Graph entry has a
     // final synchronization point for its asynchronous recording and deferred
     // outer shells even when no later non-Graph task forced an earlier commit.
-    rt->orchestrator.graph_commit();
-    rt->orchestrator.mark_done();
+    rt->orchestrator->graph_commit();
+    rt->orchestrator->mark_done();
+    // The orchestrator itself never crosses to the device, so the count of tasks
+    // it completed inline is published into the header that does.
+    rt->inline_completed_tasks = rt->orchestrator->inline_completed_tasks;
 }
 
-static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator.fatal; }
+static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator->fatal; }
 
 void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     if (fmt == nullptr || fmt[0] == '\0') {
-        rt->orchestrator.report_fatal(error_code, func, nullptr);
+        rt->orchestrator->report_fatal(error_code, func, nullptr);
     } else {
         char message[1024];
         vsnprintf(message, sizeof(message), fmt, args);
-        rt->orchestrator.report_fatal(error_code, func, "%s", message);
+        rt->orchestrator->report_fatal(error_code, func, "%s", message);
     }
     va_end(args);
 }
@@ -157,7 +160,7 @@ MAYBE_UNINITIALIZED_BEGIN
 static bool
 wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_consumers, const char *caller) {
     PTO2TaskId owner = tensor.owner_task_id;
-    PTO2OrchestratorState &orch = rt->orchestrator;
+    PTO2OrchestratorState &orch = *rt->orchestrator;
 
     // Segmented wait: collect up to kSegmentCap producer slots, then flush by
     // spinning on each. When the segment fills, we wait for the accumulated
@@ -324,7 +327,7 @@ uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndi
     uint64_t elem_addr = tensor.buffer.addr + flat_offset * elem_size;
     uint64_t result = 0;
     if (!host_tensor_read(rt->tensor_access, elem_addr, &result, elem_size)) {
-        rt->orchestrator.report_fatal(
+        rt->orchestrator->report_fatal(
             PTO2_ERROR_INVALID_ARGS, __FUNCTION__,
             "no host view for device address %#llx (%llu bytes): during host orchestration only tensors the "
             "runtime staged are readable, not runtime-created or child-memory buffers",
@@ -355,7 +358,7 @@ void set_tensor_data(
     uint64_t elem_size = get_element_size(tensor.dtype);
     uint64_t elem_addr = tensor.buffer.addr + flat_offset * elem_size;
     if (!host_tensor_write(rt->tensor_access, elem_addr, &value, elem_size)) {
-        rt->orchestrator.report_fatal(
+        rt->orchestrator->report_fatal(
             PTO2_ERROR_INVALID_ARGS, __FUNCTION__,
             "no writable host view for device address %#llx (%llu bytes): during host orchestration only tensors "
             "the runtime staged are writable, not runtime-created or child-memory buffers",
@@ -372,8 +375,8 @@ void set_tensor_data(
 static void scope_set_site_impl(const char *file, int line) { scope_stats_set_pending_site(file, line); }
 #endif
 
-static int32_t available_cluster_count_impl(PTO2Runtime *rt) { return rt->orchestrator.total_cluster_count; }
-static int32_t available_aiv_count_impl(PTO2Runtime *rt) { return rt->orchestrator.total_aiv_count; }
+static int32_t available_cluster_count_impl(PTO2Runtime *rt) { return rt->orchestrator->total_cluster_count; }
+static int32_t available_aiv_count_impl(PTO2Runtime *rt) { return rt->orchestrator->total_aiv_count; }
 
 static const PTO2RuntimeOps s_runtime_ops = {
     .submit_task = submit_task_impl,
@@ -411,15 +414,10 @@ static const PTO2RuntimeOps s_runtime_ops = {
 //
 // Layout / init_data / wire / destroy live in
 // runtime/shared/pto_runtime2_init.cpp so the host build can pre-populate the
-// prebuilt arena image. The pieces below — wiring the ops table and the
-// SPMD core counts — depend on the device-side s_runtime_ops global and the
-// AICPU SchedulerContext respectively, so they remain in the AICPU build.
+// prebuilt arena image. The piece below — wiring the ops table — depends on the
+// device-side s_runtime_ops global, so it remains in the AICPU build.
 
-void runtime_finalize_after_wire(PTO2Runtime *rt, int32_t aic_count, int32_t aiv_count) {
-    rt->ops = &s_runtime_ops;
-    rt->orchestrator.total_cluster_count = aic_count;
-    rt->orchestrator.total_aiv_count = aiv_count;
-}
+void runtime_bind_ops(PTO2Runtime *rt) { rt->ops = &s_runtime_ops; }
 
 void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode) {
     if (rt) {

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_orchestrator.h
@@ -27,8 +27,9 @@
 
 #pragma once
 
+#include <memory>
+
 #include "common/chip_swimlane_profiling.h"
-#include "utils/device_arena.h"
 #include "pto_ring_buffer.h"
 #include "graph_cache.h"
 #include "pto_runtime2_types.h"
@@ -40,20 +41,6 @@
 
 struct GraphHostState;
 
-/**
- * Layout descriptor produced by PTO2OrchestratorState::reserve_layout(). Holds
- * arena offsets for every sub-region the orchestrator owns (per-ring fanin
- * pools, scope arrays, plus the nested PTO2TensorMap layout).
- */
-struct PTO2OrchestratorLayout {
-    size_t off_fanin_seen_epoch;
-    size_t off_scope_tasks;
-    size_t off_scope_begins;
-    PTO2TensorMapLayout tensor_map;
-    int32_t scope_tasks_cap;
-    uint64_t scope_stack_capacity;
-};
-
 // =============================================================================
 // Orchestrator State
 // =============================================================================
@@ -62,6 +49,12 @@ struct PTO2OrchestratorLayout {
  * Orchestrator state structure (private to Orchestrator)
  *
  * Contains all state needed for task graph construction and buffer management.
+ *
+ * host_build_graph runs the orchestrator on the host and ships the shared-memory
+ * image it produces, so this whole object is host-only: it owns its scratch
+ * arrays outright and no device code reads any of them. PTO2Runtime therefore
+ * holds it by pointer — a by-value member would put non-trivially-copyable state
+ * inside the struct bind copies to the device.
  */
 struct PTO2OrchestratorState {
     // === SHARED MEMORY ACCESS ===
@@ -69,7 +62,7 @@ struct PTO2OrchestratorState {
 
     // === RING RESOURCES (single ring) ===
     PTO2RingSet ring;
-    uint32_t *fanin_seen_epoch;
+    std::unique_ptr<uint32_t[]> fanin_seen_epoch;
     uint32_t fanin_seen_current_epoch{1};
 
     // === TENSOR MAP (Private) ===
@@ -79,12 +72,12 @@ struct PTO2OrchestratorState {
     // Single contiguous buffer of task IDs, partitioned by scope level.
     // scope_begins[i] is the index into scope_tasks where scope i starts.
     // Tasks for the top scope occupy [scope_begins[top], scope_tasks_size).
-    PTO2TaskSlotState **scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
-    int32_t scope_tasks_size;         // Number of task IDs currently in the buffer
-    int32_t scope_tasks_capacity;     // Allocated capacity of scope_tasks
-    int32_t *scope_begins;            // scope_begins[i] = start index of scope i in scope_tasks
-    int32_t scope_stack_top;          // Current top of stack (-1 = no scope open)
-    uint64_t scope_stack_capacity;    // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
+    std::unique_ptr<PTO2TaskSlotState *[]> scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
+    int32_t scope_tasks_size{0};                         // Number of task IDs currently in the buffer
+    int32_t scope_tasks_capacity{0};                     // Allocated capacity of scope_tasks
+    std::unique_ptr<int32_t[]> scope_begins;             // scope_begins[i] = start index of scope i in scope_tasks
+    int32_t scope_stack_top{-1};                         // Current top of stack (-1 = no scope open)
+    uint64_t scope_stack_capacity{0};                    // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
     int32_t manual_begin_depth{PTO2_MAX_SCOPE_DEPTH};
 
     // === SCHEDULER REFERENCE ===
@@ -107,12 +100,12 @@ struct PTO2OrchestratorState {
 
     // Hidden alloc tasks complete synchronously inside the orchestrator and
     // therefore bypass the executor's normal worker-completion counter path.
-    // The executor adds this count into its completed_tasks_ progress counter
-    // after orchestration finishes so shutdown/profiling totals remain closed.
+    // rt_orchestration_done publishes this into PTO2Runtime, which is the copy
+    // the device-side executor adds into its completed_tasks_ progress counter
+    // so shutdown/profiling totals remain closed.
     int64_t inline_completed_tasks{0};
 
-    // This host-only state is cleared before the arena/shared-memory image
-    // crosses to the device.
+    // Host-only, like everything else here.
     GraphHostState *graph_host_state{nullptr};
 
     // === ARGUMENT POOLS (host-only) ===
@@ -145,29 +138,17 @@ struct PTO2OrchestratorState {
 
     // === Cold-path API (defined in pto_orchestrator.cpp) ===
 
-    // Phase 1: declare every sub-region (per-ring fanin pool, scope arrays,
-    // tensor_map sub-layout) on the supplied arena. task_window_sizes feeds
-    // the nested tensor_map layout. Returned layout is consumed by
-    // init_from_layout.
-    static PTO2OrchestratorLayout reserve_layout(DeviceArena &arena, int32_t task_window_size);
+    // Allocate the scratch arrays (fanin epoch table, scope arrays, tensor map)
+    // and bind this orchestrator to one shared-memory mirror, GM heap and
+    // scheduler. sm_base is the base of the mirror this orchestrator writes; it
+    // is dereferenced, so a host-orch pass passes its host mirror rather than a
+    // device address. task_window_size must be a power of two.
+    //
+    // Returns false when an allocation fails; the caller then has no hazard map
+    // and must not orchestrate.
+    bool
+    init(void *sm_base, void *gm_heap, uint64_t heap_size, uint64_t task_window_size, PTO2SchedulerState *scheduler);
 
-    // Phase 3a: write everything *except* arena-internal pointer fields.
-    // sm_dev_base is the SM device address (only stored, never dereferenced);
-    // task_window_size feeds the SM address arithmetic. Safe to call on a host
-    // arena that holds the prebuilt image.
-    bool init_data_from_layout(
-        const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap, uint64_t heap_size,
-        uint64_t task_window_size
-    );
-
-    // Phase 3b: write the arena-internal pointer fields (scope_tasks,
-    // scope_begins, tensor_map.{buckets,entry_pool,free_entry_list,
-    // task_entry_heads}, scheduler reference).
-    // Idempotent — host runs once on the image, AICPU runs once after attach.
-    void wire_arena_pointers(const PTO2OrchestratorLayout &layout, DeviceArena &arena, PTO2SchedulerState *scheduler);
-
-    // Forget pointers; arena owns the backing buffers.
-    void destroy();
     void set_scheduler(PTO2SchedulerState *scheduler);
     void report_fatal(int32_t error_code, const char *func, const char *fmt, ...);
     void begin_scope(PTO2ScopeMode mode = PTO2ScopeMode::AUTO);

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "utils/device_arena.h"
 #include "pto_runtime2_types.h"
 #include "graph_cache.h"
@@ -91,7 +93,7 @@ struct PTO2RuntimeOps {
     );
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const CoreTaskArgs &args);
     TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const CoreTaskArgs &args);
-    // This-run core geometry from runtime_finalize_after_wire: MIX clusters
+    // This-run core geometry latched by the host bind: MIX clusters
     // (one AIC each) and standalone AIV cores.
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
@@ -108,20 +110,19 @@ struct PTO2RuntimeOps {
 
 /**
  * Layout descriptor for the prebuilt runtime arena. Holds all sub-region
- * offsets (orchestrator / scheduler / sm_handle wrapper / runtime header /
- * AICore mailbox) plus the layout-defining capacities. Produced once on the
- * host by runtime_reserve_layout(); consumed by runtime_init_data_from_layout
- * and runtime_wire_arena_pointers.
+ * offsets (scheduler / sm_handle wrapper / runtime header / AICore mailbox)
+ * plus the layout-defining capacities. Produced once on the host by
+ * runtime_reserve_layout(); consumed by runtime_init_data_from_layout and
+ * runtime_wire_arena_pointers.
  */
 struct PTO2RuntimeArenaLayout {
     size_t off_sm_handle{0};
-    PTO2OrchestratorLayout orch;
     PTO2SchedulerLayout sched;
     size_t off_scheduler{0};
     size_t off_runtime{0};
     size_t off_mailbox{0};
-    // The arena is reserved in zones, in this order, and the offsets above land in
-    // exactly one of them:
+    // Every region in this arena is device-resident. The arena is reserved in two
+    // zones, in this order, and the offsets above land in exactly one of them:
     //
     //   device-only  sm_handle, the AICore mailbox, the scheduler state and its
     //                queue slot arrays. Reachable storage whose content is a
@@ -132,31 +133,27 @@ struct PTO2RuntimeArenaLayout {
     //                run's own content, so bind ships the whole zone as one
     //                contiguous range.
     //
-    // off_copied_end is where the shared part of the layout stops. Past it the two
-    // sides carry different tails, and neither reads the other's:
+    // Past off_copied_end the device carries one further tail the host arena does
+    // not: the shared-memory image, whose size is the submitted task count and
+    // therefore not known when this layout is built. bind grows the device region
+    // to cover it once orchestration ends.
     //
-    //   host tail    the orchestrator block. Dep-computation scratch no device code
-    //                reads, so it is neither copied nor allocated on the device.
-    //   device tail  the shared-memory image, whose size is the submitted task
-    //                count and therefore not known when this layout is built. bind
-    //                grows the device region to cover it once orchestration ends.
+    // The copied zone is padded to a PTO2_ALIGN_SIZE boundary, so that tail begins
+    // exactly at off_copied_end: the copied zone and the shared-memory image are
+    // adjacent on the device and travel as one copy.
     //
-    // The copied zone is padded to a PTO2_ALIGN_SIZE boundary, so the device tail
-    // begins exactly at off_copied_end: the copied zone and the shared-memory image
-    // are adjacent on the device and travel as one copy.
+    // The orchestrator is NOT here. It runs on the host, owns its own scratch, and
+    // no device code reads any of it — see PTO2OrchestratorState.
     size_t off_copied_begin{0};
     size_t off_copied_end{0};
-
-    // Byte length of the device region before its shared-memory tail. The host
-    // arena is arena_size, which instead covers the orchestrator block there.
-    size_t device_bytes{0};
 
     // Cached parameters (re-used by init_data + wire stages).
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]{};
     uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]{};
 
     // Total arena byte size post-commit. Used by host to size the prebuilt
-    // image buffer and as the rtMemcpy length.
+    // image buffer and as the rtMemcpy length, and requested of the device as
+    // the region length before its shared-memory tail.
     size_t arena_size{0};
 };
 
@@ -173,7 +170,11 @@ struct PTO2Runtime {
 
     // Components
     PTO2SharedMemoryHandle *sm_handle;
-    PTO2OrchestratorState orchestrator;
+    // Host-only, and by pointer so that this header stays trivially copyable:
+    // the orchestrator runs on the host and owns non-trivial scratch. Null on the
+    // device — bind drops it before the copied zone is uploaded, so no device code
+    // may dereference it.
+    PTO2OrchestratorState *orchestrator;
     // Device-only zone: the scheduler state holds no per-run content, so it is
     // addressed through the arena rather than carried inside this header.
     PTO2SchedulerState *scheduler;
@@ -189,6 +190,10 @@ struct PTO2Runtime {
 
     // Statistics
     int64_t total_cycles;
+    // Hidden alloc tasks the host orchestrator completed inline, published here by
+    // rt_orchestration_done. The device-side executor folds this into its
+    // completed_tasks_ progress counter so shutdown/profiling totals stay closed.
+    int64_t inline_completed_tasks;
     // Graph definitions are process-local host cache entries. The callable
     // identity prevents two orchestration DSOs from sharing the same key.
     uint64_t active_callable_hash;
@@ -211,16 +216,24 @@ struct PTO2Runtime {
     PTO2RuntimeArenaLayout prebuilt_layout;
 };
 
+// bind copies this header to the device as one contiguous range, so every byte
+// of it has to survive a memcpy with no fix-up. That rules out an owning or
+// otherwise non-trivial member — the orchestrator's scratch is reached through
+// a pointer for exactly this reason.
+static_assert(
+    std::is_trivially_copyable_v<PTO2Runtime> && std::is_standard_layout_v<PTO2Runtime>,
+    "PTO2Runtime is copied to the device verbatim"
+);
+
 // =============================================================================
 // Runtime Lifecycle API
 // =============================================================================
 
 /**
- * Phase 1 — declare every sub-region (sm_handle wrapper, orchestrator /
- * scheduler / tensor_map / mailbox / PTO2Runtime header) on the supplied
- * arena. Pure arithmetic; does not touch device memory and may run on host.
- * Returns the layout descriptor; caller commits/attaches the arena before
- * Phase 2/3.
+ * Phase 1 — declare every sub-region (sm_handle wrapper, scheduler / mailbox /
+ * PTO2Runtime header) on the supplied arena. Pure arithmetic; does not touch
+ * device memory and may run on host. Returns the layout descriptor; caller
+ * commits/attaches the arena before Phase 2/3.
  */
 PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size);
 PTO2RuntimeArenaLayout runtime_reserve_layout(
@@ -241,10 +254,9 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
  * Returns the PTO2Runtime* that sits at layout.off_runtime within the arena.
  * Caller must follow up with runtime_wire_arena_pointers; rt->ops and the
  * AICore-side count fields are left untouched and must be filled by the
- * AICPU at boot. Initializes the scheduler only: the orchestrator is left
- * zeroed for the host-orch path (run_host_orchestration) to initialize
- * against the host SM, since initializing it here would be overwritten and
- * is never uploaded to the device.
+ * AICPU at boot. Initializes the scheduler only: the orchestrator is a
+ * host-owned object the host-orch path (run_host_orchestration) stands up and
+ * points rt->orchestrator at, and it is never uploaded to the device.
  */
 PTO2Runtime *runtime_init_data_from_layout(
     DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
@@ -265,32 +277,12 @@ PTO2Runtime *runtime_init_data_from_layout(
 void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
 
 /**
- * Phase 3b — wire the orchestrator's pointers into the host-only zone
- * (orchestrator.{scope_tasks, scope_begins, scheduler, tensor_map.*}).
- *
- * Host-only by construction: that zone is past layout.device_bytes and so is not
- * allocated on the device, which makes the addresses this writes unrepresentable
- * there. Requires rt->scheduler, so it follows runtime_wire_arena_pointers.
+ * AICPU-only Phase 4 — install the ops table, the one field the host could not
+ * know at prebuilt-image build time (s_runtime_ops is a device-side file-local
+ * global, so the host cannot resolve its device address). Call once per boot
+ * after runtime_wire_arena_pointers.
  */
-void runtime_wire_host_only_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
-
-/**
- * Drop the pointers Phase 3b wrote, so the runtime header can be copied to the
- * device without carrying host addresses into it. The device reads one
- * orchestrator field, inline_completed_tasks, which this leaves alone.
- *
- * Call after orchestration finishes and before the copied zone is uploaded.
- */
-void runtime_clear_host_only_pointers(PTO2Runtime *rt);
-
-/**
- * AICPU-only Phase 4 — fill in the few fields the host could not know at
- * prebuilt-image build time: the ops table (s_runtime_ops is a device-side
- * file-local global, host cannot resolve its device address) and the
- * orchestrator's core counts (depend on the executor's scheduler context).
- * Call once per boot after runtime_wire_arena_pointers.
- */
-void runtime_finalize_after_wire(PTO2Runtime *rt, int32_t aic_count, int32_t aiv_count);
+void runtime_bind_ops(PTO2Runtime *rt);
 
 /**
  * Destroy runtime. With the prebuilt-arena fast path the arena buffer is

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_tensormap.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_tensormap.h
@@ -16,8 +16,12 @@
  * - Maps ChipTensor -> producer task ID
  * - Used by pto_submit_task() to find dependencies
  *
+ * host_build_graph runs its orchestrator on the host, so this map is host-only
+ * state: it owns its four arrays outright rather than addressing them as offsets
+ * into a device-shaped arena. Nothing here is copied to the device.
+ *
  * Key design features:
- * 1. Fixed-capacity arena pool for entries (no malloc/free)
+ * 1. Fixed-capacity entry pool (no per-entry malloc/free)
  * 2. Task completion does not retire entries; a producer stays visible until
  *    dependency computation explicitly removes it as semantically covered
  * 3. Per-task entry tracking for explicit removal
@@ -43,9 +47,10 @@
 
 #pragma once
 
+#include <memory>
+
 #include "common.h"
 #include "profiling_config.h"
-#include "utils/device_arena.h"
 #include "pto_runtime2_types.h"
 #include "tensor.h"
 
@@ -64,23 +69,6 @@ struct Segment {
 
     bool line_segment_intersection(const Segment &other) const { return end > other.begin && other.end > begin; }
     bool contains(const Segment &other) const { return begin <= other.begin && other.end <= end; }
-};
-
-/**
- * Layout descriptor produced by PTO2TensorMap::reserve_layout(). Stores the
- * region offsets returned by DeviceArena::reserve() so init_from_layout()
- * can fetch the matching pointers after the arena is committed.
- *
- * All offsets are relative to the arena's base.
- */
-struct PTO2TensorMapLayout {
-    size_t off_buckets;
-    size_t off_entry_pool;
-    size_t off_free_entry_list;
-    size_t off_task_entry_heads;
-    int32_t num_buckets;
-    int32_t pool_size;
-    int32_t task_window_size;
 };
 
 // TensorMap Lookup Profiling (must precede inline lookup/insert methods).
@@ -357,23 +345,26 @@ static_assert(
  * TensorMap structure
  *
  * Hash table with a fixed-capacity entry pool and no watermark invalidation.
+ * Owns its four arrays; init() sizes them and leaves the map empty.
  */
 struct PTO2TensorMap {
-    // Hash table buckets (fixed size, power of 2)
-    PTO2TensorMapEntry **buckets;  // Array of offsets into entry_pool (-1 = empty)
-    int32_t num_buckets;           // Must be power of 2 for fast modulo
+    // Hash table buckets (fixed size, power of 2). An empty bucket is nullptr.
+    std::unique_ptr<PTO2TensorMapEntry *[]> buckets;
+    int32_t num_buckets{0};  // Must be power of 2 for fast modulo
 
-    // Entry pool: bump allocation plus reuse of explicitly removed entries.
-    PTO2TensorMapEntry *entry_pool;
-    PTO2TensorMapEntry **free_entry_list;
-    int32_t pool_size;       // Total pool capacity
-    int32_t next_entry_idx;  // id when next entry insert
-    int32_t free_num;        // free entry number in entry pool
+    // Entry pool: bump allocation plus reuse of explicitly removed entries. A
+    // linked entry is reached by pointer, so the pool is allocated once at
+    // pool_size and never resized.
+    std::unique_ptr<PTO2TensorMapEntry[]> entry_pool;
+    std::unique_ptr<PTO2TensorMapEntry *[]> free_entry_list;
+    int32_t pool_size{0};       // Total pool capacity
+    int32_t next_entry_idx{0};  // id when next entry insert
+    int32_t free_num{0};        // free entry number in entry pool
 
     // Per-task entry tracking for O(1) unlinking of covered producers.
     // Indexed by [local_id & (task_window_size - 1)]
-    PTO2TensorMapEntry **task_entry_heads;
-    int32_t task_window_size;  // Task window size (for slot masking)
+    std::unique_ptr<PTO2TensorMapEntry *[]> task_entry_heads;
+    int32_t task_window_size{0};  // Task window size (for slot masking)
 
     uint32_t get_task_local_id_slot(uint32_t task_local_id) const { return task_local_id & (task_window_size - 1); }
 
@@ -396,7 +387,7 @@ struct PTO2TensorMap {
         }
         always_assert(next_entry_idx < pool_size);
         PTO2TensorMapEntry *res = &entry_pool[next_entry_idx++];
-        // Init-on-write: the pool is not pre-zeroed (init_data_from_layout skips
+        // Init-on-write: the pool is not pre-zeroed (init() skips
         // the O(pool_size) memset), so put this fresh slot into the same clean
         // unlinked state free_entry() leaves recycled slots in. The insert path
         // overwrites the remaining fields exactly as it does for a recycled slot,
@@ -439,40 +430,25 @@ struct PTO2TensorMap {
     // =============================================================================
 
     /**
-     * Phase 1: reserve every sub-region (buckets, entry_pool, free list, per-ring
-     * task_entry_heads) on the supplied arena. Records the resulting offsets in
-     * the returned layout descriptor. Must be called before the arena is
-     * committed.
+     * Allocate the four arrays and leave the map empty. num_buckets must be a
+     * power of two; task_window_size must be a power of two, since a producer's
+     * task chain is selected by `local_id & (task_window_size - 1)`.
+     *
+     * Returns false when an allocation fails, so a caller that still has an
+     * alternative path can take it rather than proceed without a hazard map.
+     *
+     * Clearing is O(num_buckets + task_window_size), not O(pool_size): the entry
+     * pool is left uninitialized and new_entry() puts each slot into the clean
+     * unlinked state on first use, and free_entry_list is a stack meaningful only
+     * below free_num.
      */
-    static PTO2TensorMapLayout
-    reserve_layout(DeviceArena &arena, int32_t num_buckets, int32_t pool_size, int32_t task_window_size);
+    bool init(int32_t new_num_buckets, int32_t new_pool_size, int32_t new_task_window_size);
 
     /**
-     * Same as reserve_layout() with default sizes (PTO2_TENSORMAP_NUM_BUCKETS,
+     * Same as init() with default sizes (PTO2_TENSORMAP_NUM_BUCKETS,
      * PTO2_TENSORMAP_POOL_SIZE).
      */
-    static PTO2TensorMapLayout reserve_layout_default(DeviceArena &arena, int32_t task_window_size);
-
-    /**
-     * Phase 3a: write everything *except* arena-internal pointer fields
-     * (buckets, entry_pool, free_entry_list, task_entry_heads).
-     * Uses arena.region_ptr to address the arena regions for data writes,
-     * but does not store those addresses in struct fields. Safe to call on
-     * a host arena that holds the prebuilt image.
-     */
-    bool init_data_from_layout(const PTO2TensorMapLayout &layout, DeviceArena &arena);
-
-    /**
-     * Phase 3b: write the arena-internal pointer fields. Idempotent;
-     * called once on the host arena and once on the AICPU after attach.
-     */
-    void wire_arena_pointers(const PTO2TensorMapLayout &layout, DeviceArena &arena);
-
-    /**
-     * Tear down state. Does not free memory — the arena owns the backing
-     * buffer. Pointers are set to nullptr so accidental reuse traps.
-     */
-    void destroy();
+    bool init_default(int32_t new_task_window_size);
 
     /**
      * Lookup producer for a tensor region

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -1082,7 +1082,7 @@ void SchedulerContext::on_orchestration_done(
     }
 
     // Fold tasks completed inline during orchestration
-    int32_t inline_completed = static_cast<int32_t>(rt->orchestrator.inline_completed_tasks);
+    int32_t inline_completed = static_cast<int32_t>(rt->inline_completed_tasks);
     if (inline_completed > 0) {
         completed_tasks_.fetch_add(inline_completed, std::memory_order_relaxed);
 #if SIMPLER_SCHED_PROFILING

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -50,8 +50,7 @@ static bool sum_ring_heap_sizes(const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], 
 
 size_t ready_queue_reserve_layout(DeviceArena &arena, uint64_t capacity) {
     // Align the slots[] base to a full cache line so MPMC CAS traffic on the
-    // first slot cannot false-share with whatever region sits in front of us
-    // (e.g. orchestrator tensormap heads written by the orch thread).
+    // first slot cannot false-share with whatever region sits in front of us.
     return arena.reserve(capacity * sizeof(PTO2ReadyQueueSlot), PTO2_ALIGN_SIZE);
 }
 
@@ -215,94 +214,61 @@ void PTO2SchedulerState::destroy() {
 // Orchestrator
 // =============================================================================
 
-PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(DeviceArena &arena, int32_t task_window_size) {
-    PTO2OrchestratorLayout layout{};
+bool PTO2OrchestratorState::init(
+    void *sm_base, void *gm_heap, uint64_t heap_size, uint64_t task_window_size, PTO2SchedulerState *scheduler_arg
+) {
+    auto *orch = this;
+    *orch = PTO2OrchestratorState{};
+
     // scope_tasks holds every task in the open scope, so its cap is the real
     // in-flight budget = the (runtime) task window. Using the compile-time
     // PTO2_SCOPE_TASKS_CAP instead under-sized the buffer when ring_task_window
     // was enlarged past the default (premature SCOPE_TASKS_OVERFLOW) and
     // over-allocated it when shrunk. See issue #1188.
-    always_assert(task_window_size > 0);
-    layout.scope_tasks_cap = task_window_size;
-    layout.scope_stack_capacity = PTO2_MAX_SCOPE_DEPTH;
-
-    // Polling: no fanin-spill pool — producer ids are inline on the payload.
     always_assert(task_window_size > 0 && (task_window_size & (task_window_size - 1)) == 0);
-    const size_t seen_epoch_bytes =
-        PTO2_ALIGN_UP(static_cast<size_t>(task_window_size) * sizeof(uint32_t), PTO2_ALIGN_SIZE);
-    layout.off_fanin_seen_epoch = arena.reserve(seen_epoch_bytes, PTO2_ALIGN_SIZE);
 
-    layout.off_scope_tasks =
-        arena.reserve(static_cast<size_t>(layout.scope_tasks_cap) * sizeof(uintptr_t), alignof(PTO2TaskSlotState *));
-    layout.off_scope_begins =
-        arena.reserve(static_cast<size_t>(layout.scope_stack_capacity) * sizeof(int32_t), alignof(int32_t));
-    layout.tensor_map = PTO2TensorMap::reserve_layout_default(arena, task_window_size);
-    return layout;
-}
-
-bool PTO2OrchestratorState::init_data_from_layout(
-    const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap, uint64_t heap_size,
-    uint64_t task_window_size
-) {
-    auto *orch = this;
-    *orch = PTO2OrchestratorState{};
-
-    orch->sm_header = reinterpret_cast<PTO2SharedMemoryHeader *>(sm_dev_base);
+    orch->sm_header = reinterpret_cast<PTO2SharedMemoryHeader *>(sm_base);
     orch->gm_heap_base = gm_heap;
     orch->gm_heap_size = heap_size;
     orch->fatal = false;
+    orch->scheduler = scheduler_arg;
 
-    auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_dev_base);
-    auto *cur_idx_dev = pto2_sm_layout::ring_current_task_index_addr(sm_dev_base);
+    auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_base);
+    auto *cur_idx_dev = pto2_sm_layout::ring_current_task_index_addr(sm_base);
 
     orch->ring.task_allocator.init(static_cast<int32_t>(task_window_size), cur_idx_dev, gm_heap, heap_size, orch_err);
 
     // The mirror's argument pools. Offset arithmetic on the same base as sm_header,
-    // so it holds for whichever SM this orchestrator was pointed at — the host-orch
-    // path re-inits against the host mirror before orchestration. The cursors reset
-    // with the rest of the state above.
-    auto *sm_bytes = static_cast<char *>(sm_dev_base);
+    // so it holds for whichever SM this orchestrator was pointed at. The cursors
+    // reset with the rest of the state above.
+    auto *sm_bytes = static_cast<char *>(sm_base);
     const auto pools = pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::mirror_extents(task_window_size));
     orch->fanin_pool = reinterpret_cast<int32_t *>(sm_bytes + pools.fanin_pool);
     orch->tensor_pool = reinterpret_cast<ChipTensor *>(sm_bytes + pools.tensor_pool);
     orch->scalar_pool = reinterpret_cast<uint64_t *>(sm_bytes + pools.scalar_pool);
 
-    const size_t seen_epoch_bytes =
-        PTO2_ALIGN_UP(static_cast<size_t>(layout.tensor_map.task_window_size) * sizeof(uint32_t), PTO2_ALIGN_SIZE);
-    auto *seen_epoch = static_cast<uint32_t *>(arena.region_ptr(layout.off_fanin_seen_epoch));
-    memset(seen_epoch, 0, seen_epoch_bytes);
-    orch->fanin_seen_epoch = seen_epoch;
+    // Polling: no fanin-spill pool — producer ids are inline on the payload.
+    const auto window = static_cast<size_t>(task_window_size);
+    orch->fanin_seen_epoch.reset(new (std::nothrow) uint32_t[window]);
+    orch->scope_tasks.reset(new (std::nothrow) PTO2TaskSlotState *[window]);
+    orch->scope_begins.reset(new (std::nothrow) int32_t[PTO2_MAX_SCOPE_DEPTH]);
+    if (orch->fanin_seen_epoch == nullptr || orch->scope_tasks == nullptr || orch->scope_begins == nullptr) {
+        LOG_ERROR("Orchestrator scratch allocation failed (task_window=%" PRIu64 ")", task_window_size);
+        return false;
+    }
+    memset(orch->fanin_seen_epoch.get(), 0, window * sizeof(uint32_t));
 
-    if (!orch->tensor_map.init_data_from_layout(layout.tensor_map, arena)) {
+    if (!orch->tensor_map.init_default(static_cast<int32_t>(task_window_size))) {
         return false;
     }
 
     orch->scope_tasks_size = 0;
-    orch->scope_tasks_capacity = layout.scope_tasks_cap;
+    orch->scope_tasks_capacity = static_cast<int32_t>(window);
     orch->scope_stack_top = -1;
-    orch->scope_stack_capacity = layout.scope_stack_capacity;
+    orch->scope_stack_capacity = PTO2_MAX_SCOPE_DEPTH;
     orch->manual_begin_depth = PTO2_MAX_SCOPE_DEPTH;
 
     return true;
-}
-
-void PTO2OrchestratorState::wire_arena_pointers(
-    const PTO2OrchestratorLayout &layout, DeviceArena &arena, PTO2SchedulerState *scheduler_arg
-) {
-    auto *orch = this;
-    orch->fanin_seen_epoch = static_cast<uint32_t *>(arena.region_ptr(layout.off_fanin_seen_epoch));
-    orch->tensor_map.wire_arena_pointers(layout.tensor_map, arena);
-    orch->scope_tasks = static_cast<PTO2TaskSlotState **>(arena.region_ptr(layout.off_scope_tasks));
-    orch->scope_begins = static_cast<int32_t *>(arena.region_ptr(layout.off_scope_begins));
-    orch->scheduler = scheduler_arg;
-}
-
-void PTO2OrchestratorState::destroy() {
-    auto *orch = this;
-    orch->tensor_map.destroy();
-    orch->fanin_seen_epoch = nullptr;
-    orch->scope_tasks = nullptr;
-    orch->scope_begins = nullptr;
 }
 
 void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler) { this->scheduler = scheduler; }
@@ -350,9 +316,6 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
     layout.off_runtime = arena.reserve(PTO2_ALIGN_UP(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE), PTO2_ALIGN_SIZE);
     layout.off_copied_end = arena.total_size();
 
-    layout.device_bytes = arena.total_size();
-    layout.orch = PTO2OrchestratorState::reserve_layout(arena, static_cast<int32_t>(task_window_sizes[0]));
-
     layout.arena_size = arena.total_size();
     return layout;
 }
@@ -373,12 +336,11 @@ PTO2Runtime *runtime_init_data_from_layout(
  *
  * Zeroes the PTO2Runtime header at layout.off_runtime, records the GM heap,
  * and initializes the scheduler (ready / sync / dummy / graph queues) against
- * the device SM. The orchestrator is deliberately left zeroed: the host-orch
- * path (run_host_orchestration) initializes it against the host SM once that
- * buffer exists. Initializing it here would be dead work — overwritten by that
- * re-init, and the orchestrator arena block is never uploaded to the device. Caller must follow up with
- * runtime_wire_arena_pointers. Returns the arena-resident PTO2Runtime*, or
- * nullptr on failure.
+ * the device SM. rt->orchestrator is left null: the orchestrator is a host-owned
+ * object the host-orch path (run_host_orchestration) stands up against the host
+ * SM once that buffer exists, and it is never uploaded to the device. Caller must
+ * follow up with runtime_wire_arena_pointers. Returns the arena-resident
+ * PTO2Runtime*, or nullptr on failure.
  */
 PTO2Runtime *runtime_init_data_from_layout(
     DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
@@ -401,11 +363,10 @@ PTO2Runtime *runtime_init_data_from_layout(
 
     // Two components are deliberately not initialized here.
     //
-    // The orchestrator is initialized by the host-orch path
-    // (run_host_orchestration) against the host SM once it is allocated. Doing it
-    // here would be dead work: its arena content (tensormap + seen_epoch memset)
-    // is immediately overwritten by that re-init, and the orchestrator block is
-    // host-only anyway.
+    // The orchestrator is not in this arena at all: it is a host-owned object the
+    // host-orch path (run_host_orchestration) stands up against the host SM once
+    // that buffer is allocated, and rt->orchestrator only points at it for the
+    // duration of that pass.
     //
     // The scheduler and sm_handle live in the device-only zone, so their bytes
     // never travel; the AICPU initializes them at boot. Writing them here would
@@ -422,17 +383,10 @@ void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayou
     rt->scheduler->wire_arena_pointers(layout.sched, arena);
 }
 
-void runtime_wire_host_only_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt) {
-    rt->orchestrator.wire_arena_pointers(layout.orch, arena, rt->scheduler);
-}
-
-void runtime_clear_host_only_pointers(PTO2Runtime *rt) { rt->orchestrator.destroy(); }
-
 void runtime_destroy(PTO2Runtime *rt, DeviceArena & /*arena*/) {
     // Arena buffer is pooled across runs by DeviceRunner — never freed here.
     if (!rt) return;
     rt->scheduler->destroy();
-    rt->orchestrator.destroy();
     rt->aicore_mailbox = nullptr;
     rt->sm_handle = nullptr;
 }

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/pto_tensormap.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/pto_tensormap.cpp
@@ -11,7 +11,7 @@
 /**
  * PTO Runtime2 - TensorMap Implementation
  *
- * Implements TensorMap with a fixed-capacity arena pool. Task completion does
+ * Implements TensorMap with a fixed-capacity entry pool. Task completion does
  * not invalidate entries; dependency computation explicitly removes only
  * producers made redundant by coverage.
  *
@@ -28,6 +28,8 @@
 
 #include <stdlib.h>
 #include <string.h>
+
+#include <new>
 
 #include "common.h"
 #include "common/unified_log.h"
@@ -48,54 +50,45 @@ uint64_t g_insert_count = 0;
 // Initialization and Destruction
 // =============================================================================
 
-PTO2TensorMapLayout PTO2TensorMap::reserve_layout(
-    DeviceArena &arena, int32_t new_num_buckets, int32_t new_pool_size, int32_t new_task_window_size
-) {
-    // num_buckets must be a power of two for the hash truncation to work.
-    always_assert((new_num_buckets & (new_num_buckets - 1)) == 0);
-
-    PTO2TensorMapLayout layout{};
-    layout.num_buckets = new_num_buckets;
-    layout.pool_size = new_pool_size;
-    layout.task_window_size = new_task_window_size;
-
-    layout.off_buckets = arena.reserve(
-        static_cast<size_t>(new_num_buckets) * sizeof(PTO2TensorMapEntry *), alignof(PTO2TensorMapEntry *)
-    );
-    layout.off_entry_pool =
-        arena.reserve(static_cast<size_t>(new_pool_size) * sizeof(PTO2TensorMapEntry), alignof(PTO2TensorMapEntry));
-    layout.off_free_entry_list =
-        arena.reserve(static_cast<size_t>(new_pool_size) * sizeof(PTO2TensorMapEntry *), alignof(PTO2TensorMapEntry *));
-    layout.off_task_entry_heads = arena.reserve(
-        static_cast<size_t>(new_task_window_size) * sizeof(PTO2TensorMapEntry *), alignof(PTO2TensorMapEntry *)
-    );
-    return layout;
-}
-
-PTO2TensorMapLayout PTO2TensorMap::reserve_layout_default(DeviceArena &arena, int32_t new_task_window_size) {
-    return reserve_layout(arena, PTO2_TENSORMAP_NUM_BUCKETS, PTO2_TENSORMAP_POOL_SIZE, new_task_window_size);
-}
-
 /**
- * Reset the map to empty for a fresh orchestration pass. Addresses the arena
- * regions directly through arena.region_ptr, so it runs before
- * wire_arena_pointers binds the struct's pointer fields (and before any
- * insert/lookup). Clears the bucket heads and the per-task entry heads and
- * resets the pool cursors (next_entry_idx / free_num); the entry pool itself is
- * left untouched and initialized on write by new_entry(), so this is
- * O(num_buckets + task_window_size), not O(pool_size).
+ * Allocate the four arrays and reset the map to empty. Clears the bucket heads
+ * and the per-task entry heads and resets the pool cursors (next_entry_idx /
+ * free_num); the entry pool is left uninitialized and initialized on write by
+ * new_entry(), so this is O(num_buckets + task_window_size), not O(pool_size).
+ *
+ * `new (std::nothrow) T[n]` rather than a vector: a vector would value-initialize
+ * the whole entry pool, which is megabytes of zeroing the init-on-write path
+ * exists to avoid, and nothrow keeps the failure reportable to a caller that
+ * still has an alternative path.
  */
-bool PTO2TensorMap::init_data_from_layout(const PTO2TensorMapLayout &layout, DeviceArena &arena) {
-    num_buckets = layout.num_buckets;
-    pool_size = layout.pool_size;
+bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size, int32_t new_task_window_size) {
+    // num_buckets must be a power of two for the hash truncation to work, and
+    // task_window_size for the task-chain slot mask.
+    always_assert(new_num_buckets > 0 && (new_num_buckets & (new_num_buckets - 1)) == 0);
+    always_assert(new_task_window_size > 0 && (new_task_window_size & (new_task_window_size - 1)) == 0);
+    always_assert(new_pool_size > 0);
 
-    // Address arena regions for data writes; do not store these in struct
-    // fields (wire_arena_pointers does that).
-    auto *buckets_arena = static_cast<PTO2TensorMapEntry **>(arena.region_ptr(layout.off_buckets));
+    buckets.reset(new (std::nothrow) PTO2TensorMapEntry *[new_num_buckets]);
+    entry_pool.reset(new (std::nothrow) PTO2TensorMapEntry[new_pool_size]);
+    free_entry_list.reset(new (std::nothrow) PTO2TensorMapEntry *[new_pool_size]);
+    task_entry_heads.reset(new (std::nothrow) PTO2TensorMapEntry *[new_task_window_size]);
+    if (buckets == nullptr || entry_pool == nullptr || free_entry_list == nullptr || task_entry_heads == nullptr) {
+        LOG_ERROR(
+            "TensorMap init failed (buckets=%d, pool=%d, window=%d)", new_num_buckets, new_pool_size,
+            new_task_window_size
+        );
+        return false;
+    }
 
-    // buckets[]: empty == nullptr.
+    num_buckets = new_num_buckets;
+    pool_size = new_pool_size;
+    task_window_size = new_task_window_size;
+
     for (int32_t i = 0; i < num_buckets; i++) {
-        buckets_arena[i] = nullptr;
+        buckets[i] = nullptr;
+    }
+    for (int32_t i = 0; i < task_window_size; i++) {
+        task_entry_heads[i] = nullptr;
     }
 
     // Init-on-write: the entry pool is not pre-zeroed. new_entry() puts each
@@ -109,31 +102,11 @@ bool PTO2TensorMap::init_data_from_layout(const PTO2TensorMapLayout &layout, Dev
 
     next_entry_idx = 0;
     free_num = 0;
-
-    auto *heads_arena = static_cast<PTO2TensorMapEntry **>(arena.region_ptr(layout.off_task_entry_heads));
-    for (int32_t i = 0; i < layout.task_window_size; i++) {
-        heads_arena[i] = nullptr;
-    }
-    task_window_size = layout.task_window_size;
-
     return true;
 }
 
-void PTO2TensorMap::wire_arena_pointers(const PTO2TensorMapLayout &layout, DeviceArena &arena) {
-    buckets = static_cast<PTO2TensorMapEntry **>(arena.region_ptr(layout.off_buckets));
-    entry_pool = static_cast<PTO2TensorMapEntry *>(arena.region_ptr(layout.off_entry_pool));
-    free_entry_list = static_cast<PTO2TensorMapEntry **>(arena.region_ptr(layout.off_free_entry_list));
-    task_entry_heads = static_cast<PTO2TensorMapEntry **>(arena.region_ptr(layout.off_task_entry_heads));
-}
-
-void PTO2TensorMap::destroy() {
-    // Arena owns the backing memory; here we only forget our pointers so any
-    // stray post-destroy access trips a nullptr dereference instead of reading
-    // a recycled allocation.
-    buckets = nullptr;
-    entry_pool = nullptr;
-    free_entry_list = nullptr;
-    task_entry_heads = nullptr;
+bool PTO2TensorMap::init_default(int32_t new_task_window_size) {
+    return init(PTO2_TENSORMAP_NUM_BUCKETS, PTO2_TENSORMAP_POOL_SIZE, new_task_window_size);
 }
 
 // =============================================================================

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -308,7 +308,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         }
 
         if (boot_ok) {
-            runtime_finalize_after_wire(rt, sched_ctx_.aic_count(), sched_ctx_.aiv_count());
+            runtime_bind_ops(rt);
             runtime->set_slot_states_ptr(nullptr);
 
             sched_ctx_.bind_runtime(rt);

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -84,7 +84,7 @@ correct for the layout it was taken in, so `compact_live_image` re-takes every o
 of them against the shipped image; the copy to the device moves a field and its
 target together and leaves them all correct.
 
-### 3.1 What Ships: the Arena's Three Zones
+### 3.1 What Ships: the Arena's Two Zones
 
 Three rules decide every byte of the runtime arena:
 
@@ -97,28 +97,30 @@ Three rules decide every byte of the runtime arena:
 3. **Initialize once.** A region whose content does not differ between runs is
    established once, not re-established per bind.
 
-They partition the arena into three contiguous zones, and `runtime_reserve_layout`
+They partition the arena into two contiguous zones, and `runtime_reserve_layout`
 reserves them in this order:
 
 | Zone | Regions | Copied | Allocated on device | Written by |
 | ---- | ------- | ------ | ------------------- | ---------- |
-| copied | `[off_copied_begin, off_copied_end)`: the runtime header | whole zone, one copy | yes | host |
 | device-only | `sm_handle`, the completion mailbox, `PTO2SchedulerState` and its thirteen queue slot arrays | never | yes | AICPU at boot |
-| host-only | orchestrator block: `fanin_seen_epoch` / `scope_tasks` / TensorMap, ~9.3 MB | never | **no** | host, during graph construction |
+| copied | `[off_copied_begin, off_copied_end)`: the runtime header | whole zone, one copy | yes | host |
 
-The copied zone leads, so `bind` is a single contiguous `copy_to_device` starting
-at the arena base. Both bounds are layout fields, so no consumer infers a boundary
-from which region happens to be reserved first — `bind_callable_to_runtime_impl`
-asserts only that they are ordered and in range.
+The copied zone comes last, so `bind` is a single contiguous `copy_to_device`
+starting at `off_copied_begin` — and the device's shared-memory tail begins
+exactly where that zone ends. Both bounds are layout fields, so no consumer infers
+a boundary from which region happens to be reserved first —
+`bind_callable_to_runtime_impl` asserts only that they are ordered and in range.
 
-**Why the host-only zone comes last.** No device code dereferences a pointer into
-the orchestrator block — hbg has no device-side orchestrator, and the one
-orchestrator field the scheduler reads, `inline_completed_tasks`, is a scalar in
-the runtime header. Putting the block at the tail lets `setup_static_arena` request
-only `layout.device_bytes`, the copied + device-only prefix, so those ~9.3 MB are
-never reserved on the device at all. `runtime_wire_host_only_pointers` is therefore
-host-only, and `runtime_clear_host_only_pointers` drops those pointers before the
-copied zone is uploaded so no host address crosses the boundary.
+**Why the orchestrator is not in the arena at all.** hbg has no device-side
+orchestrator, so nothing on the device reads its state: not the `fanin_seen_epoch`
+table, not the scope arrays, not the TensorMap (~9.3 MB between them). It is
+therefore a plain host object that owns those arrays — `PTO2OrchestratorState::init`
+allocates them — and `PTO2Runtime` reaches it through a pointer that `bind` drops
+before the copied zone is uploaded, so no host address crosses the boundary. A
+`static_assert` keeps `PTO2Runtime` trivially copyable, which is what forbids
+putting an owning member back inside it. The one orchestrator value the device-side
+scheduler reads, the count of tasks completed inline during orchestration, is a
+scalar `rt_orchestration_done` publishes into the runtime header.
 
 **Why the scheduler state is device-written.** `PTO2SchedulerState` holds no
 per-run content: `sm_header` and the ring pointer derive from a pooled SM base,

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -571,14 +571,17 @@ int32_t run_host_orchestration(
     std::memset(host_sm, 0, sm_segs.descriptors);
 
     // Re-point the orchestrator half at the host SM (scheduler keeps device SM).
-    // init_data_from_layout resets the orchestrator state, so this is safe.
-    if (!rt->orchestrator.init_data_from_layout(
-            layout.orch, host_arena, host_sm, gm_heap, eff_heap_sizes[0], eff_task_window_sizes[0]
-        )) {
-        LOG_ERROR("host-orch: orchestrator re-init against host SM failed");
+    // Host-owned and destroyed with this frame, so rt->orchestrator is dropped on
+    // every exit — it must never outlive the object it names.
+    PTO2OrchestratorState orchestrator;
+    rt->orchestrator = &orchestrator;
+    RAIIScopeGuard orchestrator_binding([rt]() {
+        rt->orchestrator = nullptr;
+    });
+    if (!orchestrator.init(host_sm, gm_heap, eff_heap_sizes[0], eff_task_window_sizes[0], rt->scheduler)) {
+        LOG_ERROR("host-orch: orchestrator init against host SM failed");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
-    rt->orchestrator.wire_arena_pointers(layout.orch, host_arena, rt->scheduler);
 
     // Initialize the host SM header (ring flow control) so submit_task can run.
     PTO2SharedMemoryHandle host_sm_handle;
@@ -592,7 +595,7 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: failed to allocate Graph host state");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
-    GraphHostStateBinding graph_binding(rt->orchestrator, graph_state.get());
+    GraphHostStateBinding graph_binding(orchestrator, graph_state.get());
 
     // Install the ops table (host s_runtime_ops) and latch this run's cluster
     // counts. worker_count is published by DeviceRunner::prepare_launch_shape
@@ -603,9 +606,9 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: worker_count %d yields no clusters", runtime->get_worker_count());
         return PTO_RUNTIME_ERR_INTERNAL;
     }
-    runtime_finalize_after_wire(
-        rt, block_dim * PLATFORM_AIC_CORES_PER_BLOCKDIM, block_dim * PLATFORM_AIV_CORES_PER_BLOCKDIM
-    );
+    runtime_bind_ops(rt);
+    orchestrator.total_cluster_count = block_dim * PLATFORM_AIC_CORES_PER_BLOCKDIM;
+    orchestrator.total_aiv_count = block_dim * PLATFORM_AIV_CORES_PER_BLOCKDIM;
     rt->mode = PTO2_MODE_EXECUTE;
     // get_tensor_data/set_tensor_data resolve buffer.addr through the host
     // views registered at staging time (runtime/host_tensor_access.h), so the
@@ -658,7 +661,7 @@ int32_t run_host_orchestration(
     // edges. Uploading it would launch the device on an incomplete graph and surface
     // the cause as whatever the device notices second, usually a scheduler timeout.
     const int32_t orch_error = pto2_sm_layout::orch_error_code_addr(host_sm)->load(std::memory_order_acquire);
-    if (orch_error != PTO2_ERROR_NONE || rt->orchestrator.fatal) {
+    if (orch_error != PTO2_ERROR_NONE || orchestrator.fatal) {
         // The latched code is the diagnosis, so it is what the caller sees — through the
         // same mapping the run path uses, since a caller cannot tell which of the two
         // noticed. A fatal with no code left to read is the only generic failure.
@@ -668,7 +671,7 @@ int32_t run_host_orchestration(
         LOG_RUNTIME_FAILURE(orch_error, PTO2_ERROR_NONE, status);
         LOG_ERROR(
             "host-orch: refusing to upload an incomplete graph after %" PRIu64 " heap bytes",
-            rt->orchestrator.ring.task_allocator.heap_used_bytes()
+            orchestrator.ring.task_allocator.heap_used_bytes()
         );
         return status;
     }
@@ -678,7 +681,7 @@ int32_t run_host_orchestration(
         char attrs[96];
         snprintf(
             attrs, sizeof(attrs), "tasks=%" PRId32 " heap_used=%" PRIu64, total_tasks,
-            rt->orchestrator.ring.task_allocator.heap_used_bytes()
+            orchestrator.ring.task_allocator.heap_used_bytes()
         );
         record_bind_phase(HostPhaseKind::BindHostOrch, t_orch_ns, attrs);
     }
@@ -730,7 +733,7 @@ int32_t run_host_orchestration(
     // What this bind actually put in the pools. The orchestrator's cursors are the
     // exact populated extent of each one — no scan of the mirror is needed, and the
     // image ships that much rather than the worst case the mirror is dimensioned for.
-    const PTO2OrchestratorState &orch_state = rt->orchestrator;
+    const PTO2OrchestratorState &orch_state = orchestrator;
     const pto2_sm_layout::BindUsage bind_usage{
         nt,
         static_cast<uint64_t>(orch_state.fanin_pool_cursor),
@@ -790,10 +793,10 @@ int32_t run_host_orchestration(
     // graph_context into it, and compaction is what carries those slots.
     stage_graph_submissions(staged_submissions, upload_base + copied_bytes + image_bytes, arena_dev + off_submissions);
 
-    // The orchestrator has finished, so its pointers into the host-only tail have
-    // no further reader on either side — and this header is about to be copied, so
-    // leaving them would carry host addresses to the device.
-    runtime_clear_host_only_pointers(rt);
+    // The copied zone carries no host address: the orchestrator is host-only and
+    // no device code may reach host memory through the image. Its work is done, so
+    // the pointer goes early rather than at the guard's scope exit.
+    rt->orchestrator = nullptr;
     std::memcpy(upload_base, static_cast<const char *>(host_arena.base()) + layout.off_copied_begin, copied_bytes);
     const uint64_t compacted = pto2_sm_layout::compact_live_image(
         static_cast<const char *>(host_sm), eff_task_window_sizes[0], bind_usage, upload_base + copied_bytes
@@ -1105,33 +1108,24 @@ extern "C" int bind_callable_to_runtime_impl(
     }
     {
         char attrs[64];
-        snprintf(
-            attrs, sizeof(attrs), "bytes=%" PRIu64 " device=%" PRIu64, static_cast<uint64_t>(layout.arena_size),
-            static_cast<uint64_t>(layout.device_bytes)
-        );
+        snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, static_cast<uint64_t>(layout.arena_size));
         record_bind_phase(HostPhaseKind::BindArenaBuild, t_arena_build_ns, attrs);
     }
 
     const int64_t t_static_arena_ns = bind_now_ns();
-    // Two things this call does not ask for at full size.
-    //
-    // device_bytes, not arena_size: the host-only zone at the arena's tail is
-    // dep-computation scratch no device code reads, so reserving device memory for
-    // it would be dead space for the length of the run.
-    //
     // No pooled shared memory: hbg's shared-memory image is the tail of its own
     // runtime-arena region, so this asks for 0 and leaves that pool uncommitted.
     // The arena is asked for only up to that tail, whose size is the submitted task
     // count — run_host_orchestration grows it once it knows. The heap must exist
     // first either way: the orchestrator hands out device heap addresses as it
     // places tasks.
-    if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, layout.device_bytes) != 0) {
+    if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, layout.arena_size) != 0) {
         LOG_ERROR("Failed to setup pooled static arena");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
         char attrs[96];
-        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " arena=%" PRIu64, total_heap_size, layout.device_bytes);
+        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " arena=%" PRIu64, total_heap_size, layout.arena_size);
         record_bind_phase(HostPhaseKind::BindStaticArena, t_static_arena_ns, attrs);
     }
 
@@ -1178,7 +1172,6 @@ extern "C" int bind_callable_to_runtime_impl(
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     runtime_wire_arena_pointers(host_arena, layout, rt);
-    runtime_wire_host_only_pointers(host_arena, layout, rt);
     // Stash the layout inside the PTO2Runtime image so the AICPU can recover every
     // arena-internal offset after the copy. It is written before orchestration
     // because orchestration is what performs that copy, and the runtime header is
@@ -1190,10 +1183,11 @@ extern "C" int bind_callable_to_runtime_impl(
 
     // host_build_graph host-orch: run the orchestrator on the host now, against
     // a host SM mirror, and ship the populated SM to the device. The arena
-    // (copied to the device below) carries the resulting orchestrator/scheduler
-    // state; the device boots scheduler-only. register_callable_impl guarantees
-    // host_orch_func_ptr is non-null on success (it fails the whole prepare
-    // otherwise), so this is an assertion-style guard, not a fallback path.
+    // (copied to the device below) carries the scheduler state; the orchestrator
+    // itself stays on the host, and the device boots scheduler-only.
+    // register_callable_impl guarantees host_orch_func_ptr is non-null on success
+    // (it fails the whole prepare otherwise), so this is an assertion-style
+    // guard, not a fallback path.
     if (host_orch_func_ptr == nullptr) {
         LOG_ERROR("host-orch: orchestration entry points were not resolved");
         return PTO_RUNTIME_ERR_INTERNAL;

--- a/src/a5/runtime/host_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/host_build_graph/orchestration/pto_orchestration_api.h
@@ -99,7 +99,7 @@ typedef struct PTO2RuntimeOps {
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const CoreTaskArgs &args);
     TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const CoreTaskArgs &args);
 
-    // This-run core geometry from runtime_finalize_after_wire: MIX clusters
+    // This-run core geometry latched by the host bind: MIX clusters
     // (one AIC each) and standalone AIV cores.
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_orchestrator.cpp
@@ -395,8 +395,6 @@ struct GraphRecording {
     // (the shape every generated orchestration uses) would therefore record a
     // node with no edge to its actual producer, and the Definition would replay
     // a DAG the same body never had when submitted task by task.
-    DeviceArena tensor_map_arena;
-    PTO2TensorMapLayout tensor_map_layout{};
     PTO2TensorMap tensor_map{};
     bool tensor_map_ready{false};
     // Scope depth as the body sees it. begin_scope/end_scope leave the real
@@ -556,19 +554,14 @@ graph_classify_scalar(const GraphRecording &recording, const ArgT &args, int32_t
 // is no ordinary-path fallback left to take.
 constexpr int32_t GRAPH_RECORD_TENSORMAP_POOL_SIZE = 16384;
 
-// Stand the recording's hazard map up on its own host allocation. Failure is
+// Stand the recording's hazard map up on its own allocation. Failure is
 // reported to the caller, which is still before the outer shell is submitted and
 // so can still take the ordinary path, rather than producing a Definition with
 // inferred edges missing.
 bool graph_recording_init_tensor_map(GraphRecording &recording) {
-    recording.tensor_map_layout = PTO2TensorMap::reserve_layout(
-        recording.tensor_map_arena, PTO2_TENSORMAP_NUM_BUCKETS, GRAPH_RECORD_TENSORMAP_POOL_SIZE, GRAPH_MAX_NODES
-    );
-    if (recording.tensor_map_arena.commit() == nullptr) return false;
-    if (!recording.tensor_map.init_data_from_layout(recording.tensor_map_layout, recording.tensor_map_arena)) {
+    if (!recording.tensor_map.init(PTO2_TENSORMAP_NUM_BUCKETS, GRAPH_RECORD_TENSORMAP_POOL_SIZE, GRAPH_MAX_NODES)) {
         return false;
     }
-    recording.tensor_map.wire_arena_pointers(recording.tensor_map_layout, recording.tensor_map_arena);
     recording.tensor_map_ready = true;
     return true;
 }
@@ -940,7 +933,8 @@ static uint32_t next_fanin_seen_epoch(PTO2OrchestratorState *orch) {
     uint32_t next = orch->fanin_seen_current_epoch + 1;
     if (next == 0) {
         memset(
-            orch->fanin_seen_epoch, 0, static_cast<size_t>(orch->sm_header->ring.task_window_size) * sizeof(uint32_t)
+            orch->fanin_seen_epoch.get(), 0,
+            static_cast<size_t>(orch->sm_header->ring.task_window_size) * sizeof(uint32_t)
         );
         next = 1;
     }
@@ -975,7 +969,7 @@ struct PTO2FaninBuilder {
         if (prod_ring >= PTO2_MAX_RING_DEPTH || prod_slot < 0) {
             return false;
         }
-        uint32_t *seen = orch->fanin_seen_epoch;
+        uint32_t *seen = orch->fanin_seen_epoch.get();
         uint32_t slot = static_cast<uint32_t>(prod_slot);
         if (seen[slot] == seen_epoch) {
             return true;
@@ -1152,11 +1146,9 @@ static bool prepare_task(
 
 static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state) {
     if (orch->scope_tasks_size >= orch->scope_tasks_capacity) {
-        // scope_tasks lives in the per-Worker arena (single backing allocation),
-        // so realloc is not legal. Capacity is the total in-flight slot budget
-        // (the runtime task window; see reserve_layout) — hitting it means the
-        // ring is saturated, so no further push could succeed regardless of
-        // buffer growth.
+        // Capacity is the total in-flight slot budget (the runtime task window;
+        // see PTO2OrchestratorState::init) — hitting it means the ring is
+        // saturated, so no further push could succeed regardless of buffer growth.
         orch->report_fatal(
             PTO2_ERROR_SCOPE_TASKS_OVERFLOW, __FUNCTION__,
             "scope_tasks buffer saturated at %d entries (all rings full)", orch->scope_tasks_capacity

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/pto_runtime2.cpp
@@ -85,64 +85,67 @@ static constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_CYCLES =
 
 static TaskOutputTensors
 submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
-    return rt->orchestrator.submit_task(mixed_kernels, args);
+    return rt->orchestrator->submit_task(mixed_kernels, args);
 }
 
 static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const CoreTaskArgs &args) {
-    return rt->orchestrator.alloc_tensors(args);
+    return rt->orchestrator->alloc_tensors(args);
 }
 
 static TaskOutputTensors submit_dummy_task_impl(PTO2Runtime *rt, const CoreTaskArgs &args) {
-    return rt->orchestrator.submit_dummy_task(args);
+    return rt->orchestrator->submit_dummy_task(args);
 }
 
 static GraphScopeResult graph_begin_impl(PTO2Runtime *rt, uint64_t graph_key, const GraphTaskArgs &args) {
     if (rt == nullptr) return GraphScopeResult{};
-    return rt->orchestrator.graph_begin(graph_key, args, rt->active_callable_hash);
+    return rt->orchestrator->graph_begin(graph_key, args, rt->active_callable_hash);
 }
 
 static bool graph_prepare_impl(PTO2Runtime *rt, void *recording_handle, const GraphTaskArgs &args) {
-    return rt != nullptr && rt->orchestrator.graph_prepare(recording_handle, args);
+    return rt != nullptr && rt->orchestrator->graph_prepare(recording_handle, args);
 }
 
 static void graph_abort_impl(PTO2Runtime *rt, void *recording_handle) {
-    if (rt != nullptr) rt->orchestrator.graph_abort(recording_handle);
+    if (rt != nullptr) rt->orchestrator->graph_abort(recording_handle);
 }
 
-static bool graph_end_impl(PTO2Runtime *rt) { return rt != nullptr && rt->orchestrator.graph_end(); }
+static bool graph_end_impl(PTO2Runtime *rt) { return rt != nullptr && rt->orchestrator->graph_end(); }
 
 static void graph_commit_impl(PTO2Runtime *rt) {
-    if (rt != nullptr) rt->orchestrator.graph_commit();
+    if (rt != nullptr) rt->orchestrator->graph_commit();
 }
 
 void rt_scope_begin(PTO2Runtime *rt) {
     PTO2ScopeMode mode = rt->pending_scope_mode;
     rt->pending_scope_mode = PTO2ScopeMode::AUTO;
-    rt->orchestrator.begin_scope(mode);
+    rt->orchestrator->begin_scope(mode);
 }
 
-void rt_scope_end(PTO2Runtime *rt) { rt->orchestrator.end_scope(); }
+void rt_scope_end(PTO2Runtime *rt) { rt->orchestrator->end_scope(); }
 
 void rt_orchestration_done(PTO2Runtime *rt) {
     // Host orchestration calls this runtime entry directly rather than the
     // orchestration-SO wrapper. Commit here as well so an all-Graph entry has a
     // final synchronization point for its asynchronous recording and deferred
     // outer shells even when no later non-Graph task forced an earlier commit.
-    rt->orchestrator.graph_commit();
-    rt->orchestrator.mark_done();
+    rt->orchestrator->graph_commit();
+    rt->orchestrator->mark_done();
+    // The orchestrator itself never crosses to the device, so the count of tasks
+    // it completed inline is published into the header that does.
+    rt->inline_completed_tasks = rt->orchestrator->inline_completed_tasks;
 }
 
-static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator.fatal; }
+static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator->fatal; }
 
 void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     if (fmt == nullptr || fmt[0] == '\0') {
-        rt->orchestrator.report_fatal(error_code, func, nullptr);
+        rt->orchestrator->report_fatal(error_code, func, nullptr);
     } else {
         char message[1024];
         vsnprintf(message, sizeof(message), fmt, args);
-        rt->orchestrator.report_fatal(error_code, func, "%s", message);
+        rt->orchestrator->report_fatal(error_code, func, "%s", message);
     }
     va_end(args);
 }
@@ -157,7 +160,7 @@ MAYBE_UNINITIALIZED_BEGIN
 static bool
 wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_consumers, const char *caller) {
     PTO2TaskId owner = tensor.owner_task_id;
-    PTO2OrchestratorState &orch = rt->orchestrator;
+    PTO2OrchestratorState &orch = *rt->orchestrator;
 
     // Segmented wait: collect up to kSegmentCap producer slots, then flush by
     // spinning on each. When the segment fills, we wait for the accumulated
@@ -324,7 +327,7 @@ uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndi
     uint64_t elem_addr = tensor.buffer.addr + flat_offset * elem_size;
     uint64_t result = 0;
     if (!host_tensor_read(rt->tensor_access, elem_addr, &result, elem_size)) {
-        rt->orchestrator.report_fatal(
+        rt->orchestrator->report_fatal(
             PTO2_ERROR_INVALID_ARGS, __FUNCTION__,
             "no host view for device address %#llx (%llu bytes): during host orchestration only tensors the "
             "runtime staged are readable, not runtime-created or child-memory buffers",
@@ -355,7 +358,7 @@ void set_tensor_data(
     uint64_t elem_size = get_element_size(tensor.dtype);
     uint64_t elem_addr = tensor.buffer.addr + flat_offset * elem_size;
     if (!host_tensor_write(rt->tensor_access, elem_addr, &value, elem_size)) {
-        rt->orchestrator.report_fatal(
+        rt->orchestrator->report_fatal(
             PTO2_ERROR_INVALID_ARGS, __FUNCTION__,
             "no writable host view for device address %#llx (%llu bytes): during host orchestration only tensors "
             "the runtime staged are writable, not runtime-created or child-memory buffers",
@@ -372,8 +375,8 @@ void set_tensor_data(
 static void scope_set_site_impl(const char *file, int line) { scope_stats_set_pending_site(file, line); }
 #endif
 
-static int32_t available_cluster_count_impl(PTO2Runtime *rt) { return rt->orchestrator.total_cluster_count; }
-static int32_t available_aiv_count_impl(PTO2Runtime *rt) { return rt->orchestrator.total_aiv_count; }
+static int32_t available_cluster_count_impl(PTO2Runtime *rt) { return rt->orchestrator->total_cluster_count; }
+static int32_t available_aiv_count_impl(PTO2Runtime *rt) { return rt->orchestrator->total_aiv_count; }
 
 static const PTO2RuntimeOps s_runtime_ops = {
     .submit_task = submit_task_impl,
@@ -411,15 +414,10 @@ static const PTO2RuntimeOps s_runtime_ops = {
 //
 // Layout / init_data / wire / destroy live in
 // runtime/shared/pto_runtime2_init.cpp so the host build can pre-populate the
-// prebuilt arena image. The pieces below — wiring the ops table and the
-// SPMD core counts — depend on the device-side s_runtime_ops global and the
-// AICPU SchedulerContext respectively, so they remain in the AICPU build.
+// prebuilt arena image. The piece below — wiring the ops table — depends on the
+// device-side s_runtime_ops global, so it remains in the AICPU build.
 
-void runtime_finalize_after_wire(PTO2Runtime *rt, int32_t aic_count, int32_t aiv_count) {
-    rt->ops = &s_runtime_ops;
-    rt->orchestrator.total_cluster_count = aic_count;
-    rt->orchestrator.total_aiv_count = aiv_count;
-}
+void runtime_bind_ops(PTO2Runtime *rt) { rt->ops = &s_runtime_ops; }
 
 void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode) {
     if (rt) {

--- a/src/a5/runtime/host_build_graph/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_orchestrator.h
@@ -27,8 +27,9 @@
 
 #pragma once
 
+#include <memory>
+
 #include "common/chip_swimlane_profiling.h"
-#include "utils/device_arena.h"
 #include "pto_ring_buffer.h"
 #include "graph_cache.h"
 #include "pto_runtime2_types.h"
@@ -40,20 +41,6 @@
 
 struct GraphHostState;
 
-/**
- * Layout descriptor produced by PTO2OrchestratorState::reserve_layout(). Holds
- * arena offsets for every sub-region the orchestrator owns (per-ring fanin
- * pools, scope arrays, plus the nested PTO2TensorMap layout).
- */
-struct PTO2OrchestratorLayout {
-    size_t off_fanin_seen_epoch;
-    size_t off_scope_tasks;
-    size_t off_scope_begins;
-    PTO2TensorMapLayout tensor_map;
-    int32_t scope_tasks_cap;
-    uint64_t scope_stack_capacity;
-};
-
 // =============================================================================
 // Orchestrator State
 // =============================================================================
@@ -62,6 +49,12 @@ struct PTO2OrchestratorLayout {
  * Orchestrator state structure (private to Orchestrator)
  *
  * Contains all state needed for task graph construction and buffer management.
+ *
+ * host_build_graph runs the orchestrator on the host and ships the shared-memory
+ * image it produces, so this whole object is host-only: it owns its scratch
+ * arrays outright and no device code reads any of them. PTO2Runtime therefore
+ * holds it by pointer — a by-value member would put non-trivially-copyable state
+ * inside the struct bind copies to the device.
  */
 struct PTO2OrchestratorState {
     // === SHARED MEMORY ACCESS ===
@@ -69,7 +62,7 @@ struct PTO2OrchestratorState {
 
     // === RING RESOURCES (single ring) ===
     PTO2RingSet ring;
-    uint32_t *fanin_seen_epoch;
+    std::unique_ptr<uint32_t[]> fanin_seen_epoch;
     uint32_t fanin_seen_current_epoch{1};
 
     // === TENSOR MAP (Private) ===
@@ -79,12 +72,12 @@ struct PTO2OrchestratorState {
     // Single contiguous buffer of task IDs, partitioned by scope level.
     // scope_begins[i] is the index into scope_tasks where scope i starts.
     // Tasks for the top scope occupy [scope_begins[top], scope_tasks_size).
-    PTO2TaskSlotState **scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
-    int32_t scope_tasks_size;         // Number of task IDs currently in the buffer
-    int32_t scope_tasks_capacity;     // Allocated capacity of scope_tasks
-    int32_t *scope_begins;            // scope_begins[i] = start index of scope i in scope_tasks
-    int32_t scope_stack_top;          // Current top of stack (-1 = no scope open)
-    uint64_t scope_stack_capacity;    // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
+    std::unique_ptr<PTO2TaskSlotState *[]> scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
+    int32_t scope_tasks_size{0};                         // Number of task IDs currently in the buffer
+    int32_t scope_tasks_capacity{0};                     // Allocated capacity of scope_tasks
+    std::unique_ptr<int32_t[]> scope_begins;             // scope_begins[i] = start index of scope i in scope_tasks
+    int32_t scope_stack_top{-1};                         // Current top of stack (-1 = no scope open)
+    uint64_t scope_stack_capacity{0};                    // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
     int32_t manual_begin_depth{PTO2_MAX_SCOPE_DEPTH};
 
     // === SCHEDULER REFERENCE ===
@@ -107,12 +100,12 @@ struct PTO2OrchestratorState {
 
     // Hidden alloc tasks complete synchronously inside the orchestrator and
     // therefore bypass the executor's normal worker-completion counter path.
-    // The executor adds this count into its completed_tasks_ progress counter
-    // after orchestration finishes so shutdown/profiling totals remain closed.
+    // rt_orchestration_done publishes this into PTO2Runtime, which is the copy
+    // the device-side executor adds into its completed_tasks_ progress counter
+    // so shutdown/profiling totals remain closed.
     int64_t inline_completed_tasks{0};
 
-    // This host-only state is cleared before the arena/shared-memory image
-    // crosses to the device.
+    // Host-only, like everything else here.
     GraphHostState *graph_host_state{nullptr};
 
     // === ARGUMENT POOLS (host-only) ===
@@ -144,29 +137,17 @@ struct PTO2OrchestratorState {
 
     // === Cold-path API (defined in pto_orchestrator.cpp) ===
 
-    // Phase 1: declare every sub-region (per-ring fanin pool, scope arrays,
-    // tensor_map sub-layout) on the supplied arena. task_window_sizes feeds
-    // the nested tensor_map layout. Returned layout is consumed by
-    // init_from_layout.
-    static PTO2OrchestratorLayout reserve_layout(DeviceArena &arena, int32_t task_window_size);
+    // Allocate the scratch arrays (fanin epoch table, scope arrays, tensor map)
+    // and bind this orchestrator to one shared-memory mirror, GM heap and
+    // scheduler. sm_base is the base of the mirror this orchestrator writes; it
+    // is dereferenced, so a host-orch pass passes its host mirror rather than a
+    // device address. task_window_size must be a power of two.
+    //
+    // Returns false when an allocation fails; the caller then has no hazard map
+    // and must not orchestrate.
+    bool
+    init(void *sm_base, void *gm_heap, uint64_t heap_size, uint64_t task_window_size, PTO2SchedulerState *scheduler);
 
-    // Phase 3a: write everything *except* arena-internal pointer fields.
-    // sm_dev_base is the SM device address (only stored, never dereferenced);
-    // task_window_size feeds the SM address arithmetic. Safe to call on a host
-    // arena that holds the prebuilt image.
-    bool init_data_from_layout(
-        const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap, uint64_t heap_size,
-        uint64_t task_window_size
-    );
-
-    // Phase 3b: write the arena-internal pointer fields (scope_tasks,
-    // scope_begins, tensor_map.{buckets,entry_pool,free_entry_list,
-    // task_entry_heads}, scheduler reference).
-    // Idempotent — host runs once on the image, AICPU runs once after attach.
-    void wire_arena_pointers(const PTO2OrchestratorLayout &layout, DeviceArena &arena, PTO2SchedulerState *scheduler);
-
-    // Forget pointers; arena owns the backing buffers.
-    void destroy();
     void set_scheduler(PTO2SchedulerState *scheduler);
     void report_fatal(int32_t error_code, const char *func, const char *fmt, ...);
     void begin_scope(PTO2ScopeMode mode = PTO2ScopeMode::AUTO);

--- a/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_runtime2.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "utils/device_arena.h"
 #include "pto_runtime2_types.h"
 #include "graph_cache.h"
@@ -92,7 +94,7 @@ struct PTO2RuntimeOps {
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const CoreTaskArgs &args);
     TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const CoreTaskArgs &args);
 
-    // This-run core geometry from runtime_finalize_after_wire: MIX clusters
+    // This-run core geometry latched by the host bind: MIX clusters
     // (one AIC each) and standalone AIV cores.
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
@@ -109,20 +111,19 @@ struct PTO2RuntimeOps {
 
 /**
  * Layout descriptor for the prebuilt runtime arena. Holds all sub-region
- * offsets (orchestrator / scheduler / sm_handle wrapper / runtime header /
- * AICore mailbox) plus the layout-defining capacities. Produced once on the
- * host by runtime_reserve_layout(); consumed by runtime_init_data_from_layout
- * and runtime_wire_arena_pointers.
+ * offsets (scheduler / sm_handle wrapper / runtime header / AICore mailbox)
+ * plus the layout-defining capacities. Produced once on the host by
+ * runtime_reserve_layout(); consumed by runtime_init_data_from_layout and
+ * runtime_wire_arena_pointers.
  */
 struct PTO2RuntimeArenaLayout {
     size_t off_sm_handle{0};
-    PTO2OrchestratorLayout orch;
     PTO2SchedulerLayout sched;
     size_t off_scheduler{0};
     size_t off_runtime{0};
     size_t off_mailbox{0};
-    // The arena is reserved in zones, in this order, and the offsets above land in
-    // exactly one of them:
+    // Every region in this arena is device-resident. The arena is reserved in two
+    // zones, in this order, and the offsets above land in exactly one of them:
     //
     //   device-only  sm_handle, the AICore mailbox, the scheduler state and its
     //                queue slot arrays. Reachable storage whose content is a
@@ -133,31 +134,27 @@ struct PTO2RuntimeArenaLayout {
     //                run's own content, so bind ships the whole zone as one
     //                contiguous range.
     //
-    // off_copied_end is where the shared part of the layout stops. Past it the two
-    // sides carry different tails, and neither reads the other's:
+    // Past off_copied_end the device carries one further tail the host arena does
+    // not: the shared-memory image, whose size is the submitted task count and
+    // therefore not known when this layout is built. bind grows the device region
+    // to cover it once orchestration ends.
     //
-    //   host tail    the orchestrator block. Dep-computation scratch no device code
-    //                reads, so it is neither copied nor allocated on the device.
-    //   device tail  the shared-memory image, whose size is the submitted task
-    //                count and therefore not known when this layout is built. bind
-    //                grows the device region to cover it once orchestration ends.
+    // The copied zone is padded to a PTO2_ALIGN_SIZE boundary, so that tail begins
+    // exactly at off_copied_end: the copied zone and the shared-memory image are
+    // adjacent on the device and travel as one copy.
     //
-    // The copied zone is padded to a PTO2_ALIGN_SIZE boundary, so the device tail
-    // begins exactly at off_copied_end: the copied zone and the shared-memory image
-    // are adjacent on the device and travel as one copy.
+    // The orchestrator is NOT here. It runs on the host, owns its own scratch, and
+    // no device code reads any of it — see PTO2OrchestratorState.
     size_t off_copied_begin{0};
     size_t off_copied_end{0};
-
-    // Byte length of the device region before its shared-memory tail. The host
-    // arena is arena_size, which instead covers the orchestrator block there.
-    size_t device_bytes{0};
 
     // Cached parameters (re-used by init_data + wire stages).
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]{};
     uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]{};
 
     // Total arena byte size post-commit. Used by host to size the prebuilt
-    // image buffer and as the rtMemcpy length.
+    // image buffer and as the rtMemcpy length, and requested of the device as
+    // the region length before its shared-memory tail.
     size_t arena_size{0};
 };
 
@@ -174,7 +171,11 @@ struct PTO2Runtime {
 
     // Components
     PTO2SharedMemoryHandle *sm_handle;
-    PTO2OrchestratorState orchestrator;
+    // Host-only, and by pointer so that this header stays trivially copyable:
+    // the orchestrator runs on the host and owns non-trivial scratch. Null on the
+    // device — bind drops it before the copied zone is uploaded, so no device code
+    // may dereference it.
+    PTO2OrchestratorState *orchestrator;
     // Device-only zone: the scheduler state holds no per-run content, so it is
     // addressed through the arena rather than carried inside this header.
     PTO2SchedulerState *scheduler;
@@ -190,6 +191,10 @@ struct PTO2Runtime {
 
     // Statistics
     int64_t total_cycles;
+    // Hidden alloc tasks the host orchestrator completed inline, published here by
+    // rt_orchestration_done. The device-side executor folds this into its
+    // completed_tasks_ progress counter so shutdown/profiling totals stay closed.
+    int64_t inline_completed_tasks;
     // Graph definitions are process-local host cache entries. The callable
     // identity prevents two orchestration DSOs from sharing the same key.
     uint64_t active_callable_hash;
@@ -212,16 +217,24 @@ struct PTO2Runtime {
     PTO2RuntimeArenaLayout prebuilt_layout;
 };
 
+// bind copies this header to the device as one contiguous range, so every byte
+// of it has to survive a memcpy with no fix-up. That rules out an owning or
+// otherwise non-trivial member — the orchestrator's scratch is reached through
+// a pointer for exactly this reason.
+static_assert(
+    std::is_trivially_copyable_v<PTO2Runtime> && std::is_standard_layout_v<PTO2Runtime>,
+    "PTO2Runtime is copied to the device verbatim"
+);
+
 // =============================================================================
 // Runtime Lifecycle API
 // =============================================================================
 
 /**
- * Phase 1 — declare every sub-region (sm_handle wrapper, orchestrator /
- * scheduler / tensor_map / mailbox / PTO2Runtime header) on the supplied
- * arena. Pure arithmetic; does not touch device memory and may run on host.
- * Returns the layout descriptor; caller commits/attaches the arena before
- * Phase 2/3.
+ * Phase 1 — declare every sub-region (sm_handle wrapper, scheduler / mailbox /
+ * PTO2Runtime header) on the supplied arena. Pure arithmetic; does not touch
+ * device memory and may run on host. Returns the layout descriptor; caller
+ * commits/attaches the arena before Phase 2/3.
  */
 PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size);
 PTO2RuntimeArenaLayout runtime_reserve_layout(
@@ -242,10 +255,9 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
  * Returns the PTO2Runtime* that sits at layout.off_runtime within the arena.
  * Caller must follow up with runtime_wire_arena_pointers; rt->ops and the
  * AICore-side count fields are left untouched and must be filled by the
- * AICPU at boot. Initializes the scheduler only: the orchestrator is left
- * zeroed for the host-orch path (run_host_orchestration) to initialize
- * against the host SM, since initializing it here would be overwritten and
- * is never uploaded to the device.
+ * AICPU at boot. Initializes the scheduler only: the orchestrator is a
+ * host-owned object the host-orch path (run_host_orchestration) stands up and
+ * points rt->orchestrator at, and it is never uploaded to the device.
  */
 PTO2Runtime *runtime_init_data_from_layout(
     DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
@@ -266,32 +278,12 @@ PTO2Runtime *runtime_init_data_from_layout(
 void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
 
 /**
- * Phase 3b — wire the orchestrator's pointers into the host-only zone
- * (orchestrator.{scope_tasks, scope_begins, scheduler, tensor_map.*}).
- *
- * Host-only by construction: that zone is past layout.device_bytes and so is not
- * allocated on the device, which makes the addresses this writes unrepresentable
- * there. Requires rt->scheduler, so it follows runtime_wire_arena_pointers.
+ * AICPU-only Phase 4 — install the ops table, the one field the host could not
+ * know at prebuilt-image build time (s_runtime_ops is a device-side file-local
+ * global, so the host cannot resolve its device address). Call once per boot
+ * after runtime_wire_arena_pointers.
  */
-void runtime_wire_host_only_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
-
-/**
- * Drop the pointers Phase 3b wrote, so the runtime header can be copied to the
- * device without carrying host addresses into it. The device reads one
- * orchestrator field, inline_completed_tasks, which this leaves alone.
- *
- * Call after orchestration finishes and before the copied zone is uploaded.
- */
-void runtime_clear_host_only_pointers(PTO2Runtime *rt);
-
-/**
- * AICPU-only Phase 4 — fill in the few fields the host could not know at
- * prebuilt-image build time: the ops table (s_runtime_ops is a device-side
- * file-local global, host cannot resolve its device address) and the
- * orchestrator's core counts (depend on the executor's scheduler context).
- * Call once per boot after runtime_wire_arena_pointers.
- */
-void runtime_finalize_after_wire(PTO2Runtime *rt, int32_t aic_count, int32_t aiv_count);
+void runtime_bind_ops(PTO2Runtime *rt);
 
 /**
  * Destroy runtime. With the prebuilt-arena fast path the arena buffer is

--- a/src/a5/runtime/host_build_graph/runtime/pto_tensormap.h
+++ b/src/a5/runtime/host_build_graph/runtime/pto_tensormap.h
@@ -16,8 +16,12 @@
  * - Maps ChipTensor -> producer task ID
  * - Used by pto_submit_task() to find dependencies
  *
+ * host_build_graph runs its orchestrator on the host, so this map is host-only
+ * state: it owns its four arrays outright rather than addressing them as offsets
+ * into a device-shaped arena. Nothing here is copied to the device.
+ *
  * Key design features:
- * 1. Fixed-capacity arena pool for entries (no malloc/free)
+ * 1. Fixed-capacity entry pool (no per-entry malloc/free)
  * 2. Task completion does not retire entries; a producer stays visible until
  *    dependency computation explicitly removes it as semantically covered
  * 3. Per-task entry tracking for explicit removal
@@ -43,9 +47,10 @@
 
 #pragma once
 
+#include <memory>
+
 #include "common.h"
 #include "profiling_config.h"
-#include "utils/device_arena.h"
 #include "pto_runtime2_types.h"
 #include "tensor.h"
 
@@ -64,23 +69,6 @@ struct Segment {
 
     bool line_segment_intersection(const Segment &other) const { return end > other.begin && other.end > begin; }
     bool contains(const Segment &other) const { return begin <= other.begin && other.end <= end; }
-};
-
-/**
- * Layout descriptor produced by PTO2TensorMap::reserve_layout(). Stores the
- * region offsets returned by DeviceArena::reserve() so init_from_layout()
- * can fetch the matching pointers after the arena is committed.
- *
- * All offsets are relative to the arena's base.
- */
-struct PTO2TensorMapLayout {
-    size_t off_buckets;
-    size_t off_entry_pool;
-    size_t off_free_entry_list;
-    size_t off_task_entry_heads;
-    int32_t num_buckets;
-    int32_t pool_size;
-    int32_t task_window_size;
 };
 
 // TensorMap Lookup Profiling (must precede inline lookup/insert methods).
@@ -357,23 +345,26 @@ static_assert(
  * TensorMap structure
  *
  * Hash table with a fixed-capacity entry pool and no watermark invalidation.
+ * Owns its four arrays; init() sizes them and leaves the map empty.
  */
 struct PTO2TensorMap {
-    // Hash table buckets (fixed size, power of 2)
-    PTO2TensorMapEntry **buckets;  // Array of offsets into entry_pool (-1 = empty)
-    int32_t num_buckets;           // Must be power of 2 for fast modulo
+    // Hash table buckets (fixed size, power of 2). An empty bucket is nullptr.
+    std::unique_ptr<PTO2TensorMapEntry *[]> buckets;
+    int32_t num_buckets{0};  // Must be power of 2 for fast modulo
 
-    // Entry pool: bump allocation plus reuse of explicitly removed entries.
-    PTO2TensorMapEntry *entry_pool;
-    PTO2TensorMapEntry **free_entry_list;
-    int32_t pool_size;       // Total pool capacity
-    int32_t next_entry_idx;  // id when next entry insert
-    int32_t free_num;        // free entry number in entry pool
+    // Entry pool: bump allocation plus reuse of explicitly removed entries. A
+    // linked entry is reached by pointer, so the pool is allocated once at
+    // pool_size and never resized.
+    std::unique_ptr<PTO2TensorMapEntry[]> entry_pool;
+    std::unique_ptr<PTO2TensorMapEntry *[]> free_entry_list;
+    int32_t pool_size{0};       // Total pool capacity
+    int32_t next_entry_idx{0};  // id when next entry insert
+    int32_t free_num{0};        // free entry number in entry pool
 
     // Per-task entry tracking for O(1) unlinking of covered producers.
     // Indexed by [local_id & (task_window_size - 1)]
-    PTO2TensorMapEntry **task_entry_heads;
-    int32_t task_window_size;  // Task window size (for slot masking)
+    std::unique_ptr<PTO2TensorMapEntry *[]> task_entry_heads;
+    int32_t task_window_size{0};  // Task window size (for slot masking)
 
     uint32_t get_task_local_id_slot(uint32_t task_local_id) const { return task_local_id & (task_window_size - 1); }
 
@@ -396,7 +387,7 @@ struct PTO2TensorMap {
         }
         always_assert(next_entry_idx < pool_size);
         PTO2TensorMapEntry *res = &entry_pool[next_entry_idx++];
-        // Init-on-write: the pool is not pre-zeroed (init_data_from_layout skips
+        // Init-on-write: the pool is not pre-zeroed (init() skips
         // the O(pool_size) memset), so put this fresh slot into the same clean
         // unlinked state free_entry() leaves recycled slots in. The insert path
         // overwrites the remaining fields exactly as it does for a recycled slot,
@@ -439,40 +430,25 @@ struct PTO2TensorMap {
     // =============================================================================
 
     /**
-     * Phase 1: reserve every sub-region (buckets, entry_pool, free list, per-ring
-     * task_entry_heads) on the supplied arena. Records the resulting offsets in
-     * the returned layout descriptor. Must be called before the arena is
-     * committed.
+     * Allocate the four arrays and leave the map empty. num_buckets must be a
+     * power of two; task_window_size must be a power of two, since a producer's
+     * task chain is selected by `local_id & (task_window_size - 1)`.
+     *
+     * Returns false when an allocation fails, so a caller that still has an
+     * alternative path can take it rather than proceed without a hazard map.
+     *
+     * Clearing is O(num_buckets + task_window_size), not O(pool_size): the entry
+     * pool is left uninitialized and new_entry() puts each slot into the clean
+     * unlinked state on first use, and free_entry_list is a stack meaningful only
+     * below free_num.
      */
-    static PTO2TensorMapLayout
-    reserve_layout(DeviceArena &arena, int32_t num_buckets, int32_t pool_size, int32_t task_window_size);
+    bool init(int32_t new_num_buckets, int32_t new_pool_size, int32_t new_task_window_size);
 
     /**
-     * Same as reserve_layout() with default sizes (PTO2_TENSORMAP_NUM_BUCKETS,
+     * Same as init() with default sizes (PTO2_TENSORMAP_NUM_BUCKETS,
      * PTO2_TENSORMAP_POOL_SIZE).
      */
-    static PTO2TensorMapLayout reserve_layout_default(DeviceArena &arena, int32_t task_window_size);
-
-    /**
-     * Phase 3a: write everything *except* arena-internal pointer fields
-     * (buckets, entry_pool, free_entry_list, task_entry_heads).
-     * Uses arena.region_ptr to address the arena regions for data writes,
-     * but does not store those addresses in struct fields. Safe to call on
-     * a host arena that holds the prebuilt image.
-     */
-    bool init_data_from_layout(const PTO2TensorMapLayout &layout, DeviceArena &arena);
-
-    /**
-     * Phase 3b: write the arena-internal pointer fields. Idempotent;
-     * called once on the host arena and once on the AICPU after attach.
-     */
-    void wire_arena_pointers(const PTO2TensorMapLayout &layout, DeviceArena &arena);
-
-    /**
-     * Tear down state. Does not free memory — the arena owns the backing
-     * buffer. Pointers are set to nullptr so accidental reuse traps.
-     */
-    void destroy();
+    bool init_default(int32_t new_task_window_size);
 
     /**
      * Lookup producer for a tensor region

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -1082,7 +1082,7 @@ void SchedulerContext::on_orchestration_done(
     }
 
     // Fold tasks completed inline during orchestration
-    int32_t inline_completed = static_cast<int32_t>(rt->orchestrator.inline_completed_tasks);
+    int32_t inline_completed = static_cast<int32_t>(rt->inline_completed_tasks);
     if (inline_completed > 0) {
         completed_tasks_.fetch_add(inline_completed, std::memory_order_relaxed);
 #if SIMPLER_SCHED_PROFILING

--- a/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/pto_runtime2_init.cpp
@@ -50,8 +50,7 @@ static bool sum_ring_heap_sizes(const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], 
 
 size_t ready_queue_reserve_layout(DeviceArena &arena, uint64_t capacity) {
     // Align the slots[] base to a full cache line so MPMC CAS traffic on the
-    // first slot cannot false-share with whatever region sits in front of us
-    // (e.g. orchestrator tensormap heads written by the orch thread).
+    // first slot cannot false-share with whatever region sits in front of us.
     return arena.reserve(capacity * sizeof(PTO2ReadyQueueSlot), PTO2_ALIGN_SIZE);
 }
 
@@ -215,94 +214,61 @@ void PTO2SchedulerState::destroy() {
 // Orchestrator
 // =============================================================================
 
-PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(DeviceArena &arena, int32_t task_window_size) {
-    PTO2OrchestratorLayout layout{};
+bool PTO2OrchestratorState::init(
+    void *sm_base, void *gm_heap, uint64_t heap_size, uint64_t task_window_size, PTO2SchedulerState *scheduler_arg
+) {
+    auto *orch = this;
+    *orch = PTO2OrchestratorState{};
+
     // scope_tasks holds every task in the open scope, so its cap is the real
     // in-flight budget = the (runtime) task window. Using the compile-time
     // PTO2_SCOPE_TASKS_CAP instead under-sized the buffer when ring_task_window
     // was enlarged past the default (premature SCOPE_TASKS_OVERFLOW) and
     // over-allocated it when shrunk. See issue #1188.
-    always_assert(task_window_size > 0);
-    layout.scope_tasks_cap = task_window_size;
-    layout.scope_stack_capacity = PTO2_MAX_SCOPE_DEPTH;
-
-    // Polling: no fanin-spill pool — producer ids are inline on the payload.
     always_assert(task_window_size > 0 && (task_window_size & (task_window_size - 1)) == 0);
-    const size_t seen_epoch_bytes =
-        PTO2_ALIGN_UP(static_cast<size_t>(task_window_size) * sizeof(uint32_t), PTO2_ALIGN_SIZE);
-    layout.off_fanin_seen_epoch = arena.reserve(seen_epoch_bytes, PTO2_ALIGN_SIZE);
 
-    layout.off_scope_tasks =
-        arena.reserve(static_cast<size_t>(layout.scope_tasks_cap) * sizeof(uintptr_t), alignof(PTO2TaskSlotState *));
-    layout.off_scope_begins =
-        arena.reserve(static_cast<size_t>(layout.scope_stack_capacity) * sizeof(int32_t), alignof(int32_t));
-    layout.tensor_map = PTO2TensorMap::reserve_layout_default(arena, task_window_size);
-    return layout;
-}
-
-bool PTO2OrchestratorState::init_data_from_layout(
-    const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap, uint64_t heap_size,
-    uint64_t task_window_size
-) {
-    auto *orch = this;
-    *orch = PTO2OrchestratorState{};
-
-    orch->sm_header = reinterpret_cast<PTO2SharedMemoryHeader *>(sm_dev_base);
+    orch->sm_header = reinterpret_cast<PTO2SharedMemoryHeader *>(sm_base);
     orch->gm_heap_base = gm_heap;
     orch->gm_heap_size = heap_size;
     orch->fatal = false;
+    orch->scheduler = scheduler_arg;
 
-    auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_dev_base);
-    auto *cur_idx_dev = pto2_sm_layout::ring_current_task_index_addr(sm_dev_base);
+    auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_base);
+    auto *cur_idx_dev = pto2_sm_layout::ring_current_task_index_addr(sm_base);
 
     orch->ring.task_allocator.init(static_cast<int32_t>(task_window_size), cur_idx_dev, gm_heap, heap_size, orch_err);
 
     // The mirror's argument pools. Offset arithmetic on the same base as sm_header,
-    // so it holds for whichever SM this orchestrator was pointed at — the host-orch
-    // path re-inits against the host mirror before orchestration. The cursors reset
-    // with the rest of the state above.
-    auto *sm_bytes = static_cast<char *>(sm_dev_base);
+    // so it holds for whichever SM this orchestrator was pointed at. The cursors
+    // reset with the rest of the state above.
+    auto *sm_bytes = static_cast<char *>(sm_base);
     const auto pools = pto2_sm_layout::ring_segment_offsets(pto2_sm_layout::mirror_extents(task_window_size));
     orch->fanin_pool = reinterpret_cast<int32_t *>(sm_bytes + pools.fanin_pool);
     orch->tensor_pool = reinterpret_cast<ChipTensor *>(sm_bytes + pools.tensor_pool);
     orch->scalar_pool = reinterpret_cast<uint64_t *>(sm_bytes + pools.scalar_pool);
 
-    const size_t seen_epoch_bytes =
-        PTO2_ALIGN_UP(static_cast<size_t>(layout.tensor_map.task_window_size) * sizeof(uint32_t), PTO2_ALIGN_SIZE);
-    auto *seen_epoch = static_cast<uint32_t *>(arena.region_ptr(layout.off_fanin_seen_epoch));
-    memset(seen_epoch, 0, seen_epoch_bytes);
-    orch->fanin_seen_epoch = seen_epoch;
+    // Polling: no fanin-spill pool — producer ids are inline on the payload.
+    const auto window = static_cast<size_t>(task_window_size);
+    orch->fanin_seen_epoch.reset(new (std::nothrow) uint32_t[window]);
+    orch->scope_tasks.reset(new (std::nothrow) PTO2TaskSlotState *[window]);
+    orch->scope_begins.reset(new (std::nothrow) int32_t[PTO2_MAX_SCOPE_DEPTH]);
+    if (orch->fanin_seen_epoch == nullptr || orch->scope_tasks == nullptr || orch->scope_begins == nullptr) {
+        LOG_ERROR("Orchestrator scratch allocation failed (task_window=%" PRIu64 ")", task_window_size);
+        return false;
+    }
+    memset(orch->fanin_seen_epoch.get(), 0, window * sizeof(uint32_t));
 
-    if (!orch->tensor_map.init_data_from_layout(layout.tensor_map, arena)) {
+    if (!orch->tensor_map.init_default(static_cast<int32_t>(task_window_size))) {
         return false;
     }
 
     orch->scope_tasks_size = 0;
-    orch->scope_tasks_capacity = layout.scope_tasks_cap;
+    orch->scope_tasks_capacity = static_cast<int32_t>(window);
     orch->scope_stack_top = -1;
-    orch->scope_stack_capacity = layout.scope_stack_capacity;
+    orch->scope_stack_capacity = PTO2_MAX_SCOPE_DEPTH;
     orch->manual_begin_depth = PTO2_MAX_SCOPE_DEPTH;
 
     return true;
-}
-
-void PTO2OrchestratorState::wire_arena_pointers(
-    const PTO2OrchestratorLayout &layout, DeviceArena &arena, PTO2SchedulerState *scheduler_arg
-) {
-    auto *orch = this;
-    orch->fanin_seen_epoch = static_cast<uint32_t *>(arena.region_ptr(layout.off_fanin_seen_epoch));
-    orch->tensor_map.wire_arena_pointers(layout.tensor_map, arena);
-    orch->scope_tasks = static_cast<PTO2TaskSlotState **>(arena.region_ptr(layout.off_scope_tasks));
-    orch->scope_begins = static_cast<int32_t *>(arena.region_ptr(layout.off_scope_begins));
-    orch->scheduler = scheduler_arg;
-}
-
-void PTO2OrchestratorState::destroy() {
-    auto *orch = this;
-    orch->tensor_map.destroy();
-    orch->fanin_seen_epoch = nullptr;
-    orch->scope_tasks = nullptr;
-    orch->scope_begins = nullptr;
 }
 
 void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler) { this->scheduler = scheduler; }
@@ -350,9 +316,6 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
     layout.off_runtime = arena.reserve(PTO2_ALIGN_UP(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE), PTO2_ALIGN_SIZE);
     layout.off_copied_end = arena.total_size();
 
-    layout.device_bytes = arena.total_size();
-    layout.orch = PTO2OrchestratorState::reserve_layout(arena, static_cast<int32_t>(task_window_sizes[0]));
-
     layout.arena_size = arena.total_size();
     return layout;
 }
@@ -373,12 +336,11 @@ PTO2Runtime *runtime_init_data_from_layout(
  *
  * Zeroes the PTO2Runtime header at layout.off_runtime, records the GM heap,
  * and initializes the scheduler (ready / sync / dummy / graph queues) against
- * the device SM. The orchestrator is deliberately left zeroed: the host-orch
- * path (run_host_orchestration) initializes it against the host SM once that
- * buffer exists. Initializing it here would be dead work — overwritten by that
- * re-init, and the orchestrator arena block is never uploaded to the device. Caller must follow up with
- * runtime_wire_arena_pointers. Returns the arena-resident PTO2Runtime*, or
- * nullptr on failure.
+ * the device SM. rt->orchestrator is left null: the orchestrator is a host-owned
+ * object the host-orch path (run_host_orchestration) stands up against the host
+ * SM once that buffer exists, and it is never uploaded to the device. Caller must
+ * follow up with runtime_wire_arena_pointers. Returns the arena-resident
+ * PTO2Runtime*, or nullptr on failure.
  */
 PTO2Runtime *runtime_init_data_from_layout(
     DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
@@ -401,11 +363,10 @@ PTO2Runtime *runtime_init_data_from_layout(
 
     // Two components are deliberately not initialized here.
     //
-    // The orchestrator is initialized by the host-orch path
-    // (run_host_orchestration) against the host SM once it is allocated. Doing it
-    // here would be dead work: its arena content (tensormap + seen_epoch memset)
-    // is immediately overwritten by that re-init, and the orchestrator block is
-    // host-only anyway.
+    // The orchestrator is not in this arena at all: it is a host-owned object the
+    // host-orch path (run_host_orchestration) stands up against the host SM once
+    // that buffer is allocated, and rt->orchestrator only points at it for the
+    // duration of that pass.
     //
     // The scheduler and sm_handle live in the device-only zone, so their bytes
     // never travel; the AICPU initializes them at boot. Writing them here would
@@ -422,17 +383,10 @@ void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayou
     rt->scheduler->wire_arena_pointers(layout.sched, arena);
 }
 
-void runtime_wire_host_only_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt) {
-    rt->orchestrator.wire_arena_pointers(layout.orch, arena, rt->scheduler);
-}
-
-void runtime_clear_host_only_pointers(PTO2Runtime *rt) { rt->orchestrator.destroy(); }
-
 void runtime_destroy(PTO2Runtime *rt, DeviceArena & /*arena*/) {
     // Arena buffer is pooled across runs by DeviceRunner — never freed here.
     if (!rt) return;
     rt->scheduler->destroy();
-    rt->orchestrator.destroy();
     rt->aicore_mailbox = nullptr;
     rt->sm_handle = nullptr;
 }

--- a/src/a5/runtime/host_build_graph/runtime/shared/pto_tensormap.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/pto_tensormap.cpp
@@ -11,7 +11,7 @@
 /**
  * PTO Runtime2 - TensorMap Implementation
  *
- * Implements TensorMap with a fixed-capacity arena pool. Task completion does
+ * Implements TensorMap with a fixed-capacity entry pool. Task completion does
  * not invalidate entries; dependency computation explicitly removes only
  * producers made redundant by coverage.
  *
@@ -28,6 +28,8 @@
 
 #include <stdlib.h>
 #include <string.h>
+
+#include <new>
 
 #include "common.h"
 #include "common/unified_log.h"
@@ -48,54 +50,45 @@ uint64_t g_insert_count = 0;
 // Initialization and Destruction
 // =============================================================================
 
-PTO2TensorMapLayout PTO2TensorMap::reserve_layout(
-    DeviceArena &arena, int32_t new_num_buckets, int32_t new_pool_size, int32_t new_task_window_size
-) {
-    // num_buckets must be a power of two for the hash truncation to work.
-    always_assert((new_num_buckets & (new_num_buckets - 1)) == 0);
-
-    PTO2TensorMapLayout layout{};
-    layout.num_buckets = new_num_buckets;
-    layout.pool_size = new_pool_size;
-    layout.task_window_size = new_task_window_size;
-
-    layout.off_buckets = arena.reserve(
-        static_cast<size_t>(new_num_buckets) * sizeof(PTO2TensorMapEntry *), alignof(PTO2TensorMapEntry *)
-    );
-    layout.off_entry_pool =
-        arena.reserve(static_cast<size_t>(new_pool_size) * sizeof(PTO2TensorMapEntry), alignof(PTO2TensorMapEntry));
-    layout.off_free_entry_list =
-        arena.reserve(static_cast<size_t>(new_pool_size) * sizeof(PTO2TensorMapEntry *), alignof(PTO2TensorMapEntry *));
-    layout.off_task_entry_heads = arena.reserve(
-        static_cast<size_t>(new_task_window_size) * sizeof(PTO2TensorMapEntry *), alignof(PTO2TensorMapEntry *)
-    );
-    return layout;
-}
-
-PTO2TensorMapLayout PTO2TensorMap::reserve_layout_default(DeviceArena &arena, int32_t new_task_window_size) {
-    return reserve_layout(arena, PTO2_TENSORMAP_NUM_BUCKETS, PTO2_TENSORMAP_POOL_SIZE, new_task_window_size);
-}
-
 /**
- * Reset the map to empty for a fresh orchestration pass. Addresses the arena
- * regions directly through arena.region_ptr, so it runs before
- * wire_arena_pointers binds the struct's pointer fields (and before any
- * insert/lookup). Clears the bucket heads and the per-task entry heads and
- * resets the pool cursors (next_entry_idx / free_num); the entry pool itself is
- * left untouched and initialized on write by new_entry(), so this is
- * O(num_buckets + task_window_size), not O(pool_size).
+ * Allocate the four arrays and reset the map to empty. Clears the bucket heads
+ * and the per-task entry heads and resets the pool cursors (next_entry_idx /
+ * free_num); the entry pool is left uninitialized and initialized on write by
+ * new_entry(), so this is O(num_buckets + task_window_size), not O(pool_size).
+ *
+ * `new (std::nothrow) T[n]` rather than a vector: a vector would value-initialize
+ * the whole entry pool, which is megabytes of zeroing the init-on-write path
+ * exists to avoid, and nothrow keeps the failure reportable to a caller that
+ * still has an alternative path.
  */
-bool PTO2TensorMap::init_data_from_layout(const PTO2TensorMapLayout &layout, DeviceArena &arena) {
-    num_buckets = layout.num_buckets;
-    pool_size = layout.pool_size;
+bool PTO2TensorMap::init(int32_t new_num_buckets, int32_t new_pool_size, int32_t new_task_window_size) {
+    // num_buckets must be a power of two for the hash truncation to work, and
+    // task_window_size for the task-chain slot mask.
+    always_assert(new_num_buckets > 0 && (new_num_buckets & (new_num_buckets - 1)) == 0);
+    always_assert(new_task_window_size > 0 && (new_task_window_size & (new_task_window_size - 1)) == 0);
+    always_assert(new_pool_size > 0);
 
-    // Address arena regions for data writes; do not store these in struct
-    // fields (wire_arena_pointers does that).
-    auto *buckets_arena = static_cast<PTO2TensorMapEntry **>(arena.region_ptr(layout.off_buckets));
+    buckets.reset(new (std::nothrow) PTO2TensorMapEntry *[new_num_buckets]);
+    entry_pool.reset(new (std::nothrow) PTO2TensorMapEntry[new_pool_size]);
+    free_entry_list.reset(new (std::nothrow) PTO2TensorMapEntry *[new_pool_size]);
+    task_entry_heads.reset(new (std::nothrow) PTO2TensorMapEntry *[new_task_window_size]);
+    if (buckets == nullptr || entry_pool == nullptr || free_entry_list == nullptr || task_entry_heads == nullptr) {
+        LOG_ERROR(
+            "TensorMap init failed (buckets=%d, pool=%d, window=%d)", new_num_buckets, new_pool_size,
+            new_task_window_size
+        );
+        return false;
+    }
 
-    // buckets[]: empty == nullptr.
+    num_buckets = new_num_buckets;
+    pool_size = new_pool_size;
+    task_window_size = new_task_window_size;
+
     for (int32_t i = 0; i < num_buckets; i++) {
-        buckets_arena[i] = nullptr;
+        buckets[i] = nullptr;
+    }
+    for (int32_t i = 0; i < task_window_size; i++) {
+        task_entry_heads[i] = nullptr;
     }
 
     // Init-on-write: the entry pool is not pre-zeroed. new_entry() puts each
@@ -109,31 +102,11 @@ bool PTO2TensorMap::init_data_from_layout(const PTO2TensorMapLayout &layout, Dev
 
     next_entry_idx = 0;
     free_num = 0;
-
-    auto *heads_arena = static_cast<PTO2TensorMapEntry **>(arena.region_ptr(layout.off_task_entry_heads));
-    for (int32_t i = 0; i < layout.task_window_size; i++) {
-        heads_arena[i] = nullptr;
-    }
-    task_window_size = layout.task_window_size;
-
     return true;
 }
 
-void PTO2TensorMap::wire_arena_pointers(const PTO2TensorMapLayout &layout, DeviceArena &arena) {
-    buckets = static_cast<PTO2TensorMapEntry **>(arena.region_ptr(layout.off_buckets));
-    entry_pool = static_cast<PTO2TensorMapEntry *>(arena.region_ptr(layout.off_entry_pool));
-    free_entry_list = static_cast<PTO2TensorMapEntry **>(arena.region_ptr(layout.off_free_entry_list));
-    task_entry_heads = static_cast<PTO2TensorMapEntry **>(arena.region_ptr(layout.off_task_entry_heads));
-}
-
-void PTO2TensorMap::destroy() {
-    // Arena owns the backing memory; here we only forget our pointers so any
-    // stray post-destroy access trips a nullptr dereference instead of reading
-    // a recycled allocation.
-    buckets = nullptr;
-    entry_pool = nullptr;
-    free_entry_list = nullptr;
-    task_entry_heads = nullptr;
+bool PTO2TensorMap::init_default(int32_t new_task_window_size) {
+    return init(PTO2_TENSORMAP_NUM_BUCKETS, PTO2_TENSORMAP_POOL_SIZE, new_task_window_size);
 }
 
 // =============================================================================

--- a/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
@@ -49,7 +49,6 @@ protected:
     PTO2SharedMemoryHandle *sm_handle = nullptr;
     PTO2OrchestratorState orch{};
     PTO2SchedulerState sched{};
-    PTO2OrchestratorLayout orch_layout{};
     PTO2SchedulerLayout sched_layout{};
     std::vector<char> gm_heap;
 
@@ -58,23 +57,18 @@ protected:
         ASSERT_NE(sm_handle, nullptr);
         gm_heap.resize(4096 * PTO2_MAX_RING_DEPTH);
 
-        orch_layout = PTO2OrchestratorState::reserve_layout(runtime_arena, static_cast<int32_t>(PTO2_TASK_WINDOW_SIZE));
         sched_layout = PTO2SchedulerState::reserve_layout(runtime_arena);
         ASSERT_NE(runtime_arena.commit(), nullptr);
 
-        ASSERT_TRUE(orch.init_data_from_layout(
-            orch_layout, runtime_arena, sm_handle->sm_base, gm_heap.data(), 4096, PTO2_TASK_WINDOW_SIZE
-        ));
         ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
         sched.wire_arena_pointers(sched_layout, runtime_arena);
         // Same order the AICPU boots in: the slot arrays are not part of the
         // uploaded image, so nothing can push until they carry their ramp.
         sched.seed_queue_slots();
-        orch.wire_arena_pointers(orch_layout, runtime_arena, &sched);
+        ASSERT_TRUE(orch.init(sm_handle->sm_base, gm_heap.data(), 4096, PTO2_TASK_WINDOW_SIZE, &sched));
     }
 
     void TearDown() override {
-        orch.destroy();
         sched.destroy();
         runtime_arena.release();
         sm_arena.release();

--- a/tests/ut/cpp/a2a3/test_hbg_tensormap.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_tensormap.cpp
@@ -24,7 +24,6 @@
 #include <algorithm>
 #include <vector>
 
-#include "utils/device_arena.h"
 #include "pto_tensormap.h"
 
 namespace {
@@ -58,19 +57,8 @@ protected:
     static constexpr int32_t WINDOW_SIZE = 32;
 
     PTO2TensorMap tmap{};
-    DeviceArena arena;
 
-    void SetUp() override {
-        auto layout = PTO2TensorMap::reserve_layout(arena, NUM_BUCKETS, POOL_SIZE, WINDOW_SIZE);
-        ASSERT_NE(arena.commit(), nullptr);
-        ASSERT_TRUE(tmap.init_data_from_layout(layout, arena));
-        tmap.wire_arena_pointers(layout, arena);
-    }
-
-    void TearDown() override {
-        tmap.destroy();
-        arena.release();
-    }
+    void SetUp() override { ASSERT_TRUE(tmap.init(NUM_BUCKETS, POOL_SIZE, WINDOW_SIZE)); }
 };
 
 // Completion progress alone cannot make an older producer disappear. Direct

--- a/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
@@ -49,7 +49,6 @@ protected:
     PTO2SharedMemoryHandle *sm_handle = nullptr;
     PTO2OrchestratorState orch{};
     PTO2SchedulerState sched{};
-    PTO2OrchestratorLayout orch_layout{};
     PTO2SchedulerLayout sched_layout{};
     std::vector<char> gm_heap;
 
@@ -58,23 +57,18 @@ protected:
         ASSERT_NE(sm_handle, nullptr);
         gm_heap.resize(4096 * PTO2_MAX_RING_DEPTH);
 
-        orch_layout = PTO2OrchestratorState::reserve_layout(runtime_arena, static_cast<int32_t>(PTO2_TASK_WINDOW_SIZE));
         sched_layout = PTO2SchedulerState::reserve_layout(runtime_arena);
         ASSERT_NE(runtime_arena.commit(), nullptr);
 
-        ASSERT_TRUE(orch.init_data_from_layout(
-            orch_layout, runtime_arena, sm_handle->sm_base, gm_heap.data(), 4096, PTO2_TASK_WINDOW_SIZE
-        ));
         ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
         sched.wire_arena_pointers(sched_layout, runtime_arena);
         // Same order the AICPU boots in: the slot arrays are not part of the
         // uploaded image, so nothing can push until they carry their ramp.
         sched.seed_queue_slots();
-        orch.wire_arena_pointers(orch_layout, runtime_arena, &sched);
+        ASSERT_TRUE(orch.init(sm_handle->sm_base, gm_heap.data(), 4096, PTO2_TASK_WINDOW_SIZE, &sched));
     }
 
     void TearDown() override {
-        orch.destroy();
         sched.destroy();
         runtime_arena.release();
         sm_arena.release();

--- a/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
@@ -33,7 +33,6 @@ protected:
     PTO2SharedMemoryHandle *sm_handle = nullptr;
     PTO2OrchestratorState orch{};
     PTO2SchedulerState sched{};
-    PTO2OrchestratorLayout orch_layout{};
     PTO2SchedulerLayout sched_layout{};
     GraphHostStatePtr graph_state;
     std::vector<char> gm_heap;
@@ -50,16 +49,12 @@ protected:
         ASSERT_NE(sm_handle, nullptr);
         gm_heap.resize(HEAP_BYTES * PTO2_MAX_RING_DEPTH);
 
-        orch_layout = PTO2OrchestratorState::reserve_layout(runtime_arena, static_cast<int32_t>(PTO2_TASK_WINDOW_SIZE));
         sched_layout = PTO2SchedulerState::reserve_layout(runtime_arena);
         ASSERT_NE(runtime_arena.commit(), nullptr);
 
-        ASSERT_TRUE(orch.init_data_from_layout(
-            orch_layout, runtime_arena, sm_handle->sm_base, gm_heap.data(), HEAP_BYTES, PTO2_TASK_WINDOW_SIZE
-        ));
         ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
         sched.wire_arena_pointers(sched_layout, runtime_arena);
-        orch.wire_arena_pointers(orch_layout, runtime_arena, &sched);
+        ASSERT_TRUE(orch.init(sm_handle->sm_base, gm_heap.data(), HEAP_BYTES, PTO2_TASK_WINDOW_SIZE, &sched));
 
         graph_state = make_graph_host_state();
         ASSERT_NE(graph_state, nullptr);
@@ -69,7 +64,6 @@ protected:
     void TearDown() override {
         orch.graph_host_state = nullptr;
         graph_state.reset();
-        orch.destroy();
         sched.destroy();
         runtime_arena.release();
         sm_arena.release();

--- a/tests/ut/cpp/common/test_hbg_slot_claim.cpp
+++ b/tests/ut/cpp/common/test_hbg_slot_claim.cpp
@@ -33,7 +33,6 @@ protected:
     PTO2SharedMemoryHandle *sm_handle = nullptr;
     PTO2OrchestratorState orch{};
     PTO2SchedulerState sched{};
-    PTO2OrchestratorLayout orch_layout{};
     PTO2SchedulerLayout sched_layout{};
     GraphHostStatePtr graph_state;
     std::vector<char> gm_heap;
@@ -45,16 +44,12 @@ protected:
         ASSERT_NE(sm_handle, nullptr);
         gm_heap.resize(HEAP_BYTES * PTO2_MAX_RING_DEPTH);
 
-        orch_layout = PTO2OrchestratorState::reserve_layout(runtime_arena, static_cast<int32_t>(PTO2_TASK_WINDOW_SIZE));
         sched_layout = PTO2SchedulerState::reserve_layout(runtime_arena);
         ASSERT_NE(runtime_arena.commit(), nullptr);
 
-        ASSERT_TRUE(orch.init_data_from_layout(
-            orch_layout, runtime_arena, sm_handle->sm_base, gm_heap.data(), HEAP_BYTES, PTO2_TASK_WINDOW_SIZE
-        ));
         ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
         sched.wire_arena_pointers(sched_layout, runtime_arena);
-        orch.wire_arena_pointers(orch_layout, runtime_arena, &sched);
+        ASSERT_TRUE(orch.init(sm_handle->sm_base, gm_heap.data(), HEAP_BYTES, PTO2_TASK_WINDOW_SIZE, &sched));
 
         graph_state = make_graph_host_state();
         ASSERT_NE(graph_state, nullptr);
@@ -64,7 +59,6 @@ protected:
     void TearDown() override {
         orch.graph_host_state = nullptr;
         graph_state.reset();
-        orch.destroy();
         sched.destroy();
         runtime_arena.release();
         sm_arena.release();


### PR DESCRIPTION
## Summary

`host_build_graph` runs its orchestrator on the host, so no device code reads any of the orchestrator's state — not the fanin epoch table, not the scope arrays, not the TensorMap. The runtime arena nevertheless carried all ~9.3 MB of it as a third "host-only" zone, and that zone's correctness rested on two conventions rather than on any type:

- It had to be **reserved last**, because `device_bytes` was a cursor snapshot taken just before it. Reserve the orchestrator one line earlier and the device either receives 9.3 MB it never reads or loses a region it does.
- `runtime_clear_host_only_pointers` had to run **before the copied zone was uploaded**, because `PTO2OrchestratorState` was a by-value member of the `PTO2Runtime` header that bind `memcpy`s to the device. Forget the call and host addresses cross the boundary.

This PR removes the zone rather than documenting it harder.

- `PTO2Runtime` holds the orchestrator **by pointer**, and a `static_assert` keeps the header trivially copyable — which is what forbids putting owning state back inside it.
- The orchestrator owns its three scratch arrays; its TensorMap owns its four. `PTO2OrchestratorState::init` and `PTO2TensorMap::init` replace the `reserve_layout` / `init_data_from_layout` / `wire_arena_pointers` triple.
- Deleted: `PTO2OrchestratorLayout`, hbg's `PTO2TensorMapLayout`, `device_bytes`, `runtime_wire_host_only_pointers`, `runtime_clear_host_only_pointers`. Every region left in the arena is device-resident, so `arena_size` is what `setup_static_arena` asks for.
- `GraphRecording` drops its own `DeviceArena` and layout descriptor and holds the TensorMap directly.

Storage is `unique_ptr<T[]>` over `new (std::nothrow)` rather than a vector: a vector value-initializes, and zeroing the 8 MB entry pool is exactly what `new_entry()`'s init-on-write path exists to avoid. `nothrow` keeps an allocation failure reportable to a caller that still has an ordinary path to take.

The embedding also gave the device two reads of host-only state:

- The AICPU was writing this run's core counts into an orchestrator that never runs there, so `runtime_finalize_after_wire` splits into `runtime_bind_ops` for the ops table plus a direct host-side assignment for the counts.
- The count of tasks the host orchestrator completed inline *is* read by the device-side scheduler, so `rt_orchestration_done` publishes it into the runtime header, where it belongs.

`tensormap_and_ringbuffer` keeps the arena form: its orchestrator runs on the AICPU, where the map really is device-resident and offset-addressed.

`PTO2Runtime` shrinks 592 → 288 bytes (the copied zone shrinks with it); the orchestrator is 312 bytes. No performance claim — the host-only zone was already neither copied nor device-allocated, and init is O(buckets + window), not O(pool).

## Testing

- [x] C++ unit tests: 115/115 pass (5 hbg UT files migrated to the new init API)
- [x] Simulation tests pass — full `examples tests/st` on `a2a3sim` and `a5sim`, both runtimes green
- [x] Hardware tests pass — `a2a3` onboard via `task-submit` on 8 dies: 57 resource cases + hbg L2 (27 passed / 1 skipped) + tmr L2 (54 passed), 0 failures
- [x] `clang-format` clean

### Pre-existing failure encountered, not caused by this PR

The first onboard sweeps failed 8–9 `TestRunStreamReuseHbg` cases with `finalize_native_run failed with code -100` behind `507018 ACL_ERROR_RT_AICPU_EXCEPTION`. The device log names the mechanism as a forward-progress stall (`TIMEOUT_EXIT after_idle_iterations≈18M`) → `Scheduler fatal error detected (code=100)`, i.e. SCHEDULER_TIMEOUT, not a deadlock or capacity fatal.

It **reproduces at the parent commit with the identical command**, so it is not introduced here. The same file's 9 cases pass when run alone on 2 dies, and one sweep instead hit `tensormap_and_ringbuffer/prepared_callable` with the same signature — a runtime this PR does not touch. Both files exercise repeated register/unregister + lease-generation cycles, whose machinery lives in `src/common/platform/onboard/host/`. The green hardware run above has that one file deselected; everything else ran.
