### PR TITLE
Lift EntryArgsStorage out of the kernel-facing tensor.h

### DIFF
--- a/docs/buffer-abi.md
+++ b/docs/buffer-abi.md
@@ -37,6 +37,15 @@ forget it on.
 the address is resolved on the consuming endpoint, and the C++ orchestration on
 the chip receives the resolved form.
 
+**A kernel translation unit sees only the last two rows.** A `#include "tensor.h"`
+on a runtime's include path supplies `ChipTensor` and that runtime's `Tensor`
+(aliased `TaskTensor`), and reaches neither `task_interface/task_args.h` nor the
+wire `Tensor` in `task_interface/buffer.h`. The runtime's own entry-arg storage,
+which does need both, sits in `entry_args.h` beside it rather than in `tensor.h`.
+Since the wire type and the runtime type are both spelled `Tensor` — one at global
+scope, one in `simpler::{hbg,tmr}` — an include that reintroduces that edge makes
+the two names collide inside every kernel that picks up the header.
+
 > **Status.** `TaskArgs.add_tensor` takes a `Tensor`, and `simpler.task_interface`
 > re-exports it: the public submit surface names the type its own submit call accepts.
 > The Scope / status section at the end of this page says what is and is not connected.

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -42,7 +42,7 @@
 #include "aicpu/platform_aicpu_affinity.h"  // MAX_GATE_THREADS (aicpu_allowed_cpus bound)
 #include "dispatch_payload.h"
 #include "task_args.h"
-#include "tensor.h"  // EntryArgsStorage
+#include "host_build_graph/entry_args.h"  // EntryArgsStorage
 
 // =============================================================================
 // Configuration Macros

--- a/src/a2a3/runtime/host_build_graph/runtime/types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/types.h
@@ -40,6 +40,7 @@
 #include "aicpu/dump_arg_selection.h"
 #include "common/device_phase.h"
 #include "data_type.h"
+#include "host_build_graph/entry_args.h"  // EntryArgsStorage
 #include "profiling_config.h"
 #include "submit_types.h"
 #include "task_args.h"

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -45,7 +45,7 @@
 #include "aicpu/platform_aicpu_affinity.h"  // MAX_GATE_THREADS (aicpu_allowed_cpus bound)
 #include "dispatch_payload.h"
 #include "task_args.h"
-#include "tensor.h"  // EntryArgsStorage
+#include "tensormap_and_ringbuffer/entry_args.h"  // EntryArgsStorage
 
 // =============================================================================
 // Configuration Macros

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/types.h
@@ -42,7 +42,8 @@
 #include "submit_types.h"
 #include "task_args.h"
 #include "tensor.h"
-#include "tensor_create_info.h"  // runtime-only TensorCreateInfo + materialization helpers
+#include "tensor_create_info.h"                   // runtime-only TensorCreateInfo + materialization helpers
+#include "tensormap_and_ringbuffer/entry_args.h"  // EntryArgsStorage
 
 // TaskAttrs packs the timing tag into a 4-bit field and reports "untagged" as
 // -1, so the tag domain must fit 0..15 and the untagged sentinel must be -1.

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -41,7 +41,7 @@
 #include "aicpu/platform_aicpu_affinity.h"  // MAX_GATE_THREADS (aicpu_allowed_cpus bound)
 #include "dispatch_payload.h"
 #include "task_args.h"
-#include "tensor.h"  // EntryArgsStorage
+#include "host_build_graph/entry_args.h"  // EntryArgsStorage
 
 // =============================================================================
 // Configuration Macros

--- a/src/a5/runtime/host_build_graph/runtime/types.h
+++ b/src/a5/runtime/host_build_graph/runtime/types.h
@@ -40,6 +40,7 @@
 #include "aicpu/dump_arg_selection.h"
 #include "common/device_phase.h"
 #include "data_type.h"
+#include "host_build_graph/entry_args.h"  // EntryArgsStorage
 #include "profiling_config.h"
 #include "submit_types.h"
 #include "task_args.h"

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -44,7 +44,7 @@
 #include "aicpu/platform_aicpu_affinity.h"  // MAX_GATE_THREADS (aicpu_allowed_cpus bound)
 #include "dispatch_payload.h"
 #include "task_args.h"
-#include "tensor.h"  // EntryArgsStorage
+#include "tensormap_and_ringbuffer/entry_args.h"  // EntryArgsStorage
 
 // =============================================================================
 // Configuration Macros

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/types.h
@@ -43,7 +43,8 @@
 #include "submit_types.h"
 #include "task_args.h"
 #include "tensor.h"
-#include "tensor_create_info.h"  // runtime-only TensorCreateInfo + materialization helpers
+#include "tensor_create_info.h"                   // runtime-only TensorCreateInfo + materialization helpers
+#include "tensormap_and_ringbuffer/entry_args.h"  // EntryArgsStorage
 
 // TaskAttrs packs the timing tag into a 4-bit field and reports "untagged" as
 // -1, so the tag domain must fit 0..15 and the untagged sentinel must be -1.

--- a/src/common/host_build_graph/entry_args.h
+++ b/src/common/host_build_graph/entry_args.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Where the `hbg` runtime keeps the arguments its orchestration entry was called
+ * with.
+ *
+ * This header is runtime-internal, and separate from tensor.h for that reason: it
+ * reaches the L3+ argument surface in src/common/task_interface/task_args.h, and
+ * through it the address-free wire `Tensor` at global scope in buffer.h. A kernel
+ * translation unit needs this runtime's `Tensor` but none of that, and gets it from
+ * tensor.h, which stays clear of both.
+ */
+
+#pragma once
+
+#include "task_interface/arg_direction.h"
+#include "task_interface/task_args.h"
+#include "tensor.h"
+
+namespace simpler::hbg {
+
+// `Runtime::set_orch_args` adopts the boundary ChipStorageTaskArgs into this once,
+// on the host, before orchestration runs; from there inward nothing holds a bare
+// ChipTensor.
+using EntryArgsStorage = TaskArgsTpl<Tensor, uint64_t, CHIP_MAX_TENSOR_ARGS, CHIP_MAX_SCALAR_ARGS>;
+
+}  // namespace simpler::hbg

--- a/src/common/host_build_graph/tensor.h
+++ b/src/common/host_build_graph/tensor.h
@@ -28,7 +28,6 @@
 #include "data_type.h"
 #include "task_id.h"
 #include "task_interface/arg_direction.h"
-#include "task_interface/task_args.h"
 #include "task_interface/tensor.h"
 
 namespace simpler::hbg {
@@ -573,10 +572,5 @@ inline Tensor make_tensor_strided(
     t.buffer.size = t.extent_elem_cache * get_element_size(dtype);
     return t;
 }
-
-// The runtime's entry-arg storage. `Runtime::set_orch_args` adopts the boundary
-// ChipStorageTaskArgs into this once, on the host, before orchestration runs; from
-// there inward nothing holds a bare ChipTensor.
-using EntryArgsStorage = TaskArgsTpl<Tensor, uint64_t, CHIP_MAX_TENSOR_ARGS, CHIP_MAX_SCALAR_ARGS>;
 
 }  // namespace simpler::hbg

--- a/src/common/tensormap_and_ringbuffer/entry_args.h
+++ b/src/common/tensormap_and_ringbuffer/entry_args.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Where the `tmr` runtime keeps the arguments its orchestration entry was called
+ * with.
+ *
+ * This header is runtime-internal, and separate from tensor.h for that reason: it
+ * reaches the L3+ argument surface in src/common/task_interface/task_args.h, and
+ * through it the address-free wire `Tensor` at global scope in buffer.h. A kernel
+ * translation unit needs this runtime's `Tensor` but none of that, and gets it from
+ * tensor.h, which stays clear of both.
+ */
+
+#pragma once
+
+#include "task_interface/arg_direction.h"
+#include "task_interface/task_args.h"
+#include "tensor.h"
+
+namespace simpler::tmr {
+
+// `Runtime::set_orch_args` adopts the boundary ChipStorageTaskArgs into this once,
+// on the host, before orchestration runs; from there inward nothing holds a bare
+// ChipTensor.
+using EntryArgsStorage = TaskArgsTpl<Tensor, uint64_t, CHIP_MAX_TENSOR_ARGS, CHIP_MAX_SCALAR_ARGS>;
+
+}  // namespace simpler::tmr

--- a/src/common/tensormap_and_ringbuffer/tensor.h
+++ b/src/common/tensormap_and_ringbuffer/tensor.h
@@ -28,7 +28,6 @@
 #include "data_type.h"
 #include "task_id.h"
 #include "task_interface/arg_direction.h"
-#include "task_interface/task_args.h"
 #include "task_interface/tensor.h"
 
 namespace simpler::tmr {
@@ -573,10 +572,5 @@ inline Tensor make_tensor_strided(
     t.buffer.size = t.extent_elem_cache * get_element_size(dtype);
     return t;
 }
-
-// The runtime's entry-arg storage. `Runtime::set_orch_args` adopts the boundary
-// ChipStorageTaskArgs into this once, on the host, before orchestration runs; from
-// there inward nothing holds a bare ChipTensor.
-using EntryArgsStorage = TaskArgsTpl<Tensor, uint64_t, CHIP_MAX_TENSOR_ARGS, CHIP_MAX_SCALAR_ARGS>;
 
 }  // namespace simpler::tmr


### PR DESCRIPTION
## The defect

`src/common/{host_build_graph,tensormap_and_ringbuffer}/tensor.h` sits on **every kernel translation unit's** include path — each runtime's `runtime/tensor.h` umbrella includes it to supply that runtime's working `Tensor`, which kernels name through the umbrella's `TaskTensor` alias. Its last line was a runtime-internal container:

```cpp
using EntryArgsStorage =
    TaskArgsTpl<Tensor, uint64_t, CHIP_MAX_TENSOR_ARGS, CHIP_MAX_SCALAR_ARGS>;
```

That line was the file's **only** reason to include `task_interface/task_args.h`, and through it `task_interface/buffer.h`:

```text
kernel TU
 └─ tensor.h (umbrella)
     ├─ task_interface/tensor.h        ChipTensor            ← kernel needs
     └─ {hbg,tmr}/tensor.h             simpler::{hbg,tmr}::Tensor ← kernel needs
         └─ task_interface/task_args.h ← only for EntryArgsStorage
             └─ buffer.h               global ::Tensor, TENSOR_BLOB_MAGIC ← kernel does NOT need
```

So every kernel pulled in the L3+ argument surface it has no use for, plus the address-free wire `Tensor` that `buffer.h` declares at **global scope**. `task_args.h` needing `buffer.h` is legitimate — it declares `using TaskArgs = TaskArgsTpl<Tensor, ...>` and the blob codec, which *is* the L3+ surface. The defect is that the edge into it existed at all.

`EntryArgsStorage` has no kernel consumer. Measured, the readers are all runtime-side:

| Consumer | Use |
| -------- | --- |
| `runtime/runtime.h` ×4 | `orch_args_storage_` member + `get_orch_args()` return type |
| `runtime/types.h` ×4 | `create_from_entry_storage(const EntryArgsStorage &)` |
| `runtime/shared/runtime.cpp` ×4 | `get_orch_args()` definition, `set_orch_args` adoption |
| `host/runtime_maker.cpp` ×2 | `create_from_entry_storage` call |
| `aicpu/aicpu_executor.cpp` ×2 (tmr only) | validation read |

## The change

It moves to a sibling `entry_args.h` per runtime, which includes `tensor.h` and `task_args.h` for itself. The eight runtime headers that name the alias include that instead of the umbrella; the six `.cpp` consumers already reach it through `runtime.h`, so they are untouched. **No declaration changes** and nothing else moves — 13 files, +89/−18.

`task_interface/arg_direction.h` stays in both `tensor.h` files. It is unused there once the alias leaves, but it is a `<cstdint>`-only leaf that cannot reach `buffer.h`, it does not participate in this defect, and it exports the `MAX_TENSOR_ARGS` / `MAX_SCALAR_ARGS` **macros** — removing an include that 688 files see transitively is a separate change with its own blast radius.

## Why it matters beyond hygiene

The wire `Tensor` and a runtime's `Tensor` share a name in different scopes, so while that edge existed a kernel **could not** write the obvious alias:

```text
error: conflicting declaration 'using Tensor = struct simpler::hbg::Tensor'
note: previous declaration as 'struct Tensor'      ← task_interface/buffer.h:218
```

That is why the umbrellas export the awkward `TaskTensor` rather than `Tensor`. Both umbrellas now accept `using Tensor = simpler::{hbg,tmr}::Tensor;`. This PR does **not** rename anything (that would be 3286 occurrences across 688 files, and the name would then rest on an invariant nothing enforces) — it only removes the reason the rename was impossible.

`docs/buffer-abi.md`'s "Three types" section records the new invariant, since it is exactly the kind a future `#include` can silently undo.

## Testing

| Gate | Result |
| ---- | ------ |
| Full product build — 2 arches × 2 runtimes × sim/onboard | clean; host, aicpu **and** aicore artifacts all rebuilt (verified by timestamp, not by exit code — #1965 shipped red because a `-fsyntax-only` spot check missed `aicpu/aicpu_executor.cpp`) |
| cpput | **119/119** |
| `_st-sim-a2a3.yml` main sweep, verbatim shape | **60 passed / 8 skipped** (22 resource-phase + 10 L2-hbg + 28 L2-tmr), reconciles against `--collect-only`'s 68 selected |
| `_st-sim-a5.yml` main sweep, verbatim shape | **53 passed** (18 + 7 + 28), reconciles against 53 selected |

The acceptance check is a probe TU that includes the umbrella and aliases `Tensor`. It compiles now; a **control** that restores the `task_args.h` include by hand on the same tree still fails with the error above — so the check answers to the edge rather than to the alias.

### Pre-existing failures this surfaced, and why they are not this PR's

The whole scene-test corpus's incores were also compiled with `--manual include` on both arches — the coverage #1974 lacked when it renamed a type that only manual-only cases use. That reports **six failures per arch, all pre-existing on this base**, all carrying #1974's signature in four files:

```text
error: no member named 'tmr' in namespace 'simpler'; did you mean 'tm'?
error: no type named 'Tensor' in 'tm'; did you mean 'simpler::hbg::Tensor'?
```

- `examples/{a2a3,a5}/…/qwen3_14b_decode/kernels/vendor/paged_attention_cce/{tiling,attention_rope}/entry.cpp` — fixed by #2023, not in this base
- `tests/st/{a2a3,a5}/…/spmd_paged_attention/kernels/{mix/paged_attention_parallel.cpp,orchestration/spmd_paged_attention_orch.cpp}` — reported separately in #2023, still open

Negative evidence rather than assertion: grepping both logs for `entry_args|task_args\.h|buffer\.h|conflicting declaration|ambiguous` matches **twice**, and both are a CANN `unused variable` warning in `kernel_pop_stack_buffer.h`. No failure names a changed header, a conflicting `Tensor`, or an ambiguous call.

Note that `scene_test_compile` is a cache warmer by its own docstring and **exits 0 on a compile error**, logging `[ERROR] [Incore] Compilation failed:` instead — the log is the signal, not the status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
