### PR TITLE
Docs: retry npu-smi through task-submit where DCMI is root-only

### DIFF
--- a/.claude/lib/onboard-detection.md
+++ b/.claude/lib/onboard-detection.md
@@ -52,7 +52,10 @@ Sim variants are silicon-agnostic — no precheck, no device.
 ## C. Select idle device(s)
 
 An *idle* device is one whose **HBM-Usage is 0** in `npu-smi info` output.
-(Mirrors the `benchmark` skill's Step 2.)
+(Mirrors the `benchmark` skill's Step 2.) If that call fails, retry it as
+`task-submit --run "npu-smi info"` — some shared hosts restrict DCMI to root —
+and decide by exit status, never by whether output was produced. See
+[running-onboard.md](../rules/running-onboard.md#why).
 
 - **Single device:** pick the lowest-ID idle device. If none is free, report
   and stop.

--- a/.claude/rules/running-onboard.md
+++ b/.claude/rules/running-onboard.md
@@ -10,6 +10,50 @@ from grabbing the same device, keeps the `--list` queue accurate, and keeps
 local runs comparable to CI (CI always wraps pytest in `task-submit`, see
 `.github/workflows/ci.yml`).
 
+### Two separable things, and only one of them is about devices
+
+`task-submit` both **arbitrates devices** and **executes as root**. Everything
+below is about the first: a run that occupies a card must hold a lock, on any
+host where the tool exists.
+
+The second is why a *query* can need it too, and it is easy to reason past.
+`npu-smi` occupies no card, so the device-lock argument does not apply to it —
+yet some shared hosts grant DCMI only to root, and there a bare `npu-smi info`
+fails with `dcmi module initialize failed` rather than any device data. Which
+hosts do this is not a property to memorize; it is discovered by trying. **Run
+npu-smi bare, and on failure retry the same query through the queue:**
+
+```bash
+npu-smi info || task-submit --run "npu-smi info"
+```
+
+Three things make that one line safe to apply everywhere:
+
+- **Decide by exit status, never by output.** A DCMI refusal is written to
+  **stdout**, and on the retry path `task-submit` appends its own
+  `=== ... (exit=N) ===` banner there too. So a failed query is never empty
+  output, and `[ -z "$out" ]` is always the wrong test. Reading "no output" as
+  "no NPU" is the same misdiagnosis one layer up.
+- **The retry passes no `--device`,** so it allocates no card and waits behind
+  none. This is about privilege, never about the lock.
+- **It costs nothing where it is not needed.** An unrestricted host succeeds on
+  the bare call and never reaches the retry; a host with no `task-submit`
+  reports npu-smi's own error and status unchanged.
+
+Do not retry a `set`, `clear` or `upgrade` this way. Those modify device
+configuration, and re-running a denied mutation as root grants the caller
+privilege they did not have. The retry is for queries.
+
+### This is npu-smi-specific, not a pattern to copy
+
+`npu-smi` is the only tool here that reads the driver **without occupying a
+card**, which is exactly what puts it outside the device-lock rule while still
+needing privilege. Work that occupies a card is already covered by the explicit
+`task-submit --device … --run "…"` form below, and `msprof op simulator` runs on
+the host CPU and touches no driver at all. So there is no second case: if some
+other tool one day hits a permission wall, work out which of those two
+categories it is in rather than generalizing from this paragraph.
+
 ## Autonomous invocation — detect capability, then run without asking
 
 When a task needs the NPU, do **not** ask the user for permission to run it.
@@ -205,6 +249,13 @@ directly.
 - ❌ Bypassing `onboard-arch-precheck` — the `--platform` mismatch failure
   modes are silent (look like real bugs) and burn hours of investigation
   time. Always run the gate.
+- ❌ Reading a failed `npu-smi` as "this box has no NPU" and falling back to
+  sim. The device-lock argument genuinely does not cover npu-smi; host
+  privilege does. Retry the query through `task-submit --run` before
+  concluding anything about the silicon.
+- ❌ Deciding an npu-smi result by whether it printed anything. A DCMI refusal
+  goes to stdout, and the retry path adds a `task-submit` banner there, so a
+  failed query is never empty output. Read the exit status.
 - ❌ Fishing your run's device log out of the shared `~/ascend/log/debug/`
   by pid/timestamp guesswork. Set `ASCEND_PROCESS_LOG_PATH` to a per-run
   dir up front (see "Device logs" above) so the log is isolated and known.
@@ -219,6 +270,7 @@ directly.
 - **Wait for a submitted task** — `task-submit --wait <task-id>`
 - **Cancel pending** — `task-submit --cancel <task-id>`
 - **Per-die utilization + process table** — `npu-smi info`
+  (on failure: `task-submit --run "npu-smi info"`)
 - **Redirect device log to the run's output** —
   `mkdir -p <outdir>/ascend && export ASCEND_PROCESS_LOG_PATH=<outdir>/ascend`
   (== `task-submit --env ASCEND_PROCESS_LOG_PATH=...`; dir must pre-exist)

--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -77,10 +77,9 @@ fi
 
 When `task-submit` is available, allocate the requested device IDs or use
 `--device auto`; run the architecture gate as the first command inside that
-allocation, then pass `$TASK_DEVICE` to every benchmark command. Some shared
-hosts expose DCMI only inside `task-submit`, so a lock-external precheck cannot
-detect their silicon. Hold one allocation for the whole baseline/current
-sequence. When `task-submit` is unavailable, follow
+allocation, then pass `$TASK_DEVICE` to every benchmark command. Hold one
+allocation for the whole baseline/current sequence. When `task-submit` is
+unavailable, follow
 `.claude/lib/onboard-detection.md` and clearly report that the fallback run is
 unlocked.
 

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -114,7 +114,7 @@ Each template has **required fields** (marked `required: true` in the YAML). You
 - **Git Commit ID**: Run `git rev-parse HEAD` to get the current commit
 - **Title prefix**: Use the template's title prefix (`[Bug]`, `[Feature]`, etc.)
 - **Host Platform**: Run `uname -s -m` to detect OS and arch. Map to: `Linux aarch64` → `Linux (aarch64)`, `Linux x86_64` → `Linux (x86_64)`, `Darwin arm64` → `macOS (aarch64)`. Fall back to `Other` if unrecognized.
-- **NPU Kind**: Run `npu-smi info 2>/dev/null` to detect NPU. If command not found or no output, default to `N/A (not hardware-specific)` (or `N/A (simulation only)` for `performance_issue.yml`). Parse model name to map to Ascend 910B/910C if present.
+- **NPU Kind**: Run `npu-smi info`, and on failure retry it as `task-submit --run "npu-smi info"` (some shared hosts restrict DCMI to root, so a bare failure does not mean there is no NPU). **Branch on the exit status, not on whether it printed anything** — a DCMI refusal goes to stdout and the retry adds a `task-submit` banner there, so output is non-empty even when the query failed. If both fail, default to `N/A (not hardware-specific)` (or `N/A (simulation only)` for `performance_issue.yml`) and quote the error in the issue so the reason is visible. On success, parse model name to map to Ascend 910B/910C if present.
 
 ## Step 5: Format the Issue Body
 

--- a/.claude/skills/onboard-arch-precheck/SKILL.md
+++ b/.claude/skills/onboard-arch-precheck/SKILL.md
@@ -86,8 +86,11 @@ in-flight `task-submit` device locks).
 
 Pipeline:
 
-1. `npu-smi info -t board -i 0 -c 0` → get `Chip Name` + `NPU Name`
-   (~600 ms, no ACL init, no device binding).
+1. `npu-smi info -t board -i 0 -c 0` → get `Chip Name` + `NPU Name` (~600 ms,
+   no ACL init, no device binding). On failure the same query is retried as
+   `task-submit --run "…"`, since some shared hosts restrict DCMI to root;
+   without that retry the gate cannot detect silicon there once its cache
+   expires, and a refusal to detect is indistinguishable from a refusal to run.
 2. Construct CANN SoC name per family:
    - `Ascend910` + `B*` NPU → `Ascend910B3` (or B1/B2/B4)
    - `Ascend910` + numeric NPU → `Ascend910_9392` (Atlas A3 SKUs)

--- a/.claude/skills/onboard-arch-precheck/check.sh
+++ b/.claude/skills/onboard-arch-precheck/check.sh
@@ -47,6 +47,13 @@ esac
 # Uses npu-smi to identify the chip + the CANN platform_config ini to map
 # SoC → Short_SoC_version → repo arch. Same Short_SoC_version → arch table
 # as docs/hardware/chip-architecture.md and tools/cann-examples/query/.
+#
+# npu-smi reads the driver through DCMI, which some shared hosts grant only to
+# root; there the bare call returns no board data. The query occupies no card,
+# so it is retried through the privileged task queue with no --device: it takes
+# no lock and waits behind none. Without that retry this gate cannot detect
+# silicon on such a host once its cache expires, and a refusal to detect reads
+# exactly like a refusal to run.
 detect_silicon() {
     if ! command -v npu-smi >/dev/null 2>&1; then
         echo "onboard-arch-precheck: npu-smi not on PATH — cannot determine silicon. Install the Ascend driver or run on a host with one." >&2
@@ -57,12 +64,19 @@ detect_silicon() {
         return 1
     fi
 
+    # The retry is keyed on the exit status: a DCMI refusal is written to
+    # stdout, so an emptiness test would never fire.
+    local query="npu-smi info -t board -i 0 -c 0"
     local board chip npu
-    board=$(npu-smi info -t board -i 0 -c 0 2>/dev/null)
+    if ! board=$($query 2>/dev/null); then
+        if command -v task-submit >/dev/null 2>&1; then
+            board=$(task-submit --run "$query" 2>/dev/null)
+        fi
+    fi
     chip=$(awk -F: '/Chip Name/ { gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; exit }' <<<"$board")
     npu=$(awk -F:  '/NPU Name/  { gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; exit }' <<<"$board")
     if [ -z "$chip" ] || [ -z "$npu" ]; then
-        echo "onboard-arch-precheck: npu-smi did not return Chip Name + NPU Name (chip='$chip' npu='$npu'). Try \`npu-smi info -t board -i 0 -c 0\` manually." >&2
+        echo "onboard-arch-precheck: npu-smi did not return Chip Name + NPU Name (chip='$chip' npu='$npu'). Run \`$query\` manually to see the driver's own error, and \`task-submit --run \"$query\"\` if this host restricts DCMI to root." >&2
         return 1
     fi
 

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -113,14 +113,21 @@ command -v npu-smi &>/dev/null
 | Found | `<arch>sim` (simulation) **and** `<arch>` (hardware) |
 | Not found | Simulation only (default `a2a3sim`) |
 
-**When `npu-smi` is found**, detect the platform by parsing chip name from `npu-smi info` output:
+**When `npu-smi` is found**, detect the platform by parsing chip name from `npu-smi info` output. If that call fails, retry it as `task-submit --run "npu-smi info"` — some shared hosts restrict DCMI to root — and judge by exit status, not by whether output appeared (see [running-onboard.md](../../rules/running-onboard.md#why)):
 
 | Chip name contains | Platform |
 | ------------------ | -------- |
 | `910B` or `910C` | `a2a3` (sim: `a2a3sim`) |
 | `950` | `a5` (sim: `a5sim`) |
 
-Use the detected platform for all subsequent `--platform` flags. If the chip name is unrecognized, warn and default to `a2a3`.
+Use the detected platform for all subsequent `--platform` flags.
+
+Two different failures hide behind an empty chip name, and only one of them is safe to guess past:
+
+- **Both the bare call and the `task-submit` retry exited non-zero** — the silicon was never identified. `command -v npu-smi` above only proves the binary exists, so this is the state on a DCMI-restricted host with no `task-submit`. Report the error and test **simulation only**; do not guess a hardware platform.
+- **The query succeeded but the chip name matches no row** — genuinely unrecognized silicon. Warn and default to `a2a3`.
+
+Guessing `a2a3` in the first case runs hardware tests against silicon nobody has identified, which is the `--platform` mismatch that [onboard-arch-precheck](../onboard-arch-precheck/SKILL.md) exists to refuse.
 
 ### Step 2 — Test Scope
 
@@ -150,7 +157,7 @@ Parallelism is handled by the `#591` scheduler (`simpler_setup/parallel_schedule
 When testing on `a2a3`, detect idle devices:
 
 ```bash
-npu-smi info
+npu-smi info || task-submit --run "npu-smi info"
 ```
 
 Pick devices whose **HBM-Usage is 0** and find the **longest consecutive sub-range** (at most 4). Pass as `--device <start>-<end>` (or `--device <id>` if only one idle device). If no idle device is found, skip hardware testing and warn.


### PR DESCRIPTION
## Problem

`npu-smi` reads the driver through DCMI. Some shared hosts grant that only to root, and there a bare `npu-smi info` returns

```text
DrvMngGetConsoleLogLevel failed. (ret=4)
dcmi module initialize failed. ret is -8005
```

with exit 187 instead of device data — while the identical query succeeds under the host's privileged task queue.

The agent rules described `task-submit` purely as a **per-device lock** ("keeps two users from grabbing the same device"). Under that framing, not wrapping npu-smi is a *correct* inference: the query occupies no card. The premise was simply incomplete — on such a host `task-submit` also supplies privilege. The rules then reinforced the wrong conclusion with five bare `npu-smi` examples, including one directly beneath a `task-submit --list` call.

The observed result is agents reading `dcmi module initialize failed` as "this host has no NPU" and silently falling back to simulation.

## Fix

State the rule once, in `running-onboard.md`, and let the callers link to it:

```bash
npu-smi info || task-submit --run "npu-smi info"
```

**Which hosts restrict DCMI is never asserted in documentation — it is discovered by trying.** That is what keeps this neutral for anyone outside our shared boxes:

| Host | Behavior |
| ---- | -------- |
| npu-smi usable directly (most users) | bare call succeeds; **identical to today, zero overhead**, the retry is never reached |
| DCMI restricted, no `task-submit` | npu-smi's own stderr and exit status, unchanged — no regression |
| DCMI restricted, `task-submit` present | retry succeeds |

Three constraints ride along with the rule:

- **Decide by exit status, never by output.** A DCMI refusal is written to **stdout**, and the retry path adds `task-submit`'s own `=== ... (exit=N) ===` banner there too. A failed query is therefore never empty output, so `[ -z "$out" ]` is always the wrong test. Reading "no output" as "no NPU" is the same misdiagnosis one layer up.
- **Never retry a `set` / `clear` / `upgrade` this way.** Re-running a denied mutation as root grants the caller privilege they did not have. The retry is for queries.
- **The retry passes no `--device`,** so it allocates no card and waits behind none. Device-owning work is unchanged and stays under the explicit `task-submit --device … --run "…"` form.

## Scope: this is npu-smi-specific, not a pattern to copy

`npu-smi` is the only tool here that reads the driver **without occupying a card** — which is exactly what puts it outside the device-lock rule while still needing privilege. Card-occupying work is already covered by the explicit `--device` form, and `msprof op simulator` runs on the host CPU and touches no driver at all. There is no second case, and the rule says so, so the next permission wall gets classified rather than generalized from.

## Also repairs `onboard-arch-precheck` on a restricted host

`check.sh` is a script that runs *before* any of the above is read, so it needs the retry in code rather than prose. It called `npu-smi info -t board` directly, so once its 1-hour cache expired the gate exited 1 and could not detect silicon at all. The rules make that gate mandatory before every onboard invocation, so an agent obeying them was blocked outright; a warm cache masked it, making the failure look intermittent. It now retries the same fixed query through the queue and detects cold.

The `testing` skill had the matching hazard in its platform table: it defaulted to `a2a3` whenever the chip name came back empty, which on a restricted host without `task-submit` meant running hardware tests against silicon nobody had identified — the exact `--platform` mismatch `onboard-arch-precheck` exists to refuse. An unidentified host now selects simulation; only a chip name that matches no row still defaults.

## Verification

All three host classes exercised on a genuinely DCMI-restricted box:

- Unrestricted → bare call succeeds, queue never reached
- Restricted, no `task-submit` → npu-smi's own error and exit status
- Restricted, with `task-submit` → query succeeds
- `onboard-arch-precheck` cold cache → exit 0 in 2.3 s (33 ms warm); still refuses a mismatch (`a5` → exit 2) and passes sim variants through (`a5sim` → exit 0)

A bug in the first inlined draft was caught here: testing `[ -z "$board" ]` never fired, because the DCMI refusal is written to **stdout**, not stderr. The retry is keyed on the exit status, with a comment on the line — and that same finding is why the "decide by status" constraint above is stated for callers too.

Lint clean: `markdownlint-cli2`, `check_english_only.py`, `bash -n`.

## History

An earlier revision of this PR added a shared `.claude/lib/npu-smi.sh` wrapper and routed all callers through it. That was dropped after review: only **one** caller is code (`check.sh`) while five are docs, and an agent has to read a doc either way — so the wrapper did not remove the documentation dependency, it only changed what the doc had to teach. Every defect found in review (`$*` argument flattening, the need for a read-only subcommand gate, the banner on stdout) existed *only because* the wrapper was general; inlined into `check.sh` the arguments are literals, the subcommand is always `info`, and `awk` reads one field. Net effect of the revision: −67 lines of shell, one fewer file, and no new path for callers to learn.

## Not included

`docs/troubleshooting/a2a3-507899-aicpu-shared-so-fault.md:17,78` and `tools/cann-examples/aicpu-mmio-probes/README.md:164` still instruct a bare `npu-smi info`. Both are agent-actionable and worth rerouting, but sit outside the `.claude/` rule surface this PR scopes itself to. Happy to fold them in if preferred here rather than as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
