### PR TITLE
Split the L3+ wire argument form out of task_args.h

### DIFF
--- a/docs/buffer-abi.md
+++ b/docs/buffer-abi.md
@@ -37,14 +37,18 @@ forget it on.
 the address is resolved on the consuming endpoint, and the C++ orchestration on
 the chip receives the resolved form.
 
-**A kernel translation unit sees only the last two rows.** A `#include "tensor.h"`
-on a runtime's include path supplies `ChipTensor` and that runtime's `Tensor`
-(aliased `TaskTensor`), and reaches neither `task_interface/task_args.h` nor the
-wire `Tensor` in `task_interface/buffer.h`. The runtime's own entry-arg storage,
-which does need both, sits in `entry_args.h` beside it rather than in `tensor.h`.
-Since the wire type and the runtime type are both spelled `Tensor` — one at global
-scope, one in `simpler::{hbg,tmr}` — an include that reintroduces that edge makes
-the two names collide inside every kernel that picks up the header.
+**A kernel or orchestration translation unit sees only the last two rows.** A
+`#include "tensor.h"` on a runtime's include path supplies `ChipTensor` and that
+runtime's `Tensor` (aliased `TaskTensor`), and neither it nor `orchestration_api.h`
+reaches the wire `Tensor` in `task_interface/buffer.h`. Two headers keep that true:
+the runtime's entry-arg storage, which needs the argument template, sits in
+`entry_args.h` beside `tensor.h` rather than inside it; and `task_args.h` carries
+only the template and the L2 ABI alias, while the L3+ `TaskArgs`, the blob codec and
+the submit checks — the parts whose element *is* the wire `Tensor` — sit in
+`task_args_wire.h`. Since the wire type and a runtime type are both spelled `Tensor`
+— one at global scope, one in `simpler::{hbg,tmr}` — an include that reintroduces
+that edge makes the two names collide in every kernel and orchestration source that
+picks up the header.
 
 > **Status.** `TaskArgs.add_tensor` takes a `Tensor`, and `simpler.task_interface`
 > re-exports it: the public submit surface names the type its own submit call accepts.
@@ -352,9 +356,9 @@ enforced where a task is submitted rather than where it is materialized.
 
 **There is no second blob format.** A `Tensor` travels in the TaskArgs mailbox
 blob that `write_blob` / `read_blob` implement in
-[`task_args.h`](../src/common/task_interface/task_args.h); that blob's element is
-the `Tensor`, and `TaskArgsView::tensors` validates each one as it decodes it.
-`ChipTensor` survives only in `ChipStorageTaskArgs`, the POD `ChipWorker`
+[`task_args_wire.h`](../src/common/task_interface/task_args_wire.h); that blob's
+element is the `Tensor`, and `TaskArgsView::tensors` validates each one as it decodes
+it. `ChipTensor` survives only in `ChipStorageTaskArgs`, the POD `ChipWorker`
 consumes — an L2 worker materializes into it inside `run` before calling down.
 
 Single-machine (host + device) L3→L2 and L4→L3→L2 dispatch is implemented and

--- a/docs/remote-l3-worker-design.md
+++ b/docs/remote-l3-worker-design.md
@@ -151,7 +151,7 @@ Relevant code paths:
   - `submit_next_level()` stores `TaskArgs`, `CallConfig`,
   `CallableIdentity`, and the required target worker in a parent-side slot.
   - Dependency inference happens before dispatch from tags in `TaskArgs`.
-- `src/common/task_interface/task_args.h`
+- `src/common/task_interface/task_args_wire.h`
   - Process dispatch writes `[T][S][ChipTensor x T][uint64 x S]`.
   - Tags are stripped after submit.
 - `docs/comm-domain.md`

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -782,7 +782,7 @@ Tags (IN/OUT/INOUT/…) are used by `Orchestrator::submit_*` to derive TensorMap
 dependencies and nothing else. Scheduler, WorkerThread, child, runtime.so, and
 kernels do not inspect them. Keeping tags only in Layer ① simplifies the blob
 and makes the "tags are Orchestrator input" rule explicit. Matches existing
-runtime: `ChipStorageTaskArgs` (`task_args.h:157`) is already declared with
+runtime: `ChipStorageTaskArgs` (`task_args.h`) is already declared with
 `void` as the TensorTag parameter.
 
 ### Why no `WorkerPayload` wrapper
@@ -833,6 +833,8 @@ lives in the mailbox blob bytes on the child side — view doesn't care.
 - [chip-level-arch.md](chip-level-arch.md) — L2 single-chip: three-program
   model (host / AICPU / AICore)
 - [`../src/common/task_interface/task_args.h`](../src/common/task_interface/task_args.h)
-  — `TaskArgs` template and `ChipStorageTaskArgs` alias
+  — `TaskArgsTpl` template and the `ChipStorageTaskArgs` alias
+- [`../src/common/task_interface/task_args_wire.h`](../src/common/task_interface/task_args_wire.h)
+  — the L3+ `TaskArgs`, `TaskArgsView`, and the mailbox blob codec
 - [`../src/common/task_interface/tensor.h`](../src/common/task_interface/tensor.h)
   — `ChipTensor` POD and `TensorArgType` enum

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -14,7 +14,8 @@
  * Wraps DataType, ChipTensor, ChipStorageTaskArgs, TaskArgs (unified
  * vector-backed builder with per-tensor TensorArgType tags), TensorArgType,
  * ArgDirection, CoreCallable, ChipCallable, and helper functions from
- * data_type.h / tensor.h / task_args.h / arg_direction.h / callable.h.
+ * data_type.h / tensor.h / task_args.h / task_args_wire.h / arg_direction.h /
+ * callable.h.
  */
 
 #include <nanobind/nanobind.h>
@@ -66,7 +67,7 @@
 #include "dma_workspace.h"
 #include "worker_chip_orch_comm.h"
 #include "worker_bind.h"
-#include "task_args.h"
+#include "task_args_wire.h"
 #include "tensor.h"
 
 namespace nb = nanobind;
@@ -1946,8 +1947,8 @@ NB_MODULE(_task_interface, m) {
     // that does not fit its backing cannot be built in the first place.
     //
     // No bytes cross this binding in either direction. Python builds a Tensor from its fields and
-    // receives one already decoded; turning mailbox bytes into a Tensor is task_args.h's job, and
-    // keeping that the only decode path is what makes validate_tensor a gate rather than a habit.
+    // receives one already decoded; turning mailbox bytes into a Tensor is task_args_wire.h's job,
+    // and keeping that the only decode path is what makes validate_tensor a gate rather than a habit.
     nb::class_<Tensor>(m, "Tensor")
         .def(
             "__init__",

--- a/src/common/hierarchical/orchestrator.h
+++ b/src/common/hierarchical/orchestrator.h
@@ -43,7 +43,7 @@
 
 #include "../task_interface/call_config.h"
 #include "../task_interface/data_type.h"
-#include "../task_interface/task_args.h"
+#include "../task_interface/task_args_wire.h"
 #include "../task_interface/tensor.h"
 #include "../worker/pipeline_slot_pool.h"
 #include "../worker/device_memory_info.h"

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -44,7 +44,7 @@
 #include <vector>
 
 #include "../task_interface/call_config.h"
-#include "../task_interface/task_args.h"
+#include "../task_interface/task_args_wire.h"
 #include "../worker/runtime_c_api.h"
 
 // =============================================================================

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -29,7 +29,7 @@
 #include "device_runner_base.h"
 #include "prepare_callable_common.h"
 #include "runtime_c_api.h"
-#include "task_args.h"
+#include "task_args_wire.h"
 #include "native_run_context.h"
 
 #include <acl/acl.h>

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -50,7 +50,7 @@
 #include "host_log.h"
 #include "platform_comm/comm.h"
 #include "runtime_c_api.h"
-#include "task_args.h"
+#include "task_args_wire.h"
 #include "utils/elf_build_id.h"
 // `runtime.h` (pulled in via `device_runner_helpers.h` in the base header)
 // supplies the per-arch `Handshake` + `Runtime` types used by

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -27,7 +27,7 @@
 #include "call_config.h"
 #include "device_runner_base.h"
 #include "prepare_callable_common.h"
-#include "task_args.h"
+#include "task_args_wire.h"
 #include "native_run_context.h"
 
 #include <dlfcn.h>

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -30,7 +30,7 @@
 #include "common/host_api.h"
 #include "cpu_sim_context.h"
 #include "host/raii_scope_guard.h"
-#include "task_args.h"
+#include "task_args_wire.h"
 #include "utils/elf_build_id.h"
 
 namespace simpler::common::sim_host {

--- a/src/common/task_interface/task_args.h
+++ b/src/common/task_interface/task_args.h
@@ -22,29 +22,27 @@
  *   - void (default): no per-tensor tag — pure transport/storage
  *   - real type: adds tags_ storage + tag(i) accessor
  *
- * Concrete user-facing types (typedefs at the bottom):
- *   - TaskArgs            — vector-backed + TensorArgType tags (the unified
- *                           builder used by Orchestrator.submit_*), with
- *                           host-graph explicit dependency handles
+ * The element type is the caller's: each layer instantiates the template over
+ * whatever tensor form it holds. Only one instantiation lives here, the one whose
+ * element crosses the host->device wire:
  *   - ChipStorageTaskArgs — fixed POD matching the runtime.so ABI byte-for-byte
  *
- * Wire / dispatch helpers:
- *   - TaskArgsView        — zero-copy view over a wire blob (no tags)
- *   - write_blob/read_blob — length-prefixed serialization for PROCESS-mode
- *                            mailbox transport (tags stripped on the wire)
+ * The L3+ form — `TaskArgs`, whose element is the self-describing `Tensor` from
+ * buffer.h — is in task_args_wire.h, together with the blob codec and the
+ * submit-time checks. Nothing here reaches buffer.h, which is what keeps that
+ * header's global `Tensor` out of every kernel and orchestration translation unit;
+ * they see this one.
  */
 
 #pragma once
 
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <stdexcept>
 #include <type_traits>
 #include <vector>
 
 #include "arg_direction.h"
-#include "buffer.h"  // Tensor wire type + TENSOR_BLOB_MAGIC for the blob envelope
 #include "tensor.h"  // ChipTensor (device POD) + TensorArgType, the tag TaskArgs carries
 
 // Opaque at the Python surface. The run id prevents a slot from being reused
@@ -193,198 +191,7 @@ struct TaskArgsTpl<T, S, 0, 0, TensorTag> : TensorTagMixin<TensorTag, 0> {
 // Type aliases
 // ============================================================================
 
-// Unified user-facing builder: vector-backed with TensorArgType tags.
-// Used by Orchestrator.submit_*; tags drive dependency inference at submit
-// time and are stripped before the args cross the dispatch boundary. The element
-// is Tensor (self-describing view; L3+ holds no C++ ChipTensor) — the L3→L2 wire
-// carries Tensors, materialized to ChipStorageTaskArgs (ChipTensor) on the L2 child.
-using TaskArgs = TaskArgsTpl<Tensor, uint64_t, 0, 0, TensorArgType>;
-
 // L2 runtime ABI: fixed POD matching runtime.so byte-for-byte, and the sole ChipTensor-typed args
 // container — the materialized form a chip child decodes the L3->L2 Tensor blob into, just before
 // simpler_run.
 using ChipStorageTaskArgs = TaskArgsTpl<ChipTensor, uint64_t, CHIP_MAX_TENSOR_ARGS, CHIP_MAX_SCALAR_ARGS>;
-
-// ============================================================================
-// TaskArgsView — zero-copy view over a wire blob
-// ============================================================================
-//
-// View-only: refers to externally owned tensor + scalar arrays. No tags
-// (tags are consumed by Orchestrator at submit time and never travel further).
-
-struct TaskArgsView {
-    int32_t tensor_count;
-    int32_t scalar_count;
-    // Raw bytes of the tensor array, NOT a `const Tensor *`. The blob's tensor region starts at the
-    // 8-byte header boundary, so a `Tensor *` formed onto it would carry an alignment the type does
-    // not promise. Copy a tensor out with tensors(i).
-    const uint8_t *tensor_bytes;
-    const uint64_t *scalars;  // 8-byte aligned by blob construction; safe to address as uint64_t*
-
-    // Copy the i-th tensor into a properly-aligned local and gate it. Bounds-checked: a negative
-    // index would otherwise wrap to a huge offset once cast to size_t. This is the ONLY validation
-    // a blob element ever gets — nothing downstream re-checks magic, tag, body_len, the view's
-    // containment in its backing, or the FORK_COW read-only rule.
-    Tensor tensors(int32_t i) const {
-        if (i < 0 || i >= tensor_count) {
-            throw std::out_of_range("TaskArgsView::tensors: index out of range");
-        }
-        Tensor t;
-        std::memcpy(&t, tensor_bytes + static_cast<size_t>(i) * sizeof(Tensor), sizeof(Tensor));
-        validate_tensor(t);
-        return t;
-    }
-};
-
-// ============================================================================
-// Wire format — length-prefixed blob for PROCESS-mode mailbox transport
-// ============================================================================
-//
-// Byte layout (tags stripped):
-//   offset 0:                 int32 tensor_count = T
-//   offset 4:                 int32 scalar_count = S
-//   offset 8:                 Tensor tensors[T]             (144 B each)
-//   offset 8 + 144T:          uint64_t scalars[S]           (8 B each)
-// total bytes used:           8 + 144T + 8S
-//
-// The element is the self-describing wire `Tensor`: it carries its backing's descriptor, so a
-// consumer resolves it with no prior handshake. A chip child materializes each one to a
-// `ChipTensor` (address-bearing) and assembles a `ChipStorageTaskArgs` for the runtime.so ABI.
-
-inline constexpr size_t TASK_ARGS_BLOB_HEADER_SIZE = 8;
-
-inline size_t task_args_blob_size(const TaskArgs &a) {
-    return TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(a.tensor_count()) * sizeof(Tensor) +
-           static_cast<size_t>(a.scalar_count()) * sizeof(uint64_t);
-}
-
-// Serialize a TaskArgs into `dst`. Caller must ensure `dst` has room for
-// task_args_blob_size(a) bytes. Tags are not written.
-inline void write_blob(uint8_t *dst, const TaskArgs &a) {
-    int32_t T = a.tensor_count();
-    int32_t S = a.scalar_count();
-    std::memcpy(dst + 0, &T, sizeof(T));
-    std::memcpy(dst + 4, &S, sizeof(S));
-    if (T > 0) {
-        std::memcpy(dst + TASK_ARGS_BLOB_HEADER_SIZE, a.tensor_data(), static_cast<size_t>(T) * sizeof(Tensor));
-    }
-    if (S > 0) {
-        std::memcpy(
-            dst + TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(T) * sizeof(Tensor), a.scalar_data(),
-            static_cast<size_t>(S) * sizeof(uint64_t)
-        );
-    }
-}
-
-// Zero-copy view into a blob written by write_blob. The returned view is only
-// valid as long as `src` stays alive in mapped/shm memory.
-//
-// `capacity` is the maximum number of bytes the reader is allowed to consume
-// from `src` (e.g. MAILBOX_ARGS_CAPACITY when reading from the IPC mailbox).
-// Throws std::runtime_error if the header reports counts that would walk past
-// `capacity` — defends against shared-memory corruption or a writer-side bug
-// that slipped past the writer's own bounds check. This bounds the envelope
-// only; each element is gated by TaskArgsView::tensors.
-inline TaskArgsView read_blob(const uint8_t *src, size_t capacity) {
-    if (capacity < TASK_ARGS_BLOB_HEADER_SIZE) {
-        throw std::runtime_error(
-            "read_blob: capacity " + std::to_string(capacity) + " < header size " +
-            std::to_string(TASK_ARGS_BLOB_HEADER_SIZE)
-        );
-    }
-    int32_t T;
-    int32_t S;
-    std::memcpy(&T, src + 0, sizeof(T));
-    std::memcpy(&S, src + 4, sizeof(S));
-    if (T < 0 || S < 0) {
-        throw std::runtime_error(
-            "read_blob: negative counts — tensors=" + std::to_string(T) + ", scalars=" + std::to_string(S)
-        );
-    }
-    const size_t needed = TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(T) * sizeof(Tensor) +
-                          static_cast<size_t>(S) * sizeof(uint64_t);
-    if (needed > capacity) {
-        throw std::runtime_error(
-            "read_blob: header reports " + std::to_string(needed) + " bytes (T=" + std::to_string(T) +
-            ", S=" + std::to_string(S) + ") but capacity is " + std::to_string(capacity) +
-            " — likely shm corruption or a writer-side bug"
-        );
-    }
-    return TaskArgsView{
-        T,
-        S,
-        src + TASK_ARGS_BLOB_HEADER_SIZE,
-        reinterpret_cast<const uint64_t *>(src + TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(T) * sizeof(Tensor)),
-    };
-}
-
-// ============================================================================
-// Submit-time argument validation
-// ============================================================================
-
-// access ⊆ granted: an arg's TensorArgType may only request what the backing grants.
-//   INPUT -> READ, OUTPUT_EXISTING -> WRITE, INOUT -> READWRITE; READWRITE grants everything.
-//   NO_DEP / OUTPUT are unconstrained.
-// Catches e.g. a READ-only copy-on-write backing tagged OUTPUT_EXISTING, whose writes in a forked
-// child would silently never reach the parent.
-inline bool access_permits(uint8_t granted, TensorArgType tag) {
-    auto granted_has = [&](AccessMode need) {
-        return granted == static_cast<uint8_t>(AccessMode::READWRITE) || granted == static_cast<uint8_t>(need);
-    };
-    switch (tag) {
-    case TensorArgType::INPUT:
-        return granted_has(AccessMode::READ);
-    case TensorArgType::OUTPUT_EXISTING:
-        return granted_has(AccessMode::WRITE);
-    case TensorArgType::INOUT:
-        return granted == static_cast<uint8_t>(AccessMode::READWRITE);
-    default:
-        return true;
-    }
-}
-
-// Does this tag declare a write? NO_DEP is excluded deliberately: it opts out of dependency
-// tracking altogether, so its ordering is the caller's to arrange.
-inline bool tag_writes(TensorArgType tag) {
-    return tag == TensorArgType::OUTPUT || tag == TensorArgType::OUTPUT_EXISTING || tag == TensorArgType::INOUT;
-}
-
-/**
- * Validate one submit's whole argument set, at the point where the values are final.
- *
- * `access ⊆ granted` is re-checked here rather than trusted from add time because a tag is mutable
- * after its element is added — the pair that governs the dispatch is the one present now.
- *
- * Overlapping writes WITHIN one TaskArgs are rejected because no later layer can catch them: the two
- * args belong to one task node, so there is no order between them to express, and a device-staged
- * copy of a host backing does not even alias on the device for the L2 overlap map to notice.
- * Disjoint slices of one backing stay legal.
- *
- * Members of a group are NOT compared against each other. A group is one DAG node whose members
- * deliberately share their tags — naming one buffer as every member's OUTPUT is how a group
- * publishes a single completion token for a downstream task to depend on. Whether such a shared
- * write carries data or only ordering is not visible here, so the caller owns it.
- */
-inline void validate_submit_args(const std::vector<TaskArgs> &args_list) {
-    for (const TaskArgs &args : args_list) {
-        for (int32_t i = 0; i < args.tensor_count(); ++i) {
-            if (!access_permits(args.tensor(i).buffer.access, args.tag(i))) {
-                throw std::invalid_argument(
-                    "submit: an argument's TensorArgType requests access the backing does not grant"
-                );
-            }
-        }
-    }
-    for (const TaskArgs &args : args_list) {
-        for (int32_t i = 0; i < args.tensor_count(); ++i) {
-            if (!tag_writes(args.tag(i))) continue;
-            for (int32_t j = i + 1; j < args.tensor_count(); ++j) {
-                if (!tensors_overlap(args.tensor(i), args.tensor(j))) continue;
-                throw std::invalid_argument(
-                    "submit: two arguments of one task write overlapping bytes of the same buffer; "
-                    "give them disjoint ranges, or order them as separate tasks"
-                );
-            }
-        }
-    }
-}

--- a/src/common/task_interface/task_args_wire.h
+++ b/src/common/task_interface/task_args_wire.h
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The L3+ argument form and everything that speaks its wire format.
+ *
+ * The element here is the self-describing `Tensor` from buffer.h — a buffer
+ * descriptor plus a strided view, carrying no materialized address. That is what
+ * an L3+ submit builds and what crosses the L3->L2 boundary:
+ *
+ *   - TaskArgs             — the unified builder Orchestrator.submit_* takes:
+ *                            vector-backed, TensorArgType-tagged, with host-graph
+ *                            explicit dependency handles
+ *   - TaskArgsView         — zero-copy view over a blob (no tags; they are consumed
+ *                            at submit time and never travel)
+ *   - write_blob/read_blob — length-prefixed serialization for PROCESS-mode mailbox
+ *                            transport
+ *   - validate_submit_args — the submit-time access and overlap checks
+ *
+ * Separate from task_args.h because that header is on the include path of every
+ * kernel and orchestration translation unit, and none of them resolves a buffer
+ * descriptor: they work in `ChipTensor` and their runtime's own `Tensor`. Reaching
+ * buffer.h from there would also put a second `Tensor` — this one at global scope —
+ * in their scope. Include this header only where the L3+ form is actually handled:
+ * the host orchestrator under src/common/hierarchical/, the Python bindings, and the
+ * platform host code that decodes a blob into ChipStorageTaskArgs.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "buffer.h"  // Tensor wire type, AccessMode, validate_tensor, tensors_overlap
+#include "task_args.h"
+
+// ============================================================================
+// Type aliases
+// ============================================================================
+
+// Unified user-facing builder: vector-backed with TensorArgType tags.
+// Used by Orchestrator.submit_*; tags drive dependency inference at submit
+// time and are stripped before the args cross the dispatch boundary. The element
+// is Tensor (self-describing view; L3+ holds no C++ ChipTensor) — the L3→L2 wire
+// carries Tensors, materialized to ChipStorageTaskArgs (ChipTensor) on the L2 child.
+using TaskArgs = TaskArgsTpl<Tensor, uint64_t, 0, 0, TensorArgType>;
+
+// ============================================================================
+// TaskArgsView — zero-copy view over a wire blob
+// ============================================================================
+//
+// View-only: refers to externally owned tensor + scalar arrays. No tags
+// (tags are consumed by Orchestrator at submit time and never travel further).
+
+struct TaskArgsView {
+    int32_t tensor_count;
+    int32_t scalar_count;
+    // Raw bytes of the tensor array, NOT a `const Tensor *`. The blob's tensor region starts at the
+    // 8-byte header boundary, so a `Tensor *` formed onto it would carry an alignment the type does
+    // not promise. Copy a tensor out with tensors(i).
+    const uint8_t *tensor_bytes;
+    const uint64_t *scalars;  // 8-byte aligned by blob construction; safe to address as uint64_t*
+
+    // Copy the i-th tensor into a properly-aligned local and gate it. Bounds-checked: a negative
+    // index would otherwise wrap to a huge offset once cast to size_t. This is the ONLY validation
+    // a blob element ever gets — nothing downstream re-checks magic, tag, body_len, the view's
+    // containment in its backing, or the FORK_COW read-only rule.
+    Tensor tensors(int32_t i) const {
+        if (i < 0 || i >= tensor_count) {
+            throw std::out_of_range("TaskArgsView::tensors: index out of range");
+        }
+        Tensor t;
+        std::memcpy(&t, tensor_bytes + static_cast<size_t>(i) * sizeof(Tensor), sizeof(Tensor));
+        validate_tensor(t);
+        return t;
+    }
+};
+
+// ============================================================================
+// Wire format — length-prefixed blob for PROCESS-mode mailbox transport
+// ============================================================================
+//
+// Byte layout (tags stripped):
+//   offset 0:                 int32 tensor_count = T
+//   offset 4:                 int32 scalar_count = S
+//   offset 8:                 Tensor tensors[T]             (144 B each)
+//   offset 8 + 144T:          uint64_t scalars[S]           (8 B each)
+// total bytes used:           8 + 144T + 8S
+//
+// The element is the self-describing wire `Tensor`: it carries its backing's descriptor, so a
+// consumer resolves it with no prior handshake. A chip child materializes each one to a
+// `ChipTensor` (address-bearing) and assembles a `ChipStorageTaskArgs` for the runtime.so ABI.
+
+inline constexpr size_t TASK_ARGS_BLOB_HEADER_SIZE = 8;
+
+inline size_t task_args_blob_size(const TaskArgs &a) {
+    return TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(a.tensor_count()) * sizeof(Tensor) +
+           static_cast<size_t>(a.scalar_count()) * sizeof(uint64_t);
+}
+
+// Serialize a TaskArgs into `dst`. Caller must ensure `dst` has room for
+// task_args_blob_size(a) bytes. Tags are not written.
+inline void write_blob(uint8_t *dst, const TaskArgs &a) {
+    int32_t T = a.tensor_count();
+    int32_t S = a.scalar_count();
+    std::memcpy(dst + 0, &T, sizeof(T));
+    std::memcpy(dst + 4, &S, sizeof(S));
+    if (T > 0) {
+        std::memcpy(dst + TASK_ARGS_BLOB_HEADER_SIZE, a.tensor_data(), static_cast<size_t>(T) * sizeof(Tensor));
+    }
+    if (S > 0) {
+        std::memcpy(
+            dst + TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(T) * sizeof(Tensor), a.scalar_data(),
+            static_cast<size_t>(S) * sizeof(uint64_t)
+        );
+    }
+}
+
+// Zero-copy view into a blob written by write_blob. The returned view is only
+// valid as long as `src` stays alive in mapped/shm memory.
+//
+// `capacity` is the maximum number of bytes the reader is allowed to consume
+// from `src` (e.g. MAILBOX_ARGS_CAPACITY when reading from the IPC mailbox).
+// Throws std::runtime_error if the header reports counts that would walk past
+// `capacity` — defends against shared-memory corruption or a writer-side bug
+// that slipped past the writer's own bounds check. This bounds the envelope
+// only; each element is gated by TaskArgsView::tensors.
+inline TaskArgsView read_blob(const uint8_t *src, size_t capacity) {
+    if (capacity < TASK_ARGS_BLOB_HEADER_SIZE) {
+        throw std::runtime_error(
+            "read_blob: capacity " + std::to_string(capacity) + " < header size " +
+            std::to_string(TASK_ARGS_BLOB_HEADER_SIZE)
+        );
+    }
+    int32_t T;
+    int32_t S;
+    std::memcpy(&T, src + 0, sizeof(T));
+    std::memcpy(&S, src + 4, sizeof(S));
+    if (T < 0 || S < 0) {
+        throw std::runtime_error(
+            "read_blob: negative counts — tensors=" + std::to_string(T) + ", scalars=" + std::to_string(S)
+        );
+    }
+    const size_t needed = TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(T) * sizeof(Tensor) +
+                          static_cast<size_t>(S) * sizeof(uint64_t);
+    if (needed > capacity) {
+        throw std::runtime_error(
+            "read_blob: header reports " + std::to_string(needed) + " bytes (T=" + std::to_string(T) +
+            ", S=" + std::to_string(S) + ") but capacity is " + std::to_string(capacity) +
+            " — likely shm corruption or a writer-side bug"
+        );
+    }
+    return TaskArgsView{
+        T,
+        S,
+        src + TASK_ARGS_BLOB_HEADER_SIZE,
+        reinterpret_cast<const uint64_t *>(src + TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(T) * sizeof(Tensor)),
+    };
+}
+
+// ============================================================================
+// Submit-time argument validation
+// ============================================================================
+
+// access ⊆ granted: an arg's TensorArgType may only request what the backing grants.
+//   INPUT -> READ, OUTPUT_EXISTING -> WRITE, INOUT -> READWRITE; READWRITE grants everything.
+//   NO_DEP / OUTPUT are unconstrained.
+// Catches e.g. a READ-only copy-on-write backing tagged OUTPUT_EXISTING, whose writes in a forked
+// child would silently never reach the parent.
+inline bool access_permits(uint8_t granted, TensorArgType tag) {
+    auto granted_has = [&](AccessMode need) {
+        return granted == static_cast<uint8_t>(AccessMode::READWRITE) || granted == static_cast<uint8_t>(need);
+    };
+    switch (tag) {
+    case TensorArgType::INPUT:
+        return granted_has(AccessMode::READ);
+    case TensorArgType::OUTPUT_EXISTING:
+        return granted_has(AccessMode::WRITE);
+    case TensorArgType::INOUT:
+        return granted == static_cast<uint8_t>(AccessMode::READWRITE);
+    default:
+        return true;
+    }
+}
+
+// Does this tag declare a write? NO_DEP is excluded deliberately: it opts out of dependency
+// tracking altogether, so its ordering is the caller's to arrange.
+inline bool tag_writes(TensorArgType tag) {
+    return tag == TensorArgType::OUTPUT || tag == TensorArgType::OUTPUT_EXISTING || tag == TensorArgType::INOUT;
+}
+
+/**
+ * Validate one submit's whole argument set, at the point where the values are final.
+ *
+ * `access ⊆ granted` is re-checked here rather than trusted from add time because a tag is mutable
+ * after its element is added — the pair that governs the dispatch is the one present now.
+ *
+ * Overlapping writes WITHIN one TaskArgs are rejected because no later layer can catch them: the two
+ * args belong to one task node, so there is no order between them to express, and a device-staged
+ * copy of a host backing does not even alias on the device for the L2 overlap map to notice.
+ * Disjoint slices of one backing stay legal.
+ *
+ * Members of a group are NOT compared against each other. A group is one DAG node whose members
+ * deliberately share their tags — naming one buffer as every member's OUTPUT is how a group
+ * publishes a single completion token for a downstream task to depend on. Whether such a shared
+ * write carries data or only ordering is not visible here, so the caller owns it.
+ */
+inline void validate_submit_args(const std::vector<TaskArgs> &args_list) {
+    for (const TaskArgs &args : args_list) {
+        for (int32_t i = 0; i < args.tensor_count(); ++i) {
+            if (!access_permits(args.tensor(i).buffer.access, args.tag(i))) {
+                throw std::invalid_argument(
+                    "submit: an argument's TensorArgType requests access the backing does not grant"
+                );
+            }
+        }
+    }
+    for (const TaskArgs &args : args_list) {
+        for (int32_t i = 0; i < args.tensor_count(); ++i) {
+            if (!tag_writes(args.tag(i))) continue;
+            for (int32_t j = i + 1; j < args.tensor_count(); ++j) {
+                if (!tensors_overlap(args.tensor(i), args.tensor(j))) continue;
+                throw std::invalid_argument(
+                    "submit: two arguments of one task write overlapping bytes of the same buffer; "
+                    "give them disjoint ranges, or order them as separate tasks"
+                );
+            }
+        }
+    }
+}

--- a/tests/ut/cpp/types/test_child_memory.cpp
+++ b/tests/ut/cpp/types/test_child_memory.cpp
@@ -14,7 +14,7 @@
 
 #include <gtest/gtest.h>
 
-#include "task_args.h"
+#include "task_args_wire.h"
 
 // ---------------------------------------------------------------------------
 // ChipTensor layout


### PR DESCRIPTION
## The defect

`task_args.h` bundled two layers. The **generic container** — `TaskArgsTpl`, its tag mixin, and the `ChipStorageTaskArgs` alias whose element is `ChipTensor` — is needed by every runtime and orchestration translation unit. Sitting next to it was the **L3+ form**, whose element is the self-describing `Tensor` from `buffer.h`: the `TaskArgs` builder, `TaskArgsView`, the mailbox blob codec, `validate_submit_args`.

Because that half needs `buffer.h`, the header included it — and `buffer.h` declares a `Tensor` at **global scope**. `buffer.h` has exactly **one** includer in `src/`, that line, so the effect was that every orchestration TU saw the L3+ wire type. Measured on the pre-change tree:

```text
orchestration_api.h → runtime/graph_cache.h → common/host_build_graph/graph_cache.h
  → runtime/types.h → task_args.h → task_interface/buffer.h
```

`types.h` needs the container, because `Arg : TaskArgsTpl<TensorRef, …>` is the submit surface orchestration builds on. It has no use for the wire form.

## The change

The L3+ half moves to `task_args_wire.h`, which includes `task_args.h` + `buffer.h`. Its consumers are the layer that actually handles that form:

| Consumer | Why |
| -------- | --- |
| `src/common/hierarchical/{types,orchestrator}.h` | the host orchestrator builds `TaskArgs` and calls `validate_submit_args` |
| `src/common/platform/{onboard,sim}/host/{c_api_shared,device_runner_base}.cpp` | decode a blob into `ChipStorageTaskArgs` |
| `python/bindings/task_interface.cpp` | binds `TaskArgs` / `Tensor` |
| `tests/ut/cpp/types/test_child_memory.cpp` | round-trips a blob through `write_blob` / `read_blob` |

Eleven includes change. Nothing else moves and **no declaration changes** — 13 files, +281/−226, of which 226 deletions and 241 insertions are the move itself.

Two deliberate choices:

- **`task_args.h` keeps its name**, so the fourteen runtime and orchestration includers are untouched (they are near-duplicate a2a3/a5 trees, and a smaller diff there is worth more than a tidier filename). It carries a pointer to where `TaskArgs` went — a reader grepping the obvious file for the obvious name should not come up empty.
- **`ChipStorageTaskArgs` stays on the generic side**, by the same criterion that drove the split: its element is `ChipTensor` from `task_interface/tensor.h`, not the wire `Tensor`, so it needs no `buffer.h`. It is also the reason `runtime.h` and `orchestration_api.h` include the header at all.

## What this unblocks

`Tensor` is no longer taken inside a kernel *or* an orchestration source. #2032 established that for kernels; this closes the orchestration half, which is the larger one. Concretely, `using Tensor = simpler::hbg::Tensor;` in an orchestration TU:

```text
before:  error: conflicting declaration ‘using Tensor = struct simpler::hbg::Tensor’
         buffer.h:218:8: note: previous declaration as ‘struct Tensor’
after:   compiles
```

That matters because the umbrellas currently export the awkward `TaskTensor` precisely because `Tensor` was unavailable, and kernels *and* orchestration share one `tensor.h`. This PR does not rename anything — it removes the second of the two reasons the rename was impossible.

## Testing

| Gate | Result |
| ---- | ------ |
| Full product build — 2 arches × 2 runtimes × sim/onboard | clean, first try; host, aicpu and aicore artifacts all rebuilt |
| cpput, from a **clean** build dir | **119/119** |
| `_st-sim-a2a3.yml` main sweep, verbatim shape | **60 passed / 8 skipped** (22 resource-phase + 10 L2-hbg + 28 L2-tmr), reconciles against `--collect-only`'s 68 selected |
| `_st-sim-a5.yml` main sweep, verbatim shape | **53 passed** (18 + 7 + 28), reconciles against 53 selected |
| Whole scene-test corpus's incores, `--manual include`, both arches | **0 compile failures** |

That last row is worth a word, because a zero is only evidence if the check can be non-zero: the same sweep reported **six failures per arch** two commits ago, and reports zero now that #2027 has landed the fixes. It is sensitive, not vacuous.

"Clean build dir" in the cpput row is load-bearing, and the first CI round on this PR is why: `ut` went red at `Build and run C++ unit tests` with `exit code 2` while an *incremental* local cpput reported 119/119. An incremental build reuses object files and dependency information, so it never recompiled `test_child_memory.cpp` — the one test whose include set this change invalidates. `rm -rf tests/ut/cpp/build` first and it reproduces immediately. The macOS `ut` in that round was matrix fail-fast collateral (step 7 cancelled, 9 and 10 skipped), not a second failure.

The acceptance check probes both runtimes' orchestration paths with the include flags taken from **`compile_commands.json`**, not from `build_config.py` — that file's `include_dirs` are relative to the runtime directory and do not carry `src/common`, which the platform `CMakeLists` adds, so reading the build config alone gives the wrong answer. A control that pulls in `task_args_wire.h` by hand on the changed tree still fails with the error above, so the check answers to the include edge rather than to the alias.

## Docs

`docs/buffer-abi.md`'s invariant paragraph was added by #2032 and this change makes it inaccurate — a kernel TU now *does* see `task_args.h`, just not the wire half. Corrected, and extended to name the orchestration side. `docs/task-flow.md` and `docs/remote-l3-worker-design.md` pointed at `task_args.h` for the blob codec; both now point at `task_args_wire.h`, and a stale `task_args.h:157` line reference is dropped rather than renumbered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
