### PR TITLE
Fix: release exported views before closing provider-control SHM

### DIFF
--- a/python/simpler/comm_provider_control.py
+++ b/python/simpler/comm_provider_control.py
@@ -14,8 +14,10 @@ import worker-chip compatibility types, W2 planning, or W5a identity.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import struct
+import sys
 from enum import IntEnum
 from multiprocessing.shared_memory import SharedMemory
 from typing import Any, Protocol, TypeVar
@@ -154,8 +156,6 @@ def _as_memoryview(buf: memoryview | bytes | bytearray, size: int, *, writable: 
             RegionControlErrorKind.BAD_MESSAGE_SIZE,
             f"buffer must hold a {size}-byte wire frame",
         )
-    if view.nbytes > size:
-        view = memoryview(view).cast("B")[:size]
     if writable and view.readonly:
         raise RegionControlError(
             RegionControlErrorKind.INTERNAL_INVARIANT,
@@ -165,7 +165,7 @@ def _as_memoryview(buf: memoryview | bytes | bytearray, size: int, *, writable: 
 
 
 def _require_zero_span(view: memoryview, offset: int, length: int) -> None:
-    if any(view[offset : offset + length]):
+    if any(view[i] for i in range(offset, offset + length)):
         raise RegionControlError(RegionControlErrorKind.RESERVED_NONZERO, "reserved bytes must be zero")
 
 
@@ -220,7 +220,7 @@ def _acquire_tag(view: memoryview) -> int:
 
 def encode_allocate_request(buf: memoryview | bytearray, spec: RegionAllocationSpec) -> None:
     view = _as_memoryview(buf, ALLOCATE_REQUEST_BYTES, writable=True)
-    view[:] = b"\x00" * ALLOCATE_REQUEST_BYTES
+    view[:ALLOCATE_REQUEST_BYTES] = b"\x00" * ALLOCATE_REQUEST_BYTES
     _ALLOCATE_REQUEST.pack_into(
         view,
         0,
@@ -392,8 +392,8 @@ def _decode_local_view(view: memoryview, offset: int, expected: RegionPartKind) 
         ) from exc
 
 
-def _zero_reply(view: memoryview) -> None:
-    view[:] = b"\x00" * view.nbytes
+def _zero_reply(view: memoryview, size: int) -> None:
+    view[:size] = b"\x00" * size
 
 
 def _discard_control_shm(shm: Any) -> None:
@@ -416,6 +416,26 @@ def _discard_control_shm(shm: Any) -> None:
             "provider control shm cleanup failed: name=%s operation=unlink error=%s",
             name,
             exc,
+        )
+
+
+def _release_exported_view(view: memoryview | None) -> None:
+    if view is None:
+        return
+    with contextlib.suppress(ValueError):
+        view.release()
+
+
+def _close_attached_control_shm(shm: SharedMemory, pending: BaseException | None) -> None:
+    try:
+        shm.close()
+    except BufferError:
+        if pending is None:
+            raise
+        logging.getLogger("simpler").warning(
+            "provider control shm cleanup failed: name=%s operation=close error=%s",
+            getattr(shm, "name", "<unnamed>"),
+            sys.exc_info()[1],
         )
 
 
@@ -462,7 +482,7 @@ def encode_allocate_success_reply(
 ) -> None:
     view = _as_memoryview(buf, ALLOCATE_REPLY_BYTES, writable=True)
     validate_independent_local_views(payload_view, counter_view)
-    _zero_reply(view)
+    _zero_reply(view, ALLOCATE_REPLY_BYTES)
     _pack_allocate_header(
         view, resource_id=result.provider_resource_id, error_kind=0, failed_part=0, failed_operation=0, debt=0
     )
@@ -480,14 +500,14 @@ def encode_allocate_request_error_reply(buf: memoryview | bytearray, kind: Regio
             RegionControlErrorKind.INTERNAL_INVARIANT,
             "REQUEST_ERROR kind must be a wire syntax code",
         )
-    _zero_reply(view)
+    _zero_reply(view, ALLOCATE_REPLY_BYTES)
     _pack_allocate_header(view, resource_id=0, error_kind=int(kind), failed_part=0, failed_operation=0, debt=0)
     _publish_tag(view, AllocateReplyTag.REQUEST_ERROR)
 
 
 def encode_allocate_allocation_error_reply(buf: memoryview | bytearray, error: RegionAllocationError) -> None:
     view = _as_memoryview(buf, ALLOCATE_REPLY_BYTES, writable=True)
-    _zero_reply(view)
+    _zero_reply(view, ALLOCATE_REPLY_BYTES)
     _pack_allocate_header(
         view,
         resource_id=error.provisional_resource_id,
@@ -584,7 +604,7 @@ def decode_allocate_reply(
 
 def encode_release_request(buf: memoryview | bytearray, provider_resource_id: int) -> None:
     view = _as_memoryview(buf, RELEASE_REQUEST_BYTES, writable=True)
-    view[:] = b"\x00" * RELEASE_REQUEST_BYTES
+    view[:RELEASE_REQUEST_BYTES] = b"\x00" * RELEASE_REQUEST_BYTES
     _RELEASE_REQUEST.pack_into(
         view,
         0,
@@ -660,7 +680,7 @@ def encode_release_result_reply(buf: memoryview | bytearray, result: ProviderRel
                 RegionControlErrorKind.INTERNAL_INVARIANT,
                 "CLEANUP_INCOMPLETE requires a nonzero failure mask",
             )
-    _zero_reply(view)
+    _zero_reply(view, RELEASE_REPLY_BYTES)
     _pack_release_reply(
         view,
         resource_id=result.provider_resource_id,
@@ -683,7 +703,7 @@ def encode_release_error_reply(
             RegionControlErrorKind.INTERNAL_INVARIANT,
             "RELEASE_ERROR kind must be INVALID_FIELD_VALUE, STORE_LIFECYCLE, or INTERNAL_INVARIANT",
         )
-    _zero_reply(view)
+    _zero_reply(view, RELEASE_REPLY_BYTES)
     _pack_release_reply(
         view,
         resource_id=int(provider_resource_id),
@@ -829,7 +849,7 @@ def decode_release_reply(buf: memoryview | bytes | bytearray) -> ProviderRelease
 
 def handle_ctrl_region_allocate(req_buf: memoryview, reply_buf: memoryview, store: ProviderRegionStore) -> None:
     reply = _as_memoryview(reply_buf, ALLOCATE_REPLY_BYTES, writable=True)
-    _zero_reply(reply)
+    _zero_reply(reply, ALLOCATE_REPLY_BYTES)
     try:
         spec = decode_allocate_request(req_buf)
     except RegionControlError as exc:
@@ -853,7 +873,7 @@ def handle_ctrl_region_allocate(req_buf: memoryview, reply_buf: memoryview, stor
 
 def handle_ctrl_region_release(req_buf: memoryview, reply_buf: memoryview, store: ProviderRegionStore) -> None:
     reply = _as_memoryview(reply_buf, RELEASE_REPLY_BYTES, writable=True)
-    _zero_reply(reply)
+    _zero_reply(reply, RELEASE_REPLY_BYTES)
     try:
         resource_id = decode_release_request(req_buf)
     except RegionControlError as exc:
@@ -886,8 +906,8 @@ class ProviderAllocateClient:
         self.committed_resource_id = 0
         req_shm = SharedMemory(create=True, size=ALLOCATE_REQUEST_BYTES)
         reply_shm = SharedMemory(create=True, size=ALLOCATE_REPLY_BYTES)
-        req_buf = memoryview(_require_shm_buf(req_shm))
-        reply_buf = memoryview(_require_shm_buf(reply_shm))
+        req_buf = _require_shm_buf(req_shm)
+        reply_buf = _require_shm_buf(reply_shm)
         try:
             encode_allocate_request(req_buf, spec)
             self.dispatch_started = True
@@ -907,8 +927,8 @@ class ProviderAllocateClient:
                 RegionControlErrorKind.INVALID_FIELD_VALUE, "allocate reply is uncommitted"
             )
         finally:
-            del req_buf
-            del reply_buf
+            _release_exported_view(req_buf)
+            _release_exported_view(reply_buf)
             _discard_control_shm(req_shm)
             _discard_control_shm(reply_shm)
 
@@ -951,8 +971,8 @@ class ProviderReleaseClient:
     def _issue(self, provider_resource_id: int) -> ProviderReleaseResult:
         req_shm = SharedMemory(create=True, size=RELEASE_REQUEST_BYTES)
         reply_shm = SharedMemory(create=True, size=RELEASE_REPLY_BYTES)
-        req_buf = memoryview(_require_shm_buf(req_shm))
-        reply_buf = memoryview(_require_shm_buf(reply_shm))
+        req_buf = _require_shm_buf(req_shm)
+        reply_buf = _require_shm_buf(reply_shm)
         try:
             encode_release_request(req_buf, provider_resource_id)
             try:
@@ -967,7 +987,7 @@ class ProviderReleaseClient:
                 raise RegionControlProtocolError(decoded.kind, decoded.message or decoded.kind.name)
             return decoded
         finally:
-            del req_buf
-            del reply_buf
+            _release_exported_view(req_buf)
+            _release_exported_view(reply_buf)
             _discard_control_shm(req_shm)
             _discard_control_shm(reply_shm)

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -179,6 +179,9 @@ from .comm_provider import (
     VmmShareableHandleImport,
 )
 from .comm_provider_control import (
+    _close_attached_control_shm,
+    _release_exported_view,
+    _require_shm_buf,
     handle_ctrl_region_allocate,
     handle_ctrl_region_release,
 )
@@ -2383,15 +2386,19 @@ def _handle_ctrl_region_allocate(buf: memoryview, store: ProviderRegionStore) ->
     reply_shm_name = _read_shm_name(buf, _OFF_ARGS + _CTRL_SHM_NAME_BYTES)
     req_shm = SharedMemory(name=request_shm_name)
     reply_shm = SharedMemory(name=reply_shm_name)
-    req_buf = cast(memoryview, req_shm.buf)
-    reply_buf = cast(memoryview, reply_shm.buf)
+    req_buf = _require_shm_buf(req_shm)
+    reply_buf = _require_shm_buf(reply_shm)
+    pending: BaseException | None = None
     try:
         handle_ctrl_region_allocate(req_buf, reply_buf, store)
+    except BaseException as exc:
+        pending = exc
+        raise
     finally:
-        del req_buf
-        del reply_buf
-        req_shm.close()
-        reply_shm.close()
+        _release_exported_view(req_buf)
+        _release_exported_view(reply_buf)
+        _close_attached_control_shm(req_shm, pending)
+        _close_attached_control_shm(reply_shm, pending)
 
 
 def _handle_ctrl_region_release(buf: memoryview, store: ProviderRegionStore) -> None:
@@ -2399,15 +2406,19 @@ def _handle_ctrl_region_release(buf: memoryview, store: ProviderRegionStore) -> 
     reply_shm_name = _read_shm_name(buf, _OFF_ARGS + _CTRL_SHM_NAME_BYTES)
     req_shm = SharedMemory(name=request_shm_name)
     reply_shm = SharedMemory(name=reply_shm_name)
-    req_buf = cast(memoryview, req_shm.buf)
-    reply_buf = cast(memoryview, reply_shm.buf)
+    req_buf = _require_shm_buf(req_shm)
+    reply_buf = _require_shm_buf(reply_shm)
+    pending: BaseException | None = None
     try:
         handle_ctrl_region_release(req_buf, reply_buf, store)
+    except BaseException as exc:
+        pending = exc
+        raise
     finally:
-        del req_buf
-        del reply_buf
-        req_shm.close()
-        reply_shm.close()
+        _release_exported_view(req_buf)
+        _release_exported_view(reply_buf)
+        _close_attached_control_shm(req_shm, pending)
+        _close_attached_control_shm(reply_shm, pending)
 
 
 def _open_global_domain_payload(buf: memoryview) -> tuple[SharedMemory, memoryview, int]:

--- a/tests/ut/py/test_worker/test_comm_provider_control.py
+++ b/tests/ut/py/test_worker/test_comm_provider_control.py
@@ -11,6 +11,7 @@
 
 from __future__ import annotations
 
+import gc
 import logging
 import struct
 from multiprocessing.shared_memory import SharedMemory
@@ -54,6 +55,7 @@ from simpler.comm_provider_control import (
     ProviderReleaseClient,
     RegionControlProtocolError,
     ReleaseReplyTag,
+    _as_memoryview,
     _discard_control_shm,
     decode_allocate_reply,
     decode_allocate_request,
@@ -168,6 +170,13 @@ def test_codec_uses_wire_prefix_of_larger_transport_mapping():
 
     assert peek_allocate_reply_resource_id(reply) == 11
     assert peek_allocate_reply_resource_id(bytearray(ALLOCATE_REPLY_BYTES - 1)) == 0
+
+
+def test_as_memoryview_returns_the_input_view_for_a_padded_mapping():
+    root = memoryview(bytearray(4096))
+    view = _as_memoryview(root, ALLOCATE_REQUEST_BYTES, writable=True)
+    assert view is root
+    assert view.nbytes == 4096
 
 
 @pytest.mark.parametrize(
@@ -843,3 +852,49 @@ def test_allocate_and_release_survive_control_shm_cleanup_failure(monkeypatch, c
     assert ops == ["close", "unlink", "close", "unlink", "close", "unlink", "close", "unlink"]
     assert caplog.text.count("operation=close") == 4
     assert caplog.text.count("operation=unlink") == 4
+
+
+def _force_page_padded_control_shm(monkeypatch) -> None:
+    from simpler import comm_provider_control as control
+
+    real = control.SharedMemory
+
+    def _padded(name=None, create=False, size=0):
+        if create and 0 < size < 4096:
+            size = 4096
+        return real(name=name, create=create, size=size)
+
+    monkeypatch.setattr(control, "SharedMemory", _padded)
+
+
+@pytest.mark.filterwarnings("error::pytest.PytestUnraisableExceptionWarning")
+def test_allocate_client_page_padded_discard_does_not_leave_unraisable_close(monkeypatch):
+    _force_page_padded_control_shm(monkeypatch)
+    factory = FakeShellFactory()
+    store = ProviderRegionStore(_sim_context(), _shell_factory=factory)
+    mailbox = _CommitThenRaiseMailbox(store)
+    client = ProviderAllocateClient(mailbox, 3)
+    with pytest.raises(RuntimeError, match="mailbox down after commit"):
+        client.allocate(_allocation_spec())
+    assert client.dispatch_started is True
+    assert client.committed_resource_id == 1
+    gc.collect()
+
+
+@pytest.mark.filterwarnings("error::pytest.PytestUnraisableExceptionWarning")
+def test_release_client_page_padded_discard_does_not_leave_unraisable_close(monkeypatch):
+    _force_page_padded_control_shm(monkeypatch)
+
+    class _BoomMailbox:
+        def control_region_allocate(self, worker_id: int, request_shm_name: str, reply_shm_name: str) -> None:
+            del worker_id, request_shm_name, reply_shm_name
+            raise AssertionError("allocate must not be called")
+
+        def control_region_release(self, worker_id: int, request_shm_name: str, reply_shm_name: str) -> None:
+            del worker_id, request_shm_name, reply_shm_name
+            raise RuntimeError("mailbox down")
+
+    client = ProviderReleaseClient(_BoomMailbox(), 1)
+    with pytest.raises(RegionControlProtocolError):
+        client.release(4)
+    gc.collect()

--- a/tests/ut/py/test_worker/test_worker_chip_orch_comm.py
+++ b/tests/ut/py/test_worker/test_worker_chip_orch_comm.py
@@ -44,12 +44,15 @@ from simpler.comm_provider import (
 from simpler.comm_provider_control import (
     ALLOCATE_REPLY_BYTES,
     ALLOCATE_REQUEST_BYTES,
+    RELEASE_REQUEST_BYTES,
     AllocateReplyTag,
     decode_allocate_reply,
     decode_allocate_request,
+    decode_release_reply,
     decode_release_request,
     encode_allocate_request,
     encode_allocate_success_reply,
+    encode_release_request,
     encode_release_result_reply,
 )
 from simpler.orchestrator import Orchestrator
@@ -1190,8 +1193,8 @@ def test_region_allocate_handler_commits_store_success_into_reply_shm():
         assert released.status is ProviderReleaseStatus.RELEASED
     finally:
         ctrl_buf.release()
-        del req_buf
-        del reply_buf
+        req_buf.release()
+        reply_buf.release()
         req_shm.close()
         req_shm.unlink()
         reply_shm.close()
@@ -1221,8 +1224,133 @@ def test_region_allocate_handler_writes_request_error_for_bad_magic():
         assert error.kind is RegionControlErrorKind.BAD_MAGIC_VERSION
     finally:
         ctrl_buf.release()
-        del req_buf
-        del reply_buf
+        req_buf.release()
+        reply_buf.release()
+        req_shm.close()
+        req_shm.unlink()
+        reply_shm.close()
+        reply_shm.unlink()
+
+
+def _page_padded_region_ctrl_pair():
+    req_shm = SharedMemory(create=True, size=4096)
+    reply_shm = SharedMemory(create=True, size=4096)
+    ctrl_storage = bytearray(worker_module._OFF_ARGS + 2 * worker_module._CTRL_SHM_NAME_BYTES)
+    ctrl_buf = memoryview(ctrl_storage)
+    _write_ctrl_shm_name(ctrl_buf, worker_module._OFF_ARGS, req_shm.name)
+    _write_ctrl_shm_name(ctrl_buf, worker_module._OFF_ARGS + worker_module._CTRL_SHM_NAME_BYTES, reply_shm.name)
+    return req_shm, reply_shm, ctrl_buf
+
+
+@pytest.mark.filterwarnings("error::pytest.PytestUnraisableExceptionWarning")
+def test_region_allocate_handler_page_padded_request_error_closes_without_buffer_error():
+    from tests.ut.py.test_worker.test_comm_provider import FakeShellFactory, _sim_context
+
+    req_shm, reply_shm, ctrl_buf = _page_padded_region_ctrl_pair()
+    try:
+        req_buf = cast(memoryview, req_shm.buf)
+        req_buf[:ALLOCATE_REQUEST_BYTES] = b"\x00" * ALLOCATE_REQUEST_BYTES
+        struct.pack_into("<QI", req_buf, 0, 0xDEAD, ALLOCATE_REQUEST_BYTES)
+        req_buf.release()
+        store = ProviderRegionStore(_sim_context(), _shell_factory=FakeShellFactory())
+        worker_module._handle_ctrl_region_allocate(ctrl_buf, store)
+        reply_buf = cast(memoryview, reply_shm.buf)
+        try:
+            tag, result, _payload, _counter, error = decode_allocate_reply(reply_buf)
+        finally:
+            reply_buf.release()
+        assert tag is AllocateReplyTag.REQUEST_ERROR
+        assert result is None
+        assert isinstance(error, RegionControlError)
+        assert error.kind is RegionControlErrorKind.BAD_MAGIC_VERSION
+    finally:
+        ctrl_buf.release()
+        req_shm.close()
+        req_shm.unlink()
+        reply_shm.close()
+        reply_shm.unlink()
+
+
+@pytest.mark.filterwarnings("error::pytest.PytestUnraisableExceptionWarning")
+def test_region_allocate_handler_preserves_store_lifecycle_over_close_buffer_error(monkeypatch):
+    from tests.ut.py.test_worker.test_comm_provider import FakeShellFactory, _allocation_spec, _sim_context
+
+    req_shm, reply_shm, ctrl_buf = _page_padded_region_ctrl_pair()
+    try:
+        req_buf = cast(memoryview, req_shm.buf)
+        encode_allocate_request(req_buf, _allocation_spec())
+        req_buf.release()
+        store = ProviderRegionStore(_sim_context(), _shell_factory=FakeShellFactory())
+
+        def _closed(_spec):
+            raise RegionControlError(RegionControlErrorKind.STORE_LIFECYCLE, "store is not OPEN")
+
+        monkeypatch.setattr(store, "allocate_and_export", _closed)
+        with pytest.raises(RegionControlError) as exc_info:
+            worker_module._handle_ctrl_region_allocate(ctrl_buf, store)
+        assert exc_info.value.kind is RegionControlErrorKind.STORE_LIFECYCLE
+        attached_req = SharedMemory(name=req_shm.name)
+        attached_req.close()
+        attached_reply = SharedMemory(name=reply_shm.name)
+        attached_reply.close()
+    finally:
+        ctrl_buf.release()
+        req_shm.close()
+        req_shm.unlink()
+        reply_shm.close()
+        reply_shm.unlink()
+
+
+@pytest.mark.filterwarnings("error::pytest.PytestUnraisableExceptionWarning")
+def test_region_release_handler_page_padded_request_error_closes_without_buffer_error():
+    from tests.ut.py.test_worker.test_comm_provider import FakeShellFactory, _sim_context
+
+    req_shm, reply_shm, ctrl_buf = _page_padded_region_ctrl_pair()
+    try:
+        req_buf = cast(memoryview, req_shm.buf)
+        req_buf[:RELEASE_REQUEST_BYTES] = b"\x00" * RELEASE_REQUEST_BYTES
+        req_buf.release()
+        store = ProviderRegionStore(_sim_context(), _shell_factory=FakeShellFactory())
+        worker_module._handle_ctrl_region_release(ctrl_buf, store)
+        reply_buf = cast(memoryview, reply_shm.buf)
+        try:
+            decoded = decode_release_reply(reply_buf)
+        finally:
+            reply_buf.release()
+        assert isinstance(decoded, RegionControlError)
+        assert decoded.kind is RegionControlErrorKind.INVALID_FIELD_VALUE
+    finally:
+        ctrl_buf.release()
+        req_shm.close()
+        req_shm.unlink()
+        reply_shm.close()
+        reply_shm.unlink()
+
+
+@pytest.mark.filterwarnings("error::pytest.PytestUnraisableExceptionWarning")
+def test_region_release_handler_preserves_backend_failure_over_close_buffer_error(monkeypatch):
+    from tests.ut.py.test_worker.test_comm_provider import FakeShellFactory, _sim_context
+
+    req_shm, reply_shm, ctrl_buf = _page_padded_region_ctrl_pair()
+    try:
+        req_buf = cast(memoryview, req_shm.buf)
+        encode_release_request(req_buf, 4)
+        req_buf.release()
+        store = ProviderRegionStore(_sim_context(), _shell_factory=FakeShellFactory())
+
+        def _injected(_resource_id):
+            raise RegionControlError(RegionControlErrorKind.BACKEND_FAILURE, "injected")
+
+        monkeypatch.setattr(store, "release", _injected)
+        with pytest.raises(RegionControlError) as exc_info:
+            worker_module._handle_ctrl_region_release(ctrl_buf, store)
+        assert exc_info.value.kind is RegionControlErrorKind.BACKEND_FAILURE
+        attached_req = SharedMemory(name=req_shm.name)
+        attached_req.close()
+        attached_reply = SharedMemory(name=reply_shm.name)
+        attached_reply.close()
+    finally:
+        ctrl_buf.release()
         req_shm.close()
         req_shm.unlink()
         reply_shm.close()
@@ -1899,6 +2027,7 @@ def test_sim_worker_counter_wait_timeout_does_not_poison_region_and_free_is_idem
         worker.close()
 
 
+@pytest.mark.filterwarnings("error::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.parametrize("platform", ["a2a3sim", "a5sim"])
 def test_sim_public_api_two_shm_objects_and_two_consecutive_lifecycles(platform, monkeypatch):
     try:


### PR DESCRIPTION
## Summary
- Fixes [#2008](https://github.com/hw-native-sys/simpler/issues/2008): provider-region allocate/release could `close()` control `SharedMemory` while exported `memoryview`s were still live, raising `BufferError: cannot close exported pointers exist`.
- That cleanup error replaced codec/store failures (including allocate `STORE_LIFECYCLE`) and later reappeared as `PytestUnraisableExceptionWarning` from `SharedMemory.__del__`. Regression path is from [#1933](https://github.com/hw-native-sys/simpler/pull/1933).
- Stop returning a long-lived prefix slice from `_as_memoryview`, zero only the wire-frame prefix, release root views before attach-side `close()` / owner-side `_discard_control_shm`, and preserve the original mailbox exception when a cleanup `BufferError` happens on an already-failing path.
