### PR TITLE
Update: report the redundant edges creator protection retains

### DIFF
--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -486,6 +486,10 @@ python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
 python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
     --edge-mode omitted
 
+# Retained: the redundant edges reduction keeps for creator tensor lifetime
+python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
+    --edge-mode retained
+
 # Dataflow-verified view: preserve OUTPUT_EXISTING reuse boundaries and require
 # direct TensorMap dataflow around every byte of an omitted INOUT
 python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
@@ -502,6 +506,12 @@ python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
   alone cannot replace that lifetime relationship.
 - `omitted` — only the redundant edges `reduced` would drop (its complement),
   for auditing exactly which dependencies are transitively covered.
+- `retained` — only the redundant edges `reduced` keeps for creator tensor
+  lifetime. These are transitively implied as ordering but must not be dropped,
+  so `reduced` cannot remove them and `omitted` never lists them. Without this
+  mode a graph whose redundancy is entirely creator-protected looks exactly
+  like a graph with no redundancy: on a captured attention graph of 6128 edges,
+  `reduced` reports `removed 0` while 2032 edges are transitively implied.
 - `reduced_dataflow` — structural reduction only selects candidate edges; it
   does not reduce the annotations used for proof. Every candidate is checked
   against the complete original `creator` and `tensormap` annotations before
@@ -514,8 +524,15 @@ python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
   preserved conservatively.
 - `omitted_dataflow` — only structurally redundant edges that pass the
   dataflow proof; the complement of `reduced_dataflow`.
+- `retained_dataflow` — the redundant edges still retained after that proof.
+  An edge the proof licenses leaves this set, so it is always a subset of
+  `retained`.
 
-All reduction modes print the redundant edges to stdout as a
+`reduced` and `omitted` also report how many further redundant edges creator
+protection retained, naming the mode that lists them, so a `removed 0` is never
+read as "this graph carries no redundancy".
+
+All reduction modes print their redundant edges to stdout as a
 `<task> -> <task>` list, where each task uses the same label as the rendered
 graph — the bare `local` counter when every task is in ring 0, or the explicit
 `(ring, local)` tuple once any task lives in ring >= 1. Text output emits only
@@ -524,8 +541,8 @@ colors unselected edges like the page background, so `reduced` / `omitted`
 preserve the full-graph node placement and routing while showing only the
 selected edge set. Selected edges are drawn above background-colored edges so
 they stay visible where routes overlap. When `-o` is omitted the graph is
-written to a mode-specific stem (`deps_viewer_reduced.*` /
-`deps_viewer_omitted.*`) rather than `deps_viewer.*` so it never clobbers a
+written to a mode-specific stem (`deps_viewer_reduced.*`,
+`deps_viewer_retained.*`, …) rather than `deps_viewer.*` so it never clobbers a
 full-graph render in the same directory. In `reduced` / `omitted`, any
 annotation with `source=creator` protects that `(pred, succ)` pair from
 reduction. The dataflow modes use the complete original annotations to prove
@@ -539,7 +556,7 @@ the graph contains a cycle.
 | `input` | | Path to `deps.json` (default: newest under `./outputs/`) |
 | `--output` | `-o` | Output path; default stem is `deps_viewer`, or `deps_viewer_{mode}` for any reduction mode |
 | `--format` | | Output format: `text` (default) or `html` |
-| `--edge-mode` | | Select visible edges: `full`, `reduced`, `omitted`, `reduced_dataflow`, or `omitted_dataflow`; HTML preserves full layout. |
+| `--edge-mode` | | Select visible edges: `full`, `reduced`, `omitted`, `retained`, or their `_dataflow` variants; HTML preserves full layout. |
 | `--engine` | | HTML-only Graphviz layout engine: `dot` (default), `sfdp`, `neato`, `fdp`, `circo`, `twopi` |
 | `--direction` | | HTML-only flow direction for hierarchical layouts: `LR` (default) / `TB` / `BT` / `RL` |
 | `--show-tensor-info` | | HTML-only: render per-task tensor rows and route edges to specific arg ports |

--- a/simpler_setup/tools/deps_viewer.py
+++ b/simpler_setup/tools/deps_viewer.py
@@ -35,6 +35,7 @@ Usage:
     python -m simpler_setup.tools.deps_viewer DEPS_JSON --format html --engine sfdp
     python -m simpler_setup.tools.deps_viewer DEPS_JSON --edge-mode reduced
     python -m simpler_setup.tools.deps_viewer DEPS_JSON --edge-mode omitted
+    python -m simpler_setup.tools.deps_viewer DEPS_JSON --edge-mode retained
     python -m simpler_setup.tools.deps_viewer DEPS_JSON --edge-mode reduced_dataflow
     python -m simpler_setup.tools.deps_viewer DEPS_JSON --edge-mode omitted_dataflow
 
@@ -47,13 +48,21 @@ warning if the graph contains a cycle:
   ``A->C`` when ``A->B->C`` exists), while retaining every ``creator`` edge.
 - ``omitted`` — only the redundant edges ``reduced`` would drop (its complement),
   useful for auditing exactly which dependencies are transitively covered.
-- ``reduced_dataflow`` / ``omitted_dataflow`` — structural reduction only
+- ``retained`` — the redundant edges reduction keeps for creator tensor
+  lifetime. These are transitively implied as ordering, so ``reduced`` cannot
+  drop them and ``omitted`` never lists them; without this mode a graph whose
+  redundancy is entirely creator-protected is indistinguishable from a graph
+  with no redundancy at all.
+- ``reduced_dataflow`` / ``omitted_dataflow`` / ``retained_dataflow`` — structural reduction only
   selects candidate edges. Each candidate creator edge is preserved unless
   full, unfiltered annotations prove every byte of an ``INOUT`` has direct
   TensorMap dataflow from an earlier Output and to a later ``INOUT`` owned by
   the same creator. ``OUTPUT_EXISTING`` reuse boundaries are always preserved.
 
-All reduction modes print the redundant edges to stdout. Text output
+All reduction modes print the redundant edges to stdout, and ``reduced`` /
+``omitted`` additionally report how many further redundant edges creator
+protection retained, so a ``removed 0`` is never mistaken for a graph that
+carries no redundancy. Text output
 emits only the selected edge set. HTML output keeps every edge in the Graphviz
 layout and colors the unselected edges like the page background, preserving the
 full-graph layout while drawing the selected edge set above unselected edges.
@@ -1768,17 +1777,27 @@ Examples:
     )
     p.add_argument(
         "--edge-mode",
-        choices=["full", "reduced", "omitted", "reduced_dataflow", "omitted_dataflow"],
+        choices=[
+            "full",
+            "reduced",
+            "omitted",
+            "retained",
+            "reduced_dataflow",
+            "omitted_dataflow",
+            "retained_dataflow",
+        ],
         default="full",
         help=(
             "full (default) selects every dependency edge; reduced applies transitive reduction, selecting the "
             "minimal scheduling-edge set while preserving creator tensor-lifetime edges; omitted selects only "
-            "the redundant edges reduced would drop (the complement of reduced). reduced/omitted print the "
-            "redundant edges to stdout. reduced_dataflow/omitted_dataflow use structural reduction only to select "
-            "candidates, then inspect full original annotations: OUTPUT_EXISTING reuse boundaries are retained, "
-            "and every byte of an INOUT needs direct TensorMap dataflow into and out of it before its creator edge "
-            "is omitted. All reduction modes work for text and html and are skipped with a warning on a cyclic graph. "
-            "In html, all edges still participate in layout; "
+            "the redundant edges reduced would drop (the complement of reduced); retained selects the redundant "
+            "edges reduction keeps for creator tensor lifetime, which reduced/omitted can never drop and which "
+            "reduced/omitted therefore report only as a count. reduced/omitted print the redundant edges to "
+            "stdout, retained prints the retained ones. The _dataflow variants use structural reduction only to "
+            "select candidates, then inspect full original annotations: OUTPUT_EXISTING reuse boundaries are "
+            "retained, and every byte of an INOUT needs direct TensorMap dataflow into and out of it before its "
+            "creator edge is omitted. All reduction modes work for text and html and are skipped with a warning "
+            "on a cyclic graph. In html, all edges still participate in layout; "
             "unselected edges are colored as background and drawn below selected edges."
         ),
     )
@@ -1844,20 +1863,41 @@ def _apply_edge_mode(edge_mode, output_format, edges, nodes, annotations, tensor
         )
         return edges, annotations, "deps_viewer", hidden_html_edges, visible_html_edge_count
 
+    # Structural reduction ignores creator protection, so the edges it drops that
+    # this mode still keeps are exactly the ones held for tensor lifetime.
+    _, structural_redundant, _ = _transitive_reduction(edges, nodes)
+    removed_set = set(removed)
+    retained = [edge for edge in structural_redundant if edge not in removed_set]
+
     fmt_task = _make_task_formatter(nodes)
-    is_reduced = edge_mode.startswith("reduced")
-    shown = kept if is_reduced else removed
-    if is_reduced:
-        prefix = "Dataflow-verified transitive reduction" if is_dataflow else "Transitive reduction"
-        print(f"{prefix}: removed {len(removed)} redundant edge(s) of {len(edges)} ({len(kept)} kept)")
+    selection = edge_mode.split("_", 1)[0]
+    shown = {"reduced": kept, "omitted": removed, "retained": retained}[selection]
+    listed = retained if selection == "retained" else removed
+    headline = {
+        ("reduced", False): "Transitive reduction",
+        ("reduced", True): "Dataflow-verified transitive reduction",
+        ("omitted", False): "Redundant edges only",
+        ("omitted", True): "Dataflow-verified redundant edges only",
+        ("retained", False): "Creator-protected redundant edges",
+        ("retained", True): "Creator-protected redundant edges (dataflow-verified)",
+    }[(selection, is_dataflow)]
+    if selection == "reduced":
+        print(f"{headline}: removed {len(removed)} redundant edge(s) of {len(edges)} ({len(kept)} kept)")
+    elif selection == "omitted":
+        print(f"{headline}: showing {len(removed)} redundant edge(s) of {len(edges)}")
     else:
-        prefix = "Dataflow-verified redundant edges only" if is_dataflow else "Redundant edges only"
-        print(f"{prefix}: showing {len(removed)} redundant edge(s) of {len(edges)}")
-    for pred, succ in removed:
+        print(f"{headline}: showing {len(retained)} of {len(edges)} edge(s), retained for tensor lifetime")
+    if selection != "retained" and retained:
+        lister = "retained_dataflow" if is_dataflow else "retained"
+        print(
+            f"  ({len(retained)} further redundant edge(s) retained for creator tensor lifetime; "
+            f"--edge-mode {lister} lists them)"
+        )
+    for pred, succ in listed:
         print(f"  - {fmt_task(pred)} -> {fmt_task(succ)}")
 
     if output_format == "html":
-        hidden_html_edges = set(removed if is_reduced else kept)
+        hidden_html_edges = set(edges) - set(shown)
         visible_html_edge_count = len(shown)
         print(
             f"HTML layout preserves all {len(edges)} edge(s); "

--- a/tests/ut/py/test_deps_viewer.py
+++ b/tests/ut/py/test_deps_viewer.py
@@ -769,6 +769,94 @@ def test_main_reduced_mode_keeps_transitive_creator_reference(tmp_path, capsys):
     assert "removed 0 redundant edge(s)" in capsys.readouterr().out
 
 
+def test_main_reduced_mode_reports_creator_retained_count(tmp_path, capsys):
+    # Same graph as above: reduction removes nothing, but one edge is redundant
+    # and kept only for tensor lifetime. Without the retention count, "removed 0"
+    # is indistinguishable from a graph that carries no redundancy at all.
+    t0, t1, t3, t4 = 1, 2, 3, 4
+    edges = [(t0, t1), (t1, t3), (t3, t4), (t0, t4)]
+    deps_path = _write_deps_edges(tmp_path, edges, sources={(t0, t4): "creator"})
+
+    rc = deps_viewer.main([str(deps_path), "--edge-mode", "reduced", "-o", str(tmp_path / "graph.txt")])
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "removed 0 redundant edge(s)" in stdout
+    assert "1 further redundant edge(s) retained for creator tensor lifetime" in stdout
+    assert "--edge-mode retained lists them" in stdout
+
+
+def test_main_reduced_mode_reports_no_retention_when_nothing_is_protected(tmp_path, capsys):
+    a, b, c = 1, 2, 3
+    deps_path = _write_deps_edges(tmp_path, [(a, b), (b, c), (a, c)])
+
+    rc = deps_viewer.main([str(deps_path), "--edge-mode", "reduced", "-o", str(tmp_path / "graph.txt")])
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "removed 1 redundant edge(s)" in stdout
+    assert "retained for creator tensor lifetime" not in stdout
+
+
+def test_main_retained_mode_selects_only_creator_protected_redundant_edges(tmp_path, capsys):
+    t0, t1, t3, t4 = 1, 2, 3, 4
+    edges = [(t0, t1), (t1, t3), (t3, t4), (t0, t4)]
+    deps_path = _write_deps_edges(tmp_path, edges, sources={(t0, t4): "creator"})
+    out = tmp_path / "graph.txt"
+
+    rc = deps_viewer.main([str(deps_path), "--edge-mode", "retained", "-o", str(out)])
+
+    assert rc == 0
+    assert "unique_task_edges: 1" in out.read_text()
+    stdout = capsys.readouterr().out
+    assert "Creator-protected redundant edges: showing 1 of 4 edge(s)" in stdout
+    assert "  - 1 -> 4" in stdout
+
+
+def test_main_retained_mode_is_empty_when_reduction_drops_everything(tmp_path, capsys):
+    a, b, c = 1, 2, 3
+    deps_path = _write_deps_edges(tmp_path, [(a, b), (b, c), (a, c)])
+    out = tmp_path / "graph.txt"
+
+    rc = deps_viewer.main([str(deps_path), "--edge-mode", "retained", "-o", str(out)])
+
+    assert rc == 0
+    assert "unique_task_edges: 0" in out.read_text()
+    assert "showing 0 of 3 edge(s)" in capsys.readouterr().out
+
+
+def test_main_retained_dataflow_drops_the_edge_its_proof_licenses(tmp_path, capsys):
+    # The dataflow proof licenses removing the middle Output edge, so it leaves
+    # the retained set; the OUTPUT_EXISTING reuse boundary stays retained.
+    deps_path, _nodes = _write_output_lifetime_deps(tmp_path)
+
+    structural_rc = deps_viewer.main([str(deps_path), "--edge-mode", "retained", "-o", str(tmp_path / "s.txt")])
+    structural_out = capsys.readouterr().out
+    dataflow_rc = deps_viewer.main([str(deps_path), "--edge-mode", "retained_dataflow", "-o", str(tmp_path / "d.txt")])
+    dataflow_out = capsys.readouterr().out
+
+    assert structural_rc == 0
+    assert dataflow_rc == 0
+    assert "showing 2 of 5 edge(s)" in structural_out
+    assert "  - 1 -> 3" in structural_out
+    assert "  - 1 -> 4" in structural_out
+    assert "Creator-protected redundant edges (dataflow-verified): showing 1 of 5 edge(s)" in dataflow_out
+    assert "  - 1 -> 3" not in dataflow_out
+    assert "  - 1 -> 4" in dataflow_out
+
+
+def test_main_retained_default_output_stem(tmp_path):
+    ring = 1 << 32
+    a, b, c = ring + 1, ring + 2, ring + 3
+    deps_path = _write_deps_edges(tmp_path, [(a, b), (b, c), (a, c)])
+
+    rc = deps_viewer.main([str(deps_path), "--edge-mode", "retained"])
+
+    assert rc == 0
+    assert (tmp_path / "deps_viewer_retained.txt").exists()
+    assert not (tmp_path / "deps_viewer.txt").exists()
+
+
 def test_main_full_mode_keeps_all_edges(tmp_path, capsys):
     ring = 1 << 32
     a, b, c = ring + 1, ring + 2, ring + 3


### PR DESCRIPTION
## Summary

`--edge-mode reduced` protects any `(pred, succ)` pair carrying a `source=creator`
annotation — such an edge keeps the task that owns a tensor alive rather than
expressing an execution order, so reduction must not drop it. But the tool then
reported only what it *removed*, which makes a graph whose redundancy is entirely
creator-protected indistinguishable from a graph with no redundancy at all.

That case is not rare. Step-A creator retention (`compute_task_fanin`) emits a
creator row for exactly the pairs a dataflow dependency also covers, so the
protection fires on mixed-source graphs as hard as on all-creator ones.

Measured over **64 dependency graphs** captured from `tests/st/a2a3/{tensormap_and_ringbuffer,host_build_graph}`
with `--enable-dep-gen` on a2a3:

| | edges | structurally redundant | `reduced` reported |
| --- | ---: | ---: | ---: |
| all 64 graphs | 43784 | 5839 | 722 (12%) |
| `batch_paged_attention` Case1 | 6128 | 2032 | **0** |
| `paged_attention_unroll` Case1 | 1280 | 256 | **0** |

Before / after on that 6128-edge graph:

```text
# before
Transitive reduction: removed 0 redundant edge(s) of 6128 (6128 kept)

# after
Transitive reduction: removed 0 redundant edge(s) of 6128 (6128 kept)
  (2032 further redundant edge(s) retained for creator tensor lifetime; --edge-mode retained lists them)
```

- Report the retained count in `reduced` / `omitted`, naming the mode that lists
  those edges, so `removed 0` can no longer be read as "this graph carries no
  redundancy".
- Add `retained` / `retained_dataflow`, selecting the redundant edges the
  corresponding reduction keeps for tensor lifetime. The dataflow variant is
  always a subset: an edge its byte-level proof licenses leaves the retained set
  (on `batch_paged_attention`, 2032 retained structurally → 992 removed by the
  proof → 1040 still retained).
- Both are derived from a structural reduction that ignores annotations, so the
  retained set is exactly what protection changed.

No behavior change to the edges any existing mode selects; `full`, `reduced`,
`omitted`, and the two `_dataflow` modes render exactly what they did before.

## Testing

- [x] Unit tests pass — `pytest tests/ut/py` → 1917 passed, 20 skipped;
      `tests/ut/py/test_deps_viewer.py` → 42 passed, including 6 new cases
      covering the retained count line, its absence when nothing is protected,
      both new modes, the dataflow subset relation, and the output stem.
- [x] Lint clean — `ruff check`, `ruff format --check`, `pyright` (0 errors),
      `markdownlint-cli2` on the changed README.
- [x] Verified against real captures — the four modes re-run on the
      `batch_paged_attention` and `paged_attention_unroll` graphs above.
- [ ] Simulation / hardware scene tests — not run; this change touches only the
      post-processing tool under `simpler_setup/tools/`, which no scene test
      executes.