### PR TITLE
Docs: replace an unreproducible dsv4 bind-phase baseline

### DIFF
--- a/docs/dfx/hbg-bind-phases.md
+++ b/docs/dfx/hbg-bind-phases.md
@@ -374,10 +374,13 @@ scale.** Both are per-byte costs over what a bind stages, and dsv4's parameters
 now live in child memory: allocated once before the first round, and passed
 through without malloc, H2D or a host view. What still crosses is
 `num_tokens_per_owner`, the one caller tensor the host orchestrator has to read —
-so a bind stages **1 of its 92 tensors, 8 bytes**. Before the caller-buffer view
-change, the same recipe on `f830f13c3` plus the child-memory change measured
-`args` at 0.045–0.074 ms and `host_view_close` at 0.014–0.028 ms, against 1.48 s
-and 0.28 s over 45.8 GB above. qwen still stages its fixture.
+so a bind stages **1 of its 92 tensors, 8 bytes**. On `dcf7559e8`, 12 binds
+(`--rounds 6`, both ranks) measure `args` at 0.036–0.075 ms and
+`host_view_close` at 0.0012–0.0030 ms with `count=0 bytes=0`, against 1.48 s and
+0.28 s over 45.8 GB above. The same run peaks at 1.31 GiB of host RSS across the
+whole process tree under `--skip-golden`, and at 23.4 GiB when the fixture is
+streamed in, where the row above cost ~45.5 GB per rank. qwen still stages its
+fixture.
 
 The rows also describe the legacy mapping behavior at the pinned commit. A
 current bind uses the caller's existing host buffers as its


### PR DESCRIPTION
## Summary

`docs/dfx/hbg-bind-phases.md` corrects two rows of its pinned table — dsv4's
`args` and `host_view_close` — in a paragraph that tells the reader what to
expect on a current tree. Both of its figures were unusable for that:

- The baseline was `f830f13c3` **plus a then-uncommitted child-memory change**,
  so it cannot be reproduced from any commit in the tree.
- `host_view_close` was measured before #1973 removed the `halHostRegister`
  side, leaving it an order of magnitude high. A reader A/B-ing against
  0.014–0.028 ms today reads a 10x regression where there is none.

Both now come from the merged tree at `dcf7559e8`, 12 binds over two ranks at
`--rounds 6`: `args` 0.036–0.075 ms, `host_view_close` 0.0012–0.0030 ms with
`count=0 bytes=0`. #2022 established that giving a phase's counters the span its
clock covers changes what the numbers mean and not their values, so these remain
the current figures and were not re-measured on top of it.

Peak host RSS is recorded beside them, because the rows being corrected are
per-byte costs over what a bind stages: **1.31 GiB** across the whole process
tree under `--skip-golden` and **23.4 GiB** when the fixture is streamed in,
against the ~45.5 GB per rank the pinned row cost. That also retires the local
note that dsv4 was SIGKILLed at `--rounds 6` — both modes now complete six
rounds with exit 0.

**The pinned table itself is untouched.** It is anchored to `777d4171` on
purpose and says so ("For orientation, not thresholds … Re-measure rather than
trusting this table"), so refreshing its rows would work against its intent.
Only the paragraph that speaks for the current tree is changed.

## Testing

- [x] `markdownlint-cli2 --config tests/lint/.markdownlint.yaml` — 0 errors
- [x] `tests/lint/check_retired_names.py` — clean
- [x] Figures measured on `dcf7559e8` via the doc's own recipe, two arms,
      `task-submit --device auto --device-num 2`, 12 binds each

Docs-only; no code path is touched.
