### PR TITLE
Fix: support explicit L3 task dependencies

### DIFF
--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -20,12 +20,13 @@ flows through `submit`, see [task-flow.md](task-flow.md).
 ## 1. Python Facade and C++ Internal API
 
 The Python user's orch fn receives a `simpler.orchestrator.Orchestrator`
-facade. Its `submit_*` methods enqueue DAG nodes and return `None`; task slots
-remain internal to the worker.
+facade. `submit_next_level` and `submit_next_level_group` enqueue DAG nodes and
+return opaque `TaskHandle` objects. A later `TaskArgs.add_dep(handle)` or
+`TaskArgs.add_dep_wait(handle)` uses the handle to add an edge that tensor-tag
+inference cannot derive.
+`submit_sub` and `submit_sub_group` still return `None`.
 
-The C++ Orchestrator still returns `SubmitResult` for internal scheduling and
-C++ tests, but nanobind intentionally drops that return value instead of
-exposing it to Python:
+The C++ `SubmitResult` name is an alias of the same run-scoped handle:
 
 ```cpp
 class Orchestrator {
@@ -69,8 +70,19 @@ private:
     // ... components: Ring, TensorMap, Scope, and the RunState registry
 };
 
-struct SubmitResult { TaskSlot task_slot; };  // internal only; not bound to Python
+struct TaskHandle {
+    RunId run_id;
+    TaskSlot task_slot;
+};
+using SubmitResult = TaskHandle;
 ```
+
+Python does not expose either field or a public constructor. A handle is valid
+only while building the run that returned it; passing it to another run is a
+submit-time error. Naming a producer that has already completed or reached
+`CONSUMED` in the same run is valid and the dependency is already satisfied.
+The monotonic `run_id` prevents a stale handle from accidentally naming a slot
+reused after the Ring resets.
 
 **Status**: `submit_sub` takes only `(CallableIdentity, args)` — no
 `config`, since SUB has no per-call config.
@@ -147,18 +159,21 @@ SubmitResult Orchestrator::submit_next_level(const CallableIdentity &callable,
     s.config      = config;
     s.target_worker_ids = {worker};
 
-    // 3. Walk task_args tags, derive dependencies
-    //    (dedup producers: same producer may appear on multiple input tensors)
-    std::vector<TaskSlot> producers;
-    std::unordered_set<TaskSlot> producers_seen;
+    // 3. Collect explicit deps, then walk task_args tags to derive retained
+    //    dependencies. Repeated producers collapse to one edge and retention
+    //    wins when any path names the same producer with retain=true.
+    std::vector<ProducerDependency> producers;
+    for (int i = 0; i < s.task_args.explicit_dep_count(); ++i) {
+        add_unique_producer(s.task_args.explicit_dep(i).task_slot,
+                            s.task_args.explicit_dep_retain(i));
+    }
     for (int i = 0; i < s.task_args.tensor_count(); i++) {
         TensorArgType tag = s.task_args.tag(i);
         TensorKey key     = key_for_tensor_or_remote_sidecar(i);
 
         if (tag == INPUT || tag == INOUT) {
             if (TaskSlot prod = tensormap_.lookup(key); prod != INVALID)
-                if (producers_seen.insert(prod).second)
-                    producers.push_back(prod);
+                add_unique_producer(prod, /*retain=*/true);
         }
         if (tag == OUTPUT || tag == INOUT || tag == OUTPUT_EXISTING) {
             tensormap_.insert(key, sid);
@@ -188,13 +203,13 @@ SubmitResult Orchestrator::submit_next_level(const CallableIdentity &callable,
         ready = s.fanin_released >= live;   // releases that landed while BUILDING
         if (!s.state.compare_exchange_strong(BUILDING, ready ? READY : PENDING)) {
             propagate_failure(sid);         // a producer claimed us mid-wiring
-            return {sid};
+            return {run_id, sid};
         }
     }
     if (ready) enqueue_ready(sid);          // outside the lock: takes runs_mu_
 
     // 7. Return handle
-    return {sid};
+    return {run_id, sid};
 }
 ```
 
@@ -207,9 +222,9 @@ if all slots are in-flight; this is the system's back-pressure mechanism.
 small POD copied by value. `callable` is a `uint64_t` opaque handle (see
 [task-flow.md](task-flow.md) §2).
 
-**Step 3 — tag walk**: The only place tags are consumed. After this step tags
-are never inspected again; they are not carried into the slot's stored
-`task_args` value during dispatch (see [task-flow.md](task-flow.md) §3).
+**Step 3 — explicit deps and tag walk**: The only place dependency handles and
+tags are consumed. Neither is carried across the dispatch boundary (see
+[task-flow.md](task-flow.md) §3).
 Every TensorMap key starts with the current `RunId`. Local tensor identity is
 then `(LOCAL_HOST, ptr)` or `(LOCAL_CHILD, worker, ptr)`. Remote tensors with
 sidecars use `(address_kind, owner_worker_id, buffer_id, generation, offset)`.
@@ -228,6 +243,16 @@ register this task as the new producer of the tensor's dependency key. For
 local tensors this key contains `tensor.data`; for remote sidecars it contains
 remote buffer identity and logical offset.
 
+`TaskArgs.add_dep(*handles)` and `TaskArgs.add_dep_wait(*handles)` accept one or
+more handles and may be called before or after `add_tensor` / `add_scalar`.
+Their dynamic host-side vector has no fixed dependency cap. Every handle must
+belong to the current run and name an already submitted task. Both edge kinds
+contribute to the consumer's `fanin_count`, propagate producer failure, and
+delay READY until the producer finishes. `add_dep` additionally retains each
+producer until the consumer finishes; `add_dep_wait` is ordering-only. Neither
+creates a TensorMap entry. Repeated handles and tag-inferred edges deduplicate,
+with lifetime retention winning if any path requests it.
+
 Before each output mapping becomes visible, its key is appended to the slot's
 cleanup journal. A failed journal append therefore publishes no mapping, while
 a later failure leaves a key `on_consumed` can erase. Erasure remains
@@ -241,11 +266,12 @@ See [§6 Scope](#6-scope).
 
 **Step 5 — fanout attachment and live-fanin count**: Submission synchronously
 locks each producer's `fanout_mu`, attaches the consumer, and counts only live
-producers. The producer's forward edge and the consumer's reverse edge are one
-transaction: failure to publish the reverse edge rolls the forward edge and
-its reference charge back. A completing live producer advances
-`fanin_released`; completed producers retain the reference edge but do not
-contribute to `fanin_count`.
+producers. Every edge registers the consumer for completion notification.
+Tensor-derived and explicit `add_dep` edges additionally charge `fanout_total`
+and record a reverse edge so the consumer retains the producer until it
+finishes; `add_dep_wait` edges omit both lifetime operations. A completed
+producer contributes no live fanin. A completed wait-only dependency needs no
+notification edge at all.
 
 **Step 6 — publication and READY routing**: `fanin_count` and the transition
 from BUILDING to PENDING or READY are published together under `fanout_mu`. An
@@ -454,8 +480,8 @@ Scope solves two concerns at once:
    to a deeper HeapRing (§5), so a long-lived outer-scope task cannot hold
    the FIFO head against inner-scope churn.
 
-Every slot has a `fanout_total` counter: the number of outstanding
-references (downstream consumers + any scope refs). A slot transitions to
+Every slot has a `fanout_total` counter: the number of outstanding lifetime
+references (retaining consumers + any scope refs). A slot transitions to
 `CONSUMED` (slot + heap slab freed) only when `fanout_released` meets the
 threshold (`>= total + 1`; see §8 fanout-release threshold).
 
@@ -680,7 +706,7 @@ rules carry that:
 - **The charge immediately follows successful registration** and precedes Step
   2 publishing the slot's outputs. A failure between registration and charge
   leaves an extra scope release, which is safe; the opposite order would leave
-  an unreleasable charge. Once an output is published, downstream consumers
+  an unreleasable charge. Once an output is published, retaining consumers
   increment the same `fanout_total` field.
 - **The output cleanup journal precedes TensorMap publication.** A failure can
   never leave a mapping cancellation does not know to erase, and the map's
@@ -784,18 +810,20 @@ per-slab free syscall.
 
 ### Consumer interaction
 
-`infer_deps` treats `COMPLETED` producers specially: it still wires the
-fanout edge (so the producer waits for the consumer before being consumed and
-freeing its buffer) but does not bump `live_fanins` (the consumer is
-immediately ready because the producer is already done). A producer that is
-already `FAILED` is not a successful fanin; downstream consumers are poisoned
-by the Scheduler rather than dispatched.
+`infer_deps` treats `COMPLETED` producers specially. A retained tensor or
+`add_dep` edge still holds the producer until the consumer finishes, but
+contributes no live fanin. An ordering-only `add_dep_wait` is already satisfied
+and adds no lifetime reference. A producer that is already `FAILED` poisons
+downstream consumers instead of dispatching them.
 
 ```cpp
 if (ps_state == TaskState::CONSUMED) continue;  // already gone
+if (!dep.retain && ps_state == TaskState::COMPLETED) continue;
 ps.fanout_consumers.push_back(slot);
-ps.fanout_total++;
-s.fanin_producers.push_back(prod);
+if (dep.retain) {
+    ps.fanout_total++;
+    s.fanin_producers.push_back(prod);
+}
 if (ps_state != TaskState::COMPLETED) live_fanins++;   // wait only if not yet done
 ```
 

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -106,9 +106,12 @@ class TaskArgs {
     std::vector<ChipTensor> tensors_;
     std::vector<TensorArgType>    tags_;     // per-tensor: INPUT/OUTPUT/INOUT/OUTPUT_EXISTING/NO_DEP
     std::vector<uint64_t>         scalars_;
+    std::vector<TaskHandle>       explicit_deps_;  // parent graph only
 public:
     void add_tensor(const ChipTensor&, TensorArgType tag = TensorArgType::INPUT);
     void add_scalar(uint64_t);
+    void add_dep(const TaskHandle&);
+    void add_dep_wait(const TaskHandle&);
     TaskArgsView view() const;
     int32_t tensor_count() const;
     int32_t scalar_count() const;
@@ -135,11 +138,12 @@ remote sidecars; the remote framed path encodes the sidecar as a
 | **③ Dispatch wire (PROCESS only)** | length-prefixed blob | shm mailbox (MAP_SHARED) | parent WorkerThread encodes | forked child decodes |
 | **④ L2 ABI edge** | `ChipStorageTaskArgs` POD | child stack | `ChipWorker::run` assembles | `pto2_run_runtime` consumes |
 
-### Tags stripped at submit
+### Tags and explicit dependencies stay parent-side
 
 Tags are consumed by `Orchestrator::submit_*` to derive TensorMap dependencies
-and then discarded. Phases ②, ③, ④ do not carry tags — scheduler, worker
-thread, child, and runtime.so all ignore per-tensor direction.
+and `TaskHandle` dependencies are consumed to add task-to-task ordering edges.
+Neither reaches phases ③ or ④ — scheduler dispatch payloads, child workers,
+and runtime.so do not receive them.
 
 ### Blob byte layout (phase ③)
 
@@ -493,8 +497,8 @@ framed protocol instead of the local mailbox.
 ## 6. Data flow through a submit
 
 The user's Python orch fn receives an `Orchestrator` facade (not a `Worker`)
-and calls `submit_next_level` / `submit_sub`. These Python methods return
-`None`; the task slot remains internal to the scheduling engine.
+and calls `submit_next_level` / `submit_sub`. NEXT_LEVEL submits return an
+opaque, run-scoped `TaskHandle`; SUB submits return `None`.
 
 ```python
 class Orchestrator:
@@ -502,23 +506,24 @@ class Orchestrator:
     # remote L3 dispatch, stable ids are returned by add_worker(...) or
     # add_remote_worker(...). For L3 ChipCallable dispatch, worker ids are
     # the existing chip worker ids.
-    def submit_next_level(self, handle, args, config=None, *, worker) -> None: ...
-    def submit_next_level_group(self, handle, args_list, config=None, *, workers) -> None: ...
+    def submit_next_level(self, handle, args, config=None, *, worker) -> TaskHandle: ...
+    def submit_next_level_group(self, handle, args_list, config=None, *, workers) -> TaskHandle: ...
     def submit_sub(self, handle, args=None) -> None: ...
     def submit_sub_group(self, handle, args_list) -> None: ...
 ```
 
-The C++ implementation still allocates an internal task slot to drive
-scheduling, but nanobind does not expose that slot. Downstream consumers
-reference tensors by their own pointers (already registered in TensorMap by
-the OUTPUT/INOUT tag).
+The handle exposes no slot fields or constructor in Python. It can only be
+passed to `TaskArgs.add_dep` or `TaskArgs.add_dep_wait`, which creates a task
+edge without inventing a tensor dependency. `add_dep` retains the producer
+until the consumer completes; `add_dep_wait` only waits for producer
+completion. Handles from another run are rejected before a slot is allocated.
 
 Where the data goes after submit:
 
 1. `CallableIdentity` — copied into `slot.callable` (parent heap)
 2. `TaskArgs` — moved into `slot.task_args` (parent heap, vector-backed).
-   Tags are consumed during the same submit call for dep inference and
-   **never carried further**.
+   Tags and explicit handles are consumed during the same submit call for dep
+   inference and **never carried across the dispatch boundary**.
 3. `CallConfig` — copied into `slot.config` (parent heap, POD)
 4. `PipelineSlotLease` — copied from the owning run into
    `slot.pipeline_lease`; local chip mailboxes forward `{slot_id, generation}`

--- a/docs/user/reference/python-api.md
+++ b/docs/user/reference/python-api.md
@@ -17,7 +17,7 @@ extension.
 from simpler import Worker           # or: from simpler.worker import Worker
 from simpler.task_interface import (
     ArgDirection, CallConfig, ChipCallable, ChipStorageTaskArgs,
-    ChipTensor, CoreCallable, DataType,
+    ChipTensor, CoreCallable, DataType, TaskArgs, TaskHandle,
 )
 from simpler_setup import KernelCompiler, SceneTestCase, scene_test
 ```
@@ -84,7 +84,8 @@ callable is a **Python orchestration function** `f(orch, args, cfg)`, where
 
 | Method | Notes |
 | ------ | ----- |
-| `submit_next_level(callable_handle, args, config=None, *, worker: int)` | Hands a `ChipCallable` to one chip child. `worker` is keyword-only |
+| `submit_next_level(callable_handle, args, config=None, *, worker: int) -> TaskHandle` | Hands a callable to one exact NEXT_LEVEL child and returns an opaque handle for explicit task dependencies |
+| `submit_next_level_group(callable_handle, args_list, config=None, *, workers: list[int]) -> TaskHandle` | Submits one group DAG node and returns its opaque handle |
 | `submit_sub(callable_handle, args=None)` | Schedules a registered host-side Python callable |
 | `allocate_domain(name, workers, window_size, buffers=[...])` | Context manager returning a handle indexed by domain-local rank |
 | `malloc(worker_id, size) -> int` | **Argument order is `(worker_id, size)`** — the reverse of `Worker.malloc(size, worker_id=0)` |
@@ -105,6 +106,13 @@ ChipCallable.build(
 `ArgDirection` is `SCALAR`, `IN`, `OUT`, or `INOUT`. The signature list is
 positional and defines the task-arg order. `func_id` must match the id the
 orchestration submits. `ChipCallable` exposes `binary_size`.
+
+For L3+ graph construction, `TaskArgs.add_dep(*handles)` adds `WAIT | RETAIN`
+edges: each consumer waits for its producers and keeps their task-owned
+resources alive until it completes. `TaskArgs.add_dep_wait(*handles)` adds
+ordering-only `WAIT` edges. Handles must come from a NEXT_LEVEL submit in the
+same orchestration run; they are opaque and cannot be constructed by the
+caller.
 
 ```python
 args = ChipStorageTaskArgs()

--- a/docs/war-anti-dependency.md
+++ b/docs/war-anti-dependency.md
@@ -88,6 +88,20 @@ rt_submit_aic_task(FUNC_WRITE_X, w_args);
 Multiple readers each contribute one `add_dep(reader.task_id())` on the writer
 and still run in parallel with each other — only the writer waits.
 
+At L3 and above, the Python API offers the same two dependency names as L2
+with opaque host task handles. This WAR edge is ordering-only, so it uses
+`add_dep_wait` rather than the retaining `add_dep`:
+
+```python
+reader = orch.submit_next_level(reader_handle, reader_args, cfg, worker=rank)
+writer_args.add_dep_wait(reader)
+orch.submit_next_level(writer_handle, writer_args, cfg, worker=rank)
+```
+
+The handle is valid only in the run that returned it. Host `TaskArgs` stores an
+unbounded dynamic list, so there is no `CoreTaskArgsWithDeps<N>`-style fixed
+capacity.
+
 **`add_dep` is a task-to-task edge only — it is invisible to the host-side
 `set_tensor_data`.** `set_tensor_data(X)` is a host write, not a task in the
 graph, so a "writer depends on reader" edge places no constraint on it. Its

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -2215,6 +2215,8 @@ NB_MODULE(_task_interface, m) {
         .value("OUTPUT_EXISTING", TensorArgType::OUTPUT_EXISTING)
         .value("NO_DEP", TensorArgType::NO_DEP);
 
+    nb::class_<TaskHandle>(m, "TaskHandle");
+
     // --- TaskArgs (unified vector-backed builder with per-tensor TensorArgType tags) ---
     nb::class_<TaskArgs>(m, "TaskArgs", nb::is_weak_referenceable())
         .def(nb::init<>())
@@ -2234,6 +2236,42 @@ NB_MODULE(_task_interface, m) {
         .def(
             "add_scalar", &TaskArgs::add_scalar, nb::arg("s"),
             "Add a uint64_t scalar. After this, add_tensor() is no longer allowed."
+        )
+
+        .def(
+            "add_dep",
+            [](TaskArgs &self, nb::args deps) {
+                if (deps.size() == 0) {
+                    throw std::invalid_argument("TaskArgs.add_dep requires at least one TaskHandle");
+                }
+                for (nb::handle dep : deps) {
+                    if (!nb::isinstance<TaskHandle>(dep)) {
+                        throw nb::type_error("TaskArgs.add_dep arguments must be TaskHandle objects");
+                    }
+                }
+                for (nb::handle dep : deps) {
+                    self.add_dep(nb::cast<const TaskHandle &>(dep));
+                }
+            },
+            "Add dependencies that retain each producer until this task completes."
+        )
+
+        .def(
+            "add_dep_wait",
+            [](TaskArgs &self, nb::args deps) {
+                if (deps.size() == 0) {
+                    throw std::invalid_argument("TaskArgs.add_dep_wait requires at least one TaskHandle");
+                }
+                for (nb::handle dep : deps) {
+                    if (!nb::isinstance<TaskHandle>(dep)) {
+                        throw nb::type_error("TaskArgs.add_dep_wait arguments must be TaskHandle objects");
+                    }
+                }
+                for (nb::handle dep : deps) {
+                    self.add_dep_wait(nb::cast<const TaskHandle &>(dep));
+                }
+            },
+            "Add one or more ordering-only dependencies returned by an Orchestrator submit."
         )
 
         .def(

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -264,8 +264,8 @@ inline void bind_worker(nb::module_ &m) {
             "submit_next_level",
             [](Orchestrator &self, nb::bytes digest, const std::string &kind, const std::string &target_namespace,
                const TaskArgs &args, const CallConfig &config, int32_t worker_id,
-               const std::vector<int32_t> &eligible_worker_ids, nb::object remote_sidecar) {
-                self.submit_next_level(
+               const std::vector<int32_t> &eligible_worker_ids, nb::object remote_sidecar) -> TaskHandle {
+                return self.submit_next_level(
                     make_callable_identity(digest, kind, target_namespace), args, config, worker_id,
                     eligible_worker_ids, parse_remote_task_args_sidecar(remote_sidecar)
                 );
@@ -280,8 +280,8 @@ inline void bind_worker(nb::module_ &m) {
             "submit_next_level_group",
             [](Orchestrator &self, nb::bytes digest, const std::string &kind, const std::string &target_namespace,
                const std::vector<TaskArgs> &args_list, const CallConfig &config, const std::vector<int32_t> &worker_ids,
-               const std::vector<std::vector<int32_t>> &eligible_worker_ids, nb::object remote_sidecars) {
-                self.submit_next_level_group(
+               const std::vector<std::vector<int32_t>> &eligible_worker_ids, nb::object remote_sidecars) -> TaskHandle {
+                return self.submit_next_level_group(
                     make_callable_identity(digest, kind, target_namespace), args_list, config, worker_ids,
                     eligible_worker_ids, parse_remote_task_args_sidecars(remote_sidecars)
                 );

--- a/python/simpler/orchestrator.py
+++ b/python/simpler/orchestrator.py
@@ -54,6 +54,7 @@ from .task_interface import (
     GlobalCommDomainView,
     RemoteAddressSpace,
     TaskArgs,
+    TaskHandle,
     _empty_remote_sidecar_for,
     _remote_sidecar_for,
     _RemoteTaskArgsSidecar,
@@ -304,12 +305,16 @@ class Orchestrator:
     # User-facing submit API
     # ------------------------------------------------------------------
 
-    def submit_next_level(self, callable_handle: Any, args: TaskArgs, config: CallConfig | None = None, *, worker: int):
+    def submit_next_level(
+        self, callable_handle: Any, args: TaskArgs, config: CallConfig | None = None, *, worker: int
+    ) -> TaskHandle:
         """Submit a NEXT_LEVEL task by registered callable handle.
 
         ``callable_handle`` must be returned by ``Worker.register``. Tags inside ``args`` drive deps.
         ``worker`` is the exact stable NEXT_LEVEL worker id that runs the
         task. For L3 chip dispatch, these are the existing chip worker ids.
+        Returns an opaque ``TaskHandle`` accepted by ``TaskArgs.add_dep`` or
+        ``TaskArgs.add_dep_wait`` during the same orchestration run.
         """
         cfg = config if config is not None else CallConfig()
         cpp_worker_id = _require_next_level_worker_id(worker, argument="worker")
@@ -353,7 +358,7 @@ class Orchestrator:
                 worker._adopt_remote_sidecar_refs((remote_sidecar,))
                 worker._record_touched_identities(c_args)
             _admit_task_submission(self._worker)
-            self._o.submit_next_level(
+            return self._o.submit_next_level(
                 digest, kind, target_namespace, c_args, cfg, cpp_worker_id, final_worker_ids, remote_sidecar
             )
 
@@ -364,7 +369,7 @@ class Orchestrator:
         config: CallConfig | None = None,
         *,
         workers: list,
-    ):
+    ) -> TaskHandle:
         """Submit a group of NEXT_LEVEL tasks (N TaskArgs → N worker selections, 1 DAG node).
 
         ``workers`` contains the exact stable NEXT_LEVEL worker id for each
@@ -373,6 +378,7 @@ class Orchestrator:
         ``args_list`` becomes one per-rank mailbox request: MPI rank
         ``workers[i]`` executes only ``args_list[i]``. A single worker id remains
         directed and is never silently widened to the whole group.
+        Returns one opaque ``TaskHandle`` for the group DAG node.
         """
         cfg = config if config is not None else CallConfig()
         worker_ids = [_require_next_level_worker_id(value, argument="workers entries") for value in workers]
@@ -464,7 +470,7 @@ class Orchestrator:
                 for c_args in c_args_list:
                     worker._record_touched_identities(c_args)
             _admit_task_submission(self._worker)
-            self._o.submit_next_level_group(
+            return self._o.submit_next_level_group(
                 digest, kind, target_namespace, c_args_list, cfg, worker_ids, worker_id_sets, remote_sidecars
             )
 

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -10,10 +10,10 @@
 """Public Python API for task_interface nanobind bindings.
 
 Re-exports the canonical C++ types (DataType, ChipTensor, ChipStorageTaskArgs, TaskArgs,
-TensorArgType) plus ``scalar_to_uint64``, and re-exports the address-free ``Tensor`` — the task
-argument users build — from ``simpler.buffer``. Torch-aware helpers (``make_chip_tensor_arg``,
-``torch_dtype_to_datatype``) live in ``simpler_setup.torch_interop`` — this module has no torch
-dependency.
+TaskHandle, TensorArgType) plus ``scalar_to_uint64``, and re-exports the address-free ``Tensor`` —
+the task argument users build — from ``simpler.buffer``. Torch-aware helpers
+(``make_chip_tensor_arg``, ``torch_dtype_to_datatype``) live in ``simpler_setup.torch_interop`` —
+this module has no torch dependency.
 
 ``ChipTensor`` is the chip-only POD the runtime ABI expects, paired with
 ``ChipStorageTaskArgs`` on the direct ``ChipWorker`` path; it carries a
@@ -61,6 +61,7 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
     DataType,
     RuntimeEnv,
     TaskArgs,
+    TaskHandle,
     TaskState,
     TensorArgType,
     WorkerType,
@@ -154,6 +155,7 @@ __all__ = [
     "ChipStorageTaskArgs",
     "TensorArgType",
     "TaskArgs",
+    "TaskHandle",
     "RemoteAddressSpace",
     "RemoteBufferHandle",
     "RemoteBufferExport",

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -622,8 +622,8 @@ uint64_t Orchestrator::alloc(const std::vector<uint32_t> &shape, DataType dtype,
     s.fanin_count.store(0, std::memory_order_relaxed);
     s.fanin_released.store(0, std::memory_order_relaxed);
 
-    // Initial fanout_total = scope_ref. Consumers that wire on this slot
-    // will increment fanout_total in infer_deps.
+    // Initial fanout_total = scope_ref. Tensor-derived consumers that retain
+    // this slot increment fanout_total in infer_deps.
     const int32_t scope_ref = (scope_->depth() > 0) ? 1 : 0;
     if (scope_ref > 0) {
         // Register before charging fanout_total. If registration throws, scope
@@ -717,6 +717,7 @@ SubmitResult Orchestrator::submit_impl(
     config.validate();
     validate_worker_eligibility(worker_type, args_list.size(), target_worker_ids, eligible_worker_ids);
     validate_remote_sidecars(args_list, remote_sidecars, eligible_worker_ids);
+    validate_explicit_deps(run->id, args_list);
     validate_submit_args(args_list);
 
     {
@@ -777,8 +778,8 @@ SubmitResult Orchestrator::submit_impl(
     // terminal release, the threshold is never reached, the slot never reaches
     // CONSUMED, and the run's task count — and its fence — never resolve.
     // fanout_total is charged here rather than later for the opposite reason:
-    // once Step 2 publishes this slot's outputs, a consumer can wire onto it
-    // and increment fanout_total, and a later assignment would drop that.
+    // once Step 2 publishes this slot's outputs, a retaining consumer can wire
+    // onto it and increment fanout_total, and a later assignment would drop that.
     int32_t scope_ref = (scope_->depth() > 0) ? 1 : 0;
     if (scope_ref > 0) {
         scope_->register_task(slot);
@@ -795,7 +796,7 @@ SubmitResult Orchestrator::submit_impl(
     // --- Step 2: Walk tags → tensormap.lookup (deps) + tensormap.insert
     // (outputs). Must happen before we move args_list into the slot because
     // infer_deps reads tensor data pointers and tags from it.
-    std::vector<TaskSlot> producers;
+    std::vector<ProducerDependency> producers;
     infer_deps(slot, args_list, target_worker_ids, remote_sidecars, producers, s.output_keys);
 
     // --- Step 3: Store TaskArgs directly (no chip-storage pre-build) ---
@@ -839,7 +840,8 @@ SubmitResult Orchestrator::submit_impl(
     int32_t live_fanins = 0;
     bool poisoned_by_failed_producer = false;
     std::string poison_message;
-    for (TaskSlot prod : producers) {
+    for (const ProducerDependency &dependency : producers) {
+        TaskSlot prod = dependency.slot;
         TaskSlotState &ps = slot_state(prod);
         std::lock_guard<std::mutex> lk(ps.fanout_mu);
 
@@ -847,15 +849,24 @@ SubmitResult Orchestrator::submit_impl(
         if (ps_state == TaskState::CONSUMED) {
             continue;
         }
+        if (!dependency.retain && (ps_state == TaskState::COMPLETED || ps_state == TaskState::FAILED)) {
+            if (ps_state == TaskState::FAILED) {
+                poisoned_by_failed_producer = true;
+                if (poison_message.empty()) poison_message = ps.failure_message;
+            }
+            continue;
+        }
         ps.fanout_consumers.push_back(slot);
-        ps.fanout_total++;
-        try {
-            if (test_hook_) test_hook_(OrchestratorTestPoint::PRODUCER_FORWARD_EDGE_PUBLISHED);
-            s.fanin_producers.push_back(prod);
-        } catch (...) {
-            ps.fanout_total--;
-            ps.fanout_consumers.pop_back();
-            throw;
+        if (dependency.retain) {
+            ps.fanout_total++;
+            try {
+                if (test_hook_) test_hook_(OrchestratorTestPoint::PRODUCER_FORWARD_EDGE_PUBLISHED);
+                s.fanin_producers.push_back(prod);
+            } catch (...) {
+                ps.fanout_total--;
+                ps.fanout_consumers.pop_back();
+                throw;
+            }
         }
         if (ps_state == TaskState::FAILED) {
             poisoned_by_failed_producer = true;
@@ -945,7 +956,7 @@ SubmitResult Orchestrator::submit_impl(
                 try_consume(prod);
             }
         }
-        return SubmitResult{slot};
+        return SubmitResult{run->id, slot};
     }
 
     // Enqueued outside the publication lock: enqueue_ready takes runs_mu_, and
@@ -956,7 +967,7 @@ SubmitResult Orchestrator::submit_impl(
         if (ready_notify_cb_) ready_notify_cb_();
     }
 
-    return SubmitResult{slot};
+    return SubmitResult{run->id, slot};
 }
 
 void Orchestrator::enqueue_ready(TaskSlot slot) {
@@ -1138,6 +1149,21 @@ void Orchestrator::validate_remote_sidecars(
     }
 }
 
+void Orchestrator::validate_explicit_deps(RunId run_id, const std::vector<TaskArgs> &args_list) const {
+    for (const TaskArgs &args : args_list) {
+        for (int32_t i = 0; i < args.explicit_dep_count(); ++i) {
+            const TaskHandle &dep = args.explicit_dep(i);
+            if (dep.run_id != run_id) {
+                throw std::invalid_argument("Orchestrator: explicit dependency belongs to another run");
+            }
+            TaskSlotState *producer = allocator_->slot_state(dep.task_slot);
+            if (producer == nullptr || producer->run_id != run_id) {
+                throw std::invalid_argument("Orchestrator: explicit dependency names an unknown task");
+            }
+        }
+    }
+}
+
 // =============================================================================
 // reserve_slot — claim this submit's task slot
 // =============================================================================
@@ -1161,27 +1187,38 @@ AllocResult Orchestrator::reserve_outputs_and_slot(
 
 void Orchestrator::infer_deps(
     TaskSlot slot, const std::vector<TaskArgs> &args_list, const std::vector<int32_t> &target_worker_ids,
-    const std::vector<RemoteTaskArgsSidecar> &remote_sidecars, std::vector<TaskSlot> &producers,
+    const std::vector<RemoteTaskArgsSidecar> &remote_sidecars, std::vector<ProducerDependency> &producers,
     std::vector<TensorKey> &output_keys
 ) {
     RunId run_id = slot_state(slot).run_id;
-    std::unordered_set<TaskSlot> producer_seen;
+    std::unordered_map<TaskSlot, size_t> producer_indices;
     size_t tensor_count_hint = 0;
+    size_t explicit_dep_count_hint = 0;
     for (const TaskArgs &args : args_list) {
         tensor_count_hint += static_cast<size_t>(args.tensor_count());
+        explicit_dep_count_hint += static_cast<size_t>(args.explicit_dep_count());
     }
-    producer_seen.reserve(tensor_count_hint);
+    producer_indices.reserve(tensor_count_hint + explicit_dep_count_hint);
 
-    auto add_unique_producer = [&](TaskSlot p) {
+    auto add_unique_producer = [&](TaskSlot p, bool retain) {
         // Group submits walk many TaskArgs under one slot: if two entries in
         // the same group tag the same buffer (e.g. both OUTPUT 0xCAFE), the
         // second-pass lookup would return the slot that the first pass just
         // inserted — a self-loop. Skip it.
         if (p == slot) return;
-        if (producer_seen.insert(p).second) {
-            producers.push_back(p);
+        auto [it, inserted] = producer_indices.emplace(p, producers.size());
+        if (inserted) {
+            producers.push_back(ProducerDependency{p, retain});
+        } else if (retain) {
+            producers[it->second].retain = true;
         }
     };
+
+    for (const TaskArgs &args : args_list) {
+        for (int32_t i = 0; i < args.explicit_dep_count(); ++i) {
+            add_unique_producer(args.explicit_dep(i).task_slot, args.explicit_dep_retain(i));
+        }
+    }
 
     // One key can resolve to several producers, one per live view under it that this arg's own
     // view reaches. `overlapping` is scratch reused across args.
@@ -1190,7 +1227,7 @@ void Orchestrator::infer_deps(
         overlapping.clear();
         tensormap_->lookup_overlapping(run_id, key, view, overlapping);
         for (TaskSlot prod : overlapping) {
-            add_unique_producer(prod);
+            add_unique_producer(prod, true);
         }
     };
 

--- a/src/common/hierarchical/orchestrator.h
+++ b/src/common/hierarchical/orchestrator.h
@@ -54,17 +54,16 @@
 class WorkerManager;
 
 // ---------------------------------------------------------------------------
-// SubmitResult — C++ internal slot id
+// TaskHandle — run-scoped producer handle
 // ---------------------------------------------------------------------------
 //
 // Downstream consumers reference outputs by their own tensor pointers (the
 // tensors live in the HeapRing allocated by the Worker), and tensormap.lookup
 // finds the producer slot from the data pointer. No outputs[] field needed.
-// This is intentionally not exposed through the Python facade.
+// The Python facade exposes this as an opaque handle for TaskArgs.add_dep()
+// and TaskArgs.add_dep_wait().
 
-struct SubmitResult {
-    TaskSlot task_slot{INVALID_SLOT};
-};
+using SubmitResult = TaskHandle;
 
 // Deterministic seams for exception-safety unit tests. Production workers
 // leave the callback unset.
@@ -281,16 +280,23 @@ private:
         std::vector<TaskArgs> &args_list, const std::vector<RemoteTaskArgsSidecar> &remote_sidecars
     );
 
+    struct ProducerDependency {
+        TaskSlot slot{INVALID_SLOT};
+        bool retain{false};
+    };
+
     // Walk the tags of each TaskArgs in `args_list`, accumulating producer
-    // slots (for INPUT/INOUT tags) and registering outputs in the tensormap
-    // (for OUTPUT/INOUT/OUTPUT_EXISTING tags). NO_DEP tags are skipped.
+    // edges (explicit wait/retain deps plus retained INPUT/INOUT deps) and
+    // registering outputs in the tensormap (for
+    // OUTPUT/INOUT/OUTPUT_EXISTING tags). NO_DEP tags are skipped.
     // `target_worker_ids` maps NEXT_LEVEL args_list[i] to its exact worker for
     // TensorKey construction. It is empty for SUB tasks.
     void infer_deps(
         TaskSlot slot, const std::vector<TaskArgs> &args_list, const std::vector<int32_t> &target_worker_ids,
-        const std::vector<RemoteTaskArgsSidecar> &remote_sidecars, std::vector<TaskSlot> &producers,
+        const std::vector<RemoteTaskArgsSidecar> &remote_sidecars, std::vector<ProducerDependency> &producers,
         std::vector<TensorKey> &output_keys
     );
+    void validate_explicit_deps(RunId run_id, const std::vector<TaskArgs> &args_list) const;
     void validate_worker_eligibility(
         WorkerType worker_type, size_t args_count, const std::vector<int32_t> &target_worker_ids,
         const std::vector<std::vector<int32_t>> &eligible_worker_ids

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -360,12 +360,12 @@ struct TaskSlotState {
     std::atomic<bool> failure_propagation_pending{false};
 
     // --- Fanout, plus the slot's pre-dispatch state transitions ---
-    // orch adds consumers; scheduler traverses on completion. The same mutex
+    // orch adds wait consumers; scheduler traverses on completion. The same mutex
     // covers every BUILDING/PENDING -> {READY, FAILED} transition and the
     // fields each of those decisions reads.
     std::mutex fanout_mu;
     std::vector<TaskSlot> fanout_consumers;
-    int32_t fanout_total{0};                  // 1 (scope ref) + fanout_consumers.size()
+    int32_t fanout_total{0};                  // scope ref + retained consumer refs
     std::atomic<int32_t> fanout_released{0};  // incremented as each ref is released
 
     // --- TensorMap keys registered by this task (for cleanup on CONSUMED) ---

--- a/src/common/task_interface/task_args.h
+++ b/src/common/task_interface/task_args.h
@@ -24,7 +24,8 @@
  *
  * Concrete user-facing types (typedefs at the bottom):
  *   - TaskArgs            — vector-backed + TensorArgType tags (the unified
- *                           builder used by Orchestrator.submit_*)
+ *                           builder used by Orchestrator.submit_*), with
+ *                           host-graph explicit dependency handles
  *   - ChipStorageTaskArgs — fixed POD matching the runtime.so ABI byte-for-byte
  *
  * Wire / dispatch helpers:
@@ -45,6 +46,18 @@
 #include "arg_direction.h"
 #include "buffer.h"  // Tensor wire type + TENSOR_BLOB_MAGIC for the blob envelope
 #include "tensor.h"  // ChipTensor (device POD) + TensorArgType, the tag TaskArgs carries
+
+// Opaque at the Python surface. The run id prevents a slot from being reused
+// as a dependency after the parent-side Ring resets its monotonic slot ids.
+struct TaskHandle {
+    uint64_t run_id{0};
+    int32_t task_slot{-1};
+};
+
+struct ExplicitTaskDependency {
+    TaskHandle task;
+    bool retain{false};
+};
 
 // ============================================================================
 // TensorTagMixin — conditionally provides per-tensor tag storage
@@ -128,6 +141,7 @@ template <typename T, typename S, typename TensorTag>
 struct TaskArgsTpl<T, S, 0, 0, TensorTag> : TensorTagMixin<TensorTag, 0> {
     std::vector<T> tensors_;
     std::vector<S> scalars_;
+    std::vector<ExplicitTaskDependency> explicit_deps_;
 
     void add_tensor(const T &t) {
         if (!scalars_.empty()) throw std::logic_error("TaskArgs: cannot add tensor after scalar");
@@ -147,6 +161,9 @@ struct TaskArgsTpl<T, S, 0, 0, TensorTag> : TensorTagMixin<TensorTag, 0> {
 
     void add_scalar(S s) { scalars_.push_back(s); }
 
+    void add_dep(const TaskHandle &task) { explicit_deps_.push_back(ExplicitTaskDependency{task, true}); }
+    void add_dep_wait(const TaskHandle &task) { explicit_deps_.push_back(ExplicitTaskDependency{task, false}); }
+
     const T &tensor(int32_t i) const { return tensors_[static_cast<size_t>(i)]; }
     T &tensor(int32_t i) { return tensors_[static_cast<size_t>(i)]; }
 
@@ -158,10 +175,14 @@ struct TaskArgsTpl<T, S, 0, 0, TensorTag> : TensorTagMixin<TensorTag, 0> {
 
     int32_t tensor_count() const { return static_cast<int32_t>(tensors_.size()); }
     int32_t scalar_count() const { return static_cast<int32_t>(scalars_.size()); }
+    int32_t explicit_dep_count() const { return static_cast<int32_t>(explicit_deps_.size()); }
+    const TaskHandle &explicit_dep(int32_t i) const { return explicit_deps_[static_cast<size_t>(i)].task; }
+    bool explicit_dep_retain(int32_t i) const { return explicit_deps_[static_cast<size_t>(i)].retain; }
 
     void clear() {
         tensors_.clear();
         scalars_.clear();
+        explicit_deps_.clear();
         if constexpr (!std::is_void_v<TensorTag>) {
             this->tags_.clear();
         }

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -2627,6 +2627,156 @@ TEST_F(SchedulerFixture, DependentTaskDispatchedAfterProducerCompletes) {
     (void)a;
 }
 
+TEST_F(SchedulerFixture, ExplicitTaskDependencyOrdersIndependentTaskWithoutRetainingProducer) {
+    auto producer = orch.submit_next_level(C(12), single_tensor_args(0xA100, TensorArgType::OUTPUT), cfg, 0);
+    EXPECT_EQ(producer.run_id, run_id);
+
+    TaskArgs consumer_args = single_tensor_args(0xB200, TensorArgType::OUTPUT);
+    consumer_args.add_dep_wait(producer);
+    auto consumer = orch.submit_next_level(C(13), consumer_args, cfg, 0);
+
+    EXPECT_EQ(S(consumer.task_slot).state.load(std::memory_order_acquire), TaskState::PENDING);
+    EXPECT_EQ(S(consumer.task_slot).fanin_count.load(std::memory_order_acquire), 1);
+    EXPECT_TRUE(S(consumer.task_slot).fanin_producers.empty());
+    {
+        std::lock_guard<std::mutex> lk(S(producer.task_slot).fanout_mu);
+        EXPECT_EQ(S(producer.task_slot).fanout_consumers, (std::vector<TaskSlot>{consumer.task_slot}));
+        EXPECT_EQ(S(producer.task_slot).fanout_total, 0);
+    }
+
+    mock_worker.wait_running();
+    ASSERT_EQ(mock_worker.dispatched_count(), 1);
+    EXPECT_EQ(mock_worker.dispatched[0].callable_hash0, 12u);
+    mock_worker.complete();
+
+    wait_consumed(producer.task_slot);
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(300);
+    while (mock_worker.dispatched_count() < 2 && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_EQ(mock_worker.dispatched_count(), 2);
+    EXPECT_EQ(mock_worker.dispatched[1].callable_hash0, 13u);
+
+    mock_worker.complete();
+    wait_consumed(consumer.task_slot);
+}
+
+TEST_F(SchedulerFixture, ExplicitWaitAndRetainDependenciesDeduplicateAndKeepProducerAlive) {
+    auto producer = orch.submit_next_level(C(22), single_tensor_args(0xFA00, TensorArgType::OUTPUT), cfg, 0);
+
+    TaskArgs consumer_args = single_tensor_args(0xFB00, TensorArgType::OUTPUT);
+    consumer_args.add_dep_wait(producer);
+    consumer_args.add_dep(producer);
+    auto consumer = orch.submit_next_level(C(23), consumer_args, cfg, 0);
+
+    EXPECT_EQ(S(consumer.task_slot).state.load(std::memory_order_acquire), TaskState::PENDING);
+    EXPECT_EQ(S(consumer.task_slot).fanin_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(S(consumer.task_slot).fanin_producers, (std::vector<TaskSlot>{producer.task_slot}));
+    {
+        std::lock_guard<std::mutex> lk(S(producer.task_slot).fanout_mu);
+        EXPECT_EQ(S(producer.task_slot).fanout_consumers, (std::vector<TaskSlot>{consumer.task_slot}));
+        EXPECT_EQ(S(producer.task_slot).fanout_total, 1);
+    }
+
+    mock_worker.wait_running();
+    mock_worker.complete();
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(300);
+    while (mock_worker.dispatched_count() < 2 && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_EQ(mock_worker.dispatched_count(), 2);
+    EXPECT_EQ(mock_worker.dispatched[1].callable_hash0, 23u);
+    EXPECT_EQ(S(producer.task_slot).state.load(std::memory_order_acquire), TaskState::COMPLETED);
+
+    mock_worker.complete();
+    wait_consumed(producer.task_slot);
+    wait_consumed(consumer.task_slot);
+}
+
+TEST_F(SchedulerFixture, ExplicitTaskDependencyOnAnAlreadyConsumedProducerIsSatisfied) {
+    auto producer = orch.submit_next_level(C(18), single_tensor_args(0xF600, TensorArgType::OUTPUT), cfg, 0);
+    mock_worker.wait_running();
+    mock_worker.complete();
+    wait_consumed(producer.task_slot);
+
+    TaskArgs consumer_args = single_tensor_args(0xF700, TensorArgType::OUTPUT);
+    consumer_args.add_dep_wait(producer);
+    auto consumer = orch.submit_next_level(C(19), consumer_args, cfg, 0);
+
+    EXPECT_EQ(S(consumer.task_slot).fanin_count.load(std::memory_order_acquire), 0);
+    EXPECT_NE(S(consumer.task_slot).state.load(std::memory_order_acquire), TaskState::PENDING);
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(300);
+    while (mock_worker.dispatched_count() < 2 && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_EQ(mock_worker.dispatched_count(), 2);
+    EXPECT_EQ(mock_worker.dispatched[1].callable_hash0, 19u);
+
+    mock_worker.complete();
+    wait_consumed(consumer.task_slot);
+}
+
+TEST_F(SchedulerFixture, FailedExplicitTaskDependencyPoisonsConsumer) {
+    auto producer = orch.submit_next_level(C(20), single_tensor_args(0xF800, TensorArgType::OUTPUT), cfg, 0);
+    TaskArgs consumer_args = single_tensor_args(0xF900, TensorArgType::OUTPUT);
+    consumer_args.add_dep_wait(producer);
+    auto consumer = orch.submit_next_level(C(21), consumer_args, cfg, 0);
+
+    EXPECT_EQ(S(consumer.task_slot).state.load(std::memory_order_acquire), TaskState::PENDING);
+    mock_worker.wait_running();
+    mock_worker.complete_with_error("explicit producer boom");
+
+    wait_consumed(producer.task_slot);
+    wait_consumed(consumer.task_slot);
+    EXPECT_TRUE(orch.run_failed(run_id));
+    EXPECT_EQ(mock_worker.dispatched_count(), 1);
+}
+
+TEST_F(SchedulerFixture, ExplicitTaskDependencyDeduplicatesAnInferredLifetimeEdge) {
+    auto producer = orch.submit_next_level(C(14), single_tensor_args(0xC300, TensorArgType::OUTPUT), cfg, 0);
+
+    TaskArgs consumer_args = single_tensor_args(0xC300, TensorArgType::INPUT);
+    consumer_args.add_dep_wait(producer);
+    consumer_args.add_dep_wait(producer);
+    auto consumer = orch.submit_next_level(C(15), consumer_args, cfg, 0);
+
+    EXPECT_EQ(S(consumer.task_slot).fanin_count.load(std::memory_order_acquire), 1);
+    EXPECT_EQ(S(consumer.task_slot).fanin_producers, (std::vector<TaskSlot>{producer.task_slot}));
+    {
+        std::lock_guard<std::mutex> lk(S(producer.task_slot).fanout_mu);
+        EXPECT_EQ(S(producer.task_slot).fanout_consumers, (std::vector<TaskSlot>{consumer.task_slot}));
+        EXPECT_EQ(S(producer.task_slot).fanout_total, 1);
+    }
+
+    mock_worker.wait_running();
+    mock_worker.complete();
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(300);
+    while (mock_worker.dispatched_count() < 2 && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_EQ(mock_worker.dispatched_count(), 2);
+    mock_worker.complete();
+    wait_consumed(producer.task_slot);
+    wait_consumed(consumer.task_slot);
+}
+
+TEST_F(SchedulerFixture, ExplicitTaskDependencyRejectsAHandleFromAnotherRunBeforeAllocating) {
+    auto producer = orch.submit_next_level(C(16), single_tensor_args(0xD400, TensorArgType::OUTPUT), cfg, 0);
+    TaskHandle foreign = producer;
+    foreign.run_id++;
+
+    TaskArgs consumer_args = single_tensor_args(0xE500, TensorArgType::OUTPUT);
+    consumer_args.add_dep_wait(foreign);
+    int32_t next_task_id = allocator.next_task_id();
+    EXPECT_THROW((void)orch.submit_next_level(C(17), consumer_args, cfg, 0), std::invalid_argument);
+    EXPECT_EQ(allocator.next_task_id(), next_task_id);
+
+    mock_worker.wait_running();
+    mock_worker.complete();
+    wait_consumed(producer.task_slot);
+}
+
 // Issue #1024: composed child kernels can carry far more tensor args than a
 // top-level entry (repro: 76 tensors + 2 scalars = 3064-byte blob). The
 // mailbox must hold any blob the runtime itself accepts, i.e. up to

--- a/tests/ut/py/test_callable_identity.py
+++ b/tests/ut/py/test_callable_identity.py
@@ -815,6 +815,26 @@ def test_chip_submit_uses_chip_index_worker_id():
     assert call[6] == []
 
 
+def test_next_level_submit_returns_native_task_handle():
+    task_handle = object()
+
+    class FakeCOrchestrator:
+        def submit_next_level(self, *args):
+            self.submit_next_level_args = args
+            return task_handle
+
+    handle = CallableHandle(
+        "sha256:" + "00" * 32,
+        "CHIP_CALLABLE",
+        "LOCAL_CHIP",
+    )
+    orch = Orchestrator(FakeCOrchestrator())
+
+    result = orch.submit_next_level(handle, TaskArgs(), worker=0)
+
+    assert result is task_handle
+
+
 def test_next_level_submit_requires_valid_explicit_targets():
     class FakeCOrchestrator:
         def submit_next_level(self, *args):

--- a/tests/ut/py/test_task_interface.py
+++ b/tests/ut/py/test_task_interface.py
@@ -27,6 +27,7 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
     CoreCallable,
     DataType,
     TaskArgs,
+    TaskHandle,
     TaskState,
     TensorArgType,
     arg_direction_name,
@@ -499,6 +500,18 @@ class TestTaskArgs:
         assert args.scalar_count() == 1
         assert args.tensor_count() == 0
         assert len(args) == 1
+
+    def test_task_handle_is_opaque_and_dependency_methods_require_one(self):
+        with pytest.raises(TypeError):
+            TaskHandle()
+
+        args = TaskArgs()
+        for method_name in ("add_dep", "add_dep_wait"):
+            method = getattr(args, method_name)
+            with pytest.raises(ValueError, match="at least one"):
+                method()
+            with pytest.raises(TypeError):
+                method(object())
 
     def test_mixed_with_tags(self):
         args = TaskArgs()

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -7241,7 +7241,7 @@ class TestParallelSubWorkers:
 
 
 # ---------------------------------------------------------------------------
-# Test: submit_* returns None at the Python facade; task slots stay internal.
+# Test: SUB submit returns None at the Python facade.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/ut/py/test_worker/test_l4_recursive.py
+++ b/tests/ut/py/test_worker/test_l4_recursive.py
@@ -25,7 +25,7 @@ import pytest
 from _task_interface import DataType
 from simpler.buffer import mint_owner_instance_id, wrap_device_malloc
 from simpler.callable_identity import CallableHandle
-from simpler.task_interface import CallConfig, TaskArgs
+from simpler.task_interface import CallConfig, TaskArgs, TaskHandle
 from simpler.worker import Worker
 
 from ._harness import (
@@ -323,6 +323,38 @@ class TestL4ToL3SingleDispatch:
 
 
 class TestL4ToL3MultipleDispatches:
+    @pytest.mark.parametrize("dep_method", ["add_dep", "add_dep_wait"])
+    def test_l4_explicit_task_dependency_uses_returned_handle(self, dep_method):
+        counter_shm, counter_buf = _make_shared_counter()
+
+        try:
+            l3 = Worker(level=3, num_sub_workers=1)
+            l3_sub_handle = l3.register(lambda args: _increment_counter(counter_buf))
+
+            def l3_orch(orch, args, config):
+                orch.submit_sub(l3_sub_handle)
+
+            w4 = Worker(level=4, num_sub_workers=0)
+            l3_handle = w4.register(l3_orch)
+            l3_worker_id = w4.add_worker(l3)
+            w4.init()
+
+            def l4_orch(orch, args, config):
+                producer = orch.submit_next_level(l3_handle, TaskArgs(), CallConfig(), worker=l3_worker_id)
+                assert isinstance(producer, TaskHandle)
+                consumer_args = TaskArgs()
+                getattr(consumer_args, dep_method)(producer)
+                consumer = orch.submit_next_level(l3_handle, consumer_args, CallConfig(), worker=l3_worker_id)
+                assert isinstance(consumer, TaskHandle)
+
+            w4.run(l4_orch)
+            w4.close()
+
+            assert _read_counter(counter_buf) == 2
+        finally:
+            counter_shm.close()
+            counter_shm.unlink()
+
     def test_l4_dispatches_three_times(self):
         """L4 orch submits 3 tasks to L3 child, each running a sub callable."""
         counter_shm, counter_buf = _make_shared_counter()


### PR DESCRIPTION
## Summary
- Return opaque, run-scoped `TaskHandle` values from NEXT_LEVEL submissions.
- Add `TaskArgs.add_dep(*handles)` with `WAIT | RETAIN` semantics.
- Add `TaskArgs.add_dep_wait(*handles)` with ordering-only `WAIT` semantics.
- Validate handle ownership and deduplicate explicit and tensor-inferred edges with retention winning.
- Document both APIs and cover scheduler, binding, facade, and L4-to-L3 integration behavior.

## Semantics
- `add_dep` keeps each producer and its task-owned resources alive until the consumer completes.
- `add_dep_wait` lets each producer be consumed after it completes and notifies the consumer.
- Repeated handles collapse to one edge; any retaining path upgrades the edge to retained.
- Python handles are opaque and valid only within the orchestration run that created them.

## Testing
- [x] All pre-commit hooks pass
- [x] `ctest --test-dir tests/ut/cpp/build -LE requires_hardware --output-on-failure` (117 passed)
- [x] `.venv/bin/python -m pytest tests/ut/py -q` (1919 passed, 7 skipped)
- [x] No hardware testing required for this common host scheduler/API change

Fixes #1954