### PR TITLE
Refactor: retire the PTO2 prefix on the task-id type

### DIFF
--- a/docs/buffer-abi.md
+++ b/docs/buffer-abi.md
@@ -104,7 +104,7 @@ resolved address, which by definition does not exist while the argument is still
 crossing processes. `owner_task_id` / `version` / `manual_dep` are L2 OverlapMap
 state — the producing task and its dependency treatment are decided by the chip
 runtime, so an L3 builder has nothing to put there (`make_tensor_strided` fills
-`PTO2TaskId::invalid()`, `0`, `false`). `is_contiguous` and `extent_elem_cache`
+`TaskId::invalid()`, `0`, `false`). `is_contiguous` and `extent_elem_cache`
 are derived from `shapes`/`strides`, cached for the AICore hot path so it can
 skip cache line 2.
 

--- a/docs/dfx/dep-gen.md
+++ b/docs/dfx/dep-gen.md
@@ -179,7 +179,7 @@ these through `int(v)` which accepts either form, so the schema is
 JS-safe without burdening Python.
 
 Task ids encode `(ring_id << 32) | local_id` — the same layout as
-`PTO2TaskId::raw`:
+`TaskId::raw`:
 
 ```python
 ring = (raw >> 32) & 0xFF
@@ -211,7 +211,7 @@ Each edge is `{pred, succ}` plus annotation. Fields:
 
 | Field | Type | When present | Meaning |
 | ----- | ---- | ------------ | ------- |
-| `pred`, `succ` | uint64 (string) | always | `PTO2TaskId::raw` of producer and consumer |
+| `pred`, `succ` | uint64 (string) | always | `TaskId::raw` of producer and consumer |
 | `arg` | int32 | always | Consumer's arg-slot index; `-1` for `explicit` source |
 | `source` | string | always | `explicit` (from `explicit_deps[]`), `creator` (`owner_task_id` retention), or `tensormap` (overlap lookup hit) |
 | `flags` | string array | always | Subset of `["wait", "retain"]` — the edge's `DepFlags`. `wait` = ordering (readiness); `retain` = producer lifetime held until the consumer releases. `creator` edges are `["wait","retain"]`; `tensormap` edges `["wait"]`. `explicit` edges are **always recorded as `["wait","retain"]`**: the `DepGenRecord` does not carry per-dep kinds, so a replayed explicit dep cannot distinguish the ordering-only `CoreTaskArgsWithDeps::add_dep_wait()` API from the default. The differential gate is unaffected (both passes read the same constant). At runtime an `add_dep_wait()` edge is genuinely `["wait"]`; that distinction is a known replay limitation, not written to `deps.json`. |

--- a/docs/manual-scope.md
+++ b/docs/manual-scope.md
@@ -46,7 +46,7 @@ auto out = rt_submit_task(mixed_kernels, args);
 ```cpp
 CoreTaskArgs args;
 args.add_input(tensor);
-PTO2TaskId deps[] = {prev_task_id};
+TaskId deps[] = {prev_task_id};
 args.set_dependencies(deps, 1);
 ```
 
@@ -71,7 +71,7 @@ Rules:
 
 ```cpp
 auto alloc = alloc_tensors(ci0, ci1, ci2);
-PTO2TaskId alloc_tid = alloc.task_id();
+TaskId alloc_tid = alloc.task_id();
 const Tensor &tmp = alloc.get_ref(0);
 ```
 
@@ -137,21 +137,21 @@ PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
     CoreTaskArgs qk;
     qk.add_input(qi, kj);
     qk.add_output(sij_ci);
-    PTO2TaskId qk_deps[] = {alloc.task_id()};
+    TaskId qk_deps[] = {alloc.task_id()};
     qk.set_dependencies(qk_deps, 1);
     auto qk_out = rt_submit_aic_task(FUNC_QK, qk);
 
     CoreTaskArgs sf;
     sf.add_input(qk_out.get_ref(0));
     sf.add_output(pij_ci, li_ci, mi_ci);
-    PTO2TaskId sf_deps[] = {qk_out.task_id()};
+    TaskId sf_deps[] = {qk_out.task_id()};
     sf.set_dependencies(sf_deps, 1);
     auto sf_out = rt_submit_aiv_task(FUNC_SF, sf);
 
     CoreTaskArgs up;
     up.add_input(sf_out.get_ref(1), sf_out.get_ref(2), pv_out.get_ref(0));
     up.add_inout(mi, li, out_view, tmp);
-    PTO2TaskId up_deps[] = {sf_out.task_id(), pv_out.task_id()};
+    TaskId up_deps[] = {sf_out.task_id(), pv_out.task_id()};
     up.set_dependencies(up_deps, 2);
     auto up_out = rt_submit_aiv_task(FUNC_UP, up);
 }
@@ -163,10 +163,10 @@ When the dep set is conditional, build the array up first and call
 needed on the first iteration:
 
 ```cpp
-PTO2TaskId prev_update = PTO2TaskId::invalid();
+TaskId prev_update = TaskId::invalid();
 for (...) {
     CoreTaskArgs up = ...;
-    PTO2TaskId up_deps[1];
+    TaskId up_deps[1];
     uint32_t up_dep_count = 0;
     if (prev_update.is_valid()) {
         up_deps[up_dep_count++] = prev_update;

--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd_graph.cpp
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd_graph.cpp
@@ -495,18 +495,18 @@ void csa_attn_block(const GraphTaskArgs &args) {
         params_t128.launch_spec.set_block_num((t_dim_inline1640_inline10473 / 8));
         params_t128.set_allow_early_resolve(true);
         TaskOutputTensors task_128_outs = rt_submit_aiv_task(132, params_t128);
-        PTO2TaskId rms_tid_inline1641_inline10652 = task_128_outs.task_id();
-        PTO2TaskId rms_tid_inline10816 = rms_tid_inline1641_inline10652;
+        TaskId rms_tid_inline1641_inline10652 = task_128_outs.task_id();
+        TaskId rms_tid_inline10816 = rms_tid_inline1641_inline10652;
 
         // Phase-fence barrier 4: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_4;
-        PTO2TaskId params_phase_fence_barrier_4_deps[1];
+        TaskId params_phase_fence_barrier_4_deps[1];
         uint32_t params_phase_fence_barrier_4_deps_count = 0;
         params_phase_fence_barrier_4_deps[params_phase_fence_barrier_4_deps_count++] = rms_tid_inline1641_inline10652;
         params_phase_fence_barrier_4.set_dependencies(
             params_phase_fence_barrier_4_deps, params_phase_fence_barrier_4_deps_count
         );
-        PTO2TaskId late_dep_inline10645 = PTO2TaskId::invalid();
+        TaskId late_dep_inline10645 = TaskId::invalid();
         if (params_phase_fence_barrier_4_deps_count > 0) {
             TaskOutputTensors phase_fence_barrier_4_outs = rt_submit_dummy_task(params_phase_fence_barrier_4);
             late_dep_inline10645 = phase_fence_barrier_4_outs.task_id();
@@ -687,7 +687,7 @@ void csa_attn_block(const GraphTaskArgs &args) {
         params_t135.add_scalar(t_matmul_inline1739_inline10470);
         params_t135.add_scalar(t_dim_inline1772_inline10498);
         params_t135.launch_spec.set_block_num(16);
-        PTO2TaskId params_t135_deps[1];
+        TaskId params_t135_deps[1];
         uint32_t params_t135_deps_count = 0;
         if (late_dep_inline10645.is_valid()) params_t135_deps[params_t135_deps_count++] = late_dep_inline10645;
         params_t135.set_dependencies(params_t135_deps, params_t135_deps_count);
@@ -766,7 +766,7 @@ void csa_attn_block(const GraphTaskArgs &args) {
         params_t139.add_inout(cmp4_kv_proj_pad_inline1900_inline10467);
         params_t139.add_inout(cmp4_score_proj_pad_inline1878_inline10597);
         params_t139.launch_spec.set_block_num(16);
-        PTO2TaskId params_t139_deps[1];
+        TaskId params_t139_deps[1];
         uint32_t params_t139_deps_count = 0;
         if (late_dep_inline10645.is_valid()) params_t139_deps[params_t139_deps_count++] = late_dep_inline10645;
         params_t139.set_dependencies(params_t139_deps, params_t139_deps_count);
@@ -867,7 +867,7 @@ void csa_attn_block(const GraphTaskArgs &args) {
         params_t148.add_input(csa_weights_proj_csa_inline553);
         params_t148.add_inout(weights_partial_inline2014_inline10666);
         params_t148.launch_spec.set_block_num(4);
-        PTO2TaskId params_t148_deps[1];
+        TaskId params_t148_deps[1];
         uint32_t params_t148_deps_count = 0;
         if (late_dep_inline10645.is_valid()) params_t148_deps[params_t148_deps_count++] = late_dep_inline10645;
         params_t148.set_dependencies(params_t148_deps, params_t148_deps_count);
@@ -909,7 +909,7 @@ void csa_attn_block(const GraphTaskArgs &args) {
         params_t150.add_inout(kv_proj_pad_inline14688);
         params_t150.add_inout(score_proj_pad_inline14676);
         params_t150.launch_spec.set_block_num(8);
-        PTO2TaskId params_t150_deps[1];
+        TaskId params_t150_deps[1];
         uint32_t params_t150_deps_count = 0;
         if (late_dep_inline10645.is_valid()) params_t150_deps[params_t150_deps_count++] = late_dep_inline10645;
         params_t150.set_dependencies(params_t150_deps, params_t150_deps_count);
@@ -1032,7 +1032,7 @@ void csa_attn_block(const GraphTaskArgs &args) {
         params_t158.add_inout(qk_order_inline2147_inline10861);
         params_t158.set_allow_early_resolve(true);
         TaskOutputTensors task_158_outs = rt_submit_aiv_task(163, params_t158);
-        PTO2TaskId qk_plan_tid_inline2134_inline10864 = task_158_outs.task_id();
+        TaskId qk_plan_tid_inline2134_inline10864 = task_158_outs.task_id();
         int64_t cmp_block_num_inline2124_inline10406 = (int64_t)cmp_kv_csa_inline638.shapes[0];
         uint32_t cmp_kv_flat_inline2128_inline10589_shapes[2] = {
             static_cast<uint32_t>((cmp_block_num_inline2124_inline10406 * 128)), 512
@@ -1061,7 +1061,7 @@ void csa_attn_block(const GraphTaskArgs &args) {
         MixedKernels mixed_159 = {164, 165, 165};
         params_t159.launch_spec.set_block_num(24);
         params_t159.set_allow_early_resolve(true);
-        PTO2TaskId params_t159_deps[1];
+        TaskId params_t159_deps[1];
         uint32_t params_t159_deps_count = 0;
         params_t159_deps[params_t159_deps_count++] = qk_plan_tid_inline2134_inline10864;
         params_t159.set_dependencies(params_t159_deps, params_t159_deps_count);
@@ -1089,10 +1089,10 @@ void csa_attn_block(const GraphTaskArgs &args) {
         params_t161.add_inout(o_packed_inline2242_inline10294);
         params_t161.launch_spec.set_block_num(32);
         TaskOutputTensors task_161_outs = rt_submit_aiv_task(167, params_t161);
-        PTO2TaskId merge_tid_inline2186_inline10613 = task_161_outs.task_id();
-        PTO2TaskId proj_b_tids_inline2079_inline10609[8];
+        TaskId merge_tid_inline2186_inline10613 = task_161_outs.task_id();
+        TaskId proj_b_tids_inline2079_inline10609[8];
         for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
-            proj_b_tids_inline2079_inline10609[__init_i] = PTO2TaskId::invalid();
+            proj_b_tids_inline2079_inline10609[__init_i] = TaskId::invalid();
         ChipTensor o_r_pad_inline2225_inline10832__rv_v2 = o_r_pad_inline2225_inline10832;
         PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
             for (int64_t g_inline2162_inline10271 = 0; g_inline2162_inline10271 < 8; g_inline2162_inline10271 += 1) {
@@ -1109,13 +1109,13 @@ void csa_attn_block(const GraphTaskArgs &args) {
                 params_t162.add_scalar(out_col_g_inline2181_inline10439);
                 params_t162.launch_spec.set_block_num(8);
                 params_t162.set_allow_early_resolve(true);
-                PTO2TaskId params_t162_deps[1];
+                TaskId params_t162_deps[1];
                 uint32_t params_t162_deps_count = 0;
                 params_t162_deps[params_t162_deps_count++] = merge_tid_inline2186_inline10613;
                 params_t162.set_dependencies(params_t162_deps, params_t162_deps_count);
                 TaskOutputTensors task_162_outs = rt_submit_aic_task(168, params_t162);
                 int64_t n0_inline2077_inline10269 = 0;
-                PTO2TaskId pa_tid_inline2168_inline10270 = task_162_outs.task_id();
+                TaskId pa_tid_inline2168_inline10270 = task_162_outs.task_id();
                 int64_t col_g_inline2196_inline10384 = (g_inline2162_inline10271 * 1024);
 
                 // Task 163: quant_1
@@ -1125,13 +1125,13 @@ void csa_attn_block(const GraphTaskArgs &args) {
                 params_t163.add_input(o_r_pad_inline2225_inline10832__rv_v2);
                 params_t163.add_scalar(col_g_inline2196_inline10384);
                 params_t163.add_scalar(g_inline2162_inline10271);
-                PTO2TaskId params_t163_deps[1];
+                TaskId params_t163_deps[1];
                 uint32_t params_t163_deps_count = 0;
                 params_t163_deps[params_t163_deps_count++] = pa_tid_inline2168_inline10270;
                 params_t163.set_dependencies(params_t163_deps, params_t163_deps_count);
                 params_t163.set_allow_early_resolve(true);
                 TaskOutputTensors task_163_outs = rt_submit_aiv_task(169, params_t163);
-                PTO2TaskId q_tid_inline2071_inline10277 = task_163_outs.task_id();
+                TaskId q_tid_inline2071_inline10277 = task_163_outs.task_id();
 
                 // Spmd proj_b_mm_spmd_1: proj_b_mm_1
                 CoreTaskArgs params_t164;
@@ -1143,33 +1143,33 @@ void csa_attn_block(const GraphTaskArgs &args) {
                 params_t164.add_scalar(g_inline2162_inline10271);
                 params_t164.launch_spec.set_block_num(8);
                 params_t164.set_allow_early_resolve(true);
-                PTO2TaskId params_t164_deps[1];
+                TaskId params_t164_deps[1];
                 uint32_t params_t164_deps_count = 0;
                 params_t164_deps[params_t164_deps_count++] = q_tid_inline2071_inline10277;
                 params_t164.set_dependencies(params_t164_deps, params_t164_deps_count);
                 TaskOutputTensors task_164_outs = rt_submit_aic_task(170, params_t164);
-                PTO2TaskId pb_tid_inline2057_inline10779 = task_164_outs.task_id();
+                TaskId pb_tid_inline2057_inline10779 = task_164_outs.task_id();
                 proj_b_tids_inline2079_inline10609[g_inline2162_inline10271] = pb_tid_inline2057_inline10779;
             }
         }
-        PTO2TaskId _submit_deps_buf_inline2166_inline10248[8];
+        TaskId _submit_deps_buf_inline2166_inline10248[8];
         for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
-            _submit_deps_buf_inline2166_inline10248[__init_i] = PTO2TaskId::invalid();
-        PTO2TaskId t__tmp_v1016 = proj_b_tids_inline2079_inline10609[0];
+            _submit_deps_buf_inline2166_inline10248[__init_i] = TaskId::invalid();
+        TaskId t__tmp_v1016 = proj_b_tids_inline2079_inline10609[0];
         _submit_deps_buf_inline2166_inline10248[0] = t__tmp_v1016;
-        PTO2TaskId t__tmp_v1017 = proj_b_tids_inline2079_inline10609[1];
+        TaskId t__tmp_v1017 = proj_b_tids_inline2079_inline10609[1];
         _submit_deps_buf_inline2166_inline10248[1] = t__tmp_v1017;
-        PTO2TaskId t__tmp_v1018 = proj_b_tids_inline2079_inline10609[2];
+        TaskId t__tmp_v1018 = proj_b_tids_inline2079_inline10609[2];
         _submit_deps_buf_inline2166_inline10248[2] = t__tmp_v1018;
-        PTO2TaskId t__tmp_v1019 = proj_b_tids_inline2079_inline10609[3];
+        TaskId t__tmp_v1019 = proj_b_tids_inline2079_inline10609[3];
         _submit_deps_buf_inline2166_inline10248[3] = t__tmp_v1019;
-        PTO2TaskId t__tmp_v1020 = proj_b_tids_inline2079_inline10609[4];
+        TaskId t__tmp_v1020 = proj_b_tids_inline2079_inline10609[4];
         _submit_deps_buf_inline2166_inline10248[4] = t__tmp_v1020;
-        PTO2TaskId t__tmp_v1021 = proj_b_tids_inline2079_inline10609[5];
+        TaskId t__tmp_v1021 = proj_b_tids_inline2079_inline10609[5];
         _submit_deps_buf_inline2166_inline10248[5] = t__tmp_v1021;
-        PTO2TaskId t__tmp_v1022 = proj_b_tids_inline2079_inline10609[6];
+        TaskId t__tmp_v1022 = proj_b_tids_inline2079_inline10609[6];
         _submit_deps_buf_inline2166_inline10248[6] = t__tmp_v1022;
-        PTO2TaskId t__tmp_v1023 = proj_b_tids_inline2079_inline10609[7];
+        TaskId t__tmp_v1023 = proj_b_tids_inline2079_inline10609[7];
         _submit_deps_buf_inline2166_inline10248[7] = t__tmp_v1023;
 
         // Spmd proj_b_act_spmd_1: proj_b_act_1
@@ -1180,7 +1180,7 @@ void csa_attn_block(const GraphTaskArgs &args) {
         params_t165.add_inout(attn_out_inline10836);
         params_t165.launch_spec.set_block_num(8);
         params_t165.set_allow_early_resolve(true);
-        PTO2TaskId params_t165_deps[8];
+        TaskId params_t165_deps[8];
         uint32_t params_t165_deps_count = 0;
         if (_submit_deps_buf_inline2166_inline10248[0].is_valid())
             params_t165_deps[params_t165_deps_count++] = _submit_deps_buf_inline2166_inline10248[0];
@@ -1480,7 +1480,7 @@ void csa_moe_block(const GraphTaskArgs &args, bool route_by_hash) {
         // Phase-fence barrier 5: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_5;
         TaskOutputTensors phase_fence_barrier_5_outs = rt_submit_dummy_task(params_phase_fence_barrier_5);
-        PTO2TaskId seed_dummy_inline2602_inline11128 = phase_fence_barrier_5_outs.task_id();
+        TaskId seed_dummy_inline2602_inline11128 = phase_fence_barrier_5_outs.task_id();
         for (int64_t t0_inline2605_inline11063 = 0;
              t0_inline2605_inline11063 < active_gate_tokens_inline2604_inline11120__phi_v2;
              t0_inline2605_inline11063 += 8) {
@@ -1490,7 +1490,7 @@ void csa_moe_block(const GraphTaskArgs &args, bool route_by_hash) {
             params_t174.add_inout(x_norm_i8_inline11072);
             params_t174.add_input(xg_buf_inline2582_inline11203);
             params_t174.add_scalar(t0_inline2605_inline11063);
-            PTO2TaskId params_t174_deps[1];
+            TaskId params_t174_deps[1];
             uint32_t params_t174_deps_count = 0;
             if (seed_dummy_inline2602_inline11128.is_valid())
                 params_t174_deps[params_t174_deps_count++] = seed_dummy_inline2602_inline11128;
@@ -1677,7 +1677,7 @@ void csa_moe_block(const GraphTaskArgs &args, bool route_by_hash) {
         params_t184.add_scalar(arrived_ctx);
         params_t184.set_allow_early_resolve(true);
         TaskOutputTensors task_184_outs = rt_submit_aiv_task(191, params_t184);
-        PTO2TaskId _meta_tid_inline2705_inline11213 = task_184_outs.task_id();
+        TaskId _meta_tid_inline2705_inline11213 = task_184_outs.task_id();
 
         // Spmd dispatch_push_spmd_1: dispatch_push_1
         CoreTaskArgs params_t185;
@@ -1698,7 +1698,7 @@ void csa_moe_block(const GraphTaskArgs &args, bool route_by_hash) {
         params_t185.launch_spec.set_block_num(32);
         params_t185.set_allow_early_resolve(true);
         TaskOutputTensors task_185_outs = rt_submit_aiv_task(192, params_t185);
-        PTO2TaskId _push_tid_inline2710_inline11085 = task_185_outs.task_id();
+        TaskId _push_tid_inline2710_inline11085 = task_185_outs.task_id();
 
         // Task 186: dispatch_wait_1
         CoreTaskArgs params_t186;
@@ -1707,13 +1707,13 @@ void csa_moe_block(const GraphTaskArgs &args, bool route_by_hash) {
         params_t186.add_scalar(my_rank);
         params_t186.add_scalar(csa_moe_epoch_inline715);
         params_t186.add_scalar(data_arrived_ctx);
-        PTO2TaskId params_t186_deps[1];
+        TaskId params_t186_deps[1];
         uint32_t params_t186_deps_count = 0;
         params_t186_deps[params_t186_deps_count++] = _push_tid_inline2710_inline11085;
         params_t186.set_dependencies(params_t186_deps, params_t186_deps_count);
         params_t186.set_allow_early_resolve(true);
         TaskOutputTensors task_186_outs = rt_submit_aiv_task(193, params_t186);
-        PTO2TaskId _wait_tid_inline2685_inline11068 = task_186_outs.task_id();
+        TaskId _wait_tid_inline2685_inline11068 = task_186_outs.task_id();
 
         // Spmd dispatch_gather_spmd_1: dispatch_gather_1
         CoreTaskArgs params_t187;
@@ -1729,13 +1729,13 @@ void csa_moe_block(const GraphTaskArgs &args, bool route_by_hash) {
         params_t187.add_scalar(recv_aux_ctx);
         params_t187.add_scalar(recv_route_ctx);
         params_t187.launch_spec.set_block_num(32);
-        PTO2TaskId params_t187_deps[2];
+        TaskId params_t187_deps[2];
         uint32_t params_t187_deps_count = 0;
         params_t187_deps[params_t187_deps_count++] = _wait_tid_inline2685_inline11068;
         params_t187_deps[params_t187_deps_count++] = _meta_tid_inline2705_inline11213;
         params_t187.set_dependencies(params_t187_deps, params_t187_deps_count);
         TaskOutputTensors task_187_outs = rt_submit_aiv_task(194, params_t187);
-        PTO2TaskId dispatch_push_tid_inline11245 = _push_tid_inline2710_inline11085;
+        TaskId dispatch_push_tid_inline11245 = _push_tid_inline2710_inline11085;
         PTO2_SCOPE() {
             uint32_t recv_y_inline11016_ci_shapes[3] = {32, 16, 4096};
             TensorCreateInfo recv_y_inline11016_ci(recv_y_inline11016_ci_shapes, 3, DataType::BFLOAT16);
@@ -2029,7 +2029,7 @@ void csa_moe_block(const GraphTaskArgs &args, bool route_by_hash) {
             params_t194.add_scalar(routed_y_buf_ctx);
             params_t194.launch_spec.set_block_num(32);
             TaskOutputTensors task_194_outs = rt_submit_aiv_task(201, params_t194);
-            PTO2TaskId _combine_tid_inline2817_inline11196 = task_194_outs.task_id();
+            TaskId _combine_tid_inline2817_inline11196 = task_194_outs.task_id();
 
             // Task 195: combine_wait_1
             CoreTaskArgs params_t195;
@@ -2037,13 +2037,13 @@ void csa_moe_block(const GraphTaskArgs &args, bool route_by_hash) {
             params_t195.add_scalar(my_rank);
             params_t195.add_scalar(csa_moe_epoch_inline715);
             params_t195.add_scalar(combine_arrived_ctx);
-            PTO2TaskId params_t195_deps[2];
+            TaskId params_t195_deps[2];
             uint32_t params_t195_deps_count = 0;
             params_t195_deps[params_t195_deps_count++] = _combine_tid_inline2817_inline11196;
             params_t195_deps[params_t195_deps_count++] = _push_tid_inline2710_inline11085;
             params_t195.set_dependencies(params_t195_deps, params_t195_deps_count);
             TaskOutputTensors task_195_outs = rt_submit_aiv_task(202, params_t195);
-            PTO2TaskId _cwait_tid_inline2826_inline10971 = task_195_outs.task_id();
+            TaskId _cwait_tid_inline2826_inline10971 = task_195_outs.task_id();
             int64_t active_tokens_inline2816_inline11163 = static_cast<int64_t>(nt_inline677__rv_v2);
             int64_t active_tokens_inline2816_inline11163__phi_v4;
             if ((8 < active_tokens_inline2816_inline11163)) {
@@ -2061,7 +2061,7 @@ void csa_moe_block(const GraphTaskArgs &args, bool route_by_hash) {
             params_t196.add_scalar(active_tokens_inline2816_inline11163__phi_v4);
             params_t196.add_scalar(routed_y_buf_ctx);
             params_t196.launch_spec.set_block_num(8);
-            PTO2TaskId params_t196_deps[1];
+            TaskId params_t196_deps[1];
             uint32_t params_t196_deps_count = 0;
             params_t196_deps[params_t196_deps_count++] = _cwait_tid_inline2826_inline10971;
             params_t196.set_dependencies(params_t196_deps, params_t196_deps_count);
@@ -2398,18 +2398,18 @@ void hca_attn_block(const GraphTaskArgs &args) {
         params_t206.launch_spec.set_block_num((t_dim_inline1151_inline11588 / 8));
         params_t206.set_allow_early_resolve(true);
         TaskOutputTensors task_206_outs = rt_submit_aiv_task(213, params_t206);
-        PTO2TaskId rms_tid_inline1152_inline11584 = task_206_outs.task_id();
-        PTO2TaskId rms_tid_inline11632 = rms_tid_inline1152_inline11584;
+        TaskId rms_tid_inline1152_inline11584 = task_206_outs.task_id();
+        TaskId rms_tid_inline11632 = rms_tid_inline1152_inline11584;
 
         // Phase-fence barrier 6: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_6;
-        PTO2TaskId params_phase_fence_barrier_6_deps[1];
+        TaskId params_phase_fence_barrier_6_deps[1];
         uint32_t params_phase_fence_barrier_6_deps_count = 0;
         params_phase_fence_barrier_6_deps[params_phase_fence_barrier_6_deps_count++] = rms_tid_inline1152_inline11584;
         params_phase_fence_barrier_6.set_dependencies(
             params_phase_fence_barrier_6_deps, params_phase_fence_barrier_6_deps_count
         );
-        PTO2TaskId late_dep_inline11598 = PTO2TaskId::invalid();
+        TaskId late_dep_inline11598 = TaskId::invalid();
         if (params_phase_fence_barrier_6_deps_count > 0) {
             TaskOutputTensors phase_fence_barrier_6_outs = rt_submit_dummy_task(params_phase_fence_barrier_6);
             late_dep_inline11598 = phase_fence_barrier_6_outs.task_id();
@@ -2590,7 +2590,7 @@ void hca_attn_block(const GraphTaskArgs &args) {
         params_t213.add_scalar(t_matmul_inline1250_inline11559);
         params_t213.add_scalar(t_dim_inline1283_inline11618);
         params_t213.launch_spec.set_block_num(16);
-        PTO2TaskId params_t213_deps[1];
+        TaskId params_t213_deps[1];
         uint32_t params_t213_deps_count = 0;
         if (late_dep_inline11598.is_valid()) params_t213_deps[params_t213_deps_count++] = late_dep_inline11598;
         params_t213.set_dependencies(params_t213_deps, params_t213_deps_count);
@@ -2655,7 +2655,7 @@ void hca_attn_block(const GraphTaskArgs &args) {
         params_t217.add_inout(score_proj_pad_inline1382_inline11463);
         params_t217.add_scalar(bs_inline1375_inline11667);
         params_t217.launch_spec.set_block_num((t_matmul_inline1366_inline11787 / 2));
-        PTO2TaskId params_t217_deps[1];
+        TaskId params_t217_deps[1];
         uint32_t params_t217_deps_count = 0;
         if (late_dep_inline11598.is_valid()) params_t217_deps[params_t217_deps_count++] = late_dep_inline11598;
         params_t217.set_dependencies(params_t217_deps, params_t217_deps_count);
@@ -2680,7 +2680,7 @@ void hca_attn_block(const GraphTaskArgs &args) {
         params_t218.add_scalar(b_dim_inline1393_inline11785);
         params_t218.add_scalar(s_dim_inline1364_inline11456);
         TaskOutputTensors task_218_outs = rt_submit_aiv_task(225, params_t218);
-        PTO2TaskId pool_tid_inline1365_inline11753 = task_218_outs.task_id();
+        TaskId pool_tid_inline1365_inline11753 = task_218_outs.task_id();
         uint32_t norm_w_2d_inline1362_inline11652_shapes[2] = {1, 512};
         ChipTensor norm_w_2d_inline1362_inline11652 =
             hca_cmp_norm_w_hca_inline520.reshape(norm_w_2d_inline1362_inline11652_shapes, 2);
@@ -2707,7 +2707,7 @@ void hca_attn_block(const GraphTaskArgs &args) {
         params_t219.add_input(cmp_slot_mapping_bsd_inline11721);
         params_t219.add_scalar(b_dim_inline1393_inline11785);
         params_t219.add_scalar(s_dim_inline1364_inline11456);
-        PTO2TaskId params_t219_deps[1];
+        TaskId params_t219_deps[1];
         uint32_t params_t219_deps_count = 0;
         params_t219_deps[params_t219_deps_count++] = pool_tid_inline1365_inline11753;
         params_t219.set_dependencies(params_t219_deps, params_t219_deps_count);
@@ -2752,7 +2752,7 @@ void hca_attn_block(const GraphTaskArgs &args) {
         params_t222.add_input(cmp_kv_flat_inline1500_inline11375);
         params_t222.launch_spec.set_block_num(32);
         TaskOutputTensors task_222_outs = rt_submit_aiv_task(229, params_t222);
-        PTO2TaskId gather_tid_inline1486_inline11365 = task_222_outs.task_id();
+        TaskId gather_tid_inline1486_inline11365 = task_222_outs.task_id();
         uint32_t q_flat_inline1542_inline11350_shapes[2] = {512, 512};
         ChipTensor q_flat_inline1542_inline11350 = q_inline11621.reshape(q_flat_inline1542_inline11350_shapes, 2);
 
@@ -2768,7 +2768,7 @@ void hca_attn_block(const GraphTaskArgs &args) {
         MixedKernels mixed_223 = {230, 231, 231};
         params_t223.launch_spec.set_block_num(16);
         params_t223.set_allow_early_resolve(true);
-        PTO2TaskId params_t223_deps[1];
+        TaskId params_t223_deps[1];
         uint32_t params_t223_deps_count = 0;
         params_t223_deps[params_t223_deps_count++] = gather_tid_inline1486_inline11365;
         params_t223.set_dependencies(params_t223_deps, params_t223_deps_count);
@@ -2800,10 +2800,10 @@ void hca_attn_block(const GraphTaskArgs &args) {
         params_t226.add_inout(o_packed_inline1463_inline11349);
         params_t226.launch_spec.set_block_num(32);
         TaskOutputTensors task_226_outs = rt_submit_aiv_task(234, params_t226);
-        PTO2TaskId merge_tid_inline1576_inline11323 = task_226_outs.task_id();
-        PTO2TaskId proj_b_tids_inline1519_inline11335[8];
+        TaskId merge_tid_inline1576_inline11323 = task_226_outs.task_id();
+        TaskId proj_b_tids_inline1519_inline11335[8];
         for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
-            proj_b_tids_inline1519_inline11335[__init_i] = PTO2TaskId::invalid();
+            proj_b_tids_inline1519_inline11335[__init_i] = TaskId::invalid();
         ChipTensor o_r_pad_inline1536_inline11403__rv_v2 = o_r_pad_inline1536_inline11403;
         PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
             for (int64_t g_inline1480_inline11801 = 0; g_inline1480_inline11801 < 8; g_inline1480_inline11801 += 1) {
@@ -2820,13 +2820,13 @@ void hca_attn_block(const GraphTaskArgs &args) {
                 params_t227.add_scalar(out_col_g_inline1609_inline11551);
                 params_t227.launch_spec.set_block_num(8);
                 params_t227.set_allow_early_resolve(true);
-                PTO2TaskId params_t227_deps[1];
+                TaskId params_t227_deps[1];
                 uint32_t params_t227_deps_count = 0;
                 params_t227_deps[params_t227_deps_count++] = merge_tid_inline1576_inline11323;
                 params_t227.set_dependencies(params_t227_deps, params_t227_deps_count);
                 TaskOutputTensors task_227_outs = rt_submit_aic_task(235, params_t227);
                 int64_t n0_inline1453_inline11306 = 0;
-                PTO2TaskId pa_tid_inline1586_inline11308 = task_227_outs.task_id();
+                TaskId pa_tid_inline1586_inline11308 = task_227_outs.task_id();
                 int64_t col_g_inline1449_inline11676 = (g_inline1480_inline11801 * 1024);
 
                 // Task 228: quant_2
@@ -2836,13 +2836,13 @@ void hca_attn_block(const GraphTaskArgs &args) {
                 params_t228.add_input(o_r_pad_inline1536_inline11403__rv_v2);
                 params_t228.add_scalar(col_g_inline1449_inline11676);
                 params_t228.add_scalar(g_inline1480_inline11801);
-                PTO2TaskId params_t228_deps[1];
+                TaskId params_t228_deps[1];
                 uint32_t params_t228_deps_count = 0;
                 params_t228_deps[params_t228_deps_count++] = pa_tid_inline1586_inline11308;
                 params_t228.set_dependencies(params_t228_deps, params_t228_deps_count);
                 params_t228.set_allow_early_resolve(true);
                 TaskOutputTensors task_228_outs = rt_submit_aiv_task(236, params_t228);
-                PTO2TaskId q_tid_inline1448_inline11299 = task_228_outs.task_id();
+                TaskId q_tid_inline1448_inline11299 = task_228_outs.task_id();
 
                 // Spmd proj_b_mm_spmd_2: proj_b_mm_2
                 CoreTaskArgs params_t229;
@@ -2854,33 +2854,33 @@ void hca_attn_block(const GraphTaskArgs &args) {
                 params_t229.add_scalar(g_inline1480_inline11801);
                 params_t229.launch_spec.set_block_num(8);
                 params_t229.set_allow_early_resolve(true);
-                PTO2TaskId params_t229_deps[1];
+                TaskId params_t229_deps[1];
                 uint32_t params_t229_deps_count = 0;
                 params_t229_deps[params_t229_deps_count++] = q_tid_inline1448_inline11299;
                 params_t229.set_dependencies(params_t229_deps, params_t229_deps_count);
                 TaskOutputTensors task_229_outs = rt_submit_aic_task(237, params_t229);
-                PTO2TaskId pb_tid_inline1437_inline11597 = task_229_outs.task_id();
+                TaskId pb_tid_inline1437_inline11597 = task_229_outs.task_id();
                 proj_b_tids_inline1519_inline11335[g_inline1480_inline11801] = pb_tid_inline1437_inline11597;
             }
         }
-        PTO2TaskId _submit_deps_buf_inline1434_inline11286[8];
+        TaskId _submit_deps_buf_inline1434_inline11286[8];
         for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
-            _submit_deps_buf_inline1434_inline11286[__init_i] = PTO2TaskId::invalid();
-        PTO2TaskId t__tmp_v1414 = proj_b_tids_inline1519_inline11335[0];
+            _submit_deps_buf_inline1434_inline11286[__init_i] = TaskId::invalid();
+        TaskId t__tmp_v1414 = proj_b_tids_inline1519_inline11335[0];
         _submit_deps_buf_inline1434_inline11286[0] = t__tmp_v1414;
-        PTO2TaskId t__tmp_v1415 = proj_b_tids_inline1519_inline11335[1];
+        TaskId t__tmp_v1415 = proj_b_tids_inline1519_inline11335[1];
         _submit_deps_buf_inline1434_inline11286[1] = t__tmp_v1415;
-        PTO2TaskId t__tmp_v1416 = proj_b_tids_inline1519_inline11335[2];
+        TaskId t__tmp_v1416 = proj_b_tids_inline1519_inline11335[2];
         _submit_deps_buf_inline1434_inline11286[2] = t__tmp_v1416;
-        PTO2TaskId t__tmp_v1417 = proj_b_tids_inline1519_inline11335[3];
+        TaskId t__tmp_v1417 = proj_b_tids_inline1519_inline11335[3];
         _submit_deps_buf_inline1434_inline11286[3] = t__tmp_v1417;
-        PTO2TaskId t__tmp_v1418 = proj_b_tids_inline1519_inline11335[4];
+        TaskId t__tmp_v1418 = proj_b_tids_inline1519_inline11335[4];
         _submit_deps_buf_inline1434_inline11286[4] = t__tmp_v1418;
-        PTO2TaskId t__tmp_v1419 = proj_b_tids_inline1519_inline11335[5];
+        TaskId t__tmp_v1419 = proj_b_tids_inline1519_inline11335[5];
         _submit_deps_buf_inline1434_inline11286[5] = t__tmp_v1419;
-        PTO2TaskId t__tmp_v1420 = proj_b_tids_inline1519_inline11335[6];
+        TaskId t__tmp_v1420 = proj_b_tids_inline1519_inline11335[6];
         _submit_deps_buf_inline1434_inline11286[6] = t__tmp_v1420;
-        PTO2TaskId t__tmp_v1421 = proj_b_tids_inline1519_inline11335[7];
+        TaskId t__tmp_v1421 = proj_b_tids_inline1519_inline11335[7];
         _submit_deps_buf_inline1434_inline11286[7] = t__tmp_v1421;
 
         // Spmd proj_b_act_spmd_2: proj_b_act_2
@@ -2891,7 +2891,7 @@ void hca_attn_block(const GraphTaskArgs &args) {
         params_t230.add_inout(attn_out_inline11390);
         params_t230.launch_spec.set_block_num(8);
         params_t230.set_allow_early_resolve(true);
-        PTO2TaskId params_t230_deps[8];
+        TaskId params_t230_deps[8];
         uint32_t params_t230_deps_count = 0;
         if (_submit_deps_buf_inline1434_inline11286[0].is_valid())
             params_t230_deps[params_t230_deps_count++] = _submit_deps_buf_inline1434_inline11286[0];
@@ -3188,7 +3188,7 @@ void hca_moe_block(const GraphTaskArgs &args) {
         // Phase-fence barrier 7: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_7;
         TaskOutputTensors phase_fence_barrier_7_outs = rt_submit_dummy_task(params_phase_fence_barrier_7);
-        PTO2TaskId seed_dummy_inline2602_inline12007 = phase_fence_barrier_7_outs.task_id();
+        TaskId seed_dummy_inline2602_inline12007 = phase_fence_barrier_7_outs.task_id();
         for (int64_t t0_inline2605_inline11942 = 0;
              t0_inline2605_inline11942 < active_gate_tokens_inline2604_inline11999__phi_v2;
              t0_inline2605_inline11942 += 8) {
@@ -3198,7 +3198,7 @@ void hca_moe_block(const GraphTaskArgs &args) {
             params_t239.add_inout(x_norm_i8_inline11951);
             params_t239.add_input(xg_buf_inline2582_inline12082);
             params_t239.add_scalar(t0_inline2605_inline11942);
-            PTO2TaskId params_t239_deps[1];
+            TaskId params_t239_deps[1];
             uint32_t params_t239_deps_count = 0;
             if (seed_dummy_inline2602_inline12007.is_valid())
                 params_t239_deps[params_t239_deps_count++] = seed_dummy_inline2602_inline12007;
@@ -3364,7 +3364,7 @@ void hca_moe_block(const GraphTaskArgs &args) {
         params_t248.add_scalar(arrived_ctx);
         params_t248.set_allow_early_resolve(true);
         TaskOutputTensors task_248_outs = rt_submit_aiv_task(257, params_t248);
-        PTO2TaskId _meta_tid_inline2705_inline12092 = task_248_outs.task_id();
+        TaskId _meta_tid_inline2705_inline12092 = task_248_outs.task_id();
 
         // Spmd dispatch_push_spmd_2: dispatch_push_2
         CoreTaskArgs params_t249;
@@ -3385,7 +3385,7 @@ void hca_moe_block(const GraphTaskArgs &args) {
         params_t249.launch_spec.set_block_num(32);
         params_t249.set_allow_early_resolve(true);
         TaskOutputTensors task_249_outs = rt_submit_aiv_task(258, params_t249);
-        PTO2TaskId _push_tid_inline2710_inline11964 = task_249_outs.task_id();
+        TaskId _push_tid_inline2710_inline11964 = task_249_outs.task_id();
 
         // Task 250: dispatch_wait_2
         CoreTaskArgs params_t250;
@@ -3394,13 +3394,13 @@ void hca_moe_block(const GraphTaskArgs &args) {
         params_t250.add_scalar(my_rank);
         params_t250.add_scalar(hca_moe_epoch_inline716);
         params_t250.add_scalar(data_arrived_ctx);
-        PTO2TaskId params_t250_deps[1];
+        TaskId params_t250_deps[1];
         uint32_t params_t250_deps_count = 0;
         params_t250_deps[params_t250_deps_count++] = _push_tid_inline2710_inline11964;
         params_t250.set_dependencies(params_t250_deps, params_t250_deps_count);
         params_t250.set_allow_early_resolve(true);
         TaskOutputTensors task_250_outs = rt_submit_aiv_task(259, params_t250);
-        PTO2TaskId _wait_tid_inline2685_inline11947 = task_250_outs.task_id();
+        TaskId _wait_tid_inline2685_inline11947 = task_250_outs.task_id();
 
         // Spmd dispatch_gather_spmd_2: dispatch_gather_2
         CoreTaskArgs params_t251;
@@ -3416,13 +3416,13 @@ void hca_moe_block(const GraphTaskArgs &args) {
         params_t251.add_scalar(recv_aux_ctx);
         params_t251.add_scalar(recv_route_ctx);
         params_t251.launch_spec.set_block_num(32);
-        PTO2TaskId params_t251_deps[2];
+        TaskId params_t251_deps[2];
         uint32_t params_t251_deps_count = 0;
         params_t251_deps[params_t251_deps_count++] = _wait_tid_inline2685_inline11947;
         params_t251_deps[params_t251_deps_count++] = _meta_tid_inline2705_inline12092;
         params_t251.set_dependencies(params_t251_deps, params_t251_deps_count);
         TaskOutputTensors task_251_outs = rt_submit_aiv_task(260, params_t251);
-        PTO2TaskId dispatch_push_tid_inline12124 = _push_tid_inline2710_inline11964;
+        TaskId dispatch_push_tid_inline12124 = _push_tid_inline2710_inline11964;
         PTO2_SCOPE() {
             uint32_t recv_y_inline11895_ci_shapes[3] = {32, 16, 4096};
             TensorCreateInfo recv_y_inline11895_ci(recv_y_inline11895_ci_shapes, 3, DataType::BFLOAT16);
@@ -3716,7 +3716,7 @@ void hca_moe_block(const GraphTaskArgs &args) {
             params_t258.add_scalar(routed_y_buf_ctx);
             params_t258.launch_spec.set_block_num(32);
             TaskOutputTensors task_258_outs = rt_submit_aiv_task(267, params_t258);
-            PTO2TaskId _combine_tid_inline2817_inline12075 = task_258_outs.task_id();
+            TaskId _combine_tid_inline2817_inline12075 = task_258_outs.task_id();
 
             // Task 259: combine_wait_2
             CoreTaskArgs params_t259;
@@ -3724,13 +3724,13 @@ void hca_moe_block(const GraphTaskArgs &args) {
             params_t259.add_scalar(my_rank);
             params_t259.add_scalar(hca_moe_epoch_inline716);
             params_t259.add_scalar(combine_arrived_ctx);
-            PTO2TaskId params_t259_deps[2];
+            TaskId params_t259_deps[2];
             uint32_t params_t259_deps_count = 0;
             params_t259_deps[params_t259_deps_count++] = _combine_tid_inline2817_inline12075;
             params_t259_deps[params_t259_deps_count++] = _push_tid_inline2710_inline11964;
             params_t259.set_dependencies(params_t259_deps, params_t259_deps_count);
             TaskOutputTensors task_259_outs = rt_submit_aiv_task(268, params_t259);
-            PTO2TaskId _cwait_tid_inline2826_inline11850 = task_259_outs.task_id();
+            TaskId _cwait_tid_inline2826_inline11850 = task_259_outs.task_id();
             int64_t active_tokens_inline2816_inline12042 = static_cast<int64_t>(nt_inline677__rv_v2);
             int64_t active_tokens_inline2816_inline12042__phi_v4;
             if ((8 < active_tokens_inline2816_inline12042)) {
@@ -3748,7 +3748,7 @@ void hca_moe_block(const GraphTaskArgs &args) {
             params_t260.add_scalar(active_tokens_inline2816_inline12042__phi_v4);
             params_t260.add_scalar(routed_y_buf_ctx);
             params_t260.launch_spec.set_block_num(8);
-            PTO2TaskId params_t260_deps[1];
+            TaskId params_t260_deps[1];
             uint32_t params_t260_deps_count = 0;
             params_t260_deps[params_t260_deps_count++] = _cwait_tid_inline2826_inline11850;
             params_t260.set_dependencies(params_t260_deps, params_t260_deps_count);
@@ -4015,18 +4015,18 @@ void swa_attn_block(const GraphTaskArgs &args) {
         params_t11.launch_spec.set_block_num((t_dim_inline757_inline8959 / 8));
         params_t11.set_allow_early_resolve(true);
         TaskOutputTensors task_11_outs = rt_submit_aiv_task(11, params_t11);
-        PTO2TaskId rms_tid_inline758_inline8904 = task_11_outs.task_id();
-        PTO2TaskId rms_tid_inline8953 = rms_tid_inline758_inline8904;
+        TaskId rms_tid_inline758_inline8904 = task_11_outs.task_id();
+        TaskId rms_tid_inline8953 = rms_tid_inline758_inline8904;
 
         // Phase-fence barrier 0: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_0;
-        PTO2TaskId params_phase_fence_barrier_0_deps[1];
+        TaskId params_phase_fence_barrier_0_deps[1];
         uint32_t params_phase_fence_barrier_0_deps_count = 0;
         params_phase_fence_barrier_0_deps[params_phase_fence_barrier_0_deps_count++] = rms_tid_inline758_inline8904;
         params_phase_fence_barrier_0.set_dependencies(
             params_phase_fence_barrier_0_deps, params_phase_fence_barrier_0_deps_count
         );
-        PTO2TaskId late_dep_inline8961 = PTO2TaskId::invalid();
+        TaskId late_dep_inline8961 = TaskId::invalid();
         if (params_phase_fence_barrier_0_deps_count > 0) {
             TaskOutputTensors phase_fence_barrier_0_outs = rt_submit_dummy_task(params_phase_fence_barrier_0);
             late_dep_inline8961 = phase_fence_barrier_0_outs.task_id();
@@ -4196,7 +4196,7 @@ void swa_attn_block(const GraphTaskArgs &args) {
         params_t18.add_scalar(t_matmul_inline856_inline8847);
         params_t18.add_scalar(t_dim_inline889_inline8972);
         params_t18.launch_spec.set_block_num(16);
-        PTO2TaskId params_t18_deps[1];
+        TaskId params_t18_deps[1];
         uint32_t params_t18_deps_count = 0;
         if (late_dep_inline8961.is_valid()) params_t18_deps[params_t18_deps_count++] = late_dep_inline8961;
         params_t18.set_dependencies(params_t18_deps, params_t18_deps_count);
@@ -4239,12 +4239,12 @@ void swa_attn_block(const GraphTaskArgs &args) {
         };
         ChipTensor ori_kv_flat_inline1033_inline8970 =
             kv_cache_l0_inline603.reshape(ori_kv_flat_inline1033_inline8970_shapes, 2);
-        PTO2TaskId proj_b_tids_inline1013_inline9033[8];
+        TaskId proj_b_tids_inline1013_inline9033[8];
         for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
-            proj_b_tids_inline1013_inline9033[__init_i] = PTO2TaskId::invalid();
-        PTO2TaskId gather_tids_inline1022_inline9089[1];
+            proj_b_tids_inline1013_inline9033[__init_i] = TaskId::invalid();
+        TaskId gather_tids_inline1022_inline9089[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-            gather_tids_inline1022_inline9089[__init_i] = PTO2TaskId::invalid();
+            gather_tids_inline1022_inline9089[__init_i] = TaskId::invalid();
 
         // Spmd swa_gather_kv_spmd: swa_gather_kv
         CoreTaskArgs params_t22;
@@ -4253,17 +4253,17 @@ void swa_attn_block(const GraphTaskArgs &args) {
         params_t22.add_input(ori_kv_flat_inline1033_inline8970);
         params_t22.launch_spec.set_block_num(32);
         TaskOutputTensors task_22_outs = rt_submit_aiv_task(22, params_t22);
-        PTO2TaskId gather_tid_inline1039_inline9091 = task_22_outs.task_id();
+        TaskId gather_tid_inline1039_inline9091 = task_22_outs.task_id();
         gather_tids_inline1022_inline9089[0] = gather_tid_inline1039_inline9091;
         uint32_t q_flat_inline1064_inline8925_shapes[2] = {512, 512};
         ChipTensor q_flat_inline1064_inline8925 = q_inline8956.reshape(q_flat_inline1064_inline8925_shapes, 2);
         uint32_t o_packed_inline1065_inline9106_shapes[2] = {64, 4096};
         ChipTensor o_packed_inline1065_inline9106 =
             o_packed_heads_inline1025_inline8944.reshape(o_packed_inline1065_inline9106_shapes, 2);
-        PTO2TaskId _submit_deps_buf_inline1099_inline9111[1];
+        TaskId _submit_deps_buf_inline1099_inline9111[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-            _submit_deps_buf_inline1099_inline9111[__init_i] = PTO2TaskId::invalid();
-        PTO2TaskId t__tmp_v127 = gather_tids_inline1022_inline9089[0];
+            _submit_deps_buf_inline1099_inline9111[__init_i] = TaskId::invalid();
+        TaskId t__tmp_v127 = gather_tids_inline1022_inline9089[0];
         _submit_deps_buf_inline1099_inline9111[0] = t__tmp_v127;
 
         // Group qk_pv: MixedKernels (AIC + AIV lanes)
@@ -4278,13 +4278,13 @@ void swa_attn_block(const GraphTaskArgs &args) {
         MixedKernels mixed_23 = {23, 24, 24};
         params_t23.launch_spec.set_block_num(8);
         params_t23.set_allow_early_resolve(true);
-        PTO2TaskId params_t23_deps[1];
+        TaskId params_t23_deps[1];
         uint32_t params_t23_deps_count = 0;
         if (_submit_deps_buf_inline1099_inline9111[0].is_valid())
             params_t23_deps[params_t23_deps_count++] = _submit_deps_buf_inline1099_inline9111[0];
         params_t23.set_dependencies(params_t23_deps, params_t23_deps_count);
         TaskOutputTensors task_23_outs = rt_submit_task(mixed_23, params_t23);
-        PTO2TaskId qk_tid_inline993_inline8938 = task_23_outs.task_id();
+        TaskId qk_tid_inline993_inline8938 = task_23_outs.task_id();
 
         // Task 24: rope_cs
         CoreTaskArgs params_t24;
@@ -4294,7 +4294,7 @@ void swa_attn_block(const GraphTaskArgs &args) {
         params_t24.add_input(rope_cos_t_inline8914);
         params_t24.add_input(rope_sin_t_inline8931);
         TaskOutputTensors task_24_outs = rt_submit_aiv_task(25, params_t24);
-        PTO2TaskId rope_tid_inline998_inline8791 = task_24_outs.task_id();
+        TaskId rope_tid_inline998_inline8791 = task_24_outs.task_id();
 
         // Spmd merge_norm_spmd: merge_norm
         CoreTaskArgs params_t25;
@@ -4308,13 +4308,13 @@ void swa_attn_block(const GraphTaskArgs &args) {
         params_t25.add_inout(o_packed_heads_inline1025_inline8944);
         params_t25.launch_spec.set_block_num(32);
         params_t25.set_allow_early_resolve(true);
-        PTO2TaskId params_t25_deps[2];
+        TaskId params_t25_deps[2];
         uint32_t params_t25_deps_count = 0;
         params_t25_deps[params_t25_deps_count++] = qk_tid_inline993_inline8938;
         params_t25_deps[params_t25_deps_count++] = rope_tid_inline998_inline8791;
         params_t25.set_dependencies(params_t25_deps, params_t25_deps_count);
         TaskOutputTensors task_25_outs = rt_submit_aiv_task(26, params_t25);
-        PTO2TaskId merge_tid_inline1108_inline8902 = task_25_outs.task_id();
+        TaskId merge_tid_inline1108_inline8902 = task_25_outs.task_id();
         ChipTensor o_r_pad_inline974_inline8862__rv_v2 = o_r_pad_inline974_inline8862;
         PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
             for (int64_t g_inline978_inline8746 = 0; g_inline978_inline8746 < 8; g_inline978_inline8746 += 1) {
@@ -4331,13 +4331,13 @@ void swa_attn_block(const GraphTaskArgs &args) {
                 params_t26.add_scalar(out_col_g_inline1092_inline8900);
                 params_t26.launch_spec.set_block_num(8);
                 params_t26.set_allow_early_resolve(true);
-                PTO2TaskId params_t26_deps[1];
+                TaskId params_t26_deps[1];
                 uint32_t params_t26_deps_count = 0;
                 params_t26_deps[params_t26_deps_count++] = merge_tid_inline1108_inline8902;
                 params_t26.set_dependencies(params_t26_deps, params_t26_deps_count);
                 TaskOutputTensors task_26_outs = rt_submit_aic_task(27, params_t26);
                 int64_t n0_inline1077_inline8742 = 0;
-                PTO2TaskId pa_tid_inline1023_inline8744 = task_26_outs.task_id();
+                TaskId pa_tid_inline1023_inline8744 = task_26_outs.task_id();
                 int64_t col_g_inline1089_inline8999 = (g_inline978_inline8746 * 1024);
 
                 // Task 27: quant
@@ -4347,13 +4347,13 @@ void swa_attn_block(const GraphTaskArgs &args) {
                 params_t27.add_input(o_r_pad_inline974_inline8862__rv_v2);
                 params_t27.add_scalar(col_g_inline1089_inline8999);
                 params_t27.add_scalar(g_inline978_inline8746);
-                PTO2TaskId params_t27_deps[1];
+                TaskId params_t27_deps[1];
                 uint32_t params_t27_deps_count = 0;
                 params_t27_deps[params_t27_deps_count++] = pa_tid_inline1023_inline8744;
                 params_t27.set_dependencies(params_t27_deps, params_t27_deps_count);
                 params_t27.set_allow_early_resolve(true);
                 TaskOutputTensors task_27_outs = rt_submit_aiv_task(28, params_t27);
-                PTO2TaskId q_tid_inline1085_inline8958 = task_27_outs.task_id();
+                TaskId q_tid_inline1085_inline8958 = task_27_outs.task_id();
 
                 // Spmd proj_b_mm_spmd: proj_b_mm
                 CoreTaskArgs params_t28;
@@ -4365,33 +4365,33 @@ void swa_attn_block(const GraphTaskArgs &args) {
                 params_t28.add_scalar(g_inline978_inline8746);
                 params_t28.launch_spec.set_block_num(8);
                 params_t28.set_allow_early_resolve(true);
-                PTO2TaskId params_t28_deps[1];
+                TaskId params_t28_deps[1];
                 uint32_t params_t28_deps_count = 0;
                 params_t28_deps[params_t28_deps_count++] = q_tid_inline1085_inline8958;
                 params_t28.set_dependencies(params_t28_deps, params_t28_deps_count);
                 TaskOutputTensors task_28_outs = rt_submit_aic_task(29, params_t28);
-                PTO2TaskId pb_tid_inline954_inline8979 = task_28_outs.task_id();
+                TaskId pb_tid_inline954_inline8979 = task_28_outs.task_id();
                 proj_b_tids_inline1013_inline9033[g_inline978_inline8746] = pb_tid_inline954_inline8979;
             }
         }
-        PTO2TaskId _submit_deps_buf_inline949_inline9070[8];
+        TaskId _submit_deps_buf_inline949_inline9070[8];
         for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
-            _submit_deps_buf_inline949_inline9070[__init_i] = PTO2TaskId::invalid();
-        PTO2TaskId t__tmp_v147 = proj_b_tids_inline1013_inline9033[0];
+            _submit_deps_buf_inline949_inline9070[__init_i] = TaskId::invalid();
+        TaskId t__tmp_v147 = proj_b_tids_inline1013_inline9033[0];
         _submit_deps_buf_inline949_inline9070[0] = t__tmp_v147;
-        PTO2TaskId t__tmp_v148 = proj_b_tids_inline1013_inline9033[1];
+        TaskId t__tmp_v148 = proj_b_tids_inline1013_inline9033[1];
         _submit_deps_buf_inline949_inline9070[1] = t__tmp_v148;
-        PTO2TaskId t__tmp_v149 = proj_b_tids_inline1013_inline9033[2];
+        TaskId t__tmp_v149 = proj_b_tids_inline1013_inline9033[2];
         _submit_deps_buf_inline949_inline9070[2] = t__tmp_v149;
-        PTO2TaskId t__tmp_v150 = proj_b_tids_inline1013_inline9033[3];
+        TaskId t__tmp_v150 = proj_b_tids_inline1013_inline9033[3];
         _submit_deps_buf_inline949_inline9070[3] = t__tmp_v150;
-        PTO2TaskId t__tmp_v151 = proj_b_tids_inline1013_inline9033[4];
+        TaskId t__tmp_v151 = proj_b_tids_inline1013_inline9033[4];
         _submit_deps_buf_inline949_inline9070[4] = t__tmp_v151;
-        PTO2TaskId t__tmp_v152 = proj_b_tids_inline1013_inline9033[5];
+        TaskId t__tmp_v152 = proj_b_tids_inline1013_inline9033[5];
         _submit_deps_buf_inline949_inline9070[5] = t__tmp_v152;
-        PTO2TaskId t__tmp_v153 = proj_b_tids_inline1013_inline9033[6];
+        TaskId t__tmp_v153 = proj_b_tids_inline1013_inline9033[6];
         _submit_deps_buf_inline949_inline9070[6] = t__tmp_v153;
-        PTO2TaskId t__tmp_v154 = proj_b_tids_inline1013_inline9033[7];
+        TaskId t__tmp_v154 = proj_b_tids_inline1013_inline9033[7];
         _submit_deps_buf_inline949_inline9070[7] = t__tmp_v154;
 
         // Spmd proj_b_act_spmd: proj_b_act
@@ -4402,7 +4402,7 @@ void swa_attn_block(const GraphTaskArgs &args) {
         params_t29.add_inout(attn_out_inline9085);
         params_t29.launch_spec.set_block_num(8);
         params_t29.set_allow_early_resolve(true);
-        PTO2TaskId params_t29_deps[8];
+        TaskId params_t29_deps[8];
         uint32_t params_t29_deps_count = 0;
         if (_submit_deps_buf_inline949_inline9070[0].is_valid())
             params_t29_deps[params_t29_deps_count++] = _submit_deps_buf_inline949_inline9070[0];
@@ -4690,7 +4690,7 @@ void hash_moe_l0_block(const GraphTaskArgs &args) {
         // Phase-fence barrier 1: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_1;
         TaskOutputTensors phase_fence_barrier_1_outs = rt_submit_dummy_task(params_phase_fence_barrier_1);
-        PTO2TaskId seed_dummy_inline2602_inline9321 = phase_fence_barrier_1_outs.task_id();
+        TaskId seed_dummy_inline2602_inline9321 = phase_fence_barrier_1_outs.task_id();
         for (int64_t t0_inline2605_inline9256 = 0;
              t0_inline2605_inline9256 < active_gate_tokens_inline2604_inline9313__phi_v2;
              t0_inline2605_inline9256 += 8) {
@@ -4700,7 +4700,7 @@ void hash_moe_l0_block(const GraphTaskArgs &args) {
             params_t38.add_output(x_norm_i8_inline9265);
             params_t38.add_input(xg_buf_inline2582_inline9396);
             params_t38.add_scalar(t0_inline2605_inline9256);
-            PTO2TaskId params_t38_deps[1];
+            TaskId params_t38_deps[1];
             uint32_t params_t38_deps_count = 0;
             if (seed_dummy_inline2602_inline9321.is_valid())
                 params_t38_deps[params_t38_deps_count++] = seed_dummy_inline2602_inline9321;
@@ -4859,7 +4859,7 @@ void hash_moe_l0_block(const GraphTaskArgs &args) {
         params_t47.add_scalar(arrived_ctx);
         params_t47.set_allow_early_resolve(true);
         TaskOutputTensors task_47_outs = rt_submit_aiv_task(49, params_t47);
-        PTO2TaskId _meta_tid_inline2705_inline9406 = task_47_outs.task_id();
+        TaskId _meta_tid_inline2705_inline9406 = task_47_outs.task_id();
 
         // Spmd dispatch_push_spmd: dispatch_push
         CoreTaskArgs params_t48;
@@ -4880,7 +4880,7 @@ void hash_moe_l0_block(const GraphTaskArgs &args) {
         params_t48.launch_spec.set_block_num(32);
         params_t48.set_allow_early_resolve(true);
         TaskOutputTensors task_48_outs = rt_submit_aiv_task(50, params_t48);
-        PTO2TaskId _push_tid_inline2710_inline9278 = task_48_outs.task_id();
+        TaskId _push_tid_inline2710_inline9278 = task_48_outs.task_id();
 
         // Task 49: dispatch_wait
         CoreTaskArgs params_t49;
@@ -4888,13 +4888,13 @@ void hash_moe_l0_block(const GraphTaskArgs &args) {
         params_t49.add_input(ext_data_arrived);
         params_t49.add_scalar(my_rank);
         params_t49.add_scalar(data_arrived_ctx);
-        PTO2TaskId params_t49_deps[1];
+        TaskId params_t49_deps[1];
         uint32_t params_t49_deps_count = 0;
         params_t49_deps[params_t49_deps_count++] = _push_tid_inline2710_inline9278;
         params_t49.set_dependencies(params_t49_deps, params_t49_deps_count);
         params_t49.set_allow_early_resolve(true);
         TaskOutputTensors task_49_outs = rt_submit_aiv_task(51, params_t49);
-        PTO2TaskId _wait_tid_inline2685_inline9261 = task_49_outs.task_id();
+        TaskId _wait_tid_inline2685_inline9261 = task_49_outs.task_id();
 
         // Spmd dispatch_gather_spmd: dispatch_gather
         CoreTaskArgs params_t50;
@@ -4910,13 +4910,13 @@ void hash_moe_l0_block(const GraphTaskArgs &args) {
         params_t50.add_scalar(recv_aux_ctx);
         params_t50.add_scalar(recv_route_ctx);
         params_t50.launch_spec.set_block_num(32);
-        PTO2TaskId params_t50_deps[2];
+        TaskId params_t50_deps[2];
         uint32_t params_t50_deps_count = 0;
         params_t50_deps[params_t50_deps_count++] = _wait_tid_inline2685_inline9261;
         params_t50_deps[params_t50_deps_count++] = _meta_tid_inline2705_inline9406;
         params_t50.set_dependencies(params_t50_deps, params_t50_deps_count);
         TaskOutputTensors task_50_outs = rt_submit_aiv_task(52, params_t50);
-        PTO2TaskId dispatch_push_tid_inline9438 = _push_tid_inline2710_inline9278;
+        TaskId dispatch_push_tid_inline9438 = _push_tid_inline2710_inline9278;
         PTO2_SCOPE() {
             uint32_t recv_y_inline9209_ci_shapes[3] = {32, 16, 4096};
             TensorCreateInfo recv_y_inline9209_ci(recv_y_inline9209_ci_shapes, 3, DataType::BFLOAT16);
@@ -5207,20 +5207,20 @@ void hash_moe_l0_block(const GraphTaskArgs &args) {
             params_t57.add_scalar(routed_y_buf_ctx);
             params_t57.launch_spec.set_block_num(32);
             TaskOutputTensors task_57_outs = rt_submit_aiv_task(59, params_t57);
-            PTO2TaskId _combine_tid_inline2817_inline9389 = task_57_outs.task_id();
+            TaskId _combine_tid_inline2817_inline9389 = task_57_outs.task_id();
 
             // Task 58: combine_wait
             CoreTaskArgs params_t58;
             params_t58.add_input(ext_combine_arrived);
             params_t58.add_scalar(my_rank);
             params_t58.add_scalar(combine_arrived_ctx);
-            PTO2TaskId params_t58_deps[2];
+            TaskId params_t58_deps[2];
             uint32_t params_t58_deps_count = 0;
             params_t58_deps[params_t58_deps_count++] = _combine_tid_inline2817_inline9389;
             params_t58_deps[params_t58_deps_count++] = _push_tid_inline2710_inline9278;
             params_t58.set_dependencies(params_t58_deps, params_t58_deps_count);
             TaskOutputTensors task_58_outs = rt_submit_aiv_task(60, params_t58);
-            PTO2TaskId _cwait_tid_inline2826_inline9164 = task_58_outs.task_id();
+            TaskId _cwait_tid_inline2826_inline9164 = task_58_outs.task_id();
             int64_t active_tokens_inline2816_inline9356 = static_cast<int64_t>(nt_inline677__rv_v2);
             int64_t active_tokens_inline2816_inline9356__phi_v4;
             if ((8 < active_tokens_inline2816_inline9356)) {
@@ -5238,7 +5238,7 @@ void hash_moe_l0_block(const GraphTaskArgs &args) {
             params_t59.add_scalar(active_tokens_inline2816_inline9356__phi_v4);
             params_t59.add_scalar(routed_y_buf_ctx);
             params_t59.launch_spec.set_block_num(8);
-            PTO2TaskId params_t59_deps[1];
+            TaskId params_t59_deps[1];
             uint32_t params_t59_deps_count = 0;
             params_t59_deps[params_t59_deps_count++] = _cwait_tid_inline2826_inline9164;
             params_t59.set_dependencies(params_t59_deps, params_t59_deps_count);
@@ -5518,7 +5518,7 @@ void hash_moe_l1_block(const GraphTaskArgs &args) {
         // Phase-fence barrier 3: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_3;
         TaskOutputTensors phase_fence_barrier_3_outs = rt_submit_dummy_task(params_phase_fence_barrier_3);
-        PTO2TaskId seed_dummy_inline2602_inline10083 = phase_fence_barrier_3_outs.task_id();
+        TaskId seed_dummy_inline2602_inline10083 = phase_fence_barrier_3_outs.task_id();
         for (int64_t t0_inline2605_inline10018 = 0;
              t0_inline2605_inline10018 < active_gate_tokens_inline2604_inline10075__phi_v2;
              t0_inline2605_inline10018 += 8) {
@@ -5528,7 +5528,7 @@ void hash_moe_l1_block(const GraphTaskArgs &args) {
             params_t95.add_output(x_norm_i8_inline10027);
             params_t95.add_input(xg_buf_inline2582_inline10158);
             params_t95.add_scalar(t0_inline2605_inline10018);
-            PTO2TaskId params_t95_deps[1];
+            TaskId params_t95_deps[1];
             uint32_t params_t95_deps_count = 0;
             if (seed_dummy_inline2602_inline10083.is_valid())
                 params_t95_deps[params_t95_deps_count++] = seed_dummy_inline2602_inline10083;
@@ -5689,7 +5689,7 @@ void hash_moe_l1_block(const GraphTaskArgs &args) {
         params_t104.add_scalar(arrived_ctx);
         params_t104.set_allow_early_resolve(true);
         TaskOutputTensors task_104_outs = rt_submit_aiv_task(108, params_t104);
-        PTO2TaskId _meta_tid_inline2705_inline10168 = task_104_outs.task_id();
+        TaskId _meta_tid_inline2705_inline10168 = task_104_outs.task_id();
 
         // Spmd dispatch_push_spmd_0: dispatch_push_0
         CoreTaskArgs params_t105;
@@ -5710,7 +5710,7 @@ void hash_moe_l1_block(const GraphTaskArgs &args) {
         params_t105.launch_spec.set_block_num(32);
         params_t105.set_allow_early_resolve(true);
         TaskOutputTensors task_105_outs = rt_submit_aiv_task(109, params_t105);
-        PTO2TaskId _push_tid_inline2710_inline10040 = task_105_outs.task_id();
+        TaskId _push_tid_inline2710_inline10040 = task_105_outs.task_id();
 
         // Task 106: dispatch_wait_0
         CoreTaskArgs params_t106;
@@ -5718,13 +5718,13 @@ void hash_moe_l1_block(const GraphTaskArgs &args) {
         params_t106.add_input(ext_data_arrived);
         params_t106.add_scalar(my_rank);
         params_t106.add_scalar(data_arrived_ctx);
-        PTO2TaskId params_t106_deps[1];
+        TaskId params_t106_deps[1];
         uint32_t params_t106_deps_count = 0;
         params_t106_deps[params_t106_deps_count++] = _push_tid_inline2710_inline10040;
         params_t106.set_dependencies(params_t106_deps, params_t106_deps_count);
         params_t106.set_allow_early_resolve(true);
         TaskOutputTensors task_106_outs = rt_submit_aiv_task(110, params_t106);
-        PTO2TaskId _wait_tid_inline2685_inline10023 = task_106_outs.task_id();
+        TaskId _wait_tid_inline2685_inline10023 = task_106_outs.task_id();
 
         // Spmd dispatch_gather_spmd_0: dispatch_gather_0
         CoreTaskArgs params_t107;
@@ -5740,13 +5740,13 @@ void hash_moe_l1_block(const GraphTaskArgs &args) {
         params_t107.add_scalar(recv_aux_ctx);
         params_t107.add_scalar(recv_route_ctx);
         params_t107.launch_spec.set_block_num(32);
-        PTO2TaskId params_t107_deps[2];
+        TaskId params_t107_deps[2];
         uint32_t params_t107_deps_count = 0;
         params_t107_deps[params_t107_deps_count++] = _wait_tid_inline2685_inline10023;
         params_t107_deps[params_t107_deps_count++] = _meta_tid_inline2705_inline10168;
         params_t107.set_dependencies(params_t107_deps, params_t107_deps_count);
         TaskOutputTensors task_107_outs = rt_submit_aiv_task(111, params_t107);
-        PTO2TaskId dispatch_push_tid_inline10200 = _push_tid_inline2710_inline10040;
+        TaskId dispatch_push_tid_inline10200 = _push_tid_inline2710_inline10040;
         PTO2_SCOPE() {
             uint32_t recv_y_inline9971_ci_shapes[3] = {32, 16, 4096};
             TensorCreateInfo recv_y_inline9971_ci(recv_y_inline9971_ci_shapes, 3, DataType::BFLOAT16);
@@ -6039,20 +6039,20 @@ void hash_moe_l1_block(const GraphTaskArgs &args) {
             params_t114.add_scalar(routed_y_buf_ctx);
             params_t114.launch_spec.set_block_num(32);
             TaskOutputTensors task_114_outs = rt_submit_aiv_task(118, params_t114);
-            PTO2TaskId _combine_tid_inline2817_inline10151 = task_114_outs.task_id();
+            TaskId _combine_tid_inline2817_inline10151 = task_114_outs.task_id();
 
             // Task 115: combine_wait_0
             CoreTaskArgs params_t115;
             params_t115.add_input(ext_combine_arrived);
             params_t115.add_scalar(my_rank);
             params_t115.add_scalar(combine_arrived_ctx);
-            PTO2TaskId params_t115_deps[2];
+            TaskId params_t115_deps[2];
             uint32_t params_t115_deps_count = 0;
             params_t115_deps[params_t115_deps_count++] = _combine_tid_inline2817_inline10151;
             params_t115_deps[params_t115_deps_count++] = _push_tid_inline2710_inline10040;
             params_t115.set_dependencies(params_t115_deps, params_t115_deps_count);
             TaskOutputTensors task_115_outs = rt_submit_aiv_task(119, params_t115);
-            PTO2TaskId _cwait_tid_inline2826_inline9926 = task_115_outs.task_id();
+            TaskId _cwait_tid_inline2826_inline9926 = task_115_outs.task_id();
             int64_t active_tokens_inline2816_inline10118 = static_cast<int64_t>(nt_inline677__rv_v2);
             int64_t active_tokens_inline2816_inline10118__phi_v4;
             if ((8 < active_tokens_inline2816_inline10118)) {
@@ -6070,7 +6070,7 @@ void hash_moe_l1_block(const GraphTaskArgs &args) {
             params_t116.add_scalar(active_tokens_inline2816_inline10118__phi_v4);
             params_t116.add_scalar(routed_y_buf_ctx);
             params_t116.launch_spec.set_block_num(8);
-            PTO2TaskId params_t116_deps[1];
+            TaskId params_t116_deps[1];
             uint32_t params_t116_deps_count = 0;
             params_t116_deps[params_t116_deps_count++] = _cwait_tid_inline2826_inline9926;
             params_t116.set_dependencies(params_t116_deps, params_t116_deps_count);
@@ -8631,7 +8631,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_hc_head_mixes_zero.launch_spec.set_block_num(((t_linear_inline13230 + 15) / 16));
         TaskOutputTensors hc_head_mixes_zero_outs = rt_submit_aiv_task(367, params_hc_head_mixes_zero);
         const ChipTensor &mixes_raw_inline13234 = hc_head_mixes_zero_outs.get_ref(0);
-        PTO2TaskId hc_head_mixes_zero_tid = hc_head_mixes_zero_outs.task_id();
+        TaskId hc_head_mixes_zero_tid = hc_head_mixes_zero_outs.task_id();
 
         // Spmd hc_head_linear_spmd: hc_head_linear
         CoreTaskArgs params_t343;
@@ -8639,7 +8639,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t343.add_input(ext_hc_head_fn);
         params_t343.add_inout(mixes_raw_inline13234);
         params_t343.launch_spec.set_block_num(((t_linear_inline13230 / 16) * 16));
-        PTO2TaskId params_t343_deps[1];
+        TaskId params_t343_deps[1];
         params_t343_deps[0] = hc_head_mixes_zero_tid;
         params_t343.set_dependencies(params_t343_deps, 1);
         rt_submit_aic_task(355, params_t343);
@@ -8687,7 +8687,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t347.add_scalar(my_rank);
         params_t347.add_scalar(lm_head_hidden_done_ctx);
         TaskOutputTensors task_347_outs = rt_submit_aiv_task(359, params_t347);
-        PTO2TaskId _dwait_tid_inline26_inline13309 = task_347_outs.task_id();
+        TaskId _dwait_tid_inline26_inline13309 = task_347_outs.task_id();
 
         // Spmd lm_head_dispatch_gather_spmd: lm_head_dispatch_gather
         CoreTaskArgs params_t348;
@@ -8695,7 +8695,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t348.add_inout(owner_hiddens_inline50_inline13292);
         params_t348.add_scalar(lm_head_hidden_window_ctx);
         params_t348.launch_spec.set_block_num(8);
-        PTO2TaskId params_t348_deps[1];
+        TaskId params_t348_deps[1];
         uint32_t params_t348_deps_count = 0;
         params_t348_deps[params_t348_deps_count++] = _dwait_tid_inline26_inline13309;
         params_t348.set_dependencies(params_t348_deps, params_t348_deps_count);
@@ -8727,7 +8727,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t351.add_scalar(my_rank);
         params_t351.add_scalar(lm_head_logits_done_ctx);
         TaskOutputTensors task_351_outs = rt_submit_aiv_task(363, params_t351);
-        PTO2TaskId _cwait_tid_inline8_inline13331 = task_351_outs.task_id();
+        TaskId _cwait_tid_inline8_inline13331 = task_351_outs.task_id();
 
         // Spmd lm_head_combine_gather_spmd: lm_head_combine_gather
         CoreTaskArgs params_t352;
@@ -8735,7 +8735,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t352.add_input(ext_lm_head_logits_window);
         params_t352.add_scalar(lm_head_logits_window_ctx);
         params_t352.launch_spec.set_block_num(24);
-        PTO2TaskId params_t352_deps[1];
+        TaskId params_t352_deps[1];
         uint32_t params_t352_deps_count = 0;
         params_t352_deps[params_t352_deps_count++] = _cwait_tid_inline8_inline13331;
         params_t352.set_dependencies(params_t352_deps, params_t352_deps_count);

--- a/examples/a2a3/host_build_graph/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
+++ b/examples/a2a3/host_build_graph/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
@@ -124,16 +124,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t0.launch_spec.set_block_num(1);
         params_t0.set_allow_early_resolve(true);
         TaskOutputTensors task_0_outs = rt_submit_aiv_task(0, params_t0);
-        PTO2TaskId tiling_tid_inline0 = task_0_outs.task_id();
-        PTO2TaskId pa_tiling_tid = tiling_tid_inline0;
-        PTO2TaskId prev_out_tid[1];
+        TaskId tiling_tid_inline0 = task_0_outs.task_id();
+        TaskId pa_tiling_tid = tiling_tid_inline0;
+        TaskId prev_out_tid[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-            prev_out_tid[__init_i] = PTO2TaskId::invalid();
+            prev_out_tid[__init_i] = TaskId::invalid();
 
         // Phase-fence barrier 0: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_0;
         TaskOutputTensors phase_fence_barrier_0_outs = rt_submit_dummy_task(params_phase_fence_barrier_0);
-        PTO2TaskId t = phase_fence_barrier_0_outs.task_id();
+        TaskId t = phase_fence_barrier_0_outs.task_id();
         prev_out_tid[0] = t;
         for (int64_t cb0 = 0; cb0 < 16; cb0 += 16) {
             PTO2_SCOPE() {
@@ -143,18 +143,18 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t1.add_input(ext_hidden_states);
                 params_t1.add_scalar(cb0);
                 TaskOutputTensors task_1_outs = rt_submit_aiv_task(1, params_t1);
-                PTO2TaskId ch_tid = task_1_outs.task_id();
+                TaskId ch_tid = task_1_outs.task_id();
                 prev_out_tid[0] = ch_tid;
             }
         }
-        PTO2TaskId prev_normed_tid[1];
+        TaskId prev_normed_tid[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-            prev_normed_tid[__init_i] = PTO2TaskId::invalid();
+            prev_normed_tid[__init_i] = TaskId::invalid();
         PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
-            PTO2TaskId _submit_deps_buf[1];
+            TaskId _submit_deps_buf[1];
             for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                _submit_deps_buf[__init_i] = PTO2TaskId::invalid();
-            PTO2TaskId t__tmp_v3 = prev_out_tid[0];
+                _submit_deps_buf[__init_i] = TaskId::invalid();
+            TaskId t__tmp_v3 = prev_out_tid[0];
             _submit_deps_buf[0] = t__tmp_v3;
 
             // Spmd x_gamma0_spmd: x_gamma0
@@ -164,12 +164,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t2.add_input(ext_input_rms_weight);
             params_t2.launch_spec.set_block_num(5);
             params_t2.set_allow_early_resolve(true);
-            PTO2TaskId params_t2_deps[1];
+            TaskId params_t2_deps[1];
             uint32_t params_t2_deps_count = 0;
             if (_submit_deps_buf[0].is_valid()) params_t2_deps[params_t2_deps_count++] = _submit_deps_buf[0];
             params_t2.set_dependencies(params_t2_deps, params_t2_deps_count);
             TaskOutputTensors task_2_outs = rt_submit_aiv_task(2, params_t2);
-            PTO2TaskId xgamma_tid = task_2_outs.task_id();
+            TaskId xgamma_tid = task_2_outs.task_id();
             prev_normed_tid[0] = xgamma_tid;
         }
         ChipTensor cur__rv_v7 = cur;
@@ -281,7 +281,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     constexpr int64_t layer_hidden_base_inline151 = 0;
                     constexpr int64_t layer_inter_base_inline107 = 0;
                     constexpr int64_t layer_cache_base_inline193 = 0;
-                    PTO2TaskId prev_normed_tid[1] = {normed__rv_v5.owner_task_id};
+                    TaskId prev_normed_tid[1] = {normed__rv_v5.owner_task_id};
 
                     uint32_t inv_rms_states_inline176_ci_shapes[2] = {16, 1};
                     TensorCreateInfo inv_rms_states_inline176_ci(
@@ -333,19 +333,19 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     ChipTensor inv_rms_tile_inline126 = fp32_arena.allocate(inv_rms_tile_inline126_ci);
                     ChipTensor mlp_tile_inline149 = bf16_arena.allocate(mlp_tile_inline149_ci);
 
-                    PTO2TaskId down_tids_inline156[85];
+                    TaskId down_tids_inline156[85];
                     for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
-                        down_tids_inline156[__init_i] = PTO2TaskId::invalid();
+                        down_tids_inline156[__init_i] = TaskId::invalid();
                     PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
                         // Phase-fence barrier 1: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_1;
                         TaskOutputTensors phase_fence_barrier_1_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_1);
-                        PTO2TaskId seed_dummy_inline49 = phase_fence_barrier_1_outs.task_id();
-                        PTO2TaskId prev_normed_seed_deps_inline120[2];
+                        TaskId seed_dummy_inline49 = phase_fence_barrier_1_outs.task_id();
+                        TaskId prev_normed_seed_deps_inline120[2];
                         for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                            prev_normed_seed_deps_inline120[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v7 = prev_normed_tid[0];
+                            prev_normed_seed_deps_inline120[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v7 = prev_normed_tid[0];
                         prev_normed_seed_deps_inline120[0] = t__tmp_v7;
                         prev_normed_seed_deps_inline120[1] = seed_dummy_inline49;
 
@@ -354,20 +354,20 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t3.add_input(attn_out_inline282);
                         params_t3.set_allow_early_resolve(true);
                         TaskOutputTensors task_3_outs = rt_submit_aiv_task(3, params_t3);
-                        PTO2TaskId attn_out_seed_tid_inline116 = task_3_outs.task_id();
-                        PTO2TaskId _submit_deps_buf_inline42[2];
+                        TaskId attn_out_seed_tid_inline116 = task_3_outs.task_id();
+                        TaskId _submit_deps_buf_inline42[2];
                         for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                            _submit_deps_buf_inline42[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v8 = prev_normed_seed_deps_inline120[0];
+                            _submit_deps_buf_inline42[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v8 = prev_normed_seed_deps_inline120[0];
                         _submit_deps_buf_inline42[0] = t__tmp_v8;
-                        PTO2TaskId t__tmp_v9 = prev_normed_seed_deps_inline120[1];
+                        TaskId t__tmp_v9 = prev_normed_seed_deps_inline120[1];
                         _submit_deps_buf_inline42[1] = t__tmp_v9;
 
                         // Task 4: rms_recip
                         CoreTaskArgs params_t4;
                         params_t4.add_input(cur__rv_v7);
                         params_t4.add_inout(inv_rms_states_inline176);
-                        PTO2TaskId params_t4_deps[2];
+                        TaskId params_t4_deps[2];
                         uint32_t params_t4_deps_count = 0;
                         if (_submit_deps_buf_inline42[0].is_valid())
                             params_t4_deps[params_t4_deps_count++] = _submit_deps_buf_inline42[0];
@@ -376,26 +376,26 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t4.set_dependencies(params_t4_deps, params_t4_deps_count);
                         params_t4.set_allow_early_resolve(true);
                         TaskOutputTensors task_4_outs = rt_submit_aiv_task(4, params_t4);
-                        PTO2TaskId rms_tid_inline148 = task_4_outs.task_id();
+                        TaskId rms_tid_inline148 = task_4_outs.task_id();
 
                         // Task 5: q_seed
                         CoreTaskArgs params_t5;
                         params_t5.add_inout(q_proj_inline139);
                         params_t5.set_allow_early_resolve(true);
                         TaskOutputTensors task_5_outs = rt_submit_aiv_task(5, params_t5);
-                        PTO2TaskId q_seed_tid_inline162 = task_5_outs.task_id();
-                        PTO2TaskId prev_normed_q_deps_inline105[2];
+                        TaskId q_seed_tid_inline162 = task_5_outs.task_id();
+                        TaskId prev_normed_q_deps_inline105[2];
                         for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                            prev_normed_q_deps_inline105[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v17 = prev_normed_tid[0];
+                            prev_normed_q_deps_inline105[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v17 = prev_normed_tid[0];
                         prev_normed_q_deps_inline105[0] = t__tmp_v17;
                         prev_normed_q_deps_inline105[1] = q_seed_tid_inline162;
-                        PTO2TaskId _submit_deps_buf_inline182[2];
+                        TaskId _submit_deps_buf_inline182[2];
                         for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                            _submit_deps_buf_inline182[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v18 = prev_normed_q_deps_inline105[0];
+                            _submit_deps_buf_inline182[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v18 = prev_normed_q_deps_inline105[0];
                         _submit_deps_buf_inline182[0] = t__tmp_v18;
-                        PTO2TaskId t__tmp_v19 = prev_normed_q_deps_inline105[1];
+                        TaskId t__tmp_v19 = prev_normed_q_deps_inline105[1];
                         _submit_deps_buf_inline182[1] = t__tmp_v19;
 
                         // Spmd q_proj_spmd: q_proj
@@ -406,7 +406,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t6.add_scalar(layer_hidden_base_inline151);
                         params_t6.launch_spec.set_block_num(50);
                         params_t6.set_allow_early_resolve(true);
-                        PTO2TaskId params_t6_deps[2];
+                        TaskId params_t6_deps[2];
                         uint32_t params_t6_deps_count = 0;
                         if (_submit_deps_buf_inline182[0].is_valid())
                             params_t6_deps[params_t6_deps_count++] = _submit_deps_buf_inline182[0];
@@ -414,20 +414,20 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t6_deps[params_t6_deps_count++] = _submit_deps_buf_inline182[1];
                         params_t6.set_dependencies(params_t6_deps, params_t6_deps_count);
                         TaskOutputTensors task_6_outs = rt_submit_aic_task(6, params_t6);
-                        PTO2TaskId q_proj_tid_inline183 = task_6_outs.task_id();
-                        PTO2TaskId _submit_deps_buf_inline261[2];
+                        TaskId q_proj_tid_inline183 = task_6_outs.task_id();
+                        TaskId _submit_deps_buf_inline261[2];
                         for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                            _submit_deps_buf_inline261[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v24 = prev_normed_seed_deps_inline120[0];
+                            _submit_deps_buf_inline261[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v24 = prev_normed_seed_deps_inline120[0];
                         _submit_deps_buf_inline261[0] = t__tmp_v24;
-                        PTO2TaskId t__tmp_v25 = prev_normed_seed_deps_inline120[1];
+                        TaskId t__tmp_v25 = prev_normed_seed_deps_inline120[1];
                         _submit_deps_buf_inline261[1] = t__tmp_v25;
 
                         // Task 7: kv_seed
                         CoreTaskArgs params_t7;
                         params_t7.add_inout(k_proj_inline135);
                         params_t7.add_inout(v_proj_inline255);
-                        PTO2TaskId params_t7_deps[2];
+                        TaskId params_t7_deps[2];
                         uint32_t params_t7_deps_count = 0;
                         if (_submit_deps_buf_inline261[0].is_valid())
                             params_t7_deps[params_t7_deps_count++] = _submit_deps_buf_inline261[0];
@@ -435,13 +435,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t7_deps[params_t7_deps_count++] = _submit_deps_buf_inline261[1];
                         params_t7.set_dependencies(params_t7_deps, params_t7_deps_count);
                         TaskOutputTensors task_7_outs = rt_submit_aiv_task(7, params_t7);
-                        PTO2TaskId kv_seed_tid_inline238 = task_7_outs.task_id();
-                        PTO2TaskId _submit_deps_buf_inline267[2];
+                        TaskId kv_seed_tid_inline238 = task_7_outs.task_id();
+                        TaskId _submit_deps_buf_inline267[2];
                         for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                            _submit_deps_buf_inline267[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v28 = prev_normed_seed_deps_inline120[0];
+                            _submit_deps_buf_inline267[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v28 = prev_normed_seed_deps_inline120[0];
                         _submit_deps_buf_inline267[0] = t__tmp_v28;
-                        PTO2TaskId t__tmp_v29 = prev_normed_seed_deps_inline120[1];
+                        TaskId t__tmp_v29 = prev_normed_seed_deps_inline120[1];
                         _submit_deps_buf_inline267[1] = t__tmp_v29;
 
                         // Task 8: mlp_out_seed
@@ -450,7 +450,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t8.add_inout(gate_acc_all_inline203);
                         params_t8.add_inout(up_acc_all_inline303);
                         params_t8.add_inout(attn_proj_fp32_inline220);
-                        PTO2TaskId params_t8_deps[2];
+                        TaskId params_t8_deps[2];
                         uint32_t params_t8_deps_count = 0;
                         if (_submit_deps_buf_inline267[0].is_valid())
                             params_t8_deps[params_t8_deps_count++] = _submit_deps_buf_inline267[0];
@@ -459,7 +459,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t8.set_dependencies(params_t8_deps, params_t8_deps_count);
                         params_t8.set_allow_early_resolve(true);
                         TaskOutputTensors task_8_outs = rt_submit_aiv_task(8, params_t8);
-                        PTO2TaskId mlp_out_seed_tid_inline206 = task_8_outs.task_id();
+                        TaskId mlp_out_seed_tid_inline206 = task_8_outs.task_id();
 
                         // Spmd k_proj_spmd: k_proj
                         CoreTaskArgs params_t9;
@@ -469,12 +469,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t9.add_scalar(layer_hidden_base_inline151);
                         params_t9.launch_spec.set_block_num(10);
                         params_t9.set_allow_early_resolve(true);
-                        PTO2TaskId params_t9_deps[1];
+                        TaskId params_t9_deps[1];
                         uint32_t params_t9_deps_count = 0;
                         params_t9_deps[params_t9_deps_count++] = kv_seed_tid_inline238;
                         params_t9.set_dependencies(params_t9_deps, params_t9_deps_count);
                         TaskOutputTensors task_9_outs = rt_submit_aic_task(9, params_t9);
-                        PTO2TaskId k_proj_tid_inline136 = task_9_outs.task_id();
+                        TaskId k_proj_tid_inline136 = task_9_outs.task_id();
 
                         // Spmd v_proj_spmd: v_proj
                         CoreTaskArgs params_t10;
@@ -484,12 +484,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t10.add_scalar(layer_hidden_base_inline151);
                         params_t10.launch_spec.set_block_num(10);
                         params_t10.set_allow_early_resolve(true);
-                        PTO2TaskId params_t10_deps[1];
+                        TaskId params_t10_deps[1];
                         uint32_t params_t10_deps_count = 0;
                         params_t10_deps[params_t10_deps_count++] = kv_seed_tid_inline238;
                         params_t10.set_dependencies(params_t10_deps, params_t10_deps_count);
                         TaskOutputTensors task_10_outs = rt_submit_aic_task(10, params_t10);
-                        PTO2TaskId v_proj_tid_inline63 = task_10_outs.task_id();
+                        TaskId v_proj_tid_inline63 = task_10_outs.task_id();
                         uint32_t q_tnd_inline191_shapes[3] = {16, 40, 128};
                         ChipTensor q_tnd_inline191 = q_tnd_flat_inline127.reshape(q_tnd_inline191_shapes, 3);
                         uint32_t attn_out_tnd_inline79_shapes[3] = {16, 40, 128};
@@ -520,7 +520,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t11.launch_spec.set_block_num(attention_core_num_inline188);
                         params_t11.launch_spec.set_require_sync_start(true);
                         params_t11.set_allow_early_resolve(true);
-                        PTO2TaskId params_t11_deps[7];
+                        TaskId params_t11_deps[7];
                         uint32_t params_t11_deps_count = 0;
                         params_t11_deps[params_t11_deps_count++] = q_proj_tid_inline183;
                         params_t11_deps[params_t11_deps_count++] = k_proj_tid_inline136;
@@ -531,42 +531,42 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t11.set_dependencies(params_t11_deps, params_t11_deps_count);
                         TaskOutputTensors task_11_outs = rt_submit_task(mixed_11, params_t11);
                         const ChipTensor &attn_out_tnd_inline79__ssa_v1 = attn_out_tnd_inline79;
-                        PTO2TaskId attn_done_tid_inline78 = task_11_outs.task_id();
+                        TaskId attn_done_tid_inline78 = task_11_outs.task_id();
                         uint32_t attn_out_inline282__ssa_v4_shapes[2] = {16, 5120};
                         ChipTensor attn_out_inline282__ssa_v4 =
                             attn_out_tnd_inline79__ssa_v1.reshape(attn_out_inline282__ssa_v4_shapes, 2);
-                        PTO2TaskId silu_tids_inline265[17];
+                        TaskId silu_tids_inline265[17];
                         for (int64_t __init_i = 0; __init_i < 17; ++__init_i)
-                            silu_tids_inline265[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId gate_tids_inline56[85];
+                            silu_tids_inline265[__init_i] = TaskId::invalid();
+                        TaskId gate_tids_inline56[85];
                         for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
-                            gate_tids_inline56[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId up_tids_inline310[85];
+                            gate_tids_inline56[__init_i] = TaskId::invalid();
+                        TaskId up_tids_inline310[85];
                         for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
-                            up_tids_inline310[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId cast_tids_inline88[5];
+                            up_tids_inline310[__init_i] = TaskId::invalid();
+                        TaskId cast_tids_inline88[5];
                         for (int64_t __init_i = 0; __init_i < 5; ++__init_i)
-                            cast_tids_inline88[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId gate_late_tids_inline249[5];
+                            cast_tids_inline88[__init_i] = TaskId::invalid();
+                        TaskId gate_late_tids_inline249[5];
                         for (int64_t __init_i = 0; __init_i < 5; ++__init_i)
-                            gate_late_tids_inline249[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId up_late_tids_inline69[5];
+                            gate_late_tids_inline249[__init_i] = TaskId::invalid();
+                        TaskId up_late_tids_inline69[5];
                         for (int64_t __init_i = 0; __init_i < 5; ++__init_i)
-                            up_late_tids_inline69[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId out_tids_inline271[50];
+                            up_late_tids_inline69[__init_i] = TaskId::invalid();
+                        TaskId out_tids_inline271[50];
                         for (int64_t __init_i = 0; __init_i < 50; ++__init_i)
-                            out_tids_inline271[__init_i] = PTO2TaskId::invalid();
+                            out_tids_inline271[__init_i] = TaskId::invalid();
 
                         // Phase-fence barrier 2: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_2;
-                        PTO2TaskId params_phase_fence_barrier_2_deps[1];
+                        TaskId params_phase_fence_barrier_2_deps[1];
                         uint32_t params_phase_fence_barrier_2_deps_count = 0;
                         params_phase_fence_barrier_2_deps[params_phase_fence_barrier_2_deps_count++] =
                             attn_done_tid_inline78;
                         params_phase_fence_barrier_2.set_dependencies(
                             params_phase_fence_barrier_2_deps, params_phase_fence_barrier_2_deps_count
                         );
-                        PTO2TaskId out_proj_dummy_inline257 = PTO2TaskId::invalid();
+                        TaskId out_proj_dummy_inline257 = TaskId::invalid();
                         if (params_phase_fence_barrier_2_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_2_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_2);
@@ -588,13 +588,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t12.add_scalar(k_op_inline266);
                             params_t12.add_scalar(layer_hidden_base_inline151);
                             params_t12.add_scalar(n_op_inline64);
-                            PTO2TaskId params_t12_deps[1];
+                            TaskId params_t12_deps[1];
                             uint32_t params_t12_deps_count = 0;
                             if (out_proj_dummy_inline257.is_valid())
                                 params_t12_deps[params_t12_deps_count++] = out_proj_dummy_inline257;
                             params_t12.set_dependencies(params_t12_deps, params_t12_deps_count);
                             TaskOutputTensors task_12_outs = rt_submit_aic_task(13, params_t12);
-                            PTO2TaskId out_tid_inline141 = task_12_outs.task_id();
+                            TaskId out_tid_inline141 = task_12_outs.task_id();
                             out_tids_inline271[out_idx_inline74] = out_tid_inline141;
                         }
 
@@ -606,12 +606,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t13.add_scalar(N_OUT_DIRECT_inline61);
                         params_t13.add_scalar(layer_hidden_base_inline151);
                         params_t13.launch_spec.set_block_num(24);
-                        PTO2TaskId params_t13_deps[1];
+                        TaskId params_t13_deps[1];
                         uint32_t params_t13_deps_count = 0;
                         params_t13_deps[params_t13_deps_count++] = attn_done_tid_inline78;
                         params_t13.set_dependencies(params_t13_deps, params_t13_deps_count);
                         TaskOutputTensors task_13_outs = rt_submit_aic_task(14, params_t13);
-                        PTO2TaskId out_proj_direct_tid_inline70 = task_13_outs.task_id();
+                        TaskId out_proj_direct_tid_inline70 = task_13_outs.task_id();
                         out_tids_inline271[N_OUT_DIRECT_inline61] = out_proj_direct_tid_inline70;
                         out_tids_inline271[(N_OUT_DIRECT_inline61 + 1)] = out_proj_direct_tid_inline70;
                         out_tids_inline271[(N_OUT_DIRECT_inline61 + 2)] = out_proj_direct_tid_inline70;
@@ -638,28 +638,28 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         out_tids_inline271[(N_OUT_DIRECT_inline61 + 23)] = out_proj_direct_tid_inline70;
                         int64_t k_base_inline111 = 0;
                         int64_t n_split_base_inline163 = 0;
-                        PTO2TaskId _submit_deps_buf_inline165[10];
+                        TaskId _submit_deps_buf_inline165[10];
                         for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                            _submit_deps_buf_inline165[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v39 = out_tids_inline271[(n_split_base_inline163 * 5)];
+                            _submit_deps_buf_inline165[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v39 = out_tids_inline271[(n_split_base_inline163 * 5)];
                         _submit_deps_buf_inline165[0] = t__tmp_v39;
-                        PTO2TaskId t__tmp_v40 = out_tids_inline271[((n_split_base_inline163 * 5) + 1)];
+                        TaskId t__tmp_v40 = out_tids_inline271[((n_split_base_inline163 * 5) + 1)];
                         _submit_deps_buf_inline165[1] = t__tmp_v40;
-                        PTO2TaskId t__tmp_v41 = out_tids_inline271[((n_split_base_inline163 * 5) + 2)];
+                        TaskId t__tmp_v41 = out_tids_inline271[((n_split_base_inline163 * 5) + 2)];
                         _submit_deps_buf_inline165[2] = t__tmp_v41;
-                        PTO2TaskId t__tmp_v42 = out_tids_inline271[((n_split_base_inline163 * 5) + 3)];
+                        TaskId t__tmp_v42 = out_tids_inline271[((n_split_base_inline163 * 5) + 3)];
                         _submit_deps_buf_inline165[3] = t__tmp_v42;
-                        PTO2TaskId t__tmp_v43 = out_tids_inline271[((n_split_base_inline163 * 5) + 4)];
+                        TaskId t__tmp_v43 = out_tids_inline271[((n_split_base_inline163 * 5) + 4)];
                         _submit_deps_buf_inline165[4] = t__tmp_v43;
-                        PTO2TaskId t__tmp_v44 = out_tids_inline271[((n_split_base_inline163 * 5) + 5)];
+                        TaskId t__tmp_v44 = out_tids_inline271[((n_split_base_inline163 * 5) + 5)];
                         _submit_deps_buf_inline165[5] = t__tmp_v44;
-                        PTO2TaskId t__tmp_v45 = out_tids_inline271[((n_split_base_inline163 * 5) + 6)];
+                        TaskId t__tmp_v45 = out_tids_inline271[((n_split_base_inline163 * 5) + 6)];
                         _submit_deps_buf_inline165[6] = t__tmp_v45;
-                        PTO2TaskId t__tmp_v46 = out_tids_inline271[((n_split_base_inline163 * 5) + 7)];
+                        TaskId t__tmp_v46 = out_tids_inline271[((n_split_base_inline163 * 5) + 7)];
                         _submit_deps_buf_inline165[7] = t__tmp_v46;
-                        PTO2TaskId t__tmp_v47 = out_tids_inline271[((n_split_base_inline163 * 5) + 8)];
+                        TaskId t__tmp_v47 = out_tids_inline271[((n_split_base_inline163 * 5) + 8)];
                         _submit_deps_buf_inline165[8] = t__tmp_v47;
-                        PTO2TaskId t__tmp_v48 = out_tids_inline271[((n_split_base_inline163 * 5) + 9)];
+                        TaskId t__tmp_v48 = out_tids_inline271[((n_split_base_inline163 * 5) + 9)];
                         _submit_deps_buf_inline165[9] = t__tmp_v48;
 
                         // Task 14: residual_rms_cast
@@ -671,7 +671,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t14.add_input(ext_post_rms_weight);
                         params_t14.add_scalar(k_base_inline111);
                         params_t14.add_scalar(i);
-                        PTO2TaskId params_t14_deps[10];
+                        TaskId params_t14_deps[10];
                         uint32_t params_t14_deps_count = 0;
                         if (_submit_deps_buf_inline165[0].is_valid())
                             params_t14_deps[params_t14_deps_count++] = _submit_deps_buf_inline165[0];
@@ -696,32 +696,32 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t14.set_dependencies(params_t14_deps, params_t14_deps_count);
                         params_t14.set_allow_early_resolve(true);
                         TaskOutputTensors task_14_outs = rt_submit_aiv_task(15, params_t14);
-                        PTO2TaskId cast_tid_k_inline76 = task_14_outs.task_id();
+                        TaskId cast_tid_k_inline76 = task_14_outs.task_id();
                         cast_tids_inline88[0] = cast_tid_k_inline76;
                         int64_t k_base_inline111__ssa_v1 = 1024;
                         int64_t n_split_base_inline163__ssa_v1 = 2;
-                        PTO2TaskId _submit_deps_buf_inline165__ssa_v1[10];
+                        TaskId _submit_deps_buf_inline165__ssa_v1[10];
                         for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                            _submit_deps_buf_inline165__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v51 = out_tids_inline271[(n_split_base_inline163__ssa_v1 * 5)];
+                            _submit_deps_buf_inline165__ssa_v1[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v51 = out_tids_inline271[(n_split_base_inline163__ssa_v1 * 5)];
                         _submit_deps_buf_inline165__ssa_v1[0] = t__tmp_v51;
-                        PTO2TaskId t__tmp_v52 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 1)];
+                        TaskId t__tmp_v52 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 1)];
                         _submit_deps_buf_inline165__ssa_v1[1] = t__tmp_v52;
-                        PTO2TaskId t__tmp_v53 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 2)];
+                        TaskId t__tmp_v53 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 2)];
                         _submit_deps_buf_inline165__ssa_v1[2] = t__tmp_v53;
-                        PTO2TaskId t__tmp_v54 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 3)];
+                        TaskId t__tmp_v54 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 3)];
                         _submit_deps_buf_inline165__ssa_v1[3] = t__tmp_v54;
-                        PTO2TaskId t__tmp_v55 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 4)];
+                        TaskId t__tmp_v55 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 4)];
                         _submit_deps_buf_inline165__ssa_v1[4] = t__tmp_v55;
-                        PTO2TaskId t__tmp_v56 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 5)];
+                        TaskId t__tmp_v56 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 5)];
                         _submit_deps_buf_inline165__ssa_v1[5] = t__tmp_v56;
-                        PTO2TaskId t__tmp_v57 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 6)];
+                        TaskId t__tmp_v57 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 6)];
                         _submit_deps_buf_inline165__ssa_v1[6] = t__tmp_v57;
-                        PTO2TaskId t__tmp_v58 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 7)];
+                        TaskId t__tmp_v58 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 7)];
                         _submit_deps_buf_inline165__ssa_v1[7] = t__tmp_v58;
-                        PTO2TaskId t__tmp_v59 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 8)];
+                        TaskId t__tmp_v59 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 8)];
                         _submit_deps_buf_inline165__ssa_v1[8] = t__tmp_v59;
-                        PTO2TaskId t__tmp_v60 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 9)];
+                        TaskId t__tmp_v60 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 9)];
                         _submit_deps_buf_inline165__ssa_v1[9] = t__tmp_v60;
 
                         // Task 15: residual_rms_cast_0
@@ -733,7 +733,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t15.add_input(ext_post_rms_weight);
                         params_t15.add_scalar(k_base_inline111__ssa_v1);
                         params_t15.add_scalar(i);
-                        PTO2TaskId params_t15_deps[10];
+                        TaskId params_t15_deps[10];
                         uint32_t params_t15_deps_count = 0;
                         if (_submit_deps_buf_inline165__ssa_v1[0].is_valid())
                             params_t15_deps[params_t15_deps_count++] = _submit_deps_buf_inline165__ssa_v1[0];
@@ -758,32 +758,32 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t15.set_dependencies(params_t15_deps, params_t15_deps_count);
                         params_t15.set_allow_early_resolve(true);
                         TaskOutputTensors task_15_outs = rt_submit_aiv_task(16, params_t15);
-                        PTO2TaskId cast_tid_k_inline76__ssa_v1 = task_15_outs.task_id();
+                        TaskId cast_tid_k_inline76__ssa_v1 = task_15_outs.task_id();
                         cast_tids_inline88[1] = cast_tid_k_inline76__ssa_v1;
                         int64_t k_base_inline111__ssa_v2 = 2048;
                         int64_t n_split_base_inline163__ssa_v2 = 4;
-                        PTO2TaskId _submit_deps_buf_inline165__ssa_v2[10];
+                        TaskId _submit_deps_buf_inline165__ssa_v2[10];
                         for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                            _submit_deps_buf_inline165__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v63 = out_tids_inline271[(n_split_base_inline163__ssa_v2 * 5)];
+                            _submit_deps_buf_inline165__ssa_v2[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v63 = out_tids_inline271[(n_split_base_inline163__ssa_v2 * 5)];
                         _submit_deps_buf_inline165__ssa_v2[0] = t__tmp_v63;
-                        PTO2TaskId t__tmp_v64 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 1)];
+                        TaskId t__tmp_v64 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 1)];
                         _submit_deps_buf_inline165__ssa_v2[1] = t__tmp_v64;
-                        PTO2TaskId t__tmp_v65 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 2)];
+                        TaskId t__tmp_v65 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 2)];
                         _submit_deps_buf_inline165__ssa_v2[2] = t__tmp_v65;
-                        PTO2TaskId t__tmp_v66 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 3)];
+                        TaskId t__tmp_v66 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 3)];
                         _submit_deps_buf_inline165__ssa_v2[3] = t__tmp_v66;
-                        PTO2TaskId t__tmp_v67 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 4)];
+                        TaskId t__tmp_v67 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 4)];
                         _submit_deps_buf_inline165__ssa_v2[4] = t__tmp_v67;
-                        PTO2TaskId t__tmp_v68 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 5)];
+                        TaskId t__tmp_v68 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 5)];
                         _submit_deps_buf_inline165__ssa_v2[5] = t__tmp_v68;
-                        PTO2TaskId t__tmp_v69 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 6)];
+                        TaskId t__tmp_v69 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 6)];
                         _submit_deps_buf_inline165__ssa_v2[6] = t__tmp_v69;
-                        PTO2TaskId t__tmp_v70 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 7)];
+                        TaskId t__tmp_v70 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 7)];
                         _submit_deps_buf_inline165__ssa_v2[7] = t__tmp_v70;
-                        PTO2TaskId t__tmp_v71 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 8)];
+                        TaskId t__tmp_v71 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 8)];
                         _submit_deps_buf_inline165__ssa_v2[8] = t__tmp_v71;
-                        PTO2TaskId t__tmp_v72 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 9)];
+                        TaskId t__tmp_v72 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 9)];
                         _submit_deps_buf_inline165__ssa_v2[9] = t__tmp_v72;
 
                         // Task 16: residual_rms_cast_1
@@ -795,7 +795,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t16.add_input(ext_post_rms_weight);
                         params_t16.add_scalar(k_base_inline111__ssa_v2);
                         params_t16.add_scalar(i);
-                        PTO2TaskId params_t16_deps[10];
+                        TaskId params_t16_deps[10];
                         uint32_t params_t16_deps_count = 0;
                         if (_submit_deps_buf_inline165__ssa_v2[0].is_valid())
                             params_t16_deps[params_t16_deps_count++] = _submit_deps_buf_inline165__ssa_v2[0];
@@ -820,32 +820,32 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t16.set_dependencies(params_t16_deps, params_t16_deps_count);
                         params_t16.set_allow_early_resolve(true);
                         TaskOutputTensors task_16_outs = rt_submit_aiv_task(17, params_t16);
-                        PTO2TaskId cast_tid_k_inline76__ssa_v2 = task_16_outs.task_id();
+                        TaskId cast_tid_k_inline76__ssa_v2 = task_16_outs.task_id();
                         cast_tids_inline88[2] = cast_tid_k_inline76__ssa_v2;
                         int64_t k_base_inline111__ssa_v3 = 3072;
                         int64_t n_split_base_inline163__ssa_v3 = 6;
-                        PTO2TaskId _submit_deps_buf_inline165__ssa_v3[10];
+                        TaskId _submit_deps_buf_inline165__ssa_v3[10];
                         for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                            _submit_deps_buf_inline165__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v75 = out_tids_inline271[(n_split_base_inline163__ssa_v3 * 5)];
+                            _submit_deps_buf_inline165__ssa_v3[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v75 = out_tids_inline271[(n_split_base_inline163__ssa_v3 * 5)];
                         _submit_deps_buf_inline165__ssa_v3[0] = t__tmp_v75;
-                        PTO2TaskId t__tmp_v76 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 1)];
+                        TaskId t__tmp_v76 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 1)];
                         _submit_deps_buf_inline165__ssa_v3[1] = t__tmp_v76;
-                        PTO2TaskId t__tmp_v77 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 2)];
+                        TaskId t__tmp_v77 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 2)];
                         _submit_deps_buf_inline165__ssa_v3[2] = t__tmp_v77;
-                        PTO2TaskId t__tmp_v78 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 3)];
+                        TaskId t__tmp_v78 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 3)];
                         _submit_deps_buf_inline165__ssa_v3[3] = t__tmp_v78;
-                        PTO2TaskId t__tmp_v79 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 4)];
+                        TaskId t__tmp_v79 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 4)];
                         _submit_deps_buf_inline165__ssa_v3[4] = t__tmp_v79;
-                        PTO2TaskId t__tmp_v80 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 5)];
+                        TaskId t__tmp_v80 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 5)];
                         _submit_deps_buf_inline165__ssa_v3[5] = t__tmp_v80;
-                        PTO2TaskId t__tmp_v81 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 6)];
+                        TaskId t__tmp_v81 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 6)];
                         _submit_deps_buf_inline165__ssa_v3[6] = t__tmp_v81;
-                        PTO2TaskId t__tmp_v82 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 7)];
+                        TaskId t__tmp_v82 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 7)];
                         _submit_deps_buf_inline165__ssa_v3[7] = t__tmp_v82;
-                        PTO2TaskId t__tmp_v83 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 8)];
+                        TaskId t__tmp_v83 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 8)];
                         _submit_deps_buf_inline165__ssa_v3[8] = t__tmp_v83;
-                        PTO2TaskId t__tmp_v84 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 9)];
+                        TaskId t__tmp_v84 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 9)];
                         _submit_deps_buf_inline165__ssa_v3[9] = t__tmp_v84;
 
                         // Task 17: residual_rms_cast_2
@@ -857,7 +857,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t17.add_input(ext_post_rms_weight);
                         params_t17.add_scalar(k_base_inline111__ssa_v3);
                         params_t17.add_scalar(i);
-                        PTO2TaskId params_t17_deps[10];
+                        TaskId params_t17_deps[10];
                         uint32_t params_t17_deps_count = 0;
                         if (_submit_deps_buf_inline165__ssa_v3[0].is_valid())
                             params_t17_deps[params_t17_deps_count++] = _submit_deps_buf_inline165__ssa_v3[0];
@@ -882,32 +882,32 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t17.set_dependencies(params_t17_deps, params_t17_deps_count);
                         params_t17.set_allow_early_resolve(true);
                         TaskOutputTensors task_17_outs = rt_submit_aiv_task(18, params_t17);
-                        PTO2TaskId cast_tid_k_inline76__ssa_v3 = task_17_outs.task_id();
+                        TaskId cast_tid_k_inline76__ssa_v3 = task_17_outs.task_id();
                         cast_tids_inline88[3] = cast_tid_k_inline76__ssa_v3;
                         int64_t k_base_inline111__ssa_v4 = 4096;
                         int64_t n_split_base_inline163__ssa_v4 = 8;
-                        PTO2TaskId _submit_deps_buf_inline165__ssa_v4[10];
+                        TaskId _submit_deps_buf_inline165__ssa_v4[10];
                         for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                            _submit_deps_buf_inline165__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v87 = out_tids_inline271[(n_split_base_inline163__ssa_v4 * 5)];
+                            _submit_deps_buf_inline165__ssa_v4[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v87 = out_tids_inline271[(n_split_base_inline163__ssa_v4 * 5)];
                         _submit_deps_buf_inline165__ssa_v4[0] = t__tmp_v87;
-                        PTO2TaskId t__tmp_v88 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 1)];
+                        TaskId t__tmp_v88 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 1)];
                         _submit_deps_buf_inline165__ssa_v4[1] = t__tmp_v88;
-                        PTO2TaskId t__tmp_v89 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 2)];
+                        TaskId t__tmp_v89 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 2)];
                         _submit_deps_buf_inline165__ssa_v4[2] = t__tmp_v89;
-                        PTO2TaskId t__tmp_v90 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 3)];
+                        TaskId t__tmp_v90 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 3)];
                         _submit_deps_buf_inline165__ssa_v4[3] = t__tmp_v90;
-                        PTO2TaskId t__tmp_v91 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 4)];
+                        TaskId t__tmp_v91 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 4)];
                         _submit_deps_buf_inline165__ssa_v4[4] = t__tmp_v91;
-                        PTO2TaskId t__tmp_v92 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 5)];
+                        TaskId t__tmp_v92 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 5)];
                         _submit_deps_buf_inline165__ssa_v4[5] = t__tmp_v92;
-                        PTO2TaskId t__tmp_v93 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 6)];
+                        TaskId t__tmp_v93 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 6)];
                         _submit_deps_buf_inline165__ssa_v4[6] = t__tmp_v93;
-                        PTO2TaskId t__tmp_v94 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 7)];
+                        TaskId t__tmp_v94 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 7)];
                         _submit_deps_buf_inline165__ssa_v4[7] = t__tmp_v94;
-                        PTO2TaskId t__tmp_v95 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 8)];
+                        TaskId t__tmp_v95 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 8)];
                         _submit_deps_buf_inline165__ssa_v4[8] = t__tmp_v95;
-                        PTO2TaskId t__tmp_v96 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 9)];
+                        TaskId t__tmp_v96 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 9)];
                         _submit_deps_buf_inline165__ssa_v4[9] = t__tmp_v96;
 
                         // Task 18: residual_rms_cast_3
@@ -919,7 +919,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t18.add_input(ext_post_rms_weight);
                         params_t18.add_scalar(k_base_inline111__ssa_v4);
                         params_t18.add_scalar(i);
-                        PTO2TaskId params_t18_deps[10];
+                        TaskId params_t18_deps[10];
                         uint32_t params_t18_deps_count = 0;
                         if (_submit_deps_buf_inline165__ssa_v4[0].is_valid())
                             params_t18_deps[params_t18_deps_count++] = _submit_deps_buf_inline165__ssa_v4[0];
@@ -944,7 +944,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t18.set_dependencies(params_t18_deps, params_t18_deps_count);
                         params_t18.set_allow_early_resolve(true);
                         TaskOutputTensors task_18_outs = rt_submit_aiv_task(19, params_t18);
-                        PTO2TaskId cast_tid_k_inline76__ssa_v4 = task_18_outs.task_id();
+                        TaskId cast_tid_k_inline76__ssa_v4 = task_18_outs.task_id();
                         cast_tids_inline88[4] = cast_tid_k_inline76__ssa_v4;
 
                         // Task 19: post_rms_reduce
@@ -952,7 +952,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t19.add_input(attn_proj_fp32_inline220);
                         params_t19.add_input(cur__rv_v7);
                         params_t19.add_inout(inv_rms_tile_inline126);
-                        PTO2TaskId params_t19_deps[50];
+                        TaskId params_t19_deps[50];
                         uint32_t params_t19_deps_count = 0;
                         if (out_tids_inline271[0].is_valid())
                             params_t19_deps[params_t19_deps_count++] = out_tids_inline271[0];
@@ -1056,17 +1056,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t19_deps[params_t19_deps_count++] = out_tids_inline271[49];
                         params_t19.set_dependencies(params_t19_deps, params_t19_deps_count);
                         TaskOutputTensors task_19_outs = rt_submit_aiv_task(20, params_t19);
-                        PTO2TaskId reduce_tid_inline226 = task_19_outs.task_id();
+                        TaskId reduce_tid_inline226 = task_19_outs.task_id();
                         int64_t gu_k0_inline131 = 0;
-                        PTO2TaskId _submit_deps_buf_inline236[1];
+                        TaskId _submit_deps_buf_inline236[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline236[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v105 = cast_tids_inline88[0];
+                            _submit_deps_buf_inline236[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v105 = cast_tids_inline88[0];
                         _submit_deps_buf_inline236[0] = t__tmp_v105;
 
                         // Phase-fence barrier 3: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_3;
-                        PTO2TaskId params_phase_fence_barrier_3_deps[1];
+                        TaskId params_phase_fence_barrier_3_deps[1];
                         uint32_t params_phase_fence_barrier_3_deps_count = 0;
                         if (_submit_deps_buf_inline236[0].is_valid())
                             params_phase_fence_barrier_3_deps[params_phase_fence_barrier_3_deps_count++] =
@@ -1074,22 +1074,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_3.set_dependencies(
                             params_phase_fence_barrier_3_deps, params_phase_fence_barrier_3_deps_count
                         );
-                        PTO2TaskId t__tmp_v106 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v106 = TaskId::invalid();
                         if (params_phase_fence_barrier_3_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_3_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_3);
                             t__tmp_v106 = phase_fence_barrier_3_outs.task_id();
                         }
                         gate_late_tids_inline249[0] = t__tmp_v106;
-                        PTO2TaskId _submit_deps_buf_inline225[1];
+                        TaskId _submit_deps_buf_inline225[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline225[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v107 = cast_tids_inline88[0];
+                            _submit_deps_buf_inline225[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v107 = cast_tids_inline88[0];
                         _submit_deps_buf_inline225[0] = t__tmp_v107;
 
                         // Phase-fence barrier 4: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_4;
-                        PTO2TaskId params_phase_fence_barrier_4_deps[1];
+                        TaskId params_phase_fence_barrier_4_deps[1];
                         uint32_t params_phase_fence_barrier_4_deps_count = 0;
                         if (_submit_deps_buf_inline225[0].is_valid())
                             params_phase_fence_barrier_4_deps[params_phase_fence_barrier_4_deps_count++] =
@@ -1097,17 +1097,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_4.set_dependencies(
                             params_phase_fence_barrier_4_deps, params_phase_fence_barrier_4_deps_count
                         );
-                        PTO2TaskId t__tmp_v108 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v108 = TaskId::invalid();
                         if (params_phase_fence_barrier_4_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_4_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_4);
                             t__tmp_v108 = phase_fence_barrier_4_outs.task_id();
                         }
                         up_late_tids_inline69[0] = t__tmp_v108;
-                        PTO2TaskId _submit_deps_buf_inline237[1];
+                        TaskId _submit_deps_buf_inline237[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline237[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v109 = cast_tids_inline88[0];
+                            _submit_deps_buf_inline237[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v109 = cast_tids_inline88[0];
                         _submit_deps_buf_inline237[0] = t__tmp_v109;
 
                         // Spmd gate_proj_spmd: gate_proj
@@ -1118,23 +1118,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t20.add_scalar(gu_k0_inline131);
                         params_t20.add_scalar(layer_hidden_base_inline151);
                         params_t20.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t20_deps[1];
+                        TaskId params_t20_deps[1];
                         uint32_t params_t20_deps_count = 0;
                         if (_submit_deps_buf_inline237[0].is_valid())
                             params_t20_deps[params_t20_deps_count++] = _submit_deps_buf_inline237[0];
                         params_t20.set_dependencies(params_t20_deps, params_t20_deps_count);
                         TaskOutputTensors task_20_outs = rt_submit_aic_task(21, params_t20);
-                        PTO2TaskId gate_spmd_tid_inline245 = task_20_outs.task_id();
+                        TaskId gate_spmd_tid_inline245 = task_20_outs.task_id();
                         gate_tids_inline56[0] = gate_spmd_tid_inline245;
                         gate_tids_inline56[5] = gate_spmd_tid_inline245;
                         gate_tids_inline56[10] = gate_spmd_tid_inline245;
                         gate_tids_inline56[15] = gate_spmd_tid_inline245;
                         gate_tids_inline56[20] = gate_spmd_tid_inline245;
                         gate_tids_inline56[25] = gate_spmd_tid_inline245;
-                        PTO2TaskId _submit_deps_buf_inline260[1];
+                        TaskId _submit_deps_buf_inline260[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline260[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v110 = cast_tids_inline88[0];
+                            _submit_deps_buf_inline260[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v110 = cast_tids_inline88[0];
                         _submit_deps_buf_inline260[0] = t__tmp_v110;
 
                         // Spmd up_proj_spmd: up_proj
@@ -1145,13 +1145,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t21.add_scalar(gu_k0_inline131);
                         params_t21.add_scalar(layer_hidden_base_inline151);
                         params_t21.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t21_deps[1];
+                        TaskId params_t21_deps[1];
                         uint32_t params_t21_deps_count = 0;
                         if (_submit_deps_buf_inline260[0].is_valid())
                             params_t21_deps[params_t21_deps_count++] = _submit_deps_buf_inline260[0];
                         params_t21.set_dependencies(params_t21_deps, params_t21_deps_count);
                         TaskOutputTensors task_21_outs = rt_submit_aic_task(22, params_t21);
-                        PTO2TaskId up_spmd_tid_inline264 = task_21_outs.task_id();
+                        TaskId up_spmd_tid_inline264 = task_21_outs.task_id();
                         up_tids_inline310[0] = up_spmd_tid_inline264;
                         up_tids_inline310[5] = up_spmd_tid_inline264;
                         up_tids_inline310[10] = up_spmd_tid_inline264;
@@ -1159,15 +1159,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         up_tids_inline310[20] = up_spmd_tid_inline264;
                         up_tids_inline310[25] = up_spmd_tid_inline264;
                         int64_t gu_k0_inline131__ssa_v1 = 1024;
-                        PTO2TaskId _submit_deps_buf_inline236__ssa_v1[1];
+                        TaskId _submit_deps_buf_inline236__ssa_v1[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline236__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v111 = cast_tids_inline88[1];
+                            _submit_deps_buf_inline236__ssa_v1[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v111 = cast_tids_inline88[1];
                         _submit_deps_buf_inline236__ssa_v1[0] = t__tmp_v111;
 
                         // Phase-fence barrier 5: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_5;
-                        PTO2TaskId params_phase_fence_barrier_5_deps[1];
+                        TaskId params_phase_fence_barrier_5_deps[1];
                         uint32_t params_phase_fence_barrier_5_deps_count = 0;
                         if (_submit_deps_buf_inline236__ssa_v1[0].is_valid())
                             params_phase_fence_barrier_5_deps[params_phase_fence_barrier_5_deps_count++] =
@@ -1175,22 +1175,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_5.set_dependencies(
                             params_phase_fence_barrier_5_deps, params_phase_fence_barrier_5_deps_count
                         );
-                        PTO2TaskId t__tmp_v112 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v112 = TaskId::invalid();
                         if (params_phase_fence_barrier_5_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_5_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_5);
                             t__tmp_v112 = phase_fence_barrier_5_outs.task_id();
                         }
                         gate_late_tids_inline249[1] = t__tmp_v112;
-                        PTO2TaskId _submit_deps_buf_inline225__ssa_v1[1];
+                        TaskId _submit_deps_buf_inline225__ssa_v1[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline225__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v113 = cast_tids_inline88[1];
+                            _submit_deps_buf_inline225__ssa_v1[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v113 = cast_tids_inline88[1];
                         _submit_deps_buf_inline225__ssa_v1[0] = t__tmp_v113;
 
                         // Phase-fence barrier 6: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_6;
-                        PTO2TaskId params_phase_fence_barrier_6_deps[1];
+                        TaskId params_phase_fence_barrier_6_deps[1];
                         uint32_t params_phase_fence_barrier_6_deps_count = 0;
                         if (_submit_deps_buf_inline225__ssa_v1[0].is_valid())
                             params_phase_fence_barrier_6_deps[params_phase_fence_barrier_6_deps_count++] =
@@ -1198,17 +1198,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_6.set_dependencies(
                             params_phase_fence_barrier_6_deps, params_phase_fence_barrier_6_deps_count
                         );
-                        PTO2TaskId t__tmp_v114 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v114 = TaskId::invalid();
                         if (params_phase_fence_barrier_6_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_6_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_6);
                             t__tmp_v114 = phase_fence_barrier_6_outs.task_id();
                         }
                         up_late_tids_inline69[1] = t__tmp_v114;
-                        PTO2TaskId _submit_deps_buf_inline237__ssa_v1[1];
+                        TaskId _submit_deps_buf_inline237__ssa_v1[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline237__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v115 = cast_tids_inline88[1];
+                            _submit_deps_buf_inline237__ssa_v1[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v115 = cast_tids_inline88[1];
                         _submit_deps_buf_inline237__ssa_v1[0] = t__tmp_v115;
 
                         // Spmd gate_proj_spmd_0: gate_proj_0
@@ -1219,23 +1219,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t22.add_scalar(gu_k0_inline131__ssa_v1);
                         params_t22.add_scalar(layer_hidden_base_inline151);
                         params_t22.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t22_deps[1];
+                        TaskId params_t22_deps[1];
                         uint32_t params_t22_deps_count = 0;
                         if (_submit_deps_buf_inline237__ssa_v1[0].is_valid())
                             params_t22_deps[params_t22_deps_count++] = _submit_deps_buf_inline237__ssa_v1[0];
                         params_t22.set_dependencies(params_t22_deps, params_t22_deps_count);
                         TaskOutputTensors task_22_outs = rt_submit_aic_task(23, params_t22);
-                        PTO2TaskId gate_spmd_tid_inline245__ssa_v1 = task_22_outs.task_id();
+                        TaskId gate_spmd_tid_inline245__ssa_v1 = task_22_outs.task_id();
                         gate_tids_inline56[1] = gate_spmd_tid_inline245__ssa_v1;
                         gate_tids_inline56[6] = gate_spmd_tid_inline245__ssa_v1;
                         gate_tids_inline56[11] = gate_spmd_tid_inline245__ssa_v1;
                         gate_tids_inline56[16] = gate_spmd_tid_inline245__ssa_v1;
                         gate_tids_inline56[21] = gate_spmd_tid_inline245__ssa_v1;
                         gate_tids_inline56[26] = gate_spmd_tid_inline245__ssa_v1;
-                        PTO2TaskId _submit_deps_buf_inline260__ssa_v1[1];
+                        TaskId _submit_deps_buf_inline260__ssa_v1[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline260__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v116 = cast_tids_inline88[1];
+                            _submit_deps_buf_inline260__ssa_v1[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v116 = cast_tids_inline88[1];
                         _submit_deps_buf_inline260__ssa_v1[0] = t__tmp_v116;
 
                         // Spmd up_proj_spmd_0: up_proj_0
@@ -1246,13 +1246,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t23.add_scalar(gu_k0_inline131__ssa_v1);
                         params_t23.add_scalar(layer_hidden_base_inline151);
                         params_t23.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t23_deps[1];
+                        TaskId params_t23_deps[1];
                         uint32_t params_t23_deps_count = 0;
                         if (_submit_deps_buf_inline260__ssa_v1[0].is_valid())
                             params_t23_deps[params_t23_deps_count++] = _submit_deps_buf_inline260__ssa_v1[0];
                         params_t23.set_dependencies(params_t23_deps, params_t23_deps_count);
                         TaskOutputTensors task_23_outs = rt_submit_aic_task(24, params_t23);
-                        PTO2TaskId up_spmd_tid_inline264__ssa_v1 = task_23_outs.task_id();
+                        TaskId up_spmd_tid_inline264__ssa_v1 = task_23_outs.task_id();
                         up_tids_inline310[1] = up_spmd_tid_inline264__ssa_v1;
                         up_tids_inline310[6] = up_spmd_tid_inline264__ssa_v1;
                         up_tids_inline310[11] = up_spmd_tid_inline264__ssa_v1;
@@ -1260,15 +1260,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         up_tids_inline310[21] = up_spmd_tid_inline264__ssa_v1;
                         up_tids_inline310[26] = up_spmd_tid_inline264__ssa_v1;
                         int64_t gu_k0_inline131__ssa_v2 = 2048;
-                        PTO2TaskId _submit_deps_buf_inline236__ssa_v2[1];
+                        TaskId _submit_deps_buf_inline236__ssa_v2[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline236__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v117 = cast_tids_inline88[2];
+                            _submit_deps_buf_inline236__ssa_v2[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v117 = cast_tids_inline88[2];
                         _submit_deps_buf_inline236__ssa_v2[0] = t__tmp_v117;
 
                         // Phase-fence barrier 7: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_7;
-                        PTO2TaskId params_phase_fence_barrier_7_deps[1];
+                        TaskId params_phase_fence_barrier_7_deps[1];
                         uint32_t params_phase_fence_barrier_7_deps_count = 0;
                         if (_submit_deps_buf_inline236__ssa_v2[0].is_valid())
                             params_phase_fence_barrier_7_deps[params_phase_fence_barrier_7_deps_count++] =
@@ -1276,22 +1276,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_7.set_dependencies(
                             params_phase_fence_barrier_7_deps, params_phase_fence_barrier_7_deps_count
                         );
-                        PTO2TaskId t__tmp_v118 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v118 = TaskId::invalid();
                         if (params_phase_fence_barrier_7_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_7_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_7);
                             t__tmp_v118 = phase_fence_barrier_7_outs.task_id();
                         }
                         gate_late_tids_inline249[2] = t__tmp_v118;
-                        PTO2TaskId _submit_deps_buf_inline225__ssa_v2[1];
+                        TaskId _submit_deps_buf_inline225__ssa_v2[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline225__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v119 = cast_tids_inline88[2];
+                            _submit_deps_buf_inline225__ssa_v2[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v119 = cast_tids_inline88[2];
                         _submit_deps_buf_inline225__ssa_v2[0] = t__tmp_v119;
 
                         // Phase-fence barrier 8: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_8;
-                        PTO2TaskId params_phase_fence_barrier_8_deps[1];
+                        TaskId params_phase_fence_barrier_8_deps[1];
                         uint32_t params_phase_fence_barrier_8_deps_count = 0;
                         if (_submit_deps_buf_inline225__ssa_v2[0].is_valid())
                             params_phase_fence_barrier_8_deps[params_phase_fence_barrier_8_deps_count++] =
@@ -1299,17 +1299,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_8.set_dependencies(
                             params_phase_fence_barrier_8_deps, params_phase_fence_barrier_8_deps_count
                         );
-                        PTO2TaskId t__tmp_v120 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v120 = TaskId::invalid();
                         if (params_phase_fence_barrier_8_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_8_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_8);
                             t__tmp_v120 = phase_fence_barrier_8_outs.task_id();
                         }
                         up_late_tids_inline69[2] = t__tmp_v120;
-                        PTO2TaskId _submit_deps_buf_inline237__ssa_v2[1];
+                        TaskId _submit_deps_buf_inline237__ssa_v2[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline237__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v121 = cast_tids_inline88[2];
+                            _submit_deps_buf_inline237__ssa_v2[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v121 = cast_tids_inline88[2];
                         _submit_deps_buf_inline237__ssa_v2[0] = t__tmp_v121;
 
                         // Spmd gate_proj_spmd_1: gate_proj_1
@@ -1320,23 +1320,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t24.add_scalar(gu_k0_inline131__ssa_v2);
                         params_t24.add_scalar(layer_hidden_base_inline151);
                         params_t24.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t24_deps[1];
+                        TaskId params_t24_deps[1];
                         uint32_t params_t24_deps_count = 0;
                         if (_submit_deps_buf_inline237__ssa_v2[0].is_valid())
                             params_t24_deps[params_t24_deps_count++] = _submit_deps_buf_inline237__ssa_v2[0];
                         params_t24.set_dependencies(params_t24_deps, params_t24_deps_count);
                         TaskOutputTensors task_24_outs = rt_submit_aic_task(25, params_t24);
-                        PTO2TaskId gate_spmd_tid_inline245__ssa_v2 = task_24_outs.task_id();
+                        TaskId gate_spmd_tid_inline245__ssa_v2 = task_24_outs.task_id();
                         gate_tids_inline56[2] = gate_spmd_tid_inline245__ssa_v2;
                         gate_tids_inline56[7] = gate_spmd_tid_inline245__ssa_v2;
                         gate_tids_inline56[12] = gate_spmd_tid_inline245__ssa_v2;
                         gate_tids_inline56[17] = gate_spmd_tid_inline245__ssa_v2;
                         gate_tids_inline56[22] = gate_spmd_tid_inline245__ssa_v2;
                         gate_tids_inline56[27] = gate_spmd_tid_inline245__ssa_v2;
-                        PTO2TaskId _submit_deps_buf_inline260__ssa_v2[1];
+                        TaskId _submit_deps_buf_inline260__ssa_v2[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline260__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v122 = cast_tids_inline88[2];
+                            _submit_deps_buf_inline260__ssa_v2[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v122 = cast_tids_inline88[2];
                         _submit_deps_buf_inline260__ssa_v2[0] = t__tmp_v122;
 
                         // Spmd up_proj_spmd_1: up_proj_1
@@ -1347,13 +1347,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t25.add_scalar(gu_k0_inline131__ssa_v2);
                         params_t25.add_scalar(layer_hidden_base_inline151);
                         params_t25.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t25_deps[1];
+                        TaskId params_t25_deps[1];
                         uint32_t params_t25_deps_count = 0;
                         if (_submit_deps_buf_inline260__ssa_v2[0].is_valid())
                             params_t25_deps[params_t25_deps_count++] = _submit_deps_buf_inline260__ssa_v2[0];
                         params_t25.set_dependencies(params_t25_deps, params_t25_deps_count);
                         TaskOutputTensors task_25_outs = rt_submit_aic_task(26, params_t25);
-                        PTO2TaskId up_spmd_tid_inline264__ssa_v2 = task_25_outs.task_id();
+                        TaskId up_spmd_tid_inline264__ssa_v2 = task_25_outs.task_id();
                         up_tids_inline310[2] = up_spmd_tid_inline264__ssa_v2;
                         up_tids_inline310[7] = up_spmd_tid_inline264__ssa_v2;
                         up_tids_inline310[12] = up_spmd_tid_inline264__ssa_v2;
@@ -1361,15 +1361,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         up_tids_inline310[22] = up_spmd_tid_inline264__ssa_v2;
                         up_tids_inline310[27] = up_spmd_tid_inline264__ssa_v2;
                         int64_t gu_k0_inline131__ssa_v3 = 3072;
-                        PTO2TaskId _submit_deps_buf_inline236__ssa_v3[1];
+                        TaskId _submit_deps_buf_inline236__ssa_v3[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline236__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v123 = cast_tids_inline88[3];
+                            _submit_deps_buf_inline236__ssa_v3[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v123 = cast_tids_inline88[3];
                         _submit_deps_buf_inline236__ssa_v3[0] = t__tmp_v123;
 
                         // Phase-fence barrier 9: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_9;
-                        PTO2TaskId params_phase_fence_barrier_9_deps[1];
+                        TaskId params_phase_fence_barrier_9_deps[1];
                         uint32_t params_phase_fence_barrier_9_deps_count = 0;
                         if (_submit_deps_buf_inline236__ssa_v3[0].is_valid())
                             params_phase_fence_barrier_9_deps[params_phase_fence_barrier_9_deps_count++] =
@@ -1377,22 +1377,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_9.set_dependencies(
                             params_phase_fence_barrier_9_deps, params_phase_fence_barrier_9_deps_count
                         );
-                        PTO2TaskId t__tmp_v124 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v124 = TaskId::invalid();
                         if (params_phase_fence_barrier_9_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_9_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_9);
                             t__tmp_v124 = phase_fence_barrier_9_outs.task_id();
                         }
                         gate_late_tids_inline249[3] = t__tmp_v124;
-                        PTO2TaskId _submit_deps_buf_inline225__ssa_v3[1];
+                        TaskId _submit_deps_buf_inline225__ssa_v3[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline225__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v125 = cast_tids_inline88[3];
+                            _submit_deps_buf_inline225__ssa_v3[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v125 = cast_tids_inline88[3];
                         _submit_deps_buf_inline225__ssa_v3[0] = t__tmp_v125;
 
                         // Phase-fence barrier 10: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_10;
-                        PTO2TaskId params_phase_fence_barrier_10_deps[1];
+                        TaskId params_phase_fence_barrier_10_deps[1];
                         uint32_t params_phase_fence_barrier_10_deps_count = 0;
                         if (_submit_deps_buf_inline225__ssa_v3[0].is_valid())
                             params_phase_fence_barrier_10_deps[params_phase_fence_barrier_10_deps_count++] =
@@ -1400,17 +1400,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_10.set_dependencies(
                             params_phase_fence_barrier_10_deps, params_phase_fence_barrier_10_deps_count
                         );
-                        PTO2TaskId t__tmp_v126 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v126 = TaskId::invalid();
                         if (params_phase_fence_barrier_10_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_10_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_10);
                             t__tmp_v126 = phase_fence_barrier_10_outs.task_id();
                         }
                         up_late_tids_inline69[3] = t__tmp_v126;
-                        PTO2TaskId _submit_deps_buf_inline237__ssa_v3[1];
+                        TaskId _submit_deps_buf_inline237__ssa_v3[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline237__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v127 = cast_tids_inline88[3];
+                            _submit_deps_buf_inline237__ssa_v3[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v127 = cast_tids_inline88[3];
                         _submit_deps_buf_inline237__ssa_v3[0] = t__tmp_v127;
 
                         // Spmd gate_proj_spmd_2: gate_proj_2
@@ -1421,23 +1421,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t26.add_scalar(gu_k0_inline131__ssa_v3);
                         params_t26.add_scalar(layer_hidden_base_inline151);
                         params_t26.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t26_deps[1];
+                        TaskId params_t26_deps[1];
                         uint32_t params_t26_deps_count = 0;
                         if (_submit_deps_buf_inline237__ssa_v3[0].is_valid())
                             params_t26_deps[params_t26_deps_count++] = _submit_deps_buf_inline237__ssa_v3[0];
                         params_t26.set_dependencies(params_t26_deps, params_t26_deps_count);
                         TaskOutputTensors task_26_outs = rt_submit_aic_task(27, params_t26);
-                        PTO2TaskId gate_spmd_tid_inline245__ssa_v3 = task_26_outs.task_id();
+                        TaskId gate_spmd_tid_inline245__ssa_v3 = task_26_outs.task_id();
                         gate_tids_inline56[3] = gate_spmd_tid_inline245__ssa_v3;
                         gate_tids_inline56[8] = gate_spmd_tid_inline245__ssa_v3;
                         gate_tids_inline56[13] = gate_spmd_tid_inline245__ssa_v3;
                         gate_tids_inline56[18] = gate_spmd_tid_inline245__ssa_v3;
                         gate_tids_inline56[23] = gate_spmd_tid_inline245__ssa_v3;
                         gate_tids_inline56[28] = gate_spmd_tid_inline245__ssa_v3;
-                        PTO2TaskId _submit_deps_buf_inline260__ssa_v3[1];
+                        TaskId _submit_deps_buf_inline260__ssa_v3[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline260__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v128 = cast_tids_inline88[3];
+                            _submit_deps_buf_inline260__ssa_v3[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v128 = cast_tids_inline88[3];
                         _submit_deps_buf_inline260__ssa_v3[0] = t__tmp_v128;
 
                         // Spmd up_proj_spmd_2: up_proj_2
@@ -1448,13 +1448,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t27.add_scalar(gu_k0_inline131__ssa_v3);
                         params_t27.add_scalar(layer_hidden_base_inline151);
                         params_t27.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t27_deps[1];
+                        TaskId params_t27_deps[1];
                         uint32_t params_t27_deps_count = 0;
                         if (_submit_deps_buf_inline260__ssa_v3[0].is_valid())
                             params_t27_deps[params_t27_deps_count++] = _submit_deps_buf_inline260__ssa_v3[0];
                         params_t27.set_dependencies(params_t27_deps, params_t27_deps_count);
                         TaskOutputTensors task_27_outs = rt_submit_aic_task(28, params_t27);
-                        PTO2TaskId up_spmd_tid_inline264__ssa_v3 = task_27_outs.task_id();
+                        TaskId up_spmd_tid_inline264__ssa_v3 = task_27_outs.task_id();
                         up_tids_inline310[3] = up_spmd_tid_inline264__ssa_v3;
                         up_tids_inline310[8] = up_spmd_tid_inline264__ssa_v3;
                         up_tids_inline310[13] = up_spmd_tid_inline264__ssa_v3;
@@ -1462,15 +1462,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         up_tids_inline310[23] = up_spmd_tid_inline264__ssa_v3;
                         up_tids_inline310[28] = up_spmd_tid_inline264__ssa_v3;
                         int64_t gu_k0_inline131__ssa_v4 = 4096;
-                        PTO2TaskId _submit_deps_buf_inline236__ssa_v4[1];
+                        TaskId _submit_deps_buf_inline236__ssa_v4[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline236__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v129 = cast_tids_inline88[4];
+                            _submit_deps_buf_inline236__ssa_v4[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v129 = cast_tids_inline88[4];
                         _submit_deps_buf_inline236__ssa_v4[0] = t__tmp_v129;
 
                         // Phase-fence barrier 11: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_11;
-                        PTO2TaskId params_phase_fence_barrier_11_deps[1];
+                        TaskId params_phase_fence_barrier_11_deps[1];
                         uint32_t params_phase_fence_barrier_11_deps_count = 0;
                         if (_submit_deps_buf_inline236__ssa_v4[0].is_valid())
                             params_phase_fence_barrier_11_deps[params_phase_fence_barrier_11_deps_count++] =
@@ -1478,22 +1478,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_11.set_dependencies(
                             params_phase_fence_barrier_11_deps, params_phase_fence_barrier_11_deps_count
                         );
-                        PTO2TaskId t__tmp_v130 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v130 = TaskId::invalid();
                         if (params_phase_fence_barrier_11_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_11_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_11);
                             t__tmp_v130 = phase_fence_barrier_11_outs.task_id();
                         }
                         gate_late_tids_inline249[4] = t__tmp_v130;
-                        PTO2TaskId _submit_deps_buf_inline225__ssa_v4[1];
+                        TaskId _submit_deps_buf_inline225__ssa_v4[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline225__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v131 = cast_tids_inline88[4];
+                            _submit_deps_buf_inline225__ssa_v4[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v131 = cast_tids_inline88[4];
                         _submit_deps_buf_inline225__ssa_v4[0] = t__tmp_v131;
 
                         // Phase-fence barrier 12: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_12;
-                        PTO2TaskId params_phase_fence_barrier_12_deps[1];
+                        TaskId params_phase_fence_barrier_12_deps[1];
                         uint32_t params_phase_fence_barrier_12_deps_count = 0;
                         if (_submit_deps_buf_inline225__ssa_v4[0].is_valid())
                             params_phase_fence_barrier_12_deps[params_phase_fence_barrier_12_deps_count++] =
@@ -1501,17 +1501,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_12.set_dependencies(
                             params_phase_fence_barrier_12_deps, params_phase_fence_barrier_12_deps_count
                         );
-                        PTO2TaskId t__tmp_v132 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v132 = TaskId::invalid();
                         if (params_phase_fence_barrier_12_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_12_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_12);
                             t__tmp_v132 = phase_fence_barrier_12_outs.task_id();
                         }
                         up_late_tids_inline69[4] = t__tmp_v132;
-                        PTO2TaskId _submit_deps_buf_inline237__ssa_v4[1];
+                        TaskId _submit_deps_buf_inline237__ssa_v4[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline237__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v133 = cast_tids_inline88[4];
+                            _submit_deps_buf_inline237__ssa_v4[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v133 = cast_tids_inline88[4];
                         _submit_deps_buf_inline237__ssa_v4[0] = t__tmp_v133;
 
                         // Spmd gate_proj_spmd_3: gate_proj_3
@@ -1522,23 +1522,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t28.add_scalar(gu_k0_inline131__ssa_v4);
                         params_t28.add_scalar(layer_hidden_base_inline151);
                         params_t28.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t28_deps[1];
+                        TaskId params_t28_deps[1];
                         uint32_t params_t28_deps_count = 0;
                         if (_submit_deps_buf_inline237__ssa_v4[0].is_valid())
                             params_t28_deps[params_t28_deps_count++] = _submit_deps_buf_inline237__ssa_v4[0];
                         params_t28.set_dependencies(params_t28_deps, params_t28_deps_count);
                         TaskOutputTensors task_28_outs = rt_submit_aic_task(29, params_t28);
-                        PTO2TaskId gate_spmd_tid_inline245__ssa_v4 = task_28_outs.task_id();
+                        TaskId gate_spmd_tid_inline245__ssa_v4 = task_28_outs.task_id();
                         gate_tids_inline56[4] = gate_spmd_tid_inline245__ssa_v4;
                         gate_tids_inline56[9] = gate_spmd_tid_inline245__ssa_v4;
                         gate_tids_inline56[14] = gate_spmd_tid_inline245__ssa_v4;
                         gate_tids_inline56[19] = gate_spmd_tid_inline245__ssa_v4;
                         gate_tids_inline56[24] = gate_spmd_tid_inline245__ssa_v4;
                         gate_tids_inline56[29] = gate_spmd_tid_inline245__ssa_v4;
-                        PTO2TaskId _submit_deps_buf_inline260__ssa_v4[1];
+                        TaskId _submit_deps_buf_inline260__ssa_v4[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline260__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v134 = cast_tids_inline88[4];
+                            _submit_deps_buf_inline260__ssa_v4[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v134 = cast_tids_inline88[4];
                         _submit_deps_buf_inline260__ssa_v4[0] = t__tmp_v134;
 
                         // Spmd up_proj_spmd_3: up_proj_3
@@ -1549,13 +1549,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t29.add_scalar(gu_k0_inline131__ssa_v4);
                         params_t29.add_scalar(layer_hidden_base_inline151);
                         params_t29.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t29_deps[1];
+                        TaskId params_t29_deps[1];
                         uint32_t params_t29_deps_count = 0;
                         if (_submit_deps_buf_inline260__ssa_v4[0].is_valid())
                             params_t29_deps[params_t29_deps_count++] = _submit_deps_buf_inline260__ssa_v4[0];
                         params_t29.set_dependencies(params_t29_deps, params_t29_deps_count);
                         TaskOutputTensors task_29_outs = rt_submit_aic_task(30, params_t29);
-                        PTO2TaskId up_spmd_tid_inline264__ssa_v4 = task_29_outs.task_id();
+                        TaskId up_spmd_tid_inline264__ssa_v4 = task_29_outs.task_id();
                         up_tids_inline310[4] = up_spmd_tid_inline264__ssa_v4;
                         up_tids_inline310[9] = up_spmd_tid_inline264__ssa_v4;
                         up_tids_inline310[14] = up_spmd_tid_inline264__ssa_v4;
@@ -1566,10 +1566,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             int64_t n0_inline122 = (n_out_inline275 * 1024);
                             for (int64_t k_split_inline276 = 0; k_split_inline276 < 5; k_split_inline276 += 1) {
                                 int64_t k0_inline113 = (k_split_inline276 * 1024);
-                                PTO2TaskId _submit_deps_buf_inline102[1];
+                                TaskId _submit_deps_buf_inline102[1];
                                 for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                                    _submit_deps_buf_inline102[__init_i] = PTO2TaskId::invalid();
-                                PTO2TaskId t__tmp_v135 = gate_late_tids_inline249[k_split_inline276];
+                                    _submit_deps_buf_inline102[__init_i] = TaskId::invalid();
+                                TaskId t__tmp_v135 = gate_late_tids_inline249[k_split_inline276];
                                 _submit_deps_buf_inline102[0] = t__tmp_v135;
 
                                 // Task 30: gate_proj_4
@@ -1580,18 +1580,18 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t30.add_scalar(k0_inline113);
                                 params_t30.add_scalar(layer_hidden_base_inline151);
                                 params_t30.add_scalar(n0_inline122);
-                                PTO2TaskId params_t30_deps[1];
+                                TaskId params_t30_deps[1];
                                 uint32_t params_t30_deps_count = 0;
                                 if (_submit_deps_buf_inline102[0].is_valid())
                                     params_t30_deps[params_t30_deps_count++] = _submit_deps_buf_inline102[0];
                                 params_t30.set_dependencies(params_t30_deps, params_t30_deps_count);
                                 TaskOutputTensors task_30_outs = rt_submit_aic_task(31, params_t30);
-                                PTO2TaskId gate_tid_inline277 = task_30_outs.task_id();
+                                TaskId gate_tid_inline277 = task_30_outs.task_id();
                                 gate_tids_inline56[((n_out_inline275 * 5) + k_split_inline276)] = gate_tid_inline277;
-                                PTO2TaskId _submit_deps_buf_inline246[1];
+                                TaskId _submit_deps_buf_inline246[1];
                                 for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                                    _submit_deps_buf_inline246[__init_i] = PTO2TaskId::invalid();
-                                PTO2TaskId t__tmp_v136 = up_late_tids_inline69[k_split_inline276];
+                                    _submit_deps_buf_inline246[__init_i] = TaskId::invalid();
+                                TaskId t__tmp_v136 = up_late_tids_inline69[k_split_inline276];
                                 _submit_deps_buf_inline246[0] = t__tmp_v136;
 
                                 // Task 31: up_proj_4
@@ -1602,41 +1602,41 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t31.add_scalar(k0_inline113);
                                 params_t31.add_scalar(layer_hidden_base_inline151);
                                 params_t31.add_scalar(n0_inline122);
-                                PTO2TaskId params_t31_deps[1];
+                                TaskId params_t31_deps[1];
                                 uint32_t params_t31_deps_count = 0;
                                 if (_submit_deps_buf_inline246[0].is_valid())
                                     params_t31_deps[params_t31_deps_count++] = _submit_deps_buf_inline246[0];
                                 params_t31.set_dependencies(params_t31_deps, params_t31_deps_count);
                                 TaskOutputTensors task_31_outs = rt_submit_aic_task(32, params_t31);
-                                PTO2TaskId up_tid_inline290 = task_31_outs.task_id();
+                                TaskId up_tid_inline290 = task_31_outs.task_id();
                                 up_tids_inline310[((n_out_inline275 * 5) + k_split_inline276)] = up_tid_inline290;
                             }
                         }
                         for (int64_t n_out_inline292 = 0; n_out_inline292 < 17; n_out_inline292 += 1) {
                             int64_t n0_inline122__ssa_v7 = (n_out_inline292 * 1024);
-                            PTO2TaskId _submit_deps_buf_inline167[11];
+                            TaskId _submit_deps_buf_inline167[11];
                             for (int64_t __init_i = 0; __init_i < 11; ++__init_i)
-                                _submit_deps_buf_inline167[__init_i] = PTO2TaskId::invalid();
+                                _submit_deps_buf_inline167[__init_i] = TaskId::invalid();
                             _submit_deps_buf_inline167[0] = reduce_tid_inline226;
-                            PTO2TaskId t__tmp_v137 = gate_tids_inline56[(n_out_inline292 * 5)];
+                            TaskId t__tmp_v137 = gate_tids_inline56[(n_out_inline292 * 5)];
                             _submit_deps_buf_inline167[1] = t__tmp_v137;
-                            PTO2TaskId t__tmp_v138 = gate_tids_inline56[((n_out_inline292 * 5) + 1)];
+                            TaskId t__tmp_v138 = gate_tids_inline56[((n_out_inline292 * 5) + 1)];
                             _submit_deps_buf_inline167[2] = t__tmp_v138;
-                            PTO2TaskId t__tmp_v139 = gate_tids_inline56[((n_out_inline292 * 5) + 2)];
+                            TaskId t__tmp_v139 = gate_tids_inline56[((n_out_inline292 * 5) + 2)];
                             _submit_deps_buf_inline167[3] = t__tmp_v139;
-                            PTO2TaskId t__tmp_v140 = gate_tids_inline56[((n_out_inline292 * 5) + 3)];
+                            TaskId t__tmp_v140 = gate_tids_inline56[((n_out_inline292 * 5) + 3)];
                             _submit_deps_buf_inline167[4] = t__tmp_v140;
-                            PTO2TaskId t__tmp_v141 = gate_tids_inline56[((n_out_inline292 * 5) + 4)];
+                            TaskId t__tmp_v141 = gate_tids_inline56[((n_out_inline292 * 5) + 4)];
                             _submit_deps_buf_inline167[5] = t__tmp_v141;
-                            PTO2TaskId t__tmp_v142 = up_tids_inline310[(n_out_inline292 * 5)];
+                            TaskId t__tmp_v142 = up_tids_inline310[(n_out_inline292 * 5)];
                             _submit_deps_buf_inline167[6] = t__tmp_v142;
-                            PTO2TaskId t__tmp_v143 = up_tids_inline310[((n_out_inline292 * 5) + 1)];
+                            TaskId t__tmp_v143 = up_tids_inline310[((n_out_inline292 * 5) + 1)];
                             _submit_deps_buf_inline167[7] = t__tmp_v143;
-                            PTO2TaskId t__tmp_v144 = up_tids_inline310[((n_out_inline292 * 5) + 2)];
+                            TaskId t__tmp_v144 = up_tids_inline310[((n_out_inline292 * 5) + 2)];
                             _submit_deps_buf_inline167[8] = t__tmp_v144;
-                            PTO2TaskId t__tmp_v145 = up_tids_inline310[((n_out_inline292 * 5) + 3)];
+                            TaskId t__tmp_v145 = up_tids_inline310[((n_out_inline292 * 5) + 3)];
                             _submit_deps_buf_inline167[9] = t__tmp_v145;
-                            PTO2TaskId t__tmp_v146 = up_tids_inline310[((n_out_inline292 * 5) + 4)];
+                            TaskId t__tmp_v146 = up_tids_inline310[((n_out_inline292 * 5) + 4)];
                             _submit_deps_buf_inline167[10] = t__tmp_v146;
 
                             // Task 32: silu
@@ -1646,7 +1646,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t32.add_input(gate_acc_all_inline203);
                             params_t32.add_input(up_acc_all_inline303);
                             params_t32.add_scalar(n0_inline122__ssa_v7);
-                            PTO2TaskId params_t32_deps[11];
+                            TaskId params_t32_deps[11];
                             uint32_t params_t32_deps_count = 0;
                             if (_submit_deps_buf_inline167[0].is_valid())
                                 params_t32_deps[params_t32_deps_count++] = _submit_deps_buf_inline167[0];
@@ -1672,17 +1672,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t32_deps[params_t32_deps_count++] = _submit_deps_buf_inline167[10];
                             params_t32.set_dependencies(params_t32_deps, params_t32_deps_count);
                             TaskOutputTensors task_32_outs = rt_submit_aiv_task(33, params_t32);
-                            PTO2TaskId silu_tid_inline80 = task_32_outs.task_id();
+                            TaskId silu_tid_inline80 = task_32_outs.task_id();
                             silu_tids_inline265[n_out_inline292] = silu_tid_inline80;
                         }
                         for (int64_t n_out_inline195 = 0; n_out_inline195 < 5; n_out_inline195 += 1) {
                             int64_t n0_inline122__ssa_v8 = (n_out_inline195 * 1024);
                             for (int64_t k_split_inline302 = 0; k_split_inline302 < 17; k_split_inline302 += 1) {
                                 int64_t k0_inline113__ssa_v8 = (k_split_inline302 * 1024);
-                                PTO2TaskId _submit_deps_buf_inline229[1];
+                                TaskId _submit_deps_buf_inline229[1];
                                 for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                                    _submit_deps_buf_inline229[__init_i] = PTO2TaskId::invalid();
-                                PTO2TaskId t__tmp_v152 = silu_tids_inline265[k_split_inline302];
+                                    _submit_deps_buf_inline229[__init_i] = TaskId::invalid();
+                                TaskId t__tmp_v152 = silu_tids_inline265[k_split_inline302];
                                 _submit_deps_buf_inline229[0] = t__tmp_v152;
 
                                 // Task 33: down_proj
@@ -1693,190 +1693,190 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t33.add_scalar(k0_inline113__ssa_v8);
                                 params_t33.add_scalar(layer_inter_base_inline107);
                                 params_t33.add_scalar(n0_inline122__ssa_v8);
-                                PTO2TaskId params_t33_deps[1];
+                                TaskId params_t33_deps[1];
                                 uint32_t params_t33_deps_count = 0;
                                 if (_submit_deps_buf_inline229[0].is_valid())
                                     params_t33_deps[params_t33_deps_count++] = _submit_deps_buf_inline229[0];
                                 params_t33.set_dependencies(params_t33_deps, params_t33_deps_count);
                                 params_t33.set_allow_early_resolve(true);
                                 TaskOutputTensors task_33_outs = rt_submit_aic_task(34, params_t33);
-                                PTO2TaskId down_tid_inline210 = task_33_outs.task_id();
+                                TaskId down_tid_inline210 = task_33_outs.task_id();
                                 down_tids_inline156[((n_out_inline195 * 17) + k_split_inline302)] = down_tid_inline210;
                             }
                         }
                     }
-                    PTO2TaskId _submit_deps_buf_inline123[85];
+                    TaskId _submit_deps_buf_inline123[85];
                     for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
-                        _submit_deps_buf_inline123[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v153 = down_tids_inline156[0];
+                        _submit_deps_buf_inline123[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v153 = down_tids_inline156[0];
                     _submit_deps_buf_inline123[0] = t__tmp_v153;
-                    PTO2TaskId t__tmp_v154 = down_tids_inline156[1];
+                    TaskId t__tmp_v154 = down_tids_inline156[1];
                     _submit_deps_buf_inline123[1] = t__tmp_v154;
-                    PTO2TaskId t__tmp_v155 = down_tids_inline156[2];
+                    TaskId t__tmp_v155 = down_tids_inline156[2];
                     _submit_deps_buf_inline123[2] = t__tmp_v155;
-                    PTO2TaskId t__tmp_v156 = down_tids_inline156[3];
+                    TaskId t__tmp_v156 = down_tids_inline156[3];
                     _submit_deps_buf_inline123[3] = t__tmp_v156;
-                    PTO2TaskId t__tmp_v157 = down_tids_inline156[4];
+                    TaskId t__tmp_v157 = down_tids_inline156[4];
                     _submit_deps_buf_inline123[4] = t__tmp_v157;
-                    PTO2TaskId t__tmp_v158 = down_tids_inline156[5];
+                    TaskId t__tmp_v158 = down_tids_inline156[5];
                     _submit_deps_buf_inline123[5] = t__tmp_v158;
-                    PTO2TaskId t__tmp_v159 = down_tids_inline156[6];
+                    TaskId t__tmp_v159 = down_tids_inline156[6];
                     _submit_deps_buf_inline123[6] = t__tmp_v159;
-                    PTO2TaskId t__tmp_v160 = down_tids_inline156[7];
+                    TaskId t__tmp_v160 = down_tids_inline156[7];
                     _submit_deps_buf_inline123[7] = t__tmp_v160;
-                    PTO2TaskId t__tmp_v161 = down_tids_inline156[8];
+                    TaskId t__tmp_v161 = down_tids_inline156[8];
                     _submit_deps_buf_inline123[8] = t__tmp_v161;
-                    PTO2TaskId t__tmp_v162 = down_tids_inline156[9];
+                    TaskId t__tmp_v162 = down_tids_inline156[9];
                     _submit_deps_buf_inline123[9] = t__tmp_v162;
-                    PTO2TaskId t__tmp_v163 = down_tids_inline156[10];
+                    TaskId t__tmp_v163 = down_tids_inline156[10];
                     _submit_deps_buf_inline123[10] = t__tmp_v163;
-                    PTO2TaskId t__tmp_v164 = down_tids_inline156[11];
+                    TaskId t__tmp_v164 = down_tids_inline156[11];
                     _submit_deps_buf_inline123[11] = t__tmp_v164;
-                    PTO2TaskId t__tmp_v165 = down_tids_inline156[12];
+                    TaskId t__tmp_v165 = down_tids_inline156[12];
                     _submit_deps_buf_inline123[12] = t__tmp_v165;
-                    PTO2TaskId t__tmp_v166 = down_tids_inline156[13];
+                    TaskId t__tmp_v166 = down_tids_inline156[13];
                     _submit_deps_buf_inline123[13] = t__tmp_v166;
-                    PTO2TaskId t__tmp_v167 = down_tids_inline156[14];
+                    TaskId t__tmp_v167 = down_tids_inline156[14];
                     _submit_deps_buf_inline123[14] = t__tmp_v167;
-                    PTO2TaskId t__tmp_v168 = down_tids_inline156[15];
+                    TaskId t__tmp_v168 = down_tids_inline156[15];
                     _submit_deps_buf_inline123[15] = t__tmp_v168;
-                    PTO2TaskId t__tmp_v169 = down_tids_inline156[16];
+                    TaskId t__tmp_v169 = down_tids_inline156[16];
                     _submit_deps_buf_inline123[16] = t__tmp_v169;
-                    PTO2TaskId t__tmp_v170 = down_tids_inline156[17];
+                    TaskId t__tmp_v170 = down_tids_inline156[17];
                     _submit_deps_buf_inline123[17] = t__tmp_v170;
-                    PTO2TaskId t__tmp_v171 = down_tids_inline156[18];
+                    TaskId t__tmp_v171 = down_tids_inline156[18];
                     _submit_deps_buf_inline123[18] = t__tmp_v171;
-                    PTO2TaskId t__tmp_v172 = down_tids_inline156[19];
+                    TaskId t__tmp_v172 = down_tids_inline156[19];
                     _submit_deps_buf_inline123[19] = t__tmp_v172;
-                    PTO2TaskId t__tmp_v173 = down_tids_inline156[20];
+                    TaskId t__tmp_v173 = down_tids_inline156[20];
                     _submit_deps_buf_inline123[20] = t__tmp_v173;
-                    PTO2TaskId t__tmp_v174 = down_tids_inline156[21];
+                    TaskId t__tmp_v174 = down_tids_inline156[21];
                     _submit_deps_buf_inline123[21] = t__tmp_v174;
-                    PTO2TaskId t__tmp_v175 = down_tids_inline156[22];
+                    TaskId t__tmp_v175 = down_tids_inline156[22];
                     _submit_deps_buf_inline123[22] = t__tmp_v175;
-                    PTO2TaskId t__tmp_v176 = down_tids_inline156[23];
+                    TaskId t__tmp_v176 = down_tids_inline156[23];
                     _submit_deps_buf_inline123[23] = t__tmp_v176;
-                    PTO2TaskId t__tmp_v177 = down_tids_inline156[24];
+                    TaskId t__tmp_v177 = down_tids_inline156[24];
                     _submit_deps_buf_inline123[24] = t__tmp_v177;
-                    PTO2TaskId t__tmp_v178 = down_tids_inline156[25];
+                    TaskId t__tmp_v178 = down_tids_inline156[25];
                     _submit_deps_buf_inline123[25] = t__tmp_v178;
-                    PTO2TaskId t__tmp_v179 = down_tids_inline156[26];
+                    TaskId t__tmp_v179 = down_tids_inline156[26];
                     _submit_deps_buf_inline123[26] = t__tmp_v179;
-                    PTO2TaskId t__tmp_v180 = down_tids_inline156[27];
+                    TaskId t__tmp_v180 = down_tids_inline156[27];
                     _submit_deps_buf_inline123[27] = t__tmp_v180;
-                    PTO2TaskId t__tmp_v181 = down_tids_inline156[28];
+                    TaskId t__tmp_v181 = down_tids_inline156[28];
                     _submit_deps_buf_inline123[28] = t__tmp_v181;
-                    PTO2TaskId t__tmp_v182 = down_tids_inline156[29];
+                    TaskId t__tmp_v182 = down_tids_inline156[29];
                     _submit_deps_buf_inline123[29] = t__tmp_v182;
-                    PTO2TaskId t__tmp_v183 = down_tids_inline156[30];
+                    TaskId t__tmp_v183 = down_tids_inline156[30];
                     _submit_deps_buf_inline123[30] = t__tmp_v183;
-                    PTO2TaskId t__tmp_v184 = down_tids_inline156[31];
+                    TaskId t__tmp_v184 = down_tids_inline156[31];
                     _submit_deps_buf_inline123[31] = t__tmp_v184;
-                    PTO2TaskId t__tmp_v185 = down_tids_inline156[32];
+                    TaskId t__tmp_v185 = down_tids_inline156[32];
                     _submit_deps_buf_inline123[32] = t__tmp_v185;
-                    PTO2TaskId t__tmp_v186 = down_tids_inline156[33];
+                    TaskId t__tmp_v186 = down_tids_inline156[33];
                     _submit_deps_buf_inline123[33] = t__tmp_v186;
-                    PTO2TaskId t__tmp_v187 = down_tids_inline156[34];
+                    TaskId t__tmp_v187 = down_tids_inline156[34];
                     _submit_deps_buf_inline123[34] = t__tmp_v187;
-                    PTO2TaskId t__tmp_v188 = down_tids_inline156[35];
+                    TaskId t__tmp_v188 = down_tids_inline156[35];
                     _submit_deps_buf_inline123[35] = t__tmp_v188;
-                    PTO2TaskId t__tmp_v189 = down_tids_inline156[36];
+                    TaskId t__tmp_v189 = down_tids_inline156[36];
                     _submit_deps_buf_inline123[36] = t__tmp_v189;
-                    PTO2TaskId t__tmp_v190 = down_tids_inline156[37];
+                    TaskId t__tmp_v190 = down_tids_inline156[37];
                     _submit_deps_buf_inline123[37] = t__tmp_v190;
-                    PTO2TaskId t__tmp_v191 = down_tids_inline156[38];
+                    TaskId t__tmp_v191 = down_tids_inline156[38];
                     _submit_deps_buf_inline123[38] = t__tmp_v191;
-                    PTO2TaskId t__tmp_v192 = down_tids_inline156[39];
+                    TaskId t__tmp_v192 = down_tids_inline156[39];
                     _submit_deps_buf_inline123[39] = t__tmp_v192;
-                    PTO2TaskId t__tmp_v193 = down_tids_inline156[40];
+                    TaskId t__tmp_v193 = down_tids_inline156[40];
                     _submit_deps_buf_inline123[40] = t__tmp_v193;
-                    PTO2TaskId t__tmp_v194 = down_tids_inline156[41];
+                    TaskId t__tmp_v194 = down_tids_inline156[41];
                     _submit_deps_buf_inline123[41] = t__tmp_v194;
-                    PTO2TaskId t__tmp_v195 = down_tids_inline156[42];
+                    TaskId t__tmp_v195 = down_tids_inline156[42];
                     _submit_deps_buf_inline123[42] = t__tmp_v195;
-                    PTO2TaskId t__tmp_v196 = down_tids_inline156[43];
+                    TaskId t__tmp_v196 = down_tids_inline156[43];
                     _submit_deps_buf_inline123[43] = t__tmp_v196;
-                    PTO2TaskId t__tmp_v197 = down_tids_inline156[44];
+                    TaskId t__tmp_v197 = down_tids_inline156[44];
                     _submit_deps_buf_inline123[44] = t__tmp_v197;
-                    PTO2TaskId t__tmp_v198 = down_tids_inline156[45];
+                    TaskId t__tmp_v198 = down_tids_inline156[45];
                     _submit_deps_buf_inline123[45] = t__tmp_v198;
-                    PTO2TaskId t__tmp_v199 = down_tids_inline156[46];
+                    TaskId t__tmp_v199 = down_tids_inline156[46];
                     _submit_deps_buf_inline123[46] = t__tmp_v199;
-                    PTO2TaskId t__tmp_v200 = down_tids_inline156[47];
+                    TaskId t__tmp_v200 = down_tids_inline156[47];
                     _submit_deps_buf_inline123[47] = t__tmp_v200;
-                    PTO2TaskId t__tmp_v201 = down_tids_inline156[48];
+                    TaskId t__tmp_v201 = down_tids_inline156[48];
                     _submit_deps_buf_inline123[48] = t__tmp_v201;
-                    PTO2TaskId t__tmp_v202 = down_tids_inline156[49];
+                    TaskId t__tmp_v202 = down_tids_inline156[49];
                     _submit_deps_buf_inline123[49] = t__tmp_v202;
-                    PTO2TaskId t__tmp_v203 = down_tids_inline156[50];
+                    TaskId t__tmp_v203 = down_tids_inline156[50];
                     _submit_deps_buf_inline123[50] = t__tmp_v203;
-                    PTO2TaskId t__tmp_v204 = down_tids_inline156[51];
+                    TaskId t__tmp_v204 = down_tids_inline156[51];
                     _submit_deps_buf_inline123[51] = t__tmp_v204;
-                    PTO2TaskId t__tmp_v205 = down_tids_inline156[52];
+                    TaskId t__tmp_v205 = down_tids_inline156[52];
                     _submit_deps_buf_inline123[52] = t__tmp_v205;
-                    PTO2TaskId t__tmp_v206 = down_tids_inline156[53];
+                    TaskId t__tmp_v206 = down_tids_inline156[53];
                     _submit_deps_buf_inline123[53] = t__tmp_v206;
-                    PTO2TaskId t__tmp_v207 = down_tids_inline156[54];
+                    TaskId t__tmp_v207 = down_tids_inline156[54];
                     _submit_deps_buf_inline123[54] = t__tmp_v207;
-                    PTO2TaskId t__tmp_v208 = down_tids_inline156[55];
+                    TaskId t__tmp_v208 = down_tids_inline156[55];
                     _submit_deps_buf_inline123[55] = t__tmp_v208;
-                    PTO2TaskId t__tmp_v209 = down_tids_inline156[56];
+                    TaskId t__tmp_v209 = down_tids_inline156[56];
                     _submit_deps_buf_inline123[56] = t__tmp_v209;
-                    PTO2TaskId t__tmp_v210 = down_tids_inline156[57];
+                    TaskId t__tmp_v210 = down_tids_inline156[57];
                     _submit_deps_buf_inline123[57] = t__tmp_v210;
-                    PTO2TaskId t__tmp_v211 = down_tids_inline156[58];
+                    TaskId t__tmp_v211 = down_tids_inline156[58];
                     _submit_deps_buf_inline123[58] = t__tmp_v211;
-                    PTO2TaskId t__tmp_v212 = down_tids_inline156[59];
+                    TaskId t__tmp_v212 = down_tids_inline156[59];
                     _submit_deps_buf_inline123[59] = t__tmp_v212;
-                    PTO2TaskId t__tmp_v213 = down_tids_inline156[60];
+                    TaskId t__tmp_v213 = down_tids_inline156[60];
                     _submit_deps_buf_inline123[60] = t__tmp_v213;
-                    PTO2TaskId t__tmp_v214 = down_tids_inline156[61];
+                    TaskId t__tmp_v214 = down_tids_inline156[61];
                     _submit_deps_buf_inline123[61] = t__tmp_v214;
-                    PTO2TaskId t__tmp_v215 = down_tids_inline156[62];
+                    TaskId t__tmp_v215 = down_tids_inline156[62];
                     _submit_deps_buf_inline123[62] = t__tmp_v215;
-                    PTO2TaskId t__tmp_v216 = down_tids_inline156[63];
+                    TaskId t__tmp_v216 = down_tids_inline156[63];
                     _submit_deps_buf_inline123[63] = t__tmp_v216;
-                    PTO2TaskId t__tmp_v217 = down_tids_inline156[64];
+                    TaskId t__tmp_v217 = down_tids_inline156[64];
                     _submit_deps_buf_inline123[64] = t__tmp_v217;
-                    PTO2TaskId t__tmp_v218 = down_tids_inline156[65];
+                    TaskId t__tmp_v218 = down_tids_inline156[65];
                     _submit_deps_buf_inline123[65] = t__tmp_v218;
-                    PTO2TaskId t__tmp_v219 = down_tids_inline156[66];
+                    TaskId t__tmp_v219 = down_tids_inline156[66];
                     _submit_deps_buf_inline123[66] = t__tmp_v219;
-                    PTO2TaskId t__tmp_v220 = down_tids_inline156[67];
+                    TaskId t__tmp_v220 = down_tids_inline156[67];
                     _submit_deps_buf_inline123[67] = t__tmp_v220;
-                    PTO2TaskId t__tmp_v221 = down_tids_inline156[68];
+                    TaskId t__tmp_v221 = down_tids_inline156[68];
                     _submit_deps_buf_inline123[68] = t__tmp_v221;
-                    PTO2TaskId t__tmp_v222 = down_tids_inline156[69];
+                    TaskId t__tmp_v222 = down_tids_inline156[69];
                     _submit_deps_buf_inline123[69] = t__tmp_v222;
-                    PTO2TaskId t__tmp_v223 = down_tids_inline156[70];
+                    TaskId t__tmp_v223 = down_tids_inline156[70];
                     _submit_deps_buf_inline123[70] = t__tmp_v223;
-                    PTO2TaskId t__tmp_v224 = down_tids_inline156[71];
+                    TaskId t__tmp_v224 = down_tids_inline156[71];
                     _submit_deps_buf_inline123[71] = t__tmp_v224;
-                    PTO2TaskId t__tmp_v225 = down_tids_inline156[72];
+                    TaskId t__tmp_v225 = down_tids_inline156[72];
                     _submit_deps_buf_inline123[72] = t__tmp_v225;
-                    PTO2TaskId t__tmp_v226 = down_tids_inline156[73];
+                    TaskId t__tmp_v226 = down_tids_inline156[73];
                     _submit_deps_buf_inline123[73] = t__tmp_v226;
-                    PTO2TaskId t__tmp_v227 = down_tids_inline156[74];
+                    TaskId t__tmp_v227 = down_tids_inline156[74];
                     _submit_deps_buf_inline123[74] = t__tmp_v227;
-                    PTO2TaskId t__tmp_v228 = down_tids_inline156[75];
+                    TaskId t__tmp_v228 = down_tids_inline156[75];
                     _submit_deps_buf_inline123[75] = t__tmp_v228;
-                    PTO2TaskId t__tmp_v229 = down_tids_inline156[76];
+                    TaskId t__tmp_v229 = down_tids_inline156[76];
                     _submit_deps_buf_inline123[76] = t__tmp_v229;
-                    PTO2TaskId t__tmp_v230 = down_tids_inline156[77];
+                    TaskId t__tmp_v230 = down_tids_inline156[77];
                     _submit_deps_buf_inline123[77] = t__tmp_v230;
-                    PTO2TaskId t__tmp_v231 = down_tids_inline156[78];
+                    TaskId t__tmp_v231 = down_tids_inline156[78];
                     _submit_deps_buf_inline123[78] = t__tmp_v231;
-                    PTO2TaskId t__tmp_v232 = down_tids_inline156[79];
+                    TaskId t__tmp_v232 = down_tids_inline156[79];
                     _submit_deps_buf_inline123[79] = t__tmp_v232;
-                    PTO2TaskId t__tmp_v233 = down_tids_inline156[80];
+                    TaskId t__tmp_v233 = down_tids_inline156[80];
                     _submit_deps_buf_inline123[80] = t__tmp_v233;
-                    PTO2TaskId t__tmp_v234 = down_tids_inline156[81];
+                    TaskId t__tmp_v234 = down_tids_inline156[81];
                     _submit_deps_buf_inline123[81] = t__tmp_v234;
-                    PTO2TaskId t__tmp_v235 = down_tids_inline156[82];
+                    TaskId t__tmp_v235 = down_tids_inline156[82];
                     _submit_deps_buf_inline123[82] = t__tmp_v235;
-                    PTO2TaskId t__tmp_v236 = down_tids_inline156[83];
+                    TaskId t__tmp_v236 = down_tids_inline156[83];
                     _submit_deps_buf_inline123[83] = t__tmp_v236;
-                    PTO2TaskId t__tmp_v237 = down_tids_inline156[84];
+                    TaskId t__tmp_v237 = down_tids_inline156[84];
                     _submit_deps_buf_inline123[84] = t__tmp_v237;
 
                     // Spmd dcr_xgamma_spmd: dcr_xgamma
@@ -1889,7 +1889,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t34.add_scalar(next_gamma_idx);
                     params_t34.launch_spec.set_block_num(5);
                     params_t34.set_allow_early_resolve(true);
-                    PTO2TaskId params_t34_deps[85];
+                    TaskId params_t34_deps[85];
                     uint32_t params_t34_deps_count = 0;
                     if (_submit_deps_buf_inline123[0].is_valid())
                         params_t34_deps[params_t34_deps_count++] = _submit_deps_buf_inline123[0];

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd.cpp
@@ -1275,18 +1275,18 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t11.launch_spec.set_block_num((t_dim_inline757_inline8959 / 8));
         params_t11.set_allow_early_resolve(true);
         TaskOutputTensors task_11_outs = rt_submit_aiv_task(11, params_t11);
-        PTO2TaskId rms_tid_inline758_inline8904 = task_11_outs.task_id();
-        PTO2TaskId rms_tid_inline8953 = rms_tid_inline758_inline8904;
+        TaskId rms_tid_inline758_inline8904 = task_11_outs.task_id();
+        TaskId rms_tid_inline8953 = rms_tid_inline758_inline8904;
 
         // Phase-fence barrier 0: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_0;
-        PTO2TaskId params_phase_fence_barrier_0_deps[1];
+        TaskId params_phase_fence_barrier_0_deps[1];
         uint32_t params_phase_fence_barrier_0_deps_count = 0;
         params_phase_fence_barrier_0_deps[params_phase_fence_barrier_0_deps_count++] = rms_tid_inline758_inline8904;
         params_phase_fence_barrier_0.set_dependencies(
             params_phase_fence_barrier_0_deps, params_phase_fence_barrier_0_deps_count
         );
-        PTO2TaskId late_dep_inline8961 = PTO2TaskId::invalid();
+        TaskId late_dep_inline8961 = TaskId::invalid();
         if (params_phase_fence_barrier_0_deps_count > 0) {
             TaskOutputTensors phase_fence_barrier_0_outs = rt_submit_dummy_task(params_phase_fence_barrier_0);
             late_dep_inline8961 = phase_fence_barrier_0_outs.task_id();
@@ -1456,7 +1456,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t18.add_scalar(t_matmul_inline856_inline8847);
         params_t18.add_scalar(t_dim_inline889_inline8972);
         params_t18.launch_spec.set_block_num(16);
-        PTO2TaskId params_t18_deps[1];
+        TaskId params_t18_deps[1];
         uint32_t params_t18_deps_count = 0;
         if (late_dep_inline8961.is_valid()) params_t18_deps[params_t18_deps_count++] = late_dep_inline8961;
         params_t18.set_dependencies(params_t18_deps, params_t18_deps_count);
@@ -1499,12 +1499,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         };
         ChipTensor ori_kv_flat_inline1033_inline8970 =
             kv_cache_l0_inline603.reshape(ori_kv_flat_inline1033_inline8970_shapes, 2);
-        PTO2TaskId proj_b_tids_inline1013_inline9033[8];
+        TaskId proj_b_tids_inline1013_inline9033[8];
         for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
-            proj_b_tids_inline1013_inline9033[__init_i] = PTO2TaskId::invalid();
-        PTO2TaskId gather_tids_inline1022_inline9089[1];
+            proj_b_tids_inline1013_inline9033[__init_i] = TaskId::invalid();
+        TaskId gather_tids_inline1022_inline9089[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-            gather_tids_inline1022_inline9089[__init_i] = PTO2TaskId::invalid();
+            gather_tids_inline1022_inline9089[__init_i] = TaskId::invalid();
 
         // Spmd swa_gather_kv_spmd: swa_gather_kv
         CoreTaskArgs params_t22;
@@ -1513,17 +1513,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t22.add_input(ori_kv_flat_inline1033_inline8970);
         params_t22.launch_spec.set_block_num(32);
         TaskOutputTensors task_22_outs = rt_submit_aiv_task(22, params_t22);
-        PTO2TaskId gather_tid_inline1039_inline9091 = task_22_outs.task_id();
+        TaskId gather_tid_inline1039_inline9091 = task_22_outs.task_id();
         gather_tids_inline1022_inline9089[0] = gather_tid_inline1039_inline9091;
         uint32_t q_flat_inline1064_inline8925_shapes[2] = {512, 512};
         ChipTensor q_flat_inline1064_inline8925 = q_inline8956.reshape(q_flat_inline1064_inline8925_shapes, 2);
         uint32_t o_packed_inline1065_inline9106_shapes[2] = {64, 4096};
         ChipTensor o_packed_inline1065_inline9106 =
             o_packed_heads_inline1025_inline8944.reshape(o_packed_inline1065_inline9106_shapes, 2);
-        PTO2TaskId _submit_deps_buf_inline1099_inline9111[1];
+        TaskId _submit_deps_buf_inline1099_inline9111[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-            _submit_deps_buf_inline1099_inline9111[__init_i] = PTO2TaskId::invalid();
-        PTO2TaskId t__tmp_v127 = gather_tids_inline1022_inline9089[0];
+            _submit_deps_buf_inline1099_inline9111[__init_i] = TaskId::invalid();
+        TaskId t__tmp_v127 = gather_tids_inline1022_inline9089[0];
         _submit_deps_buf_inline1099_inline9111[0] = t__tmp_v127;
 
         // Group qk_pv: MixedKernels (AIC + AIV lanes)
@@ -1538,13 +1538,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         MixedKernels mixed_23 = {23, 24, 24};
         params_t23.launch_spec.set_block_num(8);
         params_t23.set_allow_early_resolve(true);
-        PTO2TaskId params_t23_deps[1];
+        TaskId params_t23_deps[1];
         uint32_t params_t23_deps_count = 0;
         if (_submit_deps_buf_inline1099_inline9111[0].is_valid())
             params_t23_deps[params_t23_deps_count++] = _submit_deps_buf_inline1099_inline9111[0];
         params_t23.set_dependencies(params_t23_deps, params_t23_deps_count);
         TaskOutputTensors task_23_outs = rt_submit_task(mixed_23, params_t23);
-        PTO2TaskId qk_tid_inline993_inline8938 = task_23_outs.task_id();
+        TaskId qk_tid_inline993_inline8938 = task_23_outs.task_id();
 
         // Task 24: rope_cs
         CoreTaskArgs params_t24;
@@ -1554,7 +1554,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t24.add_input(rope_cos_t_inline8914);
         params_t24.add_input(rope_sin_t_inline8931);
         TaskOutputTensors task_24_outs = rt_submit_aiv_task(25, params_t24);
-        PTO2TaskId rope_tid_inline998_inline8791 = task_24_outs.task_id();
+        TaskId rope_tid_inline998_inline8791 = task_24_outs.task_id();
 
         // Spmd merge_norm_spmd: merge_norm
         CoreTaskArgs params_t25;
@@ -1568,13 +1568,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t25.add_inout(o_packed_heads_inline1025_inline8944);
         params_t25.launch_spec.set_block_num(32);
         params_t25.set_allow_early_resolve(true);
-        PTO2TaskId params_t25_deps[2];
+        TaskId params_t25_deps[2];
         uint32_t params_t25_deps_count = 0;
         params_t25_deps[params_t25_deps_count++] = qk_tid_inline993_inline8938;
         params_t25_deps[params_t25_deps_count++] = rope_tid_inline998_inline8791;
         params_t25.set_dependencies(params_t25_deps, params_t25_deps_count);
         TaskOutputTensors task_25_outs = rt_submit_aiv_task(26, params_t25);
-        PTO2TaskId merge_tid_inline1108_inline8902 = task_25_outs.task_id();
+        TaskId merge_tid_inline1108_inline8902 = task_25_outs.task_id();
         ChipTensor o_r_pad_inline974_inline8862__rv_v2 = o_r_pad_inline974_inline8862;
         PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
             for (int64_t g_inline978_inline8746 = 0; g_inline978_inline8746 < 8; g_inline978_inline8746 += 1) {
@@ -1591,13 +1591,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t26.add_scalar(out_col_g_inline1092_inline8900);
                 params_t26.launch_spec.set_block_num(8);
                 params_t26.set_allow_early_resolve(true);
-                PTO2TaskId params_t26_deps[1];
+                TaskId params_t26_deps[1];
                 uint32_t params_t26_deps_count = 0;
                 params_t26_deps[params_t26_deps_count++] = merge_tid_inline1108_inline8902;
                 params_t26.set_dependencies(params_t26_deps, params_t26_deps_count);
                 TaskOutputTensors task_26_outs = rt_submit_aic_task(27, params_t26);
                 int64_t n0_inline1077_inline8742 = 0;
-                PTO2TaskId pa_tid_inline1023_inline8744 = task_26_outs.task_id();
+                TaskId pa_tid_inline1023_inline8744 = task_26_outs.task_id();
                 int64_t col_g_inline1089_inline8999 = (g_inline978_inline8746 * 1024);
 
                 // Task 27: quant
@@ -1607,13 +1607,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t27.add_input(o_r_pad_inline974_inline8862__rv_v2);
                 params_t27.add_scalar(col_g_inline1089_inline8999);
                 params_t27.add_scalar(g_inline978_inline8746);
-                PTO2TaskId params_t27_deps[1];
+                TaskId params_t27_deps[1];
                 uint32_t params_t27_deps_count = 0;
                 params_t27_deps[params_t27_deps_count++] = pa_tid_inline1023_inline8744;
                 params_t27.set_dependencies(params_t27_deps, params_t27_deps_count);
                 params_t27.set_allow_early_resolve(true);
                 TaskOutputTensors task_27_outs = rt_submit_aiv_task(28, params_t27);
-                PTO2TaskId q_tid_inline1085_inline8958 = task_27_outs.task_id();
+                TaskId q_tid_inline1085_inline8958 = task_27_outs.task_id();
 
                 // Spmd proj_b_mm_spmd: proj_b_mm
                 CoreTaskArgs params_t28;
@@ -1625,33 +1625,33 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t28.add_scalar(g_inline978_inline8746);
                 params_t28.launch_spec.set_block_num(8);
                 params_t28.set_allow_early_resolve(true);
-                PTO2TaskId params_t28_deps[1];
+                TaskId params_t28_deps[1];
                 uint32_t params_t28_deps_count = 0;
                 params_t28_deps[params_t28_deps_count++] = q_tid_inline1085_inline8958;
                 params_t28.set_dependencies(params_t28_deps, params_t28_deps_count);
                 TaskOutputTensors task_28_outs = rt_submit_aic_task(29, params_t28);
-                PTO2TaskId pb_tid_inline954_inline8979 = task_28_outs.task_id();
+                TaskId pb_tid_inline954_inline8979 = task_28_outs.task_id();
                 proj_b_tids_inline1013_inline9033[g_inline978_inline8746] = pb_tid_inline954_inline8979;
             }
         }
-        PTO2TaskId _submit_deps_buf_inline949_inline9070[8];
+        TaskId _submit_deps_buf_inline949_inline9070[8];
         for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
-            _submit_deps_buf_inline949_inline9070[__init_i] = PTO2TaskId::invalid();
-        PTO2TaskId t__tmp_v147 = proj_b_tids_inline1013_inline9033[0];
+            _submit_deps_buf_inline949_inline9070[__init_i] = TaskId::invalid();
+        TaskId t__tmp_v147 = proj_b_tids_inline1013_inline9033[0];
         _submit_deps_buf_inline949_inline9070[0] = t__tmp_v147;
-        PTO2TaskId t__tmp_v148 = proj_b_tids_inline1013_inline9033[1];
+        TaskId t__tmp_v148 = proj_b_tids_inline1013_inline9033[1];
         _submit_deps_buf_inline949_inline9070[1] = t__tmp_v148;
-        PTO2TaskId t__tmp_v149 = proj_b_tids_inline1013_inline9033[2];
+        TaskId t__tmp_v149 = proj_b_tids_inline1013_inline9033[2];
         _submit_deps_buf_inline949_inline9070[2] = t__tmp_v149;
-        PTO2TaskId t__tmp_v150 = proj_b_tids_inline1013_inline9033[3];
+        TaskId t__tmp_v150 = proj_b_tids_inline1013_inline9033[3];
         _submit_deps_buf_inline949_inline9070[3] = t__tmp_v150;
-        PTO2TaskId t__tmp_v151 = proj_b_tids_inline1013_inline9033[4];
+        TaskId t__tmp_v151 = proj_b_tids_inline1013_inline9033[4];
         _submit_deps_buf_inline949_inline9070[4] = t__tmp_v151;
-        PTO2TaskId t__tmp_v152 = proj_b_tids_inline1013_inline9033[5];
+        TaskId t__tmp_v152 = proj_b_tids_inline1013_inline9033[5];
         _submit_deps_buf_inline949_inline9070[5] = t__tmp_v152;
-        PTO2TaskId t__tmp_v153 = proj_b_tids_inline1013_inline9033[6];
+        TaskId t__tmp_v153 = proj_b_tids_inline1013_inline9033[6];
         _submit_deps_buf_inline949_inline9070[6] = t__tmp_v153;
-        PTO2TaskId t__tmp_v154 = proj_b_tids_inline1013_inline9033[7];
+        TaskId t__tmp_v154 = proj_b_tids_inline1013_inline9033[7];
         _submit_deps_buf_inline949_inline9070[7] = t__tmp_v154;
 
         // Spmd proj_b_act_spmd: proj_b_act
@@ -1662,7 +1662,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t29.add_inout(attn_out_inline9085);
         params_t29.launch_spec.set_block_num(8);
         params_t29.set_allow_early_resolve(true);
-        PTO2TaskId params_t29_deps[8];
+        TaskId params_t29_deps[8];
         uint32_t params_t29_deps_count = 0;
         if (_submit_deps_buf_inline949_inline9070[0].is_valid())
             params_t29_deps[params_t29_deps_count++] = _submit_deps_buf_inline949_inline9070[0];
@@ -1907,7 +1907,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         // Phase-fence barrier 1: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_1;
         TaskOutputTensors phase_fence_barrier_1_outs = rt_submit_dummy_task(params_phase_fence_barrier_1);
-        PTO2TaskId seed_dummy_inline2602_inline9321 = phase_fence_barrier_1_outs.task_id();
+        TaskId seed_dummy_inline2602_inline9321 = phase_fence_barrier_1_outs.task_id();
         for (int64_t t0_inline2605_inline9256 = 0;
              t0_inline2605_inline9256 < active_gate_tokens_inline2604_inline9313__phi_v2;
              t0_inline2605_inline9256 += 8) {
@@ -1917,7 +1917,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t38.add_output(x_norm_i8_inline9265);
             params_t38.add_input(xg_buf_inline2582_inline9396);
             params_t38.add_scalar(t0_inline2605_inline9256);
-            PTO2TaskId params_t38_deps[1];
+            TaskId params_t38_deps[1];
             uint32_t params_t38_deps_count = 0;
             if (seed_dummy_inline2602_inline9321.is_valid())
                 params_t38_deps[params_t38_deps_count++] = seed_dummy_inline2602_inline9321;
@@ -2076,7 +2076,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t47.add_scalar(arrived_ctx);
         params_t47.set_allow_early_resolve(true);
         TaskOutputTensors task_47_outs = rt_submit_aiv_task(49, params_t47);
-        PTO2TaskId _meta_tid_inline2705_inline9406 = task_47_outs.task_id();
+        TaskId _meta_tid_inline2705_inline9406 = task_47_outs.task_id();
 
         // Spmd dispatch_push_spmd: dispatch_push
         CoreTaskArgs params_t48;
@@ -2097,7 +2097,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t48.launch_spec.set_block_num(32);
         params_t48.set_allow_early_resolve(true);
         TaskOutputTensors task_48_outs = rt_submit_aiv_task(50, params_t48);
-        PTO2TaskId _push_tid_inline2710_inline9278 = task_48_outs.task_id();
+        TaskId _push_tid_inline2710_inline9278 = task_48_outs.task_id();
 
         // Task 49: dispatch_wait
         CoreTaskArgs params_t49;
@@ -2105,13 +2105,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t49.add_input(ext_data_arrived);
         params_t49.add_scalar(my_rank);
         params_t49.add_scalar(data_arrived_ctx);
-        PTO2TaskId params_t49_deps[1];
+        TaskId params_t49_deps[1];
         uint32_t params_t49_deps_count = 0;
         params_t49_deps[params_t49_deps_count++] = _push_tid_inline2710_inline9278;
         params_t49.set_dependencies(params_t49_deps, params_t49_deps_count);
         params_t49.set_allow_early_resolve(true);
         TaskOutputTensors task_49_outs = rt_submit_aiv_task(51, params_t49);
-        PTO2TaskId _wait_tid_inline2685_inline9261 = task_49_outs.task_id();
+        TaskId _wait_tid_inline2685_inline9261 = task_49_outs.task_id();
 
         // Spmd dispatch_gather_spmd: dispatch_gather
         CoreTaskArgs params_t50;
@@ -2127,13 +2127,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t50.add_scalar(recv_aux_ctx);
         params_t50.add_scalar(recv_route_ctx);
         params_t50.launch_spec.set_block_num(32);
-        PTO2TaskId params_t50_deps[2];
+        TaskId params_t50_deps[2];
         uint32_t params_t50_deps_count = 0;
         params_t50_deps[params_t50_deps_count++] = _wait_tid_inline2685_inline9261;
         params_t50_deps[params_t50_deps_count++] = _meta_tid_inline2705_inline9406;
         params_t50.set_dependencies(params_t50_deps, params_t50_deps_count);
         TaskOutputTensors task_50_outs = rt_submit_aiv_task(52, params_t50);
-        PTO2TaskId dispatch_push_tid_inline9438 = _push_tid_inline2710_inline9278;
+        TaskId dispatch_push_tid_inline9438 = _push_tid_inline2710_inline9278;
         PTO2_SCOPE() {
             uint32_t recv_y_inline9209_ci_shapes[3] = {32, 16, 4096};
             TensorCreateInfo recv_y_inline9209_ci(recv_y_inline9209_ci_shapes, 3, DataType::BFLOAT16);
@@ -2424,20 +2424,20 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t57.add_scalar(routed_y_buf_ctx);
             params_t57.launch_spec.set_block_num(32);
             TaskOutputTensors task_57_outs = rt_submit_aiv_task(59, params_t57);
-            PTO2TaskId _combine_tid_inline2817_inline9389 = task_57_outs.task_id();
+            TaskId _combine_tid_inline2817_inline9389 = task_57_outs.task_id();
 
             // Task 58: combine_wait
             CoreTaskArgs params_t58;
             params_t58.add_input(ext_combine_arrived);
             params_t58.add_scalar(my_rank);
             params_t58.add_scalar(combine_arrived_ctx);
-            PTO2TaskId params_t58_deps[2];
+            TaskId params_t58_deps[2];
             uint32_t params_t58_deps_count = 0;
             params_t58_deps[params_t58_deps_count++] = _combine_tid_inline2817_inline9389;
             params_t58_deps[params_t58_deps_count++] = _push_tid_inline2710_inline9278;
             params_t58.set_dependencies(params_t58_deps, params_t58_deps_count);
             TaskOutputTensors task_58_outs = rt_submit_aiv_task(60, params_t58);
-            PTO2TaskId _cwait_tid_inline2826_inline9164 = task_58_outs.task_id();
+            TaskId _cwait_tid_inline2826_inline9164 = task_58_outs.task_id();
             int64_t active_tokens_inline2816_inline9356 = static_cast<int64_t>(nt_inline677__rv_v2);
             int64_t active_tokens_inline2816_inline9356__phi_v4;
             if ((8 < active_tokens_inline2816_inline9356)) {
@@ -2455,7 +2455,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t59.add_scalar(active_tokens_inline2816_inline9356__phi_v4);
             params_t59.add_scalar(routed_y_buf_ctx);
             params_t59.launch_spec.set_block_num(8);
-            PTO2TaskId params_t59_deps[1];
+            TaskId params_t59_deps[1];
             uint32_t params_t59_deps_count = 0;
             params_t59_deps[params_t59_deps_count++] = _cwait_tid_inline2826_inline9164;
             params_t59.set_dependencies(params_t59_deps, params_t59_deps_count);
@@ -2695,18 +2695,18 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t68.launch_spec.set_block_num((t_dim_inline757_inline9721 / 8));
         params_t68.set_allow_early_resolve(true);
         TaskOutputTensors task_68_outs = rt_submit_aiv_task(70, params_t68);
-        PTO2TaskId rms_tid_inline758_inline9666 = task_68_outs.task_id();
-        PTO2TaskId rms_tid_inline9715 = rms_tid_inline758_inline9666;
+        TaskId rms_tid_inline758_inline9666 = task_68_outs.task_id();
+        TaskId rms_tid_inline9715 = rms_tid_inline758_inline9666;
 
         // Phase-fence barrier 2: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_2;
-        PTO2TaskId params_phase_fence_barrier_2_deps[1];
+        TaskId params_phase_fence_barrier_2_deps[1];
         uint32_t params_phase_fence_barrier_2_deps_count = 0;
         params_phase_fence_barrier_2_deps[params_phase_fence_barrier_2_deps_count++] = rms_tid_inline758_inline9666;
         params_phase_fence_barrier_2.set_dependencies(
             params_phase_fence_barrier_2_deps, params_phase_fence_barrier_2_deps_count
         );
-        PTO2TaskId late_dep_inline9723 = PTO2TaskId::invalid();
+        TaskId late_dep_inline9723 = TaskId::invalid();
         if (params_phase_fence_barrier_2_deps_count > 0) {
             TaskOutputTensors phase_fence_barrier_2_outs = rt_submit_dummy_task(params_phase_fence_barrier_2);
             late_dep_inline9723 = phase_fence_barrier_2_outs.task_id();
@@ -2876,7 +2876,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t75.add_scalar(t_matmul_inline856_inline9609);
         params_t75.add_scalar(t_dim_inline889_inline9734);
         params_t75.launch_spec.set_block_num(16);
-        PTO2TaskId params_t75_deps[1];
+        TaskId params_t75_deps[1];
         uint32_t params_t75_deps_count = 0;
         if (late_dep_inline9723.is_valid()) params_t75_deps[params_t75_deps_count++] = late_dep_inline9723;
         params_t75.set_dependencies(params_t75_deps, params_t75_deps_count);
@@ -2919,12 +2919,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         };
         ChipTensor ori_kv_flat_inline1033_inline9732 =
             kv_cache_l1_inline569.reshape(ori_kv_flat_inline1033_inline9732_shapes, 2);
-        PTO2TaskId proj_b_tids_inline1013_inline9795[8];
+        TaskId proj_b_tids_inline1013_inline9795[8];
         for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
-            proj_b_tids_inline1013_inline9795[__init_i] = PTO2TaskId::invalid();
-        PTO2TaskId gather_tids_inline1022_inline9851[1];
+            proj_b_tids_inline1013_inline9795[__init_i] = TaskId::invalid();
+        TaskId gather_tids_inline1022_inline9851[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-            gather_tids_inline1022_inline9851[__init_i] = PTO2TaskId::invalid();
+            gather_tids_inline1022_inline9851[__init_i] = TaskId::invalid();
 
         // Spmd swa_gather_kv_spmd_0: swa_gather_kv_0
         CoreTaskArgs params_t79;
@@ -2933,17 +2933,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t79.add_input(ori_kv_flat_inline1033_inline9732);
         params_t79.launch_spec.set_block_num(32);
         TaskOutputTensors task_79_outs = rt_submit_aiv_task(81, params_t79);
-        PTO2TaskId gather_tid_inline1039_inline9853 = task_79_outs.task_id();
+        TaskId gather_tid_inline1039_inline9853 = task_79_outs.task_id();
         gather_tids_inline1022_inline9851[0] = gather_tid_inline1039_inline9853;
         uint32_t q_flat_inline1064_inline9687_shapes[2] = {512, 512};
         ChipTensor q_flat_inline1064_inline9687 = q_inline9718.reshape(q_flat_inline1064_inline9687_shapes, 2);
         uint32_t o_packed_inline1065_inline9868_shapes[2] = {64, 4096};
         ChipTensor o_packed_inline1065_inline9868 =
             o_packed_heads_inline1025_inline9706.reshape(o_packed_inline1065_inline9868_shapes, 2);
-        PTO2TaskId _submit_deps_buf_inline1099_inline9873[1];
+        TaskId _submit_deps_buf_inline1099_inline9873[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-            _submit_deps_buf_inline1099_inline9873[__init_i] = PTO2TaskId::invalid();
-        PTO2TaskId t__tmp_v425 = gather_tids_inline1022_inline9851[0];
+            _submit_deps_buf_inline1099_inline9873[__init_i] = TaskId::invalid();
+        TaskId t__tmp_v425 = gather_tids_inline1022_inline9851[0];
         _submit_deps_buf_inline1099_inline9873[0] = t__tmp_v425;
 
         // Group qk_pv_0: MixedKernels (AIC + AIV lanes)
@@ -2958,13 +2958,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         MixedKernels mixed_80 = {82, 83, 83};
         params_t80.launch_spec.set_block_num(8);
         params_t80.set_allow_early_resolve(true);
-        PTO2TaskId params_t80_deps[1];
+        TaskId params_t80_deps[1];
         uint32_t params_t80_deps_count = 0;
         if (_submit_deps_buf_inline1099_inline9873[0].is_valid())
             params_t80_deps[params_t80_deps_count++] = _submit_deps_buf_inline1099_inline9873[0];
         params_t80.set_dependencies(params_t80_deps, params_t80_deps_count);
         TaskOutputTensors task_80_outs = rt_submit_task(mixed_80, params_t80);
-        PTO2TaskId qk_tid_inline993_inline9700 = task_80_outs.task_id();
+        TaskId qk_tid_inline993_inline9700 = task_80_outs.task_id();
 
         // Task 81: rope_cs_0
         CoreTaskArgs params_t81;
@@ -2974,7 +2974,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t81.add_input(rope_cos_t_inline9676);
         params_t81.add_input(rope_sin_t_inline9693);
         TaskOutputTensors task_81_outs = rt_submit_aiv_task(84, params_t81);
-        PTO2TaskId rope_tid_inline998_inline9553 = task_81_outs.task_id();
+        TaskId rope_tid_inline998_inline9553 = task_81_outs.task_id();
 
         // Spmd merge_norm_spmd_0: merge_norm_0
         CoreTaskArgs params_t82;
@@ -2988,13 +2988,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t82.add_inout(o_packed_heads_inline1025_inline9706);
         params_t82.launch_spec.set_block_num(32);
         params_t82.set_allow_early_resolve(true);
-        PTO2TaskId params_t82_deps[2];
+        TaskId params_t82_deps[2];
         uint32_t params_t82_deps_count = 0;
         params_t82_deps[params_t82_deps_count++] = qk_tid_inline993_inline9700;
         params_t82_deps[params_t82_deps_count++] = rope_tid_inline998_inline9553;
         params_t82.set_dependencies(params_t82_deps, params_t82_deps_count);
         TaskOutputTensors task_82_outs = rt_submit_aiv_task(85, params_t82);
-        PTO2TaskId merge_tid_inline1108_inline9664 = task_82_outs.task_id();
+        TaskId merge_tid_inline1108_inline9664 = task_82_outs.task_id();
         ChipTensor o_r_pad_inline974_inline9624__rv_v2 = o_r_pad_inline974_inline9624;
         PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
             for (int64_t g_inline978_inline9508 = 0; g_inline978_inline9508 < 8; g_inline978_inline9508 += 1) {
@@ -3011,13 +3011,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t83.add_scalar(out_col_g_inline1092_inline9662);
                 params_t83.launch_spec.set_block_num(8);
                 params_t83.set_allow_early_resolve(true);
-                PTO2TaskId params_t83_deps[1];
+                TaskId params_t83_deps[1];
                 uint32_t params_t83_deps_count = 0;
                 params_t83_deps[params_t83_deps_count++] = merge_tid_inline1108_inline9664;
                 params_t83.set_dependencies(params_t83_deps, params_t83_deps_count);
                 TaskOutputTensors task_83_outs = rt_submit_aic_task(86, params_t83);
                 int64_t n0_inline1077_inline9504 = 0;
-                PTO2TaskId pa_tid_inline1023_inline9506 = task_83_outs.task_id();
+                TaskId pa_tid_inline1023_inline9506 = task_83_outs.task_id();
                 int64_t col_g_inline1089_inline9761 = (g_inline978_inline9508 * 1024);
 
                 // Task 84: quant_0
@@ -3027,13 +3027,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t84.add_input(o_r_pad_inline974_inline9624__rv_v2);
                 params_t84.add_scalar(col_g_inline1089_inline9761);
                 params_t84.add_scalar(g_inline978_inline9508);
-                PTO2TaskId params_t84_deps[1];
+                TaskId params_t84_deps[1];
                 uint32_t params_t84_deps_count = 0;
                 params_t84_deps[params_t84_deps_count++] = pa_tid_inline1023_inline9506;
                 params_t84.set_dependencies(params_t84_deps, params_t84_deps_count);
                 params_t84.set_allow_early_resolve(true);
                 TaskOutputTensors task_84_outs = rt_submit_aiv_task(87, params_t84);
-                PTO2TaskId q_tid_inline1085_inline9720 = task_84_outs.task_id();
+                TaskId q_tid_inline1085_inline9720 = task_84_outs.task_id();
 
                 // Spmd proj_b_mm_spmd_0: proj_b_mm_0
                 CoreTaskArgs params_t85;
@@ -3045,33 +3045,33 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t85.add_scalar(g_inline978_inline9508);
                 params_t85.launch_spec.set_block_num(8);
                 params_t85.set_allow_early_resolve(true);
-                PTO2TaskId params_t85_deps[1];
+                TaskId params_t85_deps[1];
                 uint32_t params_t85_deps_count = 0;
                 params_t85_deps[params_t85_deps_count++] = q_tid_inline1085_inline9720;
                 params_t85.set_dependencies(params_t85_deps, params_t85_deps_count);
                 TaskOutputTensors task_85_outs = rt_submit_aic_task(88, params_t85);
-                PTO2TaskId pb_tid_inline954_inline9741 = task_85_outs.task_id();
+                TaskId pb_tid_inline954_inline9741 = task_85_outs.task_id();
                 proj_b_tids_inline1013_inline9795[g_inline978_inline9508] = pb_tid_inline954_inline9741;
             }
         }
-        PTO2TaskId _submit_deps_buf_inline949_inline9832[8];
+        TaskId _submit_deps_buf_inline949_inline9832[8];
         for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
-            _submit_deps_buf_inline949_inline9832[__init_i] = PTO2TaskId::invalid();
-        PTO2TaskId t__tmp_v445 = proj_b_tids_inline1013_inline9795[0];
+            _submit_deps_buf_inline949_inline9832[__init_i] = TaskId::invalid();
+        TaskId t__tmp_v445 = proj_b_tids_inline1013_inline9795[0];
         _submit_deps_buf_inline949_inline9832[0] = t__tmp_v445;
-        PTO2TaskId t__tmp_v446 = proj_b_tids_inline1013_inline9795[1];
+        TaskId t__tmp_v446 = proj_b_tids_inline1013_inline9795[1];
         _submit_deps_buf_inline949_inline9832[1] = t__tmp_v446;
-        PTO2TaskId t__tmp_v447 = proj_b_tids_inline1013_inline9795[2];
+        TaskId t__tmp_v447 = proj_b_tids_inline1013_inline9795[2];
         _submit_deps_buf_inline949_inline9832[2] = t__tmp_v447;
-        PTO2TaskId t__tmp_v448 = proj_b_tids_inline1013_inline9795[3];
+        TaskId t__tmp_v448 = proj_b_tids_inline1013_inline9795[3];
         _submit_deps_buf_inline949_inline9832[3] = t__tmp_v448;
-        PTO2TaskId t__tmp_v449 = proj_b_tids_inline1013_inline9795[4];
+        TaskId t__tmp_v449 = proj_b_tids_inline1013_inline9795[4];
         _submit_deps_buf_inline949_inline9832[4] = t__tmp_v449;
-        PTO2TaskId t__tmp_v450 = proj_b_tids_inline1013_inline9795[5];
+        TaskId t__tmp_v450 = proj_b_tids_inline1013_inline9795[5];
         _submit_deps_buf_inline949_inline9832[5] = t__tmp_v450;
-        PTO2TaskId t__tmp_v451 = proj_b_tids_inline1013_inline9795[6];
+        TaskId t__tmp_v451 = proj_b_tids_inline1013_inline9795[6];
         _submit_deps_buf_inline949_inline9832[6] = t__tmp_v451;
-        PTO2TaskId t__tmp_v452 = proj_b_tids_inline1013_inline9795[7];
+        TaskId t__tmp_v452 = proj_b_tids_inline1013_inline9795[7];
         _submit_deps_buf_inline949_inline9832[7] = t__tmp_v452;
 
         // Spmd proj_b_act_spmd_0: proj_b_act_0
@@ -3082,7 +3082,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t86.add_inout(attn_out_inline9847);
         params_t86.launch_spec.set_block_num(8);
         params_t86.set_allow_early_resolve(true);
-        PTO2TaskId params_t86_deps[8];
+        TaskId params_t86_deps[8];
         uint32_t params_t86_deps_count = 0;
         if (_submit_deps_buf_inline949_inline9832[0].is_valid())
             params_t86_deps[params_t86_deps_count++] = _submit_deps_buf_inline949_inline9832[0];
@@ -3331,7 +3331,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         // Phase-fence barrier 3: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_3;
         TaskOutputTensors phase_fence_barrier_3_outs = rt_submit_dummy_task(params_phase_fence_barrier_3);
-        PTO2TaskId seed_dummy_inline2602_inline10083 = phase_fence_barrier_3_outs.task_id();
+        TaskId seed_dummy_inline2602_inline10083 = phase_fence_barrier_3_outs.task_id();
         for (int64_t t0_inline2605_inline10018 = 0;
              t0_inline2605_inline10018 < active_gate_tokens_inline2604_inline10075__phi_v2;
              t0_inline2605_inline10018 += 8) {
@@ -3341,7 +3341,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t95.add_output(x_norm_i8_inline10027);
             params_t95.add_input(xg_buf_inline2582_inline10158);
             params_t95.add_scalar(t0_inline2605_inline10018);
-            PTO2TaskId params_t95_deps[1];
+            TaskId params_t95_deps[1];
             uint32_t params_t95_deps_count = 0;
             if (seed_dummy_inline2602_inline10083.is_valid())
                 params_t95_deps[params_t95_deps_count++] = seed_dummy_inline2602_inline10083;
@@ -3502,7 +3502,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t104.add_scalar(arrived_ctx);
         params_t104.set_allow_early_resolve(true);
         TaskOutputTensors task_104_outs = rt_submit_aiv_task(108, params_t104);
-        PTO2TaskId _meta_tid_inline2705_inline10168 = task_104_outs.task_id();
+        TaskId _meta_tid_inline2705_inline10168 = task_104_outs.task_id();
 
         // Spmd dispatch_push_spmd_0: dispatch_push_0
         CoreTaskArgs params_t105;
@@ -3523,7 +3523,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t105.launch_spec.set_block_num(32);
         params_t105.set_allow_early_resolve(true);
         TaskOutputTensors task_105_outs = rt_submit_aiv_task(109, params_t105);
-        PTO2TaskId _push_tid_inline2710_inline10040 = task_105_outs.task_id();
+        TaskId _push_tid_inline2710_inline10040 = task_105_outs.task_id();
 
         // Task 106: dispatch_wait_0
         CoreTaskArgs params_t106;
@@ -3531,13 +3531,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t106.add_input(ext_data_arrived);
         params_t106.add_scalar(my_rank);
         params_t106.add_scalar(data_arrived_ctx);
-        PTO2TaskId params_t106_deps[1];
+        TaskId params_t106_deps[1];
         uint32_t params_t106_deps_count = 0;
         params_t106_deps[params_t106_deps_count++] = _push_tid_inline2710_inline10040;
         params_t106.set_dependencies(params_t106_deps, params_t106_deps_count);
         params_t106.set_allow_early_resolve(true);
         TaskOutputTensors task_106_outs = rt_submit_aiv_task(110, params_t106);
-        PTO2TaskId _wait_tid_inline2685_inline10023 = task_106_outs.task_id();
+        TaskId _wait_tid_inline2685_inline10023 = task_106_outs.task_id();
 
         // Spmd dispatch_gather_spmd_0: dispatch_gather_0
         CoreTaskArgs params_t107;
@@ -3553,13 +3553,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t107.add_scalar(recv_aux_ctx);
         params_t107.add_scalar(recv_route_ctx);
         params_t107.launch_spec.set_block_num(32);
-        PTO2TaskId params_t107_deps[2];
+        TaskId params_t107_deps[2];
         uint32_t params_t107_deps_count = 0;
         params_t107_deps[params_t107_deps_count++] = _wait_tid_inline2685_inline10023;
         params_t107_deps[params_t107_deps_count++] = _meta_tid_inline2705_inline10168;
         params_t107.set_dependencies(params_t107_deps, params_t107_deps_count);
         TaskOutputTensors task_107_outs = rt_submit_aiv_task(111, params_t107);
-        PTO2TaskId dispatch_push_tid_inline10200 = _push_tid_inline2710_inline10040;
+        TaskId dispatch_push_tid_inline10200 = _push_tid_inline2710_inline10040;
         PTO2_SCOPE() {
             uint32_t recv_y_inline9971_ci_shapes[3] = {32, 16, 4096};
             TensorCreateInfo recv_y_inline9971_ci(recv_y_inline9971_ci_shapes, 3, DataType::BFLOAT16);
@@ -3852,20 +3852,20 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t114.add_scalar(routed_y_buf_ctx);
             params_t114.launch_spec.set_block_num(32);
             TaskOutputTensors task_114_outs = rt_submit_aiv_task(118, params_t114);
-            PTO2TaskId _combine_tid_inline2817_inline10151 = task_114_outs.task_id();
+            TaskId _combine_tid_inline2817_inline10151 = task_114_outs.task_id();
 
             // Task 115: combine_wait_0
             CoreTaskArgs params_t115;
             params_t115.add_input(ext_combine_arrived);
             params_t115.add_scalar(my_rank);
             params_t115.add_scalar(combine_arrived_ctx);
-            PTO2TaskId params_t115_deps[2];
+            TaskId params_t115_deps[2];
             uint32_t params_t115_deps_count = 0;
             params_t115_deps[params_t115_deps_count++] = _combine_tid_inline2817_inline10151;
             params_t115_deps[params_t115_deps_count++] = _push_tid_inline2710_inline10040;
             params_t115.set_dependencies(params_t115_deps, params_t115_deps_count);
             TaskOutputTensors task_115_outs = rt_submit_aiv_task(119, params_t115);
-            PTO2TaskId _cwait_tid_inline2826_inline9926 = task_115_outs.task_id();
+            TaskId _cwait_tid_inline2826_inline9926 = task_115_outs.task_id();
             int64_t active_tokens_inline2816_inline10118 = static_cast<int64_t>(nt_inline677__rv_v2);
             int64_t active_tokens_inline2816_inline10118__phi_v4;
             if ((8 < active_tokens_inline2816_inline10118)) {
@@ -3883,7 +3883,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t116.add_scalar(active_tokens_inline2816_inline10118__phi_v4);
             params_t116.add_scalar(routed_y_buf_ctx);
             params_t116.launch_spec.set_block_num(8);
-            PTO2TaskId params_t116_deps[1];
+            TaskId params_t116_deps[1];
             uint32_t params_t116_deps_count = 0;
             params_t116_deps[params_t116_deps_count++] = _cwait_tid_inline2826_inline9926;
             params_t116.set_dependencies(params_t116_deps, params_t116_deps_count);
@@ -4977,19 +4977,19 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t128.launch_spec.set_block_num((t_dim_inline1640_inline10473 / 8));
             params_t128.set_allow_early_resolve(true);
             TaskOutputTensors task_128_outs = rt_submit_aiv_task(132, params_t128);
-            PTO2TaskId rms_tid_inline1641_inline10652 = task_128_outs.task_id();
-            PTO2TaskId rms_tid_inline10816 = rms_tid_inline1641_inline10652;
+            TaskId rms_tid_inline1641_inline10652 = task_128_outs.task_id();
+            TaskId rms_tid_inline10816 = rms_tid_inline1641_inline10652;
 
             // Phase-fence barrier 4: dependency-only dummy task
             CoreTaskArgs params_phase_fence_barrier_4;
-            PTO2TaskId params_phase_fence_barrier_4_deps[1];
+            TaskId params_phase_fence_barrier_4_deps[1];
             uint32_t params_phase_fence_barrier_4_deps_count = 0;
             params_phase_fence_barrier_4_deps[params_phase_fence_barrier_4_deps_count++] =
                 rms_tid_inline1641_inline10652;
             params_phase_fence_barrier_4.set_dependencies(
                 params_phase_fence_barrier_4_deps, params_phase_fence_barrier_4_deps_count
             );
-            PTO2TaskId late_dep_inline10645 = PTO2TaskId::invalid();
+            TaskId late_dep_inline10645 = TaskId::invalid();
             if (params_phase_fence_barrier_4_deps_count > 0) {
                 TaskOutputTensors phase_fence_barrier_4_outs = rt_submit_dummy_task(params_phase_fence_barrier_4);
                 late_dep_inline10645 = phase_fence_barrier_4_outs.task_id();
@@ -5180,7 +5180,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t135.add_scalar(t_matmul_inline1739_inline10470);
             params_t135.add_scalar(t_dim_inline1772_inline10498);
             params_t135.launch_spec.set_block_num(16);
-            PTO2TaskId params_t135_deps[1];
+            TaskId params_t135_deps[1];
             uint32_t params_t135_deps_count = 0;
             if (late_dep_inline10645.is_valid()) params_t135_deps[params_t135_deps_count++] = late_dep_inline10645;
             params_t135.set_dependencies(params_t135_deps, params_t135_deps_count);
@@ -5262,7 +5262,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t139.add_inout(cmp4_kv_proj_pad_inline1900_inline10467);
             params_t139.add_inout(cmp4_score_proj_pad_inline1878_inline10597);
             params_t139.launch_spec.set_block_num(16);
-            PTO2TaskId params_t139_deps[1];
+            TaskId params_t139_deps[1];
             uint32_t params_t139_deps_count = 0;
             if (late_dep_inline10645.is_valid()) params_t139_deps[params_t139_deps_count++] = late_dep_inline10645;
             params_t139.set_dependencies(params_t139_deps, params_t139_deps_count);
@@ -5363,7 +5363,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t148.add_input(csa_weights_proj_csa_inline553);
             params_t148.add_inout(weights_partial_inline2014_inline10666);
             params_t148.launch_spec.set_block_num(4);
-            PTO2TaskId params_t148_deps[1];
+            TaskId params_t148_deps[1];
             uint32_t params_t148_deps_count = 0;
             if (late_dep_inline10645.is_valid()) params_t148_deps[params_t148_deps_count++] = late_dep_inline10645;
             params_t148.set_dependencies(params_t148_deps, params_t148_deps_count);
@@ -5405,7 +5405,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t150.add_inout(kv_proj_pad_inline14688);
             params_t150.add_inout(score_proj_pad_inline14676);
             params_t150.launch_spec.set_block_num(8);
-            PTO2TaskId params_t150_deps[1];
+            TaskId params_t150_deps[1];
             uint32_t params_t150_deps_count = 0;
             if (late_dep_inline10645.is_valid()) params_t150_deps[params_t150_deps_count++] = late_dep_inline10645;
             params_t150.set_dependencies(params_t150_deps, params_t150_deps_count);
@@ -5529,7 +5529,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t158.add_inout(qk_order_inline2147_inline10861);
             params_t158.set_allow_early_resolve(true);
             TaskOutputTensors task_158_outs = rt_submit_aiv_task(163, params_t158);
-            PTO2TaskId qk_plan_tid_inline2134_inline10864 = task_158_outs.task_id();
+            TaskId qk_plan_tid_inline2134_inline10864 = task_158_outs.task_id();
             int64_t cmp_block_num_inline2124_inline10406 = (int64_t)cmp_kv_csa_inline638.shapes[0];
             uint32_t cmp_kv_flat_inline2128_inline10589_shapes[2] = {
                 static_cast<uint32_t>((cmp_block_num_inline2124_inline10406 * 128)), 512
@@ -5558,7 +5558,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             MixedKernels mixed_159 = {164, 165, 165};
             params_t159.launch_spec.set_block_num(24);
             params_t159.set_allow_early_resolve(true);
-            PTO2TaskId params_t159_deps[1];
+            TaskId params_t159_deps[1];
             uint32_t params_t159_deps_count = 0;
             params_t159_deps[params_t159_deps_count++] = qk_plan_tid_inline2134_inline10864;
             params_t159.set_dependencies(params_t159_deps, params_t159_deps_count);
@@ -5586,10 +5586,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t161.add_inout(o_packed_inline2242_inline10294);
             params_t161.launch_spec.set_block_num(32);
             TaskOutputTensors task_161_outs = rt_submit_aiv_task(167, params_t161);
-            PTO2TaskId merge_tid_inline2186_inline10613 = task_161_outs.task_id();
-            PTO2TaskId proj_b_tids_inline2079_inline10609[8];
+            TaskId merge_tid_inline2186_inline10613 = task_161_outs.task_id();
+            TaskId proj_b_tids_inline2079_inline10609[8];
             for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
-                proj_b_tids_inline2079_inline10609[__init_i] = PTO2TaskId::invalid();
+                proj_b_tids_inline2079_inline10609[__init_i] = TaskId::invalid();
             ChipTensor o_r_pad_inline2225_inline10832__rv_v2 = o_r_pad_inline2225_inline10832;
             PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
                 for (int64_t g_inline2162_inline10271 = 0; g_inline2162_inline10271 < 8;
@@ -5607,13 +5607,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t162.add_scalar(out_col_g_inline2181_inline10439);
                     params_t162.launch_spec.set_block_num(8);
                     params_t162.set_allow_early_resolve(true);
-                    PTO2TaskId params_t162_deps[1];
+                    TaskId params_t162_deps[1];
                     uint32_t params_t162_deps_count = 0;
                     params_t162_deps[params_t162_deps_count++] = merge_tid_inline2186_inline10613;
                     params_t162.set_dependencies(params_t162_deps, params_t162_deps_count);
                     TaskOutputTensors task_162_outs = rt_submit_aic_task(168, params_t162);
                     int64_t n0_inline2077_inline10269 = 0;
-                    PTO2TaskId pa_tid_inline2168_inline10270 = task_162_outs.task_id();
+                    TaskId pa_tid_inline2168_inline10270 = task_162_outs.task_id();
                     int64_t col_g_inline2196_inline10384 = (g_inline2162_inline10271 * 1024);
 
                     // Task 163: quant_1
@@ -5623,13 +5623,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t163.add_input(o_r_pad_inline2225_inline10832__rv_v2);
                     params_t163.add_scalar(col_g_inline2196_inline10384);
                     params_t163.add_scalar(g_inline2162_inline10271);
-                    PTO2TaskId params_t163_deps[1];
+                    TaskId params_t163_deps[1];
                     uint32_t params_t163_deps_count = 0;
                     params_t163_deps[params_t163_deps_count++] = pa_tid_inline2168_inline10270;
                     params_t163.set_dependencies(params_t163_deps, params_t163_deps_count);
                     params_t163.set_allow_early_resolve(true);
                     TaskOutputTensors task_163_outs = rt_submit_aiv_task(169, params_t163);
-                    PTO2TaskId q_tid_inline2071_inline10277 = task_163_outs.task_id();
+                    TaskId q_tid_inline2071_inline10277 = task_163_outs.task_id();
 
                     // Spmd proj_b_mm_spmd_1: proj_b_mm_1
                     CoreTaskArgs params_t164;
@@ -5641,33 +5641,33 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t164.add_scalar(g_inline2162_inline10271);
                     params_t164.launch_spec.set_block_num(8);
                     params_t164.set_allow_early_resolve(true);
-                    PTO2TaskId params_t164_deps[1];
+                    TaskId params_t164_deps[1];
                     uint32_t params_t164_deps_count = 0;
                     params_t164_deps[params_t164_deps_count++] = q_tid_inline2071_inline10277;
                     params_t164.set_dependencies(params_t164_deps, params_t164_deps_count);
                     TaskOutputTensors task_164_outs = rt_submit_aic_task(170, params_t164);
-                    PTO2TaskId pb_tid_inline2057_inline10779 = task_164_outs.task_id();
+                    TaskId pb_tid_inline2057_inline10779 = task_164_outs.task_id();
                     proj_b_tids_inline2079_inline10609[g_inline2162_inline10271] = pb_tid_inline2057_inline10779;
                 }
             }
-            PTO2TaskId _submit_deps_buf_inline2166_inline10248[8];
+            TaskId _submit_deps_buf_inline2166_inline10248[8];
             for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
-                _submit_deps_buf_inline2166_inline10248[__init_i] = PTO2TaskId::invalid();
-            PTO2TaskId t__tmp_v1016 = proj_b_tids_inline2079_inline10609[0];
+                _submit_deps_buf_inline2166_inline10248[__init_i] = TaskId::invalid();
+            TaskId t__tmp_v1016 = proj_b_tids_inline2079_inline10609[0];
             _submit_deps_buf_inline2166_inline10248[0] = t__tmp_v1016;
-            PTO2TaskId t__tmp_v1017 = proj_b_tids_inline2079_inline10609[1];
+            TaskId t__tmp_v1017 = proj_b_tids_inline2079_inline10609[1];
             _submit_deps_buf_inline2166_inline10248[1] = t__tmp_v1017;
-            PTO2TaskId t__tmp_v1018 = proj_b_tids_inline2079_inline10609[2];
+            TaskId t__tmp_v1018 = proj_b_tids_inline2079_inline10609[2];
             _submit_deps_buf_inline2166_inline10248[2] = t__tmp_v1018;
-            PTO2TaskId t__tmp_v1019 = proj_b_tids_inline2079_inline10609[3];
+            TaskId t__tmp_v1019 = proj_b_tids_inline2079_inline10609[3];
             _submit_deps_buf_inline2166_inline10248[3] = t__tmp_v1019;
-            PTO2TaskId t__tmp_v1020 = proj_b_tids_inline2079_inline10609[4];
+            TaskId t__tmp_v1020 = proj_b_tids_inline2079_inline10609[4];
             _submit_deps_buf_inline2166_inline10248[4] = t__tmp_v1020;
-            PTO2TaskId t__tmp_v1021 = proj_b_tids_inline2079_inline10609[5];
+            TaskId t__tmp_v1021 = proj_b_tids_inline2079_inline10609[5];
             _submit_deps_buf_inline2166_inline10248[5] = t__tmp_v1021;
-            PTO2TaskId t__tmp_v1022 = proj_b_tids_inline2079_inline10609[6];
+            TaskId t__tmp_v1022 = proj_b_tids_inline2079_inline10609[6];
             _submit_deps_buf_inline2166_inline10248[6] = t__tmp_v1022;
-            PTO2TaskId t__tmp_v1023 = proj_b_tids_inline2079_inline10609[7];
+            TaskId t__tmp_v1023 = proj_b_tids_inline2079_inline10609[7];
             _submit_deps_buf_inline2166_inline10248[7] = t__tmp_v1023;
 
             // Spmd proj_b_act_spmd_1: proj_b_act_1
@@ -5678,7 +5678,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t165.add_inout(attn_out_inline10836);
             params_t165.launch_spec.set_block_num(8);
             params_t165.set_allow_early_resolve(true);
-            PTO2TaskId params_t165_deps[8];
+            TaskId params_t165_deps[8];
             uint32_t params_t165_deps_count = 0;
             if (_submit_deps_buf_inline2166_inline10248[0].is_valid())
                 params_t165_deps[params_t165_deps_count++] = _submit_deps_buf_inline2166_inline10248[0];
@@ -5933,7 +5933,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             // Phase-fence barrier 5: dependency-only dummy task
             CoreTaskArgs params_phase_fence_barrier_5;
             TaskOutputTensors phase_fence_barrier_5_outs = rt_submit_dummy_task(params_phase_fence_barrier_5);
-            PTO2TaskId seed_dummy_inline2602_inline11128 = phase_fence_barrier_5_outs.task_id();
+            TaskId seed_dummy_inline2602_inline11128 = phase_fence_barrier_5_outs.task_id();
             for (int64_t t0_inline2605_inline11063 = 0;
                  t0_inline2605_inline11063 < active_gate_tokens_inline2604_inline11120__phi_v2;
                  t0_inline2605_inline11063 += 8) {
@@ -5943,7 +5943,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t174.add_inout(x_norm_i8_inline11072);
                 params_t174.add_input(xg_buf_inline2582_inline11203);
                 params_t174.add_scalar(t0_inline2605_inline11063);
-                PTO2TaskId params_t174_deps[1];
+                TaskId params_t174_deps[1];
                 uint32_t params_t174_deps_count = 0;
                 if (seed_dummy_inline2602_inline11128.is_valid())
                     params_t174_deps[params_t174_deps_count++] = seed_dummy_inline2602_inline11128;
@@ -6124,7 +6124,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t184.add_scalar(arrived_ctx);
             params_t184.set_allow_early_resolve(true);
             TaskOutputTensors task_184_outs = rt_submit_aiv_task(191, params_t184);
-            PTO2TaskId _meta_tid_inline2705_inline11213 = task_184_outs.task_id();
+            TaskId _meta_tid_inline2705_inline11213 = task_184_outs.task_id();
 
             // Spmd dispatch_push_spmd_1: dispatch_push_1
             CoreTaskArgs params_t185;
@@ -6145,7 +6145,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t185.launch_spec.set_block_num(32);
             params_t185.set_allow_early_resolve(true);
             TaskOutputTensors task_185_outs = rt_submit_aiv_task(192, params_t185);
-            PTO2TaskId _push_tid_inline2710_inline11085 = task_185_outs.task_id();
+            TaskId _push_tid_inline2710_inline11085 = task_185_outs.task_id();
 
             // Task 186: dispatch_wait_1
             CoreTaskArgs params_t186;
@@ -6154,13 +6154,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t186.add_scalar(my_rank);
             params_t186.add_scalar(csa_moe_epoch_inline715);
             params_t186.add_scalar(data_arrived_ctx);
-            PTO2TaskId params_t186_deps[1];
+            TaskId params_t186_deps[1];
             uint32_t params_t186_deps_count = 0;
             params_t186_deps[params_t186_deps_count++] = _push_tid_inline2710_inline11085;
             params_t186.set_dependencies(params_t186_deps, params_t186_deps_count);
             params_t186.set_allow_early_resolve(true);
             TaskOutputTensors task_186_outs = rt_submit_aiv_task(193, params_t186);
-            PTO2TaskId _wait_tid_inline2685_inline11068 = task_186_outs.task_id();
+            TaskId _wait_tid_inline2685_inline11068 = task_186_outs.task_id();
 
             // Spmd dispatch_gather_spmd_1: dispatch_gather_1
             CoreTaskArgs params_t187;
@@ -6176,13 +6176,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t187.add_scalar(recv_aux_ctx);
             params_t187.add_scalar(recv_route_ctx);
             params_t187.launch_spec.set_block_num(32);
-            PTO2TaskId params_t187_deps[2];
+            TaskId params_t187_deps[2];
             uint32_t params_t187_deps_count = 0;
             params_t187_deps[params_t187_deps_count++] = _wait_tid_inline2685_inline11068;
             params_t187_deps[params_t187_deps_count++] = _meta_tid_inline2705_inline11213;
             params_t187.set_dependencies(params_t187_deps, params_t187_deps_count);
             TaskOutputTensors task_187_outs = rt_submit_aiv_task(194, params_t187);
-            PTO2TaskId dispatch_push_tid_inline11245 = _push_tid_inline2710_inline11085;
+            TaskId dispatch_push_tid_inline11245 = _push_tid_inline2710_inline11085;
             PTO2_SCOPE() {
                 uint32_t recv_y_inline11016_ci_shapes[3] = {32, 16, 4096};
                 TensorCreateInfo recv_y_inline11016_ci(recv_y_inline11016_ci_shapes, 3, DataType::BFLOAT16);
@@ -6481,7 +6481,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t194.add_scalar(routed_y_buf_ctx);
                 params_t194.launch_spec.set_block_num(32);
                 TaskOutputTensors task_194_outs = rt_submit_aiv_task(201, params_t194);
-                PTO2TaskId _combine_tid_inline2817_inline11196 = task_194_outs.task_id();
+                TaskId _combine_tid_inline2817_inline11196 = task_194_outs.task_id();
 
                 // Task 195: combine_wait_1
                 CoreTaskArgs params_t195;
@@ -6489,13 +6489,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t195.add_scalar(my_rank);
                 params_t195.add_scalar(csa_moe_epoch_inline715);
                 params_t195.add_scalar(combine_arrived_ctx);
-                PTO2TaskId params_t195_deps[2];
+                TaskId params_t195_deps[2];
                 uint32_t params_t195_deps_count = 0;
                 params_t195_deps[params_t195_deps_count++] = _combine_tid_inline2817_inline11196;
                 params_t195_deps[params_t195_deps_count++] = _push_tid_inline2710_inline11085;
                 params_t195.set_dependencies(params_t195_deps, params_t195_deps_count);
                 TaskOutputTensors task_195_outs = rt_submit_aiv_task(202, params_t195);
-                PTO2TaskId _cwait_tid_inline2826_inline10971 = task_195_outs.task_id();
+                TaskId _cwait_tid_inline2826_inline10971 = task_195_outs.task_id();
                 int64_t active_tokens_inline2816_inline11163 = static_cast<int64_t>(nt_inline677__rv_v2);
                 int64_t active_tokens_inline2816_inline11163__phi_v4;
                 if ((8 < active_tokens_inline2816_inline11163)) {
@@ -6513,7 +6513,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t196.add_scalar(active_tokens_inline2816_inline11163__phi_v4);
                 params_t196.add_scalar(routed_y_buf_ctx);
                 params_t196.launch_spec.set_block_num(8);
-                PTO2TaskId params_t196_deps[1];
+                TaskId params_t196_deps[1];
                 uint32_t params_t196_deps_count = 0;
                 params_t196_deps[params_t196_deps_count++] = _cwait_tid_inline2826_inline10971;
                 params_t196.set_dependencies(params_t196_deps, params_t196_deps_count);
@@ -7311,19 +7311,19 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t206.launch_spec.set_block_num((t_dim_inline1151_inline11588 / 8));
             params_t206.set_allow_early_resolve(true);
             TaskOutputTensors task_206_outs = rt_submit_aiv_task(213, params_t206);
-            PTO2TaskId rms_tid_inline1152_inline11584 = task_206_outs.task_id();
-            PTO2TaskId rms_tid_inline11632 = rms_tid_inline1152_inline11584;
+            TaskId rms_tid_inline1152_inline11584 = task_206_outs.task_id();
+            TaskId rms_tid_inline11632 = rms_tid_inline1152_inline11584;
 
             // Phase-fence barrier 6: dependency-only dummy task
             CoreTaskArgs params_phase_fence_barrier_6;
-            PTO2TaskId params_phase_fence_barrier_6_deps[1];
+            TaskId params_phase_fence_barrier_6_deps[1];
             uint32_t params_phase_fence_barrier_6_deps_count = 0;
             params_phase_fence_barrier_6_deps[params_phase_fence_barrier_6_deps_count++] =
                 rms_tid_inline1152_inline11584;
             params_phase_fence_barrier_6.set_dependencies(
                 params_phase_fence_barrier_6_deps, params_phase_fence_barrier_6_deps_count
             );
-            PTO2TaskId late_dep_inline11598 = PTO2TaskId::invalid();
+            TaskId late_dep_inline11598 = TaskId::invalid();
             if (params_phase_fence_barrier_6_deps_count > 0) {
                 TaskOutputTensors phase_fence_barrier_6_outs = rt_submit_dummy_task(params_phase_fence_barrier_6);
                 late_dep_inline11598 = phase_fence_barrier_6_outs.task_id();
@@ -7514,7 +7514,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t213.add_scalar(t_matmul_inline1250_inline11559);
             params_t213.add_scalar(t_dim_inline1283_inline11618);
             params_t213.launch_spec.set_block_num(16);
-            PTO2TaskId params_t213_deps[1];
+            TaskId params_t213_deps[1];
             uint32_t params_t213_deps_count = 0;
             if (late_dep_inline11598.is_valid()) params_t213_deps[params_t213_deps_count++] = late_dep_inline11598;
             params_t213.set_dependencies(params_t213_deps, params_t213_deps_count);
@@ -7582,7 +7582,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t217.add_inout(score_proj_pad_inline1382_inline11463);
             params_t217.add_scalar(bs_inline1375_inline11667);
             params_t217.launch_spec.set_block_num((t_matmul_inline1366_inline11787 / 2));
-            PTO2TaskId params_t217_deps[1];
+            TaskId params_t217_deps[1];
             uint32_t params_t217_deps_count = 0;
             if (late_dep_inline11598.is_valid()) params_t217_deps[params_t217_deps_count++] = late_dep_inline11598;
             params_t217.set_dependencies(params_t217_deps, params_t217_deps_count);
@@ -7608,7 +7608,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t218.add_scalar(b_dim_inline1393_inline11785);
             params_t218.add_scalar(s_dim_inline1364_inline11456);
             TaskOutputTensors task_218_outs = rt_submit_aiv_task(225, params_t218);
-            PTO2TaskId pool_tid_inline1365_inline11753 = task_218_outs.task_id();
+            TaskId pool_tid_inline1365_inline11753 = task_218_outs.task_id();
             uint32_t norm_w_2d_inline1362_inline11652_shapes[2] = {1, 512};
             ChipTensor norm_w_2d_inline1362_inline11652 =
                 hca_cmp_norm_w_hca_inline520.reshape(norm_w_2d_inline1362_inline11652_shapes, 2);
@@ -7635,7 +7635,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t219.add_input(cmp_slot_mapping_bsd_inline11721);
             params_t219.add_scalar(b_dim_inline1393_inline11785);
             params_t219.add_scalar(s_dim_inline1364_inline11456);
-            PTO2TaskId params_t219_deps[1];
+            TaskId params_t219_deps[1];
             uint32_t params_t219_deps_count = 0;
             params_t219_deps[params_t219_deps_count++] = pool_tid_inline1365_inline11753;
             params_t219.set_dependencies(params_t219_deps, params_t219_deps_count);
@@ -7680,7 +7680,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t222.add_input(cmp_kv_flat_inline1500_inline11375);
             params_t222.launch_spec.set_block_num(32);
             TaskOutputTensors task_222_outs = rt_submit_aiv_task(229, params_t222);
-            PTO2TaskId gather_tid_inline1486_inline11365 = task_222_outs.task_id();
+            TaskId gather_tid_inline1486_inline11365 = task_222_outs.task_id();
             uint32_t q_flat_inline1542_inline11350_shapes[2] = {512, 512};
             ChipTensor q_flat_inline1542_inline11350 = q_inline11621.reshape(q_flat_inline1542_inline11350_shapes, 2);
 
@@ -7696,7 +7696,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             MixedKernels mixed_223 = {230, 231, 231};
             params_t223.launch_spec.set_block_num(16);
             params_t223.set_allow_early_resolve(true);
-            PTO2TaskId params_t223_deps[1];
+            TaskId params_t223_deps[1];
             uint32_t params_t223_deps_count = 0;
             params_t223_deps[params_t223_deps_count++] = gather_tid_inline1486_inline11365;
             params_t223.set_dependencies(params_t223_deps, params_t223_deps_count);
@@ -7728,10 +7728,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t226.add_inout(o_packed_inline1463_inline11349);
             params_t226.launch_spec.set_block_num(32);
             TaskOutputTensors task_226_outs = rt_submit_aiv_task(234, params_t226);
-            PTO2TaskId merge_tid_inline1576_inline11323 = task_226_outs.task_id();
-            PTO2TaskId proj_b_tids_inline1519_inline11335[8];
+            TaskId merge_tid_inline1576_inline11323 = task_226_outs.task_id();
+            TaskId proj_b_tids_inline1519_inline11335[8];
             for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
-                proj_b_tids_inline1519_inline11335[__init_i] = PTO2TaskId::invalid();
+                proj_b_tids_inline1519_inline11335[__init_i] = TaskId::invalid();
             ChipTensor o_r_pad_inline1536_inline11403__rv_v2 = o_r_pad_inline1536_inline11403;
             PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
                 for (int64_t g_inline1480_inline11801 = 0; g_inline1480_inline11801 < 8;
@@ -7749,13 +7749,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t227.add_scalar(out_col_g_inline1609_inline11551);
                     params_t227.launch_spec.set_block_num(8);
                     params_t227.set_allow_early_resolve(true);
-                    PTO2TaskId params_t227_deps[1];
+                    TaskId params_t227_deps[1];
                     uint32_t params_t227_deps_count = 0;
                     params_t227_deps[params_t227_deps_count++] = merge_tid_inline1576_inline11323;
                     params_t227.set_dependencies(params_t227_deps, params_t227_deps_count);
                     TaskOutputTensors task_227_outs = rt_submit_aic_task(235, params_t227);
                     int64_t n0_inline1453_inline11306 = 0;
-                    PTO2TaskId pa_tid_inline1586_inline11308 = task_227_outs.task_id();
+                    TaskId pa_tid_inline1586_inline11308 = task_227_outs.task_id();
                     int64_t col_g_inline1449_inline11676 = (g_inline1480_inline11801 * 1024);
 
                     // Task 228: quant_2
@@ -7765,13 +7765,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t228.add_input(o_r_pad_inline1536_inline11403__rv_v2);
                     params_t228.add_scalar(col_g_inline1449_inline11676);
                     params_t228.add_scalar(g_inline1480_inline11801);
-                    PTO2TaskId params_t228_deps[1];
+                    TaskId params_t228_deps[1];
                     uint32_t params_t228_deps_count = 0;
                     params_t228_deps[params_t228_deps_count++] = pa_tid_inline1586_inline11308;
                     params_t228.set_dependencies(params_t228_deps, params_t228_deps_count);
                     params_t228.set_allow_early_resolve(true);
                     TaskOutputTensors task_228_outs = rt_submit_aiv_task(236, params_t228);
-                    PTO2TaskId q_tid_inline1448_inline11299 = task_228_outs.task_id();
+                    TaskId q_tid_inline1448_inline11299 = task_228_outs.task_id();
 
                     // Spmd proj_b_mm_spmd_2: proj_b_mm_2
                     CoreTaskArgs params_t229;
@@ -7783,33 +7783,33 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t229.add_scalar(g_inline1480_inline11801);
                     params_t229.launch_spec.set_block_num(8);
                     params_t229.set_allow_early_resolve(true);
-                    PTO2TaskId params_t229_deps[1];
+                    TaskId params_t229_deps[1];
                     uint32_t params_t229_deps_count = 0;
                     params_t229_deps[params_t229_deps_count++] = q_tid_inline1448_inline11299;
                     params_t229.set_dependencies(params_t229_deps, params_t229_deps_count);
                     TaskOutputTensors task_229_outs = rt_submit_aic_task(237, params_t229);
-                    PTO2TaskId pb_tid_inline1437_inline11597 = task_229_outs.task_id();
+                    TaskId pb_tid_inline1437_inline11597 = task_229_outs.task_id();
                     proj_b_tids_inline1519_inline11335[g_inline1480_inline11801] = pb_tid_inline1437_inline11597;
                 }
             }
-            PTO2TaskId _submit_deps_buf_inline1434_inline11286[8];
+            TaskId _submit_deps_buf_inline1434_inline11286[8];
             for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
-                _submit_deps_buf_inline1434_inline11286[__init_i] = PTO2TaskId::invalid();
-            PTO2TaskId t__tmp_v1414 = proj_b_tids_inline1519_inline11335[0];
+                _submit_deps_buf_inline1434_inline11286[__init_i] = TaskId::invalid();
+            TaskId t__tmp_v1414 = proj_b_tids_inline1519_inline11335[0];
             _submit_deps_buf_inline1434_inline11286[0] = t__tmp_v1414;
-            PTO2TaskId t__tmp_v1415 = proj_b_tids_inline1519_inline11335[1];
+            TaskId t__tmp_v1415 = proj_b_tids_inline1519_inline11335[1];
             _submit_deps_buf_inline1434_inline11286[1] = t__tmp_v1415;
-            PTO2TaskId t__tmp_v1416 = proj_b_tids_inline1519_inline11335[2];
+            TaskId t__tmp_v1416 = proj_b_tids_inline1519_inline11335[2];
             _submit_deps_buf_inline1434_inline11286[2] = t__tmp_v1416;
-            PTO2TaskId t__tmp_v1417 = proj_b_tids_inline1519_inline11335[3];
+            TaskId t__tmp_v1417 = proj_b_tids_inline1519_inline11335[3];
             _submit_deps_buf_inline1434_inline11286[3] = t__tmp_v1417;
-            PTO2TaskId t__tmp_v1418 = proj_b_tids_inline1519_inline11335[4];
+            TaskId t__tmp_v1418 = proj_b_tids_inline1519_inline11335[4];
             _submit_deps_buf_inline1434_inline11286[4] = t__tmp_v1418;
-            PTO2TaskId t__tmp_v1419 = proj_b_tids_inline1519_inline11335[5];
+            TaskId t__tmp_v1419 = proj_b_tids_inline1519_inline11335[5];
             _submit_deps_buf_inline1434_inline11286[5] = t__tmp_v1419;
-            PTO2TaskId t__tmp_v1420 = proj_b_tids_inline1519_inline11335[6];
+            TaskId t__tmp_v1420 = proj_b_tids_inline1519_inline11335[6];
             _submit_deps_buf_inline1434_inline11286[6] = t__tmp_v1420;
-            PTO2TaskId t__tmp_v1421 = proj_b_tids_inline1519_inline11335[7];
+            TaskId t__tmp_v1421 = proj_b_tids_inline1519_inline11335[7];
             _submit_deps_buf_inline1434_inline11286[7] = t__tmp_v1421;
 
             // Spmd proj_b_act_spmd_2: proj_b_act_2
@@ -7820,7 +7820,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t230.add_inout(attn_out_inline11390);
             params_t230.launch_spec.set_block_num(8);
             params_t230.set_allow_early_resolve(true);
-            PTO2TaskId params_t230_deps[8];
+            TaskId params_t230_deps[8];
             uint32_t params_t230_deps_count = 0;
             if (_submit_deps_buf_inline1434_inline11286[0].is_valid())
                 params_t230_deps[params_t230_deps_count++] = _submit_deps_buf_inline1434_inline11286[0];
@@ -8075,7 +8075,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             // Phase-fence barrier 7: dependency-only dummy task
             CoreTaskArgs params_phase_fence_barrier_7;
             TaskOutputTensors phase_fence_barrier_7_outs = rt_submit_dummy_task(params_phase_fence_barrier_7);
-            PTO2TaskId seed_dummy_inline2602_inline12007 = phase_fence_barrier_7_outs.task_id();
+            TaskId seed_dummy_inline2602_inline12007 = phase_fence_barrier_7_outs.task_id();
             for (int64_t t0_inline2605_inline11942 = 0;
                  t0_inline2605_inline11942 < active_gate_tokens_inline2604_inline11999__phi_v2;
                  t0_inline2605_inline11942 += 8) {
@@ -8085,7 +8085,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t239.add_inout(x_norm_i8_inline11951);
                 params_t239.add_input(xg_buf_inline2582_inline12082);
                 params_t239.add_scalar(t0_inline2605_inline11942);
-                PTO2TaskId params_t239_deps[1];
+                TaskId params_t239_deps[1];
                 uint32_t params_t239_deps_count = 0;
                 if (seed_dummy_inline2602_inline12007.is_valid())
                     params_t239_deps[params_t239_deps_count++] = seed_dummy_inline2602_inline12007;
@@ -8252,7 +8252,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t248.add_scalar(arrived_ctx);
             params_t248.set_allow_early_resolve(true);
             TaskOutputTensors task_248_outs = rt_submit_aiv_task(257, params_t248);
-            PTO2TaskId _meta_tid_inline2705_inline12092 = task_248_outs.task_id();
+            TaskId _meta_tid_inline2705_inline12092 = task_248_outs.task_id();
 
             // Spmd dispatch_push_spmd_2: dispatch_push_2
             CoreTaskArgs params_t249;
@@ -8273,7 +8273,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t249.launch_spec.set_block_num(32);
             params_t249.set_allow_early_resolve(true);
             TaskOutputTensors task_249_outs = rt_submit_aiv_task(258, params_t249);
-            PTO2TaskId _push_tid_inline2710_inline11964 = task_249_outs.task_id();
+            TaskId _push_tid_inline2710_inline11964 = task_249_outs.task_id();
 
             // Task 250: dispatch_wait_2
             CoreTaskArgs params_t250;
@@ -8282,13 +8282,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t250.add_scalar(my_rank);
             params_t250.add_scalar(hca_moe_epoch_inline716);
             params_t250.add_scalar(data_arrived_ctx);
-            PTO2TaskId params_t250_deps[1];
+            TaskId params_t250_deps[1];
             uint32_t params_t250_deps_count = 0;
             params_t250_deps[params_t250_deps_count++] = _push_tid_inline2710_inline11964;
             params_t250.set_dependencies(params_t250_deps, params_t250_deps_count);
             params_t250.set_allow_early_resolve(true);
             TaskOutputTensors task_250_outs = rt_submit_aiv_task(259, params_t250);
-            PTO2TaskId _wait_tid_inline2685_inline11947 = task_250_outs.task_id();
+            TaskId _wait_tid_inline2685_inline11947 = task_250_outs.task_id();
 
             // Spmd dispatch_gather_spmd_2: dispatch_gather_2
             CoreTaskArgs params_t251;
@@ -8304,13 +8304,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t251.add_scalar(recv_aux_ctx);
             params_t251.add_scalar(recv_route_ctx);
             params_t251.launch_spec.set_block_num(32);
-            PTO2TaskId params_t251_deps[2];
+            TaskId params_t251_deps[2];
             uint32_t params_t251_deps_count = 0;
             params_t251_deps[params_t251_deps_count++] = _wait_tid_inline2685_inline11947;
             params_t251_deps[params_t251_deps_count++] = _meta_tid_inline2705_inline12092;
             params_t251.set_dependencies(params_t251_deps, params_t251_deps_count);
             TaskOutputTensors task_251_outs = rt_submit_aiv_task(260, params_t251);
-            PTO2TaskId dispatch_push_tid_inline12124 = _push_tid_inline2710_inline11964;
+            TaskId dispatch_push_tid_inline12124 = _push_tid_inline2710_inline11964;
             PTO2_SCOPE() {
                 uint32_t recv_y_inline11895_ci_shapes[3] = {32, 16, 4096};
                 TensorCreateInfo recv_y_inline11895_ci(recv_y_inline11895_ci_shapes, 3, DataType::BFLOAT16);
@@ -8609,7 +8609,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t258.add_scalar(routed_y_buf_ctx);
                 params_t258.launch_spec.set_block_num(32);
                 TaskOutputTensors task_258_outs = rt_submit_aiv_task(267, params_t258);
-                PTO2TaskId _combine_tid_inline2817_inline12075 = task_258_outs.task_id();
+                TaskId _combine_tid_inline2817_inline12075 = task_258_outs.task_id();
 
                 // Task 259: combine_wait_2
                 CoreTaskArgs params_t259;
@@ -8617,13 +8617,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t259.add_scalar(my_rank);
                 params_t259.add_scalar(hca_moe_epoch_inline716);
                 params_t259.add_scalar(combine_arrived_ctx);
-                PTO2TaskId params_t259_deps[2];
+                TaskId params_t259_deps[2];
                 uint32_t params_t259_deps_count = 0;
                 params_t259_deps[params_t259_deps_count++] = _combine_tid_inline2817_inline12075;
                 params_t259_deps[params_t259_deps_count++] = _push_tid_inline2710_inline11964;
                 params_t259.set_dependencies(params_t259_deps, params_t259_deps_count);
                 TaskOutputTensors task_259_outs = rt_submit_aiv_task(268, params_t259);
-                PTO2TaskId _cwait_tid_inline2826_inline11850 = task_259_outs.task_id();
+                TaskId _cwait_tid_inline2826_inline11850 = task_259_outs.task_id();
                 int64_t active_tokens_inline2816_inline12042 = static_cast<int64_t>(nt_inline677__rv_v2);
                 int64_t active_tokens_inline2816_inline12042__phi_v4;
                 if ((8 < active_tokens_inline2816_inline12042)) {
@@ -8641,7 +8641,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t260.add_scalar(active_tokens_inline2816_inline12042__phi_v4);
                 params_t260.add_scalar(routed_y_buf_ctx);
                 params_t260.launch_spec.set_block_num(8);
-                PTO2TaskId params_t260_deps[1];
+                TaskId params_t260_deps[1];
                 uint32_t params_t260_deps_count = 0;
                 params_t260_deps[params_t260_deps_count++] = _cwait_tid_inline2826_inline11850;
                 params_t260.set_dependencies(params_t260_deps, params_t260_deps_count);
@@ -9708,18 +9708,18 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t272.launch_spec.set_block_num((t_dim_inline1640_inline12397 / 8));
         params_t272.set_allow_early_resolve(true);
         TaskOutputTensors task_272_outs = rt_submit_aiv_task(281, params_t272);
-        PTO2TaskId rms_tid_inline1641_inline12576 = task_272_outs.task_id();
-        PTO2TaskId rms_tid_inline12740 = rms_tid_inline1641_inline12576;
+        TaskId rms_tid_inline1641_inline12576 = task_272_outs.task_id();
+        TaskId rms_tid_inline12740 = rms_tid_inline1641_inline12576;
 
         // Phase-fence barrier 8: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_8;
-        PTO2TaskId params_phase_fence_barrier_8_deps[1];
+        TaskId params_phase_fence_barrier_8_deps[1];
         uint32_t params_phase_fence_barrier_8_deps_count = 0;
         params_phase_fence_barrier_8_deps[params_phase_fence_barrier_8_deps_count++] = rms_tid_inline1641_inline12576;
         params_phase_fence_barrier_8.set_dependencies(
             params_phase_fence_barrier_8_deps, params_phase_fence_barrier_8_deps_count
         );
-        PTO2TaskId late_dep_inline12569 = PTO2TaskId::invalid();
+        TaskId late_dep_inline12569 = TaskId::invalid();
         if (params_phase_fence_barrier_8_deps_count > 0) {
             TaskOutputTensors phase_fence_barrier_8_outs = rt_submit_dummy_task(params_phase_fence_barrier_8);
             late_dep_inline12569 = phase_fence_barrier_8_outs.task_id();
@@ -9900,7 +9900,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t279.add_scalar(t_matmul_inline1739_inline12394);
         params_t279.add_scalar(t_dim_inline1772_inline12422);
         params_t279.launch_spec.set_block_num(16);
-        PTO2TaskId params_t279_deps[1];
+        TaskId params_t279_deps[1];
         uint32_t params_t279_deps_count = 0;
         if (late_dep_inline12569.is_valid()) params_t279_deps[params_t279_deps_count++] = late_dep_inline12569;
         params_t279.set_dependencies(params_t279_deps, params_t279_deps_count);
@@ -9979,7 +9979,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t283.add_inout(cmp4_kv_proj_pad_inline1900_inline12391);
         params_t283.add_inout(cmp4_score_proj_pad_inline1878_inline12521);
         params_t283.launch_spec.set_block_num(16);
-        PTO2TaskId params_t283_deps[1];
+        TaskId params_t283_deps[1];
         uint32_t params_t283_deps_count = 0;
         if (late_dep_inline12569.is_valid()) params_t283_deps[params_t283_deps_count++] = late_dep_inline12569;
         params_t283.set_dependencies(params_t283_deps, params_t283_deps_count);
@@ -10080,7 +10080,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t292.add_input(csa_weights_proj_last_inline671);
         params_t292.add_inout(weights_partial_inline2014_inline12590);
         params_t292.launch_spec.set_block_num(4);
-        PTO2TaskId params_t292_deps[1];
+        TaskId params_t292_deps[1];
         uint32_t params_t292_deps_count = 0;
         if (late_dep_inline12569.is_valid()) params_t292_deps[params_t292_deps_count++] = late_dep_inline12569;
         params_t292.set_dependencies(params_t292_deps, params_t292_deps_count);
@@ -10122,7 +10122,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t294.add_inout(kv_proj_pad_inline15316);
         params_t294.add_inout(score_proj_pad_inline15304);
         params_t294.launch_spec.set_block_num(8);
-        PTO2TaskId params_t294_deps[1];
+        TaskId params_t294_deps[1];
         uint32_t params_t294_deps_count = 0;
         if (late_dep_inline12569.is_valid()) params_t294_deps[params_t294_deps_count++] = late_dep_inline12569;
         params_t294.set_dependencies(params_t294_deps, params_t294_deps_count);
@@ -10245,7 +10245,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t302.add_output(qk_order_inline2147_inline12785);
         params_t302.set_allow_early_resolve(true);
         TaskOutputTensors task_302_outs = rt_submit_aiv_task(312, params_t302);
-        PTO2TaskId qk_plan_tid_inline2134_inline12788 = task_302_outs.task_id();
+        TaskId qk_plan_tid_inline2134_inline12788 = task_302_outs.task_id();
         int64_t cmp_block_num_inline2124_inline12330 = (int64_t)cmp_kv_last_inline555.shapes[0];
         uint32_t cmp_kv_flat_inline2128_inline12513_shapes[2] = {
             static_cast<uint32_t>((cmp_block_num_inline2124_inline12330 * 128)), 512
@@ -10274,7 +10274,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         MixedKernels mixed_303 = {313, 314, 314};
         params_t303.launch_spec.set_block_num(24);
         params_t303.set_allow_early_resolve(true);
-        PTO2TaskId params_t303_deps[1];
+        TaskId params_t303_deps[1];
         uint32_t params_t303_deps_count = 0;
         params_t303_deps[params_t303_deps_count++] = qk_plan_tid_inline2134_inline12788;
         params_t303.set_dependencies(params_t303_deps, params_t303_deps_count);
@@ -10302,10 +10302,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t305.add_inout(o_packed_inline2242_inline12218);
         params_t305.launch_spec.set_block_num(32);
         TaskOutputTensors task_305_outs = rt_submit_aiv_task(316, params_t305);
-        PTO2TaskId merge_tid_inline2186_inline12537 = task_305_outs.task_id();
-        PTO2TaskId proj_b_tids_inline2079_inline12533[8];
+        TaskId merge_tid_inline2186_inline12537 = task_305_outs.task_id();
+        TaskId proj_b_tids_inline2079_inline12533[8];
         for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
-            proj_b_tids_inline2079_inline12533[__init_i] = PTO2TaskId::invalid();
+            proj_b_tids_inline2079_inline12533[__init_i] = TaskId::invalid();
         ChipTensor o_r_pad_inline2225_inline12756__rv_v2 = o_r_pad_inline2225_inline12756;
         PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
             for (int64_t g_inline2162_inline12195 = 0; g_inline2162_inline12195 < 8; g_inline2162_inline12195 += 1) {
@@ -10322,13 +10322,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t306.add_scalar(out_col_g_inline2181_inline12363);
                 params_t306.launch_spec.set_block_num(8);
                 params_t306.set_allow_early_resolve(true);
-                PTO2TaskId params_t306_deps[1];
+                TaskId params_t306_deps[1];
                 uint32_t params_t306_deps_count = 0;
                 params_t306_deps[params_t306_deps_count++] = merge_tid_inline2186_inline12537;
                 params_t306.set_dependencies(params_t306_deps, params_t306_deps_count);
                 TaskOutputTensors task_306_outs = rt_submit_aic_task(317, params_t306);
                 int64_t n0_inline2077_inline12193 = 0;
-                PTO2TaskId pa_tid_inline2168_inline12194 = task_306_outs.task_id();
+                TaskId pa_tid_inline2168_inline12194 = task_306_outs.task_id();
                 int64_t col_g_inline2196_inline12308 = (g_inline2162_inline12195 * 1024);
 
                 // Task 307: quant_3
@@ -10338,13 +10338,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t307.add_input(o_r_pad_inline2225_inline12756__rv_v2);
                 params_t307.add_scalar(col_g_inline2196_inline12308);
                 params_t307.add_scalar(g_inline2162_inline12195);
-                PTO2TaskId params_t307_deps[1];
+                TaskId params_t307_deps[1];
                 uint32_t params_t307_deps_count = 0;
                 params_t307_deps[params_t307_deps_count++] = pa_tid_inline2168_inline12194;
                 params_t307.set_dependencies(params_t307_deps, params_t307_deps_count);
                 params_t307.set_allow_early_resolve(true);
                 TaskOutputTensors task_307_outs = rt_submit_aiv_task(318, params_t307);
-                PTO2TaskId q_tid_inline2071_inline12201 = task_307_outs.task_id();
+                TaskId q_tid_inline2071_inline12201 = task_307_outs.task_id();
 
                 // Spmd proj_b_mm_spmd_3: proj_b_mm_3
                 CoreTaskArgs params_t308;
@@ -10356,33 +10356,33 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t308.add_scalar(g_inline2162_inline12195);
                 params_t308.launch_spec.set_block_num(8);
                 params_t308.set_allow_early_resolve(true);
-                PTO2TaskId params_t308_deps[1];
+                TaskId params_t308_deps[1];
                 uint32_t params_t308_deps_count = 0;
                 params_t308_deps[params_t308_deps_count++] = q_tid_inline2071_inline12201;
                 params_t308.set_dependencies(params_t308_deps, params_t308_deps_count);
                 TaskOutputTensors task_308_outs = rt_submit_aic_task(319, params_t308);
-                PTO2TaskId pb_tid_inline2057_inline12703 = task_308_outs.task_id();
+                TaskId pb_tid_inline2057_inline12703 = task_308_outs.task_id();
                 proj_b_tids_inline2079_inline12533[g_inline2162_inline12195] = pb_tid_inline2057_inline12703;
             }
         }
-        PTO2TaskId _submit_deps_buf_inline2166_inline12172[8];
+        TaskId _submit_deps_buf_inline2166_inline12172[8];
         for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
-            _submit_deps_buf_inline2166_inline12172[__init_i] = PTO2TaskId::invalid();
-        PTO2TaskId t__tmp_v1986 = proj_b_tids_inline2079_inline12533[0];
+            _submit_deps_buf_inline2166_inline12172[__init_i] = TaskId::invalid();
+        TaskId t__tmp_v1986 = proj_b_tids_inline2079_inline12533[0];
         _submit_deps_buf_inline2166_inline12172[0] = t__tmp_v1986;
-        PTO2TaskId t__tmp_v1987 = proj_b_tids_inline2079_inline12533[1];
+        TaskId t__tmp_v1987 = proj_b_tids_inline2079_inline12533[1];
         _submit_deps_buf_inline2166_inline12172[1] = t__tmp_v1987;
-        PTO2TaskId t__tmp_v1988 = proj_b_tids_inline2079_inline12533[2];
+        TaskId t__tmp_v1988 = proj_b_tids_inline2079_inline12533[2];
         _submit_deps_buf_inline2166_inline12172[2] = t__tmp_v1988;
-        PTO2TaskId t__tmp_v1989 = proj_b_tids_inline2079_inline12533[3];
+        TaskId t__tmp_v1989 = proj_b_tids_inline2079_inline12533[3];
         _submit_deps_buf_inline2166_inline12172[3] = t__tmp_v1989;
-        PTO2TaskId t__tmp_v1990 = proj_b_tids_inline2079_inline12533[4];
+        TaskId t__tmp_v1990 = proj_b_tids_inline2079_inline12533[4];
         _submit_deps_buf_inline2166_inline12172[4] = t__tmp_v1990;
-        PTO2TaskId t__tmp_v1991 = proj_b_tids_inline2079_inline12533[5];
+        TaskId t__tmp_v1991 = proj_b_tids_inline2079_inline12533[5];
         _submit_deps_buf_inline2166_inline12172[5] = t__tmp_v1991;
-        PTO2TaskId t__tmp_v1992 = proj_b_tids_inline2079_inline12533[6];
+        TaskId t__tmp_v1992 = proj_b_tids_inline2079_inline12533[6];
         _submit_deps_buf_inline2166_inline12172[6] = t__tmp_v1992;
-        PTO2TaskId t__tmp_v1993 = proj_b_tids_inline2079_inline12533[7];
+        TaskId t__tmp_v1993 = proj_b_tids_inline2079_inline12533[7];
         _submit_deps_buf_inline2166_inline12172[7] = t__tmp_v1993;
 
         // Spmd proj_b_act_spmd_3: proj_b_act_3
@@ -10393,7 +10393,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t309.add_inout(attn_out_inline12760);
         params_t309.launch_spec.set_block_num(8);
         params_t309.set_allow_early_resolve(true);
-        PTO2TaskId params_t309_deps[8];
+        TaskId params_t309_deps[8];
         uint32_t params_t309_deps_count = 0;
         if (_submit_deps_buf_inline2166_inline12172[0].is_valid())
             params_t309_deps[params_t309_deps_count++] = _submit_deps_buf_inline2166_inline12172[0];
@@ -10643,7 +10643,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         // Phase-fence barrier 9: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_9;
         TaskOutputTensors phase_fence_barrier_9_outs = rt_submit_dummy_task(params_phase_fence_barrier_9);
-        PTO2TaskId seed_dummy_inline2602_inline13052 = phase_fence_barrier_9_outs.task_id();
+        TaskId seed_dummy_inline2602_inline13052 = phase_fence_barrier_9_outs.task_id();
         for (int64_t t0_inline2605_inline12987 = 0;
              t0_inline2605_inline12987 < active_gate_tokens_inline2604_inline13044__phi_v2;
              t0_inline2605_inline12987 += 8) {
@@ -10653,7 +10653,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t318.add_output(x_norm_i8_inline12996);
             params_t318.add_input(xg_buf_inline2582_inline13127);
             params_t318.add_scalar(t0_inline2605_inline12987);
-            PTO2TaskId params_t318_deps[1];
+            TaskId params_t318_deps[1];
             uint32_t params_t318_deps_count = 0;
             if (seed_dummy_inline2602_inline13052.is_valid())
                 params_t318_deps[params_t318_deps_count++] = seed_dummy_inline2602_inline13052;
@@ -10815,7 +10815,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t327.add_scalar(arrived_ctx);
         params_t327.set_allow_early_resolve(true);
         TaskOutputTensors task_327_outs = rt_submit_aiv_task(339, params_t327);
-        PTO2TaskId _meta_tid_inline2705_inline13137 = task_327_outs.task_id();
+        TaskId _meta_tid_inline2705_inline13137 = task_327_outs.task_id();
 
         // Spmd dispatch_push_spmd_3: dispatch_push_3
         CoreTaskArgs params_t328;
@@ -10836,7 +10836,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t328.launch_spec.set_block_num(32);
         params_t328.set_allow_early_resolve(true);
         TaskOutputTensors task_328_outs = rt_submit_aiv_task(340, params_t328);
-        PTO2TaskId _push_tid_inline2710_inline13009 = task_328_outs.task_id();
+        TaskId _push_tid_inline2710_inline13009 = task_328_outs.task_id();
 
         // Task 329: dispatch_wait_3
         CoreTaskArgs params_t329;
@@ -10845,13 +10845,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t329.add_scalar(my_rank);
         params_t329.add_scalar(last_moe_epoch_inline624);
         params_t329.add_scalar(data_arrived_ctx);
-        PTO2TaskId params_t329_deps[1];
+        TaskId params_t329_deps[1];
         uint32_t params_t329_deps_count = 0;
         params_t329_deps[params_t329_deps_count++] = _push_tid_inline2710_inline13009;
         params_t329.set_dependencies(params_t329_deps, params_t329_deps_count);
         params_t329.set_allow_early_resolve(true);
         TaskOutputTensors task_329_outs = rt_submit_aiv_task(341, params_t329);
-        PTO2TaskId _wait_tid_inline2685_inline12992 = task_329_outs.task_id();
+        TaskId _wait_tid_inline2685_inline12992 = task_329_outs.task_id();
 
         // Spmd dispatch_gather_spmd_3: dispatch_gather_3
         CoreTaskArgs params_t330;
@@ -10867,13 +10867,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t330.add_scalar(recv_aux_ctx);
         params_t330.add_scalar(recv_route_ctx);
         params_t330.launch_spec.set_block_num(32);
-        PTO2TaskId params_t330_deps[2];
+        TaskId params_t330_deps[2];
         uint32_t params_t330_deps_count = 0;
         params_t330_deps[params_t330_deps_count++] = _wait_tid_inline2685_inline12992;
         params_t330_deps[params_t330_deps_count++] = _meta_tid_inline2705_inline13137;
         params_t330.set_dependencies(params_t330_deps, params_t330_deps_count);
         TaskOutputTensors task_330_outs = rt_submit_aiv_task(342, params_t330);
-        PTO2TaskId dispatch_push_tid_inline13169 = _push_tid_inline2710_inline13009;
+        TaskId dispatch_push_tid_inline13169 = _push_tid_inline2710_inline13009;
         PTO2_SCOPE() {
             uint32_t recv_y_inline12940_ci_shapes[3] = {32, 16, 4096};
             TensorCreateInfo recv_y_inline12940_ci(recv_y_inline12940_ci_shapes, 3, DataType::BFLOAT16);
@@ -11167,7 +11167,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t337.add_scalar(routed_y_buf_ctx);
             params_t337.launch_spec.set_block_num(32);
             TaskOutputTensors task_337_outs = rt_submit_aiv_task(349, params_t337);
-            PTO2TaskId _combine_tid_inline2817_inline13120 = task_337_outs.task_id();
+            TaskId _combine_tid_inline2817_inline13120 = task_337_outs.task_id();
 
             // Task 338: combine_wait_3
             CoreTaskArgs params_t338;
@@ -11175,13 +11175,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t338.add_scalar(my_rank);
             params_t338.add_scalar(last_moe_epoch_inline624);
             params_t338.add_scalar(combine_arrived_ctx);
-            PTO2TaskId params_t338_deps[2];
+            TaskId params_t338_deps[2];
             uint32_t params_t338_deps_count = 0;
             params_t338_deps[params_t338_deps_count++] = _combine_tid_inline2817_inline13120;
             params_t338_deps[params_t338_deps_count++] = _push_tid_inline2710_inline13009;
             params_t338.set_dependencies(params_t338_deps, params_t338_deps_count);
             TaskOutputTensors task_338_outs = rt_submit_aiv_task(350, params_t338);
-            PTO2TaskId _cwait_tid_inline2826_inline12895 = task_338_outs.task_id();
+            TaskId _cwait_tid_inline2826_inline12895 = task_338_outs.task_id();
             int64_t active_tokens_inline2816_inline13087 = static_cast<int64_t>(nt_inline677__rv_v2);
             int64_t active_tokens_inline2816_inline13087__phi_v4;
             if ((8 < active_tokens_inline2816_inline13087)) {
@@ -11199,7 +11199,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t339.add_scalar(active_tokens_inline2816_inline13087__phi_v4);
             params_t339.add_scalar(routed_y_buf_ctx);
             params_t339.launch_spec.set_block_num(8);
-            PTO2TaskId params_t339_deps[1];
+            TaskId params_t339_deps[1];
             uint32_t params_t339_deps_count = 0;
             params_t339_deps[params_t339_deps_count++] = _cwait_tid_inline2826_inline12895;
             params_t339.set_dependencies(params_t339_deps, params_t339_deps_count);
@@ -11284,7 +11284,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_hc_head_mixes_zero.launch_spec.set_block_num(((t_linear_inline13230 + 15) / 16));
         TaskOutputTensors hc_head_mixes_zero_outs = rt_submit_aiv_task(367, params_hc_head_mixes_zero);
         const ChipTensor &mixes_raw_inline13234 = hc_head_mixes_zero_outs.get_ref(0);
-        PTO2TaskId hc_head_mixes_zero_tid = hc_head_mixes_zero_outs.task_id();
+        TaskId hc_head_mixes_zero_tid = hc_head_mixes_zero_outs.task_id();
 
         // Spmd hc_head_linear_spmd: hc_head_linear
         CoreTaskArgs params_t343;
@@ -11292,7 +11292,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t343.add_input(ext_hc_head_fn);
         params_t343.add_inout(mixes_raw_inline13234);
         params_t343.launch_spec.set_block_num(((t_linear_inline13230 / 16) * 16));
-        PTO2TaskId params_t343_deps[1];
+        TaskId params_t343_deps[1];
         params_t343_deps[0] = hc_head_mixes_zero_tid;
         params_t343.set_dependencies(params_t343_deps, 1);
         rt_submit_aic_task(355, params_t343);
@@ -11340,7 +11340,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t347.add_scalar(my_rank);
         params_t347.add_scalar(lm_head_hidden_done_ctx);
         TaskOutputTensors task_347_outs = rt_submit_aiv_task(359, params_t347);
-        PTO2TaskId _dwait_tid_inline26_inline13309 = task_347_outs.task_id();
+        TaskId _dwait_tid_inline26_inline13309 = task_347_outs.task_id();
 
         // Spmd lm_head_dispatch_gather_spmd: lm_head_dispatch_gather
         CoreTaskArgs params_t348;
@@ -11348,7 +11348,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t348.add_inout(owner_hiddens_inline50_inline13292);
         params_t348.add_scalar(lm_head_hidden_window_ctx);
         params_t348.launch_spec.set_block_num(8);
-        PTO2TaskId params_t348_deps[1];
+        TaskId params_t348_deps[1];
         uint32_t params_t348_deps_count = 0;
         params_t348_deps[params_t348_deps_count++] = _dwait_tid_inline26_inline13309;
         params_t348.set_dependencies(params_t348_deps, params_t348_deps_count);
@@ -11380,7 +11380,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t351.add_scalar(my_rank);
         params_t351.add_scalar(lm_head_logits_done_ctx);
         TaskOutputTensors task_351_outs = rt_submit_aiv_task(363, params_t351);
-        PTO2TaskId _cwait_tid_inline8_inline13331 = task_351_outs.task_id();
+        TaskId _cwait_tid_inline8_inline13331 = task_351_outs.task_id();
 
         // Spmd lm_head_combine_gather_spmd: lm_head_combine_gather
         CoreTaskArgs params_t352;
@@ -11388,7 +11388,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t352.add_input(ext_lm_head_logits_window);
         params_t352.add_scalar(lm_head_logits_window_ctx);
         params_t352.launch_spec.set_block_num(24);
-        PTO2TaskId params_t352_deps[1];
+        TaskId params_t352_deps[1];
         uint32_t params_t352_deps_count = 0;
         params_t352_deps[params_t352_deps_count++] = _cwait_tid_inline8_inline13331;
         params_t352.set_dependencies(params_t352_deps, params_t352_deps_count);

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/README.md
@@ -24,7 +24,7 @@ choice:
 
 | API | Shape | Suited to |
 | --- | ----- | --------- |
-| Primitive | `PTO2TaskId deps[] = {...}; params.set_dependencies(deps, n);` | Codegen, and any task whose dependency set is fixed and known at the call site. The caller owns the buffer; the `Arg` stores `(ptr, count)`. |
+| Primitive | `TaskId deps[] = {...}; params.set_dependencies(deps, n);` | Codegen, and any task whose dependency set is fixed and known at the call site. The caller owns the buffer; the `Arg` stores `(ptr, count)`. |
 | Convenience | `CoreTaskArgsWithDeps<> params; params.add_dep(id);` | Hand-written orchestration where the set is assembled conditionally across branches. The wrapper owns a stack-sized buffer and binds it on submit. |
 
 `SF` and `PV` use the primitive form (one predecessor each). `UP` uses the

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -166,8 +166,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 const ChipTensor &oi = alloc_outs.get_ref(0);
                 const ChipTensor &li_update = alloc_outs.get_ref(1);
                 const ChipTensor &mi_update = alloc_outs.get_ref(2);
-                PTO2TaskId alloc_task = alloc_outs.task_id();
-                PTO2TaskId prev_update_task = PTO2TaskId::invalid();
+                TaskId alloc_task = alloc_outs.task_id();
+                TaskId prev_update_task = TaskId::invalid();
                 PROF_INC(prof_submit_count, 1);
                 CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -208,7 +208,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_sf.add_output(pij_f16_ci);
                     params_sf.add_output(scalar_ci);
                     params_sf.add_output(scalar_ci);
-                    PTO2TaskId sf_deps[] = {qk_outs.task_id()};
+                    TaskId sf_deps[] = {qk_outs.task_id()};
                     params_sf.set_dependencies(sf_deps, 1);
                     params_sf.add_scalar(scale_value);
                     CYCLE_COUNT_LAP(prof_param_setup);
@@ -223,7 +223,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_pv.add_input(pij_f16);
                     params_pv.add_input(vj);
                     params_pv.add_output(tile2d_ci);
-                    PTO2TaskId pv_deps[] = {sf_outs.task_id()};
+                    TaskId pv_deps[] = {sf_outs.task_id()};
                     params_pv.set_dependencies(pv_deps, 1);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors pv_outs = rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -176,7 +176,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 const ChipTensor &oi = alloc_outs.get_ref(0);
                 const ChipTensor &li_update = alloc_outs.get_ref(1);
                 const ChipTensor &mi_update = alloc_outs.get_ref(2);
-                PTO2TaskId pre_task_id;
+                TaskId pre_task_id;
 #ifdef ENABLE_PROFILING
                 prof_submit_count++;
                 CYCLE_COUNT_LAP(prof_submit_task);
@@ -234,7 +234,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_sf.add_output(pij_buf_ci);
                     params_sf.add_output(scalar_ci);
                     params_sf.add_output(scalar_ci);
-                    PTO2TaskId sf_deps[] = {qk_outs.task_id()};
+                    TaskId sf_deps[] = {qk_outs.task_id()};
                     params_sf.set_dependencies(sf_deps, 1);
                     params_sf.add_scalar(scale_value);
                     params_sf.add_scalar(n_blocks);
@@ -255,7 +255,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_pv.add_input(value_cache);
                     params_pv.add_input(block_table);
                     params_pv.add_output(tile2d_ci);
-                    PTO2TaskId pv_deps[] = {sf_outs.task_id()};
+                    TaskId pv_deps[] = {sf_outs.task_id()};
                     params_pv.set_dependencies(pv_deps, 1);
                     params_pv.add_scalar(n_blocks);
                     params_pv.add_scalar(b_idx * block_num + bn);
@@ -279,7 +279,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_up.add_inout(li_update);
                     params_up.add_inout(oi);
                     params_up.add_inout(out_view);
-                    PTO2TaskId up_deps[3];
+                    TaskId up_deps[3];
                     uint32_t up_dep_count = 0;
                     up_deps[up_dep_count++] = pv_outs.task_id();
                     if (!is_first) {

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
@@ -86,16 +86,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t0.launch_spec.set_block_num(1);
         params_t0.set_allow_early_resolve(true);
         TaskOutputTensors task_0_outs = rt_submit_aiv_task(0, params_t0);
-        PTO2TaskId tiling_tid_inline0 = task_0_outs.task_id();
-        PTO2TaskId pa_tiling_tid = tiling_tid_inline0;
-        PTO2TaskId prev_out_tid[1];
+        TaskId tiling_tid_inline0 = task_0_outs.task_id();
+        TaskId pa_tiling_tid = tiling_tid_inline0;
+        TaskId prev_out_tid[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-            prev_out_tid[__init_i] = PTO2TaskId::invalid();
+            prev_out_tid[__init_i] = TaskId::invalid();
 
         // Phase-fence barrier 0: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_0;
         TaskOutputTensors phase_fence_barrier_0_outs = rt_submit_dummy_task(params_phase_fence_barrier_0);
-        PTO2TaskId t = phase_fence_barrier_0_outs.task_id();
+        TaskId t = phase_fence_barrier_0_outs.task_id();
         prev_out_tid[0] = t;
         for (int64_t cb0 = 0; cb0 < 16; cb0 += 16) {
             PTO2_SCOPE() {
@@ -105,18 +105,18 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t1.add_input(ext_hidden_states);
                 params_t1.add_scalar(cb0);
                 TaskOutputTensors task_1_outs = rt_submit_aiv_task(1, params_t1);
-                PTO2TaskId ch_tid = task_1_outs.task_id();
+                TaskId ch_tid = task_1_outs.task_id();
                 prev_out_tid[0] = ch_tid;
             }
         }
-        PTO2TaskId prev_normed_tid[1];
+        TaskId prev_normed_tid[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-            prev_normed_tid[__init_i] = PTO2TaskId::invalid();
+            prev_normed_tid[__init_i] = TaskId::invalid();
         PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
-            PTO2TaskId _submit_deps_buf[1];
+            TaskId _submit_deps_buf[1];
             for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                _submit_deps_buf[__init_i] = PTO2TaskId::invalid();
-            PTO2TaskId t__tmp_v3 = prev_out_tid[0];
+                _submit_deps_buf[__init_i] = TaskId::invalid();
+            TaskId t__tmp_v3 = prev_out_tid[0];
             _submit_deps_buf[0] = t__tmp_v3;
 
             // Spmd x_gamma0_spmd: x_gamma0
@@ -126,12 +126,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t2.add_input(ext_input_rms_weight);
             params_t2.launch_spec.set_block_num(5);
             params_t2.set_allow_early_resolve(true);
-            PTO2TaskId params_t2_deps[1];
+            TaskId params_t2_deps[1];
             uint32_t params_t2_deps_count = 0;
             if (_submit_deps_buf[0].is_valid()) params_t2_deps[params_t2_deps_count++] = _submit_deps_buf[0];
             params_t2.set_dependencies(params_t2_deps, params_t2_deps_count);
             TaskOutputTensors task_2_outs = rt_submit_aiv_task(2, params_t2);
-            PTO2TaskId xgamma_tid = task_2_outs.task_id();
+            TaskId xgamma_tid = task_2_outs.task_id();
             prev_normed_tid[0] = xgamma_tid;
         }
         ChipTensor cur__rv_v7 = cur;
@@ -195,9 +195,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 };
                 ChipTensor k_norm_w_inline114 =
                     ext_k_norm_weight.view(k_norm_w_inline114_shapes, k_norm_w_inline114_offsets);
-                PTO2TaskId down_tids_inline156[85];
+                TaskId down_tids_inline156[85];
                 for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
-                    down_tids_inline156[__init_i] = PTO2TaskId::invalid();
+                    down_tids_inline156[__init_i] = TaskId::invalid();
                 uint32_t down_acc_all_inline168_ci_shapes[2] = {16, 5120};
                 TensorCreateInfo down_acc_all_inline168_ci(down_acc_all_inline168_ci_shapes, 2, DataType::FLOAT32);
                 uint32_t gate_acc_all_inline203_ci_shapes[2] = {16, 17408};
@@ -233,11 +233,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     // Phase-fence barrier 1: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_1;
                     TaskOutputTensors phase_fence_barrier_1_outs = rt_submit_dummy_task(params_phase_fence_barrier_1);
-                    PTO2TaskId seed_dummy_inline49 = phase_fence_barrier_1_outs.task_id();
-                    PTO2TaskId prev_normed_seed_deps_inline120[2];
+                    TaskId seed_dummy_inline49 = phase_fence_barrier_1_outs.task_id();
+                    TaskId prev_normed_seed_deps_inline120[2];
                     for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                        prev_normed_seed_deps_inline120[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v7 = prev_normed_tid[0];
+                        prev_normed_seed_deps_inline120[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v7 = prev_normed_tid[0];
                     prev_normed_seed_deps_inline120[0] = t__tmp_v7;
                     prev_normed_seed_deps_inline120[1] = seed_dummy_inline49;
 
@@ -246,20 +246,20 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t3.add_input(attn_out_inline282);
                     params_t3.set_allow_early_resolve(true);
                     TaskOutputTensors task_3_outs = rt_submit_aiv_task(3, params_t3);
-                    PTO2TaskId attn_out_seed_tid_inline116 = task_3_outs.task_id();
-                    PTO2TaskId _submit_deps_buf_inline42[2];
+                    TaskId attn_out_seed_tid_inline116 = task_3_outs.task_id();
+                    TaskId _submit_deps_buf_inline42[2];
                     for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                        _submit_deps_buf_inline42[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v8 = prev_normed_seed_deps_inline120[0];
+                        _submit_deps_buf_inline42[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v8 = prev_normed_seed_deps_inline120[0];
                     _submit_deps_buf_inline42[0] = t__tmp_v8;
-                    PTO2TaskId t__tmp_v9 = prev_normed_seed_deps_inline120[1];
+                    TaskId t__tmp_v9 = prev_normed_seed_deps_inline120[1];
                     _submit_deps_buf_inline42[1] = t__tmp_v9;
 
                     // Task 4: rms_recip
                     CoreTaskArgs params_t4;
                     params_t4.add_input(cur__rv_v7);
                     params_t4.add_inout(inv_rms_states_inline176);
-                    PTO2TaskId params_t4_deps[2];
+                    TaskId params_t4_deps[2];
                     uint32_t params_t4_deps_count = 0;
                     if (_submit_deps_buf_inline42[0].is_valid())
                         params_t4_deps[params_t4_deps_count++] = _submit_deps_buf_inline42[0];
@@ -268,26 +268,26 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t4.set_dependencies(params_t4_deps, params_t4_deps_count);
                     params_t4.set_allow_early_resolve(true);
                     TaskOutputTensors task_4_outs = rt_submit_aiv_task(4, params_t4);
-                    PTO2TaskId rms_tid_inline148 = task_4_outs.task_id();
+                    TaskId rms_tid_inline148 = task_4_outs.task_id();
 
                     // Task 5: q_seed
                     CoreTaskArgs params_t5;
                     params_t5.add_inout(q_proj_inline139);
                     params_t5.set_allow_early_resolve(true);
                     TaskOutputTensors task_5_outs = rt_submit_aiv_task(5, params_t5);
-                    PTO2TaskId q_seed_tid_inline162 = task_5_outs.task_id();
-                    PTO2TaskId prev_normed_q_deps_inline105[2];
+                    TaskId q_seed_tid_inline162 = task_5_outs.task_id();
+                    TaskId prev_normed_q_deps_inline105[2];
                     for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                        prev_normed_q_deps_inline105[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v17 = prev_normed_tid[0];
+                        prev_normed_q_deps_inline105[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v17 = prev_normed_tid[0];
                     prev_normed_q_deps_inline105[0] = t__tmp_v17;
                     prev_normed_q_deps_inline105[1] = q_seed_tid_inline162;
-                    PTO2TaskId _submit_deps_buf_inline182[2];
+                    TaskId _submit_deps_buf_inline182[2];
                     for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                        _submit_deps_buf_inline182[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v18 = prev_normed_q_deps_inline105[0];
+                        _submit_deps_buf_inline182[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v18 = prev_normed_q_deps_inline105[0];
                     _submit_deps_buf_inline182[0] = t__tmp_v18;
-                    PTO2TaskId t__tmp_v19 = prev_normed_q_deps_inline105[1];
+                    TaskId t__tmp_v19 = prev_normed_q_deps_inline105[1];
                     _submit_deps_buf_inline182[1] = t__tmp_v19;
 
                     // Spmd q_proj_spmd: q_proj
@@ -298,7 +298,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t6.add_scalar(layer_hidden_base_inline151);
                     params_t6.launch_spec.set_block_num(50);
                     params_t6.set_allow_early_resolve(true);
-                    PTO2TaskId params_t6_deps[2];
+                    TaskId params_t6_deps[2];
                     uint32_t params_t6_deps_count = 0;
                     if (_submit_deps_buf_inline182[0].is_valid())
                         params_t6_deps[params_t6_deps_count++] = _submit_deps_buf_inline182[0];
@@ -306,20 +306,20 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t6_deps[params_t6_deps_count++] = _submit_deps_buf_inline182[1];
                     params_t6.set_dependencies(params_t6_deps, params_t6_deps_count);
                     TaskOutputTensors task_6_outs = rt_submit_aic_task(6, params_t6);
-                    PTO2TaskId q_proj_tid_inline183 = task_6_outs.task_id();
-                    PTO2TaskId _submit_deps_buf_inline261[2];
+                    TaskId q_proj_tid_inline183 = task_6_outs.task_id();
+                    TaskId _submit_deps_buf_inline261[2];
                     for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                        _submit_deps_buf_inline261[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v24 = prev_normed_seed_deps_inline120[0];
+                        _submit_deps_buf_inline261[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v24 = prev_normed_seed_deps_inline120[0];
                     _submit_deps_buf_inline261[0] = t__tmp_v24;
-                    PTO2TaskId t__tmp_v25 = prev_normed_seed_deps_inline120[1];
+                    TaskId t__tmp_v25 = prev_normed_seed_deps_inline120[1];
                     _submit_deps_buf_inline261[1] = t__tmp_v25;
 
                     // Task 7: kv_seed
                     CoreTaskArgs params_t7;
                     params_t7.add_inout(k_proj_inline135);
                     params_t7.add_inout(v_proj_inline255);
-                    PTO2TaskId params_t7_deps[2];
+                    TaskId params_t7_deps[2];
                     uint32_t params_t7_deps_count = 0;
                     if (_submit_deps_buf_inline261[0].is_valid())
                         params_t7_deps[params_t7_deps_count++] = _submit_deps_buf_inline261[0];
@@ -327,13 +327,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t7_deps[params_t7_deps_count++] = _submit_deps_buf_inline261[1];
                     params_t7.set_dependencies(params_t7_deps, params_t7_deps_count);
                     TaskOutputTensors task_7_outs = rt_submit_aiv_task(7, params_t7);
-                    PTO2TaskId kv_seed_tid_inline238 = task_7_outs.task_id();
-                    PTO2TaskId _submit_deps_buf_inline267[2];
+                    TaskId kv_seed_tid_inline238 = task_7_outs.task_id();
+                    TaskId _submit_deps_buf_inline267[2];
                     for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                        _submit_deps_buf_inline267[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v28 = prev_normed_seed_deps_inline120[0];
+                        _submit_deps_buf_inline267[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v28 = prev_normed_seed_deps_inline120[0];
                     _submit_deps_buf_inline267[0] = t__tmp_v28;
-                    PTO2TaskId t__tmp_v29 = prev_normed_seed_deps_inline120[1];
+                    TaskId t__tmp_v29 = prev_normed_seed_deps_inline120[1];
                     _submit_deps_buf_inline267[1] = t__tmp_v29;
 
                     // Task 8: mlp_out_seed
@@ -342,7 +342,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t8.add_inout(gate_acc_all_inline203);
                     params_t8.add_inout(up_acc_all_inline303);
                     params_t8.add_inout(attn_proj_fp32_inline220);
-                    PTO2TaskId params_t8_deps[2];
+                    TaskId params_t8_deps[2];
                     uint32_t params_t8_deps_count = 0;
                     if (_submit_deps_buf_inline267[0].is_valid())
                         params_t8_deps[params_t8_deps_count++] = _submit_deps_buf_inline267[0];
@@ -351,7 +351,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t8.set_dependencies(params_t8_deps, params_t8_deps_count);
                     params_t8.set_allow_early_resolve(true);
                     TaskOutputTensors task_8_outs = rt_submit_aiv_task(8, params_t8);
-                    PTO2TaskId mlp_out_seed_tid_inline206 = task_8_outs.task_id();
+                    TaskId mlp_out_seed_tid_inline206 = task_8_outs.task_id();
 
                     // Spmd k_proj_spmd: k_proj
                     CoreTaskArgs params_t9;
@@ -361,12 +361,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t9.add_scalar(layer_hidden_base_inline151);
                     params_t9.launch_spec.set_block_num(10);
                     params_t9.set_allow_early_resolve(true);
-                    PTO2TaskId params_t9_deps[1];
+                    TaskId params_t9_deps[1];
                     uint32_t params_t9_deps_count = 0;
                     params_t9_deps[params_t9_deps_count++] = kv_seed_tid_inline238;
                     params_t9.set_dependencies(params_t9_deps, params_t9_deps_count);
                     TaskOutputTensors task_9_outs = rt_submit_aic_task(9, params_t9);
-                    PTO2TaskId k_proj_tid_inline136 = task_9_outs.task_id();
+                    TaskId k_proj_tid_inline136 = task_9_outs.task_id();
 
                     // Spmd v_proj_spmd: v_proj
                     CoreTaskArgs params_t10;
@@ -376,12 +376,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t10.add_scalar(layer_hidden_base_inline151);
                     params_t10.launch_spec.set_block_num(10);
                     params_t10.set_allow_early_resolve(true);
-                    PTO2TaskId params_t10_deps[1];
+                    TaskId params_t10_deps[1];
                     uint32_t params_t10_deps_count = 0;
                     params_t10_deps[params_t10_deps_count++] = kv_seed_tid_inline238;
                     params_t10.set_dependencies(params_t10_deps, params_t10_deps_count);
                     TaskOutputTensors task_10_outs = rt_submit_aic_task(10, params_t10);
-                    PTO2TaskId v_proj_tid_inline63 = task_10_outs.task_id();
+                    TaskId v_proj_tid_inline63 = task_10_outs.task_id();
                     uint32_t q_tnd_inline191_shapes[3] = {16, 40, 128};
                     ChipTensor q_tnd_inline191 = q_tnd_flat_inline127.reshape(q_tnd_inline191_shapes, 3);
                     uint32_t attn_out_tnd_inline79_shapes[3] = {16, 40, 128};
@@ -412,7 +412,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t11.launch_spec.set_block_num(attention_core_num_inline188);
                     params_t11.launch_spec.set_require_sync_start(true);
                     params_t11.set_allow_early_resolve(true);
-                    PTO2TaskId params_t11_deps[7];
+                    TaskId params_t11_deps[7];
                     uint32_t params_t11_deps_count = 0;
                     params_t11_deps[params_t11_deps_count++] = q_proj_tid_inline183;
                     params_t11_deps[params_t11_deps_count++] = k_proj_tid_inline136;
@@ -424,42 +424,42 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t11.set_dependencies(params_t11_deps, params_t11_deps_count);
                     TaskOutputTensors task_11_outs = rt_submit_task(mixed_11, params_t11);
                     const ChipTensor &attn_out_tnd_inline79__ssa_v1 = attn_out_tnd_inline79;
-                    PTO2TaskId attn_done_tid_inline78 = task_11_outs.task_id();
+                    TaskId attn_done_tid_inline78 = task_11_outs.task_id();
                     uint32_t attn_out_inline282__ssa_v4_shapes[2] = {16, 5120};
                     ChipTensor attn_out_inline282__ssa_v4 =
                         attn_out_tnd_inline79__ssa_v1.reshape(attn_out_inline282__ssa_v4_shapes, 2);
-                    PTO2TaskId silu_tids_inline265[17];
+                    TaskId silu_tids_inline265[17];
                     for (int64_t __init_i = 0; __init_i < 17; ++__init_i)
-                        silu_tids_inline265[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId gate_tids_inline56[85];
+                        silu_tids_inline265[__init_i] = TaskId::invalid();
+                    TaskId gate_tids_inline56[85];
                     for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
-                        gate_tids_inline56[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId up_tids_inline310[85];
+                        gate_tids_inline56[__init_i] = TaskId::invalid();
+                    TaskId up_tids_inline310[85];
                     for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
-                        up_tids_inline310[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId cast_tids_inline88[5];
+                        up_tids_inline310[__init_i] = TaskId::invalid();
+                    TaskId cast_tids_inline88[5];
                     for (int64_t __init_i = 0; __init_i < 5; ++__init_i)
-                        cast_tids_inline88[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId gate_late_tids_inline249[5];
+                        cast_tids_inline88[__init_i] = TaskId::invalid();
+                    TaskId gate_late_tids_inline249[5];
                     for (int64_t __init_i = 0; __init_i < 5; ++__init_i)
-                        gate_late_tids_inline249[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId up_late_tids_inline69[5];
+                        gate_late_tids_inline249[__init_i] = TaskId::invalid();
+                    TaskId up_late_tids_inline69[5];
                     for (int64_t __init_i = 0; __init_i < 5; ++__init_i)
-                        up_late_tids_inline69[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId out_tids_inline271[50];
+                        up_late_tids_inline69[__init_i] = TaskId::invalid();
+                    TaskId out_tids_inline271[50];
                     for (int64_t __init_i = 0; __init_i < 50; ++__init_i)
-                        out_tids_inline271[__init_i] = PTO2TaskId::invalid();
+                        out_tids_inline271[__init_i] = TaskId::invalid();
 
                     // Phase-fence barrier 2: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_2;
-                    PTO2TaskId params_phase_fence_barrier_2_deps[1];
+                    TaskId params_phase_fence_barrier_2_deps[1];
                     uint32_t params_phase_fence_barrier_2_deps_count = 0;
                     params_phase_fence_barrier_2_deps[params_phase_fence_barrier_2_deps_count++] =
                         attn_done_tid_inline78;
                     params_phase_fence_barrier_2.set_dependencies(
                         params_phase_fence_barrier_2_deps, params_phase_fence_barrier_2_deps_count
                     );
-                    PTO2TaskId out_proj_dummy_inline257 = PTO2TaskId::invalid();
+                    TaskId out_proj_dummy_inline257 = TaskId::invalid();
                     if (params_phase_fence_barrier_2_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_2_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_2);
@@ -481,13 +481,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t12.add_scalar(k_op_inline266);
                         params_t12.add_scalar(layer_hidden_base_inline151);
                         params_t12.add_scalar(n_op_inline64);
-                        PTO2TaskId params_t12_deps[1];
+                        TaskId params_t12_deps[1];
                         uint32_t params_t12_deps_count = 0;
                         if (out_proj_dummy_inline257.is_valid())
                             params_t12_deps[params_t12_deps_count++] = out_proj_dummy_inline257;
                         params_t12.set_dependencies(params_t12_deps, params_t12_deps_count);
                         TaskOutputTensors task_12_outs = rt_submit_aic_task(13, params_t12);
-                        PTO2TaskId out_tid_inline141 = task_12_outs.task_id();
+                        TaskId out_tid_inline141 = task_12_outs.task_id();
                         out_tids_inline271[out_idx_inline74] = out_tid_inline141;
                     }
 
@@ -499,12 +499,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t13.add_scalar(N_OUT_DIRECT_inline61);
                     params_t13.add_scalar(layer_hidden_base_inline151);
                     params_t13.launch_spec.set_block_num(24);
-                    PTO2TaskId params_t13_deps[1];
+                    TaskId params_t13_deps[1];
                     uint32_t params_t13_deps_count = 0;
                     params_t13_deps[params_t13_deps_count++] = attn_done_tid_inline78;
                     params_t13.set_dependencies(params_t13_deps, params_t13_deps_count);
                     TaskOutputTensors task_13_outs = rt_submit_aic_task(14, params_t13);
-                    PTO2TaskId out_proj_direct_tid_inline70 = task_13_outs.task_id();
+                    TaskId out_proj_direct_tid_inline70 = task_13_outs.task_id();
                     out_tids_inline271[N_OUT_DIRECT_inline61] = out_proj_direct_tid_inline70;
                     out_tids_inline271[(N_OUT_DIRECT_inline61 + 1)] = out_proj_direct_tid_inline70;
                     out_tids_inline271[(N_OUT_DIRECT_inline61 + 2)] = out_proj_direct_tid_inline70;
@@ -531,28 +531,28 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     out_tids_inline271[(N_OUT_DIRECT_inline61 + 23)] = out_proj_direct_tid_inline70;
                     int64_t k_base_inline111 = 0;
                     int64_t n_split_base_inline163 = 0;
-                    PTO2TaskId _submit_deps_buf_inline165[10];
+                    TaskId _submit_deps_buf_inline165[10];
                     for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                        _submit_deps_buf_inline165[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v39 = out_tids_inline271[(n_split_base_inline163 * 5)];
+                        _submit_deps_buf_inline165[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v39 = out_tids_inline271[(n_split_base_inline163 * 5)];
                     _submit_deps_buf_inline165[0] = t__tmp_v39;
-                    PTO2TaskId t__tmp_v40 = out_tids_inline271[((n_split_base_inline163 * 5) + 1)];
+                    TaskId t__tmp_v40 = out_tids_inline271[((n_split_base_inline163 * 5) + 1)];
                     _submit_deps_buf_inline165[1] = t__tmp_v40;
-                    PTO2TaskId t__tmp_v41 = out_tids_inline271[((n_split_base_inline163 * 5) + 2)];
+                    TaskId t__tmp_v41 = out_tids_inline271[((n_split_base_inline163 * 5) + 2)];
                     _submit_deps_buf_inline165[2] = t__tmp_v41;
-                    PTO2TaskId t__tmp_v42 = out_tids_inline271[((n_split_base_inline163 * 5) + 3)];
+                    TaskId t__tmp_v42 = out_tids_inline271[((n_split_base_inline163 * 5) + 3)];
                     _submit_deps_buf_inline165[3] = t__tmp_v42;
-                    PTO2TaskId t__tmp_v43 = out_tids_inline271[((n_split_base_inline163 * 5) + 4)];
+                    TaskId t__tmp_v43 = out_tids_inline271[((n_split_base_inline163 * 5) + 4)];
                     _submit_deps_buf_inline165[4] = t__tmp_v43;
-                    PTO2TaskId t__tmp_v44 = out_tids_inline271[((n_split_base_inline163 * 5) + 5)];
+                    TaskId t__tmp_v44 = out_tids_inline271[((n_split_base_inline163 * 5) + 5)];
                     _submit_deps_buf_inline165[5] = t__tmp_v44;
-                    PTO2TaskId t__tmp_v45 = out_tids_inline271[((n_split_base_inline163 * 5) + 6)];
+                    TaskId t__tmp_v45 = out_tids_inline271[((n_split_base_inline163 * 5) + 6)];
                     _submit_deps_buf_inline165[6] = t__tmp_v45;
-                    PTO2TaskId t__tmp_v46 = out_tids_inline271[((n_split_base_inline163 * 5) + 7)];
+                    TaskId t__tmp_v46 = out_tids_inline271[((n_split_base_inline163 * 5) + 7)];
                     _submit_deps_buf_inline165[7] = t__tmp_v46;
-                    PTO2TaskId t__tmp_v47 = out_tids_inline271[((n_split_base_inline163 * 5) + 8)];
+                    TaskId t__tmp_v47 = out_tids_inline271[((n_split_base_inline163 * 5) + 8)];
                     _submit_deps_buf_inline165[8] = t__tmp_v47;
-                    PTO2TaskId t__tmp_v48 = out_tids_inline271[((n_split_base_inline163 * 5) + 9)];
+                    TaskId t__tmp_v48 = out_tids_inline271[((n_split_base_inline163 * 5) + 9)];
                     _submit_deps_buf_inline165[9] = t__tmp_v48;
 
                     // Task 14: residual_rms_cast
@@ -564,7 +564,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t14.add_input(ext_post_rms_weight);
                     params_t14.add_scalar(k_base_inline111);
                     params_t14.add_scalar(i);
-                    PTO2TaskId params_t14_deps[10];
+                    TaskId params_t14_deps[10];
                     uint32_t params_t14_deps_count = 0;
                     if (_submit_deps_buf_inline165[0].is_valid())
                         params_t14_deps[params_t14_deps_count++] = _submit_deps_buf_inline165[0];
@@ -589,32 +589,32 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t14.set_dependencies(params_t14_deps, params_t14_deps_count);
                     params_t14.set_allow_early_resolve(true);
                     TaskOutputTensors task_14_outs = rt_submit_aiv_task(15, params_t14);
-                    PTO2TaskId cast_tid_k_inline76 = task_14_outs.task_id();
+                    TaskId cast_tid_k_inline76 = task_14_outs.task_id();
                     cast_tids_inline88[0] = cast_tid_k_inline76;
                     int64_t k_base_inline111__ssa_v1 = 1024;
                     int64_t n_split_base_inline163__ssa_v1 = 2;
-                    PTO2TaskId _submit_deps_buf_inline165__ssa_v1[10];
+                    TaskId _submit_deps_buf_inline165__ssa_v1[10];
                     for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                        _submit_deps_buf_inline165__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v51 = out_tids_inline271[(n_split_base_inline163__ssa_v1 * 5)];
+                        _submit_deps_buf_inline165__ssa_v1[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v51 = out_tids_inline271[(n_split_base_inline163__ssa_v1 * 5)];
                     _submit_deps_buf_inline165__ssa_v1[0] = t__tmp_v51;
-                    PTO2TaskId t__tmp_v52 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 1)];
+                    TaskId t__tmp_v52 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 1)];
                     _submit_deps_buf_inline165__ssa_v1[1] = t__tmp_v52;
-                    PTO2TaskId t__tmp_v53 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 2)];
+                    TaskId t__tmp_v53 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 2)];
                     _submit_deps_buf_inline165__ssa_v1[2] = t__tmp_v53;
-                    PTO2TaskId t__tmp_v54 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 3)];
+                    TaskId t__tmp_v54 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 3)];
                     _submit_deps_buf_inline165__ssa_v1[3] = t__tmp_v54;
-                    PTO2TaskId t__tmp_v55 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 4)];
+                    TaskId t__tmp_v55 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 4)];
                     _submit_deps_buf_inline165__ssa_v1[4] = t__tmp_v55;
-                    PTO2TaskId t__tmp_v56 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 5)];
+                    TaskId t__tmp_v56 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 5)];
                     _submit_deps_buf_inline165__ssa_v1[5] = t__tmp_v56;
-                    PTO2TaskId t__tmp_v57 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 6)];
+                    TaskId t__tmp_v57 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 6)];
                     _submit_deps_buf_inline165__ssa_v1[6] = t__tmp_v57;
-                    PTO2TaskId t__tmp_v58 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 7)];
+                    TaskId t__tmp_v58 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 7)];
                     _submit_deps_buf_inline165__ssa_v1[7] = t__tmp_v58;
-                    PTO2TaskId t__tmp_v59 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 8)];
+                    TaskId t__tmp_v59 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 8)];
                     _submit_deps_buf_inline165__ssa_v1[8] = t__tmp_v59;
-                    PTO2TaskId t__tmp_v60 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 9)];
+                    TaskId t__tmp_v60 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 9)];
                     _submit_deps_buf_inline165__ssa_v1[9] = t__tmp_v60;
 
                     // Task 15: residual_rms_cast_0
@@ -626,7 +626,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t15.add_input(ext_post_rms_weight);
                     params_t15.add_scalar(k_base_inline111__ssa_v1);
                     params_t15.add_scalar(i);
-                    PTO2TaskId params_t15_deps[10];
+                    TaskId params_t15_deps[10];
                     uint32_t params_t15_deps_count = 0;
                     if (_submit_deps_buf_inline165__ssa_v1[0].is_valid())
                         params_t15_deps[params_t15_deps_count++] = _submit_deps_buf_inline165__ssa_v1[0];
@@ -651,32 +651,32 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t15.set_dependencies(params_t15_deps, params_t15_deps_count);
                     params_t15.set_allow_early_resolve(true);
                     TaskOutputTensors task_15_outs = rt_submit_aiv_task(16, params_t15);
-                    PTO2TaskId cast_tid_k_inline76__ssa_v1 = task_15_outs.task_id();
+                    TaskId cast_tid_k_inline76__ssa_v1 = task_15_outs.task_id();
                     cast_tids_inline88[1] = cast_tid_k_inline76__ssa_v1;
                     int64_t k_base_inline111__ssa_v2 = 2048;
                     int64_t n_split_base_inline163__ssa_v2 = 4;
-                    PTO2TaskId _submit_deps_buf_inline165__ssa_v2[10];
+                    TaskId _submit_deps_buf_inline165__ssa_v2[10];
                     for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                        _submit_deps_buf_inline165__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v63 = out_tids_inline271[(n_split_base_inline163__ssa_v2 * 5)];
+                        _submit_deps_buf_inline165__ssa_v2[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v63 = out_tids_inline271[(n_split_base_inline163__ssa_v2 * 5)];
                     _submit_deps_buf_inline165__ssa_v2[0] = t__tmp_v63;
-                    PTO2TaskId t__tmp_v64 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 1)];
+                    TaskId t__tmp_v64 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 1)];
                     _submit_deps_buf_inline165__ssa_v2[1] = t__tmp_v64;
-                    PTO2TaskId t__tmp_v65 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 2)];
+                    TaskId t__tmp_v65 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 2)];
                     _submit_deps_buf_inline165__ssa_v2[2] = t__tmp_v65;
-                    PTO2TaskId t__tmp_v66 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 3)];
+                    TaskId t__tmp_v66 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 3)];
                     _submit_deps_buf_inline165__ssa_v2[3] = t__tmp_v66;
-                    PTO2TaskId t__tmp_v67 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 4)];
+                    TaskId t__tmp_v67 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 4)];
                     _submit_deps_buf_inline165__ssa_v2[4] = t__tmp_v67;
-                    PTO2TaskId t__tmp_v68 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 5)];
+                    TaskId t__tmp_v68 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 5)];
                     _submit_deps_buf_inline165__ssa_v2[5] = t__tmp_v68;
-                    PTO2TaskId t__tmp_v69 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 6)];
+                    TaskId t__tmp_v69 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 6)];
                     _submit_deps_buf_inline165__ssa_v2[6] = t__tmp_v69;
-                    PTO2TaskId t__tmp_v70 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 7)];
+                    TaskId t__tmp_v70 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 7)];
                     _submit_deps_buf_inline165__ssa_v2[7] = t__tmp_v70;
-                    PTO2TaskId t__tmp_v71 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 8)];
+                    TaskId t__tmp_v71 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 8)];
                     _submit_deps_buf_inline165__ssa_v2[8] = t__tmp_v71;
-                    PTO2TaskId t__tmp_v72 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 9)];
+                    TaskId t__tmp_v72 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 9)];
                     _submit_deps_buf_inline165__ssa_v2[9] = t__tmp_v72;
 
                     // Task 16: residual_rms_cast_1
@@ -688,7 +688,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t16.add_input(ext_post_rms_weight);
                     params_t16.add_scalar(k_base_inline111__ssa_v2);
                     params_t16.add_scalar(i);
-                    PTO2TaskId params_t16_deps[10];
+                    TaskId params_t16_deps[10];
                     uint32_t params_t16_deps_count = 0;
                     if (_submit_deps_buf_inline165__ssa_v2[0].is_valid())
                         params_t16_deps[params_t16_deps_count++] = _submit_deps_buf_inline165__ssa_v2[0];
@@ -713,32 +713,32 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t16.set_dependencies(params_t16_deps, params_t16_deps_count);
                     params_t16.set_allow_early_resolve(true);
                     TaskOutputTensors task_16_outs = rt_submit_aiv_task(17, params_t16);
-                    PTO2TaskId cast_tid_k_inline76__ssa_v2 = task_16_outs.task_id();
+                    TaskId cast_tid_k_inline76__ssa_v2 = task_16_outs.task_id();
                     cast_tids_inline88[2] = cast_tid_k_inline76__ssa_v2;
                     int64_t k_base_inline111__ssa_v3 = 3072;
                     int64_t n_split_base_inline163__ssa_v3 = 6;
-                    PTO2TaskId _submit_deps_buf_inline165__ssa_v3[10];
+                    TaskId _submit_deps_buf_inline165__ssa_v3[10];
                     for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                        _submit_deps_buf_inline165__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v75 = out_tids_inline271[(n_split_base_inline163__ssa_v3 * 5)];
+                        _submit_deps_buf_inline165__ssa_v3[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v75 = out_tids_inline271[(n_split_base_inline163__ssa_v3 * 5)];
                     _submit_deps_buf_inline165__ssa_v3[0] = t__tmp_v75;
-                    PTO2TaskId t__tmp_v76 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 1)];
+                    TaskId t__tmp_v76 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 1)];
                     _submit_deps_buf_inline165__ssa_v3[1] = t__tmp_v76;
-                    PTO2TaskId t__tmp_v77 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 2)];
+                    TaskId t__tmp_v77 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 2)];
                     _submit_deps_buf_inline165__ssa_v3[2] = t__tmp_v77;
-                    PTO2TaskId t__tmp_v78 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 3)];
+                    TaskId t__tmp_v78 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 3)];
                     _submit_deps_buf_inline165__ssa_v3[3] = t__tmp_v78;
-                    PTO2TaskId t__tmp_v79 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 4)];
+                    TaskId t__tmp_v79 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 4)];
                     _submit_deps_buf_inline165__ssa_v3[4] = t__tmp_v79;
-                    PTO2TaskId t__tmp_v80 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 5)];
+                    TaskId t__tmp_v80 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 5)];
                     _submit_deps_buf_inline165__ssa_v3[5] = t__tmp_v80;
-                    PTO2TaskId t__tmp_v81 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 6)];
+                    TaskId t__tmp_v81 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 6)];
                     _submit_deps_buf_inline165__ssa_v3[6] = t__tmp_v81;
-                    PTO2TaskId t__tmp_v82 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 7)];
+                    TaskId t__tmp_v82 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 7)];
                     _submit_deps_buf_inline165__ssa_v3[7] = t__tmp_v82;
-                    PTO2TaskId t__tmp_v83 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 8)];
+                    TaskId t__tmp_v83 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 8)];
                     _submit_deps_buf_inline165__ssa_v3[8] = t__tmp_v83;
-                    PTO2TaskId t__tmp_v84 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 9)];
+                    TaskId t__tmp_v84 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 9)];
                     _submit_deps_buf_inline165__ssa_v3[9] = t__tmp_v84;
 
                     // Task 17: residual_rms_cast_2
@@ -750,7 +750,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t17.add_input(ext_post_rms_weight);
                     params_t17.add_scalar(k_base_inline111__ssa_v3);
                     params_t17.add_scalar(i);
-                    PTO2TaskId params_t17_deps[10];
+                    TaskId params_t17_deps[10];
                     uint32_t params_t17_deps_count = 0;
                     if (_submit_deps_buf_inline165__ssa_v3[0].is_valid())
                         params_t17_deps[params_t17_deps_count++] = _submit_deps_buf_inline165__ssa_v3[0];
@@ -775,32 +775,32 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t17.set_dependencies(params_t17_deps, params_t17_deps_count);
                     params_t17.set_allow_early_resolve(true);
                     TaskOutputTensors task_17_outs = rt_submit_aiv_task(18, params_t17);
-                    PTO2TaskId cast_tid_k_inline76__ssa_v3 = task_17_outs.task_id();
+                    TaskId cast_tid_k_inline76__ssa_v3 = task_17_outs.task_id();
                     cast_tids_inline88[3] = cast_tid_k_inline76__ssa_v3;
                     int64_t k_base_inline111__ssa_v4 = 4096;
                     int64_t n_split_base_inline163__ssa_v4 = 8;
-                    PTO2TaskId _submit_deps_buf_inline165__ssa_v4[10];
+                    TaskId _submit_deps_buf_inline165__ssa_v4[10];
                     for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                        _submit_deps_buf_inline165__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v87 = out_tids_inline271[(n_split_base_inline163__ssa_v4 * 5)];
+                        _submit_deps_buf_inline165__ssa_v4[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v87 = out_tids_inline271[(n_split_base_inline163__ssa_v4 * 5)];
                     _submit_deps_buf_inline165__ssa_v4[0] = t__tmp_v87;
-                    PTO2TaskId t__tmp_v88 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 1)];
+                    TaskId t__tmp_v88 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 1)];
                     _submit_deps_buf_inline165__ssa_v4[1] = t__tmp_v88;
-                    PTO2TaskId t__tmp_v89 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 2)];
+                    TaskId t__tmp_v89 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 2)];
                     _submit_deps_buf_inline165__ssa_v4[2] = t__tmp_v89;
-                    PTO2TaskId t__tmp_v90 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 3)];
+                    TaskId t__tmp_v90 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 3)];
                     _submit_deps_buf_inline165__ssa_v4[3] = t__tmp_v90;
-                    PTO2TaskId t__tmp_v91 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 4)];
+                    TaskId t__tmp_v91 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 4)];
                     _submit_deps_buf_inline165__ssa_v4[4] = t__tmp_v91;
-                    PTO2TaskId t__tmp_v92 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 5)];
+                    TaskId t__tmp_v92 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 5)];
                     _submit_deps_buf_inline165__ssa_v4[5] = t__tmp_v92;
-                    PTO2TaskId t__tmp_v93 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 6)];
+                    TaskId t__tmp_v93 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 6)];
                     _submit_deps_buf_inline165__ssa_v4[6] = t__tmp_v93;
-                    PTO2TaskId t__tmp_v94 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 7)];
+                    TaskId t__tmp_v94 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 7)];
                     _submit_deps_buf_inline165__ssa_v4[7] = t__tmp_v94;
-                    PTO2TaskId t__tmp_v95 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 8)];
+                    TaskId t__tmp_v95 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 8)];
                     _submit_deps_buf_inline165__ssa_v4[8] = t__tmp_v95;
-                    PTO2TaskId t__tmp_v96 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 9)];
+                    TaskId t__tmp_v96 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 9)];
                     _submit_deps_buf_inline165__ssa_v4[9] = t__tmp_v96;
 
                     // Task 18: residual_rms_cast_3
@@ -812,7 +812,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t18.add_input(ext_post_rms_weight);
                     params_t18.add_scalar(k_base_inline111__ssa_v4);
                     params_t18.add_scalar(i);
-                    PTO2TaskId params_t18_deps[10];
+                    TaskId params_t18_deps[10];
                     uint32_t params_t18_deps_count = 0;
                     if (_submit_deps_buf_inline165__ssa_v4[0].is_valid())
                         params_t18_deps[params_t18_deps_count++] = _submit_deps_buf_inline165__ssa_v4[0];
@@ -837,7 +837,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t18.set_dependencies(params_t18_deps, params_t18_deps_count);
                     params_t18.set_allow_early_resolve(true);
                     TaskOutputTensors task_18_outs = rt_submit_aiv_task(19, params_t18);
-                    PTO2TaskId cast_tid_k_inline76__ssa_v4 = task_18_outs.task_id();
+                    TaskId cast_tid_k_inline76__ssa_v4 = task_18_outs.task_id();
                     cast_tids_inline88[4] = cast_tid_k_inline76__ssa_v4;
 
                     // Task 19: post_rms_reduce
@@ -845,7 +845,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t19.add_input(attn_proj_fp32_inline220);
                     params_t19.add_input(cur__rv_v7);
                     params_t19.add_inout(inv_rms_tile_inline126);
-                    PTO2TaskId params_t19_deps[50];
+                    TaskId params_t19_deps[50];
                     uint32_t params_t19_deps_count = 0;
                     if (out_tids_inline271[0].is_valid())
                         params_t19_deps[params_t19_deps_count++] = out_tids_inline271[0];
@@ -949,17 +949,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t19_deps[params_t19_deps_count++] = out_tids_inline271[49];
                     params_t19.set_dependencies(params_t19_deps, params_t19_deps_count);
                     TaskOutputTensors task_19_outs = rt_submit_aiv_task(20, params_t19);
-                    PTO2TaskId reduce_tid_inline226 = task_19_outs.task_id();
+                    TaskId reduce_tid_inline226 = task_19_outs.task_id();
                     int64_t gu_k0_inline131 = 0;
-                    PTO2TaskId _submit_deps_buf_inline236[1];
+                    TaskId _submit_deps_buf_inline236[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline236[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v105 = cast_tids_inline88[0];
+                        _submit_deps_buf_inline236[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v105 = cast_tids_inline88[0];
                     _submit_deps_buf_inline236[0] = t__tmp_v105;
 
                     // Phase-fence barrier 3: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_3;
-                    PTO2TaskId params_phase_fence_barrier_3_deps[1];
+                    TaskId params_phase_fence_barrier_3_deps[1];
                     uint32_t params_phase_fence_barrier_3_deps_count = 0;
                     if (_submit_deps_buf_inline236[0].is_valid())
                         params_phase_fence_barrier_3_deps[params_phase_fence_barrier_3_deps_count++] =
@@ -967,22 +967,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_3.set_dependencies(
                         params_phase_fence_barrier_3_deps, params_phase_fence_barrier_3_deps_count
                     );
-                    PTO2TaskId t__tmp_v106 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v106 = TaskId::invalid();
                     if (params_phase_fence_barrier_3_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_3_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_3);
                         t__tmp_v106 = phase_fence_barrier_3_outs.task_id();
                     }
                     gate_late_tids_inline249[0] = t__tmp_v106;
-                    PTO2TaskId _submit_deps_buf_inline225[1];
+                    TaskId _submit_deps_buf_inline225[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline225[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v107 = cast_tids_inline88[0];
+                        _submit_deps_buf_inline225[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v107 = cast_tids_inline88[0];
                     _submit_deps_buf_inline225[0] = t__tmp_v107;
 
                     // Phase-fence barrier 4: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_4;
-                    PTO2TaskId params_phase_fence_barrier_4_deps[1];
+                    TaskId params_phase_fence_barrier_4_deps[1];
                     uint32_t params_phase_fence_barrier_4_deps_count = 0;
                     if (_submit_deps_buf_inline225[0].is_valid())
                         params_phase_fence_barrier_4_deps[params_phase_fence_barrier_4_deps_count++] =
@@ -990,17 +990,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_4.set_dependencies(
                         params_phase_fence_barrier_4_deps, params_phase_fence_barrier_4_deps_count
                     );
-                    PTO2TaskId t__tmp_v108 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v108 = TaskId::invalid();
                     if (params_phase_fence_barrier_4_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_4_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_4);
                         t__tmp_v108 = phase_fence_barrier_4_outs.task_id();
                     }
                     up_late_tids_inline69[0] = t__tmp_v108;
-                    PTO2TaskId _submit_deps_buf_inline237[1];
+                    TaskId _submit_deps_buf_inline237[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline237[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v109 = cast_tids_inline88[0];
+                        _submit_deps_buf_inline237[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v109 = cast_tids_inline88[0];
                     _submit_deps_buf_inline237[0] = t__tmp_v109;
 
                     // Spmd gate_proj_spmd: gate_proj
@@ -1011,23 +1011,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t20.add_scalar(gu_k0_inline131);
                     params_t20.add_scalar(layer_hidden_base_inline151);
                     params_t20.launch_spec.set_block_num(6);
-                    PTO2TaskId params_t20_deps[1];
+                    TaskId params_t20_deps[1];
                     uint32_t params_t20_deps_count = 0;
                     if (_submit_deps_buf_inline237[0].is_valid())
                         params_t20_deps[params_t20_deps_count++] = _submit_deps_buf_inline237[0];
                     params_t20.set_dependencies(params_t20_deps, params_t20_deps_count);
                     TaskOutputTensors task_20_outs = rt_submit_aic_task(21, params_t20);
-                    PTO2TaskId gate_spmd_tid_inline245 = task_20_outs.task_id();
+                    TaskId gate_spmd_tid_inline245 = task_20_outs.task_id();
                     gate_tids_inline56[0] = gate_spmd_tid_inline245;
                     gate_tids_inline56[5] = gate_spmd_tid_inline245;
                     gate_tids_inline56[10] = gate_spmd_tid_inline245;
                     gate_tids_inline56[15] = gate_spmd_tid_inline245;
                     gate_tids_inline56[20] = gate_spmd_tid_inline245;
                     gate_tids_inline56[25] = gate_spmd_tid_inline245;
-                    PTO2TaskId _submit_deps_buf_inline260[1];
+                    TaskId _submit_deps_buf_inline260[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline260[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v110 = cast_tids_inline88[0];
+                        _submit_deps_buf_inline260[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v110 = cast_tids_inline88[0];
                     _submit_deps_buf_inline260[0] = t__tmp_v110;
 
                     // Spmd up_proj_spmd: up_proj
@@ -1038,13 +1038,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t21.add_scalar(gu_k0_inline131);
                     params_t21.add_scalar(layer_hidden_base_inline151);
                     params_t21.launch_spec.set_block_num(6);
-                    PTO2TaskId params_t21_deps[1];
+                    TaskId params_t21_deps[1];
                     uint32_t params_t21_deps_count = 0;
                     if (_submit_deps_buf_inline260[0].is_valid())
                         params_t21_deps[params_t21_deps_count++] = _submit_deps_buf_inline260[0];
                     params_t21.set_dependencies(params_t21_deps, params_t21_deps_count);
                     TaskOutputTensors task_21_outs = rt_submit_aic_task(22, params_t21);
-                    PTO2TaskId up_spmd_tid_inline264 = task_21_outs.task_id();
+                    TaskId up_spmd_tid_inline264 = task_21_outs.task_id();
                     up_tids_inline310[0] = up_spmd_tid_inline264;
                     up_tids_inline310[5] = up_spmd_tid_inline264;
                     up_tids_inline310[10] = up_spmd_tid_inline264;
@@ -1052,15 +1052,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     up_tids_inline310[20] = up_spmd_tid_inline264;
                     up_tids_inline310[25] = up_spmd_tid_inline264;
                     int64_t gu_k0_inline131__ssa_v1 = 1024;
-                    PTO2TaskId _submit_deps_buf_inline236__ssa_v1[1];
+                    TaskId _submit_deps_buf_inline236__ssa_v1[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline236__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v111 = cast_tids_inline88[1];
+                        _submit_deps_buf_inline236__ssa_v1[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v111 = cast_tids_inline88[1];
                     _submit_deps_buf_inline236__ssa_v1[0] = t__tmp_v111;
 
                     // Phase-fence barrier 5: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_5;
-                    PTO2TaskId params_phase_fence_barrier_5_deps[1];
+                    TaskId params_phase_fence_barrier_5_deps[1];
                     uint32_t params_phase_fence_barrier_5_deps_count = 0;
                     if (_submit_deps_buf_inline236__ssa_v1[0].is_valid())
                         params_phase_fence_barrier_5_deps[params_phase_fence_barrier_5_deps_count++] =
@@ -1068,22 +1068,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_5.set_dependencies(
                         params_phase_fence_barrier_5_deps, params_phase_fence_barrier_5_deps_count
                     );
-                    PTO2TaskId t__tmp_v112 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v112 = TaskId::invalid();
                     if (params_phase_fence_barrier_5_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_5_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_5);
                         t__tmp_v112 = phase_fence_barrier_5_outs.task_id();
                     }
                     gate_late_tids_inline249[1] = t__tmp_v112;
-                    PTO2TaskId _submit_deps_buf_inline225__ssa_v1[1];
+                    TaskId _submit_deps_buf_inline225__ssa_v1[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline225__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v113 = cast_tids_inline88[1];
+                        _submit_deps_buf_inline225__ssa_v1[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v113 = cast_tids_inline88[1];
                     _submit_deps_buf_inline225__ssa_v1[0] = t__tmp_v113;
 
                     // Phase-fence barrier 6: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_6;
-                    PTO2TaskId params_phase_fence_barrier_6_deps[1];
+                    TaskId params_phase_fence_barrier_6_deps[1];
                     uint32_t params_phase_fence_barrier_6_deps_count = 0;
                     if (_submit_deps_buf_inline225__ssa_v1[0].is_valid())
                         params_phase_fence_barrier_6_deps[params_phase_fence_barrier_6_deps_count++] =
@@ -1091,17 +1091,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_6.set_dependencies(
                         params_phase_fence_barrier_6_deps, params_phase_fence_barrier_6_deps_count
                     );
-                    PTO2TaskId t__tmp_v114 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v114 = TaskId::invalid();
                     if (params_phase_fence_barrier_6_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_6_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_6);
                         t__tmp_v114 = phase_fence_barrier_6_outs.task_id();
                     }
                     up_late_tids_inline69[1] = t__tmp_v114;
-                    PTO2TaskId _submit_deps_buf_inline237__ssa_v1[1];
+                    TaskId _submit_deps_buf_inline237__ssa_v1[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline237__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v115 = cast_tids_inline88[1];
+                        _submit_deps_buf_inline237__ssa_v1[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v115 = cast_tids_inline88[1];
                     _submit_deps_buf_inline237__ssa_v1[0] = t__tmp_v115;
 
                     // Spmd gate_proj_spmd_0: gate_proj_0
@@ -1112,23 +1112,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t22.add_scalar(gu_k0_inline131__ssa_v1);
                     params_t22.add_scalar(layer_hidden_base_inline151);
                     params_t22.launch_spec.set_block_num(6);
-                    PTO2TaskId params_t22_deps[1];
+                    TaskId params_t22_deps[1];
                     uint32_t params_t22_deps_count = 0;
                     if (_submit_deps_buf_inline237__ssa_v1[0].is_valid())
                         params_t22_deps[params_t22_deps_count++] = _submit_deps_buf_inline237__ssa_v1[0];
                     params_t22.set_dependencies(params_t22_deps, params_t22_deps_count);
                     TaskOutputTensors task_22_outs = rt_submit_aic_task(23, params_t22);
-                    PTO2TaskId gate_spmd_tid_inline245__ssa_v1 = task_22_outs.task_id();
+                    TaskId gate_spmd_tid_inline245__ssa_v1 = task_22_outs.task_id();
                     gate_tids_inline56[1] = gate_spmd_tid_inline245__ssa_v1;
                     gate_tids_inline56[6] = gate_spmd_tid_inline245__ssa_v1;
                     gate_tids_inline56[11] = gate_spmd_tid_inline245__ssa_v1;
                     gate_tids_inline56[16] = gate_spmd_tid_inline245__ssa_v1;
                     gate_tids_inline56[21] = gate_spmd_tid_inline245__ssa_v1;
                     gate_tids_inline56[26] = gate_spmd_tid_inline245__ssa_v1;
-                    PTO2TaskId _submit_deps_buf_inline260__ssa_v1[1];
+                    TaskId _submit_deps_buf_inline260__ssa_v1[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline260__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v116 = cast_tids_inline88[1];
+                        _submit_deps_buf_inline260__ssa_v1[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v116 = cast_tids_inline88[1];
                     _submit_deps_buf_inline260__ssa_v1[0] = t__tmp_v116;
 
                     // Spmd up_proj_spmd_0: up_proj_0
@@ -1139,13 +1139,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t23.add_scalar(gu_k0_inline131__ssa_v1);
                     params_t23.add_scalar(layer_hidden_base_inline151);
                     params_t23.launch_spec.set_block_num(6);
-                    PTO2TaskId params_t23_deps[1];
+                    TaskId params_t23_deps[1];
                     uint32_t params_t23_deps_count = 0;
                     if (_submit_deps_buf_inline260__ssa_v1[0].is_valid())
                         params_t23_deps[params_t23_deps_count++] = _submit_deps_buf_inline260__ssa_v1[0];
                     params_t23.set_dependencies(params_t23_deps, params_t23_deps_count);
                     TaskOutputTensors task_23_outs = rt_submit_aic_task(24, params_t23);
-                    PTO2TaskId up_spmd_tid_inline264__ssa_v1 = task_23_outs.task_id();
+                    TaskId up_spmd_tid_inline264__ssa_v1 = task_23_outs.task_id();
                     up_tids_inline310[1] = up_spmd_tid_inline264__ssa_v1;
                     up_tids_inline310[6] = up_spmd_tid_inline264__ssa_v1;
                     up_tids_inline310[11] = up_spmd_tid_inline264__ssa_v1;
@@ -1153,15 +1153,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     up_tids_inline310[21] = up_spmd_tid_inline264__ssa_v1;
                     up_tids_inline310[26] = up_spmd_tid_inline264__ssa_v1;
                     int64_t gu_k0_inline131__ssa_v2 = 2048;
-                    PTO2TaskId _submit_deps_buf_inline236__ssa_v2[1];
+                    TaskId _submit_deps_buf_inline236__ssa_v2[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline236__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v117 = cast_tids_inline88[2];
+                        _submit_deps_buf_inline236__ssa_v2[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v117 = cast_tids_inline88[2];
                     _submit_deps_buf_inline236__ssa_v2[0] = t__tmp_v117;
 
                     // Phase-fence barrier 7: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_7;
-                    PTO2TaskId params_phase_fence_barrier_7_deps[1];
+                    TaskId params_phase_fence_barrier_7_deps[1];
                     uint32_t params_phase_fence_barrier_7_deps_count = 0;
                     if (_submit_deps_buf_inline236__ssa_v2[0].is_valid())
                         params_phase_fence_barrier_7_deps[params_phase_fence_barrier_7_deps_count++] =
@@ -1169,22 +1169,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_7.set_dependencies(
                         params_phase_fence_barrier_7_deps, params_phase_fence_barrier_7_deps_count
                     );
-                    PTO2TaskId t__tmp_v118 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v118 = TaskId::invalid();
                     if (params_phase_fence_barrier_7_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_7_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_7);
                         t__tmp_v118 = phase_fence_barrier_7_outs.task_id();
                     }
                     gate_late_tids_inline249[2] = t__tmp_v118;
-                    PTO2TaskId _submit_deps_buf_inline225__ssa_v2[1];
+                    TaskId _submit_deps_buf_inline225__ssa_v2[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline225__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v119 = cast_tids_inline88[2];
+                        _submit_deps_buf_inline225__ssa_v2[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v119 = cast_tids_inline88[2];
                     _submit_deps_buf_inline225__ssa_v2[0] = t__tmp_v119;
 
                     // Phase-fence barrier 8: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_8;
-                    PTO2TaskId params_phase_fence_barrier_8_deps[1];
+                    TaskId params_phase_fence_barrier_8_deps[1];
                     uint32_t params_phase_fence_barrier_8_deps_count = 0;
                     if (_submit_deps_buf_inline225__ssa_v2[0].is_valid())
                         params_phase_fence_barrier_8_deps[params_phase_fence_barrier_8_deps_count++] =
@@ -1192,17 +1192,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_8.set_dependencies(
                         params_phase_fence_barrier_8_deps, params_phase_fence_barrier_8_deps_count
                     );
-                    PTO2TaskId t__tmp_v120 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v120 = TaskId::invalid();
                     if (params_phase_fence_barrier_8_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_8_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_8);
                         t__tmp_v120 = phase_fence_barrier_8_outs.task_id();
                     }
                     up_late_tids_inline69[2] = t__tmp_v120;
-                    PTO2TaskId _submit_deps_buf_inline237__ssa_v2[1];
+                    TaskId _submit_deps_buf_inline237__ssa_v2[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline237__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v121 = cast_tids_inline88[2];
+                        _submit_deps_buf_inline237__ssa_v2[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v121 = cast_tids_inline88[2];
                     _submit_deps_buf_inline237__ssa_v2[0] = t__tmp_v121;
 
                     // Spmd gate_proj_spmd_1: gate_proj_1
@@ -1213,23 +1213,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t24.add_scalar(gu_k0_inline131__ssa_v2);
                     params_t24.add_scalar(layer_hidden_base_inline151);
                     params_t24.launch_spec.set_block_num(6);
-                    PTO2TaskId params_t24_deps[1];
+                    TaskId params_t24_deps[1];
                     uint32_t params_t24_deps_count = 0;
                     if (_submit_deps_buf_inline237__ssa_v2[0].is_valid())
                         params_t24_deps[params_t24_deps_count++] = _submit_deps_buf_inline237__ssa_v2[0];
                     params_t24.set_dependencies(params_t24_deps, params_t24_deps_count);
                     TaskOutputTensors task_24_outs = rt_submit_aic_task(25, params_t24);
-                    PTO2TaskId gate_spmd_tid_inline245__ssa_v2 = task_24_outs.task_id();
+                    TaskId gate_spmd_tid_inline245__ssa_v2 = task_24_outs.task_id();
                     gate_tids_inline56[2] = gate_spmd_tid_inline245__ssa_v2;
                     gate_tids_inline56[7] = gate_spmd_tid_inline245__ssa_v2;
                     gate_tids_inline56[12] = gate_spmd_tid_inline245__ssa_v2;
                     gate_tids_inline56[17] = gate_spmd_tid_inline245__ssa_v2;
                     gate_tids_inline56[22] = gate_spmd_tid_inline245__ssa_v2;
                     gate_tids_inline56[27] = gate_spmd_tid_inline245__ssa_v2;
-                    PTO2TaskId _submit_deps_buf_inline260__ssa_v2[1];
+                    TaskId _submit_deps_buf_inline260__ssa_v2[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline260__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v122 = cast_tids_inline88[2];
+                        _submit_deps_buf_inline260__ssa_v2[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v122 = cast_tids_inline88[2];
                     _submit_deps_buf_inline260__ssa_v2[0] = t__tmp_v122;
 
                     // Spmd up_proj_spmd_1: up_proj_1
@@ -1240,13 +1240,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t25.add_scalar(gu_k0_inline131__ssa_v2);
                     params_t25.add_scalar(layer_hidden_base_inline151);
                     params_t25.launch_spec.set_block_num(6);
-                    PTO2TaskId params_t25_deps[1];
+                    TaskId params_t25_deps[1];
                     uint32_t params_t25_deps_count = 0;
                     if (_submit_deps_buf_inline260__ssa_v2[0].is_valid())
                         params_t25_deps[params_t25_deps_count++] = _submit_deps_buf_inline260__ssa_v2[0];
                     params_t25.set_dependencies(params_t25_deps, params_t25_deps_count);
                     TaskOutputTensors task_25_outs = rt_submit_aic_task(26, params_t25);
-                    PTO2TaskId up_spmd_tid_inline264__ssa_v2 = task_25_outs.task_id();
+                    TaskId up_spmd_tid_inline264__ssa_v2 = task_25_outs.task_id();
                     up_tids_inline310[2] = up_spmd_tid_inline264__ssa_v2;
                     up_tids_inline310[7] = up_spmd_tid_inline264__ssa_v2;
                     up_tids_inline310[12] = up_spmd_tid_inline264__ssa_v2;
@@ -1254,15 +1254,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     up_tids_inline310[22] = up_spmd_tid_inline264__ssa_v2;
                     up_tids_inline310[27] = up_spmd_tid_inline264__ssa_v2;
                     int64_t gu_k0_inline131__ssa_v3 = 3072;
-                    PTO2TaskId _submit_deps_buf_inline236__ssa_v3[1];
+                    TaskId _submit_deps_buf_inline236__ssa_v3[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline236__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v123 = cast_tids_inline88[3];
+                        _submit_deps_buf_inline236__ssa_v3[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v123 = cast_tids_inline88[3];
                     _submit_deps_buf_inline236__ssa_v3[0] = t__tmp_v123;
 
                     // Phase-fence barrier 9: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_9;
-                    PTO2TaskId params_phase_fence_barrier_9_deps[1];
+                    TaskId params_phase_fence_barrier_9_deps[1];
                     uint32_t params_phase_fence_barrier_9_deps_count = 0;
                     if (_submit_deps_buf_inline236__ssa_v3[0].is_valid())
                         params_phase_fence_barrier_9_deps[params_phase_fence_barrier_9_deps_count++] =
@@ -1270,22 +1270,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_9.set_dependencies(
                         params_phase_fence_barrier_9_deps, params_phase_fence_barrier_9_deps_count
                     );
-                    PTO2TaskId t__tmp_v124 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v124 = TaskId::invalid();
                     if (params_phase_fence_barrier_9_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_9_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_9);
                         t__tmp_v124 = phase_fence_barrier_9_outs.task_id();
                     }
                     gate_late_tids_inline249[3] = t__tmp_v124;
-                    PTO2TaskId _submit_deps_buf_inline225__ssa_v3[1];
+                    TaskId _submit_deps_buf_inline225__ssa_v3[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline225__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v125 = cast_tids_inline88[3];
+                        _submit_deps_buf_inline225__ssa_v3[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v125 = cast_tids_inline88[3];
                     _submit_deps_buf_inline225__ssa_v3[0] = t__tmp_v125;
 
                     // Phase-fence barrier 10: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_10;
-                    PTO2TaskId params_phase_fence_barrier_10_deps[1];
+                    TaskId params_phase_fence_barrier_10_deps[1];
                     uint32_t params_phase_fence_barrier_10_deps_count = 0;
                     if (_submit_deps_buf_inline225__ssa_v3[0].is_valid())
                         params_phase_fence_barrier_10_deps[params_phase_fence_barrier_10_deps_count++] =
@@ -1293,17 +1293,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_10.set_dependencies(
                         params_phase_fence_barrier_10_deps, params_phase_fence_barrier_10_deps_count
                     );
-                    PTO2TaskId t__tmp_v126 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v126 = TaskId::invalid();
                     if (params_phase_fence_barrier_10_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_10_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_10);
                         t__tmp_v126 = phase_fence_barrier_10_outs.task_id();
                     }
                     up_late_tids_inline69[3] = t__tmp_v126;
-                    PTO2TaskId _submit_deps_buf_inline237__ssa_v3[1];
+                    TaskId _submit_deps_buf_inline237__ssa_v3[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline237__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v127 = cast_tids_inline88[3];
+                        _submit_deps_buf_inline237__ssa_v3[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v127 = cast_tids_inline88[3];
                     _submit_deps_buf_inline237__ssa_v3[0] = t__tmp_v127;
 
                     // Spmd gate_proj_spmd_2: gate_proj_2
@@ -1314,23 +1314,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t26.add_scalar(gu_k0_inline131__ssa_v3);
                     params_t26.add_scalar(layer_hidden_base_inline151);
                     params_t26.launch_spec.set_block_num(6);
-                    PTO2TaskId params_t26_deps[1];
+                    TaskId params_t26_deps[1];
                     uint32_t params_t26_deps_count = 0;
                     if (_submit_deps_buf_inline237__ssa_v3[0].is_valid())
                         params_t26_deps[params_t26_deps_count++] = _submit_deps_buf_inline237__ssa_v3[0];
                     params_t26.set_dependencies(params_t26_deps, params_t26_deps_count);
                     TaskOutputTensors task_26_outs = rt_submit_aic_task(27, params_t26);
-                    PTO2TaskId gate_spmd_tid_inline245__ssa_v3 = task_26_outs.task_id();
+                    TaskId gate_spmd_tid_inline245__ssa_v3 = task_26_outs.task_id();
                     gate_tids_inline56[3] = gate_spmd_tid_inline245__ssa_v3;
                     gate_tids_inline56[8] = gate_spmd_tid_inline245__ssa_v3;
                     gate_tids_inline56[13] = gate_spmd_tid_inline245__ssa_v3;
                     gate_tids_inline56[18] = gate_spmd_tid_inline245__ssa_v3;
                     gate_tids_inline56[23] = gate_spmd_tid_inline245__ssa_v3;
                     gate_tids_inline56[28] = gate_spmd_tid_inline245__ssa_v3;
-                    PTO2TaskId _submit_deps_buf_inline260__ssa_v3[1];
+                    TaskId _submit_deps_buf_inline260__ssa_v3[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline260__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v128 = cast_tids_inline88[3];
+                        _submit_deps_buf_inline260__ssa_v3[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v128 = cast_tids_inline88[3];
                     _submit_deps_buf_inline260__ssa_v3[0] = t__tmp_v128;
 
                     // Spmd up_proj_spmd_2: up_proj_2
@@ -1341,13 +1341,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t27.add_scalar(gu_k0_inline131__ssa_v3);
                     params_t27.add_scalar(layer_hidden_base_inline151);
                     params_t27.launch_spec.set_block_num(6);
-                    PTO2TaskId params_t27_deps[1];
+                    TaskId params_t27_deps[1];
                     uint32_t params_t27_deps_count = 0;
                     if (_submit_deps_buf_inline260__ssa_v3[0].is_valid())
                         params_t27_deps[params_t27_deps_count++] = _submit_deps_buf_inline260__ssa_v3[0];
                     params_t27.set_dependencies(params_t27_deps, params_t27_deps_count);
                     TaskOutputTensors task_27_outs = rt_submit_aic_task(28, params_t27);
-                    PTO2TaskId up_spmd_tid_inline264__ssa_v3 = task_27_outs.task_id();
+                    TaskId up_spmd_tid_inline264__ssa_v3 = task_27_outs.task_id();
                     up_tids_inline310[3] = up_spmd_tid_inline264__ssa_v3;
                     up_tids_inline310[8] = up_spmd_tid_inline264__ssa_v3;
                     up_tids_inline310[13] = up_spmd_tid_inline264__ssa_v3;
@@ -1355,15 +1355,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     up_tids_inline310[23] = up_spmd_tid_inline264__ssa_v3;
                     up_tids_inline310[28] = up_spmd_tid_inline264__ssa_v3;
                     int64_t gu_k0_inline131__ssa_v4 = 4096;
-                    PTO2TaskId _submit_deps_buf_inline236__ssa_v4[1];
+                    TaskId _submit_deps_buf_inline236__ssa_v4[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline236__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v129 = cast_tids_inline88[4];
+                        _submit_deps_buf_inline236__ssa_v4[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v129 = cast_tids_inline88[4];
                     _submit_deps_buf_inline236__ssa_v4[0] = t__tmp_v129;
 
                     // Phase-fence barrier 11: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_11;
-                    PTO2TaskId params_phase_fence_barrier_11_deps[1];
+                    TaskId params_phase_fence_barrier_11_deps[1];
                     uint32_t params_phase_fence_barrier_11_deps_count = 0;
                     if (_submit_deps_buf_inline236__ssa_v4[0].is_valid())
                         params_phase_fence_barrier_11_deps[params_phase_fence_barrier_11_deps_count++] =
@@ -1371,22 +1371,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_11.set_dependencies(
                         params_phase_fence_barrier_11_deps, params_phase_fence_barrier_11_deps_count
                     );
-                    PTO2TaskId t__tmp_v130 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v130 = TaskId::invalid();
                     if (params_phase_fence_barrier_11_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_11_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_11);
                         t__tmp_v130 = phase_fence_barrier_11_outs.task_id();
                     }
                     gate_late_tids_inline249[4] = t__tmp_v130;
-                    PTO2TaskId _submit_deps_buf_inline225__ssa_v4[1];
+                    TaskId _submit_deps_buf_inline225__ssa_v4[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline225__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v131 = cast_tids_inline88[4];
+                        _submit_deps_buf_inline225__ssa_v4[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v131 = cast_tids_inline88[4];
                     _submit_deps_buf_inline225__ssa_v4[0] = t__tmp_v131;
 
                     // Phase-fence barrier 12: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_12;
-                    PTO2TaskId params_phase_fence_barrier_12_deps[1];
+                    TaskId params_phase_fence_barrier_12_deps[1];
                     uint32_t params_phase_fence_barrier_12_deps_count = 0;
                     if (_submit_deps_buf_inline225__ssa_v4[0].is_valid())
                         params_phase_fence_barrier_12_deps[params_phase_fence_barrier_12_deps_count++] =
@@ -1394,17 +1394,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_12.set_dependencies(
                         params_phase_fence_barrier_12_deps, params_phase_fence_barrier_12_deps_count
                     );
-                    PTO2TaskId t__tmp_v132 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v132 = TaskId::invalid();
                     if (params_phase_fence_barrier_12_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_12_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_12);
                         t__tmp_v132 = phase_fence_barrier_12_outs.task_id();
                     }
                     up_late_tids_inline69[4] = t__tmp_v132;
-                    PTO2TaskId _submit_deps_buf_inline237__ssa_v4[1];
+                    TaskId _submit_deps_buf_inline237__ssa_v4[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline237__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v133 = cast_tids_inline88[4];
+                        _submit_deps_buf_inline237__ssa_v4[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v133 = cast_tids_inline88[4];
                     _submit_deps_buf_inline237__ssa_v4[0] = t__tmp_v133;
 
                     // Spmd gate_proj_spmd_3: gate_proj_3
@@ -1415,23 +1415,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t28.add_scalar(gu_k0_inline131__ssa_v4);
                     params_t28.add_scalar(layer_hidden_base_inline151);
                     params_t28.launch_spec.set_block_num(6);
-                    PTO2TaskId params_t28_deps[1];
+                    TaskId params_t28_deps[1];
                     uint32_t params_t28_deps_count = 0;
                     if (_submit_deps_buf_inline237__ssa_v4[0].is_valid())
                         params_t28_deps[params_t28_deps_count++] = _submit_deps_buf_inline237__ssa_v4[0];
                     params_t28.set_dependencies(params_t28_deps, params_t28_deps_count);
                     TaskOutputTensors task_28_outs = rt_submit_aic_task(29, params_t28);
-                    PTO2TaskId gate_spmd_tid_inline245__ssa_v4 = task_28_outs.task_id();
+                    TaskId gate_spmd_tid_inline245__ssa_v4 = task_28_outs.task_id();
                     gate_tids_inline56[4] = gate_spmd_tid_inline245__ssa_v4;
                     gate_tids_inline56[9] = gate_spmd_tid_inline245__ssa_v4;
                     gate_tids_inline56[14] = gate_spmd_tid_inline245__ssa_v4;
                     gate_tids_inline56[19] = gate_spmd_tid_inline245__ssa_v4;
                     gate_tids_inline56[24] = gate_spmd_tid_inline245__ssa_v4;
                     gate_tids_inline56[29] = gate_spmd_tid_inline245__ssa_v4;
-                    PTO2TaskId _submit_deps_buf_inline260__ssa_v4[1];
+                    TaskId _submit_deps_buf_inline260__ssa_v4[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline260__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v134 = cast_tids_inline88[4];
+                        _submit_deps_buf_inline260__ssa_v4[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v134 = cast_tids_inline88[4];
                     _submit_deps_buf_inline260__ssa_v4[0] = t__tmp_v134;
 
                     // Spmd up_proj_spmd_3: up_proj_3
@@ -1442,13 +1442,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t29.add_scalar(gu_k0_inline131__ssa_v4);
                     params_t29.add_scalar(layer_hidden_base_inline151);
                     params_t29.launch_spec.set_block_num(6);
-                    PTO2TaskId params_t29_deps[1];
+                    TaskId params_t29_deps[1];
                     uint32_t params_t29_deps_count = 0;
                     if (_submit_deps_buf_inline260__ssa_v4[0].is_valid())
                         params_t29_deps[params_t29_deps_count++] = _submit_deps_buf_inline260__ssa_v4[0];
                     params_t29.set_dependencies(params_t29_deps, params_t29_deps_count);
                     TaskOutputTensors task_29_outs = rt_submit_aic_task(30, params_t29);
-                    PTO2TaskId up_spmd_tid_inline264__ssa_v4 = task_29_outs.task_id();
+                    TaskId up_spmd_tid_inline264__ssa_v4 = task_29_outs.task_id();
                     up_tids_inline310[4] = up_spmd_tid_inline264__ssa_v4;
                     up_tids_inline310[9] = up_spmd_tid_inline264__ssa_v4;
                     up_tids_inline310[14] = up_spmd_tid_inline264__ssa_v4;
@@ -1459,10 +1459,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         int64_t n0_inline122 = (n_out_inline275 * 1024);
                         for (int64_t k_split_inline276 = 0; k_split_inline276 < 5; k_split_inline276 += 1) {
                             int64_t k0_inline113 = (k_split_inline276 * 1024);
-                            PTO2TaskId _submit_deps_buf_inline102[1];
+                            TaskId _submit_deps_buf_inline102[1];
                             for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                                _submit_deps_buf_inline102[__init_i] = PTO2TaskId::invalid();
-                            PTO2TaskId t__tmp_v135 = gate_late_tids_inline249[k_split_inline276];
+                                _submit_deps_buf_inline102[__init_i] = TaskId::invalid();
+                            TaskId t__tmp_v135 = gate_late_tids_inline249[k_split_inline276];
                             _submit_deps_buf_inline102[0] = t__tmp_v135;
 
                             // Task 30: gate_proj_4
@@ -1473,18 +1473,18 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t30.add_scalar(k0_inline113);
                             params_t30.add_scalar(layer_hidden_base_inline151);
                             params_t30.add_scalar(n0_inline122);
-                            PTO2TaskId params_t30_deps[1];
+                            TaskId params_t30_deps[1];
                             uint32_t params_t30_deps_count = 0;
                             if (_submit_deps_buf_inline102[0].is_valid())
                                 params_t30_deps[params_t30_deps_count++] = _submit_deps_buf_inline102[0];
                             params_t30.set_dependencies(params_t30_deps, params_t30_deps_count);
                             TaskOutputTensors task_30_outs = rt_submit_aic_task(31, params_t30);
-                            PTO2TaskId gate_tid_inline277 = task_30_outs.task_id();
+                            TaskId gate_tid_inline277 = task_30_outs.task_id();
                             gate_tids_inline56[((n_out_inline275 * 5) + k_split_inline276)] = gate_tid_inline277;
-                            PTO2TaskId _submit_deps_buf_inline246[1];
+                            TaskId _submit_deps_buf_inline246[1];
                             for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                                _submit_deps_buf_inline246[__init_i] = PTO2TaskId::invalid();
-                            PTO2TaskId t__tmp_v136 = up_late_tids_inline69[k_split_inline276];
+                                _submit_deps_buf_inline246[__init_i] = TaskId::invalid();
+                            TaskId t__tmp_v136 = up_late_tids_inline69[k_split_inline276];
                             _submit_deps_buf_inline246[0] = t__tmp_v136;
 
                             // Task 31: up_proj_4
@@ -1495,41 +1495,41 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t31.add_scalar(k0_inline113);
                             params_t31.add_scalar(layer_hidden_base_inline151);
                             params_t31.add_scalar(n0_inline122);
-                            PTO2TaskId params_t31_deps[1];
+                            TaskId params_t31_deps[1];
                             uint32_t params_t31_deps_count = 0;
                             if (_submit_deps_buf_inline246[0].is_valid())
                                 params_t31_deps[params_t31_deps_count++] = _submit_deps_buf_inline246[0];
                             params_t31.set_dependencies(params_t31_deps, params_t31_deps_count);
                             TaskOutputTensors task_31_outs = rt_submit_aic_task(32, params_t31);
-                            PTO2TaskId up_tid_inline290 = task_31_outs.task_id();
+                            TaskId up_tid_inline290 = task_31_outs.task_id();
                             up_tids_inline310[((n_out_inline275 * 5) + k_split_inline276)] = up_tid_inline290;
                         }
                     }
                     for (int64_t n_out_inline292 = 0; n_out_inline292 < 17; n_out_inline292 += 1) {
                         int64_t n0_inline122__ssa_v7 = (n_out_inline292 * 1024);
-                        PTO2TaskId _submit_deps_buf_inline167[11];
+                        TaskId _submit_deps_buf_inline167[11];
                         for (int64_t __init_i = 0; __init_i < 11; ++__init_i)
-                            _submit_deps_buf_inline167[__init_i] = PTO2TaskId::invalid();
+                            _submit_deps_buf_inline167[__init_i] = TaskId::invalid();
                         _submit_deps_buf_inline167[0] = reduce_tid_inline226;
-                        PTO2TaskId t__tmp_v137 = gate_tids_inline56[(n_out_inline292 * 5)];
+                        TaskId t__tmp_v137 = gate_tids_inline56[(n_out_inline292 * 5)];
                         _submit_deps_buf_inline167[1] = t__tmp_v137;
-                        PTO2TaskId t__tmp_v138 = gate_tids_inline56[((n_out_inline292 * 5) + 1)];
+                        TaskId t__tmp_v138 = gate_tids_inline56[((n_out_inline292 * 5) + 1)];
                         _submit_deps_buf_inline167[2] = t__tmp_v138;
-                        PTO2TaskId t__tmp_v139 = gate_tids_inline56[((n_out_inline292 * 5) + 2)];
+                        TaskId t__tmp_v139 = gate_tids_inline56[((n_out_inline292 * 5) + 2)];
                         _submit_deps_buf_inline167[3] = t__tmp_v139;
-                        PTO2TaskId t__tmp_v140 = gate_tids_inline56[((n_out_inline292 * 5) + 3)];
+                        TaskId t__tmp_v140 = gate_tids_inline56[((n_out_inline292 * 5) + 3)];
                         _submit_deps_buf_inline167[4] = t__tmp_v140;
-                        PTO2TaskId t__tmp_v141 = gate_tids_inline56[((n_out_inline292 * 5) + 4)];
+                        TaskId t__tmp_v141 = gate_tids_inline56[((n_out_inline292 * 5) + 4)];
                         _submit_deps_buf_inline167[5] = t__tmp_v141;
-                        PTO2TaskId t__tmp_v142 = up_tids_inline310[(n_out_inline292 * 5)];
+                        TaskId t__tmp_v142 = up_tids_inline310[(n_out_inline292 * 5)];
                         _submit_deps_buf_inline167[6] = t__tmp_v142;
-                        PTO2TaskId t__tmp_v143 = up_tids_inline310[((n_out_inline292 * 5) + 1)];
+                        TaskId t__tmp_v143 = up_tids_inline310[((n_out_inline292 * 5) + 1)];
                         _submit_deps_buf_inline167[7] = t__tmp_v143;
-                        PTO2TaskId t__tmp_v144 = up_tids_inline310[((n_out_inline292 * 5) + 2)];
+                        TaskId t__tmp_v144 = up_tids_inline310[((n_out_inline292 * 5) + 2)];
                         _submit_deps_buf_inline167[8] = t__tmp_v144;
-                        PTO2TaskId t__tmp_v145 = up_tids_inline310[((n_out_inline292 * 5) + 3)];
+                        TaskId t__tmp_v145 = up_tids_inline310[((n_out_inline292 * 5) + 3)];
                         _submit_deps_buf_inline167[9] = t__tmp_v145;
-                        PTO2TaskId t__tmp_v146 = up_tids_inline310[((n_out_inline292 * 5) + 4)];
+                        TaskId t__tmp_v146 = up_tids_inline310[((n_out_inline292 * 5) + 4)];
                         _submit_deps_buf_inline167[10] = t__tmp_v146;
 
                         // Task 32: silu
@@ -1539,7 +1539,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t32.add_input(gate_acc_all_inline203);
                         params_t32.add_input(up_acc_all_inline303);
                         params_t32.add_scalar(n0_inline122__ssa_v7);
-                        PTO2TaskId params_t32_deps[11];
+                        TaskId params_t32_deps[11];
                         uint32_t params_t32_deps_count = 0;
                         if (_submit_deps_buf_inline167[0].is_valid())
                             params_t32_deps[params_t32_deps_count++] = _submit_deps_buf_inline167[0];
@@ -1565,17 +1565,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t32_deps[params_t32_deps_count++] = _submit_deps_buf_inline167[10];
                         params_t32.set_dependencies(params_t32_deps, params_t32_deps_count);
                         TaskOutputTensors task_32_outs = rt_submit_aiv_task(33, params_t32);
-                        PTO2TaskId silu_tid_inline80 = task_32_outs.task_id();
+                        TaskId silu_tid_inline80 = task_32_outs.task_id();
                         silu_tids_inline265[n_out_inline292] = silu_tid_inline80;
                     }
                     for (int64_t n_out_inline195 = 0; n_out_inline195 < 5; n_out_inline195 += 1) {
                         int64_t n0_inline122__ssa_v8 = (n_out_inline195 * 1024);
                         for (int64_t k_split_inline302 = 0; k_split_inline302 < 17; k_split_inline302 += 1) {
                             int64_t k0_inline113__ssa_v8 = (k_split_inline302 * 1024);
-                            PTO2TaskId _submit_deps_buf_inline229[1];
+                            TaskId _submit_deps_buf_inline229[1];
                             for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                                _submit_deps_buf_inline229[__init_i] = PTO2TaskId::invalid();
-                            PTO2TaskId t__tmp_v152 = silu_tids_inline265[k_split_inline302];
+                                _submit_deps_buf_inline229[__init_i] = TaskId::invalid();
+                            TaskId t__tmp_v152 = silu_tids_inline265[k_split_inline302];
                             _submit_deps_buf_inline229[0] = t__tmp_v152;
 
                             // Task 33: down_proj
@@ -1586,190 +1586,190 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t33.add_scalar(k0_inline113__ssa_v8);
                             params_t33.add_scalar(layer_inter_base_inline107);
                             params_t33.add_scalar(n0_inline122__ssa_v8);
-                            PTO2TaskId params_t33_deps[1];
+                            TaskId params_t33_deps[1];
                             uint32_t params_t33_deps_count = 0;
                             if (_submit_deps_buf_inline229[0].is_valid())
                                 params_t33_deps[params_t33_deps_count++] = _submit_deps_buf_inline229[0];
                             params_t33.set_dependencies(params_t33_deps, params_t33_deps_count);
                             params_t33.set_allow_early_resolve(true);
                             TaskOutputTensors task_33_outs = rt_submit_aic_task(34, params_t33);
-                            PTO2TaskId down_tid_inline210 = task_33_outs.task_id();
+                            TaskId down_tid_inline210 = task_33_outs.task_id();
                             down_tids_inline156[((n_out_inline195 * 17) + k_split_inline302)] = down_tid_inline210;
                         }
                     }
                 }
-                PTO2TaskId _submit_deps_buf_inline123[85];
+                TaskId _submit_deps_buf_inline123[85];
                 for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
-                    _submit_deps_buf_inline123[__init_i] = PTO2TaskId::invalid();
-                PTO2TaskId t__tmp_v153 = down_tids_inline156[0];
+                    _submit_deps_buf_inline123[__init_i] = TaskId::invalid();
+                TaskId t__tmp_v153 = down_tids_inline156[0];
                 _submit_deps_buf_inline123[0] = t__tmp_v153;
-                PTO2TaskId t__tmp_v154 = down_tids_inline156[1];
+                TaskId t__tmp_v154 = down_tids_inline156[1];
                 _submit_deps_buf_inline123[1] = t__tmp_v154;
-                PTO2TaskId t__tmp_v155 = down_tids_inline156[2];
+                TaskId t__tmp_v155 = down_tids_inline156[2];
                 _submit_deps_buf_inline123[2] = t__tmp_v155;
-                PTO2TaskId t__tmp_v156 = down_tids_inline156[3];
+                TaskId t__tmp_v156 = down_tids_inline156[3];
                 _submit_deps_buf_inline123[3] = t__tmp_v156;
-                PTO2TaskId t__tmp_v157 = down_tids_inline156[4];
+                TaskId t__tmp_v157 = down_tids_inline156[4];
                 _submit_deps_buf_inline123[4] = t__tmp_v157;
-                PTO2TaskId t__tmp_v158 = down_tids_inline156[5];
+                TaskId t__tmp_v158 = down_tids_inline156[5];
                 _submit_deps_buf_inline123[5] = t__tmp_v158;
-                PTO2TaskId t__tmp_v159 = down_tids_inline156[6];
+                TaskId t__tmp_v159 = down_tids_inline156[6];
                 _submit_deps_buf_inline123[6] = t__tmp_v159;
-                PTO2TaskId t__tmp_v160 = down_tids_inline156[7];
+                TaskId t__tmp_v160 = down_tids_inline156[7];
                 _submit_deps_buf_inline123[7] = t__tmp_v160;
-                PTO2TaskId t__tmp_v161 = down_tids_inline156[8];
+                TaskId t__tmp_v161 = down_tids_inline156[8];
                 _submit_deps_buf_inline123[8] = t__tmp_v161;
-                PTO2TaskId t__tmp_v162 = down_tids_inline156[9];
+                TaskId t__tmp_v162 = down_tids_inline156[9];
                 _submit_deps_buf_inline123[9] = t__tmp_v162;
-                PTO2TaskId t__tmp_v163 = down_tids_inline156[10];
+                TaskId t__tmp_v163 = down_tids_inline156[10];
                 _submit_deps_buf_inline123[10] = t__tmp_v163;
-                PTO2TaskId t__tmp_v164 = down_tids_inline156[11];
+                TaskId t__tmp_v164 = down_tids_inline156[11];
                 _submit_deps_buf_inline123[11] = t__tmp_v164;
-                PTO2TaskId t__tmp_v165 = down_tids_inline156[12];
+                TaskId t__tmp_v165 = down_tids_inline156[12];
                 _submit_deps_buf_inline123[12] = t__tmp_v165;
-                PTO2TaskId t__tmp_v166 = down_tids_inline156[13];
+                TaskId t__tmp_v166 = down_tids_inline156[13];
                 _submit_deps_buf_inline123[13] = t__tmp_v166;
-                PTO2TaskId t__tmp_v167 = down_tids_inline156[14];
+                TaskId t__tmp_v167 = down_tids_inline156[14];
                 _submit_deps_buf_inline123[14] = t__tmp_v167;
-                PTO2TaskId t__tmp_v168 = down_tids_inline156[15];
+                TaskId t__tmp_v168 = down_tids_inline156[15];
                 _submit_deps_buf_inline123[15] = t__tmp_v168;
-                PTO2TaskId t__tmp_v169 = down_tids_inline156[16];
+                TaskId t__tmp_v169 = down_tids_inline156[16];
                 _submit_deps_buf_inline123[16] = t__tmp_v169;
-                PTO2TaskId t__tmp_v170 = down_tids_inline156[17];
+                TaskId t__tmp_v170 = down_tids_inline156[17];
                 _submit_deps_buf_inline123[17] = t__tmp_v170;
-                PTO2TaskId t__tmp_v171 = down_tids_inline156[18];
+                TaskId t__tmp_v171 = down_tids_inline156[18];
                 _submit_deps_buf_inline123[18] = t__tmp_v171;
-                PTO2TaskId t__tmp_v172 = down_tids_inline156[19];
+                TaskId t__tmp_v172 = down_tids_inline156[19];
                 _submit_deps_buf_inline123[19] = t__tmp_v172;
-                PTO2TaskId t__tmp_v173 = down_tids_inline156[20];
+                TaskId t__tmp_v173 = down_tids_inline156[20];
                 _submit_deps_buf_inline123[20] = t__tmp_v173;
-                PTO2TaskId t__tmp_v174 = down_tids_inline156[21];
+                TaskId t__tmp_v174 = down_tids_inline156[21];
                 _submit_deps_buf_inline123[21] = t__tmp_v174;
-                PTO2TaskId t__tmp_v175 = down_tids_inline156[22];
+                TaskId t__tmp_v175 = down_tids_inline156[22];
                 _submit_deps_buf_inline123[22] = t__tmp_v175;
-                PTO2TaskId t__tmp_v176 = down_tids_inline156[23];
+                TaskId t__tmp_v176 = down_tids_inline156[23];
                 _submit_deps_buf_inline123[23] = t__tmp_v176;
-                PTO2TaskId t__tmp_v177 = down_tids_inline156[24];
+                TaskId t__tmp_v177 = down_tids_inline156[24];
                 _submit_deps_buf_inline123[24] = t__tmp_v177;
-                PTO2TaskId t__tmp_v178 = down_tids_inline156[25];
+                TaskId t__tmp_v178 = down_tids_inline156[25];
                 _submit_deps_buf_inline123[25] = t__tmp_v178;
-                PTO2TaskId t__tmp_v179 = down_tids_inline156[26];
+                TaskId t__tmp_v179 = down_tids_inline156[26];
                 _submit_deps_buf_inline123[26] = t__tmp_v179;
-                PTO2TaskId t__tmp_v180 = down_tids_inline156[27];
+                TaskId t__tmp_v180 = down_tids_inline156[27];
                 _submit_deps_buf_inline123[27] = t__tmp_v180;
-                PTO2TaskId t__tmp_v181 = down_tids_inline156[28];
+                TaskId t__tmp_v181 = down_tids_inline156[28];
                 _submit_deps_buf_inline123[28] = t__tmp_v181;
-                PTO2TaskId t__tmp_v182 = down_tids_inline156[29];
+                TaskId t__tmp_v182 = down_tids_inline156[29];
                 _submit_deps_buf_inline123[29] = t__tmp_v182;
-                PTO2TaskId t__tmp_v183 = down_tids_inline156[30];
+                TaskId t__tmp_v183 = down_tids_inline156[30];
                 _submit_deps_buf_inline123[30] = t__tmp_v183;
-                PTO2TaskId t__tmp_v184 = down_tids_inline156[31];
+                TaskId t__tmp_v184 = down_tids_inline156[31];
                 _submit_deps_buf_inline123[31] = t__tmp_v184;
-                PTO2TaskId t__tmp_v185 = down_tids_inline156[32];
+                TaskId t__tmp_v185 = down_tids_inline156[32];
                 _submit_deps_buf_inline123[32] = t__tmp_v185;
-                PTO2TaskId t__tmp_v186 = down_tids_inline156[33];
+                TaskId t__tmp_v186 = down_tids_inline156[33];
                 _submit_deps_buf_inline123[33] = t__tmp_v186;
-                PTO2TaskId t__tmp_v187 = down_tids_inline156[34];
+                TaskId t__tmp_v187 = down_tids_inline156[34];
                 _submit_deps_buf_inline123[34] = t__tmp_v187;
-                PTO2TaskId t__tmp_v188 = down_tids_inline156[35];
+                TaskId t__tmp_v188 = down_tids_inline156[35];
                 _submit_deps_buf_inline123[35] = t__tmp_v188;
-                PTO2TaskId t__tmp_v189 = down_tids_inline156[36];
+                TaskId t__tmp_v189 = down_tids_inline156[36];
                 _submit_deps_buf_inline123[36] = t__tmp_v189;
-                PTO2TaskId t__tmp_v190 = down_tids_inline156[37];
+                TaskId t__tmp_v190 = down_tids_inline156[37];
                 _submit_deps_buf_inline123[37] = t__tmp_v190;
-                PTO2TaskId t__tmp_v191 = down_tids_inline156[38];
+                TaskId t__tmp_v191 = down_tids_inline156[38];
                 _submit_deps_buf_inline123[38] = t__tmp_v191;
-                PTO2TaskId t__tmp_v192 = down_tids_inline156[39];
+                TaskId t__tmp_v192 = down_tids_inline156[39];
                 _submit_deps_buf_inline123[39] = t__tmp_v192;
-                PTO2TaskId t__tmp_v193 = down_tids_inline156[40];
+                TaskId t__tmp_v193 = down_tids_inline156[40];
                 _submit_deps_buf_inline123[40] = t__tmp_v193;
-                PTO2TaskId t__tmp_v194 = down_tids_inline156[41];
+                TaskId t__tmp_v194 = down_tids_inline156[41];
                 _submit_deps_buf_inline123[41] = t__tmp_v194;
-                PTO2TaskId t__tmp_v195 = down_tids_inline156[42];
+                TaskId t__tmp_v195 = down_tids_inline156[42];
                 _submit_deps_buf_inline123[42] = t__tmp_v195;
-                PTO2TaskId t__tmp_v196 = down_tids_inline156[43];
+                TaskId t__tmp_v196 = down_tids_inline156[43];
                 _submit_deps_buf_inline123[43] = t__tmp_v196;
-                PTO2TaskId t__tmp_v197 = down_tids_inline156[44];
+                TaskId t__tmp_v197 = down_tids_inline156[44];
                 _submit_deps_buf_inline123[44] = t__tmp_v197;
-                PTO2TaskId t__tmp_v198 = down_tids_inline156[45];
+                TaskId t__tmp_v198 = down_tids_inline156[45];
                 _submit_deps_buf_inline123[45] = t__tmp_v198;
-                PTO2TaskId t__tmp_v199 = down_tids_inline156[46];
+                TaskId t__tmp_v199 = down_tids_inline156[46];
                 _submit_deps_buf_inline123[46] = t__tmp_v199;
-                PTO2TaskId t__tmp_v200 = down_tids_inline156[47];
+                TaskId t__tmp_v200 = down_tids_inline156[47];
                 _submit_deps_buf_inline123[47] = t__tmp_v200;
-                PTO2TaskId t__tmp_v201 = down_tids_inline156[48];
+                TaskId t__tmp_v201 = down_tids_inline156[48];
                 _submit_deps_buf_inline123[48] = t__tmp_v201;
-                PTO2TaskId t__tmp_v202 = down_tids_inline156[49];
+                TaskId t__tmp_v202 = down_tids_inline156[49];
                 _submit_deps_buf_inline123[49] = t__tmp_v202;
-                PTO2TaskId t__tmp_v203 = down_tids_inline156[50];
+                TaskId t__tmp_v203 = down_tids_inline156[50];
                 _submit_deps_buf_inline123[50] = t__tmp_v203;
-                PTO2TaskId t__tmp_v204 = down_tids_inline156[51];
+                TaskId t__tmp_v204 = down_tids_inline156[51];
                 _submit_deps_buf_inline123[51] = t__tmp_v204;
-                PTO2TaskId t__tmp_v205 = down_tids_inline156[52];
+                TaskId t__tmp_v205 = down_tids_inline156[52];
                 _submit_deps_buf_inline123[52] = t__tmp_v205;
-                PTO2TaskId t__tmp_v206 = down_tids_inline156[53];
+                TaskId t__tmp_v206 = down_tids_inline156[53];
                 _submit_deps_buf_inline123[53] = t__tmp_v206;
-                PTO2TaskId t__tmp_v207 = down_tids_inline156[54];
+                TaskId t__tmp_v207 = down_tids_inline156[54];
                 _submit_deps_buf_inline123[54] = t__tmp_v207;
-                PTO2TaskId t__tmp_v208 = down_tids_inline156[55];
+                TaskId t__tmp_v208 = down_tids_inline156[55];
                 _submit_deps_buf_inline123[55] = t__tmp_v208;
-                PTO2TaskId t__tmp_v209 = down_tids_inline156[56];
+                TaskId t__tmp_v209 = down_tids_inline156[56];
                 _submit_deps_buf_inline123[56] = t__tmp_v209;
-                PTO2TaskId t__tmp_v210 = down_tids_inline156[57];
+                TaskId t__tmp_v210 = down_tids_inline156[57];
                 _submit_deps_buf_inline123[57] = t__tmp_v210;
-                PTO2TaskId t__tmp_v211 = down_tids_inline156[58];
+                TaskId t__tmp_v211 = down_tids_inline156[58];
                 _submit_deps_buf_inline123[58] = t__tmp_v211;
-                PTO2TaskId t__tmp_v212 = down_tids_inline156[59];
+                TaskId t__tmp_v212 = down_tids_inline156[59];
                 _submit_deps_buf_inline123[59] = t__tmp_v212;
-                PTO2TaskId t__tmp_v213 = down_tids_inline156[60];
+                TaskId t__tmp_v213 = down_tids_inline156[60];
                 _submit_deps_buf_inline123[60] = t__tmp_v213;
-                PTO2TaskId t__tmp_v214 = down_tids_inline156[61];
+                TaskId t__tmp_v214 = down_tids_inline156[61];
                 _submit_deps_buf_inline123[61] = t__tmp_v214;
-                PTO2TaskId t__tmp_v215 = down_tids_inline156[62];
+                TaskId t__tmp_v215 = down_tids_inline156[62];
                 _submit_deps_buf_inline123[62] = t__tmp_v215;
-                PTO2TaskId t__tmp_v216 = down_tids_inline156[63];
+                TaskId t__tmp_v216 = down_tids_inline156[63];
                 _submit_deps_buf_inline123[63] = t__tmp_v216;
-                PTO2TaskId t__tmp_v217 = down_tids_inline156[64];
+                TaskId t__tmp_v217 = down_tids_inline156[64];
                 _submit_deps_buf_inline123[64] = t__tmp_v217;
-                PTO2TaskId t__tmp_v218 = down_tids_inline156[65];
+                TaskId t__tmp_v218 = down_tids_inline156[65];
                 _submit_deps_buf_inline123[65] = t__tmp_v218;
-                PTO2TaskId t__tmp_v219 = down_tids_inline156[66];
+                TaskId t__tmp_v219 = down_tids_inline156[66];
                 _submit_deps_buf_inline123[66] = t__tmp_v219;
-                PTO2TaskId t__tmp_v220 = down_tids_inline156[67];
+                TaskId t__tmp_v220 = down_tids_inline156[67];
                 _submit_deps_buf_inline123[67] = t__tmp_v220;
-                PTO2TaskId t__tmp_v221 = down_tids_inline156[68];
+                TaskId t__tmp_v221 = down_tids_inline156[68];
                 _submit_deps_buf_inline123[68] = t__tmp_v221;
-                PTO2TaskId t__tmp_v222 = down_tids_inline156[69];
+                TaskId t__tmp_v222 = down_tids_inline156[69];
                 _submit_deps_buf_inline123[69] = t__tmp_v222;
-                PTO2TaskId t__tmp_v223 = down_tids_inline156[70];
+                TaskId t__tmp_v223 = down_tids_inline156[70];
                 _submit_deps_buf_inline123[70] = t__tmp_v223;
-                PTO2TaskId t__tmp_v224 = down_tids_inline156[71];
+                TaskId t__tmp_v224 = down_tids_inline156[71];
                 _submit_deps_buf_inline123[71] = t__tmp_v224;
-                PTO2TaskId t__tmp_v225 = down_tids_inline156[72];
+                TaskId t__tmp_v225 = down_tids_inline156[72];
                 _submit_deps_buf_inline123[72] = t__tmp_v225;
-                PTO2TaskId t__tmp_v226 = down_tids_inline156[73];
+                TaskId t__tmp_v226 = down_tids_inline156[73];
                 _submit_deps_buf_inline123[73] = t__tmp_v226;
-                PTO2TaskId t__tmp_v227 = down_tids_inline156[74];
+                TaskId t__tmp_v227 = down_tids_inline156[74];
                 _submit_deps_buf_inline123[74] = t__tmp_v227;
-                PTO2TaskId t__tmp_v228 = down_tids_inline156[75];
+                TaskId t__tmp_v228 = down_tids_inline156[75];
                 _submit_deps_buf_inline123[75] = t__tmp_v228;
-                PTO2TaskId t__tmp_v229 = down_tids_inline156[76];
+                TaskId t__tmp_v229 = down_tids_inline156[76];
                 _submit_deps_buf_inline123[76] = t__tmp_v229;
-                PTO2TaskId t__tmp_v230 = down_tids_inline156[77];
+                TaskId t__tmp_v230 = down_tids_inline156[77];
                 _submit_deps_buf_inline123[77] = t__tmp_v230;
-                PTO2TaskId t__tmp_v231 = down_tids_inline156[78];
+                TaskId t__tmp_v231 = down_tids_inline156[78];
                 _submit_deps_buf_inline123[78] = t__tmp_v231;
-                PTO2TaskId t__tmp_v232 = down_tids_inline156[79];
+                TaskId t__tmp_v232 = down_tids_inline156[79];
                 _submit_deps_buf_inline123[79] = t__tmp_v232;
-                PTO2TaskId t__tmp_v233 = down_tids_inline156[80];
+                TaskId t__tmp_v233 = down_tids_inline156[80];
                 _submit_deps_buf_inline123[80] = t__tmp_v233;
-                PTO2TaskId t__tmp_v234 = down_tids_inline156[81];
+                TaskId t__tmp_v234 = down_tids_inline156[81];
                 _submit_deps_buf_inline123[81] = t__tmp_v234;
-                PTO2TaskId t__tmp_v235 = down_tids_inline156[82];
+                TaskId t__tmp_v235 = down_tids_inline156[82];
                 _submit_deps_buf_inline123[82] = t__tmp_v235;
-                PTO2TaskId t__tmp_v236 = down_tids_inline156[83];
+                TaskId t__tmp_v236 = down_tids_inline156[83];
                 _submit_deps_buf_inline123[83] = t__tmp_v236;
-                PTO2TaskId t__tmp_v237 = down_tids_inline156[84];
+                TaskId t__tmp_v237 = down_tids_inline156[84];
                 _submit_deps_buf_inline123[84] = t__tmp_v237;
 
                 // Spmd dcr_xgamma_spmd: dcr_xgamma
@@ -1782,7 +1782,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t34.add_scalar(next_gamma_idx);
                 params_t34.launch_spec.set_block_num(5);
                 params_t34.set_allow_early_resolve(true);
-                PTO2TaskId params_t34_deps[85];
+                TaskId params_t34_deps[85];
                 uint32_t params_t34_deps_count = 0;
                 if (_submit_deps_buf_inline123[0].is_valid())
                     params_t34_deps[params_t34_deps_count++] = _submit_deps_buf_inline123[0];
@@ -1956,7 +1956,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t34_deps[params_t34_deps_count++] = _submit_deps_buf_inline123[84];
                 params_t34.set_dependencies(params_t34_deps, params_t34_deps_count);
                 TaskOutputTensors task_34_outs = rt_submit_aiv_task(35, params_t34);
-                PTO2TaskId dcr_tid_inline58 = task_34_outs.task_id();
+                TaskId dcr_tid_inline58 = task_34_outs.task_id();
                 prev_out_tid[0] = dcr_tid_inline58;
                 prev_normed_tid[0] = dcr_tid_inline58;
                 ChipTensor cur__ssa_v8 = next_hidden;

--- a/examples/a5/host_build_graph/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
+++ b/examples/a5/host_build_graph/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
@@ -124,16 +124,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t0.launch_spec.set_block_num(1);
         params_t0.set_allow_early_resolve(true);
         TaskOutputTensors task_0_outs = rt_submit_aiv_task(0, params_t0);
-        PTO2TaskId tiling_tid_inline0 = task_0_outs.task_id();
-        PTO2TaskId pa_tiling_tid = tiling_tid_inline0;
-        PTO2TaskId prev_out_tid[1];
+        TaskId tiling_tid_inline0 = task_0_outs.task_id();
+        TaskId pa_tiling_tid = tiling_tid_inline0;
+        TaskId prev_out_tid[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-            prev_out_tid[__init_i] = PTO2TaskId::invalid();
+            prev_out_tid[__init_i] = TaskId::invalid();
 
         // Phase-fence barrier 0: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_0;
         TaskOutputTensors phase_fence_barrier_0_outs = rt_submit_dummy_task(params_phase_fence_barrier_0);
-        PTO2TaskId t = phase_fence_barrier_0_outs.task_id();
+        TaskId t = phase_fence_barrier_0_outs.task_id();
         prev_out_tid[0] = t;
         for (int64_t cb0 = 0; cb0 < 16; cb0 += 16) {
             PTO2_SCOPE() {
@@ -143,18 +143,18 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t1.add_input(ext_hidden_states);
                 params_t1.add_scalar(cb0);
                 TaskOutputTensors task_1_outs = rt_submit_aiv_task(1, params_t1);
-                PTO2TaskId ch_tid = task_1_outs.task_id();
+                TaskId ch_tid = task_1_outs.task_id();
                 prev_out_tid[0] = ch_tid;
             }
         }
-        PTO2TaskId prev_normed_tid[1];
+        TaskId prev_normed_tid[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-            prev_normed_tid[__init_i] = PTO2TaskId::invalid();
+            prev_normed_tid[__init_i] = TaskId::invalid();
         PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
-            PTO2TaskId _submit_deps_buf[1];
+            TaskId _submit_deps_buf[1];
             for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                _submit_deps_buf[__init_i] = PTO2TaskId::invalid();
-            PTO2TaskId t__tmp_v3 = prev_out_tid[0];
+                _submit_deps_buf[__init_i] = TaskId::invalid();
+            TaskId t__tmp_v3 = prev_out_tid[0];
             _submit_deps_buf[0] = t__tmp_v3;
 
             // Spmd x_gamma0_spmd: x_gamma0
@@ -164,12 +164,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t2.add_input(ext_input_rms_weight);
             params_t2.launch_spec.set_block_num(5);
             params_t2.set_allow_early_resolve(true);
-            PTO2TaskId params_t2_deps[1];
+            TaskId params_t2_deps[1];
             uint32_t params_t2_deps_count = 0;
             if (_submit_deps_buf[0].is_valid()) params_t2_deps[params_t2_deps_count++] = _submit_deps_buf[0];
             params_t2.set_dependencies(params_t2_deps, params_t2_deps_count);
             TaskOutputTensors task_2_outs = rt_submit_aiv_task(2, params_t2);
-            PTO2TaskId xgamma_tid = task_2_outs.task_id();
+            TaskId xgamma_tid = task_2_outs.task_id();
             prev_normed_tid[0] = xgamma_tid;
         }
         ChipTensor cur__rv_v7 = cur;
@@ -281,7 +281,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     constexpr int64_t layer_hidden_base_inline151 = 0;
                     constexpr int64_t layer_inter_base_inline107 = 0;
                     constexpr int64_t layer_cache_base_inline193 = 0;
-                    PTO2TaskId prev_normed_tid[1] = {normed__rv_v5.owner_task_id};
+                    TaskId prev_normed_tid[1] = {normed__rv_v5.owner_task_id};
 
                     uint32_t inv_rms_states_inline176_ci_shapes[2] = {16, 1};
                     TensorCreateInfo inv_rms_states_inline176_ci(
@@ -333,19 +333,19 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     ChipTensor inv_rms_tile_inline126 = fp32_arena.allocate(inv_rms_tile_inline126_ci);
                     ChipTensor mlp_tile_inline149 = bf16_arena.allocate(mlp_tile_inline149_ci);
 
-                    PTO2TaskId down_tids_inline156[85];
+                    TaskId down_tids_inline156[85];
                     for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
-                        down_tids_inline156[__init_i] = PTO2TaskId::invalid();
+                        down_tids_inline156[__init_i] = TaskId::invalid();
                     PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
                         // Phase-fence barrier 1: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_1;
                         TaskOutputTensors phase_fence_barrier_1_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_1);
-                        PTO2TaskId seed_dummy_inline49 = phase_fence_barrier_1_outs.task_id();
-                        PTO2TaskId prev_normed_seed_deps_inline120[2];
+                        TaskId seed_dummy_inline49 = phase_fence_barrier_1_outs.task_id();
+                        TaskId prev_normed_seed_deps_inline120[2];
                         for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                            prev_normed_seed_deps_inline120[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v7 = prev_normed_tid[0];
+                            prev_normed_seed_deps_inline120[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v7 = prev_normed_tid[0];
                         prev_normed_seed_deps_inline120[0] = t__tmp_v7;
                         prev_normed_seed_deps_inline120[1] = seed_dummy_inline49;
 
@@ -354,20 +354,20 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t3.add_input(attn_out_inline282);
                         params_t3.set_allow_early_resolve(true);
                         TaskOutputTensors task_3_outs = rt_submit_aiv_task(3, params_t3);
-                        PTO2TaskId attn_out_seed_tid_inline116 = task_3_outs.task_id();
-                        PTO2TaskId _submit_deps_buf_inline42[2];
+                        TaskId attn_out_seed_tid_inline116 = task_3_outs.task_id();
+                        TaskId _submit_deps_buf_inline42[2];
                         for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                            _submit_deps_buf_inline42[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v8 = prev_normed_seed_deps_inline120[0];
+                            _submit_deps_buf_inline42[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v8 = prev_normed_seed_deps_inline120[0];
                         _submit_deps_buf_inline42[0] = t__tmp_v8;
-                        PTO2TaskId t__tmp_v9 = prev_normed_seed_deps_inline120[1];
+                        TaskId t__tmp_v9 = prev_normed_seed_deps_inline120[1];
                         _submit_deps_buf_inline42[1] = t__tmp_v9;
 
                         // Task 4: rms_recip
                         CoreTaskArgs params_t4;
                         params_t4.add_input(cur__rv_v7);
                         params_t4.add_inout(inv_rms_states_inline176);
-                        PTO2TaskId params_t4_deps[2];
+                        TaskId params_t4_deps[2];
                         uint32_t params_t4_deps_count = 0;
                         if (_submit_deps_buf_inline42[0].is_valid())
                             params_t4_deps[params_t4_deps_count++] = _submit_deps_buf_inline42[0];
@@ -376,26 +376,26 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t4.set_dependencies(params_t4_deps, params_t4_deps_count);
                         params_t4.set_allow_early_resolve(true);
                         TaskOutputTensors task_4_outs = rt_submit_aiv_task(4, params_t4);
-                        PTO2TaskId rms_tid_inline148 = task_4_outs.task_id();
+                        TaskId rms_tid_inline148 = task_4_outs.task_id();
 
                         // Task 5: q_seed
                         CoreTaskArgs params_t5;
                         params_t5.add_inout(q_proj_inline139);
                         params_t5.set_allow_early_resolve(true);
                         TaskOutputTensors task_5_outs = rt_submit_aiv_task(5, params_t5);
-                        PTO2TaskId q_seed_tid_inline162 = task_5_outs.task_id();
-                        PTO2TaskId prev_normed_q_deps_inline105[2];
+                        TaskId q_seed_tid_inline162 = task_5_outs.task_id();
+                        TaskId prev_normed_q_deps_inline105[2];
                         for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                            prev_normed_q_deps_inline105[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v17 = prev_normed_tid[0];
+                            prev_normed_q_deps_inline105[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v17 = prev_normed_tid[0];
                         prev_normed_q_deps_inline105[0] = t__tmp_v17;
                         prev_normed_q_deps_inline105[1] = q_seed_tid_inline162;
-                        PTO2TaskId _submit_deps_buf_inline182[2];
+                        TaskId _submit_deps_buf_inline182[2];
                         for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                            _submit_deps_buf_inline182[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v18 = prev_normed_q_deps_inline105[0];
+                            _submit_deps_buf_inline182[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v18 = prev_normed_q_deps_inline105[0];
                         _submit_deps_buf_inline182[0] = t__tmp_v18;
-                        PTO2TaskId t__tmp_v19 = prev_normed_q_deps_inline105[1];
+                        TaskId t__tmp_v19 = prev_normed_q_deps_inline105[1];
                         _submit_deps_buf_inline182[1] = t__tmp_v19;
 
                         // Spmd q_proj_spmd: q_proj
@@ -406,7 +406,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t6.add_scalar(layer_hidden_base_inline151);
                         params_t6.launch_spec.set_block_num(50);
                         params_t6.set_allow_early_resolve(true);
-                        PTO2TaskId params_t6_deps[2];
+                        TaskId params_t6_deps[2];
                         uint32_t params_t6_deps_count = 0;
                         if (_submit_deps_buf_inline182[0].is_valid())
                             params_t6_deps[params_t6_deps_count++] = _submit_deps_buf_inline182[0];
@@ -414,20 +414,20 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t6_deps[params_t6_deps_count++] = _submit_deps_buf_inline182[1];
                         params_t6.set_dependencies(params_t6_deps, params_t6_deps_count);
                         TaskOutputTensors task_6_outs = rt_submit_aic_task(6, params_t6);
-                        PTO2TaskId q_proj_tid_inline183 = task_6_outs.task_id();
-                        PTO2TaskId _submit_deps_buf_inline261[2];
+                        TaskId q_proj_tid_inline183 = task_6_outs.task_id();
+                        TaskId _submit_deps_buf_inline261[2];
                         for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                            _submit_deps_buf_inline261[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v24 = prev_normed_seed_deps_inline120[0];
+                            _submit_deps_buf_inline261[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v24 = prev_normed_seed_deps_inline120[0];
                         _submit_deps_buf_inline261[0] = t__tmp_v24;
-                        PTO2TaskId t__tmp_v25 = prev_normed_seed_deps_inline120[1];
+                        TaskId t__tmp_v25 = prev_normed_seed_deps_inline120[1];
                         _submit_deps_buf_inline261[1] = t__tmp_v25;
 
                         // Task 7: kv_seed
                         CoreTaskArgs params_t7;
                         params_t7.add_inout(k_proj_inline135);
                         params_t7.add_inout(v_proj_inline255);
-                        PTO2TaskId params_t7_deps[2];
+                        TaskId params_t7_deps[2];
                         uint32_t params_t7_deps_count = 0;
                         if (_submit_deps_buf_inline261[0].is_valid())
                             params_t7_deps[params_t7_deps_count++] = _submit_deps_buf_inline261[0];
@@ -435,13 +435,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t7_deps[params_t7_deps_count++] = _submit_deps_buf_inline261[1];
                         params_t7.set_dependencies(params_t7_deps, params_t7_deps_count);
                         TaskOutputTensors task_7_outs = rt_submit_aiv_task(7, params_t7);
-                        PTO2TaskId kv_seed_tid_inline238 = task_7_outs.task_id();
-                        PTO2TaskId _submit_deps_buf_inline267[2];
+                        TaskId kv_seed_tid_inline238 = task_7_outs.task_id();
+                        TaskId _submit_deps_buf_inline267[2];
                         for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                            _submit_deps_buf_inline267[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v28 = prev_normed_seed_deps_inline120[0];
+                            _submit_deps_buf_inline267[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v28 = prev_normed_seed_deps_inline120[0];
                         _submit_deps_buf_inline267[0] = t__tmp_v28;
-                        PTO2TaskId t__tmp_v29 = prev_normed_seed_deps_inline120[1];
+                        TaskId t__tmp_v29 = prev_normed_seed_deps_inline120[1];
                         _submit_deps_buf_inline267[1] = t__tmp_v29;
 
                         // Task 8: mlp_out_seed
@@ -450,7 +450,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t8.add_inout(gate_acc_all_inline203);
                         params_t8.add_inout(up_acc_all_inline303);
                         params_t8.add_inout(attn_proj_fp32_inline220);
-                        PTO2TaskId params_t8_deps[2];
+                        TaskId params_t8_deps[2];
                         uint32_t params_t8_deps_count = 0;
                         if (_submit_deps_buf_inline267[0].is_valid())
                             params_t8_deps[params_t8_deps_count++] = _submit_deps_buf_inline267[0];
@@ -459,7 +459,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t8.set_dependencies(params_t8_deps, params_t8_deps_count);
                         params_t8.set_allow_early_resolve(true);
                         TaskOutputTensors task_8_outs = rt_submit_aiv_task(8, params_t8);
-                        PTO2TaskId mlp_out_seed_tid_inline206 = task_8_outs.task_id();
+                        TaskId mlp_out_seed_tid_inline206 = task_8_outs.task_id();
 
                         // Spmd k_proj_spmd: k_proj
                         CoreTaskArgs params_t9;
@@ -469,12 +469,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t9.add_scalar(layer_hidden_base_inline151);
                         params_t9.launch_spec.set_block_num(10);
                         params_t9.set_allow_early_resolve(true);
-                        PTO2TaskId params_t9_deps[1];
+                        TaskId params_t9_deps[1];
                         uint32_t params_t9_deps_count = 0;
                         params_t9_deps[params_t9_deps_count++] = kv_seed_tid_inline238;
                         params_t9.set_dependencies(params_t9_deps, params_t9_deps_count);
                         TaskOutputTensors task_9_outs = rt_submit_aic_task(9, params_t9);
-                        PTO2TaskId k_proj_tid_inline136 = task_9_outs.task_id();
+                        TaskId k_proj_tid_inline136 = task_9_outs.task_id();
 
                         // Spmd v_proj_spmd: v_proj
                         CoreTaskArgs params_t10;
@@ -484,12 +484,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t10.add_scalar(layer_hidden_base_inline151);
                         params_t10.launch_spec.set_block_num(10);
                         params_t10.set_allow_early_resolve(true);
-                        PTO2TaskId params_t10_deps[1];
+                        TaskId params_t10_deps[1];
                         uint32_t params_t10_deps_count = 0;
                         params_t10_deps[params_t10_deps_count++] = kv_seed_tid_inline238;
                         params_t10.set_dependencies(params_t10_deps, params_t10_deps_count);
                         TaskOutputTensors task_10_outs = rt_submit_aic_task(10, params_t10);
-                        PTO2TaskId v_proj_tid_inline63 = task_10_outs.task_id();
+                        TaskId v_proj_tid_inline63 = task_10_outs.task_id();
                         uint32_t q_tnd_inline191_shapes[3] = {16, 40, 128};
                         ChipTensor q_tnd_inline191 = q_tnd_flat_inline127.reshape(q_tnd_inline191_shapes, 3);
                         uint32_t attn_out_tnd_inline79_shapes[3] = {16, 40, 128};
@@ -520,7 +520,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t11.launch_spec.set_block_num(attention_core_num_inline188);
                         params_t11.launch_spec.set_require_sync_start(true);
                         params_t11.set_allow_early_resolve(true);
-                        PTO2TaskId params_t11_deps[7];
+                        TaskId params_t11_deps[7];
                         uint32_t params_t11_deps_count = 0;
                         params_t11_deps[params_t11_deps_count++] = q_proj_tid_inline183;
                         params_t11_deps[params_t11_deps_count++] = k_proj_tid_inline136;
@@ -531,42 +531,42 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t11.set_dependencies(params_t11_deps, params_t11_deps_count);
                         TaskOutputTensors task_11_outs = rt_submit_task(mixed_11, params_t11);
                         const ChipTensor &attn_out_tnd_inline79__ssa_v1 = attn_out_tnd_inline79;
-                        PTO2TaskId attn_done_tid_inline78 = task_11_outs.task_id();
+                        TaskId attn_done_tid_inline78 = task_11_outs.task_id();
                         uint32_t attn_out_inline282__ssa_v4_shapes[2] = {16, 5120};
                         ChipTensor attn_out_inline282__ssa_v4 =
                             attn_out_tnd_inline79__ssa_v1.reshape(attn_out_inline282__ssa_v4_shapes, 2);
-                        PTO2TaskId silu_tids_inline265[17];
+                        TaskId silu_tids_inline265[17];
                         for (int64_t __init_i = 0; __init_i < 17; ++__init_i)
-                            silu_tids_inline265[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId gate_tids_inline56[85];
+                            silu_tids_inline265[__init_i] = TaskId::invalid();
+                        TaskId gate_tids_inline56[85];
                         for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
-                            gate_tids_inline56[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId up_tids_inline310[85];
+                            gate_tids_inline56[__init_i] = TaskId::invalid();
+                        TaskId up_tids_inline310[85];
                         for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
-                            up_tids_inline310[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId cast_tids_inline88[5];
+                            up_tids_inline310[__init_i] = TaskId::invalid();
+                        TaskId cast_tids_inline88[5];
                         for (int64_t __init_i = 0; __init_i < 5; ++__init_i)
-                            cast_tids_inline88[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId gate_late_tids_inline249[5];
+                            cast_tids_inline88[__init_i] = TaskId::invalid();
+                        TaskId gate_late_tids_inline249[5];
                         for (int64_t __init_i = 0; __init_i < 5; ++__init_i)
-                            gate_late_tids_inline249[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId up_late_tids_inline69[5];
+                            gate_late_tids_inline249[__init_i] = TaskId::invalid();
+                        TaskId up_late_tids_inline69[5];
                         for (int64_t __init_i = 0; __init_i < 5; ++__init_i)
-                            up_late_tids_inline69[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId out_tids_inline271[50];
+                            up_late_tids_inline69[__init_i] = TaskId::invalid();
+                        TaskId out_tids_inline271[50];
                         for (int64_t __init_i = 0; __init_i < 50; ++__init_i)
-                            out_tids_inline271[__init_i] = PTO2TaskId::invalid();
+                            out_tids_inline271[__init_i] = TaskId::invalid();
 
                         // Phase-fence barrier 2: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_2;
-                        PTO2TaskId params_phase_fence_barrier_2_deps[1];
+                        TaskId params_phase_fence_barrier_2_deps[1];
                         uint32_t params_phase_fence_barrier_2_deps_count = 0;
                         params_phase_fence_barrier_2_deps[params_phase_fence_barrier_2_deps_count++] =
                             attn_done_tid_inline78;
                         params_phase_fence_barrier_2.set_dependencies(
                             params_phase_fence_barrier_2_deps, params_phase_fence_barrier_2_deps_count
                         );
-                        PTO2TaskId out_proj_dummy_inline257 = PTO2TaskId::invalid();
+                        TaskId out_proj_dummy_inline257 = TaskId::invalid();
                         if (params_phase_fence_barrier_2_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_2_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_2);
@@ -588,13 +588,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t12.add_scalar(k_op_inline266);
                             params_t12.add_scalar(layer_hidden_base_inline151);
                             params_t12.add_scalar(n_op_inline64);
-                            PTO2TaskId params_t12_deps[1];
+                            TaskId params_t12_deps[1];
                             uint32_t params_t12_deps_count = 0;
                             if (out_proj_dummy_inline257.is_valid())
                                 params_t12_deps[params_t12_deps_count++] = out_proj_dummy_inline257;
                             params_t12.set_dependencies(params_t12_deps, params_t12_deps_count);
                             TaskOutputTensors task_12_outs = rt_submit_aic_task(13, params_t12);
-                            PTO2TaskId out_tid_inline141 = task_12_outs.task_id();
+                            TaskId out_tid_inline141 = task_12_outs.task_id();
                             out_tids_inline271[out_idx_inline74] = out_tid_inline141;
                         }
 
@@ -606,12 +606,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t13.add_scalar(N_OUT_DIRECT_inline61);
                         params_t13.add_scalar(layer_hidden_base_inline151);
                         params_t13.launch_spec.set_block_num(24);
-                        PTO2TaskId params_t13_deps[1];
+                        TaskId params_t13_deps[1];
                         uint32_t params_t13_deps_count = 0;
                         params_t13_deps[params_t13_deps_count++] = attn_done_tid_inline78;
                         params_t13.set_dependencies(params_t13_deps, params_t13_deps_count);
                         TaskOutputTensors task_13_outs = rt_submit_aic_task(14, params_t13);
-                        PTO2TaskId out_proj_direct_tid_inline70 = task_13_outs.task_id();
+                        TaskId out_proj_direct_tid_inline70 = task_13_outs.task_id();
                         out_tids_inline271[N_OUT_DIRECT_inline61] = out_proj_direct_tid_inline70;
                         out_tids_inline271[(N_OUT_DIRECT_inline61 + 1)] = out_proj_direct_tid_inline70;
                         out_tids_inline271[(N_OUT_DIRECT_inline61 + 2)] = out_proj_direct_tid_inline70;
@@ -638,28 +638,28 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         out_tids_inline271[(N_OUT_DIRECT_inline61 + 23)] = out_proj_direct_tid_inline70;
                         int64_t k_base_inline111 = 0;
                         int64_t n_split_base_inline163 = 0;
-                        PTO2TaskId _submit_deps_buf_inline165[10];
+                        TaskId _submit_deps_buf_inline165[10];
                         for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                            _submit_deps_buf_inline165[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v39 = out_tids_inline271[(n_split_base_inline163 * 5)];
+                            _submit_deps_buf_inline165[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v39 = out_tids_inline271[(n_split_base_inline163 * 5)];
                         _submit_deps_buf_inline165[0] = t__tmp_v39;
-                        PTO2TaskId t__tmp_v40 = out_tids_inline271[((n_split_base_inline163 * 5) + 1)];
+                        TaskId t__tmp_v40 = out_tids_inline271[((n_split_base_inline163 * 5) + 1)];
                         _submit_deps_buf_inline165[1] = t__tmp_v40;
-                        PTO2TaskId t__tmp_v41 = out_tids_inline271[((n_split_base_inline163 * 5) + 2)];
+                        TaskId t__tmp_v41 = out_tids_inline271[((n_split_base_inline163 * 5) + 2)];
                         _submit_deps_buf_inline165[2] = t__tmp_v41;
-                        PTO2TaskId t__tmp_v42 = out_tids_inline271[((n_split_base_inline163 * 5) + 3)];
+                        TaskId t__tmp_v42 = out_tids_inline271[((n_split_base_inline163 * 5) + 3)];
                         _submit_deps_buf_inline165[3] = t__tmp_v42;
-                        PTO2TaskId t__tmp_v43 = out_tids_inline271[((n_split_base_inline163 * 5) + 4)];
+                        TaskId t__tmp_v43 = out_tids_inline271[((n_split_base_inline163 * 5) + 4)];
                         _submit_deps_buf_inline165[4] = t__tmp_v43;
-                        PTO2TaskId t__tmp_v44 = out_tids_inline271[((n_split_base_inline163 * 5) + 5)];
+                        TaskId t__tmp_v44 = out_tids_inline271[((n_split_base_inline163 * 5) + 5)];
                         _submit_deps_buf_inline165[5] = t__tmp_v44;
-                        PTO2TaskId t__tmp_v45 = out_tids_inline271[((n_split_base_inline163 * 5) + 6)];
+                        TaskId t__tmp_v45 = out_tids_inline271[((n_split_base_inline163 * 5) + 6)];
                         _submit_deps_buf_inline165[6] = t__tmp_v45;
-                        PTO2TaskId t__tmp_v46 = out_tids_inline271[((n_split_base_inline163 * 5) + 7)];
+                        TaskId t__tmp_v46 = out_tids_inline271[((n_split_base_inline163 * 5) + 7)];
                         _submit_deps_buf_inline165[7] = t__tmp_v46;
-                        PTO2TaskId t__tmp_v47 = out_tids_inline271[((n_split_base_inline163 * 5) + 8)];
+                        TaskId t__tmp_v47 = out_tids_inline271[((n_split_base_inline163 * 5) + 8)];
                         _submit_deps_buf_inline165[8] = t__tmp_v47;
-                        PTO2TaskId t__tmp_v48 = out_tids_inline271[((n_split_base_inline163 * 5) + 9)];
+                        TaskId t__tmp_v48 = out_tids_inline271[((n_split_base_inline163 * 5) + 9)];
                         _submit_deps_buf_inline165[9] = t__tmp_v48;
 
                         // Task 14: residual_rms_cast
@@ -671,7 +671,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t14.add_input(ext_post_rms_weight);
                         params_t14.add_scalar(k_base_inline111);
                         params_t14.add_scalar(i);
-                        PTO2TaskId params_t14_deps[10];
+                        TaskId params_t14_deps[10];
                         uint32_t params_t14_deps_count = 0;
                         if (_submit_deps_buf_inline165[0].is_valid())
                             params_t14_deps[params_t14_deps_count++] = _submit_deps_buf_inline165[0];
@@ -696,32 +696,32 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t14.set_dependencies(params_t14_deps, params_t14_deps_count);
                         params_t14.set_allow_early_resolve(true);
                         TaskOutputTensors task_14_outs = rt_submit_aiv_task(15, params_t14);
-                        PTO2TaskId cast_tid_k_inline76 = task_14_outs.task_id();
+                        TaskId cast_tid_k_inline76 = task_14_outs.task_id();
                         cast_tids_inline88[0] = cast_tid_k_inline76;
                         int64_t k_base_inline111__ssa_v1 = 1024;
                         int64_t n_split_base_inline163__ssa_v1 = 2;
-                        PTO2TaskId _submit_deps_buf_inline165__ssa_v1[10];
+                        TaskId _submit_deps_buf_inline165__ssa_v1[10];
                         for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                            _submit_deps_buf_inline165__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v51 = out_tids_inline271[(n_split_base_inline163__ssa_v1 * 5)];
+                            _submit_deps_buf_inline165__ssa_v1[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v51 = out_tids_inline271[(n_split_base_inline163__ssa_v1 * 5)];
                         _submit_deps_buf_inline165__ssa_v1[0] = t__tmp_v51;
-                        PTO2TaskId t__tmp_v52 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 1)];
+                        TaskId t__tmp_v52 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 1)];
                         _submit_deps_buf_inline165__ssa_v1[1] = t__tmp_v52;
-                        PTO2TaskId t__tmp_v53 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 2)];
+                        TaskId t__tmp_v53 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 2)];
                         _submit_deps_buf_inline165__ssa_v1[2] = t__tmp_v53;
-                        PTO2TaskId t__tmp_v54 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 3)];
+                        TaskId t__tmp_v54 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 3)];
                         _submit_deps_buf_inline165__ssa_v1[3] = t__tmp_v54;
-                        PTO2TaskId t__tmp_v55 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 4)];
+                        TaskId t__tmp_v55 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 4)];
                         _submit_deps_buf_inline165__ssa_v1[4] = t__tmp_v55;
-                        PTO2TaskId t__tmp_v56 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 5)];
+                        TaskId t__tmp_v56 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 5)];
                         _submit_deps_buf_inline165__ssa_v1[5] = t__tmp_v56;
-                        PTO2TaskId t__tmp_v57 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 6)];
+                        TaskId t__tmp_v57 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 6)];
                         _submit_deps_buf_inline165__ssa_v1[6] = t__tmp_v57;
-                        PTO2TaskId t__tmp_v58 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 7)];
+                        TaskId t__tmp_v58 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 7)];
                         _submit_deps_buf_inline165__ssa_v1[7] = t__tmp_v58;
-                        PTO2TaskId t__tmp_v59 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 8)];
+                        TaskId t__tmp_v59 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 8)];
                         _submit_deps_buf_inline165__ssa_v1[8] = t__tmp_v59;
-                        PTO2TaskId t__tmp_v60 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 9)];
+                        TaskId t__tmp_v60 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 9)];
                         _submit_deps_buf_inline165__ssa_v1[9] = t__tmp_v60;
 
                         // Task 15: residual_rms_cast_0
@@ -733,7 +733,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t15.add_input(ext_post_rms_weight);
                         params_t15.add_scalar(k_base_inline111__ssa_v1);
                         params_t15.add_scalar(i);
-                        PTO2TaskId params_t15_deps[10];
+                        TaskId params_t15_deps[10];
                         uint32_t params_t15_deps_count = 0;
                         if (_submit_deps_buf_inline165__ssa_v1[0].is_valid())
                             params_t15_deps[params_t15_deps_count++] = _submit_deps_buf_inline165__ssa_v1[0];
@@ -758,32 +758,32 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t15.set_dependencies(params_t15_deps, params_t15_deps_count);
                         params_t15.set_allow_early_resolve(true);
                         TaskOutputTensors task_15_outs = rt_submit_aiv_task(16, params_t15);
-                        PTO2TaskId cast_tid_k_inline76__ssa_v1 = task_15_outs.task_id();
+                        TaskId cast_tid_k_inline76__ssa_v1 = task_15_outs.task_id();
                         cast_tids_inline88[1] = cast_tid_k_inline76__ssa_v1;
                         int64_t k_base_inline111__ssa_v2 = 2048;
                         int64_t n_split_base_inline163__ssa_v2 = 4;
-                        PTO2TaskId _submit_deps_buf_inline165__ssa_v2[10];
+                        TaskId _submit_deps_buf_inline165__ssa_v2[10];
                         for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                            _submit_deps_buf_inline165__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v63 = out_tids_inline271[(n_split_base_inline163__ssa_v2 * 5)];
+                            _submit_deps_buf_inline165__ssa_v2[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v63 = out_tids_inline271[(n_split_base_inline163__ssa_v2 * 5)];
                         _submit_deps_buf_inline165__ssa_v2[0] = t__tmp_v63;
-                        PTO2TaskId t__tmp_v64 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 1)];
+                        TaskId t__tmp_v64 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 1)];
                         _submit_deps_buf_inline165__ssa_v2[1] = t__tmp_v64;
-                        PTO2TaskId t__tmp_v65 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 2)];
+                        TaskId t__tmp_v65 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 2)];
                         _submit_deps_buf_inline165__ssa_v2[2] = t__tmp_v65;
-                        PTO2TaskId t__tmp_v66 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 3)];
+                        TaskId t__tmp_v66 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 3)];
                         _submit_deps_buf_inline165__ssa_v2[3] = t__tmp_v66;
-                        PTO2TaskId t__tmp_v67 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 4)];
+                        TaskId t__tmp_v67 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 4)];
                         _submit_deps_buf_inline165__ssa_v2[4] = t__tmp_v67;
-                        PTO2TaskId t__tmp_v68 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 5)];
+                        TaskId t__tmp_v68 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 5)];
                         _submit_deps_buf_inline165__ssa_v2[5] = t__tmp_v68;
-                        PTO2TaskId t__tmp_v69 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 6)];
+                        TaskId t__tmp_v69 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 6)];
                         _submit_deps_buf_inline165__ssa_v2[6] = t__tmp_v69;
-                        PTO2TaskId t__tmp_v70 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 7)];
+                        TaskId t__tmp_v70 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 7)];
                         _submit_deps_buf_inline165__ssa_v2[7] = t__tmp_v70;
-                        PTO2TaskId t__tmp_v71 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 8)];
+                        TaskId t__tmp_v71 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 8)];
                         _submit_deps_buf_inline165__ssa_v2[8] = t__tmp_v71;
-                        PTO2TaskId t__tmp_v72 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 9)];
+                        TaskId t__tmp_v72 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 9)];
                         _submit_deps_buf_inline165__ssa_v2[9] = t__tmp_v72;
 
                         // Task 16: residual_rms_cast_1
@@ -795,7 +795,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t16.add_input(ext_post_rms_weight);
                         params_t16.add_scalar(k_base_inline111__ssa_v2);
                         params_t16.add_scalar(i);
-                        PTO2TaskId params_t16_deps[10];
+                        TaskId params_t16_deps[10];
                         uint32_t params_t16_deps_count = 0;
                         if (_submit_deps_buf_inline165__ssa_v2[0].is_valid())
                             params_t16_deps[params_t16_deps_count++] = _submit_deps_buf_inline165__ssa_v2[0];
@@ -820,32 +820,32 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t16.set_dependencies(params_t16_deps, params_t16_deps_count);
                         params_t16.set_allow_early_resolve(true);
                         TaskOutputTensors task_16_outs = rt_submit_aiv_task(17, params_t16);
-                        PTO2TaskId cast_tid_k_inline76__ssa_v2 = task_16_outs.task_id();
+                        TaskId cast_tid_k_inline76__ssa_v2 = task_16_outs.task_id();
                         cast_tids_inline88[2] = cast_tid_k_inline76__ssa_v2;
                         int64_t k_base_inline111__ssa_v3 = 3072;
                         int64_t n_split_base_inline163__ssa_v3 = 6;
-                        PTO2TaskId _submit_deps_buf_inline165__ssa_v3[10];
+                        TaskId _submit_deps_buf_inline165__ssa_v3[10];
                         for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                            _submit_deps_buf_inline165__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v75 = out_tids_inline271[(n_split_base_inline163__ssa_v3 * 5)];
+                            _submit_deps_buf_inline165__ssa_v3[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v75 = out_tids_inline271[(n_split_base_inline163__ssa_v3 * 5)];
                         _submit_deps_buf_inline165__ssa_v3[0] = t__tmp_v75;
-                        PTO2TaskId t__tmp_v76 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 1)];
+                        TaskId t__tmp_v76 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 1)];
                         _submit_deps_buf_inline165__ssa_v3[1] = t__tmp_v76;
-                        PTO2TaskId t__tmp_v77 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 2)];
+                        TaskId t__tmp_v77 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 2)];
                         _submit_deps_buf_inline165__ssa_v3[2] = t__tmp_v77;
-                        PTO2TaskId t__tmp_v78 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 3)];
+                        TaskId t__tmp_v78 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 3)];
                         _submit_deps_buf_inline165__ssa_v3[3] = t__tmp_v78;
-                        PTO2TaskId t__tmp_v79 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 4)];
+                        TaskId t__tmp_v79 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 4)];
                         _submit_deps_buf_inline165__ssa_v3[4] = t__tmp_v79;
-                        PTO2TaskId t__tmp_v80 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 5)];
+                        TaskId t__tmp_v80 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 5)];
                         _submit_deps_buf_inline165__ssa_v3[5] = t__tmp_v80;
-                        PTO2TaskId t__tmp_v81 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 6)];
+                        TaskId t__tmp_v81 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 6)];
                         _submit_deps_buf_inline165__ssa_v3[6] = t__tmp_v81;
-                        PTO2TaskId t__tmp_v82 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 7)];
+                        TaskId t__tmp_v82 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 7)];
                         _submit_deps_buf_inline165__ssa_v3[7] = t__tmp_v82;
-                        PTO2TaskId t__tmp_v83 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 8)];
+                        TaskId t__tmp_v83 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 8)];
                         _submit_deps_buf_inline165__ssa_v3[8] = t__tmp_v83;
-                        PTO2TaskId t__tmp_v84 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 9)];
+                        TaskId t__tmp_v84 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 9)];
                         _submit_deps_buf_inline165__ssa_v3[9] = t__tmp_v84;
 
                         // Task 17: residual_rms_cast_2
@@ -857,7 +857,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t17.add_input(ext_post_rms_weight);
                         params_t17.add_scalar(k_base_inline111__ssa_v3);
                         params_t17.add_scalar(i);
-                        PTO2TaskId params_t17_deps[10];
+                        TaskId params_t17_deps[10];
                         uint32_t params_t17_deps_count = 0;
                         if (_submit_deps_buf_inline165__ssa_v3[0].is_valid())
                             params_t17_deps[params_t17_deps_count++] = _submit_deps_buf_inline165__ssa_v3[0];
@@ -882,32 +882,32 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t17.set_dependencies(params_t17_deps, params_t17_deps_count);
                         params_t17.set_allow_early_resolve(true);
                         TaskOutputTensors task_17_outs = rt_submit_aiv_task(18, params_t17);
-                        PTO2TaskId cast_tid_k_inline76__ssa_v3 = task_17_outs.task_id();
+                        TaskId cast_tid_k_inline76__ssa_v3 = task_17_outs.task_id();
                         cast_tids_inline88[3] = cast_tid_k_inline76__ssa_v3;
                         int64_t k_base_inline111__ssa_v4 = 4096;
                         int64_t n_split_base_inline163__ssa_v4 = 8;
-                        PTO2TaskId _submit_deps_buf_inline165__ssa_v4[10];
+                        TaskId _submit_deps_buf_inline165__ssa_v4[10];
                         for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                            _submit_deps_buf_inline165__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v87 = out_tids_inline271[(n_split_base_inline163__ssa_v4 * 5)];
+                            _submit_deps_buf_inline165__ssa_v4[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v87 = out_tids_inline271[(n_split_base_inline163__ssa_v4 * 5)];
                         _submit_deps_buf_inline165__ssa_v4[0] = t__tmp_v87;
-                        PTO2TaskId t__tmp_v88 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 1)];
+                        TaskId t__tmp_v88 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 1)];
                         _submit_deps_buf_inline165__ssa_v4[1] = t__tmp_v88;
-                        PTO2TaskId t__tmp_v89 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 2)];
+                        TaskId t__tmp_v89 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 2)];
                         _submit_deps_buf_inline165__ssa_v4[2] = t__tmp_v89;
-                        PTO2TaskId t__tmp_v90 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 3)];
+                        TaskId t__tmp_v90 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 3)];
                         _submit_deps_buf_inline165__ssa_v4[3] = t__tmp_v90;
-                        PTO2TaskId t__tmp_v91 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 4)];
+                        TaskId t__tmp_v91 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 4)];
                         _submit_deps_buf_inline165__ssa_v4[4] = t__tmp_v91;
-                        PTO2TaskId t__tmp_v92 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 5)];
+                        TaskId t__tmp_v92 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 5)];
                         _submit_deps_buf_inline165__ssa_v4[5] = t__tmp_v92;
-                        PTO2TaskId t__tmp_v93 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 6)];
+                        TaskId t__tmp_v93 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 6)];
                         _submit_deps_buf_inline165__ssa_v4[6] = t__tmp_v93;
-                        PTO2TaskId t__tmp_v94 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 7)];
+                        TaskId t__tmp_v94 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 7)];
                         _submit_deps_buf_inline165__ssa_v4[7] = t__tmp_v94;
-                        PTO2TaskId t__tmp_v95 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 8)];
+                        TaskId t__tmp_v95 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 8)];
                         _submit_deps_buf_inline165__ssa_v4[8] = t__tmp_v95;
-                        PTO2TaskId t__tmp_v96 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 9)];
+                        TaskId t__tmp_v96 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 9)];
                         _submit_deps_buf_inline165__ssa_v4[9] = t__tmp_v96;
 
                         // Task 18: residual_rms_cast_3
@@ -919,7 +919,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t18.add_input(ext_post_rms_weight);
                         params_t18.add_scalar(k_base_inline111__ssa_v4);
                         params_t18.add_scalar(i);
-                        PTO2TaskId params_t18_deps[10];
+                        TaskId params_t18_deps[10];
                         uint32_t params_t18_deps_count = 0;
                         if (_submit_deps_buf_inline165__ssa_v4[0].is_valid())
                             params_t18_deps[params_t18_deps_count++] = _submit_deps_buf_inline165__ssa_v4[0];
@@ -944,7 +944,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t18.set_dependencies(params_t18_deps, params_t18_deps_count);
                         params_t18.set_allow_early_resolve(true);
                         TaskOutputTensors task_18_outs = rt_submit_aiv_task(19, params_t18);
-                        PTO2TaskId cast_tid_k_inline76__ssa_v4 = task_18_outs.task_id();
+                        TaskId cast_tid_k_inline76__ssa_v4 = task_18_outs.task_id();
                         cast_tids_inline88[4] = cast_tid_k_inline76__ssa_v4;
 
                         // Task 19: post_rms_reduce
@@ -952,7 +952,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t19.add_input(attn_proj_fp32_inline220);
                         params_t19.add_input(cur__rv_v7);
                         params_t19.add_inout(inv_rms_tile_inline126);
-                        PTO2TaskId params_t19_deps[50];
+                        TaskId params_t19_deps[50];
                         uint32_t params_t19_deps_count = 0;
                         if (out_tids_inline271[0].is_valid())
                             params_t19_deps[params_t19_deps_count++] = out_tids_inline271[0];
@@ -1056,17 +1056,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t19_deps[params_t19_deps_count++] = out_tids_inline271[49];
                         params_t19.set_dependencies(params_t19_deps, params_t19_deps_count);
                         TaskOutputTensors task_19_outs = rt_submit_aiv_task(20, params_t19);
-                        PTO2TaskId reduce_tid_inline226 = task_19_outs.task_id();
+                        TaskId reduce_tid_inline226 = task_19_outs.task_id();
                         int64_t gu_k0_inline131 = 0;
-                        PTO2TaskId _submit_deps_buf_inline236[1];
+                        TaskId _submit_deps_buf_inline236[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline236[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v105 = cast_tids_inline88[0];
+                            _submit_deps_buf_inline236[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v105 = cast_tids_inline88[0];
                         _submit_deps_buf_inline236[0] = t__tmp_v105;
 
                         // Phase-fence barrier 3: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_3;
-                        PTO2TaskId params_phase_fence_barrier_3_deps[1];
+                        TaskId params_phase_fence_barrier_3_deps[1];
                         uint32_t params_phase_fence_barrier_3_deps_count = 0;
                         if (_submit_deps_buf_inline236[0].is_valid())
                             params_phase_fence_barrier_3_deps[params_phase_fence_barrier_3_deps_count++] =
@@ -1074,22 +1074,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_3.set_dependencies(
                             params_phase_fence_barrier_3_deps, params_phase_fence_barrier_3_deps_count
                         );
-                        PTO2TaskId t__tmp_v106 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v106 = TaskId::invalid();
                         if (params_phase_fence_barrier_3_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_3_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_3);
                             t__tmp_v106 = phase_fence_barrier_3_outs.task_id();
                         }
                         gate_late_tids_inline249[0] = t__tmp_v106;
-                        PTO2TaskId _submit_deps_buf_inline225[1];
+                        TaskId _submit_deps_buf_inline225[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline225[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v107 = cast_tids_inline88[0];
+                            _submit_deps_buf_inline225[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v107 = cast_tids_inline88[0];
                         _submit_deps_buf_inline225[0] = t__tmp_v107;
 
                         // Phase-fence barrier 4: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_4;
-                        PTO2TaskId params_phase_fence_barrier_4_deps[1];
+                        TaskId params_phase_fence_barrier_4_deps[1];
                         uint32_t params_phase_fence_barrier_4_deps_count = 0;
                         if (_submit_deps_buf_inline225[0].is_valid())
                             params_phase_fence_barrier_4_deps[params_phase_fence_barrier_4_deps_count++] =
@@ -1097,17 +1097,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_4.set_dependencies(
                             params_phase_fence_barrier_4_deps, params_phase_fence_barrier_4_deps_count
                         );
-                        PTO2TaskId t__tmp_v108 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v108 = TaskId::invalid();
                         if (params_phase_fence_barrier_4_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_4_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_4);
                             t__tmp_v108 = phase_fence_barrier_4_outs.task_id();
                         }
                         up_late_tids_inline69[0] = t__tmp_v108;
-                        PTO2TaskId _submit_deps_buf_inline237[1];
+                        TaskId _submit_deps_buf_inline237[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline237[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v109 = cast_tids_inline88[0];
+                            _submit_deps_buf_inline237[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v109 = cast_tids_inline88[0];
                         _submit_deps_buf_inline237[0] = t__tmp_v109;
 
                         // Spmd gate_proj_spmd: gate_proj
@@ -1118,23 +1118,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t20.add_scalar(gu_k0_inline131);
                         params_t20.add_scalar(layer_hidden_base_inline151);
                         params_t20.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t20_deps[1];
+                        TaskId params_t20_deps[1];
                         uint32_t params_t20_deps_count = 0;
                         if (_submit_deps_buf_inline237[0].is_valid())
                             params_t20_deps[params_t20_deps_count++] = _submit_deps_buf_inline237[0];
                         params_t20.set_dependencies(params_t20_deps, params_t20_deps_count);
                         TaskOutputTensors task_20_outs = rt_submit_aic_task(21, params_t20);
-                        PTO2TaskId gate_spmd_tid_inline245 = task_20_outs.task_id();
+                        TaskId gate_spmd_tid_inline245 = task_20_outs.task_id();
                         gate_tids_inline56[0] = gate_spmd_tid_inline245;
                         gate_tids_inline56[5] = gate_spmd_tid_inline245;
                         gate_tids_inline56[10] = gate_spmd_tid_inline245;
                         gate_tids_inline56[15] = gate_spmd_tid_inline245;
                         gate_tids_inline56[20] = gate_spmd_tid_inline245;
                         gate_tids_inline56[25] = gate_spmd_tid_inline245;
-                        PTO2TaskId _submit_deps_buf_inline260[1];
+                        TaskId _submit_deps_buf_inline260[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline260[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v110 = cast_tids_inline88[0];
+                            _submit_deps_buf_inline260[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v110 = cast_tids_inline88[0];
                         _submit_deps_buf_inline260[0] = t__tmp_v110;
 
                         // Spmd up_proj_spmd: up_proj
@@ -1145,13 +1145,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t21.add_scalar(gu_k0_inline131);
                         params_t21.add_scalar(layer_hidden_base_inline151);
                         params_t21.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t21_deps[1];
+                        TaskId params_t21_deps[1];
                         uint32_t params_t21_deps_count = 0;
                         if (_submit_deps_buf_inline260[0].is_valid())
                             params_t21_deps[params_t21_deps_count++] = _submit_deps_buf_inline260[0];
                         params_t21.set_dependencies(params_t21_deps, params_t21_deps_count);
                         TaskOutputTensors task_21_outs = rt_submit_aic_task(22, params_t21);
-                        PTO2TaskId up_spmd_tid_inline264 = task_21_outs.task_id();
+                        TaskId up_spmd_tid_inline264 = task_21_outs.task_id();
                         up_tids_inline310[0] = up_spmd_tid_inline264;
                         up_tids_inline310[5] = up_spmd_tid_inline264;
                         up_tids_inline310[10] = up_spmd_tid_inline264;
@@ -1159,15 +1159,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         up_tids_inline310[20] = up_spmd_tid_inline264;
                         up_tids_inline310[25] = up_spmd_tid_inline264;
                         int64_t gu_k0_inline131__ssa_v1 = 1024;
-                        PTO2TaskId _submit_deps_buf_inline236__ssa_v1[1];
+                        TaskId _submit_deps_buf_inline236__ssa_v1[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline236__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v111 = cast_tids_inline88[1];
+                            _submit_deps_buf_inline236__ssa_v1[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v111 = cast_tids_inline88[1];
                         _submit_deps_buf_inline236__ssa_v1[0] = t__tmp_v111;
 
                         // Phase-fence barrier 5: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_5;
-                        PTO2TaskId params_phase_fence_barrier_5_deps[1];
+                        TaskId params_phase_fence_barrier_5_deps[1];
                         uint32_t params_phase_fence_barrier_5_deps_count = 0;
                         if (_submit_deps_buf_inline236__ssa_v1[0].is_valid())
                             params_phase_fence_barrier_5_deps[params_phase_fence_barrier_5_deps_count++] =
@@ -1175,22 +1175,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_5.set_dependencies(
                             params_phase_fence_barrier_5_deps, params_phase_fence_barrier_5_deps_count
                         );
-                        PTO2TaskId t__tmp_v112 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v112 = TaskId::invalid();
                         if (params_phase_fence_barrier_5_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_5_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_5);
                             t__tmp_v112 = phase_fence_barrier_5_outs.task_id();
                         }
                         gate_late_tids_inline249[1] = t__tmp_v112;
-                        PTO2TaskId _submit_deps_buf_inline225__ssa_v1[1];
+                        TaskId _submit_deps_buf_inline225__ssa_v1[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline225__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v113 = cast_tids_inline88[1];
+                            _submit_deps_buf_inline225__ssa_v1[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v113 = cast_tids_inline88[1];
                         _submit_deps_buf_inline225__ssa_v1[0] = t__tmp_v113;
 
                         // Phase-fence barrier 6: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_6;
-                        PTO2TaskId params_phase_fence_barrier_6_deps[1];
+                        TaskId params_phase_fence_barrier_6_deps[1];
                         uint32_t params_phase_fence_barrier_6_deps_count = 0;
                         if (_submit_deps_buf_inline225__ssa_v1[0].is_valid())
                             params_phase_fence_barrier_6_deps[params_phase_fence_barrier_6_deps_count++] =
@@ -1198,17 +1198,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_6.set_dependencies(
                             params_phase_fence_barrier_6_deps, params_phase_fence_barrier_6_deps_count
                         );
-                        PTO2TaskId t__tmp_v114 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v114 = TaskId::invalid();
                         if (params_phase_fence_barrier_6_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_6_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_6);
                             t__tmp_v114 = phase_fence_barrier_6_outs.task_id();
                         }
                         up_late_tids_inline69[1] = t__tmp_v114;
-                        PTO2TaskId _submit_deps_buf_inline237__ssa_v1[1];
+                        TaskId _submit_deps_buf_inline237__ssa_v1[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline237__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v115 = cast_tids_inline88[1];
+                            _submit_deps_buf_inline237__ssa_v1[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v115 = cast_tids_inline88[1];
                         _submit_deps_buf_inline237__ssa_v1[0] = t__tmp_v115;
 
                         // Spmd gate_proj_spmd_0: gate_proj_0
@@ -1219,23 +1219,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t22.add_scalar(gu_k0_inline131__ssa_v1);
                         params_t22.add_scalar(layer_hidden_base_inline151);
                         params_t22.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t22_deps[1];
+                        TaskId params_t22_deps[1];
                         uint32_t params_t22_deps_count = 0;
                         if (_submit_deps_buf_inline237__ssa_v1[0].is_valid())
                             params_t22_deps[params_t22_deps_count++] = _submit_deps_buf_inline237__ssa_v1[0];
                         params_t22.set_dependencies(params_t22_deps, params_t22_deps_count);
                         TaskOutputTensors task_22_outs = rt_submit_aic_task(23, params_t22);
-                        PTO2TaskId gate_spmd_tid_inline245__ssa_v1 = task_22_outs.task_id();
+                        TaskId gate_spmd_tid_inline245__ssa_v1 = task_22_outs.task_id();
                         gate_tids_inline56[1] = gate_spmd_tid_inline245__ssa_v1;
                         gate_tids_inline56[6] = gate_spmd_tid_inline245__ssa_v1;
                         gate_tids_inline56[11] = gate_spmd_tid_inline245__ssa_v1;
                         gate_tids_inline56[16] = gate_spmd_tid_inline245__ssa_v1;
                         gate_tids_inline56[21] = gate_spmd_tid_inline245__ssa_v1;
                         gate_tids_inline56[26] = gate_spmd_tid_inline245__ssa_v1;
-                        PTO2TaskId _submit_deps_buf_inline260__ssa_v1[1];
+                        TaskId _submit_deps_buf_inline260__ssa_v1[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline260__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v116 = cast_tids_inline88[1];
+                            _submit_deps_buf_inline260__ssa_v1[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v116 = cast_tids_inline88[1];
                         _submit_deps_buf_inline260__ssa_v1[0] = t__tmp_v116;
 
                         // Spmd up_proj_spmd_0: up_proj_0
@@ -1246,13 +1246,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t23.add_scalar(gu_k0_inline131__ssa_v1);
                         params_t23.add_scalar(layer_hidden_base_inline151);
                         params_t23.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t23_deps[1];
+                        TaskId params_t23_deps[1];
                         uint32_t params_t23_deps_count = 0;
                         if (_submit_deps_buf_inline260__ssa_v1[0].is_valid())
                             params_t23_deps[params_t23_deps_count++] = _submit_deps_buf_inline260__ssa_v1[0];
                         params_t23.set_dependencies(params_t23_deps, params_t23_deps_count);
                         TaskOutputTensors task_23_outs = rt_submit_aic_task(24, params_t23);
-                        PTO2TaskId up_spmd_tid_inline264__ssa_v1 = task_23_outs.task_id();
+                        TaskId up_spmd_tid_inline264__ssa_v1 = task_23_outs.task_id();
                         up_tids_inline310[1] = up_spmd_tid_inline264__ssa_v1;
                         up_tids_inline310[6] = up_spmd_tid_inline264__ssa_v1;
                         up_tids_inline310[11] = up_spmd_tid_inline264__ssa_v1;
@@ -1260,15 +1260,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         up_tids_inline310[21] = up_spmd_tid_inline264__ssa_v1;
                         up_tids_inline310[26] = up_spmd_tid_inline264__ssa_v1;
                         int64_t gu_k0_inline131__ssa_v2 = 2048;
-                        PTO2TaskId _submit_deps_buf_inline236__ssa_v2[1];
+                        TaskId _submit_deps_buf_inline236__ssa_v2[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline236__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v117 = cast_tids_inline88[2];
+                            _submit_deps_buf_inline236__ssa_v2[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v117 = cast_tids_inline88[2];
                         _submit_deps_buf_inline236__ssa_v2[0] = t__tmp_v117;
 
                         // Phase-fence barrier 7: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_7;
-                        PTO2TaskId params_phase_fence_barrier_7_deps[1];
+                        TaskId params_phase_fence_barrier_7_deps[1];
                         uint32_t params_phase_fence_barrier_7_deps_count = 0;
                         if (_submit_deps_buf_inline236__ssa_v2[0].is_valid())
                             params_phase_fence_barrier_7_deps[params_phase_fence_barrier_7_deps_count++] =
@@ -1276,22 +1276,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_7.set_dependencies(
                             params_phase_fence_barrier_7_deps, params_phase_fence_barrier_7_deps_count
                         );
-                        PTO2TaskId t__tmp_v118 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v118 = TaskId::invalid();
                         if (params_phase_fence_barrier_7_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_7_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_7);
                             t__tmp_v118 = phase_fence_barrier_7_outs.task_id();
                         }
                         gate_late_tids_inline249[2] = t__tmp_v118;
-                        PTO2TaskId _submit_deps_buf_inline225__ssa_v2[1];
+                        TaskId _submit_deps_buf_inline225__ssa_v2[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline225__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v119 = cast_tids_inline88[2];
+                            _submit_deps_buf_inline225__ssa_v2[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v119 = cast_tids_inline88[2];
                         _submit_deps_buf_inline225__ssa_v2[0] = t__tmp_v119;
 
                         // Phase-fence barrier 8: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_8;
-                        PTO2TaskId params_phase_fence_barrier_8_deps[1];
+                        TaskId params_phase_fence_barrier_8_deps[1];
                         uint32_t params_phase_fence_barrier_8_deps_count = 0;
                         if (_submit_deps_buf_inline225__ssa_v2[0].is_valid())
                             params_phase_fence_barrier_8_deps[params_phase_fence_barrier_8_deps_count++] =
@@ -1299,17 +1299,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_8.set_dependencies(
                             params_phase_fence_barrier_8_deps, params_phase_fence_barrier_8_deps_count
                         );
-                        PTO2TaskId t__tmp_v120 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v120 = TaskId::invalid();
                         if (params_phase_fence_barrier_8_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_8_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_8);
                             t__tmp_v120 = phase_fence_barrier_8_outs.task_id();
                         }
                         up_late_tids_inline69[2] = t__tmp_v120;
-                        PTO2TaskId _submit_deps_buf_inline237__ssa_v2[1];
+                        TaskId _submit_deps_buf_inline237__ssa_v2[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline237__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v121 = cast_tids_inline88[2];
+                            _submit_deps_buf_inline237__ssa_v2[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v121 = cast_tids_inline88[2];
                         _submit_deps_buf_inline237__ssa_v2[0] = t__tmp_v121;
 
                         // Spmd gate_proj_spmd_1: gate_proj_1
@@ -1320,23 +1320,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t24.add_scalar(gu_k0_inline131__ssa_v2);
                         params_t24.add_scalar(layer_hidden_base_inline151);
                         params_t24.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t24_deps[1];
+                        TaskId params_t24_deps[1];
                         uint32_t params_t24_deps_count = 0;
                         if (_submit_deps_buf_inline237__ssa_v2[0].is_valid())
                             params_t24_deps[params_t24_deps_count++] = _submit_deps_buf_inline237__ssa_v2[0];
                         params_t24.set_dependencies(params_t24_deps, params_t24_deps_count);
                         TaskOutputTensors task_24_outs = rt_submit_aic_task(25, params_t24);
-                        PTO2TaskId gate_spmd_tid_inline245__ssa_v2 = task_24_outs.task_id();
+                        TaskId gate_spmd_tid_inline245__ssa_v2 = task_24_outs.task_id();
                         gate_tids_inline56[2] = gate_spmd_tid_inline245__ssa_v2;
                         gate_tids_inline56[7] = gate_spmd_tid_inline245__ssa_v2;
                         gate_tids_inline56[12] = gate_spmd_tid_inline245__ssa_v2;
                         gate_tids_inline56[17] = gate_spmd_tid_inline245__ssa_v2;
                         gate_tids_inline56[22] = gate_spmd_tid_inline245__ssa_v2;
                         gate_tids_inline56[27] = gate_spmd_tid_inline245__ssa_v2;
-                        PTO2TaskId _submit_deps_buf_inline260__ssa_v2[1];
+                        TaskId _submit_deps_buf_inline260__ssa_v2[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline260__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v122 = cast_tids_inline88[2];
+                            _submit_deps_buf_inline260__ssa_v2[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v122 = cast_tids_inline88[2];
                         _submit_deps_buf_inline260__ssa_v2[0] = t__tmp_v122;
 
                         // Spmd up_proj_spmd_1: up_proj_1
@@ -1347,13 +1347,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t25.add_scalar(gu_k0_inline131__ssa_v2);
                         params_t25.add_scalar(layer_hidden_base_inline151);
                         params_t25.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t25_deps[1];
+                        TaskId params_t25_deps[1];
                         uint32_t params_t25_deps_count = 0;
                         if (_submit_deps_buf_inline260__ssa_v2[0].is_valid())
                             params_t25_deps[params_t25_deps_count++] = _submit_deps_buf_inline260__ssa_v2[0];
                         params_t25.set_dependencies(params_t25_deps, params_t25_deps_count);
                         TaskOutputTensors task_25_outs = rt_submit_aic_task(26, params_t25);
-                        PTO2TaskId up_spmd_tid_inline264__ssa_v2 = task_25_outs.task_id();
+                        TaskId up_spmd_tid_inline264__ssa_v2 = task_25_outs.task_id();
                         up_tids_inline310[2] = up_spmd_tid_inline264__ssa_v2;
                         up_tids_inline310[7] = up_spmd_tid_inline264__ssa_v2;
                         up_tids_inline310[12] = up_spmd_tid_inline264__ssa_v2;
@@ -1361,15 +1361,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         up_tids_inline310[22] = up_spmd_tid_inline264__ssa_v2;
                         up_tids_inline310[27] = up_spmd_tid_inline264__ssa_v2;
                         int64_t gu_k0_inline131__ssa_v3 = 3072;
-                        PTO2TaskId _submit_deps_buf_inline236__ssa_v3[1];
+                        TaskId _submit_deps_buf_inline236__ssa_v3[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline236__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v123 = cast_tids_inline88[3];
+                            _submit_deps_buf_inline236__ssa_v3[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v123 = cast_tids_inline88[3];
                         _submit_deps_buf_inline236__ssa_v3[0] = t__tmp_v123;
 
                         // Phase-fence barrier 9: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_9;
-                        PTO2TaskId params_phase_fence_barrier_9_deps[1];
+                        TaskId params_phase_fence_barrier_9_deps[1];
                         uint32_t params_phase_fence_barrier_9_deps_count = 0;
                         if (_submit_deps_buf_inline236__ssa_v3[0].is_valid())
                             params_phase_fence_barrier_9_deps[params_phase_fence_barrier_9_deps_count++] =
@@ -1377,22 +1377,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_9.set_dependencies(
                             params_phase_fence_barrier_9_deps, params_phase_fence_barrier_9_deps_count
                         );
-                        PTO2TaskId t__tmp_v124 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v124 = TaskId::invalid();
                         if (params_phase_fence_barrier_9_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_9_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_9);
                             t__tmp_v124 = phase_fence_barrier_9_outs.task_id();
                         }
                         gate_late_tids_inline249[3] = t__tmp_v124;
-                        PTO2TaskId _submit_deps_buf_inline225__ssa_v3[1];
+                        TaskId _submit_deps_buf_inline225__ssa_v3[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline225__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v125 = cast_tids_inline88[3];
+                            _submit_deps_buf_inline225__ssa_v3[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v125 = cast_tids_inline88[3];
                         _submit_deps_buf_inline225__ssa_v3[0] = t__tmp_v125;
 
                         // Phase-fence barrier 10: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_10;
-                        PTO2TaskId params_phase_fence_barrier_10_deps[1];
+                        TaskId params_phase_fence_barrier_10_deps[1];
                         uint32_t params_phase_fence_barrier_10_deps_count = 0;
                         if (_submit_deps_buf_inline225__ssa_v3[0].is_valid())
                             params_phase_fence_barrier_10_deps[params_phase_fence_barrier_10_deps_count++] =
@@ -1400,17 +1400,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_10.set_dependencies(
                             params_phase_fence_barrier_10_deps, params_phase_fence_barrier_10_deps_count
                         );
-                        PTO2TaskId t__tmp_v126 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v126 = TaskId::invalid();
                         if (params_phase_fence_barrier_10_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_10_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_10);
                             t__tmp_v126 = phase_fence_barrier_10_outs.task_id();
                         }
                         up_late_tids_inline69[3] = t__tmp_v126;
-                        PTO2TaskId _submit_deps_buf_inline237__ssa_v3[1];
+                        TaskId _submit_deps_buf_inline237__ssa_v3[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline237__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v127 = cast_tids_inline88[3];
+                            _submit_deps_buf_inline237__ssa_v3[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v127 = cast_tids_inline88[3];
                         _submit_deps_buf_inline237__ssa_v3[0] = t__tmp_v127;
 
                         // Spmd gate_proj_spmd_2: gate_proj_2
@@ -1421,23 +1421,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t26.add_scalar(gu_k0_inline131__ssa_v3);
                         params_t26.add_scalar(layer_hidden_base_inline151);
                         params_t26.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t26_deps[1];
+                        TaskId params_t26_deps[1];
                         uint32_t params_t26_deps_count = 0;
                         if (_submit_deps_buf_inline237__ssa_v3[0].is_valid())
                             params_t26_deps[params_t26_deps_count++] = _submit_deps_buf_inline237__ssa_v3[0];
                         params_t26.set_dependencies(params_t26_deps, params_t26_deps_count);
                         TaskOutputTensors task_26_outs = rt_submit_aic_task(27, params_t26);
-                        PTO2TaskId gate_spmd_tid_inline245__ssa_v3 = task_26_outs.task_id();
+                        TaskId gate_spmd_tid_inline245__ssa_v3 = task_26_outs.task_id();
                         gate_tids_inline56[3] = gate_spmd_tid_inline245__ssa_v3;
                         gate_tids_inline56[8] = gate_spmd_tid_inline245__ssa_v3;
                         gate_tids_inline56[13] = gate_spmd_tid_inline245__ssa_v3;
                         gate_tids_inline56[18] = gate_spmd_tid_inline245__ssa_v3;
                         gate_tids_inline56[23] = gate_spmd_tid_inline245__ssa_v3;
                         gate_tids_inline56[28] = gate_spmd_tid_inline245__ssa_v3;
-                        PTO2TaskId _submit_deps_buf_inline260__ssa_v3[1];
+                        TaskId _submit_deps_buf_inline260__ssa_v3[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline260__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v128 = cast_tids_inline88[3];
+                            _submit_deps_buf_inline260__ssa_v3[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v128 = cast_tids_inline88[3];
                         _submit_deps_buf_inline260__ssa_v3[0] = t__tmp_v128;
 
                         // Spmd up_proj_spmd_2: up_proj_2
@@ -1448,13 +1448,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t27.add_scalar(gu_k0_inline131__ssa_v3);
                         params_t27.add_scalar(layer_hidden_base_inline151);
                         params_t27.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t27_deps[1];
+                        TaskId params_t27_deps[1];
                         uint32_t params_t27_deps_count = 0;
                         if (_submit_deps_buf_inline260__ssa_v3[0].is_valid())
                             params_t27_deps[params_t27_deps_count++] = _submit_deps_buf_inline260__ssa_v3[0];
                         params_t27.set_dependencies(params_t27_deps, params_t27_deps_count);
                         TaskOutputTensors task_27_outs = rt_submit_aic_task(28, params_t27);
-                        PTO2TaskId up_spmd_tid_inline264__ssa_v3 = task_27_outs.task_id();
+                        TaskId up_spmd_tid_inline264__ssa_v3 = task_27_outs.task_id();
                         up_tids_inline310[3] = up_spmd_tid_inline264__ssa_v3;
                         up_tids_inline310[8] = up_spmd_tid_inline264__ssa_v3;
                         up_tids_inline310[13] = up_spmd_tid_inline264__ssa_v3;
@@ -1462,15 +1462,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         up_tids_inline310[23] = up_spmd_tid_inline264__ssa_v3;
                         up_tids_inline310[28] = up_spmd_tid_inline264__ssa_v3;
                         int64_t gu_k0_inline131__ssa_v4 = 4096;
-                        PTO2TaskId _submit_deps_buf_inline236__ssa_v4[1];
+                        TaskId _submit_deps_buf_inline236__ssa_v4[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline236__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v129 = cast_tids_inline88[4];
+                            _submit_deps_buf_inline236__ssa_v4[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v129 = cast_tids_inline88[4];
                         _submit_deps_buf_inline236__ssa_v4[0] = t__tmp_v129;
 
                         // Phase-fence barrier 11: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_11;
-                        PTO2TaskId params_phase_fence_barrier_11_deps[1];
+                        TaskId params_phase_fence_barrier_11_deps[1];
                         uint32_t params_phase_fence_barrier_11_deps_count = 0;
                         if (_submit_deps_buf_inline236__ssa_v4[0].is_valid())
                             params_phase_fence_barrier_11_deps[params_phase_fence_barrier_11_deps_count++] =
@@ -1478,22 +1478,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_11.set_dependencies(
                             params_phase_fence_barrier_11_deps, params_phase_fence_barrier_11_deps_count
                         );
-                        PTO2TaskId t__tmp_v130 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v130 = TaskId::invalid();
                         if (params_phase_fence_barrier_11_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_11_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_11);
                             t__tmp_v130 = phase_fence_barrier_11_outs.task_id();
                         }
                         gate_late_tids_inline249[4] = t__tmp_v130;
-                        PTO2TaskId _submit_deps_buf_inline225__ssa_v4[1];
+                        TaskId _submit_deps_buf_inline225__ssa_v4[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline225__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v131 = cast_tids_inline88[4];
+                            _submit_deps_buf_inline225__ssa_v4[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v131 = cast_tids_inline88[4];
                         _submit_deps_buf_inline225__ssa_v4[0] = t__tmp_v131;
 
                         // Phase-fence barrier 12: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_12;
-                        PTO2TaskId params_phase_fence_barrier_12_deps[1];
+                        TaskId params_phase_fence_barrier_12_deps[1];
                         uint32_t params_phase_fence_barrier_12_deps_count = 0;
                         if (_submit_deps_buf_inline225__ssa_v4[0].is_valid())
                             params_phase_fence_barrier_12_deps[params_phase_fence_barrier_12_deps_count++] =
@@ -1501,17 +1501,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_phase_fence_barrier_12.set_dependencies(
                             params_phase_fence_barrier_12_deps, params_phase_fence_barrier_12_deps_count
                         );
-                        PTO2TaskId t__tmp_v132 = PTO2TaskId::invalid();
+                        TaskId t__tmp_v132 = TaskId::invalid();
                         if (params_phase_fence_barrier_12_deps_count > 0) {
                             TaskOutputTensors phase_fence_barrier_12_outs =
                                 rt_submit_dummy_task(params_phase_fence_barrier_12);
                             t__tmp_v132 = phase_fence_barrier_12_outs.task_id();
                         }
                         up_late_tids_inline69[4] = t__tmp_v132;
-                        PTO2TaskId _submit_deps_buf_inline237__ssa_v4[1];
+                        TaskId _submit_deps_buf_inline237__ssa_v4[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline237__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v133 = cast_tids_inline88[4];
+                            _submit_deps_buf_inline237__ssa_v4[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v133 = cast_tids_inline88[4];
                         _submit_deps_buf_inline237__ssa_v4[0] = t__tmp_v133;
 
                         // Spmd gate_proj_spmd_3: gate_proj_3
@@ -1522,23 +1522,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t28.add_scalar(gu_k0_inline131__ssa_v4);
                         params_t28.add_scalar(layer_hidden_base_inline151);
                         params_t28.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t28_deps[1];
+                        TaskId params_t28_deps[1];
                         uint32_t params_t28_deps_count = 0;
                         if (_submit_deps_buf_inline237__ssa_v4[0].is_valid())
                             params_t28_deps[params_t28_deps_count++] = _submit_deps_buf_inline237__ssa_v4[0];
                         params_t28.set_dependencies(params_t28_deps, params_t28_deps_count);
                         TaskOutputTensors task_28_outs = rt_submit_aic_task(29, params_t28);
-                        PTO2TaskId gate_spmd_tid_inline245__ssa_v4 = task_28_outs.task_id();
+                        TaskId gate_spmd_tid_inline245__ssa_v4 = task_28_outs.task_id();
                         gate_tids_inline56[4] = gate_spmd_tid_inline245__ssa_v4;
                         gate_tids_inline56[9] = gate_spmd_tid_inline245__ssa_v4;
                         gate_tids_inline56[14] = gate_spmd_tid_inline245__ssa_v4;
                         gate_tids_inline56[19] = gate_spmd_tid_inline245__ssa_v4;
                         gate_tids_inline56[24] = gate_spmd_tid_inline245__ssa_v4;
                         gate_tids_inline56[29] = gate_spmd_tid_inline245__ssa_v4;
-                        PTO2TaskId _submit_deps_buf_inline260__ssa_v4[1];
+                        TaskId _submit_deps_buf_inline260__ssa_v4[1];
                         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                            _submit_deps_buf_inline260__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                        PTO2TaskId t__tmp_v134 = cast_tids_inline88[4];
+                            _submit_deps_buf_inline260__ssa_v4[__init_i] = TaskId::invalid();
+                        TaskId t__tmp_v134 = cast_tids_inline88[4];
                         _submit_deps_buf_inline260__ssa_v4[0] = t__tmp_v134;
 
                         // Spmd up_proj_spmd_3: up_proj_3
@@ -1549,13 +1549,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t29.add_scalar(gu_k0_inline131__ssa_v4);
                         params_t29.add_scalar(layer_hidden_base_inline151);
                         params_t29.launch_spec.set_block_num(6);
-                        PTO2TaskId params_t29_deps[1];
+                        TaskId params_t29_deps[1];
                         uint32_t params_t29_deps_count = 0;
                         if (_submit_deps_buf_inline260__ssa_v4[0].is_valid())
                             params_t29_deps[params_t29_deps_count++] = _submit_deps_buf_inline260__ssa_v4[0];
                         params_t29.set_dependencies(params_t29_deps, params_t29_deps_count);
                         TaskOutputTensors task_29_outs = rt_submit_aic_task(30, params_t29);
-                        PTO2TaskId up_spmd_tid_inline264__ssa_v4 = task_29_outs.task_id();
+                        TaskId up_spmd_tid_inline264__ssa_v4 = task_29_outs.task_id();
                         up_tids_inline310[4] = up_spmd_tid_inline264__ssa_v4;
                         up_tids_inline310[9] = up_spmd_tid_inline264__ssa_v4;
                         up_tids_inline310[14] = up_spmd_tid_inline264__ssa_v4;
@@ -1566,10 +1566,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             int64_t n0_inline122 = (n_out_inline275 * 1024);
                             for (int64_t k_split_inline276 = 0; k_split_inline276 < 5; k_split_inline276 += 1) {
                                 int64_t k0_inline113 = (k_split_inline276 * 1024);
-                                PTO2TaskId _submit_deps_buf_inline102[1];
+                                TaskId _submit_deps_buf_inline102[1];
                                 for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                                    _submit_deps_buf_inline102[__init_i] = PTO2TaskId::invalid();
-                                PTO2TaskId t__tmp_v135 = gate_late_tids_inline249[k_split_inline276];
+                                    _submit_deps_buf_inline102[__init_i] = TaskId::invalid();
+                                TaskId t__tmp_v135 = gate_late_tids_inline249[k_split_inline276];
                                 _submit_deps_buf_inline102[0] = t__tmp_v135;
 
                                 // Task 30: gate_proj_4
@@ -1580,18 +1580,18 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t30.add_scalar(k0_inline113);
                                 params_t30.add_scalar(layer_hidden_base_inline151);
                                 params_t30.add_scalar(n0_inline122);
-                                PTO2TaskId params_t30_deps[1];
+                                TaskId params_t30_deps[1];
                                 uint32_t params_t30_deps_count = 0;
                                 if (_submit_deps_buf_inline102[0].is_valid())
                                     params_t30_deps[params_t30_deps_count++] = _submit_deps_buf_inline102[0];
                                 params_t30.set_dependencies(params_t30_deps, params_t30_deps_count);
                                 TaskOutputTensors task_30_outs = rt_submit_aic_task(31, params_t30);
-                                PTO2TaskId gate_tid_inline277 = task_30_outs.task_id();
+                                TaskId gate_tid_inline277 = task_30_outs.task_id();
                                 gate_tids_inline56[((n_out_inline275 * 5) + k_split_inline276)] = gate_tid_inline277;
-                                PTO2TaskId _submit_deps_buf_inline246[1];
+                                TaskId _submit_deps_buf_inline246[1];
                                 for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                                    _submit_deps_buf_inline246[__init_i] = PTO2TaskId::invalid();
-                                PTO2TaskId t__tmp_v136 = up_late_tids_inline69[k_split_inline276];
+                                    _submit_deps_buf_inline246[__init_i] = TaskId::invalid();
+                                TaskId t__tmp_v136 = up_late_tids_inline69[k_split_inline276];
                                 _submit_deps_buf_inline246[0] = t__tmp_v136;
 
                                 // Task 31: up_proj_4
@@ -1602,41 +1602,41 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t31.add_scalar(k0_inline113);
                                 params_t31.add_scalar(layer_hidden_base_inline151);
                                 params_t31.add_scalar(n0_inline122);
-                                PTO2TaskId params_t31_deps[1];
+                                TaskId params_t31_deps[1];
                                 uint32_t params_t31_deps_count = 0;
                                 if (_submit_deps_buf_inline246[0].is_valid())
                                     params_t31_deps[params_t31_deps_count++] = _submit_deps_buf_inline246[0];
                                 params_t31.set_dependencies(params_t31_deps, params_t31_deps_count);
                                 TaskOutputTensors task_31_outs = rt_submit_aic_task(32, params_t31);
-                                PTO2TaskId up_tid_inline290 = task_31_outs.task_id();
+                                TaskId up_tid_inline290 = task_31_outs.task_id();
                                 up_tids_inline310[((n_out_inline275 * 5) + k_split_inline276)] = up_tid_inline290;
                             }
                         }
                         for (int64_t n_out_inline292 = 0; n_out_inline292 < 17; n_out_inline292 += 1) {
                             int64_t n0_inline122__ssa_v7 = (n_out_inline292 * 1024);
-                            PTO2TaskId _submit_deps_buf_inline167[11];
+                            TaskId _submit_deps_buf_inline167[11];
                             for (int64_t __init_i = 0; __init_i < 11; ++__init_i)
-                                _submit_deps_buf_inline167[__init_i] = PTO2TaskId::invalid();
+                                _submit_deps_buf_inline167[__init_i] = TaskId::invalid();
                             _submit_deps_buf_inline167[0] = reduce_tid_inline226;
-                            PTO2TaskId t__tmp_v137 = gate_tids_inline56[(n_out_inline292 * 5)];
+                            TaskId t__tmp_v137 = gate_tids_inline56[(n_out_inline292 * 5)];
                             _submit_deps_buf_inline167[1] = t__tmp_v137;
-                            PTO2TaskId t__tmp_v138 = gate_tids_inline56[((n_out_inline292 * 5) + 1)];
+                            TaskId t__tmp_v138 = gate_tids_inline56[((n_out_inline292 * 5) + 1)];
                             _submit_deps_buf_inline167[2] = t__tmp_v138;
-                            PTO2TaskId t__tmp_v139 = gate_tids_inline56[((n_out_inline292 * 5) + 2)];
+                            TaskId t__tmp_v139 = gate_tids_inline56[((n_out_inline292 * 5) + 2)];
                             _submit_deps_buf_inline167[3] = t__tmp_v139;
-                            PTO2TaskId t__tmp_v140 = gate_tids_inline56[((n_out_inline292 * 5) + 3)];
+                            TaskId t__tmp_v140 = gate_tids_inline56[((n_out_inline292 * 5) + 3)];
                             _submit_deps_buf_inline167[4] = t__tmp_v140;
-                            PTO2TaskId t__tmp_v141 = gate_tids_inline56[((n_out_inline292 * 5) + 4)];
+                            TaskId t__tmp_v141 = gate_tids_inline56[((n_out_inline292 * 5) + 4)];
                             _submit_deps_buf_inline167[5] = t__tmp_v141;
-                            PTO2TaskId t__tmp_v142 = up_tids_inline310[(n_out_inline292 * 5)];
+                            TaskId t__tmp_v142 = up_tids_inline310[(n_out_inline292 * 5)];
                             _submit_deps_buf_inline167[6] = t__tmp_v142;
-                            PTO2TaskId t__tmp_v143 = up_tids_inline310[((n_out_inline292 * 5) + 1)];
+                            TaskId t__tmp_v143 = up_tids_inline310[((n_out_inline292 * 5) + 1)];
                             _submit_deps_buf_inline167[7] = t__tmp_v143;
-                            PTO2TaskId t__tmp_v144 = up_tids_inline310[((n_out_inline292 * 5) + 2)];
+                            TaskId t__tmp_v144 = up_tids_inline310[((n_out_inline292 * 5) + 2)];
                             _submit_deps_buf_inline167[8] = t__tmp_v144;
-                            PTO2TaskId t__tmp_v145 = up_tids_inline310[((n_out_inline292 * 5) + 3)];
+                            TaskId t__tmp_v145 = up_tids_inline310[((n_out_inline292 * 5) + 3)];
                             _submit_deps_buf_inline167[9] = t__tmp_v145;
-                            PTO2TaskId t__tmp_v146 = up_tids_inline310[((n_out_inline292 * 5) + 4)];
+                            TaskId t__tmp_v146 = up_tids_inline310[((n_out_inline292 * 5) + 4)];
                             _submit_deps_buf_inline167[10] = t__tmp_v146;
 
                             // Task 32: silu
@@ -1646,7 +1646,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t32.add_input(gate_acc_all_inline203);
                             params_t32.add_input(up_acc_all_inline303);
                             params_t32.add_scalar(n0_inline122__ssa_v7);
-                            PTO2TaskId params_t32_deps[11];
+                            TaskId params_t32_deps[11];
                             uint32_t params_t32_deps_count = 0;
                             if (_submit_deps_buf_inline167[0].is_valid())
                                 params_t32_deps[params_t32_deps_count++] = _submit_deps_buf_inline167[0];
@@ -1672,17 +1672,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t32_deps[params_t32_deps_count++] = _submit_deps_buf_inline167[10];
                             params_t32.set_dependencies(params_t32_deps, params_t32_deps_count);
                             TaskOutputTensors task_32_outs = rt_submit_aiv_task(33, params_t32);
-                            PTO2TaskId silu_tid_inline80 = task_32_outs.task_id();
+                            TaskId silu_tid_inline80 = task_32_outs.task_id();
                             silu_tids_inline265[n_out_inline292] = silu_tid_inline80;
                         }
                         for (int64_t n_out_inline195 = 0; n_out_inline195 < 5; n_out_inline195 += 1) {
                             int64_t n0_inline122__ssa_v8 = (n_out_inline195 * 1024);
                             for (int64_t k_split_inline302 = 0; k_split_inline302 < 17; k_split_inline302 += 1) {
                                 int64_t k0_inline113__ssa_v8 = (k_split_inline302 * 1024);
-                                PTO2TaskId _submit_deps_buf_inline229[1];
+                                TaskId _submit_deps_buf_inline229[1];
                                 for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                                    _submit_deps_buf_inline229[__init_i] = PTO2TaskId::invalid();
-                                PTO2TaskId t__tmp_v152 = silu_tids_inline265[k_split_inline302];
+                                    _submit_deps_buf_inline229[__init_i] = TaskId::invalid();
+                                TaskId t__tmp_v152 = silu_tids_inline265[k_split_inline302];
                                 _submit_deps_buf_inline229[0] = t__tmp_v152;
 
                                 // Task 33: down_proj
@@ -1693,190 +1693,190 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                                 params_t33.add_scalar(k0_inline113__ssa_v8);
                                 params_t33.add_scalar(layer_inter_base_inline107);
                                 params_t33.add_scalar(n0_inline122__ssa_v8);
-                                PTO2TaskId params_t33_deps[1];
+                                TaskId params_t33_deps[1];
                                 uint32_t params_t33_deps_count = 0;
                                 if (_submit_deps_buf_inline229[0].is_valid())
                                     params_t33_deps[params_t33_deps_count++] = _submit_deps_buf_inline229[0];
                                 params_t33.set_dependencies(params_t33_deps, params_t33_deps_count);
                                 params_t33.set_allow_early_resolve(true);
                                 TaskOutputTensors task_33_outs = rt_submit_aic_task(34, params_t33);
-                                PTO2TaskId down_tid_inline210 = task_33_outs.task_id();
+                                TaskId down_tid_inline210 = task_33_outs.task_id();
                                 down_tids_inline156[((n_out_inline195 * 17) + k_split_inline302)] = down_tid_inline210;
                             }
                         }
                     }
-                    PTO2TaskId _submit_deps_buf_inline123[85];
+                    TaskId _submit_deps_buf_inline123[85];
                     for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
-                        _submit_deps_buf_inline123[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v153 = down_tids_inline156[0];
+                        _submit_deps_buf_inline123[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v153 = down_tids_inline156[0];
                     _submit_deps_buf_inline123[0] = t__tmp_v153;
-                    PTO2TaskId t__tmp_v154 = down_tids_inline156[1];
+                    TaskId t__tmp_v154 = down_tids_inline156[1];
                     _submit_deps_buf_inline123[1] = t__tmp_v154;
-                    PTO2TaskId t__tmp_v155 = down_tids_inline156[2];
+                    TaskId t__tmp_v155 = down_tids_inline156[2];
                     _submit_deps_buf_inline123[2] = t__tmp_v155;
-                    PTO2TaskId t__tmp_v156 = down_tids_inline156[3];
+                    TaskId t__tmp_v156 = down_tids_inline156[3];
                     _submit_deps_buf_inline123[3] = t__tmp_v156;
-                    PTO2TaskId t__tmp_v157 = down_tids_inline156[4];
+                    TaskId t__tmp_v157 = down_tids_inline156[4];
                     _submit_deps_buf_inline123[4] = t__tmp_v157;
-                    PTO2TaskId t__tmp_v158 = down_tids_inline156[5];
+                    TaskId t__tmp_v158 = down_tids_inline156[5];
                     _submit_deps_buf_inline123[5] = t__tmp_v158;
-                    PTO2TaskId t__tmp_v159 = down_tids_inline156[6];
+                    TaskId t__tmp_v159 = down_tids_inline156[6];
                     _submit_deps_buf_inline123[6] = t__tmp_v159;
-                    PTO2TaskId t__tmp_v160 = down_tids_inline156[7];
+                    TaskId t__tmp_v160 = down_tids_inline156[7];
                     _submit_deps_buf_inline123[7] = t__tmp_v160;
-                    PTO2TaskId t__tmp_v161 = down_tids_inline156[8];
+                    TaskId t__tmp_v161 = down_tids_inline156[8];
                     _submit_deps_buf_inline123[8] = t__tmp_v161;
-                    PTO2TaskId t__tmp_v162 = down_tids_inline156[9];
+                    TaskId t__tmp_v162 = down_tids_inline156[9];
                     _submit_deps_buf_inline123[9] = t__tmp_v162;
-                    PTO2TaskId t__tmp_v163 = down_tids_inline156[10];
+                    TaskId t__tmp_v163 = down_tids_inline156[10];
                     _submit_deps_buf_inline123[10] = t__tmp_v163;
-                    PTO2TaskId t__tmp_v164 = down_tids_inline156[11];
+                    TaskId t__tmp_v164 = down_tids_inline156[11];
                     _submit_deps_buf_inline123[11] = t__tmp_v164;
-                    PTO2TaskId t__tmp_v165 = down_tids_inline156[12];
+                    TaskId t__tmp_v165 = down_tids_inline156[12];
                     _submit_deps_buf_inline123[12] = t__tmp_v165;
-                    PTO2TaskId t__tmp_v166 = down_tids_inline156[13];
+                    TaskId t__tmp_v166 = down_tids_inline156[13];
                     _submit_deps_buf_inline123[13] = t__tmp_v166;
-                    PTO2TaskId t__tmp_v167 = down_tids_inline156[14];
+                    TaskId t__tmp_v167 = down_tids_inline156[14];
                     _submit_deps_buf_inline123[14] = t__tmp_v167;
-                    PTO2TaskId t__tmp_v168 = down_tids_inline156[15];
+                    TaskId t__tmp_v168 = down_tids_inline156[15];
                     _submit_deps_buf_inline123[15] = t__tmp_v168;
-                    PTO2TaskId t__tmp_v169 = down_tids_inline156[16];
+                    TaskId t__tmp_v169 = down_tids_inline156[16];
                     _submit_deps_buf_inline123[16] = t__tmp_v169;
-                    PTO2TaskId t__tmp_v170 = down_tids_inline156[17];
+                    TaskId t__tmp_v170 = down_tids_inline156[17];
                     _submit_deps_buf_inline123[17] = t__tmp_v170;
-                    PTO2TaskId t__tmp_v171 = down_tids_inline156[18];
+                    TaskId t__tmp_v171 = down_tids_inline156[18];
                     _submit_deps_buf_inline123[18] = t__tmp_v171;
-                    PTO2TaskId t__tmp_v172 = down_tids_inline156[19];
+                    TaskId t__tmp_v172 = down_tids_inline156[19];
                     _submit_deps_buf_inline123[19] = t__tmp_v172;
-                    PTO2TaskId t__tmp_v173 = down_tids_inline156[20];
+                    TaskId t__tmp_v173 = down_tids_inline156[20];
                     _submit_deps_buf_inline123[20] = t__tmp_v173;
-                    PTO2TaskId t__tmp_v174 = down_tids_inline156[21];
+                    TaskId t__tmp_v174 = down_tids_inline156[21];
                     _submit_deps_buf_inline123[21] = t__tmp_v174;
-                    PTO2TaskId t__tmp_v175 = down_tids_inline156[22];
+                    TaskId t__tmp_v175 = down_tids_inline156[22];
                     _submit_deps_buf_inline123[22] = t__tmp_v175;
-                    PTO2TaskId t__tmp_v176 = down_tids_inline156[23];
+                    TaskId t__tmp_v176 = down_tids_inline156[23];
                     _submit_deps_buf_inline123[23] = t__tmp_v176;
-                    PTO2TaskId t__tmp_v177 = down_tids_inline156[24];
+                    TaskId t__tmp_v177 = down_tids_inline156[24];
                     _submit_deps_buf_inline123[24] = t__tmp_v177;
-                    PTO2TaskId t__tmp_v178 = down_tids_inline156[25];
+                    TaskId t__tmp_v178 = down_tids_inline156[25];
                     _submit_deps_buf_inline123[25] = t__tmp_v178;
-                    PTO2TaskId t__tmp_v179 = down_tids_inline156[26];
+                    TaskId t__tmp_v179 = down_tids_inline156[26];
                     _submit_deps_buf_inline123[26] = t__tmp_v179;
-                    PTO2TaskId t__tmp_v180 = down_tids_inline156[27];
+                    TaskId t__tmp_v180 = down_tids_inline156[27];
                     _submit_deps_buf_inline123[27] = t__tmp_v180;
-                    PTO2TaskId t__tmp_v181 = down_tids_inline156[28];
+                    TaskId t__tmp_v181 = down_tids_inline156[28];
                     _submit_deps_buf_inline123[28] = t__tmp_v181;
-                    PTO2TaskId t__tmp_v182 = down_tids_inline156[29];
+                    TaskId t__tmp_v182 = down_tids_inline156[29];
                     _submit_deps_buf_inline123[29] = t__tmp_v182;
-                    PTO2TaskId t__tmp_v183 = down_tids_inline156[30];
+                    TaskId t__tmp_v183 = down_tids_inline156[30];
                     _submit_deps_buf_inline123[30] = t__tmp_v183;
-                    PTO2TaskId t__tmp_v184 = down_tids_inline156[31];
+                    TaskId t__tmp_v184 = down_tids_inline156[31];
                     _submit_deps_buf_inline123[31] = t__tmp_v184;
-                    PTO2TaskId t__tmp_v185 = down_tids_inline156[32];
+                    TaskId t__tmp_v185 = down_tids_inline156[32];
                     _submit_deps_buf_inline123[32] = t__tmp_v185;
-                    PTO2TaskId t__tmp_v186 = down_tids_inline156[33];
+                    TaskId t__tmp_v186 = down_tids_inline156[33];
                     _submit_deps_buf_inline123[33] = t__tmp_v186;
-                    PTO2TaskId t__tmp_v187 = down_tids_inline156[34];
+                    TaskId t__tmp_v187 = down_tids_inline156[34];
                     _submit_deps_buf_inline123[34] = t__tmp_v187;
-                    PTO2TaskId t__tmp_v188 = down_tids_inline156[35];
+                    TaskId t__tmp_v188 = down_tids_inline156[35];
                     _submit_deps_buf_inline123[35] = t__tmp_v188;
-                    PTO2TaskId t__tmp_v189 = down_tids_inline156[36];
+                    TaskId t__tmp_v189 = down_tids_inline156[36];
                     _submit_deps_buf_inline123[36] = t__tmp_v189;
-                    PTO2TaskId t__tmp_v190 = down_tids_inline156[37];
+                    TaskId t__tmp_v190 = down_tids_inline156[37];
                     _submit_deps_buf_inline123[37] = t__tmp_v190;
-                    PTO2TaskId t__tmp_v191 = down_tids_inline156[38];
+                    TaskId t__tmp_v191 = down_tids_inline156[38];
                     _submit_deps_buf_inline123[38] = t__tmp_v191;
-                    PTO2TaskId t__tmp_v192 = down_tids_inline156[39];
+                    TaskId t__tmp_v192 = down_tids_inline156[39];
                     _submit_deps_buf_inline123[39] = t__tmp_v192;
-                    PTO2TaskId t__tmp_v193 = down_tids_inline156[40];
+                    TaskId t__tmp_v193 = down_tids_inline156[40];
                     _submit_deps_buf_inline123[40] = t__tmp_v193;
-                    PTO2TaskId t__tmp_v194 = down_tids_inline156[41];
+                    TaskId t__tmp_v194 = down_tids_inline156[41];
                     _submit_deps_buf_inline123[41] = t__tmp_v194;
-                    PTO2TaskId t__tmp_v195 = down_tids_inline156[42];
+                    TaskId t__tmp_v195 = down_tids_inline156[42];
                     _submit_deps_buf_inline123[42] = t__tmp_v195;
-                    PTO2TaskId t__tmp_v196 = down_tids_inline156[43];
+                    TaskId t__tmp_v196 = down_tids_inline156[43];
                     _submit_deps_buf_inline123[43] = t__tmp_v196;
-                    PTO2TaskId t__tmp_v197 = down_tids_inline156[44];
+                    TaskId t__tmp_v197 = down_tids_inline156[44];
                     _submit_deps_buf_inline123[44] = t__tmp_v197;
-                    PTO2TaskId t__tmp_v198 = down_tids_inline156[45];
+                    TaskId t__tmp_v198 = down_tids_inline156[45];
                     _submit_deps_buf_inline123[45] = t__tmp_v198;
-                    PTO2TaskId t__tmp_v199 = down_tids_inline156[46];
+                    TaskId t__tmp_v199 = down_tids_inline156[46];
                     _submit_deps_buf_inline123[46] = t__tmp_v199;
-                    PTO2TaskId t__tmp_v200 = down_tids_inline156[47];
+                    TaskId t__tmp_v200 = down_tids_inline156[47];
                     _submit_deps_buf_inline123[47] = t__tmp_v200;
-                    PTO2TaskId t__tmp_v201 = down_tids_inline156[48];
+                    TaskId t__tmp_v201 = down_tids_inline156[48];
                     _submit_deps_buf_inline123[48] = t__tmp_v201;
-                    PTO2TaskId t__tmp_v202 = down_tids_inline156[49];
+                    TaskId t__tmp_v202 = down_tids_inline156[49];
                     _submit_deps_buf_inline123[49] = t__tmp_v202;
-                    PTO2TaskId t__tmp_v203 = down_tids_inline156[50];
+                    TaskId t__tmp_v203 = down_tids_inline156[50];
                     _submit_deps_buf_inline123[50] = t__tmp_v203;
-                    PTO2TaskId t__tmp_v204 = down_tids_inline156[51];
+                    TaskId t__tmp_v204 = down_tids_inline156[51];
                     _submit_deps_buf_inline123[51] = t__tmp_v204;
-                    PTO2TaskId t__tmp_v205 = down_tids_inline156[52];
+                    TaskId t__tmp_v205 = down_tids_inline156[52];
                     _submit_deps_buf_inline123[52] = t__tmp_v205;
-                    PTO2TaskId t__tmp_v206 = down_tids_inline156[53];
+                    TaskId t__tmp_v206 = down_tids_inline156[53];
                     _submit_deps_buf_inline123[53] = t__tmp_v206;
-                    PTO2TaskId t__tmp_v207 = down_tids_inline156[54];
+                    TaskId t__tmp_v207 = down_tids_inline156[54];
                     _submit_deps_buf_inline123[54] = t__tmp_v207;
-                    PTO2TaskId t__tmp_v208 = down_tids_inline156[55];
+                    TaskId t__tmp_v208 = down_tids_inline156[55];
                     _submit_deps_buf_inline123[55] = t__tmp_v208;
-                    PTO2TaskId t__tmp_v209 = down_tids_inline156[56];
+                    TaskId t__tmp_v209 = down_tids_inline156[56];
                     _submit_deps_buf_inline123[56] = t__tmp_v209;
-                    PTO2TaskId t__tmp_v210 = down_tids_inline156[57];
+                    TaskId t__tmp_v210 = down_tids_inline156[57];
                     _submit_deps_buf_inline123[57] = t__tmp_v210;
-                    PTO2TaskId t__tmp_v211 = down_tids_inline156[58];
+                    TaskId t__tmp_v211 = down_tids_inline156[58];
                     _submit_deps_buf_inline123[58] = t__tmp_v211;
-                    PTO2TaskId t__tmp_v212 = down_tids_inline156[59];
+                    TaskId t__tmp_v212 = down_tids_inline156[59];
                     _submit_deps_buf_inline123[59] = t__tmp_v212;
-                    PTO2TaskId t__tmp_v213 = down_tids_inline156[60];
+                    TaskId t__tmp_v213 = down_tids_inline156[60];
                     _submit_deps_buf_inline123[60] = t__tmp_v213;
-                    PTO2TaskId t__tmp_v214 = down_tids_inline156[61];
+                    TaskId t__tmp_v214 = down_tids_inline156[61];
                     _submit_deps_buf_inline123[61] = t__tmp_v214;
-                    PTO2TaskId t__tmp_v215 = down_tids_inline156[62];
+                    TaskId t__tmp_v215 = down_tids_inline156[62];
                     _submit_deps_buf_inline123[62] = t__tmp_v215;
-                    PTO2TaskId t__tmp_v216 = down_tids_inline156[63];
+                    TaskId t__tmp_v216 = down_tids_inline156[63];
                     _submit_deps_buf_inline123[63] = t__tmp_v216;
-                    PTO2TaskId t__tmp_v217 = down_tids_inline156[64];
+                    TaskId t__tmp_v217 = down_tids_inline156[64];
                     _submit_deps_buf_inline123[64] = t__tmp_v217;
-                    PTO2TaskId t__tmp_v218 = down_tids_inline156[65];
+                    TaskId t__tmp_v218 = down_tids_inline156[65];
                     _submit_deps_buf_inline123[65] = t__tmp_v218;
-                    PTO2TaskId t__tmp_v219 = down_tids_inline156[66];
+                    TaskId t__tmp_v219 = down_tids_inline156[66];
                     _submit_deps_buf_inline123[66] = t__tmp_v219;
-                    PTO2TaskId t__tmp_v220 = down_tids_inline156[67];
+                    TaskId t__tmp_v220 = down_tids_inline156[67];
                     _submit_deps_buf_inline123[67] = t__tmp_v220;
-                    PTO2TaskId t__tmp_v221 = down_tids_inline156[68];
+                    TaskId t__tmp_v221 = down_tids_inline156[68];
                     _submit_deps_buf_inline123[68] = t__tmp_v221;
-                    PTO2TaskId t__tmp_v222 = down_tids_inline156[69];
+                    TaskId t__tmp_v222 = down_tids_inline156[69];
                     _submit_deps_buf_inline123[69] = t__tmp_v222;
-                    PTO2TaskId t__tmp_v223 = down_tids_inline156[70];
+                    TaskId t__tmp_v223 = down_tids_inline156[70];
                     _submit_deps_buf_inline123[70] = t__tmp_v223;
-                    PTO2TaskId t__tmp_v224 = down_tids_inline156[71];
+                    TaskId t__tmp_v224 = down_tids_inline156[71];
                     _submit_deps_buf_inline123[71] = t__tmp_v224;
-                    PTO2TaskId t__tmp_v225 = down_tids_inline156[72];
+                    TaskId t__tmp_v225 = down_tids_inline156[72];
                     _submit_deps_buf_inline123[72] = t__tmp_v225;
-                    PTO2TaskId t__tmp_v226 = down_tids_inline156[73];
+                    TaskId t__tmp_v226 = down_tids_inline156[73];
                     _submit_deps_buf_inline123[73] = t__tmp_v226;
-                    PTO2TaskId t__tmp_v227 = down_tids_inline156[74];
+                    TaskId t__tmp_v227 = down_tids_inline156[74];
                     _submit_deps_buf_inline123[74] = t__tmp_v227;
-                    PTO2TaskId t__tmp_v228 = down_tids_inline156[75];
+                    TaskId t__tmp_v228 = down_tids_inline156[75];
                     _submit_deps_buf_inline123[75] = t__tmp_v228;
-                    PTO2TaskId t__tmp_v229 = down_tids_inline156[76];
+                    TaskId t__tmp_v229 = down_tids_inline156[76];
                     _submit_deps_buf_inline123[76] = t__tmp_v229;
-                    PTO2TaskId t__tmp_v230 = down_tids_inline156[77];
+                    TaskId t__tmp_v230 = down_tids_inline156[77];
                     _submit_deps_buf_inline123[77] = t__tmp_v230;
-                    PTO2TaskId t__tmp_v231 = down_tids_inline156[78];
+                    TaskId t__tmp_v231 = down_tids_inline156[78];
                     _submit_deps_buf_inline123[78] = t__tmp_v231;
-                    PTO2TaskId t__tmp_v232 = down_tids_inline156[79];
+                    TaskId t__tmp_v232 = down_tids_inline156[79];
                     _submit_deps_buf_inline123[79] = t__tmp_v232;
-                    PTO2TaskId t__tmp_v233 = down_tids_inline156[80];
+                    TaskId t__tmp_v233 = down_tids_inline156[80];
                     _submit_deps_buf_inline123[80] = t__tmp_v233;
-                    PTO2TaskId t__tmp_v234 = down_tids_inline156[81];
+                    TaskId t__tmp_v234 = down_tids_inline156[81];
                     _submit_deps_buf_inline123[81] = t__tmp_v234;
-                    PTO2TaskId t__tmp_v235 = down_tids_inline156[82];
+                    TaskId t__tmp_v235 = down_tids_inline156[82];
                     _submit_deps_buf_inline123[82] = t__tmp_v235;
-                    PTO2TaskId t__tmp_v236 = down_tids_inline156[83];
+                    TaskId t__tmp_v236 = down_tids_inline156[83];
                     _submit_deps_buf_inline123[83] = t__tmp_v236;
-                    PTO2TaskId t__tmp_v237 = down_tids_inline156[84];
+                    TaskId t__tmp_v237 = down_tids_inline156[84];
                     _submit_deps_buf_inline123[84] = t__tmp_v237;
 
                     // Spmd dcr_xgamma_spmd: dcr_xgamma
@@ -1889,7 +1889,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t34.add_scalar(next_gamma_idx);
                     params_t34.launch_spec.set_block_num(5);
                     params_t34.set_allow_early_resolve(true);
-                    PTO2TaskId params_t34_deps[85];
+                    TaskId params_t34_deps[85];
                     uint32_t params_t34_deps_count = 0;
                     if (_submit_deps_buf_inline123[0].is_valid())
                         params_t34_deps[params_t34_deps_count++] = _submit_deps_buf_inline123[0];

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -165,8 +165,8 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                 const ChipTensor &oi = alloc_outs.get_ref(0);
                 const ChipTensor &li_update = alloc_outs.get_ref(1);
                 const ChipTensor &mi_update = alloc_outs.get_ref(2);
-                PTO2TaskId alloc_task = alloc_outs.task_id();
-                PTO2TaskId prev_update_task = PTO2TaskId::invalid();
+                TaskId alloc_task = alloc_outs.task_id();
+                TaskId prev_update_task = TaskId::invalid();
                 prof_submit_count++;
                 CYCLE_COUNT_LAP(prof_submit_task);
 
@@ -208,7 +208,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_sf.add_output(scalar_ci);
                     params_sf.add_output(scalar_ci);
                     params_sf.add_scalar(scale_value);
-                    PTO2TaskId sf_deps[] = {qk_outs.task_id()};
+                    TaskId sf_deps[] = {qk_outs.task_id()};
                     params_sf.set_dependencies(sf_deps, 1);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors sf_outs = rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
@@ -222,7 +222,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_pv.add_input(pij_f16);
                     params_pv.add_input(vj);
                     params_pv.add_output(tile2d_ci);
-                    PTO2TaskId pv_deps[] = {sf_outs.task_id()};
+                    TaskId pv_deps[] = {sf_outs.task_id()};
                     params_pv.set_dependencies(pv_deps, 1);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors pv_outs = rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -173,7 +173,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                 const ChipTensor &oi = alloc_outs.get_ref(0);
                 const ChipTensor &li_update = alloc_outs.get_ref(1);
                 const ChipTensor &mi_update = alloc_outs.get_ref(2);
-                PTO2TaskId prev_update_task = PTO2TaskId::invalid();
+                TaskId prev_update_task = TaskId::invalid();
 #ifdef ENABLE_PROFILING
                 prof_submit_count++;
                 CYCLE_COUNT_LAP(prof_submit_task);
@@ -226,7 +226,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_sf.add_output(pij_buf_ci);
                     params_sf.add_output(scalar_ci);
                     params_sf.add_output(scalar_ci);
-                    PTO2TaskId sf_deps[] = {qk_outs.task_id()};
+                    TaskId sf_deps[] = {qk_outs.task_id()};
                     params_sf.set_dependencies(sf_deps, 1);
                     params_sf.add_scalar(scale_value);
                     params_sf.add_scalar(n_blocks);
@@ -246,7 +246,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_pv.add_input(value_cache);
                     params_pv.add_input(block_table);
                     params_pv.add_output(tile2d_ci);
-                    PTO2TaskId pv_deps[] = {sf_outs.task_id()};
+                    TaskId pv_deps[] = {sf_outs.task_id()};
                     params_pv.set_dependencies(pv_deps, 1);
                     params_pv.add_scalar(n_blocks);
                     params_pv.add_scalar(b_idx * block_num + bn);
@@ -269,7 +269,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_up.add_inout(li_update);
                     params_up.add_inout(oi);
                     params_up.add_inout(out_view);
-                    PTO2TaskId up_deps[3];
+                    TaskId up_deps[3];
                     uint32_t up_dep_count = 0;
                     up_deps[up_dep_count++] = pv_outs.task_id();
                     if (prev_update_task.is_valid()) {

--- a/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
@@ -86,16 +86,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t0.launch_spec.set_core_num(1);
         params_t0.set_allow_early_resolve(true);
         TaskOutputTensors task_0_outs = rt_submit_aiv_task(0, params_t0);
-        PTO2TaskId tiling_tid_inline0 = task_0_outs.task_id();
-        PTO2TaskId pa_tiling_tid = tiling_tid_inline0;
-        PTO2TaskId prev_out_tid[1];
+        TaskId tiling_tid_inline0 = task_0_outs.task_id();
+        TaskId pa_tiling_tid = tiling_tid_inline0;
+        TaskId prev_out_tid[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-            prev_out_tid[__init_i] = PTO2TaskId::invalid();
+            prev_out_tid[__init_i] = TaskId::invalid();
 
         // Phase-fence barrier 0: dependency-only dummy task
         CoreTaskArgs params_phase_fence_barrier_0;
         TaskOutputTensors phase_fence_barrier_0_outs = rt_submit_dummy_task(params_phase_fence_barrier_0);
-        PTO2TaskId t = phase_fence_barrier_0_outs.task_id();
+        TaskId t = phase_fence_barrier_0_outs.task_id();
         prev_out_tid[0] = t;
         for (int64_t cb0 = 0; cb0 < 16; cb0 += 16) {
             PTO2_SCOPE() {
@@ -105,18 +105,18 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t1.add_input(ext_hidden_states);
                 params_t1.add_scalar(cb0);
                 TaskOutputTensors task_1_outs = rt_submit_aiv_task(1, params_t1);
-                PTO2TaskId ch_tid = task_1_outs.task_id();
+                TaskId ch_tid = task_1_outs.task_id();
                 prev_out_tid[0] = ch_tid;
             }
         }
-        PTO2TaskId prev_normed_tid[1];
+        TaskId prev_normed_tid[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-            prev_normed_tid[__init_i] = PTO2TaskId::invalid();
+            prev_normed_tid[__init_i] = TaskId::invalid();
         PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
-            PTO2TaskId _submit_deps_buf[1];
+            TaskId _submit_deps_buf[1];
             for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                _submit_deps_buf[__init_i] = PTO2TaskId::invalid();
-            PTO2TaskId t__tmp_v3 = prev_out_tid[0];
+                _submit_deps_buf[__init_i] = TaskId::invalid();
+            TaskId t__tmp_v3 = prev_out_tid[0];
             _submit_deps_buf[0] = t__tmp_v3;
 
             // Spmd x_gamma0_spmd: x_gamma0
@@ -126,12 +126,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t2.add_input(ext_input_rms_weight);
             params_t2.launch_spec.set_core_num(5);
             params_t2.set_allow_early_resolve(true);
-            PTO2TaskId params_t2_deps[1];
+            TaskId params_t2_deps[1];
             uint32_t params_t2_deps_count = 0;
             if (_submit_deps_buf[0].is_valid()) params_t2_deps[params_t2_deps_count++] = _submit_deps_buf[0];
             params_t2.set_dependencies(params_t2_deps, params_t2_deps_count);
             TaskOutputTensors task_2_outs = rt_submit_aiv_task(2, params_t2);
-            PTO2TaskId xgamma_tid = task_2_outs.task_id();
+            TaskId xgamma_tid = task_2_outs.task_id();
             prev_normed_tid[0] = xgamma_tid;
         }
         ChipTensor cur__rv_v7 = cur;
@@ -195,9 +195,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 };
                 ChipTensor k_norm_w_inline114 =
                     ext_k_norm_weight.view(k_norm_w_inline114_shapes, k_norm_w_inline114_offsets);
-                PTO2TaskId down_tids_inline156[85];
+                TaskId down_tids_inline156[85];
                 for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
-                    down_tids_inline156[__init_i] = PTO2TaskId::invalid();
+                    down_tids_inline156[__init_i] = TaskId::invalid();
                 uint32_t down_acc_all_inline168_ci_shapes[2] = {16, 5120};
                 TensorCreateInfo down_acc_all_inline168_ci(down_acc_all_inline168_ci_shapes, 2, DataType::FLOAT32);
                 uint32_t gate_acc_all_inline203_ci_shapes[2] = {16, 17408};
@@ -233,11 +233,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     // Phase-fence barrier 1: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_1;
                     TaskOutputTensors phase_fence_barrier_1_outs = rt_submit_dummy_task(params_phase_fence_barrier_1);
-                    PTO2TaskId seed_dummy_inline49 = phase_fence_barrier_1_outs.task_id();
-                    PTO2TaskId prev_normed_seed_deps_inline120[2];
+                    TaskId seed_dummy_inline49 = phase_fence_barrier_1_outs.task_id();
+                    TaskId prev_normed_seed_deps_inline120[2];
                     for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                        prev_normed_seed_deps_inline120[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v7 = prev_normed_tid[0];
+                        prev_normed_seed_deps_inline120[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v7 = prev_normed_tid[0];
                     prev_normed_seed_deps_inline120[0] = t__tmp_v7;
                     prev_normed_seed_deps_inline120[1] = seed_dummy_inline49;
 
@@ -246,20 +246,20 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t3.add_input(attn_out_inline282);
                     params_t3.set_allow_early_resolve(true);
                     TaskOutputTensors task_3_outs = rt_submit_aiv_task(3, params_t3);
-                    PTO2TaskId attn_out_seed_tid_inline116 = task_3_outs.task_id();
-                    PTO2TaskId _submit_deps_buf_inline42[2];
+                    TaskId attn_out_seed_tid_inline116 = task_3_outs.task_id();
+                    TaskId _submit_deps_buf_inline42[2];
                     for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                        _submit_deps_buf_inline42[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v8 = prev_normed_seed_deps_inline120[0];
+                        _submit_deps_buf_inline42[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v8 = prev_normed_seed_deps_inline120[0];
                     _submit_deps_buf_inline42[0] = t__tmp_v8;
-                    PTO2TaskId t__tmp_v9 = prev_normed_seed_deps_inline120[1];
+                    TaskId t__tmp_v9 = prev_normed_seed_deps_inline120[1];
                     _submit_deps_buf_inline42[1] = t__tmp_v9;
 
                     // Task 4: rms_recip
                     CoreTaskArgs params_t4;
                     params_t4.add_input(cur__rv_v7);
                     params_t4.add_inout(inv_rms_states_inline176);
-                    PTO2TaskId params_t4_deps[2];
+                    TaskId params_t4_deps[2];
                     uint32_t params_t4_deps_count = 0;
                     if (_submit_deps_buf_inline42[0].is_valid())
                         params_t4_deps[params_t4_deps_count++] = _submit_deps_buf_inline42[0];
@@ -268,26 +268,26 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t4.set_dependencies(params_t4_deps, params_t4_deps_count);
                     params_t4.set_allow_early_resolve(true);
                     TaskOutputTensors task_4_outs = rt_submit_aiv_task(4, params_t4);
-                    PTO2TaskId rms_tid_inline148 = task_4_outs.task_id();
+                    TaskId rms_tid_inline148 = task_4_outs.task_id();
 
                     // Task 5: q_seed
                     CoreTaskArgs params_t5;
                     params_t5.add_inout(q_proj_inline139);
                     params_t5.set_allow_early_resolve(true);
                     TaskOutputTensors task_5_outs = rt_submit_aiv_task(5, params_t5);
-                    PTO2TaskId q_seed_tid_inline162 = task_5_outs.task_id();
-                    PTO2TaskId prev_normed_q_deps_inline105[2];
+                    TaskId q_seed_tid_inline162 = task_5_outs.task_id();
+                    TaskId prev_normed_q_deps_inline105[2];
                     for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                        prev_normed_q_deps_inline105[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v17 = prev_normed_tid[0];
+                        prev_normed_q_deps_inline105[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v17 = prev_normed_tid[0];
                     prev_normed_q_deps_inline105[0] = t__tmp_v17;
                     prev_normed_q_deps_inline105[1] = q_seed_tid_inline162;
-                    PTO2TaskId _submit_deps_buf_inline182[2];
+                    TaskId _submit_deps_buf_inline182[2];
                     for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                        _submit_deps_buf_inline182[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v18 = prev_normed_q_deps_inline105[0];
+                        _submit_deps_buf_inline182[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v18 = prev_normed_q_deps_inline105[0];
                     _submit_deps_buf_inline182[0] = t__tmp_v18;
-                    PTO2TaskId t__tmp_v19 = prev_normed_q_deps_inline105[1];
+                    TaskId t__tmp_v19 = prev_normed_q_deps_inline105[1];
                     _submit_deps_buf_inline182[1] = t__tmp_v19;
 
                     // Spmd q_proj_spmd: q_proj
@@ -298,7 +298,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t6.add_scalar(layer_hidden_base_inline151);
                     params_t6.launch_spec.set_core_num(50);
                     params_t6.set_allow_early_resolve(true);
-                    PTO2TaskId params_t6_deps[2];
+                    TaskId params_t6_deps[2];
                     uint32_t params_t6_deps_count = 0;
                     if (_submit_deps_buf_inline182[0].is_valid())
                         params_t6_deps[params_t6_deps_count++] = _submit_deps_buf_inline182[0];
@@ -306,20 +306,20 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t6_deps[params_t6_deps_count++] = _submit_deps_buf_inline182[1];
                     params_t6.set_dependencies(params_t6_deps, params_t6_deps_count);
                     TaskOutputTensors task_6_outs = rt_submit_aic_task(6, params_t6);
-                    PTO2TaskId q_proj_tid_inline183 = task_6_outs.task_id();
-                    PTO2TaskId _submit_deps_buf_inline261[2];
+                    TaskId q_proj_tid_inline183 = task_6_outs.task_id();
+                    TaskId _submit_deps_buf_inline261[2];
                     for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                        _submit_deps_buf_inline261[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v24 = prev_normed_seed_deps_inline120[0];
+                        _submit_deps_buf_inline261[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v24 = prev_normed_seed_deps_inline120[0];
                     _submit_deps_buf_inline261[0] = t__tmp_v24;
-                    PTO2TaskId t__tmp_v25 = prev_normed_seed_deps_inline120[1];
+                    TaskId t__tmp_v25 = prev_normed_seed_deps_inline120[1];
                     _submit_deps_buf_inline261[1] = t__tmp_v25;
 
                     // Task 7: kv_seed
                     CoreTaskArgs params_t7;
                     params_t7.add_inout(k_proj_inline135);
                     params_t7.add_inout(v_proj_inline255);
-                    PTO2TaskId params_t7_deps[2];
+                    TaskId params_t7_deps[2];
                     uint32_t params_t7_deps_count = 0;
                     if (_submit_deps_buf_inline261[0].is_valid())
                         params_t7_deps[params_t7_deps_count++] = _submit_deps_buf_inline261[0];
@@ -327,13 +327,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t7_deps[params_t7_deps_count++] = _submit_deps_buf_inline261[1];
                     params_t7.set_dependencies(params_t7_deps, params_t7_deps_count);
                     TaskOutputTensors task_7_outs = rt_submit_aiv_task(7, params_t7);
-                    PTO2TaskId kv_seed_tid_inline238 = task_7_outs.task_id();
-                    PTO2TaskId _submit_deps_buf_inline267[2];
+                    TaskId kv_seed_tid_inline238 = task_7_outs.task_id();
+                    TaskId _submit_deps_buf_inline267[2];
                     for (int64_t __init_i = 0; __init_i < 2; ++__init_i)
-                        _submit_deps_buf_inline267[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v28 = prev_normed_seed_deps_inline120[0];
+                        _submit_deps_buf_inline267[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v28 = prev_normed_seed_deps_inline120[0];
                     _submit_deps_buf_inline267[0] = t__tmp_v28;
-                    PTO2TaskId t__tmp_v29 = prev_normed_seed_deps_inline120[1];
+                    TaskId t__tmp_v29 = prev_normed_seed_deps_inline120[1];
                     _submit_deps_buf_inline267[1] = t__tmp_v29;
 
                     // Task 8: mlp_out_seed
@@ -342,7 +342,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t8.add_inout(gate_acc_all_inline203);
                     params_t8.add_inout(up_acc_all_inline303);
                     params_t8.add_inout(attn_proj_fp32_inline220);
-                    PTO2TaskId params_t8_deps[2];
+                    TaskId params_t8_deps[2];
                     uint32_t params_t8_deps_count = 0;
                     if (_submit_deps_buf_inline267[0].is_valid())
                         params_t8_deps[params_t8_deps_count++] = _submit_deps_buf_inline267[0];
@@ -351,7 +351,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t8.set_dependencies(params_t8_deps, params_t8_deps_count);
                     params_t8.set_allow_early_resolve(true);
                     TaskOutputTensors task_8_outs = rt_submit_aiv_task(8, params_t8);
-                    PTO2TaskId mlp_out_seed_tid_inline206 = task_8_outs.task_id();
+                    TaskId mlp_out_seed_tid_inline206 = task_8_outs.task_id();
 
                     // Spmd k_proj_spmd: k_proj
                     CoreTaskArgs params_t9;
@@ -361,12 +361,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t9.add_scalar(layer_hidden_base_inline151);
                     params_t9.launch_spec.set_core_num(10);
                     params_t9.set_allow_early_resolve(true);
-                    PTO2TaskId params_t9_deps[1];
+                    TaskId params_t9_deps[1];
                     uint32_t params_t9_deps_count = 0;
                     params_t9_deps[params_t9_deps_count++] = kv_seed_tid_inline238;
                     params_t9.set_dependencies(params_t9_deps, params_t9_deps_count);
                     TaskOutputTensors task_9_outs = rt_submit_aic_task(9, params_t9);
-                    PTO2TaskId k_proj_tid_inline136 = task_9_outs.task_id();
+                    TaskId k_proj_tid_inline136 = task_9_outs.task_id();
 
                     // Spmd v_proj_spmd: v_proj
                     CoreTaskArgs params_t10;
@@ -376,12 +376,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t10.add_scalar(layer_hidden_base_inline151);
                     params_t10.launch_spec.set_core_num(10);
                     params_t10.set_allow_early_resolve(true);
-                    PTO2TaskId params_t10_deps[1];
+                    TaskId params_t10_deps[1];
                     uint32_t params_t10_deps_count = 0;
                     params_t10_deps[params_t10_deps_count++] = kv_seed_tid_inline238;
                     params_t10.set_dependencies(params_t10_deps, params_t10_deps_count);
                     TaskOutputTensors task_10_outs = rt_submit_aic_task(10, params_t10);
-                    PTO2TaskId v_proj_tid_inline63 = task_10_outs.task_id();
+                    TaskId v_proj_tid_inline63 = task_10_outs.task_id();
                     uint32_t q_tnd_inline191_shapes[3] = {16, 40, 128};
                     ChipTensor q_tnd_inline191 = q_tnd_flat_inline127.reshape(q_tnd_inline191_shapes, 3);
                     uint32_t attn_out_tnd_inline79_shapes[3] = {16, 40, 128};
@@ -412,7 +412,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t11.launch_spec.set_core_num(attention_core_num_inline188);
                     params_t11.launch_spec.set_require_sync_start(true);
                     params_t11.set_allow_early_resolve(true);
-                    PTO2TaskId params_t11_deps[7];
+                    TaskId params_t11_deps[7];
                     uint32_t params_t11_deps_count = 0;
                     params_t11_deps[params_t11_deps_count++] = q_proj_tid_inline183;
                     params_t11_deps[params_t11_deps_count++] = k_proj_tid_inline136;
@@ -424,42 +424,42 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t11.set_dependencies(params_t11_deps, params_t11_deps_count);
                     TaskOutputTensors task_11_outs = rt_submit_task(mixed_11, params_t11);
                     const ChipTensor &attn_out_tnd_inline79__ssa_v1 = attn_out_tnd_inline79;
-                    PTO2TaskId attn_done_tid_inline78 = task_11_outs.task_id();
+                    TaskId attn_done_tid_inline78 = task_11_outs.task_id();
                     uint32_t attn_out_inline282__ssa_v4_shapes[2] = {16, 5120};
                     ChipTensor attn_out_inline282__ssa_v4 =
                         attn_out_tnd_inline79__ssa_v1.reshape(attn_out_inline282__ssa_v4_shapes, 2);
-                    PTO2TaskId silu_tids_inline265[17];
+                    TaskId silu_tids_inline265[17];
                     for (int64_t __init_i = 0; __init_i < 17; ++__init_i)
-                        silu_tids_inline265[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId gate_tids_inline56[85];
+                        silu_tids_inline265[__init_i] = TaskId::invalid();
+                    TaskId gate_tids_inline56[85];
                     for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
-                        gate_tids_inline56[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId up_tids_inline310[85];
+                        gate_tids_inline56[__init_i] = TaskId::invalid();
+                    TaskId up_tids_inline310[85];
                     for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
-                        up_tids_inline310[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId cast_tids_inline88[5];
+                        up_tids_inline310[__init_i] = TaskId::invalid();
+                    TaskId cast_tids_inline88[5];
                     for (int64_t __init_i = 0; __init_i < 5; ++__init_i)
-                        cast_tids_inline88[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId gate_late_tids_inline249[5];
+                        cast_tids_inline88[__init_i] = TaskId::invalid();
+                    TaskId gate_late_tids_inline249[5];
                     for (int64_t __init_i = 0; __init_i < 5; ++__init_i)
-                        gate_late_tids_inline249[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId up_late_tids_inline69[5];
+                        gate_late_tids_inline249[__init_i] = TaskId::invalid();
+                    TaskId up_late_tids_inline69[5];
                     for (int64_t __init_i = 0; __init_i < 5; ++__init_i)
-                        up_late_tids_inline69[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId out_tids_inline271[50];
+                        up_late_tids_inline69[__init_i] = TaskId::invalid();
+                    TaskId out_tids_inline271[50];
                     for (int64_t __init_i = 0; __init_i < 50; ++__init_i)
-                        out_tids_inline271[__init_i] = PTO2TaskId::invalid();
+                        out_tids_inline271[__init_i] = TaskId::invalid();
 
                     // Phase-fence barrier 2: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_2;
-                    PTO2TaskId params_phase_fence_barrier_2_deps[1];
+                    TaskId params_phase_fence_barrier_2_deps[1];
                     uint32_t params_phase_fence_barrier_2_deps_count = 0;
                     params_phase_fence_barrier_2_deps[params_phase_fence_barrier_2_deps_count++] =
                         attn_done_tid_inline78;
                     params_phase_fence_barrier_2.set_dependencies(
                         params_phase_fence_barrier_2_deps, params_phase_fence_barrier_2_deps_count
                     );
-                    PTO2TaskId out_proj_dummy_inline257 = PTO2TaskId::invalid();
+                    TaskId out_proj_dummy_inline257 = TaskId::invalid();
                     if (params_phase_fence_barrier_2_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_2_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_2);
@@ -481,13 +481,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t12.add_scalar(k_op_inline266);
                         params_t12.add_scalar(layer_hidden_base_inline151);
                         params_t12.add_scalar(n_op_inline64);
-                        PTO2TaskId params_t12_deps[1];
+                        TaskId params_t12_deps[1];
                         uint32_t params_t12_deps_count = 0;
                         if (out_proj_dummy_inline257.is_valid())
                             params_t12_deps[params_t12_deps_count++] = out_proj_dummy_inline257;
                         params_t12.set_dependencies(params_t12_deps, params_t12_deps_count);
                         TaskOutputTensors task_12_outs = rt_submit_aic_task(13, params_t12);
-                        PTO2TaskId out_tid_inline141 = task_12_outs.task_id();
+                        TaskId out_tid_inline141 = task_12_outs.task_id();
                         out_tids_inline271[out_idx_inline74] = out_tid_inline141;
                     }
 
@@ -499,12 +499,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t13.add_scalar(N_OUT_DIRECT_inline61);
                     params_t13.add_scalar(layer_hidden_base_inline151);
                     params_t13.launch_spec.set_core_num(24);
-                    PTO2TaskId params_t13_deps[1];
+                    TaskId params_t13_deps[1];
                     uint32_t params_t13_deps_count = 0;
                     params_t13_deps[params_t13_deps_count++] = attn_done_tid_inline78;
                     params_t13.set_dependencies(params_t13_deps, params_t13_deps_count);
                     TaskOutputTensors task_13_outs = rt_submit_aic_task(14, params_t13);
-                    PTO2TaskId out_proj_direct_tid_inline70 = task_13_outs.task_id();
+                    TaskId out_proj_direct_tid_inline70 = task_13_outs.task_id();
                     out_tids_inline271[N_OUT_DIRECT_inline61] = out_proj_direct_tid_inline70;
                     out_tids_inline271[(N_OUT_DIRECT_inline61 + 1)] = out_proj_direct_tid_inline70;
                     out_tids_inline271[(N_OUT_DIRECT_inline61 + 2)] = out_proj_direct_tid_inline70;
@@ -531,28 +531,28 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     out_tids_inline271[(N_OUT_DIRECT_inline61 + 23)] = out_proj_direct_tid_inline70;
                     int64_t k_base_inline111 = 0;
                     int64_t n_split_base_inline163 = 0;
-                    PTO2TaskId _submit_deps_buf_inline165[10];
+                    TaskId _submit_deps_buf_inline165[10];
                     for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                        _submit_deps_buf_inline165[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v39 = out_tids_inline271[(n_split_base_inline163 * 5)];
+                        _submit_deps_buf_inline165[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v39 = out_tids_inline271[(n_split_base_inline163 * 5)];
                     _submit_deps_buf_inline165[0] = t__tmp_v39;
-                    PTO2TaskId t__tmp_v40 = out_tids_inline271[((n_split_base_inline163 * 5) + 1)];
+                    TaskId t__tmp_v40 = out_tids_inline271[((n_split_base_inline163 * 5) + 1)];
                     _submit_deps_buf_inline165[1] = t__tmp_v40;
-                    PTO2TaskId t__tmp_v41 = out_tids_inline271[((n_split_base_inline163 * 5) + 2)];
+                    TaskId t__tmp_v41 = out_tids_inline271[((n_split_base_inline163 * 5) + 2)];
                     _submit_deps_buf_inline165[2] = t__tmp_v41;
-                    PTO2TaskId t__tmp_v42 = out_tids_inline271[((n_split_base_inline163 * 5) + 3)];
+                    TaskId t__tmp_v42 = out_tids_inline271[((n_split_base_inline163 * 5) + 3)];
                     _submit_deps_buf_inline165[3] = t__tmp_v42;
-                    PTO2TaskId t__tmp_v43 = out_tids_inline271[((n_split_base_inline163 * 5) + 4)];
+                    TaskId t__tmp_v43 = out_tids_inline271[((n_split_base_inline163 * 5) + 4)];
                     _submit_deps_buf_inline165[4] = t__tmp_v43;
-                    PTO2TaskId t__tmp_v44 = out_tids_inline271[((n_split_base_inline163 * 5) + 5)];
+                    TaskId t__tmp_v44 = out_tids_inline271[((n_split_base_inline163 * 5) + 5)];
                     _submit_deps_buf_inline165[5] = t__tmp_v44;
-                    PTO2TaskId t__tmp_v45 = out_tids_inline271[((n_split_base_inline163 * 5) + 6)];
+                    TaskId t__tmp_v45 = out_tids_inline271[((n_split_base_inline163 * 5) + 6)];
                     _submit_deps_buf_inline165[6] = t__tmp_v45;
-                    PTO2TaskId t__tmp_v46 = out_tids_inline271[((n_split_base_inline163 * 5) + 7)];
+                    TaskId t__tmp_v46 = out_tids_inline271[((n_split_base_inline163 * 5) + 7)];
                     _submit_deps_buf_inline165[7] = t__tmp_v46;
-                    PTO2TaskId t__tmp_v47 = out_tids_inline271[((n_split_base_inline163 * 5) + 8)];
+                    TaskId t__tmp_v47 = out_tids_inline271[((n_split_base_inline163 * 5) + 8)];
                     _submit_deps_buf_inline165[8] = t__tmp_v47;
-                    PTO2TaskId t__tmp_v48 = out_tids_inline271[((n_split_base_inline163 * 5) + 9)];
+                    TaskId t__tmp_v48 = out_tids_inline271[((n_split_base_inline163 * 5) + 9)];
                     _submit_deps_buf_inline165[9] = t__tmp_v48;
 
                     // Task 14: residual_rms_cast
@@ -564,7 +564,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t14.add_input(ext_post_rms_weight);
                     params_t14.add_scalar(k_base_inline111);
                     params_t14.add_scalar(i);
-                    PTO2TaskId params_t14_deps[10];
+                    TaskId params_t14_deps[10];
                     uint32_t params_t14_deps_count = 0;
                     if (_submit_deps_buf_inline165[0].is_valid())
                         params_t14_deps[params_t14_deps_count++] = _submit_deps_buf_inline165[0];
@@ -589,32 +589,32 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t14.set_dependencies(params_t14_deps, params_t14_deps_count);
                     params_t14.set_allow_early_resolve(true);
                     TaskOutputTensors task_14_outs = rt_submit_aiv_task(15, params_t14);
-                    PTO2TaskId cast_tid_k_inline76 = task_14_outs.task_id();
+                    TaskId cast_tid_k_inline76 = task_14_outs.task_id();
                     cast_tids_inline88[0] = cast_tid_k_inline76;
                     int64_t k_base_inline111__ssa_v1 = 1024;
                     int64_t n_split_base_inline163__ssa_v1 = 2;
-                    PTO2TaskId _submit_deps_buf_inline165__ssa_v1[10];
+                    TaskId _submit_deps_buf_inline165__ssa_v1[10];
                     for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                        _submit_deps_buf_inline165__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v51 = out_tids_inline271[(n_split_base_inline163__ssa_v1 * 5)];
+                        _submit_deps_buf_inline165__ssa_v1[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v51 = out_tids_inline271[(n_split_base_inline163__ssa_v1 * 5)];
                     _submit_deps_buf_inline165__ssa_v1[0] = t__tmp_v51;
-                    PTO2TaskId t__tmp_v52 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 1)];
+                    TaskId t__tmp_v52 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 1)];
                     _submit_deps_buf_inline165__ssa_v1[1] = t__tmp_v52;
-                    PTO2TaskId t__tmp_v53 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 2)];
+                    TaskId t__tmp_v53 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 2)];
                     _submit_deps_buf_inline165__ssa_v1[2] = t__tmp_v53;
-                    PTO2TaskId t__tmp_v54 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 3)];
+                    TaskId t__tmp_v54 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 3)];
                     _submit_deps_buf_inline165__ssa_v1[3] = t__tmp_v54;
-                    PTO2TaskId t__tmp_v55 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 4)];
+                    TaskId t__tmp_v55 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 4)];
                     _submit_deps_buf_inline165__ssa_v1[4] = t__tmp_v55;
-                    PTO2TaskId t__tmp_v56 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 5)];
+                    TaskId t__tmp_v56 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 5)];
                     _submit_deps_buf_inline165__ssa_v1[5] = t__tmp_v56;
-                    PTO2TaskId t__tmp_v57 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 6)];
+                    TaskId t__tmp_v57 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 6)];
                     _submit_deps_buf_inline165__ssa_v1[6] = t__tmp_v57;
-                    PTO2TaskId t__tmp_v58 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 7)];
+                    TaskId t__tmp_v58 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 7)];
                     _submit_deps_buf_inline165__ssa_v1[7] = t__tmp_v58;
-                    PTO2TaskId t__tmp_v59 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 8)];
+                    TaskId t__tmp_v59 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 8)];
                     _submit_deps_buf_inline165__ssa_v1[8] = t__tmp_v59;
-                    PTO2TaskId t__tmp_v60 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 9)];
+                    TaskId t__tmp_v60 = out_tids_inline271[((n_split_base_inline163__ssa_v1 * 5) + 9)];
                     _submit_deps_buf_inline165__ssa_v1[9] = t__tmp_v60;
 
                     // Task 15: residual_rms_cast_0
@@ -626,7 +626,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t15.add_input(ext_post_rms_weight);
                     params_t15.add_scalar(k_base_inline111__ssa_v1);
                     params_t15.add_scalar(i);
-                    PTO2TaskId params_t15_deps[10];
+                    TaskId params_t15_deps[10];
                     uint32_t params_t15_deps_count = 0;
                     if (_submit_deps_buf_inline165__ssa_v1[0].is_valid())
                         params_t15_deps[params_t15_deps_count++] = _submit_deps_buf_inline165__ssa_v1[0];
@@ -651,32 +651,32 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t15.set_dependencies(params_t15_deps, params_t15_deps_count);
                     params_t15.set_allow_early_resolve(true);
                     TaskOutputTensors task_15_outs = rt_submit_aiv_task(16, params_t15);
-                    PTO2TaskId cast_tid_k_inline76__ssa_v1 = task_15_outs.task_id();
+                    TaskId cast_tid_k_inline76__ssa_v1 = task_15_outs.task_id();
                     cast_tids_inline88[1] = cast_tid_k_inline76__ssa_v1;
                     int64_t k_base_inline111__ssa_v2 = 2048;
                     int64_t n_split_base_inline163__ssa_v2 = 4;
-                    PTO2TaskId _submit_deps_buf_inline165__ssa_v2[10];
+                    TaskId _submit_deps_buf_inline165__ssa_v2[10];
                     for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                        _submit_deps_buf_inline165__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v63 = out_tids_inline271[(n_split_base_inline163__ssa_v2 * 5)];
+                        _submit_deps_buf_inline165__ssa_v2[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v63 = out_tids_inline271[(n_split_base_inline163__ssa_v2 * 5)];
                     _submit_deps_buf_inline165__ssa_v2[0] = t__tmp_v63;
-                    PTO2TaskId t__tmp_v64 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 1)];
+                    TaskId t__tmp_v64 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 1)];
                     _submit_deps_buf_inline165__ssa_v2[1] = t__tmp_v64;
-                    PTO2TaskId t__tmp_v65 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 2)];
+                    TaskId t__tmp_v65 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 2)];
                     _submit_deps_buf_inline165__ssa_v2[2] = t__tmp_v65;
-                    PTO2TaskId t__tmp_v66 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 3)];
+                    TaskId t__tmp_v66 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 3)];
                     _submit_deps_buf_inline165__ssa_v2[3] = t__tmp_v66;
-                    PTO2TaskId t__tmp_v67 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 4)];
+                    TaskId t__tmp_v67 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 4)];
                     _submit_deps_buf_inline165__ssa_v2[4] = t__tmp_v67;
-                    PTO2TaskId t__tmp_v68 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 5)];
+                    TaskId t__tmp_v68 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 5)];
                     _submit_deps_buf_inline165__ssa_v2[5] = t__tmp_v68;
-                    PTO2TaskId t__tmp_v69 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 6)];
+                    TaskId t__tmp_v69 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 6)];
                     _submit_deps_buf_inline165__ssa_v2[6] = t__tmp_v69;
-                    PTO2TaskId t__tmp_v70 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 7)];
+                    TaskId t__tmp_v70 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 7)];
                     _submit_deps_buf_inline165__ssa_v2[7] = t__tmp_v70;
-                    PTO2TaskId t__tmp_v71 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 8)];
+                    TaskId t__tmp_v71 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 8)];
                     _submit_deps_buf_inline165__ssa_v2[8] = t__tmp_v71;
-                    PTO2TaskId t__tmp_v72 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 9)];
+                    TaskId t__tmp_v72 = out_tids_inline271[((n_split_base_inline163__ssa_v2 * 5) + 9)];
                     _submit_deps_buf_inline165__ssa_v2[9] = t__tmp_v72;
 
                     // Task 16: residual_rms_cast_1
@@ -688,7 +688,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t16.add_input(ext_post_rms_weight);
                     params_t16.add_scalar(k_base_inline111__ssa_v2);
                     params_t16.add_scalar(i);
-                    PTO2TaskId params_t16_deps[10];
+                    TaskId params_t16_deps[10];
                     uint32_t params_t16_deps_count = 0;
                     if (_submit_deps_buf_inline165__ssa_v2[0].is_valid())
                         params_t16_deps[params_t16_deps_count++] = _submit_deps_buf_inline165__ssa_v2[0];
@@ -713,32 +713,32 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t16.set_dependencies(params_t16_deps, params_t16_deps_count);
                     params_t16.set_allow_early_resolve(true);
                     TaskOutputTensors task_16_outs = rt_submit_aiv_task(17, params_t16);
-                    PTO2TaskId cast_tid_k_inline76__ssa_v2 = task_16_outs.task_id();
+                    TaskId cast_tid_k_inline76__ssa_v2 = task_16_outs.task_id();
                     cast_tids_inline88[2] = cast_tid_k_inline76__ssa_v2;
                     int64_t k_base_inline111__ssa_v3 = 3072;
                     int64_t n_split_base_inline163__ssa_v3 = 6;
-                    PTO2TaskId _submit_deps_buf_inline165__ssa_v3[10];
+                    TaskId _submit_deps_buf_inline165__ssa_v3[10];
                     for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                        _submit_deps_buf_inline165__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v75 = out_tids_inline271[(n_split_base_inline163__ssa_v3 * 5)];
+                        _submit_deps_buf_inline165__ssa_v3[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v75 = out_tids_inline271[(n_split_base_inline163__ssa_v3 * 5)];
                     _submit_deps_buf_inline165__ssa_v3[0] = t__tmp_v75;
-                    PTO2TaskId t__tmp_v76 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 1)];
+                    TaskId t__tmp_v76 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 1)];
                     _submit_deps_buf_inline165__ssa_v3[1] = t__tmp_v76;
-                    PTO2TaskId t__tmp_v77 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 2)];
+                    TaskId t__tmp_v77 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 2)];
                     _submit_deps_buf_inline165__ssa_v3[2] = t__tmp_v77;
-                    PTO2TaskId t__tmp_v78 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 3)];
+                    TaskId t__tmp_v78 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 3)];
                     _submit_deps_buf_inline165__ssa_v3[3] = t__tmp_v78;
-                    PTO2TaskId t__tmp_v79 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 4)];
+                    TaskId t__tmp_v79 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 4)];
                     _submit_deps_buf_inline165__ssa_v3[4] = t__tmp_v79;
-                    PTO2TaskId t__tmp_v80 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 5)];
+                    TaskId t__tmp_v80 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 5)];
                     _submit_deps_buf_inline165__ssa_v3[5] = t__tmp_v80;
-                    PTO2TaskId t__tmp_v81 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 6)];
+                    TaskId t__tmp_v81 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 6)];
                     _submit_deps_buf_inline165__ssa_v3[6] = t__tmp_v81;
-                    PTO2TaskId t__tmp_v82 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 7)];
+                    TaskId t__tmp_v82 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 7)];
                     _submit_deps_buf_inline165__ssa_v3[7] = t__tmp_v82;
-                    PTO2TaskId t__tmp_v83 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 8)];
+                    TaskId t__tmp_v83 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 8)];
                     _submit_deps_buf_inline165__ssa_v3[8] = t__tmp_v83;
-                    PTO2TaskId t__tmp_v84 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 9)];
+                    TaskId t__tmp_v84 = out_tids_inline271[((n_split_base_inline163__ssa_v3 * 5) + 9)];
                     _submit_deps_buf_inline165__ssa_v3[9] = t__tmp_v84;
 
                     // Task 17: residual_rms_cast_2
@@ -750,7 +750,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t17.add_input(ext_post_rms_weight);
                     params_t17.add_scalar(k_base_inline111__ssa_v3);
                     params_t17.add_scalar(i);
-                    PTO2TaskId params_t17_deps[10];
+                    TaskId params_t17_deps[10];
                     uint32_t params_t17_deps_count = 0;
                     if (_submit_deps_buf_inline165__ssa_v3[0].is_valid())
                         params_t17_deps[params_t17_deps_count++] = _submit_deps_buf_inline165__ssa_v3[0];
@@ -775,32 +775,32 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t17.set_dependencies(params_t17_deps, params_t17_deps_count);
                     params_t17.set_allow_early_resolve(true);
                     TaskOutputTensors task_17_outs = rt_submit_aiv_task(18, params_t17);
-                    PTO2TaskId cast_tid_k_inline76__ssa_v3 = task_17_outs.task_id();
+                    TaskId cast_tid_k_inline76__ssa_v3 = task_17_outs.task_id();
                     cast_tids_inline88[3] = cast_tid_k_inline76__ssa_v3;
                     int64_t k_base_inline111__ssa_v4 = 4096;
                     int64_t n_split_base_inline163__ssa_v4 = 8;
-                    PTO2TaskId _submit_deps_buf_inline165__ssa_v4[10];
+                    TaskId _submit_deps_buf_inline165__ssa_v4[10];
                     for (int64_t __init_i = 0; __init_i < 10; ++__init_i)
-                        _submit_deps_buf_inline165__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v87 = out_tids_inline271[(n_split_base_inline163__ssa_v4 * 5)];
+                        _submit_deps_buf_inline165__ssa_v4[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v87 = out_tids_inline271[(n_split_base_inline163__ssa_v4 * 5)];
                     _submit_deps_buf_inline165__ssa_v4[0] = t__tmp_v87;
-                    PTO2TaskId t__tmp_v88 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 1)];
+                    TaskId t__tmp_v88 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 1)];
                     _submit_deps_buf_inline165__ssa_v4[1] = t__tmp_v88;
-                    PTO2TaskId t__tmp_v89 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 2)];
+                    TaskId t__tmp_v89 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 2)];
                     _submit_deps_buf_inline165__ssa_v4[2] = t__tmp_v89;
-                    PTO2TaskId t__tmp_v90 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 3)];
+                    TaskId t__tmp_v90 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 3)];
                     _submit_deps_buf_inline165__ssa_v4[3] = t__tmp_v90;
-                    PTO2TaskId t__tmp_v91 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 4)];
+                    TaskId t__tmp_v91 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 4)];
                     _submit_deps_buf_inline165__ssa_v4[4] = t__tmp_v91;
-                    PTO2TaskId t__tmp_v92 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 5)];
+                    TaskId t__tmp_v92 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 5)];
                     _submit_deps_buf_inline165__ssa_v4[5] = t__tmp_v92;
-                    PTO2TaskId t__tmp_v93 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 6)];
+                    TaskId t__tmp_v93 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 6)];
                     _submit_deps_buf_inline165__ssa_v4[6] = t__tmp_v93;
-                    PTO2TaskId t__tmp_v94 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 7)];
+                    TaskId t__tmp_v94 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 7)];
                     _submit_deps_buf_inline165__ssa_v4[7] = t__tmp_v94;
-                    PTO2TaskId t__tmp_v95 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 8)];
+                    TaskId t__tmp_v95 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 8)];
                     _submit_deps_buf_inline165__ssa_v4[8] = t__tmp_v95;
-                    PTO2TaskId t__tmp_v96 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 9)];
+                    TaskId t__tmp_v96 = out_tids_inline271[((n_split_base_inline163__ssa_v4 * 5) + 9)];
                     _submit_deps_buf_inline165__ssa_v4[9] = t__tmp_v96;
 
                     // Task 18: residual_rms_cast_3
@@ -812,7 +812,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t18.add_input(ext_post_rms_weight);
                     params_t18.add_scalar(k_base_inline111__ssa_v4);
                     params_t18.add_scalar(i);
-                    PTO2TaskId params_t18_deps[10];
+                    TaskId params_t18_deps[10];
                     uint32_t params_t18_deps_count = 0;
                     if (_submit_deps_buf_inline165__ssa_v4[0].is_valid())
                         params_t18_deps[params_t18_deps_count++] = _submit_deps_buf_inline165__ssa_v4[0];
@@ -837,7 +837,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t18.set_dependencies(params_t18_deps, params_t18_deps_count);
                     params_t18.set_allow_early_resolve(true);
                     TaskOutputTensors task_18_outs = rt_submit_aiv_task(19, params_t18);
-                    PTO2TaskId cast_tid_k_inline76__ssa_v4 = task_18_outs.task_id();
+                    TaskId cast_tid_k_inline76__ssa_v4 = task_18_outs.task_id();
                     cast_tids_inline88[4] = cast_tid_k_inline76__ssa_v4;
 
                     // Task 19: post_rms_reduce
@@ -845,7 +845,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t19.add_input(attn_proj_fp32_inline220);
                     params_t19.add_input(cur__rv_v7);
                     params_t19.add_inout(inv_rms_tile_inline126);
-                    PTO2TaskId params_t19_deps[50];
+                    TaskId params_t19_deps[50];
                     uint32_t params_t19_deps_count = 0;
                     if (out_tids_inline271[0].is_valid())
                         params_t19_deps[params_t19_deps_count++] = out_tids_inline271[0];
@@ -949,17 +949,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t19_deps[params_t19_deps_count++] = out_tids_inline271[49];
                     params_t19.set_dependencies(params_t19_deps, params_t19_deps_count);
                     TaskOutputTensors task_19_outs = rt_submit_aiv_task(20, params_t19);
-                    PTO2TaskId reduce_tid_inline226 = task_19_outs.task_id();
+                    TaskId reduce_tid_inline226 = task_19_outs.task_id();
                     int64_t gu_k0_inline131 = 0;
-                    PTO2TaskId _submit_deps_buf_inline236[1];
+                    TaskId _submit_deps_buf_inline236[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline236[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v105 = cast_tids_inline88[0];
+                        _submit_deps_buf_inline236[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v105 = cast_tids_inline88[0];
                     _submit_deps_buf_inline236[0] = t__tmp_v105;
 
                     // Phase-fence barrier 3: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_3;
-                    PTO2TaskId params_phase_fence_barrier_3_deps[1];
+                    TaskId params_phase_fence_barrier_3_deps[1];
                     uint32_t params_phase_fence_barrier_3_deps_count = 0;
                     if (_submit_deps_buf_inline236[0].is_valid())
                         params_phase_fence_barrier_3_deps[params_phase_fence_barrier_3_deps_count++] =
@@ -967,22 +967,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_3.set_dependencies(
                         params_phase_fence_barrier_3_deps, params_phase_fence_barrier_3_deps_count
                     );
-                    PTO2TaskId t__tmp_v106 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v106 = TaskId::invalid();
                     if (params_phase_fence_barrier_3_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_3_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_3);
                         t__tmp_v106 = phase_fence_barrier_3_outs.task_id();
                     }
                     gate_late_tids_inline249[0] = t__tmp_v106;
-                    PTO2TaskId _submit_deps_buf_inline225[1];
+                    TaskId _submit_deps_buf_inline225[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline225[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v107 = cast_tids_inline88[0];
+                        _submit_deps_buf_inline225[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v107 = cast_tids_inline88[0];
                     _submit_deps_buf_inline225[0] = t__tmp_v107;
 
                     // Phase-fence barrier 4: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_4;
-                    PTO2TaskId params_phase_fence_barrier_4_deps[1];
+                    TaskId params_phase_fence_barrier_4_deps[1];
                     uint32_t params_phase_fence_barrier_4_deps_count = 0;
                     if (_submit_deps_buf_inline225[0].is_valid())
                         params_phase_fence_barrier_4_deps[params_phase_fence_barrier_4_deps_count++] =
@@ -990,17 +990,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_4.set_dependencies(
                         params_phase_fence_barrier_4_deps, params_phase_fence_barrier_4_deps_count
                     );
-                    PTO2TaskId t__tmp_v108 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v108 = TaskId::invalid();
                     if (params_phase_fence_barrier_4_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_4_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_4);
                         t__tmp_v108 = phase_fence_barrier_4_outs.task_id();
                     }
                     up_late_tids_inline69[0] = t__tmp_v108;
-                    PTO2TaskId _submit_deps_buf_inline237[1];
+                    TaskId _submit_deps_buf_inline237[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline237[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v109 = cast_tids_inline88[0];
+                        _submit_deps_buf_inline237[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v109 = cast_tids_inline88[0];
                     _submit_deps_buf_inline237[0] = t__tmp_v109;
 
                     // Spmd gate_proj_spmd: gate_proj
@@ -1011,23 +1011,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t20.add_scalar(gu_k0_inline131);
                     params_t20.add_scalar(layer_hidden_base_inline151);
                     params_t20.launch_spec.set_core_num(6);
-                    PTO2TaskId params_t20_deps[1];
+                    TaskId params_t20_deps[1];
                     uint32_t params_t20_deps_count = 0;
                     if (_submit_deps_buf_inline237[0].is_valid())
                         params_t20_deps[params_t20_deps_count++] = _submit_deps_buf_inline237[0];
                     params_t20.set_dependencies(params_t20_deps, params_t20_deps_count);
                     TaskOutputTensors task_20_outs = rt_submit_aic_task(21, params_t20);
-                    PTO2TaskId gate_spmd_tid_inline245 = task_20_outs.task_id();
+                    TaskId gate_spmd_tid_inline245 = task_20_outs.task_id();
                     gate_tids_inline56[0] = gate_spmd_tid_inline245;
                     gate_tids_inline56[5] = gate_spmd_tid_inline245;
                     gate_tids_inline56[10] = gate_spmd_tid_inline245;
                     gate_tids_inline56[15] = gate_spmd_tid_inline245;
                     gate_tids_inline56[20] = gate_spmd_tid_inline245;
                     gate_tids_inline56[25] = gate_spmd_tid_inline245;
-                    PTO2TaskId _submit_deps_buf_inline260[1];
+                    TaskId _submit_deps_buf_inline260[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline260[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v110 = cast_tids_inline88[0];
+                        _submit_deps_buf_inline260[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v110 = cast_tids_inline88[0];
                     _submit_deps_buf_inline260[0] = t__tmp_v110;
 
                     // Spmd up_proj_spmd: up_proj
@@ -1038,13 +1038,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t21.add_scalar(gu_k0_inline131);
                     params_t21.add_scalar(layer_hidden_base_inline151);
                     params_t21.launch_spec.set_core_num(6);
-                    PTO2TaskId params_t21_deps[1];
+                    TaskId params_t21_deps[1];
                     uint32_t params_t21_deps_count = 0;
                     if (_submit_deps_buf_inline260[0].is_valid())
                         params_t21_deps[params_t21_deps_count++] = _submit_deps_buf_inline260[0];
                     params_t21.set_dependencies(params_t21_deps, params_t21_deps_count);
                     TaskOutputTensors task_21_outs = rt_submit_aic_task(22, params_t21);
-                    PTO2TaskId up_spmd_tid_inline264 = task_21_outs.task_id();
+                    TaskId up_spmd_tid_inline264 = task_21_outs.task_id();
                     up_tids_inline310[0] = up_spmd_tid_inline264;
                     up_tids_inline310[5] = up_spmd_tid_inline264;
                     up_tids_inline310[10] = up_spmd_tid_inline264;
@@ -1052,15 +1052,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     up_tids_inline310[20] = up_spmd_tid_inline264;
                     up_tids_inline310[25] = up_spmd_tid_inline264;
                     int64_t gu_k0_inline131__ssa_v1 = 1024;
-                    PTO2TaskId _submit_deps_buf_inline236__ssa_v1[1];
+                    TaskId _submit_deps_buf_inline236__ssa_v1[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline236__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v111 = cast_tids_inline88[1];
+                        _submit_deps_buf_inline236__ssa_v1[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v111 = cast_tids_inline88[1];
                     _submit_deps_buf_inline236__ssa_v1[0] = t__tmp_v111;
 
                     // Phase-fence barrier 5: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_5;
-                    PTO2TaskId params_phase_fence_barrier_5_deps[1];
+                    TaskId params_phase_fence_barrier_5_deps[1];
                     uint32_t params_phase_fence_barrier_5_deps_count = 0;
                     if (_submit_deps_buf_inline236__ssa_v1[0].is_valid())
                         params_phase_fence_barrier_5_deps[params_phase_fence_barrier_5_deps_count++] =
@@ -1068,22 +1068,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_5.set_dependencies(
                         params_phase_fence_barrier_5_deps, params_phase_fence_barrier_5_deps_count
                     );
-                    PTO2TaskId t__tmp_v112 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v112 = TaskId::invalid();
                     if (params_phase_fence_barrier_5_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_5_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_5);
                         t__tmp_v112 = phase_fence_barrier_5_outs.task_id();
                     }
                     gate_late_tids_inline249[1] = t__tmp_v112;
-                    PTO2TaskId _submit_deps_buf_inline225__ssa_v1[1];
+                    TaskId _submit_deps_buf_inline225__ssa_v1[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline225__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v113 = cast_tids_inline88[1];
+                        _submit_deps_buf_inline225__ssa_v1[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v113 = cast_tids_inline88[1];
                     _submit_deps_buf_inline225__ssa_v1[0] = t__tmp_v113;
 
                     // Phase-fence barrier 6: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_6;
-                    PTO2TaskId params_phase_fence_barrier_6_deps[1];
+                    TaskId params_phase_fence_barrier_6_deps[1];
                     uint32_t params_phase_fence_barrier_6_deps_count = 0;
                     if (_submit_deps_buf_inline225__ssa_v1[0].is_valid())
                         params_phase_fence_barrier_6_deps[params_phase_fence_barrier_6_deps_count++] =
@@ -1091,17 +1091,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_6.set_dependencies(
                         params_phase_fence_barrier_6_deps, params_phase_fence_barrier_6_deps_count
                     );
-                    PTO2TaskId t__tmp_v114 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v114 = TaskId::invalid();
                     if (params_phase_fence_barrier_6_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_6_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_6);
                         t__tmp_v114 = phase_fence_barrier_6_outs.task_id();
                     }
                     up_late_tids_inline69[1] = t__tmp_v114;
-                    PTO2TaskId _submit_deps_buf_inline237__ssa_v1[1];
+                    TaskId _submit_deps_buf_inline237__ssa_v1[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline237__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v115 = cast_tids_inline88[1];
+                        _submit_deps_buf_inline237__ssa_v1[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v115 = cast_tids_inline88[1];
                     _submit_deps_buf_inline237__ssa_v1[0] = t__tmp_v115;
 
                     // Spmd gate_proj_spmd_0: gate_proj_0
@@ -1112,23 +1112,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t22.add_scalar(gu_k0_inline131__ssa_v1);
                     params_t22.add_scalar(layer_hidden_base_inline151);
                     params_t22.launch_spec.set_core_num(6);
-                    PTO2TaskId params_t22_deps[1];
+                    TaskId params_t22_deps[1];
                     uint32_t params_t22_deps_count = 0;
                     if (_submit_deps_buf_inline237__ssa_v1[0].is_valid())
                         params_t22_deps[params_t22_deps_count++] = _submit_deps_buf_inline237__ssa_v1[0];
                     params_t22.set_dependencies(params_t22_deps, params_t22_deps_count);
                     TaskOutputTensors task_22_outs = rt_submit_aic_task(23, params_t22);
-                    PTO2TaskId gate_spmd_tid_inline245__ssa_v1 = task_22_outs.task_id();
+                    TaskId gate_spmd_tid_inline245__ssa_v1 = task_22_outs.task_id();
                     gate_tids_inline56[1] = gate_spmd_tid_inline245__ssa_v1;
                     gate_tids_inline56[6] = gate_spmd_tid_inline245__ssa_v1;
                     gate_tids_inline56[11] = gate_spmd_tid_inline245__ssa_v1;
                     gate_tids_inline56[16] = gate_spmd_tid_inline245__ssa_v1;
                     gate_tids_inline56[21] = gate_spmd_tid_inline245__ssa_v1;
                     gate_tids_inline56[26] = gate_spmd_tid_inline245__ssa_v1;
-                    PTO2TaskId _submit_deps_buf_inline260__ssa_v1[1];
+                    TaskId _submit_deps_buf_inline260__ssa_v1[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline260__ssa_v1[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v116 = cast_tids_inline88[1];
+                        _submit_deps_buf_inline260__ssa_v1[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v116 = cast_tids_inline88[1];
                     _submit_deps_buf_inline260__ssa_v1[0] = t__tmp_v116;
 
                     // Spmd up_proj_spmd_0: up_proj_0
@@ -1139,13 +1139,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t23.add_scalar(gu_k0_inline131__ssa_v1);
                     params_t23.add_scalar(layer_hidden_base_inline151);
                     params_t23.launch_spec.set_core_num(6);
-                    PTO2TaskId params_t23_deps[1];
+                    TaskId params_t23_deps[1];
                     uint32_t params_t23_deps_count = 0;
                     if (_submit_deps_buf_inline260__ssa_v1[0].is_valid())
                         params_t23_deps[params_t23_deps_count++] = _submit_deps_buf_inline260__ssa_v1[0];
                     params_t23.set_dependencies(params_t23_deps, params_t23_deps_count);
                     TaskOutputTensors task_23_outs = rt_submit_aic_task(24, params_t23);
-                    PTO2TaskId up_spmd_tid_inline264__ssa_v1 = task_23_outs.task_id();
+                    TaskId up_spmd_tid_inline264__ssa_v1 = task_23_outs.task_id();
                     up_tids_inline310[1] = up_spmd_tid_inline264__ssa_v1;
                     up_tids_inline310[6] = up_spmd_tid_inline264__ssa_v1;
                     up_tids_inline310[11] = up_spmd_tid_inline264__ssa_v1;
@@ -1153,15 +1153,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     up_tids_inline310[21] = up_spmd_tid_inline264__ssa_v1;
                     up_tids_inline310[26] = up_spmd_tid_inline264__ssa_v1;
                     int64_t gu_k0_inline131__ssa_v2 = 2048;
-                    PTO2TaskId _submit_deps_buf_inline236__ssa_v2[1];
+                    TaskId _submit_deps_buf_inline236__ssa_v2[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline236__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v117 = cast_tids_inline88[2];
+                        _submit_deps_buf_inline236__ssa_v2[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v117 = cast_tids_inline88[2];
                     _submit_deps_buf_inline236__ssa_v2[0] = t__tmp_v117;
 
                     // Phase-fence barrier 7: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_7;
-                    PTO2TaskId params_phase_fence_barrier_7_deps[1];
+                    TaskId params_phase_fence_barrier_7_deps[1];
                     uint32_t params_phase_fence_barrier_7_deps_count = 0;
                     if (_submit_deps_buf_inline236__ssa_v2[0].is_valid())
                         params_phase_fence_barrier_7_deps[params_phase_fence_barrier_7_deps_count++] =
@@ -1169,22 +1169,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_7.set_dependencies(
                         params_phase_fence_barrier_7_deps, params_phase_fence_barrier_7_deps_count
                     );
-                    PTO2TaskId t__tmp_v118 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v118 = TaskId::invalid();
                     if (params_phase_fence_barrier_7_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_7_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_7);
                         t__tmp_v118 = phase_fence_barrier_7_outs.task_id();
                     }
                     gate_late_tids_inline249[2] = t__tmp_v118;
-                    PTO2TaskId _submit_deps_buf_inline225__ssa_v2[1];
+                    TaskId _submit_deps_buf_inline225__ssa_v2[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline225__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v119 = cast_tids_inline88[2];
+                        _submit_deps_buf_inline225__ssa_v2[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v119 = cast_tids_inline88[2];
                     _submit_deps_buf_inline225__ssa_v2[0] = t__tmp_v119;
 
                     // Phase-fence barrier 8: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_8;
-                    PTO2TaskId params_phase_fence_barrier_8_deps[1];
+                    TaskId params_phase_fence_barrier_8_deps[1];
                     uint32_t params_phase_fence_barrier_8_deps_count = 0;
                     if (_submit_deps_buf_inline225__ssa_v2[0].is_valid())
                         params_phase_fence_barrier_8_deps[params_phase_fence_barrier_8_deps_count++] =
@@ -1192,17 +1192,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_8.set_dependencies(
                         params_phase_fence_barrier_8_deps, params_phase_fence_barrier_8_deps_count
                     );
-                    PTO2TaskId t__tmp_v120 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v120 = TaskId::invalid();
                     if (params_phase_fence_barrier_8_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_8_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_8);
                         t__tmp_v120 = phase_fence_barrier_8_outs.task_id();
                     }
                     up_late_tids_inline69[2] = t__tmp_v120;
-                    PTO2TaskId _submit_deps_buf_inline237__ssa_v2[1];
+                    TaskId _submit_deps_buf_inline237__ssa_v2[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline237__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v121 = cast_tids_inline88[2];
+                        _submit_deps_buf_inline237__ssa_v2[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v121 = cast_tids_inline88[2];
                     _submit_deps_buf_inline237__ssa_v2[0] = t__tmp_v121;
 
                     // Spmd gate_proj_spmd_1: gate_proj_1
@@ -1213,23 +1213,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t24.add_scalar(gu_k0_inline131__ssa_v2);
                     params_t24.add_scalar(layer_hidden_base_inline151);
                     params_t24.launch_spec.set_core_num(6);
-                    PTO2TaskId params_t24_deps[1];
+                    TaskId params_t24_deps[1];
                     uint32_t params_t24_deps_count = 0;
                     if (_submit_deps_buf_inline237__ssa_v2[0].is_valid())
                         params_t24_deps[params_t24_deps_count++] = _submit_deps_buf_inline237__ssa_v2[0];
                     params_t24.set_dependencies(params_t24_deps, params_t24_deps_count);
                     TaskOutputTensors task_24_outs = rt_submit_aic_task(25, params_t24);
-                    PTO2TaskId gate_spmd_tid_inline245__ssa_v2 = task_24_outs.task_id();
+                    TaskId gate_spmd_tid_inline245__ssa_v2 = task_24_outs.task_id();
                     gate_tids_inline56[2] = gate_spmd_tid_inline245__ssa_v2;
                     gate_tids_inline56[7] = gate_spmd_tid_inline245__ssa_v2;
                     gate_tids_inline56[12] = gate_spmd_tid_inline245__ssa_v2;
                     gate_tids_inline56[17] = gate_spmd_tid_inline245__ssa_v2;
                     gate_tids_inline56[22] = gate_spmd_tid_inline245__ssa_v2;
                     gate_tids_inline56[27] = gate_spmd_tid_inline245__ssa_v2;
-                    PTO2TaskId _submit_deps_buf_inline260__ssa_v2[1];
+                    TaskId _submit_deps_buf_inline260__ssa_v2[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline260__ssa_v2[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v122 = cast_tids_inline88[2];
+                        _submit_deps_buf_inline260__ssa_v2[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v122 = cast_tids_inline88[2];
                     _submit_deps_buf_inline260__ssa_v2[0] = t__tmp_v122;
 
                     // Spmd up_proj_spmd_1: up_proj_1
@@ -1240,13 +1240,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t25.add_scalar(gu_k0_inline131__ssa_v2);
                     params_t25.add_scalar(layer_hidden_base_inline151);
                     params_t25.launch_spec.set_core_num(6);
-                    PTO2TaskId params_t25_deps[1];
+                    TaskId params_t25_deps[1];
                     uint32_t params_t25_deps_count = 0;
                     if (_submit_deps_buf_inline260__ssa_v2[0].is_valid())
                         params_t25_deps[params_t25_deps_count++] = _submit_deps_buf_inline260__ssa_v2[0];
                     params_t25.set_dependencies(params_t25_deps, params_t25_deps_count);
                     TaskOutputTensors task_25_outs = rt_submit_aic_task(26, params_t25);
-                    PTO2TaskId up_spmd_tid_inline264__ssa_v2 = task_25_outs.task_id();
+                    TaskId up_spmd_tid_inline264__ssa_v2 = task_25_outs.task_id();
                     up_tids_inline310[2] = up_spmd_tid_inline264__ssa_v2;
                     up_tids_inline310[7] = up_spmd_tid_inline264__ssa_v2;
                     up_tids_inline310[12] = up_spmd_tid_inline264__ssa_v2;
@@ -1254,15 +1254,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     up_tids_inline310[22] = up_spmd_tid_inline264__ssa_v2;
                     up_tids_inline310[27] = up_spmd_tid_inline264__ssa_v2;
                     int64_t gu_k0_inline131__ssa_v3 = 3072;
-                    PTO2TaskId _submit_deps_buf_inline236__ssa_v3[1];
+                    TaskId _submit_deps_buf_inline236__ssa_v3[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline236__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v123 = cast_tids_inline88[3];
+                        _submit_deps_buf_inline236__ssa_v3[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v123 = cast_tids_inline88[3];
                     _submit_deps_buf_inline236__ssa_v3[0] = t__tmp_v123;
 
                     // Phase-fence barrier 9: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_9;
-                    PTO2TaskId params_phase_fence_barrier_9_deps[1];
+                    TaskId params_phase_fence_barrier_9_deps[1];
                     uint32_t params_phase_fence_barrier_9_deps_count = 0;
                     if (_submit_deps_buf_inline236__ssa_v3[0].is_valid())
                         params_phase_fence_barrier_9_deps[params_phase_fence_barrier_9_deps_count++] =
@@ -1270,22 +1270,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_9.set_dependencies(
                         params_phase_fence_barrier_9_deps, params_phase_fence_barrier_9_deps_count
                     );
-                    PTO2TaskId t__tmp_v124 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v124 = TaskId::invalid();
                     if (params_phase_fence_barrier_9_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_9_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_9);
                         t__tmp_v124 = phase_fence_barrier_9_outs.task_id();
                     }
                     gate_late_tids_inline249[3] = t__tmp_v124;
-                    PTO2TaskId _submit_deps_buf_inline225__ssa_v3[1];
+                    TaskId _submit_deps_buf_inline225__ssa_v3[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline225__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v125 = cast_tids_inline88[3];
+                        _submit_deps_buf_inline225__ssa_v3[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v125 = cast_tids_inline88[3];
                     _submit_deps_buf_inline225__ssa_v3[0] = t__tmp_v125;
 
                     // Phase-fence barrier 10: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_10;
-                    PTO2TaskId params_phase_fence_barrier_10_deps[1];
+                    TaskId params_phase_fence_barrier_10_deps[1];
                     uint32_t params_phase_fence_barrier_10_deps_count = 0;
                     if (_submit_deps_buf_inline225__ssa_v3[0].is_valid())
                         params_phase_fence_barrier_10_deps[params_phase_fence_barrier_10_deps_count++] =
@@ -1293,17 +1293,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_10.set_dependencies(
                         params_phase_fence_barrier_10_deps, params_phase_fence_barrier_10_deps_count
                     );
-                    PTO2TaskId t__tmp_v126 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v126 = TaskId::invalid();
                     if (params_phase_fence_barrier_10_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_10_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_10);
                         t__tmp_v126 = phase_fence_barrier_10_outs.task_id();
                     }
                     up_late_tids_inline69[3] = t__tmp_v126;
-                    PTO2TaskId _submit_deps_buf_inline237__ssa_v3[1];
+                    TaskId _submit_deps_buf_inline237__ssa_v3[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline237__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v127 = cast_tids_inline88[3];
+                        _submit_deps_buf_inline237__ssa_v3[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v127 = cast_tids_inline88[3];
                     _submit_deps_buf_inline237__ssa_v3[0] = t__tmp_v127;
 
                     // Spmd gate_proj_spmd_2: gate_proj_2
@@ -1314,23 +1314,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t26.add_scalar(gu_k0_inline131__ssa_v3);
                     params_t26.add_scalar(layer_hidden_base_inline151);
                     params_t26.launch_spec.set_core_num(6);
-                    PTO2TaskId params_t26_deps[1];
+                    TaskId params_t26_deps[1];
                     uint32_t params_t26_deps_count = 0;
                     if (_submit_deps_buf_inline237__ssa_v3[0].is_valid())
                         params_t26_deps[params_t26_deps_count++] = _submit_deps_buf_inline237__ssa_v3[0];
                     params_t26.set_dependencies(params_t26_deps, params_t26_deps_count);
                     TaskOutputTensors task_26_outs = rt_submit_aic_task(27, params_t26);
-                    PTO2TaskId gate_spmd_tid_inline245__ssa_v3 = task_26_outs.task_id();
+                    TaskId gate_spmd_tid_inline245__ssa_v3 = task_26_outs.task_id();
                     gate_tids_inline56[3] = gate_spmd_tid_inline245__ssa_v3;
                     gate_tids_inline56[8] = gate_spmd_tid_inline245__ssa_v3;
                     gate_tids_inline56[13] = gate_spmd_tid_inline245__ssa_v3;
                     gate_tids_inline56[18] = gate_spmd_tid_inline245__ssa_v3;
                     gate_tids_inline56[23] = gate_spmd_tid_inline245__ssa_v3;
                     gate_tids_inline56[28] = gate_spmd_tid_inline245__ssa_v3;
-                    PTO2TaskId _submit_deps_buf_inline260__ssa_v3[1];
+                    TaskId _submit_deps_buf_inline260__ssa_v3[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline260__ssa_v3[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v128 = cast_tids_inline88[3];
+                        _submit_deps_buf_inline260__ssa_v3[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v128 = cast_tids_inline88[3];
                     _submit_deps_buf_inline260__ssa_v3[0] = t__tmp_v128;
 
                     // Spmd up_proj_spmd_2: up_proj_2
@@ -1341,13 +1341,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t27.add_scalar(gu_k0_inline131__ssa_v3);
                     params_t27.add_scalar(layer_hidden_base_inline151);
                     params_t27.launch_spec.set_core_num(6);
-                    PTO2TaskId params_t27_deps[1];
+                    TaskId params_t27_deps[1];
                     uint32_t params_t27_deps_count = 0;
                     if (_submit_deps_buf_inline260__ssa_v3[0].is_valid())
                         params_t27_deps[params_t27_deps_count++] = _submit_deps_buf_inline260__ssa_v3[0];
                     params_t27.set_dependencies(params_t27_deps, params_t27_deps_count);
                     TaskOutputTensors task_27_outs = rt_submit_aic_task(28, params_t27);
-                    PTO2TaskId up_spmd_tid_inline264__ssa_v3 = task_27_outs.task_id();
+                    TaskId up_spmd_tid_inline264__ssa_v3 = task_27_outs.task_id();
                     up_tids_inline310[3] = up_spmd_tid_inline264__ssa_v3;
                     up_tids_inline310[8] = up_spmd_tid_inline264__ssa_v3;
                     up_tids_inline310[13] = up_spmd_tid_inline264__ssa_v3;
@@ -1355,15 +1355,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     up_tids_inline310[23] = up_spmd_tid_inline264__ssa_v3;
                     up_tids_inline310[28] = up_spmd_tid_inline264__ssa_v3;
                     int64_t gu_k0_inline131__ssa_v4 = 4096;
-                    PTO2TaskId _submit_deps_buf_inline236__ssa_v4[1];
+                    TaskId _submit_deps_buf_inline236__ssa_v4[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline236__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v129 = cast_tids_inline88[4];
+                        _submit_deps_buf_inline236__ssa_v4[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v129 = cast_tids_inline88[4];
                     _submit_deps_buf_inline236__ssa_v4[0] = t__tmp_v129;
 
                     // Phase-fence barrier 11: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_11;
-                    PTO2TaskId params_phase_fence_barrier_11_deps[1];
+                    TaskId params_phase_fence_barrier_11_deps[1];
                     uint32_t params_phase_fence_barrier_11_deps_count = 0;
                     if (_submit_deps_buf_inline236__ssa_v4[0].is_valid())
                         params_phase_fence_barrier_11_deps[params_phase_fence_barrier_11_deps_count++] =
@@ -1371,22 +1371,22 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_11.set_dependencies(
                         params_phase_fence_barrier_11_deps, params_phase_fence_barrier_11_deps_count
                     );
-                    PTO2TaskId t__tmp_v130 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v130 = TaskId::invalid();
                     if (params_phase_fence_barrier_11_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_11_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_11);
                         t__tmp_v130 = phase_fence_barrier_11_outs.task_id();
                     }
                     gate_late_tids_inline249[4] = t__tmp_v130;
-                    PTO2TaskId _submit_deps_buf_inline225__ssa_v4[1];
+                    TaskId _submit_deps_buf_inline225__ssa_v4[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline225__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v131 = cast_tids_inline88[4];
+                        _submit_deps_buf_inline225__ssa_v4[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v131 = cast_tids_inline88[4];
                     _submit_deps_buf_inline225__ssa_v4[0] = t__tmp_v131;
 
                     // Phase-fence barrier 12: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_12;
-                    PTO2TaskId params_phase_fence_barrier_12_deps[1];
+                    TaskId params_phase_fence_barrier_12_deps[1];
                     uint32_t params_phase_fence_barrier_12_deps_count = 0;
                     if (_submit_deps_buf_inline225__ssa_v4[0].is_valid())
                         params_phase_fence_barrier_12_deps[params_phase_fence_barrier_12_deps_count++] =
@@ -1394,17 +1394,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_phase_fence_barrier_12.set_dependencies(
                         params_phase_fence_barrier_12_deps, params_phase_fence_barrier_12_deps_count
                     );
-                    PTO2TaskId t__tmp_v132 = PTO2TaskId::invalid();
+                    TaskId t__tmp_v132 = TaskId::invalid();
                     if (params_phase_fence_barrier_12_deps_count > 0) {
                         TaskOutputTensors phase_fence_barrier_12_outs =
                             rt_submit_dummy_task(params_phase_fence_barrier_12);
                         t__tmp_v132 = phase_fence_barrier_12_outs.task_id();
                     }
                     up_late_tids_inline69[4] = t__tmp_v132;
-                    PTO2TaskId _submit_deps_buf_inline237__ssa_v4[1];
+                    TaskId _submit_deps_buf_inline237__ssa_v4[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline237__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v133 = cast_tids_inline88[4];
+                        _submit_deps_buf_inline237__ssa_v4[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v133 = cast_tids_inline88[4];
                     _submit_deps_buf_inline237__ssa_v4[0] = t__tmp_v133;
 
                     // Spmd gate_proj_spmd_3: gate_proj_3
@@ -1415,23 +1415,23 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t28.add_scalar(gu_k0_inline131__ssa_v4);
                     params_t28.add_scalar(layer_hidden_base_inline151);
                     params_t28.launch_spec.set_core_num(6);
-                    PTO2TaskId params_t28_deps[1];
+                    TaskId params_t28_deps[1];
                     uint32_t params_t28_deps_count = 0;
                     if (_submit_deps_buf_inline237__ssa_v4[0].is_valid())
                         params_t28_deps[params_t28_deps_count++] = _submit_deps_buf_inline237__ssa_v4[0];
                     params_t28.set_dependencies(params_t28_deps, params_t28_deps_count);
                     TaskOutputTensors task_28_outs = rt_submit_aic_task(29, params_t28);
-                    PTO2TaskId gate_spmd_tid_inline245__ssa_v4 = task_28_outs.task_id();
+                    TaskId gate_spmd_tid_inline245__ssa_v4 = task_28_outs.task_id();
                     gate_tids_inline56[4] = gate_spmd_tid_inline245__ssa_v4;
                     gate_tids_inline56[9] = gate_spmd_tid_inline245__ssa_v4;
                     gate_tids_inline56[14] = gate_spmd_tid_inline245__ssa_v4;
                     gate_tids_inline56[19] = gate_spmd_tid_inline245__ssa_v4;
                     gate_tids_inline56[24] = gate_spmd_tid_inline245__ssa_v4;
                     gate_tids_inline56[29] = gate_spmd_tid_inline245__ssa_v4;
-                    PTO2TaskId _submit_deps_buf_inline260__ssa_v4[1];
+                    TaskId _submit_deps_buf_inline260__ssa_v4[1];
                     for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                        _submit_deps_buf_inline260__ssa_v4[__init_i] = PTO2TaskId::invalid();
-                    PTO2TaskId t__tmp_v134 = cast_tids_inline88[4];
+                        _submit_deps_buf_inline260__ssa_v4[__init_i] = TaskId::invalid();
+                    TaskId t__tmp_v134 = cast_tids_inline88[4];
                     _submit_deps_buf_inline260__ssa_v4[0] = t__tmp_v134;
 
                     // Spmd up_proj_spmd_3: up_proj_3
@@ -1442,13 +1442,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t29.add_scalar(gu_k0_inline131__ssa_v4);
                     params_t29.add_scalar(layer_hidden_base_inline151);
                     params_t29.launch_spec.set_core_num(6);
-                    PTO2TaskId params_t29_deps[1];
+                    TaskId params_t29_deps[1];
                     uint32_t params_t29_deps_count = 0;
                     if (_submit_deps_buf_inline260__ssa_v4[0].is_valid())
                         params_t29_deps[params_t29_deps_count++] = _submit_deps_buf_inline260__ssa_v4[0];
                     params_t29.set_dependencies(params_t29_deps, params_t29_deps_count);
                     TaskOutputTensors task_29_outs = rt_submit_aic_task(30, params_t29);
-                    PTO2TaskId up_spmd_tid_inline264__ssa_v4 = task_29_outs.task_id();
+                    TaskId up_spmd_tid_inline264__ssa_v4 = task_29_outs.task_id();
                     up_tids_inline310[4] = up_spmd_tid_inline264__ssa_v4;
                     up_tids_inline310[9] = up_spmd_tid_inline264__ssa_v4;
                     up_tids_inline310[14] = up_spmd_tid_inline264__ssa_v4;
@@ -1459,10 +1459,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         int64_t n0_inline122 = (n_out_inline275 * 1024);
                         for (int64_t k_split_inline276 = 0; k_split_inline276 < 5; k_split_inline276 += 1) {
                             int64_t k0_inline113 = (k_split_inline276 * 1024);
-                            PTO2TaskId _submit_deps_buf_inline102[1];
+                            TaskId _submit_deps_buf_inline102[1];
                             for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                                _submit_deps_buf_inline102[__init_i] = PTO2TaskId::invalid();
-                            PTO2TaskId t__tmp_v135 = gate_late_tids_inline249[k_split_inline276];
+                                _submit_deps_buf_inline102[__init_i] = TaskId::invalid();
+                            TaskId t__tmp_v135 = gate_late_tids_inline249[k_split_inline276];
                             _submit_deps_buf_inline102[0] = t__tmp_v135;
 
                             // Task 30: gate_proj_4
@@ -1473,18 +1473,18 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t30.add_scalar(k0_inline113);
                             params_t30.add_scalar(layer_hidden_base_inline151);
                             params_t30.add_scalar(n0_inline122);
-                            PTO2TaskId params_t30_deps[1];
+                            TaskId params_t30_deps[1];
                             uint32_t params_t30_deps_count = 0;
                             if (_submit_deps_buf_inline102[0].is_valid())
                                 params_t30_deps[params_t30_deps_count++] = _submit_deps_buf_inline102[0];
                             params_t30.set_dependencies(params_t30_deps, params_t30_deps_count);
                             TaskOutputTensors task_30_outs = rt_submit_aic_task(31, params_t30);
-                            PTO2TaskId gate_tid_inline277 = task_30_outs.task_id();
+                            TaskId gate_tid_inline277 = task_30_outs.task_id();
                             gate_tids_inline56[((n_out_inline275 * 5) + k_split_inline276)] = gate_tid_inline277;
-                            PTO2TaskId _submit_deps_buf_inline246[1];
+                            TaskId _submit_deps_buf_inline246[1];
                             for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                                _submit_deps_buf_inline246[__init_i] = PTO2TaskId::invalid();
-                            PTO2TaskId t__tmp_v136 = up_late_tids_inline69[k_split_inline276];
+                                _submit_deps_buf_inline246[__init_i] = TaskId::invalid();
+                            TaskId t__tmp_v136 = up_late_tids_inline69[k_split_inline276];
                             _submit_deps_buf_inline246[0] = t__tmp_v136;
 
                             // Task 31: up_proj_4
@@ -1495,41 +1495,41 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t31.add_scalar(k0_inline113);
                             params_t31.add_scalar(layer_hidden_base_inline151);
                             params_t31.add_scalar(n0_inline122);
-                            PTO2TaskId params_t31_deps[1];
+                            TaskId params_t31_deps[1];
                             uint32_t params_t31_deps_count = 0;
                             if (_submit_deps_buf_inline246[0].is_valid())
                                 params_t31_deps[params_t31_deps_count++] = _submit_deps_buf_inline246[0];
                             params_t31.set_dependencies(params_t31_deps, params_t31_deps_count);
                             TaskOutputTensors task_31_outs = rt_submit_aic_task(32, params_t31);
-                            PTO2TaskId up_tid_inline290 = task_31_outs.task_id();
+                            TaskId up_tid_inline290 = task_31_outs.task_id();
                             up_tids_inline310[((n_out_inline275 * 5) + k_split_inline276)] = up_tid_inline290;
                         }
                     }
                     for (int64_t n_out_inline292 = 0; n_out_inline292 < 17; n_out_inline292 += 1) {
                         int64_t n0_inline122__ssa_v7 = (n_out_inline292 * 1024);
-                        PTO2TaskId _submit_deps_buf_inline167[11];
+                        TaskId _submit_deps_buf_inline167[11];
                         for (int64_t __init_i = 0; __init_i < 11; ++__init_i)
-                            _submit_deps_buf_inline167[__init_i] = PTO2TaskId::invalid();
+                            _submit_deps_buf_inline167[__init_i] = TaskId::invalid();
                         _submit_deps_buf_inline167[0] = reduce_tid_inline226;
-                        PTO2TaskId t__tmp_v137 = gate_tids_inline56[(n_out_inline292 * 5)];
+                        TaskId t__tmp_v137 = gate_tids_inline56[(n_out_inline292 * 5)];
                         _submit_deps_buf_inline167[1] = t__tmp_v137;
-                        PTO2TaskId t__tmp_v138 = gate_tids_inline56[((n_out_inline292 * 5) + 1)];
+                        TaskId t__tmp_v138 = gate_tids_inline56[((n_out_inline292 * 5) + 1)];
                         _submit_deps_buf_inline167[2] = t__tmp_v138;
-                        PTO2TaskId t__tmp_v139 = gate_tids_inline56[((n_out_inline292 * 5) + 2)];
+                        TaskId t__tmp_v139 = gate_tids_inline56[((n_out_inline292 * 5) + 2)];
                         _submit_deps_buf_inline167[3] = t__tmp_v139;
-                        PTO2TaskId t__tmp_v140 = gate_tids_inline56[((n_out_inline292 * 5) + 3)];
+                        TaskId t__tmp_v140 = gate_tids_inline56[((n_out_inline292 * 5) + 3)];
                         _submit_deps_buf_inline167[4] = t__tmp_v140;
-                        PTO2TaskId t__tmp_v141 = gate_tids_inline56[((n_out_inline292 * 5) + 4)];
+                        TaskId t__tmp_v141 = gate_tids_inline56[((n_out_inline292 * 5) + 4)];
                         _submit_deps_buf_inline167[5] = t__tmp_v141;
-                        PTO2TaskId t__tmp_v142 = up_tids_inline310[(n_out_inline292 * 5)];
+                        TaskId t__tmp_v142 = up_tids_inline310[(n_out_inline292 * 5)];
                         _submit_deps_buf_inline167[6] = t__tmp_v142;
-                        PTO2TaskId t__tmp_v143 = up_tids_inline310[((n_out_inline292 * 5) + 1)];
+                        TaskId t__tmp_v143 = up_tids_inline310[((n_out_inline292 * 5) + 1)];
                         _submit_deps_buf_inline167[7] = t__tmp_v143;
-                        PTO2TaskId t__tmp_v144 = up_tids_inline310[((n_out_inline292 * 5) + 2)];
+                        TaskId t__tmp_v144 = up_tids_inline310[((n_out_inline292 * 5) + 2)];
                         _submit_deps_buf_inline167[8] = t__tmp_v144;
-                        PTO2TaskId t__tmp_v145 = up_tids_inline310[((n_out_inline292 * 5) + 3)];
+                        TaskId t__tmp_v145 = up_tids_inline310[((n_out_inline292 * 5) + 3)];
                         _submit_deps_buf_inline167[9] = t__tmp_v145;
-                        PTO2TaskId t__tmp_v146 = up_tids_inline310[((n_out_inline292 * 5) + 4)];
+                        TaskId t__tmp_v146 = up_tids_inline310[((n_out_inline292 * 5) + 4)];
                         _submit_deps_buf_inline167[10] = t__tmp_v146;
 
                         // Task 32: silu
@@ -1539,7 +1539,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_t32.add_input(gate_acc_all_inline203);
                         params_t32.add_input(up_acc_all_inline303);
                         params_t32.add_scalar(n0_inline122__ssa_v7);
-                        PTO2TaskId params_t32_deps[11];
+                        TaskId params_t32_deps[11];
                         uint32_t params_t32_deps_count = 0;
                         if (_submit_deps_buf_inline167[0].is_valid())
                             params_t32_deps[params_t32_deps_count++] = _submit_deps_buf_inline167[0];
@@ -1565,17 +1565,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t32_deps[params_t32_deps_count++] = _submit_deps_buf_inline167[10];
                         params_t32.set_dependencies(params_t32_deps, params_t32_deps_count);
                         TaskOutputTensors task_32_outs = rt_submit_aiv_task(33, params_t32);
-                        PTO2TaskId silu_tid_inline80 = task_32_outs.task_id();
+                        TaskId silu_tid_inline80 = task_32_outs.task_id();
                         silu_tids_inline265[n_out_inline292] = silu_tid_inline80;
                     }
                     for (int64_t n_out_inline195 = 0; n_out_inline195 < 5; n_out_inline195 += 1) {
                         int64_t n0_inline122__ssa_v8 = (n_out_inline195 * 1024);
                         for (int64_t k_split_inline302 = 0; k_split_inline302 < 17; k_split_inline302 += 1) {
                             int64_t k0_inline113__ssa_v8 = (k_split_inline302 * 1024);
-                            PTO2TaskId _submit_deps_buf_inline229[1];
+                            TaskId _submit_deps_buf_inline229[1];
                             for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
-                                _submit_deps_buf_inline229[__init_i] = PTO2TaskId::invalid();
-                            PTO2TaskId t__tmp_v152 = silu_tids_inline265[k_split_inline302];
+                                _submit_deps_buf_inline229[__init_i] = TaskId::invalid();
+                            TaskId t__tmp_v152 = silu_tids_inline265[k_split_inline302];
                             _submit_deps_buf_inline229[0] = t__tmp_v152;
 
                             // Task 33: down_proj
@@ -1586,190 +1586,190 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             params_t33.add_scalar(k0_inline113__ssa_v8);
                             params_t33.add_scalar(layer_inter_base_inline107);
                             params_t33.add_scalar(n0_inline122__ssa_v8);
-                            PTO2TaskId params_t33_deps[1];
+                            TaskId params_t33_deps[1];
                             uint32_t params_t33_deps_count = 0;
                             if (_submit_deps_buf_inline229[0].is_valid())
                                 params_t33_deps[params_t33_deps_count++] = _submit_deps_buf_inline229[0];
                             params_t33.set_dependencies(params_t33_deps, params_t33_deps_count);
                             params_t33.set_allow_early_resolve(true);
                             TaskOutputTensors task_33_outs = rt_submit_aic_task(34, params_t33);
-                            PTO2TaskId down_tid_inline210 = task_33_outs.task_id();
+                            TaskId down_tid_inline210 = task_33_outs.task_id();
                             down_tids_inline156[((n_out_inline195 * 17) + k_split_inline302)] = down_tid_inline210;
                         }
                     }
                 }
-                PTO2TaskId _submit_deps_buf_inline123[85];
+                TaskId _submit_deps_buf_inline123[85];
                 for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
-                    _submit_deps_buf_inline123[__init_i] = PTO2TaskId::invalid();
-                PTO2TaskId t__tmp_v153 = down_tids_inline156[0];
+                    _submit_deps_buf_inline123[__init_i] = TaskId::invalid();
+                TaskId t__tmp_v153 = down_tids_inline156[0];
                 _submit_deps_buf_inline123[0] = t__tmp_v153;
-                PTO2TaskId t__tmp_v154 = down_tids_inline156[1];
+                TaskId t__tmp_v154 = down_tids_inline156[1];
                 _submit_deps_buf_inline123[1] = t__tmp_v154;
-                PTO2TaskId t__tmp_v155 = down_tids_inline156[2];
+                TaskId t__tmp_v155 = down_tids_inline156[2];
                 _submit_deps_buf_inline123[2] = t__tmp_v155;
-                PTO2TaskId t__tmp_v156 = down_tids_inline156[3];
+                TaskId t__tmp_v156 = down_tids_inline156[3];
                 _submit_deps_buf_inline123[3] = t__tmp_v156;
-                PTO2TaskId t__tmp_v157 = down_tids_inline156[4];
+                TaskId t__tmp_v157 = down_tids_inline156[4];
                 _submit_deps_buf_inline123[4] = t__tmp_v157;
-                PTO2TaskId t__tmp_v158 = down_tids_inline156[5];
+                TaskId t__tmp_v158 = down_tids_inline156[5];
                 _submit_deps_buf_inline123[5] = t__tmp_v158;
-                PTO2TaskId t__tmp_v159 = down_tids_inline156[6];
+                TaskId t__tmp_v159 = down_tids_inline156[6];
                 _submit_deps_buf_inline123[6] = t__tmp_v159;
-                PTO2TaskId t__tmp_v160 = down_tids_inline156[7];
+                TaskId t__tmp_v160 = down_tids_inline156[7];
                 _submit_deps_buf_inline123[7] = t__tmp_v160;
-                PTO2TaskId t__tmp_v161 = down_tids_inline156[8];
+                TaskId t__tmp_v161 = down_tids_inline156[8];
                 _submit_deps_buf_inline123[8] = t__tmp_v161;
-                PTO2TaskId t__tmp_v162 = down_tids_inline156[9];
+                TaskId t__tmp_v162 = down_tids_inline156[9];
                 _submit_deps_buf_inline123[9] = t__tmp_v162;
-                PTO2TaskId t__tmp_v163 = down_tids_inline156[10];
+                TaskId t__tmp_v163 = down_tids_inline156[10];
                 _submit_deps_buf_inline123[10] = t__tmp_v163;
-                PTO2TaskId t__tmp_v164 = down_tids_inline156[11];
+                TaskId t__tmp_v164 = down_tids_inline156[11];
                 _submit_deps_buf_inline123[11] = t__tmp_v164;
-                PTO2TaskId t__tmp_v165 = down_tids_inline156[12];
+                TaskId t__tmp_v165 = down_tids_inline156[12];
                 _submit_deps_buf_inline123[12] = t__tmp_v165;
-                PTO2TaskId t__tmp_v166 = down_tids_inline156[13];
+                TaskId t__tmp_v166 = down_tids_inline156[13];
                 _submit_deps_buf_inline123[13] = t__tmp_v166;
-                PTO2TaskId t__tmp_v167 = down_tids_inline156[14];
+                TaskId t__tmp_v167 = down_tids_inline156[14];
                 _submit_deps_buf_inline123[14] = t__tmp_v167;
-                PTO2TaskId t__tmp_v168 = down_tids_inline156[15];
+                TaskId t__tmp_v168 = down_tids_inline156[15];
                 _submit_deps_buf_inline123[15] = t__tmp_v168;
-                PTO2TaskId t__tmp_v169 = down_tids_inline156[16];
+                TaskId t__tmp_v169 = down_tids_inline156[16];
                 _submit_deps_buf_inline123[16] = t__tmp_v169;
-                PTO2TaskId t__tmp_v170 = down_tids_inline156[17];
+                TaskId t__tmp_v170 = down_tids_inline156[17];
                 _submit_deps_buf_inline123[17] = t__tmp_v170;
-                PTO2TaskId t__tmp_v171 = down_tids_inline156[18];
+                TaskId t__tmp_v171 = down_tids_inline156[18];
                 _submit_deps_buf_inline123[18] = t__tmp_v171;
-                PTO2TaskId t__tmp_v172 = down_tids_inline156[19];
+                TaskId t__tmp_v172 = down_tids_inline156[19];
                 _submit_deps_buf_inline123[19] = t__tmp_v172;
-                PTO2TaskId t__tmp_v173 = down_tids_inline156[20];
+                TaskId t__tmp_v173 = down_tids_inline156[20];
                 _submit_deps_buf_inline123[20] = t__tmp_v173;
-                PTO2TaskId t__tmp_v174 = down_tids_inline156[21];
+                TaskId t__tmp_v174 = down_tids_inline156[21];
                 _submit_deps_buf_inline123[21] = t__tmp_v174;
-                PTO2TaskId t__tmp_v175 = down_tids_inline156[22];
+                TaskId t__tmp_v175 = down_tids_inline156[22];
                 _submit_deps_buf_inline123[22] = t__tmp_v175;
-                PTO2TaskId t__tmp_v176 = down_tids_inline156[23];
+                TaskId t__tmp_v176 = down_tids_inline156[23];
                 _submit_deps_buf_inline123[23] = t__tmp_v176;
-                PTO2TaskId t__tmp_v177 = down_tids_inline156[24];
+                TaskId t__tmp_v177 = down_tids_inline156[24];
                 _submit_deps_buf_inline123[24] = t__tmp_v177;
-                PTO2TaskId t__tmp_v178 = down_tids_inline156[25];
+                TaskId t__tmp_v178 = down_tids_inline156[25];
                 _submit_deps_buf_inline123[25] = t__tmp_v178;
-                PTO2TaskId t__tmp_v179 = down_tids_inline156[26];
+                TaskId t__tmp_v179 = down_tids_inline156[26];
                 _submit_deps_buf_inline123[26] = t__tmp_v179;
-                PTO2TaskId t__tmp_v180 = down_tids_inline156[27];
+                TaskId t__tmp_v180 = down_tids_inline156[27];
                 _submit_deps_buf_inline123[27] = t__tmp_v180;
-                PTO2TaskId t__tmp_v181 = down_tids_inline156[28];
+                TaskId t__tmp_v181 = down_tids_inline156[28];
                 _submit_deps_buf_inline123[28] = t__tmp_v181;
-                PTO2TaskId t__tmp_v182 = down_tids_inline156[29];
+                TaskId t__tmp_v182 = down_tids_inline156[29];
                 _submit_deps_buf_inline123[29] = t__tmp_v182;
-                PTO2TaskId t__tmp_v183 = down_tids_inline156[30];
+                TaskId t__tmp_v183 = down_tids_inline156[30];
                 _submit_deps_buf_inline123[30] = t__tmp_v183;
-                PTO2TaskId t__tmp_v184 = down_tids_inline156[31];
+                TaskId t__tmp_v184 = down_tids_inline156[31];
                 _submit_deps_buf_inline123[31] = t__tmp_v184;
-                PTO2TaskId t__tmp_v185 = down_tids_inline156[32];
+                TaskId t__tmp_v185 = down_tids_inline156[32];
                 _submit_deps_buf_inline123[32] = t__tmp_v185;
-                PTO2TaskId t__tmp_v186 = down_tids_inline156[33];
+                TaskId t__tmp_v186 = down_tids_inline156[33];
                 _submit_deps_buf_inline123[33] = t__tmp_v186;
-                PTO2TaskId t__tmp_v187 = down_tids_inline156[34];
+                TaskId t__tmp_v187 = down_tids_inline156[34];
                 _submit_deps_buf_inline123[34] = t__tmp_v187;
-                PTO2TaskId t__tmp_v188 = down_tids_inline156[35];
+                TaskId t__tmp_v188 = down_tids_inline156[35];
                 _submit_deps_buf_inline123[35] = t__tmp_v188;
-                PTO2TaskId t__tmp_v189 = down_tids_inline156[36];
+                TaskId t__tmp_v189 = down_tids_inline156[36];
                 _submit_deps_buf_inline123[36] = t__tmp_v189;
-                PTO2TaskId t__tmp_v190 = down_tids_inline156[37];
+                TaskId t__tmp_v190 = down_tids_inline156[37];
                 _submit_deps_buf_inline123[37] = t__tmp_v190;
-                PTO2TaskId t__tmp_v191 = down_tids_inline156[38];
+                TaskId t__tmp_v191 = down_tids_inline156[38];
                 _submit_deps_buf_inline123[38] = t__tmp_v191;
-                PTO2TaskId t__tmp_v192 = down_tids_inline156[39];
+                TaskId t__tmp_v192 = down_tids_inline156[39];
                 _submit_deps_buf_inline123[39] = t__tmp_v192;
-                PTO2TaskId t__tmp_v193 = down_tids_inline156[40];
+                TaskId t__tmp_v193 = down_tids_inline156[40];
                 _submit_deps_buf_inline123[40] = t__tmp_v193;
-                PTO2TaskId t__tmp_v194 = down_tids_inline156[41];
+                TaskId t__tmp_v194 = down_tids_inline156[41];
                 _submit_deps_buf_inline123[41] = t__tmp_v194;
-                PTO2TaskId t__tmp_v195 = down_tids_inline156[42];
+                TaskId t__tmp_v195 = down_tids_inline156[42];
                 _submit_deps_buf_inline123[42] = t__tmp_v195;
-                PTO2TaskId t__tmp_v196 = down_tids_inline156[43];
+                TaskId t__tmp_v196 = down_tids_inline156[43];
                 _submit_deps_buf_inline123[43] = t__tmp_v196;
-                PTO2TaskId t__tmp_v197 = down_tids_inline156[44];
+                TaskId t__tmp_v197 = down_tids_inline156[44];
                 _submit_deps_buf_inline123[44] = t__tmp_v197;
-                PTO2TaskId t__tmp_v198 = down_tids_inline156[45];
+                TaskId t__tmp_v198 = down_tids_inline156[45];
                 _submit_deps_buf_inline123[45] = t__tmp_v198;
-                PTO2TaskId t__tmp_v199 = down_tids_inline156[46];
+                TaskId t__tmp_v199 = down_tids_inline156[46];
                 _submit_deps_buf_inline123[46] = t__tmp_v199;
-                PTO2TaskId t__tmp_v200 = down_tids_inline156[47];
+                TaskId t__tmp_v200 = down_tids_inline156[47];
                 _submit_deps_buf_inline123[47] = t__tmp_v200;
-                PTO2TaskId t__tmp_v201 = down_tids_inline156[48];
+                TaskId t__tmp_v201 = down_tids_inline156[48];
                 _submit_deps_buf_inline123[48] = t__tmp_v201;
-                PTO2TaskId t__tmp_v202 = down_tids_inline156[49];
+                TaskId t__tmp_v202 = down_tids_inline156[49];
                 _submit_deps_buf_inline123[49] = t__tmp_v202;
-                PTO2TaskId t__tmp_v203 = down_tids_inline156[50];
+                TaskId t__tmp_v203 = down_tids_inline156[50];
                 _submit_deps_buf_inline123[50] = t__tmp_v203;
-                PTO2TaskId t__tmp_v204 = down_tids_inline156[51];
+                TaskId t__tmp_v204 = down_tids_inline156[51];
                 _submit_deps_buf_inline123[51] = t__tmp_v204;
-                PTO2TaskId t__tmp_v205 = down_tids_inline156[52];
+                TaskId t__tmp_v205 = down_tids_inline156[52];
                 _submit_deps_buf_inline123[52] = t__tmp_v205;
-                PTO2TaskId t__tmp_v206 = down_tids_inline156[53];
+                TaskId t__tmp_v206 = down_tids_inline156[53];
                 _submit_deps_buf_inline123[53] = t__tmp_v206;
-                PTO2TaskId t__tmp_v207 = down_tids_inline156[54];
+                TaskId t__tmp_v207 = down_tids_inline156[54];
                 _submit_deps_buf_inline123[54] = t__tmp_v207;
-                PTO2TaskId t__tmp_v208 = down_tids_inline156[55];
+                TaskId t__tmp_v208 = down_tids_inline156[55];
                 _submit_deps_buf_inline123[55] = t__tmp_v208;
-                PTO2TaskId t__tmp_v209 = down_tids_inline156[56];
+                TaskId t__tmp_v209 = down_tids_inline156[56];
                 _submit_deps_buf_inline123[56] = t__tmp_v209;
-                PTO2TaskId t__tmp_v210 = down_tids_inline156[57];
+                TaskId t__tmp_v210 = down_tids_inline156[57];
                 _submit_deps_buf_inline123[57] = t__tmp_v210;
-                PTO2TaskId t__tmp_v211 = down_tids_inline156[58];
+                TaskId t__tmp_v211 = down_tids_inline156[58];
                 _submit_deps_buf_inline123[58] = t__tmp_v211;
-                PTO2TaskId t__tmp_v212 = down_tids_inline156[59];
+                TaskId t__tmp_v212 = down_tids_inline156[59];
                 _submit_deps_buf_inline123[59] = t__tmp_v212;
-                PTO2TaskId t__tmp_v213 = down_tids_inline156[60];
+                TaskId t__tmp_v213 = down_tids_inline156[60];
                 _submit_deps_buf_inline123[60] = t__tmp_v213;
-                PTO2TaskId t__tmp_v214 = down_tids_inline156[61];
+                TaskId t__tmp_v214 = down_tids_inline156[61];
                 _submit_deps_buf_inline123[61] = t__tmp_v214;
-                PTO2TaskId t__tmp_v215 = down_tids_inline156[62];
+                TaskId t__tmp_v215 = down_tids_inline156[62];
                 _submit_deps_buf_inline123[62] = t__tmp_v215;
-                PTO2TaskId t__tmp_v216 = down_tids_inline156[63];
+                TaskId t__tmp_v216 = down_tids_inline156[63];
                 _submit_deps_buf_inline123[63] = t__tmp_v216;
-                PTO2TaskId t__tmp_v217 = down_tids_inline156[64];
+                TaskId t__tmp_v217 = down_tids_inline156[64];
                 _submit_deps_buf_inline123[64] = t__tmp_v217;
-                PTO2TaskId t__tmp_v218 = down_tids_inline156[65];
+                TaskId t__tmp_v218 = down_tids_inline156[65];
                 _submit_deps_buf_inline123[65] = t__tmp_v218;
-                PTO2TaskId t__tmp_v219 = down_tids_inline156[66];
+                TaskId t__tmp_v219 = down_tids_inline156[66];
                 _submit_deps_buf_inline123[66] = t__tmp_v219;
-                PTO2TaskId t__tmp_v220 = down_tids_inline156[67];
+                TaskId t__tmp_v220 = down_tids_inline156[67];
                 _submit_deps_buf_inline123[67] = t__tmp_v220;
-                PTO2TaskId t__tmp_v221 = down_tids_inline156[68];
+                TaskId t__tmp_v221 = down_tids_inline156[68];
                 _submit_deps_buf_inline123[68] = t__tmp_v221;
-                PTO2TaskId t__tmp_v222 = down_tids_inline156[69];
+                TaskId t__tmp_v222 = down_tids_inline156[69];
                 _submit_deps_buf_inline123[69] = t__tmp_v222;
-                PTO2TaskId t__tmp_v223 = down_tids_inline156[70];
+                TaskId t__tmp_v223 = down_tids_inline156[70];
                 _submit_deps_buf_inline123[70] = t__tmp_v223;
-                PTO2TaskId t__tmp_v224 = down_tids_inline156[71];
+                TaskId t__tmp_v224 = down_tids_inline156[71];
                 _submit_deps_buf_inline123[71] = t__tmp_v224;
-                PTO2TaskId t__tmp_v225 = down_tids_inline156[72];
+                TaskId t__tmp_v225 = down_tids_inline156[72];
                 _submit_deps_buf_inline123[72] = t__tmp_v225;
-                PTO2TaskId t__tmp_v226 = down_tids_inline156[73];
+                TaskId t__tmp_v226 = down_tids_inline156[73];
                 _submit_deps_buf_inline123[73] = t__tmp_v226;
-                PTO2TaskId t__tmp_v227 = down_tids_inline156[74];
+                TaskId t__tmp_v227 = down_tids_inline156[74];
                 _submit_deps_buf_inline123[74] = t__tmp_v227;
-                PTO2TaskId t__tmp_v228 = down_tids_inline156[75];
+                TaskId t__tmp_v228 = down_tids_inline156[75];
                 _submit_deps_buf_inline123[75] = t__tmp_v228;
-                PTO2TaskId t__tmp_v229 = down_tids_inline156[76];
+                TaskId t__tmp_v229 = down_tids_inline156[76];
                 _submit_deps_buf_inline123[76] = t__tmp_v229;
-                PTO2TaskId t__tmp_v230 = down_tids_inline156[77];
+                TaskId t__tmp_v230 = down_tids_inline156[77];
                 _submit_deps_buf_inline123[77] = t__tmp_v230;
-                PTO2TaskId t__tmp_v231 = down_tids_inline156[78];
+                TaskId t__tmp_v231 = down_tids_inline156[78];
                 _submit_deps_buf_inline123[78] = t__tmp_v231;
-                PTO2TaskId t__tmp_v232 = down_tids_inline156[79];
+                TaskId t__tmp_v232 = down_tids_inline156[79];
                 _submit_deps_buf_inline123[79] = t__tmp_v232;
-                PTO2TaskId t__tmp_v233 = down_tids_inline156[80];
+                TaskId t__tmp_v233 = down_tids_inline156[80];
                 _submit_deps_buf_inline123[80] = t__tmp_v233;
-                PTO2TaskId t__tmp_v234 = down_tids_inline156[81];
+                TaskId t__tmp_v234 = down_tids_inline156[81];
                 _submit_deps_buf_inline123[81] = t__tmp_v234;
-                PTO2TaskId t__tmp_v235 = down_tids_inline156[82];
+                TaskId t__tmp_v235 = down_tids_inline156[82];
                 _submit_deps_buf_inline123[82] = t__tmp_v235;
-                PTO2TaskId t__tmp_v236 = down_tids_inline156[83];
+                TaskId t__tmp_v236 = down_tids_inline156[83];
                 _submit_deps_buf_inline123[83] = t__tmp_v236;
-                PTO2TaskId t__tmp_v237 = down_tids_inline156[84];
+                TaskId t__tmp_v237 = down_tids_inline156[84];
                 _submit_deps_buf_inline123[84] = t__tmp_v237;
 
                 // Spmd dcr_xgamma_spmd: dcr_xgamma
@@ -1782,7 +1782,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 params_t34.add_scalar(next_gamma_idx);
                 params_t34.launch_spec.set_core_num(5);
                 params_t34.set_allow_early_resolve(true);
-                PTO2TaskId params_t34_deps[85];
+                TaskId params_t34_deps[85];
                 uint32_t params_t34_deps_count = 0;
                 if (_submit_deps_buf_inline123[0].is_valid())
                     params_t34_deps[params_t34_deps_count++] = _submit_deps_buf_inline123[0];
@@ -1956,7 +1956,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_t34_deps[params_t34_deps_count++] = _submit_deps_buf_inline123[84];
                 params_t34.set_dependencies(params_t34_deps, params_t34_deps_count);
                 TaskOutputTensors task_34_outs = rt_submit_aiv_task(35, params_t34);
-                PTO2TaskId dcr_tid_inline58 = task_34_outs.task_id();
+                TaskId dcr_tid_inline58 = task_34_outs.task_id();
                 prev_out_tid[0] = dcr_tid_inline58;
                 prev_normed_tid[0] = dcr_tid_inline58;
                 ChipTensor cur__ssa_v8 = next_hidden;

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -104,7 +104,7 @@ def normalize_pto2_task_id_int(v):
 def format_task_display(task_id):
     """Format PTO2 task_id for human-readable labels.
 
-    Layout: 64-bit raw = (ring_id << 32) | local_id (same as runtime PTO2TaskId).
+    Layout: 64-bit raw = (ring_id << 32) | local_id (same as runtime TaskId).
 
     Returns:
         ``r{ring}t{local}`` when ring != 0 (e.g. r2t100), else ``t{local}`` for single-ring (ring 0).
@@ -2121,7 +2121,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                 # Strip "orch_" prefix for display name
                 display_name = phase.replace("orch_", "") if phase.startswith("orch_") else phase
 
-                # Full PTO2TaskId in JSON (device uses task_id.raw, same as TensorMap) → rXtY / tY
+                # Full TaskId in JSON (device uses task_id.raw, same as TensorMap) → rXtY / tY
                 if task_id >= 0:
                     label = f"{display_name}({format_task_display(task_id)})"
                 else:

--- a/src/a2a3/runtime/host_build_graph/common/intrinsic.h
+++ b/src/a2a3/runtime/host_build_graph/common/intrinsic.h
@@ -122,13 +122,13 @@ struct AsyncCtx {
     volatile __gm__ int32_t *completion_error_code;
     volatile __gm__ DeferredCompletionEntry *completion_entries;
     uint32_t completion_capacity;
-    PTO2TaskId task_token;
+    TaskId task_token;
 
-    static inline AsyncCtx make(PTO2TaskId task_token, volatile __gm__ DeferredCompletionSlab *buffer) {
+    static inline AsyncCtx make(TaskId task_token, volatile __gm__ DeferredCompletionSlab *buffer) {
         AsyncCtx ctx{};
         ctx.task_token = task_token;
         if (buffer == nullptr) {
-            ctx.task_token = PTO2TaskId::invalid();
+            ctx.task_token = TaskId::invalid();
             return ctx;
         }
         ctx.completion_count = &buffer->count;

--- a/src/a2a3/runtime/host_build_graph/orchestration/arg_with_deps.h
+++ b/src/a2a3/runtime/host_build_graph/orchestration/arg_with_deps.h
@@ -73,7 +73,7 @@ public:
     /**
      * Append one or more dependencies to the bundled buffer. May be called
      * multiple times; deps accumulate. Variadic accepts any non-zero number
-     * of PTO2TaskId arguments.
+     * of TaskId arguments.
      *
      * Overflow (more than MAX_DEP_COUNT total) records an error on the
      * underlying Arg; the error surfaces at submit time.
@@ -81,9 +81,7 @@ public:
     template <typename... Ids>
     void add_dep(Ids... ids) {
         static_assert(sizeof...(Ids) >= 1, "add_dep: at least one task id is required");
-        static_assert(
-            (std::is_same_v<std::decay_t<Ids>, PTO2TaskId> && ...), "add_dep: all arguments must be PTO2TaskId"
-        );
+        static_assert((std::is_same_v<std::decay_t<Ids>, TaskId> && ...), "add_dep: all arguments must be TaskId");
         if (count_ + sizeof...(Ids) > MAX_DEP_COUNT) {
             CoreTaskArgs::set_error(
                 "CoreTaskArgsWithDeps::add_dep: dep count exceeds MAX_DEP_COUNT (bump the template arg)"
@@ -118,7 +116,7 @@ public:
     }
 
 private:
-    PTO2TaskId deps_[MAX_DEP_COUNT];
+    TaskId deps_[MAX_DEP_COUNT];
     uint32_t count_ = 0;
 };
 

--- a/src/a2a3/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
@@ -50,7 +50,7 @@ struct AICoreCompletionMailboxMessage {
     // value with an acquire load. The release-acquire pair publishes all
     // other fields below as a side effect, so they stay plain.
     std::atomic<uint64_t> seq;
-    PTO2TaskId task_token;
+    TaskId task_token;
     // CONDITION: completion observation addr (counter / backend record).
     // TASK_NORMAL_DONE: PTO2TaskSlotState pointer carried over to the consumer
     //   so it can finalize the AsyncWaitEntry.slot_state binding.
@@ -77,7 +77,7 @@ static_assert(
 // payload, so try_pop copies out only the fields below (and seq is not even
 // copyable — it is a std::atomic).
 struct AICoreCompletionMsgView {
-    PTO2TaskId task_token{PTO2TaskId::invalid()};
+    TaskId task_token{TaskId::invalid()};
     uint64_t addr{0};
     uint64_t backend_cookie{0};
     uint32_t expected_value{0};
@@ -139,13 +139,13 @@ struct AICoreCompletionMailbox {
     // Safe to call concurrently from any number of producers; structurally
     // independent of the AsyncWaitList::busy lock.
     bool try_push_condition(
-        PTO2TaskId task_token, uint64_t addr, uint32_t expected_value, uint32_t engine, int32_t completion_type
+        TaskId task_token, uint64_t addr, uint32_t expected_value, uint32_t engine, int32_t completion_type
     ) {
         return try_push_condition(task_token, addr, 0, expected_value, engine, completion_type);
     }
 
     bool try_push_condition(
-        PTO2TaskId task_token, uint64_t addr, uint64_t backend_cookie, uint32_t expected_value, uint32_t engine,
+        TaskId task_token, uint64_t addr, uint64_t backend_cookie, uint32_t expected_value, uint32_t engine,
         int32_t completion_type
     ) {
         while (true) {
@@ -172,7 +172,7 @@ struct AICoreCompletionMailbox {
     // MPSC push for a TASK_NORMAL_DONE sentinel. Carries the PTO2TaskSlotState
     // pointer in the `addr` field so the consumer can finish binding the
     // AsyncWaitEntry.slot_state without going back to the FIN-handling thread.
-    bool try_push_normal_done(PTO2TaskId task_token, uint64_t slot_state_addr) {
+    bool try_push_normal_done(TaskId task_token, uint64_t slot_state_addr) {
         while (true) {
             uint64_t h = head.load(std::memory_order_relaxed);
             uint64_t t = tail.load(std::memory_order_acquire);

--- a/src/a2a3/runtime/host_build_graph/runtime/async_wait.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/async_wait.h
@@ -115,7 +115,7 @@ inline void CompletionCondition::retire() {
 
 struct AsyncWaitEntry {
     PTO2TaskSlotState *slot_state{nullptr};
-    PTO2TaskId task_token{PTO2TaskId::invalid()};
+    TaskId task_token{TaskId::invalid()};
     CompletionCondition conditions[MAX_COMPLETIONS_PER_TASK];
     int32_t condition_count{0};
     int32_t waiting_completion_count{0};
@@ -161,7 +161,7 @@ struct AsyncWaitList {
 
     void unlock() { busy.store(0, std::memory_order_release); }
 
-    AsyncWaitEntry *find_entry_by_token(PTO2TaskId token) {
+    AsyncWaitEntry *find_entry_by_token(TaskId token) {
         for (int32_t i = 0; i < count; i++) {
             if (entries[i].task_token == token) return &entries[i];
         }

--- a/src/a2a3/runtime/host_build_graph/runtime/dep_compute.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/dep_compute.h
@@ -29,13 +29,13 @@
  * the minor structural overlap.
  *
  * The Emit callback contract:
- *   bool emit(PTO2TaskId producer);
+ *   bool emit(TaskId producer);
  *     - return true to continue (whether or not the producer was actually recorded —
  *       producer-not-alive / dedup-hit / etc. all return true silently)
  *     - return false to signal fatal (e.g. fanin spill overflow); caller bails
  *
  * The Annotate callback contract (dep_gen graph capture):
- *   void annotate.creator(int32_t arg_idx, const ChipTensor &consumer, PTO2TaskId producer);
+ *   void annotate.creator(int32_t arg_idx, const ChipTensor &consumer, TaskId producer);
  *   void annotate.tensormap(int32_t arg_idx, const ChipTensor &consumer,
  *                           const PTO2TensorMapEntry &entry, OverlapStatus overlap);
  * Both fire for exactly the producers `emit` saw, with the tensor-side context an
@@ -71,7 +71,7 @@ struct DepInputs {
     const TensorRef *tensors;        // length = tensor_count (union; OUTPUT slots' .ptr is unused)
     const TensorArgType *arg_types;  // length = tensor_count
     int32_t explicit_dep_count;
-    const PTO2TaskId *explicit_deps;  // length = explicit_dep_count (validity checked by caller)
+    const TaskId *explicit_deps;  // length = explicit_dep_count (validity checked by caller)
 };
 
 /**
@@ -79,7 +79,7 @@ struct DepInputs {
  * costs exactly what it did before the hooks existed.
  */
 struct NoDepAnnotate {
-    void creator(int32_t, const ChipTensor &, PTO2TaskId) const {}
+    void creator(int32_t, const ChipTensor &, TaskId) const {}
     void tensormap(int32_t, const ChipTensor &, const PTO2TensorMapEntry &, OverlapStatus) const {}
 };
 
@@ -114,7 +114,7 @@ template <typename Emit, typename Annotate = NoDepAnnotate>
         const ChipTensor *tensor = &inputs.tensors[i].ref();
 
         // Step A: creator retention — all existing tensors extend their creator lifetime.
-        PTO2TaskId owner = tensor->owner_task_id;
+        TaskId owner = tensor->owner_task_id;
         if (owner.is_valid()) {
             if (!emit(owner)) {
                 return false;
@@ -158,7 +158,7 @@ template <typename Emit, typename Annotate = NoDepAnnotate>
  * No-op when in_manual_scope.
  */
 inline void
-register_task_outputs(const DepInputs &inputs, PTO2TaskId task_id, PTO2TensorMap &tensor_map, bool in_manual_scope) {
+register_task_outputs(const DepInputs &inputs, TaskId task_id, PTO2TensorMap &tensor_map, bool in_manual_scope) {
     if (in_manual_scope) {
         return;
     }

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -77,7 +77,7 @@ __attribute__((weak, visibility("hidden"))) void dep_gen_host_graph_end_task() {
 // instantiation. Shared by the ordinary submit path and the outer GRAPH task so
 // both describe an edge the same way.
 struct DepGraphAnnotate {
-    void creator(int32_t arg_idx, const ChipTensor &consumer, PTO2TaskId producer) const {
+    void creator(int32_t arg_idx, const ChipTensor &consumer, TaskId producer) const {
         dep_gen_host_graph_add_creator_edge(producer.raw, arg_idx, consumer);
     }
     void tensormap(
@@ -961,7 +961,7 @@ struct PTO2FaninBuilder {
 
 static bool append_fanin_or_fail(
     PTO2OrchestratorState *orch, uint8_t prod_ring, int32_t prod_slot, PTO2TaskSlotState *prod_state,
-    PTO2TaskId producer_task_id, PTO2FaninBuilder *fanin_builder
+    TaskId producer_task_id, PTO2FaninBuilder *fanin_builder
 ) {
     // Skip a stale/reused producer slot: the cached owner id no longer resolves
     // to this producer (defensive — whole-graph-resident hbg does not reuse slots
@@ -1001,7 +1001,7 @@ static bool append_fanin_or_fail(
 static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state);
 
 struct PTO2PreparedTask {
-    PTO2TaskId task_id = PTO2TaskId::invalid();
+    TaskId task_id = TaskId::invalid();
     PTO2TaskAllocResult alloc_result = {-1, 0, nullptr, nullptr};
     PTO2TaskDescriptor *task = nullptr;
     PTO2TaskPayload *payload = nullptr;
@@ -1048,7 +1048,7 @@ static bool prepare_task(
         return false;
     }
 
-    out->task_id = PTO2TaskId::make(ring_id, static_cast<uint32_t>(out->alloc_result.task_id));
+    out->task_id = TaskId::make(ring_id, static_cast<uint32_t>(out->alloc_result.task_id));
     out->slot_state = &orch->sm_header->ring.get_slot_state_by_slot(out->alloc_result.slot);
     out->task = &orch->sm_header->ring.task_descriptors[out->alloc_result.slot];
     out->payload = &orch->sm_header->ring.task_payloads[out->alloc_result.slot];
@@ -1316,7 +1316,7 @@ static TaskOutputTensors submit_task_common(
         return result;
     }
     PTO2SchedulerState *sched = orch->scheduler;
-    PTO2TaskId task_id = prepared.task_id;
+    TaskId task_id = prepared.task_id;
     PTO2TaskDescriptor &task = *prepared.task;
     PTO2TaskPayload &payload = *prepared.payload;
     result.set_task_id(task_id);
@@ -1351,7 +1351,7 @@ static TaskOutputTensors submit_task_common(
 #endif
 
     for (uint32_t i = 0; i < args.explicit_dep_count(); i++) {
-        PTO2TaskId dep_task_id = args.explicit_dep(i);
+        TaskId dep_task_id = args.explicit_dep(i);
         if (!dep_task_id.is_valid()) {
             orch->report_fatal(
                 SIMPLER_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.set_dependencies(...) requires valid task ids"
@@ -1377,7 +1377,7 @@ static TaskOutputTensors submit_task_common(
         args.explicit_deps_data(),
     };
 
-    auto runtime_emit = [&](PTO2TaskId producer_task_id) -> bool {
+    auto runtime_emit = [&](TaskId producer_task_id) -> bool {
         uint8_t prod_ring = producer_task_id.ring();
         PTO2SharedMemoryRingHeader &producer_ring = orch->sm_header->ring;
         int32_t prod_slot = producer_ring.get_slot_by_task_id(static_cast<int32_t>(producer_task_id.local()));
@@ -1607,7 +1607,7 @@ void graph_reset_outer_payload(PTO2TaskPayload &payload) {
 
 bool graph_submit_outer(
     PTO2OrchestratorState *orch, GraphHostState *state, uint64_t full_key, uint64_t definition_hash, int32_t owned_heap,
-    bool defer_heap, const GraphTaskArgs &args, PTO2TaskId *submitted_id
+    bool defer_heap, const GraphTaskArgs &args, TaskId *submitted_id
 ) {
     always_assert(orch->scope_stack_top >= 0 && "Cannot submit Graph outside a scope");
     auto &allocator = orch->ring.task_allocator;
@@ -1650,7 +1650,7 @@ bool graph_submit_outer(
         orch_mark_fatal(orch, SIMPLER_ERROR_HEAP_RING_DEADLOCK);
         return false;
     }
-    const PTO2TaskId task_id = PTO2TaskId::make(0, static_cast<uint32_t>(allocation.task_id));
+    const TaskId task_id = TaskId::make(0, static_cast<uint32_t>(allocation.task_id));
     PTO2SharedMemoryRingHeader &ring = orch->sm_header->ring;
     PTO2TaskDescriptor &task = ring.task_descriptors[allocation.slot];
     PTO2TaskPayload &payload = ring.task_payloads[allocation.slot];
@@ -1702,7 +1702,7 @@ bool graph_submit_outer(
     }
 
     PTO2FaninBuilder fanin_builder(orch, &payload, static_cast<int32_t>(task_id.local()), next_fanin_seen_epoch(orch));
-    auto emit = [&](PTO2TaskId producer_id) -> bool {
+    auto emit = [&](TaskId producer_id) -> bool {
         const int32_t producer_local = static_cast<int32_t>(producer_id.local());
         const int32_t producer_slot = ring.get_slot_by_task_id(producer_local);
         PTO2TaskSlotState *producer = &ring.get_slot_state_by_slot(producer_slot);
@@ -1753,7 +1753,7 @@ bool graph_submit_outer(
 
 bool graph_submit_definition(
     PTO2OrchestratorState *orch, GraphHostState *state, const std::vector<std::byte> &definition_image,
-    const GraphTaskArgs &args, PTO2TaskId *submitted_id
+    const GraphTaskArgs &args, TaskId *submitted_id
 ) {
     const GraphDefinition *definition = graph_definition(definition_image);
     if (definition == nullptr || !graph_boundary_matches(*definition, args) ||
@@ -1771,7 +1771,7 @@ bool graph_submit_definition(
 
 bool graph_submit_pending_definition(
     PTO2OrchestratorState *orch, GraphHostState *state, uint64_t full_key, const GraphTaskArgs &args,
-    PTO2TaskId *submitted_id
+    TaskId *submitted_id
 ) {
     return graph_submit_outer(orch, state, full_key, 0, 0, true, args, submitted_id);
 }
@@ -1832,8 +1832,8 @@ TaskOutputTensors graph_record_submit_node(
     // A recorded node's index equals its local task id minus the recording
     // baseline, so its synthetic id keeps classification and explicit-dep
     // arithmetic identical to the ordinary path.
-    const PTO2TaskId task_id =
-        PTO2TaskId::make(0, static_cast<uint32_t>(recording.start_local_task_id) + static_cast<uint32_t>(node_index));
+    const TaskId task_id =
+        TaskId::make(0, static_cast<uint32_t>(recording.start_local_task_id) + static_cast<uint32_t>(node_index));
     result.set_task_id(task_id);
 
     if (node_index >= GRAPH_MAX_NODES || args.has_error) {
@@ -2015,7 +2015,7 @@ TaskOutputTensors graph_record_submit_node(
             );
             recording.unsupported = true;
         } else {
-            auto emit_inferred = [&recording, &add_fanin, node_index](PTO2TaskId producer) -> bool {
+            auto emit_inferred = [&recording, &add_fanin, node_index](TaskId producer) -> bool {
                 const int32_t producer_index = static_cast<int32_t>(producer.local()) - recording.start_local_task_id;
                 if (producer.ring() == 0 && producer_index >= 0 && producer_index < static_cast<int32_t>(node_index)) {
                     add_fanin(static_cast<size_t>(producer_index));
@@ -2027,7 +2027,7 @@ TaskOutputTensors graph_record_submit_node(
         }
     }
     for (uint32_t i = 0; i < args.explicit_dep_count(); ++i) {
-        const PTO2TaskId dep = args.explicit_dep(i);
+        const TaskId dep = args.explicit_dep(i);
         const int32_t dep_index = static_cast<int32_t>(dep.local()) - recording.start_local_task_id;
         if (!dep.is_valid() || dep.ring() != 0 || dep_index >= static_cast<int32_t>(node_index)) {
             recording.unsupported = true;
@@ -2087,7 +2087,7 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
     // would make an already-built Definition wait for an unrelated one.
     auto definition_it = state->definitions.find(full_key);
     if (definition_it != state->definitions.end()) {
-        PTO2TaskId submitted = PTO2TaskId::invalid();
+        TaskId submitted = TaskId::invalid();
         ORCH_PHASE_START();
         if (graph_submit_definition(orch, state, definition_it->second, args, &submitted)) {
             result.execute_block = false;
@@ -2113,7 +2113,7 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
             !graph_recording_boundary_matches(*entry.recording, args)) {
             return result;
         }
-        PTO2TaskId submitted = PTO2TaskId::invalid();
+        TaskId submitted = TaskId::invalid();
         ORCH_PHASE_START();
         if (graph_submit_pending_definition(orch, state, full_key, args, &submitted)) {
             result.execute_block = false;
@@ -2162,7 +2162,7 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
     state->inflight.emplace(full_key, std::move(entry));
     state->inflight_count.store(state->inflight.size(), std::memory_order_release);
 
-    PTO2TaskId submitted = PTO2TaskId::invalid();
+    TaskId submitted = TaskId::invalid();
     ORCH_PHASE_START();
     if (graph_submit_pending_definition(orch, state, full_key, args, &submitted)) {
         result.execute_block = false;

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
@@ -159,7 +159,7 @@ void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, cons
 MAYBE_UNINITIALIZED_BEGIN
 static bool
 wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_consumers, const char *caller) {
-    PTO2TaskId owner = tensor.owner_task_id;
+    TaskId owner = tensor.owner_task_id;
     PTO2OrchestratorState &orch = *rt->orchestrator;
 
     // Segmented wait: collect up to kSegmentCap producer slots, then flush by
@@ -176,7 +176,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
     // Returns nullptr for every rejected producer, having latched the fatal.
     // Callers branch on the returned pointer, not on `failed`: the slot is
     // dereferenced immediately and a null return is the only safe signal.
-    auto resolve_producer = [&](PTO2TaskId producer) -> const PTO2TaskSlotState * {
+    auto resolve_producer = [&](TaskId producer) -> const PTO2TaskSlotState * {
         if (!producer.is_valid() || producer.ring() != 0) {
             orch.report_fatal(
                 SIMPLER_ERROR_INVALID_ARGS, caller,
@@ -294,7 +294,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
 
         // Step B: modifier writer lookup (OverlapMap), direct callback
         orch.tensor_map.lookup(tensor, [&](PTO2TensorMapEntry &entry, OverlapStatus) -> bool {
-            PTO2TaskId pid = entry.producer_task_id;
+            TaskId pid = entry.producer_task_id;
             const auto *slot = resolve_producer(pid);
             if (slot == nullptr) return false;
             try_push(*slot);

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime_types.h
@@ -209,7 +209,7 @@ struct PTO2TaskSlotState;  // Forward declaration (defined below)
  */
 struct PTO2TaskDescriptor {
     // Mixed-task identification (encodes ring_id in upper 32 bits)
-    PTO2TaskId task_id;  // raw: (ring_id << 32) | local_id
+    TaskId task_id;  // raw: (ring_id << 32) | local_id
 
     // Per-slot kernel IDs (INVALID_KERNEL_ID = inactive)
     int32_t kernel_id[PTO2_SUBTASK_SLOT_COUNT];

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -133,7 +133,7 @@ void SchedulerContext::complete_slot_task(
             // be this thread or a later one).
             slot_state.mark_any_subtask_deferred();
 
-            const PTO2TaskId token = slot_state.task->task_id;
+            const TaskId token = slot_state.task->task_id;
             for (uint32_t i = 0; i < cond_count; ++i) {
                 volatile DeferredCompletionEntry *e = &deferred_slab->entries[i];
                 while (!mailbox->try_push_condition(

--- a/src/a2a3/runtime/host_build_graph/runtime/tensor_create_info.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/tensor_create_info.h
@@ -114,7 +114,7 @@ inline void init_tensor_from_create_info(ChipTensor &t, const TensorCreateInfo &
     always_assert(ci.ndims > 0 && ci.ndims <= MAX_TENSOR_DIMS);
     memcpy(&t, &ci, 64);
     t.buffer = {reinterpret_cast<uint64_t>(addr), buffer_size};
-    t.owner_task_id = PTO2TaskId::invalid();  // caller (orchestrator) overwrites with actual task_id
+    t.owner_task_id = TaskId::invalid();  // caller (orchestrator) overwrites with actual task_id
     uint32_t s = 1;
     for (int32_t i = static_cast<int32_t>(t.ndims) - 1; i >= 0; --i) {
         t.strides[i] = s;

--- a/src/a2a3/runtime/host_build_graph/runtime/tensormap.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/tensormap.h
@@ -115,15 +115,15 @@ struct alignas(64) PTO2TensorMapEntry {
     // === Cache line 1 (64B) — lookup hot path; mirrors ChipTensor line 1 from byte 16 ===
     uint64_t buffer_addr;  // 8B [0, 8):   tensor base address (hash key, mirrors ChipTensor::buffer.addr)
     PTO2TensorMapEntry
-        *next_in_bucket;          // 8B [8, 16):  next entry in hash bucket chain (overlays ChipTensor::buffer.size)
-    PTO2TaskId producer_task_id;  // 8B [16,24):  mirrors ChipTensor::owner_task_id slot
-    uint64_t start_offset;        // 8B [24,32):  mirrors ChipTensor::start_offset (element offset)
-    int32_t version;              // 4B [32,36):  mirrors ChipTensor::version
-    uint32_t ndims;               // 4B [36,40):  mirrors ChipTensor::ndims
-    DataType dtype;               // 1B [40,41):  mirrors ChipTensor::dtype
-    bool manual_dep;              // 1B [41,42):  mirrors ChipTensor::manual_dep
-    bool is_contiguous;           // 1B [42,43):  mirrors ChipTensor::is_contiguous
-    uint8_t __padding1__;         // 1B [43,44):  mirrors ChipTensor padding
+        *next_in_bucket;      // 8B [8, 16):  next entry in hash bucket chain (overlays ChipTensor::buffer.size)
+    TaskId producer_task_id;  // 8B [16,24):  mirrors ChipTensor::owner_task_id slot
+    uint64_t start_offset;    // 8B [24,32):  mirrors ChipTensor::start_offset (element offset)
+    int32_t version;          // 4B [32,36):  mirrors ChipTensor::version
+    uint32_t ndims;           // 4B [36,40):  mirrors ChipTensor::ndims
+    DataType dtype;           // 1B [40,41):  mirrors ChipTensor::dtype
+    bool manual_dep;          // 1B [41,42):  mirrors ChipTensor::manual_dep
+    bool is_contiguous;       // 1B [42,43):  mirrors ChipTensor::is_contiguous
+    uint8_t __padding1__;     // 1B [43,44):  mirrors ChipTensor padding
     uint32_t shapes[MAX_TENSOR_DIMS];  // 20B [44,64): mirrors ChipTensor::shapes
 
     // === Cache line 2 (64B) — chain manipulation + non-contiguous overlap data ===
@@ -521,7 +521,7 @@ struct PTO2TensorMap {
      * @param tensor            ChipTensor produced
      * @param producer_task_id  Task ID of producer
      */
-    void insert(const ChipTensor &tensor, PTO2TaskId producer_task_id) {
+    void insert(const ChipTensor &tensor, TaskId producer_task_id) {
         PTO2TensorMapEntry *entry = new_entry();
         entry->copy_from_tensor(tensor);
         link_entry(entry, tensor.buffer.addr, producer_task_id);
@@ -547,7 +547,7 @@ struct PTO2TensorMap {
     /**
      * Link an initialized entry into bucket and task chains.
      */
-    void link_entry(PTO2TensorMapEntry *entry, uint64_t addr, PTO2TaskId producer_task_id) {
+    void link_entry(PTO2TensorMapEntry *entry, uint64_t addr, TaskId producer_task_id) {
 #if SIMPLER_TENSORMAP_PROFILING
         g_insert_count++;
 #endif

--- a/src/a2a3/runtime/host_build_graph/runtime/types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/types.h
@@ -105,7 +105,7 @@ enum class PTO2ScopeMode : uint8_t {
 class TaskOutputTensors {
 public:
     TaskOutputTensors() :
-        task_id_(PTO2TaskId::invalid()),
+        task_id_(TaskId::invalid()),
         output_count_(0) {}
 
     bool empty() const { return output_count_ == 0; }
@@ -124,12 +124,12 @@ public:
         tensors_[output_count_++] = &tensor;
     }
 
-    void set_task_id(PTO2TaskId id) { task_id_ = id; }
+    void set_task_id(TaskId id) { task_id_ = id; }
 
-    PTO2TaskId task_id() const { return task_id_; }
+    TaskId task_id() const { return task_id_; }
 
 private:
-    PTO2TaskId task_id_;
+    TaskId task_id_;
     uint32_t output_count_;
     // Upper bound: a task cannot have more outputs than total tensor args
     // (every OUTPUT/OUTPUT_EXISTING slot is one of the Arg's tensor slots).
@@ -389,7 +389,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
      * count == 0 is a valid "set empty" — it clears any previously stored deps
      * and returns. This lets callers that build the dep set conditionally pass
      * the result through unguarded, including in the no-dep branch:
-     *   PTO2TaskId deps[3];
+     *   TaskId deps[3];
      *   uint32_t n = 0;
      *   if (have_prev) deps[n++] = prev;
      *   if (is_last)   deps[n++] = alloc;
@@ -399,7 +399,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
      * deps are already set will fail with set_error(). Use count == 0 first
      * if you need to re-set.
      */
-    void set_dependencies(const PTO2TaskId *deps, uint32_t count) {
+    void set_dependencies(const TaskId *deps, uint32_t count) {
         if (count == 0) {
             explicit_deps_ = nullptr;
             explicit_dep_count_ = 0;
@@ -419,12 +419,12 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
 
     uint32_t explicit_dep_count() const { return explicit_dep_count_; }
 
-    PTO2TaskId explicit_dep(uint32_t index) const {
+    TaskId explicit_dep(uint32_t index) const {
         always_assert(index < explicit_dep_count_);
         return explicit_deps_[index];
     }
 
-    const PTO2TaskId *explicit_deps_data() const { return explicit_deps_; }
+    const TaskId *explicit_deps_data() const { return explicit_deps_; }
 
     /**
      * Add scalar values. Types are deduced per argument; each value is
@@ -560,7 +560,7 @@ private:
 #if SIMPLER_DFX
     DumpArgSelection dump_arg_selection_;
 #endif
-    const PTO2TaskId *explicit_deps_{nullptr};
+    const TaskId *explicit_deps_{nullptr};
     uint32_t explicit_dep_count_{0};
 #if SIMPLER_DFX
     template <typename T>

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -132,13 +132,13 @@ struct AsyncCtx {
     volatile __gm__ int32_t *completion_error_code;
     volatile __gm__ DeferredCompletionEntry *completion_entries;
     uint32_t completion_capacity;
-    PTO2TaskId task_token;
+    TaskId task_token;
 
-    static inline AsyncCtx make(PTO2TaskId task_token, volatile __gm__ DeferredCompletionSlab *buffer) {
+    static inline AsyncCtx make(TaskId task_token, volatile __gm__ DeferredCompletionSlab *buffer) {
         AsyncCtx ctx{};
         ctx.task_token = task_token;
         if (buffer == nullptr) {
-            ctx.task_token = PTO2TaskId::invalid();
+            ctx.task_token = TaskId::invalid();
             return ctx;
         }
         ctx.completion_count = &buffer->count;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -27,11 +27,11 @@ Task IDs are widened from 32-bit to 64-bit to carry the ring identity:
 task_id.raw = (ring_id << 32) | local_id
 ```
 
-`PTO2TaskId` exposes direct accessors in `src/common/task_interface/task_id.h`:
+`TaskId` exposes direct accessors in `src/common/task_interface/task_id.h`:
 
 | API | Purpose |
 | --- | ------- |
-| `PTO2TaskId::make(ring_id, local_id)` | Compose a 64-bit task ID (`PTO2TaskId`) |
+| `TaskId::make(ring_id, local_id)` | Compose a 64-bit task ID (`TaskId`) |
 | `task_id.ring()` | Extract `ring_id` (bits 63-32) |
 | `task_id.local()` | Extract `local_id` (bits 31-0) |
 | `task_id.raw` | Access the packed 64-bit encoding |
@@ -40,8 +40,8 @@ Type changes:
 
 | Field | Before | After |
 | ----- | ------ | ----- |
-| `PTO2TaskDescriptor.task_id` | `int32_t` | `PTO2TaskId` |
-| `PTO2TensorMapEntry.producer_task_id` | `int32_t` | `PTO2TaskId` |
+| `PTO2TaskDescriptor.task_id` | `int32_t` | `TaskId` |
+| `PTO2TensorMapEntry.producer_task_id` | `int32_t` | `TaskId` |
 | `PTO2TaskSlotState.ring_id` | N/A | `uint8_t` (new, denormalized for fast access) |
 
 ## 4. Data Structures

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -21,7 +21,7 @@
  *   ORACLE pass (read-only contract):
  *     Drives `compute_task_fanin` (the same template the device orchestrator
  *     uses in orchestrator.cpp:submit_task) against `tm_oracle`. Its emit
- *     fires with (PTO2TaskId, DepFlags) — the canonical (producer, WAIT/RETAIN)
+ *     fires with (TaskId, DepFlags) — the canonical (producer, WAIT/RETAIN)
  *     mapping the runtime would have wired, OR-accumulated per producer. This
  *     pass IS the contract, and any future change to `compute_task_fanin`
  *     automatically refreshes the oracle.
@@ -439,7 +439,7 @@ void annot_pass(
         const ChipTensor *tensor = &inputs.tensors[i].ref();
 
         // STEP A: creator retention.
-        PTO2TaskId owner = tensor->owner_task_id;
+        TaskId owner = tensor->owner_task_id;
         if (owner.is_valid()) {
             emit_creator(owner, i, *tensor);
         }
@@ -484,7 +484,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
     int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     uint32_t max_local[PTO2_MAX_RING_DEPTH] = {0};
     for (size_t i = 0; i < num_records; i++) {
-        PTO2TaskId tid{records[i].task_id};
+        TaskId tid{records[i].task_id};
         uint8_t ring = tid.ring();
         uint32_t local = tid.local();
         if (ring < PTO2_MAX_RING_DEPTH && local > max_local[ring]) {
@@ -556,7 +556,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         // overflow's reinterpreted bytes as tensor/dep info.
         if (rec.flags & DEP_GEN_FLAG_OVERFLOW) continue;
 
-        PTO2TaskId task_id{rec.task_id};
+        TaskId task_id{rec.task_id};
         bool in_manual_scope = (rec.flags & DEP_GEN_FLAG_IN_MANUAL_SCOPE) != 0;
 
         oracle_preds.clear();
@@ -653,7 +653,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         inputs.tensors = tref_buf;
         inputs.arg_types = atype_buf;
         inputs.explicit_dep_count = dc;
-        inputs.explicit_deps = reinterpret_cast<const PTO2TaskId *>(deps_data);
+        inputs.explicit_deps = reinterpret_cast<const TaskId *>(deps_data);
 
         // Register tasks[] entry (with per-arg slot info) and any unseen
         // tensors[] entries up-front. ChipTensors are registered from the
@@ -721,11 +721,10 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         }
 
         // ============ ORACLE pass — drive compute_task_fanin ============
-        bool ok =
-            compute_task_fanin(inputs, tm_oracle, in_manual_scope, [&](PTO2TaskId producer, DepFlags kind) -> bool {
-                oracle_preds[producer.raw] |= kind;
-                return true;
-            });
+        bool ok = compute_task_fanin(inputs, tm_oracle, in_manual_scope, [&](TaskId producer, DepFlags kind) -> bool {
+            oracle_preds[producer.raw] |= kind;
+            return true;
+        });
         if (!ok) {
             LOG_ERROR("dep_gen replay: compute_task_fanin returned fatal at task_id=%" PRIu64, rec.task_id);
             tm_oracle.destroy();
@@ -737,7 +736,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         annot_pass(
             inputs, tm_annot, in_manual_scope,
             // emit_creator(producer, arg_idx, consumer_tensor)
-            [&](PTO2TaskId producer, int32_t arg_idx, const ChipTensor &consumer) {
+            [&](TaskId producer, int32_t arg_idx, const ChipTensor &consumer) {
                 bool first = annot_preds.find(producer.raw) == annot_preds.end();
                 annot_preds[producer.raw] |= (DEP_WAIT | DEP_RETAIN);
                 if (!first) {
@@ -754,7 +753,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
                 annot_edges.push_back(e);
             },
             // emit_tensormap(producer, arg_idx, consumer_tensor, entry, status)
-            [&](PTO2TaskId producer, int32_t arg_idx, const ChipTensor &consumer, const PTO2TensorMapEntry &entry,
+            [&](TaskId producer, int32_t arg_idx, const ChipTensor &consumer, const PTO2TensorMapEntry &entry,
                 OverlapStatus status) {
                 // Per-(succ, arg_idx, producer_buffer_addr, producer_version)
                 // dedup gives us "the same producer slice fired twice for the

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.h
@@ -48,7 +48,7 @@
  *                 "producer_strides":[...] (tensormap)},
  *                ...]}
  *
- *   - All task ids are ``PTO2TaskId::raw`` values (``(ring_id << 32) | local_id``).
+ *   - All task ids are ``TaskId::raw`` values (``(ring_id << 32) | local_id``).
  *   - ``tensor_id`` is a stable FNV-1a hash of ``(buffer_addr, version)``.
  *   - ``buffer_numel`` is the underlying storage element count; tensor shapes
  *     are carried per-arg / per-edge alongside ``start_offset`` + ``strides``.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/arg_with_deps.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/arg_with_deps.h
@@ -75,7 +75,7 @@ public:
      * is kept alive (its slot/output buffer retained) until this consumer
      * completes. This is the conservative default — use it when the consumer reads
      * a tensor whose buffer the producer allocated. May be called multiple times;
-     * deps accumulate. Variadic accepts any non-zero number of PTO2TaskId args.
+     * deps accumulate. Variadic accepts any non-zero number of TaskId args.
      *
      * Overflow (more than MAX_DEP_COUNT total) records an error on the
      * underlying Arg; the error surfaces at submit time.
@@ -125,8 +125,7 @@ private:
     void add_dep_impl(DepFlags kind, Ids... ids) {
         static_assert(sizeof...(Ids) >= 1, "add_dep/add_dep_wait: at least one task id is required");
         static_assert(
-            (std::is_same_v<std::decay_t<Ids>, PTO2TaskId> && ...),
-            "add_dep/add_dep_wait: all arguments must be PTO2TaskId"
+            (std::is_same_v<std::decay_t<Ids>, TaskId> && ...), "add_dep/add_dep_wait: all arguments must be TaskId"
         );
         if (count_ + sizeof...(Ids) > MAX_DEP_COUNT) {
             CoreTaskArgs::set_error(
@@ -137,7 +136,7 @@ private:
         ((kinds_[count_] = kind, deps_[count_] = ids, ++count_), ...);
     }
 
-    PTO2TaskId deps_[MAX_DEP_COUNT];
+    TaskId deps_[MAX_DEP_COUNT];
     DepFlags kinds_[MAX_DEP_COUNT];
     uint32_t count_ = 0;
 };

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
@@ -51,7 +51,7 @@ struct AICoreCompletionMailboxMessage {
     // value with an acquire load. The release-acquire pair publishes all
     // other fields below as a side effect, so they stay plain.
     std::atomic<uint64_t> seq;
-    PTO2TaskId task_token;
+    TaskId task_token;
     // CONDITION: completion observation addr (counter / backend record).
     // TASK_NORMAL_DONE: PTO2TaskSlotState pointer carried over to the consumer
     //   so it can finalize the AsyncWaitEntry.slot_state binding.
@@ -78,7 +78,7 @@ static_assert(
 // payload, so try_pop copies out only the fields below (and seq is not even
 // copyable — it is a std::atomic).
 struct AICoreCompletionMsgView {
-    PTO2TaskId task_token{PTO2TaskId::invalid()};
+    TaskId task_token{TaskId::invalid()};
     uint64_t addr{0};
     uint64_t backend_cookie{0};
     uint32_t expected_value{0};
@@ -116,13 +116,13 @@ struct AICoreCompletionMailbox {
     // Safe to call concurrently from any number of producers; structurally
     // independent of the AsyncWaitList::busy lock.
     bool try_push_condition(
-        PTO2TaskId task_token, uint64_t addr, uint32_t expected_value, uint32_t engine, int32_t completion_type
+        TaskId task_token, uint64_t addr, uint32_t expected_value, uint32_t engine, int32_t completion_type
     ) {
         return try_push_condition(task_token, addr, 0, expected_value, engine, completion_type);
     }
 
     bool try_push_condition(
-        PTO2TaskId task_token, uint64_t addr, uint64_t backend_cookie, uint32_t expected_value, uint32_t engine,
+        TaskId task_token, uint64_t addr, uint64_t backend_cookie, uint32_t expected_value, uint32_t engine,
         int32_t completion_type
     ) {
         while (true) {
@@ -149,7 +149,7 @@ struct AICoreCompletionMailbox {
     // MPSC push for a TASK_NORMAL_DONE sentinel. Carries the PTO2TaskSlotState
     // pointer in the `addr` field so the consumer can finish binding the
     // AsyncWaitEntry.slot_state without going back to the FIN-handling thread.
-    bool try_push_normal_done(PTO2TaskId task_token, uint64_t slot_state_addr) {
+    bool try_push_normal_done(TaskId task_token, uint64_t slot_state_addr) {
         while (true) {
             uint64_t h = head.load(std::memory_order_relaxed);
             uint64_t t = tail.load(std::memory_order_acquire);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/async_wait.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/async_wait.h
@@ -116,7 +116,7 @@ inline void CompletionCondition::retire() {
 
 struct AsyncWaitEntry {
     PTO2TaskSlotState *slot_state{nullptr};
-    PTO2TaskId task_token{PTO2TaskId::invalid()};
+    TaskId task_token{TaskId::invalid()};
     CompletionCondition conditions[MAX_COMPLETIONS_PER_TASK];
     int32_t condition_count{0};
     int32_t waiting_completion_count{0};
@@ -167,7 +167,7 @@ struct AsyncWaitList {
 
     void unlock() { busy.store(0, std::memory_order_release); }
 
-    AsyncWaitEntry *find_entry_by_token(PTO2TaskId token) {
+    AsyncWaitEntry *find_entry_by_token(TaskId token) {
         for (int32_t i = 0; i < count; i++) {
             if (entries[i].task_token == token) return &entries[i];
         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/dep_compute.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/dep_compute.h
@@ -29,7 +29,7 @@
  * the minor structural overlap. Replay handles STEP 1 with a one-line loop of its own.
  *
  * The Emit callback contract:
- *   bool emit(PTO2TaskId producer, DepFlags kind);
+ *   bool emit(TaskId producer, DepFlags kind);
  *     - kind is DEP_WAIT|DEP_RETAIN for a Step-A creator edge (the consumer reads
  *       the producer's allocated buffer, so the producer is retained) and DEP_WAIT
  *       for a Step-B modifier edge (ordering only; the buffer was allocated
@@ -65,7 +65,7 @@ struct DepInputs {
     const TensorRef *tensors;        // length = tensor_count (union; OUTPUT slots' .ptr is unused)
     const TensorArgType *arg_types;  // length = tensor_count
     int32_t explicit_dep_count;
-    const PTO2TaskId *explicit_deps;  // length = explicit_dep_count (validity checked by caller)
+    const TaskId *explicit_deps;  // length = explicit_dep_count (validity checked by caller)
 };
 
 /**
@@ -99,7 +99,7 @@ compute_task_fanin(const DepInputs &inputs, PTO2TensorMap &tensor_map, bool in_m
 
         // Step A: creator retention — reading a tensor retains its allocator, so
         // the creator edge carries both ordering and lifetime.
-        PTO2TaskId owner = tensor->owner_task_id;
+        TaskId owner = tensor->owner_task_id;
         if (owner.is_valid()) {
             if (!emit(owner, DEP_WAIT | DEP_RETAIN)) {
                 return false;
@@ -151,7 +151,7 @@ compute_task_fanin(const DepInputs &inputs, PTO2TensorMap &tensor_map, bool in_m
  * No-op when in_manual_scope.
  */
 inline void
-register_task_outputs(const DepInputs &inputs, PTO2TaskId task_id, PTO2TensorMap &tensor_map, bool in_manual_scope) {
+register_task_outputs(const DepInputs &inputs, TaskId task_id, PTO2TensorMap &tensor_map, bool in_manual_scope) {
     if (in_manual_scope) {
         return;
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
@@ -317,7 +317,7 @@ private:
 
 static bool append_fanin_or_fail(
     PTO2OrchestratorState *orch, uint8_t prod_ring, int32_t prod_slot, PTO2TaskSlotState *prod_state,
-    PTO2TaskId producer_task_id, PTO2FaninBuilder *fanin_builder, uint8_t ring_id, DepFlags kind
+    TaskId producer_task_id, PTO2FaninBuilder *fanin_builder, uint8_t ring_id, DepFlags kind
 ) {
     // Decide-and-claim under the producer's fanout_lock. Two conditions make this
     // resolved slot a non-dependency, and both must be checked together with the
@@ -538,7 +538,7 @@ static bool orch_wire_live_fanin_task(PTO2OrchestratorState *orch, PTO2TaskSlotS
 static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state);
 
 struct PTO2PreparedTask {
-    PTO2TaskId task_id = PTO2TaskId::invalid();
+    TaskId task_id = TaskId::invalid();
     PTO2TaskAllocResult alloc_result = {-1, 0, nullptr, nullptr};
     PTO2TaskDescriptor *task = nullptr;
     PTO2TaskPayload *payload = nullptr;
@@ -609,7 +609,7 @@ static bool prepare_task(
         return false;
     }
 
-    out->task_id = PTO2TaskId::make(ring_id, static_cast<uint32_t>(out->alloc_result.task_id));
+    out->task_id = TaskId::make(ring_id, static_cast<uint32_t>(out->alloc_result.task_id));
     out->slot_state = &orch->sm_header->rings[ring_id].get_slot_state_by_slot(out->alloc_result.slot);
     out->task = &orch->sm_header->rings[ring_id].task_descriptors[out->alloc_result.slot];
     out->payload = &orch->sm_header->rings[ring_id].task_payloads[out->alloc_result.slot];
@@ -895,7 +895,7 @@ static TaskOutputTensors submit_task_common(
     uint8_t ring_id = prepared.task_id.ring();
     PTO2SchedulerState *sched = orch->scheduler;
     PTO2RingFlowControl &fc = orch->sm_header->rings[ring_id].fc;
-    PTO2TaskId task_id = prepared.task_id;
+    TaskId task_id = prepared.task_id;
     PTO2TaskSlotState &cur_slot_state = *prepared.slot_state;
     PTO2TaskDescriptor &task = *prepared.task;
     PTO2TaskPayload &payload = *prepared.payload;
@@ -957,7 +957,7 @@ static TaskOutputTensors submit_task_common(
     CYCLE_COUNT_LAP(g_orch_sync_cycle);
 
     for (uint32_t i = 0; i < args.explicit_dep_count(); i++) {
-        PTO2TaskId dep_task_id = args.explicit_dep(i);
+        TaskId dep_task_id = args.explicit_dep(i);
         if (!dep_task_id.is_valid()) {
             orch->report_fatal(
                 SIMPLER_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.set_dependencies(...) requires valid task ids"
@@ -987,7 +987,7 @@ static TaskOutputTensors submit_task_common(
         args.explicit_deps_data(),
     };
 
-    auto runtime_emit = [&](PTO2TaskId producer_task_id, DepFlags kind) -> bool {
+    auto runtime_emit = [&](TaskId producer_task_id, DepFlags kind) -> bool {
         uint8_t prod_ring = producer_task_id.ring();
         PTO2SharedMemoryRingHeader &producer_ring = orch->sm_header->rings[prod_ring];
         int32_t prod_slot = producer_ring.get_slot_by_task_id(static_cast<int32_t>(producer_task_id.local()));

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_core.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_core.cpp
@@ -98,7 +98,7 @@ void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, cons
 MAYBE_UNINITIALIZED_BEGIN
 static bool
 wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_consumers, const char *caller) {
-    PTO2TaskId owner = tensor.owner_task_id;
+    TaskId owner = tensor.owner_task_id;
     PTO2OrchestratorState &orch = rt->orchestrator;
 
     // Segmented wait: collect up to kSegmentCap producer slots, then flush by
@@ -197,7 +197,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
 
         // Step B: modifier writer lookup (OverlapMap), direct callback
         orch.tensor_map.lookup(tensor, [&](PTO2TensorMapEntry &entry, OverlapStatus) -> bool {
-            PTO2TaskId pid = entry.producer_task_id;
+            TaskId pid = entry.producer_task_id;
             auto &s = orch.sm_header->rings[pid.ring()].get_slot_state_by_task_id(pid.local());
             try_push(s);
             return !failed;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_types.h
@@ -217,7 +217,7 @@ struct PTO2DepListEntry {
  */
 struct PTO2TaskDescriptor {
     // Mixed-task identification (encodes ring_id in upper 32 bits)
-    PTO2TaskId task_id;  // raw: (ring_id << 32) | local_id
+    TaskId task_id;  // raw: (ring_id << 32) | local_id
 
     // Per-slot kernel IDs (INVALID_KERNEL_ID = inactive)
     int32_t kernel_id[PTO2_SUBTASK_SLOT_COUNT];

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -137,7 +137,7 @@ void SchedulerContext::complete_slot_task(
             // be this thread or a later one).
             slot_state.mark_any_subtask_deferred();
 
-            const PTO2TaskId token = slot_state.task->task_id;
+            const TaskId token = slot_state.task->task_id;
             for (uint32_t i = 0; i < cond_count; ++i) {
                 volatile DeferredCompletionEntry *e = &deferred_slab->entries[i];
                 while (!mailbox->try_push_condition(

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/tensormap.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/tensormap.cpp
@@ -112,7 +112,7 @@ bool PTO2TensorMap::init_data_from_layout(const PTO2TensorMapLayout &layout, Dev
         entry_pool_arena[i].prev_in_bucket = nullptr;
         entry_pool_arena[i].next_in_task = nullptr;
         entry_pool_arena[i].prev_in_task = nullptr;
-        entry_pool_arena[i].producer_task_id = PTO2TaskId{};
+        entry_pool_arena[i].producer_task_id = TaskId{};
     }
 
     // free_entry_list: zeroed (was calloc'd before); contents become meaningful
@@ -255,7 +255,7 @@ int32_t PTO2TensorMap::valid_count() {
     return count;
 }
 
-void PTO2TensorMap::sync_tensormap(PTO2TaskId task_id, int32_t sm_last_task_alive) {
+void PTO2TensorMap::sync_tensormap(TaskId task_id, int32_t sm_last_task_alive) {
     auto ring_id = task_id.ring();
     auto local_id = task_id.local();
     sync_validity(ring_id, sm_last_task_alive);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor_create_info.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor_create_info.h
@@ -134,7 +134,7 @@ inline void init_tensor_from_create_info(ChipTensor &t, const TensorCreateInfo &
     always_assert(ci.ndims > 0 && ci.ndims <= MAX_TENSOR_DIMS);
     memcpy(&t, &ci, 64);
     t.buffer = {reinterpret_cast<uint64_t>(addr), buffer_size};
-    t.owner_task_id = PTO2TaskId::invalid();  // caller (orchestrator) overwrites with actual task_id
+    t.owner_task_id = TaskId::invalid();  // caller (orchestrator) overwrites with actual task_id
     uint32_t s = 1;
     for (int32_t i = static_cast<int32_t>(t.ndims) - 1; i >= 0; --i) {
         t.strides[i] = s;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensormap.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensormap.h
@@ -128,15 +128,15 @@ struct alignas(64) PTO2TensorMapEntry {
     // === Cache line 1 (64B) — lookup hot path; mirrors ChipTensor line 1 from byte 16 ===
     uint64_t buffer_addr;  // 8B [0, 8):   tensor base address (hash key, mirrors ChipTensor::buffer.addr)
     PTO2TensorMapEntry
-        *next_in_bucket;          // 8B [8, 16):  next entry in hash bucket chain (overlays ChipTensor::buffer.size)
-    PTO2TaskId producer_task_id;  // 8B [16,24):  mirrors ChipTensor::owner_task_id slot
-    uint64_t start_offset;        // 8B [24,32):  mirrors ChipTensor::start_offset (element offset)
-    int32_t version;              // 4B [32,36):  mirrors ChipTensor::version
-    uint32_t ndims;               // 4B [36,40):  mirrors ChipTensor::ndims
-    DataType dtype;               // 1B [40,41):  mirrors ChipTensor::dtype
-    bool manual_dep;              // 1B [41,42):  mirrors ChipTensor::manual_dep
-    bool is_contiguous;           // 1B [42,43):  mirrors ChipTensor::is_contiguous
-    uint8_t __padding1__;         // 1B [43,44):  mirrors ChipTensor padding
+        *next_in_bucket;      // 8B [8, 16):  next entry in hash bucket chain (overlays ChipTensor::buffer.size)
+    TaskId producer_task_id;  // 8B [16,24):  mirrors ChipTensor::owner_task_id slot
+    uint64_t start_offset;    // 8B [24,32):  mirrors ChipTensor::start_offset (element offset)
+    int32_t version;          // 4B [32,36):  mirrors ChipTensor::version
+    uint32_t ndims;           // 4B [36,40):  mirrors ChipTensor::ndims
+    DataType dtype;           // 1B [40,41):  mirrors ChipTensor::dtype
+    bool manual_dep;          // 1B [41,42):  mirrors ChipTensor::manual_dep
+    bool is_contiguous;       // 1B [42,43):  mirrors ChipTensor::is_contiguous
+    uint8_t __padding1__;     // 1B [43,44):  mirrors ChipTensor padding
     uint32_t shapes[MAX_TENSOR_DIMS];  // 20B [44,64): mirrors ChipTensor::shapes
 
     // === Cache line 2 (64B) — chain manipulation + non-contiguous overlap data ===
@@ -588,7 +588,7 @@ struct PTO2TensorMap {
      * @param tensor            ChipTensor produced
      * @param producer_task_id  Task ID of producer
      */
-    void insert(const ChipTensor &tensor, PTO2TaskId producer_task_id) {
+    void insert(const ChipTensor &tensor, TaskId producer_task_id) {
         PTO2TensorMapEntry *entry = new_entry();
         entry->copy_from_tensor(tensor);
         link_entry(entry, tensor.buffer.addr, producer_task_id);
@@ -614,7 +614,7 @@ struct PTO2TensorMap {
             // reused the slot (local_id + N * window) before this cleanup ran.
             // Free only entries produced by the retiring local_id, unlinking
             // each from the chain; entries from other tasks stay linked.
-            PTO2TaskId retired_task = PTO2TaskId::make(static_cast<uint8_t>(ring_id), static_cast<uint32_t>(local_id));
+            TaskId retired_task = TaskId::make(static_cast<uint8_t>(ring_id), static_cast<uint32_t>(local_id));
             PTO2TensorMapEntry *cur_entry = task_entry_heads[ring_id][task_slot];
             while (cur_entry != nullptr) {
                 PTO2TensorMapEntry *next_entry = cur_entry->next_in_task;  // free_entry clears it
@@ -654,7 +654,7 @@ struct PTO2TensorMap {
     /**
      * Link an initialized entry into bucket and task chains.
      */
-    void link_entry(PTO2TensorMapEntry *entry, uint64_t addr, PTO2TaskId producer_task_id) {
+    void link_entry(PTO2TensorMapEntry *entry, uint64_t addr, TaskId producer_task_id) {
 #if SIMPLER_TENSORMAP_PROFILING
         g_insert_count++;
 #endif
@@ -753,7 +753,7 @@ struct PTO2TensorMap {
      * Called periodically to refresh the lazy invalidation threshold.
      * Also triggers cleanup if threshold has advanced significantly.
      */
-    void sync_tensormap(PTO2TaskId task_id, int32_t sm_last_task_alive);
+    void sync_tensormap(TaskId task_id, int32_t sm_last_task_alive);
 };
 
 #if SIMPLER_TENSORMAP_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/types.h
@@ -138,7 +138,7 @@ constexpr bool dep_has_retain(DepFlags f) { return (f & DEP_RETAIN) != DEP_NONE;
 class TaskOutputTensors {
 public:
     TaskOutputTensors() :
-        task_id_(PTO2TaskId::invalid()),
+        task_id_(TaskId::invalid()),
         output_count_(0) {}
 
     bool empty() const { return output_count_ == 0; }
@@ -157,12 +157,12 @@ public:
         tensors_[output_count_++] = &tensor;
     }
 
-    void set_task_id(PTO2TaskId id) { task_id_ = id; }
+    void set_task_id(TaskId id) { task_id_ = id; }
 
-    PTO2TaskId task_id() const { return task_id_; }
+    TaskId task_id() const { return task_id_; }
 
 private:
-    PTO2TaskId task_id_;
+    TaskId task_id_;
     uint32_t output_count_;
     // Upper bound: a task cannot have more outputs than total tensor args
     // (every OUTPUT/OUTPUT_EXISTING slot is one of the Arg's tensor slots).
@@ -419,7 +419,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
      * count == 0 is a valid "set empty" — it clears any previously stored deps
      * and returns. This lets callers that build the dep set conditionally pass
      * the result through unguarded, including in the no-dep branch:
-     *   PTO2TaskId deps[3];
+     *   TaskId deps[3];
      *   uint32_t n = 0;
      *   if (have_prev) deps[n++] = prev;
      *   if (is_last)   deps[n++] = alloc;
@@ -429,7 +429,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
      * deps are already set will fail with set_error(). Use count == 0 first
      * if you need to re-set.
      */
-    void set_dependencies(const PTO2TaskId *deps, uint32_t count) {
+    void set_dependencies(const TaskId *deps, uint32_t count) {
         if (count == 0) {
             explicit_deps_ = nullptr;
             explicit_dep_count_ = 0;
@@ -457,7 +457,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
      * with count > 0 is rejected; use set_dependencies() for the
      * conservative DEP_WAIT|DEP_RETAIN default.
      */
-    void set_dependencies_with_kinds(const PTO2TaskId *deps, const DepFlags *kinds, uint32_t count) {
+    void set_dependencies_with_kinds(const TaskId *deps, const DepFlags *kinds, uint32_t count) {
         if (count == 0) {
             explicit_deps_ = nullptr;
             explicit_dep_count_ = 0;
@@ -479,7 +479,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
 
     uint32_t explicit_dep_count() const { return explicit_dep_count_; }
 
-    PTO2TaskId explicit_dep(uint32_t index) const {
+    TaskId explicit_dep(uint32_t index) const {
         always_assert(index < explicit_dep_count_);
         return explicit_deps_[index];
     }
@@ -494,7 +494,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
         return explicit_dep_kinds_ ? explicit_dep_kinds_[index] : (DEP_WAIT | DEP_RETAIN);
     }
 
-    const PTO2TaskId *explicit_deps_data() const { return explicit_deps_; }
+    const TaskId *explicit_deps_data() const { return explicit_deps_; }
 
     /**
      * Add scalar values. Types are deduced per argument; each value is
@@ -592,7 +592,7 @@ private:
 #if SIMPLER_DFX
     DumpArgSelection dump_arg_selection_;
 #endif
-    const PTO2TaskId *explicit_deps_{nullptr};
+    const TaskId *explicit_deps_{nullptr};
     const DepFlags *explicit_dep_kinds_{nullptr};
     uint32_t explicit_dep_count_{0};
 #if SIMPLER_DFX

--- a/src/a5/runtime/host_build_graph/common/intrinsic.h
+++ b/src/a5/runtime/host_build_graph/common/intrinsic.h
@@ -122,13 +122,13 @@ struct AsyncCtx {
     volatile __gm__ int32_t *completion_error_code;
     volatile __gm__ DeferredCompletionEntry *completion_entries;
     uint32_t completion_capacity;
-    PTO2TaskId task_token;
+    TaskId task_token;
 
-    static inline AsyncCtx make(PTO2TaskId task_token, volatile __gm__ DeferredCompletionSlab *buffer) {
+    static inline AsyncCtx make(TaskId task_token, volatile __gm__ DeferredCompletionSlab *buffer) {
         AsyncCtx ctx{};
         ctx.task_token = task_token;
         if (buffer == nullptr) {
-            ctx.task_token = PTO2TaskId::invalid();
+            ctx.task_token = TaskId::invalid();
             return ctx;
         }
         ctx.completion_count = &buffer->count;

--- a/src/a5/runtime/host_build_graph/orchestration/arg_with_deps.h
+++ b/src/a5/runtime/host_build_graph/orchestration/arg_with_deps.h
@@ -73,7 +73,7 @@ public:
     /**
      * Append one or more dependencies to the bundled buffer. May be called
      * multiple times; deps accumulate. Variadic accepts any non-zero number
-     * of PTO2TaskId arguments.
+     * of TaskId arguments.
      *
      * Overflow (more than MAX_DEP_COUNT total) records an error on the
      * underlying Arg; the error surfaces at submit time.
@@ -81,9 +81,7 @@ public:
     template <typename... Ids>
     void add_dep(Ids... ids) {
         static_assert(sizeof...(Ids) >= 1, "add_dep: at least one task id is required");
-        static_assert(
-            (std::is_same_v<std::decay_t<Ids>, PTO2TaskId> && ...), "add_dep: all arguments must be PTO2TaskId"
-        );
+        static_assert((std::is_same_v<std::decay_t<Ids>, TaskId> && ...), "add_dep: all arguments must be TaskId");
         if (count_ + sizeof...(Ids) > MAX_DEP_COUNT) {
             CoreTaskArgs::set_error(
                 "CoreTaskArgsWithDeps::add_dep: dep count exceeds MAX_DEP_COUNT (bump the template arg)"
@@ -118,7 +116,7 @@ public:
     }
 
 private:
-    PTO2TaskId deps_[MAX_DEP_COUNT];
+    TaskId deps_[MAX_DEP_COUNT];
     uint32_t count_ = 0;
 };
 

--- a/src/a5/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
+++ b/src/a5/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
@@ -50,7 +50,7 @@ struct AICoreCompletionMailboxMessage {
     // value with an acquire load. The release-acquire pair publishes all
     // other fields below as a side effect, so they stay plain.
     std::atomic<uint64_t> seq;
-    PTO2TaskId task_token;
+    TaskId task_token;
     // CONDITION: completion observation addr (counter / backend record).
     // TASK_NORMAL_DONE: PTO2TaskSlotState pointer carried over to the consumer
     //   so it can finalize the AsyncWaitEntry.slot_state binding.
@@ -77,7 +77,7 @@ static_assert(
 // payload, so try_pop copies out only the fields below (and seq is not even
 // copyable — it is a std::atomic).
 struct AICoreCompletionMsgView {
-    PTO2TaskId task_token{PTO2TaskId::invalid()};
+    TaskId task_token{TaskId::invalid()};
     uint64_t addr{0};
     uint64_t backend_cookie{0};
     uint32_t expected_value{0};
@@ -139,13 +139,13 @@ struct AICoreCompletionMailbox {
     // Safe to call concurrently from any number of producers; structurally
     // independent of the AsyncWaitList::busy lock.
     bool try_push_condition(
-        PTO2TaskId task_token, uint64_t addr, uint32_t expected_value, uint32_t engine, int32_t completion_type
+        TaskId task_token, uint64_t addr, uint32_t expected_value, uint32_t engine, int32_t completion_type
     ) {
         return try_push_condition(task_token, addr, 0, expected_value, engine, completion_type);
     }
 
     bool try_push_condition(
-        PTO2TaskId task_token, uint64_t addr, uint64_t backend_cookie, uint32_t expected_value, uint32_t engine,
+        TaskId task_token, uint64_t addr, uint64_t backend_cookie, uint32_t expected_value, uint32_t engine,
         int32_t completion_type
     ) {
         while (true) {
@@ -172,7 +172,7 @@ struct AICoreCompletionMailbox {
     // MPSC push for a TASK_NORMAL_DONE sentinel. Carries the PTO2TaskSlotState
     // pointer in the `addr` field so the consumer can finish binding the
     // AsyncWaitEntry.slot_state without going back to the FIN-handling thread.
-    bool try_push_normal_done(PTO2TaskId task_token, uint64_t slot_state_addr) {
+    bool try_push_normal_done(TaskId task_token, uint64_t slot_state_addr) {
         while (true) {
             uint64_t h = head.load(std::memory_order_relaxed);
             uint64_t t = tail.load(std::memory_order_acquire);

--- a/src/a5/runtime/host_build_graph/runtime/async_wait.h
+++ b/src/a5/runtime/host_build_graph/runtime/async_wait.h
@@ -115,7 +115,7 @@ inline void CompletionCondition::retire() {
 
 struct AsyncWaitEntry {
     PTO2TaskSlotState *slot_state{nullptr};
-    PTO2TaskId task_token{PTO2TaskId::invalid()};
+    TaskId task_token{TaskId::invalid()};
     CompletionCondition conditions[MAX_COMPLETIONS_PER_TASK];
     int32_t condition_count{0};
     int32_t waiting_completion_count{0};
@@ -161,7 +161,7 @@ struct AsyncWaitList {
 
     void unlock() { busy.store(0, std::memory_order_release); }
 
-    AsyncWaitEntry *find_entry_by_token(PTO2TaskId token) {
+    AsyncWaitEntry *find_entry_by_token(TaskId token) {
         for (int32_t i = 0; i < count; i++) {
             if (entries[i].task_token == token) return &entries[i];
         }

--- a/src/a5/runtime/host_build_graph/runtime/dep_compute.h
+++ b/src/a5/runtime/host_build_graph/runtime/dep_compute.h
@@ -29,13 +29,13 @@
  * the minor structural overlap.
  *
  * The Emit callback contract:
- *   bool emit(PTO2TaskId producer);
+ *   bool emit(TaskId producer);
  *     - return true to continue (whether or not the producer was actually recorded —
  *       producer-not-alive / dedup-hit / etc. all return true silently)
  *     - return false to signal fatal (e.g. fanin spill overflow); caller bails
  *
  * The Annotate callback contract (dep_gen graph capture):
- *   void annotate.creator(int32_t arg_idx, const ChipTensor &consumer, PTO2TaskId producer);
+ *   void annotate.creator(int32_t arg_idx, const ChipTensor &consumer, TaskId producer);
  *   void annotate.tensormap(int32_t arg_idx, const ChipTensor &consumer,
  *                           const PTO2TensorMapEntry &entry, OverlapStatus overlap);
  * Both fire for exactly the producers `emit` saw, with the tensor-side context an
@@ -70,7 +70,7 @@ struct DepInputs {
     const TensorRef *tensors;        // length = tensor_count (union; OUTPUT slots' .ptr is unused)
     const TensorArgType *arg_types;  // length = tensor_count
     int32_t explicit_dep_count;
-    const PTO2TaskId *explicit_deps;  // length = explicit_dep_count (validity checked by caller)
+    const TaskId *explicit_deps;  // length = explicit_dep_count (validity checked by caller)
 };
 
 /**
@@ -78,7 +78,7 @@ struct DepInputs {
  * costs exactly what it did before the hooks existed.
  */
 struct NoDepAnnotate {
-    void creator(int32_t, const ChipTensor &, PTO2TaskId) const {}
+    void creator(int32_t, const ChipTensor &, TaskId) const {}
     void tensormap(int32_t, const ChipTensor &, const PTO2TensorMapEntry &, OverlapStatus) const {}
 };
 
@@ -113,7 +113,7 @@ template <typename Emit, typename Annotate = NoDepAnnotate>
         const ChipTensor *tensor = &inputs.tensors[i].ref();
 
         // Step A: creator retention — all existing tensors extend their creator lifetime.
-        PTO2TaskId owner = tensor->owner_task_id;
+        TaskId owner = tensor->owner_task_id;
         if (owner.is_valid()) {
             if (!emit(owner)) {
                 return false;
@@ -157,7 +157,7 @@ template <typename Emit, typename Annotate = NoDepAnnotate>
  * No-op when in_manual_scope.
  */
 inline void
-register_task_outputs(const DepInputs &inputs, PTO2TaskId task_id, PTO2TensorMap &tensor_map, bool in_manual_scope) {
+register_task_outputs(const DepInputs &inputs, TaskId task_id, PTO2TensorMap &tensor_map, bool in_manual_scope) {
     if (in_manual_scope) {
         return;
     }

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -77,7 +77,7 @@ __attribute__((weak, visibility("hidden"))) void dep_gen_host_graph_end_task() {
 // instantiation. Shared by the ordinary submit path and the outer GRAPH task so
 // both describe an edge the same way.
 struct DepGraphAnnotate {
-    void creator(int32_t arg_idx, const ChipTensor &consumer, PTO2TaskId producer) const {
+    void creator(int32_t arg_idx, const ChipTensor &consumer, TaskId producer) const {
         dep_gen_host_graph_add_creator_edge(producer.raw, arg_idx, consumer);
     }
     void tensormap(
@@ -961,7 +961,7 @@ struct PTO2FaninBuilder {
 
 static bool append_fanin_or_fail(
     PTO2OrchestratorState *orch, uint8_t prod_ring, int32_t prod_slot, PTO2TaskSlotState *prod_state,
-    PTO2TaskId producer_task_id, PTO2FaninBuilder *fanin_builder
+    TaskId producer_task_id, PTO2FaninBuilder *fanin_builder
 ) {
     // Skip a stale/reused producer slot: the cached owner id no longer resolves
     // to this producer (defensive — whole-graph-resident hbg does not reuse slots
@@ -1001,7 +1001,7 @@ static bool append_fanin_or_fail(
 static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state);
 
 struct PTO2PreparedTask {
-    PTO2TaskId task_id = PTO2TaskId::invalid();
+    TaskId task_id = TaskId::invalid();
     PTO2TaskAllocResult alloc_result = {-1, 0, nullptr, nullptr};
     PTO2TaskDescriptor *task = nullptr;
     PTO2TaskPayload *payload = nullptr;
@@ -1048,7 +1048,7 @@ static bool prepare_task(
         return false;
     }
 
-    out->task_id = PTO2TaskId::make(ring_id, static_cast<uint32_t>(out->alloc_result.task_id));
+    out->task_id = TaskId::make(ring_id, static_cast<uint32_t>(out->alloc_result.task_id));
     out->slot_state = &orch->sm_header->ring.get_slot_state_by_slot(out->alloc_result.slot);
     out->task = &orch->sm_header->ring.task_descriptors[out->alloc_result.slot];
     out->payload = &orch->sm_header->ring.task_payloads[out->alloc_result.slot];
@@ -1316,7 +1316,7 @@ static TaskOutputTensors submit_task_common(
         return result;
     }
     PTO2SchedulerState *sched = orch->scheduler;
-    PTO2TaskId task_id = prepared.task_id;
+    TaskId task_id = prepared.task_id;
     PTO2TaskDescriptor &task = *prepared.task;
     PTO2TaskPayload &payload = *prepared.payload;
     result.set_task_id(task_id);
@@ -1351,7 +1351,7 @@ static TaskOutputTensors submit_task_common(
 #endif
 
     for (uint32_t i = 0; i < args.explicit_dep_count(); i++) {
-        PTO2TaskId dep_task_id = args.explicit_dep(i);
+        TaskId dep_task_id = args.explicit_dep(i);
         if (!dep_task_id.is_valid()) {
             orch->report_fatal(
                 SIMPLER_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.set_dependencies(...) requires valid task ids"
@@ -1377,7 +1377,7 @@ static TaskOutputTensors submit_task_common(
         args.explicit_deps_data(),
     };
 
-    auto runtime_emit = [&](PTO2TaskId producer_task_id) -> bool {
+    auto runtime_emit = [&](TaskId producer_task_id) -> bool {
         uint8_t prod_ring = producer_task_id.ring();
         PTO2SharedMemoryRingHeader &producer_ring = orch->sm_header->ring;
         int32_t prod_slot = producer_ring.get_slot_by_task_id(static_cast<int32_t>(producer_task_id.local()));
@@ -1607,7 +1607,7 @@ void graph_reset_outer_payload(PTO2TaskPayload &payload) {
 
 bool graph_submit_outer(
     PTO2OrchestratorState *orch, GraphHostState *state, uint64_t full_key, uint64_t definition_hash, int32_t owned_heap,
-    bool defer_heap, const GraphTaskArgs &args, PTO2TaskId *submitted_id
+    bool defer_heap, const GraphTaskArgs &args, TaskId *submitted_id
 ) {
     always_assert(orch->scope_stack_top >= 0 && "Cannot submit Graph outside a scope");
     auto &allocator = orch->ring.task_allocator;
@@ -1650,7 +1650,7 @@ bool graph_submit_outer(
         orch_mark_fatal(orch, SIMPLER_ERROR_HEAP_RING_DEADLOCK);
         return false;
     }
-    const PTO2TaskId task_id = PTO2TaskId::make(0, static_cast<uint32_t>(allocation.task_id));
+    const TaskId task_id = TaskId::make(0, static_cast<uint32_t>(allocation.task_id));
     PTO2SharedMemoryRingHeader &ring = orch->sm_header->ring;
     PTO2TaskDescriptor &task = ring.task_descriptors[allocation.slot];
     PTO2TaskPayload &payload = ring.task_payloads[allocation.slot];
@@ -1702,7 +1702,7 @@ bool graph_submit_outer(
     }
 
     PTO2FaninBuilder fanin_builder(orch, &payload, static_cast<int32_t>(task_id.local()), next_fanin_seen_epoch(orch));
-    auto emit = [&](PTO2TaskId producer_id) -> bool {
+    auto emit = [&](TaskId producer_id) -> bool {
         const int32_t producer_local = static_cast<int32_t>(producer_id.local());
         const int32_t producer_slot = ring.get_slot_by_task_id(producer_local);
         PTO2TaskSlotState *producer = &ring.get_slot_state_by_slot(producer_slot);
@@ -1753,7 +1753,7 @@ bool graph_submit_outer(
 
 bool graph_submit_definition(
     PTO2OrchestratorState *orch, GraphHostState *state, const std::vector<std::byte> &definition_image,
-    const GraphTaskArgs &args, PTO2TaskId *submitted_id
+    const GraphTaskArgs &args, TaskId *submitted_id
 ) {
     const GraphDefinition *definition = graph_definition(definition_image);
     if (definition == nullptr || !graph_boundary_matches(*definition, args) ||
@@ -1771,7 +1771,7 @@ bool graph_submit_definition(
 
 bool graph_submit_pending_definition(
     PTO2OrchestratorState *orch, GraphHostState *state, uint64_t full_key, const GraphTaskArgs &args,
-    PTO2TaskId *submitted_id
+    TaskId *submitted_id
 ) {
     return graph_submit_outer(orch, state, full_key, 0, 0, true, args, submitted_id);
 }
@@ -1832,8 +1832,8 @@ TaskOutputTensors graph_record_submit_node(
     // A recorded node's index equals its local task id minus the recording
     // baseline, so its synthetic id keeps classification and explicit-dep
     // arithmetic identical to the ordinary path.
-    const PTO2TaskId task_id =
-        PTO2TaskId::make(0, static_cast<uint32_t>(recording.start_local_task_id) + static_cast<uint32_t>(node_index));
+    const TaskId task_id =
+        TaskId::make(0, static_cast<uint32_t>(recording.start_local_task_id) + static_cast<uint32_t>(node_index));
     result.set_task_id(task_id);
 
     if (node_index >= GRAPH_MAX_NODES || args.has_error) {
@@ -2015,7 +2015,7 @@ TaskOutputTensors graph_record_submit_node(
             );
             recording.unsupported = true;
         } else {
-            auto emit_inferred = [&recording, &add_fanin, node_index](PTO2TaskId producer) -> bool {
+            auto emit_inferred = [&recording, &add_fanin, node_index](TaskId producer) -> bool {
                 const int32_t producer_index = static_cast<int32_t>(producer.local()) - recording.start_local_task_id;
                 if (producer.ring() == 0 && producer_index >= 0 && producer_index < static_cast<int32_t>(node_index)) {
                     add_fanin(static_cast<size_t>(producer_index));
@@ -2027,7 +2027,7 @@ TaskOutputTensors graph_record_submit_node(
         }
     }
     for (uint32_t i = 0; i < args.explicit_dep_count(); ++i) {
-        const PTO2TaskId dep = args.explicit_dep(i);
+        const TaskId dep = args.explicit_dep(i);
         const int32_t dep_index = static_cast<int32_t>(dep.local()) - recording.start_local_task_id;
         if (!dep.is_valid() || dep.ring() != 0 || dep_index >= static_cast<int32_t>(node_index)) {
             recording.unsupported = true;
@@ -2087,7 +2087,7 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
     // would make an already-built Definition wait for an unrelated one.
     auto definition_it = state->definitions.find(full_key);
     if (definition_it != state->definitions.end()) {
-        PTO2TaskId submitted = PTO2TaskId::invalid();
+        TaskId submitted = TaskId::invalid();
         ORCH_PHASE_START();
         if (graph_submit_definition(orch, state, definition_it->second, args, &submitted)) {
             result.execute_block = false;
@@ -2113,7 +2113,7 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
             !graph_recording_boundary_matches(*entry.recording, args)) {
             return result;
         }
-        PTO2TaskId submitted = PTO2TaskId::invalid();
+        TaskId submitted = TaskId::invalid();
         ORCH_PHASE_START();
         if (graph_submit_pending_definition(orch, state, full_key, args, &submitted)) {
             result.execute_block = false;
@@ -2162,7 +2162,7 @@ PTO2OrchestratorState::graph_begin(uint64_t graph_key, const GraphTaskArgs &args
     state->inflight.emplace(full_key, std::move(entry));
     state->inflight_count.store(state->inflight.size(), std::memory_order_release);
 
-    PTO2TaskId submitted = PTO2TaskId::invalid();
+    TaskId submitted = TaskId::invalid();
     ORCH_PHASE_START();
     if (graph_submit_pending_definition(orch, state, full_key, args, &submitted)) {
         result.execute_block = false;

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
@@ -159,7 +159,7 @@ void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, cons
 MAYBE_UNINITIALIZED_BEGIN
 static bool
 wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_consumers, const char *caller) {
-    PTO2TaskId owner = tensor.owner_task_id;
+    TaskId owner = tensor.owner_task_id;
     PTO2OrchestratorState &orch = *rt->orchestrator;
 
     // Segmented wait: collect up to kSegmentCap producer slots, then flush by
@@ -176,7 +176,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
     // Returns nullptr for every rejected producer, having latched the fatal.
     // Callers branch on the returned pointer, not on `failed`: the slot is
     // dereferenced immediately and a null return is the only safe signal.
-    auto resolve_producer = [&](PTO2TaskId producer) -> const PTO2TaskSlotState * {
+    auto resolve_producer = [&](TaskId producer) -> const PTO2TaskSlotState * {
         if (!producer.is_valid() || producer.ring() != 0) {
             orch.report_fatal(
                 SIMPLER_ERROR_INVALID_ARGS, caller,
@@ -294,7 +294,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
 
         // Step B: modifier writer lookup (OverlapMap), direct callback
         orch.tensor_map.lookup(tensor, [&](PTO2TensorMapEntry &entry, OverlapStatus) -> bool {
-            PTO2TaskId pid = entry.producer_task_id;
+            TaskId pid = entry.producer_task_id;
             const auto *slot = resolve_producer(pid);
             if (slot == nullptr) return false;
             try_push(*slot);

--- a/src/a5/runtime/host_build_graph/runtime/runtime_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime_types.h
@@ -209,7 +209,7 @@ struct PTO2TaskSlotState;  // Forward declaration (defined below)
  */
 struct PTO2TaskDescriptor {
     // Mixed-task identification (encodes ring_id in upper 32 bits)
-    PTO2TaskId task_id;  // raw: (ring_id << 32) | local_id
+    TaskId task_id;  // raw: (ring_id << 32) | local_id
 
     // Per-slot kernel IDs (INVALID_KERNEL_ID = inactive)
     int32_t kernel_id[PTO2_SUBTASK_SLOT_COUNT];

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -133,7 +133,7 @@ void SchedulerContext::complete_slot_task(
             // be this thread or a later one).
             slot_state.mark_any_subtask_deferred();
 
-            const PTO2TaskId token = slot_state.task->task_id;
+            const TaskId token = slot_state.task->task_id;
             for (uint32_t i = 0; i < cond_count; ++i) {
                 volatile DeferredCompletionEntry *e = &deferred_slab->entries[i];
                 while (!mailbox->try_push_condition(

--- a/src/a5/runtime/host_build_graph/runtime/tensor_create_info.h
+++ b/src/a5/runtime/host_build_graph/runtime/tensor_create_info.h
@@ -114,7 +114,7 @@ inline void init_tensor_from_create_info(ChipTensor &t, const TensorCreateInfo &
     always_assert(ci.ndims > 0 && ci.ndims <= MAX_TENSOR_DIMS);
     memcpy(&t, &ci, 64);
     t.buffer = {reinterpret_cast<uint64_t>(addr), buffer_size};
-    t.owner_task_id = PTO2TaskId::invalid();  // caller (orchestrator) overwrites with actual task_id
+    t.owner_task_id = TaskId::invalid();  // caller (orchestrator) overwrites with actual task_id
     uint32_t s = 1;
     for (int32_t i = static_cast<int32_t>(t.ndims) - 1; i >= 0; --i) {
         t.strides[i] = s;

--- a/src/a5/runtime/host_build_graph/runtime/tensormap.h
+++ b/src/a5/runtime/host_build_graph/runtime/tensormap.h
@@ -115,15 +115,15 @@ struct alignas(64) PTO2TensorMapEntry {
     // === Cache line 1 (64B) — lookup hot path; mirrors ChipTensor line 1 from byte 16 ===
     uint64_t buffer_addr;  // 8B [0, 8):   tensor base address (hash key, mirrors ChipTensor::buffer.addr)
     PTO2TensorMapEntry
-        *next_in_bucket;          // 8B [8, 16):  next entry in hash bucket chain (overlays ChipTensor::buffer.size)
-    PTO2TaskId producer_task_id;  // 8B [16,24):  mirrors ChipTensor::owner_task_id slot
-    uint64_t start_offset;        // 8B [24,32):  mirrors ChipTensor::start_offset (element offset)
-    int32_t version;              // 4B [32,36):  mirrors ChipTensor::version
-    uint32_t ndims;               // 4B [36,40):  mirrors ChipTensor::ndims
-    DataType dtype;               // 1B [40,41):  mirrors ChipTensor::dtype
-    bool manual_dep;              // 1B [41,42):  mirrors ChipTensor::manual_dep
-    bool is_contiguous;           // 1B [42,43):  mirrors ChipTensor::is_contiguous
-    uint8_t __padding1__;         // 1B [43,44):  mirrors ChipTensor padding
+        *next_in_bucket;      // 8B [8, 16):  next entry in hash bucket chain (overlays ChipTensor::buffer.size)
+    TaskId producer_task_id;  // 8B [16,24):  mirrors ChipTensor::owner_task_id slot
+    uint64_t start_offset;    // 8B [24,32):  mirrors ChipTensor::start_offset (element offset)
+    int32_t version;          // 4B [32,36):  mirrors ChipTensor::version
+    uint32_t ndims;           // 4B [36,40):  mirrors ChipTensor::ndims
+    DataType dtype;           // 1B [40,41):  mirrors ChipTensor::dtype
+    bool manual_dep;          // 1B [41,42):  mirrors ChipTensor::manual_dep
+    bool is_contiguous;       // 1B [42,43):  mirrors ChipTensor::is_contiguous
+    uint8_t __padding1__;     // 1B [43,44):  mirrors ChipTensor padding
     uint32_t shapes[MAX_TENSOR_DIMS];  // 20B [44,64): mirrors ChipTensor::shapes
 
     // === Cache line 2 (64B) — chain manipulation + non-contiguous overlap data ===
@@ -521,7 +521,7 @@ struct PTO2TensorMap {
      * @param tensor            ChipTensor produced
      * @param producer_task_id  Task ID of producer
      */
-    void insert(const ChipTensor &tensor, PTO2TaskId producer_task_id) {
+    void insert(const ChipTensor &tensor, TaskId producer_task_id) {
         PTO2TensorMapEntry *entry = new_entry();
         entry->copy_from_tensor(tensor);
         link_entry(entry, tensor.buffer.addr, producer_task_id);
@@ -547,7 +547,7 @@ struct PTO2TensorMap {
     /**
      * Link an initialized entry into bucket and task chains.
      */
-    void link_entry(PTO2TensorMapEntry *entry, uint64_t addr, PTO2TaskId producer_task_id) {
+    void link_entry(PTO2TensorMapEntry *entry, uint64_t addr, TaskId producer_task_id) {
 #if SIMPLER_TENSORMAP_PROFILING
         g_insert_count++;
 #endif

--- a/src/a5/runtime/host_build_graph/runtime/types.h
+++ b/src/a5/runtime/host_build_graph/runtime/types.h
@@ -104,7 +104,7 @@ enum class PTO2ScopeMode : uint8_t {
 class TaskOutputTensors {
 public:
     TaskOutputTensors() :
-        task_id_(PTO2TaskId::invalid()),
+        task_id_(TaskId::invalid()),
         output_count_(0) {}
 
     bool empty() const { return output_count_ == 0; }
@@ -123,12 +123,12 @@ public:
         tensors_[output_count_++] = &tensor;
     }
 
-    void set_task_id(PTO2TaskId id) { task_id_ = id; }
+    void set_task_id(TaskId id) { task_id_ = id; }
 
-    PTO2TaskId task_id() const { return task_id_; }
+    TaskId task_id() const { return task_id_; }
 
 private:
-    PTO2TaskId task_id_;
+    TaskId task_id_;
     uint32_t output_count_;
     // Upper bound: a task cannot have more outputs than total tensor args
     // (every OUTPUT/OUTPUT_EXISTING slot is one of the Arg's tensor slots).
@@ -388,7 +388,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
      * count == 0 is a valid "set empty" — it clears any previously stored deps
      * and returns. This lets callers that build the dep set conditionally pass
      * the result through unguarded, including in the no-dep branch:
-     *   PTO2TaskId deps[3];
+     *   TaskId deps[3];
      *   uint32_t n = 0;
      *   if (have_prev) deps[n++] = prev;
      *   if (is_last)   deps[n++] = alloc;
@@ -398,7 +398,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
      * deps are already set will fail with set_error(). Use count == 0 first
      * if you need to re-set.
      */
-    void set_dependencies(const PTO2TaskId *deps, uint32_t count) {
+    void set_dependencies(const TaskId *deps, uint32_t count) {
         if (count == 0) {
             explicit_deps_ = nullptr;
             explicit_dep_count_ = 0;
@@ -418,12 +418,12 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
 
     uint32_t explicit_dep_count() const { return explicit_dep_count_; }
 
-    PTO2TaskId explicit_dep(uint32_t index) const {
+    TaskId explicit_dep(uint32_t index) const {
         always_assert(index < explicit_dep_count_);
         return explicit_deps_[index];
     }
 
-    const PTO2TaskId *explicit_deps_data() const { return explicit_deps_; }
+    const TaskId *explicit_deps_data() const { return explicit_deps_; }
 
     /**
      * Add scalar values. Types are deduced per argument; each value is
@@ -559,7 +559,7 @@ private:
 #if SIMPLER_DFX
     DumpArgSelection dump_arg_selection_;
 #endif
-    const PTO2TaskId *explicit_deps_{nullptr};
+    const TaskId *explicit_deps_{nullptr};
     uint32_t explicit_dep_count_{0};
 #if SIMPLER_DFX
     template <typename T>

--- a/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -132,13 +132,13 @@ struct AsyncCtx {
     volatile __gm__ int32_t *completion_error_code;
     volatile __gm__ DeferredCompletionEntry *completion_entries;
     uint32_t completion_capacity;
-    PTO2TaskId task_token;
+    TaskId task_token;
 
-    static inline AsyncCtx make(PTO2TaskId task_token, volatile __gm__ DeferredCompletionSlab *buffer) {
+    static inline AsyncCtx make(TaskId task_token, volatile __gm__ DeferredCompletionSlab *buffer) {
         AsyncCtx ctx{};
         ctx.task_token = task_token;
         if (buffer == nullptr) {
-            ctx.task_token = PTO2TaskId::invalid();
+            ctx.task_token = TaskId::invalid();
             return ctx;
         }
         ctx.completion_count = &buffer->count;

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -27,11 +27,11 @@ Task IDs are widened from 32-bit to 64-bit to carry the ring identity:
 task_id.raw = (ring_id << 32) | local_id
 ```
 
-`PTO2TaskId` exposes direct accessors in `src/common/task_interface/task_id.h`:
+`TaskId` exposes direct accessors in `src/common/task_interface/task_id.h`:
 
 | API | Purpose |
 | --- | ------- |
-| `PTO2TaskId::make(ring_id, local_id)` | Compose a 64-bit task ID (`PTO2TaskId`) |
+| `TaskId::make(ring_id, local_id)` | Compose a 64-bit task ID (`TaskId`) |
 | `task_id.ring()` | Extract `ring_id` (bits 63-32) |
 | `task_id.local()` | Extract `local_id` (bits 31-0) |
 | `task_id.raw` | Access the packed 64-bit encoding |
@@ -40,8 +40,8 @@ Type changes:
 
 | Field | Before | After |
 | ----- | ------ | ----- |
-| `PTO2TaskDescriptor.task_id` | `int32_t` | `PTO2TaskId` |
-| `PTO2TensorMapEntry.producer_task_id` | `int32_t` | `PTO2TaskId` |
+| `PTO2TaskDescriptor.task_id` | `int32_t` | `TaskId` |
+| `PTO2TensorMapEntry.producer_task_id` | `int32_t` | `TaskId` |
 | `PTO2TaskSlotState.ring_id` | N/A | `uint8_t` (new, denormalized for fast access) |
 
 ## 4. Data Structures

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -21,7 +21,7 @@
  *   ORACLE pass (read-only contract):
  *     Drives `compute_task_fanin` (the same template the device orchestrator
  *     uses in orchestrator.cpp:submit_task) against `tm_oracle`. Its emit
- *     fires with (PTO2TaskId, DepFlags) — the canonical (producer, WAIT/RETAIN)
+ *     fires with (TaskId, DepFlags) — the canonical (producer, WAIT/RETAIN)
  *     mapping the runtime would have wired, OR-accumulated per producer. This
  *     pass IS the contract, and any future change to `compute_task_fanin`
  *     automatically refreshes the oracle.
@@ -439,7 +439,7 @@ void annot_pass(
         const ChipTensor *tensor = &inputs.tensors[i].ref();
 
         // STEP A: creator retention.
-        PTO2TaskId owner = tensor->owner_task_id;
+        TaskId owner = tensor->owner_task_id;
         if (owner.is_valid()) {
             emit_creator(owner, i, *tensor);
         }
@@ -484,7 +484,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
     int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     uint32_t max_local[PTO2_MAX_RING_DEPTH] = {0};
     for (size_t i = 0; i < num_records; i++) {
-        PTO2TaskId tid{records[i].task_id};
+        TaskId tid{records[i].task_id};
         uint8_t ring = tid.ring();
         uint32_t local = tid.local();
         if (ring < PTO2_MAX_RING_DEPTH && local > max_local[ring]) {
@@ -556,7 +556,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         // overflow's reinterpreted bytes as tensor/dep info.
         if (rec.flags & DEP_GEN_FLAG_OVERFLOW) continue;
 
-        PTO2TaskId task_id{rec.task_id};
+        TaskId task_id{rec.task_id};
         bool in_manual_scope = (rec.flags & DEP_GEN_FLAG_IN_MANUAL_SCOPE) != 0;
 
         oracle_preds.clear();
@@ -653,7 +653,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         inputs.tensors = tref_buf;
         inputs.arg_types = atype_buf;
         inputs.explicit_dep_count = dc;
-        inputs.explicit_deps = reinterpret_cast<const PTO2TaskId *>(deps_data);
+        inputs.explicit_deps = reinterpret_cast<const TaskId *>(deps_data);
 
         // Register tasks[] entry (with per-arg slot info) and any unseen
         // tensors[] entries up-front. ChipTensors are registered from the
@@ -721,11 +721,10 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         }
 
         // ============ ORACLE pass — drive compute_task_fanin ============
-        bool ok =
-            compute_task_fanin(inputs, tm_oracle, in_manual_scope, [&](PTO2TaskId producer, DepFlags kind) -> bool {
-                oracle_preds[producer.raw] |= kind;
-                return true;
-            });
+        bool ok = compute_task_fanin(inputs, tm_oracle, in_manual_scope, [&](TaskId producer, DepFlags kind) -> bool {
+            oracle_preds[producer.raw] |= kind;
+            return true;
+        });
         if (!ok) {
             LOG_ERROR("dep_gen replay: compute_task_fanin returned fatal at task_id=%" PRIu64, rec.task_id);
             tm_oracle.destroy();
@@ -737,7 +736,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         annot_pass(
             inputs, tm_annot, in_manual_scope,
             // emit_creator(producer, arg_idx, consumer_tensor)
-            [&](PTO2TaskId producer, int32_t arg_idx, const ChipTensor &consumer) {
+            [&](TaskId producer, int32_t arg_idx, const ChipTensor &consumer) {
                 bool first = annot_preds.find(producer.raw) == annot_preds.end();
                 annot_preds[producer.raw] |= (DEP_WAIT | DEP_RETAIN);
                 if (!first) {
@@ -754,7 +753,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
                 annot_edges.push_back(e);
             },
             // emit_tensormap(producer, arg_idx, consumer_tensor, entry, status)
-            [&](PTO2TaskId producer, int32_t arg_idx, const ChipTensor &consumer, const PTO2TensorMapEntry &entry,
+            [&](TaskId producer, int32_t arg_idx, const ChipTensor &consumer, const PTO2TensorMapEntry &entry,
                 OverlapStatus status) {
                 // Per-(succ, arg_idx, producer_buffer_addr, producer_version)
                 // dedup gives us "the same producer slice fired twice for the

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.h
@@ -48,7 +48,7 @@
  *                 "producer_strides":[...] (tensormap)},
  *                ...]}
  *
- *   - All task ids are ``PTO2TaskId::raw`` values (``(ring_id << 32) | local_id``).
+ *   - All task ids are ``TaskId::raw`` values (``(ring_id << 32) | local_id``).
  *   - ``tensor_id`` is a stable FNV-1a hash of ``(buffer_addr, version)``.
  *   - ``buffer_numel`` is the underlying storage element count; tensor shapes
  *     are carried per-arg / per-edge alongside ``start_offset`` + ``strides``.

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/arg_with_deps.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/arg_with_deps.h
@@ -75,7 +75,7 @@ public:
      * is kept alive (its slot/output buffer retained) until this consumer
      * completes. This is the conservative default — use it when the consumer reads
      * a tensor whose buffer the producer allocated. May be called multiple times;
-     * deps accumulate. Variadic accepts any non-zero number of PTO2TaskId args.
+     * deps accumulate. Variadic accepts any non-zero number of TaskId args.
      *
      * Overflow (more than MAX_DEP_COUNT total) records an error on the
      * underlying Arg; the error surfaces at submit time.
@@ -125,8 +125,7 @@ private:
     void add_dep_impl(DepFlags kind, Ids... ids) {
         static_assert(sizeof...(Ids) >= 1, "add_dep/add_dep_wait: at least one task id is required");
         static_assert(
-            (std::is_same_v<std::decay_t<Ids>, PTO2TaskId> && ...),
-            "add_dep/add_dep_wait: all arguments must be PTO2TaskId"
+            (std::is_same_v<std::decay_t<Ids>, TaskId> && ...), "add_dep/add_dep_wait: all arguments must be TaskId"
         );
         if (count_ + sizeof...(Ids) > MAX_DEP_COUNT) {
             CoreTaskArgs::set_error(
@@ -137,7 +136,7 @@ private:
         ((kinds_[count_] = kind, deps_[count_] = ids, ++count_), ...);
     }
 
-    PTO2TaskId deps_[MAX_DEP_COUNT];
+    TaskId deps_[MAX_DEP_COUNT];
     DepFlags kinds_[MAX_DEP_COUNT];
     uint32_t count_ = 0;
 };

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
@@ -51,7 +51,7 @@ struct AICoreCompletionMailboxMessage {
     // value with an acquire load. The release-acquire pair publishes all
     // other fields below as a side effect, so they stay plain.
     std::atomic<uint64_t> seq;
-    PTO2TaskId task_token;
+    TaskId task_token;
     // CONDITION: completion observation addr (counter / SDMA event record).
     // TASK_NORMAL_DONE: PTO2TaskSlotState pointer carried over to the consumer
     //   so it can finalize the AsyncWaitEntry.slot_state binding.
@@ -78,7 +78,7 @@ static_assert(
 // payload, so try_pop copies out only the fields below (and seq is not even
 // copyable — it is a std::atomic).
 struct AICoreCompletionMsgView {
-    PTO2TaskId task_token{PTO2TaskId::invalid()};
+    TaskId task_token{TaskId::invalid()};
     uint64_t addr{0};
     uint64_t backend_cookie{0};
     uint32_t expected_value{0};
@@ -116,13 +116,13 @@ struct AICoreCompletionMailbox {
     // Safe to call concurrently from any number of producers; structurally
     // independent of the AsyncWaitList::busy lock.
     bool try_push_condition(
-        PTO2TaskId task_token, uint64_t addr, uint32_t expected_value, uint32_t engine, int32_t completion_type
+        TaskId task_token, uint64_t addr, uint32_t expected_value, uint32_t engine, int32_t completion_type
     ) {
         return try_push_condition(task_token, addr, 0, expected_value, engine, completion_type);
     }
 
     bool try_push_condition(
-        PTO2TaskId task_token, uint64_t addr, uint64_t backend_cookie, uint32_t expected_value, uint32_t engine,
+        TaskId task_token, uint64_t addr, uint64_t backend_cookie, uint32_t expected_value, uint32_t engine,
         int32_t completion_type
     ) {
         while (true) {
@@ -149,7 +149,7 @@ struct AICoreCompletionMailbox {
     // MPSC push for a TASK_NORMAL_DONE sentinel. Carries the PTO2TaskSlotState
     // pointer in the `addr` field so the consumer can finish binding the
     // AsyncWaitEntry.slot_state without going back to the FIN-handling thread.
-    bool try_push_normal_done(PTO2TaskId task_token, uint64_t slot_state_addr) {
+    bool try_push_normal_done(TaskId task_token, uint64_t slot_state_addr) {
         while (true) {
             uint64_t h = head.load(std::memory_order_relaxed);
             uint64_t t = tail.load(std::memory_order_acquire);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/async_wait.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/async_wait.h
@@ -122,7 +122,7 @@ inline void CompletionCondition::retire() {
 
 struct AsyncWaitEntry {
     PTO2TaskSlotState *slot_state{nullptr};
-    PTO2TaskId task_token{PTO2TaskId::invalid()};
+    TaskId task_token{TaskId::invalid()};
     CompletionCondition conditions[MAX_COMPLETIONS_PER_TASK];
     int32_t condition_count{0};
     int32_t waiting_completion_count{0};
@@ -173,7 +173,7 @@ struct AsyncWaitList {
 
     void unlock() { busy.store(0, std::memory_order_release); }
 
-    AsyncWaitEntry *find_entry_by_token(PTO2TaskId token) {
+    AsyncWaitEntry *find_entry_by_token(TaskId token) {
         for (int32_t i = 0; i < count; i++) {
             if (entries[i].task_token == token) return &entries[i];
         }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/dep_compute.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/dep_compute.h
@@ -29,7 +29,7 @@
  * the minor structural overlap. Replay handles STEP 1 with a one-line loop of its own.
  *
  * The Emit callback contract:
- *   bool emit(PTO2TaskId producer, DepFlags kind);
+ *   bool emit(TaskId producer, DepFlags kind);
  *     - kind is DEP_WAIT|DEP_RETAIN for a Step-A creator edge (the consumer reads
  *       the producer's allocated buffer, so the producer is retained) and DEP_WAIT
  *       for a Step-B modifier edge (ordering only; the buffer was allocated
@@ -65,7 +65,7 @@ struct DepInputs {
     const TensorRef *tensors;        // length = tensor_count (union; OUTPUT slots' .ptr is unused)
     const TensorArgType *arg_types;  // length = tensor_count
     int32_t explicit_dep_count;
-    const PTO2TaskId *explicit_deps;  // length = explicit_dep_count (validity checked by caller)
+    const TaskId *explicit_deps;  // length = explicit_dep_count (validity checked by caller)
 };
 
 /**
@@ -99,7 +99,7 @@ compute_task_fanin(const DepInputs &inputs, PTO2TensorMap &tensor_map, bool in_m
 
         // Step A: creator retention — reading a tensor retains its allocator, so
         // the creator edge carries both ordering and lifetime.
-        PTO2TaskId owner = tensor->owner_task_id;
+        TaskId owner = tensor->owner_task_id;
         if (owner.is_valid()) {
             if (!emit(owner, DEP_WAIT | DEP_RETAIN)) {
                 return false;
@@ -151,7 +151,7 @@ compute_task_fanin(const DepInputs &inputs, PTO2TensorMap &tensor_map, bool in_m
  * No-op when in_manual_scope.
  */
 inline void
-register_task_outputs(const DepInputs &inputs, PTO2TaskId task_id, PTO2TensorMap &tensor_map, bool in_manual_scope) {
+register_task_outputs(const DepInputs &inputs, TaskId task_id, PTO2TensorMap &tensor_map, bool in_manual_scope) {
     if (in_manual_scope) {
         return;
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
@@ -311,7 +311,7 @@ private:
 
 static bool append_fanin_or_fail(
     PTO2OrchestratorState *orch, uint8_t prod_ring, int32_t prod_slot, PTO2TaskSlotState *prod_state,
-    PTO2TaskId producer_task_id, PTO2FaninBuilder *fanin_builder, uint8_t ring_id, DepFlags kind
+    TaskId producer_task_id, PTO2FaninBuilder *fanin_builder, uint8_t ring_id, DepFlags kind
 ) {
     // Decide-and-claim under the producer's fanout_lock. Two conditions make this
     // resolved slot a non-dependency, and both must be checked together with the
@@ -530,7 +530,7 @@ static bool orch_wire_live_fanin_task(PTO2OrchestratorState *orch, PTO2TaskSlotS
 static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state);
 
 struct PTO2PreparedTask {
-    PTO2TaskId task_id = PTO2TaskId::invalid();
+    TaskId task_id = TaskId::invalid();
     PTO2TaskAllocResult alloc_result = {-1, 0, nullptr, nullptr};
     PTO2TaskDescriptor *task = nullptr;
     PTO2TaskPayload *payload = nullptr;
@@ -601,7 +601,7 @@ static bool prepare_task(
         return false;
     }
 
-    out->task_id = PTO2TaskId::make(ring_id, static_cast<uint32_t>(out->alloc_result.task_id));
+    out->task_id = TaskId::make(ring_id, static_cast<uint32_t>(out->alloc_result.task_id));
     out->slot_state = &orch->sm_header->rings[ring_id].get_slot_state_by_slot(out->alloc_result.slot);
     out->task = &orch->sm_header->rings[ring_id].task_descriptors[out->alloc_result.slot];
     out->payload = &orch->sm_header->rings[ring_id].task_payloads[out->alloc_result.slot];
@@ -897,7 +897,7 @@ static TaskOutputTensors submit_task_common(
     uint8_t ring_id = prepared.task_id.ring();
     PTO2SchedulerState *sched = orch->scheduler;
     PTO2RingFlowControl &fc = orch->sm_header->rings[ring_id].fc;
-    PTO2TaskId task_id = prepared.task_id;
+    TaskId task_id = prepared.task_id;
     PTO2TaskSlotState &cur_slot_state = *prepared.slot_state;
     PTO2TaskDescriptor &task = *prepared.task;
     PTO2TaskPayload &payload = *prepared.payload;
@@ -959,7 +959,7 @@ static TaskOutputTensors submit_task_common(
     CYCLE_COUNT_LAP(g_orch_sync_cycle);
 
     for (uint32_t i = 0; i < args.explicit_dep_count(); i++) {
-        PTO2TaskId dep_task_id = args.explicit_dep(i);
+        TaskId dep_task_id = args.explicit_dep(i);
         if (!dep_task_id.is_valid()) {
             orch->report_fatal(
                 SIMPLER_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.set_dependencies(...) requires valid task ids"
@@ -989,7 +989,7 @@ static TaskOutputTensors submit_task_common(
         args.explicit_deps_data(),
     };
 
-    auto runtime_emit = [&](PTO2TaskId producer_task_id, DepFlags kind) -> bool {
+    auto runtime_emit = [&](TaskId producer_task_id, DepFlags kind) -> bool {
         uint8_t prod_ring = producer_task_id.ring();
         PTO2SharedMemoryRingHeader &producer_ring = orch->sm_header->rings[prod_ring];
         int32_t prod_slot = producer_ring.get_slot_by_task_id(static_cast<int32_t>(producer_task_id.local()));

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.h
@@ -70,7 +70,7 @@ constexpr uint32_t ring_mask_bit(int32_t ring_id) {
 inline bool
 reclaim_head_matches_open_task(int32_t head_task_id, uint8_t ring_id, const PTO2TaskSlotState *oldest_open_task) {
     return oldest_open_task != nullptr && oldest_open_task->task != nullptr &&
-           oldest_open_task->task->task_id == PTO2TaskId::make(ring_id, static_cast<uint32_t>(head_task_id));
+           oldest_open_task->task->task_id == TaskId::make(ring_id, static_cast<uint32_t>(head_task_id));
 }
 
 class ReclaimPublicationRequest {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_core.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_core.cpp
@@ -98,7 +98,7 @@ void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, cons
 MAYBE_UNINITIALIZED_BEGIN
 static bool
 wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_consumers, const char *caller) {
-    PTO2TaskId owner = tensor.owner_task_id;
+    TaskId owner = tensor.owner_task_id;
     PTO2OrchestratorState &orch = rt->orchestrator;
 
     // Segmented wait: collect up to kSegmentCap producer slots, then flush by
@@ -197,7 +197,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
 
         // Step B: modifier writer lookup (OverlapMap), direct callback
         orch.tensor_map.lookup(tensor, [&](PTO2TensorMapEntry &entry, OverlapStatus) -> bool {
-            PTO2TaskId pid = entry.producer_task_id;
+            TaskId pid = entry.producer_task_id;
             auto &s = orch.sm_header->rings[pid.ring()].get_slot_state_by_task_id(pid.local());
             try_push(s);
             return !failed;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_types.h
@@ -217,7 +217,7 @@ struct PTO2DepListEntry {
  */
 struct PTO2TaskDescriptor {
     // Mixed-task identification (encodes ring_id in upper 32 bits)
-    PTO2TaskId task_id;  // raw: (ring_id << 32) | local_id
+    TaskId task_id;  // raw: (ring_id << 32) | local_id
 
     // Per-slot kernel IDs (INVALID_KERNEL_ID = inactive)
     int32_t kernel_id[PTO2_SUBTASK_SLOT_COUNT];

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -121,7 +121,7 @@ void SchedulerContext::complete_slot_task(
         if (cond_count > 0) {
             slot_state.mark_any_subtask_deferred();
 
-            const PTO2TaskId token = slot_state.task->task_id;
+            const TaskId token = slot_state.task->task_id;
             for (uint32_t i = 0; i < cond_count; ++i) {
                 volatile DeferredCompletionEntry *e = &deferred_slab->entries[i];
                 while (!mailbox->try_push_condition(

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/tensormap.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/tensormap.cpp
@@ -112,7 +112,7 @@ bool PTO2TensorMap::init_data_from_layout(const PTO2TensorMapLayout &layout, Dev
         entry_pool_arena[i].prev_in_bucket = nullptr;
         entry_pool_arena[i].next_in_task = nullptr;
         entry_pool_arena[i].prev_in_task = nullptr;
-        entry_pool_arena[i].producer_task_id = PTO2TaskId{};
+        entry_pool_arena[i].producer_task_id = TaskId{};
     }
 
     // free_entry_list: zeroed (was calloc'd before); contents become meaningful
@@ -255,7 +255,7 @@ int32_t PTO2TensorMap::valid_count() {
     return count;
 }
 
-void PTO2TensorMap::sync_tensormap(PTO2TaskId task_id, int32_t sm_last_task_alive) {
+void PTO2TensorMap::sync_tensormap(TaskId task_id, int32_t sm_last_task_alive) {
     auto ring_id = task_id.ring();
     auto local_id = task_id.local();
     sync_validity(ring_id, sm_last_task_alive);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor_create_info.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor_create_info.h
@@ -134,7 +134,7 @@ inline void init_tensor_from_create_info(ChipTensor &t, const TensorCreateInfo &
     always_assert(ci.ndims > 0 && ci.ndims <= MAX_TENSOR_DIMS);
     memcpy(&t, &ci, 64);
     t.buffer = {reinterpret_cast<uint64_t>(addr), buffer_size};
-    t.owner_task_id = PTO2TaskId::invalid();  // caller (orchestrator) overwrites with actual task_id
+    t.owner_task_id = TaskId::invalid();  // caller (orchestrator) overwrites with actual task_id
     uint32_t s = 1;
     for (int32_t i = static_cast<int32_t>(t.ndims) - 1; i >= 0; --i) {
         t.strides[i] = s;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensormap.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensormap.h
@@ -128,15 +128,15 @@ struct alignas(64) PTO2TensorMapEntry {
     // === Cache line 1 (64B) — lookup hot path; mirrors ChipTensor line 1 from byte 16 ===
     uint64_t buffer_addr;  // 8B [0, 8):   tensor base address (hash key, mirrors ChipTensor::buffer.addr)
     PTO2TensorMapEntry
-        *next_in_bucket;          // 8B [8, 16):  next entry in hash bucket chain (overlays ChipTensor::buffer.size)
-    PTO2TaskId producer_task_id;  // 8B [16,24):  mirrors ChipTensor::owner_task_id slot
-    uint64_t start_offset;        // 8B [24,32):  mirrors ChipTensor::start_offset (element offset)
-    int32_t version;              // 4B [32,36):  mirrors ChipTensor::version
-    uint32_t ndims;               // 4B [36,40):  mirrors ChipTensor::ndims
-    DataType dtype;               // 1B [40,41):  mirrors ChipTensor::dtype
-    bool manual_dep;              // 1B [41,42):  mirrors ChipTensor::manual_dep
-    bool is_contiguous;           // 1B [42,43):  mirrors ChipTensor::is_contiguous
-    uint8_t __padding1__;         // 1B [43,44):  mirrors ChipTensor padding
+        *next_in_bucket;      // 8B [8, 16):  next entry in hash bucket chain (overlays ChipTensor::buffer.size)
+    TaskId producer_task_id;  // 8B [16,24):  mirrors ChipTensor::owner_task_id slot
+    uint64_t start_offset;    // 8B [24,32):  mirrors ChipTensor::start_offset (element offset)
+    int32_t version;          // 4B [32,36):  mirrors ChipTensor::version
+    uint32_t ndims;           // 4B [36,40):  mirrors ChipTensor::ndims
+    DataType dtype;           // 1B [40,41):  mirrors ChipTensor::dtype
+    bool manual_dep;          // 1B [41,42):  mirrors ChipTensor::manual_dep
+    bool is_contiguous;       // 1B [42,43):  mirrors ChipTensor::is_contiguous
+    uint8_t __padding1__;     // 1B [43,44):  mirrors ChipTensor padding
     uint32_t shapes[MAX_TENSOR_DIMS];  // 20B [44,64): mirrors ChipTensor::shapes
 
     // === Cache line 2 (64B) — chain manipulation + non-contiguous overlap data ===
@@ -588,7 +588,7 @@ struct PTO2TensorMap {
      * @param tensor            ChipTensor produced
      * @param producer_task_id  Task ID of producer
      */
-    void insert(const ChipTensor &tensor, PTO2TaskId producer_task_id) {
+    void insert(const ChipTensor &tensor, TaskId producer_task_id) {
         PTO2TensorMapEntry *entry = new_entry();
         entry->copy_from_tensor(tensor);
         link_entry(entry, tensor.buffer.addr, producer_task_id);
@@ -614,7 +614,7 @@ struct PTO2TensorMap {
             // reused the slot (local_id + N * window) before this cleanup ran.
             // Free only entries produced by the retiring local_id, unlinking
             // each from the chain; entries from other tasks stay linked.
-            PTO2TaskId retired_task = PTO2TaskId::make(static_cast<uint8_t>(ring_id), static_cast<uint32_t>(local_id));
+            TaskId retired_task = TaskId::make(static_cast<uint8_t>(ring_id), static_cast<uint32_t>(local_id));
             PTO2TensorMapEntry *cur_entry = task_entry_heads[ring_id][task_slot];
             while (cur_entry != nullptr) {
                 PTO2TensorMapEntry *next_entry = cur_entry->next_in_task;  // free_entry clears it
@@ -654,7 +654,7 @@ struct PTO2TensorMap {
     /**
      * Link an initialized entry into bucket and task chains.
      */
-    void link_entry(PTO2TensorMapEntry *entry, uint64_t addr, PTO2TaskId producer_task_id) {
+    void link_entry(PTO2TensorMapEntry *entry, uint64_t addr, TaskId producer_task_id) {
 #if SIMPLER_TENSORMAP_PROFILING
         g_insert_count++;
 #endif
@@ -753,7 +753,7 @@ struct PTO2TensorMap {
      * Called periodically to refresh the lazy invalidation threshold.
      * Also triggers cleanup if threshold has advanced significantly.
      */
-    void sync_tensormap(PTO2TaskId task_id, int32_t sm_last_task_alive);
+    void sync_tensormap(TaskId task_id, int32_t sm_last_task_alive);
 };
 
 #if SIMPLER_TENSORMAP_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/types.h
@@ -139,7 +139,7 @@ constexpr bool dep_has_retain(DepFlags f) { return (f & DEP_RETAIN) != DEP_NONE;
 class TaskOutputTensors {
 public:
     TaskOutputTensors() :
-        task_id_(PTO2TaskId::invalid()),
+        task_id_(TaskId::invalid()),
         output_count_(0) {}
 
     bool empty() const { return output_count_ == 0; }
@@ -158,12 +158,12 @@ public:
         tensors_[output_count_++] = &tensor;
     }
 
-    void set_task_id(PTO2TaskId id) { task_id_ = id; }
+    void set_task_id(TaskId id) { task_id_ = id; }
 
-    PTO2TaskId task_id() const { return task_id_; }
+    TaskId task_id() const { return task_id_; }
 
 private:
-    PTO2TaskId task_id_;
+    TaskId task_id_;
     uint32_t output_count_;
     // Upper bound: a task cannot have more outputs than total tensor args
     // (every OUTPUT/OUTPUT_EXISTING slot is one of the Arg's tensor slots).
@@ -420,7 +420,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
      * count == 0 is a valid "set empty" — it clears any previously stored deps
      * and returns. This lets callers that build the dep set conditionally pass
      * the result through unguarded, including in the no-dep branch:
-     *   PTO2TaskId deps[3];
+     *   TaskId deps[3];
      *   uint32_t n = 0;
      *   if (have_prev) deps[n++] = prev;
      *   if (is_last)   deps[n++] = alloc;
@@ -430,7 +430,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
      * deps are already set will fail with set_error(). Use count == 0 first
      * if you need to re-set.
      */
-    void set_dependencies(const PTO2TaskId *deps, uint32_t count) {
+    void set_dependencies(const TaskId *deps, uint32_t count) {
         if (count == 0) {
             explicit_deps_ = nullptr;
             explicit_dep_count_ = 0;
@@ -458,7 +458,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
      * with count > 0 is rejected; use set_dependencies() for the
      * conservative DEP_WAIT|DEP_RETAIN default.
      */
-    void set_dependencies_with_kinds(const PTO2TaskId *deps, const DepFlags *kinds, uint32_t count) {
+    void set_dependencies_with_kinds(const TaskId *deps, const DepFlags *kinds, uint32_t count) {
         if (count == 0) {
             explicit_deps_ = nullptr;
             explicit_dep_count_ = 0;
@@ -480,7 +480,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
 
     uint32_t explicit_dep_count() const { return explicit_dep_count_; }
 
-    PTO2TaskId explicit_dep(uint32_t index) const {
+    TaskId explicit_dep(uint32_t index) const {
         always_assert(index < explicit_dep_count_);
         return explicit_deps_[index];
     }
@@ -495,7 +495,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
         return explicit_dep_kinds_ ? explicit_dep_kinds_[index] : (DEP_WAIT | DEP_RETAIN);
     }
 
-    const PTO2TaskId *explicit_deps_data() const { return explicit_deps_; }
+    const TaskId *explicit_deps_data() const { return explicit_deps_; }
 
     /**
      * Add scalar values. Types are deduced per argument; each value is
@@ -593,7 +593,7 @@ private:
 #if SIMPLER_DFX
     DumpArgSelection dump_arg_selection_;
 #endif
-    const PTO2TaskId *explicit_deps_{nullptr};
+    const TaskId *explicit_deps_{nullptr};
     const DepFlags *explicit_dep_kinds_{nullptr};
     uint32_t explicit_dep_count_{0};
 #if SIMPLER_DFX

--- a/src/common/host_build_graph/graph_cache.h
+++ b/src/common/host_build_graph/graph_cache.h
@@ -22,7 +22,7 @@
 struct GraphScopeResult {
     bool execute_block{true};
     bool recording{false};
-    PTO2TaskId task_id{PTO2TaskId::invalid()};
+    TaskId task_id{TaskId::invalid()};
     // The recording this call opened, non-null exactly when `recording` is set.
     // The recording thread hands it back to graph_prepare so binding needs no
     // lookup: several Definitions record at once, and finding one by key would

--- a/src/common/host_build_graph/graph_execution.cpp
+++ b/src/common/host_build_graph/graph_execution.cpp
@@ -440,7 +440,7 @@ GraphMaterializeResult graph_execution_materialize_slice(
 
         const uint32_t synthetic_local =
             (static_cast<uint32_t>(outer_slot.task->task_id.local()) << 10) | static_cast<uint32_t>(i);
-        task.task_id = PTO2TaskId::make(1, synthetic_local);
+        task.task_id = TaskId::make(1, synthetic_local);
         const GraphNodeDefinition &source = nodes[i];
         const uint64_t node_offset = node_offsets[i];
         const uint64_t output_bytes = PTO2_ALIGN_UP(static_cast<uint64_t>(source.total_output_size), PTO2_ALIGN_SIZE);

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -328,7 +328,7 @@ inline GraphTensor graph_tensor_pack(const ChipTensor &tensor) {
 
 inline void graph_tensor_unpack(const GraphTensor &packed, ChipTensor *tensor) {
     tensor->buffer = PTOBufferHandle{packed.buffer_addr, packed.buffer_size};
-    tensor->owner_task_id = PTO2TaskId{packed.owner_task_id};
+    tensor->owner_task_id = TaskId{packed.owner_task_id};
     tensor->start_offset = packed.start_offset;
     tensor->extent_elem_cache = packed.extent_elem;
     tensor->version = packed.version;

--- a/src/common/platform/include/aicpu/dep_gen_collector_aicpu.h
+++ b/src/common/platform/include/aicpu/dep_gen_collector_aicpu.h
@@ -30,7 +30,7 @@
  *   dep_gen_aicpu_finalize()            — clear bookkeeping.
  *
  * All-primitive interface (no runtime types in platform header):
- *   - task_id passed as raw uint64 (PTO2TaskId::raw)
+ *   - task_id passed as raw uint64 (TaskId::raw)
  *   - tensor data passed via opaque void* pointers (memcpy'd into the
  *     DEP_GEN_TENSOR_SIZE-byte slot; static_asserted against sizeof(ChipTensor)
  *     in the .cpp)
@@ -96,14 +96,14 @@ void dep_gen_aicpu_init();
  * submit whose chain would exceed the buffer's remaining capacity (even
  * after switch) is truncated to fit; the dropped tail is logged.
  *
- * @param task_id_raw         PTO2TaskId::raw (the assigned task_id for this submit)
+ * @param task_id_raw         TaskId::raw (the assigned task_id for this submit)
  * @param in_manual_scope     true iff the submit happened inside a manual scope
  * @param tensor_count        Number of slots in tensor_ptrs / arg_types (≤ CORE_MAX_TENSOR_ARGS)
  * @param tensor_ptrs         Per-slot ChipTensor pointer (nullptr to skip the slot)
  * @param arg_types           Per-slot TensorArgType (interpreted as raw byte)
  * @param explicit_dep_count  Number of explicit_deps — no static cap; truncated only when the
  *                            chain would not fit in a single DepGenBuffer
- * @param explicit_deps_raw   Per-dep PTO2TaskId::raw (length = explicit_dep_count)
+ * @param explicit_deps_raw   Per-dep TaskId::raw (length = explicit_dep_count)
  * @param block_num           SPMD logical block count; 1 means non-SPMD
  * @param kernel_ids          Per-subslot kernel id triple {AIC, AIV0, AIV1};
  *                            inactive subslots use INVALID_KERNEL_ID (-1).

--- a/src/common/platform/include/common/chip_swimlane_profiling.h
+++ b/src/common/platform/include/common/chip_swimlane_profiling.h
@@ -175,7 +175,7 @@ static_assert(sizeof(ChipSwimlaneAicpuTaskRecord) == 32, "ChipSwimlaneAicpuTaskR
 struct ChipSwimlaneAicoreTaskRecord {
     uint64_t start_time;               // Post-dcci+ack timestamp (kernel begins next)
     uint64_t end_time;                 // Post-kernel timestamp
-    uint64_t task_token_raw;           // PTO2TaskId::raw — identity (NOT join key)
+    uint64_t task_token_raw;           // TaskId::raw — identity (NOT join key)
     uint32_t reg_task_id;              // Per-core dispatch token — host join key vs AICPU stream
     uint32_t receive_to_start_cycles;  // start_time - receive_time (AICore-local dcci + ack cost)
 } __attribute__((aligned(32)));

--- a/src/common/platform/include/common/dep_gen.h
+++ b/src/common/platform/include/common/dep_gen.h
@@ -108,7 +108,7 @@ struct DepGenRecord {
     uint32_t flags;                                     // DepGenRecordFlags bitmask
     uint16_t tensor_count;                              // number of valid ChipTensor slots
     uint16_t explicit_dep_count;                        // number of valid explicit_dep slots
-    uint64_t explicit_deps[DEP_GEN_MAX_EXPLICIT_DEPS];  // PTO2TaskId::raw, length = explicit_dep_count
+    uint64_t explicit_deps[DEP_GEN_MAX_EXPLICIT_DEPS];  // TaskId::raw, length = explicit_dep_count
     uint8_t arg_types[CORE_MAX_TENSOR_ARGS];            // TensorArgType, length = tensor_count
     int32_t kernel_id[3];  // per-subslot kernel id (AIC, AIV0, AIV1); INVALID_KERNEL_ID = -1
     uint32_t block_num;    // SPMD logical block count; 1 means non-SPMD
@@ -154,7 +154,7 @@ struct DepGenOverflowRecord {
     uint32_t flags;      // DEP_GEN_FLAG_OVERFLOW [| DEP_GEN_FLAG_LAST_OVERFLOW]
     uint16_t dep_count;  // number of valid entries in deps[]
     uint16_t _reserved;
-    uint64_t deps[DEP_GEN_OVERFLOW_DEPS_PER_RECORD];  // PTO2TaskId::raw, length = dep_count
+    uint64_t deps[DEP_GEN_OVERFLOW_DEPS_PER_RECORD];  // TaskId::raw, length = dep_count
 } __attribute__((aligned(64)));
 
 static_assert(

--- a/src/common/task_interface/task_id.h
+++ b/src/common/task_interface/task_id.h
@@ -10,7 +10,7 @@
  */
 
 /**
- * PTO2TaskId — minimal standalone header.
+ * TaskId — minimal standalone header.
  *
  * Factored out of runtime_types.h so that tensor.h can include it
  * without pulling in scheduler-internal constants (heap sizes, timeouts, etc.).
@@ -21,7 +21,7 @@
 #include <cstdint>
 
 /**
- * TaskId: 64-bit encoding used across Runtime2.
+ * TaskId: 64-bit encoding shared by both runtimes.
  *
  * raw encoding: (ring_id << 32) | local_id
  *
@@ -30,22 +30,22 @@
  *
  * Invalid sentinel: raw == UINT64_MAX (no valid task has this encoding).
  */
-struct PTO2TaskId {
+struct TaskId {
     uint64_t raw;
 
-    static constexpr PTO2TaskId make(uint8_t ring_id, uint32_t local_id) {
-        return PTO2TaskId{(static_cast<uint64_t>(ring_id) << 32) | static_cast<uint64_t>(local_id)};
+    static constexpr TaskId make(uint8_t ring_id, uint32_t local_id) {
+        return TaskId{(static_cast<uint64_t>(ring_id) << 32) | static_cast<uint64_t>(local_id)};
     }
 
-    static constexpr PTO2TaskId invalid() { return PTO2TaskId{UINT64_MAX}; }
+    static constexpr TaskId invalid() { return TaskId{UINT64_MAX}; }
 
     constexpr uint8_t ring() const { return static_cast<uint8_t>(raw >> 32); }
     constexpr uint32_t local() const { return static_cast<uint32_t>(raw & 0xFFFFFFFFu); }
     constexpr bool is_valid() const { return raw != UINT64_MAX; }
     constexpr bool is_invalid() const { return raw == UINT64_MAX; }
 
-    constexpr bool operator==(const PTO2TaskId &other) const { return raw == other.raw; }
-    constexpr bool operator!=(const PTO2TaskId &other) const { return raw != other.raw; }
+    constexpr bool operator==(const TaskId &other) const { return raw == other.raw; }
+    constexpr bool operator!=(const TaskId &other) const { return raw != other.raw; }
 };
 
-static_assert(sizeof(PTO2TaskId) == 8, "PTO2TaskId must stay 8 bytes (shared memory ABI)");
+static_assert(sizeof(TaskId) == 8, "TaskId must stay 8 bytes (shared memory ABI)");

--- a/src/common/task_interface/tensor.h
+++ b/src/common/task_interface/tensor.h
@@ -95,7 +95,7 @@ enum class TensorArgType : int32_t {
 struct alignas(64) ChipTensor {
     // === Cache line 1 (64B) — hot path ===
     PTOBufferHandle buffer;            // Underlying memory buffer (addr in bytes, size in bytes)
-    PTO2TaskId owner_task_id;          // Creator task; PTO2TaskId::invalid() for external tensors
+    TaskId owner_task_id;              // Creator task; TaskId::invalid() for external tensors
     uint64_t start_offset;             // 1D ELEMENT offset of the view origin into `buffer`
     int32_t version;                   // ChipTensor version for overlap detection
     uint32_t ndims;                    // Number of dimensions used
@@ -190,7 +190,7 @@ struct alignas(64) ChipTensor {
         is_contiguous = true;
         address_space = in_address_space;
         start_offset = 0;
-        owner_task_id = PTO2TaskId::invalid();
+        owner_task_id = TaskId::invalid();
         // Single reverse pass: write shapes, accumulate row-major stride, and
         // track numel — `s` ends as prod(shapes) which is also extent_elem
         // for a contiguous view.
@@ -537,7 +537,7 @@ inline ChipTensor make_tensor_strided(
     t.manual_dep = manual_dep;
     t.address_space = address_space;
     t.start_offset = 0;
-    t.owner_task_id = PTO2TaskId::invalid();
+    t.owner_task_id = TaskId::invalid();
     for (uint32_t i = 0; i < ndims; i++) {
         t.shapes[i] = shapes[i];
         t.strides[i] = strides[i];

--- a/tests/st/a2a3/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
@@ -32,7 +32,7 @@ void layer(const GraphTaskArgs &args, int variant) {
     CoreTaskArgs add_args;
     add_args.add_input(a, b);
     add_args.add_output(intermediate);
-    const std::array<PTO2TaskId, 1> external_dep{a.owner_task_id};
+    const std::array<TaskId, 1> external_dep{a.owner_task_id};
     add_args.set_dependencies(external_dep.data(), static_cast<uint32_t>(external_dep.size()));
     TaskOutputTensors add_outputs = rt_submit_aiv_task(FUNC_ADD, add_args);
     ChipTensor sum = add_outputs.get_ref(0);

--- a/tests/st/a2a3/host_build_graph/graph_predicated_dispatch/kernels/orchestration/graph_predicated_dispatch_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/graph_predicated_dispatch/kernels/orchestration/graph_predicated_dispatch_orch.cpp
@@ -94,35 +94,35 @@ void layer(const GraphTaskArgs &args, int variant) {
     gate_args.add_scalar(args.scalar(0));
     TaskOutputTensors gate_outputs = rt_submit_aic_task(FUNC_WRITE_GATE, gate_args);
     ChipTensor internal_gate = gate_outputs.get_ref(0);
-    PTO2TaskId gate_tid = gate_outputs.task_id();
+    TaskId gate_tid = gate_outputs.task_id();
 
     // X is a boundary tensor, so the four tasks below share no Graph-internal
     // tensor and the recorder derives no edge between them. Their write-then-read
     // order is stated explicitly, which is what a recorded Graph preserves.
-    PTO2TaskId sentinel_tid;
+    TaskId sentinel_tid;
     {
         CoreTaskArgs sentinel_args;
         sentinel_args.add_inout(x);
         sentinel_tid = rt_submit_aic_task(FUNC_WRITE_CONST, sentinel_args).task_id();
     }
 
-    PTO2TaskId clobber_tid;
+    TaskId clobber_tid;
     {
         CoreTaskArgs clobber_args;
         clobber_args.add_inout(x);
-        const std::array<PTO2TaskId, 1> deps{sentinel_tid};
+        const std::array<TaskId, 1> deps{sentinel_tid};
         clobber_args.set_dependencies(deps.data(), static_cast<uint32_t>(deps.size()));
         clobber_args.set_predicate(gate_predicate(boundary_gate, 0));
         clobber_tid = rt_submit_aic_task(FUNC_CLOBBER, clobber_args).task_id();
     }
 
-    PTO2TaskId clobber_alt_tid;
+    TaskId clobber_alt_tid;
     {
         CoreTaskArgs clobber_args;
         clobber_args.add_inout(x);
         // The predicate is a condition, not a dependency: the operand's producer
         // is named here so the value is written by the time this task is ready.
-        const std::array<PTO2TaskId, 2> deps{clobber_tid, gate_tid};
+        const std::array<TaskId, 2> deps{clobber_tid, gate_tid};
         clobber_args.set_dependencies(deps.data(), static_cast<uint32_t>(deps.size()));
         clobber_args.set_predicate(gate_predicate(internal_gate, 0));
         clobber_alt_tid = rt_submit_aic_task(FUNC_CLOBBER_ALT, clobber_args).task_id();
@@ -132,7 +132,7 @@ void layer(const GraphTaskArgs &args, int variant) {
         CoreTaskArgs consumer_args;
         consumer_args.add_input(x);
         consumer_args.add_inout(y);
-        const std::array<PTO2TaskId, 1> deps{clobber_alt_tid};
+        const std::array<TaskId, 1> deps{clobber_alt_tid};
         consumer_args.set_dependencies(deps.data(), static_cast<uint32_t>(deps.size()));
         consumer_args.set_predicate(gate_predicate(gate_view, 1));
         rt_submit_aic_task(FUNC_COPY_FIRST, consumer_args);

--- a/tests/st/a2a3/host_build_graph/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
@@ -69,7 +69,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     int64_t gate_value = (case_id == 1) ? 0 : 1;
 
     // gate producer: gate[0] = gate_value
-    PTO2TaskId gate_tid;
+    TaskId gate_tid;
     {
         CoreTaskArgs args;
         args.add_inout(ext_gate);
@@ -90,7 +90,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     {
         CoreTaskArgs args;
         args.add_inout(ext_X);
-        PTO2TaskId deps[] = {gate_tid};
+        TaskId deps[] = {gate_tid};
         args.set_dependencies(deps, 1);
         // predicate: gate[0] > 0  (operand op target), built level by level.
         CoreTaskPredicate pred;

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/kernels/orchestration/sync_start_early_local_owner_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/kernels/orchestration/sync_start_early_local_owner_orch.cpp
@@ -77,13 +77,13 @@ static bool wait_for_blockers_started(const ChipTensor &out, int32_t blocker_cou
 
 static bool wait_for_scheduler_loop_fence() {
     CoreTaskArgs first_args;
-    PTO2TaskId first = rt_submit_dummy_task(first_args).task_id();
+    TaskId first = rt_submit_dummy_task(first_args).task_id();
 
     uint32_t fence_shape[1] = {1};
     TensorCreateInfo fence_info(fence_shape, 1, DataType::INT32);
     CoreTaskArgs second_args;
     second_args.add_output(fence_info);
-    PTO2TaskId deps[1] = {first};
+    TaskId deps[1] = {first};
     second_args.set_dependencies(deps, 1);
     TaskOutputTensors outputs = rt_submit_dummy_task(second_args);
 
@@ -96,7 +96,7 @@ static bool wait_for_scheduler_loop_fence() {
     return !rt_is_fatal();
 }
 
-static PTO2TaskId submit_producer(const ChipTensor &out) {
+static TaskId submit_producer(const ChipTensor &out) {
     CoreTaskArgs args;
     args.add_inout(out);
     args.add_scalar(0);  // base cache line
@@ -106,7 +106,7 @@ static PTO2TaskId submit_producer(const ChipTensor &out) {
     return rt_submit_aic_task(FUNC_SLOW_PRODUCER_AIC, args).task_id();
 }
 
-static PTO2TaskId submit_aiv_blocker(const ChipTensor &out, int32_t blocker_count) {
+static TaskId submit_aiv_blocker(const ChipTensor &out, int32_t blocker_count) {
     CoreTaskArgs args;
     args.add_inout(out);
     args.add_scalar(BLOCKER_STATUS_BASE_CL);
@@ -116,7 +116,7 @@ static PTO2TaskId submit_aiv_blocker(const ChipTensor &out, int32_t blocker_coun
     return rt_submit_aiv_task(FUNC_SPIN_BLOCKER_AIV, args).task_id();
 }
 
-static void submit_consumer(const ChipTensor &out, PTO2TaskId producer, int16_t consumer_blocks) {
+static void submit_consumer(const ChipTensor &out, TaskId producer, int16_t consumer_blocks) {
     CoreTaskArgsWithDeps<1> args;
     args.add_inout(out);
     args.add_scalar(PRODUCER_BLOCKS);  // base cache line
@@ -142,7 +142,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     }
 
     rt_scope_begin(PTO2ScopeMode::MANUAL);
-    PTO2TaskId producer = use_pending ? submit_aiv_blocker(output, blocker_count) : submit_producer(output);
+    TaskId producer = use_pending ? submit_aiv_blocker(output, blocker_count) : submit_producer(output);
     if (use_pending && (!wait_for_blockers_started(output, blocker_count) || !wait_for_scheduler_loop_fence())) return;
     submit_consumer(output, producer, consumer_blocks);
     if (use_pending && !wait_for_scheduler_loop_fence()) return;

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
@@ -61,7 +61,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         return;
     }
 
-    PTO2TaskId producer_ids[MAX_PRODUCERS];
+    TaskId producer_ids[MAX_PRODUCERS];
 
     // N producers each INOUT X. tensormap auto-deps them in a chain, so X[0]
     // stays at SENTINEL through all of them — the host only checks the final
@@ -74,7 +74,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     // Dummy barrier with explicit deps on ALL N producers. dc=n > 64 forces
     // the dep_gen writer to emit base + overflow chain.
-    PTO2TaskId barrier_id;
+    TaskId barrier_id;
     {
         CoreTaskArgs args;
         args.set_dependencies(producer_ids, n);
@@ -84,7 +84,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     // Consumer: explicit dep on barrier only, reads X, writes Y.
     {
         CoreTaskArgs args;
-        PTO2TaskId consumer_deps[] = {barrier_id};
+        TaskId consumer_deps[] = {barrier_id};
         args.set_dependencies(consumer_deps, 1);
         args.add_input(ext_X);
         args.add_inout(ext_Y);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
@@ -45,7 +45,7 @@ KERNELS_BASE = "../../../../../../examples/a2a3/tensormap_and_ringbuffer/vector_
 
 
 def _task_id(ring: int, local: int) -> int:
-    """Encode (ring_id, local_id) → 64-bit raw matching ``PTO2TaskId::raw`` —
+    """Encode (ring_id, local_id) → 64-bit raw matching ``TaskId::raw`` —
     keeps the bit layout (``(ring << 32) | local``) in one place rather than
     repeating ``1 << 32`` arithmetic at every call site.
     """

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
@@ -113,8 +113,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         }
     } else if (case_id == 3) {
         // producer A writes X, producer B writes W
-        PTO2TaskId a_id;
-        PTO2TaskId b_id;
+        TaskId a_id;
+        TaskId b_id;
         {
             CoreTaskArgs args;
             args.add_inout(ext_X);
@@ -126,17 +126,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             b_id = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
         }
         // dummy barrier on A + B (no tensor args, only explicit deps)
-        PTO2TaskId dummy_id;
+        TaskId dummy_id;
         {
             CoreTaskArgs args;
-            PTO2TaskId barrier_deps[] = {a_id, b_id};
+            TaskId barrier_deps[] = {a_id, b_id};
             args.set_dependencies(barrier_deps, 2);
             dummy_id = rt_submit_dummy_task(args).task_id();
         }
         // consumer: explicit dep on dummy, reads X
         {
             CoreTaskArgs args;
-            PTO2TaskId consumer_deps[] = {dummy_id};
+            TaskId consumer_deps[] = {dummy_id};
             args.set_dependencies(consumer_deps, 1);
             args.add_input(ext_X);
             args.add_inout(ext_Y);
@@ -145,16 +145,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     } else if (case_id == 4) {
         // One producer feeds DENSE_DEP_COUNT dummy barriers, then one consumer
         // depends on all of them, exercising both dense-dependency diagnostics.
-        PTO2TaskId a_id;
+        TaskId a_id;
         {
             CoreTaskArgs args;
             args.add_inout(ext_X);
             a_id = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
         }
-        PTO2TaskId dummies[DENSE_DEP_COUNT];
+        TaskId dummies[DENSE_DEP_COUNT];
         for (int32_t i = 0; i < DENSE_DEP_COUNT; i++) {
             CoreTaskArgs args;
-            PTO2TaskId dep[] = {a_id};
+            TaskId dep[] = {a_id};
             args.set_dependencies(dep, 1);
             dummies[i] = rt_submit_dummy_task(args).task_id();
         }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/orchestration/fanin_lookup_perf_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/orchestration/fanin_lookup_perf_orch.cpp
@@ -63,7 +63,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         return;
     }
 
-    PTO2TaskId producer_ids[MAX_PRODUCERS];
+    TaskId producer_ids[MAX_PRODUCERS];
     uint32_t slot_shape[1] = {SLOT_ELEMS};
     for (int32_t i = 0; i < producer_count; i++) {
         CoreTaskArgs args;

--- a/tests/st/a2a3/tensormap_and_ringbuffer/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
@@ -69,7 +69,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     int64_t gate_value = (case_id == 1) ? 0 : 1;
 
     // gate producer: gate[0] = gate_value
-    PTO2TaskId gate_tid;
+    TaskId gate_tid;
     {
         CoreTaskArgs args;
         args.add_inout(ext_gate);
@@ -90,7 +90,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     {
         CoreTaskArgs args;
         args.add_inout(ext_X);
-        PTO2TaskId deps[] = {gate_tid};
+        TaskId deps[] = {gate_tid};
         args.set_dependencies(deps, 1);
         // predicate: gate[0] > 0  (operand op target), built level by level.
         CoreTaskPredicate pred;

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/kernels/orchestration/spmd_sync_start_early_dispatch_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/kernels/orchestration/spmd_sync_start_early_dispatch_orch.cpp
@@ -55,7 +55,7 @@ static constexpr int64_t PRODUCER_SPIN_ITERS = 10000000;
 
 static constexpr int32_t PRODUCER_BLOCKS = 50;
 
-static PTO2TaskId submit_producer(const ChipTensor &out, int16_t block_num, int64_t base_cl) {
+static TaskId submit_producer(const ChipTensor &out, int16_t block_num, int64_t base_cl) {
     CoreTaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
@@ -65,7 +65,7 @@ static PTO2TaskId submit_producer(const ChipTensor &out, int16_t block_num, int6
     return rt_submit_aic_task(FUNC_SPMD_WRITE_AIC, args).task_id();
 }
 
-static void submit_sync_consumer(const ChipTensor &out, int16_t block_num, int64_t base_cl, PTO2TaskId dep) {
+static void submit_sync_consumer(const ChipTensor &out, int16_t block_num, int64_t base_cl, TaskId dep) {
     MixedKernels kernels;
     kernels.aic_kernel_id = FUNC_SPMD_MIX_AIC;
     kernels.aiv0_kernel_id = FUNC_SPMD_MIX_AIV0;
@@ -90,7 +90,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const int32_t sync_blocks = rt_available_cluster_count();
 
     rt_scope_begin(PTO2ScopeMode::MANUAL);
-    PTO2TaskId prod = submit_producer(ext_output, PRODUCER_BLOCKS, 0);
+    TaskId prod = submit_producer(ext_output, PRODUCER_BLOCKS, 0);
     submit_sync_consumer(ext_output, static_cast<int16_t>(sync_blocks), PRODUCER_BLOCKS, prod);
     rt_scope_end();
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/kernels/orchestration/spmd_sync_start_mix_spill_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/kernels/orchestration/spmd_sync_start_mix_spill_orch.cpp
@@ -70,7 +70,7 @@ static MixedKernels mix_kernels() {
     return mk;
 }
 
-static PTO2TaskId submit_aiv_producer(const ChipTensor &out, int16_t block_num, int64_t base_cl) {
+static TaskId submit_aiv_producer(const ChipTensor &out, int16_t block_num, int64_t base_cl) {
     CoreTaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
@@ -80,7 +80,7 @@ static PTO2TaskId submit_aiv_producer(const ChipTensor &out, int16_t block_num, 
     return rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args).task_id();
 }
 
-static void submit_mix_sync_consumer(const ChipTensor &out, int16_t block_num, int64_t base_cl, PTO2TaskId dep) {
+static void submit_mix_sync_consumer(const ChipTensor &out, int16_t block_num, int64_t base_cl, TaskId dep) {
     CoreTaskArgsWithDeps<4> args;
     args.add_inout(out);
     args.add_scalar(base_cl);
@@ -102,7 +102,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const int32_t producer_blocks = rt_available_aiv_count();
     const int32_t consumer_blocks = rt_available_cluster_count();
 
-    PTO2TaskId prod = submit_aiv_producer(ext_output, static_cast<int16_t>(producer_blocks), 0);
+    TaskId prod = submit_aiv_producer(ext_output, static_cast<int16_t>(producer_blocks), 0);
     submit_mix_sync_consumer(ext_output, static_cast<int16_t>(consumer_blocks), producer_blocks, prod);
 
     uint32_t idx[1] = {0};

--- a/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
+++ b/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
@@ -32,7 +32,7 @@ void layer(const GraphTaskArgs &args, int variant) {
     CoreTaskArgs add_args;
     add_args.add_input(a, b);
     add_args.add_output(intermediate);
-    const std::array<PTO2TaskId, 1> external_dep{a.owner_task_id};
+    const std::array<TaskId, 1> external_dep{a.owner_task_id};
     add_args.set_dependencies(external_dep.data(), static_cast<uint32_t>(external_dep.size()));
     TaskOutputTensors add_outputs = rt_submit_aiv_task(FUNC_ADD, add_args);
     ChipTensor sum = add_outputs.get_ref(0);

--- a/tests/st/a5/host_build_graph/graph_predicated_dispatch/kernels/orchestration/graph_predicated_dispatch_orch.cpp
+++ b/tests/st/a5/host_build_graph/graph_predicated_dispatch/kernels/orchestration/graph_predicated_dispatch_orch.cpp
@@ -94,35 +94,35 @@ void layer(const GraphTaskArgs &args, int variant) {
     gate_args.add_scalar(args.scalar(0));
     TaskOutputTensors gate_outputs = rt_submit_aic_task(FUNC_WRITE_GATE, gate_args);
     ChipTensor internal_gate = gate_outputs.get_ref(0);
-    PTO2TaskId gate_tid = gate_outputs.task_id();
+    TaskId gate_tid = gate_outputs.task_id();
 
     // X is a boundary tensor, so the four tasks below share no Graph-internal
     // tensor and the recorder derives no edge between them. Their write-then-read
     // order is stated explicitly, which is what a recorded Graph preserves.
-    PTO2TaskId sentinel_tid;
+    TaskId sentinel_tid;
     {
         CoreTaskArgs sentinel_args;
         sentinel_args.add_inout(x);
         sentinel_tid = rt_submit_aic_task(FUNC_WRITE_CONST, sentinel_args).task_id();
     }
 
-    PTO2TaskId clobber_tid;
+    TaskId clobber_tid;
     {
         CoreTaskArgs clobber_args;
         clobber_args.add_inout(x);
-        const std::array<PTO2TaskId, 1> deps{sentinel_tid};
+        const std::array<TaskId, 1> deps{sentinel_tid};
         clobber_args.set_dependencies(deps.data(), static_cast<uint32_t>(deps.size()));
         clobber_args.set_predicate(gate_predicate(boundary_gate, 0));
         clobber_tid = rt_submit_aic_task(FUNC_CLOBBER, clobber_args).task_id();
     }
 
-    PTO2TaskId clobber_alt_tid;
+    TaskId clobber_alt_tid;
     {
         CoreTaskArgs clobber_args;
         clobber_args.add_inout(x);
         // The predicate is a condition, not a dependency: the operand's producer
         // is named here so the value is written by the time this task is ready.
-        const std::array<PTO2TaskId, 2> deps{clobber_tid, gate_tid};
+        const std::array<TaskId, 2> deps{clobber_tid, gate_tid};
         clobber_args.set_dependencies(deps.data(), static_cast<uint32_t>(deps.size()));
         clobber_args.set_predicate(gate_predicate(internal_gate, 0));
         clobber_alt_tid = rt_submit_aic_task(FUNC_CLOBBER_ALT, clobber_args).task_id();
@@ -132,7 +132,7 @@ void layer(const GraphTaskArgs &args, int variant) {
         CoreTaskArgs consumer_args;
         consumer_args.add_input(x);
         consumer_args.add_inout(y);
-        const std::array<PTO2TaskId, 1> deps{clobber_alt_tid};
+        const std::array<TaskId, 1> deps{clobber_alt_tid};
         consumer_args.set_dependencies(deps.data(), static_cast<uint32_t>(deps.size()));
         consumer_args.set_predicate(gate_predicate(gate_view, 1));
         rt_submit_aic_task(FUNC_COPY_FIRST, consumer_args);

--- a/tests/st/a5/host_build_graph/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
+++ b/tests/st/a5/host_build_graph/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
@@ -69,7 +69,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     int64_t gate_value = (case_id == 1) ? 0 : 1;
 
     // gate producer: gate[0] = gate_value
-    PTO2TaskId gate_tid;
+    TaskId gate_tid;
     {
         CoreTaskArgs args;
         args.add_inout(ext_gate);
@@ -90,7 +90,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     {
         CoreTaskArgs args;
         args.add_inout(ext_X);
-        PTO2TaskId deps[] = {gate_tid};
+        TaskId deps[] = {gate_tid};
         args.set_dependencies(deps, 1);
         // predicate: gate[0] > 0  (operand op target), built level by level.
         CoreTaskPredicate pred;

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/kernels/orchestration/sync_start_early_local_owner_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/kernels/orchestration/sync_start_early_local_owner_orch.cpp
@@ -69,13 +69,13 @@ static bool wait_for_blockers_started(const ChipTensor &out, int32_t blocker_cou
 
 static bool wait_for_scheduler_loop_fence() {
     CoreTaskArgs first_args;
-    PTO2TaskId first = rt_submit_dummy_task(first_args).task_id();
+    TaskId first = rt_submit_dummy_task(first_args).task_id();
 
     uint32_t fence_shape[1] = {1};
     TensorCreateInfo fence_info(fence_shape, 1, DataType::INT32);
     CoreTaskArgs second_args;
     second_args.add_output(fence_info);
-    PTO2TaskId deps[1] = {first};
+    TaskId deps[1] = {first};
     second_args.set_dependencies(deps, 1);
     TaskOutputTensors outputs = rt_submit_dummy_task(second_args);
 
@@ -88,7 +88,7 @@ static bool wait_for_scheduler_loop_fence() {
     return !rt_is_fatal();
 }
 
-static PTO2TaskId submit_producer(const ChipTensor &out) {
+static TaskId submit_producer(const ChipTensor &out) {
     CoreTaskArgs args;
     args.add_inout(out);
     args.add_scalar(0);
@@ -98,7 +98,7 @@ static PTO2TaskId submit_producer(const ChipTensor &out) {
     return rt_submit_aic_task(FUNC_SLOW_PRODUCER_AIC, args).task_id();
 }
 
-static PTO2TaskId submit_aiv_blocker(const ChipTensor &out, int32_t blocker_count) {
+static TaskId submit_aiv_blocker(const ChipTensor &out, int32_t blocker_count) {
     CoreTaskArgs args;
     args.add_inout(out);
     args.add_scalar(BLOCKER_STATUS_BASE_CL);
@@ -108,7 +108,7 @@ static PTO2TaskId submit_aiv_blocker(const ChipTensor &out, int32_t blocker_coun
     return rt_submit_aiv_task(FUNC_SPIN_BLOCKER_AIV, args).task_id();
 }
 
-static void submit_consumer(const ChipTensor &out, PTO2TaskId producer, int16_t consumer_blocks) {
+static void submit_consumer(const ChipTensor &out, TaskId producer, int16_t consumer_blocks) {
     CoreTaskArgsWithDeps<1> args;
     args.add_inout(out);
     args.add_scalar(PRODUCER_BLOCKS);
@@ -134,7 +134,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     }
 
     rt_scope_begin(PTO2ScopeMode::MANUAL);
-    PTO2TaskId producer = use_pending ? submit_aiv_blocker(output, blocker_count) : submit_producer(output);
+    TaskId producer = use_pending ? submit_aiv_blocker(output, blocker_count) : submit_producer(output);
     if (use_pending && (!wait_for_blockers_started(output, blocker_count) || !wait_for_scheduler_loop_fence())) return;
     submit_consumer(output, producer, consumer_blocks);
     if (use_pending && !wait_for_scheduler_loop_fence()) return;

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
@@ -61,7 +61,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         return;
     }
 
-    PTO2TaskId producer_ids[MAX_PRODUCERS];
+    TaskId producer_ids[MAX_PRODUCERS];
 
     // N producers each INOUT X. tensormap auto-deps them in a chain, so X[0]
     // stays at SENTINEL through all of them — the host only checks the final
@@ -74,7 +74,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     // Dummy barrier with explicit deps on ALL N producers. dc=n > 64 forces
     // the dep_gen writer to emit base + overflow chain.
-    PTO2TaskId barrier_id;
+    TaskId barrier_id;
     {
         CoreTaskArgs args;
         args.set_dependencies(producer_ids, n);
@@ -84,7 +84,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     // Consumer: explicit dep on barrier only, reads X, writes Y.
     {
         CoreTaskArgs args;
-        PTO2TaskId consumer_deps[] = {barrier_id};
+        TaskId consumer_deps[] = {barrier_id};
         args.set_dependencies(consumer_deps, 1);
         args.add_input(ext_X);
         args.add_inout(ext_Y);

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
@@ -45,7 +45,7 @@ KERNELS_BASE = "../../../../../../examples/a5/tensormap_and_ringbuffer/vector_ex
 
 
 def _task_id(ring: int, local: int) -> int:
-    """Encode (ring_id, local_id) → 64-bit raw matching ``PTO2TaskId::raw`` —
+    """Encode (ring_id, local_id) → 64-bit raw matching ``TaskId::raw`` —
     keeps the bit layout (``(ring << 32) | local``) in one place rather than
     repeating ``1 << 32`` arithmetic at every call site.
     """

--- a/tests/st/a5/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
@@ -113,8 +113,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         }
     } else if (case_id == 3) {
         // producer A writes X, producer B writes W
-        PTO2TaskId a_id;
-        PTO2TaskId b_id;
+        TaskId a_id;
+        TaskId b_id;
         {
             CoreTaskArgs args;
             args.add_inout(ext_X);
@@ -126,17 +126,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             b_id = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
         }
         // dummy barrier on A + B (no tensor args, only explicit deps)
-        PTO2TaskId dummy_id;
+        TaskId dummy_id;
         {
             CoreTaskArgs args;
-            PTO2TaskId barrier_deps[] = {a_id, b_id};
+            TaskId barrier_deps[] = {a_id, b_id};
             args.set_dependencies(barrier_deps, 2);
             dummy_id = rt_submit_dummy_task(args).task_id();
         }
         // consumer: explicit dep on dummy, reads X
         {
             CoreTaskArgs args;
-            PTO2TaskId consumer_deps[] = {dummy_id};
+            TaskId consumer_deps[] = {dummy_id};
             args.set_dependencies(consumer_deps, 1);
             args.add_input(ext_X);
             args.add_inout(ext_Y);
@@ -145,16 +145,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     } else if (case_id == 4) {
         // One producer feeds DENSE_DEP_COUNT dummy barriers, then one consumer
         // depends on all of them, exercising both dense-dependency diagnostics.
-        PTO2TaskId a_id;
+        TaskId a_id;
         {
             CoreTaskArgs args;
             args.add_inout(ext_X);
             a_id = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
         }
-        PTO2TaskId dummies[DENSE_DEP_COUNT];
+        TaskId dummies[DENSE_DEP_COUNT];
         for (int32_t i = 0; i < DENSE_DEP_COUNT; i++) {
             CoreTaskArgs args;
-            PTO2TaskId dep[] = {a_id};
+            TaskId dep[] = {a_id};
             args.set_dependencies(dep, 1);
             dummies[i] = rt_submit_dummy_task(args).task_id();
         }

--- a/tests/st/a5/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/orchestration/fanin_lookup_perf_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/orchestration/fanin_lookup_perf_orch.cpp
@@ -63,7 +63,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         return;
     }
 
-    PTO2TaskId producer_ids[MAX_PRODUCERS];
+    TaskId producer_ids[MAX_PRODUCERS];
     uint32_t slot_shape[1] = {SLOT_ELEMS};
     for (int32_t i = 0; i < producer_count; i++) {
         CoreTaskArgs args;

--- a/tests/st/a5/tensormap_and_ringbuffer/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
@@ -69,7 +69,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     int64_t gate_value = (case_id == 1) ? 0 : 1;
 
     // gate producer: gate[0] = gate_value
-    PTO2TaskId gate_tid;
+    TaskId gate_tid;
     {
         CoreTaskArgs args;
         args.add_inout(ext_gate);
@@ -90,7 +90,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     {
         CoreTaskArgs args;
         args.add_inout(ext_X);
-        PTO2TaskId deps[] = {gate_tid};
+        TaskId deps[] = {gate_tid};
         args.set_dependencies(deps, 1);
         // predicate: gate[0] > 0  (operand op target), built level by level.
         CoreTaskPredicate pred;

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/kernels/orchestration/spmd_sync_start_early_dispatch_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/kernels/orchestration/spmd_sync_start_early_dispatch_orch.cpp
@@ -49,7 +49,7 @@ static constexpr int64_t PRODUCER_SPIN_ITERS = 10000000;
 
 static constexpr int32_t PRODUCER_BLOCKS = 50;
 
-static PTO2TaskId submit_producer(const ChipTensor &out, int16_t core_num, int64_t base_cl, bool early_on) {
+static TaskId submit_producer(const ChipTensor &out, int16_t core_num, int64_t base_cl, bool early_on) {
     CoreTaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
@@ -59,7 +59,7 @@ static PTO2TaskId submit_producer(const ChipTensor &out, int16_t core_num, int64
     return rt_submit_aic_task(FUNC_SPMD_WRITE_AIC, args).task_id();
 }
 
-static void submit_sync_consumer(const ChipTensor &out, int16_t core_num, int64_t base_cl, PTO2TaskId dep) {
+static void submit_sync_consumer(const ChipTensor &out, int16_t core_num, int64_t base_cl, TaskId dep) {
     MixedKernels kernels;
     kernels.aic_kernel_id = FUNC_SPMD_MIX_AIC;
     kernels.aiv0_kernel_id = FUNC_SPMD_MIX_AIV0;
@@ -85,7 +85,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const int32_t sync_blocks = rt_available_cluster_count();
 
     rt_scope_begin(PTO2ScopeMode::MANUAL);
-    PTO2TaskId prod = submit_producer(ext_output, PRODUCER_BLOCKS, 0, early_on);
+    TaskId prod = submit_producer(ext_output, PRODUCER_BLOCKS, 0, early_on);
     submit_sync_consumer(ext_output, static_cast<int16_t>(sync_blocks), PRODUCER_BLOCKS, prod);
     rt_scope_end();
 

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/kernels/orchestration/spmd_sync_start_mix_spill_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/kernels/orchestration/spmd_sync_start_mix_spill_orch.cpp
@@ -51,7 +51,7 @@ static MixedKernels mix_kernels() {
     return mk;
 }
 
-static PTO2TaskId submit_aiv_producer(const ChipTensor &out, int16_t core_num, int64_t base_cl, bool early_on) {
+static TaskId submit_aiv_producer(const ChipTensor &out, int16_t core_num, int64_t base_cl, bool early_on) {
     CoreTaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
@@ -61,7 +61,7 @@ static PTO2TaskId submit_aiv_producer(const ChipTensor &out, int16_t core_num, i
     return rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args).task_id();
 }
 
-static void submit_mix_sync_consumer(const ChipTensor &out, int16_t core_num, int64_t base_cl, PTO2TaskId dep) {
+static void submit_mix_sync_consumer(const ChipTensor &out, int16_t core_num, int64_t base_cl, TaskId dep) {
     CoreTaskArgsWithDeps<4> args;
     args.add_inout(out);
     args.add_scalar(base_cl);
@@ -84,7 +84,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const int32_t producer_blocks = rt_available_aiv_count();
     const int32_t consumer_blocks = rt_available_cluster_count();
 
-    PTO2TaskId prod = submit_aiv_producer(ext_output, static_cast<int16_t>(producer_blocks), 0, early_on);
+    TaskId prod = submit_aiv_producer(ext_output, static_cast<int16_t>(producer_blocks), 0, early_on);
     submit_mix_sync_consumer(ext_output, static_cast<int16_t>(consumer_blocks), producer_blocks, prod);
 
     uint32_t idx[1] = {0};

--- a/tests/st/host_build_graph_validation/kernels/orchestration/validation_orch.cpp
+++ b/tests/st/host_build_graph_validation/kernels/orchestration/validation_orch.cpp
@@ -40,7 +40,7 @@ void submit_overflowing_mix_task() {
 
 ChipTensor tensor_with_unbound_owner(const ChipTensor &external) {
     ChipTensor forged = external;
-    forged.owner_task_id = PTO2TaskId::make(0, 17);
+    forged.owner_task_id = TaskId::make(0, 17);
     return forged;
 }
 

--- a/tests/st/host_build_graph_wide_dispatch/kernels/orchestration/host_build_graph_wide_dispatch_orch.cpp
+++ b/tests/st/host_build_graph_wide_dispatch/kernels/orchestration/host_build_graph_wide_dispatch_orch.cpp
@@ -29,7 +29,7 @@ MixedKernels mix_kernels() {
     return kernels;
 }
 
-PTO2TaskId submit_aiv(const ChipTensor &output, int16_t block_num) {
+TaskId submit_aiv(const ChipTensor &output, int16_t block_num) {
     CoreTaskArgs args;
     args.add_inout(output);
     args.add_scalar(0);
@@ -38,7 +38,7 @@ PTO2TaskId submit_aiv(const ChipTensor &output, int16_t block_num) {
     return rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args).task_id();
 }
 
-PTO2TaskId submit_sync_mix(const ChipTensor &output, int16_t block_num, int64_t base, PTO2TaskId producer) {
+TaskId submit_sync_mix(const ChipTensor &output, int16_t block_num, int64_t base, TaskId producer) {
     CoreTaskArgsWithDeps<1> args;
     args.add_inout(output);
     args.add_scalar(base);
@@ -49,7 +49,7 @@ PTO2TaskId submit_sync_mix(const ChipTensor &output, int16_t block_num, int64_t 
     return rt_submit_task(mix_kernels(), args).task_id();
 }
 
-void submit_normal_mix(const ChipTensor &output, int16_t block_num, int64_t base, PTO2TaskId producer) {
+void submit_normal_mix(const ChipTensor &output, int16_t block_num, int64_t base, TaskId producer) {
     CoreTaskArgsWithDeps<1> args;
     args.add_inout(output);
     args.add_scalar(base);
@@ -75,8 +75,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     int16_t aiv_blocks = static_cast<int16_t>(rt_available_aiv_count());
     int16_t mix_blocks = static_cast<int16_t>(rt_available_cluster_count());
 
-    PTO2TaskId aiv = submit_aiv(output, aiv_blocks);
-    PTO2TaskId sync_mix = submit_sync_mix(output, mix_blocks, aiv_blocks, aiv);
+    TaskId aiv = submit_aiv(output, aiv_blocks);
+    TaskId sync_mix = submit_sync_mix(output, mix_blocks, aiv_blocks, aiv);
     int64_t normal_base = aiv_blocks + 3 * mix_blocks;
     submit_normal_mix(output, mix_blocks, normal_base, sync_mix);
 

--- a/tests/st/runtime_fatal_codes/kernels/orchestration/dep_pool_overflow_orch.cpp
+++ b/tests/st/runtime_fatal_codes/kernels/orchestration/dep_pool_overflow_orch.cpp
@@ -50,7 +50,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     TensorCreateInfo ci(shape, 1, DataType::INT32);
 
     PTO2_SCOPE() {
-        PTO2TaskId producers[PRODUCER_COUNT];
+        TaskId producers[PRODUCER_COUNT];
         for (int32_t i = 0; i < PRODUCER_COUNT; i++) {
             CoreTaskArgs args;
             args.add_output(ci);

--- a/tests/ut/cpp/a2a3/test_aicore_completion_mailbox.cpp
+++ b/tests/ut/cpp/a2a3/test_aicore_completion_mailbox.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-PTO2TaskId make_token(uint32_t local) { return PTO2TaskId::make(/*ring=*/0, local); }
+TaskId make_token(uint32_t local) { return TaskId::make(/*ring=*/0, local); }
 
 AICoreCompletionMailbox *fresh_mailbox() {
     // ~256KB heap allocation — avoid stack/BSS pressure across tests.
@@ -57,7 +57,7 @@ TEST(AICoreCompletionMailbox, PushConditionThenDrainCreatesEntry) {
     AICoreCompletionMailbox *mb = fresh_mailbox();
     AsyncWaitList wait_list{};
 
-    PTO2TaskId token = make_token(42);
+    TaskId token = make_token(42);
     constexpr uint64_t kAddr = 0xCAFEBABEDEADBEEFull;
     ASSERT_TRUE(
         mb->try_push_condition(token, kAddr, /*expected=*/7, /*engine=*/COMPLETION_ENGINE_ROCE, COMPLETION_TYPE_COUNTER)
@@ -89,7 +89,7 @@ TEST(AICoreCompletionMailbox, PushNormalDoneCreatesEntryReadyToComplete) {
     AICoreCompletionMailbox *mb = fresh_mailbox();
     AsyncWaitList wait_list{};
 
-    PTO2TaskId token = make_token(99);
+    TaskId token = make_token(99);
     PTO2TaskSlotState dummy_slot{};
     uint64_t slot_addr = reinterpret_cast<uint64_t>(&dummy_slot);
     ASSERT_TRUE(mb->try_push_normal_done(token, slot_addr));
@@ -119,7 +119,7 @@ TEST(AICoreCompletionMailbox, NormalDoneAttachesToExistingEntry) {
 
     // Pre-seed an entry so drain's TASK_NORMAL_DONE branch flips it in place
     // rather than stashing. Exercises the "entry exists already" arm.
-    PTO2TaskId token = make_token(7);
+    TaskId token = make_token(7);
     wait_list.entries[0].task_token = token;
     wait_list.entries[0].slot_state = nullptr;
     wait_list.entries[0].condition_count = 0;
@@ -146,7 +146,7 @@ TEST(AICoreCompletionMailbox, ConditionAttachesToExistingEntry) {
     AICoreCompletionMailbox *mb = fresh_mailbox();
     AsyncWaitList wait_list{};
 
-    PTO2TaskId token = make_token(15);
+    TaskId token = make_token(15);
     wait_list.entries[0].task_token = token;
     wait_list.entries[0].slot_state = nullptr;
     wait_list.entries[0].condition_count = 0;
@@ -208,7 +208,7 @@ TEST(AICoreCompletionMailbox, PushReturnsFalseWhenFull) {
     AICoreCompletionMailbox *mb = fresh_mailbox();
 
     constexpr uint32_t kCap = AICORE_COMPLETION_MAILBOX_CAPACITY;
-    PTO2TaskId token = make_token(1);
+    TaskId token = make_token(1);
     for (uint32_t i = 0; i < kCap; i++) {
         ASSERT_TRUE(
             mb->try_push_condition(token, /*addr=*/i, /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER)
@@ -237,7 +237,7 @@ TEST(AICoreCompletionMailbox, MultiProducerNoLossAndPerProducerOrder) {
     producers.reserve(kProducers);
     for (int p = 0; p < kProducers; p++) {
         producers.emplace_back([mb, p]() {
-            PTO2TaskId token = make_token(static_cast<uint32_t>(p));
+            TaskId token = make_token(static_cast<uint32_t>(p));
             for (int i = 0; i < kPerProducer; i++) {
                 // Encode (producer, index) into addr to check per-producer
                 // ordering on the consumer side.
@@ -300,7 +300,7 @@ TEST(AICoreCompletionMailbox, ProducerInterleavedWithDrain) {
     AsyncWaitList wait_list{};
     // Pre-seed the entry for `token` so the drained CONDITIONs append to a
     // known slot the final assertions can read.
-    PTO2TaskId token = make_token(5);
+    TaskId token = make_token(5);
     wait_list.entries[0].task_token = token;
     wait_list.entries[0].slot_state = nullptr;
     wait_list.entries[0].condition_count = 0;
@@ -372,7 +372,7 @@ TEST(AICoreCompletionMailbox, MonotonicSeqSurvivesCapacityWrapWithoutZeroing) {
     // Drive head/tail one full capacity past the wrap point so every physical
     // slot has been published once and now carries a stale seq in [1, CAPACITY].
     // Each push is drained immediately so the ring never reports full.
-    PTO2TaskId token = make_token(7);
+    TaskId token = make_token(7);
     AICoreCompletionMsgView msg;
     for (uint64_t i = 0; i < AICORE_COMPLETION_MAILBOX_CAPACITY + 17; i++) {
         ASSERT_TRUE(
@@ -403,7 +403,7 @@ TEST(AICoreCompletionMailbox, TailEqualsHeadDiscardsUndrainedLeftovers) {
 
     // Simulate a prior run that pushed messages but aborted before draining
     // them all (error path): head advances, tail lags.
-    PTO2TaskId token = make_token(11);
+    TaskId token = make_token(11);
     for (int i = 0; i < 5; i++) {
         ASSERT_TRUE(mb->try_push_condition(
             token, /*addr=*/static_cast<uint64_t>(i), /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER

--- a/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
@@ -107,7 +107,7 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     ASSERT_TRUE(root.task_id().is_valid());
 
     // 2. Multi-fanin dummy consumer (duplicate dep deduped to one fanin).
-    PTO2TaskId deps[] = {root.task_id(), root.task_id()};
+    TaskId deps[] = {root.task_id(), root.task_id()};
     CoreTaskArgs consumer_args;
     consumer_args.set_dependencies(deps, 2);
     TaskOutputTensors consumer = orch.submit_dummy_task(consumer_args);

--- a/tests/ut/cpp/a2a3/test_hbg_tensormap.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_tensormap.cpp
@@ -65,21 +65,21 @@ protected:
 // inserts remain visible until dependency computation explicitly removes one.
 TEST_F(HbgTensorMapTest, EveryProducerOfARegionStaysVisible) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    tmap.insert(t, PTO2TaskId::make(0, 0));
-    tmap.insert(t, PTO2TaskId::make(0, 1));
-    tmap.insert(t, PTO2TaskId::make(0, 2));
+    tmap.insert(t, TaskId::make(0, 0));
+    tmap.insert(t, TaskId::make(0, 1));
+    tmap.insert(t, TaskId::make(0, 2));
     EXPECT_EQ(tmap.valid_count(), 3);
 
     TestLookupResult result;
     run_lookup(tmap, t, result);
     ASSERT_EQ(result.count, 3);
-    std::vector<PTO2TaskId> producers;
+    std::vector<TaskId> producers;
     for (const auto &e : result.entries) {
         producers.push_back(e.entry->producer_task_id);
     }
-    EXPECT_NE(std::find(producers.begin(), producers.end(), PTO2TaskId::make(0, 0)), producers.end());
-    EXPECT_NE(std::find(producers.begin(), producers.end(), PTO2TaskId::make(0, 1)), producers.end());
-    EXPECT_NE(std::find(producers.begin(), producers.end(), PTO2TaskId::make(0, 2)), producers.end());
+    EXPECT_NE(std::find(producers.begin(), producers.end(), TaskId::make(0, 0)), producers.end());
+    EXPECT_NE(std::find(producers.begin(), producers.end(), TaskId::make(0, 1)), producers.end());
+    EXPECT_NE(std::find(producers.begin(), producers.end(), TaskId::make(0, 2)), producers.end());
 }
 
 // Two tasks whose local ids alias to the same task slot both keep their entries;
@@ -87,19 +87,19 @@ TEST_F(HbgTensorMapTest, EveryProducerOfARegionStaysVisible) {
 TEST_F(HbgTensorMapTest, SlotAliasingTasksBothKeepTheirEntries) {
     ChipTensor t = make_test_tensor(0x1000, 256);
     // Task 0 and task 0 + WINDOW_SIZE share slot 0 (local_id & (WINDOW_SIZE-1)).
-    tmap.insert(t, PTO2TaskId::make(0, 0));
-    tmap.insert(t, PTO2TaskId::make(0, WINDOW_SIZE));
+    tmap.insert(t, TaskId::make(0, 0));
+    tmap.insert(t, TaskId::make(0, WINDOW_SIZE));
 
     EXPECT_EQ(tmap.valid_count(), 2);
     TestLookupResult result;
     run_lookup(tmap, t, result);
     ASSERT_EQ(result.count, 2);
-    std::vector<PTO2TaskId> producers;
+    std::vector<TaskId> producers;
     for (const auto &e : result.entries) {
         producers.push_back(e.entry->producer_task_id);
     }
-    EXPECT_NE(std::find(producers.begin(), producers.end(), PTO2TaskId::make(0, 0)), producers.end());
-    EXPECT_NE(std::find(producers.begin(), producers.end(), PTO2TaskId::make(0, WINDOW_SIZE)), producers.end());
+    EXPECT_NE(std::find(producers.begin(), producers.end(), TaskId::make(0, 0)), producers.end());
+    EXPECT_NE(std::find(producers.begin(), producers.end(), TaskId::make(0, WINDOW_SIZE)), producers.end());
 }
 
 // Without an explicit semantic removal, direct inserts consume one pool entry
@@ -111,7 +111,7 @@ TEST_F(HbgTensorMapTest, PoolOccupancyOnlyGrows) {
     EXPECT_EQ(tmap.free_entries(), POOL_SIZE);
 
     for (int32_t i = 0; i < 8; i++) {
-        tmap.insert(make_test_tensor(0x1000 + 0x100 * i, 64), PTO2TaskId::make(0, i));
+        tmap.insert(make_test_tensor(0x1000 + 0x100 * i, 64), TaskId::make(0, i));
         EXPECT_EQ(tmap.current_used(), i + 1);
         EXPECT_EQ(tmap.free_entries(), POOL_SIZE - (i + 1));
     }
@@ -122,7 +122,7 @@ TEST_F(HbgTensorMapTest, PoolOccupancyOnlyGrows) {
 // waiting for asynchronous reclaim that HBG does not have.
 TEST_F(HbgTensorMapTest, ExhaustedPoolStaysExhausted) {
     for (int32_t i = 0; i < POOL_SIZE; i++) {
-        tmap.insert(make_test_tensor(0x10000 + 0x100 * i, 64), PTO2TaskId::make(0, i % WINDOW_SIZE));
+        tmap.insert(make_test_tensor(0x10000 + 0x100 * i, 64), TaskId::make(0, i % WINDOW_SIZE));
     }
     EXPECT_EQ(tmap.current_used(), POOL_SIZE);
     EXPECT_EQ(tmap.free_entries(), 0);

--- a/tests/ut/cpp/a2a3/test_orchestrator_fanin.cpp
+++ b/tests/ut/cpp/a2a3/test_orchestrator_fanin.cpp
@@ -74,7 +74,7 @@ TEST_F(OrchestratorFaninTest, DuplicateExplicitProducerAddsOneFanin) {
     TaskOutputTensors producer = orch.submit_dummy_task(producer_args);
     ASSERT_TRUE(producer.task_id().is_valid());
 
-    PTO2TaskId deps[] = {producer.task_id(), producer.task_id()};
+    TaskId deps[] = {producer.task_id(), producer.task_id()};
     CoreTaskArgs consumer_args;
     consumer_args.set_dependencies(deps, 2);
     TaskOutputTensors consumer = orch.submit_dummy_task(consumer_args);
@@ -105,7 +105,7 @@ TEST_F(OrchestratorFaninTest, ExplicitWaitDepProducesWaitOnlyEdge) {
     TaskOutputTensors producer = orch.submit_dummy_task(producer_args);
     ASSERT_TRUE(producer.task_id().is_valid());
 
-    PTO2TaskId deps[] = {producer.task_id()};
+    TaskId deps[] = {producer.task_id()};
     DepFlags kinds[] = {DEP_WAIT};
     CoreTaskArgs consumer_args;
     consumer_args.set_dependencies_with_kinds(deps, kinds, 1);
@@ -128,7 +128,7 @@ TEST_F(OrchestratorFaninTest, DuplicateProducerOrAccumulatesFlags) {
     TaskOutputTensors producer = orch.submit_dummy_task(producer_args);
     ASSERT_TRUE(producer.task_id().is_valid());
 
-    PTO2TaskId deps[] = {producer.task_id(), producer.task_id()};
+    TaskId deps[] = {producer.task_id(), producer.task_id()};
     DepFlags kinds[] = {DEP_WAIT, DEP_WAIT | DEP_RETAIN};
     CoreTaskArgs consumer_args;
     consumer_args.set_dependencies_with_kinds(deps, kinds, 2);
@@ -160,7 +160,7 @@ TEST_F(OrchestratorFaninTest, DuplicateProducerInSpillRegionDedups) {
         ASSERT_TRUE(producers.back().task_id().is_valid());
     }
 
-    std::vector<PTO2TaskId> deps;
+    std::vector<TaskId> deps;
     std::vector<DepFlags> kinds;
     deps.reserve(kProducers + 1);
     kinds.reserve(kProducers + 1);
@@ -182,7 +182,7 @@ TEST_F(OrchestratorFaninTest, DuplicateProducerInSpillRegionDedups) {
     PTO2TaskPayload *payload = consumer_slot.payload;
     EXPECT_EQ(payload->fanin_actual_count, kProducers);  // duplicate folded, not 66
 
-    PTO2TaskId dup = producers.back().task_id();
+    TaskId dup = producers.back().task_id();
     auto &dup_slot = sm_handle->header->rings[dup.ring()].get_slot_state_by_task_id(dup.local());
     EXPECT_EQ(dup_slot.fanout_count, PTO2_FANOUT_SCOPE_BIT + 1);  // one pin, not two
 
@@ -210,7 +210,7 @@ TEST_F(OrchestratorFaninTest, AllCompletedFastPathReleasesWaitOnlyPin) {
     producer_slot.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
     int32_t rc_before = producer_slot.fanout_refcount.load();
 
-    PTO2TaskId deps[] = {producer.task_id()};
+    TaskId deps[] = {producer.task_id()};
     DepFlags kinds[] = {DEP_WAIT};  // ordering-only
     CoreTaskArgs consumer_args;
     consumer_args.set_dependencies_with_kinds(deps, kinds, 1);

--- a/tests/ut/cpp/a2a3/test_tensormap.cpp
+++ b/tests/ut/cpp/a2a3/test_tensormap.cpp
@@ -152,7 +152,7 @@ TEST_F(TensorMapTest, HashBoundedByBucketCount) {
 
 TEST_F(TensorMapTest, InsertThenLookupFindsProducer) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    PTO2TaskId tid = PTO2TaskId::make(0, 0);
+    TaskId tid = TaskId::make(0, 0);
     tmap.insert(t, tid);
 
     TestLookupResult result;
@@ -171,8 +171,8 @@ TEST_F(TensorMapTest, LookupEmptyReturnsZero) {
 TEST_F(TensorMapTest, InsertMultipleSameBuffer) {
     ChipTensor t1 = make_test_tensor(0x1000, 256);
     ChipTensor t2 = make_test_tensor(0x1000, 128);
-    PTO2TaskId tid1 = PTO2TaskId::make(0, 0);
-    PTO2TaskId tid2 = PTO2TaskId::make(0, 1);
+    TaskId tid1 = TaskId::make(0, 0);
+    TaskId tid2 = TaskId::make(0, 1);
 
     tmap.insert(t1, tid1);
     tmap.insert(t2, tid2);
@@ -186,18 +186,18 @@ TEST_F(TensorMapTest, InsertMultipleSameBuffer) {
 TEST_F(TensorMapTest, InsertDifferentBuffersNoCollision) {
     ChipTensor t1 = make_test_tensor(0x1000, 256);
     ChipTensor t2 = make_test_tensor(0x2000, 256);
-    tmap.insert(t1, PTO2TaskId::make(0, 0));
-    tmap.insert(t2, PTO2TaskId::make(0, 1));
+    tmap.insert(t1, TaskId::make(0, 0));
+    tmap.insert(t2, TaskId::make(0, 1));
 
     TestLookupResult r1;
     run_lookup(tmap, t1, r1);
     EXPECT_EQ(r1.count, 1);
-    EXPECT_EQ(r1.entries[0].entry->producer_task_id, PTO2TaskId::make(0, 0));
+    EXPECT_EQ(r1.entries[0].entry->producer_task_id, TaskId::make(0, 0));
 
     TestLookupResult r2;
     run_lookup(tmap, t2, r2);
     EXPECT_EQ(r2.count, 1);
-    EXPECT_EQ(r2.entries[0].entry->producer_task_id, PTO2TaskId::make(0, 1));
+    EXPECT_EQ(r2.entries[0].entry->producer_task_id, TaskId::make(0, 1));
 }
 
 // =============================================================================
@@ -209,7 +209,7 @@ TEST_F(TensorMapTest, OverlapFastPathCovered) {
     // Consumer covers producer -> COVERED
     ChipTensor producer = make_test_tensor(0x1000, 256);
     ChipTensor consumer = make_test_tensor(0x1000, 512);
-    tmap.insert(producer, PTO2TaskId::make(0, 0));
+    tmap.insert(producer, TaskId::make(0, 0));
 
     TestLookupResult result;
     run_lookup(tmap, consumer, result);
@@ -222,7 +222,7 @@ TEST_F(TensorMapTest, OverlapFastPathOther) {
     // Consumer does NOT cover producer -> OTHER
     ChipTensor producer = make_test_tensor(0x1000, 512);
     ChipTensor consumer = make_test_tensor(0x1000, 256);
-    tmap.insert(producer, PTO2TaskId::make(0, 0));
+    tmap.insert(producer, TaskId::make(0, 0));
 
     TestLookupResult result;
     run_lookup(tmap, consumer, result);
@@ -232,7 +232,7 @@ TEST_F(TensorMapTest, OverlapFastPathOther) {
 
 TEST_F(TensorMapTest, OverlapFastPathExactMatch) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    tmap.insert(t, PTO2TaskId::make(0, 0));
+    tmap.insert(t, TaskId::make(0, 0));
 
     TestLookupResult result;
     run_lookup(tmap, t, result);
@@ -255,7 +255,7 @@ TEST_F(TensorMapTest, OverlapSlowPathNoOverlap) {
     uint32_t con_offsets[] = {128, 0};
     ChipTensor consumer = base.view(con_shapes, con_offsets);
 
-    tmap.insert(producer, PTO2TaskId::make(0, 0));
+    tmap.insert(producer, TaskId::make(0, 0));
 
     TestLookupResult result;
     run_lookup(tmap, consumer, result);
@@ -273,7 +273,7 @@ TEST_F(TensorMapTest, OverlapSlowPathPartialOverlap) {
     uint32_t con_offsets[] = {64, 0};
     ChipTensor consumer = base.view(con_shapes, con_offsets);
 
-    tmap.insert(producer, PTO2TaskId::make(0, 0));
+    tmap.insert(producer, TaskId::make(0, 0));
 
     TestLookupResult result;
     run_lookup(tmap, consumer, result);
@@ -292,7 +292,7 @@ TEST_F(TensorMapTest, OverlapSlowPathCovered) {
     uint32_t con_offsets[] = {0, 0};
     ChipTensor consumer = base.view(con_shapes, con_offsets);
 
-    tmap.insert(producer, PTO2TaskId::make(0, 0));
+    tmap.insert(producer, TaskId::make(0, 0));
 
     TestLookupResult result;
     run_lookup(tmap, consumer, result);
@@ -309,7 +309,7 @@ TEST_F(TensorMapTest, VersionMismatchReturnsOther) {
     ChipTensor producer = make_test_tensor(0x1000, 256, 1, 0);
     ChipTensor consumer = make_test_tensor(0x1000, 256, 1, 1);
 
-    tmap.insert(producer, PTO2TaskId::make(0, 0));
+    tmap.insert(producer, TaskId::make(0, 0));
 
     TestLookupResult result;
     run_lookup(tmap, consumer, result);
@@ -323,8 +323,8 @@ TEST_F(TensorMapTest, VersionMismatchReturnsOther) {
 
 TEST_F(TensorMapTest, StaleEntriesSkippedDuringLookup) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    tmap.insert(t, PTO2TaskId::make(0, 0));
-    tmap.insert(t, PTO2TaskId::make(0, 1));
+    tmap.insert(t, TaskId::make(0, 0));
+    tmap.insert(t, TaskId::make(0, 1));
 
     // Advance validity to skip task 0
     tmap.sync_validity(0, 1);
@@ -332,14 +332,14 @@ TEST_F(TensorMapTest, StaleEntriesSkippedDuringLookup) {
     TestLookupResult result;
     run_lookup(tmap, t, result);
     ASSERT_EQ(result.count, 1);
-    EXPECT_EQ(result.entries[0].entry->producer_task_id, PTO2TaskId::make(0, 1));
+    EXPECT_EQ(result.entries[0].entry->producer_task_id, TaskId::make(0, 1));
 }
 
 TEST_F(TensorMapTest, StaleEntriesNotTruncatedAcrossRings) {
     ChipTensor t = make_test_tensor(0x1000, 256);
     // Ring 0, task 0 and Ring 1, task 0 -> same bucket
-    tmap.insert(t, PTO2TaskId::make(0, 0));
-    tmap.insert(t, PTO2TaskId::make(1, 0));
+    tmap.insert(t, TaskId::make(0, 0));
+    tmap.insert(t, TaskId::make(1, 0));
 
     // Invalidate ring 0 only
     tmap.sync_validity(0, 1);
@@ -348,7 +348,7 @@ TEST_F(TensorMapTest, StaleEntriesNotTruncatedAcrossRings) {
     run_lookup(tmap, t, result);
     // Ring 1 task 0 still valid, ring 0 task 0 invalidated
     ASSERT_EQ(result.count, 1);
-    EXPECT_EQ(result.entries[0].entry->producer_task_id, PTO2TaskId::make(1, 0));
+    EXPECT_EQ(result.entries[0].entry->producer_task_id, TaskId::make(1, 0));
 }
 
 // =============================================================================
@@ -357,9 +357,9 @@ TEST_F(TensorMapTest, StaleEntriesNotTruncatedAcrossRings) {
 
 TEST_F(TensorMapTest, CleanupRetiredRemovesEntriesForRetiredTasks) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    tmap.insert(t, PTO2TaskId::make(0, 0));
-    tmap.insert(t, PTO2TaskId::make(0, 1));
-    tmap.insert(t, PTO2TaskId::make(0, 2));
+    tmap.insert(t, TaskId::make(0, 0));
+    tmap.insert(t, TaskId::make(0, 1));
+    tmap.insert(t, TaskId::make(0, 2));
     EXPECT_EQ(tmap.valid_count(), 3);
 
     // Cleanup tasks [0, 2) on ring 0
@@ -370,13 +370,13 @@ TEST_F(TensorMapTest, CleanupRetiredRemovesEntriesForRetiredTasks) {
     TestLookupResult result;
     run_lookup(tmap, t, result);
     ASSERT_EQ(result.count, 1);
-    EXPECT_EQ(result.entries[0].entry->producer_task_id, PTO2TaskId::make(0, 2));
+    EXPECT_EQ(result.entries[0].entry->producer_task_id, TaskId::make(0, 2));
 }
 
 TEST_F(TensorMapTest, CleanupRetiredPreservesOtherRings) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    tmap.insert(t, PTO2TaskId::make(0, 0));
-    tmap.insert(t, PTO2TaskId::make(1, 0));
+    tmap.insert(t, TaskId::make(0, 0));
+    tmap.insert(t, TaskId::make(1, 0));
 
     tmap.cleanup_retired(0, 0, 1);
 
@@ -385,12 +385,12 @@ TEST_F(TensorMapTest, CleanupRetiredPreservesOtherRings) {
     TestLookupResult result;
     run_lookup(tmap, t, result);
     ASSERT_EQ(result.count, 1);
-    EXPECT_EQ(result.entries[0].entry->producer_task_id, PTO2TaskId::make(1, 0));
+    EXPECT_EQ(result.entries[0].entry->producer_task_id, TaskId::make(1, 0));
 }
 
 TEST_F(TensorMapTest, CleanupRetiredFreesEntriesToPool) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    tmap.insert(t, PTO2TaskId::make(0, 0));
+    tmap.insert(t, TaskId::make(0, 0));
     EXPECT_EQ(tmap.free_num, 0);
     EXPECT_EQ(tmap.next_entry_idx, 1);
 
@@ -399,7 +399,7 @@ TEST_F(TensorMapTest, CleanupRetiredFreesEntriesToPool) {
     EXPECT_EQ(tmap.free_num, 1) << "Cleaned entry should be in free list";
 
     // New insert should reuse free entry instead of allocating fresh
-    tmap.insert(t, PTO2TaskId::make(0, 1));
+    tmap.insert(t, TaskId::make(0, 1));
     EXPECT_EQ(tmap.free_num, 0);
     EXPECT_EQ(tmap.next_entry_idx, 1) << "Should reuse freed entry, not allocate new";
 }
@@ -411,8 +411,8 @@ TEST_F(TensorMapTest, CleanupRetiredFreesEntriesToPool) {
 TEST_F(TensorMapTest, CleanupRetiredSparesLaterTaskReusingSlot) {
     ChipTensor t = make_test_tensor(0x1000, 256);
     // Task 0 and task 0 + WINDOW_SIZE share slot 0 (local_id & (WINDOW_SIZE-1)).
-    tmap.insert(t, PTO2TaskId::make(0, 0));
-    tmap.insert(t, PTO2TaskId::make(0, WINDOW_SIZE));
+    tmap.insert(t, TaskId::make(0, 0));
+    tmap.insert(t, TaskId::make(0, WINDOW_SIZE));
     ASSERT_EQ(tmap.valid_count(), 2);
 
     // Retire only task 0.
@@ -423,7 +423,7 @@ TEST_F(TensorMapTest, CleanupRetiredSparesLaterTaskReusingSlot) {
     TestLookupResult result;
     run_lookup(tmap, t, result);
     ASSERT_EQ(result.count, 1);
-    EXPECT_EQ(result.entries[0].entry->producer_task_id, PTO2TaskId::make(0, WINDOW_SIZE));
+    EXPECT_EQ(result.entries[0].entry->producer_task_id, TaskId::make(0, WINDOW_SIZE));
 }
 
 // =============================================================================
@@ -432,9 +432,9 @@ TEST_F(TensorMapTest, CleanupRetiredSparesLaterTaskReusingSlot) {
 
 TEST_F(TensorMapTest, MultiRingIndependentLookup) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    tmap.insert(t, PTO2TaskId::make(0, 5));
-    tmap.insert(t, PTO2TaskId::make(1, 3));
-    tmap.insert(t, PTO2TaskId::make(2, 7));
+    tmap.insert(t, TaskId::make(0, 5));
+    tmap.insert(t, TaskId::make(1, 3));
+    tmap.insert(t, TaskId::make(2, 7));
 
     TestLookupResult result;
     run_lookup(tmap, t, result);
@@ -447,7 +447,7 @@ TEST_F(TensorMapTest, MultiRingIndependentLookup) {
     TestLookupResult result2;
     run_lookup(tmap, t, result2);
     EXPECT_EQ(result2.count, 1);
-    EXPECT_EQ(result2.entries[0].entry->producer_task_id, PTO2TaskId::make(1, 3));
+    EXPECT_EQ(result2.entries[0].entry->producer_task_id, TaskId::make(1, 3));
 }
 
 // =============================================================================
@@ -458,7 +458,7 @@ TEST_F(TensorMapTest, LookupReturnsAllMatches) {
     ChipTensor t = make_test_tensor(0x1000, 256);
     // Insert 20 entries for the same buffer (was capped at 16 before #669)
     for (int i = 0; i < 20; i++) {
-        tmap.insert(t, PTO2TaskId::make(0, i));
+        tmap.insert(t, TaskId::make(0, i));
     }
 
     TestLookupResult result;
@@ -474,28 +474,28 @@ TEST_F(TensorMapTest, PoolExhaustionAsserts) {
     // With pool_size=64, inserting 64 entries should work, 65th should fail
     for (int i = 0; i < POOL_SIZE; i++) {
         ChipTensor t = make_test_tensor(0x1000 + i * 0x100, 256);
-        tmap.insert(t, PTO2TaskId::make(0, i));
+        tmap.insert(t, TaskId::make(0, i));
     }
     EXPECT_EQ(tmap.next_entry_idx, POOL_SIZE);
     EXPECT_EQ(tmap.free_num, 0);
 
     // 65th insert should trigger always_assert (pool overflow)
     ChipTensor overflow = make_test_tensor(0x9000, 256);
-    EXPECT_THROW(tmap.insert(overflow, PTO2TaskId::make(0, POOL_SIZE)), std::runtime_error);
+    EXPECT_THROW(tmap.insert(overflow, TaskId::make(0, POOL_SIZE)), std::runtime_error);
 }
 
 TEST_F(TensorMapTest, FreeListRecycling) {
     ChipTensor t = make_test_tensor(0x1000, 256);
     // Insert and cleanup 10 entries
     for (int i = 0; i < 10; i++) {
-        tmap.insert(t, PTO2TaskId::make(0, i));
+        tmap.insert(t, TaskId::make(0, i));
     }
     tmap.cleanup_retired(0, 0, 10);
     EXPECT_EQ(tmap.free_num, 10);
 
     // Re-insert should use free list
     for (int i = 10; i < 20; i++) {
-        tmap.insert(t, PTO2TaskId::make(0, i));
+        tmap.insert(t, TaskId::make(0, i));
     }
     EXPECT_EQ(tmap.free_num, 0);
     EXPECT_EQ(tmap.next_entry_idx, 10) << "No new pool entries consumed when free list available";
@@ -508,7 +508,7 @@ TEST_F(TensorMapTest, FreeListRecycling) {
 TEST_F(TensorMapTest, PerTaskEntryListTracksMultipleOutputs) {
     ChipTensor t1 = make_test_tensor(0x1000, 256);
     ChipTensor t2 = make_test_tensor(0x2000, 128);
-    PTO2TaskId tid = PTO2TaskId::make(0, 5);
+    TaskId tid = TaskId::make(0, 5);
 
     tmap.insert(t1, tid);
     tmap.insert(t2, tid);
@@ -526,9 +526,9 @@ TEST_F(TensorMapTest, PerTaskEntryListTracksMultipleOutputs) {
 
 TEST_F(TensorMapTest, RemoveMiddleEntryPreservesChain) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    PTO2TaskId tid0 = PTO2TaskId::make(0, 0);
-    PTO2TaskId tid1 = PTO2TaskId::make(0, 1);
-    PTO2TaskId tid2 = PTO2TaskId::make(0, 2);
+    TaskId tid0 = TaskId::make(0, 0);
+    TaskId tid1 = TaskId::make(0, 1);
+    TaskId tid2 = TaskId::make(0, 2);
 
     tmap.insert(t, tid0);
     tmap.insert(t, tid1);
@@ -550,37 +550,37 @@ TEST_F(TensorMapTest, RemoveMiddleEntryPreservesChain) {
 }
 
 // =============================================================================
-// PTO2TaskId encoding/decoding
+// TaskId encoding/decoding
 // =============================================================================
 
 TEST(TaskIdTest, MakeAndDecode) {
-    auto tid = PTO2TaskId::make(3, 42);
+    auto tid = TaskId::make(3, 42);
     EXPECT_EQ(tid.ring(), 3);
     EXPECT_EQ(tid.local(), 42u);
 }
 
 TEST(TaskIdTest, InvalidSentinel) {
-    auto inv = PTO2TaskId::invalid();
+    auto inv = TaskId::invalid();
     EXPECT_FALSE(inv.is_valid());
     EXPECT_EQ(inv.raw, UINT64_MAX);
 }
 
 TEST(TaskIdTest, Equality) {
-    auto a = PTO2TaskId::make(1, 100);
-    auto b = PTO2TaskId::make(1, 100);
-    auto c = PTO2TaskId::make(2, 100);
+    auto a = TaskId::make(1, 100);
+    auto b = TaskId::make(1, 100);
+    auto c = TaskId::make(2, 100);
     EXPECT_EQ(a, b);
     EXPECT_NE(a, c);
 }
 
 TEST(TaskIdTest, RingIdMaxValue) {
-    auto tid = PTO2TaskId::make(255, 0);
+    auto tid = TaskId::make(255, 0);
     EXPECT_EQ(tid.ring(), 255);
     EXPECT_EQ(tid.local(), 0u);
 }
 
 TEST(TaskIdTest, LocalIdMaxValue) {
-    auto tid = PTO2TaskId::make(0, UINT32_MAX);
+    auto tid = TaskId::make(0, UINT32_MAX);
     EXPECT_EQ(tid.ring(), 0);
     EXPECT_EQ(tid.local(), UINT32_MAX);
 }

--- a/tests/ut/cpp/a5/test_aicore_completion_mailbox.cpp
+++ b/tests/ut/cpp/a5/test_aicore_completion_mailbox.cpp
@@ -29,7 +29,7 @@
 
 namespace {
 
-PTO2TaskId make_token(uint32_t local) { return PTO2TaskId::make(/*ring=*/0, local); }
+TaskId make_token(uint32_t local) { return TaskId::make(/*ring=*/0, local); }
 
 AICoreCompletionMailbox *fresh_mailbox() {
     void *raw = ::operator new(sizeof(AICoreCompletionMailbox));
@@ -49,7 +49,7 @@ TEST(A5AICoreCompletionMailbox, PushConditionThenDrainCreatesEntry) {
     AICoreCompletionMailbox *mb = fresh_mailbox();
     AsyncWaitList wait_list{};
 
-    PTO2TaskId token = make_token(42);
+    TaskId token = make_token(42);
     constexpr uint64_t kAddr = 0xCAFEBABEDEADBEEFull;
     ASSERT_TRUE(
         mb->try_push_condition(token, kAddr, /*expected=*/7, /*engine=*/COMPLETION_ENGINE_ROCE, COMPLETION_TYPE_COUNTER)
@@ -77,7 +77,7 @@ TEST(A5AICoreCompletionMailbox, PushNormalDoneCreatesEntryReadyToComplete) {
     AICoreCompletionMailbox *mb = fresh_mailbox();
     AsyncWaitList wait_list{};
 
-    PTO2TaskId token = make_token(99);
+    TaskId token = make_token(99);
     PTO2TaskSlotState dummy_slot{};
     uint64_t slot_addr = reinterpret_cast<uint64_t>(&dummy_slot);
     ASSERT_TRUE(mb->try_push_normal_done(token, slot_addr));
@@ -101,7 +101,7 @@ TEST(A5AICoreCompletionMailbox, NormalDoneAttachesToExistingEntry) {
     AICoreCompletionMailbox *mb = fresh_mailbox();
     AsyncWaitList wait_list{};
 
-    PTO2TaskId token = make_token(7);
+    TaskId token = make_token(7);
     wait_list.entries[0].task_token = token;
     wait_list.entries[0].slot_state = nullptr;
     wait_list.entries[0].condition_count = 0;
@@ -128,7 +128,7 @@ TEST(A5AICoreCompletionMailbox, ConditionAttachesToExistingEntry) {
     AICoreCompletionMailbox *mb = fresh_mailbox();
     AsyncWaitList wait_list{};
 
-    PTO2TaskId token = make_token(15);
+    TaskId token = make_token(15);
     wait_list.entries[0].task_token = token;
     wait_list.entries[0].slot_state = nullptr;
     wait_list.entries[0].condition_count = 0;
@@ -183,7 +183,7 @@ TEST(A5AICoreCompletionMailbox, PushReturnsFalseWhenFull) {
     AICoreCompletionMailbox *mb = fresh_mailbox();
 
     constexpr uint32_t kCap = AICORE_COMPLETION_MAILBOX_CAPACITY;
-    PTO2TaskId token = make_token(1);
+    TaskId token = make_token(1);
     for (uint32_t i = 0; i < kCap; i++) {
         ASSERT_TRUE(mb->try_push_condition(
             token, /*addr=*/0x10000 + i, /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER
@@ -208,7 +208,7 @@ TEST(A5AICoreCompletionMailbox, MultiProducerNoLossAndPerProducerOrder) {
     producers.reserve(kProducers);
     for (int p = 0; p < kProducers; p++) {
         producers.emplace_back([mb, p]() {
-            PTO2TaskId token = make_token(static_cast<uint32_t>(p));
+            TaskId token = make_token(static_cast<uint32_t>(p));
             for (int i = 0; i < kPerProducer; i++) {
                 uint64_t addr = (static_cast<uint64_t>(p) << 32) | static_cast<uint64_t>(i);
                 while (!mb->try_push_condition(
@@ -265,7 +265,7 @@ TEST(A5AICoreCompletionMailbox, ProducerInterleavedWithDrain) {
     AsyncWaitList wait_list{};
     // Pre-seed the entry for `token` so the drained CONDITIONs append to a
     // known slot the final assertions can read.
-    PTO2TaskId token = make_token(5);
+    TaskId token = make_token(5);
     wait_list.entries[0].task_token = token;
     wait_list.entries[0].slot_state = nullptr;
     wait_list.entries[0].condition_count = 0;
@@ -337,7 +337,7 @@ TEST(A5AICoreCompletionMailbox, MonotonicSeqSurvivesCapacityWrapWithoutZeroing) 
     // Drive head/tail one full capacity past the wrap point so every physical
     // slot has been published once and now carries a stale seq in [1, CAPACITY].
     // Each push is drained immediately so the ring never reports full.
-    PTO2TaskId token = make_token(7);
+    TaskId token = make_token(7);
     AICoreCompletionMsgView msg;
     for (uint64_t i = 0; i < AICORE_COMPLETION_MAILBOX_CAPACITY + 17; i++) {
         ASSERT_TRUE(
@@ -368,7 +368,7 @@ TEST(A5AICoreCompletionMailbox, TailEqualsHeadDiscardsUndrainedLeftovers) {
 
     // Simulate a prior run that pushed messages but aborted before draining
     // them all (error path): head advances, tail lags.
-    PTO2TaskId token = make_token(11);
+    TaskId token = make_token(11);
     for (int i = 0; i < 5; i++) {
         ASSERT_TRUE(mb->try_push_condition(
             token, /*addr=*/static_cast<uint64_t>(i), /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER

--- a/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
@@ -107,7 +107,7 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     ASSERT_TRUE(root.task_id().is_valid());
 
     // 2. Multi-fanin dummy consumer (duplicate dep deduped to one fanin).
-    PTO2TaskId deps[] = {root.task_id(), root.task_id()};
+    TaskId deps[] = {root.task_id(), root.task_id()};
     CoreTaskArgs consumer_args;
     consumer_args.set_dependencies(deps, 2);
     TaskOutputTensors consumer = orch.submit_dummy_task(consumer_args);

--- a/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
+++ b/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
@@ -86,7 +86,7 @@ TEST_F(OrchestratorFaninTest, DuplicateExplicitProducerAddsOneFanin) {
     TaskOutputTensors producer = orch.submit_dummy_task(producer_args);
     ASSERT_TRUE(producer.task_id().is_valid());
 
-    PTO2TaskId deps[] = {producer.task_id(), producer.task_id()};
+    TaskId deps[] = {producer.task_id(), producer.task_id()};
     CoreTaskArgs consumer_args;
     consumer_args.set_dependencies(deps, 2);
     TaskOutputTensors consumer = orch.submit_dummy_task(consumer_args);
@@ -117,7 +117,7 @@ TEST_F(OrchestratorFaninTest, ExplicitWaitDepProducesWaitOnlyEdge) {
     TaskOutputTensors producer = orch.submit_dummy_task(producer_args);
     ASSERT_TRUE(producer.task_id().is_valid());
 
-    PTO2TaskId deps[] = {producer.task_id()};
+    TaskId deps[] = {producer.task_id()};
     DepFlags kinds[] = {DEP_WAIT};
     CoreTaskArgs consumer_args;
     consumer_args.set_dependencies_with_kinds(deps, kinds, 1);
@@ -140,7 +140,7 @@ TEST_F(OrchestratorFaninTest, DuplicateProducerOrAccumulatesFlags) {
     TaskOutputTensors producer = orch.submit_dummy_task(producer_args);
     ASSERT_TRUE(producer.task_id().is_valid());
 
-    PTO2TaskId deps[] = {producer.task_id(), producer.task_id()};
+    TaskId deps[] = {producer.task_id(), producer.task_id()};
     DepFlags kinds[] = {DEP_WAIT, DEP_WAIT | DEP_RETAIN};
     CoreTaskArgs consumer_args;
     consumer_args.set_dependencies_with_kinds(deps, kinds, 2);
@@ -172,7 +172,7 @@ TEST_F(OrchestratorFaninTest, DuplicateProducerInSpillRegionDedups) {
         ASSERT_TRUE(producers.back().task_id().is_valid());
     }
 
-    std::vector<PTO2TaskId> deps;
+    std::vector<TaskId> deps;
     std::vector<DepFlags> kinds;
     deps.reserve(kProducers + 1);
     kinds.reserve(kProducers + 1);
@@ -194,7 +194,7 @@ TEST_F(OrchestratorFaninTest, DuplicateProducerInSpillRegionDedups) {
     PTO2TaskPayload *payload = consumer_slot.payload;
     EXPECT_EQ(payload->fanin_actual_count, kProducers);  // duplicate folded, not 66
 
-    PTO2TaskId dup = producers.back().task_id();
+    TaskId dup = producers.back().task_id();
     auto &dup_slot = sm_handle->header->rings[dup.ring()].get_slot_state_by_task_id(dup.local());
     EXPECT_EQ(dup_slot.fanout_count, PTO2_FANOUT_SCOPE_BIT + 1);  // one pin, not two
 
@@ -222,7 +222,7 @@ TEST_F(OrchestratorFaninTest, AllCompletedFastPathReleasesWaitOnlyPin) {
     producer_slot.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
     int32_t rc_before = producer_slot.fanout_refcount.load();
 
-    PTO2TaskId deps[] = {producer.task_id()};
+    TaskId deps[] = {producer.task_id()};
     DepFlags kinds[] = {DEP_WAIT};  // ordering-only
     CoreTaskArgs consumer_args;
     consumer_args.set_dependencies_with_kinds(deps, kinds, 1);

--- a/tests/ut/cpp/a5/test_tensormap.cpp
+++ b/tests/ut/cpp/a5/test_tensormap.cpp
@@ -153,7 +153,7 @@ TEST_F(TensorMapTest, HashBoundedByBucketCount) {
 
 TEST_F(TensorMapTest, InsertThenLookupFindsProducer) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    PTO2TaskId tid = PTO2TaskId::make(0, 0);
+    TaskId tid = TaskId::make(0, 0);
     tmap.insert(t, tid);
 
     TestLookupResult result;
@@ -172,8 +172,8 @@ TEST_F(TensorMapTest, LookupEmptyReturnsZero) {
 TEST_F(TensorMapTest, InsertMultipleSameBuffer) {
     ChipTensor t1 = make_test_tensor(0x1000, 256);
     ChipTensor t2 = make_test_tensor(0x1000, 128);
-    PTO2TaskId tid1 = PTO2TaskId::make(0, 0);
-    PTO2TaskId tid2 = PTO2TaskId::make(0, 1);
+    TaskId tid1 = TaskId::make(0, 0);
+    TaskId tid2 = TaskId::make(0, 1);
 
     tmap.insert(t1, tid1);
     tmap.insert(t2, tid2);
@@ -187,18 +187,18 @@ TEST_F(TensorMapTest, InsertMultipleSameBuffer) {
 TEST_F(TensorMapTest, InsertDifferentBuffersNoCollision) {
     ChipTensor t1 = make_test_tensor(0x1000, 256);
     ChipTensor t2 = make_test_tensor(0x2000, 256);
-    tmap.insert(t1, PTO2TaskId::make(0, 0));
-    tmap.insert(t2, PTO2TaskId::make(0, 1));
+    tmap.insert(t1, TaskId::make(0, 0));
+    tmap.insert(t2, TaskId::make(0, 1));
 
     TestLookupResult r1;
     run_lookup(tmap, t1, r1);
     EXPECT_EQ(r1.count, 1);
-    EXPECT_EQ(r1.entries[0].entry->producer_task_id, PTO2TaskId::make(0, 0));
+    EXPECT_EQ(r1.entries[0].entry->producer_task_id, TaskId::make(0, 0));
 
     TestLookupResult r2;
     run_lookup(tmap, t2, r2);
     EXPECT_EQ(r2.count, 1);
-    EXPECT_EQ(r2.entries[0].entry->producer_task_id, PTO2TaskId::make(0, 1));
+    EXPECT_EQ(r2.entries[0].entry->producer_task_id, TaskId::make(0, 1));
 }
 
 // =============================================================================
@@ -210,7 +210,7 @@ TEST_F(TensorMapTest, OverlapFastPathCovered) {
     // Consumer covers producer -> COVERED
     ChipTensor producer = make_test_tensor(0x1000, 256);
     ChipTensor consumer = make_test_tensor(0x1000, 512);
-    tmap.insert(producer, PTO2TaskId::make(0, 0));
+    tmap.insert(producer, TaskId::make(0, 0));
 
     TestLookupResult result;
     run_lookup(tmap, consumer, result);
@@ -223,7 +223,7 @@ TEST_F(TensorMapTest, OverlapFastPathOther) {
     // Consumer does NOT cover producer -> OTHER
     ChipTensor producer = make_test_tensor(0x1000, 512);
     ChipTensor consumer = make_test_tensor(0x1000, 256);
-    tmap.insert(producer, PTO2TaskId::make(0, 0));
+    tmap.insert(producer, TaskId::make(0, 0));
 
     TestLookupResult result;
     run_lookup(tmap, consumer, result);
@@ -233,7 +233,7 @@ TEST_F(TensorMapTest, OverlapFastPathOther) {
 
 TEST_F(TensorMapTest, OverlapFastPathExactMatch) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    tmap.insert(t, PTO2TaskId::make(0, 0));
+    tmap.insert(t, TaskId::make(0, 0));
 
     TestLookupResult result;
     run_lookup(tmap, t, result);
@@ -256,7 +256,7 @@ TEST_F(TensorMapTest, OverlapSlowPathNoOverlap) {
     uint32_t con_offsets[] = {128, 0};
     ChipTensor consumer = base.view(con_shapes, con_offsets);
 
-    tmap.insert(producer, PTO2TaskId::make(0, 0));
+    tmap.insert(producer, TaskId::make(0, 0));
 
     TestLookupResult result;
     run_lookup(tmap, consumer, result);
@@ -274,7 +274,7 @@ TEST_F(TensorMapTest, OverlapSlowPathPartialOverlap) {
     uint32_t con_offsets[] = {64, 0};
     ChipTensor consumer = base.view(con_shapes, con_offsets);
 
-    tmap.insert(producer, PTO2TaskId::make(0, 0));
+    tmap.insert(producer, TaskId::make(0, 0));
 
     TestLookupResult result;
     run_lookup(tmap, consumer, result);
@@ -293,7 +293,7 @@ TEST_F(TensorMapTest, OverlapSlowPathCovered) {
     uint32_t con_offsets[] = {0, 0};
     ChipTensor consumer = base.view(con_shapes, con_offsets);
 
-    tmap.insert(producer, PTO2TaskId::make(0, 0));
+    tmap.insert(producer, TaskId::make(0, 0));
 
     TestLookupResult result;
     run_lookup(tmap, consumer, result);
@@ -310,7 +310,7 @@ TEST_F(TensorMapTest, VersionMismatchReturnsOther) {
     ChipTensor producer = make_test_tensor(0x1000, 256, 1, 0);
     ChipTensor consumer = make_test_tensor(0x1000, 256, 1, 1);
 
-    tmap.insert(producer, PTO2TaskId::make(0, 0));
+    tmap.insert(producer, TaskId::make(0, 0));
 
     TestLookupResult result;
     run_lookup(tmap, consumer, result);
@@ -324,8 +324,8 @@ TEST_F(TensorMapTest, VersionMismatchReturnsOther) {
 
 TEST_F(TensorMapTest, StaleEntriesSkippedDuringLookup) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    tmap.insert(t, PTO2TaskId::make(0, 0));
-    tmap.insert(t, PTO2TaskId::make(0, 1));
+    tmap.insert(t, TaskId::make(0, 0));
+    tmap.insert(t, TaskId::make(0, 1));
 
     // Advance validity to skip task 0
     tmap.sync_validity(0, 1);
@@ -333,14 +333,14 @@ TEST_F(TensorMapTest, StaleEntriesSkippedDuringLookup) {
     TestLookupResult result;
     run_lookup(tmap, t, result);
     ASSERT_EQ(result.count, 1);
-    EXPECT_EQ(result.entries[0].entry->producer_task_id, PTO2TaskId::make(0, 1));
+    EXPECT_EQ(result.entries[0].entry->producer_task_id, TaskId::make(0, 1));
 }
 
 TEST_F(TensorMapTest, StaleEntriesNotTruncatedAcrossRings) {
     ChipTensor t = make_test_tensor(0x1000, 256);
     // Ring 0, task 0 and Ring 1, task 0 -> same bucket
-    tmap.insert(t, PTO2TaskId::make(0, 0));
-    tmap.insert(t, PTO2TaskId::make(1, 0));
+    tmap.insert(t, TaskId::make(0, 0));
+    tmap.insert(t, TaskId::make(1, 0));
 
     // Invalidate ring 0 only
     tmap.sync_validity(0, 1);
@@ -349,7 +349,7 @@ TEST_F(TensorMapTest, StaleEntriesNotTruncatedAcrossRings) {
     run_lookup(tmap, t, result);
     // Ring 1 task 0 still valid, ring 0 task 0 invalidated
     ASSERT_EQ(result.count, 1);
-    EXPECT_EQ(result.entries[0].entry->producer_task_id, PTO2TaskId::make(1, 0));
+    EXPECT_EQ(result.entries[0].entry->producer_task_id, TaskId::make(1, 0));
 }
 
 // =============================================================================
@@ -358,9 +358,9 @@ TEST_F(TensorMapTest, StaleEntriesNotTruncatedAcrossRings) {
 
 TEST_F(TensorMapTest, CleanupRetiredRemovesEntriesForRetiredTasks) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    tmap.insert(t, PTO2TaskId::make(0, 0));
-    tmap.insert(t, PTO2TaskId::make(0, 1));
-    tmap.insert(t, PTO2TaskId::make(0, 2));
+    tmap.insert(t, TaskId::make(0, 0));
+    tmap.insert(t, TaskId::make(0, 1));
+    tmap.insert(t, TaskId::make(0, 2));
     EXPECT_EQ(tmap.valid_count(), 3);
 
     // Cleanup tasks [0, 2) on ring 0
@@ -371,13 +371,13 @@ TEST_F(TensorMapTest, CleanupRetiredRemovesEntriesForRetiredTasks) {
     TestLookupResult result;
     run_lookup(tmap, t, result);
     ASSERT_EQ(result.count, 1);
-    EXPECT_EQ(result.entries[0].entry->producer_task_id, PTO2TaskId::make(0, 2));
+    EXPECT_EQ(result.entries[0].entry->producer_task_id, TaskId::make(0, 2));
 }
 
 TEST_F(TensorMapTest, CleanupRetiredPreservesOtherRings) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    tmap.insert(t, PTO2TaskId::make(0, 0));
-    tmap.insert(t, PTO2TaskId::make(1, 0));
+    tmap.insert(t, TaskId::make(0, 0));
+    tmap.insert(t, TaskId::make(1, 0));
 
     tmap.cleanup_retired(0, 0, 1);
 
@@ -386,12 +386,12 @@ TEST_F(TensorMapTest, CleanupRetiredPreservesOtherRings) {
     TestLookupResult result;
     run_lookup(tmap, t, result);
     ASSERT_EQ(result.count, 1);
-    EXPECT_EQ(result.entries[0].entry->producer_task_id, PTO2TaskId::make(1, 0));
+    EXPECT_EQ(result.entries[0].entry->producer_task_id, TaskId::make(1, 0));
 }
 
 TEST_F(TensorMapTest, CleanupRetiredFreesEntriesToPool) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    tmap.insert(t, PTO2TaskId::make(0, 0));
+    tmap.insert(t, TaskId::make(0, 0));
     EXPECT_EQ(tmap.free_num, 0);
     EXPECT_EQ(tmap.next_entry_idx, 1);
 
@@ -400,7 +400,7 @@ TEST_F(TensorMapTest, CleanupRetiredFreesEntriesToPool) {
     EXPECT_EQ(tmap.free_num, 1) << "Cleaned entry should be in free list";
 
     // New insert should reuse free entry instead of allocating fresh
-    tmap.insert(t, PTO2TaskId::make(0, 1));
+    tmap.insert(t, TaskId::make(0, 1));
     EXPECT_EQ(tmap.free_num, 0);
     EXPECT_EQ(tmap.next_entry_idx, 1) << "Should reuse freed entry, not allocate new";
 }
@@ -412,8 +412,8 @@ TEST_F(TensorMapTest, CleanupRetiredFreesEntriesToPool) {
 TEST_F(TensorMapTest, CleanupRetiredSparesLaterTaskReusingSlot) {
     ChipTensor t = make_test_tensor(0x1000, 256);
     // Task 0 and task 0 + WINDOW_SIZE share slot 0 (local_id & (WINDOW_SIZE-1)).
-    tmap.insert(t, PTO2TaskId::make(0, 0));
-    tmap.insert(t, PTO2TaskId::make(0, WINDOW_SIZE));
+    tmap.insert(t, TaskId::make(0, 0));
+    tmap.insert(t, TaskId::make(0, WINDOW_SIZE));
     ASSERT_EQ(tmap.valid_count(), 2);
 
     // Retire only task 0.
@@ -424,7 +424,7 @@ TEST_F(TensorMapTest, CleanupRetiredSparesLaterTaskReusingSlot) {
     TestLookupResult result;
     run_lookup(tmap, t, result);
     ASSERT_EQ(result.count, 1);
-    EXPECT_EQ(result.entries[0].entry->producer_task_id, PTO2TaskId::make(0, WINDOW_SIZE));
+    EXPECT_EQ(result.entries[0].entry->producer_task_id, TaskId::make(0, WINDOW_SIZE));
 }
 
 // =============================================================================
@@ -433,9 +433,9 @@ TEST_F(TensorMapTest, CleanupRetiredSparesLaterTaskReusingSlot) {
 
 TEST_F(TensorMapTest, MultiRingIndependentLookup) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    tmap.insert(t, PTO2TaskId::make(0, 5));
-    tmap.insert(t, PTO2TaskId::make(1, 3));
-    tmap.insert(t, PTO2TaskId::make(2, 7));
+    tmap.insert(t, TaskId::make(0, 5));
+    tmap.insert(t, TaskId::make(1, 3));
+    tmap.insert(t, TaskId::make(2, 7));
 
     TestLookupResult result;
     run_lookup(tmap, t, result);
@@ -448,7 +448,7 @@ TEST_F(TensorMapTest, MultiRingIndependentLookup) {
     TestLookupResult result2;
     run_lookup(tmap, t, result2);
     EXPECT_EQ(result2.count, 1);
-    EXPECT_EQ(result2.entries[0].entry->producer_task_id, PTO2TaskId::make(1, 3));
+    EXPECT_EQ(result2.entries[0].entry->producer_task_id, TaskId::make(1, 3));
 }
 
 // =============================================================================
@@ -459,7 +459,7 @@ TEST_F(TensorMapTest, LookupReturnsAllMatches) {
     ChipTensor t = make_test_tensor(0x1000, 256);
     // Insert 20 entries for the same buffer (was capped at 16 before #669)
     for (int i = 0; i < 20; i++) {
-        tmap.insert(t, PTO2TaskId::make(0, i));
+        tmap.insert(t, TaskId::make(0, i));
     }
 
     TestLookupResult result;
@@ -475,28 +475,28 @@ TEST_F(TensorMapTest, PoolExhaustionAsserts) {
     // With pool_size=64, inserting 64 entries should work, 65th should fail
     for (int i = 0; i < POOL_SIZE; i++) {
         ChipTensor t = make_test_tensor(0x1000 + i * 0x100, 256);
-        tmap.insert(t, PTO2TaskId::make(0, i));
+        tmap.insert(t, TaskId::make(0, i));
     }
     EXPECT_EQ(tmap.next_entry_idx, POOL_SIZE);
     EXPECT_EQ(tmap.free_num, 0);
 
     // 65th insert should trigger always_assert (pool overflow)
     ChipTensor overflow = make_test_tensor(0x9000, 256);
-    EXPECT_THROW(tmap.insert(overflow, PTO2TaskId::make(0, POOL_SIZE)), std::runtime_error);
+    EXPECT_THROW(tmap.insert(overflow, TaskId::make(0, POOL_SIZE)), std::runtime_error);
 }
 
 TEST_F(TensorMapTest, FreeListRecycling) {
     ChipTensor t = make_test_tensor(0x1000, 256);
     // Insert and cleanup 10 entries
     for (int i = 0; i < 10; i++) {
-        tmap.insert(t, PTO2TaskId::make(0, i));
+        tmap.insert(t, TaskId::make(0, i));
     }
     tmap.cleanup_retired(0, 0, 10);
     EXPECT_EQ(tmap.free_num, 10);
 
     // Re-insert should use free list
     for (int i = 10; i < 20; i++) {
-        tmap.insert(t, PTO2TaskId::make(0, i));
+        tmap.insert(t, TaskId::make(0, i));
     }
     EXPECT_EQ(tmap.free_num, 0);
     EXPECT_EQ(tmap.next_entry_idx, 10) << "No new pool entries consumed when free list available";
@@ -509,7 +509,7 @@ TEST_F(TensorMapTest, FreeListRecycling) {
 TEST_F(TensorMapTest, PerTaskEntryListTracksMultipleOutputs) {
     ChipTensor t1 = make_test_tensor(0x1000, 256);
     ChipTensor t2 = make_test_tensor(0x2000, 128);
-    PTO2TaskId tid = PTO2TaskId::make(0, 5);
+    TaskId tid = TaskId::make(0, 5);
 
     tmap.insert(t1, tid);
     tmap.insert(t2, tid);
@@ -527,9 +527,9 @@ TEST_F(TensorMapTest, PerTaskEntryListTracksMultipleOutputs) {
 
 TEST_F(TensorMapTest, RemoveMiddleEntryPreservesChain) {
     ChipTensor t = make_test_tensor(0x1000, 256);
-    PTO2TaskId tid0 = PTO2TaskId::make(0, 0);
-    PTO2TaskId tid1 = PTO2TaskId::make(0, 1);
-    PTO2TaskId tid2 = PTO2TaskId::make(0, 2);
+    TaskId tid0 = TaskId::make(0, 0);
+    TaskId tid1 = TaskId::make(0, 1);
+    TaskId tid2 = TaskId::make(0, 2);
 
     tmap.insert(t, tid0);
     tmap.insert(t, tid1);
@@ -551,37 +551,37 @@ TEST_F(TensorMapTest, RemoveMiddleEntryPreservesChain) {
 }
 
 // =============================================================================
-// PTO2TaskId encoding/decoding
+// TaskId encoding/decoding
 // =============================================================================
 
 TEST(TaskIdTest, MakeAndDecode) {
-    auto tid = PTO2TaskId::make(3, 42);
+    auto tid = TaskId::make(3, 42);
     EXPECT_EQ(tid.ring(), 3);
     EXPECT_EQ(tid.local(), 42u);
 }
 
 TEST(TaskIdTest, InvalidSentinel) {
-    auto inv = PTO2TaskId::invalid();
+    auto inv = TaskId::invalid();
     EXPECT_FALSE(inv.is_valid());
     EXPECT_EQ(inv.raw, UINT64_MAX);
 }
 
 TEST(TaskIdTest, Equality) {
-    auto a = PTO2TaskId::make(1, 100);
-    auto b = PTO2TaskId::make(1, 100);
-    auto c = PTO2TaskId::make(2, 100);
+    auto a = TaskId::make(1, 100);
+    auto b = TaskId::make(1, 100);
+    auto c = TaskId::make(2, 100);
     EXPECT_EQ(a, b);
     EXPECT_NE(a, c);
 }
 
 TEST(TaskIdTest, RingIdMaxValue) {
-    auto tid = PTO2TaskId::make(255, 0);
+    auto tid = TaskId::make(255, 0);
     EXPECT_EQ(tid.ring(), 255);
     EXPECT_EQ(tid.local(), 0u);
 }
 
 TEST(TaskIdTest, LocalIdMaxValue) {
-    auto tid = PTO2TaskId::make(0, UINT32_MAX);
+    auto tid = TaskId::make(0, UINT32_MAX);
     EXPECT_EQ(tid.ring(), 0);
     EXPECT_EQ(tid.local(), UINT32_MAX);
 }

--- a/tests/ut/cpp/a5/test_wiring.cpp
+++ b/tests/ut/cpp/a5/test_wiring.cpp
@@ -124,7 +124,7 @@ TEST(ReclaimHeadMatchTest, ComparesExactRingAndLocalTaskId) {
     PTO2TaskDescriptor descriptor{};
     PTO2TaskSlotState slot{};
     slot.task = &descriptor;
-    descriptor.task_id = PTO2TaskId::make(0, 16);
+    descriptor.task_id = TaskId::make(0, 16);
 
     EXPECT_FALSE(reclaim_head_matches_open_task(0, 0, &slot));
     EXPECT_TRUE(reclaim_head_matches_open_task(16, 0, &slot));

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -453,7 +453,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     ASSERT_NE(execution, nullptr);
 
     PTO2TaskDescriptor outer_task{};
-    outer_task.task_id = PTO2TaskId::make(1, 7);
+    outer_task.task_id = TaskId::make(1, 7);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
     PTO2TaskSlotState outer_slot{};
@@ -477,7 +477,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
 
     graph_execution_mark_completed(*execution);
     execution->retired_nodes.store(2, std::memory_order_release);
-    outer_task.task_id = PTO2TaskId::make(1, 8);
+    outer_task.task_id = TaskId::make(1, 8);
 
     // Poison every field the rebuild is responsible for restoring. A replay that
     // preserved any of them would leave the poison observable.
@@ -501,7 +501,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     EXPECT_EQ(node.payload.scalar_data()[0], 99U);
     EXPECT_EQ(execution->node_at(1).payload.scalar_data()[0], 18U);
     EXPECT_EQ(node.payload.tensor_data()[0].version, 0);
-    EXPECT_EQ(node.task.task_id, PTO2TaskId::make(1, (8U << 10U)));
+    EXPECT_EQ(node.task.task_id, TaskId::make(1, (8U << 10U)));
     EXPECT_EQ(node.task.packed_buffer_base, heap.base());
     EXPECT_EQ(node.payload.tensor_data()[0].buffer.addr, reinterpret_cast<uint64_t>(second_boundary.data()));
     EXPECT_EQ(execution->node_at(1).payload.tensor_data()[0].buffer.addr, reinterpret_cast<uint64_t>(heap.base() + 16));
@@ -529,7 +529,7 @@ TEST(GraphExecutionReplay, MaterializesBoundaryScalarPoolWiderThanTaskPayload) {
     ASSERT_NE(execution, nullptr);
 
     PTO2TaskDescriptor outer_task{};
-    outer_task.task_id = PTO2TaskId::make(1, 7);
+    outer_task.task_id = TaskId::make(1, 7);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
     PTO2TaskSlotState outer_slot{};
@@ -709,7 +709,7 @@ TEST(GraphExecutionProgress, InternalNodeResolutionIsNotAHostCompletion) {
 
     AsyncWaitList wait_list{};
     wait_list.entries[0].slot_state = &node.slot;
-    wait_list.entries[0].task_token = PTO2TaskId::make(0, 1);
+    wait_list.entries[0].task_token = TaskId::make(0, 1);
     wait_list.entries[0].normal_done = true;
     wait_list.count = 1;
 
@@ -736,7 +736,7 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
     ASSERT_NE(execution, nullptr);
 
     PTO2TaskDescriptor outer_task{};
-    outer_task.task_id = PTO2TaskId::make(1, 5);
+    outer_task.task_id = TaskId::make(1, 5);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
     PTO2TaskSlotState outer_slot{};

--- a/tests/ut/cpp/common/test_hbg_mailbox_init.cpp
+++ b/tests/ut/cpp/common/test_hbg_mailbox_init.cpp
@@ -27,7 +27,7 @@
 
 namespace {
 
-PTO2TaskId make_token(uint32_t local) { return PTO2TaskId::make(/*ring=*/0, local); }
+TaskId make_token(uint32_t local) { return TaskId::make(/*ring=*/0, local); }
 
 // A mailbox on memory holding a prior generation's bytes, which is what the
 // pooled arena hands the AICPU: the region is never uploaded, so nothing zeroes
@@ -86,7 +86,7 @@ TEST(HbgMailboxInit, DirtyMemoryYieldsAUsableRing) {
     AICoreCompletionMailbox *mb = dirty_mailbox(0xAA);
     mb->init_empty();
 
-    const PTO2TaskId token = make_token(11);
+    const TaskId token = make_token(11);
     ASSERT_TRUE(
         mb->try_push_condition(token, /*addr=*/0x4000, /*expected_value=*/7, /*engine=*/1, /*completion_type=*/0)
     );

--- a/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
+++ b/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
@@ -85,7 +85,7 @@ public:
         // orchestrator's bump cursors hand them out, and gets content that identifies
         // the slot so the compaction can be checked element by element.
         for (uint64_t i = 0; i < SUBMITTED; ++i) {
-            descriptors()[i].task_id = PTO2TaskId::make(0, static_cast<uint32_t>(i));
+            descriptors()[i].task_id = TaskId::make(0, static_cast<uint32_t>(i));
             payloads()[i].tensor_count = TENSORS_PER_TASK;
             payloads()[i].scalar_count = SCALARS_PER_TASK;
             payloads()[i].fanin_count = FANIN_PER_TASK;
@@ -108,7 +108,7 @@ public:
             completion_flags()[i].store(static_cast<uint8_t>(i & 1), std::memory_order_relaxed);
         }
         // A slot past the submitted prefix, to prove it does not travel.
-        descriptors()[SUBMITTED].task_id = PTO2TaskId::make(0, 0xBEEF);
+        descriptors()[SUBMITTED].task_id = TaskId::make(0, 0xBEEF);
     }
 
     const char *base() const { return image_.base(); }

--- a/tests/ut/cpp/common/test_scope_deadlock_detection.cpp
+++ b/tests/ut/cpp/common/test_scope_deadlock_detection.cpp
@@ -25,7 +25,7 @@ constexpr int32_t POOL_CAPACITY = 8;
 void make_head_match_old_structural_predicate(
     PTO2TaskSlotState &head, PTO2TaskDescriptor &descriptor, uint8_t ring_id, uint32_t local_task_id
 ) {
-    descriptor.task_id = PTO2TaskId::make(ring_id, local_task_id);
+    descriptor.task_id = TaskId::make(ring_id, local_task_id);
     head.task = &descriptor;
     head.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
     head.fanout_count = PTO2_FANOUT_SCOPE_BIT;


### PR DESCRIPTION
## Summary

`PTO2TaskId` → `TaskId`. **2462 occurrences across 119 files**, one identifier in one commit so no reader has to know both spellings (`.claude/rules/codestyle.md` rule 10).

The name was free, and the tree already wanted it: the only other occurrence of `TaskId` was this type's own docstring in `src/common/task_interface/task_id.h`, which called it `TaskId` while the type was spelled `PTO2TaskId`. The external pto-isa headers do not use the name either.

That docstring also loses *"used across Runtime2"* — the `2` never denoted a version any reader can identify, and the encoding is shared by both runtimes, which is what the line now says.

The shorter name re-flowed some aligned parameter lists and trailing comments; that is the rest of the diff.

## Why one identifier per PR

`PTO2TaskId` alone touches 119 files, so there is no batching of the remaining large identifiers that stays under a reviewable size — measured per identifier:

| identifier | occurrences | files |
| --- | --- | --- |
| `PTO2TaskId` | 2462 | **119** ← this PR |
| `PTO2OrchestrationConfig` | 308 | 156 |
| `PTO2TaskSlotState` | 855 | 108 |
| `PTO2_SCOPE` | 189 | 84 |
| `PTO2_MAX_RING_DEPTH` | 638 | 77 |
| `PTO2Runtime` | 603 | 69 |

The alternative is one sweep over 464 files, which rule 10 rejects outright and which the bot reviewer skips (it skipped #1963 at 475 files). Splitting by identifier at least keeps each diff mechanical and single-purpose.

**Remaining after this: 8653 occurrences over 150 identifiers.** Six of them — `PTO2Runtime`, `PTO2TaskSlotState`, `PTO2ReadyQueue`, `PTO2TensorMap` and two smaller — collide with an existing type once stripped, so they need a considered name or a namespace rather than a prefix strip. That is the disambiguation the `PTO2` prefix was actually providing, and rule 9 asks for "clear names or a `namespace`" in its place.

## Cross-repo

`TaskId` is used directly by orchestration sources outside this repo, so this lands **without a compatibility alias** by the same explicit decision as #1963. Those repos need the matching rename and merge order matters.

## Testing

- [x] all four runtimes build
- [x] `a2a3sim` scene sweep — 59 cases, 0 failures
- [x] `a5sim` scene sweep — 52 cases, 0 failures
- [x] `a2a3` onboard sweep (`-m "not sdma" --exclude-level 4`) — 149 passed, 1 skipped
- [x] cpput — 117/117
- [x] pyut — 1886 passed, 7 skipped
- [x] `clang-format`, `ruff`, `markdownlint-cli2` clean
