### PR TITLE
Fix: prefer staging views for host tensor access

### DIFF
--- a/docs/dfx/hbg-bind-phases.md
+++ b/docs/dfx/hbg-bind-phases.md
@@ -25,18 +25,19 @@ line per segment per bind at `LOG_TIMING`:
 
 | Segment | What it covers |
 | ------- | -------------- |
-| `args` | staging the caller's host tensors and mapping them for host access |
+| `args` | staging readable caller tensors H2D and exposing their existing host buffers to orchestration; pure outputs skip both |
 | `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init` | arena layout, GM heap and shared-memory bring-up |
 | `host_orch` | **all** orchestration: every task submitted, every Graph node recorded, the Definition built |
 | `graph_upload` | one H2D of the block holding every Definition object, and binding each Graph task to the one with its key. The recorders built the objects in that block's host staging during `host_orch`, so this segment writes their headers and copies in only what did not fit |
 | `arena_h2d` | one H2D of the arena's copied zone and the shared-memory image |
-| `host_view_close` | unmapping the host views taken in `args` |
+| `host_view_close` | closing per-run tensor-access regions and any optional device mappings; the current bind path installs none (`count=0 bytes=0`) |
 
 The **control plane** is `host_orch + graph_upload + relocate + sm_h2d +
 arena_h2d`: everything between "the caller's data is in place" and "the device
-can start". It is what the < 1 ms target applies to. `args` and
-`host_view_close` are excluded — they scale with the caller's tensor bytes, not
-with the graph.
+can start". It is what the < 1 ms target applies to. `args` is excluded because
+it scales with the caller's tensor bytes, not with the graph. `host_view_close`
+stays excluded so current reports remain comparable with older logs, although
+the current bind path has no device mappings to close.
 
 **Two of those five are retired kinds a current run does not emit.** `relocate`
 and `sm_h2d` date from when the shared-memory image was relocated and copied on
@@ -47,9 +48,8 @@ as absent from every bind. The table above is what a current run emits: ten
 segments, three of them control plane.
 
 **The control plane is a sum of costs, not an interval.** `arena_h2d` runs
-*after* `host_view_close`, hundreds of milliseconds later, so the segments do not
-form one contiguous window. Sum the ones the bind has; do not subtract two
-timestamps.
+*after* `host_view_close`, so the segments do not form one contiguous window.
+Sum the ones the bind has; do not subtract two timestamps.
 
 ## Prerequisites
 
@@ -359,7 +359,7 @@ meant to outlive it.
 | `heap_used` | 127,673,344 | 2,038,508,544 |
 | device wall | 39.3 ms | does not complete yet (`sched_error_code=5 INVALID_ARGS`) |
 | `args` (excluded) | 1.37 s / 40.9 GB, 19 of 20 staged | 1.48 s / 45.8 GB, 77 of 92 staged |
-| `host_view_close` (excluded) | 0.25 s / 40.9 GB | 0.28 s / 45.8 GB |
+| `host_view_close` (excluded, legacy mapping path) | 0.25 s / 40.9 GB | 0.28 s / 45.8 GB |
 
 † The three upload rows are the markers as they read at that commit, before the
 upload was restructured: `graph_upload`'s `bytes=` then also counted the Graph
@@ -374,21 +374,29 @@ scale.** Both are per-byte costs over what a bind stages, and dsv4's parameters
 now live in child memory: allocated once before the first round, and passed
 through without malloc, H2D or a host view. What still crosses is
 `num_tokens_per_owner`, the one caller tensor the host orchestrator has to read —
-so a bind stages **1 of its 92 tensors, 8 bytes**, and closes one host view over
-the same 8 bytes. Measured with the same recipe on `f830f13c3` plus that change,
-6 rounds on two dies: `args` 0.045–0.074 ms and `host_view_close`
-0.014–0.028 ms, against 1.48 s and 0.28 s over 45.8 GB above. qwen still stages
-its fixture and its two rows still read as in the table.
+so a bind stages **1 of its 92 tensors, 8 bytes**. Before the caller-buffer view
+change, the same recipe on `f830f13c3` plus the child-memory change measured
+`args` at 0.045–0.074 ms and `host_view_close` at 0.014–0.028 ms, against 1.48 s
+and 0.28 s over 45.8 GB above. qwen still stages its fixture.
+
+The rows also describe the legacy mapping behavior at the pinned commit. A
+current bind uses the caller's existing host buffers as its
+orchestration views, so it performs no `halHostRegister` calls and reports
+`host_view_close count=0 bytes=0`. On Qwen3-14B this makes the close marker
+20.12–24.73 us instead of the 0.25 s shown above. The old `args` figure included
+20 registrations in addition to staging 19 tensors H2D; current `args` retains
+the H2D work but removes that registration side.
 
 Three of these deserve reading together. `host_orch` is the whole story on dsv4 —
 839 `submit_task`, 743 `record_node` and 272 `alloc_tensors` per bind against qwen's
 5, 277 and 2 — and its 2.3 ms of scatter is why a claim about it needs a
-sub-counter rather than a stopwatch. `args` plus `host_view_close` are two orders of
-magnitude above everything else while being excluded from the control plane: they
-are per-byte costs over the ~41–46 GB of weights each case staged at that commit,
-so they belong to getting the weights resident, not to dispatching a graph —
-which is why moving dsv4's parameters to child memory left its bind staging one
-8-byte tensor rather than 45.8 GB. And dsv4's device wall is absent because the
-case did not complete on device on that commit — it is a completion case with no
-golden whose host path is what these numbers describe, which is also why
+sub-counter rather than a stopwatch. At the pinned commit, `args` plus
+`host_view_close` are two orders of magnitude above everything else while being
+excluded from the control plane: they are staging and legacy mapping costs over
+the ~41–46 GB of weights, not graph dispatch. Current qwen runs retain the
+staging cost in `args` but close no mappings; moving dsv4's parameters to child
+memory left its bind staging one 8-byte tensor, whose caller-buffer view also
+needs no mapping. And dsv4's device wall is absent because the case did not
+complete on device at the pinned commit — it is a completion case with no golden
+whose host path is what these numbers describe, which is also why
 `SIMPLER_SKIP_DEVICE_RUN` appears in its recipe.

--- a/docs/investigations/2026-08-hbg-graph-block-decomposition.md
+++ b/docs/investigations/2026-08-hbg-graph-block-decomposition.md
@@ -182,11 +182,13 @@ The stage this was aimed at is still not where the case's host time lives.
 `record_node` + `build_definition` + `graph_upload` are rebuilt from scratch on
 every run because the Definition cache lives in the per-run `GraphHostState`:
 roughly half the host prepare path re-deriving artifacts identical to the
-previous run's. And the `bind` stage as a whole is dominated by neither, at
-**2.65 s** for `args` (staging this network's weights) and 312 ms for
-`host_view_close` against ~4 ms of orchestration — the orchestration window is
-the interesting number only because the weight staging is a fixture artifact a
-serving loop would pay once.
+previous run's. And at the measured commit the `bind` stage as a whole is
+dominated by neither, at **2.65 s** for `args` (staging this network's weights
+and registering their device buffers) and 312 ms for `host_view_close` against
+~4 ms of orchestration. The staging-view change later removed those per-tensor
+registrations, so current runs report `host_view_close count=0 bytes=0`; the
+remaining weight-staging cost is still a fixture artifact a serving loop would
+pay once.
 
 ## What is still open
 

--- a/examples/a2a3/host_build_graph/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a2a3/host_build_graph/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -52,11 +52,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const simpler::hbg::Tensor &ext_config = orch_args.tensor(3).ref();
 
     // Read config from tensor data: [tile_size, grid_k, num_groups, incore_loop]
-    int64_t *host_config = orch_args.tensor(3).ref().data_as<int64_t>();
-    int tile_size = static_cast<int>(host_config[0]);
-    int grid_k = static_cast<int>(host_config[1]);
-    int num_groups = static_cast<int>(host_config[2]);
-    int incore_loop = static_cast<int>(host_config[3]);
+    uint32_t config_idx[1] = {0};
+    int tile_size = static_cast<int>(get_tensor_data<int64_t>(ext_config, 1, config_idx));
+    config_idx[0]++;
+    int grid_k = static_cast<int>(get_tensor_data<int64_t>(ext_config, 1, config_idx));
+    config_idx[0]++;
+    int num_groups = static_cast<int>(get_tensor_data<int64_t>(ext_config, 1, config_idx));
+    config_idx[0]++;
+    int incore_loop = static_cast<int>(get_tensor_data<int64_t>(ext_config, 1, config_idx));
     uint64_t tile_elems = static_cast<uint64_t>(tile_size) * tile_size;
 
     int grid_m = 1;

--- a/simpler_setup/tools/hbg_bind_phases.py
+++ b/simpler_setup/tools/hbg_bind_phases.py
@@ -28,8 +28,8 @@ PHASE_LINE = re.compile(r"bind phase=(\w+) start_ns=(\d+) dur_ns=(\d+)")
 STAMP_LINE = re.compile(r"^\[stamp\] (.*)$")
 
 # The segments between "the caller's data is in place" and "the device can run".
-# `args` and `host_view_close` are per-byte costs over the weights the case
-# stages, so they belong to getting the weights resident, not to dispatch.
+# `args` is a per-byte staging cost. `host_view_close` remains excluded for
+# comparison with historical mapped-view logs; current binds close no mappings.
 CONTROL_PLANE = ("host_orch", "graph_upload", "relocate", "sm_h2d", "arena_h2d")
 
 # Display order: the bind stage's own sequence, so a reader can follow it down.

--- a/src/a2a3/runtime/host_build_graph/host/host_tensor_access.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/host_tensor_access.cpp
@@ -26,9 +26,9 @@ struct HostTensorRegion {
     uint64_t dev_base;
     uint64_t size;
     unsigned char *host_view;
-    // The host view is a copy of the device bytes rather than the device bytes
-    // themselves, so a write reaches the device only once pushed back.
-    bool mirrored;
+    // A caller-buffer fallback needs a push-back. A platform mapping writes
+    // the device allocation directly, even when its host VA differs.
+    bool needs_push_back;
 };
 
 // One entry per tensor staged for the run being orchestrated. A run stages a
@@ -72,23 +72,23 @@ bool HostTensorAccessor::add(uint64_t dev_base, uint64_t size, void *fallback_ho
     if (impl_->api == nullptr || dev_base == 0 || size == 0) {
         return false;
     }
-    // Both push_backs below run after the registration succeeds, so reserve
-    // first: a reallocation that threw there would leak the mapping.
     impl_->regions.reserve(impl_->regions.size() + 1);
-    impl_->mappings.reserve(impl_->mappings.size() + 1);
-    void *host_view = impl_->api->register_device_memory_to_host(reinterpret_cast<void *>(dev_base), size);
-    if (host_view != nullptr) {
-        impl_->mappings.push_back(reinterpret_cast<void *>(dev_base));
-        impl_->mapped_bytes += size;
-    } else {
-        host_view = fallback_host_view;
+    const bool needs_push_back = fallback_host_view != nullptr;
+    void *host_view = fallback_host_view;
+    if (host_view == nullptr) {
+        // Reserve before registration: a later reallocation that threw would
+        // leak the mapping.
+        impl_->mappings.reserve(impl_->mappings.size() + 1);
+        host_view = impl_->api->register_device_memory_to_host(reinterpret_cast<void *>(dev_base), size);
+        if (host_view != nullptr) {
+            impl_->mappings.push_back(reinterpret_cast<void *>(dev_base));
+            impl_->mapped_bytes += size;
+        }
     }
     if (host_view == nullptr) {
         return false;
     }
-    impl_->regions.push_back(
-        {dev_base, size, static_cast<unsigned char *>(host_view), reinterpret_cast<uintptr_t>(host_view) != dev_base}
-    );
+    impl_->regions.push_back({dev_base, size, static_cast<unsigned char *>(host_view), needs_push_back});
     return true;
 }
 
@@ -110,7 +110,7 @@ bool HostTensorAccessor::write(uint64_t dev_addr, const void *src, uint64_t byte
     }
     unsigned char *dst = region->host_view + offset;
     memcpy(dst, src, bytes);
-    if (!region->mirrored) {
+    if (!region->needs_push_back) {
         return true;
     }
     return impl_->api->copy_to_device(reinterpret_cast<void *>(dev_addr), dst, static_cast<size_t>(bytes)) == 0;

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -1070,16 +1070,13 @@ extern "C" int bind_callable_to_runtime_impl(
         LOG_DEBUG("  ChipTensor %d: %zu bytes at %p", i, size, dev_ptr);
 
         // host_build_graph runs the orchestrator on the host, which may read
-        // control tensors (e.g. paged_attention's context_lens/block_table) via
-        // get_tensor_data to shape the graph. Give it a host view of this
-        // buffer: the device buffer itself where the platform can map it into
-        // the host address space (released in validate_runtime_impl before
-        // device_free), otherwise the staging copy, which holds the same bytes
-        // for the whole orchestration window and whose writes are pushed back
-        // to the device. A tensor with neither is not host-accessible, so the
-        // prepare fails here rather than the orchestrator dereferencing a
-        // device address.
-        if (!tensor_access.add(reinterpret_cast<uint64_t>(dev_ptr), size, host_ptr)) {
+        // staged control tensors (e.g. paged_attention's context_lens and
+        // block_table) via get_tensor_data to shape the graph. A pure output
+        // has no valid readable bytes before execution, and a5 cannot map it;
+        // exposing its caller buffer would therefore make reads unsafe. Leave
+        // it unregistered so both get_tensor_data and set_tensor_data fail
+        // closed during orchestration.
+        if (!is_pure_output && !tensor_access.add(reinterpret_cast<uint64_t>(dev_ptr), size, host_ptr)) {
             LOG_ERROR("host-orch: no host view for tensor %d (dev_ptr %p, %zu bytes)", i, dev_ptr, size);
             return PTO_RUNTIME_ERR_INTERNAL;
         }

--- a/src/a2a3/runtime/host_build_graph/runtime/host_tensor_access.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/host_tensor_access.h
@@ -20,25 +20,32 @@
  * that capability is resolved, so the orchestrator core never dereferences a
  * device address itself.
  *
- * A region is registered per staged tensor with the host address serving it:
+ * The current bind path registers one region per staged tensor, backed by the
+ * caller's host tensor buffer:
  *
- *   - `host_view == dev_base`  — the device buffer is mapped into the host
- *     address space (a2a3 `halHostRegister(DEV_SVM_MAP_HOST)`; sim, where a
- *     device pointer is already a host pointer). Reads and writes land on the
- *     device bytes directly.
- *   - `host_view != dev_base`  — no host mapping exists. The region is served
- *     from the staging buffer holding the same bytes, and a write is pushed
- *     back through the device-copy hook so the device observes it.
+ *   - A read observes that caller buffer.
+ *   - A write mutates that caller buffer, then uses the device-copy hook so the
+ *     device observes it too. This is visible even for an `IN` argument if its
+ *     host orchestration calls `set_tensor_data`.
+ *
+ * `add` also retains a null-fallback platform path: it asks the platform for a
+ * host-readable mapping whose address may equal or differ from `dev_base`, and
+ * always accesses the returned address. The current runtime-maker path cannot
+ * reach it: staged tensors always have the caller buffer, while pure outputs
+ * are deliberately left unregistered. The path remains as an explicit
+ * platform-capability escape hatch in `add` and is covered directly by unit
+ * tests; no current production caller reaches it.
  *
  * An address no registered region covers is a failure, never a raw
- * dereference: only tensors the runtime staged have a host view at all, so a
- * GM-heap tensor or a pass-through child-memory buffer resolves to nothing.
+ * dereference. Pure outputs, GM-heap tensors and pass-through child-memory
+ * buffers have no region, so both reads and writes resolve to nothing.
  *
- * Registrations are owned by one orchestration run — the window between
- * staging and the first dispatched task. A mirror is a copy, and nothing has
- * executed yet to make it stale; once tasks run, a stale mirror would be
- * indistinguishable from live device memory. `HostTensorAccessor` bounds that
- * window and releases its mappings on every exit path.
+ * Regions and any optional mappings are owned by one orchestration run — the
+ * window between staging and the first dispatched task. A caller-buffer view
+ * holds the staged bytes, and nothing has executed yet to make it stale; once
+ * tasks run, that view would be indistinguishable from live device memory.
+ * `HostTensorAccessor` bounds the window and releases its mappings on every
+ * exit path.
  *
  * The read/write pair carries weak fallbacks in the runtime translation unit
  * (`orchestrator_core/runtime_core.cpp`) that dereference `dev_addr` directly,
@@ -55,8 +62,8 @@
 struct HostApi;  // common/host_api.h — fwd-declared so this header stays out of platform includes
 
 /**
- * The registered regions of one orchestration run, and the mappings that run
- * installed to serve them.
+ * The registered regions of one orchestration run, and any optional mappings
+ * that run installed to serve them.
  *
  * One accessor per run, mutated only by the thread running that run's
  * orchestration. The region and mapping tables are plain vectors with no lock,
@@ -87,9 +94,11 @@ public:
     HostTensorAccessor &operator=(const HostTensorAccessor &) = delete;
 
     /**
-     * Register `[dev_base, dev_base + size)`, preferring a host mapping of the
-     * device buffer and falling back to `fallback_host_view` (the staging copy)
-     * when the platform cannot map it.
+     * Register `[dev_base, dev_base + size)`, using `fallback_host_view` (the
+     * caller's host tensor buffer) when available and asking the platform for a
+     * host mapping otherwise. The current runtime-maker always supplies the
+     * fallback for staged tensors and skips pure outputs, so its bind path does
+     * not install mappings.
      *
      * @return false for an empty region, a null `api`, or when neither a
      *         mapping nor a fallback view is available.

--- a/src/a5/runtime/host_build_graph/host/host_tensor_access.cpp
+++ b/src/a5/runtime/host_build_graph/host/host_tensor_access.cpp
@@ -26,9 +26,9 @@ struct HostTensorRegion {
     uint64_t dev_base;
     uint64_t size;
     unsigned char *host_view;
-    // The host view is a copy of the device bytes rather than the device bytes
-    // themselves, so a write reaches the device only once pushed back.
-    bool mirrored;
+    // A caller-buffer fallback needs a push-back. A platform mapping writes
+    // the device allocation directly, even when its host VA differs.
+    bool needs_push_back;
 };
 
 // One entry per tensor staged for the run being orchestrated. A run stages a
@@ -72,23 +72,23 @@ bool HostTensorAccessor::add(uint64_t dev_base, uint64_t size, void *fallback_ho
     if (impl_->api == nullptr || dev_base == 0 || size == 0) {
         return false;
     }
-    // Both push_backs below run after the registration succeeds, so reserve
-    // first: a reallocation that threw there would leak the mapping.
     impl_->regions.reserve(impl_->regions.size() + 1);
-    impl_->mappings.reserve(impl_->mappings.size() + 1);
-    void *host_view = impl_->api->register_device_memory_to_host(reinterpret_cast<void *>(dev_base), size);
-    if (host_view != nullptr) {
-        impl_->mappings.push_back(reinterpret_cast<void *>(dev_base));
-        impl_->mapped_bytes += size;
-    } else {
-        host_view = fallback_host_view;
+    const bool needs_push_back = fallback_host_view != nullptr;
+    void *host_view = fallback_host_view;
+    if (host_view == nullptr) {
+        // Reserve before registration: a later reallocation that threw would
+        // leak the mapping.
+        impl_->mappings.reserve(impl_->mappings.size() + 1);
+        host_view = impl_->api->register_device_memory_to_host(reinterpret_cast<void *>(dev_base), size);
+        if (host_view != nullptr) {
+            impl_->mappings.push_back(reinterpret_cast<void *>(dev_base));
+            impl_->mapped_bytes += size;
+        }
     }
     if (host_view == nullptr) {
         return false;
     }
-    impl_->regions.push_back(
-        {dev_base, size, static_cast<unsigned char *>(host_view), reinterpret_cast<uintptr_t>(host_view) != dev_base}
-    );
+    impl_->regions.push_back({dev_base, size, static_cast<unsigned char *>(host_view), needs_push_back});
     return true;
 }
 
@@ -110,7 +110,7 @@ bool HostTensorAccessor::write(uint64_t dev_addr, const void *src, uint64_t byte
     }
     unsigned char *dst = region->host_view + offset;
     memcpy(dst, src, bytes);
-    if (!region->mirrored) {
+    if (!region->needs_push_back) {
         return true;
     }
     return impl_->api->copy_to_device(reinterpret_cast<void *>(dev_addr), dst, static_cast<size_t>(bytes)) == 0;

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -1086,16 +1086,13 @@ extern "C" int bind_callable_to_runtime_impl(
         LOG_DEBUG("  ChipTensor %d: %zu bytes at %p", i, size, dev_ptr);
 
         // host_build_graph runs the orchestrator on the host, which may read
-        // control tensors (e.g. paged_attention's context_lens/block_table) via
-        // get_tensor_data to shape the graph. Give it a host view of this
-        // buffer: the device buffer itself where the platform can map it into
-        // the host address space (released in validate_runtime_impl before
-        // device_free), otherwise the staging copy, which holds the same bytes
-        // for the whole orchestration window and whose writes are pushed back
-        // to the device. A tensor with neither is not host-accessible, so the
-        // prepare fails here rather than the orchestrator dereferencing a
-        // device address.
-        if (!tensor_access.add(reinterpret_cast<uint64_t>(dev_ptr), size, host_ptr)) {
+        // staged control tensors (e.g. paged_attention's context_lens and
+        // block_table) via get_tensor_data to shape the graph. A pure output
+        // has no valid readable bytes before execution, and a5 cannot map it;
+        // exposing its caller buffer would therefore make reads unsafe. Leave
+        // it unregistered so both get_tensor_data and set_tensor_data fail
+        // closed during orchestration.
+        if (!is_pure_output && !tensor_access.add(reinterpret_cast<uint64_t>(dev_ptr), size, host_ptr)) {
             LOG_ERROR("host-orch: no host view for tensor %d (dev_ptr %p, %zu bytes)", i, dev_ptr, size);
             return PTO_RUNTIME_ERR_INTERNAL;
         }

--- a/src/a5/runtime/host_build_graph/runtime/host_tensor_access.h
+++ b/src/a5/runtime/host_build_graph/runtime/host_tensor_access.h
@@ -20,25 +20,32 @@
  * that capability is resolved, so the orchestrator core never dereferences a
  * device address itself.
  *
- * A region is registered per staged tensor with the host address serving it:
+ * The current bind path registers one region per staged tensor, backed by the
+ * caller's host tensor buffer:
  *
- *   - `host_view == dev_base`  — the device buffer is mapped into the host
- *     address space (a2a3 `halHostRegister(DEV_SVM_MAP_HOST)`; sim, where a
- *     device pointer is already a host pointer). Reads and writes land on the
- *     device bytes directly.
- *   - `host_view != dev_base`  — no host mapping exists. The region is served
- *     from the staging buffer holding the same bytes, and a write is pushed
- *     back through the device-copy hook so the device observes it.
+ *   - A read observes that caller buffer.
+ *   - A write mutates that caller buffer, then uses the device-copy hook so the
+ *     device observes it too. This is visible even for an `IN` argument if its
+ *     host orchestration calls `set_tensor_data`.
+ *
+ * `add` also retains a null-fallback platform path: it asks the platform for a
+ * host-readable mapping whose address may equal or differ from `dev_base`, and
+ * always accesses the returned address. The current runtime-maker path cannot
+ * reach it: staged tensors always have the caller buffer, while pure outputs
+ * are deliberately left unregistered. The path remains as an explicit
+ * platform-capability escape hatch in `add` and is covered directly by unit
+ * tests; no current production caller reaches it.
  *
  * An address no registered region covers is a failure, never a raw
- * dereference: only tensors the runtime staged have a host view at all, so a
- * GM-heap tensor or a pass-through child-memory buffer resolves to nothing.
+ * dereference. Pure outputs, GM-heap tensors and pass-through child-memory
+ * buffers have no region, so both reads and writes resolve to nothing.
  *
- * Registrations are owned by one orchestration run — the window between
- * staging and the first dispatched task. A mirror is a copy, and nothing has
- * executed yet to make it stale; once tasks run, a stale mirror would be
- * indistinguishable from live device memory. `HostTensorAccessor` bounds that
- * window and releases its mappings on every exit path.
+ * Regions and any optional mappings are owned by one orchestration run — the
+ * window between staging and the first dispatched task. A caller-buffer view
+ * holds the staged bytes, and nothing has executed yet to make it stale; once
+ * tasks run, that view would be indistinguishable from live device memory.
+ * `HostTensorAccessor` bounds the window and releases its mappings on every
+ * exit path.
  *
  * The read/write pair carries weak fallbacks in the runtime translation unit
  * (`orchestrator_core/runtime_core.cpp`) that dereference `dev_addr` directly,
@@ -55,8 +62,8 @@
 struct HostApi;  // common/host_api.h — fwd-declared so this header stays out of platform includes
 
 /**
- * The registered regions of one orchestration run, and the mappings that run
- * installed to serve them.
+ * The registered regions of one orchestration run, and any optional mappings
+ * that run installed to serve them.
  *
  * One accessor per run, mutated only by the thread running that run's
  * orchestration. The region and mapping tables are plain vectors with no lock,
@@ -87,9 +94,11 @@ public:
     HostTensorAccessor &operator=(const HostTensorAccessor &) = delete;
 
     /**
-     * Register `[dev_base, dev_base + size)`, preferring a host mapping of the
-     * device buffer and falling back to `fallback_host_view` (the staging copy)
-     * when the platform cannot map it.
+     * Register `[dev_base, dev_base + size)`, using `fallback_host_view` (the
+     * caller's host tensor buffer) when available and asking the platform for a
+     * host mapping otherwise. The current runtime-maker always supplies the
+     * fallback for staged tensors and skips pure outputs, so its bind path does
+     * not install mappings.
      *
      * @return false for an empty region, a null `api`, or when neither a
      *         mapping nor a fallback view is available.

--- a/tests/ut/cpp/a2a3/test_hbg_tensor_access.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_tensor_access.cpp
@@ -13,11 +13,9 @@
  * Host-view resolution for the host orchestrator's tensor reads and writes,
  * and the per-run ownership of the mappings that serve them.
  *
- * The mirror path (a platform that cannot map device memory into the host
- * address space) has no reachable call site on a2a3, whose SVM map always
- * succeeds, so these tests are the only place it executes. `g_registered_view`
- * is what the fake `register_device_memory_to_host` hands back: null models a
- * platform with no mapping, so `add` falls back to the staging view.
+ * The fallback path serves staged tensors without mapping their device
+ * allocations. `g_registered_view` is what the fake
+ * `register_device_memory_to_host` hands back when no fallback is available.
  */
 
 #include <gtest/gtest.h>
@@ -46,6 +44,7 @@ struct CopyCall {
 std::vector<CopyCall> g_copies;
 std::vector<void *> g_unregistered;
 void *g_registered_view = nullptr;
+int g_register_count = 0;
 int g_copy_result = 0;
 
 int record_copy(void *, void *dev_ptr, const void *host_ptr, size_t size) {
@@ -53,7 +52,10 @@ int record_copy(void *, void *dev_ptr, const void *host_ptr, size_t size) {
     return g_copy_result;
 }
 
-void *record_register(void *, void *, size_t) { return g_registered_view; }
+void *record_register(void *, void *, size_t) {
+    ++g_register_count;
+    return g_registered_view;
+}
 
 void record_unregister(void *, void *dev_ptr) { g_unregistered.push_back(dev_ptr); }
 
@@ -70,31 +72,55 @@ protected:
         g_copies.clear();
         g_unregistered.clear();
         g_registered_view = nullptr;
+        g_register_count = 0;
         g_copy_result = 0;
     }
 };
 
-TEST_F(HostTensorAccessTest, DirectRegionReadsAndWritesInPlace) {
+TEST_F(HostTensorAccessTest, MissingFallbackUsesReturnedDeviceMappingAddress) {
     int32_t buffer[4] = {10, 20, 30, 40};
-    const uint64_t base = reinterpret_cast<uint64_t>(buffer);
     g_registered_view = buffer;
     HostTensorAccessor accessor(&kHostApi);
-    ASSERT_TRUE(accessor.add(base, sizeof(buffer), nullptr));
+    ASSERT_TRUE(accessor.add(kFakeDeviceBase, sizeof(buffer), nullptr));
+    EXPECT_EQ(g_register_count, 1);
+    EXPECT_EQ(accessor.mapping_count(), 1u);
+    EXPECT_EQ(accessor.mapped_bytes(), sizeof(buffer));
 
     int32_t value = 0;
-    ASSERT_TRUE(host_tensor_read(&accessor, base + 2 * sizeof(int32_t), &value, sizeof(value)));
+    ASSERT_TRUE(host_tensor_read(&accessor, kFakeDeviceBase + 2 * sizeof(int32_t), &value, sizeof(value)));
     EXPECT_EQ(value, 30);
 
     const int32_t written = 99;
-    ASSERT_TRUE(host_tensor_write(&accessor, base + sizeof(int32_t), &written, sizeof(written)));
+    ASSERT_TRUE(host_tensor_write(&accessor, kFakeDeviceBase + sizeof(int32_t), &written, sizeof(written)));
     EXPECT_EQ(buffer[1], 99);
     EXPECT_TRUE(g_copies.empty());
+
+    accessor.close();
+    EXPECT_EQ(g_unregistered, std::vector<void *>{reinterpret_cast<void *>(kFakeDeviceBase)});
 }
 
-TEST_F(HostTensorAccessTest, MirroredRegionReadsAndPushesWrites) {
-    int32_t mirror[4] = {1, 2, 3, 4};
+TEST_F(HostTensorAccessTest, FallbackViewAvoidsDeviceMapping) {
+    int32_t fallback[2] = {1, 2};
+    int32_t mapped[2] = {3, 4};
+    g_registered_view = mapped;
     HostTensorAccessor accessor(&kHostApi);
-    ASSERT_TRUE(accessor.add(kFakeDeviceBase, sizeof(mirror), mirror));
+    ASSERT_TRUE(accessor.add(kFakeDeviceBase, sizeof(fallback), fallback));
+
+    EXPECT_EQ(g_register_count, 0);
+    EXPECT_EQ(accessor.mapping_count(), 0u);
+    EXPECT_EQ(accessor.mapped_bytes(), 0u);
+    int32_t value = 0;
+    ASSERT_TRUE(host_tensor_read(&accessor, kFakeDeviceBase, &value, sizeof(value)));
+    EXPECT_EQ(value, 1);
+
+    accessor.close();
+    EXPECT_TRUE(g_unregistered.empty());
+}
+
+TEST_F(HostTensorAccessTest, FallbackWriteMutatesCallerBufferAndPushesToDevice) {
+    int32_t fallback[4] = {1, 2, 3, 4};
+    HostTensorAccessor accessor(&kHostApi);
+    ASSERT_TRUE(accessor.add(kFakeDeviceBase, sizeof(fallback), fallback));
 
     int32_t value = 0;
     ASSERT_TRUE(host_tensor_read(&accessor, kFakeDeviceBase + 3 * sizeof(int32_t), &value, sizeof(value)));
@@ -103,17 +129,17 @@ TEST_F(HostTensorAccessTest, MirroredRegionReadsAndPushesWrites) {
     const int32_t written = 77;
     const uint64_t dev_addr = kFakeDeviceBase + 2 * sizeof(int32_t);
     ASSERT_TRUE(host_tensor_write(&accessor, dev_addr, &written, sizeof(written)));
-    EXPECT_EQ(mirror[2], 77);
+    EXPECT_EQ(fallback[2], 77);
     ASSERT_EQ(g_copies.size(), 1u);
     EXPECT_EQ(g_copies[0].dev_ptr, reinterpret_cast<void *>(dev_addr));
-    EXPECT_EQ(g_copies[0].host_ptr, static_cast<const void *>(&mirror[2]));
+    EXPECT_EQ(g_copies[0].host_ptr, static_cast<const void *>(&fallback[2]));
     EXPECT_EQ(g_copies[0].size, sizeof(int32_t));
 }
 
-TEST_F(HostTensorAccessTest, MirroredWriteReportsCopyFailure) {
-    int32_t mirror[2] = {1, 2};
+TEST_F(HostTensorAccessTest, FallbackWriteReportsCopyFailure) {
+    int32_t fallback[2] = {1, 2};
     HostTensorAccessor accessor(&kHostApi);
-    ASSERT_TRUE(accessor.add(kFakeDeviceBase, sizeof(mirror), mirror));
+    ASSERT_TRUE(accessor.add(kFakeDeviceBase, sizeof(fallback), fallback));
 
     g_copy_result = -1;
     const int32_t written = 5;
@@ -121,12 +147,12 @@ TEST_F(HostTensorAccessTest, MirroredWriteReportsCopyFailure) {
 }
 
 // The fail-closed contract: an address outside every registered region — a
-// GM-heap tensor the orchestrator created, or a pass-through child-memory
+// GM-heap tensor the orchestrator created or a pass-through child-memory
 // buffer — resolves to nothing instead of being dereferenced.
 TEST_F(HostTensorAccessTest, UnregisteredSpanFailsClosed) {
-    int32_t mirror[2] = {1, 2};
+    int32_t fallback[2] = {1, 2};
     HostTensorAccessor accessor(&kHostApi);
-    ASSERT_TRUE(accessor.add(kFakeDeviceBase, sizeof(mirror), mirror));
+    ASSERT_TRUE(accessor.add(kFakeDeviceBase, sizeof(fallback), fallback));
 
     int32_t value = 0xABCD;
     EXPECT_FALSE(host_tensor_read(&accessor, kFakeDeviceBase + 0x100000, &value, sizeof(value)));
@@ -138,9 +164,9 @@ TEST_F(HostTensorAccessTest, UnregisteredSpanFailsClosed) {
 }
 
 TEST_F(HostTensorAccessTest, SpanOverrunningTheRegionFails) {
-    int32_t mirror[2] = {1, 2};
+    int32_t fallback[2] = {1, 2};
     HostTensorAccessor accessor(&kHostApi);
-    ASSERT_TRUE(accessor.add(kFakeDeviceBase, sizeof(mirror), mirror));
+    ASSERT_TRUE(accessor.add(kFakeDeviceBase, sizeof(fallback), fallback));
 
     int64_t value = 0;
     // Starts inside the region, ends past it.


### PR DESCRIPTION
## Summary
- Prefer existing caller buffers when host graph orchestration accesses staged entry tensors, removing per-tensor host registrations from the normal bind path.
- Keep the optional platform-mapping path as an explicit capability escape hatch; no current runtime-maker caller reaches it. Mapping addresses may differ from device addresses, so access always uses the returned host VA.
- Leave pure output tensors unregistered because they have no valid pre-execution bytes and a5 has no device-mapping capability; both attempted reads and writes fail closed.
- Read the shared BGEMM configuration through `get_tensor_data()` so HBG never dereferences a raw device address. This is required by the tensor-access contract, not a drive-by change.
- Keep a2a3 and a5 behavior aligned. a5 onboard already used caller-buffer fallbacks because it has no `halHostRegister` path.

## Performance
- Qwen3-14B HBG reports `host_view_close count=0 bytes=0` across four onboard rounds.
- `host_view_close` is 20.12–24.73 us instead of about 255.98 ms in the issue reproduction.
- The old `args` phase included 20 registrations plus 19 H2D copies; the current path retains the required H2D work but removes all 20 registrations.

## Testing
- [x] Pre-commit hooks passed
- [x] C++ no-hardware suite: 119/119 passed
- [x] Host tensor access regression: 1/1 passed, including distinct returned mapping VA and fallback write-back
- [x] a2a3sim HBG benchmark_bgemm: 1/1 passed
- [x] a5sim HBG benchmark_bgemm: 1/1 passed
- [x] Earlier a2a3 onboard CI regressions: paged_attention + benchmark_bgemm, 2 passed (`task_20260823_234452_297495916244`)
- [x] Earlier a2a3 onboard Qwen3-14B HBG, 4 rounds: 1 passed (`task_20260823_195845_151406924`)

Fixes #1848