### PR TITLE
Feature: add A5 HBG Gang scheduling

### DIFF
--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -11,7 +11,7 @@
 
 #include "aicore/aicore.h"
 #include "aicore/aicore_profiling_state.h"
-// Cluster-local dependency scheduling uses one device-side protocol.
+// Cluster-local normal and gang scheduling share one device-side protocol.
 #include "scheduler/scheduler_dispatch.h"
 #include "common/platform_config.h"
 #include "dispatch_payload.h"
@@ -113,9 +113,14 @@ __aicore__ __attribute__((always_inline)) void execute_task(__gm__ DispatchPaylo
     OUT_OF_ORDER_STORE_BARRIER();
 }
 
-__aicore__ __attribute__((always_inline)) bool
-should_commit_scheduler_trace(__gm__ void *, __gm__ SchedulerWorkerContext *, __gm__ SchedulerDispatchSlot *slot) {
-    return slot->gang == 0;
+__aicore__ __attribute__((always_inline)) bool should_commit_scheduler_trace(
+    __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context, __gm__ SchedulerDispatchSlot *slot
+) {
+    if (slot->gang == 0) return true;
+    if (slot->block_idx != 0) return false;
+    __gm__ SchedulerTaskMetadata *metadata = scheduler_task_metadata_at(scheduler_state_base, context, slot->task_id);
+    scheduler_observe_cache_line(metadata);
+    return slot->subtask_slot == scheduler_metadata_single_subtask_slot(metadata->active_mask);
 }
 
 __aicore__ __attribute__((always_inline)) void local_backoff(uint32_t iterations) {
@@ -271,14 +276,20 @@ __aicore__ bool bootstrap_ready_graph(
                 ) :
                 SchedulerRouteResult::READY_TO_ENQUEUE;
         if (route == SchedulerRouteResult::ERROR) return false;
-        if (route == SchedulerRouteResult::READY_TO_ENQUEUE &&
-            !scheduler_bootstrap_ready_batch_append(
-                scheduler_state_base, resolver, static_cast<int64_t>(task_id),
-                &batches[scheduler_metadata_core_type_index(scheduler_metadata_single_subtask_slot(metadata
-                                                                                                       ->active_mask))],
-                &stats->ready, trace_enabled
-            )) {
-            return false;
+        if (route == SchedulerRouteResult::READY_TO_ENQUEUE) {
+            if (scheduler_task_is_gang(metadata->flags)) {
+                __gm__ SchedulerTaskControl *control =
+                    scheduler_task_control_at(scheduler_state_base, resolver, static_cast<int64_t>(task_id));
+                scheduler_publish_gang_ready(scheduler_state_base, resolver, control, metadata->flags);
+            } else if (!scheduler_bootstrap_ready_batch_append(
+                           scheduler_state_base, resolver, static_cast<int64_t>(task_id),
+                           &batches[scheduler_metadata_core_type_index(
+                               scheduler_metadata_single_subtask_slot(metadata->active_mask)
+                           )],
+                           &stats->ready, trace_enabled
+                       )) {
+                return false;
+            }
         }
         ++stats->bootstrap_task_count;
     }
@@ -328,11 +339,15 @@ __aicore__ bool bootstrap_ready_graph(
     if (trace_enabled) stats->target_bootstrap_end_cycles = scheduler_cycles();
 
     // Prepare the first executable wave while the sole DMB launch gate is
-    // still closed.
+    // still closed. Gang service runs first to preserve SPMD > Mix > normal
+    // priority; normal fill is suppressed while a gang dispatch is pending.
     uint64_t ready_victim_cursors[SCHEDULER_CORE_TYPE_COUNT]{
         (resolver->inbox_index + 1) % resolver_count,
         (resolver->inbox_index + 1) % resolver_count,
     };
+    (void)scheduler_service_gang(
+        graph, scheduler_state_base, resolver, run_control, &stats->wake, &stats->ready, &stats->completion
+    );
     (void)scheduler_fill_cluster_normal_slots(
         graph, scheduler_state_base, resolver, run_control, ready_victim_cursors, &stats->ready, trace_enabled, 0,
         nullptr, deferred_aiv
@@ -443,6 +458,13 @@ __aicore__ bool run_ready_dispatch_loop(
                 inter_task_timing.completion.finalize_cycles += completion_timing.finalize_cycles;
             }
             scheduler_progress = completion_progress;
+            operation_start = trace_enabled ? get_sys_cnt_aicore() : 0;
+            scheduler_progress = scheduler_service_gang(
+                                     graph, scheduler_state_base, context, run_control, &stats->wake, &stats->ready,
+                                     &stats->completion, ready_owner
+                                 ) ||
+                                 scheduler_progress;
+            if (trace_enabled) inter_task_timing.gang_service_cycles += get_sys_cnt_aicore() - operation_start;
             operation_start = trace_enabled ? get_sys_cnt_aicore() : 0;
             SchedulerNormalDispatchTiming dispatch_timing{};
             scheduler_progress = scheduler_fill_cluster_normal_slots(
@@ -649,6 +671,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
     __gm__ SchedulerWorkerContext *context = reinterpret_cast<__gm__ SchedulerWorkerContext *>(handshake->task);
     scheduler_observe_cache_line(context);
     scheduler_observe_cache_line(&context->task_metadata_offset);
+    scheduler_observe_cache_line(&context->gang_coordinator_offset);
     context->worker_index = static_cast<uint64_t>(block_idx);
     scheduler_publish_cache_line(&context->scheduler_state_base_address);
     __gm__ void *scheduler_state_base = reinterpret_cast<__gm__ void *>(context->scheduler_state_base_address);

--- a/src/a5/runtime/host_build_graph/aicpu/aicore_lifecycle.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicore_lifecycle.cpp
@@ -189,6 +189,7 @@ int32_t AicoreLifecycle::post_handshake_init(Runtime *runtime) {
     }
 
     const uint64_t executable_task_count = runtime->scheduler_layout.executable_task_count;
+    const bool has_gang_tasks = runtime->scheduler_layout.gang_task_count != 0;
     const int32_t requested_aic = static_cast<int32_t>(std::min<uint64_t>(
         aic_count, std::max(runtime->scheduler_layout.aic_worker_demand, runtime->scheduler_layout.aic_task_count)
     ));
@@ -200,9 +201,12 @@ int32_t AicoreLifecycle::post_handshake_init(Runtime *runtime) {
         (static_cast<uint64_t>(requested_aiv) + PLATFORM_AIV_CORES_PER_BLOCKDIM - 1) / PLATFORM_AIV_CORES_PER_BLOCKDIM
     );
     if (executable_task_count != 0) required_clusters = std::max<uint64_t>(required_clusters, 1);
+    if (has_gang_tasks) required_clusters = static_cast<uint64_t>(aic_count);
     const int32_t active_clusters = static_cast<int32_t>(std::min<uint64_t>(required_clusters, aic_count));
-    if (runtime->scheduler_layout.aic_worker_demand > static_cast<uint64_t>(aic_count) ||
-        runtime->scheduler_layout.aiv_worker_demand > static_cast<uint64_t>(aiv_count) ||
+    if ((runtime->scheduler_layout.aic_worker_demand > static_cast<uint64_t>(aic_count) &&
+         runtime->scheduler_layout.gang_task_count == 0) ||
+        (runtime->scheduler_layout.aiv_worker_demand > static_cast<uint64_t>(aiv_count) &&
+         runtime->scheduler_layout.gang_task_count == 0) ||
         (executable_task_count != 0 && active_clusters == 0)) {
         LOG_ERROR(
             "A5 HBG AICore scheduler: topology cannot execute graph (demand AIC=%" PRIu64 " AIV=%" PRIu64
@@ -226,8 +230,9 @@ int32_t AicoreLifecycle::post_handshake_init(Runtime *runtime) {
             const bool resolver_lane = static_cast<uint64_t>(worker) == resolver_worker;
             const bool additional_aiv_lane =
                 lane != 0 && !resolver_lane && cluster * PLATFORM_AIV_CORES_PER_BLOCKDIM + 1 < requested_aiv;
-            const bool active_lane = cluster < active_clusters &&
-                                     (resolver_lane || (lane == 0 && cluster < requested_aic) || additional_aiv_lane);
+            const bool active_lane =
+                cluster < active_clusters &&
+                (has_gang_tasks || resolver_lane || (lane == 0 && cluster < requested_aic) || additional_aiv_lane);
             contexts[worker].active = active_lane ? 1 : 0;
             contexts[worker].cluster_count = static_cast<uint64_t>(active_clusters);
             contexts[worker].cluster_index = static_cast<uint64_t>(cluster);
@@ -252,6 +257,11 @@ int32_t AicoreLifecycle::post_handshake_init(Runtime *runtime) {
     run_control->aic_active_worker_count = static_cast<uint64_t>(active_aic);
     run_control->aiv_active_worker_count = static_cast<uint64_t>(active_aiv);
     run_control->resolver_count = static_cast<uint64_t>(active_clusters);
+    auto *coordinator = scheduler_state_at<SchedulerGangCoordinator>(
+        runtime->scheduler_state_base, runtime->scheduler_layout.gang_coordinator_offset
+    );
+    coordinator->resolver_count = static_cast<uint64_t>(active_clusters);
+    cache_flush_range(coordinator, sizeof(*coordinator));
     if (executable_task_count == 0) {
         run_control->bootstrap_scan_arrived_count = static_cast<uint64_t>(active_clusters);
         run_control->bootstrap_scan_complete = 1;

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -602,12 +602,6 @@ bool create_scheduler_state(
             return false;
         }
         const uint32_t logical_block_num = static_cast<uint32_t>(slot.logical_block_num);
-        if (active_subtasks != 1 || logical_block_num != 1 || slot.task_attrs.requires_sync_start()) {
-            LOG_ERROR(
-                "A5 HBG AICore scheduler: task id=%" PRId64 " requires MIX, SPMD, or sync-start scheduling", task_id
-            );
-            return false;
-        }
         if (logical_block_num > UINT16_MAX / active_subtasks) {
             LOG_ERROR(
                 "A5 HBG AICore scheduler: task id=%" PRId64 " block/subtask product exceeds scheduler state capacity",

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include "scheduler_ready.h"
+#include "scheduler_gang.h"
 
 inline __aicore__ bool scheduler_service_cluster_completion_slot(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver,
@@ -41,13 +41,11 @@ inline __aicore__ bool scheduler_service_cluster_completion_slot(
     uint64_t operation_start = record_timeline ? scheduler_cycles() : 0;
     scheduler_observe_cache_line(slot);
     const int64_t task_id = slot->task_id;
-    if (slot->gang != 0) {
-        scheduler_record_error(
-            run_control, task_id, SchedulerGraphResult::UNSUPPORTED_SHAPE, &graph, resolver, UINT64_C(73)
-        );
-        return false;
-    }
+    const bool gang = slot->gang != 0;
     const uint8_t completed_subtask_slot = slot->subtask_slot;
+    const uint32_t cohort_index = slot->cohort_index;
+    const uint32_t cohort_generation = slot->cohort_generation;
+    if (gang && replacement_ready != nullptr) return false;
     scheduler_gm_store(completion_line->completed_generations[pending_slot], UINT32_C(0));
     uint64_t operation_end = record_timeline ? scheduler_cycles() : 0;
     if (timing != nullptr) timing->consume_cycles += operation_end - operation_start;
@@ -58,49 +56,76 @@ inline __aicore__ bool scheduler_service_cluster_completion_slot(
     uint64_t refill_start_cycles = 0;
     uint64_t refill_end_cycles = 0;
     bool refilled = false;
-    __gm__ SchedulerTaskControl *control = scheduler_task_control_at(scheduler_state_base, resolver, task_id);
-    scheduler_gm_store(control->state, static_cast<int64_t>(SchedulerTaskState::DONE));
-    if (!scheduler_resolve_completion(
-            graph, scheduler_state_base, resolver, run_control, task_id, wake_stats, ready_stats, completion_stats,
-            false, false, timing == nullptr ? nullptr : &ready_publish_cycles, owner_state
-        ))
-        return false;
-    if (timing != nullptr) timing->ready_publish_cycles += ready_publish_cycles;
-    if (completion_stats != nullptr) ++completion_stats->resolve_count;
-    uint64_t resolved_count_start = timing == nullptr ? 0 : scheduler_cycles();
-    scheduler_gm_fetch_add(run_control->resolved_task_count, UINT64_C(1));
-    if (timing != nullptr) {
-        finalize_cycles = scheduler_cycles() - resolved_count_start;
-        timing->finalize_cycles += finalize_cycles;
-    }
-    refill_start_cycles = record_timeline ? scheduler_cycles() : 0;
-    SchedulerReadyClaim ready{};
-    bool ready_available = replacement_ready != nullptr;
-    if (ready_available) {
-        ready = *replacement_ready;
-    } else if (ready_victim_cursors != nullptr && worker_id != resolver->worker_index) {
-        // A normal AIV task is never refilled directly onto the Resolver.
-        // Its completed slot becomes capacity for late binding instead.
-        const uint32_t core_type = scheduler_metadata_core_type_index(completed_subtask_slot);
-        if (!scheduler_claim_ready_for_slot(
-                graph, scheduler_state_base, resolver, run_control, resolver->resolver_count, core_type,
-                &ready_victim_cursors[core_type], ready_stats, &ready, trace_enabled, owner_state
+    if (gang) {
+        if (cohort_index >= SCHEDULER_GANG_COHORT_COUNT) return false;
+        __gm__ SchedulerGangParticipant *participant =
+            scheduler_gang_participant_at(scheduler_state_base, resolver, cohort_index, resolver->resolver_index);
+        scheduler_observe_cache_line(participant);
+        if (participant->config_generation != cohort_generation || participant->task_id != task_id ||
+            participant->local_completed_subtasks >= participant->local_expected_subtasks) {
+            scheduler_record_error(
+                run_control, task_id, SchedulerGraphResult::INVALID_ARGUMENTS, &graph, resolver, UINT64_C(73)
+            );
+            return false;
+        }
+        ++participant->local_completed_subtasks;
+        scheduler_publish_cache_line(participant);
+    } else {
+        __gm__ SchedulerTaskControl *control = scheduler_task_control_at(scheduler_state_base, resolver, task_id);
+        scheduler_gm_store(control->state, static_cast<int64_t>(SchedulerTaskState::DONE));
+        if (!scheduler_resolve_completion(
+                graph, scheduler_state_base, resolver, run_control, task_id, wake_stats, ready_stats, completion_stats,
+                false, false, timing == nullptr ? nullptr : &ready_publish_cycles, owner_state
             ))
             return false;
-        ready_available = ready.task_id >= 0;
-    }
-    if (ready_available) {
-        SchedulerFreeSlotClaim claim{worker_id, pending_slot, slot->generation};
-        if (!scheduler_fill_dispatch_slot(
-                graph, scheduler_state_base, resolver, run_control, claim, ready, trace_enabled
-            ))
-            return false;
-        refilled = true;
-    }
-    refill_end_cycles = record_timeline ? scheduler_cycles() : 0;
-    if (timing != nullptr) {
-        refill_cycles = refill_end_cycles - refill_start_cycles;
-        timing->refill_cycles += refill_cycles;
+        if (timing != nullptr) timing->ready_publish_cycles += ready_publish_cycles;
+        if (completion_stats != nullptr) ++completion_stats->resolve_count;
+        uint64_t resolved_count_start = timing == nullptr ? 0 : scheduler_cycles();
+        scheduler_gm_fetch_add(run_control->resolved_task_count, UINT64_C(1));
+        if (timing != nullptr) {
+            finalize_cycles = scheduler_cycles() - resolved_count_start;
+            timing->finalize_cycles += finalize_cycles;
+        }
+        refill_start_cycles = record_timeline ? scheduler_cycles() : 0;
+        SchedulerReadyClaim ready{};
+        bool ready_available = replacement_ready != nullptr;
+        if (ready_available) {
+            ready = *replacement_ready;
+        } else if (ready_victim_cursors != nullptr && worker_id != resolver->worker_index) {
+            // A normal AIV task is never refilled directly onto the Resolver.
+            // Its completed slot becomes capacity for late binding instead.
+            __gm__ SchedulerGangCoordinator *coordinator =
+                scheduler_gang_coordinator_at(scheduler_state_base, resolver);
+            bool normal_fill_allowed = coordinator->gang_task_count == 0;
+            if (!normal_fill_allowed) {
+                scheduler_observe_cache_line(coordinator);
+                scheduler_observe_cache_line(&coordinator->active_dispatch_cohort);
+                normal_fill_allowed =
+                    coordinator->ready_priority_bits == 0 && coordinator->active_dispatch_cohort == UINT64_MAX;
+            }
+            if (normal_fill_allowed) {
+                const uint32_t core_type = scheduler_metadata_core_type_index(completed_subtask_slot);
+                if (!scheduler_claim_ready_for_slot(
+                        graph, scheduler_state_base, resolver, run_control, resolver->resolver_count, core_type,
+                        &ready_victim_cursors[core_type], ready_stats, &ready, trace_enabled, owner_state
+                    ))
+                    return false;
+                ready_available = ready.task_id >= 0;
+            }
+        }
+        if (ready_available) {
+            SchedulerFreeSlotClaim claim{worker_id, pending_slot, slot->generation};
+            if (!scheduler_fill_dispatch_slot(
+                    graph, scheduler_state_base, resolver, run_control, claim, ready, trace_enabled
+                ))
+                return false;
+            refilled = true;
+        }
+        refill_end_cycles = record_timeline ? scheduler_cycles() : 0;
+        if (timing != nullptr) {
+            refill_cycles = refill_end_cycles - refill_start_cycles;
+            timing->refill_cycles += refill_cycles;
+        }
     }
     operation_end = record_timeline ? scheduler_cycles() : 0;
     if (refill_start_cycles == 0) refill_start_cycles = operation_end;

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.h
@@ -74,6 +74,15 @@ inline __aicore__ bool scheduler_fill_cluster_normal_slots(
     const uint32_t aic_core_type = static_cast<uint32_t>(CoreType::AIC);
     uint64_t stage_start = timing == nullptr ? 0 : scheduler_cycles();
     uint64_t detail_start = timing == nullptr ? 0 : scheduler_normal_dispatch_detail_cycles(*timing, aic_core_type);
+    __gm__ SchedulerGangCoordinator *coordinator = scheduler_gang_coordinator_at(scheduler_state_base, resolver);
+    if (coordinator->gang_task_count != 0) {
+        scheduler_observe_cache_line(coordinator);
+        scheduler_observe_cache_line(&coordinator->active_dispatch_cohort);
+        if (coordinator->ready_priority_bits != 0 || coordinator->active_dispatch_cohort != UINT64_MAX) {
+            scheduler_finish_normal_dispatch_stage(timing, aic_core_type, stage_start, detail_start);
+            return false;
+        }
+    }
     bool progress = false;
 
     // AIC has no peer lane in its Cluster, so preserve the existing slot order.

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_gang.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_gang.h
@@ -1,0 +1,794 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include "scheduler_ready.h"
+
+enum class SchedulerGangTokenPhase : uint32_t {
+    DRAIN = 0,
+    STAGE = 1,
+    DISPATCH = 2,
+    COMPLETION = 3,
+};
+
+inline __host__ __aicore__ __gm__ SchedulerGangCohort *scheduler_gang_cohort_at(
+    __gm__ void *scheduler_state_base, __gm__ const SchedulerWorkerContext *context, uint32_t cohort_index
+) {
+    return scheduler_state_at<SchedulerGangCohort>(
+        scheduler_state_base,
+        context->gang_cohorts_offset + static_cast<uint64_t>(cohort_index) * sizeof(SchedulerGangCohort)
+    );
+}
+
+inline __host__ __aicore__ __gm__ SchedulerGangParticipant *scheduler_gang_participant_at(
+    __gm__ void *scheduler_state_base, __gm__ const SchedulerWorkerContext *context, uint32_t cohort_index,
+    uint64_t resolver_index
+) {
+    const uint64_t linear = static_cast<uint64_t>(cohort_index) * SCHEDULER_CLUSTER_CAPACITY + resolver_index;
+    return scheduler_state_at<SchedulerGangParticipant>(
+        scheduler_state_base, context->gang_participants_offset + linear * sizeof(SchedulerGangParticipant)
+    );
+}
+
+inline __host__ __aicore__ __gm__ SchedulerGangCommand *scheduler_gang_command_at(
+    __gm__ void *scheduler_state_base, __gm__ const SchedulerWorkerContext *context, uint64_t resolver_index
+) {
+    return scheduler_state_at<SchedulerGangCommand>(
+        scheduler_state_base, context->gang_commands_offset + resolver_index * sizeof(SchedulerGangCommand)
+    );
+}
+
+inline __aicore__ void scheduler_gang_publish_command(
+    __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver, uint64_t resolver_index,
+    uint32_t cohort_index, uint64_t generation, SchedulerGangCohortState state
+) {
+    __gm__ SchedulerGangCommand *command = scheduler_gang_command_at(scheduler_state_base, resolver, resolver_index);
+    command->generation[cohort_index] = generation;
+    command->state[cohort_index] = static_cast<uint64_t>(state);
+    scheduler_publish_cache_line(command);
+}
+
+inline __aicore__ bool scheduler_gang_forward_command(
+    __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver,
+    __gm__ SchedulerGangParticipant *participant, uint32_t cohort_index, uint64_t generation,
+    SchedulerGangCohortState state
+) {
+    if (participant->forwarded_generation == generation && participant->forwarded_state == static_cast<uint32_t>(state))
+        return false;
+    const uint64_t children[2] = {resolver->resolver_index * 2 + 1, resolver->resolver_index * 2 + 2};
+    for (uint32_t child_slot = 0; child_slot < 2; ++child_slot) {
+        if (children[child_slot] >= participant->participant_count) continue;
+        scheduler_gang_publish_command(
+            scheduler_state_base, resolver, children[child_slot], cohort_index, generation, state
+        );
+    }
+    participant->forwarded_generation = generation;
+    participant->forwarded_state = static_cast<uint32_t>(state);
+    scheduler_publish_cache_line(participant);
+    return true;
+}
+
+inline __host__ __aicore__ uint32_t scheduler_gang_popcount(uint32_t mask) {
+    return static_cast<uint32_t>(__builtin_popcount(mask));
+}
+
+inline __aicore__ __gm__ volatile uint64_t *
+scheduler_gang_local_token(__gm__ SchedulerGangParticipant *participant, SchedulerGangTokenPhase phase) {
+    if (phase == SchedulerGangTokenPhase::DRAIN) return &participant->drain_local_token;
+    if (phase == SchedulerGangTokenPhase::STAGE) return &participant->stage_local_token;
+    if (phase == SchedulerGangTokenPhase::DISPATCH) return &participant->dispatch_local_token;
+    return &participant->completion_local_token;
+}
+
+inline __aicore__ __gm__ volatile uint64_t *
+scheduler_gang_subtree_token(__gm__ SchedulerGangParticipant *participant, SchedulerGangTokenPhase phase) {
+    if (phase == SchedulerGangTokenPhase::DRAIN) return &participant->drain_subtree_token;
+    if (phase == SchedulerGangTokenPhase::STAGE) return &participant->stage_subtree_token;
+    if (phase == SchedulerGangTokenPhase::DISPATCH) return &participant->dispatch_subtree_token;
+    return &participant->completion_subtree_token;
+}
+
+inline __aicore__ bool scheduler_gang_publish_local_token(
+    __gm__ SchedulerGangParticipant *participant, SchedulerGangTokenPhase phase, uint64_t generation
+) {
+    __gm__ volatile uint64_t *token = scheduler_gang_local_token(participant, phase);
+    if (*token == generation) return false;
+    *token = generation;
+    scheduler_publish_cache_line(token);
+    return true;
+}
+
+inline __aicore__ bool scheduler_gang_update_subtree_token(
+    __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver, uint32_t cohort_index,
+    uint64_t participant_count, uint64_t generation, SchedulerGangTokenPhase phase
+) {
+    const uint64_t resolver_index = resolver->resolver_index;
+    if (resolver_index >= participant_count) return false;
+    __gm__ SchedulerGangParticipant *participant =
+        scheduler_gang_participant_at(scheduler_state_base, resolver, cohort_index, resolver_index);
+    __gm__ volatile uint64_t *local_token = scheduler_gang_local_token(participant, phase);
+    __gm__ volatile uint64_t *subtree_token = scheduler_gang_subtree_token(participant, phase);
+    if (*subtree_token == generation) return true;
+    scheduler_observe_cache_line(local_token);
+    if (*local_token != generation) return false;
+    const uint64_t children[2] = {resolver_index * 2 + 1, resolver_index * 2 + 2};
+    for (uint32_t child_slot = 0; child_slot < 2; ++child_slot) {
+        if (children[child_slot] >= participant_count) continue;
+        __gm__ SchedulerGangParticipant *child =
+            scheduler_gang_participant_at(scheduler_state_base, resolver, cohort_index, children[child_slot]);
+        __gm__ volatile uint64_t *child_token = scheduler_gang_subtree_token(child, phase);
+        scheduler_observe_cache_line(child_token);
+        if (*child_token != generation) return false;
+    }
+    *subtree_token = generation;
+    scheduler_publish_cache_line(subtree_token);
+    return true;
+}
+
+inline __aicore__ bool scheduler_gang_root_token_ready(
+    __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver, uint32_t cohort_index,
+    uint64_t generation, SchedulerGangTokenPhase phase
+) {
+    __gm__ SchedulerGangParticipant *root =
+        scheduler_gang_participant_at(scheduler_state_base, resolver, cohort_index, 0);
+    __gm__ volatile uint64_t *token = scheduler_gang_subtree_token(root, phase);
+    scheduler_observe_cache_line(token);
+    return *token == generation;
+}
+
+inline __host__ __aicore__ uint64_t scheduler_gang_retire_token(uint64_t generation) { return ~generation; }
+
+inline __aicore__ void scheduler_gang_publish_retire(
+    __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver,
+    __gm__ SchedulerGangParticipant *participant, uint32_t cohort_index, uint64_t generation
+) {
+    const uint64_t retire_token = scheduler_gang_retire_token(generation);
+    scheduler_gang_publish_local_token(participant, SchedulerGangTokenPhase::COMPLETION, retire_token);
+    (void)scheduler_gang_update_subtree_token(
+        scheduler_state_base, resolver, cohort_index, participant->participant_count, retire_token,
+        SchedulerGangTokenPhase::COMPLETION
+    );
+}
+
+inline __aicore__ bool scheduler_fill_explicit_dispatch_slot(
+    const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver,
+    __gm__ SchedulerRunControl *run_control, uint64_t worker_id, uint32_t pending_slot, int64_t task_id,
+    uint8_t subtask_slot, uint32_t block_idx, uint32_t block_num, uint32_t cohort_index, uint32_t cohort_generation,
+    SchedulerDispatchSlotState publication
+) {
+    if (worker_id >= resolver->runtime_worker_count || pending_slot >= SCHEDULER_PENDING_SLOT_COUNT || task_id < 0 ||
+        static_cast<uint64_t>(task_id) >= graph.task_count || subtask_slot >= 3 || block_num == 0 ||
+        block_idx >= block_num) {
+        return false;
+    }
+    __gm__ SchedulerTaskMetadata *metadata = scheduler_task_metadata_at(scheduler_state_base, resolver, task_id);
+    scheduler_observe_cache_line(metadata);
+    if ((metadata->active_mask & (1U << subtask_slot)) == 0) return false;
+    const uint16_t kernel_id = metadata->kernel_ids[subtask_slot];
+    __gm__ uint64_t *callable_addresses =
+        scheduler_state_at<uint64_t>(scheduler_state_base, resolver->callable_addresses_offset);
+    scheduler_observe_cache_line(&callable_addresses[kernel_id]);
+    const uint64_t callable_address = callable_addresses[kernel_id];
+    if (kernel_id == UINT16_MAX || callable_address == 0) {
+        scheduler_record_error(
+            run_control, task_id, SchedulerGraphResult::INVALID_CALLABLE, &graph, resolver, UINT64_C(70)
+        );
+        return false;
+    }
+
+    __gm__ SchedulerWorkerContext *target = scheduler_worker_context_at(scheduler_state_base, resolver, worker_id);
+    scheduler_observe_cache_line(target);
+    __gm__ SchedulerDispatchSlot *slot =
+        scheduler_dispatch_slot_at(scheduler_state_base, resolver, worker_id, pending_slot);
+    scheduler_observe_cache_line(slot);
+    uint32_t generation = slot->generation + 1;
+    if (generation == 0) generation = 1;
+    slot->task_id = task_id;
+    slot->ready_inbox_index = resolver->resolver_index;
+    slot->claim_start_cycles = 0;
+    slot->claim_end_cycles = 0;
+    slot->claim_worker_id = resolver->worker_index;
+    slot->kernel_id = kernel_id;
+    slot->subtask_slot = subtask_slot;
+    slot->has_fanin = scheduler_task_has_fanin(metadata->flags) ? 1 : 0;
+    slot->ready_source = static_cast<uint8_t>(SchedulerReadySource::LOCAL);
+    slot->pending_slot = static_cast<uint8_t>(pending_slot);
+    slot->block_num = static_cast<uint16_t>(block_num);
+    slot->generation = generation;
+    slot->block_idx = block_idx;
+    slot->cohort_generation = cohort_generation;
+    slot->cohort_index = static_cast<uint8_t>(cohort_index);
+    slot->gang = 1;
+    scheduler_writeback_cache_line(slot);
+
+    SchedulerTaskInfo task{
+        task_id,
+        static_cast<int32_t>(kernel_id),
+        static_cast<int32_t>(subtask_slot),
+        subtask_slot == 0 ? CoreType::AIC : CoreType::AIV,
+    };
+    __gm__ DispatchPayload *payload = scheduler_state_at<DispatchPayload>(
+        scheduler_state_base,
+        target->dispatch_payload_offset + static_cast<uint64_t>(pending_slot) * sizeof(DispatchPayload)
+    );
+    SchedulerGraphResult status = scheduler_materialize_task_payload_resolved(
+        graph, task, callable_address, payload, static_cast<int32_t>(block_idx), static_cast<int32_t>(block_num)
+    );
+    if (status != SchedulerGraphResult::OK) {
+        scheduler_record_error(run_control, task_id, status, &graph, resolver, UINT64_C(71));
+        return false;
+    }
+    scheduler_publish_dispatch_payload(payload);
+    scheduler_gm_store(slot->publication, scheduler_dispatch_publication(generation, publication));
+    return true;
+}
+
+inline __aicore__ int32_t scheduler_gang_find_free_pending_slot(
+    __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver, uint64_t worker_id
+) {
+    for (uint32_t pending_slot = 0; pending_slot < SCHEDULER_PENDING_SLOT_COUNT; ++pending_slot) {
+        __gm__ SchedulerDispatchSlot *slot =
+            scheduler_dispatch_slot_at(scheduler_state_base, resolver, worker_id, pending_slot);
+        if (scheduler_dispatch_state(scheduler_gm_query(slot->publication)) == SchedulerDispatchSlotState::FREE)
+            return static_cast<int32_t>(pending_slot);
+    }
+    return -1;
+}
+
+inline __aicore__ bool scheduler_gang_fill_single(
+    const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver,
+    __gm__ SchedulerRunControl *run_control, __gm__ SchedulerGangParticipant *participant, uint32_t cohort_index,
+    uint64_t worker_id, uint8_t subtask_slot, uint32_t block_idx, SchedulerDispatchSlotState publication
+) {
+    const int32_t pending_slot = scheduler_gang_find_free_pending_slot(scheduler_state_base, resolver, worker_id);
+    if (pending_slot < 0) return false;
+    __gm__ SchedulerDispatchSlot *slot =
+        scheduler_dispatch_slot_at(scheduler_state_base, resolver, worker_id, static_cast<uint32_t>(pending_slot));
+    const uint32_t generation = scheduler_dispatch_generation(scheduler_gm_query(slot->publication));
+    scheduler_gm_store(
+        slot->publication, scheduler_dispatch_publication(generation, SchedulerDispatchSlotState::FILLING)
+    );
+    if (!scheduler_fill_explicit_dispatch_slot(
+            graph, scheduler_state_base, resolver, run_control, worker_id, static_cast<uint32_t>(pending_slot),
+            participant->task_id, subtask_slot, block_idx, participant->logical_block_num, cohort_index,
+            static_cast<uint32_t>(participant->config_generation), publication
+        )) {
+        return false;
+    }
+    ++participant->local_published_subtasks;
+    return true;
+}
+
+inline __aicore__ bool scheduler_gang_fill_mix_block(
+    const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver,
+    __gm__ SchedulerRunControl *run_control, __gm__ SchedulerGangParticipant *participant, uint32_t cohort_index,
+    uint32_t block_idx, SchedulerDispatchSlotState publication
+) {
+    int32_t pending_slot = -1;
+    for (uint32_t candidate = 0; candidate < SCHEDULER_PENDING_SLOT_COUNT; ++candidate) {
+        bool all_free = true;
+        for (uint8_t subtask_slot = 0; subtask_slot < 3; ++subtask_slot) {
+            if ((participant->active_mask & (1U << subtask_slot)) == 0) continue;
+            const uint64_t worker_id = resolver->cluster_worker_ids[subtask_slot];
+            __gm__ SchedulerDispatchSlot *slot =
+                scheduler_dispatch_slot_at(scheduler_state_base, resolver, worker_id, candidate);
+            if (scheduler_dispatch_state(scheduler_gm_query(slot->publication)) != SchedulerDispatchSlotState::FREE) {
+                all_free = false;
+                break;
+            }
+        }
+        if (all_free) {
+            pending_slot = static_cast<int32_t>(candidate);
+            break;
+        }
+    }
+    if (pending_slot < 0) return false;
+    for (uint8_t subtask_slot = 0; subtask_slot < 3; ++subtask_slot) {
+        if ((participant->active_mask & (1U << subtask_slot)) == 0) continue;
+        const uint64_t worker_id = resolver->cluster_worker_ids[subtask_slot];
+        __gm__ SchedulerDispatchSlot *slot =
+            scheduler_dispatch_slot_at(scheduler_state_base, resolver, worker_id, static_cast<uint32_t>(pending_slot));
+        const uint32_t generation = scheduler_dispatch_generation(scheduler_gm_query(slot->publication));
+        scheduler_gm_store(
+            slot->publication, scheduler_dispatch_publication(generation, SchedulerDispatchSlotState::FILLING)
+        );
+    }
+    for (uint8_t subtask_slot = 0; subtask_slot < 3; ++subtask_slot) {
+        if ((participant->active_mask & (1U << subtask_slot)) == 0) continue;
+        if (!scheduler_fill_explicit_dispatch_slot(
+                graph, scheduler_state_base, resolver, run_control, resolver->cluster_worker_ids[subtask_slot],
+                static_cast<uint32_t>(pending_slot), participant->task_id, subtask_slot, block_idx,
+                participant->logical_block_num, cohort_index, static_cast<uint32_t>(participant->config_generation),
+                SchedulerDispatchSlotState::GATED
+            )) {
+            return false;
+        }
+    }
+    if (publication == SchedulerDispatchSlotState::READY) {
+        for (uint8_t subtask_slot = 0; subtask_slot < 3; ++subtask_slot) {
+            if ((participant->active_mask & (1U << subtask_slot)) == 0) continue;
+            __gm__ SchedulerDispatchSlot *slot = scheduler_dispatch_slot_at(
+                scheduler_state_base, resolver, resolver->cluster_worker_ids[subtask_slot],
+                static_cast<uint32_t>(pending_slot)
+            );
+            scheduler_gm_store(
+                slot->publication, scheduler_dispatch_publication(slot->generation, SchedulerDispatchSlotState::READY)
+            );
+        }
+    }
+    participant->local_published_subtasks += scheduler_gang_popcount(participant->active_mask);
+    return true;
+}
+
+inline __aicore__ bool scheduler_gang_local_slots_drained(
+    __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver, uint32_t active_mask
+) {
+    const bool single_aiv = scheduler_gang_popcount(active_mask) == 1 && (active_mask & 6U) != 0;
+    for (uint32_t cluster_lane = 0; cluster_lane < 3; ++cluster_lane) {
+        const bool used =
+            cluster_lane == 0 ? (active_mask & 1U) != 0 : (single_aiv || (active_mask & (1U << cluster_lane)) != 0);
+        if (!used) continue;
+        for (uint32_t pending_slot = 0; pending_slot < SCHEDULER_PENDING_SLOT_COUNT; ++pending_slot) {
+            __gm__ SchedulerDispatchSlot *slot = scheduler_dispatch_slot_at(
+                scheduler_state_base, resolver, resolver->cluster_worker_ids[cluster_lane], pending_slot
+            );
+            if (scheduler_dispatch_state(scheduler_gm_query(slot->publication)) != SchedulerDispatchSlotState::FREE)
+                return false;
+        }
+    }
+    return true;
+}
+
+inline __aicore__ void scheduler_gang_fill_participant(
+    const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver,
+    __gm__ SchedulerRunControl *run_control, __gm__ SchedulerGangParticipant *participant, uint32_t cohort_index,
+    SchedulerDispatchSlotState publication
+) {
+    const uint32_t active_mask = participant->active_mask;
+    if (scheduler_gang_popcount(active_mask) > 1) {
+        while (participant->next_block[0] < participant->logical_block_num) {
+            const uint32_t block_idx = participant->next_block[0];
+            if (!scheduler_gang_fill_mix_block(
+                    graph, scheduler_state_base, resolver, run_control, participant, cohort_index, block_idx,
+                    publication
+                ))
+                break;
+            participant->next_block[0] += participant->block_stride;
+        }
+    } else if ((active_mask & 1U) != 0) {
+        while (participant->next_block[0] < participant->logical_block_num) {
+            const uint32_t block_idx = participant->next_block[0];
+            if (!scheduler_gang_fill_single(
+                    graph, scheduler_state_base, resolver, run_control, participant, cohort_index,
+                    resolver->cluster_worker_ids[0], 0, block_idx, publication
+                ))
+                break;
+            participant->next_block[0] += participant->block_stride;
+        }
+    } else {
+        const uint8_t subtask_slot = (active_mask & 2U) != 0 ? 1 : 2;
+        for (uint32_t lane = 0; lane < 2; ++lane) {
+            while (participant->next_block[lane] < participant->logical_block_num) {
+                const uint32_t block_idx = participant->next_block[lane];
+                if (!scheduler_gang_fill_single(
+                        graph, scheduler_state_base, resolver, run_control, participant, cohort_index,
+                        resolver->cluster_worker_ids[lane + 1], subtask_slot, block_idx, publication
+                    ))
+                    break;
+                participant->next_block[lane] += participant->block_stride;
+            }
+        }
+    }
+    scheduler_publish_cache_line(participant);
+}
+
+inline __aicore__ void scheduler_gang_release_local_slots(
+    __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver, uint32_t cohort_index,
+    uint64_t generation
+) {
+    for (uint32_t cluster_lane = 0; cluster_lane < 3; ++cluster_lane) {
+        for (uint32_t pending_slot = 0; pending_slot < SCHEDULER_PENDING_SLOT_COUNT; ++pending_slot) {
+            __gm__ SchedulerDispatchSlot *slot = scheduler_dispatch_slot_at(
+                scheduler_state_base, resolver, resolver->cluster_worker_ids[cluster_lane], pending_slot
+            );
+            const uint64_t publication = scheduler_gm_query(slot->publication);
+            if (scheduler_dispatch_state(publication) != SchedulerDispatchSlotState::GATED) continue;
+            scheduler_observe_cache_line(slot);
+            if (slot->cohort_index != cohort_index || slot->cohort_generation != generation) continue;
+            scheduler_gm_store(
+                slot->publication, scheduler_dispatch_publication(slot->generation, SchedulerDispatchSlotState::READY)
+            );
+        }
+    }
+}
+
+inline __aicore__ int64_t scheduler_gang_select_ready_task(
+    __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver, uint64_t priority_bit
+) {
+    for (uint64_t task_id = 0; task_id < resolver->graph_task_count; ++task_id) {
+        __gm__ SchedulerTaskMetadata *metadata =
+            scheduler_task_metadata_at(scheduler_state_base, resolver, static_cast<int64_t>(task_id));
+        if (!scheduler_task_is_gang(metadata->flags) || scheduler_task_priority_bit(metadata->flags) != priority_bit)
+            continue;
+        __gm__ SchedulerTaskControl *control =
+            scheduler_task_control_at(scheduler_state_base, resolver, static_cast<int64_t>(task_id));
+        if (scheduler_gm_query(control->state) == static_cast<int64_t>(SchedulerTaskState::READY))
+            return static_cast<int64_t>(task_id);
+    }
+    return SCHEDULER_TASK_ID_INVALID;
+}
+
+inline __aicore__ uint32_t scheduler_gang_assigned_blocks(uint32_t first, uint32_t stride, uint32_t logical_block_num) {
+    if (first >= logical_block_num) return 0;
+    return 1 + (logical_block_num - 1 - first) / stride;
+}
+
+inline __aicore__ bool scheduler_gang_admit_one(
+    const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver,
+    __gm__ SchedulerRunControl *run_control
+) {
+    if (resolver->resolver_index != 0) return false;
+    __gm__ SchedulerGangCoordinator *coordinator = scheduler_gang_coordinator_at(scheduler_state_base, resolver);
+    scheduler_observe_cache_line(coordinator);
+    scheduler_observe_cache_line(&coordinator->active_dispatch_cohort);
+    if (coordinator->active_dispatch_cohort != UINT64_MAX) return false;
+    uint64_t ready_bits = coordinator->ready_priority_bits;
+    if (ready_bits == 0) return false;
+    const uint64_t priority_bit = (ready_bits & 1U) != 0 ? 1U : ((ready_bits & 2U) != 0 ? 2U : 4U);
+    uint32_t cohort_index = UINT32_MAX;
+    for (uint32_t candidate = 0; candidate < SCHEDULER_GANG_COHORT_COUNT; ++candidate) {
+        __gm__ SchedulerGangCohort *cohort = scheduler_gang_cohort_at(scheduler_state_base, resolver, candidate);
+        scheduler_observe_cache_line(cohort);
+        if (cohort->state == static_cast<uint64_t>(SchedulerGangCohortState::FREE)) {
+            cohort_index = candidate;
+            break;
+        }
+    }
+    if (cohort_index == UINT32_MAX) return false;
+    const int64_t task_id = scheduler_gang_select_ready_task(scheduler_state_base, resolver, priority_bit);
+    if (task_id < 0) {
+        scheduler_gm_fetch_and(coordinator->ready_priority_bits, ~priority_bit);
+        if (scheduler_gang_select_ready_task(scheduler_state_base, resolver, priority_bit) >= 0)
+            scheduler_gm_fetch_or(coordinator->ready_priority_bits, priority_bit);
+        return false;
+    }
+    __gm__ SchedulerTaskMetadata *metadata = scheduler_task_metadata_at(scheduler_state_base, resolver, task_id);
+    scheduler_observe_cache_line(metadata);
+    const uint32_t active_mask = metadata->active_mask;
+    const uint32_t block_num = metadata->logical_block_num;
+    const bool mix = scheduler_task_is_mix(metadata->flags);
+    const bool single_aiv = !mix && (active_mask & 6U) != 0;
+    const uint32_t capacity = single_aiv ? static_cast<uint32_t>(resolver->resolver_count * 2) :
+                                           static_cast<uint32_t>(resolver->resolver_count);
+    if (scheduler_task_requires_sync_start(metadata->flags) && block_num > capacity) {
+        ++coordinator->capacity_reject_count;
+        scheduler_publish_cache_line(&coordinator->admitted_count);
+        scheduler_record_error(
+            run_control, task_id, SchedulerGraphResult::UNSUPPORTED_SHAPE, &graph, resolver, UINT64_C(72)
+        );
+        return false;
+    }
+    const uint32_t required_participants = single_aiv ? (block_num + 1) / 2 : block_num;
+    const uint32_t participant_count = required_participants < resolver->resolver_count ?
+                                           required_participants :
+                                           static_cast<uint32_t>(resolver->resolver_count);
+    uint64_t generation = ++coordinator->next_generation;
+    if (generation == 0) generation = ++coordinator->next_generation;
+    for (uint32_t participant_index = 0; participant_index < participant_count; ++participant_index) {
+        __gm__ SchedulerGangParticipant *participant =
+            scheduler_gang_participant_at(scheduler_state_base, resolver, cohort_index, participant_index);
+        participant->config_generation = generation;
+        participant->task_id = task_id;
+        participant->active_mask = active_mask;
+        participant->logical_block_num = block_num;
+        participant->local_published_subtasks = 0;
+        participant->local_completed_subtasks = 0;
+        participant->forwarded_state = UINT32_MAX;
+        participant->forwarded_generation = 0;
+        participant->drain_local_token = 0;
+        participant->drain_subtree_token = 0;
+        participant->stage_local_token = 0;
+        participant->stage_subtree_token = 0;
+        participant->dispatch_local_token = 0;
+        participant->dispatch_subtree_token = 0;
+        participant->completion_local_token = 0;
+        participant->completion_subtree_token = 0;
+        if (single_aiv) {
+            participant->block_stride = static_cast<uint32_t>(resolver->resolver_count * 2);
+            participant->next_block[0] = participant_index * 2;
+            participant->next_block[1] = participant_index * 2 + 1;
+            participant->local_expected_subtasks =
+                scheduler_gang_assigned_blocks(participant->next_block[0], participant->block_stride, block_num) +
+                scheduler_gang_assigned_blocks(participant->next_block[1], participant->block_stride, block_num);
+        } else {
+            participant->block_stride = static_cast<uint32_t>(resolver->resolver_count);
+            participant->next_block[0] = participant_index;
+            participant->next_block[1] = UINT32_MAX;
+            participant->local_expected_subtasks =
+                scheduler_gang_assigned_blocks(participant_index, participant->block_stride, block_num) *
+                scheduler_gang_popcount(active_mask);
+        }
+        participant->participant_count = participant_count;
+        scheduler_publish_cache_line(participant);
+        scheduler_publish_cache_line(&participant->drain_local_token);
+    }
+    __gm__ SchedulerGangCohort *cohort = scheduler_gang_cohort_at(scheduler_state_base, resolver, cohort_index);
+    cohort->task_id = task_id;
+    cohort->generation = generation;
+    cohort->priority_bit = priority_bit;
+    cohort->active_mask = active_mask;
+    cohort->logical_block_num = block_num;
+    cohort->participant_count = participant_count;
+    cohort->local_stride = single_aiv ? resolver->resolver_count * 2 : resolver->resolver_count;
+    cohort->admitted_cycles = scheduler_cycles();
+    cohort->state = static_cast<uint64_t>(
+        scheduler_task_requires_sync_start(metadata->flags) ? SchedulerGangCohortState::DRAINING :
+                                                              SchedulerGangCohortState::DISPATCHING
+    );
+    scheduler_publish_cache_line(cohort);
+    __gm__ SchedulerTaskControl *control = scheduler_task_control_at(scheduler_state_base, resolver, task_id);
+    scheduler_gm_store(control->state, static_cast<int64_t>(SchedulerTaskState::DISPATCHING));
+    coordinator->active_dispatch_cohort = cohort_index;
+    ++coordinator->admitted_count;
+    if (priority_bit == 1) ++coordinator->sync_drain_count;
+    else if (priority_bit == 2) ++coordinator->mix_dispatch_count;
+    else ++coordinator->spmd_dispatch_count;
+    scheduler_publish_cache_line(&coordinator->active_dispatch_cohort);
+    scheduler_publish_cache_line(&coordinator->admitted_count);
+    scheduler_gang_publish_command(
+        scheduler_state_base, resolver, 0, cohort_index, generation,
+        scheduler_task_requires_sync_start(metadata->flags) ? SchedulerGangCohortState::DRAINING :
+                                                              SchedulerGangCohortState::DISPATCHING
+    );
+    return true;
+}
+
+inline __aicore__ bool scheduler_gang_service_participant(
+    const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver,
+    __gm__ SchedulerRunControl *run_control, uint32_t cohort_index, uint64_t cohort_generation,
+    SchedulerGangCohortState state
+) {
+    __gm__ SchedulerGangParticipant *participant =
+        scheduler_gang_participant_at(scheduler_state_base, resolver, cohort_index, resolver->resolver_index);
+    scheduler_observe_cache_line(participant);
+    if (participant->config_generation != cohort_generation ||
+        resolver->resolver_index >= participant->participant_count)
+        return false;
+    bool progress = scheduler_gang_forward_command(
+        scheduler_state_base, resolver, participant, cohort_index, cohort_generation, state
+    );
+    if (state == SchedulerGangCohortState::DRAINING) {
+        if (scheduler_gang_local_slots_drained(scheduler_state_base, resolver, participant->active_mask)) {
+            progress =
+                scheduler_gang_publish_local_token(participant, SchedulerGangTokenPhase::DRAIN, cohort_generation) ||
+                progress;
+        }
+        (void)scheduler_gang_update_subtree_token(
+            scheduler_state_base, resolver, cohort_index, participant->participant_count, cohort_generation,
+            SchedulerGangTokenPhase::DRAIN
+        );
+    } else if (state == SchedulerGangCohortState::STAGING) {
+        const uint32_t before = participant->local_published_subtasks;
+        scheduler_gang_fill_participant(
+            graph, scheduler_state_base, resolver, run_control, participant, cohort_index,
+            SchedulerDispatchSlotState::GATED
+        );
+        progress = participant->local_published_subtasks != before;
+        if (participant->local_published_subtasks == participant->local_expected_subtasks)
+            scheduler_gang_publish_local_token(participant, SchedulerGangTokenPhase::STAGE, cohort_generation);
+        (void)scheduler_gang_update_subtree_token(
+            scheduler_state_base, resolver, cohort_index, participant->participant_count, cohort_generation,
+            SchedulerGangTokenPhase::STAGE
+        );
+    } else if (state == SchedulerGangCohortState::RELEASING) {
+        scheduler_gang_release_local_slots(scheduler_state_base, resolver, cohort_index, cohort_generation);
+        progress =
+            scheduler_gang_publish_local_token(participant, SchedulerGangTokenPhase::DISPATCH, cohort_generation) ||
+            progress;
+        (void)scheduler_gang_update_subtree_token(
+            scheduler_state_base, resolver, cohort_index, participant->participant_count, cohort_generation,
+            SchedulerGangTokenPhase::DISPATCH
+        );
+    } else if (state == SchedulerGangCohortState::DISPATCHING) {
+        const uint32_t before = participant->local_published_subtasks;
+        scheduler_gang_fill_participant(
+            graph, scheduler_state_base, resolver, run_control, participant, cohort_index,
+            SchedulerDispatchSlotState::READY
+        );
+        progress = participant->local_published_subtasks != before;
+        if (participant->local_published_subtasks == participant->local_expected_subtasks)
+            scheduler_gang_publish_local_token(participant, SchedulerGangTokenPhase::DISPATCH, cohort_generation);
+        (void)scheduler_gang_update_subtree_token(
+            scheduler_state_base, resolver, cohort_index, participant->participant_count, cohort_generation,
+            SchedulerGangTokenPhase::DISPATCH
+        );
+    } else if (state == SchedulerGangCohortState::RETIRING) {
+        scheduler_gang_publish_retire(scheduler_state_base, resolver, participant, cohort_index, cohort_generation);
+    }
+    if (state != SchedulerGangCohortState::RETIRING &&
+        participant->local_completed_subtasks == participant->local_expected_subtasks &&
+        participant->local_expected_subtasks != 0) {
+        scheduler_gang_publish_local_token(participant, SchedulerGangTokenPhase::COMPLETION, cohort_generation);
+    }
+    if (state != SchedulerGangCohortState::RETIRING) {
+        (void)scheduler_gang_update_subtree_token(
+            scheduler_state_base, resolver, cohort_index, participant->participant_count, cohort_generation,
+            SchedulerGangTokenPhase::COMPLETION
+        );
+    }
+    return progress;
+}
+
+inline __aicore__ bool scheduler_gang_service_owner(
+    const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver,
+    __gm__ SchedulerRunControl *run_control, uint32_t cohort_index, __gm__ SchedulerGangCohort *cohort,
+    SchedulerWakeStats *wake_stats, SchedulerReadyStats *ready_stats, SchedulerCompletionStats *completion_stats,
+    __gm__ SchedulerReadyOwnerState *owner_state = nullptr
+) {
+    if (resolver->resolver_index != 0 || cohort->participant_count == 0) return false;
+    const uint64_t generation = cohort->generation;
+    auto state = static_cast<SchedulerGangCohortState>(cohort->state);
+    bool progress = false;
+    if (state == SchedulerGangCohortState::DRAINING &&
+        scheduler_gang_root_token_ready(
+            scheduler_state_base, resolver, cohort_index, generation, SchedulerGangTokenPhase::DRAIN
+        )) {
+        cohort->drain_complete_cycles = scheduler_cycles();
+        cohort->state = static_cast<uint64_t>(SchedulerGangCohortState::STAGING);
+        scheduler_publish_cache_line(cohort);
+        scheduler_gang_publish_command(
+            scheduler_state_base, resolver, 0, cohort_index, generation, SchedulerGangCohortState::STAGING
+        );
+        progress = true;
+    } else if (state == SchedulerGangCohortState::STAGING &&
+               scheduler_gang_root_token_ready(
+                   scheduler_state_base, resolver, cohort_index, generation, SchedulerGangTokenPhase::STAGE
+               )) {
+        cohort->stage_complete_cycles = scheduler_cycles();
+        cohort->state = static_cast<uint64_t>(SchedulerGangCohortState::RELEASING);
+        scheduler_publish_cache_line(cohort);
+        scheduler_gang_publish_command(
+            scheduler_state_base, resolver, 0, cohort_index, generation, SchedulerGangCohortState::RELEASING
+        );
+        progress = true;
+    } else if ((state == SchedulerGangCohortState::RELEASING || state == SchedulerGangCohortState::DISPATCHING) &&
+               scheduler_gang_root_token_ready(
+                   scheduler_state_base, resolver, cohort_index, generation, SchedulerGangTokenPhase::DISPATCH
+               )) {
+        cohort->dispatch_complete_cycles = scheduler_cycles();
+        cohort->state = static_cast<uint64_t>(SchedulerGangCohortState::EXECUTING);
+        scheduler_publish_cache_line(cohort);
+        __gm__ SchedulerGangCoordinator *coordinator = scheduler_gang_coordinator_at(scheduler_state_base, resolver);
+        coordinator->active_dispatch_cohort = UINT64_MAX;
+        scheduler_publish_cache_line(&coordinator->active_dispatch_cohort);
+        scheduler_gang_publish_command(
+            scheduler_state_base, resolver, 0, cohort_index, generation, SchedulerGangCohortState::EXECUTING
+        );
+        progress = true;
+    }
+    state = static_cast<SchedulerGangCohortState>(cohort->state);
+    if (state == SchedulerGangCohortState::EXECUTING &&
+        scheduler_gang_root_token_ready(
+            scheduler_state_base, resolver, cohort_index, generation, SchedulerGangTokenPhase::COMPLETION
+        )) {
+        __gm__ SchedulerTaskControl *control =
+            scheduler_task_control_at(scheduler_state_base, resolver, cohort->task_id);
+        scheduler_gm_store(control->state, static_cast<int64_t>(SchedulerTaskState::DONE));
+        if (!scheduler_resolve_completion(
+                graph, scheduler_state_base, resolver, run_control, cohort->task_id, wake_stats, ready_stats,
+                completion_stats, false, false, nullptr, owner_state
+            )) {
+            return false;
+        }
+        if (completion_stats != nullptr) ++completion_stats->resolve_count;
+        cohort->completion_cycles = scheduler_cycles();
+        cohort->state = static_cast<uint64_t>(SchedulerGangCohortState::RETIRING);
+        scheduler_publish_cache_line(cohort);
+        scheduler_gang_publish_command(
+            scheduler_state_base, resolver, 0, cohort_index, generation, SchedulerGangCohortState::FREE
+        );
+        __gm__ SchedulerGangParticipant *root =
+            scheduler_gang_participant_at(scheduler_state_base, resolver, cohort_index, 0);
+        scheduler_observe_cache_line(root);
+        (void)scheduler_gang_forward_command(
+            scheduler_state_base, resolver, root, cohort_index, generation, SchedulerGangCohortState::FREE
+        );
+        scheduler_gang_publish_retire(scheduler_state_base, resolver, root, cohort_index, generation);
+        progress = true;
+    }
+    state = static_cast<SchedulerGangCohortState>(cohort->state);
+    if (state == SchedulerGangCohortState::RETIRING &&
+        scheduler_gang_root_token_ready(
+            scheduler_state_base, resolver, cohort_index, scheduler_gang_retire_token(generation),
+            SchedulerGangTokenPhase::COMPLETION
+        )) {
+        cohort->task_id = SCHEDULER_TASK_ID_INVALID;
+        cohort->state = static_cast<uint64_t>(SchedulerGangCohortState::FREE);
+        scheduler_publish_cache_line(cohort);
+        // A gang task is globally resolved only after every Resolver has observed
+        // the FREE command. Otherwise AICPU may stop the AICore schedulers while
+        // the tree still contains a retiring generation, making the cohort unsafe
+        // to reuse and failing final scheduler validation.
+        scheduler_gm_fetch_add(run_control->resolved_task_count, UINT64_C(1));
+        progress = true;
+    }
+    return progress;
+}
+
+inline __aicore__ bool scheduler_service_gang(
+    const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *resolver,
+    __gm__ SchedulerRunControl *run_control, SchedulerWakeStats *wake_stats, SchedulerReadyStats *ready_stats,
+    SchedulerCompletionStats *completion_stats, __gm__ SchedulerReadyOwnerState *owner_state = nullptr
+) {
+    if (resolver->is_resolver == 0) return false;
+    __gm__ SchedulerGangCoordinator *coordinator = scheduler_gang_coordinator_at(scheduler_state_base, resolver);
+    if (coordinator->gang_task_count == 0) return false;
+    bool progress = false;
+    const bool owner = resolver->resolver_index == 0;
+    uint64_t command_generations[SCHEDULER_GANG_COHORT_COUNT]{};
+    uint64_t command_states[SCHEDULER_GANG_COHORT_COUNT]{};
+    if (!owner) {
+        __gm__ SchedulerGangCommand *command =
+            scheduler_gang_command_at(scheduler_state_base, resolver, resolver->resolver_index);
+        scheduler_observe_cache_line(command);
+        for (uint32_t cohort_index = 0; cohort_index < SCHEDULER_GANG_COHORT_COUNT; ++cohort_index) {
+            command_generations[cohort_index] = command->generation[cohort_index];
+            command_states[cohort_index] = command->state[cohort_index];
+        }
+    }
+    for (uint32_t cohort_index = 0; cohort_index < SCHEDULER_GANG_COHORT_COUNT; ++cohort_index) {
+        __gm__ SchedulerGangCohort *cohort = nullptr;
+        uint64_t generation = command_generations[cohort_index];
+        auto state = static_cast<SchedulerGangCohortState>(command_states[cohort_index]);
+        if (owner) {
+            cohort = scheduler_gang_cohort_at(scheduler_state_base, resolver, cohort_index);
+            scheduler_observe_cache_line(cohort);
+            generation = cohort->generation;
+            state = static_cast<SchedulerGangCohortState>(cohort->state);
+        }
+        if (state == SchedulerGangCohortState::FREE) {
+            if (!owner && generation != 0) {
+                __gm__ SchedulerGangParticipant *participant = scheduler_gang_participant_at(
+                    scheduler_state_base, resolver, cohort_index, resolver->resolver_index
+                );
+                // This Resolver necessarily observed its participant config in
+                // an earlier active phase before the cohort could complete.
+                // Keep that owner-local line hot after FREE instead of forcing
+                // a DCCI invalidate on every idle scheduler iteration.
+                if (participant->config_generation == generation &&
+                    resolver->resolver_index < participant->participant_count) {
+                    progress = scheduler_gang_forward_command(
+                                   scheduler_state_base, resolver, participant, cohort_index, generation, state
+                               ) ||
+                               progress;
+                    scheduler_gang_publish_retire(
+                        scheduler_state_base, resolver, participant, cohort_index, generation
+                    );
+                }
+            }
+            continue;
+        }
+        progress = scheduler_gang_service_participant(
+                       graph, scheduler_state_base, resolver, run_control, cohort_index, generation, state
+                   ) ||
+                   progress;
+        if (owner) {
+            progress = scheduler_gang_service_owner(
+                           graph, scheduler_state_base, resolver, run_control, cohort_index, cohort, wake_stats,
+                           ready_stats, completion_stats, owner_state
+                       ) ||
+                       progress;
+        }
+    }
+    if (owner) progress = scheduler_gang_admit_one(graph, scheduler_state_base, resolver, run_control) || progress;
+    return progress;
+}

--- a/tests/st/a5/host_build_graph/mix_spmd_sync_start/kernels/orchestration/mix_spmd_sync_start_orch.cpp
+++ b/tests/st/a5/host_build_graph/mix_spmd_sync_start/kernels/orchestration/mix_spmd_sync_start_orch.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "orchestration_api.h"
+
+namespace {
+
+constexpr int32_t kAicFuncId = 0;
+constexpr int32_t kAiv0FuncId = 1;
+constexpr int32_t kAiv1FuncId = 2;
+constexpr int32_t kSlotsPerBlock = 3;
+
+int16_t half_capacity(int32_t capacity) {
+    const int32_t half = capacity / 2;
+    return static_cast<int16_t>(half < 2 ? 2 : half);
+}
+
+TaskId submit(
+    const simpler::hbg::Tensor &output, const MixedKernels &kernels, int16_t block_num, int64_t base_cache_line,
+    bool sync_start, const TaskId *dependency = nullptr
+) {
+    CoreTaskArgs args;
+    args.add_inout(output);
+    args.add_scalar(base_cache_line);
+    args.launch_spec.set_block_num(block_num);
+    args.launch_spec.set_require_sync_start(sync_start);
+    if (dependency != nullptr) args.set_dependencies(dependency, 1);
+    return rt_submit_task(kernels, args).task_id();
+}
+
+void report_layout(
+    const simpler::hbg::Tensor &layout, int32_t task, int16_t block_num, int32_t base_cache_line, int32_t mask
+) {
+    const int32_t values[3] = {block_num, base_cache_line, mask};
+    for (int32_t field = 0; field < 3; ++field) {
+        uint32_t index[1] = {static_cast<uint32_t>(task * 3 + field)};
+        set_tensor_data<int32_t>(layout, 1, index, values[field]);
+    }
+}
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &args) {
+    (void)args;
+    return OrchestrationConfig{.expected_arg_count = 2};
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &args) {
+    const simpler::hbg::Tensor &output = args.tensor(0).ref();
+    const simpler::hbg::Tensor &layout = args.tensor(1).ref();
+    const int16_t aiv_blocks = half_capacity(rt_available_aiv_count());
+    const int16_t mix_blocks = half_capacity(rt_available_cluster_count());
+    const MixedKernels aic{kAicFuncId, INVALID_KERNEL_ID, INVALID_KERNEL_ID};
+    const MixedKernels aiv{INVALID_KERNEL_ID, kAiv0FuncId, INVALID_KERNEL_ID};
+    const MixedKernels mix{kAicFuncId, kAiv0FuncId, kAiv1FuncId};
+    const int16_t block_nums[5] = {1, aiv_blocks, mix_blocks, aiv_blocks, mix_blocks};
+    const int32_t masks[5] = {1, 2, 7, 2, 7};
+    int32_t base_cache_line = 0;
+
+    TaskId root = submit(output, aic, block_nums[0], base_cache_line, false);
+    report_layout(layout, 0, block_nums[0], base_cache_line, masks[0]);
+    base_cache_line += block_nums[0] * kSlotsPerBlock;
+    (void)submit(output, aiv, block_nums[1], base_cache_line, false);
+    report_layout(layout, 1, block_nums[1], base_cache_line, masks[1]);
+    base_cache_line += block_nums[1] * kSlotsPerBlock;
+    (void)submit(output, mix, block_nums[2], base_cache_line, false);
+    report_layout(layout, 2, block_nums[2], base_cache_line, masks[2]);
+    base_cache_line += block_nums[2] * kSlotsPerBlock;
+    (void)submit(output, aiv, block_nums[3], base_cache_line, true);
+    report_layout(layout, 3, block_nums[3], base_cache_line, masks[3]);
+    base_cache_line += block_nums[3] * kSlotsPerBlock;
+    (void)submit(output, mix, block_nums[4], base_cache_line, true, &root);
+    report_layout(layout, 4, block_nums[4], base_cache_line, masks[4]);
+}
+
+}  // extern "C"

--- a/tests/st/a5/host_build_graph/mix_spmd_sync_start/test_mix_spmd_sync_start.py
+++ b/tests/st/a5/host_build_graph/mix_spmd_sync_start/test_mix_spmd_sync_start.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Cluster-local Mix, SPMD, and sync-start execution on the HBG AICore scheduler."""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+
+FLOATS_PER_CACHE_LINE = 16
+SLOTS_PER_BLOCK = 3
+NUM_TASKS = 5
+MAX_AIV = 72
+MAX_CLUSTERS = 36
+MAX_TOTAL_CL = (1 + MAX_AIV // 2 + MAX_CLUSTERS // 2 + MAX_AIV // 2 + MAX_CLUSTERS // 2) * SLOTS_PER_BLOCK
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestMixSpmdSyncStart(SceneTestCase):
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/mix_spmd_sync_start_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT, D.INOUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "source": "../../tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aic/kernel_spmd_mix.cpp",
+                "core_type": "aic",
+            },
+            {
+                "func_id": 1,
+                "source": "../../tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aiv/kernel_spmd_mix.cpp",
+                "core_type": "aiv",
+            },
+            {
+                "func_id": 2,
+                "source": "../../tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/aiv/kernel_spmd_mix.cpp",
+                "core_type": "aiv",
+            },
+        ],
+    }
+
+    CASES = [{"name": "mixed_priorities", "platforms": ["a5sim", "a5"], "params": {}}]
+
+    def generate_args(self, params):
+        return TaskArgsBuilder(
+            TensorArg("output", torch.zeros(MAX_TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(NUM_TASKS * 3, dtype=torch.int32)),
+        )
+
+    def compute_golden(self, args, params):
+        pass
+
+    def compare_outputs(self, test_args, golden_args, output_names, params):
+        layout = [int(value) for value in test_args.layout]
+        expected = torch.zeros(MAX_TOTAL_CL, dtype=torch.float32)
+        for task in range(NUM_TASKS):
+            block_num, base_cl, active_mask = layout[task * 3 : task * 3 + 3]
+            assert block_num > 0
+            assert base_cl + block_num * SLOTS_PER_BLOCK <= MAX_TOTAL_CL
+            for block_idx in range(block_num):
+                for subtask_slot in range(3):
+                    if active_mask & (1 << subtask_slot):
+                        expected[base_cl + block_idx * SLOTS_PER_BLOCK + subtask_slot] = float(block_idx)
+        actual = test_args.output.reshape(MAX_TOTAL_CL, FLOATS_PER_CACHE_LINE)[:, 0]
+        assert torch.equal(actual, expected), f"layout={layout}, actual={actual.tolist()}, expected={expected.tolist()}"
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a5/host_build_graph/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a5/host_build_graph/paged_attention_unroll/test_paged_attention_unroll.py
@@ -62,6 +62,21 @@ class TestPagedAttentionUnrollHostBuildGraph(SceneTestCase):
 
     CASES = [
         {
+            "name": "SmallCaseMixedGroups",
+            "platforms": ["a5sim", "a5"],
+            "params": {
+                "batch": 2,
+                "num_heads": 16,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 128,
+                "context_len": 8193,
+                "context_lens_list": [8193, 257],
+                "max_model_len": 8448,
+                "dtype": "bfloat16",
+            },
+        },
+        {
             "name": "Case1",
             "platforms": ["a5"],
             "params": {

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -908,6 +908,7 @@ target_sources(test_hbg_submit_poison PRIVATE
 add_a5_hbg_runtime_test(test_a5_hbg_scheduler_contracts a5/test_hbg_scheduler_contracts.cpp)
 add_a5_hbg_runtime_test(test_a5_hbg_scheduler_ready a5/test_hbg_scheduler_ready.cpp)
 add_a5_hbg_runtime_test(test_a5_hbg_scheduler_dispatch a5/test_hbg_scheduler_dispatch.cpp)
+add_a5_hbg_runtime_test(test_a5_hbg_scheduler_gang a5/test_hbg_scheduler_gang.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_graph_submit_failure common/test_hbg_graph_submit_failure.cpp)
 target_sources(test_hbg_graph_submit_failure PRIVATE
     ${HBG_RUNTIME_DIR}/orchestrator_core/orchestrator.cpp

--- a/tests/ut/cpp/a5/test_hbg_scheduler_gang.cpp
+++ b/tests/ut/cpp/a5/test_hbg_scheduler_gang.cpp
@@ -1,0 +1,410 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "scheduler/scheduler_dispatch.h"
+#include "scheduler/scheduler_topology.h"
+#include "runtime_types.h"
+
+namespace {
+
+class SchedulerStateBuffer {
+public:
+    explicit SchedulerStateBuffer(const AicoreSchedulerLayout &layout) :
+        base_(std::aligned_alloc(SCHEDULER_STATE_ALIGNMENT, layout.total_size)) {
+        EXPECT_NE(base_, nullptr);
+        if (base_ != nullptr) EXPECT_TRUE(scheduler_init_data_from_layout(base_, layout));
+    }
+    ~SchedulerStateBuffer() { std::free(base_); }
+    void *base() const { return base_; }
+
+private:
+    void *base_{nullptr};
+};
+
+class GraphBuffer {
+public:
+    explicit GraphBuffer(size_t task_count) :
+        task_count_(task_count) {
+        while (capacity_ < std::max<size_t>(task_count, 1))
+            capacity_ <<= 1;
+        descriptors_ = std::make_unique<TaskDescriptor[]>(capacity_);
+        payloads_ = std::make_unique<TaskPayload[]>(capacity_);
+        fanins_ = std::make_unique<int32_t[]>(capacity_ * SCHEDULER_GRAPH_MAX_FANIN);
+        for (size_t task = 0; task < capacity_; ++task) {
+            descriptors_[task].task_id = TaskId{static_cast<uint64_t>(task)};
+            payloads_[task].bind_regions(
+                nullptr, nullptr, fanins_.get() + task * static_cast<size_t>(SCHEDULER_GRAPH_MAX_FANIN)
+            );
+            for (int slot = 0; slot < 3; ++slot)
+                descriptors_[task].kernel_id[slot] = INVALID_KERNEL_ID;
+        }
+    }
+
+    void executable(size_t task, uint8_t subtask_slot, std::vector<int32_t> fanins = {}) {
+        ASSERT_LT(task, task_count_);
+        ASSERT_LT(subtask_slot, 3);
+        ASSERT_LE(fanins.size(), static_cast<size_t>(SCHEDULER_GRAPH_MAX_FANIN));
+        descriptors_[task].kernel_id[subtask_slot] = 1;
+        payloads_[task].fanin_count = static_cast<int32_t>(fanins.size());
+        std::copy(fanins.begin(), fanins.end(), payloads_[task].fanin_data());
+    }
+
+    void mixed(size_t task, uint8_t active_mask) {
+        ASSERT_LT(task, task_count_);
+        for (uint8_t subtask_slot = 0; subtask_slot < 3; ++subtask_slot) {
+            if ((active_mask & (1U << subtask_slot)) != 0) descriptors_[task].kernel_id[subtask_slot] = 1;
+        }
+        payloads_[task].fanin_count = 0;
+    }
+
+    SchedulerGraphView graph() const {
+        return {
+            reinterpret_cast<uint64_t>(descriptors_.get()),
+            reinterpret_cast<uint64_t>(payloads_.get()),
+            task_count_,
+            capacity_ - 1,
+        };
+    }
+
+private:
+    size_t task_count_;
+    size_t capacity_{1};
+    std::unique_ptr<TaskDescriptor[]> descriptors_;
+    std::unique_ptr<TaskPayload[]> payloads_;
+    std::unique_ptr<int32_t[]> fanins_;
+};
+
+struct FixtureStorage {
+    explicit FixtureStorage(uint64_t task_count, uint64_t workers = 2) {
+        EXPECT_TRUE(scheduler_plan_layout(task_count, task_count, 0, &layout));
+        scheduler_state = std::make_unique<SchedulerStateBuffer>(layout);
+        run_control = scheduler_state_at<SchedulerRunControl>(scheduler_state->base(), layout.run_control_offset);
+        contexts = scheduler_state_at<SchedulerWorkerContext>(scheduler_state->base(), layout.worker_contexts_offset);
+        run_control->aiv_active_worker_count = workers;
+        run_control->resolver_count = workers;
+        for (uint64_t worker = 0; worker < workers; ++worker) {
+            SchedulerWorkerContext &context = contexts[worker];
+            context.core_type = static_cast<int32_t>(CoreType::AIV);
+            context.active = 1;
+            context.task_controls_offset = layout.task_controls_offset;
+            context.task_metadata_offset = layout.task_metadata_offset;
+            context.completion_inboxes_offset = layout.completion_inboxes_offset;
+            context.ready_inboxes_offset = layout.ready_inboxes_offset;
+            context.ready_owner_states_offset = layout.ready_owner_states_offset;
+            context.ready_directory_offset = layout.ready_directory_offset;
+            context.trace_cells_offset = layout.trace_cells_offset;
+            context.worker_contexts_offset = layout.worker_contexts_offset;
+            context.dispatch_slots_offset = layout.dispatch_slots_offset;
+            context.callable_addresses_offset = layout.callable_addresses_offset;
+            context.gang_coordinator_offset = layout.gang_coordinator_offset;
+            context.gang_cohorts_offset = layout.gang_cohorts_offset;
+            context.gang_participants_offset = layout.gang_participants_offset;
+            context.gang_commands_offset = layout.gang_commands_offset;
+            context.dispatch_payload_offset =
+                layout.dispatch_payloads_offset + worker * SCHEDULER_PENDING_SLOT_COUNT * sizeof(DispatchPayload);
+            context.graph_task_count = task_count;
+            context.runtime_worker_count = workers;
+            context.worker_index = worker;
+            context.inbox_index = worker;
+        }
+        metadata = scheduler_state_at<SchedulerTaskMetadata>(scheduler_state->base(), layout.task_metadata_offset);
+        for (uint64_t task = 0; task < task_count; ++task) {
+            metadata[task].kernel_ids[0] = 1;
+            metadata[task].kernel_ids[1] = UINT16_MAX;
+            metadata[task].kernel_ids[2] = UINT16_MAX;
+            metadata[task].active_mask = 1;
+            metadata[task].logical_block_num = 1;
+            metadata[task].total_required_subtasks = 1;
+            metadata[task].flags = SCHEDULER_TASK_EXECUTABLE;
+        }
+    }
+
+    AicoreSchedulerLayout layout{};
+    std::unique_ptr<SchedulerStateBuffer> scheduler_state;
+    SchedulerRunControl *run_control{nullptr};
+    SchedulerWorkerContext *contexts{nullptr};
+    SchedulerTaskMetadata *metadata{nullptr};
+};
+
+TEST(SchedulerGangPriority, SyncStartPrecedesMixAndSpmd) {
+    EXPECT_EQ(scheduler_task_priority_bit(SCHEDULER_TASK_SPMD), 4u);
+    EXPECT_EQ(scheduler_task_priority_bit(SCHEDULER_TASK_MIX), 2u);
+    EXPECT_EQ(scheduler_task_priority_bit(SCHEDULER_TASK_MIX | SCHEDULER_TASK_SYNC_START), 1u);
+
+    FixtureStorage storage(3, 3);
+    GraphBuffer graph(3);
+    graph.executable(0, 0);
+    graph.mixed(1, 3);
+    graph.executable(2, 1);
+    auto *coordinator = scheduler_state_at<SchedulerGangCoordinator>(
+        storage.scheduler_state->base(), storage.layout.gang_coordinator_offset
+    );
+    coordinator->gang_task_count = 3;
+    coordinator->resolver_count = 1;
+    coordinator->ready_priority_bits = 7;
+    storage.run_control->resolver_count = 1;
+    SchedulerWorkerContext &resolver = storage.contexts[1];
+    resolver.is_resolver = 1;
+    resolver.resolver_index = 0;
+    resolver.resolver_count = 1;
+    resolver.cluster_worker_ids[0] = 0;
+    resolver.cluster_worker_ids[1] = 1;
+    resolver.cluster_worker_ids[2] = 2;
+    auto *controls =
+        scheduler_state_at<SchedulerTaskControl>(storage.scheduler_state->base(), storage.layout.task_controls_offset);
+    for (uint32_t task = 0; task < 3; ++task)
+        controls[task].state = static_cast<int64_t>(SchedulerTaskState::READY);
+    storage.metadata[0].active_mask = 1;
+    storage.metadata[0].logical_block_num = 4;
+    storage.metadata[0].total_required_subtasks = 4;
+    storage.metadata[0].flags = SCHEDULER_TASK_EXECUTABLE | SCHEDULER_TASK_SPMD;
+    storage.metadata[1].active_mask = 3;
+    storage.metadata[1].logical_block_num = 1;
+    storage.metadata[1].total_required_subtasks = 2;
+    storage.metadata[1].flags = SCHEDULER_TASK_EXECUTABLE | SCHEDULER_TASK_MIX;
+    storage.metadata[2].active_mask = 2;
+    storage.metadata[2].logical_block_num = 2;
+    storage.metadata[2].total_required_subtasks = 2;
+    storage.metadata[2].flags = SCHEDULER_TASK_EXECUTABLE | SCHEDULER_TASK_SPMD | SCHEDULER_TASK_SYNC_START;
+
+    ASSERT_TRUE(
+        scheduler_gang_admit_one(graph.graph(), storage.scheduler_state->base(), &resolver, storage.run_control)
+    );
+    auto *cohort =
+        scheduler_state_at<SchedulerGangCohort>(storage.scheduler_state->base(), storage.layout.gang_cohorts_offset);
+    EXPECT_EQ(cohort->task_id, 2);
+    EXPECT_EQ(cohort->state, static_cast<uint64_t>(SchedulerGangCohortState::DRAINING));
+    EXPECT_EQ(controls[2].state, static_cast<int64_t>(SchedulerTaskState::DISPATCHING));
+    EXPECT_FALSE(
+        scheduler_gang_admit_one(graph.graph(), storage.scheduler_state->base(), &resolver, storage.run_control)
+    );
+}
+
+TEST(SchedulerSyncStart, RejectsImpossibleCohortBeforeDrain) {
+    FixtureStorage storage(1, 3);
+    GraphBuffer graph(1);
+    graph.executable(0, 1);
+    SchedulerWorkerContext &resolver = storage.contexts[1];
+    resolver.is_resolver = 1;
+    resolver.resolver_index = 0;
+    resolver.resolver_count = 1;
+    resolver.cluster_worker_ids[0] = 0;
+    resolver.cluster_worker_ids[1] = 1;
+    resolver.cluster_worker_ids[2] = 2;
+    storage.run_control->resolver_count = 1;
+    storage.metadata[0].kernel_ids[1] = 1;
+    storage.metadata[0].active_mask = 2;
+    storage.metadata[0].logical_block_num = 3;
+    storage.metadata[0].total_required_subtasks = 3;
+    storage.metadata[0].flags = SCHEDULER_TASK_EXECUTABLE | SCHEDULER_TASK_SPMD | SCHEDULER_TASK_SYNC_START;
+    auto *control = scheduler_task_control_at(storage.scheduler_state->base(), &resolver, 0);
+    control->state = static_cast<int64_t>(SchedulerTaskState::READY);
+    auto *coordinator = scheduler_gang_coordinator_at(storage.scheduler_state->base(), &resolver);
+    coordinator->gang_task_count = 1;
+    coordinator->resolver_count = 1;
+    coordinator->ready_priority_bits = 1;
+
+    EXPECT_FALSE(
+        scheduler_gang_admit_one(graph.graph(), storage.scheduler_state->base(), &resolver, storage.run_control)
+    );
+    EXPECT_EQ(coordinator->capacity_reject_count, 1u);
+    EXPECT_EQ(storage.run_control->scheduler_error, static_cast<uint64_t>(SchedulerGraphResult::UNSUPPORTED_SHAPE));
+    EXPECT_EQ(storage.run_control->error_reserved[0], 72u);
+    EXPECT_EQ(coordinator->active_dispatch_cohort, UINT64_MAX);
+}
+
+TEST(SchedulerGangTokens, StaleGenerationCannotCompleteTree) {
+    FixtureStorage storage(1, 3);
+    SchedulerWorkerContext &resolver = storage.contexts[0];
+    resolver.resolver_index = 0;
+    resolver.resolver_count = 3;
+    constexpr uint64_t kGeneration = 9;
+    for (uint64_t participant_index = 0; participant_index < 3; ++participant_index) {
+        auto *participant =
+            scheduler_gang_participant_at(storage.scheduler_state->base(), &resolver, 0, participant_index);
+        participant->dispatch_local_token = kGeneration;
+    }
+    auto *stale_child = scheduler_gang_participant_at(storage.scheduler_state->base(), &resolver, 0, 2);
+    stale_child->dispatch_local_token = kGeneration - 1;
+    resolver.resolver_index = 1;
+    EXPECT_TRUE(scheduler_gang_update_subtree_token(
+        storage.scheduler_state->base(), &resolver, 0, 3, kGeneration, SchedulerGangTokenPhase::DISPATCH
+    ));
+    resolver.resolver_index = 2;
+    EXPECT_FALSE(scheduler_gang_update_subtree_token(
+        storage.scheduler_state->base(), &resolver, 0, 3, kGeneration, SchedulerGangTokenPhase::DISPATCH
+    ));
+    resolver.resolver_index = 0;
+    EXPECT_FALSE(scheduler_gang_update_subtree_token(
+        storage.scheduler_state->base(), &resolver, 0, 3, kGeneration, SchedulerGangTokenPhase::DISPATCH
+    ));
+    stale_child->dispatch_local_token = kGeneration;
+    resolver.resolver_index = 2;
+    EXPECT_TRUE(scheduler_gang_update_subtree_token(
+        storage.scheduler_state->base(), &resolver, 0, 3, kGeneration, SchedulerGangTokenPhase::DISPATCH
+    ));
+    resolver.resolver_index = 0;
+    EXPECT_TRUE(scheduler_gang_update_subtree_token(
+        storage.scheduler_state->base(), &resolver, 0, 3, kGeneration, SchedulerGangTokenPhase::DISPATCH
+    ));
+}
+
+TEST(SchedulerGangMix, ReservesWholeClusterOrNothing) {
+    FixtureStorage storage(1, 3);
+    GraphBuffer graph(1);
+    graph.mixed(0, 7);
+    SchedulerWorkerContext &resolver = storage.contexts[1];
+    resolver.is_resolver = 1;
+    resolver.resolver_index = 0;
+    resolver.resolver_count = 1;
+    resolver.cluster_worker_ids[0] = 0;
+    resolver.cluster_worker_ids[1] = 1;
+    resolver.cluster_worker_ids[2] = 2;
+    storage.contexts[0].core_type = static_cast<int32_t>(CoreType::AIC);
+    for (uint32_t worker = 0; worker < 3; ++worker) {
+        for (uint32_t pending_slot = 0; pending_slot < SCHEDULER_PENDING_SLOT_COUNT; ++pending_slot)
+            scheduler_initialize_free_slot(
+                scheduler_dispatch_slot_at(storage.scheduler_state->base(), &resolver, worker, pending_slot)
+            );
+    }
+    storage.metadata[0].active_mask = 7;
+    storage.metadata[0].kernel_ids[0] = 1;
+    storage.metadata[0].kernel_ids[1] = 1;
+    storage.metadata[0].kernel_ids[2] = 1;
+    storage.metadata[0].logical_block_num = 1;
+    storage.metadata[0].total_required_subtasks = 3;
+    storage.metadata[0].flags = SCHEDULER_TASK_EXECUTABLE | SCHEDULER_TASK_MIX;
+    auto *callables =
+        scheduler_state_at<uint64_t>(storage.scheduler_state->base(), storage.layout.callable_addresses_offset);
+    callables[1] = 0x1000;
+    auto *participant = scheduler_gang_participant_at(storage.scheduler_state->base(), &resolver, 0, 0);
+    participant->config_generation = 1;
+    participant->task_id = 0;
+    participant->active_mask = 7;
+    participant->logical_block_num = 1;
+    participant->local_expected_subtasks = 3;
+    auto *blocked0 = scheduler_dispatch_slot_at(storage.scheduler_state->base(), &resolver, 1, 0);
+    auto *blocked1 = scheduler_dispatch_slot_at(storage.scheduler_state->base(), &resolver, 2, 1);
+    scheduler_gm_store(
+        blocked0->publication, scheduler_dispatch_publication(blocked0->generation, SchedulerDispatchSlotState::READY)
+    );
+    scheduler_gm_store(
+        blocked1->publication, scheduler_dispatch_publication(blocked1->generation, SchedulerDispatchSlotState::READY)
+    );
+    EXPECT_FALSE(scheduler_gang_fill_mix_block(
+        graph.graph(), storage.scheduler_state->base(), &resolver, storage.run_control, participant, 0, 0,
+        SchedulerDispatchSlotState::GATED
+    ));
+    EXPECT_EQ(participant->local_published_subtasks, 0u);
+    scheduler_gm_store(
+        blocked0->publication, scheduler_dispatch_publication(blocked0->generation, SchedulerDispatchSlotState::FREE)
+    );
+    scheduler_gm_store(
+        blocked1->publication, scheduler_dispatch_publication(blocked1->generation, SchedulerDispatchSlotState::FREE)
+    );
+    ASSERT_TRUE(scheduler_gang_fill_mix_block(
+        graph.graph(), storage.scheduler_state->base(), &resolver, storage.run_control, participant, 0, 0,
+        SchedulerDispatchSlotState::GATED
+    ));
+    EXPECT_EQ(participant->local_published_subtasks, 3u);
+    for (uint32_t worker = 0; worker < 3; ++worker) {
+        auto *slot = scheduler_dispatch_slot_at(storage.scheduler_state->base(), &resolver, worker, 0);
+        EXPECT_EQ(scheduler_dispatch_state(slot->publication), SchedulerDispatchSlotState::GATED);
+        EXPECT_EQ(slot->block_idx, 0u);
+        EXPECT_EQ(slot->block_num, 1u);
+    }
+}
+
+TEST(SchedulerSyncStart, DrainsStagesAndReleasesBeforeCompletion) {
+    FixtureStorage storage(1, 3);
+    GraphBuffer graph(1);
+    graph.executable(0, 1);
+    SchedulerWorkerContext &resolver = storage.contexts[1];
+    resolver.is_resolver = 1;
+    resolver.resolver_index = 0;
+    resolver.resolver_count = 1;
+    resolver.cluster_worker_ids[0] = 0;
+    resolver.cluster_worker_ids[1] = 1;
+    resolver.cluster_worker_ids[2] = 2;
+    storage.contexts[0].core_type = static_cast<int32_t>(CoreType::AIC);
+    storage.run_control->resolver_count = 1;
+    for (uint32_t worker = 0; worker < 3; ++worker) {
+        for (uint32_t pending_slot = 0; pending_slot < SCHEDULER_PENDING_SLOT_COUNT; ++pending_slot)
+            scheduler_initialize_free_slot(
+                scheduler_dispatch_slot_at(storage.scheduler_state->base(), &resolver, worker, pending_slot)
+            );
+    }
+    storage.metadata[0].kernel_ids[1] = 1;
+    storage.metadata[0].active_mask = 2;
+    storage.metadata[0].logical_block_num = 2;
+    storage.metadata[0].total_required_subtasks = 2;
+    storage.metadata[0].flags = SCHEDULER_TASK_EXECUTABLE | SCHEDULER_TASK_SPMD | SCHEDULER_TASK_SYNC_START;
+    auto *callables =
+        scheduler_state_at<uint64_t>(storage.scheduler_state->base(), storage.layout.callable_addresses_offset);
+    callables[1] = 0x1000;
+    auto *control = scheduler_task_control_at(storage.scheduler_state->base(), &resolver, 0);
+    control->state = static_cast<int64_t>(SchedulerTaskState::READY);
+    auto *coordinator = scheduler_gang_coordinator_at(storage.scheduler_state->base(), &resolver);
+    coordinator->gang_task_count = 1;
+    coordinator->resolver_count = 1;
+    coordinator->ready_priority_bits = 1;
+    SchedulerWakeStats wake_stats{};
+    SchedulerReadyStats ready_stats{};
+    SchedulerCompletionStats completion_stats{};
+    ASSERT_TRUE(
+        scheduler_gang_admit_one(graph.graph(), storage.scheduler_state->base(), &resolver, storage.run_control)
+    );
+    auto *cohort = scheduler_gang_cohort_at(storage.scheduler_state->base(), &resolver, 0);
+    ASSERT_TRUE(scheduler_service_gang(
+        graph.graph(), storage.scheduler_state->base(), &resolver, storage.run_control, &wake_stats, &ready_stats,
+        &completion_stats
+    ));
+    EXPECT_EQ(cohort->state, static_cast<uint64_t>(SchedulerGangCohortState::STAGING));
+    ASSERT_TRUE(scheduler_service_gang(
+        graph.graph(), storage.scheduler_state->base(), &resolver, storage.run_control, &wake_stats, &ready_stats,
+        &completion_stats
+    ));
+    EXPECT_EQ(cohort->state, static_cast<uint64_t>(SchedulerGangCohortState::RELEASING));
+    ASSERT_TRUE(scheduler_service_gang(
+        graph.graph(), storage.scheduler_state->base(), &resolver, storage.run_control, &wake_stats, &ready_stats,
+        &completion_stats
+    ));
+    EXPECT_EQ(cohort->state, static_cast<uint64_t>(SchedulerGangCohortState::EXECUTING));
+    EXPECT_EQ(coordinator->active_dispatch_cohort, UINT64_MAX);
+    for (uint32_t worker = 1; worker <= 2; ++worker) {
+        auto *slot = scheduler_dispatch_slot_at(storage.scheduler_state->base(), &resolver, worker, 0);
+        ASSERT_EQ(scheduler_dispatch_state(slot->publication), SchedulerDispatchSlotState::READY);
+        scheduler_completion_inbox_at(storage.scheduler_state->base(), &resolver, worker)->completed_generations[0] =
+            slot->generation;
+    }
+    ASSERT_TRUE(scheduler_service_cluster_completions(
+        graph.graph(), storage.scheduler_state->base(), &resolver, storage.run_control, &wake_stats, &ready_stats,
+        &completion_stats
+    ));
+    ASSERT_TRUE(scheduler_service_gang(
+        graph.graph(), storage.scheduler_state->base(), &resolver, storage.run_control, &wake_stats, &ready_stats,
+        &completion_stats
+    ));
+    EXPECT_EQ(cohort->state, static_cast<uint64_t>(SchedulerGangCohortState::FREE));
+    EXPECT_EQ(control->state, static_cast<int64_t>(SchedulerTaskState::DONE));
+    EXPECT_EQ(storage.run_control->resolved_task_count, 1u);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary
- This is PR 5 of 6 in the A5 HBG resident-scheduler stack and depends on #2048. After #2048 merges, retarget this PR to `main`.
- Extend the resident scheduler with generation-tagged Gang admission and execution for MIX, multi-block SPMD, and sync-start tasks.
- Add atomic lane reservation plus generation-tagged drain, stage, release, dispatch, and completion aggregation while preserving ordinary-task priority isolation.
- Activate the Gang lifecycle topology and cover cohort ordering, completion, MIX/SPMD/sync-start, and paged-attention-unroll behavior in focused unit and scene tests; the final stacked head passes the editable build and relevant UT/A5sim validation.
