### PR TITLE
Retire the PTO brand names, and hold the line with a hook

### DIFF
--- a/.claude/rules/codestyle.md
+++ b/.claude/rules/codestyle.md
@@ -127,28 +127,39 @@
     "PTO Runtime2", and a bare "Runtime2" are not names of anything** — the
     `2` never denoted a version any reader can identify.
 
-    **The retirement is complete** (snapshot 2026-08-24: 6.6k occurrences across
-    367 files on 2026-07-26 → 0 that this repo reads). Nothing here reads a
-    `PTO2` name any more: the last of them were the `PTO2_RING_*` ring-sizing
-    environment variables, retired in favour of per-task
-    `CallConfig.runtime_env`. What is left in the tree is this rule's own
-    examples, the warning that fires if a caller still exports a retired ring
-    variable, prose recording that these names are gone, and
-    `PTO2_MANUAL_MAX_SEQ` — a pypto-lib knob two example READMEs document and
-    this repo never reads. **So a new `PTO2` match is a defect** — there is no
-    backlog to work through. Find the surface with:
+    **No `PTO2` identifier is left.** The last of them were the `PTO2_RING_*`
+    ring-sizing environment variables, retired in favour of per-task
+    `CallConfig.runtime_env`; `git grep -Io -E "PTO2|pto2_"` now finds only this
+    rule's own examples, the warning that fires if a caller still exports a
+    retired ring variable, prose recording that these names are gone, and
+    `PTO2_MANUAL_MAX_SEQ` — a pypto-lib knob two example READMEs document and this
+    repo never reads. **So a new `PTO2` match is a defect.**
+
+    **The brand spellings are held by a hook, not by a count.**
+    `tests/lint/check_retired_names.py` fails pre-commit on any new
+    `PTO Runtime`, `PTO Runtime2`, or bare `Runtime2`. That hook exists because
+    this paragraph once asserted the whole surface was empty while the rule's own
+    grep found 38 banners across 36 files: the assertion had been measured with
+    `PTO2|pto2_`, which cannot see a brand name with a space in it. Do not put a
+    number here again — put it in the hook.
+
+    Find the surface with the rule's own pattern, which is wider than the hook's
+    on purpose (it also reaches the tiers below):
 
     ```bash
     grep -rIn -E "PTO Runtime2?|PTO2|pto2_|pto_runtime2" --include=* . | grep -v '^\./\.git/'
     ```
 
-    Each match falls in exactly one tier, and the tier decides what you owe:
+    Each match falls in exactly one tier, and the tier decides what you owe. Note
+    that **the first two tiers share the `pto_*` namespace and have opposite
+    risk** — that is the trap this table exists to spell out:
 
     | Tier | What | Policy |
     | ---- | ---- | ------ |
-    | **A — prose** | Brand mentions in docs, headings, skill descriptions, issue templates, and code comments (`# PTO Runtime2 Profiling Levels`, "the PTO Runtime consists of…") | **Fix on sight, unconditionally.** No compile risk, no contract. Say `simpler`, or name the actual component ("the AICPU orchestrator", "the `tensormap_and_ringbuffer` runtime") when that is what the sentence means. |
+    | **A1 — brand prose** | The brand itself in docs, headings, skill descriptions, issue templates, and code comments (`# PTO Runtime2 Profiling Levels`, "the PTO Runtime consists of…") | **Fix on sight, unconditionally**, and the hook will make you. No compile risk, no contract, and no Tier-C name can hide in a file banner. Say `simpler`, or name the actual component ("the AICPU orchestrator", "the `tensormap_and_ringbuffer` runtime"). Follow the banner style already in the tree: `orchestrator_core/orchestrator.cpp` opens `* host_build_graph orchestrator implementation`. |
+    | **A2 — comments naming a `pto_*` that does not exist** | e.g. `pto_submit_task` (the entry is `rt_submit_task`), `pto_runtime2_init` (the work is `SchedulerState::init_data_from_layout`) | **Fix on sight**, but this is a [`doc-consistency.md`](doc-consistency.md) §3 defect, not a naming preference: a reader who greps the name finds nothing. Confirm the symbol is absent before renaming it — `git grep -w <name>` returning only comments is the test. |
     | **B — internal identifiers** | `PTO2Foo` types, `pto2_*` functions, internal `PTO2_*` macros and enumerators, `pto_*.h` / `pto_runtime2*.cpp` file names | Rename **only when you are already modifying that code**, per rule 9, and finish the identifier you started (below). |
-    | **C — external contracts** | `runtime_env` knobs, `extern "C"` symbols in `runtime_c_api.h`, on-wire / serialized names | **Exempt until a migration ships.** Renaming these breaks callers in other repos. Ask the user before touching one; land it only with a compatibility alias or a coordinated cross-repo change. |
+    | **C — external contracts** | `runtime_env` knobs, `extern "C"` symbols in `runtime_c_api.h`, on-wire / serialized names, and **every live `pto_cpu_sim_*` / `pto_sim_*` hook** | **Exempt until a migration ships.** Renaming these breaks callers in other repos. The sim hooks are the worst case and the reason A2 above demands a grep first: `cpu_sim_context.cpp` exports them for "pto-isa via `dlsym(RTLD_DEFAULT)`" and `device_runner_base.cpp` fetches `pto_sim_register_hooks` by `dlsym`, so a rename produces **no compile error** — just a hook that is never found at run time. Ask the user before touching one; land it only with a compatibility alias or a coordinated cross-repo change. |
 
     An environment variable is the worst case in Tier C and the reason it
     exists: an unrecognised name is *ignored*, so the rename fails silently
@@ -172,9 +183,11 @@
       tensormap_and_ringbuffer}/` trees are near-duplicates, so a Tier-B
       rename in one of them must land in its siblings in the same commit.
       Verify with the grep above returning zero hits for that identifier.
-    - **The count only goes down.** Introducing a new `PTO2`/`PTO Runtime`
-      spelling anywhere — including by copying an existing `pto_*.h` to a
-      new arch — is a defect, not neutral. Rule 9 makes this unconditional.
+    - **The count only goes down**, and for the brand spellings
+      `tests/lint/check_retired_names.py` enforces it. Introducing a new
+      `PTO2`/`PTO Runtime` spelling anywhere — including by copying an existing
+      `pto_*.h` to a new arch — is a defect, not neutral. Rule 9 makes this
+      unconditional.
     - **Check the target name against three things, not one.** The bare name
       may be taken by the host orchestrator under `src/common/hierarchical/`
       (`TensorMap`, `ReadyQueue`, `TaskState`, `HeapRing`, `MAX_SCOPE_DEPTH`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,13 @@ repos:
           language_version: python3
           files: ^(examples|tests/st)/(.*/)?test_[^/]*\.py$
 
+        - id: check-retired-names
+          name: check-retired-names
+          entry: python tests/lint/check_retired_names.py
+          language: python
+          language_version: python3
+          exclude: ^3rdparty/|vendor/
+
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.6.0
       hooks:

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_ringbuffer/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_ringbuffer/README.md
@@ -29,9 +29,9 @@ referenced, the golden check fails or the orchestrator wedges.
 
 Two things this example is the reference for:
 
-- **Per-case ring sizing through `config.runtime_env`**, not the process-global
-  now-retired `PTO2_RING_*` environment variables. The rings are sized per task, so one
-  suite can mix a stress case with normally-sized ones.
+- **Per-case ring sizing through `config.runtime_env`.** The rings are sized per
+  task rather than per process, so one suite can mix a stress case with
+  normally-sized ones.
 - **Non-power-of-2 sizes are accepted.** 4 MiB is chosen to keep the stress
   intent compact, not because the runtime requires a round number.
 

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_ringbuffer/test_paged_attention_ringbuffer.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_ringbuffer/test_paged_attention_ringbuffer.py
@@ -10,7 +10,7 @@
 """Paged attention with small ring buffer sizes — stress test for ring rotation/reclamation.
 
 Drives per-case ring sizing through ``config.runtime_env`` (ring_task_window /
-ring_heap / ring_dep_pool) rather than the process-global PTO2_RING_* env it replaced, plus
+ring_heap / ring_dep_pool), which is per task rather than per process, plus
 INOUT tensors, bfloat16, and AIC+AIV mixed execution.
 """
 

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_ringbuffer/README.md
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_ringbuffer/README.md
@@ -29,9 +29,9 @@ referenced, the golden check fails or the orchestrator wedges.
 
 Two things this example is the reference for:
 
-- **Per-case ring sizing through `config.runtime_env`**, not the process-global
-  now-retired `PTO2_RING_*` environment variables. The rings are sized per task, so one
-  suite can mix a stress case with normally-sized ones.
+- **Per-case ring sizing through `config.runtime_env`.** The rings are sized per
+  task rather than per process, so one suite can mix a stress case with
+  normally-sized ones.
 - **Non-power-of-2 sizes are accepted.** 4 MiB is chosen to keep the stress
   intent compact, not because the runtime requires a round number.
 

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_ringbuffer/test_paged_attention_ringbuffer.py
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_ringbuffer/test_paged_attention_ringbuffer.py
@@ -10,7 +10,7 @@
 """Paged attention with small ring buffer sizes — stress test for ring rotation/reclamation.
 
 Drives per-case ring sizing through ``config.runtime_env`` (ring_task_window /
-ring_heap / ring_dep_pool) rather than the process-global PTO2_RING_* env it replaced, plus
+ring_heap / ring_dep_pool), which is per task rather than per process, plus
 INOUT tensors, bfloat16, and AIC+AIV mixed execution.
 """
 

--- a/examples/workers/l3/per_task_runtime_env/README.md
+++ b/examples/workers/l3/per_task_runtime_env/README.md
@@ -7,9 +7,9 @@ each need a different ring footprint.
 
 ## What it shows
 
-Before this knob, every L2 dispatched from one L3 shared the process-wide
-process-wide `PTO2_RING_*` env, since retired, and could not be sized independently. Now each
-`submit_next_level` gets its own `CallConfig`:
+Before this knob, every L2 dispatched from one L3 shared one process-wide ring
+sizing and could not be sized independently. Now each `submit_next_level` gets
+its own `CallConfig`:
 
 Each spec sets `ring_task_window` / `ring_heap` / `ring_dep_pool` to a scalar
 (broadcast to every ring) or a 4-entry list (per-ring). `_l2_config` preserves

--- a/examples/workers/l3/per_task_runtime_env/main.py
+++ b/examples/workers/l3/per_task_runtime_env/main.py
@@ -14,7 +14,7 @@ This is the headline use case for ``CallConfig.runtime_env``: an L3 fans out
 several heterogeneous L2 tasks in one launch, and each L2 needs a different
 ring footprint (a heavy task wants a big heap / wide window; a light one is
 fine with the default). Before this knob, all L2 tasks in one L3 launch shared
-the process-wide ``PTO2_RING_*`` env, since retired, and could not be sized independently.
+one process-wide ring sizing and could not be sized independently.
 
 The demo dispatches three L2 tasks: two use the scalar form (one ring value
 broadcast to every ring), and a third passes 4-entry lists for

--- a/src/a2a3/platform/onboard/host/runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/runtime_c_api.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime C API — a2a3 arch-specific entries
+ * simpler host-runtime C API — a2a3 arch-specific entries
  *
  * The shared c_api glue (simpler_init / simpler_register_callable / simpler_run /
  * device_*_ctx / etc.) lives in

--- a/src/a2a3/platform/sim/host/runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/runtime_c_api.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime C API — a2a3 sim arch-specific entries.
+ * simpler host-runtime C API — a2a3 sim arch-specific entries.
  *
  * The shared c_api glue (simpler_init / simpler_register_callable / simpler_run /
  * device_*_ctx / etc.) lives in `src/common/platform/sim/host/c_api_shared.cpp`

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime_types.h
@@ -10,9 +10,9 @@
  */
 
 /**
- * PTO Runtime2 - Core Type Definitions
+ * host_build_graph core type definitions
  *
- * This header defines all fundamental types used by the PTO Runtime2 system:
+ * This header defines all fundamental types used by the host_build_graph runtime:
  * - Configuration constants
  * - Worker types and task states
  * - simpler::hbg::Tensor regions and task parameters

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Scheduler Implementation
+ * host_build_graph scheduler implementation
  *
  * Implements scheduler state management, ready queues, and task lifecycle.
  *

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -10,7 +10,7 @@
  */
 
 /**
- * PTO Runtime2 - Scheduler Interface
+ * host_build_graph scheduler interface
  *
  * The Scheduler is responsible for:
  * 1. Maintaining per-resource-shape ready queues

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/shared_memory.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/shared_memory.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Shared Memory Implementation
+ * host_build_graph shared-memory implementation
  *
  * Implements shared memory allocation, initialization, and management
  * for Orchestrator-Scheduler communication.

--- a/src/a2a3/runtime/host_build_graph/runtime/shared/tensormap.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/shared/tensormap.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - TensorMap Implementation
+ * host_build_graph TensorMap implementation
  *
  * Implements TensorMap with a fixed-capacity entry pool. Task completion does
  * not invalidate entries; dependency computation explicitly removes only

--- a/src/a2a3/runtime/host_build_graph/runtime/tensormap.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/tensormap.h
@@ -10,11 +10,11 @@
  */
 
 /**
- * PTO Runtime2 - TensorMap Interface
+ * host_build_graph TensorMap interface
  *
  * TensorMap provides producer lookup for dependency discovery:
  * - Maps simpler::hbg::Tensor -> producer task ID
- * - Used by pto_submit_task() to find dependencies
+ * - Used by rt_submit_task() to find dependencies
  *
  * host_build_graph runs its orchestrator on the host, so this map is host-only
  * state: it owns its four arrays outright rather than addressing them as offsets

--- a/src/a2a3/runtime/host_build_graph/runtime/types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/types.h
@@ -13,7 +13,7 @@
  *
  * Standalone header defining orchestration-specific types for:
  * - TaskOutputTensors: Return value from submit containing materialized output ChipTensors
- * - Arg: Aggregated argument container for pto_submit_task API
+ * - Arg: Aggregated argument container for rt_submit_task API
  *
  * simpler::hbg::Tensor descriptor types (simpler::hbg::Tensor, PTOBufferHandle, TensorCreateInfo) are
  * defined in tensor.h.
@@ -137,7 +137,7 @@ private:
 using TaskSubmitResult = TaskOutputTensors;
 
 // =============================================================================
-// Argument Types (for pto_submit_task API)
+// Argument Types (for rt_submit_task API)
 // =============================================================================
 
 // TensorArgType is defined in tensor.h (included via task_args.h above)
@@ -182,7 +182,7 @@ public:
 };
 
 /**
- * Aggregated argument container for pto_submit_task
+ * Aggregated argument container for rt_submit_task
  *
  * Inherits storage from TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType>.
  * Each tensor slot stores a TensorRef union (simpler::hbg::Tensor* or TensorCreateInfo)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
@@ -10,7 +10,7 @@
  */
 
 /**
- * PTO Runtime2 - Orchestrator Implementation
+ * tensormap_and_ringbuffer orchestrator implementation
  *
  * Implements orchestrator state management, scope handling, and task submission.
  *

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orchestrator.h
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Orchestrator Interface
+ * tensormap_and_ringbuffer orchestrator interface
  *
  * The Orchestrator is responsible for:
  * 1. Executing the orchestration function (Turing-complete control flow)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Ring Buffer Implementation
+ * tensormap_and_ringbuffer ring buffer implementation
  *
  * Implements DepListPool ring buffer for zero-overhead dependency management.
  * TaskAllocator methods are defined inline in ring_buffer.h.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.h
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Ring Buffer Data Structures
+ * tensormap_and_ringbuffer ring buffer data structures
  *
  * Implements ring buffer designs for zero-overhead memory management:
  *

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Scheduler Implementation
+ * tensormap_and_ringbuffer scheduler implementation
  *
  * Implements scheduler state management, ready queues, and task lifecycle.
  *

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
@@ -10,7 +10,7 @@
  */
 
 /**
- * PTO Runtime2 - Scheduler Interface
+ * tensormap_and_ringbuffer scheduler interface
  *
  * The Scheduler is responsible for:
  * 1. Maintaining per-resource-shape ready queues

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/shared_memory.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/shared_memory.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Shared Memory Implementation
+ * tensormap_and_ringbuffer shared-memory implementation
  *
  * Implements shared memory allocation, initialization, and management
  * for Orchestrator-Scheduler communication.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/tensormap.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/tensormap.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - TensorMap Implementation
+ * tensormap_and_ringbuffer TensorMap implementation
  *
  * Implements TensorMap with ring buffer pool, lazy invalidation,
  * and chain truncation optimization.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared_memory.h
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Shared Memory Layout
+ * tensormap_and_ringbuffer shared-memory layout
  *
  * Defines the shared memory structure for Orchestrator-Scheduler communication.
  *

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensormap.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensormap.h
@@ -10,11 +10,11 @@
  */
 
 /**
- * PTO Runtime2 - TensorMap Interface
+ * tensormap_and_ringbuffer TensorMap interface
  *
  * TensorMap provides producer lookup for dependency discovery:
  * - Maps simpler::tmr::Tensor -> producer task ID
- * - Used by pto_submit_task() to find dependencies
+ * - Used by rt_submit_task() to find dependencies
  *
  * Key design features:
  * 1. Ring buffer pool for entries (no malloc/free)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/types.h
@@ -13,7 +13,7 @@
  *
  * Standalone header defining orchestration-specific types for:
  * - TaskOutputTensors: Return value from submit containing materialized output ChipTensors
- * - Arg: Aggregated argument container for pto_submit_task API
+ * - Arg: Aggregated argument container for rt_submit_task API
  *
  * simpler::tmr::Tensor descriptor types (simpler::tmr::Tensor, PTOBufferHandle, TensorCreateInfo) are
  * defined in tensor.h.
@@ -170,7 +170,7 @@ private:
 };
 
 // =============================================================================
-// Argument Types (for pto_submit_task API)
+// Argument Types (for rt_submit_task API)
 // =============================================================================
 
 // TensorArgType is defined in tensor.h (included via task_args.h above)
@@ -215,7 +215,7 @@ public:
 };
 
 /**
- * Aggregated argument container for pto_submit_task
+ * Aggregated argument container for rt_submit_task
  *
  * Inherits storage from TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType>.
  * Each tensor slot stores a TensorRef union (simpler::tmr::Tensor* or TensorCreateInfo)

--- a/src/a5/platform/onboard/host/runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/runtime_c_api.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime C API — a5 arch-specific entries
+ * simpler host-runtime C API — a5 arch-specific entries
  *
  * The shared c_api glue (simpler_init / simpler_register_callable / simpler_run /
  * device_*_ctx / etc.) lives in

--- a/src/a5/platform/sim/host/runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/runtime_c_api.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime C API — a5 sim arch-specific entries.
+ * simpler host-runtime C API — a5 sim arch-specific entries.
  *
  * The shared c_api glue (simpler_init / simpler_register_callable / simpler_run /
  * device_*_ctx / etc.) lives in `src/common/platform/sim/host/c_api_shared.cpp`

--- a/src/a5/runtime/host_build_graph/runtime/runtime_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime_types.h
@@ -10,9 +10,9 @@
  */
 
 /**
- * PTO Runtime2 - Core Type Definitions
+ * host_build_graph core type definitions
  *
- * This header defines all fundamental types used by the PTO Runtime2 system:
+ * This header defines all fundamental types used by the host_build_graph runtime:
  * - Configuration constants
  * - Worker types and task states
  * - simpler::hbg::Tensor regions and task parameters

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Scheduler Implementation
+ * host_build_graph scheduler implementation
  *
  * Implements scheduler state management, ready queues, and task lifecycle.
  *

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -10,7 +10,7 @@
  */
 
 /**
- * PTO Runtime2 - Scheduler Interface
+ * host_build_graph scheduler interface
  *
  * The Scheduler is responsible for:
  * 1. Maintaining per-resource-shape ready queues

--- a/src/a5/runtime/host_build_graph/runtime/shared/shared_memory.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/shared_memory.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Shared Memory Implementation
+ * host_build_graph shared-memory implementation
  *
  * Implements shared memory allocation, initialization, and management
  * for Orchestrator-Scheduler communication.

--- a/src/a5/runtime/host_build_graph/runtime/shared/tensormap.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/shared/tensormap.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - TensorMap Implementation
+ * host_build_graph TensorMap implementation
  *
  * Implements TensorMap with a fixed-capacity entry pool. Task completion does
  * not invalidate entries; dependency computation explicitly removes only

--- a/src/a5/runtime/host_build_graph/runtime/tensormap.h
+++ b/src/a5/runtime/host_build_graph/runtime/tensormap.h
@@ -10,11 +10,11 @@
  */
 
 /**
- * PTO Runtime2 - TensorMap Interface
+ * host_build_graph TensorMap interface
  *
  * TensorMap provides producer lookup for dependency discovery:
  * - Maps simpler::hbg::Tensor -> producer task ID
- * - Used by pto_submit_task() to find dependencies
+ * - Used by rt_submit_task() to find dependencies
  *
  * host_build_graph runs its orchestrator on the host, so this map is host-only
  * state: it owns its four arrays outright rather than addressing them as offsets

--- a/src/a5/runtime/host_build_graph/runtime/types.h
+++ b/src/a5/runtime/host_build_graph/runtime/types.h
@@ -13,7 +13,7 @@
  *
  * Standalone header defining orchestration-specific types for:
  * - TaskOutputTensors: Return value from submit containing materialized output ChipTensors
- * - Arg: Aggregated argument container for pto_submit_task API
+ * - Arg: Aggregated argument container for rt_submit_task API
  *
  * simpler::hbg::Tensor descriptor types (simpler::hbg::Tensor, PTOBufferHandle, TensorCreateInfo) are
  * defined in tensor.h.
@@ -137,7 +137,7 @@ private:
 using TaskSubmitResult = TaskOutputTensors;
 
 // =============================================================================
-// Argument Types (for pto_submit_task API)
+// Argument Types (for rt_submit_task API)
 // =============================================================================
 
 // TensorArgType is defined in tensor.h (included via task_args.h above)
@@ -182,7 +182,7 @@ public:
 };
 
 /**
- * Aggregated argument container for pto_submit_task
+ * Aggregated argument container for rt_submit_task
  *
  * Inherits storage from TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType>.
  * Each tensor slot stores a TensorRef union (simpler::hbg::Tensor* or TensorCreateInfo)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
@@ -10,7 +10,7 @@
  */
 
 /**
- * PTO Runtime2 - Orchestrator Implementation
+ * tensormap_and_ringbuffer orchestrator implementation
  *
  * Implements orchestrator state management, scope handling, and task submission.
  *

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.h
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Orchestrator Interface
+ * tensormap_and_ringbuffer orchestrator interface
  *
  * The Orchestrator is responsible for:
  * 1. Executing the orchestration function (Turing-complete control flow)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Ring Buffer Implementation
+ * tensormap_and_ringbuffer ring buffer implementation
  *
  * Implements DepListPool ring buffer for zero-overhead dependency management.
  * TaskAllocator methods are defined inline in ring_buffer.h.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/ring_buffer.h
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Ring Buffer Data Structures
+ * tensormap_and_ringbuffer ring buffer data structures
  *
  * Implements ring buffer designs for zero-overhead memory management:
  *

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Scheduler Implementation
+ * tensormap_and_ringbuffer scheduler implementation
  *
  * Implements scheduler state management, ready queues, and task lifecycle.
  *

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
@@ -10,7 +10,7 @@
  */
 
 /**
- * PTO Runtime2 - Scheduler Interface
+ * tensormap_and_ringbuffer scheduler interface
  *
  * The Scheduler is responsible for:
  * 1. Maintaining per-resource-shape ready queues

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/shared_memory.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/shared_memory.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Shared Memory Implementation
+ * tensormap_and_ringbuffer shared-memory implementation
  *
  * Implements shared memory allocation, initialization, and management
  * for Orchestrator-Scheduler communication.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/tensormap.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/tensormap.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - TensorMap Implementation
+ * tensormap_and_ringbuffer TensorMap implementation
  *
  * Implements TensorMap with ring buffer pool, lazy invalidation,
  * and chain truncation optimization.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared_memory.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared_memory.h
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * PTO Runtime2 - Shared Memory Layout
+ * tensormap_and_ringbuffer shared-memory layout
  *
  * Defines the shared memory structure for Orchestrator-Scheduler communication.
  *

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensormap.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensormap.h
@@ -10,11 +10,11 @@
  */
 
 /**
- * PTO Runtime2 - TensorMap Interface
+ * tensormap_and_ringbuffer TensorMap interface
  *
  * TensorMap provides producer lookup for dependency discovery:
  * - Maps simpler::tmr::Tensor -> producer task ID
- * - Used by pto_submit_task() to find dependencies
+ * - Used by rt_submit_task() to find dependencies
  *
  * Key design features:
  * 1. Ring buffer pool for entries (no malloc/free)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/types.h
@@ -13,7 +13,7 @@
  *
  * Standalone header defining orchestration-specific types for:
  * - TaskOutputTensors: Return value from submit containing materialized output ChipTensors
- * - Arg: Aggregated argument container for pto_submit_task API
+ * - Arg: Aggregated argument container for rt_submit_task API
  *
  * simpler::tmr::Tensor descriptor types (simpler::tmr::Tensor, PTOBufferHandle, TensorCreateInfo) are
  * defined in tensor.h.
@@ -171,7 +171,7 @@ private:
 };
 
 // =============================================================================
-// Argument Types (for pto_submit_task API)
+// Argument Types (for rt_submit_task API)
 // =============================================================================
 
 // TensorArgType is defined in tensor.h (included via task_args.h above)
@@ -216,7 +216,7 @@ public:
 };
 
 /**
- * Aggregated argument container for pto_submit_task
+ * Aggregated argument container for rt_submit_task
  *
  * Inherits storage from TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType>.
  * Each tensor slot stores a TensorRef union (simpler::tmr::Tensor* or TensorCreateInfo)

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -9,7 +9,7 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * Shared `pto_runtime_c_api` glue — the byte-identical part of every arch's
+ * Shared `runtime_c_api` glue — the byte-identical part of every arch's
  * onboard `runtime_c_api.cpp`. Linked into each arch's
  * `libhost_runtime.so` directly (not as a separate library) so all C ABI
  * symbols are exported from each `.so` for ChipWorker's `dlsym`.

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -511,7 +511,7 @@ public:
 
     // ---- Virtual entry points called by the shared c_api ----------------
     //
-    // The shared `pto_runtime_c_api` glue (`src/common/platform/onboard/host/
+    // The shared `runtime_c_api` glue (`src/common/platform/onboard/host/
     // c_api_shared.cpp`) works through `DeviceRunnerBase *` and dispatches
     // through these virtuals. Each arch's `DeviceRunner` overrides the
     // enqueue/poll/drain lifecycle and `finalize`; a2a3 and a5 both override

--- a/tests/lint/check_retired_names.py
+++ b/tests/lint/check_retired_names.py
@@ -1,0 +1,83 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+Script to check that the retired brand names do not come back.
+
+`.claude/rules/codestyle.md` rule 10 says "PTO Runtime", "PTO Runtime2" and a bare
+"Runtime2" are not names of anything, and that the count only goes down. That was a
+promise with nothing keeping it: the rule's prose claimed the surface was empty
+while its own grep found 38 banners across 36 files, because the number in the
+prose had been measured with a narrower pattern (`PTO2|pto2_`) than the rule
+prescribes. A count in prose cannot stay true; a hook can.
+
+Scope, and why it is this narrow:
+
+- Only the **brand** spellings are checked. `PTO2_*` still appears legitimately in
+  prose that records the retirement of a specific name ("the now-retired
+  `PTO2_RING_*` variables"), and in `PTO2_MANUAL_MAX_SEQ`, a pypto-lib knob this
+  repository never reads. Banning those would fail the sentences that explain them.
+- The lowercase `pto_*` identifier namespace is **not** checked, and must not be.
+  `pto_cpu_sim_bind_device`, `pto_sim_get_subblock_id`,
+  `pto_sim_get_pipe_shared_state` and `pto_sim_register_hooks` are live symbols at
+  the pto-isa boundary, resolved by `dlsym(RTLD_DEFAULT)`. Renaming one produces no
+  compile error — just a hook that is never found at run time.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# "PTO Runtime", "PTO Runtime2", "Runtime2" as a standalone word.
+RETIRED_BRAND = re.compile(r"PTO[ _-]Runtime2?\b|\bRuntime2\b")
+
+# The rule has to spell the names it bans, and this hook has to quote them to
+# explain itself. Paths are repo-relative and matched exactly.
+EXEMPT = frozenset(
+    {
+        ".claude/rules/codestyle.md",
+        "tests/lint/check_retired_names.py",
+    }
+)
+
+
+def offending_lines(path: Path) -> list[tuple[int, str]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    return [(lineno, line.strip()) for lineno, line in enumerate(text.splitlines(), 1) if RETIRED_BRAND.search(line)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("files", nargs="*", help="files to check (pre-commit passes the staged set)")
+    args = parser.parse_args()
+
+    failures = []
+    for name in args.files:
+        if name in EXEMPT:
+            continue
+        for lineno, line in offending_lines(Path(name)):
+            failures.append(f"{name}:{lineno}: {line}")
+
+    if not failures:
+        return 0
+
+    print("Retired brand name reintroduced. The project is `simpler`; its runtimes are")
+    print("`host_build_graph` and `tensormap_and_ringbuffer`. Name the runtime, or the")
+    print("component the sentence actually means — see .claude/rules/codestyle.md rule 10.")
+    print()
+    for failure in failures:
+        print(f"  {failure}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`.claude/rules/codestyle.md` rule 10 said the retirement was complete and that "there is no backlog to work through". Two of its three claims held. The third was false — the rule's **own** grep, `PTO Runtime2?|PTO2|pto2_|pto_runtime2`, found **38 brand banners across 36 files** in `src/`.

The claim had been measured with `PTO2|pto2_`, which cannot see a brand name with a space in it. #1980's title was "finish the PTO2 retirement" and it finished exactly that, verifiably — 62 remaining under its own pattern, reproducible today. The sentence it added generalised from "PTO2 identifiers" to "the retirement".

## What changed

### The 38 banners

Following the style already in the tree — `orchestrator_core/orchestrator.cpp` opens `* host_build_graph orchestrator implementation`, so the runtime's directory name leads, subsystem words are lower case, type names keep their case:

```
* PTO Runtime2 - TensorMap Interface       ->  * host_build_graph TensorMap interface
* PTO Runtime2 - Ring Buffer Data Struct…  ->  * tensormap_and_ringbuffer ring buffer data structures
```

The four `PTO Runtime C API` banners are in the platform layer, which serves both runtimes, so they take the name the canonical header already uses for itself: `simpler host-runtime C API`.

### Eighteen comments naming a `pto_*` that does not exist

`doc-consistency.md` §3 defects rather than naming preferences — a reader who greps the name finds nothing:

| stale | actual | uses |
| ----- | ------ | ---- |
| `pto_submit_task` | `rt_submit_task`, in `orchestration/orchestration_api.h` | 16 |
| `pto_runtime_c_api` | `runtime_c_api`, the file name | 2 |

`git grep -w <name>` returning only comments is what established each was absent.

### Six mentions that named a retired variable only for history

"the now-retired `PTO2_RING_*` environment variables", "the process-wide `PTO2_RING_*` env, since retired" — these explained a design by contrast with something the reader cannot find. They now state the current mechanism and what it enables. (`per_task_runtime_env/README.md` also carried "shared the process-wide **process-wide**", a duplicated line from #1980's edit.)

### `tests/lint/check_retired_names.py`, wired into pre-commit

Rule 10 already demanded that "the count only goes down"; nothing enforced it, and **a count written into prose cannot stay true** — that is how this rotted. The hook fails on any new `PTO Runtime`, `PTO Runtime2`, or bare `Runtime2`, so the rule can point at it and drop the number it could not keep current.

### Rule 10 itself

- The "no backlog" claim is replaced by a pointer to the hook, plus "do not put a number here again — put it in the hook".
- **Tier A is split in two**, because it had been lumping populations with opposite risk: **A1** brand prose (mechanically safe, no Tier-C name can hide in a file banner) and **A2** dangling `pto_*` references (grep first — it is a §3 defect, and the namespace is shared with Tier C).
- Tier C now names the `dlsym` trap explicitly.

## What is deliberately untouched, and why

**Every live `pto_cpu_sim_*` / `pto_sim_*` hook** — 33 occurrences, all left alone. `cpu_sim_context.cpp` exports them for "pto-isa via `dlsym(RTLD_DEFAULT)`", and `device_runner_base.cpp:863` fetches `pto_sim_register_hooks` by `dlsym`. Renaming one produces **no compile error** — just a hook that is never found at run time.

That is the "handful of Tier-C names hiding in it" rule 10's no-sweep ban was written to protect, and it is real. It just hides in the lowercase `pto_*` namespace, **not** in the banner namespace — which is exactly why the hook checks only the brand spellings and why Tier A had to be split.

**`PTO2_*` is out of the hook's scope**, because what remains of that spelling is load-bearing in two ways a regex cannot distinguish:

- **Twelve** occurrences belong to `warn_on_retired_ring_env()` in each `host/runtime_maker.cpp` — a `kRetired[]` array of env names plus the comment explaining it — and three doc sites that tell a reader what the warning they just saw means. The names cannot leave without the warning leaving, and that warning is **one day old** (#1980, 2026-08-25); rule 10 holds it up as the model for retiring a knob rather than silently falling back.
- **Eight** are `PTO2_MANUAL_MAX_SEQ`, pypto-lib's own variable, which the qwen READMEs tell a user to `export` literally.

So banning the spelling would either delete a live diagnostic or break working instructions. Happy to remove the warning and its 15 mentions in a follow-up if the transition is considered over — that is a behaviour change, so it wants its own decision.

## Testing

Comments, docs, and one new lint script. No declaration, signature or expression changed.

- [x] Full product build — both arches, sim and onboard, all four runtimes
- [x] `ctest` cpput — 119/119
- [x] Per-PR sim gate (`--manual exclude`) — green on `a2a3sim` and `a5sim`
- [x] `clang-format --dry-run --Werror` clean on all 42 changed C++ files; every one is a matched a2a3/a5 pair
- [x] `markdownlint-cli2` clean on every changed doc

The hook's own behaviour, verified four ways: **0** over all 2294 tracked files; **1** on a probe containing `PTO Runtime2 - Something`; **1** on a bare `Runtime2`; **0** on `codestyle.md`, which is exempt because a rule has to spell what it bans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
