### PR TITLE
CI: improve macOS packaging cache reuse

### DIFF
--- a/.github/workflows/_packaging.yml
+++ b/.github/workflows/_packaging.yml
@@ -91,6 +91,20 @@ jobs:
       - name: Run packaging matrix
         run: |
           . .venv/bin/activate
+          if [[ -z "${CC:-}" && -z "${CXX:-}" ]]; then
+            # Use the unversioned platform-default compilers intentionally (Apple
+            # Clang on current macOS runners), not versioned Homebrew GCC. Absolute
+            # paths keep the compiler identity stable across packaging modes.
+            if CC="$(command -v gcc)" && CXX="$(command -v g++)"; then
+              export CC CXX
+              echo "Resolved platform compilers: CC=$CC CXX=$CXX"
+              "$CC" --version
+              "$CXX" --version
+            else
+              echo "::error::gcc/g++ not found on PATH; runner provisioning is incomplete"
+              exit 1
+            fi
+          fi
           if [[ "${{ runner.os }}" == "macOS" ]]; then
             export MACOSX_DEPLOYMENT_TARGET
             MACOSX_DEPLOYMENT_TARGET="$(sw_vers -productVersion | cut -d. -f1,2)"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -44,7 +44,12 @@ also installs ccache, while its macOS fallback is outside the shared action's
 strict GCC 15 contract. Only the compiler is required there — ninja comes from
 PyPI with the venv, and both the workflow and `tools/verify_packaging.sh` run
 without ccache — so a package manager that cannot serve ccache emits a warning
-and the job continues. `apt-install` gives every apt operation a wall-clock
+and the job continues. The packaging matrix preserves any explicit `CC`/`CXX`
+selection and resolves its required `gcc`/`g++` pair once when neither is set,
+so every install mode and its nested runtime builds use one compiler identity.
+The job logs the default pair's resolved paths and compiler versions, and
+reports an explicit runner-provisioning error if that pair is absent.
+`apt-install` gives every apt operation a wall-clock
 bound and attempts to repair an interrupted dpkg transaction before another apt
 operation can run. It uses the runner's existing package indexes by default, avoiding a
 full mirror refresh for ordinary CI dependencies. `setup-gcc-15` is the one

--- a/tests/ut/py/test_packaging_compiler_identity.py
+++ b/tests/ut/py/test_packaging_compiler_identity.py
@@ -1,0 +1,91 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+VENV_ACTIVATE = ". .venv/bin/activate\n"
+MACOS_GUARD = 'if [[ "${{ runner.os }}" == "macOS" ]]'
+
+
+def _packaging_script() -> str:
+    workflow: dict[str, Any] = yaml.safe_load((PROJECT_ROOT / ".github" / "workflows" / "_packaging.yml").read_text())
+    matches = [
+        step["run"]
+        for job in workflow["jobs"].values()
+        for step in job["steps"]
+        if step.get("name") == "Run packaging matrix"
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _compiler_setup() -> str:
+    script = _packaging_script()
+    _, activate, remainder = script.partition(VENV_ACTIVATE)
+    assert activate, "packaging step no longer has the expected venv activation"
+    setup, guard, _ = remainder.partition(MACOS_GUARD)
+    assert guard, "packaging step no longer has the expected compiler setup before the macOS guard"
+    return setup
+
+
+def _run_setup(script: str, env: dict[str, str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    command = f'{script}\nprintf "%s\\n%s\\n" "${{CC-unset}}" "${{CXX-unset}}"'
+    return subprocess.run(
+        ["/bin/bash", "-euo", "pipefail", "-c", command],
+        check=check,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+
+def test_packaging_modes_share_one_compiler_identity_without_overriding_callers(tmp_path: Path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for compiler in ("gcc", "g++"):
+        path = bin_dir / compiler
+        path.write_text('#!/bin/sh\nprintf "%s %s\\n" "$0" "$*"\n')
+        path.chmod(0o755)
+
+    env = os.environ.copy()
+    env.pop("CC", None)
+    env.pop("CXX", None)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    script = _compiler_setup()
+
+    result = _run_setup(script, env)
+    assert f"Resolved platform compilers: CC={bin_dir / 'gcc'} CXX={bin_dir / 'g++'}" in result.stdout
+    assert f"{bin_dir / 'gcc'} --version" in result.stdout
+    assert f"{bin_dir / 'g++'} --version" in result.stdout
+    assert result.stdout.splitlines()[-2:] == [str(bin_dir / "gcc"), str(bin_dir / "g++")]
+
+    env["CC"] = "/opt/custom/clang"
+    env["CXX"] = "/opt/custom/clang++"
+    assert _run_setup(script, env).stdout.splitlines() == [env["CC"], env["CXX"]]
+
+    env.pop("CXX")
+    assert _run_setup(script, env).stdout.splitlines() == [env["CC"], "unset"]
+
+
+def test_packaging_compiler_setup_reports_missing_platform_compilers(tmp_path: Path):
+    env = os.environ.copy()
+    env.pop("CC", None)
+    env.pop("CXX", None)
+    env["PATH"] = str(tmp_path)
+
+    result = _run_setup(_compiler_setup(), env, check=False)
+
+    assert result.returncode == 1
+    assert "::error::gcc/g++ not found on PATH; runner provisioning is incomplete" in result.stdout


### PR DESCRIPTION
## Summary

- resolve the platform-default `gcc`/`g++` paths once when neither `CC` nor `CXX` is supplied
- preserve complete and partial caller compiler overrides
- keep all five packaging modes on one compiler identity so nested runtime objects retain stable ccache keys
- add a focused workflow contract test for default and caller-supplied compiler selection

## Why

The packaging matrix invokes the same builds through pip and direct CMake modes. On macOS, the unversioned `gcc`/`g++` commands are Apple Clang drivers, but different textual compiler identities prevented ccache from recognizing equivalent nested runtime compilations. Resolving one absolute compiler pair before the matrix keeps the platform-default toolchain while making those cache keys stable.

The code intentionally uses the unversioned platform default rather than the separately installed versioned Homebrew GCC. Explicit `CC`/`CXX` selections remain authoritative.

## Validation

| Runner | Comparable baseline | Clean-head result | Difference |
| --- | ---: | ---: | ---: |
| Ubuntu | 218s | 222s | +4s, effectively flat |
| macOS | 422s | 261s | -161s (-38%) |

- full pre-commit suite passed
- focused compiler-identity contract test passed
- all five packaging modes remain enabled, including the full direct-CMake target
- clean-head jobs: [Ubuntu](https://github.com/doraemonmj/simpler_wc/actions/runs/32802099807/job/97664932411), [macOS](https://github.com/doraemonmj/simpler_wc/actions/runs/32802099807/job/97664932351)
- benchmark history and rejected experiments: [personal-fork PR #15](https://github.com/doraemonmj/simpler_wc/pull/15)

## Compatibility

This does not pin a compiler version across runner-image updates. It pins the resolved compiler paths only for the duration of one packaging job, which is the scope needed for cross-mode ccache reuse.