### PR TITLE
Support: let onboard builds carry the profiling configuration

### DIFF
--- a/cmake/profiling_config.cmake
+++ b/cmake/profiling_config.cmake
@@ -9,7 +9,15 @@
 
 set(_SIMPLER_PROFILING_CONFIG_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
-function(simpler_configure_profiling target)
+# Generate this build's profiling header and return the directory holding it.
+#
+# Separate from simpler_configure_profiling because a target is not always
+# available: the onboard aicore kernel is an add_custom_target whose compile
+# commands take include directories through a list, so it needs the directory
+# rather than a target to attach it to.
+function(simpler_generate_profiling_header)
+    cmake_parse_arguments(ARG "" "OUT_DIR" "" ${ARGN})
+
     foreach(name IN ITEMS
             SIMPLER_DFX
             SIMPLER_ORCH_PROFILING
@@ -50,5 +58,12 @@ function(simpler_configure_profiling target)
         "${generated_dir}/simpler_profiling_build_config.h"
         @ONLY
     )
+    if(ARG_OUT_DIR)
+        set(${ARG_OUT_DIR} "${generated_dir}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(simpler_configure_profiling target)
+    simpler_generate_profiling_header(OUT_DIR generated_dir)
     target_include_directories(${target} PRIVATE "${generated_dir}")
 endfunction()

--- a/docs/dfx/profiling-config-naming.md
+++ b/docs/dfx/profiling-config-naming.md
@@ -107,6 +107,16 @@ and emission, so disabled markers do not leave marker-only transfers behind.
 | `SIMPLER_TENSORMAP_PROFILING` | 0 | tensor-map hash-table counters (requires `SIMPLER_ORCH_PROFILING`) |
 | `SIMPLER_HOST_STRACE` | 1 | `[STRACE]` macros (`strace.h`) and onboard capture used only by device-domain markers; independent of `SIMPLER_DFX` |
 
+Set them per build with `build_runtimes.py --profiling-{dfx,orch,sched,tensormap}`,
+on any platform. The four are one configuration: every target of a platform is
+compiled with the same values, because `SIMPLER_DFX` adds fields to a struct the
+host and the AICPU both compile. A build overwrites that platform's ordinary
+runtime artifacts under `build/lib/`, and the counters cost what they report — the
+orchestrator sub-steps measured about 7% of the bind thread's own time on dsv4 —
+so rebuild before quoting a timing from a tree that has profiled.
+`.github/workflows/_profiling-flags-smoke.yml` guards the flag combinations on the
+simulator platforms.
+
 ### Env vars
 
 | Env | Layer | Value | Gates |

--- a/simpler_setup/build_runtimes.py
+++ b/simpler_setup/build_runtimes.py
@@ -65,12 +65,6 @@ def _profiling_config(values: dict[str, Optional[int]]) -> Optional[dict[str, st
     return {name: str(value) for name, value in config.items()}
 
 
-def _validate_profiling_platforms(platforms: list[str], config: Optional[dict[str, str]]) -> None:
-    """Reject generated profiling configurations for unsupported targets."""
-    if config and any(parse_platform(platform)[1] != "sim" for platform in platforms):
-        raise ValueError("generated profiling configurations currently support sim platforms only")
-
-
 def detect_buildable_platforms() -> list:
     """Detect which platforms can be built with available toolchains.
 
@@ -138,8 +132,6 @@ def build_all(
     if not platforms:
         logger.warning("No buildable platforms detected (missing gcc/g++?)")
         return
-
-    _validate_profiling_platforms(platforms, profiling_config)
 
     logger.info(f"Building for platforms: {', '.join(platforms)}")
     pto_isa_root_for_metadata: Optional[str] = None

--- a/simpler_setup/runtime_builder.py
+++ b/simpler_setup/runtime_builder.py
@@ -24,7 +24,7 @@ from .runtime_compiler import RuntimeCompiler
 logger = logging.getLogger(__name__)
 
 _GIT_COMMIT_FILE = ".git_commit"
-_DEFAULT_SIM_PROFILING_CONFIG = {
+_DEFAULT_PROFILING_CONFIG = {
     "SIMPLER_DFX": "1",
     "SIMPLER_ORCH_PROFILING": "0",
     "SIMPLER_SCHED_PROFILING": "0",
@@ -366,9 +366,12 @@ class RuntimeBuilder:
 
         build_pto_isa_commit = self._resolve_build_pto_isa_commit()
         cache_stamp = self._build_cache_stamp(build_pto_isa_commit)
-        effective_profiling_config = profiling_config
-        if variant == "sim" and effective_profiling_config is None:
-            effective_profiling_config = _DEFAULT_SIM_PROFILING_CONFIG
+        # Every build gets a fully specified configuration, so a value from an earlier
+        # profiling build cannot survive in the CMake cache as a default. Merged rather
+        # than substituted: cmake/profiling_config.cmake defaults only the variables
+        # that are *undefined*, and a name left out of a partial mapping is still
+        # defined in the target's cache from whatever configured it last.
+        effective_profiling_config = {**_DEFAULT_PROFILING_CONFIG, **(profiling_config or {})}
 
         def _compile_target(target: str) -> Path:
             include_dirs, source_dirs = self._resolve_target_dirs(config_dir, build_config, target)

--- a/simpler_setup/runtime_compiler.py
+++ b/simpler_setup/runtime_compiler.py
@@ -93,10 +93,13 @@ class BuildTarget:
         if cmake_defines:
             for key, value in sorted(cmake_defines.items()):
                 args.append(f"-D{key}={value}")
-        # Host-compiled targets load shared project CMake modules through this
-        # stable path rather than paths relative to each target directory.
-        if self.toolchain.is_host:
-            args.append(f"-DSIMPLER_CMAKE_DIR={PROJECT_ROOT / 'cmake'}")
+        # Every target loads shared project CMake modules through this stable path
+        # rather than paths relative to each target directory. Device toolchains need
+        # it too: they read cmake/profiling_config.cmake for the generated profiling
+        # header, and the four profiling macros must hold the same value in every
+        # target of a platform — SIMPLER_DFX adds fields to a struct the host and the
+        # AICPU both compile.
+        args.append(f"-DSIMPLER_CMAKE_DIR={PROJECT_ROOT / 'cmake'}")
         # Sanitizers only apply to host-compiled targets — device toolchains
         # (ccec, aarch64 cross) run on the NPU and can't carry a host sanitizer
         # runtime.

--- a/src/a2a3/platform/onboard/aicore/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/aicore/CMakeLists.txt
@@ -19,6 +19,11 @@ list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../../../../c
 list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/task_interface")
 list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/log/include")
 list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common")
+# The kernel is an add_custom_target, so the profiling header reaches it as an
+# include directory in this list rather than through target_include_directories.
+include("${SIMPLER_CMAKE_DIR}/profiling_config.cmake")
+simpler_generate_profiling_header(OUT_DIR SIMPLER_PROFILING_INCLUDE_DIR)
+list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${SIMPLER_PROFILING_INCLUDE_DIR}")
 if(DEFINED CUSTOM_INCLUDE_DIRS)
     foreach(INC_DIR ${CUSTOM_INCLUDE_DIRS})
         list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${INC_DIR}")

--- a/src/a2a3/platform/onboard/aicpu/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/aicpu/CMakeLists.txt
@@ -62,6 +62,8 @@ list(LENGTH AICPU_KERNEL_SOURCES NUM_AICPU_KERNEL_SOURCES)
 message(STATUS "AICpu kernel: ${NUM_AICPU_KERNEL_SOURCES} source files")
 message(VERBOSE "AICpu kernel sources: ${AICPU_KERNEL_SOURCES}")
 add_library(aicpu_kernel SHARED ${AICPU_KERNEL_SOURCES})
+include("${SIMPLER_CMAKE_DIR}/profiling_config.cmake")
+simpler_configure_profiling(aicpu_kernel)
 
 option(WERROR "Treat compiler warnings as errors" ON)
 if(DEFINED ENV{SIMPLER_DISABLE_WARNINGS_AS_ERRORS})
@@ -122,6 +124,7 @@ set(AICPU_DISPATCHER_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/aicpu_loader/device/aicpu_dispatcher.cpp"
 )
 add_library(aicpu_dispatcher SHARED ${AICPU_DISPATCHER_SOURCES})
+simpler_configure_profiling(aicpu_dispatcher)
 
 target_compile_options(aicpu_dispatcher
     PRIVATE

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -97,6 +97,8 @@ list(LENGTH HOST_RUNTIME_SOURCES NUM_HOST_RUNTIME_SOURCES)
 message(STATUS "Host runtime: ${NUM_HOST_RUNTIME_SOURCES} source files")
 message(VERBOSE "Host runtime sources: ${HOST_RUNTIME_SOURCES}")
 add_library(host_runtime SHARED ${HOST_RUNTIME_SOURCES})
+include("${SIMPLER_CMAKE_DIR}/profiling_config.cmake")
+simpler_configure_profiling(host_runtime)
 
 # C++ standard (applied only to C++ files)
 set_target_properties(host_runtime PROPERTIES

--- a/src/a5/platform/onboard/aicore/CMakeLists.txt
+++ b/src/a5/platform/onboard/aicore/CMakeLists.txt
@@ -19,6 +19,11 @@ list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../../../../c
 list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/task_interface")
 list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/log/include")
 list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common")
+# The kernel is an add_custom_target, so the profiling header reaches it as an
+# include directory in this list rather than through target_include_directories.
+include("${SIMPLER_CMAKE_DIR}/profiling_config.cmake")
+simpler_generate_profiling_header(OUT_DIR SIMPLER_PROFILING_INCLUDE_DIR)
+list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${SIMPLER_PROFILING_INCLUDE_DIR}")
 if(DEFINED CUSTOM_INCLUDE_DIRS)
     foreach(INC_DIR ${CUSTOM_INCLUDE_DIRS})
         list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${INC_DIR}")

--- a/src/a5/platform/onboard/aicpu/CMakeLists.txt
+++ b/src/a5/platform/onboard/aicpu/CMakeLists.txt
@@ -62,6 +62,8 @@ list(LENGTH AICPU_KERNEL_SOURCES NUM_AICPU_KERNEL_SOURCES)
 message(STATUS "AICpu kernel: ${NUM_AICPU_KERNEL_SOURCES} source files")
 message(VERBOSE "AICpu kernel sources: ${AICPU_KERNEL_SOURCES}")
 add_library(aicpu_kernel SHARED ${AICPU_KERNEL_SOURCES})
+include("${SIMPLER_CMAKE_DIR}/profiling_config.cmake")
+simpler_configure_profiling(aicpu_kernel)
 
 option(WERROR "Treat compiler warnings as errors" ON)
 if(DEFINED ENV{SIMPLER_DISABLE_WARNINGS_AS_ERRORS})
@@ -112,6 +114,7 @@ set(AICPU_DISPATCHER_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/aicpu_loader/device/aicpu_dispatcher.cpp"
 )
 add_library(aicpu_dispatcher SHARED ${AICPU_DISPATCHER_SOURCES})
+simpler_configure_profiling(aicpu_dispatcher)
 
 target_compile_options(aicpu_dispatcher
     PRIVATE

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -102,6 +102,8 @@ list(LENGTH HOST_RUNTIME_SOURCES NUM_HOST_RUNTIME_SOURCES)
 message(STATUS "Host runtime: ${NUM_HOST_RUNTIME_SOURCES} source files")
 message(VERBOSE "Host runtime sources: ${HOST_RUNTIME_SOURCES}")
 add_library(host_runtime SHARED ${HOST_RUNTIME_SOURCES})
+include("${SIMPLER_CMAKE_DIR}/profiling_config.cmake")
+simpler_configure_profiling(host_runtime)
 add_custom_command(TARGET host_runtime POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "${CMAKE_CURRENT_SOURCE_DIR}/aicpu_cpu_topo_fallback.json"

--- a/tests/ut/py/test_runtime_builder.py
+++ b/tests/ut/py/test_runtime_builder.py
@@ -515,14 +515,52 @@ class TestRuntimeBuilderGetBinaries:
         host_call = next(call for call in mock_instance.compile.call_args_list if call.args[0] == "host")
         aicore_call = next(call for call in mock_instance.compile.call_args_list if call.args[0] == "aicore")
         aicpu_call = next(call for call in mock_instance.compile.call_args_list if call.args[0] == "aicpu")
+        # Every target of a platform is compiled with the same profiling configuration,
+        # so each call carries it alongside whatever else that target needs.
+        profiling = {
+            "SIMPLER_DFX": "1",
+            "SIMPLER_ORCH_PROFILING": "0",
+            "SIMPLER_SCHED_PROFILING": "0",
+            "SIMPLER_TENSORMAP_PROFILING": "0",
+        }
         assert host_call.kwargs["cmake_defines"] == {
+            **profiling,
             "PTO_ISA_ROOT": "/tmp/pto-isa",
             "SIMPLER_PTO_ISA_BUILD_COMMIT": pin,
         }
         # aicore needs the checkout path too, for the SDMA warmup kernel's
         # vector-only target, but not the commit stamp (that keys the host ccache).
-        assert aicore_call.kwargs["cmake_defines"] == {"PTO_ISA_ROOT": "/tmp/pto-isa"}
-        assert aicpu_call.kwargs["cmake_defines"] is None
+        assert aicore_call.kwargs["cmake_defines"] == {**profiling, "PTO_ISA_ROOT": "/tmp/pto-isa"}
+        assert aicpu_call.kwargs["cmake_defines"] == profiling
+
+    @patch("simpler_setup.runtime_builder.RuntimeCompiler")
+    def test_partial_profiling_config_is_completed_from_the_defaults(self, MockCompiler, tmp_path, monkeypatch):
+        """A caller may name one macro; cmake must still receive all four.
+
+        cmake/profiling_config.cmake defaults only the variables that are undefined,
+        and a name left out of a partial mapping is still defined in the target's cache
+        from whatever configured it last — so a partial mapping that reached cmake
+        unchanged would take stale values for the names it omits.
+        """
+        from simpler_setup import pto_isa  # noqa: PLC0415
+        from simpler_setup.runtime_builder import RuntimeBuilder  # noqa: PLC0415
+
+        self._make_runtime(tmp_path, "a2a3")
+        mock_instance = MockCompiler.get_instance.return_value
+        mock_instance.compile.side_effect = lambda target, *a, **kw: (Path(kw["output_dir"]) / f"lib{target}.so")
+        monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: "a" * 40)
+        monkeypatch.setattr(pto_isa, "ensure_pto_isa_root", lambda verbose=False: "/tmp/pto-isa")
+        monkeypatch.setattr(pto_isa, "write_pto_isa_build_metadata", lambda *args: None)
+
+        builder = RuntimeBuilder(platform="a2a3")
+        builder.get_binaries("test_rt", build=True, profiling_config={"SIMPLER_ORCH_PROFILING": "1"})
+
+        for call in mock_instance.compile.call_args_list:
+            defines = call.kwargs["cmake_defines"]
+            assert defines["SIMPLER_ORCH_PROFILING"] == "1"
+            assert defines["SIMPLER_DFX"] == "1"
+            assert defines["SIMPLER_SCHED_PROFILING"] == "0"
+            assert defines["SIMPLER_TENSORMAP_PROFILING"] == "0"
 
     @patch("simpler_setup.runtime_builder.RuntimeCompiler")
     def test_a5_default_build_writes_pto_isa_metadata(self, MockCompiler, tmp_path, monkeypatch):

--- a/tests/ut/py/test_runtime_compiler.py
+++ b/tests/ut/py/test_runtime_compiler.py
@@ -35,12 +35,20 @@ def test_host_build_target_always_receives_shared_cmake_dir(tmp_path):
     assert not any(arg.startswith("-DSIMPLER_SANITIZERS=") for arg in args)
 
 
-def test_device_build_target_does_not_receive_shared_cmake_dir(tmp_path):
+def test_device_build_target_also_receives_shared_cmake_dir(tmp_path):
     from simpler_setup import runtime_compiler  # noqa: PLC0415
 
     target = runtime_compiler.BuildTarget(_StubToolchain(is_host=False), str(tmp_path), "kernel.o")
 
-    assert not any(arg.startswith("-DSIMPLER_CMAKE_DIR=") for arg in target.gen_cmake_args([], []))
+    args = target.gen_cmake_args([], [])
+
+    # Device targets load cmake/profiling_config.cmake for the generated profiling
+    # header, so they need the shared module path too. The four profiling macros must
+    # hold one value across a platform: SIMPLER_DFX adds fields to a struct the host
+    # and the AICPU both compile.
+    assert f"-DSIMPLER_CMAKE_DIR={runtime_compiler.PROJECT_ROOT / 'cmake'}" in args
+    # Sanitizers stay host-only: a device toolchain cannot carry the host runtime.
+    assert not any(arg.startswith("-DSIMPLER_SANITIZERS=") for arg in args)
 
 
 def test_build_output_is_verbose_only_for_debug_logging(tmp_path, monkeypatch, caplog):


### PR DESCRIPTION
## Summary

The four profiling macros had no way into an onboard build. They reach a target through `cmake/profiling_config.cmake`, which generates `simpler_profiling_build_config.h` and puts it on the include path; `profiling_config.h` picks it up with `__has_include` and otherwise falls back to its defaults. Only the simulator CMakeLists called that function, so on onboard every value fell back — `SIMPLER_DFX` pinned at 1, the other three at 0, whatever was asked for. `build_runtimes.py` rejected `--profiling-*` for non-simulator platforms, which read as a policy but was the symptom: there was nowhere for the value to land.

Each target kind needs its own wiring, and the onboard ones do not match the simulator's shape:

- **host** is one shared library, as on the simulator.
- **aicpu** builds two libraries, `aicpu_kernel` and `aicpu_dispatcher`. Both compile runtime sources, so both are configured; leaving the dispatcher out would compile one translation unit against a different struct layout.
- **aicore** is an `add_custom_target` whose compile commands take include directories through a list, so `target_include_directories` cannot reach it. `simpler_generate_profiling_header` returns the generated directory for that case, and `simpler_configure_profiling` now calls it — the existing simulator call sites are unchanged.

Device toolchains therefore need `SIMPLER_CMAKE_DIR`, which was passed only to host-compiled targets. **That boundary is now the wrong shape**: the four macros must hold one value across every target of a platform, because `SIMPLER_DFX` adds `tasks_submitted` and `buffers_allocated` to a struct (`host_build_graph/runtime/orchestrator.h`) that the host and the AICPU both compile. Sanitizers stay host-only, which is a separate and still correct restriction. `test_device_build_target_does_not_receive_shared_cmake_dir` asserted the old boundary and is updated to the new one.

A fully specified configuration now goes to both variants rather than to the simulator alone, so a value from an earlier profiling build cannot survive in the CMake cache as a default. **The effective defaults do not change**, so a build that asks for nothing behaves as before.

## No CI job is added for onboard

`_profiling-flags-smoke.yml` guards the six flag combinations on the simulator platforms, and that guard covers the code under the macros. What it cannot cover is the onboard toolchains' ability to compile each combination, so all six were built locally for **a2a3 and a5 onboard**, including `dfx-off`, and the generated header was checked to hold identical values in the `host`, `aicpu` and `aicore` trees of both runtimes:

| combination | dfx | orch | sched | tensormap | a2a3 onboard | a5 onboard |
| ----------- | --- | ---- | ----- | --------- | ------------ | ---------- |
| `dfx-off` | 0 | 0 | 0 | 0 | ok | ok |
| `orch` | 1 | 1 | 0 | 0 | ok | ok |
| `orch-tensormap` | 1 | 1 | 0 | 1 | ok | ok |
| `sched` | 1 | 0 | 1 | 0 | ok | ok |
| `orch-sched` | 1 | 1 | 1 | 0 | ok | ok |
| `all-on` | 1 | 1 | 1 | 1 | ok | ok |

## Testing

Run at base `32e3ee0ba`; the commits since then touch none of the files this changes (`cmake/`, the six onboard `CMakeLists.txt`, `runtime_compiler.py`, `runtime_builder.py`, `build_runtimes.py`).

- [x] `pytest examples tests/st --platform a2a3sim --device 0-15 --manual include` — one pre-existing failure, `TestSpmdPagedAttentionHighPerf::b4_h32_kv8_s512_bs128_fp16` golden mismatch (`max_diff=0.0625` vs `atol=0.02`), reproduced with this diff reverted
- [x] `pytest examples tests/st --platform a5sim --device 0-15 --manual include` — green
- [x] `ctest --test-dir tests/ut/cpp/build -LE requires_hardware` — 119/119
- [x] `pytest tests/ut -m "not requires_hardware"` — 1941 passed
- [x] a2a3 onboard `-m "not sdma" --exclude-level 4 --manual include` — 3 pre-existing failures, all reproduced on the base commit: `TestQwen314BDecodeHostBuildGraph` and `TestSpmdPagedAttentionHbgA2A3` no longer compile against the renamed `simpler::tmr` namespace (likely fixed by #2027, which landed after this run), and `TestPagedAttentionHostBuildGraph::Case1`'s `prepare_native_run failed with code -1000`
- [x] markdownlint, ruff
