### PR TITLE
Add: a host span per scheduler-loop iteration that did work

### DIFF
--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -196,10 +196,28 @@ which every one of those levels runs on:
 | `<level>.activate` | prepared-frame activation |
 | `<level>.complete` | terminal child progress handling |
 | `<level>.post_fence_retirement` | run erase + quiescent compaction, after the completion fence |
+| `<level>.scheduler_loop` | one scheduler-loop iteration that drained a completion or dispatched a task |
 
 Their attributes carry the available `run_id`, `task_slot`, `group_index`,
 `worker_id`, `dispatch_id`, endpoint kind, and the dispatch's pipeline lease
 (`slot_id` / `generation`).
+
+`<level>.scheduler_loop` is the exception to that list and to the tree below: a
+loop iteration serves whichever runs were ready, so it belongs to no run and
+carries no key at all. Its own attributes are the counts:
+
+| Attribute | Meaning |
+| --------- | ------- |
+| `drained` `dispatched` | completions handled and tasks handed to a worker in this iteration |
+| `drain_ns` | how much of the span was phase 1, so the two phases are separable from one record |
+| `spins` | iterations since the previous span that did neither |
+
+**An iteration that neither drained nor dispatched emits nothing.** The loop
+skips its condition-variable wait entirely whenever any worker is busy, so its
+iteration count is bounded by CPU speed rather than by work — one span per
+iteration would be unbounded, and the ratio that matters is recoverable without
+them: the gap between two spans on the scheduler lane is the wait, and `spins`
+reports how many empty iterations the gap contained.
 
 The word is resolved once per process, from its Worker's level, and the **first
 binding wins**: a `SpanScope` keeps the name pointer it was handed, so a process
@@ -210,7 +228,7 @@ one vocabulary — which is what makes an L4 run readable, since its own spans s
 
 One process contributes at most two host lanes, because the scheduler runs on
 one thread: the facade thread emits `<level>.graph_build` and `<level>.submit`,
-and the scheduler thread emits the other four. `role=worker` on
+and the scheduler thread emits the other five. `role=worker` on
 `<level>.frame_submit`, `<level>.activate` and `<level>.complete` names the
 worker a dispatch targets, not the thread that ran it.
 

--- a/src/common/hierarchical/scheduler.cpp
+++ b/src/common/hierarchical/scheduler.cpp
@@ -14,8 +14,11 @@
 #include <algorithm>
 #include <optional>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
+#include "common/host_span_names.h"
+#include "common/host_span_scope.h"
 #include "ring.h"
 #include "types.h"
 #include "worker_manager.h"
@@ -253,6 +256,14 @@ void Scheduler::notify_ready() {
 
 void Scheduler::run() {
     uint64_t observed_wake_generation = 0;
+#if SIMPLER_HOST_STRACE
+    // Iterations that neither drained nor dispatched, since the last iteration
+    // that did. The loop skips its wait whenever any worker is busy, so its
+    // iteration count is bounded by CPU speed rather than by work — a span per
+    // iteration would be unbounded. Carrying the count on the next span that
+    // does describe work keeps the spin ratio observable at zero records.
+    uint64_t spins = 0;
+#endif
     while (true) {
         {
             std::unique_lock<std::mutex> lk(completion_mu_);
@@ -270,6 +281,15 @@ void Scheduler::run() {
             observed_wake_generation = wake_generation_;
         }
 
+#if SIMPLER_HOST_STRACE
+        // Outside the loop_mu_ acquisition below, so a span covers the wait for
+        // that lock: the gap between two spans is then the condition-variable
+        // wait alone, which is the "no work to do" reading the span cannot give.
+        const bool trace_loop = simpler::host_trace::enabled();
+        const int64_t loop_start_ns = trace_loop ? simpler::host_trace::now_ns() : 0;
+        const uint64_t dispatched_before = dispatched_total_.load(std::memory_order_relaxed);
+#endif
+
         // Hold loop_mu_ across the entire slot-touching body so quiescent
         // compaction cannot free TaskSlotStates while on_task_complete or
         // dispatch_ready is still reading them.
@@ -278,6 +298,7 @@ void Scheduler::run() {
         cfg_.manager->progress();
 
         // Phase 1: drain completions
+        [[maybe_unused]] uint64_t drained = 0;
         while (true) {
             WorkerCompletion completion;
             {
@@ -287,11 +308,35 @@ void Scheduler::run() {
                 completion_queue_.pop();
             }
             on_task_complete(completion);
+            drained++;
         }
+
+#if SIMPLER_HOST_STRACE
+        const int64_t drain_end_ns = trace_loop ? simpler::host_trace::now_ns() : 0;
+#endif
 
         // Phase 2: dispatch ready tasks. Once teardown publishes stop, the
         // existing endpoint-owned work drains but no new slot enters a worker.
         if (!stop_requested_.load(std::memory_order_acquire)) dispatch_ready();
+
+#if SIMPLER_HOST_STRACE
+        const uint64_t dispatched = dispatched_total_.load(std::memory_order_relaxed) - dispatched_before;
+        if (drained == 0 && dispatched == 0) {
+            spins++;
+        } else {
+            if (trace_loop) {
+                const int64_t loop_end_ns = simpler::host_trace::now_ns();
+                const std::string loop_attrs =
+                    "role=scheduler drained=" + std::to_string(drained) + " dispatched=" + std::to_string(dispatched) +
+                    " drain_ns=" + std::to_string(drain_end_ns - loop_start_ns) + " spins=" + std::to_string(spins);
+                simpler::host_trace::emit(
+                    simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::SchedulerLoop), 0, 0, 0,
+                    loop_start_ns, loop_end_ns - loop_start_ns, loop_attrs.c_str()
+                );
+            }
+            spins = 0;
+        }
+#endif
 
         // Exit when stop requested and all workers idle
         if (stop_requested_.load(std::memory_order_acquire)) {
@@ -459,6 +504,7 @@ bool claim_for_dispatch(TaskSlotState &s) {
 }
 
 void Scheduler::dispatch_claimed(WorkerThread *worker, WorkerDispatch dispatch, bool prepared) {
+    dispatched_total_.fetch_add(1, std::memory_order_relaxed);
     // The endpoint lane owns publication failure through one terminal callback.
     // Retrying here after that callback starts can duplicate a partially
     // published completion. The callback contract is the same non-throwing

--- a/src/common/hierarchical/scheduler.h
+++ b/src/common/hierarchical/scheduler.h
@@ -125,6 +125,9 @@ public:
     // Diagnostic only — counts dispatch passes so an observer can tell a parked
     // scheduler from one spinning on unplaceable work. Orders nothing.
     uint64_t dispatch_round_count() const { return dispatch_round_count_.load(std::memory_order_relaxed); }
+    // Diagnostic only — tasks actually handed to a worker, which a dispatch pass
+    // may do any number of times including none. Orders nothing.
+    uint64_t dispatched_total() const { return dispatched_total_.load(std::memory_order_relaxed); }
 
     // Called by WorkerManager after endpoint progress reaches a terminal outcome.
     void worker_done(WorkerCompletion completion);
@@ -167,6 +170,10 @@ private:
     };
 
     std::atomic<uint64_t> dispatch_round_count_{0};
+    // Tasks handed to a worker, counted at the one funnel every dispatch passes
+    // through. Atomic for the same reason as the round count above: the loop
+    // writes it on sched_thread_ while a reader is on another thread.
+    std::atomic<uint64_t> dispatched_total_{0};
     // sched_thread_ owns this: update_reservation_stall() writes it under
     // loop_mu_ and reservation_stall_deadline() reads it under completion_mu_,
     // which is only race-free because both run on that one thread. start()

--- a/src/common/log/include/common/host_span_names.h
+++ b/src/common/log/include/common/host_span_names.h
@@ -37,8 +37,8 @@
 
 namespace simpler::host_trace {
 
-/// The host-scheduler family. One entry per span the orchestrator or a worker
-/// thread emits; `kCount` sizes the resolved table.
+/// The host-scheduler family. One entry per span the orchestrator, a worker
+/// thread, or the scheduler loop emits; `kCount` sizes the resolved table.
 enum class HostSpan : size_t {
     GraphBuild = 0,
     Submit,
@@ -47,13 +47,15 @@ enum class HostSpan : size_t {
     Activate,
     Complete,
     PostFenceRetirement,
+    SchedulerLoop,
     kCount,
 };
 
 namespace detail {
 
 inline constexpr std::array<const char *, static_cast<size_t>(HostSpan::kCount)> kHostSpanSuffixes = {
-    ".graph_build", ".submit", ".dispatch", ".frame_submit", ".activate", ".complete", ".post_fence_retirement",
+    ".graph_build",           ".submit",         ".dispatch", ".frame_submit", ".activate", ".complete",
+    ".post_fence_retirement", ".scheduler_loop",
 };
 
 /// The bound level word. Defaults to `node`: L3 is the only level that has ever

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -2589,6 +2589,53 @@ TEST_F(SchedulerFixture, NextLevelSubmitEmitsAPairableHostSpan) {
     wait_consumed(submitted.task_slot);
 }
 
+// A dispatch pass the scheduler thread has completed since `before`, so a test
+// can assert on what an iteration did without a wall-clock budget deciding the
+// verdict: a loaded box waits longer here rather than failing.
+void wait_dispatch_round_after(Scheduler &sched, uint64_t before) {
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (sched.dispatch_round_count() == before) {
+        if (std::chrono::steady_clock::now() > deadline) {
+            FAIL() << "Scheduler ran no dispatch pass after being notified";
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+}
+
+TEST_F(SchedulerFixture, ADispatchingLoopIterationEmitsOneSpanCountingWhatItDid) {
+    ScopedHostSpanCapture host_span_capture;
+
+    auto submitted = orch.submit_next_level(C(0x42), single_tensor_args(0xCAFE, TensorArgType::OUTPUT), cfg, 0);
+    mock_worker.wait_running();
+    mock_worker.complete();
+    wait_consumed(submitted.task_slot);
+
+    const std::string loop_span = simpler::host_trace::host_span_name(simpler::host_trace::HostSpan::SchedulerLoop);
+    ASSERT_TRUE(captured_host_span(loop_span));
+    // The first one is the iteration that dispatched this task: nothing had
+    // completed yet, so it drained none, and `spins` counts the iterations
+    // before it that did neither.
+    const std::string attrs = captured_host_span_attrs(loop_span);
+    EXPECT_EQ(attrs.rfind("role=scheduler drained=0 dispatched=1 drain_ns=", 0), 0u) << attrs;
+    EXPECT_NE(attrs.find(" spins="), std::string::npos) << attrs;
+    EXPECT_EQ(sched.dispatched_total(), 1u);
+}
+
+TEST_F(SchedulerFixture, AnIterationThatNeitherDrainedNorDispatchedEmitsNothing) {
+    // A wake with nothing ready is an ordinary event — the loop also skips its
+    // wait entirely while any worker is busy — so an unbounded number of these
+    // iterations can run per unit of work. The round counter is the positive
+    // control: without it, a loop that never woke would pass this test.
+    ScopedHostSpanCapture host_span_capture;
+
+    const uint64_t rounds_before = sched.dispatch_round_count();
+    sched.notify_ready();
+    wait_dispatch_round_after(sched, rounds_before);
+
+    EXPECT_TRUE(captured_host_spans_empty());
+    EXPECT_EQ(sched.dispatched_total(), 0u);
+}
+
 TEST_F(SchedulerFixture, IndependentTaskDispatchedAndConsumed) {
     auto args_a = single_tensor_args(0xCAFE, TensorArgType::OUTPUT);
     auto res = orch.submit_next_level(C(42), args_a, cfg, 0);

--- a/tests/ut/py/test_strace_timing.py
+++ b/tests/ut/py/test_strace_timing.py
@@ -351,6 +351,45 @@ def test_host_swimlane_names_the_scheduler_lane_from_every_role_it_emits():
     assert thread_names == {(41, 411): "scheduler"}
 
 
+def test_a_scheduler_loop_span_lands_on_the_scheduler_lane_and_no_invocation():
+    """It is the one host span that belongs to no run, and both views must cope.
+
+    A loop iteration drains completions and dispatches tasks belonging to
+    whichever runs happened to be ready, so it carries no `run_id` and its `inv`
+    is 0 rather than a run epoch. The swimlane still has to place it — `role`
+    names the lane, which is why the attribute is there and not inferred from the
+    name — and the invocation-keyed views still have to leave it out, or every
+    one of them gains a forged invocation 0.
+    """
+    lines = [
+        _span_record(
+            pid=41,
+            tid=411,
+            inv=0,
+            name="node.scheduler_loop",
+            ts=1_400,
+            dur=120,
+            attrs="role=scheduler drained=2 dispatched=1 drain_ns=40 spins=917",
+        )
+    ]
+    spans = list(parse_spans(lines))
+
+    assert invocation_spans(spans) == []
+
+    trace = to_host_swimlane(spans)
+    thread_names = {
+        (event["pid"], event["tid"]): event["args"]["name"]
+        for event in trace["traceEvents"]
+        if event["ph"] == "M" and event["name"] == "thread_name"
+    }
+    assert thread_names == {(41, 411): "scheduler"}
+
+    slices = [event for event in trace["traceEvents"] if event["ph"] == "X"]
+    assert [event["name"] for event in slices] == ["node.scheduler_loop"]
+    assert slices[0]["args"]["spins"] == 917
+    assert slices[0]["args"]["drained"] == 2
+
+
 def test_parse_spans_decodes_percent_escaped_name_and_attribute_values():
     """`encode_host_span_field` escapes whatever would otherwise be record grammar."""
     lines = [


### PR DESCRIPTION
## Summary

The host swimlane covered every decision point *around* `Scheduler::run()` and nothing *inside* it, so a trace could show that a task was dispatched late but not whether the scheduler had no work, was slow to drain completions, or was slow to place them. `<level>.scheduler_loop` closes that — the last undelivered item of the host-swimlane design.

**One span per loop iteration that drained a completion or dispatched a task**, carrying four counters:

| Attribute | Meaning |
| --------- | ------- |
| `drained` `dispatched` | completions handled and tasks handed to a worker in this iteration |
| `drain_ns` | how much of the span was phase 1, so the two phases separate from one record |
| `spins` | iterations since the previous span that did neither |

### An iteration that did neither emits nothing, and that is the load-bearing decision

Not a volume optimization. `scheduler.cpp` skips its condition-variable wait entirely whenever any worker is busy, so while work is outstanding the loop spins at CPU speed and **its iteration count is bounded by nothing a trace can predict**. A span per iteration — or the wait/drain/dispatch triple the design originally proposed — would be unbounded per unit of work, and gating that behind a second verbosity tier hides the problem rather than solving it.

Nothing is lost by staying silent:

- The **gap** between two spans on the scheduler lane already *is* the wait. It is also a better reading than a `sched.wait` span, which could not have separated blocking in the condition variable from being descheduled either.
- `spins` reports how many empty iterations a gap contained, so the ratio the span cannot express survives **as a counter, at zero records**.
- One span with `drain_ns` separates the two phases from a single record, where nesting a drain span inside a dispatch span would have tripled the count to answer the same question.

Consequently this needs **no new verbosity tier, no new environment variable or macro, and no change to the span-level API**: the record volume is now the same order as the seven existing decision points, i.e. plain first-tier.

### Why this record family

`Scheduler::run()` lives in `src/common/hierarchical/`, which is runtime-agnostic, and `[STRACE]` host spans are already emitted from exactly that directory (`orchestrator.cpp`, `worker_manager.cpp` are the only two emitters in `src/`). The alternative carrier, `HostPhaseKind`, has all 23 of its producers under `src/a{2a3,5}/runtime/host_build_graph/` and its pool is armed and finished per prepare *pass*, while this loop outlives passes and idles between them.

### Renderer

Unchanged. The span carries no run key — a loop iteration serves whichever runs were ready, so `inv` is 0 rather than a run epoch, and `invocation_spans` already excludes the whole `node`/`network*` family from the invocation-keyed views for exactly this reason. `role=scheduler` is what places it, so `--swimlane` names its lane with no new code.

`dispatched_total()` counts at `dispatch_claimed`, the one funnel every dispatch passes through, which also makes the count assertable without capturing a log.

## Testing

- [x] `ctest` 119/119 (`-LE requires_hardware`). Two new cases on `SchedulerFixture`, which runs the real `Scheduler` on its real thread through a real dispatch and completion: one asserts the productive iteration's attributes and `dispatched_total() == 1`; the other asserts an iteration that woke and did nothing emits nothing, with `dispatch_round_count()` as the positive control so a loop that never woke cannot pass it. Neither verdict depends on beating a wall-clock deadline.
- [x] **Negative control**: inverting the emit condition reddens both new cases.
- [x] `pytest tests/ut/py` — 1947 passed, 18 skipped, including a new renderer case.
- [x] Simulation tests pass — `pytest examples tests/st --platform a2a3sim -m "not sdma"`, 0 failures.
- [x] Compiles clean under `-Wall -Wextra -Werror` with `SIMPLER_HOST_STRACE` both 0 and 1.
- [x] End-to-end through the real logger and the real renderer: the record comes out as

  ```text
  [STRACE] v=1 pid=… tid=… inv=0 hid=0 depth=0 name=node.scheduler_loop ts=1400 dur=120 role=scheduler drained=2 dispatched=1 drain_ns=40 spins=917
  ```

  and `--swimlane` places it on a lane named `scheduler` in a process labelled `simpler node`, with all four counters as typed `args`.
- [ ] Hardware tests pass — **not run.** Also not obtainable through the scene harness: it swallows child stderr, so all 68 collected `a2a3sim` cases produce zero `[STRACE]` records, which is pre-existing and equally true of the seven existing host spans.

Part of #1708; the host-side half of #1792's "one grammar" question is discussed in the record-family note above.