### PR TITLE
Support: split a bind phase's wall time into running and waiting

### DIFF
--- a/docs/dfx/hbg-bind-phases.md
+++ b/docs/dfx/hbg-bind-phases.md
@@ -184,6 +184,47 @@ is a copy count of the other.)
 The first bind of each rank is warm-up and belongs in neither statistic; drop it
 explicitly rather than letting a minimum quietly exclude it.
 
+### Was the segment running or waiting?
+
+Every line also carries the kernel counters, which say what a duration cannot. Each
+covers the same span the duration does.
+
+| Field | Source | What it says |
+| ----- | ------ | ------------ |
+| `cpu_ns` | the bind thread's `CLOCK_THREAD_CPUTIME_ID` | how much of the segment that thread spent **running**, so `dur_ns - cpu_ns` is what it spent **off CPU** — blocked *and* runnable-but-preempted, which the two `*csw` counters separate |
+| `rec_cpu_ns` | every recording worker's CPU clock, summed | how many threads' worth of work ran **alongside** — a ratio to `dur_ns`, never something to subtract from it |
+| `minflt` / `tminflt` | `getrusage` `RUSAGE_SELF` / `RUSAGE_THREAD` | minor faults for the whole process, and the bind thread's share of them; the difference is the recorders' |
+| `nvcsw` / `nivcsw` | `getrusage` `RUSAGE_SELF` | voluntary and involuntary context switches **for the whole process**, so the recorders' switches are in here too. A high `nivcsw` says the box was loaded, not that this code was; neither counter isolates the bind thread — `tminflt` is the only thread-scoped field |
+
+**`rec_cpu_ns` and `tminflt` are Linux-only, and read zero elsewhere.** Sampling
+another thread's CPU clock needs `pthread_getcpuclockid` and a per-thread fault count
+needs `getrusage(RUSAGE_THREAD)`; Darwin provides neither. That costs nothing where it
+matters — a bind is profiled on the silicon it binds to — but on a `*sim` platform
+built for macOS a `reccpu` of 0 means "not measurable here", not "nothing ran
+alongside". `cpu_ns` uses `CLOCK_THREAD_CPUTIME_ID` for the calling thread and works
+everywhere.
+
+```bash
+python -m simpler_setup.tools.phase_time_split <log>          # cold and warm, per segment
+python -m simpler_setup.tools.phase_time_split <log> --phase host_orch
+```
+
+**CPU time comes from per-thread clocks and never from rusage.** `ru_utime` and
+`ru_stime` are accounted per scheduler tick — 10 ms at `CLK_TCK=100` — so on a segment
+of a millisecond they quantise to either zero or a whole tick, and the values look
+plausible one at a time while being noise. A per-thread clock reads the scheduler's
+running total in nanoseconds; measured against a busy and a sleeping thread over a
+1.29 ms window it resolved both to under 10 µs. The three counters stay on rusage
+because they are event counts, which do not quantise.
+
+**On-CPU sends you somewhere different from off-CPU.** A segment that is mostly
+on-CPU is running, so split it further by the fault count and by the syscalls inside
+its window. A segment that is mostly off-CPU is waiting, and `nvcsw` versus `nivcsw`
+says whether it blocked or merely lost the CPU. Reading a fault count without this
+split is what let a page-fault tail be chased three times on a segment whose faults
+were on threads with spare parallelism — see
+[`docs/investigations/2026-08-host-orch-phase-tail-is-page-faults.md`](../investigations/2026-08-host-orch-phase-tail-is-page-faults.md).
+
 Device wall clock for the same rounds comes from the `[STRACE]` markers, on a run
 that did not skip the device:
 

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -15,6 +15,7 @@ no repo checkout required.
 - **[critical_path](#critical_path)** — chip swimlane critical-path compute/stall analysis
 - **[strace_timing](#strace_timing)** — per-stage `chip.run` breakdown (host + AICPU phases) from `[STRACE]` log markers → TPOT table, per-round table (`--rounds-table`), nested tree (`--tree`), or Perfetto JSON
 - **[hbg_bind_phases](#hbg_bind_phases)** — `host_build_graph` `bind`-stage phases from `bind phase=` log markers → per-phase min/median/max plus the control-plane total
+- **[phase_time_split](#phase_time_split)** — the same `bind phase=` markers split into on-CPU and off-CPU per phase, from per-thread CPU clocks, with cold and warm binds reported separately
 - **[dump_viewer](#dump_viewer)** — inspect / export args dumps (see [docs/args-dump.md](../../docs/dfx/args-dump.md) for full workflow)
 - **[deps_viewer](#deps_viewer)** — `deps.json` (dep_gen) → text or pan/zoom HTML dependency graph
 
@@ -415,6 +416,44 @@ excluded with a warning. If the log's first line is a `[stamp]` line naming the
 command and commit, it is echoed above the table. Distinct
 `torch_backend_autoload` records are printed alongside it. Missing stamps or
 autoload records produce an explicit comparison warning.
+
+---
+
+## phase_time_split
+
+The same `bind phase=` markers, read for a different question: was a segment
+**running** or **waiting**? A duration cannot say, and the answer decides where to
+look next — an on-CPU segment is split further by its fault count and by the
+syscalls inside its window, while an off-CPU one is a wait, and `nvcsw` versus
+`nivcsw` suggests whether the waiting was blocking or losing the CPU to a loaded box.
+Both come from `RUSAGE_SELF` and so count the whole process, recorders included, which
+is why they suggest rather than decide.
+
+```bash
+python -m simpler_setup.tools.phase_time_split path/to/log
+python -m simpler_setup.tools.phase_time_split path/to/log --phase host_orch
+```
+
+`cpu` is the bind thread's own CPU time, so `dur - cpu` is what it spent off CPU.
+`reccpu` is every Graph recording worker's summed, so `rec/dur` is how many threads'
+worth of work ran alongside — a concurrency ratio, not a share of the wall. One
+recorder busy for the whole segment reads about 1, partial overlap reads below it, and
+only aggregate recorder CPU exceeding one wall-time interval — two or more busy at
+once — pushes it above 1. `reccpu` and `tminflt` need Linux
+(`pthread_getcpuclockid`, `getrusage(RUSAGE_THREAD)`); on a log from a macOS `*sim`
+build they are 0 because they cannot be sampled, not because nothing ran.
+
+Cold and warm binds are reported as separate rows rather than the cold one being
+dropped: a cold bind pays the one-off cost of standing recorder storage and the arenas
+up, and its size is the thing worth knowing when the goal is to move that cost to
+`Worker.init()`.
+
+Times come from per-thread CPU clocks, in nanoseconds. rusage times are not used:
+`ru_utime`/`ru_stime` are accounted per scheduler tick, 10 ms at `CLK_TCK=100`, so on a
+segment of a millisecond they quantise to either zero or a whole tick — plausible
+one at a time, noise in aggregate. A log written before the clocks existed is refused
+rather than reported as all-on-CPU. See
+[docs/dfx/hbg-bind-phases.md](../../docs/dfx/hbg-bind-phases.md) for the field table.
 
 ---
 

--- a/simpler_setup/tools/phase_time_split.py
+++ b/simpler_setup/tools/phase_time_split.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Split a bind phase's wall time into running and waiting, per phase and per thread.
+
+Reads the `bind phase=` markers a run emits under
+`SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1`. A phase's duration alone cannot say whether it
+was computing or blocked, and that decides where to look next:
+
+  on-CPU dominates   -> it is running. Split it by the fault count and by the syscalls
+                        inside the phase's window, neither of which quantises.
+  off-CPU dominates  -> it is waiting. `nvcsw` counts blocking and `nivcsw` counts being
+                        preempted, which is a loaded box rather than the code.
+
+Times come from per-thread CPU clocks, in nanoseconds, so a phase of a millisecond
+resolves. rusage times are deliberately not used: `ru_utime`/`ru_stime` are accounted per
+scheduler tick, 10 ms at `CLK_TCK=100`, so on such a phase they quantise to either zero
+or a whole tick. rusage still supplies the three counters, which are event counts and do
+not quantise.
+
+`cpu` is the bind thread's own, so `dur - cpu` is the time it spent off CPU. `reccpu` is
+every recording worker's summed, so `rec/dur` is how many threads' worth of work ran
+alongside it — a ratio, not something to subtract from the wall.
+
+Cold and warm binds are reported separately, because they answer different questions: a
+cold bind pays the one-off cost of standing recorder storage and the arenas up, and a
+warm one does not.
+"""
+
+import argparse
+import re
+import statistics
+import sys
+
+FIELDS = ("minflt", "tminflt", "nivcsw", "nvcsw", "cpu_ns", "rec_cpu_ns")
+MARKER = re.compile(r"bind phase=(?P<phase>[a-z_]+) start_ns=\d+ dur_ns=(?P<dur>\d+)(?P<rest>.*)")
+
+
+def parse(path):
+    rows = []
+    for line in open(path, errors="replace"):
+        marker = MARKER.search(line)
+        if not marker:
+            continue
+        row = {"phase": marker.group("phase"), "dur_us": int(marker.group("dur")) / 1000.0}
+        for field in FIELDS:
+            hit = re.search(rf"\b{field}=(\d+)", marker.group("rest"))
+            row[field] = int(hit.group(1)) if hit else None
+        rows.append(row)
+    return rows
+
+
+def summarise(group):
+    """Medians of the per-bind figures, so one outlying bind cannot set the row."""
+
+    def med(pick):
+        return statistics.median(pick(row) for row in group)
+
+    return {
+        "n": len(group),
+        "dur": med(lambda r: r["dur_us"]),
+        "cpu": med(lambda r: r["cpu_ns"] / 1000.0),
+        # Per bind, so the median of the differences rather than the difference of medians.
+        "offcpu": med(lambda r: max(0.0, r["dur_us"] - r["cpu_ns"] / 1000.0)),
+        "reccpu": med(lambda r: r["rec_cpu_ns"] / 1000.0),
+        "rec_ratio": med(lambda r: r["rec_cpu_ns"] / 1000.0 / r["dur_us"] if r["dur_us"] else 0.0),
+        "minflt": med(lambda r: r["minflt"]),
+        "tminflt": med(lambda r: r["tminflt"]),
+        "nvcsw": med(lambda r: r["nvcsw"]),
+        "nivcsw": med(lambda r: r["nivcsw"]),
+        # One thread cannot spend more CPU than the phase's own wall, so a row like this
+        # means the counter mark belongs to a different span than the duration. Each
+        # phase now carries its own mark in the frame that opened it, so no other phase
+        # — nested, or on a concurrently preparing thread — can take it; this stays as a
+        # backstop, and a non-zero count is a defect in the runtime rather than a known
+        # limitation. The affected row's cpu, offcpu and off% describe neither span and
+        # are flagged rather than clamped.
+        "unmarked": sum(1 for row in group if row["cpu_ns"] / 1000.0 > row["dur_us"]),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("log", help="run log carrying `bind phase=` markers")
+    parser.add_argument("--ranks", type=int, default=2, help="binds to treat as cold, one per rank (default 2)")
+    parser.add_argument("--phase", default=None, help="only this phase")
+    args = parser.parse_args()
+
+    rows = parse(args.log)
+    if not rows:
+        sys.exit(f"{args.log}: no `bind phase=` markers — was SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 set?")
+    if rows[0]["cpu_ns"] is None:
+        sys.exit(f"{args.log}: markers carry no cpu_ns — this log predates the per-thread CPU clocks")
+
+    phases = {}
+    for row in rows:
+        phases.setdefault(row["phase"], []).append(row)
+
+    header = (
+        f"{'phase':<16}{'':>6}{'n':>3}{'dur':>13}{'cpu':>13}{'offcpu':>13}{'off%':>6}"
+        f"{'reccpu':>13}{'rec/dur':>9}{'minflt':>8}{'tminflt':>8}{'nvcsw':>8}{'nivcsw':>7}"
+    )
+    print(header)
+    print("-" * len(header))
+    flagged = False
+    for phase, group in phases.items():
+        if args.phase and phase != args.phase:
+            continue
+        for label, part in (("cold", group[: args.ranks]), ("warm", group[args.ranks :])):
+            if not part:
+                continue
+            stats = summarise(part)
+            off_pct = 100.0 * stats["offcpu"] / stats["dur"] if stats["dur"] else 0.0
+            mark = " !" if stats["unmarked"] else ""
+            flagged = flagged or bool(mark)
+            print(
+                f"{phase:<16}{label:>6}{stats['n']:>3}{stats['dur']:>13.1f}{stats['cpu']:>13.1f}"
+                f"{stats['offcpu']:>13.1f}{off_pct:>5.0f}%{stats['reccpu']:>13.1f}{stats['rec_ratio']:>9.2f}"
+                f"{stats['minflt']:>8.0f}{stats['tminflt']:>8.0f}{stats['nvcsw']:>8.0f}{stats['nivcsw']:>7.0f}{mark}"
+            )
+    print("\nmedians over the binds in each group; times in us. cpu/offcpu are the bind")
+    print("thread's own, reccpu is every recording worker's, so rec/dur is concurrency.")
+    if flagged:
+        print("! at least one bind reported more CPU than the segment's own wall, so its")
+        print("  counter mark covers a different span than its duration: that row's")
+        print("  cpu/offcpu/off% are unusable. Each phase carries its own mark, so this is")
+        print("  a runtime defect worth reporting rather than a known limitation.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/a2a3/runtime/host_build_graph/host/graph_recorder_pool.h
+++ b/src/a2a3/runtime/host_build_graph/host/graph_recorder_pool.h
@@ -193,6 +193,40 @@ public:
         });
     }
 
+    // Sum of every recording worker's CPU time. Differencing this across a phase says
+    // how many threads' worth of work ran alongside the thread that runs the bind,
+    // which a wall-clock duration cannot: the recorders overlap it.
+    //
+    // A per-thread CPU clock is the only instrument that resolves a phase of a
+    // millisecond. rusage times are accounted per scheduler tick, 10 ms at
+    // CLK_TCK=100, so on such a phase they quantise to either zero or a whole tick.
+    //
+    // Read under this pool's own mutex, from whichever thread asks, so no handle is
+    // sampled while it is being created or destroyed: create_worker_locked() runs under
+    // that mutex, and shutdown() empties workers_ under it before it joins anything. A
+    // thread that has already exited answers EINVAL and contributes nothing, which is
+    // correct: its time belongs to no phase still being measured.
+    //
+    // Linux only, and zero elsewhere: reading another thread's CPU clock needs
+    // pthread_getcpuclockid, which Darwin does not provide. The bind breakdown profiles
+    // onboard runs, so the platforms that lack it are the ones that never take this
+    // measurement -- but rec_cpu_ns carries no information there, and the tooling says so.
+    uint64_t worker_cpu_ns() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        uint64_t total = 0;
+#if defined(__linux__)
+        for (std::thread &worker : workers_) {
+            if (!worker.joinable()) continue;
+            clockid_t clock_id{};
+            if (pthread_getcpuclockid(worker.native_handle(), &clock_id) != 0) continue;
+            timespec ts{};
+            if (clock_gettime(clock_id, &ts) != 0) continue;
+            total += static_cast<uint64_t>(ts.tv_sec) * 1000000000ULL + static_cast<uint64_t>(ts.tv_nsec);
+        }
+#endif
+        return total;
+    }
+
 private:
     bool storage_failed_{false};
 
@@ -272,12 +306,19 @@ private:
 
     void shutdown() {
         wait();
+        std::vector<std::thread> draining;
         {
             std::lock_guard<std::mutex> lock(mutex_);
             stopping_ = true;
+            // The handles leave workers_ under the lock and are joined without it.
+            // Joining while holding mutex_ deadlocks: a worker reacquires it inside
+            // cv_.wait to observe stopping_ and return. Emptying workers_ here is also
+            // what keeps worker_cpu_ns() off a handle mid-join, since it samples under
+            // this same mutex and so sees an empty pool for the rest of teardown.
+            draining.swap(workers_);
         }
         cv_.notify_all();
-        for (std::thread &worker : workers_) {
+        for (std::thread &worker : draining) {
             if (worker.joinable()) worker.join();
         }
     }

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -143,41 +143,89 @@ static int64_t bind_now_ns() { return static_cast<int64_t>(host_phase_now_ns());
 // once per page, and the bind maps its shared-memory mirror and arenas per call, so
 // a phase's fault count is what separates work from page-table cost — a count, so it
 // does not move with how loaded the box is.
+//
+// CPU time answers what a count cannot: whether a phase's wall time was spent running
+// or waiting. It comes from per-thread CPU clocks and never from rusage —
+// `ru_utime`/`ru_stime` are accounted per scheduler tick, 10 ms at CLK_TCK=100, so on
+// a phase of a millisecond they quantise to either zero or a whole tick and no split
+// survives. A per-thread clock reads the scheduler's running total in nanoseconds.
+//
+// Two CPU figures, because a phase runs on more than one thread. `cpu_ns` is the bind
+// thread's own, so a phase's `dur - cpu_ns` is the time that thread spent off CPU;
+// `recorder_cpu_ns` is every recording worker's summed, so its ratio to `dur` is how
+// many threads' worth of work ran alongside. Only the first can be subtracted from the
+// wall. `thread_minflt` is the same split applied to the fault count: it says how much
+// of `minflt` the bind thread took rather than the recorders.
 struct BindKernelCounters {
     uint64_t minflt;
+    uint64_t thread_minflt;
     uint64_t nivcsw;  // involuntary: the scheduler took the CPU away
     uint64_t nvcsw;   // voluntary: the thread blocked
+    uint64_t cpu_ns;
+    uint64_t recorder_cpu_ns;
 };
 
+static uint64_t thread_cpu_ns() {
+    timespec ts{};
+    if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) != 0) return 0;
+    return static_cast<uint64_t>(ts.tv_sec) * 1000000000ULL + static_cast<uint64_t>(ts.tv_nsec);
+}
+
 static BindKernelCounters bind_kernel_counters() {
+    BindKernelCounters counters{};
     rusage usage{};
-    if (getrusage(RUSAGE_SELF, &usage) != 0) return BindKernelCounters{};
-    return BindKernelCounters{
-        static_cast<uint64_t>(usage.ru_minflt), static_cast<uint64_t>(usage.ru_nivcsw),
-        static_cast<uint64_t>(usage.ru_nvcsw)
-    };
-}
-
-// A phase's own counts are the delta since its own start, so they cover the same
-// span its duration does. The markers do not partition the bind: the stretches
-// between one phase's close and the next one's open belong to neither, in counts
-// exactly as in time. Process-wide, so a phase that runs while the Graph recorders
-// are working is charged their faults too — which is the intent: it is the bind's
-// total page-table cost that is being attributed, not one thread's.
-static BindKernelCounters g_bind_counter_mark{};
-
-// Open one segment: the instant its duration measures from, and the counter mark
-// its faults measure from. Every phase start comes from here, so a phase's two
-// spans cannot drift apart — a fault count taken over a wider span than the clock
-// describes work the phase does not contain.
-static int64_t bind_phase_begin() {
-    if (host_phase_breakdown_enabled()) {
-        g_bind_counter_mark = bind_kernel_counters();
+    if (getrusage(RUSAGE_SELF, &usage) == 0) {
+        counters.minflt = static_cast<uint64_t>(usage.ru_minflt);
+        counters.nivcsw = static_cast<uint64_t>(usage.ru_nivcsw);
+        counters.nvcsw = static_cast<uint64_t>(usage.ru_nvcsw);
     }
-    return bind_now_ns();
+#if defined(__linux__)
+    // RUSAGE_THREAD is a Linux extension. Darwin has no per-thread rusage, so
+    // thread_minflt stays zero there and the process total in minflt is the whole of
+    // what is available.
+    rusage thread_usage{};
+    if (getrusage(RUSAGE_THREAD, &thread_usage) == 0) {
+        counters.thread_minflt = static_cast<uint64_t>(thread_usage.ru_minflt);
+    }
+#endif
+    counters.cpu_ns = thread_cpu_ns();
+    counters.recorder_cpu_ns = graph_recorder_pool().worker_cpu_ns();
+    return counters;
 }
 
-static void record_bind_phase(HostPhaseKind kind, int64_t start_ns, const char *attrs = "", uint64_t payload = 0) {
+// One segment's two origins: the instant its duration measures from and the counter
+// mark its faults measure from. Both live in the caller's frame, so a phase that
+// opens while another is still open cannot disturb it — the two would share a single
+// mark if one were held here, and the outer phase would then report counts measured
+// from the inner phase's start while its duration still spanned its own.
+//
+// A phase's own counts are the delta since its own start, so they cover the same
+// span its duration does. The marks do not partition the bind: the stretches
+// between one phase's close and the next one's open belong to neither, in counts
+// exactly as in time. The process-wide counters are process-wide on purpose, so a
+// phase that runs while the Graph recorders are working is charged their faults too
+// — it is the bind's total page-table cost that is being attributed, not one
+// thread's.
+struct BindPhaseMark {
+    int64_t start_ns{0};
+    BindKernelCounters counters{};
+};
+
+// Open one segment. Every phase start comes from here, so a phase's two spans cannot
+// drift apart — a fault count taken over a wider span than the clock describes work
+// the phase does not contain.
+static BindPhaseMark bind_phase_begin() {
+    BindPhaseMark mark{};
+    if (host_phase_breakdown_enabled()) {
+        mark.counters = bind_kernel_counters();
+    }
+    mark.start_ns = bind_now_ns();
+    return mark;
+}
+
+static void
+record_bind_phase(HostPhaseKind kind, const BindPhaseMark &mark, const char *attrs = "", uint64_t payload = 0) {
+    const int64_t start_ns = mark.start_ns;
     if (!host_phase_breakdown_enabled()) {
         host_phase_record_bind(static_cast<uint32_t>(kind), static_cast<uint64_t>(start_ns), attrs, payload);
         return;
@@ -194,9 +242,13 @@ static void record_bind_phase(HostPhaseKind kind, int64_t start_ns, const char *
     };
     char with_counters[kBindAttrsCapacity];
     snprintf(
-        with_counters, sizeof(with_counters), "%s%sminflt=%" PRIu64 " nivcsw=%" PRIu64 " nvcsw=%" PRIu64, attrs,
-        *attrs == '\0' ? "" : " ", since(now.minflt, g_bind_counter_mark.minflt),
-        since(now.nivcsw, g_bind_counter_mark.nivcsw), since(now.nvcsw, g_bind_counter_mark.nvcsw)
+        with_counters, sizeof(with_counters),
+        "%s%sminflt=%" PRIu64 " tminflt=%" PRIu64 " nivcsw=%" PRIu64 " nvcsw=%" PRIu64 " cpu_ns=%" PRIu64
+        " rec_cpu_ns=%" PRIu64,
+        attrs, *attrs == '\0' ? "" : " ", since(now.minflt, mark.counters.minflt),
+        since(now.thread_minflt, mark.counters.thread_minflt), since(now.nivcsw, mark.counters.nivcsw),
+        since(now.nvcsw, mark.counters.nvcsw), since(now.cpu_ns, mark.counters.cpu_ns),
+        since(now.recorder_cpu_ns, mark.counters.recorder_cpu_ns)
     );
     host_phase_record_bind(
         static_cast<uint32_t>(kind), static_cast<uint64_t>(start_ns), with_counters, payload,
@@ -630,7 +682,7 @@ int32_t run_host_orchestration(
     // rt_orchestration_done take the runtime as an argument.
     entry_points->bind(rt);
 
-    const int64_t t_orch_ns = bind_phase_begin();
+    const BindPhaseMark orch_phase = bind_phase_begin();
     rt_scope_begin(rt);
     entry_points->entry(orch_l2);
     rt_scope_end(rt);
@@ -683,7 +735,7 @@ int32_t run_host_orchestration(
             attrs, sizeof(attrs), "tasks=%" PRId32 " heap_used=%" PRIu64 " sm_mirror=%" PRIu64, total_tasks,
             orchestrator.task_allocator.heap_used_bytes(), sm_size
         );
-        record_bind_phase(HostPhaseKind::BindHostOrch, t_orch_ns, attrs);
+        record_bind_phase(HostPhaseKind::BindHostOrch, orch_phase, attrs);
     }
     // After the span closes: the reduction walks a few hundred records and emits
     // five markers, which must not be charged to the bind it measures.
@@ -705,7 +757,7 @@ int32_t run_host_orchestration(
     // Upload each distinct Definition as its own retained device object and bind
     // every outer Graph task to it. Per-invocation data already lives in that
     // task's payload regions and is copied with the shared-memory image below.
-    const int64_t t_graph_ns = bind_phase_begin();
+    const BindPhaseMark graph_phase = bind_phase_begin();
     DefinitionUploads definition_uploads{};
     if (!bind_graph_definitions(api, *graph_state, &definition_uploads, &ready_queue_populations)) {
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -722,7 +774,7 @@ int32_t run_host_orchestration(
             attrs, sizeof(attrs), "defs=%zu bytes=%" PRIu64 " submissions=%zu spilled=%zu", definition_uploads.count,
             definition_uploads.bytes, graph_host_upload_count(*graph_state), definition_uploads.spilled
         );
-        record_bind_phase(HostPhaseKind::BindGraphUpload, t_graph_ns, attrs, definition_uploads.bytes);
+        record_bind_phase(HostPhaseKind::BindGraphUpload, graph_phase, attrs, definition_uploads.bytes);
     }
 
     ReadyQueueCapacities ready_queue_capacities{};
@@ -779,7 +831,7 @@ int32_t run_host_orchestration(
     // region and short-circuits a request an existing one already covers, so a
     // repeated workload pays for neither twice and the heap is grow-only across a
     // Worker's binds.
-    const int64_t t_static_arena_ns = bind_phase_begin();
+    const BindPhaseMark static_arena_phase = bind_phase_begin();
     // The compact shared-memory image is the only per-run tail in the device
     // arena. GraphExecution is initialized later in each outer Graph heap.
     const uint64_t device_arena_bytes = layout.off_copied_end + image_bytes;
@@ -806,10 +858,10 @@ int32_t run_host_orchestration(
     {
         char attrs[kBindAttrsCapacity];
         snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " arena=%" PRIu64, heap_bytes, device_arena_bytes);
-        record_bind_phase(HostPhaseKind::BindStaticArena, t_static_arena_ns, attrs);
+        record_bind_phase(HostPhaseKind::BindStaticArena, static_arena_phase, attrs);
     }
 
-    const int64_t t_sm_ns = bind_phase_begin();
+    const BindPhaseMark sm_phase = bind_phase_begin();
     void *device_arena = api->acquire_pooled_runtime_arena();
     if (device_arena == nullptr) {
         LOG_ERROR("%s", "host-orch: failed to acquire the pooled runtime arena");
@@ -821,12 +873,12 @@ int32_t run_host_orchestration(
     {
         char attrs[kBindAttrsCapacity];
         snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, image_bytes);
-        record_bind_phase(HostPhaseKind::BindSharedMem, t_sm_ns, attrs, image_bytes);
+        record_bind_phase(HostPhaseKind::BindSharedMem, sm_phase, attrs, image_bytes);
     }
 
-    const int64_t t_heap_ns = bind_phase_begin();
+    const BindPhaseMark heap_phase = bind_phase_begin();
     void *gm_heap = api->acquire_pooled_gm_heap();
-    record_bind_phase(HostPhaseKind::BindGmHeap, t_heap_ns);
+    record_bind_phase(HostPhaseKind::BindGmHeap, heap_phase);
     if (gm_heap == nullptr) {
         LOG_ERROR("host-orch: failed to acquire the pooled GM heap");
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -876,7 +928,7 @@ int32_t run_host_orchestration(
     );
     always_assert(compacted == image_bytes);
 
-    const int64_t t_h2d_ns = bind_phase_begin();
+    const BindPhaseMark h2d_phase = bind_phase_begin();
     if (api->copy_to_device(arena_dev + layout.off_copied_begin, upload_base, upload_bytes) != 0) {
         LOG_ERROR("host-orch: H2D of the runtime image failed");
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -891,7 +943,7 @@ int32_t run_host_orchestration(
             nt, upload_bytes, copied_bytes, image_bytes, bind_usage.fanin_elems, bind_usage.tensor_elems,
             bind_usage.scalar_elems
         );
-        record_bind_phase(HostPhaseKind::BindArenaH2d, t_h2d_ns, attrs, upload_bytes);
+        record_bind_phase(HostPhaseKind::BindArenaH2d, h2d_phase, attrs, upload_bytes);
     }
     return total_tasks;
 }
@@ -1090,7 +1142,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // the point at which a task could make it stale.
     HostTensorAccessor tensor_access(api);
 
-    const int64_t t_args_ns = bind_phase_begin();
+    const BindPhaseMark args_phase = bind_phase_begin();
     uint64_t staged_bytes = 0;
     int staged_tensors = 0;
     for (int i = 0; i < tensor_count; i++) {
@@ -1165,7 +1217,7 @@ extern "C" int bind_callable_to_runtime_impl(
         snprintf(
             attrs, sizeof(attrs), "ntensor=%d staged=%d bytes=%" PRIu64, tensor_count, staged_tensors, staged_bytes
         );
-        record_bind_phase(HostPhaseKind::BindArgs, t_args_ns, attrs);
+        record_bind_phase(HostPhaseKind::BindArgs, args_phase, attrs);
     }
 
     // Lay out the per-Worker static device arena. The GM heap and the prebuilt
@@ -1179,7 +1231,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // the reserve sequence on a host-side arena.
     uint64_t sm_size = SharedMemoryHandle::calculate_size(task_capacity);
 
-    const int64_t t_arena_build_ns = bind_phase_begin();
+    const BindPhaseMark arena_build_phase = bind_phase_begin();
     DeviceArena host_arena;
     RuntimeArenaLayout layout = runtime_reserve_layout(host_arena, task_capacity);
     if (host_arena.commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
@@ -1189,7 +1241,7 @@ extern "C" int bind_callable_to_runtime_impl(
     {
         char attrs[kBindAttrsCapacity];
         snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, static_cast<uint64_t>(layout.arena_size));
-        record_bind_phase(HostPhaseKind::BindArenaBuild, t_arena_build_ns, attrs);
+        record_bind_phase(HostPhaseKind::BindArenaBuild, arena_build_phase, attrs);
     }
 
     // The shared memory is placed at the end of orchestration, so until then this
@@ -1210,7 +1262,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // boot becomes attach + wire (cheap pointer fixup) + sm_handle->init (SM
     // reset) + a handful of device-only field fixups.
     // -------------------------------------------------------------------------
-    const int64_t t_runtime_init_ns = bind_phase_begin();
+    const BindPhaseMark runtime_init_phase = bind_phase_begin();
     // No SM base: the scheduler and sm_handle are device-written now, so nothing
     // here stores one, and the region is not even committed yet.
     RuntimeContext *rt =
@@ -1227,7 +1279,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // on the host Runtime (set_prebuilt_arena below), since the AICPU needs that
     // pointer before it can dereference the image.
     rt->prebuilt_layout = layout;
-    record_bind_phase(HostPhaseKind::BindRuntimeInit, t_runtime_init_ns);
+    record_bind_phase(HostPhaseKind::BindRuntimeInit, runtime_init_phase);
 
     if (host_orch_func_ptr == nullptr) {
         LOG_ERROR("host-orch: orchestration entry points were not resolved");
@@ -1243,12 +1295,12 @@ extern "C" int bind_callable_to_runtime_impl(
         // owns these buffers, so drop the window on both exits.
         const size_t view_count = tensor_access.mapping_count();
         const uint64_t view_bytes = tensor_access.mapped_bytes();
-        const int64_t t_view_close_ns = bind_phase_begin();
+        const BindPhaseMark view_close_phase = bind_phase_begin();
         tensor_access.close();
         {
             char attrs[kBindAttrsCapacity];
             snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, view_count, view_bytes);
-            record_bind_phase(HostPhaseKind::BindHostViewClose, t_view_close_ns, attrs);
+            record_bind_phase(HostPhaseKind::BindHostViewClose, view_close_phase, attrs);
         }
         if (total_tasks < 0) {
             LOG_ERROR("host-orch: orchestration run failed");

--- a/src/a5/runtime/host_build_graph/host/graph_recorder_pool.h
+++ b/src/a5/runtime/host_build_graph/host/graph_recorder_pool.h
@@ -193,6 +193,40 @@ public:
         });
     }
 
+    // Sum of every recording worker's CPU time. Differencing this across a phase says
+    // how many threads' worth of work ran alongside the thread that runs the bind,
+    // which a wall-clock duration cannot: the recorders overlap it.
+    //
+    // A per-thread CPU clock is the only instrument that resolves a phase of a
+    // millisecond. rusage times are accounted per scheduler tick, 10 ms at
+    // CLK_TCK=100, so on such a phase they quantise to either zero or a whole tick.
+    //
+    // Read under this pool's own mutex, from whichever thread asks, so no handle is
+    // sampled while it is being created or destroyed: create_worker_locked() runs under
+    // that mutex, and shutdown() empties workers_ under it before it joins anything. A
+    // thread that has already exited answers EINVAL and contributes nothing, which is
+    // correct: its time belongs to no phase still being measured.
+    //
+    // Linux only, and zero elsewhere: reading another thread's CPU clock needs
+    // pthread_getcpuclockid, which Darwin does not provide. The bind breakdown profiles
+    // onboard runs, so the platforms that lack it are the ones that never take this
+    // measurement -- but rec_cpu_ns carries no information there, and the tooling says so.
+    uint64_t worker_cpu_ns() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        uint64_t total = 0;
+#if defined(__linux__)
+        for (std::thread &worker : workers_) {
+            if (!worker.joinable()) continue;
+            clockid_t clock_id{};
+            if (pthread_getcpuclockid(worker.native_handle(), &clock_id) != 0) continue;
+            timespec ts{};
+            if (clock_gettime(clock_id, &ts) != 0) continue;
+            total += static_cast<uint64_t>(ts.tv_sec) * 1000000000ULL + static_cast<uint64_t>(ts.tv_nsec);
+        }
+#endif
+        return total;
+    }
+
 private:
     bool storage_failed_{false};
 
@@ -272,12 +306,19 @@ private:
 
     void shutdown() {
         wait();
+        std::vector<std::thread> draining;
         {
             std::lock_guard<std::mutex> lock(mutex_);
             stopping_ = true;
+            // The handles leave workers_ under the lock and are joined without it.
+            // Joining while holding mutex_ deadlocks: a worker reacquires it inside
+            // cv_.wait to observe stopping_ and return. Emptying workers_ here is also
+            // what keeps worker_cpu_ns() off a handle mid-join, since it samples under
+            // this same mutex and so sees an empty pool for the rest of teardown.
+            draining.swap(workers_);
         }
         cv_.notify_all();
-        for (std::thread &worker : workers_) {
+        for (std::thread &worker : draining) {
             if (worker.joinable()) worker.join();
         }
     }

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -143,41 +143,89 @@ static int64_t bind_now_ns() { return static_cast<int64_t>(host_phase_now_ns());
 // once per page, and the bind maps its shared-memory mirror and arenas per call, so
 // a phase's fault count is what separates work from page-table cost — a count, so it
 // does not move with how loaded the box is.
+//
+// CPU time answers what a count cannot: whether a phase's wall time was spent running
+// or waiting. It comes from per-thread CPU clocks and never from rusage —
+// `ru_utime`/`ru_stime` are accounted per scheduler tick, 10 ms at CLK_TCK=100, so on
+// a phase of a millisecond they quantise to either zero or a whole tick and no split
+// survives. A per-thread clock reads the scheduler's running total in nanoseconds.
+//
+// Two CPU figures, because a phase runs on more than one thread. `cpu_ns` is the bind
+// thread's own, so a phase's `dur - cpu_ns` is the time that thread spent off CPU;
+// `recorder_cpu_ns` is every recording worker's summed, so its ratio to `dur` is how
+// many threads' worth of work ran alongside. Only the first can be subtracted from the
+// wall. `thread_minflt` is the same split applied to the fault count: it says how much
+// of `minflt` the bind thread took rather than the recorders.
 struct BindKernelCounters {
     uint64_t minflt;
+    uint64_t thread_minflt;
     uint64_t nivcsw;  // involuntary: the scheduler took the CPU away
     uint64_t nvcsw;   // voluntary: the thread blocked
+    uint64_t cpu_ns;
+    uint64_t recorder_cpu_ns;
 };
 
+static uint64_t thread_cpu_ns() {
+    timespec ts{};
+    if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) != 0) return 0;
+    return static_cast<uint64_t>(ts.tv_sec) * 1000000000ULL + static_cast<uint64_t>(ts.tv_nsec);
+}
+
 static BindKernelCounters bind_kernel_counters() {
+    BindKernelCounters counters{};
     rusage usage{};
-    if (getrusage(RUSAGE_SELF, &usage) != 0) return BindKernelCounters{};
-    return BindKernelCounters{
-        static_cast<uint64_t>(usage.ru_minflt), static_cast<uint64_t>(usage.ru_nivcsw),
-        static_cast<uint64_t>(usage.ru_nvcsw)
-    };
-}
-
-// A phase's own counts are the delta since its own start, so they cover the same
-// span its duration does. The markers do not partition the bind: the stretches
-// between one phase's close and the next one's open belong to neither, in counts
-// exactly as in time. Process-wide, so a phase that runs while the Graph recorders
-// are working is charged their faults too — which is the intent: it is the bind's
-// total page-table cost that is being attributed, not one thread's.
-static BindKernelCounters g_bind_counter_mark{};
-
-// Open one segment: the instant its duration measures from, and the counter mark
-// its faults measure from. Every phase start comes from here, so a phase's two
-// spans cannot drift apart — a fault count taken over a wider span than the clock
-// describes work the phase does not contain.
-static int64_t bind_phase_begin() {
-    if (host_phase_breakdown_enabled()) {
-        g_bind_counter_mark = bind_kernel_counters();
+    if (getrusage(RUSAGE_SELF, &usage) == 0) {
+        counters.minflt = static_cast<uint64_t>(usage.ru_minflt);
+        counters.nivcsw = static_cast<uint64_t>(usage.ru_nivcsw);
+        counters.nvcsw = static_cast<uint64_t>(usage.ru_nvcsw);
     }
-    return bind_now_ns();
+#if defined(__linux__)
+    // RUSAGE_THREAD is a Linux extension. Darwin has no per-thread rusage, so
+    // thread_minflt stays zero there and the process total in minflt is the whole of
+    // what is available.
+    rusage thread_usage{};
+    if (getrusage(RUSAGE_THREAD, &thread_usage) == 0) {
+        counters.thread_minflt = static_cast<uint64_t>(thread_usage.ru_minflt);
+    }
+#endif
+    counters.cpu_ns = thread_cpu_ns();
+    counters.recorder_cpu_ns = graph_recorder_pool().worker_cpu_ns();
+    return counters;
 }
 
-static void record_bind_phase(HostPhaseKind kind, int64_t start_ns, const char *attrs = "", uint64_t payload = 0) {
+// One segment's two origins: the instant its duration measures from and the counter
+// mark its faults measure from. Both live in the caller's frame, so a phase that
+// opens while another is still open cannot disturb it — the two would share a single
+// mark if one were held here, and the outer phase would then report counts measured
+// from the inner phase's start while its duration still spanned its own.
+//
+// A phase's own counts are the delta since its own start, so they cover the same
+// span its duration does. The marks do not partition the bind: the stretches
+// between one phase's close and the next one's open belong to neither, in counts
+// exactly as in time. The process-wide counters are process-wide on purpose, so a
+// phase that runs while the Graph recorders are working is charged their faults too
+// — it is the bind's total page-table cost that is being attributed, not one
+// thread's.
+struct BindPhaseMark {
+    int64_t start_ns{0};
+    BindKernelCounters counters{};
+};
+
+// Open one segment. Every phase start comes from here, so a phase's two spans cannot
+// drift apart — a fault count taken over a wider span than the clock describes work
+// the phase does not contain.
+static BindPhaseMark bind_phase_begin() {
+    BindPhaseMark mark{};
+    if (host_phase_breakdown_enabled()) {
+        mark.counters = bind_kernel_counters();
+    }
+    mark.start_ns = bind_now_ns();
+    return mark;
+}
+
+static void
+record_bind_phase(HostPhaseKind kind, const BindPhaseMark &mark, const char *attrs = "", uint64_t payload = 0) {
+    const int64_t start_ns = mark.start_ns;
     if (!host_phase_breakdown_enabled()) {
         host_phase_record_bind(static_cast<uint32_t>(kind), static_cast<uint64_t>(start_ns), attrs, payload);
         return;
@@ -194,9 +242,13 @@ static void record_bind_phase(HostPhaseKind kind, int64_t start_ns, const char *
     };
     char with_counters[kBindAttrsCapacity];
     snprintf(
-        with_counters, sizeof(with_counters), "%s%sminflt=%" PRIu64 " nivcsw=%" PRIu64 " nvcsw=%" PRIu64, attrs,
-        *attrs == '\0' ? "" : " ", since(now.minflt, g_bind_counter_mark.minflt),
-        since(now.nivcsw, g_bind_counter_mark.nivcsw), since(now.nvcsw, g_bind_counter_mark.nvcsw)
+        with_counters, sizeof(with_counters),
+        "%s%sminflt=%" PRIu64 " tminflt=%" PRIu64 " nivcsw=%" PRIu64 " nvcsw=%" PRIu64 " cpu_ns=%" PRIu64
+        " rec_cpu_ns=%" PRIu64,
+        attrs, *attrs == '\0' ? "" : " ", since(now.minflt, mark.counters.minflt),
+        since(now.thread_minflt, mark.counters.thread_minflt), since(now.nivcsw, mark.counters.nivcsw),
+        since(now.nvcsw, mark.counters.nvcsw), since(now.cpu_ns, mark.counters.cpu_ns),
+        since(now.recorder_cpu_ns, mark.counters.recorder_cpu_ns)
     );
     host_phase_record_bind(
         static_cast<uint32_t>(kind), static_cast<uint64_t>(start_ns), with_counters, payload,
@@ -646,7 +698,7 @@ int32_t run_host_orchestration(
     // rt_orchestration_done take the runtime as an argument.
     entry_points->bind(rt);
 
-    const int64_t t_orch_ns = bind_phase_begin();
+    const BindPhaseMark orch_phase = bind_phase_begin();
     rt_scope_begin(rt);
     entry_points->entry(orch_l2);
     rt_scope_end(rt);
@@ -699,7 +751,7 @@ int32_t run_host_orchestration(
             attrs, sizeof(attrs), "tasks=%" PRId32 " heap_used=%" PRIu64 " sm_mirror=%" PRIu64, total_tasks,
             orchestrator.task_allocator.heap_used_bytes(), sm_size
         );
-        record_bind_phase(HostPhaseKind::BindHostOrch, t_orch_ns, attrs);
+        record_bind_phase(HostPhaseKind::BindHostOrch, orch_phase, attrs);
     }
     // After the span closes: the reduction walks a few hundred records and emits
     // five markers, which must not be charged to the bind it measures.
@@ -721,7 +773,7 @@ int32_t run_host_orchestration(
     // Upload each distinct Definition as its own retained device object and bind
     // every outer Graph task to it. Per-invocation data already lives in that
     // task's payload regions and is copied with the shared-memory image below.
-    const int64_t t_graph_ns = bind_phase_begin();
+    const BindPhaseMark graph_phase = bind_phase_begin();
     DefinitionUploads definition_uploads{};
     if (!bind_graph_definitions(api, *graph_state, &definition_uploads, &ready_queue_populations)) {
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -738,7 +790,7 @@ int32_t run_host_orchestration(
             attrs, sizeof(attrs), "defs=%zu bytes=%" PRIu64 " submissions=%zu spilled=%zu", definition_uploads.count,
             definition_uploads.bytes, graph_host_upload_count(*graph_state), definition_uploads.spilled
         );
-        record_bind_phase(HostPhaseKind::BindGraphUpload, t_graph_ns, attrs, definition_uploads.bytes);
+        record_bind_phase(HostPhaseKind::BindGraphUpload, graph_phase, attrs, definition_uploads.bytes);
     }
 
     ReadyQueueCapacities ready_queue_capacities{};
@@ -795,7 +847,7 @@ int32_t run_host_orchestration(
     // region and short-circuits a request an existing one already covers, so a
     // repeated workload pays for neither twice and the heap is grow-only across a
     // Worker's binds.
-    const int64_t t_static_arena_ns = bind_phase_begin();
+    const BindPhaseMark static_arena_phase = bind_phase_begin();
     // The compact shared-memory image is the only per-run tail in the device
     // arena. GraphExecution is initialized later in each outer Graph heap.
     const uint64_t device_arena_bytes = layout.off_copied_end + image_bytes;
@@ -822,10 +874,10 @@ int32_t run_host_orchestration(
     {
         char attrs[kBindAttrsCapacity];
         snprintf(attrs, sizeof(attrs), "heap=%" PRIu64 " arena=%" PRIu64, heap_bytes, device_arena_bytes);
-        record_bind_phase(HostPhaseKind::BindStaticArena, t_static_arena_ns, attrs);
+        record_bind_phase(HostPhaseKind::BindStaticArena, static_arena_phase, attrs);
     }
 
-    const int64_t t_sm_ns = bind_phase_begin();
+    const BindPhaseMark sm_phase = bind_phase_begin();
     void *device_arena = api->acquire_pooled_runtime_arena();
     if (device_arena == nullptr) {
         LOG_ERROR("%s", "host-orch: failed to acquire the pooled runtime arena");
@@ -837,12 +889,12 @@ int32_t run_host_orchestration(
     {
         char attrs[kBindAttrsCapacity];
         snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, image_bytes);
-        record_bind_phase(HostPhaseKind::BindSharedMem, t_sm_ns, attrs, image_bytes);
+        record_bind_phase(HostPhaseKind::BindSharedMem, sm_phase, attrs, image_bytes);
     }
 
-    const int64_t t_heap_ns = bind_phase_begin();
+    const BindPhaseMark heap_phase = bind_phase_begin();
     void *gm_heap = api->acquire_pooled_gm_heap();
-    record_bind_phase(HostPhaseKind::BindGmHeap, t_heap_ns);
+    record_bind_phase(HostPhaseKind::BindGmHeap, heap_phase);
     if (gm_heap == nullptr) {
         LOG_ERROR("host-orch: failed to acquire the pooled GM heap");
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -892,7 +944,7 @@ int32_t run_host_orchestration(
     );
     always_assert(compacted == image_bytes);
 
-    const int64_t t_h2d_ns = bind_phase_begin();
+    const BindPhaseMark h2d_phase = bind_phase_begin();
     if (api->copy_to_device(arena_dev + layout.off_copied_begin, upload_base, upload_bytes) != 0) {
         LOG_ERROR("host-orch: H2D of the runtime image failed");
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -907,7 +959,7 @@ int32_t run_host_orchestration(
             nt, upload_bytes, copied_bytes, image_bytes, bind_usage.fanin_elems, bind_usage.tensor_elems,
             bind_usage.scalar_elems
         );
-        record_bind_phase(HostPhaseKind::BindArenaH2d, t_h2d_ns, attrs, upload_bytes);
+        record_bind_phase(HostPhaseKind::BindArenaH2d, h2d_phase, attrs, upload_bytes);
     }
     return total_tasks;
 }
@@ -1106,7 +1158,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // the point at which a task could make it stale.
     HostTensorAccessor tensor_access(api);
 
-    const int64_t t_args_ns = bind_phase_begin();
+    const BindPhaseMark args_phase = bind_phase_begin();
     uint64_t staged_bytes = 0;
     int staged_tensors = 0;
     for (int i = 0; i < tensor_count; i++) {
@@ -1181,7 +1233,7 @@ extern "C" int bind_callable_to_runtime_impl(
         snprintf(
             attrs, sizeof(attrs), "ntensor=%d staged=%d bytes=%" PRIu64, tensor_count, staged_tensors, staged_bytes
         );
-        record_bind_phase(HostPhaseKind::BindArgs, t_args_ns, attrs);
+        record_bind_phase(HostPhaseKind::BindArgs, args_phase, attrs);
     }
 
     // Lay out the per-Worker static device arena. The GM heap and the prebuilt
@@ -1195,7 +1247,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // the reserve sequence on a host-side arena.
     uint64_t sm_size = SharedMemoryHandle::calculate_size(task_capacity);
 
-    const int64_t t_arena_build_ns = bind_phase_begin();
+    const BindPhaseMark arena_build_phase = bind_phase_begin();
     DeviceArena host_arena;
     RuntimeArenaLayout layout = runtime_reserve_layout(host_arena, task_capacity);
     if (host_arena.commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
@@ -1205,7 +1257,7 @@ extern "C" int bind_callable_to_runtime_impl(
     {
         char attrs[kBindAttrsCapacity];
         snprintf(attrs, sizeof(attrs), "bytes=%" PRIu64, static_cast<uint64_t>(layout.arena_size));
-        record_bind_phase(HostPhaseKind::BindArenaBuild, t_arena_build_ns, attrs);
+        record_bind_phase(HostPhaseKind::BindArenaBuild, arena_build_phase, attrs);
     }
 
     // The shared memory is placed at the end of orchestration, so until then this
@@ -1226,7 +1278,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // boot becomes attach + wire (cheap pointer fixup) + sm_handle->init (SM
     // reset) + a handful of device-only field fixups.
     // -------------------------------------------------------------------------
-    const int64_t t_runtime_init_ns = bind_phase_begin();
+    const BindPhaseMark runtime_init_phase = bind_phase_begin();
     // No SM base: the scheduler and sm_handle are device-written now, so nothing
     // here stores one, and the region is not even committed yet.
     RuntimeContext *rt =
@@ -1243,7 +1295,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // on the host Runtime (set_prebuilt_arena below), since the AICPU needs that
     // pointer before it can dereference the image.
     rt->prebuilt_layout = layout;
-    record_bind_phase(HostPhaseKind::BindRuntimeInit, t_runtime_init_ns);
+    record_bind_phase(HostPhaseKind::BindRuntimeInit, runtime_init_phase);
 
     // host_build_graph host-orch: run the orchestrator on the host now, against
     // a host SM mirror, and ship the populated SM to the device. The arena
@@ -1266,12 +1318,12 @@ extern "C" int bind_callable_to_runtime_impl(
         // owns these buffers, so drop the window on both exits.
         const size_t view_count = tensor_access.mapping_count();
         const uint64_t view_bytes = tensor_access.mapped_bytes();
-        const int64_t t_view_close_ns = bind_phase_begin();
+        const BindPhaseMark view_close_phase = bind_phase_begin();
         tensor_access.close();
         {
             char attrs[kBindAttrsCapacity];
             snprintf(attrs, sizeof(attrs), "count=%zu bytes=%" PRIu64, view_count, view_bytes);
-            record_bind_phase(HostPhaseKind::BindHostViewClose, t_view_close_ns, attrs);
+            record_bind_phase(HostPhaseKind::BindHostViewClose, view_close_phase, attrs);
         }
         if (total_tasks < 0) {
             LOG_ERROR("host-orch: orchestration run failed");

--- a/tests/ut/py/test_phase_time_split.py
+++ b/tests/ut/py/test_phase_time_split.py
@@ -1,0 +1,189 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Tests for the bind-phase CPU-time split reader."""
+
+import pytest
+
+from simpler_setup.tools import phase_time_split
+
+
+def _marker(phase, dur_ns, cpu_ns, rec_cpu_ns, minflt=0, tminflt=0, nvcsw=0, nivcsw=0):
+    return (
+        f"[TIMING] host_phase_trace_end: bind phase={phase} start_ns=1000 dur_ns={dur_ns} "
+        f"minflt={minflt} tminflt={tminflt} nivcsw={nivcsw} nvcsw={nvcsw} "
+        f"cpu_ns={cpu_ns} rec_cpu_ns={rec_cpu_ns}\n"
+    )
+
+
+def test_parse_reads_every_counter(tmp_path):
+    log = tmp_path / "run.log"
+    log.write_text(_marker("host_orch", 2_000_000, 1_500_000, 8_000_000, minflt=99, tminflt=7, nvcsw=3, nivcsw=1))
+
+    rows = phase_time_split.parse(str(log))
+
+    assert len(rows) == 1
+    assert rows[0] == {
+        "phase": "host_orch",
+        "dur_us": 2000.0,
+        "minflt": 99,
+        "tminflt": 7,
+        "nivcsw": 1,
+        "nvcsw": 3,
+        "cpu_ns": 1_500_000,
+        "rec_cpu_ns": 8_000_000,
+    }
+
+
+def test_parse_ignores_lines_without_a_marker(tmp_path):
+    log = tmp_path / "run.log"
+    log.write_text("some other TIMING line\n" + _marker("graph_upload", 1000, 1000, 0))
+
+    assert [row["phase"] for row in phase_time_split.parse(str(log))] == ["graph_upload"]
+
+
+def test_off_cpu_is_the_wall_the_bind_thread_did_not_run():
+    rows = [
+        {
+            "phase": "p",
+            "dur_us": 100.0,
+            "cpu_ns": 40_000,
+            "rec_cpu_ns": 0,
+            **dict.fromkeys(("minflt", "tminflt", "nvcsw", "nivcsw"), 0),
+        }
+    ]
+
+    stats = phase_time_split.summarise(rows)
+
+    assert stats["cpu"] == pytest.approx(40.0)
+    assert stats["offcpu"] == pytest.approx(60.0)
+
+
+def test_cpu_above_the_wall_is_counted_rather_than_clamped_away():
+    """One thread cannot outspend the segment's wall, so the row's mark is another's.
+
+    Clamping off-CPU to zero and printing the row would read as "ran the whole time",
+    which is the opposite of what an unusable mark means.
+    """
+    rows = [
+        {
+            "phase": "p",
+            "dur_us": 10.0,
+            "cpu_ns": 11_000,
+            "rec_cpu_ns": 0,
+            **dict.fromkeys(("minflt", "tminflt", "nvcsw", "nivcsw"), 0),
+        }
+    ]
+
+    stats = phase_time_split.summarise(rows)
+
+    assert stats["offcpu"] == 0.0
+    assert stats["unmarked"] == 1
+
+
+def test_a_sane_row_is_not_flagged():
+    rows = [
+        {
+            "phase": "p",
+            "dur_us": 10.0,
+            "cpu_ns": 9_000,
+            "rec_cpu_ns": 0,
+            **dict.fromkeys(("minflt", "tminflt", "nvcsw", "nivcsw"), 0),
+        }
+    ]
+
+    assert phase_time_split.summarise(rows)["unmarked"] == 0
+
+
+def test_recorder_ratio_is_concurrency_not_a_share_of_the_wall():
+    """reccpu above dur is the expected reading: eight workers overlap the bind thread."""
+    rows = [
+        {
+            "phase": "p",
+            "dur_us": 100.0,
+            "cpu_ns": 50_000,
+            "rec_cpu_ns": 400_000,
+            **dict.fromkeys(("minflt", "tminflt", "nvcsw", "nivcsw"), 0),
+        }
+    ]
+
+    stats = phase_time_split.summarise(rows)
+
+    assert stats["reccpu"] == pytest.approx(400.0)
+    assert stats["rec_ratio"] == pytest.approx(4.0)
+
+
+def test_medians_are_taken_per_bind_not_across_columns():
+    """offcpu is the median of the differences, which a difference of medians can miss."""
+    rows = [
+        {
+            "phase": "p",
+            "dur_us": 100.0,
+            "cpu_ns": 100_000,
+            "rec_cpu_ns": 0,
+            **dict.fromkeys(("minflt", "tminflt", "nvcsw", "nivcsw"), 0),
+        },
+        {
+            "phase": "p",
+            "dur_us": 300.0,
+            "cpu_ns": 100_000,
+            "rec_cpu_ns": 0,
+            **dict.fromkeys(("minflt", "tminflt", "nvcsw", "nivcsw"), 0),
+        },
+        {
+            "phase": "p",
+            "dur_us": 200.0,
+            "cpu_ns": 200_000,
+            "rec_cpu_ns": 0,
+            **dict.fromkeys(("minflt", "tminflt", "nvcsw", "nivcsw"), 0),
+        },
+    ]
+
+    # Medians: dur 200, cpu 100 -> a difference of medians would say 100.
+    assert phase_time_split.summarise(rows)["offcpu"] == pytest.approx(0.0)
+
+
+def test_a_log_without_the_cpu_counters_is_refused(tmp_path, monkeypatch):
+    """Refusing beats printing zeros: a pre-counters log would read as all-on-CPU."""
+    log = tmp_path / "run.log"
+    log.write_text("[TIMING] bind phase=host_orch start_ns=1000 dur_ns=2000 minflt=1 nivcsw=0 nvcsw=0\n")
+    monkeypatch.setattr("sys.argv", ["phase_time_split", str(log)])
+
+    with pytest.raises(SystemExit) as exit_info:
+        phase_time_split.main()
+
+    assert "cpu_ns" in str(exit_info.value)
+
+
+def test_a_log_with_no_markers_at_all_is_refused(tmp_path, monkeypatch):
+    log = tmp_path / "run.log"
+    log.write_text("nothing here\n")
+    monkeypatch.setattr("sys.argv", ["phase_time_split", str(log)])
+
+    with pytest.raises(SystemExit) as exit_info:
+        phase_time_split.main()
+
+    assert "SIMPLER_HBG_BIND_BREAKDOWN_ENABLE" in str(exit_info.value)
+
+
+def test_cold_and_warm_are_reported_separately(tmp_path, monkeypatch, capsys):
+    log = tmp_path / "run.log"
+    log.write_text(
+        _marker("host_orch", 4_000_000, 3_000_000, 0)  # cold, one per rank
+        + _marker("host_orch", 4_000_000, 3_000_000, 0)
+        + _marker("host_orch", 1_000_000, 900_000, 0)
+        + _marker("host_orch", 1_000_000, 900_000, 0)
+    )
+    monkeypatch.setattr("sys.argv", ["phase_time_split", str(log)])
+
+    phase_time_split.main()
+
+    rows = [line for line in capsys.readouterr().out.splitlines() if "host_orch" in line]
+    assert len(rows) == 2
+    assert "cold" in rows[0] and "4000.0" in rows[0]
+    assert "warm" in rows[1] and "1000.0" in rows[1]


### PR DESCRIPTION
## Summary

A phase's breakdown could say how long it took and how many faults it took, but not whether that time was spent computing or blocked — and the two send you to different places. `host_orch` is the case that matters: its faults are mostly on the Graph recorder threads, which run *alongside* the bind thread, so a fault count without this split reads as a cost the phase pays when it is a cost that overlaps. That reading is why the same tail was chased three times (see the entry amended by #2036).

- Each marker now carries **`cpu_ns`**, the bind thread's own CPU time, so a phase's `dur_ns - cpu_ns` is what that thread spent off CPU; **`rec_cpu_ns`**, every recording worker's summed, whose ratio to `dur_ns` is how many threads' worth of work ran alongside; and **`tminflt`**, the bind thread's share of `minflt`, so the recorders' share is the difference.
- **Times come from per-thread CPU clocks and never from rusage.** `ru_utime`/`ru_stime` are accounted per scheduler tick — 10 ms at `CLK_TCK=100` — so on a phase of a millisecond they quantise to either zero or a whole tick: the values look plausible one at a time and are noise in aggregate. A per-thread clock reads the scheduler's running total in nanoseconds; measured against a busy and a sleeping thread over a 1.29 ms window it resolved both to under 10 µs. rusage keeps the three counters, which are event counts and do not quantise.
- The recorders' clocks are reachable through the pool that owns them since #2020, so `GraphAsyncRecordingState::worker_cpu_ns()` reads them under the pool's own mutex — a worker being created or joined concurrently cannot be sampled through a dangling handle, and one that has already exited contributes nothing.
- `simpler_setup.tools.phase_time_split` reports the split per phase, with **cold and warm binds as separate rows** rather than the cold one dropped: a cold bind pays the one-off cost of standing recorder storage and the arenas up, and its size is the thing worth knowing.

## What it reads on dsv4

```text
phase                   n          dur          cpu       offcpu  off%       reccpu  rec/dur  minflt tminflt   nvcsw nivcsw
host_orch         cold  2       1797.3       1528.3        269.1   15%       4138.2     2.32     961      64      76      0
host_orch         warm 10        673.0        580.4         81.0   12%       2424.4     3.51      10       1      38      0
graph_upload      cold  2       1344.4        734.7        609.7   45%          0.0     0.00     248     248     206      0
graph_upload      warm 10        226.7        185.8         32.9   14%          0.0     0.00       0       0       1      0
```

Two things a duration alone could not say: `host_orch`'s 961 cold faults are almost all *not* the bind thread's (`tminflt` 64) and sit inside 2.3 threads' worth of overlapping work, and `graph_upload`'s cold bind is **45% waiting** rather than computing.

## One limitation, flagged rather than hidden

The counter mark is a single global (introduced with `bind_phase_begin()` in #2022) and the segments do not nest, so a segment that opens while another is still open takes that one's mark with it. The symptom is a row reporting more CPU than the segment's own wall, which on dsv4 is `args`. Such a row's `cpu`/`offcpu` describe neither segment, so the tool marks it `!` and explains why. Clamping off-CPU to zero and printing it would read as "ran the whole time" — the opposite of what an unusable mark means.

## Testing

No behavior changes outside the `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` diagnostic: both sampling sites are already behind it, so a default run reads no clock and takes no pool lock.

- [x] `pytest examples tests/st --platform a2a3sim --device 0-15 --manual include` — one pre-existing failure, `TestSpmdPagedAttentionHighPerf::b4_h32_kv8_s512_bs128_fp16` golden mismatch
- [x] `pytest examples tests/st --platform a5sim --device 0-15 --manual include` — green
- [x] `ctest --test-dir tests/ut/cpp/build -LE requires_hardware` — 119/119
- [x] `pytest tests/ut -m "not requires_hardware"` — 1951 passed; one failure in `test_second_child_failure_reaps_first`, a wall-clock budget on a forked child that passes alone and is load-dependent
- [x] a2a3 onboard `-m "not sdma" --exclude-level 4 --manual include` — 1 failure, `TestPagedAttentionHostBuildGraph::Case1`'s `prepare_native_run failed with code -1000`, reproduced on the base commit
- [x] The tool has its own unit tests, including that a log written before the clocks existed is refused rather than reported as all-on-CPU
