### PR TITLE
Refactor: drop the two DFX artifact schema versions nothing reads

### DIFF
--- a/docs/dfx/scope-stats.md
+++ b/docs/dfx/scope-stats.md
@@ -161,13 +161,11 @@ only the `real_occupancy` curve.
 ## 3. Output: `scope_stats.jsonl`
 
 NDJSON. Line 1 is run metadata; each subsequent line is one scope
-sample (`begin` or `end`). Schema version 6 (bumped from 5 when
-`heap_start`/`heap_end` changed from wrapping ring offsets to monotonic
-cumulative bytes — a `version == 5` file's heap fields wrap, a `version == 6`
-file's do not):
+sample (`begin` or `end`). `heap_start`/`heap_end` are monotonic cumulative
+bytes, not wrapping ring offsets:
 
 ```json
-{"version": 6, "fatal": false, "dropped": 0, "total": 4, "task_window_max": [8, 4], "heap_max": [268435456, 268435456], "dep_pool_max": [1024, 1024], "tensormap_max": 65536}
+{"fatal": false, "dropped": 0, "total": 4, "task_window_max": [8, 4], "heap_max": [268435456, 268435456], "dep_pool_max": [1024, 1024], "tensormap_max": 65536}
 {"site": "example_orchestration.cpp:77", "phase": "begin", "depth": 1, "ring": 1, "task_window_start": 0, "task_window_end": 0, "heap_start": 0, "heap_end": 0, "dep_pool_start": 1, "dep_pool_end": 1, "tensormap": 0}
 {"site": "example_orchestration.cpp:77", "phase": "end", "depth": 1, "ring": 1, "task_window_start": 0, "task_window_end": 4, "heap_start": 0, "heap_end": 8192, "dep_pool_start": 1, "dep_pool_end": 6, "tensormap": 5}
 ```
@@ -176,7 +174,6 @@ Metadata line (line 1):
 
 | Field | Type | Meaning |
 | ----- | ---- | ------- |
-| `version` | int | Schema version (`6`) |
 | `fatal` | bool | `true` iff a fatal was latched during the run; records past it are diagnostic-only |
 | `dropped` | uint | Records dropped on device (free_queue empty / ready_queue full); `0` on a healthy run |
 | `total` | uint | Total records the device attempted (collected + dropped) |

--- a/src/common/platform/include/host/scope_stats_collector.h
+++ b/src/common/platform/include/host/scope_stats_collector.h
@@ -43,7 +43,7 @@
  *   finalize()           — Free all device memory, unregister.
  *
  * Output (scope_stats/scope_stats.jsonl), NDJSON:
- *   line 1: {"version":6,"fatal":bool,"dropped":uint,"total":uint,
+ *   line 1: {"fatal":bool,"dropped":uint,"total":uint,
  *            "task_window_max":[...],"heap_max":[...],
  *            "dep_pool_max":[...],"tensormap_max":uint}
  *   line k: {"site":"file:line","phase":"begin|end","depth":int,

--- a/src/common/platform/shared/host/chip_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/chip_swimlane_collector.cpp
@@ -1046,7 +1046,6 @@ int ChipSwimlaneCollector::export_swimlane_json() {
     }
     if (clock_correlation_session_.started()) {
         outfile << ",\n    \"clock_anchors\": {";
-        outfile << "\n      \"schema_version\": 1,";
         outfile << "\n      \"provider\": \"" << clock_correlation_session_.provider_name() << "\",";
         outfile << "\n      \"device_timestamp_unit\": \"syscnt_cycles\",";
         outfile << "\n      \"raw_device_timestamp_unit\": \"" << clock_correlation_session_.raw_device_timestamp_unit()

--- a/src/common/platform/shared/host/scope_stats_collector.cpp
+++ b/src/common/platform/shared/host/scope_stats_collector.cpp
@@ -288,9 +288,9 @@ int ScopeStatsCollector::write_jsonl(const std::string &output_dir) {
     }
     std::fprintf(
         fp,
-        // version 6: heap_start/heap_end are monotonic cumulative bytes (was
-        // wrapping ring offsets in v5) — see docs/dfx/scope-stats.md.
-        "{\"version\": 6, \"fatal\": %s, \"dropped\": %u, \"total\": %u, "
+        // heap_start/heap_end are monotonic cumulative bytes, not wrapping ring
+        // offsets — see docs/dfx/scope-stats.md.
+        "{\"fatal\": %s, \"dropped\": %u, \"total\": %u, "
         "\"task_window_max\": [%s], \"heap_max\": [%s], \"dep_pool_max\": [%s], \"tensormap_max\": %d}\n",
         hdr->fatal_latched ? "true" : "false", state->dropped_record_count, state->total_record_count,
         task_window_max.c_str(), heap_max.c_str(), dep_pool_max.c_str(), hdr->tensormap_cap

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
@@ -18,7 +18,7 @@ runtime takes care of the ``set_pending_site`` / ``scope_stats_begin`` /
 ``scope_stats_end`` calls. Schema lives in ``docs/dfx/scope-stats.md`` §3.
 
 Output (``scope_stats.jsonl``): line 1 is run metadata
-(``{"version":6,"fatal":bool,"dropped":uint,"total":uint}``); each subsequent
+(``{"fatal":bool,"dropped":uint,"total":uint}``); each subsequent
 line is one scope-boundary record carrying task/heap/dep_pool start-end.
 """
 
@@ -132,7 +132,6 @@ class TestScopeStats(SceneTestCase):
         lines = [ln for ln in path.read_text().splitlines() if ln.strip()]
         assert lines, f"scope_stats.jsonl empty under {out_dir}"
         meta = json.loads(lines[0])
-        assert meta.get("version") == 6, f"unexpected schema version: {meta!r}"
         assert meta.get("fatal") is False, f"run latched fatal: {meta!r}"
         assert meta.get("dropped", 0) == 0, f"records dropped on device: {meta!r}"
         assert "dep_pool_max" in meta, f"metadata missing dep_pool_max: {meta!r}"

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
@@ -18,7 +18,7 @@ runtime takes care of the ``set_pending_site`` / ``scope_stats_begin`` /
 ``scope_stats_end`` calls. Schema lives in ``docs/dfx/scope-stats.md`` §3.
 
 Output (``scope_stats.jsonl``): line 1 is run metadata
-(``{"version":6,"fatal":bool,"dropped":uint,"total":uint}``); each subsequent
+(``{"fatal":bool,"dropped":uint,"total":uint}``); each subsequent
 line is one scope-boundary record carrying task/heap/dep_pool start-end.
 """
 
@@ -132,7 +132,6 @@ class TestScopeStats(SceneTestCase):
         lines = [ln for ln in path.read_text().splitlines() if ln.strip()]
         assert lines, f"scope_stats.jsonl empty under {out_dir}"
         meta = json.loads(lines[0])
-        assert meta.get("version") == 6, f"unexpected schema version: {meta!r}"
         assert meta.get("fatal") is False, f"run latched fatal: {meta!r}"
         assert meta.get("dropped", 0) == 0, f"records dropped on device: {meta!r}"
         assert "dep_pool_max" in meta, f"metadata missing dep_pool_max: {meta!r}"


### PR DESCRIPTION
## Summary

`scope_stats.jsonl` carried `"version": 6` and the chip-swimlane `clock_anchors` object carried `"schema_version": 1`. Both are written by platform C++ in this repo and read by tools in this repo, from the same checkout, in the same build — the two sides cannot disagree, so neither number can ever be anything but the current one. And neither is actually read:

```console
$ grep -n version simpler_setup/tools/scope_stats_plot.py
$ grep -rn schema_version simpler_setup/tools/
$ # both empty
```

What they cost is maintenance. `version` reached **6** — five bumps of a field no consumer branches on, each carrying a comment explaining what the previous value meant. The scope-stats ST asserted the current value, so a sixth bump also meant editing a test that only checked the number matched itself.

Removed: the field from each writer, the header's output-format comment, the ST assertion and its docstring (both arch copies), and the schema table plus version prose in `docs/dfx/scope-stats.md`. The heap semantics that motivated v6 stay documented — as a statement of what `heap_start`/`heap_end` *mean*, rather than of which version changed them.

## Deliberately not touched

Two version constants sit outside this reasoning because their two sides genuinely can be built separately, and both are actively validated:

| Constant | Why it stays |
| --- | --- |
| `remote_wire.h` / `remote_l3_protocol.py` `PROTOCOL_VERSION` | The remote L3 runner is a different process on a **different host**, negotiating through the `HELLO` handshake. `decode_frame` raises `"remote_wire: unsupported frame version"` on a mismatch. |
| `runtime_c_api.h` `PTO_PIPELINE_CONTRACT_ABI_VERSION` | The external contract surface another repository compiles against (Tier-C in `codestyle.md` §10). |

`t.version` in the dep-gen artifact is also untouched — it is a tensor's mutation generation, real data rather than a format number.

## Testing

- [x] `clang-format --dry-run -Werror` clean; `markdownlint-cli2` clean on the doc
- [x] `pytest tests/ut -m "not requires_hardware"` — 1900 passed, 7 skipped
- [x] `ctest -LE requires_hardware` — 119/119
- [x] Simulation tests pass — scope-stats smoke on both arches, and the artifact inspected rather than assumed:

  ```console
  $ pytest tests/st/{a2a3,a5}/.../dfx/scope_stats/ --platform {a2a3,a5}sim \
      --manual include --enable-scope-stats
  1 passed   (each)

  $ # emitted metadata line:
  records: 4
  meta keys: ['dep_pool_max', 'dropped', 'fatal', 'heap_max',
              'task_window_max', 'tensormap_max', 'total']
  version key present: False
  ```

- [x] Hardware tests pass — the `clock_anchors` branch only runs **on hardware with the swimlane at ORCH_PHASES**, so it was executed rather than reasoned about:

  ```console
  $ pytest tests/st/a2a3/host_build_graph/vector_example --platform a2a3 \
      --enable-chip-swimlane
  1 passed
  $ # metadata.clock_anchors from that run — parses, five keys, no schema_version:
  ['device_timestamp_unit', 'provider', 'raw_device_timestamp_unit',
   'samples', 'samples_per_position']
  ```

  Plus the onboard chip-swimlane smoke, `4 passed`. (Its first attempt hit one `sched_error_code=100 SCHEDULER_TIMEOUT` on a `tensormap_and_ringbuffer` case — the shared box's known contention flake; a host-side JSON key cannot cause a device scheduler timeout, and the re-run was clean.)
