### PR TITLE
Name the failing scene-test case without replacing its exception

### DIFF
--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -1140,6 +1140,33 @@ def _plot_case_scope_stats(case_label: str, output_prefix: Path) -> None:
         sys.path.remove(str(tools_dir))
 
 
+def _name_failing_case(exc: BaseException, cls_name: str, case_name: str) -> None:
+    """Prefix `exc`'s message with the class and case that raised it, in place.
+
+    The exception object, its type, its traceback and its attributes all survive,
+    which two callers depend on:
+
+    - A negative scene test asserts on the exception its own orchestration raised
+      (`TestAllreduceIbingNranksError` expects `ValueError`). Re-raising a wrapper
+      of a fixed type makes such a test unable to pass however it is written.
+    - `conftest._requires_l2_worker_retirement` gates on
+      `issubclass(excinfo.type, RuntimeError)` before matching device-poison codes
+      in the message. Every code and marker it looks for comes out of the native
+      layer as a `RuntimeError`, so preserving the type keeps it classifiable.
+
+    `str(exc)` keeps the original text after the prefix, so both that classifier
+    and `pytest.raises(match=...)` still match on it.
+
+    Only `args[0]` is rewritten. An exception that renders itself from dedicated
+    attributes rather than from `args` (`OSError` and its errno/strerror) simply
+    does not gain the prefix; it is never left inconsistent. Python 3.11's
+    `BaseException.add_note` would express this directly, but `requires-python` is
+    `>=3.9`.
+    """
+    context = f"SceneTest case failed: {cls_name}::{case_name}"
+    exc.args = (f"{context}: {exc}", *exc.args[1:]) if exc.args else (context,)
+
+
 def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI surface
     worker,
     cls_inst,
@@ -1196,7 +1223,8 @@ def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI
                 output_prefix=str(prefix) if diagnostics_on else "",
             )
         except Exception as exc:
-            raise RuntimeError(f"SceneTest case failed: {cls_name}::{case['name']}: {exc}") from exc
+            _name_failing_case(exc, cls_name, case["name"])
+            raise
         finally:
             if enable_chip_swimlane:
                 _convert_case_swimlane(

--- a/tests/ut/py/test_scene_test_cli_contract.py
+++ b/tests/ut/py/test_scene_test_cli_contract.py
@@ -106,8 +106,10 @@ def test_run_class_cases_reports_the_failing_case_name() -> None:
 
     case = {"name": "large_bf16", "params": {"batch": 64, "dtype": "bfloat16"}}
 
+    # The scene's own exception type reaches the caller: a negative scene test
+    # asserts on it, so a fixed-type wrapper would make such a test unable to pass.
     with pytest.raises(
-        RuntimeError,
+        ValueError,
         match=r"SceneTest case failed: FailingScene::large_bf16: device run failed$",
     ) as failure:
         run_class_cases(
@@ -125,8 +127,36 @@ def test_run_class_cases_reports_the_failing_case_name() -> None:
             enable_scope_stats=False,
         )
 
-    assert isinstance(failure.value.__cause__, ValueError)
-    assert str(failure.value.__cause__) == "device run failed"
+    # Annotated in place, so there is no wrapper to unwrap and the traceback still
+    # points at the scene that raised.
+    assert failure.value.__cause__ is None
+    assert failure.value.args[0] == "SceneTest case failed: FailingScene::large_bf16: device run failed"
+
+
+def test_run_class_cases_names_the_case_without_args() -> None:
+    """An exception carrying no message still gets the case name, not `'…: '`."""
+
+    class FailingScene:
+        def _run_and_validate(self, *_args, **_kwargs):
+            raise ValueError
+
+    with pytest.raises(ValueError) as failure:
+        run_class_cases(
+            object(),
+            FailingScene(),
+            [{"name": "empty_args"}],
+            callable_obj=object(),
+            sub_handles={},
+            rounds=1,
+            skip_golden=False,
+            enable_chip_swimlane=0,
+            enable_dump_args=0,
+            enable_pmu=0,
+            enable_dep_gen=False,
+            enable_scope_stats=False,
+        )
+
+    assert str(failure.value) == "SceneTest case failed: FailingScene::empty_args"
 
 
 def test_run_class_cases_keeps_device_error_visible_to_poison_classifier() -> None:


### PR DESCRIPTION
## Summary

`run_class_cases` reported which case failed by wrapping every case exception in a fresh `RuntimeError`. That makes a **negative** scene test — one whose subject *is* the exception its own orchestration raises — unable to pass:

```python
# tests/st/worker/collectives/allreduce/test_allreduce.py:326
with pytest.raises(ValueError, match="ibing mode is only supported for nranks=2"):
    super().test_run(st_platform, st_worker, request)
```

`TestAllreduceIbingNranksError` asserts exactly that. The `ValueError` **does** fire — in `allreduce_orch_fn`, `ibing` is 2-rank only and the case passes 4 — but it reaches the test as a `RuntimeError` carrying it as `__cause__`, and `pytest.raises` matches the raised type, not the cause.

The wrapper arrived in #1927 ("report failing SceneTest case context") and didn't update this test. The case is `manual: True`, and per-PR CI runs the sim/NPU workflows with their default `manual_mode: exclude` — only the **daily** full sweep reaches it. It has been red there since, invisibly.

## What changed

The case name is now added to the exception **already in flight** and the original re-raised:

```python
except Exception as exc:
    _name_failing_case(exc, cls_name, case["name"])   # rewrites args[0]
    raise
```

Type, identity, traceback and attributes all survive, and `str()` still ends with the original text. Two things depend on that:

- a negative test can assert on the type its orchestration raised — the only way to state what such a test is actually checking;
- `conftest._requires_l2_worker_retirement` gates on `issubclass(excinfo.type, RuntimeError)` before matching device-poison codes. Every code in `_DEVICE_POISON_CODES` and every string in `_L2_WORKER_RETIREMENT_MARKERS` names a native-layer failure (`{prepare,launch,poll,finalize}_native_run`, `simpler_init`, device quarantine), all of which surface as `RuntimeError` — so keeping the type keeps them classifiable. The wrapper had been *widening* non-`RuntimeError` failures into that gate, never narrowing it.

`BaseException.add_note` would say this directly, but `requires-python` is `>=3.9`. Only `args[0]` is rewritten; an exception that renders itself from dedicated attributes instead of `args` (`OSError`'s errno/strerror) simply doesn't gain the prefix, and is never left inconsistent.

## Blast radius

`tests/st/worker/collectives/allreduce/test_allreduce.py:326` is the **only** place that wraps `super().test_run(...)` in `pytest.raises` — checked across `tests/st` and `examples`; every other override calls it plainly and lets exceptions fail the test. So no other scene test changes behaviour.

## Testing

Per `discipline.md` §3, `TestAllreduceIbingNranksError` needs no change and *is* the regression test:

```
# on the parent commit f830f13c3
E   RuntimeError: SceneTest case failed: TestAllreduceIbingNranksError::ibing_nranks_4: ibing mode is only supported for nranks=2, got nranks=4
1 failed
# here
1 passed
```

The unit contract test moves to the new shape (same type out, case name in the message, no wrapper to unwrap) and gains a case for an exception raised with **no arguments**, so the annotation can't degrade to a bare `"…::case: "`.

- [x] `pytest tests/ut/py` — 1937 passed, 14 skipped
- [x] `tests/st/worker/collectives` in **daily** mode (`--manual include`) — green, 0 failures
- [x] Per-PR sim gate (`--manual exclude`) — green on `a2a3sim` and `a5sim`

No C++ changed, so no rebuild or onboard run is implicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
