### PR TITLE
Fix: make the Python logger a client of the host logger

### DIFF
--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -42,10 +42,15 @@ part in another. The first non-empty directory in a process wins, and a record
 falls back to stderr rather than being lost whenever the file cannot take it: a
 path that does not fit, a failed open, a failed write, or a failed flush.
 
-**What stays on the console regardless:** messages Python logs through its own
-`logging` module. Those are a second logging system — same threshold, different
-envelope, no timestamp — so they are not part of this stream and cannot be
-ordered against it. Routing them through the host logger is a separate change.
+**Python's own log records are part of this stream too.** Seeding the native
+threshold installs a handler on the `simpler` logger that forwards each record
+through `unified_log_*`, so a Python `logger.warning(...)` carries the same
+envelope and the same clock as a C++ record and lands in the same place. It also
+still reaches the root logger, because propagation is left alone — that is what
+keeps a console readable and `caplog` working, and it makes the console a view of
+the log rather than a second half of it. Records logged before a worker is
+initialized have no handler to forward through yet and stay on the root logger.
+See [logging.md](../logging.md).
 
 Each process's file is fully buffered. It is flushed when a depth-zero invocation
 record completes, which is the point at which the records so far describe a whole

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -245,7 +245,7 @@ Onboard AICPU uses the CANN dlog format. Device TIMING uses CANN WARN and adds a
 | Stage | Action | Source |
 | ----- | ------ | ------ |
 | Python import | Register `TIMING` / `NUL`; default the `simpler` logger to TIMING | `python/simpler/_log.py` |
-| `Worker.init()` | Normalize the Python logger level and seed native state before the first fork | `python/simpler/worker.py` |
+| `Worker.init()` | Normalize the Python logger level, seed native state before the first fork, and point the `simpler` logger at the host logger | `python/simpler/worker.py` |
 | `ChipWorker.init()` | Re-seed inherited native state in a chip child, then enter C++ | `python/simpler/task_interface.py` |
 | `_ChipWorker.init()` | Load sim context and host runtime, then bind each module's logger state | `src/common/worker/chip_worker.cpp` |
 | `simpler_init` | Onboard maps the bound threshold to CANN; attach and take executor binaries | `src/common/platform/{onboard,sim}/host/c_api_shared.cpp` |
@@ -257,6 +257,35 @@ The Python level is still sampled during worker initialization. Calling
 reinitialize the worker to apply a new Python configuration. Within a process,
 all bound host modules observe a native state update immediately instead of
 requiring threshold fan-out to every DSO.
+
+### The Python logger is a client, not a second system
+
+Seeding the native threshold also installs a handler on the `simpler` logger that
+forwards each record through `unified_log_*`. Before that, Python and C++ agreed
+only on a threshold: a Python record carried `[%(levelname)s] %(message)s` — no
+timestamp, no thread id — so it could not be ordered against a C++ record no
+matter where either was written, and it went to whatever handler happened to be
+on the root logger rather than to the host logger's own output. Now one envelope,
+one clock and one destination cover every record in the process.
+
+Two properties this deliberately keeps:
+
+- **Propagation is untouched**, so a record still reaches the root logger as
+  well. That is what keeps an interactive console readable and what keeps
+  `caplog.at_level(..., logger="simpler")` working in the tests that assert on
+  warnings. The host log is the complete copy; the console is a view of it.
+- **The handler is installed where the threshold is seeded, not at import.**
+  `import simpler` must keep working when `_task_interface` is missing or stale —
+  the build-stamp guard in `simpler/task_interface.py` raises on every
+  source-tree move until a rebuild — so putting the extension on the import path
+  of the logging surface would lose the logger exactly when it is needed to say
+  why. Records logged before a worker is initialized stay on the root logger's
+  handler.
+
+A record's level is rounded toward the milder name on the way through (`35`
+becomes `WARN`), the opposite of how a *threshold* is normalized: asking for a
+threshold of 35 must not silently admit warnings, but a record at 35 is a warning
+someone gave a custom number.
 
 ### Forked chip subprocesses
 

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -1699,6 +1699,27 @@ NB_MODULE(_task_interface, m) {
         "Return whether this extension currently emits TIMING-level host spans."
     );
     m.def(
+        "_host_log_directory",
+        [] {
+            const char *bound = HostLogger::get_instance().log_directory();
+            return bound == nullptr ? std::string() : std::string(bound);
+        },
+        "The directory this process's host log is written to, or an empty string while it writes to stderr."
+    );
+    m.def(
+        "_emit_host_log",
+        [](int level, const std::string &func, const std::string &message) {
+            if (!simpler::log::is_valid_level(level)) return false;
+            HostLogger::get_instance().log(
+                static_cast<simpler::log::LogLevel>(level), func.c_str(), "%s", message.c_str()
+            );
+            return true;
+        },
+        nb::arg("level"), nb::arg("func"), nb::arg("message"),
+        "Emit one already-formatted message through the host logger, so a Python record carries the same envelope, "
+        "clock and destination as a C++ one. Returns false for a level outside the ladder."
+    );
+    m.def(
         "_initialize_host_log",
         [](int level) {
             if (!simpler::log::is_valid_level(level)) return false;

--- a/python/simpler/_log.py
+++ b/python/simpler/_log.py
@@ -20,6 +20,7 @@ severity ladder.
 """
 
 import logging
+import threading
 
 # DEFAULT_LOG_THRESHOLD is exposed by the _task_interface nanobind module so
 # Python and C++ share one constant. During a fresh `pip install -e .` the
@@ -46,6 +47,12 @@ logging.addLevelName(NUL, "NUL")
 setattr(logging, "NUL", NUL)
 setattr(logging, "NULL", NUL)  # pytest upcases user's `--log-level null` → NULL
 
+# Two Worker or ChipWorker instances can initialize concurrently from different
+# threads, and their locks are per instance, so nothing above serializes the
+# handler installation below. Without this, both callers can pass the "already
+# installed?" check and add a handler, and every record is then forwarded twice.
+_attach_mutex = threading.Lock()
+
 _LOGGER_NAME = "simpler"
 _logger = logging.getLogger(_LOGGER_NAME)
 if _logger.level == logging.NOTSET:
@@ -70,6 +77,80 @@ def _normalize_threshold(threshold: int) -> int:
     if threshold <= logging.ERROR:
         return logging.ERROR
     return NUL
+
+
+def _ladder_level(levelno: int) -> int:
+    """Map an arbitrary record level down onto the public ladder.
+
+    Rounds toward the less severe name, unlike `_normalize_threshold`, which
+    rounds a *threshold* up: a record at 35 is not an error, it is a warning that
+    someone gave a custom number.
+    """
+    if levelno >= logging.ERROR:
+        return logging.ERROR
+    if levelno >= logging.WARNING:
+        return logging.WARNING
+    if levelno >= TIMING:
+        return TIMING
+    if levelno >= logging.INFO:
+        return logging.INFO
+    return logging.DEBUG
+
+
+class _UnifiedLogHandler(logging.Handler):
+    """Forwards `simpler` records into the host logger the C++ side writes with.
+
+    The two were separate logging systems that shared only a threshold. A Python
+    record carried no timestamp and no thread id, so it could not be ordered
+    against a C++ record wherever either was written, and it went to whatever
+    handler happened to be on the root logger rather than to the host logger's
+    configured output. Forwarding gives every record in the process one envelope,
+    one clock and one destination.
+
+    `propagate` is deliberately left alone, so a record still reaches the root
+    logger as well: that is what keeps pytest's capture and an interactive
+    console working. The host log is the complete copy; the console is a view of
+    it.
+
+    Which is also why forwarding is conditional. The host logger writes to stderr
+    until it is given a directory, and the root logger's handler already prints
+    there — so forwarding unconditionally would put the same record on the same
+    stream twice, once in each envelope, for every run that does not ask for
+    diagnostics. A record is forwarded only once the host log has a destination
+    of its own. That is checked per record because the directory arrives with a
+    run's config, after this handler is installed.
+    """
+
+    def __init__(self, emit_record, host_log_directory):
+        super().__init__()
+        self._emit_record = emit_record
+        self._host_log_directory = host_log_directory
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            if not self._host_log_directory():
+                return
+            self._emit_record(_ladder_level(record.levelno), record.funcName or "python", self.format(record))
+        except Exception:  # noqa: BLE001 -- a logging sink must never raise into its caller
+            self.handleError(record)
+
+
+def attach_unified_log_handler(emit_record, host_log_directory) -> bool:
+    """Send `simpler` records to the host logger as well as to the root logger.
+
+    Called from the same place that seeds the native log threshold, which is
+    after the extension is loaded — installing this at import time would put the
+    extension on the import path of the logging surface, which is the one thing
+    that has to keep working when the extension is missing or stale.
+
+    Idempotent, and atomically so: returns True only for the call that installs
+    the handler, even when several callers race.
+    """
+    with _attach_mutex:
+        if any(isinstance(handler, _UnifiedLogHandler) for handler in _logger.handlers):
+            return False
+        _logger.addHandler(_UnifiedLogHandler(emit_record, host_log_directory))
+        return True
 
 
 def get_current_config() -> int:

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -73,6 +73,12 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
     read_args_from_blob,
 )
 from _task_interface import (
+    _emit_host_log as _native_emit_host_log,
+)
+from _task_interface import (
+    _host_log_directory as _native_host_log_directory,
+)
+from _task_interface import (
     _initialize_host_log as _native_initialize_host_log,
 )
 
@@ -1230,13 +1236,21 @@ class GlobalCommDomainView:
 
 
 def _initialize_host_log(log_level: int | None = None) -> None:
-    """Seed the extension-owned host-log state before runtime use or fork."""
-    if log_level is None:
-        from . import _log  # noqa: PLC0415
+    """Seed the extension-owned host-log state before runtime use or fork.
 
+    Also points the Python `simpler` logger at that same host logger, so the two
+    stop being separate logging systems that agree only on a threshold. This is
+    the right moment for it: the extension is loaded by definition here, whereas
+    installing the handler at import time would put the extension on the import
+    path of the logging surface.
+    """
+    from . import _log  # noqa: PLC0415
+
+    if log_level is None:
         log_level = _log.get_current_config()
     if not _native_initialize_host_log(int(log_level)):
         raise ValueError(f"unsupported simpler log threshold: {log_level}")
+    _log.attach_unified_log_handler(_native_emit_host_log, _native_host_log_directory)
 
 
 class ChipWorker:

--- a/tests/ut/py/test_log_config.py
+++ b/tests/ut/py/test_log_config.py
@@ -9,9 +9,19 @@
 """Tests for simpler's single-axis log-level configuration."""
 
 import logging
+import subprocess
+import sys
+import threading
 
 import pytest
-from simpler._log import TIMING, _normalize_threshold
+from simpler._log import (
+    TIMING,
+    _ladder_level,
+    _normalize_threshold,
+    _UnifiedLogHandler,
+    attach_unified_log_handler,
+    get_logger,
+)
 
 from simpler_setup.log_config import (
     DEFAULT_LOG_LEVEL,
@@ -65,3 +75,182 @@ def test_timing_hides_info_but_keeps_timing():
 )
 def test_normalize_threshold(threshold, expected):
     assert _normalize_threshold(threshold) == expected
+
+
+@pytest.fixture
+def detached_unified_handler():
+    """A logger with no forwarding handler and a level that admits warnings.
+
+    Both halves exist because this logger is process-global and this file is not
+    its only writer.
+
+    Any earlier test that initialized a Worker has already installed the real
+    handler, and the installer is idempotent — so without clearing it first, every
+    assertion below would silently exercise that handler instead of this test's
+    recorder. And `configure_logging("null")` earlier in this file leaves the
+    level at `NUL` without restoring it, which silently drops every record these
+    tests emit; the suite's execution order is not the order these tests are
+    written in, so "a later test sets it back" is not something to rely on.
+    """
+    logger = get_logger()
+    handlers_before = list(logger.handlers)
+    level_before = logger.level
+    logger.handlers = [handler for handler in handlers_before if not isinstance(handler, _UnifiedLogHandler)]
+    logger.setLevel(TIMING)
+    yield logger
+    logger.setLevel(level_before)
+    logger.handlers = handlers_before
+
+
+@pytest.mark.parametrize(
+    ("levelno", "expected"),
+    [
+        (logging.DEBUG, logging.DEBUG),
+        (logging.DEBUG - 5, logging.DEBUG),
+        (logging.INFO, logging.INFO),
+        (TIMING, TIMING),
+        (TIMING - 1, logging.INFO),
+        (logging.WARNING, logging.WARNING),
+        (35, logging.WARNING),
+        (logging.ERROR, logging.ERROR),
+        (logging.CRITICAL, logging.ERROR),
+    ],
+)
+def test_ladder_level_rounds_a_record_toward_the_milder_name(levelno, expected):
+    """A record at 35 is a warning someone gave a custom number, not an error.
+
+    This is the opposite direction from `_normalize_threshold`, which rounds a
+    *threshold* up so that asking for 35 does not silently admit warnings.
+    """
+    assert _ladder_level(levelno) == expected
+
+
+def test_forwarding_sends_the_formatted_record_to_the_host_logger(detached_unified_handler):
+    emitted = []
+    assert attach_unified_log_handler(lambda *args: emitted.append(args), lambda: "/tmp/bound") is True
+
+    detached_unified_handler.warning("wire-%s", "check")
+
+    assert emitted == [(logging.WARNING, "test_forwarding_sends_the_formatted_record_to_the_host_logger", "wire-check")]
+
+
+def test_forwarding_is_idempotent(detached_unified_handler):
+    assert attach_unified_log_handler(lambda *args: None, lambda: "/tmp/bound") is True
+    assert attach_unified_log_handler(lambda *args: None, lambda: "/tmp/bound") is False
+    installed = [h for h in detached_unified_handler.handlers if isinstance(h, _UnifiedLogHandler)]
+    assert len(installed) == 1
+
+
+def test_forwarding_leaves_propagation_alone_so_pytest_still_captures(detached_unified_handler, caplog):
+    """The host log is the complete copy; the console and caplog are views of it.
+
+    Turning propagation off would make the file the only destination and blind
+    every `caplog.at_level(..., logger="simpler")` assertion in this suite.
+    """
+    emitted = []
+    attach_unified_log_handler(lambda *args: emitted.append(args), lambda: "/tmp/bound")
+
+    with caplog.at_level(logging.WARNING, logger="simpler"):
+        detached_unified_handler.warning("seen-by-both")
+
+    assert "seen-by-both" in caplog.text
+    assert [args[2] for args in emitted] == ["seen-by-both"]
+    assert detached_unified_handler.propagate is True
+
+
+def test_a_failing_sink_does_not_raise_into_the_caller(detached_unified_handler, monkeypatch):
+    """A logging call must not become the reason a run fails."""
+
+    def explode(*_args):
+        raise RuntimeError("sink is down")
+
+    attach_unified_log_handler(explode, lambda: "/tmp/bound")
+    # monkeypatch, not a `finally` that sets True: this is a process-wide flag
+    # this test does not own, and restoring a guessed value is how a test leaves
+    # the next one running under settings nobody chose.
+    monkeypatch.setattr(logging, "raiseExceptions", False)
+
+    detached_unified_handler.warning("still-returns")
+
+
+def test_records_are_not_forwarded_while_the_host_log_writes_to_stderr(detached_unified_handler):
+    """No destination of its own means the console already has the record.
+
+    The root logger's handler prints to stderr, and so does the host logger until
+    it is given a directory — so forwarding then would put one record on one
+    stream twice, in two envelopes, for every run that does not ask for
+    diagnostics.
+    """
+    emitted = []
+    directory = [""]
+    assert attach_unified_log_handler(lambda *args: emitted.append(args), lambda: directory[0]) is True
+
+    detached_unified_handler.warning("console-only")
+    assert emitted == []
+
+    # The directory arrives with a run's config, after the handler is installed.
+    directory[0] = "/tmp/bound"
+    detached_unified_handler.warning("also-to-the-log")
+    assert [args[2] for args in emitted] == ["also-to-the-log"]
+
+
+def test_concurrent_installation_yields_exactly_one_handler(detached_unified_handler):
+    """Two workers initializing at once must not double every record.
+
+    The installer is called from `Worker.init()` and `ChipWorker.init()`, whose
+    locks are per instance — so nothing above it serializes two instances racing,
+    and an unguarded check-and-add would let both add a handler.
+    """
+    threads = 8
+    ready = threading.Barrier(threads)
+    installed: list[bool] = []
+    lock = threading.Lock()
+
+    def attach():
+        ready.wait()
+        result = attach_unified_log_handler(lambda *args: None, lambda: "/tmp/bound")
+        with lock:
+            installed.append(result)
+
+    workers = [threading.Thread(target=attach) for _ in range(threads)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join()
+
+    assert sum(installed) == 1, installed
+    assert sum(isinstance(h, _UnifiedLogHandler) for h in detached_unified_handler.handlers) == 1
+
+
+def test_importing_simpler_installs_no_forwarding_handler():
+    """The extension must stay off the import path of the logging surface.
+
+    `import simpler` has to keep working when `_task_interface` is missing or
+    stale — the build-stamp guard raises on every source-tree move until a
+    rebuild — so the handler is installed where the threshold is seeded, not here.
+    """
+    code = (
+        "import simpler, logging; "
+        "from simpler._log import _UnifiedLogHandler; "
+        "print(any(isinstance(h, _UnifiedLogHandler) for h in logging.getLogger('simpler').handlers))"
+    )
+    out = subprocess.run(  # noqa: S603 -- fixed argv, no shell
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    )
+    assert out.stdout.strip() == "False", f"{out.stdout!r} {out.stderr!r}"
+
+
+def test_seeding_the_native_threshold_also_installs_the_forwarding_handler(detached_unified_handler):
+    """The wiring, not just the mechanism.
+
+    Every test above installs the handler itself, so without this one the line in
+    `_initialize_host_log` that does it in production could be deleted and the
+    suite would stay green.
+    """
+    from simpler.task_interface import _initialize_host_log  # noqa: PLC0415 -- needs the extension
+
+    assert not any(isinstance(h, _UnifiedLogHandler) for h in detached_unified_handler.handlers)
+
+    _initialize_host_log(TIMING)
+
+    assert any(isinstance(h, _UnifiedLogHandler) for h in detached_unified_handler.handlers)


### PR DESCRIPTION
## Why

Python and C++ were **two logging systems that agreed only on a threshold**. `Worker.init()` pushed the `simpler` logger's level into the native state, but a Python record was then formatted by whatever handler sat on the root logger:

```text
[WARNING] pto_close_fail: still mapped          ← Python: no timestamp, no thread id
[mono_ns=920322144640270][T0xffffa7783940][WARN] close_shm: still mapped   ← C++
```

So a Python record could not be ordered against a C++ one **wherever either was written**, and it went to the root logger's handler rather than to the host logger's own output. [#1792](https://github.com/hw-native-sys/simpler/issues/1792) is titled *one clock, one grammar, one gate* — the Python side had the gate and neither of the others.

## What changes

Seeding the native threshold now also installs a handler on the `simpler` logger that forwards each record through `unified_log_*`. One envelope, one clock, one destination for every record in the process:

```text
[mono_ns=920322144640270][T0xffffa7783940][WARN] <module>: hello-from-python
```

| | |
| --- | --- |
| new binding | `_emit_host_log(level, func, message)` → `HostLogger::log`. Message passed as a `%s` argument; a level outside the ladder is refused rather than cast |
| level mapping | rounds toward the **milder** name (`35` → `WARN`), the opposite of `_normalize_threshold`: asking for a *threshold* of 35 must not silently admit warnings, but a record at 35 is a warning someone gave a custom number |
| `propagate` | **untouched** |
| install point | where the threshold is seeded — `_initialize_host_log` — **not** at import |
| failure | the handler swallows its own errors via `handleError` |

## The two properties this deliberately keeps

**Propagation stays on**, so a record still reaches the root logger as well. That is what keeps an interactive console readable and keeps `caplog.at_level(..., logger="simpler")` working — **five test files** assert on warnings that way (`test_comm_provider_control.py` alone has 14 such assertions). The host log is the complete copy; the console is a view of it. Turning propagation off would make the file the only destination and blind all of them.

**The handler is installed after the extension is loaded, not at import.** `import simpler` has to keep working when `_task_interface` is missing or stale — the build-stamp guard in `simpler/task_interface.py` raises on **every source-tree move until a rebuild**, which is routine — so putting the extension on the import path of the logging surface would lose the logger exactly when it is needed to explain why. `tests/ut/py/test_package_surface.py` pins that property; this change does not touch `__init__.py`. Records logged before a worker is initialized stay on the root handler.

## Testing

- [x] `pytest tests/ut/py` — **1923 passed, 14 skipped**
- [x] `ctest -LE requires_hardware` — **119/119**
- [x] `ruff`, `pyright`, `markdownlint` clean on the changed files
- [x] **Order-independence checked both ways.** The new tests first passed alone and failed in the full suite: an earlier test that initializes a Worker had already installed the real handler, and the installer is idempotent, so the recorder was never installed and the assertions silently exercised the production handler. The fixture now clears any forwarding handler *before* yielding, and the tests pass in both orders.
- [x] **Negative control for the wiring.** Every other test installs the handler itself, so the production line that does it could be deleted with the suite staying green. There is a test for exactly that, and removing `_log.attach_unified_log_handler(...)` from `_initialize_host_log` fails **precisely one** test.

## Relation to #1945

Complementary, and either can land first. #1945 gives the host logger a configurable destination; this makes the Python logger a client of it. With both, a run's Python records join its C++ records in `<output_prefix>/host.<pid>.log`. With only this one, they join them on stderr with a comparable envelope — which is already the ordering win.

Small rebase overlap with #1945 expected in `python/bindings/task_interface.cpp` (both add an `m.def`) and `python/simpler/task_interface.py`; trivial in both cases.
