### PR TITLE
Fix: reject unsupported paged-attention shapes before hardware submission

### DIFF
--- a/examples/a2a3/host_build_graph/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
+++ b/examples/a2a3/host_build_graph/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
@@ -110,6 +110,7 @@ class TestPagedAttentionUnrollManualScopeHostBuildGraph(SceneTestCase):
     ]
 
     def generate_args(self, params):
+        params = {**params, "variant": "paged_attention_unroll"}
         result = _pa_generate_inputs(params)
         specs = []
         for name, value in result:

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
@@ -108,6 +108,7 @@ class TestPagedAttentionUnrollManualScope(SceneTestCase):
     ]
 
     def generate_args(self, params):
+        params = {**params, "variant": "paged_attention_unroll"}
         inputs = _pa_generate_inputs(params)
         specs = []
         for name, val in inputs:

--- a/examples/a5/host_build_graph/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
+++ b/examples/a5/host_build_graph/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
@@ -97,6 +97,7 @@ class TestPagedAttentionUnrollManualScopeHostBuildGraph(SceneTestCase):
     ]
 
     def generate_args(self, params):
+        params = {**params, "variant": "paged_attention_unroll"}
         inputs = _pa_generate_inputs(params)
         specs = []
         for name, val in inputs:

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/test_paged_attention_unroll_manual_scope.py
@@ -140,6 +140,7 @@ class TestPagedAttentionUnrollManualScope(SceneTestCase):
     ]
 
     def generate_args(self, params):
+        params = {**params, "variant": "paged_attention_unroll"}
         inputs = _pa_generate_inputs(params)
         specs = []
         for name, val in inputs:

--- a/simpler_setup/goldens/paged_attention.py
+++ b/simpler_setup/goldens/paged_attention.py
@@ -27,6 +27,46 @@ import ctypes
 import torch
 
 
+def assert_supported_shape(params: dict, variant: str) -> None:
+    """Reject (q_tile, head_dim, block_size) tuples the kernels silently miscompute.
+
+    The QK/PV/online-update kernels dispatch on runtime tensor shapes but their
+    fallback arm hardcodes (64, 128, 64): an unsupported tuple computes a wrong
+    answer with no diagnostic (issue #1832's months-late ``max_diff ~= 1.0``),
+    so the shape contract is enforced here, before any hardware submission.
+
+    q_tile derives from num_heads exactly as the orchestrations do
+    (``min(num_heads, 128)``); variants differ only in which tuples their
+    kernel copies instantiate.
+    """
+    num_heads = params["num_heads"]
+    head_dim = params["head_dim"]
+    block_size = params["block_size"]
+    q_tile = min(num_heads, 128)
+    shape = (q_tile, head_dim, block_size)
+    if variant == "paged_attention":
+        supported = (q_tile == 16 and head_dim <= 16 and block_size <= 16) or shape == (16, 128, 128)
+    elif variant == "paged_attention_unroll":
+        supported = shape == (16, 128, 128)
+    else:
+        raise ValueError(f"unknown paged-attention variant: {variant}")
+    supported = supported or shape in {
+        (64, 128, 64),
+        (64, 256, 64),
+    }
+    supported = supported or (q_tile, head_dim, block_size) in {
+        (64, 128, 64),
+        (64, 256, 64),
+    }
+    if not supported:
+        raise ValueError(
+            f"unsupported paged-attention shape (q_tile={q_tile}, head_dim={head_dim}, "
+            f"block_size={block_size}) for variant '{variant}': the kernels have no "
+            "matching dispatch arm and would silently compute a wrong result; extend "
+            "the kernel dispatch (and this table) first"
+        )
+
+
 def generate_inputs(params: dict) -> list:
     """Generate input tensors and zeroed output tensor.
 
@@ -35,6 +75,7 @@ def generate_inputs(params: dict) -> list:
                 block_size, context_len, max_model_len, dtype.
                 Optional: context_lens_list (for variable sequence lengths).
     """
+    assert_supported_shape(params, params.get("variant", "paged_attention"))
     batch = params["batch"]
     num_heads = params["num_heads"]
     kv_head_num = params["kv_head_num"]

--- a/tests/st/a2a3/host_build_graph/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a2a3/host_build_graph/paged_attention_unroll/test_paged_attention_unroll.py
@@ -110,6 +110,7 @@ class TestPagedAttentionUnrollHostBuildGraph(SceneTestCase):
     ]
 
     def generate_args(self, params):
+        params = {**params, "variant": "paged_attention_unroll"}
         result = _pa_generate_inputs(params)
         specs = []
         for name, value in result:

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
@@ -108,6 +108,7 @@ class TestPagedAttentionUnroll(SceneTestCase):
     ]
 
     def generate_args(self, params):
+        params = {**params, "variant": "paged_attention_unroll"}
         result = _pa_generate_inputs(params)
         specs = []
         for name, value in result:

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/test_paged_attention_unroll_4dims.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/test_paged_attention_unroll_4dims.py
@@ -111,6 +111,7 @@ class TestPagedAttentionUnroll4dims(SceneTestCase):
     ]
 
     def generate_args(self, params):
+        params = {**params, "variant": "paged_attention_unroll"}
         inputs = _pa_generate_inputs(params)
         batch = params["batch"]
         num_heads = params["num_heads"]

--- a/tests/st/a5/host_build_graph/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a5/host_build_graph/paged_attention_unroll/test_paged_attention_unroll.py
@@ -95,6 +95,7 @@ class TestPagedAttentionUnrollHostBuildGraph(SceneTestCase):
     ]
 
     def generate_args(self, params):
+        params = {**params, "variant": "paged_attention_unroll"}
         result = _pa_generate_inputs(params)
         specs = []
         for name, value in result:

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
@@ -108,6 +108,7 @@ class TestPagedAttentionUnroll(SceneTestCase):
     ]
 
     def generate_args(self, params):
+        params = {**params, "variant": "paged_attention_unroll"}
         result = _pa_generate_inputs(params)
         specs = []
         for name, value in result:

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll_4dims/test_paged_attention_unroll_4dims.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll_4dims/test_paged_attention_unroll_4dims.py
@@ -112,6 +112,7 @@ class TestPagedAttentionUnroll4dims(SceneTestCase):
     ]
 
     def generate_args(self, params):
+        params = {**params, "variant": "paged_attention_unroll"}
         inputs = _pa_generate_inputs(params)
         batch = params["batch"]
         num_heads = params["num_heads"]


### PR DESCRIPTION
## Summary

- Add `assert_supported_shape()` to the shared paged-attention goldens module (`simpler_setup/goldens/paged_attention.py`) and call it from `generate_inputs()`, so every scene that uses the shared generator validates its shape before any device work.
- The unroll-family scenes (kernels without the 16×16 small-shape arm) pass `variant="paged_attention_unroll"` from `generate_args`; all other variants use the default.

## Problem

Follow-up to #1925 (part of #1832). The QK/PV/online-update kernels dispatch on runtime tensor shapes, but:

- the fallback arm hardcodes `(q_tile=64, head_dim=128, block_size=64)` — it *assumes*, not checks;
- the `q_tile_size == 16` arm never consults `head_dim`.

A case with an unsupported tuple — `head_dim=192/512`, `head_dim=256, block_size=128`, or the `(16, 256)` corner — compiles fine, runs fine, and **silently computes a wrong result**. That failure mode is exactly how #1832 surfaced months late as a bare `max_diff ~= 1.0` in a Daily run. #1925 fixed the `Case3` dispatch but deliberately kept this property (out of scope per review discussion); this PR closes the gap on the Python side, where the failure becomes a loud `ValueError` naming the tuple and the fix direction, before any hardware submission.

## Shape table

`q_tile` derives from `num_heads` exactly as the orchestrations do (`min(num_heads, 128)`).

| Variant | Supported `(q_tile, head_dim, block_size)` |
| --- | --- |
| `paged_attention` (default) | `(16, ≤16, ≤16)`, `(16, 128, 128)`, `(64, 128, 64)`, `(64, 256, 64)` |
| `paged_attention_unroll` | `(16, 128, 128)`, `(64, 128, 64)`, `(64, 256, 64)` |

The table matches the actual kernel dispatch arms verified across all 24 scene files that reference the dispatch kernels (local copies and `TMR_CASE`/`_PA_KERNELS` references resolved individually). The SPMD variants use a different mix-kernel dispatch (fixed `HEAD_DIM=128`, no runtime fallback) and are out of scope.

## Verification

- Unit-checked the helper: 7 supported tuples pass, 6 unsupported tuples (including `(16, 256)` and `head_dim=192/512`) raise.
- Dry-ran the assertion against **all 102 existing case params across the 24 scene files — zero false rejections**.
- End-to-end negative test: mutated `Case1` to `head_dim=192` → pytest fails in `generate_args` with `unsupported paged-attention shape (q_tile=16, head_dim=192, block_size=128) ... extend the kernel dispatch (and this table) first` — no device touched.
- Positive smoke on `a2a3sim`: `batch_paged_attention` and `multi_round_paged_attention` pass with `--manual include`.
- Pre-commit hooks all pass.

Part of #1832.

🤖 Generated with [Claude Code](https://claude.com/claude-code)