### PR TITLE
Fix a heap overflow in the hbg Graph recording hazard map, and name its task id spaces by Graph membership

### DIFF
--- a/docs/dfx/dep-gen.md
+++ b/docs/dfx/dep-gen.md
@@ -181,7 +181,7 @@ JS-safe without burdening Python.
 Task ids are `TaskId::raw`. The low 32 bits are a local id; the high 32 bits
 mean whatever the runtime that minted the record says they mean — a ring index
 (`tensormap_and_ringbuffer`, `0..CHIP_MAX_RING_DEPTH-1`) or an id space
-(`host_build_graph`, `0 = RING`, `1 = GRAPH_NODE`). See
+(`host_build_graph`, `0 = GLOBAL`, `1 = IN_GRAPH`). See
 `src/common/{tensormap_and_ringbuffer,host_build_graph}/task_id_encoding.h`.
 Which one a record carries is a property of its runtime, not of the value:
 

--- a/simpler_setup/tools/deps_viewer.py
+++ b/simpler_setup/tools/deps_viewer.py
@@ -126,7 +126,7 @@ def _node_id(task_id):
 
     The high field is a ring index under ``tensormap_and_ringbuffer`` (any ring in
     ``0..CHIP_MAX_RING_DEPTH-1``) and an id space under ``host_build_graph``
-    (0 = RING, 1 = GRAPH_NODE), so its meaning depends on which runtime wrote the
+    (0 = GLOBAL, 1 = IN_GRAPH), so its meaning depends on which runtime wrote the
     record. It is printed verbatim either way.
     """
     tid = _normalize_task_id(task_id)

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -106,8 +106,8 @@ def format_task_display(task_id):
 
     The high 32 bits are a ring index under ``tensormap_and_ringbuffer`` (any ring in
     ``0..CHIP_MAX_RING_DEPTH-1``) and an id space under ``host_build_graph``
-    (0 = RING, 1 = GRAPH_NODE). The short form below therefore covers tmr ring 0 and
-    every hbg RING task; a tmr task on ring 2 is equally ordinary and gets the long
+    (0 = GLOBAL, 1 = IN_GRAPH). The short form below therefore covers tmr ring 0 and
+    every hbg GLOBAL task; a tmr task on ring 2 is equally ordinary and gets the long
     form.
 
     Returns:
@@ -128,9 +128,9 @@ def format_task_display(task_id):
 def _decode_graph_node_task_id(task_id):
     """Decode Scheduler-owned Graph-node ids.
 
-    ``host_build_graph`` puts a materialized node in id space 1 (GRAPH_NODE) with
-    ``local=(outer_local << 10) | node_index``; the stream-visible outer Graph task
-    stays in space 0 (RING). See src/common/host_build_graph/task_id_encoding.h.
+    ``host_build_graph`` puts a materialized node in id space 1 (IN_GRAPH) with
+    ``local=(graph_local_id << 10) | task_index``; the stream-visible outer Graph task
+    stays in space 0 (GLOBAL). See src/common/host_build_graph/task_id_encoding.h.
     """
     tid = normalize_task_id_int(task_id)
     if tid is None or ((tid >> 32) & 0xFFFFFFFF) != 1:

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -273,10 +273,10 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
             // Performance profiling: record task execution.
             // Two identity fields go into the record (different roles):
-            //   - task_token_raw (ring/local) is pulled from the dispatch
+            //   - task_token_raw (the full TaskId) is pulled from the dispatch
             //     payload's LocalContext.async_ctx — already in AICore cache
             //     from the just-completed task, no extra GM load. Host uses
-            //     it as the canonical task identity for JSON output / ring
+            //     it as the canonical task identity for JSON output / task-id
             //     decoding.
             //   - reg_task_id is `task_id` (= reg_val, the per-core dispatch
             //     token AICore just read from DATA_MAIN_BASE). Per-dispatch

--- a/src/a2a3/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a2a3/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
@@ -70,8 +70,8 @@ it derives for itself, from a heap block whose prior contents it never reads.
 
 Before a wait slot is used, the runtime verifies:
 
-- the task ID is valid and lies in the `RING` id space — a `GRAPH_NODE` id packs
-  its outer task and node index into the low bits, so it indexes no task table
+- the task ID is valid and lies in the `GLOBAL` id space — an `IN_GRAPH` id packs
+  its Graph task and task index into the low bits, so it indexes no task table
   slot (see `src/common/host_build_graph/task_id_encoding.h`);
 - the task table slot that ID indexes has a bound task descriptor; and
 - the descriptor's full task ID matches the tensor's owner/producer ID.

--- a/src/a2a3/runtime/host_build_graph/host/dep_gen_host_graph.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/dep_gen_host_graph.cpp
@@ -19,11 +19,10 @@
  *   tensormap — a producer whose written slice overlaps what this task reads
  *               (STEP 3 Step B); carries both slices' geometry.
  *
- * Per-task producer dedup mirrors FaninBuilder::append_fanin_or_fail, which
- * collapses all three sources into one fanin list: the first edge to name a
- * producer is kept. tensormap edges are exempt — a second producer slice for the
- * same task is a distinct fact about the data flow, and viewers rely on seeing
- * every overlap.
+ * Per-task producer dedup mirrors append_fanin_or_fail, which collapses all three
+ * sources into one fanin list: the first edge to name a producer is kept. tensormap
+ * edges are exempt — a second producer slice for the same task is a distinct fact
+ * about the data flow, and viewers rely on seeing every overlap.
  */
 
 #include "dep_gen_host_graph.h"

--- a/src/a2a3/runtime/host_build_graph/runtime/dep_compute.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/dep_compute.h
@@ -44,9 +44,9 @@
  * away.
  *
  * Performance: Emit and Annotate are template parameters, not std::function. The
- * runtime lambda (capturing fanin_builder + sm_header) instantiates at the call site
- * and inlines through. Do NOT replace with std::function — it would break the
- * inlining and add ~5 ns/call to the orch hot path.
+ * runtime lambda (capturing the consumer's fanin region + count) instantiates at the
+ * call site and inlines through. Do NOT replace with std::function — it would break
+ * the inlining and add ~5 ns/call to the orch hot path.
  */
 
 #ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_DEP_COMPUTE_H_

--- a/src/a2a3/runtime/host_build_graph/runtime/dep_compute.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/dep_compute.h
@@ -49,8 +49,7 @@
  * the inlining and add ~5 ns/call to the orch hot path.
  */
 
-#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_DEP_COMPUTE_H_
-#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_DEP_COMPUTE_H_
+#pragma once
 
 #include <cstdint>
 
@@ -196,5 +195,3 @@ inline int32_t count_registrable_outputs(const DepInputs &inputs, bool in_manual
     }
     return needed;
 }
-
-#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_DEP_COMPUTE_H_

--- a/src/a2a3/runtime/host_build_graph/runtime/dep_gen_host_graph.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/dep_gen_host_graph.h
@@ -43,10 +43,10 @@
  * progress loop satisfies this by being single-threaded; emit returns -3 if the
  * invariant is ever broken.
  *
- * Per-task producer dedup mirrors FaninBuilder, which keys on (ring, slot);
- * this keys on producer task id. The two agree only because host_build_graph is
- * whole-graph-resident and never reuses a task slot at build time (see
- * append_fanin_or_fail in orchestrator.cpp). A runtime that recycles slots
+ * Per-task producer dedup mirrors append_fanin_or_fail, which keys on the producer's
+ * local id; this keys on producer task id. The two agree only because
+ * host_build_graph is whole-graph-resident and never reuses a task slot at build time
+ * (see append_fanin_or_fail in orchestrator.cpp). A runtime that recycles slots
  * mid-build would need this key revisited.
  *
  * Output is `deps.json` in the schema documented in docs/dfx/dep-gen.md — the

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator.h
@@ -109,9 +109,9 @@ struct OrchestratorState {
     // case (max_tasks tasks each at their full cap), so a bump cannot overflow.
     // The bases live here, not in the task header: nothing on the device resolves one.
     //
-    // The fanin cursor does not advance at bind time. FaninBuilder appends and
-    // dedups producers afterwards, so the region's length is known only when the count
-    // is published, and it advances there.
+    // The fanin cursor does not advance at bind time. append_fanin_or_fail appends and
+    // dedups producers afterwards, so the region's length is known only once the last
+    // producer is appended, and it advances there.
     int32_t *fanin_pool{nullptr};
     simpler::hbg::Tensor *tensor_pool{nullptr};
     uint64_t *scalar_pool{nullptr};

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator.h
@@ -61,7 +61,7 @@ struct OrchestratorState {
     SharedMemoryHeader *sm_header;
 
     // === TASK / HEAP ALLOCATION ===
-    // hbg is single-ring, so one allocator covers the whole graph.
+    // hbg has one task table, so one allocator covers the whole graph.
     TaskAllocator task_allocator;
     std::unique_ptr<uint32_t[]> fanin_seen_epoch;
     uint32_t fanin_seen_current_epoch{1};

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -679,13 +679,13 @@ constexpr int32_t GRAPH_RECORD_TENSORMAP_POOL_SIZE = 16384;
 constexpr size_t GRAPH_RECORD_NODE_TENSOR_POOL_ELEMS =
     static_cast<size_t>(GRAPH_MAX_NODES) * static_cast<size_t>(CORE_MAX_TENSOR_ARGS);
 
-// The outer local id a recorded node's GRAPH_NODE id carries. A recorded node
-// belongs to no outer task -- every shell replaying the Definition re-mints the id
-// with its own local id at materialize -- so record time names a node by its index
-// alone, and the id's low field is that index and nothing else. That is what keeps
-// the index inside the GRAPH_MAX_NODES task chains the recording's hazard map is
+// The graph_local_id a recorded task's IN_GRAPH id carries. A recorded task belongs
+// to no Graph task yet -- every shell replaying the Definition re-mints the id with
+// its own local id at materialize -- so record time names a task by its index alone,
+// and the id's low field is that index and nothing else. That is what keeps the
+// index inside the GRAPH_MAX_NODES task chains the recording's hazard map is
 // dimensioned for.
-constexpr uint32_t GRAPH_RECORD_OUTER_LOCAL_ID = 0;
+constexpr uint32_t GRAPH_RECORD_NO_OWNING_GRAPH = 0;
 
 // Stand the recording's hazard map up on its own allocation. Failure is
 // reported to the caller, which abandons the recording rather than producing a
@@ -1240,10 +1240,10 @@ static bool fanin_mark_seen(OrchestratorState &orch, TaskId producer_task_id) {
 static bool append_fanin_or_fail(
     OrchestratorState &orch, TaskId producer_task_id, TaskId self_task_id, int32_t *fanin_slots, int32_t &fanin_count
 ) {
-    // Only a RING-space producer has an entry in the task table. A GRAPH_NODE id's
-    // low bits are a packed (outer task, node index) pair, so using them as a table
+    // Only a GLOBAL producer has an entry in the task table. An IN_GRAPH id's low
+    // bits are a packed (Graph task, task index) pair, so using them as a table
     // index names an unrelated task — or, since get_slot_state_by_task_id does not
-    // bounds-check, no task at all. A recorded node's id is GRAPH_NODE and the
+    // bounds-check, no task at all. A recorded task's id is IN_GRAPH and the
     // recorder resolves it against its own body, never here, so a foreign space
     // reaching this point is an id that escaped its Graph — a caller error, not a
     // case to tolerate.
@@ -1251,11 +1251,11 @@ static bool append_fanin_or_fail(
     // The table lookup lives here, after this check, rather than at the three call
     // sites: that keeps the id-space invariant in one place and makes it impossible
     // for a caller to form the out-of-bounds slot reference before reaching it.
-    if (!simpler::hbg::is_ring_task(producer_task_id)) {
+    if (!simpler::hbg::is_global_task(producer_task_id)) {
         orch.report_fatal(
             SIMPLER_ERROR_INVALID_ARGS, __FUNCTION__,
-            "producer task %#llx is in id space %u, not RING; host_build_graph resolves every fanin edge against its "
-            "one task table",
+            "producer task %#llx is in id space %u, not GLOBAL; host_build_graph resolves every fanin edge against "
+            "its one task table",
             static_cast<unsigned long long>(producer_task_id.raw),
             static_cast<unsigned int>(simpler::hbg::task_id_space(producer_task_id))
         );
@@ -1347,7 +1347,7 @@ static bool prepare_task(
         return false;
     }
 
-    out->task_id = simpler::hbg::make_ring_task(static_cast<uint32_t>(out->alloc_result.task_id));
+    out->task_id = simpler::hbg::make_global_task(static_cast<uint32_t>(out->alloc_result.task_id));
     out->slot_state = &orch->sm_header->tasks.get_slot_state_by_task_id(out->alloc_result.task_id);
     out->task = &orch->sm_header->tasks.task_descriptors[out->alloc_result.task_id];
     out->payload = &orch->sm_header->tasks.task_payloads[out->alloc_result.task_id];
@@ -1876,7 +1876,7 @@ bool graph_submit_outer(
         orch_mark_fatal(orch, SIMPLER_ERROR_HEAP_RING_DEADLOCK);
         return false;
     }
-    const TaskId task_id = simpler::hbg::make_ring_task(static_cast<uint32_t>(allocation.task_id));
+    const TaskId task_id = simpler::hbg::make_global_task(static_cast<uint32_t>(allocation.task_id));
     SharedMemoryTaskHeader &tasks = orch->sm_header->tasks;
     TaskDescriptor &task = tasks.task_descriptors[allocation.task_id];
     TaskPayload &payload = tasks.task_payloads[allocation.task_id];
@@ -2048,12 +2048,12 @@ TaskOutputTensors graph_record_submit_node(
     GraphRecording &recording = *active_graph_recording(orch);
 
     const size_t node_index = recording.node_count;
-    // A recorded node lives in the GRAPH_NODE id space, so an id the body hands
+    // A recorded task lives in the IN_GRAPH id space, so an id the body hands
     // around says which of the two kinds of thing it names without any arithmetic:
-    // a GRAPH_NODE id is a node of this body, indexed by its low field; a RING id is
-    // a task submitted before the Graph, which no node may depend on.
+    // an IN_GRAPH id is a task of this body, indexed by its low field; a GLOBAL id is
+    // a task submitted before the Graph, which nothing in the body may depend on.
     const TaskId task_id =
-        simpler::hbg::make_graph_node(GRAPH_RECORD_OUTER_LOCAL_ID, static_cast<uint32_t>(node_index));
+        simpler::hbg::make_in_graph_task(GRAPH_RECORD_NO_OWNING_GRAPH, static_cast<uint32_t>(node_index));
     result.set_task_id(task_id);
 
     if (node_index >= GRAPH_MAX_NODES || args.has_error) {
@@ -2248,8 +2248,8 @@ TaskOutputTensors graph_record_submit_node(
         };
         const bool manual_scope = recording.in_manual_scope();
         if (!recording.storage_ready || node_index >= GRAPH_MAX_NODES) {
-            // An over-cap body is already abandoned, and its node ids have run past
-            // the index field make_graph_node packs them into, so registering one
+            // An over-cap body is already abandoned, and its task ids have run past
+            // the index field make_in_graph_task packs them into, so registering one
             // would key the map outside its task chains.
             recording.unsupported = true;
         } else if (recording.tensor_map.free_entries() < count_registrable_outputs(dep_inputs, manual_scope)) {
@@ -2263,11 +2263,11 @@ TaskOutputTensors graph_record_submit_node(
             recording.unsupported = true;
         } else {
             auto emit_inferred = [&add_fanin, node_index](TaskId producer) -> bool {
-                // A RING producer is a task submitted before the Graph. The outer shell
+                // A GLOBAL producer is a task submitted before the Graph. The outer shell
                 // was submitted through the ordinary path against this same boundary, so
                 // its own fanin already orders the whole body behind that task and the
                 // Definition carries no edge of its own.
-                if (simpler::hbg::is_ring_task(producer)) return true;
+                if (simpler::hbg::is_global_task(producer)) return true;
                 const uint32_t producer_index = simpler::hbg::task_local_id(producer);
                 if (producer_index < static_cast<uint32_t>(node_index)) {
                     add_fanin(static_cast<size_t>(producer_index));
@@ -2284,7 +2284,7 @@ TaskOutputTensors graph_record_submit_node(
             recording.unsupported = true;
             continue;
         }
-        if (simpler::hbg::is_ring_task(dep)) {
+        if (simpler::hbg::is_global_task(dep)) {
             // Only the outer shell can order the body behind a pre-Graph task, and it
             // does so through its boundary args -- so a dep no boundary tensor carries
             // has no edge in the Definition and the body cannot be recorded.
@@ -2299,7 +2299,7 @@ TaskOutputTensors graph_record_submit_node(
         }
         const uint32_t dep_index = simpler::hbg::task_local_id(dep);
         if (dep_index >= static_cast<uint32_t>(node_index)) {
-            // A node of this body that is not yet recorded: the Definition's edges are
+            // A task of this body that is not yet recorded: the Definition's edges are
             // acyclic by construction, so a forward reference cannot be expressed.
             recording.unsupported = true;
             continue;

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -462,7 +462,7 @@ struct GraphRecording {
     // Scope depth as the body sees it. begin_scope/end_scope leave the real
     // orchestrator stack untouched while recording (a Graph replays flat), but
     // the manual-scope flag still has to follow the body: a manual scope
-    // suppresses inference on the ring, so it must suppress it here too.
+    // suppresses inference on the ordinary path, so it must suppress it here too.
     int32_t scope_stack_top{-1};
     int32_t manual_begin_depth{CHIP_MAX_SCOPE_DEPTH};
 
@@ -666,7 +666,7 @@ graph_classify_scalar(const GraphRecording &recording, const ArgT &args, int32_t
 // Entry capacity for one recorded body's hazard map. A Definition is capped at
 // GRAPH_MAX_NODES nodes and each node registers at most its INOUT/OUTPUT_EXISTING
 // args, so this bounds the worst realistic body while staying a small fraction of
-// the ring path's whole-orchestration pool (CHIP_TENSORMAP_POOL_SIZE). Exhausting
+// the ordinary path's whole-orchestration pool (CHIP_TENSORMAP_POOL_SIZE). Exhausting
 // it marks the recording unsupported, which graph_commit reports as
 // SIMPLER_ERROR_INVALID_ARGS -- the outer shell is already submitted by then, so there
 // is no ordinary-path fallback left to take.
@@ -1215,7 +1215,7 @@ static void next_fanin_seen_epoch(OrchestratorState *orch) {
 // True when this producer was already appended under the current epoch. A negative
 // local id cannot index the epoch table, so it is reported as not-yet-seen and the
 // caller appends it rather than rejecting it; append_fanin_or_fail has already
-// established that the producer is a ring task whose local id is a valid table
+// established that the producer is a GLOBAL task whose local id is a valid table
 // entry.
 static bool fanin_mark_seen(OrchestratorState &orch, TaskId producer_task_id) {
     const int32_t prod_local = static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id));
@@ -1293,7 +1293,7 @@ static bool append_fanin_or_fail(
     fanin_slots[fanin_count++] = static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id));
 
     // Reclaim gate: record this task as a consumer of the producer. The producer
-    // slot retires once the per-ring completed_watermark reaches this consumer id.
+    // slot retires once the completed_watermark reaches this consumer id.
     const int32_t self_local = static_cast<int32_t>(simpler::hbg::task_local_id(self_task_id));
     if (self_local > prod_state->last_consumer_local_id) {
         prod_state->last_consumer_local_id = self_local;
@@ -1411,7 +1411,8 @@ static bool prepare_task(
     // it in append_fanin_or_fail. completion_flags for this slot were cleared
     // above (whole-graph-resident hbg never reuses a slot).
     out->slot_state->last_consumer_local_id = static_cast<int32_t>(simpler::hbg::task_local_id(out->task_id));
-    // payload.fanin_count is set in submit_task_common's STEP 6.
+    // payload.fanin_count is left untouched here: submit_task_common zeroes it before
+    // its fanin appends, which accumulate into it in place.
 
     return true;
 }
@@ -1426,14 +1427,14 @@ void OrchestratorState::begin_scope(ScopeMode mode) {
         return;
     }
     // A Graph replays as a flat DAG with no scope structure: scope boundaries only
-    // shape scheduling on the ring, and the shadow-record path submits no ring
-    // tasks. So a scope inside a Graph body must not touch the real scope stack.
-    // Its manual/auto mode still matters, though — the recorder infers a node's
-    // producers with the same compute_task_fanin the ring path uses, and that
-    // inference is suppressed inside a manual scope — so the depth is tracked on
+    // shape scheduling on the ordinary path, and the shadow-record path submits no
+    // ordinary tasks. So a scope inside a Graph body must not touch the real scope
+    // stack. Its manual/auto mode still matters, though — the recorder infers a
+    // node's producers with the same compute_task_fanin the ordinary path uses, and
+    // that inference is suppressed inside a manual scope — so the depth is tracked on
     // the recording instead.
     if (GraphRecording *recording = active_graph_recording(orch); recording != nullptr) {
-        // Reject what the ring rejects. An auto scope inside a manual one is a
+        // Reject what the ordinary path rejects. An auto scope inside a manual one is a
         // fatal below; accepting it here would let a Graph record and replay a
         // body that ordinary submission refuses. The push still happens so
         // end_scope stays balanced -- the recording is doomed either way, since
@@ -1659,7 +1660,8 @@ static TaskOutputTensors submit_task_common(
     // Dispatch predicate: resolve the (tensor, indices) to an absolute GM address
     // now so the scheduler can read it at the dispatch point with a single load,
     // no Arg/simpler::hbg::Tensor access. Both branches write predicate.op explicitly because
-    // payload slots are ring-reused; op == NONE means "always dispatch".
+    // a payload slot is raw shared memory with no constructor; op == NONE means
+    // "always dispatch".
     {
         const CoreTaskPredicate &pred = args.predicate();
         if (pred.op != PredicateOp::NONE && pred.operand.tensor != nullptr && pred.operand.tensor->buffer.addr != 0) {
@@ -2227,7 +2229,7 @@ TaskOutputTensors graph_record_submit_node(
         if (source.source == GraphRecordedTensorSource::INTERNAL) add_fanin(source.source_index);
     }
 
-    // Inferred hazards, on the same terms as the ring path. The loop above only
+    // Inferred hazards, on the same terms as the ordinary path. The loop above only
     // names the node that ALLOCATED each buffer; every write-then-read through a
     // buffer someone else allocated — an alloc_tensors output written in place
     // with add_inout, or a view of a boundary tensor — needs the last-writer

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -406,7 +406,6 @@ struct GraphBoundary {
 // recording rather than allocated per recording — see recorder_recording().
 struct GraphRecording {
     uint64_t full_key{0};
-    int32_t start_local_task_id{0};
     uint64_t next_virtual_offset{0};
     // The in-flight entry's boundary copy, bound at graph_prepare and valid until
     // graph_end/graph_abort. Not owned here: the submitting thread reads it for
@@ -497,7 +496,6 @@ enum class GraphRecordingStatus : uint8_t { RECORDING = 0, READY = 1, FAILED = 2
 // nothing here is sized by the graph.
 struct GraphInflightRecording {
     uint64_t full_key{0};
-    int32_t start_local_task_id{0};
     GraphBoundary boundary;
     // Atomic because graph_prepare reads it on the recording thread without
     // taking recording_mutex, by design: acquiring the mutex there lets a
@@ -681,6 +679,14 @@ constexpr int32_t GRAPH_RECORD_TENSORMAP_POOL_SIZE = 16384;
 constexpr size_t GRAPH_RECORD_NODE_TENSOR_POOL_ELEMS =
     static_cast<size_t>(GRAPH_MAX_NODES) * static_cast<size_t>(CORE_MAX_TENSOR_ARGS);
 
+// The outer local id a recorded node's GRAPH_NODE id carries. A recorded node
+// belongs to no outer task -- every shell replaying the Definition re-mints the id
+// with its own local id at materialize -- so record time names a node by its index
+// alone, and the id's low field is that index and nothing else. That is what keeps
+// the index inside the GRAPH_MAX_NODES task chains the recording's hazard map is
+// dimensioned for.
+constexpr uint32_t GRAPH_RECORD_OUTER_LOCAL_ID = 0;
+
 // Stand the recording's hazard map up on its own allocation. Failure is
 // reported to the caller, which abandons the recording rather than producing a
 // Definition with inferred edges missing.
@@ -783,7 +789,6 @@ bool graph_recording_reset(GraphRecording &recording, const GraphInflightRecordi
     }
     recording.tensor_map.reset();
     recording.full_key = entry.full_key;
-    recording.start_local_task_id = entry.start_local_task_id;
     recording.boundary = &entry.boundary;
     recording.next_virtual_offset = 0;
     recording.unsupported = false;
@@ -1238,9 +1243,10 @@ static bool append_fanin_or_fail(
     // Only a RING-space producer has an entry in the task table. A GRAPH_NODE id's
     // low bits are a packed (outer task, node index) pair, so using them as a table
     // index names an unrelated task — or, since get_slot_state_by_task_id does not
-    // bounds-check, no task at all. Nothing inside a Graph is reachable as a
-    // producer here — a recorded node hands out a RING id — so a foreign space is a
-    // caller error, not a case to tolerate.
+    // bounds-check, no task at all. A recorded node's id is GRAPH_NODE and the
+    // recorder resolves it against its own body, never here, so a foreign space
+    // reaching this point is an id that escaped its Graph — a caller error, not a
+    // case to tolerate.
     //
     // The table lookup lives here, after this check, rather than at the three call
     // sites: that keeps the id-space invariant in one place and makes it impossible
@@ -2042,12 +2048,12 @@ TaskOutputTensors graph_record_submit_node(
     GraphRecording &recording = *active_graph_recording(orch);
 
     const size_t node_index = recording.node_count;
-    // A recorded node's index equals its local task id minus the recording
-    // baseline, so its synthetic id keeps classification and explicit-dep
-    // arithmetic identical to the ordinary path.
-    const TaskId task_id = simpler::hbg::make_ring_task(
-        static_cast<uint32_t>(recording.start_local_task_id) + static_cast<uint32_t>(node_index)
-    );
+    // A recorded node lives in the GRAPH_NODE id space, so an id the body hands
+    // around says which of the two kinds of thing it names without any arithmetic:
+    // a GRAPH_NODE id is a node of this body, indexed by its low field; a RING id is
+    // a task submitted before the Graph, which no node may depend on.
+    const TaskId task_id =
+        simpler::hbg::make_graph_node(GRAPH_RECORD_OUTER_LOCAL_ID, static_cast<uint32_t>(node_index));
     result.set_task_id(task_id);
 
     if (node_index >= GRAPH_MAX_NODES || args.has_error) {
@@ -2241,7 +2247,10 @@ TaskOutputTensors graph_record_submit_node(
             args.explicit_deps_data(),
         };
         const bool manual_scope = recording.in_manual_scope();
-        if (!recording.storage_ready) {
+        if (!recording.storage_ready || node_index >= GRAPH_MAX_NODES) {
+            // An over-cap body is already abandoned, and its node ids have run past
+            // the index field make_graph_node packs them into, so registering one
+            // would key the map outside its task chains.
             recording.unsupported = true;
         } else if (recording.tensor_map.free_entries() < count_registrable_outputs(dep_inputs, manual_scope)) {
             // Recording one more node would assert inside new_entry(). Abandon the
@@ -2253,11 +2262,14 @@ TaskOutputTensors graph_record_submit_node(
             );
             recording.unsupported = true;
         } else {
-            auto emit_inferred = [&recording, &add_fanin, node_index](TaskId producer) -> bool {
-                const int32_t producer_index =
-                    static_cast<int32_t>(simpler::hbg::task_local_id(producer)) - recording.start_local_task_id;
-                if (simpler::hbg::is_ring_task(producer) && producer_index >= 0 &&
-                    producer_index < static_cast<int32_t>(node_index)) {
+            auto emit_inferred = [&add_fanin, node_index](TaskId producer) -> bool {
+                // A RING producer is a task submitted before the Graph. The outer shell
+                // was submitted through the ordinary path against this same boundary, so
+                // its own fanin already orders the whole body behind that task and the
+                // Definition carries no edge of its own.
+                if (simpler::hbg::is_ring_task(producer)) return true;
+                const uint32_t producer_index = simpler::hbg::task_local_id(producer);
+                if (producer_index < static_cast<uint32_t>(node_index)) {
                     add_fanin(static_cast<size_t>(producer_index));
                 }
                 return true;
@@ -2268,13 +2280,14 @@ TaskOutputTensors graph_record_submit_node(
     }
     for (uint32_t i = 0; i < args.explicit_dep_count(); ++i) {
         const TaskId dep = args.explicit_dep(i);
-        const int32_t dep_index =
-            static_cast<int32_t>(simpler::hbg::task_local_id(dep)) - recording.start_local_task_id;
-        if (!dep.is_valid() || !simpler::hbg::is_ring_task(dep) || dep_index >= static_cast<int32_t>(node_index)) {
+        if (!dep.is_valid()) {
             recording.unsupported = true;
             continue;
         }
-        if (dep_index < 0) {
+        if (simpler::hbg::is_ring_task(dep)) {
+            // Only the outer shell can order the body behind a pre-Graph task, and it
+            // does so through its boundary args -- so a dep no boundary tensor carries
+            // has no edge in the Definition and the body cannot be recorded.
             const bool represented_by_boundary = std::any_of(
                 recording.boundary_tensors().begin(), recording.boundary_tensors().end(),
                 [dep](const simpler::hbg::Tensor &tensor) {
@@ -2282,9 +2295,16 @@ TaskOutputTensors graph_record_submit_node(
                 }
             );
             if (!represented_by_boundary) recording.unsupported = true;
-        } else {
-            add_fanin(static_cast<size_t>(dep_index));
+            continue;
         }
+        const uint32_t dep_index = simpler::hbg::task_local_id(dep);
+        if (dep_index >= static_cast<uint32_t>(node_index)) {
+            // A node of this body that is not yet recorded: the Definition's edges are
+            // acyclic by construction, so a forward reference cannot be expressed.
+            recording.unsupported = true;
+            continue;
+        }
+        add_fanin(static_cast<size_t>(dep_index));
     }
 
     node.fanin_count = static_cast<uint32_t>(recording.internal_fanins.size() - node.fanin_offset);
@@ -2400,7 +2420,6 @@ OrchestratorState::graph_begin_inner(uint64_t graph_key, const GraphTaskArgs &ar
     // up here would sit on the submitting thread, between two outer shells.
     auto entry = std::make_unique<GraphInflightRecording>();
     entry->full_key = full_key;
-    entry->start_local_task_id = orch->task_allocator.active_count();
     entry->boundary.scalar_count = args.scalar_count();
     entry->boundary.tensors.reserve(static_cast<size_t>(args.tensor_count()));
     entry->boundary.types.reserve(static_cast<size_t>(args.tensor_count()));

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -1194,7 +1194,9 @@ GraphHostDefinitionList graph_host_definitions(GraphHostState &state) {
     return list;
 }
 
-static uint32_t next_fanin_seen_epoch(OrchestratorState *orch) {
+// Advances the epoch fanin_mark_seen keys against, so a mark left by an earlier task
+// never reads as a repeat. The table is cleared only on wraparound.
+static void next_fanin_seen_epoch(OrchestratorState *orch) {
     uint32_t next = orch->fanin_seen_current_epoch + 1;
     if (next == 0) {
         memset(
@@ -1203,52 +1205,36 @@ static uint32_t next_fanin_seen_epoch(OrchestratorState *orch) {
         next = 1;
     }
     orch->fanin_seen_current_epoch = next;
-    return next;
 }
 
-// Polling: fanin is a flat array of position-independent producer local ids on
-// the payload (no dep-pool spill, no producer pointers). The builder writes them
-// directly into the payload's fanin region as producers are appended, deduping by
-// slot and hard-capping at CHIP_MAX_FANIN. self_local is this task's own local id
-// (the consumer), used to bump each producer's last_consumer_local_id (the
-// reclaim gate the host wait_for_consumers polls via completed_watermark).
-struct FaninBuilder {
-    FaninBuilder(OrchestratorState *orch, TaskPayload *payload, int32_t self_local, uint32_t seen_epoch) :
-        count(0),
-        orch(orch),
-        seen_epoch(seen_epoch),
-        self_local(self_local),
-        payload(payload),
-        slots(payload->fanin_data()) {}
-    int32_t count{0};
-    OrchestratorState *orch{nullptr};
-    uint32_t seen_epoch{0};
-    int32_t self_local{0};
-    TaskPayload *payload{nullptr};
-    // The payload's fanin region, resolved once: the appends below would otherwise
-    // re-resolve the delta per producer. Requires the regions bound before construction.
-    int32_t *slots{nullptr};
-
-    bool mark_seen(TaskId producer_task_id) {
-        // Dedup only. A negative local id cannot index the epoch table, so it is
-        // reported as not-yet-seen and the caller appends it rather than rejecting
-        // it; append_fanin_or_fail has already established that the producer is a
-        // ring task whose local id is a valid table entry.
-        const int32_t prod_local = static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id));
-        if (prod_local < 0) {
-            return false;
-        }
-        uint32_t *seen = orch->fanin_seen_epoch.get();
-        uint32_t slot = static_cast<uint32_t>(prod_local);
-        if (seen[slot] == seen_epoch) {
-            return true;
-        }
-        seen[slot] = seen_epoch;
+// True when this producer was already appended under the current epoch. A negative
+// local id cannot index the epoch table, so it is reported as not-yet-seen and the
+// caller appends it rather than rejecting it; append_fanin_or_fail has already
+// established that the producer is a ring task whose local id is a valid table
+// entry.
+static bool fanin_mark_seen(OrchestratorState &orch, TaskId producer_task_id) {
+    const int32_t prod_local = static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id));
+    if (prod_local < 0) {
         return false;
     }
-};
+    uint32_t *seen = orch.fanin_seen_epoch.get();
+    uint32_t slot = static_cast<uint32_t>(prod_local);
+    if (seen[slot] == orch.fanin_seen_current_epoch) {
+        return true;
+    }
+    seen[slot] = orch.fanin_seen_current_epoch;
+    return false;
+}
 
-static bool append_fanin_or_fail(OrchestratorState *orch, TaskId producer_task_id, FaninBuilder *fanin_builder) {
+// Polling: fanin is a flat array of position-independent producer local ids in the
+// payload's own fanin region (no dep-pool spill, no producer pointers), deduped
+// against the current fanin_seen epoch and hard-capped at CHIP_MAX_FANIN.
+// fanin_slots and fanin_count are that region and payload.fanin_count itself: the
+// region is named by a SelfRelativePtr delta, so the caller resolves it once, and
+// the count accumulates in place instead of being copied back at the end.
+static bool append_fanin_or_fail(
+    OrchestratorState &orch, TaskId producer_task_id, TaskId self_task_id, int32_t *fanin_slots, int32_t &fanin_count
+) {
     // Only a RING-space producer has an entry in the task table. A GRAPH_NODE id's
     // low bits are a packed (outer task, node index) pair, so using them as a table
     // index names an unrelated task — or, since get_slot_state_by_task_id does not
@@ -1260,7 +1246,7 @@ static bool append_fanin_or_fail(OrchestratorState *orch, TaskId producer_task_i
     // sites: that keeps the id-space invariant in one place and makes it impossible
     // for a caller to form the out-of-bounds slot reference before reaching it.
     if (!simpler::hbg::is_ring_task(producer_task_id)) {
-        orch->report_fatal(
+        orch.report_fatal(
             SIMPLER_ERROR_INVALID_ARGS, __FUNCTION__,
             "producer task %#llx is in id space %u, not RING; host_build_graph resolves every fanin edge against its "
             "one task table",
@@ -1269,7 +1255,7 @@ static bool append_fanin_or_fail(OrchestratorState *orch, TaskId producer_task_i
         );
         return false;
     }
-    ChipTaskSlotState *prod_state = &orch->sm_header->tasks.get_slot_state_by_task_id(
+    ChipTaskSlotState *prod_state = &orch.sm_header->tasks.get_slot_state_by_task_id(
         static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id))
     );
     // Skip a stale/reused producer slot: the cached owner id no longer resolves
@@ -1281,29 +1267,30 @@ static bool append_fanin_or_fail(OrchestratorState *orch, TaskId producer_task_i
         return true;
     }
     // Dedup by producer local id, which is also its task-table slot.
-    if (fanin_builder->mark_seen(producer_task_id)) {
+    if (fanin_mark_seen(orch, producer_task_id)) {
         return true;
     }
-    if (fanin_builder->count >= CHIP_MAX_FANIN) {
+    if (fanin_count >= CHIP_MAX_FANIN) {
         LOG_ERROR("========================================");
         LOG_ERROR("FATAL: Fanin Capacity Exhausted!");
         LOG_ERROR("========================================");
         LOG_ERROR("HBG stores every producer dependency in the consumer task's fanin region.");
-        LOG_ERROR("  Fanin:     used=%d/%d", fanin_builder->count, CHIP_MAX_FANIN);
-        LOG_ERROR("  Requested: at least %d distinct producer dependencies", fanin_builder->count + 1);
+        LOG_ERROR("  Fanin:     used=%d/%d", fanin_count, CHIP_MAX_FANIN);
+        LOG_ERROR("  Requested: at least %d distinct producer dependencies", fanin_count + 1);
         LOG_ERROR("Solution:");
         LOG_ERROR("  Reduce the task fanin to at most CHIP_MAX_FANIN=%d.", CHIP_MAX_FANIN);
         LOG_ERROR("  HBG has no dependency spill pool; runtime_env.ring_dep_pool does not apply.");
         LOG_ERROR("========================================");
-        orch_mark_fatal(orch, SIMPLER_ERROR_FANIN_CAPACITY_EXCEEDED);
+        orch_mark_fatal(&orch, SIMPLER_ERROR_FANIN_CAPACITY_EXCEEDED);
         return false;
     }
-    fanin_builder->slots[fanin_builder->count++] = static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id));
+    fanin_slots[fanin_count++] = static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id));
 
     // Reclaim gate: record this task as a consumer of the producer. The producer
     // slot retires once the per-ring completed_watermark reaches this consumer id.
-    if (fanin_builder->self_local > prod_state->last_consumer_local_id) {
-        prod_state->last_consumer_local_id = fanin_builder->self_local;
+    const int32_t self_local = static_cast<int32_t>(simpler::hbg::task_local_id(self_task_id));
+    if (self_local > prod_state->last_consumer_local_id) {
+        prod_state->last_consumer_local_id = self_local;
     }
     return true;
 }
@@ -1572,9 +1559,13 @@ static TaskOutputTensors submit_task_common(
         );
     }
 
-    FaninBuilder fanin_builder(
-        orch, &payload, static_cast<int32_t>(simpler::hbg::task_local_id(task_id)), next_fanin_seen_epoch(orch)
-    );
+    // The region delta is resolved once here, after prepare_task bound the regions.
+    // Zeroing the count gives the appends their starting point, and is this
+    // device-read field's only write on the submit path — hbg never zero-fills the
+    // task table.
+    next_fanin_seen_epoch(orch);
+    int32_t *fanin_slots = payload.fanin_data();
+    payload.fanin_count = 0;
 
     CYCLE_COUNT_LAP(g_orch_alloc_cycle);
 
@@ -1596,7 +1587,7 @@ static TaskOutputTensors submit_task_common(
         if (capture_dep_graph) {
             dep_gen_host_graph_add_explicit_edge(dep_task_id.raw);
         }
-        if (!append_fanin_or_fail(orch, dep_task_id, &fanin_builder)) {
+        if (!append_fanin_or_fail(*orch, dep_task_id, task_id, fanin_slots, payload.fanin_count)) {
             return result;
         }
     }
@@ -1608,7 +1599,7 @@ static TaskOutputTensors submit_task_common(
     };
 
     auto runtime_emit = [&](TaskId producer_task_id) -> bool {
-        return append_fanin_or_fail(orch, producer_task_id, &fanin_builder);
+        return append_fanin_or_fail(*orch, producer_task_id, task_id, fanin_slots, payload.fanin_count);
     };
 
     // The capture branch instantiates compute_task_fanin with a live Annotate;
@@ -1653,9 +1644,10 @@ static TaskOutputTensors submit_task_common(
     task.packed_buffer_base = prepared.alloc_result.packed_base;
     task.packed_buffer_end = prepared.alloc_result.packed_end;
 
-    // append_fanin_or_fail wrote each producer's local id straight into
-    // the payload's fanin region and bumped its last_consumer_local_id; the count is
-    // published in STEP 6 below. payload.init does not touch the fanin region.
+    // append_fanin_or_fail wrote every producer's local id into the payload's fanin
+    // region, counted them in payload.fanin_count, and bumped each producer's
+    // last_consumer_local_id. payload.init writes tensor_count/scalar_count only and
+    // must not touch either, or it would discard that.
     payload.init(args, result, prepared.alloc_result, layout);
 
     // Dispatch predicate: resolve the (tensor, indices) to an absolute GM address
@@ -1678,10 +1670,10 @@ static TaskOutputTensors submit_task_common(
     }
     CYCLE_COUNT_LAP(g_orch_args_cycle);
 
-    // === STEP 6: publish the inline fanin count (device boot classifies) ===
-    // Polling + host-orch: append_fanin_or_fail already wrote each producer's
-    // local id into the payload's fanin region and bumped its last_consumer_local_id.
-    // All that remains is to record how many. There is NO fanout adjacency, NO
+    // === STEP 6: close the fanin region (device boot classifies) ===
+    // Polling + host-orch: append_fanin_or_fail already wrote each producer's local
+    // id into the payload's fanin region, counted them in payload.fanin_count, and
+    // bumped each producer's last_consumer_local_id. There is NO fanout adjacency, NO
     // dep_pool, and NO ready routing here — the initial device boot scan classifies
     // each task once. A -1 result from classify_fanin_state routes the task through
     // push_ready_routed; otherwise the returned index selects the producer passed
@@ -1690,12 +1682,11 @@ static TaskOutputTensors submit_task_common(
     // The initial scan happens before the scheduler dispatch loop starts. Fanin is
     // a flat array of position-independent integers, so it crosses to the device
     // unchanged.
-    payload.fanin_count = fanin_builder.count;
     // The region's length is settled, so the cursor closes it at the real count. The
     // equality holds only while nothing between the bind and here bound another fanin
     // region, which is what makes the deferred advance safe.
     debug_assert(orch->fanin_pool_cursor == static_cast<int32_t>(payload.fanin_data() - orch->fanin_pool));
-    orch->fanin_pool_cursor += CHIP_ALIGN_UP(fanin_builder.count, ARG_POOL_ALIGN / (int32_t)sizeof(int32_t));
+    orch->fanin_pool_cursor += CHIP_ALIGN_UP(payload.fanin_count, ARG_POOL_ALIGN / (int32_t)sizeof(int32_t));
 
     (void)sched;
 
@@ -1929,11 +1920,12 @@ bool graph_submit_outer(
         );
     }
 
-    FaninBuilder fanin_builder(
-        orch, &payload, static_cast<int32_t>(simpler::hbg::task_local_id(task_id)), next_fanin_seen_epoch(orch)
-    );
+    // graph_reset_outer_payload above zeroed the count; the region delta is resolved
+    // once here.
+    next_fanin_seen_epoch(orch);
+    int32_t *fanin_slots = payload.fanin_data();
     auto emit = [&](TaskId producer_id) -> bool {
-        return append_fanin_or_fail(orch, producer_id, &fanin_builder);
+        return append_fanin_or_fail(*orch, producer_id, task_id, fanin_slots, payload.fanin_count);
     };
     // An outer GRAPH task is an ordinary task, so the dependency graph
     // has to carry it: without this the whole Graph — and every edge into it —
@@ -1962,12 +1954,11 @@ bool graph_submit_outer(
         return false;
     }
     register_task_outputs(boundary_inputs, task_id, orch->tensor_map, orch->in_manual_scope());
-    payload.fanin_count = fanin_builder.count;
     // The region's length is settled, so the cursor closes it at the real count. The
     // equality holds only while nothing between the bind and here bound another fanin
     // region, which is what makes the deferred advance safe.
     debug_assert(orch->fanin_pool_cursor == static_cast<int32_t>(payload.fanin_data() - orch->fanin_pool));
-    orch->fanin_pool_cursor += CHIP_ALIGN_UP(fanin_builder.count, ARG_POOL_ALIGN / (int32_t)sizeof(int32_t));
+    orch->fanin_pool_cursor += CHIP_ALIGN_UP(payload.fanin_count, ARG_POOL_ALIGN / (int32_t)sizeof(int32_t));
 
     pending.outer_slot = &slot;
     state->pending_uploads.push_back(pending);

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
@@ -243,7 +243,7 @@ static bool wait_for_tensor_ready(
         int32_t local_id = simpler::hbg::task_local_id(slot.task->task_id);
         uint64_t t0 = get_sys_cnt_aicpu();
         int32_t spin_count = 0;
-        // Polling: all consumers of this producer have retired once the per-ring
+        // Polling: all consumers of this producer have retired once the
         // completed_watermark reaches the producer's highest consumer id (set at
         // submit in append_fanin_or_fail). Replaces the fanout_refcount ==
         // fanout_count wiring check, which polling removes.

--- a/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
@@ -186,11 +186,11 @@ static bool wait_for_tensor_ready(
     // Callers branch on the returned pointer, not on `failed`: the slot is
     // dereferenced immediately and a null return is the only safe signal.
     auto resolve_producer = [&](TaskId producer) -> const ChipTaskSlotState * {
-        if (!producer.is_valid() || !simpler::hbg::is_ring_task(producer)) {
+        if (!producer.is_valid() || !simpler::hbg::is_global_task(producer)) {
             orch.report_fatal(
                 SIMPLER_ERROR_INVALID_ARGS, caller,
-                "tensor producer task %#llx is in id space %u, not RING; host_build_graph resolves a producer against "
-                "its one task table",
+                "tensor producer task %#llx is in id space %u, not GLOBAL; host_build_graph resolves a producer "
+                "against its one task table",
                 static_cast<unsigned long long>(producer.raw),
                 static_cast<unsigned int>(simpler::hbg::task_id_space(producer))
             );

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime_types.h
@@ -188,7 +188,7 @@ constexpr uint64_t TENSOR_DATA_TIMEOUT_MS = 15000;  // 15 s
  *                         hidden alloc completed inline by the orchestrator
  *
  * COMPLETED is terminal: no slot is recycled before the run ends, so nothing
- * advances a task past it. Consumer retirement is observed through the per-ring
+ * advances a task past it. Consumer retirement is observed through the
  * completed_watermark instead.
  */
 typedef enum {
@@ -236,7 +236,7 @@ struct ChipTaskSlotState;  // Forward declaration (defined below)
 /**
  * Task descriptor structure (shared memory)
  *
- * Stored in the TaskDescriptor ring buffer in shared memory.
+ * Stored in the TaskDescriptor table in shared memory.
  * Contains static identification and buffer pointers only.
  * Dynamic scheduling state (fanin/fanout/task_state) is in ChipTaskSlotState.
  *
@@ -268,8 +268,8 @@ static_assert(offsetof(TaskDescriptor, packed_buffer_base) == 24, "packed_buffer
  * Task payload data (cold path - only accessed during orchestration and dispatch)
  *
  * Layout: metadata + inline fanin packed in the first 9 cache lines, followed
- * by bulk tensor and scalar data. Small fanins stay fully inline; larger
- * fanins spill into a per-ring ring buffer slice.
+ * by bulk tensor and scalar data. Fanin is always inline: it is hard-capped at
+ * CHIP_MAX_FANIN and there is no spill pool.
  */
 // Early-dispatch claim states for TaskPayload::early_dispatch_state.
 enum EarlyDispatchState : uint8_t {
@@ -317,9 +317,9 @@ struct TaskPayload {
     // the mirror when the slot is claimed, and against the image in
     // compact_live_image, which re-pitches the segments.
     //
-    // fanin holds flat position-independent producer local task ids. Single-ring
-    // hbg: every producer is ring 0, so no per-edge ring id is stored. Scanned by
-    // classify_fanin_state against the ring completion_flags. Hard-capped at
+    // fanin holds flat position-independent producer local task ids. A producer is
+    // named by its local id alone, so no per-edge indirection is stored. Scanned by
+    // classify_fanin_state against the shared-memory completion_flags. Hard-capped at
     // CHIP_MAX_FANIN (no dep-pool spill). Unbound on a Graph node, whose
     // dependencies live in the Definition's fanin CSR instead.
     simpler::hbg::SelfRelativePtr<simpler::hbg::Tensor> tensors;
@@ -470,8 +470,8 @@ struct TaskPayload {
         // zero additional cost.
         memcpy(scalar_data(), args.scalars(), CHIP_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
 
-        // The ring's payload storage is reused raw memory that no constructor runs
-        // over, so an unset predicate reads back as whatever the slot last held —
+        // The task table's payload storage is raw shared memory that no constructor
+        // runs over, so an unset predicate reads back as whatever the slot last held —
         // and compact_live_image translates predicate.addr as a graph-heap address
         // for every submitted slot. An ordinary task overwrites this right
         // after init(); a hidden-alloc task has nothing following it, so this is
@@ -542,7 +542,7 @@ static_assert(sizeof(simpler::hbg::Tensor) == 128, "simpler::hbg::Tensor must be
  * Per-task slot scheduling state (scheduler-private, NOT in shared memory)
  *
  * 64 bytes = one cache line. Under the polling completion model a task's
- * readiness is derived from its producers' completion_flags (in the ring
+ * readiness is derived from its producers' completion_flags (in the SM
  * header); producer completion is published by setting this task's own
  * completion_flag + draining its wake list. There is no fanout adjacency,
  * refcount, or per-task lock here.
@@ -554,7 +554,7 @@ static_assert(sizeof(simpler::hbg::Tensor) == 128, "simpler::hbg::Tensor must be
  */
 struct alignas(64) ChipTaskSlotState {
     // Highest local task id among this slot's consumers. Reclaim gate: the slot
-    // is safe to retire once the per-ring completed_watermark reaches this id.
+    // is safe to retire once the completed_watermark reaches this id.
     // Whole-graph-resident hbg never reclaims at runtime, so this is
     // inert-but-scaffolded for parity. Seeded to own local_id in prepare_task;
     // bumped via max() at submit for each consumer.

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -571,8 +571,8 @@ struct SchedulerState {
 
     // ---- Polling completion primitives ---------------------------------------
     // Readiness: a task is ready iff every producer named in its inline fanin has
-    // set its completion_flags byte. Single-ring: all producers are ring 0, so
-    // there is no per-edge ring indirection.
+    // set its completion_flags byte. A producer is named by its local id alone, so
+    // there is no per-edge indirection.
 
     // Unmet-fanin classification. Returns -1 (all fanins met -> route to ready)
     // or the index of an unmet fanin (register on that producer's wake list).
@@ -1154,14 +1154,14 @@ struct SchedulerState {
 
     // on_task_release is gone under polling. It existed to bump each producer's
     // fanout_refcount so the host wait_for_consumers could observe consumer
-    // retirement; that signal is now the per-ring completed_watermark advanced by
+    // retirement; that signal is now the completed_watermark advanced by
     // on_mixed_task_complete. There is likewise no self CONSUMED flip (host-orch
     // never reclaimed slots on device).
 
     // === Cold-path API (defined in scheduler.cpp) ===
 
-    // Phase 1: declare every sub-region (ready_queue slots, dummy queue slots,
-    // per-ring dep_pool entries) on the supplied arena.
+    // Phase 1: declare every sub-region (ready_queue slots, dummy queue slots) on
+    // the supplied arena.
     // Capacities are baked into the returned layout; init_data_from_layout uses
     // the same values.
     static SchedulerLayout reserve_layout(DeviceArena &arena);
@@ -1175,8 +1175,8 @@ struct SchedulerState {
     bool init_data_from_layout(const SchedulerLayout &layout, DeviceArena &arena, void *sm_dev_base);
 
     // Phase 3b: write the arena-internal pointer fields
-    // (ready_queues[].slots, dummy_ready_queue.slots, dep_pool.base for each
-    // ring). Called on both host and device sides.
+    // (ready_queues[].slots, dummy_ready_queue.slots). Called on both host and
+    // device sides.
     void wire_arena_pointers(const SchedulerLayout &layout, DeviceArena &arena);
 
     // Phase 3c, device only: bring every queue's slots[] to its empty ramp. The

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -129,7 +129,7 @@ LoopAction SchedulerContext::check_idle_fatal_error(int32_t thread_idx, SharedMe
 //
 // Categories (and which thread emits them):
 //   SUMMARY  — completed / total counts and scan totals               (thread 0 only)
-//   TASK     — one per non-completed task scanned from shared rings   (thread 0 only)
+//   TASK     — one per non-completed task in the shared table          (thread 0 only)
 //              - state=RUNNING: includes running_on=[...] cross-ref
 //              - state=READY:   fanin satisfied but no idle core yet
 //              - state=WAIT:    includes missing_deps=N

--- a/src/a2a3/runtime/host_build_graph/runtime/tensormap.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/tensormap.h
@@ -567,6 +567,10 @@ struct ChipTensorMap {
         uint32_t bucket_index = hash(addr);
         auto local_id = simpler::hbg::task_local_id(producer_task_id);
         const int32_t task_slot = local_id;
+        // A producer's low id field is a task chain index directly, so the id space a
+        // caller inserts under has to be the one this map was dimensioned for: a
+        // whole-run map takes task capacity, a Graph recording's takes GRAPH_MAX_NODES.
+        debug_assert(task_slot >= 0 && task_slot < max_tasks);
 
         entry->producer_task_id = producer_task_id;
 
@@ -605,6 +609,7 @@ struct ChipTensorMap {
             // Entry is the head of its task chain, update task_entry_heads
             int32_t local_id = static_cast<int32_t>(simpler::hbg::task_local_id(entry.producer_task_id));
             const int32_t task_slot = local_id;
+            debug_assert(task_slot >= 0 && task_slot < max_tasks);
             task_entry_heads[task_slot] = entry.next_in_task;
         } else {
             entry.prev_in_task->next_in_task = entry.next_in_task;

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -273,10 +273,10 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
             // Performance profiling: record task execution.
             // Two identity fields go into the record (different roles):
-            //   - task_token_raw (ring/local) is pulled from the dispatch
+            //   - task_token_raw (the full TaskId) is pulled from the dispatch
             //     payload's LocalContext.async_ctx — already in AICore cache
             //     from the just-completed task, no extra GM load. Host uses
-            //     it as the canonical task identity for JSON output / ring
+            //     it as the canonical task identity for JSON output / task-id
             //     decoding.
             //   - reg_task_id is `task_id` (= reg_val, the per-core dispatch
             //     token AICore just read from DATA_MAIN_BASE). Per-dispatch

--- a/src/a5/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a5/runtime/host_build_graph/docs/SCALAR_DATA_ACCESS.md
@@ -70,8 +70,8 @@ it derives for itself, from a heap block whose prior contents it never reads.
 
 Before a wait slot is used, the runtime verifies:
 
-- the task ID is valid and lies in the `RING` id space — a `GRAPH_NODE` id packs
-  its outer task and node index into the low bits, so it indexes no task table
+- the task ID is valid and lies in the `GLOBAL` id space — an `IN_GRAPH` id packs
+  its Graph task and task index into the low bits, so it indexes no task table
   slot (see `src/common/host_build_graph/task_id_encoding.h`);
 - the task table slot that ID indexes has a bound task descriptor; and
 - the descriptor's full task ID matches the tensor's owner/producer ID.

--- a/src/a5/runtime/host_build_graph/host/dep_gen_host_graph.cpp
+++ b/src/a5/runtime/host_build_graph/host/dep_gen_host_graph.cpp
@@ -19,11 +19,10 @@
  *   tensormap — a producer whose written slice overlaps what this task reads
  *               (STEP 3 Step B); carries both slices' geometry.
  *
- * Per-task producer dedup mirrors FaninBuilder::append_fanin_or_fail, which
- * collapses all three sources into one fanin list: the first edge to name a
- * producer is kept. tensormap edges are exempt — a second producer slice for the
- * same task is a distinct fact about the data flow, and viewers rely on seeing
- * every overlap.
+ * Per-task producer dedup mirrors append_fanin_or_fail, which collapses all three
+ * sources into one fanin list: the first edge to name a producer is kept. tensormap
+ * edges are exempt — a second producer slice for the same task is a distinct fact
+ * about the data flow, and viewers rely on seeing every overlap.
  */
 
 #include "dep_gen_host_graph.h"

--- a/src/a5/runtime/host_build_graph/runtime/dep_compute.h
+++ b/src/a5/runtime/host_build_graph/runtime/dep_compute.h
@@ -44,9 +44,9 @@
  * away.
  *
  * Performance: Emit and Annotate are template parameters, not std::function. The
- * runtime lambda (capturing fanin_builder + sm_header) instantiates at the call site
- * and inlines through. Do NOT replace with std::function — it would break the
- * inlining and add ~5 ns/call to the orch hot path.
+ * runtime lambda (capturing the consumer's fanin region + count) instantiates at the
+ * call site and inlines through. Do NOT replace with std::function — it would break
+ * the inlining and add ~5 ns/call to the orch hot path.
  */
 
 #pragma once

--- a/src/a5/runtime/host_build_graph/runtime/dep_gen_host_graph.h
+++ b/src/a5/runtime/host_build_graph/runtime/dep_gen_host_graph.h
@@ -43,10 +43,10 @@
  * progress loop satisfies this by being single-threaded; emit returns -3 if the
  * invariant is ever broken.
  *
- * Per-task producer dedup mirrors FaninBuilder, which keys on (ring, slot);
- * this keys on producer task id. The two agree only because host_build_graph is
- * whole-graph-resident and never reuses a task slot at build time (see
- * append_fanin_or_fail in orchestrator.cpp). A runtime that recycles slots
+ * Per-task producer dedup mirrors append_fanin_or_fail, which keys on the producer's
+ * local id; this keys on producer task id. The two agree only because
+ * host_build_graph is whole-graph-resident and never reuses a task slot at build time
+ * (see append_fanin_or_fail in orchestrator.cpp). A runtime that recycles slots
  * mid-build would need this key revisited.
  *
  * Output is `deps.json` in the schema documented in docs/dfx/dep-gen.md — the

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator.h
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator.h
@@ -109,9 +109,9 @@ struct OrchestratorState {
     // case (max_tasks tasks each at their full cap), so a bump cannot overflow.
     // The bases live here, not in the task header: nothing on the device resolves one.
     //
-    // The fanin cursor does not advance at bind time. FaninBuilder appends and
-    // dedups producers afterwards, so the region's length is known only when the count
-    // is published, and it advances there.
+    // The fanin cursor does not advance at bind time. append_fanin_or_fail appends and
+    // dedups producers afterwards, so the region's length is known only once the last
+    // producer is appended, and it advances there.
     int32_t *fanin_pool{nullptr};
     simpler::hbg::Tensor *tensor_pool{nullptr};
     uint64_t *scalar_pool{nullptr};

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator.h
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator.h
@@ -61,7 +61,7 @@ struct OrchestratorState {
     SharedMemoryHeader *sm_header;
 
     // === TASK / HEAP ALLOCATION ===
-    // hbg is single-ring, so one allocator covers the whole graph.
+    // hbg has one task table, so one allocator covers the whole graph.
     TaskAllocator task_allocator;
     std::unique_ptr<uint32_t[]> fanin_seen_epoch;
     uint32_t fanin_seen_current_epoch{1};

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -679,13 +679,13 @@ constexpr int32_t GRAPH_RECORD_TENSORMAP_POOL_SIZE = 16384;
 constexpr size_t GRAPH_RECORD_NODE_TENSOR_POOL_ELEMS =
     static_cast<size_t>(GRAPH_MAX_NODES) * static_cast<size_t>(CORE_MAX_TENSOR_ARGS);
 
-// The outer local id a recorded node's GRAPH_NODE id carries. A recorded node
-// belongs to no outer task -- every shell replaying the Definition re-mints the id
-// with its own local id at materialize -- so record time names a node by its index
-// alone, and the id's low field is that index and nothing else. That is what keeps
-// the index inside the GRAPH_MAX_NODES task chains the recording's hazard map is
+// The graph_local_id a recorded task's IN_GRAPH id carries. A recorded task belongs
+// to no Graph task yet -- every shell replaying the Definition re-mints the id with
+// its own local id at materialize -- so record time names a task by its index alone,
+// and the id's low field is that index and nothing else. That is what keeps the
+// index inside the GRAPH_MAX_NODES task chains the recording's hazard map is
 // dimensioned for.
-constexpr uint32_t GRAPH_RECORD_OUTER_LOCAL_ID = 0;
+constexpr uint32_t GRAPH_RECORD_NO_OWNING_GRAPH = 0;
 
 // Stand the recording's hazard map up on its own allocation. Failure is
 // reported to the caller, which abandons the recording rather than producing a
@@ -1240,10 +1240,10 @@ static bool fanin_mark_seen(OrchestratorState &orch, TaskId producer_task_id) {
 static bool append_fanin_or_fail(
     OrchestratorState &orch, TaskId producer_task_id, TaskId self_task_id, int32_t *fanin_slots, int32_t &fanin_count
 ) {
-    // Only a RING-space producer has an entry in the task table. A GRAPH_NODE id's
-    // low bits are a packed (outer task, node index) pair, so using them as a table
+    // Only a GLOBAL producer has an entry in the task table. An IN_GRAPH id's low
+    // bits are a packed (Graph task, task index) pair, so using them as a table
     // index names an unrelated task — or, since get_slot_state_by_task_id does not
-    // bounds-check, no task at all. A recorded node's id is GRAPH_NODE and the
+    // bounds-check, no task at all. A recorded task's id is IN_GRAPH and the
     // recorder resolves it against its own body, never here, so a foreign space
     // reaching this point is an id that escaped its Graph — a caller error, not a
     // case to tolerate.
@@ -1251,11 +1251,11 @@ static bool append_fanin_or_fail(
     // The table lookup lives here, after this check, rather than at the three call
     // sites: that keeps the id-space invariant in one place and makes it impossible
     // for a caller to form the out-of-bounds slot reference before reaching it.
-    if (!simpler::hbg::is_ring_task(producer_task_id)) {
+    if (!simpler::hbg::is_global_task(producer_task_id)) {
         orch.report_fatal(
             SIMPLER_ERROR_INVALID_ARGS, __FUNCTION__,
-            "producer task %#llx is in id space %u, not RING; host_build_graph resolves every fanin edge against its "
-            "one task table",
+            "producer task %#llx is in id space %u, not GLOBAL; host_build_graph resolves every fanin edge against "
+            "its one task table",
             static_cast<unsigned long long>(producer_task_id.raw),
             static_cast<unsigned int>(simpler::hbg::task_id_space(producer_task_id))
         );
@@ -1347,7 +1347,7 @@ static bool prepare_task(
         return false;
     }
 
-    out->task_id = simpler::hbg::make_ring_task(static_cast<uint32_t>(out->alloc_result.task_id));
+    out->task_id = simpler::hbg::make_global_task(static_cast<uint32_t>(out->alloc_result.task_id));
     out->slot_state = &orch->sm_header->tasks.get_slot_state_by_task_id(out->alloc_result.task_id);
     out->task = &orch->sm_header->tasks.task_descriptors[out->alloc_result.task_id];
     out->payload = &orch->sm_header->tasks.task_payloads[out->alloc_result.task_id];
@@ -1876,7 +1876,7 @@ bool graph_submit_outer(
         orch_mark_fatal(orch, SIMPLER_ERROR_HEAP_RING_DEADLOCK);
         return false;
     }
-    const TaskId task_id = simpler::hbg::make_ring_task(static_cast<uint32_t>(allocation.task_id));
+    const TaskId task_id = simpler::hbg::make_global_task(static_cast<uint32_t>(allocation.task_id));
     SharedMemoryTaskHeader &tasks = orch->sm_header->tasks;
     TaskDescriptor &task = tasks.task_descriptors[allocation.task_id];
     TaskPayload &payload = tasks.task_payloads[allocation.task_id];
@@ -2048,12 +2048,12 @@ TaskOutputTensors graph_record_submit_node(
     GraphRecording &recording = *active_graph_recording(orch);
 
     const size_t node_index = recording.node_count;
-    // A recorded node lives in the GRAPH_NODE id space, so an id the body hands
+    // A recorded task lives in the IN_GRAPH id space, so an id the body hands
     // around says which of the two kinds of thing it names without any arithmetic:
-    // a GRAPH_NODE id is a node of this body, indexed by its low field; a RING id is
-    // a task submitted before the Graph, which no node may depend on.
+    // an IN_GRAPH id is a task of this body, indexed by its low field; a GLOBAL id is
+    // a task submitted before the Graph, which nothing in the body may depend on.
     const TaskId task_id =
-        simpler::hbg::make_graph_node(GRAPH_RECORD_OUTER_LOCAL_ID, static_cast<uint32_t>(node_index));
+        simpler::hbg::make_in_graph_task(GRAPH_RECORD_NO_OWNING_GRAPH, static_cast<uint32_t>(node_index));
     result.set_task_id(task_id);
 
     if (node_index >= GRAPH_MAX_NODES || args.has_error) {
@@ -2248,8 +2248,8 @@ TaskOutputTensors graph_record_submit_node(
         };
         const bool manual_scope = recording.in_manual_scope();
         if (!recording.storage_ready || node_index >= GRAPH_MAX_NODES) {
-            // An over-cap body is already abandoned, and its node ids have run past
-            // the index field make_graph_node packs them into, so registering one
+            // An over-cap body is already abandoned, and its task ids have run past
+            // the index field make_in_graph_task packs them into, so registering one
             // would key the map outside its task chains.
             recording.unsupported = true;
         } else if (recording.tensor_map.free_entries() < count_registrable_outputs(dep_inputs, manual_scope)) {
@@ -2263,11 +2263,11 @@ TaskOutputTensors graph_record_submit_node(
             recording.unsupported = true;
         } else {
             auto emit_inferred = [&add_fanin, node_index](TaskId producer) -> bool {
-                // A RING producer is a task submitted before the Graph. The outer shell
+                // A GLOBAL producer is a task submitted before the Graph. The outer shell
                 // was submitted through the ordinary path against this same boundary, so
                 // its own fanin already orders the whole body behind that task and the
                 // Definition carries no edge of its own.
-                if (simpler::hbg::is_ring_task(producer)) return true;
+                if (simpler::hbg::is_global_task(producer)) return true;
                 const uint32_t producer_index = simpler::hbg::task_local_id(producer);
                 if (producer_index < static_cast<uint32_t>(node_index)) {
                     add_fanin(static_cast<size_t>(producer_index));
@@ -2284,7 +2284,7 @@ TaskOutputTensors graph_record_submit_node(
             recording.unsupported = true;
             continue;
         }
-        if (simpler::hbg::is_ring_task(dep)) {
+        if (simpler::hbg::is_global_task(dep)) {
             // Only the outer shell can order the body behind a pre-Graph task, and it
             // does so through its boundary args -- so a dep no boundary tensor carries
             // has no edge in the Definition and the body cannot be recorded.
@@ -2299,7 +2299,7 @@ TaskOutputTensors graph_record_submit_node(
         }
         const uint32_t dep_index = simpler::hbg::task_local_id(dep);
         if (dep_index >= static_cast<uint32_t>(node_index)) {
-            // A node of this body that is not yet recorded: the Definition's edges are
+            // A task of this body that is not yet recorded: the Definition's edges are
             // acyclic by construction, so a forward reference cannot be expressed.
             recording.unsupported = true;
             continue;

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -462,7 +462,7 @@ struct GraphRecording {
     // Scope depth as the body sees it. begin_scope/end_scope leave the real
     // orchestrator stack untouched while recording (a Graph replays flat), but
     // the manual-scope flag still has to follow the body: a manual scope
-    // suppresses inference on the ring, so it must suppress it here too.
+    // suppresses inference on the ordinary path, so it must suppress it here too.
     int32_t scope_stack_top{-1};
     int32_t manual_begin_depth{CHIP_MAX_SCOPE_DEPTH};
 
@@ -666,7 +666,7 @@ graph_classify_scalar(const GraphRecording &recording, const ArgT &args, int32_t
 // Entry capacity for one recorded body's hazard map. A Definition is capped at
 // GRAPH_MAX_NODES nodes and each node registers at most its INOUT/OUTPUT_EXISTING
 // args, so this bounds the worst realistic body while staying a small fraction of
-// the ring path's whole-orchestration pool (CHIP_TENSORMAP_POOL_SIZE). Exhausting
+// the ordinary path's whole-orchestration pool (CHIP_TENSORMAP_POOL_SIZE). Exhausting
 // it marks the recording unsupported, which graph_commit reports as
 // SIMPLER_ERROR_INVALID_ARGS -- the outer shell is already submitted by then, so there
 // is no ordinary-path fallback left to take.
@@ -1215,7 +1215,7 @@ static void next_fanin_seen_epoch(OrchestratorState *orch) {
 // True when this producer was already appended under the current epoch. A negative
 // local id cannot index the epoch table, so it is reported as not-yet-seen and the
 // caller appends it rather than rejecting it; append_fanin_or_fail has already
-// established that the producer is a ring task whose local id is a valid table
+// established that the producer is a GLOBAL task whose local id is a valid table
 // entry.
 static bool fanin_mark_seen(OrchestratorState &orch, TaskId producer_task_id) {
     const int32_t prod_local = static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id));
@@ -1293,7 +1293,7 @@ static bool append_fanin_or_fail(
     fanin_slots[fanin_count++] = static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id));
 
     // Reclaim gate: record this task as a consumer of the producer. The producer
-    // slot retires once the per-ring completed_watermark reaches this consumer id.
+    // slot retires once the completed_watermark reaches this consumer id.
     const int32_t self_local = static_cast<int32_t>(simpler::hbg::task_local_id(self_task_id));
     if (self_local > prod_state->last_consumer_local_id) {
         prod_state->last_consumer_local_id = self_local;
@@ -1411,7 +1411,8 @@ static bool prepare_task(
     // it in append_fanin_or_fail. completion_flags for this slot were cleared
     // above (whole-graph-resident hbg never reuses a slot).
     out->slot_state->last_consumer_local_id = static_cast<int32_t>(simpler::hbg::task_local_id(out->task_id));
-    // payload.fanin_count is set in submit_task_common's STEP 6.
+    // payload.fanin_count is left untouched here: submit_task_common zeroes it before
+    // its fanin appends, which accumulate into it in place.
 
     return true;
 }
@@ -1426,14 +1427,14 @@ void OrchestratorState::begin_scope(ScopeMode mode) {
         return;
     }
     // A Graph replays as a flat DAG with no scope structure: scope boundaries only
-    // shape scheduling on the ring, and the shadow-record path submits no ring
-    // tasks. So a scope inside a Graph body must not touch the real scope stack.
-    // Its manual/auto mode still matters, though — the recorder infers a node's
-    // producers with the same compute_task_fanin the ring path uses, and that
-    // inference is suppressed inside a manual scope — so the depth is tracked on
+    // shape scheduling on the ordinary path, and the shadow-record path submits no
+    // ordinary tasks. So a scope inside a Graph body must not touch the real scope
+    // stack. Its manual/auto mode still matters, though — the recorder infers a
+    // node's producers with the same compute_task_fanin the ordinary path uses, and
+    // that inference is suppressed inside a manual scope — so the depth is tracked on
     // the recording instead.
     if (GraphRecording *recording = active_graph_recording(orch); recording != nullptr) {
-        // Reject what the ring rejects. An auto scope inside a manual one is a
+        // Reject what the ordinary path rejects. An auto scope inside a manual one is a
         // fatal below; accepting it here would let a Graph record and replay a
         // body that ordinary submission refuses. The push still happens so
         // end_scope stays balanced -- the recording is doomed either way, since
@@ -1659,7 +1660,8 @@ static TaskOutputTensors submit_task_common(
     // Dispatch predicate: resolve the (tensor, indices) to an absolute GM address
     // now so the scheduler can read it at the dispatch point with a single load,
     // no Arg/simpler::hbg::Tensor access. Both branches write predicate.op explicitly because
-    // payload slots are ring-reused; op == NONE means "always dispatch".
+    // a payload slot is raw shared memory with no constructor; op == NONE means
+    // "always dispatch".
     {
         const CoreTaskPredicate &pred = args.predicate();
         if (pred.op != PredicateOp::NONE && pred.operand.tensor != nullptr && pred.operand.tensor->buffer.addr != 0) {
@@ -2227,7 +2229,7 @@ TaskOutputTensors graph_record_submit_node(
         if (source.source == GraphRecordedTensorSource::INTERNAL) add_fanin(source.source_index);
     }
 
-    // Inferred hazards, on the same terms as the ring path. The loop above only
+    // Inferred hazards, on the same terms as the ordinary path. The loop above only
     // names the node that ALLOCATED each buffer; every write-then-read through a
     // buffer someone else allocated — an alloc_tensors output written in place
     // with add_inout, or a view of a boundary tensor — needs the last-writer

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -406,7 +406,6 @@ struct GraphBoundary {
 // recording rather than allocated per recording — see recorder_recording().
 struct GraphRecording {
     uint64_t full_key{0};
-    int32_t start_local_task_id{0};
     uint64_t next_virtual_offset{0};
     // The in-flight entry's boundary copy, bound at graph_prepare and valid until
     // graph_end/graph_abort. Not owned here: the submitting thread reads it for
@@ -497,7 +496,6 @@ enum class GraphRecordingStatus : uint8_t { RECORDING = 0, READY = 1, FAILED = 2
 // nothing here is sized by the graph.
 struct GraphInflightRecording {
     uint64_t full_key{0};
-    int32_t start_local_task_id{0};
     GraphBoundary boundary;
     // Atomic because graph_prepare reads it on the recording thread without
     // taking recording_mutex, by design: acquiring the mutex there lets a
@@ -681,6 +679,14 @@ constexpr int32_t GRAPH_RECORD_TENSORMAP_POOL_SIZE = 16384;
 constexpr size_t GRAPH_RECORD_NODE_TENSOR_POOL_ELEMS =
     static_cast<size_t>(GRAPH_MAX_NODES) * static_cast<size_t>(CORE_MAX_TENSOR_ARGS);
 
+// The outer local id a recorded node's GRAPH_NODE id carries. A recorded node
+// belongs to no outer task -- every shell replaying the Definition re-mints the id
+// with its own local id at materialize -- so record time names a node by its index
+// alone, and the id's low field is that index and nothing else. That is what keeps
+// the index inside the GRAPH_MAX_NODES task chains the recording's hazard map is
+// dimensioned for.
+constexpr uint32_t GRAPH_RECORD_OUTER_LOCAL_ID = 0;
+
 // Stand the recording's hazard map up on its own allocation. Failure is
 // reported to the caller, which abandons the recording rather than producing a
 // Definition with inferred edges missing.
@@ -783,7 +789,6 @@ bool graph_recording_reset(GraphRecording &recording, const GraphInflightRecordi
     }
     recording.tensor_map.reset();
     recording.full_key = entry.full_key;
-    recording.start_local_task_id = entry.start_local_task_id;
     recording.boundary = &entry.boundary;
     recording.next_virtual_offset = 0;
     recording.unsupported = false;
@@ -1238,9 +1243,10 @@ static bool append_fanin_or_fail(
     // Only a RING-space producer has an entry in the task table. A GRAPH_NODE id's
     // low bits are a packed (outer task, node index) pair, so using them as a table
     // index names an unrelated task — or, since get_slot_state_by_task_id does not
-    // bounds-check, no task at all. Nothing inside a Graph is reachable as a
-    // producer here — a recorded node hands out a RING id — so a foreign space is a
-    // caller error, not a case to tolerate.
+    // bounds-check, no task at all. A recorded node's id is GRAPH_NODE and the
+    // recorder resolves it against its own body, never here, so a foreign space
+    // reaching this point is an id that escaped its Graph — a caller error, not a
+    // case to tolerate.
     //
     // The table lookup lives here, after this check, rather than at the three call
     // sites: that keeps the id-space invariant in one place and makes it impossible
@@ -2042,12 +2048,12 @@ TaskOutputTensors graph_record_submit_node(
     GraphRecording &recording = *active_graph_recording(orch);
 
     const size_t node_index = recording.node_count;
-    // A recorded node's index equals its local task id minus the recording
-    // baseline, so its synthetic id keeps classification and explicit-dep
-    // arithmetic identical to the ordinary path.
-    const TaskId task_id = simpler::hbg::make_ring_task(
-        static_cast<uint32_t>(recording.start_local_task_id) + static_cast<uint32_t>(node_index)
-    );
+    // A recorded node lives in the GRAPH_NODE id space, so an id the body hands
+    // around says which of the two kinds of thing it names without any arithmetic:
+    // a GRAPH_NODE id is a node of this body, indexed by its low field; a RING id is
+    // a task submitted before the Graph, which no node may depend on.
+    const TaskId task_id =
+        simpler::hbg::make_graph_node(GRAPH_RECORD_OUTER_LOCAL_ID, static_cast<uint32_t>(node_index));
     result.set_task_id(task_id);
 
     if (node_index >= GRAPH_MAX_NODES || args.has_error) {
@@ -2241,7 +2247,10 @@ TaskOutputTensors graph_record_submit_node(
             args.explicit_deps_data(),
         };
         const bool manual_scope = recording.in_manual_scope();
-        if (!recording.storage_ready) {
+        if (!recording.storage_ready || node_index >= GRAPH_MAX_NODES) {
+            // An over-cap body is already abandoned, and its node ids have run past
+            // the index field make_graph_node packs them into, so registering one
+            // would key the map outside its task chains.
             recording.unsupported = true;
         } else if (recording.tensor_map.free_entries() < count_registrable_outputs(dep_inputs, manual_scope)) {
             // Recording one more node would assert inside new_entry(). Abandon the
@@ -2253,11 +2262,14 @@ TaskOutputTensors graph_record_submit_node(
             );
             recording.unsupported = true;
         } else {
-            auto emit_inferred = [&recording, &add_fanin, node_index](TaskId producer) -> bool {
-                const int32_t producer_index =
-                    static_cast<int32_t>(simpler::hbg::task_local_id(producer)) - recording.start_local_task_id;
-                if (simpler::hbg::is_ring_task(producer) && producer_index >= 0 &&
-                    producer_index < static_cast<int32_t>(node_index)) {
+            auto emit_inferred = [&add_fanin, node_index](TaskId producer) -> bool {
+                // A RING producer is a task submitted before the Graph. The outer shell
+                // was submitted through the ordinary path against this same boundary, so
+                // its own fanin already orders the whole body behind that task and the
+                // Definition carries no edge of its own.
+                if (simpler::hbg::is_ring_task(producer)) return true;
+                const uint32_t producer_index = simpler::hbg::task_local_id(producer);
+                if (producer_index < static_cast<uint32_t>(node_index)) {
                     add_fanin(static_cast<size_t>(producer_index));
                 }
                 return true;
@@ -2268,13 +2280,14 @@ TaskOutputTensors graph_record_submit_node(
     }
     for (uint32_t i = 0; i < args.explicit_dep_count(); ++i) {
         const TaskId dep = args.explicit_dep(i);
-        const int32_t dep_index =
-            static_cast<int32_t>(simpler::hbg::task_local_id(dep)) - recording.start_local_task_id;
-        if (!dep.is_valid() || !simpler::hbg::is_ring_task(dep) || dep_index >= static_cast<int32_t>(node_index)) {
+        if (!dep.is_valid()) {
             recording.unsupported = true;
             continue;
         }
-        if (dep_index < 0) {
+        if (simpler::hbg::is_ring_task(dep)) {
+            // Only the outer shell can order the body behind a pre-Graph task, and it
+            // does so through its boundary args -- so a dep no boundary tensor carries
+            // has no edge in the Definition and the body cannot be recorded.
             const bool represented_by_boundary = std::any_of(
                 recording.boundary_tensors().begin(), recording.boundary_tensors().end(),
                 [dep](const simpler::hbg::Tensor &tensor) {
@@ -2282,9 +2295,16 @@ TaskOutputTensors graph_record_submit_node(
                 }
             );
             if (!represented_by_boundary) recording.unsupported = true;
-        } else {
-            add_fanin(static_cast<size_t>(dep_index));
+            continue;
         }
+        const uint32_t dep_index = simpler::hbg::task_local_id(dep);
+        if (dep_index >= static_cast<uint32_t>(node_index)) {
+            // A node of this body that is not yet recorded: the Definition's edges are
+            // acyclic by construction, so a forward reference cannot be expressed.
+            recording.unsupported = true;
+            continue;
+        }
+        add_fanin(static_cast<size_t>(dep_index));
     }
 
     node.fanin_count = static_cast<uint32_t>(recording.internal_fanins.size() - node.fanin_offset);
@@ -2400,7 +2420,6 @@ OrchestratorState::graph_begin_inner(uint64_t graph_key, const GraphTaskArgs &ar
     // up here would sit on the submitting thread, between two outer shells.
     auto entry = std::make_unique<GraphInflightRecording>();
     entry->full_key = full_key;
-    entry->start_local_task_id = orch->task_allocator.active_count();
     entry->boundary.scalar_count = args.scalar_count();
     entry->boundary.tensors.reserve(static_cast<size_t>(args.tensor_count()));
     entry->boundary.types.reserve(static_cast<size_t>(args.tensor_count()));

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/orchestrator.cpp
@@ -1194,7 +1194,9 @@ GraphHostDefinitionList graph_host_definitions(GraphHostState &state) {
     return list;
 }
 
-static uint32_t next_fanin_seen_epoch(OrchestratorState *orch) {
+// Advances the epoch fanin_mark_seen keys against, so a mark left by an earlier task
+// never reads as a repeat. The table is cleared only on wraparound.
+static void next_fanin_seen_epoch(OrchestratorState *orch) {
     uint32_t next = orch->fanin_seen_current_epoch + 1;
     if (next == 0) {
         memset(
@@ -1203,52 +1205,36 @@ static uint32_t next_fanin_seen_epoch(OrchestratorState *orch) {
         next = 1;
     }
     orch->fanin_seen_current_epoch = next;
-    return next;
 }
 
-// Polling: fanin is a flat array of position-independent producer local ids on
-// the payload (no dep-pool spill, no producer pointers). The builder writes them
-// directly into the payload's fanin region as producers are appended, deduping by
-// slot and hard-capping at CHIP_MAX_FANIN. self_local is this task's own local id
-// (the consumer), used to bump each producer's last_consumer_local_id (the
-// reclaim gate the host wait_for_consumers polls via completed_watermark).
-struct FaninBuilder {
-    FaninBuilder(OrchestratorState *orch, TaskPayload *payload, int32_t self_local, uint32_t seen_epoch) :
-        count(0),
-        orch(orch),
-        seen_epoch(seen_epoch),
-        self_local(self_local),
-        payload(payload),
-        slots(payload->fanin_data()) {}
-    int32_t count{0};
-    OrchestratorState *orch{nullptr};
-    uint32_t seen_epoch{0};
-    int32_t self_local{0};
-    TaskPayload *payload{nullptr};
-    // The payload's fanin region, resolved once: the appends below would otherwise
-    // re-resolve the delta per producer. Requires the regions bound before construction.
-    int32_t *slots{nullptr};
-
-    bool mark_seen(TaskId producer_task_id) {
-        // Dedup only. A negative local id cannot index the epoch table, so it is
-        // reported as not-yet-seen and the caller appends it rather than rejecting
-        // it; append_fanin_or_fail has already established that the producer is a
-        // ring task whose local id is a valid table entry.
-        const int32_t prod_local = static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id));
-        if (prod_local < 0) {
-            return false;
-        }
-        uint32_t *seen = orch->fanin_seen_epoch.get();
-        uint32_t slot = static_cast<uint32_t>(prod_local);
-        if (seen[slot] == seen_epoch) {
-            return true;
-        }
-        seen[slot] = seen_epoch;
+// True when this producer was already appended under the current epoch. A negative
+// local id cannot index the epoch table, so it is reported as not-yet-seen and the
+// caller appends it rather than rejecting it; append_fanin_or_fail has already
+// established that the producer is a ring task whose local id is a valid table
+// entry.
+static bool fanin_mark_seen(OrchestratorState &orch, TaskId producer_task_id) {
+    const int32_t prod_local = static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id));
+    if (prod_local < 0) {
         return false;
     }
-};
+    uint32_t *seen = orch.fanin_seen_epoch.get();
+    uint32_t slot = static_cast<uint32_t>(prod_local);
+    if (seen[slot] == orch.fanin_seen_current_epoch) {
+        return true;
+    }
+    seen[slot] = orch.fanin_seen_current_epoch;
+    return false;
+}
 
-static bool append_fanin_or_fail(OrchestratorState *orch, TaskId producer_task_id, FaninBuilder *fanin_builder) {
+// Polling: fanin is a flat array of position-independent producer local ids in the
+// payload's own fanin region (no dep-pool spill, no producer pointers), deduped
+// against the current fanin_seen epoch and hard-capped at CHIP_MAX_FANIN.
+// fanin_slots and fanin_count are that region and payload.fanin_count itself: the
+// region is named by a SelfRelativePtr delta, so the caller resolves it once, and
+// the count accumulates in place instead of being copied back at the end.
+static bool append_fanin_or_fail(
+    OrchestratorState &orch, TaskId producer_task_id, TaskId self_task_id, int32_t *fanin_slots, int32_t &fanin_count
+) {
     // Only a RING-space producer has an entry in the task table. A GRAPH_NODE id's
     // low bits are a packed (outer task, node index) pair, so using them as a table
     // index names an unrelated task — or, since get_slot_state_by_task_id does not
@@ -1260,7 +1246,7 @@ static bool append_fanin_or_fail(OrchestratorState *orch, TaskId producer_task_i
     // sites: that keeps the id-space invariant in one place and makes it impossible
     // for a caller to form the out-of-bounds slot reference before reaching it.
     if (!simpler::hbg::is_ring_task(producer_task_id)) {
-        orch->report_fatal(
+        orch.report_fatal(
             SIMPLER_ERROR_INVALID_ARGS, __FUNCTION__,
             "producer task %#llx is in id space %u, not RING; host_build_graph resolves every fanin edge against its "
             "one task table",
@@ -1269,7 +1255,7 @@ static bool append_fanin_or_fail(OrchestratorState *orch, TaskId producer_task_i
         );
         return false;
     }
-    ChipTaskSlotState *prod_state = &orch->sm_header->tasks.get_slot_state_by_task_id(
+    ChipTaskSlotState *prod_state = &orch.sm_header->tasks.get_slot_state_by_task_id(
         static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id))
     );
     // Skip a stale/reused producer slot: the cached owner id no longer resolves
@@ -1281,29 +1267,30 @@ static bool append_fanin_or_fail(OrchestratorState *orch, TaskId producer_task_i
         return true;
     }
     // Dedup by producer local id, which is also its task-table slot.
-    if (fanin_builder->mark_seen(producer_task_id)) {
+    if (fanin_mark_seen(orch, producer_task_id)) {
         return true;
     }
-    if (fanin_builder->count >= CHIP_MAX_FANIN) {
+    if (fanin_count >= CHIP_MAX_FANIN) {
         LOG_ERROR("========================================");
         LOG_ERROR("FATAL: Fanin Capacity Exhausted!");
         LOG_ERROR("========================================");
         LOG_ERROR("HBG stores every producer dependency in the consumer task's fanin region.");
-        LOG_ERROR("  Fanin:     used=%d/%d", fanin_builder->count, CHIP_MAX_FANIN);
-        LOG_ERROR("  Requested: at least %d distinct producer dependencies", fanin_builder->count + 1);
+        LOG_ERROR("  Fanin:     used=%d/%d", fanin_count, CHIP_MAX_FANIN);
+        LOG_ERROR("  Requested: at least %d distinct producer dependencies", fanin_count + 1);
         LOG_ERROR("Solution:");
         LOG_ERROR("  Reduce the task fanin to at most CHIP_MAX_FANIN=%d.", CHIP_MAX_FANIN);
         LOG_ERROR("  HBG has no dependency spill pool; runtime_env.ring_dep_pool does not apply.");
         LOG_ERROR("========================================");
-        orch_mark_fatal(orch, SIMPLER_ERROR_FANIN_CAPACITY_EXCEEDED);
+        orch_mark_fatal(&orch, SIMPLER_ERROR_FANIN_CAPACITY_EXCEEDED);
         return false;
     }
-    fanin_builder->slots[fanin_builder->count++] = static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id));
+    fanin_slots[fanin_count++] = static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id));
 
     // Reclaim gate: record this task as a consumer of the producer. The producer
     // slot retires once the per-ring completed_watermark reaches this consumer id.
-    if (fanin_builder->self_local > prod_state->last_consumer_local_id) {
-        prod_state->last_consumer_local_id = fanin_builder->self_local;
+    const int32_t self_local = static_cast<int32_t>(simpler::hbg::task_local_id(self_task_id));
+    if (self_local > prod_state->last_consumer_local_id) {
+        prod_state->last_consumer_local_id = self_local;
     }
     return true;
 }
@@ -1572,9 +1559,13 @@ static TaskOutputTensors submit_task_common(
         );
     }
 
-    FaninBuilder fanin_builder(
-        orch, &payload, static_cast<int32_t>(simpler::hbg::task_local_id(task_id)), next_fanin_seen_epoch(orch)
-    );
+    // The region delta is resolved once here, after prepare_task bound the regions.
+    // Zeroing the count gives the appends their starting point, and is this
+    // device-read field's only write on the submit path — hbg never zero-fills the
+    // task table.
+    next_fanin_seen_epoch(orch);
+    int32_t *fanin_slots = payload.fanin_data();
+    payload.fanin_count = 0;
 
     CYCLE_COUNT_LAP(g_orch_alloc_cycle);
 
@@ -1596,7 +1587,7 @@ static TaskOutputTensors submit_task_common(
         if (capture_dep_graph) {
             dep_gen_host_graph_add_explicit_edge(dep_task_id.raw);
         }
-        if (!append_fanin_or_fail(orch, dep_task_id, &fanin_builder)) {
+        if (!append_fanin_or_fail(*orch, dep_task_id, task_id, fanin_slots, payload.fanin_count)) {
             return result;
         }
     }
@@ -1608,7 +1599,7 @@ static TaskOutputTensors submit_task_common(
     };
 
     auto runtime_emit = [&](TaskId producer_task_id) -> bool {
-        return append_fanin_or_fail(orch, producer_task_id, &fanin_builder);
+        return append_fanin_or_fail(*orch, producer_task_id, task_id, fanin_slots, payload.fanin_count);
     };
 
     // The capture branch instantiates compute_task_fanin with a live Annotate;
@@ -1653,9 +1644,10 @@ static TaskOutputTensors submit_task_common(
     task.packed_buffer_base = prepared.alloc_result.packed_base;
     task.packed_buffer_end = prepared.alloc_result.packed_end;
 
-    // append_fanin_or_fail wrote each producer's local id straight into
-    // the payload's fanin region and bumped its last_consumer_local_id; the count is
-    // published in STEP 6 below. payload.init does not touch the fanin region.
+    // append_fanin_or_fail wrote every producer's local id into the payload's fanin
+    // region, counted them in payload.fanin_count, and bumped each producer's
+    // last_consumer_local_id. payload.init writes tensor_count/scalar_count only and
+    // must not touch either, or it would discard that.
     payload.init(args, result, prepared.alloc_result, layout);
 
     // Dispatch predicate: resolve the (tensor, indices) to an absolute GM address
@@ -1678,10 +1670,10 @@ static TaskOutputTensors submit_task_common(
     }
     CYCLE_COUNT_LAP(g_orch_args_cycle);
 
-    // === STEP 6: publish the inline fanin count (device boot classifies) ===
-    // Polling + host-orch: append_fanin_or_fail already wrote each producer's
-    // local id into the payload's fanin region and bumped its last_consumer_local_id.
-    // All that remains is to record how many. There is NO fanout adjacency, NO
+    // === STEP 6: close the fanin region (device boot classifies) ===
+    // Polling + host-orch: append_fanin_or_fail already wrote each producer's local
+    // id into the payload's fanin region, counted them in payload.fanin_count, and
+    // bumped each producer's last_consumer_local_id. There is NO fanout adjacency, NO
     // dep_pool, and NO ready routing here — the initial device boot scan classifies
     // each task once. A -1 result from classify_fanin_state routes the task through
     // push_ready_routed; otherwise the returned index selects the producer passed
@@ -1690,12 +1682,11 @@ static TaskOutputTensors submit_task_common(
     // The initial scan happens before the scheduler dispatch loop starts. Fanin is
     // a flat array of position-independent integers, so it crosses to the device
     // unchanged.
-    payload.fanin_count = fanin_builder.count;
     // The region's length is settled, so the cursor closes it at the real count. The
     // equality holds only while nothing between the bind and here bound another fanin
     // region, which is what makes the deferred advance safe.
     debug_assert(orch->fanin_pool_cursor == static_cast<int32_t>(payload.fanin_data() - orch->fanin_pool));
-    orch->fanin_pool_cursor += CHIP_ALIGN_UP(fanin_builder.count, ARG_POOL_ALIGN / (int32_t)sizeof(int32_t));
+    orch->fanin_pool_cursor += CHIP_ALIGN_UP(payload.fanin_count, ARG_POOL_ALIGN / (int32_t)sizeof(int32_t));
 
     (void)sched;
 
@@ -1929,11 +1920,12 @@ bool graph_submit_outer(
         );
     }
 
-    FaninBuilder fanin_builder(
-        orch, &payload, static_cast<int32_t>(simpler::hbg::task_local_id(task_id)), next_fanin_seen_epoch(orch)
-    );
+    // graph_reset_outer_payload above zeroed the count; the region delta is resolved
+    // once here.
+    next_fanin_seen_epoch(orch);
+    int32_t *fanin_slots = payload.fanin_data();
     auto emit = [&](TaskId producer_id) -> bool {
-        return append_fanin_or_fail(orch, producer_id, &fanin_builder);
+        return append_fanin_or_fail(*orch, producer_id, task_id, fanin_slots, payload.fanin_count);
     };
     // An outer GRAPH task is an ordinary task, so the dependency graph
     // has to carry it: without this the whole Graph — and every edge into it —
@@ -1962,12 +1954,11 @@ bool graph_submit_outer(
         return false;
     }
     register_task_outputs(boundary_inputs, task_id, orch->tensor_map, orch->in_manual_scope());
-    payload.fanin_count = fanin_builder.count;
     // The region's length is settled, so the cursor closes it at the real count. The
     // equality holds only while nothing between the bind and here bound another fanin
     // region, which is what makes the deferred advance safe.
     debug_assert(orch->fanin_pool_cursor == static_cast<int32_t>(payload.fanin_data() - orch->fanin_pool));
-    orch->fanin_pool_cursor += CHIP_ALIGN_UP(fanin_builder.count, ARG_POOL_ALIGN / (int32_t)sizeof(int32_t));
+    orch->fanin_pool_cursor += CHIP_ALIGN_UP(payload.fanin_count, ARG_POOL_ALIGN / (int32_t)sizeof(int32_t));
 
     pending.outer_slot = &slot;
     state->pending_uploads.push_back(pending);

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
@@ -243,7 +243,7 @@ static bool wait_for_tensor_ready(
         int32_t local_id = simpler::hbg::task_local_id(slot.task->task_id);
         uint64_t t0 = get_sys_cnt_aicpu();
         int32_t spin_count = 0;
-        // Polling: all consumers of this producer have retired once the per-ring
+        // Polling: all consumers of this producer have retired once the
         // completed_watermark reaches the producer's highest consumer id (set at
         // submit in append_fanin_or_fail). Replaces the fanout_refcount ==
         // fanout_count wiring check, which polling removes.

--- a/src/a5/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/orchestrator_core/runtime_core.cpp
@@ -186,11 +186,11 @@ static bool wait_for_tensor_ready(
     // Callers branch on the returned pointer, not on `failed`: the slot is
     // dereferenced immediately and a null return is the only safe signal.
     auto resolve_producer = [&](TaskId producer) -> const ChipTaskSlotState * {
-        if (!producer.is_valid() || !simpler::hbg::is_ring_task(producer)) {
+        if (!producer.is_valid() || !simpler::hbg::is_global_task(producer)) {
             orch.report_fatal(
                 SIMPLER_ERROR_INVALID_ARGS, caller,
-                "tensor producer task %#llx is in id space %u, not RING; host_build_graph resolves a producer against "
-                "its one task table",
+                "tensor producer task %#llx is in id space %u, not GLOBAL; host_build_graph resolves a producer "
+                "against its one task table",
                 static_cast<unsigned long long>(producer.raw),
                 static_cast<unsigned int>(simpler::hbg::task_id_space(producer))
             );

--- a/src/a5/runtime/host_build_graph/runtime/runtime_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime_types.h
@@ -188,7 +188,7 @@ constexpr uint64_t TENSOR_DATA_TIMEOUT_MS = 15000;  // 15 s
  *                         hidden alloc completed inline by the orchestrator
  *
  * COMPLETED is terminal: no slot is recycled before the run ends, so nothing
- * advances a task past it. Consumer retirement is observed through the per-ring
+ * advances a task past it. Consumer retirement is observed through the
  * completed_watermark instead.
  */
 typedef enum {
@@ -236,7 +236,7 @@ struct ChipTaskSlotState;  // Forward declaration (defined below)
 /**
  * Task descriptor structure (shared memory)
  *
- * Stored in the TaskDescriptor ring buffer in shared memory.
+ * Stored in the TaskDescriptor table in shared memory.
  * Contains static identification and buffer pointers only.
  * Dynamic scheduling state (fanin/fanout/task_state) is in ChipTaskSlotState.
  *
@@ -268,8 +268,8 @@ static_assert(offsetof(TaskDescriptor, packed_buffer_base) == 24, "packed_buffer
  * Task payload data (cold path - only accessed during orchestration and dispatch)
  *
  * Layout: metadata + inline fanin packed in the first 9 cache lines, followed
- * by bulk tensor and scalar data. Small fanins stay fully inline; larger
- * fanins spill into a per-ring ring buffer slice.
+ * by bulk tensor and scalar data. Fanin is always inline: it is hard-capped at
+ * CHIP_MAX_FANIN and there is no spill pool.
  */
 // Early-dispatch claim states for TaskPayload::early_dispatch_state.
 enum EarlyDispatchState : uint8_t {
@@ -317,9 +317,9 @@ struct TaskPayload {
     // the mirror when the slot is claimed, and against the image in
     // compact_live_image, which re-pitches the segments.
     //
-    // fanin holds flat position-independent producer local task ids. Single-ring
-    // hbg: every producer is ring 0, so no per-edge ring id is stored. Scanned by
-    // classify_fanin_state against the ring completion_flags. Hard-capped at
+    // fanin holds flat position-independent producer local task ids. A producer is
+    // named by its local id alone, so no per-edge indirection is stored. Scanned by
+    // classify_fanin_state against the shared-memory completion_flags. Hard-capped at
     // CHIP_MAX_FANIN (no dep-pool spill). Unbound on a Graph node, whose
     // dependencies live in the Definition's fanin CSR instead.
     simpler::hbg::SelfRelativePtr<simpler::hbg::Tensor> tensors;
@@ -470,8 +470,8 @@ struct TaskPayload {
         // zero additional cost.
         memcpy(scalar_data(), args.scalars(), CHIP_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
 
-        // The ring's payload storage is reused raw memory that no constructor runs
-        // over, so an unset predicate reads back as whatever the slot last held —
+        // The task table's payload storage is raw shared memory that no constructor
+        // runs over, so an unset predicate reads back as whatever the slot last held —
         // and compact_live_image translates predicate.addr as a graph-heap address
         // for every submitted slot. An ordinary task overwrites this right
         // after init(); a hidden-alloc task has nothing following it, so this is
@@ -542,7 +542,7 @@ static_assert(sizeof(simpler::hbg::Tensor) == 128, "simpler::hbg::Tensor must be
  * Per-task slot scheduling state (scheduler-private, NOT in shared memory)
  *
  * 64 bytes = one cache line. Under the polling completion model a task's
- * readiness is derived from its producers' completion_flags (in the ring
+ * readiness is derived from its producers' completion_flags (in the SM
  * header); producer completion is published by setting this task's own
  * completion_flag + draining its wake list. There is no fanout adjacency,
  * refcount, or per-task lock here.
@@ -554,7 +554,7 @@ static_assert(sizeof(simpler::hbg::Tensor) == 128, "simpler::hbg::Tensor must be
  */
 struct alignas(64) ChipTaskSlotState {
     // Highest local task id among this slot's consumers. Reclaim gate: the slot
-    // is safe to retire once the per-ring completed_watermark reaches this id.
+    // is safe to retire once the completed_watermark reaches this id.
     // Whole-graph-resident hbg never reclaims at runtime, so this is
     // inert-but-scaffolded for parity. Seeded to own local_id in prepare_task;
     // bumped via max() at submit for each consumer.

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -571,8 +571,8 @@ struct SchedulerState {
 
     // ---- Polling completion primitives ---------------------------------------
     // Readiness: a task is ready iff every producer named in its inline fanin has
-    // set its completion_flags byte. Single-ring: all producers are ring 0, so
-    // there is no per-edge ring indirection.
+    // set its completion_flags byte. A producer is named by its local id alone, so
+    // there is no per-edge indirection.
 
     // Unmet-fanin classification. Returns -1 (all fanins met -> route to ready)
     // or the index of an unmet fanin (register on that producer's wake list).
@@ -1154,14 +1154,14 @@ struct SchedulerState {
 
     // on_task_release is gone under polling. It existed to bump each producer's
     // fanout_refcount so the host wait_for_consumers could observe consumer
-    // retirement; that signal is now the per-ring completed_watermark advanced by
+    // retirement; that signal is now the completed_watermark advanced by
     // on_mixed_task_complete. There is likewise no self CONSUMED flip (host-orch
     // never reclaimed slots on device).
 
     // === Cold-path API (defined in scheduler.cpp) ===
 
-    // Phase 1: declare every sub-region (ready_queue slots, dummy queue slots,
-    // per-ring dep_pool entries) on the supplied arena.
+    // Phase 1: declare every sub-region (ready_queue slots, dummy queue slots) on
+    // the supplied arena.
     // Capacities are baked into the returned layout; init_data_from_layout uses
     // the same values.
     static SchedulerLayout reserve_layout(DeviceArena &arena);
@@ -1175,8 +1175,8 @@ struct SchedulerState {
     bool init_data_from_layout(const SchedulerLayout &layout, DeviceArena &arena, void *sm_dev_base);
 
     // Phase 3b: write the arena-internal pointer fields
-    // (ready_queues[].slots, dummy_ready_queue.slots, dep_pool.base for each
-    // ring). Called on both host and device sides.
+    // (ready_queues[].slots, dummy_ready_queue.slots). Called on both host and
+    // device sides.
     void wire_arena_pointers(const SchedulerLayout &layout, DeviceArena &arena);
 
     // Phase 3c, device only: bring every queue's slots[] to its empty ramp. The

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -129,7 +129,7 @@ LoopAction SchedulerContext::check_idle_fatal_error(int32_t thread_idx, SharedMe
 //
 // Categories (and which thread emits them):
 //   SUMMARY  — completed / total counts and scan totals               (thread 0 only)
-//   TASK     — one per non-completed task scanned from shared rings   (thread 0 only)
+//   TASK     — one per non-completed task in the shared table          (thread 0 only)
 //              - state=RUNNING: includes running_on=[...] cross-ref
 //              - state=READY:   fanin satisfied but no idle core yet
 //              - state=WAIT:    includes missing_deps=N

--- a/src/a5/runtime/host_build_graph/runtime/tensormap.h
+++ b/src/a5/runtime/host_build_graph/runtime/tensormap.h
@@ -567,6 +567,10 @@ struct ChipTensorMap {
         uint32_t bucket_index = hash(addr);
         auto local_id = simpler::hbg::task_local_id(producer_task_id);
         const int32_t task_slot = local_id;
+        // A producer's low id field is a task chain index directly, so the id space a
+        // caller inserts under has to be the one this map was dimensioned for: a
+        // whole-run map takes task capacity, a Graph recording's takes GRAPH_MAX_NODES.
+        debug_assert(task_slot >= 0 && task_slot < max_tasks);
 
         entry->producer_task_id = producer_task_id;
 
@@ -605,6 +609,7 @@ struct ChipTensorMap {
             // Entry is the head of its task chain, update task_entry_heads
             int32_t local_id = static_cast<int32_t>(simpler::hbg::task_local_id(entry.producer_task_id));
             const int32_t task_slot = local_id;
+            debug_assert(task_slot >= 0 && task_slot < max_tasks);
             task_entry_heads[task_slot] = entry.next_in_task;
         } else {
             entry.prev_in_task->next_in_task = entry.next_in_task;

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -6,7 +6,7 @@ MIX, or SPMD task, but contains a recorded task DAG.
 
 Every invocation places exactly one `GRAPH` task in the host task window. On a
 first miss, the caller immediately submits an outer task shell keyed by Graph
-identity while a recording thread records the DAG off the ring. Internal
+identity while a recording thread records the DAG off the ordinary submit path. Internal
 submissions build host-only node metadata and assign output addresses from a
 private bit-63 virtual range instead of consuming task-window slots or heap.
 Later calls for the same in-flight identity submit more shells without waiting
@@ -16,7 +16,7 @@ every recording and fills each shell's heap range and Definition content hash.
 Cached invocations submit the same one `GRAPH` task directly — a cache hit never
 waits on a recording. In both cases the device Scheduler expands the saved
 topology and dispatches the internal nodes; the Host Orchestrator never submits
-those nodes as ring tasks.
+those nodes as tasks of the run itself.
 
 Boundary contracts are checked before an in-flight shell is accepted. Once a
 shell has entered the task/dependency sequence, an unsupported construct found
@@ -368,7 +368,7 @@ outer payload as a kernel payload; device localization reads the compact values
 directly, so boundary metadata does not need to expand to full `ChipTensor`
 records on either side of H2D.
 
-Internal nodes consume no ring task-window slots. Their descriptor, payload, slot
+Internal nodes consume no task-table slots. Their descriptor, payload, slot
 state, and argument pools live in the tail of the outer `GRAPH` task's own heap block,
 past `required_heap`: `[GraphExecution][GraphNodeStorage...][tensor pool][scalar pool]`. One
 `TaskAllocator::alloc` covers both the packed outputs and this execution storage,
@@ -434,7 +434,7 @@ dependency wiring remains an Orchestrator responsibility:
 - materialization registers each non-root on one producer selected from its
   saved fanin CSR;
 - a node's release/acquire `task_state` is its Graph-local completion flag, so
-  internal nodes need neither ring completion flags nor task-window slots;
+  internal nodes need neither shared-memory completion flags nor task-table slots;
 - producer completion closes and drains only its current wake-list rather than
   traversing the saved fanout CSR;
 - a woken consumer scans its saved fanin CSR and either enters its shape queue
@@ -457,8 +457,8 @@ outer GRAPH
   -> final internal completion completes the outer GRAPH
 ```
 
-Internal nodes count as zero outer ring tasks. The final node completes
-the one outer Graph task, publishes the outer ring completion flag, wakes
+Internal nodes count as zero tasks of the run itself. The final node completes
+the one outer Graph task, publishes that task's completion flag, wakes
 external consumers, and contributes one to the host-visible completion count.
 
 Localization or materialization failure is fail-fast: the Scheduler latches an

--- a/src/common/host_build_graph/graph_execution.cpp
+++ b/src/common/host_build_graph/graph_execution.cpp
@@ -402,7 +402,7 @@ GraphMaterializeResult graph_execution_materialize_slice(
         TaskPayload &payload = storage->payload;
         ChipTaskSlotState &slot = storage->slot;
 
-        task.task_id = simpler::hbg::make_graph_node(
+        task.task_id = simpler::hbg::make_in_graph_task(
             simpler::hbg::task_local_id(outer_slot.task->task_id), static_cast<uint32_t>(i)
         );
         const GraphNodeDefinition &source = nodes[i];

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -24,8 +24,8 @@
 
 inline constexpr uint32_t GRAPH_MAX_NODES = 1024;
 static_assert(
-    GRAPH_MAX_NODES <= (1u << simpler::hbg::GRAPH_NODE_INDEX_BITS),
-    "a node index must fit the low field of a GRAPH_NODE task id"
+    GRAPH_MAX_NODES <= (1u << simpler::hbg::IN_GRAPH_TASK_INDEX_BITS),
+    "a node index must fit the low field of an IN_GRAPH task id"
 );
 inline constexpr int32_t GRAPH_MATERIALIZE_SLICE_NODES = 4;
 

--- a/src/common/host_build_graph/self_relative_ptr.h
+++ b/src/common/host_build_graph/self_relative_ptr.h
@@ -20,7 +20,7 @@
  *
  * The block is `memcpy`'d to the device as one image, so a delta between two
  * addresses inside it is invariant under the move while a raw pointer is not.
- * Every user has to satisfy that precondition: a ring task's payload and
+ * Every user has to satisfy that precondition: a GLOBAL task's payload and
  * descriptor live in the same shared-memory image as its slot state, and a Graph
  * node's live in the same GraphNodeStorage.
  *

--- a/src/common/host_build_graph/task_id_encoding.h
+++ b/src/common/host_build_graph/task_id_encoding.h
@@ -25,47 +25,52 @@ namespace simpler::hbg {
 /**
  * Which id space a task id belongs to, held in the high 32 bits.
  *
- * This runtime has exactly one ring, so the high bits name the *storage* an id
- * resolves against rather than a ring index:
+ * Everything this runtime schedules is a task. The high bits say whether a task
+ * belongs to a Graph task or stands on its own, which is also what decides where
+ * its id resolves:
  *
- *   RING       — a task placed on the shared-memory ring. Its low bits are the
- *                task allocator's local id, resolvable via get_slot_by_task_id().
- *   GRAPH_NODE — a node of a Graph body. It lives in that Graph's own storage,
- *                not on the ring, so its low bits are the packed pair below and
- *                must never be resolved against a ring slot.
+ *   GLOBAL   — a task of the run itself, holding a slot in the shared-memory task
+ *              table. Its low bits are the task allocator's local id, resolvable
+ *              via get_slot_by_task_id().
+ *   IN_GRAPH — a task belonging to one Graph task's body. It lives in that Graph's
+ *              own storage, not in the task table, so its low bits are the packed
+ *              pair below and must never be resolved against a table slot.
  *
- * A GRAPH_NODE id is minted twice for the same node, in two disjoint scopes. The
- * recorder mints one per node it records, with `outer_local_id` fixed at 0: a
+ * An IN_GRAPH id is minted twice for the same task, in two disjoint scopes. The
+ * recorder mints one per task it records, with `graph_local_id` fixed at 0: a
  * Definition is shared by every shell that replays it, so record time has no
- * single outer task to name, and the low field is then the node index alone —
+ * single Graph task to name, and the low field is then the task index alone —
  * which is what keeps it inside the task chains the recording's hazard map is
  * dimensioned for. Materialize mints the other, with the replaying shell's real
  * local id. The two never meet: a recorded id lives only in the recorder thread's
- * private map and the body's own locals, and a materialized node is addressed by
+ * private map and the body's own locals, and a materialized task is addressed by
  * index rather than looked up by id.
  */
-enum class TaskIdSpace : uint32_t { RING = 0, GRAPH_NODE = 1 };
+enum class TaskIdSpace : uint32_t { GLOBAL = 0, IN_GRAPH = 1 };
 
-// A graph node's low bits pack its outer GRAPH task's local id above its index
-// within that graph. graph_execution.h asserts GRAPH_MAX_NODES fits the index.
-inline constexpr uint32_t GRAPH_NODE_INDEX_BITS = 10;
+// An in-graph task's low bits pack its Graph task's local id above its index
+// within that Graph. graph_execution.h asserts GRAPH_MAX_NODES fits the index.
+inline constexpr uint32_t IN_GRAPH_TASK_INDEX_BITS = 10;
 
-constexpr TaskId make_ring_task(uint32_t local_id) {
-    return TaskId{(static_cast<uint64_t>(TaskIdSpace::RING) << 32) | static_cast<uint64_t>(local_id)};
+constexpr TaskId make_global_task(uint32_t local_id) {
+    return TaskId{(static_cast<uint64_t>(TaskIdSpace::GLOBAL) << 32) | static_cast<uint64_t>(local_id)};
 }
 
-constexpr TaskId make_graph_node(uint32_t outer_local_id, uint32_t node_index) {
-    const uint32_t packed = (outer_local_id << GRAPH_NODE_INDEX_BITS) | node_index;
-    return TaskId{(static_cast<uint64_t>(TaskIdSpace::GRAPH_NODE) << 32) | static_cast<uint64_t>(packed)};
+constexpr TaskId make_in_graph_task(uint32_t graph_local_id, uint32_t task_index) {
+    const uint32_t packed = (graph_local_id << IN_GRAPH_TASK_INDEX_BITS) | task_index;
+    return TaskId{(static_cast<uint64_t>(TaskIdSpace::IN_GRAPH) << 32) | static_cast<uint64_t>(packed)};
 }
 
 constexpr TaskIdSpace task_id_space(TaskId id) { return static_cast<TaskIdSpace>(static_cast<uint32_t>(id.raw >> 32)); }
 
-constexpr bool is_ring_task(TaskId id) { return task_id_space(id) == TaskIdSpace::RING; }
+// True exactly when this id names a slot in the shared-memory task table, which is
+// what every caller that is about to resolve one is really asking. An IN_GRAPH id
+// answers false and must not reach get_slot_by_task_id().
+constexpr bool is_global_task(TaskId id) { return task_id_space(id) == TaskIdSpace::GLOBAL; }
 
-// The low 32 bits. A ring local id for a RING task; the packed pair above for a
-// GRAPH_NODE, which is why callers that resolve a ring slot must gate on
-// is_ring_task() first.
+// The low 32 bits. A task-table local id for a GLOBAL task; the packed pair above
+// for an IN_GRAPH one, which is why callers that resolve a table slot must gate on
+// is_global_task() first.
 constexpr uint32_t task_local_id(TaskId id) { return static_cast<uint32_t>(id.raw & 0xFFFFFFFFu); }
 
 }  // namespace simpler::hbg

--- a/src/common/host_build_graph/task_id_encoding.h
+++ b/src/common/host_build_graph/task_id_encoding.h
@@ -30,10 +30,19 @@ namespace simpler::hbg {
  *
  *   RING       — a task placed on the shared-memory ring. Its low bits are the
  *                task allocator's local id, resolvable via get_slot_by_task_id().
- *   GRAPH_NODE — a node materialized inside a Graph execution. It lives in that
- *                execution's GraphNodeStorage, not on the ring, so its low bits
- *                are the packed pair below and must never be resolved against a
- *                ring slot.
+ *   GRAPH_NODE — a node of a Graph body. It lives in that Graph's own storage,
+ *                not on the ring, so its low bits are the packed pair below and
+ *                must never be resolved against a ring slot.
+ *
+ * A GRAPH_NODE id is minted twice for the same node, in two disjoint scopes. The
+ * recorder mints one per node it records, with `outer_local_id` fixed at 0: a
+ * Definition is shared by every shell that replays it, so record time has no
+ * single outer task to name, and the low field is then the node index alone —
+ * which is what keeps it inside the task chains the recording's hazard map is
+ * dimensioned for. Materialize mints the other, with the replaying shell's real
+ * local id. The two never meet: a recorded id lives only in the recorder thread's
+ * private map and the body's own locals, and a materialized node is addressed by
+ * index rather than looked up by id.
  */
 enum class TaskIdSpace : uint32_t { RING = 0, GRAPH_NODE = 1 };
 

--- a/src/common/platform/include/common/host_phase_kind.h
+++ b/src/common/platform/include/common/host_phase_kind.h
@@ -52,7 +52,7 @@ enum class HostPhaseKind : uint32_t {
     BindArenaH2d,
     BindHostViewClose,
     // Recorded by the host orchestrator (orchestrator_core/orchestrator.cpp).
-    OrchSubmitTask,       // submit_task_common: one ordinary ring task
+    OrchSubmitTask,       // submit_task_common: one ordinary task
     OrchAllocTensors,     // prepare_task: one alloc_tensors slot
     OrchRecordNode,       // graph_record_submit_node: one recorded Graph node
     OrchGraphSubmit,      // graph_submit_definition: one outer GRAPH task

--- a/tests/st/host_build_graph_validation/kernels/orchestration/validation_orch.cpp
+++ b/tests/st/host_build_graph_validation/kernels/orchestration/validation_orch.cpp
@@ -42,15 +42,15 @@ void submit_overflowing_mix_task() {
 
 simpler::hbg::Tensor tensor_with_unbound_owner(const simpler::hbg::Tensor &external) {
     simpler::hbg::Tensor forged = external;
-    forged.owner_task_id = simpler::hbg::make_ring_task(17);
+    forged.owner_task_id = simpler::hbg::make_global_task(17);
     return forged;
 }
 
-// A GRAPH_NODE id names storage inside a Graph execution, not a ring slot, so it
-// can never be a fanin producer. Declaring one as an explicit dependency is the
-// caller error append_fanin_or_fail rejects.
+// An IN_GRAPH id names storage inside one Graph task's body, not a task-table slot,
+// so it can never be a fanin producer. Declaring one as an explicit dependency is
+// the caller error append_fanin_or_fail rejects.
 void submit_task_depending_on_graph_node() {
-    const TaskId deps[1] = {simpler::hbg::make_graph_node(/*outer_local_id=*/1, /*node_index=*/0)};
+    const TaskId deps[1] = {simpler::hbg::make_in_graph_task(/*graph_local_id=*/1, /*task_index=*/0)};
     CoreTaskArgs args;
     args.launch_spec.set_block_num(1);
     args.set_dependencies(deps, 1);

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -932,6 +932,15 @@ target_sources(test_hbg_slot_claim PRIVATE
     ${HBG_RUNTIME_DIR}/shared/runtime.cpp
     ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
 )
+add_a2a3_hbg_runtime_test(test_hbg_graph_recording_bounds common/test_hbg_graph_recording_bounds.cpp)
+target_sources(test_hbg_graph_recording_bounds PRIVATE
+    ${HBG_RUNTIME_DIR}/orchestrator_core/orchestrator.cpp
+    ${HBG_RUNTIME_DIR}/shared/shared_memory.cpp
+    ${HBG_RUNTIME_DIR}/shared/tensormap.cpp
+    ${HBG_RUNTIME_DIR}/shared/runtime_init.cpp
+    ${HBG_RUNTIME_DIR}/shared/runtime.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+)
 add_a5_hbg_runtime_test(test_a5_hbg_graph_submit_failure common/test_hbg_graph_submit_failure.cpp)
 target_sources(test_a5_hbg_graph_submit_failure PRIVATE
     ${A5_HBG_RUNTIME_DIR}/orchestrator_core/orchestrator.cpp

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -941,6 +941,15 @@ target_sources(test_hbg_graph_recording_bounds PRIVATE
     ${HBG_RUNTIME_DIR}/shared/runtime.cpp
     ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
 )
+add_a5_hbg_runtime_test(test_a5_hbg_graph_recording_bounds common/test_hbg_graph_recording_bounds.cpp)
+target_sources(test_a5_hbg_graph_recording_bounds PRIVATE
+    ${A5_HBG_RUNTIME_DIR}/orchestrator_core/orchestrator.cpp
+    ${A5_HBG_RUNTIME_DIR}/shared/shared_memory.cpp
+    ${A5_HBG_RUNTIME_DIR}/shared/tensormap.cpp
+    ${A5_HBG_RUNTIME_DIR}/shared/runtime_init.cpp
+    ${A5_HBG_RUNTIME_DIR}/shared/runtime.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+)
 add_a5_hbg_runtime_test(test_a5_hbg_graph_submit_failure common/test_hbg_graph_submit_failure.cpp)
 target_sources(test_a5_hbg_graph_submit_failure PRIVATE
     ${A5_HBG_RUNTIME_DIR}/orchestrator_core/orchestrator.cpp

--- a/tests/ut/cpp/a2a3/test_hbg_tensormap.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_tensormap.cpp
@@ -108,10 +108,20 @@ TEST_F(HbgTensorMapTest, DistinctLocalIdsGetDistinctTaskChains) {
         std::find(producers.begin(), producers.end(), simpler::hbg::make_global_task(LAST_TASK)), producers.end()
     );
 
-    // Unlinking the head of one chain leaves the other chain's entry alone, which it
-    // could not if the two ids had folded onto one chain.
-    tmap.remove_entry(*result.entries[0].entry);
+    // Each producer's chain head is its own entry, and LAST_TASK reaches the last
+    // reserved chain rather than folding onto a lower one. Read the heads directly:
+    // an entry count cannot tell one chain per producer from one shared chain.
+    ASSERT_NE(tmap.task_entry_heads[0], nullptr);
+    ASSERT_NE(tmap.task_entry_heads[LAST_TASK], nullptr);
+    EXPECT_EQ(tmap.task_entry_heads[0]->producer_task_id, simpler::hbg::make_global_task(0));
+    EXPECT_EQ(tmap.task_entry_heads[LAST_TASK]->producer_task_id, simpler::hbg::make_global_task(LAST_TASK));
+
+    // Unlinking a chain's only entry empties that chain and leaves the other intact.
+    tmap.remove_entry(*tmap.task_entry_heads[LAST_TASK]);
     EXPECT_EQ(tmap.valid_count(), 1);
+    EXPECT_EQ(tmap.task_entry_heads[LAST_TASK], nullptr);
+    ASSERT_NE(tmap.task_entry_heads[0], nullptr);
+    EXPECT_EQ(tmap.task_entry_heads[0]->producer_task_id, simpler::hbg::make_global_task(0));
 }
 
 // Without an explicit semantic removal, direct inserts consume one pool entry

--- a/tests/ut/cpp/a2a3/test_hbg_tensormap.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_tensormap.cpp
@@ -70,9 +70,9 @@ protected:
 // inserts remain visible until dependency computation explicitly removes one.
 TEST_F(HbgTensorMapTest, EveryProducerOfARegionStaysVisible) {
     simpler::hbg::Tensor t = make_test_tensor(0x1000, 256);
-    tmap.insert(t, simpler::hbg::make_ring_task(0));
-    tmap.insert(t, simpler::hbg::make_ring_task(1));
-    tmap.insert(t, simpler::hbg::make_ring_task(2));
+    tmap.insert(t, simpler::hbg::make_global_task(0));
+    tmap.insert(t, simpler::hbg::make_global_task(1));
+    tmap.insert(t, simpler::hbg::make_global_task(2));
     EXPECT_EQ(tmap.valid_count(), 3);
 
     TestLookupResult result;
@@ -82,9 +82,9 @@ TEST_F(HbgTensorMapTest, EveryProducerOfARegionStaysVisible) {
     for (const auto &e : result.entries) {
         producers.push_back(e.entry->producer_task_id);
     }
-    EXPECT_NE(std::find(producers.begin(), producers.end(), simpler::hbg::make_ring_task(0)), producers.end());
-    EXPECT_NE(std::find(producers.begin(), producers.end(), simpler::hbg::make_ring_task(1)), producers.end());
-    EXPECT_NE(std::find(producers.begin(), producers.end(), simpler::hbg::make_ring_task(2)), producers.end());
+    EXPECT_NE(std::find(producers.begin(), producers.end(), simpler::hbg::make_global_task(0)), producers.end());
+    EXPECT_NE(std::find(producers.begin(), producers.end(), simpler::hbg::make_global_task(1)), producers.end());
+    EXPECT_NE(std::find(producers.begin(), producers.end(), simpler::hbg::make_global_task(2)), producers.end());
 }
 
 // A local id is its own task chain index -- nothing masks with the chain count -- so
@@ -92,8 +92,8 @@ TEST_F(HbgTensorMapTest, EveryProducerOfARegionStaysVisible) {
 // dimensioned for reaches its own chain rather than folding onto a lower one.
 TEST_F(HbgTensorMapTest, DistinctLocalIdsGetDistinctTaskChains) {
     simpler::hbg::Tensor t = make_test_tensor(0x1000, 256);
-    tmap.insert(t, simpler::hbg::make_ring_task(0));
-    tmap.insert(t, simpler::hbg::make_ring_task(LAST_TASK));
+    tmap.insert(t, simpler::hbg::make_global_task(0));
+    tmap.insert(t, simpler::hbg::make_global_task(LAST_TASK));
 
     EXPECT_EQ(tmap.valid_count(), 2);
     TestLookupResult result;
@@ -103,8 +103,10 @@ TEST_F(HbgTensorMapTest, DistinctLocalIdsGetDistinctTaskChains) {
     for (const auto &e : result.entries) {
         producers.push_back(e.entry->producer_task_id);
     }
-    EXPECT_NE(std::find(producers.begin(), producers.end(), simpler::hbg::make_ring_task(0)), producers.end());
-    EXPECT_NE(std::find(producers.begin(), producers.end(), simpler::hbg::make_ring_task(LAST_TASK)), producers.end());
+    EXPECT_NE(std::find(producers.begin(), producers.end(), simpler::hbg::make_global_task(0)), producers.end());
+    EXPECT_NE(
+        std::find(producers.begin(), producers.end(), simpler::hbg::make_global_task(LAST_TASK)), producers.end()
+    );
 
     // Unlinking the head of one chain leaves the other chain's entry alone, which it
     // could not if the two ids had folded onto one chain.
@@ -121,7 +123,7 @@ TEST_F(HbgTensorMapTest, PoolOccupancyOnlyGrows) {
     EXPECT_EQ(tmap.free_entries(), POOL_SIZE);
 
     for (int32_t i = 0; i < 8; i++) {
-        tmap.insert(make_test_tensor(0x1000 + 0x100 * i, 64), simpler::hbg::make_ring_task(i));
+        tmap.insert(make_test_tensor(0x1000 + 0x100 * i, 64), simpler::hbg::make_global_task(i));
         EXPECT_EQ(tmap.current_used(), i + 1);
         EXPECT_EQ(tmap.free_entries(), POOL_SIZE - (i + 1));
     }
@@ -134,9 +136,9 @@ TEST_F(HbgTensorMapTest, PoolOccupancyOnlyGrows) {
 TEST_F(HbgTensorMapTest, ResetLeavesTheMapAsFreshlyInitialized) {
     simpler::hbg::Tensor t = make_test_tensor(0x1000, 256);
     for (int32_t i = 0; i < 8; i++) {
-        tmap.insert(make_test_tensor(0x1000 + 0x100 * i, 64), simpler::hbg::make_ring_task(i));
+        tmap.insert(make_test_tensor(0x1000 + 0x100 * i, 64), simpler::hbg::make_global_task(i));
     }
-    tmap.insert(t, simpler::hbg::make_ring_task(9));
+    tmap.insert(t, simpler::hbg::make_global_task(9));
     ASSERT_EQ(tmap.current_used(), 9);
 
     tmap.reset();
@@ -151,12 +153,12 @@ TEST_F(HbgTensorMapTest, ResetLeavesTheMapAsFreshlyInitialized) {
 
     // And it is usable, not merely empty: the second body's producer is the only one a
     // lookup can reach.
-    tmap.insert(t, simpler::hbg::make_ring_task(3));
+    tmap.insert(t, simpler::hbg::make_global_task(3));
     EXPECT_EQ(tmap.current_used(), 1);
     TestLookupResult second_body;
     run_lookup(tmap, t, second_body);
     ASSERT_EQ(second_body.count, 1);
-    EXPECT_EQ(second_body.entries[0].entry->producer_task_id, simpler::hbg::make_ring_task(3));
+    EXPECT_EQ(second_body.entries[0].entry->producer_task_id, simpler::hbg::make_global_task(3));
 }
 
 // Reset is reachable any number of times, including on a map that was never inserted
@@ -170,11 +172,11 @@ TEST_F(HbgTensorMapTest, ResetIsIdempotentAndKeepsReservedSizes) {
 
     // The last reserved chain is still a working chain after two resets.
     simpler::hbg::Tensor t = make_test_tensor(0x2000, 128);
-    tmap.insert(t, simpler::hbg::make_ring_task(LAST_TASK));
+    tmap.insert(t, simpler::hbg::make_global_task(LAST_TASK));
     TestLookupResult result;
     run_lookup(tmap, t, result);
     ASSERT_EQ(result.count, 1);
-    EXPECT_EQ(result.entries[0].entry->producer_task_id, simpler::hbg::make_ring_task(LAST_TASK));
+    EXPECT_EQ(result.entries[0].entry->producer_task_id, simpler::hbg::make_global_task(LAST_TASK));
 }
 
 // Filling the pool drives free_entries() to zero. No device-completion watermark
@@ -182,7 +184,7 @@ TEST_F(HbgTensorMapTest, ResetIsIdempotentAndKeepsReservedSizes) {
 // waiting for asynchronous reclaim that HBG does not have.
 TEST_F(HbgTensorMapTest, ExhaustedPoolStaysExhausted) {
     for (int32_t i = 0; i < POOL_SIZE; i++) {
-        tmap.insert(make_test_tensor(0x10000 + 0x100 * i, 64), simpler::hbg::make_ring_task(i % MAX_TASKS));
+        tmap.insert(make_test_tensor(0x10000 + 0x100 * i, 64), simpler::hbg::make_global_task(i % MAX_TASKS));
     }
     EXPECT_EQ(tmap.current_used(), POOL_SIZE);
     EXPECT_EQ(tmap.free_entries(), 0);

--- a/tests/ut/cpp/a2a3/test_hbg_tensormap.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_tensormap.cpp
@@ -55,11 +55,15 @@ class HbgTensorMapTest : public ::testing::Test {
 protected:
     static constexpr int32_t NUM_BUCKETS = 16;
     static constexpr int32_t POOL_SIZE = 64;
-    static constexpr int32_t WINDOW_SIZE = 32;
+    // Task chains this map is dimensioned for. A local id is its own chain index
+    // here, so it is also the exclusive upper bound on a producer id these tests
+    // may insert under.
+    static constexpr int32_t MAX_TASKS = 64;
+    static constexpr int32_t LAST_TASK = MAX_TASKS - 1;
 
     ChipTensorMap tmap{};
 
-    void SetUp() override { ASSERT_TRUE(tmap.init(NUM_BUCKETS, POOL_SIZE, WINDOW_SIZE)); }
+    void SetUp() override { ASSERT_TRUE(tmap.init(NUM_BUCKETS, POOL_SIZE, MAX_TASKS)); }
 };
 
 // Completion progress alone cannot make an older producer disappear. Direct
@@ -83,13 +87,13 @@ TEST_F(HbgTensorMapTest, EveryProducerOfARegionStaysVisible) {
     EXPECT_NE(std::find(producers.begin(), producers.end(), simpler::hbg::make_ring_task(2)), producers.end());
 }
 
-// Two tasks whose local ids alias to the same task slot both keep their entries;
-// slot reuse is not retirement.
-TEST_F(HbgTensorMapTest, SlotAliasingTasksBothKeepTheirEntries) {
+// A local id is its own task chain index -- nothing masks with the chain count -- so
+// two distinct producers never share a chain, and the highest id the map is
+// dimensioned for reaches its own chain rather than folding onto a lower one.
+TEST_F(HbgTensorMapTest, DistinctLocalIdsGetDistinctTaskChains) {
     simpler::hbg::Tensor t = make_test_tensor(0x1000, 256);
-    // Task 0 and task 0 + WINDOW_SIZE share slot 0 (local_id & (WINDOW_SIZE-1)).
     tmap.insert(t, simpler::hbg::make_ring_task(0));
-    tmap.insert(t, simpler::hbg::make_ring_task(WINDOW_SIZE));
+    tmap.insert(t, simpler::hbg::make_ring_task(LAST_TASK));
 
     EXPECT_EQ(tmap.valid_count(), 2);
     TestLookupResult result;
@@ -100,9 +104,12 @@ TEST_F(HbgTensorMapTest, SlotAliasingTasksBothKeepTheirEntries) {
         producers.push_back(e.entry->producer_task_id);
     }
     EXPECT_NE(std::find(producers.begin(), producers.end(), simpler::hbg::make_ring_task(0)), producers.end());
-    EXPECT_NE(
-        std::find(producers.begin(), producers.end(), simpler::hbg::make_ring_task(WINDOW_SIZE)), producers.end()
-    );
+    EXPECT_NE(std::find(producers.begin(), producers.end(), simpler::hbg::make_ring_task(LAST_TASK)), producers.end());
+
+    // Unlinking the head of one chain leaves the other chain's entry alone, which it
+    // could not if the two ids had folded onto one chain.
+    tmap.remove_entry(*result.entries[0].entry);
+    EXPECT_EQ(tmap.valid_count(), 1);
 }
 
 // Without an explicit semantic removal, direct inserts consume one pool entry
@@ -153,21 +160,21 @@ TEST_F(HbgTensorMapTest, ResetLeavesTheMapAsFreshlyInitialized) {
 }
 
 // Reset is reachable any number of times, including on a map that was never inserted
-// into, and does not depend on the task window having been narrowed or widened -- it
-// keeps the sizes init() reserved.
+// into, and does not depend on how many task chains it reserved -- it keeps the sizes
+// init() reserved.
 TEST_F(HbgTensorMapTest, ResetIsIdempotentAndKeepsReservedSizes) {
     tmap.reset();
     tmap.reset();
     EXPECT_EQ(tmap.pool_capacity(), POOL_SIZE);
     EXPECT_EQ(tmap.free_entries(), POOL_SIZE);
 
-    // A task id that aliases slot 0 still lands in a working chain after two resets.
+    // The last reserved chain is still a working chain after two resets.
     simpler::hbg::Tensor t = make_test_tensor(0x2000, 128);
-    tmap.insert(t, simpler::hbg::make_ring_task(WINDOW_SIZE));
+    tmap.insert(t, simpler::hbg::make_ring_task(LAST_TASK));
     TestLookupResult result;
     run_lookup(tmap, t, result);
     ASSERT_EQ(result.count, 1);
-    EXPECT_EQ(result.entries[0].entry->producer_task_id, simpler::hbg::make_ring_task(WINDOW_SIZE));
+    EXPECT_EQ(result.entries[0].entry->producer_task_id, simpler::hbg::make_ring_task(LAST_TASK));
 }
 
 // Filling the pool drives free_entries() to zero. No device-completion watermark
@@ -175,7 +182,7 @@ TEST_F(HbgTensorMapTest, ResetIsIdempotentAndKeepsReservedSizes) {
 // waiting for asynchronous reclaim that HBG does not have.
 TEST_F(HbgTensorMapTest, ExhaustedPoolStaysExhausted) {
     for (int32_t i = 0; i < POOL_SIZE; i++) {
-        tmap.insert(make_test_tensor(0x10000 + 0x100 * i, 64), simpler::hbg::make_ring_task(i % WINDOW_SIZE));
+        tmap.insert(make_test_tensor(0x10000 + 0x100 * i, 64), simpler::hbg::make_ring_task(i % MAX_TASKS));
     }
     EXPECT_EQ(tmap.current_used(), POOL_SIZE);
     EXPECT_EQ(tmap.free_entries(), 0);

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -395,7 +395,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     ASSERT_NE(execution, nullptr);
 
     TaskDescriptor outer_task{};
-    outer_task.task_id = simpler::hbg::make_ring_task(7);
+    outer_task.task_id = simpler::hbg::make_global_task(7);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
     ChipTaskSlotState outer_slot{};
@@ -419,7 +419,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
 
     graph_execution_mark_completed(*execution);
     execution->retired_nodes.store(2, std::memory_order_release);
-    outer_task.task_id = simpler::hbg::make_ring_task(8);
+    outer_task.task_id = simpler::hbg::make_global_task(8);
 
     // Poison every field the rebuild is responsible for restoring. A replay that
     // preserved any of them would leave the poison observable.
@@ -443,7 +443,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     EXPECT_EQ(node.payload.scalar_data()[0], 99U);
     EXPECT_EQ(execution->node_at(1).payload.scalar_data()[0], 18U);
     EXPECT_EQ(node.payload.tensor_data()[0].version, 0);
-    EXPECT_EQ(node.task.task_id, simpler::hbg::make_graph_node(/*outer_local_id=*/8, /*node_index=*/0));
+    EXPECT_EQ(node.task.task_id, simpler::hbg::make_in_graph_task(/*graph_local_id=*/8, /*task_index=*/0));
     EXPECT_EQ(node.task.packed_buffer_base, heap.base());
     EXPECT_EQ(node.payload.tensor_data()[0].buffer.addr, reinterpret_cast<uint64_t>(second_boundary.data()));
     EXPECT_EQ(execution->node_at(1).payload.tensor_data()[0].buffer.addr, reinterpret_cast<uint64_t>(heap.base() + 16));
@@ -471,7 +471,7 @@ TEST(GraphExecutionReplay, MaterializesBoundaryScalarPoolWiderThanTaskPayload) {
     ASSERT_NE(execution, nullptr);
 
     TaskDescriptor outer_task{};
-    outer_task.task_id = simpler::hbg::make_ring_task(7);
+    outer_task.task_id = simpler::hbg::make_global_task(7);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
     ChipTaskSlotState outer_slot{};
@@ -668,7 +668,7 @@ TEST(GraphExecutionProgress, InternalNodeResolutionIsNotAHostCompletion) {
 
     AsyncWaitList wait_list{};
     wait_list.entries[0].slot_state = &node.slot;
-    wait_list.entries[0].task_token = simpler::hbg::make_ring_task(1);
+    wait_list.entries[0].task_token = simpler::hbg::make_global_task(1);
     wait_list.entries[0].normal_done = true;
     wait_list.count = 1;
 
@@ -695,7 +695,7 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
     ASSERT_NE(execution, nullptr);
 
     TaskDescriptor outer_task{};
-    outer_task.task_id = simpler::hbg::make_ring_task(5);
+    outer_task.task_id = simpler::hbg::make_global_task(5);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
     ChipTaskSlotState outer_slot{};

--- a/tests/ut/cpp/common/test_hbg_graph_recording_bounds.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_recording_bounds.cpp
@@ -9,10 +9,11 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * A recorded node's id is what its entry in the recording's hazard map is keyed on,
- * and that map holds GRAPH_MAX_NODES task chains. A GRAPH_NODE id's low field is
- * the node index, so the key is in range however far into a run the Graph begins —
- * which a RING id carrying the allocator's own local id would not be.
+ * A recorded task's id is what its entry in the recording's hazard map is keyed on,
+ * and that map holds GRAPH_MAX_NODES task chains. An IN_GRAPH id's low field is the
+ * task's index within its body, so the key is in range however far into a run the
+ * Graph begins — which a GLOBAL id carrying the allocator's own local id would not
+ * be.
  *
  * These tests place the Graph past that many ordinary tasks, where an id drawn from
  * the run's numbering would key the map outside its chains.
@@ -79,10 +80,10 @@ protected:
     }
 };
 
-// A Graph recorded after GRAPH_MAX_NODES ordinary tasks. Its node registers its
-// outputs in the recording hazard map keyed on its own id, so that id decides
+// A Graph recorded after GRAPH_MAX_NODES ordinary tasks. Its recorded task registers
+// its outputs in the recording hazard map keyed on its own id, so that id decides
 // whether the key lands inside the map's task chains.
-TEST_F(HbgGraphRecordingBoundsTest, RecordedNodeIsKeyedByItsIndexNotByTheRunsNumbering) {
+TEST_F(HbgGraphRecordingBoundsTest, RecordedTaskIsKeyedByItsIndexNotByTheRunsNumbering) {
     std::array<uint32_t, 16> storage{};
     uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
     simpler::hbg::Tensor boundary = simpler::hbg::make_tensor_external(storage.data(), shape, 1);
@@ -104,17 +105,17 @@ TEST_F(HbgGraphRecordingBoundsTest, RecordedNodeIsKeyedByItsIndexNotByTheRunsNum
     ASSERT_NE(graph.recording_handle, nullptr);
     ASSERT_TRUE(orch.graph_prepare(graph.recording_handle, boundary_args));
 
-    // An INOUT operand is what makes the node register an output: the recording's
-    // hazard map exists for exactly the write-in-place shape.
+    // An INOUT operand is what makes the recorded task register an output: the
+    // recording's hazard map exists for exactly the write-in-place shape.
     CoreTaskArgs node_args;
     node_args.add_inout(boundary);
     const TaskId node_id = orch.submit_dummy_task(node_args).task_id();
     ASSERT_TRUE(node_id.is_valid());
-    EXPECT_EQ(simpler::hbg::task_id_space(node_id), simpler::hbg::TaskIdSpace::GRAPH_NODE)
-        << "a recorded node must not take a RING id: nothing resolves it against the task table, and its low "
+    EXPECT_EQ(simpler::hbg::task_id_space(node_id), simpler::hbg::TaskIdSpace::IN_GRAPH)
+        << "a recorded task must not take a GLOBAL id: nothing resolves it against the task table, and its low "
            "field is what keys the recording's hazard map";
     EXPECT_EQ(simpler::hbg::task_local_id(node_id), 0u)
-        << "the first recorded node's low field is node index 0, independent of how many tasks the run has "
+        << "the first recorded task's low field is task index 0, independent of how many tasks the run has "
            "already allocated";
     EXPECT_LT(simpler::hbg::task_local_id(node_id), GRAPH_MAX_NODES);
 
@@ -122,7 +123,7 @@ TEST_F(HbgGraphRecordingBoundsTest, RecordedNodeIsKeyedByItsIndexNotByTheRunsNum
 }
 
 // Channel the outer shell owns: a boundary tensor allocated before the Graph makes
-// compute_task_fanin emit that pre-Graph producer for every node reading it. No edge
+// compute_task_fanin emit that pre-Graph producer for every task reading it. No edge
 // in the Definition may name it — the shell was submitted through the ordinary path
 // against the same boundary, so its own fanin orders the whole body behind it.
 TEST_F(HbgGraphRecordingBoundsTest, PreGraphProducerOfABoundaryTensorContributesNoEdge) {

--- a/tests/ut/cpp/common/test_hbg_graph_recording_bounds.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_recording_bounds.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * A recorded node's id is what its entry in the recording's hazard map is keyed on,
+ * and that map holds GRAPH_MAX_NODES task chains. A GRAPH_NODE id's low field is
+ * the node index, so the key is in range however far into a run the Graph begins —
+ * which a RING id carrying the allocator's own local id would not be.
+ *
+ * These tests place the Graph past that many ordinary tasks, where an id drawn from
+ * the run's numbering would key the map outside its chains.
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "graph_execution.h"
+#include "graph_host_state.h"
+#include "orchestrator.h"
+#include "shared_memory.h"
+#include "utils/device_arena.h"
+#include "host_build_graph/task_id_encoding.h"
+
+class HbgGraphRecordingBoundsTest : public ::testing::Test {
+protected:
+    DeviceArena sm_arena;
+    DeviceArena runtime_arena;
+    SharedMemoryHandle *sm_handle = nullptr;
+    OrchestratorState orch{};
+    SchedulerState sched{};
+    SchedulerLayout sched_layout{};
+    GraphHostStatePtr graph_state;
+    std::vector<char> gm_heap;
+    std::vector<std::byte> definition_staging;
+
+    static constexpr size_t HEAP_BYTES = 8 * 1024 * 1024;
+    static constexpr size_t STAGING_BYTES = 256 * 1024;
+
+    void SetUp() override {
+        sm_handle = SharedMemoryHandle::create_and_init_default(sm_arena);
+        ASSERT_NE(sm_handle, nullptr);
+        gm_heap.resize(HEAP_BYTES);
+
+        sched_layout = SchedulerState::reserve_layout(runtime_arena);
+        ASSERT_NE(runtime_arena.commit(), nullptr);
+
+        ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
+        sched.wire_arena_pointers(sched_layout, runtime_arena);
+        ASSERT_TRUE(orch.init(sm_handle->sm_base, gm_heap.data(), HEAP_BYTES, CHIP_DEFAULT_GRAPH_TASKS, &sched));
+
+        definition_staging.assign(STAGING_BYTES, std::byte{0});
+        GraphDefinitionArena arena{};
+        arena.base = definition_staging.data();
+        arena.capacity = definition_staging.size();
+        arena.object_prefix_bytes = sizeof(GraphDefinitionHeader);
+        arena.object_align = GRAPH_DEFINITION_OBJECT_ALIGN;
+        graph_state = make_graph_host_state(arena);
+        ASSERT_NE(graph_state, nullptr);
+        orch.graph_host_state = graph_state.get();
+    }
+
+    void TearDown() override {
+        orch.graph_host_state = nullptr;
+        graph_state.reset();
+        sched.destroy();
+        runtime_arena.release();
+        sm_arena.release();
+    }
+};
+
+// A Graph recorded after GRAPH_MAX_NODES ordinary tasks. Its node registers its
+// outputs in the recording hazard map keyed on its own id, so that id decides
+// whether the key lands inside the map's task chains.
+TEST_F(HbgGraphRecordingBoundsTest, RecordedNodeIsKeyedByItsIndexNotByTheRunsNumbering) {
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    simpler::hbg::Tensor boundary = simpler::hbg::make_tensor_external(storage.data(), shape, 1);
+
+    orch.begin_scope();
+    // Move the allocator's local-id counter past the recording map's task-chain
+    // count, the way any run that submits a while before its first Graph does.
+    for (uint32_t i = 0; i < GRAPH_MAX_NODES; ++i) {
+        CoreTaskArgs filler;
+        filler.add_input(boundary);
+        ASSERT_TRUE(orch.submit_dummy_task(filler).task_id().is_valid()) << "filler task " << i;
+    }
+    ASSERT_EQ(orch.task_allocator.active_count(), static_cast<int32_t>(GRAPH_MAX_NODES));
+
+    GraphTaskArgs boundary_args;
+    boundary_args.add_input(boundary);
+    const GraphScopeResult graph = orch.graph_begin(0x6B0D5A1E, boundary_args, 0x1736);
+    ASSERT_TRUE(graph.recording);
+    ASSERT_NE(graph.recording_handle, nullptr);
+    ASSERT_TRUE(orch.graph_prepare(graph.recording_handle, boundary_args));
+
+    // An INOUT operand is what makes the node register an output: the recording's
+    // hazard map exists for exactly the write-in-place shape.
+    CoreTaskArgs node_args;
+    node_args.add_inout(boundary);
+    const TaskId node_id = orch.submit_dummy_task(node_args).task_id();
+    ASSERT_TRUE(node_id.is_valid());
+    EXPECT_EQ(simpler::hbg::task_id_space(node_id), simpler::hbg::TaskIdSpace::GRAPH_NODE)
+        << "a recorded node must not take a RING id: nothing resolves it against the task table, and its low "
+           "field is what keys the recording's hazard map";
+    EXPECT_EQ(simpler::hbg::task_local_id(node_id), 0u)
+        << "the first recorded node's low field is node index 0, independent of how many tasks the run has "
+           "already allocated";
+    EXPECT_LT(simpler::hbg::task_local_id(node_id), GRAPH_MAX_NODES);
+
+    ASSERT_TRUE(orch.graph_end());
+}
+
+// Channel the outer shell owns: a boundary tensor allocated before the Graph makes
+// compute_task_fanin emit that pre-Graph producer for every node reading it. No edge
+// in the Definition may name it — the shell was submitted through the ordinary path
+// against the same boundary, so its own fanin orders the whole body behind it.
+TEST_F(HbgGraphRecordingBoundsTest, PreGraphProducerOfABoundaryTensorContributesNoEdge) {
+    std::array<uint32_t, 16> storage{};
+    uint32_t shape[] = {static_cast<uint32_t>(storage.size())};
+    simpler::hbg::Tensor external = simpler::hbg::make_tensor_external(storage.data(), shape, 1);
+
+    orch.begin_scope();
+    // The tensor the Graph takes as its boundary is this task's write target, so it
+    // carries that task's id as its owner.
+    CoreTaskArgs producer_args;
+    producer_args.add_inout(external);
+    const TaskId producer_id = orch.submit_dummy_task(producer_args).task_id();
+    ASSERT_TRUE(producer_id.is_valid());
+    simpler::hbg::Tensor boundary = external;
+    boundary.owner_task_id = producer_id;
+
+    GraphTaskArgs boundary_args;
+    boundary_args.add_input(boundary);
+    const GraphScopeResult graph = orch.graph_begin(0x6B0D5A1F, boundary_args, 0x1736);
+    ASSERT_TRUE(graph.recording);
+    ASSERT_TRUE(orch.graph_prepare(graph.recording_handle, boundary_args));
+
+    CoreTaskArgs node_args;
+    node_args.add_inout(boundary);
+    ASSERT_TRUE(orch.submit_dummy_task(node_args).task_id().is_valid());
+    ASSERT_TRUE(orch.graph_end());
+
+    const GraphHostDefinitionList published = graph_host_definitions(*graph_state);
+    ASSERT_EQ(published.entries.size(), 1u);
+    const GraphHostDefinition &entry = published.entries.front();
+    ASSERT_NE(entry.object_offset, GRAPH_NO_OBJECT_OFFSET) << "the staging arena is sized to hold this image";
+    const auto *definition = reinterpret_cast<const GraphDefinition *>(
+        definition_staging.data() + entry.object_offset + sizeof(GraphDefinitionHeader)
+    );
+    EXPECT_EQ(definition->task_count, 1u);
+    EXPECT_EQ(definition->edge_count, 0u) << "the pre-Graph producer is reached through the shell, not through an "
+                                             "edge the Definition carries";
+    EXPECT_EQ(definition->root_count, 1u);
+}

--- a/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
+++ b/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
@@ -87,7 +87,7 @@ public:
         // orchestrator's bump cursors hand them out, and gets content that identifies
         // the slot so the compaction can be checked element by element.
         for (uint64_t i = 0; i < SUBMITTED; ++i) {
-            descriptors()[i].task_id = simpler::hbg::make_ring_task(static_cast<uint32_t>(i));
+            descriptors()[i].task_id = simpler::hbg::make_global_task(static_cast<uint32_t>(i));
             payloads()[i].tensor_count = TENSORS_PER_TASK;
             payloads()[i].scalar_count = SCALARS_PER_TASK;
             payloads()[i].fanin_count = FANIN_PER_TASK;
@@ -110,7 +110,7 @@ public:
             completion_flags()[i].store(static_cast<uint8_t>(i & 1), std::memory_order_relaxed);
         }
         // A slot past the submitted prefix, to prove it does not travel.
-        descriptors()[SUBMITTED].task_id = simpler::hbg::make_ring_task(0xBEEF);
+        descriptors()[SUBMITTED].task_id = simpler::hbg::make_global_task(0xBEEF);
     }
 
     // Overwrite the three fields that can hold a graph-heap address with ones out


### PR DESCRIPTION
Four changes to `host_build_graph`, each independent enough to review on its own.

## 1. Drop the `FaninBuilder` struct

`FaninBuilder` had shrunk to four fields and one method. Two of those fields, `count`
and `slots`, were copies of `payload.fanin_count` and `payload.fanin_data()`, and
STEP 6 copied the count back to the payload at the end of every submit.

`append_fanin_or_fail` now takes the consumer payload's fanin region and its count
directly, so the count accumulates in place and the copy-back is gone. `mark_seen`
becomes the free function `fanin_mark_seen`, and `next_fanin_seen_epoch` drops its
return value now that the epoch it advances to is read from
`orch.fanin_seen_current_epoch`. The region is still resolved once per task, not per
producer: it is named by a `SelfRelativePtr` delta.

## 2. Fix a heap out-of-bounds write in the Graph recording hazard map

The recording's hazard map holds `GRAPH_MAX_NODES` task chains and indexes them by a
producer's low id field directly, but a recorded node was minted in the RING space as
`start_local_task_id + node_index`. **Any Graph that begins after the run's first
`GRAPH_MAX_NODES` tasks — the ordinary shape for a decode workload — registered its
nodes past the last chain and wrote outside `task_entry_heads`.**

Confirmed under ASAN, full stack:

```
heap-buffer-overflow, 8192-byte region
  ChipTensorMap::link_entry      tensormap.h
  ChipTensorMap::insert          tensormap.h
  register_task_outputs          dep_compute.h
  graph_record_submit_node       orchestrator.cpp
allocated by graph_recording_init_tensor_map   <- max_tasks = GRAPH_MAX_NODES = 1024
```

A recorded node now takes a `GRAPH_NODE` id whose low field is the node index alone,
so the key is in range however far into a run the Graph begins. The recording baseline
that existed only to tell a node from a pre-Graph task by numeric range is gone: the
two now differ by id space, decided at the mint rather than derived by subtraction.

Two consequences beyond the out-of-bounds write:

- A ring id the main thread allocates while a recorder thread runs can no longer land
  inside a node's index range and be wired as an internal fanin. That
  misclassification was unreachable in practice, but only because of what a body can
  hold — not by construction.
- A node id that escapes its Graph and is later declared as an explicit dependency now
  trips `append_fanin_or_fail`'s id-space guard instead of resolving to an unrelated
  task slot and wiring a wrong edge.

An over-cap body skips hazard-map registration: its node index has run past the field
`make_graph_node` packs it into, and the Definition is abandoned already.
`link_entry` and `remove_from_task` carry a `debug_assert` on the chain index, so a
future caller inserting under the wrong id space is caught where it happens rather
than corrupting the heap.

`test_hbg_tensormap`'s slot-aliasing case rested on a mask hbg does not have — its own
inserts ran one chain past the fixture's dimension. It now pins the invariant that
holds: a local id is its own chain index, so distinct producers never share a chain.

The new `test_hbg_graph_recording_bounds` runs against both arch trees, matching every
other hbg case under `tests/ut/cpp/common/` — the fix is mirrored in a5, so its test
has to be too.

## 3. Name the task id spaces by Graph membership

`TaskIdSpace::RING` dated from a ring design `host_build_graph` no longer has — the
header's own comment had to apologize for the name. And there is no separate "node"
concept to name: everything the runtime schedules is a task, and the only question the
high bits answer is whether a task belongs to a Graph task or stands on its own.

```
TaskIdSpace::RING       -> TaskIdSpace::GLOBAL
TaskIdSpace::GRAPH_NODE -> TaskIdSpace::IN_GRAPH
make_ring_task          -> make_global_task
is_ring_task            -> is_global_task
make_graph_node         -> make_in_graph_task
GRAPH_NODE_INDEX_BITS   -> IN_GRAPH_TASK_INDEX_BITS
```

`TaskIdSpace` keeps its name: the field holds which id namespace an id belongs to,
which is what "space" says, and "type" would collide conceptually with `TaskKind`.
`is_global_task` gains a comment naming what its callers actually depend on — that the
id resolves to a shared-memory task table slot — since the old name carried that by
implication and the new one does not.

The deeper `node` vocabulary is untouched: `GraphNodeStorage`, `GraphNodeDefinition`,
`graph_node_index`, `GRAPH_MAX_NODES`, `node_count` and `node_at` are ~350 occurrences
across host, device and the Definition wire structs. `TaskKind::GRAPH_NODE` is not a
rename at all — it conflates task kind with Graph membership while also serving as the
discriminator for what `graph_context` points at, so retiring it changes scheduler
dispatch and needs its own review.

## 4. Retire the ring vocabulary from comments and docs

`host_build_graph` has no ring, which is why #3 renames `TaskIdSpace::RING`. That
settled the identifiers, but the surrounding prose still described tasks as living on
a ring — so the concept stayed spelled two ways.

**Six of those comments described mechanisms the runtime does not have**, which is the
part worth reviewing: a reader who trusted them would go looking for absent code.

- `TaskPayload`'s layout comment promised large fanins "spill into a per-ring ring
  buffer slice". Fanin is always inline and hard-capped at `CHIP_MAX_FANIN` —
  `append_fanin_or_fail`'s own fatal says exactly that.
- `reserve_layout` and `wire_arena_pointers` claimed to declare and wire per-ring
  `dep_pool` regions. Polling has no `dep_pool`, as a comment 700 lines above them
  already states.
- `TaskDescriptor` placed itself in a "ring buffer"; it lives in the task table.
- `TaskPayload::init` and the predicate write in `submit_task_common` attributed
  uninitialized payload storage to slot reuse. hbg never reuses a slot: the storage is
  raw because shared memory is not zero-filled, and *that* is what the surrounding
  code depends on.

The rest is vocabulary. `per-ring completed_watermark` drops a modifier that
distinguishes nothing, there being one watermark. `the ring path` becomes `the ordinary
path`, which is what `GRAPH_EXECUTION.md` and eight existing comments already call it —
one of them the line directly below a `ring path` mention.

Untouched, because each is accurate or externally consumed: the ring names describing
`tensormap_and_ringbuffer`, the mailbox and ready-queue ring buffers, the doorbell verb
(`ring_one_doorbell`, `maybe_rendezvous_ring`, ...), the `runtime_env.ring_*` knobs, and
the `TASK ring=%d` stall-log field.

`dep_compute.h` also takes `#pragma once`: its guard macro named
`tensormap_and_ringbuffer` and carried the retired `PTO` prefix, and the a5 copy was
already converted.

Comments and docs only. The a2a3 and a5 trees stay line-for-line identical wherever
they already were.

## Testing

- `ctest` on `tests/ut/cpp`: 121/121 (120 + the new a5 target).
- **ASAN build of `tests/ut/cpp`**: the two `link_entry` overflows reported before the
  fix (one from the new recording test, one the pre-existing `test_hbg_tensormap`
  aliasing case triggered on itself) are both gone. This is the only thing that proves
  the write is actually gone, and CI does not cover it — `sanitizers.yml` runs sim
  scene tests, not cpput.
- Scene tests on `a2a3sim` and `a5sim` with `--manual include`.
- `pre-commit` over every changed file, including `check-retired-names`, `clang-tidy`,
  `cpplint` and `markdownlint`.
- `host_build_graph_validation` including `graph_node_dependency`, which is the
  standing regression barrier for "a Graph-internal id used as an explicit dependency
  is a fatal".

