### PR TITLE
Fix: make host logging nonblocking with accountable loss

### DIFF
--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -38,9 +38,12 @@ writes follows it: `LOG_*` records, `[STRACE]` spans, `[CLOCK_ANCHOR]`, the
 `bind phase=` summaries, and the spans Python emits through
 `unified_log_host_span`. Nothing declares an intent and no record kind is treated
 specially, so there is no state in which part of a run's log is in one place and
-part in another. The first non-empty directory in a process wins, and a record
-falls back to stderr rather than being lost whenever the file cannot take it: a
-path that does not fit, a failed open, a failed write, or a failed flush.
+part in another. The first non-empty directory in a process wins, and it is the
+destination rather than a preference: a record the file cannot take — a path
+that does not fit, a failed open, a failed write — is dropped and counted, not
+relocated to stderr. That is what keeps "the log is complete" and
+"`dropped_record_count` is zero" the same statement. stderr is the destination
+only while no directory is bound.
 
 **Python's own log records are part of this stream too.** Seeding the native
 threshold installs a handler on the `simpler` logger that forwards each record
@@ -52,15 +55,19 @@ the log rather than a second half of it. Records logged before a worker is
 initialized have no handler to forward through yet and stay on the root logger.
 See [logging.md](../logging.md).
 
-Each process's file is fully buffered. It is flushed when a depth-zero invocation
-record completes, which is the point at which the records so far describe a whole
-invocation, and whenever a `WARN` or `ERROR` record is written, which is rare and
-worth having on disk if the process dies. That flush runs on the thread that
-emitted the record, so this reduces the observer effect by roughly the ratio of
-records to flushes rather than removing it: expect a residual tail at each flush
-boundary, not a clean floor. A system tracer would hand the bytes to a consumer
-instead, and would bound its buffer and count what it drops; this does neither,
-deliberately.
+Each process has one bounded background writer. A producer formats a complete
+record of at most 512 bytes and submits it through a 4096-slot lock-free queue;
+after that writer is published, it never performs file/stderr I/O or waits for a
+flush. The pre-writer hierarchical initialization window is the deliberate
+exception: it writes synchronously so startup diagnostics survive the final
+local fork. The writer appends each accepted record directly to the process
+file, or to stderr while no directory is bound. Queue-full, bounded-claim
+failure, and final output failure increment an explicit process drop counter, attributed by cause. A quiescent boundary writes that breakdown into the log as `[HOSTLOG_DROPS]` when it has grown, so a reader holding only the log can tell that the timing below it is derived from an incomplete one. Worker shutdown and `os._exit()`
+call sites wait only boundedly for accepted records, so a stuck output cannot
+turn task execution or teardown into an unbounded wait; a timeout reports both
+pending and dropped counts. `WARN`, `ERROR`, and depth-zero spans use the same
+async path as every other steady-state record. An overlong ordinary record is
+truncated to 512 bytes and ends in `~\n`.
 
 Every DSO that compiles the logger holds its own buffered stream on that one
 file, so the buffering above is per module rather than per process: a `WARN` from

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -118,26 +118,44 @@ forwards to its local backend.
 
 ### Layer 3 — backend primitives
 
-`HostLogger::vlog` is the host-side authority for level gating. It formats a
-complete record and performs one `write(2)` under its module-local mutex.
+`HostLogger::vlog` is the host-side authority for level gating. It formats one
+bounded record (at most the portable 512-byte `PIPE_BUF` floor) and submits it
+to the process-owned queue. The queue has 4096 fixed slots and a lock-free
+multi-producer claim path. Once the writer is published, producers never perform
+file or stderr I/O, wait on a condition variable, acquire the drain mutex, or
+grow memory. During hierarchical initialization only, before the final local
+fork and writer startup, records use the synchronous destination so startup
+failures are not silently discarded. A full queue or exhausted bounded claim is
+a dropped record and increments `dropped_record_count`. An immediately-unlinked
+named semaphore provides the writer wakeup because unnamed semaphores are not
+available on every supported host OS.
+
+Any ordinary human-readable record whose formatted envelope and body exceed
+512 bytes is truncated to that fixed size and ends in `~\n`. This keeps one
+record to one atomic pipe write when several forked processes share captured
+stderr; callers that need a large payload must split it into separate records.
+
+One background writer drains the queue. When `CallConfig.output_prefix` is
+present it appends every C++ host-log record to the process-private
+`host.<pid>.log`; otherwise it writes to stderr. The bound directory is the
+destination, not a preference: a record it cannot take is counted as a drop
+rather than relocated, so a run's log is never split across two places.
+Severity and span depth no longer choose synchronous producer-side flush paths.
+Explicit lifecycle drains wait boundedly for records already accepted by the
+process.
+
 `HostLogger::log_host_span` additionally bounds and escapes machine-readable
 fields so a STRACE record fits the portable `PIPE_BUF` floor. Its early gate
 keeps direct ABI and legacy STRACE callers from paying those encoding costs
 when TIMING is disabled; `vlog` remains the final check if the threshold changes
 between the caller's query and emission.
 
-The mutex serializes writers only within the DSO that owns it. Writers from
-different DSOs, or from forked processes sharing a pipe, are indivisible only
-when their single `write(2)` is no larger than that pipe's `PIPE_BUF`.
-Machine-readable `[STRACE]` records satisfy that bound. Longer human-readable
-records are best-effort and may interleave across module boundaries. Blocking
-and drop accounting for those writes remain part of issue #1792 item 6.
-
 The AICPU `dev_vlog_*` interface remains source-compatible on both platforms.
 Sim implements it as a thin `va_list` adapter into its bound `HostLogger`, so it
-shares the live threshold, envelope, destination, and fallback with the other
-host-side modules in that process. Only real-silicon AICPU retains a separate
-backend, because its records go through CANN dlog rather than a host process.
+shares the live threshold, envelope, queue, destination, and fallback with
+the other host-side modules in that process. Only real-silicon AICPU retains a
+separate backend because its records go through CANN dlog rather than a host
+process.
 
 ## Cross-DSO host state
 
@@ -145,20 +163,39 @@ Each host DSO has a private `HostLogger` object, but every copy in one process
 reads the same `SimplerHostLogState`:
 
 ```c
+struct SimplerHostLogState;
+typedef int (*SimplerHostLogEnqueueFn)(
+    void *context, struct SimplerHostLogState *state,
+    const char *record, uint32_t size, int32_t anchor_pid);
+
 typedef struct SimplerHostLogState {
-    uint32_t abi_version;
-    uint32_t struct_size;
     int32_t threshold;
     int32_t clock_anchor_pid;
+    int32_t log_directory_bound;
+    char log_directory[1024];
+    int32_t sink_owner_pid;
+    int32_t sink_process_pid;
+    void *sink_context;
+    SimplerHostLogEnqueueFn sink_enqueue;
+    uint64_t dropped_record_count;
+    uint64_t pending_record_count;
+    uint64_t sink_producer_state;
+    uint64_t dropped_by_reason[4];
+    uint64_t reported_drop_count;
 } SimplerHostLogState;
 
 int simpler_host_log_bind_state(SimplerHostLogState *state);
 ```
 
-The native `_task_interface` extension owns the state for the process. The
-fields are plain fixed-width integers to keep the ABI compiler-independent;
-`host_log.cpp` accesses mutable fields with atomic builtins. ABI version and
-size are checked before a module accepts the pointer.
+The native `_task_interface` extension owns the state for the process.
+Thresholds and counters use fixed-width integers; `sink_context` and
+`sink_enqueue` are process-local native pointer values shared only by modules
+from the same build. `host_log.cpp` accesses mutable fields with atomic
+builtins. The struct carries no version or size word: every module that binds it
+is compiled from this repository in the same build, and the orchestration SOs
+compiled at run time hash this header's whole include closure into their
+scene-test cache key, so a stale layout cannot reach a binding. A module that
+binds is rejected only for a null pointer or a threshold outside the ladder.
 
 Only `simpler_host_log_bind_state` is exported from a host logging consumer.
 `HostLogger` and every `unified_log_*` definition are hidden. This avoids
@@ -167,17 +204,67 @@ interposition while still giving loaders one stable binding entry point.
 
 `clock_anchor_pid` is also shared. Consequently the private logger copies
 coordinate one successful `[CLOCK_ANCHOR]` per process. A negative PID is a
-temporary writer claim; a failed stderr write releases the claim so the next
-record can retry.
+temporary writer claim; a failed output releases the claim so the next record
+can retry. The first non-empty `log_directory` binding wins, so every bound DSO
+in the process chooses the same output without moving a file already in use.
+
+The owner publishes a C callback and opaque context in the same state. A private
+logger in any bound DSO can therefore submit to the one process queue without
+exporting a C++ object or relying on ELF interposition. The callback accepts a
+record only after it owns a queue slot. Binding marks that private logger as a
+consumer: it can recognize and use an existing sink, but it cannot create one.
+Only the extension copy that owns the process state creates the writer, so a
+transient DSO cannot leave its callback or thread behind after `dlclose()`.
+`pending_record_count` tracks accepted
+work for bounded drains; `dropped_record_count` tracks enqueue rejection and
+final write failure. The high bit of `sink_producer_state` closes admission
+before a fork boundary; its low bits keep `sink_context` alive until every DSO
+caller that may have loaded it has returned. `_host_log_dropped_records()`
+exposes the drop counter to diagnostics and tests, while
+`_host_log_pending_records()` distinguishes accepted work still waiting for the
+writer. Python and C++ flush defaults are both 1000 ms. Teardown and `os._exit()`
+paths report a timeout with both counters instead of silently abandoning the
+accepted backlog.
+
+### Attributing a drop, and saying so in the log
+
+`dropped_by_reason` splits the total four ways, because the total alone is not
+actionable — `queue_full` says the queue is too small for the burst,
+`claim_exhausted` says the lock-free claim budget lost to contention with room
+still in the queue, `output_failed` says the destination rejected the write, and
+`not_admitted` says there was no sink to submit to. Those call for four different
+fixes. Every drop increments the total and exactly one reason, so the breakdown
+always sums to the total; `_host_log_dropped_records_by_reason()` returns it as a
+dict.
+
+The counters live in process memory and die with the process, so a reader holding
+only `host.<pid>.log` would otherwise have no way to know records are missing —
+truncation leaves a record header behind, a drop leaves nothing. `prepare_to_fork()`
+therefore writes the breakdown into the log itself, at ERROR, whenever the total
+has grown since the last report:
+
+```text
+[HOSTLOG_DROPS] v=1 pid=1234 new=3 total=5 queue_full=5 claim_exhausted=0 output_failed=0 not_admitted=0
+```
+
+It reports a growth rather than a running total, so a process that quiesces at
+several fork boundaries does not restate the same losses each time. Every path
+that stops logging passes through that boundary, including `~HostLogger`.
+`strace_timing.py` parses these records and warns before it prints any timing,
+since a run that dropped records produces numbers derived from an incomplete log.
 
 ### Load and bind order
 
 Python seeds the extension-owned state before C++ loads consumers:
 
 ```python
-_initialize_host_log(level)
+_initialize_host_log(level, defer_writer=is_hierarchical)
+# Hierarchical workers perform all local forks here.
+_start_host_log_writer()
 self._impl.init(host_path, aicpu_path, aicore_path, dispatcher_path,
                 device_id, prewarm_config, enable_sdma, sim_context_path)
+# At submit, after CallConfig is available:
+_set_host_log_directory(config.output_prefix)
 ```
 
 `ChipWorker::init` then performs the module-specific work:
@@ -245,7 +332,7 @@ message tag.
 | Stage | Action | Source |
 | ----- | ------ | ------ |
 | Python import | Register `TIMING` / `NUL`; default the `simpler` logger to TIMING | `python/simpler/_log.py` |
-| `Worker.init()` | Normalize the Python logger level, seed native state before the first fork, and point the `simpler` logger at the host logger | `python/simpler/worker.py` |
+| `Worker.init()` | Normalize the Python level, attach it to the host logger, quiesce an old writer before local forks, then start a new writer after the final fork | `python/simpler/worker.py` |
 | `ChipWorker.init()` | Re-seed inherited native state in a chip child, then enter C++ | `python/simpler/task_interface.py` |
 | `_ChipWorker.init()` | Load sim context and host runtime, then bind each module's logger state | `src/common/worker/chip_worker.cpp` |
 | `simpler_init` | Onboard maps the bound threshold to CANN; attach and take executor binaries | `src/common/platform/{onboard,sim}/host/c_api_shared.cpp` |
@@ -289,11 +376,14 @@ someone gave a custom number.
 
 ### Forked chip subprocesses
 
-The hierarchical parent seeds native state before `fork()` and passes the
-normalized level explicitly to `_chip_process_loop`. The child re-seeds its
-inherited copy before loading runtime modules. This covers both chip-owning L3
-workers and higher-level processes that emit scheduler spans without loading a
-chip runtime.
+The hierarchical parent seeds native state and joins any prior writer before
+`fork()`. It starts its new writer only after the final local child exists and
+before remote activation creates other threads. A generic fork child starts a
+writer after its fallible setup returns (setup may recursively fork a lower
+subtree); a chip child starts one while initializing its `ChipWorker`. Normal
+`os._exit()` paths and Worker/ChipWorker teardown perform a bounded drain. This
+covers both chip-owning L3 workers and higher-level processes that emit
+scheduler spans without loading a chip runtime.
 
 ### Onboard AICPU severity is CANN-owned
 

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -1735,12 +1735,62 @@ NB_MODULE(_task_interface, m) {
     );
     m.def(
         "_initialize_host_log",
-        [](int level) {
+        [](int level, bool defer_writer) {
             if (!simpler::log::is_valid_level(level)) return false;
-            HostLogger::get_instance().set_level(static_cast<simpler::log::LogLevel>(level));
-            return true;
+            HostLogger &logger = HostLogger::get_instance();
+            if (defer_writer && !logger.prepare_to_fork()) return false;
+            logger.set_level(static_cast<simpler::log::LogLevel>(level), /*defer_writer=*/true);
+            return defer_writer || logger.start_writer();
         },
-        nb::arg("level"), "Seed the process-owned host-log state before workers fork or load runtime modules."
+        nb::arg("level"), nb::arg("defer_writer") = false,
+        "Seed the process-owned host-log state. A hierarchical worker defers its writer until after its last fork."
+    );
+    m.def(
+        "_start_host_log_writer",
+        [] {
+            return HostLogger::get_instance().start_writer();
+        },
+        "Start this process's bounded host-log writer after its final local fork."
+    );
+    m.def(
+        "_flush_host_log",
+        [](uint32_t timeout_ms) {
+            return HostLogger::get_instance().flush(timeout_ms);
+        },
+        nb::arg("timeout_ms") = 1000, nb::call_guard<nb::gil_scoped_release>(),
+        "Wait boundedly for all host-log records accepted by this process to be written."
+    );
+    m.def(
+        "_host_log_dropped_records",
+        [] {
+            return HostLogger::get_instance().dropped_records();
+        },
+        "Return the number of host-log records rejected by or lost from this process sink."
+    );
+    m.def(
+        "_host_log_dropped_records_by_reason",
+        [] {
+            const HostLogger &logger = HostLogger::get_instance();
+            nb::dict counts;
+            counts["queue_full"] = logger.dropped_records(SIMPLER_HOST_LOG_DROP_QUEUE_FULL);
+            counts["claim_exhausted"] = logger.dropped_records(SIMPLER_HOST_LOG_DROP_CLAIM_EXHAUSTED);
+            counts["output_failed"] = logger.dropped_records(SIMPLER_HOST_LOG_DROP_OUTPUT_FAILED);
+            counts["not_admitted"] = logger.dropped_records(SIMPLER_HOST_LOG_DROP_NOT_ADMITTED);
+            return counts;
+        },
+        "Return this process's host-log drops attributed by cause. The keys sum to "
+        "_host_log_dropped_records(). `queue_full` means the queue is too small for the burst; "
+        "`claim_exhausted` means the lock-free claim budget lost to contention with room still "
+        "in the queue; `output_failed` means the destination rejected the write; `not_admitted` "
+        "means there was no sink to submit to. They call for different fixes, which is why the "
+        "total alone is not actionable."
+    );
+    m.def(
+        "_host_log_pending_records",
+        [] {
+            return HostLogger::get_instance().pending_records();
+        },
+        "Return the number of accepted host-log records not yet written by this process sink."
     );
     m.def(
         "_set_host_log_directory",

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -26,7 +26,9 @@ Usage:
 
 from __future__ import annotations
 
+import contextlib
 import ctypes
+import sys
 import threading
 import uuid
 import weakref
@@ -77,10 +79,22 @@ from _task_interface import (
     _emit_host_log as _native_emit_host_log,
 )
 from _task_interface import (
+    _flush_host_log as _native_flush_host_log,
+)
+from _task_interface import (
     _host_log_directory as _native_host_log_directory,
 )
 from _task_interface import (
+    _host_log_dropped_records as _native_host_log_dropped_records,
+)
+from _task_interface import (
+    _host_log_pending_records as _native_host_log_pending_records,
+)
+from _task_interface import (
     _initialize_host_log as _native_initialize_host_log,
+)
+from _task_interface import (
+    _start_host_log_writer as _native_start_host_log_writer,
 )
 
 from .buffer import Buffer, Tensor
@@ -1240,8 +1254,8 @@ class GlobalCommDomainView:
         return self._committed
 
 
-def _initialize_host_log(log_level: int | None = None) -> None:
-    """Seed the extension-owned host-log state before runtime use or fork.
+def _initialize_host_log(log_level: int | None = None, *, defer_writer: bool = False) -> None:
+    """Seed host-log state, optionally leaving its writer stopped for local forks.
 
     Also points the Python `simpler` logger at that same host logger, so the two
     stop being separate logging systems that agree only on a threshold. This is
@@ -1253,9 +1267,61 @@ def _initialize_host_log(log_level: int | None = None) -> None:
 
     if log_level is None:
         log_level = _log.get_current_config()
-    if not _native_initialize_host_log(int(log_level)):
+    if int(log_level) not in (10, 20, 25, 30, 40, 60):
         raise ValueError(f"unsupported simpler log threshold: {log_level}")
+    if not _native_initialize_host_log(int(log_level), bool(defer_writer)):
+        raise RuntimeError(f"cannot initialize simpler host logging at threshold {log_level}")
     _log.attach_unified_log_handler(_native_emit_host_log, _native_host_log_directory)
+
+
+def _start_host_log_writer() -> None:
+    """Start the process-owned writer after the process's final local fork."""
+    if not _native_start_host_log_writer():
+        raise RuntimeError("cannot start simpler host-log writer")
+
+
+def _flush_host_log(timeout_ms: int = 1000) -> bool:
+    """Wait boundedly for this process's accepted host-log records."""
+    return bool(_native_flush_host_log(int(timeout_ms)))
+
+
+def _host_log_dropped_records() -> int:
+    """Return the process-owned sink's explicit loss counter."""
+    return int(_native_host_log_dropped_records())
+
+
+def _host_log_pending_records() -> int:
+    """Return accepted records that the process writer has not completed."""
+    return int(_native_host_log_pending_records())
+
+
+def _flush_host_log_or_warn(context: str, timeout_ms: int = 1000) -> bool:
+    """Flush boundedly and make a timeout or logger failure observable."""
+    try:
+        flushed = _flush_host_log(timeout_ms)
+    except BaseException as flush_error:  # noqa: BLE001
+        # The native logger is the failed component, so stderr is the only
+        # non-recursive diagnostic path left during teardown.
+        with contextlib.suppress(BaseException):
+            sys.stderr.write(f"WARNING: host-log flush failed during {context}: {flush_error}\n")
+        return False
+    if flushed:
+        return True
+
+    try:
+        pending: int | str = _host_log_pending_records()
+    except BaseException:  # noqa: BLE001
+        pending = "unknown"
+    try:
+        dropped: int | str = _host_log_dropped_records()
+    except BaseException:  # noqa: BLE001
+        dropped = "unknown"
+    with contextlib.suppress(BaseException):
+        sys.stderr.write(
+            f"WARNING: host-log flush timed out after {timeout_ms} ms during {context}; "
+            f"pending_records={pending}, dropped_records={dropped}; accepted records may be lost.\n"
+        )
+    return False
 
 
 class ChipWorker:
@@ -1377,6 +1443,7 @@ class ChipWorker:
         try:
             self._impl.finalize()
         finally:
+            _flush_host_log_or_warn("ChipWorker.finalize()")
             with self._registry_lock:
                 self._callable_registry.clear()
                 self._identity_registry.clear()

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -83,7 +83,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field, replace
 from multiprocessing import resource_tracker
 from multiprocessing.shared_memory import SharedMemory
-from typing import Any, cast
+from typing import Any, NoReturn, cast
 
 import cloudpickle
 from _task_interface import (  # pyright: ignore[reportMissingImports]
@@ -279,7 +279,9 @@ from .task_interface import (
     RemoteBufferExport,
     RemoteBufferHandle,
     TaskArgs,
+    _flush_host_log_or_warn,
     _initialize_host_log,
+    _start_host_log_writer,
     _Worker,
 )
 from .worker_chip_orch_comm import (
@@ -4339,6 +4341,12 @@ class RunHandle:
             raise
 
 
+def _exit_after_host_log_flush(status: int) -> NoReturn:
+    """Boundedly preserve accepted records before a fork child uses os._exit()."""
+    _flush_host_log_or_warn("fork-child os._exit()")
+    os._exit(status)
+
+
 def _forked_child_main(buf: memoryview, label: str, setup, serve, make_group_leader: bool = False) -> None:
     """Run a forked child to completion, always terminating via ``os._exit``.
 
@@ -4385,6 +4393,9 @@ def _forked_child_main(buf: memoryview, label: str, setup, serve, make_group_lea
         try:
             try:
                 ctx = setup()
+                # setup may recursively fork a complete lower-level subtree.
+                # Starting here keeps every C++ writer behind the final fork.
+                _start_host_log_writer()
             finally:
                 setup_active = False
         except _StartupCancelled:
@@ -4408,7 +4419,7 @@ def _forked_child_main(buf: memoryview, label: str, setup, serve, make_group_lea
             else:
                 exit_code = 0
     finally:
-        os._exit(exit_code)
+        _exit_after_host_log_flush(exit_code)
 
 
 # ---------------------------------------------------------------------------
@@ -7671,6 +7682,20 @@ class Worker:
             try:
                 self._cleanup_partial_init()
             finally:
+                # _start_hierarchical() quiesces the process-owned log writer
+                # before its first fork. If anything fails before the normal
+                # post-fork restart, restore that process-global service after
+                # rollback; otherwise this failed Worker silently disables logs
+                # from unrelated Workers and callers in the same parent.
+                if self.level >= 3:
+                    try:
+                        _start_host_log_writer()
+                    except BaseException as log_restore_error:  # noqa: BLE001 -- preserve the startup cause
+                        with contextlib.suppress(BaseException):
+                            sys.stderr.write(
+                                f"[worker pid={os.getpid()}] WARN: failed to restore host-log writer after "
+                                f"startup rollback: {log_restore_error}\n"
+                            )
                 with self._hierarchical_start_cv:
                     # Only an INITIALIZING epoch commits FAILED. FAILED is only
                     # written by the init thread. CLOSED is absorbing.
@@ -7873,7 +7898,7 @@ class Worker:
         # and emits their spans. A chip child re-seeds its inherited state before
         # binding the logger copies embedded in the runtime modules it loads.
         chip_log_level = _simpler_log.get_current_config()
-        _initialize_host_log(chip_log_level)
+        _initialize_host_log(chip_log_level, defer_writer=True)
 
         # Bind the level word this process's host-scheduler spans lead with. The
         # C++ emit sites in Orchestrator / WorkerThread are level-agnostic — the
@@ -7974,8 +7999,8 @@ class Worker:
                         if _mailbox_load_i32(_buffer_field_addr(buf, _OFF_STATE)) == _IDLE:
                             _write_error(buf, 1, _format_exc(f"chip worker {idx} dev={dev_id} init", e))
                             _mailbox_store_i32(_buffer_field_addr(buf, _OFF_STATE), _INIT_FAILED)
-                        os._exit(1)
-                    os._exit(0)
+                        _exit_after_host_log_flush(1)
+                    _exit_after_host_log_flush(0)
                 else:
                     self._chip_pids.append(pid)
                     if self._is_startup_root:
@@ -8065,6 +8090,11 @@ class Worker:
         # its descendants, so its INIT_READY means the whole subtree is ready. A
         # failure, exit, or hang aborts startup here.
         self._await_children_ready(self._next_level_shms, self._next_level_pids, "next_level", deadline)
+
+        # No local fork may follow this point. Only now is it safe to create the
+        # process-owned C++ writer thread; remote activation below creates its
+        # own health threads too.
+        _start_host_log_writer()
 
         # Last local fork is done. Now — and only now — open and register remote
         # L3 sessions: opening starts the remote subtree and registering spawns
@@ -11899,6 +11929,11 @@ class Worker:
                     if result is None:
                         result = exc
                 finally:
+                    # CLOSED prevents new admissions and teardown has quiesced
+                    # this Worker's producers. Preserve accepted records before
+                    # publishing completion, but never turn a stuck output into
+                    # an unbounded wait or a new close failure.
+                    _flush_host_log_or_warn("Worker.close()")
                     # The immutable outcome reference is the completion flag and
                     # result. A reader can therefore never observe completion
                     # without its error/incomplete payload. Publication precedes

--- a/simpler_setup/tools/strace_timing.py
+++ b/simpler_setup/tools/strace_timing.py
@@ -87,6 +87,15 @@ _BIND_PHASE_RE = re.compile(
     r"\[mono_ns=\d+\]\[T0x(?P<tid_hex>[0-9a-fA-F]+)\]\[TIMING\]\s+\S+:\s+"
     r"\[[^\]]*\]\s+bind phase=(?P<phase>\w+)\s+start_ns=(?P<start>\d+)\s+dur_ns=(?P<dur>\d+)(?P<attrs>[^\r\n]*)",
 )
+# The writer's own loss report, emitted at each quiescent boundary when the drop
+# total has grown. The counters live in process memory and die with it, so this
+# record is the only way a reader holding just the log learns that records are
+# missing — and the breakdown says which knob is wrong.
+_DROP_SUMMARY_RE = re.compile(
+    r"\[HOSTLOG_DROPS\]\s+v=(?P<v>\d+)\s+pid=(?P<pid>\d+)\s+new=(?P<new>\d+)\s+total=(?P<total>\d+)\s+"
+    r"queue_full=(?P<queue_full>\d+)\s+claim_exhausted=(?P<claim_exhausted>\d+)\s+"
+    r"output_failed=(?P<output_failed>\d+)\s+not_admitted=(?P<not_admitted>\d+)",
+)
 _CLOCK_ANCHOR_RE = re.compile(
     r"\[mono_ns=\d+\]\[T0x[0-9a-fA-F]+\]\[TIMING\]\s+clock_anchor:\s+"
     r"\[CLOCK_ANCHOR\]\s+v=(?P<v>\d+)\s+pid=(?P<pid>\d+)\s+"
@@ -220,6 +229,53 @@ def count_record_heads(lines):
     without it a torn record is indistinguishable from a real measurement.
     """
     return sum(len(_STRACE_HEAD_RE.findall(line)) for line in lines)
+
+
+def parse_drop_summaries(lines):
+    """Return the cumulative loss report per process, keyed by pid.
+
+    A process reports a growth at every quiescent boundary, so the last record
+    for a pid carries its running totals. Keyed by pid because each process has
+    its own queue and its own counters.
+    """
+    latest = {}
+    for line in lines:
+        for match in _DROP_SUMMARY_RE.finditer(line):
+            if int(match["v"]) != 1:
+                continue
+            pid = int(match["pid"])
+            total = int(match["total"])
+            previous = latest.get(pid)
+            if previous is None or total >= previous["total"]:
+                latest[pid] = {
+                    key: int(match[key])
+                    for key in ("total", "queue_full", "claim_exhausted", "output_failed", "not_admitted")
+                }
+    return latest
+
+
+def warn_about_lost_records(lines, spans):
+    """Report both ways a log can be incomplete, before any timing is derived.
+
+    They are separate channels and only one is visible in the records: a torn
+    record leaves a header behind, while a dropped one leaves nothing at all and
+    is knowable only from the writer's own summary.
+    """
+    heads = count_record_heads(lines)
+    if heads > len(spans):
+        print(
+            f"warning: {heads - len(spans)} of {heads} [STRACE] records are incomplete and are "
+            "excluded from the timing below",
+            file=sys.stderr,
+        )
+    for pid, counts in sorted(parse_drop_summaries(lines).items()):
+        print(
+            f"warning: pid {pid} dropped {counts['total']} host-log record(s) before they reached the "
+            f"destination (queue_full={counts['queue_full']} claim_exhausted={counts['claim_exhausted']} "
+            f"output_failed={counts['output_failed']} not_admitted={counts['not_admitted']}); "
+            "the timing below is computed from an incomplete log",
+            file=sys.stderr,
+        )
 
 
 def parse_clock_anchors(lines):
@@ -1470,13 +1526,7 @@ def main(argv=None):
             "check that every input is complete and that no process's stream is missing.",
             file=sys.stderr,
         )
-    heads = count_record_heads(lines)
-    if heads > len(spans):
-        print(
-            f"warning: {heads - len(spans)} of {heads} [STRACE] records are incomplete and are "
-            "excluded from the timing below",
-            file=sys.stderr,
-        )
+    warn_about_lost_records(lines, spans)
     keyed = invocation_spans(spans)
     invocations = group_invocations(keyed)
     buckets = bucket_by_hid(invocations)

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -209,11 +209,14 @@ int DeviceRunner::ensure_binaries_loaded() {
         using SetLogLevelFunc = void (*)(int);
         SetLogLevelFunc set_log_level_func = nullptr;
         if (!load_sym("set_log_level", reinterpret_cast<void **>(&set_log_level_func))) return PTO_RUNTIME_ERR_INTERNAL;
-        using SetHostLogStateFunc = void (*)(SimplerHostLogState *);
+        using SetHostLogStateFunc = int (*)(SimplerHostLogState *);
         SetHostLogStateFunc set_host_log_state_func = nullptr;
         if (!load_sym("set_host_log_state", reinterpret_cast<void **>(&set_host_log_state_func)))
             return PTO_RUNTIME_ERR_INTERNAL;
-        set_host_log_state_func(HostLogger::get_instance().state());
+        if (set_host_log_state_func(HostLogger::get_instance().state()) != 0) {
+            LOG_ERROR("AICPU SO rejected the host-log state ABI");
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
         set_log_level_func(HostLogger::get_instance().level());
 
         aicpu_so_loaded_ = true;

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -209,11 +209,14 @@ int DeviceRunner::ensure_binaries_loaded() {
         using SetLogLevelFunc = void (*)(int);
         SetLogLevelFunc set_log_level_func = nullptr;
         if (!load_sym("set_log_level", reinterpret_cast<void **>(&set_log_level_func))) return PTO_RUNTIME_ERR_INTERNAL;
-        using SetHostLogStateFunc = void (*)(SimplerHostLogState *);
+        using SetHostLogStateFunc = int (*)(SimplerHostLogState *);
         SetHostLogStateFunc set_host_log_state_func = nullptr;
         if (!load_sym("set_host_log_state", reinterpret_cast<void **>(&set_host_log_state_func)))
             return PTO_RUNTIME_ERR_INTERNAL;
-        set_host_log_state_func(HostLogger::get_instance().state());
+        if (set_host_log_state_func(HostLogger::get_instance().state()) != 0) {
+            LOG_ERROR("AICPU SO rejected the host-log state ABI");
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
         set_log_level_func(HostLogger::get_instance().level());
 
         aicpu_so_loaded_ = true;

--- a/src/common/log/host_log.cpp
+++ b/src/common/log/host_log.cpp
@@ -15,16 +15,23 @@
 
 #include "host_log.h"
 
+#include <algorithm>
+#include <array>
 #include <cerrno>
 #include <chrono>
 #include <cinttypes>
+#include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <fcntl.h>
 #include <limits.h>
+#include <mutex>
+#include <new>
 #include <pthread.h>
+#include <semaphore.h>
 #include <string>
-#include <vector>
+#include <thread>
 
 #include <unistd.h>
 
@@ -39,10 +46,23 @@ using simpler::log::LogLevel;
 
 namespace {
 
-// Every STRACE marker renders well inside this allocation bound, so the heap
-// fallback below stays off the path a traced run pays per span. This capacity
-// is not an atomic-write guarantee.
-constexpr size_t kRecordStackCapacity = 2048;
+// Every queued record fits the portable atomic pipe-write floor. The writer
+// therefore preserves one physical write per record when it falls back to a
+// stderr pipe shared by several processes.
+constexpr size_t kRecordCapacity = _POSIX_PIPE_BUF;
+// About 2 MiB per logging process: large enough to absorb ordinary bursts,
+// fixed enough that a permanently blocked destination cannot grow memory use.
+constexpr size_t kQueueCapacity = 4096;
+// Producers receive a fixed CPU budget for the lock-free MPSC position claim.
+// Exhausting it is a counted drop, never an I/O wait or condition-variable sleep.
+constexpr size_t kProducerClaimAttempts = 1024;
+constexpr uint64_t kProducerStopFlag = UINT64_C(1) << 63;
+static_assert(kQueueCapacity + 1 <= _POSIX_SEM_VALUE_MAX);
+
+#if defined(SIMPLER_HOST_LOG_TEST_HOOKS)
+std::atomic<void (*)(size_t)> g_after_queue_claim_hook{nullptr};
+std::atomic<void (*)()> g_before_gap_wait_hook{nullptr};
+#endif
 
 // POSIX guarantees atomic pipe writes up to _POSIX_PIPE_BUF (512 bytes). A
 // conservative bound for the logger prefix, fixed-width STRACE fields, and
@@ -50,6 +70,18 @@ constexpr size_t kRecordStackCapacity = 2048;
 constexpr size_t kHostSpanNameCapacity = 64;
 constexpr size_t kHostSpanAttributesCapacity = 192;
 static_assert(kHostSpanNameCapacity + kHostSpanAttributesCapacity <= _POSIX_PIPE_BUF - 256);
+static_assert(kRecordCapacity >= 2);
+
+struct QueuedRecord {
+    uint32_t size;
+    int32_t anchor_pid;
+    char data[kRecordCapacity];
+};
+
+struct QueueSlot {
+    std::atomic<size_t> sequence;
+    QueuedRecord record;
+};
 
 std::string encode_host_span_field(const char *value, size_t capacity, bool attributes) {
     static constexpr char kHex[] = "0123456789ABCDEF";
@@ -89,8 +121,8 @@ std::string encode_host_span_field(const char *value, size_t capacity, bool attr
 
 // Renders the timestamp/thread/level prefix, the caller's message, and an
 // optional trailing newline into `buffer`, and returns the length of the whole
-// record. A return value of `capacity` or more means `buffer` holds only a
-// truncated prefix and the caller must re-render into that many bytes.
+// record. A return value of `capacity` or more means `buffer` holds a truncated
+// record and the caller must replace its tail with the truncation marker.
 size_t format_record(
     char *buffer, size_t capacity, int64_t monotonic_ns, unsigned long tid, const char *level_tag, const char *func,
     const char *fmt, va_list args, bool append_newline
@@ -130,10 +162,10 @@ size_t format_record(
     return length;
 }
 
-bool write_stderr(const char *record, size_t size) {
+bool write_fd(int fd, const char *record, size_t size) {
     size_t offset = 0;
     while (offset < size) {
-        const ssize_t written = ::write(STDERR_FILENO, record + offset, size - offset);
+        const ssize_t written = ::write(fd, record + offset, size - offset);
         if (written > 0) {
             offset += static_cast<size_t>(written);
         } else if (written < 0 && errno == EINTR) {
@@ -143,6 +175,33 @@ bool write_stderr(const char *record, size_t size) {
         }
     }
     return true;
+}
+
+bool write_stderr(const char *record, size_t size) { return write_fd(STDERR_FILENO, record, size); }
+
+uint64_t atomic_load_u64(const uint64_t *value) { return __atomic_load_n(value, __ATOMIC_ACQUIRE); }
+
+void atomic_add_u64(uint64_t *value, uint64_t count) { __atomic_fetch_add(value, count, __ATOMIC_RELAXED); }
+
+void atomic_sub_u64(uint64_t *value, uint64_t count) { __atomic_fetch_sub(value, count, __ATOMIC_RELEASE); }
+
+void atomic_store_u64(uint64_t *value, uint64_t desired) { __atomic_store_n(value, desired, __ATOMIC_RELEASE); }
+
+// Every drop is one increment of the total plus one of its reason. Keeping them
+// in step is why no site touches dropped_record_count directly: a total that
+// disagrees with the breakdown is worse than either alone, because it makes both
+// unusable.
+void count_drop(SimplerHostLogState *state, SimplerHostLogDropReason reason) {
+    atomic_add_u64(&state->dropped_record_count, 1);
+    atomic_add_u64(&state->dropped_by_reason[reason], 1);
+}
+
+void release_anchor_after_write_failure(SimplerHostLogState *state, int32_t pid) {
+    int32_t observed = __atomic_load_n(&state->clock_anchor_pid, __ATOMIC_ACQUIRE);
+    while (
+        (observed == pid || observed == -pid) &&
+        !__atomic_compare_exchange_n(&state->clock_anchor_pid, &observed, 0, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)
+    ) {}
 }
 
 long host_trace_tid() {
@@ -155,17 +214,18 @@ long host_trace_tid() {
 
 struct HostLogFileSink {
     HostLogFileSink();
-    ~HostLogFileSink();
 
     std::mutex mutex;
-    FILE *stream = nullptr;
+    int fd = -1;
     pid_t pid = -1;
     std::string directory;
 };
 
 HostLogFileSink &host_log_file_sink() {
-    static HostLogFileSink sink;
-    return sink;
+    // Process-lifetime allocation avoids static-destruction order racing the
+    // writer thread. The kernel closes the fd when the process exits.
+    static auto *sink = new HostLogFileSink;
+    return *sink;
 }
 
 void host_log_sink_before_fork() { host_log_file_sink().mutex.lock(); }
@@ -179,83 +239,264 @@ HostLogFileSink::HostLogFileSink() {
     (void)pthread_atfork(host_log_sink_before_fork, host_log_sink_after_fork, host_log_sink_after_fork);
 }
 
-// One sink per DSO that compiles this file, so each holds its own buffered
-// stream on the shared per-process log. Closing it here is what puts that
-// buffer's tail on disk when the DSO is unloaded: dlclose runs this destructor,
-// and a dlopened module's records would otherwise be discarded with its mapping.
-// A stream this process did not open belongs to the parent that forked it and
-// is left alone, so the parent's copied stdio buffer is never flushed twice.
-HostLogFileSink::~HostLogFileSink() {
-    std::scoped_lock lock(mutex);
-    if (stream != nullptr && pid == getpid()) (void)std::fclose(stream);
-    stream = nullptr;
-}
-
-// Append one already-formatted record. The <=`PIPE_BUF` single-write rule that
-// makes a stderr record indivisible neither applies nor is needed here: this file
-// has exactly one writer process and the sink mutex serializes the writers inside
-// it, so a flush of up to the buffer's size cannot interleave with anything.
-//
-// Two properties a system tracer would have and this deliberately does not, so
-// the difference is not mistaken for an oversight. The flush runs on the thread
-// that emitted the record, where ftrace and Perfetto hand the bytes to a consumer
-// and never let a producer touch the output; and a full buffer here blocks that
-// thread rather than dropping and counting, where every comparable tracer bounds
-// the buffer and exports a loss counter. What this buys is one write per root
-// span instead of one per record — an order of magnitude, not the elimination of
-// the observer effect.
-bool write_log_file(const char *directory, const char *record, size_t size, bool flush) {
+// Blocking I/O is confined to the process writer thread. A raw append fd makes
+// completion and loss accounting exact: successful write(2) means the whole
+// record reached the kernel, with no hidden stdio buffer left to fail later.
+bool write_log_file(const char *directory, const char *record, size_t size) {
     HostLogFileSink &sink = host_log_file_sink();
     std::scoped_lock lock(sink.mutex);
     const pid_t pid = getpid();
-    const bool inherited = sink.stream != nullptr && sink.pid != pid;
-    const bool changed_directory = sink.stream != nullptr && sink.directory != directory;
+    const bool inherited = sink.fd >= 0 && sink.pid != pid;
+    const bool changed_directory = sink.fd >= 0 && sink.directory != directory;
     if (inherited) {
-        // Do not fclose(): its copied stdio buffer contains records already
-        // owned by the parent and must never be flushed again by the child.
-        // Dropping the FILE leaks it and its buffer in the child, one per
-        // process, which is the price of not duplicating the parent's records —
-        // C offers no portable way to discard a stream's buffer.
-        const int inherited_fd = fileno(sink.stream);
-        if (inherited_fd >= 0) (void)::close(inherited_fd);
-        sink.stream = nullptr;
+        (void)::close(sink.fd);
+        sink.fd = -1;
         sink.pid = -1;
         sink.directory.clear();
     } else if (changed_directory) {
-        std::fclose(sink.stream);
-        sink.stream = nullptr;
+        (void)::close(sink.fd);
+        sink.fd = -1;
         sink.pid = -1;
         sink.directory.clear();
     }
-    if (sink.stream == nullptr) {
+    if (sink.fd < 0) {
         char path[PATH_MAX];
         const int length = std::snprintf(path, sizeof(path), "%s/host.%d.log", directory, pid);
         if (length <= 0 || static_cast<size_t>(length) >= sizeof(path)) return false;
-        sink.stream = std::fopen(path, "a");
-        if (sink.stream == nullptr) return false;
-        std::setvbuf(sink.stream, nullptr, _IOFBF, 1U << 20U);
+        int flags = O_WRONLY | O_CREAT | O_APPEND;
+#ifdef O_CLOEXEC
+        flags |= O_CLOEXEC;
+#endif
+        sink.fd = ::open(path, flags, 0666);
+        if (sink.fd < 0) return false;
         sink.pid = pid;
         sink.directory = directory;
     }
-    if (std::fwrite(record, 1, size, sink.stream) != size) return false;
-    return !flush || std::fflush(sink.stream) == 0;
+    if (write_fd(sink.fd, record, size)) return true;
+    (void)::close(sink.fd);
+    sink.fd = -1;
+    sink.pid = -1;
+    sink.directory.clear();
+    return false;
 }
 
-bool flush_log_file() {
-    HostLogFileSink &sink = host_log_file_sink();
-    std::scoped_lock lock(sink.mutex);
-    return sink.stream == nullptr || std::fflush(sink.stream) == 0;
+const char *bound_log_directory(const SimplerHostLogState *state) {
+    if (__atomic_load_n(&state->log_directory_bound, __ATOMIC_ACQUIRE) != 1) return nullptr;
+    return state->log_directory;
 }
 
-}  // namespace
+// The one place a destination is chosen, and it chooses exactly one: a bound
+// directory is the destination, not a preference. A record the file cannot take
+// is dropped and counted rather than relocated to stderr, so "the log is
+// complete" and "dropped_record_count is zero" stay the same statement. The
+// alternative loses that: a bound directory that cannot be opened would send
+// every record to stderr while the counter still read zero, which is a silent
+// failure wearing a healthy counter.
+bool write_record_now(const SimplerHostLogState *state, const char *record, size_t size) {
+    const char *directory = bound_log_directory(state);
+    if (directory != nullptr) return write_log_file(directory, record, size);
+    return write_stderr(record, size);
+}
 
-namespace {
+struct HostLogAsyncSink {
+    explicit HostLogAsyncSink(SimplerHostLogState *shared_state) :
+        state(shared_state),
+        pid(getpid()) {
+        for (size_t index = 0; index < kQueueCapacity; ++index) {
+            queue[index].sequence.store(index, std::memory_order_relaxed);
+        }
+        // macOS deliberately does not implement unnamed semaphores. A named
+        // semaphore works on both supported host OSes; unlink it immediately so
+        // the kernel object has this process's handles as its only lifetime.
+        char name[32];
+        const int length = snprintf(
+            name, sizeof(name), "/sl-%x-%llx", static_cast<unsigned int>(pid),
+            static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(this))
+        );
+        if (length > 0 && static_cast<size_t>(length) < sizeof(name)) {
+            ready = sem_open(name, O_CREAT | O_EXCL, 0600, 0);
+            if (ready != SEM_FAILED && sem_unlink(name) != 0) {
+                (void)sem_close(ready);
+                ready = SEM_FAILED;
+            }
+        }
+    }
+
+    ~HostLogAsyncSink() {
+        if (ready != SEM_FAILED) (void)sem_close(ready);
+    }
+
+    bool start() {
+        if (ready == SEM_FAILED) return false;
+        try {
+            writer = std::thread([this] {
+                run();
+            });
+            return true;
+        } catch (...) {
+            return false;
+        }
+    }
+
+    bool stop_when_empty(uint32_t timeout_ms) {
+        if (!wait_until_empty(timeout_ms)) return false;
+
+        stopping.store(true, std::memory_order_release);
+        (void)sem_post(ready);
+        if (writer.joinable()) writer.join();
+        return true;
+    }
+
+    bool wait_until_empty(uint32_t timeout_ms) {
+        std::unique_lock<std::mutex> lock(completion_mutex);
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+        for (;;) {
+            if ((atomic_load_u64(&state->sink_producer_state) & ~kProducerStopFlag) == 0 &&
+                atomic_load_u64(&state->pending_record_count) == 0) {
+                return true;
+            }
+            const auto now = std::chrono::steady_clock::now();
+            if (now >= deadline) return false;
+            completion_cv.wait_until(lock, std::min(deadline, now + std::chrono::milliseconds(1)));
+        }
+    }
+
+    SimplerHostLogState *state;
+    pid_t pid;
+
+    static int
+    enqueue(void *context, SimplerHostLogState *state, const char *record, uint32_t size, int32_t anchor_pid) {
+        auto *sink = static_cast<HostLogAsyncSink *>(context);
+        if (sink == nullptr) {
+            atomic_sub_u64(&state->sink_producer_state, 1);
+            count_drop(state, SIMPLER_HOST_LOG_DROP_NOT_ADMITTED);
+            return 0;
+        }
+        if (sink->state != state || sink->pid != getpid() || size > kRecordCapacity) {
+            sink->producer_done();
+            count_drop(state, SIMPLER_HOST_LOG_DROP_NOT_ADMITTED);
+            return 0;
+        }
+
+        size_t position = sink->enqueue_position.load(std::memory_order_relaxed);
+        QueueSlot *slot = nullptr;
+        for (size_t attempt = 0; attempt < kProducerClaimAttempts; ++attempt) {
+            slot = &sink->queue[position % kQueueCapacity];
+            const size_t sequence = slot->sequence.load(std::memory_order_acquire);
+            const auto difference = static_cast<intptr_t>(sequence) - static_cast<intptr_t>(position);
+            if (difference == 0) {
+                if (sink->enqueue_position.compare_exchange_weak(
+                        position, position + 1, std::memory_order_relaxed, std::memory_order_relaxed
+                    )) {
+                    break;
+                }
+            } else if (difference < 0) {
+                sink->producer_done();
+                count_drop(state, SIMPLER_HOST_LOG_DROP_QUEUE_FULL);
+                return 0;  // The consumer has not freed this lap: queue full.
+            } else {
+                position = sink->enqueue_position.load(std::memory_order_relaxed);
+            }
+            slot = nullptr;
+        }
+        if (slot == nullptr) {
+            sink->producer_done();
+            count_drop(state, SIMPLER_HOST_LOG_DROP_CLAIM_EXHAUSTED);
+            return 0;
+        }
+
+#if defined(SIMPLER_HOST_LOG_TEST_HOOKS)
+        if (auto hook = g_after_queue_claim_hook.load(std::memory_order_acquire); hook != nullptr) hook(position);
+#endif
+
+        slot->record.size = size;
+        slot->record.anchor_pid = anchor_pid;
+        std::memcpy(slot->record.data, record, size);
+        atomic_add_u64(&state->pending_record_count, 1);
+        slot->sequence.store(position + 1, std::memory_order_release);
+        sink->queue_size.fetch_add(1, std::memory_order_release);
+        (void)sem_post(sink->ready);
+        sink->producer_done();
+        return 1;
+    }
+
+private:
+    void producer_done() {
+        // Producers never take the drain waiter's mutex. A waiter polls the
+        // atomic producer count at a bounded interval, so it cannot miss this
+        // transition permanently even though no condition-variable signal is
+        // needed on this hot path.
+        atomic_sub_u64(&state->sink_producer_state, 1);
+    }
+
+    bool pop(QueuedRecord *record) {
+        if (queue_size.load(std::memory_order_acquire) == 0) return false;
+        QueueSlot &slot = queue[dequeue_position % kQueueCapacity];
+        if (slot.sequence.load(std::memory_order_acquire) != dequeue_position + 1) return false;
+        *record = slot.record;
+        slot.sequence.store(dequeue_position + kQueueCapacity, std::memory_order_release);
+        ++dequeue_position;
+        queue_size.fetch_sub(1, std::memory_order_release);
+        return true;
+    }
+
+    void run() {
+        size_t ready_tokens = 0;
+        for (;;) {
+            if (ready_tokens == 0) {
+                int result;
+                do {
+                    result = sem_wait(ready);
+                } while (result != 0 && errno == EINTR);
+                if (result != 0) return;
+                if (stopping.load(std::memory_order_acquire) && queue_size.load(std::memory_order_acquire) == 0) return;
+                ++ready_tokens;
+            }
+
+            QueuedRecord record;
+            // Producers can publish adjacent MPSC positions out of order. A
+            // later token may wake us before the next position is visible, so
+            // retain every later token and sleep for the earlier producer's
+            // token instead of burning a CPU in an unbounded yield loop.
+            if (!pop(&record)) {
+#if defined(SIMPLER_HOST_LOG_TEST_HOOKS)
+                if (auto hook = g_before_gap_wait_hook.load(std::memory_order_acquire); hook != nullptr) hook();
+#endif
+                int result;
+                do {
+                    result = sem_wait(ready);
+                } while (result != 0 && errno == EINTR);
+                if (result != 0) return;
+                ++ready_tokens;
+                continue;
+            }
+            --ready_tokens;
+
+            if (!write_record_now(state, record.data, record.size)) {
+                count_drop(state, SIMPLER_HOST_LOG_DROP_OUTPUT_FAILED);
+                if (record.anchor_pid != 0) release_anchor_after_write_failure(state, record.anchor_pid);
+            }
+            atomic_sub_u64(&state->pending_record_count, 1);
+            completion_cv.notify_all();
+        }
+    }
+
+    std::array<QueueSlot, kQueueCapacity> queue;
+    std::atomic<size_t> queue_size{0};
+    std::atomic<size_t> enqueue_position{0};
+    size_t dequeue_position = 0;
+    sem_t *ready = SEM_FAILED;
+    std::atomic<bool> stopping{false};
+    std::mutex completion_mutex;
+    std::condition_variable completion_cv;
+    std::thread writer;
+};
 
 // A private logger stays silent until its owner seeds this state or its loader
 // binds the process-owned state. Missing binding is therefore observable as an
 // absent module stream rather than output filtered at the wrong threshold.
 SimplerHostLogState g_module_log_state{
-    SIMPLER_HOST_LOG_STATE_ABI_VERSION, sizeof(SimplerHostLogState), static_cast<int32_t>(LogLevel::NUL), 0, 0, {},
+    static_cast<int32_t>(LogLevel::NUL), 0, 0, {}, 0, 0, nullptr, nullptr, 0, 0, 0, {}, 0,
 };
 
 int32_t atomic_load_i32(const int32_t *value) { return __atomic_load_n(value, __ATOMIC_ACQUIRE); }
@@ -265,6 +506,34 @@ void atomic_store_i32(int32_t *value, int32_t desired) { __atomic_store_n(value,
 bool atomic_compare_exchange_i32(int32_t *value, int32_t *expected, int32_t desired) {
     return __atomic_compare_exchange_n(value, expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
 }
+
+void *atomic_load_pointer(void *const *value) { return __atomic_load_n(value, __ATOMIC_ACQUIRE); }
+
+void atomic_store_pointer(void **value, void *desired) { __atomic_store_n(value, desired, __ATOMIC_RELEASE); }
+
+SimplerHostLogEnqueueFn atomic_load_enqueue(SimplerHostLogEnqueueFn const *value) {
+    return __atomic_load_n(value, __ATOMIC_ACQUIRE);
+}
+
+void atomic_store_enqueue(SimplerHostLogEnqueueFn *value, SimplerHostLogEnqueueFn desired) {
+    __atomic_store_n(value, desired, __ATOMIC_RELEASE);
+}
+
+bool acquire_sink_producer(SimplerHostLogState *state) {
+    // Admission and stop are ordered by one atomic RMW. If stop won first, undo
+    // our transient producer reference and reject the record. If admission won
+    // first, prepare_to_fork() observes the reference and keeps sink_context
+    // alive until this producer returns. Unlike a CAS retry loop, this gives
+    // every producer a fixed admission cost under contention.
+    const uint64_t previous = __atomic_fetch_add(&state->sink_producer_state, 1, __ATOMIC_ACQ_REL);
+    if ((previous & kProducerStopFlag) != 0) {
+        atomic_sub_u64(&state->sink_producer_state, 1);
+        return false;
+    }
+    return true;
+}
+
+void release_sink_producer(SimplerHostLogState *state) { atomic_sub_u64(&state->sink_producer_state, 1); }
 
 }  // namespace
 
@@ -276,21 +545,185 @@ HostLogger &HostLogger::get_instance() {
 HostLogger::HostLogger() :
     state_(&g_module_log_state) {}
 
+HostLogger::~HostLogger() {
+    // Normal executable/module teardown gets a bounded chance to preserve
+    // accepted records. os._exit() call sites flush explicitly because static
+    // destructors do not run there.
+    (void)prepare_to_fork(100);
+}
+
 int HostLogger::bind_state(SimplerHostLogState *state) {
-    if (state == nullptr || state->abi_version != SIMPLER_HOST_LOG_STATE_ABI_VERSION ||
-        state->struct_size < sizeof(SimplerHostLogState) ||
-        !simpler::log::is_valid_level(atomic_load_i32(&state->threshold))) {
+    if (state == nullptr || !simpler::log::is_valid_level(atomic_load_i32(&state->threshold))) {
+        return -1;
+    }
+    state_owner_.store(false, std::memory_order_release);
+    state_.store(state, std::memory_order_release);
+    return 0;
+}
+
+int HostLogger::adopt_state(SimplerHostLogState *state) {
+    if (state == nullptr || !simpler::log::is_valid_level(atomic_load_i32(&state->threshold))) {
         return -1;
     }
     state_.store(state, std::memory_order_release);
+    state_owner_.store(true, std::memory_order_release);
     return 0;
 }
 
 SimplerHostLogState *HostLogger::state() const { return state_.load(std::memory_order_acquire); }
 
-void HostLogger::set_level(LogLevel level) {
+void HostLogger::set_level(LogLevel level, bool defer_writer) {
     atomic_store_i32(&state()->threshold, static_cast<int32_t>(level));
+    if (!defer_writer) (void)start_writer();
+}
+
+bool HostLogger::start_writer() {
+    SimplerHostLogState *shared = state();
+    const int32_t pid = static_cast<int32_t>(getpid());
+    int32_t owner = atomic_load_i32(&shared->sink_owner_pid);
+    const auto enqueue = atomic_load_enqueue(&shared->sink_enqueue);
+    void *context = atomic_load_pointer(&shared->sink_context);
+    if (owner == pid && enqueue != nullptr && context != nullptr) {
+        emit_clock_anchor_if_needed();
+        return true;
+    }
+
+    // A bound DSO may submit to an already-published process sink, but only the
+    // module that owns the process state may create that sink. Otherwise the
+    // callback and writer thread could outlive a transient dlopen() consumer.
+    if (!state_owner_.load(std::memory_order_acquire)) return false;
+
+    // Another caller is already constructing this process's sink. Treat that
+    // as a failed duplicate start instead of letting -pid claim itself.
+    if (owner == -pid) return false;
+    if (!atomic_compare_exchange_i32(&shared->sink_owner_pid, &owner, -pid)) return false;
+    __atomic_fetch_or(&shared->sink_producer_state, kProducerStopFlag, __ATOMIC_ACQ_REL);
+
+    const int32_t process_pid = atomic_load_i32(&shared->sink_process_pid);
+    if (process_pid != 0 && process_pid != pid) {
+        // A fork child inherits the parent's counters and callback addresses,
+        // but none of its threads or accepted records. Its new sink starts clean,
+        // even when the parent had already quiesced to owner=0 before fork.
+        atomic_store_u64(&shared->dropped_record_count, 0);
+        atomic_store_u64(&shared->pending_record_count, 0);
+        for (int reason = 0; reason < SIMPLER_HOST_LOG_DROP_REASON_COUNT; ++reason)
+            atomic_store_u64(&shared->dropped_by_reason[reason], 0);
+        atomic_store_u64(&shared->reported_drop_count, 0);
+        atomic_store_u64(&shared->sink_producer_state, kProducerStopFlag);
+    }
+    atomic_store_i32(&shared->sink_process_pid, pid);
+
+    auto *candidate = new (std::nothrow) HostLogAsyncSink(shared);
+    if (candidate == nullptr || !candidate->start()) {
+        delete candidate;
+        atomic_store_enqueue(&shared->sink_enqueue, nullptr);
+        atomic_store_pointer(&shared->sink_context, nullptr);
+        int32_t claim = -pid;
+        (void)atomic_compare_exchange_i32(&shared->sink_owner_pid, &claim, 0);
+        __atomic_fetch_and(&shared->sink_producer_state, ~kProducerStopFlag, __ATOMIC_RELEASE);
+        return false;
+    }
+
+    // The active sink normally has process lifetime. prepare_to_fork() is the
+    // explicit quiescent boundary that can join and reclaim it before a later
+    // hierarchical Worker forks in this process.
+    sink_.store(candidate, std::memory_order_release);
+    atomic_store_pointer(&shared->sink_context, candidate);
+    atomic_store_enqueue(&shared->sink_enqueue, &HostLogAsyncSink::enqueue);
+    atomic_store_i32(&shared->sink_owner_pid, pid);
+    __atomic_fetch_and(&shared->sink_producer_state, ~kProducerStopFlag, __ATOMIC_RELEASE);
     emit_clock_anchor_if_needed();
+    return true;
+}
+
+bool HostLogger::prepare_to_fork(uint32_t timeout_ms) {
+    SimplerHostLogState *shared = state();
+    const int32_t pid = static_cast<int32_t>(getpid());
+    int32_t owner = atomic_load_i32(&shared->sink_owner_pid);
+    if (owner == 0) return true;
+    if (owner == -pid) return false;
+    if (owner != pid) return true;
+
+    auto *sink = static_cast<HostLogAsyncSink *>(sink_.load(std::memory_order_acquire));
+    if (sink == nullptr || sink->state != shared || sink->pid != getpid()) return false;
+
+    if (!atomic_compare_exchange_i32(&shared->sink_owner_pid, &owner, -pid)) return false;
+    __atomic_fetch_or(&shared->sink_producer_state, kProducerStopFlag, __ATOMIC_ACQ_REL);
+    if (!sink->stop_when_empty(timeout_ms)) {
+        __atomic_fetch_and(&shared->sink_producer_state, ~kProducerStopFlag, __ATOMIC_RELEASE);
+        atomic_store_i32(&shared->sink_owner_pid, pid);
+        return false;
+    }
+
+    atomic_store_enqueue(&shared->sink_enqueue, nullptr);
+    atomic_store_pointer(&shared->sink_context, nullptr);
+    sink_.store(nullptr, std::memory_order_release);
+    atomic_store_i32(&shared->sink_owner_pid, 0);
+    delete sink;
+    // Last, once no queue remains to admit anyone into: the quiesced state is
+    // the same "no sink" state a process starts in, and emit()'s synchronous
+    // fallback is gated on the flag being clear. Leaving it set here would make
+    // every record between this call and the next start_writer() a silent drop —
+    // exactly the initialization window the fallback exists to cover. A producer
+    // that observes the pre-clear state still drops, as it must; one that
+    // observes the post-clear state re-reads sink_enqueue and finds it null, so
+    // it takes the fallback rather than a freed sink.
+    __atomic_fetch_and(&shared->sink_producer_state, ~kProducerStopFlag, __ATOMIC_RELEASE);
+    // Last, with the fallback usable again, so the summary reaches the same
+    // destination as everything it is accounting for.
+    report_drops_if_grown();
+    return true;
+}
+
+// The drop counters live in process memory and die with the process, so a reader
+// holding only host.<pid>.log has no other way to learn that records are missing.
+// This is the one place that can still write: every path that stops logging —
+// each fork boundary and ~HostLogger — passes through prepare_to_fork().
+//
+// Reported as a growth rather than a total, so a process that quiesces several
+// times does not restate the same losses at every boundary. ERROR, not WARN:
+// losing diagnostics is itself the failure, and a run whose threshold is ERROR
+// is exactly the one whose dropped records mattered most.
+void HostLogger::report_drops_if_grown() {
+    SimplerHostLogState *shared = state();
+    const uint64_t total = atomic_load_u64(&shared->dropped_record_count);
+    const uint64_t reported = atomic_load_u64(&shared->reported_drop_count);
+    if (total <= reported) return;
+    atomic_store_u64(&shared->reported_drop_count, total);
+    if (!is_enabled(LogLevel::ERROR)) return;
+    unsigned long long by_reason[SIMPLER_HOST_LOG_DROP_REASON_COUNT];
+    for (int reason = 0; reason < SIMPLER_HOST_LOG_DROP_REASON_COUNT; ++reason) {
+        by_reason[reason] = static_cast<unsigned long long>(atomic_load_u64(&shared->dropped_by_reason[reason]));
+    }
+    (void)emit_ungated(
+        0, level_name(LogLevel::ERROR), "host_log_drops",
+        "[HOSTLOG_DROPS] v=1 pid=%d new=%llu total=%llu queue_full=%llu claim_exhausted=%llu output_failed=%llu "
+        "not_admitted=%llu\n",
+        static_cast<int>(getpid()), static_cast<unsigned long long>(total - reported),
+        static_cast<unsigned long long>(total), by_reason[SIMPLER_HOST_LOG_DROP_QUEUE_FULL],
+        by_reason[SIMPLER_HOST_LOG_DROP_CLAIM_EXHAUSTED], by_reason[SIMPLER_HOST_LOG_DROP_OUTPUT_FAILED],
+        by_reason[SIMPLER_HOST_LOG_DROP_NOT_ADMITTED]
+    );
+}
+
+bool HostLogger::flush(uint32_t timeout_ms) {
+    SimplerHostLogState *shared = state();
+    if ((atomic_load_u64(&shared->sink_producer_state) & ~kProducerStopFlag) == 0 &&
+        atomic_load_u64(&shared->pending_record_count) == 0) {
+        return true;
+    }
+    auto *sink = static_cast<HostLogAsyncSink *>(sink_.load(std::memory_order_acquire));
+    if (sink == nullptr || sink->state != shared || sink->pid != getpid()) return false;
+    return sink->wait_until_empty(timeout_ms);
+}
+
+uint64_t HostLogger::dropped_records() const { return atomic_load_u64(&state()->dropped_record_count); }
+
+uint64_t HostLogger::pending_records() const { return atomic_load_u64(&state()->pending_record_count); }
+
+uint64_t HostLogger::dropped_records(SimplerHostLogDropReason reason) const {
+    if (reason < 0 || reason >= SIMPLER_HOST_LOG_DROP_REASON_COUNT) return 0;
+    return atomic_load_u64(&state()->dropped_by_reason[reason]);
 }
 
 int HostLogger::level() const { return atomic_load_i32(&state()->threshold); }
@@ -327,48 +760,67 @@ const char *HostLogger::level_name(LogLevel level) const {
     return "?";
 }
 
-bool HostLogger::emit(const char *level_tag, const char *func, const char *fmt, va_list args, bool flush) {
+bool HostLogger::emit(const char *level_tag, const char *func, const char *fmt, va_list args, int32_t anchor_pid) {
     const int64_t monotonic_ns = simpler::log::monotonic_now_ns();
     auto tid = static_cast<unsigned long>(reinterpret_cast<uintptr_t>(pthread_self()));
 
     const bool append_newline = fmt[0] != '\0' && fmt[strlen(fmt) - 1] != '\n';
 
-    // One write per record avoids thread interleaving under mutex_. On a shared
-    // pipe, only records no larger than that pipe's PIPE_BUF are indivisible
-    // across forked writers. Machine-readable host spans are separately
-    // budgeted to the portable _POSIX_PIPE_BUF floor (512 bytes); longer human
-    // log records use this same best-effort write path without that promise.
-    char stack_buffer[kRecordStackCapacity];
-    const size_t length = format_record(
-        stack_buffer, sizeof(stack_buffer), monotonic_ns, tid, level_tag, func, fmt, args, append_newline
-    );
-    if (length < sizeof(stack_buffer)) {
-        return write_record(stack_buffer, length, flush);
+    char record[kRecordCapacity];
+    const size_t length =
+        format_record(record, sizeof(record), monotonic_ns, tid, level_tag, func, fmt, args, append_newline);
+    size_t size = length;
+    if (length >= sizeof(record)) {
+        // A bounded record is part of the producer non-blocking contract. Keep
+        // a visible truncation marker and a complete physical log line.
+        record[sizeof(record) - 2] = '~';
+        record[sizeof(record) - 1] = '\n';
+        size = sizeof(record);
     }
 
-    std::vector<char> heap_buffer(length + 1);
-    const size_t heap_length = format_record(
-        heap_buffer.data(), heap_buffer.size(), monotonic_ns, tid, level_tag, func, fmt, args, append_newline
-    );
-    return write_record(heap_buffer.data(), heap_length < heap_buffer.size() ? heap_length : length, flush);
+    SimplerHostLogState *shared = state();
+    const int32_t pid = static_cast<int32_t>(getpid());
+    const int32_t owner = atomic_load_i32(&shared->sink_owner_pid);
+    const auto current_enqueue = atomic_load_enqueue(&shared->sink_enqueue);
+    void *current_context = atomic_load_pointer(&shared->sink_context);
+    const uint64_t producer_state = atomic_load_u64(&shared->sink_producer_state);
+    if (owner == 0 && current_enqueue == nullptr && current_context == nullptr &&
+        (producer_state & kProducerStopFlag) == 0) {
+        // Hierarchical processes deliberately have no writer until their final
+        // local fork. Preserve initialization records with the synchronous
+        // path; steady-state producers below remain bounded and do no output I/O.
+        if (write_record_now(shared, record, size)) return true;
+        count_drop(shared, SIMPLER_HOST_LOG_DROP_OUTPUT_FAILED);
+        if (anchor_pid != 0) release_anchor_after_write_failure(shared, anchor_pid);
+        return false;
+    }
+    if (!acquire_sink_producer(shared)) {
+        count_drop(shared, SIMPLER_HOST_LOG_DROP_NOT_ADMITTED);
+        return false;
+    }
+    if (atomic_load_i32(&shared->sink_owner_pid) != pid) {
+        release_sink_producer(shared);
+        count_drop(shared, SIMPLER_HOST_LOG_DROP_NOT_ADMITTED);
+        return false;
+    }
+    const auto enqueue = atomic_load_enqueue(&shared->sink_enqueue);
+    void *context = atomic_load_pointer(&shared->sink_context);
+    if (enqueue == nullptr || context == nullptr) {
+        release_sink_producer(shared);
+        count_drop(shared, SIMPLER_HOST_LOG_DROP_NOT_ADMITTED);
+        return false;
+    }
+    // A rejection is attributed by the sink, which is the only side that knows
+    // whether the queue was full or the claim budget ran out.
+    return enqueue(context, shared, record, size, anchor_pid) != 0;
 }
 
-// The one place a destination is chosen. It is a property of this logger, so it
-// holds for every record from every caller: nothing about a record's kind, its
-// producer, or its level selects a sink here.
-bool HostLogger::write_record(const char *record, size_t size, bool flush) {
-    const char *directory = log_directory();
-    if (directory != nullptr && write_log_file(directory, record, size, flush)) return true;
-    std::scoped_lock lock(mutex_);
-    return write_stderr(record, size);
-}
-
-bool HostLogger::emit_ungated(const char *level_tag, const char *func, const char *fmt, ...) {
+bool HostLogger::emit_ungated(int32_t anchor_pid, const char *level_tag, const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     // Its one caller writes the clock anchor, which every reader of this stream
     // needs before it can place anything else in wall time.
-    const bool written = emit(level_tag, func, fmt, args, /*flush=*/true);
+    const bool written = emit(level_tag, func, fmt, args, anchor_pid);
     va_end(args);
     return written;
 }
@@ -390,7 +842,7 @@ void HostLogger::emit_clock_anchor_if_needed() {
         std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch())
             .count();
     const bool written = emit_ungated(
-        level_name(LogLevel::TIMING), "clock_anchor", "[CLOCK_ANCHOR] v=1 pid=%d mono_ns=%lld wall_ns=%lld",
+        pid_value, level_name(LogLevel::TIMING), "clock_anchor", "[CLOCK_ANCHOR] v=1 pid=%d mono_ns=%lld wall_ns=%lld",
         static_cast<int>(pid), static_cast<long long>(monotonic_ns), static_cast<long long>(wall_ns)
     );
     int32_t claim = -pid_value;
@@ -402,9 +854,7 @@ void HostLogger::vlog(LogLevel level, const char *func, const char *fmt, va_list
         return;
     }
     emit_clock_anchor_if_needed();
-    // A warning or an error is rare and is worth having on disk if the process
-    // dies; everything below that rides the buffer.
-    emit(level_name(level), func, fmt, args, /*flush=*/level >= LogLevel::WARN);
+    (void)emit(level_name(level), func, fmt, args);
 }
 
 void HostLogger::log(LogLevel level, const char *func, const char *fmt, ...) {
@@ -447,7 +897,7 @@ void HostLogger::log_host_span(const SimplerHostSpan *span) {
 
     // One record grammar, in one place. Where it lands is the logger's business,
     // not this emitter's.
-    char record[kRecordStackCapacity];
+    char record[kRecordCapacity];
     (void)std::snprintf(
         record, sizeof(record),
         "[STRACE] v=1 pid=%d tid=%ld inv=%" PRIu64 " hid=%" PRIx64 " depth=%d name=%s ts=%" PRId64 " dur=%" PRId64
@@ -457,12 +907,15 @@ void HostLogger::log_host_span(const SimplerHostSpan *span) {
     );
 
     log(LogLevel::TIMING, "emit_host_span", "%s", record);
-    // A closed root span is where the records so far describe a whole
-    // invocation, which is what makes an in-progress run readable. It is the one
-    // thing this emitter knows that the writer does not.
-    if (span->depth == 0) (void)flush_log_file();
 }
 
 extern "C" __attribute__((visibility("default"))) int simpler_host_log_bind_state(SimplerHostLogState *state) {
     return HostLogger::get_instance().bind_state(state);
 }
+
+#if defined(SIMPLER_HOST_LOG_TEST_HOOKS)
+extern "C" void simpler_host_log_set_queue_hooks_for_test(void (*after_claim)(size_t), void (*before_gap_wait)()) {
+    g_after_queue_claim_hook.store(after_claim, std::memory_order_release);
+    g_before_gap_wait_hook.store(before_gap_wait, std::memory_order_release);
+}
+#endif

--- a/src/common/log/include/common/host_log_state.h
+++ b/src/common/log/include/common/host_log_state.h
@@ -13,8 +13,6 @@
 
 #include <stdint.h>
 
-#define SIMPLER_HOST_LOG_STATE_ABI_VERSION 2U
-
 /* Matches CallConfig::output_prefix, which is where the path comes from. */
 #define SIMPLER_HOST_LOG_DIR_CAPACITY 1024
 
@@ -24,32 +22,78 @@ extern "C" {
 
 /*
  * Process-owned state shared by the private HostLogger copy compiled into
- * every host-side DSO. The fields are plain integers and fixed char arrays so
- * modules built by different host compiler versions share a C ABI;
- * host_log.cpp performs all scalar accesses with compiler atomic builtins.
+ * every host-side DSO. Fixed-width fields plus a C callback keep the boundary
+ * independent of the C++ library ABI; host_log.cpp performs all mutable scalar
+ * accesses with compiler atomic builtins.
  *
  * clock_anchor_pid is positive after a successful anchor write and temporarily
  * negative while one writer owns the claim for that PID. Linux PIDs are
  * positive and bounded well below INT32_MAX.
  *
- * log_directory is where this logger writes, one fully-buffered file per
+ * log_directory is where the process writer appends records, one file per
  * process. It is empty until a caller that knows the run's artifact directory
- * supplies it, and every record goes to stderr while it is. The destination is
- * a property of the logger, so it applies to every record from every caller —
+ * supplies it, and the writer uses stderr while it is. The destination is a
+ * property of the logger, so it applies to every record from every caller —
  * there is no per-record or per-call-site routing.
  *
  * The first non-empty path wins: log_directory_bound is release-stored after the
  * path is filled and acquire-loaded before it is read, so a reader sees either no
  * directory or the whole one, and a reader that has already opened the file never
  * has the path change under it.
+ *
+ * sink_owner_pid follows the anchor's claim convention while the process owner
+ * creates the bounded sink. sink_process_pid distinguishes a parent restarting
+ * after a quiescent fork boundary from a child that inherited owner=0; the child
+ * starts fresh counters. The high bit of sink_producer_state closes admission;
+ * its low bits count callers that may still hold sink_context. Bound private
+ * logger copies submit complete records through sink_enqueue without exporting
+ * or interposing another ELF symbol.
+ *
+ * dropped_record_count is the total; dropped_by_reason attributes it. A total
+ * without the breakdown cannot answer the question a reader actually has —
+ * whether the queue was too small, the claim budget too tight, or the
+ * destination broken — and those three want opposite fixes. reported_drop_count
+ * is the total the last written loss summary named, so the quiescent boundary
+ * reports a growth rather than repeating a cumulative figure at every fork.
  */
+struct SimplerHostLogState;
+
+/* Why a record never reached the destination. Each drop increments the total and
+ * exactly one of these. */
+enum SimplerHostLogDropReason {
+    /* The consumer had not freed the slot this record's position maps to. */
+    SIMPLER_HOST_LOG_DROP_QUEUE_FULL = 0,
+    /* kProducerClaimAttempts atomic attempts did not win a position. Distinct
+     * from a full queue: the queue had room and contention took the budget. */
+    SIMPLER_HOST_LOG_DROP_CLAIM_EXHAUSTED = 1,
+    /* write(2) to the file or to stderr failed. */
+    SIMPLER_HOST_LOG_DROP_OUTPUT_FAILED = 2,
+    /* Admission was closed, or no sink was published to submit to. */
+    SIMPLER_HOST_LOG_DROP_NOT_ADMITTED = 3,
+    SIMPLER_HOST_LOG_DROP_REASON_COUNT = 4
+};
+
+/* Return nonzero only after the complete record has been accepted by the
+ * process sink. A zero return has already been attributed to a reason by the
+ * callee, so the caller must not count it again. */
+typedef int (*SimplerHostLogEnqueueFn)(
+    void *context, struct SimplerHostLogState *state, const char *record, uint32_t size, int32_t anchor_pid
+);
+
 typedef struct SimplerHostLogState {
-    uint32_t abi_version;
-    uint32_t struct_size;
     int32_t threshold;
     int32_t clock_anchor_pid;
     int32_t log_directory_bound;
     char log_directory[SIMPLER_HOST_LOG_DIR_CAPACITY];
+    int32_t sink_owner_pid;
+    int32_t sink_process_pid;
+    void *sink_context;
+    SimplerHostLogEnqueueFn sink_enqueue;
+    uint64_t dropped_record_count;
+    uint64_t pending_record_count;
+    uint64_t sink_producer_state;
+    uint64_t dropped_by_reason[SIMPLER_HOST_LOG_DROP_REASON_COUNT];
+    uint64_t reported_drop_count;
 } SimplerHostLogState;
 
 typedef int (*SimplerHostLogBindStateFn)(SimplerHostLogState *state);

--- a/src/common/log/include/host_log.h
+++ b/src/common/log/include/host_log.h
@@ -21,8 +21,7 @@
 
 #include <atomic>
 #include <cstdarg>
-#include <cstdio>
-#include <mutex>
+#include <cstdint>
 
 #include <sys/types.h>
 
@@ -44,6 +43,11 @@ public:
     // Bind this module-local logger implementation to process-owned state.
     // Must happen during module init, before the module starts worker threads.
     int bind_state(SimplerHostLogState *state);
+    // Internal owner-side counterpart used when an embedding executable
+    // supplies storage instead of this module's default state. Cross-DSO
+    // loaders must use bind_state(), so a transient consumer cannot own the
+    // process writer across dlclose().
+    int adopt_state(SimplerHostLogState *state);
     SimplerHostLogState *state() const;
 
     void log(simpler::log::LogLevel level, const char *func, const char *fmt, ...);
@@ -52,7 +56,26 @@ public:
     // responsible for `va_start` / `va_end`.
     void vlog(simpler::log::LogLevel level, const char *func, const char *fmt, va_list args);
 
-    void set_level(simpler::log::LogLevel level);
+    // Owner initialization starts the bounded writer by default. Hierarchical
+    // workers defer it until their final local fork so no process forks with a
+    // C++ thread already running.
+    void set_level(simpler::log::LogLevel level, bool defer_writer = false);
+    bool start_writer();
+
+    // A later hierarchical Worker may fork in the same process. Quiesce and
+    // join an earlier writer before that fork; fail boundedly if its output is
+    // pinned instead of forking while a C++ thread is alive.
+    bool prepare_to_fork(uint32_t timeout_ms = 1000);
+
+    // Drain records already accepted by this process owner. Producers must be
+    // quiescent if the caller needs a strict shutdown boundary.
+    bool flush(uint32_t timeout_ms = 1000);
+    uint64_t dropped_records() const;
+    // The same total, attributed. A caller sizing the queue or the claim budget
+    // needs to know which of them the losses came from; the total alone cannot
+    // distinguish "too small" from "too contended" from "destination broken".
+    uint64_t dropped_records(SimplerHostLogDropReason reason) const;
+    uint64_t pending_records() const;
 
     // Write this process's records to `path`/host.<pid>.log instead of stderr.
     // The caller is the one that knows where this run's artifacts go —
@@ -83,7 +106,7 @@ public:
 
 private:
     HostLogger();
-    ~HostLogger() = default;
+    ~HostLogger();
 
     HostLogger(const HostLogger &) = delete;
     HostLogger &operator=(const HostLogger &) = delete;
@@ -91,16 +114,20 @@ private:
     HostLogger &operator=(HostLogger &&) = delete;
 
     const char *level_name(simpler::log::LogLevel level) const;
-    bool emit(const char *level_tag, const char *func, const char *fmt, va_list args, bool flush);
-    // Writes one formatted record wherever this logger is configured to write.
-    // The only place a destination is chosen, and it is chosen per logger, not
-    // per record: no caller declares anything and no record kind is special.
-    bool write_record(const char *record, size_t size, bool flush);
-    bool emit_ungated(const char *level_tag, const char *func, const char *fmt, ...);
+    bool emit(const char *level_tag, const char *func, const char *fmt, va_list args, int32_t anchor_pid = 0);
+    bool emit_ungated(int32_t anchor_pid, const char *level_tag, const char *func, const char *fmt, ...);
     void emit_clock_anchor_if_needed();
+    // Write the loss breakdown into the log itself when it has grown since the
+    // last report. The counters die with the process, so without this a reader
+    // holding only the log file cannot tell that records are missing.
+    void report_drops_if_grown();
 
     std::atomic<SimplerHostLogState *> state_;
-    std::mutex mutex_;
+    std::atomic<bool> state_owner_{true};
+    // The queue implementation is private to host_log.cpp. Keeping only an
+    // opaque pointer here prevents its C++ type and inline methods from becoming
+    // preemptible symbols in every DSO that compiles the host logger.
+    std::atomic<void *> sink_{nullptr};
 };
 
 #undef SIMPLER_HOST_LOG_LOCAL

--- a/src/common/platform/include/aicpu/device_log.h
+++ b/src/common/platform/include/aicpu/device_log.h
@@ -68,8 +68,9 @@ extern "C" void set_log_level(int level);
 // host-side loader resolves it by name from the AICPU SO handle. Declared here
 // so both sides agree on the signature at compile time — the struct is only
 // forward-declared, keeping <dlfcn.h> and the state layout off device targets.
+// Returns zero when the ABI is accepted and nonzero otherwise.
 struct SimplerHostLogState;
-extern "C" void set_host_log_state(struct SimplerHostLogState *state);
+extern "C" int set_host_log_state(struct SimplerHostLogState *state);
 
 // Apply the platform's logging policy to a newly loaded orchestration SO.
 // Simulation binds the process-owned host state; onboard requires no handoff.

--- a/src/common/platform/sim/aicpu/device_log.cpp
+++ b/src/common/platform/sim/aicpu/device_log.cpp
@@ -46,8 +46,10 @@ extern "C" void set_log_level(int level) {
     }
 }
 
-extern "C" void set_host_log_state(SimplerHostLogState *state) {
-    if (HostLogger::get_instance().bind_state(state) == 0) g_host_log_state = state;
+extern "C" int set_host_log_state(SimplerHostLogState *state) {
+    const int result = HostLogger::get_instance().bind_state(state);
+    if (result == 0) g_host_log_state = state;
+    return result;
 }
 
 int bind_orchestration_host_log_state(void *handle, const char **error) {

--- a/tests/st/host_build_graph_validation/test_host_build_graph_validation.py
+++ b/tests/st/host_build_graph_validation/test_host_build_graph_validation.py
@@ -11,6 +11,7 @@
 
 import functools
 import os
+import time
 
 import pytest
 import torch
@@ -22,6 +23,8 @@ from simpler.task_interface import (
     DataType,
     TaskArgs,
     TensorArgType,
+    _flush_host_log,
+    _host_log_dropped_records,
 )
 from simpler.worker import Worker
 
@@ -43,6 +46,33 @@ CASES = {
     "write_task_produced_tensor": 6,
     "read_alloc_tensors_output": 7,
 }
+
+
+def _wait_for_host_log(capfd, markers: tuple[str, ...], dropped_before: int, timeout_s: float = 5.0) -> str:
+    """Poll for required records; a single scheduler-dependent flush is not the verdict."""
+    chunks: list[str] = []
+    deadline = time.monotonic() + timeout_s
+    last_flush = False
+    while True:
+        last_flush = _flush_host_log(100)
+        captured = capfd.readouterr()
+        chunks.extend((captured.err, captured.out))
+        log = "".join(chunks)
+        if all(marker in log for marker in markers):
+            dropped_after = _host_log_dropped_records()
+            assert dropped_after == dropped_before, (
+                f"host-log drop counter changed while waiting for {markers}: "
+                f"before={dropped_before}, after={dropped_after}"
+            )
+            return log
+        if time.monotonic() >= deadline:
+            dropped_after = _host_log_dropped_records()
+            missing = [marker for marker in markers if marker not in log]
+            raise AssertionError(
+                f"host-log records did not arrive within {timeout_s:.1f}s: missing={missing}, "
+                f"last_flush={last_flush}, dropped_delta={dropped_after - dropped_before}, tail={log[-2000:]!r}"
+            )
+        time.sleep(0.01)
 
 
 @functools.cache
@@ -85,6 +115,7 @@ def _build_callable(platform: str) -> ChipCallable:
 def test_invalid_input_reports_code_five(st_platform, st_device_ids, case_name, capfd):
     worker = Worker(level=2, platform=st_platform, runtime=RUNTIME, device_id=int(st_device_ids[0]))
     buffer = None
+    dropped_before = _host_log_dropped_records()
     try:
         handle = worker.register(_build_callable(st_platform))
         worker.init()
@@ -102,10 +133,7 @@ def test_invalid_input_reports_code_five(st_platform, st_device_ids, case_name, 
         with pytest.raises(RuntimeError, match=r"(run_runtime|run) failed with code -5\b"):
             worker.run(handle, args, config)
 
-        captured = capfd.readouterr()
-        log = captured.err + captured.out
-        assert "orch_error_code=5" in log
-        assert "INVALID_ARGS" in log
+        _wait_for_host_log(capfd, ("orch_error_code=5", "INVALID_ARGS"), dropped_before)
     finally:
         if buffer is not None:
             worker.free(buffer)

--- a/tests/st/runtime_fatal_codes/test_runtime_fatal_codes.py
+++ b/tests/st/runtime_fatal_codes/test_runtime_fatal_codes.py
@@ -29,9 +29,17 @@ Two host behaviours are exercised, because they genuinely differ:
 """
 
 import os
+import time
 
 import pytest
-from simpler.task_interface import ArgDirection, CallConfig, ChipCallable, CoreCallable
+from simpler.task_interface import (
+    ArgDirection,
+    CallConfig,
+    ChipCallable,
+    CoreCallable,
+    _flush_host_log,
+    _host_log_dropped_records,
+)
 from simpler.worker import Worker
 
 from simpler_setup.elf_parser import extract_text_section
@@ -43,6 +51,34 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 RUNTIME = "tensormap_and_ringbuffer"
 KERNELS = os.path.join(HERE, "kernels")
 ORCH_DIR = os.path.join(KERNELS, "orchestration")
+
+
+def _wait_for_host_log(capfd, markers: tuple[str, ...], dropped_before: int, timeout_s: float = 5.0) -> str:
+    """Poll for required records and report queue loss instead of trusting one flush deadline."""
+    chunks: list[str] = []
+    deadline = time.monotonic() + timeout_s
+    last_flush = False
+    while True:
+        last_flush = _flush_host_log(100)
+        captured = capfd.readouterr()
+        chunks.extend((captured.err, captured.out))
+        log = "".join(chunks)
+        if all(marker in log for marker in markers):
+            dropped_after = _host_log_dropped_records()
+            assert dropped_after == dropped_before, (
+                f"host-log drop counter changed while waiting for {markers}: "
+                f"before={dropped_before}, after={dropped_after}"
+            )
+            return log
+        if time.monotonic() >= deadline:
+            dropped_after = _host_log_dropped_records()
+            missing = [marker for marker in markers if marker not in log]
+            raise AssertionError(
+                f"host-log records did not arrive within {timeout_s:.1f}s: missing={missing}, "
+                f"last_flush={last_flush}, dropped_delta={dropped_after - dropped_before}, tail={log[-2000:]!r}"
+            )
+        time.sleep(0.01)
+
 
 # case -> dict(orch, code, runtime_env, kernel, marker, explain)
 #   code       : runtime status the host reports in sim (orch_error_code or sched_error_code)
@@ -304,13 +340,16 @@ def test_fatal_code_surfaces_on_sim(st_platform, st_device_ids, case_name, monke
     case = CASES[case_name]
     if case.get("onboard_only"):
         pytest.skip("hang kernel would spin the simulator forever (no STARS watchdog on sim)")
+    dropped_before = _host_log_dropped_records()
     worker, handle, config = _make_worker(st_platform, int(st_device_ids[0]), case_name, monkeypatch)
     try:
         with pytest.raises(RuntimeError, match=rf"(run_runtime|run) failed with code -{case['code']}\b"):
             worker.run(handle, None, config)
-        captured = capfd.readouterr()
-        log = captured.err + captured.out
-        assert case["marker"] in log, f"missing '{case['marker']}' in host log"
+        log = _wait_for_host_log(
+            capfd,
+            (case["marker"], "error detail:", case["explain"], "error hint:"),
+            dropped_before,
+        )
         _assert_annotated(log, case)
     finally:
         worker.close()
@@ -325,6 +364,7 @@ def test_device_error_class_reaches_host_log(st_platform, st_device_ids, case_na
     """onboard: the watchdog may mask the code as 507xxx, but the device class still reaches the host log."""
     configure_logging("error")
     case = CASES[case_name]
+    dropped_before = _host_log_dropped_records()
     worker, handle, config = _make_worker(st_platform, int(st_device_ids[0]), case_name, monkeypatch)
     try:
         # On hardware the op-execute / stream-sync watchdog can surface a generic
@@ -332,9 +372,11 @@ def test_device_error_class_reaches_host_log(st_platform, st_device_ids, case_na
         # run fails. The point of the test is the device-classified host LOG.
         with pytest.raises(RuntimeError):
             worker.run(handle, None, config)
-        captured = capfd.readouterr()
-        log = captured.err + captured.out
-        assert case["marker"] in log, f"device error class '{case['marker']}' not in host log"
+        log = _wait_for_host_log(
+            capfd,
+            (case["marker"], "error detail:", case["explain"], "error hint:"),
+            dropped_before,
+        )
         _assert_annotated(log, case)
     finally:
         worker.close()

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -1151,6 +1151,56 @@ add_dependencies(test_host_log_dso_unload test_host_log_unload_consumer)
 add_test(NAME test_host_log_dso_unload COMMAND test_host_log_dso_unload)
 set_tests_properties(test_host_log_dso_unload PROPERTIES LABELS "no_hardware")
 
+add_executable(test_host_log_nonblocking
+    common/test_host_log_nonblocking.cpp
+    ${HOST_LOG_TEST_SOURCES}
+)
+target_compile_definitions(test_host_log_nonblocking PRIVATE SIMPLER_HOST_LOG_TEST_HOOKS=1)
+target_include_directories(test_host_log_nonblocking PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${SIMPLER_LOG_DIR}
+    ${SIMPLER_LOG_DIR}/include
+)
+target_link_libraries(test_host_log_nonblocking PRIVATE
+    ${GTEST_MAIN_LIB}
+    ${GTEST_LIB}
+    pthread
+)
+add_test(NAME test_host_log_nonblocking COMMAND test_host_log_nonblocking)
+set_tests_properties(test_host_log_nonblocking PROPERTIES TIMEOUT 8 LABELS "no_hardware")
+
+add_library(test_host_log_consumer SHARED
+    common/test_host_log_consumer.cpp
+    ${HOST_LOG_TEST_SOURCES}
+)
+target_include_directories(test_host_log_consumer PRIVATE
+    ${SIMPLER_LOG_DIR}
+    ${SIMPLER_LOG_DIR}/include
+)
+target_link_libraries(test_host_log_consumer PRIVATE pthread)
+
+add_executable(test_host_log_cross_dso
+    common/test_host_log_cross_dso.cpp
+    ${HOST_LOG_TEST_SOURCES}
+)
+target_compile_definitions(test_host_log_cross_dso PRIVATE
+    TEST_HOST_LOG_CONSUMER_PATH="$<TARGET_FILE:test_host_log_consumer>"
+)
+target_include_directories(test_host_log_cross_dso PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${SIMPLER_LOG_DIR}
+    ${SIMPLER_LOG_DIR}/include
+)
+target_link_libraries(test_host_log_cross_dso PRIVATE
+    ${GTEST_MAIN_LIB}
+    ${GTEST_LIB}
+    ${CMAKE_DL_LIBS}
+    pthread
+)
+add_dependencies(test_host_log_cross_dso test_host_log_consumer)
+add_test(NAME test_host_log_cross_dso COMMAND test_host_log_cross_dso)
+set_tests_properties(test_host_log_cross_dso PROPERTIES LABELS "no_hardware")
+
 set(COMMON_PLATFORM_DIR ${CMAKE_SOURCE_DIR}/../../../src/common/platform)
 function(add_device_phase_capture_test name host_strace device_strace expected)
     add_executable(${name}

--- a/tests/ut/cpp/a5/test_host_log_off.cpp
+++ b/tests/ut/cpp/a5/test_host_log_off.cpp
@@ -52,10 +52,7 @@ struct CannLogLevelCall {
 
 CannLogLevelCall g_cann_log_level_call{};
 SimplerHostLogState g_shared_log_state{
-    SIMPLER_HOST_LOG_STATE_ABI_VERSION,
-    sizeof(SimplerHostLogState),
-    static_cast<int32_t>(LogLevel::TIMING),
-    0,
+    static_cast<int32_t>(LogLevel::TIMING), 0, 0, {}, 0, 0, nullptr, nullptr, 0, 0, 0, {}, 0,
 };
 
 int capture_cann_log_level(int module_id, int level, int enable_event) {
@@ -80,6 +77,7 @@ CapturedStdio run_with_config(LogLevel level, Fn &&fn) {
     HostLogger::get_instance().set_level(level);
 
     fn();
+    EXPECT_TRUE(HostLogger::get_instance().flush());
 
     fflush(stdout);
     fflush(stderr);
@@ -104,15 +102,8 @@ CapturedStdio run_with_config(LogLevel level, Fn &&fn) {
 
 }  // namespace
 
-TEST(HostLogTest, SharedStateBindingValidatesAbiAndOwnsThreshold) {
-    SimplerHostLogState bad_version = g_shared_log_state;
-    bad_version.abi_version++;
+TEST(HostLogTest, SharedStateBindingValidatesThresholdAndOwnsIt) {
     EXPECT_NE(simpler_host_log_bind_state(nullptr), 0);
-    EXPECT_NE(simpler_host_log_bind_state(&bad_version), 0);
-
-    SimplerHostLogState bad_size = g_shared_log_state;
-    bad_size.struct_size = sizeof(SimplerHostLogState) - 1;
-    EXPECT_NE(simpler_host_log_bind_state(&bad_size), 0);
 
     SimplerHostLogState bad_threshold = g_shared_log_state;
     bad_threshold.threshold = 26;
@@ -121,6 +112,9 @@ TEST(HostLogTest, SharedStateBindingValidatesAbiAndOwnsThreshold) {
     g_shared_log_state.threshold = static_cast<int32_t>(LogLevel::ERROR);
     g_shared_log_state.clock_anchor_pid = 0;
     ASSERT_EQ(simpler_host_log_bind_state(&g_shared_log_state), 0);
+    // This executable supplies the process-owned storage; production consumers
+    // only take the exported bind path and therefore cannot create its writer.
+    ASSERT_EQ(HostLogger::get_instance().adopt_state(&g_shared_log_state), 0);
     EXPECT_EQ(HostLogger::get_instance().state(), &g_shared_log_state);
     EXPECT_EQ(HostLogger::get_instance().level(), static_cast<int>(LogLevel::ERROR));
     EXPECT_FALSE(HostLogger::get_instance().is_enabled(LogLevel::WARN));
@@ -154,6 +148,7 @@ TEST(HostLogTest, HostSpanEnabledFollowsTimingVisibility) {
         EXPECT_EQ(unified_log_host_span_enabled(), expected);
     }
     HostLogger::get_instance().set_level(LogLevel::TIMING);
+    EXPECT_TRUE(HostLogger::get_instance().flush());
 }
 
 TEST(HostLogTest, ErrorLevelEmitsErrorOnly) {
@@ -248,6 +243,7 @@ TEST(HostLogTest, EmitPrefixHasMonotonicNanosecondsAndTid) {
 }
 
 TEST(HostLogTest, TimingStartupEmitsOneClockAnchorPerProcess) {
+    ASSERT_TRUE(HostLogger::get_instance().prepare_to_fork());
     int log_pipe[2];
     ASSERT_EQ(pipe(log_pipe), 0);
 
@@ -261,6 +257,7 @@ TEST(HostLogTest, TimingStartupEmitsOneClockAnchorPerProcess) {
         HostLogger::get_instance().set_level(LogLevel::TIMING);
         HostLogger::get_instance().log(LogLevel::TIMING, "child", "first-record");
         HostLogger::get_instance().log(LogLevel::TIMING, "child", "second-record");
+        if (!HostLogger::get_instance().flush()) _exit(3);
         _exit(0);
     }
 
@@ -277,6 +274,7 @@ TEST(HostLogTest, TimingStartupEmitsOneClockAnchorPerProcess) {
     ASSERT_EQ(waitpid(child, &status, 0), child);
     ASSERT_TRUE(WIFEXITED(status));
     ASSERT_EQ(WEXITSTATUS(status), 0);
+    ASSERT_TRUE(HostLogger::get_instance().start_writer());
 
     const size_t anchor_pos = captured.find("[CLOCK_ANCHOR]");
     ASSERT_NE(anchor_pos, std::string::npos);
@@ -321,6 +319,19 @@ TEST(HostLogTest, AllOutputGoesToStderr) {
     EXPECT_NE(captured.err.find("timing-output-marker"), std::string::npos);
     EXPECT_NE(captured.err.find("info-output-marker"), std::string::npos);
     EXPECT_NE(captured.err.find("debug-output-marker"), std::string::npos);
+}
+
+TEST(HostLogTest, LongHumanRecordFitsPortableAtomicWriteBound) {
+    const std::string payload(4096, 'x');
+    auto captured = run_with_config(LogLevel::ERROR, [&] {
+        HostLogger::get_instance().log(LogLevel::ERROR, "long_record", "%s", payload.c_str());
+    });
+
+    EXPECT_EQ(captured.out, "");
+    ASSERT_EQ(captured.err.size(), static_cast<size_t>(_POSIX_PIPE_BUF));
+    EXPECT_EQ(std::count(captured.err.begin(), captured.err.end(), '\n'), 1);
+    EXPECT_EQ(captured.err[captured.err.size() - 2], '~');
+    EXPECT_EQ(captured.err.back(), '\n');
 }
 
 TEST(HostLogTest, HostSpanEscapesDelimitersAndFitsAtomicPipeRecord) {
@@ -384,7 +395,7 @@ std::string read_log_file(const char *directory, pid_t pid) {
     return std::string((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
 }
 
-TEST(HostLogTest, LogDirectorySendsEveryRecordToOneBufferedFilePerProcess) {
+TEST(HostLogTest, LogDirectorySendsEveryRecordToOneAsyncFilePerProcess) {
     char directory_template[] = "/tmp/simpler-host-strace-XXXXXX";
     char *directory = mkdtemp(directory_template);
     ASSERT_NE(directory, nullptr);
@@ -434,7 +445,7 @@ TEST(HostLogTest, LogDirectorySendsEveryRecordToOneBufferedFilePerProcess) {
     EXPECT_EQ(rmdir(directory), 0);
 }
 
-TEST(HostLogTest, LogDirectoryTakesOrdinaryRecordsAndFlushesTheSevereOnes) {
+TEST(HostLogTest, ExplicitDrainMakesAllAcceptedFileRecordsVisible) {
     char directory_template[] = "/tmp/simpler-host-log-ordinary-XXXXXX";
     char *directory = mkdtemp(directory_template);
     ASSERT_NE(directory, nullptr);
@@ -443,22 +454,22 @@ TEST(HostLogTest, LogDirectoryTakesOrdinaryRecordsAndFlushesTheSevereOnes) {
     g_shared_log_state.clock_anchor_pid = 0;
     const auto captured = run_with_config(LogLevel::TIMING, [] {
         HostLogger::get_instance().log(LogLevel::ERROR, "fn", "disk-please");
-        HostLogger::get_instance().log(LogLevel::INFO, "fn", "buffered-please");
+        HostLogger::get_instance().log(LogLevel::TIMING, "fn", "queued-please");
     });
     EXPECT_EQ(captured.err, "");
 
-    // Read before any root span closes: an error is rare and worth having on
-    // disk if the process dies, so it is flushed as it is written. The INFO
-    // record rides the buffer and need not be visible yet.
+    // run_with_config performs the explicit shutdown/test drain. Severity no
+    // longer selects a producer-side flush path: both records use one queue.
     const std::string contents = read_log_file(directory, getpid());
     EXPECT_NE(contents.find("disk-please"), std::string::npos);
+    EXPECT_NE(contents.find("queued-please"), std::string::npos);
 
     const std::string path = std::string(directory) + "/host." + std::to_string(static_cast<int>(getpid())) + ".log";
     EXPECT_EQ(unlink(path.c_str()), 0);
     EXPECT_EQ(rmdir(directory), 0);
 }
 
-TEST(HostLogTest, ForkedChildReopensItsOwnSpanFileWithoutFlushingParentBuffer) {
+TEST(HostLogTest, ForkBoundaryDrainsParentAndChildOpensItsOwnFile) {
     char directory_template[] = "/tmp/simpler-host-strace-fork-XXXXXX";
     char *directory = mkdtemp(directory_template);
     ASSERT_NE(directory, nullptr);
@@ -472,6 +483,9 @@ TEST(HostLogTest, ForkedChildReopensItsOwnSpanFileWithoutFlushingParentBuffer) {
         SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 8, 0x1234, 1, 0, 100, 25, "parent.span", ""
     };
     unified_log_host_span(&parent_span);
+    // Production uses this same quiescent boundary before a hierarchical
+    // Worker forks: accepted parent records are drained and the thread joined.
+    ASSERT_TRUE(HostLogger::get_instance().prepare_to_fork());
 
     const pid_t child = fork();
     ASSERT_GE(child, 0);
@@ -479,9 +493,12 @@ TEST(HostLogTest, ForkedChildReopensItsOwnSpanFileWithoutFlushingParentBuffer) {
         const SimplerHostSpan child_span{
             SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 9, 0x1234, 0, 0, 200, 25, "child.span", ""
         };
+        HostLogger::get_instance().set_level(LogLevel::TIMING);
         unified_log_host_span(&child_span);
+        if (!HostLogger::get_instance().flush()) _exit(3);
         _exit(0);
     }
+    ASSERT_TRUE(HostLogger::get_instance().start_writer());
     int status = 0;
     ASSERT_EQ(waitpid(child, &status, 0), child);
     ASSERT_TRUE(WIFEXITED(status));
@@ -495,14 +512,10 @@ TEST(HostLogTest, ForkedChildReopensItsOwnSpanFileWithoutFlushingParentBuffer) {
     const std::string child_contents((std::istreambuf_iterator<char>(child_input)), std::istreambuf_iterator<char>());
     EXPECT_EQ(child_contents.find("name=parent.span"), std::string::npos);
     EXPECT_NE(child_contents.find("name=child.span"), std::string::npos);
-    // The parent's record is depth 1, so it is still unflushed in the parent's
-    // own buffer. It can only have reached the parent's file if the child
-    // flushed the copy it inherited — which is what this test is named for, and
-    // what the child's file alone cannot show.
     std::ifstream parent_input(parent_path);
     const std::string parent_contents((std::istreambuf_iterator<char>(parent_input)), std::istreambuf_iterator<char>());
-    EXPECT_EQ(parent_contents.find("name=parent.span"), std::string::npos)
-        << "the child flushed the parent's copied stdio buffer";
+    EXPECT_NE(parent_contents.find("name=parent.span"), std::string::npos);
+    EXPECT_EQ(parent_contents.find("name=child.span"), std::string::npos);
     EXPECT_EQ(unlink(parent_path.c_str()), 0);
     EXPECT_EQ(unlink(child_path.c_str()), 0);
     EXPECT_EQ(rmdir(directory), 0);
@@ -510,7 +523,7 @@ TEST(HostLogTest, ForkedChildReopensItsOwnSpanFileWithoutFlushingParentBuffer) {
 
 TEST(HostLogTest, DisabledHostSpanProducesNoRecord) {
     const SimplerHostSpan span{
-        SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 7, 0x1234, 0, 0, 100, 25, "host.dispatch",
+        SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 7, 0x1234, 0, 0, 100, 25, "node.dispatch",
         "run_id=7 role=scheduler"
     };
 
@@ -586,6 +599,7 @@ TEST(HostLogTest, HostSpanTruncationDropsAWholeEscapeRatherThanItsLastByte) {
 }
 
 TEST(HostLogTest, ForkedProcessesEmitWholePipeRecords) {
+    ASSERT_TRUE(HostLogger::get_instance().prepare_to_fork());
     int log_pipe[2];
     int start_pipe[2];
     ASSERT_EQ(pipe(log_pipe), 0);
@@ -593,7 +607,7 @@ TEST(HostLogTest, ForkedProcessesEmitWholePipeRecords) {
 
     const long pipe_buf = fpathconf(log_pipe[1], _PC_PIPE_BUF);
     ASSERT_GT(pipe_buf, 256);
-    const size_t payload_size = static_cast<size_t>(std::min<long>(pipe_buf - 256, 2048));
+    constexpr size_t payload_size = 128;
     constexpr int child_count = 16;
     constexpr int records_per_child = 128;
 
@@ -618,6 +632,7 @@ TEST(HostLogTest, ForkedProcessesEmitWholePipeRecords) {
                     LogLevel::ERROR, "fork_writer", "child=%d seq=%d payload=%s", child, seq, payload.c_str()
                 );
             }
+            if (!HostLogger::get_instance().flush(5000)) _exit(3);
             _exit(0);
         }
         children.push_back(pid);
@@ -657,6 +672,7 @@ TEST(HostLogTest, ForkedProcessesEmitWholePipeRecords) {
         }
     }
     reader.join();
+    ASSERT_TRUE(HostLogger::get_instance().start_writer());
 
     std::vector<std::vector<bool>> seen(child_count, std::vector<bool>(records_per_child, false));
     std::set<int> anchor_pids;

--- a/tests/ut/cpp/common/test_host_log_consumer.cpp
+++ b/tests/ut/cpp/common/test_host_log_consumer.cpp
@@ -9,21 +9,12 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#include <gtest/gtest.h>
-
-#include "common/host_span.h"
-#include "common/log_level.h"
 #include "host_log.h"
 
-TEST(HostLogUnboundTest, PrivateModuleStateStartsSilent) {
-    EXPECT_EQ(HostLogger::get_instance().level(), static_cast<int>(simpler::log::LogLevel::NUL));
-    EXPECT_EQ(unified_log_host_span_enabled(), 0);
+extern "C" __attribute__((visibility("default"))) void test_host_log_consumer_emit() {
+    HostLogger::get_instance().log(simpler::log::LogLevel::ERROR, "consumer", "cross-dso-record");
+}
 
-    const SimplerHostSpan span{
-        SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 1, 0, 0, 0, 100, 25, "node.dispatch", "run_id=1"
-    };
-    testing::internal::CaptureStderr();
-    HostLogger::get_instance().log(simpler::log::LogLevel::ERROR, "unbound", "must stay silent");
-    unified_log_host_span(&span);
-    EXPECT_EQ(testing::internal::GetCapturedStderr(), "");
+extern "C" __attribute__((visibility("default"))) int test_host_log_consumer_start_writer() {
+    return HostLogger::get_instance().start_writer() ? 1 : 0;
 }

--- a/tests/ut/cpp/common/test_host_log_cross_dso.cpp
+++ b/tests/ut/cpp/common/test_host_log_cross_dso.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <fstream>
+#include <string>
+
+#include <dlfcn.h>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+#include "common/host_log_state.h"
+#include "host_log.h"
+
+using simpler::log::LogLevel;
+
+TEST(HostLogCrossDsoTest, BoundConsumerUsesProcessOwnedFileSink) {
+    char directory_template[] = "/tmp/simpler-host-log-cross-dso-XXXXXX";
+    char *directory = mkdtemp(directory_template);
+    ASSERT_NE(directory, nullptr);
+
+    HostLogger &owner = HostLogger::get_instance();
+    owner.set_log_directory(directory);
+    owner.set_level(LogLevel::ERROR);
+
+    void *handle = dlopen(TEST_HOST_LOG_CONSUMER_PATH, RTLD_NOW | RTLD_LOCAL);
+    ASSERT_NE(handle, nullptr) << dlerror();
+
+    dlerror();
+    auto bind = reinterpret_cast<SimplerHostLogBindStateFn>(dlsym(handle, "simpler_host_log_bind_state"));
+    ASSERT_NE(bind, nullptr) << dlerror();
+    ASSERT_EQ(bind(owner.state()), 0);
+
+    dlerror();
+    auto emit = reinterpret_cast<void (*)()>(dlsym(handle, "test_host_log_consumer_emit"));
+    ASSERT_NE(emit, nullptr) << dlerror();
+    dlerror();
+    auto start_writer = reinterpret_cast<int (*)()>(dlsym(handle, "test_host_log_consumer_start_writer"));
+    ASSERT_NE(start_writer, nullptr) << dlerror();
+
+    owner.log(LogLevel::ERROR, "owner", "owner-record");
+    emit();
+    ASSERT_TRUE(owner.flush());
+    EXPECT_EQ(start_writer(), 1) << "a bound consumer should recognize the already-published owner sink";
+
+    const std::string path = std::string(directory) + "/host." + std::to_string(static_cast<int>(getpid())) + ".log";
+    std::ifstream input(path);
+    ASSERT_TRUE(input.good());
+    const std::string captured((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+    input.close();
+
+    EXPECT_NE(captured.find("][ERROR] owner: owner-record\n"), std::string::npos);
+    EXPECT_NE(captured.find("][ERROR] consumer: cross-dso-record\n"), std::string::npos);
+    ASSERT_TRUE(owner.prepare_to_fork());
+    EXPECT_EQ(start_writer(), 0) << "a transient bound DSO must not become the process sink owner";
+    EXPECT_EQ(dlclose(handle), 0);
+    EXPECT_EQ(unlink(path.c_str()), 0);
+    EXPECT_EQ(rmdir(directory), 0);
+}

--- a/tests/ut/cpp/common/test_host_log_dso_unload.cpp
+++ b/tests/ut/cpp/common/test_host_log_dso_unload.cpp
@@ -9,11 +9,12 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-// Every DSO that compiles the host logger owns a private buffered stream on the
-// shared per-process log file. This pins the consequence: unloading such a
-// module must put that stream's tail on disk, because dlclose discards the
-// mapping the buffer lives in. DeviceRunner::unload_executor_binaries() does
-// exactly this to the sim AICPU SO on every teardown.
+// A bound consumer DSO submits through the process owner's queue, and enqueue
+// copies the record into the owner's slot rather than retaining the caller's
+// storage. This pins the consequence: unloading such a module cannot lose the
+// records it already submitted, even though dlclose discards the mapping they
+// were formatted in. DeviceRunner::unload_executor_binaries() does exactly this
+// to the sim AICPU SO on every teardown.
 
 #include <fstream>
 #include <string>
@@ -64,6 +65,10 @@ TEST(HostLogUnloadTest, UnloadedModuleLeavesNoRecordsInItsPrivateBuffer) {
     ASSERT_EQ(bind(owner.state()), 0);
     emit(kRecords);
     ASSERT_EQ(dlclose(handle), 0);
+    // After the unload, so this asserts the owner can still write records whose
+    // producer is gone. The writer owns the destination, so nothing is on disk
+    // until this returns — reading the file without it races the writer thread.
+    ASSERT_TRUE(owner.flush());
 
     const std::string path = std::string(directory) + "/host." + std::to_string(static_cast<int>(getpid())) + ".log";
     std::ifstream input(path);

--- a/tests/ut/cpp/common/test_host_log_nonblocking.cpp
+++ b/tests/ut/cpp/common/test_host_log_nonblocking.cpp
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <csignal>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+#include "host_log.h"
+
+using simpler::log::LogLevel;
+
+extern "C" void simpler_host_log_set_queue_hooks_for_test(void (*after_claim)(size_t), void (*before_gap_wait)());
+
+namespace {
+
+std::mutex g_gap_mutex;
+std::condition_variable g_gap_cv;
+bool g_first_claimed = false;
+bool g_release_first = false;
+bool g_writer_waiting_for_gap = false;
+
+void pause_first_queue_claim(size_t position) {
+    if (position != 0) return;
+    std::unique_lock<std::mutex> lock(g_gap_mutex);
+    g_first_claimed = true;
+    g_gap_cv.notify_all();
+    g_gap_cv.wait(lock, [] {
+        return g_release_first;
+    });
+}
+
+void observe_writer_gap_wait() {
+    std::scoped_lock lock(g_gap_mutex);
+    g_writer_waiting_for_gap = true;
+    g_gap_cv.notify_all();
+}
+
+}  // namespace
+
+TEST(HostLogNonblockingTest, DeferredWriterPreservesInitializationRecordsAndDropCount) {
+    HostLogger &logger = HostLogger::get_instance();
+    logger.set_level(LogLevel::ERROR, /*defer_writer=*/true);
+
+    const uint64_t before = logger.dropped_records();
+    testing::internal::CaptureStderr();
+    logger.log(LogLevel::ERROR, "initialization", "before-writer");
+    const std::string captured = testing::internal::GetCapturedStderr();
+    EXPECT_NE(captured.find("][ERROR] initialization: before-writer\n"), std::string::npos);
+    EXPECT_EQ(logger.dropped_records(), before);
+
+    const int saved_stderr = dup(STDERR_FILENO);
+    ASSERT_GE(saved_stderr, 0);
+    ASSERT_EQ(close(STDERR_FILENO), 0);
+    logger.log(LogLevel::ERROR, "initialization", "failed-before-writer");
+    ASSERT_GE(dup2(saved_stderr, STDERR_FILENO), 0);
+    close(saved_stderr);
+    ASSERT_EQ(logger.dropped_records(), before + 1);
+
+    // The first writer start records this process PID. It is not a fork-child
+    // transition and must not erase failures observed during initialization.
+    ASSERT_TRUE(logger.start_writer());
+    EXPECT_EQ(logger.dropped_records(), before + 1);
+    EXPECT_TRUE(logger.prepare_to_fork());
+}
+
+// A total without a breakdown cannot tell "the queue is too small" from "the
+// destination is broken", and those want opposite fixes. Pin that each drop lands
+// in exactly one bucket and that the buckets sum to the total.
+TEST(HostLogNonblockingTest, OutputFailureIsAttributedToTheOutputBucket) {
+    HostLogger &logger = HostLogger::get_instance();
+    logger.set_level(LogLevel::ERROR, /*defer_writer=*/true);
+
+    const uint64_t before_total = logger.dropped_records();
+    const uint64_t before_output = logger.dropped_records(SIMPLER_HOST_LOG_DROP_OUTPUT_FAILED);
+    const uint64_t before_queue = logger.dropped_records(SIMPLER_HOST_LOG_DROP_QUEUE_FULL);
+    const uint64_t before_claim = logger.dropped_records(SIMPLER_HOST_LOG_DROP_CLAIM_EXHAUSTED);
+
+    // Closing stderr is the portable way to make the final write(2) fail; there
+    // is no bound directory here, so stderr is the destination.
+    const int saved_stderr = dup(STDERR_FILENO);
+    ASSERT_GE(saved_stderr, 0);
+    ASSERT_EQ(close(STDERR_FILENO), 0);
+    logger.log(LogLevel::ERROR, "attribution", "unwritable");
+    ASSERT_GE(dup2(saved_stderr, STDERR_FILENO), 0);
+    close(saved_stderr);
+
+    EXPECT_EQ(logger.dropped_records(), before_total + 1);
+    EXPECT_EQ(logger.dropped_records(SIMPLER_HOST_LOG_DROP_OUTPUT_FAILED), before_output + 1);
+    EXPECT_EQ(logger.dropped_records(SIMPLER_HOST_LOG_DROP_QUEUE_FULL), before_queue);
+    EXPECT_EQ(logger.dropped_records(SIMPLER_HOST_LOG_DROP_CLAIM_EXHAUSTED), before_claim);
+
+    uint64_t summed = 0;
+    for (int reason = 0; reason < SIMPLER_HOST_LOG_DROP_REASON_COUNT; ++reason) {
+        summed += logger.dropped_records(static_cast<SimplerHostLogDropReason>(reason));
+    }
+    EXPECT_EQ(summed, logger.dropped_records()) << "the breakdown must account for every drop";
+
+    ASSERT_TRUE(logger.start_writer());
+    EXPECT_TRUE(logger.prepare_to_fork());
+}
+
+// The counters die with the process, so a reader holding only the log has to be
+// told in the log. prepare_to_fork() is the boundary every path that stops
+// logging passes through, and it reports a growth rather than a running total.
+TEST(HostLogNonblockingTest, QuiesceWritesTheLossBreakdownIntoTheLog) {
+    HostLogger &logger = HostLogger::get_instance();
+    logger.set_level(LogLevel::ERROR, /*defer_writer=*/true);
+
+    const int saved_stderr = dup(STDERR_FILENO);
+    ASSERT_GE(saved_stderr, 0);
+    ASSERT_EQ(close(STDERR_FILENO), 0);
+    logger.log(LogLevel::ERROR, "loss_summary", "lost-one");
+    ASSERT_GE(dup2(saved_stderr, STDERR_FILENO), 0);
+    close(saved_stderr);
+
+    ASSERT_TRUE(logger.start_writer());
+    testing::internal::CaptureStderr();
+    ASSERT_TRUE(logger.prepare_to_fork());
+    const std::string first = testing::internal::GetCapturedStderr();
+    EXPECT_NE(first.find("[HOSTLOG_DROPS] v=1 "), std::string::npos) << first;
+    EXPECT_NE(first.find("output_failed="), std::string::npos) << first;
+
+    // Nothing new was dropped, so a second quiesce must stay silent rather than
+    // restating the same losses at every boundary.
+    ASSERT_TRUE(logger.start_writer());
+    testing::internal::CaptureStderr();
+    ASSERT_TRUE(logger.prepare_to_fork());
+    const std::string second = testing::internal::GetCapturedStderr();
+    EXPECT_EQ(second.find("[HOSTLOG_DROPS]"), std::string::npos) << second;
+}
+
+// Quiescing a live writer re-enters the same no-sink window a process starts in,
+// so the synchronous fallback has to be usable on the way out of it. A process
+// that initializes a second hierarchical Worker after a first one would
+// otherwise lose every record of that second initialization: the stop flag the
+// quiesce raises rejects both the queue and the fallback.
+TEST(HostLogNonblockingTest, QuiescingALiveWriterKeepsTheSynchronousFallback) {
+    HostLogger &logger = HostLogger::get_instance();
+    logger.set_level(LogLevel::ERROR, /*defer_writer=*/true);
+    ASSERT_TRUE(logger.start_writer());
+    logger.log(LogLevel::ERROR, "first_worker", "owned-writer-record");
+    ASSERT_TRUE(logger.flush());
+
+    const uint64_t before = logger.dropped_records();
+    ASSERT_TRUE(logger.prepare_to_fork());
+
+    testing::internal::CaptureStderr();
+    logger.log(LogLevel::ERROR, "second_worker", "after-quiesce-record");
+    const std::string captured = testing::internal::GetCapturedStderr();
+
+    EXPECT_NE(captured.find("][ERROR] second_worker: after-quiesce-record\n"), std::string::npos);
+    EXPECT_EQ(logger.dropped_records(), before);
+
+    ASSERT_TRUE(logger.start_writer());
+    EXPECT_TRUE(logger.prepare_to_fork());
+}
+
+TEST(HostLogNonblockingTest, WriterSleepsWhenAdjacentProducersPublishOutOfOrder) {
+    HostLogger &logger = HostLogger::get_instance();
+    logger.set_level(LogLevel::ERROR);
+    {
+        std::scoped_lock lock(g_gap_mutex);
+        g_first_claimed = false;
+        g_release_first = false;
+        g_writer_waiting_for_gap = false;
+    }
+    simpler_host_log_set_queue_hooks_for_test(pause_first_queue_claim, observe_writer_gap_wait);
+
+    std::thread first([&logger] {
+        logger.log(LogLevel::ERROR, "producer", "first-reserved");
+    });
+    {
+        std::unique_lock<std::mutex> lock(g_gap_mutex);
+        EXPECT_TRUE(g_gap_cv.wait_for(lock, std::chrono::seconds(1), [] {
+            return g_first_claimed;
+        }));
+    }
+
+    std::thread second([&logger] {
+        logger.log(LogLevel::ERROR, "producer", "second-published");
+    });
+    second.join();
+    {
+        std::unique_lock<std::mutex> lock(g_gap_mutex);
+        EXPECT_TRUE(g_gap_cv.wait_for(lock, std::chrono::seconds(1), [] {
+            return g_writer_waiting_for_gap;
+        })) << "writer did not return to sem_wait for the missing earlier slot";
+        g_release_first = true;
+    }
+    g_gap_cv.notify_all();
+    first.join();
+    simpler_host_log_set_queue_hooks_for_test(nullptr, nullptr);
+
+    EXPECT_TRUE(logger.flush());
+    EXPECT_TRUE(logger.prepare_to_fork());
+}
+
+TEST(HostLogNonblockingTest, FullStderrPipeDoesNotStallProducer) {
+    int stderr_pipe[2];
+    ASSERT_EQ(pipe(stderr_pipe), 0);
+#ifdef F_SETPIPE_SZ
+    ASSERT_GE(fcntl(stderr_pipe[0], F_SETPIPE_SZ, 4096), 0);
+#endif
+
+    const pid_t pid = fork();
+    ASSERT_GE(pid, 0);
+    if (pid == 0) {
+        close(stderr_pipe[0]);
+        if (dup2(stderr_pipe[1], STDERR_FILENO) < 0) _exit(10);
+        close(stderr_pipe[1]);
+
+        alarm(2);
+        HostLogger::get_instance().set_level(LogLevel::ERROR);
+        const std::string payload(400, 'x');
+        for (int i = 0; i < 10000; ++i) {
+            HostLogger::get_instance().log(LogLevel::ERROR, "producer", "record=%d %s", i, payload.c_str());
+        }
+        if (HostLogger::get_instance().dropped_records() == 0) _exit(11);
+        // A blocked writer cannot be joined, so a later hierarchical startup
+        // must fail boundedly instead of proceeding to fork with it alive.
+        _exit(HostLogger::get_instance().prepare_to_fork(10) ? 12 : 0);
+    }
+
+    close(stderr_pipe[1]);
+    int status = 0;
+    ASSERT_EQ(waitpid(pid, &status, 0), pid);
+    close(stderr_pipe[0]);
+
+    ASSERT_TRUE(WIFEXITED(status)) << "producer stalled on stderr (wait status " << status << ")";
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+}
+
+TEST(HostLogNonblockingTest, HardWriteFailureIncrementsDropCounter) {
+    int stderr_pipe[2];
+    ASSERT_EQ(pipe(stderr_pipe), 0);
+    close(stderr_pipe[0]);
+
+    const int saved_stderr = dup(STDERR_FILENO);
+    ASSERT_GE(saved_stderr, 0);
+    auto previous_sigpipe = std::signal(SIGPIPE, SIG_IGN);
+    ASSERT_NE(previous_sigpipe, SIG_ERR);
+    ASSERT_GE(dup2(stderr_pipe[1], STDERR_FILENO), 0);
+    close(stderr_pipe[1]);
+
+    HostLogger::get_instance().set_level(LogLevel::ERROR);
+    const uint64_t before = HostLogger::get_instance().dropped_records();
+    HostLogger::get_instance().log(LogLevel::ERROR, "producer", "write-must-fail");
+    EXPECT_TRUE(HostLogger::get_instance().flush());
+
+    ASSERT_GE(dup2(saved_stderr, STDERR_FILENO), 0);
+    close(saved_stderr);
+    std::signal(SIGPIPE, previous_sigpipe);
+    EXPECT_EQ(HostLogger::get_instance().dropped_records(), before + 1);
+}
+
+TEST(HostLogNonblockingTest, ExistingWriterIsJoinedBeforeALaterFork) {
+    HostLogger &logger = HostLogger::get_instance();
+    logger.set_level(LogLevel::ERROR);
+    logger.log(LogLevel::ERROR, "producer", "before-second-worker");
+    ASSERT_TRUE(logger.prepare_to_fork());
+
+    const pid_t pid = fork();
+    ASSERT_GE(pid, 0);
+    if (pid == 0) {
+        logger.set_level(LogLevel::NUL);
+        _exit(logger.flush() ? 0 : 12);
+    }
+
+    int status = 0;
+    ASSERT_EQ(waitpid(pid, &status, 0), pid);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+
+    // The parent can install a fresh writer after the fork boundary.
+    EXPECT_TRUE(logger.start_writer());
+    EXPECT_TRUE(logger.prepare_to_fork());
+}
+
+TEST(HostLogNonblockingTest, ConcurrentProducersCanBeQuiescedSafely) {
+    const int saved_stderr = dup(STDERR_FILENO);
+    ASSERT_GE(saved_stderr, 0);
+    const int null_fd = open("/dev/null", O_WRONLY);
+    ASSERT_GE(null_fd, 0);
+    ASSERT_GE(dup2(null_fd, STDERR_FILENO), 0);
+    close(null_fd);
+
+    HostLogger &logger = HostLogger::get_instance();
+    logger.set_level(LogLevel::ERROR);
+    std::atomic<bool> running{true};
+    std::vector<std::thread> producers;
+    for (int index = 0; index < 4; ++index) {
+        producers.emplace_back([&logger, &running, index] {
+            uint64_t sequence = 0;
+            while (running.load(std::memory_order_acquire)) {
+                logger.log(LogLevel::ERROR, "producer", "thread=%d sequence=%lu", index, sequence++);
+            }
+        });
+    }
+
+    for (int iteration = 0; iteration < 20; ++iteration) {
+        ASSERT_TRUE(logger.prepare_to_fork(1000));
+        ASSERT_TRUE(logger.start_writer());
+    }
+    running.store(false, std::memory_order_release);
+    for (std::thread &producer : producers)
+        producer.join();
+    EXPECT_TRUE(logger.prepare_to_fork(1000));
+
+    ASSERT_GE(dup2(saved_stderr, STDERR_FILENO), 0);
+    close(saved_stderr);
+}

--- a/tests/ut/cpp/common/test_sim_device_log.cpp
+++ b/tests/ut/cpp/common/test_sim_device_log.cpp
@@ -38,12 +38,7 @@ namespace {
 constexpr const char *kTags[] = {"DEBUG", "INFO", "TIMING", "WARN", "ERROR"};
 
 SimplerHostLogState g_log_state{
-    SIMPLER_HOST_LOG_STATE_ABI_VERSION,
-    sizeof(SimplerHostLogState),
-    static_cast<int32_t>(simpler::log::LogLevel::ERROR),
-    0,
-    0,
-    {},
+    static_cast<int32_t>(simpler::log::LogLevel::ERROR), 0, 0, {}, 0, 0, nullptr, nullptr, 0, 0, 0, {}, 0,
 };
 
 // level_idx selects the compatibility entry point under test.
@@ -79,9 +74,31 @@ void bind_level(simpler::log::LogLevel level) {
     g_log_state.clock_anchor_pid = static_cast<int32_t>(getpid());
     g_log_state.log_directory_bound = 0;
     g_log_state.log_directory[0] = '\0';
-    set_host_log_state(&g_log_state);
+    ASSERT_EQ(set_host_log_state(&g_log_state), 0);
+    // This host-only executable supplies the process state. A production sim
+    // AICPU DSO remains a bound consumer and cannot create the owner writer.
+    ASSERT_EQ(HostLogger::get_instance().adopt_state(&g_log_state), 0);
     set_log_level(static_cast<int>(level));
 }
+
+// A failed assertion must not leave the process-global writer stopped for the
+// next test. Normal paths call restart() after stderr capture is restored;
+// early returns get a best-effort restart from the destructor.
+class ScopedHostWriterRestart {
+public:
+    ~ScopedHostWriterRestart() {
+        if (armed_) (void)HostLogger::get_instance().start_writer();
+    }
+
+    bool restart() {
+        if (!HostLogger::get_instance().start_writer()) return false;
+        armed_ = false;
+        return true;
+    }
+
+private:
+    bool armed_ = true;
+};
 
 // Redirect stderr onto a fresh pipe, drained from the moment it is installed.
 //
@@ -124,6 +141,7 @@ Capture begin_capture() {
 // Restore stderr, which drops this process's last write handle; with every child
 // already reaped the reader then sees EOF and finishes.
 std::string end_capture(Capture &cap) {
+    EXPECT_TRUE(HostLogger::get_instance().flush());
     fflush(stderr);
     EXPECT_GE(dup2(cap.saved_stderr, STDERR_FILENO), 0);
     close(cap.saved_stderr);
@@ -155,12 +173,25 @@ void expect_intact(const std::string &captured, std::multiset<std::string> expec
 
 }  // namespace
 
+// set_host_log_state reports its bind result so a sim AICPU SO that cannot bind
+// fails device init instead of running with an unbound logger that silently
+// drops every record.
+TEST(SimDeviceLogTest, RejectsUnusableHostLogState) {
+    SimplerHostLogState unusable = g_log_state;
+    unusable.threshold = 26;
+
+    EXPECT_NE(set_host_log_state(nullptr), 0);
+    EXPECT_NE(set_host_log_state(&unusable), 0);
+    EXPECT_EQ(set_host_log_state(&g_log_state), 0);
+}
+
 TEST(SimDeviceLogTest, UsesHostEnvelopeAndLiveBoundThreshold) {
     bind_level(simpler::log::LogLevel::ERROR);
 
     testing::internal::CaptureStderr();
     emit(3, "worker", "warn-hidden");
     emit(4, "worker", "error-visible");
+    ASSERT_TRUE(HostLogger::get_instance().flush());
     std::string captured = testing::internal::GetCapturedStderr();
 
     EXPECT_EQ(captured.find("warn-hidden"), std::string::npos);
@@ -173,6 +204,7 @@ TEST(SimDeviceLogTest, UsesHostEnvelopeAndLiveBoundThreshold) {
     g_log_state.threshold = static_cast<int32_t>(simpler::log::LogLevel::WARN);
     testing::internal::CaptureStderr();
     emit(3, "worker", "warn-visible");
+    ASSERT_TRUE(HostLogger::get_instance().flush());
     captured = testing::internal::GetCapturedStderr();
     EXPECT_NE(captured.find("][WARN] worker: warn-visible\n"), std::string::npos);
 }
@@ -187,13 +219,15 @@ TEST(SimDeviceLogTest, BoundLogDirectoryTakesSimRecordsInsteadOfStderr) {
 
     testing::internal::CaptureStderr();
     emit(4, "chip_worker", "device-record-to-file");
+    // The writer owns the destination, so the record is on disk only once this
+    // returns; nothing about its level makes it synchronous.
+    ASSERT_TRUE(HostLogger::get_instance().flush());
     const std::string captured = testing::internal::GetCapturedStderr();
     EXPECT_EQ(captured.find("device-record-to-file"), std::string::npos)
         << "a bound directory is the logger's destination for device records too";
 
     // The destination is a property of the logger, so a sim device record lands
-    // in the same per-process file as every host record. An ERROR is written
-    // through rather than buffered, so it is on disk by the time this reads.
+    // in the same per-process file as every host record.
     const std::string path = std::string(directory) + "/host." + std::to_string(static_cast<int>(getpid())) + ".log";
     std::ifstream input(path);
     ASSERT_TRUE(input.good());
@@ -205,6 +239,29 @@ TEST(SimDeviceLogTest, BoundLogDirectoryTakesSimRecordsInsteadOfStderr) {
     g_log_state.log_directory[0] = '\0';
     EXPECT_EQ(unlink(path.c_str()), 0);
     EXPECT_EQ(rmdir(directory), 0);
+}
+
+// A bound directory is the destination, not a preference. A record it cannot
+// take is dropped and counted rather than relocated to stderr — otherwise a
+// directory that cannot be opened sends every record somewhere nobody reads
+// while the drop counter still says zero, and "the log is complete" stops
+// meaning "dropped_record_count is zero".
+TEST(SimDeviceLogTest, UnwritableBoundDirectoryDropsRatherThanRelocating) {
+    bind_level(simpler::log::LogLevel::DEBUG);
+    HostLogger::get_instance().set_log_directory("/nonexistent/simpler-host-log-destination");
+
+    const uint64_t before = HostLogger::get_instance().dropped_records();
+    testing::internal::CaptureStderr();
+    emit(4, "chip_worker", "record-with-no-destination");
+    ASSERT_TRUE(HostLogger::get_instance().flush());
+    const std::string captured = testing::internal::GetCapturedStderr();
+
+    EXPECT_EQ(captured.find("record-with-no-destination"), std::string::npos)
+        << "an unwritable bound directory must not silently relocate records to stderr";
+    EXPECT_EQ(HostLogger::get_instance().dropped_records(), before + 1);
+
+    g_log_state.log_directory_bound = 0;
+    g_log_state.log_directory[0] = '\0';
 }
 
 TEST(SimDeviceLogTest, MultiThreadedRecordsStayIntact) {
@@ -244,6 +301,8 @@ TEST(SimDeviceLogTest, ForkedProcessesEmitWholeRecords) {
     constexpr int kPerChild = 100;
 
     bind_level(simpler::log::LogLevel::DEBUG);
+    ASSERT_TRUE(HostLogger::get_instance().prepare_to_fork());
+    ScopedHostWriterRestart writer_restart;
     std::multiset<std::string> expected;
     for (int c = 0; c < kChildren; ++c) {
         for (int i = 0; i < kPerChild; ++i) {
@@ -261,9 +320,11 @@ TEST(SimDeviceLogTest, ForkedProcessesEmitWholeRecords) {
         ASSERT_GE(pid, 0);
         if (pid == 0) {
             g_log_state.clock_anchor_pid = static_cast<int32_t>(getpid());
+            set_log_level(static_cast<int>(simpler::log::LogLevel::DEBUG));
             for (int i = 0; i < kPerChild; ++i) {
                 emit(c, "chip_worker", "c%d-r%03d", c, i);
             }
+            if (!HostLogger::get_instance().flush()) _exit(3);
             _exit(0);  // skip gtest/atexit teardown so nothing else hits the pipe
         }
         pids.push_back(pid);
@@ -275,6 +336,7 @@ TEST(SimDeviceLogTest, ForkedProcessesEmitWholeRecords) {
         EXPECT_EQ(WEXITSTATUS(status), 0);
     }
     std::string captured = end_capture(cap);
+    ASSERT_TRUE(writer_restart.restart());
 
     ASSERT_NO_FATAL_FAILURE(expect_intact(captured, std::move(expected)));
 }
@@ -291,6 +353,8 @@ TEST(SimDeviceLogTest, WritersOutrunASmallPipeWithoutDeadlocking) {
     constexpr int kPerChild = 400;
 
     bind_level(simpler::log::LogLevel::DEBUG);
+    ASSERT_TRUE(HostLogger::get_instance().prepare_to_fork());
+    ScopedHostWriterRestart writer_restart;
     std::multiset<std::string> expected;
     for (int c = 0; c < kChildren; ++c) {
         for (int i = 0; i < kPerChild; ++i) {
@@ -303,6 +367,7 @@ TEST(SimDeviceLogTest, WritersOutrunASmallPipeWithoutDeadlocking) {
     Capture cap = begin_capture();
     if (fcntl(cap.read_fd, F_SETPIPE_SZ, 4096) < 0) {
         std::string discard = end_capture(cap);
+        ASSERT_TRUE(writer_restart.restart());
         GTEST_SKIP() << "cannot shrink the pipe on this kernel";
     }
 
@@ -313,9 +378,11 @@ TEST(SimDeviceLogTest, WritersOutrunASmallPipeWithoutDeadlocking) {
         ASSERT_GE(pid, 0);
         if (pid == 0) {
             g_log_state.clock_anchor_pid = static_cast<int32_t>(getpid());
+            set_log_level(static_cast<int>(simpler::log::LogLevel::DEBUG));
             for (int i = 0; i < kPerChild; ++i) {
                 emit(c, "chip_worker", "c%d-r%03d", c, i);
             }
+            if (!HostLogger::get_instance().flush(5000)) _exit(3);
             _exit(0);
         }
         pids.push_back(pid);
@@ -327,6 +394,7 @@ TEST(SimDeviceLogTest, WritersOutrunASmallPipeWithoutDeadlocking) {
         EXPECT_EQ(WEXITSTATUS(status), 0);
     }
     std::string captured = end_capture(cap);
+    ASSERT_TRUE(writer_restart.restart());
 
     ASSERT_NO_FATAL_FAILURE(expect_intact(captured, std::move(expected)));
 }

--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -343,6 +343,65 @@ class TestChipWorkerPython:
         with pytest.raises(RuntimeError, match=r"while ChipWorker\.init\(\) is in progress"):
             worker.finalize()
 
+    def test_public_wrapper_flush_failure_does_not_skip_finalize_cleanup(self, monkeypatch, capsys):
+        import simpler.task_interface as task_interface_mod  # noqa: PLC0415
+        from _task_interface import ChipCallable  # noqa: PLC0415
+        from simpler.task_interface import ChipWorker  # noqa: PLC0415  # pyright: ignore[reportAttributeAccessIssue]
+
+        finalized = []
+
+        class FakeImpl:
+            initialized = True
+            device_id = 0
+
+            def finalize(self):
+                finalized.append(True)
+
+        def fail_flush(_timeout_ms):
+            raise RuntimeError("injected host-log flush failure")
+
+        worker = ChipWorker()
+        worker._impl = FakeImpl()
+        worker._callable_registry[0] = ChipCallable.build(signature=[], func_name="test", binary=b"\x00", children=[])
+        worker._identity_registry[b"digest"] = object()
+        worker._live_handles[1] = b"digest"
+        monkeypatch.setattr(task_interface_mod, "_flush_host_log", fail_flush)
+
+        worker.finalize()
+
+        assert finalized == [True]
+        assert worker._callable_registry == {}
+        assert worker._identity_registry == {}
+        assert worker._live_handles == {}
+        expected_warning = (
+            "WARNING: host-log flush failed during ChipWorker.finalize(): injected host-log flush failure"
+        )
+        assert expected_warning in capsys.readouterr().err
+
+    def test_public_wrapper_flush_timeout_is_reported_with_loss_counters(self, monkeypatch, capsys):
+        import simpler.task_interface as task_interface_mod  # noqa: PLC0415
+        from simpler.task_interface import ChipWorker  # noqa: PLC0415  # pyright: ignore[reportAttributeAccessIssue]
+
+        class FakeImpl:
+            initialized = True
+            device_id = 0
+
+            def finalize(self):
+                pass
+
+        worker = ChipWorker()
+        worker._impl = FakeImpl()
+        monkeypatch.setattr(task_interface_mod, "_flush_host_log", lambda _timeout_ms: False)
+        monkeypatch.setattr(task_interface_mod, "_host_log_pending_records", lambda: 7)
+        monkeypatch.setattr(task_interface_mod, "_host_log_dropped_records", lambda: 3)
+
+        worker.finalize()
+
+        warning = capsys.readouterr().err
+        assert "host-log flush timed out after 1000 ms during ChipWorker.finalize()" in warning
+        assert "pending_records=7, dropped_records=3" in warning
+        assert "accepted records may be lost" in warning
+
 
 # ============================================================================
 # Mailbox CallConfig wire round-trip

--- a/tests/ut/py/test_strace_timing.py
+++ b/tests/ut/py/test_strace_timing.py
@@ -31,6 +31,7 @@ from simpler_setup.tools.strace_timing import (
     main,
     node_span_leaf,
     parse_clock_anchors,
+    parse_drop_summaries,
     parse_spans,
     print_rounds_table,
     span_family,
@@ -245,6 +246,53 @@ def test_count_record_heads_sees_a_torn_record_that_parse_spans_drops():
 
     assert count_record_heads(lines) == 2
     assert len(list(parse_spans(lines))) == 1
+
+
+def _drop_summary(pid, new, total, queue_full=0, claim_exhausted=0, output_failed=0, not_admitted=0):
+    return (
+        f"[mono_ns=1000][T0xabc][ERROR] host_log_drops: [HOSTLOG_DROPS] v=1 pid={pid} new={new} "
+        f"total={total} queue_full={queue_full} claim_exhausted={claim_exhausted} "
+        f"output_failed={output_failed} not_admitted={not_admitted}\n"
+    )
+
+
+def test_parse_drop_summaries_keeps_the_running_total_per_process():
+    # A process reports a growth at every quiescent boundary, so the reader must
+    # keep the last (largest) figure rather than summing the reports.
+    lines = [
+        _drop_summary(71, new=2, total=2, queue_full=2),
+        _drop_summary(72, new=1, total=1, output_failed=1),
+        _drop_summary(71, new=3, total=5, queue_full=5),
+    ]
+
+    summaries = parse_drop_summaries(lines)
+    assert summaries[71] == {
+        "total": 5,
+        "queue_full": 5,
+        "claim_exhausted": 0,
+        "output_failed": 0,
+        "not_admitted": 0,
+    }
+    assert summaries[72]["total"] == 1
+    assert summaries[72]["output_failed"] == 1
+
+
+def test_parse_drop_summaries_ignores_an_unknown_grammar_version():
+    lines = [_drop_summary(71, new=1, total=1).replace("v=1", "v=2")]
+
+    assert parse_drop_summaries(lines) == {}
+
+
+def test_main_warns_that_dropped_records_make_the_timing_incomplete(tmp_path, capsys):
+    log_file = tmp_path / "host.71.log"
+    log_file.write_text(_record(1, 1, "chip.run", "rank=0") + "\n" + _drop_summary(71, new=4, total=4, queue_full=4))
+
+    main([str(log_file)])
+
+    stderr = capsys.readouterr().err
+    assert "pid 71 dropped 4 host-log record(s)" in stderr
+    assert "queue_full=4" in stderr
+    assert "incomplete log" in stderr
 
 
 def test_host_swimlane_keeps_real_host_lanes_and_builds_dispatch_flow():

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -595,9 +595,10 @@ def test_start_hierarchical_passes_each_chip_its_negotiated_frame_count(monkeypa
     monkeypatch.setattr(
         worker_mod,
         "_initialize_host_log",
-        lambda level: startup_events.append(("log", level)),
+        lambda level, *, defer_writer=False: startup_events.append(("log", level, defer_writer)),
         raising=False,
     )
+    monkeypatch.setattr(worker_mod, "_start_host_log_writer", lambda: startup_events.append(("writer",)))
     monkeypatch.setattr(worker, "_await_children_ready", fake_await_children_ready)
     monkeypatch.setattr(worker_mod, "Orchestrator", lambda native, owner: (native, owner))
     try:
@@ -610,8 +611,8 @@ def test_start_hierarchical_passes_each_chip_its_negotiated_frame_count(monkeypa
     assert fake_parent.configured_depths == [1]
     assert [call[1:] for call in fake_parent.next_level_calls] == [(12001, 2), (12002, 1)]
     assert fake_parent.initialized
-    assert startup_events[0] == ("log", 60)
-    assert startup_events[1:] == [("fork",), ("fork",)]
+    assert startup_events[0] == ("log", 60, True)
+    assert startup_events[1:] == [("fork",), ("fork",), ("writer",)]
 
 
 def test_start_hierarchical_seeds_the_logger_when_the_process_owns_no_chips(monkeypatch):
@@ -660,9 +661,10 @@ def test_start_hierarchical_seeds_the_logger_when_the_process_owns_no_chips(monk
     monkeypatch.setattr(
         worker_mod,
         "_initialize_host_log",
-        lambda level: startup_events.append(("log", level)),
+        lambda level, *, defer_writer=False: startup_events.append(("log", level, defer_writer)),
         raising=False,
     )
+    monkeypatch.setattr(worker_mod, "_start_host_log_writer", lambda: startup_events.append(("writer",)))
     monkeypatch.setattr(worker, "_await_children_ready", lambda *args, **kwargs: None)
     monkeypatch.setattr(worker_mod, "Orchestrator", lambda native, owner: (native, owner))
     try:
@@ -672,8 +674,8 @@ def test_start_hierarchical_seeds_the_logger_when_the_process_owns_no_chips(monk
             shm.close()
             shm.unlink()
 
-    assert startup_events[0] == ("log", 60)
-    assert startup_events[1:] == [("fork",)]
+    assert startup_events[0] == ("log", 60, True)
+    assert startup_events[1:] == [("fork",), ("writer",)]
 
 
 def test_a_worker_above_l3_can_never_carry_device_ids():

--- a/tests/ut/py/test_worker/test_startup_readiness.py
+++ b/tests/ut/py/test_worker/test_startup_readiness.py
@@ -2085,3 +2085,23 @@ class TestFailureSurfacing:
             assert w._lifecycle is worker_mod._Lifecycle.FAILED
             assert w._sub_pids == []
             w.close()
+
+    def test_failed_hierarchical_start_restores_process_log_writer(self, monkeypatch):
+        import simpler.worker as worker_mod  # noqa: PLC0415
+
+        events: list[str] = []
+        original = RuntimeError("injected failure after logger quiesce")
+
+        monkeypatch.setattr(Worker, "_init_hierarchical", lambda self: None)
+        monkeypatch.setattr(Worker, "_start_hierarchical", _raiser(original))
+        monkeypatch.setattr(Worker, "_cleanup_partial_init", lambda self: events.append("cleanup"))
+        monkeypatch.setattr(worker_mod, "_start_host_log_writer", lambda: events.append("writer"))
+
+        w = Worker(level=3, num_sub_workers=1)
+        with pytest.raises(RuntimeError) as raised:
+            w.init()
+
+        assert raised.value is original
+        assert events == ["cleanup", "writer"]
+        assert w._lifecycle is worker_mod._Lifecycle.FAILED
+        w.close()


### PR DESCRIPTION
- Route simulated AICPU logs through the process HostLogger so sim and
  host records share one threshold, envelope, queue, and destination.
- Add a fixed MPSC queue with bounded producer admission, explicit drop
  accounting, and no steady-state producer-side output I/O.
- Preserve pre-writer initialization diagnostics synchronously and retain
  their failure count across the first writer startup, including after a live
  writer is quiesced: `prepare_to_fork()` clears its producer stop flag once
  the sink is gone, so the window it opens keeps the synchronous fallback
  instead of silently dropping every record until the next `start_writer()`.
- Restrict sink ownership to the process-state owner so a bound DSO cannot
  leave a callback or writer thread behind after dlclose.
- Replace the writer publication-gap spin with semaphore waiting and keep
  fork, shutdown, and os._exit drains bounded and observable.
- Extend the shared host-log state with the queue callback and lifecycle
  fields, and drop its `abi_version` / `struct_size` handshake: every module
  that binds it is compiled from this repository in the same build, and a
  run-time orchestration SO hashes the header's whole include closure into its
  scene-test cache key, so no stale layout can reach a binding. Binding is
  rejected for a null pointer or an out-of-ladder threshold, and
  `set_host_log_state` reports that so a sim AICPU SO cannot run unbound.
- Make a bound log directory the destination rather than a preference: a record
  the file cannot take is dropped and counted, not relocated to stderr, so "the
  log is complete" and "`dropped_record_count` is zero" stay the same statement.
  The two-level fallback [#1945](https://github.com/hw-native-sys/simpler/pull/1945)
  introduced left a bound-but-unopenable directory sending every record to
  stderr while the counter still read zero. stderr is the destination only while
  no directory is bound.
- Attribute every drop to one of `queue_full` / `claim_exhausted` /
  `output_failed` / `not_admitted`, and write that breakdown into the log as
  `[HOSTLOG_DROPS]` at each quiescent boundary whose total has grown. The
  counters die with the process, so a reader holding only `host.<pid>.log`
  otherwise cannot tell records are missing — a truncated record leaves a header
  behind, a dropped one leaves nothing. `strace_timing.py` warns from those
  records before printing any timing.
- Make scene tests wait for diagnostic content and unchanged drop counts
  instead of treating a one-second flush deadline as correctness.
- Document the 512-byte record cap and cover initialization loss, bounded
  waiting, DSO ownership, sim output, and teardown reporting.

**Closes item 6** of [#1792](https://github.com/hw-native-sys/simpler/issues/1792). Item 5 landed separately as [#2061](https://github.com/hw-native-sys/simpler/pull/2061), so it is no longer in this diff — the routing, the second writer's removal and the sim CMake changes are all on `main`. What remains on the sim path here is `set_host_log_state` propagating its bind result (4 files, 20 lines), which is bind hardening for the shared state, not item 5.

## Scope after the rebase

Item 5 landed separately as [#2061](https://github.com/hw-native-sys/simpler/pull/2061), so this branch was carrying an older copy of work already on `main` — 18 of 28 files overlapped it, 4 byte-identical, 7 conflicting. Rebased onto `1f3995c6d`: **28 files / +1619−331 → 24 files / +1485−237**.

Two consequences worth calling out, since neither is visible in the diff alone:

- The raw-append fd here retires the buffered stream and its unload-time
  destructor that #2061 added — with `write(2)` there is no userspace buffer
  for a `dlclose` to discard. `test_host_log_dso_unload` still passes (60/60
  repeats).
- #2061's `BoundLogDirectoryTakesSimRecordsInsteadOfStderr` assumed an ERROR
  record was on disk by the time it read the file. The writer, not the
  record's level, now decides that, so the case takes a `flush()`.

## Testing

Local, on the final tree; onboard through `task-submit`.

| | |
| --- | --- |
| cpput | 130/130 |
| pyut | 2099 passed, 18 skipped |
| st a2a3sim / a5sim | 33 / 29, no failures |
| st a2a3 onboard | 67, no failures (incl. `runtime_fatal_codes`, `host_build_graph_validation`) |
| st a2a3 `-m sdma` | 2/2, incl. `test_sdma_worker_aicore_fault_teardown_is_bounded` |
| linters | clang-format, clang-tidy, ruff, pyright, markdownlint, retired-names, headers, english-only — clean |

New coverage: `QuiescingALiveWriterKeepsTheSynchronousFallback` pins the quiesce
window against the stop-flag regression and was verified to fail without the fix;
`OutputFailureIsAttributedToTheOutputBucket` pins that the breakdown sums to the
total; `QuiesceWritesTheLossBreakdownIntoTheLog` pins the log record and that it
is not restated when nothing new was lost.

A contention probe (N threads × 100k records to `/dev/null`) puts every loss in
`queue_full` and **zero** in `claim_exhausted` at 4, 16 and 64 threads, so the
1024-attempt claim budget is not the binding constraint — the queue's drain rate
is. Structural rather than incidental: a full queue returns before spending any
of the budget.
