### PR TITLE
Test: make environment-sensitive wall-clock UTs deterministic

### DIFF
--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -617,6 +617,11 @@ public:
         return active_leases_;
     }
 
+    bool closing() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return state_ == State::CLOSING;
+    }
+
     void close() {
         std::unique_ptr<RegionMapping> mapping;
         std::exception_ptr close_error;
@@ -727,6 +732,15 @@ public:
             throw std::runtime_error("mapped-region handle is closed or unknown");
         }
         return it->second->active_leases();
+    }
+
+    bool closing(uint64_t handle) const {
+        std::lock_guard<std::mutex> lk(mu_);
+        auto it = regions_.find(handle);
+        if (it == regions_.end()) {
+            throw std::runtime_error("mapped-region handle is closed or unknown");
+        }
+        return it->second->closing();
     }
 
     void close(uint64_t handle) {
@@ -3334,6 +3348,13 @@ NB_MODULE(_task_interface, m) {
         nb::arg("handle"), "Return the number of in-flight native operations holding this mapped region."
     );
     m.def(
+        "_region_closing_for_test",
+        [](uint64_t handle) {
+            return region_registry().closing(handle);
+        },
+        nb::arg("handle"), "Report whether close is waiting for mapped-region leases."
+    );
+    m.def(
         "_region_take_cleanup_error",
         [](const std::string &owner_token) {
             if (owner_token.empty()) {
@@ -3488,6 +3509,13 @@ NB_MODULE(_task_interface, m) {
             return region_registry().active_leases(handle);
         },
         nb::arg("handle"), "Return the number of in-flight native operations holding this mapped region."
+    );
+    m.def(
+        "_worker_host_mapped_region_closing_for_test",
+        [](uint64_t handle) {
+            return region_registry().closing(handle);
+        },
+        nb::arg("handle"), "Report whether close is waiting for L3 Host mapped-region leases."
     );
     m.def(
         "_worker_host_mapped_region_take_cleanup_error",

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -383,6 +383,14 @@ inline void bind_worker(nb::module_ &m) {
             nb::call_guard<nb::gil_scoped_release>(), "Wait up to timeout_seconds for one run to become terminal."
         )
         .def("_run_done", &Orchestrator::run_done, nb::arg("run_id"))
+        .def(
+            "_current_run_failed_for_test", &Orchestrator::current_building_run_failed_for_test,
+            "Report whether an asynchronous failure has reached the run whose graph is still being built."
+        )
+        .def(
+            "_begin_run_waiter_count_for_test", &Orchestrator::begin_run_waiter_count_for_test,
+            "Return the number of begin_run calls currently waiting for a pipeline slot."
+        )
         .def("_release_run", &Orchestrator::release_run, nb::arg("run_id"));
 
     // --- Worker ---
@@ -925,6 +933,29 @@ inline void bind_worker(nb::module_ &m) {
         nb::arg("addr"), nb::arg("expected"), nb::arg("timeout_s"),
         "Block (GIL released) until the mailbox word at `addr` differs from `expected`, a peer "
         "wakes the word, or `timeout_s` elapses. May return spuriously; callers re-check the word."
+    );
+    m.def(
+        "_mailbox_wait_i32_result_for_test",
+        [](uint64_t addr, int32_t expected, double timeout_s) {
+            nb::gil_scoped_release release;
+            switch (mpi_group_mailbox::wait_word(reinterpret_cast<int32_t *>(addr), expected, timeout_s)) {
+            case mpi_group_mailbox::WaitWordResult::NO_WAIT:
+                return std::string("no_wait");
+            case mpi_group_mailbox::WaitWordResult::VALUE_MISMATCH:
+                return std::string("value_mismatch");
+            case mpi_group_mailbox::WaitWordResult::WOKEN:
+                return std::string("woken");
+            case mpi_group_mailbox::WaitWordResult::TIMED_OUT:
+                return std::string("timed_out");
+            case mpi_group_mailbox::WaitWordResult::INTERRUPTED:
+                return std::string("interrupted");
+            case mpi_group_mailbox::WaitWordResult::ERROR:
+                return std::string("error");
+            }
+            return std::string("error");
+        },
+        nb::arg("addr"), nb::arg("expected"), nb::arg("timeout_s"),
+        "Return why a mailbox-word wait ended, for deterministic timeout tests."
     );
     m.def(
         "_mpi_mailbox_layout",

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -480,6 +480,16 @@ _ROLLBACK_GRACEFUL_TIMEOUT_S = 10.0
 # gets its own, larger budget. Rollback stays at the tighter value above: its
 # wait guards an unlink-only graceful path that is stuck when it exceeds it.
 _CLOSE_CHILD_REAP_TIMEOUT_S = 60.0
+
+
+def _monotonic() -> float:
+    return time.monotonic()
+
+
+def _sleep(seconds: float) -> None:
+    time.sleep(seconds)
+
+
 # Bounded re-check interval for a close() joiner waiting on an in-flight
 # _CloseAttempt. A joiner normally wakes immediately on the completing thread's
 # notify_all(); the timeout is a backstop so that if that notify is skipped (an
@@ -3964,7 +3974,7 @@ class RunHandle:
         value = float(timeout)
         if value < 0 or not math.isfinite(value):
             raise ValueError("RunHandle timeout must be a non-negative finite number of seconds")
-        return time.monotonic() + value
+        return _monotonic() + value
 
     @property
     def done(self) -> bool:
@@ -4121,7 +4131,7 @@ class RunHandle:
         try:
             with self._cv:
                 while not self._terminal and self._wait_in_progress:
-                    remaining = None if deadline is None else deadline - time.monotonic()
+                    remaining = None if deadline is None else deadline - _monotonic()
                     if remaining is not None and remaining <= 0:
                         raise TimeoutError("RunHandle.wait() timed out")
                     recheck = (
@@ -4142,7 +4152,7 @@ class RunHandle:
                 boundary_hook("after_election")
 
             assert run_id is not None
-            remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+            remaining = None if deadline is None else max(0.0, deadline - _monotonic())
             try:
                 completed = self._worker._wait_run_handle(run_id, remaining)
             except Exception as exc:  # native run failures are terminal
@@ -4158,7 +4168,7 @@ class RunHandle:
             # execution with acceptance waiting.
             with self._cv:
                 while self._accept_wait_in_progress:
-                    remaining = None if deadline is None else deadline - time.monotonic()
+                    remaining = None if deadline is None else deadline - _monotonic()
                     if remaining is not None and remaining <= 0:
                         raise TimeoutError("RunHandle.wait() timed out")
                     recheck = (
@@ -4771,7 +4781,7 @@ class Worker:
         # A blocking op's slice of the single root startup deadline. Raising here
         # keeps the timeout local and clear, and avoids settimeout(0.0) — which
         # would flip the socket to non-blocking and surface BlockingIOError.
-        remaining = deadline - time.monotonic()
+        remaining = deadline - _monotonic()
         if remaining <= 0:
             raise TimeoutError(f"{what}: startup deadline exceeded")
         return remaining
@@ -5313,7 +5323,7 @@ class Worker:
                         f"MPI L3 group {group.group_id} exited before READY (status {group.process.returncode})"
                     )
                 self._remaining_until(deadline, "MPI L3 mailbox READY")
-                time.sleep(_STARTUP_POLL_INTERVAL_S)
+                _sleep(_STARTUP_POLL_INTERVAL_S)
             if mailbox.group_state is not MailboxGroupState.READY:
                 raise RuntimeError(f"MPI L3 group {group.group_id} failed before READY: {mailbox.terminal_reason()}")
             self._worker.add_mpi_group_mailbox(
@@ -5331,7 +5341,7 @@ class Worker:
                 name=f"simpler-mpirun-monitor-{group.group_id[:8]}",
             )
             group.monitor_thread.start()
-        if time.monotonic() >= deadline:
+        if _monotonic() >= deadline:
             raise RuntimeError("MPI L3 activation: startup deadline exceeded after attach")
 
     def _require_remote_worker_started(self, worker_id: int) -> None:
@@ -7511,7 +7521,7 @@ class Worker:
             self._owner_instance_id: bytes = mint_owner_instance_id()
             if self.level >= 3:
                 self._is_startup_root = _startup_deadline is None
-                own_deadline = time.monotonic() + self._startup_timeout_s
+                own_deadline = _monotonic() + self._startup_timeout_s
                 # A recursive descendant caps its own timeout at the parent's
                 # remaining budget so the whole tree fits one startup_timeout_s.
                 self._startup_deadline = (
@@ -7537,7 +7547,7 @@ class Worker:
                 # every hierarchical worker, not just those with direct remote
                 # sessions — a local child may have remote descendants whose
                 # startup this deadline also bounds.
-                if self.level >= 3 and time.monotonic() >= self._startup_deadline:
+                if self.level >= 3 and _monotonic() >= self._startup_deadline:
                     raise RuntimeError("hierarchical startup: startup deadline exceeded before READY")
                 if self._cancel_token:
                     raise InitCancelled("init cancelled by close() before READY commit")
@@ -7673,7 +7683,7 @@ class Worker:
             raise ValueError("remote worker ids/specs length mismatch")
         session_timeout = self._remote_session_timeout_s()
         for worker_id, spec in zip(self._remote_worker_ids, self._remote_worker_specs):
-            remaining = deadline - time.monotonic()
+            remaining = deadline - _monotonic()
             if remaining <= 0:
                 raise RuntimeError("remote L3 session activation: startup deadline exceeded")
             session_id = uuid.uuid4().int & ((1 << 63) - 1)
@@ -7695,7 +7705,7 @@ class Worker:
                     f"remote L3 session open failed for worker {worker_id}: {type(exc).__name__}: {exc}"
                 ) from exc
             self._remote_sessions.append(session)
-            remaining = deadline - time.monotonic()
+            remaining = deadline - _monotonic()
             if remaining <= 0:
                 raise RuntimeError("remote L3 endpoint attach: startup deadline exceeded")
             assert self._worker is not None
@@ -7722,7 +7732,7 @@ class Worker:
                 ) from exc
         # Attach may have consumed the last slice of the budget; a final root
         # deadline check keeps a just-over-budget attach from committing READY.
-        if time.monotonic() >= deadline:
+        if _monotonic() >= deadline:
             raise RuntimeError("remote L3 activation: startup deadline exceeded after attach")
 
     def _start_hierarchical(self) -> None:  # noqa: PLR0912 -- three parallel fork loops (sub/chip/next) + bootstrap wait + scheduler register/init; branches track the fork order documented in the body
@@ -8035,12 +8045,12 @@ class Worker:
             if pending:
                 if self._cancel_token:
                     raise InitCancelled(f"{kind} worker readiness wait cancelled by close()")
-                if time.monotonic() > deadline:
+                if _monotonic() > deadline:
                     raise RuntimeError(
                         f"{kind} worker(s) {pending} did not become ready within "
                         f"{self._startup_timeout_s}s (startup deadline exceeded)"
                     )
-                time.sleep(_STARTUP_POLL_INTERVAL_S)
+                _sleep(_STARTUP_POLL_INTERVAL_S)
 
     # ------------------------------------------------------------------
     # Hierarchical abort
@@ -8075,7 +8085,7 @@ class Worker:
            already reaped are excluded so a reused PID is never signalled.
         """
         if deadline is None:
-            deadline = time.monotonic() + _ROLLBACK_GRACEFUL_TIMEOUT_S
+            deadline = _monotonic() + _ROLLBACK_GRACEFUL_TIMEOUT_S
         reaped = set(self._startup_reaped_pids)
         graceful: list[int] = []
         cancelled: list[int] = []
@@ -8120,7 +8130,7 @@ class Worker:
 
         waiting = set(graceful) | set(cancelled)
         if waiting:
-            while waiting and time.monotonic() <= deadline:
+            while waiting and _monotonic() <= deadline:
                 for pid in list(waiting):
                     try:
                         wpid, _status = os.waitpid(pid, os.WNOHANG)
@@ -8132,7 +8142,7 @@ class Worker:
                         waiting.discard(pid)
                         reaped.add(pid)
                 if waiting:
-                    time.sleep(_STARTUP_POLL_INTERVAL_S)
+                    _sleep(_STARTUP_POLL_INTERVAL_S)
 
         # Phase 2: hard backstop for any survivor. A not-yet-reaped pid still
         # holds its slot (no reuse), so killpg on the root reaps the survivor's
@@ -8165,8 +8175,8 @@ class Worker:
                 if wpid != 0:
                     to_reap.discard(pid)
                     reaped.add(pid)
-            if to_reap and time.monotonic() <= deadline:
-                time.sleep(_STARTUP_POLL_INTERVAL_S)
+            if to_reap and _monotonic() <= deadline:
+                _sleep(_STARTUP_POLL_INTERVAL_S)
             else:
                 break
 
@@ -8213,7 +8223,7 @@ class Worker:
         (including ``_abort_hierarchical``) so the whole rollback is bounded
         end-to-end rather than each phase re-acquiring a full timeout.
         """
-        deadline = time.monotonic() + _ROLLBACK_GRACEFUL_TIMEOUT_S
+        deadline = _monotonic() + _ROLLBACK_GRACEFUL_TIMEOUT_S
 
         with contextlib.suppress(BaseException):
             self._teardown_worker_tree(startup_abort=True, deadline=deadline)
@@ -11273,9 +11283,9 @@ class Worker:
                         raise RuntimeError("Worker.close(): cannot cancel init() from the init-owner thread")
                     self._cancel_token = True
                     self._hierarchical_start_cv.notify_all()
-                    _cancel_deadline = time.monotonic() + _CLOSE_CANCEL_UNWIND_TIMEOUT_S
+                    _cancel_deadline = _monotonic() + _CLOSE_CANCEL_UNWIND_TIMEOUT_S
                     while self._lifecycle is _Lifecycle.INITIALIZING:
-                        _remaining = _cancel_deadline - time.monotonic()
+                        _remaining = _cancel_deadline - _monotonic()
                         if _remaining <= 0:
                             raise RuntimeError(
                                 "Worker.close(): cancelled init() did not unwind within "
@@ -11335,7 +11345,7 @@ class Worker:
                 # One absolute budget covers both kinds of admitted work. A
                 # lease that consumes most of it must not be followed by a
                 # fresh full-budget wait on an accepted run fence.
-                drain_deadline = time.monotonic() + _ROLLBACK_GRACEFUL_TIMEOUT_S
+                drain_deadline = _monotonic() + _ROLLBACK_GRACEFUL_TIMEOUT_S
                 # Drain in-flight leases before touching the tree. CLOSED already
                 # rejects new leases; a tree with a live op is never torn down.
                 # If an op outlives the budget, teardown stays UN-attempted and
@@ -11344,7 +11354,7 @@ class Worker:
                 # an async interruption leaving an accepted run fence undrained).
                 if self._active_ops > 0:
                     while self._active_ops > 0:
-                        remaining = drain_deadline - time.monotonic()
+                        remaining = drain_deadline - _monotonic()
                         if remaining <= 0:
                             break
                         self._hierarchical_start_cv.wait(timeout=remaining)
@@ -11362,7 +11372,7 @@ class Worker:
                 # the lifecycle CV: handle retirement acquires the same lock.
                 assert drain_deadline is not None
                 for handle in handles_to_drain:
-                    remaining = drain_deadline - time.monotonic()
+                    remaining = drain_deadline - _monotonic()
                     if remaining <= 0:
                         drain_deadline_expired = True
                         break
@@ -11371,7 +11381,7 @@ class Worker:
                     except BaseException as exc:  # noqa: BLE001
                         if result is None:
                             result = exc
-                        if isinstance(exc, TimeoutError) and time.monotonic() >= drain_deadline:
+                        if isinstance(exc, TimeoutError) and _monotonic() >= drain_deadline:
                             drain_deadline_expired = True
                             break
                 with self._hierarchical_start_cv:
@@ -11535,8 +11545,8 @@ class Worker:
                 else:
                     still.append((g, i))
             pending = still
-            if pending and time.monotonic() <= deadline:
-                time.sleep(_STARTUP_POLL_INTERVAL_S)
+            if pending and _monotonic() <= deadline:
+                _sleep(_STARTUP_POLL_INTERVAL_S)
             else:
                 break
         survivors: list[int] = []
@@ -11783,7 +11793,7 @@ class Worker:
             # teardown entry — so the (blocking) pre-child cleanup above cannot
             # eat it. Reap transfers a surviving pid/shm pair into the journal;
             # a later close() can retry without freeing a live mailbox.
-            reap_deadline = time.monotonic() + _CLOSE_CHILD_REAP_TIMEOUT_S
+            reap_deadline = _monotonic() + _CLOSE_CHILD_REAP_TIMEOUT_S
             _step(lambda: self._reclaim_child_groups(reap_deadline))
             # A prior attempt may already have transferred a surviving child
             # and its mailbox into the journal. Retry those entries only after

--- a/src/common/hierarchical/mpi_group_mailbox.h
+++ b/src/common/hierarchical/mpi_group_mailbox.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 
@@ -67,24 +68,39 @@ inline void wake_word(int32_t *addr) {
 #endif
 }
 
+enum class WaitWordResult : int32_t {
+    NO_WAIT = 0,
+    VALUE_MISMATCH = 1,
+    WOKEN = 2,
+    TIMED_OUT = 3,
+    INTERRUPTED = 4,
+    ERROR = 5,
+};
+
 // Blocks until the word at `addr` differs from `expected`, a wake arrives, or
 // `timeout_s` elapses. Non-Linux builds have no futex and poll the word until
 // the timeout instead.
-inline void wait_word(int32_t *addr, int32_t expected, double timeout_s) {
-    if (!(timeout_s > 0.0)) return;
+inline WaitWordResult wait_word(int32_t *addr, int32_t expected, double timeout_s) {
+    if (!(timeout_s > 0.0)) return WaitWordResult::NO_WAIT;
 #if defined(__linux__)
     struct timespec ts;
     const int64_t timeout_ns = static_cast<int64_t>(timeout_s * 1e9);
     ts.tv_sec = static_cast<time_t>(timeout_ns / 1000000000);
     ts.tv_nsec = static_cast<long>(timeout_ns % 1000000000);
-    (void)::syscall(SYS_futex, addr, FUTEX_WAIT, expected, &ts, nullptr, 0);
+    long rc = ::syscall(SYS_futex, addr, FUTEX_WAIT, expected, &ts, nullptr, 0);
+    if (rc == 0) return WaitWordResult::WOKEN;
+    if (errno == EAGAIN) return WaitWordResult::VALUE_MISMATCH;
+    if (errno == ETIMEDOUT) return WaitWordResult::TIMED_OUT;
+    if (errno == EINTR) return WaitWordResult::INTERRUPTED;
+    return WaitWordResult::ERROR;
 #else
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::duration<double>(timeout_s);
     int32_t value = expected;
     while (std::chrono::steady_clock::now() < deadline) {
         __atomic_load(addr, &value, __ATOMIC_ACQUIRE);
-        if (value != expected) return;
+        if (value != expected) return WaitWordResult::VALUE_MISMATCH;
     }
+    return WaitWordResult::TIMED_OUT;
 #endif
 }
 

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -74,10 +74,17 @@ RunId Orchestrator::begin_run() {
             throw std::logic_error("Orchestrator::begin_run: another run is still building");
         }
         std::optional<PipelineSlotLease> lease;
-        runs_cv_.wait(lk, [this, &lease] {
-            lease = pipeline_slots_.try_acquire(admission_depth_);
-            return lease.has_value();
-        });
+        ++begin_run_waiters_;
+        try {
+            runs_cv_.wait(lk, [this, &lease] {
+                lease = pipeline_slots_.try_acquire(admission_depth_);
+                return lease.has_value();
+            });
+        } catch (...) {
+            --begin_run_waiters_;
+            throw;
+        }
+        --begin_run_waiters_;
         if (next_run_id_ == INVALID_RUN_ID || next_run_id_ == std::numeric_limits<RunId>::max()) {
             pipeline_slots_.release(*lease);
             throw std::overflow_error("Orchestrator::begin_run: run id space exhausted");
@@ -517,6 +524,17 @@ void Orchestrator::record_run_error(const std::shared_ptr<RunState> &run, std::e
 void Orchestrator::record_run_error(RunId run_id, std::exception_ptr error) {
     if (!error) return;
     record_run_error(find_run(run_id), std::move(error));
+}
+
+bool Orchestrator::current_building_run_failed_for_test() const {
+    auto run = current_building_run();
+    std::lock_guard<std::mutex> lk(run->completion_mu);
+    return static_cast<bool>(run->first_error);
+}
+
+size_t Orchestrator::begin_run_waiter_count_for_test() const {
+    std::lock_guard<std::mutex> lk(runs_mu_);
+    return begin_run_waiters_;
 }
 
 void Orchestrator::report_task_error(TaskSlot slot, const std::string &message) {

--- a/src/common/hierarchical/orchestrator.h
+++ b/src/common/hierarchical/orchestrator.h
@@ -209,6 +209,11 @@ public:
 
     void set_test_hook(std::function<void(OrchestratorTestPoint)> hook) { test_hook_ = std::move(hook); }
 
+    // Deterministic observation seam for tests that must issue another submit
+    // only after an asynchronous task failure has reached the current run.
+    bool current_building_run_failed_for_test() const;
+    size_t begin_run_waiter_count_for_test() const;
+
 private:
     TensorMap *tensormap_ = nullptr;
     Ring *allocator_ = nullptr;
@@ -228,6 +233,7 @@ private:
     RunId next_run_id_{1};
     RunId building_run_id_{INVALID_RUN_ID};
     RunId active_run_id_{INVALID_RUN_ID};
+    size_t begin_run_waiters_{0};
 
     // Scheduler's loop mutex (not owned). Held across optional quiescent
     // compaction so the scheduler cannot retain a slot pointer being removed.

--- a/src/common/hierarchical/remote_endpoint.cpp
+++ b/src/common/hierarchical/remote_endpoint.cpp
@@ -541,6 +541,7 @@ void RemoteL3SocketTransport::write_all(
 }
 
 std::vector<uint8_t> RemoteL3SocketTransport::read_frame(std::chrono::steady_clock::time_point deadline) {
+    last_read_deadline_ = deadline;
     std::vector<uint8_t> frame(remote_l3::FRAME_HEADER_BYTES);
     size_t off = 0;
     while (off < remote_l3::FRAME_HEADER_BYTES) {

--- a/src/common/hierarchical/remote_endpoint.h
+++ b/src/common/hierarchical/remote_endpoint.h
@@ -55,6 +55,11 @@ public:
     bool poll_progress_reply(remote_l3::FrameType frame_type, uint64_t sequence, std::vector<uint8_t> &reply) override;
     void shutdown() override;
 
+    // Read-only test seam: records the actual deadline passed into the most
+    // recent frame read, so deadline selection can be asserted without timing
+    // the host running the test.
+    bool last_read_used_attach_deadline_for_test() const { return last_read_deadline_ == attach_deadline_; }
+
 private:
     std::string host_;
     uint16_t port_{0};
@@ -79,6 +84,7 @@ private:
     size_t progress_read_offset_{0};
     size_t progress_read_size_{remote_l3::FRAME_HEADER_BYTES};
     std::chrono::steady_clock::time_point progress_deadline_{};
+    std::chrono::steady_clock::time_point last_read_deadline_{};
     bool progress_command_active_{false};
 
     void connect_socket();

--- a/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
+++ b/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
@@ -53,7 +53,8 @@ void count_sigpipe(int) { ++g_sigpipe_count; }
 // Declare before the transport so the transport is destroyed first.
 class ScopedServerThread {
 public:
-    ScopedServerThread() = default;
+    explicit ScopedServerThread(std::atomic<bool> *join_observed = nullptr) :
+        join_observed_(join_observed) {}
     ~ScopedServerThread() { stop_and_join(); }
 
     ScopedServerThread(const ScopedServerThread &) = delete;
@@ -66,12 +67,16 @@ public:
     // destructor then finds nothing joinable.
     void stop_and_join() {
         stop_.store(true, std::memory_order_release);
-        if (thread_.joinable()) thread_.join();
+        if (thread_.joinable()) {
+            thread_.join();
+            if (join_observed_ != nullptr) join_observed_->store(true, std::memory_order_release);
+        }
     }
 
 private:
     std::thread thread_;
     std::atomic<bool> stop_{false};
+    std::atomic<bool> *join_observed_{nullptr};
 };
 
 class ScopedSigpipeCounter {
@@ -258,6 +263,49 @@ start_delayed_reply_server(std::thread &server_thread, std::atomic<bool> &stop, 
                 off += static_cast<size_t>(n);
             }
             std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            ::close(fd);
+        }
+        ::close(listener);
+    });
+    return port;
+}
+
+uint16_t start_gated_reply_server(
+    std::thread &server_thread, std::atomic<bool> &stop, std::atomic<bool> &request_received,
+    std::atomic<bool> &send_reply, uint64_t sequence
+) {
+    uint16_t port = 0;
+    int listener = make_loopback_listener(port);
+    server_thread = std::thread([listener, &stop, &request_received, &send_reply, sequence]() {
+        int fd = accept_until_stop(listener, stop);
+        if (fd >= 0) {
+            std::array<uint8_t, remote_l3::FRAME_HEADER_BYTES> request{};
+            size_t offset = 0;
+            while (offset < request.size()) {
+                ssize_t n = ::recv(fd, request.data() + offset, request.size() - offset, 0);
+                if (n <= 0) break;
+                offset += static_cast<size_t>(n);
+            }
+            if (offset == request.size()) {
+                request_received.store(true, std::memory_order_release);
+                while (!send_reply.load(std::memory_order_acquire) && !stop.load(std::memory_order_acquire)) {
+                    std::this_thread::yield();
+                }
+                if (!stop.load(std::memory_order_acquire)) {
+                    remote_l3::FrameHeader header;
+                    header.frame_type = remote_l3::FrameType::COMPLETION;
+                    header.session_id = 1;
+                    header.worker_id = 0;
+                    header.sequence = sequence;
+                    std::vector<uint8_t> frame = remote_l3::encode_frame(header, {});
+                    offset = 0;
+                    while (offset < frame.size()) {
+                        ssize_t n = ::send(fd, frame.data() + offset, frame.size() - offset, MSG_NOSIGNAL);
+                        if (n <= 0) break;
+                        offset += static_cast<size_t>(n);
+                    }
+                }
+            }
             ::close(fd);
         }
         ::close(listener);
@@ -636,18 +684,16 @@ TEST(RemoteSocketTransport, ClosedPeerWriteDoesNotRaiseSigpipe) {
 // accept() is still reapable — the join must not hang.
 TEST(RemoteSocketTransport, ServerThreadIsJoinedWhenTestBodyUnwinds) {
     bool caught = false;
-    auto t0 = std::chrono::steady_clock::now();
+    std::atomic<bool> join_observed{false};
     try {
-        ScopedServerThread server;
+        ScopedServerThread server(&join_observed);
         (void)start_stalling_server(server.thread(), server.stop_flag());
         throw std::runtime_error("stands in for a transport constructor timeout");
     } catch (const std::runtime_error &) {
         caught = true;
     }
-    double elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
-
     EXPECT_TRUE(caught);
-    EXPECT_LT(elapsed, 5.0) << "destructor join should not wait out the server's own cap";
+    EXPECT_TRUE(join_observed.load(std::memory_order_acquire));
 }
 
 TEST(RemoteSocketTransport, CtorRejectsNonPositiveTimeouts) {
@@ -667,10 +713,8 @@ TEST(RemoteSocketTransport, HelloReadBoundedByAttachTimeout) {
     uint16_t port = start_stalling_server(server.thread(), server.stop_flag());
     RemoteL3SocketTransport transport("127.0.0.1", port, "127.0.0.1", 1, /*attach*/ 0.2, /*runtime*/ 5.0);
 
-    auto t0 = std::chrono::steady_clock::now();
     EXPECT_THROW(transport.expect_hello_ready(1, 0, "sim"), std::runtime_error);
-    double elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
-    EXPECT_LT(elapsed, 1.0);
+    EXPECT_TRUE(transport.last_read_used_attach_deadline_for_test());
 
     transport.shutdown();
     server.stop_and_join();
@@ -697,8 +741,11 @@ TEST(RemoteSocketTransport, RuntimeReadSurvivesElapsedAttachDeadline) {
 }
 
 TEST(RemoteSocketTransport, ProgressPollDoesNotWaitForDelayedReply) {
+    std::atomic<bool> request_received{false};
+    std::atomic<bool> send_reply{false};
     ScopedServerThread server;
-    uint16_t port = start_delayed_reply_server(server.thread(), server.stop_flag(), /*delay_ms=*/500, /*sequence=*/1);
+    uint16_t port =
+        start_gated_reply_server(server.thread(), server.stop_flag(), request_received, send_reply, /*sequence=*/1);
     RemoteL3SocketTransport transport("127.0.0.1", port, "127.0.0.1", 1, /*attach*/ 1.0, /*runtime*/ 2.0);
 
     remote_l3::FrameHeader header;
@@ -709,14 +756,20 @@ TEST(RemoteSocketTransport, ProgressPollDoesNotWaitForDelayedReply) {
     transport.submit_progress_frame(remote_l3::encode_frame(header, {}));
 
     std::vector<uint8_t> reply;
-    auto t0 = std::chrono::steady_clock::now();
     EXPECT_FALSE(transport.poll_progress_reply(remote_l3::FrameType::COMPLETION, 1, reply));
-    double elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
-    EXPECT_LT(elapsed, 0.2);
+    for (int i = 0; i < 30000 && !request_received.load(std::memory_order_acquire); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(request_received.load(std::memory_order_acquire));
+    // The server has consumed the request and is held behind send_reply, so
+    // no response exists yet. This is an event/state assertion, independent
+    // of how quickly either thread was scheduled.
+    EXPECT_FALSE(transport.poll_progress_reply(remote_l3::FrameType::COMPLETION, 1, reply));
 
+    send_reply.store(true, std::memory_order_release);
     bool complete = false;
-    for (int i = 0; i < 100 && !complete; ++i) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    for (int i = 0; i < 30000 && !complete; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
         complete = transport.poll_progress_reply(remote_l3::FrameType::COMPLETION, 1, reply);
     }
     EXPECT_TRUE(complete);
@@ -797,10 +850,17 @@ TEST(RemoteSocketTransport, RuntimeWriteToStalledReaderTimesOut) {
     RemoteL3SocketTransport transport("127.0.0.1", port, "127.0.0.1", 1, /*attach*/ 1.0, /*runtime*/ 0.5);
 
     std::vector<uint8_t> big(16 * 1024 * 1024, 0x7E);
-    auto t0 = std::chrono::steady_clock::now();
-    EXPECT_THROW(transport.submit_frame(big), std::runtime_error);
-    double elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
-    EXPECT_LT(elapsed, 3.0);
+    EXPECT_THROW(
+        {
+            try {
+                transport.submit_frame(big);
+            } catch (const std::runtime_error &error) {
+                EXPECT_NE(std::string(error.what()).find("timed out writing frame"), std::string::npos);
+                throw;
+            }
+        },
+        std::runtime_error
+    );
 
     transport.shutdown();
     server.stop_and_join();

--- a/tests/ut/py/test_mpi_group_mailbox.py
+++ b/tests/ut/py/test_mpi_group_mailbox.py
@@ -14,7 +14,10 @@ import time
 
 import pytest
 import simpler.mpi_group_mailbox as mailbox_mod
-from _task_interface import _mpi_mailbox_layout  # pyright: ignore[reportMissingImports]
+from _task_interface import (  # pyright: ignore[reportMissingImports]
+    _mailbox_wait_i32_result_for_test,
+    _mpi_mailbox_layout,
+)
 from simpler.mpi_group_mailbox import (
     MAILBOX_REQUEST_OFFSET,
     MailboxGroupState,
@@ -27,6 +30,8 @@ from simpler.mpi_group_mailbox import (
     _as_byte_view,
     open_rank_mailbox,
 )
+
+_NATIVE_TIMEOUT_WATCHDOG_S = 5.0
 
 
 def test_shared_memory_view_is_normalized_to_unsigned_bytes():
@@ -324,13 +329,48 @@ def test_wait_request_state_unblocks_on_mismatch_and_bounds_the_park():
     mailbox = MpiGroupMailbox.create(world_size=1)
     try:
         mailbox.publish_ready()
+        request_state_addr = mailbox._address + mailbox_mod._OFF_REQUEST_STATE  # noqa: SLF001
+        assert (
+            _mailbox_wait_i32_result_for_test(
+                request_state_addr,
+                int(MailboxRequestState.TASK_DONE),
+                30.0,
+            )
+            == "value_mismatch"
+        )
         start = time.monotonic()
-        mailbox.wait_request_state(MailboxRequestState.TASK_DONE, timeout_s=30.0)
-        assert time.monotonic() - start < 5.0
-
-        start = time.monotonic()
-        mailbox.wait_request_state(MailboxRequestState.IDLE, timeout_s=0.05)
+        timeout_result = _mailbox_wait_i32_result_for_test(
+            request_state_addr,
+            int(MailboxRequestState.IDLE),
+            0.05,
+        )
         elapsed = time.monotonic() - start
-        assert 0.02 <= elapsed < 5.0
+        assert timeout_result == "timed_out"
+        assert elapsed < _NATIVE_TIMEOUT_WATCHDOG_S, (
+            f"50ms mailbox timeout exceeded its 5s end-to-end watchdog; native wait returned after {elapsed:.3f}s"
+        )
+    finally:
+        mailbox.close(unlink=True)
+
+
+def test_wait_request_state_forwards_address_expected_and_timeout(monkeypatch):
+    mailbox = MpiGroupMailbox.create(world_size=1)
+    calls: list[tuple[int, int, float]] = []
+    try:
+        monkeypatch.setattr(
+            mailbox_mod,
+            "_mailbox_wait_i32",
+            lambda addr, expected, timeout_s: calls.append((addr, expected, timeout_s)),
+        )
+
+        mailbox.wait_request_state(MailboxRequestState.TASK_DONE, timeout_s=0.25)
+
+        assert calls == [
+            (
+                mailbox._address + mailbox_mod._OFF_REQUEST_STATE,  # noqa: SLF001
+                int(MailboxRequestState.TASK_DONE),
+                0.25,
+            )
+        ]
     finally:
         mailbox.close(unlink=True)

--- a/tests/ut/py/test_worker/_harness.py
+++ b/tests/ut/py/test_worker/_harness.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import ctypes
 import signal
+import threading
 import time
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
@@ -53,6 +54,48 @@ TEST_WALL_BUDGET_S = 30.0
 _HANG_S = 3600.0
 
 _SCRIPTS = ("ok", "raises", "hangs")
+
+
+class ObservedCondition:
+    def __init__(
+        self,
+        condition: threading.Condition,
+        wait_entered: threading.Event | None = None,
+        *,
+        enter_thread_name: str | None = None,
+        enter_attempted: threading.Event | None = None,
+    ) -> None:
+        self._condition = condition
+        self._wait_entered = wait_entered
+        self._enter_thread_name = enter_thread_name
+        self._enter_attempted = enter_attempted
+
+    def __enter__(self):
+        if self._enter_attempted is not None and threading.current_thread().name == self._enter_thread_name:
+            self._enter_attempted.set()
+        return self._condition.__enter__()
+
+    def __exit__(self, *exc_info):
+        return self._condition.__exit__(*exc_info)
+
+    def wait(self, timeout=None):
+        if self._wait_entered is not None:
+            self._wait_entered.set()
+        return self._condition.wait(timeout)
+
+    def __getattr__(self, name):
+        return getattr(self._condition, name)
+
+
+class TickingClock:
+    def __init__(self, tick_s: float = 1.0) -> None:
+        self.now = 0.0
+        self.tick_s = tick_s
+
+    def monotonic(self) -> float:
+        now = self.now
+        self.now += self.tick_s
+        return now
 
 
 @contextmanager

--- a/tests/ut/py/test_worker/test_admission_fence.py
+++ b/tests/ut/py/test_worker/test_admission_fence.py
@@ -40,14 +40,11 @@ import simpler.worker as worker_mod
 from _task_interface import ChipCallable  # pyright: ignore[reportMissingImports]
 from simpler.worker import RemoteCallable, RemoteWorkerSpec, Worker
 
-from ._harness import SIM_PLATFORM, SIM_RUNTIME, install_fake_chip
+from ._harness import SIM_PLATFORM, SIM_RUNTIME, TEST_WALL_BUDGET_S, ObservedCondition, install_fake_chip
 
 # Comfortably above every wait these tests actually take, well under any hang.
-_TEST_WALL_BUDGET_S = 30.0
-# How long close() must be observed NOT to return while a fenced operation is
-# parked mid-transaction. Only has to outlast the scheduling noise of handing
-# the GIL to the close() thread.
-_FENCE_OBSERVATION_S = 1.0
+_TEST_WALL_BUDGET_S = TEST_WALL_BUDGET_S
+_DEADLINE_AFTER_WATCHDOG_S = 2 * _TEST_WALL_BUDGET_S
 
 
 @contextlib.contextmanager
@@ -86,7 +83,7 @@ def ready_worker(monkeypatch):
         platform=SIM_PLATFORM,
         runtime=SIM_RUNTIME,
         num_sub_workers=1,
-        startup_timeout_s=_TEST_WALL_BUDGET_S,
+        startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S,
     )
     w.init()
     try:
@@ -106,6 +103,7 @@ class _ParkedTransaction:
 
     def __init__(self, obj, name: str):
         self.entered = threading.Event()
+        self.completed = threading.Event()
         self.release = threading.Event()
         self.lease_held: bool | None = None
         self._obj = obj
@@ -118,6 +116,7 @@ class _ParkedTransaction:
             self.lease_held = threading.get_ident() in self._obj._lease_depth
             self.entered.set()
             self.release.wait(timeout=_TEST_WALL_BUDGET_S)
+            self.completed.set()
             return result
 
         setattr(self._obj, self._name, patched)
@@ -132,24 +131,33 @@ class _ParkedTransaction:
         return False
 
 
-def _close_while_parked(worker: Worker, parked: _ParkedTransaction) -> float:
-    """close() the worker from THIS thread while ``parked`` holds a transaction
-    open, and return how long it took.
+def _close_while_parked(worker: Worker, parked: _ParkedTransaction, monkeypatch) -> None:
+    close_waiting = threading.Event()
+    monkeypatch.setattr(
+        worker,
+        "_hierarchical_start_cv",
+        ObservedCondition(worker._hierarchical_start_cv, wait_entered=close_waiting),
+    )
 
-    close() runs on the caller's thread because a worker with a live native tree
-    may only be closed on the thread that init()'d it. A timer releases the
-    parked transaction, so a close() that is properly fenced behind the lease
-    takes at least ``_FENCE_OBSERVATION_S`` and an unfenced one returns at once.
-    """
-    releaser = threading.Timer(_FENCE_OBSERVATION_S, parked.release.set)
+    close_wait_observed: list[tuple[bool, bool]] = []
+
+    def release_after_close_waits():
+        try:
+            observed = close_waiting.wait(5.0)
+            close_wait_observed.append((observed, worker._active_ops > 0))
+        finally:
+            parked.release.set()
+
+    releaser = threading.Thread(target=release_after_close_waits)
     releaser.start()
-    started = time.monotonic()
     try:
         worker.close()
     finally:
-        releaser.cancel()
         parked.release.set()
-    return time.monotonic() - started
+        releaser.join(_TEST_WALL_BUDGET_S)
+    assert not releaser.is_alive()
+    assert close_wait_observed == [(True, True)], "close never waited for an admitted operation lease"
+    assert parked.completed.is_set(), "close returned before the parked transaction completed"
 
 
 def _run_in_thread(fn):
@@ -176,17 +184,16 @@ class TestRegisterAdmissionFence:
         assert parked.lease_held is True
         ready_worker.unregister(handle)
 
-    def test_close_drains_a_register_in_flight(self, ready_worker):
+    def test_close_drains_a_register_in_flight(self, ready_worker, monkeypatch):
         # Parks at the broadcast, not at publication: publication runs under
         # ``_registry_lock``, which close()'s registry detach also takes, so a
         # park there would delay close() even with no lease at all.
         with _ParkedTransaction(ready_worker, "_post_init_register") as parked:
             register_thread, register_box = _run_in_thread(lambda: ready_worker.register(_chip_callable()))
             assert parked.entered.wait(timeout=_TEST_WALL_BUDGET_S), "register never reached its broadcast"
-            elapsed = _close_while_parked(ready_worker, parked)
+            _close_while_parked(ready_worker, parked, monkeypatch)
             register_thread.join(timeout=_TEST_WALL_BUDGET_S)
 
-        assert elapsed >= _FENCE_OBSERVATION_S, "close() tore the worker down while a register was mid-broadcast"
         assert not register_thread.is_alive()
         assert "error" not in register_box, f"register() failed: {register_box.get('error')}"
         # Nothing survives a terminal close: the registration either completed
@@ -234,15 +241,14 @@ class TestUnregisterAdmissionFence:
             ready_worker.unregister(handle)
         assert parked.lease_held is True
 
-    def test_close_cannot_slip_into_the_unregister_broadcast(self, ready_worker):
+    def test_close_cannot_slip_into_the_unregister_broadcast(self, ready_worker, monkeypatch):
         handle = ready_worker.register(_chip_callable())
         with _ParkedTransaction(ready_worker, "_broadcast_unregister") as parked:
             unregister_thread, unregister_box = _run_in_thread(lambda: ready_worker.unregister(handle))
             assert parked.entered.wait(timeout=_TEST_WALL_BUDGET_S), "unregister never reached its broadcast"
-            elapsed = _close_while_parked(ready_worker, parked)
+            _close_while_parked(ready_worker, parked, monkeypatch)
             unregister_thread.join(timeout=_TEST_WALL_BUDGET_S)
 
-        assert elapsed >= _FENCE_OBSERVATION_S, "close() tore the worker down while an unregister was mid-transaction"
         assert not unregister_thread.is_alive()
         assert "error" not in unregister_box, f"unregister() failed: {unregister_box.get('error')}"
         assert ready_worker._identity_registry == {}

--- a/tests/ut/py/test_worker/test_cancellation_journal.py
+++ b/tests/ut/py/test_worker/test_cancellation_journal.py
@@ -18,9 +18,10 @@ import pytest
 import simpler.worker as worker_mod
 from simpler.worker import CleanupJournal, Worker, _journal_child_survivors, _Lifecycle, _shm_name
 
-from ._harness import TEST_WALL_BUDGET_S, hard_timeout
+from ._harness import TEST_WALL_BUDGET_S, TickingClock, hard_timeout
 
 _TEST_WALL_BUDGET_S = TEST_WALL_BUDGET_S
+_DEADLINE_AFTER_WATCHDOG_S = 2 * _TEST_WALL_BUDGET_S
 _hard_timeout = hard_timeout
 
 
@@ -121,6 +122,7 @@ class TestCloseDuringInitializing:
     def test_close_cancels_init_reaches_closed(self, monkeypatch):
         entered = threading.Event()
         release = threading.Event()
+        cancel_latched = threading.Event()
         orig = Worker._start_hierarchical
 
         def paused_start(self):
@@ -129,8 +131,16 @@ class TestCloseDuringInitializing:
             return orig(self)
 
         monkeypatch.setattr(Worker, "_start_hierarchical", paused_start)
-        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=30.0)
+        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
         w.register(lambda args: None)
+        real_monotonic = worker_mod._monotonic
+
+        def observe_cancel():
+            if w._cancel_token:
+                cancel_latched.set()
+            return real_monotonic()
+
+        monkeypatch.setattr(worker_mod, "_monotonic", observe_cancel)
 
         def owner_body():
             _run_catch(w.init)
@@ -143,8 +153,7 @@ class TestCloseDuringInitializing:
                 close_result: list = []
                 ct = threading.Thread(target=lambda: close_result.append(_run_catch(w.close)))
                 ct.start()
-                while not w._cancel_token:
-                    time.sleep(0.001)
+                assert cancel_latched.wait(3.0)
                 release.set()
                 ct.join(10.0)
                 it.join(10.0)
@@ -168,7 +177,9 @@ class TestCloseDuringInitializing:
 
         monkeypatch.setattr(Worker, "_start_hierarchical", paused_start)
         monkeypatch.setattr(worker_mod, "_CLOSE_CANCEL_UNWIND_TIMEOUT_S", 0.5)
-        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=30.0)
+        clock = TickingClock()
+        monkeypatch.setattr(worker_mod, "_monotonic", clock.monotonic)
+        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
         w.register(lambda args: None)
 
         def owner_body():
@@ -201,7 +212,7 @@ class TestCloseDuringInitializing:
             return orig(self)
 
         monkeypatch.setattr(Worker, "_start_hierarchical", paused_start)
-        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=30.0)
+        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
         w.register(lambda args: None)
         try:
             with _hard_timeout(_TEST_WALL_BUDGET_S):
@@ -300,7 +311,7 @@ class TestJournalInAbortHierarchical:
     def test_fully_reaped_abort_leaves_empty_journal(self, monkeypatch):
         l3 = _l3_child()
         l3.init = _init_raises
-        w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=10.0)
+        w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
         w4.register(_trivial_orch)
         w4.add_worker(l3)
         try:

--- a/tests/ut/py/test_worker/test_error_propagation.py
+++ b/tests/ut/py/test_worker/test_error_propagation.py
@@ -30,6 +30,8 @@ import pytest
 from simpler.task_interface import CallConfig, TaskArgs
 from simpler.worker import Worker
 
+_TEST_WALL_BUDGET_S = 30.0
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -185,10 +187,14 @@ class TestScopeMidFailure:
 
             def orch(o, args, cfg):
                 o.submit_sub(handle)
-                # Give the child enough wall-clock time to run and fail
-                # before issuing the second submit, so the fail-fast check
-                # in submit_impl has something to trip on.
-                time.sleep(1.0)
+                # The second submit specifically exercises the native
+                # fail-fast check. Wait for that state, rather than guessing
+                # how long this server needs to propagate the child failure.
+                deadline = time.monotonic() + _TEST_WALL_BUDGET_S
+                while not o._o._current_run_failed_for_test():
+                    if time.monotonic() >= deadline:
+                        pytest.fail("child failure never reached the current orchestration run")
+                    time.sleep(0.001)
                 o.submit_sub(handle)
 
             with pytest.raises(RuntimeError) as info:

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -19,6 +19,7 @@ import dis
 import gc
 import inspect
 import multiprocessing.shared_memory as shared_memory_mod
+import signal
 import struct
 import subprocess
 import sys
@@ -96,11 +97,27 @@ def _native_control_region_release(recorder, worker_id, request_shm_name, reply_
         reply_shm.close()
 
 
-from ._harness import chip_callable, fake_chip_l3, requires_sim_binaries
+from ._harness import (
+    TEST_WALL_BUDGET_S,
+    ObservedCondition,
+    chip_callable,
+    fake_chip_l3,
+    requires_sim_binaries,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+_TEST_WALL_BUDGET_S = TEST_WALL_BUDGET_S
+
+
+def _wait_for_observed_state(predicate, failure_message: str) -> None:
+    deadline = time.monotonic() + _TEST_WALL_BUDGET_S
+    while not predicate():
+        if time.monotonic() >= deadline:
+            pytest.fail(failure_message)
+        time.sleep(0.001)
 
 
 def _make_shared_counter():
@@ -132,6 +149,25 @@ def _set_flag(buf, offset: int, value: int) -> None:
 
 def _get_flag(buf, offset: int) -> int:
     return struct.unpack_from("i", buf, offset)[0]
+
+
+class _ObservedLock:
+    def __init__(self, lock, blocked_attempt: threading.Event) -> None:
+        self._lock = lock
+        self._blocked_attempt = blocked_attempt
+        self._attempts = 0
+        self._attempts_lock = threading.Lock()
+
+    def __enter__(self):
+        with self._attempts_lock:
+            self._attempts += 1
+            if self._attempts == 2:
+                self._blocked_attempt.set()
+        self._lock.acquire()
+        return self
+
+    def __exit__(self, *_exc_info):
+        self._lock.release()
 
 
 def _roundtrip_py_callable_payload(target):
@@ -688,6 +724,8 @@ class _FakeNativeRunImpl:
         self.completed = [threading.Event(), threading.Event()]
         self.prepared = [threading.Event(), threading.Event()]
         self.launched = [threading.Event(), threading.Event()]
+        self._non_head_progress_cv = threading.Condition()
+        self._non_head_progress_counts = [0, 0]
         self.finalized = [threading.Event(), threading.Event()]
         self.launch_errors: dict[tuple[int, int], BaseException] = {}
         self.prepare_errors: dict[tuple[int, int], BaseException] = {}
@@ -705,6 +743,13 @@ class _FakeNativeRunImpl:
     def register_callable_from_blob(self, cid: int, blob_addr: int) -> None:
         self.register_calls.append((int(cid), int(blob_addr)))
         self.register_called.set()
+
+    def wait_for_non_head_progress(self, slot: int, rounds: int = 2) -> bool:
+        with self._non_head_progress_cv:
+            return self._non_head_progress_cv.wait_for(
+                lambda: self._non_head_progress_counts[slot] >= rounds,
+                timeout=5.0,
+            )
 
     def _prepare_native_run_materialized(
         self,
@@ -860,6 +905,11 @@ class _FakeNativeRunImpl:
         if target.terminal:
             return True
         if not self._runs or self._runs[0] is not target:
+            if target.activated:
+                slot = target.submission.slot_id
+                with self._non_head_progress_cv:
+                    self._non_head_progress_counts[slot] += 1
+                    self._non_head_progress_cv.notify_all()
             return False
         self._launch_front()
         self._prepare_successor()
@@ -962,6 +1012,18 @@ class _TwoFrameLoopHarness:
         self.buf = cast(memoryview, self.shm.buf)
         assert self.buf is not None
         self.mailbox_addr = _mailbox_addr(self.shm)
+        self._control_cv = threading.Condition()
+        self._control_reads = 0
+        self._mailbox_load_i32 = worker_mod._mailbox_load_i32
+
+        def observed_mailbox_load(addr: int) -> int:
+            value = self._mailbox_load_i32(addr)
+            if addr == self.mailbox_addr + _OFF_STATE and value == worker_mod._CONTROL_REQUEST:
+                with self._control_cv:
+                    self._control_reads += 1
+                    self._control_cv.notify_all()
+            return value
+
         self.digest = bytes([0x42]) * worker_mod.CALLABLE_HASH_DIGEST_BYTES
         self.cw = _FakeTwoFrameChipWorker(supports_concurrent_native_prepare=supports_concurrent_native_prepare)
         self.registry = {7: object()}
@@ -988,6 +1050,8 @@ class _TwoFrameLoopHarness:
                 "task_frame_count": 2,
             },
         )
+        self._mailbox_load_patch = patch.object(worker_mod, "_mailbox_load_i32", observed_mailbox_load)
+        self._mailbox_load_patch.start()
 
     def _frame_offset(self, index: int) -> int:
         return (1 + index) * worker_mod.MAILBOX_FRAME_SIZE
@@ -1044,19 +1108,23 @@ class _TwoFrameLoopHarness:
             assert time.monotonic() < deadline
             time.sleep(0.001)
 
-    def assert_control_stays_pending(self, duration: float = 0.05) -> None:
-        deadline = time.monotonic() + duration
-        while time.monotonic() < deadline:
-            assert _mailbox_load_i32(self.mailbox_addr + _OFF_STATE) == worker_mod._CONTROL_REQUEST
-            time.sleep(0.001)
+    def assert_control_stays_pending(self, rounds: int = 2) -> None:
+        with self._control_cv:
+            target_reads = self._control_reads + rounds
+            assert self._control_cv.wait_for(lambda: self._control_reads >= target_reads, timeout=5.0)
+        assert _mailbox_load_i32(self.mailbox_addr + _OFF_STATE) == worker_mod._CONTROL_REQUEST
 
     def publish_unregister(self, digest: Optional[bytes] = None) -> None:
+        with self._control_cv:
+            self._control_reads = 0
         digest = self.digest if digest is None else digest
         struct.pack_into("Q", self.buf, worker_mod._OFF_CALLABLE, worker_mod._CTRL_UNREGISTER)
         self.buf[worker_mod._OFF_CONTROL_CALLABLE_HASH : worker_mod._OFF_CONTROL_CALLABLE_HASH + len(digest)] = digest
         _mailbox_store_i32(self.mailbox_addr + _OFF_STATE, worker_mod._CONTROL_REQUEST)
 
     def publish_register(self, callable_obj: ChipCallable, payload_shm: SharedMemory, digest: bytes) -> None:
+        with self._control_cv:
+            self._control_reads = 0
         struct.pack_into("Q", self.buf, worker_mod._OFF_CALLABLE, worker_mod._CTRL_REGISTER)
         struct.pack_into("Q", self.buf, worker_mod._CTRL_OFF_ARG0, int(callable_obj.buffer_size()))
         self.buf[worker_mod._OFF_CONTROL_CALLABLE_HASH : worker_mod._OFF_CONTROL_CALLABLE_HASH + len(digest)] = digest
@@ -1078,9 +1146,12 @@ class _TwoFrameLoopHarness:
         assert not self.thread.is_alive()
 
     def close(self) -> None:
-        self.stop()
-        self.shm.close()
-        self.shm.unlink()
+        try:
+            self.stop()
+        finally:
+            self._mailbox_load_patch.stop()
+            self.shm.close()
+            self.shm.unlink()
 
 
 def test_two_frame_stages_b_without_native_prepare_until_a_finalizes():
@@ -1153,7 +1224,8 @@ def test_two_frame_hbg_prepares_b_while_a_runs_but_accepts_only_after_launch():
         assert _mailbox_load_i32(harness.accepted_addr(1)) == 0
 
         _mailbox_store_i32(harness.state_addr(1), worker_mod._ACTIVATE)
-        assert not harness.cw._impl.launched[1].wait(0.05)
+        assert harness.cw._impl.wait_for_non_head_progress(1)
+        assert not harness.cw._impl.launched[1].is_set()
         assert _mailbox_load_i32(harness.accepted_addr(1)) == 0
 
         harness.cw._impl.completed[0].set()
@@ -1232,11 +1304,7 @@ def test_two_frame_hbg_prepares_and_launches_reverse_ready_frames_by_dispatch_id
         harness.publish(1, 1)
         harness.start()
 
-        deadline = time.monotonic() + 5.0
-        while not any(event.is_set() for event in harness.cw._impl.launched):
-            assert time.monotonic() < deadline
-            time.sleep(0.001)
-        assert harness.cw._impl.launched[1].is_set()
+        assert harness.cw._impl.launched[1].wait(5.0)
         assert not harness.cw._impl.launched[0].is_set()
         assert [event[:2] for event in harness.cw._impl.events if event[0] in {"prepare", "launch"}] == [
             ("prepare", 1),
@@ -2504,7 +2572,11 @@ class TestLifecycle:
 
             register_thread = threading.Thread(target=do_register)
             register_thread.start()
-            register_thread.join(timeout=0.05)
+            sub_state_addr = _mailbox_addr(hw._sub_shms[0]) + _OFF_STATE
+            _wait_for_observed_state(
+                lambda: _mailbox_load_i32(sub_state_addr) == _CONTROL_REQUEST,
+                "dynamic register never published its control request to the active sub mailbox",
+            )
             assert register_thread.is_alive()
 
             _set_flag(control_shm.buf, 4, 1)
@@ -3302,15 +3374,20 @@ class TestRunHandle:
 
             second = hw.submit(second_graph)
             assert second_callback_done
-            time.sleep(0.05)
-            assert _get_flag(state_buf, 8) == 0, "prepared run dispatched before the active run became terminal"
+            assert hw._orch is not None
+            native_orch = hw._orch._o
 
             def third_graph(_o, _args, _cfg):
                 third_callback.set()
 
             submitter = threading.Thread(target=lambda: third_result.setdefault("handle", hw.submit(third_graph)))
             submitter.start()
-            assert not third_callback.wait(0.05), "third callback ran before depth-two admission freed a slot"
+            _wait_for_observed_state(
+                lambda: native_orch._begin_run_waiter_count_for_test() == 1,
+                "third submission never reached native pipeline-slot admission wait",
+            )
+            assert _get_flag(state_buf, 8) == 0, "prepared run dispatched before the active run became terminal"
+            assert not third_callback.is_set(), "third callback ran before depth-two admission freed a slot"
 
             _set_flag(state_buf, 4, 1)
             assert third_callback.wait(3.0)
@@ -3371,7 +3448,7 @@ class TestRunHandle:
             counter_shm.close()
             counter_shm.unlink()
 
-    def test_close_drains_accepted_handle_and_rejects_later_submit(self):
+    def test_close_drains_accepted_handle_and_rejects_later_submit(self, monkeypatch):
         state_shm = SharedMemory(create=True, size=4)
         state_buf = state_shm.buf
         assert state_buf is not None
@@ -3386,13 +3463,33 @@ class TestRunHandle:
             target = hw.register(delayed)
             hw.init()
             handle = hw.submit(lambda o, _args, _cfg: o.submit_sub(target))
-            releaser = threading.Thread(target=lambda: (time.sleep(0.1), _set_flag(state_buf, 0, 1)))
+            close_waiting = threading.Event()
+            run_handle_wait = RunHandle.wait
+
+            def observed_wait(self, *args, **kwargs):
+                if self is handle:
+                    close_waiting.set()
+                return run_handle_wait(self, *args, **kwargs)
+
+            monkeypatch.setattr(RunHandle, "wait", observed_wait)
+
+            close_wait_observed: list[bool] = []
+
+            def release_after_close_waits():
+                try:
+                    close_wait_observed.append(close_waiting.wait(5.0))
+                finally:
+                    _set_flag(state_buf, 0, 1)
+
+            releaser = threading.Thread(target=release_after_close_waits)
             releaser.start()
             try:
                 hw.close()
             finally:
                 _set_flag(state_buf, 0, 1)
                 releaser.join(5.0)
+            assert not releaser.is_alive()
+            assert close_wait_observed == [True], "close never waited for the accepted run handle"
             assert handle.done
             with pytest.raises(RuntimeError, match="requires an initialized"):
                 hw.submit(lambda *_args: None)
@@ -3481,9 +3578,10 @@ class TestRunHandle:
         assert worker._close_completion is not None and not worker._close_completion.incomplete
         assert native_closes == ["close"]
 
-    def test_submit_close_race_accepts_and_drains_admitted_run(self):
+    def test_submit_close_race_accepts_and_drains_admitted_run(self, monkeypatch):
         callback_entered = threading.Event()
         callback_release = threading.Event()
+        close_draining = threading.Event()
         result: dict[str, object] = {}
         hw = Worker(level=3, num_sub_workers=0)
         hw.init()
@@ -3495,7 +3593,24 @@ class TestRunHandle:
         submitter = threading.Thread(target=lambda: result.setdefault("handle", hw.submit(orch)))
         submitter.start()
         assert callback_entered.wait(3.0)
-        releaser = threading.Thread(target=lambda: (time.sleep(0.1), callback_release.set()))
+        real_monotonic = worker_mod._monotonic
+
+        def observe_close_drain():
+            if hw._lifecycle is worker_mod._Lifecycle.CLOSED:
+                close_draining.set()
+            return real_monotonic()
+
+        monkeypatch.setattr(worker_mod, "_monotonic", observe_close_drain)
+
+        close_drain_observed: list[bool] = []
+
+        def release_after_close_drains():
+            try:
+                close_drain_observed.append(close_draining.wait(5.0))
+            finally:
+                callback_release.set()
+
+        releaser = threading.Thread(target=release_after_close_drains)
         releaser.start()
         try:
             hw.close()
@@ -3503,6 +3618,8 @@ class TestRunHandle:
             callback_release.set()
             submitter.join(5.0)
             releaser.join(5.0)
+        assert not releaser.is_alive()
+        assert close_drain_observed == [True], "close never reached the accepted-run draining state"
         handle = result["handle"]
         assert isinstance(handle, RunHandle)
         assert handle.done
@@ -3634,14 +3751,21 @@ class TestRunHandle:
                 return error
 
         handle = RunHandle(cast(Worker, FakeWorker.__new__(FakeWorker)), 1, ())
+        wait_attempted = threading.Event()
+        handle._cv = ObservedCondition(  # noqa: SLF001
+            handle._cv,  # noqa: SLF001
+            enter_thread_name="completion-waiter",
+            enter_attempted=wait_attempted,
+        )
         observed: list[bool] = []
         done_thread = threading.Thread(target=lambda: observed.append(handle.done))
-        wait_thread = threading.Thread(target=handle.wait)
+        wait_thread = threading.Thread(target=handle.wait, name="completion-waiter")
         done_thread.start()
         assert done_entered.wait(3.0)
         wait_thread.start()
         try:
-            assert not wait_entered.wait(0.1)
+            assert wait_attempted.wait(3.0)
+            assert not wait_entered.is_set()
         finally:
             done_release.set()
             done_thread.join(5.0)
@@ -4915,6 +5039,8 @@ class TestRunHandle:
         worker = Worker(level=3, num_sub_workers=0)
         worker._worker = cast(Any, object())
         entered, in_backend, let_go = self._gated_domain_worker(worker, target_id=7)
+        second_waiting = threading.Event()
+        worker._domain_free_mu = _ObservedLock(worker._domain_free_mu, second_waiting)  # noqa: SLF001
 
         resources = worker_mod._RunResources()
         contested = self._retired_domain(worker, resources, "contested", 7)
@@ -4932,7 +5058,8 @@ class TestRunHandle:
             assert in_backend.wait(5.0), "owner never reached the backend"
             assert not contested.freed, "freed must stay false while the backend call is in flight"
             second.start()
-            assert not second_done.wait(0.5), "the second caller returned while the owner was still releasing"
+            assert second_waiting.wait(5.0)
+            assert not second_done.is_set(), "the second caller returned while the owner was still releasing"
             assert not contested.freed
         finally:
             let_go.set()
@@ -5293,10 +5420,16 @@ class TestDirectControlOrdering:
         control = threading.Thread(target=lambda: self._alloc(worker), daemon=True)
         control.start()
         assert in_control.wait(5.0), "the control call never reached the child"
+        submit_waiting = threading.Event()
+        worker._submit_mu._cv = ObservedCondition(  # noqa: SLF001
+            worker._submit_mu._cv,  # noqa: SLF001
+            wait_entered=submit_waiting,
+        )
 
         submitter = threading.Thread(target=lambda: worker._submit_locked(lambda *a: None, None, None), daemon=True)
         submitter.start()
-        assert not submit_entered.wait(0.5), "a run was admitted while a control call was still in flight"
+        assert submit_waiting.wait(5.0)
+        assert not submit_entered.is_set(), "a run was admitted while a control call was still in flight"
 
         release_control.set()
         control.join(5.0)
@@ -5928,12 +6061,15 @@ class TestUnreclaimedDeviceStateIsNeverSilent:
         first_interrupt = KeyboardInterrupt("after confirmed launch")
         raised: list[BaseException] = []
         hook_calls: list[int] = []
+        completion_order: list[str] = []
 
         def target(rank: int) -> None:
             if rank == 0:
                 rank_zero_entered.set()
                 assert allow_rank_zero.wait(5.0)
             calls.append(rank)
+            if rank == 0:
+                completion_order.append("rank_zero")
             if rank == 1:
                 rank_one_completed.set()
 
@@ -5953,6 +6089,7 @@ class TestUnreclaimedDeviceStateIsNeverSilent:
             except BaseException as exc:  # noqa: BLE001
                 raised.append(exc)
             finally:
+                completion_order.append("runner")
                 runner_completed.set()
 
         runner = threading.Thread(target=run_fanout)
@@ -5960,7 +6097,6 @@ class TestUnreclaimedDeviceStateIsNeverSilent:
             runner.start()
             assert rank_zero_entered.wait(5.0)
             assert rank_one_completed.wait(5.0), "the later rank was not launched after the boundary interrupt"
-            assert not runner_completed.wait(0.1), "fanout returned while rank zero still owned caller state"
             allow_rank_zero.set()
             runner.join(5.0)
 
@@ -5968,6 +6104,7 @@ class TestUnreclaimedDeviceStateIsNeverSilent:
             assert sorted(calls) == [0, 1]
             assert hook_calls == [0, 1]
             assert raised == [first_interrupt]
+            assert completion_order == ["rank_zero", "runner"]
         finally:
             allow_rank_zero.set()
             runner.join(5.0)
@@ -5980,11 +6117,13 @@ class TestUnreclaimedDeviceStateIsNeverSilent:
         first_interrupt = KeyboardInterrupt("phase advance")
         phase_advances: list[int] = []
         raised: list[BaseException] = []
+        completion_order: list[str] = []
 
         def target(rank: int) -> None:
             if rank == 0:
                 rank_zero_entered.set()
                 assert allow_rank_zero.wait(5.0)
+                completion_order.append("rank_zero")
             if rank == 1:
                 rank_one_completed.set()
 
@@ -6004,6 +6143,7 @@ class TestUnreclaimedDeviceStateIsNeverSilent:
             except BaseException as exc:  # noqa: BLE001
                 raised.append(exc)
             finally:
+                completion_order.append("runner")
                 runner_completed.set()
 
         runner = threading.Thread(target=run_fanout)
@@ -6011,13 +6151,13 @@ class TestUnreclaimedDeviceStateIsNeverSilent:
             runner.start()
             assert rank_zero_entered.wait(5.0)
             assert rank_one_completed.wait(5.0)
-            assert not runner_completed.wait(0.1), "fanout returned before the launched target released caller state"
             allow_rank_zero.set()
             runner.join(5.0)
 
             assert not runner.is_alive()
             assert phase_advances == [0, 1, 2, 3]
             assert len(raised) == 1 and raised[0] is first_interrupt
+            assert completion_order == ["rank_zero", "runner"]
         finally:
             allow_rank_zero.set()
             runner.join(5.0)
@@ -6075,12 +6215,15 @@ class TestUnreclaimedDeviceStateIsNeverSilent:
         rank_one_completed = threading.Event()
         allow_rank_zero = threading.Event()
         calls: list[int] = []
+        completion_order: list[str] = []
 
         def release(chip_idx, _request_name):
             if chip_idx == 0:
                 rank_zero_entered.set()
                 assert allow_rank_zero.wait(5.0)
             calls.append(chip_idx)
+            if chip_idx == 0:
+                completion_order.append("rank_zero")
             if chip_idx == 1:
                 rank_one_completed.set()
 
@@ -6117,6 +6260,7 @@ class TestUnreclaimedDeviceStateIsNeverSilent:
             except BaseException as exc:  # noqa: BLE001
                 raised.append(exc)
             finally:
+                completion_order.append("runner")
                 runner_completed.set()
 
         runner = real_thread(target=run_dispatch)
@@ -6124,13 +6268,13 @@ class TestUnreclaimedDeviceStateIsNeverSilent:
             runner.start()
             assert rank_one_completed.wait(5.0), "a later collective rank was not launched"
             assert rank_zero_entered.wait(5.0), "the interrupted rank was not retried"
-            assert not runner_completed.wait(0.1), "fanout returned while the retried rank still owned the request shm"
             allow_rank_zero.set()
             runner.join(5.0)
 
             assert not runner.is_alive()
             assert sorted(calls) == [0, 1]
             assert len(raised) == 1 and isinstance(raised[0], KeyboardInterrupt)
+            assert completion_order == ["rank_zero", "runner"]
         finally:
             allow_rank_zero.set()
             runner.join(5.0)
@@ -6438,15 +6582,21 @@ class TestUnreclaimedDeviceStateIsNeverSilent:
         monkeypatch.setattr(worker, "_comm_plan_rootinfo_path", lambda: "/tmp/comm-rootinfo")
         real_ensure_comm_base = worker._ensure_comm_base
         interrupt_sent = threading.Event()
+        interrupt_observed = threading.Event()
+        previous_sigint = signal.getsignal(signal.SIGINT)
+
+        def observe_interrupt(_signum, _frame):
+            interrupt_observed.set()
+            raise KeyboardInterrupt
+
+        signal.signal(signal.SIGINT, observe_interrupt)
 
         def interrupt_main() -> None:
             if interrupt_sent.is_set():
                 return
             interrupt_sent.set()
             _thread.interrupt_main()
-            # Keep the lifecycle active long enough for the main thread to
-            # observe the signal while the owned name is still live.
-            time.sleep(0.01)
+            assert interrupt_observed.wait(5.0)
 
         if operation == "comm_init":
             worker._worker = cast(Any, SimpleNamespace(control_comm_init=lambda *_args: interrupt_main()))
@@ -6499,6 +6649,7 @@ class TestUnreclaimedDeviceStateIsNeverSilent:
                 with pytest.raises(FileNotFoundError):
                     SharedMemory(name=name)
         finally:
+            signal.signal(signal.SIGINT, previous_sigint)
             monkeypatch.setattr(SharedMemory, "__init__", real_init)
             for shm in created:
                 try:

--- a/tests/ut/py/test_worker/test_release_buffer.py
+++ b/tests/ut/py/test_worker/test_release_buffer.py
@@ -32,7 +32,7 @@ from simpler.orchestrator import Orchestrator
 from simpler.task_interface import CallConfig, TaskArgs
 from simpler.worker import RunHandle, Worker, _RunResources
 
-from ._harness import fake_chip_l3
+from ._harness import ObservedCondition, fake_chip_l3
 
 _F32 = 0  # DataType.FLOAT32 value
 _OID = mint_owner_instance_id()
@@ -242,7 +242,7 @@ class TestReleaseBuffer:
         w.release_buffer(buf)  # must not raise
         assert buf.closed
 
-    def test_serializes_with_a_racing_orchestration_callback(self):
+    def test_serializes_with_a_racing_orchestration_callback(self, monkeypatch):
         # _submit_l3_locked adds a run's handle to _accepted_run_handles (worker.py:9910) BEFORE
         # its orchestration callback runs -- the callback is what eventually records
         # touched_identities via submit_next_level. Without taking _submit_mu exclusively (the same
@@ -274,6 +274,12 @@ class TestReleaseBuffer:
         callback_thread = threading.Thread(target=fake_orchestration_callback)
         callback_thread.start()
         assert entered_callback.wait(timeout=5)
+        release_waiting = threading.Event()
+        monkeypatch.setattr(
+            w._submit_mu,
+            "_cv",
+            ObservedCondition(w._submit_mu._cv, release_waiting),
+        )
 
         def try_release():
             try:
@@ -287,7 +293,8 @@ class TestReleaseBuffer:
         releaser.start()
         # release_buffer must block behind _submit_mu, not race past it while touched_identities
         # is still empty.
-        assert not release_returned.wait(timeout=0.3)
+        assert release_waiting.wait(timeout=5)
+        assert not release_returned.is_set()
 
         proceed.set()
         callback_thread.join(timeout=5)

--- a/tests/ut/py/test_worker/test_remote_zero_residual.py
+++ b/tests/ut/py/test_worker/test_remote_zero_residual.py
@@ -30,10 +30,11 @@ import simpler.worker as worker_mod
 from simpler.worker import RemoteCallable, RemoteWorkerSpec, Worker
 
 from tests.ut.py.test_callable_identity import _free_tcp_port, _RemoteL3Daemon  # noqa: PLC2701
-from tests.ut.py.test_worker._harness import hard_timeout
+from tests.ut.py.test_worker._harness import TEST_WALL_BUDGET_S, hard_timeout
 
 _SHM_ROOT = Path("/dev/shm")
-_TEST_WALL_BUDGET_S = 30.0
+_TEST_WALL_BUDGET_S = TEST_WALL_BUDGET_S
+_DEADLINE_AFTER_WATCHDOG_S = 2 * _TEST_WALL_BUDGET_S
 _CLEANUP_OBSERVE_S = 8.0
 
 pytestmark = pytest.mark.skipif(
@@ -172,8 +173,14 @@ def _start_delayed_daemon(monkeypatch, port: int, import_delay_s: float) -> _Rem
         monkeypatch.delenv("SIMPLER_TEST_REMOTE_IMPORT_DELAY_S")
 
 
+@hard_timeout(_TEST_WALL_BUDGET_S)
 def _assert_daemon_accepts_next_session(port: int) -> None:
-    worker = Worker(level=4, num_sub_workers=0, startup_timeout_s=10.0, remote_session_timeout_s=5.0)
+    worker = Worker(
+        level=4,
+        num_sub_workers=0,
+        startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S,
+        remote_session_timeout_s=_DEADLINE_AFTER_WATCHDOG_S,
+    )
     try:
         worker.add_remote_worker(_remote_spec(port))
         worker.init()
@@ -254,7 +261,12 @@ def test_later_remote_failure_reclaims_ready_session_and_full_local_tree(monkeyp
 
     monkeypatch.setattr(Worker, "_open_remote_session", observed_open)
     with _unlistening_port() as failing_port:
-        worker = Worker(level=4, num_sub_workers=1, startup_timeout_s=10.0, remote_session_timeout_s=5.0)
+        worker = Worker(
+            level=4,
+            num_sub_workers=1,
+            startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S,
+            remote_session_timeout_s=_DEADLINE_AFTER_WATCHDOG_S,
+        )
         try:
             daemon.await_ready()
             first_worker_id = worker.add_remote_worker(_remote_spec(port, num_sub_workers=1))
@@ -302,7 +314,12 @@ def test_attach_failure_reclaims_open_session_and_full_local_tree(monkeypatch):
         with monkeypatch.context() as patch:
             patch.setattr(worker_mod, "_Worker", AttachFailingWorker)
             patch.setattr(Worker, "_open_remote_session", observed_open)
-            worker = Worker(level=4, num_sub_workers=1, startup_timeout_s=10.0, remote_session_timeout_s=5.0)
+            worker = Worker(
+                level=4,
+                num_sub_workers=1,
+                startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S,
+                remote_session_timeout_s=_DEADLINE_AFTER_WATCHDOG_S,
+            )
             worker_id = worker.add_remote_worker(_remote_spec(port, num_sub_workers=1))
             with (
                 hard_timeout(_TEST_WALL_BUDGET_S),

--- a/tests/ut/py/test_worker/test_startup_readiness.py
+++ b/tests/ut/py/test_worker/test_startup_readiness.py
@@ -33,15 +33,20 @@ import os
 import struct
 import threading
 import time
+from functools import partial
+from multiprocessing import Event
 from multiprocessing.shared_memory import SharedMemory
+from typing import Protocol
 
 import pytest
+import simpler.worker as worker_mod
 from simpler.task_interface import CallConfig, TaskArgs
 from simpler.worker import RemoteCallable, RemoteWorkerSpec, RunHandle, Worker
 
 from ._harness import (
     CHIP_INIT_FAILURE,
     TEST_WALL_BUDGET_S,
+    TickingClock,
     chip_callable,
     fake_chip_l3,
     hard_timeout,
@@ -50,7 +55,76 @@ from ._harness import (
 )
 
 _TEST_WALL_BUDGET_S = TEST_WALL_BUDGET_S
+_DEADLINE_AFTER_WATCHDOG_S = 2 * _TEST_WALL_BUDGET_S
 _hard_timeout = hard_timeout
+
+
+class _EventLike(Protocol):
+    def set(self) -> None: ...
+
+    def wait(self, timeout: float = ...) -> bool: ...
+
+
+class _ManualClock:
+    def __init__(self, poll_advance_s: float = 1.0, advance_limit_s: float = 2.0) -> None:
+        self.now = 0.0
+        self.poll_advance_s = poll_advance_s
+        self.advance_limit_s = advance_limit_s
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, _seconds: float) -> None:
+        self.now = min(self.now + self.poll_advance_s, self.advance_limit_s)
+
+
+def _install_manual_worker_clock(monkeypatch, *, poll_advance_s: float = 1.0) -> _ManualClock:
+    clock = _ManualClock(poll_advance_s)
+    monkeypatch.setattr(worker_mod, "_monotonic", clock.monotonic)
+    monkeypatch.setattr(worker_mod, "_sleep", clock.sleep)
+    return clock
+
+
+class _ReleaseOnFirstReady(set):
+    def __init__(self, release: _EventLike) -> None:
+        super().__init__()
+        self._release = release
+
+    def add(self, pid: int) -> None:
+        super().add(pid)
+        self._release.set()
+
+
+def _release_failure_after_first_ready(monkeypatch, release: _EventLike) -> _ReleaseOnFirstReady:
+    ready_pids = _ReleaseOnFirstReady(release)
+    await_children_ready = Worker._await_children_ready
+
+    def observed(self, shms, pids, kind, deadline):
+        if kind == "next_level":
+            ready_pids.update(self._startup_ready_pids)
+            self._startup_ready_pids = ready_pids
+        return await_children_ready(self, shms, pids, kind, deadline)
+
+    monkeypatch.setattr(Worker, "_await_children_ready", observed)
+    return ready_pids
+
+
+def _observe_init_waiters(monkeypatch, expected: int = 1) -> threading.Event:
+    all_entered = threading.Event()
+    lock = threading.Lock()
+    entered = 0
+    wait_out_init = Worker._wait_out_init_locked
+
+    def observed(self, api):
+        nonlocal entered
+        with lock:
+            entered += 1
+            if entered == expected:
+                all_entered.set()
+        return wait_out_init(self, api)
+
+    monkeypatch.setattr(Worker, "_wait_out_init_locked", observed)
+    return all_entered
 
 
 def _raiser(exc: BaseException):
@@ -97,11 +171,10 @@ def _init_raises(*_a, **_k):
     raise RuntimeError("injected inner init failure")
 
 
-def _init_slow_raises(*_a, **_k):
-    # Delay so a healthy sibling reliably reaches READY before this one fails,
-    # exercising the graceful-close rollback path deterministically.
-    time.sleep(0.5)
-    raise RuntimeError("injected slow inner init failure")
+def _init_after_release_raises(release: _EventLike, message: str, *_a, **_k):
+    if not release.wait(_TEST_WALL_BUDGET_S):
+        raise TimeoutError("test release was not signalled after a sibling became ready")
+    raise RuntimeError(message)
 
 
 def _init_hard_exits(*_a, **_k):
@@ -213,15 +286,15 @@ class TestNextLevelStartupFailure:
         l3 = _l3_child()
         l3.init = _init_raises  # noqa: SLF001 -- test injection inherited across fork
 
-        w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=10.0)
+        w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
         w4.register(_trivial_orch)
         w4.add_worker(l3)
-        start = time.monotonic()
         try:
             with _hard_timeout(_TEST_WALL_BUDGET_S):
                 with pytest.raises(RuntimeError, match="injected inner init failure"):
                     w4.init()
-            assert time.monotonic() - start < _TEST_WALL_BUDGET_S
+            assert w4._next_level_pids == []
+            assert w4._next_level_shms == []
         finally:
             w4.close()
 
@@ -230,7 +303,7 @@ class TestNextLevelStartupFailure:
         l3 = _l3_child()
         l3.init = _init_hard_exits  # noqa: SLF001
 
-        w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=10.0)
+        w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
         w4.register(_trivial_orch)
         w4.add_worker(l3)
         try:
@@ -240,26 +313,27 @@ class TestNextLevelStartupFailure:
         finally:
             w4.close()
 
-    def test_startup_deadline_fires_on_hung_child(self):
+    def test_startup_deadline_fires_on_hung_child(self, monkeypatch):
         """A child that hangs in init trips the startup deadline, not an infinite spin."""
+        clock = _install_manual_worker_clock(monkeypatch)
         l3 = _l3_child()
         l3.init = _init_hangs  # noqa: SLF001
 
         w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=1.5)
         w4.register(_trivial_orch)
         w4.add_worker(l3)
-        start = time.monotonic()
         try:
             with _hard_timeout(_TEST_WALL_BUDGET_S):
                 with pytest.raises(RuntimeError, match="deadline"):
                     w4.init()
-            elapsed = time.monotonic() - start
-            assert 1.5 <= elapsed < _TEST_WALL_BUDGET_S
+            assert clock.now > 1.5
+            assert w4._next_level_pids == []
         finally:
             w4.close()
 
     def test_failed_startup_reaps_children_no_leak(self, monkeypatch):
         """After a startup failure the forked children are killed and reaped."""
+        _install_manual_worker_clock(monkeypatch)
         l3 = _l3_child()
         l3.init = _init_hangs  # noqa: SLF001
 
@@ -293,24 +367,30 @@ class TestNextLevelStartupFailure:
         finally:
             w4.close()
 
-    def test_ready_sibling_closed_gracefully_on_sibling_failure(self):
+    def test_ready_sibling_closed_gracefully_on_sibling_failure(self, monkeypatch):
         """A child that reached READY is closed gracefully (not SIGKILLed) when a sibling fails.
 
         The healthy L3 owns a nested sub-worker mailbox shm only it can unlink;
         graceful SHUTDOWN lets it clean up. The failing L3 is delayed so the
         healthy one is reliably READY first.
         """
+        allow_failure = Event()
         good = _l3_child(num_sub_workers=1)
         bad = _l3_child(num_sub_workers=1)
-        bad.init = _init_slow_raises  # noqa: SLF001
+        bad.init = partial(  # noqa: SLF001
+            _init_after_release_raises,
+            allow_failure,
+            "injected sibling init failure",
+        )
 
-        w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=20.0)
+        w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
+        ready_pids = _release_failure_after_first_ready(monkeypatch, allow_failure)
         w4.register(_trivial_orch)
         w4.add_worker(good)
         w4.add_worker(bad)
         try:
             with _hard_timeout(_TEST_WALL_BUDGET_S):
-                with pytest.raises(RuntimeError, match="slow inner init failure"):
+                with pytest.raises(RuntimeError, match="sibling init failure"):
                     w4.init()
 
             report = w4._last_rollback
@@ -319,17 +399,25 @@ class TestNextLevelStartupFailure:
             # gracefully (SHUTDOWN + reaped), not SIGKILLed.
             assert len(report["graceful"]) >= 1
             assert set(report["graceful"]).isdisjoint(report["killed"])
+            assert set(report["graceful"]) == ready_pids
             assert w4._next_level_pids == []
         finally:
+            allow_failure.set()
             w4.close()
 
-    def test_second_child_failure_reaps_first(self):
+    def test_second_child_failure_reaps_first(self, monkeypatch):
         """When one of several next-level children fails, all are torn down."""
+        allow_failure = Event()
         good = _l3_child()
         bad = _l3_child()
-        bad.init = _init_raises  # noqa: SLF001
+        bad.init = partial(  # noqa: SLF001
+            _init_after_release_raises,
+            allow_failure,
+            "injected inner init failure",
+        )
 
-        w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=10.0)
+        w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
+        ready_pids = _release_failure_after_first_ready(monkeypatch, allow_failure)
         w4.register(_trivial_orch)
         w4.add_worker(good)
         w4.add_worker(bad)
@@ -337,8 +425,14 @@ class TestNextLevelStartupFailure:
             with _hard_timeout(_TEST_WALL_BUDGET_S):
                 with pytest.raises(RuntimeError, match="injected inner init failure"):
                     w4.init()
+            report = w4._last_rollback
+            assert report is not None
+            assert set(report["graceful"]) == ready_pids
+            assert set(report["graceful"]).isdisjoint(report["killed"])
             assert w4._next_level_pids == []
+            assert w4._next_level_shms == []
         finally:
+            allow_failure.set()
             w4.close()
 
 
@@ -358,7 +452,7 @@ class TestSubStartupFailure:
 
         monkeypatch.setattr(worker_mod, "_make_local_identity_tables", _boom)
 
-        w3 = Worker(level=3, num_sub_workers=1, startup_timeout_s=10.0)
+        w3 = Worker(level=3, num_sub_workers=1, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
         w3.register(lambda args: None)
         try:
             with _hard_timeout(_TEST_WALL_BUDGET_S):
@@ -389,6 +483,7 @@ class TestReadyBarrierHappyPath:
     children) came up during the parent's init(), not on first run.
     """
 
+    @_hard_timeout(_TEST_WALL_BUDGET_S)
     def test_l4_l3_tree_comes_up_and_runs(self):
         counter_shm, counter_buf = _make_shared_counter()
         w4 = None
@@ -399,7 +494,7 @@ class TestReadyBarrierHappyPath:
             def l3_orch(orch, args, config):
                 orch.submit_sub(l3_sub)
 
-            w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=30.0)
+            w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
             l3_handle = w4.register(l3_orch)
             l3_worker_id = w4.add_worker(l3)
             w4.init()
@@ -415,6 +510,7 @@ class TestReadyBarrierHappyPath:
             counter_shm.close()
             counter_shm.unlink()
 
+    @_hard_timeout(_TEST_WALL_BUDGET_S)
     def test_multiple_l3_children_all_ready(self):
         """Two next-level children both pass the barrier and dispatch.
 
@@ -437,7 +533,7 @@ class TestReadyBarrierHappyPath:
             def l3b_orch(orch, args, config):
                 orch.submit_sub(b_sub)
 
-            w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=30.0)
+            w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
             ha = w4.register(l3a_orch)
             hb = w4.register(l3b_orch)
             l3a_worker_id = w4.add_worker(l3a)
@@ -488,9 +584,10 @@ class TestEagerInitContract:
         assert hw._sub_pids == []
         assert hw._worker is None
 
+    @_hard_timeout(_TEST_WALL_BUDGET_S)
     def test_l4_l3_sub_subtree_ready_after_init_no_run(self):
         l3 = _l3_child(num_sub_workers=1)
-        w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=30.0)
+        w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
         w4.register(_trivial_orch)
         w4.add_worker(l3)
         w4.init()
@@ -623,9 +720,10 @@ class TestApiLinearizationDuringInit:
     def test_register_blocks_during_initializing_then_completes(self, monkeypatch):
         entered = threading.Event()
         release = threading.Event()
+        register_waiting = _observe_init_waiters(monkeypatch)
         monkeypatch.setattr(Worker, "_start_hierarchical", self._pause_start(entered, release))
 
-        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=30.0)
+        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
         w.register(lambda args: None)
         init_err: list = []
         proceed = threading.Event()
@@ -642,16 +740,13 @@ class TestApiLinearizationDuringInit:
             with _hard_timeout(_TEST_WALL_BUDGET_S):
                 assert entered.wait(3.0)
                 reg_out: list[object] = []
-                reg_started = threading.Event()
 
                 def do_reg():
-                    reg_started.set()
                     reg_out.append(w.register(lambda args: None))
 
                 rt = threading.Thread(target=do_reg)
                 rt.start()
-                assert reg_started.wait(3.0)
-                time.sleep(0.3)
+                assert register_waiting.wait(3.0)
                 assert reg_out == [], "register must block while INITIALIZING"
                 release.set()
                 rt.join(10.0)  # register completes post-READY (implies init done)
@@ -665,6 +760,7 @@ class TestApiLinearizationDuringInit:
     def test_init_failure_wakes_register_waiter_with_startup_error(self, monkeypatch):
         entered = threading.Event()
         release = threading.Event()
+        register_waiting = _observe_init_waiters(monkeypatch)
 
         def boom(_self):
             entered.set()
@@ -673,7 +769,7 @@ class TestApiLinearizationDuringInit:
 
         monkeypatch.setattr(Worker, "_start_hierarchical", boom)
 
-        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=30.0)
+        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
         w.register(lambda args: None)
         init_err: list = []
         it = threading.Thread(target=lambda: init_err.append(_run_catch(w.init)))
@@ -682,16 +778,13 @@ class TestApiLinearizationDuringInit:
             with _hard_timeout(_TEST_WALL_BUDGET_S):
                 assert entered.wait(3.0)
                 reg_err: list = []
-                reg_started = threading.Event()
 
                 def do_reg():
-                    reg_started.set()
                     reg_err.append(_run_catch(lambda: w.register(lambda args: None)))
 
                 rt = threading.Thread(target=do_reg)
                 rt.start()
-                assert reg_started.wait(3.0)
-                time.sleep(0.2)
+                assert register_waiting.wait(3.0)
                 release.set()
                 it.join(10.0)
                 rt.join(10.0)
@@ -707,7 +800,7 @@ class TestApiLinearizationDuringInit:
         release = threading.Event()
         monkeypatch.setattr(Worker, "_start_hierarchical", self._pause_start(entered, release))
 
-        w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=30.0)
+        w4 = Worker(level=4, num_sub_workers=0, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
         w4.register(_trivial_orch)
         w4.add_worker(_l3_child())
         proceed = threading.Event()
@@ -738,10 +831,19 @@ class TestApiLinearizationDuringInit:
 
         entered = threading.Event()
         release = threading.Event()
+        cancel_latched = threading.Event()
         monkeypatch.setattr(Worker, "_start_hierarchical", self._pause_start(entered, release))
 
-        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=30.0)
+        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
         w.register(lambda args: None)
+        real_monotonic = worker_mod._monotonic
+
+        def observe_cancel():
+            if w._cancel_token:
+                cancel_latched.set()
+            return real_monotonic()
+
+        monkeypatch.setattr(worker_mod, "_monotonic", observe_cancel)
 
         def owner_body():
             _run_catch(w.init)
@@ -755,9 +857,7 @@ class TestApiLinearizationDuringInit:
                 close_result: list = []
                 ct = threading.Thread(target=lambda: close_result.append(_run_catch(w.close)))
                 ct.start()
-                # Wait for cancel token to latch, then release the init thread.
-                while not w._cancel_token:
-                    time.sleep(0.001)
+                assert cancel_latched.wait(3.0)
                 release.set()
                 ct.join(10.0)
                 it.join(10.0)
@@ -1111,6 +1211,7 @@ class TestLevel2Lifecycle:
         interrupt = SystemExit("before close outcome publication")
         entered = threading.Event()
         release = threading.Event()
+        joiner_waiting = threading.Event()
         attempt_type = worker_mod._CloseAttempt
 
         class _InterruptBeforeOutcome(attempt_type):
@@ -1128,6 +1229,13 @@ class TestLevel2Lifecycle:
                     raise interrupt
                 return super().publish(error, incomplete)
 
+            @property
+            def done(self):
+                done = super().done
+                if not done:
+                    joiner_waiting.set()
+                return done
+
         monkeypatch.setattr(worker_mod, "_CloseAttempt", _InterruptBeforeOutcome)
         w = self._make_l2(monkeypatch)
         owner_result: list = []
@@ -1143,7 +1251,7 @@ class TestLevel2Lifecycle:
         try:
             assert entered.wait(5.0)
             joiner_thread.start()
-            time.sleep(0.1)
+            assert joiner_waiting.wait(5.0)
             assert joiner_thread.is_alive()
             release.set()
             owner_thread.join(5.0)
@@ -1226,23 +1334,25 @@ class TestLevel2Lifecycle:
 
         import simpler.worker as worker_mod  # noqa: PLC0415
 
-        monkeypatch.setattr(worker_mod, "_ROLLBACK_GRACEFUL_TIMEOUT_S", 1.0)
+        monkeypatch.setattr(worker_mod, "_CLOSE_CHILD_REAP_TIMEOUT_S", 1.0)
+        clock = _ManualClock(poll_advance_s=0.0, advance_limit_s=10.0)
+        monkeypatch.setattr(worker_mod, "_monotonic", clock.monotonic)
         w = Worker(level=3, num_sub_workers=0)
         w._worker = types.SimpleNamespace(close=lambda: None)  # look "started" for the L3 branch
 
-        # A slow pre-child cleanup step (runs before the SHUTDOWN broadcast).
-        monkeypatch.setattr(Worker, "_release_all_buffers", lambda self: time.sleep(0.6))
+        def consume_pre_child_budget(_self):
+            clock.now += 0.6
+
+        monkeypatch.setattr(Worker, "_release_all_buffers", consume_pre_child_budget)
         captured: dict = {}
 
         def capture_reap(groups, deadline):
-            captured["remaining"] = deadline - time.monotonic()
+            captured["remaining"] = deadline - clock.monotonic()
 
         monkeypatch.setattr(Worker, "_reap_child_groups", staticmethod(capture_reap))
         with _hard_timeout(_TEST_WALL_BUDGET_S):
             w._teardown_ready_tree()
-        # The reap got ~full grace (1.0s), not 1.0 - 0.6 left over from a deadline
-        # fixed at teardown entry.
-        assert captured["remaining"] > 0.7
+        assert captured["remaining"] == pytest.approx(1.0)
 
     def test_reap_child_groups_stuck_child_no_starvation(self, monkeypatch):
         # A stuck child in one group must not starve the reap of healthy children
@@ -1274,11 +1384,12 @@ class TestLevel2Lifecycle:
             return (pid, 0)  # reaped, clean exit
 
         monkeypatch.setattr(worker_mod.os, "waitpid", fake_waitpid)
+        clock = _install_manual_worker_clock(monkeypatch)
         sub_shms, sub_pids = [_FakeShm()], [stuck_pid]
         chip_shms, chip_pids = [_FakeShm()], [90002]
         next_shms, next_pids = [_FakeShm()], [90003]
         groups = [(sub_shms, sub_pids), (chip_shms, chip_pids), (next_shms, next_pids)]
-        deadline = time.monotonic() + 1.0
+        deadline = clock.monotonic() + 1.0
         with _hard_timeout(_TEST_WALL_BUDGET_S):
             err = _run_catch(lambda: Worker._reap_child_groups(groups, deadline))  # type: ignore[arg-type]
         # The wedged child is a reported survivor, kept in its group...
@@ -1310,7 +1421,17 @@ class TestLevel2Lifecycle:
 
         entered = threading.Event()
         release = threading.Event()
+        joiner_waiting = threading.Event()
         orig_teardown = Worker._teardown_ready_tree
+        attempt_type = worker_mod._CloseAttempt
+
+        class _ObservedCloseAttempt(attempt_type):
+            @property
+            def done(self):
+                done = super().done
+                if not done:
+                    joiner_waiting.set()
+                return done
 
         def paused_teardown(self):
             entered.set()
@@ -1318,6 +1439,7 @@ class TestLevel2Lifecycle:
             return orig_teardown(self)
 
         monkeypatch.setattr(Worker, "_teardown_ready_tree", paused_teardown)
+        monkeypatch.setattr(worker_mod, "_CloseAttempt", _ObservedCloseAttempt)
         w = self._make_l2(monkeypatch)
         results: dict = {}
 
@@ -1334,7 +1456,7 @@ class TestLevel2Lifecycle:
                 joiner: list = []
                 jt = threading.Thread(target=lambda: joiner.append(_run_catch(w.close)))
                 jt.start()
-                time.sleep(0.2)  # joiner parks on the in-flight attempt
+                assert joiner_waiting.wait(3.0)
                 assert w._close_completion is not None and not w._close_completion.done
                 release.set()
                 ot.join(10.0)
@@ -1353,6 +1475,7 @@ class TestLevel2Lifecycle:
 
         entered = threading.Event()
         release = threading.Event()
+        drain_started = threading.Event()
 
         def paused_run(self, *_a, **_k):
             entered.set()
@@ -1368,11 +1491,22 @@ class TestLevel2Lifecycle:
             try:
                 assert entered.wait(3.0)  # run() admitted, holding a lease
                 assert w._active_ops == 1
-                releaser = threading.Thread(target=lambda: (time.sleep(0.5), release.set()))
+                real_monotonic = worker_mod._monotonic
+
+                def observe_drain_start():
+                    drain_started.set()
+                    return real_monotonic()
+
+                monkeypatch.setattr(worker_mod, "_monotonic", observe_drain_start)
+
+                def release_after_drain_starts():
+                    assert drain_started.wait(10.0)
+                    assert w._active_ops == 1
+                    release.set()
+
+                releaser = threading.Thread(target=release_after_drain_starts)
                 releaser.start()
-                t0 = time.monotonic()
                 w.close()  # owner close: drains the lease before teardown
-                assert time.monotonic() - t0 >= 0.4
                 assert w._lifecycle is worker_mod._Lifecycle.CLOSED
                 assert w._active_ops == 0
                 releaser.join(5.0)
@@ -1424,6 +1558,8 @@ class TestLevel2Lifecycle:
             try:
                 assert entered.wait(3.0)
                 assert w._active_ops == 1
+                clock = TickingClock()
+                monkeypatch.setattr(worker_mod, "_monotonic", clock.monotonic)
                 err = _run_catch(w.close)  # owner drains, times out at 0.5s
                 assert isinstance(err, TimeoutError)
                 assert w._lifecycle is worker_mod._Lifecycle.CLOSED  # admission fenced
@@ -1459,6 +1595,8 @@ class TestLevel2Lifecycle:
             rt.start()
             try:
                 assert entered.wait(3.0)
+                clock = TickingClock()
+                monkeypatch.setattr(worker_mod, "_monotonic", clock.monotonic)
                 # First close: times out, CLOSED + incomplete, native intact.
                 assert isinstance(_run_catch(w.close), TimeoutError)
                 assert w._chip_worker is not None
@@ -1525,12 +1663,14 @@ class TestLevel2Lifecycle:
         w = self._make_l2_with_chip(monkeypatch, _PausingChip)
         errs: list = []
         proceed = threading.Event()
+        owner_finished = threading.Event()
         state: dict = {}
 
         def owner_body():
             errs.append(_run_catch(w.init))
             state["initialized"] = w._initialized
             state["build"] = build_count["n"]
+            owner_finished.set()
             proceed.wait(10.0)
             _run_catch(w.close)  # the winning (owner) thread closes
 
@@ -1544,10 +1684,7 @@ class TestLevel2Lifecycle:
                 assert isinstance(err2, RuntimeError)
                 assert "in progress" in str(err2)
                 release.set()
-                # Wait for the owner to finish init (it then parks on `proceed`).
-                deadline = time.monotonic() + 10.0
-                while "initialized" not in state and time.monotonic() < deadline:
-                    time.sleep(0.01)
+                assert owner_finished.wait(10.0)
                 assert errs == [None]
                 assert state["initialized"] is True
                 assert state["build"] == 1
@@ -1565,6 +1702,7 @@ class TestLevel2Lifecycle:
 
         entered = threading.Event()
         release = threading.Event()
+        cancel_latched = threading.Event()
         finalized = {"n": 0}
 
         class _PausingChip:
@@ -1579,6 +1717,14 @@ class TestLevel2Lifecycle:
                 finalized["n"] += 1
 
         w = self._make_l2_with_chip(monkeypatch, _PausingChip)
+        real_monotonic = worker_mod._monotonic
+
+        def observe_cancel():
+            if w._cancel_token:
+                cancel_latched.set()
+            return real_monotonic()
+
+        monkeypatch.setattr(worker_mod, "_monotonic", observe_cancel)
         init_err: list = []
 
         def owner_body():
@@ -1593,9 +1739,7 @@ class TestLevel2Lifecycle:
                 close_result: list = []
                 ct = threading.Thread(target=lambda: close_result.append(_run_catch(w.close)))
                 ct.start()
-                # Wait for cancel token to latch, then release init.
-                while not w._cancel_token:
-                    time.sleep(0.001)
+                assert cancel_latched.wait(3.0)
                 release.set()
                 ct.join(10.0)
                 t1.join(10.0)
@@ -1621,16 +1765,21 @@ class TestChipStartupFailure:
 
     def test_chip_init_failure_raises_bounded(self, monkeypatch):
         # chip-only L3; the chip forks from device_ids
-        with fake_chip_l3(monkeypatch, script="raises", init=False, startup_timeout_s=10.0) as l3:
+        with fake_chip_l3(
+            monkeypatch,
+            script="raises",
+            init=False,
+            startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S,
+        ) as l3:
             with pytest.raises(RuntimeError, match=CHIP_INIT_FAILURE):
                 l3.init()
 
     def test_chip_init_hang_trips_deadline(self, monkeypatch):
-        start = time.monotonic()
+        clock = _install_manual_worker_clock(monkeypatch)
         with fake_chip_l3(monkeypatch, script="hangs", init=False, startup_timeout_s=1.5) as l3:
             with pytest.raises(RuntimeError, match="deadline"):
                 l3.init()
-            assert 1.5 <= time.monotonic() - start < _TEST_WALL_BUDGET_S
+            assert clock.now > 1.5
 
 
 class TestEligibleTargetPrecheck:
@@ -1871,9 +2020,10 @@ class TestFailureSurfacing:
         entered = threading.Event()
         release = threading.Event()
         original = RuntimeError("distinctive start failure")
+        waiters_parked = _observe_init_waiters(monkeypatch, expected=3)
         monkeypatch.setattr(Worker, "_start_hierarchical", self._fail_start(entered, release, original))
 
-        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=30.0)
+        w = Worker(level=3, num_sub_workers=1, startup_timeout_s=_DEADLINE_AFTER_WATCHDOG_S)
         init_err: list = []
         it = threading.Thread(target=lambda: init_err.append(_run_catch(w.init)))
         it.start()
@@ -1881,18 +2031,15 @@ class TestFailureSurfacing:
             with _hard_timeout(_TEST_WALL_BUDGET_S):
                 assert entered.wait(3.0)
                 reg_errs: list = []
-                started = threading.Event()
                 n = 3
 
                 def do_reg():
-                    started.set()
                     reg_errs.append(_run_catch(lambda: w.register(lambda args: None)))
 
                 threads = [threading.Thread(target=do_reg) for _ in range(n)]
                 for t in threads:
                     t.start()
-                assert started.wait(3.0)
-                time.sleep(0.3)  # let the waiters park on the epoch condition
+                assert waiters_parked.wait(3.0)
                 release.set()
                 for t in threads:
                     t.join(10.0)

--- a/tests/ut/py/test_worker/test_worker_chip_orch_comm.py
+++ b/tests/ut/py/test_worker/test_worker_chip_orch_comm.py
@@ -75,6 +75,16 @@ _TASK_INTERFACE_CPP = Path(__file__).resolve().parents[4] / "python" / "bindings
 _WORKER_PY = Path(__file__).resolve().parents[4] / "python" / "simpler" / "worker.py"
 _ACCESS_ONBOARD_VMM = 1
 _ACCESS_SIM_POSIX_SHM = 2
+_TEST_WALL_BUDGET_S = 30.0
+_TEST_WALL_BUDGET_NS = int(_TEST_WALL_BUDGET_S * 1_000_000_000)
+
+
+def _wait_until(predicate, failure_message: str) -> None:
+    deadline = time.monotonic() + _TEST_WALL_BUDGET_S
+    while not predicate():
+        if time.monotonic() >= deadline:
+            pytest.fail(failure_message)
+        time.sleep(0.001)
 
 
 def test_worker_host_mapped_backend_types_are_removed_from_native_implementation():
@@ -1237,15 +1247,18 @@ def test_worker_host_mapped_counter_wait_releases_gil_for_python_notifier():
         handle = int(owner)
 
         def notify() -> None:
-            time.sleep(0.05)
+            _wait_until(
+                lambda: _task_interface_ext._worker_host_mapped_region_active_leases(handle) == 1,
+                "counter wait never acquired its mapped-region lease",
+            )
             _task_interface_ext._worker_host_mapped_counter_notify(handle, 0, 1, int(NotifyOp.Set))
 
         with ThreadPoolExecutor(max_workers=1) as executor:
             future = executor.submit(notify)
             status, error_kind, observed, matched, message = _task_interface_ext._worker_host_mapped_counter_wait(
-                handle, 0, 1, int(WaitCmp.EQ), 1_000_000_000
+                handle, 0, 1, int(WaitCmp.EQ), _TEST_WALL_BUDGET_NS
             )
-            future.result(timeout=1.0)
+            future.result(timeout=_TEST_WALL_BUDGET_S)
 
         assert (status, error_kind, observed, matched, message) == (0, 0, 1, True, "")
     finally:
@@ -1263,15 +1276,18 @@ def test_region_neutral_counter_wait_releases_gil_for_python_notifier():
         handle = int(owner)
 
         def notify() -> None:
-            time.sleep(0.05)
+            _wait_until(
+                lambda: _task_interface_ext._region_active_leases(handle) == 1,
+                "counter wait never acquired its mapped-region lease",
+            )
             _task_interface_ext._region_counter_notify(handle, 0, 1, int(NotifyOp.Set))
 
         with ThreadPoolExecutor(max_workers=1) as executor:
             future = executor.submit(notify)
             status, error_kind, observed, matched, message = _task_interface_ext._region_counter_wait(
-                handle, 0, 1, int(WaitCmp.EQ), 1_000_000_000
+                handle, 0, 1, int(WaitCmp.EQ), _TEST_WALL_BUDGET_NS
             )
-            future.result(timeout=1.0)
+            future.result(timeout=_TEST_WALL_BUDGET_S)
 
         assert (status, error_kind, observed, matched, message) == (0, 0, 1, True, "")
     finally:
@@ -1332,13 +1348,13 @@ def test_region_neutral_byte_copy_holds_active_lease_until_native_copy_returns()
 
         with ThreadPoolExecutor(max_workers=1) as executor:
             future = executor.submit(delayed_copy_to)
-            deadline = time.monotonic() + 1.0
-            while _task_interface_ext._region_active_leases(handle) != 1:
-                assert time.monotonic() < deadline, "byte copy never acquired its mapped-region lease"
-                time.sleep(0.001)
+            _wait_until(
+                lambda: _task_interface_ext._region_active_leases(handle) == 1,
+                "byte copy never acquired its mapped-region lease",
+            )
 
             assert _task_interface_ext._region_active_leases(handle) == 1
-            future.result(timeout=1.0)
+            future.result(timeout=_TEST_WALL_BUDGET_S)
 
         assert _task_interface_ext._region_active_leases(handle) == 0
         assert bytes(cast(memoryview, shm.buf)[16:24]) == bytes(range(1, 9))
@@ -1416,7 +1432,7 @@ def test_region_neutral_concurrent_closes_wait_for_in_flight_counter_wait():
         close_done = [threading.Event(), threading.Event()]
 
         def wait_for_counter():
-            return _task_interface_ext._region_counter_wait(handle, 0, 1, int(WaitCmp.EQ), 1_000_000_000)
+            return _task_interface_ext._region_counter_wait(handle, 0, 1, int(WaitCmp.EQ), _TEST_WALL_BUDGET_NS)
 
         def close_mapping(index: int) -> None:
             close_entered[index].set()
@@ -1425,21 +1441,25 @@ def test_region_neutral_concurrent_closes_wait_for_in_flight_counter_wait():
 
         with ThreadPoolExecutor(max_workers=3) as executor:
             wait_future = executor.submit(wait_for_counter)
-            deadline = time.monotonic() + 1.0
-            while _task_interface_ext._region_active_leases(handle) != 1:
-                assert time.monotonic() < deadline, "counter wait never acquired its mapped-region lease"
-                time.sleep(0.001)
+            _wait_until(
+                lambda: _task_interface_ext._region_active_leases(handle) == 1,
+                "counter wait never acquired its mapped-region lease",
+            )
 
             close_futures = [executor.submit(close_mapping, index) for index in range(2)]
-            assert all(event.wait(1.0) for event in close_entered)
-            assert not any(event.wait(0.05) for event in close_done), (
+            assert all(event.wait(_TEST_WALL_BUDGET_S) for event in close_entered)
+            _wait_until(
+                lambda: _task_interface_ext._region_closing_for_test(handle),
+                "mapped-region close never started waiting for the active lease",
+            )
+            assert not any(event.is_set() for event in close_done), (
                 "a concurrent close returned while a native operation still held the region"
             )
 
             cast(memoryview, shm.buf)[:4] = b"\x01\x00\x00\x00"
-            assert wait_future.result(timeout=1.0) == (0, 0, 1, True, "")
+            assert wait_future.result(timeout=_TEST_WALL_BUDGET_S) == (0, 0, 1, True, "")
             for close_future in close_futures:
-                close_future.result(timeout=1.0)
+                close_future.result(timeout=_TEST_WALL_BUDGET_S)
 
         with pytest.raises(RuntimeError, match="closed or unknown"):
             _task_interface_ext._region_counter_test(handle, 0, 1, int(WaitCmp.EQ))
@@ -1585,7 +1605,9 @@ def test_worker_host_mapped_concurrent_closes_wait_for_in_flight_counter_wait():
         close_done = [threading.Event(), threading.Event()]
 
         def wait_for_counter():
-            return _task_interface_ext._worker_host_mapped_counter_wait(handle, 0, 1, int(WaitCmp.EQ), 1_000_000_000)
+            return _task_interface_ext._worker_host_mapped_counter_wait(
+                handle, 0, 1, int(WaitCmp.EQ), _TEST_WALL_BUDGET_NS
+            )
 
         def close_mapping(index: int) -> None:
             close_entered[index].set()
@@ -1594,21 +1616,25 @@ def test_worker_host_mapped_concurrent_closes_wait_for_in_flight_counter_wait():
 
         with ThreadPoolExecutor(max_workers=3) as executor:
             wait_future = executor.submit(wait_for_counter)
-            deadline = time.monotonic() + 1.0
-            while _task_interface_ext._worker_host_mapped_region_active_leases(handle) != 1:
-                assert time.monotonic() < deadline, "counter wait never acquired its mapped-region lease"
-                time.sleep(0.001)
+            _wait_until(
+                lambda: _task_interface_ext._worker_host_mapped_region_active_leases(handle) == 1,
+                "counter wait never acquired its mapped-region lease",
+            )
 
             close_futures = [executor.submit(close_mapping, index) for index in range(2)]
-            assert all(event.wait(1.0) for event in close_entered)
-            assert not any(event.wait(0.05) for event in close_done), (
+            assert all(event.wait(_TEST_WALL_BUDGET_S) for event in close_entered)
+            _wait_until(
+                lambda: _task_interface_ext._worker_host_mapped_region_closing_for_test(handle),
+                "L3 Host mapped-region close never started waiting for the active lease",
+            )
+            assert not any(event.is_set() for event in close_done), (
                 "a concurrent close returned while a native operation still held the region"
             )
 
             cast(memoryview, shm.buf)[:4] = b"\x01\x00\x00\x00"
-            assert wait_future.result(timeout=1.0) == (0, 0, 1, True, "")
+            assert wait_future.result(timeout=_TEST_WALL_BUDGET_S) == (0, 0, 1, True, "")
             for close_future in close_futures:
-                close_future.result(timeout=1.0)
+                close_future.result(timeout=_TEST_WALL_BUDGET_S)
 
         with pytest.raises(RuntimeError, match="closed or unknown"):
             _task_interface_ext._worker_host_mapped_counter_test(handle, 0, 1, int(WaitCmp.EQ))


### PR DESCRIPTION
## Summary

- Replace scheduling-by-`sleep`, short negative waits, and narrow elapsed-time assertions with explicit state/event ordering.
- Add private test seams for the few states that were otherwise only observable through elapsed wall time.
- Keep real time where timeout behavior is the contract, but separate the semantic assertion from a deliberately broad hang watchdog.
- Make each replacement observation discriminating: it fires only after the behavior under test has reached a stable blocking point or completed a full decision round.

## Why

The selection rule for this batch is:

> If logical state and event ordering stay unchanged, changing how quickly the environment executes code, wakes waiters, or advances processes relative to a real-time deadline must not change the test result.

This is broader than machine load. CPU scheduling, VM/container quotas, process startup, IPC and shared-memory latency, timer wakeups, debug/sanitizer/coverage builds, and other server differences can all change progress relative to `monotonic`/`steady_clock` deadlines. A monotonic clock avoids clock rollback, but it still measures real elapsed time and can therefore participate in this race.

`test_second_child_failure_reaps_first` is included for that reason. Its expected result was an injected child-init failure, but the production startup deadline started before child creation and readiness. On a slower environment, the same logical child sequence could instead surface a startup timeout. The test now establishes `first child READY -> release second child failure` explicitly, uses a controlled clock for the unrelated startup deadline, and verifies graceful/forced rollback sets plus PID and shared-memory cleanup.

## What changed

### Startup, cleanup, and host concurrency

- Add private `_monotonic()` / `_sleep()` adapters in `worker.py`; production still delegates to the real monotonic clock and sleep.
- Drive deadline-specific unit tests with manual/ticking clocks.
- Use `Event`, `Condition`, observed locks, mailbox state, and native waiter state to establish execution order before asserting that another action is blocked.
- Strengthen startup rollback checks without deleting coverage.

In particular, the two HostWorker cases now wait for their actual blocking points:

- post-start registration waits until the sub-worker mailbox is in `CONTROL_REQUEST`;
- the depth-two test waits until the third submission is inside native pipeline-slot admission.

The review-sensitive observations also establish the decision boundary itself:

- admission-fence tests release a parked registry transaction only after `close()` enters the lifecycle condition wait with an active operation lease;
- the two-frame HBG test observes two completed non-head progress rounds before asserting that the successor has not launched;
- registry-control deferral tests observe two additional top-level mailbox-loop reads before asserting that the request remains pending.

### Private native observations

- expose mapped-region closing state and the current run-failure state as read-only private test helpers;
- expose the number of native `begin_run` admission waiters;
- record the frame-read deadline source used by the socket transport;
- return an internal mailbox wait reason (`value_mismatch`, `woken`, `timed_out`, etc.) to tests.

These are private test seams. This change adds no environment variable, user-facing Python API, wire-format change, or resource-ownership change.

### Timeout contracts retained

This does **not** remove all real-clock tests. Real time remains where it is the behavior under test or a broad deadlock watchdog, including the native mailbox timeout and stalled socket write smoke tests.

For the MPI mailbox case:

- the native test distinguishes immediate value mismatch from an actual timeout;
- the 50 ms timeout keeps a 5 second end-to-end watchdog, so a regression to multi-second/unbounded waiting still fails without relying on a tight machine-speed bound;
- a separate wrapper test calls `MpiGroupMailbox.wait_request_state()` and verifies the exact native address (including request-state offset), expected value, and `timeout_s` forwarding.

Mutation checks confirmed that a forced 6 second native wait is rejected by the watchdog and that replacing the Python wrapper with a broken implementation is rejected by the forwarding test.

## Scope boundaries

- No tests were deleted in this batch.
- Pure conversion tests, `timeout=0` semantics, and wide OS/process watchdogs were not changed merely because they mention time.
- Timeout-contract smoke tests remain real-time; only narrow environment-speed oracles were removed.
- No NPU/DCMI access is needed for this device-free unit-test change.
- `test_reap_deadline_starts_after_shutdown_broadcast` now patches `_CLOSE_CHILD_REAP_TIMEOUT_S`, the constant the close path actually uses. The previous `_ROLLBACK_GRACEFUL_TIMEOUT_S` patch left its `> 0.7` assertion vacuous against the real 60 second reap budget; this is a semantic test correction in addition to removing its wall-clock dependency.

## Validation

After rebasing onto the current `main` and rebuilding the editable native extension:

- review-affected Python files: `372 passed in 26.41s`;
- full `tests/ut/py/test_worker`: `935 passed, 7 skipped in 63.18s`;
- mutation checks rejected all three targeted regressions: bypassing the operation-lease drain, launching a non-head successor, and processing registry control instead of deferring it;
- five key mailbox/HostWorker/startup cases: 20 consecutive rounds, `100/100` test invocations passed;
- `test_orchestrator`: `61 passed`;
- `test_remote_endpoint`: `24 passed`;
- repository commit hooks passed, including headers, clang-format, clang-tidy, cpplint, Ruff, and Pyright;
- `git diff --check` passed.
