### PR TITLE
Fix: check the wheel ships the cmake includes a runtime configure needs

### DIFF
--- a/docs/python-packaging.md
+++ b/docs/python-packaging.md
@@ -31,6 +31,7 @@ simpler_setup/            ← test framework + build/runtime assembly (simpler_s
     paged_attention.py    attention reference (used by multiple paged_attention tests)
   _assets/                (wheel-only, populated by CMake install)
     src/                  source tree mirror
+    cmake/                the includes a runtime configure needs, via SIMPLER_CMAKE_DIR
     build/lib/            pre-built per-arch/platform/runtime .so/.o
 
 _task_interface.*.so      nanobind extension at site-packages root
@@ -69,10 +70,10 @@ NPU hardware (`a2a3`/`a5` with CANN toolkit).
 
 `simpler_setup.environment.PROJECT_ROOT` auto-detects between:
 
-- **Wheel install**: `simpler_setup/_assets/` exists → `PROJECT_ROOT = .../site-packages/simpler_setup/_assets`. The wheel's bundled `_assets/src/` and `_assets/build/lib/` provide everything needed at runtime.
-- **Source tree / editable install**: `_assets/` doesn't exist → `PROJECT_ROOT = repo root`. Live `src/` and `build/lib/` are used.
+- **Wheel install**: `simpler_setup/_assets/` exists → `PROJECT_ROOT = .../site-packages/simpler_setup/_assets`. Everything the runtime reads at that root has to be installed there: `_assets/src/`, `_assets/build/lib/`, and `_assets/cmake/`, which is where `SIMPLER_CMAKE_DIR` lands and therefore what the platform `CMakeLists.txt` include. An asset directory the install block forgets fails only at use — a runtime configure dies on `include could not find requested file` — so `tools/verify_packaging.sh` asserts the set exists in every mode.
+- **Source tree / editable install**: `_assets/` doesn't exist → `PROJECT_ROOT = repo root`. Live `src/`, `cmake/` and `build/lib/` are used.
 
-Anything that needs to find `src/`, `build/lib/`, or `build/cache/` MUST go through `simpler_setup.environment.PROJECT_ROOT` — never `Path(__file__).parent.parent...`.
+Anything that needs to find `src/`, `cmake/`, `build/lib/`, or `build/cache/` MUST go through `simpler_setup.environment.PROJECT_ROOT` — never `Path(__file__).parent.parent...`.
 
 ## Import rules
 

--- a/tools/verify_packaging.sh
+++ b/tools/verify_packaging.sh
@@ -50,13 +50,15 @@ smoke() {
     echo "::group::[${mode}] import surface"
     (
         cd "${PACKAGING_SMOKE_DIR}"
-        python -c "
+        REPO_ROOT="${REPO_ROOT}" python -c "
 import os
+import pathlib
 
 import simpler, simpler_setup
 from simpler.worker import Worker
 from simpler.task_interface import ChipWorker
 from simpler.orchestrator import Orchestrator
+from simpler_setup.environment import PROJECT_ROOT
 from simpler_setup.runtime_builder import RuntimeBuilder
 from simpler_setup.runtime_compiler import RuntimeCompiler
 from simpler_setup.kernel_compiler import KernelCompiler
@@ -74,6 +76,23 @@ for rel in ('pipe_sync.h', os.path.join('common', 'dma_workspace.h')):
     assert any(os.path.isfile(os.path.join(d, rel)) for d in inc_dirs), \
         'incore helper not shipped: ' + rel + '; include dirs: ' + repr(inc_dirs)
 print('incore helpers OK:', inc_dirs)
+# Verify the cmake includes a runtime configure needs are reachable. The platform
+# CMakeLists reach them through SIMPLER_CMAKE_DIR, which runtime_compiler.py
+# resolves to PROJECT_ROOT/cmake — the installed simpler_setup/_assets/cmake in a
+# wheel, the repo's cmake/ in a source-tree layout. An install rule that forgets
+# to ship them leaves every runtime configure dying on 'include could not find
+# requested file', which reaches the user as an empty compile database. Compare
+# against the repo so a file added to cmake/ is covered without editing a list,
+# and walk it recursively: install(DIRECTORY) ships nested paths, so a check that
+# only looked at immediate children would stop covering the directory the moment
+# anyone nested a file in it.
+cmake_dir = PROJECT_ROOT / 'cmake'
+repo_cmake_dir = pathlib.Path(os.environ['REPO_ROOT'], 'cmake')
+expected = sorted(str(p.relative_to(repo_cmake_dir)) for p in repo_cmake_dir.rglob('*') if p.is_file())
+missing = [rel for rel in expected if not (cmake_dir / rel).is_file()]
+assert expected, 'no cmake includes found in the repository to compare against'
+assert not missing, 'cmake includes not shipped: ' + repr(missing) + '; resolved dir: ' + str(cmake_dir)
+print('cmake includes OK:', cmake_dir, expected)
 "
     )
     echo "::endgroup::"


### PR DESCRIPTION
## Summary

`tools/verify_packaging.sh` calls itself the single source of truth for the five install paths, and `docs/getting-started.md` points at it — but it only exercised the import surface and the two entry points. **Nothing asserted the asset tree**, so a wheel could omit an entire directory the runtime reads and all five modes still reported green.

That is what happened. #1845 added `include("${SIMPLER_CMAKE_DIR}/host_log_sources.cmake")` to six platform `CMakeLists.txt` without the matching install rule, so `simpler_setup/_assets/cmake` never shipped and any runtime cmake configure from a wheel install died on:

```text
CMake Error at CMakeLists.txt:21 (include):
  include could not find requested file:
    .../simpler_setup/_assets/cmake/host_log_sources.cmake
```

reaching the caller as `ValueError: empty compile database`. Two things hid it for a week: the only CI consumer is the clang-tidy pre-commit hook, which configures **only on a build-cache miss** — and when it finally did fire, every gated job declares `pre-commit` in `needs:`, so one hook failure **skipped the entire test matrix** rather than failing one job. The install rule itself was fixed in #1980; this is the check that would have caught it.

## What the check does

It resolves the directory the way production does — `PROJECT_ROOT / "cmake"`, which is exactly what `runtime_compiler.py` passes as `SIMPLER_CMAKE_DIR` — and requires every file in the repository's `cmake/` to be present there.

Two deliberate choices:

- **Compare against the repository, not a hard-coded list.** A file added to `cmake/` is covered without editing this script. That matters because the omission being caught *was* a new file — a list would have needed the same person who forgot the install rule to remember to update it.
- **Put it in `smoke()`, so all five modes are covered without branching on install kind.** `PROJECT_ROOT` already abstracts the layout: in a wheel it is the installed `_assets`, and in the editable / cmake-plus-PYTHONPATH layouts it is the repository, where the check is trivially satisfied.

It sits beside the existing incore-helper assertion for the same stated reason that one exists: a missing data file otherwise surfaces far downstream as a cryptic compilation error rather than as a packaging failure.

## Testing

- [x] `tools/verify_packaging.sh` — **ALL 5 MODES PASSED**, with the new assertion firing in each: modes 1-2 resolve to `site-packages/simpler_setup/_assets/cmake`, modes 3-5 to the repo's `cmake/`
- [x] Negative case: deleting `_assets/cmake` from an installed wheel makes it fail with `cmake includes not shipped: ['host_log_sources.cmake', 'profiling_build_config.h.in', 'profiling_config.cmake', 'sanitizers.cmake']` and the resolved directory
- [x] `bash -n tools/verify_packaging.sh`
