### PR TITLE
Refactor: hbg carries no per-ring dimension, and no ring-set wrapper

### DIFF
--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -278,7 +278,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // attach_populated.
             memset(rt->sm_handle, 0, sizeof(*rt->sm_handle));
             if (!rt->sm_handle->attach_populated(
-                    sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes, live_slots, runtime->sm_image_bytes
+                    sm_ptr, sm_size, rt->prebuilt_layout.task_window_size, live_slots, runtime->sm_image_bytes
                 )) {
                 LOG_ERROR("Thread %d: host-orch: sm_handle->attach_populated failed", thread_idx);
                 rt = nullptr;

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -120,9 +120,9 @@ extern "C" int concurrent_native_prepare_supported_impl(void) {
 
 // RuntimeEnv (call_config.h) is the cross-runtime ABI for per-ring config and
 // carries RUNTIME_ENV_RING_COUNT slots, shared with tensormap_and_ringbuffer.
-// host_build_graph is single-ring (PTO2_MAX_RING_DEPTH == 1) and reads only the
-// first slot; it must fit within the ABI's slot budget, not equal it.
-static_assert(PTO2_MAX_RING_DEPTH <= RUNTIME_ENV_RING_COUNT, "PTO2 runtime ring depth must fit RuntimeEnv ring slots");
+// host_build_graph has one ring and reads slot 0, so it only needs the ABI to
+// carry at least one.
+static_assert(RUNTIME_ENV_RING_COUNT >= 1, "RuntimeEnv must carry the ring slot host_build_graph reads");
 
 static bool is_power_of_2_u64(uint64_t value) { return value != 0 && (value & (value - 1)) == 0; }
 
@@ -183,19 +183,6 @@ static void record_bind_phase(HostPhaseKind kind, int64_t start_ns, const char *
     host_phase_record_bind(static_cast<uint32_t>(kind), static_cast<uint64_t>(start_ns), with_counters, payload);
 }
 
-template <typename T>
-static std::string format_ring_array(const T (&values)[PTO2_MAX_RING_DEPTH]) {
-    std::string out = "[";
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; ++r) {
-        if (r != 0) {
-            out += ", ";
-        }
-        out += std::to_string(values[r]);
-    }
-    out += "]";
-    return out;
-}
-
 static std::string trim_copy(const std::string &input) {
     size_t begin = 0;
     while (begin < input.size() && std::isspace(static_cast<unsigned char>(input[begin]))) {
@@ -244,52 +231,25 @@ static bool parse_uint_token(
     return true;
 }
 
-static void apply_env_ring_values(
-    const char *name, uint64_t min_val, uint64_t max_val, bool require_power_of_2, uint64_t out[PTO2_MAX_RING_DEPTH]
-) {
+// The PTO2_RING_* knobs are shared with tensormap_and_ringbuffer, where a value
+// may be a comma-separated list, one entry per ring. hbg has one ring, so it
+// accepts the single-value spelling and rejects a list — which is what the
+// multi-ring parser did here too, since it required exactly one entry.
+static void
+apply_env_ring_value(const char *name, uint64_t min_val, uint64_t max_val, bool require_power_of_2, uint64_t *out) {
     const char *env = std::getenv(name);
     if (!env) return;
 
     std::string text(env);
-    if (text.find(',') == std::string::npos) {
-        uint64_t value = 0;
-        if (!parse_uint_token(name, text, min_val, max_val, require_power_of_2, &value)) {
-            return;
-        }
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            out[r] = value;
-        }
+    if (text.find(',') != std::string::npos) {
+        LOG_WARN("%s=%s invalid (this runtime has one ring; expected a single value), ignored", name, env);
         return;
     }
-
-    uint64_t parsed[PTO2_MAX_RING_DEPTH]{};
-    size_t pos = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        size_t comma = text.find(',', pos);
-        std::string token = text.substr(pos, comma == std::string::npos ? std::string::npos : comma - pos);
-        if (!parse_uint_token(name, token, min_val, max_val, require_power_of_2, &parsed[r])) {
-            return;
-        }
-        if (comma == std::string::npos) {
-            if (r != PTO2_MAX_RING_DEPTH - 1) {
-                LOG_WARN(
-                    "%s=%s invalid (expected exactly %d comma-separated values), ignored", name, env,
-                    PTO2_MAX_RING_DEPTH
-                );
-                return;
-            }
-            pos = text.size();
-        } else {
-            pos = comma + 1;
-        }
-    }
-    if (pos < text.size() || (!text.empty() && text.back() == ',')) {
-        LOG_WARN("%s=%s invalid (expected exactly %d comma-separated values), ignored", name, env, PTO2_MAX_RING_DEPTH);
+    uint64_t value = 0;
+    if (!parse_uint_token(name, text, min_val, max_val, require_power_of_2, &value)) {
         return;
     }
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        out[r] = parsed[r];
-    }
+    *out = value;
 }
 
 // ring_task_window / ring_heap / ring_dep_pool point into the #pragma pack(1)
@@ -307,56 +267,48 @@ static uint64_t read_ring_override(const uint64_t *base, int idx) {
     return value;
 }
 
-// Each of ring_task_window / ring_heap is a per-ring array of PTO2_MAX_RING_DEPTH
-// entries (0 = unset). Precedence per ring: per-task entry > PTO2_RING_* env value
-// > compile-time default. A "size all rings the same" request arrives already
-// broadcast to every entry by the caller. (Polling has no dep_pool, so the former
-// PTO2_RING_DEP_POOL knob is gone.)
+// ring_task_window / ring_heap point at the first slot of a per-ring array in the
+// RuntimeEnv wire struct (0 = unset); hbg has one ring and reads slot 0.
+// Precedence: per-task entry > PTO2_RING_* env value > compile-time default.
+// (Polling has no dep_pool, so the former PTO2_RING_DEP_POOL knob is gone.)
 static bool resolve_ring_config(
-    const uint64_t *ring_task_window, const uint64_t *ring_heap, uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH],
-    uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH]
+    const uint64_t *ring_task_window, const uint64_t *ring_heap, uint64_t *eff_task_window_size, uint64_t *eff_heap_size
 ) {
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        eff_task_window_sizes[r] = PTO2_TASK_WINDOW_SIZE;
-        eff_heap_sizes[r] = PTO2_HEAP_SIZE;
+    *eff_task_window_size = PTO2_TASK_WINDOW_SIZE;
+    *eff_heap_size = PTO2_HEAP_SIZE;
+
+    apply_env_ring_value("PTO2_RING_TASK_WINDOW", 4, static_cast<uint64_t>(INT32_MAX), true, eff_task_window_size);
+    apply_env_ring_value("PTO2_RING_HEAP", 1024, std::numeric_limits<uint64_t>::max(), false, eff_heap_size);
+
+    const uint64_t task_window_override = read_ring_override(ring_task_window, 0);
+    const uint64_t heap_override = read_ring_override(ring_heap, 0);
+    if (task_window_override != 0) {
+        *eff_task_window_size = task_window_override;
+    }
+    if (heap_override != 0) {
+        *eff_heap_size = heap_override;
     }
 
-    apply_env_ring_values("PTO2_RING_TASK_WINDOW", 4, static_cast<uint64_t>(INT32_MAX), true, eff_task_window_sizes);
-    apply_env_ring_values("PTO2_RING_HEAP", 1024, std::numeric_limits<uint64_t>::max(), false, eff_heap_sizes);
-
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        const uint64_t task_window_override = read_ring_override(ring_task_window, r);
-        const uint64_t heap_override = read_ring_override(ring_heap, r);
-        if (task_window_override != 0) {
-            eff_task_window_sizes[r] = task_window_override;
-        }
-        if (heap_override != 0) {
-            eff_heap_sizes[r] = heap_override;
-        }
-
-        if (eff_task_window_sizes[r] < 4 || eff_task_window_sizes[r] > static_cast<uint64_t>(INT32_MAX) ||
-            !is_power_of_2_u64(eff_task_window_sizes[r])) {
-            LOG_ERROR(
-                "ring_task_window[%d]=%" PRIu64 " must be a power of 2 in [4, INT32_MAX]", r, eff_task_window_sizes[r]
-            );
-            return false;
-        }
-        if (eff_heap_sizes[r] < 1024) {
-            LOG_ERROR("ring_heap[%d]=%" PRIu64 " must be >= 1024", r, eff_heap_sizes[r]);
-            return false;
-        }
-        // A slot state reaches its payload and descriptor through a 32-bit
-        // self-relative delta, so every pair of addresses in the shared-memory
-        // image must be within INT32_MAX of each other.
-        const uint64_t sm_bytes = pto2_sm_layout::ring_segment_offsets(eff_task_window_sizes[r]).end;
-        if (sm_bytes > static_cast<uint64_t>(INT32_MAX)) {
-            LOG_ERROR(
-                "ring_task_window[%d]=%" PRIu64 " needs a %" PRIu64 "-byte shared memory image, past the %d-byte limit "
-                "a slot state's self-relative payload/descriptor delta can span",
-                r, eff_task_window_sizes[r], sm_bytes, INT32_MAX
-            );
-            return false;
-        }
+    if (*eff_task_window_size < 4 || *eff_task_window_size > static_cast<uint64_t>(INT32_MAX) ||
+        !is_power_of_2_u64(*eff_task_window_size)) {
+        LOG_ERROR("ring_task_window=%" PRIu64 " must be a power of 2 in [4, INT32_MAX]", *eff_task_window_size);
+        return false;
+    }
+    if (*eff_heap_size < 1024) {
+        LOG_ERROR("ring_heap=%" PRIu64 " must be >= 1024", *eff_heap_size);
+        return false;
+    }
+    // A slot state reaches its payload and descriptor through a 32-bit
+    // self-relative delta, so every pair of addresses in the shared-memory
+    // image must be within INT32_MAX of each other.
+    const uint64_t sm_bytes = pto2_sm_layout::ring_segment_offsets(*eff_task_window_size).end;
+    if (sm_bytes > static_cast<uint64_t>(INT32_MAX)) {
+        LOG_ERROR(
+            "ring_task_window=%" PRIu64 " needs a %" PRIu64 "-byte shared memory image, past the %d-byte limit "
+            "a slot state's self-relative payload/descriptor delta can span",
+            *eff_task_window_size, sm_bytes, INT32_MAX
+        );
+        return false;
     }
 
     return true;
@@ -557,9 +509,8 @@ struct GraphHostStateBinding {
 
 int32_t run_host_orchestration(
     Runtime *runtime, const HostApi *api, HostTensorAccessor &tensor_access, PTO2Runtime *rt, DeviceArena &host_arena,
-    const PTO2RuntimeArenaLayout &layout, uint64_t sm_size, void *device_arena, void *gm_heap,
-    const uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH],
-    void *host_orch_func_ptr, const ChipTaskArgs &orch_l2
+    const PTO2RuntimeArenaLayout &layout, uint64_t sm_size, void *device_arena, void *gm_heap, uint64_t eff_heap_size,
+    uint64_t eff_task_window_size, void *host_orch_func_ptr, const ChipTaskArgs &orch_l2
 ) {
     dep_gen_host_graph_begin_capture();
 
@@ -567,8 +518,7 @@ int32_t run_host_orchestration(
     // each written per task at submit and read only for [0, total_tasks). Zero
     // only the fixed-size header here; the per-slot segments are initialized in
     // orch::prepare_task and shipped bounded to total_tasks below.
-    const pto2_sm_layout::PTO2RingSegmentOffsets sm_segs =
-        pto2_sm_layout::ring_segment_offsets(eff_task_window_sizes[0]);
+    const pto2_sm_layout::PTO2RingSegmentOffsets sm_segs = pto2_sm_layout::ring_segment_offsets(eff_task_window_size);
     // Over-allocated and rounded up: every segment offset is a multiple of
     // PTO2_ALIGN_SIZE and PTO2TaskSlotState is alignas(64), which a plain
     // new uint8_t[] does not guarantee.
@@ -587,13 +537,13 @@ int32_t run_host_orchestration(
     RAIIScopeGuard orchestrator_binding([rt]() {
         rt->orchestrator = nullptr;
     });
-    if (!orchestrator.init(host_sm, gm_heap, eff_heap_sizes[0], eff_task_window_sizes[0], rt->scheduler)) {
+    if (!orchestrator.init(host_sm, gm_heap, eff_heap_size, eff_task_window_size, rt->scheduler)) {
         LOG_ERROR("host-orch: orchestrator init against host SM failed");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     PTO2SharedMemoryHandle host_sm_handle;
-    if (!host_sm_handle.init_per_ring(host_sm, sm_size, eff_task_window_sizes, eff_heap_sizes)) {
+    if (!host_sm_handle.init(host_sm, sm_size, eff_task_window_size, eff_heap_size)) {
         LOG_ERROR("host-orch: host SM init_per_ring failed");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
@@ -670,7 +620,7 @@ int32_t run_host_orchestration(
         LOG_RUNTIME_FAILURE(orch_error, SIMPLER_ERROR_NONE, status);
         LOG_ERROR(
             "host-orch: refusing to upload an incomplete graph after %" PRIu64 " heap bytes",
-            orchestrator.ring.task_allocator.heap_used_bytes()
+            orchestrator.task_allocator.heap_used_bytes()
         );
         return status;
     }
@@ -680,7 +630,7 @@ int32_t run_host_orchestration(
         char attrs[160];
         snprintf(
             attrs, sizeof(attrs), "tasks=%" PRId32 " heap_used=%" PRIu64 " sm_mirror=%" PRIu64, total_tasks,
-            orchestrator.ring.task_allocator.heap_used_bytes(), sm_size
+            orchestrator.task_allocator.heap_used_bytes(), sm_size
         );
         record_bind_phase(HostPhaseKind::BindHostOrch, t_orch_ns, attrs);
     }
@@ -709,8 +659,8 @@ int32_t run_host_orchestration(
 
     // total_tasks sizes the bounded per-segment H2D copies below; a value outside
     // [0, task_window] would make those copies read/write out of bounds.
-    if (total_tasks < 0 || static_cast<uint64_t>(total_tasks) > eff_task_window_sizes[0]) {
-        LOG_ERROR("host-orch: total_tasks %d out of range [0, %" PRIu64 "]", total_tasks, eff_task_window_sizes[0]);
+    if (total_tasks < 0 || static_cast<uint64_t>(total_tasks) > eff_task_window_size) {
+        LOG_ERROR("host-orch: total_tasks %d out of range [0, %" PRIu64 "]", total_tasks, eff_task_window_size);
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     host_phase_trace_note_submitted(static_cast<uint64_t>(total_tasks));
@@ -745,14 +695,10 @@ int32_t run_host_orchestration(
     // repeated workload grows the arena once. Growing reallocates, so the base is
     // re-acquired rather than reused.
     const int64_t t_sm_ns = bind_now_ns();
-    uint64_t total_heap_size = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        total_heap_size += eff_heap_sizes[r];
-    }
     // The compact shared-memory image is the only per-run tail in the device
     // arena. GraphExecution is initialized later in each outer Graph heap.
     const uint64_t device_arena_bytes = layout.off_copied_end + image_bytes;
-    if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, device_arena_bytes) != 0) {
+    if (api->setup_static_arena(eff_heap_size, /*gm_sm_size=*/0, device_arena_bytes) != 0) {
         LOG_ERROR("host-orch: failed to commit %" PRIu64 " bytes of device runtime arena", device_arena_bytes);
         return PTO_RUNTIME_ERR_INTERNAL;
     }
@@ -789,7 +735,7 @@ int32_t run_host_orchestration(
     rt->orchestrator = nullptr;
     std::memcpy(upload_base, static_cast<const char *>(host_arena.base()) + layout.off_copied_begin, copied_bytes);
     const uint64_t compacted = pto2_sm_layout::compact_live_image(
-        static_cast<const char *>(host_sm), eff_task_window_sizes[0], bind_usage, upload_base + copied_bytes
+        static_cast<const char *>(host_sm), eff_task_window_size, bind_usage, upload_base + copied_bytes
     );
     always_assert(compacted == image_bytes);
 
@@ -980,14 +926,12 @@ extern "C" int bind_callable_to_runtime_impl(
         host_phase_trace_end();
     });
 
-    uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH];
-    if (!resolve_ring_config(ring_task_window, ring_heap, eff_task_window_sizes, eff_heap_sizes)) {
+    uint64_t eff_task_window_size = 0;
+    uint64_t eff_heap_size = 0;
+    if (!resolve_ring_config(ring_task_window, ring_heap, &eff_task_window_size, &eff_heap_size)) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
-    const std::string task_window_log = format_ring_array(eff_task_window_sizes);
-    const std::string heap_log = format_ring_array(eff_heap_sizes);
-    LOG_INFO("Ring buffer sizes: task_window=%s heap=%s", task_window_log.c_str(), heap_log.c_str());
+    LOG_INFO("Ring buffer sizes: task_window=%" PRIu64 " heap=%" PRIu64, eff_task_window_size, eff_heap_size);
 
     // Build device args: copy from input, replace host tensor pointers with device pointers
     ChipStorageTaskArgs device_args;
@@ -1078,19 +1022,11 @@ extern "C" int bind_callable_to_runtime_impl(
     // Owned by DeviceRunner across runs — do NOT record in tensor_pairs_; the
     // free is deferred to DeviceRunner::finalize(). The runtime-arena size is
     // determined by replaying the reserve sequence on a host-side arena.
-    uint64_t total_heap_size = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (eff_heap_sizes[r] > std::numeric_limits<uint64_t>::max() - total_heap_size) {
-            LOG_ERROR("Total ring heap size overflows uint64_t");
-            return PTO_RUNTIME_ERR_INTERNAL;
-        }
-        total_heap_size += eff_heap_sizes[r];
-    }
-    uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(eff_task_window_sizes);
+    uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size(eff_task_window_size);
 
     const int64_t t_arena_build_ns = bind_now_ns();
     DeviceArena host_arena;
-    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(host_arena, eff_task_window_sizes, eff_heap_sizes);
+    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(host_arena, eff_task_window_size, eff_heap_size);
     if (host_arena.commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
         LOG_ERROR("Failed to commit host arena for prebuilt runtime image");
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -1108,13 +1044,13 @@ extern "C" int bind_callable_to_runtime_impl(
     // count — run_host_orchestration grows it once it knows. The heap must exist
     // first either way: the orchestrator hands out device heap addresses as it
     // places tasks.
-    if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, layout.arena_size) != 0) {
+    if (api->setup_static_arena(eff_heap_size, /*gm_sm_size=*/0, layout.arena_size) != 0) {
         LOG_ERROR("Failed to setup pooled static arena");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
         char attrs[96];
-        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " arena=%" PRIu64, total_heap_size, layout.arena_size);
+        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " arena=%" PRIu64, eff_heap_size, layout.arena_size);
         record_bind_phase(HostPhaseKind::BindStaticArena, t_static_arena_ns, attrs);
     }
 
@@ -1154,7 +1090,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // No SM base: the scheduler and sm_handle are device-written now, so nothing
     // here stores one, and the region is not even committed yet.
     PTO2Runtime *rt = runtime_init_data_from_layout(
-        host_arena, layout, PTO2_MODE_EXECUTE, /*sm_dev_base=*/nullptr, sm_size, gm_heap, eff_heap_sizes
+        host_arena, layout, PTO2_MODE_EXECUTE, /*sm_dev_base=*/nullptr, sm_size, gm_heap, eff_heap_size
     );
     if (rt == nullptr) {
         LOG_ERROR("runtime_init_data_from_layout failed");
@@ -1178,8 +1114,8 @@ extern "C" int bind_callable_to_runtime_impl(
         ChipTaskArgs orch_l2;
         orch_l2.create_from_chip_args(device_args);
         int32_t total_tasks = run_host_orchestration(
-            runtime, api, tensor_access, rt, host_arena, layout, sm_size, runtime_arena_dev, gm_heap, eff_heap_sizes,
-            eff_task_window_sizes, host_orch_func_ptr, orch_l2
+            runtime, api, tensor_access, rt, host_arena, layout, sm_size, runtime_arena_dev, gm_heap, eff_heap_size,
+            eff_task_window_size, host_orch_func_ptr, orch_l2
         );
         // The orchestrator is the only host-view reader; from here the device
         // owns these buffers, so drop the window on both exits.

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator.h
@@ -60,8 +60,9 @@ struct PTO2OrchestratorState {
     // === SHARED MEMORY ACCESS ===
     PTO2SharedMemoryHeader *sm_header;
 
-    // === RING RESOURCES (single ring) ===
-    PTO2RingSet ring;
+    // === TASK / HEAP ALLOCATION ===
+    // hbg is single-ring, so one allocator covers the whole graph.
+    PTO2TaskAllocator task_allocator;
     std::unique_ptr<uint32_t[]> fanin_seen_epoch;
     uint32_t fanin_seen_current_epoch{1};
 

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -966,7 +966,13 @@ struct PTO2FaninBuilder {
     int32_t *slots{nullptr};
 
     bool mark_seen(uint8_t prod_ring, int32_t prod_slot) {
-        if (prod_ring >= PTO2_MAX_RING_DEPTH || prod_slot < 0) {
+        // Dedup only: a producer this orchestrator did not place has no slot in the
+        // epoch table, so it is reported as not-yet-seen and the caller appends it
+        // rather than rejecting it. hbg places every task on its one ring, so the
+        // assert is the invariant; enforcing it on the caller's side would be a new
+        // fatal path.
+        debug_assert(prod_ring == 0 && "hbg places every task on its one ring");
+        if (prod_ring != 0 || prod_slot < 0) {
             return false;
         }
         uint32_t *seen = orch->fanin_seen_epoch.get();
@@ -1048,7 +1054,7 @@ static bool prepare_task(
 ) {
     always_assert(orch->scope_stack_top >= 0 && "Cannot submit task outside a scope");
     uint8_t ring_id = 0;
-    auto &allocator = orch->ring.task_allocator;
+    auto &allocator = orch->task_allocator;
 
     int16_t block_num = args.launch_spec.block_num();
     int32_t active_subtasks_per_block = __builtin_popcount(active_mask.core_mask());
@@ -1208,7 +1214,7 @@ void PTO2OrchestratorState::begin_scope(PTO2ScopeMode mode) {
     // task/heap start-end and tensormap usage at the scope boundary.
     if (is_scope_stats_enabled()) {
         uint8_t ring_id = 0;
-        auto &alloc = orch->ring.task_allocator;
+        auto &alloc = orch->task_allocator;
         // Polling: no dep_pool to report (readiness is via completion_flags).
         int32_t dep_pool_tail = 0;
         int32_t dep_pool_top = 0;
@@ -1247,7 +1253,7 @@ void PTO2OrchestratorState::end_scope() {
     // emits the end-boundary record and tears down bookkeeping.
     if (is_scope_stats_enabled()) {
         uint8_t ring_id = 0;
-        auto &alloc = orch->ring.task_allocator;
+        auto &alloc = orch->task_allocator;
         // Polling: no dep_pool to report (readiness is via completion_flags).
         int32_t dep_pool_tail = 0;
         int32_t dep_pool_top = 0;
@@ -1630,7 +1636,7 @@ bool graph_submit_outer(
     bool defer_heap, const GraphTaskArgs &args, TaskId *submitted_id
 ) {
     always_assert(orch->scope_stack_top >= 0 && "Cannot submit Graph outside a scope");
-    auto &allocator = orch->ring.task_allocator;
+    auto &allocator = orch->task_allocator;
     if (allocator.active_count() >= allocator.window_size() ||
         (!defer_heap && static_cast<uint64_t>(owned_heap) > allocator.heap_available())) {
         LOG_WARN("%s", "[GraphExecution] task-window/heap preflight failed; using ordinary path");
@@ -1816,9 +1822,7 @@ bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostSt
         }
         void *packed_base = nullptr;
         void *packed_end = nullptr;
-        if (!orch->ring.task_allocator.reserve_deferred_heap(
-                static_cast<int32_t>(owned_heap), &packed_base, &packed_end
-            )) {
+        if (!orch->task_allocator.reserve_deferred_heap(static_cast<int32_t>(owned_heap), &packed_base, &packed_end)) {
             if (failed_key != nullptr) *failed_key = pending.full_key;
             return false;
         }
@@ -2171,7 +2175,7 @@ PTO2OrchestratorState::graph_begin_inner(uint64_t graph_key, const GraphTaskArgs
 
     auto recording = std::make_unique<GraphRecording>();
     recording->full_key = full_key;
-    recording->start_local_task_id = orch->ring.task_allocator.active_count();
+    recording->start_local_task_id = orch->task_allocator.active_count();
     if (!graph_recording_init_tensor_map(*recording)) {
         LOG_WARN("[GraphExecution] recording hazard map allocation failed; using ordinary path");
         return result;
@@ -2611,11 +2615,9 @@ TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const CoreTaskArgs &args)
 
 void PTO2OrchestratorState::mark_done() {
     auto *orch = this;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        int32_t total_tasks = orch->ring.task_allocator.active_count();
-        if (total_tasks > 0) {
-            LOG_DEBUG("=== [Orchestrator] ring %d: total_tasks=%d ===", r, total_tasks);
-        }
+    int32_t total_tasks = orch->task_allocator.active_count();
+    if (total_tasks > 0) {
+        LOG_DEBUG("=== [Orchestrator] total_tasks=%d ===", total_tasks);
     }
     orch->sm_header->orchestrator_done.store(1, std::memory_order_release);
     orch->scope_tasks_size = 0;

--- a/src/a2a3/runtime/host_build_graph/runtime/ring_buffer.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/ring_buffer.h
@@ -11,23 +11,11 @@
 /**
  * PTO Runtime2 - Ring Buffer Data Structures
  *
- * Implements ring buffer designs for zero-overhead memory management:
- *
- * 1. TaskAllocator - Unified task slot + output buffer allocation
- *    - Combines task ring (slot allocation) and heap ring (output buffer allocation)
- *    - O(1) forward bump allocation for both task slots and heap buffers
- *    - Neither resource is reclaimed during a run, so exhaustion of either is a
- *      capacity error reported on the spot, never back-pressure to wait on
- *
- * 2. FaninPool - Fanin spill entry allocation
- *    - Ring buffer for spilled fanin entries
- *    - O(1) append allocation
- *    - Implicit reclamation with task ring
- *
- * 3. DepListPool - Dependency list entry allocation
- *    - Ring buffer for linked list entries
- *    - O(1) prepend operation
- *    - Implicit reclamation with task ring
+ * TaskAllocator - Unified task slot + output buffer allocation
+ *   - Combines task ring (slot allocation) and heap ring (output buffer allocation)
+ *   - O(1) forward bump allocation for both task slots and heap buffers
+ *   - Neither resource is reclaimed during a run, so exhaustion of either is a
+ *     capacity error reported on the spot, never back-pressure to wait on
  *
  * Based on: docs/RUNTIME_LOGIC.md
  */
@@ -49,9 +37,6 @@
 // offsets. That classification is only sound while the range is disjoint from
 // every real heap address, which PTO2TaskAllocator::init() asserts.
 inline constexpr uint64_t GRAPH_RECORD_VIRTUAL_BASE = 1ULL << 63;
-
-// Dep pool spin limit - if exceeded, dep pool capacity too small for workload
-#define PTO2_DEP_POOL_SPIN_LIMIT 100000
 
 // =============================================================================
 // Task Allocator (unified task slot + heap buffer allocation)
@@ -268,16 +253,4 @@ private:
             error_code_ptr_->store(code, std::memory_order_release);
         }
     }
-};
-
-// =============================================================================
-// Ring Set (per-depth aggregate)
-// =============================================================================
-
-/**
- * Groups the per-depth allocator state into one unit; PTO2_MAX_RING_DEPTH
- * instances exist, one per scope depth.
- */
-struct PTO2RingSet {
-    PTO2TaskAllocator task_allocator;
 };

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime_core.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime_core.h
@@ -152,9 +152,10 @@ struct PTO2RuntimeArenaLayout {
     size_t off_copied_begin{0};
     size_t off_copied_end{0};
 
-    // Cached parameters (re-used by init_data + wire stages).
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]{};
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]{};
+    // Cached parameters (re-used by init_data + wire stages). hbg is single-ring,
+    // so these are the one ring's.
+    uint64_t task_window_size{0};
+    uint64_t heap_size{0};
 
     // Total arena byte size post-commit. Used by host to size the prebuilt
     // image buffer and as the rtMemcpy length, and requested of the device as
@@ -240,11 +241,7 @@ static_assert(
  * device memory and may run on host. Returns the layout descriptor; caller
  * commits/attaches the arena before Phase 2/3.
  */
-PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size);
-PTO2RuntimeArenaLayout runtime_reserve_layout(
-    DeviceArena &arena, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
-);
+PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, uint64_t heap_size = 0);
 
 /**
  * Phase 2 — write the data half of the runtime arena: standalone fields,
@@ -266,10 +263,6 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
 PTO2Runtime *runtime_init_data_from_layout(
     DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
     void *gm_heap_dev_base, uint64_t heap_size
-);
-PTO2Runtime *runtime_init_data_from_layout(
-    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
-    void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
 );
 
 /**

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime_types.h
@@ -70,18 +70,18 @@
 // =============================================================================
 
 // Task management
-// NOTE: PTO2_TASK_WINDOW_SIZE is now a per-ring default value.
 // Actual window size is passed at runtime to runtime_create_from_sm().
 // Use pto2_task_slot(sched, task_id) for slot calculation.
-#define PTO2_TASK_WINDOW_SIZE 16384  // Default per-ring task window size (power of 2)
+#define PTO2_TASK_WINDOW_SIZE 16384  // Default task window size (power of 2)
 
-// Single ring. host_build_graph is host-orch: the whole graph is built on the
-// host, fits one ring, and the device runs it once without reclaim. The
-// multi-ring design existed only to
+// host_build_graph has one ring, and carries no per-ring dimension anywhere:
+// host-orch builds the whole graph on the host, it fits that ring, and the
+// device runs it once without reclaim. tmr's multi-ring design existed only to
 // let inner scopes reclaim independently under small rings; with no reclaim and
-// a whole-graph-resident ring, per-depth isolation is moot, so all scope depths
-// map to the single ring 0 (0 == 0).
-#define PTO2_MAX_RING_DEPTH 1
+// a whole-graph-resident ring, per-depth isolation is moot, so every scope depth
+// uses the same ring. The RuntimeEnv ABI still carries RUNTIME_ENV_RING_COUNT
+// slots because it is shared with tmr; this runtime reads slot 0 (see
+// bind_callable_to_runtime_impl).
 
 // Memory pools (total = value, single ring)
 #define PTO2_HEAP_SIZE (256 * 1024 * 1024)  // 256MB
@@ -90,12 +90,11 @@
 
 // Scope management
 #define PTO2_MAX_SCOPE_DEPTH 64  // Maximum nesting depth
-// Hard cap for the scope_tasks buffer. Equals the total in-flight ring slot
-// budget (PTO2_TASK_WINDOW_SIZE × PTO2_MAX_RING_DEPTH): once every ring slot
-// is in flight, no more tasks can ever be pushed regardless of buffer size.
-// scope_tasks_push fatals on overflow rather than growing the arena-owned
-// buffer (which would be UB on the arena's malloc'd backing).
-#define PTO2_SCOPE_TASKS_CAP (PTO2_TASK_WINDOW_SIZE * PTO2_MAX_RING_DEPTH)
+// Hard cap for the scope_tasks buffer. Equals the in-flight ring slot budget:
+// once every ring slot is in flight, no more tasks can ever be pushed regardless
+// of buffer size. scope_tasks_push fatals on overflow rather than growing the
+// buffer.
+#define PTO2_SCOPE_TASKS_CAP (PTO2_TASK_WINDOW_SIZE)
 
 // Per-shape ready-queue capacity (power of two). This is a ring buffer that
 // bounds peak CONCURRENT occupancy (enqueue_pos - dequeue_pos), not total task

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -232,79 +232,77 @@ void SchedulerContext::log_stall_diagnostics(
     // produce identical TASK lines once per scheduler thread.
     if (thread_idx == 0) {
         int32_t cnt_ready = 0, cnt_waiting = 0, cnt_running = 0, submitted_in_ring = 0;
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            PTO2SharedMemoryRingHeader &ring = *sched_->ring_sched_state.ring;
-            int32_t ring_task_count = ring.fc.current_task_index.load(std::memory_order_relaxed);
-            submitted_in_ring += ring_task_count;
-            for (int32_t si = 0; si < ring_task_count; si++) {
-                PTO2TaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
-                PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
-                // Polling: no fanin_refcount. Recompute met/total from the inline
-                // fanin ids vs the ring completion_flags (rc = satisfied producers,
-                // fi = raw producer count) so the stall dump still shows readiness.
-                int32_t fi = slot_state.payload != nullptr ? slot_state.payload->fanin_count : 0;
-                int32_t rc = 0;
-                if (slot_state.payload != nullptr) {
-                    const int32_t *fanin = slot_state.payload->fanin_data();
-                    for (int32_t k = 0; k < fi; k++) {
-                        if (ring.is_completion_flag_set(fanin[k], std::memory_order_relaxed)) rc++;
-                    }
+        PTO2SharedMemoryRingHeader &ring = *sched_->ring_sched_state.ring;
+        int32_t ring_task_count = ring.fc.current_task_index.load(std::memory_order_relaxed);
+        submitted_in_ring += ring_task_count;
+        for (int32_t si = 0; si < ring_task_count; si++) {
+            PTO2TaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
+            PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
+            // Polling: no fanin_refcount. Recompute met/total from the inline
+            // fanin ids vs the ring completion_flags (rc = satisfied producers,
+            // fi = raw producer count) so the stall dump still shows readiness.
+            int32_t fi = slot_state.payload != nullptr ? slot_state.payload->fanin_count : 0;
+            int32_t rc = 0;
+            if (slot_state.payload != nullptr) {
+                const int32_t *fanin = slot_state.payload->fanin_data();
+                for (int32_t k = 0; k < fi; k++) {
+                    if (ring.is_completion_flag_set(fanin[k], std::memory_order_relaxed)) rc++;
                 }
-                int32_t kid_aic = slot_state.task->kernel_id[0];
-                int32_t kid_aiv0 = slot_state.task->kernel_id[1];
-                int32_t kid_aiv1 = slot_state.task->kernel_id[2];
-                int64_t task_id = static_cast<int64_t>(slot_state.task->task_id.raw);
-                if (st >= PTO2_TASK_COMPLETED) continue;
-                // task_state has no intermediate ready/running value — it
-                // stays PENDING until the worker stores COMPLETED. Classify
-                // by the ground truth instead: a slot is RUNNING iff some
-                // core has it as running_slot_state. A task occupies at most
-                // 3 cores (one cluster), all under the same owner thread by
-                // construction of assign_cores_to_threads.
-                char running_on[192] = {0};
-                int32_t owner = -1;
-                int32_t pos = 0;
-                bool is_running = false;
-                for (int32_t cid = 0; cid < cores_total_num_ && pos + 32 < (int32_t)sizeof(running_on); cid++) {
-                    if (core_exec_states_[cid].running_slot_state != &slot_state) continue;
-                    is_running = true;
-                    if (owner < 0) owner = find_core_owner_thread(cid);
-                    const char *sname = subslot_name(core_exec_states_[cid].running_subslot);
-                    int32_t written = snprintf(
-                        running_on + pos, sizeof(running_on) - pos, "%score=%d(%s)", pos == 0 ? "" : " ", cid, sname
-                    );
-                    if (written > 0) pos += written;
-                }
+            }
+            int32_t kid_aic = slot_state.task->kernel_id[0];
+            int32_t kid_aiv0 = slot_state.task->kernel_id[1];
+            int32_t kid_aiv1 = slot_state.task->kernel_id[2];
+            int64_t task_id = static_cast<int64_t>(slot_state.task->task_id.raw);
+            if (st >= PTO2_TASK_COMPLETED) continue;
+            // task_state has no intermediate ready/running value — it
+            // stays PENDING until the worker stores COMPLETED. Classify
+            // by the ground truth instead: a slot is RUNNING iff some
+            // core has it as running_slot_state. A task occupies at most
+            // 3 cores (one cluster), all under the same owner thread by
+            // construction of assign_cores_to_threads.
+            char running_on[192] = {0};
+            int32_t owner = -1;
+            int32_t pos = 0;
+            bool is_running = false;
+            for (int32_t cid = 0; cid < cores_total_num_ && pos + 32 < (int32_t)sizeof(running_on); cid++) {
+                if (core_exec_states_[cid].running_slot_state != &slot_state) continue;
+                is_running = true;
+                if (owner < 0) owner = find_core_owner_thread(cid);
+                const char *sname = subslot_name(core_exec_states_[cid].running_subslot);
+                int32_t written = snprintf(
+                    running_on + pos, sizeof(running_on) - pos, "%score=%d(%s)", pos == 0 ? "" : " ", cid, sname
+                );
+                if (written > 0) pos += written;
+            }
 
-                if (is_running) {
-                    cnt_running++;
-                    if (cnt_running > STALL_DUMP_READY_MAX) continue;
-                    LOG_INFO(
-                        "[STALL thread=%d idle_iterations=%d] TASK ring=%d task_id=%" PRId64
-                        " state=RUNNING fanin_met=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d] "
-                        "running_on=[owner_thread=%d cores=[%s]]",
-                        thread_idx, idle_iterations, r, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1, owner, running_on
-                    );
-                    continue;
-                }
-                if (rc >= fi) {
-                    cnt_ready++;
-                    if (cnt_ready > STALL_DUMP_READY_MAX) continue;
-                    LOG_INFO(
-                        "[STALL thread=%d idle_iterations=%d] TASK ring=%d task_id=%" PRId64
-                        " state=READY   fanin_met=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d]",
-                        thread_idx, idle_iterations, r, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1
-                    );
-                    continue;
-                }
-                cnt_waiting++;
-                if (cnt_waiting > STALL_DUMP_WAIT_MAX) continue;
+            if (is_running) {
+                cnt_running++;
+                if (cnt_running > STALL_DUMP_READY_MAX) continue;
                 LOG_INFO(
                     "[STALL thread=%d idle_iterations=%d] TASK ring=%d task_id=%" PRId64
-                    " state=WAIT    fanin_met=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d] missing_deps=%d",
-                    thread_idx, idle_iterations, r, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1, fi - rc
+                    " state=RUNNING fanin_met=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d] "
+                    "running_on=[owner_thread=%d cores=[%s]]",
+                    thread_idx, idle_iterations, 0, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1, owner, running_on
                 );
+                continue;
             }
+            if (rc >= fi) {
+                cnt_ready++;
+                if (cnt_ready > STALL_DUMP_READY_MAX) continue;
+                LOG_INFO(
+                    "[STALL thread=%d idle_iterations=%d] TASK ring=%d task_id=%" PRId64
+                    " state=READY   fanin_met=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d]",
+                    thread_idx, idle_iterations, 0, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1
+                );
+                continue;
+            }
+            cnt_waiting++;
+            if (cnt_waiting > STALL_DUMP_WAIT_MAX) continue;
+            LOG_INFO(
+                "[STALL thread=%d idle_iterations=%d] TASK ring=%d task_id=%" PRId64
+                " state=WAIT    fanin_met=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d] missing_deps=%d",
+                thread_idx, idle_iterations, 0, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1, fi - rc
+            );
         }
         int32_t effective_total = task_count > 0 ? task_count : submitted_in_ring;
         int32_t c = completed_tasks_.load(std::memory_order_relaxed);
@@ -918,12 +916,10 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
         // more than the scope cap. This rejects any garbage pattern (negative
         // or positive), so uninitialized rings contribute 0 (the correct boot
         // count) while valid counts still add up, with no signed overflow.
-        int64_t pto2_count = 0;
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            int32_t ring_tasks = header->ring.fc.current_task_index.load(std::memory_order_acquire);
-            if (ring_tasks > 0 && ring_tasks <= PTO2_SCOPE_TASKS_CAP) pto2_count += ring_tasks;
-        }
-        total_tasks_ = static_cast<int32_t>(pto2_count);
+        int32_t pto2_count = 0;
+        int32_t ring_tasks = header->ring.fc.current_task_index.load(std::memory_order_acquire);
+        if (ring_tasks > 0 && ring_tasks <= PTO2_SCOPE_TASKS_CAP) pto2_count = ring_tasks;
+        total_tasks_ = pto2_count;
     } else {
         total_tasks_ = 0;
     }

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/runtime_init.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/runtime_init.cpp
@@ -22,27 +22,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <limits>
-
 #include "orchestrator.h"
 #include "runtime_core.h"
 #include "ring_buffer.h"
 #include "shared_memory.h"
 #include "tensormap.h"
 #include "scheduler/scheduler.h"
-
-static bool sum_ring_heap_sizes(const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], uint64_t *total) {
-    uint64_t sum = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (heap_sizes[r] > std::numeric_limits<uint64_t>::max() - sum) {
-            LOG_ERROR("Total ring heap size overflows uint64_t");
-            return false;
-        }
-        sum += heap_sizes[r];
-    }
-    *total = sum;
-    return true;
-}
 
 // =============================================================================
 // Ready queue
@@ -236,7 +221,7 @@ bool PTO2OrchestratorState::init(
     auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_base);
     auto *cur_idx_dev = pto2_sm_layout::ring_current_task_index_addr(sm_base);
 
-    orch->ring.task_allocator.init(static_cast<int32_t>(task_window_size), cur_idx_dev, gm_heap, heap_size, orch_err);
+    orch->task_allocator.init(static_cast<int32_t>(task_window_size), cur_idx_dev, gm_heap, heap_size, orch_err);
 
     // The mirror's argument pools. Offset arithmetic on the same base as sm_header,
     // so it holds for whichever SM this orchestrator was pointed at. The cursors
@@ -277,26 +262,11 @@ void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler) { this-
 // Top-level runtime arena
 // =============================================================================
 
-PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        task_window_sizes[r] = task_window_size;
-        heap_sizes[r] = 0;
-    }
-    return runtime_reserve_layout(arena, task_window_sizes, heap_sizes);
-}
-
-PTO2RuntimeArenaLayout runtime_reserve_layout(
-    DeviceArena &arena, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
-) {
+PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, uint64_t heap_size) {
     PTO2RuntimeArenaLayout layout{};
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        layout.task_window_sizes[r] = task_window_sizes[r];
-        layout.heap_sizes[r] = heap_sizes[r];
-    }
+    layout.task_window_size = task_window_size;
+    layout.heap_size = heap_size;
 
     // Reservation order is the zone partition (see PTO2RuntimeArenaLayout):
     // everything the device initializes itself, then the one copied range. Each
@@ -320,17 +290,6 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
     return layout;
 }
 
-PTO2Runtime *runtime_init_data_from_layout(
-    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
-    uint64_t /*sm_size*/, void *gm_heap_dev_base, uint64_t heap_size
-) {
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        heap_sizes[r] = heap_size;
-    }
-    return runtime_init_data_from_layout(arena, layout, mode, sm_dev_base, 0, gm_heap_dev_base, heap_sizes);
-}
-
 /**
  * Populate the prebuilt runtime-arena image in place (host build path).
  *
@@ -344,7 +303,7 @@ PTO2Runtime *runtime_init_data_from_layout(
  */
 PTO2Runtime *runtime_init_data_from_layout(
     DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
-    uint64_t /*sm_size*/, void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+    uint64_t /*sm_size*/, void *gm_heap_dev_base, uint64_t heap_size
 ) {
     PTO2Runtime *rt = static_cast<PTO2Runtime *>(arena.region_ptr(layout.off_runtime));
     memset(rt, 0, sizeof(*rt));
@@ -352,11 +311,7 @@ PTO2Runtime *runtime_init_data_from_layout(
     // rt->ops is filled by the AICPU at boot.
     rt->mode = mode;
     rt->gm_heap = gm_heap_dev_base;
-    uint64_t total_heap_size = 0;
-    if (!sum_ring_heap_sizes(heap_sizes, &total_heap_size)) {
-        return nullptr;
-    }
-    rt->gm_heap_size = total_heap_size;
+    rt->gm_heap_size = heap_size;
     rt->gm_heap_owned = false;
     rt->total_cycles = 0;
     rt->active_callable_hash = 0;

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/shared_memory.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/shared_memory.cpp
@@ -28,27 +28,16 @@
 // =============================================================================
 
 uint64_t PTO2SharedMemoryHandle::calculate_size(uint64_t task_window_size) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        task_window_sizes[r] = task_window_size;
-    }
-    return calculate_size_per_ring(task_window_sizes);
-}
-
-uint64_t PTO2SharedMemoryHandle::calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
     // Total SM size = offset just past the ring's slot_states, from the single
     // source of truth for the layout (pto2_sm_layout::ring_segment_offsets).
-    return pto2_sm_layout::ring_segment_offsets(task_window_sizes[0]).end;
+    return pto2_sm_layout::ring_segment_offsets(task_window_size).end;
 }
 
 // =============================================================================
 // Creation and Destruction
 // =============================================================================
 
-void PTO2SharedMemoryHandle::setup_pointers_per_ring(
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch
-) {
-    (void)task_window_sizes;
+void PTO2SharedMemoryHandle::setup_pointers(uint64_t pitch) {
     char *base = (char *)sm_base;
     header = (PTO2SharedMemoryHeader *)base;
 
@@ -68,32 +57,11 @@ void PTO2SharedMemoryHandle::setup_pointers_per_ring(
     ring.completion_flags = (std::atomic<uint8_t> *)(base + off.completion_flags);
 }
 
-void PTO2SharedMemoryHandle::setup_pointers(uint64_t task_window_size) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        task_window_sizes[r] = task_window_size;
-    }
-    setup_pointers_per_ring(task_window_sizes, task_window_size);
-}
-
 bool PTO2SharedMemoryHandle::init(
     void *sm_base_arg, uint64_t sm_size_arg, uint64_t task_window_size, uint64_t heap_size
 ) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        task_window_sizes[r] = task_window_size;
-        heap_sizes[r] = heap_size;
-    }
-    return init_per_ring(sm_base_arg, sm_size_arg, task_window_sizes, heap_sizes);
-}
-
-bool PTO2SharedMemoryHandle::init_per_ring(
-    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
-) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
-    const uint64_t mirror_bytes = calculate_size_per_ring(task_window_sizes);
+    const uint64_t mirror_bytes = calculate_size(task_window_size);
     // The mirror has to stay inside an int32 delta's reach: a payload names its
     // argument regions that way, and set() leaves a field unbound rather than
     // truncating, so a pool out of reach would read back as null and be dereferenced
@@ -107,21 +75,20 @@ bool PTO2SharedMemoryHandle::init_per_ring(
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers_per_ring(task_window_sizes, task_window_sizes[0]);
-    init_header_per_ring(task_window_sizes, heap_sizes);
+    setup_pointers(task_window_size);
+    init_header(task_window_size, heap_size);
     return true;
 }
 
 bool PTO2SharedMemoryHandle::attach_populated(
-    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t live_slots,
-    uint64_t image_bytes
+    void *sm_base_arg, uint64_t sm_size_arg, uint64_t task_window_size, uint64_t live_slots, uint64_t image_bytes
 ) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
     // A pitch above the capacity would name a slot the ring cannot address, and one
     // below what the host used would place every segment past the descriptors
     // short. This is the whole contract between the two sides, checked once at
     // attach rather than trusted.
-    if (live_slots == 0 || live_slots > task_window_sizes[0]) return false;
+    if (live_slots == 0 || live_slots > task_window_size) return false;
     // The image must at least hold the four slot-pitched segments; anything beyond
     // that is its argument pools, whose extents are the bind's cursors and are not
     // recomputable here. The first pool's offset is exactly where those four end.
@@ -139,9 +106,9 @@ bool PTO2SharedMemoryHandle::attach_populated(
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers_per_ring(task_window_sizes, live_slots);
-    // Deliberately NO init_header_per_ring: the SM already holds the host
-    // orchestrator's task graph (descriptors, slot states, ring counters).
+    setup_pointers(live_slots);
+    // Deliberately NO init_header: the SM already holds the host orchestrator's
+    // task graph (descriptors, slot states, ring counters).
     return true;
 }
 
@@ -174,18 +141,6 @@ void PTO2SharedMemoryHandle::destroy() {
 //
 // no need init data in pool, init pool data when used
 void PTO2SharedMemoryHandle::init_header(uint64_t task_window_size, uint64_t heap_size) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        task_window_sizes[r] = task_window_size;
-        heap_sizes[r] = heap_size;
-    }
-    init_header_per_ring(task_window_sizes, heap_sizes);
-}
-
-void PTO2SharedMemoryHandle::init_header_per_ring(
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
-) {
     // Flow control (starts at 0)
     header->ring.fc.init();
 
@@ -197,13 +152,13 @@ void PTO2SharedMemoryHandle::init_header_per_ring(
 
     // Ring layout info
     uint64_t offset = PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
-    header->ring.task_window_size = task_window_sizes[0];
-    header->ring.task_window_mask = static_cast<int32_t>(task_window_sizes[0] - 1);
-    header->ring.heap_size = heap_sizes[0];
+    header->ring.task_window_size = task_window_size;
+    header->ring.task_window_mask = static_cast<int32_t>(task_window_size - 1);
+    header->ring.heap_size = heap_size;
     header->ring.task_descriptors_offset = offset;
-    offset += PTO2_ALIGN_UP(task_window_sizes[0] * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
-    offset += PTO2_ALIGN_UP(task_window_sizes[0] * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
-    offset += PTO2_ALIGN_UP(task_window_sizes[0] * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
+    offset += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
+    offset += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
+    offset += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
 
     header->total_size = sm_size;
 
@@ -232,17 +187,14 @@ void PTO2SharedMemoryHandle::print_layout() {
     LOG_DEBUG("=== PTO2 Shared Memory Layout ===");
     LOG_DEBUG("Base address:       %p", sm_base);
     LOG_DEBUG("Total size:         %" PRIu64 " bytes", h->total_size);
-    LOG_DEBUG("Ring depth:         %d", PTO2_MAX_RING_DEPTH);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        LOG_DEBUG("Ring %d:", r);
-        LOG_DEBUG("  task_window_size: %" PRIu64, h->ring.task_window_size);
-        LOG_DEBUG("  heap_size:        %" PRIu64 " bytes", h->ring.heap_size);
-        LOG_DEBUG(
-            "  descriptors_off:  %" PRIu64 " (0x%" PRIx64 ")", h->ring.task_descriptors_offset,
-            h->ring.task_descriptors_offset
-        );
-        LOG_DEBUG("  current_task_idx: %d", h->ring.fc.current_task_index.load(std::memory_order_acquire));
-    }
+    LOG_DEBUG("Ring:");
+    LOG_DEBUG("  task_window_size: %" PRIu64, h->ring.task_window_size);
+    LOG_DEBUG("  heap_size:        %" PRIu64 " bytes", h->ring.heap_size);
+    LOG_DEBUG(
+        "  descriptors_off:  %" PRIu64 " (0x%" PRIx64 ")", h->ring.task_descriptors_offset,
+        h->ring.task_descriptors_offset
+    );
+    LOG_DEBUG("  current_task_idx: %d", h->ring.fc.current_task_index.load(std::memory_order_acquire));
     LOG_DEBUG("orchestrator_done:  %d", h->orchestrator_done.load(std::memory_order_acquire));
     LOG_DEBUG("Error state:");
     LOG_DEBUG("  orch_error_code:    %d", h->orch_error_code.load(std::memory_order_relaxed));
@@ -258,17 +210,14 @@ bool PTO2SharedMemoryHandle::validate() {
 
     PTO2SharedMemoryHeader *h = header;
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (!h->ring.fc.validate(this, r)) return false;
-    }
+    if (!h->ring.fc.validate(this)) return false;
 
     return true;
 }
 
-bool PTO2RingFlowControl::validate(PTO2SharedMemoryHandle *handle, int32_t ring_id) const {
+bool PTO2RingFlowControl::validate(PTO2SharedMemoryHandle *handle) const {
     if (!handle) return false;
     if (!handle->header) return false;
-    if (ring_id < 0 || ring_id >= PTO2_MAX_RING_DEPTH) return false;
 
     const PTO2SharedMemoryHeader *h = handle->header;
 

--- a/src/a2a3/runtime/host_build_graph/runtime/shared_memory.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared_memory.h
@@ -63,7 +63,7 @@ struct alignas(64) PTO2RingFlowControl {
     // submit IDs will be off by the divergence.
     void init() { current_task_index.store(0, std::memory_order_relaxed); }
 
-    bool validate(PTO2SharedMemoryHandle *handle, int32_t ring_id) const;
+    bool validate(PTO2SharedMemoryHandle *handle) const;
 };
 
 static_assert(sizeof(PTO2RingFlowControl) == 64, "PTO2RingFlowControl must be exactly one cache line (64B)");
@@ -216,7 +216,6 @@ struct PTO2SharedMemoryHandle {
     // === Static helpers ===
 
     static uint64_t calculate_size(uint64_t task_window_size);
-    static uint64_t calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
 
     // UT convenience: reserve wrapper + sm_base on `arena`, commit, and init
     // using default PTO2_TASK_WINDOW_SIZE / PTO2_HEAP_SIZE. Only valid when the
@@ -231,17 +230,13 @@ struct PTO2SharedMemoryHandle {
     // init_header. Returns false when `sm_size` is too small for the requested
     // `task_window_size`.
     bool init(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size);
-    bool init_per_ring(
-        void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-        const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
-    );
 
     // Attach to an ALREADY-populated shared memory region: point the handle and
     // every ring header's data pointers (descriptors / payloads / slot_states)
     // at `sm_base`, but do NOT reset the flow-control counters / slot states.
     // Used by host_build_graph host-orch, where the host orchestrator populated
     // the SM and H2D'd it; the device must re-point at its own SM base without
-    // wiping the contents (unlike init_per_ring, which also resets the header).
+    // wiping the contents (unlike init, which also resets the header).
     //
     // `live_slots` is the pitch the uploaded arrays were laid out with — the
     // number of slots the host actually submitted, not the ring capacity. It must
@@ -256,8 +251,7 @@ struct PTO2SharedMemoryHandle {
     // pool base is resolved here. The value bounds the region and checks the int32
     // delta reach.
     bool attach_populated(
-        void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t live_slots,
-        uint64_t image_bytes
+        void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t live_slots, uint64_t image_bytes
     );
 
     void destroy();
@@ -266,14 +260,10 @@ struct PTO2SharedMemoryHandle {
 
 private:
     void init_header(uint64_t task_window_size, uint64_t heap_size);
-    void init_header_per_ring(
-        const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
-    );
-    void setup_pointers(uint64_t task_window_size);
-    // `pitch` is the slot count the arrays are dimensioned for. init_per_ring passes
-    // the ring capacity (the mirror the orchestrator writes into); attach_populated
+    // `pitch` is the slot count the arrays are dimensioned for. init passes the
+    // ring capacity (the mirror the orchestrator writes into); attach_populated
     // passes the submitted count (the compacted image that shipped).
-    void setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch);
+    void setup_pointers(uint64_t pitch);
 };
 
 // =============================================================================

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -278,7 +278,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // attach_populated.
             memset(rt->sm_handle, 0, sizeof(*rt->sm_handle));
             if (!rt->sm_handle->attach_populated(
-                    sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes, live_slots, runtime->sm_image_bytes
+                    sm_ptr, sm_size, rt->prebuilt_layout.task_window_size, live_slots, runtime->sm_image_bytes
                 )) {
                 LOG_ERROR("Thread %d: host-orch: sm_handle->attach_populated failed", thread_idx);
                 rt = nullptr;

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -120,9 +120,9 @@ extern "C" int concurrent_native_prepare_supported_impl(void) {
 
 // RuntimeEnv (call_config.h) is the cross-runtime ABI for per-ring config and
 // carries RUNTIME_ENV_RING_COUNT slots, shared with tensormap_and_ringbuffer.
-// host_build_graph is single-ring (PTO2_MAX_RING_DEPTH == 1) and reads only the
-// first slot; it must fit within the ABI's slot budget, not equal it.
-static_assert(PTO2_MAX_RING_DEPTH <= RUNTIME_ENV_RING_COUNT, "PTO2 runtime ring depth must fit RuntimeEnv ring slots");
+// host_build_graph has one ring and reads slot 0, so it only needs the ABI to
+// carry at least one.
+static_assert(RUNTIME_ENV_RING_COUNT >= 1, "RuntimeEnv must carry the ring slot host_build_graph reads");
 
 static bool is_power_of_2_u64(uint64_t value) { return value != 0 && (value & (value - 1)) == 0; }
 
@@ -183,19 +183,6 @@ static void record_bind_phase(HostPhaseKind kind, int64_t start_ns, const char *
     host_phase_record_bind(static_cast<uint32_t>(kind), static_cast<uint64_t>(start_ns), with_counters, payload);
 }
 
-template <typename T>
-static std::string format_ring_array(const T (&values)[PTO2_MAX_RING_DEPTH]) {
-    std::string out = "[";
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; ++r) {
-        if (r != 0) {
-            out += ", ";
-        }
-        out += std::to_string(values[r]);
-    }
-    out += "]";
-    return out;
-}
-
 static std::string trim_copy(const std::string &input) {
     size_t begin = 0;
     while (begin < input.size() && std::isspace(static_cast<unsigned char>(input[begin]))) {
@@ -244,52 +231,25 @@ static bool parse_uint_token(
     return true;
 }
 
-static void apply_env_ring_values(
-    const char *name, uint64_t min_val, uint64_t max_val, bool require_power_of_2, uint64_t out[PTO2_MAX_RING_DEPTH]
-) {
+// The PTO2_RING_* knobs are shared with tensormap_and_ringbuffer, where a value
+// may be a comma-separated list, one entry per ring. hbg has one ring, so it
+// accepts the single-value spelling and rejects a list — which is what the
+// multi-ring parser did here too, since it required exactly one entry.
+static void
+apply_env_ring_value(const char *name, uint64_t min_val, uint64_t max_val, bool require_power_of_2, uint64_t *out) {
     const char *env = std::getenv(name);
     if (!env) return;
 
     std::string text(env);
-    if (text.find(',') == std::string::npos) {
-        uint64_t value = 0;
-        if (!parse_uint_token(name, text, min_val, max_val, require_power_of_2, &value)) {
-            return;
-        }
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            out[r] = value;
-        }
+    if (text.find(',') != std::string::npos) {
+        LOG_WARN("%s=%s invalid (this runtime has one ring; expected a single value), ignored", name, env);
         return;
     }
-
-    uint64_t parsed[PTO2_MAX_RING_DEPTH]{};
-    size_t pos = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        size_t comma = text.find(',', pos);
-        std::string token = text.substr(pos, comma == std::string::npos ? std::string::npos : comma - pos);
-        if (!parse_uint_token(name, token, min_val, max_val, require_power_of_2, &parsed[r])) {
-            return;
-        }
-        if (comma == std::string::npos) {
-            if (r != PTO2_MAX_RING_DEPTH - 1) {
-                LOG_WARN(
-                    "%s=%s invalid (expected exactly %d comma-separated values), ignored", name, env,
-                    PTO2_MAX_RING_DEPTH
-                );
-                return;
-            }
-            pos = text.size();
-        } else {
-            pos = comma + 1;
-        }
-    }
-    if (pos < text.size() || (!text.empty() && text.back() == ',')) {
-        LOG_WARN("%s=%s invalid (expected exactly %d comma-separated values), ignored", name, env, PTO2_MAX_RING_DEPTH);
+    uint64_t value = 0;
+    if (!parse_uint_token(name, text, min_val, max_val, require_power_of_2, &value)) {
         return;
     }
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        out[r] = parsed[r];
-    }
+    *out = value;
 }
 
 // ring_task_window / ring_heap / ring_dep_pool point into the #pragma pack(1)
@@ -307,56 +267,48 @@ static uint64_t read_ring_override(const uint64_t *base, int idx) {
     return value;
 }
 
-// Each of ring_task_window / ring_heap is a per-ring array of PTO2_MAX_RING_DEPTH
-// entries (0 = unset). Precedence per ring: per-task entry > PTO2_RING_* env value
-// > compile-time default. A "size all rings the same" request arrives already
-// broadcast to every entry by the caller. (Polling has no dep_pool, so the former
-// PTO2_RING_DEP_POOL knob is gone.)
+// ring_task_window / ring_heap point at the first slot of a per-ring array in the
+// RuntimeEnv wire struct (0 = unset); hbg has one ring and reads slot 0.
+// Precedence: per-task entry > PTO2_RING_* env value > compile-time default.
+// (Polling has no dep_pool, so the former PTO2_RING_DEP_POOL knob is gone.)
 static bool resolve_ring_config(
-    const uint64_t *ring_task_window, const uint64_t *ring_heap, uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH],
-    uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH]
+    const uint64_t *ring_task_window, const uint64_t *ring_heap, uint64_t *eff_task_window_size, uint64_t *eff_heap_size
 ) {
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        eff_task_window_sizes[r] = PTO2_TASK_WINDOW_SIZE;
-        eff_heap_sizes[r] = PTO2_HEAP_SIZE;
+    *eff_task_window_size = PTO2_TASK_WINDOW_SIZE;
+    *eff_heap_size = PTO2_HEAP_SIZE;
+
+    apply_env_ring_value("PTO2_RING_TASK_WINDOW", 4, static_cast<uint64_t>(INT32_MAX), true, eff_task_window_size);
+    apply_env_ring_value("PTO2_RING_HEAP", 1024, std::numeric_limits<uint64_t>::max(), false, eff_heap_size);
+
+    const uint64_t task_window_override = read_ring_override(ring_task_window, 0);
+    const uint64_t heap_override = read_ring_override(ring_heap, 0);
+    if (task_window_override != 0) {
+        *eff_task_window_size = task_window_override;
+    }
+    if (heap_override != 0) {
+        *eff_heap_size = heap_override;
     }
 
-    apply_env_ring_values("PTO2_RING_TASK_WINDOW", 4, static_cast<uint64_t>(INT32_MAX), true, eff_task_window_sizes);
-    apply_env_ring_values("PTO2_RING_HEAP", 1024, std::numeric_limits<uint64_t>::max(), false, eff_heap_sizes);
-
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        const uint64_t task_window_override = read_ring_override(ring_task_window, r);
-        const uint64_t heap_override = read_ring_override(ring_heap, r);
-        if (task_window_override != 0) {
-            eff_task_window_sizes[r] = task_window_override;
-        }
-        if (heap_override != 0) {
-            eff_heap_sizes[r] = heap_override;
-        }
-
-        if (eff_task_window_sizes[r] < 4 || eff_task_window_sizes[r] > static_cast<uint64_t>(INT32_MAX) ||
-            !is_power_of_2_u64(eff_task_window_sizes[r])) {
-            LOG_ERROR(
-                "ring_task_window[%d]=%" PRIu64 " must be a power of 2 in [4, INT32_MAX]", r, eff_task_window_sizes[r]
-            );
-            return false;
-        }
-        if (eff_heap_sizes[r] < 1024) {
-            LOG_ERROR("ring_heap[%d]=%" PRIu64 " must be >= 1024", r, eff_heap_sizes[r]);
-            return false;
-        }
-        // A slot state reaches its payload and descriptor through a 32-bit
-        // self-relative delta, so every pair of addresses in the shared-memory
-        // image must be within INT32_MAX of each other.
-        const uint64_t sm_bytes = pto2_sm_layout::ring_segment_offsets(eff_task_window_sizes[r]).end;
-        if (sm_bytes > static_cast<uint64_t>(INT32_MAX)) {
-            LOG_ERROR(
-                "ring_task_window[%d]=%" PRIu64 " needs a %" PRIu64 "-byte shared memory image, past the %d-byte limit "
-                "a slot state's self-relative payload/descriptor delta can span",
-                r, eff_task_window_sizes[r], sm_bytes, INT32_MAX
-            );
-            return false;
-        }
+    if (*eff_task_window_size < 4 || *eff_task_window_size > static_cast<uint64_t>(INT32_MAX) ||
+        !is_power_of_2_u64(*eff_task_window_size)) {
+        LOG_ERROR("ring_task_window=%" PRIu64 " must be a power of 2 in [4, INT32_MAX]", *eff_task_window_size);
+        return false;
+    }
+    if (*eff_heap_size < 1024) {
+        LOG_ERROR("ring_heap=%" PRIu64 " must be >= 1024", *eff_heap_size);
+        return false;
+    }
+    // A slot state reaches its payload and descriptor through a 32-bit
+    // self-relative delta, so every pair of addresses in the shared-memory
+    // image must be within INT32_MAX of each other.
+    const uint64_t sm_bytes = pto2_sm_layout::ring_segment_offsets(*eff_task_window_size).end;
+    if (sm_bytes > static_cast<uint64_t>(INT32_MAX)) {
+        LOG_ERROR(
+            "ring_task_window=%" PRIu64 " needs a %" PRIu64 "-byte shared memory image, past the %d-byte limit "
+            "a slot state's self-relative payload/descriptor delta can span",
+            *eff_task_window_size, sm_bytes, INT32_MAX
+        );
+        return false;
     }
 
     return true;
@@ -562,9 +514,8 @@ struct GraphHostStateBinding {
 
 int32_t run_host_orchestration(
     Runtime *runtime, const HostApi *api, HostTensorAccessor &tensor_access, PTO2Runtime *rt, DeviceArena &host_arena,
-    const PTO2RuntimeArenaLayout &layout, uint64_t sm_size, void *device_arena, void *gm_heap,
-    const uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH],
-    void *host_orch_func_ptr, const ChipTaskArgs &orch_l2
+    const PTO2RuntimeArenaLayout &layout, uint64_t sm_size, void *device_arena, void *gm_heap, uint64_t eff_heap_size,
+    uint64_t eff_task_window_size, void *host_orch_func_ptr, const ChipTaskArgs &orch_l2
 ) {
     // The dep_gen graph belongs to the orchestration that is about to run.
     dep_gen_host_graph_begin_capture();
@@ -573,8 +524,7 @@ int32_t run_host_orchestration(
     // each written per task at submit and read only for [0, total_tasks). Zero
     // only the fixed-size header here; the per-slot segments are initialized in
     // orch::prepare_task and shipped bounded to total_tasks below.
-    const pto2_sm_layout::PTO2RingSegmentOffsets sm_segs =
-        pto2_sm_layout::ring_segment_offsets(eff_task_window_sizes[0]);
+    const pto2_sm_layout::PTO2RingSegmentOffsets sm_segs = pto2_sm_layout::ring_segment_offsets(eff_task_window_size);
     // Over-allocated and rounded up: every segment offset is a multiple of
     // PTO2_ALIGN_SIZE and PTO2TaskSlotState is alignas(64), which a plain
     // new uint8_t[] does not guarantee.
@@ -593,14 +543,14 @@ int32_t run_host_orchestration(
     RAIIScopeGuard orchestrator_binding([rt]() {
         rt->orchestrator = nullptr;
     });
-    if (!orchestrator.init(host_sm, gm_heap, eff_heap_sizes[0], eff_task_window_sizes[0], rt->scheduler)) {
+    if (!orchestrator.init(host_sm, gm_heap, eff_heap_size, eff_task_window_size, rt->scheduler)) {
         LOG_ERROR("host-orch: orchestrator init against host SM failed");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Initialize the host SM header (ring flow control) so submit_task can run.
     PTO2SharedMemoryHandle host_sm_handle;
-    if (!host_sm_handle.init_per_ring(host_sm, sm_size, eff_task_window_sizes, eff_heap_sizes)) {
+    if (!host_sm_handle.init(host_sm, sm_size, eff_task_window_size, eff_heap_size)) {
         LOG_ERROR("host-orch: host SM init_per_ring failed");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
@@ -686,7 +636,7 @@ int32_t run_host_orchestration(
         LOG_RUNTIME_FAILURE(orch_error, SIMPLER_ERROR_NONE, status);
         LOG_ERROR(
             "host-orch: refusing to upload an incomplete graph after %" PRIu64 " heap bytes",
-            orchestrator.ring.task_allocator.heap_used_bytes()
+            orchestrator.task_allocator.heap_used_bytes()
         );
         return status;
     }
@@ -696,7 +646,7 @@ int32_t run_host_orchestration(
         char attrs[160];
         snprintf(
             attrs, sizeof(attrs), "tasks=%" PRId32 " heap_used=%" PRIu64 " sm_mirror=%" PRIu64, total_tasks,
-            orchestrator.ring.task_allocator.heap_used_bytes(), sm_size
+            orchestrator.task_allocator.heap_used_bytes(), sm_size
         );
         record_bind_phase(HostPhaseKind::BindHostOrch, t_orch_ns, attrs);
     }
@@ -725,8 +675,8 @@ int32_t run_host_orchestration(
 
     // total_tasks sizes the bounded per-segment H2D copies below; a value outside
     // [0, task_window] would make those copies read/write out of bounds.
-    if (total_tasks < 0 || static_cast<uint64_t>(total_tasks) > eff_task_window_sizes[0]) {
-        LOG_ERROR("host-orch: total_tasks %d out of range [0, %" PRIu64 "]", total_tasks, eff_task_window_sizes[0]);
+    if (total_tasks < 0 || static_cast<uint64_t>(total_tasks) > eff_task_window_size) {
+        LOG_ERROR("host-orch: total_tasks %d out of range [0, %" PRIu64 "]", total_tasks, eff_task_window_size);
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     host_phase_trace_note_submitted(static_cast<uint64_t>(total_tasks));
@@ -761,14 +711,10 @@ int32_t run_host_orchestration(
     // repeated workload grows the arena once. Growing reallocates, so the base is
     // re-acquired rather than reused.
     const int64_t t_sm_ns = bind_now_ns();
-    uint64_t total_heap_size = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        total_heap_size += eff_heap_sizes[r];
-    }
     // The compact shared-memory image is the only per-run tail in the device
     // arena. GraphExecution is initialized later in each outer Graph heap.
     const uint64_t device_arena_bytes = layout.off_copied_end + image_bytes;
-    if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, device_arena_bytes) != 0) {
+    if (api->setup_static_arena(eff_heap_size, /*gm_sm_size=*/0, device_arena_bytes) != 0) {
         LOG_ERROR("host-orch: failed to commit %" PRIu64 " bytes of device runtime arena", device_arena_bytes);
         return PTO_RUNTIME_ERR_INTERNAL;
     }
@@ -805,7 +751,7 @@ int32_t run_host_orchestration(
     rt->orchestrator = nullptr;
     std::memcpy(upload_base, static_cast<const char *>(host_arena.base()) + layout.off_copied_begin, copied_bytes);
     const uint64_t compacted = pto2_sm_layout::compact_live_image(
-        static_cast<const char *>(host_sm), eff_task_window_sizes[0], bind_usage, upload_base + copied_bytes
+        static_cast<const char *>(host_sm), eff_task_window_size, bind_usage, upload_base + copied_bytes
     );
     always_assert(compacted == image_bytes);
 
@@ -996,14 +942,12 @@ extern "C" int bind_callable_to_runtime_impl(
         host_phase_trace_end();
     });
 
-    uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH];
-    if (!resolve_ring_config(ring_task_window, ring_heap, eff_task_window_sizes, eff_heap_sizes)) {
+    uint64_t eff_task_window_size = 0;
+    uint64_t eff_heap_size = 0;
+    if (!resolve_ring_config(ring_task_window, ring_heap, &eff_task_window_size, &eff_heap_size)) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
-    const std::string task_window_log = format_ring_array(eff_task_window_sizes);
-    const std::string heap_log = format_ring_array(eff_heap_sizes);
-    LOG_INFO("Ring buffer sizes: task_window=%s heap=%s", task_window_log.c_str(), heap_log.c_str());
+    LOG_INFO("Ring buffer sizes: task_window=%" PRIu64 " heap=%" PRIu64, eff_task_window_size, eff_heap_size);
 
     // Build device args: copy from input, replace host tensor pointers with device pointers
     ChipStorageTaskArgs device_args;
@@ -1094,19 +1038,11 @@ extern "C" int bind_callable_to_runtime_impl(
     // Owned by DeviceRunner across runs — do NOT record in tensor_pairs_; the
     // free is deferred to DeviceRunner::finalize(). The runtime-arena size is
     // determined by replaying the reserve sequence on a host-side arena.
-    uint64_t total_heap_size = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (eff_heap_sizes[r] > std::numeric_limits<uint64_t>::max() - total_heap_size) {
-            LOG_ERROR("Total ring heap size overflows uint64_t");
-            return PTO_RUNTIME_ERR_INTERNAL;
-        }
-        total_heap_size += eff_heap_sizes[r];
-    }
-    uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(eff_task_window_sizes);
+    uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size(eff_task_window_size);
 
     const int64_t t_arena_build_ns = bind_now_ns();
     DeviceArena host_arena;
-    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(host_arena, eff_task_window_sizes, eff_heap_sizes);
+    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(host_arena, eff_task_window_size, eff_heap_size);
     if (host_arena.commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
         LOG_ERROR("Failed to commit host arena for prebuilt runtime image");
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -1124,13 +1060,13 @@ extern "C" int bind_callable_to_runtime_impl(
     // count — run_host_orchestration grows it once it knows. The heap must exist
     // first either way: the orchestrator hands out device heap addresses as it
     // places tasks.
-    if (api->setup_static_arena(total_heap_size, /*gm_sm_size=*/0, layout.arena_size) != 0) {
+    if (api->setup_static_arena(eff_heap_size, /*gm_sm_size=*/0, layout.arena_size) != 0) {
         LOG_ERROR("Failed to setup pooled static arena");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
         char attrs[96];
-        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " arena=%" PRIu64, total_heap_size, layout.arena_size);
+        snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " arena=%" PRIu64, eff_heap_size, layout.arena_size);
         record_bind_phase(HostPhaseKind::BindStaticArena, t_static_arena_ns, attrs);
     }
 
@@ -1170,7 +1106,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // No SM base: the scheduler and sm_handle are device-written now, so nothing
     // here stores one, and the region is not even committed yet.
     PTO2Runtime *rt = runtime_init_data_from_layout(
-        host_arena, layout, PTO2_MODE_EXECUTE, /*sm_dev_base=*/nullptr, sm_size, gm_heap, eff_heap_sizes
+        host_arena, layout, PTO2_MODE_EXECUTE, /*sm_dev_base=*/nullptr, sm_size, gm_heap, eff_heap_size
     );
     if (rt == nullptr) {
         LOG_ERROR("runtime_init_data_from_layout failed");
@@ -1201,8 +1137,8 @@ extern "C" int bind_callable_to_runtime_impl(
         ChipTaskArgs orch_l2;
         orch_l2.create_from_chip_args(device_args);
         int32_t total_tasks = run_host_orchestration(
-            runtime, api, tensor_access, rt, host_arena, layout, sm_size, runtime_arena_dev, gm_heap, eff_heap_sizes,
-            eff_task_window_sizes, host_orch_func_ptr, orch_l2
+            runtime, api, tensor_access, rt, host_arena, layout, sm_size, runtime_arena_dev, gm_heap, eff_heap_size,
+            eff_task_window_size, host_orch_func_ptr, orch_l2
         );
         // The orchestrator is the only host-view reader; from here the device
         // owns these buffers, so drop the window on both exits.

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator.h
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator.h
@@ -60,8 +60,9 @@ struct PTO2OrchestratorState {
     // === SHARED MEMORY ACCESS ===
     PTO2SharedMemoryHeader *sm_header;
 
-    // === RING RESOURCES (single ring) ===
-    PTO2RingSet ring;
+    // === TASK / HEAP ALLOCATION ===
+    // hbg is single-ring, so one allocator covers the whole graph.
+    PTO2TaskAllocator task_allocator;
     std::unique_ptr<uint32_t[]> fanin_seen_epoch;
     uint32_t fanin_seen_current_epoch{1};
 

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -966,7 +966,13 @@ struct PTO2FaninBuilder {
     int32_t *slots{nullptr};
 
     bool mark_seen(uint8_t prod_ring, int32_t prod_slot) {
-        if (prod_ring >= PTO2_MAX_RING_DEPTH || prod_slot < 0) {
+        // Dedup only: a producer this orchestrator did not place has no slot in the
+        // epoch table, so it is reported as not-yet-seen and the caller appends it
+        // rather than rejecting it. hbg places every task on its one ring, so the
+        // assert is the invariant; enforcing it on the caller's side would be a new
+        // fatal path.
+        debug_assert(prod_ring == 0 && "hbg places every task on its one ring");
+        if (prod_ring != 0 || prod_slot < 0) {
             return false;
         }
         uint32_t *seen = orch->fanin_seen_epoch.get();
@@ -1048,7 +1054,7 @@ static bool prepare_task(
 ) {
     always_assert(orch->scope_stack_top >= 0 && "Cannot submit task outside a scope");
     uint8_t ring_id = 0;
-    auto &allocator = orch->ring.task_allocator;
+    auto &allocator = orch->task_allocator;
 
     int16_t block_num = args.launch_spec.block_num();
     int32_t active_subtasks_per_block = __builtin_popcount(active_mask.core_mask());
@@ -1208,7 +1214,7 @@ void PTO2OrchestratorState::begin_scope(PTO2ScopeMode mode) {
     // task/heap start-end and tensormap usage at the scope boundary.
     if (is_scope_stats_enabled()) {
         uint8_t ring_id = 0;
-        auto &alloc = orch->ring.task_allocator;
+        auto &alloc = orch->task_allocator;
         // Polling: no dep_pool to report (readiness is via completion_flags).
         int32_t dep_pool_tail = 0;
         int32_t dep_pool_top = 0;
@@ -1247,7 +1253,7 @@ void PTO2OrchestratorState::end_scope() {
     // emits the end-boundary record and tears down bookkeeping.
     if (is_scope_stats_enabled()) {
         uint8_t ring_id = 0;
-        auto &alloc = orch->ring.task_allocator;
+        auto &alloc = orch->task_allocator;
         // Polling: no dep_pool to report (readiness is via completion_flags).
         int32_t dep_pool_tail = 0;
         int32_t dep_pool_top = 0;
@@ -1630,7 +1636,7 @@ bool graph_submit_outer(
     bool defer_heap, const GraphTaskArgs &args, TaskId *submitted_id
 ) {
     always_assert(orch->scope_stack_top >= 0 && "Cannot submit Graph outside a scope");
-    auto &allocator = orch->ring.task_allocator;
+    auto &allocator = orch->task_allocator;
     if (allocator.active_count() >= allocator.window_size() ||
         (!defer_heap && static_cast<uint64_t>(owned_heap) > allocator.heap_available())) {
         LOG_WARN("%s", "[GraphExecution] task-window/heap preflight failed; using ordinary path");
@@ -1816,9 +1822,7 @@ bool graph_finalize_pending_submissions(PTO2OrchestratorState *orch, GraphHostSt
         }
         void *packed_base = nullptr;
         void *packed_end = nullptr;
-        if (!orch->ring.task_allocator.reserve_deferred_heap(
-                static_cast<int32_t>(owned_heap), &packed_base, &packed_end
-            )) {
+        if (!orch->task_allocator.reserve_deferred_heap(static_cast<int32_t>(owned_heap), &packed_base, &packed_end)) {
             if (failed_key != nullptr) *failed_key = pending.full_key;
             return false;
         }
@@ -2171,7 +2175,7 @@ PTO2OrchestratorState::graph_begin_inner(uint64_t graph_key, const GraphTaskArgs
 
     auto recording = std::make_unique<GraphRecording>();
     recording->full_key = full_key;
-    recording->start_local_task_id = orch->ring.task_allocator.active_count();
+    recording->start_local_task_id = orch->task_allocator.active_count();
     if (!graph_recording_init_tensor_map(*recording)) {
         LOG_WARN("[GraphExecution] recording hazard map allocation failed; using ordinary path");
         return result;
@@ -2611,11 +2615,9 @@ TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const CoreTaskArgs &args)
 
 void PTO2OrchestratorState::mark_done() {
     auto *orch = this;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        int32_t total_tasks = orch->ring.task_allocator.active_count();
-        if (total_tasks > 0) {
-            LOG_DEBUG("=== [Orchestrator] ring %d: total_tasks=%d ===", r, total_tasks);
-        }
+    int32_t total_tasks = orch->task_allocator.active_count();
+    if (total_tasks > 0) {
+        LOG_DEBUG("=== [Orchestrator] total_tasks=%d ===", total_tasks);
     }
     orch->sm_header->orchestrator_done.store(1, std::memory_order_release);
     orch->scope_tasks_size = 0;

--- a/src/a5/runtime/host_build_graph/runtime/ring_buffer.h
+++ b/src/a5/runtime/host_build_graph/runtime/ring_buffer.h
@@ -11,23 +11,11 @@
 /**
  * PTO Runtime2 - Ring Buffer Data Structures
  *
- * Implements ring buffer designs for zero-overhead memory management:
- *
- * 1. TaskAllocator - Unified task slot + output buffer allocation
- *    - Combines task ring (slot allocation) and heap ring (output buffer allocation)
- *    - O(1) forward bump allocation for both task slots and heap buffers
- *    - Neither resource is reclaimed during a run, so exhaustion of either is a
- *      capacity error reported on the spot, never back-pressure to wait on
- *
- * 2. FaninPool - Fanin spill entry allocation
- *    - Ring buffer for spilled fanin entries
- *    - O(1) append allocation
- *    - Implicit reclamation with task ring
- *
- * 3. DepListPool - Dependency list entry allocation
- *    - Ring buffer for linked list entries
- *    - O(1) prepend operation
- *    - Implicit reclamation with task ring
+ * TaskAllocator - Unified task slot + output buffer allocation
+ *   - Combines task ring (slot allocation) and heap ring (output buffer allocation)
+ *   - O(1) forward bump allocation for both task slots and heap buffers
+ *   - Neither resource is reclaimed during a run, so exhaustion of either is a
+ *     capacity error reported on the spot, never back-pressure to wait on
  *
  * Based on: docs/RUNTIME_LOGIC.md
  */
@@ -49,9 +37,6 @@
 // offsets. That classification is only sound while the range is disjoint from
 // every real heap address, which PTO2TaskAllocator::init() asserts.
 inline constexpr uint64_t GRAPH_RECORD_VIRTUAL_BASE = 1ULL << 63;
-
-// Dep pool spin limit - if exceeded, dep pool capacity too small for workload
-#define PTO2_DEP_POOL_SPIN_LIMIT 100000
 
 // =============================================================================
 // Task Allocator (unified task slot + heap buffer allocation)
@@ -268,16 +253,4 @@ private:
             error_code_ptr_->store(code, std::memory_order_release);
         }
     }
-};
-
-// =============================================================================
-// Ring Set (per-depth aggregate)
-// =============================================================================
-
-/**
- * Groups the per-depth allocator state into one unit; PTO2_MAX_RING_DEPTH
- * instances exist, one per scope depth.
- */
-struct PTO2RingSet {
-    PTO2TaskAllocator task_allocator;
 };

--- a/src/a5/runtime/host_build_graph/runtime/runtime_core.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime_core.h
@@ -153,9 +153,10 @@ struct PTO2RuntimeArenaLayout {
     size_t off_copied_begin{0};
     size_t off_copied_end{0};
 
-    // Cached parameters (re-used by init_data + wire stages).
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]{};
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]{};
+    // Cached parameters (re-used by init_data + wire stages). hbg is single-ring,
+    // so these are the one ring's.
+    uint64_t task_window_size{0};
+    uint64_t heap_size{0};
 
     // Total arena byte size post-commit. Used by host to size the prebuilt
     // image buffer and as the rtMemcpy length, and requested of the device as
@@ -241,11 +242,7 @@ static_assert(
  * device memory and may run on host. Returns the layout descriptor; caller
  * commits/attaches the arena before Phase 2/3.
  */
-PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size);
-PTO2RuntimeArenaLayout runtime_reserve_layout(
-    DeviceArena &arena, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
-);
+PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, uint64_t heap_size = 0);
 
 /**
  * Phase 2 — write the data half of the runtime arena: standalone fields,
@@ -267,10 +264,6 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
 PTO2Runtime *runtime_init_data_from_layout(
     DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
     void *gm_heap_dev_base, uint64_t heap_size
-);
-PTO2Runtime *runtime_init_data_from_layout(
-    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
-    void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
 );
 
 /**

--- a/src/a5/runtime/host_build_graph/runtime/runtime_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime_types.h
@@ -70,18 +70,19 @@
 // =============================================================================
 
 // Task management
-// NOTE: PTO2_TASK_WINDOW_SIZE is now a per-ring default value.
 // Actual window size is passed at runtime to runtime_create_from_sm().
 // Use pto2_task_slot(sched, task_id) for slot calculation.
-#define PTO2_TASK_WINDOW_SIZE 16384  // Default per-ring task window size (power of 2)
+#define PTO2_TASK_WINDOW_SIZE 16384  // Default task window size (power of 2)
 
-// Single ring. host_build_graph is host-orch: the whole graph is built on the
-// host, fits one ring, and the device runs it once without reclaim (see stages
-// 1-2 — execution-time recycle removed). The multi-ring design existed only to
+// host_build_graph has one ring, and carries no per-ring dimension anywhere:
+// host-orch builds the whole graph on the host, it fits that ring, and the
+// device runs it once without reclaim (execution-time recycle removed). tmr's
+// multi-ring design existed only to
 // let inner scopes reclaim independently under small rings; with no reclaim and
-// a whole-graph-resident ring, per-depth isolation is moot, so all scope depths
-// map to the single ring 0 (0 == 0).
-#define PTO2_MAX_RING_DEPTH 1
+// a whole-graph-resident ring, per-depth isolation is moot, so every scope depth
+// uses the same ring. The RuntimeEnv ABI still carries RUNTIME_ENV_RING_COUNT
+// slots because it is shared with tmr; this runtime reads slot 0 (see
+// bind_callable_to_runtime_impl).
 
 // Memory pools (total = value, single ring)
 #define PTO2_HEAP_SIZE (256 * 1024 * 1024)  // 256MB
@@ -90,12 +91,11 @@
 
 // Scope management
 #define PTO2_MAX_SCOPE_DEPTH 64  // Maximum nesting depth
-// Hard cap for the scope_tasks buffer. Equals the total in-flight ring slot
-// budget (PTO2_TASK_WINDOW_SIZE × PTO2_MAX_RING_DEPTH): once every ring slot
-// is in flight, no more tasks can ever be pushed regardless of buffer size.
-// scope_tasks_push fatals on overflow rather than growing the arena-owned
-// buffer (which would be UB on the arena's malloc'd backing).
-#define PTO2_SCOPE_TASKS_CAP (PTO2_TASK_WINDOW_SIZE * PTO2_MAX_RING_DEPTH)
+// Hard cap for the scope_tasks buffer. Equals the in-flight ring slot budget:
+// once every ring slot is in flight, no more tasks can ever be pushed regardless
+// of buffer size. scope_tasks_push fatals on overflow rather than growing the
+// buffer.
+#define PTO2_SCOPE_TASKS_CAP (PTO2_TASK_WINDOW_SIZE)
 
 // Per-shape ready-queue capacity (power of two). This is a ring buffer that
 // bounds peak CONCURRENT occupancy (enqueue_pos - dequeue_pos), not total task

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -232,79 +232,77 @@ void SchedulerContext::log_stall_diagnostics(
     // produce identical TASK lines once per scheduler thread.
     if (thread_idx == 0) {
         int32_t cnt_ready = 0, cnt_waiting = 0, cnt_running = 0, submitted_in_ring = 0;
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            PTO2SharedMemoryRingHeader &ring = *sched_->ring_sched_state.ring;
-            int32_t ring_task_count = ring.fc.current_task_index.load(std::memory_order_relaxed);
-            submitted_in_ring += ring_task_count;
-            for (int32_t si = 0; si < ring_task_count; si++) {
-                PTO2TaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
-                PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
-                // Polling: no fanin_refcount. Recompute met/total from the inline
-                // fanin ids vs the ring completion_flags (rc = satisfied producers,
-                // fi = raw producer count) so the stall dump still shows readiness.
-                int32_t fi = slot_state.payload != nullptr ? slot_state.payload->fanin_count : 0;
-                int32_t rc = 0;
-                if (slot_state.payload != nullptr) {
-                    const int32_t *fanin = slot_state.payload->fanin_data();
-                    for (int32_t k = 0; k < fi; k++) {
-                        if (ring.is_completion_flag_set(fanin[k], std::memory_order_relaxed)) rc++;
-                    }
+        PTO2SharedMemoryRingHeader &ring = *sched_->ring_sched_state.ring;
+        int32_t ring_task_count = ring.fc.current_task_index.load(std::memory_order_relaxed);
+        submitted_in_ring += ring_task_count;
+        for (int32_t si = 0; si < ring_task_count; si++) {
+            PTO2TaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
+            PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
+            // Polling: no fanin_refcount. Recompute met/total from the inline
+            // fanin ids vs the ring completion_flags (rc = satisfied producers,
+            // fi = raw producer count) so the stall dump still shows readiness.
+            int32_t fi = slot_state.payload != nullptr ? slot_state.payload->fanin_count : 0;
+            int32_t rc = 0;
+            if (slot_state.payload != nullptr) {
+                const int32_t *fanin = slot_state.payload->fanin_data();
+                for (int32_t k = 0; k < fi; k++) {
+                    if (ring.is_completion_flag_set(fanin[k], std::memory_order_relaxed)) rc++;
                 }
-                int32_t kid_aic = slot_state.task->kernel_id[0];
-                int32_t kid_aiv0 = slot_state.task->kernel_id[1];
-                int32_t kid_aiv1 = slot_state.task->kernel_id[2];
-                int64_t task_id = static_cast<int64_t>(slot_state.task->task_id.raw);
-                if (st >= PTO2_TASK_COMPLETED) continue;
-                // task_state has no intermediate ready/running value — it
-                // stays PENDING until the worker stores COMPLETED. Classify
-                // by the ground truth instead: a slot is RUNNING iff some
-                // core has it as running_slot_state. A task occupies at most
-                // 3 cores (one cluster), all under the same owner thread by
-                // construction of assign_cores_to_threads.
-                char running_on[192] = {0};
-                int32_t owner = -1;
-                int32_t pos = 0;
-                bool is_running = false;
-                for (int32_t cid = 0; cid < cores_total_num_ && pos + 32 < (int32_t)sizeof(running_on); cid++) {
-                    if (core_exec_states_[cid].running_slot_state != &slot_state) continue;
-                    is_running = true;
-                    if (owner < 0) owner = find_core_owner_thread(cid);
-                    const char *sname = subslot_name(core_exec_states_[cid].running_subslot);
-                    int32_t written = snprintf(
-                        running_on + pos, sizeof(running_on) - pos, "%score=%d(%s)", pos == 0 ? "" : " ", cid, sname
-                    );
-                    if (written > 0) pos += written;
-                }
+            }
+            int32_t kid_aic = slot_state.task->kernel_id[0];
+            int32_t kid_aiv0 = slot_state.task->kernel_id[1];
+            int32_t kid_aiv1 = slot_state.task->kernel_id[2];
+            int64_t task_id = static_cast<int64_t>(slot_state.task->task_id.raw);
+            if (st >= PTO2_TASK_COMPLETED) continue;
+            // task_state has no intermediate ready/running value — it
+            // stays PENDING until the worker stores COMPLETED. Classify
+            // by the ground truth instead: a slot is RUNNING iff some
+            // core has it as running_slot_state. A task occupies at most
+            // 3 cores (one cluster), all under the same owner thread by
+            // construction of assign_cores_to_threads.
+            char running_on[192] = {0};
+            int32_t owner = -1;
+            int32_t pos = 0;
+            bool is_running = false;
+            for (int32_t cid = 0; cid < cores_total_num_ && pos + 32 < (int32_t)sizeof(running_on); cid++) {
+                if (core_exec_states_[cid].running_slot_state != &slot_state) continue;
+                is_running = true;
+                if (owner < 0) owner = find_core_owner_thread(cid);
+                const char *sname = subslot_name(core_exec_states_[cid].running_subslot);
+                int32_t written = snprintf(
+                    running_on + pos, sizeof(running_on) - pos, "%score=%d(%s)", pos == 0 ? "" : " ", cid, sname
+                );
+                if (written > 0) pos += written;
+            }
 
-                if (is_running) {
-                    cnt_running++;
-                    if (cnt_running > STALL_DUMP_READY_MAX) continue;
-                    LOG_INFO(
-                        "[STALL thread=%d idle_iterations=%d] TASK ring=%d task_id=%" PRId64
-                        " state=RUNNING fanin_met=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d] "
-                        "running_on=[owner_thread=%d cores=[%s]]",
-                        thread_idx, idle_iterations, r, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1, owner, running_on
-                    );
-                    continue;
-                }
-                if (rc >= fi) {
-                    cnt_ready++;
-                    if (cnt_ready > STALL_DUMP_READY_MAX) continue;
-                    LOG_INFO(
-                        "[STALL thread=%d idle_iterations=%d] TASK ring=%d task_id=%" PRId64
-                        " state=READY   fanin_met=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d]",
-                        thread_idx, idle_iterations, r, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1
-                    );
-                    continue;
-                }
-                cnt_waiting++;
-                if (cnt_waiting > STALL_DUMP_WAIT_MAX) continue;
+            if (is_running) {
+                cnt_running++;
+                if (cnt_running > STALL_DUMP_READY_MAX) continue;
                 LOG_INFO(
                     "[STALL thread=%d idle_iterations=%d] TASK ring=%d task_id=%" PRId64
-                    " state=WAIT    fanin_met=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d] missing_deps=%d",
-                    thread_idx, idle_iterations, r, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1, fi - rc
+                    " state=RUNNING fanin_met=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d] "
+                    "running_on=[owner_thread=%d cores=[%s]]",
+                    thread_idx, idle_iterations, 0, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1, owner, running_on
                 );
+                continue;
             }
+            if (rc >= fi) {
+                cnt_ready++;
+                if (cnt_ready > STALL_DUMP_READY_MAX) continue;
+                LOG_INFO(
+                    "[STALL thread=%d idle_iterations=%d] TASK ring=%d task_id=%" PRId64
+                    " state=READY   fanin_met=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d]",
+                    thread_idx, idle_iterations, 0, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1
+                );
+                continue;
+            }
+            cnt_waiting++;
+            if (cnt_waiting > STALL_DUMP_WAIT_MAX) continue;
+            LOG_INFO(
+                "[STALL thread=%d idle_iterations=%d] TASK ring=%d task_id=%" PRId64
+                " state=WAIT    fanin_met=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d] missing_deps=%d",
+                thread_idx, idle_iterations, 0, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1, fi - rc
+            );
         }
         int32_t effective_total = task_count > 0 ? task_count : submitted_in_ring;
         int32_t c = completed_tasks_.load(std::memory_order_relaxed);
@@ -918,12 +916,10 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
         // more than the scope cap. This rejects any garbage pattern (negative
         // or positive), so uninitialized rings contribute 0 (the correct boot
         // count) while valid counts still add up, with no signed overflow.
-        int64_t pto2_count = 0;
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            int32_t ring_tasks = header->ring.fc.current_task_index.load(std::memory_order_acquire);
-            if (ring_tasks > 0 && ring_tasks <= PTO2_SCOPE_TASKS_CAP) pto2_count += ring_tasks;
-        }
-        total_tasks_ = static_cast<int32_t>(pto2_count);
+        int32_t pto2_count = 0;
+        int32_t ring_tasks = header->ring.fc.current_task_index.load(std::memory_order_acquire);
+        if (ring_tasks > 0 && ring_tasks <= PTO2_SCOPE_TASKS_CAP) pto2_count = ring_tasks;
+        total_tasks_ = pto2_count;
     } else {
         total_tasks_ = 0;
     }

--- a/src/a5/runtime/host_build_graph/runtime/shared/runtime_init.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/runtime_init.cpp
@@ -22,27 +22,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <limits>
-
 #include "orchestrator.h"
 #include "runtime_core.h"
 #include "ring_buffer.h"
 #include "shared_memory.h"
 #include "tensormap.h"
 #include "scheduler/scheduler.h"
-
-static bool sum_ring_heap_sizes(const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], uint64_t *total) {
-    uint64_t sum = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (heap_sizes[r] > std::numeric_limits<uint64_t>::max() - sum) {
-            LOG_ERROR("Total ring heap size overflows uint64_t");
-            return false;
-        }
-        sum += heap_sizes[r];
-    }
-    *total = sum;
-    return true;
-}
 
 // =============================================================================
 // Ready queue
@@ -236,7 +221,7 @@ bool PTO2OrchestratorState::init(
     auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_base);
     auto *cur_idx_dev = pto2_sm_layout::ring_current_task_index_addr(sm_base);
 
-    orch->ring.task_allocator.init(static_cast<int32_t>(task_window_size), cur_idx_dev, gm_heap, heap_size, orch_err);
+    orch->task_allocator.init(static_cast<int32_t>(task_window_size), cur_idx_dev, gm_heap, heap_size, orch_err);
 
     // The mirror's argument pools. Offset arithmetic on the same base as sm_header,
     // so it holds for whichever SM this orchestrator was pointed at. The cursors
@@ -277,26 +262,11 @@ void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler) { this-
 // Top-level runtime arena
 // =============================================================================
 
-PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        task_window_sizes[r] = task_window_size;
-        heap_sizes[r] = 0;
-    }
-    return runtime_reserve_layout(arena, task_window_sizes, heap_sizes);
-}
-
-PTO2RuntimeArenaLayout runtime_reserve_layout(
-    DeviceArena &arena, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
-) {
+PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, uint64_t heap_size) {
     PTO2RuntimeArenaLayout layout{};
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        layout.task_window_sizes[r] = task_window_sizes[r];
-        layout.heap_sizes[r] = heap_sizes[r];
-    }
+    layout.task_window_size = task_window_size;
+    layout.heap_size = heap_size;
 
     // Reservation order is the zone partition (see PTO2RuntimeArenaLayout):
     // everything the device initializes itself, then the one copied range. Each
@@ -320,17 +290,6 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
     return layout;
 }
 
-PTO2Runtime *runtime_init_data_from_layout(
-    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
-    uint64_t /*sm_size*/, void *gm_heap_dev_base, uint64_t heap_size
-) {
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        heap_sizes[r] = heap_size;
-    }
-    return runtime_init_data_from_layout(arena, layout, mode, sm_dev_base, 0, gm_heap_dev_base, heap_sizes);
-}
-
 /**
  * Populate the prebuilt runtime-arena image in place (host build path).
  *
@@ -344,7 +303,7 @@ PTO2Runtime *runtime_init_data_from_layout(
  */
 PTO2Runtime *runtime_init_data_from_layout(
     DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
-    uint64_t /*sm_size*/, void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+    uint64_t /*sm_size*/, void *gm_heap_dev_base, uint64_t heap_size
 ) {
     PTO2Runtime *rt = static_cast<PTO2Runtime *>(arena.region_ptr(layout.off_runtime));
     memset(rt, 0, sizeof(*rt));
@@ -352,11 +311,7 @@ PTO2Runtime *runtime_init_data_from_layout(
     // rt->ops is filled by the AICPU at boot.
     rt->mode = mode;
     rt->gm_heap = gm_heap_dev_base;
-    uint64_t total_heap_size = 0;
-    if (!sum_ring_heap_sizes(heap_sizes, &total_heap_size)) {
-        return nullptr;
-    }
-    rt->gm_heap_size = total_heap_size;
+    rt->gm_heap_size = heap_size;
     rt->gm_heap_owned = false;
     rt->total_cycles = 0;
     rt->active_callable_hash = 0;

--- a/src/a5/runtime/host_build_graph/runtime/shared/shared_memory.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/shared_memory.cpp
@@ -28,27 +28,16 @@
 // =============================================================================
 
 uint64_t PTO2SharedMemoryHandle::calculate_size(uint64_t task_window_size) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        task_window_sizes[r] = task_window_size;
-    }
-    return calculate_size_per_ring(task_window_sizes);
-}
-
-uint64_t PTO2SharedMemoryHandle::calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
     // Total SM size = offset just past the ring's slot_states, from the single
     // source of truth for the layout (pto2_sm_layout::ring_segment_offsets).
-    return pto2_sm_layout::ring_segment_offsets(task_window_sizes[0]).end;
+    return pto2_sm_layout::ring_segment_offsets(task_window_size).end;
 }
 
 // =============================================================================
 // Creation and Destruction
 // =============================================================================
 
-void PTO2SharedMemoryHandle::setup_pointers_per_ring(
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch
-) {
-    (void)task_window_sizes;
+void PTO2SharedMemoryHandle::setup_pointers(uint64_t pitch) {
     char *base = (char *)sm_base;
     header = (PTO2SharedMemoryHeader *)base;
 
@@ -68,32 +57,11 @@ void PTO2SharedMemoryHandle::setup_pointers_per_ring(
     ring.completion_flags = (std::atomic<uint8_t> *)(base + off.completion_flags);
 }
 
-void PTO2SharedMemoryHandle::setup_pointers(uint64_t task_window_size) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        task_window_sizes[r] = task_window_size;
-    }
-    setup_pointers_per_ring(task_window_sizes, task_window_size);
-}
-
 bool PTO2SharedMemoryHandle::init(
     void *sm_base_arg, uint64_t sm_size_arg, uint64_t task_window_size, uint64_t heap_size
 ) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        task_window_sizes[r] = task_window_size;
-        heap_sizes[r] = heap_size;
-    }
-    return init_per_ring(sm_base_arg, sm_size_arg, task_window_sizes, heap_sizes);
-}
-
-bool PTO2SharedMemoryHandle::init_per_ring(
-    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
-) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
-    const uint64_t mirror_bytes = calculate_size_per_ring(task_window_sizes);
+    const uint64_t mirror_bytes = calculate_size(task_window_size);
     // The mirror has to stay inside an int32 delta's reach: a payload names its
     // argument regions that way, and set() leaves a field unbound rather than
     // truncating, so a pool out of reach would read back as null and be dereferenced
@@ -107,21 +75,20 @@ bool PTO2SharedMemoryHandle::init_per_ring(
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers_per_ring(task_window_sizes, task_window_sizes[0]);
-    init_header_per_ring(task_window_sizes, heap_sizes);
+    setup_pointers(task_window_size);
+    init_header(task_window_size, heap_size);
     return true;
 }
 
 bool PTO2SharedMemoryHandle::attach_populated(
-    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t live_slots,
-    uint64_t image_bytes
+    void *sm_base_arg, uint64_t sm_size_arg, uint64_t task_window_size, uint64_t live_slots, uint64_t image_bytes
 ) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
     // A pitch above the capacity would name a slot the ring cannot address, and one
     // below what the host used would place every segment past the descriptors
     // short. This is the whole contract between the two sides, checked once at
     // attach rather than trusted.
-    if (live_slots == 0 || live_slots > task_window_sizes[0]) return false;
+    if (live_slots == 0 || live_slots > task_window_size) return false;
     // The image must at least hold the four slot-pitched segments; anything beyond
     // that is its argument pools, whose extents are the bind's cursors and are not
     // recomputable here. The first pool's offset is exactly where those four end.
@@ -139,9 +106,9 @@ bool PTO2SharedMemoryHandle::attach_populated(
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers_per_ring(task_window_sizes, live_slots);
-    // Deliberately NO init_header_per_ring: the SM already holds the host
-    // orchestrator's task graph (descriptors, slot states, ring counters).
+    setup_pointers(live_slots);
+    // Deliberately NO init_header: the SM already holds the host orchestrator's
+    // task graph (descriptors, slot states, ring counters).
     return true;
 }
 
@@ -174,18 +141,6 @@ void PTO2SharedMemoryHandle::destroy() {
 //
 // no need init data in pool, init pool data when used
 void PTO2SharedMemoryHandle::init_header(uint64_t task_window_size, uint64_t heap_size) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        task_window_sizes[r] = task_window_size;
-        heap_sizes[r] = heap_size;
-    }
-    init_header_per_ring(task_window_sizes, heap_sizes);
-}
-
-void PTO2SharedMemoryHandle::init_header_per_ring(
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
-) {
     // Flow control (starts at 0)
     header->ring.fc.init();
 
@@ -197,13 +152,13 @@ void PTO2SharedMemoryHandle::init_header_per_ring(
 
     // Ring layout info
     uint64_t offset = PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
-    header->ring.task_window_size = task_window_sizes[0];
-    header->ring.task_window_mask = static_cast<int32_t>(task_window_sizes[0] - 1);
-    header->ring.heap_size = heap_sizes[0];
+    header->ring.task_window_size = task_window_size;
+    header->ring.task_window_mask = static_cast<int32_t>(task_window_size - 1);
+    header->ring.heap_size = heap_size;
     header->ring.task_descriptors_offset = offset;
-    offset += PTO2_ALIGN_UP(task_window_sizes[0] * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
-    offset += PTO2_ALIGN_UP(task_window_sizes[0] * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
-    offset += PTO2_ALIGN_UP(task_window_sizes[0] * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
+    offset += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
+    offset += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
+    offset += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
 
     header->total_size = sm_size;
 
@@ -232,17 +187,14 @@ void PTO2SharedMemoryHandle::print_layout() {
     LOG_DEBUG("=== PTO2 Shared Memory Layout ===");
     LOG_DEBUG("Base address:       %p", sm_base);
     LOG_DEBUG("Total size:         %" PRIu64 " bytes", h->total_size);
-    LOG_DEBUG("Ring depth:         %d", PTO2_MAX_RING_DEPTH);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        LOG_DEBUG("Ring %d:", r);
-        LOG_DEBUG("  task_window_size: %" PRIu64, h->ring.task_window_size);
-        LOG_DEBUG("  heap_size:        %" PRIu64 " bytes", h->ring.heap_size);
-        LOG_DEBUG(
-            "  descriptors_off:  %" PRIu64 " (0x%" PRIx64 ")", h->ring.task_descriptors_offset,
-            h->ring.task_descriptors_offset
-        );
-        LOG_DEBUG("  current_task_idx: %d", h->ring.fc.current_task_index.load(std::memory_order_acquire));
-    }
+    LOG_DEBUG("Ring:");
+    LOG_DEBUG("  task_window_size: %" PRIu64, h->ring.task_window_size);
+    LOG_DEBUG("  heap_size:        %" PRIu64 " bytes", h->ring.heap_size);
+    LOG_DEBUG(
+        "  descriptors_off:  %" PRIu64 " (0x%" PRIx64 ")", h->ring.task_descriptors_offset,
+        h->ring.task_descriptors_offset
+    );
+    LOG_DEBUG("  current_task_idx: %d", h->ring.fc.current_task_index.load(std::memory_order_acquire));
     LOG_DEBUG("orchestrator_done:  %d", h->orchestrator_done.load(std::memory_order_acquire));
     LOG_DEBUG("Error state:");
     LOG_DEBUG("  orch_error_code:    %d", h->orch_error_code.load(std::memory_order_relaxed));
@@ -258,17 +210,14 @@ bool PTO2SharedMemoryHandle::validate() {
 
     PTO2SharedMemoryHeader *h = header;
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (!h->ring.fc.validate(this, r)) return false;
-    }
+    if (!h->ring.fc.validate(this)) return false;
 
     return true;
 }
 
-bool PTO2RingFlowControl::validate(PTO2SharedMemoryHandle *handle, int32_t ring_id) const {
+bool PTO2RingFlowControl::validate(PTO2SharedMemoryHandle *handle) const {
     if (!handle) return false;
     if (!handle->header) return false;
-    if (ring_id < 0 || ring_id >= PTO2_MAX_RING_DEPTH) return false;
 
     const PTO2SharedMemoryHeader *h = handle->header;
 

--- a/src/a5/runtime/host_build_graph/runtime/shared_memory.h
+++ b/src/a5/runtime/host_build_graph/runtime/shared_memory.h
@@ -63,7 +63,7 @@ struct alignas(64) PTO2RingFlowControl {
     // submit IDs will be off by the divergence.
     void init() { current_task_index.store(0, std::memory_order_relaxed); }
 
-    bool validate(PTO2SharedMemoryHandle *handle, int32_t ring_id) const;
+    bool validate(PTO2SharedMemoryHandle *handle) const;
 };
 
 static_assert(sizeof(PTO2RingFlowControl) == 64, "PTO2RingFlowControl must be exactly one cache line (64B)");
@@ -216,7 +216,6 @@ struct PTO2SharedMemoryHandle {
     // === Static helpers ===
 
     static uint64_t calculate_size(uint64_t task_window_size);
-    static uint64_t calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
 
     // UT convenience: reserve wrapper + sm_base on `arena`, commit, and init
     // using default PTO2_TASK_WINDOW_SIZE / PTO2_HEAP_SIZE. Only valid when the
@@ -231,17 +230,13 @@ struct PTO2SharedMemoryHandle {
     // init_header. Returns false when `sm_size` is too small for the requested
     // `task_window_size`.
     bool init(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size);
-    bool init_per_ring(
-        void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-        const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
-    );
 
     // Attach to an ALREADY-populated shared memory region: point the handle and
     // every ring header's data pointers (descriptors / payloads / slot_states)
     // at `sm_base`, but do NOT reset the flow-control counters / slot states.
     // Used by host_build_graph host-orch, where the host orchestrator populated
     // the SM and H2D'd it; the device must re-point at its own SM base without
-    // wiping the contents (unlike init_per_ring, which also resets the header).
+    // wiping the contents (unlike init, which also resets the header).
     //
     // `live_slots` is the pitch the uploaded arrays were laid out with — the
     // number of slots the host actually submitted, not the ring capacity. It must
@@ -256,8 +251,7 @@ struct PTO2SharedMemoryHandle {
     // pool base is resolved here. The value bounds the region and checks the int32
     // delta reach.
     bool attach_populated(
-        void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t live_slots,
-        uint64_t image_bytes
+        void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t live_slots, uint64_t image_bytes
     );
 
     void destroy();
@@ -266,14 +260,10 @@ struct PTO2SharedMemoryHandle {
 
 private:
     void init_header(uint64_t task_window_size, uint64_t heap_size);
-    void init_header_per_ring(
-        const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
-    );
-    void setup_pointers(uint64_t task_window_size);
-    // `pitch` is the slot count the arrays are dimensioned for. init_per_ring passes
-    // the ring capacity (the mirror the orchestrator writes into); attach_populated
+    // `pitch` is the slot count the arrays are dimensioned for. init passes the
+    // ring capacity (the mirror the orchestrator writes into); attach_populated
     // passes the submitted count (the compacted image that shipped).
-    void setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t pitch);
+    void setup_pointers(uint64_t pitch);
 };
 
 // =============================================================================

--- a/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
@@ -55,7 +55,7 @@ protected:
     void SetUp() override {
         sm_handle = PTO2SharedMemoryHandle::create_and_init_default(sm_arena);
         ASSERT_NE(sm_handle, nullptr);
-        gm_heap.resize(4096 * PTO2_MAX_RING_DEPTH);
+        gm_heap.resize(4096);
 
         sched_layout = PTO2SchedulerState::reserve_layout(runtime_arena);
         ASSERT_NE(runtime_arena.commit(), nullptr);

--- a/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
@@ -55,7 +55,7 @@ protected:
     void SetUp() override {
         sm_handle = PTO2SharedMemoryHandle::create_and_init_default(sm_arena);
         ASSERT_NE(sm_handle, nullptr);
-        gm_heap.resize(4096 * PTO2_MAX_RING_DEPTH);
+        gm_heap.resize(4096);
 
         sched_layout = PTO2SchedulerState::reserve_layout(runtime_arena);
         ASSERT_NE(runtime_arena.commit(), nullptr);

--- a/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
@@ -47,7 +47,7 @@ protected:
     void SetUp() override {
         sm_handle = PTO2SharedMemoryHandle::create_and_init_default(sm_arena);
         ASSERT_NE(sm_handle, nullptr);
-        gm_heap.resize(HEAP_BYTES * PTO2_MAX_RING_DEPTH);
+        gm_heap.resize(HEAP_BYTES);
 
         sched_layout = PTO2SchedulerState::reserve_layout(runtime_arena);
         ASSERT_NE(runtime_arena.commit(), nullptr);
@@ -86,7 +86,7 @@ TEST_F(HbgGraphSubmitFailureTest, InFlightGraphInvocationsReserveHeapOnlyAtCommi
     EXPECT_FALSE(second.execute_block);
     ASSERT_TRUE(second.task_id.is_valid());
     EXPECT_EQ(second.task_id.local(), first.task_id.local() + 1);
-    EXPECT_EQ(orch.ring.task_allocator.heap_top(), 0u);
+    EXPECT_EQ(orch.task_allocator.heap_top(), 0u);
     EXPECT_EQ(graph_host_upload_count(*graph_state), 2u);
 
     ASSERT_TRUE(orch.graph_prepare(first.recording_handle, boundary_args));
@@ -96,11 +96,11 @@ TEST_F(HbgGraphSubmitFailureTest, InFlightGraphInvocationsReserveHeapOnlyAtCommi
     node_args.add_output(recorded_output);
     ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
     ASSERT_TRUE(orch.graph_end());
-    EXPECT_EQ(orch.ring.task_allocator.heap_top(), 0u);
+    EXPECT_EQ(orch.task_allocator.heap_top(), 0u);
 
     orch.graph_commit();
     EXPECT_FALSE(orch.fatal);
-    EXPECT_GT(orch.ring.task_allocator.heap_top(), 0u);
+    EXPECT_GT(orch.task_allocator.heap_top(), 0u);
     const std::optional<GraphHostUpload> first_upload = graph_host_upload(*graph_state, 0);
     const std::optional<GraphHostUpload> second_upload = graph_host_upload(*graph_state, 1);
     ASSERT_TRUE(first_upload.has_value());
@@ -218,7 +218,7 @@ TEST_F(HbgGraphSubmitFailureTest, WorkerRecordsWhileMainThreadSubmitsSameHashShe
     ASSERT_TRUE(third.task_id.is_valid());
     EXPECT_EQ(second.task_id.local(), first.task_id.local() + 1);
     EXPECT_EQ(third.task_id.local(), first.task_id.local() + 2);
-    EXPECT_EQ(orch.ring.task_allocator.heap_top(), 0u) << "no shell may take heap before commit";
+    EXPECT_EQ(orch.task_allocator.heap_top(), 0u) << "no shell may take heap before commit";
 
     orch.graph_commit();
     ASSERT_FALSE(orch.fatal);
@@ -358,13 +358,13 @@ TEST_F(HbgGraphSubmitFailureTest, FaninFailureLatchesFatalWithoutPartialUpload) 
     node_args.add_input(boundary);
     TensorCreateInfo recorded_output(shape, 1, DataType::UINT32);
     node_args.add_output(recorded_output);
-    const uint64_t heap_top_before_record = orch.ring.task_allocator.heap_top();
+    const uint64_t heap_top_before_record = orch.task_allocator.heap_top();
     ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
-    EXPECT_EQ(orch.ring.task_allocator.heap_top(), heap_top_before_record);
+    EXPECT_EQ(orch.task_allocator.heap_top(), heap_top_before_record);
     ASSERT_TRUE(orch.graph_end());
-    EXPECT_EQ(orch.ring.task_allocator.heap_top(), heap_top_before_record);
+    EXPECT_EQ(orch.task_allocator.heap_top(), heap_top_before_record);
     orch.graph_commit();
-    EXPECT_GT(orch.ring.task_allocator.heap_top(), heap_top_before_record);
+    EXPECT_GT(orch.task_allocator.heap_top(), heap_top_before_record);
     ASSERT_FALSE(orch.fatal);
     const size_t uploads_before_failure = graph_host_upload_count(*graph_state);
 
@@ -402,9 +402,9 @@ TEST_F(HbgGraphSubmitFailureTest, CachedGraphUsesFinalTaskWindowSlot) {
     node_args.add_input(boundary);
     ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
     ASSERT_TRUE(orch.graph_end());
-    ASSERT_EQ(orch.ring.task_allocator.active_count(), 1);
+    ASSERT_EQ(orch.task_allocator.active_count(), 1);
 
-    PTO2TaskAllocator &allocator = orch.ring.task_allocator;
+    PTO2TaskAllocator &allocator = orch.task_allocator;
     while (allocator.active_count() < allocator.window_size() - 1) {
         ASSERT_FALSE(allocator.alloc(0).failed());
     }
@@ -668,7 +668,7 @@ TEST_F(HbgGraphSubmitFailureTest, ACachedGraphReplaysWhileAnotherKeyRecords) {
     ASSERT_TRUE(replay.task_id.is_valid());
     // A replay off the cache carries its own heap, unlike the zero-heap shells
     // key B is still deferring.
-    EXPECT_GT(orch.ring.task_allocator.heap_top(), 0u);
+    EXPECT_GT(orch.task_allocator.heap_top(), 0u);
 
     ASSERT_TRUE(orch.graph_prepare(second.recording_handle, args_b));
     CoreTaskArgs node_b;
@@ -696,7 +696,7 @@ TEST_F(HbgGraphSubmitFailureTest, AnOrdinaryAllocationInterleavesWithADeferredSh
     orch.begin_scope();
     const GraphScopeResult graph = orch.graph_begin(0x1905, boundary_args, 0x1736);
     ASSERT_TRUE(graph.recording);
-    EXPECT_EQ(orch.ring.task_allocator.heap_top(), 0u) << "the shell defers its heap";
+    EXPECT_EQ(orch.task_allocator.heap_top(), 0u) << "the shell defers its heap";
 
     // The ordinary task goes first, from the base of the heap.
     CoreTaskArgs ordinary_args;
@@ -704,7 +704,7 @@ TEST_F(HbgGraphSubmitFailureTest, AnOrdinaryAllocationInterleavesWithADeferredSh
     ordinary_args.add_output(ordinary_output);
     const TaskOutputTensors ordinary = orch.alloc_tensors(ordinary_args);
     ASSERT_TRUE(ordinary.task_id().is_valid());
-    const uint64_t heap_after_ordinary = orch.ring.task_allocator.heap_top();
+    const uint64_t heap_after_ordinary = orch.task_allocator.heap_top();
     EXPECT_GT(heap_after_ordinary, 0u);
 
     // Only then does the recording finish and the shell claim its block.
@@ -717,7 +717,7 @@ TEST_F(HbgGraphSubmitFailureTest, AnOrdinaryAllocationInterleavesWithADeferredSh
     orch.graph_commit();
 
     EXPECT_FALSE(orch.fatal);
-    EXPECT_GT(orch.ring.task_allocator.heap_top(), heap_after_ordinary)
+    EXPECT_GT(orch.task_allocator.heap_top(), heap_after_ordinary)
         << "the shell's block sits above the ordinary task's, not before it";
     PTO2SharedMemoryRingHeader &ring = sm_handle->header->ring;
     const int32_t shell_slot = ring.get_slot_by_task_id(static_cast<int32_t>(graph.task_id.local()));

--- a/tests/ut/cpp/common/test_hbg_slot_claim.cpp
+++ b/tests/ut/cpp/common/test_hbg_slot_claim.cpp
@@ -42,7 +42,7 @@ protected:
     void SetUp() override {
         sm_handle = PTO2SharedMemoryHandle::create_and_init_default(sm_arena);
         ASSERT_NE(sm_handle, nullptr);
-        gm_heap.resize(HEAP_BYTES * PTO2_MAX_RING_DEPTH);
+        gm_heap.resize(HEAP_BYTES);
 
         sched_layout = PTO2SchedulerState::reserve_layout(runtime_arena);
         ASSERT_NE(runtime_arena.commit(), nullptr);
@@ -135,7 +135,7 @@ TEST_F(HbgSlotClaimTest, GraphOuterTaskClaimsAPoisonedSlot) {
     node_args.add_input(boundary);
     ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
     ASSERT_TRUE(orch.graph_end());
-    ASSERT_EQ(orch.ring.task_allocator.active_count(), 1);
+    ASSERT_EQ(orch.task_allocator.active_count(), 1);
 
     PTO2TaskSlotState &outer = sm_handle->header->ring.get_slot_state_by_slot(0);
     ASSERT_EQ(outer.task_kind, TaskKind::GRAPH);


### PR DESCRIPTION
## Summary

`host_build_graph` has one ring — `PTO2_MAX_RING_DEPTH` was `1` against `tensormap_and_ringbuffer`'s `4` — yet the tree carried tmr's multi-ring shape throughout: **38 `[PTO2_MAX_RING_DEPTH]` array declarations and 21 loops that ran exactly once**, with callers then indexing `[0]` anyway.

Every shared-memory operation existed twice: a scalar wrapper that filled a one-element array, and a `_per_ring` implementation that read `task_window_sizes[0]`. One of them (`setup_pointers_per_ring`) did not read the array at all — it cast it to `void`.

- The macro is gone from this runtime, and each operation has one scalar form: `calculate_size`, `init`, `init_header`, `setup_pointers`, `attach_populated`, `runtime_reserve_layout`, `runtime_init_data_from_layout`.
- `PTO2RuntimeArenaLayout` carries `task_window_size` / `heap_size` instead of one-element arrays (same 8 bytes each, so the uploaded header's size is unchanged).
- `sum_ring_heap_sizes` — which summed one element and checked it for overflow against itself — is deleted, along with the two open-coded copies of the same loop in `runtime_maker.cpp`.
- `PTO2RingSet` was a struct with a single member, `PTO2TaskAllocator task_allocator`, whose own doc comment claimed "PTO2_MAX_RING_DEPTH instances exist, one per scope depth". The allocator now sits on the orchestrator directly.
- `PTO2_DEP_POOL_SPIN_LIMIT` is deleted: hbg has no dependency spill pool and nothing referenced it. Two struct summaries in `pto_ring_buffer.h`'s file comment described `FaninPool` and `DepListPool`, which that file has not held since the pools were removed.

### What deliberately did not change

- **The `PTO2_RING_TASK_WINDOW` / `PTO2_RING_HEAP` knobs accept exactly what they did before.** The multi-ring parser required exactly one comma-separated value here, so it took a bare number and rejected a list — which is what the scalar parser does.
- **The `RuntimeEnv` ABI keeps its `RUNTIME_ENV_RING_COUNT` slots** (it is shared with tmr) and this runtime still reads slot 0. The `static_assert` now states that, rather than comparing against a ring depth this runtime no longer has.
- **`bind_callable_to_runtime_impl`'s `extern "C"` signature is untouched** — it is a cross-runtime contract.
- **The `[STALL]` diagnostic grammar is byte-identical.** Its per-ring loop is unwrapped with the `ring=` field kept and its value written as the `0` it always was, so existing triage greps still match.
- **`tensormap_and_ringbuffer` is untouched** — it really has four rings.

Net −419 lines across 26 files.

## Testing

- [x] C++ unit tests: 115/115 pass (4 hbg UT files updated for the removed wrapper)
- [x] Simulation tests pass — full `examples tests/st` on `a2a3sim` and `a5sim`, both runtimes green
- [x] `clang-format` clean
- [ ] **Hardware: locally inconclusive — see below. Relying on this PR's `st-onboard-a2a3` / `st-onboard-a5` jobs.**

### Why the hardware claim is deferred to CI

An `a2a3` onboard sweep of this branch on my dev box produced `finalize_native_run failed with code -100` (behind `507018 ACL_ERROR_RT_AICPU_EXCEPTION`, errcode 21008) on a varying set of cases: 8 failures on one run, 1 on the next, 0 on a third. Every failing case passes when run alone. One sweep at the merge base produced 0 failures.

That looked like a signal against this branch, so I dug further, and found the comparison was not controlled: **other concurrent sessions on that shared box were running their own onboard sweeps against other worktrees during these runs**, so the background device load differed between the baseline run and the branch runs. The failure count also fell as the box quietened, which fits contention rather than a defect in the diff.

I am not claiming this is unrelated — I could not establish either way locally, and the same signature family is already recorded on that box for `run_stream_reuse` (which does reproduce at the merge base). CI's self-hosted runners are isolated, so their onboard result is the real gate here. If `st-onboard-a2a3` or `st-onboard-a5` reddens, treat it as this PR's problem and I will bisect against the merge base on a quiet box.

Follow-up from the same audit, deliberately not in this PR: hbg reports `PTO2_ERROR_DEP_POOL_OVERFLOW` when a task's fanin region is exhausted, in a runtime that has no dependency spill pool. That status code is externally visible and sits in the band #1960 just reorganised, so renaming it needs its own coordinated change.
