### PR TITLE
Refactor: drop the TensorCreateInfo initial-value fill from tensormap_and_ringbuffer

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/scalar_data/kernels/orchestration/scalar_data_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/scalar_data/kernels/orchestration/scalar_data_orch.cpp
@@ -12,13 +12,13 @@
  * Scalar Data Dependency Test Orchestration
  *
  * End-to-end test for get_tensor_data, set_tensor_data, and add_inout
- * with runtime-created outputs and initial value support.
+ * with runtime-created outputs.
  *
  * Flow:
  *   1. c = a + b           (kernel_add, runtime-created tensor)
  *   2. get_tensor_data(c, {0})   → check[0] = 2.0
  *   3. get_tensor_data(c, {100}) → check[1] = 102.0
- *   4. scalar_tensor = add_output(TensorCreateInfo, 77.0f), submit noop
+ *   4. scalar_tensor = alloc_tensors(TensorCreateInfo), set_tensor_data(77.0f)
  *   5. get_tensor_data(scalar_tensor, {0}) → check[2] = 77.0
  *   6. add_inout(scalar_tensor) (INOUT path), submit noop
  *   7. get_tensor_data(scalar_tensor, {0}) → check[3] = 77.0
@@ -94,18 +94,21 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     set_tensor_data(ext_check, 1, check_idx, c100_val);
 
     // =========================================================
-    // Step 4: Runtime-created scalar output with initial value
-    //   Runtime allocates HeapRing buffer, writes 77.0 to element [0]
+    // Step 4: Runtime-created scalar output, seeded by orchestration
+    //   Runtime allocates HeapRing buffer; set_tensor_data writes 77.0 to
+    //   element [0]. No producer or consumer exists yet, so the write
+    //   runs without waiting.
     // =========================================================
     uint32_t scalar_shapes[1] = {1};
     TensorCreateInfo scalar_ci(scalar_shapes, 1, DataType::FLOAT32);
-    scalar_ci.set_initial_value(77.0f);
     TaskOutputTensors scalar_alloc_outs = alloc_tensors(scalar_ci);
     const ChipTensor &scalar_tensor = scalar_alloc_outs.get_ref(0);
+    uint32_t scalar_idx[1] = {0};
+    set_tensor_data(scalar_tensor, 1, scalar_idx, 77.0f);
 
     // =========================================================
     // Step 5: get_tensor_data(scalar_tensor, {0}) → check[2]
-    //   Verifies initial value was written correctly
+    //   Verifies the seeded value was written correctly
     // =========================================================
     idx[0] = 0;
     float s0_val = get_tensor_data<float>(scalar_tensor, 1, idx);

--- a/examples/a5/tensormap_and_ringbuffer/scalar_data/kernels/orchestration/scalar_data_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/scalar_data/kernels/orchestration/scalar_data_orch.cpp
@@ -12,13 +12,13 @@
  * Scalar Data Dependency Test Orchestration
  *
  * End-to-end test for get_tensor_data, set_tensor_data, and add_inout
- * with runtime-created outputs and initial value support.
+ * with runtime-created outputs.
  *
  * Flow:
  *   1. c = a + b           (kernel_add, runtime-created tensor)
  *   2. get_tensor_data(c, {0})   → check[0] = 2.0
  *   3. get_tensor_data(c, {100}) → check[1] = 102.0
- *   4. scalar_tensor = add_output(TensorCreateInfo, 77.0f), submit noop
+ *   4. scalar_tensor = alloc_tensors(TensorCreateInfo), set_tensor_data(77.0f)
  *   5. get_tensor_data(scalar_tensor, {0}) → check[2] = 77.0
  *   6. add_inout(scalar_tensor) (INOUT path), submit noop
  *   7. get_tensor_data(scalar_tensor, {0}) → check[3] = 77.0
@@ -94,18 +94,21 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     set_tensor_data(ext_check, 1, check_idx, c100_val);
 
     // =========================================================
-    // Step 4: Runtime-created scalar output with initial value
-    //   Runtime allocates HeapRing buffer, writes 77.0 to element [0]
+    // Step 4: Runtime-created scalar output, seeded by orchestration
+    //   Runtime allocates HeapRing buffer; set_tensor_data writes 77.0 to
+    //   element [0]. No producer or consumer exists yet, so the write
+    //   runs without waiting.
     // =========================================================
     uint32_t scalar_shapes[1] = {1};
     TensorCreateInfo scalar_ci(scalar_shapes, 1, DataType::FLOAT32);
-    scalar_ci.set_initial_value(77.0f);
     TaskOutputTensors scalar_alloc_outs = alloc_tensors(scalar_ci);
     const ChipTensor &scalar_tensor = scalar_alloc_outs.get_ref(0);
+    uint32_t scalar_idx[1] = {0};
+    set_tensor_data(scalar_tensor, 1, scalar_idx, 77.0f);
 
     // =========================================================
     // Step 5: get_tensor_data(scalar_tensor, {0}) → check[2]
-    //   Verifies initial value was written correctly
+    //   Verifies the seeded value was written correctly
     // =========================================================
     idx[0] = 0;
     float s0_val = get_tensor_data<float>(scalar_tensor, 1, idx);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
@@ -49,22 +49,25 @@ One extra step versus get_tensor_data: wait for all consumers to finish (`fanout
 - Threshold: `PTO2_TENSOR_DATA_TIMEOUT_CYCLES` (~10 s at 1.5 GHz)
 - On timeout: sets `orch.fatal = true`, preventing further task submission
 
-## 4. add_output with Initial Value
+## 4. Seeding a Runtime-Created Output
+
+`TensorCreateInfo` carries no initial-value fill; a fresh allocation starts
+with whatever the heap block last held. Two ways to give it defined content:
 
 ```cpp
+// Orchestration-side write: alloc returns before any producer or consumer
+// exists, so set_tensor_data finds nothing to wait for and writes at once.
+// Suited to scalars and a handful of elements; each call writes one element.
 TensorCreateInfo ci(shapes, ndims, dtype);
-ci.set_initial_value(initial_value);
-args.add_output(ci);
+TaskOutputTensors outs = alloc_tensors(ci);
+const ChipTensor &t = outs.get_ref(0);
+set_tensor_data(t, 1, idx, 42.0f);
+
+// Device-side fill: a task (a dedicated seed kernel, or a prefix of the
+// first consumer) writes the buffer. Suited to whole-buffer initialization
+// such as zeroing a large accumulator; task dependencies order every reader
+// and writer after the seed.
 ```
-
-**Mechanism**:
-
-1. `ci.set_initial_value(value)` marks the create-info with an initial value before submission
-2. `add_output(ci)` stores a pointer to `ci` in `CoreTaskArgs` (the original must remain valid until submit)
-3. During payload init, the output tensor is materialized via `init_from_create_info()` which triggers the fill
-4. Fill strategy:
-   - Small buffer (< 64 B): element-by-element memcpy directly into dst
-   - Large buffer (≥ 64 B): fill the first 64 bytes as a template block, then bulk-memcpy in 64 B chunks; partial tail copy for remainder
 
 **Constraint**: existing tensors are write targets only through `add_inout()`.
 
@@ -76,15 +79,13 @@ Traditional scalars (`CoreTaskArgs::add_scalar`) are one-way inputs with no Tens
 uint32_t shapes[1] = {1};
 TensorCreateInfo scalar_ci(shapes, 1, DataType::FLOAT32);
 
-// Submit with initial value and keep the returned tensor
-scalar_ci.set_initial_value(float_to_u64(77.0f));
-CoreTaskArgs args;
-args.add_output(scalar_ci);
-TaskOutputTensors outs = rt_submit_aiv_task(FUNC_NOOP, args);
+// Allocate, seed from orchestration, and keep the returned tensor
+TaskOutputTensors outs = alloc_tensors(scalar_ci);
 const Tensor& scalar_tensor = outs.get_ref(0);
+uint32_t idx[1] = {0};
+set_tensor_data(scalar_tensor, 1, idx, 77.0f);
 
 // Orchestration-side blocking read (waits for kernel completion)
-uint32_t idx[1] = {0};
 float val = get_tensor_data<float>(scalar_tensor, 1, idx);
 ```
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor_create_info.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor_create_info.h
@@ -14,9 +14,15 @@
  * Runtime-only: this header (and the materialization helpers below) are NOT
  * part of the wire/host-facing ChipTensor in src/common/task_interface/tensor.h.
  * It carries the metadata required to materialize a fresh contiguous output:
- * dtype, ndims, shapes, manual_dep, and an optional initial value fill. Its
- * 64B layout mirrors ChipTensor cache line 1 so init_tensor_from_create_info() can
- * copy the whole line with a single memcpy.
+ * dtype, ndims, shapes, manual_dep. Its 64B layout mirrors ChipTensor cache
+ * line 1 so init_tensor_from_create_info() can copy the whole line with a
+ * single memcpy.
+ *
+ * There is no initial-value fill. That fill ran inside the hidden alloc task
+ * where nothing could race it, but it bound the AICPU orchestrator to writing
+ * the buffer itself; an orchestration that needs a defined starting content
+ * writes it with set_tensor_data or has a task write it. See
+ * docs/SCALAR_DATA_ACCESS.md.
  */
 
 #pragma once
@@ -33,8 +39,7 @@ public:
     TensorCreateInfo(
         const uint32_t shapes_in[], uint32_t ndims_in, DataType dtype_in = DataType::FLOAT32, bool manual_dep_in = false
     ) :
-        initial_value(0),
-        has_initial_value(false),
+        __pad0__{0, 0},
         __pad2__(0),
         start_offset(0),  // mirrors ChipTensor::start_offset; pre-zeroed for create-info outputs
         version(0),
@@ -54,12 +59,6 @@ public:
 
     void copy(const TensorCreateInfo &other) { memcpy(this, &other, sizeof(other)); }
 
-    template <typename T = uint64_t>
-    void set_initial_value(T value) {
-        has_initial_value = true;
-        initial_value = to_u64(value);
-    }
-
     uint64_t buffer_size_bytes() const {
         uint64_t total = 1;
         for (uint32_t i = 0; i < ndims; i++) {
@@ -73,9 +72,7 @@ public:
     // These occupy the same positions as ChipTensor::buffer, ChipTensor::owner_task_id,
     // and ChipTensor::start_offset. The runtime overwrites owner metadata after the
     // memcpy and recomputes start_offset / stride during payload materialization.
-    uint64_t initial_value;
-    bool has_initial_value;
-    uint8_t __pad1__[7];
+    uint64_t __pad0__[2];   // → ChipTensor::buffer (overwritten post-memcpy)
     uint64_t __pad2__;      // → ChipTensor::owner_task_id (overwritten post-memcpy)
     uint64_t start_offset;  // mirrors ChipTensor::start_offset; always 0 for create-info outputs
 
@@ -93,6 +90,7 @@ public:
 
 // TensorCreateInfo layout must match ChipTensor cacheline 1 for memcpy optimization
 static_assert(sizeof(TensorCreateInfo) == 64, "TensorCreateInfo must match ChipTensor cacheline 1 size (64 bytes)");
+static_assert(offsetof(TensorCreateInfo, __pad0__) == offsetof(ChipTensor, buffer));
 static_assert(offsetof(TensorCreateInfo, start_offset) == offsetof(ChipTensor, start_offset));
 static_assert(offsetof(TensorCreateInfo, version) == offsetof(ChipTensor, version));
 static_assert(offsetof(TensorCreateInfo, ndims) == offsetof(ChipTensor, ndims));
@@ -107,24 +105,6 @@ static_assert(offsetof(TensorCreateInfo, shapes) == offsetof(ChipTensor, shapes)
 // Factored out of ChipTensor (which now lives in the wire/host-facing common
 // header) so the create-info dependency stays runtime-only.
 // ============================================================================
-
-/// Fill the entire backing buffer of `t` with `initial_value` (doubling memcpy).
-inline void fill_tensor_initial_value(ChipTensor &t, uint64_t initial_value) {
-    always_assert(reinterpret_cast<char *>(t.buffer.addr) != nullptr);
-    uint64_t elem_size = get_element_size(t.dtype);
-    char *dst = reinterpret_cast<char *>(t.buffer.addr);
-    constexpr uint64_t blk_size = 64;
-    uint64_t blk = (t.buffer.size < blk_size) ? t.buffer.size : blk_size;
-    for (uint64_t b = 0; b < blk; b += elem_size) {
-        memcpy(dst + b, &initial_value, elem_size);
-    }
-    uint64_t filled = blk;
-    while (filled < t.buffer.size) {
-        uint64_t copy_size = ((t.buffer.size - filled) < filled) ? (t.buffer.size - filled) : filled;
-        memcpy(dst + filled, dst, copy_size);
-        filled += copy_size;
-    }
-}
 
 /// Materialize a TensorCreateInfo into `t` (fresh contiguous output).
 /// Single 64B memcpy covers cache line 1; `ci` pre-initialises start_offset (=0)
@@ -141,7 +121,4 @@ inline void init_tensor_from_create_info(ChipTensor &t, const TensorCreateInfo &
         s *= t.shapes[i];
     }
     t.extent_elem_cache = s;
-    if (ci.has_initial_value) {
-        fill_tensor_initial_value(t, ci.initial_value);
-    }
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
@@ -49,22 +49,25 @@ One extra step versus get_tensor_data: wait for all consumers to finish (`fanout
 - Threshold: `PTO2_TENSOR_DATA_TIMEOUT_CYCLES` (~10 s at 1.5 GHz)
 - On timeout: sets `orch.fatal = true`, preventing further task submission
 
-## 4. add_output with Initial Value
+## 4. Seeding a Runtime-Created Output
+
+`TensorCreateInfo` carries no initial-value fill; a fresh allocation starts
+with whatever the heap block last held. Two ways to give it defined content:
 
 ```cpp
+// Orchestration-side write: alloc returns before any producer or consumer
+// exists, so set_tensor_data finds nothing to wait for and writes at once.
+// Suited to scalars and a handful of elements; each call writes one element.
 TensorCreateInfo ci(shapes, ndims, dtype);
-ci.set_initial_value(initial_value);
-args.add_output(ci);
+TaskOutputTensors outs = alloc_tensors(ci);
+const ChipTensor &t = outs.get_ref(0);
+set_tensor_data(t, 1, idx, 42.0f);
+
+// Device-side fill: a task (a dedicated seed kernel, or a prefix of the
+// first consumer) writes the buffer. Suited to whole-buffer initialization
+// such as zeroing a large accumulator; task dependencies order every reader
+// and writer after the seed.
 ```
-
-**Mechanism**:
-
-1. `ci.set_initial_value(value)` marks the create-info with an initial value before submission
-2. `add_output(ci)` stores a pointer to `ci` in `CoreTaskArgs` (the original must remain valid until submit)
-3. During payload init, the output tensor is materialized via `init_from_create_info()` which triggers the fill
-4. Fill strategy:
-   - Small buffer (< 64 B): element-by-element memcpy directly into dst
-   - Large buffer (≥ 64 B): fill the first 64 bytes as a template block, then bulk-memcpy in 64 B chunks; partial tail copy for remainder
 
 **Constraint**: existing tensors are write targets only through `add_inout()`.
 
@@ -76,15 +79,13 @@ Traditional scalars (`CoreTaskArgs::add_scalar`) are one-way inputs with no Tens
 uint32_t shapes[1] = {1};
 TensorCreateInfo scalar_ci(shapes, 1, DataType::FLOAT32);
 
-// Submit with initial value and keep the returned tensor
-scalar_ci.set_initial_value(float_to_u64(77.0f));
-CoreTaskArgs args;
-args.add_output(scalar_ci);
-TaskOutputTensors outs = rt_submit_aiv_task(FUNC_NOOP, args);
+// Allocate, seed from orchestration, and keep the returned tensor
+TaskOutputTensors outs = alloc_tensors(scalar_ci);
 const Tensor& scalar_tensor = outs.get_ref(0);
+uint32_t idx[1] = {0};
+set_tensor_data(scalar_tensor, 1, idx, 77.0f);
 
 // Orchestration-side blocking read (waits for kernel completion)
-uint32_t idx[1] = {0};
 float val = get_tensor_data<float>(scalar_tensor, 1, idx);
 ```
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor_create_info.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor_create_info.h
@@ -14,9 +14,15 @@
  * Runtime-only: this header (and the materialization helpers below) are NOT
  * part of the wire/host-facing ChipTensor in src/common/task_interface/tensor.h.
  * It carries the metadata required to materialize a fresh contiguous output:
- * dtype, ndims, shapes, manual_dep, and an optional initial value fill. Its
- * 64B layout mirrors ChipTensor cache line 1 so init_tensor_from_create_info() can
- * copy the whole line with a single memcpy.
+ * dtype, ndims, shapes, manual_dep. Its 64B layout mirrors ChipTensor cache
+ * line 1 so init_tensor_from_create_info() can copy the whole line with a
+ * single memcpy.
+ *
+ * There is no initial-value fill. That fill ran inside the hidden alloc task
+ * where nothing could race it, but it bound the AICPU orchestrator to writing
+ * the buffer itself; an orchestration that needs a defined starting content
+ * writes it with set_tensor_data or has a task write it. See
+ * docs/SCALAR_DATA_ACCESS.md.
  */
 
 #pragma once
@@ -33,8 +39,7 @@ public:
     TensorCreateInfo(
         const uint32_t shapes_in[], uint32_t ndims_in, DataType dtype_in = DataType::FLOAT32, bool manual_dep_in = false
     ) :
-        initial_value(0),
-        has_initial_value(false),
+        __pad0__{0, 0},
         __pad2__(0),
         start_offset(0),  // mirrors ChipTensor::start_offset; pre-zeroed for create-info outputs
         version(0),
@@ -54,12 +59,6 @@ public:
 
     void copy(const TensorCreateInfo &other) { memcpy(this, &other, sizeof(other)); }
 
-    template <typename T = uint64_t>
-    void set_initial_value(T value) {
-        has_initial_value = true;
-        initial_value = to_u64(value);
-    }
-
     uint64_t buffer_size_bytes() const {
         uint64_t total = 1;
         for (uint32_t i = 0; i < ndims; i++) {
@@ -73,9 +72,7 @@ public:
     // These occupy the same positions as ChipTensor::buffer, ChipTensor::owner_task_id,
     // and ChipTensor::start_offset. The runtime overwrites owner metadata after the
     // memcpy and recomputes start_offset / stride during payload materialization.
-    uint64_t initial_value;
-    bool has_initial_value;
-    uint8_t __pad1__[7];
+    uint64_t __pad0__[2];   // → ChipTensor::buffer (overwritten post-memcpy)
     uint64_t __pad2__;      // → ChipTensor::owner_task_id (overwritten post-memcpy)
     uint64_t start_offset;  // mirrors ChipTensor::start_offset; always 0 for create-info outputs
 
@@ -93,6 +90,7 @@ public:
 
 // TensorCreateInfo layout must match ChipTensor cacheline 1 for memcpy optimization
 static_assert(sizeof(TensorCreateInfo) == 64, "TensorCreateInfo must match ChipTensor cacheline 1 size (64 bytes)");
+static_assert(offsetof(TensorCreateInfo, __pad0__) == offsetof(ChipTensor, buffer));
 static_assert(offsetof(TensorCreateInfo, start_offset) == offsetof(ChipTensor, start_offset));
 static_assert(offsetof(TensorCreateInfo, version) == offsetof(ChipTensor, version));
 static_assert(offsetof(TensorCreateInfo, ndims) == offsetof(ChipTensor, ndims));
@@ -107,24 +105,6 @@ static_assert(offsetof(TensorCreateInfo, shapes) == offsetof(ChipTensor, shapes)
 // Factored out of ChipTensor (which now lives in the wire/host-facing common
 // header) so the create-info dependency stays runtime-only.
 // ============================================================================
-
-/// Fill the entire backing buffer of `t` with `initial_value` (doubling memcpy).
-inline void fill_tensor_initial_value(ChipTensor &t, uint64_t initial_value) {
-    always_assert(reinterpret_cast<char *>(t.buffer.addr) != nullptr);
-    uint64_t elem_size = get_element_size(t.dtype);
-    char *dst = reinterpret_cast<char *>(t.buffer.addr);
-    constexpr uint64_t blk_size = 64;
-    uint64_t blk = (t.buffer.size < blk_size) ? t.buffer.size : blk_size;
-    for (uint64_t b = 0; b < blk; b += elem_size) {
-        memcpy(dst + b, &initial_value, elem_size);
-    }
-    uint64_t filled = blk;
-    while (filled < t.buffer.size) {
-        uint64_t copy_size = ((t.buffer.size - filled) < filled) ? (t.buffer.size - filled) : filled;
-        memcpy(dst + filled, dst, copy_size);
-        filled += copy_size;
-    }
-}
 
 /// Materialize a TensorCreateInfo into `t` (fresh contiguous output).
 /// Single 64B memcpy covers cache line 1; `ci` pre-initialises start_offset (=0)
@@ -141,7 +121,4 @@ inline void init_tensor_from_create_info(ChipTensor &t, const TensorCreateInfo &
         s *= t.shapes[i];
     }
     t.extent_elem_cache = s;
-    if (ci.has_initial_value) {
-        fill_tensor_initial_value(t, ci.initial_value);
-    }
 }

--- a/src/common/task_interface/tensor.h
+++ b/src/common/task_interface/tensor.h
@@ -246,9 +246,7 @@ struct alignas(64) ChipTensor {
     // in the runtime tensor_create_info.h as init_tensor_from_create_info(), which
     // operates on a ChipTensor& through its public members. Kept out of the
     // wire/host-facing ChipTensor so this header has no dependency on the
-    // runtime-only create-info. tensormap_and_ringbuffer additionally has
-    // fill_tensor_initial_value(); host_build_graph does not, because that store
-    // goes to a device address its host orchestrator cannot reach.
+    // runtime-only create-info.
 
     // ========================================================================
     // Address / offset computation


### PR DESCRIPTION
## Summary

- Remove `TensorCreateInfo::set_initial_value`, the two metadata fields, and
  `fill_tensor_initial_value` from the `tensormap_and_ringbuffer` copies of
  the create-info header (a2a3 + a5), mirroring the layout host_build_graph
  landed in #1930: bytes [0, 16) become explicit `__pad0__` padding pinned to
  `ChipTensor::buffer` by a new `offsetof` assertion.
- The two runtimes now expose the same create-info surface; an orchestration
  written against one compiles against the other.
- The only in-tree caller — the `scalar_data` example's 1-element scalar — now
  allocates first and seeds with `set_tensor_data`. The hidden alloc task
  completes inline in the orchestrator before any producer or consumer
  exists, so the write finds nothing to wait for. Goldens unchanged.
- Whole-buffer initialization (e.g. zeroing a large accumulator) is not served
  by per-element `set_tensor_data`; a task writes the buffer, ordered ahead of
  every reader/writer by task dependencies — the pattern #1922 established for
  the DeepSeek-V4 decode buffers. Both replacement patterns are documented in
  the TMR `SCALAR_DATA_ACCESS.md`; the stale cross-reference in the shared
  `tensor.h` comment is removed.

## Testing

- [x] `scalar_data` on a2a3sim with golden comparison — PASSED
- [x] `scalar_data` on a5sim with golden comparison — PASSED
- [x] C++ unit tests — 117/117 passed
- [x] Python unit tests — 1892 passed, 20 skipped
- [ ] Hardware runs (a2a3/a5 onboard) — left to CI; this box's silicon was
  busy and its arch could not be confirmed at run time