### PR TITLE
CI: give scope-stats the DFX smoke step the other four have

### DIFF
--- a/.github/workflows/_st-sim-a2a3.yml
+++ b/.github/workflows/_st-sim-a2a3.yml
@@ -133,3 +133,11 @@ jobs:
           .venv/bin/python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py \
             --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --manual "${{ inputs.manual_mode == 'only' && 'only' || 'include' }}" --dump-args
+
+      - name: scope_stats smoke (a2a3)
+        if: inputs.include_dfx_smokes
+        run: |
+          .venv/bin/python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/ \
+            --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
+            --require-pto-isa --manual "${{ inputs.manual_mode == 'only' && 'only' || 'include' }}" \
+            --enable-scope-stats

--- a/.github/workflows/_st-sim-a5.yml
+++ b/.github/workflows/_st-sim-a5.yml
@@ -126,3 +126,11 @@ jobs:
           .venv/bin/python -m pytest tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py \
             --platform a5sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --manual "${{ inputs.manual_mode == 'only' && 'only' || 'include' }}" --dump-args
+
+      - name: scope_stats smoke (a5)
+        if: inputs.include_dfx_smokes
+        run: |
+          .venv/bin/python -m pytest tests/st/a5/tensormap_and_ringbuffer/dfx/scope_stats/ \
+            --platform a5sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
+            --require-pto-isa --manual "${{ inputs.manual_mode == 'only' && 'only' || 'include' }}" \
+            --enable-scope-stats

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -138,14 +138,17 @@ same DFX smoke steps used by Per-PR run once in each Daily platform job, and
 the A2/A3 `network1` corpus runs through the existing two-machine workflow. The
 main Per-PR scene-test steps keep the default `--manual exclude`, so moving an
 ordinary case to Daily does not require a second workflow exclusion list.
-The dedicated dep-gen, chip-swimlane, PMU, and args-dump steps instead use
+The dedicated dep-gen, chip-swimlane, PMU, args-dump, and scope-stats steps
+instead use
 `include` for the normal Per-PR and Daily modes because they own the full
 corpus under their target paths; a `manual_mode` of `only` remains `only` in
 those steps. Marking a case under one of those paths manual therefore removes
 its duplicate main-step execution without removing its dedicated Per-PR
-coverage. Scope-stats has no dedicated CI smoke: its ordinary scene test stays
-in the main sweep, and artifact validation runs only when
-`--enable-scope-stats` is supplied explicitly.
+coverage. Scope-stats needs its own step for a reason the others do not: its
+scene test runs in the main sweep either way, but `_validate_scope_stats_artifact`
+returns early unless `--enable-scope-stats` is supplied, so without the dedicated
+step the run happens and the `scope_stats.jsonl` it should have produced is never
+asserted on.
 
 Use `"manual": True` on an individual `SceneTestCase.CASES` entry and
 `@pytest.mark.manual` on a standalone pytest test. The reusable scene-test


### PR DESCRIPTION
## Summary

`tests/st/{a2a3,a5}/tensormap_and_ringbuffer/dfx/scope_stats/` is the only test of the scope-stats capture pipeline, and **its artifact validation never ran in any pipeline**.

`_validate_scope_stats_artifact` returns early unless `--enable-scope-stats` is on (`test_scope_stats.py:117`), and nothing passed it:

```console
$ grep -rn "scope_stats\|enable-scope-stats" .github/
$ # empty

$ # meanwhile, in the same two workflows:
      3 enable-dep-gen
      1 enable-chip-swimlane
      1 enable-pmu
      1 --dump-args
```

To be precise about what was and wasn't covered: the **scene half did run**. The class is an ordinary `SceneTestCase`, so the main sweep compiled and ran its `vector_example` and checked the golden. What never ran is the part that matters for this feature — the `scope_stats.jsonl` assertions: at least four begin/end records, `dropped == 0`, the metadata schema, and the required per-record fields. A collector that silently emitted nothing, or dropped every record, would have kept CI green.

Both new steps copy the shape of the `args_dump` step beside them, including the `manual_mode` mapping that keeps `only` as `only` and otherwise uses `include`, since these steps own the whole corpus under their path.

`docs/ci.md` had recorded the omission as a fact — *"Scope-stats has no dedicated CI smoke: its ordinary scene test stays in the main sweep, and artifact validation runs only when `--enable-scope-stats` is supplied explicitly."* It now describes the step, and why scope-stats needed one for a different reason than the others: for the other four the dedicated step exists so coverage survives a case being marked manual, whereas here the scene test runs either way and only the artifact assertions were gated off.

## Testing

- [x] `check-yaml` equivalent (`yaml.safe_load`) on both workflows; `markdownlint-cli2` clean on `docs/ci.md`
- [x] Both new steps run **exactly as the workflows invoke them**, including `--manual include`:

  ```console
  $ pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/ \
      --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
      --require-pto-isa --manual include --enable-scope-stats
  1 passed

  $ pytest tests/st/a5/tensormap_and_ringbuffer/dfx/scope_stats/ \
      --platform a5sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
      --require-pto-isa --manual include --enable-scope-stats
  1 passed
  ```

- [x] The assertions are not vacuous — the validator checks record count, `dropped == 0`, schema and per-record fields, so the step fails if the collector stops producing.

This touches `.github/workflows/_*.yml`, which `.claude/rules/ci-change-detection.md` §2 keeps out of `NON_CODE` precisely so a CI-implementation change runs the whole matrix — including the two jobs this PR modifies.
