### PR TITLE
Fix: sync scalar_data docs to the alloc-then-seed flow of #1975

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/scalar_data/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/scalar_data/README.md
@@ -35,7 +35,7 @@ landing a value in `check[0..8]`:
 | Steps | What is exercised | Lands in |
 | ----- | ----------------- | -------- |
 | 1–3 | `get_tensor_data` on a runtime-created tensor at two indices | `check[0]` = 2.0, `check[1]` = 102.0 |
-| 4–5 | `add_output(TensorCreateInfo, 77.0f)` — a runtime-created output with an **initial value** | `check[2]` = 77.0 |
+| 4–5 | `alloc_tensors(TensorCreateInfo)` then `set_tensor_data(…, 77.0f)` — seeding a runtime-created output from the orchestration | `check[2]` = 77.0 |
 | 6–7 | `add_inout` on the same tensor: the buffer already exists, so the submit only registers a dependency; the value survives | `check[3]` = 77.0 |
 | 8 | Plain arithmetic in the orchestration on a value it read back | `check[4]` = 79.0 |
 | 9 | `set_tensor_data` → `get_tensor_data` round-trip | `check[5]` = 42.0 |

--- a/examples/a2a3/tensormap_and_ringbuffer/scalar_data/kernels/aiv/kernel_noop.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/scalar_data/kernels/aiv/kernel_noop.cpp
@@ -13,8 +13,8 @@
  *
  * Empty kernel used to trigger runtime allocation for tensors passed
  * as OUTPUT/INOUT via add_inout(). The runtime allocates HeapRing memory
- * and writes initial values before dispatching this task; the kernel
- * itself does not read or modify any data.
+ * before dispatching this task; the kernel itself does not read or
+ * modify any data.
  */
 
 #include <cstdint>

--- a/examples/a2a3/tensormap_and_ringbuffer/scalar_data/test_scalar_data.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/scalar_data/test_scalar_data.py
@@ -21,7 +21,7 @@ from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
 class TestScalarData(SceneTestCase):
-    """Scalar data dependency: Get/SetTensorData, add_inout with initial value."""
+    """Scalar data dependency: Get/SetTensorData, add_inout with orchestration-seeded outputs."""
 
     CALLABLE = {
         "orchestration": {

--- a/examples/a5/tensormap_and_ringbuffer/scalar_data/README.md
+++ b/examples/a5/tensormap_and_ringbuffer/scalar_data/README.md
@@ -35,7 +35,7 @@ landing a value in `check[0..8]`:
 | Steps | What is exercised | Lands in |
 | ----- | ----------------- | -------- |
 | 1–3 | `get_tensor_data` on a runtime-created tensor at two indices | `check[0]` = 2.0, `check[1]` = 102.0 |
-| 4–5 | `add_output(TensorCreateInfo, 77.0f)` — a runtime-created output with an **initial value** | `check[2]` = 77.0 |
+| 4–5 | `alloc_tensors(TensorCreateInfo)` then `set_tensor_data(…, 77.0f)` — seeding a runtime-created output from the orchestration | `check[2]` = 77.0 |
 | 6–7 | `add_inout` on the same tensor: the buffer already exists, so the submit only registers a dependency; the value survives | `check[3]` = 77.0 |
 | 8 | Plain arithmetic in the orchestration on a value it read back | `check[4]` = 79.0 |
 | 9 | `set_tensor_data` → `get_tensor_data` round-trip | `check[5]` = 42.0 |

--- a/examples/a5/tensormap_and_ringbuffer/scalar_data/kernels/aiv/kernel_noop.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/scalar_data/kernels/aiv/kernel_noop.cpp
@@ -13,8 +13,8 @@
  *
  * Empty kernel used to trigger runtime allocation for tensors passed
  * as OUTPUT/INOUT via add_inout(). The runtime allocates HeapRing memory
- * and writes initial values before dispatching this task; the kernel
- * itself does not read or modify any data.
+ * before dispatching this task; the kernel itself does not read or
+ * modify any data.
  */
 
 #include <cstdint>

--- a/examples/a5/tensormap_and_ringbuffer/scalar_data/test_scalar_data.py
+++ b/examples/a5/tensormap_and_ringbuffer/scalar_data/test_scalar_data.py
@@ -21,7 +21,7 @@ from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
 class TestScalarData(SceneTestCase):
-    """Scalar data dependency: Get/SetTensorData, add_inout with initial value."""
+    """Scalar data dependency: Get/SetTensorData, add_inout with orchestration-seeded outputs."""
 
     CALLABLE = {
         "orchestration": {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
@@ -12,12 +12,13 @@ During task graph construction, orchestration sometimes needs to read InCore ker
 // Blocking read: returns value at the given indices (default: raw uint64_t bits)
 // Specify T for typed read: float val = get_tensor_data<float>(tensor, 1, idx);
 template<typename T = uint64_t>
-T get_tensor_data(const Tensor& tensor, uint32_t ndims, const uint32_t indices[]);
+T get_tensor_data(const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
 
 // Blocking write: stores value at the given indices (type deduced from argument)
 // Typed write: set_tensor_data(tensor, 1, idx, 42.0f);
+// The tensor is const: the write targets buffer memory, never the descriptor.
 template<typename T = uint64_t>
-void set_tensor_data(Tensor& tensor, uint32_t ndims, const uint32_t indices[], T value);
+void set_tensor_data(const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], T value);
 ```
 
 Both call into the runtime through the ops table — orchestration .so needs no runtime symbol linkage.
@@ -81,7 +82,7 @@ TensorCreateInfo scalar_ci(shapes, 1, DataType::FLOAT32);
 
 // Allocate, seed from orchestration, and keep the returned tensor
 TaskOutputTensors outs = alloc_tensors(scalar_ci);
-const Tensor& scalar_tensor = outs.get_ref(0);
+const ChipTensor &scalar_tensor = outs.get_ref(0);
 uint32_t idx[1] = {0};
 set_tensor_data(scalar_tensor, 1, idx, 77.0f);
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
@@ -12,12 +12,13 @@ During task graph construction, orchestration sometimes needs to read InCore ker
 // Blocking read: returns value at the given indices (default: raw uint64_t bits)
 // Specify T for typed read: float val = get_tensor_data<float>(tensor, 1, idx);
 template<typename T = uint64_t>
-T get_tensor_data(const Tensor& tensor, uint32_t ndims, const uint32_t indices[]);
+T get_tensor_data(const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[]);
 
 // Blocking write: stores value at the given indices (type deduced from argument)
 // Typed write: set_tensor_data(tensor, 1, idx, 42.0f);
+// The tensor is const: the write targets buffer memory, never the descriptor.
 template<typename T = uint64_t>
-void set_tensor_data(Tensor& tensor, uint32_t ndims, const uint32_t indices[], T value);
+void set_tensor_data(const ChipTensor &tensor, uint32_t ndims, const uint32_t indices[], T value);
 ```
 
 Both call into the runtime through the ops table — orchestration .so needs no runtime symbol linkage.
@@ -81,7 +82,7 @@ TensorCreateInfo scalar_ci(shapes, 1, DataType::FLOAT32);
 
 // Allocate, seed from orchestration, and keep the returned tensor
 TaskOutputTensors outs = alloc_tensors(scalar_ci);
-const Tensor& scalar_tensor = outs.get_ref(0);
+const ChipTensor &scalar_tensor = outs.get_ref(0);
 uint32_t idx[1] = {0};
 set_tensor_data(scalar_tensor, 1, idx, 77.0f);
 


### PR DESCRIPTION
## Summary

Follow-up to #1975 (merged). The removal of `set_initial_value` migrated the
scalar_data example to `alloc_tensors` + `set_tensor_data`, but left the
surrounding prose describing the removed flow, and one API block disagreeing
with the code:

- **scalar_data README step table + test docstring** (a2a3 + a5): step 4–5 was
  still documented as `add_output(TensorCreateInfo, 77.0f)` with an *initial
  value* — an API form that no longer compiles. Now describes
  `alloc_tensors(TensorCreateInfo)` then `set_tensor_data(…, 77.0f)`.
- **`kernel_noop.cpp` header comment** (a2a3 + a5): still claimed "the runtime
  … writes initial values before dispatching this task". After #1975 the
  runtime never writes buffer content at allocation time; the claim is removed.
- **`SCALAR_DATA_ACCESS.md` §2 API block** (a2a3 + a5): declared
  `set_tensor_data(Tensor& …)` with the pre-#1681 type name. Both wrappers
  (`orchestration_api.h`) take `const ChipTensor &` — the write targets buffer
  memory through `buffer.addr`, never the descriptor — and the §5 snippet's
  `const Tensor&` carried the same stale type name. Both now read
  `const ChipTensor &`, with a one-line note on why const is correct.

Docs-and-comments only; no behavior change, goldens untouched.

## Testing

- [x] pre-commit (markdownlint, ruff, cpplint, clang-format) — passed
- [ ] CI (docs-mostly diff; gates expected to skip the hardware matrix where the
  detection allows)