### PR TITLE
CI: test A3 onboard jobs on x86 runner

### DIFF
--- a/.github/actions/run-onboard-dfx-smokes/action.yml
+++ b/.github/actions/run-onboard-dfx-smokes/action.yml
@@ -165,15 +165,10 @@ runs:
         exit "$failed"
         DFX_DRIVER
 
-        if [[ "$DFX_PLATFORM" == "a2a3" && "$(uname -m)" != "x86_64" ]]; then
+        if [[ "$DFX_PLATFORM" == "a2a3" ]]; then
           task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
             --run "bash '$DRIVER' a2a3 \$TASK_DEVICE"
         else
-          if [[ "$DFX_PLATFORM" == "a2a3" ]]; then
-            DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-            bash "$DRIVER" a2a3 "$DEVICE_LIST"
-          else
-            task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
-              --run "bash '$DRIVER' a5 \$TASK_DEVICE"
-          fi
+          task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
+            --run "bash '$DRIVER' a5 \$TASK_DEVICE"
         fi

--- a/.github/workflows/_st-deepseek-a2a3.yml
+++ b/.github/workflows/_st-deepseek-a2a3.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 30
     env:
-      SIMPLER_SCHEDULER_TIMEOUT_MS: "2000"
-      SIMPLER_OP_EXECUTE_TIMEOUT_US: "3000000"
-      SIMPLER_STREAM_SYNC_TIMEOUT_MS: "4000"
+      SIMPLER_SCHEDULER_TIMEOUT_MS: "10000"
+      SIMPLER_OP_EXECUTE_TIMEOUT_US: "45000000"
+      SIMPLER_STREAM_SYNC_TIMEOUT_MS: "50000"
     steps:
       - name: Checkout target
         uses: actions/checkout@v5

--- a/.github/workflows/_st-deepseek-a2a3.yml
+++ b/.github/workflows/_st-deepseek-a2a3.yml
@@ -35,7 +35,7 @@ jobs:
 
       # Own key family, separate from _st-npu-a2a3.yml's: the main sweep
       # compiles with --manual exclude and never builds these kernels, while
-      # this job compiles only the two DS directories. Sharing the main key
+      # this job compiles only the HBG DS directory. Sharing the main key
       # would let this partial compilation win the immutable-cache save race
       # and starve the main sweep's cache.
       - name: Restore scene-test kernel cache (a2a3)
@@ -60,21 +60,13 @@ jobs:
           source /usr/local/Ascend/cann/set_env.sh
           .venv/bin/python -m simpler_setup.tools.scene_test_compile \
             examples/a2a3/host_build_graph/deepseek_v4_flash_decode \
-            examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode \
             --platform a2a3 --require-pto-isa --compile-workers 8 -q --manual only
 
-      # The DS cases are the only manual cases under these two directories, so
-      # --manual only selects exactly the two smoke classes. They stay manual:
-      # the main sweep runs --manual exclude and must not adopt them back.
-      # Each case needs 2 devices (EP world size); 4 devices let both run
-      # concurrently.
+      # The HBG DS case is manual, so the main sweep runs --manual exclude and
+      # must not adopt it back. The case needs 2 devices for its EP world size.
       - name: Run DeepSeek pytest smokes (a2a3)
         run: |
           source /usr/local/Ascend/cann/set_env.sh
-          DS_TESTS="examples/a2a3/host_build_graph/deepseek_v4_flash_decode examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode"
-          if [ "$(uname -m)" = "x86_64" ]; then
-            .venv/bin/python -m pytest $DS_TESTS -m "not sdma" --platform a2a3 --exclude-level 4 --manual only --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 1200
-          else
-            task-submit --timeout 1800 --max-time 1800 --device auto --device-num 4 \
-              --run ".venv/bin/python -m pytest $DS_TESTS -m 'not sdma' --platform a2a3 --exclude-level 4 --manual only --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 1200"
-          fi
+          DS_TEST="examples/a2a3/host_build_graph/deepseek_v4_flash_decode"
+          task-submit --timeout 1800 --max-time 1800 --device auto --device-num 2 \
+            --run ".venv/bin/python -m pytest $DS_TEST -m 'not sdma' --platform a2a3 --exclude-level 4 --manual only --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 1200"

--- a/.github/workflows/_st-npu-a2a3.yml
+++ b/.github/workflows/_st-npu-a2a3.yml
@@ -87,24 +87,16 @@ jobs:
       - name: Run pytest scene tests (a2a3)
         run: |
           source /usr/local/Ascend/cann/set_env.sh
-          if [ "$(uname -m)" = "x86_64" ]; then
-            .venv/bin/python -m pytest examples tests/st -m "not sdma" --platform a2a3 --exclude-level 4 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 1200 --manual "$MANUAL_MODE"
-          else
-            task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
-              --run ".venv/bin/python -m pytest examples tests/st -m 'not sdma' --platform a2a3 --exclude-level 4 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 1200 --manual '$MANUAL_MODE'"
-          fi
+          task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
+            --run ".venv/bin/python -m pytest examples tests/st -m 'not sdma' --platform a2a3 --exclude-level 4 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 1200 --manual '$MANUAL_MODE'"
 
       - name: SDMA pytest (a2a3)
         if: inputs.manual_mode != 'only'
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           SDMA_TESTS="examples tests/st -m sdma"
-          if [ "$(uname -m)" = "x86_64" ]; then
-            .venv/bin/python -m pytest $SDMA_TESTS --platform a2a3 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 600
-          else
-            task-submit --timeout 1800 --max-time 1800 --device auto --device-num 2 \
-              --run ".venv/bin/python -m pytest $SDMA_TESTS --platform a2a3 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 600"
-          fi
+          task-submit --timeout 1800 --max-time 1800 --device auto --device-num 2 \
+            --run ".venv/bin/python -m pytest $SDMA_TESTS --platform a2a3 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 600"
 
       - name: DFX smokes (a2a3)
         if: inputs.include_dfx_smokes

--- a/.github/workflows/_ut-npu-a2a3.yml
+++ b/.github/workflows/_ut-npu-a2a3.yml
@@ -63,20 +63,8 @@ jobs:
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
-          if [ "$(uname -m)" = "x86_64" ]; then
-            python -m pytest tests/ut -m requires_hardware --platform a2a3 --device ${DEVICE_RANGE} -v
-            python3 -c "
-          import json, os
-          p = os.environ['DEVICE_RANGE'].split('-'); s, e = p[0], p[-1]
-          npus = [{'id': str(i), 'slots': 1} for i in range(int(s), int(e)+1)]
-          json.dump({'version': {'major': 1, 'minor': 0}, 'local': [{'npus': npus}]},
-                    open('tests/ut/cpp/build/resources.json', 'w'))
-          "
-            ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure --timeout 300
-          else
-            task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
-              --run "python -m pytest tests/ut -m requires_hardware --platform a2a3 --device \$TASK_DEVICE -v && python3 -c \"import json,os; ids=os.environ['TASK_DEVICE'].split(','); json.dump({'version':{'major':1,'minor':0},'local':[{'npus':[{'id':i,'slots':1} for i in ids]}]}, open('tests/ut/cpp/build/resources.json','w'))\" && ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?\$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure --timeout 300"
-          fi
+          task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
+            --run "python -m pytest tests/ut -m requires_hardware --platform a2a3 --device \$TASK_DEVICE -v && python3 -c \"import json,os; ids=os.environ['TASK_DEVICE'].split(','); json.dump({'version':{'major':1,'minor':0},'local':[{'npus':[{'id':i,'slots':1} for i in ids]}]}, open('tests/ut/cpp/build/resources.json','w'))\" && ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?\$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure --timeout 300"
 
       - name: Build cann-examples/query
         if: inputs.include_cann_examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,18 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ut-a2a3:
-    uses: ./.github/workflows/_ut-npu-a2a3.yml
-    with:
-      runs_on: '["self-hosted","test"]'
-      include_cann_examples: true
-
-  st-onboard-a2a3:
-    uses: ./.github/workflows/_st-npu-a2a3.yml
-    with:
-      runs_on: '["self-hosted","test"]'
-      include_dfx_smokes: true
-
   st-deepseek-onboard-a2a3:
     uses: ./.github/workflows/_st-deepseek-a2a3.yml
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,144 +13,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  detect-changes:
-    uses: ./.github/workflows/_detect-changes.yml
-    with:
-      repository: ${{ github.event.pull_request.head.repo.full_name }}
-      ref: ${{ github.event.pull_request.head.sha }}
-      base_repository: ${{ github.event.pull_request.base.repo.full_name }}
-      base_ref: ${{ github.event.pull_request.base.ref }}
-      base_sha: ${{ github.event.pull_request.base.sha }}
-      head_sha: ${{ github.event.pull_request.head.sha }}
-      runs_on: '["ubuntu-latest"]'
-
-  pre-commit:
-    uses: ./.github/workflows/_pre-commit.yml
-    with:
-      base_sha: ${{ github.event.pull_request.base.sha }}
-      head_sha: ${{ github.event.pull_request.head.sha }}
-      runs_on: '["ubuntu-latest"]'
-      setup_variant: github
-
-  packaging-matrix:
-    needs: [detect-changes, pre-commit]
-    if: needs.detect-changes.outputs.non_code_only != 'true' && needs.detect-changes.outputs.examples_only != 'true' && needs.detect-changes.outputs.tests_only != 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10"]
-    uses: ./.github/workflows/_packaging.yml
-    with:
-      runs_on: ${{ toJSON(matrix.os) }}
-      setup_variant: github
-      python_version: ${{ matrix.python-version }}
-
-  ut:
-    needs: [detect-changes, pre-commit]
-    if: needs.detect-changes.outputs.non_code_only != 'true' && needs.detect-changes.outputs.ut_affected == 'true'
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10"]
-    uses: ./.github/workflows/_ut-no-hardware.yml
-    with:
-      runs_on: ${{ toJSON(matrix.os) }}
-      setup_variant: github
-      python_version: ${{ matrix.python-version }}
-
-  st-sim-a2a3:
-    needs: [detect-changes, pre-commit]
-    if: needs.detect-changes.outputs.a2a3_changed == 'true' && needs.detect-changes.outputs.st_affected == 'true'
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10"]
-    uses: ./.github/workflows/_st-sim-a2a3.yml
-    with:
-      runs_on: ${{ toJSON(matrix.os) }}
-      setup_variant: github
-      include_dfx_smokes: true
-      python_version: ${{ matrix.python-version }}
-
-  st-sim-a5:
-    needs: [detect-changes, pre-commit]
-    if: needs.detect-changes.outputs.a5_changed == 'true' && needs.detect-changes.outputs.st_affected == 'true'
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10"]
-    uses: ./.github/workflows/_st-sim-a5.yml
-    with:
-      runs_on: ${{ toJSON(matrix.os) }}
-      setup_variant: github
-      include_dfx_smokes: true
-      python_version: ${{ matrix.python-version }}
-
-  profiling-flags-smoke:
-    needs: [detect-changes, pre-commit]
-    if: (needs.detect-changes.outputs.a2a3_changed == 'true' || needs.detect-changes.outputs.a5_changed == 'true') && needs.detect-changes.outputs.examples_only != 'true' && needs.detect-changes.outputs.tests_only != 'true'
-    uses: ./.github/workflows/_profiling-flags-smoke.yml
-    with:
-      runs_on: '["ubuntu-latest"]'
-      setup_variant: github
-
   ut-a2a3:
-    needs: [detect-changes, pre-commit]
-    if: needs.detect-changes.outputs.non_code_only != 'true' && needs.detect-changes.outputs.ut_affected == 'true'
     uses: ./.github/workflows/_ut-npu-a2a3.yml
     with:
-      runs_on: '["self-hosted","a2a3"]'
+      runs_on: '["self-hosted","test"]'
       include_cann_examples: true
 
   st-onboard-a2a3:
-    needs: [detect-changes, pre-commit]
-    if: needs.detect-changes.outputs.a2a3_changed == 'true' && needs.detect-changes.outputs.st_affected == 'true'
     uses: ./.github/workflows/_st-npu-a2a3.yml
     with:
-      runs_on: '["self-hosted","a2a3"]'
+      runs_on: '["self-hosted","test"]'
       include_dfx_smokes: true
 
-  # The only job that spans two machines. It is arch-specific and the most
-  # expensive thing in this file, so it gates exactly as st-onboard-a2a3 does —
-  # never on a weaker signal than a cheaper job, per
-  # .claude/rules/ci-change-detection.md.
-  st-network1-onboard-a2a3:
-    needs: [detect-changes, pre-commit]
-    if: needs.detect-changes.outputs.a2a3_changed == 'true' && needs.detect-changes.outputs.st_affected == 'true'
-    uses: ./.github/workflows/_st-network1.yml
-    with:
-      platform: a2a3
-      # a2a3pod is a label on the runner machines, not a value this repo
-      # controls, so it keeps the older word until those machines are
-      # relabelled. A job matches every label in this list, so it cannot accept
-      # either spelling.
-      runs_on: '["self-hosted","Linux","ARM64","a2a3pod"]'
-
-  # The two DeepSeek smoke cases stay manual, so the main sweep (--manual
-  # exclude) never picks them up; this job selects them with --manual only and
-  # runs on its own devices in parallel with st-onboard-a2a3, keeping their
-  # ~9 min of device time off the main sweep's critical path. Gates exactly as
-  # st-onboard-a2a3 does, per .claude/rules/ci-change-detection.md.
   st-deepseek-onboard-a2a3:
-    needs: [detect-changes, pre-commit]
-    if: needs.detect-changes.outputs.a2a3_changed == 'true' && needs.detect-changes.outputs.st_affected == 'true'
     uses: ./.github/workflows/_st-deepseek-a2a3.yml
     with:
-      runs_on: '["self-hosted","a2a3"]'
-
-  ut-a5:
-    needs: [detect-changes, pre-commit]
-    if: needs.detect-changes.outputs.non_code_only != 'true' && needs.detect-changes.outputs.ut_affected == 'true'
-    uses: ./.github/workflows/_ut-npu-a5.yml
-    with:
-      runs_on: '["self-hosted","a5"]'
-      include_cann_examples: true
-
-  st-onboard-a5:
-    needs: [detect-changes, pre-commit]
-    if: needs.detect-changes.outputs.a5_changed == 'true' && needs.detect-changes.outputs.st_affected == 'true'
-    uses: ./.github/workflows/_st-npu-a5.yml
-    with:
-      runs_on: '["self-hosted","a5"]'
-      include_dfx_smokes: true
+      runs_on: '["self-hosted","test"]'

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -84,7 +84,7 @@ PullRequest
 | `ut-a5` | a5 self-hosted | `pytest tests/ut --platform a5` + build `tools/cann-examples/query` and run `query version` (no device) + build `tools/cann-examples/aicpu-device-query` and `tools/cann-examples/aicpu-kernel-launch` (link smoke only) |
 | `st-onboard-a5` | a5 self-hosted | `pytest examples tests/st --platform a5 --exclude-level 4 --device ...`, including SDMA tests, then adaptive-parallel DFX feature smokes |
 | `st-network1-onboard-a2a3` | a pair of `a2a3pod` machines | `pytest examples tests/st --level 4 --platform a2a3 --device ... --max-parallel 1`, one L3 daemon on the peer |
-| `st-deepseek-onboard-a2a3` | a2a3 self-hosted | `pytest <the two deepseek_v4_flash_decode dirs> --platform a2a3 --manual only --device ...`, both 2-device cases concurrently, in parallel with `st-onboard-a2a3` |
+| `st-deepseek-onboard-a2a3` | a2a3 self-hosted | `pytest examples/a2a3/host_build_graph/deepseek_v4_flash_decode --platform a2a3 --manual only --device ...`, one 2-device HBG case, in parallel with `st-onboard-a2a3` |
 
 ### Multi-machine network1 jobs
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -762,9 +762,10 @@ Dedicated DFX steps are the exception: they use `--manual include` in normal
 Per-PR and Daily jobs, so marking a case under their target path removes only
 its duplicate main-sweep execution. A caller selecting `--manual only` keeps
 that mode in the DFX steps. The A2/A3 `network1` cases run in the same Daily
-workflow through their existing two-machine job, and the DeepSeek smokes run
-Per-PR in their own parallel job (`st-deepseek-onboard-a2a3`, `--manual only`
-over the two `deepseek_v4_flash_decode` directories).
+workflow through their existing two-machine job, and the DeepSeek HBG smoke
+runs Per-PR in its own parallel job (`st-deepseek-onboard-a2a3`,
+`--manual only` over the `host_build_graph/deepseek_v4_flash_decode`
+directory).
 
 To move only selected platforms, pass the platform list to the same marker:
 use `@pytest.mark.manual(["a2a3sim", "a5sim"])` (or the equivalent


### PR DESCRIPTION
## Summary

- keep the A3 hardware UT, regular onboard scene-test, DFX, and DeepSeek jobs
- target all retained jobs at the `test` runner label without requiring the `a2a3` runner label
- acquire devices through `task-submit --device auto` and remove the x86 `DEVICE_RANGE` paths
- exclude only network1 because it requires an ARM64 `a2a3pod` pair
- omit CPU, simulation, packaging, and A5 jobs during this validation

## Testing

- pre-commit hooks passed
- workflow/action YAML tests: 16 passed
- `git diff --check` passed

This PR is for validating the A3 x86 runner path.