### PR TITLE
Fix: stop shared scene-test sources naming one runtime's Tensor

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/vendor/paged_attention_cce/kernel/fai_body.hpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/vendor/paged_attention_cce/kernel/fai_body.hpp
@@ -68,7 +68,7 @@ acquire_qwen_fai_metadata(GM_ADDR metadata) {
 template <typename T>
 static __aicore__ __attribute__((always_inline)) GM_ADDR
 tensor_data(__gm__ int64_t *args, int32_t index) {
-  __gm__ simpler::tmr::Tensor *tensor = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[index]);
+  __gm__ TaskTensor *tensor = reinterpret_cast<__gm__ TaskTensor *>(args[index]);
   __gm__ T *data =
       reinterpret_cast<__gm__ T *>(tensor->buffer.addr) + tensor->start_offset;
   return reinterpret_cast<GM_ADDR>(data);
@@ -207,7 +207,7 @@ run_qwen_fai(__gm__ int64_t *args, __gm__ int32_t *barrier_state = nullptr) {
     // slot_mapping, rope_cos, rope_sin, k_proj, k_norm_w, v_proj, q_proj,
     // q_norm_w, layer_cache_base, KV_CACHE_ROWS, block_idx, block_num).
     int64_t kv_cache_rows = static_cast<int64_t>(
-        reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[2])->shapes[0]);
+        reinterpret_cast<__gm__ TaskTensor *>(args[2])->shapes[0]);
     uint32_t rope_lane = block_idx * 2 + sub_block_idx;
     if (rope_lane < kQwenRopeCores) {
       qwen_rope_gen::rope_qkv(

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/vendor/paged_attention_cce/tiling/entry.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/vendor/paged_attention_cce/tiling/entry.cpp
@@ -34,13 +34,12 @@ namespace {
 
 template <typename T>
 static __aicore__ __attribute__((always_inline)) __gm__ T *tensor_data(__gm__ int64_t *args, int32_t index) {
-    __gm__ simpler::tmr::Tensor *tensor = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[index]);
+    __gm__ TaskTensor *tensor = reinterpret_cast<__gm__ TaskTensor *>(args[index]);
     return reinterpret_cast<__gm__ T *>(tensor->buffer.addr) + tensor->start_offset;
 }
 
-static __aicore__ __attribute__((always_inline)) __gm__ simpler::tmr::Tensor *
-tensor_desc(__gm__ int64_t *args, int32_t index) {
-    return reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[index]);
+static __aicore__ __attribute__((always_inline)) __gm__ TaskTensor *tensor_desc(__gm__ int64_t *args, int32_t index) {
+    return reinterpret_cast<__gm__ TaskTensor *>(args[index]);
 }
 
 static __aicore__ __attribute__((always_inline)) __gm__ int32_t *barrier_data(__gm__ uint8_t *metadata) {
@@ -72,7 +71,7 @@ static __aicore__ void flush_metadata_prefix(__gm__ uint8_t *metadata) {
 }  // namespace
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
-    __gm__ simpler::tmr::Tensor *seq_lens_desc = tensor_desc(args, 0);
+    __gm__ TaskTensor *seq_lens_desc = tensor_desc(args, 0);
     __gm__ const int32_t *seq_lens = tensor_data<const int32_t>(args, 0);
     __gm__ uint8_t *metadata = tensor_data<uint8_t>(args, 1);
     __gm__ uint32_t *tiling_out = reinterpret_cast<__gm__ uint32_t *>(metadata + qwen_fai_metadata::kTilingOffset);

--- a/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/vendor/paged_attention_cce/kernel/fai_body.hpp
+++ b/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/vendor/paged_attention_cce/kernel/fai_body.hpp
@@ -78,7 +78,7 @@ acquire_qwen_fai_metadata(GM_ADDR metadata) {
 template <typename T>
 static __aicore__ __attribute__((always_inline)) GM_ADDR
 tensor_data(__gm__ int64_t *args, int32_t index) {
-  __gm__ simpler::tmr::Tensor *tensor = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[index]);
+  __gm__ TaskTensor *tensor = reinterpret_cast<__gm__ TaskTensor *>(args[index]);
   __gm__ T *data =
       reinterpret_cast<__gm__ T *>(tensor->buffer.addr) + tensor->start_offset;
   return reinterpret_cast<GM_ADDR>(data);
@@ -217,7 +217,7 @@ run_qwen_fai(__gm__ int64_t *args, __gm__ int32_t *barrier_state = nullptr) {
     // slot_mapping, rope_cos, rope_sin, k_proj, k_norm_w, v_proj, q_proj,
     // q_norm_w, layer_cache_base, KV_CACHE_ROWS, block_idx, block_num).
     int64_t kv_cache_rows = static_cast<int64_t>(
-        reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[2])->shapes[0]);
+        reinterpret_cast<__gm__ TaskTensor *>(args[2])->shapes[0]);
     uint32_t rope_lane = block_idx * 2 + sub_block_idx;
     if (rope_lane < kQwenRopeCores) {
       qwen_rope_gen::rope_qkv(

--- a/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/vendor/paged_attention_cce/tiling/entry.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/vendor/paged_attention_cce/tiling/entry.cpp
@@ -34,13 +34,12 @@ namespace {
 
 template <typename T>
 static __aicore__ __attribute__((always_inline)) __gm__ T *tensor_data(__gm__ int64_t *args, int32_t index) {
-    __gm__ simpler::tmr::Tensor *tensor = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[index]);
+    __gm__ TaskTensor *tensor = reinterpret_cast<__gm__ TaskTensor *>(args[index]);
     return reinterpret_cast<__gm__ T *>(tensor->buffer.addr) + tensor->start_offset;
 }
 
-static __aicore__ __attribute__((always_inline)) __gm__ simpler::tmr::Tensor *
-tensor_desc(__gm__ int64_t *args, int32_t index) {
-    return reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[index]);
+static __aicore__ __attribute__((always_inline)) __gm__ TaskTensor *tensor_desc(__gm__ int64_t *args, int32_t index) {
+    return reinterpret_cast<__gm__ TaskTensor *>(args[index]);
 }
 
 static __aicore__ __attribute__((always_inline)) __gm__ int32_t *barrier_data(__gm__ uint8_t *metadata) {
@@ -75,7 +74,7 @@ static __aicore__ void flush_metadata_prefix(__gm__ uint8_t *metadata) {
 }  // namespace
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
-    __gm__ simpler::tmr::Tensor *seq_lens_desc = tensor_desc(args, 0);
+    __gm__ TaskTensor *seq_lens_desc = tensor_desc(args, 0);
     __gm__ const int32_t *seq_lens = tensor_data<const int32_t>(args, 0);
     __gm__ uint8_t *metadata = tensor_data<uint8_t>(args, 1);
     __gm__ uint32_t *tiling_out = reinterpret_cast<__gm__ uint32_t *>(metadata + qwen_fai_metadata::kTilingOffset);

--- a/tests/st/a2a3/host_build_graph/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * SPMD Paged Attention Orchestration with TPUSH/TPOP (fixed block_num=24)
+ *
+ * Submits a single MixedKernels task with hardware block_num fixed at 24.
+ * total_logical_blocks = batch * q_loop logical work items are distributed
+ * across the 24 hardware blocks via a stride loop inside the kernel:
+ *   for (block_idx = hw_block_idx; block_idx < total_logical_blocks; block_idx += 24)
+ *
+ * q_tile adapts to num_heads at runtime: q_tile = min(num_heads, MAX_Q_TILE).
+ * When num_heads <= MAX_Q_TILE (=64), q_loop = 1 and each block processes all heads.
+ *
+ * Each iteration of the stride loop processes one (batch_idx, q_tile_idx) logical
+ * position, running the full AIC/AIV cooperative pipeline via TPUSH/TPOP pipes:
+ *   AIC: QK matmul -> TPUSH(sij) -> TPOP(pij) -> PV matmul -> TPUSH(oi_new)
+ *   AIV: TPOP(sij) -> online softmax -> TPUSH(pij) -> TPOP(oi_new) -> online update
+ *
+ * GM FIFO buffers for TPUSH/TPOP are sized for the 24 hardware blocks (not for
+ * total_logical_blocks). Each hardware block owns its own FIFO slots and reuses
+ * them across stride-loop iterations.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <cinttypes>
+
+#include "orchestration_api.h"
+
+#define FUNC_PA_AIC 0
+#define FUNC_PA_AIV 1
+
+static constexpr uint64_t MAX_Q_TILE = 64;
+static constexpr uint64_t HEAD_DIM = 128;
+static constexpr uint64_t MAX_BLOCK_SIZE = 128;
+static constexpr int16_t SPMD_BLOCK_NUM = 24;
+
+// GM FIFO slot sizes (must match kernel's PAConfig<MAX_Q_TILE> constants).
+// Sized for the maximum (q_tile, block_size) so the same FIFO layout works
+// for both q_tile=16 and q_tile=64 dispatch paths inside the kernel.
+static constexpr uint32_t SIJ_SLOT_SIZE = MAX_Q_TILE * MAX_BLOCK_SIZE * sizeof(float);
+static constexpr uint32_t PIJ_SLOT_SIZE = MAX_Q_TILE * MAX_BLOCK_SIZE * sizeof(uint16_t);
+static constexpr uint32_t OI_SLOT_SIZE = MAX_Q_TILE * HEAD_DIM * sizeof(float);
+static constexpr uint32_t FIFO_DEPTH = 2;
+
+extern "C" {
+
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+    (void)orch_args;
+    return OrchestrationConfig{
+        .expected_arg_count = 7,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
+    uint64_t batch = orch_args.tensor(0).ref().shapes[0];
+    uint64_t num_heads = orch_args.tensor(0).ref().shapes[1];
+    uint64_t head_dim = orch_args.tensor(0).ref().shapes[2];
+    DataType data_type = orch_args.tensor(0).ref().dtype;
+
+    uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
+    uint64_t max_num_blocks_per_req = orch_args.tensor(3).ref().shapes[1];
+    uint64_t scale_value = orch_args.scalar(0);
+
+    // q_tile adapts to num_heads: use 64 when num_heads >= 64, else 16.
+    // The kernel statically dispatches on q_tile == 16 vs 64.
+    uint64_t q_tile = (num_heads >= MAX_Q_TILE) ? MAX_Q_TILE : 16;
+    uint64_t q_loop = (num_heads + q_tile - 1) / q_tile;
+    int64_t total_logical_blocks = static_cast<int64_t>(batch * q_loop);
+
+    LOG_INFO(
+        "SPMD PA TPUSH/TPOP: batch=%" PRIu64 " heads=%" PRIu64 " hd=%" PRIu64 " bs=%" PRIu64 " q_tile=%" PRIu64
+        " q_loop=%" PRIu64 " hw_blocks=%d logical_blocks=%" PRId64,
+        batch, num_heads, head_dim, block_size, q_tile, q_loop, SPMD_BLOCK_NUM, total_logical_blocks
+    );
+
+    // Wrap host tensors
+    void *query_ptr = orch_args.tensor(0).ref().data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).ref().data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).ref().data_as<void>();
+    void *out_ptr = orch_args.tensor(5).ref().data_as<void>();
+
+    uint64_t total_kv_blocks = orch_args.tensor(1).ref().shapes[0];
+    uint64_t kv_total_rows = total_kv_blocks * block_size;
+
+    uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
+    uint32_t kv_shapes[2] = {static_cast<uint32_t>(kv_total_rows), static_cast<uint32_t>(head_dim)};
+    uint32_t out_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
+
+    simpler::hbg::Tensor query = simpler::hbg::make_tensor_external(query_ptr, query_shapes, 2, data_type);
+    simpler::hbg::Tensor key_cache = simpler::hbg::make_tensor_external(kc_ptr, kv_shapes, 2, data_type);
+    simpler::hbg::Tensor value_cache = simpler::hbg::make_tensor_external(vc_ptr, kv_shapes, 2, data_type);
+    simpler::hbg::Tensor out = simpler::hbg::make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
+
+    uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(max_num_blocks_per_req)};
+    simpler::hbg::Tensor block_table = simpler::hbg::make_tensor_external(
+        orch_args.tensor(3).ref().data_as<void>(), bt_shapes, 2, DataType::INT32, false
+    );
+    uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
+    simpler::hbg::Tensor context_lens = simpler::hbg::make_tensor_external(
+        orch_args.tensor(4).ref().data_as<void>(), cl_shapes, 1, DataType::INT32, false
+    );
+
+    // GM FIFO buffers for TPUSH/TPOP (one set of slots per hardware block)
+    uint32_t sij_fifo_total = static_cast<uint32_t>(SPMD_BLOCK_NUM) * SIJ_SLOT_SIZE * FIFO_DEPTH;
+    uint32_t pij_fifo_total = static_cast<uint32_t>(SPMD_BLOCK_NUM) * PIJ_SLOT_SIZE * FIFO_DEPTH;
+    uint32_t oi_fifo_total = static_cast<uint32_t>(SPMD_BLOCK_NUM) * OI_SLOT_SIZE * FIFO_DEPTH;
+
+    // Allocate as 1D byte tensors (using INT32 for 4-byte alignment, divide by 4)
+    uint32_t sij_fifo_shapes[1] = {static_cast<uint32_t>(sij_fifo_total / sizeof(int32_t))};
+    uint32_t pij_fifo_shapes[1] = {static_cast<uint32_t>(pij_fifo_total / sizeof(int32_t))};
+    uint32_t oi_fifo_shapes[1] = {static_cast<uint32_t>(oi_fifo_total / sizeof(int32_t))};
+
+    TensorCreateInfo sij_fifo_ci(sij_fifo_shapes, 1, DataType::INT32);
+    TensorCreateInfo pij_fifo_ci(pij_fifo_shapes, 1, DataType::INT32);
+    TensorCreateInfo oi_fifo_ci(oi_fifo_shapes, 1, DataType::INT32);
+
+    SIMPLER_SCOPE() {
+        CoreTaskArgs args;
+        args.add_input(query);
+        args.add_input(key_cache);
+        args.add_input(value_cache);
+        args.add_input(block_table);
+        args.add_input(context_lens);
+        args.add_inout(out);
+        args.add_output(sij_fifo_ci);
+        args.add_output(pij_fifo_ci);
+        args.add_output(oi_fifo_ci);
+        args.add_scalar(scale_value);
+        args.add_scalar(static_cast<int64_t>(num_heads));
+        args.add_scalar(static_cast<int64_t>(head_dim));
+        args.add_scalar(static_cast<int64_t>(block_size));
+        args.add_scalar(static_cast<int64_t>(max_num_blocks_per_req));
+        args.add_scalar(static_cast<int64_t>(q_loop));
+        args.add_scalar(total_logical_blocks);
+        args.add_scalar(static_cast<int64_t>(q_tile));
+        args.launch_spec.set_block_num(SPMD_BLOCK_NUM);
+
+        MixedKernels mk;
+        mk.aic_kernel_id = FUNC_PA_AIC;
+        mk.aiv0_kernel_id = FUNC_PA_AIV;
+        mk.aiv1_kernel_id = FUNC_PA_AIV;
+        rt_submit_task(mk, args);
+    }
+
+    LOG_INFO(
+        "SPMD PA TPUSH/TPOP: submitted 1 MixedKernels task, hw_blocks=%d logical=%" PRId64,
+        static_cast<int>(SPMD_BLOCK_NUM), total_logical_blocks
+    );
+}
+
+}  // extern "C"

--- a/tests/st/a2a3/host_build_graph/spmd_paged_attention/test_spmd_paged_attention.py
+++ b/tests/st/a2a3/host_build_graph/spmd_paged_attention/test_spmd_paged_attention.py
@@ -20,9 +20,13 @@ from tests.st.a2a3.tensormap_and_ringbuffer.spmd_paged_attention.test_spmd_paged
 
 @scene_test(level=2, runtime="host_build_graph")
 class TestSpmdPagedAttentionHbgA2A3(_TmrBase):
+    # Orchestration names one runtime's `Tensor` and builds tensors through that
+    # runtime's factory, so it cannot be compiled under both — this runtime has
+    # its own copy under `kernels/`. The MIX kernel names `TaskTensor`, the
+    # per-translation-unit alias each runtime exports, and is shared.
     _SHARED_DIR = Path(__file__).resolve().parents[2] / "tensormap_and_ringbuffer/spmd_paged_attention"
     CALLABLE = deepcopy(_TmrBase.CALLABLE)
-    CALLABLE["orchestration"]["source"] = str(_SHARED_DIR / "kernels/orchestration/spmd_paged_attention_orch.cpp")
+    CALLABLE["orchestration"]["source"] = "kernels/orchestration/spmd_paged_attention_orch.cpp"
     for _incore in CALLABLE["incores"]:
         _incore["source"] = str(_SHARED_DIR / "kernels/mix/paged_attention_parallel.cpp")
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/mix/paged_attention_parallel.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/mix/paged_attention_parallel.cpp
@@ -32,15 +32,15 @@
  *   AIV: TPOP(sij) → online softmax → TPUSH(pij) → TPOP(oi_new) → online update
  *
  * MixedKernels args:
- *   args[0]  = query         simpler::tmr::Tensor* (batch*num_heads, head_dim) bf16
- *   args[1]  = key_cache     simpler::tmr::Tensor* (kv_total_rows, head_dim) bf16
- *   args[2]  = value_cache   simpler::tmr::Tensor* (kv_total_rows, head_dim) bf16
- *   args[3]  = block_table   simpler::tmr::Tensor* (batch, max_blocks_per_req) int32
- *   args[4]  = context_lens  simpler::tmr::Tensor* (batch,) int32
- *   args[5]  = out           simpler::tmr::Tensor* (batch*num_heads, head_dim) float32 [output]
- *   args[6]  = sij_fifo      simpler::tmr::Tensor* GM ring buffer for sij pipe
- *   args[7]  = pij_fifo      simpler::tmr::Tensor* GM ring buffer for pij pipe
- *   args[8]  = oi_fifo       simpler::tmr::Tensor* GM ring buffer for oi_new pipe
+ *   args[0]  = query         TaskTensor* (batch*num_heads, head_dim) bf16
+ *   args[1]  = key_cache     TaskTensor* (kv_total_rows, head_dim) bf16
+ *   args[2]  = value_cache   TaskTensor* (kv_total_rows, head_dim) bf16
+ *   args[3]  = block_table   TaskTensor* (batch, max_blocks_per_req) int32
+ *   args[4]  = context_lens  TaskTensor* (batch,) int32
+ *   args[5]  = out           TaskTensor* (batch*num_heads, head_dim) float32 [output]
+ *   args[6]  = sij_fifo      TaskTensor* GM ring buffer for sij pipe
+ *   args[7]  = pij_fifo      TaskTensor* GM ring buffer for pij pipe
+ *   args[8]  = oi_fifo       TaskTensor* GM ring buffer for oi_new pipe
  *   args[9]  = scale_value   scalar (float bits in uint64)
  *   args[10] = num_heads     scalar
  *   args[11] = head_dim      scalar
@@ -642,10 +642,10 @@ static __aicore__ void run_aic(
     typename Cfg::PijPipeT pij_pipe(pij_fifo_base, 0U, Cfg::PIJ_L1_BASE);
     typename Cfg::OiPipeT oi_pipe(oi_fifo_base, Cfg::OI_UB_BASE, 0U);
 
-    __gm__ simpler::tmr::Tensor *query_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[0]);
-    __gm__ simpler::tmr::Tensor *key_cache_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[1]);
-    __gm__ simpler::tmr::Tensor *value_cache_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[2]);
-    __gm__ simpler::tmr::Tensor *block_table_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[3]);
+    __gm__ TaskTensor *query_t = reinterpret_cast<__gm__ TaskTensor *>(args[0]);
+    __gm__ TaskTensor *key_cache_t = reinterpret_cast<__gm__ TaskTensor *>(args[1]);
+    __gm__ TaskTensor *value_cache_t = reinterpret_cast<__gm__ TaskTensor *>(args[2]);
+    __gm__ TaskTensor *block_table_t = reinterpret_cast<__gm__ TaskTensor *>(args[3]);
 
     __gm__ bfloat16_t *query_base = reinterpret_cast<__gm__ bfloat16_t *>(query_t->buffer.addr) + query_t->start_offset;
     __gm__ bfloat16_t *key_base =
@@ -688,7 +688,7 @@ static __aicore__ void run_aiv(
     typename Cfg::PijPipeT pij_pipe(pij_fifo_base, 0U, Cfg::PIJ_L1_BASE);
     typename Cfg::OiPipeT oi_pipe(oi_fifo_base, Cfg::OI_UB_BASE, 0U);
 
-    __gm__ simpler::tmr::Tensor *out_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[5]);
+    __gm__ TaskTensor *out_t = reinterpret_cast<__gm__ TaskTensor *>(args[5]);
     float scale_value = from_u64<float>(static_cast<uint64_t>(args[9]));
 
     int32_t sub_block_id = get_sub_block_id(args);
@@ -755,10 +755,10 @@ static __aicore__ void run_aiv(
 // ============================================================================
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
-    __gm__ simpler::tmr::Tensor *context_lens_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[4]);
-    __gm__ simpler::tmr::Tensor *sij_fifo_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[6]);
-    __gm__ simpler::tmr::Tensor *pij_fifo_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[7]);
-    __gm__ simpler::tmr::Tensor *oi_fifo_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[8]);
+    __gm__ TaskTensor *context_lens_t = reinterpret_cast<__gm__ TaskTensor *>(args[4]);
+    __gm__ TaskTensor *sij_fifo_t = reinterpret_cast<__gm__ TaskTensor *>(args[6]);
+    __gm__ TaskTensor *pij_fifo_t = reinterpret_cast<__gm__ TaskTensor *>(args[7]);
+    __gm__ TaskTensor *oi_fifo_t = reinterpret_cast<__gm__ TaskTensor *>(args[8]);
 
     int64_t num_heads = static_cast<int64_t>(args[10]);
     int64_t head_dim = static_cast<int64_t>(args[11]);

--- a/tests/st/a5/host_build_graph/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
+++ b/tests/st/a5/host_build_graph/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * SPMD Paged Attention Orchestration with TPUSH/TPOP (fixed block_num=24)
+ *
+ * Submits a single MixedKernels task with hardware block_num fixed at 24.
+ * total_logical_blocks = batch * q_loop logical work items are distributed
+ * across the 24 hardware blocks via a stride loop inside the kernel:
+ *   for (block_idx = hw_block_idx; block_idx < total_logical_blocks; block_idx += 24)
+ *
+ * q_tile adapts to num_heads at runtime: q_tile = min(num_heads, MAX_Q_TILE).
+ * When num_heads <= MAX_Q_TILE (=64), q_loop = 1 and each block processes all heads.
+ *
+ * Each iteration of the stride loop processes one (batch_idx, q_tile_idx) logical
+ * position, running the full AIC/AIV cooperative pipeline via TPUSH/TPOP pipes:
+ *   AIC: QK matmul -> TPUSH(sij) -> TPOP(pij) -> PV matmul -> TPUSH(oi_new)
+ *   AIV: TPOP(sij) -> online softmax -> TPUSH(pij) -> TPOP(oi_new) -> online update
+ *
+ * GM FIFO buffers for TPUSH/TPOP are sized for the 24 hardware blocks (not for
+ * total_logical_blocks). Each hardware block owns its own FIFO slots and reuses
+ * them across stride-loop iterations.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <cinttypes>
+
+#include "orchestration_api.h"
+
+#define FUNC_PA_AIC 0
+#define FUNC_PA_AIV 1
+
+static constexpr uint64_t MAX_Q_TILE = 64;
+static constexpr uint64_t HEAD_DIM = 128;
+static constexpr uint64_t MAX_BLOCK_SIZE = 128;
+static constexpr int16_t SPMD_BLOCK_NUM = 24;
+
+// GM FIFO slot sizes (must match kernel's PAConfig<MAX_Q_TILE> constants).
+// Sized for the maximum (q_tile, block_size) so the same FIFO layout works
+// for both q_tile=16 and q_tile=64 dispatch paths inside the kernel.
+static constexpr uint32_t SIJ_SLOT_SIZE = MAX_Q_TILE * MAX_BLOCK_SIZE * sizeof(float);
+static constexpr uint32_t PIJ_SLOT_SIZE = MAX_Q_TILE * MAX_BLOCK_SIZE * sizeof(uint16_t);
+static constexpr uint32_t OI_SLOT_SIZE = MAX_Q_TILE * HEAD_DIM * sizeof(float);
+static constexpr uint32_t FIFO_DEPTH = 2;
+
+extern "C" {
+
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+    (void)orch_args;
+    return OrchestrationConfig{
+        .expected_arg_count = 7,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
+    uint64_t batch = orch_args.tensor(0).ref().shapes[0];
+    uint64_t num_heads = orch_args.tensor(0).ref().shapes[1];
+    uint64_t head_dim = orch_args.tensor(0).ref().shapes[2];
+    DataType data_type = orch_args.tensor(0).ref().dtype;
+
+    uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
+    uint64_t max_num_blocks_per_req = orch_args.tensor(3).ref().shapes[1];
+    uint64_t scale_value = orch_args.scalar(0);
+
+    uint64_t q_tile = (num_heads < MAX_Q_TILE) ? num_heads : MAX_Q_TILE;
+    if ((q_tile != 16 && q_tile != MAX_Q_TILE) || num_heads % q_tile != 0) {
+        LOG_ERROR("SPMD PA: num_heads=%" PRIu64 " requires q_tile 16 or 64 and an exact tile multiple", num_heads);
+        return;
+    }
+    if (head_dim != HEAD_DIM) {
+        LOG_ERROR("SPMD PA: head_dim=%" PRIu64 " is unsupported; expected %" PRIu64, head_dim, HEAD_DIM);
+        return;
+    }
+    if (block_size != 64 && block_size != MAX_BLOCK_SIZE) {
+        LOG_ERROR("SPMD PA: block_size=%" PRIu64 " is unsupported; expected 64 or 128", block_size);
+        return;
+    }
+    uint64_t q_loop = (num_heads + q_tile - 1) / q_tile;
+    int64_t total_logical_blocks = static_cast<int64_t>(batch * q_loop);
+
+    LOG_INFO(
+        "SPMD PA TPUSH/TPOP: batch=%" PRIu64 " heads=%" PRIu64 " hd=%" PRIu64 " bs=%" PRIu64 " q_tile=%" PRIu64
+        " q_loop=%" PRIu64 " hw_blocks=%d logical_blocks=%" PRId64,
+        batch, num_heads, head_dim, block_size, q_tile, q_loop, SPMD_BLOCK_NUM, total_logical_blocks
+    );
+
+    // Wrap host tensors
+    void *query_ptr = orch_args.tensor(0).ref().data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).ref().data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).ref().data_as<void>();
+    void *out_ptr = orch_args.tensor(5).ref().data_as<void>();
+
+    uint64_t total_kv_blocks = orch_args.tensor(1).ref().shapes[0];
+    uint64_t kv_total_rows = total_kv_blocks * block_size;
+
+    uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
+    uint32_t kv_shapes[2] = {static_cast<uint32_t>(kv_total_rows), static_cast<uint32_t>(head_dim)};
+    uint32_t out_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
+
+    simpler::hbg::Tensor query = simpler::hbg::make_tensor_external(query_ptr, query_shapes, 2, data_type);
+    simpler::hbg::Tensor key_cache = simpler::hbg::make_tensor_external(kc_ptr, kv_shapes, 2, data_type);
+    simpler::hbg::Tensor value_cache = simpler::hbg::make_tensor_external(vc_ptr, kv_shapes, 2, data_type);
+    simpler::hbg::Tensor out = simpler::hbg::make_tensor_external(out_ptr, out_shapes, 2, DataType::FLOAT32);
+
+    uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(max_num_blocks_per_req)};
+    simpler::hbg::Tensor block_table = simpler::hbg::make_tensor_external(
+        orch_args.tensor(3).ref().data_as<void>(), bt_shapes, 2, DataType::INT32, false
+    );
+    uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
+    simpler::hbg::Tensor context_lens = simpler::hbg::make_tensor_external(
+        orch_args.tensor(4).ref().data_as<void>(), cl_shapes, 1, DataType::INT32, false
+    );
+
+    // GM FIFO buffers for TPUSH/TPOP (one set of slots per hardware block)
+    uint32_t sij_fifo_total = static_cast<uint32_t>(SPMD_BLOCK_NUM) * SIJ_SLOT_SIZE * FIFO_DEPTH;
+    uint32_t pij_fifo_total = static_cast<uint32_t>(SPMD_BLOCK_NUM) * PIJ_SLOT_SIZE * FIFO_DEPTH;
+    uint32_t oi_fifo_total = static_cast<uint32_t>(SPMD_BLOCK_NUM) * OI_SLOT_SIZE * FIFO_DEPTH;
+
+    // Allocate as 1D byte tensors (using INT32 for 4-byte alignment, divide by 4)
+    uint32_t sij_fifo_shapes[1] = {static_cast<uint32_t>(sij_fifo_total / sizeof(int32_t))};
+    uint32_t pij_fifo_shapes[1] = {static_cast<uint32_t>(pij_fifo_total / sizeof(int32_t))};
+    uint32_t oi_fifo_shapes[1] = {static_cast<uint32_t>(oi_fifo_total / sizeof(int32_t))};
+
+    TensorCreateInfo sij_fifo_ci(sij_fifo_shapes, 1, DataType::INT32);
+    TensorCreateInfo pij_fifo_ci(pij_fifo_shapes, 1, DataType::INT32);
+    TensorCreateInfo oi_fifo_ci(oi_fifo_shapes, 1, DataType::INT32);
+
+    SIMPLER_SCOPE() {
+        CoreTaskArgs args;
+        args.add_input(query);
+        args.add_input(key_cache);
+        args.add_input(value_cache);
+        args.add_input(block_table);
+        args.add_input(context_lens);
+        args.add_inout(out);
+        args.add_output(sij_fifo_ci);
+        args.add_output(pij_fifo_ci);
+        args.add_output(oi_fifo_ci);
+        args.add_scalar(scale_value);
+        args.add_scalar(static_cast<int64_t>(num_heads));
+        args.add_scalar(static_cast<int64_t>(head_dim));
+        args.add_scalar(static_cast<int64_t>(block_size));
+        args.add_scalar(static_cast<int64_t>(max_num_blocks_per_req));
+        args.add_scalar(static_cast<int64_t>(q_loop));
+        args.add_scalar(total_logical_blocks);
+        args.add_scalar(static_cast<int64_t>(q_tile));
+        args.launch_spec.set_block_num(SPMD_BLOCK_NUM);
+
+        MixedKernels mk;
+        mk.aic_kernel_id = FUNC_PA_AIC;
+        mk.aiv0_kernel_id = FUNC_PA_AIV;
+        mk.aiv1_kernel_id = FUNC_PA_AIV;
+        rt_submit_task(mk, args);
+    }
+
+    LOG_INFO(
+        "SPMD PA TPUSH/TPOP: submitted 1 MixedKernels task, hw_blocks=%d logical=%" PRId64,
+        static_cast<int>(SPMD_BLOCK_NUM), total_logical_blocks
+    );
+}
+
+}  // extern "C"

--- a/tests/st/a5/host_build_graph/spmd_paged_attention/test_spmd_paged_attention.py
+++ b/tests/st/a5/host_build_graph/spmd_paged_attention/test_spmd_paged_attention.py
@@ -10,6 +10,7 @@
 """Manual HBG coverage for the disabled A5 SPMD paged-attention workload."""
 
 from copy import deepcopy
+from pathlib import Path
 
 from simpler_setup import scene_test
 from tests.st.a5.tensormap_and_ringbuffer.spmd_paged_attention.test_spmd_paged_attention import (
@@ -19,6 +20,16 @@ from tests.st.a5.tensormap_and_ringbuffer.spmd_paged_attention.test_spmd_paged_a
 
 @scene_test(level=2, runtime="host_build_graph")
 class TestSpmdPagedAttentionHbgA5(_TmrBase):
+    # Orchestration names one runtime's `Tensor` and builds tensors through that
+    # runtime's factory, so it cannot be compiled under both — this runtime has
+    # its own copy under `kernels/`. The MIX kernel names `TaskTensor`, the
+    # per-translation-unit alias each runtime exports, and is shared.
+    _SHARED_DIR = Path(__file__).resolve().parents[2] / "tensormap_and_ringbuffer/spmd_paged_attention"
+    CALLABLE = deepcopy(_TmrBase.CALLABLE)
+    CALLABLE["orchestration"]["source"] = "kernels/orchestration/spmd_paged_attention_orch.cpp"
+    for _incore in CALLABLE["incores"]:
+        _incore["source"] = str(_SHARED_DIR / "kernels/mix/paged_attention_parallel.cpp")
+
     # The TMR shapes, run through host_build_graph. Deep-copied so the two
     # classes do not share a params dict. Onboard only: the MIX kernel's
     # TPUSH/TPOP path does not build for the CPU simulator (PTO-ISA rejects the

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/kernels/mix/paged_attention_parallel.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_paged_attention/kernels/mix/paged_attention_parallel.cpp
@@ -32,15 +32,15 @@
  *   AIV: TPOP(sij) → online softmax → TPUSH(pij) → TPOP(oi_new) → online update
  *
  * MixedKernels args:
- *   args[0]  = query         simpler::tmr::Tensor* (batch*num_heads, head_dim) bf16
- *   args[1]  = key_cache     simpler::tmr::Tensor* (kv_total_rows, head_dim) bf16
- *   args[2]  = value_cache   simpler::tmr::Tensor* (kv_total_rows, head_dim) bf16
- *   args[3]  = block_table   simpler::tmr::Tensor* (batch, max_blocks_per_req) int32
- *   args[4]  = context_lens  simpler::tmr::Tensor* (batch,) int32
- *   args[5]  = out           simpler::tmr::Tensor* (batch*num_heads, head_dim) float32 [output]
- *   args[6]  = sij_fifo      simpler::tmr::Tensor* GM ring buffer for sij pipe
- *   args[7]  = pij_fifo      simpler::tmr::Tensor* GM ring buffer for pij pipe
- *   args[8]  = oi_fifo       simpler::tmr::Tensor* GM ring buffer for oi_new pipe
+ *   args[0]  = query         TaskTensor* (batch*num_heads, head_dim) bf16
+ *   args[1]  = key_cache     TaskTensor* (kv_total_rows, head_dim) bf16
+ *   args[2]  = value_cache   TaskTensor* (kv_total_rows, head_dim) bf16
+ *   args[3]  = block_table   TaskTensor* (batch, max_blocks_per_req) int32
+ *   args[4]  = context_lens  TaskTensor* (batch,) int32
+ *   args[5]  = out           TaskTensor* (batch*num_heads, head_dim) float32 [output]
+ *   args[6]  = sij_fifo      TaskTensor* GM ring buffer for sij pipe
+ *   args[7]  = pij_fifo      TaskTensor* GM ring buffer for pij pipe
+ *   args[8]  = oi_fifo       TaskTensor* GM ring buffer for oi_new pipe
  *   args[9]  = scale_value   scalar (float bits in uint64)
  *   args[10] = num_heads     scalar
  *   args[11] = head_dim      scalar
@@ -543,10 +543,10 @@ static __aicore__ void run_aic(
     typename Cfg::PijPipeT pij_pipe(pij_fifo_base, 0U, Cfg::PIJ_L1_BASE);
     typename Cfg::OiPipeT oi_pipe(oi_fifo_base, Cfg::OI_UB_BASE, 0U);
 
-    __gm__ simpler::tmr::Tensor *query_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[0]);
-    __gm__ simpler::tmr::Tensor *key_cache_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[1]);
-    __gm__ simpler::tmr::Tensor *value_cache_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[2]);
-    __gm__ simpler::tmr::Tensor *block_table_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[3]);
+    __gm__ TaskTensor *query_t = reinterpret_cast<__gm__ TaskTensor *>(args[0]);
+    __gm__ TaskTensor *key_cache_t = reinterpret_cast<__gm__ TaskTensor *>(args[1]);
+    __gm__ TaskTensor *value_cache_t = reinterpret_cast<__gm__ TaskTensor *>(args[2]);
+    __gm__ TaskTensor *block_table_t = reinterpret_cast<__gm__ TaskTensor *>(args[3]);
 
     __gm__ bfloat16_t *query_base = reinterpret_cast<__gm__ bfloat16_t *>(query_t->buffer.addr) + query_t->start_offset;
     __gm__ bfloat16_t *key_base =
@@ -591,7 +591,7 @@ static __aicore__ void run_aiv(
     typename Cfg::PijPipeT pij_pipe(pij_fifo_base, 0U, Cfg::PIJ_L1_BASE);
     typename Cfg::OiPipeT oi_pipe(oi_fifo_base, Cfg::OI_UB_BASE, 0U);
 
-    __gm__ simpler::tmr::Tensor *out_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[5]);
+    __gm__ TaskTensor *out_t = reinterpret_cast<__gm__ TaskTensor *>(args[5]);
     float scale_value = from_u64<float>(static_cast<uint64_t>(args[9]));
 
     int32_t sub_block_id = get_sub_block_id(args);
@@ -650,10 +650,10 @@ static __aicore__ void run_aiv(
 // ============================================================================
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
-    __gm__ simpler::tmr::Tensor *context_lens_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[4]);
-    __gm__ simpler::tmr::Tensor *sij_fifo_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[6]);
-    __gm__ simpler::tmr::Tensor *pij_fifo_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[7]);
-    __gm__ simpler::tmr::Tensor *oi_fifo_t = reinterpret_cast<__gm__ simpler::tmr::Tensor *>(args[8]);
+    __gm__ TaskTensor *context_lens_t = reinterpret_cast<__gm__ TaskTensor *>(args[4]);
+    __gm__ TaskTensor *sij_fifo_t = reinterpret_cast<__gm__ TaskTensor *>(args[6]);
+    __gm__ TaskTensor *pij_fifo_t = reinterpret_cast<__gm__ TaskTensor *>(args[7]);
+    __gm__ TaskTensor *oi_fifo_t = reinterpret_cast<__gm__ TaskTensor *>(args[8]);
 
     int64_t num_heads = static_cast<int64_t>(args[10]);
     int64_t head_dim = static_cast<int64_t>(args[11]);


### PR DESCRIPTION
## Summary

`host_build_graph` does not build four scene-test sources per arch. #1974 split
`ChipTensor` from `simpler::hbg::Tensor` / `simpler::tmr::Tensor` and rewrote the
corpus onto the new spellings; these four are compiled under **both** runtimes and
took the `simpler::tmr::` one:

| Source (a2a3 + a5) | Reached from |
| --- | --- |
| `spmd_paged_attention/kernels/mix/paged_attention_parallel.cpp` | `tests/st/{arch}/host_build_graph/spmd_paged_attention` |
| `spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp` | same |
| `qwen3_14b_decode/kernels/vendor/paged_attention_cce/tiling/entry.cpp` | `examples/{arch}/host_build_graph/qwen3_14b_decode` |
| `qwen3_14b_decode/kernels/vendor/paged_attention_cce/kernel/fai_body.hpp` | same, via `attention_rope/entry.cpp` |

```
error: 'simpler::tmr' has not been declared
error: no member named 'tmr' in namespace 'simpler'
```

Every case that reaches them is `manual: True`, and per-PR CI runs
`--manual exclude`, so the jobs pass by never compiling these files.

## What changed

**Kernel-side sources name `TaskTensor`.** A kernel does not care which
orchestrator produced its payload, and `TaskTensor` is the per-translation-unit
alias each runtime's `runtime/tensor.h` exports for exactly this — the same
resolution #1974 applied to the dsv4 kernels.

**Orchestration gets a per-runtime copy.** It cannot use the alias: it builds
tensors through `simpler::<runtime>::make_tensor_external`, whose constructor is
private to a friend factory, so naming the type alone is not enough. This follows
`run_stream_reuse` / `worker_async_fifo` / `qwen3` / `dsv4`, which all keep the
orchestration per-runtime and share only incores. Each new copy differs from its
`tensormap_and_ringbuffer` sibling only in the namespace.

The A5 shim gains the `CALLABLE` override it was missing — it inherited the TMR
one whole, absolute paths included. Its copy also drops `set_block_count`, whose
`#if` selected `set_core_num` for `tensormap_and_ringbuffer`; in a
`host_build_graph`-only file the live entry point is `set_block_num`.

## Testing

Verified on a2a3 silicon (`task-submit`, pto-isa `be5ccb76`):

- [x] Each kernel source compiles under **both** runtimes; each orchestration copy
      under its own only.
- [x] `spmd_paged_attention` — 3 cases, both runtimes, `--manual include`, onboard.
- [x] `qwen3_14b_decode` — both runtimes, `--manual include`, onboard.
- [x] `check_retired_names`, `clang-format`, `ruff check` / `ruff format` clean.

A5 is compile-verified only; this box is a2a3 silicon.

## Note on what this does not fix

No static check can catch this class of break — the driving runtime hides behind
`deepcopy`'d `CALLABLE`s, rebased path strings and inherited base classes, so it
cannot be read off the Python. The only reliable gate is compiling every kernel
under both runtimes. That gate is not added here; it wants its own change.