### PR TITLE
Add: expose device-wide HBM information

### DIFF
--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -2817,6 +2817,20 @@ NB_MODULE(_task_interface, m) {
     // breakdown) is no longer returned from run(); the platform emits it as
     // `[STRACE]` log markers — parse with simpler_setup.tools.strace_timing.
 
+    nb::class_<DeviceMemoryInfo>(m, "DeviceMemoryInfo")
+        .def_ro("free_bytes", &DeviceMemoryInfo::free_bytes)
+        .def_ro("total_bytes", &DeviceMemoryInfo::total_bytes)
+        .def(
+            "__iter__",
+            [](const DeviceMemoryInfo &self) {
+                return nb::make_tuple(self.free_bytes, self.total_bytes).attr("__iter__")();
+            }
+        )
+        .def("__repr__", [](const DeviceMemoryInfo &self) {
+            return "DeviceMemoryInfo(free_bytes=" + std::to_string(self.free_bytes) +
+                   ", total_bytes=" + std::to_string(self.total_bytes) + ")";
+        });
+
     nb::class_<ChipWorkerNativeRun>(m, "_ChipWorkerNativeRun")
         .def_ro("slot_id", &ChipWorkerNativeRun::slot_id)
         .def_ro("generation", &ChipWorkerNativeRun::generation)
@@ -3102,6 +3116,18 @@ NB_MODULE(_task_interface, m) {
             "Excludes HCCL/VMM comm windows. 0 when not "
             "initialized. Lets downstream runtimes subtract simpler's own HBM "
             "from their cache budget (it may be invisible to aclrtGetMemInfo)."
+        )
+        .def(
+            "device_memory_info",
+            [](const ChipWorker &self) {
+                try {
+                    return self.device_memory_info();
+                } catch (const UnsupportedRuntimeOperation &e) {
+                    PyErr_SetString(PyExc_NotImplementedError, e.what());
+                    throw nb::python_error();
+                }
+            },
+            "Return the ACL_HBM_MEM free/total byte snapshot for this worker's device."
         )
         .def("malloc", &ChipWorker::malloc, nb::arg("size"))
         .def("free", &ChipWorker::free, nb::arg("ptr"))

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -330,6 +330,14 @@ inline void bind_worker(nb::module_ &m) {
             "(tensors + pooled arenas + runtime buffers)."
         )
         .def(
+            "device_memory_info",
+            [](Orchestrator &self, int worker_id) {
+                return self.device_memory_info(worker_id);
+            },
+            nb::arg("worker_id"), nb::call_guard<nb::gil_scoped_release>(),
+            "Device-wide ACL_HBM_MEM free/total byte snapshot for a next-level worker."
+        )
+        .def(
             "alloc",
             [](Orchestrator &self, const std::vector<uint32_t> &shape, DataType dtype,
                const CanonicalIdentity &identity) {

--- a/python/simpler/orchestrator.py
+++ b/python/simpler/orchestrator.py
@@ -50,6 +50,7 @@ from .task_interface import (
     CommBufferSpec,
     CommDomainHandle,
     DataType,
+    DeviceMemoryInfo,
     GlobalCommDomainHandle,
     GlobalCommDomainView,
     RemoteAddressSpace,
@@ -739,6 +740,11 @@ class Orchestrator:
         """
         with self._control_admission("committed_device_memory"):
             return int(self._o.committed_device_memory(int(worker_id)))
+
+    def device_memory_info(self, worker_id: int) -> DeviceMemoryInfo:
+        """Device-wide ACL_HBM_MEM free/total byte snapshot for *worker_id*."""
+        with self._control_admission("device_memory_info"):
+            return self._o.device_memory_info(int(worker_id))
 
     # A Worker is the only allocator. The Orchestrator exposes thin wrappers that delegate to the
     # bound Worker's implementation so an orchestration fn can allocate / copy / free without reaching

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -59,6 +59,7 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
     ChipTensor,
     CoreCallable,
     DataType,
+    DeviceMemoryInfo,
     RuntimeEnv,
     TaskArgs,
     TaskHandle,
@@ -153,6 +154,7 @@ from .global_comm_domain import GlobalDomainAttachment, GlobalDomainBuffer, Glob
 
 __all__ = [
     "DataType",
+    "DeviceMemoryInfo",
     "get_element_size",
     "get_dtype_name",
     "MAX_TENSOR_DIMS",
@@ -1702,3 +1704,7 @@ class ChipWorker:
     def committed_device_memory(self) -> int:
         """Total device HBM (bytes) committed by this chip worker's MemoryAllocator."""
         return int(self._impl.committed_device_memory)
+
+    def device_memory_info(self) -> DeviceMemoryInfo:
+        """Device-wide ACL_HBM_MEM free/total byte snapshot."""
+        return self._impl.device_memory_info()

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -254,6 +254,7 @@ from .task_interface import (
     ChipWorker,
     CommBufferSpec,
     CommDomainHandle,
+    DeviceMemoryInfo,
     GlobalCommDomainHandle,
     GlobalCommDomainView,
     RemoteAddressSpace,
@@ -567,6 +568,8 @@ _CTRL_COMMITTED_DEVICE_MEMORY = 18
 # enclosed command uses remote_l3_protocol.ControlName; values 18-23 belong to
 # chip-child controls.
 _CTRL_GLOBAL_DOMAIN_NODE = 24
+_CTRL_DEVICE_MEMORY_INFO = 25
+_CTRL_OP_NAMES[_CTRL_DEVICE_MEMORY_INFO] = "device_memory_info"
 _LOCAL_GLOBAL_CONTROL_HEADER = struct.Struct("<IIQ")
 _CTRL_OP_NAMES[_CTRL_GLOBAL_DOMAIN_NODE] = "global_domain"
 
@@ -615,6 +618,7 @@ _OFF_DOMAIN_REPLY_COMMITTED = 0
 #   offset 40:                  uint64  result (returned ptr from malloc)
 _CTRL_OFF_ARG0 = 16
 _CTRL_OFF_RESULT = 40
+_DEVICE_MEMORY_INFO = struct.Struct("<QQ")
 
 
 class _NoBufferConsumerError(RuntimeError):
@@ -2924,6 +2928,9 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
                 _handle_ctrl_region_release(buf, provider_region_store)
             elif sub_cmd == _CTRL_COMMITTED_DEVICE_MEMORY:
                 struct.pack_into("Q", buf, _CTRL_OFF_RESULT, cw.committed_device_memory)
+            elif sub_cmd == _CTRL_DEVICE_MEMORY_INFO:
+                info = cw.device_memory_info()
+                _DEVICE_MEMORY_INFO.pack_into(buf, _CTRL_OFF_RESULT, info.free_bytes, info.total_bytes)
             elif sub_cmd == _CTRL_IMPORT_RELEASE:
                 import_registry.unregister(_unpack_identity_wire(_read_control_digest(buf)))
             elif sub_cmd == CTRL_GLOBAL_DOMAIN_PREPARE:
@@ -10166,6 +10173,29 @@ class Worker:
             self._check_chip_worker_id(worker_id)
             assert self._orch is not None
             return int(self._orch.committed_device_memory(worker_id))
+
+    def device_memory_info(self, worker_id: int = 0) -> DeviceMemoryInfo:
+        """Return the target device's ACL_HBM_MEM free/total byte snapshot.
+
+        Level 2 queries the in-process chip worker. Level 3 routes by logical
+        *worker_id* to the matching forked chip child. Simulator backends do
+        not synthesize device-wide memory and raise ``NotImplementedError``.
+        """
+        worker_id = int(worker_id)
+        with self._operation_lease("device_memory_info"):
+            if self.level == 2:
+                if str(self._config.get("platform", "")).endswith("sim"):
+                    raise NotImplementedError("device_memory_info is not supported on simulator backends")
+                assert self._chip_worker is not None
+                with self._child_prov_worker_lock(0), self._child_prov_lock:
+                    return self._chip_worker.device_memory_info()
+            if not self._chip_shms:
+                raise NotImplementedError("device_memory_info requires at least one forked chip worker")
+            self._check_chip_worker_id(worker_id)
+            if str(self._config.get("platform", "")).endswith("sim"):
+                raise NotImplementedError("device_memory_info is not supported on simulator backends")
+            assert self._orch is not None
+            return self._orch.device_memory_info(worker_id)
 
     @staticmethod
     def _check_copy_handle(handle: Buffer, nbytes: int, *, writing: bool, api: str) -> None:

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -560,6 +560,12 @@ uint64_t Orchestrator::committed_device_memory(int worker_id) {
     return wt->control_committed_device_memory();
 }
 
+DeviceMemoryInfo Orchestrator::device_memory_info(int worker_id) {
+    auto *wt = manager_->get_worker_by_id(WorkerType::NEXT_LEVEL, worker_id);
+    if (!wt) throw std::runtime_error("Orchestrator::device_memory_info: invalid worker_id");
+    return wt->control_device_memory_info();
+}
+
 TaskSlotState &Orchestrator::slot_state(TaskSlot s) {
     TaskSlotState *p = allocator_->slot_state(s);
     if (!p) throw std::runtime_error("Orchestrator::slot_state: invalid slot id");

--- a/src/common/hierarchical/orchestrator.h
+++ b/src/common/hierarchical/orchestrator.h
@@ -46,6 +46,7 @@
 #include "../task_interface/task_args.h"
 #include "../task_interface/tensor.h"
 #include "../worker/pipeline_slot_pool.h"
+#include "../worker/device_memory_info.h"
 #include "ring.h"
 #include "scope.h"
 #include "tensormap.h"
@@ -107,6 +108,7 @@ public:
     // allocator. Thread-safe: can be called from the orch thread while the
     // target worker is running a task (MemoryAllocator is mutex-protected).
     uint64_t committed_device_memory(int worker_id);
+    DeviceMemoryInfo device_memory_info(int worker_id);
 
     // Submit a NEXT_LEVEL task. `callable` is the stable identity returned
     // by Worker.register(); the child resolves its digest to a private slot.

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -137,6 +137,9 @@ uint64_t WorkerEndpoint::control_malloc(size_t) { throw_unsupported_control("con
 uint64_t WorkerEndpoint::control_committed_device_memory() {
     throw_unsupported_control("control_committed_device_memory");
 }
+DeviceMemoryInfo WorkerEndpoint::control_device_memory_info() {
+    throw_unsupported_control("control_device_memory_info");
+}
 void WorkerEndpoint::control_free(uint64_t) { throw_unsupported_control("control_free"); }
 void WorkerEndpoint::control_copy_to(const BufferDescriptor &, const BufferDescriptor &, uint64_t) {
     throw_unsupported_control("control_copy_to");
@@ -1273,6 +1276,15 @@ uint64_t LocalMailboxEndpoint::control_committed_device_memory() {
     return read_control_result(mbox());
 }
 
+DeviceMemoryInfo LocalMailboxEndpoint::control_device_memory_info() {
+    std::lock_guard<std::mutex> lk(mailbox_mu_);
+    write_control_args(mbox(), CTRL_DEVICE_MEMORY_INFO);
+    run_control_command("control_device_memory_info");
+    DeviceMemoryInfo info{};
+    std::memcpy(&info, mbox() + CTRL_OFF_RESULT, sizeof(info));
+    return info;
+}
+
 void LocalMailboxEndpoint::control_prepare(const uint8_t *digest) {
     std::lock_guard<std::mutex> lk(mailbox_mu_);
     write_control_args(mbox(), CTRL_PREPARE);
@@ -1477,6 +1489,11 @@ uint64_t WorkerThread::control_malloc(size_t size) {
 uint64_t WorkerThread::control_committed_device_memory() {
     if (!endpoint_) throw std::runtime_error("control_committed_device_memory: null endpoint");
     return endpoint_->control_committed_device_memory();
+}
+
+DeviceMemoryInfo WorkerThread::control_device_memory_info() {
+    if (!endpoint_) throw std::runtime_error("control_device_memory_info: null endpoint");
+    return endpoint_->control_device_memory_info();
 }
 
 void WorkerThread::control_prepare(const uint8_t *digest) {

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -43,6 +43,7 @@
 
 #include "../task_interface/buffer.h"
 #include "../task_interface/call_config.h"
+#include "../worker/device_memory_info.h"
 #include "remote_wire.h"
 #include "types.h"
 
@@ -215,8 +216,12 @@ static constexpr uint64_t CTRL_PY_UNREGISTER = 11;
 static constexpr uint64_t CTRL_REGION_ALLOCATE = 16;
 static constexpr uint64_t CTRL_REGION_RELEASE = 17;
 // Query a chip child's MemoryAllocator-committed HBM (bytes). The child writes
-// the value to CTRL_OFF_RESULT; the parent sums across children for L3.
+// the selected chip's value to CTRL_OFF_RESULT.
 static constexpr uint64_t CTRL_COMMITTED_DEVICE_MEMORY = 18;
+// 19..24 are reserved by the Python Global CommDomain chip controls and its
+// L4-to-local-L3 envelope. Query a chip child's device-wide ACL_HBM_MEM
+// snapshot; the child writes one DeviceMemoryInfo at CTRL_OFF_RESULT.
+static constexpr uint64_t CTRL_DEVICE_MEMORY_INFO = 25;
 
 // Control args occupy the base frame's config-sized region:
 //   offset 16: uint64 arg0 (size for malloc/register; ptr for free)
@@ -343,6 +348,7 @@ public:
     virtual void shutdown_child() {}
     virtual uint64_t control_malloc(size_t size);
     virtual uint64_t control_committed_device_memory();
+    virtual DeviceMemoryInfo control_device_memory_info();
     virtual void control_free(uint64_t ptr);
     virtual void control_copy_to(const BufferDescriptor &dst, const BufferDescriptor &src, uint64_t nbytes);
     virtual void control_copy_from(const BufferDescriptor &dst, const BufferDescriptor &src, uint64_t nbytes);
@@ -407,6 +413,7 @@ public:
     void shutdown_child() override;
     uint64_t control_malloc(size_t size) override;
     uint64_t control_committed_device_memory() override;
+    DeviceMemoryInfo control_device_memory_info() override;
     void control_free(uint64_t ptr) override;
     void control_copy_to(const BufferDescriptor &dst, const BufferDescriptor &src, uint64_t nbytes) override;
     void control_copy_from(const BufferDescriptor &dst, const BufferDescriptor &src, uint64_t nbytes) override;
@@ -561,6 +568,7 @@ public:
     // child progress owner may observe a control request while a task is active.
     uint64_t control_malloc(size_t size);
     uint64_t control_committed_device_memory();
+    DeviceMemoryInfo control_device_memory_info();
     void control_free(uint64_t ptr);
     void control_copy_to(const BufferDescriptor &dst, const BufferDescriptor &src, uint64_t nbytes);
     void control_copy_from(const BufferDescriptor &dst, const BufferDescriptor &src, uint64_t nbytes);

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -32,6 +32,7 @@
 #include "task_args.h"
 #include "native_run_context.h"
 
+#include <acl/acl.h>
 #include <dlfcn.h>
 #include <cstdlib>
 #include <cstdio>
@@ -42,6 +43,7 @@
 
 #include "common/strace.h"
 #include "common/unified_log.h"
+#include "host/acl_error_log.h"
 #include "host_log.h"
 #include "host/raii_scope_guard.h"
 #include "runtime.h"
@@ -1109,6 +1111,29 @@ size_t committed_device_memory_ctx(DeviceContextHandle ctx) {
         return static_cast<DeviceRunnerBase *>(ctx)->committed_device_memory();
     } catch (...) {
         return 0;
+    }
+}
+
+int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info) {
+    if (ctx == NULL || info == NULL) return PTO_RUNTIME_ERR_INTERNAL;
+    DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
+    try {
+        int rc = runner->attach_current_thread(runner->device_id());
+        if (rc != 0) return rc;
+
+        size_t free_bytes = 0;
+        size_t total_bytes = 0;
+        aclError acl_rc = aclrtGetMemInfo(ACL_HBM_MEM, &free_bytes, &total_bytes);
+        if (acl_rc != ACL_SUCCESS) {
+            LOG_ERROR("aclrtGetMemInfo(ACL_HBM_MEM) failed: %d", static_cast<int>(acl_rc));
+            ACL_LOG_ERROR_DETAIL(acl_rc);
+            return static_cast<int>(acl_rc);
+        }
+        info->free_bytes = static_cast<uint64_t>(free_bytes);
+        info->total_bytes = static_cast<uint64_t>(total_bytes);
+        return 0;
+    } catch (...) {
+        return PTO_RUNTIME_ERR_INTERNAL;
     }
 }
 

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -937,6 +937,11 @@ size_t committed_device_memory_ctx(DeviceContextHandle ctx) {
     }
 }
 
+int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info) {
+    if (ctx == NULL || info == NULL) return PTO_RUNTIME_ERR_INTERNAL;
+    return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
+
 int simpler_provision_dma_workspace(
     DeviceContextHandle ctx, uint32_t required_mask, const void *sdma_warmup_binary, uint64_t sdma_warmup_size
 ) {

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -207,6 +207,7 @@ void ChipWorker::init(
         device_malloc_ctx_fn_ = load_symbol<DeviceMallocCtxFn>(handle, "device_malloc_ctx");
         device_free_ctx_fn_ = load_symbol<DeviceFreeCtxFn>(handle, "device_free_ctx");
         device_committed_memory_fn_ = load_symbol<GetCommittedDeviceMemoryFn>(handle, "committed_device_memory_ctx");
+        device_memory_info_fn_ = load_symbol<GetDeviceMemoryInfoFn>(handle, "device_memory_info_ctx");
         copy_to_device_ctx_fn_ = load_symbol<CopyToDeviceCtxFn>(handle, "copy_to_device_ctx");
         copy_from_device_ctx_fn_ = load_symbol<CopyFromDeviceCtxFn>(handle, "copy_from_device_ctx");
         get_runtime_size_fn_ = load_symbol<GetRuntimeSizeFn>(handle, "get_runtime_size");
@@ -333,6 +334,7 @@ void ChipWorker::init(
         device_malloc_ctx_fn_ = nullptr;
         device_free_ctx_fn_ = nullptr;
         device_committed_memory_fn_ = nullptr;
+        device_memory_info_fn_ = nullptr;
         copy_to_device_ctx_fn_ = nullptr;
         copy_from_device_ctx_fn_ = nullptr;
         get_runtime_size_fn_ = nullptr;
@@ -384,6 +386,7 @@ void ChipWorker::init(
         device_malloc_ctx_fn_ = nullptr;
         device_free_ctx_fn_ = nullptr;
         device_committed_memory_fn_ = nullptr;
+        device_memory_info_fn_ = nullptr;
         copy_to_device_ctx_fn_ = nullptr;
         copy_from_device_ctx_fn_ = nullptr;
         get_runtime_size_fn_ = nullptr;
@@ -508,6 +511,7 @@ void ChipWorker::finalize() {
     device_malloc_ctx_fn_ = nullptr;
     device_free_ctx_fn_ = nullptr;
     device_committed_memory_fn_ = nullptr;
+    device_memory_info_fn_ = nullptr;
     copy_to_device_ctx_fn_ = nullptr;
     copy_from_device_ctx_fn_ = nullptr;
     get_runtime_size_fn_ = nullptr;
@@ -949,6 +953,21 @@ size_t ChipWorker::committed_device_memory() const {
         return 0;
     }
     return device_committed_memory_fn_(device_ctx_);
+}
+
+DeviceMemoryInfo ChipWorker::device_memory_info() const {
+    if (!initialized_) {
+        throw std::runtime_error("ChipWorker not initialized; call init() first");
+    }
+    DeviceMemoryInfo info{};
+    int rc = device_memory_info_fn_(device_ctx_, &info);
+    if (rc == PTO_RUNTIME_ERR_UNSUPPORTED) {
+        throw UnsupportedRuntimeOperation("device_memory_info is not supported by this runtime");
+    }
+    if (rc != 0) {
+        throw std::runtime_error("device_memory_info failed with code " + std::to_string(rc));
+    }
+    return info;
 }
 
 size_t ChipWorker::host_dlopen_count() const {

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -47,6 +47,11 @@ class ChipRun;
 class ChipRunLane;
 struct ChipRunLaneState;
 
+class UnsupportedRuntimeOperation : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
 class ChipWorker {
 public:
     ChipWorker() = default;
@@ -242,6 +247,7 @@ public:
     /// pipeline slot, or 0 while that slot holds none.
     uint64_t retained_temp_addr(uint32_t slot_id) const;
     size_t committed_device_memory() const;
+    DeviceMemoryInfo device_memory_info() const;
 
 private:
     using CreateDeviceContextFn = void *(*)();
@@ -253,6 +259,7 @@ private:
     using GetRuntimeSizeFn = size_t (*)();
     using GetRuntimeAlignmentFn = size_t (*)();
     using GetCommittedDeviceMemoryFn = size_t (*)(void *);
+    using GetDeviceMemoryInfoFn = decltype(&device_memory_info_ctx);
     // From host_runtime.so. Single platform-side init that does (a) thread
     // attach + device-id record, (b) executor binary takeover, (c) onboard
     // CANN dlog sync. Reads the current log level off HostLogger itself.
@@ -314,6 +321,7 @@ private:
     GetRuntimeSizeFn get_runtime_size_fn_ = nullptr;
     GetRuntimeAlignmentFn get_runtime_alignment_fn_ = nullptr;
     GetCommittedDeviceMemoryFn device_committed_memory_fn_ = nullptr;
+    GetDeviceMemoryInfoFn device_memory_info_fn_ = nullptr;
     SimplerInitFn simpler_init_fn_ = nullptr;
     SimplerRegisterCallableFn register_callable_fn_ = nullptr;
     SimplerRunFn run_fn_ = nullptr;

--- a/src/common/worker/device_memory_info.h
+++ b/src/common/worker/device_memory_info.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+typedef struct DeviceMemoryInfo {
+    uint64_t free_bytes;
+    uint64_t total_bytes;
+} DeviceMemoryInfo;
+
+#ifdef __cplusplus
+#include <type_traits>
+
+static_assert(std::is_trivially_copyable_v<DeviceMemoryInfo> && std::is_standard_layout_v<DeviceMemoryInfo>);
+static_assert(sizeof(DeviceMemoryInfo) == 2 * sizeof(uint64_t));
+#endif

--- a/src/common/worker/runtime_c_api.h
+++ b/src/common/worker/runtime_c_api.h
@@ -22,7 +22,7 @@
  *                   simpler_init, finalize_device
  *   - sizing:       get_runtime_size, get_runtime_alignment
  *   - device-mem:   device_malloc_ctx, device_free_ctx,
- *                   committed_device_memory_ctx,
+ *                   committed_device_memory_ctx, device_memory_info_ctx,
  *                   copy_to_device_ctx, copy_from_device_ctx
  *   - prepared run: simpler_register_callable, simpler_prepare_run,
  *                   simpler_launch_run, simpler_poll_run, simpler_wait_run,
@@ -55,6 +55,8 @@
 
 #include <stddef.h>
 #include <stdint.h>
+
+#include "device_memory_info.h"
 
 // simpler_run takes a pointer to the C++ CallConfig POD (task_interface/
 // call_config.h). Forward-declared so this C-linkage header needn't pull the
@@ -248,6 +250,13 @@ void device_free_ctx(DeviceContextHandle ctx, void *dev_ptr);
  * runtime buffers). Excludes HCCL/VMM comm windows. Returns 0 on NULL ctx.
  */
 size_t committed_device_memory_ctx(DeviceContextHandle ctx);
+
+/**
+ * Query the target device's ACL_HBM_MEM free/total byte snapshot. The caller
+ * owns `info`; valid output is published only when the function returns 0.
+ * Unsupported backends return PTO_RUNTIME_ERR_UNSUPPORTED.
+ */
+int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info);
 
 /** Copy host memory to a device pointer within the given device context. */
 int copy_to_device_ctx(DeviceContextHandle ctx, void *dev_ptr, const void *host_ptr, size_t size);

--- a/tests/ut/py/test_worker/test_device_memory_info.py
+++ b/tests/ut/py/test_worker/test_device_memory_info.py
@@ -1,0 +1,127 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ruff: noqa: PLC0415
+
+from __future__ import annotations
+
+import ctypes
+import multiprocessing as mp
+import os
+import traceback
+
+import pytest
+
+_RUNTIMES = ("host_build_graph", "tensormap_and_ringbuffer")
+_SIM_PLATFORMS = ("a2a3sim", "a5sim")
+
+
+def _require_runtime(platform: str, runtime: str) -> None:
+    from simpler_setup.runtime_builder import RuntimeBuilder
+
+    try:
+        RuntimeBuilder(platform=platform).get_binaries(runtime, build=bool(os.environ.get("PTO_UT_BUILD")))
+    except FileNotFoundError as exc:
+        pytest.skip(f"{platform}/{runtime} runtime binaries unavailable: {exc}")
+
+
+def _make_worker(*, level: int, platform: str, runtime: str, device_id: int):
+    from simpler.worker import Worker
+
+    common = {"level": level, "platform": platform, "runtime": runtime}
+    if level == 2:
+        return Worker(device_id=device_id, **common)
+    return Worker(device_ids=[device_id], num_sub_workers=0, **common)
+
+
+def _acl_memory_info() -> tuple[int, int]:
+    lib = ctypes.CDLL("libascendcl.so")
+    get_mem_info = lib.aclrtGetMemInfo
+    get_mem_info.argtypes = [ctypes.c_int, ctypes.POINTER(ctypes.c_size_t), ctypes.POINTER(ctypes.c_size_t)]
+    get_mem_info.restype = ctypes.c_int
+    free_bytes = ctypes.c_size_t()
+    total_bytes = ctypes.c_size_t()
+    acl_hbm_mem = 1
+    rc = get_mem_info(acl_hbm_mem, ctypes.byref(free_bytes), ctypes.byref(total_bytes))
+    assert rc == 0
+    return int(free_bytes.value), int(total_bytes.value)
+
+
+def _onboard_query_entry(level: int, platform: str, runtime: str, device_id: int, result_queue) -> None:
+    """Keep ACL init/reset out of pytest's process so later L3 cases may fork safely."""
+    worker = None
+    result: dict[str, object] = {}
+    try:
+        worker = _make_worker(level=level, platform=platform, runtime=runtime, device_id=device_id)
+        worker.init()
+        info = worker.device_memory_info()
+        result["info"] = (int(info.free_bytes), int(info.total_bytes))
+        result["unpacked"] = tuple(info)
+        if level == 2:
+            result["acl"] = _acl_memory_info()
+    except BaseException:  # noqa: BLE001 -- marshal child failures back to pytest
+        result["error"] = traceback.format_exc()
+    finally:
+        if worker is not None:
+            worker.close()
+    result_queue.put(result)
+
+
+def test_device_memory_info_propagates_worker_lifecycle_errors():
+    worker = _make_worker(level=2, platform="a2a3sim", runtime="host_build_graph", device_id=0)
+    with pytest.raises(RuntimeError, match=r"requires an initialized \(READY\) worker"):
+        worker.device_memory_info()
+
+
+@pytest.mark.parametrize("platform", _SIM_PLATFORMS)
+@pytest.mark.parametrize("runtime", _RUNTIMES)
+@pytest.mark.parametrize("level", (2, 3))
+def test_simulator_reports_device_memory_info_as_unsupported(platform, runtime, level):
+    _require_runtime(platform, runtime)
+    worker = _make_worker(level=level, platform=platform, runtime=runtime, device_id=0)
+    worker.init()
+    try:
+        with pytest.raises(NotImplementedError, match="device_memory_info"):
+            worker.device_memory_info()
+        if level == 2:
+            assert worker._chip_worker is not None
+            with pytest.raises(NotImplementedError, match="device_memory_info"):
+                worker._chip_worker.device_memory_info()
+    finally:
+        worker.close()
+
+
+@pytest.mark.requires_hardware
+@pytest.mark.platforms(["a2a3", "a5"])
+@pytest.mark.device_count(1)
+@pytest.mark.parametrize("runtime", _RUNTIMES)
+@pytest.mark.parametrize("level", (2, 3))
+def test_onboard_device_memory_info_matches_acl(st_platform, st_device_ids, runtime, level):
+    device_id = int(st_device_ids[0])
+    _require_runtime(st_platform, runtime)
+    ctx = mp.get_context("fork")
+    result_queue = ctx.Queue()
+    process = ctx.Process(target=_onboard_query_entry, args=(level, st_platform, runtime, device_id, result_queue))
+    process.start()
+    process.join(timeout=300)
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=10)
+        pytest.fail("device_memory_info child did not finish")
+    assert process.exitcode == 0, f"device_memory_info child exited with {process.exitcode}"
+    result = result_queue.get(timeout=5)
+    assert "error" not in result, result.get("error")
+
+    free_bytes, total_bytes = result["info"]
+    assert isinstance(free_bytes, int)
+    assert isinstance(total_bytes, int)
+    assert 0 <= free_bytes <= total_bytes
+    assert total_bytes > 0
+    assert result["unpacked"] == result["info"]
+    if level == 2:
+        assert result["info"] == result["acl"]

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -5432,6 +5432,19 @@ class TestDirectControlOrdering:
         with pytest.raises(RuntimeError, match="still in flight"):
             orch.committed_device_memory(0)
 
+    def test_device_memory_info_routes_logical_id_and_takes_mailbox_ordering(self):
+        worker = Worker(level=3, num_sub_workers=0)
+        orch, native = self._orch(worker)
+        worker._chip_shms = cast(Any, [object(), object()])
+        expected = SimpleNamespace(free_bytes=1024, total_bytes=2048)
+        native.device_memory_info.return_value = expected
+
+        with orch_mod._callback_run(12, worker):
+            assert worker.device_memory_info(1) is expected
+
+        native.device_memory_info.assert_called_once_with(1)
+        native.await_run_admission.assert_called_once_with(12)
+
     def test_owner_less_control_is_refused_while_a_run_is_in_flight(self):
         worker = Worker(level=3, num_sub_workers=0)
         orch, native = self._orch(worker)


### PR DESCRIPTION
## Summary

- add `Worker.device_memory_info(worker_id=0)` with a structured, unpackable `DeviceMemoryInfo`
- query device-wide HBM through `aclrtGetMemInfo(ACL_HBM_MEM)` in the target chip worker while keeping `committed_device_memory()` separate
- route L2 and local L3 queries through the existing lifecycle and control-ordering paths; report simulator backends as unsupported
- cover both runtimes and execution levels, logical worker routing, lifecycle behavior, and direct ACL comparison on hardware

## Testing

- `pre-commit run`
- targeted Python unit tests: 10 passed
- a2a3 hardware tests: 4 passed
- full a2a3sim and a5sim scene sweeps
- C++ CTest suite; the socket test also passed outside the sandbox

Fixes #1878
