### PR TITLE
Fix: contain SIGTERM during child startup failure

### DIFF
--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -4255,7 +4255,10 @@ def _forked_child_main(buf: memoryview, label: str, setup, serve, make_group_lea
     with one ``killpg``; deeper descendants inherit the group and do not set
     their own. During ``setup`` a SIGTERM is a cooperative cancel: it raises
     ``_StartupCancelled``, which unwinds ``setup`` (recursively tearing down any
-    grandchildren and their nested shms) before the child exits.
+    grandchildren and their nested shms) before the child exits. Once the setup
+    frame has returned or unwound, SIGTERM terminates directly instead of
+    injecting another Python exception into readiness publication or failure
+    handling.
 
     Load-bearing invariant: a forked child must NEVER let an exception unwind
     back into the forked copy of the parent's ``_start_hierarchical`` frames.
@@ -4263,41 +4266,52 @@ def _forked_child_main(buf: memoryview, label: str, setup, serve, make_group_lea
     into the startup rollback path would SIGKILL this child's *siblings* (real
     processes at those PIDs). Catch everything and exit instead.
     """
-    import traceback as _tb  # noqa: PLC0415
-
-    if make_group_leader:
-        with contextlib.suppress(OSError):
-            os.setpgid(0, 0)
-
-    state_addr = _buffer_field_addr(buf, _OFF_STATE)
-
-    def _on_cancel(_signum, _frame):
-        raise _StartupCancelled()
-
-    prev_term = signal.signal(signal.SIGTERM, _on_cancel)
+    exit_code = 1  # Fail closed; only a clean serve() return marks success.
     try:
-        ctx = setup()
-    except _StartupCancelled:
-        # Parent cancelled us mid-init; setup() already unwound its own subtree.
-        _tb.print_exc()
-        os._exit(1)
-    except BaseException as e:  # noqa: BLE001
-        _tb.print_exc()
-        _write_error(buf, 1, _format_exc(f"{label} init", e))
-        _mailbox_store_i32(state_addr, _INIT_FAILED)
-        os._exit(1)
-    # Serving is torn down via the SHUTDOWN mailbox state, not the cancel signal.
-    # signal.signal returns None when the prior handler was not installed from
-    # Python (e.g. a C library / host default); restore SIG_DFL in that case so
-    # the round-trip does not raise TypeError.
-    signal.signal(signal.SIGTERM, prev_term if prev_term is not None else signal.SIG_DFL)
-    _mailbox_store_i32(state_addr, _INIT_READY)
-    try:
-        serve(ctx)
-    except BaseException:  # noqa: BLE001
-        _tb.print_exc()
-        os._exit(1)
-    os._exit(0)
+        import traceback as _tb  # noqa: PLC0415
+
+        if make_group_leader:
+            with contextlib.suppress(OSError):
+                os.setpgid(0, 0)
+
+        state_addr = _buffer_field_addr(buf, _OFF_STATE)
+        setup_active = True
+
+        def _on_cancel(_signum, _frame):
+            # Make cancellation one-shot so setup unwinding cannot be interrupted again.
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+            if setup_active:
+                raise _StartupCancelled()
+            os._exit(1)
+
+        prev_term = signal.signal(signal.SIGTERM, _on_cancel)
+        try:
+            try:
+                ctx = setup()
+            finally:
+                setup_active = False
+        except _StartupCancelled:
+            # Parent cancelled us mid-init; setup() already unwound its own subtree.
+            _tb.print_exc()
+        except BaseException as e:  # noqa: BLE001
+            _tb.print_exc()
+            _write_error(buf, 1, _format_exc(f"{label} init", e))
+            _mailbox_store_i32(state_addr, _INIT_FAILED)
+        else:
+            # Serving is torn down via the SHUTDOWN mailbox state, not the cancel signal.
+            # signal.signal returns None when the prior handler was not installed from
+            # Python (e.g. a C library / host default); restore SIG_DFL in that case so
+            # the round-trip does not raise TypeError.
+            signal.signal(signal.SIGTERM, prev_term if prev_term is not None else signal.SIG_DFL)
+            _mailbox_store_i32(state_addr, _INIT_READY)
+            try:
+                serve(ctx)
+            except BaseException:  # noqa: BLE001
+                _tb.print_exc()
+            else:
+                exit_code = 0
+    finally:
+        os._exit(exit_code)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/py/test_worker/test_startup_readiness.py
+++ b/tests/ut/py/test_worker/test_startup_readiness.py
@@ -123,6 +123,91 @@ def _trivial_orch(orch, args, config):
 
 
 class TestNextLevelStartupFailure:
+    def test_sigterm_during_setup_unwinds_before_child_exit(self, monkeypatch):
+        """Cooperative cancellation lets setup release its resources before exit."""
+        import simpler.worker as worker_mod  # noqa: PLC0415
+
+        class ExitCalled(BaseException):
+            def __init__(self, code):
+                self.code = code
+
+        handlers = {worker_mod.signal.SIGTERM: worker_mod.signal.SIG_DFL}
+
+        def install_handler(signum, handler):
+            previous = handlers.get(signum, worker_mod.signal.SIG_DFL)
+            handlers[signum] = handler
+            return previous
+
+        setup_events = []
+
+        def cancel_during_setup():
+            try:
+                handlers[worker_mod.signal.SIGTERM](worker_mod.signal.SIGTERM, None)
+            finally:
+                setup_events.append("unwound")
+
+        def record_exit(code):
+            raise ExitCalled(code)
+
+        monkeypatch.setattr(worker_mod.signal, "signal", install_handler)
+        monkeypatch.setattr(worker_mod.os, "_exit", record_exit)
+
+        buf = memoryview(bytearray(worker_mod.MAILBOX_FRAME_SIZE))
+        try:
+            with pytest.raises(ExitCalled) as exit_info:
+                worker_mod._forked_child_main(
+                    buf,
+                    "next_level worker 1",
+                    cancel_during_setup,
+                    lambda _ctx: setup_events.append("served"),
+                )
+            assert exit_info.value.code == 1
+            assert setup_events == ["unwound"]
+            assert handlers[worker_mod.signal.SIGTERM] == worker_mod.signal.SIG_IGN
+        finally:
+            buf.release()
+
+    def test_sigterm_during_init_failed_publication_cannot_escape_child_main(self, monkeypatch):
+        """The fork boundary remains terminal when cancellation interrupts failure publication."""
+        import simpler.worker as worker_mod  # noqa: PLC0415
+
+        class ExitCalled(BaseException):
+            def __init__(self, code):
+                self.code = code
+
+        handlers = {worker_mod.signal.SIGTERM: worker_mod.signal.SIG_DFL}
+
+        def install_handler(signum, handler):
+            previous = handlers.get(signum, worker_mod.signal.SIG_DFL)
+            handlers[signum] = handler
+            return previous
+
+        def interrupt_failed_publication(_addr, value):
+            if value == worker_mod._INIT_FAILED:
+                handlers[worker_mod.signal.SIGTERM](worker_mod.signal.SIGTERM, None)
+
+        def record_exit(code):
+            raise ExitCalled(code)
+
+        monkeypatch.setattr(worker_mod.signal, "signal", install_handler)
+        monkeypatch.setattr(worker_mod, "_mailbox_store_i32", interrupt_failed_publication)
+        monkeypatch.setattr(worker_mod.os, "_exit", record_exit)
+
+        buf = memoryview(bytearray(worker_mod.MAILBOX_FRAME_SIZE))
+        try:
+            with pytest.raises(ExitCalled) as exit_info:
+                worker_mod._forked_child_main(
+                    buf,
+                    "next_level worker 1",
+                    _init_raises,
+                    lambda _ctx: None,
+                )
+            assert exit_info.value.code == 1
+            assert "injected inner init failure" in worker_mod._read_error_msg(buf)
+            assert handlers[worker_mod.signal.SIGTERM] == worker_mod.signal.SIG_IGN
+        finally:
+            buf.release()
+
     def test_inner_init_failure_raises_bounded_error(self):
         """A next-level child whose init raises surfaces its error at startup."""
         l3 = _l3_child()


### PR DESCRIPTION
## Summary

- Keep SIGTERM cooperative only while a forked child is running setup, so cancellation still unwinds and cleans up its nested subtree.
- Make cancellation one-shot and terminate directly once setup has returned or unwound, preventing a signal-raised exception from escaping failure publication into inherited parent startup frames.
- Keep the fork boundary fail-closed through `os._exit()` and add deterministic regression coverage for cancellation during setup and during `INIT_FAILED` publication.

## Root cause

A parent rollback can send SIGTERM after a child has caught its setup error and entered the `except BaseException` failure-publication path. The signal handler previously raised `_StartupCancelled` there, but a sibling `except _StartupCancelled` cannot catch an exception raised from inside another `except` suite. That exception could therefore unwind into the forked copy of the parent's startup frames.

## Testing

- [x] `pytest tests/ut/py/test_worker/test_startup_readiness.py -q` — 72 passed
- [x] `pytest tests/ut -m 'not requires_hardware' -q` — 1896 passed, 13 skipped, 15 deselected
- [x] Hardware-marked Python UT through `task-submit` with onboard architecture precheck — passed
- [x] Ruff lint and format checks — passed

## Scope

This PR contains the child exception-containment fix. It does not change the cleanup journal retry or rollback reap-deadline policy; those can be hardened independently without expanding this signal-safety change.

Fixes #1948
