### PR TITLE
Docs: name the ring types the chip runtime actually has

### DIFF
--- a/docs/dfx/scope-stats.md
+++ b/docs/dfx/scope-stats.md
@@ -157,7 +157,7 @@ only the `real_occupancy` curve.
   by site to compute the metrics above.
 - **Per-ring.** Each ring's task window, heap, and dep pool are tracked
   independently; a scope only ever touches its own ring
-  (`ring = min(depth, MAX_RING_DEPTH−1)`).
+  (`ring = min(depth, CHIP_MAX_RING_DEPTH−1)`).
 - **Capacity denominators.** The `*_max` capacities in the metadata line
   are snapshots of what the runtime actually configured for that run, so
   `used/cap` ratios are exact.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -48,22 +48,25 @@ Type changes:
 
 ### 4.1 ChipRingSet (new)
 
-Bundles the three per-ring resources into a single aggregate (`ring_buffer.h`):
+Bundles the per-ring resources into a single aggregate (`ring_buffer.h`):
 
 ```cpp
 struct ChipRingSet {
-    ChipHeapRing   heap_ring;
-    ChipTaskRing   task_ring;
+    TaskAllocator task_allocator;
     FaninPool fanin_pool;
 };
 ```
 
+`TaskAllocator` owns both the task window and the heap. The two are always
+allocated together, so it checks each before committing to either and needs no
+rollback on partial failure — which is why there is no separate heap-ring or
+task-ring type to hold.
+
 ### 4.2 OrchestratorState (modified)
 
 ```cpp
-// Before: single ring
-ChipHeapRing heap_ring;
-ChipTaskRing task_ring;
+// Before: one set of ring resources, held directly
+TaskAllocator task_allocator;
 DepListPool dep_pool;
 
 // After: per-ring array (dep_pool moved to scheduler, see §4.5)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -189,7 +189,7 @@ Alignment is 64 bytes (`CHIP_ALIGN_SIZE`).
 
 The task ring manages task slot allocation with back-pressure flow control.
 
-**Structure** (`ChipTaskRing`):
+**Structure** (the task-window half of `TaskAllocator`):
 
 - `descriptors`: pointer to `TaskDescriptor[]` in shared memory
 - `window_size`: number of slots (power of 2)
@@ -216,7 +216,7 @@ else:
 
 The heap ring manages output buffer allocation from a circular GM heap.
 
-**Structure** (`ChipHeapRing`):
+**Structure** (the heap half of the same `TaskAllocator`):
 
 - `base`: GM heap base address
 - `size`: total heap size (default 1 GB)
@@ -421,7 +421,7 @@ The orchestrator runs on AICPU Thread 3 and builds the task graph by calling the
 
 Key members:
 
-- `rings[CHIP_MAX_RING_DEPTH]`: per-ring `ChipRingSet` (HeapRing + TaskRing + FaninPool). See [MULTI_RING.md §4.2](MULTI_RING.md).
+- `rings[CHIP_MAX_RING_DEPTH]`: per-ring `ChipRingSet` (`TaskAllocator` + `FaninPool`). See [MULTI_RING.md §4.2](MULTI_RING.md).
 - `tensor_map`, `tensor_pool`: dependency tracking
 - `scope_tasks[]`, `scope_begins[]`, `scope_stack_top`: scope nesting stack (flat buffer partitioned by level)
 - `scheduler`: pointer to scheduler state (for Orch-side wiring helpers and ready queue access)

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -48,22 +48,25 @@ Type changes:
 
 ### 4.1 ChipRingSet (new)
 
-Bundles the three per-ring resources into a single aggregate (`ring_buffer.h`):
+Bundles the per-ring resources into a single aggregate (`ring_buffer.h`):
 
 ```cpp
 struct ChipRingSet {
-    ChipHeapRing   heap_ring;
-    ChipTaskRing   task_ring;
+    TaskAllocator task_allocator;
     FaninPool fanin_pool;
 };
 ```
 
+`TaskAllocator` owns both the task window and the heap. The two are always
+allocated together, so it checks each before committing to either and needs no
+rollback on partial failure — which is why there is no separate heap-ring or
+task-ring type to hold.
+
 ### 4.2 OrchestratorState (modified)
 
 ```cpp
-// Before: single ring
-ChipHeapRing heap_ring;
-ChipTaskRing task_ring;
+// Before: one set of ring resources, held directly
+TaskAllocator task_allocator;
 DepListPool dep_pool;
 
 // After: per-ring array (dep_pool moved to scheduler, see §4.5)

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -190,7 +190,7 @@ Alignment is 64 bytes (`CHIP_ALIGN_SIZE`).
 
 The task ring manages task slot allocation with back-pressure flow control.
 
-**Structure** (`ChipTaskRing`):
+**Structure** (the task-window half of `TaskAllocator`):
 
 - `descriptors`: pointer to `TaskDescriptor[]` in shared memory
 - `window_size`: number of slots (power of 2)
@@ -217,7 +217,7 @@ else:
 
 The heap ring manages output buffer allocation from a circular GM heap.
 
-**Structure** (`ChipHeapRing`):
+**Structure** (the heap half of the same `TaskAllocator`):
 
 - `base`: GM heap base address
 - `size`: total heap size (default 1 GB)
@@ -431,7 +431,7 @@ The orchestrator runs on AICPU Thread 3 and builds the task graph by calling the
 
 Key members:
 
-- `rings[CHIP_MAX_RING_DEPTH]`: per-ring `ChipRingSet` (HeapRing + TaskRing + FaninPool). See [MULTI_RING.md §4.2](MULTI_RING.md).
+- `rings[CHIP_MAX_RING_DEPTH]`: per-ring `ChipRingSet` (`TaskAllocator` + `FaninPool`). See [MULTI_RING.md §4.2](MULTI_RING.md).
 - `tensor_map`, `tensor_pool`: dependency tracking
 - `scope_tasks[]`, `scope_begins[]`, `scope_stack_top`: scope nesting stack (flat buffer partitioned by level)
 - `scheduler`: pointer to scheduler state (for Orch-side wiring helpers and ready queue access)

--- a/tests/ut/cpp/a2a3/test_task_allocator.cpp
+++ b/tests/ut/cpp/a2a3/test_task_allocator.cpp
@@ -15,8 +15,8 @@
  * task window flow control, and heap_available semantics.
  *
  * The allocator is single-threaded (orchestrator thread), so no concurrency
- * tests are needed. The unified TaskAllocator replaces the previous
- * separate ChipHeapRing + ChipTaskRing.
+ * tests are needed. TaskAllocator owns the task window and the heap together,
+ * so a slot and its output buffer are checked and committed as one unit.
  *
  * Design contracts (try_bump_heap):
  *

--- a/tests/ut/cpp/a5/test_task_allocator.cpp
+++ b/tests/ut/cpp/a5/test_task_allocator.cpp
@@ -15,8 +15,8 @@
  * task window flow control, and heap_available semantics.
  *
  * The allocator is single-threaded (orchestrator thread), so no concurrency
- * tests are needed. The unified TaskAllocator replaces the previous
- * separate ChipHeapRing + ChipTaskRing.
+ * tests are needed. TaskAllocator owns the task window and the heap together,
+ * so a slot and its output buffer are checked and committed as one unit.
  *
  * Design contracts (try_bump_heap):
  *


### PR DESCRIPTION
## Summary

`ChipHeapRing` and `ChipTaskRing` **do not exist**. `TaskAllocator` unified the task window and the heap — its own header says so ("Unified task slot + heap buffer allocator … checks both resources BEFORE committing to either"), and so does the allocator unit test — but four documents still described the two as live types, and `ChipRingSet` as an aggregate of them:

```cpp
struct ChipRingSet {
    ChipHeapRing   heap_ring;     // neither member exists
    ChipTaskRing   task_ring;
    FaninPool fanin_pool;
};
```

The real struct in `ring_buffer.h` is `TaskAllocator task_allocator; FaninPool fanin_pool;`.

## Why now

Both names survive nowhere but in prose — `git grep` finds them only in these docs and one test comment. That is what makes it worth fixing rather than leaving: retiring the `PTO2` prefix in #1980 renamed these mentions along with everything else, so a description that had been stale since the two types were folded together started reading as a *current* one.

The rename's collision check could not have caught it. It asks whether the target name is taken; it never asks whether the source name still names anything. I've since swept the whole `Chip*`/`CHIP_*` vocabulary docs use against the code — these two were the only phantoms, and the one remaining hit (`CHIP_SIGNATURE_SCHEMA_V1` in `callable-identity-registration.md`) is a false positive: it labels a hash-input format block, and `build_chip_signature_schema()` packs exactly the three fields listed under it.

## Changes

- `MULTI_RING.md` §4.1 — `ChipRingSet` gets its real members, plus one sentence on why there is no separate ring type: the allocator owns both resources because they are always allocated together, so it validates each before committing to either and needs no rollback.
- `MULTI_RING.md` §4.2 — the before/after now shows the layout that actually preceded the per-ring array.
- `RUNTIME_LOGIC.md` — the two **Structure** sections are labelled as the task-window and heap halves of the one allocator rather than two types; the `ChipRingSet` composition line matches the struct.
- `tests/ut/cpp/{a2a3,a5}/test_task_allocator.cpp` — the header comment drops both dead names for what the class actually guarantees.
- `docs/dfx/scope-stats.md` — the ring formula read `min(depth, MAX_RING_DEPTH−1)`, but `scope_stats.h` computes it with `CHIP_MAX_RING_DEPTH`, and the bare spelling is the *host* orchestrator's own constant. It pointed at the wrong one.

Docs and comments only, except the two test-file headers; no behavior change.

## Testing

- [x] `git grep ChipHeapRing\|ChipTaskRing` — no hits anywhere
- [x] Chip-vocabulary phantom sweep — no remaining doc name absent from the code
- [x] all four runtimes build; cpput builds; `ctest -R task_allocator` 3/3
- [x] `markdownlint-cli2` on the 5 changed docs, `clang-format --dry-run --Werror` on the 2 tests
