### PR TITLE
Refactor: reduce the hbg scope to its depth

### DIFF
--- a/docs/manual-scope.md
+++ b/docs/manual-scope.md
@@ -91,16 +91,17 @@ Manual scope v0 is:
 
 ### Scope State
 
-The runtime keeps two manual-scope-specific pieces of state:
+`manual_begin_depth` is the only manual-scope-specific state, and it decides whether
+the current submit is in manual mode. It is explicitly initialized in
+`PTO2OrchestratorState::init()` and reset in `mark_done()` so a reused orchestrator
+starts cleanly on the next run.
 
-- `manual_begin_depth`
-- the current scope task list (`scope_tasks[...]`)
-
-`manual_begin_depth` decides whether the current submit is in manual mode.
-`scope_tasks[...]` remains scope-lifetime bookkeeping for `scope_end()`.
-`manual_begin_depth` is explicitly initialized in `PTO2OrchestratorState::init()` and
-reset in `mark_done()` so a reused orchestrator starts cleanly on
-the next run.
+Whether a scope keeps a task list at all is runtime-specific, and manual mode does
+not change it either way. `tensormap_and_ringbuffer` keeps `scope_tasks[...]` so
+`scope_end()` can release each enclosed task's producer-side reference and let its
+slot be reclaimed. `host_build_graph` keeps no such list and has no scope-end hook:
+its ring is whole-graph-resident, so nothing is reclaimed before the run ends and a
+scope there is depth alone.
 
 The depth model treats `manual_begin_depth` as the depth where the outermost
 active manual scope began:

--- a/docs/troubleshooting/device-error-codes/untested.md
+++ b/docs/troubleshooting/device-error-codes/untested.md
@@ -10,11 +10,13 @@ they cannot be provoked. Recording why, so the next person does not re-derive it
   at `MAX_COMPLETIONS_PER_TASK` (64) and latches **102** on the 65th condition, so
   the scheduler-side "more than 64" check that would raise 103 never sees enough
   messages. 103 is reachable only by corrupting the slab (UB) or a malformed message.
-- **10 SCOPE_TASKS_OVERFLOW** cannot be reached either. `scope_tasks_cap` is the sum
-  of the per-ring windows, but each ring physically holds only `window - 1` tasks, so
-  all rings together top out at `cap - PTO2_MAX_RING_DEPTH` — strictly below the cap.
+- **10 SCOPE_TASKS_OVERFLOW** has no raise site at all in `host_build_graph`: an hbg
+  scope keeps no task list, so nothing can saturate one. In
+  `tensormap_and_ringbuffer` it exists but cannot be reached — `scope_tasks_cap` is the
+  sum of the per-ring windows, but each ring physically holds only `window - 1` tasks,
+  so all rings together top out at `cap - PTO2_MAX_RING_DEPTH`, strictly below the cap.
   The rings always fill first and latch 1 or 3. Shrinking the window shrinks both, so
-  the gap holds.
+  the gap holds. The number stays reserved in both runtimes' code tables.
 - **11 TENSORMAP_OVERFLOW** needs the 65536-entry pool (`PTO2_TENSORMAP_POOL_SIZE`,
   compile-time, not tunable via `runtime_env`) flooded *and* a stalled producer
   holding entries.

--- a/src/a2a3/runtime/host_build_graph/common/runtime_status.h
+++ b/src/a2a3/runtime/host_build_graph/common/runtime_status.h
@@ -36,7 +36,7 @@
 #define SIMPLER_ERROR_REQUIRE_SYNC_START_INVALID 7
 #define SIMPLER_ERROR_TENSOR_WAIT_TIMEOUT 8
 #define SIMPLER_ERROR_EXPLICIT_ORCH_FATAL 9
-#define SIMPLER_ERROR_SCOPE_TASKS_OVERFLOW 10  // scope_tasks buffer saturated (all rings full)
+#define SIMPLER_ERROR_SCOPE_TASKS_OVERFLOW 10  // Not raised here; the number stays reserved across runtimes
 #define SIMPLER_ERROR_TENSORMAP_OVERFLOW 11    // graph registers more outputs than the tensormap entry pool holds
 
 // Scheduler errors (100+): detected in scheduler threads

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -124,9 +124,9 @@ scalar `rt_orchestration_done` publishes into the runtime header.
 
 **Why the scheduler state is device-written.** `PTO2SchedulerState` holds no
 per-run content: `sm_header` and the ring pointer derive from a pooled SM base,
-queue capacities are compile-time constants, and hbg never advances
-`last_task_alive`. Its one host-side entry point, `on_scope_end`, is an empty stub
-here. So the host would only be writing an initialization pattern — 203,392 bytes
+queue capacities are compile-time constants, hbg never advances
+`last_task_alive`, and it has no host-side entry point at all. So the host would
+only be writing an initialization pattern — 203,392 bytes
 of it, dominated by `AsyncWaitList::entries` — for the device to receive and never
 read. `PTO2Runtime` therefore holds a *pointer* to it, wired from
 `off_scheduler` on each side, and the AICPU calls `init_data_from_layout` at boot.

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -594,7 +594,7 @@ int32_t run_host_orchestration(
         const PTO2OrchProfilingData prof = orchestrator_get_profiling();
         const std::pair<const char *, uint64_t> steps[] = {
             {"alloc", prof.alloc_cycle},   {"args", prof.args_cycle},   {"lookup", prof.lookup_cycle},
-            {"insert", prof.insert_cycle}, {"fanin", prof.fanin_cycle}, {"scope_end", prof.scope_end_cycle},
+            {"insert", prof.insert_cycle}, {"fanin", prof.fanin_cycle},
         };
         for (const auto &step : steps) {
             if (step.second == 0) continue;

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator.h
@@ -16,7 +16,7 @@
  * 2. Allocating intermediate buffers from the heap
  * 3. Submitting tasks via async InCore function calls
  * 4. Building the dependency graph using TensorMap
- * 5. Managing buffer scopes for lifecycle control
+ * 5. Tracking scope nesting, which selects TensorMap or explicit dependencies
  *
  * The Orchestrator can run on either:
  * - Host CPU (lower latency for complex control, easier debugging)
@@ -70,15 +70,11 @@ struct PTO2OrchestratorState {
     PTO2TensorMap tensor_map;  // Producer lookup
 
     // === SCOPE STACK (Private) ===
-    // Single contiguous buffer of task IDs, partitioned by scope level.
-    // scope_begins[i] is the index into scope_tasks where scope i starts.
-    // Tasks for the top scope occupy [scope_begins[top], scope_tasks_size).
-    std::unique_ptr<PTO2TaskSlotState *[]> scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
-    int32_t scope_tasks_size{0};                         // Number of task IDs currently in the buffer
-    int32_t scope_tasks_capacity{0};                     // Allocated capacity of scope_tasks
-    std::unique_ptr<int32_t[]> scope_begins;             // scope_begins[i] = start index of scope i in scope_tasks
-    int32_t scope_stack_top{-1};                         // Current top of stack (-1 = no scope open)
-    uint64_t scope_stack_capacity{0};                    // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
+    // Depth only. A scope decides whether a submit takes its fanin from TensorMap
+    // discovery or from CoreTaskArgs::set_dependencies, and submit_task requires
+    // one to be open; it bounds no task or buffer lifetime, so there is no
+    // per-scope task list to walk at scope end.
+    int32_t scope_stack_top{-1};  // Current top of stack (-1 = no scope open)
     int32_t manual_begin_depth{PTO2_MAX_SCOPE_DEPTH};
 
     // === SCHEDULER REFERENCE ===
@@ -180,13 +176,11 @@ struct PTO2OrchProfilingData {
     uint64_t lookup_cycle;
     uint64_t insert_cycle;
     uint64_t fanin_cycle;
-    uint64_t scope_end_cycle;
     int64_t submit_count;
     // Wait time tracking for blocking phases
     uint64_t fanin_wait_cycle;  // Legacy (wiring): fanout_lock wait; polling has no such lock
     // Atomic operation counts per phase
     uint64_t args_atomic_count;
-    uint64_t scope_end_atomic_count;
 };
 
 PTO2OrchProfilingData orchestrator_get_profiling();

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -143,17 +143,15 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() {
 // The strong symbol from the AICPU build wins when profiling is available.
 // Also hidden to prevent HOST .so from polluting the global symbol table.
 // Accumulated cycles per sub-step (only needed for ORCH_PROFILING export)
-static uint64_t g_orch_alloc_cycle = 0;      // unified task+heap alloc
-static uint64_t g_orch_args_cycle = 0;       // param copy
-static uint64_t g_orch_lookup_cycle = 0;     // tensormap lookup + dep building
-static uint64_t g_orch_insert_cycle = 0;     // tensormap insert
-static uint64_t g_orch_fanin_cycle = 0;      // fanin list + early-return check
-static uint64_t g_orch_scope_end_cycle = 0;  // scope_end overhead
+static uint64_t g_orch_alloc_cycle = 0;   // unified task+heap alloc
+static uint64_t g_orch_args_cycle = 0;    // param copy
+static uint64_t g_orch_lookup_cycle = 0;  // tensormap lookup + dep building
+static uint64_t g_orch_insert_cycle = 0;  // tensormap insert
+static uint64_t g_orch_fanin_cycle = 0;   // fanin list + early-return check
 static int64_t g_orch_submit_count = 0;
 static uint32_t g_orch_submit_idx = 0;
 uint64_t g_orch_fanin_wait_cycle = 0;
 uint64_t g_orch_args_atomic_count = 0;
-uint64_t g_orch_scope_end_atomic_count = 0;
 // Cycle accumulation is unconditional under SIMPLER_ORCH_PROFILING (that's what
 // the flag is for) and feeds the per-sub-step `g_orch_*_cycle` cumulatives
 // printed in the cold-path log. Per-event records are a separate channel on a
@@ -1024,8 +1022,6 @@ static bool append_fanin_or_fail(
     return true;
 }
 
-static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state);
-
 struct PTO2PreparedTask {
     TaskId task_id = TaskId::invalid();
     PTO2TaskAllocResult alloc_result = {-1, 0, nullptr, nullptr};
@@ -1141,7 +1137,6 @@ static bool prepare_task(
     // above (whole-graph-resident hbg never reuses a slot).
     out->slot_state->last_consumer_local_id = static_cast<int32_t>(out->task_id.local());
     // payload.fanin_count is set in submit_task_common's STEP 6.
-    scope_tasks_push(orch, out->slot_state);
 
     return true;
 }
@@ -1149,20 +1144,6 @@ static bool prepare_task(
 // =============================================================================
 // Scope Management
 // =============================================================================
-
-static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state) {
-    if (orch->scope_tasks_size >= orch->scope_tasks_capacity) {
-        // Capacity is the total in-flight slot budget (the runtime task window;
-        // see PTO2OrchestratorState::init) — hitting it means the ring is
-        // saturated, so no further push could succeed regardless of buffer growth.
-        orch->report_fatal(
-            SIMPLER_ERROR_SCOPE_TASKS_OVERFLOW, __FUNCTION__,
-            "scope_tasks buffer saturated at %d entries (all rings full)", orch->scope_tasks_capacity
-        );
-        return;
-    }
-    orch->scope_tasks[orch->scope_tasks_size++] = task_slot_state;
-}
 
 void PTO2OrchestratorState::begin_scope(PTO2ScopeMode mode) {
     auto *orch = this;
@@ -1194,7 +1175,7 @@ void PTO2OrchestratorState::begin_scope(PTO2ScopeMode mode) {
         }
         return;
     }
-    assert(orch->scope_stack_top < static_cast<int32_t>(orch->scope_stack_capacity - 1) && "Scope stack overflow");
+    assert(orch->scope_stack_top < PTO2_MAX_SCOPE_DEPTH - 1 && "Scope stack overflow");
     if (mode == PTO2ScopeMode::AUTO && orch->in_manual_scope()) {
         report_fatal(
             SIMPLER_ERROR_INVALID_ARGS, __FUNCTION__, "auto scope nested inside manual scope is not supported"
@@ -1204,7 +1185,6 @@ void PTO2OrchestratorState::begin_scope(PTO2ScopeMode mode) {
 
     bool already_in_manual_scope = orch->in_manual_scope();
     ++orch->scope_stack_top;
-    orch->scope_begins[orch->scope_stack_top] = orch->scope_tasks_size;
     if (mode == PTO2ScopeMode::MANUAL && !already_in_manual_scope) {
         orch->manual_begin_depth = orch->scope_stack_top;
     }
@@ -1245,9 +1225,6 @@ void PTO2OrchestratorState::end_scope() {
     }
     assert(orch->scope_stack_top >= 0 && "Scope stack underflow");
 
-    // Snapshot the ring start/end BEFORE the orchestrator drains pending tasks
-    // via scheduler->on_scope_end, so the end record reflects the scope's
-    // occupancy at close, not the residual after teardown.
 #if SIMPLER_DFX
     // Gate via is_scope_stats_enabled() (see begin_scope). One collector call
     // emits the end-boundary record and tears down bookkeeping.
@@ -1265,28 +1242,10 @@ void PTO2OrchestratorState::end_scope() {
     }
 #endif
 
-#if SIMPLER_ORCH_PROFILING
-    uint64_t _se0 = get_sys_cnt_aicpu();
-#endif
-
-    bool ending_manual_scope = orch->scope_stack_top == orch->manual_begin_depth;
-    int32_t begin = orch->scope_begins[orch->scope_stack_top--];
-    int32_t count = orch->scope_tasks_size - begin;
-    if (ending_manual_scope) {
+    if (orch->scope_stack_top == orch->manual_begin_depth) {
         orch->manual_begin_depth = PTO2_MAX_SCOPE_DEPTH;
     }
-
-    if (orch->scheduler && count > 0) {
-        orch->scheduler->on_scope_end(&orch->scope_tasks[begin], count);
-    }
-
-    // Rewind the task buffer — these entries are no longer needed
-    orch->scope_tasks_size = begin;
-
-#if SIMPLER_ORCH_PROFILING
-    uint64_t _se1 = get_sys_cnt_aicpu();
-    g_orch_scope_end_cycle += (_se1 - _se0);
-#endif
+    --orch->scope_stack_top;
 }
 
 // =============================================================================
@@ -1708,7 +1667,6 @@ bool graph_submit_outer(
     slot.total_required_subtasks = 0;
     slot.logical_block_num = 1;
     slot.task_kind = TaskKind::GRAPH;
-    scope_tasks_push(orch, &slot);
 
     task.task_id = task_id;
     std::fill(std::begin(task.kernel_id), std::end(task.kernel_id), INVALID_KERNEL_ID);
@@ -2570,8 +2528,8 @@ TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const CoreTaskArgs &args)
         // subtasks to retire. Running the full on_task_complete path
         // would only pay unnecessary fanout_lock / traversal overhead here.
         // The generic slot initialization done in prepare_task() is still
-        // required so scope_end can release the producer-side reference and
-        // drive the slot to CONSUMED, but worker dispatch fields are never
+        // required — a consumer reads this slot's task_attrs and completion
+        // mirror, both set below — but worker dispatch fields are never
         // observed for hidden alloc tasks.
         //
         // Flag the creator so it does NOT suppress its consumers' early-dispatch.
@@ -2620,7 +2578,6 @@ void PTO2OrchestratorState::mark_done() {
         LOG_DEBUG("=== [Orchestrator] total_tasks=%d ===", total_tasks);
     }
     orch->sm_header->orchestrator_done.store(1, std::memory_order_release);
-    orch->scope_tasks_size = 0;
     orch->scope_stack_top = -1;
     orch->manual_begin_depth = PTO2_MAX_SCOPE_DEPTH;
 #if !SIMPLER_ORCH_PROFILING && SIMPLER_DFX
@@ -2636,21 +2593,18 @@ PTO2OrchProfilingData orchestrator_get_profiling() {
     d.lookup_cycle = g_orch_lookup_cycle;
     d.insert_cycle = g_orch_insert_cycle;
     d.fanin_cycle = g_orch_fanin_cycle;
-    d.scope_end_cycle = g_orch_scope_end_cycle;
     d.submit_count = g_orch_submit_count;
     d.fanin_wait_cycle = g_orch_fanin_wait_cycle;
     d.args_atomic_count = g_orch_args_atomic_count;
-    d.scope_end_atomic_count = g_orch_scope_end_atomic_count;
 
     // Reset
     g_orch_alloc_cycle = g_orch_args_cycle = 0;
     g_orch_lookup_cycle = g_orch_insert_cycle = 0;
-    g_orch_fanin_cycle = g_orch_scope_end_cycle = 0;
+    g_orch_fanin_cycle = 0;
     g_orch_submit_count = 0;
     g_orch_submit_idx = 0;
     g_orch_fanin_wait_cycle = 0;
     g_orch_args_atomic_count = 0;
-    g_orch_scope_end_atomic_count = 0;
     return d;
 }
 #endif

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime_core.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime_core.h
@@ -17,7 +17,7 @@
  * Key Features:
  * - Ring buffer based memory management (zero allocation overhead)
  * - Lazy invalidation TensorMap for dependency discovery
- * - Scope-based buffer lifecycle management
+ * - Manual scopes that bypass TensorMap discovery for explicit dependencies
  * - Per-task spinlocks for concurrent fanout updates
  * - Orchestrator-Scheduler decoupling via shared memory
  *
@@ -302,17 +302,21 @@ void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
 /**
  * Begin a new scope
  *
- * All tasks submitted within this scope will have their lifetime
- * bounded by the scope. When scope_end() is called, the scope
- * releases its reference to all enclosed tasks.
+ * submit_task requires at least one open scope. A MANUAL scope additionally makes
+ * every submit inside it bypass TensorMap discovery and take its fanin from
+ * CoreTaskArgs::set_dependencies() instead; an AUTO scope nested inside a MANUAL
+ * one is rejected. The mode is read from PTO2Runtime::pending_scope_mode, which
+ * PTO2_SCOPE sets immediately before this call.
  */
 void rt_scope_begin(PTO2Runtime *rt);
 
 /**
  * End current scope
  *
- * Releases scope reference for all tasks submitted since scope_begin().
- * Tasks whose refcount reaches zero will have their buffers released.
+ * Closes the innermost scope, and when that is the outermost MANUAL one, returns
+ * later submits to TensorMap discovery. A scope bounds no task or buffer lifetime
+ * here: the ring is whole-graph-resident, so no task slot and no heap byte is
+ * reclaimed before the run ends.
  */
 void rt_scope_end(PTO2Runtime *rt);
 

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime_types.h
@@ -90,11 +90,6 @@
 
 // Scope management
 #define PTO2_MAX_SCOPE_DEPTH 64  // Maximum nesting depth
-// Hard cap for the scope_tasks buffer. Equals the in-flight ring slot budget:
-// once every ring slot is in flight, no more tasks can ever be pushed regardless
-// of buffer size. scope_tasks_push fatals on overflow rather than growing the
-// buffer.
-#define PTO2_SCOPE_TASKS_CAP (PTO2_TASK_WINDOW_SIZE)
 
 // Per-shape ready-queue capacity (power of two). This is a ring buffer that
 // bounds peak CONCURRENT occupancy (enqueue_pos - dequeue_pos), not total task
@@ -145,7 +140,7 @@ constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_MS = 15000;  // 15 s
  * Task state enumeration
  *
  * State transitions:
- *   PENDING -> COMPLETED -> CONSUMED
+ *   PENDING -> COMPLETED
  *
  * The slot stays in PENDING from submit through "ready in queue" and "running
  * on a worker"; readiness and running-vs-idle are derived from fanin_refcount
@@ -154,12 +149,15 @@ constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_MS = 15000;  // 15 s
  * Conditions:
  *   PENDING->COMPLETED:   all subtasks finish (set by scheduler) or task is a
  *                         hidden alloc completed inline by the orchestrator
- *   COMPLETED->CONSUMED:  per-ring completed_watermark >= last_consumer_local_id
+ *
+ * COMPLETED is terminal: no slot is recycled before the run ends, so nothing
+ * advances a task past it. Consumer retirement is observed through the per-ring
+ * completed_watermark instead.
  */
 typedef enum {
     PTO2_TASK_PENDING = 0,    // Submitted; awaiting fanin, queued, or dispatched
     PTO2_TASK_COMPLETED = 1,  // Execution finished, output may still be in use
-    PTO2_TASK_CONSUMED = 2    // Output fully consumed, buffers can be released
+    PTO2_TASK_CONSUMED = 2    // Unused: host_build_graph never advances past COMPLETED
 } PTO2TaskState;
 
 /**

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -892,12 +892,6 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    // Polling: scope-end takes no per-producer action. Under the wiring model
-    // this bumped each task's scope refcount (PTO2_FANOUT_SCOPE_BIT); reclaim now
-    // gates on completed_watermark >= last_consumer_local_id, which needs no
-    // scope reference. Kept as a no-op so the orchestrator call site is unchanged.
-    void on_scope_end(PTO2TaskSlotState ** /*task_slot_states*/, int32_t /*count*/) {}
-
     // Orch owns dependency discovery and saves the immutable fanin wire.
     // Scheduler polling only chooses which already-wired producer a consumer
     // waits on at this instant; it never recomputes producer relationships.

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -909,16 +909,15 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
     // Initialize task counters. Task count comes from PTO2 shared memory.
     if (runtime->get_gm_sm_ptr()) {
         auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_gm_sm_ptr());
-        // Read at one-time boot init, before the SM is reset for the run, so a
-        // ring not yet written holds uninitialized memory (0xbe... under ASAN's
-        // malloc-fill). Sum in int64 and only count rings whose value is a
-        // plausible task count — (0, PTO2_SCOPE_TASKS_CAP]; a ring cannot hold
-        // more than the scope cap. This rejects any garbage pattern (negative
-        // or positive), so uninitialized rings contribute 0 (the correct boot
-        // count) while valid counts still add up, with no signed overflow.
+        // Read at one-time boot init, before the SM is reset for the run, so a ring
+        // not yet written holds uninitialized memory (0xbe... under ASAN's
+        // malloc-fill). Only a plausible count is taken — (0,
+        // PTO2_TASK_WINDOW_SIZE], since the ring cannot hold more than its task
+        // window — so any garbage pattern, negative or positive, leaves the count
+        // at 0, which is the correct value at boot.
         int32_t pto2_count = 0;
         int32_t ring_tasks = header->ring.fc.current_task_index.load(std::memory_order_acquire);
-        if (ring_tasks > 0 && ring_tasks <= PTO2_SCOPE_TASKS_CAP) pto2_count = ring_tasks;
+        if (ring_tasks > 0 && ring_tasks <= PTO2_TASK_WINDOW_SIZE) pto2_count = ring_tasks;
         total_tasks_ = pto2_count;
     } else {
         total_tasks_ = 0;

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/runtime_init.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/runtime_init.cpp
@@ -205,11 +205,7 @@ bool PTO2OrchestratorState::init(
     auto *orch = this;
     *orch = PTO2OrchestratorState{};
 
-    // scope_tasks holds every task in the open scope, so its cap is the real
-    // in-flight budget = the (runtime) task window. Using the compile-time
-    // PTO2_SCOPE_TASKS_CAP instead under-sized the buffer when ring_task_window
-    // was enlarged past the default (premature SCOPE_TASKS_OVERFLOW) and
-    // over-allocated it when shrunk. See issue #1188.
+    // A power-of-two window lets pto2_task_slot() mask instead of dividing.
     always_assert(task_window_size > 0 && (task_window_size & (task_window_size - 1)) == 0);
 
     orch->sm_header = reinterpret_cast<PTO2SharedMemoryHeader *>(sm_base);
@@ -235,9 +231,7 @@ bool PTO2OrchestratorState::init(
     // Polling: no fanin-spill pool — producer ids are inline on the payload.
     const auto window = static_cast<size_t>(task_window_size);
     orch->fanin_seen_epoch.reset(new (std::nothrow) uint32_t[window]);
-    orch->scope_tasks.reset(new (std::nothrow) PTO2TaskSlotState *[window]);
-    orch->scope_begins.reset(new (std::nothrow) int32_t[PTO2_MAX_SCOPE_DEPTH]);
-    if (orch->fanin_seen_epoch == nullptr || orch->scope_tasks == nullptr || orch->scope_begins == nullptr) {
+    if (orch->fanin_seen_epoch == nullptr) {
         LOG_ERROR("Orchestrator scratch allocation failed (task_window=%" PRIu64 ")", task_window_size);
         return false;
     }
@@ -247,10 +241,7 @@ bool PTO2OrchestratorState::init(
         return false;
     }
 
-    orch->scope_tasks_size = 0;
-    orch->scope_tasks_capacity = static_cast<int32_t>(window);
     orch->scope_stack_top = -1;
-    orch->scope_stack_capacity = PTO2_MAX_SCOPE_DEPTH;
     orch->manual_begin_depth = PTO2_MAX_SCOPE_DEPTH;
 
     return true;

--- a/src/a2a3/runtime/host_build_graph/runtime/types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/types.h
@@ -22,8 +22,7 @@
  * without type conflicts (Handshake, TensorPair, HostApi).
  */
 
-#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_TYPES_H_
-#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_TYPES_H_
+#pragma once
 
 #include <stdint.h>
 #include <string.h>
@@ -85,22 +84,21 @@ enum class PTO2ScopeMode : uint8_t {
  * Users must hold a named TaskOutputTensors variable and borrow via get_ref();
  * binding get_ref() on an rvalue is compile-time rejected to prevent dangling.
  *
- * LIFETIME — single-scope only:
- *   Internally this class stores pointers into the submitting task's payload
- *   (PTO2TaskPayload::tensors[]), which lives in a ring-buffer slot. After
- *   scope_end the slot becomes eligible for reuse, and a later submit will
- *   overwrite the same ChipTensor storage in place. Therefore the
- *   TaskOutputTensors instance, the const ChipTensor& returned by get_ref(), and
- *   any pointer derived from either MUST NOT outlive the PTO2_SCOPE in which
- *   submit was called — do not move/copy them to outer-scope variables, do
- *   not capture references by std::reference_wrapper or raw pointers across
- *   scope boundaries.
+ * LIFETIME — single-pass only:
+ *   Internally this class stores pointers into the submitting task's tensor
+ *   storage: the region named by PTO2TaskPayload::tensors for a plain submit, the
+ *   GraphRecording node's tensors for a submit inside a Graph body. Both belong to
+ *   one orchestration pass, which the next bind rebuilds over the same bytes.
+ *   Therefore the TaskOutputTensors instance, the const ChipTensor& returned by
+ *   get_ref(), and any pointer derived from either MUST NOT outlive the
+ *   orchestration entry that submitted the task — do not move/copy them into state
+ *   that survives the pass, and do not capture them by std::reference_wrapper or
+ *   raw pointer across that boundary.
  *
- *   This invariant is intentionally not enforced at runtime: a reused slot
- *   simply carries a different but valid owner_task_id, so checking
- *   owner_task_id cannot distinguish "still mine" from "silently aliased to
- *   an unrelated task". Misuse manifests as a wrong-tensor read with no
- *   diagnostic.
+ *   This invariant is intentionally not enforced at runtime: rebuilt storage
+ *   carries a different but valid owner_task_id, so checking owner_task_id cannot
+ *   distinguish "still mine" from "silently aliased to an unrelated task". Misuse
+ *   manifests as a wrong-tensor read with no diagnostic.
  */
 class TaskOutputTensors {
 public:
@@ -719,5 +717,3 @@ struct ChipTaskArgs : Arg<CHIP_MAX_TENSOR_ARGS, CHIP_MAX_SCALAR_ARGS> {
         }
     }
 };
-
-#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_TYPES_H_

--- a/src/a5/runtime/host_build_graph/common/runtime_status.h
+++ b/src/a5/runtime/host_build_graph/common/runtime_status.h
@@ -36,7 +36,7 @@
 #define SIMPLER_ERROR_REQUIRE_SYNC_START_INVALID 7
 #define SIMPLER_ERROR_TENSOR_WAIT_TIMEOUT 8
 #define SIMPLER_ERROR_EXPLICIT_ORCH_FATAL 9
-#define SIMPLER_ERROR_SCOPE_TASKS_OVERFLOW 10  // scope_tasks buffer saturated (all rings full)
+#define SIMPLER_ERROR_SCOPE_TASKS_OVERFLOW 10  // Not raised here; the number stays reserved across runtimes
 #define SIMPLER_ERROR_TENSORMAP_OVERFLOW 11    // graph registers more outputs than the tensormap entry pool holds
 
 // Scheduler errors (100+): detected in scheduler threads

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -124,9 +124,9 @@ scalar `rt_orchestration_done` publishes into the runtime header.
 
 **Why the scheduler state is device-written.** `PTO2SchedulerState` holds no
 per-run content: `sm_header` and the ring pointer derive from a pooled SM base,
-queue capacities are compile-time constants, and hbg never advances
-`last_task_alive`. Its one host-side entry point, `on_scope_end`, is an empty stub
-here. So the host would only be writing an initialization pattern — 203,392 bytes
+queue capacities are compile-time constants, hbg never advances
+`last_task_alive`, and it has no host-side entry point at all. So the host would
+only be writing an initialization pattern — 203,392 bytes
 of it, dominated by `AsyncWaitList::entries` — for the device to receive and never
 read. `PTO2Runtime` therefore holds a *pointer* to it, wired from
 `off_scheduler` on each side, and the AICPU calls `init_data_from_layout` at boot.

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -610,7 +610,7 @@ int32_t run_host_orchestration(
         const PTO2OrchProfilingData prof = orchestrator_get_profiling();
         const std::pair<const char *, uint64_t> steps[] = {
             {"alloc", prof.alloc_cycle},   {"args", prof.args_cycle},   {"lookup", prof.lookup_cycle},
-            {"insert", prof.insert_cycle}, {"fanin", prof.fanin_cycle}, {"scope_end", prof.scope_end_cycle},
+            {"insert", prof.insert_cycle}, {"fanin", prof.fanin_cycle},
         };
         for (const auto &step : steps) {
             if (step.second == 0) continue;

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator.h
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator.h
@@ -16,7 +16,7 @@
  * 2. Allocating intermediate buffers from the heap
  * 3. Submitting tasks via async InCore function calls
  * 4. Building the dependency graph using TensorMap
- * 5. Managing buffer scopes for lifecycle control
+ * 5. Tracking scope nesting, which selects TensorMap or explicit dependencies
  *
  * The Orchestrator can run on either:
  * - Host CPU (lower latency for complex control, easier debugging)
@@ -70,15 +70,11 @@ struct PTO2OrchestratorState {
     PTO2TensorMap tensor_map;  // Producer lookup
 
     // === SCOPE STACK (Private) ===
-    // Single contiguous buffer of task IDs, partitioned by scope level.
-    // scope_begins[i] is the index into scope_tasks where scope i starts.
-    // Tasks for the top scope occupy [scope_begins[top], scope_tasks_size).
-    std::unique_ptr<PTO2TaskSlotState *[]> scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
-    int32_t scope_tasks_size{0};                         // Number of task IDs currently in the buffer
-    int32_t scope_tasks_capacity{0};                     // Allocated capacity of scope_tasks
-    std::unique_ptr<int32_t[]> scope_begins;             // scope_begins[i] = start index of scope i in scope_tasks
-    int32_t scope_stack_top{-1};                         // Current top of stack (-1 = no scope open)
-    uint64_t scope_stack_capacity{0};                    // Max nesting depth (PTO2_MAX_SCOPE_DEPTH)
+    // Depth only. A scope decides whether a submit takes its fanin from TensorMap
+    // discovery or from CoreTaskArgs::set_dependencies, and submit_task requires
+    // one to be open; it bounds no task or buffer lifetime, so there is no
+    // per-scope task list to walk at scope end.
+    int32_t scope_stack_top{-1};  // Current top of stack (-1 = no scope open)
     int32_t manual_begin_depth{PTO2_MAX_SCOPE_DEPTH};
 
     // === SCHEDULER REFERENCE ===
@@ -179,13 +175,11 @@ struct PTO2OrchProfilingData {
     uint64_t lookup_cycle;
     uint64_t insert_cycle;
     uint64_t fanin_cycle;
-    uint64_t scope_end_cycle;
     int64_t submit_count;
     // Wait time tracking for blocking phases
     uint64_t fanin_wait_cycle;  // Legacy (wiring): fanout_lock wait; polling has no such lock
     // Atomic operation counts per phase
     uint64_t args_atomic_count;
-    uint64_t scope_end_atomic_count;
 };
 
 PTO2OrchProfilingData orchestrator_get_profiling();

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -143,17 +143,15 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() {
 // The strong symbol from the AICPU build wins when profiling is available.
 // Also hidden to prevent HOST .so from polluting the global symbol table.
 // Accumulated cycles per sub-step (only needed for ORCH_PROFILING export)
-static uint64_t g_orch_alloc_cycle = 0;      // unified task+heap alloc
-static uint64_t g_orch_args_cycle = 0;       // param copy
-static uint64_t g_orch_lookup_cycle = 0;     // tensormap lookup + dep building
-static uint64_t g_orch_insert_cycle = 0;     // tensormap insert
-static uint64_t g_orch_fanin_cycle = 0;      // fanin list + early-return check
-static uint64_t g_orch_scope_end_cycle = 0;  // scope_end overhead
+static uint64_t g_orch_alloc_cycle = 0;   // unified task+heap alloc
+static uint64_t g_orch_args_cycle = 0;    // param copy
+static uint64_t g_orch_lookup_cycle = 0;  // tensormap lookup + dep building
+static uint64_t g_orch_insert_cycle = 0;  // tensormap insert
+static uint64_t g_orch_fanin_cycle = 0;   // fanin list + early-return check
 static int64_t g_orch_submit_count = 0;
 static uint32_t g_orch_submit_idx = 0;
 uint64_t g_orch_fanin_wait_cycle = 0;
 uint64_t g_orch_args_atomic_count = 0;
-uint64_t g_orch_scope_end_atomic_count = 0;
 // Cycle accumulation is unconditional under SIMPLER_ORCH_PROFILING (that's what
 // the flag is for) and feeds the per-sub-step `g_orch_*_cycle` cumulatives
 // printed in the cold-path log. Per-event records are a separate channel on a
@@ -1024,8 +1022,6 @@ static bool append_fanin_or_fail(
     return true;
 }
 
-static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state);
-
 struct PTO2PreparedTask {
     TaskId task_id = TaskId::invalid();
     PTO2TaskAllocResult alloc_result = {-1, 0, nullptr, nullptr};
@@ -1141,7 +1137,6 @@ static bool prepare_task(
     // above (whole-graph-resident hbg never reuses a slot).
     out->slot_state->last_consumer_local_id = static_cast<int32_t>(out->task_id.local());
     // payload.fanin_count is set in submit_task_common's STEP 6.
-    scope_tasks_push(orch, out->slot_state);
 
     return true;
 }
@@ -1149,20 +1144,6 @@ static bool prepare_task(
 // =============================================================================
 // Scope Management
 // =============================================================================
-
-static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state) {
-    if (orch->scope_tasks_size >= orch->scope_tasks_capacity) {
-        // Capacity is the total in-flight slot budget (the runtime task window;
-        // see PTO2OrchestratorState::init) — hitting it means the ring is
-        // saturated, so no further push could succeed regardless of buffer growth.
-        orch->report_fatal(
-            SIMPLER_ERROR_SCOPE_TASKS_OVERFLOW, __FUNCTION__,
-            "scope_tasks buffer saturated at %d entries (all rings full)", orch->scope_tasks_capacity
-        );
-        return;
-    }
-    orch->scope_tasks[orch->scope_tasks_size++] = task_slot_state;
-}
 
 void PTO2OrchestratorState::begin_scope(PTO2ScopeMode mode) {
     auto *orch = this;
@@ -1194,7 +1175,7 @@ void PTO2OrchestratorState::begin_scope(PTO2ScopeMode mode) {
         }
         return;
     }
-    assert(orch->scope_stack_top < static_cast<int32_t>(orch->scope_stack_capacity - 1) && "Scope stack overflow");
+    assert(orch->scope_stack_top < PTO2_MAX_SCOPE_DEPTH - 1 && "Scope stack overflow");
     if (mode == PTO2ScopeMode::AUTO && orch->in_manual_scope()) {
         report_fatal(
             SIMPLER_ERROR_INVALID_ARGS, __FUNCTION__, "auto scope nested inside manual scope is not supported"
@@ -1204,7 +1185,6 @@ void PTO2OrchestratorState::begin_scope(PTO2ScopeMode mode) {
 
     bool already_in_manual_scope = orch->in_manual_scope();
     ++orch->scope_stack_top;
-    orch->scope_begins[orch->scope_stack_top] = orch->scope_tasks_size;
     if (mode == PTO2ScopeMode::MANUAL && !already_in_manual_scope) {
         orch->manual_begin_depth = orch->scope_stack_top;
     }
@@ -1245,9 +1225,6 @@ void PTO2OrchestratorState::end_scope() {
     }
     assert(orch->scope_stack_top >= 0 && "Scope stack underflow");
 
-    // Snapshot the ring start/end BEFORE the orchestrator drains pending tasks
-    // via scheduler->on_scope_end, so the end record reflects the scope's
-    // occupancy at close, not the residual after teardown.
 #if SIMPLER_DFX
     // Gate via is_scope_stats_enabled() (see begin_scope). One collector call
     // emits the end-boundary record and tears down bookkeeping.
@@ -1265,28 +1242,10 @@ void PTO2OrchestratorState::end_scope() {
     }
 #endif
 
-#if SIMPLER_ORCH_PROFILING
-    uint64_t _se0 = get_sys_cnt_aicpu();
-#endif
-
-    bool ending_manual_scope = orch->scope_stack_top == orch->manual_begin_depth;
-    int32_t begin = orch->scope_begins[orch->scope_stack_top--];
-    int32_t count = orch->scope_tasks_size - begin;
-    if (ending_manual_scope) {
+    if (orch->scope_stack_top == orch->manual_begin_depth) {
         orch->manual_begin_depth = PTO2_MAX_SCOPE_DEPTH;
     }
-
-    if (orch->scheduler && count > 0) {
-        orch->scheduler->on_scope_end(&orch->scope_tasks[begin], count);
-    }
-
-    // Rewind the task buffer — these entries are no longer needed
-    orch->scope_tasks_size = begin;
-
-#if SIMPLER_ORCH_PROFILING
-    uint64_t _se1 = get_sys_cnt_aicpu();
-    g_orch_scope_end_cycle += (_se1 - _se0);
-#endif
+    --orch->scope_stack_top;
 }
 
 // =============================================================================
@@ -1708,7 +1667,6 @@ bool graph_submit_outer(
     slot.total_required_subtasks = 0;
     slot.logical_block_num = 1;
     slot.task_kind = TaskKind::GRAPH;
-    scope_tasks_push(orch, &slot);
 
     task.task_id = task_id;
     std::fill(std::begin(task.kernel_id), std::end(task.kernel_id), INVALID_KERNEL_ID);
@@ -2570,8 +2528,8 @@ TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const CoreTaskArgs &args)
         // subtasks to retire. Running the full on_task_complete path
         // would only pay unnecessary fanout_lock / traversal overhead here.
         // The generic slot initialization done in prepare_task() is still
-        // required so scope_end can release the producer-side reference and
-        // drive the slot to CONSUMED, but worker dispatch fields are never
+        // required — a consumer reads this slot's task_attrs and completion
+        // mirror, both set below — but worker dispatch fields are never
         // observed for hidden alloc tasks.
         //
         // Flag the creator so it does NOT suppress its consumers' early-dispatch.
@@ -2620,7 +2578,6 @@ void PTO2OrchestratorState::mark_done() {
         LOG_DEBUG("=== [Orchestrator] total_tasks=%d ===", total_tasks);
     }
     orch->sm_header->orchestrator_done.store(1, std::memory_order_release);
-    orch->scope_tasks_size = 0;
     orch->scope_stack_top = -1;
     orch->manual_begin_depth = PTO2_MAX_SCOPE_DEPTH;
 #if !SIMPLER_ORCH_PROFILING && SIMPLER_DFX
@@ -2636,21 +2593,18 @@ PTO2OrchProfilingData orchestrator_get_profiling() {
     d.lookup_cycle = g_orch_lookup_cycle;
     d.insert_cycle = g_orch_insert_cycle;
     d.fanin_cycle = g_orch_fanin_cycle;
-    d.scope_end_cycle = g_orch_scope_end_cycle;
     d.submit_count = g_orch_submit_count;
     d.fanin_wait_cycle = g_orch_fanin_wait_cycle;
     d.args_atomic_count = g_orch_args_atomic_count;
-    d.scope_end_atomic_count = g_orch_scope_end_atomic_count;
 
     // Reset
     g_orch_alloc_cycle = g_orch_args_cycle = 0;
     g_orch_lookup_cycle = g_orch_insert_cycle = 0;
-    g_orch_fanin_cycle = g_orch_scope_end_cycle = 0;
+    g_orch_fanin_cycle = 0;
     g_orch_submit_count = 0;
     g_orch_submit_idx = 0;
     g_orch_fanin_wait_cycle = 0;
     g_orch_args_atomic_count = 0;
-    g_orch_scope_end_atomic_count = 0;
     return d;
 }
 #endif

--- a/src/a5/runtime/host_build_graph/runtime/runtime_core.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime_core.h
@@ -17,7 +17,7 @@
  * Key Features:
  * - Ring buffer based memory management (zero allocation overhead)
  * - Lazy invalidation TensorMap for dependency discovery
- * - Scope-based buffer lifecycle management
+ * - Manual scopes that bypass TensorMap discovery for explicit dependencies
  * - Per-task spinlocks for concurrent fanout updates
  * - Orchestrator-Scheduler decoupling via shared memory
  *
@@ -303,17 +303,21 @@ void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
 /**
  * Begin a new scope
  *
- * All tasks submitted within this scope will have their lifetime
- * bounded by the scope. When scope_end() is called, the scope
- * releases its reference to all enclosed tasks.
+ * submit_task requires at least one open scope. A MANUAL scope additionally makes
+ * every submit inside it bypass TensorMap discovery and take its fanin from
+ * CoreTaskArgs::set_dependencies() instead; an AUTO scope nested inside a MANUAL
+ * one is rejected. The mode is read from PTO2Runtime::pending_scope_mode, which
+ * PTO2_SCOPE sets immediately before this call.
  */
 void rt_scope_begin(PTO2Runtime *rt);
 
 /**
  * End current scope
  *
- * Releases scope reference for all tasks submitted since scope_begin().
- * Tasks whose refcount reaches zero will have their buffers released.
+ * Closes the innermost scope, and when that is the outermost MANUAL one, returns
+ * later submits to TensorMap discovery. A scope bounds no task or buffer lifetime
+ * here: the ring is whole-graph-resident, so no task slot and no heap byte is
+ * reclaimed before the run ends.
  */
 void rt_scope_end(PTO2Runtime *rt);
 

--- a/src/a5/runtime/host_build_graph/runtime/runtime_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime_types.h
@@ -91,11 +91,6 @@
 
 // Scope management
 #define PTO2_MAX_SCOPE_DEPTH 64  // Maximum nesting depth
-// Hard cap for the scope_tasks buffer. Equals the in-flight ring slot budget:
-// once every ring slot is in flight, no more tasks can ever be pushed regardless
-// of buffer size. scope_tasks_push fatals on overflow rather than growing the
-// buffer.
-#define PTO2_SCOPE_TASKS_CAP (PTO2_TASK_WINDOW_SIZE)
 
 // Per-shape ready-queue capacity (power of two). This is a ring buffer that
 // bounds peak CONCURRENT occupancy (enqueue_pos - dequeue_pos), not total task
@@ -146,7 +141,7 @@ constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_MS = 15000;  // 15 s
  * Task state enumeration
  *
  * State transitions:
- *   PENDING -> COMPLETED -> CONSUMED
+ *   PENDING -> COMPLETED
  *
  * The slot stays in PENDING from submit through "ready in queue" and "running
  * on a worker"; readiness and running-vs-idle are derived from fanin_refcount
@@ -155,12 +150,15 @@ constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_MS = 15000;  // 15 s
  * Conditions:
  *   PENDING->COMPLETED:   all subtasks finish (set by scheduler) or task is a
  *                         hidden alloc completed inline by the orchestrator
- *   COMPLETED->CONSUMED:  per-ring completed_watermark >= last_consumer_local_id
+ *
+ * COMPLETED is terminal: no slot is recycled before the run ends, so nothing
+ * advances a task past it. Consumer retirement is observed through the per-ring
+ * completed_watermark instead.
  */
 typedef enum {
     PTO2_TASK_PENDING = 0,    // Submitted; awaiting fanin, queued, or dispatched
     PTO2_TASK_COMPLETED = 1,  // Execution finished, output may still be in use
-    PTO2_TASK_CONSUMED = 2    // Output fully consumed, buffers can be released
+    PTO2_TASK_CONSUMED = 2    // Unused: host_build_graph never advances past COMPLETED
 } PTO2TaskState;
 
 /**

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -892,12 +892,6 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    // Polling: scope-end takes no per-producer action. Under the wiring model
-    // this bumped each task's scope refcount (PTO2_FANOUT_SCOPE_BIT); reclaim now
-    // gates on completed_watermark >= last_consumer_local_id, which needs no
-    // scope reference. Kept as a no-op so the orchestrator call site is unchanged.
-    void on_scope_end(PTO2TaskSlotState ** /*task_slot_states*/, int32_t /*count*/) {}
-
     // Orch owns dependency discovery and saves the immutable fanin wire.
     // Scheduler polling only chooses which already-wired producer a consumer
     // waits on at this instant; it never recomputes producer relationships.

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -909,16 +909,15 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
     // Initialize task counters. Task count comes from PTO2 shared memory.
     if (runtime->get_gm_sm_ptr()) {
         auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_gm_sm_ptr());
-        // Read at one-time boot init, before the SM is reset for the run, so a
-        // ring not yet written holds uninitialized memory (0xbe... under ASAN's
-        // malloc-fill). Sum in int64 and only count rings whose value is a
-        // plausible task count — (0, PTO2_SCOPE_TASKS_CAP]; a ring cannot hold
-        // more than the scope cap. This rejects any garbage pattern (negative
-        // or positive), so uninitialized rings contribute 0 (the correct boot
-        // count) while valid counts still add up, with no signed overflow.
+        // Read at one-time boot init, before the SM is reset for the run, so a ring
+        // not yet written holds uninitialized memory (0xbe... under ASAN's
+        // malloc-fill). Only a plausible count is taken — (0,
+        // PTO2_TASK_WINDOW_SIZE], since the ring cannot hold more than its task
+        // window — so any garbage pattern, negative or positive, leaves the count
+        // at 0, which is the correct value at boot.
         int32_t pto2_count = 0;
         int32_t ring_tasks = header->ring.fc.current_task_index.load(std::memory_order_acquire);
-        if (ring_tasks > 0 && ring_tasks <= PTO2_SCOPE_TASKS_CAP) pto2_count = ring_tasks;
+        if (ring_tasks > 0 && ring_tasks <= PTO2_TASK_WINDOW_SIZE) pto2_count = ring_tasks;
         total_tasks_ = pto2_count;
     } else {
         total_tasks_ = 0;

--- a/src/a5/runtime/host_build_graph/runtime/shared/runtime_init.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/runtime_init.cpp
@@ -205,11 +205,7 @@ bool PTO2OrchestratorState::init(
     auto *orch = this;
     *orch = PTO2OrchestratorState{};
 
-    // scope_tasks holds every task in the open scope, so its cap is the real
-    // in-flight budget = the (runtime) task window. Using the compile-time
-    // PTO2_SCOPE_TASKS_CAP instead under-sized the buffer when ring_task_window
-    // was enlarged past the default (premature SCOPE_TASKS_OVERFLOW) and
-    // over-allocated it when shrunk. See issue #1188.
+    // A power-of-two window lets pto2_task_slot() mask instead of dividing.
     always_assert(task_window_size > 0 && (task_window_size & (task_window_size - 1)) == 0);
 
     orch->sm_header = reinterpret_cast<PTO2SharedMemoryHeader *>(sm_base);
@@ -235,9 +231,7 @@ bool PTO2OrchestratorState::init(
     // Polling: no fanin-spill pool — producer ids are inline on the payload.
     const auto window = static_cast<size_t>(task_window_size);
     orch->fanin_seen_epoch.reset(new (std::nothrow) uint32_t[window]);
-    orch->scope_tasks.reset(new (std::nothrow) PTO2TaskSlotState *[window]);
-    orch->scope_begins.reset(new (std::nothrow) int32_t[PTO2_MAX_SCOPE_DEPTH]);
-    if (orch->fanin_seen_epoch == nullptr || orch->scope_tasks == nullptr || orch->scope_begins == nullptr) {
+    if (orch->fanin_seen_epoch == nullptr) {
         LOG_ERROR("Orchestrator scratch allocation failed (task_window=%" PRIu64 ")", task_window_size);
         return false;
     }
@@ -247,10 +241,7 @@ bool PTO2OrchestratorState::init(
         return false;
     }
 
-    orch->scope_tasks_size = 0;
-    orch->scope_tasks_capacity = static_cast<int32_t>(window);
     orch->scope_stack_top = -1;
-    orch->scope_stack_capacity = PTO2_MAX_SCOPE_DEPTH;
     orch->manual_begin_depth = PTO2_MAX_SCOPE_DEPTH;
 
     return true;

--- a/src/a5/runtime/host_build_graph/runtime/types.h
+++ b/src/a5/runtime/host_build_graph/runtime/types.h
@@ -84,22 +84,21 @@ enum class PTO2ScopeMode : uint8_t {
  * Users must hold a named TaskOutputTensors variable and borrow via get_ref();
  * binding get_ref() on an rvalue is compile-time rejected to prevent dangling.
  *
- * LIFETIME — single-scope only:
- *   Internally this class stores pointers into the submitting task's payload
- *   (PTO2TaskPayload::tensors[]), which lives in a ring-buffer slot. After
- *   scope_end the slot becomes eligible for reuse, and a later submit will
- *   overwrite the same ChipTensor storage in place. Therefore the
- *   TaskOutputTensors instance, the const ChipTensor& returned by get_ref(), and
- *   any pointer derived from either MUST NOT outlive the PTO2_SCOPE in which
- *   submit was called — do not move/copy them to outer-scope variables, do
- *   not capture references by std::reference_wrapper or raw pointers across
- *   scope boundaries.
+ * LIFETIME — single-pass only:
+ *   Internally this class stores pointers into the submitting task's tensor
+ *   storage: the region named by PTO2TaskPayload::tensors for a plain submit, the
+ *   GraphRecording node's tensors for a submit inside a Graph body. Both belong to
+ *   one orchestration pass, which the next bind rebuilds over the same bytes.
+ *   Therefore the TaskOutputTensors instance, the const ChipTensor& returned by
+ *   get_ref(), and any pointer derived from either MUST NOT outlive the
+ *   orchestration entry that submitted the task — do not move/copy them into state
+ *   that survives the pass, and do not capture them by std::reference_wrapper or
+ *   raw pointer across that boundary.
  *
- *   This invariant is intentionally not enforced at runtime: a reused slot
- *   simply carries a different but valid owner_task_id, so checking
- *   owner_task_id cannot distinguish "still mine" from "silently aliased to
- *   an unrelated task". Misuse manifests as a wrong-tensor read with no
- *   diagnostic.
+ *   This invariant is intentionally not enforced at runtime: rebuilt storage
+ *   carries a different but valid owner_task_id, so checking owner_task_id cannot
+ *   distinguish "still mine" from "silently aliased to an unrelated task". Misuse
+ *   manifests as a wrong-tensor read with no diagnostic.
  */
 class TaskOutputTensors {
 public:


### PR DESCRIPTION
## Summary

An hbg scope no longer bounds any lifetime, so this reduces it to the one thing it still decides — depth — and deletes the machinery built to feed a stub.

`SchedulerState::on_scope_end` was an empty function. The ring is whole-graph-resident, so no task slot and no heap byte is reclaimed before the run ends, and `MAX_RING_DEPTH` is 1, so scope depth selects nothing. What a scope still decides is whether a submit takes its fanin from TensorMap discovery or from `CoreTaskArgs::set_dependencies`, plus the `submit_task` precondition that one be open — and both need only `scope_stack_top` and `manual_begin_depth`. Everything else goes:

- `scope_tasks` / `scope_begins`, their size and capacity fields, and `scope_stack_capacity`, whose only remaining use was an assert bound `MAX_SCOPE_DEPTH` states directly. `OrchestratorState::init` stops allocating **131,072 + 256 bytes** per orchestrator.
- `scope_tasks_push`, called from every `prepare_task` and every `graph_submit_outer`: one bounds check and one store per submitted task, for a buffer whose only consumer was the stub.
- `on_scope_end` itself, and the `end_scope` arithmetic that computed the range to hand it.
- `SCOPE_TASKS_CAP`. Its other user, the boot-time `total_tasks_` garbage filter in `scheduler_cold_path.cpp`, now bounds against `TASK_WINDOW_SIZE` — the same value at `MAX_RING_DEPTH == 1`, and the honest name for "a ring cannot hold more than its task window".
- `scope_end_cycle` and the `[ORCH_PROFILING]` `scope_end` row that reported it. `scope_end_atomic_count` goes with them; nothing ever incremented it.

`SIMPLER_ERROR_SCOPE_TASKS_OVERFLOW` keeps its number and its name: nothing in hbg raises it now, but `error_names.h` is shared with `tensormap_and_ringbuffer`, which still does, and `test_error_code_names.cpp` requires the tables to stay complete. `untested.md` records that hbg has no raise site rather than leaving the reader with tmr's multi-ring argument.

### Comments and docs that described the old model

These were asserting a scope-refcount design the runtime does not have, which is the kind of documentation that misleads for years because it reads as authoritative:

- `rt_scope_begin` / `rt_scope_end` state the submit precondition, the MANUAL bypass, and that nothing is reclaimed mid-run, instead of promising a scope-bounded task lifetime and a refcount that releases buffers.
- `TaskOutputTensors`'s LIFETIME contract binds to the orchestration pass rather than the enclosing scope, and names its real backing storage: the region `TaskPayload::tensors` points at, or the `GraphRecording` node's tensors inside a Graph body. The old text named an inline payload array in a reusable ring slot; neither is still true. **The rule it gives callers is unchanged in strength** — only its stated mechanism was wrong.
- `TaskState` documents the transition it has, `PENDING -> COMPLETED`, and marks that state terminal. Nothing stores `TASK_CONSUMED`: no slot is recycled before the run ends, and consumer retirement is observed through the per-ring `completed_watermark`.
- The hidden-alloc note in `alloc_tensors` says why the generic slot initialization is required — a consumer reads the slot's `task_attrs` and completion mirror — instead of crediting a `scope_end` release and a CONSUMED flip that hbg never performs.
- `docs/manual-scope.md` keeps `manual_begin_depth` as the only manual-scope-specific state and marks the scope task list as generic bookkeeping whose `scope_end` consumer differs per runtime: live in `tensormap_and_ringbuffer`, absent in `host_build_graph`.

a2a3's `types.h` also moves to `#pragma once` per `codestyle.md` §12: its `#ifndef` guard was spelled `SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_TYPES_H_`, naming a runtime the file does not belong to, and no source referenced the macro. Its a5 sibling already used `#pragma once`, so the two files are now identical.

Both architecture trees move together.

## Testing

- [x] `clang-format --dry-run -Werror` clean on all 20 changed C++ files; `markdownlint-cli2` clean on all 4 changed docs
- [x] `-fsyntax-only` with `-DSIMPLER_DFX=1 -DSIMPLER_ORCH_PROFILING=1` on `orchestrator.cpp` and `runtime_maker.cpp`, both arches — the profiling struct change is invisible to a default build, so it needs its own check
- [x] `pytest tests/ut -m "not requires_hardware"` — 1886 passed, 7 skipped
- [x] `ctest --test-dir tests/ut/cpp/build -LE requires_hardware` — 117/117
- [x] Simulation tests pass — `pytest examples tests/st --platform a2a3sim --device 0-15` and `--platform a5sim`, both 0 failures
- [x] Hardware tests pass — `pytest examples tests/st -m "not sdma" --platform a2a3 --exclude-level 4` and the separate `-m sdma` arm
- [ ] a5 onboard not run: this box is a2a3 silicon (`onboard-arch-precheck` refuses); covered by a5sim

### On the async-endpoint / FIFO scene tests

Across eight full a2a3 onboard runs on a shared box, four different cases failed at least once, never the same set twice, all as `507018` / `sched_error_code=100 SCHEDULER_TIMEOUT` or `RunHandle.wait() timed out`. **An unmodified base at this PR's merge-base reproduces it** — that control run failed `worker_async_fifo::TestWorkerAsyncWholeRunFifoTmr::test_run`. Two of the affected cases are `runtime="tensormap_and_ringbuffer"`, which this hbg-only diff cannot reach. These tests park a run at a SubTask fence and poll from Python with wall-clock deadlines, and the failing runs pin a single `chip.run` at ~46.05 s (the ~45 s op-execute timeout), so they are load-sensitive by construction; failures clustered while 12/16 devices were held by other users. `worker_async_endpoint` passes 6/6 standalone on both the branch and the base. Flagging rather than filing, since it wants a maintainer's read on whether to quarantine or raise the deadlines.
