### PR TITLE
Fix: sum a phase's detail only where detail counts something

### DIFF
--- a/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
@@ -259,6 +259,29 @@ The last three come from the generated orchestration `.so` rather than the runti
 through the ops table's `record_orch_phase`, so they carry submit group 0 rather
 than the submission they belong to.
 
+### A phase is an interval; a quantity is an attribute
+
+The two shapes of information on this path are not interchangeable, and choosing
+the wrong one produces a number that reads as data and is not:
+
+- **A record is an interval** — one operation, start to end. Its `detail` says
+  *which* operation (a task id, a Graph key, the submission index) or *how much*
+  it covered (`build_definition`'s node count, `recording_wait`'s in-flight
+  count). That is the whole contract.
+- **A quantity about a segment is an attribute** — `bytes=`, `heap_used=`,
+  `spilled=`, `minflt=`, `nvcsw=`. It goes in the segment's attribute string,
+  which is what the `bind phase=` line prints.
+
+So: **a new interval to name earns a new kind; a new quantity about an interval
+that already exists is an attribute on it.** Adding a kind to carry a statistic
+puts a measurement into the timeline where a reader expects a duration, and the
+breakdown will then sum it.
+
+Which is exactly why `detail` is summed only where it counts something
+(`host_phase_kind_detail_is_quantity`). Nine of the eleven orchestrator kinds
+carry an identity, and a sum over identities — task ids added together — was
+printed as `detail_sum` for as long as the column was unconditional.
+
 ### The three switches
 
 | Switch | Turns on |

--- a/src/a2a3/runtime/host_build_graph/host/host_phase_trace.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/host_phase_trace.cpp
@@ -38,17 +38,6 @@
 
 namespace {
 
-// Bind segments carry a few attributes each beyond their duration (byte counts,
-// tensor counts, this thread's fault and context-switch deltas). They are formatted
-// when the segment ends and printed at flush, so a segment's values need not outlive
-// it and the log write stays off the measured path.
-//
-// Sized to the widest buffer any caller formats into (`char attrs[224]` in
-// runtime_maker.cpp), not to what a run happens to produce: the copy in below
-// truncates silently, and the widest segment already formats 86 bytes, so a workload
-// with one wider counter would drop a trailing attribute with nothing to say it had.
-constexpr size_t kBindAttrsCapacity = 224;
-
 // One producer's counters and in-flight claim, on its own cache lines.
 //
 // The producers of a bind are independent -- each records its own Definition and
@@ -99,6 +88,12 @@ struct TraceState {
     std::mutex lifecycle_mutex;
     std::atomic<uint64_t> submitted_tasks{0};
     std::array<ProducerLane, kProducerLanes> lanes;
+    // Each bind segment's attributes beyond its duration (byte counts, tensor
+    // counts, this thread's fault and context-switch deltas), formatted when the
+    // segment ends and printed at flush -- so a segment's values need not outlive
+    // it and the log write stays off the measured path. `kBindAttrsCapacity` is
+    // shared with every caller that formats one, because the copy in truncates
+    // silently.
     std::array<std::array<char, kBindAttrsCapacity>, kHostPhaseKindCount> bind_attrs;
 };
 
@@ -407,10 +402,22 @@ void host_phase_trace_end() {
         // A summed cost share, not an interval: several of these kinds are
         // sub-operations of another, so there is no honest way to draw the total
         // on a timeline. Per-event bars come from the artifact instead.
+        //
+        // `detail_sum` appears only where `detail` counts something. The other
+        // kinds put the identity of what they measured there — a task id, a Graph
+        // key, the submission index — and printing a sum of identities invites a
+        // reader to act on a number that means nothing.
+        if (host_phase_kind_detail_is_quantity(static_cast<HostPhaseKind>(kind))) {
+            LOG_TIMING(
+                "host-orch phase=%s total_ns=%llu count=%llu detail_sum=%llu dropped=%llu", name,
+                static_cast<unsigned long long>(total_ns), static_cast<unsigned long long>(count),
+                static_cast<unsigned long long>(payload_sum), static_cast<unsigned long long>(dropped)
+            );
+            continue;
+        }
         LOG_TIMING(
-            "host-orch phase=%s total_ns=%llu count=%llu detail_sum=%llu dropped=%llu", name,
-            static_cast<unsigned long long>(total_ns), static_cast<unsigned long long>(count),
-            static_cast<unsigned long long>(payload_sum), static_cast<unsigned long long>(dropped)
+            "host-orch phase=%s total_ns=%llu count=%llu dropped=%llu", name, static_cast<unsigned long long>(total_ns),
+            static_cast<unsigned long long>(count), static_cast<unsigned long long>(dropped)
         );
     }
 }

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -191,7 +191,7 @@ static void record_bind_phase(HostPhaseKind kind, int64_t start_ns, const char *
     auto since = [](uint64_t current, uint64_t mark) {
         return current >= mark ? current - mark : 0;
     };
-    char with_counters[352];
+    char with_counters[kBindAttrsCapacity];
     snprintf(
         with_counters, sizeof(with_counters), "%s%sminflt=%" PRIu64 " nivcsw=%" PRIu64 " nvcsw=%" PRIu64, attrs,
         *attrs == '\0' ? "" : " ", since(now.minflt, g_bind_counter_mark.minflt),
@@ -656,7 +656,7 @@ int32_t run_host_orchestration(
 
     const int32_t total_tasks = orchestrator.task_allocator.active_count();
     {
-        char attrs[160];
+        char attrs[kBindAttrsCapacity];
         snprintf(
             attrs, sizeof(attrs), "tasks=%" PRId32 " heap_used=%" PRIu64 " sm_mirror=%" PRIu64, total_tasks,
             orchestrator.task_allocator.heap_used_bytes(), sm_size
@@ -681,7 +681,7 @@ int32_t run_host_orchestration(
         // objects the recorders could not build in the block, and so is 0 for a bind
         // the retained staging was big enough for. It is deliberately not spelled
         // `copied=`, which on arena_h2d means a zone rather than a count.
-        char attrs[128];
+        char attrs[kBindAttrsCapacity];
         snprintf(
             attrs, sizeof(attrs), "defs=%zu bytes=%" PRIu64 " submissions=%zu spilled=%zu", definition_uploads.count,
             definition_uploads.bytes, graph_host_upload_count(*graph_state), definition_uploads.spilled
@@ -758,7 +758,7 @@ int32_t run_host_orchestration(
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
-        char attrs[96];
+        char attrs[kBindAttrsCapacity];
         snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " arena=%" PRIu64, heap_bytes, device_arena_bytes);
         record_bind_phase(HostPhaseKind::BindStaticArena, t_static_arena_ns, attrs);
     }
@@ -773,7 +773,7 @@ int32_t run_host_orchestration(
     void *device_sm = arena_dev + layout.off_copied_end;
     runtime->set_gm_sm_ptr(device_sm);
     {
-        char attrs[96];
+        char attrs[kBindAttrsCapacity];
         snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, image_bytes);
         record_bind_phase(HostPhaseKind::BindSharedMem, t_sm_ns, attrs, image_bytes);
     }
@@ -836,9 +836,9 @@ int32_t run_host_orchestration(
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
-        // Eight uint64 fields plus their labels; 96 would truncate the trailing
-        // `args=` counts on a large bind, which are the ones this marker exists for.
-        char attrs[224];
+        // The widest attribute string a segment formats: eight uint64 fields plus
+        // their labels, which is what sets kBindAttrsCapacity's margin.
+        char attrs[kBindAttrsCapacity];
         snprintf(
             attrs, sizeof(attrs),
             "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " args=%" PRIu64 "/%" PRIu64 "/%" PRIu64,
@@ -1115,7 +1115,7 @@ extern "C" int bind_callable_to_runtime_impl(
         device_args.add_scalar(orch_args->scalar(i));
     }
     {
-        char attrs[128];
+        char attrs[kBindAttrsCapacity];
         snprintf(
             attrs, sizeof(attrs), "ntensor=%d staged=%d bytes=%" PRIu64, tensor_count, staged_tensors, staged_bytes
         );
@@ -1141,7 +1141,7 @@ extern "C" int bind_callable_to_runtime_impl(
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
-        char attrs[64];
+        char attrs[kBindAttrsCapacity];
         snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, static_cast<uint64_t>(layout.arena_size));
         record_bind_phase(HostPhaseKind::BindArenaBuild, t_arena_build_ns, attrs);
     }
@@ -1200,7 +1200,7 @@ extern "C" int bind_callable_to_runtime_impl(
         const int64_t t_view_close_ns = bind_phase_begin();
         tensor_access.close();
         {
-            char attrs[96];
+            char attrs[kBindAttrsCapacity];
             snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, view_count, view_bytes);
             record_bind_phase(HostPhaseKind::BindHostViewClose, t_view_close_ns, attrs);
         }

--- a/src/a2a3/runtime/host_build_graph/runtime/host_phase_trace.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/host_phase_trace.h
@@ -11,7 +11,25 @@
 
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
+
+/**
+ * One bind segment's attribute string, for every buffer on the path from the
+ * caller that formats it to the store that holds it until flush.
+ *
+ * It is one number rather than a size per buffer because the two ends have to
+ * agree: a caller formats its own attributes and then `record_bind_phase`
+ * appends this thread's fault and context-switch deltas, and the store copies
+ * the result in with `snprintf`, which truncates in silence. Nine separate
+ * literals cannot state that relationship, and the widest of them was already
+ * larger than the store.
+ *
+ * The margin is deliberate: the widest segment formats about 100 bytes today
+ * (`arena_h2d`'s itemized upload plus the counters), so a workload whose counts
+ * grow a digit does not start dropping a trailing attribute.
+ */
+constexpr size_t kBindAttrsCapacity = 256;
 
 /**
  * Timing of this runtime's prepare path: the bind stage's segments and the host
@@ -76,7 +94,16 @@ uint64_t host_phase_now_ns();
  * orchestrator core declares a weak fallback for this function and is also
  * compiled for the AICPU, where the platform's host headers are absent.
  *
- * @param payload  task id for the kinds that submit a task, else a detail count
+ * A record is an **interval**: this kind's operation, from when it started to
+ * when it ended. `payload` says which one — a task id, a Graph key, the
+ * submission index — or counts what the interval covered, and nothing else. It
+ * is not a slot for a second measurement over the same window: a quantity about
+ * a segment (bytes moved, faults taken, memory used) belongs in that segment's
+ * attribute string, which `host_phase_record_bind` carries and the breakdown
+ * line prints. `host_phase_kind_detail_is_quantity` is what decides whether the
+ * breakdown may sum this field at all.
+ *
+ * @param payload  which operation this interval was, or how much it covered
  * @param index    submit_idx for orchestrator operations, 0 for bind segments
  */
 void host_phase_record(uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload, uint32_t index);

--- a/src/a5/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a5/runtime/host_build_graph/docs/profiling_levels.md
@@ -259,6 +259,29 @@ The last three come from the generated orchestration `.so` rather than the runti
 through the ops table's `record_orch_phase`, so they carry submit group 0 rather
 than the submission they belong to.
 
+### A phase is an interval; a quantity is an attribute
+
+The two shapes of information on this path are not interchangeable, and choosing
+the wrong one produces a number that reads as data and is not:
+
+- **A record is an interval** — one operation, start to end. Its `detail` says
+  *which* operation (a task id, a Graph key, the submission index) or *how much*
+  it covered (`build_definition`'s node count, `recording_wait`'s in-flight
+  count). That is the whole contract.
+- **A quantity about a segment is an attribute** — `bytes=`, `heap_used=`,
+  `spilled=`, `minflt=`, `nvcsw=`. It goes in the segment's attribute string,
+  which is what the `bind phase=` line prints.
+
+So: **a new interval to name earns a new kind; a new quantity about an interval
+that already exists is an attribute on it.** Adding a kind to carry a statistic
+puts a measurement into the timeline where a reader expects a duration, and the
+breakdown will then sum it.
+
+Which is exactly why `detail` is summed only where it counts something
+(`host_phase_kind_detail_is_quantity`). Nine of the eleven orchestrator kinds
+carry an identity, and a sum over identities — task ids added together — was
+printed as `detail_sum` for as long as the column was unconditional.
+
 ### The three switches
 
 | Switch | Turns on |

--- a/src/a5/runtime/host_build_graph/host/host_phase_trace.cpp
+++ b/src/a5/runtime/host_build_graph/host/host_phase_trace.cpp
@@ -38,17 +38,6 @@
 
 namespace {
 
-// Bind segments carry a few attributes each beyond their duration (byte counts,
-// tensor counts, this thread's fault and context-switch deltas). They are formatted
-// when the segment ends and printed at flush, so a segment's values need not outlive
-// it and the log write stays off the measured path.
-//
-// Sized to the widest buffer any caller formats into (`char attrs[224]` in
-// runtime_maker.cpp), not to what a run happens to produce: the copy in below
-// truncates silently, and the widest segment already formats 86 bytes, so a workload
-// with one wider counter would drop a trailing attribute with nothing to say it had.
-constexpr size_t kBindAttrsCapacity = 224;
-
 // One producer's counters and in-flight claim, on its own cache lines.
 //
 // The producers of a bind are independent -- each records its own Definition and
@@ -99,6 +88,12 @@ struct TraceState {
     std::mutex lifecycle_mutex;
     std::atomic<uint64_t> submitted_tasks{0};
     std::array<ProducerLane, kProducerLanes> lanes;
+    // Each bind segment's attributes beyond its duration (byte counts, tensor
+    // counts, this thread's fault and context-switch deltas), formatted when the
+    // segment ends and printed at flush -- so a segment's values need not outlive
+    // it and the log write stays off the measured path. `kBindAttrsCapacity` is
+    // shared with every caller that formats one, because the copy in truncates
+    // silently.
     std::array<std::array<char, kBindAttrsCapacity>, kHostPhaseKindCount> bind_attrs;
 };
 
@@ -407,10 +402,22 @@ void host_phase_trace_end() {
         // A summed cost share, not an interval: several of these kinds are
         // sub-operations of another, so there is no honest way to draw the total
         // on a timeline. Per-event bars come from the artifact instead.
+        //
+        // `detail_sum` appears only where `detail` counts something. The other
+        // kinds put the identity of what they measured there — a task id, a Graph
+        // key, the submission index — and printing a sum of identities invites a
+        // reader to act on a number that means nothing.
+        if (host_phase_kind_detail_is_quantity(static_cast<HostPhaseKind>(kind))) {
+            LOG_TIMING(
+                "host-orch phase=%s total_ns=%llu count=%llu detail_sum=%llu dropped=%llu", name,
+                static_cast<unsigned long long>(total_ns), static_cast<unsigned long long>(count),
+                static_cast<unsigned long long>(payload_sum), static_cast<unsigned long long>(dropped)
+            );
+            continue;
+        }
         LOG_TIMING(
-            "host-orch phase=%s total_ns=%llu count=%llu detail_sum=%llu dropped=%llu", name,
-            static_cast<unsigned long long>(total_ns), static_cast<unsigned long long>(count),
-            static_cast<unsigned long long>(payload_sum), static_cast<unsigned long long>(dropped)
+            "host-orch phase=%s total_ns=%llu count=%llu dropped=%llu", name, static_cast<unsigned long long>(total_ns),
+            static_cast<unsigned long long>(count), static_cast<unsigned long long>(dropped)
         );
     }
 }

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -191,7 +191,7 @@ static void record_bind_phase(HostPhaseKind kind, int64_t start_ns, const char *
     auto since = [](uint64_t current, uint64_t mark) {
         return current >= mark ? current - mark : 0;
     };
-    char with_counters[352];
+    char with_counters[kBindAttrsCapacity];
     snprintf(
         with_counters, sizeof(with_counters), "%s%sminflt=%" PRIu64 " nivcsw=%" PRIu64 " nvcsw=%" PRIu64, attrs,
         *attrs == '\0' ? "" : " ", since(now.minflt, g_bind_counter_mark.minflt),
@@ -672,7 +672,7 @@ int32_t run_host_orchestration(
 
     const int32_t total_tasks = orchestrator.task_allocator.active_count();
     {
-        char attrs[160];
+        char attrs[kBindAttrsCapacity];
         snprintf(
             attrs, sizeof(attrs), "tasks=%" PRId32 " heap_used=%" PRIu64 " sm_mirror=%" PRIu64, total_tasks,
             orchestrator.task_allocator.heap_used_bytes(), sm_size
@@ -697,7 +697,7 @@ int32_t run_host_orchestration(
         // objects the recorders could not build in the block, and so is 0 for a bind
         // the retained staging was big enough for. It is deliberately not spelled
         // `copied=`, which on arena_h2d means a zone rather than a count.
-        char attrs[128];
+        char attrs[kBindAttrsCapacity];
         snprintf(
             attrs, sizeof(attrs), "defs=%zu bytes=%" PRIu64 " submissions=%zu spilled=%zu", definition_uploads.count,
             definition_uploads.bytes, graph_host_upload_count(*graph_state), definition_uploads.spilled
@@ -774,7 +774,7 @@ int32_t run_host_orchestration(
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
-        char attrs[96];
+        char attrs[kBindAttrsCapacity];
         snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " arena=%" PRIu64, heap_bytes, device_arena_bytes);
         record_bind_phase(HostPhaseKind::BindStaticArena, t_static_arena_ns, attrs);
     }
@@ -789,7 +789,7 @@ int32_t run_host_orchestration(
     void *device_sm = arena_dev + layout.off_copied_end;
     runtime->set_gm_sm_ptr(device_sm);
     {
-        char attrs[96];
+        char attrs[kBindAttrsCapacity];
         snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, image_bytes);
         record_bind_phase(HostPhaseKind::BindSharedMem, t_sm_ns, attrs, image_bytes);
     }
@@ -852,9 +852,9 @@ int32_t run_host_orchestration(
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
-        // Eight uint64 fields plus their labels; 96 would truncate the trailing
-        // `args=` counts on a large bind, which are the ones this marker exists for.
-        char attrs[224];
+        // The widest attribute string a segment formats: eight uint64 fields plus
+        // their labels, which is what sets kBindAttrsCapacity's margin.
+        char attrs[kBindAttrsCapacity];
         snprintf(
             attrs, sizeof(attrs),
             "nt=%" PRIu64 " bytes=%" PRIu64 " copied=%" PRIu64 " sm=%" PRIu64 " args=%" PRIu64 "/%" PRIu64 "/%" PRIu64,
@@ -1131,7 +1131,7 @@ extern "C" int bind_callable_to_runtime_impl(
         device_args.add_scalar(orch_args->scalar(i));
     }
     {
-        char attrs[128];
+        char attrs[kBindAttrsCapacity];
         snprintf(
             attrs, sizeof(attrs), "ntensor=%d staged=%d bytes=%" PRIu64, tensor_count, staged_tensors, staged_bytes
         );
@@ -1157,7 +1157,7 @@ extern "C" int bind_callable_to_runtime_impl(
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     {
-        char attrs[64];
+        char attrs[kBindAttrsCapacity];
         snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, static_cast<uint64_t>(layout.arena_size));
         record_bind_phase(HostPhaseKind::BindArenaBuild, t_arena_build_ns, attrs);
     }
@@ -1223,7 +1223,7 @@ extern "C" int bind_callable_to_runtime_impl(
         const int64_t t_view_close_ns = bind_phase_begin();
         tensor_access.close();
         {
-            char attrs[96];
+            char attrs[kBindAttrsCapacity];
             snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, view_count, view_bytes);
             record_bind_phase(HostPhaseKind::BindHostViewClose, t_view_close_ns, attrs);
         }

--- a/src/a5/runtime/host_build_graph/runtime/host_phase_trace.h
+++ b/src/a5/runtime/host_build_graph/runtime/host_phase_trace.h
@@ -11,7 +11,25 @@
 
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
+
+/**
+ * One bind segment's attribute string, for every buffer on the path from the
+ * caller that formats it to the store that holds it until flush.
+ *
+ * It is one number rather than a size per buffer because the two ends have to
+ * agree: a caller formats its own attributes and then `record_bind_phase`
+ * appends this thread's fault and context-switch deltas, and the store copies
+ * the result in with `snprintf`, which truncates in silence. Nine separate
+ * literals cannot state that relationship, and the widest of them was already
+ * larger than the store.
+ *
+ * The margin is deliberate: the widest segment formats about 100 bytes today
+ * (`arena_h2d`'s itemized upload plus the counters), so a workload whose counts
+ * grow a digit does not start dropping a trailing attribute.
+ */
+constexpr size_t kBindAttrsCapacity = 256;
 
 /**
  * Timing of this runtime's prepare path: the bind stage's segments and the host
@@ -76,7 +94,16 @@ uint64_t host_phase_now_ns();
  * orchestrator core declares a weak fallback for this function and is also
  * compiled for the AICPU, where the platform's host headers are absent.
  *
- * @param payload  task id for the kinds that submit a task, else a detail count
+ * A record is an **interval**: this kind's operation, from when it started to
+ * when it ended. `payload` says which one — a task id, a Graph key, the
+ * submission index — or counts what the interval covered, and nothing else. It
+ * is not a slot for a second measurement over the same window: a quantity about
+ * a segment (bytes moved, faults taken, memory used) belongs in that segment's
+ * attribute string, which `host_phase_record_bind` carries and the breakdown
+ * line prints. `host_phase_kind_detail_is_quantity` is what decides whether the
+ * breakdown may sum this field at all.
+ *
+ * @param payload  which operation this interval was, or how much it covered
  * @param index    submit_idx for orchestrator operations, 0 for bind segments
  */
 void host_phase_record(uint64_t start_ns, uint64_t end_ns, uint32_t kind, uint64_t payload, uint32_t index);

--- a/src/common/platform/include/common/chip_swimlane_profiling.h
+++ b/src/common/platform/include/common/chip_swimlane_profiling.h
@@ -669,6 +669,19 @@ inline bool host_phase_kind_is_device_upload(HostPhaseKind kind) {
            kind == HostPhaseKind::BindArenaH2d;
 }
 
+/**
+ * Whether a kind's `detail` is a quantity, i.e. whether summing it across a bind
+ * means anything.
+ *
+ * Most kinds put in `detail` the identity of what their interval measured — a
+ * task id, a Graph key, the submission index — and a sum over identities is a
+ * number no reader can act on. Only the kinds that carry a count get the summed
+ * column in the breakdown; the rest print their count and total alone.
+ */
+inline bool host_phase_kind_detail_is_quantity(HostPhaseKind kind) {
+    return kind == HostPhaseKind::OrchBuildDefinition || kind == HostPhaseKind::OrchRecordingWait;
+}
+
 inline const char *host_phase_kind_name(HostPhaseKind kind) {
     switch (kind) {
     case HostPhaseKind::BindArgs:


### PR DESCRIPTION
## Summary

A bind phase carries two shapes of information and the code let them be confused. `detail` on a record says **which** operation the interval was — `submit_task` puts a task id there, `graph_begin` a Graph key, `generated_args` the submission index — while two kinds put a **count** there instead. The breakdown summed the field for all eleven, so nine of its lines reported a sum over identities:

```text
host-orch phase=record_node total_ns=3460729 count=1679 detail_sum=237153               ← task ids added up
host-orch phase=graph_begin total_ns=720047  count=86   detail_sum=16707697590923393163 ← Graph keys added up
```

Both read as data and neither is.

`host_phase_kind_detail_is_quantity` names the two kinds that count something — `build_definition`'s nodes, `recording_wait`'s in-flight recordings — beside the two predicates that already classify kinds this way, and the breakdown prints the column only for those. The other nine lines keep their count and total, which is what a reader can act on.

**The rule this follows was nowhere.** `profiling_levels.md` now states it: a record is an *interval* whose `detail` names or sizes it; a quantity about a segment is an *attribute* in that segment's string; therefore a new interval earns a new kind, while a new quantity about an interval that already exists does not. `host_phase_record`'s `@param` said *"task id for the kinds that submit a task, else a detail count"* — true of the values, silent about the contract — and now states it.

## One number replaces nine

`kBindAttrsCapacity` moves to `runtime/host_phase_trace.h` so the store and every caller that formats into it share it. They did not agree before: the store held **224** while `record_bind_phase` formatted into **352**, so a caller filling its buffer lost the tail to a silent `snprintf` truncation — the failure the store's own comment was written to prevent, while describing a `char attrs[224]` that was not the widest caller. The widest segment formats about 90 bytes today, so 256 leaves the margin the comment claims.

## Testing

- [x] `ctest -LE requires_hardware` — 119/119
- [x] dsv4 FLASH decode bind path at `--rounds 6` over two ranks: `detail_sum` now appears on `build_definition` (1679) and `recording_wait` (8) alone, and all 120 `bind phase=` lines are intact
- [x] clang-format, markdownlint
- [x] both arches, one commit, diffs identical modulo the path
