### PR TITLE
Refactor: retire five PTO2 identifiers, one per commit

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -34,7 +34,7 @@ body:
       placeholder: |
         ```cpp
         // Example of proposed orchestration API
-        PTO2_SCOPE(rt) {
+        SIMPLER_SCOPE(rt) {
             // dynamic block iteration
         }
         ```

--- a/docs/callable-identity-registration.md
+++ b/docs/callable-identity-registration.md
@@ -72,7 +72,7 @@ temporary file, `dlopen` it, resolve the entry/config/bind symbols, and
 populate `orch_so_table_[callable_id]`. It must
 stop before any real task execution: it does not call the orchestration entry,
 does not configure runtime arguments from user task inputs, does not create a
-`PTO2Runtime`, does not enter runtime scopes, and does not submit scheduler or
+`RuntimeContext`, does not enter runtime scopes, and does not submit scheduler or
 AICore work. `dlopen` may still run ELF or C++ static constructors; the
 contract is that prewarm does not explicitly invoke orchestration logic.
 

--- a/docs/dfx/device-phases.md
+++ b/docs/dfx/device-phases.md
@@ -185,7 +185,7 @@ threads, no per-task AICore records, works in `SIMPLER_DFX=0`. See
   switch. An untagged task's only added hot-path cost is one cache-hot sentinel
   compare; it never reads `get_sys_cnt_aicpu()`.
 * **Transport reuses this same buffer.** The id rides the scheduler's hot
-  `PTO2TaskSlotState` in the `TaskAttrs` byte (bit 3 `is_timed` + bits 4-7 the
+  `ChipTaskSlotState` in the `TaskAttrs` byte (bit 3 `is_timed` + bits 4-7 the
   0..15 tag), co-located with the other per-task scheduling flags. The 16 slots
   are a fixed `TaskTimingRecord[16]` **tail** appended after the `AicpuPhaseRecord`
   region in the same device buffer — same base pointer and per-run H2D reset.

--- a/docs/dfx/profiling-config-naming.md
+++ b/docs/dfx/profiling-config-naming.md
@@ -64,7 +64,7 @@ runtime-specific ones) unambiguous about ownership.
 ### 4. Everything carries the `SIMPLER_` project prefix
 
 `PTO2_` is the device runtime's internal namespace (89 identifiers:
-`PTO2_MAX_RING_DEPTH`, `SIMPLER_ERROR_*`, `RuntimeContext`, …). Configuration
+`CHIP_MAX_RING_DEPTH`, `SIMPLER_ERROR_*`, `RuntimeContext`, …). Configuration
 surface exposed to users / CI / external consumers is unified under
 `SIMPLER_`, regardless of which internal namespace implements it.
 

--- a/docs/dfx/profiling-config-naming.md
+++ b/docs/dfx/profiling-config-naming.md
@@ -64,7 +64,7 @@ runtime-specific ones) unambiguous about ownership.
 ### 4. Everything carries the `SIMPLER_` project prefix
 
 `PTO2_` is the device runtime's internal namespace (89 identifiers:
-`PTO2_MAX_RING_DEPTH`, `SIMPLER_ERROR_*`, `PTO2Runtime`, …). Configuration
+`PTO2_MAX_RING_DEPTH`, `SIMPLER_ERROR_*`, `RuntimeContext`, …). Configuration
 surface exposed to users / CI / external consumers is unified under
 `SIMPLER_`, regardless of which internal namespace implements it.
 

--- a/docs/dfx/scope-stats.md
+++ b/docs/dfx/scope-stats.md
@@ -1,7 +1,7 @@
 # Scope Stats — Per-scope Resource Usage Peaks
 
 Scope stats records the peak resource usage — task-window slots, heap
-bytes, dep-pool entries, and tensormap entries — for every `PTO2_SCOPE` region in an
+bytes, dep-pool entries, and tensormap entries — for every `SIMPLER_SCOPE` region in an
 orchestration, so you can see *which scope* drove each resource to its
 high-water mark. When a model runs out of task windows, heap, or
 tensormap / dependency-list entries, the failure tells you *which* resource is exhausted
@@ -140,12 +140,12 @@ only the `real_occupancy` curve.
 ## 2. What gets captured
 
 - **The whole orchestration, automatically.** You do not mark a region
-  to profile — instrumentation lives inside the `PTO2_SCOPE` macro
+  to profile — instrumentation lives inside the `SIMPLER_SCOPE` macro
   itself, so *every* scope in the orchestration is recorded once the
   flag is on. The executor wraps the orchestration entry in a root
-  `PTO2_SCOPE` (`depth` 0), and every user-written `PTO2_SCOPE` nests
+  `SIMPLER_SCOPE` (`depth` 0), and every user-written `SIMPLER_SCOPE` nests
   under it, so the report covers the entire orch scope tree end to end.
-- **One sample per scope boundary.** Each `PTO2_SCOPE` emits a `begin`
+- **One sample per scope boundary.** Each `SIMPLER_SCOPE` emits a `begin`
   record on entry and an `end` record on exit. The plot tool pairs them
   by site to compute the metrics above.
 - **Per-ring.** Each ring's task window, heap, and dep pool are tracked
@@ -189,7 +189,7 @@ Per-sample lines, oldest-first:
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| `site` | `"basename:line"` | Source location of the `PTO2_SCOPE()` call |
+| `site` | `"basename:line"` | Source location of the `SIMPLER_SCOPE()` call |
 | `phase` | `"begin"`/`"end"` | Scope entry or exit sample |
 | `depth` | int | Nesting depth (0 = root scope inside the executor) |
 | `ring` | int | Ring this scope used; indexes `task_window_max` / `heap_max` / `dep_pool_max` |
@@ -292,7 +292,7 @@ they track the submit path directly. The runtime gates both on the local
 weak `is_scope_stats_enabled()` stub first, so a disabled run pays neither the
 cross-`.so` calls nor the cross-agent `active_count()` read (same idiom as
 `is_dep_gen_enabled`).
-`PTO2_SCOPE()` expansion calls `set_pending_site(__FILE__, __LINE__)`
+`SIMPLER_SCOPE()` expansion calls `set_pending_site(__FILE__, __LINE__)`
 before `begin`; `copy_basename` keeps the JSON readable without forcing
 the host to chase a device pointer into the orchestration `.so`'s string
 table. `on_fatal` sets `header.fatal_latched`, surfacing as
@@ -331,7 +331,7 @@ ScopeStatsCollector                platform scope_stats_collector_aicpu.cpp
   set kernel_args fields             runtime: scope_stats_set_ring_capacity()
   launch kernel                      runtime: scope_stats_set_tensormap_capacity()
       │                                  │
-  collector shard(s):                on PTO2_SCOPE begin/end:
+  collector shard(s):                on SIMPLER_SCOPE begin/end:
    append records to memory  ◀──┐      runtime samples task/heap/dep_pool/tensormap
       │                         │      runtime: scope_stats_begin()/end()
       │                         │         └─ emit record, append to buffer;

--- a/docs/dynamic-linking.md
+++ b/docs/dynamic-linking.md
@@ -94,10 +94,10 @@ SOs need from the host SO are passed via explicit function pointer injection
 
 Loaded by the AICPU executor at runtime from a temp file. Uses `RTLD_LAZY`
 because not all symbols may be referenced. Communicates with the runtime
-through a function pointer table (`PTO2RuntimeOps`), not direct symbol
+through a function pointer table (`RuntimeOps`), not direct symbol
 linkage.
 
-`PTO2RuntimeOps` is a binary ABI without size or version negotiation.
+`RuntimeOps` is a binary ABI without size or version negotiation.
 Orchestration SOs and their runtime must therefore be built from the same
 simpler revision. Changing the table's field count, order, or signatures
 invalidates previously built orchestration SOs; cached or prebuilt artifacts

--- a/docs/manual-scope.md
+++ b/docs/manual-scope.md
@@ -13,7 +13,7 @@ Keep manual scope small and explicit:
 
 The v0 design keeps these rules:
 
-1. `PTO2_SCOPE(PTO2ScopeMode::MANUAL)` opts a scope into manual mode.
+1. `SIMPLER_SCOPE(PTO2ScopeMode::MANUAL)` opts a scope into manual mode.
 2. `MANUAL` nested inside active `MANUAL` is allowed.
 3. `AUTO` nested inside active `MANUAL` is rejected.
 4. Manual deps are attached before submit through `CoreTaskArgs.set_dependencies(...)`.
@@ -26,7 +26,7 @@ The v0 design keeps these rules:
 ### Scope
 
 ```cpp
-PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
     ...
 }
 ```
@@ -132,7 +132,7 @@ For a submitted task:
 ## Example Pattern
 
 ```cpp
-PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
     auto alloc = alloc_tensors(tmp_ci);
 
     CoreTaskArgs qk;

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -345,7 +345,7 @@ SubmitResult Orchestrator::submit_sub(const CallableIdentity &callable, TaskArgs
    buys us nothing here. A monotonic `int32_t` gives ~2 billion ids per
    globally quiescent compaction interval.
 2. **`MAX_RING_DEPTH = 4` independent shared-memory heap slabs**
-   (Strict-1; matches L2's `PTO2_MAX_RING_DEPTH`). Each slab has its own
+   (Strict-1; matches L2's `CHIP_MAX_RING_DEPTH`). Each slab has its own
    `mmap(MAP_SHARED | MAP_ANONYMOUS)` region, bump cursor, FIFO
    reclamation pointer, and mutex / cv. A task's ring is chosen by
    **scope depth**:

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -585,7 +585,7 @@ is reclaimed individually when it reaches CONSUMED. The deque is reset only
 when the worker has no registered runs or live slots.
 
 The HeapRing is **partitioned into `MAX_RING_DEPTH = 4` independent
-rings** (Strict-1; matches L2's `PTO2_MAX_RING_DEPTH`). Each ring is its
+rings** (Strict-1; matches L2's `CHIP_MAX_RING_DEPTH`). Each ring is its
 own `mmap(MAP_SHARED | MAP_ANONYMOUS)` taken before fork, so children
 inherit all four at the same virtual addresses. The `heap_ring_size`
 knob on `Worker(...)` is the **per-ring** size (default 1 GiB → 4 GiB

--- a/docs/troubleshooting/device-error-codes/capacity.md
+++ b/docs/troubleshooting/device-error-codes/capacity.md
@@ -23,7 +23,7 @@ resource and determines how strong that diagnosis is:
 
 Do not guess at the ring sizes from the error code alone. Turn on `scope_stats`,
 which records the high-water mark of all four resources (task-window slots, heap
-bytes, dep-pool entries, tensormap entries) per `PTO2_SCOPE`:
+bytes, dep-pool entries, tensormap entries) per `SIMPLER_SCOPE`:
 
 ```python
 cfg = CallConfig()

--- a/docs/troubleshooting/device-error-codes/untested.md
+++ b/docs/troubleshooting/device-error-codes/untested.md
@@ -14,7 +14,7 @@ they cannot be provoked. Recording why, so the next person does not re-derive it
   scope keeps no task list, so nothing can saturate one. In
   `tensormap_and_ringbuffer` it exists but cannot be reached — `scope_tasks_cap` is the
   sum of the per-ring windows, but each ring physically holds only `window - 1` tasks,
-  so all rings together top out at `cap - PTO2_MAX_RING_DEPTH`, strictly below the cap.
+  so all rings together top out at `cap - CHIP_MAX_RING_DEPTH`, strictly below the cap.
   The rings always fill first and latch 1 or 3. Shrinking the window shrinks both, so
   the gap holds. The number stays reserved in both runtimes' code tables.
 - **11 TENSORMAP_OVERFLOW** needs the 65536-entry pool (`PTO2_TENSORMAP_POOL_SIZE`,

--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd_graph.cpp
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd_graph.cpp
@@ -96,7 +96,7 @@ void csa_attn_block(const GraphTaskArgs &args) {
     const ChipTensor &ori_slot_mapping_inline614 = args.tensor(45).ref();
     const ChipTensor &swa_indices_inline636 = args.tensor(46).ref();
     const ChipTensor &x_attn_csa_inline721 = args.tensor(47).ref();
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t x_mixed_inline10524_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline10524_ci(x_mixed_inline10524_ci_shapes, 2, DataType::BFLOAT16);
         uint32_t post_t_inline10558_ci_shapes[2] = {8, 4};
@@ -1093,7 +1093,7 @@ void csa_attn_block(const GraphTaskArgs &args) {
         for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
             proj_b_tids_inline2079_inline10609[__init_i] = TaskId::invalid();
         ChipTensor o_r_pad_inline2225_inline10832__rv_v2 = o_r_pad_inline2225_inline10832;
-        PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+        SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
             for (int64_t g_inline2162_inline10271 = 0; g_inline2162_inline10271 < 8; g_inline2162_inline10271 += 1) {
                 int64_t row_base_o_inline2078_inline10745 = (g_inline2162_inline10271 * 8);
                 int64_t out_col_g_inline2181_inline10439 = (g_inline2162_inline10271 * 1024);
@@ -1269,7 +1269,7 @@ void csa_moe_block(const GraphTaskArgs &args, bool route_by_hash) {
     uint64_t recv_aux_ctx = args.scalar(9);
     uint64_t recv_route_ctx = args.scalar(10);
     uint64_t routed_y_buf_ctx = args.scalar(11);
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t x_mixed_inline11049_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline11049_ci(x_mixed_inline11049_ci_shapes, 2, DataType::BFLOAT16);
         uint32_t post_ffn_inline11048_ci_shapes[2] = {8, 4};
@@ -1735,7 +1735,7 @@ void csa_moe_block(const GraphTaskArgs &args, bool route_by_hash) {
         params_t187.set_dependencies(params_t187_deps, params_t187_deps_count);
         TaskOutputTensors task_187_outs = rt_submit_aiv_task(194, params_t187);
         TaskId dispatch_push_tid_inline11245 = _push_tid_inline2710_inline11085;
-        PTO2_SCOPE() {
+        SIMPLER_SCOPE() {
             uint32_t recv_y_inline11016_ci_shapes[3] = {32, 16, 4096};
             TensorCreateInfo recv_y_inline11016_ci(recv_y_inline11016_ci_shapes, 3, DataType::BFLOAT16);
             uint32_t ffn_out_inline10948_ci_shapes[2] = {8, 4096};
@@ -1749,7 +1749,7 @@ void csa_moe_block(const GraphTaskArgs &args, bool route_by_hash) {
             uint32_t recv_x_flat_inline2781_inline11205_shapes[2] = {512, 4096};
             ChipTensor recv_x_flat_inline2781_inline11205 =
                 recv_x_out_inline11043.reshape(recv_x_flat_inline2781_inline11205_shapes, 2);
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 uint32_t h_i8_inline2773_inline11141_ci_shapes[2] = {512, 2048};
                 TensorCreateInfo h_i8_inline2773_inline11141_ci(
                     h_i8_inline2773_inline11141_ci_shapes, 2, DataType::INT8
@@ -1780,7 +1780,7 @@ void csa_moe_block(const GraphTaskArgs &args, bool route_by_hash) {
                         expert_rows_pred.target = t0_inline2784_inline11251;
                         int64_t flat_t0_inline2786_inline11215 =
                             (flat_base_inline2774_inline11027 + t0_inline2784_inline11251);
-                        PTO2_SCOPE() {
+                        SIMPLER_SCOPE() {
                             uint32_t gate_tile_i32_inline2749_inline11102_ci_shapes[2] = {16, 2048};
                             TensorCreateInfo gate_tile_i32_inline2749_inline11102_ci(
                                 gate_tile_i32_inline2749_inline11102_ci_shapes, 2, DataType::INT32
@@ -1891,7 +1891,7 @@ void csa_moe_block(const GraphTaskArgs &args, bool route_by_hash) {
                         }
                     }
                 }
-                PTO2_SCOPE() {
+                SIMPLER_SCOPE() {
                     for (int64_t local_e_inline2742_inline11189 = 0; local_e_inline2742_inline11189 < 32;
                          local_e_inline2742_inline11189 += 1) {
                         int64_t e_flat_base_inline2746_inline11067 = (local_e_inline2742_inline11189 * 16);
@@ -2124,7 +2124,7 @@ void hca_attn_block(const GraphTaskArgs &args) {
     const ChipTensor &swa_indices_inline636 = args.tensor(30).ref();
     const ChipTensor &x_attn_hca_inline723 = args.tensor(31).ref();
     const ChipTensor &hidden_mid_inline726 = args.tensor(32).ref();
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t x_mixed_inline11578_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline11578_ci(x_mixed_inline11578_ci_shapes, 2, DataType::BFLOAT16);
         uint32_t post_t_inline11780_ci_shapes[2] = {8, 4};
@@ -2804,7 +2804,7 @@ void hca_attn_block(const GraphTaskArgs &args) {
         for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
             proj_b_tids_inline1519_inline11335[__init_i] = TaskId::invalid();
         ChipTensor o_r_pad_inline1536_inline11403__rv_v2 = o_r_pad_inline1536_inline11403;
-        PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+        SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
             for (int64_t g_inline1480_inline11801 = 0; g_inline1480_inline11801 < 8; g_inline1480_inline11801 += 1) {
                 int64_t row_base_o_inline1525_inline11698 = (g_inline1480_inline11801 * 8);
                 int64_t out_col_g_inline1609_inline11551 = (g_inline1480_inline11801 * 1024);
@@ -2977,7 +2977,7 @@ void hca_moe_block(const GraphTaskArgs &args) {
     uint64_t recv_aux_ctx = args.scalar(8);
     uint64_t recv_route_ctx = args.scalar(9);
     uint64_t routed_y_buf_ctx = args.scalar(10);
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t x_mixed_inline11928_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline11928_ci(x_mixed_inline11928_ci_shapes, 2, DataType::BFLOAT16);
         uint32_t post_ffn_inline11927_ci_shapes[2] = {8, 4};
@@ -3422,7 +3422,7 @@ void hca_moe_block(const GraphTaskArgs &args) {
         params_t251.set_dependencies(params_t251_deps, params_t251_deps_count);
         TaskOutputTensors task_251_outs = rt_submit_aiv_task(260, params_t251);
         TaskId dispatch_push_tid_inline12124 = _push_tid_inline2710_inline11964;
-        PTO2_SCOPE() {
+        SIMPLER_SCOPE() {
             uint32_t recv_y_inline11895_ci_shapes[3] = {32, 16, 4096};
             TensorCreateInfo recv_y_inline11895_ci(recv_y_inline11895_ci_shapes, 3, DataType::BFLOAT16);
             uint32_t ffn_out_inline11827_ci_shapes[2] = {8, 4096};
@@ -3436,7 +3436,7 @@ void hca_moe_block(const GraphTaskArgs &args) {
             uint32_t recv_x_flat_inline2781_inline12084_shapes[2] = {512, 4096};
             ChipTensor recv_x_flat_inline2781_inline12084 =
                 recv_x_out_inline11922.reshape(recv_x_flat_inline2781_inline12084_shapes, 2);
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 uint32_t h_i8_inline2773_inline12020_ci_shapes[2] = {512, 2048};
                 TensorCreateInfo h_i8_inline2773_inline12020_ci(
                     h_i8_inline2773_inline12020_ci_shapes, 2, DataType::INT8
@@ -3467,7 +3467,7 @@ void hca_moe_block(const GraphTaskArgs &args) {
                         expert_rows_pred.target = t0_inline2784_inline12130;
                         int64_t flat_t0_inline2786_inline12094 =
                             (flat_base_inline2774_inline11906 + t0_inline2784_inline12130);
-                        PTO2_SCOPE() {
+                        SIMPLER_SCOPE() {
                             uint32_t gate_tile_i32_inline2749_inline11981_ci_shapes[2] = {16, 2048};
                             TensorCreateInfo gate_tile_i32_inline2749_inline11981_ci(
                                 gate_tile_i32_inline2749_inline11981_ci_shapes, 2, DataType::INT32
@@ -3578,7 +3578,7 @@ void hca_moe_block(const GraphTaskArgs &args) {
                         }
                     }
                 }
-                PTO2_SCOPE() {
+                SIMPLER_SCOPE() {
                     for (int64_t local_e_inline2742_inline12068 = 0; local_e_inline2742_inline12068 < 32;
                          local_e_inline2742_inline12068 += 1) {
                         int64_t e_flat_base_inline2746_inline11946 = (local_e_inline2742_inline12068 * 16);
@@ -3801,7 +3801,7 @@ void swa_attn_block(const GraphTaskArgs &args) {
     const ChipTensor &wo_b_l0_inline643 = args.tensor(20).ref();
     const ChipTensor &wo_b_scale_l0_inline653 = args.tensor(21).ref();
     const ChipTensor &x_attn0_inline706 = args.tensor(22).ref();
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t x_mixed_inline8888_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline8888_ci(x_mixed_inline8888_ci_shapes, 2, DataType::BFLOAT16);
         uint32_t post_t_inline8947_ci_shapes[2] = {8, 4};
@@ -4315,7 +4315,7 @@ void swa_attn_block(const GraphTaskArgs &args) {
         TaskOutputTensors task_25_outs = rt_submit_aiv_task(26, params_t25);
         TaskId merge_tid_inline1108_inline8902 = task_25_outs.task_id();
         ChipTensor o_r_pad_inline974_inline8862__rv_v2 = o_r_pad_inline974_inline8862;
-        PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+        SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
             for (int64_t g_inline978_inline8746 = 0; g_inline978_inline8746 < 8; g_inline978_inline8746 += 1) {
                 int64_t row_base_o_inline1126_inline8745 = (g_inline978_inline8746 * 8);
                 int64_t out_col_g_inline1092_inline8900 = (g_inline978_inline8746 * 1024);
@@ -4483,7 +4483,7 @@ void hash_moe_l0_block(const GraphTaskArgs &args) {
     uint64_t data_arrived_ctx = args.scalar(7);
     uint64_t routed_y_buf_ctx = args.scalar(8);
     uint64_t combine_arrived_ctx = args.scalar(9);
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t x_mixed_inline9242_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline9242_ci(x_mixed_inline9242_ci_shapes, 2, DataType::BFLOAT16);
         uint32_t post_ffn_inline9241_ci_shapes[2] = {8, 4};
@@ -4916,7 +4916,7 @@ void hash_moe_l0_block(const GraphTaskArgs &args) {
         params_t50.set_dependencies(params_t50_deps, params_t50_deps_count);
         TaskOutputTensors task_50_outs = rt_submit_aiv_task(52, params_t50);
         TaskId dispatch_push_tid_inline9438 = _push_tid_inline2710_inline9278;
-        PTO2_SCOPE() {
+        SIMPLER_SCOPE() {
             uint32_t recv_y_inline9209_ci_shapes[3] = {32, 16, 4096};
             TensorCreateInfo recv_y_inline9209_ci(recv_y_inline9209_ci_shapes, 3, DataType::BFLOAT16);
             uint32_t ffn_out_inline9141_ci_shapes[2] = {8, 4096};
@@ -4930,7 +4930,7 @@ void hash_moe_l0_block(const GraphTaskArgs &args) {
             uint32_t recv_x_flat_inline2781_inline9398_shapes[2] = {512, 4096};
             ChipTensor recv_x_flat_inline2781_inline9398 =
                 recv_x_out_inline9236.reshape(recv_x_flat_inline2781_inline9398_shapes, 2);
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 uint32_t h_i8_inline2773_inline9334_ci_shapes[2] = {512, 2048};
                 TensorCreateInfo h_i8_inline2773_inline9334_ci(h_i8_inline2773_inline9334_ci_shapes, 2, DataType::INT8);
                 uint32_t h_scale_dq_inline2766_inline9425_ci_shapes[2] = {512, 1};
@@ -4959,7 +4959,7 @@ void hash_moe_l0_block(const GraphTaskArgs &args) {
                         expert_rows_pred.target = t0_inline2784_inline9444;
                         int64_t flat_t0_inline2786_inline9408 =
                             (flat_base_inline2774_inline9220 + t0_inline2784_inline9444);
-                        PTO2_SCOPE() {
+                        SIMPLER_SCOPE() {
                             uint32_t gate_tile_i32_inline2749_inline9295_ci_shapes[2] = {16, 2048};
                             TensorCreateInfo gate_tile_i32_inline2749_inline9295_ci(
                                 gate_tile_i32_inline2749_inline9295_ci_shapes, 2, DataType::INT32
@@ -5070,7 +5070,7 @@ void hash_moe_l0_block(const GraphTaskArgs &args) {
                         }
                     }
                 }
-                PTO2_SCOPE() {
+                SIMPLER_SCOPE() {
                     for (int64_t local_e_inline2742_inline9382 = 0; local_e_inline2742_inline9382 < 32;
                          local_e_inline2742_inline9382 += 1) {
                         int64_t e_flat_base_inline2746_inline9260 = (local_e_inline2742_inline9382 * 16);
@@ -5307,7 +5307,7 @@ void hash_moe_l1_block(const GraphTaskArgs &args) {
     uint64_t data_arrived_ctx = args.scalar(7);
     uint64_t routed_y_buf_ctx = args.scalar(8);
     uint64_t combine_arrived_ctx = args.scalar(9);
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t x_mixed_inline10004_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline10004_ci(x_mixed_inline10004_ci_shapes, 2, DataType::BFLOAT16);
         uint32_t post_ffn_inline10003_ci_shapes[2] = {8, 4};
@@ -5746,7 +5746,7 @@ void hash_moe_l1_block(const GraphTaskArgs &args) {
         params_t107.set_dependencies(params_t107_deps, params_t107_deps_count);
         TaskOutputTensors task_107_outs = rt_submit_aiv_task(111, params_t107);
         TaskId dispatch_push_tid_inline10200 = _push_tid_inline2710_inline10040;
-        PTO2_SCOPE() {
+        SIMPLER_SCOPE() {
             uint32_t recv_y_inline9971_ci_shapes[3] = {32, 16, 4096};
             TensorCreateInfo recv_y_inline9971_ci(recv_y_inline9971_ci_shapes, 3, DataType::BFLOAT16);
             uint32_t ffn_out_inline9903_ci_shapes[2] = {8, 4096};
@@ -5760,7 +5760,7 @@ void hash_moe_l1_block(const GraphTaskArgs &args) {
             uint32_t recv_x_flat_inline2781_inline10160_shapes[2] = {512, 4096};
             ChipTensor recv_x_flat_inline2781_inline10160 =
                 recv_x_out_inline9998.reshape(recv_x_flat_inline2781_inline10160_shapes, 2);
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 uint32_t h_i8_inline2773_inline10096_ci_shapes[2] = {512, 2048};
                 TensorCreateInfo h_i8_inline2773_inline10096_ci(
                     h_i8_inline2773_inline10096_ci_shapes, 2, DataType::INT8
@@ -5791,7 +5791,7 @@ void hash_moe_l1_block(const GraphTaskArgs &args) {
                         expert_rows_pred.target = t0_inline2784_inline10206;
                         int64_t flat_t0_inline2786_inline10170 =
                             (flat_base_inline2774_inline9982 + t0_inline2784_inline10206);
-                        PTO2_SCOPE() {
+                        SIMPLER_SCOPE() {
                             uint32_t gate_tile_i32_inline2749_inline10057_ci_shapes[2] = {16, 2048};
                             TensorCreateInfo gate_tile_i32_inline2749_inline10057_ci(
                                 gate_tile_i32_inline2749_inline10057_ci_shapes, 2, DataType::INT32
@@ -5902,7 +5902,7 @@ void hash_moe_l1_block(const GraphTaskArgs &args) {
                         }
                     }
                 }
-                PTO2_SCOPE() {
+                SIMPLER_SCOPE() {
                     for (int64_t local_e_inline2742_inline10144 = 0; local_e_inline2742_inline10144 < 32;
                          local_e_inline2742_inline10144 += 1) {
                         int64_t e_flat_base_inline2746_inline10022 = (local_e_inline2742_inline10144 * 16);
@@ -8584,7 +8584,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     params_t341.add_scalar(data_arrived_ctx);
     params_t341.add_scalar(combine_arrived_ctx);
     rt_submit_aiv_task(353, params_t341);
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t selected_hidden_inline51_inline13294_ci_shapes[2] = {8, 4096};
         TensorCreateInfo selected_hidden_inline51_inline13294_ci(
             selected_hidden_inline51_inline13294_ci_shapes, 2, DataType::BFLOAT16

--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd_graph.cpp
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd_graph.cpp
@@ -30,10 +30,9 @@ constexpr int32_t EXPERT_ROWS_BUDGET = 16;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 105,
     };
 }

--- a/examples/a2a3/host_build_graph/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
+++ b/examples/a2a3/host_build_graph/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
@@ -60,10 +60,9 @@ private:
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 20,
     };
 }

--- a/examples/a2a3/host_build_graph/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
+++ b/examples/a2a3/host_build_graph/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
@@ -94,7 +94,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     int64_t BLOCK_TABLE_FLAT_DYN = (int64_t)orch_args.tensor(8).ref().shapes[0];
     int64_t KV_CACHE_ROWS_DYN = (int64_t)orch_args.tensor(12).ref().shapes[0];
 
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t pa_metadata_ci_shapes[1] = {27840};
         TensorCreateInfo pa_metadata_ci(pa_metadata_ci_shapes, 1, DataType::UINT8);
         uint32_t pa_workspace_ci_shapes[1] = {66132544};
@@ -135,7 +135,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         TaskId t = phase_fence_barrier_0_outs.task_id();
         prev_out_tid[0] = t;
         for (int64_t cb0 = 0; cb0 < 16; cb0 += 16) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 // Task 1: copy_hidden
                 CoreTaskArgs params_t1;
                 params_t1.add_output(cur);
@@ -149,7 +149,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         TaskId prev_normed_tid[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
             prev_normed_tid[__init_i] = TaskId::invalid();
-        PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+        SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
             TaskId _submit_deps_buf[1];
             for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
                 _submit_deps_buf[__init_i] = TaskId::invalid();
@@ -188,7 +188,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             next_hidden_ci, next_normed_ci, next_hidden_ci, next_normed_ci, bf16_scratch_ci, fp32_scratch_ci
         );
         for (uint32_t layer = 0; layer < num_layers; layer += 1) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 const uint32_t storage_base = (layer % 2) * 2;
                 const ChipTensor &next_hidden = layer_storage.get_ref(storage_base);
                 const ChipTensor &next_normed = layer_storage.get_ref(storage_base + 1);
@@ -335,7 +335,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     TaskId down_tids_inline156[85];
                     for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
                         down_tids_inline156[__init_i] = TaskId::invalid();
-                    PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+                    SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
                         // Phase-fence barrier 1: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_1;
                         TaskOutputTensors phase_fence_barrier_1_outs =
@@ -2071,7 +2071,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             }
         }
         for (int64_t ob0 = 0; ob0 < 16; ob0 += 16) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 // Task 35: copy_out
                 CoreTaskArgs params_t35;
                 params_t35.add_output(ext_out);

--- a/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -37,10 +37,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 4,
     };
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -78,7 +78,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     // A/B layout: [num_groups, grid_k, incore_loop, tile_size, tile_size]
     // C layout:   [incore_loop * num_groups, tile_size, tile_size]
     for (int group_idx = 0; group_idx < num_groups; group_idx++) {
-        PTO2_SCOPE_GUARD();
+        SIMPLER_SCOPE_GUARD();
 
         uint32_t c_elem_offset = static_cast<uint32_t>(static_cast<uint64_t>(group_idx) * group_tile_elems);
         uint32_t c_view_offsets[1] = {c_elem_offset};

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd.cpp
@@ -30,10 +30,9 @@ constexpr int32_t EXPERT_ROWS_BUDGET = 16;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 105,
     };
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd.cpp
@@ -1061,7 +1061,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     };
     ChipTensor shared_w2_scale_l1_inline702 =
         ext_shared_w2_scale.view(shared_w2_scale_l1_inline702_shapes, shared_w2_scale_l1_inline702_offsets);
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t x_mixed_inline8888_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline8888_ci(x_mixed_inline8888_ci_shapes, 2, DataType::BFLOAT16);
         uint32_t post_t_inline8947_ci_shapes[2] = {8, 4};
@@ -1575,7 +1575,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         TaskOutputTensors task_25_outs = rt_submit_aiv_task(26, params_t25);
         TaskId merge_tid_inline1108_inline8902 = task_25_outs.task_id();
         ChipTensor o_r_pad_inline974_inline8862__rv_v2 = o_r_pad_inline974_inline8862;
-        PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+        SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
             for (int64_t g_inline978_inline8746 = 0; g_inline978_inline8746 < 8; g_inline978_inline8746 += 1) {
                 int64_t row_base_o_inline1126_inline8745 = (g_inline978_inline8746 * 8);
                 int64_t out_col_g_inline1092_inline8900 = (g_inline978_inline8746 * 1024);
@@ -1700,7 +1700,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t30.launch_spec.set_block_num(((t_dim_inline1140_inline8710 / 4) * 4));
         rt_submit_aiv_task(31, params_t30);
     }
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t x_mixed_inline9242_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline9242_ci(x_mixed_inline9242_ci_shapes, 2, DataType::BFLOAT16);
         uint32_t post_ffn_inline9241_ci_shapes[2] = {8, 4};
@@ -2133,7 +2133,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t50.set_dependencies(params_t50_deps, params_t50_deps_count);
         TaskOutputTensors task_50_outs = rt_submit_aiv_task(52, params_t50);
         TaskId dispatch_push_tid_inline9438 = _push_tid_inline2710_inline9278;
-        PTO2_SCOPE() {
+        SIMPLER_SCOPE() {
             uint32_t recv_y_inline9209_ci_shapes[3] = {32, 16, 4096};
             TensorCreateInfo recv_y_inline9209_ci(recv_y_inline9209_ci_shapes, 3, DataType::BFLOAT16);
             uint32_t ffn_out_inline9141_ci_shapes[2] = {8, 4096};
@@ -2147,7 +2147,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             uint32_t recv_x_flat_inline2781_inline9398_shapes[2] = {512, 4096};
             ChipTensor recv_x_flat_inline2781_inline9398 =
                 recv_x_out_inline9236.reshape(recv_x_flat_inline2781_inline9398_shapes, 2);
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 uint32_t h_i8_inline2773_inline9334_ci_shapes[2] = {512, 2048};
                 TensorCreateInfo h_i8_inline2773_inline9334_ci(h_i8_inline2773_inline9334_ci_shapes, 2, DataType::INT8);
                 uint32_t h_scale_dq_inline2766_inline9425_ci_shapes[2] = {512, 1};
@@ -2176,7 +2176,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         expert_rows_pred.target = t0_inline2784_inline9444;
                         int64_t flat_t0_inline2786_inline9408 =
                             (flat_base_inline2774_inline9220 + t0_inline2784_inline9444);
-                        PTO2_SCOPE() {
+                        SIMPLER_SCOPE() {
                             uint32_t gate_tile_i32_inline2749_inline9295_ci_shapes[2] = {16, 2048};
                             TensorCreateInfo gate_tile_i32_inline2749_inline9295_ci(
                                 gate_tile_i32_inline2749_inline9295_ci_shapes, 2, DataType::INT32
@@ -2287,7 +2287,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         }
                     }
                 }
-                PTO2_SCOPE() {
+                SIMPLER_SCOPE() {
                     for (int64_t local_e_inline2742_inline9382 = 0; local_e_inline2742_inline9382 < 32;
                          local_e_inline2742_inline9382 += 1) {
                         int64_t e_flat_base_inline2746_inline9260 = (local_e_inline2742_inline9382 * 16);
@@ -2481,7 +2481,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             rt_submit_aiv_task(62, params_t60);
         }
     }
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t x_mixed_inline9650_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline9650_ci(x_mixed_inline9650_ci_shapes, 2, DataType::BFLOAT16);
         uint32_t post_t_inline9709_ci_shapes[2] = {8, 4};
@@ -2995,7 +2995,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         TaskOutputTensors task_82_outs = rt_submit_aiv_task(85, params_t82);
         TaskId merge_tid_inline1108_inline9664 = task_82_outs.task_id();
         ChipTensor o_r_pad_inline974_inline9624__rv_v2 = o_r_pad_inline974_inline9624;
-        PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+        SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
             for (int64_t g_inline978_inline9508 = 0; g_inline978_inline9508 < 8; g_inline978_inline9508 += 1) {
                 int64_t row_base_o_inline1126_inline9507 = (g_inline978_inline9508 * 8);
                 int64_t out_col_g_inline1092_inline9662 = (g_inline978_inline9508 * 1024);
@@ -3120,7 +3120,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t87.launch_spec.set_block_num(((t_dim_inline1140_inline9472 / 4) * 4));
         rt_submit_aiv_task(90, params_t87);
     }
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t x_mixed_inline10004_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline10004_ci(x_mixed_inline10004_ci_shapes, 2, DataType::BFLOAT16);
         uint32_t post_ffn_inline10003_ci_shapes[2] = {8, 4};
@@ -3559,7 +3559,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t107.set_dependencies(params_t107_deps, params_t107_deps_count);
         TaskOutputTensors task_107_outs = rt_submit_aiv_task(111, params_t107);
         TaskId dispatch_push_tid_inline10200 = _push_tid_inline2710_inline10040;
-        PTO2_SCOPE() {
+        SIMPLER_SCOPE() {
             uint32_t recv_y_inline9971_ci_shapes[3] = {32, 16, 4096};
             TensorCreateInfo recv_y_inline9971_ci(recv_y_inline9971_ci_shapes, 3, DataType::BFLOAT16);
             uint32_t ffn_out_inline9903_ci_shapes[2] = {8, 4096};
@@ -3573,7 +3573,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             uint32_t recv_x_flat_inline2781_inline10160_shapes[2] = {512, 4096};
             ChipTensor recv_x_flat_inline2781_inline10160 =
                 recv_x_out_inline9998.reshape(recv_x_flat_inline2781_inline10160_shapes, 2);
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 uint32_t h_i8_inline2773_inline10096_ci_shapes[2] = {512, 2048};
                 TensorCreateInfo h_i8_inline2773_inline10096_ci(
                     h_i8_inline2773_inline10096_ci_shapes, 2, DataType::INT8
@@ -3604,7 +3604,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         expert_rows_pred.target = t0_inline2784_inline10206;
                         int64_t flat_t0_inline2786_inline10170 =
                             (flat_base_inline2774_inline9982 + t0_inline2784_inline10206);
-                        PTO2_SCOPE() {
+                        SIMPLER_SCOPE() {
                             uint32_t gate_tile_i32_inline2749_inline10057_ci_shapes[2] = {16, 2048};
                             TensorCreateInfo gate_tile_i32_inline2749_inline10057_ci(
                                 gate_tile_i32_inline2749_inline10057_ci_shapes, 2, DataType::INT32
@@ -3715,7 +3715,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         }
                     }
                 }
-                PTO2_SCOPE() {
+                SIMPLER_SCOPE() {
                     for (int64_t local_e_inline2742_inline10144 = 0; local_e_inline2742_inline10144 < 32;
                          local_e_inline2742_inline10144 += 1) {
                         int64_t e_flat_base_inline2746_inline10022 = (local_e_inline2742_inline10144 * 16);
@@ -4571,7 +4571,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         };
         ChipTensor shared_w2_scale_csa_inline708 =
             ext_shared_w2_scale.view(shared_w2_scale_csa_inline708_shapes, shared_w2_scale_csa_inline708_offsets);
-        PTO2_SCOPE() {
+        SIMPLER_SCOPE() {
             uint32_t x_mixed_inline10524_ci_shapes[2] = {8, 4096};
             TensorCreateInfo x_mixed_inline10524_ci(x_mixed_inline10524_ci_shapes, 2, DataType::BFLOAT16);
             uint32_t post_t_inline10558_ci_shapes[2] = {8, 4};
@@ -5590,7 +5590,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
                 proj_b_tids_inline2079_inline10609[__init_i] = TaskId::invalid();
             ChipTensor o_r_pad_inline2225_inline10832__rv_v2 = o_r_pad_inline2225_inline10832;
-            PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+            SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
                 for (int64_t g_inline2162_inline10271 = 0; g_inline2162_inline10271 < 8;
                      g_inline2162_inline10271 += 1) {
                     int64_t row_base_o_inline2078_inline10745 = (g_inline2162_inline10271 * 8);
@@ -5719,7 +5719,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t166.launch_spec.set_block_num(((t_dim_inline2270_inline10388 / 4) * 4));
             rt_submit_aiv_task(172, params_t166);
         }
-        PTO2_SCOPE() {
+        SIMPLER_SCOPE() {
             uint32_t x_mixed_inline11049_ci_shapes[2] = {8, 4096};
             TensorCreateInfo x_mixed_inline11049_ci(x_mixed_inline11049_ci_shapes, 2, DataType::BFLOAT16);
             uint32_t post_ffn_inline11048_ci_shapes[2] = {8, 4};
@@ -6182,7 +6182,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t187.set_dependencies(params_t187_deps, params_t187_deps_count);
             TaskOutputTensors task_187_outs = rt_submit_aiv_task(194, params_t187);
             TaskId dispatch_push_tid_inline11245 = _push_tid_inline2710_inline11085;
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 uint32_t recv_y_inline11016_ci_shapes[3] = {32, 16, 4096};
                 TensorCreateInfo recv_y_inline11016_ci(recv_y_inline11016_ci_shapes, 3, DataType::BFLOAT16);
                 uint32_t ffn_out_inline10948_ci_shapes[2] = {8, 4096};
@@ -6196,7 +6196,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 uint32_t recv_x_flat_inline2781_inline11205_shapes[2] = {512, 4096};
                 ChipTensor recv_x_flat_inline2781_inline11205 =
                     recv_x_out_inline11043.reshape(recv_x_flat_inline2781_inline11205_shapes, 2);
-                PTO2_SCOPE() {
+                SIMPLER_SCOPE() {
                     uint32_t h_i8_inline2773_inline11141_ci_shapes[2] = {512, 2048};
                     TensorCreateInfo h_i8_inline2773_inline11141_ci(
                         h_i8_inline2773_inline11141_ci_shapes, 2, DataType::INT8
@@ -6227,7 +6227,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             expert_rows_pred.target = t0_inline2784_inline11251;
                             int64_t flat_t0_inline2786_inline11215 =
                                 (flat_base_inline2774_inline11027 + t0_inline2784_inline11251);
-                            PTO2_SCOPE() {
+                            SIMPLER_SCOPE() {
                                 uint32_t gate_tile_i32_inline2749_inline11102_ci_shapes[2] = {16, 2048};
                                 TensorCreateInfo gate_tile_i32_inline2749_inline11102_ci(
                                     gate_tile_i32_inline2749_inline11102_ci_shapes, 2, DataType::INT32
@@ -6341,7 +6341,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             }
                         }
                     }
-                    PTO2_SCOPE() {
+                    SIMPLER_SCOPE() {
                         for (int64_t local_e_inline2742_inline11189 = 0; local_e_inline2742_inline11189 < 32;
                              local_e_inline2742_inline11189 += 1) {
                             int64_t e_flat_base_inline2746_inline11067 = (local_e_inline2742_inline11189 * 16);
@@ -7035,7 +7035,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         };
         ChipTensor shared_w2_scale_hca_inline523 =
             ext_shared_w2_scale.view(shared_w2_scale_hca_inline523_shapes, shared_w2_scale_hca_inline523_offsets);
-        PTO2_SCOPE() {
+        SIMPLER_SCOPE() {
             uint32_t x_mixed_inline11578_ci_shapes[2] = {8, 4096};
             TensorCreateInfo x_mixed_inline11578_ci(x_mixed_inline11578_ci_shapes, 2, DataType::BFLOAT16);
             uint32_t post_t_inline11780_ci_shapes[2] = {8, 4};
@@ -7732,7 +7732,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
                 proj_b_tids_inline1519_inline11335[__init_i] = TaskId::invalid();
             ChipTensor o_r_pad_inline1536_inline11403__rv_v2 = o_r_pad_inline1536_inline11403;
-            PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+            SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
                 for (int64_t g_inline1480_inline11801 = 0; g_inline1480_inline11801 < 8;
                      g_inline1480_inline11801 += 1) {
                     int64_t row_base_o_inline1525_inline11698 = (g_inline1480_inline11801 * 8);
@@ -7861,7 +7861,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t231.launch_spec.set_block_num(((t_dim_inline1623_inline11547 / 4) * 4));
             rt_submit_aiv_task(239, params_t231);
         }
-        PTO2_SCOPE() {
+        SIMPLER_SCOPE() {
             uint32_t x_mixed_inline11928_ci_shapes[2] = {8, 4096};
             TensorCreateInfo x_mixed_inline11928_ci(x_mixed_inline11928_ci_shapes, 2, DataType::BFLOAT16);
             uint32_t post_ffn_inline11927_ci_shapes[2] = {8, 4};
@@ -8310,7 +8310,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_t251.set_dependencies(params_t251_deps, params_t251_deps_count);
             TaskOutputTensors task_251_outs = rt_submit_aiv_task(260, params_t251);
             TaskId dispatch_push_tid_inline12124 = _push_tid_inline2710_inline11964;
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 uint32_t recv_y_inline11895_ci_shapes[3] = {32, 16, 4096};
                 TensorCreateInfo recv_y_inline11895_ci(recv_y_inline11895_ci_shapes, 3, DataType::BFLOAT16);
                 uint32_t ffn_out_inline11827_ci_shapes[2] = {8, 4096};
@@ -8324,7 +8324,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 uint32_t recv_x_flat_inline2781_inline12084_shapes[2] = {512, 4096};
                 ChipTensor recv_x_flat_inline2781_inline12084 =
                     recv_x_out_inline11922.reshape(recv_x_flat_inline2781_inline12084_shapes, 2);
-                PTO2_SCOPE() {
+                SIMPLER_SCOPE() {
                     uint32_t h_i8_inline2773_inline12020_ci_shapes[2] = {512, 2048};
                     TensorCreateInfo h_i8_inline2773_inline12020_ci(
                         h_i8_inline2773_inline12020_ci_shapes, 2, DataType::INT8
@@ -8355,7 +8355,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             expert_rows_pred.target = t0_inline2784_inline12130;
                             int64_t flat_t0_inline2786_inline12094 =
                                 (flat_base_inline2774_inline11906 + t0_inline2784_inline12130);
-                            PTO2_SCOPE() {
+                            SIMPLER_SCOPE() {
                                 uint32_t gate_tile_i32_inline2749_inline11981_ci_shapes[2] = {16, 2048};
                                 TensorCreateInfo gate_tile_i32_inline2749_inline11981_ci(
                                     gate_tile_i32_inline2749_inline11981_ci_shapes, 2, DataType::INT32
@@ -8469,7 +8469,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                             }
                         }
                     }
-                    PTO2_SCOPE() {
+                    SIMPLER_SCOPE() {
                         for (int64_t local_e_inline2742_inline12068 = 0; local_e_inline2742_inline12068 < 32;
                              local_e_inline2742_inline12068 += 1) {
                             int64_t e_flat_base_inline2746_inline11946 = (local_e_inline2742_inline12068 * 16);
@@ -9309,7 +9309,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     };
     ChipTensor shared_w2_scale_last_inline549 =
         ext_shared_w2_scale.view(shared_w2_scale_last_inline549_shapes, shared_w2_scale_last_inline549_offsets);
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t x_mixed_inline12448_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline12448_ci(x_mixed_inline12448_ci_shapes, 2, DataType::BFLOAT16);
         uint32_t post_t_inline12482_ci_shapes[2] = {8, 4};
@@ -10306,7 +10306,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         for (int64_t __init_i = 0; __init_i < 8; ++__init_i)
             proj_b_tids_inline2079_inline12533[__init_i] = TaskId::invalid();
         ChipTensor o_r_pad_inline2225_inline12756__rv_v2 = o_r_pad_inline2225_inline12756;
-        PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+        SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
             for (int64_t g_inline2162_inline12195 = 0; g_inline2162_inline12195 < 8; g_inline2162_inline12195 += 1) {
                 int64_t row_base_o_inline2078_inline12669 = (g_inline2162_inline12195 * 8);
                 int64_t out_col_g_inline2181_inline12363 = (g_inline2162_inline12195 * 1024);
@@ -10432,7 +10432,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t310.launch_spec.set_block_num(((t_dim_inline2270_inline12312 / 4) * 4));
         rt_submit_aiv_task(321, params_t310);
     }
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t x_mixed_inline12973_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline12973_ci(x_mixed_inline12973_ci_shapes, 2, DataType::BFLOAT16);
         uint32_t post_ffn_inline12972_ci_shapes[2] = {8, 4};
@@ -10873,7 +10873,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t330.set_dependencies(params_t330_deps, params_t330_deps_count);
         TaskOutputTensors task_330_outs = rt_submit_aiv_task(342, params_t330);
         TaskId dispatch_push_tid_inline13169 = _push_tid_inline2710_inline13009;
-        PTO2_SCOPE() {
+        SIMPLER_SCOPE() {
             uint32_t recv_y_inline12940_ci_shapes[3] = {32, 16, 4096};
             TensorCreateInfo recv_y_inline12940_ci(recv_y_inline12940_ci_shapes, 3, DataType::BFLOAT16);
             uint32_t ffn_out_inline12872_ci_shapes[2] = {8, 4096};
@@ -10887,7 +10887,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             uint32_t recv_x_flat_inline2781_inline13129_shapes[2] = {512, 4096};
             ChipTensor recv_x_flat_inline2781_inline13129 =
                 recv_x_out_inline12967.reshape(recv_x_flat_inline2781_inline13129_shapes, 2);
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 uint32_t h_i8_inline2773_inline13065_ci_shapes[2] = {512, 2048};
                 TensorCreateInfo h_i8_inline2773_inline13065_ci(
                     h_i8_inline2773_inline13065_ci_shapes, 2, DataType::INT8
@@ -10918,7 +10918,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         expert_rows_pred.target = t0_inline2784_inline13175;
                         int64_t flat_t0_inline2786_inline13139 =
                             (flat_base_inline2774_inline12951 + t0_inline2784_inline13175);
-                        PTO2_SCOPE() {
+                        SIMPLER_SCOPE() {
                             uint32_t gate_tile_i32_inline2749_inline13026_ci_shapes[2] = {16, 2048};
                             TensorCreateInfo gate_tile_i32_inline2749_inline13026_ci(
                                 gate_tile_i32_inline2749_inline13026_ci_shapes, 2, DataType::INT32
@@ -11029,7 +11029,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         }
                     }
                 }
-                PTO2_SCOPE() {
+                SIMPLER_SCOPE() {
                     for (int64_t local_e_inline2742_inline13113 = 0; local_e_inline2742_inline13113 < 32;
                          local_e_inline2742_inline13113 += 1) {
                         int64_t e_flat_base_inline2746_inline12991 = (local_e_inline2742_inline13113 * 16);
@@ -11237,7 +11237,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     params_t341.add_scalar(data_arrived_ctx);
     params_t341.add_scalar(combine_arrived_ctx);
     rt_submit_aiv_task(353, params_t341);
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t selected_hidden_inline51_inline13294_ci_shapes[2] = {8, 4096};
         TensorCreateInfo selected_hidden_inline51_inline13294_ci(
             selected_hidden_inline51_inline13294_ci_shapes, 2, DataType::BFLOAT16

--- a/examples/a2a3/tensormap_and_ringbuffer/docs/INCORE_ORCHESTRATION_GUIDE.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/docs/INCORE_ORCHESTRATION_GUIDE.md
@@ -32,7 +32,7 @@ Validate `arg_count` in `aicpu_orchestration_config` and interpret pointers as d
 
 ## Building The Graph
 
-1. Wrap orchestration in scopes with `PTO2_SCOPE()` to control tensor lifetimes.
+1. Wrap orchestration in scopes with `SIMPLER_SCOPE()` to control tensor lifetimes.
 2. Use `make_tensor_external` for existing device buffers and `TensorCreateInfo` + `add_output(...)` for runtime-created intermediates.
 3. Use `add_inout(...)` for existing tensors that a kernel writes.
 4. Build `CoreTaskArgs` with `add_input`, `add_output`, `add_inout` for tensors and `add_scalar` for scalars.

--- a/examples/a2a3/tensormap_and_ringbuffer/docs/INCORE_ORCHESTRATION_GUIDE.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/docs/INCORE_ORCHESTRATION_GUIDE.md
@@ -14,7 +14,7 @@ In tensormap_and_ringbuffer, the orchestration function runs on AICPU and builds
 Your orchestration shared object must export:
 
 ```cpp
-extern "C" PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args);
+extern "C" OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args);
 extern "C" void aicpu_orchestration_entry(const ChipTaskArgs &orch_args);
 ```
 

--- a/examples/a2a3/tensormap_and_ringbuffer/merge_pipeline_barrier/kernels/orchestration/merge_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/merge_pipeline_barrier/kernels/orchestration/merge_orch.cpp
@@ -21,10 +21,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 4};
+    return OrchestrationConfig{.expected_arg_count = 4};
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/README.md
@@ -14,8 +14,8 @@ Per (batch, head) and per KV block, the orchestration submits four tasks:
 | `PV` | AIC | `P @ V` |
 | `UP` | AIV | online-softmax accumulation into the running output |
 
-Ordering is **not written down**. The tasks sit inside a plain `PTO2_SCOPE()`
-with a `PTO2_SCOPE_GUARD()`, and TensorMap derives `QK → SF → PV → UP` from the
+Ordering is **not written down**. The tasks sit inside a plain `SIMPLER_SCOPE()`
+with a `SIMPLER_SCOPE_GUARD()`, and TensorMap derives `QK → SF → PV → UP` from the
 tensors they share. That is the whole point of the baseline: the dependency
 graph is a consequence of the data, not of the code.
 

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -66,10 +66,9 @@ inline uint64_t get_sys_cnt_aicpu() {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -153,7 +153,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         uint64_t cur_seq = static_cast<uint64_t>(get_tensor_data<int32_t>(context_lens, 1, cl_idx));
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 CYCLE_COUNT_LAP(prof_scope);
                 uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
 
@@ -173,7 +173,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 CYCLE_COUNT_LAP(prof_submit_task);
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn++) {
-                    PTO2_SCOPE_GUARD();
+                    SIMPLER_SCOPE_GUARD();
 
                     uint32_t bt_idx[2] = {static_cast<uint32_t>(b_idx), static_cast<uint32_t>(bn)};
                     uint64_t cur_block_idx = static_cast<uint64_t>(get_tensor_data<int32_t>(block_table, 2, bt_idx));

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/README.md
@@ -15,7 +15,7 @@ diff -r ../paged_attention/kernels ./kernels     # only the orch file differs
 
 ## What changes
 
-`PTO2_SCOPE()` + `PTO2_SCOPE_GUARD()` becomes `PTO2_SCOPE(PTO2ScopeMode::MANUAL)`,
+`SIMPLER_SCOPE()` + `SIMPLER_SCOPE_GUARD()` becomes `SIMPLER_SCOPE(PTO2ScopeMode::MANUAL)`,
 and each submit names its predecessors. See
 [`docs/manual-scope.md`](../../../../docs/manual-scope.md) for the mode itself.
 

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -62,10 +62,9 @@ inline uint64_t get_sys_cnt_aicpu() {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -13,7 +13,7 @@
  *
  * Matches the small-case paged_attention orchestration shape while replacing
  * the automatic same-scope dependency wiring with explicit task-to-task deps
- * inside PTO2_SCOPE(PTO2ScopeMode::MANUAL).
+ * inside SIMPLER_SCOPE(PTO2ScopeMode::MANUAL).
  */
 
 #include <algorithm>
@@ -149,7 +149,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         uint64_t cur_seq = static_cast<uint64_t>(get_tensor_data<int32_t>(context_lens, 1, cl_idx));
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
-            PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+            SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
                 CYCLE_COUNT_LAP(prof_scope);
                 uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
 

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/README.md
@@ -37,7 +37,7 @@ rewritten rather than adjusted.
 **64**.
 
 Dependencies are declared explicitly inside
-`PTO2_SCOPE(PTO2ScopeMode::MANUAL)`, using the primitive
+`SIMPLER_SCOPE(PTO2ScopeMode::MANUAL)`, using the primitive
 `set_dependencies(deps, n)` form throughout —
 [`../paged_attention_manual_scope/`](../paged_attention_manual_scope/) is the
 directory to read for that API on its own, against unchanged kernels.

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -65,10 +65,9 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -157,7 +157,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
             CYCLE_COUNT_LAP(prof_scope_and_loop);
-            PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+            SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
                 uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
 
                 uint32_t qi_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};

--- a/examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo/kernels/orchestration/prefetch_async_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo/kernels/orchestration/prefetch_async_orch.cpp
@@ -22,14 +22,13 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 prefetch_async_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 2};
+    return OrchestrationConfig{.expected_arg_count = 2};
 }
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     return prefetch_async_orchestration_config(orch_args);
 }
 

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
@@ -56,7 +56,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     int64_t BLOCK_TABLE_FLAT_DYN = (int64_t)orch_args.tensor(8).ref().shapes[0];
     int64_t KV_CACHE_ROWS_DYN = (int64_t)orch_args.tensor(12).ref().shapes[0];
 
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t pa_metadata_ci_shapes[1] = {27840};
         TensorCreateInfo pa_metadata_ci(pa_metadata_ci_shapes, 1, DataType::UINT8);
         uint32_t pa_workspace_ci_shapes[1] = {66132544};
@@ -97,7 +97,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         TaskId t = phase_fence_barrier_0_outs.task_id();
         prev_out_tid[0] = t;
         for (int64_t cb0 = 0; cb0 < 16; cb0 += 16) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 // Task 1: copy_hidden
                 CoreTaskArgs params_t1;
                 params_t1.add_output(cur);
@@ -111,7 +111,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         TaskId prev_normed_tid[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
             prev_normed_tid[__init_i] = TaskId::invalid();
-        PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+        SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
             TaskId _submit_deps_buf[1];
             for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
                 _submit_deps_buf[__init_i] = TaskId::invalid();
@@ -136,7 +136,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         ChipTensor cur__rv_v7 = cur;
         ChipTensor normed__rv_v5 = normed;
         for (int64_t i = 0; i < 40; i += 1) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 uint32_t next_hidden_ci_shapes[2] = {16, 5120};
                 TensorCreateInfo next_hidden_ci(next_hidden_ci_shapes, 2, DataType::FLOAT32);
                 uint32_t next_normed_ci_shapes[2] = {16, 5120};
@@ -228,7 +228,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 const ChipTensor &mlp_norm_in_inline71 = alloc_2.get_ref(5);
                 const ChipTensor &inv_rms_tile_inline126 = alloc_2.get_ref(6);
                 const ChipTensor &mlp_tile_inline149 = alloc_2.get_ref(7);
-                PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+                SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
                     // Phase-fence barrier 1: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_1;
                     TaskOutputTensors phase_fence_barrier_1_outs = rt_submit_dummy_task(params_phase_fence_barrier_1);
@@ -1965,7 +1965,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             }
         }
         for (int64_t ob0 = 0; ob0 < 16; ob0 += 16) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 // Task 35: copy_out
                 CoreTaskArgs params_t35;
                 params_t35.add_output(ext_out);

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
@@ -22,10 +22,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 20,
     };
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/scalar_data/kernels/orchestration/scalar_data_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/scalar_data/kernels/orchestration/scalar_data_orch.cpp
@@ -40,10 +40,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 4,  // a, b, result, check
     };
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/orchestration/sdma_async_completion_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/orchestration/sdma_async_completion_orch.cpp
@@ -16,14 +16,13 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 sdma_async_completion_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 4};
+    return OrchestrationConfig{.expected_arg_count = 4};
 }
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     return sdma_async_completion_orchestration_config(orch_args);
 }
 

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -48,7 +48,7 @@ __attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_c
 
 /**
  * Orchestration entry — runtime is bound implicitly by the framework.
- * The executor wraps this call in PTO2_SCOPE, so we are already inside
+ * The executor wraps this call in SIMPLER_SCOPE, so we are already inside
  * the outer scope on entry.
  */
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
@@ -73,7 +73,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     // Inner scope: owns t1, t2, t3, t4; intermediates d, e, g release on scope end.
     // c flows in from outer scope (outer-scope tensors are visible to inner scopes).
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         // t1: d = c + 1 (kernel_id=1, kernel_add_scalar)
         CoreTaskArgs params_t1;
         params_t1.add_input(c);

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -25,7 +25,7 @@
  *   - c flows from outer to inner scope (outer-scope tensors are visible to inner scopes)
  *
  * This file compiles as a standalone .so with zero runtime link dependencies.
- * All runtime calls go through the PTO2RuntimeOps function-pointer table.
+ * All runtime calls go through the RuntimeOps function-pointer table.
  */
 
 #include <stddef.h>

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -39,10 +39,9 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/examples/a5/host_build_graph/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
+++ b/examples/a5/host_build_graph/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
@@ -60,10 +60,9 @@ private:
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 20,
     };
 }

--- a/examples/a5/host_build_graph/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
+++ b/examples/a5/host_build_graph/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
@@ -94,7 +94,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     int64_t BLOCK_TABLE_FLAT_DYN = (int64_t)orch_args.tensor(8).ref().shapes[0];
     int64_t KV_CACHE_ROWS_DYN = (int64_t)orch_args.tensor(12).ref().shapes[0];
 
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t pa_metadata_ci_shapes[1] = {27840};
         TensorCreateInfo pa_metadata_ci(pa_metadata_ci_shapes, 1, DataType::UINT8);
         uint32_t pa_workspace_ci_shapes[1] = {66132544};
@@ -135,7 +135,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         TaskId t = phase_fence_barrier_0_outs.task_id();
         prev_out_tid[0] = t;
         for (int64_t cb0 = 0; cb0 < 16; cb0 += 16) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 // Task 1: copy_hidden
                 CoreTaskArgs params_t1;
                 params_t1.add_output(cur);
@@ -149,7 +149,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         TaskId prev_normed_tid[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
             prev_normed_tid[__init_i] = TaskId::invalid();
-        PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+        SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
             TaskId _submit_deps_buf[1];
             for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
                 _submit_deps_buf[__init_i] = TaskId::invalid();
@@ -188,7 +188,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             next_hidden_ci, next_normed_ci, next_hidden_ci, next_normed_ci, bf16_scratch_ci, fp32_scratch_ci
         );
         for (uint32_t layer = 0; layer < num_layers; layer += 1) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 const uint32_t storage_base = (layer % 2) * 2;
                 const ChipTensor &next_hidden = layer_storage.get_ref(storage_base);
                 const ChipTensor &next_normed = layer_storage.get_ref(storage_base + 1);
@@ -335,7 +335,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     TaskId down_tids_inline156[85];
                     for (int64_t __init_i = 0; __init_i < 85; ++__init_i)
                         down_tids_inline156[__init_i] = TaskId::invalid();
-                    PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+                    SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
                         // Phase-fence barrier 1: dependency-only dummy task
                         CoreTaskArgs params_phase_fence_barrier_1;
                         TaskOutputTensors phase_fence_barrier_1_outs =
@@ -2071,7 +2071,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             }
         }
         for (int64_t ob0 = 0; ob0 < 16; ob0 += 16) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 // Task 35: copy_out
                 CoreTaskArgs params_t35;
                 params_t35.add_output(ext_out);

--- a/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -58,7 +58,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     int total_add = 0;
 
     for (int group_idx = 0; group_idx < num_groups; group_idx++) {
-        PTO2_SCOPE_GUARD();
+        SIMPLER_SCOPE_GUARD();
 
         uint32_t c_elem_offset = static_cast<uint32_t>(static_cast<uint64_t>(group_idx) * group_tile_elems);
         uint32_t c_view_offsets[1] = {c_elem_offset};

--- a/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -27,10 +27,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/examples/a5/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -73,7 +73,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     for (int batch = 0; batch < BATCH; batch++) {
         for (int m_idx = 0; m_idx < GRID_M; m_idx++) {
             for (int n_idx = 0; n_idx < GRID_N; n_idx++) {
-                PTO2_SCOPE() {
+                SIMPLER_SCOPE() {
                     uint32_t c_elem_offset = (static_cast<uint32_t>(batch) * GRID_M * GRID_N +
                                               static_cast<uint32_t>(m_idx) * GRID_N + static_cast<uint32_t>(n_idx)) *
                                              TILE_ELEMS;

--- a/examples/a5/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -53,10 +53,9 @@ static constexpr uint32_t TILE_ELEMS = TILE * TILE;  // 4096 elements
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/examples/a5/tensormap_and_ringbuffer/docs/INCORE_ORCHESTRATION_GUIDE.md
+++ b/examples/a5/tensormap_and_ringbuffer/docs/INCORE_ORCHESTRATION_GUIDE.md
@@ -32,7 +32,7 @@ Validate `arg_count` in `aicpu_orchestration_config` and interpret pointers as d
 
 ## Building The Graph
 
-1. Wrap orchestration in scopes with `PTO2_SCOPE()` to control tensor lifetimes.
+1. Wrap orchestration in scopes with `SIMPLER_SCOPE()` to control tensor lifetimes.
 2. Use `make_tensor_external` for existing device buffers and `TensorCreateInfo` + `add_output(...)` for runtime-created intermediates.
 3. Use `add_inout(...)` for existing tensors that a kernel writes.
 4. Build `CoreTaskArgs` with `add_input`, `add_output`, `add_inout` for tensors and `add_scalar` for scalars.

--- a/examples/a5/tensormap_and_ringbuffer/docs/INCORE_ORCHESTRATION_GUIDE.md
+++ b/examples/a5/tensormap_and_ringbuffer/docs/INCORE_ORCHESTRATION_GUIDE.md
@@ -14,7 +14,7 @@ In tensormap_and_ringbuffer, the orchestration function runs on AICPU and builds
 Your orchestration shared object must export:
 
 ```cpp
-extern "C" PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args);
+extern "C" OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args);
 extern "C" void aicpu_orchestration_entry(const ChipTaskArgs &orch_args);
 ```
 

--- a/examples/a5/tensormap_and_ringbuffer/merge_pipeline_barrier/kernels/orchestration/merge_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/merge_pipeline_barrier/kernels/orchestration/merge_orch.cpp
@@ -21,10 +21,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 4};
+    return OrchestrationConfig{.expected_arg_count = 4};
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -61,10 +61,9 @@ inline uint64_t get_sys_cnt_aicpu() {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -148,7 +148,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
         uint64_t cur_seq = static_cast<uint64_t>(get_tensor_data<int32_t>(context_lens, 1, cl_idx));
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 CYCLE_COUNT_LAP(prof_scope);
                 uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
 
@@ -168,7 +168,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                 CYCLE_COUNT_LAP(prof_submit_task);
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn++) {
-                    PTO2_SCOPE_GUARD();
+                    SIMPLER_SCOPE_GUARD();
 
                     uint32_t bt_idx[2] = {static_cast<uint32_t>(b_idx), static_cast<uint32_t>(bn)};
                     uint64_t cur_block_idx = static_cast<uint64_t>(get_tensor_data<int32_t>(block_table, 2, bt_idx));

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -148,7 +148,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
         uint64_t cur_seq = static_cast<uint64_t>(get_tensor_data<int32_t>(context_lens, 1, cl_idx));
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
-            PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+            SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
                 CYCLE_COUNT_LAP(prof_scope);
                 uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
 

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -61,10 +61,9 @@ inline uint64_t get_sys_cnt_aicpu() {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -154,7 +154,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
 
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
             CYCLE_COUNT_LAP(prof_scope_and_loop);
-            PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+            SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
                 uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
 
                 uint32_t qi_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -70,10 +70,9 @@ inline uint64_t get_sys_cnt_aicpu() {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
@@ -56,7 +56,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     int64_t BLOCK_TABLE_FLAT_DYN = (int64_t)orch_args.tensor(8).ref().shapes[0];
     int64_t KV_CACHE_ROWS_DYN = (int64_t)orch_args.tensor(12).ref().shapes[0];
 
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         uint32_t pa_metadata_ci_shapes[1] = {27840};
         TensorCreateInfo pa_metadata_ci(pa_metadata_ci_shapes, 1, DataType::UINT8);
         uint32_t pa_workspace_ci_shapes[1] = {66132544};
@@ -97,7 +97,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         TaskId t = phase_fence_barrier_0_outs.task_id();
         prev_out_tid[0] = t;
         for (int64_t cb0 = 0; cb0 < 16; cb0 += 16) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 // Task 1: copy_hidden
                 CoreTaskArgs params_t1;
                 params_t1.add_output(cur);
@@ -111,7 +111,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         TaskId prev_normed_tid[1];
         for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
             prev_normed_tid[__init_i] = TaskId::invalid();
-        PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+        SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
             TaskId _submit_deps_buf[1];
             for (int64_t __init_i = 0; __init_i < 1; ++__init_i)
                 _submit_deps_buf[__init_i] = TaskId::invalid();
@@ -136,7 +136,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         ChipTensor cur__rv_v7 = cur;
         ChipTensor normed__rv_v5 = normed;
         for (int64_t i = 0; i < 40; i += 1) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 uint32_t next_hidden_ci_shapes[2] = {16, 5120};
                 TensorCreateInfo next_hidden_ci(next_hidden_ci_shapes, 2, DataType::FLOAT32);
                 uint32_t next_normed_ci_shapes[2] = {16, 5120};
@@ -228,7 +228,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 const ChipTensor &mlp_norm_in_inline71 = alloc_2.get_ref(5);
                 const ChipTensor &inv_rms_tile_inline126 = alloc_2.get_ref(6);
                 const ChipTensor &mlp_tile_inline149 = alloc_2.get_ref(7);
-                PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
+                SIMPLER_SCOPE(PTO2ScopeMode::MANUAL) {
                     // Phase-fence barrier 1: dependency-only dummy task
                     CoreTaskArgs params_phase_fence_barrier_1;
                     TaskOutputTensors phase_fence_barrier_1_outs = rt_submit_dummy_task(params_phase_fence_barrier_1);
@@ -1965,7 +1965,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             }
         }
         for (int64_t ob0 = 0; ob0 < 16; ob0 += 16) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 // Task 35: copy_out
                 CoreTaskArgs params_t35;
                 params_t35.add_output(ext_out);

--- a/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/orchestration/decode_fwd_layers.cpp
@@ -22,10 +22,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 20,
     };
 }

--- a/examples/a5/tensormap_and_ringbuffer/scalar_data/kernels/orchestration/scalar_data_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/scalar_data/kernels/orchestration/scalar_data_orch.cpp
@@ -40,10 +40,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 4,  // a, b, result, check
     };
 }

--- a/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/orchestration/sdma_async_completion_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/orchestration/sdma_async_completion_orch.cpp
@@ -16,14 +16,13 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 sdma_async_completion_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 4};
+    return OrchestrationConfig{.expected_arg_count = 4};
 }
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     return sdma_async_completion_orchestration_config(orch_args);
 }
 

--- a/examples/a5/tensormap_and_ringbuffer/urma_deferred_completion_demo/kernels/orchestration/urma_deferred_completion_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/urma_deferred_completion_demo/kernels/orchestration/urma_deferred_completion_orch.cpp
@@ -16,14 +16,13 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 urma_deferred_completion_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 4};
+    return OrchestrationConfig{.expected_arg_count = 4};
 }
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     return urma_deferred_completion_orchestration_config(orch_args);
 }
 

--- a/examples/a5/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -48,7 +48,7 @@ __attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_c
 
 /**
  * Orchestration entry — runtime is bound implicitly by the framework.
- * The executor wraps this call in PTO2_SCOPE, so we are already inside
+ * The executor wraps this call in SIMPLER_SCOPE, so we are already inside
  * the outer scope on entry.
  */
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
@@ -73,7 +73,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     // Inner scope: owns t1, t2, t3, t4; intermediates d, e, g release on scope end.
     // c flows in from outer scope (outer-scope tensors are visible to inner scopes).
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         // t1: d = c + 1 (kernel_id=1, kernel_add_scalar)
         CoreTaskArgs params_t1;
         params_t1.add_input(c);

--- a/examples/a5/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -25,7 +25,7 @@
  *   - c flows from outer to inner scope (outer-scope tensors are visible to inner scopes)
  *
  * This file compiles as a standalone .so with zero runtime link dependencies.
- * All runtime calls go through the PTO2RuntimeOps function-pointer table.
+ * All runtime calls go through the RuntimeOps function-pointer table.
  */
 
 #include <stddef.h>

--- a/examples/a5/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -39,10 +39,9 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/examples/workers/l2/vector_add/kernels/orchestration/vector_add_orch.cpp
+++ b/examples/workers/l2/vector_add/kernels/orchestration/vector_add_orch.cpp
@@ -24,10 +24,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 vector_add_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,  // a, b, out
     };
 }

--- a/examples/workers/l3/allreduce/kernels/orchestration/allreduce_onephase_orch.cpp
+++ b/examples/workers/l3/allreduce/kernels/orchestration/allreduce_onephase_orch.cpp
@@ -31,10 +31,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 allreduce_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 5,  // 3 tensors + 2 scalars
     };
 }

--- a/examples/workers/l3/dual_domain_overlap/kernels/orchestration/affine_orch.cpp
+++ b/examples/workers/l3/dual_domain_overlap/kernels/orchestration/affine_orch.cpp
@@ -15,10 +15,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-affine_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig affine_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 4};
+    return OrchestrationConfig{.expected_arg_count = 4};
 }
 
 __attribute__((visibility("default"))) void affine_orchestration(const ChipTaskArgs &orch_args) {

--- a/examples/workers/l3/dual_domain_overlap/kernels/orchestration/domain_allreduce_orch.cpp
+++ b/examples/workers/l3/dual_domain_overlap/kernels/orchestration/domain_allreduce_orch.cpp
@@ -15,10 +15,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 domain_allreduce_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 5};
+    return OrchestrationConfig{.expected_arg_count = 5};
 }
 
 __attribute__((visibility("default"))) void domain_allreduce_orchestration(const ChipTaskArgs &orch_args) {

--- a/examples/workers/l3/ep_dispatch_combine/kernels/orchestration/ep_dispatch_combine_orch.cpp
+++ b/examples/workers/l3/ep_dispatch_combine/kernels/orchestration/ep_dispatch_combine_orch.cpp
@@ -50,10 +50,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 ep_dispatch_combine_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 13,  // 11 tensors + 2 scalars
     };
 }

--- a/examples/workers/l3/ffn_tp_parallel/kernels/orchestration/allreduce_sum_orch.cpp
+++ b/examples/workers/l3/ffn_tp_parallel/kernels/orchestration/allreduce_sum_orch.cpp
@@ -24,10 +24,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 allreduce_sum_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 5};  // 3 tensors + 2 scalars
+    return OrchestrationConfig{.expected_arg_count = 5};  // 3 tensors + 2 scalars
 }
 
 __attribute__((visibility("default"))) void allreduce_sum_orchestration(const ChipTaskArgs &orch_args) {

--- a/examples/workers/l3/ffn_tp_parallel/kernels/orchestration/ffn_local_orch.cpp
+++ b/examples/workers/l3/ffn_tp_parallel/kernels/orchestration/ffn_local_orch.cpp
@@ -22,10 +22,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 ffn_local_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 3};
+    return OrchestrationConfig{.expected_arg_count = 3};
 }
 
 __attribute__((visibility("default"))) void ffn_local_orchestration(const ChipTaskArgs &orch_args) {

--- a/examples/workers/l3/multi_chip_dispatch/kernels/orchestration/vector_add_orch.cpp
+++ b/examples/workers/l3/multi_chip_dispatch/kernels/orchestration/vector_add_orch.cpp
@@ -24,10 +24,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 vector_add_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,  // a, b, out
     };
 }

--- a/examples/workers/l3/worker_chip_message_queue/kernels/orchestration/worker_chip_message_queue_orch.cpp
+++ b/examples/workers/l3/worker_chip_message_queue/kernels/orchestration/worker_chip_message_queue_orch.cpp
@@ -232,10 +232,9 @@ bool finish_pending_inputs(QueueEndpoint &queue, ActiveRequest *active) {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{.expected_arg_count = kExpectedArgCount};
+    return OrchestrationConfig{.expected_arg_count = kExpectedArgCount};
 }
 
 __attribute__((visibility("default"))) void worker_chip_message_queue_orchestration(const ChipTaskArgs &orch_args) {

--- a/examples/workers/l3/worker_chip_orch_comm_stream/kernels/orchestration/worker_chip_orch_comm_orch.cpp
+++ b/examples/workers/l3/worker_chip_orch_comm_stream/kernels/orchestration/worker_chip_orch_comm_orch.cpp
@@ -57,10 +57,9 @@ bool read_payload_or_fail(
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{.expected_arg_count = kExpectedArgCount};
+    return OrchestrationConfig{.expected_arg_count = kExpectedArgCount};
 }
 
 __attribute__((visibility("default"))) void worker_chip_orch_comm_orchestration(const ChipTaskArgs &orch_args) {

--- a/examples/workers/l4/compute_then_tload_mixed_l3/kernels/orchestration/global_tload_orch.cpp
+++ b/examples/workers/l4/compute_then_tload_mixed_l3/kernels/orchestration/global_tload_orch.cpp
@@ -15,10 +15,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 global_tload_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 4,
     };
 }

--- a/examples/workers/l4/compute_then_tload_mixed_l3/kernels/orchestration/local_add_orch.cpp
+++ b/examples/workers/l4/compute_then_tload_mixed_l3/kernels/orchestration/local_add_orch.cpp
@@ -15,10 +15,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 local_add_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/examples/workers/l4/global_tload_mixed_l3/kernels/orchestration/global_tload_orch.cpp
+++ b/examples/workers/l4/global_tload_mixed_l3/kernels/orchestration/global_tload_orch.cpp
@@ -15,10 +15,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 global_tload_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 4,
     };
 }

--- a/examples/workers/l4/vector_add_mixed_l3/kernels/orchestration/vector_add_mixed_l3_orchestration.cpp
+++ b/examples/workers/l4/vector_add_mixed_l3/kernels/orchestration/vector_add_mixed_l3_orchestration.cpp
@@ -48,7 +48,7 @@ __attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_c
 
 /**
  * Orchestration entry — runtime is bound implicitly by the framework.
- * The executor wraps this call in PTO2_SCOPE, so we are already inside
+ * The executor wraps this call in SIMPLER_SCOPE, so we are already inside
  * the outer scope on entry.
  */
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
@@ -73,7 +73,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     // Inner scope: owns t1, t2, t3, t4; intermediates d, e, g release on scope end.
     // c flows in from outer scope (outer-scope tensors are visible to inner scopes).
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         // t1: d = c + 1 (kernel_id=1, kernel_add_scalar)
         CoreTaskArgs params_t1;
         params_t1.add_input(c);

--- a/examples/workers/l4/vector_add_mixed_l3/kernels/orchestration/vector_add_mixed_l3_orchestration.cpp
+++ b/examples/workers/l4/vector_add_mixed_l3/kernels/orchestration/vector_add_mixed_l3_orchestration.cpp
@@ -25,7 +25,7 @@
  *   - c flows from outer to inner scope (outer-scope tensors are visible to inner scopes)
  *
  * This file compiles as a standalone .so with zero runtime link dependencies.
- * All runtime calls go through the PTO2RuntimeOps function-pointer table.
+ * All runtime calls go through the RuntimeOps function-pointer table.
  */
 
 #include <stddef.h>

--- a/examples/workers/l4/vector_add_mixed_l3/kernels/orchestration/vector_add_mixed_l3_orchestration.cpp
+++ b/examples/workers/l4/vector_add_mixed_l3/kernels/orchestration/vector_add_mixed_l3_orchestration.cpp
@@ -39,10 +39,9 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -59,7 +59,7 @@
 
 // From orchestration/common.cpp linked into this DSO — updates g_current_runtime
 // here (cleared on teardown before runtime_destroy).
-extern "C" void framework_bind_runtime(PTO2Runtime *rt);
+extern "C" void framework_bind_runtime(RuntimeContext *rt);
 
 static int32_t read_pto2_runtime_status(Runtime *runtime) {
     if (runtime == nullptr) {
@@ -77,7 +77,7 @@ static int32_t read_pto2_runtime_status(Runtime *runtime) {
     return runtime_status_from_error_codes(orch_error_code, sched_error_code);
 }
 
-static PTO2Runtime *rt{nullptr};
+static RuntimeContext *rt{nullptr};
 
 struct AicpuExecutor {
     // ===== Thread management state =====
@@ -110,7 +110,7 @@ struct AicpuExecutor {
     simpler::ThreadCompletionGate completion_gate_;
     std::atomic<bool> runtime_init_ready_{false};
 
-    // Per-Worker arena backing the PTO2Runtime + sm_handle + orch/sched/mailbox
+    // Per-Worker arena backing the RuntimeContext + sm_handle + orch/sched/mailbox
     // sub-regions (created in runtime_create_from_sm, released in runtime_destroy).
     // Default-constructed: libc-backed backend, no ctx.
     DeviceArena runtime_arena_;
@@ -260,7 +260,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
         if (boot_ok) {
             runtime_arena_.attach(prebuilt_arena, DeviceArena::kDefaultBaseAlign);
-            rt = reinterpret_cast<PTO2Runtime *>(static_cast<char *>(prebuilt_arena) + off_runtime);
+            rt = reinterpret_cast<RuntimeContext *>(static_cast<char *>(prebuilt_arena) + off_runtime);
             runtime_wire_arena_pointers(runtime_arena_, rt->prebuilt_layout, rt);
 
             void *sm_ptr = runtime->get_gm_sm_ptr();

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -27,7 +27,7 @@
 #include "runtime.h"
 #include "spin_hint.h"
 
-// Runtime headers (full struct definition for create/destroy + PTO2_SCOPE)
+// Runtime headers (full struct definition for create/destroy + SIMPLER_SCOPE)
 #include "runtime_core.h"
 #include "runtime_types.h"
 #include "shared_memory.h"

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -115,9 +115,9 @@ a boundary from which region happens to be reserved first —
 orchestrator, so nothing on the device reads its state: not the `fanin_seen_epoch`
 table, not the scope arrays, not the TensorMap (~9.3 MB between them). It is
 therefore a plain host object that owns those arrays — `PTO2OrchestratorState::init`
-allocates them — and `PTO2Runtime` reaches it through a pointer that `bind` drops
+allocates them — and `RuntimeContext` reaches it through a pointer that `bind` drops
 before the copied zone is uploaded, so no host address crosses the boundary. A
-`static_assert` keeps `PTO2Runtime` trivially copyable, which is what forbids
+`static_assert` keeps `RuntimeContext` trivially copyable, which is what forbids
 putting an owning member back inside it. The one orchestrator value the device-side
 scheduler reads, the count of tasks completed inline during orchestration, is a
 scalar `rt_orchestration_done` publishes into the runtime header.
@@ -128,7 +128,7 @@ queue capacities are compile-time constants, hbg never advances
 `last_task_alive`, and it has no host-side entry point at all. So the host would
 only be writing an initialization pattern — 203,392 bytes
 of it, dominated by `AsyncWaitList::entries` — for the device to receive and never
-read. `PTO2Runtime` therefore holds a *pointer* to it, wired from
+read. `RuntimeContext` therefore holds a *pointer* to it, wired from
 `off_scheduler` on each side, and the AICPU calls `init_data_from_layout` at boot.
 
 **Why the queue slots are device-written.** `push` claims `slots[pos & mask]` only

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -74,7 +74,7 @@ The shared image uses three per-slot structures:
 | --------- | ------- |
 | `PTO2TaskDescriptor` | Full task ID, kernel IDs, packed-buffer addresses |
 | `PTO2TaskPayload` | Argument counts, predicate, dispatch metadata, and a delta naming each of its tensor, scalar and fanin regions — the arguments themselves live in the pool segments, so the payload is a fixed three cache lines regardless of the argument caps |
-| `PTO2TaskSlotState` | Active mask, attributes, block/subtask counters, completion state, task/payload bindings |
+| `ChipTaskSlotState` | Active mask, attributes, block/subtask counters, completion state, task/payload bindings |
 
 The host/device boundary is POD and position-independent. Fanins are integer
 producer IDs, not pointers, and a slot state names its payload and descriptor — and

--- a/src/a2a3/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a2a3/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
@@ -31,7 +31,7 @@ The shared graph image separates stable task identity from scheduling state:
 - `PTO2TaskPayload` contains the argument counts, predicate, and a delta naming
   each of its tensor, scalar and position-independent fanin-id regions. The
   arguments live in the pool segments, not in the payload.
-- `PTO2TaskSlotState` contains the active mask, task attributes, logical block
+- `ChipTaskSlotState` contains the active mask, task attributes, logical block
   count, subtask counters, completion state, and descriptor/payload bindings.
 
 This image is built on the host and copied to the device verbatim. It contains

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -520,7 +520,7 @@ int32_t run_host_orchestration(
     // orch::prepare_task and shipped bounded to total_tasks below.
     const pto2_sm_layout::PTO2RingSegmentOffsets sm_segs = pto2_sm_layout::ring_segment_offsets(eff_task_window_size);
     // Over-allocated and rounded up: every segment offset is a multiple of
-    // PTO2_ALIGN_SIZE and PTO2TaskSlotState is alignas(64), which a plain
+    // PTO2_ALIGN_SIZE and ChipTaskSlotState is alignas(64), which a plain
     // new uint8_t[] does not guarantee.
     std::unique_ptr<uint8_t[]> host_sm_buf(new uint8_t[sm_size + PTO2_ALIGN_SIZE]);
     void *host_sm = reinterpret_cast<void *>(
@@ -719,7 +719,7 @@ int32_t run_host_orchestration(
     // One host source for one copy: the copied zone and shared-memory image at
     // exactly the offsets they occupy on the device.
     // Over-allocated and rounded up because every segment offset is
-    // PTO2_ALIGN_SIZE-aligned and PTO2TaskSlotState is alignas(64), which a byte
+    // PTO2_ALIGN_SIZE-aligned and ChipTaskSlotState is alignas(64), which a byte
     // vector's data() is not.
     const uint64_t copied_bytes = layout.off_copied_end - layout.off_copied_begin;
     const uint64_t upload_bytes = copied_bytes + image_bytes;

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -382,7 +382,7 @@ bool create_orch_so_tempfile(const uint8_t *data, size_t size, std::string *out_
 
 // The orchestration .so exports these (PTO2 submit_task form).
 typedef void (*OrchestrationEntryFunc)(const ChipTaskArgs &);
-typedef void (*OrchestrationBindFunc)(PTO2Runtime *);
+typedef void (*OrchestrationBindFunc)(RuntimeContext *);
 typedef void (*OrchestrationPrewarmFunc)();
 
 // Resolved orchestration .so entry points. register_callable_impl allocates one
@@ -508,9 +508,9 @@ struct GraphHostStateBinding {
 };
 
 int32_t run_host_orchestration(
-    Runtime *runtime, const HostApi *api, HostTensorAccessor &tensor_access, PTO2Runtime *rt, DeviceArena &host_arena,
-    const PTO2RuntimeArenaLayout &layout, uint64_t sm_size, void *device_arena, void *gm_heap, uint64_t eff_heap_size,
-    uint64_t eff_task_window_size, void *host_orch_func_ptr, const ChipTaskArgs &orch_l2
+    Runtime *runtime, const HostApi *api, HostTensorAccessor &tensor_access, RuntimeContext *rt,
+    DeviceArena &host_arena, const RuntimeArenaLayout &layout, uint64_t sm_size, void *device_arena, void *gm_heap,
+    uint64_t eff_heap_size, uint64_t eff_task_window_size, void *host_orch_func_ptr, const ChipTaskArgs &orch_l2
 ) {
     dep_gen_host_graph_begin_capture();
 
@@ -1026,7 +1026,7 @@ extern "C" int bind_callable_to_runtime_impl(
 
     const int64_t t_arena_build_ns = bind_now_ns();
     DeviceArena host_arena;
-    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(host_arena, eff_task_window_size, eff_heap_size);
+    RuntimeArenaLayout layout = runtime_reserve_layout(host_arena, eff_task_window_size, eff_heap_size);
     if (host_arena.commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
         LOG_ERROR("Failed to commit host arena for prebuilt runtime image");
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -1089,7 +1089,7 @@ extern "C" int bind_callable_to_runtime_impl(
     const int64_t t_runtime_init_ns = bind_now_ns();
     // No SM base: the scheduler and sm_handle are device-written now, so nothing
     // here stores one, and the region is not even committed yet.
-    PTO2Runtime *rt = runtime_init_data_from_layout(
+    RuntimeContext *rt = runtime_init_data_from_layout(
         host_arena, layout, PTO2_MODE_EXECUTE, /*sm_dev_base=*/nullptr, sm_size, gm_heap, eff_heap_size
     );
     if (rt == nullptr) {
@@ -1097,7 +1097,7 @@ extern "C" int bind_callable_to_runtime_impl(
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     runtime_wire_arena_pointers(host_arena, layout, rt);
-    // Stash the layout inside the PTO2Runtime image so the AICPU can recover every
+    // Stash the layout inside the RuntimeContext image so the AICPU can recover every
     // arena-internal offset after the copy. It is written before orchestration
     // because orchestration is what performs that copy, and the runtime header is
     // part of what travels. The runtime arena's device base does NOT travel — it is

--- a/src/a2a3/runtime/host_build_graph/orchestration/common.cpp
+++ b/src/a2a3/runtime/host_build_graph/orchestration/common.cpp
@@ -21,7 +21,7 @@
 #include <vector>
 #endif
 
-struct PTO2Runtime;
+struct RuntimeContext;
 
 // Unified-log error sink. Forward-declared here rather than pulled via
 // common/unified_log.h: that header lives under common/log/include, which is
@@ -36,16 +36,18 @@ namespace {
 // crash (BZ #32412) when the orchestration SO is dlclose'd/re-dlopen'd
 // between execution rounds.  All orchestrator threads bind the same rt
 // value, so per-thread storage is unnecessary.
-PTO2Runtime *g_current_runtime = nullptr;
+RuntimeContext *g_current_runtime = nullptr;
 }  // namespace
 
-extern "C" __attribute__((visibility("default"))) void framework_bind_runtime(PTO2Runtime *rt) {
+extern "C" __attribute__((visibility("default"))) void framework_bind_runtime(RuntimeContext *rt) {
     g_current_runtime = rt;
 }
 
 // Keep current_runtime local to this .so so orchestration helpers do not
 // accidentally bind to the AICPU binary's same-named symbol.
-extern "C" __attribute__((visibility("hidden"))) PTO2Runtime *framework_current_runtime() { return g_current_runtime; }
+extern "C" __attribute__((visibility("hidden"))) RuntimeContext *framework_current_runtime() {
+    return g_current_runtime;
+}
 
 /**
  * Use addr2line to convert an address to file:line information.

--- a/src/a2a3/runtime/host_build_graph/orchestration/orchestration_api.h
+++ b/src/a2a3/runtime/host_build_graph/orchestration/orchestration_api.h
@@ -884,7 +884,7 @@ rt_submit_graph(GraphFunctionWithConfig<Config...> function, const GraphTaskArgs
  */
 #ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
-struct PTO2OrchestrationConfig {
+struct OrchestrationConfig {
     int expected_arg_count;
 };
 #endif

--- a/src/a2a3/runtime/host_build_graph/orchestration/orchestration_api.h
+++ b/src/a2a3/runtime/host_build_graph/orchestration/orchestration_api.h
@@ -110,7 +110,7 @@ typedef struct PTO2RuntimeOps {
     bool (*graph_end)(PTO2Runtime *rt);
     void (*graph_commit)(PTO2Runtime *rt);
 
-    // Stash the call-site of the next PTO2ScopeGuard so the [ScopeStats]
+    // Stash the call-site of the next ScopeGuard so the [ScopeStats]
     // collector can log it. Always present to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
     void (*scope_set_site)(const char *file, int line);
@@ -690,9 +690,9 @@ static inline void set_tensor_data(const ChipTensor &tensor, uint32_t ndims, con
 /**
  * RAII Scope Guard (calls through ops table)
  */
-class PTO2ScopeGuard {
+class ScopeGuard {
 public:
-    explicit PTO2ScopeGuard(
+    explicit ScopeGuard(
         PTO2ScopeMode mode = PTO2ScopeMode::AUTO, const char *file = __builtin_FILE(), int line = __builtin_LINE()
     ) :
         rt_(current_runtime()) {
@@ -702,7 +702,7 @@ public:
             rt_->ops->scope_begin(rt_);
         }
     }
-    ~PTO2ScopeGuard() {
+    ~ScopeGuard() {
         if (!rt_->ops->is_fatal(rt_)) {
             rt_->ops->scope_end(rt_);
         }
@@ -858,18 +858,18 @@ rt_submit_graph(GraphFunctionWithConfig<Config...> function, const GraphTaskArgs
     return rt_submit_graph(rt_graph_function_id(function), function, args, config...);
 }
 
-#define _PTO2_CONCATENATE_IMPL(x, y) x##y
-#define _PTO2_CONCATENATE(x, y) _PTO2_CONCATENATE_IMPL(x, y)
+#define _SIMPLER_CONCATENATE_IMPL(x, y) x##y
+#define _SIMPLER_CONCATENATE(x, y) _SIMPLER_CONCATENATE_IMPL(x, y)
 
-#define PTO2_SCOPE_GUARD() [[maybe_unused]] PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__)
+#define SIMPLER_SCOPE_GUARD() [[maybe_unused]] ScopeGuard _SIMPLER_CONCATENATE(scope_guard_, __COUNTER__)
 
 /**
  * Scoped block macro:
- *   PTO2_SCOPE() {
+ *   SIMPLER_SCOPE() {
  *       rt_submit_task(...);
  *   }
  */
-#define PTO2_SCOPE(...) if (PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__){__VA_ARGS__}; true)
+#define SIMPLER_SCOPE(...) if (ScopeGuard _SIMPLER_CONCATENATE(scope_guard_, __COUNTER__){__VA_ARGS__}; true)
 
 // =============================================================================
 // Orchestration Config

--- a/src/a2a3/runtime/host_build_graph/orchestration/orchestration_api.h
+++ b/src/a2a3/runtime/host_build_graph/orchestration/orchestration_api.h
@@ -14,14 +14,14 @@
  * This header provides everything an orchestration source needs without
  * pulling in runtime implementation headers.  The orchestration .so has
  * zero link dependencies on runtime .cpp files; all runtime calls go
- * through the PTO2RuntimeOps function-pointer table embedded in
- * PTO2Runtime.
+ * through the RuntimeOps function-pointer table embedded in
+ * RuntimeContext.
  *
  * Orchestration sources include ONLY this header:
  *   #include "orchestration_api.h"
  *
  * Runtime sources continue to use runtime_core.h (which defines the
- * full PTO2Runtime struct with all internal fields).
+ * full RuntimeContext struct with all internal fields).
  */
 
 #pragma once
@@ -66,23 +66,23 @@
 // =============================================================================
 
 /**
- * Forward declaration — the orchestration sees PTO2Runtime as a partial
+ * Forward declaration — the orchestration sees RuntimeContext as a partial
  * struct whose first field is the ops pointer.  The full definition
  * lives in runtime_core.h (used only by runtime .cpp files).
  */
-typedef struct PTO2Runtime PTO2Runtime;
+typedef struct RuntimeContext RuntimeContext;
 
 /**
  * Function-pointer table for runtime operations.
  * Populated by the runtime; called by orchestration through inline wrappers.
  */
-typedef struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
-    void (*scope_begin)(PTO2Runtime *rt);
-    void (*scope_end)(PTO2Runtime *rt);
-    void (*orchestration_done)(PTO2Runtime *rt);
-    bool (*is_fatal)(PTO2Runtime *rt);
-    void (*report_fatal)(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
+typedef struct RuntimeOps {
+    TaskOutputTensors (*submit_task)(RuntimeContext *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
+    void (*scope_begin)(RuntimeContext *rt);
+    void (*scope_end)(RuntimeContext *rt);
+    void (*orchestration_done)(RuntimeContext *rt);
+    bool (*is_fatal)(RuntimeContext *rt);
+    void (*report_fatal)(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
     // Logging (populated by runtime, called by orchestration)
     void (*log_error)(const char *func, const char *fmt, ...);
@@ -93,22 +93,22 @@ typedef struct PTO2RuntimeOps {
 
     // Cross-layer data access (orchestration reads/writes tensor values via runtime)
     // Placed after logging to avoid shifting hot-path field offsets.
-    uint64_t (*get_tensor_data)(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
+    uint64_t (*get_tensor_data)(RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
     void (*set_tensor_data)(
-        PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+        RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
     );
-    TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const CoreTaskArgs &args);
-    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const CoreTaskArgs &args);
+    TaskOutputTensors (*alloc_tensors)(RuntimeContext *rt, const CoreTaskArgs &args);
+    TaskOutputTensors (*submit_dummy_task)(RuntimeContext *rt, const CoreTaskArgs &args);
 
     // This-run core geometry latched by the host bind: MIX clusters
     // (one AIC each) and standalone AIV cores.
-    int32_t (*available_cluster_count)(PTO2Runtime *rt);
-    int32_t (*available_aiv_count)(PTO2Runtime *rt);
-    GraphScopeResult (*graph_begin)(PTO2Runtime *rt, uint64_t graph_key, const GraphTaskArgs &args);
-    bool (*graph_prepare)(PTO2Runtime *rt, void *recording_handle, const GraphTaskArgs &args);
-    void (*graph_abort)(PTO2Runtime *rt, void *recording_handle);
-    bool (*graph_end)(PTO2Runtime *rt);
-    void (*graph_commit)(PTO2Runtime *rt);
+    int32_t (*available_cluster_count)(RuntimeContext *rt);
+    int32_t (*available_aiv_count)(RuntimeContext *rt);
+    GraphScopeResult (*graph_begin)(RuntimeContext *rt, uint64_t graph_key, const GraphTaskArgs &args);
+    bool (*graph_prepare)(RuntimeContext *rt, void *recording_handle, const GraphTaskArgs &args);
+    void (*graph_abort)(RuntimeContext *rt, void *recording_handle);
+    bool (*graph_end)(RuntimeContext *rt);
+    void (*graph_commit)(RuntimeContext *rt);
 
     // Stash the call-site of the next ScopeGuard so the [ScopeStats]
     // collector can log it. Always present to keep ops-table layout stable
@@ -122,18 +122,18 @@ typedef struct PTO2RuntimeOps {
     // the two must stay in lockstep field for field, since the runtime fills the table
     // and this .so calls through it.
     void (*record_orch_phase)(uint32_t kind, uint64_t start_ns, uint64_t end_ns, uint64_t detail);
-} PTO2RuntimeOps;
+} RuntimeOps;
 
 /**
- * Partial PTO2Runtime definition for orchestration.
+ * Partial RuntimeContext definition for orchestration.
  *
  * Exposes the ops pointer (for runtime calls) and pending_scope_mode
  * (read directly by inline scope wrappers).  The real struct (in
  * runtime_core.h) has the same first fields, so accessing them through
  * this definition is well-defined (C struct layout guarantee).
  */
-struct PTO2Runtime {
-    const PTO2RuntimeOps *ops;
+struct RuntimeContext {
+    const RuntimeOps *ops;
     PTO2ScopeMode pending_scope_mode;
 };
 
@@ -379,7 +379,7 @@ inline GraphAsyncRecordingState &rt_graph_async_recording() {
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================
 
-static inline PTO2Runtime *current_runtime() { return framework_current_runtime(); }
+static inline RuntimeContext *current_runtime() { return framework_current_runtime(); }
 
 // Where the previous submission on this thread left off, so the generated code's own
 // work between two submissions can be named rather than showing as an unattributed gap.
@@ -409,7 +409,7 @@ static inline void rt_graph_commit();
 // submitting thread for the rest of every recording in flight, which on the
 // four-Definition DeepSeek-V4 decode was a third of the orchestration window.
 static inline TaskOutputTensors alloc_tensors(const CoreTaskArgs &args) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -417,7 +417,7 @@ static inline TaskOutputTensors alloc_tensors(const CoreTaskArgs &args) {
 }
 
 static inline TaskOutputTensors alloc_tensors(const TensorCreateInfo create_infos[], uint32_t count) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -442,7 +442,7 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
         (std::is_same_v<std::decay_t<CIs>, TensorCreateInfo> && ...),
         "alloc_tensors only accepts TensorCreateInfo arguments"
     );
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -459,7 +459,7 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
 }
 
 static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -492,7 +492,7 @@ static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const Core
  * barrier or as a placeholder producer for tests / dep-graph wiring.
  */
 static inline TaskOutputTensors rt_submit_dummy_task(const CoreTaskArgs &args) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -500,7 +500,7 @@ static inline TaskOutputTensors rt_submit_dummy_task(const CoreTaskArgs &args) {
 }
 
 static inline GraphScopeResult rt_graph_begin(uint64_t graph_key, const GraphTaskArgs &args) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt) || rt->ops->graph_begin == nullptr) {
         return GraphScopeResult{};
     }
@@ -511,19 +511,19 @@ static inline GraphScopeResult rt_graph_begin(uint64_t graph_key, const GraphTas
 // from the GraphScopeResult that opened it, so a thread can only ever record
 // into the recording it was handed.
 static inline bool rt_graph_prepare(void *recording_handle, const GraphTaskArgs &args) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     return rt->ops->graph_prepare != nullptr && rt->ops->graph_prepare(rt, recording_handle, args);
 }
 
 static inline void rt_graph_abort(void *recording_handle) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->graph_abort != nullptr) rt->ops->graph_abort(rt, recording_handle);
 }
 
 // Finish the recording pass and publish its Definition. The calling thread
 // finalizes the already-submitted outer Graph shells in rt_graph_commit.
 static inline bool rt_graph_end() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt) || rt->ops->graph_end == nullptr) {
         return true;
     }
@@ -534,12 +534,12 @@ static inline void rt_graph_commit() {
     GraphAsyncRecordingState &async = rt_graph_async_recording();
     async.wait();
 
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (!rt->ops->is_fatal(rt) && rt->ops->graph_commit != nullptr) rt->ops->graph_commit(rt);
 }
 
 static inline void rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
@@ -548,7 +548,7 @@ static inline void rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {
 }
 
 static inline void rt_scope_end() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
@@ -558,30 +558,30 @@ static inline void rt_scope_end() {
 static inline void rt_orchestration_done() {
     rt_graph_commit();
     rt_submit_phase_state() = RtSubmitPhaseState{};
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     rt->ops->orchestration_done(rt);
 }
 
 /** This-run MIX cluster (= AIC) count. Do not hardcode 24/36; MIX cohorts use this. */
 static inline int32_t rt_available_cluster_count() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     return rt->ops->available_cluster_count(rt);
 }
 
 /** This-run standalone AIV core count. AIV-only cohorts size themselves on this. */
 static inline int32_t rt_available_aiv_count() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     return rt->ops->available_aiv_count(rt);
 }
 
 static inline bool rt_is_fatal() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     return rt->ops->is_fatal(rt);
 }
 
 #define rt_report_fatal(code, fmt, ...)                                          \
     do {                                                                         \
-        PTO2Runtime *_rt = current_runtime();                                    \
+        RuntimeContext *_rt = current_runtime();                                 \
         _rt->ops->report_fatal(_rt, (code), __FUNCTION__, (fmt), ##__VA_ARGS__); \
     } while (0)
 
@@ -610,7 +610,7 @@ enum class RtOrchPhase : uint32_t {
 };
 
 inline void rt_record_orch_phase(RtOrchPhase phase, uint64_t start_ns, uint64_t end_ns, uint64_t detail) {
-    const PTO2RuntimeOps *ops = current_runtime()->ops;
+    const RuntimeOps *ops = current_runtime()->ops;
     if (ops->record_orch_phase != nullptr) {
         ops->record_orch_phase(static_cast<uint32_t>(phase), start_ns, end_ns, detail);
     }
@@ -653,7 +653,7 @@ inline uint64_t rt_orch_phase_now_ns() {
  */
 template <typename T = uint64_t>
 static inline T get_tensor_data(const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return from_u64<T>(0);
     }
@@ -676,7 +676,7 @@ static inline T get_tensor_data(const ChipTensor &tensor, uint32_t ndims, const 
  */
 template <typename T = uint64_t>
 static inline void set_tensor_data(const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], T value) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
@@ -709,7 +709,7 @@ public:
     }
 
 private:
-    PTO2Runtime *rt_;
+    RuntimeContext *rt_;
 };
 
 // Define or submit a Graph Execution. On a cache miss the function executes

--- a/src/a2a3/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
@@ -52,7 +52,7 @@ struct AICoreCompletionMailboxMessage {
     std::atomic<uint64_t> seq;
     TaskId task_token;
     // CONDITION: completion observation addr (counter / backend record).
-    // TASK_NORMAL_DONE: PTO2TaskSlotState pointer carried over to the consumer
+    // TASK_NORMAL_DONE: ChipTaskSlotState pointer carried over to the consumer
     //   so it can finalize the AsyncWaitEntry.slot_state binding.
     uint64_t addr;
     uint64_t backend_cookie;
@@ -169,7 +169,7 @@ struct AICoreCompletionMailbox {
         }
     }
 
-    // MPSC push for a TASK_NORMAL_DONE sentinel. Carries the PTO2TaskSlotState
+    // MPSC push for a TASK_NORMAL_DONE sentinel. Carries the ChipTaskSlotState
     // pointer in the `addr` field so the consumer can finish binding the
     // AsyncWaitEntry.slot_state without going back to the FIN-handling thread.
     bool try_push_normal_done(TaskId task_token, uint64_t slot_state_addr) {

--- a/src/a2a3/runtime/host_build_graph/runtime/async_wait.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/async_wait.h
@@ -114,7 +114,7 @@ inline void CompletionCondition::retire() {
 }
 
 struct AsyncWaitEntry {
-    PTO2TaskSlotState *slot_state{nullptr};
+    ChipTaskSlotState *slot_state{nullptr};
     TaskId task_token{TaskId::invalid()};
     CompletionCondition conditions[MAX_COMPLETIONS_PER_TASK];
     int32_t condition_count{0};
@@ -126,7 +126,7 @@ struct AsyncPollResult {
     int32_t completed{0};  // Host-submitted stream tasks completed.
     int32_t resolved{0};   // All task completions, including internal Graph nodes.
     int32_t error_code{SIMPLER_ERROR_NONE};
-    PTO2TaskSlotState *failed_slot_state{nullptr};
+    ChipTaskSlotState *failed_slot_state{nullptr};
 };
 
 inline const char *async_engine_name(AsyncEngine engine) {
@@ -184,7 +184,7 @@ struct AsyncWaitList {
     };
 
     // Inline-complete a NotDeferred task during drain.
-    bool try_inline_complete_locked(DrainCompletionSink &sink, PTO2TaskSlotState &slot_state);
+    bool try_inline_complete_locked(DrainCompletionSink &sink, ChipTaskSlotState &slot_state);
 
     // Single-consumer drain: pop each published message in tail order and
     // translate it into wait-list state. An empty sink (sched == nullptr) just
@@ -227,8 +227,8 @@ struct AsyncWaitList {
                     return drained;
                 }
             } else if (msg.kind == MSG_KIND_TASK_NORMAL_DONE) {
-                PTO2TaskSlotState *slot_state_ptr =
-                    reinterpret_cast<PTO2TaskSlotState *>(static_cast<uintptr_t>(msg.addr));
+                ChipTaskSlotState *slot_state_ptr =
+                    reinterpret_cast<ChipTaskSlotState *>(static_cast<uintptr_t>(msg.addr));
                 AsyncWaitEntry *entry = find_entry_by_token(msg.task_token);
                 if (entry == nullptr) {
                     // Producers strictly order: all CONDITIONs for token T are

--- a/src/a2a3/runtime/host_build_graph/runtime/common.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/common.h
@@ -23,7 +23,7 @@
 
 // Framework-internal TLS bridge. The executor binds the current thread's
 // runtime before invoking the orchestration entry, so orchestration helpers can
-// fetch the current PTO2Runtime without explicit parameter threading. Declared
+// fetch the current RuntimeContext without explicit parameter threading. Declared
 // here (rather than in orchestration_api.h) so framework TUs the AICore
 // build also compiles — notably orchestration/common.cpp — see these symbols
 // without pulling in types.h, whose Arg::add_scalar → to_u64 path is
@@ -31,9 +31,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-struct PTO2Runtime;
-PTO2Runtime *framework_current_runtime(void);
-void framework_bind_runtime(PTO2Runtime *rt);
+struct RuntimeContext;
+RuntimeContext *framework_current_runtime(void);
+void framework_bind_runtime(RuntimeContext *rt);
 #ifdef __cplusplus
 }
 #endif

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator.h
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Orchestrator Interface
+ * Orchestrator interface
  *
  * The Orchestrator is responsible for:
  * 1. Executing the orchestration function (Turing-complete control flow)
@@ -52,7 +52,7 @@ struct GraphHostState;
  *
  * host_build_graph runs the orchestrator on the host and ships the shared-memory
  * image it produces, so this whole object is host-only: it owns its scratch
- * arrays outright and no device code reads any of them. PTO2Runtime therefore
+ * arrays outright and no device code reads any of them. RuntimeContext therefore
  * holds it by pointer — a by-value member would put non-trivially-copyable state
  * inside the struct bind copies to the device.
  */
@@ -97,7 +97,7 @@ struct PTO2OrchestratorState {
 
     // Hidden alloc tasks complete synchronously inside the orchestrator and
     // therefore bypass the executor's normal worker-completion counter path.
-    // rt_orchestration_done publishes this into PTO2Runtime, which is the copy
+    // rt_orchestration_done publishes this into RuntimeContext, which is the copy
     // the device-side executor adds into its completed_tasks_ progress counter
     // so shutdown/profiling totals remain closed.
     int64_t inline_completed_tasks{0};

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -426,7 +426,7 @@ struct GraphRecording {
 };
 
 struct GraphPendingUpload {
-    PTO2TaskSlotState *outer_slot{nullptr};
+    ChipTaskSlotState *outer_slot{nullptr};
     uint64_t full_key{0};
     uint64_t definition_hash{0};
     bool deferred_heap{false};
@@ -984,7 +984,7 @@ struct PTO2FaninBuilder {
 };
 
 static bool append_fanin_or_fail(
-    PTO2OrchestratorState *orch, uint8_t prod_ring, int32_t prod_slot, PTO2TaskSlotState *prod_state,
+    PTO2OrchestratorState *orch, uint8_t prod_ring, int32_t prod_slot, ChipTaskSlotState *prod_state,
     TaskId producer_task_id, PTO2FaninBuilder *fanin_builder
 ) {
     // Skip a stale/reused producer slot: the cached owner id no longer resolves
@@ -1027,7 +1027,7 @@ struct PTO2PreparedTask {
     PTO2TaskAllocResult alloc_result = {-1, 0, nullptr, nullptr};
     PTO2TaskDescriptor *task = nullptr;
     PTO2TaskPayload *payload = nullptr;
-    PTO2TaskSlotState *slot_state = nullptr;
+    ChipTaskSlotState *slot_state = nullptr;
 };
 
 static PTO2OutputLayout calculate_output_layout(const CoreTaskArgs &args) {
@@ -1350,7 +1350,7 @@ static TaskOutputTensors submit_task_common(
         PTO2SharedMemoryRingHeader &dep_ring = orch->sm_header->ring;
         int32_t dep_local_task_id = static_cast<int32_t>(dep_task_id.local());
         int32_t dep_slot = dep_ring.get_slot_by_task_id(dep_local_task_id);
-        PTO2TaskSlotState *producer_slot_state = &dep_ring.get_slot_state_by_slot(dep_slot);
+        ChipTaskSlotState *producer_slot_state = &dep_ring.get_slot_state_by_slot(dep_slot);
         if (!append_fanin_or_fail(orch, dep_ring_id, dep_slot, producer_slot_state, dep_task_id, &fanin_builder)) {
             return result;
         }
@@ -1366,7 +1366,7 @@ static TaskOutputTensors submit_task_common(
         uint8_t prod_ring = producer_task_id.ring();
         PTO2SharedMemoryRingHeader &producer_ring = orch->sm_header->ring;
         int32_t prod_slot = producer_ring.get_slot_by_task_id(static_cast<int32_t>(producer_task_id.local()));
-        PTO2TaskSlotState *prod_state = &producer_ring.get_slot_state_by_slot(prod_slot);
+        ChipTaskSlotState *prod_state = &producer_ring.get_slot_state_by_slot(prod_slot);
         return append_fanin_or_fail(orch, prod_ring, prod_slot, prod_state, producer_task_id, &fanin_builder);
     };
 
@@ -1639,7 +1639,7 @@ bool graph_submit_outer(
     PTO2SharedMemoryRingHeader &ring = orch->sm_header->ring;
     PTO2TaskDescriptor &task = ring.task_descriptors[allocation.slot];
     PTO2TaskPayload &payload = ring.task_payloads[allocation.slot];
-    PTO2TaskSlotState &slot = ring.get_slot_state_by_slot(allocation.slot);
+    ChipTaskSlotState &slot = ring.get_slot_state_by_slot(allocation.slot);
 
     // Init-on-write, as in prepare_task: this slot's dynamic scheduling fields and
     // completion flag are established here, at the claim, because nothing else
@@ -1689,7 +1689,7 @@ bool graph_submit_outer(
     auto emit = [&](TaskId producer_id) -> bool {
         const int32_t producer_local = static_cast<int32_t>(producer_id.local());
         const int32_t producer_slot = ring.get_slot_by_task_id(producer_local);
-        PTO2TaskSlotState *producer = &ring.get_slot_state_by_slot(producer_slot);
+        ChipTaskSlotState *producer = &ring.get_slot_state_by_slot(producer_slot);
         return append_fanin_or_fail(orch, producer_id.ring(), producer_slot, producer, producer_id, &fanin_builder);
     };
     // An outer GRAPH task is a ring task like any other, so the dependency graph

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
@@ -378,7 +378,7 @@ void set_tensor_data(
     }
 }
 
-// Ops-table entry that hands the call-site captured by PTO2ScopeGuard to the
+// Ops-table entry that hands the call-site captured by ScopeGuard to the
 // [ScopeStats] collector. The slot is always present in the struct to keep
 // the layout stable; at SIMPLER_DFX=0 we fill nullptr so the orchestration
 // .so's null-check skips it.

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
@@ -180,14 +180,14 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
     // idempotent (task_state is monotonic) and only adds one atomic load on
     // the second encounter.
     constexpr int kSegmentCap = 64;
-    const PTO2TaskSlotState *seg[kSegmentCap];
+    const ChipTaskSlotState *seg[kSegmentCap];
     int seg_count = 0;
     bool failed = false;
 
     // Returns nullptr for every rejected producer, having latched the fatal.
     // Callers branch on the returned pointer, not on `failed`: the slot is
     // dereferenced immediately and a null return is the only safe signal.
-    auto resolve_producer = [&](TaskId producer) -> const PTO2TaskSlotState * {
+    auto resolve_producer = [&](TaskId producer) -> const ChipTaskSlotState * {
         if (!producer.is_valid() || producer.ring() != 0) {
             orch.report_fatal(
                 SIMPLER_ERROR_INVALID_ARGS, caller,
@@ -214,7 +214,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
         return &slot;
     };
 
-    auto wait_one_producer = [&](const PTO2TaskSlotState &slot) {
+    auto wait_one_producer = [&](const ChipTaskSlotState &slot) {
         uint8_t ring_id = 0;
         int32_t local_id = static_cast<int32_t>(slot.task->task_id.local());
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -241,7 +241,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
         }
     };
 
-    auto wait_one_consumers = [&](const PTO2TaskSlotState &slot) {
+    auto wait_one_consumers = [&](const ChipTaskSlotState &slot) {
         uint8_t ring_id = 0;
         int32_t local_id = slot.task->task_id.local();
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -284,7 +284,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
         seg_count = 0;
     };
 
-    auto try_push = [&](const PTO2TaskSlotState &s) {
+    auto try_push = [&](const ChipTaskSlotState &s) {
         for (int j = 0; j < seg_count; j++) {
             if (seg[j] == &s) return;  // per-segment dedup
         }

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
@@ -85,32 +85,32 @@ static constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_CYCLES =
 // =============================================================================
 
 static TaskOutputTensors
-submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
+submit_task_impl(RuntimeContext *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
     return rt->orchestrator->submit_task(mixed_kernels, args);
 }
 
-static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const CoreTaskArgs &args) {
+static TaskOutputTensors alloc_tensors_impl(RuntimeContext *rt, const CoreTaskArgs &args) {
     return rt->orchestrator->alloc_tensors(args);
 }
 
-static TaskOutputTensors submit_dummy_task_impl(PTO2Runtime *rt, const CoreTaskArgs &args) {
+static TaskOutputTensors submit_dummy_task_impl(RuntimeContext *rt, const CoreTaskArgs &args) {
     return rt->orchestrator->submit_dummy_task(args);
 }
 
-static GraphScopeResult graph_begin_impl(PTO2Runtime *rt, uint64_t graph_key, const GraphTaskArgs &args) {
+static GraphScopeResult graph_begin_impl(RuntimeContext *rt, uint64_t graph_key, const GraphTaskArgs &args) {
     if (rt == nullptr) return GraphScopeResult{};
     return rt->orchestrator->graph_begin(graph_key, args, rt->active_callable_hash);
 }
 
-static bool graph_prepare_impl(PTO2Runtime *rt, void *recording_handle, const GraphTaskArgs &args) {
+static bool graph_prepare_impl(RuntimeContext *rt, void *recording_handle, const GraphTaskArgs &args) {
     return rt != nullptr && rt->orchestrator->graph_prepare(recording_handle, args);
 }
 
-static void graph_abort_impl(PTO2Runtime *rt, void *recording_handle) {
+static void graph_abort_impl(RuntimeContext *rt, void *recording_handle) {
     if (rt != nullptr) rt->orchestrator->graph_abort(recording_handle);
 }
 
-static bool graph_end_impl(PTO2Runtime *rt) { return rt != nullptr && rt->orchestrator->graph_end(); }
+static bool graph_end_impl(RuntimeContext *rt) { return rt != nullptr && rt->orchestrator->graph_end(); }
 
 // The orchestration .so's phases arrive already bracketed, so this only forwards them
 // to the same pool the runtime's own records go to. Defined only at SIMPLER_DFX=1, like
@@ -122,19 +122,19 @@ static void record_orch_phase_impl(uint32_t kind, uint64_t start_ns, uint64_t en
 }
 #endif
 
-static void graph_commit_impl(PTO2Runtime *rt) {
+static void graph_commit_impl(RuntimeContext *rt) {
     if (rt != nullptr) rt->orchestrator->graph_commit();
 }
 
-void rt_scope_begin(PTO2Runtime *rt) {
+void rt_scope_begin(RuntimeContext *rt) {
     PTO2ScopeMode mode = rt->pending_scope_mode;
     rt->pending_scope_mode = PTO2ScopeMode::AUTO;
     rt->orchestrator->begin_scope(mode);
 }
 
-void rt_scope_end(PTO2Runtime *rt) { rt->orchestrator->end_scope(); }
+void rt_scope_end(RuntimeContext *rt) { rt->orchestrator->end_scope(); }
 
-void rt_orchestration_done(PTO2Runtime *rt) {
+void rt_orchestration_done(RuntimeContext *rt) {
     // Host orchestration calls this runtime entry directly rather than the
     // orchestration-SO wrapper. Commit here as well so an all-Graph entry has a
     // final synchronization point for its asynchronous recording and deferred
@@ -146,9 +146,9 @@ void rt_orchestration_done(PTO2Runtime *rt) {
     rt->inline_completed_tasks = rt->orchestrator->inline_completed_tasks;
 }
 
-static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator->fatal; }
+static bool is_fatal_impl(RuntimeContext *rt) { return rt->orchestrator->fatal; }
 
-void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...) {
+void rt_report_fatal(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     if (fmt == nullptr || fmt[0] == '\0') {
@@ -169,7 +169,7 @@ void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, cons
 // producer while one of its submitted consumers is still live.
 MAYBE_UNINITIALIZED_BEGIN
 static bool
-wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_consumers, const char *caller) {
+wait_for_tensor_ready(RuntimeContext *rt, const ChipTensor &tensor, bool wait_for_consumers, const char *caller) {
     TaskId owner = tensor.owner_task_id;
     PTO2OrchestratorState &orch = *rt->orchestrator;
 
@@ -320,7 +320,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
 }
 MAYBE_UNINITIALIZED_END
 
-uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]) {
+uint64_t get_tensor_data(RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]) {
     if (tensor.buffer.addr == 0) {
         unified_log_error(
             __FUNCTION__, "get_tensor_data: buffer not allocated (addr=0). "
@@ -350,7 +350,7 @@ uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndi
 }
 
 void set_tensor_data(
-    PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+    RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
 ) {
     if (tensor.buffer.addr == 0) {
         unified_log_error(
@@ -386,10 +386,10 @@ void set_tensor_data(
 static void scope_set_site_impl(const char *file, int line) { scope_stats_set_pending_site(file, line); }
 #endif
 
-static int32_t available_cluster_count_impl(PTO2Runtime *rt) { return rt->orchestrator->total_cluster_count; }
-static int32_t available_aiv_count_impl(PTO2Runtime *rt) { return rt->orchestrator->total_aiv_count; }
+static int32_t available_cluster_count_impl(RuntimeContext *rt) { return rt->orchestrator->total_cluster_count; }
+static int32_t available_aiv_count_impl(RuntimeContext *rt) { return rt->orchestrator->total_aiv_count; }
 
-static const PTO2RuntimeOps s_runtime_ops = {
+static const RuntimeOps s_runtime_ops = {
     .submit_task = submit_task_impl,
     .scope_begin = rt_scope_begin,
     .scope_end = rt_scope_end,
@@ -430,9 +430,9 @@ static const PTO2RuntimeOps s_runtime_ops = {
 // prebuilt arena image. The piece below — wiring the ops table — depends on the
 // device-side s_runtime_ops global, so it remains in the AICPU build.
 
-void runtime_bind_ops(PTO2Runtime *rt) { rt->ops = &s_runtime_ops; }
+void runtime_bind_ops(RuntimeContext *rt) { rt->ops = &s_runtime_ops; }
 
-void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode) {
+void runtime_set_mode(RuntimeContext *rt, RuntimeMode mode) {
     if (rt) {
         rt->mode = mode;
     }

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -186,7 +186,7 @@ private:
 
     void *gm_sm_ptr_;                        // GM pointer to PTO2 shared memory (device)
     void *gm_heap_ptr_;                      // GM heap for orchestrator output buffers (device)
-    void *slot_states_ptr_;                  // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
+    void *slot_states_ptr_;                  // Pointer to ChipTaskSlotState array (scheduler-private, for profiling)
     ChipStorageTaskArgs orch_args_storage_;  // Copy of args for device
 
     // Prebuilt-arena fast path (trb only). Set by the host before rtMemcpy'ing

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -12,7 +12,7 @@
  * Runtime Class - Device Execution and Handshake Control
  *
  * This class manages device-side execution through AICPU-AICore handshake
- * protocol. Task graph construction is handled by PTO2Runtime; this class
+ * protocol. Task graph construction is handled by RuntimeContext; this class
  * only handles:
  * - Handshake buffers for AICPU-AICore communication
  * - Execution parameters (block_dim, aicpu_thread_num)
@@ -136,7 +136,7 @@ struct Task {
  * Runtime class for device execution and handshake control
  *
  * This class manages AICPU-AICore communication through handshake buffers.
- * Task graph construction is handled by PTO2Runtime; this class only handles
+ * Task graph construction is handled by RuntimeContext; this class only handles
  * execution control and device orchestration state.
  */
 class Runtime {
@@ -253,7 +253,7 @@ public:
 
     // Prebuilt-arena fast path (trb only). Set by host's
     // bind_callable_to_runtime_impl; consumed by AICPU at boot to attach a
-    // DeviceArena to `prebuilt_arena_base_` and pick up the PTO2Runtime at
+    // DeviceArena to `prebuilt_arena_base_` and pick up the RuntimeContext at
     // `prebuilt_arena_base_ + prebuilt_runtime_offset_`. Both stay zero on
     // first construction (Runtime() ctor zeros them) so a non-prebuilt boot
     // path can still detect "no prebuilt image set" via nullptr.
@@ -293,7 +293,7 @@ public:
 
     // =========================================================================
     // Deprecated API (for platform compatibility, always returns 0/nullptr)
-    // Task graph is now managed by PTO2Runtime, not Runtime
+    // Task graph is now managed by RuntimeContext, not Runtime
     // =========================================================================
 
     /** @deprecated Task count is now in PTO2 shared memory */

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime_core.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime_core.h
@@ -9,9 +9,9 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Main Interface
+ * Runtime core interface
  *
- * This is the main header for the PTO Runtime2 system.
+ * This is the main header for the runtime.
  * It provides a unified API for task graph construction and execution.
  *
  * Key Features:
@@ -22,7 +22,7 @@
  * - Orchestrator-Scheduler decoupling via shared memory
  *
  * Usage:
- *   1. Create runtime: PTO2Runtime create methods
+ *   1. Create runtime: RuntimeContext create methods
  *   2. Build task graph in orchestration function:
  *      - begin_scope() / end_scope()
  *      - submit_task()
@@ -54,7 +54,7 @@
 /**
  * Runtime execution mode
  */
-enum PTO2RuntimeMode {
+enum RuntimeMode {
     PTO2_MODE_EXECUTE = 0,    // Execute tasks on workers
     PTO2_MODE_SIMULATE = 1,   // Simulate task execution with cycle counting
     PTO2_MODE_GRAPH_ONLY = 2  // Build graph only, no execution
@@ -67,16 +67,16 @@ enum PTO2RuntimeMode {
  * (via orchestration_api.h inline wrappers), so it has zero link
  * dependencies on runtime .cpp files.
  */
-typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
+typedef struct RuntimeContext RuntimeContext;  // forward declare for ops signatures
 class HostTensorAccessor;
 
-struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
-    void (*scope_begin)(PTO2Runtime *rt);
-    void (*scope_end)(PTO2Runtime *rt);
-    void (*orchestration_done)(PTO2Runtime *rt);
-    bool (*is_fatal)(PTO2Runtime *rt);
-    void (*report_fatal)(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
+struct RuntimeOps {
+    TaskOutputTensors (*submit_task)(RuntimeContext *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
+    void (*scope_begin)(RuntimeContext *rt);
+    void (*scope_end)(RuntimeContext *rt);
+    void (*orchestration_done)(RuntimeContext *rt);
+    bool (*is_fatal)(RuntimeContext *rt);
+    void (*report_fatal)(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
     // Logging (populated by runtime, called by orchestration)
     void (*log_error)(const char *func, const char *fmt, ...);
@@ -87,21 +87,21 @@ struct PTO2RuntimeOps {
 
     // Cross-layer data access (orchestration reads/writes tensor values via runtime)
     // Placed after logging to avoid shifting hot-path field offsets.
-    uint64_t (*get_tensor_data)(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
+    uint64_t (*get_tensor_data)(RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
     void (*set_tensor_data)(
-        PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+        RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
     );
-    TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const CoreTaskArgs &args);
-    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const CoreTaskArgs &args);
+    TaskOutputTensors (*alloc_tensors)(RuntimeContext *rt, const CoreTaskArgs &args);
+    TaskOutputTensors (*submit_dummy_task)(RuntimeContext *rt, const CoreTaskArgs &args);
     // This-run core geometry latched by the host bind: MIX clusters
     // (one AIC each) and standalone AIV cores.
-    int32_t (*available_cluster_count)(PTO2Runtime *rt);
-    int32_t (*available_aiv_count)(PTO2Runtime *rt);
-    GraphScopeResult (*graph_begin)(PTO2Runtime *rt, uint64_t graph_key, const GraphTaskArgs &args);
-    bool (*graph_prepare)(PTO2Runtime *rt, void *recording_handle, const GraphTaskArgs &args);
-    void (*graph_abort)(PTO2Runtime *rt, void *recording_handle);
-    bool (*graph_end)(PTO2Runtime *rt);
-    void (*graph_commit)(PTO2Runtime *rt);
+    int32_t (*available_cluster_count)(RuntimeContext *rt);
+    int32_t (*available_aiv_count)(RuntimeContext *rt);
+    GraphScopeResult (*graph_begin)(RuntimeContext *rt, uint64_t graph_key, const GraphTaskArgs &args);
+    bool (*graph_prepare)(RuntimeContext *rt, void *recording_handle, const GraphTaskArgs &args);
+    void (*graph_abort)(RuntimeContext *rt, void *recording_handle);
+    bool (*graph_end)(RuntimeContext *rt);
+    void (*graph_commit)(RuntimeContext *rt);
     // Stash the call-site captured by ScopeGuard into the [ScopeStats]
     // collector. Always present in the struct to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
@@ -120,7 +120,7 @@ struct PTO2RuntimeOps {
  * runtime_reserve_layout(); consumed by runtime_init_data_from_layout and
  * runtime_wire_arena_pointers.
  */
-struct PTO2RuntimeArenaLayout {
+struct RuntimeArenaLayout {
     size_t off_sm_handle{0};
     PTO2SchedulerLayout sched;
     size_t off_scheduler{0};
@@ -164,14 +164,14 @@ struct PTO2RuntimeArenaLayout {
 };
 
 /**
- * PTO Runtime2 context
+ * Runtime context
  *
  * Contains all state for orchestration and scheduling.
  * In simulated mode, runs in single process with shared address space.
  */
-struct PTO2Runtime {
+struct RuntimeContext {
     // Ops table (first field — used by orchestration .so via function pointers)
-    const PTO2RuntimeOps *ops;
+    const RuntimeOps *ops;
     PTO2ScopeMode pending_scope_mode;
 
     // Components
@@ -192,7 +192,7 @@ struct PTO2Runtime {
     bool gm_heap_owned;  // True if we allocated it
 
     // Mode
-    PTO2RuntimeMode mode;
+    RuntimeMode mode;
 
     // Statistics
     int64_t total_cycles;
@@ -208,7 +208,7 @@ struct PTO2Runtime {
     // registered them. Null on the AICPU path, which loads device addresses
     // directly; get_tensor_data / set_tensor_data then fail closed rather than
     // dereferencing one. Lives past the first two fields, so the orchestration
-    // .so's partial PTO2Runtime definition neither sees nor needs it.
+    // .so's partial RuntimeContext definition neither sees nor needs it.
     HostTensorAccessor *tensor_access;
 
     // Prebuilt-arena fast path metadata. Carries every offset
@@ -219,7 +219,7 @@ struct PTO2Runtime {
     // *before* dereferencing this image. Populated on host by
     // runtime_init_data_from_layout + runtime_wire_arena_pointers; read by
     // aicpu_executor.cpp.
-    PTO2RuntimeArenaLayout prebuilt_layout;
+    RuntimeArenaLayout prebuilt_layout;
 };
 
 // bind copies this header to the device as one contiguous range, so every byte
@@ -227,8 +227,8 @@ struct PTO2Runtime {
 // otherwise non-trivial member — the orchestrator's scratch is reached through
 // a pointer for exactly this reason.
 static_assert(
-    std::is_trivially_copyable_v<PTO2Runtime> && std::is_standard_layout_v<PTO2Runtime>,
-    "PTO2Runtime is copied to the device verbatim"
+    std::is_trivially_copyable_v<RuntimeContext> && std::is_standard_layout_v<RuntimeContext>,
+    "RuntimeContext is copied to the device verbatim"
 );
 
 // =============================================================================
@@ -237,11 +237,11 @@ static_assert(
 
 /**
  * Phase 1 — declare every sub-region (sm_handle wrapper, scheduler / mailbox /
- * PTO2Runtime header) on the supplied arena. Pure arithmetic; does not touch
+ * RuntimeContext header) on the supplied arena. Pure arithmetic; does not touch
  * device memory and may run on host. Returns the layout descriptor; caller
  * commits/attaches the arena before Phase 2/3.
  */
-PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, uint64_t heap_size = 0);
+RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, uint64_t heap_size = 0);
 
 /**
  * Phase 2 — write the data half of the runtime arena: standalone fields,
@@ -253,15 +253,15 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_
  * them (never dereference). Safe to run on a host arena that owns a host
  * mirror of the runtime image — the resulting buffer is rtMemcpy-ready.
  *
- * Returns the PTO2Runtime* that sits at layout.off_runtime within the arena.
+ * Returns the RuntimeContext* that sits at layout.off_runtime within the arena.
  * Caller must follow up with runtime_wire_arena_pointers; rt->ops and the
  * AICore-side count fields are left untouched and must be filled by the
  * AICPU at boot. Initializes the scheduler only: the orchestrator is a
  * host-owned object the host-orch path (run_host_orchestration) stands up and
  * points rt->orchestrator at, and it is never uploaded to the device.
  */
-PTO2Runtime *runtime_init_data_from_layout(
-    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
+RuntimeContext *runtime_init_data_from_layout(
+    DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
     void *gm_heap_dev_base, uint64_t heap_size
 );
 
@@ -272,7 +272,7 @@ PTO2Runtime *runtime_init_data_from_layout(
  * holds arena.base() + offset. Idempotent — runs on both host (writing
  * host-mirror addresses) and AICPU (writing device addresses) sides.
  */
-void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
+void runtime_wire_arena_pointers(DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeContext *rt);
 
 /**
  * AICPU-only Phase 4 — install the ops table, the one field the host could not
@@ -280,7 +280,7 @@ void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayou
  * global, so the host cannot resolve its device address). Call once per boot
  * after runtime_wire_arena_pointers.
  */
-void runtime_bind_ops(PTO2Runtime *rt);
+void runtime_bind_ops(RuntimeContext *rt);
 
 /**
  * Destroy runtime. With the prebuilt-arena fast path the arena buffer is
@@ -288,12 +288,12 @@ void runtime_bind_ops(PTO2Runtime *rt);
  * here — the destructor only forgets sub-structure pointers (idempotent
  * cleanup).
  */
-void runtime_destroy(PTO2Runtime *rt, DeviceArena &arena);
+void runtime_destroy(RuntimeContext *rt, DeviceArena &arena);
 
 /**
  * Set execution mode
  */
-void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
+void runtime_set_mode(RuntimeContext *rt, RuntimeMode mode);
 
 // =============================================================================
 // Orchestration API (called by orchestration function)
@@ -305,10 +305,10 @@ void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
  * submit_task requires at least one open scope. A MANUAL scope additionally makes
  * every submit inside it bypass TensorMap discovery and take its fanin from
  * CoreTaskArgs::set_dependencies() instead; an AUTO scope nested inside a MANUAL
- * one is rejected. The mode is read from PTO2Runtime::pending_scope_mode, which
+ * one is rejected. The mode is read from RuntimeContext::pending_scope_mode, which
  * SIMPLER_SCOPE sets immediately before this call.
  */
-void rt_scope_begin(PTO2Runtime *rt);
+void rt_scope_begin(RuntimeContext *rt);
 
 /**
  * End current scope
@@ -318,24 +318,24 @@ void rt_scope_begin(PTO2Runtime *rt);
  * here: the ring is whole-graph-resident, so no task slot and no heap byte is
  * reclaimed before the run ends.
  */
-void rt_scope_end(PTO2Runtime *rt);
+void rt_scope_end(RuntimeContext *rt);
 
 /**
  * Mark orchestration as complete
  *
  * Signals that no more tasks will be submitted.
  */
-void rt_orchestration_done(PTO2Runtime *rt);
+void rt_orchestration_done(RuntimeContext *rt);
 
 /**
  * Enter fatal state explicitly from orchestration.
  */
-void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
+void rt_report_fatal(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
 /**
  * Cross-layer data access: read a tensor value by waiting for its producer.
  */
-uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
+uint64_t get_tensor_data(RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
 
 /**
  * Cross-layer data access: write a value to a tensor at given indices.
@@ -343,7 +343,7 @@ uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndi
  * See set_tensor_data in orchestration_api.h for full documentation.
  */
 void set_tensor_data(
-    PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+    RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
 );
 
 /**

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime_core.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime_core.h
@@ -102,7 +102,7 @@ struct PTO2RuntimeOps {
     void (*graph_abort)(PTO2Runtime *rt, void *recording_handle);
     bool (*graph_end)(PTO2Runtime *rt);
     void (*graph_commit)(PTO2Runtime *rt);
-    // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]
+    // Stash the call-site captured by ScopeGuard into the [ScopeStats]
     // collector. Always present in the struct to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
     void (*scope_set_site)(const char *file, int line);
@@ -306,7 +306,7 @@ void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
  * every submit inside it bypass TensorMap discovery and take its fanin from
  * CoreTaskArgs::set_dependencies() instead; an AUTO scope nested inside a MANUAL
  * one is rejected. The mode is read from PTO2Runtime::pending_scope_mode, which
- * PTO2_SCOPE sets immediately before this call.
+ * SIMPLER_SCOPE sets immediately before this call.
  */
 void rt_scope_begin(PTO2Runtime *rt);
 

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime_core.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime_core.h
@@ -352,7 +352,7 @@ void set_tensor_data(
  */
 #ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
-struct PTO2OrchestrationConfig {
+struct OrchestrationConfig {
     int expected_arg_count;
 };
 #endif

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime_types.h
@@ -189,7 +189,7 @@ struct PTO2OutputLayout {
 // Dependency List Entry
 // =============================================================================
 
-struct PTO2TaskSlotState;  // Forward declaration (defined below)
+struct ChipTaskSlotState;  // Forward declaration (defined below)
 
 // =============================================================================
 // Task Descriptor
@@ -200,7 +200,7 @@ struct PTO2TaskSlotState;  // Forward declaration (defined below)
  *
  * Stored in the TaskDescriptor ring buffer in shared memory.
  * Contains static identification and buffer pointers only.
- * Dynamic scheduling state (fanin/fanout/task_state) is in PTO2TaskSlotState.
+ * Dynamic scheduling state (fanin/fanout/task_state) is in ChipTaskSlotState.
  *
  * Fields set by Orchestrator at submission, read by Scheduler for dispatch.
  */
@@ -509,7 +509,7 @@ static_assert(sizeof(ChipTensor) == 128, "ChipTensor must be 2 cache lines");
  * deadlock detector, and the cold-path stall dump. completion_flags is the
  * device-side readiness truth; task_state is the host-visible mirror.
  */
-struct alignas(64) PTO2TaskSlotState {
+struct alignas(64) ChipTaskSlotState {
     // Highest local task id among this slot's consumers. Reclaim gate: the slot
     // is safe to retire once the per-ring completed_watermark reaches this id.
     // Whole-graph-resident hbg never reclaims at runtime, so this is
@@ -533,8 +533,8 @@ struct alignas(64) PTO2TaskSlotState {
     // that producer's wake list (CAS push through next_in_wake_list). On
     // completion the producer atomic-exchanges wake_list_head to
     // WAKE_LIST_SENTINEL and routes every waiter. Reset to nullptr at init.
-    std::atomic<PTO2TaskSlotState *> wake_list_head{nullptr};
-    PTO2TaskSlotState *next_in_wake_list{nullptr};
+    std::atomic<ChipTaskSlotState *> wake_list_head{nullptr};
+    ChipTaskSlotState *next_in_wake_list{nullptr};
 
     // --- Set per-submit (depend on task inputs) ---
     ActiveMask active_mask;  // Bitmask of active subtask slots (set once)
@@ -624,8 +624,8 @@ struct alignas(64) PTO2TaskSlotState {
     }
 };
 
-static_assert(sizeof(PTO2TaskSlotState) == 64);
+static_assert(sizeof(ChipTaskSlotState) == 64);
 
 // Sentinel marking a wake list as "owner already completed; no more
 // registrations accepted". Distinct from any real slot_state pointer.
-inline PTO2TaskSlotState *const WAKE_LIST_SENTINEL = reinterpret_cast<PTO2TaskSlotState *>(static_cast<uintptr_t>(0x1));
+inline ChipTaskSlotState *const WAKE_LIST_SENTINEL = reinterpret_cast<ChipTaskSlotState *>(static_cast<uintptr_t>(0x1));

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -63,7 +63,7 @@
  */
 struct PTO2ReadyQueueSlot {
     std::atomic<int64_t> sequence;
-    PTO2TaskSlotState *slot_state;
+    ChipTaskSlotState *slot_state;
     uint64_t task_id_snapshot;
 };
 
@@ -121,9 +121,9 @@ struct alignas(64) PTO2ReadyQueue {
                                  )) {}
     }
 
-    bool push(PTO2TaskSlotState *slot_state) { return push_tagged(slot_state, 0); }
+    bool push(ChipTaskSlotState *slot_state) { return push_tagged(slot_state, 0); }
 
-    bool push_tagged(PTO2TaskSlotState *slot_state, uint64_t task_id_snapshot) {
+    bool push_tagged(ChipTaskSlotState *slot_state, uint64_t task_id_snapshot) {
         uint64_t pos;
         PTO2ReadyQueueSlot *slot;
         while (true) {
@@ -155,9 +155,9 @@ struct alignas(64) PTO2ReadyQueue {
     // `count` items. A target slot holding an older generation means full and
     // ends the call; a slot a peer has reserved but not yet published is
     // transient and retries, so this only spins while a peer is mid-publish.
-    bool push_batch(PTO2TaskSlotState **items, int count) { return push_batch_tagged(items, nullptr, count); }
+    bool push_batch(ChipTaskSlotState **items, int count) { return push_batch_tagged(items, nullptr, count); }
 
-    bool push_batch_tagged(PTO2TaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
+    bool push_batch_tagged(ChipTaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
         if (count == 0) return true;
         if (static_cast<uint64_t>(count) > capacity) return false;
 
@@ -198,7 +198,7 @@ struct alignas(64) PTO2ReadyQueue {
     }
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
-    bool push(PTO2TaskSlotState *slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {
+    bool push(ChipTaskSlotState *slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {
         uint64_t pos;
         PTO2ReadyQueueSlot *slot;
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -237,9 +237,9 @@ struct alignas(64) PTO2ReadyQueue {
     }
 #endif
 
-    PTO2TaskSlotState *pop() { return pop_tagged(nullptr); }
+    ChipTaskSlotState *pop() { return pop_tagged(nullptr); }
 
-    PTO2TaskSlotState *pop_tagged(uint64_t *task_id_snapshot) {
+    ChipTaskSlotState *pop_tagged(uint64_t *task_id_snapshot) {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -264,14 +264,14 @@ struct alignas(64) PTO2ReadyQueue {
             }
         }
 
-        PTO2TaskSlotState *result = slot->slot_state;
+        ChipTaskSlotState *result = slot->slot_state;
         if (task_id_snapshot != nullptr) *task_id_snapshot = slot->task_id_snapshot;
         slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
 
 #if SIMPLER_SCHED_PROFILING
-    PTO2TaskSlotState *pop(uint64_t &atomic_count, uint64_t &wait_cycle) {
+    ChipTaskSlotState *pop(uint64_t &atomic_count, uint64_t &wait_cycle) {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -313,7 +313,7 @@ struct alignas(64) PTO2ReadyQueue {
             wait_cycle += (get_sys_cnt_aicpu() - t0);
         }
 
-        PTO2TaskSlotState *result = slot->slot_state;
+        ChipTaskSlotState *result = slot->slot_state;
         slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
@@ -321,9 +321,9 @@ struct alignas(64) PTO2ReadyQueue {
 
     // Batch pop: reserve a contiguous run of ready slots with a single CAS.
     // Returns actual number of items popped (may be less than max_count).
-    int pop_batch(PTO2TaskSlotState **out, int max_count) { return pop_batch_tagged(out, nullptr, max_count); }
+    int pop_batch(ChipTaskSlotState **out, int max_count) { return pop_batch_tagged(out, nullptr, max_count); }
 
-    int pop_batch_tagged(PTO2TaskSlotState **out, uint64_t *task_id_snapshots, int max_count) {
+    int pop_batch_tagged(ChipTaskSlotState **out, uint64_t *task_id_snapshots, int max_count) {
         uint64_t pos;
         int count;
         while (true) {
@@ -362,7 +362,7 @@ struct alignas(64) PTO2ReadyQueue {
     }
 
 #if SIMPLER_SCHED_PROFILING
-    int pop_batch(PTO2TaskSlotState **out, int max_count, uint64_t &atomic_count, uint64_t &wait_cycle) {
+    int pop_batch(ChipTaskSlotState **out, int max_count, uint64_t &atomic_count, uint64_t &wait_cycle) {
         uint64_t pos;
         int count;
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -537,13 +537,13 @@ struct PTO2SchedulerState {
         }
     }
 
-    bool push_graph_prepare(PTO2TaskSlotState *slot_state, uint64_t task_id, int32_t thread_idx) {
+    bool push_graph_prepare(ChipTaskSlotState *slot_state, uint64_t task_id, int32_t thread_idx) {
         if (graph_prepare_queue.push_tagged(slot_state, task_id)) return true;
         latch_ready_queue_overflow(thread_idx);
         return false;
     }
 
-    void push_ready_routed(PTO2TaskSlotState *slot_state) {
+    void push_ready_routed(ChipTaskSlotState *slot_state) {
         bool pushed;
         if (slot_state->task_kind == TaskKind::GRAPH) {
             pushed = graph_ready_queue.push(slot_state);
@@ -584,7 +584,7 @@ struct PTO2SchedulerState {
     // its first one completes) and the CAS traffic those transfers put on the
     // lists. The decision is terminal: tasks are never re-polled; a producer's
     // completion re-scans its waiters via on_mixed_task_complete's wake drain.
-    int classify_fanin_state(const PTO2TaskSlotState *s) const {
+    int classify_fanin_state(const ChipTaskSlotState *s) const {
         const PTO2TaskPayload &p = *s->payload;
         const PTO2SharedMemoryRingHeader &ring = *ring_sched_state.ring;
         const int32_t *fanin = p.fanin_data();
@@ -598,10 +598,10 @@ struct PTO2SchedulerState {
     // completed (head == SENTINEL), re-classify against ALL fanins: route to
     // ready only when every fanin is met, else re-target the next unmet producer
     // and retry. Monotonic completion_flags guarantee termination.
-    void register_wake(PTO2TaskSlotState *producer, PTO2TaskSlotState *consumer) {
+    void register_wake(ChipTaskSlotState *producer, ChipTaskSlotState *consumer) {
         PTO2SharedMemoryRingHeader &ring = *ring_sched_state.ring;
         while (true) {
-            PTO2TaskSlotState *expected = producer->wake_list_head.load(std::memory_order_relaxed);
+            ChipTaskSlotState *expected = producer->wake_list_head.load(std::memory_order_relaxed);
             while (expected != WAKE_LIST_SENTINEL) {
                 consumer->next_in_wake_list = expected;
                 if (producer->wake_list_head.compare_exchange_weak(
@@ -625,16 +625,16 @@ struct PTO2SchedulerState {
     // completed_watermark (load-bearing: the host wait_for_consumers gates on
     // watermark >= producer.last_consumer_local_id). Whole-graph-resident hbg
     // has no device slot reclaim, so no advance_ring_pointers here.
-    void on_mixed_task_complete(PTO2TaskSlotState &slot_state) {
+    void on_mixed_task_complete(ChipTaskSlotState &slot_state) {
         const int32_t task_id = static_cast<int32_t>(slot_state.task->task_id.local());
         PTO2SharedMemoryRingHeader &ring = *ring_sched_state.ring;
 
         slot_state.mark_completed();  // host-visible mirror (task_state = COMPLETED)
         ring.set_completion_flag(task_id);
 
-        PTO2TaskSlotState *waiter = slot_state.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
+        ChipTaskSlotState *waiter = slot_state.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
         while (waiter != nullptr && waiter != WAKE_LIST_SENTINEL) {
-            PTO2TaskSlotState *next = waiter->next_in_wake_list;
+            ChipTaskSlotState *next = waiter->next_in_wake_list;
             if (waiter->payload->fanin_count == 1) {
                 push_ready_routed(waiter);  // single-fanin waiter was waiting only on us
                 waiter = next;
@@ -764,7 +764,7 @@ struct PTO2SchedulerState {
         );
     }
 
-    inline void record_published_blocks(PTO2TaskSlotState &slot_state, int32_t count) {
+    inline void record_published_blocks(ChipTaskSlotState &slot_state, int32_t count) {
         if (count <= 0 || !slot_state.task_attrs.allow_early_resolve()) return;
         slot_state.payload->published_block_count.fetch_add(static_cast<int16_t>(count), std::memory_order_seq_cst);
     }
@@ -772,7 +772,7 @@ struct PTO2SchedulerState {
     // Ring one sync_start cohort from its stable staged_core_mask. The caller owns
     // the NONE->RINGING launch latch and invokes this exactly once after local or
     // global staging completes, while the corresponding per-core table entries are live.
-    inline void ring_all_staged_doorbells(PTO2TaskSlotState &slot_state) {
+    inline void ring_all_staged_doorbells(ChipTaskSlotState &slot_state) {
         for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
             uint64_t bits = slot_state.payload->staged_core_mask[w].load(std::memory_order_seq_cst);
             while (bits != 0) {
@@ -806,7 +806,7 @@ struct PTO2SchedulerState {
         return (previous & PTO2_EARLY_SYNC_DRAIN_OWNER) != 0;
     }
 
-    inline void cancel_early_sync_drain(PTO2TaskSlotState &slot_state) {
+    inline void cancel_early_sync_drain(ChipTaskSlotState &slot_state) {
         uint8_t previous =
             slot_state.payload->early_sync_drain_state.exchange(PTO2_EARLY_SYNC_DRAIN_NONE, std::memory_order_seq_cst);
         if ((previous & PTO2_EARLY_SYNC_DRAIN_OWNER) == 0) return;
@@ -839,7 +839,7 @@ struct PTO2SchedulerState {
     // release and each pending->running promotion); whichever observes the second half
     // wins the launch latch and rings exactly once. Returns true only to that winner,
     // which may then expose the cohort to its fanout.
-    inline bool maybe_rendezvous_ring(PTO2TaskSlotState &slot_state) {
+    inline bool maybe_rendezvous_ring(ChipTaskSlotState &slot_state) {
         // running_slot_count is the publication seed: every staged_core_mask OR
         // happens-before its final store. Read the seed first, then the mask, so
         // observing the final count cannot be paired with a partially published
@@ -862,7 +862,7 @@ struct PTO2SchedulerState {
         return true;
     }
 
-    inline bool retry_sync_start_rendezvous_after_staging(PTO2TaskSlotState &slot_state) {
+    inline bool retry_sync_start_rendezvous_after_staging(ChipTaskSlotState &slot_state) {
         if (!maybe_rendezvous_ring(slot_state)) return false;
         propagate_dispatch_fanin(slot_state);
         return true;
@@ -877,15 +877,15 @@ struct PTO2SchedulerState {
     // path (wake drain -> push_ready_routed). Milestone 2 replaces this with the
     // consumer-pull publish_flags design. sync_start cohorts still launch via
     // ready_sync_queues (unaffected).
-    void propagate_dispatch_fanin(PTO2TaskSlotState & /*p*/) {}
+    void propagate_dispatch_fanin(ChipTaskSlotState & /*p*/) {}
 
-    int get_ready_tasks_batch(PTO2ReadyQueue *queues, PTO2ResourceShape shape, PTO2TaskSlotState **out, int max_count) {
+    int get_ready_tasks_batch(PTO2ReadyQueue *queues, PTO2ResourceShape shape, ChipTaskSlotState **out, int max_count) {
         return queues[static_cast<int32_t>(shape)].pop_batch(out, max_count);
     }
 
 #if SIMPLER_SCHED_PROFILING
     int get_ready_tasks_batch(
-        PTO2ReadyQueue *queues, PTO2ResourceShape shape, PTO2TaskSlotState **out, int max_count, uint64_t &atomic_count,
+        PTO2ReadyQueue *queues, PTO2ResourceShape shape, ChipTaskSlotState **out, int max_count, uint64_t &atomic_count,
         uint64_t &wait_cycle
     ) {
         return queues[static_cast<int32_t>(shape)].pop_batch(out, max_count, atomic_count, wait_cycle);
@@ -895,13 +895,13 @@ struct PTO2SchedulerState {
     // Orch owns dependency discovery and saves the immutable fanin wire.
     // Scheduler polling only chooses which already-wired producer a consumer
     // waits on at this instant; it never recomputes producer relationships.
-    int32_t graph_first_unmet_producer(const GraphExecution &execution, const PTO2TaskSlotState &consumer) const {
+    int32_t graph_first_unmet_producer(const GraphExecution &execution, const ChipTaskSlotState &consumer) const {
         const uint32_t node_index = static_cast<uint32_t>(consumer.graph_node_index);
         const uint32_t begin = execution.fanin_offsets[node_index];
         const uint32_t end = execution.fanin_offsets[node_index + 1];
         for (uint32_t edge = begin; edge < end; ++edge) {
             const uint16_t producer_index = execution.fanin_indices[edge];
-            const PTO2TaskSlotState &producer = execution.node_at(producer_index).slot;
+            const ChipTaskSlotState &producer = execution.node_at(producer_index).slot;
             if (producer.task_state.load(std::memory_order_acquire) != PTO2_TASK_COMPLETED) {
                 return static_cast<int32_t>(producer_index);
             }
@@ -909,9 +909,9 @@ struct PTO2SchedulerState {
         return -1;
     }
 
-    void register_graph_wake(GraphExecution &execution, PTO2TaskSlotState *producer, PTO2TaskSlotState *consumer) {
+    void register_graph_wake(GraphExecution &execution, ChipTaskSlotState *producer, ChipTaskSlotState *consumer) {
         while (true) {
-            PTO2TaskSlotState *expected = producer->wake_list_head.load(std::memory_order_relaxed);
+            ChipTaskSlotState *expected = producer->wake_list_head.load(std::memory_order_relaxed);
             while (expected != WAKE_LIST_SENTINEL) {
                 consumer->next_in_wake_list = expected;
                 if (producer->wake_list_head.compare_exchange_weak(
@@ -933,11 +933,11 @@ struct PTO2SchedulerState {
         }
     }
 
-    uint32_t drain_graph_wake_list(GraphExecution &execution, PTO2TaskSlotState &producer) {
+    uint32_t drain_graph_wake_list(GraphExecution &execution, ChipTaskSlotState &producer) {
         uint32_t consumers_rescanned = 0;
-        PTO2TaskSlotState *waiter = producer.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
+        ChipTaskSlotState *waiter = producer.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
         while (waiter != nullptr && waiter != WAKE_LIST_SENTINEL) {
-            PTO2TaskSlotState *next = waiter->next_in_wake_list;
+            ChipTaskSlotState *next = waiter->next_in_wake_list;
             const int32_t unmet_producer = graph_first_unmet_producer(execution, *waiter);
             if (unmet_producer < 0) {
                 push_ready_routed(waiter);
@@ -987,7 +987,7 @@ struct PTO2SchedulerState {
     void graph_incremental_publish(GraphExecution &execution, int32_t first, int32_t last) {
         for (int32_t i = first; i < last; ++i) {
             if (execution.fanin_offsets[i] == execution.fanin_offsets[i + 1]) continue;  // root
-            PTO2TaskSlotState &node = execution.node_at(i).slot;
+            ChipTaskSlotState &node = execution.node_at(i).slot;
             const int32_t unmet = graph_first_unmet_producer(execution, node);
             if (unmet < 0) {
                 push_ready_routed(&node);
@@ -1007,7 +1007,7 @@ struct PTO2SchedulerState {
     }
 
     GraphMaterializeResult prepare_graph_task(
-        PTO2TaskSlotState &outer_slot, int32_t max_nodes = GRAPH_MATERIALIZE_SLICE_NODES,
+        ChipTaskSlotState &outer_slot, int32_t max_nodes = GRAPH_MATERIALIZE_SLICE_NODES,
         int32_t *nodes_materialized = nullptr
     ) {
         GraphExecution *execution = graph_execution_from_outer_slot(outer_slot);
@@ -1024,7 +1024,7 @@ struct PTO2SchedulerState {
         return result;
     }
 
-    int32_t activate_graph_task(PTO2TaskSlotState &outer_slot) {
+    int32_t activate_graph_task(ChipTaskSlotState &outer_slot) {
         GraphExecution *execution = graph_execution_from_outer_slot(outer_slot);
         if (execution == nullptr) return 0;
         graph_execution_signal_external_ready(*execution);
@@ -1038,7 +1038,7 @@ struct PTO2SchedulerState {
     };
 
     TaskCompletionOutcome complete_task(
-        PTO2TaskSlotState &slot_state
+        ChipTaskSlotState &slot_state
 #if SIMPLER_SCHED_PROFILING
         ,
         int thread_idx
@@ -1110,7 +1110,7 @@ struct PTO2SchedulerState {
      *
      * @return true if this was the last subtask, completing the entire task.
      */
-    bool on_subtask_complete(PTO2TaskSlotState &slot_state) {
+    bool on_subtask_complete(ChipTaskSlotState &slot_state) {
         int16_t prev = slot_state.completed_subtasks.fetch_add(1, std::memory_order_acq_rel);
         return (prev + 1) == slot_state.total_required_subtasks;
     }
@@ -1133,7 +1133,7 @@ struct PTO2SchedulerState {
     uint32_t
 #endif
     on_task_complete(
-        PTO2TaskSlotState &slot_state
+        ChipTaskSlotState &slot_state
 #if SIMPLER_SCHED_PROFILING
         ,
         int thread_idx
@@ -1206,7 +1206,7 @@ struct PTO2SchedulerState {
 // Polling: on_task_complete publishes completion + drains the wake list inline,
 // so the async-drain path no longer buffers producer releases.
 inline bool
-AsyncWaitList::try_inline_complete_locked(AsyncWaitList::DrainCompletionSink &sink, PTO2TaskSlotState &slot_state) {
+AsyncWaitList::try_inline_complete_locked(AsyncWaitList::DrainCompletionSink &sink, ChipTaskSlotState &slot_state) {
     // Return value (CompletionStats / consumer-walk count) discarded:
     // async-wait drain path has no Resolve swimlane bar attached.
 #if SIMPLER_SCHED_PROFILING

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -236,7 +236,7 @@ void SchedulerContext::log_stall_diagnostics(
         int32_t ring_task_count = ring.fc.current_task_index.load(std::memory_order_relaxed);
         submitted_in_ring += ring_task_count;
         for (int32_t si = 0; si < ring_task_count; si++) {
-            PTO2TaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
+            ChipTaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
             PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
             // Polling: no fanin_refcount. Recompute met/total from the inline
             // fanin ids vs the ring completion_flags (rc = satisfied producers,
@@ -396,7 +396,7 @@ int32_t SchedulerContext::handle_timeout_exit(
                 [this](int32_t func_id) {
                     return get_function_bin_addr(func_id);
                 },
-                [](const PTO2TaskSlotState &slot_state) {
+                [](const ChipTaskSlotState &slot_state) {
                     return &slot_state.payload->dump_metadata;
                 }
             );
@@ -1135,7 +1135,7 @@ void SchedulerContext::classify_partition(int32_t thread_idx, int32_t nthreads) 
         if (ring.is_completion_flag_set(id)) {
             continue;  // completed on the host (hidden alloc); nothing to dispatch
         }
-        PTO2TaskSlotState &slot = ring.get_slot_state_by_task_id(id);
+        ChipTaskSlotState &slot = ring.get_slot_state_by_task_id(id);
         if (slot.task_kind == TaskKind::GRAPH) {
             if (graph_execution_localize(slot) == nullptr) slot.graph_context = nullptr;
             if (!sched_->push_graph_prepare(&slot, slot.task->task_id.raw, thread_idx)) return;

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -1035,7 +1035,7 @@ void SchedulerContext::deinit() {
     func_id_to_addr_ = nullptr;
 }
 
-void SchedulerContext::bind_runtime(PTO2Runtime *rt) {
+void SchedulerContext::bind_runtime(RuntimeContext *rt) {
     rt_ = rt;
     sched_ = rt->scheduler;
 }
@@ -1049,7 +1049,7 @@ void SchedulerContext::bind_runtime(PTO2Runtime *rt) {
 // dispatching.
 // =============================================================================
 void SchedulerContext::on_orchestration_done(
-    Runtime *runtime, PTO2Runtime *rt, [[maybe_unused]] int32_t thread_idx, int32_t total_tasks
+    Runtime *runtime, RuntimeContext *rt, [[maybe_unused]] int32_t thread_idx, int32_t total_tasks
 ) {
     total_tasks_ = total_tasks;
 

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -81,7 +81,7 @@ SlotTransition SchedulerContext::decide_slot_transition(
 
 // Complete one slot's task: subtask counting, mixed completion, deferred release, profiling.
 void SchedulerContext::complete_slot_task(
-    PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, [[maybe_unused]] PTO2SubtaskSlot subslot,
+    ChipTaskSlotState &slot_state, int32_t expected_reg_task_id, [[maybe_unused]] PTO2SubtaskSlot subslot,
     int32_t thread_idx, int32_t core_id, Handshake *hank, [[maybe_unused]] int32_t &completed_this_turn
 #if SIMPLER_DFX
     ,
@@ -272,7 +272,7 @@ void SchedulerContext::check_running_cores_for_completion(
         // which point the core becomes pollable again and its FIN is caught.
         // Cheap cacheable load; no MMIO. Pending slot is empty while gated.
         {
-            PTO2TaskSlotState *rs = core.running_slot_state;
+            ChipTaskSlotState *rs = core.running_slot_state;
             if (rs != nullptr && rs->payload != nullptr &&
                 rs->payload->early_dispatch_state.load(std::memory_order_relaxed) == PTO2_EARLY_DISPATCH_STAGING) {
                 continue;
@@ -388,7 +388,7 @@ void SchedulerContext::check_running_cores_for_completion(
                 // rendezvous. Capture that BEFORE promote nulls the pending fields; after
                 // it lands, bump running_slot_count and ring iff this was the block that
                 // completed the cohort (and the producer already released).
-                PTO2TaskSlotState *promoted = core.pending_slot_state;
+                ChipTaskSlotState *promoted = core.pending_slot_state;
                 bool sync_start_promote = pending_gated && promoted->task_attrs.requires_sync_start();
                 promote_pending_to_running(core);  // Case 2 or Case 3 (with pending)
                 if (sync_start_promote) {
@@ -439,7 +439,7 @@ void SchedulerContext::check_running_cores_for_completion(
 // Two-phase protocol: CAS 0 -> -1 (sentinel) to claim ownership, store task and
 // reset staging state, then release-store block_num. Other threads acquire-load
 // sync_start_pending; seeing block_num > 0 ensures all relaxed stores are visible.
-bool SchedulerContext::enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t block_num) {
+bool SchedulerContext::enter_drain_mode(ChipTaskSlotState *slot_state, int32_t block_num) {
     int32_t expected = 0;
     if (!drain_state_.sync_start_pending.compare_exchange_strong(
             expected, -1, std::memory_order_acquire, std::memory_order_relaxed
@@ -488,7 +488,7 @@ int32_t SchedulerContext::count_global_available(PTO2ResourceShape shape, uint8_
 // block uses SPLIT placement (each core independently: idle->running, busy->pending) — safe
 // only because gated.
 SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
-    PTO2TaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated,
+    ChipTaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated,
     [[maybe_unused]] bool record_drain_phases
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -661,7 +661,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     }
     bool coordinator = thread_idx == 0;
 
-    PTO2TaskSlotState *slot_state = drain_state_.pending_task.load(std::memory_order_acquire);
+    ChipTaskSlotState *slot_state = drain_state_.pending_task.load(std::memory_order_acquire);
     // Null means this thread arrived after the drain it entered for had already
     // reopened, and no check above rejects it: the reopen below clears pending_task
     // before sync_start_pending, so a thread entering on a stale non-zero snapshot of

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -38,7 +38,7 @@ struct PTO2Runtime;
 
 // SPSC ring carrying completed-but-unresolved task slots from one scheduler (S)
 // thread to the dedicated resolution (P) thread. Whole-graph-resident hbg never
-// reclaims a slot, so the queued PTO2TaskSlotState* stays valid until P reads it.
+// reclaims a slot, so the queued ChipTaskSlotState* stays valid until P reads it.
 // Single producer (the owning S thread) / single consumer (P): plain
 // acquire/release on head/tail, no CAS. Capacity is a power of two sized to the
 // in-flight bound (min of total tasks and the ring window), so a producer does
@@ -47,7 +47,7 @@ struct PTO2Runtime;
 // make this type non-copyable / non-movable, so `buf` cannot be double-freed
 // through an accidental copy.
 struct CompletedTaskQueue {
-    PTO2TaskSlotState **buf{nullptr};
+    ChipTaskSlotState **buf{nullptr};
     uint64_t cap{0};
     uint64_t mask{0};
     alignas(64) std::atomic<uint64_t> head{0};  // consumer (P) cursor
@@ -57,7 +57,7 @@ struct CompletedTaskQueue {
         debug_assert(capacity_pow2 != 0 && (capacity_pow2 & (capacity_pow2 - 1)) == 0);
         cap = capacity_pow2;
         mask = capacity_pow2 - 1;
-        buf = new PTO2TaskSlotState *[capacity_pow2];
+        buf = new ChipTaskSlotState *[capacity_pow2];
         head.store(0, std::memory_order_relaxed);
         tail.store(0, std::memory_order_relaxed);
     }
@@ -66,7 +66,7 @@ struct CompletedTaskQueue {
         buf = nullptr;
     }
     // Producer (S). Spins only if the ring is full — sized so this never fires.
-    void push(PTO2TaskSlotState *s) {
+    void push(ChipTaskSlotState *s) {
         uint64_t t = tail.load(std::memory_order_relaxed);
         while (t - head.load(std::memory_order_acquire) >= cap) {
             SPIN_WAIT_HINT();
@@ -75,12 +75,12 @@ struct CompletedTaskQueue {
         tail.store(t + 1, std::memory_order_release);
     }
     // Consumer (P). Returns nullptr when empty.
-    PTO2TaskSlotState *pop() {
+    ChipTaskSlotState *pop() {
         uint64_t h = head.load(std::memory_order_relaxed);
         if (h == tail.load(std::memory_order_acquire)) {
             return nullptr;
         }
-        PTO2TaskSlotState *s = buf[h & mask];
+        ChipTaskSlotState *s = buf[h & mask];
         head.store(h + 1, std::memory_order_release);
         return s;
     }
@@ -299,11 +299,11 @@ private:
     }
 
     int pop_ready_tasks_batch(
-        PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, PTO2TaskSlotState **out, int max_count
+        PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, ChipTaskSlotState **out, int max_count
     );
 
     void build_payload(
-        PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
+        PTO2DispatchPayload &dispatch_payload, ChipTaskSlotState &slot_state, PTO2SubtaskSlot subslot,
         int32_t block_idx, bool force_gate
     );
 
@@ -325,7 +325,7 @@ private:
     };
 
     PublishHandle prepare_subtask_to_core(
-        int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
+        int32_t thread_idx, int32_t core_offset, ChipTaskSlotState &slot_state, PTO2SubtaskSlot subslot,
         bool to_pending, int32_t block_idx, bool force_gate
     );
 
@@ -380,7 +380,7 @@ private:
     // Fan out one block's subtasks (1 for AIC/AIV, 1-3 for MIX) into the
     // caller-supplied handles buffer. Returns the number of handles written.
     int prepare_block_for_dispatch(
-        int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2ResourceShape shape,
+        int32_t thread_idx, int32_t core_offset, ChipTaskSlotState &slot_state, PTO2ResourceShape shape,
         bool to_pending, int32_t block_idx, PublishHandle *out_handles, bool force_gate = false
     );
 
@@ -407,7 +407,7 @@ private:
     // concurrently with peers (mirrors the normal SPMD dispatch path). Returns the
     // number of blocks staged.
     int32_t stage_consumer_blocks(
-        int32_t thread_idx, PTO2TaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
+        int32_t thread_idx, ChipTaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
         CoreTracker::BitStates &idle, CoreTracker::BitStates &pend
     );
 
@@ -484,7 +484,7 @@ private:
     );
 
     void complete_slot_task(
-        PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
+        ChipTaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
         int32_t core_id, Handshake *hank, int32_t &completed_this_turn
 #if SIMPLER_DFX
         ,
@@ -500,7 +500,7 @@ private:
         bool &made_progress
     );
 
-    bool enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t block_num);
+    bool enter_drain_mode(ChipTaskSlotState *slot_state, int32_t block_num);
     int32_t count_global_available(PTO2ResourceShape shape, uint8_t core_mask, bool include_pending = false);
     struct SyncStartStageResult {
         int32_t staged_blocks{0};
@@ -511,7 +511,7 @@ private:
     // the local fast path invokes it once after proving this tracker has enough
     // capacity. record_drain_phases keeps local work attributed to EarlyDispatch.
     SyncStartStageResult stage_sync_start_cores(
-        PTO2TaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated, bool record_drain_phases
+        ChipTaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated, bool record_drain_phases
     );
     // out_stage_wall_cycles (profiling only): cycles this thread spent in stage_sync_start_cores
     // (prepare + publish), set ONLY on threads that actually staged. Lets the caller isolate

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -34,7 +34,7 @@
 // Forward declarations — avoid pulling in full headers for pointer/reference params.
 class Runtime;
 struct Handshake;
-struct PTO2Runtime;
+struct RuntimeContext;
 
 // SPSC ring carrying completed-but-unresolved task slots from one scheduler (S)
 // thread to the dedicated resolution (P) thread. Whole-graph-resident hbg never
@@ -159,7 +159,7 @@ public:
     //    (skipped on fatal error — emergency_shutdown runs instead)
     // Callers must invoke rt_orchestration_done(rt) before this — that
     // step belongs to the orchestrator lifecycle, not the scheduler.
-    void on_orchestration_done(Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks);
+    void on_orchestration_done(Runtime *runtime, RuntimeContext *rt, int32_t thread_idx, int32_t total_tasks);
 
     // Seed the ready queues + wake lists for the whole graph at boot. Called by
     // every AICPU thread on a disjoint slice of the submitted-task range, after
@@ -168,8 +168,8 @@ public:
     // register_wake are the same lock-free primitives used during the run.
     void classify_partition(int32_t thread_idx, int32_t nthreads);
 
-    // Bind the PTO2Runtime scheduler pointer.
-    void bind_runtime(PTO2Runtime *rt);
+    // Bind the RuntimeContext scheduler pointer.
+    void bind_runtime(RuntimeContext *rt);
 
     // =========================================================================
     // State queries / external synchronization points
@@ -189,7 +189,7 @@ private:
 
     // --- Scheduler binding & per-core runtime state ---
     alignas(64) PTO2SchedulerState *sched_{nullptr};
-    PTO2Runtime *rt_{nullptr};
+    RuntimeContext *rt_{nullptr};
 
     // Per-core execution state, indexed by core_id (= worker_id)
     CoreExecState core_exec_states_[RUNTIME_MAX_WORKER];

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -92,7 +92,7 @@ bool SchedulerContext::has_idle_in_other_threads(int32_t self_thread_idx, PTO2Re
 }
 
 int SchedulerContext::pop_ready_tasks_batch(
-    PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, PTO2TaskSlotState **out, int max_count
+    PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, ChipTaskSlotState **out, int max_count
 ) {
 #if SIMPLER_DFX
     auto &chip_swimlane = sched_chip_swimlane_[thread_idx];
@@ -121,7 +121,7 @@ int SchedulerContext::pop_ready_tasks_batch(
 }
 
 void SchedulerContext::build_payload(
-    PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot, int32_t block_idx,
+    PTO2DispatchPayload &dispatch_payload, ChipTaskSlotState &slot_state, PTO2SubtaskSlot subslot, int32_t block_idx,
     bool force_gate
 ) {
     int32_t slot_idx = static_cast<int32_t>(subslot);
@@ -169,7 +169,7 @@ void SchedulerContext::build_payload(
 }
 
 SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
-    int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot, bool to_pending,
+    int32_t thread_idx, int32_t core_offset, ChipTaskSlotState &slot_state, PTO2SubtaskSlot subslot, bool to_pending,
     int32_t block_idx, bool force_gate
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -242,7 +242,7 @@ SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
 }
 
 int SchedulerContext::prepare_block_for_dispatch(
-    int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2ResourceShape shape, bool to_pending,
+    int32_t thread_idx, int32_t core_offset, ChipTaskSlotState &slot_state, PTO2ResourceShape shape, bool to_pending,
     int32_t block_idx, PublishHandle *out_handles, bool force_gate
 ) {
 #if SIMPLER_DFX
@@ -328,7 +328,7 @@ void SchedulerContext::dispatch_shape(
 
     while (cores.has_value() && !entered_drain) {
         int want = cores.count();
-        PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
+        ChipTaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
         int got = pop_ready_tasks_batch(disp_queues, shape, thread_idx, batch, want);
         if (got == 0) break;
 
@@ -369,7 +369,7 @@ void SchedulerContext::dispatch_shape(
         bool dispatched_any = false;
         // Logical block ranges published by this pop. AIV can pop two entries per
         // cluster, so this ledger has the same worst-case bound as handles[].
-        PTO2TaskSlotState *published_list[CoreTracker::MAX_CLUSTERS * 3];
+        ChipTaskSlotState *published_list[CoreTracker::MAX_CLUSTERS * 3];
         int16_t published_counts[CoreTracker::MAX_CLUSTERS * 3];
         int published_n = 0;
 #if SIMPLER_SCHED_PROFILING
@@ -396,7 +396,7 @@ void SchedulerContext::dispatch_shape(
         };
 
         for (int bi = 0; bi < got; bi++) {
-            PTO2TaskSlotState *slot_state = batch[bi];
+            ChipTaskSlotState *slot_state = batch[bi];
             CoreTracker::BitStates selected_mix_clusters(0ULL);
 
             if (is_mix) {
@@ -620,7 +620,7 @@ void SchedulerContext::dispatch_ready_tasks(
 // those release did not take and rings them from its immutable local handles.
 // The seq_cst order guarantees every gated core has exactly one writer.
 int32_t SchedulerContext::stage_consumer_blocks(
-    int32_t thread_idx, PTO2TaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
+    int32_t thread_idx, ChipTaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
     CoreTracker::BitStates &idle, CoreTracker::BitStates &pend
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -720,7 +720,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
     if (!cores.has_value()) return 0;
 
     int32_t total_staged = 0;
-    PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
+    ChipTaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
     uint64_t task_id_snapshots[CoreTracker::MAX_CLUSTERS * 3];
     // Batch-pop in one queue op (fewer CAS than one pop per consumer); the pop is
     // bounded by the shape's capacity so the stack buffer always holds it. Then for
@@ -735,7 +735,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
     // the unconsumed tail).
     int got = sched_->early_dispatch_queues[s].pop_batch_tagged(batch, task_id_snapshots, cores.count());
     for (int bi = 0; bi < got; bi++) {
-        PTO2TaskSlotState *c = batch[bi];
+        ChipTaskSlotState *c = batch[bi];
         if (static_cast<uint64_t>(c->task->task_id.raw) != task_id_snapshots[bi]) continue;
         if (c->payload->early_dispatch_state.load(std::memory_order_acquire) != PTO2_EARLY_DISPATCH_STAGING)
             continue;  // released
@@ -822,7 +822,7 @@ int32_t SchedulerContext::try_early_dispatch(
     // stop-the-world drain. Both paths force-gate every block even if producer release races
     // STAGING -> DISPATCHED. A non-STAGING pop was already released and is dropped.
     uint64_t sync_task_id_snapshot = 0;
-    if (PTO2TaskSlotState *c = sched_->early_sync_start_queue.pop_tagged(&sync_task_id_snapshot)) {
+    if (ChipTaskSlotState *c = sched_->early_sync_start_queue.pop_tagged(&sync_task_id_snapshot)) {
         bool current_sync_task =
             static_cast<uint64_t>(c->task->task_id.raw) == sync_task_id_snapshot && c->task_attrs.requires_sync_start();
         if (current_sync_task && PTO2SchedulerState::try_claim_early_sync_drain(*c->payload)) {
@@ -922,7 +922,7 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
         int32_t resolved_this_pass = 0;
         bool resolved_any = false;
         for (int32_t s = 0; s < active_sched_threads_ && !completed_.load(std::memory_order_acquire); s++) {
-            PTO2TaskSlotState *slot;
+            ChipTaskSlotState *slot;
             while ((slot = sp_queues_[s].pop()) != nullptr) {
 #if SIMPLER_SCHED_PROFILING
                 PTO2SchedulerState::TaskCompletionOutcome outcome = sched_->complete_task(*slot, thread_idx);
@@ -966,7 +966,7 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
         // resolution can make further dummies ready in the same pass.
         {
             constexpr int DUMMY_DRAIN_BATCH = 8;
-            PTO2TaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
+            ChipTaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
             int dummy_got;
             while ((dummy_got = sched_->dummy_ready_queue.pop_batch(dummy_batch, DUMMY_DRAIN_BATCH)) > 0) {
                 for (int di = 0; di < dummy_got; di++) {
@@ -1306,7 +1306,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         // slice per loop prevents a large definition from monopolizing a
         // scheduler thread.
         if (thread_idx < active_sched_threads_) {
-            PTO2TaskSlotState *graph_slot = sched_->graph_ready_queue.pop();
+            ChipTaskSlotState *graph_slot = sched_->graph_ready_queue.pop();
             if (graph_slot != nullptr) {
                 if (graph_slot->task != nullptr && graph_slot->task_kind == TaskKind::GRAPH) {
                     (void)sched_->activate_graph_task(*graph_slot);
@@ -1318,7 +1318,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             }
 
             uint64_t prepare_task_id = 0;
-            PTO2TaskSlotState *prepare_slot = sched_->graph_prepare_queue.pop_tagged(&prepare_task_id);
+            ChipTaskSlotState *prepare_slot = sched_->graph_prepare_queue.pop_tagged(&prepare_task_id);
             if (prepare_slot != nullptr) {
                 const bool valid_slot = prepare_slot->task != nullptr && prepare_slot->task_kind == TaskKind::GRAPH &&
                                         prepare_slot->task->task_id.raw == prepare_task_id;

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
@@ -19,7 +19,7 @@
 #include "runtime_types.h"
 #include "spin_hint.h"
 
-// host_build_graph host-orch build: PTO2Runtime embeds PTO2SchedulerState by
+// host_build_graph host-orch build: RuntimeContext embeds PTO2SchedulerState by
 // value, so this header is compiled into the host libhost_runtime.so. The AICPU
 // spin_hint.h that defines PLATFORM_SCHEDULER_TIMEOUT_MS is not on the host
 // include path; supply it here. The value only sizes an on-device scheduler

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
@@ -106,8 +106,8 @@ enum class LoopAction : int8_t {
 struct alignas(64) CoreExecState {
     // --- Hot fields (completion + dispatch, every iteration) ---
     uint64_t reg_addr;                      // offset  0: register base address (set once in handshake)
-    PTO2TaskSlotState *running_slot_state;  // offset  8: slot state for running task (nullptr = empty)
-    PTO2TaskSlotState *pending_slot_state;  // offset 16: slot state for pending task (nullptr = empty)
+    ChipTaskSlotState *running_slot_state;  // offset  8: slot state for running task (nullptr = empty)
+    ChipTaskSlotState *pending_slot_state;  // offset 16: slot state for pending task (nullptr = empty)
     int32_t running_reg_task_id;            // offset 24: register task ID (AICPU_TASK_INVALID = idle)
     int32_t pending_reg_task_id;            // offset 28: pending register task ID (AICPU_TASK_INVALID = none)
     uint32_t dispatch_seq;                  // offset 32: monotonic dispatch counter
@@ -579,7 +579,7 @@ struct alignas(64) SchedChipSwimlaneCounters {
 // (only process completions) until the fixed coordinator finishes launching all blocks.
 struct alignas(64) SyncStartDrainState {
     std::atomic<int32_t> sync_start_pending{0};              // 0=normal; -1=initializing; >0=active (value=block_num)
-    std::atomic<PTO2TaskSlotState *> pending_task{nullptr};  // held task (not re-queued)
+    std::atomic<ChipTaskSlotState *> pending_task{nullptr};  // held task (not re-queued)
     std::atomic<uint64_t> drain_attempt{0};                  // incremented whenever an ack round is reset
     // Parallel staging: after the coordinator confirms global availability it sets
     // stage_go, releasing every thread to stage its OWN cores concurrently (vs the old

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/runtime.cpp
@@ -12,7 +12,7 @@
  * Runtime Class - Implementation
  *
  * Device execution and handshake control.
- * Task graph construction is handled by PTO2Runtime.
+ * Task graph construction is handled by RuntimeContext.
  */
 
 #include "runtime.h"

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/runtime_init.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/runtime_init.cpp
@@ -253,13 +253,13 @@ void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler) { this-
 // Top-level runtime arena
 // =============================================================================
 
-PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, uint64_t heap_size) {
-    PTO2RuntimeArenaLayout layout{};
+RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, uint64_t heap_size) {
+    RuntimeArenaLayout layout{};
 
     layout.task_window_size = task_window_size;
     layout.heap_size = heap_size;
 
-    // Reservation order is the zone partition (see PTO2RuntimeArenaLayout):
+    // Reservation order is the zone partition (see RuntimeArenaLayout):
     // everything the device initializes itself, then the one copied range. Each
     // zone is contiguous, so bind is a single copy and no consumer has to infer a
     // boundary from what happens to come first.
@@ -274,7 +274,7 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_
     layout.off_copied_begin = arena.total_size();
     // Padded to a PTO2_ALIGN_SIZE boundary: the shared-memory image starts at
     // off_copied_end on the device and its segment offsets are aligned from there.
-    layout.off_runtime = arena.reserve(PTO2_ALIGN_UP(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE), PTO2_ALIGN_SIZE);
+    layout.off_runtime = arena.reserve(PTO2_ALIGN_UP(sizeof(RuntimeContext), PTO2_ALIGN_SIZE), PTO2_ALIGN_SIZE);
     layout.off_copied_end = arena.total_size();
 
     layout.arena_size = arena.total_size();
@@ -284,19 +284,19 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_
 /**
  * Populate the prebuilt runtime-arena image in place (host build path).
  *
- * Zeroes the PTO2Runtime header at layout.off_runtime, records the GM heap,
+ * Zeroes the RuntimeContext header at layout.off_runtime, records the GM heap,
  * and initializes the scheduler (ready / sync / dummy / graph queues) against
  * the device SM. rt->orchestrator is left null: the orchestrator is a host-owned
  * object the host-orch path (run_host_orchestration) stands up against the host
  * SM once that buffer exists, and it is never uploaded to the device. Caller must
  * follow up with runtime_wire_arena_pointers. Returns the arena-resident
- * PTO2Runtime*, or nullptr on failure.
+ * RuntimeContext*, or nullptr on failure.
  */
-PTO2Runtime *runtime_init_data_from_layout(
-    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
-    uint64_t /*sm_size*/, void *gm_heap_dev_base, uint64_t heap_size
+RuntimeContext *runtime_init_data_from_layout(
+    DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t /*sm_size*/,
+    void *gm_heap_dev_base, uint64_t heap_size
 ) {
-    PTO2Runtime *rt = static_cast<PTO2Runtime *>(arena.region_ptr(layout.off_runtime));
+    RuntimeContext *rt = static_cast<RuntimeContext *>(arena.region_ptr(layout.off_runtime));
     memset(rt, 0, sizeof(*rt));
 
     // rt->ops is filled by the AICPU at boot.
@@ -322,14 +322,14 @@ PTO2Runtime *runtime_init_data_from_layout(
     return rt;
 }
 
-void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt) {
+void runtime_wire_arena_pointers(DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeContext *rt) {
     rt->sm_handle = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(layout.off_sm_handle));
     rt->aicore_mailbox = static_cast<AICoreCompletionMailbox *>(arena.region_ptr(layout.off_mailbox));
     rt->scheduler = static_cast<PTO2SchedulerState *>(arena.region_ptr(layout.off_scheduler));
     rt->scheduler->wire_arena_pointers(layout.sched, arena);
 }
 
-void runtime_destroy(PTO2Runtime *rt, DeviceArena & /*arena*/) {
+void runtime_destroy(RuntimeContext *rt, DeviceArena & /*arena*/) {
     // Arena buffer is pooled across runs by DeviceRunner — never freed here.
     if (!rt) return;
     rt->scheduler->destroy();

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/shared_memory.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/shared_memory.cpp
@@ -53,7 +53,7 @@ void PTO2SharedMemoryHandle::setup_pointers(uint64_t pitch) {
     auto &ring = header->ring;
     ring.task_descriptors = (PTO2TaskDescriptor *)(base + off.descriptors);
     ring.task_payloads = (PTO2TaskPayload *)(base + off.payloads);
-    ring.slot_states = (PTO2TaskSlotState *)(base + off.slot_states);
+    ring.slot_states = (ChipTaskSlotState *)(base + off.slot_states);
     ring.completion_flags = (std::atomic<uint8_t> *)(base + off.completion_flags);
 }
 
@@ -158,7 +158,7 @@ void PTO2SharedMemoryHandle::init_header(uint64_t task_window_size, uint64_t hea
     header->ring.task_descriptors_offset = offset;
     offset += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
     offset += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
-    offset += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
+    offset += PTO2_ALIGN_UP(task_window_size * sizeof(ChipTaskSlotState), PTO2_ALIGN_SIZE);
 
     header->total_size = sm_size;
 

--- a/src/a2a3/runtime/host_build_graph/runtime/shared_memory.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared_memory.h
@@ -94,7 +94,7 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     // Per-ring data pointers (host-side, set by setup_pointers)
     PTO2TaskDescriptor *task_descriptors;
     PTO2TaskPayload *task_payloads;
-    PTO2TaskSlotState *slot_states;
+    ChipTaskSlotState *slot_states;
 
     // Polling-completion state (device-addressed array, one byte per slot).
     // 0 = pending, 1 = task fully COMPLETED. Writer = the task's completer at
@@ -149,9 +149,9 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     // through its slot state's `payload` delta, which the image's restack rebinds to
     // the real address.
 
-    PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
+    ChipTaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
-    PTO2TaskSlotState &get_slot_state_by_task_id(int32_t local_id) {
+    ChipTaskSlotState &get_slot_state_by_task_id(int32_t local_id) {
         return slot_states[get_slot_by_task_id(local_id)];
     }
 };
@@ -354,7 +354,7 @@ inline PTO2RingSegmentOffsets ring_segment_offsets(const RingImageExtents &e) no
     o.payloads = off;
     off += PTO2_ALIGN_UP(e.slots * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
     o.slot_states = off;
-    off += PTO2_ALIGN_UP(e.slots * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
+    off += PTO2_ALIGN_UP(e.slots * sizeof(ChipTaskSlotState), PTO2_ALIGN_SIZE);
     o.completion_flags = off;
     off += PTO2_ALIGN_UP(e.slots * sizeof(std::atomic<uint8_t>), PTO2_ALIGN_SIZE);
     o.fanin_pool = off;
@@ -453,13 +453,13 @@ compact_live_image(const char *mirror_base, uint64_t task_window_size, const Bin
     // One copy, not one per payload: PTO2TaskPayload is fixed-size, so the mirror and
     // the image share a stride. Each pool is likewise one copy of its own prefix.
     std::memcpy(out_base + to.payloads, mirror_base + from.payloads, nt * sizeof(PTO2TaskPayload));
-    std::memcpy(out_base + to.slot_states, mirror_base + from.slot_states, nt * sizeof(PTO2TaskSlotState));
+    std::memcpy(out_base + to.slot_states, mirror_base + from.slot_states, nt * sizeof(ChipTaskSlotState));
     std::memcpy(out_base + to.completion_flags, mirror_base + from.completion_flags, nt * sizeof(std::atomic<uint8_t>));
     std::memcpy(out_base + to.fanin_pool, mirror_base + from.fanin_pool, used.fanin_elems * sizeof(int32_t));
     std::memcpy(out_base + to.tensor_pool, mirror_base + from.tensor_pool, used.tensor_elems * sizeof(ChipTensor));
     std::memcpy(out_base + to.scalar_pool, mirror_base + from.scalar_pool, used.scalar_elems * sizeof(uint64_t));
 
-    auto *out_slots = reinterpret_cast<PTO2TaskSlotState *>(out_base + to.slot_states);
+    auto *out_slots = reinterpret_cast<ChipTaskSlotState *>(out_base + to.slot_states);
     auto *out_descriptors = reinterpret_cast<PTO2TaskDescriptor *>(out_base + to.descriptors);
     auto *out_payloads = reinterpret_cast<PTO2TaskPayload *>(out_base + to.payloads);
     const auto *mirror_payloads = reinterpret_cast<const PTO2TaskPayload *>(mirror_base + from.payloads);

--- a/src/a2a3/runtime/host_build_graph/runtime/submit_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/submit_types.h
@@ -167,7 +167,7 @@ private:
 static_assert(sizeof(ActiveMask) == 1, "ActiveMask must be exactly 1 byte");
 
 /**
- * Per-task scheduling attributes, packed into one byte on PTO2TaskSlotState.
+ * Per-task scheduling attributes, packed into one byte on ChipTaskSlotState.
  *
  * Single home for the independent per-task flags: an early-dispatch hint, the
  * two dispatch-time predicates (sync_start / has_predicate), and the selective

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -64,17 +64,17 @@
 #include "scheduler/scheduler_context.h"
 
 // Device orchestration function signature (loaded via dlopen).
-// The executor binds the current thread's PTO2Runtime into orchestration TLS
+// The executor binds the current thread's RuntimeContext into orchestration TLS
 // before calling the user entry.
 typedef void (*DeviceOrchestrationFunc)(const ChipTaskArgs &orch_args);
-typedef void (*DeviceOrchestrationBindRuntimeFunc)(PTO2Runtime *rt);
+typedef void (*DeviceOrchestrationBindRuntimeFunc)(RuntimeContext *rt);
 
 // Config function exported by orchestration .so
 typedef OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipTaskArgs &orch_args);
 
 // From orchestration/common.cpp linked into this DSO — updates g_current_runtime here (distinct from
 // framework_bind_runtime in the dlopen'd libdevice_orch_*.so).
-extern "C" void framework_bind_runtime(PTO2Runtime *rt);
+extern "C" void framework_bind_runtime(RuntimeContext *rt);
 
 constexpr const char *DEFAULT_ORCH_ENTRY_SYMBOL = "aicpu_orchestration_entry";
 constexpr const char *DEFAULT_ORCH_CONFIG_SYMBOL = "aicpu_orchestration_config";
@@ -95,7 +95,7 @@ static int32_t read_runtime_status(Runtime *runtime) {
     return runtime_status_from_error_codes(orch_error_code, sched_error_code);
 }
 
-static PTO2Runtime *rt{nullptr};
+static RuntimeContext *rt{nullptr};
 
 // Per-callable_id orchestration SO table. The executor dispatches
 // `orch_so_table_[active_callable_id_]` (created on first sighting of
@@ -141,7 +141,7 @@ struct AicpuExecutor {
     std::atomic<int32_t> finished_count_{0};
     std::atomic<bool> runtime_init_ready_{false};
 
-    // Per-Worker arena backing the PTO2Runtime + sm_handle + orch/sched/mailbox
+    // Per-Worker arena backing the RuntimeContext + sm_handle + orch/sched/mailbox
     // sub-regions (created in runtime_create_from_sm, released in runtime_destroy).
     // Default-constructed: libc-backed backend, no ctx.
     DeviceArena runtime_arena_;
@@ -606,7 +606,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                     return -1;
                 }
                 runtime_arena_.attach(prebuilt_arena, DeviceArena::kDefaultBaseAlign);
-                rt = reinterpret_cast<PTO2Runtime *>(static_cast<char *>(prebuilt_arena) + off_runtime);
+                rt = reinterpret_cast<RuntimeContext *>(static_cast<char *>(prebuilt_arena) + off_runtime);
 
                 // Wire every arena-internal pointer field (host wrote host-mirror
                 // addresses; we overwrite them with device addresses).
@@ -670,7 +670,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 }
 #endif
 
-                // Wire scheduler context to the newly created PTO2Runtime before
+                // Wire scheduler context to the newly created RuntimeContext before
                 // releasing scheduler threads from runtime_init_ready_.
                 sched_ctx_.bind_runtime(rt);
             }
@@ -886,7 +886,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
     if (prev_finished + 1 == aicpu_thread_num_) {
         aicpu_publish_task_timing_tail_usage(aicpu_thread_num_);
         finished_.store(true, std::memory_order_release);
-        // Destroy PTO2 runtime. sm_handle / rt are recreated every run so we
+        // Destroy the runtime context. sm_handle / rt are recreated every run so we
         // always tear them down here, but we keep the per-cid orch SO entries
         // alive — they are loaded once by register_callable and consumed by
         // every subsequent run.
@@ -930,7 +930,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     // are loaded once by register_callable and consumed by every subsequent
     // run. The destructor releases them at process teardown.
 
-    // Clear file-scope PTO2Runtime pointer (freed by orchestrator thread before deinit)
+    // Clear file-scope RuntimeContext pointer (freed by orchestrator thread before deinit)
     rt = nullptr;
 
     // Clear dep_gen file-local bookkeeping. No-op when dep_gen is disabled.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -659,7 +659,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 rt->orchestrator.chip_swimlane_level = get_chip_swimlane_level();
                 {
                     auto &orch = rt->orchestrator;
-                    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+                    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
                         auto &alloc = orch.rings[r].task_allocator;
                         scope_stats_set_ring_capacity(
                             r, alloc.window_size(), alloc.heap_capacity(),
@@ -808,7 +808,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // streams that already cover everything inside submit_task().
             int32_t total_tasks = 0;
             if (rt->orchestrator.sm_header) {
-                for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+                for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
                     total_tasks +=
                         rt->orchestrator.sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
                 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -32,7 +32,7 @@
 #include "runtime.h"
 #include "spin_hint.h"
 
-// Runtime headers (full struct definition for create/destroy + PTO2_SCOPE)
+// Runtime headers (full struct definition for create/destroy + SIMPLER_SCOPE)
 #include "runtime_core.h"
 #include "runtime_types.h"
 #include "shared_memory.h"

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -70,7 +70,7 @@ typedef void (*DeviceOrchestrationFunc)(const ChipTaskArgs &orch_args);
 typedef void (*DeviceOrchestrationBindRuntimeFunc)(PTO2Runtime *rt);
 
 // Config function exported by orchestration .so
-typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipTaskArgs &orch_args);
+typedef OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipTaskArgs &orch_args);
 
 // From orchestration/common.cpp linked into this DSO — updates g_current_runtime here (distinct from
 // framework_bind_runtime in the dlopen'd libdevice_orch_*.so).
@@ -566,7 +566,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
                 // Validate arg count on every run against the registered SO.
                 if (*p_config_func != nullptr) {
-                    PTO2OrchestrationConfig cfg = (*p_config_func)(orch_args_cached_);
+                    OrchestrationConfig cfg = (*p_config_func)(orch_args_cached_);
                     LOG_DEBUG("Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
                     if (cfg.expected_arg_count > 0) {
                         const ChipStorageTaskArgs &args_validate = runtime->get_orch_args();

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -8,7 +8,7 @@ The single-ring design uses one `last_task_alive` watermark shared by HeapRing, 
 
 ## 2. Solution
 
-Split HeapRing, TaskRing, and DepPool into arrays of `PTO2_MAX_RING_DEPTH` (4) independent instances. Each scope depth maps to its own ring, with an independent `last_task_alive` watermark.
+Split HeapRing, TaskRing, and DepPool into arrays of `CHIP_MAX_RING_DEPTH` (4) independent instances. Each scope depth maps to its own ring, with an independent `last_task_alive` watermark.
 
 ```text
 Scope depth 0  ──►  rings[0] = { HeapRing, TaskRing, DepPool }
@@ -67,10 +67,10 @@ PTO2TaskRing task_ring;
 PTO2DepListPool dep_pool;
 
 // After: per-ring array (dep_pool moved to scheduler, see §4.5)
-PTO2RingSet rings[PTO2_MAX_RING_DEPTH];
+PTO2RingSet rings[CHIP_MAX_RING_DEPTH];
 ```
 
-Ring selection: `current_ring_id() = min(scope_stack_top, PTO2_MAX_RING_DEPTH - 1)`.
+Ring selection: `current_ring_id() = min(scope_stack_top, CHIP_MAX_RING_DEPTH - 1)`.
 
 ### 4.3 PTO2SharedMemoryHeader (modified)
 
@@ -108,7 +108,7 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
 };
 
 // In header:
-PTO2SharedMemoryRingHeader rings[PTO2_MAX_RING_DEPTH];
+PTO2SharedMemoryRingHeader rings[CHIP_MAX_RING_DEPTH];
 ```
 
 Per-ring try-locks in the scheduler state prevent concurrent scheduler threads from interleaving watermark writes within the same ring. `FaninPool`/`DepListPool` `reclaim`/`ensure_space` take `PTO2SharedMemoryRingHeader&` directly (no `ring_id` or `fc` parameters).
@@ -139,7 +139,7 @@ struct RingSchedState {
     alignas(64) PTO2DepListPool dep_pool;
 };
 
-RingSchedState ring_sched_states[PTO2_MAX_RING_DEPTH];
+RingSchedState ring_sched_states[CHIP_MAX_RING_DEPTH];
 ```
 
 `slot_states`, `task_window_size`, and `task_window_mask` are no longer duplicated — callers access them via `ring->get_slot_state_by_*()` and other ring header accessors. The ring pointer shares cache line 0 with `last_task_alive` and `advance_lock`.
@@ -147,8 +147,8 @@ RingSchedState ring_sched_states[PTO2_MAX_RING_DEPTH];
 ### 4.6 PTO2TensorMap (modified)
 
 ```cpp
-PTO2TensorMapEntry** task_entry_heads[PTO2_MAX_RING_DEPTH];
-int64_t last_task_alives[PTO2_MAX_RING_DEPTH];
+PTO2TensorMapEntry** task_entry_heads[CHIP_MAX_RING_DEPTH];
+int64_t last_task_alives[CHIP_MAX_RING_DEPTH];
 ```
 
 Entry validity checks and `cleanup_retired` operate per-ring:

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -42,7 +42,7 @@ Type changes:
 | ----- | ------ | ----- |
 | `PTO2TaskDescriptor.task_id` | `int32_t` | `TaskId` |
 | `PTO2TensorMapEntry.producer_task_id` | `int32_t` | `TaskId` |
-| `PTO2TaskSlotState.ring_id` | N/A | `uint8_t` (new, denormalized for fast access) |
+| `ChipTaskSlotState.ring_id` | N/A | `uint8_t` (new, denormalized for fast access) |
 
 ## 4. Data Structures
 
@@ -96,15 +96,15 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     // Per-ring data pointers (host-side, set by setup_pointers)
     PTO2TaskDescriptor *task_descriptors;
     PTO2TaskPayload *task_payloads;
-    PTO2TaskSlotState *slot_states;
+    ChipTaskSlotState *slot_states;
 
     // Accessors (slot = local_id & task_window_mask)
     PTO2TaskDescriptor &get_task_by_slot(int32_t slot);
     PTO2TaskDescriptor &get_task_by_task_id(int32_t local_id);
     PTO2TaskPayload &get_payload_by_slot(int32_t slot);
     PTO2TaskPayload &get_payload_by_task_id(int32_t local_id);
-    PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot);
-    PTO2TaskSlotState &get_slot_state_by_task_id(int32_t local_id);
+    ChipTaskSlotState &get_slot_state_by_slot(int32_t slot);
+    ChipTaskSlotState &get_slot_state_by_task_id(int32_t local_id);
 };
 
 // In header:
@@ -165,7 +165,7 @@ bool entry_valid(const PTO2TensorMapEntry& e) {
 
 | Structure | Reason |
 | --------- | ------ |
-| `PTO2DepListEntry` | Stores `PTO2TaskSlotState*` pointer — naturally crosses ring boundaries |
+| `PTO2DepListEntry` | Stores `ChipTaskSlotState*` pointer — naturally crosses ring boundaries |
 | `PTO2TaskPayload` | `fanin_slot_states[]` are pointers — no ring coupling |
 | `PTO2ReadyQueue` | Global ready queues shared across all rings (tasks ready to dispatch regardless of origin ring) |
 | `PTO2DispatchPayload` | Built per-dispatch, no ring state needed |
@@ -191,9 +191,9 @@ For ring-heap stall triage, a `CONSUMED` head whose ring bit remains set means t
 
 ### 5.2 Cross-Ring Dependencies
 
-Dependency edges use `PTO2TaskSlotState*` pointers, which naturally span rings:
+Dependency edges use `ChipTaskSlotState*` pointers, which naturally span rings:
 
-- Ring 1 task depends on ring 0 producer → ring 0's `fanout_head` linked list contains a ring 1 `PTO2TaskSlotState*`
+- Ring 1 task depends on ring 0 producer → ring 0's `fanout_head` linked list contains a ring 1 `ChipTaskSlotState*`
 - When ring 0 task completes, it walks its fanout list and decrements ring 1 consumers' `fanin_refcount`
 - No special cross-ring logic needed — pointer-based design is ring-agnostic
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -328,4 +328,4 @@ first line of `scope_stats/scope_stats.jsonl` includes `task_window_max`,
 - `heap` must accommodate peak output buffer allocation across all in-flight tasks on that ring
 - `dep_pool` must be ≥ total dependency entries for all in-flight tasks on that ring
 - On hardware, back-pressure latency is higher than in simulation — size conservatively
-- Adding inner `PTO2_SCOPE` reduces peak per-ring usage, enabling smaller sizes
+- Adding inner `SIMPLER_SCOPE` reduces peak per-ring usage, enabling smaller sizes

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -291,7 +291,7 @@ Solution:
 
 The FATAL message is logged to the device log and the process exits. The solution is to increase the ring size so that it can hold at least all tasks within the largest parallel scope. For example, if a scope submits 13 tasks, `task_window >= 14` is required (13 + 1 to distinguish full from empty).
 
-**Sizing guideline**: `task_window_size` must be larger than the maximum number of tasks in any single `PTO2_SCOPE`. A safe choice is `2 × max_tasks_per_scope` or simply the default 65536 for production.
+**Sizing guideline**: `task_window_size` must be larger than the maximum number of tasks in any single `SIMPLER_SCOPE`. A safe choice is `2 × max_tasks_per_scope` or simply the default 65536 for production.
 
 ---
 
@@ -465,7 +465,7 @@ The scheduler's completion handler mirrors this:
 
 This protocol guarantees every consumer is accounted for exactly once.
 
-### 7.4 Scope Mechanism (`PTO2_SCOPE`)
+### 7.4 Scope Mechanism (`SIMPLER_SCOPE`)
 
 Scopes control the lifetime of intermediate buffers. Each scope:
 
@@ -473,7 +473,7 @@ Scopes control the lifetime of intermediate buffers. Each scope:
 - On `scope_end`: increments `fanout_refcount` for scope tasks; when it reaches `fanout_count`, the task's packed buffer can be reclaimed
 
 ```cpp
-PTO2_SCOPE(rt) {
+SIMPLER_SCOPE(rt) {
     // Tasks submitted here belong to this scope
     rt_submit_aic_task(FUNC_QK, args);
     rt_submit_aiv_task(FUNC_SF, args);
@@ -490,11 +490,11 @@ eligible for reuse; once `advance_ring_pointers` reaches it,
 Tensor storage in place.
 
 Therefore the `TaskOutputTensors` instance, the references it returns, and
-any pointer derived from them MUST NOT outlive the `PTO2_SCOPE` in which
+any pointer derived from them MUST NOT outlive the `SIMPLER_SCOPE` in which
 submit was called. The typical safe pattern is:
 
 ```cpp
-PTO2_SCOPE() {
+SIMPLER_SCOPE() {
     TaskOutputTensors outs = rt_submit_aic_task(FUNC_QK, args);
     const Tensor &y = outs.get_ref(0);
     // Use y here and in subsequent submits within the same scope.
@@ -505,7 +505,7 @@ Anti-patterns that compile but silently break:
 
 ```cpp
 const Tensor *kept = nullptr;
-PTO2_SCOPE() {
+SIMPLER_SCOPE() {
     TaskOutputTensors outs = rt_submit_aic_task(FUNC_QK, args);
     kept = &outs.get_ref(0);          // escapes the scope
 }
@@ -514,7 +514,7 @@ PTO2_SCOPE() {
 // tensor — a wrong-tensor read with no runtime diagnostic.
 
 TaskOutputTensors outs;               // declared in outer scope
-PTO2_SCOPE() {
+SIMPLER_SCOPE() {
     outs = rt_submit_aic_task(FUNC_QK, args);
 }
 const Tensor &t = outs.get_ref(0);    // same hazard: outs survives scope
@@ -787,7 +787,7 @@ Built by the scheduler from `PTO2TaskDescriptor`:
 3. The orchestrator thread writes the SO to a temp file, calls `dlopen`
 4. `dlsym("aicpu_orchestration_config")` returns configuration (expected arg count)
 5. `dlsym("aicpu_orchestration_entry")` returns the orchestration function pointer
-6. The orchestrator thread creates a `PTO2Runtime`, calls the orchestration function within a `PTO2_SCOPE`
+6. The orchestrator thread creates a `PTO2Runtime`, calls the orchestration function within a `SIMPLER_SCOPE`
 7. After orchestration completes: `dlclose`, delete temp file
 
 ### 10.3 Thread Startup Synchronization
@@ -829,7 +829,7 @@ The orchestration API is defined in `orchestration_api.h`. Orchestration code de
 | `rt_submit_task(mixed_kernels, args)` | Submit a mixed task with `MixedKernels` struct |
 | `rt_submit_aic_task(kernel_id, args)` | Convenience: submit AIC-only task |
 | `rt_submit_aiv_task(kernel_id, args)` | Convenience: submit AIV-only task |
-| `PTO2_SCOPE() { ... }` | RAII scope for buffer lifetime |
+| `SIMPLER_SCOPE() { ... }` | RAII scope for buffer lifetime |
 | `rt_orchestration_done()` | Signal orchestration complete |
 
 ### 11.2 Parameter Construction
@@ -898,7 +898,7 @@ void aicpu_orchestration_entry(uint64_t* args, int arg_count) {
     // Unpack args: query, key_cache, value_cache, block_table, context_lens, out, config
     for (q_idx = 0; q_idx < q_loop; q_idx++) {
         for (batch_start = 0; batch_start < batch; batch_start += IN_CORE_BATCH) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 // Describe accumulator tensors (oi, li, mi) with TensorCreateInfo
                 // Submit AIV_HUB to initialize accumulators
                 for (bn = 0; bn < max_bn; bn++) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -860,7 +860,7 @@ Tasks are queued by resource shape, which is derived from the `active_mask` in t
 Each orchestration `.so` must export:
 
 ```cpp
-extern "C" PTO2OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count);
+extern "C" OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count);
 extern "C" void aicpu_orchestration_entry(uint64_t* args, int arg_count);
 ```
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -1,8 +1,8 @@
-# PTO2 Runtime System Design
+# `tensormap_and_ringbuffer` Runtime Design
 
 ## Overview
 
-PTO2 (Parallel Task Orchestration v2) is a runtime system for executing task graphs on Ascend AI processors. It coordinates four layers of execution:
+`tensormap_and_ringbuffer` is a runtime for executing task graphs on Ascend AI processors. It coordinates four layers of execution:
 
 - **Host** (x86/ARM CPU): compiles kernels, allocates device memory, initializes the Runtime, and launches AICPU/AICore threads.
 - **AICPU** (device ARM cores): runs the orchestrator (task graph builder) and scheduler threads.
@@ -45,7 +45,7 @@ The host builds the complete task graph before launching device execution. The o
 - **Scheduling**: AICPU receives the pre-built graph and dispatches tasks by traversing dependencies
 - **Use case**: development and debugging; no device-side orchestration overhead
 
-### 1.2 tensormap_and_ringbuffer (PTO2)
+### 1.2 tensormap_and_ringbuffer
 
 The primary production runtime. Uses ring buffers for task slots and output memory, with a TensorMap for automatic dependency tracking.
 
@@ -787,7 +787,7 @@ Built by the scheduler from `PTO2TaskDescriptor`:
 3. The orchestrator thread writes the SO to a temp file, calls `dlopen`
 4. `dlsym("aicpu_orchestration_config")` returns configuration (expected arg count)
 5. `dlsym("aicpu_orchestration_entry")` returns the orchestration function pointer
-6. The orchestrator thread creates a `PTO2Runtime`, calls the orchestration function within a `SIMPLER_SCOPE`
+6. The orchestrator thread creates a `RuntimeContext`, calls the orchestration function within a `SIMPLER_SCOPE`
 7. After orchestration completes: `dlclose`, delete temp file
 
 ### 10.3 Thread Startup Synchronization

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -150,7 +150,7 @@ The orchestrator and schedulers communicate through a contiguous shared memory r
 │  Per-ring regions ×4:       │
 │    PTO2TaskDescriptor[N]    │  N = task_window_size per ring
 │    PTO2TaskPayload[N]       │
-│    PTO2TaskSlotState[N]     │
+│    ChipTaskSlotState[N]     │
 └─────────────────────────────┘
 ```
 
@@ -702,7 +702,7 @@ publication and early-candidate readiness.
 
 The producer's slot-local dispatch-propagated bit in `lifecycle_flags` and fanout snapshot are
 serialized under `fanout_lock` with consumer wiring. Wiring already locks and reads the
-producer's 64-byte `PTO2TaskSlotState`, so testing this bit does not read a producer payload
+producer's 64-byte `ChipTaskSlotState`, so testing this bit does not read a producer payload
 cache line. An edge already in the snapshot is counted by scheduler propagation; wiring seeds
 an edge added after the claim and enqueues the consumer if that seed completes
 `dispatch_fanin`. This gives each eligible producer-consumer edge exactly one early-candidate

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -53,7 +53,7 @@ The primary production runtime. Uses ring buffers for task slots and output memo
 - **Memory**: GM Heap ring for output buffer allocation
 - **Dependencies**: automatically derived from tensor read/write patterns via TensorMap
 - **Thread model**: 3 scheduler threads + 1 orchestrator thread on AICPU
-- **Multi-ring**: HeapRing, TaskRing, and DepPool are split into `PTO2_MAX_RING_DEPTH` (4) independent instances for nested scope isolation. See [MULTI_RING.md](MULTI_RING.md) for details.
+- **Multi-ring**: HeapRing, TaskRing, and DepPool are split into `CHIP_MAX_RING_DEPTH` (4) independent instances for nested scope isolation. See [MULTI_RING.md](MULTI_RING.md) for details.
 - **Use case**: production workloads; supports streaming, flow control, and large batch sizes
 
 ---
@@ -421,7 +421,7 @@ The orchestrator runs on AICPU Thread 3 and builds the task graph by calling the
 
 Key members:
 
-- `rings[PTO2_MAX_RING_DEPTH]`: per-ring `PTO2RingSet` (HeapRing + TaskRing + FaninPool). See [MULTI_RING.md §4.2](MULTI_RING.md).
+- `rings[CHIP_MAX_RING_DEPTH]`: per-ring `PTO2RingSet` (HeapRing + TaskRing + FaninPool). See [MULTI_RING.md §4.2](MULTI_RING.md).
 - `tensor_map`, `tensor_pool`: dependency tracking
 - `scope_tasks[]`, `scope_begins[]`, `scope_stack_top`: scope nesting stack (flat buffer partitioned by level)
 - `scheduler`: pointer to scheduler state (for Orch-side wiring helpers and ready queue access)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
@@ -58,17 +58,17 @@ struct MixedKernels {
     int32_t aiv1_kernel_id{INVALID_KERNEL_ID};
 };
 
-static inline void rt_submit_task(PTO2Runtime* rt,
+static inline void rt_submit_task(RuntimeContext* rt,
                                        const MixedKernels& mixed_kernels,
                                        Arg* args,
                                        int32_t num_args);
 
-static inline void rt_submit_aic_task(PTO2Runtime* rt,
+static inline void rt_submit_aic_task(RuntimeContext* rt,
                                            int32_t kernel_id,
                                            Arg* args,
                                            int32_t num_args);
 
-static inline void rt_submit_aiv_task(PTO2Runtime* rt,
+static inline void rt_submit_aiv_task(RuntimeContext* rt,
                                            int32_t kernel_id,
                                            Arg* args,
                                            int32_t num_args);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -481,17 +481,17 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
     // ring's window comfortably covers its observed max local_id (no slot
     // aliasing during INOUT+COVERED remove_from_task). Same sizes feed both
     // maps so they stay in lockstep.
-    int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint32_t max_local[PTO2_MAX_RING_DEPTH] = {0};
+    int32_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+    uint32_t max_local[CHIP_MAX_RING_DEPTH] = {0};
     for (size_t i = 0; i < num_records; i++) {
         TaskId tid{records[i].task_id};
         uint8_t ring = tid.ring();
         uint32_t local = tid.local();
-        if (ring < PTO2_MAX_RING_DEPTH && local > max_local[ring]) {
+        if (ring < CHIP_MAX_RING_DEPTH && local > max_local[ring]) {
             max_local[ring] = local;
         }
     }
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         int32_t need = static_cast<int32_t>(max_local[r] + 1);
         task_window_sizes[r] = ceil_pow2(need < 16 ? 16 : need);
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -94,9 +94,7 @@ extern "C" const PipelineContract *get_pipeline_contract(void) {
 
 extern "C" int concurrent_native_prepare_supported_impl(void) { return 1; }
 
-static_assert(
-    RUNTIME_ENV_RING_COUNT == PTO2_MAX_RING_DEPTH, "RuntimeEnv ring count must match PTO2 runtime ring depth"
-);
+static_assert(RUNTIME_ENV_RING_COUNT == PTO2_MAX_RING_DEPTH, "RuntimeEnv ring count must match the runtime ring depth");
 
 // Helper: return current time in milliseconds
 static int64_t _now_ms() {
@@ -685,7 +683,7 @@ static bool ensure_static_arenas(
     const HostApi *api, const ArenaSizingConfig &sizing, const ArenaStaticSizes &sizes, StaticArenaPtrs *out
 ) {
     DeviceArena sizing_arena;  // discarded; only its computed arena_size is read
-    PTO2RuntimeArenaLayout layout =
+    RuntimeArenaLayout layout =
         runtime_reserve_layout(sizing_arena, sizing.task_window_sizes, sizing.heap_sizes, sizing.dep_pool_capacities);
 
     int64_t t_setup_start = _now_ms();
@@ -740,16 +738,16 @@ static bool ensure_static_arenas(
 // *before* it can dereference the image.
 static bool build_runtime_image(
     const ArenaSizingConfig &sizing, const ArenaStaticSizes &sizes, const StaticArenaPtrs &ptrs,
-    DeviceArena *host_arena, PTO2RuntimeArenaLayout *out_layout
+    DeviceArena *host_arena, RuntimeArenaLayout *out_layout
 ) {
-    PTO2RuntimeArenaLayout layout =
+    RuntimeArenaLayout layout =
         runtime_reserve_layout(*host_arena, sizing.task_window_sizes, sizing.heap_sizes, sizing.dep_pool_capacities);
     if (host_arena->commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
         LOG_ERROR("Failed to commit host arena for prebuilt runtime image");
         return false;
     }
 
-    PTO2Runtime *rt = runtime_init_data_from_layout(
+    RuntimeContext *rt = runtime_init_data_from_layout(
         *host_arena, layout, PTO2_MODE_EXECUTE, ptrs.gm_sm, sizes.sm_size, ptrs.gm_heap, sizing.heap_sizes
     );
     if (rt == nullptr) {
@@ -791,7 +789,7 @@ static int bind_cached_runtime_image(
 
 static void store_prebuilt_runtime_image(
     const HostApi *api, const PrebuiltRuntimeArenaCacheProbe &probe, const StaticArenaPtrs &ptrs,
-    const PTO2RuntimeArenaLayout &layout, const DeviceArena &host_arena
+    const RuntimeArenaLayout &layout, const DeviceArena &host_arena
 ) {
     api->mark_prebuilt_runtime_arena_cached(
         probe.hash, probe.serialized_key.data(), probe.serialized_key.size(), ptrs.gm_heap, ptrs.gm_sm,
@@ -809,7 +807,7 @@ static void store_prebuilt_runtime_image(
 // prewarm_config_impl entry, so both build the arena identically.
 static bool build_and_cache_prebuilt_arena(
     const HostApi *api, const ArenaSizingConfig &sizing, StaticArenaPtrs *out_ptrs = nullptr,
-    PTO2RuntimeArenaLayout *out_layout = nullptr
+    RuntimeArenaLayout *out_layout = nullptr
 ) {
     ArenaStaticSizes sizes;
     if (!derive_arena_static_sizes(sizing, &sizes)) {
@@ -822,7 +820,7 @@ static bool build_and_cache_prebuilt_arena(
     }
 
     DeviceArena host_arena;  // libc malloc backend; owns the image until upload
-    PTO2RuntimeArenaLayout layout;
+    RuntimeArenaLayout layout;
     if (!build_runtime_image(sizing, sizes, ptrs, &host_arena, &layout)) {
         return false;
     }
@@ -937,7 +935,7 @@ extern "C" int bind_callable_to_runtime_impl(
             // cache round-trip, so a backend with no-op cache callbacks still
             // binds successfully.
             StaticArenaPtrs ptrs;
-            PTO2RuntimeArenaLayout layout;
+            RuntimeArenaLayout layout;
             if (!build_and_cache_prebuilt_arena(api, sizing, &ptrs, &layout)) {
                 return PTO_RUNTIME_ERR_INTERNAL;
             }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -94,7 +94,7 @@ extern "C" const PipelineContract *get_pipeline_contract(void) {
 
 extern "C" int concurrent_native_prepare_supported_impl(void) { return 1; }
 
-static_assert(RUNTIME_ENV_RING_COUNT == PTO2_MAX_RING_DEPTH, "RuntimeEnv ring count must match the runtime ring depth");
+static_assert(RUNTIME_ENV_RING_COUNT == CHIP_MAX_RING_DEPTH, "RuntimeEnv ring count must match the runtime ring depth");
 
 // Helper: return current time in milliseconds
 static int64_t _now_ms() {
@@ -106,9 +106,9 @@ static int64_t _now_ms() {
 static bool is_power_of_2_u64(uint64_t value) { return value != 0 && (value & (value - 1)) == 0; }
 
 template <typename T>
-static std::string format_ring_array(const T (&values)[PTO2_MAX_RING_DEPTH]) {
+static std::string format_ring_array(const T (&values)[CHIP_MAX_RING_DEPTH]) {
     std::string out = "[";
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; ++r) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; ++r) {
         if (r != 0) {
             out += ", ";
         }
@@ -167,7 +167,7 @@ static bool parse_uint_token(
 }
 
 static void apply_env_ring_values(
-    const char *name, uint64_t min_val, uint64_t max_val, bool require_power_of_2, uint64_t out[PTO2_MAX_RING_DEPTH]
+    const char *name, uint64_t min_val, uint64_t max_val, bool require_power_of_2, uint64_t out[CHIP_MAX_RING_DEPTH]
 ) {
     const char *env = std::getenv(name);
     if (!env) return;
@@ -178,25 +178,25 @@ static void apply_env_ring_values(
         if (!parse_uint_token(name, text, min_val, max_val, require_power_of_2, &value)) {
             return;
         }
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             out[r] = value;
         }
         return;
     }
 
-    uint64_t parsed[PTO2_MAX_RING_DEPTH]{};
+    uint64_t parsed[CHIP_MAX_RING_DEPTH]{};
     size_t pos = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         size_t comma = text.find(',', pos);
         std::string token = text.substr(pos, comma == std::string::npos ? std::string::npos : comma - pos);
         if (!parse_uint_token(name, token, min_val, max_val, require_power_of_2, &parsed[r])) {
             return;
         }
         if (comma == std::string::npos) {
-            if (r != PTO2_MAX_RING_DEPTH - 1) {
+            if (r != CHIP_MAX_RING_DEPTH - 1) {
                 LOG_WARN(
                     "%s=%s invalid (expected exactly %d comma-separated values), ignored", name, env,
-                    PTO2_MAX_RING_DEPTH
+                    CHIP_MAX_RING_DEPTH
                 );
                 return;
             }
@@ -206,10 +206,10 @@ static void apply_env_ring_values(
         }
     }
     if (pos < text.size() || (!text.empty() && text.back() == ',')) {
-        LOG_WARN("%s=%s invalid (expected exactly %d comma-separated values), ignored", name, env, PTO2_MAX_RING_DEPTH);
+        LOG_WARN("%s=%s invalid (expected exactly %d comma-separated values), ignored", name, env, CHIP_MAX_RING_DEPTH);
         return;
     }
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         out[r] = parsed[r];
     }
 }
@@ -230,16 +230,16 @@ static uint64_t read_ring_override(const uint64_t *base, int idx) {
 }
 
 // Each of ring_task_window / ring_heap / ring_dep_pool is a per-ring array of
-// PTO2_MAX_RING_DEPTH entries (0 = unset). Precedence per ring: per-task entry >
+// CHIP_MAX_RING_DEPTH entries (0 = unset). Precedence per ring: per-task entry >
 // PTO2_RING_* env value > compile-time default. A "size all rings the same"
 // request arrives already broadcast to every entry by the caller.
 static bool resolve_ring_config(
     const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool,
-    uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH],
-    int32_t eff_dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+    uint64_t eff_task_window_sizes[CHIP_MAX_RING_DEPTH], uint64_t eff_heap_sizes[CHIP_MAX_RING_DEPTH],
+    int32_t eff_dep_pool_capacities[CHIP_MAX_RING_DEPTH]
 ) {
-    uint64_t dep_pool_values[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    uint64_t dep_pool_values[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         eff_task_window_sizes[r] = PTO2_TASK_WINDOW_SIZE;
         eff_heap_sizes[r] = PTO2_HEAP_SIZE;
         dep_pool_values[r] = PTO2_DEP_LIST_POOL_SIZE;
@@ -249,7 +249,7 @@ static bool resolve_ring_config(
     apply_env_ring_values("PTO2_RING_HEAP", 1024, std::numeric_limits<uint64_t>::max(), false, eff_heap_sizes);
     apply_env_ring_values("PTO2_RING_DEP_POOL", 4, static_cast<uint64_t>(INT32_MAX), false, dep_pool_values);
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         const uint64_t task_window_override = read_ring_override(ring_task_window, r);
         const uint64_t heap_override = read_ring_override(ring_heap, r);
         const uint64_t dep_pool_override = read_ring_override(ring_dep_pool, r);
@@ -458,9 +458,9 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
 // arena description. Resolved once per config from per-task overrides + env +
 // compile-time defaults; depends on nothing that varies per run.
 struct ArenaSizingConfig {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
+    uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+    uint64_t heap_sizes[CHIP_MAX_RING_DEPTH];
+    int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH];
 };
 
 struct ArenaStaticSizes {
@@ -498,8 +498,8 @@ static void append_cache_key_u64(std::vector<uint8_t> *out, uint64_t value) {
 static PrebuiltRuntimeArenaCacheProbe make_prebuilt_runtime_arena_cache_probe(const ArenaSizingConfig &sizing) {
     PrebuiltRuntimeArenaCacheProbe probe;
     uint64_t hash = 1469598103934665603ULL;
-    probe.serialized_key.reserve(PTO2_MAX_RING_DEPTH * 3 * sizeof(uint64_t));
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    probe.serialized_key.reserve(CHIP_MAX_RING_DEPTH * 3 * sizeof(uint64_t));
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         hash_mix_u64(&hash, sizing.task_window_sizes[r]);
         append_cache_key_u64(&probe.serialized_key, sizing.task_window_sizes[r]);
         hash_mix_u64(&hash, sizing.heap_sizes[r]);
@@ -563,7 +563,7 @@ static bool resolve_arena_sizing(
 
 static bool derive_arena_static_sizes(const ArenaSizingConfig &sizing, ArenaStaticSizes *out) {
     out->total_heap = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         if (sizing.heap_sizes[r] > std::numeric_limits<uint64_t>::max() - out->total_heap) {
             LOG_ERROR("Total ring heap size overflows uint64_t");
             return false;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
@@ -21,7 +21,7 @@
 #include <vector>
 #endif
 
-struct PTO2Runtime;
+struct RuntimeContext;
 
 // Unified-log error sink. Forward-declared here rather than pulled via
 // common/unified_log.h: that header lives under common/log/include, which is
@@ -36,16 +36,18 @@ namespace {
 // crash (BZ #32412) when the orchestration SO is dlclose'd/re-dlopen'd
 // between execution rounds.  All orchestrator threads bind the same rt
 // value, so per-thread storage is unnecessary.
-PTO2Runtime *g_current_runtime = nullptr;
+RuntimeContext *g_current_runtime = nullptr;
 }  // namespace
 
-extern "C" __attribute__((visibility("default"))) void framework_bind_runtime(PTO2Runtime *rt) {
+extern "C" __attribute__((visibility("default"))) void framework_bind_runtime(RuntimeContext *rt) {
     g_current_runtime = rt;
 }
 
 // Keep current_runtime local to this .so so orchestration helpers do not
 // accidentally bind to the AICPU binary's same-named symbol.
-extern "C" __attribute__((visibility("hidden"))) PTO2Runtime *framework_current_runtime() { return g_current_runtime; }
+extern "C" __attribute__((visibility("hidden"))) RuntimeContext *framework_current_runtime() {
+    return g_current_runtime;
+}
 
 /**
  * Use addr2line to convert an address to file:line information.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/orchestration_api.h
@@ -381,7 +381,7 @@ private:
  */
 #ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
-struct PTO2OrchestrationConfig {
+struct OrchestrationConfig {
     int expected_arg_count;
 };
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/orchestration_api.h
@@ -14,14 +14,14 @@
  * This header provides everything an orchestration source needs without
  * pulling in runtime implementation headers.  The orchestration .so has
  * zero link dependencies on runtime .cpp files; all runtime calls go
- * through the PTO2RuntimeOps function-pointer table embedded in
- * PTO2Runtime.
+ * through the RuntimeOps function-pointer table embedded in
+ * RuntimeContext.
  *
  * Orchestration sources include ONLY this header:
  *   #include "orchestration_api.h"
  *
  * Runtime sources continue to use runtime_core.h (which defines the
- * full PTO2Runtime struct with all internal fields).
+ * full RuntimeContext struct with all internal fields).
  */
 
 #pragma once
@@ -53,23 +53,23 @@
 // =============================================================================
 
 /**
- * Forward declaration — the orchestration sees PTO2Runtime as a partial
+ * Forward declaration — the orchestration sees RuntimeContext as a partial
  * struct whose first field is the ops pointer.  The full definition
  * lives in runtime_core.h (used only by runtime .cpp files).
  */
-typedef struct PTO2Runtime PTO2Runtime;
+typedef struct RuntimeContext RuntimeContext;
 
 /**
  * Function-pointer table for runtime operations.
  * Populated by the runtime; called by orchestration through inline wrappers.
  */
-typedef struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
-    void (*scope_begin)(PTO2Runtime *rt);
-    void (*scope_end)(PTO2Runtime *rt);
-    void (*orchestration_done)(PTO2Runtime *rt);
-    bool (*is_fatal)(PTO2Runtime *rt);
-    void (*report_fatal)(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
+typedef struct RuntimeOps {
+    TaskOutputTensors (*submit_task)(RuntimeContext *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
+    void (*scope_begin)(RuntimeContext *rt);
+    void (*scope_end)(RuntimeContext *rt);
+    void (*orchestration_done)(RuntimeContext *rt);
+    bool (*is_fatal)(RuntimeContext *rt);
+    void (*report_fatal)(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
     // Logging (populated by runtime, called by orchestration)
     void (*log_error)(const char *func, const char *fmt, ...);
@@ -80,34 +80,34 @@ typedef struct PTO2RuntimeOps {
 
     // Cross-layer data access (orchestration reads/writes tensor values via runtime)
     // Placed after logging to avoid shifting hot-path field offsets.
-    uint64_t (*get_tensor_data)(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
+    uint64_t (*get_tensor_data)(RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
     void (*set_tensor_data)(
-        PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+        RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
     );
-    TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const CoreTaskArgs &args);
-    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const CoreTaskArgs &args);
+    TaskOutputTensors (*alloc_tensors)(RuntimeContext *rt, const CoreTaskArgs &args);
+    TaskOutputTensors (*submit_dummy_task)(RuntimeContext *rt, const CoreTaskArgs &args);
 
     // This-run core geometry from runtime_finalize_after_wire: MIX clusters
     // (one AIC each) and standalone AIV cores.
-    int32_t (*available_cluster_count)(PTO2Runtime *rt);
-    int32_t (*available_aiv_count)(PTO2Runtime *rt);
+    int32_t (*available_cluster_count)(RuntimeContext *rt);
+    int32_t (*available_aiv_count)(RuntimeContext *rt);
 
     // Stash the call-site of the next ScopeGuard so the [ScopeStats]
     // collector can log it. Always present to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
     void (*scope_set_site)(const char *file, int line);
-} PTO2RuntimeOps;
+} RuntimeOps;
 
 /**
- * Partial PTO2Runtime definition for orchestration.
+ * Partial RuntimeContext definition for orchestration.
  *
  * Exposes the ops pointer (for runtime calls) and pending_scope_mode
  * (read directly by inline scope wrappers).  The real struct (in
  * runtime_core.h) has the same first fields, so accessing them through
  * this definition is well-defined (C struct layout guarantee).
  */
-struct PTO2Runtime {
-    const PTO2RuntimeOps *ops;
+struct RuntimeContext {
+    const RuntimeOps *ops;
     PTO2ScopeMode pending_scope_mode;
 };
 
@@ -115,10 +115,10 @@ struct PTO2Runtime {
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================
 
-static inline PTO2Runtime *current_runtime() { return framework_current_runtime(); }
+static inline RuntimeContext *current_runtime() { return framework_current_runtime(); }
 
 static inline TaskOutputTensors alloc_tensors(const CoreTaskArgs &args) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -126,7 +126,7 @@ static inline TaskOutputTensors alloc_tensors(const CoreTaskArgs &args) {
 }
 
 static inline TaskOutputTensors alloc_tensors(const TensorCreateInfo create_infos[], uint32_t count) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -151,7 +151,7 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
         (std::is_same_v<std::decay_t<CIs>, TensorCreateInfo> && ...),
         "alloc_tensors only accepts TensorCreateInfo arguments"
     );
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -168,7 +168,7 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
 }
 
 static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -201,7 +201,7 @@ static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const Core
  * barrier or as a placeholder producer for tests / dep-graph wiring.
  */
 static inline TaskOutputTensors rt_submit_dummy_task(const CoreTaskArgs &args) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -209,7 +209,7 @@ static inline TaskOutputTensors rt_submit_dummy_task(const CoreTaskArgs &args) {
 }
 
 static inline void rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
@@ -218,7 +218,7 @@ static inline void rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {
 }
 
 static inline void rt_scope_end() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
@@ -226,30 +226,30 @@ static inline void rt_scope_end() {
 }
 
 static inline void rt_orchestration_done() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     rt->ops->orchestration_done(rt);
 }
 
 /** This-run MIX cluster (= AIC) count. Do not hardcode 24/36; MIX cohorts use this. */
 static inline int32_t rt_available_cluster_count() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     return rt->ops->available_cluster_count(rt);
 }
 
 /** This-run standalone AIV core count. AIV-only cohorts size themselves on this. */
 static inline int32_t rt_available_aiv_count() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     return rt->ops->available_aiv_count(rt);
 }
 
 static inline bool rt_is_fatal() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     return rt->ops->is_fatal(rt);
 }
 
 #define rt_report_fatal(code, fmt, ...)                                          \
     do {                                                                         \
-        PTO2Runtime *_rt = current_runtime();                                    \
+        RuntimeContext *_rt = current_runtime();                                 \
         _rt->ops->report_fatal(_rt, (code), __FUNCTION__, (fmt), ##__VA_ARGS__); \
     } while (0)
 
@@ -282,7 +282,7 @@ static inline bool rt_is_fatal() {
  */
 template <typename T = uint64_t>
 static inline T get_tensor_data(const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return from_u64<T>(0);
     }
@@ -318,7 +318,7 @@ static inline T get_tensor_data(const ChipTensor &tensor, uint32_t ndims, const 
  */
 template <typename T = uint64_t>
 static inline void set_tensor_data(const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], T value) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
@@ -351,7 +351,7 @@ public:
     }
 
 private:
-    PTO2Runtime *rt_;
+    RuntimeContext *rt_;
 };
 
 #define _SIMPLER_CONCATENATE_IMPL(x, y) x##y

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/orchestration_api.h
@@ -92,7 +92,7 @@ typedef struct PTO2RuntimeOps {
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
 
-    // Stash the call-site of the next PTO2ScopeGuard so the [ScopeStats]
+    // Stash the call-site of the next ScopeGuard so the [ScopeStats]
     // collector can log it. Always present to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
     void (*scope_set_site)(const char *file, int line);
@@ -332,9 +332,9 @@ static inline void set_tensor_data(const ChipTensor &tensor, uint32_t ndims, con
 /**
  * RAII Scope Guard (calls through ops table)
  */
-class PTO2ScopeGuard {
+class ScopeGuard {
 public:
-    explicit PTO2ScopeGuard(
+    explicit ScopeGuard(
         PTO2ScopeMode mode = PTO2ScopeMode::AUTO, const char *file = __builtin_FILE(), int line = __builtin_LINE()
     ) :
         rt_(current_runtime()) {
@@ -344,7 +344,7 @@ public:
             rt_->ops->scope_begin(rt_);
         }
     }
-    ~PTO2ScopeGuard() {
+    ~ScopeGuard() {
         if (!rt_->ops->is_fatal(rt_)) {
             rt_->ops->scope_end(rt_);
         }
@@ -354,19 +354,19 @@ private:
     PTO2Runtime *rt_;
 };
 
-#define _PTO2_CONCATENATE_IMPL(x, y) x##y
-#define _PTO2_CONCATENATE(x, y) _PTO2_CONCATENATE_IMPL(x, y)
+#define _SIMPLER_CONCATENATE_IMPL(x, y) x##y
+#define _SIMPLER_CONCATENATE(x, y) _SIMPLER_CONCATENATE_IMPL(x, y)
 
-#define PTO2_SCOPE_GUARD(...) \
-    [[maybe_unused]] PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__) { __VA_ARGS__ }
+#define SIMPLER_SCOPE_GUARD(...) \
+    [[maybe_unused]] ScopeGuard _SIMPLER_CONCATENATE(scope_guard_, __COUNTER__) { __VA_ARGS__ }
 
 /**
  * Scoped block macro:
- *   PTO2_SCOPE() {
+ *   SIMPLER_SCOPE() {
  *       rt_submit_task(...);
  *   }
  */
-#define PTO2_SCOPE(...) if (PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__){__VA_ARGS__}; true)
+#define SIMPLER_SCOPE(...) if (ScopeGuard _SIMPLER_CONCATENATE(scope_guard_, __COUNTER__){__VA_ARGS__}; true)
 
 // =============================================================================
 // Orchestration Config

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
@@ -53,7 +53,7 @@ struct AICoreCompletionMailboxMessage {
     std::atomic<uint64_t> seq;
     TaskId task_token;
     // CONDITION: completion observation addr (counter / backend record).
-    // TASK_NORMAL_DONE: PTO2TaskSlotState pointer carried over to the consumer
+    // TASK_NORMAL_DONE: ChipTaskSlotState pointer carried over to the consumer
     //   so it can finalize the AsyncWaitEntry.slot_state binding.
     uint64_t addr;
     uint64_t backend_cookie;
@@ -146,7 +146,7 @@ struct AICoreCompletionMailbox {
         }
     }
 
-    // MPSC push for a TASK_NORMAL_DONE sentinel. Carries the PTO2TaskSlotState
+    // MPSC push for a TASK_NORMAL_DONE sentinel. Carries the ChipTaskSlotState
     // pointer in the `addr` field so the consumer can finish binding the
     // AsyncWaitEntry.slot_state without going back to the FIN-handling thread.
     bool try_push_normal_done(TaskId task_token, uint64_t slot_state_addr) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/async_wait.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/async_wait.h
@@ -115,7 +115,7 @@ inline void CompletionCondition::retire() {
 }
 
 struct AsyncWaitEntry {
-    PTO2TaskSlotState *slot_state{nullptr};
+    ChipTaskSlotState *slot_state{nullptr};
     TaskId task_token{TaskId::invalid()};
     CompletionCondition conditions[MAX_COMPLETIONS_PER_TASK];
     int32_t condition_count{0};
@@ -126,7 +126,7 @@ struct AsyncWaitEntry {
 struct AsyncPollResult {
     int32_t completed{0};
     int32_t error_code{SIMPLER_ERROR_NONE};
-    PTO2TaskSlotState *failed_slot_state{nullptr};
+    ChipTaskSlotState *failed_slot_state{nullptr};
 };
 
 inline const char *async_engine_name(AsyncEngine engine) {
@@ -179,7 +179,7 @@ struct AsyncWaitList {
     // entries[]).
     struct DrainCompletionSink {
         PTO2SchedulerState *sched{nullptr};
-        PTO2TaskSlotState **deferred_release_slot_states{nullptr};
+        ChipTaskSlotState **deferred_release_slot_states{nullptr};
         int32_t *deferred_release_count{nullptr};
         int32_t deferred_release_capacity{0};
         int32_t inline_completed{0};
@@ -192,7 +192,7 @@ struct AsyncWaitList {
 
     // Inline-complete a NotDeferred task during drain. Returns false on
     // deferred_release_slot_states overflow.
-    bool try_inline_complete_locked(DrainCompletionSink &sink, PTO2TaskSlotState &slot_state);
+    bool try_inline_complete_locked(DrainCompletionSink &sink, ChipTaskSlotState &slot_state);
 
     // Single-consumer drain: pop each published message in tail order and
     // translate it into wait-list state. An empty sink (sched == nullptr) just
@@ -235,8 +235,8 @@ struct AsyncWaitList {
                     return drained;
                 }
             } else if (msg.kind == MSG_KIND_TASK_NORMAL_DONE) {
-                PTO2TaskSlotState *slot_state_ptr =
-                    reinterpret_cast<PTO2TaskSlotState *>(static_cast<uintptr_t>(msg.addr));
+                ChipTaskSlotState *slot_state_ptr =
+                    reinterpret_cast<ChipTaskSlotState *>(static_cast<uintptr_t>(msg.addr));
                 AsyncWaitEntry *entry = find_entry_by_token(msg.task_token);
                 if (entry == nullptr) {
                     // Producers strictly order: all CONDITIONs for token T are
@@ -299,7 +299,7 @@ struct AsyncWaitList {
     template <bool Profiling>
     AsyncPollResult poll_and_complete(
         AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched,
-        PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count,
+        ChipTaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count,
         int32_t deferred_release_capacity
 #if SIMPLER_SCHED_PROFILING
         ,

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/common.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/common.h
@@ -23,7 +23,7 @@
 
 // Framework-internal TLS bridge. The executor binds the current thread's
 // runtime before invoking the orchestration entry, so orchestration helpers can
-// fetch the current PTO2Runtime without explicit parameter threading. Declared
+// fetch the current RuntimeContext without explicit parameter threading. Declared
 // here (rather than in orchestration_api.h) so framework TUs the AICore
 // build also compiles — notably orchestration/common.cpp — see these symbols
 // without pulling in types.h, whose Arg::add_scalar → to_u64 path is
@@ -31,9 +31,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-struct PTO2Runtime;
-PTO2Runtime *framework_current_runtime(void);
-void framework_bind_runtime(PTO2Runtime *rt);
+struct RuntimeContext;
+RuntimeContext *framework_current_runtime(void);
+void framework_bind_runtime(RuntimeContext *rt);
 #ifdef __cplusplus
 }
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
@@ -269,7 +269,7 @@ struct PTO2FaninBuilder {
     }
 
     // Append a new edge (caller has already claimed the producer's fanout pin).
-    void push_edge(PTO2FaninSpillEntry &entry, PTO2TaskSlotState *prod_state, DepFlags kind) {
+    void push_edge(PTO2FaninSpillEntry &entry, ChipTaskSlotState *prod_state, DepFlags kind) {
         entry.set(prod_state, kind);
         count++;
         if (dep_has_wait(kind)) {
@@ -280,7 +280,7 @@ struct PTO2FaninBuilder {
     // Dedup path: a producer already recorded this submission is reached again
     // (e.g. as both a creator and a modifier). OR the new flags into the existing
     // edge instead of adding a second one — no extra fanout pin is claimed.
-    void or_flags_into_existing(PTO2TaskSlotState *prod_state, DepFlags kind) {
+    void or_flags_into_existing(ChipTaskSlotState *prod_state, DepFlags kind) {
         for (int32_t i = 0; i < count; i++) {
             PTO2FaninSpillEntry &entry = entry_at(i);
             if (entry.slot_state() == prod_state) {
@@ -316,7 +316,7 @@ private:
 };
 
 static bool append_fanin_or_fail(
-    PTO2OrchestratorState *orch, uint8_t prod_ring, int32_t prod_slot, PTO2TaskSlotState *prod_state,
+    PTO2OrchestratorState *orch, uint8_t prod_ring, int32_t prod_slot, ChipTaskSlotState *prod_state,
     TaskId producer_task_id, PTO2FaninBuilder *fanin_builder, uint8_t ring_id, DepFlags kind
 ) {
     // Decide-and-claim under the producer's fanout_lock. Two conditions make this
@@ -338,7 +338,7 @@ static bool append_fanin_or_fail(
     // until the consumer's on_task_release. check_and_handle_consumed flips
     // COMPLETED->CONSUMED under the same lock, so the check and the ++ are atomic
     // against the consume. fanout_count is lock-protected per the
-    // PTO2TaskSlotState contract.
+    // ChipTaskSlotState contract.
     //
     // Dedup (mark_seen) happens HERE, gated on a live producer — NOT before the
     // gone check. mark_seen keys only on (ring, slot); a stale owner that resolves
@@ -417,7 +417,7 @@ static bool all_claimed_fanin_completed(const PTO2FaninBuilder &fanin_builder) {
     if (fanin_builder.count == 0) return true;
     // Only DEP_WAIT edges gate readiness; a retention-only edge never blocks
     // dispatch, so it is treated as satisfied here.
-    return fanin_builder.for_each([](PTO2TaskSlotState *producer, DepFlags flags) -> bool {
+    return fanin_builder.for_each([](ChipTaskSlotState *producer, DepFlags flags) -> bool {
         if (!dep_has_wait(flags)) return true;
         return producer != nullptr && producer->task_state.load(std::memory_order_acquire) >= PTO2_TASK_COMPLETED;
     });
@@ -425,13 +425,13 @@ static bool all_claimed_fanin_completed(const PTO2FaninBuilder &fanin_builder) {
 
 static bool all_claimed_fanin_allow_early_resolve(const PTO2FaninBuilder &fanin_builder) {
     if (fanin_builder.count == 0) return true;
-    return fanin_builder.for_each([](PTO2TaskSlotState *producer, DepFlags flags) -> bool {
+    return fanin_builder.for_each([](ChipTaskSlotState *producer, DepFlags flags) -> bool {
         if (!dep_has_wait(flags)) return true;
         return producer != nullptr && producer->task_attrs.allow_early_resolve();
     });
 }
 
-void PTO2OrchestratorState::mark_dep_pool_position(PTO2TaskSlotState &slot_state) {
+void PTO2OrchestratorState::mark_dep_pool_position(ChipTaskSlotState &slot_state) {
     PTO2SchedulerState *sched = scheduler;
     auto &rss = sched->ring_sched_states[slot_state.ring_id];
     slot_state.dep_pool_mark = rss.dep_pool.top;
@@ -442,7 +442,7 @@ void PTO2OrchestratorState::mark_dep_pool_position(PTO2TaskSlotState &slot_state
 #endif
 }
 
-void PTO2OrchestratorState::wire_fanin_task(PTO2TaskSlotState &slot_state, int32_t wfanin) {
+void PTO2OrchestratorState::wire_fanin_task(ChipTaskSlotState &slot_state, int32_t wfanin) {
     PTO2SchedulerState *sched = scheduler;
     auto &rss = sched->ring_sched_states[slot_state.ring_id];
     PTO2TaskPayload *payload = slot_state.payload;
@@ -451,7 +451,7 @@ void PTO2OrchestratorState::wire_fanin_task(PTO2TaskSlotState &slot_state, int32
     int32_t completed_fanin = 0;
     int32_t early_propagated = 0;
     bool early_disqualified = false;
-    for_each_fanin_slot_state(*payload, [&](PTO2TaskSlotState *producer, DepFlags flags) {
+    for_each_fanin_slot_state(*payload, [&](ChipTaskSlotState *producer, DepFlags flags) {
         // Only DEP_WAIT edges contribute to readiness: they gate fanin and are
         // linked onto the producer's fanout_head for completion notification. A
         // retention-only edge carries no ordering, so it is skipped here.
@@ -508,7 +508,7 @@ void PTO2OrchestratorState::wire_fanin_task(PTO2TaskSlotState &slot_state, int32
     }
 }
 
-static PTO2TaskSlotState *oldest_open_task_on_current_ring(const PTO2OrchestratorState *orch) {
+static ChipTaskSlotState *oldest_open_task_on_current_ring(const PTO2OrchestratorState *orch) {
     // Scope depth maps directly to a ring until the deepest ring, where all
     // further nested scopes share that ring. Its shallowest open scope begin
     // therefore marks the oldest task pinned by any open scope on this ring.
@@ -516,7 +516,7 @@ static PTO2TaskSlotState *oldest_open_task_on_current_ring(const PTO2Orchestrato
     return begin < orch->scope_tasks_size ? orch->scope_tasks[begin] : nullptr;
 }
 
-static bool orch_wire_live_fanin_task(PTO2OrchestratorState *orch, PTO2TaskSlotState &slot_state, int32_t wfanin) {
+static bool orch_wire_live_fanin_task(PTO2OrchestratorState *orch, ChipTaskSlotState &slot_state, int32_t wfanin) {
     PTO2SchedulerState *sched = orch->scheduler;
     auto &rss = sched->ring_sched_states[slot_state.ring_id];
 
@@ -535,14 +535,14 @@ static bool orch_wire_live_fanin_task(PTO2OrchestratorState *orch, PTO2TaskSlotS
     return true;
 }
 
-static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state);
+static void scope_tasks_push(PTO2OrchestratorState *orch, ChipTaskSlotState *task_slot_state);
 
 struct PTO2PreparedTask {
     TaskId task_id = TaskId::invalid();
     PTO2TaskAllocResult alloc_result = {-1, 0, nullptr, nullptr};
     PTO2TaskDescriptor *task = nullptr;
     PTO2TaskPayload *payload = nullptr;
-    PTO2TaskSlotState *slot_state = nullptr;
+    ChipTaskSlotState *slot_state = nullptr;
 };
 
 static PTO2OutputLayout calculate_output_layout(const CoreTaskArgs &args) {
@@ -668,7 +668,7 @@ static bool prepare_task(
 // Scope Management
 // =============================================================================
 
-static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state) {
+static void scope_tasks_push(PTO2OrchestratorState *orch, ChipTaskSlotState *task_slot_state) {
     if (orch->scope_tasks_size >= orch->scope_tasks_capacity) {
         // scope_tasks lives in the per-Worker arena (single backing allocation),
         // so realloc is not legal. Capacity is the total in-flight slot budget
@@ -896,7 +896,7 @@ static TaskOutputTensors submit_task_common(
     PTO2SchedulerState *sched = orch->scheduler;
     PTO2RingFlowControl &fc = orch->sm_header->rings[ring_id].fc;
     TaskId task_id = prepared.task_id;
-    PTO2TaskSlotState &cur_slot_state = *prepared.slot_state;
+    ChipTaskSlotState &cur_slot_state = *prepared.slot_state;
     PTO2TaskDescriptor &task = *prepared.task;
     PTO2TaskPayload &payload = *prepared.payload;
     result.set_task_id(task_id);
@@ -972,7 +972,7 @@ static TaskOutputTensors submit_task_common(
             continue;
         }
         int32_t dep_slot = dep_ring.get_slot_by_task_id(dep_local_task_id);
-        PTO2TaskSlotState *producer_slot_state = &dep_ring.get_slot_state_by_slot(dep_slot);
+        ChipTaskSlotState *producer_slot_state = &dep_ring.get_slot_state_by_slot(dep_slot);
         if (!append_fanin_or_fail(
                 orch, dep_ring_id, dep_slot, producer_slot_state, dep_task_id, &fanin_builder, ring_id,
                 args.explicit_dep_kind(i)
@@ -991,7 +991,7 @@ static TaskOutputTensors submit_task_common(
         uint8_t prod_ring = producer_task_id.ring();
         PTO2SharedMemoryRingHeader &producer_ring = orch->sm_header->rings[prod_ring];
         int32_t prod_slot = producer_ring.get_slot_by_task_id(static_cast<int32_t>(producer_task_id.local()));
-        PTO2TaskSlotState *prod_state = &producer_ring.get_slot_state_by_slot(prod_slot);
+        ChipTaskSlotState *prod_state = &producer_ring.get_slot_state_by_slot(prod_slot);
         return append_fanin_or_fail(
             orch, prod_ring, prod_slot, prod_state, producer_task_id, &fanin_builder, ring_id, kind
         );
@@ -1117,7 +1117,7 @@ static TaskOutputTensors submit_task_common(
         // wire_fanin_task is skipped here, so its ordering-only pin release runs
         // on this path too: an edge without retention drops its submit->wire pin
         // so the (already completed) producer can be CONSUMED.
-        for_each_fanin_slot_state(payload, [&](PTO2TaskSlotState *producer, DepFlags flags) {
+        for_each_fanin_slot_state(payload, [&](ChipTaskSlotState *producer, DepFlags flags) {
             if (dep_has_wait(flags) && !dep_has_retain(flags)) {
                 sched->release_producer(*producer);  // wiring-phase atomic, not bucketed (see wire_fanin_task)
             }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
@@ -222,7 +222,7 @@ void PTO2OrchestratorState::report_fatal(int32_t error_code, const char *func, c
 static uint32_t next_fanin_seen_epoch(PTO2OrchestratorState *orch) {
     uint32_t next = orch->fanin_seen_current_epoch + 1;
     if (next == 0) {
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             memset(
                 orch->fanin_seen_epoch[r], 0,
                 static_cast<size_t>(orch->sm_header->rings[r].task_window_size) * sizeof(uint32_t)
@@ -256,7 +256,7 @@ struct PTO2FaninBuilder {
     }
 
     bool mark_seen(uint8_t prod_ring, int32_t prod_slot) {
-        if (prod_ring >= PTO2_MAX_RING_DEPTH || prod_slot < 0) {
+        if (prod_ring >= CHIP_MAX_RING_DEPTH || prod_slot < 0) {
             return false;
         }
         uint32_t *seen = orch->fanin_seen_epoch[prod_ring];
@@ -795,9 +795,9 @@ static bool ensure_tensormap_capacity(PTO2OrchestratorState *orch, int32_t neede
         return true;
     }
 
-    int32_t alive[PTO2_MAX_RING_DEPTH];
+    int32_t alive[CHIP_MAX_RING_DEPTH];
     auto read_alive = [&]() {
-        for (int32_t r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int32_t r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             // Relaxed: a self-correcting poll re-read every reclaim tick, so a stale
             // watermark only defers reclaim one tick and never over-frees.
             alive[r] = orch->sm_header->rings[r].fc.last_task_alive.load(std::memory_order_relaxed);
@@ -1367,7 +1367,7 @@ TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const CoreTaskArgs &args)
 
 void PTO2OrchestratorState::mark_done() {
     auto *orch = this;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         int32_t total_tasks = orch->rings[r].task_allocator.active_count();
         if (total_tasks > 0) {
             LOG_DEBUG("=== [Orchestrator] ring %d: total_tasks=%d ===", r, total_tasks);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orchestrator.h
@@ -78,7 +78,7 @@ struct PTO2OrchestratorState {
     // Single contiguous buffer of task IDs, partitioned by scope level.
     // scope_begins[i] is the index into scope_tasks where scope i starts.
     // Tasks for the top scope occupy [scope_begins[top], scope_tasks_size).
-    PTO2TaskSlotState **scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
+    ChipTaskSlotState **scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
     int32_t scope_tasks_size;         // Number of task IDs currently in the buffer
     int32_t scope_tasks_capacity;     // Allocated capacity of scope_tasks
     int32_t *scope_begins;            // scope_begins[i] = start index of scope i in scope_tasks
@@ -174,8 +174,8 @@ struct PTO2OrchestratorState {
     // Forget pointers; arena owns the backing buffers.
     void destroy();
     void set_scheduler(PTO2SchedulerState *scheduler);
-    void mark_dep_pool_position(PTO2TaskSlotState &slot_state);
-    void wire_fanin_task(PTO2TaskSlotState &slot_state, int32_t wfanin);
+    void mark_dep_pool_position(ChipTaskSlotState &slot_state);
+    void wire_fanin_task(ChipTaskSlotState &slot_state, int32_t wfanin);
     void report_fatal(int32_t error_code, const char *func, const char *fmt, ...);
     void begin_scope(PTO2ScopeMode mode = PTO2ScopeMode::AUTO);
     void end_scope();

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orchestrator.h
@@ -43,12 +43,12 @@
  * pools, scope arrays, plus the nested PTO2TensorMap layout).
  */
 struct PTO2OrchestratorLayout {
-    size_t off_fanin_pool[PTO2_MAX_RING_DEPTH];
-    size_t off_fanin_seen_epoch[PTO2_MAX_RING_DEPTH];
+    size_t off_fanin_pool[CHIP_MAX_RING_DEPTH];
+    size_t off_fanin_seen_epoch[CHIP_MAX_RING_DEPTH];
     size_t off_scope_tasks;
     size_t off_scope_begins;
     PTO2TensorMapLayout tensor_map;
-    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
+    int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH];
     int32_t scope_tasks_cap;
     uint64_t scope_stack_capacity;
 };
@@ -67,8 +67,8 @@ struct PTO2OrchestratorState {
     PTO2SharedMemoryHeader *sm_header;
 
     // === PER-RING RESOURCES ===
-    PTO2RingSet rings[PTO2_MAX_RING_DEPTH];
-    uint32_t *fanin_seen_epoch[PTO2_MAX_RING_DEPTH];
+    PTO2RingSet rings[CHIP_MAX_RING_DEPTH];
+    uint32_t *fanin_seen_epoch[CHIP_MAX_RING_DEPTH];
     uint32_t fanin_seen_current_epoch{1};
 
     // === TENSOR MAP (Private) ===
@@ -123,12 +123,12 @@ struct PTO2OrchestratorState {
 
     /**
      * Get current ring index from scope depth.
-     * Maps scope depth to ring_id: min(scope_depth, PTO2_MAX_RING_DEPTH - 1)
+     * Maps scope depth to ring_id: min(scope_depth, CHIP_MAX_RING_DEPTH - 1)
      */
     uint8_t current_ring_id() const {
         int32_t depth = scope_stack_top;
         if (depth < 0) depth = 0;
-        return depth < PTO2_MAX_RING_DEPTH ? static_cast<uint8_t>(depth) : PTO2_MAX_RING_DEPTH - 1;
+        return depth < CHIP_MAX_RING_DEPTH ? static_cast<uint8_t>(depth) : CHIP_MAX_RING_DEPTH - 1;
     }
 
     bool in_manual_scope() const { return scope_stack_top >= manual_begin_depth; }
@@ -140,12 +140,12 @@ struct PTO2OrchestratorState {
     // the nested tensor_map layout. Returned layout is consumed by
     // init_data_from_layout.
     static PTO2OrchestratorLayout reserve_layout(
-        DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+        DeviceArena &arena, const int32_t task_window_sizes[CHIP_MAX_RING_DEPTH],
         int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
     );
     static PTO2OrchestratorLayout reserve_layout(
-        DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-        const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+        DeviceArena &arena, const int32_t task_window_sizes[CHIP_MAX_RING_DEPTH],
+        const int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH]
     );
 
     // Phase 3a: write everything *except* arena-internal pointer fields.
@@ -158,11 +158,11 @@ struct PTO2OrchestratorState {
     );
     bool init_data_from_layout(
         const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap,
-        const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+        const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH], const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]
     );
     bool reset_for_reuse(
         const PTO2OrchestratorLayout &layout, void *sm_dev_base, void *gm_heap,
-        const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+        const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH], const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]
     );
 
     // Phase 3b: write the arena-internal pointer fields (scope_tasks,

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.cpp
@@ -160,7 +160,7 @@ void PTO2DepListPool::report_deadlock(
     LOG_ERROR("  - In-flight tasks: %d", current - last_alive);
     // Head-task dump: what the shared reclaim watermark is actually waiting on.
     if (ring.slot_states != nullptr) {
-        PTO2TaskSlotState &h = ring.get_slot_state_by_task_id(last_alive);
+        ChipTaskSlotState &h = ring.get_slot_state_by_task_id(last_alive);
         uint32_t fc = h.fanout_count;
         uint32_t rc = h.fanout_refcount.load(std::memory_order_acquire);
         LOG_ERROR(
@@ -177,7 +177,7 @@ void PTO2DepListPool::report_deadlock(
 }
 
 bool PTO2DepListPool::ensure_space(
-    PTO2SharedMemoryRingHeader &ring, int32_t needed, PTO2TaskSlotState *oldest_open_task
+    PTO2SharedMemoryRingHeader &ring, int32_t needed, ChipTaskSlotState *oldest_open_task
 ) {
     if (available() >= needed) return true;
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.h
@@ -92,7 +92,7 @@ public:
     void init(
         PTO2TaskDescriptor *descriptors, int32_t window_size, std::atomic<int32_t> *current_index_ptr,
         std::atomic<int32_t> *last_alive_ptr, void *heap_base, uint64_t heap_size, std::atomic<int32_t> *error_code_ptr,
-        PTO2TaskSlotState *slot_states = nullptr, int32_t initial_local_task_id = 0, uint8_t ring_id = 0
+        ChipTaskSlotState *slot_states = nullptr, int32_t initial_local_task_id = 0, uint8_t ring_id = 0
     ) {
         descriptors_ = descriptors;
         slot_states_ = slot_states;
@@ -122,7 +122,7 @@ public:
      * @param oldest_open_task Oldest task owned by any open scope on this ring
      * @return Allocation result; check failed() for errors
      */
-    PTO2TaskAllocResult alloc(int32_t output_size, PTO2TaskSlotState *oldest_open_task = nullptr) {
+    PTO2TaskAllocResult alloc(int32_t output_size, ChipTaskSlotState *oldest_open_task = nullptr) {
         uint64_t aligned_size =
             output_size > 0 ? PTO2_ALIGN_UP(static_cast<uint64_t>(output_size), PTO2_ALIGN_SIZE) : 0;
 
@@ -257,7 +257,7 @@ private:
     PTO2TaskDescriptor *descriptors_ = nullptr;
     // Parallel to descriptors_, indexed by task_id & window_mask_. Read-only here,
     // used by the deadlock detector to identify the head task's slot.
-    PTO2TaskSlotState *slot_states_ = nullptr;
+    ChipTaskSlotState *slot_states_ = nullptr;
     uint8_t ring_id_ = 0;
     int32_t window_size_ = 0;
     int32_t window_mask_ = 0;
@@ -406,7 +406,7 @@ private:
     }
 #endif
 
-    bool head_is_oldest_open_task(int32_t head_task_id, const PTO2TaskSlotState *oldest_open_task) const {
+    bool head_is_oldest_open_task(int32_t head_task_id, const ChipTaskSlotState *oldest_open_task) const {
         return oldest_open_task != nullptr && slot_states_ != nullptr &&
                oldest_open_task == &slot_states_[head_task_id & window_mask_];
     }
@@ -451,7 +451,7 @@ private:
         }
         // Head-task state dump: what the reclaim watermark is actually waiting on.
         if (slot_states_ != nullptr) {
-            PTO2TaskSlotState &h = slot_states_[last_alive & window_mask_];
+            ChipTaskSlotState &h = slot_states_[last_alive & window_mask_];
             uint32_t fc = h.fanout_count;
             uint32_t rc = h.fanout_refcount.load(std::memory_order_acquire);
             LOG_ERROR(
@@ -576,7 +576,7 @@ struct PTO2FaninPool {
 };
 
 template <typename Fn>
-using PTO2FaninCallbackResult = std::invoke_result_t<Fn &, PTO2TaskSlotState *, DepFlags>;
+using PTO2FaninCallbackResult = std::invoke_result_t<Fn &, ChipTaskSlotState *, DepFlags>;
 
 template <typename Fn>
 using PTO2FaninForEachReturn = std::conditional_t<std::is_same_v<PTO2FaninCallbackResult<Fn>, void>, void, bool>;
@@ -728,7 +728,7 @@ struct PTO2DepListPool {
      * reclaim watermark the same way PTO2TaskAllocator::alloc does: a structural
      * head-of-line check plus a wall-clock backstop, each emitting report_deadlock.
      */
-    bool ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed, PTO2TaskSlotState *oldest_open_task = nullptr);
+    bool ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed, ChipTaskSlotState *oldest_open_task = nullptr);
 
     /**
      * Structured dep-pool deadlock report, mirroring PTO2TaskAllocator::report_deadlock.
@@ -788,7 +788,7 @@ struct PTO2DepListPool {
      * @param task_slot     Task slot to prepend
      * @return New head offset
      */
-    PTO2DepListEntry *prepend(PTO2DepListEntry *cur, PTO2TaskSlotState *slot_state) {
+    PTO2DepListEntry *prepend(PTO2DepListEntry *cur, ChipTaskSlotState *slot_state) {
         PTO2DepListEntry *new_entry = alloc();
         if (!new_entry) return nullptr;
         new_entry->slot_state = slot_state;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.h
@@ -807,7 +807,7 @@ struct PTO2DepListPool {
 
 /**
  * Groups a TaskAllocator and DepPool into one per-depth unit.
- * PTO2_MAX_RING_DEPTH instances provide independent reclamation per scope depth.
+ * CHIP_MAX_RING_DEPTH instances provide independent reclamation per scope depth.
  */
 struct PTO2RingSet {
     PTO2TaskAllocator task_allocator;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -12,7 +12,7 @@
  * Runtime Class - Device Execution and Handshake Control
  *
  * This class manages device-side execution through AICPU-AICore handshake
- * protocol. Task graph construction is handled by PTO2Runtime; this class
+ * protocol. Task graph construction is handled by RuntimeContext; this class
  * only handles:
  * - Handshake buffers for AICPU-AICore communication
  * - Execution parameters (block_dim, aicpu_thread_num)
@@ -211,7 +211,7 @@ struct alignas(64) DeviceRuntimeLaunchDesc {
  * Runtime class for device execution and handshake control
  *
  * This class manages AICPU-AICore communication through handshake buffers.
- * Task graph construction is handled by PTO2Runtime; this class only handles
+ * Task graph construction is handled by RuntimeContext; this class only handles
  * execution control and device orchestration state.
  *
  * Layout: the device-read fields live in the first member `dev`
@@ -267,7 +267,7 @@ public:
 
     // Prebuilt-arena fast path (trb only). Set by host's
     // bind_callable_to_runtime_impl; consumed by AICPU at boot to attach a
-    // DeviceArena to `prebuilt_arena_base_` and pick up the PTO2Runtime at
+    // DeviceArena to `prebuilt_arena_base_` and pick up the RuntimeContext at
     // `prebuilt_arena_base_ + prebuilt_runtime_offset_`. Both stay zero on
     // first construction (Runtime() ctor zeros them) so a non-prebuilt boot
     // path can still detect "no prebuilt image set" via nullptr.
@@ -303,7 +303,7 @@ public:
 
     // =========================================================================
     // Deprecated API (for platform compatibility, always returns 0/nullptr)
-    // Task graph is now managed by PTO2Runtime, not Runtime
+    // Task graph is now managed by RuntimeContext, not Runtime
     // =========================================================================
 
     /** @deprecated Task count is now in PTO2 shared memory */

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_core.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_core.cpp
@@ -108,11 +108,11 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
     // idempotent (task_state is monotonic) and only adds one atomic load on
     // the second encounter.
     constexpr int kSegmentCap = 64;
-    const PTO2TaskSlotState *seg[kSegmentCap];
+    const ChipTaskSlotState *seg[kSegmentCap];
     int seg_count = 0;
     bool failed = false;
 
-    auto wait_one_producer = [&](const PTO2TaskSlotState &slot) {
+    auto wait_one_producer = [&](const ChipTaskSlotState &slot) {
         uint8_t ring_id = slot.ring_id;
         int32_t local_id = static_cast<int32_t>(slot.task->task_id.local());
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -138,7 +138,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
         }
     };
 
-    auto wait_one_consumers = [&](const PTO2TaskSlotState &slot) {
+    auto wait_one_consumers = [&](const ChipTaskSlotState &slot) {
         uint8_t ring_id = slot.ring_id;
         int32_t local_id = slot.task->task_id.local();
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -176,7 +176,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
         seg_count = 0;
     };
 
-    auto try_push = [&](const PTO2TaskSlotState &s) {
+    auto try_push = [&](const ChipTaskSlotState &s) {
         for (int j = 0; j < seg_count; j++) {
             if (seg[j] == &s) return;  // per-segment dedup
         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_core.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_core.cpp
@@ -254,7 +254,7 @@ void set_tensor_data(
     memcpy(ptr, &value, elem_size);
 }
 
-// Ops-table entry that hands the call-site captured by PTO2ScopeGuard to the
+// Ops-table entry that hands the call-site captured by ScopeGuard to the
 // [ScopeStats] collector. The slot is always present in the struct to keep
 // the layout stable; at SIMPLER_DFX=0 we fill nullptr so the orchestration
 // .so's null-check skips it.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_core.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_core.cpp
@@ -10,7 +10,7 @@
  */
 
 /**
- * PTO Runtime2 - Main Implementation
+ * Runtime core implementation
  *
  * Implements the unified runtime API that combines orchestrator and scheduler.
  *
@@ -50,31 +50,31 @@ static constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_CYCLES =
 // =============================================================================
 
 static TaskOutputTensors
-submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
+submit_task_impl(RuntimeContext *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
     return rt->orchestrator.submit_task(mixed_kernels, args);
 }
 
-static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const CoreTaskArgs &args) {
+static TaskOutputTensors alloc_tensors_impl(RuntimeContext *rt, const CoreTaskArgs &args) {
     return rt->orchestrator.alloc_tensors(args);
 }
 
-static TaskOutputTensors submit_dummy_task_impl(PTO2Runtime *rt, const CoreTaskArgs &args) {
+static TaskOutputTensors submit_dummy_task_impl(RuntimeContext *rt, const CoreTaskArgs &args) {
     return rt->orchestrator.submit_dummy_task(args);
 }
 
-void rt_scope_begin(PTO2Runtime *rt) {
+void rt_scope_begin(RuntimeContext *rt) {
     PTO2ScopeMode mode = rt->pending_scope_mode;
     rt->pending_scope_mode = PTO2ScopeMode::AUTO;
     rt->orchestrator.begin_scope(mode);
 }
 
-void rt_scope_end(PTO2Runtime *rt) { rt->orchestrator.end_scope(); }
+void rt_scope_end(RuntimeContext *rt) { rt->orchestrator.end_scope(); }
 
-void rt_orchestration_done(PTO2Runtime *rt) { rt->orchestrator.mark_done(); }
+void rt_orchestration_done(RuntimeContext *rt) { rt->orchestrator.mark_done(); }
 
-static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator.fatal; }
+static bool is_fatal_impl(RuntimeContext *rt) { return rt->orchestrator.fatal; }
 
-void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...) {
+void rt_report_fatal(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     if (fmt == nullptr || fmt[0] == '\0') {
@@ -97,7 +97,7 @@ void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, cons
 // Returns false on timeout (sets orch.fatal).
 MAYBE_UNINITIALIZED_BEGIN
 static bool
-wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_consumers, const char *caller) {
+wait_for_tensor_ready(RuntimeContext *rt, const ChipTensor &tensor, bool wait_for_consumers, const char *caller) {
     TaskId owner = tensor.owner_task_id;
     PTO2OrchestratorState &orch = rt->orchestrator;
 
@@ -211,7 +211,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
 }
 MAYBE_UNINITIALIZED_END
 
-uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]) {
+uint64_t get_tensor_data(RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]) {
     if (tensor.buffer.addr == 0) {
         unified_log_error(
             __FUNCTION__, "get_tensor_data: buffer not allocated (addr=0). "
@@ -233,7 +233,7 @@ uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndi
 }
 
 void set_tensor_data(
-    PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+    RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
 ) {
     if (tensor.buffer.addr == 0) {
         unified_log_error(
@@ -262,10 +262,10 @@ void set_tensor_data(
 static void scope_set_site_impl(const char *file, int line) { scope_stats_set_pending_site(file, line); }
 #endif
 
-static int32_t available_cluster_count_impl(PTO2Runtime *rt) { return rt->orchestrator.total_cluster_count; }
-static int32_t available_aiv_count_impl(PTO2Runtime *rt) { return rt->orchestrator.total_aiv_count; }
+static int32_t available_cluster_count_impl(RuntimeContext *rt) { return rt->orchestrator.total_cluster_count; }
+static int32_t available_aiv_count_impl(RuntimeContext *rt) { return rt->orchestrator.total_aiv_count; }
 
-static const PTO2RuntimeOps s_runtime_ops = {
+static const RuntimeOps s_runtime_ops = {
     .submit_task = submit_task_impl,
     .scope_begin = rt_scope_begin,
     .scope_end = rt_scope_end,
@@ -300,13 +300,13 @@ static const PTO2RuntimeOps s_runtime_ops = {
 // SPMD core counts — depend on the device-side s_runtime_ops global and the
 // AICPU SchedulerContext respectively, so they remain in the AICPU build.
 
-void runtime_finalize_after_wire(PTO2Runtime *rt, int32_t aic_count, int32_t aiv_count) {
+void runtime_finalize_after_wire(RuntimeContext *rt, int32_t aic_count, int32_t aiv_count) {
     rt->ops = &s_runtime_ops;
     rt->orchestrator.total_cluster_count = aic_count;
     rt->orchestrator.total_aiv_count = aiv_count;
 }
 
-void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode) {
+void runtime_set_mode(RuntimeContext *rt, RuntimeMode mode) {
     if (rt) {
         rt->mode = mode;
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_core.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_core.h
@@ -312,7 +312,7 @@ void set_tensor_data(
  */
 #ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
-struct PTO2OrchestrationConfig {
+struct OrchestrationConfig {
     int expected_arg_count;
 };
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_core.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_core.h
@@ -9,9 +9,9 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Main Interface
+ * Runtime core interface
  *
- * This is the main header for the PTO Runtime2 system.
+ * This is the main header for the runtime.
  * It provides a unified API for task graph construction and execution.
  *
  * Key Features:
@@ -22,7 +22,7 @@
  * - Orchestrator-Scheduler decoupling via shared memory
  *
  * Usage:
- *   1. Create runtime: PTO2Runtime create methods
+ *   1. Create runtime: RuntimeContext create methods
  *   2. Build task graph in orchestration function:
  *      - begin_scope() / end_scope()
  *      - submit_task()
@@ -51,7 +51,7 @@
 /**
  * Runtime execution mode
  */
-enum PTO2RuntimeMode {
+enum RuntimeMode {
     PTO2_MODE_EXECUTE = 0,    // Execute tasks on workers
     PTO2_MODE_SIMULATE = 1,   // Simulate task execution with cycle counting
     PTO2_MODE_GRAPH_ONLY = 2  // Build graph only, no execution
@@ -64,15 +64,15 @@ enum PTO2RuntimeMode {
  * (via orchestration_api.h inline wrappers), so it has zero link
  * dependencies on runtime .cpp files.
  */
-typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
+typedef struct RuntimeContext RuntimeContext;  // forward declare for ops signatures
 
-struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
-    void (*scope_begin)(PTO2Runtime *rt);
-    void (*scope_end)(PTO2Runtime *rt);
-    void (*orchestration_done)(PTO2Runtime *rt);
-    bool (*is_fatal)(PTO2Runtime *rt);
-    void (*report_fatal)(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
+struct RuntimeOps {
+    TaskOutputTensors (*submit_task)(RuntimeContext *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
+    void (*scope_begin)(RuntimeContext *rt);
+    void (*scope_end)(RuntimeContext *rt);
+    void (*orchestration_done)(RuntimeContext *rt);
+    bool (*is_fatal)(RuntimeContext *rt);
+    void (*report_fatal)(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
     // Logging (populated by runtime, called by orchestration)
     void (*log_error)(const char *func, const char *fmt, ...);
@@ -83,17 +83,17 @@ struct PTO2RuntimeOps {
 
     // Cross-layer data access (orchestration reads/writes tensor values via runtime)
     // Placed after logging to avoid shifting hot-path field offsets.
-    uint64_t (*get_tensor_data)(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
+    uint64_t (*get_tensor_data)(RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
     void (*set_tensor_data)(
-        PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+        RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
     );
-    TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const CoreTaskArgs &args);
-    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const CoreTaskArgs &args);
+    TaskOutputTensors (*alloc_tensors)(RuntimeContext *rt, const CoreTaskArgs &args);
+    TaskOutputTensors (*submit_dummy_task)(RuntimeContext *rt, const CoreTaskArgs &args);
 
     // This-run core geometry from runtime_finalize_after_wire: MIX clusters
     // (one AIC each) and standalone AIV cores.
-    int32_t (*available_cluster_count)(PTO2Runtime *rt);
-    int32_t (*available_aiv_count)(PTO2Runtime *rt);
+    int32_t (*available_cluster_count)(RuntimeContext *rt);
+    int32_t (*available_aiv_count)(RuntimeContext *rt);
 
     // Stash the call-site captured by ScopeGuard into the [ScopeStats]
     // collector. Always present in the struct to keep ops-table layout stable
@@ -139,20 +139,20 @@ struct ArenaOffsets {
  * offsets + arena size. Produced once on the host by runtime_reserve_layout();
  * consumed by runtime_init_data_from_layout and runtime_wire_arena_pointers.
  */
-struct PTO2RuntimeArenaLayout {
+struct RuntimeArenaLayout {
     ArenaSizingKey sizing;
     ArenaOffsets offsets;
 };
 
 /**
- * PTO Runtime2 context
+ * Runtime context
  *
  * Contains all state for orchestration and scheduling.
  * In simulated mode, runs in single process with shared address space.
  */
-struct PTO2Runtime {
+struct RuntimeContext {
     // Ops table (first field — used by orchestration .so via function pointers)
-    const PTO2RuntimeOps *ops;
+    const RuntimeOps *ops;
     PTO2ScopeMode pending_scope_mode;
 
     // Components
@@ -167,7 +167,7 @@ struct PTO2Runtime {
     bool gm_heap_owned;  // True if we allocated it
 
     // Mode
-    PTO2RuntimeMode mode;
+    RuntimeMode mode;
 
     // Statistics
     int64_t total_cycles;
@@ -180,7 +180,7 @@ struct PTO2Runtime {
     // *before* dereferencing this image. Populated on host by
     // runtime_init_data_from_layout + runtime_wire_arena_pointers; read by
     // aicpu_executor.cpp.
-    PTO2RuntimeArenaLayout prebuilt_layout;
+    RuntimeArenaLayout prebuilt_layout;
 };
 
 // =============================================================================
@@ -189,15 +189,15 @@ struct PTO2Runtime {
 
 /**
  * Phase 1 — declare every sub-region (sm_handle wrapper, orchestrator /
- * scheduler / tensor_map / mailbox / PTO2Runtime header) on the supplied
+ * scheduler / tensor_map / mailbox / RuntimeContext header) on the supplied
  * arena. Pure arithmetic; does not touch device memory and may run on host.
  * Returns the layout descriptor; caller commits/attaches the arena before
  * Phase 2/3.
  */
-PTO2RuntimeArenaLayout runtime_reserve_layout(
+RuntimeArenaLayout runtime_reserve_layout(
     DeviceArena &arena, uint64_t task_window_size, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
 );
-PTO2RuntimeArenaLayout runtime_reserve_layout(
+RuntimeArenaLayout runtime_reserve_layout(
     DeviceArena &arena, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
     const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
 );
@@ -212,17 +212,17 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
  * them (never dereference). Safe to run on a host arena that owns a host
  * mirror of the runtime image — the resulting buffer is rtMemcpy-ready.
  *
- * Returns the PTO2Runtime* that sits at layout.off_runtime within the arena.
+ * Returns the RuntimeContext* that sits at layout.off_runtime within the arena.
  * Caller must follow up with runtime_wire_arena_pointers; rt->ops and the
  * AICore-side count fields are left untouched and must be filled by the
  * AICPU at boot.
  */
-PTO2Runtime *runtime_init_data_from_layout(
-    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
+RuntimeContext *runtime_init_data_from_layout(
+    DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
     void *gm_heap_dev_base, uint64_t heap_size
 );
-PTO2Runtime *runtime_init_data_from_layout(
-    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
+RuntimeContext *runtime_init_data_from_layout(
+    DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
     void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
 );
 
@@ -234,8 +234,8 @@ PTO2Runtime *runtime_init_data_from_layout(
  * both host (writing host-mirror addresses) and AICPU (writing device
  * addresses) sides.
  */
-void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
-bool runtime_reset_for_reuse(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
+void runtime_wire_arena_pointers(DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeContext *rt);
+bool runtime_reset_for_reuse(DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeContext *rt);
 
 /**
  * AICPU-only Phase 4 — fill in the few fields the host could not know at
@@ -244,7 +244,7 @@ bool runtime_reset_for_reuse(DeviceArena &arena, const PTO2RuntimeArenaLayout &l
  * orchestrator's core counts (depend on the executor's scheduler context).
  * Call once per boot after runtime_wire_arena_pointers.
  */
-void runtime_finalize_after_wire(PTO2Runtime *rt, int32_t aic_count, int32_t aiv_count);
+void runtime_finalize_after_wire(RuntimeContext *rt, int32_t aic_count, int32_t aiv_count);
 
 /**
  * Destroy runtime. With the prebuilt-arena fast path the arena buffer is
@@ -252,12 +252,12 @@ void runtime_finalize_after_wire(PTO2Runtime *rt, int32_t aic_count, int32_t aiv
  * here — the destructor only forgets sub-structure pointers (idempotent
  * cleanup).
  */
-void runtime_destroy(PTO2Runtime *rt, DeviceArena &arena);
+void runtime_destroy(RuntimeContext *rt, DeviceArena &arena);
 
 /**
  * Set execution mode
  */
-void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
+void runtime_set_mode(RuntimeContext *rt, RuntimeMode mode);
 
 // =============================================================================
 // Orchestration API (called by orchestration function)
@@ -270,7 +270,7 @@ void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
  * bounded by the scope. When scope_end() is called, the scope
  * releases its reference to all enclosed tasks.
  */
-void rt_scope_begin(PTO2Runtime *rt);
+void rt_scope_begin(RuntimeContext *rt);
 
 /**
  * End current scope
@@ -278,24 +278,24 @@ void rt_scope_begin(PTO2Runtime *rt);
  * Releases scope reference for all tasks submitted since scope_begin().
  * Tasks whose refcount reaches zero will have their buffers released.
  */
-void rt_scope_end(PTO2Runtime *rt);
+void rt_scope_end(RuntimeContext *rt);
 
 /**
  * Mark orchestration as complete
  *
  * Signals that no more tasks will be submitted.
  */
-void rt_orchestration_done(PTO2Runtime *rt);
+void rt_orchestration_done(RuntimeContext *rt);
 
 /**
  * Enter fatal state explicitly from orchestration.
  */
-void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
+void rt_report_fatal(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
 /**
  * Cross-layer data access: read a tensor value by waiting for its producer.
  */
-uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
+uint64_t get_tensor_data(RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
 
 /**
  * Cross-layer data access: write a value to a tensor at given indices.
@@ -303,7 +303,7 @@ uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndi
  * See set_tensor_data in orchestration_api.h for full documentation.
  */
 void set_tensor_data(
-    PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+    RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
 );
 
 /**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_core.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_core.h
@@ -107,9 +107,9 @@ struct RuntimeOps {
  * config); re-read at AICPU boot to reconstruct ring/heap/dep-pool capacities.
  */
 struct ArenaSizingKey {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]{};
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]{};
-    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]{};
+    uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]{};
+    uint64_t heap_sizes[CHIP_MAX_RING_DEPTH]{};
+    int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH]{};
 };
 
 /**
@@ -198,8 +198,8 @@ RuntimeArenaLayout runtime_reserve_layout(
     DeviceArena &arena, uint64_t task_window_size, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
 );
 RuntimeArenaLayout runtime_reserve_layout(
-    DeviceArena &arena, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+    DeviceArena &arena, const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH], const int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH]
 );
 
 /**
@@ -223,7 +223,7 @@ RuntimeContext *runtime_init_data_from_layout(
 );
 RuntimeContext *runtime_init_data_from_layout(
     DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
-    void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+    void *gm_heap_dev_base, const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH]
 );
 
 /**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_core.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_core.h
@@ -95,7 +95,7 @@ struct PTO2RuntimeOps {
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
 
-    // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]
+    // Stash the call-site captured by ScopeGuard into the [ScopeStats]
     // collector. Always present in the struct to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
     void (*scope_set_site)(const char *file, int line);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_types.h
@@ -166,11 +166,11 @@ struct PTO2OutputLayout {
  * Fanin spill entry
  * Stored in the dedicated fanin spill ring buffer.
  */
-struct PTO2TaskSlotState;  // Forward declaration
+struct ChipTaskSlotState;  // Forward declaration
 struct PTO2FaninPool;      // Forward declaration
 
 // One fanin edge: a producer slot pointer with the per-edge DepFlags packed into
-// bits 0..1 of the pointer. PTO2TaskSlotState is alignas(64), so bits 0..5 are
+// bits 0..1 of the pointer. ChipTaskSlotState is alignas(64), so bits 0..5 are
 // always zero in a real pointer. Used for both the inline fanin array and the
 // spill pool, keeping sizeof == sizeof(uintptr_t) so neither footprint grows.
 struct PTO2FaninSpillEntry {
@@ -181,11 +181,11 @@ struct PTO2FaninSpillEntry {
     // are written via set()). Value-init (`PTO2FaninSpillEntry{}`) still zeroes it.
     uintptr_t packed;
 
-    PTO2TaskSlotState *slot_state() const { return reinterpret_cast<PTO2TaskSlotState *>(packed & ~FLAG_MASK); }
+    ChipTaskSlotState *slot_state() const { return reinterpret_cast<ChipTaskSlotState *>(packed & ~FLAG_MASK); }
     DepFlags flags() const { return static_cast<DepFlags>(packed & FLAG_MASK); }
     // Only bits within FLAG_MASK are stored; any bit outside it (a malformed
     // DepFlags value) is masked off so it can never corrupt the slot pointer.
-    void set(PTO2TaskSlotState *s, DepFlags f) {
+    void set(ChipTaskSlotState *s, DepFlags f) {
         packed = reinterpret_cast<uintptr_t>(s) | (static_cast<uintptr_t>(f) & FLAG_MASK);
     }
     void add_flags(DepFlags f) { packed |= (static_cast<uintptr_t>(f) & FLAG_MASK); }
@@ -198,7 +198,7 @@ static_assert(sizeof(PTO2FaninSpillEntry) == sizeof(uintptr_t));
  * Stored in DepListPool ring buffer.
  */
 struct PTO2DepListEntry {
-    PTO2TaskSlotState *slot_state;  // Consumer slot state (direct pointer)
+    ChipTaskSlotState *slot_state;  // Consumer slot state (direct pointer)
     PTO2DepListEntry *next;         // next entry
 };
 
@@ -211,7 +211,7 @@ struct PTO2DepListEntry {
  *
  * Stored in the TaskDescriptor ring buffer in shared memory.
  * Contains static identification and buffer pointers only.
- * Dynamic scheduling state (fanin/fanout/task_state) is in PTO2TaskSlotState.
+ * Dynamic scheduling state (fanin/fanout/task_state) is in ChipTaskSlotState.
  *
  * Fields set by Orchestrator at submission, read by Scheduler for dispatch.
  */
@@ -473,7 +473,7 @@ enum PTO2TaskLifecycleFlag : uint8_t {
 
 static_assert((PTO2_DISPATCH_PROPAGATED & (PTO2_READY_CLAIMED | PTO2_COMPLETION_DONE | PTO2_SUBTASK_DEFERRED)) == 0);
 
-struct alignas(64) PTO2TaskSlotState {
+struct alignas(64) ChipTaskSlotState {
     // Fanout lock + list (accessed together under lock in on_task_complete)
     std::atomic<int32_t> fanout_lock;  // Per-task spinlock (0=unlocked, 1=locked)
     uint32_t fanout_count;             // SCOPE_BIT (owning scope) | number of consumers
@@ -505,7 +505,7 @@ struct alignas(64) PTO2TaskSlotState {
     // has_predicate, selective timing tag). Lives on slot_state (not payload) so
     // fanin walks and the completion path read them off the already-hot producer
     // slot_state cache line. Packed into the padding before dep_pool_mark to keep
-    // PTO2TaskSlotState at 64 bytes. Plain-write (set once at submit, before the
+    // ChipTaskSlotState at 64 bytes. Plain-write (set once at submit, before the
     // slot is scheduler-visible), so it MUST NOT share a byte with the atomically
     // mutated lifecycle_flags.
     TaskAttrs task_attrs{};
@@ -665,10 +665,10 @@ struct alignas(64) PTO2TaskSlotState {
     void unlock_fanout() { fanout_lock.store(0, std::memory_order_release); }
 };
 
-static_assert(sizeof(PTO2TaskSlotState) == 64);
-// PTO2FaninSpillEntry packs DepFlags into the low bits of a PTO2TaskSlotState*.
+static_assert(sizeof(ChipTaskSlotState) == 64);
+// PTO2FaninSpillEntry packs DepFlags into the low bits of a ChipTaskSlotState*.
 // That is only lossless while the type is aligned past those tag bits.
 static_assert(
-    alignof(PTO2TaskSlotState) > PTO2FaninSpillEntry::FLAG_MASK,
-    "PTO2TaskSlotState alignment must exceed PTO2FaninSpillEntry::FLAG_MASK so the packed DepFlags bits are free"
+    alignof(ChipTaskSlotState) > PTO2FaninSpillEntry::FLAG_MASK,
+    "ChipTaskSlotState alignment must exceed PTO2FaninSpillEntry::FLAG_MASK so the packed DepFlags bits are free"
 );

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime_types.h
@@ -65,10 +65,10 @@
 #define PTO2_TASK_WINDOW_SIZE 16384  // Default per-ring task window size (power of 2)
 
 // Multi-ring: number of independent ring layers (HeapRing + TaskRing + DepPool per layer)
-// Scope depth maps to ring index via: min(scope_depth, PTO2_MAX_RING_DEPTH - 1)
-#define PTO2_MAX_RING_DEPTH 4
+// Scope depth maps to ring index via: min(scope_depth, CHIP_MAX_RING_DEPTH - 1)
+#define CHIP_MAX_RING_DEPTH 4
 
-// Memory pools (per-ring defaults; total = value × PTO2_MAX_RING_DEPTH)
+// Memory pools (per-ring defaults; total = value × CHIP_MAX_RING_DEPTH)
 #define PTO2_HEAP_SIZE (256 * 1024 * 1024)  // 256MB per ring (1GB total)
 #define PTO2_DEP_LIST_POOL_SIZE 16384       // Per-ring dependency list pool entries
 #define PTO2_TENSORMAP_POOL_SIZE (65536)    // TensorMap entry pool
@@ -77,11 +77,11 @@
 // Scope management
 #define PTO2_MAX_SCOPE_DEPTH 64  // Maximum nesting depth
 // Hard cap for the scope_tasks buffer. Equals the total in-flight ring slot
-// budget (PTO2_TASK_WINDOW_SIZE × PTO2_MAX_RING_DEPTH): once every ring slot
+// budget (PTO2_TASK_WINDOW_SIZE × CHIP_MAX_RING_DEPTH): once every ring slot
 // is in flight, no more tasks can ever be pushed regardless of buffer size.
 // scope_tasks_push fatals on overflow rather than growing the arena-owned
 // buffer (which would be UB on the arena's malloc'd backing).
-#define PTO2_SCOPE_TASKS_CAP (PTO2_TASK_WINDOW_SIZE * PTO2_MAX_RING_DEPTH)
+#define PTO2_SCOPE_TASKS_CAP (PTO2_TASK_WINDOW_SIZE * CHIP_MAX_RING_DEPTH)
 
 // Ready queue
 #define PTO2_READY_QUEUE_SIZE 65536  // Per-shape queue size

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.cpp
@@ -74,7 +74,7 @@ PTO2SchedProfilingData scheduler_get_profiling(int thread_idx) {
 void PTO2SchedulerState::print_stats() {
     PTO2SchedulerState *sched = this;
     LOG_DEBUG("=== Scheduler Statistics ===");
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         if (sched->ring_sched_states[r].last_task_alive > 0) {
             LOG_DEBUG("Ring %d:", r);
             LOG_DEBUG("  last_task_alive: %d", sched->ring_sched_states[r].last_task_alive);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
@@ -429,9 +429,9 @@ struct PTO2SchedulerLayout {
     size_t off_dummy_ready_queue_slots;
     size_t off_early_dispatch_queue_slots[PTO2_NUM_RESOURCE_SHAPES];
     size_t off_early_sync_start_queue_slots;
-    size_t off_dep_pool_entries[PTO2_MAX_RING_DEPTH];
+    size_t off_dep_pool_entries[CHIP_MAX_RING_DEPTH];
     uint64_t ready_queue_capacity;
-    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
+    int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH];
 };
 
 /**
@@ -507,7 +507,7 @@ struct PTO2SchedulerState {
 
             sync_to_sm();
         }
-    } ring_sched_states[PTO2_MAX_RING_DEPTH];
+    } ring_sched_states[CHIP_MAX_RING_DEPTH];
 
     alignas(64) std::atomic<uint32_t> advance_pending_mask;
 
@@ -554,7 +554,7 @@ struct PTO2SchedulerState {
     }
 
     static uint32_t ring_advance_pending_bit(int32_t ring_id) {
-        static_assert(PTO2_MAX_RING_DEPTH <= 32, "advance_pending_mask uses one uint32_t bit per ring");
+        static_assert(CHIP_MAX_RING_DEPTH <= 32, "advance_pending_mask uses one uint32_t bit per ring");
         return 1u << static_cast<uint32_t>(ring_id);
     }
 
@@ -571,7 +571,7 @@ struct PTO2SchedulerState {
         if (pending == 0) return false;
 
         bool advanced = false;
-        for (int32_t ring_id = 0; ring_id < PTO2_MAX_RING_DEPTH; ring_id++) {
+        for (int32_t ring_id = 0; ring_id < CHIP_MAX_RING_DEPTH; ring_id++) {
             uint32_t bit = ring_advance_pending_bit(ring_id);
             if ((pending & bit) == 0) continue;
 
@@ -1382,7 +1382,7 @@ struct PTO2SchedulerState {
     // the same values.
     static PTO2SchedulerLayout reserve_layout(DeviceArena &arena, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
     static PTO2SchedulerLayout
-    reserve_layout(DeviceArena &arena, const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]);
+    reserve_layout(DeviceArena &arena, const int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH]);
 
     // Phase 3a: write everything *except* arena-internal pointer fields.
     // `sm_dev_base` is the device address of the SM (only stored, never

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
@@ -59,7 +59,7 @@
  */
 struct PTO2ReadyQueueSlot {
     std::atomic<int64_t> sequence;
-    PTO2TaskSlotState *slot_state;
+    ChipTaskSlotState *slot_state;
     uint64_t task_id_snapshot;
 };
 
@@ -93,9 +93,9 @@ struct alignas(64) PTO2ReadyQueue {
 
     void reset_for_reuse() {}
 
-    bool push(PTO2TaskSlotState *slot_state) { return push_tagged(slot_state, 0); }
+    bool push(ChipTaskSlotState *slot_state) { return push_tagged(slot_state, 0); }
 
-    bool push_tagged(PTO2TaskSlotState *slot_state, uint64_t task_id_snapshot) {
+    bool push_tagged(ChipTaskSlotState *slot_state, uint64_t task_id_snapshot) {
         uint64_t pos;
         PTO2ReadyQueueSlot *slot;
         while (true) {
@@ -126,9 +126,9 @@ struct alignas(64) PTO2ReadyQueue {
     // `count` items. A target slot holding an older generation means full and
     // ends the call; a slot a peer has reserved but not yet published is
     // transient and retries, so this only spins while a peer is mid-publish.
-    bool push_batch(PTO2TaskSlotState **items, int count) { return push_batch_tagged(items, nullptr, count); }
+    bool push_batch(ChipTaskSlotState **items, int count) { return push_batch_tagged(items, nullptr, count); }
 
-    bool push_batch_tagged(PTO2TaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
+    bool push_batch_tagged(ChipTaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
         if (count == 0) return true;
         if (static_cast<uint64_t>(count) > capacity) return false;
 
@@ -168,7 +168,7 @@ struct alignas(64) PTO2ReadyQueue {
     }
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
-    bool push(PTO2TaskSlotState *slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {
+    bool push(ChipTaskSlotState *slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {
         uint64_t pos;
         PTO2ReadyQueueSlot *slot;
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -207,9 +207,9 @@ struct alignas(64) PTO2ReadyQueue {
     }
 #endif
 
-    PTO2TaskSlotState *pop() { return pop_tagged(nullptr); }
+    ChipTaskSlotState *pop() { return pop_tagged(nullptr); }
 
-    PTO2TaskSlotState *pop_tagged(uint64_t *task_id_snapshot) {
+    ChipTaskSlotState *pop_tagged(uint64_t *task_id_snapshot) {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -234,14 +234,14 @@ struct alignas(64) PTO2ReadyQueue {
             }
         }
 
-        PTO2TaskSlotState *result = slot->slot_state;
+        ChipTaskSlotState *result = slot->slot_state;
         if (task_id_snapshot != nullptr) *task_id_snapshot = slot->task_id_snapshot;
         slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
 
 #if SIMPLER_SCHED_PROFILING
-    PTO2TaskSlotState *pop(uint64_t &atomic_count, uint64_t &wait_cycle) {
+    ChipTaskSlotState *pop(uint64_t &atomic_count, uint64_t &wait_cycle) {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -283,7 +283,7 @@ struct alignas(64) PTO2ReadyQueue {
             wait_cycle += (get_sys_cnt_aicpu() - t0);
         }
 
-        PTO2TaskSlotState *result = slot->slot_state;
+        ChipTaskSlotState *result = slot->slot_state;
         slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
@@ -291,9 +291,9 @@ struct alignas(64) PTO2ReadyQueue {
 
     // Batch pop: reserve a contiguous run of ready slots with a single CAS.
     // Returns actual number of items popped (may be less than max_count).
-    int pop_batch(PTO2TaskSlotState **out, int max_count) { return pop_batch_tagged(out, nullptr, max_count); }
+    int pop_batch(ChipTaskSlotState **out, int max_count) { return pop_batch_tagged(out, nullptr, max_count); }
 
-    int pop_batch_tagged(PTO2TaskSlotState **out, uint64_t *task_id_snapshots, int max_count) {
+    int pop_batch_tagged(ChipTaskSlotState **out, uint64_t *task_id_snapshots, int max_count) {
         uint64_t pos;
         int count;
         while (true) {
@@ -332,7 +332,7 @@ struct alignas(64) PTO2ReadyQueue {
     }
 
 #if SIMPLER_SCHED_PROFILING
-    int pop_batch(PTO2TaskSlotState **out, int max_count, uint64_t &atomic_count, uint64_t &wait_cycle) {
+    int pop_batch(ChipTaskSlotState **out, int max_count, uint64_t &atomic_count, uint64_t &wait_cycle) {
         uint64_t pos;
         int count;
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -489,7 +489,7 @@ struct PTO2SchedulerState {
             int32_t old_last_task_alive = last_task_alive;
 
             while (last_task_alive < current_task_index) {
-                PTO2TaskSlotState &slot_state = ring->get_slot_state_by_task_id(last_task_alive);
+                ChipTaskSlotState &slot_state = ring->get_slot_state_by_task_id(last_task_alive);
                 if (slot_state.task_state.load(std::memory_order_acquire) != PTO2_TASK_CONSUMED) {
                     break;
                 }
@@ -541,7 +541,7 @@ struct PTO2SchedulerState {
     // dummy_ready_queue and are retired inline; a ready sync_start cohort goes to
     // the per-shape ready_sync_queues[] (drained as Tier-0); everything else to
     // ready_queues[].
-    void push_ready_routed(PTO2TaskSlotState *slot_state) {
+    void push_ready_routed(ChipTaskSlotState *slot_state) {
         PTO2ResourceShape shape = slot_state->active_mask.to_shape();
         if (shape == PTO2ResourceShape::DUMMY ||
             (slot_state->task_attrs.has_predicate() && !slot_state->payload->predicate.pass())) {
@@ -592,7 +592,7 @@ struct PTO2SchedulerState {
         return advanced;
     }
 
-    bool try_claim_ready_once(PTO2TaskSlotState &slot_state) {
+    bool try_claim_ready_once(ChipTaskSlotState &slot_state) {
         uint8_t flags = slot_state.lifecycle_flags.load(std::memory_order_acquire);
         for (;;) {
             if ((flags & PTO2_READY_CLAIMED) != 0) return false;
@@ -605,7 +605,7 @@ struct PTO2SchedulerState {
         }
     }
 
-    void check_and_handle_consumed(PTO2TaskSlotState &slot_state) {
+    void check_and_handle_consumed(ChipTaskSlotState &slot_state) {
         // Read fanout_refcount/fanout_count and flip COMPLETED->CONSUMED under
         // fanout_lock. The orchestrator claims producers (fanout_count++) under the
         // same lock, so the consume decision is serialized against a concurrent
@@ -643,7 +643,7 @@ struct PTO2SchedulerState {
     }
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
-    void check_and_handle_consumed(PTO2TaskSlotState &slot_state, uint64_t &atomic_count) {
+    void check_and_handle_consumed(ChipTaskSlotState &slot_state, uint64_t &atomic_count) {
         // See the non-profiling overload for why the read + COMPLETED->CONSUMED
         // flip is serialized against the orchestrator's claim under fanout_lock.
         bool became_consumed = false;
@@ -683,26 +683,26 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    void release_producer(PTO2TaskSlotState &slot_state) {
+    void release_producer(ChipTaskSlotState &slot_state) {
         slot_state.fanout_refcount.fetch_add(1, std::memory_order_acq_rel);
         check_and_handle_consumed(slot_state);
     }
 
     // Scope-end release: sets bit31 (PTO2_FANOUT_SCOPE_BIT) instead of bumping a
     // consumer ref. Called exactly once per task from on_scope_end.
-    void release_producer_scope(PTO2TaskSlotState &slot_state) {
+    void release_producer_scope(ChipTaskSlotState &slot_state) {
         slot_state.fanout_refcount.fetch_add(PTO2_FANOUT_SCOPE_BIT, std::memory_order_acq_rel);
         check_and_handle_consumed(slot_state);
     }
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
-    void release_producer(PTO2TaskSlotState &slot_state, uint64_t &atomic_count) {
+    void release_producer(ChipTaskSlotState &slot_state, uint64_t &atomic_count) {
         slot_state.fanout_refcount.fetch_add(1, std::memory_order_acq_rel);
         atomic_count += 1;  // fanout_refcount.fetch_add
         check_and_handle_consumed(slot_state, atomic_count);
     }
 
-    void release_producer_scope(PTO2TaskSlotState &slot_state, uint64_t &atomic_count) {
+    void release_producer_scope(ChipTaskSlotState &slot_state, uint64_t &atomic_count) {
         slot_state.fanout_refcount.fetch_add(PTO2_FANOUT_SCOPE_BIT, std::memory_order_acq_rel);
         atomic_count += 1;  // fanout_refcount.fetch_add
         check_and_handle_consumed(slot_state, atomic_count);
@@ -814,7 +814,7 @@ struct PTO2SchedulerState {
         );
     }
 
-    inline void record_published_blocks(PTO2TaskSlotState &slot_state, int32_t count) {
+    inline void record_published_blocks(ChipTaskSlotState &slot_state, int32_t count) {
         if (count <= 0 || !slot_state.task_attrs.allow_early_resolve()) return;
         slot_state.payload->published_block_count.fetch_add(static_cast<int16_t>(count), std::memory_order_seq_cst);
     }
@@ -822,7 +822,7 @@ struct PTO2SchedulerState {
     // Ring one sync_start cohort from its stable staged_core_mask. The caller owns
     // the NONE->RINGING launch latch and invokes this exactly once after local or
     // global staging completes, while the corresponding per-core table entries are live.
-    inline void ring_all_staged_doorbells(PTO2TaskSlotState &slot_state) {
+    inline void ring_all_staged_doorbells(ChipTaskSlotState &slot_state) {
         for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
             uint64_t bits = slot_state.payload->staged_core_mask[w].load(std::memory_order_seq_cst);
             while (bits != 0) {
@@ -856,7 +856,7 @@ struct PTO2SchedulerState {
         return (previous & PTO2_EARLY_SYNC_DRAIN_OWNER) != 0;
     }
 
-    inline void cancel_early_sync_drain(PTO2TaskSlotState &slot_state) {
+    inline void cancel_early_sync_drain(ChipTaskSlotState &slot_state) {
         uint8_t previous =
             slot_state.payload->early_sync_drain_state.exchange(PTO2_EARLY_SYNC_DRAIN_NONE, std::memory_order_seq_cst);
         if ((previous & PTO2_EARLY_SYNC_DRAIN_OWNER) == 0) return;
@@ -889,7 +889,7 @@ struct PTO2SchedulerState {
     // release and each pending->running promotion); whichever observes the second half
     // wins the launch latch and rings exactly once. Returns true only to that winner,
     // which may then expose the cohort to its fanout.
-    inline bool maybe_rendezvous_ring(PTO2TaskSlotState &slot_state) {
+    inline bool maybe_rendezvous_ring(ChipTaskSlotState &slot_state) {
         // running_slot_count is the publication seed: every staged_core_mask OR
         // happens-before its final store. Read the seed first, then the mask, so
         // observing the final count cannot be paired with a partially published
@@ -912,7 +912,7 @@ struct PTO2SchedulerState {
         return true;
     }
 
-    inline bool retry_sync_start_rendezvous_after_staging(PTO2TaskSlotState &slot_state) {
+    inline bool retry_sync_start_rendezvous_after_staging(ChipTaskSlotState &slot_state) {
         if (!maybe_rendezvous_ring(slot_state)) return false;
         propagate_dispatch_fanin(slot_state);
         return true;
@@ -920,7 +920,7 @@ struct PTO2SchedulerState {
 
     // Attempt to claim and enqueue a consumer after every direct producer becomes
     // launch-visible. Both propagation and wiring can complete dispatch_fanin.
-    inline void try_enqueue_early_dispatch_candidate(PTO2TaskSlotState &consumer) {
+    inline void try_enqueue_early_dispatch_candidate(ChipTaskSlotState &consumer) {
         // Predicated tasks resolve at the ready point, never early-dispatch. The
         // wiring caller has no separate predicate filter, so the gate lives here.
         if (consumer.task_attrs.has_predicate()) return;
@@ -969,7 +969,7 @@ struct PTO2SchedulerState {
     // every placement path publishes its claimed range. Once-guarded per producer.
     // Only codegen-flagged producers propagate: a task's successors early-dispatch off its
     // DIRECT producers' marks, never an inherited chain.
-    void propagate_dispatch_fanin(PTO2TaskSlotState &p) {
+    void propagate_dispatch_fanin(ChipTaskSlotState &p) {
         if (!p.task_attrs.allow_early_resolve()) return;  // only codegen-flagged (direct) producers propagate
         if (p.payload->published_block_count.load(std::memory_order_seq_cst) < p.logical_block_num) return;
         if (p.payload->early_dispatch_state.load(std::memory_order_acquire) == PTO2_EARLY_DISPATCH_STAGING) return;
@@ -996,7 +996,7 @@ struct PTO2SchedulerState {
         PTO2DepListEntry *edge = p.fanout_head;
         p.unlock_fanout();
         for (; edge != nullptr; edge = edge->next) {
-            PTO2TaskSlotState *c = edge->slot_state;
+            ChipTaskSlotState *c = edge->slot_state;
             if (c->task_attrs.has_predicate()) continue;  // predicated consumers never early-dispatch
             // Compare to fanin_actual_count (the real producer-edge count), NOT
             // fanin_count: fanin_count = fanin_actual_count + 1 (a self/wiring +1 that
@@ -1016,16 +1016,16 @@ struct PTO2SchedulerState {
     // propagation runs AFTER the walk — never between two siblings' doorbells.
     struct EarlyDispatchReleaseSink {
         static constexpr int CAP = 32;
-        PTO2TaskSlotState *items[CAP];
+        ChipTaskSlotState *items[CAP];
         int n = 0;
-        inline bool push(PTO2TaskSlotState *s) {
+        inline bool push(ChipTaskSlotState *s) {
             if (n >= CAP) return false;
             items[n++] = s;
             return true;
         }
     };
 
-    inline bool try_early_dispatch_release(PTO2TaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
+    inline bool try_early_dispatch_release(ChipTaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
         // A predicated task is evaluated at the ready point, never early-dispatched.
         if (slot_state.task_attrs.has_predicate()) return false;
         // Never staged => CAS NONE->DISPATCHED wins => dispatch normally.
@@ -1085,7 +1085,7 @@ struct PTO2SchedulerState {
         return slot_state.next_block_idx.load(std::memory_order_seq_cst) >= slot_state.logical_block_num;
     }
 
-    bool route_ready_once(PTO2TaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
+    bool route_ready_once(ChipTaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
         if (!try_claim_ready_once(slot_state)) return false;
 
         // Early-dispatch: pre-staged tasks are released by doorbell
@@ -1112,7 +1112,7 @@ struct PTO2SchedulerState {
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
     bool route_ready_once(
-        PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait,
+        ChipTaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait,
         EarlyDispatchReleaseSink *sink = nullptr
     ) {
         uint8_t flags = slot_state.lifecycle_flags.load(std::memory_order_acquire);
@@ -1152,7 +1152,7 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    bool release_fanin_and_check_ready(PTO2TaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
+    bool release_fanin_and_check_ready(ChipTaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
         // Atomically increment fanin_refcount and check if all producers are done
         // ACQ_REL on fanin_refcount already synchronizes with the orchestrator's
         // init release, making fanin_count visible — plain load suffices.
@@ -1166,7 +1166,7 @@ struct PTO2SchedulerState {
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
     bool release_fanin_and_check_ready(
-        PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait,
+        ChipTaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait,
         EarlyDispatchReleaseSink *sink = nullptr
     ) {
         int32_t new_refcount = slot_state.fanin_refcount.fetch_add(1, std::memory_order_acq_rel) + 1;
@@ -1179,20 +1179,20 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    int get_ready_tasks_batch(PTO2ReadyQueue *queues, PTO2ResourceShape shape, PTO2TaskSlotState **out, int max_count) {
+    int get_ready_tasks_batch(PTO2ReadyQueue *queues, PTO2ResourceShape shape, ChipTaskSlotState **out, int max_count) {
         return queues[static_cast<int32_t>(shape)].pop_batch(out, max_count);
     }
 
 #if SIMPLER_SCHED_PROFILING
     int get_ready_tasks_batch(
-        PTO2ReadyQueue *queues, PTO2ResourceShape shape, PTO2TaskSlotState **out, int max_count, uint64_t &atomic_count,
+        PTO2ReadyQueue *queues, PTO2ResourceShape shape, ChipTaskSlotState **out, int max_count, uint64_t &atomic_count,
         uint64_t &wait_cycle
     ) {
         return queues[static_cast<int32_t>(shape)].pop_batch(out, max_count, atomic_count, wait_cycle);
     }
 #endif
 
-    void on_scope_end(PTO2TaskSlotState **task_slot_states, int32_t count) {
+    void on_scope_end(ChipTaskSlotState **task_slot_states, int32_t count) {
 #if SIMPLER_ORCH_PROFILING
         extern uint64_t g_orch_scope_end_atomic_count;
         if (count > 0) __builtin_prefetch(task_slot_states[0], 1, 0);
@@ -1217,7 +1217,7 @@ struct PTO2SchedulerState {
      *
      * @return true if this was the last subtask, completing the entire task.
      */
-    bool on_subtask_complete(PTO2TaskSlotState &slot_state) {
+    bool on_subtask_complete(ChipTaskSlotState &slot_state) {
         int16_t prev = slot_state.completed_subtasks.fetch_add(1, std::memory_order_acq_rel);
         return (prev + 1) == slot_state.total_required_subtasks;
     }
@@ -1240,7 +1240,7 @@ struct PTO2SchedulerState {
     uint32_t
 #endif
     on_task_complete(
-        PTO2TaskSlotState &slot_state
+        ChipTaskSlotState &slot_state
 #if SIMPLER_SCHED_PROFILING
         ,
         int thread_idx
@@ -1296,7 +1296,7 @@ struct PTO2SchedulerState {
         // after the walk, so no consumer's doorbell waits on a sibling's propagate.
         EarlyDispatchReleaseSink rel_sink;
         while (current != nullptr) {
-            PTO2TaskSlotState &consumer_slot = *current->slot_state;
+            ChipTaskSlotState &consumer_slot = *current->slot_state;
 #if SIMPLER_SCHED_PROFILING
             stats.fanout_edges++;
             if (release_fanin_and_check_ready(consumer_slot, fanout_atomics, push_wait, &rel_sink)) {
@@ -1329,7 +1329,7 @@ struct PTO2SchedulerState {
      */
 
 #if SIMPLER_SCHED_PROFILING
-    int32_t on_task_release(PTO2TaskSlotState &slot_state, int32_t thread_idx) {
+    int32_t on_task_release(ChipTaskSlotState &slot_state, int32_t thread_idx) {
         PTO2_SCHED_CYCLE_START();
         extern uint64_t g_sched_fanin_cycle[], g_sched_fanin_atomic_count[];
         extern uint64_t g_sched_self_atomic_count[];
@@ -1337,7 +1337,7 @@ struct PTO2SchedulerState {
         extern uint64_t g_sched_complete_count[];
         uint64_t fanin_atomics = 0;
 #else
-    int32_t on_task_release(PTO2TaskSlotState &slot_state) {
+    int32_t on_task_release(ChipTaskSlotState &slot_state) {
 #endif
         PTO2TaskPayload *payload = slot_state.payload;
         int32_t released = 0;
@@ -1345,7 +1345,7 @@ struct PTO2SchedulerState {
         // ordering-only edge released its submit->wire pin at wiring, so releasing
         // it again here would over-count fanout_refcount against fanout_count and
         // break the rc == fc consume invariant.
-        for_each_fanin_slot_state(*payload, [&](PTO2TaskSlotState *producer_slot_state, DepFlags flags) {
+        for_each_fanin_slot_state(*payload, [&](ChipTaskSlotState *producer_slot_state, DepFlags flags) {
             if (!dep_has_retain(flags)) {
                 return;
             }
@@ -1418,7 +1418,7 @@ struct PTO2SchedulerState {
 // that scheduler_completion.cpp's inline NotDeferred path uses, so high task
 // rates don't surface as ASYNC_WAIT_OVERFLOW errors.
 inline bool
-AsyncWaitList::try_inline_complete_locked(AsyncWaitList::DrainCompletionSink &sink, PTO2TaskSlotState &slot_state) {
+AsyncWaitList::try_inline_complete_locked(AsyncWaitList::DrainCompletionSink &sink, ChipTaskSlotState &slot_state) {
     // Return value (CompletionStats / consumer-walk count) discarded:
     // async-wait drain path has no Resolve swimlane bar attached.
 #if SIMPLER_SCHED_PROFILING
@@ -1445,7 +1445,7 @@ AsyncWaitList::try_inline_complete_locked(AsyncWaitList::DrainCompletionSink &si
 template <bool Profiling>
 inline AsyncPollResult AsyncWaitList::poll_and_complete(
     AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched,
-    PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count, int32_t deferred_release_capacity
+    ChipTaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count, int32_t deferred_release_capacity
 #if SIMPLER_SCHED_PROFILING
     ,
     int thread_idx

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -229,7 +229,7 @@ void SchedulerContext::log_stall_diagnostics(
     // produce identical TASK lines once per scheduler thread.
     if (thread_idx == 0) {
         int32_t cnt_ready = 0, cnt_waiting = 0, cnt_running = 0, submitted_in_ring = 0;
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             PTO2SharedMemoryRingHeader &ring = *sched_->ring_sched_states[r].ring;
             int32_t ring_task_count = ring.fc.current_task_index.load(std::memory_order_relaxed);
             submitted_in_ring += ring_task_count;
@@ -365,7 +365,7 @@ SchedulerContext::StallClassification SchedulerContext::classify_stall_reason() 
     cls.stuck_task_id = -1;
     cls.stuck_core = -1;
     int32_t cnt_running = 0, cnt_ready = 0, cnt_waiting = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         PTO2SharedMemoryRingHeader &ring = *sched_->ring_sched_states[r].ring;
         int32_t ring_task_count = ring.fc.current_task_index.load(std::memory_order_relaxed);
         // Active task_ids live in [last_task_alive, current_task_index); slots wrap
@@ -1182,7 +1182,7 @@ int32_t SchedulerContext::pre_handshake_init(
     if (runtime->get_gm_sm_ptr()) {
         auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_gm_sm_ptr());
         int64_t pto2_count = 0;
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             int32_t ring_tasks = header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
             if (ring_tasks > 0 && ring_tasks <= PTO2_SCOPE_TASKS_CAP) pto2_count += ring_tasks;
         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -238,7 +238,7 @@ void SchedulerContext::log_stall_diagnostics(
             // slot once per earlier task_id and inflates the scan_* counts.
             int32_t ring_task_start = ring.fc.last_task_alive.load(std::memory_order_relaxed);
             for (int32_t si = ring_task_start; si < ring_task_count; si++) {
-                PTO2TaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
+                ChipTaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
                 PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
                 int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
                 int32_t fi = slot_state.fanin_count;
@@ -374,7 +374,7 @@ SchedulerContext::StallClassification SchedulerContext::classify_stall_reason() 
         // Start at the tail so each live slot is visited exactly once (O(window)).
         int32_t ring_task_start = ring.fc.last_task_alive.load(std::memory_order_relaxed);
         for (int32_t si = ring_task_start; si < ring_task_count; si++) {
-            PTO2TaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
+            ChipTaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
             PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
             if (st >= PTO2_TASK_COMPLETED) continue;
             // Same ground truth as log_stall_diagnostics: task_state stays PENDING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -1366,7 +1366,7 @@ void SchedulerContext::deinit() {
     func_id_to_addr_ = nullptr;
 }
 
-void SchedulerContext::bind_runtime(PTO2Runtime *rt) {
+void SchedulerContext::bind_runtime(RuntimeContext *rt) {
     rt_ = rt;
     sched_ = &rt->scheduler;
 }
@@ -1387,7 +1387,7 @@ void SchedulerContext::wait_for_orchestration_done_before_dispatch(Runtime *runt
 // and drives the orchestrator → scheduler core transition (or fatal shutdown).
 // =============================================================================
 void SchedulerContext::on_orchestration_done(
-    Runtime *runtime, PTO2Runtime *rt, [[maybe_unused]] int32_t thread_idx, int32_t total_tasks
+    Runtime *runtime, RuntimeContext *rt, [[maybe_unused]] int32_t thread_idx, int32_t total_tasks
 ) {
 #if SIMPLER_DFX
     if (chip_swimlane_level_ >= ChipSwimlaneLevel::ORCH_PHASES) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -84,9 +84,9 @@ SlotTransition SchedulerContext::decide_slot_transition(
 
 // Complete one slot's task: subtask counting, mixed completion, deferred release, profiling.
 void SchedulerContext::complete_slot_task(
-    PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, [[maybe_unused]] PTO2SubtaskSlot subslot,
+    ChipTaskSlotState &slot_state, int32_t expected_reg_task_id, [[maybe_unused]] PTO2SubtaskSlot subslot,
     [[maybe_unused]] int32_t thread_idx, int32_t core_id, Handshake *hank, int32_t &completed_this_turn,
-    PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count
+    ChipTaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count
 #if SIMPLER_DFX
     ,
     uint64_t dispatch_ts, uint64_t finish_ts
@@ -300,7 +300,7 @@ void SchedulerContext::clear_running_slot(CoreExecState &core) {
 
 void SchedulerContext::check_running_cores_for_completion(
     int32_t thread_idx, Handshake *hank, int32_t &completed_this_turn, int32_t &cur_thread_completed,
-    bool &made_progress, PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count
+    bool &made_progress, ChipTaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count
 ) {
 #if SIMPLER_SCHED_PROFILING
     auto &chip_swimlane = sched_chip_swimlane_[thread_idx];
@@ -320,7 +320,7 @@ void SchedulerContext::check_running_cores_for_completion(
         // which point the core becomes pollable again and its FIN is caught.
         // Cheap cacheable load; no MMIO. Pending slot is empty while gated.
         {
-            PTO2TaskSlotState *rs = core.running_slot_state;
+            ChipTaskSlotState *rs = core.running_slot_state;
             if (rs != nullptr && rs->payload != nullptr &&
                 rs->payload->early_dispatch_state.load(std::memory_order_relaxed) == PTO2_EARLY_DISPATCH_STAGING) {
                 continue;
@@ -449,7 +449,7 @@ void SchedulerContext::check_running_cores_for_completion(
                 // rendezvous. Capture that BEFORE promote nulls the pending fields; after
                 // it lands, bump running_slot_count and ring iff this was the block that
                 // completed the cohort (and the producer already released).
-                PTO2TaskSlotState *promoted = core.pending_slot_state;
+                ChipTaskSlotState *promoted = core.pending_slot_state;
                 bool sync_start_promote = pending_gated && promoted->task_attrs.requires_sync_start();
                 promote_pending_to_running(core);  // Case 2 or Case 3 (with pending)
                 if (sync_start_promote) {
@@ -500,7 +500,7 @@ void SchedulerContext::check_running_cores_for_completion(
 // Two-phase protocol: CAS 0 -> -1 (sentinel) to claim ownership, store task and
 // reset staging state, then release-store block_num. Other threads acquire-load
 // sync_start_pending; seeing block_num > 0 ensures all relaxed stores are visible.
-bool SchedulerContext::enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t block_num) {
+bool SchedulerContext::enter_drain_mode(ChipTaskSlotState *slot_state, int32_t block_num) {
     int32_t expected = 0;
     if (!drain_state_.sync_start_pending.compare_exchange_strong(
             expected, -1, std::memory_order_acquire, std::memory_order_relaxed
@@ -549,7 +549,7 @@ int32_t SchedulerContext::count_global_available(PTO2ResourceShape shape, uint8_
 // block uses SPLIT placement (each core independently: idle->running, busy->pending) — safe
 // only because gated.
 SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
-    PTO2TaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated,
+    ChipTaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated,
     [[maybe_unused]] bool record_drain_phases
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -727,7 +727,7 @@ void SchedulerContext::handle_drain_mode(
 
     bool coordinator = thread_idx == 0;
 
-    PTO2TaskSlotState *slot_state = drain_state_.pending_task.load(std::memory_order_acquire);
+    ChipTaskSlotState *slot_state = drain_state_.pending_task.load(std::memory_order_acquire);
     // OWNER is acquired before the drain is published and persists through
     // completion, so every staging thread makes the same gate decision even if
     // producer release changes early_dispatch_state during the barrier.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -35,7 +35,7 @@
 // Forward declarations — avoid pulling in full headers for pointer/reference params.
 class Runtime;
 struct Handshake;
-struct PTO2Runtime;
+struct RuntimeContext;
 
 /**
  * SchedulerContext: owns all scheduler-side state and methods.
@@ -116,11 +116,11 @@ public:
     //    (skipped on fatal error — emergency_shutdown runs instead)
     // Callers must invoke rt_orchestration_done(rt) before this — that
     // step belongs to the orchestrator lifecycle, not the scheduler.
-    void on_orchestration_done(Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks);
+    void on_orchestration_done(Runtime *runtime, RuntimeContext *rt, int32_t thread_idx, int32_t total_tasks);
 
-    // Bind the PTO2Runtime scheduler pointer. Required in device-orchestration
+    // Bind the RuntimeContext scheduler pointer. Required in device-orchestration
     // mode where rt is created by the orchestrator thread after init().
-    void bind_runtime(PTO2Runtime *rt);
+    void bind_runtime(RuntimeContext *rt);
 
     // Serial orch->sched mode pre-dispatch wait. No AICore dispatch happens
     // before orchestrator_done_.
@@ -144,7 +144,7 @@ private:
 
     // --- Scheduler binding & per-core runtime state ---
     alignas(64) PTO2SchedulerState *sched_{nullptr};
-    PTO2Runtime *rt_{nullptr};
+    RuntimeContext *rt_{nullptr};
 
     // Per-core execution state, indexed by core_id (= worker_id)
     CoreExecState core_exec_states_[RUNTIME_MAX_WORKER];

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -249,11 +249,11 @@ private:
     }
 
     int pop_ready_tasks_batch(
-        PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, PTO2TaskSlotState **out, int max_count
+        PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, ChipTaskSlotState **out, int max_count
     );
 
     void build_payload(
-        PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
+        PTO2DispatchPayload &dispatch_payload, ChipTaskSlotState &slot_state, PTO2SubtaskSlot subslot,
         int32_t block_idx, bool force_gate
     );
 
@@ -275,7 +275,7 @@ private:
     };
 
     PublishHandle prepare_subtask_to_core(
-        int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
+        int32_t thread_idx, int32_t core_offset, ChipTaskSlotState &slot_state, PTO2SubtaskSlot subslot,
         bool to_pending, int32_t block_idx, bool force_gate
     );
 
@@ -330,7 +330,7 @@ private:
     // Fan out one block's subtasks (1 for AIC/AIV, 1-3 for MIX) into the
     // caller-supplied handles buffer. Returns the number of handles written.
     int prepare_block_for_dispatch(
-        int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2ResourceShape shape,
+        int32_t thread_idx, int32_t core_offset, ChipTaskSlotState &slot_state, PTO2ResourceShape shape,
         bool to_pending, int32_t block_idx, PublishHandle *out_handles, bool force_gate = false
     );
 
@@ -357,7 +357,7 @@ private:
     // concurrently with peers (mirrors the normal SPMD dispatch path). Returns the
     // number of blocks staged.
     int32_t stage_consumer_blocks(
-        int32_t thread_idx, PTO2TaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
+        int32_t thread_idx, ChipTaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
         CoreTracker::BitStates &idle, CoreTracker::BitStates &pend
     );
 
@@ -434,9 +434,9 @@ private:
     );
 
     void complete_slot_task(
-        PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
+        ChipTaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
         int32_t core_id, Handshake *hank, int32_t &completed_this_turn,
-        PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count
+        ChipTaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count
 #if SIMPLER_DFX
         ,
         uint64_t dispatch_ts, uint64_t finish_ts
@@ -448,10 +448,10 @@ private:
 
     void check_running_cores_for_completion(
         int32_t thread_idx, Handshake *hank, int32_t &completed_this_turn, int32_t &cur_thread_completed,
-        bool &made_progress, PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count
+        bool &made_progress, ChipTaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count
     );
 
-    bool enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t block_num);
+    bool enter_drain_mode(ChipTaskSlotState *slot_state, int32_t block_num);
     int32_t count_global_available(PTO2ResourceShape shape, uint8_t core_mask, bool include_pending = false);
     struct SyncStartStageResult {
         int32_t staged_blocks{0};
@@ -462,7 +462,7 @@ private:
     // the local fast path invokes it once after proving this tracker has enough
     // capacity. record_drain_phases keeps local work attributed to EarlyDispatch.
     SyncStartStageResult stage_sync_start_cores(
-        PTO2TaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated, bool record_drain_phases
+        ChipTaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated, bool record_drain_phases
     );
     // out_stage_wall_cycles (profiling only): cycles this thread spent in stage_sync_start_cores
     // (prepare + publish), set ONLY on threads that actually staged. Lets the caller isolate

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -94,7 +94,7 @@ bool SchedulerContext::has_idle_in_other_threads(int32_t self_thread_idx, PTO2Re
 }
 
 int SchedulerContext::pop_ready_tasks_batch(
-    PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, PTO2TaskSlotState **out, int max_count
+    PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, ChipTaskSlotState **out, int max_count
 ) {
 #if SIMPLER_DFX
     auto &chip_swimlane = sched_chip_swimlane_[thread_idx];
@@ -123,7 +123,7 @@ int SchedulerContext::pop_ready_tasks_batch(
 }
 
 void SchedulerContext::build_payload(
-    PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot, int32_t block_idx,
+    PTO2DispatchPayload &dispatch_payload, ChipTaskSlotState &slot_state, PTO2SubtaskSlot subslot, int32_t block_idx,
     bool force_gate
 ) {
     int32_t slot_idx = static_cast<int32_t>(subslot);
@@ -164,7 +164,7 @@ void SchedulerContext::build_payload(
 }
 
 SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
-    int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot, bool to_pending,
+    int32_t thread_idx, int32_t core_offset, ChipTaskSlotState &slot_state, PTO2SubtaskSlot subslot, bool to_pending,
     int32_t block_idx, bool force_gate
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -238,7 +238,7 @@ SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
 }
 
 int SchedulerContext::prepare_block_for_dispatch(
-    int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2ResourceShape shape, bool to_pending,
+    int32_t thread_idx, int32_t core_offset, ChipTaskSlotState &slot_state, PTO2ResourceShape shape, bool to_pending,
     int32_t block_idx, PublishHandle *out_handles, bool force_gate
 ) {
 #if SIMPLER_DFX
@@ -323,7 +323,7 @@ void SchedulerContext::dispatch_shape(
 
     while (cores.has_value() && !entered_drain) {
         int want = cores.count();
-        PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
+        ChipTaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
         int got = pop_ready_tasks_batch(disp_queues, shape, thread_idx, batch, want);
         if (got == 0) break;
 
@@ -364,7 +364,7 @@ void SchedulerContext::dispatch_shape(
         bool dispatched_any = false;
         // Logical block ranges published by this pop. AIV can pop two entries per
         // cluster, so this ledger has the same worst-case bound as handles[].
-        PTO2TaskSlotState *published_list[CoreTracker::MAX_CLUSTERS * 3];
+        ChipTaskSlotState *published_list[CoreTracker::MAX_CLUSTERS * 3];
         int16_t published_counts[CoreTracker::MAX_CLUSTERS * 3];
         int published_n = 0;
 #if SIMPLER_SCHED_PROFILING
@@ -391,7 +391,7 @@ void SchedulerContext::dispatch_shape(
         };
 
         for (int bi = 0; bi < got; bi++) {
-            PTO2TaskSlotState *slot_state = batch[bi];
+            ChipTaskSlotState *slot_state = batch[bi];
             CoreTracker::BitStates selected_mix_clusters(0ULL);
 
             if (is_mix) {
@@ -621,7 +621,7 @@ void SchedulerContext::dispatch_ready_tasks(
 // those release did not take and rings them from its immutable local handles.
 // The seq_cst order guarantees every gated core has exactly one writer.
 int32_t SchedulerContext::stage_consumer_blocks(
-    int32_t thread_idx, PTO2TaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
+    int32_t thread_idx, ChipTaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
     CoreTracker::BitStates &idle, CoreTracker::BitStates &pend
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -721,7 +721,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
     if (!cores.has_value()) return 0;
 
     int32_t total_staged = 0;
-    PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
+    ChipTaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
     uint64_t task_id_snapshots[CoreTracker::MAX_CLUSTERS * 3];
     // Batch-pop in one queue op (fewer CAS than one pop per consumer); the pop is
     // bounded by the shape's capacity so the stack buffer always holds it. Then for
@@ -736,7 +736,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
     // the unconsumed tail).
     int got = sched_->early_dispatch_queues[s].pop_batch_tagged(batch, task_id_snapshots, cores.count());
     for (int bi = 0; bi < got; bi++) {
-        PTO2TaskSlotState *c = batch[bi];
+        ChipTaskSlotState *c = batch[bi];
         if (static_cast<uint64_t>(c->task->task_id.raw) != task_id_snapshots[bi]) continue;
         if (c->payload->early_dispatch_state.load(std::memory_order_acquire) != PTO2_EARLY_DISPATCH_STAGING)
             continue;  // released
@@ -829,7 +829,7 @@ int32_t SchedulerContext::try_early_dispatch(
     // stop-the-world drain. Both paths force-gate every block even if producer release races
     // STAGING -> DISPATCHED. A non-STAGING pop was already released and is dropped.
     uint64_t sync_task_id_snapshot = 0;
-    if (PTO2TaskSlotState *c = sched_->early_sync_start_queue.pop_tagged(&sync_task_id_snapshot)) {
+    if (ChipTaskSlotState *c = sched_->early_sync_start_queue.pop_tagged(&sync_task_id_snapshot)) {
         bool current_sync_task =
             static_cast<uint64_t>(c->task->task_id.raw) == sync_task_id_snapshot && c->task_attrs.requires_sync_start();
         if (current_sync_task && PTO2SchedulerState::try_claim_early_sync_drain(*c->payload)) {
@@ -915,7 +915,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     chip_swimlane.chip_swimlane_enabled = (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED);
 #endif
 
-    PTO2TaskSlotState *deferred_release_slot_states[PTO2_DEFERRED_RELEASE_CAP];
+    ChipTaskSlotState *deferred_release_slot_states[PTO2_DEFERRED_RELEASE_CAP];
     int32_t deferred_release_count = 0;
 
     // PMU runs require single-issue dispatch — overlapping in-flight tasks
@@ -1198,7 +1198,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         // the dependency-only resolve work.
         if (thread_idx < PLATFORM_MAX_AICPU_THREADS - 1) {
             constexpr int DUMMY_DRAIN_BATCH = 8;
-            PTO2TaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
+            ChipTaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
             int dummy_got = sched_->dummy_ready_queue.pop_batch(dummy_batch, DUMMY_DRAIN_BATCH);
 #if SIMPLER_DFX
             // Dummy outer phase: covers all dependency-only items popped this
@@ -1210,7 +1210,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 (dummy_got > 0 && chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES) ? get_sys_cnt_aicpu() : 0;
 #endif
             for (int di = 0; di < dummy_got; di++) {
-                PTO2TaskSlotState &dummy_slot = *dummy_batch[di];
+                ChipTaskSlotState &dummy_slot = *dummy_batch[di];
 
                 // ----- Resolve work: walk this dummy's consumer list. ------
                 // Same 1 µs filter as the main-path Resolve emit suppresses

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -95,8 +95,8 @@ enum class LoopAction : int8_t {
 struct alignas(64) CoreExecState {
     // --- Hot fields (completion + dispatch, every iteration) ---
     uint64_t reg_addr;                      // offset  0: register base address (set once in handshake)
-    PTO2TaskSlotState *running_slot_state;  // offset  8: slot state for running task (nullptr = empty)
-    PTO2TaskSlotState *pending_slot_state;  // offset 16: slot state for pending task (nullptr = empty)
+    ChipTaskSlotState *running_slot_state;  // offset  8: slot state for running task (nullptr = empty)
+    ChipTaskSlotState *pending_slot_state;  // offset 16: slot state for pending task (nullptr = empty)
     int32_t running_reg_task_id;            // offset 24: register task ID (AICPU_TASK_INVALID = idle)
     int32_t pending_reg_task_id;            // offset 28: pending register task ID (AICPU_TASK_INVALID = none)
     uint32_t dispatch_seq;                  // offset 32: monotonic dispatch counter
@@ -549,7 +549,7 @@ struct alignas(64) SchedChipSwimlaneCounters {
 // (only process completions) until the fixed coordinator finishes launching all blocks.
 struct alignas(64) SyncStartDrainState {
     std::atomic<int32_t> sync_start_pending{0};              // 0=normal; -1=initializing; >0=active (value=block_num)
-    std::atomic<PTO2TaskSlotState *> pending_task{nullptr};  // held task (not re-queued)
+    std::atomic<ChipTaskSlotState *> pending_task{nullptr};  // held task (not re-queued)
     std::atomic<uint64_t> drain_attempt{0};                  // incremented whenever an ack round is reset
     // The coordinator publishes stage_go after global capacity is confirmed.
     // Each scheduler stages its local cores, publishes its bit in

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -12,7 +12,7 @@
  * Runtime Class - Implementation
  *
  * Device execution and handshake control.
- * Task graph construction is handled by PTO2Runtime.
+ * Task graph construction is handled by RuntimeContext.
  */
 
 #include "runtime.h"

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime_init.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime_init.cpp
@@ -507,8 +507,7 @@ void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler) { this-
 // Top-level runtime arena
 // =============================================================================
 
-PTO2RuntimeArenaLayout
-runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, int32_t dep_pool_capacity) {
+RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, int32_t dep_pool_capacity) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
     int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
@@ -520,11 +519,11 @@ runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, int32_t de
     return runtime_reserve_layout(arena, task_window_sizes, heap_sizes, dep_pool_capacities);
 }
 
-PTO2RuntimeArenaLayout runtime_reserve_layout(
+RuntimeArenaLayout runtime_reserve_layout(
     DeviceArena &arena, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
     const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
 ) {
-    PTO2RuntimeArenaLayout layout{};
+    RuntimeArenaLayout layout{};
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         layout.sizing.task_window_sizes[r] = task_window_sizes[r];
@@ -539,16 +538,16 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
     }
     layout.offsets.orch = PTO2OrchestratorState::reserve_layout(arena, task_window_sizes_i32, dep_pool_capacities);
     layout.offsets.sched = PTO2SchedulerState::reserve_layout(arena, dep_pool_capacities);
-    layout.offsets.off_runtime = arena.reserve(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE);
+    layout.offsets.off_runtime = arena.reserve(sizeof(RuntimeContext), PTO2_ALIGN_SIZE);
     layout.offsets.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
 
     layout.offsets.arena_size = arena.total_size();
     return layout;
 }
 
-PTO2Runtime *runtime_init_data_from_layout(
-    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
-    uint64_t /*sm_size*/, void *gm_heap_dev_base, uint64_t heap_size
+RuntimeContext *runtime_init_data_from_layout(
+    DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t /*sm_size*/,
+    void *gm_heap_dev_base, uint64_t heap_size
 ) {
     uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -557,11 +556,11 @@ PTO2Runtime *runtime_init_data_from_layout(
     return runtime_init_data_from_layout(arena, layout, mode, sm_dev_base, 0, gm_heap_dev_base, heap_sizes);
 }
 
-PTO2Runtime *runtime_init_data_from_layout(
-    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
-    uint64_t /*sm_size*/, void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+RuntimeContext *runtime_init_data_from_layout(
+    DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t /*sm_size*/,
+    void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
 ) {
-    PTO2Runtime *rt = static_cast<PTO2Runtime *>(arena.region_ptr(layout.offsets.off_runtime));
+    RuntimeContext *rt = static_cast<RuntimeContext *>(arena.region_ptr(layout.offsets.off_runtime));
     memset(rt, 0, sizeof(*rt));
 
     auto *sm_wrap = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(layout.offsets.off_sm_handle));
@@ -593,14 +592,14 @@ PTO2Runtime *runtime_init_data_from_layout(
     return rt;
 }
 
-void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt) {
+void runtime_wire_arena_pointers(DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeContext *rt) {
     rt->sm_handle = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(layout.offsets.off_sm_handle));
     rt->aicore_mailbox = static_cast<AICoreCompletionMailbox *>(arena.region_ptr(layout.offsets.off_mailbox));
     rt->orchestrator.wire_arena_pointers(layout.offsets.orch, arena, &rt->scheduler);
     rt->scheduler.wire_arena_pointers(layout.offsets.sched, arena);
 }
 
-bool runtime_reset_for_reuse(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt) {
+bool runtime_reset_for_reuse(DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeContext *rt) {
     (void)arena;
     if (rt == nullptr) {
         return false;
@@ -626,7 +625,7 @@ bool runtime_reset_for_reuse(DeviceArena &arena, const PTO2RuntimeArenaLayout &l
     return true;
 }
 
-void runtime_destroy(PTO2Runtime *rt, DeviceArena & /*arena*/) {
+void runtime_destroy(RuntimeContext *rt, DeviceArena & /*arena*/) {
     // Arena buffer is pooled across runs by DeviceRunner — never freed here.
     if (!rt) return;
     rt->scheduler.destroy();

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime_init.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime_init.cpp
@@ -31,9 +31,9 @@
 #include "tensormap.h"
 #include "scheduler/scheduler.h"
 
-static bool sum_ring_heap_sizes(const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], uint64_t *total) {
+static bool sum_ring_heap_sizes(const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH], uint64_t *total) {
     uint64_t sum = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         if (heap_sizes[r] > std::numeric_limits<uint64_t>::max() - sum) {
             LOG_ERROR("Total ring heap size overflows uint64_t");
             return false;
@@ -120,18 +120,18 @@ void PTO2SchedulerState::RingSchedState::reset_for_reuse(
 void PTO2SchedulerState::RingSchedState::destroy() { ring = nullptr; }
 
 PTO2SchedulerLayout PTO2SchedulerState::reserve_layout(DeviceArena &arena, int32_t dep_pool_capacity) {
-    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         dep_pool_capacities[r] = dep_pool_capacity;
     }
     return reserve_layout(arena, dep_pool_capacities);
 }
 
 PTO2SchedulerLayout
-PTO2SchedulerState::reserve_layout(DeviceArena &arena, const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]) {
+PTO2SchedulerState::reserve_layout(DeviceArena &arena, const int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH]) {
     PTO2SchedulerLayout layout{};
     layout.ready_queue_capacity = PTO2_READY_QUEUE_SIZE;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         layout.dep_pool_capacities[r] = dep_pool_capacities[r];
     }
 
@@ -146,7 +146,7 @@ PTO2SchedulerState::reserve_layout(DeviceArena &arena, const int32_t dep_pool_ca
         layout.off_early_dispatch_queue_slots[i] = ready_queue_reserve_layout(arena, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
     }
     layout.off_early_sync_start_queue_slots = ready_queue_reserve_layout(arena, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         // Force a cache-line base so Orch-side dep_pool writes do not invalidate
         // adjacent multi-threaded regions like ready_queue.slots.
         layout.off_dep_pool_entries[r] =
@@ -166,7 +166,7 @@ bool PTO2SchedulerState::init_data_from_layout(
     sched->tasks_consumed.store(0, std::memory_order_relaxed);
 #endif
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         if (!sched->ring_sched_states[r].init_data_from_layout(sm_dev_base, r)) {
             return false;
         }
@@ -207,7 +207,7 @@ bool PTO2SchedulerState::init_data_from_layout(
     }
 
     auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_dev_base);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         auto *dep_entries = static_cast<PTO2DepListEntry *>(arena.region_ptr(layout.off_dep_pool_entries[r]));
         memset(dep_entries, 0, static_cast<size_t>(layout.dep_pool_capacities[r]) * sizeof(PTO2DepListEntry));
         sched->ring_sched_states[r].dep_pool.init(dep_entries, layout.dep_pool_capacities[r], orch_err);
@@ -226,7 +226,7 @@ void PTO2SchedulerState::reset_for_reuse(const PTO2SchedulerLayout &layout, void
 #endif
 
     auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_dev_base);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         sched->ring_sched_states[r].reset_for_reuse(sm_dev_base, r, orch_err);
     }
 
@@ -261,7 +261,7 @@ void PTO2SchedulerState::wire_arena_pointers(const PTO2SchedulerLayout &layout, 
         );
     }
     ready_queue_wire_arena_pointers(&sched->early_sync_start_queue, arena, layout.off_early_sync_start_queue_slots);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         sched->ring_sched_states[r].dep_pool.base =
             static_cast<PTO2DepListEntry *>(arena.region_ptr(layout.off_dep_pool_entries[r]));
     }
@@ -269,7 +269,7 @@ void PTO2SchedulerState::wire_arena_pointers(const PTO2SchedulerLayout &layout, 
 
 void PTO2SchedulerState::destroy() {
     PTO2SchedulerState *sched = this;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         sched->ring_sched_states[r].destroy();
         sched->ring_sched_states[r].dep_pool.base = nullptr;
     }
@@ -291,18 +291,18 @@ void PTO2SchedulerState::destroy() {
 // =============================================================================
 
 PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
-    DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH], int32_t dep_pool_capacity
+    DeviceArena &arena, const int32_t task_window_sizes[CHIP_MAX_RING_DEPTH], int32_t dep_pool_capacity
 ) {
-    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         dep_pool_capacities[r] = dep_pool_capacity;
     }
     return reserve_layout(arena, task_window_sizes, dep_pool_capacities);
 }
 
 PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
-    DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+    DeviceArena &arena, const int32_t task_window_sizes[CHIP_MAX_RING_DEPTH],
+    const int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH]
 ) {
     PTO2OrchestratorLayout layout{};
     // scope_tasks holds every task in the open scope across all rings, so its cap
@@ -312,21 +312,21 @@ PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
     // and over-allocated it when shrunk. See issue #1188.
     //
     // Accumulate in int64: each window is validated <= INT32_MAX individually, but
-    // the sum of PTO2_MAX_RING_DEPTH windows can exceed it — a bare int32 sum would
+    // the sum of CHIP_MAX_RING_DEPTH windows can exceed it — a bare int32 sum would
     // wrap to a negative/undersized cap. Bound the result before narrowing.
     int64_t scope_tasks_cap = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         always_assert(task_window_sizes[r] > 0);
         scope_tasks_cap += task_window_sizes[r];
     }
     always_assert(scope_tasks_cap <= std::numeric_limits<int32_t>::max());
     layout.scope_tasks_cap = static_cast<int32_t>(scope_tasks_cap);
     layout.scope_stack_capacity = PTO2_MAX_SCOPE_DEPTH;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         layout.dep_pool_capacities[r] = dep_pool_capacities[r];
     }
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         const size_t fanin_pool_bytes =
             PTO2_ALIGN_UP(static_cast<size_t>(dep_pool_capacities[r]) * sizeof(PTO2FaninSpillEntry), PTO2_ALIGN_SIZE);
         layout.off_fanin_pool[r] = arena.reserve(fanin_pool_bytes, PTO2_ALIGN_SIZE);
@@ -348,9 +348,9 @@ bool PTO2OrchestratorState::init_data_from_layout(
     const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap, uint64_t heap_size,
     uint64_t task_window_size
 ) {
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    uint64_t heap_sizes[CHIP_MAX_RING_DEPTH];
+    uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         heap_sizes[r] = heap_size;
         task_window_sizes[r] = task_window_size;
     }
@@ -359,7 +359,7 @@ bool PTO2OrchestratorState::init_data_from_layout(
 
 bool PTO2OrchestratorState::init_data_from_layout(
     const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap,
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+    const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH], const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]
 ) {
     auto *orch = this;
     *orch = PTO2OrchestratorState{};
@@ -375,7 +375,7 @@ bool PTO2OrchestratorState::init_data_from_layout(
 
     auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_dev_base);
     uint64_t heap_offset = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         void *ring_heap_base = reinterpret_cast<char *>(gm_heap) + heap_offset;
         auto *task_descs_dev = pto2_sm_layout::ring_task_descriptors_addr(sm_dev_base, task_window_sizes, r);
         auto *slot_states_dev = pto2_sm_layout::ring_slot_states_addr(sm_dev_base, task_window_sizes, r);
@@ -418,7 +418,7 @@ bool PTO2OrchestratorState::init_data_from_layout(
 
 bool PTO2OrchestratorState::reset_for_reuse(
     const PTO2OrchestratorLayout &layout, void *sm_dev_base, void *gm_heap,
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+    const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH], const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]
 ) {
     auto *orch = this;
     orch->sm_header = reinterpret_cast<PTO2SharedMemoryHeader *>(sm_dev_base);
@@ -434,7 +434,7 @@ bool PTO2OrchestratorState::reset_for_reuse(
     uint32_t next_epoch = orch->fanin_seen_current_epoch + 1;
     if (next_epoch == 0) {
         next_epoch = 1;
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             memset(
                 orch->fanin_seen_epoch[r], 0,
                 static_cast<size_t>(layout.tensor_map.task_window_sizes[r]) * sizeof(uint32_t)
@@ -445,7 +445,7 @@ bool PTO2OrchestratorState::reset_for_reuse(
 
     auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_dev_base);
     uint64_t heap_offset = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         void *ring_heap_base = reinterpret_cast<char *>(gm_heap) + heap_offset;
         auto *task_descs_dev = pto2_sm_layout::ring_task_descriptors_addr(sm_dev_base, task_window_sizes, r);
         auto *slot_states_dev = pto2_sm_layout::ring_slot_states_addr(sm_dev_base, task_window_sizes, r);
@@ -480,7 +480,7 @@ void PTO2OrchestratorState::wire_arena_pointers(
     const PTO2OrchestratorLayout &layout, DeviceArena &arena, PTO2SchedulerState *scheduler_arg
 ) {
     auto *orch = this;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         orch->rings[r].fanin_pool.base = static_cast<PTO2FaninSpillEntry *>(arena.region_ptr(layout.off_fanin_pool[r]));
         orch->fanin_seen_epoch[r] = static_cast<uint32_t *>(arena.region_ptr(layout.off_fanin_seen_epoch[r]));
     }
@@ -493,7 +493,7 @@ void PTO2OrchestratorState::wire_arena_pointers(
 void PTO2OrchestratorState::destroy() {
     auto *orch = this;
     orch->tensor_map.destroy();
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         orch->rings[r].fanin_pool.base = nullptr;
         orch->fanin_seen_epoch[r] = nullptr;
     }
@@ -508,10 +508,10 @@ void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler) { this-
 // =============================================================================
 
 RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, int32_t dep_pool_capacity) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+    uint64_t heap_sizes[CHIP_MAX_RING_DEPTH];
+    int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
         heap_sizes[r] = 0;
         dep_pool_capacities[r] = dep_pool_capacity;
@@ -520,20 +520,20 @@ RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_wind
 }
 
 RuntimeArenaLayout runtime_reserve_layout(
-    DeviceArena &arena, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+    DeviceArena &arena, const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH], const int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH]
 ) {
     RuntimeArenaLayout layout{};
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         layout.sizing.task_window_sizes[r] = task_window_sizes[r];
         layout.sizing.heap_sizes[r] = heap_sizes[r];
         layout.sizing.dep_pool_capacities[r] = dep_pool_capacities[r];
     }
 
     layout.offsets.off_sm_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
-    int32_t task_window_sizes_i32[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    int32_t task_window_sizes_i32[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_window_sizes_i32[r] = static_cast<int32_t>(task_window_sizes[r]);
     }
     layout.offsets.orch = PTO2OrchestratorState::reserve_layout(arena, task_window_sizes_i32, dep_pool_capacities);
@@ -549,8 +549,8 @@ RuntimeContext *runtime_init_data_from_layout(
     DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t /*sm_size*/,
     void *gm_heap_dev_base, uint64_t heap_size
 ) {
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    uint64_t heap_sizes[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         heap_sizes[r] = heap_size;
     }
     return runtime_init_data_from_layout(arena, layout, mode, sm_dev_base, 0, gm_heap_dev_base, heap_sizes);
@@ -558,7 +558,7 @@ RuntimeContext *runtime_init_data_from_layout(
 
 RuntimeContext *runtime_init_data_from_layout(
     DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t /*sm_size*/,
-    void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+    void *gm_heap_dev_base, const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH]
 ) {
     RuntimeContext *rt = static_cast<RuntimeContext *>(arena.region_ptr(layout.offsets.off_runtime));
     memset(rt, 0, sizeof(*rt));

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime_init.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime_init.cpp
@@ -337,7 +337,7 @@ PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
         layout.off_fanin_seen_epoch[r] = arena.reserve(seen_epoch_bytes, PTO2_ALIGN_SIZE);
     }
     layout.off_scope_tasks =
-        arena.reserve(static_cast<size_t>(layout.scope_tasks_cap) * sizeof(uintptr_t), alignof(PTO2TaskSlotState *));
+        arena.reserve(static_cast<size_t>(layout.scope_tasks_cap) * sizeof(uintptr_t), alignof(ChipTaskSlotState *));
     layout.off_scope_begins =
         arena.reserve(static_cast<size_t>(layout.scope_stack_capacity) * sizeof(int32_t), alignof(int32_t));
     layout.tensor_map = PTO2TensorMap::reserve_layout_default(arena, task_window_sizes);
@@ -485,7 +485,7 @@ void PTO2OrchestratorState::wire_arena_pointers(
         orch->fanin_seen_epoch[r] = static_cast<uint32_t *>(arena.region_ptr(layout.off_fanin_seen_epoch[r]));
     }
     orch->tensor_map.wire_arena_pointers(layout.tensor_map, arena);
-    orch->scope_tasks = static_cast<PTO2TaskSlotState **>(arena.region_ptr(layout.off_scope_tasks));
+    orch->scope_tasks = static_cast<ChipTaskSlotState **>(arena.region_ptr(layout.off_scope_tasks));
     orch->scope_begins = static_cast<int32_t *>(arena.region_ptr(layout.off_scope_begins));
     orch->scheduler = scheduler_arg;
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/shared_memory.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/shared_memory.cpp
@@ -28,31 +28,31 @@
 // =============================================================================
 
 uint64_t PTO2SharedMemoryHandle::calculate_size(uint64_t task_window_size) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
     }
     return calculate_size_per_ring(task_window_sizes);
 }
 
-uint64_t PTO2SharedMemoryHandle::calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+uint64_t PTO2SharedMemoryHandle::calculate_size_per_ring(const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]) {
     // Total SM size = offset just past the last ring, from the single source of
     // truth for the layout (pto2_sm_layout::ring_segment_offsets).
-    return pto2_sm_layout::ring_segment_offsets(task_window_sizes, PTO2_MAX_RING_DEPTH - 1).end;
+    return pto2_sm_layout::ring_segment_offsets(task_window_sizes, CHIP_MAX_RING_DEPTH - 1).end;
 }
 
 // =============================================================================
 // Creation and Destruction
 // =============================================================================
 
-void PTO2SharedMemoryHandle::setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+void PTO2SharedMemoryHandle::setup_pointers_per_ring(const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]) {
     char *base = (char *)sm_base;
     header = (PTO2SharedMemoryHeader *)base;
 
     // Per-ring descriptors / payloads / slot_states — offsets from the single
     // source of truth (pto2_sm_layout::ring_segment_offsets), so this setup and
     // the device-address helpers cannot drift.
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         auto off = pto2_sm_layout::ring_segment_offsets(task_window_sizes, r);
         auto &ring = header->rings[r];
         ring.task_descriptors = (PTO2TaskDescriptor *)(base + off.descriptors);
@@ -62,8 +62,8 @@ void PTO2SharedMemoryHandle::setup_pointers_per_ring(const uint64_t task_window_
 }
 
 void PTO2SharedMemoryHandle::setup_pointers(uint64_t task_window_size) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
     }
     setup_pointers_per_ring(task_window_sizes);
@@ -72,9 +72,9 @@ void PTO2SharedMemoryHandle::setup_pointers(uint64_t task_window_size) {
 bool PTO2SharedMemoryHandle::init(
     void *sm_base_arg, uint64_t sm_size_arg, uint64_t task_window_size, uint64_t heap_size
 ) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+    uint64_t heap_sizes[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
         heap_sizes[r] = heap_size;
     }
@@ -82,8 +82,8 @@ bool PTO2SharedMemoryHandle::init(
 }
 
 bool PTO2SharedMemoryHandle::init_per_ring(
-    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH]
 ) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
     if (sm_size_arg < calculate_size_per_ring(task_window_sizes)) return false;
@@ -125,9 +125,9 @@ void PTO2SharedMemoryHandle::destroy() {
 //
 // no need init data in pool, init pool data when used
 void PTO2SharedMemoryHandle::init_header(uint64_t task_window_size, uint64_t heap_size) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+    uint64_t heap_sizes[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
         heap_sizes[r] = heap_size;
     }
@@ -135,10 +135,10 @@ void PTO2SharedMemoryHandle::init_header(uint64_t task_window_size, uint64_t hea
 }
 
 void PTO2SharedMemoryHandle::init_header_per_ring(
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+    const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH], const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH]
 ) {
     // Per-ring flow control (start at 0)
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         header->rings[r].fc.init();
     }
 
@@ -146,7 +146,7 @@ void PTO2SharedMemoryHandle::init_header_per_ring(
 
     // Per-ring layout info
     uint64_t offset = PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         header->rings[r].task_window_size = task_window_sizes[r];
         header->rings[r].task_window_mask = static_cast<int32_t>(task_window_sizes[r] - 1);
         header->rings[r].heap_size = heap_sizes[r];
@@ -191,8 +191,8 @@ void PTO2SharedMemoryHandle::print_layout() {
     LOG_DEBUG("=== PTO2 Shared Memory Layout ===");
     LOG_DEBUG("Base address:       %p", sm_base);
     LOG_DEBUG("Total size:         %" PRIu64 " bytes", h->total_size);
-    LOG_DEBUG("Ring depth:         %d", PTO2_MAX_RING_DEPTH);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    LOG_DEBUG("Ring depth:         %d", CHIP_MAX_RING_DEPTH);
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         LOG_DEBUG("Ring %d:", r);
         LOG_DEBUG("  task_window_size: %" PRIu64, h->rings[r].task_window_size);
         LOG_DEBUG("  heap_size:        %" PRIu64 " bytes", h->rings[r].heap_size);
@@ -218,7 +218,7 @@ bool PTO2SharedMemoryHandle::validate() {
 
     PTO2SharedMemoryHeader *h = header;
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         if (!h->rings[r].fc.validate(this, r)) return false;
     }
 
@@ -228,7 +228,7 @@ bool PTO2SharedMemoryHandle::validate() {
 bool PTO2RingFlowControl::validate(PTO2SharedMemoryHandle *handle, int32_t ring_id) const {
     if (!handle) return false;
     if (!handle->header) return false;
-    if (ring_id < 0 || ring_id >= PTO2_MAX_RING_DEPTH) return false;
+    if (ring_id < 0 || ring_id >= CHIP_MAX_RING_DEPTH) return false;
 
     const PTO2SharedMemoryHeader *h = handle->header;
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/shared_memory.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/shared_memory.cpp
@@ -57,7 +57,7 @@ void PTO2SharedMemoryHandle::setup_pointers_per_ring(const uint64_t task_window_
         auto &ring = header->rings[r];
         ring.task_descriptors = (PTO2TaskDescriptor *)(base + off.descriptors);
         ring.task_payloads = (PTO2TaskPayload *)(base + off.payloads);
-        ring.slot_states = (PTO2TaskSlotState *)(base + off.slot_states);
+        ring.slot_states = (ChipTaskSlotState *)(base + off.slot_states);
     }
 }
 
@@ -153,7 +153,7 @@ void PTO2SharedMemoryHandle::init_header_per_ring(
         header->rings[r].task_descriptors_offset = offset;
         offset += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
         offset += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
-        offset += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
+        offset += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(ChipTaskSlotState), PTO2_ALIGN_SIZE);
     }
 
     header->total_size = sm_size;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/tensormap.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/tensormap.cpp
@@ -49,7 +49,7 @@ uint64_t g_insert_count = 0;
 
 PTO2TensorMapLayout PTO2TensorMap::reserve_layout(
     DeviceArena &arena, int32_t new_num_buckets, int32_t new_pool_size,
-    const int32_t new_task_window_sizes[PTO2_MAX_RING_DEPTH]
+    const int32_t new_task_window_sizes[CHIP_MAX_RING_DEPTH]
 ) {
     // num_buckets must be a power of two for the hash truncation to work.
     always_assert((new_num_buckets & (new_num_buckets - 1)) == 0);
@@ -57,7 +57,7 @@ PTO2TensorMapLayout PTO2TensorMap::reserve_layout(
     PTO2TensorMapLayout layout{};
     layout.num_buckets = new_num_buckets;
     layout.pool_size = new_pool_size;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         layout.task_window_sizes[r] = new_task_window_sizes[r];
     }
 
@@ -70,7 +70,7 @@ PTO2TensorMapLayout PTO2TensorMap::reserve_layout(
         arena.reserve(static_cast<size_t>(new_pool_size) * sizeof(PTO2TensorMapEntry), alignof(PTO2TensorMapEntry));
     layout.off_free_entry_list =
         arena.reserve(static_cast<size_t>(new_pool_size) * sizeof(PTO2TensorMapEntry *), alignof(PTO2TensorMapEntry *));
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         layout.off_task_entry_heads[r] = arena.reserve(
             static_cast<size_t>(new_task_window_sizes[r]) * sizeof(PTO2TensorMapEntry *), alignof(PTO2TensorMapEntry *)
         );
@@ -81,7 +81,7 @@ PTO2TensorMapLayout PTO2TensorMap::reserve_layout(
 }
 
 PTO2TensorMapLayout
-PTO2TensorMap::reserve_layout_default(DeviceArena &arena, const int32_t new_task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+PTO2TensorMap::reserve_layout_default(DeviceArena &arena, const int32_t new_task_window_sizes[CHIP_MAX_RING_DEPTH]) {
     return reserve_layout(arena, PTO2_TENSORMAP_NUM_BUCKETS, PTO2_TENSORMAP_POOL_SIZE, new_task_window_sizes);
 }
 
@@ -122,7 +122,7 @@ bool PTO2TensorMap::init_data_from_layout(const PTO2TensorMapLayout &layout, Dev
     next_entry_idx = 0;
     free_num = 0;
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         auto *heads_arena = static_cast<PTO2TensorMapEntry **>(arena.region_ptr(layout.off_task_entry_heads[r]));
         auto *head_epochs_arena = static_cast<uint32_t *>(arena.region_ptr(layout.off_task_entry_head_epochs[r]));
         for (int32_t i = 0; i < layout.task_window_sizes[r]; i++) {
@@ -146,12 +146,12 @@ void PTO2TensorMap::reset_for_reuse(const PTO2TensorMapLayout &layout) {
     if (current_epoch == 0) {
         current_epoch = 1;
         memset(bucket_epochs, 0, static_cast<size_t>(layout.num_buckets) * sizeof(uint32_t));
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             memset(task_entry_head_epochs[r], 0, static_cast<size_t>(layout.task_window_sizes[r]) * sizeof(uint32_t));
         }
     }
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = layout.task_window_sizes[r];
         last_task_alives[r] = 0;
         last_cleanup[r] = 0;
@@ -163,7 +163,7 @@ void PTO2TensorMap::wire_arena_pointers(const PTO2TensorMapLayout &layout, Devic
     bucket_epochs = static_cast<uint32_t *>(arena.region_ptr(layout.off_bucket_epochs));
     entry_pool = static_cast<PTO2TensorMapEntry *>(arena.region_ptr(layout.off_entry_pool));
     free_entry_list = static_cast<PTO2TensorMapEntry **>(arena.region_ptr(layout.off_free_entry_list));
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_entry_heads[r] = static_cast<PTO2TensorMapEntry **>(arena.region_ptr(layout.off_task_entry_heads[r]));
         task_entry_head_epochs[r] = static_cast<uint32_t *>(arena.region_ptr(layout.off_task_entry_head_epochs[r]));
     }
@@ -177,7 +177,7 @@ void PTO2TensorMap::destroy() {
     bucket_epochs = nullptr;
     entry_pool = nullptr;
     free_entry_list = nullptr;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_entry_heads[r] = nullptr;
         task_entry_head_epochs[r] = nullptr;
     }
@@ -237,7 +237,7 @@ void PTO2TensorMap::print_stats() {
     LOG_DEBUG("Empty buckets:       %d", empty_buckets);
     LOG_DEBUG("Max chain len:       %d", max_chain);
     LOG_DEBUG("Avg chain len:       %.2f", non_empty_buckets > 0 ? (float)total_chain / non_empty_buckets : 0);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         LOG_DEBUG("Last task alive[%d]: %d", r, last_task_alives[r]);
     }
     LOG_DEBUG("============================");

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared_memory.h
@@ -13,7 +13,7 @@
  *
  * Defines the shared memory structure for Orchestrator-Scheduler communication.
  *
- * Memory Layout (per-ring sections repeat for each ring 0..PTO2_MAX_RING_DEPTH-1):
+ * Memory Layout (per-ring sections repeat for each ring 0..CHIP_MAX_RING_DEPTH-1):
  *   +---------------------------+
  *   | SharedMemoryHeader        |  (per-ring flow control + sync)
  *   +---------------------------+
@@ -129,7 +129,7 @@ static_assert(
  */
 struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
     // === PER-RING FLOW CONTROL + LAYOUT INFO (set once at init) ===
-    PTO2SharedMemoryRingHeader rings[PTO2_MAX_RING_DEPTH];
+    PTO2SharedMemoryRingHeader rings[CHIP_MAX_RING_DEPTH];
 
     // === GLOBAL FIELDS ===
     std::atomic<int32_t> orchestrator_done;  // Flag: orchestration complete
@@ -195,7 +195,7 @@ struct PTO2SharedMemoryHandle {
     // === Static helpers ===
 
     static uint64_t calculate_size(uint64_t task_window_size);
-    static uint64_t calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
+    static uint64_t calculate_size_per_ring(const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]);
 
     // UT convenience: reserve wrapper + sm_base on `arena`, commit, and init
     // using default PTO2_TASK_WINDOW_SIZE / PTO2_HEAP_SIZE. Only valid when the
@@ -211,8 +211,8 @@ struct PTO2SharedMemoryHandle {
     // `task_window_size`.
     bool init(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size);
     bool init_per_ring(
-        void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-        const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+        void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH],
+        const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH]
     );
 
     void destroy();
@@ -222,10 +222,10 @@ struct PTO2SharedMemoryHandle {
 private:
     void init_header(uint64_t task_window_size, uint64_t heap_size);
     void init_header_per_ring(
-        const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+        const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH], const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH]
     );
     void setup_pointers(uint64_t task_window_size);
-    void setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
+    void setup_pointers_per_ring(const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]);
 };
 
 // =============================================================================
@@ -288,8 +288,8 @@ struct PTO2RingSegmentOffsets {
 // segment is a one-line edit here; every consumer follows automatically, so the
 // layout walk can never silently disagree across call sites.
 inline PTO2RingSegmentOffsets
-ring_segment_offsets(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], int ring_id) noexcept {
-    assert(ring_id >= 0 && ring_id < PTO2_MAX_RING_DEPTH && "pto2_sm_layout: ring_id out of range");
+ring_segment_offsets(const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH], int ring_id) noexcept {
+    assert(ring_id >= 0 && ring_id < CHIP_MAX_RING_DEPTH && "pto2_sm_layout: ring_id out of range");
     uint64_t off = PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
     for (int r = 0; r < ring_id; r++) {
         off += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
@@ -309,7 +309,7 @@ ring_segment_offsets(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], int 
 
 // Device address of ring `ring_id`'s task_descriptors array.
 inline PTO2TaskDescriptor *ring_task_descriptors_addr(
-    void *sm_dev_base, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], int ring_id
+    void *sm_dev_base, const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH], int ring_id
 ) noexcept {
     return reinterpret_cast<PTO2TaskDescriptor *>(
         static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_sizes, ring_id).descriptors
@@ -319,7 +319,7 @@ inline PTO2TaskDescriptor *ring_task_descriptors_addr(
 // Device address of ring `ring_id`'s slot_states array (used by the allocator's
 // deadlock detector to identify the head task's slot).
 inline ChipTaskSlotState *
-ring_slot_states_addr(void *sm_dev_base, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], int ring_id) noexcept {
+ring_slot_states_addr(void *sm_dev_base, const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH], int ring_id) noexcept {
     return reinterpret_cast<ChipTaskSlotState *>(
         static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_sizes, ring_id).slot_states
     );

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared_memory.h
@@ -95,7 +95,7 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     // Per-ring data pointers (host-side, set by setup_pointers)
     PTO2TaskDescriptor *task_descriptors;
     PTO2TaskPayload *task_payloads;
-    PTO2TaskSlotState *slot_states;
+    ChipTaskSlotState *slot_states;
 
     int32_t get_slot_by_task_id(int32_t local_task_id) { return local_task_id & task_window_mask; }
 
@@ -109,9 +109,9 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
 
     PTO2TaskPayload &get_payload_by_task_id(int32_t local_id) { return task_payloads[get_slot_by_task_id(local_id)]; }
 
-    PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
+    ChipTaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
-    PTO2TaskSlotState &get_slot_state_by_task_id(int32_t local_id) {
+    ChipTaskSlotState &get_slot_state_by_task_id(int32_t local_id) {
         return slot_states[get_slot_by_task_id(local_id)];
     }
 };
@@ -294,7 +294,7 @@ ring_segment_offsets(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], int 
     for (int r = 0; r < ring_id; r++) {
         off += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
         off += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
-        off += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
+        off += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(ChipTaskSlotState), PTO2_ALIGN_SIZE);
     }
     PTO2RingSegmentOffsets o{};
     o.descriptors = off;
@@ -302,7 +302,7 @@ ring_segment_offsets(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], int 
     o.payloads = off;
     off += PTO2_ALIGN_UP(task_window_sizes[ring_id] * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
     o.slot_states = off;
-    off += PTO2_ALIGN_UP(task_window_sizes[ring_id] * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
+    off += PTO2_ALIGN_UP(task_window_sizes[ring_id] * sizeof(ChipTaskSlotState), PTO2_ALIGN_SIZE);
     o.end = off;
     return o;
 }
@@ -318,9 +318,9 @@ inline PTO2TaskDescriptor *ring_task_descriptors_addr(
 
 // Device address of ring `ring_id`'s slot_states array (used by the allocator's
 // deadlock detector to identify the head task's slot).
-inline PTO2TaskSlotState *
+inline ChipTaskSlotState *
 ring_slot_states_addr(void *sm_dev_base, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], int ring_id) noexcept {
-    return reinterpret_cast<PTO2TaskSlotState *>(
+    return reinterpret_cast<ChipTaskSlotState *>(
         static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_sizes, ring_id).slot_states
     );
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/submit_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/submit_types.h
@@ -167,7 +167,7 @@ private:
 static_assert(sizeof(ActiveMask) == 1, "ActiveMask must be exactly 1 byte");
 
 /**
- * Per-task scheduling attributes, packed into one byte on PTO2TaskSlotState.
+ * Per-task scheduling attributes, packed into one byte on ChipTaskSlotState.
  *
  * Single home for the independent per-task flags: an early-dispatch hint, the
  * two dispatch-time predicates (sync_start / has_predicate), and the selective

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensormap.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensormap.h
@@ -77,11 +77,11 @@ struct PTO2TensorMapLayout {
     size_t off_bucket_epochs;
     size_t off_entry_pool;
     size_t off_free_entry_list;
-    size_t off_task_entry_heads[PTO2_MAX_RING_DEPTH];
-    size_t off_task_entry_head_epochs[PTO2_MAX_RING_DEPTH];
+    size_t off_task_entry_heads[CHIP_MAX_RING_DEPTH];
+    size_t off_task_entry_head_epochs[CHIP_MAX_RING_DEPTH];
     int32_t num_buckets;
     int32_t pool_size;
-    int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
+    int32_t task_window_sizes[CHIP_MAX_RING_DEPTH];
 };
 
 // TensorMap Lookup Profiling (must precede inline lookup/insert methods).
@@ -374,16 +374,16 @@ struct PTO2TensorMap {
 
     // Per-ring per-task entry tracking (for efficient bucket cleanup)
     // Indexed by [ring_id][local_id & (task_window_sizes[ring_id] - 1)]
-    PTO2TensorMapEntry **task_entry_heads[PTO2_MAX_RING_DEPTH];
-    uint32_t *task_entry_head_epochs[PTO2_MAX_RING_DEPTH];
-    int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];  // Per-ring task window size (for slot masking)
+    PTO2TensorMapEntry **task_entry_heads[CHIP_MAX_RING_DEPTH];
+    uint32_t *task_entry_head_epochs[CHIP_MAX_RING_DEPTH];
+    int32_t task_window_sizes[CHIP_MAX_RING_DEPTH];  // Per-ring task window size (for slot masking)
     uint32_t current_epoch{1};
 
     // Per-ring validity threshold (for lazy invalidation)
-    int32_t last_task_alives[PTO2_MAX_RING_DEPTH];  // Cached from shared memory per ring
+    int32_t last_task_alives[CHIP_MAX_RING_DEPTH];  // Cached from shared memory per ring
 
     // Per-ring cleanup progress (for periodic cleanup_retired)
-    int32_t last_cleanup[PTO2_MAX_RING_DEPTH]{};
+    int32_t last_cleanup[CHIP_MAX_RING_DEPTH]{};
 
     uint32_t get_task_local_id_slot(uint8_t ring_id, uint32_t task_local_id) const {
         return task_local_id & (task_window_sizes[ring_id] - 1);
@@ -404,9 +404,9 @@ struct PTO2TensorMap {
     // shortage (some ring still retiring tasks) from a wedged pool (no ring
     // advancing). Idempotent per watermark: a ring whose alive has not passed
     // last_cleanup[r] is skipped, so it never double-frees.
-    int64_t reclaim_retired_all(const int32_t sm_last_task_alive[PTO2_MAX_RING_DEPTH]) {
+    int64_t reclaim_retired_all(const int32_t sm_last_task_alive[CHIP_MAX_RING_DEPTH]) {
         int64_t alive_sum = 0;
-        for (int32_t r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int32_t r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             int32_t alive = sm_last_task_alive[r];
             sync_validity(r, alive);
             if (alive > last_cleanup[r]) {
@@ -466,7 +466,7 @@ struct PTO2TensorMap {
      * committed.
      */
     static PTO2TensorMapLayout reserve_layout(
-        DeviceArena &arena, int32_t num_buckets, int32_t pool_size, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+        DeviceArena &arena, int32_t num_buckets, int32_t pool_size, const int32_t task_window_sizes[CHIP_MAX_RING_DEPTH]
     );
 
     /**
@@ -474,7 +474,7 @@ struct PTO2TensorMap {
      * PTO2_TENSORMAP_POOL_SIZE).
      */
     static PTO2TensorMapLayout
-    reserve_layout_default(DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
+    reserve_layout_default(DeviceArena &arena, const int32_t task_window_sizes[CHIP_MAX_RING_DEPTH]);
 
     /**
      * Phase 3a: write everything *except* arena-internal pointer fields

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/types.h
@@ -124,7 +124,7 @@ constexpr bool dep_has_retain(DepFlags f) { return (f & DEP_RETAIN) != DEP_NONE;
  *   scope_end the slot becomes eligible for reuse, and a later submit will
  *   overwrite the same ChipTensor storage in place. Therefore the
  *   TaskOutputTensors instance, the const ChipTensor& returned by get_ref(), and
- *   any pointer derived from either MUST NOT outlive the PTO2_SCOPE in which
+ *   any pointer derived from either MUST NOT outlive the SIMPLER_SCOPE in which
  *   submit was called — do not move/copy them to outer-scope variables, do
  *   not capture references by std::reference_wrapper or raw pointers across
  *   scope boundaries.

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -59,7 +59,7 @@
 
 // From orchestration/common.cpp linked into this DSO — updates g_current_runtime
 // here (cleared on teardown before runtime_destroy).
-extern "C" void framework_bind_runtime(PTO2Runtime *rt);
+extern "C" void framework_bind_runtime(RuntimeContext *rt);
 
 static int32_t read_pto2_runtime_status(Runtime *runtime) {
     if (runtime == nullptr) {
@@ -77,7 +77,7 @@ static int32_t read_pto2_runtime_status(Runtime *runtime) {
     return runtime_status_from_error_codes(orch_error_code, sched_error_code);
 }
 
-static PTO2Runtime *rt{nullptr};
+static RuntimeContext *rt{nullptr};
 
 struct AicpuExecutor {
     // ===== Thread management state =====
@@ -110,7 +110,7 @@ struct AicpuExecutor {
     simpler::ThreadCompletionGate completion_gate_;
     std::atomic<bool> runtime_init_ready_{false};
 
-    // Per-Worker arena backing the PTO2Runtime + sm_handle + orch/sched/mailbox
+    // Per-Worker arena backing the RuntimeContext + sm_handle + orch/sched/mailbox
     // sub-regions (created in runtime_create_from_sm, released in runtime_destroy).
     // Default-constructed: libc-backed backend, no ctx.
     DeviceArena runtime_arena_;
@@ -260,7 +260,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
         if (boot_ok) {
             runtime_arena_.attach(prebuilt_arena, DeviceArena::kDefaultBaseAlign);
-            rt = reinterpret_cast<PTO2Runtime *>(static_cast<char *>(prebuilt_arena) + off_runtime);
+            rt = reinterpret_cast<RuntimeContext *>(static_cast<char *>(prebuilt_arena) + off_runtime);
             runtime_wire_arena_pointers(runtime_arena_, rt->prebuilt_layout, rt);
 
             void *sm_ptr = runtime->get_gm_sm_ptr();

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -27,7 +27,7 @@
 #include "runtime.h"
 #include "spin_hint.h"
 
-// Runtime headers (full struct definition for create/destroy + PTO2_SCOPE)
+// Runtime headers (full struct definition for create/destroy + SIMPLER_SCOPE)
 #include "runtime_core.h"
 #include "runtime_types.h"
 #include "shared_memory.h"

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -115,9 +115,9 @@ a boundary from which region happens to be reserved first —
 orchestrator, so nothing on the device reads its state: not the `fanin_seen_epoch`
 table, not the scope arrays, not the TensorMap (~9.3 MB between them). It is
 therefore a plain host object that owns those arrays — `PTO2OrchestratorState::init`
-allocates them — and `PTO2Runtime` reaches it through a pointer that `bind` drops
+allocates them — and `RuntimeContext` reaches it through a pointer that `bind` drops
 before the copied zone is uploaded, so no host address crosses the boundary. A
-`static_assert` keeps `PTO2Runtime` trivially copyable, which is what forbids
+`static_assert` keeps `RuntimeContext` trivially copyable, which is what forbids
 putting an owning member back inside it. The one orchestrator value the device-side
 scheduler reads, the count of tasks completed inline during orchestration, is a
 scalar `rt_orchestration_done` publishes into the runtime header.
@@ -128,7 +128,7 @@ queue capacities are compile-time constants, hbg never advances
 `last_task_alive`, and it has no host-side entry point at all. So the host would
 only be writing an initialization pattern — 203,392 bytes
 of it, dominated by `AsyncWaitList::entries` — for the device to receive and never
-read. `PTO2Runtime` therefore holds a *pointer* to it, wired from
+read. `RuntimeContext` therefore holds a *pointer* to it, wired from
 `off_scheduler` on each side, and the AICPU calls `init_data_from_layout` at boot.
 
 **Why the queue slots are device-written.** `push` claims `slots[pos & mask]` only

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -74,7 +74,7 @@ The shared image uses three per-slot structures:
 | --------- | ------- |
 | `PTO2TaskDescriptor` | Full task ID, kernel IDs, packed-buffer addresses |
 | `PTO2TaskPayload` | Argument counts, predicate, dispatch metadata, and a delta naming each of its tensor, scalar and fanin regions — the arguments themselves live in the pool segments, so the payload is a fixed three cache lines regardless of the argument caps |
-| `PTO2TaskSlotState` | Active mask, attributes, block/subtask counters, completion state, task/payload bindings |
+| `ChipTaskSlotState` | Active mask, attributes, block/subtask counters, completion state, task/payload bindings |
 
 The host/device boundary is POD and position-independent. Fanins are integer
 producer IDs, not pointers, and a slot state names its payload and descriptor — and

--- a/src/a5/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a5/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
@@ -31,7 +31,7 @@ The shared graph image separates stable task identity from scheduling state:
 - `PTO2TaskPayload` contains the argument counts, predicate, and a delta naming
   each of its tensor, scalar and position-independent fanin-id regions. The
   arguments live in the pool segments, not in the payload.
-- `PTO2TaskSlotState` contains the active mask, task attributes, logical block
+- `ChipTaskSlotState` contains the active mask, task attributes, logical block
   count, subtask counters, completion state, and descriptor/payload bindings.
 
 This image is built on the host and copied to the device verbatim. It contains

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -526,7 +526,7 @@ int32_t run_host_orchestration(
     // orch::prepare_task and shipped bounded to total_tasks below.
     const pto2_sm_layout::PTO2RingSegmentOffsets sm_segs = pto2_sm_layout::ring_segment_offsets(eff_task_window_size);
     // Over-allocated and rounded up: every segment offset is a multiple of
-    // PTO2_ALIGN_SIZE and PTO2TaskSlotState is alignas(64), which a plain
+    // PTO2_ALIGN_SIZE and ChipTaskSlotState is alignas(64), which a plain
     // new uint8_t[] does not guarantee.
     std::unique_ptr<uint8_t[]> host_sm_buf(new uint8_t[sm_size + PTO2_ALIGN_SIZE]);
     void *host_sm = reinterpret_cast<void *>(
@@ -735,7 +735,7 @@ int32_t run_host_orchestration(
     // One host source for one copy: the copied zone and shared-memory image at
     // exactly the offsets they occupy on the device.
     // Over-allocated and rounded up because every segment offset is
-    // PTO2_ALIGN_SIZE-aligned and PTO2TaskSlotState is alignas(64), which a byte
+    // PTO2_ALIGN_SIZE-aligned and ChipTaskSlotState is alignas(64), which a byte
     // vector's data() is not.
     const uint64_t copied_bytes = layout.off_copied_end - layout.off_copied_begin;
     const uint64_t upload_bytes = copied_bytes + image_bytes;

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -382,7 +382,7 @@ bool create_orch_so_tempfile(const uint8_t *data, size_t size, std::string *out_
 
 // The orchestration .so exports these (PTO2 submit_task form).
 typedef void (*OrchestrationEntryFunc)(const ChipTaskArgs &);
-typedef void (*OrchestrationBindFunc)(PTO2Runtime *);
+typedef void (*OrchestrationBindFunc)(RuntimeContext *);
 typedef void (*OrchestrationPrewarmFunc)();
 
 // Resolved orchestration .so entry points. register_callable_impl allocates one
@@ -513,9 +513,9 @@ struct GraphHostStateBinding {
 };
 
 int32_t run_host_orchestration(
-    Runtime *runtime, const HostApi *api, HostTensorAccessor &tensor_access, PTO2Runtime *rt, DeviceArena &host_arena,
-    const PTO2RuntimeArenaLayout &layout, uint64_t sm_size, void *device_arena, void *gm_heap, uint64_t eff_heap_size,
-    uint64_t eff_task_window_size, void *host_orch_func_ptr, const ChipTaskArgs &orch_l2
+    Runtime *runtime, const HostApi *api, HostTensorAccessor &tensor_access, RuntimeContext *rt,
+    DeviceArena &host_arena, const RuntimeArenaLayout &layout, uint64_t sm_size, void *device_arena, void *gm_heap,
+    uint64_t eff_heap_size, uint64_t eff_task_window_size, void *host_orch_func_ptr, const ChipTaskArgs &orch_l2
 ) {
     // The dep_gen graph belongs to the orchestration that is about to run.
     dep_gen_host_graph_begin_capture();
@@ -1042,7 +1042,7 @@ extern "C" int bind_callable_to_runtime_impl(
 
     const int64_t t_arena_build_ns = bind_now_ns();
     DeviceArena host_arena;
-    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(host_arena, eff_task_window_size, eff_heap_size);
+    RuntimeArenaLayout layout = runtime_reserve_layout(host_arena, eff_task_window_size, eff_heap_size);
     if (host_arena.commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
         LOG_ERROR("Failed to commit host arena for prebuilt runtime image");
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -1105,7 +1105,7 @@ extern "C" int bind_callable_to_runtime_impl(
     const int64_t t_runtime_init_ns = bind_now_ns();
     // No SM base: the scheduler and sm_handle are device-written now, so nothing
     // here stores one, and the region is not even committed yet.
-    PTO2Runtime *rt = runtime_init_data_from_layout(
+    RuntimeContext *rt = runtime_init_data_from_layout(
         host_arena, layout, PTO2_MODE_EXECUTE, /*sm_dev_base=*/nullptr, sm_size, gm_heap, eff_heap_size
     );
     if (rt == nullptr) {
@@ -1113,7 +1113,7 @@ extern "C" int bind_callable_to_runtime_impl(
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     runtime_wire_arena_pointers(host_arena, layout, rt);
-    // Stash the layout inside the PTO2Runtime image so the AICPU can recover every
+    // Stash the layout inside the RuntimeContext image so the AICPU can recover every
     // arena-internal offset after the copy. It is written before orchestration
     // because orchestration is what performs that copy, and the runtime header is
     // part of what travels. The runtime arena's device base does NOT travel — it is

--- a/src/a5/runtime/host_build_graph/orchestration/common.cpp
+++ b/src/a5/runtime/host_build_graph/orchestration/common.cpp
@@ -21,7 +21,7 @@
 #include <vector>
 #endif
 
-struct PTO2Runtime;
+struct RuntimeContext;
 
 // Unified-log error sink. Forward-declared here rather than pulled via
 // common/unified_log.h: that header lives under common/log/include, which is
@@ -36,16 +36,18 @@ namespace {
 // crash (BZ #32412) when the orchestration SO is dlclose'd/re-dlopen'd
 // between execution rounds.  All orchestrator threads bind the same rt
 // value, so per-thread storage is unnecessary.
-PTO2Runtime *g_current_runtime = nullptr;
+RuntimeContext *g_current_runtime = nullptr;
 }  // namespace
 
-extern "C" __attribute__((visibility("default"))) void framework_bind_runtime(PTO2Runtime *rt) {
+extern "C" __attribute__((visibility("default"))) void framework_bind_runtime(RuntimeContext *rt) {
     g_current_runtime = rt;
 }
 
 // Keep current_runtime local to this .so so orchestration helpers do not
 // accidentally bind to the AICPU binary's same-named symbol.
-extern "C" __attribute__((visibility("hidden"))) PTO2Runtime *framework_current_runtime() { return g_current_runtime; }
+extern "C" __attribute__((visibility("hidden"))) RuntimeContext *framework_current_runtime() {
+    return g_current_runtime;
+}
 
 /**
  * Use addr2line to convert an address to file:line information.

--- a/src/a5/runtime/host_build_graph/orchestration/orchestration_api.h
+++ b/src/a5/runtime/host_build_graph/orchestration/orchestration_api.h
@@ -884,7 +884,7 @@ rt_submit_graph(GraphFunctionWithConfig<Config...> function, const GraphTaskArgs
  */
 #ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
-struct PTO2OrchestrationConfig {
+struct OrchestrationConfig {
     int expected_arg_count;
 };
 #endif

--- a/src/a5/runtime/host_build_graph/orchestration/orchestration_api.h
+++ b/src/a5/runtime/host_build_graph/orchestration/orchestration_api.h
@@ -110,7 +110,7 @@ typedef struct PTO2RuntimeOps {
     bool (*graph_end)(PTO2Runtime *rt);
     void (*graph_commit)(PTO2Runtime *rt);
 
-    // Stash the call-site of the next PTO2ScopeGuard so the [ScopeStats]
+    // Stash the call-site of the next ScopeGuard so the [ScopeStats]
     // collector can log it. Always present to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
     void (*scope_set_site)(const char *file, int line);
@@ -690,9 +690,9 @@ static inline void set_tensor_data(const ChipTensor &tensor, uint32_t ndims, con
 /**
  * RAII Scope Guard (calls through ops table)
  */
-class PTO2ScopeGuard {
+class ScopeGuard {
 public:
-    explicit PTO2ScopeGuard(
+    explicit ScopeGuard(
         PTO2ScopeMode mode = PTO2ScopeMode::AUTO, const char *file = __builtin_FILE(), int line = __builtin_LINE()
     ) :
         rt_(current_runtime()) {
@@ -702,7 +702,7 @@ public:
             rt_->ops->scope_begin(rt_);
         }
     }
-    ~PTO2ScopeGuard() {
+    ~ScopeGuard() {
         if (!rt_->ops->is_fatal(rt_)) {
             rt_->ops->scope_end(rt_);
         }
@@ -858,18 +858,18 @@ rt_submit_graph(GraphFunctionWithConfig<Config...> function, const GraphTaskArgs
     return rt_submit_graph(rt_graph_function_id(function), function, args, config...);
 }
 
-#define _PTO2_CONCATENATE_IMPL(x, y) x##y
-#define _PTO2_CONCATENATE(x, y) _PTO2_CONCATENATE_IMPL(x, y)
+#define _SIMPLER_CONCATENATE_IMPL(x, y) x##y
+#define _SIMPLER_CONCATENATE(x, y) _SIMPLER_CONCATENATE_IMPL(x, y)
 
-#define PTO2_SCOPE_GUARD() [[maybe_unused]] PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__)
+#define SIMPLER_SCOPE_GUARD() [[maybe_unused]] ScopeGuard _SIMPLER_CONCATENATE(scope_guard_, __COUNTER__)
 
 /**
  * Scoped block macro:
- *   PTO2_SCOPE() {
+ *   SIMPLER_SCOPE() {
  *       rt_submit_task(...);
  *   }
  */
-#define PTO2_SCOPE(...) if (PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__){__VA_ARGS__}; true)
+#define SIMPLER_SCOPE(...) if (ScopeGuard _SIMPLER_CONCATENATE(scope_guard_, __COUNTER__){__VA_ARGS__}; true)
 
 // =============================================================================
 // Orchestration Config

--- a/src/a5/runtime/host_build_graph/orchestration/orchestration_api.h
+++ b/src/a5/runtime/host_build_graph/orchestration/orchestration_api.h
@@ -14,14 +14,14 @@
  * This header provides everything an orchestration source needs without
  * pulling in runtime implementation headers.  The orchestration .so has
  * zero link dependencies on runtime .cpp files; all runtime calls go
- * through the PTO2RuntimeOps function-pointer table embedded in
- * PTO2Runtime.
+ * through the RuntimeOps function-pointer table embedded in
+ * RuntimeContext.
  *
  * Orchestration sources include ONLY this header:
  *   #include "orchestration_api.h"
  *
  * Runtime sources continue to use runtime_core.h (which defines the
- * full PTO2Runtime struct with all internal fields).
+ * full RuntimeContext struct with all internal fields).
  */
 
 #pragma once
@@ -66,23 +66,23 @@
 // =============================================================================
 
 /**
- * Forward declaration — the orchestration sees PTO2Runtime as a partial
+ * Forward declaration — the orchestration sees RuntimeContext as a partial
  * struct whose first field is the ops pointer.  The full definition
  * lives in runtime_core.h (used only by runtime .cpp files).
  */
-typedef struct PTO2Runtime PTO2Runtime;
+typedef struct RuntimeContext RuntimeContext;
 
 /**
  * Function-pointer table for runtime operations.
  * Populated by the runtime; called by orchestration through inline wrappers.
  */
-typedef struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
-    void (*scope_begin)(PTO2Runtime *rt);
-    void (*scope_end)(PTO2Runtime *rt);
-    void (*orchestration_done)(PTO2Runtime *rt);
-    bool (*is_fatal)(PTO2Runtime *rt);
-    void (*report_fatal)(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
+typedef struct RuntimeOps {
+    TaskOutputTensors (*submit_task)(RuntimeContext *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
+    void (*scope_begin)(RuntimeContext *rt);
+    void (*scope_end)(RuntimeContext *rt);
+    void (*orchestration_done)(RuntimeContext *rt);
+    bool (*is_fatal)(RuntimeContext *rt);
+    void (*report_fatal)(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
     // Logging (populated by runtime, called by orchestration)
     void (*log_error)(const char *func, const char *fmt, ...);
@@ -93,22 +93,22 @@ typedef struct PTO2RuntimeOps {
 
     // Cross-layer data access (orchestration reads/writes tensor values via runtime)
     // Placed after logging to avoid shifting hot-path field offsets.
-    uint64_t (*get_tensor_data)(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
+    uint64_t (*get_tensor_data)(RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
     void (*set_tensor_data)(
-        PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+        RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
     );
-    TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const CoreTaskArgs &args);
-    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const CoreTaskArgs &args);
+    TaskOutputTensors (*alloc_tensors)(RuntimeContext *rt, const CoreTaskArgs &args);
+    TaskOutputTensors (*submit_dummy_task)(RuntimeContext *rt, const CoreTaskArgs &args);
 
     // This-run core geometry latched by the host bind: MIX clusters
     // (one AIC each) and standalone AIV cores.
-    int32_t (*available_cluster_count)(PTO2Runtime *rt);
-    int32_t (*available_aiv_count)(PTO2Runtime *rt);
-    GraphScopeResult (*graph_begin)(PTO2Runtime *rt, uint64_t graph_key, const GraphTaskArgs &args);
-    bool (*graph_prepare)(PTO2Runtime *rt, void *recording_handle, const GraphTaskArgs &args);
-    void (*graph_abort)(PTO2Runtime *rt, void *recording_handle);
-    bool (*graph_end)(PTO2Runtime *rt);
-    void (*graph_commit)(PTO2Runtime *rt);
+    int32_t (*available_cluster_count)(RuntimeContext *rt);
+    int32_t (*available_aiv_count)(RuntimeContext *rt);
+    GraphScopeResult (*graph_begin)(RuntimeContext *rt, uint64_t graph_key, const GraphTaskArgs &args);
+    bool (*graph_prepare)(RuntimeContext *rt, void *recording_handle, const GraphTaskArgs &args);
+    void (*graph_abort)(RuntimeContext *rt, void *recording_handle);
+    bool (*graph_end)(RuntimeContext *rt);
+    void (*graph_commit)(RuntimeContext *rt);
 
     // Stash the call-site of the next ScopeGuard so the [ScopeStats]
     // collector can log it. Always present to keep ops-table layout stable
@@ -122,18 +122,18 @@ typedef struct PTO2RuntimeOps {
     // the two must stay in lockstep field for field, since the runtime fills the table
     // and this .so calls through it.
     void (*record_orch_phase)(uint32_t kind, uint64_t start_ns, uint64_t end_ns, uint64_t detail);
-} PTO2RuntimeOps;
+} RuntimeOps;
 
 /**
- * Partial PTO2Runtime definition for orchestration.
+ * Partial RuntimeContext definition for orchestration.
  *
  * Exposes the ops pointer (for runtime calls) and pending_scope_mode
  * (read directly by inline scope wrappers).  The real struct (in
  * runtime_core.h) has the same first fields, so accessing them through
  * this definition is well-defined (C struct layout guarantee).
  */
-struct PTO2Runtime {
-    const PTO2RuntimeOps *ops;
+struct RuntimeContext {
+    const RuntimeOps *ops;
     PTO2ScopeMode pending_scope_mode;
 };
 
@@ -379,7 +379,7 @@ inline GraphAsyncRecordingState &rt_graph_async_recording() {
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================
 
-static inline PTO2Runtime *current_runtime() { return framework_current_runtime(); }
+static inline RuntimeContext *current_runtime() { return framework_current_runtime(); }
 
 // Where the previous submission on this thread left off, so the generated code's own
 // work between two submissions can be named rather than showing as an unattributed gap.
@@ -409,7 +409,7 @@ static inline void rt_graph_commit();
 // submitting thread for the rest of every recording in flight, which on the
 // four-Definition DeepSeek-V4 decode was a third of the orchestration window.
 static inline TaskOutputTensors alloc_tensors(const CoreTaskArgs &args) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -417,7 +417,7 @@ static inline TaskOutputTensors alloc_tensors(const CoreTaskArgs &args) {
 }
 
 static inline TaskOutputTensors alloc_tensors(const TensorCreateInfo create_infos[], uint32_t count) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -442,7 +442,7 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
         (std::is_same_v<std::decay_t<CIs>, TensorCreateInfo> && ...),
         "alloc_tensors only accepts TensorCreateInfo arguments"
     );
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -459,7 +459,7 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
 }
 
 static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -492,7 +492,7 @@ static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const Core
  * barrier or as a placeholder producer for tests / dep-graph wiring.
  */
 static inline TaskOutputTensors rt_submit_dummy_task(const CoreTaskArgs &args) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -500,7 +500,7 @@ static inline TaskOutputTensors rt_submit_dummy_task(const CoreTaskArgs &args) {
 }
 
 static inline GraphScopeResult rt_graph_begin(uint64_t graph_key, const GraphTaskArgs &args) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt) || rt->ops->graph_begin == nullptr) {
         return GraphScopeResult{};
     }
@@ -511,19 +511,19 @@ static inline GraphScopeResult rt_graph_begin(uint64_t graph_key, const GraphTas
 // from the GraphScopeResult that opened it, so a thread can only ever record
 // into the recording it was handed.
 static inline bool rt_graph_prepare(void *recording_handle, const GraphTaskArgs &args) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     return rt->ops->graph_prepare != nullptr && rt->ops->graph_prepare(rt, recording_handle, args);
 }
 
 static inline void rt_graph_abort(void *recording_handle) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->graph_abort != nullptr) rt->ops->graph_abort(rt, recording_handle);
 }
 
 // Finish the recording pass and publish its Definition. The calling thread
 // finalizes the already-submitted outer Graph shells in rt_graph_commit.
 static inline bool rt_graph_end() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt) || rt->ops->graph_end == nullptr) {
         return true;
     }
@@ -534,12 +534,12 @@ static inline void rt_graph_commit() {
     GraphAsyncRecordingState &async = rt_graph_async_recording();
     async.wait();
 
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (!rt->ops->is_fatal(rt) && rt->ops->graph_commit != nullptr) rt->ops->graph_commit(rt);
 }
 
 static inline void rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
@@ -548,7 +548,7 @@ static inline void rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {
 }
 
 static inline void rt_scope_end() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
@@ -558,30 +558,30 @@ static inline void rt_scope_end() {
 static inline void rt_orchestration_done() {
     rt_graph_commit();
     rt_submit_phase_state() = RtSubmitPhaseState{};
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     rt->ops->orchestration_done(rt);
 }
 
 /** This-run MIX cluster (= AIC) count. Do not hardcode 24/36; MIX cohorts use this. */
 static inline int32_t rt_available_cluster_count() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     return rt->ops->available_cluster_count(rt);
 }
 
 /** This-run standalone AIV core count. AIV-only cohorts size themselves on this. */
 static inline int32_t rt_available_aiv_count() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     return rt->ops->available_aiv_count(rt);
 }
 
 static inline bool rt_is_fatal() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     return rt->ops->is_fatal(rt);
 }
 
 #define rt_report_fatal(code, fmt, ...)                                          \
     do {                                                                         \
-        PTO2Runtime *_rt = current_runtime();                                    \
+        RuntimeContext *_rt = current_runtime();                                 \
         _rt->ops->report_fatal(_rt, (code), __FUNCTION__, (fmt), ##__VA_ARGS__); \
     } while (0)
 
@@ -610,7 +610,7 @@ enum class RtOrchPhase : uint32_t {
 };
 
 inline void rt_record_orch_phase(RtOrchPhase phase, uint64_t start_ns, uint64_t end_ns, uint64_t detail) {
-    const PTO2RuntimeOps *ops = current_runtime()->ops;
+    const RuntimeOps *ops = current_runtime()->ops;
     if (ops->record_orch_phase != nullptr) {
         ops->record_orch_phase(static_cast<uint32_t>(phase), start_ns, end_ns, detail);
     }
@@ -653,7 +653,7 @@ inline uint64_t rt_orch_phase_now_ns() {
  */
 template <typename T = uint64_t>
 static inline T get_tensor_data(const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return from_u64<T>(0);
     }
@@ -676,7 +676,7 @@ static inline T get_tensor_data(const ChipTensor &tensor, uint32_t ndims, const 
  */
 template <typename T = uint64_t>
 static inline void set_tensor_data(const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], T value) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
@@ -709,7 +709,7 @@ public:
     }
 
 private:
-    PTO2Runtime *rt_;
+    RuntimeContext *rt_;
 };
 
 // Define or submit a Graph Execution. On a cache miss the function executes

--- a/src/a5/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
+++ b/src/a5/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
@@ -52,7 +52,7 @@ struct AICoreCompletionMailboxMessage {
     std::atomic<uint64_t> seq;
     TaskId task_token;
     // CONDITION: completion observation addr (counter / backend record).
-    // TASK_NORMAL_DONE: PTO2TaskSlotState pointer carried over to the consumer
+    // TASK_NORMAL_DONE: ChipTaskSlotState pointer carried over to the consumer
     //   so it can finalize the AsyncWaitEntry.slot_state binding.
     uint64_t addr;
     uint64_t backend_cookie;
@@ -169,7 +169,7 @@ struct AICoreCompletionMailbox {
         }
     }
 
-    // MPSC push for a TASK_NORMAL_DONE sentinel. Carries the PTO2TaskSlotState
+    // MPSC push for a TASK_NORMAL_DONE sentinel. Carries the ChipTaskSlotState
     // pointer in the `addr` field so the consumer can finish binding the
     // AsyncWaitEntry.slot_state without going back to the FIN-handling thread.
     bool try_push_normal_done(TaskId task_token, uint64_t slot_state_addr) {

--- a/src/a5/runtime/host_build_graph/runtime/async_wait.h
+++ b/src/a5/runtime/host_build_graph/runtime/async_wait.h
@@ -114,7 +114,7 @@ inline void CompletionCondition::retire() {
 }
 
 struct AsyncWaitEntry {
-    PTO2TaskSlotState *slot_state{nullptr};
+    ChipTaskSlotState *slot_state{nullptr};
     TaskId task_token{TaskId::invalid()};
     CompletionCondition conditions[MAX_COMPLETIONS_PER_TASK];
     int32_t condition_count{0};
@@ -126,7 +126,7 @@ struct AsyncPollResult {
     int32_t completed{0};  // Host-submitted stream tasks completed.
     int32_t resolved{0};   // All task completions, including internal Graph nodes.
     int32_t error_code{SIMPLER_ERROR_NONE};
-    PTO2TaskSlotState *failed_slot_state{nullptr};
+    ChipTaskSlotState *failed_slot_state{nullptr};
 };
 
 inline const char *async_engine_name(AsyncEngine engine) {
@@ -184,7 +184,7 @@ struct AsyncWaitList {
     };
 
     // Inline-complete a NotDeferred task during drain.
-    bool try_inline_complete_locked(DrainCompletionSink &sink, PTO2TaskSlotState &slot_state);
+    bool try_inline_complete_locked(DrainCompletionSink &sink, ChipTaskSlotState &slot_state);
 
     // Single-consumer drain: pop each published message in tail order and
     // translate it into wait-list state. An empty sink (sched == nullptr) just
@@ -227,8 +227,8 @@ struct AsyncWaitList {
                     return drained;
                 }
             } else if (msg.kind == MSG_KIND_TASK_NORMAL_DONE) {
-                PTO2TaskSlotState *slot_state_ptr =
-                    reinterpret_cast<PTO2TaskSlotState *>(static_cast<uintptr_t>(msg.addr));
+                ChipTaskSlotState *slot_state_ptr =
+                    reinterpret_cast<ChipTaskSlotState *>(static_cast<uintptr_t>(msg.addr));
                 AsyncWaitEntry *entry = find_entry_by_token(msg.task_token);
                 if (entry == nullptr) {
                     // Producers strictly order: all CONDITIONs for token T are

--- a/src/a5/runtime/host_build_graph/runtime/common.h
+++ b/src/a5/runtime/host_build_graph/runtime/common.h
@@ -23,7 +23,7 @@
 
 // Framework-internal TLS bridge. The executor binds the current thread's
 // runtime before invoking the orchestration entry, so orchestration helpers can
-// fetch the current PTO2Runtime without explicit parameter threading. Declared
+// fetch the current RuntimeContext without explicit parameter threading. Declared
 // here (rather than in orchestration_api.h) so framework TUs the AICore
 // build also compiles — notably orchestration/common.cpp — see these symbols
 // without pulling in types.h, whose Arg::add_scalar → to_u64 path is
@@ -31,9 +31,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-struct PTO2Runtime;
-PTO2Runtime *framework_current_runtime(void);
-void framework_bind_runtime(PTO2Runtime *rt);
+struct RuntimeContext;
+RuntimeContext *framework_current_runtime(void);
+void framework_bind_runtime(RuntimeContext *rt);
 #ifdef __cplusplus
 }
 #endif

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator.h
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator.h
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Orchestrator Interface
+ * Orchestrator interface
  *
  * The Orchestrator is responsible for:
  * 1. Executing the orchestration function (Turing-complete control flow)
@@ -52,7 +52,7 @@ struct GraphHostState;
  *
  * host_build_graph runs the orchestrator on the host and ships the shared-memory
  * image it produces, so this whole object is host-only: it owns its scratch
- * arrays outright and no device code reads any of them. PTO2Runtime therefore
+ * arrays outright and no device code reads any of them. RuntimeContext therefore
  * holds it by pointer — a by-value member would put non-trivially-copyable state
  * inside the struct bind copies to the device.
  */
@@ -97,7 +97,7 @@ struct PTO2OrchestratorState {
 
     // Hidden alloc tasks complete synchronously inside the orchestrator and
     // therefore bypass the executor's normal worker-completion counter path.
-    // rt_orchestration_done publishes this into PTO2Runtime, which is the copy
+    // rt_orchestration_done publishes this into RuntimeContext, which is the copy
     // the device-side executor adds into its completed_tasks_ progress counter
     // so shutdown/profiling totals remain closed.
     int64_t inline_completed_tasks{0};

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -426,7 +426,7 @@ struct GraphRecording {
 };
 
 struct GraphPendingUpload {
-    PTO2TaskSlotState *outer_slot{nullptr};
+    ChipTaskSlotState *outer_slot{nullptr};
     uint64_t full_key{0};
     uint64_t definition_hash{0};
     bool deferred_heap{false};
@@ -984,7 +984,7 @@ struct PTO2FaninBuilder {
 };
 
 static bool append_fanin_or_fail(
-    PTO2OrchestratorState *orch, uint8_t prod_ring, int32_t prod_slot, PTO2TaskSlotState *prod_state,
+    PTO2OrchestratorState *orch, uint8_t prod_ring, int32_t prod_slot, ChipTaskSlotState *prod_state,
     TaskId producer_task_id, PTO2FaninBuilder *fanin_builder
 ) {
     // Skip a stale/reused producer slot: the cached owner id no longer resolves
@@ -1027,7 +1027,7 @@ struct PTO2PreparedTask {
     PTO2TaskAllocResult alloc_result = {-1, 0, nullptr, nullptr};
     PTO2TaskDescriptor *task = nullptr;
     PTO2TaskPayload *payload = nullptr;
-    PTO2TaskSlotState *slot_state = nullptr;
+    ChipTaskSlotState *slot_state = nullptr;
 };
 
 static PTO2OutputLayout calculate_output_layout(const CoreTaskArgs &args) {
@@ -1350,7 +1350,7 @@ static TaskOutputTensors submit_task_common(
         PTO2SharedMemoryRingHeader &dep_ring = orch->sm_header->ring;
         int32_t dep_local_task_id = static_cast<int32_t>(dep_task_id.local());
         int32_t dep_slot = dep_ring.get_slot_by_task_id(dep_local_task_id);
-        PTO2TaskSlotState *producer_slot_state = &dep_ring.get_slot_state_by_slot(dep_slot);
+        ChipTaskSlotState *producer_slot_state = &dep_ring.get_slot_state_by_slot(dep_slot);
         if (!append_fanin_or_fail(orch, dep_ring_id, dep_slot, producer_slot_state, dep_task_id, &fanin_builder)) {
             return result;
         }
@@ -1366,7 +1366,7 @@ static TaskOutputTensors submit_task_common(
         uint8_t prod_ring = producer_task_id.ring();
         PTO2SharedMemoryRingHeader &producer_ring = orch->sm_header->ring;
         int32_t prod_slot = producer_ring.get_slot_by_task_id(static_cast<int32_t>(producer_task_id.local()));
-        PTO2TaskSlotState *prod_state = &producer_ring.get_slot_state_by_slot(prod_slot);
+        ChipTaskSlotState *prod_state = &producer_ring.get_slot_state_by_slot(prod_slot);
         return append_fanin_or_fail(orch, prod_ring, prod_slot, prod_state, producer_task_id, &fanin_builder);
     };
 
@@ -1639,7 +1639,7 @@ bool graph_submit_outer(
     PTO2SharedMemoryRingHeader &ring = orch->sm_header->ring;
     PTO2TaskDescriptor &task = ring.task_descriptors[allocation.slot];
     PTO2TaskPayload &payload = ring.task_payloads[allocation.slot];
-    PTO2TaskSlotState &slot = ring.get_slot_state_by_slot(allocation.slot);
+    ChipTaskSlotState &slot = ring.get_slot_state_by_slot(allocation.slot);
 
     // Init-on-write, as in prepare_task: this slot's dynamic scheduling fields and
     // completion flag are established here, at the claim, because nothing else
@@ -1689,7 +1689,7 @@ bool graph_submit_outer(
     auto emit = [&](TaskId producer_id) -> bool {
         const int32_t producer_local = static_cast<int32_t>(producer_id.local());
         const int32_t producer_slot = ring.get_slot_by_task_id(producer_local);
-        PTO2TaskSlotState *producer = &ring.get_slot_state_by_slot(producer_slot);
+        ChipTaskSlotState *producer = &ring.get_slot_state_by_slot(producer_slot);
         return append_fanin_or_fail(orch, producer_id.ring(), producer_slot, producer, producer_id, &fanin_builder);
     };
     // An outer GRAPH task is a ring task like any other, so the dependency graph

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
@@ -378,7 +378,7 @@ void set_tensor_data(
     }
 }
 
-// Ops-table entry that hands the call-site captured by PTO2ScopeGuard to the
+// Ops-table entry that hands the call-site captured by ScopeGuard to the
 // [ScopeStats] collector. The slot is always present in the struct to keep
 // the layout stable; at SIMPLER_DFX=0 we fill nullptr so the orchestration
 // .so's null-check skips it.

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
@@ -180,14 +180,14 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
     // idempotent (task_state is monotonic) and only adds one atomic load on
     // the second encounter.
     constexpr int kSegmentCap = 64;
-    const PTO2TaskSlotState *seg[kSegmentCap];
+    const ChipTaskSlotState *seg[kSegmentCap];
     int seg_count = 0;
     bool failed = false;
 
     // Returns nullptr for every rejected producer, having latched the fatal.
     // Callers branch on the returned pointer, not on `failed`: the slot is
     // dereferenced immediately and a null return is the only safe signal.
-    auto resolve_producer = [&](TaskId producer) -> const PTO2TaskSlotState * {
+    auto resolve_producer = [&](TaskId producer) -> const ChipTaskSlotState * {
         if (!producer.is_valid() || producer.ring() != 0) {
             orch.report_fatal(
                 SIMPLER_ERROR_INVALID_ARGS, caller,
@@ -214,7 +214,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
         return &slot;
     };
 
-    auto wait_one_producer = [&](const PTO2TaskSlotState &slot) {
+    auto wait_one_producer = [&](const ChipTaskSlotState &slot) {
         uint8_t ring_id = 0;
         int32_t local_id = static_cast<int32_t>(slot.task->task_id.local());
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -241,7 +241,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
         }
     };
 
-    auto wait_one_consumers = [&](const PTO2TaskSlotState &slot) {
+    auto wait_one_consumers = [&](const ChipTaskSlotState &slot) {
         uint8_t ring_id = 0;
         int32_t local_id = slot.task->task_id.local();
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -284,7 +284,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
         seg_count = 0;
     };
 
-    auto try_push = [&](const PTO2TaskSlotState &s) {
+    auto try_push = [&](const ChipTaskSlotState &s) {
         for (int j = 0; j < seg_count; j++) {
             if (seg[j] == &s) return;  // per-segment dedup
         }

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
@@ -85,32 +85,32 @@ static constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_CYCLES =
 // =============================================================================
 
 static TaskOutputTensors
-submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
+submit_task_impl(RuntimeContext *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
     return rt->orchestrator->submit_task(mixed_kernels, args);
 }
 
-static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const CoreTaskArgs &args) {
+static TaskOutputTensors alloc_tensors_impl(RuntimeContext *rt, const CoreTaskArgs &args) {
     return rt->orchestrator->alloc_tensors(args);
 }
 
-static TaskOutputTensors submit_dummy_task_impl(PTO2Runtime *rt, const CoreTaskArgs &args) {
+static TaskOutputTensors submit_dummy_task_impl(RuntimeContext *rt, const CoreTaskArgs &args) {
     return rt->orchestrator->submit_dummy_task(args);
 }
 
-static GraphScopeResult graph_begin_impl(PTO2Runtime *rt, uint64_t graph_key, const GraphTaskArgs &args) {
+static GraphScopeResult graph_begin_impl(RuntimeContext *rt, uint64_t graph_key, const GraphTaskArgs &args) {
     if (rt == nullptr) return GraphScopeResult{};
     return rt->orchestrator->graph_begin(graph_key, args, rt->active_callable_hash);
 }
 
-static bool graph_prepare_impl(PTO2Runtime *rt, void *recording_handle, const GraphTaskArgs &args) {
+static bool graph_prepare_impl(RuntimeContext *rt, void *recording_handle, const GraphTaskArgs &args) {
     return rt != nullptr && rt->orchestrator->graph_prepare(recording_handle, args);
 }
 
-static void graph_abort_impl(PTO2Runtime *rt, void *recording_handle) {
+static void graph_abort_impl(RuntimeContext *rt, void *recording_handle) {
     if (rt != nullptr) rt->orchestrator->graph_abort(recording_handle);
 }
 
-static bool graph_end_impl(PTO2Runtime *rt) { return rt != nullptr && rt->orchestrator->graph_end(); }
+static bool graph_end_impl(RuntimeContext *rt) { return rt != nullptr && rt->orchestrator->graph_end(); }
 
 // The orchestration .so's phases arrive already bracketed, so this only forwards them
 // to the same pool the runtime's own records go to. Defined only at SIMPLER_DFX=1, like
@@ -122,19 +122,19 @@ static void record_orch_phase_impl(uint32_t kind, uint64_t start_ns, uint64_t en
 }
 #endif
 
-static void graph_commit_impl(PTO2Runtime *rt) {
+static void graph_commit_impl(RuntimeContext *rt) {
     if (rt != nullptr) rt->orchestrator->graph_commit();
 }
 
-void rt_scope_begin(PTO2Runtime *rt) {
+void rt_scope_begin(RuntimeContext *rt) {
     PTO2ScopeMode mode = rt->pending_scope_mode;
     rt->pending_scope_mode = PTO2ScopeMode::AUTO;
     rt->orchestrator->begin_scope(mode);
 }
 
-void rt_scope_end(PTO2Runtime *rt) { rt->orchestrator->end_scope(); }
+void rt_scope_end(RuntimeContext *rt) { rt->orchestrator->end_scope(); }
 
-void rt_orchestration_done(PTO2Runtime *rt) {
+void rt_orchestration_done(RuntimeContext *rt) {
     // Host orchestration calls this runtime entry directly rather than the
     // orchestration-SO wrapper. Commit here as well so an all-Graph entry has a
     // final synchronization point for its asynchronous recording and deferred
@@ -146,9 +146,9 @@ void rt_orchestration_done(PTO2Runtime *rt) {
     rt->inline_completed_tasks = rt->orchestrator->inline_completed_tasks;
 }
 
-static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator->fatal; }
+static bool is_fatal_impl(RuntimeContext *rt) { return rt->orchestrator->fatal; }
 
-void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...) {
+void rt_report_fatal(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     if (fmt == nullptr || fmt[0] == '\0') {
@@ -169,7 +169,7 @@ void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, cons
 // producer while one of its submitted consumers is still live.
 MAYBE_UNINITIALIZED_BEGIN
 static bool
-wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_consumers, const char *caller) {
+wait_for_tensor_ready(RuntimeContext *rt, const ChipTensor &tensor, bool wait_for_consumers, const char *caller) {
     TaskId owner = tensor.owner_task_id;
     PTO2OrchestratorState &orch = *rt->orchestrator;
 
@@ -320,7 +320,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
 }
 MAYBE_UNINITIALIZED_END
 
-uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]) {
+uint64_t get_tensor_data(RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]) {
     if (tensor.buffer.addr == 0) {
         unified_log_error(
             __FUNCTION__, "get_tensor_data: buffer not allocated (addr=0). "
@@ -350,7 +350,7 @@ uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndi
 }
 
 void set_tensor_data(
-    PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+    RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
 ) {
     if (tensor.buffer.addr == 0) {
         unified_log_error(
@@ -386,10 +386,10 @@ void set_tensor_data(
 static void scope_set_site_impl(const char *file, int line) { scope_stats_set_pending_site(file, line); }
 #endif
 
-static int32_t available_cluster_count_impl(PTO2Runtime *rt) { return rt->orchestrator->total_cluster_count; }
-static int32_t available_aiv_count_impl(PTO2Runtime *rt) { return rt->orchestrator->total_aiv_count; }
+static int32_t available_cluster_count_impl(RuntimeContext *rt) { return rt->orchestrator->total_cluster_count; }
+static int32_t available_aiv_count_impl(RuntimeContext *rt) { return rt->orchestrator->total_aiv_count; }
 
-static const PTO2RuntimeOps s_runtime_ops = {
+static const RuntimeOps s_runtime_ops = {
     .submit_task = submit_task_impl,
     .scope_begin = rt_scope_begin,
     .scope_end = rt_scope_end,
@@ -430,9 +430,9 @@ static const PTO2RuntimeOps s_runtime_ops = {
 // prebuilt arena image. The piece below — wiring the ops table — depends on the
 // device-side s_runtime_ops global, so it remains in the AICPU build.
 
-void runtime_bind_ops(PTO2Runtime *rt) { rt->ops = &s_runtime_ops; }
+void runtime_bind_ops(RuntimeContext *rt) { rt->ops = &s_runtime_ops; }
 
-void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode) {
+void runtime_set_mode(RuntimeContext *rt, RuntimeMode mode) {
     if (rt) {
         rt->mode = mode;
     }

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -12,7 +12,7 @@
  * Runtime Class - Device Execution and Handshake Control
  *
  * This class manages device-side execution through AICPU-AICore handshake
- * protocol. Task graph construction is handled by PTO2Runtime; this class
+ * protocol. Task graph construction is handled by RuntimeContext; this class
  * only handles:
  * - Handshake buffers for AICPU-AICore communication
  * - Execution parameters (block_dim, aicpu_thread_num)
@@ -135,7 +135,7 @@ struct Task {
  * Runtime class for device execution and handshake control
  *
  * This class manages AICPU-AICore communication through handshake buffers.
- * Task graph construction is handled by PTO2Runtime; this class only handles
+ * Task graph construction is handled by RuntimeContext; this class only handles
  * execution control and device orchestration state.
  */
 class Runtime {
@@ -252,7 +252,7 @@ public:
 
     // Prebuilt-arena fast path (trb only). Set by host's
     // bind_callable_to_runtime_impl; consumed by AICPU at boot to attach a
-    // DeviceArena to `prebuilt_arena_base_` and pick up the PTO2Runtime at
+    // DeviceArena to `prebuilt_arena_base_` and pick up the RuntimeContext at
     // `prebuilt_arena_base_ + prebuilt_runtime_offset_`. Both stay zero on
     // first construction (Runtime() ctor zeros them) so a non-prebuilt boot
     // path can still detect "no prebuilt image set" via nullptr.
@@ -292,7 +292,7 @@ public:
 
     // =========================================================================
     // Deprecated API (for platform compatibility, always returns 0/nullptr)
-    // Task graph is now managed by PTO2Runtime, not Runtime
+    // Task graph is now managed by RuntimeContext, not Runtime
     // =========================================================================
 
     /** @deprecated Task count is now in PTO2 shared memory */

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -185,7 +185,7 @@ private:
 
     void *gm_sm_ptr_;                        // GM pointer to PTO2 shared memory (device)
     void *gm_heap_ptr_;                      // GM heap for orchestrator output buffers (device)
-    void *slot_states_ptr_;                  // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
+    void *slot_states_ptr_;                  // Pointer to ChipTaskSlotState array (scheduler-private, for profiling)
     ChipStorageTaskArgs orch_args_storage_;  // Copy of args for device
 
     // Prebuilt-arena fast path (trb only). Set by the host before rtMemcpy'ing

--- a/src/a5/runtime/host_build_graph/runtime/runtime_core.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime_core.h
@@ -9,9 +9,9 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Main Interface
+ * Runtime core interface
  *
- * This is the main header for the PTO Runtime2 system.
+ * This is the main header for the runtime.
  * It provides a unified API for task graph construction and execution.
  *
  * Key Features:
@@ -22,7 +22,7 @@
  * - Orchestrator-Scheduler decoupling via shared memory
  *
  * Usage:
- *   1. Create runtime: PTO2Runtime create methods
+ *   1. Create runtime: RuntimeContext create methods
  *   2. Build task graph in orchestration function:
  *      - begin_scope() / end_scope()
  *      - submit_task()
@@ -54,7 +54,7 @@
 /**
  * Runtime execution mode
  */
-enum PTO2RuntimeMode {
+enum RuntimeMode {
     PTO2_MODE_EXECUTE = 0,    // Execute tasks on workers
     PTO2_MODE_SIMULATE = 1,   // Simulate task execution with cycle counting
     PTO2_MODE_GRAPH_ONLY = 2  // Build graph only, no execution
@@ -67,16 +67,16 @@ enum PTO2RuntimeMode {
  * (via orchestration_api.h inline wrappers), so it has zero link
  * dependencies on runtime .cpp files.
  */
-typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
+typedef struct RuntimeContext RuntimeContext;  // forward declare for ops signatures
 class HostTensorAccessor;
 
-struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
-    void (*scope_begin)(PTO2Runtime *rt);
-    void (*scope_end)(PTO2Runtime *rt);
-    void (*orchestration_done)(PTO2Runtime *rt);
-    bool (*is_fatal)(PTO2Runtime *rt);
-    void (*report_fatal)(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
+struct RuntimeOps {
+    TaskOutputTensors (*submit_task)(RuntimeContext *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
+    void (*scope_begin)(RuntimeContext *rt);
+    void (*scope_end)(RuntimeContext *rt);
+    void (*orchestration_done)(RuntimeContext *rt);
+    bool (*is_fatal)(RuntimeContext *rt);
+    void (*report_fatal)(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
     // Logging (populated by runtime, called by orchestration)
     void (*log_error)(const char *func, const char *fmt, ...);
@@ -87,22 +87,22 @@ struct PTO2RuntimeOps {
 
     // Cross-layer data access (orchestration reads/writes tensor values via runtime)
     // Placed after logging to avoid shifting hot-path field offsets.
-    uint64_t (*get_tensor_data)(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
+    uint64_t (*get_tensor_data)(RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
     void (*set_tensor_data)(
-        PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+        RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
     );
-    TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const CoreTaskArgs &args);
-    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const CoreTaskArgs &args);
+    TaskOutputTensors (*alloc_tensors)(RuntimeContext *rt, const CoreTaskArgs &args);
+    TaskOutputTensors (*submit_dummy_task)(RuntimeContext *rt, const CoreTaskArgs &args);
 
     // This-run core geometry latched by the host bind: MIX clusters
     // (one AIC each) and standalone AIV cores.
-    int32_t (*available_cluster_count)(PTO2Runtime *rt);
-    int32_t (*available_aiv_count)(PTO2Runtime *rt);
-    GraphScopeResult (*graph_begin)(PTO2Runtime *rt, uint64_t graph_key, const GraphTaskArgs &args);
-    bool (*graph_prepare)(PTO2Runtime *rt, void *recording_handle, const GraphTaskArgs &args);
-    void (*graph_abort)(PTO2Runtime *rt, void *recording_handle);
-    bool (*graph_end)(PTO2Runtime *rt);
-    void (*graph_commit)(PTO2Runtime *rt);
+    int32_t (*available_cluster_count)(RuntimeContext *rt);
+    int32_t (*available_aiv_count)(RuntimeContext *rt);
+    GraphScopeResult (*graph_begin)(RuntimeContext *rt, uint64_t graph_key, const GraphTaskArgs &args);
+    bool (*graph_prepare)(RuntimeContext *rt, void *recording_handle, const GraphTaskArgs &args);
+    void (*graph_abort)(RuntimeContext *rt, void *recording_handle);
+    bool (*graph_end)(RuntimeContext *rt);
+    void (*graph_commit)(RuntimeContext *rt);
     // Stash the call-site captured by ScopeGuard into the [ScopeStats]
     // collector. Always present in the struct to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
@@ -121,7 +121,7 @@ struct PTO2RuntimeOps {
  * runtime_reserve_layout(); consumed by runtime_init_data_from_layout and
  * runtime_wire_arena_pointers.
  */
-struct PTO2RuntimeArenaLayout {
+struct RuntimeArenaLayout {
     size_t off_sm_handle{0};
     PTO2SchedulerLayout sched;
     size_t off_scheduler{0};
@@ -165,14 +165,14 @@ struct PTO2RuntimeArenaLayout {
 };
 
 /**
- * PTO Runtime2 context
+ * Runtime context
  *
  * Contains all state for orchestration and scheduling.
  * In simulated mode, runs in single process with shared address space.
  */
-struct PTO2Runtime {
+struct RuntimeContext {
     // Ops table (first field — used by orchestration .so via function pointers)
-    const PTO2RuntimeOps *ops;
+    const RuntimeOps *ops;
     PTO2ScopeMode pending_scope_mode;
 
     // Components
@@ -193,7 +193,7 @@ struct PTO2Runtime {
     bool gm_heap_owned;  // True if we allocated it
 
     // Mode
-    PTO2RuntimeMode mode;
+    RuntimeMode mode;
 
     // Statistics
     int64_t total_cycles;
@@ -209,7 +209,7 @@ struct PTO2Runtime {
     // registered them. Null on the AICPU path, which loads device addresses
     // directly; get_tensor_data / set_tensor_data then fail closed rather than
     // dereferencing one. Lives past the first two fields, so the orchestration
-    // .so's partial PTO2Runtime definition neither sees nor needs it.
+    // .so's partial RuntimeContext definition neither sees nor needs it.
     HostTensorAccessor *tensor_access;
 
     // Prebuilt-arena fast path metadata. Carries every offset
@@ -220,7 +220,7 @@ struct PTO2Runtime {
     // *before* dereferencing this image. Populated on host by
     // runtime_init_data_from_layout + runtime_wire_arena_pointers; read by
     // aicpu_executor.cpp.
-    PTO2RuntimeArenaLayout prebuilt_layout;
+    RuntimeArenaLayout prebuilt_layout;
 };
 
 // bind copies this header to the device as one contiguous range, so every byte
@@ -228,8 +228,8 @@ struct PTO2Runtime {
 // otherwise non-trivial member — the orchestrator's scratch is reached through
 // a pointer for exactly this reason.
 static_assert(
-    std::is_trivially_copyable_v<PTO2Runtime> && std::is_standard_layout_v<PTO2Runtime>,
-    "PTO2Runtime is copied to the device verbatim"
+    std::is_trivially_copyable_v<RuntimeContext> && std::is_standard_layout_v<RuntimeContext>,
+    "RuntimeContext is copied to the device verbatim"
 );
 
 // =============================================================================
@@ -238,11 +238,11 @@ static_assert(
 
 /**
  * Phase 1 — declare every sub-region (sm_handle wrapper, scheduler / mailbox /
- * PTO2Runtime header) on the supplied arena. Pure arithmetic; does not touch
+ * RuntimeContext header) on the supplied arena. Pure arithmetic; does not touch
  * device memory and may run on host. Returns the layout descriptor; caller
  * commits/attaches the arena before Phase 2/3.
  */
-PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, uint64_t heap_size = 0);
+RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, uint64_t heap_size = 0);
 
 /**
  * Phase 2 — write the data half of the runtime arena: standalone fields,
@@ -254,15 +254,15 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_
  * them (never dereference). Safe to run on a host arena that owns a host
  * mirror of the runtime image — the resulting buffer is rtMemcpy-ready.
  *
- * Returns the PTO2Runtime* that sits at layout.off_runtime within the arena.
+ * Returns the RuntimeContext* that sits at layout.off_runtime within the arena.
  * Caller must follow up with runtime_wire_arena_pointers; rt->ops and the
  * AICore-side count fields are left untouched and must be filled by the
  * AICPU at boot. Initializes the scheduler only: the orchestrator is a
  * host-owned object the host-orch path (run_host_orchestration) stands up and
  * points rt->orchestrator at, and it is never uploaded to the device.
  */
-PTO2Runtime *runtime_init_data_from_layout(
-    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
+RuntimeContext *runtime_init_data_from_layout(
+    DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
     void *gm_heap_dev_base, uint64_t heap_size
 );
 
@@ -273,7 +273,7 @@ PTO2Runtime *runtime_init_data_from_layout(
  * holds arena.base() + offset. Idempotent — runs on both host (writing
  * host-mirror addresses) and AICPU (writing device addresses) sides.
  */
-void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
+void runtime_wire_arena_pointers(DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeContext *rt);
 
 /**
  * AICPU-only Phase 4 — install the ops table, the one field the host could not
@@ -281,7 +281,7 @@ void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayou
  * global, so the host cannot resolve its device address). Call once per boot
  * after runtime_wire_arena_pointers.
  */
-void runtime_bind_ops(PTO2Runtime *rt);
+void runtime_bind_ops(RuntimeContext *rt);
 
 /**
  * Destroy runtime. With the prebuilt-arena fast path the arena buffer is
@@ -289,12 +289,12 @@ void runtime_bind_ops(PTO2Runtime *rt);
  * here — the destructor only forgets sub-structure pointers (idempotent
  * cleanup).
  */
-void runtime_destroy(PTO2Runtime *rt, DeviceArena &arena);
+void runtime_destroy(RuntimeContext *rt, DeviceArena &arena);
 
 /**
  * Set execution mode
  */
-void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
+void runtime_set_mode(RuntimeContext *rt, RuntimeMode mode);
 
 // =============================================================================
 // Orchestration API (called by orchestration function)
@@ -306,10 +306,10 @@ void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
  * submit_task requires at least one open scope. A MANUAL scope additionally makes
  * every submit inside it bypass TensorMap discovery and take its fanin from
  * CoreTaskArgs::set_dependencies() instead; an AUTO scope nested inside a MANUAL
- * one is rejected. The mode is read from PTO2Runtime::pending_scope_mode, which
+ * one is rejected. The mode is read from RuntimeContext::pending_scope_mode, which
  * SIMPLER_SCOPE sets immediately before this call.
  */
-void rt_scope_begin(PTO2Runtime *rt);
+void rt_scope_begin(RuntimeContext *rt);
 
 /**
  * End current scope
@@ -319,24 +319,24 @@ void rt_scope_begin(PTO2Runtime *rt);
  * here: the ring is whole-graph-resident, so no task slot and no heap byte is
  * reclaimed before the run ends.
  */
-void rt_scope_end(PTO2Runtime *rt);
+void rt_scope_end(RuntimeContext *rt);
 
 /**
  * Mark orchestration as complete
  *
  * Signals that no more tasks will be submitted.
  */
-void rt_orchestration_done(PTO2Runtime *rt);
+void rt_orchestration_done(RuntimeContext *rt);
 
 /**
  * Enter fatal state explicitly from orchestration.
  */
-void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
+void rt_report_fatal(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
 /**
  * Cross-layer data access: read a tensor value by waiting for its producer.
  */
-uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
+uint64_t get_tensor_data(RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
 
 /**
  * Cross-layer data access: write a value to a tensor at given indices.
@@ -344,7 +344,7 @@ uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndi
  * See set_tensor_data in orchestration_api.h for full documentation.
  */
 void set_tensor_data(
-    PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+    RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
 );
 
 /**

--- a/src/a5/runtime/host_build_graph/runtime/runtime_core.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime_core.h
@@ -353,7 +353,7 @@ void set_tensor_data(
  */
 #ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
-struct PTO2OrchestrationConfig {
+struct OrchestrationConfig {
     int expected_arg_count;
 };
 #endif

--- a/src/a5/runtime/host_build_graph/runtime/runtime_core.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime_core.h
@@ -103,7 +103,7 @@ struct PTO2RuntimeOps {
     void (*graph_abort)(PTO2Runtime *rt, void *recording_handle);
     bool (*graph_end)(PTO2Runtime *rt);
     void (*graph_commit)(PTO2Runtime *rt);
-    // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]
+    // Stash the call-site captured by ScopeGuard into the [ScopeStats]
     // collector. Always present in the struct to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
     void (*scope_set_site)(const char *file, int line);
@@ -307,7 +307,7 @@ void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
  * every submit inside it bypass TensorMap discovery and take its fanin from
  * CoreTaskArgs::set_dependencies() instead; an AUTO scope nested inside a MANUAL
  * one is rejected. The mode is read from PTO2Runtime::pending_scope_mode, which
- * PTO2_SCOPE sets immediately before this call.
+ * SIMPLER_SCOPE sets immediately before this call.
  */
 void rt_scope_begin(PTO2Runtime *rt);
 

--- a/src/a5/runtime/host_build_graph/runtime/runtime_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime_types.h
@@ -190,7 +190,7 @@ struct PTO2OutputLayout {
 // Dependency List Entry
 // =============================================================================
 
-struct PTO2TaskSlotState;  // Forward declaration (defined below)
+struct ChipTaskSlotState;  // Forward declaration (defined below)
 
 // =============================================================================
 // Task Descriptor
@@ -201,7 +201,7 @@ struct PTO2TaskSlotState;  // Forward declaration (defined below)
  *
  * Stored in the TaskDescriptor ring buffer in shared memory.
  * Contains static identification and buffer pointers only.
- * Dynamic scheduling state (fanin/fanout/task_state) is in PTO2TaskSlotState.
+ * Dynamic scheduling state (fanin/fanout/task_state) is in ChipTaskSlotState.
  *
  * Fields set by Orchestrator at submission, read by Scheduler for dispatch.
  */
@@ -510,7 +510,7 @@ static_assert(sizeof(ChipTensor) == 128, "ChipTensor must be 2 cache lines");
  * deadlock detector, and the cold-path stall dump. completion_flags is the
  * device-side readiness truth; task_state is the host-visible mirror.
  */
-struct alignas(64) PTO2TaskSlotState {
+struct alignas(64) ChipTaskSlotState {
     // Highest local task id among this slot's consumers. Reclaim gate: the slot
     // is safe to retire once the per-ring completed_watermark reaches this id.
     // Whole-graph-resident hbg never reclaims at runtime, so this is
@@ -534,8 +534,8 @@ struct alignas(64) PTO2TaskSlotState {
     // that producer's wake list (CAS push through next_in_wake_list). On
     // completion the producer atomic-exchanges wake_list_head to
     // WAKE_LIST_SENTINEL and routes every waiter. Reset to nullptr at init.
-    std::atomic<PTO2TaskSlotState *> wake_list_head{nullptr};
-    PTO2TaskSlotState *next_in_wake_list{nullptr};
+    std::atomic<ChipTaskSlotState *> wake_list_head{nullptr};
+    ChipTaskSlotState *next_in_wake_list{nullptr};
 
     // --- Set per-submit (depend on task inputs) ---
     ActiveMask active_mask;  // Bitmask of active subtask slots (set once)
@@ -622,8 +622,8 @@ struct alignas(64) PTO2TaskSlotState {
     }
 };
 
-static_assert(sizeof(PTO2TaskSlotState) == 64);
+static_assert(sizeof(ChipTaskSlotState) == 64);
 
 // Sentinel marking a wake list as "owner already completed; no more
 // registrations accepted". Distinct from any real slot_state pointer.
-inline PTO2TaskSlotState *const WAKE_LIST_SENTINEL = reinterpret_cast<PTO2TaskSlotState *>(static_cast<uintptr_t>(0x1));
+inline ChipTaskSlotState *const WAKE_LIST_SENTINEL = reinterpret_cast<ChipTaskSlotState *>(static_cast<uintptr_t>(0x1));

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -63,7 +63,7 @@
  */
 struct PTO2ReadyQueueSlot {
     std::atomic<int64_t> sequence;
-    PTO2TaskSlotState *slot_state;
+    ChipTaskSlotState *slot_state;
     uint64_t task_id_snapshot;
 };
 
@@ -121,9 +121,9 @@ struct alignas(64) PTO2ReadyQueue {
                                  )) {}
     }
 
-    bool push(PTO2TaskSlotState *slot_state) { return push_tagged(slot_state, 0); }
+    bool push(ChipTaskSlotState *slot_state) { return push_tagged(slot_state, 0); }
 
-    bool push_tagged(PTO2TaskSlotState *slot_state, uint64_t task_id_snapshot) {
+    bool push_tagged(ChipTaskSlotState *slot_state, uint64_t task_id_snapshot) {
         uint64_t pos;
         PTO2ReadyQueueSlot *slot;
         while (true) {
@@ -155,9 +155,9 @@ struct alignas(64) PTO2ReadyQueue {
     // `count` items. A target slot holding an older generation means full and
     // ends the call; a slot a peer has reserved but not yet published is
     // transient and retries, so this only spins while a peer is mid-publish.
-    bool push_batch(PTO2TaskSlotState **items, int count) { return push_batch_tagged(items, nullptr, count); }
+    bool push_batch(ChipTaskSlotState **items, int count) { return push_batch_tagged(items, nullptr, count); }
 
-    bool push_batch_tagged(PTO2TaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
+    bool push_batch_tagged(ChipTaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
         if (count == 0) return true;
         if (static_cast<uint64_t>(count) > capacity) return false;
 
@@ -198,7 +198,7 @@ struct alignas(64) PTO2ReadyQueue {
     }
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
-    bool push(PTO2TaskSlotState *slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {
+    bool push(ChipTaskSlotState *slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {
         uint64_t pos;
         PTO2ReadyQueueSlot *slot;
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -237,9 +237,9 @@ struct alignas(64) PTO2ReadyQueue {
     }
 #endif
 
-    PTO2TaskSlotState *pop() { return pop_tagged(nullptr); }
+    ChipTaskSlotState *pop() { return pop_tagged(nullptr); }
 
-    PTO2TaskSlotState *pop_tagged(uint64_t *task_id_snapshot) {
+    ChipTaskSlotState *pop_tagged(uint64_t *task_id_snapshot) {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -264,14 +264,14 @@ struct alignas(64) PTO2ReadyQueue {
             }
         }
 
-        PTO2TaskSlotState *result = slot->slot_state;
+        ChipTaskSlotState *result = slot->slot_state;
         if (task_id_snapshot != nullptr) *task_id_snapshot = slot->task_id_snapshot;
         slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
 
 #if SIMPLER_SCHED_PROFILING
-    PTO2TaskSlotState *pop(uint64_t &atomic_count, uint64_t &wait_cycle) {
+    ChipTaskSlotState *pop(uint64_t &atomic_count, uint64_t &wait_cycle) {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -313,7 +313,7 @@ struct alignas(64) PTO2ReadyQueue {
             wait_cycle += (get_sys_cnt_aicpu() - t0);
         }
 
-        PTO2TaskSlotState *result = slot->slot_state;
+        ChipTaskSlotState *result = slot->slot_state;
         slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
@@ -321,9 +321,9 @@ struct alignas(64) PTO2ReadyQueue {
 
     // Batch pop: reserve a contiguous run of ready slots with a single CAS.
     // Returns actual number of items popped (may be less than max_count).
-    int pop_batch(PTO2TaskSlotState **out, int max_count) { return pop_batch_tagged(out, nullptr, max_count); }
+    int pop_batch(ChipTaskSlotState **out, int max_count) { return pop_batch_tagged(out, nullptr, max_count); }
 
-    int pop_batch_tagged(PTO2TaskSlotState **out, uint64_t *task_id_snapshots, int max_count) {
+    int pop_batch_tagged(ChipTaskSlotState **out, uint64_t *task_id_snapshots, int max_count) {
         uint64_t pos;
         int count;
         while (true) {
@@ -362,7 +362,7 @@ struct alignas(64) PTO2ReadyQueue {
     }
 
 #if SIMPLER_SCHED_PROFILING
-    int pop_batch(PTO2TaskSlotState **out, int max_count, uint64_t &atomic_count, uint64_t &wait_cycle) {
+    int pop_batch(ChipTaskSlotState **out, int max_count, uint64_t &atomic_count, uint64_t &wait_cycle) {
         uint64_t pos;
         int count;
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -537,13 +537,13 @@ struct PTO2SchedulerState {
         }
     }
 
-    bool push_graph_prepare(PTO2TaskSlotState *slot_state, uint64_t task_id, int32_t thread_idx) {
+    bool push_graph_prepare(ChipTaskSlotState *slot_state, uint64_t task_id, int32_t thread_idx) {
         if (graph_prepare_queue.push_tagged(slot_state, task_id)) return true;
         latch_ready_queue_overflow(thread_idx);
         return false;
     }
 
-    void push_ready_routed(PTO2TaskSlotState *slot_state) {
+    void push_ready_routed(ChipTaskSlotState *slot_state) {
         bool pushed;
         if (slot_state->task_kind == TaskKind::GRAPH) {
             pushed = graph_ready_queue.push(slot_state);
@@ -584,7 +584,7 @@ struct PTO2SchedulerState {
     // its first one completes) and the CAS traffic those transfers put on the
     // lists. The decision is terminal: tasks are never re-polled; a producer's
     // completion re-scans its waiters via on_mixed_task_complete's wake drain.
-    int classify_fanin_state(const PTO2TaskSlotState *s) const {
+    int classify_fanin_state(const ChipTaskSlotState *s) const {
         const PTO2TaskPayload &p = *s->payload;
         const PTO2SharedMemoryRingHeader &ring = *ring_sched_state.ring;
         const int32_t *fanin = p.fanin_data();
@@ -598,10 +598,10 @@ struct PTO2SchedulerState {
     // completed (head == SENTINEL), re-classify against ALL fanins: route to
     // ready only when every fanin is met, else re-target the next unmet producer
     // and retry. Monotonic completion_flags guarantee termination.
-    void register_wake(PTO2TaskSlotState *producer, PTO2TaskSlotState *consumer) {
+    void register_wake(ChipTaskSlotState *producer, ChipTaskSlotState *consumer) {
         PTO2SharedMemoryRingHeader &ring = *ring_sched_state.ring;
         while (true) {
-            PTO2TaskSlotState *expected = producer->wake_list_head.load(std::memory_order_relaxed);
+            ChipTaskSlotState *expected = producer->wake_list_head.load(std::memory_order_relaxed);
             while (expected != WAKE_LIST_SENTINEL) {
                 consumer->next_in_wake_list = expected;
                 if (producer->wake_list_head.compare_exchange_weak(
@@ -625,16 +625,16 @@ struct PTO2SchedulerState {
     // completed_watermark (load-bearing: the host wait_for_consumers gates on
     // watermark >= producer.last_consumer_local_id). Whole-graph-resident hbg
     // has no device slot reclaim, so no advance_ring_pointers here.
-    void on_mixed_task_complete(PTO2TaskSlotState &slot_state) {
+    void on_mixed_task_complete(ChipTaskSlotState &slot_state) {
         const int32_t task_id = static_cast<int32_t>(slot_state.task->task_id.local());
         PTO2SharedMemoryRingHeader &ring = *ring_sched_state.ring;
 
         slot_state.mark_completed();  // host-visible mirror (task_state = COMPLETED)
         ring.set_completion_flag(task_id);
 
-        PTO2TaskSlotState *waiter = slot_state.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
+        ChipTaskSlotState *waiter = slot_state.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
         while (waiter != nullptr && waiter != WAKE_LIST_SENTINEL) {
-            PTO2TaskSlotState *next = waiter->next_in_wake_list;
+            ChipTaskSlotState *next = waiter->next_in_wake_list;
             if (waiter->payload->fanin_count == 1) {
                 push_ready_routed(waiter);  // single-fanin waiter was waiting only on us
                 waiter = next;
@@ -764,7 +764,7 @@ struct PTO2SchedulerState {
         );
     }
 
-    inline void record_published_blocks(PTO2TaskSlotState &slot_state, int32_t count) {
+    inline void record_published_blocks(ChipTaskSlotState &slot_state, int32_t count) {
         if (count <= 0 || !slot_state.task_attrs.allow_early_resolve()) return;
         slot_state.payload->published_block_count.fetch_add(static_cast<int16_t>(count), std::memory_order_seq_cst);
     }
@@ -772,7 +772,7 @@ struct PTO2SchedulerState {
     // Ring one sync_start cohort from its stable staged_core_mask. The caller owns
     // the NONE->RINGING launch latch and invokes this exactly once after local or
     // global staging completes, while the corresponding per-core table entries are live.
-    inline void ring_all_staged_doorbells(PTO2TaskSlotState &slot_state) {
+    inline void ring_all_staged_doorbells(ChipTaskSlotState &slot_state) {
         for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
             uint64_t bits = slot_state.payload->staged_core_mask[w].load(std::memory_order_seq_cst);
             while (bits != 0) {
@@ -806,7 +806,7 @@ struct PTO2SchedulerState {
         return (previous & PTO2_EARLY_SYNC_DRAIN_OWNER) != 0;
     }
 
-    inline void cancel_early_sync_drain(PTO2TaskSlotState &slot_state) {
+    inline void cancel_early_sync_drain(ChipTaskSlotState &slot_state) {
         uint8_t previous =
             slot_state.payload->early_sync_drain_state.exchange(PTO2_EARLY_SYNC_DRAIN_NONE, std::memory_order_seq_cst);
         if ((previous & PTO2_EARLY_SYNC_DRAIN_OWNER) == 0) return;
@@ -839,7 +839,7 @@ struct PTO2SchedulerState {
     // release and each pending->running promotion); whichever observes the second half
     // wins the launch latch and rings exactly once. Returns true only to that winner,
     // which may then expose the cohort to its fanout.
-    inline bool maybe_rendezvous_ring(PTO2TaskSlotState &slot_state) {
+    inline bool maybe_rendezvous_ring(ChipTaskSlotState &slot_state) {
         // running_slot_count is the publication seed: every staged_core_mask OR
         // happens-before its final store. Read the seed first, then the mask, so
         // observing the final count cannot be paired with a partially published
@@ -862,7 +862,7 @@ struct PTO2SchedulerState {
         return true;
     }
 
-    inline bool retry_sync_start_rendezvous_after_staging(PTO2TaskSlotState &slot_state) {
+    inline bool retry_sync_start_rendezvous_after_staging(ChipTaskSlotState &slot_state) {
         if (!maybe_rendezvous_ring(slot_state)) return false;
         propagate_dispatch_fanin(slot_state);
         return true;
@@ -877,15 +877,15 @@ struct PTO2SchedulerState {
     // path (wake drain -> push_ready_routed). Milestone 2 replaces this with the
     // consumer-pull publish_flags design. sync_start cohorts still launch via
     // ready_sync_queues (unaffected).
-    void propagate_dispatch_fanin(PTO2TaskSlotState & /*p*/) {}
+    void propagate_dispatch_fanin(ChipTaskSlotState & /*p*/) {}
 
-    int get_ready_tasks_batch(PTO2ReadyQueue *queues, PTO2ResourceShape shape, PTO2TaskSlotState **out, int max_count) {
+    int get_ready_tasks_batch(PTO2ReadyQueue *queues, PTO2ResourceShape shape, ChipTaskSlotState **out, int max_count) {
         return queues[static_cast<int32_t>(shape)].pop_batch(out, max_count);
     }
 
 #if SIMPLER_SCHED_PROFILING
     int get_ready_tasks_batch(
-        PTO2ReadyQueue *queues, PTO2ResourceShape shape, PTO2TaskSlotState **out, int max_count, uint64_t &atomic_count,
+        PTO2ReadyQueue *queues, PTO2ResourceShape shape, ChipTaskSlotState **out, int max_count, uint64_t &atomic_count,
         uint64_t &wait_cycle
     ) {
         return queues[static_cast<int32_t>(shape)].pop_batch(out, max_count, atomic_count, wait_cycle);
@@ -895,13 +895,13 @@ struct PTO2SchedulerState {
     // Orch owns dependency discovery and saves the immutable fanin wire.
     // Scheduler polling only chooses which already-wired producer a consumer
     // waits on at this instant; it never recomputes producer relationships.
-    int32_t graph_first_unmet_producer(const GraphExecution &execution, const PTO2TaskSlotState &consumer) const {
+    int32_t graph_first_unmet_producer(const GraphExecution &execution, const ChipTaskSlotState &consumer) const {
         const uint32_t node_index = static_cast<uint32_t>(consumer.graph_node_index);
         const uint32_t begin = execution.fanin_offsets[node_index];
         const uint32_t end = execution.fanin_offsets[node_index + 1];
         for (uint32_t edge = begin; edge < end; ++edge) {
             const uint16_t producer_index = execution.fanin_indices[edge];
-            const PTO2TaskSlotState &producer = execution.node_at(producer_index).slot;
+            const ChipTaskSlotState &producer = execution.node_at(producer_index).slot;
             if (producer.task_state.load(std::memory_order_acquire) != PTO2_TASK_COMPLETED) {
                 return static_cast<int32_t>(producer_index);
             }
@@ -909,9 +909,9 @@ struct PTO2SchedulerState {
         return -1;
     }
 
-    void register_graph_wake(GraphExecution &execution, PTO2TaskSlotState *producer, PTO2TaskSlotState *consumer) {
+    void register_graph_wake(GraphExecution &execution, ChipTaskSlotState *producer, ChipTaskSlotState *consumer) {
         while (true) {
-            PTO2TaskSlotState *expected = producer->wake_list_head.load(std::memory_order_relaxed);
+            ChipTaskSlotState *expected = producer->wake_list_head.load(std::memory_order_relaxed);
             while (expected != WAKE_LIST_SENTINEL) {
                 consumer->next_in_wake_list = expected;
                 if (producer->wake_list_head.compare_exchange_weak(
@@ -933,11 +933,11 @@ struct PTO2SchedulerState {
         }
     }
 
-    uint32_t drain_graph_wake_list(GraphExecution &execution, PTO2TaskSlotState &producer) {
+    uint32_t drain_graph_wake_list(GraphExecution &execution, ChipTaskSlotState &producer) {
         uint32_t consumers_rescanned = 0;
-        PTO2TaskSlotState *waiter = producer.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
+        ChipTaskSlotState *waiter = producer.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
         while (waiter != nullptr && waiter != WAKE_LIST_SENTINEL) {
-            PTO2TaskSlotState *next = waiter->next_in_wake_list;
+            ChipTaskSlotState *next = waiter->next_in_wake_list;
             const int32_t unmet_producer = graph_first_unmet_producer(execution, *waiter);
             if (unmet_producer < 0) {
                 push_ready_routed(waiter);
@@ -987,7 +987,7 @@ struct PTO2SchedulerState {
     void graph_incremental_publish(GraphExecution &execution, int32_t first, int32_t last) {
         for (int32_t i = first; i < last; ++i) {
             if (execution.fanin_offsets[i] == execution.fanin_offsets[i + 1]) continue;  // root
-            PTO2TaskSlotState &node = execution.node_at(i).slot;
+            ChipTaskSlotState &node = execution.node_at(i).slot;
             const int32_t unmet = graph_first_unmet_producer(execution, node);
             if (unmet < 0) {
                 push_ready_routed(&node);
@@ -1007,7 +1007,7 @@ struct PTO2SchedulerState {
     }
 
     GraphMaterializeResult prepare_graph_task(
-        PTO2TaskSlotState &outer_slot, int32_t max_nodes = GRAPH_MATERIALIZE_SLICE_NODES,
+        ChipTaskSlotState &outer_slot, int32_t max_nodes = GRAPH_MATERIALIZE_SLICE_NODES,
         int32_t *nodes_materialized = nullptr
     ) {
         GraphExecution *execution = graph_execution_from_outer_slot(outer_slot);
@@ -1024,7 +1024,7 @@ struct PTO2SchedulerState {
         return result;
     }
 
-    int32_t activate_graph_task(PTO2TaskSlotState &outer_slot) {
+    int32_t activate_graph_task(ChipTaskSlotState &outer_slot) {
         GraphExecution *execution = graph_execution_from_outer_slot(outer_slot);
         if (execution == nullptr) return 0;
         graph_execution_signal_external_ready(*execution);
@@ -1038,7 +1038,7 @@ struct PTO2SchedulerState {
     };
 
     TaskCompletionOutcome complete_task(
-        PTO2TaskSlotState &slot_state
+        ChipTaskSlotState &slot_state
 #if SIMPLER_SCHED_PROFILING
         ,
         int thread_idx
@@ -1110,7 +1110,7 @@ struct PTO2SchedulerState {
      *
      * @return true if this was the last subtask, completing the entire task.
      */
-    bool on_subtask_complete(PTO2TaskSlotState &slot_state) {
+    bool on_subtask_complete(ChipTaskSlotState &slot_state) {
         int16_t prev = slot_state.completed_subtasks.fetch_add(1, std::memory_order_acq_rel);
         return (prev + 1) == slot_state.total_required_subtasks;
     }
@@ -1133,7 +1133,7 @@ struct PTO2SchedulerState {
     uint32_t
 #endif
     on_task_complete(
-        PTO2TaskSlotState &slot_state
+        ChipTaskSlotState &slot_state
 #if SIMPLER_SCHED_PROFILING
         ,
         int thread_idx
@@ -1206,7 +1206,7 @@ struct PTO2SchedulerState {
 // Polling: on_task_complete publishes completion + drains the wake list inline,
 // so the async-drain path no longer buffers producer releases.
 inline bool
-AsyncWaitList::try_inline_complete_locked(AsyncWaitList::DrainCompletionSink &sink, PTO2TaskSlotState &slot_state) {
+AsyncWaitList::try_inline_complete_locked(AsyncWaitList::DrainCompletionSink &sink, ChipTaskSlotState &slot_state) {
     // Return value (CompletionStats / consumer-walk count) discarded:
     // async-wait drain path has no Resolve swimlane bar attached.
 #if SIMPLER_SCHED_PROFILING

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -236,7 +236,7 @@ void SchedulerContext::log_stall_diagnostics(
         int32_t ring_task_count = ring.fc.current_task_index.load(std::memory_order_relaxed);
         submitted_in_ring += ring_task_count;
         for (int32_t si = 0; si < ring_task_count; si++) {
-            PTO2TaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
+            ChipTaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
             PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
             // Polling: no fanin_refcount. Recompute met/total from the inline
             // fanin ids vs the ring completion_flags (rc = satisfied producers,
@@ -396,7 +396,7 @@ int32_t SchedulerContext::handle_timeout_exit(
                 [this](int32_t func_id) {
                     return get_function_bin_addr(func_id);
                 },
-                [](const PTO2TaskSlotState &slot_state) {
+                [](const ChipTaskSlotState &slot_state) {
                     return &slot_state.payload->dump_metadata;
                 }
             );
@@ -1135,7 +1135,7 @@ void SchedulerContext::classify_partition(int32_t thread_idx, int32_t nthreads) 
         if (ring.is_completion_flag_set(id)) {
             continue;  // completed on the host (hidden alloc); nothing to dispatch
         }
-        PTO2TaskSlotState &slot = ring.get_slot_state_by_task_id(id);
+        ChipTaskSlotState &slot = ring.get_slot_state_by_task_id(id);
         if (slot.task_kind == TaskKind::GRAPH) {
             if (graph_execution_localize(slot) == nullptr) slot.graph_context = nullptr;
             if (!sched_->push_graph_prepare(&slot, slot.task->task_id.raw, thread_idx)) return;

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -1035,7 +1035,7 @@ void SchedulerContext::deinit() {
     func_id_to_addr_ = nullptr;
 }
 
-void SchedulerContext::bind_runtime(PTO2Runtime *rt) {
+void SchedulerContext::bind_runtime(RuntimeContext *rt) {
     rt_ = rt;
     sched_ = rt->scheduler;
 }
@@ -1049,7 +1049,7 @@ void SchedulerContext::bind_runtime(PTO2Runtime *rt) {
 // dispatching.
 // =============================================================================
 void SchedulerContext::on_orchestration_done(
-    Runtime *runtime, PTO2Runtime *rt, [[maybe_unused]] int32_t thread_idx, int32_t total_tasks
+    Runtime *runtime, RuntimeContext *rt, [[maybe_unused]] int32_t thread_idx, int32_t total_tasks
 ) {
     total_tasks_ = total_tasks;
 

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -81,7 +81,7 @@ SlotTransition SchedulerContext::decide_slot_transition(
 
 // Complete one slot's task: subtask counting, mixed completion, deferred release, profiling.
 void SchedulerContext::complete_slot_task(
-    PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, [[maybe_unused]] PTO2SubtaskSlot subslot,
+    ChipTaskSlotState &slot_state, int32_t expected_reg_task_id, [[maybe_unused]] PTO2SubtaskSlot subslot,
     int32_t thread_idx, int32_t core_id, Handshake *hank, [[maybe_unused]] int32_t &completed_this_turn
 #if SIMPLER_DFX
     ,
@@ -277,7 +277,7 @@ void SchedulerContext::check_running_cores_for_completion(
         // which point the core becomes pollable again and its FIN is caught.
         // Cheap cacheable load; no MMIO. Pending slot is empty while gated.
         {
-            PTO2TaskSlotState *rs = core.running_slot_state;
+            ChipTaskSlotState *rs = core.running_slot_state;
             if (rs != nullptr && rs->payload != nullptr &&
                 rs->payload->early_dispatch_state.load(std::memory_order_relaxed) == PTO2_EARLY_DISPATCH_STAGING) {
                 continue;
@@ -393,7 +393,7 @@ void SchedulerContext::check_running_cores_for_completion(
                 // rendezvous. Capture that BEFORE promote nulls the pending fields; after
                 // it lands, bump running_slot_count and ring iff this was the block that
                 // completed the cohort (and the producer already released).
-                PTO2TaskSlotState *promoted = core.pending_slot_state;
+                ChipTaskSlotState *promoted = core.pending_slot_state;
                 bool sync_start_promote = pending_gated && promoted->task_attrs.requires_sync_start();
                 promote_pending_to_running(core);  // Case 2 or Case 3 (with pending)
                 if (sync_start_promote) {
@@ -444,7 +444,7 @@ void SchedulerContext::check_running_cores_for_completion(
 // Two-phase protocol: CAS 0 -> -1 (sentinel) to claim ownership, store task and
 // reset staging state, then release-store block_num. Other threads acquire-load
 // sync_start_pending; seeing block_num > 0 ensures all relaxed stores are visible.
-bool SchedulerContext::enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t block_num) {
+bool SchedulerContext::enter_drain_mode(ChipTaskSlotState *slot_state, int32_t block_num) {
     int32_t expected = 0;
     if (!drain_state_.sync_start_pending.compare_exchange_strong(
             expected, -1, std::memory_order_acquire, std::memory_order_relaxed
@@ -493,7 +493,7 @@ int32_t SchedulerContext::count_global_available(PTO2ResourceShape shape, uint8_
 // block uses SPLIT placement (each core independently: idle->running, busy->pending) — safe
 // only because gated.
 SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
-    PTO2TaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated,
+    ChipTaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated,
     [[maybe_unused]] bool record_drain_phases
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -666,7 +666,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     }
     bool coordinator = thread_idx == 0;
 
-    PTO2TaskSlotState *slot_state = drain_state_.pending_task.load(std::memory_order_acquire);
+    ChipTaskSlotState *slot_state = drain_state_.pending_task.load(std::memory_order_acquire);
     // Null means this thread arrived after the drain it entered for had already
     // reopened, and no check above rejects it: the reopen below clears pending_task
     // before sync_start_pending, so a thread entering on a stale non-zero snapshot of

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -38,7 +38,7 @@ struct PTO2Runtime;
 
 // SPSC ring carrying completed-but-unresolved task slots from one scheduler (S)
 // thread to the dedicated resolution (P) thread. Whole-graph-resident hbg never
-// reclaims a slot, so the queued PTO2TaskSlotState* stays valid until P reads it.
+// reclaims a slot, so the queued ChipTaskSlotState* stays valid until P reads it.
 // Single producer (the owning S thread) / single consumer (P): plain
 // acquire/release on head/tail, no CAS. Capacity is a power of two sized to the
 // in-flight bound (min of total tasks and the ring window), so a producer does
@@ -47,7 +47,7 @@ struct PTO2Runtime;
 // make this type non-copyable / non-movable, so `buf` cannot be double-freed
 // through an accidental copy.
 struct CompletedTaskQueue {
-    PTO2TaskSlotState **buf{nullptr};
+    ChipTaskSlotState **buf{nullptr};
     uint64_t cap{0};
     uint64_t mask{0};
     alignas(64) std::atomic<uint64_t> head{0};  // consumer (P) cursor
@@ -57,7 +57,7 @@ struct CompletedTaskQueue {
         debug_assert(capacity_pow2 != 0 && (capacity_pow2 & (capacity_pow2 - 1)) == 0);
         cap = capacity_pow2;
         mask = capacity_pow2 - 1;
-        buf = new PTO2TaskSlotState *[capacity_pow2];
+        buf = new ChipTaskSlotState *[capacity_pow2];
         head.store(0, std::memory_order_relaxed);
         tail.store(0, std::memory_order_relaxed);
     }
@@ -66,7 +66,7 @@ struct CompletedTaskQueue {
         buf = nullptr;
     }
     // Producer (S). Spins only if the ring is full — sized so this never fires.
-    void push(PTO2TaskSlotState *s) {
+    void push(ChipTaskSlotState *s) {
         uint64_t t = tail.load(std::memory_order_relaxed);
         while (t - head.load(std::memory_order_acquire) >= cap) {
             SPIN_WAIT_HINT();
@@ -75,12 +75,12 @@ struct CompletedTaskQueue {
         tail.store(t + 1, std::memory_order_release);
     }
     // Consumer (P). Returns nullptr when empty.
-    PTO2TaskSlotState *pop() {
+    ChipTaskSlotState *pop() {
         uint64_t h = head.load(std::memory_order_relaxed);
         if (h == tail.load(std::memory_order_acquire)) {
             return nullptr;
         }
-        PTO2TaskSlotState *s = buf[h & mask];
+        ChipTaskSlotState *s = buf[h & mask];
         head.store(h + 1, std::memory_order_release);
         return s;
     }
@@ -299,11 +299,11 @@ private:
     }
 
     int pop_ready_tasks_batch(
-        PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, PTO2TaskSlotState **out, int max_count
+        PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, ChipTaskSlotState **out, int max_count
     );
 
     void build_payload(
-        PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
+        PTO2DispatchPayload &dispatch_payload, ChipTaskSlotState &slot_state, PTO2SubtaskSlot subslot,
         int32_t block_idx, bool force_gate
     );
 
@@ -325,7 +325,7 @@ private:
     };
 
     PublishHandle prepare_subtask_to_core(
-        int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
+        int32_t thread_idx, int32_t core_offset, ChipTaskSlotState &slot_state, PTO2SubtaskSlot subslot,
         bool to_pending, int32_t block_idx, bool force_gate
     );
 
@@ -380,7 +380,7 @@ private:
     // Fan out one block's subtasks (1 for AIC/AIV, 1-3 for MIX) into the
     // caller-supplied handles buffer. Returns the number of handles written.
     int prepare_block_for_dispatch(
-        int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2ResourceShape shape,
+        int32_t thread_idx, int32_t core_offset, ChipTaskSlotState &slot_state, PTO2ResourceShape shape,
         bool to_pending, int32_t block_idx, PublishHandle *out_handles, bool force_gate = false
     );
 
@@ -407,7 +407,7 @@ private:
     // concurrently with peers (mirrors the normal SPMD dispatch path). Returns the
     // number of blocks staged.
     int32_t stage_consumer_blocks(
-        int32_t thread_idx, PTO2TaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
+        int32_t thread_idx, ChipTaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
         CoreTracker::BitStates &idle, CoreTracker::BitStates &pend
     );
 
@@ -484,7 +484,7 @@ private:
     );
 
     void complete_slot_task(
-        PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
+        ChipTaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
         int32_t core_id, Handshake *hank, int32_t &completed_this_turn
 #if SIMPLER_DFX
         ,
@@ -500,7 +500,7 @@ private:
         bool &made_progress
     );
 
-    bool enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t block_num);
+    bool enter_drain_mode(ChipTaskSlotState *slot_state, int32_t block_num);
     int32_t count_global_available(PTO2ResourceShape shape, uint8_t core_mask, bool include_pending = false);
     struct SyncStartStageResult {
         int32_t staged_blocks{0};
@@ -511,7 +511,7 @@ private:
     // the local fast path invokes it once after proving this tracker has enough
     // capacity. record_drain_phases keeps local work attributed to EarlyDispatch.
     SyncStartStageResult stage_sync_start_cores(
-        PTO2TaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated, bool record_drain_phases
+        ChipTaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated, bool record_drain_phases
     );
     // out_stage_wall_cycles (profiling only): cycles this thread spent in stage_sync_start_cores
     // (prepare + publish), set ONLY on threads that actually staged. Lets the caller isolate

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -34,7 +34,7 @@
 // Forward declarations — avoid pulling in full headers for pointer/reference params.
 class Runtime;
 struct Handshake;
-struct PTO2Runtime;
+struct RuntimeContext;
 
 // SPSC ring carrying completed-but-unresolved task slots from one scheduler (S)
 // thread to the dedicated resolution (P) thread. Whole-graph-resident hbg never
@@ -159,7 +159,7 @@ public:
     //    (skipped on fatal error — emergency_shutdown runs instead)
     // Callers must invoke rt_orchestration_done(rt) before this — that
     // step belongs to the orchestrator lifecycle, not the scheduler.
-    void on_orchestration_done(Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks);
+    void on_orchestration_done(Runtime *runtime, RuntimeContext *rt, int32_t thread_idx, int32_t total_tasks);
 
     // Seed the ready queues + wake lists for the whole graph at boot. Called by
     // every AICPU thread on a disjoint slice of the submitted-task range, after
@@ -168,8 +168,8 @@ public:
     // register_wake are the same lock-free primitives used during the run.
     void classify_partition(int32_t thread_idx, int32_t nthreads);
 
-    // Bind the PTO2Runtime scheduler pointer.
-    void bind_runtime(PTO2Runtime *rt);
+    // Bind the RuntimeContext scheduler pointer.
+    void bind_runtime(RuntimeContext *rt);
 
     // =========================================================================
     // State queries / external synchronization points
@@ -189,7 +189,7 @@ private:
 
     // --- Scheduler binding & per-core runtime state ---
     alignas(64) PTO2SchedulerState *sched_{nullptr};
-    PTO2Runtime *rt_{nullptr};
+    RuntimeContext *rt_{nullptr};
 
     // Per-core execution state, indexed by core_id (= worker_id)
     CoreExecState core_exec_states_[RUNTIME_MAX_WORKER];

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -92,7 +92,7 @@ bool SchedulerContext::has_idle_in_other_threads(int32_t self_thread_idx, PTO2Re
 }
 
 int SchedulerContext::pop_ready_tasks_batch(
-    PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, PTO2TaskSlotState **out, int max_count
+    PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, ChipTaskSlotState **out, int max_count
 ) {
 #if SIMPLER_DFX
     auto &chip_swimlane = sched_chip_swimlane_[thread_idx];
@@ -121,7 +121,7 @@ int SchedulerContext::pop_ready_tasks_batch(
 }
 
 void SchedulerContext::build_payload(
-    PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot, int32_t block_idx,
+    PTO2DispatchPayload &dispatch_payload, ChipTaskSlotState &slot_state, PTO2SubtaskSlot subslot, int32_t block_idx,
     bool force_gate
 ) {
     int32_t slot_idx = static_cast<int32_t>(subslot);
@@ -169,7 +169,7 @@ void SchedulerContext::build_payload(
 }
 
 SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
-    int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot, bool to_pending,
+    int32_t thread_idx, int32_t core_offset, ChipTaskSlotState &slot_state, PTO2SubtaskSlot subslot, bool to_pending,
     int32_t block_idx, bool force_gate
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -242,7 +242,7 @@ SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
 }
 
 int SchedulerContext::prepare_block_for_dispatch(
-    int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2ResourceShape shape, bool to_pending,
+    int32_t thread_idx, int32_t core_offset, ChipTaskSlotState &slot_state, PTO2ResourceShape shape, bool to_pending,
     int32_t block_idx, PublishHandle *out_handles, bool force_gate
 ) {
 #if SIMPLER_DFX
@@ -328,7 +328,7 @@ void SchedulerContext::dispatch_shape(
 
     while (cores.has_value() && !entered_drain) {
         int want = cores.count();
-        PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
+        ChipTaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
         int got = pop_ready_tasks_batch(disp_queues, shape, thread_idx, batch, want);
         if (got == 0) break;
 
@@ -369,7 +369,7 @@ void SchedulerContext::dispatch_shape(
         bool dispatched_any = false;
         // Logical block ranges published by this pop. AIV can pop two entries per
         // cluster, so this ledger has the same worst-case bound as handles[].
-        PTO2TaskSlotState *published_list[CoreTracker::MAX_CLUSTERS * 3];
+        ChipTaskSlotState *published_list[CoreTracker::MAX_CLUSTERS * 3];
         int16_t published_counts[CoreTracker::MAX_CLUSTERS * 3];
         int published_n = 0;
 #if SIMPLER_SCHED_PROFILING
@@ -396,7 +396,7 @@ void SchedulerContext::dispatch_shape(
         };
 
         for (int bi = 0; bi < got; bi++) {
-            PTO2TaskSlotState *slot_state = batch[bi];
+            ChipTaskSlotState *slot_state = batch[bi];
             CoreTracker::BitStates selected_mix_clusters(0ULL);
 
             if (is_mix) {
@@ -620,7 +620,7 @@ void SchedulerContext::dispatch_ready_tasks(
 // those release did not take and rings them from its immutable local handles.
 // The seq_cst order guarantees every gated core has exactly one writer.
 int32_t SchedulerContext::stage_consumer_blocks(
-    int32_t thread_idx, PTO2TaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
+    int32_t thread_idx, ChipTaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
     CoreTracker::BitStates &idle, CoreTracker::BitStates &pend
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -720,7 +720,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
     if (!cores.has_value()) return 0;
 
     int32_t total_staged = 0;
-    PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
+    ChipTaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
     uint64_t task_id_snapshots[CoreTracker::MAX_CLUSTERS * 3];
     // Batch-pop in one queue op (fewer CAS than one pop per consumer); the pop is
     // bounded by the shape's capacity so the stack buffer always holds it. Then for
@@ -735,7 +735,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
     // the unconsumed tail).
     int got = sched_->early_dispatch_queues[s].pop_batch_tagged(batch, task_id_snapshots, cores.count());
     for (int bi = 0; bi < got; bi++) {
-        PTO2TaskSlotState *c = batch[bi];
+        ChipTaskSlotState *c = batch[bi];
         if (static_cast<uint64_t>(c->task->task_id.raw) != task_id_snapshots[bi]) continue;
         if (c->payload->early_dispatch_state.load(std::memory_order_acquire) != PTO2_EARLY_DISPATCH_STAGING)
             continue;  // released
@@ -822,7 +822,7 @@ int32_t SchedulerContext::try_early_dispatch(
     // stop-the-world drain. Both paths force-gate every block even if producer release races
     // STAGING -> DISPATCHED. A non-STAGING pop was already released and is dropped.
     uint64_t sync_task_id_snapshot = 0;
-    if (PTO2TaskSlotState *c = sched_->early_sync_start_queue.pop_tagged(&sync_task_id_snapshot)) {
+    if (ChipTaskSlotState *c = sched_->early_sync_start_queue.pop_tagged(&sync_task_id_snapshot)) {
         bool current_sync_task =
             static_cast<uint64_t>(c->task->task_id.raw) == sync_task_id_snapshot && c->task_attrs.requires_sync_start();
         if (current_sync_task && PTO2SchedulerState::try_claim_early_sync_drain(*c->payload)) {
@@ -922,7 +922,7 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
         int32_t resolved_this_pass = 0;
         bool resolved_any = false;
         for (int32_t s = 0; s < active_sched_threads_ && !completed_.load(std::memory_order_acquire); s++) {
-            PTO2TaskSlotState *slot;
+            ChipTaskSlotState *slot;
             while ((slot = sp_queues_[s].pop()) != nullptr) {
 #if SIMPLER_SCHED_PROFILING
                 PTO2SchedulerState::TaskCompletionOutcome outcome = sched_->complete_task(*slot, thread_idx);
@@ -966,7 +966,7 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
         // resolution can make further dummies ready in the same pass.
         {
             constexpr int DUMMY_DRAIN_BATCH = 8;
-            PTO2TaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
+            ChipTaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
             int dummy_got;
             while ((dummy_got = sched_->dummy_ready_queue.pop_batch(dummy_batch, DUMMY_DRAIN_BATCH)) > 0) {
                 for (int di = 0; di < dummy_got; di++) {
@@ -1306,7 +1306,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         // slice per loop prevents a large definition from monopolizing a
         // scheduler thread.
         if (thread_idx < active_sched_threads_) {
-            PTO2TaskSlotState *graph_slot = sched_->graph_ready_queue.pop();
+            ChipTaskSlotState *graph_slot = sched_->graph_ready_queue.pop();
             if (graph_slot != nullptr) {
                 if (graph_slot->task != nullptr && graph_slot->task_kind == TaskKind::GRAPH) {
                     (void)sched_->activate_graph_task(*graph_slot);
@@ -1318,7 +1318,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             }
 
             uint64_t prepare_task_id = 0;
-            PTO2TaskSlotState *prepare_slot = sched_->graph_prepare_queue.pop_tagged(&prepare_task_id);
+            ChipTaskSlotState *prepare_slot = sched_->graph_prepare_queue.pop_tagged(&prepare_task_id);
             if (prepare_slot != nullptr) {
                 const bool valid_slot = prepare_slot->task != nullptr && prepare_slot->task_kind == TaskKind::GRAPH &&
                                         prepare_slot->task->task_id.raw == prepare_task_id;

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
@@ -19,7 +19,7 @@
 #include "runtime_types.h"
 #include "spin_hint.h"
 
-// host_build_graph host-orch build: PTO2Runtime embeds PTO2SchedulerState by
+// host_build_graph host-orch build: RuntimeContext embeds PTO2SchedulerState by
 // value, so this header is compiled into the host libhost_runtime.so. The AICPU
 // spin_hint.h that defines PLATFORM_SCHEDULER_TIMEOUT_MS is not on the host
 // include path; supply it here. The value only sizes an on-device scheduler

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
@@ -106,8 +106,8 @@ enum class LoopAction : int8_t {
 struct alignas(64) CoreExecState {
     // --- Hot fields (completion + dispatch, every iteration) ---
     uint64_t reg_addr;                      // offset  0: register base address (set once in handshake)
-    PTO2TaskSlotState *running_slot_state;  // offset  8: slot state for running task (nullptr = empty)
-    PTO2TaskSlotState *pending_slot_state;  // offset 16: slot state for pending task (nullptr = empty)
+    ChipTaskSlotState *running_slot_state;  // offset  8: slot state for running task (nullptr = empty)
+    ChipTaskSlotState *pending_slot_state;  // offset 16: slot state for pending task (nullptr = empty)
     int32_t running_reg_task_id;            // offset 24: register task ID (AICPU_TASK_INVALID = idle)
     int32_t pending_reg_task_id;            // offset 28: pending register task ID (AICPU_TASK_INVALID = none)
     uint32_t dispatch_seq;                  // offset 32: monotonic dispatch counter
@@ -579,7 +579,7 @@ struct alignas(64) SchedChipSwimlaneCounters {
 // (only process completions) until the fixed coordinator finishes launching all blocks.
 struct alignas(64) SyncStartDrainState {
     std::atomic<int32_t> sync_start_pending{0};              // 0=normal; -1=initializing; >0=active (value=block_num)
-    std::atomic<PTO2TaskSlotState *> pending_task{nullptr};  // held task (not re-queued)
+    std::atomic<ChipTaskSlotState *> pending_task{nullptr};  // held task (not re-queued)
     std::atomic<uint64_t> drain_attempt{0};                  // incremented whenever an ack round is reset
     // Parallel staging: after the coordinator confirms global availability it sets
     // stage_go, releasing every thread to stage its OWN cores concurrently (vs the old

--- a/src/a5/runtime/host_build_graph/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/runtime.cpp
@@ -12,7 +12,7 @@
  * Runtime Class - Implementation
  *
  * Device execution and handshake control.
- * Task graph construction is handled by PTO2Runtime.
+ * Task graph construction is handled by RuntimeContext.
  */
 
 #include "runtime.h"

--- a/src/a5/runtime/host_build_graph/runtime/shared/runtime_init.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/runtime_init.cpp
@@ -253,13 +253,13 @@ void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler) { this-
 // Top-level runtime arena
 // =============================================================================
 
-PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, uint64_t heap_size) {
-    PTO2RuntimeArenaLayout layout{};
+RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, uint64_t heap_size) {
+    RuntimeArenaLayout layout{};
 
     layout.task_window_size = task_window_size;
     layout.heap_size = heap_size;
 
-    // Reservation order is the zone partition (see PTO2RuntimeArenaLayout):
+    // Reservation order is the zone partition (see RuntimeArenaLayout):
     // everything the device initializes itself, then the one copied range. Each
     // zone is contiguous, so bind is a single copy and no consumer has to infer a
     // boundary from what happens to come first.
@@ -274,7 +274,7 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_
     layout.off_copied_begin = arena.total_size();
     // Padded to a PTO2_ALIGN_SIZE boundary: the shared-memory image starts at
     // off_copied_end on the device and its segment offsets are aligned from there.
-    layout.off_runtime = arena.reserve(PTO2_ALIGN_UP(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE), PTO2_ALIGN_SIZE);
+    layout.off_runtime = arena.reserve(PTO2_ALIGN_UP(sizeof(RuntimeContext), PTO2_ALIGN_SIZE), PTO2_ALIGN_SIZE);
     layout.off_copied_end = arena.total_size();
 
     layout.arena_size = arena.total_size();
@@ -284,19 +284,19 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_
 /**
  * Populate the prebuilt runtime-arena image in place (host build path).
  *
- * Zeroes the PTO2Runtime header at layout.off_runtime, records the GM heap,
+ * Zeroes the RuntimeContext header at layout.off_runtime, records the GM heap,
  * and initializes the scheduler (ready / sync / dummy / graph queues) against
  * the device SM. rt->orchestrator is left null: the orchestrator is a host-owned
  * object the host-orch path (run_host_orchestration) stands up against the host
  * SM once that buffer exists, and it is never uploaded to the device. Caller must
  * follow up with runtime_wire_arena_pointers. Returns the arena-resident
- * PTO2Runtime*, or nullptr on failure.
+ * RuntimeContext*, or nullptr on failure.
  */
-PTO2Runtime *runtime_init_data_from_layout(
-    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
-    uint64_t /*sm_size*/, void *gm_heap_dev_base, uint64_t heap_size
+RuntimeContext *runtime_init_data_from_layout(
+    DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t /*sm_size*/,
+    void *gm_heap_dev_base, uint64_t heap_size
 ) {
-    PTO2Runtime *rt = static_cast<PTO2Runtime *>(arena.region_ptr(layout.off_runtime));
+    RuntimeContext *rt = static_cast<RuntimeContext *>(arena.region_ptr(layout.off_runtime));
     memset(rt, 0, sizeof(*rt));
 
     // rt->ops is filled by the AICPU at boot.
@@ -322,14 +322,14 @@ PTO2Runtime *runtime_init_data_from_layout(
     return rt;
 }
 
-void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt) {
+void runtime_wire_arena_pointers(DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeContext *rt) {
     rt->sm_handle = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(layout.off_sm_handle));
     rt->aicore_mailbox = static_cast<AICoreCompletionMailbox *>(arena.region_ptr(layout.off_mailbox));
     rt->scheduler = static_cast<PTO2SchedulerState *>(arena.region_ptr(layout.off_scheduler));
     rt->scheduler->wire_arena_pointers(layout.sched, arena);
 }
 
-void runtime_destroy(PTO2Runtime *rt, DeviceArena & /*arena*/) {
+void runtime_destroy(RuntimeContext *rt, DeviceArena & /*arena*/) {
     // Arena buffer is pooled across runs by DeviceRunner — never freed here.
     if (!rt) return;
     rt->scheduler->destroy();

--- a/src/a5/runtime/host_build_graph/runtime/shared/shared_memory.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/shared_memory.cpp
@@ -53,7 +53,7 @@ void PTO2SharedMemoryHandle::setup_pointers(uint64_t pitch) {
     auto &ring = header->ring;
     ring.task_descriptors = (PTO2TaskDescriptor *)(base + off.descriptors);
     ring.task_payloads = (PTO2TaskPayload *)(base + off.payloads);
-    ring.slot_states = (PTO2TaskSlotState *)(base + off.slot_states);
+    ring.slot_states = (ChipTaskSlotState *)(base + off.slot_states);
     ring.completion_flags = (std::atomic<uint8_t> *)(base + off.completion_flags);
 }
 
@@ -158,7 +158,7 @@ void PTO2SharedMemoryHandle::init_header(uint64_t task_window_size, uint64_t hea
     header->ring.task_descriptors_offset = offset;
     offset += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
     offset += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
-    offset += PTO2_ALIGN_UP(task_window_size * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
+    offset += PTO2_ALIGN_UP(task_window_size * sizeof(ChipTaskSlotState), PTO2_ALIGN_SIZE);
 
     header->total_size = sm_size;
 

--- a/src/a5/runtime/host_build_graph/runtime/shared_memory.h
+++ b/src/a5/runtime/host_build_graph/runtime/shared_memory.h
@@ -94,7 +94,7 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     // Per-ring data pointers (host-side, set by setup_pointers)
     PTO2TaskDescriptor *task_descriptors;
     PTO2TaskPayload *task_payloads;
-    PTO2TaskSlotState *slot_states;
+    ChipTaskSlotState *slot_states;
 
     // Polling-completion state (device-addressed array, one byte per slot).
     // 0 = pending, 1 = task fully COMPLETED. Writer = the task's completer at
@@ -149,9 +149,9 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     // through its slot state's `payload` delta, which the image's restack rebinds to
     // the real address.
 
-    PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
+    ChipTaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
-    PTO2TaskSlotState &get_slot_state_by_task_id(int32_t local_id) {
+    ChipTaskSlotState &get_slot_state_by_task_id(int32_t local_id) {
         return slot_states[get_slot_by_task_id(local_id)];
     }
 };
@@ -354,7 +354,7 @@ inline PTO2RingSegmentOffsets ring_segment_offsets(const RingImageExtents &e) no
     o.payloads = off;
     off += PTO2_ALIGN_UP(e.slots * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
     o.slot_states = off;
-    off += PTO2_ALIGN_UP(e.slots * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
+    off += PTO2_ALIGN_UP(e.slots * sizeof(ChipTaskSlotState), PTO2_ALIGN_SIZE);
     o.completion_flags = off;
     off += PTO2_ALIGN_UP(e.slots * sizeof(std::atomic<uint8_t>), PTO2_ALIGN_SIZE);
     o.fanin_pool = off;
@@ -453,13 +453,13 @@ compact_live_image(const char *mirror_base, uint64_t task_window_size, const Bin
     // One copy, not one per payload: PTO2TaskPayload is fixed-size, so the mirror and
     // the image share a stride. Each pool is likewise one copy of its own prefix.
     std::memcpy(out_base + to.payloads, mirror_base + from.payloads, nt * sizeof(PTO2TaskPayload));
-    std::memcpy(out_base + to.slot_states, mirror_base + from.slot_states, nt * sizeof(PTO2TaskSlotState));
+    std::memcpy(out_base + to.slot_states, mirror_base + from.slot_states, nt * sizeof(ChipTaskSlotState));
     std::memcpy(out_base + to.completion_flags, mirror_base + from.completion_flags, nt * sizeof(std::atomic<uint8_t>));
     std::memcpy(out_base + to.fanin_pool, mirror_base + from.fanin_pool, used.fanin_elems * sizeof(int32_t));
     std::memcpy(out_base + to.tensor_pool, mirror_base + from.tensor_pool, used.tensor_elems * sizeof(ChipTensor));
     std::memcpy(out_base + to.scalar_pool, mirror_base + from.scalar_pool, used.scalar_elems * sizeof(uint64_t));
 
-    auto *out_slots = reinterpret_cast<PTO2TaskSlotState *>(out_base + to.slot_states);
+    auto *out_slots = reinterpret_cast<ChipTaskSlotState *>(out_base + to.slot_states);
     auto *out_descriptors = reinterpret_cast<PTO2TaskDescriptor *>(out_base + to.descriptors);
     auto *out_payloads = reinterpret_cast<PTO2TaskPayload *>(out_base + to.payloads);
     const auto *mirror_payloads = reinterpret_cast<const PTO2TaskPayload *>(mirror_base + from.payloads);

--- a/src/a5/runtime/host_build_graph/runtime/submit_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/submit_types.h
@@ -167,7 +167,7 @@ private:
 static_assert(sizeof(ActiveMask) == 1, "ActiveMask must be exactly 1 byte");
 
 /**
- * Per-task scheduling attributes, packed into one byte on PTO2TaskSlotState.
+ * Per-task scheduling attributes, packed into one byte on ChipTaskSlotState.
  *
  * Single home for the independent per-task flags: an early-dispatch hint, the
  * two dispatch-time predicates (sync_start / has_predicate), and the selective

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -664,7 +664,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 rt->orchestrator.chip_swimlane_level = get_chip_swimlane_level();
                 {
                     auto &orch = rt->orchestrator;
-                    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+                    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
                         auto &alloc = orch.rings[r].task_allocator;
                         scope_stats_set_ring_capacity(
                             r, alloc.window_size(), alloc.heap_capacity(),
@@ -813,7 +813,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // submit_task().
             int32_t total_tasks = 0;
             if (rt->orchestrator.sm_header) {
-                for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+                for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
                     total_tasks +=
                         rt->orchestrator.sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
                 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -32,7 +32,7 @@
 #include "runtime.h"
 #include "spin_hint.h"
 
-// Runtime headers (full struct definition for create/destroy + PTO2_SCOPE)
+// Runtime headers (full struct definition for create/destroy + SIMPLER_SCOPE)
 #include "runtime_core.h"
 #include "runtime_types.h"
 #include "shared_memory.h"

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -64,17 +64,17 @@
 #include "scheduler/scheduler_context.h"
 
 // Device orchestration function signature (loaded via dlopen).
-// The executor binds the current thread's PTO2Runtime into orchestration TLS
+// The executor binds the current thread's RuntimeContext into orchestration TLS
 // before calling the user entry.
 typedef void (*DeviceOrchestrationFunc)(const ChipTaskArgs &orch_args);
-typedef void (*DeviceOrchestrationBindRuntimeFunc)(PTO2Runtime *rt);
+typedef void (*DeviceOrchestrationBindRuntimeFunc)(RuntimeContext *rt);
 
 // Config function exported by orchestration .so
 typedef OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipTaskArgs &orch_args);
 
 // From orchestration/common.cpp linked into this DSO — updates g_current_runtime here (distinct from
 // framework_bind_runtime in the dlopen'd libdevice_orch_*.so).
-extern "C" void framework_bind_runtime(PTO2Runtime *rt);
+extern "C" void framework_bind_runtime(RuntimeContext *rt);
 
 constexpr const char *DEFAULT_ORCH_ENTRY_SYMBOL = "aicpu_orchestration_entry";
 constexpr const char *DEFAULT_ORCH_CONFIG_SYMBOL = "aicpu_orchestration_config";
@@ -95,7 +95,7 @@ static int32_t read_runtime_status(Runtime *runtime) {
     return runtime_status_from_error_codes(orch_error_code, sched_error_code);
 }
 
-static PTO2Runtime *rt{nullptr};
+static RuntimeContext *rt{nullptr};
 
 // Per-callable_id orchestration SO table. The executor dispatches
 // `orch_so_table_[active_callable_id_]` (created on first sighting of
@@ -610,7 +610,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                     return -1;
                 }
                 runtime_arena_.attach(prebuilt_arena, DeviceArena::kDefaultBaseAlign);
-                rt = reinterpret_cast<PTO2Runtime *>(static_cast<char *>(prebuilt_arena) + off_runtime);
+                rt = reinterpret_cast<RuntimeContext *>(static_cast<char *>(prebuilt_arena) + off_runtime);
 
                 // Wire every arena-internal pointer field (host wrote host-mirror
                 // addresses; we overwrite them with device addresses).
@@ -675,7 +675,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 }
 #endif
 
-                // Wire scheduler context to the newly created PTO2Runtime before
+                // Wire scheduler context to the newly created RuntimeContext before
                 // releasing scheduler threads from runtime_init_ready_.
                 sched_ctx_.bind_runtime(rt);
             }
@@ -889,7 +889,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
     if (prev_finished + 1 == aicpu_thread_num_) {
         aicpu_publish_task_timing_tail_usage(aicpu_thread_num_);
         finished_.store(true, std::memory_order_release);
-        // Destroy PTO2 runtime. sm_handle / rt are recreated every run so we
+        // Destroy the runtime context. sm_handle / rt are recreated every run so we
         // always tear them down here, but we keep the per-cid orch SO entries
         // alive — they are loaded once by register_callable and consumed by
         // every subsequent run.
@@ -927,7 +927,7 @@ void AicpuExecutor::deinit(Runtime * /*runtime*/) {
     // are loaded once by register_callable and consumed by every subsequent
     // run. The destructor releases them at process teardown.
 
-    // Clear file-scope PTO2Runtime pointer (freed by orchestrator thread before deinit)
+    // Clear file-scope RuntimeContext pointer (freed by orchestrator thread before deinit)
     rt = nullptr;
 
     // Clear dep_gen file-local bookkeeping. No-op when dep_gen is disabled.

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -70,7 +70,7 @@ typedef void (*DeviceOrchestrationFunc)(const ChipTaskArgs &orch_args);
 typedef void (*DeviceOrchestrationBindRuntimeFunc)(PTO2Runtime *rt);
 
 // Config function exported by orchestration .so
-typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipTaskArgs &orch_args);
+typedef OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipTaskArgs &orch_args);
 
 // From orchestration/common.cpp linked into this DSO — updates g_current_runtime here (distinct from
 // framework_bind_runtime in the dlopen'd libdevice_orch_*.so).
@@ -570,7 +570,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
                 // Validate arg count on every run against the registered SO.
                 if (*p_config_func != nullptr) {
-                    PTO2OrchestrationConfig cfg = (*p_config_func)(orch_args_cached_);
+                    OrchestrationConfig cfg = (*p_config_func)(orch_args_cached_);
                     LOG_DEBUG("Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
                     if (cfg.expected_arg_count > 0) {
                         const ChipStorageTaskArgs &args_validate = runtime->get_orch_args();

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -330,4 +330,4 @@ first line of `scope_stats/scope_stats.jsonl` includes `task_window_max`,
 - `heap` must accommodate peak output buffer allocation across all in-flight tasks on that ring
 - `dep_pool` must be ≥ total dependency entries for all in-flight tasks on that ring
 - On hardware, back-pressure latency is higher than in simulation — size conservatively
-- Adding inner `PTO2_SCOPE` reduces peak per-ring usage, enabling smaller sizes
+- Adding inner `SIMPLER_SCOPE` reduces peak per-ring usage, enabling smaller sizes

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -42,7 +42,7 @@ Type changes:
 | ----- | ------ | ----- |
 | `PTO2TaskDescriptor.task_id` | `int32_t` | `TaskId` |
 | `PTO2TensorMapEntry.producer_task_id` | `int32_t` | `TaskId` |
-| `PTO2TaskSlotState.ring_id` | N/A | `uint8_t` (new, denormalized for fast access) |
+| `ChipTaskSlotState.ring_id` | N/A | `uint8_t` (new, denormalized for fast access) |
 
 ## 4. Data Structures
 
@@ -96,15 +96,15 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     // Per-ring data pointers (host-side, set by setup_pointers)
     PTO2TaskDescriptor *task_descriptors;
     PTO2TaskPayload *task_payloads;
-    PTO2TaskSlotState *slot_states;
+    ChipTaskSlotState *slot_states;
 
     // Accessors (slot = local_id & task_window_mask)
     PTO2TaskDescriptor &get_task_by_slot(int32_t slot);
     PTO2TaskDescriptor &get_task_by_task_id(int32_t local_id);
     PTO2TaskPayload &get_payload_by_slot(int32_t slot);
     PTO2TaskPayload &get_payload_by_task_id(int32_t local_id);
-    PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot);
-    PTO2TaskSlotState &get_slot_state_by_task_id(int32_t local_id);
+    ChipTaskSlotState &get_slot_state_by_slot(int32_t slot);
+    ChipTaskSlotState &get_slot_state_by_task_id(int32_t local_id);
 };
 
 // In header:
@@ -165,7 +165,7 @@ bool entry_valid(const PTO2TensorMapEntry& e) {
 
 | Structure | Reason |
 | --------- | ------ |
-| `PTO2DepListEntry` | Stores `PTO2TaskSlotState*` pointer — naturally crosses ring boundaries |
+| `PTO2DepListEntry` | Stores `ChipTaskSlotState*` pointer — naturally crosses ring boundaries |
 | `PTO2TaskPayload` | `fanin_slot_states[]` are pointers — no ring coupling |
 | `PTO2ReadyQueue` | Global ready queues shared across all rings (tasks ready to dispatch regardless of origin ring) |
 | `PTO2DispatchPayload` | Built per-dispatch, no ring state needed |
@@ -193,9 +193,9 @@ For ring-heap stall triage, a `CONSUMED` head whose ring bit remains set means t
 
 ### 5.2 Cross-Ring Dependencies
 
-Dependency edges use `PTO2TaskSlotState*` pointers, which naturally span rings:
+Dependency edges use `ChipTaskSlotState*` pointers, which naturally span rings:
 
-- Ring 1 task depends on ring 0 producer → ring 0's `fanout_head` linked list contains a ring 1 `PTO2TaskSlotState*`
+- Ring 1 task depends on ring 0 producer → ring 0's `fanout_head` linked list contains a ring 1 `ChipTaskSlotState*`
 - When ring 0 task completes, it walks its fanout list and decrements ring 1 consumers' `fanin_refcount`
 - No special cross-ring logic needed — pointer-based design is ring-agnostic
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -8,7 +8,7 @@ The single-ring design uses one `last_task_alive` watermark shared by HeapRing, 
 
 ## 2. Solution
 
-Split HeapRing, TaskRing, and DepPool into arrays of `PTO2_MAX_RING_DEPTH` (4) independent instances. Each scope depth maps to its own ring, with an independent `last_task_alive` watermark.
+Split HeapRing, TaskRing, and DepPool into arrays of `CHIP_MAX_RING_DEPTH` (4) independent instances. Each scope depth maps to its own ring, with an independent `last_task_alive` watermark.
 
 ```text
 Scope depth 0  ──►  rings[0] = { HeapRing, TaskRing, DepPool }
@@ -67,10 +67,10 @@ PTO2TaskRing task_ring;
 PTO2DepListPool dep_pool;
 
 // After: per-ring array (dep_pool moved to scheduler, see §4.5)
-PTO2RingSet rings[PTO2_MAX_RING_DEPTH];
+PTO2RingSet rings[CHIP_MAX_RING_DEPTH];
 ```
 
-Ring selection: `current_ring_id() = min(scope_stack_top, PTO2_MAX_RING_DEPTH - 1)`.
+Ring selection: `current_ring_id() = min(scope_stack_top, CHIP_MAX_RING_DEPTH - 1)`.
 
 ### 4.3 PTO2SharedMemoryHeader (modified)
 
@@ -108,7 +108,7 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
 };
 
 // In header:
-PTO2SharedMemoryRingHeader rings[PTO2_MAX_RING_DEPTH];
+PTO2SharedMemoryRingHeader rings[CHIP_MAX_RING_DEPTH];
 ```
 
 Per-ring try-locks in the scheduler state prevent concurrent scheduler threads from interleaving watermark writes within the same ring. `FaninPool`/`DepListPool` `reclaim`/`ensure_space` take `PTO2SharedMemoryRingHeader&` directly (no `ring_id` or `fc` parameters).
@@ -139,7 +139,7 @@ struct RingSchedState {
     alignas(64) PTO2DepListPool dep_pool;
 };
 
-RingSchedState ring_sched_states[PTO2_MAX_RING_DEPTH];
+RingSchedState ring_sched_states[CHIP_MAX_RING_DEPTH];
 ```
 
 `slot_states`, `task_window_size`, and `task_window_mask` are no longer duplicated — callers access them via `ring->get_slot_state_by_*()` and other ring header accessors. The ring pointer shares cache line 0 with `last_task_alive` and `advance_lock`.
@@ -147,8 +147,8 @@ RingSchedState ring_sched_states[PTO2_MAX_RING_DEPTH];
 ### 4.6 PTO2TensorMap (modified)
 
 ```cpp
-PTO2TensorMapEntry** task_entry_heads[PTO2_MAX_RING_DEPTH];
-int64_t last_task_alives[PTO2_MAX_RING_DEPTH];
+PTO2TensorMapEntry** task_entry_heads[CHIP_MAX_RING_DEPTH];
+int64_t last_task_alives[CHIP_MAX_RING_DEPTH];
 ```
 
 Entry validity checks and `cleanup_retired` operate per-ring:

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -54,7 +54,7 @@ The primary production runtime. Uses ring buffers for task slots and output memo
 - **Dependencies**: automatically derived from tensor read/write patterns via TensorMap
 - **Thread model**: `aicpu_thread_num - 1` scheduler threads + 1 orchestrator
   thread on AICPU; the default five-thread configuration uses 4 schedulers
-- **Multi-ring**: HeapRing, TaskRing, and DepPool are split into `PTO2_MAX_RING_DEPTH` (4) independent instances for nested scope isolation. See [MULTI_RING.md](MULTI_RING.md) for details.
+- **Multi-ring**: HeapRing, TaskRing, and DepPool are split into `CHIP_MAX_RING_DEPTH` (4) independent instances for nested scope isolation. See [MULTI_RING.md](MULTI_RING.md) for details.
 - **Use case**: production workloads; supports streaming, flow control, and large batch sizes
 
 ---
@@ -431,7 +431,7 @@ The orchestrator runs on AICPU Thread 3 and builds the task graph by calling the
 
 Key members:
 
-- `rings[PTO2_MAX_RING_DEPTH]`: per-ring `PTO2RingSet` (HeapRing + TaskRing + FaninPool). See [MULTI_RING.md §4.2](MULTI_RING.md).
+- `rings[CHIP_MAX_RING_DEPTH]`: per-ring `PTO2RingSet` (HeapRing + TaskRing + FaninPool). See [MULTI_RING.md §4.2](MULTI_RING.md).
 - `tensor_map`, `tensor_pool`: dependency tracking
 - `scope_tasks[]`, `scope_begins[]`, `scope_stack_top`: scope nesting stack (flat buffer partitioned by level)
 - `scheduler`: pointer to scheduler state (for Orch-side wiring helpers and ready queue access)

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -151,7 +151,7 @@ The orchestrator and schedulers communicate through a contiguous shared memory r
 │  Per-ring regions ×4:       │
 │    PTO2TaskDescriptor[N]    │  N = task_window_size per ring
 │    PTO2TaskPayload[N]       │
-│    PTO2TaskSlotState[N]     │
+│    ChipTaskSlotState[N]     │
 └─────────────────────────────┘
 ```
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -883,7 +883,7 @@ Tasks are queued by resource shape, which is derived from the `active_mask` in t
 Each orchestration `.so` must export:
 
 ```cpp
-extern "C" PTO2OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count);
+extern "C" OrchestrationConfig aicpu_orchestration_config(uint64_t* args, int arg_count);
 extern "C" void aicpu_orchestration_entry(uint64_t* args, int arg_count);
 ```
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -301,7 +301,7 @@ Solution:
 
 The FATAL message is logged to the device log and the process exits. The solution is to increase the ring size so that it can hold at least all tasks within the largest parallel scope. For example, if a scope submits 13 tasks, `task_window >= 14` is required (13 + 1 to distinguish full from empty).
 
-**Sizing guideline**: `task_window_size` must be larger than the maximum number of tasks in any single `PTO2_SCOPE`. A safe choice is `2 × max_tasks_per_scope` or simply the default 65536 for production.
+**Sizing guideline**: `task_window_size` must be larger than the maximum number of tasks in any single `SIMPLER_SCOPE`. A safe choice is `2 × max_tasks_per_scope` or simply the default 65536 for production.
 
 ---
 
@@ -475,7 +475,7 @@ The scheduler's completion handler mirrors this:
 
 This protocol guarantees every consumer is accounted for exactly once.
 
-### 7.4 Scope Mechanism (`PTO2_SCOPE`)
+### 7.4 Scope Mechanism (`SIMPLER_SCOPE`)
 
 Scopes control the lifetime of intermediate buffers. Each scope:
 
@@ -483,7 +483,7 @@ Scopes control the lifetime of intermediate buffers. Each scope:
 - On `scope_end`: increments `fanout_refcount` for scope tasks; when it reaches `fanout_count`, the task's packed buffer can be reclaimed
 
 ```cpp
-PTO2_SCOPE(rt) {
+SIMPLER_SCOPE(rt) {
     // Tasks submitted here belong to this scope
     rt_submit_aic_task(FUNC_QK, args);
     rt_submit_aiv_task(FUNC_SF, args);
@@ -500,11 +500,11 @@ eligible for reuse; once `advance_ring_pointers` reaches it,
 Tensor storage in place.
 
 Therefore the `TaskOutputTensors` instance, the references it returns, and
-any pointer derived from them MUST NOT outlive the `PTO2_SCOPE` in which
+any pointer derived from them MUST NOT outlive the `SIMPLER_SCOPE` in which
 submit was called. The typical safe pattern is:
 
 ```cpp
-PTO2_SCOPE() {
+SIMPLER_SCOPE() {
     TaskOutputTensors outs = rt_submit_aic_task(FUNC_QK, args);
     const Tensor &y = outs.get_ref(0);
     // Use y here and in subsequent submits within the same scope.
@@ -515,7 +515,7 @@ Anti-patterns that compile but silently break:
 
 ```cpp
 const Tensor *kept = nullptr;
-PTO2_SCOPE() {
+SIMPLER_SCOPE() {
     TaskOutputTensors outs = rt_submit_aic_task(FUNC_QK, args);
     kept = &outs.get_ref(0);          // escapes the scope
 }
@@ -524,7 +524,7 @@ PTO2_SCOPE() {
 // tensor — a wrong-tensor read with no runtime diagnostic.
 
 TaskOutputTensors outs;               // declared in outer scope
-PTO2_SCOPE() {
+SIMPLER_SCOPE() {
     outs = rt_submit_aic_task(FUNC_QK, args);
 }
 const Tensor &t = outs.get_ref(0);    // same hazard: outs survives scope
@@ -810,7 +810,7 @@ Built by the scheduler from `PTO2TaskDescriptor`:
 3. The orchestrator thread writes the SO to a temp file, calls `dlopen`
 4. `dlsym("aicpu_orchestration_config")` returns configuration (expected arg count)
 5. `dlsym("aicpu_orchestration_entry")` returns the orchestration function pointer
-6. The orchestrator thread creates a `PTO2Runtime`, calls the orchestration function within a `PTO2_SCOPE`
+6. The orchestrator thread creates a `PTO2Runtime`, calls the orchestration function within a `SIMPLER_SCOPE`
 7. After orchestration completes: `dlclose`, delete temp file
 
 ### 10.3 Thread Startup Synchronization
@@ -852,7 +852,7 @@ The orchestration API is defined in `orchestration_api.h`. Orchestration code de
 | `rt_submit_task(mixed_kernels, args)` | Submit a mixed task with `MixedKernels` struct |
 | `rt_submit_aic_task(kernel_id, args)` | Convenience: submit AIC-only task |
 | `rt_submit_aiv_task(kernel_id, args)` | Convenience: submit AIV-only task |
-| `PTO2_SCOPE() { ... }` | RAII scope for buffer lifetime |
+| `SIMPLER_SCOPE() { ... }` | RAII scope for buffer lifetime |
 | `rt_orchestration_done()` | Signal orchestration complete |
 
 ### 11.2 Parameter Construction
@@ -926,7 +926,7 @@ void aicpu_orchestration_entry(uint64_t* args, int arg_count) {
     // Unpack args: query, key_cache, value_cache, block_table, context_lens, out, config
     for (q_idx = 0; q_idx < q_loop; q_idx++) {
         for (batch_start = 0; batch_start < batch; batch_start += IN_CORE_BATCH) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 // Describe accumulator tensors (oi, li, mi) with TensorCreateInfo
                 // Submit AIV_HUB to initialize accumulators
                 for (bn = 0; bn < max_bn; bn++) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -1,8 +1,8 @@
-# PTO2 Runtime System Design
+# `tensormap_and_ringbuffer` Runtime Design
 
 ## Overview
 
-PTO2 (Parallel Task Orchestration v2) is a runtime system for executing task graphs on Ascend AI processors. It coordinates four layers of execution:
+`tensormap_and_ringbuffer` is a runtime for executing task graphs on Ascend AI processors. It coordinates four layers of execution:
 
 - **Host** (x86/ARM CPU): compiles kernels, allocates device memory, initializes the Runtime, and launches AICPU/AICore threads.
 - **AICPU** (device ARM cores): runs the orchestrator (task graph builder) and scheduler threads.
@@ -810,7 +810,7 @@ Built by the scheduler from `PTO2TaskDescriptor`:
 3. The orchestrator thread writes the SO to a temp file, calls `dlopen`
 4. `dlsym("aicpu_orchestration_config")` returns configuration (expected arg count)
 5. `dlsym("aicpu_orchestration_entry")` returns the orchestration function pointer
-6. The orchestrator thread creates a `PTO2Runtime`, calls the orchestration function within a `SIMPLER_SCOPE`
+6. The orchestrator thread creates a `RuntimeContext`, calls the orchestration function within a `SIMPLER_SCOPE`
 7. After orchestration completes: `dlclose`, delete temp file
 
 ### 10.3 Thread Startup Synchronization

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
@@ -58,17 +58,17 @@ struct MixedKernels {
     int32_t aiv1_kernel_id{INVALID_KERNEL_ID};
 };
 
-static inline void rt_submit_task(PTO2Runtime* rt,
+static inline void rt_submit_task(RuntimeContext* rt,
                                        const MixedKernels& mixed_kernels,
                                        Arg* args,
                                        int32_t num_args);
 
-static inline void rt_submit_aic_task(PTO2Runtime* rt,
+static inline void rt_submit_aic_task(RuntimeContext* rt,
                                            int32_t kernel_id,
                                            Arg* args,
                                            int32_t num_args);
 
-static inline void rt_submit_aiv_task(PTO2Runtime* rt,
+static inline void rt_submit_aiv_task(RuntimeContext* rt,
                                            int32_t kernel_id,
                                            Arg* args,
                                            int32_t num_args);

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -481,17 +481,17 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
     // ring's window comfortably covers its observed max local_id (no slot
     // aliasing during INOUT+COVERED remove_from_task). Same sizes feed both
     // maps so they stay in lockstep.
-    int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint32_t max_local[PTO2_MAX_RING_DEPTH] = {0};
+    int32_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+    uint32_t max_local[CHIP_MAX_RING_DEPTH] = {0};
     for (size_t i = 0; i < num_records; i++) {
         TaskId tid{records[i].task_id};
         uint8_t ring = tid.ring();
         uint32_t local = tid.local();
-        if (ring < PTO2_MAX_RING_DEPTH && local > max_local[ring]) {
+        if (ring < CHIP_MAX_RING_DEPTH && local > max_local[ring]) {
             max_local[ring] = local;
         }
     }
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         int32_t need = static_cast<int32_t>(max_local[r] + 1);
         task_window_sizes[r] = ceil_pow2(need < 16 ? 16 : need);
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -58,9 +58,7 @@
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
-static_assert(
-    RUNTIME_ENV_RING_COUNT == PTO2_MAX_RING_DEPTH, "RuntimeEnv ring count must match PTO2 runtime ring depth"
-);
+static_assert(RUNTIME_ENV_RING_COUNT == PTO2_MAX_RING_DEPTH, "RuntimeEnv ring count must match the runtime ring depth");
 
 // This file returns both kinds of negative status — a latched device code
 // negated, and PTO_RUNTIME_ERR_* for a host-side failure — so a caller can
@@ -685,7 +683,7 @@ static bool ensure_static_arenas(
     const HostApi *api, const ArenaSizingConfig &sizing, const ArenaStaticSizes &sizes, StaticArenaPtrs *out
 ) {
     DeviceArena sizing_arena;  // discarded; only its computed arena_size is read
-    PTO2RuntimeArenaLayout layout =
+    RuntimeArenaLayout layout =
         runtime_reserve_layout(sizing_arena, sizing.task_window_sizes, sizing.heap_sizes, sizing.dep_pool_capacities);
 
     int64_t t_setup_start = _now_ms();
@@ -740,16 +738,16 @@ static bool ensure_static_arenas(
 // *before* it can dereference the image.
 static bool build_runtime_image(
     const ArenaSizingConfig &sizing, const ArenaStaticSizes &sizes, const StaticArenaPtrs &ptrs,
-    DeviceArena *host_arena, PTO2RuntimeArenaLayout *out_layout
+    DeviceArena *host_arena, RuntimeArenaLayout *out_layout
 ) {
-    PTO2RuntimeArenaLayout layout =
+    RuntimeArenaLayout layout =
         runtime_reserve_layout(*host_arena, sizing.task_window_sizes, sizing.heap_sizes, sizing.dep_pool_capacities);
     if (host_arena->commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
         LOG_ERROR("Failed to commit host arena for prebuilt runtime image");
         return false;
     }
 
-    PTO2Runtime *rt = runtime_init_data_from_layout(
+    RuntimeContext *rt = runtime_init_data_from_layout(
         *host_arena, layout, PTO2_MODE_EXECUTE, ptrs.gm_sm, sizes.sm_size, ptrs.gm_heap, sizing.heap_sizes
     );
     if (rt == nullptr) {
@@ -791,7 +789,7 @@ static int bind_cached_runtime_image(
 
 static void store_prebuilt_runtime_image(
     const HostApi *api, const PrebuiltRuntimeArenaCacheProbe &probe, const StaticArenaPtrs &ptrs,
-    const PTO2RuntimeArenaLayout &layout, const DeviceArena &host_arena
+    const RuntimeArenaLayout &layout, const DeviceArena &host_arena
 ) {
     api->mark_prebuilt_runtime_arena_cached(
         probe.hash, probe.serialized_key.data(), probe.serialized_key.size(), ptrs.gm_heap, ptrs.gm_sm,
@@ -809,7 +807,7 @@ static void store_prebuilt_runtime_image(
 // prewarm_config_impl entry, so both build the arena identically.
 static bool build_and_cache_prebuilt_arena(
     const HostApi *api, const ArenaSizingConfig &sizing, StaticArenaPtrs *out_ptrs = nullptr,
-    PTO2RuntimeArenaLayout *out_layout = nullptr
+    RuntimeArenaLayout *out_layout = nullptr
 ) {
     ArenaStaticSizes sizes;
     if (!derive_arena_static_sizes(sizing, &sizes)) {
@@ -822,7 +820,7 @@ static bool build_and_cache_prebuilt_arena(
     }
 
     DeviceArena host_arena;  // libc malloc backend; owns the image until upload
-    PTO2RuntimeArenaLayout layout;
+    RuntimeArenaLayout layout;
     if (!build_runtime_image(sizing, sizes, ptrs, &host_arena, &layout)) {
         return false;
     }
@@ -937,7 +935,7 @@ extern "C" int bind_callable_to_runtime_impl(
             // cache round-trip, so a backend with no-op cache callbacks still
             // binds successfully.
             StaticArenaPtrs ptrs;
-            PTO2RuntimeArenaLayout layout;
+            RuntimeArenaLayout layout;
             if (!build_and_cache_prebuilt_arena(api, sizing, &ptrs, &layout)) {
                 return PTO_RUNTIME_ERR_INTERNAL;
             }

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -58,7 +58,7 @@
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
-static_assert(RUNTIME_ENV_RING_COUNT == PTO2_MAX_RING_DEPTH, "RuntimeEnv ring count must match the runtime ring depth");
+static_assert(RUNTIME_ENV_RING_COUNT == CHIP_MAX_RING_DEPTH, "RuntimeEnv ring count must match the runtime ring depth");
 
 // This file returns both kinds of negative status — a latched device code
 // negated, and PTO_RUNTIME_ERR_* for a host-side failure — so a caller can
@@ -106,9 +106,9 @@ static int64_t _now_ms() {
 static bool is_power_of_2_u64(uint64_t value) { return value != 0 && (value & (value - 1)) == 0; }
 
 template <typename T>
-static std::string format_ring_array(const T (&values)[PTO2_MAX_RING_DEPTH]) {
+static std::string format_ring_array(const T (&values)[CHIP_MAX_RING_DEPTH]) {
     std::string out = "[";
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; ++r) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; ++r) {
         if (r != 0) {
             out += ", ";
         }
@@ -167,7 +167,7 @@ static bool parse_uint_token(
 }
 
 static void apply_env_ring_values(
-    const char *name, uint64_t min_val, uint64_t max_val, bool require_power_of_2, uint64_t out[PTO2_MAX_RING_DEPTH]
+    const char *name, uint64_t min_val, uint64_t max_val, bool require_power_of_2, uint64_t out[CHIP_MAX_RING_DEPTH]
 ) {
     const char *env = std::getenv(name);
     if (!env) return;
@@ -178,25 +178,25 @@ static void apply_env_ring_values(
         if (!parse_uint_token(name, text, min_val, max_val, require_power_of_2, &value)) {
             return;
         }
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             out[r] = value;
         }
         return;
     }
 
-    uint64_t parsed[PTO2_MAX_RING_DEPTH]{};
+    uint64_t parsed[CHIP_MAX_RING_DEPTH]{};
     size_t pos = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         size_t comma = text.find(',', pos);
         std::string token = text.substr(pos, comma == std::string::npos ? std::string::npos : comma - pos);
         if (!parse_uint_token(name, token, min_val, max_val, require_power_of_2, &parsed[r])) {
             return;
         }
         if (comma == std::string::npos) {
-            if (r != PTO2_MAX_RING_DEPTH - 1) {
+            if (r != CHIP_MAX_RING_DEPTH - 1) {
                 LOG_WARN(
                     "%s=%s invalid (expected exactly %d comma-separated values), ignored", name, env,
-                    PTO2_MAX_RING_DEPTH
+                    CHIP_MAX_RING_DEPTH
                 );
                 return;
             }
@@ -206,10 +206,10 @@ static void apply_env_ring_values(
         }
     }
     if (pos < text.size() || (!text.empty() && text.back() == ',')) {
-        LOG_WARN("%s=%s invalid (expected exactly %d comma-separated values), ignored", name, env, PTO2_MAX_RING_DEPTH);
+        LOG_WARN("%s=%s invalid (expected exactly %d comma-separated values), ignored", name, env, CHIP_MAX_RING_DEPTH);
         return;
     }
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         out[r] = parsed[r];
     }
 }
@@ -230,16 +230,16 @@ static uint64_t read_ring_override(const uint64_t *base, int idx) {
 }
 
 // Each of ring_task_window / ring_heap / ring_dep_pool is a per-ring array of
-// PTO2_MAX_RING_DEPTH entries (0 = unset). Precedence per ring: per-task entry >
+// CHIP_MAX_RING_DEPTH entries (0 = unset). Precedence per ring: per-task entry >
 // PTO2_RING_* env value > compile-time default. A "size all rings the same"
 // request arrives already broadcast to every entry by the caller.
 static bool resolve_ring_config(
     const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool,
-    uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH],
-    int32_t eff_dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+    uint64_t eff_task_window_sizes[CHIP_MAX_RING_DEPTH], uint64_t eff_heap_sizes[CHIP_MAX_RING_DEPTH],
+    int32_t eff_dep_pool_capacities[CHIP_MAX_RING_DEPTH]
 ) {
-    uint64_t dep_pool_values[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    uint64_t dep_pool_values[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         eff_task_window_sizes[r] = PTO2_TASK_WINDOW_SIZE;
         eff_heap_sizes[r] = PTO2_HEAP_SIZE;
         dep_pool_values[r] = PTO2_DEP_LIST_POOL_SIZE;
@@ -249,7 +249,7 @@ static bool resolve_ring_config(
     apply_env_ring_values("PTO2_RING_HEAP", 1024, std::numeric_limits<uint64_t>::max(), false, eff_heap_sizes);
     apply_env_ring_values("PTO2_RING_DEP_POOL", 4, static_cast<uint64_t>(INT32_MAX), false, dep_pool_values);
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         const uint64_t task_window_override = read_ring_override(ring_task_window, r);
         const uint64_t heap_override = read_ring_override(ring_heap, r);
         const uint64_t dep_pool_override = read_ring_override(ring_dep_pool, r);
@@ -458,9 +458,9 @@ extern "C" int register_callable_impl(const ChipCallable *callable, const HostAp
 // arena description. Resolved once per config from per-task overrides + env +
 // compile-time defaults; depends on nothing that varies per run.
 struct ArenaSizingConfig {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
+    uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+    uint64_t heap_sizes[CHIP_MAX_RING_DEPTH];
+    int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH];
 };
 
 struct ArenaStaticSizes {
@@ -498,8 +498,8 @@ static void append_cache_key_u64(std::vector<uint8_t> *out, uint64_t value) {
 static PrebuiltRuntimeArenaCacheProbe make_prebuilt_runtime_arena_cache_probe(const ArenaSizingConfig &sizing) {
     PrebuiltRuntimeArenaCacheProbe probe;
     uint64_t hash = 1469598103934665603ULL;
-    probe.serialized_key.reserve(PTO2_MAX_RING_DEPTH * 3 * sizeof(uint64_t));
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    probe.serialized_key.reserve(CHIP_MAX_RING_DEPTH * 3 * sizeof(uint64_t));
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         hash_mix_u64(&hash, sizing.task_window_sizes[r]);
         append_cache_key_u64(&probe.serialized_key, sizing.task_window_sizes[r]);
         hash_mix_u64(&hash, sizing.heap_sizes[r]);
@@ -563,7 +563,7 @@ static bool resolve_arena_sizing(
 
 static bool derive_arena_static_sizes(const ArenaSizingConfig &sizing, ArenaStaticSizes *out) {
     out->total_heap = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         if (sizing.heap_sizes[r] > std::numeric_limits<uint64_t>::max() - out->total_heap) {
             LOG_ERROR("Total ring heap size overflows uint64_t");
             return false;

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
@@ -21,7 +21,7 @@
 #include <vector>
 #endif
 
-struct PTO2Runtime;
+struct RuntimeContext;
 
 // Unified-log error sink. Forward-declared here rather than pulled via
 // common/unified_log.h: that header lives under common/log/include, which is
@@ -36,16 +36,18 @@ namespace {
 // crash (BZ #32412) when the orchestration SO is dlclose'd/re-dlopen'd
 // between execution rounds.  All orchestrator threads bind the same rt
 // value, so per-thread storage is unnecessary.
-PTO2Runtime *g_current_runtime = nullptr;
+RuntimeContext *g_current_runtime = nullptr;
 }  // namespace
 
-extern "C" __attribute__((visibility("default"))) void framework_bind_runtime(PTO2Runtime *rt) {
+extern "C" __attribute__((visibility("default"))) void framework_bind_runtime(RuntimeContext *rt) {
     g_current_runtime = rt;
 }
 
 // Keep current_runtime local to this .so so orchestration helpers do not
 // accidentally bind to the AICPU binary's same-named symbol.
-extern "C" __attribute__((visibility("hidden"))) PTO2Runtime *framework_current_runtime() { return g_current_runtime; }
+extern "C" __attribute__((visibility("hidden"))) RuntimeContext *framework_current_runtime() {
+    return g_current_runtime;
+}
 
 /**
  * Use addr2line to convert an address to file:line information.

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/orchestration_api.h
@@ -381,7 +381,7 @@ private:
  */
 #ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
-struct PTO2OrchestrationConfig {
+struct OrchestrationConfig {
     int expected_arg_count;
 };
 #endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/orchestration_api.h
@@ -14,14 +14,14 @@
  * This header provides everything an orchestration source needs without
  * pulling in runtime implementation headers.  The orchestration .so has
  * zero link dependencies on runtime .cpp files; all runtime calls go
- * through the PTO2RuntimeOps function-pointer table embedded in
- * PTO2Runtime.
+ * through the RuntimeOps function-pointer table embedded in
+ * RuntimeContext.
  *
  * Orchestration sources include ONLY this header:
  *   #include "orchestration_api.h"
  *
  * Runtime sources continue to use runtime_core.h (which defines the
- * full PTO2Runtime struct with all internal fields).
+ * full RuntimeContext struct with all internal fields).
  */
 
 #pragma once
@@ -53,23 +53,23 @@
 // =============================================================================
 
 /**
- * Forward declaration — the orchestration sees PTO2Runtime as a partial
+ * Forward declaration — the orchestration sees RuntimeContext as a partial
  * struct whose first field is the ops pointer.  The full definition
  * lives in runtime_core.h (used only by runtime .cpp files).
  */
-typedef struct PTO2Runtime PTO2Runtime;
+typedef struct RuntimeContext RuntimeContext;
 
 /**
  * Function-pointer table for runtime operations.
  * Populated by the runtime; called by orchestration through inline wrappers.
  */
-typedef struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
-    void (*scope_begin)(PTO2Runtime *rt);
-    void (*scope_end)(PTO2Runtime *rt);
-    void (*orchestration_done)(PTO2Runtime *rt);
-    bool (*is_fatal)(PTO2Runtime *rt);
-    void (*report_fatal)(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
+typedef struct RuntimeOps {
+    TaskOutputTensors (*submit_task)(RuntimeContext *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
+    void (*scope_begin)(RuntimeContext *rt);
+    void (*scope_end)(RuntimeContext *rt);
+    void (*orchestration_done)(RuntimeContext *rt);
+    bool (*is_fatal)(RuntimeContext *rt);
+    void (*report_fatal)(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
     // Logging (populated by runtime, called by orchestration)
     void (*log_error)(const char *func, const char *fmt, ...);
@@ -80,34 +80,34 @@ typedef struct PTO2RuntimeOps {
 
     // Cross-layer data access (orchestration reads/writes tensor values via runtime)
     // Placed after logging to avoid shifting hot-path field offsets.
-    uint64_t (*get_tensor_data)(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
+    uint64_t (*get_tensor_data)(RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
     void (*set_tensor_data)(
-        PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+        RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
     );
-    TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const CoreTaskArgs &args);
-    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const CoreTaskArgs &args);
+    TaskOutputTensors (*alloc_tensors)(RuntimeContext *rt, const CoreTaskArgs &args);
+    TaskOutputTensors (*submit_dummy_task)(RuntimeContext *rt, const CoreTaskArgs &args);
 
     // This-run core geometry from runtime_finalize_after_wire: MIX clusters
     // (one AIC each) and standalone AIV cores.
-    int32_t (*available_cluster_count)(PTO2Runtime *rt);
-    int32_t (*available_aiv_count)(PTO2Runtime *rt);
+    int32_t (*available_cluster_count)(RuntimeContext *rt);
+    int32_t (*available_aiv_count)(RuntimeContext *rt);
 
     // Stash the call-site of the next ScopeGuard so the [ScopeStats]
     // collector can log it. Always present to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
     void (*scope_set_site)(const char *file, int line);
-} PTO2RuntimeOps;
+} RuntimeOps;
 
 /**
- * Partial PTO2Runtime definition for orchestration.
+ * Partial RuntimeContext definition for orchestration.
  *
  * Exposes the ops pointer (for runtime calls) and pending_scope_mode
  * (read directly by inline scope wrappers).  The real struct (in
  * runtime_core.h) has the same first fields, so accessing them through
  * this definition is well-defined (C struct layout guarantee).
  */
-struct PTO2Runtime {
-    const PTO2RuntimeOps *ops;
+struct RuntimeContext {
+    const RuntimeOps *ops;
     PTO2ScopeMode pending_scope_mode;
 };
 
@@ -115,10 +115,10 @@ struct PTO2Runtime {
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================
 
-static inline PTO2Runtime *current_runtime() { return framework_current_runtime(); }
+static inline RuntimeContext *current_runtime() { return framework_current_runtime(); }
 
 static inline TaskOutputTensors alloc_tensors(const CoreTaskArgs &args) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -126,7 +126,7 @@ static inline TaskOutputTensors alloc_tensors(const CoreTaskArgs &args) {
 }
 
 static inline TaskOutputTensors alloc_tensors(const TensorCreateInfo create_infos[], uint32_t count) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -151,7 +151,7 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
         (std::is_same_v<std::decay_t<CIs>, TensorCreateInfo> && ...),
         "alloc_tensors only accepts TensorCreateInfo arguments"
     );
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -168,7 +168,7 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
 }
 
 static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -201,7 +201,7 @@ static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const Core
  * barrier or as a placeholder producer for tests / dep-graph wiring.
  */
 static inline TaskOutputTensors rt_submit_dummy_task(const CoreTaskArgs &args) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -209,7 +209,7 @@ static inline TaskOutputTensors rt_submit_dummy_task(const CoreTaskArgs &args) {
 }
 
 static inline void rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
@@ -218,7 +218,7 @@ static inline void rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {
 }
 
 static inline void rt_scope_end() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
@@ -226,30 +226,30 @@ static inline void rt_scope_end() {
 }
 
 static inline void rt_orchestration_done() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     rt->ops->orchestration_done(rt);
 }
 
 /** This-run MIX cluster (= AIC) count. Do not hardcode 24/36; MIX cohorts use this. */
 static inline int32_t rt_available_cluster_count() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     return rt->ops->available_cluster_count(rt);
 }
 
 /** This-run standalone AIV core count. AIV-only cohorts size themselves on this. */
 static inline int32_t rt_available_aiv_count() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     return rt->ops->available_aiv_count(rt);
 }
 
 static inline bool rt_is_fatal() {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     return rt->ops->is_fatal(rt);
 }
 
 #define rt_report_fatal(code, fmt, ...)                                          \
     do {                                                                         \
-        PTO2Runtime *_rt = current_runtime();                                    \
+        RuntimeContext *_rt = current_runtime();                                 \
         _rt->ops->report_fatal(_rt, (code), __FUNCTION__, (fmt), ##__VA_ARGS__); \
     } while (0)
 
@@ -282,7 +282,7 @@ static inline bool rt_is_fatal() {
  */
 template <typename T = uint64_t>
 static inline T get_tensor_data(const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return from_u64<T>(0);
     }
@@ -318,7 +318,7 @@ static inline T get_tensor_data(const ChipTensor &tensor, uint32_t ndims, const 
  */
 template <typename T = uint64_t>
 static inline void set_tensor_data(const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], T value) {
-    PTO2Runtime *rt = current_runtime();
+    RuntimeContext *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
@@ -351,7 +351,7 @@ public:
     }
 
 private:
-    PTO2Runtime *rt_;
+    RuntimeContext *rt_;
 };
 
 #define _SIMPLER_CONCATENATE_IMPL(x, y) x##y

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/orchestration_api.h
@@ -92,7 +92,7 @@ typedef struct PTO2RuntimeOps {
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
 
-    // Stash the call-site of the next PTO2ScopeGuard so the [ScopeStats]
+    // Stash the call-site of the next ScopeGuard so the [ScopeStats]
     // collector can log it. Always present to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
     void (*scope_set_site)(const char *file, int line);
@@ -332,9 +332,9 @@ static inline void set_tensor_data(const ChipTensor &tensor, uint32_t ndims, con
 /**
  * RAII Scope Guard (calls through ops table)
  */
-class PTO2ScopeGuard {
+class ScopeGuard {
 public:
-    explicit PTO2ScopeGuard(
+    explicit ScopeGuard(
         PTO2ScopeMode mode = PTO2ScopeMode::AUTO, const char *file = __builtin_FILE(), int line = __builtin_LINE()
     ) :
         rt_(current_runtime()) {
@@ -344,7 +344,7 @@ public:
             rt_->ops->scope_begin(rt_);
         }
     }
-    ~PTO2ScopeGuard() {
+    ~ScopeGuard() {
         if (!rt_->ops->is_fatal(rt_)) {
             rt_->ops->scope_end(rt_);
         }
@@ -354,19 +354,19 @@ private:
     PTO2Runtime *rt_;
 };
 
-#define _PTO2_CONCATENATE_IMPL(x, y) x##y
-#define _PTO2_CONCATENATE(x, y) _PTO2_CONCATENATE_IMPL(x, y)
+#define _SIMPLER_CONCATENATE_IMPL(x, y) x##y
+#define _SIMPLER_CONCATENATE(x, y) _SIMPLER_CONCATENATE_IMPL(x, y)
 
-#define PTO2_SCOPE_GUARD(...) \
-    [[maybe_unused]] PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__) { __VA_ARGS__ }
+#define SIMPLER_SCOPE_GUARD(...) \
+    [[maybe_unused]] ScopeGuard _SIMPLER_CONCATENATE(scope_guard_, __COUNTER__) { __VA_ARGS__ }
 
 /**
  * Scoped block macro:
- *   PTO2_SCOPE() {
+ *   SIMPLER_SCOPE() {
  *       rt_submit_task(...);
  *   }
  */
-#define PTO2_SCOPE(...) if (PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__){__VA_ARGS__}; true)
+#define SIMPLER_SCOPE(...) if (ScopeGuard _SIMPLER_CONCATENATE(scope_guard_, __COUNTER__){__VA_ARGS__}; true)
 
 // =============================================================================
 // Orchestration Config

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
@@ -53,7 +53,7 @@ struct AICoreCompletionMailboxMessage {
     std::atomic<uint64_t> seq;
     TaskId task_token;
     // CONDITION: completion observation addr (counter / SDMA event record).
-    // TASK_NORMAL_DONE: PTO2TaskSlotState pointer carried over to the consumer
+    // TASK_NORMAL_DONE: ChipTaskSlotState pointer carried over to the consumer
     //   so it can finalize the AsyncWaitEntry.slot_state binding.
     uint64_t addr;
     uint64_t backend_cookie;
@@ -146,7 +146,7 @@ struct AICoreCompletionMailbox {
         }
     }
 
-    // MPSC push for a TASK_NORMAL_DONE sentinel. Carries the PTO2TaskSlotState
+    // MPSC push for a TASK_NORMAL_DONE sentinel. Carries the ChipTaskSlotState
     // pointer in the `addr` field so the consumer can finish binding the
     // AsyncWaitEntry.slot_state without going back to the FIN-handling thread.
     bool try_push_normal_done(TaskId task_token, uint64_t slot_state_addr) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/async_wait.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/async_wait.h
@@ -121,7 +121,7 @@ inline void CompletionCondition::retire() {
 }
 
 struct AsyncWaitEntry {
-    PTO2TaskSlotState *slot_state{nullptr};
+    ChipTaskSlotState *slot_state{nullptr};
     TaskId task_token{TaskId::invalid()};
     CompletionCondition conditions[MAX_COMPLETIONS_PER_TASK];
     int32_t condition_count{0};
@@ -132,7 +132,7 @@ struct AsyncWaitEntry {
 struct AsyncPollResult {
     int32_t completed{0};
     int32_t error_code{SIMPLER_ERROR_NONE};
-    PTO2TaskSlotState *failed_slot_state{nullptr};
+    ChipTaskSlotState *failed_slot_state{nullptr};
 };
 
 inline const char *async_engine_name(AsyncEngine engine) {
@@ -185,7 +185,7 @@ struct AsyncWaitList {
     // entries[]).
     struct DrainCompletionSink {
         PTO2SchedulerState *sched{nullptr};
-        PTO2TaskSlotState **deferred_release_slot_states{nullptr};
+        ChipTaskSlotState **deferred_release_slot_states{nullptr};
         int32_t *deferred_release_count{nullptr};
         int32_t deferred_release_capacity{0};
         int32_t inline_completed{0};
@@ -198,7 +198,7 @@ struct AsyncWaitList {
 
     // Inline-complete a NotDeferred task during drain. Returns false on
     // deferred_release_slot_states overflow.
-    bool try_inline_complete_locked(DrainCompletionSink &sink, PTO2TaskSlotState &slot_state);
+    bool try_inline_complete_locked(DrainCompletionSink &sink, ChipTaskSlotState &slot_state);
 
     // Single-consumer drain: pop each published message in tail order and
     // translate it into wait-list state. An empty sink (sched == nullptr) just
@@ -241,8 +241,8 @@ struct AsyncWaitList {
                     return drained;
                 }
             } else if (msg.kind == MSG_KIND_TASK_NORMAL_DONE) {
-                PTO2TaskSlotState *slot_state_ptr =
-                    reinterpret_cast<PTO2TaskSlotState *>(static_cast<uintptr_t>(msg.addr));
+                ChipTaskSlotState *slot_state_ptr =
+                    reinterpret_cast<ChipTaskSlotState *>(static_cast<uintptr_t>(msg.addr));
                 AsyncWaitEntry *entry = find_entry_by_token(msg.task_token);
                 if (entry == nullptr) {
                     // Producers strictly order: all CONDITIONs for token T are
@@ -305,7 +305,7 @@ struct AsyncWaitList {
     template <bool Profiling>
     AsyncPollResult poll_and_complete(
         AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched,
-        PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count,
+        ChipTaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count,
         int32_t deferred_release_capacity
 #if SIMPLER_SCHED_PROFILING
         ,

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/common.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/common.h
@@ -23,7 +23,7 @@
 
 // Framework-internal TLS bridge. The executor binds the current thread's
 // runtime before invoking the orchestration entry, so orchestration helpers can
-// fetch the current PTO2Runtime without explicit parameter threading. Declared
+// fetch the current RuntimeContext without explicit parameter threading. Declared
 // here (rather than in orchestration_api.h) so framework TUs the AICore
 // build also compiles — notably orchestration/common.cpp — see these symbols
 // without pulling in types.h, whose Arg::add_scalar → to_u64 path is
@@ -31,9 +31,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-struct PTO2Runtime;
-PTO2Runtime *framework_current_runtime(void);
-void framework_bind_runtime(PTO2Runtime *rt);
+struct RuntimeContext;
+RuntimeContext *framework_current_runtime(void);
+void framework_bind_runtime(RuntimeContext *rt);
 #ifdef __cplusplus
 }
 #endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
@@ -216,7 +216,7 @@ void PTO2OrchestratorState::report_fatal(int32_t error_code, const char *func, c
 static uint32_t next_fanin_seen_epoch(PTO2OrchestratorState *orch) {
     uint32_t next = orch->fanin_seen_current_epoch + 1;
     if (next == 0) {
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             memset(
                 orch->fanin_seen_epoch[r], 0,
                 static_cast<size_t>(orch->sm_header->rings[r].task_window_size) * sizeof(uint32_t)
@@ -250,7 +250,7 @@ struct PTO2FaninBuilder {
     }
 
     bool mark_seen(uint8_t prod_ring, int32_t prod_slot) {
-        if (prod_ring >= PTO2_MAX_RING_DEPTH || prod_slot < 0) {
+        if (prod_ring >= CHIP_MAX_RING_DEPTH || prod_slot < 0) {
             return false;
         }
         uint32_t *seen = orch->fanin_seen_epoch[prod_ring];
@@ -784,7 +784,7 @@ static bool ensure_tensormap_capacity(PTO2OrchestratorState *orch, int32_t neede
     }
 
     uint32_t all_ring_bits = 0;
-    for (int32_t r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int32_t r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         all_ring_bits |= PTO2SchedulerState::ring_advance_pending_bit(r);
     }
     // No acknowledgment is consumed here because TensorMap reclamation has no
@@ -794,9 +794,9 @@ static bool ensure_tensormap_capacity(PTO2OrchestratorState *orch, int32_t neede
         orch->scheduler->publication_ack_mask.fetch_and(~all_ring_bits, std::memory_order_acq_rel);
         orch->scheduler->publication_request_mask.fetch_or(all_ring_bits, std::memory_order_release);
     };
-    int32_t alive[PTO2_MAX_RING_DEPTH];
+    int32_t alive[CHIP_MAX_RING_DEPTH];
     auto read_alive = [&]() {
-        for (int32_t r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int32_t r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             // Relaxed: a self-correcting poll re-read every reclaim tick, so a stale
             // watermark only defers reclaim one tick and never over-frees.
             alive[r] = orch->sm_header->rings[r].fc.last_task_alive.load(std::memory_order_relaxed);
@@ -1369,7 +1369,7 @@ TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const CoreTaskArgs &args)
 
 void PTO2OrchestratorState::mark_done() {
     auto *orch = this;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         int32_t total_tasks = orch->rings[r].task_allocator.active_count();
         if (total_tasks > 0) {
             LOG_DEBUG("=== [Orchestrator] ring %d: total_tasks=%d ===", r, total_tasks);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
@@ -263,7 +263,7 @@ struct PTO2FaninBuilder {
     }
 
     // Append a new edge (caller has already claimed the producer's fanout pin).
-    void push_edge(PTO2FaninSpillEntry &entry, PTO2TaskSlotState *prod_state, DepFlags kind) {
+    void push_edge(PTO2FaninSpillEntry &entry, ChipTaskSlotState *prod_state, DepFlags kind) {
         entry.set(prod_state, kind);
         count++;
         if (dep_has_wait(kind)) {
@@ -274,7 +274,7 @@ struct PTO2FaninBuilder {
     // Dedup path: a producer already recorded this submission is reached again
     // (e.g. as both a creator and a modifier). OR the new flags into the existing
     // edge instead of adding a second one — no extra fanout pin is claimed.
-    void or_flags_into_existing(PTO2TaskSlotState *prod_state, DepFlags kind) {
+    void or_flags_into_existing(ChipTaskSlotState *prod_state, DepFlags kind) {
         for (int32_t i = 0; i < count; i++) {
             PTO2FaninSpillEntry &entry = entry_at(i);
             if (entry.slot_state() == prod_state) {
@@ -310,7 +310,7 @@ private:
 };
 
 static bool append_fanin_or_fail(
-    PTO2OrchestratorState *orch, uint8_t prod_ring, int32_t prod_slot, PTO2TaskSlotState *prod_state,
+    PTO2OrchestratorState *orch, uint8_t prod_ring, int32_t prod_slot, ChipTaskSlotState *prod_state,
     TaskId producer_task_id, PTO2FaninBuilder *fanin_builder, uint8_t ring_id, DepFlags kind
 ) {
     // Decide-and-claim under the producer's fanout_lock. Two conditions make this
@@ -332,7 +332,7 @@ static bool append_fanin_or_fail(
     // until the consumer's on_task_release. check_and_handle_consumed flips
     // COMPLETED->CONSUMED under the same lock, so the check and the ++ are atomic
     // against the consume. fanout_count is lock-protected per the
-    // PTO2TaskSlotState contract.
+    // ChipTaskSlotState contract.
     //
     // Dedup (mark_seen) happens HERE, gated on a live producer — NOT before the
     // gone check. mark_seen keys only on (ring, slot); a stale owner that resolves
@@ -410,7 +410,7 @@ static bool all_claimed_fanin_completed(const PTO2FaninBuilder &fanin_builder) {
     if (fanin_builder.count == 0) return true;
     // Only DEP_WAIT edges gate readiness; a retention-only edge never blocks
     // dispatch, so it is treated as satisfied here.
-    return fanin_builder.for_each([](PTO2TaskSlotState *producer, DepFlags flags) -> bool {
+    return fanin_builder.for_each([](ChipTaskSlotState *producer, DepFlags flags) -> bool {
         if (!dep_has_wait(flags)) return true;
         return producer != nullptr && producer->task_state.load(std::memory_order_acquire) >= PTO2_TASK_COMPLETED;
     });
@@ -418,13 +418,13 @@ static bool all_claimed_fanin_completed(const PTO2FaninBuilder &fanin_builder) {
 
 static bool all_claimed_fanin_allow_early_resolve(const PTO2FaninBuilder &fanin_builder) {
     if (fanin_builder.count == 0) return true;
-    return fanin_builder.for_each([](PTO2TaskSlotState *producer, DepFlags flags) -> bool {
+    return fanin_builder.for_each([](ChipTaskSlotState *producer, DepFlags flags) -> bool {
         if (!dep_has_wait(flags)) return true;
         return producer != nullptr && producer->task_attrs.allow_early_resolve();
     });
 }
 
-void PTO2OrchestratorState::mark_dep_pool_position(PTO2TaskSlotState &slot_state) {
+void PTO2OrchestratorState::mark_dep_pool_position(ChipTaskSlotState &slot_state) {
     PTO2SchedulerState *sched = scheduler;
     auto &rss = sched->ring_sched_states[slot_state.ring_id];
     slot_state.dep_pool_mark = rss.dep_pool.top;
@@ -435,7 +435,7 @@ void PTO2OrchestratorState::mark_dep_pool_position(PTO2TaskSlotState &slot_state
 #endif
 }
 
-void PTO2OrchestratorState::wire_fanin_task(PTO2TaskSlotState &slot_state, int32_t wfanin) {
+void PTO2OrchestratorState::wire_fanin_task(ChipTaskSlotState &slot_state, int32_t wfanin) {
     PTO2SchedulerState *sched = scheduler;
     auto &rss = sched->ring_sched_states[slot_state.ring_id];
     PTO2TaskPayload *payload = slot_state.payload;
@@ -445,7 +445,7 @@ void PTO2OrchestratorState::wire_fanin_task(PTO2TaskSlotState &slot_state, int32
     int32_t early_propagated = 0;
     // Direct-only (#1285): one unflagged producer => consumer never early-dispatches.
     bool early_disqualified = false;
-    for_each_fanin_slot_state(*payload, [&](PTO2TaskSlotState *producer, DepFlags flags) {
+    for_each_fanin_slot_state(*payload, [&](ChipTaskSlotState *producer, DepFlags flags) {
         // Only DEP_WAIT edges contribute to readiness: they gate fanin and are
         // linked onto the producer's fanout_head for completion notification. A
         // retention-only edge carries no ordering, so it is skipped here.
@@ -501,7 +501,7 @@ void PTO2OrchestratorState::wire_fanin_task(PTO2TaskSlotState &slot_state, int32
     }
 }
 
-static PTO2TaskSlotState *oldest_open_task_on_current_ring(const PTO2OrchestratorState *orch) {
+static ChipTaskSlotState *oldest_open_task_on_current_ring(const PTO2OrchestratorState *orch) {
     // Scope depth maps directly to a ring until the deepest ring, where all
     // further nested scopes share that ring. Its shallowest open scope begin
     // therefore marks the oldest task pinned by any open scope on this ring.
@@ -509,7 +509,7 @@ static PTO2TaskSlotState *oldest_open_task_on_current_ring(const PTO2Orchestrato
     return begin < orch->scope_tasks_size ? orch->scope_tasks[begin] : nullptr;
 }
 
-static bool orch_wire_live_fanin_task(PTO2OrchestratorState *orch, PTO2TaskSlotState &slot_state, int32_t wfanin) {
+static bool orch_wire_live_fanin_task(PTO2OrchestratorState *orch, ChipTaskSlotState &slot_state, int32_t wfanin) {
     PTO2SchedulerState *sched = orch->scheduler;
     auto &rss = sched->ring_sched_states[slot_state.ring_id];
 
@@ -527,14 +527,14 @@ static bool orch_wire_live_fanin_task(PTO2OrchestratorState *orch, PTO2TaskSlotS
     return true;
 }
 
-static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state);
+static void scope_tasks_push(PTO2OrchestratorState *orch, ChipTaskSlotState *task_slot_state);
 
 struct PTO2PreparedTask {
     TaskId task_id = TaskId::invalid();
     PTO2TaskAllocResult alloc_result = {-1, 0, nullptr, nullptr};
     PTO2TaskDescriptor *task = nullptr;
     PTO2TaskPayload *payload = nullptr;
-    PTO2TaskSlotState *slot_state = nullptr;
+    ChipTaskSlotState *slot_state = nullptr;
 };
 
 static PTO2OutputLayout calculate_output_layout(const CoreTaskArgs &args) {
@@ -656,7 +656,7 @@ static bool prepare_task(
 // Scope Management
 // =============================================================================
 
-static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state) {
+static void scope_tasks_push(PTO2OrchestratorState *orch, ChipTaskSlotState *task_slot_state) {
     if (orch->scope_tasks_size >= orch->scope_tasks_capacity) {
         // scope_tasks lives in the per-Worker arena (single backing allocation),
         // so realloc is not legal. Capacity is the total in-flight slot budget
@@ -898,7 +898,7 @@ static TaskOutputTensors submit_task_common(
     PTO2SchedulerState *sched = orch->scheduler;
     PTO2RingFlowControl &fc = orch->sm_header->rings[ring_id].fc;
     TaskId task_id = prepared.task_id;
-    PTO2TaskSlotState &cur_slot_state = *prepared.slot_state;
+    ChipTaskSlotState &cur_slot_state = *prepared.slot_state;
     PTO2TaskDescriptor &task = *prepared.task;
     PTO2TaskPayload &payload = *prepared.payload;
     result.set_task_id(task_id);
@@ -974,7 +974,7 @@ static TaskOutputTensors submit_task_common(
             continue;
         }
         int32_t dep_slot = dep_ring.get_slot_by_task_id(dep_local_task_id);
-        PTO2TaskSlotState *producer_slot_state = &dep_ring.get_slot_state_by_slot(dep_slot);
+        ChipTaskSlotState *producer_slot_state = &dep_ring.get_slot_state_by_slot(dep_slot);
         if (!append_fanin_or_fail(
                 orch, dep_ring_id, dep_slot, producer_slot_state, dep_task_id, &fanin_builder, ring_id,
                 args.explicit_dep_kind(i)
@@ -993,7 +993,7 @@ static TaskOutputTensors submit_task_common(
         uint8_t prod_ring = producer_task_id.ring();
         PTO2SharedMemoryRingHeader &producer_ring = orch->sm_header->rings[prod_ring];
         int32_t prod_slot = producer_ring.get_slot_by_task_id(static_cast<int32_t>(producer_task_id.local()));
-        PTO2TaskSlotState *prod_state = &producer_ring.get_slot_state_by_slot(prod_slot);
+        ChipTaskSlotState *prod_state = &producer_ring.get_slot_state_by_slot(prod_slot);
         return append_fanin_or_fail(
             orch, prod_ring, prod_slot, prod_state, producer_task_id, &fanin_builder, ring_id, kind
         );
@@ -1119,7 +1119,7 @@ static TaskOutputTensors submit_task_common(
         // wire_fanin_task is skipped here, so its ordering-only pin release runs
         // on this path too: an edge without retention drops its submit->wire pin
         // so the (already completed) producer can be CONSUMED.
-        for_each_fanin_slot_state(payload, [&](PTO2TaskSlotState *producer, DepFlags flags) {
+        for_each_fanin_slot_state(payload, [&](ChipTaskSlotState *producer, DepFlags flags) {
             if (dep_has_wait(flags) && !dep_has_retain(flags)) {
                 sched->release_producer(*producer);  // wiring-phase atomic, not bucketed (see wire_fanin_task)
             }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.h
@@ -78,7 +78,7 @@ struct PTO2OrchestratorState {
     // Single contiguous buffer of task IDs, partitioned by scope level.
     // scope_begins[i] is the index into scope_tasks where scope i starts.
     // Tasks for the top scope occupy [scope_begins[top], scope_tasks_size).
-    PTO2TaskSlotState **scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
+    ChipTaskSlotState **scope_tasks;  // Flat buffer of taskSlotState (all scopes concatenated)
     int32_t scope_tasks_size;         // Number of task IDs currently in the buffer
     int32_t scope_tasks_capacity;     // Allocated capacity of scope_tasks
     int32_t *scope_begins;            // scope_begins[i] = start index of scope i in scope_tasks
@@ -174,8 +174,8 @@ struct PTO2OrchestratorState {
     // Forget pointers; arena owns the backing buffers.
     void destroy();
     void set_scheduler(PTO2SchedulerState *scheduler);
-    void mark_dep_pool_position(PTO2TaskSlotState &slot_state);
-    void wire_fanin_task(PTO2TaskSlotState &slot_state, int32_t wfanin);
+    void mark_dep_pool_position(ChipTaskSlotState &slot_state);
+    void wire_fanin_task(ChipTaskSlotState &slot_state, int32_t wfanin);
     void report_fatal(int32_t error_code, const char *func, const char *fmt, ...);
     void begin_scope(PTO2ScopeMode mode = PTO2ScopeMode::AUTO);
     void end_scope();

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.h
@@ -43,12 +43,12 @@
  * pools, scope arrays, plus the nested PTO2TensorMap layout).
  */
 struct PTO2OrchestratorLayout {
-    size_t off_fanin_pool[PTO2_MAX_RING_DEPTH];
-    size_t off_fanin_seen_epoch[PTO2_MAX_RING_DEPTH];
+    size_t off_fanin_pool[CHIP_MAX_RING_DEPTH];
+    size_t off_fanin_seen_epoch[CHIP_MAX_RING_DEPTH];
     size_t off_scope_tasks;
     size_t off_scope_begins;
     PTO2TensorMapLayout tensor_map;
-    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
+    int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH];
     int32_t scope_tasks_cap;
     uint64_t scope_stack_capacity;
 };
@@ -67,8 +67,8 @@ struct PTO2OrchestratorState {
     PTO2SharedMemoryHeader *sm_header;
 
     // === PER-RING RESOURCES ===
-    PTO2RingSet rings[PTO2_MAX_RING_DEPTH];
-    uint32_t *fanin_seen_epoch[PTO2_MAX_RING_DEPTH];
+    PTO2RingSet rings[CHIP_MAX_RING_DEPTH];
+    uint32_t *fanin_seen_epoch[CHIP_MAX_RING_DEPTH];
     uint32_t fanin_seen_current_epoch{1};
 
     // === TENSOR MAP (Private) ===
@@ -123,12 +123,12 @@ struct PTO2OrchestratorState {
 
     /**
      * Get current ring index from scope depth.
-     * Maps scope depth to ring_id: min(scope_depth, PTO2_MAX_RING_DEPTH - 1)
+     * Maps scope depth to ring_id: min(scope_depth, CHIP_MAX_RING_DEPTH - 1)
      */
     uint8_t current_ring_id() const {
         int32_t depth = scope_stack_top;
         if (depth < 0) depth = 0;
-        return depth < PTO2_MAX_RING_DEPTH ? static_cast<uint8_t>(depth) : PTO2_MAX_RING_DEPTH - 1;
+        return depth < CHIP_MAX_RING_DEPTH ? static_cast<uint8_t>(depth) : CHIP_MAX_RING_DEPTH - 1;
     }
 
     bool in_manual_scope() const { return scope_stack_top >= manual_begin_depth; }
@@ -140,12 +140,12 @@ struct PTO2OrchestratorState {
     // the nested tensor_map layout. Returned layout is consumed by
     // init_data_from_layout.
     static PTO2OrchestratorLayout reserve_layout(
-        DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+        DeviceArena &arena, const int32_t task_window_sizes[CHIP_MAX_RING_DEPTH],
         int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
     );
     static PTO2OrchestratorLayout reserve_layout(
-        DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-        const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+        DeviceArena &arena, const int32_t task_window_sizes[CHIP_MAX_RING_DEPTH],
+        const int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH]
     );
 
     // Phase 3a: write everything *except* arena-internal pointer fields.
@@ -158,11 +158,11 @@ struct PTO2OrchestratorState {
     );
     bool init_data_from_layout(
         const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap,
-        const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+        const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH], const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]
     );
     bool reset_for_reuse(
         const PTO2OrchestratorLayout &layout, void *sm_dev_base, void *gm_heap,
-        const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+        const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH], const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]
     );
 
     // Phase 3b: write the arena-internal pointer fields (scope_tasks,

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.cpp
@@ -173,7 +173,7 @@ void PTO2DepListPool::report_deadlock(
     LOG_ERROR("  - In-flight tasks: %d", current - last_alive);
     // Head-task dump: what the shared reclaim watermark is actually waiting on.
     if (ring.slot_states != nullptr) {
-        PTO2TaskSlotState &h = ring.get_slot_state_by_task_id(last_alive);
+        ChipTaskSlotState &h = ring.get_slot_state_by_task_id(last_alive);
         uint32_t fc = h.fanout_count;
         uint32_t rc = h.fanout_refcount.load(std::memory_order_acquire);
         LOG_ERROR(
@@ -190,7 +190,7 @@ void PTO2DepListPool::report_deadlock(
 }
 
 bool PTO2DepListPool::ensure_space(
-    PTO2SharedMemoryRingHeader &ring, int32_t needed, PTO2TaskSlotState *oldest_open_task
+    PTO2SharedMemoryRingHeader &ring, int32_t needed, ChipTaskSlotState *oldest_open_task
 ) {
     if (available() >= needed) return true;
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.h
@@ -63,7 +63,7 @@
 #define PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES (PLATFORM_PROF_SYS_CNT_FREQ / 2)  // 500 ms
 
 constexpr uint32_t ring_mask_bit(int32_t ring_id) {
-    static_assert(PTO2_MAX_RING_DEPTH <= 32, "ring masks use one uint32_t bit per ring");
+    static_assert(CHIP_MAX_RING_DEPTH <= 32, "ring masks use one uint32_t bit per ring");
     return 1u << static_cast<uint32_t>(ring_id);
 }
 
@@ -921,7 +921,7 @@ struct PTO2DepListPool {
 
 /**
  * Groups a TaskAllocator and DepPool into one per-depth unit.
- * PTO2_MAX_RING_DEPTH instances provide independent reclamation per scope depth.
+ * CHIP_MAX_RING_DEPTH instances provide independent reclamation per scope depth.
  */
 struct PTO2RingSet {
     PTO2TaskAllocator task_allocator;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.h
@@ -68,7 +68,7 @@ constexpr uint32_t ring_mask_bit(int32_t ring_id) {
 }
 
 inline bool
-reclaim_head_matches_open_task(int32_t head_task_id, uint8_t ring_id, const PTO2TaskSlotState *oldest_open_task) {
+reclaim_head_matches_open_task(int32_t head_task_id, uint8_t ring_id, const ChipTaskSlotState *oldest_open_task) {
     return oldest_open_task != nullptr && oldest_open_task->task != nullptr &&
            oldest_open_task->task->task_id == TaskId::make(ring_id, static_cast<uint32_t>(head_task_id));
 }
@@ -136,7 +136,7 @@ public:
     void init(
         PTO2TaskDescriptor *descriptors, int32_t window_size, std::atomic<int32_t> *current_index_ptr,
         std::atomic<int32_t> *last_alive_ptr, void *heap_base, uint64_t heap_size, std::atomic<int32_t> *error_code_ptr,
-        PTO2TaskSlotState *slot_states = nullptr, int32_t initial_local_task_id = 0, uint8_t ring_id = 0
+        ChipTaskSlotState *slot_states = nullptr, int32_t initial_local_task_id = 0, uint8_t ring_id = 0
     ) {
         descriptors_ = descriptors;
         slot_states_ = slot_states;
@@ -179,7 +179,7 @@ public:
      * @param oldest_open_task Oldest task owned by any open scope on this ring
      * @return Allocation result; check failed() for errors
      */
-    PTO2TaskAllocResult alloc(int32_t output_size, PTO2TaskSlotState *oldest_open_task = nullptr) {
+    PTO2TaskAllocResult alloc(int32_t output_size, ChipTaskSlotState *oldest_open_task = nullptr) {
         uint64_t aligned_size =
             output_size > 0 ? PTO2_ALIGN_UP(static_cast<uint64_t>(output_size), PTO2_ALIGN_SIZE) : 0;
 
@@ -329,7 +329,7 @@ private:
     PTO2TaskDescriptor *descriptors_ = nullptr;
     // Parallel to descriptors_, indexed by task_id & window_mask_. Read-only here,
     // used by the deadlock detector to identify the head task's slot.
-    PTO2TaskSlotState *slot_states_ = nullptr;
+    ChipTaskSlotState *slot_states_ = nullptr;
     uint8_t ring_id_ = 0;
     int32_t window_size_ = 0;
     int32_t window_mask_ = 0;
@@ -480,7 +480,7 @@ private:
     }
 #endif
 
-    bool head_is_oldest_open_task(int32_t head_task_id, const PTO2TaskSlotState *oldest_open_task) const {
+    bool head_is_oldest_open_task(int32_t head_task_id, const ChipTaskSlotState *oldest_open_task) const {
         return slot_states_ != nullptr && reclaim_head_matches_open_task(head_task_id, ring_id_, oldest_open_task);
     }
 
@@ -524,7 +524,7 @@ private:
         }
         // Head-task state dump: what the reclaim watermark is actually waiting on.
         if (slot_states_ != nullptr) {
-            PTO2TaskSlotState &h = slot_states_[last_alive & window_mask_];
+            ChipTaskSlotState &h = slot_states_[last_alive & window_mask_];
             uint32_t fc = h.fanout_count;
             uint32_t rc = h.fanout_refcount.load(std::memory_order_acquire);
             LOG_ERROR(
@@ -669,7 +669,7 @@ struct PTO2FaninPool {
 };
 
 template <typename Fn>
-using PTO2FaninCallbackResult = std::invoke_result_t<Fn &, PTO2TaskSlotState *, DepFlags>;
+using PTO2FaninCallbackResult = std::invoke_result_t<Fn &, ChipTaskSlotState *, DepFlags>;
 
 template <typename Fn>
 using PTO2FaninForEachReturn = std::conditional_t<std::is_same_v<PTO2FaninCallbackResult<Fn>, void>, void, bool>;
@@ -842,7 +842,7 @@ struct PTO2DepListPool {
      * exact publication, then use a structural head-of-line check plus a
      * wall-clock backstop, each emitting report_deadlock.
      */
-    bool ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed, PTO2TaskSlotState *oldest_open_task = nullptr);
+    bool ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed, ChipTaskSlotState *oldest_open_task = nullptr);
 
     /**
      * Structured dep-pool deadlock report, mirroring PTO2TaskAllocator::report_deadlock.
@@ -902,7 +902,7 @@ struct PTO2DepListPool {
      * @param task_slot     Task slot to prepend
      * @return New head offset
      */
-    PTO2DepListEntry *prepend(PTO2DepListEntry *cur, PTO2TaskSlotState *slot_state) {
+    PTO2DepListEntry *prepend(PTO2DepListEntry *cur, ChipTaskSlotState *slot_state) {
         PTO2DepListEntry *new_entry = alloc();
         if (!new_entry) return nullptr;
         new_entry->slot_state = slot_state;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -12,7 +12,7 @@
  * Runtime Class - Device Execution and Handshake Control
  *
  * This class manages device-side execution through AICPU-AICore handshake
- * protocol. Task graph construction is handled by PTO2Runtime; this class
+ * protocol. Task graph construction is handled by RuntimeContext; this class
  * only handles:
  * - Handshake buffers for AICPU-AICore communication
  * - Execution parameters (block_dim, aicpu_thread_num)
@@ -224,7 +224,7 @@ struct alignas(64) DeviceRuntimeLaunchDesc {
  * Runtime class for device execution and handshake control
  *
  * This class manages AICPU-AICore communication through handshake buffers.
- * Task graph construction is handled by PTO2Runtime; this class only handles
+ * Task graph construction is handled by RuntimeContext; this class only handles
  * execution control and device orchestration state.
  *
  * Layout: the device-read fields live in the first member `dev`
@@ -280,7 +280,7 @@ public:
 
     // Prebuilt-arena fast path (trb only). Set by host's
     // bind_callable_to_runtime_impl; consumed by AICPU at boot to attach a
-    // DeviceArena to `prebuilt_arena_base_` and pick up the PTO2Runtime at
+    // DeviceArena to `prebuilt_arena_base_` and pick up the RuntimeContext at
     // `prebuilt_arena_base_ + prebuilt_runtime_offset_`. Both stay zero on
     // first construction (Runtime() ctor zeros them) so a non-prebuilt boot
     // path can still detect "no prebuilt image set" via nullptr.
@@ -316,7 +316,7 @@ public:
 
     // =========================================================================
     // Deprecated API (for platform compatibility, always returns 0/nullptr)
-    // Task graph is now managed by PTO2Runtime, not Runtime
+    // Task graph is now managed by RuntimeContext, not Runtime
     // =========================================================================
 
     /** @deprecated Task count is now in PTO2 shared memory */

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_core.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_core.cpp
@@ -108,11 +108,11 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
     // idempotent (task_state is monotonic) and only adds one atomic load on
     // the second encounter.
     constexpr int kSegmentCap = 64;
-    const PTO2TaskSlotState *seg[kSegmentCap];
+    const ChipTaskSlotState *seg[kSegmentCap];
     int seg_count = 0;
     bool failed = false;
 
-    auto wait_one_producer = [&](const PTO2TaskSlotState &slot) {
+    auto wait_one_producer = [&](const ChipTaskSlotState &slot) {
         uint8_t ring_id = slot.ring_id;
         int32_t local_id = static_cast<int32_t>(slot.task->task_id.local());
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -138,7 +138,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
         }
     };
 
-    auto wait_one_consumers = [&](const PTO2TaskSlotState &slot) {
+    auto wait_one_consumers = [&](const ChipTaskSlotState &slot) {
         uint8_t ring_id = slot.ring_id;
         int32_t local_id = slot.task->task_id.local();
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -176,7 +176,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
         seg_count = 0;
     };
 
-    auto try_push = [&](const PTO2TaskSlotState &s) {
+    auto try_push = [&](const ChipTaskSlotState &s) {
         for (int j = 0; j < seg_count; j++) {
             if (seg[j] == &s) return;  // per-segment dedup
         }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_core.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_core.cpp
@@ -254,7 +254,7 @@ void set_tensor_data(
     memcpy(ptr, &value, elem_size);
 }
 
-// Ops-table entry that hands the call-site captured by PTO2ScopeGuard to the
+// Ops-table entry that hands the call-site captured by ScopeGuard to the
 // [ScopeStats] collector. The slot is always present in the struct to keep
 // the layout stable; at SIMPLER_DFX=0 we fill nullptr so the orchestration
 // .so's null-check skips it.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_core.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_core.cpp
@@ -10,7 +10,7 @@
  */
 
 /**
- * PTO Runtime2 - Main Implementation
+ * Runtime core implementation
  *
  * Implements the unified runtime API that combines orchestrator and scheduler.
  *
@@ -50,31 +50,31 @@ static constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_CYCLES =
 // =============================================================================
 
 static TaskOutputTensors
-submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
+submit_task_impl(RuntimeContext *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args) {
     return rt->orchestrator.submit_task(mixed_kernels, args);
 }
 
-static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const CoreTaskArgs &args) {
+static TaskOutputTensors alloc_tensors_impl(RuntimeContext *rt, const CoreTaskArgs &args) {
     return rt->orchestrator.alloc_tensors(args);
 }
 
-static TaskOutputTensors submit_dummy_task_impl(PTO2Runtime *rt, const CoreTaskArgs &args) {
+static TaskOutputTensors submit_dummy_task_impl(RuntimeContext *rt, const CoreTaskArgs &args) {
     return rt->orchestrator.submit_dummy_task(args);
 }
 
-void rt_scope_begin(PTO2Runtime *rt) {
+void rt_scope_begin(RuntimeContext *rt) {
     PTO2ScopeMode mode = rt->pending_scope_mode;
     rt->pending_scope_mode = PTO2ScopeMode::AUTO;
     rt->orchestrator.begin_scope(mode);
 }
 
-void rt_scope_end(PTO2Runtime *rt) { rt->orchestrator.end_scope(); }
+void rt_scope_end(RuntimeContext *rt) { rt->orchestrator.end_scope(); }
 
-void rt_orchestration_done(PTO2Runtime *rt) { rt->orchestrator.mark_done(); }
+void rt_orchestration_done(RuntimeContext *rt) { rt->orchestrator.mark_done(); }
 
-static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator.fatal; }
+static bool is_fatal_impl(RuntimeContext *rt) { return rt->orchestrator.fatal; }
 
-void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...) {
+void rt_report_fatal(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     if (fmt == nullptr || fmt[0] == '\0') {
@@ -97,7 +97,7 @@ void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, cons
 // Returns false on timeout (sets orch.fatal).
 MAYBE_UNINITIALIZED_BEGIN
 static bool
-wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_consumers, const char *caller) {
+wait_for_tensor_ready(RuntimeContext *rt, const ChipTensor &tensor, bool wait_for_consumers, const char *caller) {
     TaskId owner = tensor.owner_task_id;
     PTO2OrchestratorState &orch = rt->orchestrator;
 
@@ -211,7 +211,7 @@ wait_for_tensor_ready(PTO2Runtime *rt, const ChipTensor &tensor, bool wait_for_c
 }
 MAYBE_UNINITIALIZED_END
 
-uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]) {
+uint64_t get_tensor_data(RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]) {
     if (tensor.buffer.addr == 0) {
         unified_log_error(
             __FUNCTION__, "get_tensor_data: buffer not allocated (addr=0). "
@@ -233,7 +233,7 @@ uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndi
 }
 
 void set_tensor_data(
-    PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+    RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
 ) {
     if (tensor.buffer.addr == 0) {
         unified_log_error(
@@ -262,10 +262,10 @@ void set_tensor_data(
 static void scope_set_site_impl(const char *file, int line) { scope_stats_set_pending_site(file, line); }
 #endif
 
-static int32_t available_cluster_count_impl(PTO2Runtime *rt) { return rt->orchestrator.total_cluster_count; }
-static int32_t available_aiv_count_impl(PTO2Runtime *rt) { return rt->orchestrator.total_aiv_count; }
+static int32_t available_cluster_count_impl(RuntimeContext *rt) { return rt->orchestrator.total_cluster_count; }
+static int32_t available_aiv_count_impl(RuntimeContext *rt) { return rt->orchestrator.total_aiv_count; }
 
-static const PTO2RuntimeOps s_runtime_ops = {
+static const RuntimeOps s_runtime_ops = {
     .submit_task = submit_task_impl,
     .scope_begin = rt_scope_begin,
     .scope_end = rt_scope_end,
@@ -300,13 +300,13 @@ static const PTO2RuntimeOps s_runtime_ops = {
 // SPMD core counts — depend on the device-side s_runtime_ops global and the
 // AICPU SchedulerContext respectively, so they remain in the AICPU build.
 
-void runtime_finalize_after_wire(PTO2Runtime *rt, int32_t aic_count, int32_t aiv_count) {
+void runtime_finalize_after_wire(RuntimeContext *rt, int32_t aic_count, int32_t aiv_count) {
     rt->ops = &s_runtime_ops;
     rt->orchestrator.total_cluster_count = aic_count;
     rt->orchestrator.total_aiv_count = aiv_count;
 }
 
-void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode) {
+void runtime_set_mode(RuntimeContext *rt, RuntimeMode mode) {
     if (rt) {
         rt->mode = mode;
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_core.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_core.h
@@ -312,7 +312,7 @@ void set_tensor_data(
  */
 #ifndef PTO2_ORCHESTRATION_CONFIG_DEFINED
 #define PTO2_ORCHESTRATION_CONFIG_DEFINED
-struct PTO2OrchestrationConfig {
+struct OrchestrationConfig {
     int expected_arg_count;
 };
 #endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_core.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_core.h
@@ -9,9 +9,9 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Main Interface
+ * Runtime core interface
  *
- * This is the main header for the PTO Runtime2 system.
+ * This is the main header for the runtime.
  * It provides a unified API for task graph construction and execution.
  *
  * Key Features:
@@ -22,7 +22,7 @@
  * - Orchestrator-Scheduler decoupling via shared memory
  *
  * Usage:
- *   1. Create runtime: PTO2Runtime create methods
+ *   1. Create runtime: RuntimeContext create methods
  *   2. Build task graph in orchestration function:
  *      - begin_scope() / end_scope()
  *      - submit_task()
@@ -51,7 +51,7 @@
 /**
  * Runtime execution mode
  */
-enum PTO2RuntimeMode {
+enum RuntimeMode {
     PTO2_MODE_EXECUTE = 0,    // Execute tasks on workers
     PTO2_MODE_SIMULATE = 1,   // Simulate task execution with cycle counting
     PTO2_MODE_GRAPH_ONLY = 2  // Build graph only, no execution
@@ -64,15 +64,15 @@ enum PTO2RuntimeMode {
  * (via orchestration_api.h inline wrappers), so it has zero link
  * dependencies on runtime .cpp files.
  */
-typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
+typedef struct RuntimeContext RuntimeContext;  // forward declare for ops signatures
 
-struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
-    void (*scope_begin)(PTO2Runtime *rt);
-    void (*scope_end)(PTO2Runtime *rt);
-    void (*orchestration_done)(PTO2Runtime *rt);
-    bool (*is_fatal)(PTO2Runtime *rt);
-    void (*report_fatal)(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
+struct RuntimeOps {
+    TaskOutputTensors (*submit_task)(RuntimeContext *rt, const MixedKernels &mixed_kernels, const CoreTaskArgs &args);
+    void (*scope_begin)(RuntimeContext *rt);
+    void (*scope_end)(RuntimeContext *rt);
+    void (*orchestration_done)(RuntimeContext *rt);
+    bool (*is_fatal)(RuntimeContext *rt);
+    void (*report_fatal)(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
     // Logging (populated by runtime, called by orchestration)
     void (*log_error)(const char *func, const char *fmt, ...);
@@ -83,17 +83,17 @@ struct PTO2RuntimeOps {
 
     // Cross-layer data access (orchestration reads/writes tensor values via runtime)
     // Placed after logging to avoid shifting hot-path field offsets.
-    uint64_t (*get_tensor_data)(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
+    uint64_t (*get_tensor_data)(RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
     void (*set_tensor_data)(
-        PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+        RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
     );
-    TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const CoreTaskArgs &args);
-    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const CoreTaskArgs &args);
+    TaskOutputTensors (*alloc_tensors)(RuntimeContext *rt, const CoreTaskArgs &args);
+    TaskOutputTensors (*submit_dummy_task)(RuntimeContext *rt, const CoreTaskArgs &args);
 
     // This-run core geometry from runtime_finalize_after_wire: MIX clusters
     // (one AIC each) and standalone AIV cores.
-    int32_t (*available_cluster_count)(PTO2Runtime *rt);
-    int32_t (*available_aiv_count)(PTO2Runtime *rt);
+    int32_t (*available_cluster_count)(RuntimeContext *rt);
+    int32_t (*available_aiv_count)(RuntimeContext *rt);
 
     // Stash the call-site captured by ScopeGuard into the [ScopeStats]
     // collector. Always present in the struct to keep ops-table layout stable
@@ -139,20 +139,20 @@ struct ArenaOffsets {
  * offsets + arena size. Produced once on the host by runtime_reserve_layout();
  * consumed by runtime_init_data_from_layout and runtime_wire_arena_pointers.
  */
-struct PTO2RuntimeArenaLayout {
+struct RuntimeArenaLayout {
     ArenaSizingKey sizing;
     ArenaOffsets offsets;
 };
 
 /**
- * PTO Runtime2 context
+ * Runtime context
  *
  * Contains all state for orchestration and scheduling.
  * In simulated mode, runs in single process with shared address space.
  */
-struct PTO2Runtime {
+struct RuntimeContext {
     // Ops table (first field — used by orchestration .so via function pointers)
-    const PTO2RuntimeOps *ops;
+    const RuntimeOps *ops;
     PTO2ScopeMode pending_scope_mode;
 
     // Components
@@ -167,7 +167,7 @@ struct PTO2Runtime {
     bool gm_heap_owned;  // True if we allocated it
 
     // Mode
-    PTO2RuntimeMode mode;
+    RuntimeMode mode;
 
     // Statistics
     int64_t total_cycles;
@@ -180,7 +180,7 @@ struct PTO2Runtime {
     // *before* dereferencing this image. Populated on host by
     // runtime_init_data_from_layout + runtime_wire_arena_pointers; read by
     // aicpu_executor.cpp.
-    PTO2RuntimeArenaLayout prebuilt_layout;
+    RuntimeArenaLayout prebuilt_layout;
 };
 
 // =============================================================================
@@ -189,15 +189,15 @@ struct PTO2Runtime {
 
 /**
  * Phase 1 — declare every sub-region (sm_handle wrapper, orchestrator /
- * scheduler / tensor_map / mailbox / PTO2Runtime header) on the supplied
+ * scheduler / tensor_map / mailbox / RuntimeContext header) on the supplied
  * arena. Pure arithmetic; does not touch device memory and may run on host.
  * Returns the layout descriptor; caller commits/attaches the arena before
  * Phase 2/3.
  */
-PTO2RuntimeArenaLayout runtime_reserve_layout(
+RuntimeArenaLayout runtime_reserve_layout(
     DeviceArena &arena, uint64_t task_window_size, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
 );
-PTO2RuntimeArenaLayout runtime_reserve_layout(
+RuntimeArenaLayout runtime_reserve_layout(
     DeviceArena &arena, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
     const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
 );
@@ -212,17 +212,17 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
  * them (never dereference). Safe to run on a host arena that owns a host
  * mirror of the runtime image — the resulting buffer is rtMemcpy-ready.
  *
- * Returns the PTO2Runtime* that sits at layout.off_runtime within the arena.
+ * Returns the RuntimeContext* that sits at layout.off_runtime within the arena.
  * Caller must follow up with runtime_wire_arena_pointers; rt->ops and the
  * AICore-side count fields are left untouched and must be filled by the
  * AICPU at boot.
  */
-PTO2Runtime *runtime_init_data_from_layout(
-    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
+RuntimeContext *runtime_init_data_from_layout(
+    DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
     void *gm_heap_dev_base, uint64_t heap_size
 );
-PTO2Runtime *runtime_init_data_from_layout(
-    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
+RuntimeContext *runtime_init_data_from_layout(
+    DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
     void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
 );
 
@@ -234,8 +234,8 @@ PTO2Runtime *runtime_init_data_from_layout(
  * both host (writing host-mirror addresses) and AICPU (writing device
  * addresses) sides.
  */
-void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
-bool runtime_reset_for_reuse(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt);
+void runtime_wire_arena_pointers(DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeContext *rt);
+bool runtime_reset_for_reuse(DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeContext *rt);
 
 /**
  * AICPU-only Phase 4 — fill in the few fields the host could not know at
@@ -244,7 +244,7 @@ bool runtime_reset_for_reuse(DeviceArena &arena, const PTO2RuntimeArenaLayout &l
  * orchestrator's core counts (depend on the executor's scheduler context).
  * Call once per boot after runtime_wire_arena_pointers.
  */
-void runtime_finalize_after_wire(PTO2Runtime *rt, int32_t aic_count, int32_t aiv_count);
+void runtime_finalize_after_wire(RuntimeContext *rt, int32_t aic_count, int32_t aiv_count);
 
 /**
  * Destroy runtime. With the prebuilt-arena fast path the arena buffer is
@@ -252,12 +252,12 @@ void runtime_finalize_after_wire(PTO2Runtime *rt, int32_t aic_count, int32_t aiv
  * here — the destructor only forgets sub-structure pointers (idempotent
  * cleanup).
  */
-void runtime_destroy(PTO2Runtime *rt, DeviceArena &arena);
+void runtime_destroy(RuntimeContext *rt, DeviceArena &arena);
 
 /**
  * Set execution mode
  */
-void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
+void runtime_set_mode(RuntimeContext *rt, RuntimeMode mode);
 
 // =============================================================================
 // Orchestration API (called by orchestration function)
@@ -270,7 +270,7 @@ void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
  * bounded by the scope. When scope_end() is called, the scope
  * releases its reference to all enclosed tasks.
  */
-void rt_scope_begin(PTO2Runtime *rt);
+void rt_scope_begin(RuntimeContext *rt);
 
 /**
  * End current scope
@@ -278,24 +278,24 @@ void rt_scope_begin(PTO2Runtime *rt);
  * Releases scope reference for all tasks submitted since scope_begin().
  * Tasks whose refcount reaches zero will have their buffers released.
  */
-void rt_scope_end(PTO2Runtime *rt);
+void rt_scope_end(RuntimeContext *rt);
 
 /**
  * Mark orchestration as complete
  *
  * Signals that no more tasks will be submitted.
  */
-void rt_orchestration_done(PTO2Runtime *rt);
+void rt_orchestration_done(RuntimeContext *rt);
 
 /**
  * Enter fatal state explicitly from orchestration.
  */
-void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
+void rt_report_fatal(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
 /**
  * Cross-layer data access: read a tensor value by waiting for its producer.
  */
-uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
+uint64_t get_tensor_data(RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
 
 /**
  * Cross-layer data access: write a value to a tensor at given indices.
@@ -303,7 +303,7 @@ uint64_t get_tensor_data(PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndi
  * See set_tensor_data in orchestration_api.h for full documentation.
  */
 void set_tensor_data(
-    PTO2Runtime *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
+    RuntimeContext *rt, const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
 );
 
 /**

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_core.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_core.h
@@ -107,9 +107,9 @@ struct RuntimeOps {
  * config); re-read at AICPU boot to reconstruct ring/heap/dep-pool capacities.
  */
 struct ArenaSizingKey {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]{};
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]{};
-    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]{};
+    uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]{};
+    uint64_t heap_sizes[CHIP_MAX_RING_DEPTH]{};
+    int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH]{};
 };
 
 /**
@@ -198,8 +198,8 @@ RuntimeArenaLayout runtime_reserve_layout(
     DeviceArena &arena, uint64_t task_window_size, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
 );
 RuntimeArenaLayout runtime_reserve_layout(
-    DeviceArena &arena, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+    DeviceArena &arena, const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH], const int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH]
 );
 
 /**
@@ -223,7 +223,7 @@ RuntimeContext *runtime_init_data_from_layout(
 );
 RuntimeContext *runtime_init_data_from_layout(
     DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
-    void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+    void *gm_heap_dev_base, const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH]
 );
 
 /**

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_core.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_core.h
@@ -95,7 +95,7 @@ struct PTO2RuntimeOps {
     int32_t (*available_cluster_count)(PTO2Runtime *rt);
     int32_t (*available_aiv_count)(PTO2Runtime *rt);
 
-    // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]
+    // Stash the call-site captured by ScopeGuard into the [ScopeStats]
     // collector. Always present in the struct to keep ops-table layout stable
     // across SIMPLER_DFX settings; set to nullptr at SIMPLER_DFX=0.
     void (*scope_set_site)(const char *file, int line);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_types.h
@@ -166,11 +166,11 @@ struct PTO2OutputLayout {
  * Fanin spill entry
  * Stored in the dedicated fanin spill ring buffer.
  */
-struct PTO2TaskSlotState;  // Forward declaration
+struct ChipTaskSlotState;  // Forward declaration
 struct PTO2FaninPool;      // Forward declaration
 
 // One fanin edge: a producer slot pointer with the per-edge DepFlags packed into
-// bits 0..1 of the pointer. PTO2TaskSlotState is alignas(64), so bits 0..5 are
+// bits 0..1 of the pointer. ChipTaskSlotState is alignas(64), so bits 0..5 are
 // always zero in a real pointer. Used for both the inline fanin array and the
 // spill pool, keeping sizeof == sizeof(uintptr_t) so neither footprint grows.
 struct PTO2FaninSpillEntry {
@@ -181,11 +181,11 @@ struct PTO2FaninSpillEntry {
     // are written via set()). Value-init (`PTO2FaninSpillEntry{}`) still zeroes it.
     uintptr_t packed;
 
-    PTO2TaskSlotState *slot_state() const { return reinterpret_cast<PTO2TaskSlotState *>(packed & ~FLAG_MASK); }
+    ChipTaskSlotState *slot_state() const { return reinterpret_cast<ChipTaskSlotState *>(packed & ~FLAG_MASK); }
     DepFlags flags() const { return static_cast<DepFlags>(packed & FLAG_MASK); }
     // Only bits within FLAG_MASK are stored; any bit outside it (a malformed
     // DepFlags value) is masked off so it can never corrupt the slot pointer.
-    void set(PTO2TaskSlotState *s, DepFlags f) {
+    void set(ChipTaskSlotState *s, DepFlags f) {
         packed = reinterpret_cast<uintptr_t>(s) | (static_cast<uintptr_t>(f) & FLAG_MASK);
     }
     void add_flags(DepFlags f) { packed |= (static_cast<uintptr_t>(f) & FLAG_MASK); }
@@ -198,7 +198,7 @@ static_assert(sizeof(PTO2FaninSpillEntry) == sizeof(uintptr_t));
  * Stored in DepListPool ring buffer.
  */
 struct PTO2DepListEntry {
-    PTO2TaskSlotState *slot_state;  // Consumer slot state (direct pointer)
+    ChipTaskSlotState *slot_state;  // Consumer slot state (direct pointer)
     PTO2DepListEntry *next;         // next entry
 };
 
@@ -211,7 +211,7 @@ struct PTO2DepListEntry {
  *
  * Stored in the TaskDescriptor ring buffer in shared memory.
  * Contains static identification and buffer pointers only.
- * Dynamic scheduling state (fanin/fanout/task_state) is in PTO2TaskSlotState.
+ * Dynamic scheduling state (fanin/fanout/task_state) is in ChipTaskSlotState.
  *
  * Fields set by Orchestrator at submission, read by Scheduler for dispatch.
  */
@@ -473,7 +473,7 @@ enum PTO2TaskLifecycleFlag : uint8_t {
 
 static_assert((PTO2_DISPATCH_PROPAGATED & (PTO2_READY_CLAIMED | PTO2_COMPLETION_DONE | PTO2_SUBTASK_DEFERRED)) == 0);
 
-struct alignas(64) PTO2TaskSlotState {
+struct alignas(64) ChipTaskSlotState {
     // Fanout lock + list (accessed together under lock in on_task_complete)
     std::atomic<int32_t> fanout_lock;  // Per-task spinlock (0=unlocked, 1=locked)
     uint32_t fanout_count;             // SCOPE_BIT (owning scope) | number of consumers
@@ -505,7 +505,7 @@ struct alignas(64) PTO2TaskSlotState {
     // has_predicate, selective timing tag). Lives on slot_state (not payload) so
     // fanin walks and the completion path read them off the already-hot producer
     // slot_state cache line. Packed into the padding before dep_pool_mark to keep
-    // PTO2TaskSlotState at 64 bytes. Plain-write (set once at submit, before the
+    // ChipTaskSlotState at 64 bytes. Plain-write (set once at submit, before the
     // slot is scheduler-visible), so it MUST NOT share a byte with the atomically
     // mutated lifecycle_flags.
     TaskAttrs task_attrs{};
@@ -665,10 +665,10 @@ struct alignas(64) PTO2TaskSlotState {
     void unlock_fanout() { fanout_lock.store(0, std::memory_order_release); }
 };
 
-static_assert(sizeof(PTO2TaskSlotState) == 64);
-// PTO2FaninSpillEntry packs DepFlags into the low bits of a PTO2TaskSlotState*.
+static_assert(sizeof(ChipTaskSlotState) == 64);
+// PTO2FaninSpillEntry packs DepFlags into the low bits of a ChipTaskSlotState*.
 // That is only lossless while the type is aligned past those tag bits.
 static_assert(
-    alignof(PTO2TaskSlotState) > PTO2FaninSpillEntry::FLAG_MASK,
-    "PTO2TaskSlotState alignment must exceed PTO2FaninSpillEntry::FLAG_MASK so the packed DepFlags bits are free"
+    alignof(ChipTaskSlotState) > PTO2FaninSpillEntry::FLAG_MASK,
+    "ChipTaskSlotState alignment must exceed PTO2FaninSpillEntry::FLAG_MASK so the packed DepFlags bits are free"
 );

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime_types.h
@@ -65,10 +65,10 @@
 #define PTO2_TASK_WINDOW_SIZE 16384  // Default per-ring task window size (power of 2)
 
 // Multi-ring: number of independent ring layers (HeapRing + TaskRing + DepPool per layer)
-// Scope depth maps to ring index via: min(scope_depth, PTO2_MAX_RING_DEPTH - 1)
-#define PTO2_MAX_RING_DEPTH 4
+// Scope depth maps to ring index via: min(scope_depth, CHIP_MAX_RING_DEPTH - 1)
+#define CHIP_MAX_RING_DEPTH 4
 
-// Memory pools (per-ring defaults; total = value × PTO2_MAX_RING_DEPTH)
+// Memory pools (per-ring defaults; total = value × CHIP_MAX_RING_DEPTH)
 #define PTO2_HEAP_SIZE (256 * 1024 * 1024)  // 256MB per ring (1GB total)
 #define PTO2_DEP_LIST_POOL_SIZE 16384       // Per-ring dependency list pool entries
 #define PTO2_TENSORMAP_POOL_SIZE (65536)    // TensorMap entry pool
@@ -77,11 +77,11 @@
 // Scope management
 #define PTO2_MAX_SCOPE_DEPTH 64  // Maximum nesting depth
 // Hard cap for the scope_tasks buffer. Equals the total in-flight ring slot
-// budget (PTO2_TASK_WINDOW_SIZE × PTO2_MAX_RING_DEPTH): once every ring slot
+// budget (PTO2_TASK_WINDOW_SIZE × CHIP_MAX_RING_DEPTH): once every ring slot
 // is in flight, no more tasks can ever be pushed regardless of buffer size.
 // scope_tasks_push fatals on overflow rather than growing the arena-owned
 // buffer (which would be UB on the arena's malloc'd backing).
-#define PTO2_SCOPE_TASKS_CAP (PTO2_TASK_WINDOW_SIZE * PTO2_MAX_RING_DEPTH)
+#define PTO2_SCOPE_TASKS_CAP (PTO2_TASK_WINDOW_SIZE * CHIP_MAX_RING_DEPTH)
 
 // Ready queue
 #define PTO2_READY_QUEUE_SIZE 65536  // Per-shape queue size

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.cpp
@@ -74,7 +74,7 @@ PTO2SchedProfilingData scheduler_get_profiling(int thread_idx) {
 void PTO2SchedulerState::print_stats() {
     PTO2SchedulerState *sched = this;
     LOG_DEBUG("=== Scheduler Statistics ===");
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         if (sched->ring_sched_states[r].last_task_alive > 0) {
             LOG_DEBUG("Ring %d:", r);
             LOG_DEBUG("  last_task_alive: %d", sched->ring_sched_states[r].last_task_alive);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
@@ -59,7 +59,7 @@
  */
 struct PTO2ReadyQueueSlot {
     std::atomic<int64_t> sequence;
-    PTO2TaskSlotState *slot_state;
+    ChipTaskSlotState *slot_state;
     uint64_t task_id_snapshot;  // generation tag for early-dispatch queue entries
 };
 
@@ -93,9 +93,9 @@ struct alignas(64) PTO2ReadyQueue {
 
     void reset_for_reuse() {}
 
-    bool push(PTO2TaskSlotState *slot_state) { return push_tagged(slot_state, 0); }
+    bool push(ChipTaskSlotState *slot_state) { return push_tagged(slot_state, 0); }
 
-    bool push_tagged(PTO2TaskSlotState *slot_state, uint64_t task_id_snapshot) {
+    bool push_tagged(ChipTaskSlotState *slot_state, uint64_t task_id_snapshot) {
         uint64_t pos;
         PTO2ReadyQueueSlot *slot;
         while (true) {
@@ -126,9 +126,9 @@ struct alignas(64) PTO2ReadyQueue {
     // `count` items. A target slot holding an older generation means full and
     // ends the call; a slot a peer has reserved but not yet published is
     // transient and retries, so this only spins while a peer is mid-publish.
-    bool push_batch(PTO2TaskSlotState **items, int count) { return push_batch_tagged(items, nullptr, count); }
+    bool push_batch(ChipTaskSlotState **items, int count) { return push_batch_tagged(items, nullptr, count); }
 
-    bool push_batch_tagged(PTO2TaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
+    bool push_batch_tagged(ChipTaskSlotState **items, const uint64_t *task_id_snapshots, int count) {
         if (count == 0) return true;
         if (static_cast<uint64_t>(count) > capacity) return false;
 
@@ -168,7 +168,7 @@ struct alignas(64) PTO2ReadyQueue {
     }
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
-    bool push(PTO2TaskSlotState *slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {
+    bool push(ChipTaskSlotState *slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {
         uint64_t pos;
         PTO2ReadyQueueSlot *slot;
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -208,9 +208,9 @@ struct alignas(64) PTO2ReadyQueue {
     }
 #endif
 
-    PTO2TaskSlotState *pop() { return pop_tagged(nullptr); }
+    ChipTaskSlotState *pop() { return pop_tagged(nullptr); }
 
-    PTO2TaskSlotState *pop_tagged(uint64_t *task_id_snapshot) {
+    ChipTaskSlotState *pop_tagged(uint64_t *task_id_snapshot) {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -235,14 +235,14 @@ struct alignas(64) PTO2ReadyQueue {
             }
         }
 
-        PTO2TaskSlotState *result = slot->slot_state;
+        ChipTaskSlotState *result = slot->slot_state;
         if (task_id_snapshot != nullptr) *task_id_snapshot = slot->task_id_snapshot;
         slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
 
 #if SIMPLER_SCHED_PROFILING
-    PTO2TaskSlotState *pop(uint64_t &atomic_count, uint64_t &wait_cycle) {
+    ChipTaskSlotState *pop(uint64_t &atomic_count, uint64_t &wait_cycle) {
         // Fast-path: skip slot load when queue is clearly empty
         uint64_t d = dequeue_pos.load(std::memory_order_relaxed);
         uint64_t e = enqueue_pos.load(std::memory_order_relaxed);
@@ -284,7 +284,7 @@ struct alignas(64) PTO2ReadyQueue {
             wait_cycle += (get_sys_cnt_aicpu() - t0);
         }
 
-        PTO2TaskSlotState *result = slot->slot_state;
+        ChipTaskSlotState *result = slot->slot_state;
         slot->sequence.store(static_cast<int64_t>(pos + mask + 1), std::memory_order_release);
         return result;
     }
@@ -292,9 +292,9 @@ struct alignas(64) PTO2ReadyQueue {
 
     // Batch pop: reserve a contiguous run of ready slots with a single CAS.
     // Returns actual number of items popped (may be less than max_count).
-    int pop_batch(PTO2TaskSlotState **out, int max_count) { return pop_batch_tagged(out, nullptr, max_count); }
+    int pop_batch(ChipTaskSlotState **out, int max_count) { return pop_batch_tagged(out, nullptr, max_count); }
 
-    int pop_batch_tagged(PTO2TaskSlotState **out, uint64_t *task_id_snapshots, int max_count) {
+    int pop_batch_tagged(ChipTaskSlotState **out, uint64_t *task_id_snapshots, int max_count) {
         uint64_t pos;
         int count;
         while (true) {
@@ -333,7 +333,7 @@ struct alignas(64) PTO2ReadyQueue {
     }
 
 #if SIMPLER_SCHED_PROFILING
-    int pop_batch(PTO2TaskSlotState **out, int max_count, uint64_t &atomic_count, uint64_t &wait_cycle) {
+    int pop_batch(ChipTaskSlotState **out, int max_count, uint64_t &atomic_count, uint64_t &wait_cycle) {
         uint64_t pos;
         int count;
         uint64_t t0 = get_sys_cnt_aicpu();
@@ -503,7 +503,7 @@ struct PTO2SchedulerState {
             int32_t old_last_task_alive = last_task_alive;
 
             while (last_task_alive < current_task_index) {
-                PTO2TaskSlotState &slot_state = ring->get_slot_state_by_task_id(last_task_alive);
+                ChipTaskSlotState &slot_state = ring->get_slot_state_by_task_id(last_task_alive);
                 if (slot_state.task_state.load(std::memory_order_acquire) != PTO2_TASK_CONSUMED) {
                     break;
                 }
@@ -557,7 +557,7 @@ struct PTO2SchedulerState {
     // dummy_ready_queue and are retired inline; a ready sync_start cohort goes to
     // the per-shape ready_sync_queues[] (drained as Tier-0); everything else to
     // ready_queues[].
-    void push_ready_routed(PTO2TaskSlotState *slot_state) {
+    void push_ready_routed(ChipTaskSlotState *slot_state) {
         PTO2ResourceShape shape = slot_state->active_mask.to_shape();
         if (shape == PTO2ResourceShape::DUMMY ||
             (slot_state->task_attrs.has_predicate() && !slot_state->payload->predicate.pass())) {
@@ -637,7 +637,7 @@ struct PTO2SchedulerState {
         return advanced;
     }
 
-    bool try_claim_ready_once(PTO2TaskSlotState &slot_state) {
+    bool try_claim_ready_once(ChipTaskSlotState &slot_state) {
         uint8_t flags = slot_state.lifecycle_flags.load(std::memory_order_acquire);
         for (;;) {
             if ((flags & PTO2_READY_CLAIMED) != 0) return false;
@@ -650,7 +650,7 @@ struct PTO2SchedulerState {
         }
     }
 
-    void check_and_handle_consumed(PTO2TaskSlotState &slot_state) {
+    void check_and_handle_consumed(ChipTaskSlotState &slot_state) {
         // Read fanout_refcount/fanout_count and flip COMPLETED->CONSUMED under
         // fanout_lock. The orchestrator claims producers (fanout_count++) under the
         // same lock, so the consume decision is serialized against a concurrent
@@ -688,7 +688,7 @@ struct PTO2SchedulerState {
     }
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
-    void check_and_handle_consumed(PTO2TaskSlotState &slot_state, uint64_t &atomic_count) {
+    void check_and_handle_consumed(ChipTaskSlotState &slot_state, uint64_t &atomic_count) {
         // See the non-profiling overload for why the read + COMPLETED->CONSUMED
         // flip is serialized against the orchestrator's claim under fanout_lock.
         bool became_consumed = false;
@@ -728,7 +728,7 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    void release_producer(PTO2TaskSlotState &slot_state) {
+    void release_producer(ChipTaskSlotState &slot_state) {
         slot_state.fanout_refcount.fetch_add(1, std::memory_order_acq_rel);
         check_and_handle_consumed(slot_state);
     }
@@ -738,19 +738,19 @@ struct PTO2SchedulerState {
     // distinct add lets a consumer release leave the scope bit unset, so "all
     // consumers done but scope still open" stays distinguishable from "fully
     // consumed".
-    void release_producer_scope(PTO2TaskSlotState &slot_state) {
+    void release_producer_scope(ChipTaskSlotState &slot_state) {
         slot_state.fanout_refcount.fetch_add(PTO2_FANOUT_SCOPE_BIT, std::memory_order_acq_rel);
         check_and_handle_consumed(slot_state);
     }
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
-    void release_producer(PTO2TaskSlotState &slot_state, uint64_t &atomic_count) {
+    void release_producer(ChipTaskSlotState &slot_state, uint64_t &atomic_count) {
         slot_state.fanout_refcount.fetch_add(1, std::memory_order_acq_rel);
         atomic_count += 1;  // fanout_refcount.fetch_add
         check_and_handle_consumed(slot_state, atomic_count);
     }
 
-    void release_producer_scope(PTO2TaskSlotState &slot_state, uint64_t &atomic_count) {
+    void release_producer_scope(ChipTaskSlotState &slot_state, uint64_t &atomic_count) {
         slot_state.fanout_refcount.fetch_add(PTO2_FANOUT_SCOPE_BIT, std::memory_order_acq_rel);
         atomic_count += 1;  // fanout_refcount.fetch_add
         check_and_handle_consumed(slot_state, atomic_count);
@@ -814,12 +814,12 @@ struct PTO2SchedulerState {
         );
     }
 
-    inline void record_published_blocks(PTO2TaskSlotState &slot_state, int32_t count) {
+    inline void record_published_blocks(ChipTaskSlotState &slot_state, int32_t count) {
         if (count <= 0 || !slot_state.task_attrs.allow_early_resolve()) return;
         slot_state.payload->published_block_count.fetch_add(static_cast<int16_t>(count), std::memory_order_seq_cst);
     }
 
-    inline void ring_all_staged_doorbells(PTO2TaskSlotState &slot_state) {
+    inline void ring_all_staged_doorbells(ChipTaskSlotState &slot_state) {
         for (int w = 0; w < PTO2_EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
             uint64_t bits = slot_state.payload->staged_core_mask[w].load(std::memory_order_seq_cst);
             while (bits != 0) {
@@ -853,7 +853,7 @@ struct PTO2SchedulerState {
         return (previous & PTO2_EARLY_SYNC_DRAIN_OWNER) != 0;
     }
 
-    inline void cancel_early_sync_drain(PTO2TaskSlotState &slot_state) {
+    inline void cancel_early_sync_drain(ChipTaskSlotState &slot_state) {
         uint8_t previous =
             slot_state.payload->early_sync_drain_state.exchange(PTO2_EARLY_SYNC_DRAIN_NONE, std::memory_order_seq_cst);
         if ((previous & PTO2_EARLY_SYNC_DRAIN_OWNER) == 0) return;
@@ -878,7 +878,7 @@ struct PTO2SchedulerState {
         }
     }
 
-    inline bool maybe_rendezvous_ring(PTO2TaskSlotState &slot_state) {
+    inline bool maybe_rendezvous_ring(ChipTaskSlotState &slot_state) {
         // Staging publishes the complete mask before seeding running_slot_count.
         // Read the seed first: observing the final seq_cst seed then orders every
         // mask read after all of the stager's mask updates. Reading the mask first
@@ -901,13 +901,13 @@ struct PTO2SchedulerState {
         return true;
     }
 
-    inline bool retry_sync_start_rendezvous_after_staging(PTO2TaskSlotState &slot_state) {
+    inline bool retry_sync_start_rendezvous_after_staging(ChipTaskSlotState &slot_state) {
         if (!maybe_rendezvous_ring(slot_state)) return false;
         propagate_dispatch_fanin(slot_state);
         return true;
     }
 
-    inline void try_enqueue_early_dispatch_candidate(PTO2TaskSlotState &consumer) {
+    inline void try_enqueue_early_dispatch_candidate(ChipTaskSlotState &consumer) {
         if (consumer.task_attrs.has_predicate()) return;
         PTO2ResourceShape shape = consumer.active_mask.to_shape();
         if (shape != PTO2ResourceShape::AIC && shape != PTO2ResourceShape::AIV && shape != PTO2ResourceShape::MIX) {
@@ -940,7 +940,7 @@ struct PTO2SchedulerState {
     // Only codegen-flagged (direct) producers propagate: a task's successors
     // early-dispatch off its DIRECT producers' marks, never an inherited chain
     // (a2a3 #1285 — a5 never had auto-chain / spec_chain_*).
-    void propagate_dispatch_fanin(PTO2TaskSlotState &p) {
+    void propagate_dispatch_fanin(ChipTaskSlotState &p) {
         if (!p.task_attrs.allow_early_resolve()) return;
         if (p.payload->published_block_count.load(std::memory_order_seq_cst) < p.logical_block_num) return;
         if (p.payload->early_dispatch_state.load(std::memory_order_acquire) == PTO2_EARLY_DISPATCH_STAGING) return;
@@ -962,7 +962,7 @@ struct PTO2SchedulerState {
         PTO2DepListEntry *edge = p.fanout_head;
         p.unlock_fanout();
         for (; edge != nullptr; edge = edge->next) {
-            PTO2TaskSlotState *c = edge->slot_state;
+            ChipTaskSlotState *c = edge->slot_state;
             if (c->task_attrs.has_predicate()) continue;
             int32_t nf = c->payload->dispatch_fanin.fetch_add(1, std::memory_order_acq_rel) + 1;
             if (nf != c->payload->fanin_actual_count) continue;
@@ -972,16 +972,16 @@ struct PTO2SchedulerState {
 
     struct EarlyDispatchReleaseSink {
         static constexpr int CAP = 32;
-        PTO2TaskSlotState *items[CAP];
+        ChipTaskSlotState *items[CAP];
         int n = 0;
-        inline bool push(PTO2TaskSlotState *s) {
+        inline bool push(ChipTaskSlotState *s) {
             if (n >= CAP) return false;
             items[n++] = s;
             return true;
         }
     };
 
-    inline bool try_early_dispatch_release(PTO2TaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
+    inline bool try_early_dispatch_release(ChipTaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
         if (slot_state.task_attrs.has_predicate()) return false;
         uint8_t expect = PTO2_EARLY_DISPATCH_NONE;
         if (slot_state.payload->early_dispatch_state.compare_exchange_strong(
@@ -1017,7 +1017,7 @@ struct PTO2SchedulerState {
         return slot_state.next_block_idx.load(std::memory_order_seq_cst) >= slot_state.logical_block_num;
     }
 
-    bool route_ready_once(PTO2TaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
+    bool route_ready_once(ChipTaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
         if (!try_claim_ready_once(slot_state)) return false;
 
         // Early-dispatch: pre-staged tasks are released by doorbell
@@ -1044,7 +1044,7 @@ struct PTO2SchedulerState {
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
     bool route_ready_once(
-        PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait,
+        ChipTaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait,
         EarlyDispatchReleaseSink *sink = nullptr
     ) {
         uint8_t flags = slot_state.lifecycle_flags.load(std::memory_order_acquire);
@@ -1080,7 +1080,7 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    bool release_fanin_and_check_ready(PTO2TaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
+    bool release_fanin_and_check_ready(ChipTaskSlotState &slot_state, EarlyDispatchReleaseSink *sink = nullptr) {
         // Atomically increment fanin_refcount and check if all producers are done
         // ACQ_REL on fanin_refcount already synchronizes with the orchestrator's
         // init release, making fanin_count visible — plain load suffices.
@@ -1094,7 +1094,7 @@ struct PTO2SchedulerState {
 
 #if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
     bool release_fanin_and_check_ready(
-        PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait,
+        ChipTaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &push_wait,
         EarlyDispatchReleaseSink *sink = nullptr
     ) {
         int32_t new_refcount = slot_state.fanin_refcount.fetch_add(1, std::memory_order_acq_rel) + 1;
@@ -1107,20 +1107,20 @@ struct PTO2SchedulerState {
     }
 #endif
 
-    int get_ready_tasks_batch(PTO2ReadyQueue *queues, PTO2ResourceShape shape, PTO2TaskSlotState **out, int max_count) {
+    int get_ready_tasks_batch(PTO2ReadyQueue *queues, PTO2ResourceShape shape, ChipTaskSlotState **out, int max_count) {
         return queues[static_cast<int32_t>(shape)].pop_batch(out, max_count);
     }
 
 #if SIMPLER_SCHED_PROFILING
     int get_ready_tasks_batch(
-        PTO2ReadyQueue *queues, PTO2ResourceShape shape, PTO2TaskSlotState **out, int max_count, uint64_t &atomic_count,
+        PTO2ReadyQueue *queues, PTO2ResourceShape shape, ChipTaskSlotState **out, int max_count, uint64_t &atomic_count,
         uint64_t &wait_cycle
     ) {
         return queues[static_cast<int32_t>(shape)].pop_batch(out, max_count, atomic_count, wait_cycle);
     }
 #endif
 
-    void on_scope_end(PTO2TaskSlotState **task_slot_states, int32_t count) {
+    void on_scope_end(ChipTaskSlotState **task_slot_states, int32_t count) {
 #if SIMPLER_ORCH_PROFILING
         extern uint64_t g_orch_scope_end_atomic_count;
         if (count > 0) __builtin_prefetch(task_slot_states[0], 1, 0);
@@ -1145,7 +1145,7 @@ struct PTO2SchedulerState {
      *
      * @return true if this was the last subtask, completing the entire task.
      */
-    bool on_subtask_complete(PTO2TaskSlotState &slot_state) {
+    bool on_subtask_complete(ChipTaskSlotState &slot_state) {
         int16_t prev = slot_state.completed_subtasks.fetch_add(1, std::memory_order_acq_rel);
         return (prev + 1) == slot_state.total_required_subtasks;
     }
@@ -1162,7 +1162,7 @@ struct PTO2SchedulerState {
     uint32_t
 #endif
     on_task_complete(
-        PTO2TaskSlotState &slot_state
+        ChipTaskSlotState &slot_state
 #if SIMPLER_SCHED_PROFILING
         ,
         int thread_idx
@@ -1203,7 +1203,7 @@ struct PTO2SchedulerState {
 #endif
         EarlyDispatchReleaseSink rel_sink;
         while (current != nullptr) {
-            PTO2TaskSlotState &consumer_slot = *current->slot_state;
+            ChipTaskSlotState &consumer_slot = *current->slot_state;
 #if SIMPLER_SCHED_PROFILING
             stats.fanout_edges++;
             if (release_fanin_and_check_ready(consumer_slot, fanout_atomics, push_wait, &rel_sink)) {
@@ -1236,7 +1236,7 @@ struct PTO2SchedulerState {
      */
 
 #if SIMPLER_SCHED_PROFILING
-    int32_t on_task_release(PTO2TaskSlotState &slot_state, int32_t thread_idx) {
+    int32_t on_task_release(ChipTaskSlotState &slot_state, int32_t thread_idx) {
         PTO2_SCHED_CYCLE_START();
         extern uint64_t g_sched_fanin_cycle[], g_sched_fanin_atomic_count[];
         extern uint64_t g_sched_self_atomic_count[];
@@ -1244,7 +1244,7 @@ struct PTO2SchedulerState {
         extern uint64_t g_sched_complete_count[];
         uint64_t fanin_atomics = 0;
 #else
-    int32_t on_task_release(PTO2TaskSlotState &slot_state) {
+    int32_t on_task_release(ChipTaskSlotState &slot_state) {
 #endif
         PTO2TaskPayload *payload = slot_state.payload;
         int32_t released = 0;
@@ -1252,7 +1252,7 @@ struct PTO2SchedulerState {
         // ordering-only edge released its submit->wire pin at wiring, so releasing
         // it again here would over-count fanout_refcount against fanout_count and
         // break the rc == fc consume invariant.
-        for_each_fanin_slot_state(*payload, [&](PTO2TaskSlotState *producer_slot_state, DepFlags flags) {
+        for_each_fanin_slot_state(*payload, [&](ChipTaskSlotState *producer_slot_state, DepFlags flags) {
             if (!dep_has_retain(flags)) {
                 return;
             }
@@ -1319,7 +1319,7 @@ struct PTO2SchedulerState {
 // Short-circuit NotDeferred completions seen during drain so they don't grow
 // entries[]. Mirrors the a2a3 impl; see that mirror for the rationale.
 inline bool
-AsyncWaitList::try_inline_complete_locked(AsyncWaitList::DrainCompletionSink &sink, PTO2TaskSlotState &slot_state) {
+AsyncWaitList::try_inline_complete_locked(AsyncWaitList::DrainCompletionSink &sink, ChipTaskSlotState &slot_state) {
 #if SIMPLER_SCHED_PROFILING
     sink.sched->on_task_complete(slot_state, sink.thread_idx);
 #else
@@ -1344,7 +1344,7 @@ AsyncWaitList::try_inline_complete_locked(AsyncWaitList::DrainCompletionSink &si
 template <bool Profiling>
 inline AsyncPollResult AsyncWaitList::poll_and_complete(
     AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched,
-    PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count, int32_t deferred_release_capacity
+    ChipTaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count, int32_t deferred_release_capacity
 #if SIMPLER_SCHED_PROFILING
     ,
     int thread_idx

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
@@ -430,9 +430,9 @@ struct PTO2SchedulerLayout {
     size_t off_dummy_ready_queue_slots;
     size_t off_early_dispatch_queue_slots[PTO2_NUM_RESOURCE_SHAPES];
     size_t off_early_sync_start_queue_slots;
-    size_t off_dep_pool_entries[PTO2_MAX_RING_DEPTH];
+    size_t off_dep_pool_entries[CHIP_MAX_RING_DEPTH];
     uint64_t ready_queue_capacity;
-    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
+    int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH];
 };
 
 /**
@@ -521,7 +521,7 @@ struct PTO2SchedulerState {
 
             sync_to_sm(force_publish || last_task_alive == current_task_index);
         }
-    } ring_sched_states[PTO2_MAX_RING_DEPTH];
+    } ring_sched_states[CHIP_MAX_RING_DEPTH];
 
     alignas(64) std::atomic<uint32_t> advance_pending_mask;
     alignas(64) std::atomic<uint32_t> publication_request_mask;
@@ -587,7 +587,7 @@ struct PTO2SchedulerState {
         if (pending == 0) return false;
 
         bool advanced = false;
-        for (int32_t ring_id = 0; ring_id < PTO2_MAX_RING_DEPTH; ring_id++) {
+        for (int32_t ring_id = 0; ring_id < CHIP_MAX_RING_DEPTH; ring_id++) {
             uint32_t bit = ring_advance_pending_bit(ring_id);
             if ((pending & bit) == 0) continue;
 
@@ -613,7 +613,7 @@ struct PTO2SchedulerState {
         if (requests == 0) return false;
 
         bool advanced = false;
-        for (int32_t ring_id = 0; ring_id < PTO2_MAX_RING_DEPTH; ring_id++) {
+        for (int32_t ring_id = 0; ring_id < CHIP_MAX_RING_DEPTH; ring_id++) {
             uint32_t bit = ring_advance_pending_bit(ring_id);
             if ((requests & bit) == 0) continue;
 
@@ -1289,7 +1289,7 @@ struct PTO2SchedulerState {
     // the same values.
     static PTO2SchedulerLayout reserve_layout(DeviceArena &arena, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
     static PTO2SchedulerLayout
-    reserve_layout(DeviceArena &arena, const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]);
+    reserve_layout(DeviceArena &arena, const int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH]);
 
     // Phase 3a: write everything *except* arena-internal pointer fields.
     // `sm_dev_base` is the device address of the SM (only stored, never

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -1335,7 +1335,7 @@ void SchedulerContext::deinit() {
     func_id_to_addr_ = nullptr;
 }
 
-void SchedulerContext::bind_runtime(PTO2Runtime *rt) {
+void SchedulerContext::bind_runtime(RuntimeContext *rt) {
     rt_ = rt;
     sched_ = &rt->scheduler;
 }
@@ -1356,7 +1356,7 @@ void SchedulerContext::wait_for_orchestration_done_before_dispatch(Runtime *runt
 // and drives the orchestrator → scheduler core transition (or fatal shutdown).
 // =============================================================================
 void SchedulerContext::on_orchestration_done(
-    Runtime *runtime, PTO2Runtime *rt, [[maybe_unused]] int32_t thread_idx, int32_t total_tasks
+    Runtime *runtime, RuntimeContext *rt, [[maybe_unused]] int32_t thread_idx, int32_t total_tasks
 ) {
 #if SIMPLER_DFX
     if (chip_swimlane_level_ >= ChipSwimlaneLevel::ORCH_PHASES) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -235,7 +235,7 @@ void SchedulerContext::log_stall_diagnostics(
     // produce identical TASK lines once per scheduler thread.
     if (thread_idx == 0) {
         int32_t cnt_ready = 0, cnt_waiting = 0, cnt_running = 0, submitted_in_ring = 0;
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             PTO2SharedMemoryRingHeader &ring = *sched_->ring_sched_states[r].ring;
             int32_t ring_task_count = ring.fc.current_task_index.load(std::memory_order_relaxed);
             submitted_in_ring += ring_task_count;
@@ -371,7 +371,7 @@ SchedulerContext::StallClassification SchedulerContext::classify_stall_reason() 
     cls.stuck_task_id = -1;
     cls.stuck_core = -1;
     int32_t cnt_running = 0, cnt_ready = 0, cnt_waiting = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         PTO2SharedMemoryRingHeader &ring = *sched_->ring_sched_states[r].ring;
         int32_t ring_task_count = ring.fc.current_task_index.load(std::memory_order_relaxed);
         // Active task_ids live in [last_task_alive, current_task_index); slots wrap
@@ -1163,7 +1163,7 @@ int32_t SchedulerContext::pre_handshake_init(
     if (runtime->get_gm_sm_ptr()) {
         auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_gm_sm_ptr());
         int64_t task_count = 0;
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             int32_t ring_tasks = header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
             if (ring_tasks > 0 && ring_tasks <= PTO2_SCOPE_TASKS_CAP) task_count += ring_tasks;
         }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -244,7 +244,7 @@ void SchedulerContext::log_stall_diagnostics(
             // slot once per earlier task_id and inflates the scan_* counts.
             int32_t ring_task_start = ring.fc.last_task_alive.load(std::memory_order_relaxed);
             for (int32_t si = ring_task_start; si < ring_task_count; si++) {
-                PTO2TaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
+                ChipTaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
                 PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
                 int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
                 int32_t fi = slot_state.fanin_count;
@@ -380,7 +380,7 @@ SchedulerContext::StallClassification SchedulerContext::classify_stall_reason() 
         // Start at the tail so each live slot is visited exactly once (O(window)).
         int32_t ring_task_start = ring.fc.last_task_alive.load(std::memory_order_relaxed);
         for (int32_t si = ring_task_start; si < ring_task_count; si++) {
-            PTO2TaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
+            ChipTaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
             PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
             if (st >= PTO2_TASK_COMPLETED) continue;
             // Same ground truth as log_stall_diagnostics: task_state stays PENDING

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -76,9 +76,9 @@ SlotTransition SchedulerContext::decide_slot_transition(
 
 // Complete one slot's task: subtask counting, mixed completion, deferred release, profiling.
 void SchedulerContext::complete_slot_task(
-    PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, [[maybe_unused]] PTO2SubtaskSlot subslot,
+    ChipTaskSlotState &slot_state, int32_t expected_reg_task_id, [[maybe_unused]] PTO2SubtaskSlot subslot,
     [[maybe_unused]] int32_t thread_idx, int32_t core_id, Handshake *hank, int32_t &completed_this_turn,
-    PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count
+    ChipTaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count
 #if SIMPLER_DFX
     ,
     uint64_t dispatch_ts, uint64_t finish_ts
@@ -273,7 +273,7 @@ void SchedulerContext::clear_running_slot(CoreExecState &core) {
 
 void SchedulerContext::check_running_cores_for_completion(
     int32_t thread_idx, Handshake *hank, int32_t &completed_this_turn, int32_t &cur_thread_completed,
-    bool &made_progress, PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count
+    bool &made_progress, ChipTaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count
 ) {
 #if SIMPLER_SCHED_PROFILING
     auto &chip_swimlane = sched_chip_swimlane_[thread_idx];
@@ -287,7 +287,7 @@ void SchedulerContext::check_running_cores_for_completion(
 
         // Skip gated early-dispatch cores still waiting for their doorbell.
         {
-            PTO2TaskSlotState *rs = core.running_slot_state;
+            ChipTaskSlotState *rs = core.running_slot_state;
             if (rs != nullptr && rs->payload != nullptr &&
                 rs->payload->early_dispatch_state.load(std::memory_order_relaxed) == PTO2_EARLY_DISPATCH_STAGING) {
                 continue;
@@ -397,7 +397,7 @@ void SchedulerContext::check_running_cores_for_completion(
         // 2. Update slot data
         if (t.running_freed) {
             if (core.pending_slot_state != nullptr && !t.pending_done) {
-                PTO2TaskSlotState *promoted = core.pending_slot_state;
+                ChipTaskSlotState *promoted = core.pending_slot_state;
                 bool sync_start_promote = pending_gated && promoted->task_attrs.requires_sync_start();
                 promote_pending_to_running(core);
                 if (sync_start_promote) {
@@ -448,7 +448,7 @@ void SchedulerContext::check_running_cores_for_completion(
 // Two-phase protocol: CAS 0 -> -1 (sentinel) to claim ownership, store task and
 // reset staging state, then release-store block_num. Other threads acquire-load
 // sync_start_pending; seeing block_num > 0 ensures all relaxed stores are visible.
-bool SchedulerContext::enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t block_num) {
+bool SchedulerContext::enter_drain_mode(ChipTaskSlotState *slot_state, int32_t block_num) {
     int32_t expected = 0;
     if (!drain_state_.sync_start_pending.compare_exchange_strong(
             expected, -1, std::memory_order_acquire, std::memory_order_relaxed
@@ -484,7 +484,7 @@ int32_t SchedulerContext::count_global_available(PTO2ResourceShape shape, uint8_
 // cohort progress, while running_cores seeds the core-count rendezvous (MIX may
 // contribute multiple running cores per logical block).
 SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
-    PTO2TaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated,
+    ChipTaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated,
     [[maybe_unused]] bool record_drain_phases
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -616,7 +616,7 @@ void SchedulerContext::handle_drain_mode(
     }
     bool coordinator = thread_idx == 0;
 
-    PTO2TaskSlotState *slot_state = drain_state_.pending_task.load(std::memory_order_acquire);
+    ChipTaskSlotState *slot_state = drain_state_.pending_task.load(std::memory_order_acquire);
     bool gated = slot_state->payload != nullptr && PTO2SchedulerState::owns_early_sync_drain(*slot_state->payload);
 
     if (coordinator) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -247,11 +247,11 @@ private:
     }
 
     int pop_ready_tasks_batch(
-        PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, PTO2TaskSlotState **out, int max_count
+        PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, ChipTaskSlotState **out, int max_count
     );
 
     void build_payload(
-        PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
+        PTO2DispatchPayload &dispatch_payload, ChipTaskSlotState &slot_state, PTO2SubtaskSlot subslot,
         int32_t block_idx, bool force_gate = false
     );
 
@@ -273,7 +273,7 @@ private:
     };
 
     PublishHandle prepare_subtask_to_core(
-        int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
+        int32_t thread_idx, int32_t core_offset, ChipTaskSlotState &slot_state, PTO2SubtaskSlot subslot,
         bool to_pending, int32_t block_idx, bool force_gate = false
     );
 
@@ -295,7 +295,7 @@ private:
     // Fan out one block's subtasks (1 for AIC/AIV, 1-3 for MIX) into the
     // caller-supplied handles buffer. Returns the number of handles written.
     int prepare_block_for_dispatch(
-        int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2ResourceShape shape,
+        int32_t thread_idx, int32_t core_offset, ChipTaskSlotState &slot_state, PTO2ResourceShape shape,
         bool to_pending, int32_t block_idx, PublishHandle *out_handles, bool force_gate = false
     );
 
@@ -335,7 +335,7 @@ private:
         int32_t thread_idx, CoreTracker &tracker, bool pmu_active, bool &made_progress, bool &try_pushed
     );
     int32_t stage_consumer_blocks(
-        int32_t thread_idx, PTO2TaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
+        int32_t thread_idx, ChipTaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
         CoreTracker::BitStates &idle, CoreTracker::BitStates &pend
     );
     int32_t early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape shape, CoreTracker::DispatchPhase phase);
@@ -375,9 +375,9 @@ private:
     );
 
     void complete_slot_task(
-        PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
+        ChipTaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
         int32_t core_id, Handshake *hank, int32_t &completed_this_turn,
-        PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count
+        ChipTaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count
 #if SIMPLER_DFX
         ,
         uint64_t dispatch_ts, uint64_t finish_ts
@@ -389,17 +389,17 @@ private:
 
     void check_running_cores_for_completion(
         int32_t thread_idx, Handshake *hank, int32_t &completed_this_turn, int32_t &cur_thread_completed,
-        bool &made_progress, PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count
+        bool &made_progress, ChipTaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count
     );
 
-    bool enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t block_num);
+    bool enter_drain_mode(ChipTaskSlotState *slot_state, int32_t block_num);
     int32_t count_global_available(PTO2ResourceShape shape, uint8_t core_mask, bool include_pending = false);
     struct SyncStartStageResult {
         int32_t staged_blocks{0};
         int32_t running_cores{0};
     };
     SyncStartStageResult stage_sync_start_cores(
-        PTO2TaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated, bool record_drain_phases
+        ChipTaskSlotState *slot_state, int32_t block_num, int32_t thread_idx, bool gated, bool record_drain_phases
     );
     void handle_drain_mode(
         int32_t thread_idx, uint64_t *out_stage_wall_cycles = nullptr, int32_t *out_staged_blocks = nullptr

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -34,7 +34,7 @@
 // Forward declarations — avoid pulling in full headers for pointer/reference params.
 class Runtime;
 struct Handshake;
-struct PTO2Runtime;
+struct RuntimeContext;
 
 /**
  * SchedulerContext: owns all scheduler-side state and methods.
@@ -115,11 +115,11 @@ public:
     //    (skipped on fatal error — emergency_shutdown runs instead)
     // Callers must invoke rt_orchestration_done(rt) before this — that
     // step belongs to the orchestrator lifecycle, not the scheduler.
-    void on_orchestration_done(Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks);
+    void on_orchestration_done(Runtime *runtime, RuntimeContext *rt, int32_t thread_idx, int32_t total_tasks);
 
-    // Bind the PTO2Runtime scheduler pointer. Required in device-orchestration
+    // Bind the RuntimeContext scheduler pointer. Required in device-orchestration
     // mode where rt is created by the orchestrator thread after init().
-    void bind_runtime(PTO2Runtime *rt);
+    void bind_runtime(RuntimeContext *rt);
 
     // Serial orch->sched mode pre-dispatch wait. No AICore dispatch happens
     // before orchestrator_done_.
@@ -143,7 +143,7 @@ private:
 
     // --- Scheduler binding & per-core runtime state ---
     alignas(64) PTO2SchedulerState *sched_{nullptr};
-    PTO2Runtime *rt_{nullptr};
+    RuntimeContext *rt_{nullptr};
 
     // Per-core execution state, indexed by core_id (= worker_id)
     CoreExecState core_exec_states_[RUNTIME_MAX_WORKER];

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -83,7 +83,7 @@ bool SchedulerContext::has_idle_in_other_threads(int32_t self_thread_idx, PTO2Re
 }
 
 int SchedulerContext::pop_ready_tasks_batch(
-    PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, PTO2TaskSlotState **out, int max_count
+    PTO2ReadyQueue *queues, PTO2ResourceShape shape, int32_t thread_idx, ChipTaskSlotState **out, int max_count
 ) {
 #if SIMPLER_DFX
     auto &chip_swimlane = sched_chip_swimlane_[thread_idx];
@@ -112,7 +112,7 @@ int SchedulerContext::pop_ready_tasks_batch(
 }
 
 void SchedulerContext::build_payload(
-    PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot, int32_t block_idx,
+    PTO2DispatchPayload &dispatch_payload, ChipTaskSlotState &slot_state, PTO2SubtaskSlot subslot, int32_t block_idx,
     bool force_gate
 ) {
     int32_t slot_idx = static_cast<int32_t>(subslot);
@@ -140,7 +140,7 @@ void SchedulerContext::build_payload(
 }
 
 SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
-    int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot, bool to_pending,
+    int32_t thread_idx, int32_t core_offset, ChipTaskSlotState &slot_state, PTO2SubtaskSlot subslot, bool to_pending,
     int32_t block_idx, bool force_gate
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -206,7 +206,7 @@ SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
 }
 
 int SchedulerContext::prepare_block_for_dispatch(
-    int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state, PTO2ResourceShape shape, bool to_pending,
+    int32_t thread_idx, int32_t core_offset, ChipTaskSlotState &slot_state, PTO2ResourceShape shape, bool to_pending,
     int32_t block_idx, PublishHandle *out_handles, bool force_gate
 ) {
 #if SIMPLER_DFX
@@ -290,7 +290,7 @@ void SchedulerContext::dispatch_shape(
 
     while (cores.has_value() && !entered_drain) {
         int want = cores.count();
-        PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
+        ChipTaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
         int got = pop_ready_tasks_batch(disp_queues, shape, thread_idx, batch, want);
         if (got == 0) break;
 
@@ -328,7 +328,7 @@ void SchedulerContext::dispatch_shape(
         // contributes ≤ 3 subtasks for MIX.
         PublishHandle handles[CoreTracker::MAX_CLUSTERS * 3];
         int handle_count = 0;
-        PTO2TaskSlotState *published_list[CoreTracker::MAX_CLUSTERS * 3];
+        ChipTaskSlotState *published_list[CoreTracker::MAX_CLUSTERS * 3];
         int16_t published_counts[CoreTracker::MAX_CLUSTERS * 3];
         int published_n = 0;
         bool dispatched_any = false;
@@ -356,7 +356,7 @@ void SchedulerContext::dispatch_shape(
         };
 
         for (int bi = 0; bi < got; bi++) {
-            PTO2TaskSlotState *slot_state = batch[bi];
+            ChipTaskSlotState *slot_state = batch[bi];
             CoreTracker::BitStates selected_mix_clusters(0ULL);
 
             if (is_mix) {
@@ -577,7 +577,7 @@ void SchedulerContext::dispatch_ready_tasks(
 // those release did not take and rings them from its immutable local handles.
 // The seq_cst order guarantees every gated core has exactly one writer.
 int32_t SchedulerContext::stage_consumer_blocks(
-    int32_t thread_idx, PTO2TaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
+    int32_t thread_idx, ChipTaskSlotState *c, PTO2ResourceShape shape, int32_t start, int32_t count,
     CoreTracker::BitStates &idle, CoreTracker::BitStates &pend
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -677,7 +677,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
     if (!cores.has_value()) return 0;
 
     int32_t total_staged = 0;
-    PTO2TaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
+    ChipTaskSlotState *batch[CoreTracker::MAX_CLUSTERS * 3];
     uint64_t task_id_snapshots[CoreTracker::MAX_CLUSTERS * 3];
     // Batch-pop in one queue op (fewer CAS than one pop per consumer); the pop is
     // bounded by the shape's capacity so the stack buffer always holds it. Then for
@@ -691,7 +691,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, PTO2ResourceShape sha
     // is pushed back for peers (mirrors normal's push_batch of the unconsumed tail).
     int got = sched_->early_dispatch_queues[s].pop_batch_tagged(batch, task_id_snapshots, cores.count());
     for (int bi = 0; bi < got; bi++) {
-        PTO2TaskSlotState *c = batch[bi];
+        ChipTaskSlotState *c = batch[bi];
         if (static_cast<uint64_t>(c->task->task_id.raw) != task_id_snapshots[bi]) continue;
         if (c->payload->early_dispatch_state.load(std::memory_order_acquire) != PTO2_EARLY_DISPATCH_STAGING)
             continue;  // released
@@ -782,7 +782,7 @@ int32_t SchedulerContext::try_early_dispatch(
     // Case B preserves the global drain fallback for cohorts that need cores
     // owned by multiple schedulers. Neither case permits a partial cohort.
     uint64_t sync_task_id_snapshot = 0;
-    if (PTO2TaskSlotState *c = sched_->early_sync_start_queue.pop_tagged(&sync_task_id_snapshot)) {
+    if (ChipTaskSlotState *c = sched_->early_sync_start_queue.pop_tagged(&sync_task_id_snapshot)) {
         bool current_sync_task =
             static_cast<uint64_t>(c->task->task_id.raw) == sync_task_id_snapshot && c->task_attrs.requires_sync_start();
         if (current_sync_task && PTO2SchedulerState::try_claim_early_sync_drain(*c->payload)) {
@@ -865,7 +865,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     chip_swimlane.chip_swimlane_enabled = (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED);
 #endif
 
-    PTO2TaskSlotState *deferred_release_slot_states[PTO2_DEFERRED_RELEASE_CAP];
+    ChipTaskSlotState *deferred_release_slot_states[PTO2_DEFERRED_RELEASE_CAP];
     int32_t deferred_release_count = 0;
 
     // PMU runs require single-issue dispatch — overlapping in-flight tasks
@@ -1131,7 +1131,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         // the dependency-only resolve work.
         if (thread_idx < PLATFORM_MAX_AICPU_THREADS - 1) {
             constexpr int DUMMY_DRAIN_BATCH = 8;
-            PTO2TaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
+            ChipTaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
             int dummy_got = sched_->dummy_ready_queue.pop_batch(dummy_batch, DUMMY_DRAIN_BATCH);
 #if SIMPLER_DFX
             // Dummy outer phase: covers handling of all dummies popped this
@@ -1140,7 +1140,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 (dummy_got > 0 && chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES) ? get_sys_cnt_aicpu() : 0;
 #endif
             for (int di = 0; di < dummy_got; di++) {
-                PTO2TaskSlotState &dummy_slot = *dummy_batch[di];
+                ChipTaskSlotState &dummy_slot = *dummy_batch[di];
 #if SIMPLER_DFX
                 uint64_t dummy_resolve_t0 =
                     (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES) ? get_sys_cnt_aicpu() : 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -95,8 +95,8 @@ enum class LoopAction : int8_t {
 struct alignas(64) CoreExecState {
     // --- Hot fields (completion + dispatch, every iteration) ---
     uint64_t reg_addr;                      // offset  0: register base address (set once in handshake)
-    PTO2TaskSlotState *running_slot_state;  // offset  8: slot state for running task (nullptr = empty)
-    PTO2TaskSlotState *pending_slot_state;  // offset 16: slot state for pending task (nullptr = empty)
+    ChipTaskSlotState *running_slot_state;  // offset  8: slot state for running task (nullptr = empty)
+    ChipTaskSlotState *pending_slot_state;  // offset 16: slot state for pending task (nullptr = empty)
     int32_t running_reg_task_id;            // offset 24: register task ID (AICPU_TASK_INVALID = idle)
     int32_t pending_reg_task_id;            // offset 28: pending register task ID (AICPU_TASK_INVALID = none)
     uint32_t dispatch_seq;                  // offset 32: monotonic dispatch counter
@@ -549,7 +549,7 @@ struct alignas(64) SchedChipSwimlaneCounters {
 // (only process completions) until the fixed coordinator finishes launching all blocks.
 struct alignas(64) SyncStartDrainState {
     std::atomic<int32_t> sync_start_pending{0};              // 0=normal; -1=initializing; >0=active (value=block_num)
-    std::atomic<PTO2TaskSlotState *> pending_task{nullptr};  // held task (not re-queued)
+    std::atomic<ChipTaskSlotState *> pending_task{nullptr};  // held task (not re-queued)
     std::atomic<uint64_t> drain_attempt{0};                  // incremented whenever an ack round is reset
     // The coordinator publishes stage_go after global capacity is confirmed.
     // Each scheduler stages its local cores, publishes its bit in

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -12,7 +12,7 @@
  * Runtime Class - Implementation
  *
  * Device execution and handshake control.
- * Task graph construction is handled by PTO2Runtime.
+ * Task graph construction is handled by RuntimeContext.
  */
 
 #include "runtime.h"

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime_init.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime_init.cpp
@@ -540,8 +540,7 @@ void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler_arg) {
 // Top-level runtime arena
 // =============================================================================
 
-PTO2RuntimeArenaLayout
-runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, int32_t dep_pool_capacity) {
+RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, int32_t dep_pool_capacity) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
     int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
@@ -553,11 +552,11 @@ runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, int32_t de
     return runtime_reserve_layout(arena, task_window_sizes, heap_sizes, dep_pool_capacities);
 }
 
-PTO2RuntimeArenaLayout runtime_reserve_layout(
+RuntimeArenaLayout runtime_reserve_layout(
     DeviceArena &arena, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
     const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
 ) {
-    PTO2RuntimeArenaLayout layout{};
+    RuntimeArenaLayout layout{};
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         layout.sizing.task_window_sizes[r] = task_window_sizes[r];
@@ -572,16 +571,16 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
     }
     layout.offsets.orch = PTO2OrchestratorState::reserve_layout(arena, task_window_sizes_i32, dep_pool_capacities);
     layout.offsets.sched = PTO2SchedulerState::reserve_layout(arena, dep_pool_capacities);
-    layout.offsets.off_runtime = arena.reserve(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE);
+    layout.offsets.off_runtime = arena.reserve(sizeof(RuntimeContext), PTO2_ALIGN_SIZE);
     layout.offsets.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
 
     layout.offsets.arena_size = arena.total_size();
     return layout;
 }
 
-PTO2Runtime *runtime_init_data_from_layout(
-    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
-    uint64_t /*sm_size*/, void *gm_heap_dev_base, uint64_t heap_size
+RuntimeContext *runtime_init_data_from_layout(
+    DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t /*sm_size*/,
+    void *gm_heap_dev_base, uint64_t heap_size
 ) {
     uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -590,11 +589,11 @@ PTO2Runtime *runtime_init_data_from_layout(
     return runtime_init_data_from_layout(arena, layout, mode, sm_dev_base, 0, gm_heap_dev_base, heap_sizes);
 }
 
-PTO2Runtime *runtime_init_data_from_layout(
-    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
-    uint64_t /*sm_size*/, void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+RuntimeContext *runtime_init_data_from_layout(
+    DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t /*sm_size*/,
+    void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
 ) {
-    PTO2Runtime *rt = static_cast<PTO2Runtime *>(arena.region_ptr(layout.offsets.off_runtime));
+    RuntimeContext *rt = static_cast<RuntimeContext *>(arena.region_ptr(layout.offsets.off_runtime));
     memset(rt, 0, sizeof(*rt));
 
     auto *sm_wrap = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(layout.offsets.off_sm_handle));
@@ -626,7 +625,7 @@ PTO2Runtime *runtime_init_data_from_layout(
     return rt;
 }
 
-static bool reclaim_publication_wiring_is_complete(const PTO2Runtime *rt) {
+static bool reclaim_publication_wiring_is_complete(const RuntimeContext *rt) {
     if (rt == nullptr || rt->orchestrator.scheduler != &rt->scheduler) return false;
 
     const auto *request_mask = &rt->scheduler.publication_request_mask;
@@ -646,11 +645,11 @@ static bool reclaim_publication_wiring_is_complete(const PTO2Runtime *rt) {
     return true;
 }
 
-static void enable_publication_batching_if_safe(PTO2Runtime *rt) {
+static void enable_publication_batching_if_safe(RuntimeContext *rt) {
     rt->scheduler.set_publication_batching_enabled(reclaim_publication_wiring_is_complete(rt));
 }
 
-void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt) {
+void runtime_wire_arena_pointers(DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeContext *rt) {
     rt->scheduler.set_publication_batching_enabled(false);
     rt->sm_handle = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(layout.offsets.off_sm_handle));
     rt->aicore_mailbox = static_cast<AICoreCompletionMailbox *>(arena.region_ptr(layout.offsets.off_mailbox));
@@ -659,7 +658,7 @@ void runtime_wire_arena_pointers(DeviceArena &arena, const PTO2RuntimeArenaLayou
     enable_publication_batching_if_safe(rt);
 }
 
-bool runtime_reset_for_reuse(DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2Runtime *rt) {
+bool runtime_reset_for_reuse(DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeContext *rt) {
     (void)arena;
     if (rt == nullptr) {
         return false;
@@ -688,7 +687,7 @@ bool runtime_reset_for_reuse(DeviceArena &arena, const PTO2RuntimeArenaLayout &l
     return true;
 }
 
-void runtime_destroy(PTO2Runtime *rt, DeviceArena & /*arena*/) {
+void runtime_destroy(RuntimeContext *rt, DeviceArena & /*arena*/) {
     // Arena buffer is pooled across runs by DeviceRunner — never freed here.
     if (!rt) return;
     rt->scheduler.destroy();

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime_init.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime_init.cpp
@@ -354,7 +354,7 @@ PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
         layout.off_fanin_seen_epoch[r] = arena.reserve(seen_epoch_bytes, PTO2_ALIGN_SIZE);
     }
     layout.off_scope_tasks =
-        arena.reserve(static_cast<size_t>(layout.scope_tasks_cap) * sizeof(uintptr_t), alignof(PTO2TaskSlotState *));
+        arena.reserve(static_cast<size_t>(layout.scope_tasks_cap) * sizeof(uintptr_t), alignof(ChipTaskSlotState *));
     layout.off_scope_begins =
         arena.reserve(static_cast<size_t>(layout.scope_stack_capacity) * sizeof(int32_t), alignof(int32_t));
     layout.tensor_map = PTO2TensorMap::reserve_layout_default(arena, task_window_sizes);
@@ -507,7 +507,7 @@ void PTO2OrchestratorState::wire_arena_pointers(
         orch->fanin_seen_epoch[r] = static_cast<uint32_t *>(arena.region_ptr(layout.off_fanin_seen_epoch[r]));
     }
     orch->tensor_map.wire_arena_pointers(layout.tensor_map, arena);
-    orch->scope_tasks = static_cast<PTO2TaskSlotState **>(arena.region_ptr(layout.off_scope_tasks));
+    orch->scope_tasks = static_cast<ChipTaskSlotState **>(arena.region_ptr(layout.off_scope_tasks));
     orch->scope_begins = static_cast<int32_t *>(arena.region_ptr(layout.off_scope_begins));
     orch->set_scheduler(scheduler_arg);
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime_init.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime_init.cpp
@@ -31,9 +31,9 @@
 #include "tensormap.h"
 #include "scheduler/scheduler.h"
 
-static bool sum_ring_heap_sizes(const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], uint64_t *total) {
+static bool sum_ring_heap_sizes(const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH], uint64_t *total) {
     uint64_t sum = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         if (heap_sizes[r] > std::numeric_limits<uint64_t>::max() - sum) {
             LOG_ERROR("Total ring heap size overflows uint64_t");
             return false;
@@ -127,18 +127,18 @@ void PTO2SchedulerState::RingSchedState::destroy() {
 }
 
 PTO2SchedulerLayout PTO2SchedulerState::reserve_layout(DeviceArena &arena, int32_t dep_pool_capacity) {
-    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         dep_pool_capacities[r] = dep_pool_capacity;
     }
     return reserve_layout(arena, dep_pool_capacities);
 }
 
 PTO2SchedulerLayout
-PTO2SchedulerState::reserve_layout(DeviceArena &arena, const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]) {
+PTO2SchedulerState::reserve_layout(DeviceArena &arena, const int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH]) {
     PTO2SchedulerLayout layout{};
     layout.ready_queue_capacity = PTO2_READY_QUEUE_SIZE;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         layout.dep_pool_capacities[r] = dep_pool_capacities[r];
     }
 
@@ -153,7 +153,7 @@ PTO2SchedulerState::reserve_layout(DeviceArena &arena, const int32_t dep_pool_ca
         layout.off_early_dispatch_queue_slots[i] = ready_queue_reserve_layout(arena, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
     }
     layout.off_early_sync_start_queue_slots = ready_queue_reserve_layout(arena, PTO2_EARLY_DISPATCH_QUEUE_SIZE);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         // Force a cache-line base so Orch-side dep_pool writes do not invalidate
         // adjacent multi-threaded regions like ready_queue.slots.
         layout.off_dep_pool_entries[r] =
@@ -175,7 +175,7 @@ bool PTO2SchedulerState::init_data_from_layout(
     sched->tasks_consumed.store(0, std::memory_order_relaxed);
 #endif
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         if (!sched->ring_sched_states[r].init_data_from_layout(sm_dev_base, r)) {
             return false;
         }
@@ -216,7 +216,7 @@ bool PTO2SchedulerState::init_data_from_layout(
     }
 
     auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_dev_base);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         auto *dep_entries = static_cast<PTO2DepListEntry *>(arena.region_ptr(layout.off_dep_pool_entries[r]));
         memset(dep_entries, 0, static_cast<size_t>(layout.dep_pool_capacities[r]) * sizeof(PTO2DepListEntry));
         sched->ring_sched_states[r].dep_pool.init(dep_entries, layout.dep_pool_capacities[r], orch_err);
@@ -240,7 +240,7 @@ void PTO2SchedulerState::reset_for_reuse(const PTO2SchedulerLayout &layout, void
 #endif
 
     auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_dev_base);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         sched->ring_sched_states[r].reset_for_reuse(sm_dev_base, r, orch_err);
     }
 
@@ -275,7 +275,7 @@ void PTO2SchedulerState::wire_arena_pointers(const PTO2SchedulerLayout &layout, 
         );
     }
     ready_queue_wire_arena_pointers(&sched->early_sync_start_queue, arena, layout.off_early_sync_start_queue_slots);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         auto &dep_pool = sched->ring_sched_states[r].dep_pool;
         dep_pool.base = static_cast<PTO2DepListEntry *>(arena.region_ptr(layout.off_dep_pool_entries[r]));
         dep_pool.set_reclaim_publication_request(
@@ -286,7 +286,7 @@ void PTO2SchedulerState::wire_arena_pointers(const PTO2SchedulerLayout &layout, 
 
 void PTO2SchedulerState::destroy() {
     PTO2SchedulerState *sched = this;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         sched->ring_sched_states[r].destroy();
         sched->ring_sched_states[r].dep_pool.base = nullptr;
     }
@@ -308,18 +308,18 @@ void PTO2SchedulerState::destroy() {
 // =============================================================================
 
 PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
-    DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH], int32_t dep_pool_capacity
+    DeviceArena &arena, const int32_t task_window_sizes[CHIP_MAX_RING_DEPTH], int32_t dep_pool_capacity
 ) {
-    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         dep_pool_capacities[r] = dep_pool_capacity;
     }
     return reserve_layout(arena, task_window_sizes, dep_pool_capacities);
 }
 
 PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
-    DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+    DeviceArena &arena, const int32_t task_window_sizes[CHIP_MAX_RING_DEPTH],
+    const int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH]
 ) {
     PTO2OrchestratorLayout layout{};
     // scope_tasks holds every task in the open scope across all rings, so its cap
@@ -329,21 +329,21 @@ PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
     // and over-allocated it when shrunk. See issue #1188.
     //
     // Accumulate in int64: each window is validated <= INT32_MAX individually, but
-    // the sum of PTO2_MAX_RING_DEPTH windows can exceed it — a bare int32 sum would
+    // the sum of CHIP_MAX_RING_DEPTH windows can exceed it — a bare int32 sum would
     // wrap to a negative/undersized cap. Bound the result before narrowing.
     int64_t scope_tasks_cap = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         always_assert(task_window_sizes[r] > 0);
         scope_tasks_cap += task_window_sizes[r];
     }
     always_assert(scope_tasks_cap <= std::numeric_limits<int32_t>::max());
     layout.scope_tasks_cap = static_cast<int32_t>(scope_tasks_cap);
     layout.scope_stack_capacity = PTO2_MAX_SCOPE_DEPTH;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         layout.dep_pool_capacities[r] = dep_pool_capacities[r];
     }
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         const size_t fanin_pool_bytes =
             PTO2_ALIGN_UP(static_cast<size_t>(dep_pool_capacities[r]) * sizeof(PTO2FaninSpillEntry), PTO2_ALIGN_SIZE);
         layout.off_fanin_pool[r] = arena.reserve(fanin_pool_bytes, PTO2_ALIGN_SIZE);
@@ -365,9 +365,9 @@ bool PTO2OrchestratorState::init_data_from_layout(
     const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap, uint64_t heap_size,
     uint64_t task_window_size
 ) {
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    uint64_t heap_sizes[CHIP_MAX_RING_DEPTH];
+    uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         heap_sizes[r] = heap_size;
         task_window_sizes[r] = task_window_size;
     }
@@ -376,7 +376,7 @@ bool PTO2OrchestratorState::init_data_from_layout(
 
 bool PTO2OrchestratorState::init_data_from_layout(
     const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap,
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+    const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH], const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]
 ) {
     auto *orch = this;
     *orch = PTO2OrchestratorState{};
@@ -392,7 +392,7 @@ bool PTO2OrchestratorState::init_data_from_layout(
 
     auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_dev_base);
     uint64_t heap_offset = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         void *ring_heap_base = reinterpret_cast<char *>(gm_heap) + heap_offset;
         auto *task_descs_dev = pto2_sm_layout::ring_task_descriptors_addr(sm_dev_base, task_window_sizes, r);
         auto *slot_states_dev = pto2_sm_layout::ring_slot_states_addr(sm_dev_base, task_window_sizes, r);
@@ -435,7 +435,7 @@ bool PTO2OrchestratorState::init_data_from_layout(
 
 bool PTO2OrchestratorState::reset_for_reuse(
     const PTO2OrchestratorLayout &layout, void *sm_dev_base, void *gm_heap,
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+    const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH], const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]
 ) {
     auto *orch = this;
     orch->sm_header = reinterpret_cast<PTO2SharedMemoryHeader *>(sm_dev_base);
@@ -451,7 +451,7 @@ bool PTO2OrchestratorState::reset_for_reuse(
     uint32_t next_epoch = orch->fanin_seen_current_epoch + 1;
     if (next_epoch == 0) {
         next_epoch = 1;
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             memset(
                 orch->fanin_seen_epoch[r], 0,
                 static_cast<size_t>(layout.tensor_map.task_window_sizes[r]) * sizeof(uint32_t)
@@ -462,7 +462,7 @@ bool PTO2OrchestratorState::reset_for_reuse(
 
     auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_dev_base);
     uint64_t heap_offset = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         void *ring_heap_base = reinterpret_cast<char *>(gm_heap) + heap_offset;
         auto *task_descs_dev = pto2_sm_layout::ring_task_descriptors_addr(sm_dev_base, task_window_sizes, r);
         auto *slot_states_dev = pto2_sm_layout::ring_slot_states_addr(sm_dev_base, task_window_sizes, r);
@@ -502,7 +502,7 @@ void PTO2OrchestratorState::wire_arena_pointers(
     const PTO2OrchestratorLayout &layout, DeviceArena &arena, PTO2SchedulerState *scheduler_arg
 ) {
     auto *orch = this;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         orch->rings[r].fanin_pool.base = static_cast<PTO2FaninSpillEntry *>(arena.region_ptr(layout.off_fanin_pool[r]));
         orch->fanin_seen_epoch[r] = static_cast<uint32_t *>(arena.region_ptr(layout.off_fanin_seen_epoch[r]));
     }
@@ -515,7 +515,7 @@ void PTO2OrchestratorState::wire_arena_pointers(
 void PTO2OrchestratorState::destroy() {
     auto *orch = this;
     orch->tensor_map.destroy();
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         orch->rings[r].fanin_pool.base = nullptr;
         orch->fanin_seen_epoch[r] = nullptr;
     }
@@ -526,7 +526,7 @@ void PTO2OrchestratorState::destroy() {
 void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler_arg) {
     scheduler = scheduler_arg;
     if (scheduler == nullptr) return;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         rings[r].task_allocator.set_reclaim_publication_request(
             &scheduler->publication_request_mask, &scheduler->publication_ack_mask
         );
@@ -541,10 +541,10 @@ void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler_arg) {
 // =============================================================================
 
 RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, int32_t dep_pool_capacity) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+    uint64_t heap_sizes[CHIP_MAX_RING_DEPTH];
+    int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
         heap_sizes[r] = 0;
         dep_pool_capacities[r] = dep_pool_capacity;
@@ -553,20 +553,20 @@ RuntimeArenaLayout runtime_reserve_layout(DeviceArena &arena, uint64_t task_wind
 }
 
 RuntimeArenaLayout runtime_reserve_layout(
-    DeviceArena &arena, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+    DeviceArena &arena, const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH], const int32_t dep_pool_capacities[CHIP_MAX_RING_DEPTH]
 ) {
     RuntimeArenaLayout layout{};
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         layout.sizing.task_window_sizes[r] = task_window_sizes[r];
         layout.sizing.heap_sizes[r] = heap_sizes[r];
         layout.sizing.dep_pool_capacities[r] = dep_pool_capacities[r];
     }
 
     layout.offsets.off_sm_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
-    int32_t task_window_sizes_i32[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    int32_t task_window_sizes_i32[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_window_sizes_i32[r] = static_cast<int32_t>(task_window_sizes[r]);
     }
     layout.offsets.orch = PTO2OrchestratorState::reserve_layout(arena, task_window_sizes_i32, dep_pool_capacities);
@@ -582,8 +582,8 @@ RuntimeContext *runtime_init_data_from_layout(
     DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t /*sm_size*/,
     void *gm_heap_dev_base, uint64_t heap_size
 ) {
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    uint64_t heap_sizes[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         heap_sizes[r] = heap_size;
     }
     return runtime_init_data_from_layout(arena, layout, mode, sm_dev_base, 0, gm_heap_dev_base, heap_sizes);
@@ -591,7 +591,7 @@ RuntimeContext *runtime_init_data_from_layout(
 
 RuntimeContext *runtime_init_data_from_layout(
     DeviceArena &arena, const RuntimeArenaLayout &layout, RuntimeMode mode, void *sm_dev_base, uint64_t /*sm_size*/,
-    void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+    void *gm_heap_dev_base, const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH]
 ) {
     RuntimeContext *rt = static_cast<RuntimeContext *>(arena.region_ptr(layout.offsets.off_runtime));
     memset(rt, 0, sizeof(*rt));
@@ -630,7 +630,7 @@ static bool reclaim_publication_wiring_is_complete(const RuntimeContext *rt) {
 
     const auto *request_mask = &rt->scheduler.publication_request_mask;
     const auto *ack_mask = &rt->scheduler.publication_ack_mask;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         uint8_t ring_id = static_cast<uint8_t>(r);
         if (!rt->orchestrator.rings[r].task_allocator.reclaim_publication_is_wired_to(
                 request_mask, ack_mask, ring_id

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/shared_memory.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/shared_memory.cpp
@@ -28,31 +28,31 @@
 // =============================================================================
 
 uint64_t PTO2SharedMemoryHandle::calculate_size(uint64_t task_window_size) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
     }
     return calculate_size_per_ring(task_window_sizes);
 }
 
-uint64_t PTO2SharedMemoryHandle::calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+uint64_t PTO2SharedMemoryHandle::calculate_size_per_ring(const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]) {
     // Total SM size = offset just past the last ring, from the single source of
     // truth for the layout (pto2_sm_layout::ring_segment_offsets).
-    return pto2_sm_layout::ring_segment_offsets(task_window_sizes, PTO2_MAX_RING_DEPTH - 1).end;
+    return pto2_sm_layout::ring_segment_offsets(task_window_sizes, CHIP_MAX_RING_DEPTH - 1).end;
 }
 
 // =============================================================================
 // Creation and Destruction
 // =============================================================================
 
-void PTO2SharedMemoryHandle::setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+void PTO2SharedMemoryHandle::setup_pointers_per_ring(const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]) {
     char *base = (char *)sm_base;
     header = (PTO2SharedMemoryHeader *)base;
 
     // Per-ring descriptors / payloads / slot_states — offsets from the single
     // source of truth (pto2_sm_layout::ring_segment_offsets), so this setup and
     // the device-address helpers cannot drift.
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         auto off = pto2_sm_layout::ring_segment_offsets(task_window_sizes, r);
         auto &ring = header->rings[r];
         ring.task_descriptors = (PTO2TaskDescriptor *)(base + off.descriptors);
@@ -62,8 +62,8 @@ void PTO2SharedMemoryHandle::setup_pointers_per_ring(const uint64_t task_window_
 }
 
 void PTO2SharedMemoryHandle::setup_pointers(uint64_t task_window_size) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
     }
     setup_pointers_per_ring(task_window_sizes);
@@ -72,9 +72,9 @@ void PTO2SharedMemoryHandle::setup_pointers(uint64_t task_window_size) {
 bool PTO2SharedMemoryHandle::init(
     void *sm_base_arg, uint64_t sm_size_arg, uint64_t task_window_size, uint64_t heap_size
 ) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+    uint64_t heap_sizes[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
         heap_sizes[r] = heap_size;
     }
@@ -82,8 +82,8 @@ bool PTO2SharedMemoryHandle::init(
 }
 
 bool PTO2SharedMemoryHandle::init_per_ring(
-    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH]
 ) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
     if (sm_size_arg < calculate_size_per_ring(task_window_sizes)) return false;
@@ -125,9 +125,9 @@ void PTO2SharedMemoryHandle::destroy() {
 //
 // no need init data in pool, init pool data when used
 void PTO2SharedMemoryHandle::init_header(uint64_t task_window_size, uint64_t heap_size) {
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+    uint64_t heap_sizes[CHIP_MAX_RING_DEPTH];
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
         heap_sizes[r] = heap_size;
     }
@@ -135,10 +135,10 @@ void PTO2SharedMemoryHandle::init_header(uint64_t task_window_size, uint64_t hea
 }
 
 void PTO2SharedMemoryHandle::init_header_per_ring(
-    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+    const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH], const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH]
 ) {
     // Per-ring flow control (start at 0)
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         header->rings[r].fc.init();
     }
 
@@ -146,7 +146,7 @@ void PTO2SharedMemoryHandle::init_header_per_ring(
 
     // Per-ring layout info
     uint64_t offset = PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         header->rings[r].task_window_size = task_window_sizes[r];
         header->rings[r].task_window_mask = static_cast<int32_t>(task_window_sizes[r] - 1);
         header->rings[r].heap_size = heap_sizes[r];
@@ -191,8 +191,8 @@ void PTO2SharedMemoryHandle::print_layout() {
     LOG_DEBUG("=== PTO2 Shared Memory Layout ===");
     LOG_DEBUG("Base address:       %p", sm_base);
     LOG_DEBUG("Total size:         %" PRIu64 " bytes", h->total_size);
-    LOG_DEBUG("Ring depth:         %d", PTO2_MAX_RING_DEPTH);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    LOG_DEBUG("Ring depth:         %d", CHIP_MAX_RING_DEPTH);
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         LOG_DEBUG("Ring %d:", r);
         LOG_DEBUG("  task_window_size: %" PRIu64, h->rings[r].task_window_size);
         LOG_DEBUG("  heap_size:        %" PRIu64 " bytes", h->rings[r].heap_size);
@@ -218,7 +218,7 @@ bool PTO2SharedMemoryHandle::validate() {
 
     PTO2SharedMemoryHeader *h = header;
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         if (!h->rings[r].fc.validate(this, r)) return false;
     }
 
@@ -228,7 +228,7 @@ bool PTO2SharedMemoryHandle::validate() {
 bool PTO2RingFlowControl::validate(PTO2SharedMemoryHandle *handle, int32_t ring_id) const {
     if (!handle) return false;
     if (!handle->header) return false;
-    if (ring_id < 0 || ring_id >= PTO2_MAX_RING_DEPTH) return false;
+    if (ring_id < 0 || ring_id >= CHIP_MAX_RING_DEPTH) return false;
 
     const PTO2SharedMemoryHeader *h = handle->header;
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/shared_memory.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/shared_memory.cpp
@@ -57,7 +57,7 @@ void PTO2SharedMemoryHandle::setup_pointers_per_ring(const uint64_t task_window_
         auto &ring = header->rings[r];
         ring.task_descriptors = (PTO2TaskDescriptor *)(base + off.descriptors);
         ring.task_payloads = (PTO2TaskPayload *)(base + off.payloads);
-        ring.slot_states = (PTO2TaskSlotState *)(base + off.slot_states);
+        ring.slot_states = (ChipTaskSlotState *)(base + off.slot_states);
     }
 }
 
@@ -153,7 +153,7 @@ void PTO2SharedMemoryHandle::init_header_per_ring(
         header->rings[r].task_descriptors_offset = offset;
         offset += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
         offset += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
-        offset += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
+        offset += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(ChipTaskSlotState), PTO2_ALIGN_SIZE);
     }
 
     header->total_size = sm_size;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/tensormap.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/tensormap.cpp
@@ -49,7 +49,7 @@ uint64_t g_insert_count = 0;
 
 PTO2TensorMapLayout PTO2TensorMap::reserve_layout(
     DeviceArena &arena, int32_t new_num_buckets, int32_t new_pool_size,
-    const int32_t new_task_window_sizes[PTO2_MAX_RING_DEPTH]
+    const int32_t new_task_window_sizes[CHIP_MAX_RING_DEPTH]
 ) {
     // num_buckets must be a power of two for the hash truncation to work.
     always_assert((new_num_buckets & (new_num_buckets - 1)) == 0);
@@ -57,7 +57,7 @@ PTO2TensorMapLayout PTO2TensorMap::reserve_layout(
     PTO2TensorMapLayout layout{};
     layout.num_buckets = new_num_buckets;
     layout.pool_size = new_pool_size;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         layout.task_window_sizes[r] = new_task_window_sizes[r];
     }
 
@@ -70,7 +70,7 @@ PTO2TensorMapLayout PTO2TensorMap::reserve_layout(
         arena.reserve(static_cast<size_t>(new_pool_size) * sizeof(PTO2TensorMapEntry), alignof(PTO2TensorMapEntry));
     layout.off_free_entry_list =
         arena.reserve(static_cast<size_t>(new_pool_size) * sizeof(PTO2TensorMapEntry *), alignof(PTO2TensorMapEntry *));
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         layout.off_task_entry_heads[r] = arena.reserve(
             static_cast<size_t>(new_task_window_sizes[r]) * sizeof(PTO2TensorMapEntry *), alignof(PTO2TensorMapEntry *)
         );
@@ -81,7 +81,7 @@ PTO2TensorMapLayout PTO2TensorMap::reserve_layout(
 }
 
 PTO2TensorMapLayout
-PTO2TensorMap::reserve_layout_default(DeviceArena &arena, const int32_t new_task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+PTO2TensorMap::reserve_layout_default(DeviceArena &arena, const int32_t new_task_window_sizes[CHIP_MAX_RING_DEPTH]) {
     return reserve_layout(arena, PTO2_TENSORMAP_NUM_BUCKETS, PTO2_TENSORMAP_POOL_SIZE, new_task_window_sizes);
 }
 
@@ -122,7 +122,7 @@ bool PTO2TensorMap::init_data_from_layout(const PTO2TensorMapLayout &layout, Dev
     next_entry_idx = 0;
     free_num = 0;
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         auto *heads_arena = static_cast<PTO2TensorMapEntry **>(arena.region_ptr(layout.off_task_entry_heads[r]));
         auto *head_epochs_arena = static_cast<uint32_t *>(arena.region_ptr(layout.off_task_entry_head_epochs[r]));
         for (int32_t i = 0; i < layout.task_window_sizes[r]; i++) {
@@ -146,12 +146,12 @@ void PTO2TensorMap::reset_for_reuse(const PTO2TensorMapLayout &layout) {
     if (current_epoch == 0) {
         current_epoch = 1;
         memset(bucket_epochs, 0, static_cast<size_t>(layout.num_buckets) * sizeof(uint32_t));
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             memset(task_entry_head_epochs[r], 0, static_cast<size_t>(layout.task_window_sizes[r]) * sizeof(uint32_t));
         }
     }
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = layout.task_window_sizes[r];
         last_task_alives[r] = 0;
         last_cleanup[r] = 0;
@@ -163,7 +163,7 @@ void PTO2TensorMap::wire_arena_pointers(const PTO2TensorMapLayout &layout, Devic
     bucket_epochs = static_cast<uint32_t *>(arena.region_ptr(layout.off_bucket_epochs));
     entry_pool = static_cast<PTO2TensorMapEntry *>(arena.region_ptr(layout.off_entry_pool));
     free_entry_list = static_cast<PTO2TensorMapEntry **>(arena.region_ptr(layout.off_free_entry_list));
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_entry_heads[r] = static_cast<PTO2TensorMapEntry **>(arena.region_ptr(layout.off_task_entry_heads[r]));
         task_entry_head_epochs[r] = static_cast<uint32_t *>(arena.region_ptr(layout.off_task_entry_head_epochs[r]));
     }
@@ -177,7 +177,7 @@ void PTO2TensorMap::destroy() {
     bucket_epochs = nullptr;
     entry_pool = nullptr;
     free_entry_list = nullptr;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         task_entry_heads[r] = nullptr;
         task_entry_head_epochs[r] = nullptr;
     }
@@ -237,7 +237,7 @@ void PTO2TensorMap::print_stats() {
     LOG_DEBUG("Empty buckets:       %d", empty_buckets);
     LOG_DEBUG("Max chain len:       %d", max_chain);
     LOG_DEBUG("Avg chain len:       %.2f", non_empty_buckets > 0 ? (float)total_chain / non_empty_buckets : 0);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         LOG_DEBUG("Last task alive[%d]: %d", r, last_task_alives[r]);
     }
     LOG_DEBUG("============================");

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared_memory.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared_memory.h
@@ -13,7 +13,7 @@
  *
  * Defines the shared memory structure for Orchestrator-Scheduler communication.
  *
- * Memory Layout (per-ring sections repeat for each ring 0..PTO2_MAX_RING_DEPTH-1):
+ * Memory Layout (per-ring sections repeat for each ring 0..CHIP_MAX_RING_DEPTH-1):
  *   +---------------------------+
  *   | SharedMemoryHeader        |  (per-ring flow control + sync)
  *   +---------------------------+
@@ -129,7 +129,7 @@ static_assert(
  */
 struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
     // === PER-RING FLOW CONTROL + LAYOUT INFO (set once at init) ===
-    PTO2SharedMemoryRingHeader rings[PTO2_MAX_RING_DEPTH];
+    PTO2SharedMemoryRingHeader rings[CHIP_MAX_RING_DEPTH];
 
     // === GLOBAL FIELDS ===
     std::atomic<int32_t> orchestrator_done;  // Flag: orchestration complete
@@ -195,7 +195,7 @@ struct PTO2SharedMemoryHandle {
     // === Static helpers ===
 
     static uint64_t calculate_size(uint64_t task_window_size);
-    static uint64_t calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
+    static uint64_t calculate_size_per_ring(const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]);
 
     // UT convenience: reserve wrapper + sm_base on `arena`, commit, and init
     // using default PTO2_TASK_WINDOW_SIZE / PTO2_HEAP_SIZE. Only valid when the
@@ -211,8 +211,8 @@ struct PTO2SharedMemoryHandle {
     // `task_window_size`.
     bool init(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size);
     bool init_per_ring(
-        void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-        const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+        void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH],
+        const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH]
     );
 
     void destroy();
@@ -222,10 +222,10 @@ struct PTO2SharedMemoryHandle {
 private:
     void init_header(uint64_t task_window_size, uint64_t heap_size);
     void init_header_per_ring(
-        const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+        const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH], const uint64_t heap_sizes[CHIP_MAX_RING_DEPTH]
     );
     void setup_pointers(uint64_t task_window_size);
-    void setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
+    void setup_pointers_per_ring(const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH]);
 };
 
 // =============================================================================
@@ -288,8 +288,8 @@ struct PTO2RingSegmentOffsets {
 // segment is a one-line edit here; every consumer follows automatically, so the
 // layout walk can never silently disagree across call sites.
 inline PTO2RingSegmentOffsets
-ring_segment_offsets(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], int ring_id) noexcept {
-    assert(ring_id >= 0 && ring_id < PTO2_MAX_RING_DEPTH && "pto2_sm_layout: ring_id out of range");
+ring_segment_offsets(const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH], int ring_id) noexcept {
+    assert(ring_id >= 0 && ring_id < CHIP_MAX_RING_DEPTH && "pto2_sm_layout: ring_id out of range");
     uint64_t off = PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
     for (int r = 0; r < ring_id; r++) {
         off += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
@@ -309,7 +309,7 @@ ring_segment_offsets(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], int 
 
 // Device address of ring `ring_id`'s task_descriptors array.
 inline PTO2TaskDescriptor *ring_task_descriptors_addr(
-    void *sm_dev_base, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], int ring_id
+    void *sm_dev_base, const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH], int ring_id
 ) noexcept {
     return reinterpret_cast<PTO2TaskDescriptor *>(
         static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_sizes, ring_id).descriptors
@@ -319,7 +319,7 @@ inline PTO2TaskDescriptor *ring_task_descriptors_addr(
 // Device address of ring `ring_id`'s slot_states array (used by the allocator's
 // deadlock detector to identify the head task's slot).
 inline ChipTaskSlotState *
-ring_slot_states_addr(void *sm_dev_base, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], int ring_id) noexcept {
+ring_slot_states_addr(void *sm_dev_base, const uint64_t task_window_sizes[CHIP_MAX_RING_DEPTH], int ring_id) noexcept {
     return reinterpret_cast<ChipTaskSlotState *>(
         static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_sizes, ring_id).slot_states
     );

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared_memory.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared_memory.h
@@ -95,7 +95,7 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     // Per-ring data pointers (host-side, set by setup_pointers)
     PTO2TaskDescriptor *task_descriptors;
     PTO2TaskPayload *task_payloads;
-    PTO2TaskSlotState *slot_states;
+    ChipTaskSlotState *slot_states;
 
     int32_t get_slot_by_task_id(int32_t local_task_id) { return local_task_id & task_window_mask; }
 
@@ -109,9 +109,9 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
 
     PTO2TaskPayload &get_payload_by_task_id(int32_t local_id) { return task_payloads[get_slot_by_task_id(local_id)]; }
 
-    PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
+    ChipTaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
-    PTO2TaskSlotState &get_slot_state_by_task_id(int32_t local_id) {
+    ChipTaskSlotState &get_slot_state_by_task_id(int32_t local_id) {
         return slot_states[get_slot_by_task_id(local_id)];
     }
 };
@@ -294,7 +294,7 @@ ring_segment_offsets(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], int 
     for (int r = 0; r < ring_id; r++) {
         off += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
         off += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
-        off += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
+        off += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(ChipTaskSlotState), PTO2_ALIGN_SIZE);
     }
     PTO2RingSegmentOffsets o{};
     o.descriptors = off;
@@ -302,7 +302,7 @@ ring_segment_offsets(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], int 
     o.payloads = off;
     off += PTO2_ALIGN_UP(task_window_sizes[ring_id] * sizeof(PTO2TaskPayload), PTO2_ALIGN_SIZE);
     o.slot_states = off;
-    off += PTO2_ALIGN_UP(task_window_sizes[ring_id] * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
+    off += PTO2_ALIGN_UP(task_window_sizes[ring_id] * sizeof(ChipTaskSlotState), PTO2_ALIGN_SIZE);
     o.end = off;
     return o;
 }
@@ -318,9 +318,9 @@ inline PTO2TaskDescriptor *ring_task_descriptors_addr(
 
 // Device address of ring `ring_id`'s slot_states array (used by the allocator's
 // deadlock detector to identify the head task's slot).
-inline PTO2TaskSlotState *
+inline ChipTaskSlotState *
 ring_slot_states_addr(void *sm_dev_base, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], int ring_id) noexcept {
-    return reinterpret_cast<PTO2TaskSlotState *>(
+    return reinterpret_cast<ChipTaskSlotState *>(
         static_cast<char *>(sm_dev_base) + ring_segment_offsets(task_window_sizes, ring_id).slot_states
     );
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/submit_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/submit_types.h
@@ -167,7 +167,7 @@ private:
 static_assert(sizeof(ActiveMask) == 1, "ActiveMask must be exactly 1 byte");
 
 /**
- * Per-task scheduling attributes, packed into one byte on PTO2TaskSlotState.
+ * Per-task scheduling attributes, packed into one byte on ChipTaskSlotState.
  *
  * Single home for the independent per-task flags: an early-dispatch hint, the
  * two dispatch-time predicates (sync_start / has_predicate), and the selective

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensormap.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensormap.h
@@ -77,11 +77,11 @@ struct PTO2TensorMapLayout {
     size_t off_bucket_epochs;
     size_t off_entry_pool;
     size_t off_free_entry_list;
-    size_t off_task_entry_heads[PTO2_MAX_RING_DEPTH];
-    size_t off_task_entry_head_epochs[PTO2_MAX_RING_DEPTH];
+    size_t off_task_entry_heads[CHIP_MAX_RING_DEPTH];
+    size_t off_task_entry_head_epochs[CHIP_MAX_RING_DEPTH];
     int32_t num_buckets;
     int32_t pool_size;
-    int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
+    int32_t task_window_sizes[CHIP_MAX_RING_DEPTH];
 };
 
 // TensorMap Lookup Profiling (must precede inline lookup/insert methods).
@@ -374,16 +374,16 @@ struct PTO2TensorMap {
 
     // Per-ring per-task entry tracking (for efficient bucket cleanup)
     // Indexed by [ring_id][local_id & (task_window_sizes[ring_id] - 1)]
-    PTO2TensorMapEntry **task_entry_heads[PTO2_MAX_RING_DEPTH];
-    uint32_t *task_entry_head_epochs[PTO2_MAX_RING_DEPTH];
-    int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];  // Per-ring task window size (for slot masking)
+    PTO2TensorMapEntry **task_entry_heads[CHIP_MAX_RING_DEPTH];
+    uint32_t *task_entry_head_epochs[CHIP_MAX_RING_DEPTH];
+    int32_t task_window_sizes[CHIP_MAX_RING_DEPTH];  // Per-ring task window size (for slot masking)
     uint32_t current_epoch{1};
 
     // Per-ring validity threshold (for lazy invalidation)
-    int32_t last_task_alives[PTO2_MAX_RING_DEPTH];  // Cached from shared memory per ring
+    int32_t last_task_alives[CHIP_MAX_RING_DEPTH];  // Cached from shared memory per ring
 
     // Per-ring cleanup progress (for periodic cleanup_retired)
-    int32_t last_cleanup[PTO2_MAX_RING_DEPTH]{};
+    int32_t last_cleanup[CHIP_MAX_RING_DEPTH]{};
 
     uint32_t get_task_local_id_slot(uint8_t ring_id, uint32_t task_local_id) const {
         return task_local_id & (task_window_sizes[ring_id] - 1);
@@ -404,9 +404,9 @@ struct PTO2TensorMap {
     // shortage (some ring still retiring tasks) from a wedged pool (no ring
     // advancing). Idempotent per watermark: a ring whose alive has not passed
     // last_cleanup[r] is skipped, so it never double-frees.
-    int64_t reclaim_retired_all(const int32_t sm_last_task_alive[PTO2_MAX_RING_DEPTH]) {
+    int64_t reclaim_retired_all(const int32_t sm_last_task_alive[CHIP_MAX_RING_DEPTH]) {
         int64_t alive_sum = 0;
-        for (int32_t r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int32_t r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             int32_t alive = sm_last_task_alive[r];
             sync_validity(r, alive);
             if (alive > last_cleanup[r]) {
@@ -466,7 +466,7 @@ struct PTO2TensorMap {
      * committed.
      */
     static PTO2TensorMapLayout reserve_layout(
-        DeviceArena &arena, int32_t num_buckets, int32_t pool_size, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+        DeviceArena &arena, int32_t num_buckets, int32_t pool_size, const int32_t task_window_sizes[CHIP_MAX_RING_DEPTH]
     );
 
     /**
@@ -474,7 +474,7 @@ struct PTO2TensorMap {
      * PTO2_TENSORMAP_POOL_SIZE).
      */
     static PTO2TensorMapLayout
-    reserve_layout_default(DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
+    reserve_layout_default(DeviceArena &arena, const int32_t task_window_sizes[CHIP_MAX_RING_DEPTH]);
 
     /**
      * Phase 3a: write everything *except* arena-internal pointer fields

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/types.h
@@ -125,7 +125,7 @@ constexpr bool dep_has_retain(DepFlags f) { return (f & DEP_RETAIN) != DEP_NONE;
  *   scope_end the slot becomes eligible for reuse, and a later submit will
  *   overwrite the same ChipTensor storage in place. Therefore the
  *   TaskOutputTensors instance, the const ChipTensor& returned by get_ref(), and
- *   any pointer derived from either MUST NOT outlive the PTO2_SCOPE in which
+ *   any pointer derived from either MUST NOT outlive the SIMPLER_SCOPE in which
  *   submit was called — do not move/copy them to outer-scope variables, do
  *   not capture references by std::reference_wrapper or raw pointers across
  *   scope boundaries.

--- a/src/common/hierarchical/ring.h
+++ b/src/common/hierarchical/ring.h
@@ -20,7 +20,7 @@
  *      child workers), so a ring index buys us nothing at L3 (see the plan's
  *      L2 Consistency Audit, allowed exception #6).
  *   2. `MAX_RING_DEPTH` independent shared-memory heap slabs (Strict-1,
- *      matches L2's `PTO2_MAX_RING_DEPTH = 4`). Each slab has its own
+ *      matches L2's `CHIP_MAX_RING_DEPTH = 4`). Each slab has its own
  *      `mmap(MAP_SHARED)` region, bump cursor, FIFO reclamation pointer,
  *      mutex and cv. Slot → ring mapping is driven by scope depth:
  *         ring_idx = min(scope_depth, MAX_RING_DEPTH - 1)

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -119,7 +119,7 @@ static constexpr int32_t MAX_SCOPE_DEPTH = 64;
 // Number of independent HeapRing layers inside Ring. Scope depth maps
 // to ring index via `min(depth, MAX_RING_DEPTH - 1)` (L2-style);
 // scopes deeper than MAX_RING_DEPTH share the innermost ring.
-// Matches L2's PTO2_MAX_RING_DEPTH (Strict-1).
+// Matches L2's CHIP_MAX_RING_DEPTH (Strict-1).
 static constexpr int32_t MAX_RING_DEPTH = 4;
 
 static constexpr int32_t INVALID_SLOT = -1;

--- a/src/common/host_build_graph/graph_execution.cpp
+++ b/src/common/host_build_graph/graph_execution.cpp
@@ -298,7 +298,7 @@ bool graph_predicate_resolve(
 
 }  // namespace
 
-GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
+GraphExecution *graph_execution_localize(ChipTaskSlotState &outer_slot) {
     if (outer_slot.task_kind != TaskKind::GRAPH || outer_slot.task == nullptr || outer_slot.payload == nullptr ||
         outer_slot.task->packed_buffer_base == nullptr || outer_slot.task->packed_buffer_end == nullptr ||
         outer_slot.graph_context == nullptr) {
@@ -352,7 +352,7 @@ GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot) {
 }
 
 GraphMaterializeResult graph_execution_materialize_slice(
-    PTO2TaskSlotState &outer_slot, GraphExecution &execution, int32_t max_nodes, int32_t *nodes_materialized
+    ChipTaskSlotState &outer_slot, GraphExecution &execution, int32_t max_nodes, int32_t *nodes_materialized
 ) {
     if (nodes_materialized != nullptr) *nodes_materialized = 0;
     if (outer_slot.task_kind != TaskKind::GRAPH || outer_slot.task == nullptr ||
@@ -436,7 +436,7 @@ GraphMaterializeResult graph_execution_materialize_slice(
         }
         PTO2TaskDescriptor &task = storage->task;
         PTO2TaskPayload &payload = storage->payload;
-        PTO2TaskSlotState &slot = storage->slot;
+        ChipTaskSlotState &slot = storage->slot;
 
         const uint32_t synthetic_local =
             (static_cast<uint32_t>(outer_slot.task->task_id.local()) << 10) | static_cast<uint32_t>(i);

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -401,7 +401,7 @@ enum class GraphMaterializeResult : uint8_t {
 
 struct alignas(64) GraphNodeStorage {
     PTO2TaskDescriptor task;
-    PTO2TaskSlotState slot;
+    ChipTaskSlotState slot;
     // The payload carries its argument regions as deltas into pools past the node
     // array, so its size is the same for every node and the slot names it by a delta
     // from the slot's own address. Field order here therefore constrains nothing, and
@@ -431,7 +431,7 @@ struct GraphExecution {
     int32_t materialized_nodes{0};
     int32_t constructed_nodes{0};
     uint32_t consumed_tensor_args{0};
-    PTO2TaskSlotState *outer_slot{nullptr};
+    ChipTaskSlotState *outer_slot{nullptr};
     GraphNodeStorage *nodes{nullptr};
     GraphNodeStorage *node_storage{nullptr};
     // This execution's node argument pools, in the storage tail past node_storage.
@@ -515,12 +515,12 @@ inline bool graph_execution_storage_bytes(
     return true;
 }
 
-GraphExecution *graph_execution_localize(PTO2TaskSlotState &outer_slot);
+GraphExecution *graph_execution_localize(ChipTaskSlotState &outer_slot);
 GraphMaterializeResult graph_execution_materialize_slice(
-    PTO2TaskSlotState &outer_slot, GraphExecution &execution, int32_t max_nodes, int32_t *nodes_materialized = nullptr
+    ChipTaskSlotState &outer_slot, GraphExecution &execution, int32_t max_nodes, int32_t *nodes_materialized = nullptr
 );
 
-inline GraphExecution *graph_execution_from_slot(PTO2TaskSlotState &slot) {
+inline GraphExecution *graph_execution_from_slot(ChipTaskSlotState &slot) {
     return slot.task_kind == TaskKind::GRAPH_NODE ? static_cast<GraphExecution *>(slot.graph_context) : nullptr;
 }
 
@@ -531,7 +531,7 @@ inline GraphExecution *graph_execution_from_slot(PTO2TaskSlotState &slot) {
 // all of them barrier before runtime_init_ready_ is published, so no dispatch — and
 // therefore no caller of this function — observes an unlocalized GRAPH slot. A slot
 // whose localization failed carries nullptr.
-inline GraphExecution *graph_execution_from_outer_slot(PTO2TaskSlotState &slot) {
+inline GraphExecution *graph_execution_from_outer_slot(ChipTaskSlotState &slot) {
     return slot.task_kind == TaskKind::GRAPH ? static_cast<GraphExecution *>(slot.graph_context) : nullptr;
 }
 

--- a/src/common/host_build_graph/graph_host_state.h
+++ b/src/common/host_build_graph/graph_host_state.h
@@ -17,7 +17,7 @@
 #include <optional>
 #include <vector>
 
-struct PTO2TaskSlotState;
+struct ChipTaskSlotState;
 struct GraphHostState;
 
 inline constexpr size_t GRAPH_MAX_DEFINITIONS = 16;
@@ -29,7 +29,7 @@ struct GraphHostStateDeleter {
 using GraphHostStatePtr = std::unique_ptr<GraphHostState, GraphHostStateDeleter>;
 
 struct GraphHostUpload {
-    PTO2TaskSlotState *outer_slot;
+    ChipTaskSlotState *outer_slot;
     uint64_t full_key;
     uint64_t definition_hash;
 };

--- a/src/common/platform/include/common/scope_stats.h
+++ b/src/common/platform/include/common/scope_stats.h
@@ -79,7 +79,7 @@ extern "C" {
 // Field order keeps the uint64 heap pointers 8-byte aligned with no internal
 // padding.
 struct ScopeStatsRecord {
-    char site_file_basename[32];  // NUL-terminated basename of the PTO2_SCOPE site,
+    char site_file_basename[32];  // NUL-terminated basename of the SIMPLER_SCOPE site,
                                   // captured at append time so the host JSON has a
                                   // human-readable path without dereferencing a
                                   // device pointer (the string table lives in the

--- a/src/common/platform/include/common/scope_stats.h
+++ b/src/common/platform/include/common/scope_stats.h
@@ -67,7 +67,7 @@ extern "C" {
 //
 // Each boundary writes one record into host-visible (uncached) device memory,
 // so record width is directly on the orchestrator hot path. A scope only ever
-// touches its own ring (ring_id = min(scope_depth, PTO2_MAX_RING_DEPTH-1)), so
+// touches its own ring (ring_id = min(scope_depth, CHIP_MAX_RING_DEPTH-1)), so
 // a single ring's start/end is stored rather than a per-ring array.
 //
 // For the ring resources, end-start is the live span: task_end-task_start is

--- a/src/common/task_interface/task_id.h
+++ b/src/common/task_interface/task_id.h
@@ -25,7 +25,7 @@
  *
  * raw encoding: (ring_id << 32) | local_id
  *
- * ring_id:  which ring layer (0..PTO2_MAX_RING_DEPTH-1)
+ * ring_id:  which ring layer (0..CHIP_MAX_RING_DEPTH-1)
  * local_id: per-ring monotonic counter
  *
  * Invalid sentinel: raw == UINT64_MAX (no valid task has this encoding).

--- a/tests/st/a2a3/host_build_graph/available_aicore_counts/kernels/orchestration/available_aicore_counts_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/available_aicore_counts/kernels/orchestration/available_aicore_counts_orch.cpp
@@ -45,10 +45,9 @@ static inline void set_block_count(CoreTaskArgs &args, int16_t n) {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 2,
     };
 }

--- a/tests/st/a2a3/host_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -45,10 +45,9 @@ static constexpr int GRID_N = 4;
 static constexpr int BATCH = 1;
 static constexpr uint32_t TILE_ELEMS = TILE * TILE;
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/tests/st/a2a3/host_build_graph/dump_args/kernels/orchestration/dump_args_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/dump_args/kernels/orchestration/dump_args_orch.cpp
@@ -31,10 +31,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/tests/st/a2a3/host_build_graph/graph_execution/kernels/orchestration/graph_execution_aic_aiv_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/graph_execution/kernels/orchestration/graph_execution_aic_aiv_orch.cpp
@@ -69,9 +69,9 @@ void submit_layer(const GraphTaskArgs &args) { rt_submit_graph(&decoder_layer, a
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
     (void)args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 6,
     };
 }

--- a/tests/st/a2a3/host_build_graph/graph_execution/kernels/orchestration/graph_execution_mix_spmd_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/graph_execution/kernels/orchestration/graph_execution_mix_spmd_orch.cpp
@@ -39,9 +39,9 @@ void submit_layer(const GraphTaskArgs &args) { rt_submit_graph(&mix_spmd_layer, 
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
     (void)args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/tests/st/a2a3/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
@@ -72,9 +72,9 @@ void submit_layer(const GraphTaskArgs &args, int variant) { rt_submit_graph(&lay
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
     (void)args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 5,
     };
 }

--- a/tests/st/a2a3/host_build_graph/graph_predicated_dispatch/kernels/orchestration/graph_predicated_dispatch_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/graph_predicated_dispatch/kernels/orchestration/graph_predicated_dispatch_orch.cpp
@@ -143,9 +143,9 @@ void layer(const GraphTaskArgs &args, int variant) {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
     (void)args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3 * GRAPH_INVOCATIONS + GRAPH_INVOCATIONS,
     };
 }

--- a/tests/st/a2a3/host_build_graph/matmul/kernels/orchestration/matmul_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/matmul/kernels/orchestration/matmul_orch.cpp
@@ -35,10 +35,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 4,
     };
 }

--- a/tests/st/a2a3/host_build_graph/native_run_lifecycle/kernels/orchestration/long_vector_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/native_run_lifecycle/kernels/orchestration/long_vector_orch.cpp
@@ -23,9 +23,9 @@ constexpr int kChainLength = 64;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
     (void)args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 3};
+    return OrchestrationConfig{.expected_arg_count = 3};
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &args) {

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -66,10 +66,9 @@ inline uint64_t get_sys_cnt_aicpu() {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -153,7 +153,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         uint64_t cur_seq = static_cast<uint64_t>(get_tensor_data<int32_t>(context_lens, 1, cl_idx));
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 CYCLE_COUNT_LAP(prof_scope);
                 uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
 
@@ -173,7 +173,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 CYCLE_COUNT_LAP(prof_submit_task);
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn++) {
-                    PTO2_SCOPE_GUARD();
+                    SIMPLER_SCOPE_GUARD();
 
                     uint32_t bt_idx[2] = {static_cast<uint32_t>(b_idx), static_cast<uint32_t>(bn)};
                     uint64_t cur_block_idx = static_cast<uint64_t>(get_tensor_data<int32_t>(block_table, 2, bt_idx));

--- a/tests/st/a2a3/host_build_graph/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
@@ -45,10 +45,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 4,  // 3 tensors + 1 case scalar
     };
 }

--- a/tests/st/a2a3/host_build_graph/vector_example/kernels/orchestration/example_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/vector_example/kernels/orchestration/example_orch.cpp
@@ -31,10 +31,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/tests/st/a2a3/host_build_graph/worker_async_endpoint/kernels/orchestration/long_vector_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/worker_async_endpoint/kernels/orchestration/long_vector_orch.cpp
@@ -23,9 +23,9 @@ constexpr int kChainLength = 64;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
     (void)args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 3};
+    return OrchestrationConfig{.expected_arg_count = 3};
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &args) {

--- a/tests/st/a2a3/host_build_graph/worker_async_fifo/kernels/orchestration/pipelined_vector_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/worker_async_fifo/kernels/orchestration/pipelined_vector_orch.cpp
@@ -23,9 +23,9 @@ constexpr int kChainLength = 512;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
     (void)args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 4};
+    return OrchestrationConfig{.expected_arg_count = 4};
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
@@ -39,10 +39,9 @@ static constexpr uint64_t ADD_ELEMS = 128 * 128;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 11,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/available_aicore_counts/kernels/orchestration/available_aicore_counts_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/available_aicore_counts/kernels/orchestration/available_aicore_counts_orch.cpp
@@ -45,10 +45,9 @@ static inline void set_block_count(CoreTaskArgs &args, int16_t n) {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 2,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -51,10 +51,9 @@
 #define FUNC_ONLINE_UPDATE 3
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -120,7 +120,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             if (chunk_bc > IN_CORE_BATCH) chunk_bc = IN_CORE_BATCH;
             uint64_t batch_start = chunk_idx * IN_CORE_BATCH;
 
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 uint32_t oi_acc_shapes[2] = {static_cast<uint32_t>(chunk_bc * q_tile), static_cast<uint32_t>(head_dim)};
                 uint32_t scalar_acc_shapes[1] = {static_cast<uint32_t>(chunk_bc * q_tile)};
                 TensorCreateInfo oi_batch_ci(oi_acc_shapes, 2, DataType::FLOAT32);
@@ -140,7 +140,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 TensorCreateInfo oi_new_ci(oi_new_shapes, 2, DataType::FLOAT32);
 
                 for (uint64_t bn = 0; bn < max_bn; bn++) {
-                    PTO2_SCOPE() {
+                    SIMPLER_SCOPE() {
                         CoreTaskArgs params_qk;
                         params_qk.add_input(query);
                         params_qk.add_input(key_cache);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/kernels/orchestration/partial_dump_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/kernels/orchestration/partial_dump_orch.cpp
@@ -15,10 +15,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/kernels/orchestration/partial_dump_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/kernels/orchestration/partial_dump_orch.cpp
@@ -38,7 +38,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     TaskOutputTensors outs_t0 = rt_submit_aiv_task(0, params_t0);
     const ChipTensor &c = outs_t0.get_ref(0);
 
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         CoreTaskArgs params_t1;
         params_t1.add_input(c);
         params_t1.add_output(inter_ci);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/kernels/orchestration/chained_mix_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/kernels/orchestration/chained_mix_orch.cpp
@@ -47,10 +47,9 @@ static constexpr uint32_t TILE_ELEMS = 128 * 128;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 8,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/kernels/orchestration/sync_start_early_local_owner_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/kernels/orchestration/sync_start_early_local_owner_orch.cpp
@@ -38,10 +38,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
@@ -42,10 +42,9 @@ static constexpr int32_t MAX_PRODUCERS = 500;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,  // X, Y, scalar(N)
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
@@ -9,7 +9,7 @@
 # -----------------------------------------------------------------------------------------------------------
 """scope_stats smoke — capture pipeline produces a usable ``scope_stats.jsonl``.
 
-Re-uses ``vector_example`` (outer executor scope + one inner ``PTO2_SCOPE()``).
+Re-uses ``vector_example`` (outer executor scope + one inner ``SIMPLER_SCOPE()``).
 With ``--enable-scope-stats`` the platform collector
 (``scope_stats_collector_aicpu.h``) appends one record per scope boundary
 (begin and end) into a pooled buffer that streams to the host, which writes
@@ -137,7 +137,7 @@ class TestScopeStats(SceneTestCase):
         assert meta.get("dropped", 0) == 0, f"records dropped on device: {meta!r}"
         assert "dep_pool_max" in meta, f"metadata missing dep_pool_max: {meta!r}"
         records = [json.loads(ln) for ln in lines[1:]]
-        # outer (executor) + inner PTO2_SCOPE, each emitting a begin and an end
+        # outer (executor) + inner SIMPLER_SCOPE, each emitting a begin and an end
         # record → ≥4 records.
         assert len(records) >= 4, f"expected ≥4 begin/end records, got {records!r}"
         for rec in records:

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
@@ -55,10 +55,9 @@ static constexpr int32_t DENSE_DEP_COUNT = 18;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 4,  // 3 tensors + 1 case scalar
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/orchestration/fanin_lookup_perf_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/orchestration/fanin_lookup_perf_orch.cpp
@@ -40,10 +40,9 @@ static constexpr uint32_t SLOT_ELEMS = 16;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 5,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/heap_empty_ring_rebase/kernels/orchestration/heap_empty_ring_rebase_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/heap_empty_ring_rebase/kernels/orchestration/heap_empty_ring_rebase_orch.cpp
@@ -38,7 +38,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     uint32_t scratch_shapes[2] = {1024, 256};
     TensorCreateInfo scratch_ci(scratch_shapes, 2, DataType::FLOAT32);
 
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         CoreTaskArgs fill1;
         fill1.add_output(scratch_ci);
         TaskOutputTensors t1_outs = rt_submit_aic_task(FUNC_FILL_CONST, fill1);
@@ -50,7 +50,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         rt_submit_aic_task(FUNC_COPY_FIRST, copy1);
     }
 
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         CoreTaskArgs fill2;
         fill2.add_output(scratch_ci);
         TaskOutputTensors t2_outs = rt_submit_aic_task(FUNC_FILL_CONST, fill2);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/heap_empty_ring_rebase/kernels/orchestration/heap_empty_ring_rebase_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/heap_empty_ring_rebase/kernels/orchestration/heap_empty_ring_rebase_orch.cpp
@@ -24,10 +24,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 2,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
@@ -74,7 +74,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     LOG_INFO("[mixed_orch] num_iters=%d", num_iters);
 
     for (int i = 0; i < num_iters; i++) {
-        PTO2_SCOPE() {
+        SIMPLER_SCOPE() {
             uint32_t view_shapes[1] = {TILE_ELEMS};
             uint32_t view_offsets[1] = {static_cast<uint32_t>(i) * TILE_ELEMS};
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
@@ -40,10 +40,9 @@ static constexpr uint32_t TILE_ELEMS = 128 * 128;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 15,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -238,10 +238,9 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -92,7 +92,7 @@ static ProfCounters g_prof;
  *            9 cur_seq, 10 data_type
  * Adding/removing a slot here must be mirrored at the caller's build site.
  *
- * Must run inside a PTO2_SCOPE: the alloc'd / submitted tensors it references
+ * Must run inside a SIMPLER_SCOPE: the alloc'd / submitted tensors it references
  * do not outlive that scope.
  */
 static void process_qtile_scope(const CoreTaskArgs &ctx) {
@@ -326,7 +326,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 static_cast<uint64_t>(data_type)
             );
 
-            PTO2_SCOPE() { process_qtile_scope(ctx); }
+            SIMPLER_SCOPE() { process_qtile_scope(ctx); }
         }
     }
     CYCLE_COUNT_LAP(g_prof.scope_and_loop);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/orchestration/paged_attention_orch.cpp
@@ -96,7 +96,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             __builtin_prefetch(&host_context_lens[b_idx + 1], 0, 3);
         }
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 // 4D views into query/out, matching (1, 1, q_tile, head_dim).
                 uint32_t view_shapes[4] = {1, 1, (uint32_t)q_tile, (uint32_t)head_dim};
                 uint32_t view_offsets[4] = {(uint32_t)b_idx, 0, (uint32_t)(q_idx * q_tile), 0};

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/orchestration/paged_attention_orch.cpp
@@ -42,10 +42,9 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
@@ -45,10 +45,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 4,  // 3 tensors + 1 case scalar
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
@@ -30,10 +30,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/kernels/orchestration/spmd_batch_dispatch_oob_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/kernels/orchestration/spmd_batch_dispatch_oob_orch.cpp
@@ -29,10 +29,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
@@ -32,10 +32,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
@@ -34,10 +34,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
@@ -122,7 +122,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     TensorCreateInfo pij_fifo_ci(pij_fifo_shapes, 1, DataType::INT32);
     TensorCreateInfo oi_fifo_ci(oi_fifo_shapes, 1, DataType::INT32);
 
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         CoreTaskArgs args;
         args.add_input(query);
         args.add_input(key_cache);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
@@ -54,10 +54,9 @@ static constexpr uint32_t FIFO_DEPTH = 2;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/kernels/orchestration/paged_attention_highperf_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/kernels/orchestration/paged_attention_highperf_orch.cpp
@@ -18,10 +18,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 16,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_starvation/kernels/orchestration/spmd_starvation_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_starvation/kernels/orchestration/spmd_starvation_orch.cpp
@@ -43,10 +43,9 @@ static constexpr int32_t SYNC_CL = SYNC_BLOCK_NUM * SLOTS_PER_BLOCK;      // 18
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start/kernels/orchestration/spmd_sync_start_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start/kernels/orchestration/spmd_sync_start_orch.cpp
@@ -40,10 +40,9 @@ static constexpr int32_t SLOTS_PER_BLOCK = 3;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 2,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp
@@ -37,10 +37,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 2,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/kernels/orchestration/spmd_sync_start_early_dispatch_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/kernels/orchestration/spmd_sync_start_early_dispatch_orch.cpp
@@ -40,10 +40,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 2,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/orchestration/spmd_sync_start_edge_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/orchestration/spmd_sync_start_edge_orch.cpp
@@ -36,10 +36,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 2,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/kernels/orchestration/spmd_sync_start_mix_spill_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/kernels/orchestration/spmd_sync_start_mix_spill_orch.cpp
@@ -49,10 +49,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 2,
     };
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/orchestration/spmd_sync_start_stress_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/orchestration/spmd_sync_start_stress_orch.cpp
@@ -51,10 +51,9 @@ static constexpr int32_t ROUNDS = 6;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 1};
+    return OrchestrationConfig{.expected_arg_count = 1};
 }
 
 static void submit_mix(const ChipTensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {

--- a/tests/st/a5/host_build_graph/dump_args/kernels/orchestration/dump_args_orch.cpp
+++ b/tests/st/a5/host_build_graph/dump_args/kernels/orchestration/dump_args_orch.cpp
@@ -31,10 +31,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_aic_aiv_orch.cpp
+++ b/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_aic_aiv_orch.cpp
@@ -59,9 +59,9 @@ void submit_layer(const GraphTaskArgs &args) { rt_submit_graph(&decoder_layer, a
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
     (void)args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 6,
     };
 }

--- a/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_mix_spmd_orch.cpp
+++ b/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_mix_spmd_orch.cpp
@@ -39,9 +39,9 @@ void submit_layer(const GraphTaskArgs &args) { rt_submit_graph(&mix_spmd_layer, 
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
     (void)args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
+++ b/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
@@ -72,9 +72,9 @@ void submit_layer(const GraphTaskArgs &args, int variant) { rt_submit_graph(&lay
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
     (void)args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 5,
     };
 }

--- a/tests/st/a5/host_build_graph/graph_predicated_dispatch/kernels/orchestration/graph_predicated_dispatch_orch.cpp
+++ b/tests/st/a5/host_build_graph/graph_predicated_dispatch/kernels/orchestration/graph_predicated_dispatch_orch.cpp
@@ -143,9 +143,9 @@ void layer(const GraphTaskArgs &args, int variant) {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
     (void)args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3 * GRAPH_INVOCATIONS + GRAPH_INVOCATIONS,
     };
 }

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -61,10 +61,9 @@ inline uint64_t get_sys_cnt_aicpu() {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -148,7 +148,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
         uint64_t cur_seq = static_cast<uint64_t>(get_tensor_data<int32_t>(context_lens, 1, cl_idx));
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 CYCLE_COUNT_LAP(prof_scope);
                 uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
 
@@ -168,7 +168,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                 CYCLE_COUNT_LAP(prof_submit_task);
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn++) {
-                    PTO2_SCOPE_GUARD();
+                    SIMPLER_SCOPE_GUARD();
 
                     uint32_t bt_idx[2] = {static_cast<uint32_t>(b_idx), static_cast<uint32_t>(bn)};
                     uint64_t cur_block_idx = static_cast<uint64_t>(get_tensor_data<int32_t>(block_table, 2, bt_idx));

--- a/tests/st/a5/host_build_graph/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
+++ b/tests/st/a5/host_build_graph/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
@@ -45,10 +45,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 4,  // 3 tensors + 1 case scalar
     };
 }

--- a/tests/st/a5/host_build_graph/vector_example/kernels/orchestration/example_orch.cpp
+++ b/tests/st/a5/host_build_graph/vector_example/kernels/orchestration/example_orch.cpp
@@ -31,10 +31,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
@@ -39,10 +39,9 @@ static constexpr uint64_t ADD_ELEMS = 128 * 128;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 11,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/available_aicore_counts/kernels/orchestration/available_aicore_counts_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/available_aicore_counts/kernels/orchestration/available_aicore_counts_orch.cpp
@@ -45,10 +45,9 @@ static inline void set_block_count(CoreTaskArgs &args, int16_t n) {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 2,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -51,10 +51,9 @@
 #define FUNC_ONLINE_UPDATE 3
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -120,7 +120,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             if (chunk_bc > IN_CORE_BATCH) chunk_bc = IN_CORE_BATCH;
             uint64_t batch_start = chunk_idx * IN_CORE_BATCH;
 
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 uint32_t oi_acc_shapes[2] = {static_cast<uint32_t>(chunk_bc * q_tile), static_cast<uint32_t>(head_dim)};
                 uint32_t scalar_acc_shapes[1] = {static_cast<uint32_t>(chunk_bc * q_tile)};
                 TensorCreateInfo oi_batch_ci(oi_acc_shapes, 2, DataType::FLOAT32);
@@ -140,7 +140,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 TensorCreateInfo oi_new_ci(oi_new_shapes, 2, DataType::FLOAT32);
 
                 for (uint64_t bn = 0; bn < max_bn; bn++) {
-                    PTO2_SCOPE() {
+                    SIMPLER_SCOPE() {
                         CoreTaskArgs params_qk;
                         params_qk.add_input(query);
                         params_qk.add_input(key_cache);

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/kernels/orchestration/partial_dump_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/kernels/orchestration/partial_dump_orch.cpp
@@ -15,10 +15,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/kernels/orchestration/partial_dump_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/kernels/orchestration/partial_dump_orch.cpp
@@ -38,7 +38,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     TaskOutputTensors outs_t0 = rt_submit_aiv_task(0, params_t0);
     const ChipTensor &c = outs_t0.get_ref(0);
 
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         CoreTaskArgs params_t1;
         params_t1.add_input(c);
         params_t1.add_output(inter_ci);

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/kernels/orchestration/chained_mix_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/kernels/orchestration/chained_mix_orch.cpp
@@ -47,10 +47,9 @@ static constexpr uint32_t TILE_ELEMS = 128 * 128;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 8,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/kernels/orchestration/sync_start_early_local_owner_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/kernels/orchestration/sync_start_early_local_owner_orch.cpp
@@ -32,10 +32,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
@@ -42,10 +42,9 @@ static constexpr int32_t MAX_PRODUCERS = 500;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,  // X, Y, scalar(N)
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
@@ -9,7 +9,7 @@
 # -----------------------------------------------------------------------------------------------------------
 """scope_stats smoke — capture pipeline produces a usable ``scope_stats.jsonl``.
 
-Re-uses ``vector_example`` (outer executor scope + one inner ``PTO2_SCOPE()``).
+Re-uses ``vector_example`` (outer executor scope + one inner ``SIMPLER_SCOPE()``).
 With ``--enable-scope-stats`` the platform collector
 (``scope_stats_collector_aicpu.h``) appends one record per scope boundary
 (begin and end) into a pooled buffer that streams to the host, which writes
@@ -137,7 +137,7 @@ class TestScopeStats(SceneTestCase):
         assert meta.get("dropped", 0) == 0, f"records dropped on device: {meta!r}"
         assert "dep_pool_max" in meta, f"metadata missing dep_pool_max: {meta!r}"
         records = [json.loads(ln) for ln in lines[1:]]
-        # outer (executor) + inner PTO2_SCOPE, each emitting a begin and an end
+        # outer (executor) + inner SIMPLER_SCOPE, each emitting a begin and an end
         # record → ≥4 records.
         assert len(records) >= 4, f"expected ≥4 begin/end records, got {records!r}"
         for rec in records:

--- a/tests/st/a5/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
@@ -55,10 +55,9 @@ static constexpr int32_t DENSE_DEP_COUNT = 18;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 4,  // 3 tensors + 1 case scalar
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/orchestration/fanin_lookup_perf_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/orchestration/fanin_lookup_perf_orch.cpp
@@ -40,10 +40,9 @@ static constexpr uint32_t SLOT_ELEMS = 16;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 5,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/heap_empty_ring_rebase/kernels/orchestration/heap_empty_ring_rebase_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/heap_empty_ring_rebase/kernels/orchestration/heap_empty_ring_rebase_orch.cpp
@@ -38,7 +38,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     uint32_t scratch_shapes[2] = {1024, 256};
     TensorCreateInfo scratch_ci(scratch_shapes, 2, DataType::FLOAT32);
 
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         CoreTaskArgs fill1;
         fill1.add_output(scratch_ci);
         TaskOutputTensors t1_outs = rt_submit_aic_task(FUNC_FILL_CONST, fill1);
@@ -50,7 +50,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         rt_submit_aic_task(FUNC_COPY_FIRST, copy1);
     }
 
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         CoreTaskArgs fill2;
         fill2.add_output(scratch_ci);
         TaskOutputTensors t2_outs = rt_submit_aic_task(FUNC_FILL_CONST, fill2);

--- a/tests/st/a5/tensormap_and_ringbuffer/heap_empty_ring_rebase/kernels/orchestration/heap_empty_ring_rebase_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/heap_empty_ring_rebase/kernels/orchestration/heap_empty_ring_rebase_orch.cpp
@@ -24,10 +24,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 2,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
@@ -74,7 +74,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     LOG_INFO("[mixed_orch] num_iters=%d", num_iters);
 
     for (int i = 0; i < num_iters; i++) {
-        PTO2_SCOPE() {
+        SIMPLER_SCOPE() {
             uint32_t view_shapes[1] = {TILE_ELEMS};
             uint32_t view_offsets[1] = {static_cast<uint32_t>(i) * TILE_ELEMS};
 

--- a/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
@@ -40,10 +40,9 @@ static constexpr uint32_t TILE_ELEMS = 128 * 128;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 15,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/mx_fp_gemm/kernels/orchestration/mx_fp_gemm_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/mx_fp_gemm/kernels/orchestration/mx_fp_gemm_orch.cpp
@@ -24,10 +24,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 6,  // A, As, B, Bs, C, mode
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/mx_fp_gemm/kernels/orchestration/mx_fp_gemm_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/mx_fp_gemm/kernels/orchestration/mx_fp_gemm_orch.cpp
@@ -45,7 +45,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         get_dtype_name(ext_bs.dtype), get_dtype_name(ext_c.dtype)
     );
 
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         CoreTaskArgs args;
         args.add_input(ext_a);
         args.add_input(ext_as);

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -65,10 +65,9 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -156,7 +156,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
             CYCLE_COUNT_LAP(prof_scope_and_loop);
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
 
                 uint32_t qi_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/orchestration/paged_attention_orch.cpp
@@ -96,7 +96,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             __builtin_prefetch(&host_context_lens[b_idx + 1], 0, 3);
         }
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
-            PTO2_SCOPE() {
+            SIMPLER_SCOPE() {
                 // 4D views into query/out, matching (1, 1, q_tile, head_dim).
                 uint32_t view_shapes[4] = {1, 1, (uint32_t)q_tile, (uint32_t)head_dim};
                 uint32_t view_offsets[4] = {(uint32_t)b_idx, 0, (uint32_t)(q_idx * q_tile), 0};

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/orchestration/paged_attention_orch.cpp
@@ -42,10 +42,9 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
@@ -45,10 +45,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 4,  // 3 tensors + 1 case scalar
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/simt_basic/kernels/orchestration/simt_basic_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/simt_basic/kernels/orchestration/simt_basic_orch.cpp
@@ -36,10 +36,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const ChipTensor &indices = orch_args.tensor(1).ref();
     const ChipTensor &out = orch_args.tensor(2).ref();
 
-    // PTO2_SCOPE ensures rt_submit_aiv_task flushes through the task
+    // SIMPLER_SCOPE ensures rt_submit_aiv_task flushes through the task
     // ringbuffer before the entry returns. No set_core_num — let the
     // runtime use the config's block_dim.
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         CoreTaskArgs args;
         args.add_input(src);
         args.add_input(indices);

--- a/tests/st/a5/tensormap_and_ringbuffer/simt_basic/kernels/orchestration/simt_basic_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/simt_basic/kernels/orchestration/simt_basic_orch.cpp
@@ -24,10 +24,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
@@ -30,10 +30,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/kernels/orchestration/spmd_batch_dispatch_oob_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/kernels/orchestration/spmd_batch_dispatch_oob_orch.cpp
@@ -29,10 +29,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
@@ -32,10 +32,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
@@ -34,10 +34,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
@@ -62,10 +62,9 @@ static inline void set_block_count(CoreTaskArgs &args, int16_t n) {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
@@ -140,7 +140,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     TensorCreateInfo pij_fifo_ci(pij_fifo_shapes, 1, DataType::INT32);
     TensorCreateInfo oi_fifo_ci(oi_fifo_shapes, 1, DataType::INT32);
 
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         CoreTaskArgs args;
         args.add_input(query);
         args.add_input(key_cache);

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_starvation/kernels/orchestration/spmd_starvation_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_starvation/kernels/orchestration/spmd_starvation_orch.cpp
@@ -43,10 +43,9 @@ static constexpr int32_t SYNC_CL = SYNC_BLOCK_NUM * SLOTS_PER_BLOCK;      // 18
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start/kernels/orchestration/spmd_sync_start_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start/kernels/orchestration/spmd_sync_start_orch.cpp
@@ -40,10 +40,9 @@ static constexpr int32_t SLOTS_PER_BLOCK = 3;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 2,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp
@@ -37,10 +37,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 2,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/kernels/orchestration/spmd_sync_start_early_dispatch_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/kernels/orchestration/spmd_sync_start_early_dispatch_orch.cpp
@@ -35,10 +35,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/orchestration/spmd_sync_start_edge_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/orchestration/spmd_sync_start_edge_orch.cpp
@@ -36,10 +36,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 2,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/kernels/orchestration/spmd_sync_start_mix_spill_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_mix_spill/kernels/orchestration/spmd_sync_start_mix_spill_orch.cpp
@@ -33,10 +33,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/orchestration/spmd_sync_start_stress_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/orchestration/spmd_sync_start_stress_orch.cpp
@@ -51,10 +51,9 @@ static constexpr int32_t ROUNDS = 6;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 1};
+    return OrchestrationConfig{.expected_arg_count = 1};
 }
 
 static void submit_mix(const ChipTensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {

--- a/tests/st/aicore_op_timeout/kernels/orchestration/aicore_op_timeout_orch.cpp
+++ b/tests/st/aicore_op_timeout/kernels/orchestration/aicore_op_timeout_orch.cpp
@@ -27,10 +27,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 0,
     };
 }

--- a/tests/st/host_build_graph_validation/kernels/orchestration/validation_orch.cpp
+++ b/tests/st/host_build_graph_validation/kernels/orchestration/validation_orch.cpp
@@ -48,10 +48,9 @@ ChipTensor tensor_with_unbound_owner(const ChipTensor &external) {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 2};
+    return OrchestrationConfig{.expected_arg_count = 2};
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {

--- a/tests/st/host_build_graph_wide_dispatch/kernels/orchestration/host_build_graph_wide_dispatch_orch.cpp
+++ b/tests/st/host_build_graph_wide_dispatch/kernels/orchestration/host_build_graph_wide_dispatch_orch.cpp
@@ -63,10 +63,9 @@ void submit_normal_mix(const ChipTensor &output, int16_t block_num, int64_t base
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 2};
+    return OrchestrationConfig{.expected_arg_count = 2};
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {

--- a/tests/st/runtime_fatal_codes/kernels/orchestration/aicore_hang_orch.cpp
+++ b/tests/st/runtime_fatal_codes/kernels/orchestration/aicore_hang_orch.cpp
@@ -29,10 +29,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 0,
     };
 }

--- a/tests/st/runtime_fatal_codes/kernels/orchestration/async_error_orch.cpp
+++ b/tests/st/runtime_fatal_codes/kernels/orchestration/async_error_orch.cpp
@@ -25,10 +25,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 0,
     };
 }

--- a/tests/st/runtime_fatal_codes/kernels/orchestration/dep_pool_overflow_orch.cpp
+++ b/tests/st/runtime_fatal_codes/kernels/orchestration/dep_pool_overflow_orch.cpp
@@ -48,7 +48,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     uint32_t shape[1] = {1};
     TensorCreateInfo ci(shape, 1, DataType::INT32);
 
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         TaskId producers[PRODUCER_COUNT];
         for (int32_t i = 0; i < PRODUCER_COUNT; i++) {
             CoreTaskArgs args;

--- a/tests/st/runtime_fatal_codes/kernels/orchestration/dep_pool_overflow_orch.cpp
+++ b/tests/st/runtime_fatal_codes/kernels/orchestration/dep_pool_overflow_orch.cpp
@@ -35,10 +35,9 @@ static constexpr int32_t PRODUCER_COUNT = 128;  // > PTO2_FANIN_INLINE_CAP (64)
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 0,
     };
 }

--- a/tests/st/runtime_fatal_codes/kernels/orchestration/explicit_fatal_orch.cpp
+++ b/tests/st/runtime_fatal_codes/kernels/orchestration/explicit_fatal_orch.cpp
@@ -25,10 +25,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 0,
     };
 }

--- a/tests/st/runtime_fatal_codes/kernels/orchestration/flow_control_deadlock_orch.cpp
+++ b/tests/st/runtime_fatal_codes/kernels/orchestration/flow_control_deadlock_orch.cpp
@@ -33,10 +33,9 @@ static constexpr int32_t PER_LEVEL = 3;  // < window so no single scope trips SC
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 0,
     };
 }

--- a/tests/st/runtime_fatal_codes/kernels/orchestration/flow_control_deadlock_orch.cpp
+++ b/tests/st/runtime_fatal_codes/kernels/orchestration/flow_control_deadlock_orch.cpp
@@ -12,7 +12,7 @@
 /**
  * Negative ST orchestration: SIMPLER_ERROR_FLOW_CONTROL_DEADLOCK (code 3).
  *
- * Scope depth maps to ring index via min(scope_depth, PTO2_MAX_RING_DEPTH - 1),
+ * Scope depth maps to ring index via min(scope_depth, CHIP_MAX_RING_DEPTH - 1),
  * so every scope nested at depth >= 3 lands on the SAME ring (ring 3). Nest well
  * past depth 3 and submit a few tasks per level: each level's own scope-task
  * count stays below the window, so the scope-admission check (SCOPE_DEADLOCK, 1)
@@ -28,7 +28,7 @@
 
 #include "orchestration_api.h"  // NOLINT(build/include_subdir)
 
-static constexpr int32_t DEPTH = 8;      // > PTO2_MAX_RING_DEPTH so depths 3..7 share ring 3
+static constexpr int32_t DEPTH = 8;      // > CHIP_MAX_RING_DEPTH so depths 3..7 share ring 3
 static constexpr int32_t PER_LEVEL = 3;  // < window so no single scope trips SCOPE_DEADLOCK
 
 extern "C" {

--- a/tests/st/runtime_fatal_codes/kernels/orchestration/heap_ring_deadlock_orch.cpp
+++ b/tests/st/runtime_fatal_codes/kernels/orchestration/heap_ring_deadlock_orch.cpp
@@ -26,10 +26,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 0,
     };
 }

--- a/tests/st/runtime_fatal_codes/kernels/orchestration/invalid_args_orch.cpp
+++ b/tests/st/runtime_fatal_codes/kernels/orchestration/invalid_args_orch.cpp
@@ -24,10 +24,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 0,
     };
 }

--- a/tests/st/runtime_fatal_codes/kernels/orchestration/require_sync_start_orch.cpp
+++ b/tests/st/runtime_fatal_codes/kernels/orchestration/require_sync_start_orch.cpp
@@ -40,10 +40,9 @@ static inline void set_block_count(CoreTaskArgs &args, int16_t n) {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 0,
     };
 }

--- a/tests/st/runtime_fatal_codes/kernels/orchestration/scope_deadlock_orch.cpp
+++ b/tests/st/runtime_fatal_codes/kernels/orchestration/scope_deadlock_orch.cpp
@@ -48,7 +48,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     // tasks-in-scope reaches window-1 the scope-admission check latches
     // SCOPE_DEADLOCK. A handful of tasks is enough — a large batch only piles up
     // post-emergency_shutdown teardown state (which destabilises a5 cleanup).
-    PTO2_SCOPE() {
+    SIMPLER_SCOPE() {
         for (int32_t i = 0; i < 8; i++) {
             CoreTaskArgs args;
             args.add_output(ci);

--- a/tests/st/runtime_fatal_codes/kernels/orchestration/scope_deadlock_orch.cpp
+++ b/tests/st/runtime_fatal_codes/kernels/orchestration/scope_deadlock_orch.cpp
@@ -31,10 +31,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 0,
     };
 }

--- a/tests/st/runtime_fatal_codes/kernels/orchestration/tensor_wait_timeout_orch.cpp
+++ b/tests/st/runtime_fatal_codes/kernels/orchestration/tensor_wait_timeout_orch.cpp
@@ -32,10 +32,9 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 0,
     };
 }

--- a/tests/st/runtime_fatal_codes/test_runtime_fatal_codes.py
+++ b/tests/st/runtime_fatal_codes/test_runtime_fatal_codes.py
@@ -179,7 +179,7 @@ CASES = {
     # * SCOPE_TASKS_OVERFLOW (10): scope_tasks_cap is the in-flight slot budget (sum
     #   of the per-ring windows, since #1188), but each ring physically holds only
     #   window-1 tasks (the ring's full/empty distinction), so all rings together
-    #   hold at most sum(window-1) = cap - PTO2_MAX_RING_DEPTH, strictly below the
+    #   hold at most sum(window-1) = cap - CHIP_MAX_RING_DEPTH, strictly below the
     #   cap. scope_tasks therefore tops out below its own cap: the rings fill first
     #   and latch SCOPE_DEADLOCK (1, single scope) or FLOW_CONTROL_DEADLOCK (3,
     #   same-ring nesting). Verified: no (depth, tasks/level, window) combo reaches

--- a/tests/st/task_timing/task_timing_slots/kernels/orchestration/task_timing_orch.cpp
+++ b/tests/st/task_timing/task_timing_slots/kernels/orchestration/task_timing_orch.cpp
@@ -45,10 +45,10 @@ static inline auto set_spmd_count(Spec &s, int16_t n) -> decltype(s.set_core_num
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 task_timing_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 3,  // a, b, out
     };
 }
@@ -159,10 +159,10 @@ __attribute__((visibility("default"))) void task_timing_mix_orchestration(const 
     rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 task_timing_mix_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 9,
     };
 }

--- a/tests/st/worker/collectives/all_to_all/kernels/orchestration/all_to_all_orch.cpp
+++ b/tests/st/worker/collectives/all_to_all/kernels/orchestration/all_to_all_orch.cpp
@@ -24,10 +24,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 all_to_all_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 5,  // 3 tensors + 2 scalars
     };
 }

--- a/tests/st/worker/collectives/allgather/kernels/orchestration/allgather_orch.cpp
+++ b/tests/st/worker/collectives/allgather/kernels/orchestration/allgather_orch.cpp
@@ -24,10 +24,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 allgather_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 5,  // 3 tensors + 2 scalars
     };
 }

--- a/tests/st/worker/collectives/allreduce/kernels/orchestration/allreduce_bidirectional_ring_orch.cpp
+++ b/tests/st/worker/collectives/allreduce/kernels/orchestration/allreduce_bidirectional_ring_orch.cpp
@@ -31,10 +31,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 allreduce_bidirectional_ring_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 5,  // 3 tensors + 2 scalars
     };
 }

--- a/tests/st/worker/collectives/allreduce/kernels/orchestration/allreduce_ibing_orch.cpp
+++ b/tests/st/worker/collectives/allreduce/kernels/orchestration/allreduce_ibing_orch.cpp
@@ -30,10 +30,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 allreduce_ibing_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 5,  // 3 tensors + 2 scalars
     };
 }

--- a/tests/st/worker/collectives/allreduce/kernels/orchestration/allreduce_onephase_orch.cpp
+++ b/tests/st/worker/collectives/allreduce/kernels/orchestration/allreduce_onephase_orch.cpp
@@ -31,10 +31,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 allreduce_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 5,  // 3 tensors + 2 scalars
     };
 }

--- a/tests/st/worker/collectives/allreduce/kernels/orchestration/allreduce_ring_orch.cpp
+++ b/tests/st/worker/collectives/allreduce/kernels/orchestration/allreduce_ring_orch.cpp
@@ -30,10 +30,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 allreduce_ring_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 5,  // 3 tensors + 2 scalars
     };
 }

--- a/tests/st/worker/collectives/allreduce/kernels/orchestration/allreduce_twophase_orch.cpp
+++ b/tests/st/worker/collectives/allreduce/kernels/orchestration/allreduce_twophase_orch.cpp
@@ -30,10 +30,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 allreduce_twophase_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 5,  // 3 tensors + 2 scalars
     };
 }

--- a/tests/st/worker/collectives/broadcast/kernels/orchestration/broadcast_orch.cpp
+++ b/tests/st/worker/collectives/broadcast/kernels/orchestration/broadcast_orch.cpp
@@ -25,10 +25,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 broadcast_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 6,  // 3 tensors + 3 scalars
     };
 }

--- a/tests/st/worker/collectives/group_reservation/kernels/orchestration/group_reservation_orch.cpp
+++ b/tests/st/worker/collectives/group_reservation/kernels/orchestration/group_reservation_orch.cpp
@@ -15,10 +15,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 group_reservation_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 4,
     };
 }

--- a/tests/st/worker/collectives/reduce_scatter/kernels/orchestration/reduce_scatter_orch.cpp
+++ b/tests/st/worker/collectives/reduce_scatter/kernels/orchestration/reduce_scatter_orch.cpp
@@ -24,10 +24,10 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 reduce_scatter_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{
+    return OrchestrationConfig{
         .expected_arg_count = 5,  // 3 tensors + 2 scalars
     };
 }

--- a/tests/st/worker/comm_domain/async_notify/kernels/orchestration/async_notify_orchestration.cpp
+++ b/tests/st/worker/comm_domain/async_notify/kernels/orchestration/async_notify_orchestration.cpp
@@ -16,14 +16,13 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 async_notify_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 5};
+    return OrchestrationConfig{.expected_arg_count = 5};
 }
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     return async_notify_orchestration_config(orch_args);
 }
 

--- a/tests/st/worker/comm_domain/deferred_notify/kernels/orchestration/deferred_notify_orch.cpp
+++ b/tests/st/worker/comm_domain/deferred_notify/kernels/orchestration/deferred_notify_orch.cpp
@@ -16,14 +16,13 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
+__attribute__((visibility("default"))) OrchestrationConfig
 deferred_notify_orchestration_config(const ChipTaskArgs &orch_args) {
     (void)orch_args;
-    return PTO2OrchestrationConfig{.expected_arg_count = 5};
+    return OrchestrationConfig{.expected_arg_count = 5};
 }
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
     return deferred_notify_orchestration_config(orch_args);
 }
 

--- a/tests/ut/cpp/a2a3/test_a2a3_fatal.cpp
+++ b/tests/ut/cpp/a2a3/test_a2a3_fatal.cpp
@@ -156,7 +156,7 @@ TEST(A2A3Fatal, ApiShortCircuitsAfterFatal) {
     rt_scope_begin();
     rt_scope_end();
     {
-        PTO2ScopeGuard guard;
+        ScopeGuard guard;
         (void)guard;
     }
 
@@ -196,7 +196,7 @@ TEST(A2A3Fatal, ScopeGuardForwardsModeUntilLexicalScopeExit) {
     runtime.pending_scope_mode = PTO2ScopeMode::MANUAL;
 
     {
-        PTO2_SCOPE_GUARD();
+        SIMPLER_SCOPE_GUARD();
         EXPECT_EQ(runtime.scope_begin_calls, 1);
         EXPECT_EQ(runtime.scope_end_calls, 0);
         EXPECT_EQ(runtime.last_scope_mode, PTO2ScopeMode::AUTO);
@@ -205,7 +205,7 @@ TEST(A2A3Fatal, ScopeGuardForwardsModeUntilLexicalScopeExit) {
     EXPECT_EQ(runtime.scope_end_calls, 1);
 
     {
-        PTO2_SCOPE_GUARD(PTO2ScopeMode::MANUAL);
+        SIMPLER_SCOPE_GUARD(PTO2ScopeMode::MANUAL);
         EXPECT_EQ(runtime.scope_begin_calls, 2);
         EXPECT_EQ(runtime.scope_end_calls, 1);
         EXPECT_EQ(runtime.last_scope_mode, PTO2ScopeMode::MANUAL);

--- a/tests/ut/cpp/a2a3/test_a2a3_fatal.cpp
+++ b/tests/ut/cpp/a2a3/test_a2a3_fatal.cpp
@@ -27,13 +27,13 @@
 
 namespace {
 
-PTO2Runtime *g_bound_runtime = nullptr;
+RuntimeContext *g_bound_runtime = nullptr;
 
-extern "C" PTO2Runtime *framework_current_runtime(void) { return g_bound_runtime; }
-extern "C" void framework_bind_runtime(PTO2Runtime *rt) { g_bound_runtime = rt; }
+extern "C" RuntimeContext *framework_current_runtime(void) { return g_bound_runtime; }
+extern "C" void framework_bind_runtime(RuntimeContext *rt) { g_bound_runtime = rt; }
 
 struct FakeRuntime {
-    const PTO2RuntimeOps *ops;
+    const RuntimeOps *ops;
     PTO2ScopeMode pending_scope_mode = PTO2ScopeMode::AUTO;
     bool fatal = false;
     int submit_calls = 0;
@@ -51,26 +51,26 @@ struct FakeRuntime {
 
 static_assert(offsetof(FakeRuntime, ops) == 0);  // Guard: reinterpret_cast below assumes ops is first member.
 static_assert(
-    offsetof(FakeRuntime, pending_scope_mode) == offsetof(PTO2Runtime, pending_scope_mode)
-);  // ...and pending_scope_mode follows ops, matching the PTO2Runtime prefix the inline scope wrappers pun through.
+    offsetof(FakeRuntime, pending_scope_mode) == offsetof(RuntimeContext, pending_scope_mode)
+);  // ...and pending_scope_mode follows ops, matching the RuntimeContext prefix the inline scope wrappers pun through.
 
-FakeRuntime *as_fake(PTO2Runtime *rt) { return reinterpret_cast<FakeRuntime *>(rt); }
+FakeRuntime *as_fake(RuntimeContext *rt) { return reinterpret_cast<FakeRuntime *>(rt); }
 
-TaskOutputTensors fake_submit(PTO2Runtime *rt, const MixedKernels &, const CoreTaskArgs &) {
+TaskOutputTensors fake_submit(RuntimeContext *rt, const MixedKernels &, const CoreTaskArgs &) {
     as_fake(rt)->submit_calls++;
     return TaskOutputTensors{};
 }
 
-void fake_scope_begin(PTO2Runtime *rt) {
+void fake_scope_begin(RuntimeContext *rt) {
     FakeRuntime *fake = as_fake(rt);
     fake->scope_begin_calls++;
     fake->last_scope_mode = fake->pending_scope_mode;
 }
-void fake_scope_end(PTO2Runtime *rt) { as_fake(rt)->scope_end_calls++; }
-void fake_orchestration_done(PTO2Runtime *) {}
-bool fake_is_fatal(PTO2Runtime *rt) { return as_fake(rt)->fatal; }
+void fake_scope_end(RuntimeContext *rt) { as_fake(rt)->scope_end_calls++; }
+void fake_orchestration_done(RuntimeContext *) {}
+bool fake_is_fatal(RuntimeContext *rt) { return as_fake(rt)->fatal; }
 
-void fake_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...) {
+void fake_report_fatal(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...) {
     FakeRuntime *fake = as_fake(rt);
     fake->report_fatal_calls++;
     fake->fatal = true;
@@ -89,23 +89,23 @@ void fake_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, co
 
 void fake_log(const char *, const char *, ...) {}
 
-uint64_t fake_get_tensor_data(PTO2Runtime *rt, const ChipTensor &, uint32_t, const uint32_t[]) {
+uint64_t fake_get_tensor_data(RuntimeContext *rt, const ChipTensor &, uint32_t, const uint32_t[]) {
     as_fake(rt)->get_calls++;
     return 0x1234ULL;
 }
 
-void fake_set_tensor_data(PTO2Runtime *rt, const ChipTensor &, uint32_t, const uint32_t[], uint64_t) {
+void fake_set_tensor_data(RuntimeContext *rt, const ChipTensor &, uint32_t, const uint32_t[], uint64_t) {
     as_fake(rt)->set_calls++;
 }
 
-TaskOutputTensors fake_alloc_tensors(PTO2Runtime *rt, const CoreTaskArgs &) {
+TaskOutputTensors fake_alloc_tensors(RuntimeContext *rt, const CoreTaskArgs &) {
     as_fake(rt)->alloc_calls++;
     return TaskOutputTensors{};
 }
 
-TaskOutputTensors fake_submit_dummy(PTO2Runtime *, const CoreTaskArgs &) { return TaskOutputTensors{}; }
+TaskOutputTensors fake_submit_dummy(RuntimeContext *, const CoreTaskArgs &) { return TaskOutputTensors{}; }
 
-const PTO2RuntimeOps kFakeOps = {
+const RuntimeOps kFakeOps = {
     .submit_task = fake_submit,
     .scope_begin = fake_scope_begin,
     .scope_end = fake_scope_end,
@@ -126,7 +126,7 @@ const PTO2RuntimeOps kFakeOps = {
 
 class RuntimeBindingGuard {
 public:
-    explicit RuntimeBindingGuard(PTO2Runtime *rt) { framework_bind_runtime(rt); }
+    explicit RuntimeBindingGuard(RuntimeContext *rt) { framework_bind_runtime(rt); }
     ~RuntimeBindingGuard() { framework_bind_runtime(nullptr); }
 };
 
@@ -141,7 +141,7 @@ TEST(A2A3Fatal, ApiShortCircuitsAfterFatal) {
     FakeRuntime runtime{};
     runtime.ops = &kFakeOps;
     runtime.fatal = true;
-    RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+    RuntimeBindingGuard bind(reinterpret_cast<RuntimeContext *>(&runtime));
 
     MixedKernels mixed{};
     CoreTaskArgs args;
@@ -172,7 +172,7 @@ TEST(A2A3Fatal, ApiShortCircuitsAfterFatal) {
 TEST(A2A3Fatal, ExplicitFatalRoutesThroughOps) {
     FakeRuntime runtime{};
     runtime.ops = &kFakeOps;
-    RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+    RuntimeBindingGuard bind(reinterpret_cast<RuntimeContext *>(&runtime));
 
     rt_report_fatal(SIMPLER_ERROR_EXPLICIT_ORCH_FATAL, "boom %d", 7);
 
@@ -191,7 +191,7 @@ TEST(A2A3Fatal, ExplicitFatalRoutesThroughOps) {
 TEST(A2A3Fatal, ScopeGuardForwardsModeUntilLexicalScopeExit) {
     FakeRuntime runtime{};
     runtime.ops = &kFakeOps;
-    RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+    RuntimeBindingGuard bind(reinterpret_cast<RuntimeContext *>(&runtime));
 
     runtime.pending_scope_mode = PTO2ScopeMode::MANUAL;
 
@@ -217,7 +217,7 @@ TEST(A2A3Fatal, ScopeGuardForwardsModeUntilLexicalScopeExit) {
 TEST(A2A3Fatal, AllocTensorConvenienceReportsInvalidArgsInsteadOfAsserting) {
     FakeRuntime runtime{};
     runtime.ops = &kFakeOps;
-    RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+    RuntimeBindingGuard bind(reinterpret_cast<RuntimeContext *>(&runtime));
 
     std::array<TensorCreateInfo, MAX_TENSOR_ARGS + 1> create_infos{};
     for (TensorCreateInfo &ci : create_infos) {

--- a/tests/ut/cpp/a2a3/test_aicore_completion_mailbox.cpp
+++ b/tests/ut/cpp/a2a3/test_aicore_completion_mailbox.cpp
@@ -90,7 +90,7 @@ TEST(AICoreCompletionMailbox, PushNormalDoneCreatesEntryReadyToComplete) {
     AsyncWaitList wait_list{};
 
     TaskId token = make_token(99);
-    PTO2TaskSlotState dummy_slot{};
+    ChipTaskSlotState dummy_slot{};
     uint64_t slot_addr = reinterpret_cast<uint64_t>(&dummy_slot);
     ASSERT_TRUE(mb->try_push_normal_done(token, slot_addr));
 
@@ -127,7 +127,7 @@ TEST(AICoreCompletionMailbox, NormalDoneAttachesToExistingEntry) {
     wait_list.entries[0].normal_done = false;
     wait_list.count = 1;
 
-    PTO2TaskSlotState dummy_slot{};
+    ChipTaskSlotState dummy_slot{};
     uint64_t slot_addr = reinterpret_cast<uint64_t>(&dummy_slot);
     ASSERT_TRUE(mb->try_push_normal_done(token, slot_addr));
 

--- a/tests/ut/cpp/a2a3/test_dep_list_pool.cpp
+++ b/tests/ut/cpp/a2a3/test_dep_list_pool.cpp
@@ -95,7 +95,7 @@ TEST_F(DepListPoolTest, EnsureSpaceDeadlockReturnsFalseAndLatchesError) {
 
 // Prepend builds LIFO linked list: verify each slot_state pointer.
 TEST_F(DepListPoolTest, PrependChainCorrectness) {
-    PTO2TaskSlotState slots[5]{};
+    ChipTaskSlotState slots[5]{};
     PTO2DepListEntry *head = nullptr;
 
     for (int i = 0; i < 5; i++) {
@@ -157,7 +157,7 @@ TEST_F(DepListPoolTest, HighWaterAccuracy) {
 
 // Prepend chain integrity under pool exhaustion: chain must be walkable.
 TEST_F(DepListPoolTest, PrependUnderExhaustion) {
-    PTO2TaskSlotState slots[POOL_CAP]{};
+    ChipTaskSlotState slots[POOL_CAP]{};
     PTO2DepListEntry *head = nullptr;
 
     int count = 0;

--- a/tests/ut/cpp/a2a3/test_fanin_pool.cpp
+++ b/tests/ut/cpp/a2a3/test_fanin_pool.cpp
@@ -162,7 +162,7 @@ protected:
     std::atomic<int32_t> error_code{SIMPLER_ERROR_NONE};
     PTO2FaninPool spill_pool{};
 
-    alignas(64) PTO2TaskSlotState slots[64];
+    alignas(64) ChipTaskSlotState slots[64];
 
     void SetUp() override {
         spill_entries.assign(POOL_CAP, PTO2FaninSpillEntry{});
@@ -178,8 +178,8 @@ TEST_F(ForEachFaninTest, InlineOnlyVoid) {
         inline_slots[i].set(&slots[i], DEP_WAIT);
     }
 
-    std::vector<PTO2TaskSlotState *> visited;
-    for_each_fanin_storage(inline_slots, 5, 0, spill_pool, [&](PTO2TaskSlotState *s, DepFlags) {
+    std::vector<ChipTaskSlotState *> visited;
+    for_each_fanin_storage(inline_slots, 5, 0, spill_pool, [&](ChipTaskSlotState *s, DepFlags) {
         visited.push_back(s);
     });
 
@@ -196,7 +196,7 @@ TEST_F(ForEachFaninTest, InlineOnlyBoolEarlyReturn) {
     }
 
     int count = 0;
-    bool result = for_each_fanin_storage(inline_slots, 5, 0, spill_pool, [&](PTO2TaskSlotState *, DepFlags) -> bool {
+    bool result = for_each_fanin_storage(inline_slots, 5, 0, spill_pool, [&](ChipTaskSlotState *, DepFlags) -> bool {
         count++;
         return count < 3;  // stop after 3rd
     });
@@ -211,7 +211,7 @@ TEST_F(ForEachFaninTest, InlineOnlyBoolAllTrue) {
         inline_slots[i].set(&slots[i], DEP_WAIT);
     }
 
-    bool result = for_each_fanin_storage(inline_slots, 3, 0, spill_pool, [](PTO2TaskSlotState *, DepFlags) -> bool {
+    bool result = for_each_fanin_storage(inline_slots, 3, 0, spill_pool, [](ChipTaskSlotState *, DepFlags) -> bool {
         return true;
     });
 
@@ -221,7 +221,7 @@ TEST_F(ForEachFaninTest, InlineOnlyBoolAllTrue) {
 TEST_F(ForEachFaninTest, ZeroFanin) {
     PTO2FaninSpillEntry inline_slots[PTO2_FANIN_INLINE_CAP] = {};
     int count = 0;
-    for_each_fanin_storage(inline_slots, 0, 0, spill_pool, [&](PTO2TaskSlotState *, DepFlags) {
+    for_each_fanin_storage(inline_slots, 0, 0, spill_pool, [&](ChipTaskSlotState *, DepFlags) {
         count++;
     });
     EXPECT_EQ(count, 0);
@@ -245,8 +245,8 @@ TEST_F(ForEachFaninTest, SpillNoWrap) {
     auto *s1 = spill_pool.alloc();
     s1->set(&slots[17], DEP_WAIT | DEP_RETAIN);
 
-    std::vector<PTO2TaskSlotState *> visited;
-    for_each_fanin_storage(inline_slots, 18, spill_start, spill_pool, [&](PTO2TaskSlotState *s, DepFlags) {
+    std::vector<ChipTaskSlotState *> visited;
+    for_each_fanin_storage(inline_slots, 18, spill_start, spill_pool, [&](ChipTaskSlotState *s, DepFlags) {
         visited.push_back(s);
     });
 
@@ -281,8 +281,8 @@ TEST_F(ForEachFaninTest, SpillWithWrap) {
         e->set(&slots[16 + i], DEP_WAIT | DEP_RETAIN);
     }
 
-    std::vector<PTO2TaskSlotState *> visited;
-    for_each_fanin_storage(inline_slots, 20, spill_start, spill_pool, [&](PTO2TaskSlotState *s, DepFlags) {
+    std::vector<ChipTaskSlotState *> visited;
+    for_each_fanin_storage(inline_slots, 20, spill_start, spill_pool, [&](ChipTaskSlotState *s, DepFlags) {
         visited.push_back(s);
     });
 
@@ -315,7 +315,7 @@ TEST_F(ForEachFaninTest, SpillBoolEarlyReturnInSpillRegion) {
 
     int count = 0;
     bool result =
-        for_each_fanin_storage(inline_slots, 20, spill_start, spill_pool, [&](PTO2TaskSlotState *, DepFlags) -> bool {
+        for_each_fanin_storage(inline_slots, 20, spill_start, spill_pool, [&](ChipTaskSlotState *, DepFlags) -> bool {
             count++;
             return count < 17;  // stop on 17th (first spill entry)
         });
@@ -347,7 +347,7 @@ TEST_F(ForEachFaninTest, DepFlagsRoundTripInlineAndSpill) {
 
     const int32_t total = PTO2_FANIN_INLINE_CAP + 2;  // 64 inline + 2 spill
     std::vector<DepFlags> flags;
-    for_each_fanin_storage(inline_slots, total, spill_start, spill_pool, [&](PTO2TaskSlotState *, DepFlags f) {
+    for_each_fanin_storage(inline_slots, total, spill_start, spill_pool, [&](ChipTaskSlotState *, DepFlags f) {
         flags.push_back(f);
     });
 

--- a/tests/ut/cpp/a2a3/test_graph_activation.cpp
+++ b/tests/ut/cpp/a2a3/test_graph_activation.cpp
@@ -88,7 +88,7 @@ TEST_F(GraphActivationTest, WakeRoutesConsumerWhenProducerCompletedBeforeRegiste
 
     sched.register_graph_wake(exec, &nodes[0].slot, &nodes[1].slot);
 
-    PTO2TaskSlotState *out[2];
+    ChipTaskSlotState *out[2];
     ASSERT_EQ(sched.get_ready_tasks_batch(sched.ready_queues, PTO2ResourceShape::AIC, out, 2), 1)
         << "consumer must route to ready, not hang on the SENTINEL wake list";
     EXPECT_EQ(out[0], &nodes[1].slot);
@@ -114,7 +114,7 @@ TEST_F(GraphActivationTest, IncrementalPublishRoutesCompletedDepsAndWakeChainsPe
     sched.graph_incremental_publish(exec, 0, 4);
     EXPECT_EQ(exec.published_nodes.load(), 4);
 
-    PTO2TaskSlotState *out[4];
+    ChipTaskSlotState *out[4];
     ASSERT_EQ(sched.get_ready_tasks_batch(sched.ready_queues, PTO2ResourceShape::AIC, out, 4), 1)
         << "only the consumer whose producers are all COMPLETED routes at publish time";
     EXPECT_EQ(out[0], &nodes[2].slot);

--- a/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
@@ -82,7 +82,7 @@ protected:
         const size_t n = static_cast<size_t>(ring.task_window_mask) + 1;
         std::memset(ring.task_descriptors, POISON, n * sizeof(PTO2TaskDescriptor));
         std::memset(ring.task_payloads, POISON, n * sizeof(PTO2TaskPayload));
-        std::memset(ring.slot_states, POISON, n * sizeof(PTO2TaskSlotState));
+        std::memset(ring.slot_states, POISON, n * sizeof(ChipTaskSlotState));
         std::memset(ring.completion_flags, POISON, n * sizeof(std::atomic<uint8_t>));
     }
 };
@@ -137,7 +137,7 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
         const int32_t slot = ring.get_slot_by_task_id(local);
         const PTO2TaskDescriptor &desc = ring.task_descriptors[slot];
         const PTO2TaskPayload &pl = ring.task_payloads[slot];
-        const PTO2TaskSlotState &st = ring.slot_states[slot];
+        const ChipTaskSlotState &st = ring.slot_states[slot];
 
         // Descriptor: the task id is written to this exact local id.
         EXPECT_EQ(desc.task_id.local(), static_cast<uint32_t>(local));

--- a/tests/ut/cpp/a2a3/test_orchestrator_fanin.cpp
+++ b/tests/ut/cpp/a2a3/test_orchestrator_fanin.cpp
@@ -33,10 +33,10 @@ protected:
     void SetUp() override {
         sm_handle = PTO2SharedMemoryHandle::create_and_init_default(sm_arena);
         ASSERT_NE(sm_handle, nullptr);
-        gm_heap.resize(4096 * PTO2_MAX_RING_DEPTH);
+        gm_heap.resize(4096 * CHIP_MAX_RING_DEPTH);
 
-        int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        int32_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             task_window_sizes[r] = static_cast<int32_t>(PTO2_TASK_WINDOW_SIZE);
         }
 
@@ -277,10 +277,10 @@ TEST_F(OrchestratorFaninTest, StructuralCheckRejectsOpenAncestorWhenNestedScopes
     std::vector<TensorCreateInfo> create_infos;
     create_infos.reserve(2);
 
-    for (int32_t depth = 0; depth < PTO2_MAX_RING_DEPTH; ++depth) {
+    for (int32_t depth = 0; depth < CHIP_MAX_RING_DEPTH; ++depth) {
         orch.begin_scope();
     }
-    ASSERT_EQ(orch.current_ring_id(), PTO2_MAX_RING_DEPTH - 1);
+    ASSERT_EQ(orch.current_ring_id(), CHIP_MAX_RING_DEPTH - 1);
 
     CoreTaskArgs parent_args;
     add_runtime_output_arg(parent_args, create_infos, 1024);
@@ -288,7 +288,7 @@ TEST_F(OrchestratorFaninTest, StructuralCheckRejectsOpenAncestorWhenNestedScopes
     ASSERT_TRUE(parent.task_id().is_valid());
 
     orch.begin_scope();
-    ASSERT_EQ(orch.current_ring_id(), PTO2_MAX_RING_DEPTH - 1);
+    ASSERT_EQ(orch.current_ring_id(), CHIP_MAX_RING_DEPTH - 1);
 
     CoreTaskArgs child_args;
     add_runtime_output_arg(child_args, create_infos, 1);
@@ -306,11 +306,11 @@ TEST_F(OrchestratorFaninTest, ClosedChildHeadUsesTimeoutWithOpenParentOnSharedRi
     std::vector<TensorCreateInfo> create_infos;
     create_infos.reserve(3);
 
-    for (int32_t depth = 0; depth < PTO2_MAX_RING_DEPTH; ++depth) {
+    for (int32_t depth = 0; depth < CHIP_MAX_RING_DEPTH; ++depth) {
         orch.begin_scope();
     }
     orch.begin_scope();
-    ASSERT_EQ(orch.current_ring_id(), PTO2_MAX_RING_DEPTH - 1);
+    ASSERT_EQ(orch.current_ring_id(), CHIP_MAX_RING_DEPTH - 1);
 
     CoreTaskArgs child_args;
     add_runtime_output_arg(child_args, create_infos, 768);
@@ -318,7 +318,7 @@ TEST_F(OrchestratorFaninTest, ClosedChildHeadUsesTimeoutWithOpenParentOnSharedRi
     ASSERT_TRUE(child.task_id().is_valid());
 
     orch.end_scope();
-    ASSERT_EQ(orch.current_ring_id(), PTO2_MAX_RING_DEPTH - 1);
+    ASSERT_EQ(orch.current_ring_id(), CHIP_MAX_RING_DEPTH - 1);
 
     CoreTaskArgs parent_args;
     add_runtime_output_arg(parent_args, create_infos, 256);
@@ -342,31 +342,31 @@ TEST_F(OrchestratorFaninTest, ClosedChildHeadUsesTimeoutWithOpenParentOnSharedRi
 // (sum of the runtime per-ring windows), not the compile-time PTO2_SCOPE_TASKS_CAP.
 // reserve_layout only computes offsets, so no commit()/backing is needed here.
 TEST(OrchestratorLayoutScopeTasksCap, FollowsRuntimeWindowSum) {
-    auto cap_for = [](const int32_t windows[PTO2_MAX_RING_DEPTH]) {
+    auto cap_for = [](const int32_t windows[CHIP_MAX_RING_DEPTH]) {
         DeviceArena arena;
         int32_t cap = PTO2OrchestratorState::reserve_layout(arena, windows).scope_tasks_cap;
         arena.release();
         return cap;
     };
 
-    int32_t windows[PTO2_MAX_RING_DEPTH];
+    int32_t windows[CHIP_MAX_RING_DEPTH];
 
     // Default window: cap == the old compile-time value (no behavior change).
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++)
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++)
         windows[r] = PTO2_TASK_WINDOW_SIZE;
-    EXPECT_EQ(cap_for(windows), PTO2_TASK_WINDOW_SIZE * PTO2_MAX_RING_DEPTH);
+    EXPECT_EQ(cap_for(windows), PTO2_TASK_WINDOW_SIZE * CHIP_MAX_RING_DEPTH);
     EXPECT_EQ(cap_for(windows), PTO2_SCOPE_TASKS_CAP);
 
     // Shrunk window: cap shrinks to the real budget (no over-allocation).
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++)
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++)
         windows[r] = 4;
-    EXPECT_EQ(cap_for(windows), 4 * PTO2_MAX_RING_DEPTH);
+    EXPECT_EQ(cap_for(windows), 4 * CHIP_MAX_RING_DEPTH);
 
     // Enlarged window past the compile default: cap grows to match the rings, so a
     // large scope no longer hits a premature SCOPE_TASKS_OVERFLOW (the bug fixed).
     const int32_t big = PTO2_TASK_WINDOW_SIZE * 2;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++)
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++)
         windows[r] = big;
-    EXPECT_EQ(cap_for(windows), big * PTO2_MAX_RING_DEPTH);
+    EXPECT_EQ(cap_for(windows), big * CHIP_MAX_RING_DEPTH);
     EXPECT_GT(cap_for(windows), PTO2_SCOPE_TASKS_CAP);
 }

--- a/tests/ut/cpp/a2a3/test_ready_queue.cpp
+++ b/tests/ut/cpp/a2a3/test_ready_queue.cpp
@@ -73,15 +73,15 @@ protected:
 TEST_F(ReadyQueueTest, EmptyPopReturnsNullptr) { EXPECT_EQ(queue.pop(), nullptr); }
 
 TEST_F(ReadyQueueTest, SinglePushPop) {
-    PTO2TaskSlotState item;
+    ChipTaskSlotState item;
     ASSERT_TRUE(queue.push(&item));
 
-    PTO2TaskSlotState *result = queue.pop();
+    ChipTaskSlotState *result = queue.pop();
     EXPECT_EQ(result, &item);
 }
 
 TEST_F(ReadyQueueTest, FIFOOrdering) {
-    PTO2TaskSlotState a, b, c;
+    ChipTaskSlotState a, b, c;
 
     ASSERT_TRUE(queue.push(&a));
     ASSERT_TRUE(queue.push(&b));
@@ -94,18 +94,18 @@ TEST_F(ReadyQueueTest, FIFOOrdering) {
 }
 
 TEST_F(ReadyQueueTest, QueueFullReturnsFalse) {
-    std::vector<PTO2TaskSlotState> items(CAPACITY);
+    std::vector<ChipTaskSlotState> items(CAPACITY);
 
     for (uint64_t i = 0; i < CAPACITY; i++) {
         ASSERT_TRUE(queue.push(&items[i]));
     }
 
-    PTO2TaskSlotState extra;
+    ChipTaskSlotState extra;
     EXPECT_FALSE(queue.push(&extra));
 }
 
 TEST_F(ReadyQueueTest, SlotReuseAfterFullDrain) {
-    std::vector<PTO2TaskSlotState> items(CAPACITY);
+    std::vector<ChipTaskSlotState> items(CAPACITY);
 
     for (uint64_t i = 0; i < CAPACITY; i++) {
         ASSERT_TRUE(queue.push(&items[i]));
@@ -126,8 +126,8 @@ TEST_F(ReadyQueueTest, SlotReuseAfterFullDrain) {
 
 TEST_F(ReadyQueueTest, PushBatchThenIndividualPop) {
     constexpr int BATCH_SIZE = 5;
-    PTO2TaskSlotState items[BATCH_SIZE];
-    PTO2TaskSlotState *ptrs[BATCH_SIZE];
+    ChipTaskSlotState items[BATCH_SIZE];
+    ChipTaskSlotState *ptrs[BATCH_SIZE];
     for (int i = 0; i < BATCH_SIZE; i++) {
         ptrs[i] = &items[i];
     }
@@ -149,13 +149,13 @@ TEST_F(ReadyQueueTest, PushBatchZeroIsNoop) {
 
 TEST_F(ReadyQueueTest, PopBatchReturnsFive) {
     constexpr int PUSH_COUNT = 10;
-    PTO2TaskSlotState items[PUSH_COUNT];
+    ChipTaskSlotState items[PUSH_COUNT];
 
     for (int i = 0; i < PUSH_COUNT; i++) {
         ASSERT_TRUE(queue.push(&items[i]));
     }
 
-    PTO2TaskSlotState *out[5];
+    ChipTaskSlotState *out[5];
     int popped = queue.pop_batch(out, 5);
     EXPECT_EQ(popped, 5);
 
@@ -166,13 +166,13 @@ TEST_F(ReadyQueueTest, PopBatchReturnsFive) {
 
 TEST_F(ReadyQueueTest, PopBatchPartial) {
     constexpr int PUSH_COUNT = 3;
-    PTO2TaskSlotState items[PUSH_COUNT];
+    ChipTaskSlotState items[PUSH_COUNT];
 
     for (int i = 0; i < PUSH_COUNT; i++) {
         ASSERT_TRUE(queue.push(&items[i]));
     }
 
-    PTO2TaskSlotState *out[5];
+    ChipTaskSlotState *out[5];
     int popped = queue.pop_batch(out, 5);
     EXPECT_EQ(popped, PUSH_COUNT);
 
@@ -182,12 +182,12 @@ TEST_F(ReadyQueueTest, PopBatchPartial) {
 }
 
 TEST_F(ReadyQueueTest, TaggedBatchPopPreservesTaskGeneration) {
-    PTO2TaskSlotState items[2];
-    PTO2TaskSlotState *input[2]{&items[0], &items[1]};
+    ChipTaskSlotState items[2];
+    ChipTaskSlotState *input[2]{&items[0], &items[1]};
     constexpr uint64_t queued_task_ids[2]{0x123456789abcdef0ULL, 0x0fedcba987654321ULL};
     queue.push_batch_tagged(input, queued_task_ids, 2);
 
-    PTO2TaskSlotState *out[2];
+    ChipTaskSlotState *out[2];
     uint64_t task_id_snapshots[2]{};
     ASSERT_EQ(queue.pop_batch_tagged(out, task_id_snapshots, 2), 2);
     EXPECT_EQ(out[0], &items[0]);
@@ -197,7 +197,7 @@ TEST_F(ReadyQueueTest, TaggedBatchPopPreservesTaskGeneration) {
 }
 
 TEST_F(ReadyQueueTest, TaggedPopPreservesTaskGeneration) {
-    PTO2TaskSlotState item;
+    ChipTaskSlotState item;
     constexpr uint64_t queued_task_id = 0xfedcba9876543210ULL;
     ASSERT_TRUE(queue.push_tagged(&item, queued_task_id));
 
@@ -207,7 +207,7 @@ TEST_F(ReadyQueueTest, TaggedPopPreservesTaskGeneration) {
 }
 
 TEST_F(ReadyQueueTest, PopBatchEmpty) {
-    PTO2TaskSlotState *out[5];
+    ChipTaskSlotState *out[5];
     int popped = queue.pop_batch(out, 5);
     EXPECT_EQ(popped, 0);
 }
@@ -215,7 +215,7 @@ TEST_F(ReadyQueueTest, PopBatchEmpty) {
 TEST_F(ReadyQueueTest, SizeAccuracy) {
     EXPECT_EQ(queue.size(), 0u);
 
-    PTO2TaskSlotState items[8];
+    ChipTaskSlotState items[8];
 
     queue.push(&items[0]);
     EXPECT_EQ(queue.size(), 1u);
@@ -245,7 +245,7 @@ class ReadyQueueBoundaryTest : public ::testing::Test {
 protected:
     static constexpr uint64_t QUEUE_CAP = 8;  // Small for boundary testing
     PTO2ReadyQueue queue{};
-    PTO2TaskSlotState dummy[8]{};
+    ChipTaskSlotState dummy[8]{};
 
     DeviceArena arena;
 
@@ -321,7 +321,7 @@ TEST_F(ReadyQueueBoundaryTest, RepeatedEmptyPop) {
 TEST_F(ReadyQueueBoundaryTest, ManyPushPopCycles) {
     for (int i = 0; i < 10000; i++) {
         ASSERT_TRUE(queue.push(&dummy[0]));
-        PTO2TaskSlotState *s = queue.pop();
+        ChipTaskSlotState *s = queue.pop();
         ASSERT_NE(s, nullptr);
         EXPECT_EQ(s, &dummy[0]);
     }
@@ -365,13 +365,13 @@ TEST_P(ReadyQueueMPMCTest, NoDuplicateNoLoss) {
     auto cfg = GetParam();
     int total = cfg.producers * cfg.items_per_producer;
 
-    std::vector<PTO2TaskSlotState> items(total);
+    std::vector<ChipTaskSlotState> items(total);
     std::vector<std::atomic<int>> consumed_count(total);
     for (int i = 0; i < total; i++) {
         consumed_count[i].store(0, std::memory_order_relaxed);
     }
 
-    auto item_index = [&](PTO2TaskSlotState *s) -> int {
+    auto item_index = [&](ChipTaskSlotState *s) -> int {
         return static_cast<int>(s - items.data());
     };
 
@@ -388,7 +388,7 @@ TEST_P(ReadyQueueMPMCTest, NoDuplicateNoLoss) {
 
     auto consumer = [&]() {
         while (true) {
-            PTO2TaskSlotState *item = queue.pop();
+            ChipTaskSlotState *item = queue.pop();
             if (item != nullptr) {
                 consumed_count[item_index(item)].fetch_add(1, std::memory_order_relaxed);
                 total_consumed.fetch_add(1, std::memory_order_relaxed);

--- a/tests/ut/cpp/a2a3/test_scheduler_state.cpp
+++ b/tests/ut/cpp/a2a3/test_scheduler_state.cpp
@@ -180,7 +180,7 @@ TEST_F(SchedulerStateTest, ConsumedTransition) {
 }
 
 TEST_F(SchedulerStateTest, ConsumedHeadAdvancesAfterContendedAdvanceLock) {
-    constexpr int32_t ring_id = PTO2_MAX_RING_DEPTH - 1;
+    constexpr int32_t ring_id = CHIP_MAX_RING_DEPTH - 1;
     constexpr int32_t head_task_id = 0;
     setup_ring_for_reclaim_race(ring_id, /*current_task_index=*/1, head_task_id);
 
@@ -226,7 +226,7 @@ TEST_F(SchedulerStateTest, ConsumedIdempotent) {
 }
 
 TEST_F(SchedulerStateTest, ContendedConsumedHeadSetsPendingAndIdleDrainAdvances) {
-    constexpr int32_t ring_id = PTO2_MAX_RING_DEPTH - 1;
+    constexpr int32_t ring_id = CHIP_MAX_RING_DEPTH - 1;
     constexpr int32_t head_task_id = 17;
     setup_contended_head_case(ring_id, head_task_id);
 
@@ -256,7 +256,7 @@ TEST_F(SchedulerStateTest, ContendedConsumedHeadSetsPendingAndIdleDrainAdvances)
 TEST_F(SchedulerStateTest, ContendedConsumedHeadIdleDrainStress) {
     const int32_t head_task_ids[] = {0, 1, 127, PTO2_TASK_WINDOW_SIZE - 2, PTO2_TASK_WINDOW_SIZE + 3};
 
-    for (int32_t ring_id = 0; ring_id < PTO2_MAX_RING_DEPTH; ring_id++) {
+    for (int32_t ring_id = 0; ring_id < CHIP_MAX_RING_DEPTH; ring_id++) {
         for (int32_t head_task_id : head_task_ids) {
             SCOPED_TRACE(::testing::Message() << "ring_id=" << ring_id << " head_task_id=" << head_task_id);
             setup_contended_head_case(ring_id, head_task_id);

--- a/tests/ut/cpp/a2a3/test_scheduler_state.cpp
+++ b/tests/ut/cpp/a2a3/test_scheduler_state.cpp
@@ -81,7 +81,7 @@ protected:
     }
 
     void init_slot(
-        PTO2TaskSlotState &slot, PTO2TaskState state, int32_t fanin_count, int32_t fanout_count, uint8_t ring_id = 0
+        ChipTaskSlotState &slot, PTO2TaskState state, int32_t fanin_count, int32_t fanout_count, uint8_t ring_id = 0
     ) {
         memset(&slot, 0, sizeof(slot));
         slot.task_state.store(state);
@@ -105,7 +105,7 @@ protected:
         PTO2SharedMemoryRingHeader &ring, int32_t task_id, PTO2TaskState state, uint8_t ring_id,
         uint32_t fanout_count = 1, uint32_t fanout_refcount = 1
     ) {
-        PTO2TaskSlotState &slot = ring.get_slot_state_by_task_id(task_id);
+        ChipTaskSlotState &slot = ring.get_slot_state_by_task_id(task_id);
         PTO2TaskPayload &payload = ring.get_payload_by_task_id(task_id);
         PTO2TaskDescriptor &task = ring.get_task_by_task_id(task_id);
         memset(&slot, 0, sizeof(slot));
@@ -162,7 +162,7 @@ protected:
 // =============================================================================
 
 TEST_F(SchedulerStateTest, ConsumedNotReady) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_COMPLETED, 1, 2);
     slot.fanout_refcount.store(1);  // 1 != 2
 
@@ -171,7 +171,7 @@ TEST_F(SchedulerStateTest, ConsumedNotReady) {
 }
 
 TEST_F(SchedulerStateTest, ConsumedTransition) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_COMPLETED, 1, 2);
     slot.fanout_refcount.store(2);  // matches fanout_count
 
@@ -186,7 +186,7 @@ TEST_F(SchedulerStateTest, ConsumedHeadAdvancesAfterContendedAdvanceLock) {
 
     PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
     PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
-    PTO2TaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
+    ChipTaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
     uint32_t pending_bit = PTO2SchedulerState::ring_advance_pending_bit(ring_id);
 
     ring_sched.advance_lock.store(1, std::memory_order_release);
@@ -207,7 +207,7 @@ TEST_F(SchedulerStateTest, ConsumedHeadAdvancesAfterContendedAdvanceLock) {
 }
 
 TEST_F(SchedulerStateTest, ConsumedNotCompletedState) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.fanout_refcount.store(1);
 
@@ -217,7 +217,7 @@ TEST_F(SchedulerStateTest, ConsumedNotCompletedState) {
 }
 
 TEST_F(SchedulerStateTest, ConsumedIdempotent) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_CONSUMED, 1, 1);
     slot.fanout_refcount.store(1);
 
@@ -232,7 +232,7 @@ TEST_F(SchedulerStateTest, ContendedConsumedHeadSetsPendingAndIdleDrainAdvances)
 
     PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
     PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
-    PTO2TaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
+    ChipTaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
     uint32_t pending_bit = PTO2SchedulerState::ring_advance_pending_bit(ring_id);
 
     ring_sched.advance_lock.store(1, std::memory_order_release);
@@ -263,7 +263,7 @@ TEST_F(SchedulerStateTest, ContendedConsumedHeadIdleDrainStress) {
 
             PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
             PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
-            PTO2TaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
+            ChipTaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
 
             ring_sched.advance_lock.store(1, std::memory_order_release);
             sched.check_and_handle_consumed(head);
@@ -281,7 +281,7 @@ TEST_F(SchedulerStateTest, ContendedConsumedHeadIdleDrainStress) {
 // =============================================================================
 
 TEST_F(SchedulerStateTest, ReleaseProducerIncrements) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_COMPLETED, 1, 3);
 
     sched.release_producer(slot);
@@ -292,7 +292,7 @@ TEST_F(SchedulerStateTest, ReleaseProducerIncrements) {
 }
 
 TEST_F(SchedulerStateTest, ReleaseProducerTriggersConsumed) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_COMPLETED, 1, 2);
     slot.fanout_refcount.store(1);  // One away
 
@@ -305,7 +305,7 @@ TEST_F(SchedulerStateTest, ReleaseProducerTriggersConsumed) {
 // =============================================================================
 
 TEST_F(SchedulerStateTest, SubtaskCompleteSingle) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.total_required_subtasks = 1;
     slot.completed_subtasks.store(0);
@@ -314,7 +314,7 @@ TEST_F(SchedulerStateTest, SubtaskCompleteSingle) {
 }
 
 TEST_F(SchedulerStateTest, SubtaskCompleteMultiBlock) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.total_required_subtasks = 6;  // 3 cores * 2 blocks
     slot.completed_subtasks.store(0);
@@ -331,8 +331,8 @@ TEST_F(SchedulerStateTest, SubtaskCompleteMultiBlock) {
 
 TEST_F(SchedulerStateTest, ScopeEndBatchRelease) {
     constexpr int N = 4;
-    alignas(64) PTO2TaskSlotState slots[N];
-    PTO2TaskSlotState *ptrs[N];
+    alignas(64) ChipTaskSlotState slots[N];
+    ChipTaskSlotState *ptrs[N];
 
     for (int i = 0; i < N; i++) {
         init_slot(slots[i], PTO2_TASK_COMPLETED, 1, 2);
@@ -353,7 +353,7 @@ TEST_F(SchedulerStateTest, ScopeEndBatchRelease) {
 // =============================================================================
 
 TEST_F(SchedulerStateTest, GetReadyTasksBatchDrainsSharedQueue) {
-    alignas(64) PTO2TaskSlotState slot_a, slot_b;
+    alignas(64) ChipTaskSlotState slot_a, slot_b;
     // fanin_count = 1 so a single release_fanin_and_check_ready call drives each
     // slot to ready (new_refcount 0->1 == fanin_count) and enqueues it.
     init_slot(slot_a, PTO2_TASK_PENDING, 1, 1);
@@ -363,7 +363,7 @@ TEST_F(SchedulerStateTest, GetReadyTasksBatchDrainsSharedQueue) {
     ASSERT_TRUE(sched.release_fanin_and_check_ready(slot_a));
     ASSERT_TRUE(sched.release_fanin_and_check_ready(slot_b));
 
-    PTO2TaskSlotState *out[4];
+    ChipTaskSlotState *out[4];
     int count = sched.get_ready_tasks_batch(sched.ready_queues, PTO2ResourceShape::AIC, out, 4);
 
     EXPECT_EQ(count, 2);

--- a/tests/ut/cpp/a2a3/test_shared_memory.cpp
+++ b/tests/ut/cpp/a2a3/test_shared_memory.cpp
@@ -99,7 +99,7 @@ TEST_F(SharedMemoryTest, HeaderInitValues) {
     EXPECT_EQ(hdr->sched_stall_task_id.load(), -1);
     EXPECT_EQ(hdr->sched_stall_core.load(), -1);
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         auto &fc = hdr->rings[r].fc;
         EXPECT_EQ(fc.current_task_index.load(), 0);
         EXPECT_EQ(fc.last_task_alive.load(), 0);
@@ -141,17 +141,17 @@ TEST(StallClassificationTest, NamesAreStableAndDistinct) {
 TEST_F(SharedMemoryTest, Validate) { EXPECT_TRUE(handle->validate()); }
 
 TEST_F(SharedMemoryTest, PerRingIndependence) {
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         EXPECT_NE(handle->header->rings[r].task_descriptors, nullptr) << "Ring " << r;
         EXPECT_NE(handle->header->rings[r].task_payloads, nullptr) << "Ring " << r;
     }
-    for (int r = 1; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 1; r < CHIP_MAX_RING_DEPTH; r++) {
         EXPECT_NE(handle->header->rings[r].task_descriptors, handle->header->rings[0].task_descriptors) << "Ring " << r;
     }
 }
 
 TEST_F(SharedMemoryTest, PointerAlignment) {
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         auto addr = reinterpret_cast<uintptr_t>(handle->header->rings[r].task_descriptors);
         EXPECT_EQ(addr % PTO2_ALIGN_SIZE, 0u) << "Ring " << r << " descriptors not aligned";
     }
@@ -168,7 +168,7 @@ TEST(SharedMemoryLayout, RegionsNonOverlapping) {
     PTO2SharedMemoryHandle *h = make_handle(arena, /*ws=*/64, /*heap=*/4096);
     ASSERT_NE(h, nullptr);
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         uintptr_t desc_start = (uintptr_t)h->header->rings[r].task_descriptors;
         uintptr_t desc_end = desc_start + 64 * sizeof(PTO2TaskDescriptor);
         uintptr_t payload_start = (uintptr_t)h->header->rings[r].task_payloads;
@@ -176,7 +176,7 @@ TEST(SharedMemoryLayout, RegionsNonOverlapping) {
         EXPECT_GE(payload_start, desc_end) << "Ring " << r << ": payload region should not overlap descriptors";
     }
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH - 1; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH - 1; r++) {
         uintptr_t this_payload_end = (uintptr_t)h->header->rings[r].task_payloads + 64 * sizeof(PTO2TaskPayload);
         uintptr_t next_desc_start = (uintptr_t)h->header->rings[r + 1].task_descriptors;
         EXPECT_GE(next_desc_start, this_payload_end) << "Ring " << r << " and " << (r + 1) << " should not overlap";
@@ -201,7 +201,7 @@ TEST(SharedMemoryCalcSize, LargerWindowGivesLargerSize) {
 TEST(SharedMemoryCalcSize, HeaderAligned) { EXPECT_EQ(sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE, 0u); }
 
 TEST(SharedMemoryCalcSize, PerRingDifferentSizes) {
-    uint64_t ws[PTO2_MAX_RING_DEPTH] = {128, 256, 512, 1024};
+    uint64_t ws[CHIP_MAX_RING_DEPTH] = {128, 256, 512, 1024};
     uint64_t size = PTO2SharedMemoryHandle::calculate_size_per_ring(ws);
 
     uint64_t uniform_size = PTO2SharedMemoryHandle::calculate_size(128);
@@ -209,8 +209,8 @@ TEST(SharedMemoryCalcSize, PerRingDifferentSizes) {
 }
 
 TEST(SharedMemoryLayout, InitPerRingWritesHeaderValues) {
-    uint64_t ws[PTO2_MAX_RING_DEPTH] = {16, 32, 64, 128};
-    uint64_t heaps[PTO2_MAX_RING_DEPTH] = {10 * 1024, 20 * 1024, 30 * 1024, 40 * 1024};
+    uint64_t ws[CHIP_MAX_RING_DEPTH] = {16, 32, 64, 128};
+    uint64_t heaps[CHIP_MAX_RING_DEPTH] = {10 * 1024, 20 * 1024, 30 * 1024, 40 * 1024};
     const uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(ws);
 
     DeviceArena arena;
@@ -224,7 +224,7 @@ TEST(SharedMemoryLayout, InitPerRingWritesHeaderValues) {
     std::memset(buffer, 0, static_cast<size_t>(sm_size));
     ASSERT_TRUE(handle->init_per_ring(buffer, sm_size, ws, heaps));
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         EXPECT_EQ(handle->header->rings[r].task_window_size, ws[r]);
         EXPECT_EQ(handle->header->rings[r].heap_size, heaps[r]);
         EXPECT_EQ(handle->header->rings[r].task_window_mask, static_cast<int32_t>(ws[r] - 1));
@@ -232,12 +232,12 @@ TEST(SharedMemoryLayout, InitPerRingWritesHeaderValues) {
 }
 
 TEST(RuntimeArenaLayout, PerRingConfigInitializesRuntimeComponents) {
-    uint64_t ws[PTO2_MAX_RING_DEPTH] = {16, 32, 64, 128};
-    uint64_t heaps[PTO2_MAX_RING_DEPTH] = {10 * 1024, 20 * 1024, 30 * 1024, 40 * 1024};
-    int32_t dep_caps[PTO2_MAX_RING_DEPTH] = {4, 8, 16, 32};
+    uint64_t ws[CHIP_MAX_RING_DEPTH] = {16, 32, 64, 128};
+    uint64_t heaps[CHIP_MAX_RING_DEPTH] = {10 * 1024, 20 * 1024, 30 * 1024, 40 * 1024};
+    int32_t dep_caps[CHIP_MAX_RING_DEPTH] = {4, 8, 16, 32};
     const uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(ws);
     uint64_t total_heap = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         total_heap += heaps[r];
     }
 
@@ -258,7 +258,7 @@ TEST(RuntimeArenaLayout, PerRingConfigInitializesRuntimeComponents) {
     runtime_wire_arena_pointers(runtime_arena, layout, rt);
 
     EXPECT_EQ(rt->gm_heap_size, total_heap);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         EXPECT_EQ(layout.sizing.task_window_sizes[r], ws[r]);
         EXPECT_EQ(layout.sizing.heap_sizes[r], heaps[r]);
         EXPECT_EQ(layout.sizing.dep_pool_capacities[r], dep_caps[r]);
@@ -270,9 +270,9 @@ TEST(RuntimeArenaLayout, PerRingConfigInitializesRuntimeComponents) {
 }
 
 TEST(RuntimeArenaLayout, RejectsOverflowingPerRingHeapSum) {
-    uint64_t ws[PTO2_MAX_RING_DEPTH] = {16, 32, 64, 128};
-    uint64_t heaps[PTO2_MAX_RING_DEPTH] = {std::numeric_limits<uint64_t>::max(), 1, 0, 0};
-    int32_t dep_caps[PTO2_MAX_RING_DEPTH] = {4, 8, 16, 32};
+    uint64_t ws[CHIP_MAX_RING_DEPTH] = {16, 32, 64, 128};
+    uint64_t heaps[CHIP_MAX_RING_DEPTH] = {std::numeric_limits<uint64_t>::max(), 1, 0, 0};
+    int32_t dep_caps[CHIP_MAX_RING_DEPTH] = {4, 8, 16, 32};
 
     DeviceArena runtime_arena;
     RuntimeArenaLayout layout = runtime_reserve_layout(runtime_arena, ws, heaps, dep_caps);
@@ -299,7 +299,7 @@ TEST(SharedMemoryBoundary, ZeroWindowSize) {
     DeviceArena arena;
     PTO2SharedMemoryHandle *h = make_handle(arena, /*ws=*/0, /*heap=*/4096);
     if (h) {
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH - 1; r++) {
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH - 1; r++) {
             EXPECT_EQ(h->header->rings[r].task_descriptors, h->header->rings[r + 1].task_descriptors)
                 << "Zero window: all rings' descriptor pointers collapse to same address";
         }

--- a/tests/ut/cpp/a2a3/test_shared_memory.cpp
+++ b/tests/ut/cpp/a2a3/test_shared_memory.cpp
@@ -242,7 +242,7 @@ TEST(RuntimeArenaLayout, PerRingConfigInitializesRuntimeComponents) {
     }
 
     DeviceArena runtime_arena;
-    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(runtime_arena, ws, heaps, dep_caps);
+    RuntimeArenaLayout layout = runtime_reserve_layout(runtime_arena, ws, heaps, dep_caps);
     ASSERT_NE(runtime_arena.commit(DeviceArena::kDefaultBaseAlign), nullptr);
 
     DeviceArena sm_arena;
@@ -252,7 +252,7 @@ TEST(RuntimeArenaLayout, PerRingConfigInitializesRuntimeComponents) {
     std::memset(sm, 0, static_cast<size_t>(sm_size));
 
     std::vector<char> gm(static_cast<size_t>(total_heap));
-    PTO2Runtime *rt =
+    RuntimeContext *rt =
         runtime_init_data_from_layout(runtime_arena, layout, PTO2_MODE_EXECUTE, sm, sm_size, gm.data(), heaps);
     ASSERT_NE(rt, nullptr);
     runtime_wire_arena_pointers(runtime_arena, layout, rt);
@@ -275,7 +275,7 @@ TEST(RuntimeArenaLayout, RejectsOverflowingPerRingHeapSum) {
     int32_t dep_caps[PTO2_MAX_RING_DEPTH] = {4, 8, 16, 32};
 
     DeviceArena runtime_arena;
-    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(runtime_arena, ws, heaps, dep_caps);
+    RuntimeArenaLayout layout = runtime_reserve_layout(runtime_arena, ws, heaps, dep_caps);
     ASSERT_NE(runtime_arena.commit(DeviceArena::kDefaultBaseAlign), nullptr);
 
     char sm = 0;

--- a/tests/ut/cpp/a2a3/test_task_state.cpp
+++ b/tests/ut/cpp/a2a3/test_task_state.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * Unit tests for PTO2TaskSlotState lifecycle through PTO2SchedulerState API.
+ * Unit tests for ChipTaskSlotState lifecycle through PTO2SchedulerState API.
  *
  * These tests drive state transitions via src methods (release_fanin,
  * on_subtask_complete, check_and_handle_consumed) rather than manually
@@ -60,7 +60,7 @@ protected:
         sm_arena.release();
     }
 
-    void init_slot(PTO2TaskSlotState &slot, PTO2TaskState state, int32_t fanin_count, int32_t fanout_count) {
+    void init_slot(ChipTaskSlotState &slot, PTO2TaskState state, int32_t fanin_count, int32_t fanout_count) {
         memset(&slot, 0, sizeof(slot));
         slot.task_state.store(state);
         slot.fanin_count = fanin_count;
@@ -85,7 +85,7 @@ protected:
 // -> (subtask) -> COMPLETED -> (fanout) -> CONSUMED
 // =============================================================================
 TEST_F(TaskStateTest, FullLifecycleThroughAPI) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.total_required_subtasks = 1;
     slot.completed_subtasks.store(0);
@@ -114,7 +114,7 @@ TEST_F(TaskStateTest, FullLifecycleThroughAPI) {
 // "dispatched to a worker" until the worker stores COMPLETED.
 // =============================================================================
 TEST_F(TaskStateTest, ReadyPathStaysPending) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
 
     bool ready = sched.release_fanin_and_check_ready(slot);
@@ -128,7 +128,7 @@ TEST_F(TaskStateTest, ReadyPathStaysPending) {
 // Multi-fanin: partial release does not trigger ready
 // =============================================================================
 TEST_F(TaskStateTest, MultiFaninPartialNotReady) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 3, 1);
 
     EXPECT_FALSE(sched.release_fanin_and_check_ready(slot));
@@ -143,7 +143,7 @@ TEST_F(TaskStateTest, ConcurrentFaninExactlyOneReady) {
     constexpr int ROUNDS = 500;
 
     for (int round = 0; round < ROUNDS; round++) {
-        alignas(64) PTO2TaskSlotState slot;
+        alignas(64) ChipTaskSlotState slot;
         init_slot(slot, PTO2_TASK_PENDING, 3, 1);
         std::atomic<int> ready_count{0};
 
@@ -169,7 +169,7 @@ TEST_F(TaskStateTest, ConcurrentSubtaskCompletion) {
     constexpr int ROUNDS = 500;
 
     for (int round = 0; round < ROUNDS; round++) {
-        alignas(64) PTO2TaskSlotState slot;
+        alignas(64) ChipTaskSlotState slot;
         init_slot(slot, PTO2_TASK_PENDING, 1, 1);
         slot.total_required_subtasks = 3;
         slot.completed_subtasks.store(0);
@@ -198,7 +198,7 @@ TEST_F(TaskStateTest, ConcurrentSubtaskCompletion) {
 // Unlike the old bitmask model, the counter cannot detect duplicates.
 // =============================================================================
 TEST_F(TaskStateTest, DoubleSubtaskCompletionCounterWeakness) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.total_required_subtasks = 2;
     slot.completed_subtasks.store(0);

--- a/tests/ut/cpp/a2a3/test_tensormap.cpp
+++ b/tests/ut/cpp/a2a3/test_tensormap.cpp
@@ -80,7 +80,7 @@ protected:
     DeviceArena arena;
 
     void SetUp() override {
-        int32_t window_sizes[PTO2_MAX_RING_DEPTH] = {WINDOW_SIZE, WINDOW_SIZE, WINDOW_SIZE, WINDOW_SIZE};
+        int32_t window_sizes[CHIP_MAX_RING_DEPTH] = {WINDOW_SIZE, WINDOW_SIZE, WINDOW_SIZE, WINDOW_SIZE};
         auto layout = PTO2TensorMap::reserve_layout(arena, NUM_BUCKETS, POOL_SIZE, window_sizes);
         ASSERT_NE(arena.commit(), nullptr);
         ASSERT_TRUE(tmap.init_data_from_layout(layout, arena));
@@ -111,7 +111,7 @@ TEST_F(TensorMapTest, InitRequiresPowerOfTwoBuckets) {
     // always_assert may compile out). Smoke-test only the success path here.
     PTO2TensorMap bad{};
     DeviceArena bad_arena;
-    int32_t ws[PTO2_MAX_RING_DEPTH] = {8, 8, 8, 8};
+    int32_t ws[CHIP_MAX_RING_DEPTH] = {8, 8, 8, 8};
     auto layout = PTO2TensorMap::reserve_layout(bad_arena, 8, 64, ws);
     ASSERT_NE(bad_arena.commit(), nullptr);
     EXPECT_TRUE(bad.init_data_from_layout(layout, bad_arena));

--- a/tests/ut/cpp/a2a3/test_wiring.cpp
+++ b/tests/ut/cpp/a2a3/test_wiring.cpp
@@ -75,7 +75,7 @@ protected:
 
     // Initialize a slot for testing wiring/completion
     void init_slot(
-        PTO2TaskSlotState &slot, PTO2TaskState state, int32_t fanin_count, int32_t fanout_count, uint8_t ring_id = 0
+        ChipTaskSlotState &slot, PTO2TaskState state, int32_t fanin_count, int32_t fanout_count, uint8_t ring_id = 0
     ) {
         memset(&slot, 0, sizeof(slot));
         slot.task_state.store(state);
@@ -99,14 +99,14 @@ protected:
         slot.task = &slot_task;
     }
 
-    void publish_no_fanin(PTO2TaskSlotState &slot) {
+    void publish_no_fanin(ChipTaskSlotState &slot) {
         slot.fanin_count = 1;
         slot.fanin_refcount.store(1, std::memory_order_release);
         orch.mark_dep_pool_position(slot);
         sched.push_ready_routed(&slot);
     }
 
-    void wire_fanin(PTO2TaskSlotState &slot, int32_t wfanin) {
+    void wire_fanin(ChipTaskSlotState &slot, int32_t wfanin) {
         auto &rss = sched.ring_sched_states[slot.ring_id];
         bool ok = rss.dep_pool.ensure_space(*rss.ring, wfanin);
         if (ok) {
@@ -122,7 +122,7 @@ protected:
 
 TEST_F(WiringTest, NoFaninTaskBecomesReady) {
     // A task with 0 actual fanins should immediately be pushed to ready queue
-    alignas(64) PTO2TaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState task_slot;
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -150,8 +150,8 @@ TEST_F(WiringTest, NoFaninTaskBecomesReady) {
 // =============================================================================
 
 TEST_F(WiringTest, WireTaskAllProducersEarlyFinished) {
-    alignas(64) PTO2TaskSlotState task_slot;
-    alignas(64) PTO2TaskSlotState producer_slots[2];
+    alignas(64) ChipTaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState producer_slots[2];
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -188,8 +188,8 @@ TEST_F(WiringTest, WireTaskAllProducersEarlyFinished) {
 // =============================================================================
 
 TEST_F(WiringTest, WireTaskProducersPendingTaskNotReady) {
-    alignas(64) PTO2TaskSlotState task_slot;
-    alignas(64) PTO2TaskSlotState producer_slots[2];
+    alignas(64) ChipTaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState producer_slots[2];
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -227,7 +227,7 @@ TEST_F(WiringTest, WireTaskProducersPendingTaskNotReady) {
 }
 
 TEST_F(WiringTest, DispatchPropagationMarkerPreservesLifecycleFlagsAndResets) {
-    alignas(64) PTO2TaskSlotState producer;
+    alignas(64) ChipTaskSlotState producer;
     init_slot(producer, PTO2_TASK_PENDING, 1, 1);
 
     EXPECT_FALSE(producer.has_dispatch_propagated());
@@ -251,8 +251,8 @@ TEST_F(WiringTest, DispatchPropagationMarkerPreservesLifecycleFlagsAndResets) {
 // =============================================================================
 
 TEST_F(WiringTest, WireTaskMixedProducerStates) {
-    alignas(64) PTO2TaskSlotState task_slot;
-    alignas(64) PTO2TaskSlotState producers[3];
+    alignas(64) ChipTaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState producers[3];
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -293,8 +293,8 @@ TEST_F(WiringTest, WireTaskMixedProducerStates) {
 // =============================================================================
 
 TEST_F(WiringTest, WireTaskAllFlaggedPrecompletedSeedsDispatchFanin) {
-    alignas(64) PTO2TaskSlotState task_slot;
-    alignas(64) PTO2TaskSlotState producer_slots[2];
+    alignas(64) ChipTaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState producer_slots[2];
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -323,8 +323,8 @@ TEST_F(WiringTest, WireTaskUnflaggedPrecompletedProducerDoesNotSeed) {
     // dispatch_fanin. It never dispatches, so it can never be the flagged-and-
     // dispatched contributor the candidate compare expects; seeding it would let
     // the consumer become an early-dispatch candidate it should stay off.
-    alignas(64) PTO2TaskSlotState task_slot;
-    alignas(64) PTO2TaskSlotState producer;
+    alignas(64) ChipTaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState producer;
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -346,8 +346,8 @@ TEST_F(WiringTest, WireTaskUnflaggedPrecompletedProducerDoesNotSeed) {
 }
 
 TEST_F(WiringTest, WireTaskOneUnflaggedProducerDisqualifiesSeed) {
-    alignas(64) PTO2TaskSlotState task_slot;
-    alignas(64) PTO2TaskSlotState producers[2];
+    alignas(64) ChipTaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState producers[2];
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -373,8 +373,8 @@ TEST_F(WiringTest, EarlyDispatchWaitsForAllProducerBlocksPublished) {
     // A flagged, still-pending producer seeds nothing at wiring (not
     // pre-completed); only publishing every logical block bumps the consumer
     // to fanin_actual_count and makes it an early-dispatch candidate.
-    alignas(64) PTO2TaskSlotState task_slot;
-    alignas(64) PTO2TaskSlotState producer;
+    alignas(64) ChipTaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState producer;
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -407,14 +407,14 @@ TEST_F(WiringTest, EarlyDispatchWaitsForAllProducerBlocksPublished) {
 }
 
 TEST_F(WiringTest, BatchPushReportsFullInsteadOfSpinning) {
-    alignas(64) PTO2TaskSlotState filler;
+    alignas(64) ChipTaskSlotState filler;
     init_slot(filler, PTO2_TASK_PENDING, 0, 1);
     auto &queue = sched.early_dispatch_queues[static_cast<int32_t>(filler.active_mask.to_shape())];
     for (uint64_t i = 0; i < queue.capacity; i++) {
         ASSERT_TRUE(queue.push_tagged(&filler, i));
     }
 
-    PTO2TaskSlotState *items[1] = {&filler};
+    ChipTaskSlotState *items[1] = {&filler};
     uint64_t tags[1] = {queue.capacity};
     // A full queue must end the call, not spin waiting for a consumer. Reaching
     // the next line at all is the assertion.
@@ -426,7 +426,7 @@ TEST_F(WiringTest, BatchPushReportsFullInsteadOfSpinning) {
 }
 
 TEST_F(WiringTest, BatchPushSucceedsAfterSpaceIsReclaimed) {
-    alignas(64) PTO2TaskSlotState filler;
+    alignas(64) ChipTaskSlotState filler;
     init_slot(filler, PTO2_TASK_PENDING, 0, 1);
     auto &queue = sched.early_dispatch_queues[static_cast<int32_t>(filler.active_mask.to_shape())];
     for (uint64_t i = 0; i < queue.capacity; i++) {
@@ -435,14 +435,14 @@ TEST_F(WiringTest, BatchPushSucceedsAfterSpaceIsReclaimed) {
     ASSERT_NE(queue.pop(), nullptr);
     ASSERT_NE(queue.pop(), nullptr);
 
-    PTO2TaskSlotState *items[2] = {&filler, &filler};
+    ChipTaskSlotState *items[2] = {&filler, &filler};
     uint64_t tags[2] = {7, 8};
     EXPECT_TRUE(queue.push_batch_tagged(items, tags, 2));
     EXPECT_EQ(queue.size(), queue.capacity);
 }
 
 TEST_F(WiringTest, EarlyDispatchQueueOverflowRollsBackStagingClaim) {
-    alignas(64) PTO2TaskSlotState filler, consumer;
+    alignas(64) ChipTaskSlotState filler, consumer;
     init_slot(filler, PTO2_TASK_PENDING, 0, 1);
     init_slot(consumer, PTO2_TASK_PENDING, 0, 1);
 
@@ -459,7 +459,7 @@ TEST_F(WiringTest, EarlyDispatchQueueOverflowRollsBackStagingClaim) {
 }
 
 TEST_F(WiringTest, EarlyDispatchQueueOverflowFallsBackToNormalDispatch) {
-    alignas(64) PTO2TaskSlotState filler, consumer;
+    alignas(64) ChipTaskSlotState filler, consumer;
     init_slot(filler, PTO2_TASK_PENDING, 0, 1);
     init_slot(consumer, PTO2_TASK_PENDING, 1, 1);
 
@@ -480,7 +480,7 @@ TEST_F(WiringTest, EarlyDispatchQueueOverflowFallsBackToNormalDispatch) {
 }
 
 TEST_F(WiringTest, EarlyDispatchSyncStartQueueOverflowFallsBackToSyncReadyQueue) {
-    alignas(64) PTO2TaskSlotState filler, consumer;
+    alignas(64) ChipTaskSlotState filler, consumer;
     init_slot(filler, PTO2_TASK_PENDING, 0, 1);
     init_slot(consumer, PTO2_TASK_PENDING, 1, 1);
     consumer.task_attrs.set_sync_start();
@@ -503,7 +503,7 @@ TEST_F(WiringTest, EarlyDispatchSyncStartQueueOverflowFallsBackToSyncReadyQueue)
 }
 
 TEST_F(WiringTest, LateWiredFullyPublishedProducerStillSeedsEarlyDispatch) {
-    alignas(64) PTO2TaskSlotState producer, consumer;
+    alignas(64) ChipTaskSlotState producer, consumer;
     alignas(64) PTO2TaskPayload consumer_payload;
     memset(&consumer_payload, 0, sizeof(consumer_payload));
     PTO2TaskDescriptor consumer_desc{};
@@ -530,7 +530,7 @@ TEST_F(WiringTest, LateWiredFullyPublishedProducerStillSeedsEarlyDispatch) {
 }
 
 TEST_F(WiringTest, WiringSeedEnqueuesAfterConcurrentPropagation) {
-    alignas(64) PTO2TaskSlotState producers[3], consumer;
+    alignas(64) ChipTaskSlotState producers[3], consumer;
     alignas(64) PTO2TaskPayload consumer_payload;
     memset(&consumer_payload, 0, sizeof(consumer_payload));
     PTO2TaskDescriptor consumer_desc{};
@@ -574,7 +574,7 @@ TEST_F(WiringTest, WiringSeedEnqueuesAfterConcurrentPropagation) {
 }
 
 TEST_F(WiringTest, ConcurrentBlockRangeClaimsDoNotOverlap) {
-    alignas(64) PTO2TaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState task_slot;
     init_slot(task_slot, PTO2_TASK_PENDING, 1, 1);
     task_slot.logical_block_num = 8;
 
@@ -609,7 +609,7 @@ TEST_F(WiringTest, ConcurrentBlockRangeClaimsDoNotOverlap) {
 }
 
 TEST_F(WiringTest, PartialStagedReleaseRoutesRemainderToReadyQueue) {
-    alignas(64) PTO2TaskSlotState consumer;
+    alignas(64) ChipTaskSlotState consumer;
     init_slot(consumer, PTO2_TASK_PENDING, 1, 1);
     consumer.logical_block_num = 5;
     consumer.next_block_idx.store(2, std::memory_order_relaxed);
@@ -683,7 +683,7 @@ TEST_F(WiringTest, EarlyDispatchLaunchHasSingleOwner) {
 }
 
 TEST_F(WiringTest, EarlyDispatchFanoutWaitsForDoorbellPass) {
-    alignas(64) PTO2TaskSlotState producer, consumer;
+    alignas(64) ChipTaskSlotState producer, consumer;
     init_slot(producer, PTO2_TASK_PENDING, 1, 1);
     init_slot(consumer, PTO2_TASK_PENDING, 1, 1);
 
@@ -733,7 +733,7 @@ TEST_F(WiringTest, EarlyDispatchReleaseConsumesDoorbellMask) {
     constexpr int core_id = 5;
     constexpr uint64_t reg_addr = 0x98760000;
     constexpr uint32_t token = 11;
-    alignas(64) PTO2TaskSlotState task;
+    alignas(64) ChipTaskSlotState task;
     init_slot(task, PTO2_TASK_PENDING, 1, 1);
     task.task_attrs.set_early_resolve(true);
     task.next_block_idx.store(1, std::memory_order_relaxed);
@@ -798,7 +798,7 @@ TEST_F(WiringTest, SyncStartDoorbellPassHasOneOwner) {
 }
 
 TEST_F(WiringTest, SyncStartStagingFinalizeRetriesProducerFirstRendezvous) {
-    alignas(64) PTO2TaskSlotState sync_consumer, downstream;
+    alignas(64) ChipTaskSlotState sync_consumer, downstream;
     init_slot(sync_consumer, PTO2_TASK_PENDING, 1, 1);
     init_slot(downstream, PTO2_TASK_PENDING, 1, 1);
 
@@ -835,7 +835,7 @@ TEST_F(WiringTest, SyncStartStagingFinalizeRetriesProducerFirstRendezvous) {
 }
 
 TEST_F(WiringTest, SyncStartProducerReleaseCompletesStagerFirstRendezvous) {
-    alignas(64) PTO2TaskSlotState sync_consumer, downstream;
+    alignas(64) ChipTaskSlotState sync_consumer, downstream;
     init_slot(sync_consumer, PTO2_TASK_PENDING, 1, 1);
     init_slot(downstream, PTO2_TASK_PENDING, 1, 1);
 
@@ -866,7 +866,7 @@ TEST_F(WiringTest, SyncStartProducerReleaseCompletesStagerFirstRendezvous) {
 }
 
 TEST_F(WiringTest, ArmedEarlySyncDrainOwnsFinalReadyRoute) {
-    alignas(64) PTO2TaskSlotState sync_consumer;
+    alignas(64) ChipTaskSlotState sync_consumer;
     init_slot(sync_consumer, PTO2_TASK_PENDING, 1, 1);
     sync_consumer.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIV0);
     sync_consumer.task_attrs.set_sync_start();
@@ -935,7 +935,7 @@ TEST_F(WiringTest, ArmedEarlySyncDrainKeepsEveryStagerGatedAfterReady) {
 }
 
 TEST_F(WiringTest, EarlySyncFinishBetweenReleasePhasesRetainsOwnerCompleteState) {
-    alignas(64) PTO2TaskSlotState sync_consumer;
+    alignas(64) ChipTaskSlotState sync_consumer;
     init_slot(sync_consumer, PTO2_TASK_PENDING, 1, 1);
     sync_consumer.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIV0);
     sync_consumer.task_attrs.set_sync_start();
@@ -959,7 +959,7 @@ TEST_F(WiringTest, EarlySyncFinishBetweenReleasePhasesRetainsOwnerCompleteState)
 }
 
 TEST_F(WiringTest, CancelledEarlySyncDrainRoutesProducerRelease) {
-    alignas(64) PTO2TaskSlotState sync_consumer;
+    alignas(64) ChipTaskSlotState sync_consumer;
     init_slot(sync_consumer, PTO2_TASK_PENDING, 1, 1);
     sync_consumer.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIV0);
     sync_consumer.task_attrs.set_sync_start();
@@ -977,7 +977,7 @@ TEST_F(WiringTest, CancelledEarlySyncDrainRoutesProducerRelease) {
 }
 
 TEST_F(WiringTest, ProducerReleaseTransfersReadyRouteToCancellingDrain) {
-    alignas(64) PTO2TaskSlotState sync_consumer;
+    alignas(64) ChipTaskSlotState sync_consumer;
     init_slot(sync_consumer, PTO2_TASK_PENDING, 1, 1);
     sync_consumer.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIV0);
     sync_consumer.task_attrs.set_sync_start();
@@ -996,8 +996,8 @@ TEST_F(WiringTest, ProducerReleaseTransfersReadyRouteToCancellingDrain) {
 }
 
 TEST_F(WiringTest, EarlyDispatchBlockedByUnflaggedProducer) {
-    alignas(64) PTO2TaskSlotState task_slot;
-    alignas(64) PTO2TaskSlotState p_flagged, q_unflagged;
+    alignas(64) ChipTaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState p_flagged, q_unflagged;
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -1027,7 +1027,7 @@ TEST_F(WiringTest, UnflaggedProducerDoesNotPropagate) {
     // Auto-chain removed: an unflagged producer never propagates, so its
     // consumers' dispatch_fanin stays untouched even after it dispatches, and the
     // once-guard is not even consumed (the gate returns first).
-    alignas(64) PTO2TaskSlotState producer, consumer;
+    alignas(64) ChipTaskSlotState producer, consumer;
     alignas(64) PTO2TaskPayload prod_payload, cons_payload;
     memset(&prod_payload, 0, sizeof(prod_payload));
     memset(&cons_payload, 0, sizeof(cons_payload));
@@ -1057,8 +1057,8 @@ TEST_F(WiringTest, FlaggedPrecompletedCreatorTransparentToEarlyDispatch) {
     // a flagged, still-pending compute producer. The creator must be transparent
     // (seeded), not a disqualifier: once the compute producer dispatches, the
     // consumer reaches fanin_actual_count and becomes an early-dispatch candidate.
-    alignas(64) PTO2TaskSlotState task_slot;
-    alignas(64) PTO2TaskSlotState creator, compute;
+    alignas(64) ChipTaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState creator, compute;
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -1088,8 +1088,8 @@ TEST_F(WiringTest, FlaggedPrecompletedCreatorTransparentToEarlyDispatch) {
 // =============================================================================
 
 TEST_F(WiringTest, OnMixedTaskCompleteNotifiesConsumers) {
-    alignas(64) PTO2TaskSlotState producer;
-    alignas(64) PTO2TaskSlotState consumer1, consumer2;
+    alignas(64) ChipTaskSlotState producer;
+    alignas(64) ChipTaskSlotState consumer1, consumer2;
     alignas(64) PTO2TaskPayload prod_payload;
     memset(&prod_payload, 0, sizeof(prod_payload));
     PTO2TaskDescriptor desc{};
@@ -1138,8 +1138,8 @@ TEST_F(WiringTest, OnMixedTaskCompleteNotifiesConsumers) {
 // =============================================================================
 
 TEST_F(WiringTest, OnTaskReleaseReleasesProducers) {
-    alignas(64) PTO2TaskSlotState task_slot;
-    alignas(64) PTO2TaskSlotState producers[2];
+    alignas(64) ChipTaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState producers[2];
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -1181,9 +1181,9 @@ TEST_F(WiringTest, OnTaskReleaseReleasesProducers) {
 // =============================================================================
 
 TEST_F(WiringTest, OrderingOnlyReleasedAtWiringRetentionHeldUntilRelease) {
-    alignas(64) PTO2TaskSlotState task_slot;
-    alignas(64) PTO2TaskSlotState wait_producer;    // DEP_WAIT only (modifier)
-    alignas(64) PTO2TaskSlotState retain_producer;  // DEP_WAIT|DEP_RETAIN (creator)
+    alignas(64) ChipTaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState wait_producer;    // DEP_WAIT only (modifier)
+    alignas(64) ChipTaskSlotState retain_producer;  // DEP_WAIT|DEP_RETAIN (creator)
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -1223,9 +1223,9 @@ TEST_F(WiringTest, OrderingOnlyReleasedAtWiringRetentionHeldUntilRelease) {
 // on_task_release must honor per-edge flags in the spill region too: a spilled
 // DEP_RETAIN edge is released; inline ordering-only edges are skipped.
 TEST_F(WiringTest, ReleaseHonorsRetainFlagInSpillRegion) {
-    alignas(64) PTO2TaskSlotState filler;        // 64 inline DEP_WAIT-only edges
-    alignas(64) PTO2TaskSlotState spill_retain;  // 1 spilled DEP_RETAIN edge
-    alignas(64) PTO2TaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState filler;        // 64 inline DEP_WAIT-only edges
+    alignas(64) ChipTaskSlotState spill_retain;  // 1 spilled DEP_RETAIN edge
+    alignas(64) ChipTaskSlotState task_slot;
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -1326,7 +1326,7 @@ TEST_F(WiringTest, AdvanceRingPointersResetsSlots) {
 }
 
 TEST_F(WiringTest, NoEdgePublishRecordsDepPoolMark) {
-    alignas(64) PTO2TaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState task_slot;
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};

--- a/tests/ut/cpp/a5/test_a5_fatal.cpp
+++ b/tests/ut/cpp/a5/test_a5_fatal.cpp
@@ -150,7 +150,7 @@ TEST(A5Fatal, ApiShortCircuitsAfterFatal) {
     rt_scope_begin();
     rt_scope_end();
     {
-        PTO2ScopeGuard guard;
+        ScopeGuard guard;
         (void)guard;
     }
 
@@ -190,7 +190,7 @@ TEST(A5Fatal, ScopeGuardForwardsModeUntilLexicalScopeExit) {
     runtime.pending_scope_mode = PTO2ScopeMode::MANUAL;
 
     {
-        PTO2_SCOPE_GUARD();
+        SIMPLER_SCOPE_GUARD();
         EXPECT_EQ(runtime.scope_begin_calls, 1);
         EXPECT_EQ(runtime.scope_end_calls, 0);
         EXPECT_EQ(runtime.last_scope_mode, PTO2ScopeMode::AUTO);
@@ -199,7 +199,7 @@ TEST(A5Fatal, ScopeGuardForwardsModeUntilLexicalScopeExit) {
     EXPECT_EQ(runtime.scope_end_calls, 1);
 
     {
-        PTO2_SCOPE_GUARD(PTO2ScopeMode::MANUAL);
+        SIMPLER_SCOPE_GUARD(PTO2ScopeMode::MANUAL);
         EXPECT_EQ(runtime.scope_begin_calls, 2);
         EXPECT_EQ(runtime.scope_end_calls, 1);
         EXPECT_EQ(runtime.last_scope_mode, PTO2ScopeMode::MANUAL);

--- a/tests/ut/cpp/a5/test_a5_fatal.cpp
+++ b/tests/ut/cpp/a5/test_a5_fatal.cpp
@@ -21,13 +21,13 @@
 
 namespace {
 
-PTO2Runtime *g_bound_runtime = nullptr;
+RuntimeContext *g_bound_runtime = nullptr;
 
-extern "C" PTO2Runtime *framework_current_runtime(void) { return g_bound_runtime; }
-extern "C" void framework_bind_runtime(PTO2Runtime *rt) { g_bound_runtime = rt; }
+extern "C" RuntimeContext *framework_current_runtime(void) { return g_bound_runtime; }
+extern "C" void framework_bind_runtime(RuntimeContext *rt) { g_bound_runtime = rt; }
 
 struct FakeRuntime {
-    const PTO2RuntimeOps *ops;
+    const RuntimeOps *ops;
     PTO2ScopeMode pending_scope_mode = PTO2ScopeMode::AUTO;
     bool fatal = false;
     int submit_calls = 0;
@@ -45,26 +45,26 @@ struct FakeRuntime {
 
 static_assert(offsetof(FakeRuntime, ops) == 0);  // Guard: reinterpret_cast below assumes ops is first member.
 static_assert(
-    offsetof(FakeRuntime, pending_scope_mode) == offsetof(PTO2Runtime, pending_scope_mode)
-);  // ...and pending_scope_mode follows ops, matching the PTO2Runtime prefix the inline scope wrappers pun through.
+    offsetof(FakeRuntime, pending_scope_mode) == offsetof(RuntimeContext, pending_scope_mode)
+);  // ...and pending_scope_mode follows ops, matching the RuntimeContext prefix the inline scope wrappers pun through.
 
-FakeRuntime *as_fake(PTO2Runtime *rt) { return reinterpret_cast<FakeRuntime *>(rt); }
+FakeRuntime *as_fake(RuntimeContext *rt) { return reinterpret_cast<FakeRuntime *>(rt); }
 
-TaskOutputTensors fake_submit(PTO2Runtime *rt, const MixedKernels &, const CoreTaskArgs &) {
+TaskOutputTensors fake_submit(RuntimeContext *rt, const MixedKernels &, const CoreTaskArgs &) {
     as_fake(rt)->submit_calls++;
     return TaskOutputTensors{};
 }
 
-void fake_scope_begin(PTO2Runtime *rt) {
+void fake_scope_begin(RuntimeContext *rt) {
     FakeRuntime *fake = as_fake(rt);
     fake->scope_begin_calls++;
     fake->last_scope_mode = fake->pending_scope_mode;
 }
-void fake_scope_end(PTO2Runtime *rt) { as_fake(rt)->scope_end_calls++; }
-void fake_orchestration_done(PTO2Runtime *) {}
-bool fake_is_fatal(PTO2Runtime *rt) { return as_fake(rt)->fatal; }
+void fake_scope_end(RuntimeContext *rt) { as_fake(rt)->scope_end_calls++; }
+void fake_orchestration_done(RuntimeContext *) {}
+bool fake_is_fatal(RuntimeContext *rt) { return as_fake(rt)->fatal; }
 
-void fake_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...) {
+void fake_report_fatal(RuntimeContext *rt, int32_t error_code, const char *func, const char *fmt, ...) {
     FakeRuntime *fake = as_fake(rt);
     fake->report_fatal_calls++;
     fake->fatal = true;
@@ -83,23 +83,23 @@ void fake_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, co
 
 void fake_log(const char *, const char *, ...) {}
 
-uint64_t fake_get_tensor_data(PTO2Runtime *rt, const ChipTensor &, uint32_t, const uint32_t[]) {
+uint64_t fake_get_tensor_data(RuntimeContext *rt, const ChipTensor &, uint32_t, const uint32_t[]) {
     as_fake(rt)->get_calls++;
     return 0x1234ULL;
 }
 
-void fake_set_tensor_data(PTO2Runtime *rt, const ChipTensor &, uint32_t, const uint32_t[], uint64_t) {
+void fake_set_tensor_data(RuntimeContext *rt, const ChipTensor &, uint32_t, const uint32_t[], uint64_t) {
     as_fake(rt)->set_calls++;
 }
 
-TaskOutputTensors fake_alloc_tensors(PTO2Runtime *rt, const CoreTaskArgs &) {
+TaskOutputTensors fake_alloc_tensors(RuntimeContext *rt, const CoreTaskArgs &) {
     as_fake(rt)->alloc_calls++;
     return TaskOutputTensors{};
 }
 
-TaskOutputTensors fake_submit_dummy(PTO2Runtime *, const CoreTaskArgs &) { return TaskOutputTensors{}; }
+TaskOutputTensors fake_submit_dummy(RuntimeContext *, const CoreTaskArgs &) { return TaskOutputTensors{}; }
 
-const PTO2RuntimeOps kFakeOps = {
+const RuntimeOps kFakeOps = {
     .submit_task = fake_submit,
     .scope_begin = fake_scope_begin,
     .scope_end = fake_scope_end,
@@ -120,7 +120,7 @@ const PTO2RuntimeOps kFakeOps = {
 
 class RuntimeBindingGuard {
 public:
-    explicit RuntimeBindingGuard(PTO2Runtime *rt) { framework_bind_runtime(rt); }
+    explicit RuntimeBindingGuard(RuntimeContext *rt) { framework_bind_runtime(rt); }
     ~RuntimeBindingGuard() { framework_bind_runtime(nullptr); }
 };
 
@@ -135,7 +135,7 @@ TEST(A5Fatal, ApiShortCircuitsAfterFatal) {
     FakeRuntime runtime{};
     runtime.ops = &kFakeOps;
     runtime.fatal = true;
-    RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+    RuntimeBindingGuard bind(reinterpret_cast<RuntimeContext *>(&runtime));
 
     MixedKernels mixed{};
     CoreTaskArgs args;
@@ -166,7 +166,7 @@ TEST(A5Fatal, ApiShortCircuitsAfterFatal) {
 TEST(A5Fatal, ExplicitFatalRoutesThroughOps) {
     FakeRuntime runtime{};
     runtime.ops = &kFakeOps;
-    RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+    RuntimeBindingGuard bind(reinterpret_cast<RuntimeContext *>(&runtime));
 
     rt_report_fatal(SIMPLER_ERROR_EXPLICIT_ORCH_FATAL, "boom %d", 7);
 
@@ -185,7 +185,7 @@ TEST(A5Fatal, ExplicitFatalRoutesThroughOps) {
 TEST(A5Fatal, ScopeGuardForwardsModeUntilLexicalScopeExit) {
     FakeRuntime runtime{};
     runtime.ops = &kFakeOps;
-    RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+    RuntimeBindingGuard bind(reinterpret_cast<RuntimeContext *>(&runtime));
 
     runtime.pending_scope_mode = PTO2ScopeMode::MANUAL;
 
@@ -211,7 +211,7 @@ TEST(A5Fatal, ScopeGuardForwardsModeUntilLexicalScopeExit) {
 TEST(A5Fatal, AllocTensorConvenienceReportsInvalidArgsInsteadOfAsserting) {
     FakeRuntime runtime{};
     runtime.ops = &kFakeOps;
-    RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
+    RuntimeBindingGuard bind(reinterpret_cast<RuntimeContext *>(&runtime));
 
     std::array<TensorCreateInfo, MAX_TENSOR_ARGS + 1> create_infos{};
     for (TensorCreateInfo &ci : create_infos) {

--- a/tests/ut/cpp/a5/test_aicore_completion_mailbox.cpp
+++ b/tests/ut/cpp/a5/test_aicore_completion_mailbox.cpp
@@ -78,7 +78,7 @@ TEST(A5AICoreCompletionMailbox, PushNormalDoneCreatesEntryReadyToComplete) {
     AsyncWaitList wait_list{};
 
     TaskId token = make_token(99);
-    PTO2TaskSlotState dummy_slot{};
+    ChipTaskSlotState dummy_slot{};
     uint64_t slot_addr = reinterpret_cast<uint64_t>(&dummy_slot);
     ASSERT_TRUE(mb->try_push_normal_done(token, slot_addr));
 
@@ -109,7 +109,7 @@ TEST(A5AICoreCompletionMailbox, NormalDoneAttachesToExistingEntry) {
     wait_list.entries[0].normal_done = false;
     wait_list.count = 1;
 
-    PTO2TaskSlotState dummy_slot{};
+    ChipTaskSlotState dummy_slot{};
     uint64_t slot_addr = reinterpret_cast<uint64_t>(&dummy_slot);
     ASSERT_TRUE(mb->try_push_normal_done(token, slot_addr));
 

--- a/tests/ut/cpp/a5/test_dep_list_pool.cpp
+++ b/tests/ut/cpp/a5/test_dep_list_pool.cpp
@@ -95,7 +95,7 @@ TEST_F(DepListPoolTest, EnsureSpaceDeadlockReturnsFalseAndLatchesError) {
 
 // Prepend builds LIFO linked list: verify each slot_state pointer.
 TEST_F(DepListPoolTest, PrependChainCorrectness) {
-    PTO2TaskSlotState slots[5]{};
+    ChipTaskSlotState slots[5]{};
     PTO2DepListEntry *head = nullptr;
 
     for (int i = 0; i < 5; i++) {
@@ -157,7 +157,7 @@ TEST_F(DepListPoolTest, HighWaterAccuracy) {
 
 // Prepend chain integrity under pool exhaustion: chain must be walkable.
 TEST_F(DepListPoolTest, PrependUnderExhaustion) {
-    PTO2TaskSlotState slots[POOL_CAP]{};
+    ChipTaskSlotState slots[POOL_CAP]{};
     PTO2DepListEntry *head = nullptr;
 
     int count = 0;

--- a/tests/ut/cpp/a5/test_fanin_pool.cpp
+++ b/tests/ut/cpp/a5/test_fanin_pool.cpp
@@ -162,7 +162,7 @@ protected:
     std::atomic<int32_t> error_code{SIMPLER_ERROR_NONE};
     PTO2FaninPool spill_pool{};
 
-    alignas(64) PTO2TaskSlotState slots[64];
+    alignas(64) ChipTaskSlotState slots[64];
 
     void SetUp() override {
         spill_entries.assign(POOL_CAP, PTO2FaninSpillEntry{});
@@ -178,8 +178,8 @@ TEST_F(ForEachFaninTest, InlineOnlyVoid) {
         inline_slots[i].set(&slots[i], DEP_WAIT);
     }
 
-    std::vector<PTO2TaskSlotState *> visited;
-    for_each_fanin_storage(inline_slots, 5, 0, spill_pool, [&](PTO2TaskSlotState *s, DepFlags) {
+    std::vector<ChipTaskSlotState *> visited;
+    for_each_fanin_storage(inline_slots, 5, 0, spill_pool, [&](ChipTaskSlotState *s, DepFlags) {
         visited.push_back(s);
     });
 
@@ -196,7 +196,7 @@ TEST_F(ForEachFaninTest, InlineOnlyBoolEarlyReturn) {
     }
 
     int count = 0;
-    bool result = for_each_fanin_storage(inline_slots, 5, 0, spill_pool, [&](PTO2TaskSlotState *, DepFlags) -> bool {
+    bool result = for_each_fanin_storage(inline_slots, 5, 0, spill_pool, [&](ChipTaskSlotState *, DepFlags) -> bool {
         count++;
         return count < 3;  // stop after 3rd
     });
@@ -211,7 +211,7 @@ TEST_F(ForEachFaninTest, InlineOnlyBoolAllTrue) {
         inline_slots[i].set(&slots[i], DEP_WAIT);
     }
 
-    bool result = for_each_fanin_storage(inline_slots, 3, 0, spill_pool, [](PTO2TaskSlotState *, DepFlags) -> bool {
+    bool result = for_each_fanin_storage(inline_slots, 3, 0, spill_pool, [](ChipTaskSlotState *, DepFlags) -> bool {
         return true;
     });
 
@@ -221,7 +221,7 @@ TEST_F(ForEachFaninTest, InlineOnlyBoolAllTrue) {
 TEST_F(ForEachFaninTest, ZeroFanin) {
     PTO2FaninSpillEntry inline_slots[PTO2_FANIN_INLINE_CAP] = {};
     int count = 0;
-    for_each_fanin_storage(inline_slots, 0, 0, spill_pool, [&](PTO2TaskSlotState *, DepFlags) {
+    for_each_fanin_storage(inline_slots, 0, 0, spill_pool, [&](ChipTaskSlotState *, DepFlags) {
         count++;
     });
     EXPECT_EQ(count, 0);
@@ -245,8 +245,8 @@ TEST_F(ForEachFaninTest, SpillNoWrap) {
     auto *s1 = spill_pool.alloc();
     s1->set(&slots[17], DEP_WAIT | DEP_RETAIN);
 
-    std::vector<PTO2TaskSlotState *> visited;
-    for_each_fanin_storage(inline_slots, 18, spill_start, spill_pool, [&](PTO2TaskSlotState *s, DepFlags) {
+    std::vector<ChipTaskSlotState *> visited;
+    for_each_fanin_storage(inline_slots, 18, spill_start, spill_pool, [&](ChipTaskSlotState *s, DepFlags) {
         visited.push_back(s);
     });
 
@@ -281,8 +281,8 @@ TEST_F(ForEachFaninTest, SpillWithWrap) {
         e->set(&slots[16 + i], DEP_WAIT | DEP_RETAIN);
     }
 
-    std::vector<PTO2TaskSlotState *> visited;
-    for_each_fanin_storage(inline_slots, 20, spill_start, spill_pool, [&](PTO2TaskSlotState *s, DepFlags) {
+    std::vector<ChipTaskSlotState *> visited;
+    for_each_fanin_storage(inline_slots, 20, spill_start, spill_pool, [&](ChipTaskSlotState *s, DepFlags) {
         visited.push_back(s);
     });
 
@@ -315,7 +315,7 @@ TEST_F(ForEachFaninTest, SpillBoolEarlyReturnInSpillRegion) {
 
     int count = 0;
     bool result =
-        for_each_fanin_storage(inline_slots, 20, spill_start, spill_pool, [&](PTO2TaskSlotState *, DepFlags) -> bool {
+        for_each_fanin_storage(inline_slots, 20, spill_start, spill_pool, [&](ChipTaskSlotState *, DepFlags) -> bool {
             count++;
             return count < 17;  // stop on 17th (first spill entry)
         });
@@ -347,7 +347,7 @@ TEST_F(ForEachFaninTest, DepFlagsRoundTripInlineAndSpill) {
 
     const int32_t total = PTO2_FANIN_INLINE_CAP + 2;  // 64 inline + 2 spill
     std::vector<DepFlags> flags;
-    for_each_fanin_storage(inline_slots, total, spill_start, spill_pool, [&](PTO2TaskSlotState *, DepFlags f) {
+    for_each_fanin_storage(inline_slots, total, spill_start, spill_pool, [&](ChipTaskSlotState *, DepFlags f) {
         flags.push_back(f);
     });
 

--- a/tests/ut/cpp/a5/test_graph_activation.cpp
+++ b/tests/ut/cpp/a5/test_graph_activation.cpp
@@ -88,7 +88,7 @@ TEST_F(GraphActivationTest, WakeRoutesConsumerWhenProducerCompletedBeforeRegiste
 
     sched.register_graph_wake(exec, &nodes[0].slot, &nodes[1].slot);
 
-    PTO2TaskSlotState *out[2];
+    ChipTaskSlotState *out[2];
     ASSERT_EQ(sched.get_ready_tasks_batch(sched.ready_queues, PTO2ResourceShape::AIC, out, 2), 1)
         << "consumer must route to ready, not hang on the SENTINEL wake list";
     EXPECT_EQ(out[0], &nodes[1].slot);
@@ -114,7 +114,7 @@ TEST_F(GraphActivationTest, IncrementalPublishRoutesCompletedDepsAndWakeChainsPe
     sched.graph_incremental_publish(exec, 0, 4);
     EXPECT_EQ(exec.published_nodes.load(), 4);
 
-    PTO2TaskSlotState *out[4];
+    ChipTaskSlotState *out[4];
     ASSERT_EQ(sched.get_ready_tasks_batch(sched.ready_queues, PTO2ResourceShape::AIC, out, 4), 1)
         << "only the consumer whose producers are all COMPLETED routes at publish time";
     EXPECT_EQ(out[0], &nodes[2].slot);

--- a/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
@@ -82,7 +82,7 @@ protected:
         const size_t n = static_cast<size_t>(ring.task_window_mask) + 1;
         std::memset(ring.task_descriptors, POISON, n * sizeof(PTO2TaskDescriptor));
         std::memset(ring.task_payloads, POISON, n * sizeof(PTO2TaskPayload));
-        std::memset(ring.slot_states, POISON, n * sizeof(PTO2TaskSlotState));
+        std::memset(ring.slot_states, POISON, n * sizeof(ChipTaskSlotState));
         std::memset(ring.completion_flags, POISON, n * sizeof(std::atomic<uint8_t>));
     }
 };
@@ -137,7 +137,7 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
         const int32_t slot = ring.get_slot_by_task_id(local);
         const PTO2TaskDescriptor &desc = ring.task_descriptors[slot];
         const PTO2TaskPayload &pl = ring.task_payloads[slot];
-        const PTO2TaskSlotState &st = ring.slot_states[slot];
+        const ChipTaskSlotState &st = ring.slot_states[slot];
 
         // Descriptor: the task id is written to this exact local id.
         EXPECT_EQ(desc.task_id.local(), static_cast<uint32_t>(local));

--- a/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
+++ b/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
@@ -33,10 +33,10 @@ protected:
     void SetUp() override {
         sm_handle = PTO2SharedMemoryHandle::create_and_init_default(sm_arena);
         ASSERT_NE(sm_handle, nullptr);
-        gm_heap.resize(4096 * PTO2_MAX_RING_DEPTH);
+        gm_heap.resize(4096 * CHIP_MAX_RING_DEPTH);
 
-        int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        int32_t task_window_sizes[CHIP_MAX_RING_DEPTH];
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             task_window_sizes[r] = static_cast<int32_t>(PTO2_TASK_WINDOW_SIZE);
         }
 
@@ -65,7 +65,7 @@ protected:
     // as exact from its first check and classifies the head without waiting for
     // an acknowledgment.
     void unwire_reclaim_publication() {
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             orch.rings[r].task_allocator.set_reclaim_publication_request(nullptr, nullptr);
             orch.rings[r].fanin_pool.set_reclaim_publication_request(nullptr, nullptr, static_cast<uint8_t>(r));
         }
@@ -290,10 +290,10 @@ TEST_F(OrchestratorFaninTest, StructuralCheckRejectsOpenAncestorWhenNestedScopes
     std::vector<TensorCreateInfo> create_infos;
     create_infos.reserve(2);
 
-    for (int32_t depth = 0; depth < PTO2_MAX_RING_DEPTH; ++depth) {
+    for (int32_t depth = 0; depth < CHIP_MAX_RING_DEPTH; ++depth) {
         orch.begin_scope();
     }
-    ASSERT_EQ(orch.current_ring_id(), PTO2_MAX_RING_DEPTH - 1);
+    ASSERT_EQ(orch.current_ring_id(), CHIP_MAX_RING_DEPTH - 1);
 
     CoreTaskArgs parent_args;
     add_runtime_output_arg(parent_args, create_infos, 1024);
@@ -301,7 +301,7 @@ TEST_F(OrchestratorFaninTest, StructuralCheckRejectsOpenAncestorWhenNestedScopes
     ASSERT_TRUE(parent.task_id().is_valid());
 
     orch.begin_scope();
-    ASSERT_EQ(orch.current_ring_id(), PTO2_MAX_RING_DEPTH - 1);
+    ASSERT_EQ(orch.current_ring_id(), CHIP_MAX_RING_DEPTH - 1);
 
     CoreTaskArgs child_args;
     add_runtime_output_arg(child_args, create_infos, 1);
@@ -320,11 +320,11 @@ TEST_F(OrchestratorFaninTest, ClosedChildHeadUsesTimeoutWithOpenParentOnSharedRi
     std::vector<TensorCreateInfo> create_infos;
     create_infos.reserve(3);
 
-    for (int32_t depth = 0; depth < PTO2_MAX_RING_DEPTH; ++depth) {
+    for (int32_t depth = 0; depth < CHIP_MAX_RING_DEPTH; ++depth) {
         orch.begin_scope();
     }
     orch.begin_scope();
-    ASSERT_EQ(orch.current_ring_id(), PTO2_MAX_RING_DEPTH - 1);
+    ASSERT_EQ(orch.current_ring_id(), CHIP_MAX_RING_DEPTH - 1);
 
     CoreTaskArgs child_args;
     add_runtime_output_arg(child_args, create_infos, 768);
@@ -332,7 +332,7 @@ TEST_F(OrchestratorFaninTest, ClosedChildHeadUsesTimeoutWithOpenParentOnSharedRi
     ASSERT_TRUE(child.task_id().is_valid());
 
     orch.end_scope();
-    ASSERT_EQ(orch.current_ring_id(), PTO2_MAX_RING_DEPTH - 1);
+    ASSERT_EQ(orch.current_ring_id(), CHIP_MAX_RING_DEPTH - 1);
 
     CoreTaskArgs parent_args;
     add_runtime_output_arg(parent_args, create_infos, 256);
@@ -356,31 +356,31 @@ TEST_F(OrchestratorFaninTest, ClosedChildHeadUsesTimeoutWithOpenParentOnSharedRi
 // (sum of the runtime per-ring windows), not the compile-time PTO2_SCOPE_TASKS_CAP.
 // reserve_layout only computes offsets, so no commit()/backing is needed here.
 TEST(OrchestratorLayoutScopeTasksCap, FollowsRuntimeWindowSum) {
-    auto cap_for = [](const int32_t windows[PTO2_MAX_RING_DEPTH]) {
+    auto cap_for = [](const int32_t windows[CHIP_MAX_RING_DEPTH]) {
         DeviceArena arena;
         int32_t cap = PTO2OrchestratorState::reserve_layout(arena, windows).scope_tasks_cap;
         arena.release();
         return cap;
     };
 
-    int32_t windows[PTO2_MAX_RING_DEPTH];
+    int32_t windows[CHIP_MAX_RING_DEPTH];
 
     // Default window: cap == the old compile-time value (no behavior change).
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++)
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++)
         windows[r] = PTO2_TASK_WINDOW_SIZE;
-    EXPECT_EQ(cap_for(windows), PTO2_TASK_WINDOW_SIZE * PTO2_MAX_RING_DEPTH);
+    EXPECT_EQ(cap_for(windows), PTO2_TASK_WINDOW_SIZE * CHIP_MAX_RING_DEPTH);
     EXPECT_EQ(cap_for(windows), PTO2_SCOPE_TASKS_CAP);
 
     // Shrunk window: cap shrinks to the real budget (no over-allocation).
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++)
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++)
         windows[r] = 4;
-    EXPECT_EQ(cap_for(windows), 4 * PTO2_MAX_RING_DEPTH);
+    EXPECT_EQ(cap_for(windows), 4 * CHIP_MAX_RING_DEPTH);
 
     // Enlarged window past the compile default: cap grows to match the rings, so a
     // large scope no longer hits a premature SCOPE_TASKS_OVERFLOW (the bug fixed).
     const int32_t big = PTO2_TASK_WINDOW_SIZE * 2;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++)
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++)
         windows[r] = big;
-    EXPECT_EQ(cap_for(windows), big * PTO2_MAX_RING_DEPTH);
+    EXPECT_EQ(cap_for(windows), big * CHIP_MAX_RING_DEPTH);
     EXPECT_GT(cap_for(windows), PTO2_SCOPE_TASKS_CAP);
 }

--- a/tests/ut/cpp/a5/test_ready_queue.cpp
+++ b/tests/ut/cpp/a5/test_ready_queue.cpp
@@ -73,15 +73,15 @@ protected:
 TEST_F(ReadyQueueTest, EmptyPopReturnsNullptr) { EXPECT_EQ(queue.pop(), nullptr); }
 
 TEST_F(ReadyQueueTest, SinglePushPop) {
-    PTO2TaskSlotState item;
+    ChipTaskSlotState item;
     ASSERT_TRUE(queue.push(&item));
 
-    PTO2TaskSlotState *result = queue.pop();
+    ChipTaskSlotState *result = queue.pop();
     EXPECT_EQ(result, &item);
 }
 
 TEST_F(ReadyQueueTest, FIFOOrdering) {
-    PTO2TaskSlotState a, b, c;
+    ChipTaskSlotState a, b, c;
 
     ASSERT_TRUE(queue.push(&a));
     ASSERT_TRUE(queue.push(&b));
@@ -94,18 +94,18 @@ TEST_F(ReadyQueueTest, FIFOOrdering) {
 }
 
 TEST_F(ReadyQueueTest, QueueFullReturnsFalse) {
-    std::vector<PTO2TaskSlotState> items(CAPACITY);
+    std::vector<ChipTaskSlotState> items(CAPACITY);
 
     for (uint64_t i = 0; i < CAPACITY; i++) {
         ASSERT_TRUE(queue.push(&items[i]));
     }
 
-    PTO2TaskSlotState extra;
+    ChipTaskSlotState extra;
     EXPECT_FALSE(queue.push(&extra));
 }
 
 TEST_F(ReadyQueueTest, SlotReuseAfterFullDrain) {
-    std::vector<PTO2TaskSlotState> items(CAPACITY);
+    std::vector<ChipTaskSlotState> items(CAPACITY);
 
     for (uint64_t i = 0; i < CAPACITY; i++) {
         ASSERT_TRUE(queue.push(&items[i]));
@@ -126,8 +126,8 @@ TEST_F(ReadyQueueTest, SlotReuseAfterFullDrain) {
 
 TEST_F(ReadyQueueTest, PushBatchThenIndividualPop) {
     constexpr int BATCH_SIZE = 5;
-    PTO2TaskSlotState items[BATCH_SIZE];
-    PTO2TaskSlotState *ptrs[BATCH_SIZE];
+    ChipTaskSlotState items[BATCH_SIZE];
+    ChipTaskSlotState *ptrs[BATCH_SIZE];
     for (int i = 0; i < BATCH_SIZE; i++) {
         ptrs[i] = &items[i];
     }
@@ -149,13 +149,13 @@ TEST_F(ReadyQueueTest, PushBatchZeroIsNoop) {
 
 TEST_F(ReadyQueueTest, PopBatchReturnsFive) {
     constexpr int PUSH_COUNT = 10;
-    PTO2TaskSlotState items[PUSH_COUNT];
+    ChipTaskSlotState items[PUSH_COUNT];
 
     for (int i = 0; i < PUSH_COUNT; i++) {
         ASSERT_TRUE(queue.push(&items[i]));
     }
 
-    PTO2TaskSlotState *out[5];
+    ChipTaskSlotState *out[5];
     int popped = queue.pop_batch(out, 5);
     EXPECT_EQ(popped, 5);
 
@@ -166,13 +166,13 @@ TEST_F(ReadyQueueTest, PopBatchReturnsFive) {
 
 TEST_F(ReadyQueueTest, PopBatchPartial) {
     constexpr int PUSH_COUNT = 3;
-    PTO2TaskSlotState items[PUSH_COUNT];
+    ChipTaskSlotState items[PUSH_COUNT];
 
     for (int i = 0; i < PUSH_COUNT; i++) {
         ASSERT_TRUE(queue.push(&items[i]));
     }
 
-    PTO2TaskSlotState *out[5];
+    ChipTaskSlotState *out[5];
     int popped = queue.pop_batch(out, 5);
     EXPECT_EQ(popped, PUSH_COUNT);
 
@@ -182,7 +182,7 @@ TEST_F(ReadyQueueTest, PopBatchPartial) {
 }
 
 TEST_F(ReadyQueueTest, PopBatchEmpty) {
-    PTO2TaskSlotState *out[5];
+    ChipTaskSlotState *out[5];
     int popped = queue.pop_batch(out, 5);
     EXPECT_EQ(popped, 0);
 }
@@ -190,7 +190,7 @@ TEST_F(ReadyQueueTest, PopBatchEmpty) {
 TEST_F(ReadyQueueTest, SizeAccuracy) {
     EXPECT_EQ(queue.size(), 0u);
 
-    PTO2TaskSlotState items[8];
+    ChipTaskSlotState items[8];
 
     queue.push(&items[0]);
     EXPECT_EQ(queue.size(), 1u);
@@ -220,7 +220,7 @@ class ReadyQueueBoundaryTest : public ::testing::Test {
 protected:
     static constexpr uint64_t QUEUE_CAP = 8;  // Small for boundary testing
     PTO2ReadyQueue queue{};
-    PTO2TaskSlotState dummy[8]{};
+    ChipTaskSlotState dummy[8]{};
 
     DeviceArena arena;
 
@@ -296,7 +296,7 @@ TEST_F(ReadyQueueBoundaryTest, RepeatedEmptyPop) {
 TEST_F(ReadyQueueBoundaryTest, ManyPushPopCycles) {
     for (int i = 0; i < 10000; i++) {
         ASSERT_TRUE(queue.push(&dummy[0]));
-        PTO2TaskSlotState *s = queue.pop();
+        ChipTaskSlotState *s = queue.pop();
         ASSERT_NE(s, nullptr);
         EXPECT_EQ(s, &dummy[0]);
     }
@@ -340,13 +340,13 @@ TEST_P(ReadyQueueMPMCTest, NoDuplicateNoLoss) {
     auto cfg = GetParam();
     int total = cfg.producers * cfg.items_per_producer;
 
-    std::vector<PTO2TaskSlotState> items(total);
+    std::vector<ChipTaskSlotState> items(total);
     std::vector<std::atomic<int>> consumed_count(total);
     for (int i = 0; i < total; i++) {
         consumed_count[i].store(0, std::memory_order_relaxed);
     }
 
-    auto item_index = [&](PTO2TaskSlotState *s) -> int {
+    auto item_index = [&](ChipTaskSlotState *s) -> int {
         return static_cast<int>(s - items.data());
     };
 
@@ -363,7 +363,7 @@ TEST_P(ReadyQueueMPMCTest, NoDuplicateNoLoss) {
 
     auto consumer = [&]() {
         while (true) {
-            PTO2TaskSlotState *item = queue.pop();
+            ChipTaskSlotState *item = queue.pop();
             if (item != nullptr) {
                 consumed_count[item_index(item)].fetch_add(1, std::memory_order_relaxed);
                 total_consumed.fetch_add(1, std::memory_order_relaxed);

--- a/tests/ut/cpp/a5/test_scheduler_state.cpp
+++ b/tests/ut/cpp/a5/test_scheduler_state.cpp
@@ -81,7 +81,7 @@ protected:
     }
 
     void init_slot(
-        PTO2TaskSlotState &slot, PTO2TaskState state, int32_t fanin_count, int32_t fanout_count, uint8_t ring_id = 0
+        ChipTaskSlotState &slot, PTO2TaskState state, int32_t fanin_count, int32_t fanout_count, uint8_t ring_id = 0
     ) {
         memset(&slot, 0, sizeof(slot));
         slot.task_state.store(state);
@@ -105,7 +105,7 @@ protected:
         PTO2SharedMemoryRingHeader &ring, int32_t task_id, PTO2TaskState state, uint8_t ring_id,
         uint32_t fanout_count = 1, uint32_t fanout_refcount = 1
     ) {
-        PTO2TaskSlotState &slot = ring.get_slot_state_by_task_id(task_id);
+        ChipTaskSlotState &slot = ring.get_slot_state_by_task_id(task_id);
         PTO2TaskPayload &payload = ring.get_payload_by_task_id(task_id);
         PTO2TaskDescriptor &task = ring.get_task_by_task_id(task_id);
         memset(&slot, 0, sizeof(slot));
@@ -178,7 +178,7 @@ TEST_F(SchedulerStateTest, UnvalidatedWiringPublishesEveryAdvance) {
 }
 
 TEST_F(SchedulerStateTest, ConsumedNotReady) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_COMPLETED, 1, 2);
     slot.fanout_refcount.store(1);  // 1 != 2
 
@@ -187,7 +187,7 @@ TEST_F(SchedulerStateTest, ConsumedNotReady) {
 }
 
 TEST_F(SchedulerStateTest, ConsumedTransition) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_COMPLETED, 1, 2);
     slot.fanout_refcount.store(2);  // matches fanout_count
 
@@ -202,7 +202,7 @@ TEST_F(SchedulerStateTest, ConsumedHeadAdvancesAfterContendedAdvanceLock) {
 
     PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
     PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
-    PTO2TaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
+    ChipTaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
     uint32_t pending_bit = PTO2SchedulerState::ring_advance_pending_bit(ring_id);
 
     ring_sched.advance_lock.store(1, std::memory_order_release);
@@ -223,7 +223,7 @@ TEST_F(SchedulerStateTest, ConsumedHeadAdvancesAfterContendedAdvanceLock) {
 }
 
 TEST_F(SchedulerStateTest, ConsumedNotCompletedState) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.fanout_refcount.store(1);
 
@@ -233,7 +233,7 @@ TEST_F(SchedulerStateTest, ConsumedNotCompletedState) {
 }
 
 TEST_F(SchedulerStateTest, ConsumedIdempotent) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_CONSUMED, 1, 1);
     slot.fanout_refcount.store(1);
 
@@ -248,7 +248,7 @@ TEST_F(SchedulerStateTest, ContendedConsumedHeadSetsPendingAndIdleDrainAdvances)
 
     PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
     PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
-    PTO2TaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
+    ChipTaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
     uint32_t pending_bit = PTO2SchedulerState::ring_advance_pending_bit(ring_id);
 
     ring_sched.advance_lock.store(1, std::memory_order_release);
@@ -276,7 +276,7 @@ TEST_F(SchedulerStateTest, DeferredAdvanceDoesNotAcknowledgePublication) {
 
     PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
     PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
-    PTO2TaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
+    ChipTaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
     uint32_t pending_bit = PTO2SchedulerState::ring_advance_pending_bit(ring_id);
 
     sched.publication_ack_mask.store(0, std::memory_order_release);
@@ -316,7 +316,7 @@ TEST_F(SchedulerStateTest, ContendedConsumedHeadIdleDrainStress) {
 
             PTO2SharedMemoryRingHeader &ring = sm_handle->header->rings[ring_id];
             PTO2SchedulerState::RingSchedState &ring_sched = sched.ring_sched_states[ring_id];
-            PTO2TaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
+            ChipTaskSlotState &head = ring.get_slot_state_by_task_id(head_task_id);
 
             ring_sched.advance_lock.store(1, std::memory_order_release);
             sched.check_and_handle_consumed(head);
@@ -334,7 +334,7 @@ TEST_F(SchedulerStateTest, ContendedConsumedHeadIdleDrainStress) {
 // =============================================================================
 
 TEST_F(SchedulerStateTest, ReleaseProducerIncrements) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_COMPLETED, 1, 3);
 
     sched.release_producer(slot);
@@ -345,7 +345,7 @@ TEST_F(SchedulerStateTest, ReleaseProducerIncrements) {
 }
 
 TEST_F(SchedulerStateTest, ReleaseProducerTriggersConsumed) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_COMPLETED, 1, 2);
     slot.fanout_refcount.store(1);  // One away
 
@@ -358,7 +358,7 @@ TEST_F(SchedulerStateTest, ReleaseProducerTriggersConsumed) {
 // =============================================================================
 
 TEST_F(SchedulerStateTest, SubtaskCompleteSingle) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.total_required_subtasks = 1;
     slot.completed_subtasks.store(0);
@@ -367,7 +367,7 @@ TEST_F(SchedulerStateTest, SubtaskCompleteSingle) {
 }
 
 TEST_F(SchedulerStateTest, SubtaskCompleteMultiBlock) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.total_required_subtasks = 6;  // 3 cores * 2 blocks
     slot.completed_subtasks.store(0);
@@ -384,8 +384,8 @@ TEST_F(SchedulerStateTest, SubtaskCompleteMultiBlock) {
 
 TEST_F(SchedulerStateTest, ScopeEndBatchRelease) {
     constexpr int N = 4;
-    alignas(64) PTO2TaskSlotState slots[N];
-    PTO2TaskSlotState *ptrs[N];
+    alignas(64) ChipTaskSlotState slots[N];
+    ChipTaskSlotState *ptrs[N];
 
     for (int i = 0; i < N; i++) {
         init_slot(slots[i], PTO2_TASK_COMPLETED, 1, 2);
@@ -406,7 +406,7 @@ TEST_F(SchedulerStateTest, ScopeEndBatchRelease) {
 // =============================================================================
 
 TEST_F(SchedulerStateTest, GetReadyTasksBatchDrainsSharedQueue) {
-    alignas(64) PTO2TaskSlotState slot_a, slot_b;
+    alignas(64) ChipTaskSlotState slot_a, slot_b;
     // fanin_count = 1 so a single release_fanin_and_check_ready call drives each
     // slot to ready (new_refcount 0->1 == fanin_count) and enqueues it.
     init_slot(slot_a, PTO2_TASK_PENDING, 1, 1);
@@ -416,7 +416,7 @@ TEST_F(SchedulerStateTest, GetReadyTasksBatchDrainsSharedQueue) {
     ASSERT_TRUE(sched.release_fanin_and_check_ready(slot_a));
     ASSERT_TRUE(sched.release_fanin_and_check_ready(slot_b));
 
-    PTO2TaskSlotState *out[4];
+    ChipTaskSlotState *out[4];
     int count = sched.get_ready_tasks_batch(sched.ready_queues, PTO2ResourceShape::AIC, out, 4);
 
     EXPECT_EQ(count, 2);
@@ -426,13 +426,13 @@ TEST_F(SchedulerStateTest, GetReadyTasksBatchDrainsSharedQueue) {
 }
 
 TEST_F(SchedulerStateTest, SyncStartRoutesToDedicatedReadyQueue) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.task_attrs.set_sync_start();
 
     ASSERT_TRUE(sched.release_fanin_and_check_ready(slot));
 
-    PTO2TaskSlotState *out[1];
+    ChipTaskSlotState *out[1];
     EXPECT_EQ(sched.get_ready_tasks_batch(sched.ready_queues, PTO2ResourceShape::AIC, out, 1), 0);
     ASSERT_EQ(sched.get_ready_tasks_batch(sched.ready_sync_queues, PTO2ResourceShape::AIC, out, 1), 1);
     EXPECT_EQ(out[0], &slot);

--- a/tests/ut/cpp/a5/test_scheduler_state.cpp
+++ b/tests/ut/cpp/a5/test_scheduler_state.cpp
@@ -196,7 +196,7 @@ TEST_F(SchedulerStateTest, ConsumedTransition) {
 }
 
 TEST_F(SchedulerStateTest, ConsumedHeadAdvancesAfterContendedAdvanceLock) {
-    constexpr int32_t ring_id = PTO2_MAX_RING_DEPTH - 1;
+    constexpr int32_t ring_id = CHIP_MAX_RING_DEPTH - 1;
     constexpr int32_t head_task_id = 0;
     setup_ring_for_reclaim_race(ring_id, /*current_task_index=*/1, head_task_id);
 
@@ -242,7 +242,7 @@ TEST_F(SchedulerStateTest, ConsumedIdempotent) {
 }
 
 TEST_F(SchedulerStateTest, ContendedConsumedHeadSetsPendingAndIdleDrainAdvances) {
-    constexpr int32_t ring_id = PTO2_MAX_RING_DEPTH - 1;
+    constexpr int32_t ring_id = CHIP_MAX_RING_DEPTH - 1;
     constexpr int32_t head_task_id = 17;
     setup_contended_head_case(ring_id, head_task_id);
 
@@ -270,7 +270,7 @@ TEST_F(SchedulerStateTest, ContendedConsumedHeadSetsPendingAndIdleDrainAdvances)
 }
 
 TEST_F(SchedulerStateTest, DeferredAdvanceDoesNotAcknowledgePublication) {
-    constexpr int32_t ring_id = PTO2_MAX_RING_DEPTH - 1;
+    constexpr int32_t ring_id = CHIP_MAX_RING_DEPTH - 1;
     constexpr int32_t head_task_id = 17;
     setup_contended_head_case(ring_id, head_task_id);
 
@@ -290,7 +290,7 @@ TEST_F(SchedulerStateTest, DeferredAdvanceDoesNotAcknowledgePublication) {
 }
 
 TEST_F(SchedulerStateTest, PublicationRequestDoesNotConsumeDeferredAdvance) {
-    constexpr int32_t ring_id = PTO2_MAX_RING_DEPTH - 1;
+    constexpr int32_t ring_id = CHIP_MAX_RING_DEPTH - 1;
     setup_ring_for_reclaim_race(ring_id, /*current_task_index=*/1, /*blocked_task_id=*/1);
 
     uint32_t pending_bit = PTO2SchedulerState::ring_advance_pending_bit(ring_id);
@@ -309,7 +309,7 @@ TEST_F(SchedulerStateTest, PublicationRequestDoesNotConsumeDeferredAdvance) {
 TEST_F(SchedulerStateTest, ContendedConsumedHeadIdleDrainStress) {
     const int32_t head_task_ids[] = {0, 1, 127, PTO2_TASK_WINDOW_SIZE - 2, PTO2_TASK_WINDOW_SIZE + 3};
 
-    for (int32_t ring_id = 0; ring_id < PTO2_MAX_RING_DEPTH; ring_id++) {
+    for (int32_t ring_id = 0; ring_id < CHIP_MAX_RING_DEPTH; ring_id++) {
         for (int32_t head_task_id : head_task_ids) {
             SCOPED_TRACE(::testing::Message() << "ring_id=" << ring_id << " head_task_id=" << head_task_id);
             setup_contended_head_case(ring_id, head_task_id);

--- a/tests/ut/cpp/a5/test_shared_memory.cpp
+++ b/tests/ut/cpp/a5/test_shared_memory.cpp
@@ -99,7 +99,7 @@ TEST_F(SharedMemoryTest, HeaderInitValues) {
     EXPECT_EQ(hdr->sched_stall_task_id.load(), -1);
     EXPECT_EQ(hdr->sched_stall_core.load(), -1);
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         auto &fc = hdr->rings[r].fc;
         EXPECT_EQ(fc.current_task_index.load(), 0);
         EXPECT_EQ(fc.last_task_alive.load(), 0);
@@ -141,17 +141,17 @@ TEST(StallClassificationTest, NamesAreStableAndDistinct) {
 TEST_F(SharedMemoryTest, Validate) { EXPECT_TRUE(handle->validate()); }
 
 TEST_F(SharedMemoryTest, PerRingIndependence) {
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         EXPECT_NE(handle->header->rings[r].task_descriptors, nullptr) << "Ring " << r;
         EXPECT_NE(handle->header->rings[r].task_payloads, nullptr) << "Ring " << r;
     }
-    for (int r = 1; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 1; r < CHIP_MAX_RING_DEPTH; r++) {
         EXPECT_NE(handle->header->rings[r].task_descriptors, handle->header->rings[0].task_descriptors) << "Ring " << r;
     }
 }
 
 TEST_F(SharedMemoryTest, PointerAlignment) {
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         auto addr = reinterpret_cast<uintptr_t>(handle->header->rings[r].task_descriptors);
         EXPECT_EQ(addr % PTO2_ALIGN_SIZE, 0u) << "Ring " << r << " descriptors not aligned";
     }
@@ -168,7 +168,7 @@ TEST(SharedMemoryLayout, RegionsNonOverlapping) {
     PTO2SharedMemoryHandle *h = make_handle(arena, /*ws=*/64, /*heap=*/4096);
     ASSERT_NE(h, nullptr);
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         uintptr_t desc_start = (uintptr_t)h->header->rings[r].task_descriptors;
         uintptr_t desc_end = desc_start + 64 * sizeof(PTO2TaskDescriptor);
         uintptr_t payload_start = (uintptr_t)h->header->rings[r].task_payloads;
@@ -176,7 +176,7 @@ TEST(SharedMemoryLayout, RegionsNonOverlapping) {
         EXPECT_GE(payload_start, desc_end) << "Ring " << r << ": payload region should not overlap descriptors";
     }
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH - 1; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH - 1; r++) {
         uintptr_t this_payload_end = (uintptr_t)h->header->rings[r].task_payloads + 64 * sizeof(PTO2TaskPayload);
         uintptr_t next_desc_start = (uintptr_t)h->header->rings[r + 1].task_descriptors;
         EXPECT_GE(next_desc_start, this_payload_end) << "Ring " << r << " and " << (r + 1) << " should not overlap";
@@ -201,7 +201,7 @@ TEST(SharedMemoryCalcSize, LargerWindowGivesLargerSize) {
 TEST(SharedMemoryCalcSize, HeaderAligned) { EXPECT_EQ(sizeof(PTO2SharedMemoryHeader) % PTO2_ALIGN_SIZE, 0u); }
 
 TEST(SharedMemoryCalcSize, PerRingDifferentSizes) {
-    uint64_t ws[PTO2_MAX_RING_DEPTH] = {128, 256, 512, 1024};
+    uint64_t ws[CHIP_MAX_RING_DEPTH] = {128, 256, 512, 1024};
     uint64_t size = PTO2SharedMemoryHandle::calculate_size_per_ring(ws);
 
     uint64_t uniform_size = PTO2SharedMemoryHandle::calculate_size(128);
@@ -209,8 +209,8 @@ TEST(SharedMemoryCalcSize, PerRingDifferentSizes) {
 }
 
 TEST(SharedMemoryLayout, InitPerRingWritesHeaderValues) {
-    uint64_t ws[PTO2_MAX_RING_DEPTH] = {16, 32, 64, 128};
-    uint64_t heaps[PTO2_MAX_RING_DEPTH] = {10 * 1024, 20 * 1024, 30 * 1024, 40 * 1024};
+    uint64_t ws[CHIP_MAX_RING_DEPTH] = {16, 32, 64, 128};
+    uint64_t heaps[CHIP_MAX_RING_DEPTH] = {10 * 1024, 20 * 1024, 30 * 1024, 40 * 1024};
     const uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(ws);
 
     DeviceArena arena;
@@ -224,7 +224,7 @@ TEST(SharedMemoryLayout, InitPerRingWritesHeaderValues) {
     std::memset(buffer, 0, static_cast<size_t>(sm_size));
     ASSERT_TRUE(handle->init_per_ring(buffer, sm_size, ws, heaps));
 
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         EXPECT_EQ(handle->header->rings[r].task_window_size, ws[r]);
         EXPECT_EQ(handle->header->rings[r].heap_size, heaps[r]);
         EXPECT_EQ(handle->header->rings[r].task_window_mask, static_cast<int32_t>(ws[r] - 1));
@@ -232,12 +232,12 @@ TEST(SharedMemoryLayout, InitPerRingWritesHeaderValues) {
 }
 
 TEST(RuntimeArenaLayout, PerRingConfigInitializesRuntimeComponents) {
-    uint64_t ws[PTO2_MAX_RING_DEPTH] = {16, 32, 64, 128};
-    uint64_t heaps[PTO2_MAX_RING_DEPTH] = {10 * 1024, 20 * 1024, 30 * 1024, 40 * 1024};
-    int32_t dep_caps[PTO2_MAX_RING_DEPTH] = {4, 8, 16, 32};
+    uint64_t ws[CHIP_MAX_RING_DEPTH] = {16, 32, 64, 128};
+    uint64_t heaps[CHIP_MAX_RING_DEPTH] = {10 * 1024, 20 * 1024, 30 * 1024, 40 * 1024};
+    int32_t dep_caps[CHIP_MAX_RING_DEPTH] = {4, 8, 16, 32};
     const uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(ws);
     uint64_t total_heap = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         total_heap += heaps[r];
     }
 
@@ -255,13 +255,13 @@ TEST(RuntimeArenaLayout, PerRingConfigInitializesRuntimeComponents) {
     RuntimeContext *rt =
         runtime_init_data_from_layout(runtime_arena, layout, PTO2_MODE_EXECUTE, sm, sm_size, gm.data(), heaps);
     ASSERT_NE(rt, nullptr);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         EXPECT_FALSE(rt->scheduler.ring_sched_states[r].publication_batching_enabled);
     }
     runtime_wire_arena_pointers(runtime_arena, layout, rt);
 
     EXPECT_EQ(rt->gm_heap_size, total_heap);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         EXPECT_EQ(layout.sizing.task_window_sizes[r], ws[r]);
         EXPECT_EQ(layout.sizing.heap_sizes[r], heaps[r]);
         EXPECT_EQ(layout.sizing.dep_pool_capacities[r], dep_caps[r]);
@@ -274,15 +274,15 @@ TEST(RuntimeArenaLayout, PerRingConfigInitializesRuntimeComponents) {
 
     rt->sm_handle->sm_base = sm;
     ASSERT_TRUE(runtime_reset_for_reuse(runtime_arena, layout, rt));
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         EXPECT_TRUE(rt->scheduler.ring_sched_states[r].publication_batching_enabled);
     }
 }
 
 TEST(RuntimeArenaLayout, RewiresReclaimPublicationPointersAfterRelocation) {
-    uint64_t ws[PTO2_MAX_RING_DEPTH] = {16, 32, 64, 128};
-    uint64_t heaps[PTO2_MAX_RING_DEPTH] = {10 * 1024, 20 * 1024, 30 * 1024, 40 * 1024};
-    int32_t dep_caps[PTO2_MAX_RING_DEPTH] = {4, 8, 16, 32};
+    uint64_t ws[CHIP_MAX_RING_DEPTH] = {16, 32, 64, 128};
+    uint64_t heaps[CHIP_MAX_RING_DEPTH] = {10 * 1024, 20 * 1024, 30 * 1024, 40 * 1024};
+    int32_t dep_caps[CHIP_MAX_RING_DEPTH] = {4, 8, 16, 32};
     const uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(ws);
 
     DeviceArena source_arena;
@@ -307,7 +307,7 @@ TEST(RuntimeArenaLayout, RewiresReclaimPublicationPointersAfterRelocation) {
     runtime_wire_arena_pointers(relocated_arena, layout, relocated_rt);
 
     ASSERT_NE(&relocated_rt->scheduler, &source_rt->scheduler);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
         auto &dep_pool = relocated_rt->scheduler.ring_sched_states[r].dep_pool;
         EXPECT_EQ(dep_pool.reclaim_request_mask, &relocated_rt->scheduler.publication_request_mask);
         EXPECT_EQ(dep_pool.reclaim_ack_mask, &relocated_rt->scheduler.publication_ack_mask);
@@ -317,9 +317,9 @@ TEST(RuntimeArenaLayout, RewiresReclaimPublicationPointersAfterRelocation) {
 }
 
 TEST(RuntimeArenaLayout, RejectsOverflowingPerRingHeapSum) {
-    uint64_t ws[PTO2_MAX_RING_DEPTH] = {16, 32, 64, 128};
-    uint64_t heaps[PTO2_MAX_RING_DEPTH] = {std::numeric_limits<uint64_t>::max(), 1, 0, 0};
-    int32_t dep_caps[PTO2_MAX_RING_DEPTH] = {4, 8, 16, 32};
+    uint64_t ws[CHIP_MAX_RING_DEPTH] = {16, 32, 64, 128};
+    uint64_t heaps[CHIP_MAX_RING_DEPTH] = {std::numeric_limits<uint64_t>::max(), 1, 0, 0};
+    int32_t dep_caps[CHIP_MAX_RING_DEPTH] = {4, 8, 16, 32};
 
     DeviceArena runtime_arena;
     RuntimeArenaLayout layout = runtime_reserve_layout(runtime_arena, ws, heaps, dep_caps);
@@ -346,7 +346,7 @@ TEST(SharedMemoryBoundary, ZeroWindowSize) {
     DeviceArena arena;
     PTO2SharedMemoryHandle *h = make_handle(arena, /*ws=*/0, /*heap=*/4096);
     if (h) {
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH - 1; r++) {
+        for (int r = 0; r < CHIP_MAX_RING_DEPTH - 1; r++) {
             EXPECT_EQ(h->header->rings[r].task_descriptors, h->header->rings[r + 1].task_descriptors)
                 << "Zero window: all rings' descriptor pointers collapse to same address";
         }

--- a/tests/ut/cpp/a5/test_shared_memory.cpp
+++ b/tests/ut/cpp/a5/test_shared_memory.cpp
@@ -242,7 +242,7 @@ TEST(RuntimeArenaLayout, PerRingConfigInitializesRuntimeComponents) {
     }
 
     DeviceArena runtime_arena;
-    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(runtime_arena, ws, heaps, dep_caps);
+    RuntimeArenaLayout layout = runtime_reserve_layout(runtime_arena, ws, heaps, dep_caps);
     ASSERT_NE(runtime_arena.commit(DeviceArena::kDefaultBaseAlign), nullptr);
 
     DeviceArena sm_arena;
@@ -252,7 +252,7 @@ TEST(RuntimeArenaLayout, PerRingConfigInitializesRuntimeComponents) {
     std::memset(sm, 0, static_cast<size_t>(sm_size));
 
     std::vector<char> gm(static_cast<size_t>(total_heap));
-    PTO2Runtime *rt =
+    RuntimeContext *rt =
         runtime_init_data_from_layout(runtime_arena, layout, PTO2_MODE_EXECUTE, sm, sm_size, gm.data(), heaps);
     ASSERT_NE(rt, nullptr);
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -286,24 +286,24 @@ TEST(RuntimeArenaLayout, RewiresReclaimPublicationPointersAfterRelocation) {
     const uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(ws);
 
     DeviceArena source_arena;
-    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(source_arena, ws, heaps, dep_caps);
+    RuntimeArenaLayout layout = runtime_reserve_layout(source_arena, ws, heaps, dep_caps);
     ASSERT_NE(source_arena.commit(DeviceArena::kDefaultBaseAlign), nullptr);
 
     std::vector<char> sm(static_cast<size_t>(sm_size));
     std::vector<char> gm(100 * 1024);
-    PTO2Runtime *source_rt =
+    RuntimeContext *source_rt =
         runtime_init_data_from_layout(source_arena, layout, PTO2_MODE_EXECUTE, sm.data(), sm_size, gm.data(), heaps);
     ASSERT_NE(source_rt, nullptr);
     runtime_wire_arena_pointers(source_arena, layout, source_rt);
 
     DeviceArena relocated_arena;
-    PTO2RuntimeArenaLayout relocated_layout = runtime_reserve_layout(relocated_arena, ws, heaps, dep_caps);
+    RuntimeArenaLayout relocated_layout = runtime_reserve_layout(relocated_arena, ws, heaps, dep_caps);
     ASSERT_EQ(relocated_layout.offsets.off_runtime, layout.offsets.off_runtime);
     ASSERT_EQ(relocated_arena.total_size(), source_arena.total_size());
     ASSERT_NE(relocated_arena.commit(DeviceArena::kDefaultBaseAlign), nullptr);
     std::memcpy(relocated_arena.base(), source_arena.base(), source_arena.total_size());
 
-    auto *relocated_rt = static_cast<PTO2Runtime *>(relocated_arena.region_ptr(layout.offsets.off_runtime));
+    auto *relocated_rt = static_cast<RuntimeContext *>(relocated_arena.region_ptr(layout.offsets.off_runtime));
     runtime_wire_arena_pointers(relocated_arena, layout, relocated_rt);
 
     ASSERT_NE(&relocated_rt->scheduler, &source_rt->scheduler);
@@ -322,7 +322,7 @@ TEST(RuntimeArenaLayout, RejectsOverflowingPerRingHeapSum) {
     int32_t dep_caps[PTO2_MAX_RING_DEPTH] = {4, 8, 16, 32};
 
     DeviceArena runtime_arena;
-    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(runtime_arena, ws, heaps, dep_caps);
+    RuntimeArenaLayout layout = runtime_reserve_layout(runtime_arena, ws, heaps, dep_caps);
     ASSERT_NE(runtime_arena.commit(DeviceArena::kDefaultBaseAlign), nullptr);
 
     char sm = 0;

--- a/tests/ut/cpp/a5/test_task_state.cpp
+++ b/tests/ut/cpp/a5/test_task_state.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * Unit tests for PTO2TaskSlotState lifecycle through PTO2SchedulerState API.
+ * Unit tests for ChipTaskSlotState lifecycle through PTO2SchedulerState API.
  *
  * These tests drive state transitions via src methods (release_fanin,
  * on_subtask_complete, check_and_handle_consumed) rather than manually
@@ -60,7 +60,7 @@ protected:
         sm_arena.release();
     }
 
-    void init_slot(PTO2TaskSlotState &slot, PTO2TaskState state, int32_t fanin_count, int32_t fanout_count) {
+    void init_slot(ChipTaskSlotState &slot, PTO2TaskState state, int32_t fanin_count, int32_t fanout_count) {
         memset(&slot, 0, sizeof(slot));
         slot.task_state.store(state);
         slot.fanin_count = fanin_count;
@@ -85,7 +85,7 @@ protected:
 // -> (subtask) -> COMPLETED -> (fanout) -> CONSUMED
 // =============================================================================
 TEST_F(TaskStateTest, FullLifecycleThroughAPI) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.total_required_subtasks = 1;
     slot.completed_subtasks.store(0);
@@ -114,7 +114,7 @@ TEST_F(TaskStateTest, FullLifecycleThroughAPI) {
 // "dispatched to a worker" until the worker stores COMPLETED.
 // =============================================================================
 TEST_F(TaskStateTest, ReadyPathStaysPending) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
 
     bool ready = sched.release_fanin_and_check_ready(slot);
@@ -128,7 +128,7 @@ TEST_F(TaskStateTest, ReadyPathStaysPending) {
 // Multi-fanin: partial release does not trigger ready
 // =============================================================================
 TEST_F(TaskStateTest, MultiFaninPartialNotReady) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 3, 1);
 
     EXPECT_FALSE(sched.release_fanin_and_check_ready(slot));
@@ -143,7 +143,7 @@ TEST_F(TaskStateTest, ConcurrentFaninExactlyOneReady) {
     constexpr int ROUNDS = 500;
 
     for (int round = 0; round < ROUNDS; round++) {
-        alignas(64) PTO2TaskSlotState slot;
+        alignas(64) ChipTaskSlotState slot;
         init_slot(slot, PTO2_TASK_PENDING, 3, 1);
         std::atomic<int> ready_count{0};
 
@@ -169,7 +169,7 @@ TEST_F(TaskStateTest, ConcurrentSubtaskCompletion) {
     constexpr int ROUNDS = 500;
 
     for (int round = 0; round < ROUNDS; round++) {
-        alignas(64) PTO2TaskSlotState slot;
+        alignas(64) ChipTaskSlotState slot;
         init_slot(slot, PTO2_TASK_PENDING, 1, 1);
         slot.total_required_subtasks = 3;
         slot.completed_subtasks.store(0);
@@ -198,7 +198,7 @@ TEST_F(TaskStateTest, ConcurrentSubtaskCompletion) {
 // Unlike the old bitmask model, the counter cannot detect duplicates.
 // =============================================================================
 TEST_F(TaskStateTest, DoubleSubtaskCompletionCounterWeakness) {
-    alignas(64) PTO2TaskSlotState slot;
+    alignas(64) ChipTaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.total_required_subtasks = 2;
     slot.completed_subtasks.store(0);

--- a/tests/ut/cpp/a5/test_tensormap.cpp
+++ b/tests/ut/cpp/a5/test_tensormap.cpp
@@ -80,7 +80,7 @@ protected:
     DeviceArena arena;
 
     void SetUp() override {
-        int32_t window_sizes[PTO2_MAX_RING_DEPTH] = {WINDOW_SIZE, WINDOW_SIZE, WINDOW_SIZE, WINDOW_SIZE};
+        int32_t window_sizes[CHIP_MAX_RING_DEPTH] = {WINDOW_SIZE, WINDOW_SIZE, WINDOW_SIZE, WINDOW_SIZE};
         auto layout = PTO2TensorMap::reserve_layout(arena, NUM_BUCKETS, POOL_SIZE, window_sizes);
         ASSERT_NE(arena.commit(), nullptr);
         ASSERT_TRUE(tmap.init_data_from_layout(layout, arena));
@@ -112,7 +112,7 @@ TEST_F(TensorMapTest, InitWithPowerOfTwoBucketsSucceeds) {
     // may compile out. Cover only the accepted (power-of-2) shape.
     PTO2TensorMap ok{};
     DeviceArena ok_arena;
-    int32_t ws[PTO2_MAX_RING_DEPTH] = {8, 8, 8, 8};
+    int32_t ws[CHIP_MAX_RING_DEPTH] = {8, 8, 8, 8};
     auto layout = PTO2TensorMap::reserve_layout(ok_arena, 8, 64, ws);
     ASSERT_NE(ok_arena.commit(), nullptr);
     EXPECT_TRUE(ok.init_data_from_layout(layout, ok_arena));

--- a/tests/ut/cpp/a5/test_wiring.cpp
+++ b/tests/ut/cpp/a5/test_wiring.cpp
@@ -72,7 +72,7 @@ protected:
 
     // Initialize a slot for testing wiring/completion
     void init_slot(
-        PTO2TaskSlotState &slot, PTO2TaskState state, int32_t fanin_count, int32_t fanout_count, uint8_t ring_id = 0
+        ChipTaskSlotState &slot, PTO2TaskState state, int32_t fanin_count, int32_t fanout_count, uint8_t ring_id = 0
     ) {
         memset(&slot, 0, sizeof(slot));
         slot.task_state.store(state);
@@ -96,14 +96,14 @@ protected:
         slot.task = &slot_task;
     }
 
-    void publish_no_fanin(PTO2TaskSlotState &slot) {
+    void publish_no_fanin(ChipTaskSlotState &slot) {
         slot.fanin_count = 1;
         slot.fanin_refcount.store(1, std::memory_order_release);
         orch.mark_dep_pool_position(slot);
         sched.push_ready_routed(&slot);
     }
 
-    void wire_fanin(PTO2TaskSlotState &slot, int32_t wfanin) {
+    void wire_fanin(ChipTaskSlotState &slot, int32_t wfanin) {
         auto &rss = sched.ring_sched_states[slot.ring_id];
         bool ok = rss.dep_pool.ensure_space(*rss.ring, wfanin);
         if (ok) {
@@ -122,7 +122,7 @@ protected:
 
 TEST(ReclaimHeadMatchTest, ComparesExactRingAndLocalTaskId) {
     PTO2TaskDescriptor descriptor{};
-    PTO2TaskSlotState slot{};
+    ChipTaskSlotState slot{};
     slot.task = &descriptor;
     descriptor.task_id = TaskId::make(0, 16);
 
@@ -138,7 +138,7 @@ TEST(ReclaimHeadMatchTest, ComparesExactRingAndLocalTaskId) {
 
 TEST_F(WiringTest, NoFaninTaskBecomesReady) {
     // A task with 0 actual fanins should immediately be pushed to ready queue
-    alignas(64) PTO2TaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState task_slot;
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -166,8 +166,8 @@ TEST_F(WiringTest, NoFaninTaskBecomesReady) {
 // =============================================================================
 
 TEST_F(WiringTest, WireTaskAllProducersEarlyFinished) {
-    alignas(64) PTO2TaskSlotState task_slot;
-    alignas(64) PTO2TaskSlotState producer_slots[2];
+    alignas(64) ChipTaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState producer_slots[2];
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -204,8 +204,8 @@ TEST_F(WiringTest, WireTaskAllProducersEarlyFinished) {
 // =============================================================================
 
 TEST_F(WiringTest, WireTaskProducersPendingTaskNotReady) {
-    alignas(64) PTO2TaskSlotState task_slot;
-    alignas(64) PTO2TaskSlotState producer_slots[2];
+    alignas(64) ChipTaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState producer_slots[2];
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -247,8 +247,8 @@ TEST_F(WiringTest, WireTaskProducersPendingTaskNotReady) {
 // =============================================================================
 
 TEST_F(WiringTest, WireTaskMixedProducerStates) {
-    alignas(64) PTO2TaskSlotState task_slot;
-    alignas(64) PTO2TaskSlotState producers[3];
+    alignas(64) ChipTaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState producers[3];
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -309,7 +309,7 @@ TEST_F(WiringTest, SyncStartDoorbellPassHasOneOwner) {
 }
 
 TEST_F(WiringTest, SyncStartStagingFinalizeRetriesProducerFirstRendezvous) {
-    alignas(64) PTO2TaskSlotState sync_consumer, downstream;
+    alignas(64) ChipTaskSlotState sync_consumer, downstream;
     init_slot(sync_consumer, PTO2_TASK_PENDING, 1, 1);
     init_slot(downstream, PTO2_TASK_PENDING, 1, 1);
 
@@ -344,7 +344,7 @@ TEST_F(WiringTest, SyncStartStagingFinalizeRetriesProducerFirstRendezvous) {
 }
 
 TEST_F(WiringTest, SyncStartProducerReleaseCompletesStagerFirstRendezvous) {
-    alignas(64) PTO2TaskSlotState sync_consumer, downstream;
+    alignas(64) ChipTaskSlotState sync_consumer, downstream;
     init_slot(sync_consumer, PTO2_TASK_PENDING, 1, 1);
     init_slot(downstream, PTO2_TASK_PENDING, 1, 1);
 
@@ -375,7 +375,7 @@ TEST_F(WiringTest, SyncStartProducerReleaseCompletesStagerFirstRendezvous) {
 }
 
 TEST_F(WiringTest, EarlySyncFinishBetweenReleasePhasesRetainsOwnerCompleteState) {
-    alignas(64) PTO2TaskSlotState sync_consumer;
+    alignas(64) ChipTaskSlotState sync_consumer;
     init_slot(sync_consumer, PTO2_TASK_PENDING, 1, 1);
     sync_consumer.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIV0);
     sync_consumer.task_attrs.set_sync_start();
@@ -402,8 +402,8 @@ TEST_F(WiringTest, EarlySyncFinishBetweenReleasePhasesRetainsOwnerCompleteState)
 // =============================================================================
 
 TEST_F(WiringTest, OnMixedTaskCompleteNotifiesConsumers) {
-    alignas(64) PTO2TaskSlotState producer;
-    alignas(64) PTO2TaskSlotState consumer1, consumer2;
+    alignas(64) ChipTaskSlotState producer;
+    alignas(64) ChipTaskSlotState consumer1, consumer2;
     alignas(64) PTO2TaskPayload prod_payload;
     memset(&prod_payload, 0, sizeof(prod_payload));
     PTO2TaskDescriptor desc{};
@@ -457,8 +457,8 @@ TEST_F(WiringTest, OnMixedTaskCompleteNotifiesConsumers) {
 // =============================================================================
 
 TEST_F(WiringTest, OnTaskReleaseReleasesProducers) {
-    alignas(64) PTO2TaskSlotState task_slot;
-    alignas(64) PTO2TaskSlotState producers[2];
+    alignas(64) ChipTaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState producers[2];
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -500,9 +500,9 @@ TEST_F(WiringTest, OnTaskReleaseReleasesProducers) {
 // =============================================================================
 
 TEST_F(WiringTest, OrderingOnlyReleasedAtWiringRetentionHeldUntilRelease) {
-    alignas(64) PTO2TaskSlotState task_slot;
-    alignas(64) PTO2TaskSlotState wait_producer;    // DEP_WAIT only (modifier)
-    alignas(64) PTO2TaskSlotState retain_producer;  // DEP_WAIT|DEP_RETAIN (creator)
+    alignas(64) ChipTaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState wait_producer;    // DEP_WAIT only (modifier)
+    alignas(64) ChipTaskSlotState retain_producer;  // DEP_WAIT|DEP_RETAIN (creator)
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -542,9 +542,9 @@ TEST_F(WiringTest, OrderingOnlyReleasedAtWiringRetentionHeldUntilRelease) {
 // on_task_release must honor per-edge flags in the spill region too: a spilled
 // DEP_RETAIN edge is released; inline ordering-only edges are skipped.
 TEST_F(WiringTest, ReleaseHonorsRetainFlagInSpillRegion) {
-    alignas(64) PTO2TaskSlotState filler;        // 64 inline DEP_WAIT-only edges
-    alignas(64) PTO2TaskSlotState spill_retain;  // 1 spilled DEP_RETAIN edge
-    alignas(64) PTO2TaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState filler;        // 64 inline DEP_WAIT-only edges
+    alignas(64) ChipTaskSlotState spill_retain;  // 1 spilled DEP_RETAIN edge
+    alignas(64) ChipTaskSlotState task_slot;
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -938,7 +938,7 @@ TEST_F(WiringTest, AdvanceRingPointersResetsSlots) {
 }
 
 TEST_F(WiringTest, NoEdgePublishRecordsDepPoolMark) {
-    alignas(64) PTO2TaskSlotState task_slot;
+    alignas(64) ChipTaskSlotState task_slot;
     alignas(64) PTO2TaskPayload payload;
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
@@ -955,14 +955,14 @@ TEST_F(WiringTest, NoEdgePublishRecordsDepPoolMark) {
 }
 
 TEST_F(WiringTest, BatchPushReportsFullInsteadOfSpinning) {
-    alignas(64) PTO2TaskSlotState filler;
+    alignas(64) ChipTaskSlotState filler;
     init_slot(filler, PTO2_TASK_PENDING, 0, 1);
     auto &queue = sched.early_dispatch_queues[static_cast<int32_t>(filler.active_mask.to_shape())];
     for (uint64_t i = 0; i < queue.capacity; i++) {
         ASSERT_TRUE(queue.push_tagged(&filler, i));
     }
 
-    PTO2TaskSlotState *items[1] = {&filler};
+    ChipTaskSlotState *items[1] = {&filler};
     uint64_t tags[1] = {queue.capacity};
     // A full queue must end the call, not spin waiting for a consumer. Reaching
     // the next line at all is the assertion.
@@ -974,7 +974,7 @@ TEST_F(WiringTest, BatchPushReportsFullInsteadOfSpinning) {
 }
 
 TEST_F(WiringTest, BatchPushSucceedsAfterSpaceIsReclaimed) {
-    alignas(64) PTO2TaskSlotState filler;
+    alignas(64) ChipTaskSlotState filler;
     init_slot(filler, PTO2_TASK_PENDING, 0, 1);
     auto &queue = sched.early_dispatch_queues[static_cast<int32_t>(filler.active_mask.to_shape())];
     for (uint64_t i = 0; i < queue.capacity; i++) {
@@ -983,14 +983,14 @@ TEST_F(WiringTest, BatchPushSucceedsAfterSpaceIsReclaimed) {
     ASSERT_NE(queue.pop(), nullptr);
     ASSERT_NE(queue.pop(), nullptr);
 
-    PTO2TaskSlotState *items[2] = {&filler, &filler};
+    ChipTaskSlotState *items[2] = {&filler, &filler};
     uint64_t tags[2] = {7, 8};
     EXPECT_TRUE(queue.push_batch_tagged(items, tags, 2));
     EXPECT_EQ(queue.size(), queue.capacity);
 }
 
 TEST_F(WiringTest, EarlyDispatchQueueOverflowFallsBackToNormalDispatch) {
-    alignas(64) PTO2TaskSlotState filler, consumer;
+    alignas(64) ChipTaskSlotState filler, consumer;
     init_slot(filler, PTO2_TASK_PENDING, 0, 1);
     init_slot(consumer, PTO2_TASK_PENDING, 1, 1);
 
@@ -1011,7 +1011,7 @@ TEST_F(WiringTest, EarlyDispatchQueueOverflowFallsBackToNormalDispatch) {
 }
 
 TEST_F(WiringTest, EarlyDispatchSyncStartQueueOverflowFallsBackToSyncReadyQueue) {
-    alignas(64) PTO2TaskSlotState filler, consumer;
+    alignas(64) ChipTaskSlotState filler, consumer;
     init_slot(filler, PTO2_TASK_PENDING, 0, 1);
     init_slot(consumer, PTO2_TASK_PENDING, 1, 1);
     consumer.task_attrs.set_sync_start();

--- a/tests/ut/cpp/common/test_hbg_graph_async_submit.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_async_submit.cpp
@@ -217,7 +217,7 @@ TEST(HbgGraphAsyncSubmit, FourDistinctGraphMissesDoNotInsertAnIntermediateCommit
 
     int body_calls = 0;
     for (uint64_t graph_key = 0x1800; graph_key < 0x1804; ++graph_key) {
-        PTO2ScopeGuard scope;
+        ScopeGuard scope;
         const GraphSubmitResult result = rt_submit_graph_impl(graph_key, args, [&](const GraphTaskArgs &) {
             std::lock_guard<std::mutex> lock(fake.mutex);
             body_calls++;
@@ -250,7 +250,7 @@ TEST(HbgGraphAsyncSubmit, WorkerRecordsWhileMainSubmitsLaterGraphs) {
     const std::thread::id caller = std::this_thread::get_id();
     GraphSubmitResult first;
     {
-        PTO2ScopeGuard scope;
+        ScopeGuard scope;
         first = rt_submit_graph_impl(0x1715, args, [&](const GraphTaskArgs &) {
             // An explicit commit reached from a Graph body must not make the
             // recorder wait for its own in-flight job.
@@ -268,7 +268,7 @@ TEST(HbgGraphAsyncSubmit, WorkerRecordsWhileMainSubmitsLaterGraphs) {
     }
     GraphSubmitResult second;
     {
-        PTO2ScopeGuard scope;
+        ScopeGuard scope;
         second = rt_submit_graph_impl(0x1715, args, [&](const GraphTaskArgs &) {
             ADD_FAILURE() << "a later submission for an in-flight Graph must not execute the body";
         });
@@ -283,7 +283,7 @@ TEST(HbgGraphAsyncSubmit, WorkerRecordsWhileMainSubmitsLaterGraphs) {
         fake.overlapped = false;
     }
     {
-        PTO2ScopeGuard scope;
+        ScopeGuard scope;
         first = rt_submit_graph_impl(0x1715, args, [&](const GraphTaskArgs &) {
             rt_graph_commit();
             std::unique_lock<std::mutex> lock(fake.mutex);
@@ -298,7 +298,7 @@ TEST(HbgGraphAsyncSubmit, WorkerRecordsWhileMainSubmitsLaterGraphs) {
         });
     }
     {
-        PTO2ScopeGuard scope;
+        ScopeGuard scope;
         second = rt_submit_graph_impl(0x1715, args, [&](const GraphTaskArgs &) {
             ADD_FAILURE() << "a later submission for an in-flight Graph must not execute the body";
         });
@@ -349,7 +349,7 @@ TEST(HbgGraphAsyncSubmit, RecordingReadsAnOwnedCopyOfTheBoundary) {
     fake.later_submit_entered = true;
 
     {
-        PTO2ScopeGuard scope;
+        ScopeGuard scope;
         (void)rt_submit_graph_impl(0x1719, args, [](const GraphTaskArgs &) {});
     }
     rt_graph_commit();

--- a/tests/ut/cpp/common/test_hbg_graph_async_submit.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_async_submit.cpp
@@ -28,13 +28,13 @@ namespace {
 // budgeted for a badly loaded host rather than for the expected microseconds.
 constexpr std::chrono::seconds kHandshakeTimeout{5};
 
-PTO2Runtime *g_bound_runtime = nullptr;
+RuntimeContext *g_bound_runtime = nullptr;
 
-extern "C" PTO2Runtime *framework_current_runtime(void) { return g_bound_runtime; }
-extern "C" void framework_bind_runtime(PTO2Runtime *rt) { g_bound_runtime = rt; }
+extern "C" RuntimeContext *framework_current_runtime(void) { return g_bound_runtime; }
+extern "C" void framework_bind_runtime(RuntimeContext *rt) { g_bound_runtime = rt; }
 
 struct FakeRuntime {
-    const PTO2RuntimeOps *ops;
+    const RuntimeOps *ops;
     PTO2ScopeMode pending_scope_mode{PTO2ScopeMode::AUTO};
     std::mutex mutex;
     std::condition_variable cv;
@@ -71,13 +71,13 @@ struct FakeRuntime {
 };
 
 static_assert(offsetof(FakeRuntime, ops) == 0);
-static_assert(offsetof(FakeRuntime, pending_scope_mode) == offsetof(PTO2Runtime, pending_scope_mode));
+static_assert(offsetof(FakeRuntime, pending_scope_mode) == offsetof(RuntimeContext, pending_scope_mode));
 
-FakeRuntime *as_fake(PTO2Runtime *rt) { return reinterpret_cast<FakeRuntime *>(rt); }
+FakeRuntime *as_fake(RuntimeContext *rt) { return reinterpret_cast<FakeRuntime *>(rt); }
 
-bool fake_is_fatal(PTO2Runtime *) { return false; }
+bool fake_is_fatal(RuntimeContext *) { return false; }
 
-GraphScopeResult fake_graph_begin(PTO2Runtime *rt, uint64_t, const GraphTaskArgs &) {
+GraphScopeResult fake_graph_begin(RuntimeContext *rt, uint64_t, const GraphTaskArgs &) {
     FakeRuntime &fake = *as_fake(rt);
     std::lock_guard<std::mutex> lock(fake.mutex);
     fake.begin_calls++;
@@ -93,7 +93,7 @@ GraphScopeResult fake_graph_begin(PTO2Runtime *rt, uint64_t, const GraphTaskArgs
     return result;
 }
 
-bool fake_graph_prepare(PTO2Runtime *rt, void *recording_handle, const GraphTaskArgs &args) {
+bool fake_graph_prepare(RuntimeContext *rt, void *recording_handle, const GraphTaskArgs &args) {
     FakeRuntime &fake = *as_fake(rt);
     std::unique_lock<std::mutex> lock(fake.mutex);
     fake.prepare_calls++;
@@ -132,9 +132,9 @@ bool fake_graph_prepare(PTO2Runtime *rt, void *recording_handle, const GraphTask
     return true;
 }
 
-void fake_graph_abort(PTO2Runtime *, void *) {}
+void fake_graph_abort(RuntimeContext *, void *) {}
 
-bool fake_graph_end(PTO2Runtime *rt) {
+bool fake_graph_end(RuntimeContext *rt) {
     FakeRuntime &fake = *as_fake(rt);
     std::lock_guard<std::mutex> lock(fake.mutex);
     fake.end_calls++;
@@ -142,13 +142,13 @@ bool fake_graph_end(PTO2Runtime *rt) {
     return true;
 }
 
-void fake_graph_commit(PTO2Runtime *rt) { as_fake(rt)->commit_calls++; }
+void fake_graph_commit(RuntimeContext *rt) { as_fake(rt)->commit_calls++; }
 
-void fake_scope_begin(PTO2Runtime *rt) { as_fake(rt)->scope_begin_calls++; }
+void fake_scope_begin(RuntimeContext *rt) { as_fake(rt)->scope_begin_calls++; }
 
-void fake_scope_end(PTO2Runtime *rt) { as_fake(rt)->scope_end_calls++; }
+void fake_scope_end(RuntimeContext *rt) { as_fake(rt)->scope_end_calls++; }
 
-const PTO2RuntimeOps kFakeOps = {
+const RuntimeOps kFakeOps = {
     .scope_begin = fake_scope_begin,
     .scope_end = fake_scope_end,
     .is_fatal = fake_is_fatal,
@@ -207,7 +207,7 @@ TEST(HbgGraphAsyncSubmit, FourDistinctGraphMissesDoNotInsertAnIntermediateCommit
     fake.ops = &kFakeOps;
     fake.record_every_begin = true;
     fake.gate_four_prepares = true;
-    framework_bind_runtime(reinterpret_cast<PTO2Runtime *>(&fake));
+    framework_bind_runtime(reinterpret_cast<RuntimeContext *>(&fake));
 
     uint32_t storage[4]{};
     uint32_t shape[] = {4};
@@ -238,7 +238,7 @@ TEST(HbgGraphAsyncSubmit, FourDistinctGraphMissesDoNotInsertAnIntermediateCommit
 TEST(HbgGraphAsyncSubmit, WorkerRecordsWhileMainSubmitsLaterGraphs) {
     FakeRuntime fake{};
     fake.ops = &kFakeOps;
-    framework_bind_runtime(reinterpret_cast<PTO2Runtime *>(&fake));
+    framework_bind_runtime(reinterpret_cast<RuntimeContext *>(&fake));
 
     uint32_t storage[4]{};
     uint32_t shape[] = {4};
@@ -330,7 +330,7 @@ TEST(HbgGraphAsyncSubmit, WorkerRecordsWhileMainSubmitsLaterGraphs) {
 TEST(HbgGraphAsyncSubmit, RecordingReadsAnOwnedCopyOfTheBoundary) {
     FakeRuntime fake{};
     fake.ops = &kFakeOps;
-    framework_bind_runtime(reinterpret_cast<PTO2Runtime *>(&fake));
+    framework_bind_runtime(reinterpret_cast<RuntimeContext *>(&fake));
 
     uint32_t storage[8]{};
     uint32_t shape[] = {8};

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -254,7 +254,7 @@ private:
     std::unique_ptr<AlignedStorage> storage_;
     PTO2TaskDescriptor task_{};
     PTO2TaskPayload payload_{};
-    PTO2TaskSlotState slot_{};
+    ChipTaskSlotState slot_{};
     std::array<ChipTensor, TENSOR_SLOTS> boundary_tensors_{};
     std::array<uint64_t, SCALAR_SPAN> boundary_scalars_{};
 };
@@ -456,7 +456,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     outer_task.task_id = TaskId::make(1, 7);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
-    PTO2TaskSlotState outer_slot{};
+    ChipTaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
     outer_slot.task.set(&outer_task);
     outer_slot.graph_context = execution;
@@ -532,7 +532,7 @@ TEST(GraphExecutionReplay, MaterializesBoundaryScalarPoolWiderThanTaskPayload) {
     outer_task.task_id = TaskId::make(1, 7);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
-    PTO2TaskSlotState outer_slot{};
+    ChipTaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
     outer_slot.task.set(&outer_task);
     outer_slot.graph_context = execution;
@@ -598,7 +598,7 @@ TEST(GraphExecutionActivationState, RetriesDoNotClearReadiness) {
 TEST(GraphExecutionActivationState, ExternalReadyBeforePrepareActivatesAtMeet) {
     PTO2SchedulerState scheduler{};
     GraphExecution execution{};
-    PTO2TaskSlotState outer_slot{};
+    ChipTaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
     outer_slot.graph_context = &execution;
     execution.outer_slot = &outer_slot;
@@ -616,7 +616,7 @@ TEST(GraphExecutionActivationState, ExternalReadyBeforePrepareActivatesAtMeet) {
 TEST(GraphExecutionActivationState, PrepareBeforeExternalReadyActivatesAtMeet) {
     PTO2SchedulerState scheduler{};
     GraphExecution execution{};
-    PTO2TaskSlotState outer_slot{};
+    ChipTaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
     outer_slot.graph_context = &execution;
     execution.outer_slot = &outer_slot;
@@ -646,8 +646,8 @@ TEST(GraphExecutionErrors, GraphReadyQueueOverflowIsReported) {
     scheduler.graph_ready_queue.mask = 1;
     scheduler.graph_ready_queue.enqueue_pos.store(0, std::memory_order_relaxed);
     scheduler.graph_ready_queue.dequeue_pos.store(0, std::memory_order_relaxed);
-    PTO2TaskSlotState graph_slots[3]{};
-    for (PTO2TaskSlotState &slot : graph_slots) {
+    ChipTaskSlotState graph_slots[3]{};
+    for (ChipTaskSlotState &slot : graph_slots) {
         slot.task_kind = TaskKind::GRAPH;
     }
 
@@ -670,7 +670,7 @@ TEST(GraphExecutionErrors, GraphPrepareQueueOverflowIsReported) {
     scheduler.graph_prepare_queue.mask = 1;
     scheduler.graph_prepare_queue.enqueue_pos.store(0, std::memory_order_relaxed);
     scheduler.graph_prepare_queue.dequeue_pos.store(0, std::memory_order_relaxed);
-    PTO2TaskSlotState graph_slots[3]{};
+    ChipTaskSlotState graph_slots[3]{};
 
     EXPECT_TRUE(scheduler.push_graph_prepare(&graph_slots[0], 10, 3));
     EXPECT_TRUE(scheduler.push_graph_prepare(&graph_slots[1], 11, 3));
@@ -683,7 +683,7 @@ TEST(GraphExecutionErrors, GraphPrepareQueueOverflowIsReported) {
 
 TEST(GraphExecutionErrors, InvalidNodeCompletionIsReported) {
     PTO2SchedulerState scheduler{};
-    PTO2TaskSlotState slot{};
+    ChipTaskSlotState slot{};
     slot.task_kind = TaskKind::GRAPH_NODE;
 
     const PTO2SchedulerState::TaskCompletionOutcome outcome = scheduler.complete_task(slot);
@@ -739,7 +739,7 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
     outer_task.task_id = TaskId::make(1, 5);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
-    PTO2TaskSlotState outer_slot{};
+    ChipTaskSlotState outer_slot{};
     outer_slot.task_kind = TaskKind::GRAPH;
     outer_slot.task.set(&outer_task);
     outer_slot.graph_context = execution;

--- a/tests/ut/cpp/common/test_hbg_ready_queue_seed.cpp
+++ b/tests/ut/cpp/common/test_hbg_ready_queue_seed.cpp
@@ -51,8 +51,8 @@ void make_queue(PTO2ReadyQueue *queue, SlotsRegion &region) {
 }
 
 // Distinct non-null slot_state values; the queue only moves the pointer around.
-PTO2TaskSlotState *fake_slot_state(size_t i) {
-    static PTO2TaskSlotState states[CAPACITY * 2];
+ChipTaskSlotState *fake_slot_state(size_t i) {
+    static ChipTaskSlotState states[CAPACITY * 2];
     return &states[i];
 }
 

--- a/tests/ut/cpp/common/test_hbg_scheduler_drain.cpp
+++ b/tests/ut/cpp/common/test_hbg_scheduler_drain.cpp
@@ -28,7 +28,7 @@ extern "C" uint64_t get_platform_pmu_reg_addrs() { return 0; }
 extern "C" uint64_t get_platform_regs() { return 0; }
 
 int SchedulerContext::prepare_block_for_dispatch(
-    int32_t, int32_t, PTO2TaskSlotState &, PTO2ResourceShape, bool, int32_t, PublishHandle *, bool
+    int32_t, int32_t, ChipTaskSlotState &, PTO2ResourceShape, bool, int32_t, PublishHandle *, bool
 ) {
     return 0;
 }

--- a/tests/ut/cpp/common/test_hbg_self_relative_ptr.cpp
+++ b/tests/ut/cpp/common/test_hbg_self_relative_ptr.cpp
@@ -75,7 +75,7 @@ TEST(HbgSelfRelativePtr, SetNullRebindsToUnbound) {
 // a host address the device would dereference verbatim, while a delta names the
 // same *relative* position in whichever copy is being read.
 TEST(HbgSelfRelativePtr, SurvivesABlockCopyToAnotherAddress) {
-    // Two real objects rather than raw byte buffers: PTO2TaskSlotState is
+    // Two real objects rather than raw byte buffers: ChipTaskSlotState is
     // alignas(64), which std::vector<std::byte>::data() does not promise, and a
     // memcpy into untyped storage would not begin the object's lifetime.
     Block source{};
@@ -100,7 +100,7 @@ TEST(HbgSelfRelativePtr, SlotStateBindingSurvivesTheImageCopy) {
     struct Image {
         PTO2TaskDescriptor descriptor;
         PTO2TaskPayload payload;
-        PTO2TaskSlotState slot;
+        ChipTaskSlotState slot;
     };
 
     // Real objects, not byte buffers: the slot state is alignas(64), which
@@ -124,7 +124,7 @@ TEST(HbgSelfRelativePtr, SlotStateBindingSurvivesTheImageCopy) {
 // unchanged by the representation: the eight bytes the two deltas save become
 // tail padding inside the same 64.
 TEST(HbgSelfRelativePtr, KeepsTheSharedMemoryAbiSizes) {
-    EXPECT_EQ(sizeof(PTO2TaskSlotState), 64u);
+    EXPECT_EQ(sizeof(ChipTaskSlotState), 64u);
     EXPECT_EQ(sizeof(PTO2TaskDescriptor), 40u);
     EXPECT_EQ(sizeof(SelfRelativePtr<PTO2TaskPayload>), 4u);
     EXPECT_EQ(offsetof(PTO2TaskDescriptor, packed_buffer_base), 24u);

--- a/tests/ut/cpp/common/test_hbg_slot_claim.cpp
+++ b/tests/ut/cpp/common/test_hbg_slot_claim.cpp
@@ -69,7 +69,7 @@ protected:
     // pass left is what the claim has to overwrite. Every value here is one a
     // completed task really leaves behind.
     void poison_slot(int32_t slot) {
-        PTO2TaskSlotState &state = sm_handle->header->ring.get_slot_state_by_slot(slot);
+        ChipTaskSlotState &state = sm_handle->header->ring.get_slot_state_by_slot(slot);
         state.wake_list_head.store(WAKE_LIST_SENTINEL, std::memory_order_relaxed);
         state.next_in_wake_list = &sm_handle->header->ring.get_slot_state_by_slot(slot + 1);
         state.any_subtask_deferred.store(true, std::memory_order_relaxed);
@@ -80,7 +80,7 @@ protected:
     }
 
     void expect_slot_pristine(int32_t slot) {
-        PTO2TaskSlotState &state = sm_handle->header->ring.get_slot_state_by_slot(slot);
+        ChipTaskSlotState &state = sm_handle->header->ring.get_slot_state_by_slot(slot);
         EXPECT_EQ(state.wake_list_head.load(std::memory_order_relaxed), nullptr)
             << "a stale SENTINEL closes the wake list, so no consumer can register on this producer";
         EXPECT_EQ(state.next_in_wake_list, nullptr);
@@ -137,7 +137,7 @@ TEST_F(HbgSlotClaimTest, GraphOuterTaskClaimsAPoisonedSlot) {
     ASSERT_TRUE(orch.graph_end());
     ASSERT_EQ(orch.task_allocator.active_count(), 1);
 
-    PTO2TaskSlotState &outer = sm_handle->header->ring.get_slot_state_by_slot(0);
+    ChipTaskSlotState &outer = sm_handle->header->ring.get_slot_state_by_slot(0);
     ASSERT_EQ(outer.task_kind, TaskKind::GRAPH);
     expect_slot_pristine(0);
 }

--- a/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
+++ b/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
@@ -41,7 +41,7 @@ constexpr int32_t FANIN_PER_TASK = 4;
 constexpr int32_t FANIN_STRIDE = static_cast<int32_t>(ARG_POOL_ALIGN / sizeof(int32_t));
 
 // A buffer aligned the way both the arena mirror and the device SM base are;
-// PTO2TaskSlotState is alignas(64) and every segment offset is a multiple of
+// ChipTaskSlotState is alignas(64) and every segment offset is a multiple of
 // PTO2_ALIGN_SIZE.
 class AlignedImage {
 public:
@@ -132,8 +132,8 @@ public:
     int32_t *fanin_pool() {
         return reinterpret_cast<int32_t *>(image_.base() + pto2_sm_layout::ring_segment_offsets(WINDOW).fanin_pool);
     }
-    PTO2TaskSlotState *slot_states() {
-        return reinterpret_cast<PTO2TaskSlotState *>(
+    ChipTaskSlotState *slot_states() {
+        return reinterpret_cast<ChipTaskSlotState *>(
             image_.base() + pto2_sm_layout::ring_segment_offsets(WINDOW).slot_states
         );
     }
@@ -181,7 +181,7 @@ struct Compacted {
         return reinterpret_cast<PTO2TaskDescriptor *>(image.base() + off().descriptors);
     }
     PTO2TaskPayload *payloads() { return payload_at(0); }
-    PTO2TaskSlotState *slot_states() { return reinterpret_cast<PTO2TaskSlotState *>(image.base() + off().slot_states); }
+    ChipTaskSlotState *slot_states() { return reinterpret_cast<ChipTaskSlotState *>(image.base() + off().slot_states); }
     std::atomic<uint8_t> *completion_flags() {
         return reinterpret_cast<std::atomic<uint8_t> *>(image.base() + off().completion_flags);
     }
@@ -244,7 +244,7 @@ TEST(HbgSmCompaction, BindingsSurviveTheCopyToTheDevice) {
     // to agree between the two, but reading them off the mirror overload here would
     // stop being true the moment a pool moved ahead of them.
     const auto off = compacted.off();
-    auto *slots = reinterpret_cast<PTO2TaskSlotState *>(landed.base() + off.slot_states);
+    auto *slots = reinterpret_cast<ChipTaskSlotState *>(landed.base() + off.slot_states);
     auto *payloads = reinterpret_cast<PTO2TaskPayload *>(landed.base() + off.payloads);
     auto *descriptors = reinterpret_cast<PTO2TaskDescriptor *>(landed.base() + off.descriptors);
 

--- a/tests/ut/cpp/common/test_scope_deadlock_detection.cpp
+++ b/tests/ut/cpp/common/test_scope_deadlock_detection.cpp
@@ -23,7 +23,7 @@ constexpr int32_t WINDOW_SIZE = 16;
 constexpr int32_t POOL_CAPACITY = 8;
 
 void make_head_match_old_structural_predicate(
-    PTO2TaskSlotState &head, PTO2TaskDescriptor &descriptor, uint8_t ring_id, uint32_t local_task_id
+    ChipTaskSlotState &head, PTO2TaskDescriptor &descriptor, uint8_t ring_id, uint32_t local_task_id
 ) {
     descriptor.task_id = TaskId::make(ring_id, local_task_id);
     head.task = &descriptor;
@@ -43,7 +43,7 @@ TEST(ScopeDeadlockDetectionTest, DepPoolUsesTimeoutForDifferentScopeHead) {
         ASSERT_NE(pool.alloc(), nullptr);
     }
 
-    alignas(64) PTO2TaskSlotState slot_states[WINDOW_SIZE]{};
+    alignas(64) ChipTaskSlotState slot_states[WINDOW_SIZE]{};
     PTO2TaskDescriptor task_descriptors[WINDOW_SIZE]{};
     PTO2SharedMemoryRingHeader ring{};
     ring.fc.init();
@@ -54,7 +54,7 @@ TEST(ScopeDeadlockDetectionTest, DepPoolUsesTimeoutForDifferentScopeHead) {
     ring.fc.last_task_alive.store(0, std::memory_order_release);
 
     make_head_match_old_structural_predicate(slot_states[0], task_descriptors[0], 0, 0);
-    PTO2TaskSlotState *oldest_open_task = &slot_states[1];
+    ChipTaskSlotState *oldest_open_task = &slot_states[1];
 
     testing::internal::CaptureStderr();
     bool available = pool.ensure_space(ring, 1, oldest_open_task);
@@ -75,7 +75,7 @@ TEST(ScopeDeadlockDetectionTest, DepPoolRejectsCurrentScopeHeadStructurally) {
         ASSERT_NE(pool.alloc(), nullptr);
     }
 
-    alignas(64) PTO2TaskSlotState slot_states[WINDOW_SIZE]{};
+    alignas(64) ChipTaskSlotState slot_states[WINDOW_SIZE]{};
     PTO2TaskDescriptor task_descriptors[WINDOW_SIZE]{};
     PTO2SharedMemoryRingHeader ring{};
     ring.fc.init();
@@ -83,7 +83,7 @@ TEST(ScopeDeadlockDetectionTest, DepPoolRejectsCurrentScopeHeadStructurally) {
     ring.task_window_mask = WINDOW_SIZE - 1;
     ring.slot_states = slot_states;
     ring.fc.current_task_index.store(1, std::memory_order_release);
-    PTO2TaskSlotState *oldest_open_task = &slot_states[0];
+    ChipTaskSlotState *oldest_open_task = &slot_states[0];
     make_head_match_old_structural_predicate(slot_states[0], task_descriptors[0], 0, 0);
 
     testing::internal::CaptureStderr();

--- a/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
+++ b/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
@@ -246,9 +246,9 @@ ChipStorageTaskArgs make_args(std::vector<uint8_t> &input, std::vector<uint8_t> 
 int bind_runtime(
     Runtime &runtime, const HostApi &api, const ChipStorageTaskArgs &args, const ArgDirection *signature, int sig_count
 ) {
-    uint64_t ring_task_window[PTO2_MAX_RING_DEPTH] = {4, 4, 4, 4};
-    uint64_t ring_heap[PTO2_MAX_RING_DEPTH] = {1024, 1024, 1024, 1024};
-    uint64_t ring_dep_pool[PTO2_MAX_RING_DEPTH] = {4, 4, 4, 4};
+    uint64_t ring_task_window[CHIP_MAX_RING_DEPTH] = {4, 4, 4, 4};
+    uint64_t ring_heap[CHIP_MAX_RING_DEPTH] = {1024, 1024, 1024, 1024};
+    uint64_t ring_dep_pool[CHIP_MAX_RING_DEPTH] = {4, 4, 4, 4};
     return bind_callable_to_runtime_impl(
         &runtime, &api, &args, nullptr, signature, sig_count, ring_task_window, ring_heap, ring_dep_pool
     );
@@ -469,9 +469,9 @@ TEST_F(TrbRuntimeTempBufferTest, FailedCopyOnTemporaryPathDoesNotFreeRetainedBuf
 TEST_F(TrbRuntimeTempBufferTest, PreparedRuntimeEnvRequiresTheActiveArenaKey) {
     fake_.reset();
     HostApi compatibility_api = make_host_api();
-    uint64_t task_window[PTO2_MAX_RING_DEPTH] = {4, 4, 4, 4};
-    uint64_t heap[PTO2_MAX_RING_DEPTH] = {1024, 1024, 1024, 1024};
-    uint64_t dep_pool[PTO2_MAX_RING_DEPTH] = {4, 4, 4, 4};
+    uint64_t task_window[CHIP_MAX_RING_DEPTH] = {4, 4, 4, 4};
+    uint64_t heap[CHIP_MAX_RING_DEPTH] = {1024, 1024, 1024, 1024};
+    uint64_t dep_pool[CHIP_MAX_RING_DEPTH] = {4, 4, 4, 4};
 
     EXPECT_EQ(concurrent_native_prepare_supported_impl(), 1);
     EXPECT_EQ(prepared_run_config_compatible_impl(&compatibility_api, task_window, heap, dep_pool), 0);


### PR DESCRIPTION
## Summary

Five commits, each retiring one `PTO2` identifier (or one coherent macro/type cluster) across every occurrence, in the order the user asked for. `.claude/rules/codestyle.md` rule 10 requires one identifier per commit — a rename that leaves both spellings alive is worse than no rename — and rule 9 requires "clear names or a `namespace`" where the prefix was actually disambiguating something.

| # | Identifier | Becomes | Occurrences | Files |
| - | ---------- | ------- | ----------- | ----- |
| 1 | `PTO2OrchestrationConfig` | `OrchestrationConfig` | 308 | 156 |
| 2 | `PTO2TaskSlotState` | `ChipTaskSlotState` | 856 | 109 |
| 3 | `PTO2_SCOPE` + guard/concat cluster | `SIMPLER_SCOPE` … | 265 | 77 |
| 4 | `PTO2Runtime` + 3 satellites | `RuntimeContext` … | 758 | 69 |
| 5 | `PTO2_MAX_RING_DEPTH` | `CHIP_MAX_RING_DEPTH` | 484 | 55 |

Only #1 was a plain prefix strip. **Three of the five could not take the bare name, and all three for the same reason: the name is already held by the host L3+ hierarchical orchestrator, which models the same concept one tier up.**

- `TaskSlotState` — `src/common/hierarchical/types.h` is the host orchestrator's per-task bookkeeping (`std::mutex`, `std::vector`); the renamed one is the chip runtime's 64-byte shared-memory slot with a spinlock and refcounts.
- `Runtime` — `runtime.h` already has a `class Runtime` for AICPU↔AICore handshake, whose own docstring drew the line: "Task graph construction is handled by PTO2Runtime; this class only handles execution control."
- `MAX_RING_DEPTH` — `hierarchical/types.h` defines the host's `= 4` heap-slab count and `worker_bind.h` exports it to Python. `docs/orchestrator.md` says the host count "matches L2's `PTO2_MAX_RING_DEPTH`", i.e. two deliberately equal but distinct constants.

So the `PTO2` prefix was doing real work in exactly the places where the chip runtime and the host orchestrator name the same idea. Rule 13 says which side keeps the bare name — L3+ does, the chip runtime takes `Chip` — so this branch spells them `ChipTaskSlotState` and `CHIP_MAX_RING_DEPTH`, matching the existing `ChipWorker` / `ChipTensor` / `ChipTaskArgs`, and names the context struct for what its docstring already called it.

`SIMPLER_SCOPE` is the one that gets a macro-shaped answer rather than a role. A bare `SCOPE` does in fact compile — it is function-like, so it only expands at `SCOPE(`, and neither this tree nor the CANN headers nor pto-isa spells that token (all four runtimes build and the `a2a3sim` sweep passes with it applied; measured, not assumed). It is rejected on cost, not feasibility: a macro obeys no namespace, so naming it `SCOPE` claims an English word followed by `(` in every translation unit that includes `orchestration_api.h`, in this repo and in the orchestration sources of every consumer repo, forever. It also stops being greppable — `git grep -w SCOPE` today returns 7 hits and all of them are `=== SCOPE STACK ===` comment banners. `RT_` is not available either (CANN owns it: `RT_ERROR_NONE`, consumed by `device_runner_helpers.cpp`), and `SIMPLER_` is what the status codes took in #1963, so the orchestration macro surface now spells its owner the same way the error codes do.

Two clusters move as a unit rather than one identifier at a time, because splitting them would leave the two spellings on adjacent lines of the same declaration: `SIMPLER_SCOPE` with its `ScopeGuard` / `_SIMPLER_CONCATENATE` implementation, and `RuntimeContext` with the `RuntimeOps` table it carries as its first field (plus `RuntimeMode`, `RuntimeArenaLayout`).

Two of the new names were already in the tree as prose: `RuntimeArenaLayout` was the gtest suite name in both `test_shared_memory.cpp` copies, and the shared-memory layout diagrams have long written the slot arrays with the prefix stripped. The diagrams stay as they are for now — they strip it from all three arrays uniformly, so they move as one piece when `PTO2TaskDescriptor` / `PTO2TaskPayload` land.

Tier-A brand prose in the touched files goes with commit 4: the `PTO Runtime2 - Main Interface` / `- Orchestrator Interface` / `- Main Implementation` banners, two `static_assert` messages, and the title and overview of both `tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md` copies, which now name the runtime the way the `host_build_graph` copies already do. Those two copies had drifted apart on a `(PTO2)` heading suffix; they agree again.

## Base

Rebased onto #1968 / #1925, and before that onto #1965. That last merge is why commit 5 is here at all: `PTO2_MAX_RING_DEPTH` had 148 lines of overlap with it while it was open, and after it landed the macro is defined only in the two `tensormap_and_ringbuffer` copies — `host_build_graph` carries no ring dimension — so the rename is smaller and no longer collides with in-flight work. Both rebases conflicted (the `scheduler_cold_path.cpp` / `shared_memory.cpp` / `runtime_core.h` / `runtime_init.cpp` / `runtime_maker.cpp` pairs against #1965; `orchestrator.cpp` / `scheduler.h` / `types.h` and one troubleshooting doc against #1968). Every one was resolved the same way — discard our side of the file, take upstream's, re-run the rename over it — so no upstream restructuring is dropped and the resolution is not hand-authored. #1968 also introduced two *new* `PTO2Runtime` / `PTO2_SCOPE` mentions in a `runtime_core.h` comment after this branch was cut; they are absorbed into the commit that owns each identifier, so the count still only goes down.

## Remaining surface

**5862 occurrences across 319 files**, led by `PTO2ResourceShape` (368), `PTO2TaskPayload` (309), `PTO2SchedulerState` (305), `PTO2TensorMapEntry` (224), `PTO2_ALIGN_SIZE` (216). Given what this PR found, expect more of the collisions above rather than fewer as the chip-runtime structs get closer to the host orchestrator's vocabulary — each needs a name decided, not a prefix deleted.

## Cross-repo

Every identifier here is reachable from orchestration sources outside this repo — `SIMPLER_SCOPE` is typed directly in orchestration code and `RuntimeContext *rt` is the handle every entry point takes. This lands **without compatibility aliases** by the same explicit decision as #1963 and #1966; the matching renames and the merge order are coordinated outside this PR.

⚠️ At 323 files this is past the bot reviewer's 100-file limit, so expect it to skip the review as it did on #1963. That is a real cost of mechanical renames at this scale and the reason each commit is separately reviewable.

## Testing

All on this box, at the final commit, after `pip install --no-build-isolation -e .`:

- [x] all four runtime variants build
- [x] `a2a3sim` scene sweep — 59 passed, 8 skipped
- [x] `a5sim` scene sweep — 52 passed
- [x] `a2a3` onboard sweep (`-m "not sdma" --exclude-level 4`) — 153 passed, 1 skipped
- [x] `a2a3` quarantined SDMA step — 2 passed
- [x] cpput — 117/117; hardware-labelled `test_comm_lifecycle` — 1/1
- [x] pyut — 1897 passed, 14 skipped, plus one pre-existing failure: `test_second_child_failure_reaps_first` is the open flake in #1948 (a SIGTERM-vs-`os._exit` race in `_forked_child_main`). It passes alone, reproduces 2/2 in the full sweep here, and the whole path it exercises — `python/simpler/worker.py`, the test, `conftest.py` — is byte-identical to `upstream/main` on this branch. Two more occurrences appended to that issue.
- [x] `clang-format --dry-run --Werror`, `ruff`, `markdownlint-cli2` clean over all 323 changed files
