### PR TITLE
Name TaskTensor in the qwen vendored kernels so both umbrellas compile them

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/vendor/paged_attention_cce/kernel/fai_body.hpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/vendor/paged_attention_cce/kernel/fai_body.hpp
@@ -68,7 +68,7 @@ acquire_qwen_fai_metadata(GM_ADDR metadata) {
 template <typename T>
 static __aicore__ __attribute__((always_inline)) GM_ADDR
 tensor_data(__gm__ int64_t *args, int32_t index) {
-  __gm__ simpler::tmr::Tensor *tensor = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[index]);
+  __gm__ TaskTensor *tensor = reinterpret_cast<__gm__ TaskTensor *>(args[index]);
   __gm__ T *data =
       reinterpret_cast<__gm__ T *>(tensor->buffer.addr) + tensor->start_offset;
   return reinterpret_cast<GM_ADDR>(data);
@@ -207,7 +207,7 @@ run_qwen_fai(__gm__ int64_t *args, __gm__ int32_t *barrier_state = nullptr) {
     // slot_mapping, rope_cos, rope_sin, k_proj, k_norm_w, v_proj, q_proj,
     // q_norm_w, layer_cache_base, KV_CACHE_ROWS, block_idx, block_num).
     int64_t kv_cache_rows = static_cast<int64_t>(
-        reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[2])->shapes[0]);
+        reinterpret_cast<__gm__ TaskTensor *>(args[2])->shapes[0]);
     uint32_t rope_lane = block_idx * 2 + sub_block_idx;
     if (rope_lane < kQwenRopeCores) {
       qwen_rope_gen::rope_qkv(

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/vendor/paged_attention_cce/tiling/entry.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/vendor/paged_attention_cce/tiling/entry.cpp
@@ -34,13 +34,13 @@ namespace {
 
 template <typename T>
 static __aicore__ __attribute__((always_inline)) __gm__ T *tensor_data(__gm__ int64_t *args, int32_t index) {
-    __gm__ simpler::tmr::Tensor *tensor = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[index]);
+    __gm__ TaskTensor *tensor = reinterpret_cast<__gm__ TaskTensor *>(args[index]);
     return reinterpret_cast<__gm__ T *>(tensor->buffer.addr) + tensor->start_offset;
 }
 
-static __aicore__ __attribute__((always_inline)) __gm__ simpler::tmr::Tensor *
+static __aicore__ __attribute__((always_inline)) __gm__ TaskTensor *
 tensor_desc(__gm__ int64_t *args, int32_t index) {
-    return reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[index]);
+    return reinterpret_cast<__gm__ TaskTensor *>(args[index]);
 }
 
 static __aicore__ __attribute__((always_inline)) __gm__ int32_t *barrier_data(__gm__ uint8_t *metadata) {
@@ -72,7 +72,7 @@ static __aicore__ void flush_metadata_prefix(__gm__ uint8_t *metadata) {
 }  // namespace
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
-    __gm__ simpler::tmr::Tensor *seq_lens_desc = tensor_desc(args, 0);
+    __gm__ TaskTensor *seq_lens_desc = tensor_desc(args, 0);
     __gm__ const int32_t *seq_lens = tensor_data<const int32_t>(args, 0);
     __gm__ uint8_t *metadata = tensor_data<uint8_t>(args, 1);
     __gm__ uint32_t *tiling_out = reinterpret_cast<__gm__ uint32_t *>(metadata + qwen_fai_metadata::kTilingOffset);

--- a/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/vendor/paged_attention_cce/kernel/fai_body.hpp
+++ b/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/vendor/paged_attention_cce/kernel/fai_body.hpp
@@ -78,7 +78,7 @@ acquire_qwen_fai_metadata(GM_ADDR metadata) {
 template <typename T>
 static __aicore__ __attribute__((always_inline)) GM_ADDR
 tensor_data(__gm__ int64_t *args, int32_t index) {
-  __gm__ simpler::tmr::Tensor *tensor = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[index]);
+  __gm__ TaskTensor *tensor = reinterpret_cast<__gm__ TaskTensor *>(args[index]);
   __gm__ T *data =
       reinterpret_cast<__gm__ T *>(tensor->buffer.addr) + tensor->start_offset;
   return reinterpret_cast<GM_ADDR>(data);
@@ -217,7 +217,7 @@ run_qwen_fai(__gm__ int64_t *args, __gm__ int32_t *barrier_state = nullptr) {
     // slot_mapping, rope_cos, rope_sin, k_proj, k_norm_w, v_proj, q_proj,
     // q_norm_w, layer_cache_base, KV_CACHE_ROWS, block_idx, block_num).
     int64_t kv_cache_rows = static_cast<int64_t>(
-        reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[2])->shapes[0]);
+        reinterpret_cast<__gm__ TaskTensor *>(args[2])->shapes[0]);
     uint32_t rope_lane = block_idx * 2 + sub_block_idx;
     if (rope_lane < kQwenRopeCores) {
       qwen_rope_gen::rope_qkv(

--- a/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/vendor/paged_attention_cce/tiling/entry.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/vendor/paged_attention_cce/tiling/entry.cpp
@@ -34,13 +34,13 @@ namespace {
 
 template <typename T>
 static __aicore__ __attribute__((always_inline)) __gm__ T *tensor_data(__gm__ int64_t *args, int32_t index) {
-    __gm__ simpler::tmr::Tensor *tensor = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[index]);
+    __gm__ TaskTensor *tensor = reinterpret_cast<__gm__ TaskTensor *>(args[index]);
     return reinterpret_cast<__gm__ T *>(tensor->buffer.addr) + tensor->start_offset;
 }
 
-static __aicore__ __attribute__((always_inline)) __gm__ simpler::tmr::Tensor *
+static __aicore__ __attribute__((always_inline)) __gm__ TaskTensor *
 tensor_desc(__gm__ int64_t *args, int32_t index) {
-    return reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[index]);
+    return reinterpret_cast<__gm__ TaskTensor *>(args[index]);
 }
 
 static __aicore__ __attribute__((always_inline)) __gm__ int32_t *barrier_data(__gm__ uint8_t *metadata) {
@@ -75,7 +75,7 @@ static __aicore__ void flush_metadata_prefix(__gm__ uint8_t *metadata) {
 }  // namespace
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
-    __gm__ simpler::tmr::Tensor *seq_lens_desc = tensor_desc(args, 0);
+    __gm__ TaskTensor *seq_lens_desc = tensor_desc(args, 0);
     __gm__ const int32_t *seq_lens = tensor_data<const int32_t>(args, 0);
     __gm__ uint8_t *metadata = tensor_data<uint8_t>(args, 1);
     __gm__ uint32_t *tiling_out = reinterpret_cast<__gm__ uint32_t *>(metadata + qwen_fai_metadata::kTilingOffset);


### PR DESCRIPTION
## Summary

`examples/{a2a3,a5}/host_build_graph/qwen3_14b_decode` has **no incores of its own**. It loads the `tensormap_and_ringbuffer` case's `CALLABLE` and swaps in only its own orchestration source, so every incore is the TMR case's file compiled against the **host_build_graph** include path — where `tensor.h` resolves to hbg's umbrella, which declares `simpler::hbg` and not `simpler::tmr`.

#1974 split the boundary `ChipTensor` from each runtime's working tensor and rewrote kernels to name `TaskTensor`, the per-translation-unit alias both umbrellas export for exactly this reason. **Two vendored files were missed**, so the hbg case has not compiled since:

```
error: no member named 'tmr' in namespace 'simpler'; did you mean 'tm'?
  __gm__ simpler::tmr::Tensor *tensor = reinterpret_cast<...>(args[index]);
                ^~~
/usr/include/bits/types/struct_tm.h:7:8: note: 'tm' declared here
```

Both cases are `manual: True` and onboard-only, and per-PR CI runs the sim and NPU workflows with their default `manual_mode: exclude` — so nothing compiled them.

## The change

The 16 occurrences in `kernel/fai_body.hpp` and `tiling/entry.cpp` now name `TaskTensor`. For the TMR path this is **exactly equivalent** — that umbrella's alias *is* `simpler::tmr::Tensor` — and it is what makes the file compile under either.

## Why #1974's gate missed them

That gate compiled every `*/kernels/{aic,aiv}/*.cpp` under both runtimes. These live in `kernels/vendor/`. Three directory shapes sit outside that glob — `vendor/`, `mix/`, `orchestration/` — which is **one** root cause, not three.

## There is a second instance, and it is not in this PR

`tests/st/{a2a3,a5}/host_build_graph/spmd_paged_attention` is broken the same way. Measured, on both arches:

| file | dir | needs |
| ---- | --- | ----- |
| `kernels/mix/paged_attention_parallel.cpp` | `mix/` | `TaskTensor` — a rename |
| `kernels/orchestration/spmd_paged_attention_orch.cpp` | `orchestration/` | `TaskTensor` **and** a neutral `make_tensor_external` |

```
tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp:117:14:
  error: 'simpler::tmr' has not been declared
  simpler::tmr::Tensor query = simpler::tmr::make_tensor_external(query_ptr, query_shapes, 2, data_type);
```

The second row is a design choice rather than a rename, which is why it is not folded in here. `TaskTensor` cannot carry the factory: a `using simpler::hbg::make_tensor_external;` in the umbrella would join an overload set with the global `::make_tensor_external` from `task_interface/tensor.h` — same first four parameters, different return type — and make a four-argument call ambiguous. The options are a namespace alias next to `TaskTensor` (`namespace task_rt = simpler::hbg;`, so a shared source writes `task_rt::make_tensor_external`), a forwarding `make_task_tensor`, or giving that hbg case its own orchestration copy the way qwen already does. Happy to take whichever the maintainers prefer in a follow-up.

## Testing

Compiled all four qwen cases through the entry the onboard CI job uses, `simpler_setup.tools.scene_test_compile … --manual only`:

| case | before | after |
| ---- | ------ | ----- |
| `examples/a2a3/host_build_graph/qwen3_14b_decode` | 3 failures | **0** |
| `examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode` | 0 | **0** |
| `examples/a5/host_build_graph/qwen3_14b_decode` | 3 failures | **0** |
| `examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode` | 0 | **0** |

Also compiled every other scene test that re-points its incores at another directory (`deepseek_v4_flash_decode`, `run_stream_reuse`, `worker_async_fifo`) — all clean; `spmd_paged_attention` is the one exception, above.

Note that `scene_test_compile` is a cache warmer by its own docstring and **exits 0 on a compile error**, logging `[ERROR] [Incore] Compilation failed:` instead — so the log is the signal, not the status. That is by design (the pytest run that follows recompiles and attributes the error to its case), but it is worth knowing when reading these numbers.

No runtime source changed, so no product rebuild is implicated; the four files have no consumer outside the qwen tree (`fai_body.hpp` is included only by the sibling `attention/` and `attention_rope/` entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
