### PR TITLE
Refactor: drop the L4-L3 control-command version

### DIFF
--- a/python/simpler/global_comm_domain.py
+++ b/python/simpler/global_comm_domain.py
@@ -24,9 +24,6 @@ from .comm_endpoints import AdapterKind, AdapterProfile, AttachmentRole
 #: without the other fails every allocation at PREPARE. The ``LOCAL_*`` L3->L2 mailbox structs
 #: in ``worker.py`` also carry it; producer and consumer there are the same build.
 GLOBAL_DOMAIN_VERSION = 2
-#: L4<->L3 control-command layout: COMM_INIT, ALLOC_DOMAIN, RELEASE and COPY. Python owns both
-#: ends, so this advances on its own -- a command-layout change needs no C++ rebuild.
-GLOBAL_DOMAIN_COMMAND_VERSION = 2
 GLOBAL_DOMAIN_MAX_RANKS = 64
 GLOBAL_DOMAIN_MAX_BUFFERS = 64
 GLOBAL_DOMAIN_MAX_ATTACHMENT_ROWS = GLOBAL_DOMAIN_MAX_RANKS
@@ -540,7 +537,7 @@ def encode_comm_init(command: GlobalCommInitCommand) -> bytes:
         raise ValueError(f"unsupported global domain profile {command.profile!r}")
     if command.node_rank < 0 or command.node_count <= 0 or command.node_rank >= command.node_count:
         raise ValueError("global comm init node identity is invalid")
-    out = bytearray(struct.pack("<III", GLOBAL_DOMAIN_COMMAND_VERSION, command.node_rank, command.node_count))
+    out = bytearray(struct.pack("<II", command.node_rank, command.node_count))
     _put_string(out, command.cluster_id, "cluster_id")
     _put_string(out, command.topology_hash, "topology_hash")
     _put_string(out, command.profile, "profile")
@@ -552,9 +549,6 @@ def encode_comm_init(command: GlobalCommInitCommand) -> bytes:
 
 def decode_comm_init(data: bytes) -> GlobalCommInitCommand:
     reader = _Reader(data)
-    version = reader.u32()
-    if version != GLOBAL_DOMAIN_COMMAND_VERSION:
-        raise ValueError("global comm init version mismatch")
     node_rank = reader.u32()
     node_count = reader.u32()
     cluster_id = reader.string("cluster_id")
@@ -636,8 +630,7 @@ def encode_domain_command(command: GlobalDomainCommand) -> bytes:  # noqa: PLR09
 
     out = bytearray(
         struct.pack(
-            "<IIQQQ",
-            GLOBAL_DOMAIN_COMMAND_VERSION,
+            "<IQQQ",
             int(command.phase),
             int(command.domain_id),
             int(command.generation),
@@ -664,9 +657,6 @@ def encode_domain_command(command: GlobalDomainCommand) -> bytes:  # noqa: PLR09
 
 def decode_domain_command(data: bytes) -> GlobalDomainCommand:
     reader = _Reader(data)
-    version = reader.u32()
-    if version != GLOBAL_DOMAIN_COMMAND_VERSION:
-        raise ValueError("global domain command version mismatch")
     try:
         phase = GlobalDomainPhase(reader.u32())
     except ValueError as exc:
@@ -733,15 +723,15 @@ def decode_descriptor_table(data: bytes) -> tuple[GlobalDomainDescriptor, ...]:
 def encode_release_command(command: GlobalDomainReleaseCommand) -> bytes:
     if command.domain_id == 0 or command.generation == 0:
         raise ValueError("global domain release identity must be positive")
-    return struct.pack("<IQQ", GLOBAL_DOMAIN_COMMAND_VERSION, int(command.domain_id), int(command.generation))
+    return struct.pack("<QQ", int(command.domain_id), int(command.generation))
 
 
 def decode_release_command(data: bytes) -> GlobalDomainReleaseCommand:
-    if len(data) != struct.calcsize("<IQQ"):
+    if len(data) != struct.calcsize("<QQ"):
         raise ValueError("global domain release size mismatch")
-    version, domain_id, generation = struct.unpack("<IQQ", data)
-    if version != GLOBAL_DOMAIN_COMMAND_VERSION or domain_id == 0 or generation == 0:
-        raise ValueError("global domain release identity or version is invalid")
+    domain_id, generation = struct.unpack("<QQ", data)
+    if domain_id == 0 or generation == 0:
+        raise ValueError("global domain release identity is invalid")
     return GlobalDomainReleaseCommand(int(domain_id), int(generation))
 
 
@@ -761,8 +751,7 @@ def encode_copy_command(command: GlobalDomainCopyCommand, *, include_data: bool)
         raise ValueError("global domain copy-from request must not contain data")
     out = bytearray(
         struct.pack(
-            "<IQQIQQ",
-            GLOBAL_DOMAIN_COMMAND_VERSION,
+            "<QQIQQ",
             int(command.domain_id),
             int(command.generation),
             int(command.domain_rank),
@@ -776,10 +765,10 @@ def encode_copy_command(command: GlobalDomainCopyCommand, *, include_data: bool)
 
 
 def decode_copy_command(data: bytes, *, include_data: bool) -> GlobalDomainCopyCommand:
-    header_size = struct.calcsize("<IQQIQQ")
+    header_size = struct.calcsize("<QQIQQ")
     if len(data) < header_size:
         raise ValueError("global domain copy request is truncated")
-    version, domain_id, generation, domain_rank, offset, nbytes = struct.unpack_from("<IQQIQQ", data)
+    domain_id, generation, domain_rank, offset, nbytes = struct.unpack_from("<QQIQQ", data)
     payload = data[header_size:]
     command = GlobalDomainCopyCommand(
         domain_id=int(domain_id),
@@ -789,8 +778,6 @@ def decode_copy_command(data: bytes, *, include_data: bool) -> GlobalDomainCopyC
         nbytes=int(nbytes),
         data=bytes(payload),
     )
-    if version != GLOBAL_DOMAIN_COMMAND_VERSION:
-        raise ValueError("global domain copy version mismatch")
     encode_copy_command(command, include_data=include_data)
     return command
 

--- a/tests/ut/py/test_global_comm_domain.py
+++ b/tests/ut/py/test_global_comm_domain.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import os
 import re
 import socket
-import struct
 import subprocess
 import sys
 import threading
@@ -23,7 +22,6 @@ from pathlib import Path
 from typing import cast
 
 import pytest
-import simpler.global_comm_domain as domain_mod
 from simpler.buffer import AddressSpace
 from simpler.comm_endpoints import AdapterKind, AdapterProfile, AttachmentRole
 from simpler.global_comm_domain import (
@@ -316,46 +314,18 @@ def test_global_domain_attachment_names_every_unknown_enum_field():
         encode_domain_command(make_command(replace(good, adapter_profile=None)))
 
 
-def test_l4_l3_commands_version_independently_of_the_descriptor(monkeypatch):
-    """Python owns both ends of the L4<->L3 commands, so their layout versions separately from the
-    backend-stamped descriptor. Both constants hold the same number today, which would let a codec
-    that still read `GLOBAL_DOMAIN_VERSION` pass unnoticed -- so drive the command version to a
-    distinct value first. Under that override a descriptor-versioned encoder stamps the wrong
-    header, and a descriptor-versioned decoder rejects a payload it should accept.
+def test_release_and_copy_commands_round_trip_and_reject_a_missized_release():
+    """RELEASE is the one command whose decoder has no length-delimited field to disagree on, so
+    its fixed size is the whole frame check: a blob of any other length is rejected outright.
     """
-    members = _members()
-    command_version = GLOBAL_DOMAIN_VERSION + 1
-    monkeypatch.setattr(domain_mod, "GLOBAL_DOMAIN_COMMAND_VERSION", command_version)
-    encoded = {
-        "comm_init": encode_comm_init(GlobalCommInitCommand("cluster", "topology", "sim", 0, 2, members)),
-        "domain": encode_domain_command(
-            GlobalDomainCommand(
-                phase=GlobalDomainPhase.PREPARE_EXPORT,
-                domain_id=11,
-                generation=1,
-                name="tp",
-                profile="sim",
-                window_size=2048,
-                members=members,
-                buffers=(GlobalDomainBuffer("payload", 128),),
-            )
-        ),
-        "release": encode_release_command(GlobalDomainReleaseCommand(11, 1)),
-        "copy": encode_copy_command(GlobalDomainCopyCommand(11, 1, 0, 0, 4, b"abcd"), include_data=True),
-    }
-    decoders = {
-        "comm_init": decode_comm_init,
-        "domain": decode_domain_command,
-        "release": decode_release_command,
-        "copy": lambda data: decode_copy_command(data, include_data=True),
-    }
+    release = GlobalDomainReleaseCommand(11, 1)
+    assert decode_release_command(encode_release_command(release)) == release
 
-    for name, blob in encoded.items():
-        assert struct.unpack_from("<I", blob)[0] == command_version, name
-        decoders[name](blob)
-        foreign = struct.pack("<I", command_version + 1) + blob[4:]
-        with pytest.raises(ValueError, match="version"):
-            decoders[name](foreign)
+    copy = GlobalDomainCopyCommand(11, 1, 0, 0, 4, b"abcd")
+    assert decode_copy_command(encode_copy_command(copy, include_data=True), include_data=True) == copy
+
+    with pytest.raises(ValueError, match="release size mismatch"):
+        decode_release_command(encode_release_command(release) + b"\0" * 4)
 
 
 def test_global_domain_encode_rejects_too_many_buffers():


### PR DESCRIPTION
## Summary

`GLOBAL_DOMAIN_COMMAND_VERSION` stamped a leading word into all four L4<->L3 control commands — COMM_INIT, ALLOC_DOMAIN, RELEASE and COPY — and each decoder compared it. Both ends of every one of those commands are Python in this repository, and neither path can present a peer that disagrees:

- The **local** path encodes and decodes in the same install (`worker.py` drives both the `encode_*` calls and the `_handle_global_domain_*` decoders).
- The **remote** path carries the command as an opaque `command_bytes` blob inside a remote-L3 frame, and `remote_wire.cpp` checks `PROTOCOL_VERSION` on *every* frame (`remote_wire.cpp:259`), not only at HELLO, which it validates in both directions (`:281`, `:300`). A change to what those frames carry is a change to that protocol, so the version that governs it is the one already being checked one layer out.

So the word could only ever read as `2`, and the four `raise ValueError(... version mismatch)` arms were unreachable.

These are sequential encodings addressed by read order rather than by named offsets, so removing the word shortens each header instead of leaving a hole:

| command | header |
| ------- | ------ |
| COMM_INIT | 12 -> 8 bytes |
| ALLOC_DOMAIN | 32 -> 28 |
| RELEASE | 20 -> 16 |
| COPY | 40 -> 36 |

Both ends move together, and the remote round trip is covered end to end by `test_two_remote_daemons_build_and_copy_global_domain_without_mpirun`.

RELEASE is the one command with no length-delimited field, so its exact-size check is now the whole frame check; `decode_release_command` keeps it and its message loses the `or version` half.

`test_l4_l3_commands_version_independently_of_the_descriptor` existed only to prove the two constants were distinct, so it goes — but it was also the only direct round-trip coverage of the RELEASE and COPY codecs, so it is replaced by one that round-trips both and asserts the size check rejects a mis-sized RELEASE.

## Not touched

- `GLOBAL_DOMAIN_VERSION`, which the platform backend stamps into every descriptor and pairs with `COMM_GLOBAL_DOMAIN_VERSION` in `src/common/platform_comm/comm.h`, and which the `LOCAL_*` L3->L2 mailbox structs also carry.
- The `remote_wire.h` / `remote_l3_protocol.py` `PROTOCOL_VERSION` that makes this removal safe.

## Testing

- [x] `pytest tests/ut/py` — 1908 passed, 14 skipped
- [x] `pytest tests/ut/py/test_global_comm_domain.py` — 41 passed
- [x] `ruff` and `pyright` clean on both changed files
