### PR TITLE
Refactor: drop the MPI group mailbox protocol version

### DIFF
--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -924,7 +924,6 @@ inline void bind_worker(nb::module_ &m) {
             using namespace mpi_group_mailbox;
             nb::dict layout;
             layout["MAGIC"] = nb::bytes(reinterpret_cast<const char *>(MAGIC), sizeof(MAGIC));
-            layout["PROTOCOL_VERSION"] = PROTOCOL_VERSION;
             layout["HEADER_BYTES"] = HEADER_BYTES;
             layout["PAYLOAD_BYTES"] = PAYLOAD_BYTES;
             layout["ERROR_BYTES"] = ERROR_BYTES;
@@ -933,7 +932,6 @@ inline void bind_worker(nb::module_ &m) {
             layout["ERROR_OFFSET"] = ERROR_OFFSET;
             layout["MAILBOX_BYTES"] = MAILBOX_BYTES;
             layout["OFF_MAGIC"] = OFF_MAGIC;
-            layout["OFF_PROTOCOL_VERSION"] = OFF_PROTOCOL_VERSION;
             layout["OFF_HEADER_BYTES"] = OFF_HEADER_BYTES;
             layout["OFF_MAILBOX_BYTES"] = OFF_MAILBOX_BYTES;
             layout["OFF_WORLD_SIZE"] = OFF_WORLD_SIZE;

--- a/python/simpler/mpi_group_mailbox.py
+++ b/python/simpler/mpi_group_mailbox.py
@@ -28,7 +28,6 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
 )
 
 MAILBOX_MAGIC = b"SMPIBOX\0"
-MAILBOX_PROTOCOL_VERSION = 1
 MAILBOX_HEADER_BYTES = 256
 MAILBOX_PAYLOAD_BYTES = 16 * 1024 * 1024
 MAILBOX_ERROR_BYTES = 64 * 1024
@@ -38,7 +37,6 @@ MAILBOX_ERROR_OFFSET = MAILBOX_RESPONSE_OFFSET + MAILBOX_PAYLOAD_BYTES
 MAILBOX_SIZE = MAILBOX_ERROR_OFFSET + MAILBOX_ERROR_BYTES
 
 _OFF_MAGIC = 0
-_OFF_PROTOCOL_VERSION = 8
 _OFF_HEADER_BYTES = 12
 _OFF_MAILBOX_BYTES = 16
 _OFF_WORLD_SIZE = 24
@@ -223,9 +221,7 @@ class MpiGroupMailbox:
             raise MpiGroupError("MPI group mailbox mapping returned no buffer")
         buffer = _as_byte_view(buffer)
         ctypes.memset(_buffer_address(buffer), 0, MAILBOX_SIZE)
-        struct.pack_into(
-            "<8sIIQ", buffer, _OFF_MAGIC, MAILBOX_MAGIC, MAILBOX_PROTOCOL_VERSION, MAILBOX_HEADER_BYTES, MAILBOX_SIZE
-        )
+        struct.pack_into("<8s4xIQ", buffer, _OFF_MAGIC, MAILBOX_MAGIC, MAILBOX_HEADER_BYTES, MAILBOX_SIZE)
         struct.pack_into("<I", buffer, _OFF_WORLD_SIZE, int(world_size))
         struct.pack_into("<i", buffer, _OFF_GROUP_STATE, int(MailboxGroupState.INITIALIZING))
         struct.pack_into("<i", buffer, _OFF_REQUEST_STATE, int(MailboxRequestState.IDLE))
@@ -269,7 +265,6 @@ class MpiGroupMailbox:
     def manifest(self) -> dict[str, Any]:
         return {
             "name": self.name,
-            "protocol_version": MAILBOX_PROTOCOL_VERSION,
             "mailbox_bytes": MAILBOX_SIZE,
             "world_size": self.world_size,
         }
@@ -456,11 +451,9 @@ class MpiGroupMailbox:
     def _validate_header(self) -> None:
         if len(self._buffer) < MAILBOX_SIZE:
             raise MpiGroupError("MPI group mailbox is smaller than the protocol layout")
-        magic, version, header_bytes, mailbox_bytes = struct.unpack_from("<8sIIQ", self._buffer, _OFF_MAGIC)
+        magic, header_bytes, mailbox_bytes = struct.unpack_from("<8s4xIQ", self._buffer, _OFF_MAGIC)
         if magic != MAILBOX_MAGIC:
             raise MpiGroupError("MPI group mailbox magic does not match")
-        if version != MAILBOX_PROTOCOL_VERSION:
-            raise MpiGroupError(f"MPI group mailbox protocol version {version} is not supported")
         if header_bytes != MAILBOX_HEADER_BYTES or mailbox_bytes != MAILBOX_SIZE:
             raise MpiGroupError("MPI group mailbox layout does not match the protocol")
         if self._read_u32(_OFF_WORLD_SIZE) == 0:
@@ -548,8 +541,6 @@ def open_rank_mailbox(manifest: dict[str, Any], *, rank: int) -> MpiGroupMailbox
 
     if int(rank) != 0:
         return None
-    if int(manifest.get("protocol_version", -1)) != MAILBOX_PROTOCOL_VERSION:
-        raise MpiGroupError("MPI group manifest mailbox protocol version does not match")
     if int(manifest.get("mailbox_bytes", -1)) != MAILBOX_SIZE:
         raise MpiGroupError("MPI group manifest mailbox size does not match")
     mailbox = MpiGroupMailbox.open(name=str(manifest["name"]))

--- a/src/common/hierarchical/mpi_group_mailbox.h
+++ b/src/common/hierarchical/mpi_group_mailbox.h
@@ -27,7 +27,6 @@
 namespace mpi_group_mailbox {
 
 inline constexpr uint8_t MAGIC[8] = {'S', 'M', 'P', 'I', 'B', 'O', 'X', '\0'};
-inline constexpr uint32_t PROTOCOL_VERSION = 1;
 inline constexpr size_t HEADER_BYTES = 256;
 inline constexpr size_t PAYLOAD_BYTES = 16U * 1024U * 1024U;
 inline constexpr size_t ERROR_BYTES = 64U * 1024U;
@@ -37,7 +36,6 @@ inline constexpr size_t ERROR_OFFSET = RESPONSE_OFFSET + PAYLOAD_BYTES;
 inline constexpr size_t MAILBOX_BYTES = ERROR_OFFSET + ERROR_BYTES;
 
 inline constexpr size_t OFF_MAGIC = 0;
-inline constexpr size_t OFF_PROTOCOL_VERSION = 8;
 inline constexpr size_t OFF_HEADER_BYTES = 12;
 inline constexpr size_t OFF_MAILBOX_BYTES = 16;
 inline constexpr size_t OFF_WORLD_SIZE = 24;
@@ -52,9 +50,10 @@ inline constexpr size_t OFF_REQUEST_BYTES = 64;
 inline constexpr size_t OFF_RESPONSE_COUNT = 68;
 inline constexpr size_t OFF_RESPONSE_BYTES = 72;
 inline constexpr size_t OFF_ERROR_BYTES = 76;
-// Header bytes [RESERVED_OFFSET, HEADER_BYTES) are reserved in protocol
-// version 1: the creator zeroes them and every attach path rejects a mailbox
-// whose reserved bytes are non-zero, so a future version can assign them.
+// Header bytes [RESERVED_OFFSET, HEADER_BYTES) are reserved: the creator zeroes
+// them and every attach path rejects a mailbox whose reserved bytes are
+// non-zero, so a later field can claim them. The word at offset 8 is likewise
+// unclaimed and left zero.
 inline constexpr size_t RESERVED_OFFSET = 80;
 
 // The request-state word doubles as a shared futex: the mailbox is mapped by

--- a/src/common/hierarchical/remote_endpoint.cpp
+++ b/src/common/hierarchical/remote_endpoint.cpp
@@ -727,7 +727,7 @@ MpiGroupMailboxChannel::MpiGroupMailboxChannel(
     if (std::memcmp(mailbox_ + OFF_MAGIC, MAGIC, sizeof(MAGIC)) != 0) {
         throw std::invalid_argument("MpiGroupMailboxChannel: mailbox magic mismatch");
     }
-    if (read_u32(OFF_PROTOCOL_VERSION) != PROTOCOL_VERSION || read_u32(OFF_HEADER_BYTES) != HEADER_BYTES) {
+    if (read_u32(OFF_HEADER_BYTES) != HEADER_BYTES) {
         throw std::invalid_argument("MpiGroupMailboxChannel: mailbox protocol mismatch");
     }
     if (read_u64(OFF_MAILBOX_BYTES) != MAILBOX_BYTES ||

--- a/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
+++ b/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
@@ -859,13 +859,11 @@ std::vector<uint8_t> ready_mpi_mailbox(int32_t world_size) {
     using namespace mpi_group_mailbox;
     std::vector<uint8_t> mailbox(MAILBOX_BYTES, 0);
     std::memcpy(mailbox.data() + OFF_MAGIC, MAGIC, sizeof(MAGIC));
-    const uint32_t version = PROTOCOL_VERSION;
     const uint32_t header_bytes = HEADER_BYTES;
     const uint64_t mailbox_bytes = MAILBOX_BYTES;
     const uint32_t size = static_cast<uint32_t>(world_size);
     const int32_t ready = static_cast<int32_t>(GroupState::READY);
     const int32_t idle = static_cast<int32_t>(RequestState::IDLE);
-    std::memcpy(mailbox.data() + OFF_PROTOCOL_VERSION, &version, sizeof(version));
     std::memcpy(mailbox.data() + OFF_HEADER_BYTES, &header_bytes, sizeof(header_bytes));
     std::memcpy(mailbox.data() + OFF_MAILBOX_BYTES, &mailbox_bytes, sizeof(mailbox_bytes));
     std::memcpy(mailbox.data() + OFF_WORLD_SIZE, &size, sizeof(size));

--- a/tests/ut/py/test_mpi_group_mailbox.py
+++ b/tests/ut/py/test_mpi_group_mailbox.py
@@ -238,7 +238,6 @@ def test_python_and_cpp_mailbox_layouts_agree():
     layout = dict(_mpi_mailbox_layout())
     assert layout == {
         "MAGIC": mailbox_mod.MAILBOX_MAGIC,
-        "PROTOCOL_VERSION": mailbox_mod.MAILBOX_PROTOCOL_VERSION,
         "HEADER_BYTES": mailbox_mod.MAILBOX_HEADER_BYTES,
         "PAYLOAD_BYTES": mailbox_mod.MAILBOX_PAYLOAD_BYTES,
         "ERROR_BYTES": mailbox_mod.MAILBOX_ERROR_BYTES,
@@ -247,7 +246,6 @@ def test_python_and_cpp_mailbox_layouts_agree():
         "ERROR_OFFSET": mailbox_mod.MAILBOX_ERROR_OFFSET,
         "MAILBOX_BYTES": mailbox_mod.MAILBOX_SIZE,
         "OFF_MAGIC": mailbox_mod._OFF_MAGIC,  # noqa: SLF001
-        "OFF_PROTOCOL_VERSION": mailbox_mod._OFF_PROTOCOL_VERSION,  # noqa: SLF001
         "OFF_HEADER_BYTES": mailbox_mod._OFF_HEADER_BYTES,  # noqa: SLF001
         "OFF_MAILBOX_BYTES": mailbox_mod._OFF_MAILBOX_BYTES,  # noqa: SLF001
         "OFF_WORLD_SIZE": mailbox_mod._OFF_WORLD_SIZE,  # noqa: SLF001

--- a/tests/ut/py/test_mpi_l3_group.py
+++ b/tests/ut/py/test_mpi_l3_group.py
@@ -32,7 +32,6 @@ class _ReadyMailbox:
     def manifest(self):
         return {
             "name": "pytest-mpi-mailbox",
-            "protocol_version": 1,
             "mailbox_bytes": MAILBOX_SIZE,
             "world_size": self.world_size,
         }


### PR DESCRIPTION
## Summary

The L4↔L3 MPI group mailbox is **POSIX shared memory opened by name on one host**, and only rank 0 ever opens it (`open_rank_mailbox` returns `None` otherwise). Producer and consumer are the same install, so `PROTOCOL_VERSION` could never read as anything but `1` — while `MAGIC` already rejects a region that is not this mailbox, which is the failure that can actually happen.

**No offset moved.** The version word sat at offset 8 of a 256-byte header addressed by named offsets, so the creator now writes `"<8s4xIQ"` instead of `"<8sIIQ"` — that word stays zero and every later offset keeps its value.

Removed on both sides, plus the two places that mirror them:

- **Python** — the constant, `_OFF_PROTOCOL_VERSION`, the creator's packed field, the `_validate_header` check, the manifest key, and `open_rank_mailbox`'s manifest comparison.
- **C++** — `PROTOCOL_VERSION` / `OFF_PROTOCOL_VERSION`, and the read in `MpiGroupMailboxChannel`, which checked version and `HEADER_BYTES` together and now checks only the layout.
- **The bridge** — `_mpi_mailbox_layout()` in nanobind and the two entries in `test_python_and_cpp_mailbox_layouts_agree`. That test is what keeps the two sides in lockstep, so it is also what proves this landed on both.

## Not touched

Four version fields stay, because their two sides genuinely can be built separately and each is actively validated:

| Field | Why |
| --- | --- |
| `remote_wire.h` / `remote_l3_protocol.py` `PROTOCOL_VERSION` | A different **host**, negotiated in the `HELLO` handshake; `decode_frame` raises on mismatch |
| `descriptor_schema_version` | `docs/remote-l3-worker-design/protocol.md:375` pins it into that same remote wire |
| python-payload version | The `PYTHON_SERIALIZED` path negotiates serializer/ABI across hosts |
| `runtime_c_api.h` `PTO_PIPELINE_CONTRACT_ABI_VERSION` | Another repository compiles against it (Tier-C) |

## Testing

- [x] `clang-format --dry-run -Werror` clean on the four C++ files; `ruff check` clean on the three Python files
- [x] `pytest tests/ut/py/test_mpi_group_mailbox.py tests/ut/py/test_mpi_l3_group.py` — 18 passed, including the cross-language layout test
- [x] `pytest tests/ut -m "not requires_hardware"` — 1900 passed, 7 skipped
- [x] `ctest -LE requires_hardware` — 119/119, including `test_remote_endpoint`
- [ ] Scene tests not affected: this path is L4↔L3 MPI group bring-up, not the device pipeline

The build is what caught the one C++ reader I first missed — `MpiGroupMailboxChannel` in `remote_endpoint.cpp` reads the word, and a path-filtered grep had hidden it. Worth noting for review: the identifier grep to trust here is `git grep -nw PROTOCOL_VERSION`, unfiltered.