### PR TITLE
CI: use task-submit for A3 onboard jobs and relax DeepSeek timeouts

### DIFF
--- a/.github/actions/run-onboard-dfx-smokes/action.yml
+++ b/.github/actions/run-onboard-dfx-smokes/action.yml
@@ -165,15 +165,10 @@ runs:
         exit "$failed"
         DFX_DRIVER
 
-        if [[ "$DFX_PLATFORM" == "a2a3" && "$(uname -m)" != "x86_64" ]]; then
+        if [[ "$DFX_PLATFORM" == "a2a3" ]]; then
           task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
             --run "bash '$DRIVER' a2a3 \$TASK_DEVICE"
         else
-          if [[ "$DFX_PLATFORM" == "a2a3" ]]; then
-            DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-            bash "$DRIVER" a2a3 "$DEVICE_LIST"
-          else
-            task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
-              --run "bash '$DRIVER' a5 \$TASK_DEVICE"
-          fi
+          task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
+            --run "bash '$DRIVER' a5 \$TASK_DEVICE"
         fi

--- a/.github/workflows/_st-deepseek-a2a3.yml
+++ b/.github/workflows/_st-deepseek-a2a3.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 30
     env:
-      SIMPLER_SCHEDULER_TIMEOUT_MS: "2000"
-      SIMPLER_OP_EXECUTE_TIMEOUT_US: "3000000"
-      SIMPLER_STREAM_SYNC_TIMEOUT_MS: "4000"
+      SIMPLER_SCHEDULER_TIMEOUT_MS: "10000"
+      SIMPLER_OP_EXECUTE_TIMEOUT_US: "45000000"
+      SIMPLER_STREAM_SYNC_TIMEOUT_MS: "50000"
     steps:
       - name: Checkout target
         uses: actions/checkout@v5
@@ -72,9 +72,5 @@ jobs:
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           DS_TESTS="examples/a2a3/host_build_graph/deepseek_v4_flash_decode examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode"
-          if [ "$(uname -m)" = "x86_64" ]; then
-            .venv/bin/python -m pytest $DS_TESTS -m "not sdma" --platform a2a3 --exclude-level 4 --manual only --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 1200
-          else
-            task-submit --timeout 1800 --max-time 1800 --device auto --device-num 4 \
-              --run ".venv/bin/python -m pytest $DS_TESTS -m 'not sdma' --platform a2a3 --exclude-level 4 --manual only --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 1200"
-          fi
+          task-submit --timeout 1800 --max-time 1800 --device auto --device-num 4 \
+            --run ".venv/bin/python -m pytest $DS_TESTS -m 'not sdma' --platform a2a3 --exclude-level 4 --manual only --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 1200"

--- a/.github/workflows/_st-npu-a2a3.yml
+++ b/.github/workflows/_st-npu-a2a3.yml
@@ -87,24 +87,16 @@ jobs:
       - name: Run pytest scene tests (a2a3)
         run: |
           source /usr/local/Ascend/cann/set_env.sh
-          if [ "$(uname -m)" = "x86_64" ]; then
-            .venv/bin/python -m pytest examples tests/st -m "not sdma" --platform a2a3 --exclude-level 4 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 1200 --manual "$MANUAL_MODE"
-          else
-            task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
-              --run ".venv/bin/python -m pytest examples tests/st -m 'not sdma' --platform a2a3 --exclude-level 4 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 1200 --manual '$MANUAL_MODE'"
-          fi
+          task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
+            --run ".venv/bin/python -m pytest examples tests/st -m 'not sdma' --platform a2a3 --exclude-level 4 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 1200 --manual '$MANUAL_MODE'"
 
       - name: SDMA pytest (a2a3)
         if: inputs.manual_mode != 'only'
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           SDMA_TESTS="examples tests/st -m sdma"
-          if [ "$(uname -m)" = "x86_64" ]; then
-            .venv/bin/python -m pytest $SDMA_TESTS --platform a2a3 --device ${DEVICE_RANGE} -v --require-pto-isa --pto-session-timeout 600
-          else
-            task-submit --timeout 1800 --max-time 1800 --device auto --device-num 2 \
-              --run ".venv/bin/python -m pytest $SDMA_TESTS --platform a2a3 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 600"
-          fi
+          task-submit --timeout 1800 --max-time 1800 --device auto --device-num 2 \
+            --run ".venv/bin/python -m pytest $SDMA_TESTS --platform a2a3 --device \$TASK_DEVICE -v --require-pto-isa --pto-session-timeout 600"
 
       - name: DFX smokes (a2a3)
         if: inputs.include_dfx_smokes

--- a/.github/workflows/_ut-npu-a2a3.yml
+++ b/.github/workflows/_ut-npu-a2a3.yml
@@ -63,20 +63,8 @@ jobs:
         run: |
           source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
-          if [ "$(uname -m)" = "x86_64" ]; then
-            python -m pytest tests/ut -m requires_hardware --platform a2a3 --device ${DEVICE_RANGE} -v
-            python3 -c "
-          import json, os
-          p = os.environ['DEVICE_RANGE'].split('-'); s, e = p[0], p[-1]
-          npus = [{'id': str(i), 'slots': 1} for i in range(int(s), int(e)+1)]
-          json.dump({'version': {'major': 1, 'minor': 0}, 'local': [{'npus': npus}]},
-                    open('tests/ut/cpp/build/resources.json', 'w'))
-          "
-            ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure --timeout 300
-          else
-            task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
-              --run "python -m pytest tests/ut -m requires_hardware --platform a2a3 --device \$TASK_DEVICE -v && python3 -c \"import json,os; ids=os.environ['TASK_DEVICE'].split(','); json.dump({'version':{'major':1,'minor':0},'local':[{'npus':[{'id':i,'slots':1} for i in ids]}]}, open('tests/ut/cpp/build/resources.json','w'))\" && ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?\$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure --timeout 300"
-          fi
+          task-submit --timeout 1800 --max-time 1800 --device auto --device-num "$DEVICE_NUM" \
+            --run "python -m pytest tests/ut -m requires_hardware --platform a2a3 --device \$TASK_DEVICE -v && python3 -c \"import json,os; ids=os.environ['TASK_DEVICE'].split(','); json.dump({'version':{'major':1,'minor':0},'local':[{'npus':[{'id':i,'slots':1} for i in ids]}]}, open('tests/ut/cpp/build/resources.json','w'))\" && ctest --test-dir tests/ut/cpp/build -L '^requires_hardware(_a2a3)?\$' --resource-spec-file $PWD/tests/ut/cpp/build/resources.json -j$(nproc) --output-on-failure --timeout 300"
 
       - name: Build cann-examples/query
         if: inputs.include_cann_examples


### PR DESCRIPTION
## Summary

- acquire devices for every A3 onboard hardware path through `task-submit --device auto`
  - hardware Python UT and CTest
  - regular scene tests and SDMA tests
  - DFX smokes
  - the two DeepSeek smokes
- remove the x86-only `DEVICE_RANGE` execution branches; ARM and x86 runners now use the same allocation path
- change the DeepSeek scheduler/op-execute/stream-sync timeouts from 2 s / 3 s / 4 s to 10 s / 45 s / 50 s

The existing `self-hosted,a2a3` runner labels, test selection, and device counts are unchanged. The DeepSeek job still runs the HBG and TMR cases with four allocated devices.

## Why

On the lower-CPU A3 CI host, the two HBG ranks showed about 6 seconds of host-side graph preparation and launch skew. The previous 2-second scheduler watchdog fired on the first rank before its peer launched, producing `SCHEDULER_TIMEOUT` (`sched_error_code=100`) and the later host-side `507018` error.

Using the runtime-default 10 s / 45 s / 50 s ordering gives the slower host enough startup margin while preserving layered stall detection. Routing all A3 device access through `task-submit` also ensures device discovery and execution happen under an explicit allocation instead of relying on a runner-wide `DEVICE_RANGE`.

## Validation

- A3 hardware UT/CTest passed with `task-submit --device auto`: https://github.com/hw-native-sys/simpler/actions/runs/32815298576/job/97702229890?pr=1998
- regular A3 onboard ST, SDMA, and DFX passed with `task-submit --device auto`: https://github.com/hw-native-sys/simpler/actions/runs/32815298576/job/97702229619?pr=1998
- the HBG-only DeepSeek diagnostic passed with 10 s / 45 s / 50 s and `task-submit --device auto`: https://github.com/hw-native-sys/simpler/actions/runs/32817937383/job/97709979073?pr=1998
- workflow/action unit tests: `38 passed`
- YAML parsing and `git diff --check` passed