### PR TITLE
Update: validate A5 HBG resident scheduler teardown

### DIFF
--- a/.claude/skills/onboard-arch-precheck/SKILL.md
+++ b/.claude/skills/onboard-arch-precheck/SKILL.md
@@ -86,12 +86,17 @@ in-flight `task-submit` device locks).
 
 Pipeline:
 
-1. `npu-smi info -t board -i 0 -c 0` → get `Chip Name` + `NPU Name`
-   (~600 ms, no ACL init, no device binding).
+1. `npu-smi info -t board -i 0` → get `Chip Name` + `NPU Name`
+   (~600 ms, no ACL init, no device binding). Do not pass `-c`: the board
+   query takes an NPU ID only, and `-c 0` returns no board fields on A5.
+   If the host restricts DCMI access to root, the script retries this exact
+   query through a no-device `task-submit` job, which does not lock an NPU.
 2. Construct CANN SoC name per family:
    - `Ascend910` + `B*` NPU → `Ascend910B3` (or B1/B2/B4)
    - `Ascend910` + numeric NPU → `Ascend910_9392` (Atlas A3 SKUs)
-   - `Ascend950` + NPU → glob for `Ascend950DT_<NPU>` or `Ascend950PR_<NPU>`
+   - `Ascend950DT` / `Ascend950PR` + NPU → `Ascend950DT_<NPU>` /
+     `Ascend950PR_<NPU>`; older drivers reporting only `Ascend950` use a
+     DT/PR filename lookup
 3. Read `Short_SoC_version=` from
    `${ASCEND_HOME_PATH}/{aarch64,x86_64}-linux/data/platform_config/<SoC>.ini`.
 4. Map `Short_SoC_version` → repo arch (must stay in sync with

--- a/.claude/skills/onboard-arch-precheck/check.sh
+++ b/.claude/skills/onboard-arch-precheck/check.sh
@@ -58,11 +58,19 @@ detect_silicon() {
     fi
 
     local board chip npu
-    board=$(npu-smi info -t board -i 0 -c 0 2>/dev/null)
+    # The board query takes an NPU ID only. `-c` is not valid for this query
+    # on A5 and makes npu-smi return no board fields. Some shared hosts also
+    # restrict DCMI access to the root task runner, so retry through a
+    # no-device task-submit job (it does not acquire an NPU lock).
+    board=$(npu-smi info -t board -i 0 2>/dev/null || true)
+    if ! grep -q 'Chip Name' <<<"$board" && command -v task-submit >/dev/null 2>&1; then
+        board=$(task-submit --timeout 60 --max-time 30 --run \
+            "npu-smi info -t board -i 0" 2>/dev/null || true)
+    fi
     chip=$(awk -F: '/Chip Name/ { gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; exit }' <<<"$board")
     npu=$(awk -F:  '/NPU Name/  { gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; exit }' <<<"$board")
     if [ -z "$chip" ] || [ -z "$npu" ]; then
-        echo "onboard-arch-precheck: npu-smi did not return Chip Name + NPU Name (chip='$chip' npu='$npu'). Try \`npu-smi info -t board -i 0 -c 0\` manually." >&2
+        echo "onboard-arch-precheck: npu-smi did not return Chip Name + NPU Name (chip='$chip' npu='$npu'). Try \`npu-smi info -t board -i 0\` manually or through a no-device task-submit job." >&2
         return 1
     fi
 
@@ -84,7 +92,7 @@ detect_silicon() {
     # Construct candidate SoC ini filename. Naming differs per family:
     #   910B series:  Ascend910B3   (chip + npu, no separator)
     #   910 9xxx:     Ascend910_9392 (chip _ npu)
-    #   950 DT/PR:    Ascend950DT_9586 / Ascend950PR_9579 (need glob)
+    #   950 DT/PR:    Ascend950DT_9586 / Ascend950PR_9579
     local soc=""
     case "$chip" in
         Ascend910)
@@ -94,7 +102,12 @@ detect_silicon() {
                 soc="${chip}_${npu}"
             fi
             ;;
+        Ascend950DT|Ascend950PR)
+            soc="${chip}_${npu}"
+            ;;
         Ascend950)
+            # Compatibility with driver versions that report only the family
+            # in Chip Name and leave the DT/PR variant to the CANN filename.
             for prefix in DT PR; do
                 if [ -f "${config_dir}/${chip}${prefix}_${npu}.ini" ]; then
                     soc="${chip}${prefix}_${npu}"

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -9,16 +9,23 @@ host register: materialize + dlopen orchestration SO
         ↓
 host run/bind: stage external tensors, execute orchestration to completion
         ↓
-host: copy the prebuilt graph image to device memory
+host: copy the graph image and publish resident scheduler state
         ↓
-device: attach the image, classify tasks, dispatch with AICPU schedulers
+device: AICPU opens the launch gate; resident AICore workers schedule and execute
         ↓
-host: collect outputs and destroy/reset per-run state
+host: validate scheduler convergence, collect outputs, and release per-run state
 ```
 
-The device has no orchestration thread. Every launched AICPU thread participates
-in scheduling its assigned AICore workers; the highest-index thread first
-attaches the prebuilt runtime and publishes the boot barrier.
+The device has no orchestration thread. For ordinary DAG runs, AICPU owns only
+worker discovery, context publication, launch gating, terminal wait, and
+teardown. AIV Resolver workers classify fanins, route Ready tasks, dispatch work,
+and consume completion generations; every active AIC/AIV worker executes its own
+resident loop.
+
+Runs containing `TaskKind::GRAPH` use the isolated AICPU compatibility executor.
+Graph replay was added after the resident-scheduler change was developed and has
+not yet been migrated to its graph view. The Host selects this path before
+allocating resident scheduler state; ordinary runs cannot fall back after launch.
 
 This ordering is the defining constraint of the runtime. The host constructs the
 whole graph before any device task can complete.
@@ -57,11 +64,21 @@ An orchestration fatal stops this sequence and is propagated through
 
 ### 2.3 Device Execution and Teardown
 
-The boot thread attaches the already-populated arena without resetting it. All
-threads classify/dispatch their core partitions and then shut those cores down.
-The last arriving thread destroys the attached runtime before publishing cleanup
-eligibility. Exactly one returning AICPU thread claims that eligibility and
-resets executor/scheduler state for the next run.
+For a resident run, AICPU discovers the physical worker topology, publishes one
+`SchedulerWorkerContext` per active lane, waits for Resolver bootstrap, and opens
+the single execution gate. AICPU then waits for the Host-planned executable task
+count or the first scheduler error. Shutdown closes every AICore loop before the
+Host reads the final state.
+
+After a successful run, the Host copies back the scheduler state and verifies
+that task controls are DONE/closed, Ready and completion inboxes are empty,
+dispatch slots are FREE, bootstrap and execution counts agree, and no scheduler
+error was recorded. A failed validation makes the run fail after diagnostic and
+output handling complete.
+
+The Graph compatibility path retains the prebuilt arena lifecycle: the boot
+thread attaches it, AICPU scheduler threads execute replay nodes, and the last
+thread destroys the attached runtime before cleanup eligibility is published.
 
 Publishing cleanup only after destruction prevents `deinit()` from racing the
 runtime arena or this run's host accessor.
@@ -86,7 +103,11 @@ target together and leaves them all correct.
 
 ### 3.1 What Ships: the Arena's Two Zones
 
-Three rules decide every byte of the runtime arena:
+The prebuilt runtime arena described below belongs to the Graph compatibility
+path. Ordinary DAG runs additionally allocate a compact resident scheduler state
+from Host-planned metadata; that state is not embedded in the graph image.
+
+Three rules decide every byte of the compatibility runtime arena:
 
 1. **Whoever generates a value writes it.** Content the host generates is written
    on the host and copied down. Content that is a function of the *layout* rather

--- a/src/a5/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a5/runtime/host_build_graph/docs/SUBMIT_BY_CLUSTER.md
@@ -80,8 +80,8 @@ must launch as one cohort:
 2. TensorMap and explicit dependencies append producer local IDs to the payload's
    fanin region.
 3. Submit publishes only the finished graph data; it does not push ready tasks.
-4. After H2D, device boot scans every submitted task exactly once.
-5. A task with every fanin complete is routed to its ready queue; otherwise it
+4. After H2D, AIV Resolvers collectively scan every submitted task exactly once.
+5. A task with every fanin complete is routed to its Resolver-owner Ready inbox; otherwise it
    registers on its latest-submitted unmet producer's wake list, minimising
    transfers between wake lists and their CAS contention.
 6. Producer completion reclassifies wake-list consumers until they become ready.
@@ -90,22 +90,23 @@ Completion flags are monotonic, so a task never needs periodic fanin polling.
 
 ## Dispatch and Completion
 
-- AIC and AIV tasks claim as many free cores as the current scheduler owns and
-  requeue remaining logical blocks for later waves.
-- MIX placement selects whole clusters whose used lanes can all accept the
-  task. High cluster offsets are represented by the runtime's 128-bit bitset.
-- `require_sync_start` uses local staging when possible and a generation-tagged
-  global drain when the cohort spans scheduler ownership domains.
-- Each completed lane increments `completed_subtasks`; the mixed task completes
-  exactly once when it reaches `block_num * popcount(active_mask)`.
+- Single-lane tasks use two generation-tagged dispatch slots per worker and may
+  directly refill a slot while resolving its previous completion.
+- MIX placement atomically reserves every active lane of a physical cluster.
+- SPMD and `require_sync_start` tasks enter the Gang scheduler. Admission order
+  is sync-start, MIX, then single-lane SPMD; generation-tagged drain/stage/
+  release tokens prevent a previous cohort from satisfying the next one.
+- Resolver-local participant records aggregate completed subtasks, and the
+  cohort retires the graph task exactly once.
 
 ## Executor Model
 
 The host loads and executes the orchestration shared object synchronously. The
-device has no orchestration thread: every launched AICPU thread participates in
-scheduling its assigned cores after the boot thread attaches the prebuilt graph.
+device has no orchestration thread. AICPU performs AICore lifecycle management;
+resident AIV Resolvers own dependency resolution, Ready routing, and dispatch.
 Cluster ownership is assigned during the AICore handshake and remains stable for
-the run.
+the run. Graph replay temporarily uses a separately selected AICPU compatibility
+executor until its node execution is represented in the resident graph view.
 
 ## Capacity
 

--- a/src/a5/runtime/host_build_graph/docs/device_log_profiling.md
+++ b/src/a5/runtime/host_build_graph/docs/device_log_profiling.md
@@ -6,8 +6,9 @@
 device launch. The device boots scheduler-only, so its device log contains no
 orchestrator-thread block and no device-side `dlopen` timing.
 
-Host graph-construction timing belongs in host-side diagnostics. This guide is
-only for the AICPU scheduler portion of a run.
+Host graph-construction timing belongs in host-side diagnostics. Ordinary DAG
+runs schedule on resident AICore workers; AICPU logs cover lifecycle timing only.
+Graph replay continues to emit the compatibility AICPU scheduler records.
 
 ## Finding the Log
 
@@ -17,37 +18,40 @@ On hardware, AICPU `LOG_INFO` records are written by CANN's dlog subsystem:
 $HOME/ascend/log/debug/device-<device_id>/device-<pid>_<timestamp>.log
 ```
 
-Find the newest file and filter the current scheduler records:
+Find the newest file and filter the current scheduler and lifecycle records:
 
 ```bash
 ls -t "$HOME/ascend/log/debug/device-<device_id>"/device-*.log | head -1
-grep -E "sched_start=|Scheduler summary|Scheduler Phase Breakdown" <logfile>
+grep -E "A5 HBG AICore scheduler|AicoreLifecycle|sched_start=" <logfile>
 ```
 
-## Scheduler Summary
+## Resident Scheduler Summary
 
-With `SIMPLER_DFX` enabled, each scheduler thread emits timing bounds and a
-summary when its dispatch loop completes:
+After a successful resident run, Host validation emits aggregate timing and
+protocol counters copied from every active worker:
 
 ```text
-Thread 0: sched_start=... sched_end=... sched_cost=3477.420us
-Thread 0: Scheduler summary: total_time=3460.100us, loops=147, tasks_scheduled=352
+A5 HBG AICore scheduler HOST TIMING: payload=... kernel=... completion=... backoff=... cycles
+A5 HBG AICore scheduler COUNTERS: bootstrap_tasks=... ready_enqueues=... ready_pops=...
 ```
 
 | Field | Meaning |
 | ----- | ------- |
-| `sched_cost` | Wall time from scheduler-loop entry to exit |
-| `total_time` | Accounted complete + dispatch + idle cycles |
-| `loops` | Scheduler-loop iterations |
-| `tasks_scheduled` | Mixed tasks this thread completed |
+| `bootstrap_tasks` | Executable tasks classified during Resolver bootstrap |
+| `ready_enqueues` / `ready_pops` | Ordinary tasks published to and claimed from Ready inboxes |
+| `completion_enqueues` | Completed AIC/AIV subtasks reported to their Resolver |
+| `completion_resolves` | Graph tasks retired after completion aggregation |
+| `ready_to_kernel_*` | Aggregate and maximum Ready-to-kernel latency |
+| `backoff` / `idle_iterations` | Resident-loop idle cost and iterations |
 
-All launched AICPU threads participate in scheduling their assigned cores. The
-highest-index thread performs one-time prebuilt-runtime attachment before it
-enters the same scheduler path; it is not an orchestrator thread.
+Validation also rejects nonempty Ready/completion state, occupied dispatch slots,
+open wake lists, incomplete bootstrap, or inconsistent execution counts. These
+errors are correctness failures, not profiling warnings.
 
-## Optional Phase Breakdown
+## Compatibility Scheduler Records
 
-When `SIMPLER_SCHED_PROFILING` is also enabled, the summary includes:
+Only Graph replay uses the AICPU scheduler phase records. With
+`SIMPLER_SCHED_PROFILING` enabled, they include:
 
 ```text
 Thread 0: === Scheduler Phase Breakdown: total=3460.100us, 352 tasks ===

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -1584,6 +1584,225 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int e
         LOG_RUNTIME_FAILURE(orch_error_code, sched_error_code, runtime_status);
     }
 
+    if (runtime->scheduler_state_base != nullptr && execution_rc == 0) {
+        const uint64_t scheduler_state_size = runtime->scheduler_layout.total_size;
+        std::vector<uint8_t> scheduler_state_storage(
+            static_cast<size_t>(scheduler_state_size + SCHEDULER_STATE_ALIGNMENT - 1)
+        );
+        uintptr_t host_scheduler_state_address =
+            (reinterpret_cast<uintptr_t>(scheduler_state_storage.data()) + SCHEDULER_STATE_ALIGNMENT - 1) &
+            ~(static_cast<uintptr_t>(SCHEDULER_STATE_ALIGNMENT) - 1);
+        void *host_scheduler_state = reinterpret_cast<void *>(host_scheduler_state_address);
+        int scheduler_state_rc = api->copy_from_device(
+            host_scheduler_state, runtime->scheduler_state_base, static_cast<size_t>(scheduler_state_size)
+        );
+        if (scheduler_state_rc != 0) {
+            LOG_ERROR("A5 HBG AICore scheduler: failed to copy scheduler state from device: %d", scheduler_state_rc);
+            rc = scheduler_state_rc;
+        } else {
+            const auto *control = scheduler_state_at<SchedulerRunControl>(
+                host_scheduler_state, runtime->scheduler_layout.run_control_offset
+            );
+            const auto *contexts = scheduler_state_at<SchedulerWorkerContext>(
+                host_scheduler_state, runtime->scheduler_layout.worker_contexts_offset
+            );
+            const auto *task_controls = scheduler_state_at<SchedulerTaskControl>(
+                host_scheduler_state, runtime->scheduler_layout.task_controls_offset
+            );
+            const auto *completion_inboxes = scheduler_state_at<SchedulerCompletionInbox>(
+                host_scheduler_state, runtime->scheduler_layout.completion_inboxes_offset
+            );
+            const auto *ready_inboxes = scheduler_state_at<SchedulerReadyInbox>(
+                host_scheduler_state, runtime->scheduler_layout.ready_inboxes_offset
+            );
+            const auto *ready_directory = scheduler_state_at<SchedulerReadyDirectory>(
+                host_scheduler_state, runtime->scheduler_layout.ready_directory_offset
+            );
+            const auto *dispatch_slots = scheduler_state_at<SchedulerDispatchSlot>(
+                host_scheduler_state, runtime->scheduler_layout.dispatch_slots_offset
+            );
+            uint64_t active_workers = 0;
+            uint64_t worker_executed = 0;
+            uint64_t bootstrap_tasks = 0;
+            uint64_t ready_enqueues = 0;
+            uint64_t ready_batches = 0;
+            uint64_t ready_pops = 0;
+            uint64_t ready_steals = 0;
+            uint64_t ready_cas_retries = 0;
+            uint64_t ready_link_waits = 0;
+            uint64_t ready_link_wait_max = 0;
+            uint64_t state_polls = 0;
+            uint64_t fanin_loads = 0;
+            uint64_t wake_registers = 0;
+            uint64_t wake_cas_retries = 0;
+            uint64_t wake_closed_retries = 0;
+            uint64_t wake_migrations = 0;
+            uint64_t wake_closes = 0;
+            uint64_t completion_enqueues = 0;
+            uint64_t completion_resolves = 0;
+            uint64_t ready_to_kernel_cycles = 0;
+            uint64_t ready_to_kernel_max_cycles = 0;
+            uint64_t idle_iterations = 0;
+            uint64_t backoff_cycles = 0;
+            uint64_t payload_cycles = 0;
+            uint64_t kernel_cycles = 0;
+            uint64_t completion_cycles = 0;
+            const uint64_t executable_task_count = runtime->scheduler_layout.executable_task_count;
+            const uint64_t executable_subtask_count = runtime->scheduler_layout.executable_subtask_count;
+            const uint64_t ordinary_task_count = executable_task_count - runtime->scheduler_layout.gang_task_count;
+            for (int32_t i = 0; i < runtime->worker_count; ++i) {
+                if (contexts[i].active != 0) ++active_workers;
+                worker_executed += contexts[i].executed_task_count;
+                bootstrap_tasks += contexts[i].bootstrap_task_count;
+                ready_enqueues += contexts[i].ready_enqueue_count;
+                ready_batches += contexts[i].ready_batch_count;
+                ready_pops += contexts[i].ready_pop_count;
+                ready_steals += contexts[i].ready_steal_count;
+                ready_cas_retries += contexts[i].ready_cas_retry_count;
+                ready_link_waits += contexts[i].ready_link_wait_count;
+                ready_link_wait_max = std::max(ready_link_wait_max, contexts[i].ready_link_wait_max);
+                state_polls += contexts[i].task_state_poll_count;
+                fanin_loads += contexts[i].fanin_state_load_count;
+                wake_registers += contexts[i].wake_register_count;
+                wake_cas_retries += contexts[i].wake_cas_retry_count;
+                wake_closed_retries += contexts[i].wake_closed_retry_count;
+                wake_migrations += contexts[i].wake_migrate_count;
+                wake_closes += contexts[i].wake_close_count;
+                completion_enqueues += contexts[i].completion_enqueue_count;
+                completion_resolves += contexts[i].completion_resolve_count;
+                ready_to_kernel_cycles += contexts[i].ready_to_kernel_cycles;
+                ready_to_kernel_max_cycles =
+                    std::max(ready_to_kernel_max_cycles, contexts[i].ready_to_kernel_max_cycles);
+                idle_iterations += contexts[i].idle_iteration_count;
+                backoff_cycles += contexts[i].backoff_cycles;
+                payload_cycles += contexts[i].payload_cycles;
+                kernel_cycles += contexts[i].kernel_cycles;
+                completion_cycles += contexts[i].completion_enqueue_cycles;
+            }
+            bool completion_inboxes_empty = true;
+            for (int32_t worker = 0; worker < runtime->worker_count; ++worker) {
+                if (contexts[worker].active == 0) continue;
+                if (completion_inboxes[worker].completed_generations[0] != 0 ||
+                    completion_inboxes[worker].completed_generations[1] != 0) {
+                    LOG_ERROR(
+                        "A5 HBG AICore scheduler: completion line=%d not empty generations={%" PRIu32 ",%" PRIu32 "}",
+                        worker, completion_inboxes[worker].completed_generations[0],
+                        completion_inboxes[worker].completed_generations[1]
+                    );
+                    completion_inboxes_empty = false;
+                    break;
+                }
+            }
+            bool ready_inboxes_empty = true;
+            for (uint32_t type = 0; type < SCHEDULER_CORE_TYPE_COUNT && ready_inboxes_empty; ++type) {
+                for (uint64_t inbox = 0; inbox < control->resolver_count; ++inbox) {
+                    uint64_t linear = static_cast<uint64_t>(type) * SCHEDULER_WORKER_CAPACITY + inbox;
+                    if (ready_inboxes[linear].head != SCHEDULER_INBOX_EMPTY) {
+                        LOG_ERROR(
+                            "A5 HBG AICore scheduler: ready type=%u inbox=%" PRIu64 " not empty head=%" PRId64, type,
+                            inbox, ready_inboxes[linear].head
+                        );
+                        ready_inboxes_empty = false;
+                        break;
+                    }
+                }
+            }
+            bool ready_directory_empty = true;
+            for (uint32_t type = 0; type < SCHEDULER_CORE_TYPE_COUNT; ++type) {
+                for (uint32_t shard = 0; shard < SCHEDULER_READY_DIRECTORY_SHARD_COUNT; ++shard)
+                    ready_directory_empty = ready_directory_empty && ready_directory->core_types[type][shard].bits == 0;
+            }
+            bool task_controls_valid = true;
+            for (int32_t task_id = 0; task_id < runtime->host_total_tasks; ++task_id) {
+                if (task_controls[task_id].state != static_cast<int64_t>(SchedulerTaskState::DONE) ||
+                    task_controls[task_id].wake_list_head != SCHEDULER_WAKE_LIST_CLOSED) {
+                    LOG_ERROR(
+                        "A5 HBG AICore scheduler: invalid task control id=%d state=%" PRId64 " wake_head=%" PRId64,
+                        task_id, task_controls[task_id].state, task_controls[task_id].wake_list_head
+                    );
+                    task_controls_valid = false;
+                    break;
+                }
+            }
+            bool dispatch_slots_free = true;
+            for (int32_t worker = 0; worker < runtime->worker_count && dispatch_slots_free; ++worker) {
+                if (contexts[worker].active == 0) continue;
+                if (contexts[worker].bootstrap_done == 0) {
+                    LOG_ERROR("A5 HBG AICore scheduler: worker=%d dispatch bootstrap incomplete", worker);
+                    dispatch_slots_free = false;
+                    break;
+                }
+                for (uint32_t slot = 0; slot < SCHEDULER_PENDING_SLOT_COUNT; ++slot) {
+                    uint64_t linear = static_cast<uint64_t>(worker) * SCHEDULER_PENDING_SLOT_COUNT + slot;
+                    const SchedulerDispatchSlot &dispatch = dispatch_slots[linear];
+                    if (dispatch.task_id != SCHEDULER_TASK_ID_INVALID ||
+                        static_cast<SchedulerDispatchSlotState>(dispatch.publication & UINT64_C(0xff)) !=
+                            SchedulerDispatchSlotState::FREE) {
+                        LOG_ERROR(
+                            "A5 HBG AICore scheduler: worker=%d slot=%u not free task=%" PRId64 " publication=%" PRIu64,
+                            worker, slot, dispatch.task_id, dispatch.publication
+                        );
+                        dispatch_slots_free = false;
+                        break;
+                    }
+                }
+            }
+            if (control->scheduler_error != 0 ||
+                control->expected_task_count != static_cast<uint64_t>(runtime->host_total_tasks) ||
+                worker_executed != executable_subtask_count || bootstrap_tasks != executable_task_count ||
+                active_workers != control->active_worker_count ||
+                control->bootstrap_scan_arrived_count != control->resolver_count ||
+                control->bootstrap_scan_complete == 0 || control->bootstrap_arrived_count != control->resolver_count ||
+                control->bootstrap_complete == 0 || control->resolved_task_count != executable_task_count ||
+                wake_closes != executable_task_count || wake_registers != wake_migrations ||
+                completion_enqueues != executable_subtask_count || completion_resolves != executable_task_count ||
+                ready_enqueues != ordinary_task_count || ready_pops != ordinary_task_count || !task_controls_valid ||
+                !completion_inboxes_empty || !ready_inboxes_empty || !ready_directory_empty || !dispatch_slots_free) {
+                LOG_ERROR(
+                    "A5 HBG AICore scheduler: invalid final state expected=%" PRIu64 " executed=%" PRIu64
+                    " executable=%" PRIu64 " inline=%" PRIu64 " active=%" PRIu64 " bootstrap=%" PRIu64
+                    " resolved=%" PRIu64 " wake_registers=%" PRIu64 " wake_migrations=%" PRIu64 " wake_closes=%" PRIu64
+                    " completion_enqueues=%" PRIu64 " completion_resolves=%" PRIu64 " ready_enqueues=%" PRIu64
+                    " ready_pops=%" PRIu64 " error=%" PRIu64,
+                    control->expected_task_count, worker_executed, executable_task_count,
+                    control->inline_completed_count, active_workers, bootstrap_tasks, control->resolved_task_count,
+                    wake_registers, wake_migrations, wake_closes, completion_enqueues, completion_resolves,
+                    ready_enqueues, ready_pops, control->scheduler_error
+                );
+                if (control->scheduler_error != 0) {
+                    LOG_ERROR(
+                        "A5 HBG AICore scheduler: first error task=%" PRIu64 " status=%" PRIu64 " core=%" PRIu64
+                        " type=%" PRIu64 " graph_tasks=%" PRIu64 " descriptors=0x%" PRIx64 " payloads=0x%" PRIx64
+                        " mask=0x%" PRIx64,
+                        control->error_task_id, control->scheduler_error, control->error_core_id,
+                        control->error_core_type, control->error_graph_task_count, control->error_descriptors_address,
+                        control->error_payloads_address, control->error_task_window_mask
+                    );
+                }
+                rc = -1;
+            } else if (control->expected_task_count != 0) {
+                LOG_INFO(
+                    "A5 HBG AICore scheduler HOST TIMING: payload=%" PRIu64 " kernel=%" PRIu64 " completion=%" PRIu64
+                    " backoff=%" PRIu64 " cycles",
+                    payload_cycles, kernel_cycles, completion_cycles, backoff_cycles
+                );
+                LOG_INFO(
+                    "A5 HBG AICore scheduler COUNTERS: bootstrap_tasks=%" PRIu64 " ready_enqueues=%" PRIu64
+                    " ready_batches=%" PRIu64 " ready_pops=%" PRIu64 " ready_steals=%" PRIu64
+                    " ready_cas_retries=%" PRIu64 " ready_link_waits=%" PRIu64 " ready_link_wait_max=%" PRIu64
+                    " state_polls=%" PRIu64 " fanin_loads=%" PRIu64 " wake_registers=%" PRIu64
+                    " wake_cas_retries=%" PRIu64 " wake_closed_retries=%" PRIu64 " wake_migrations=%" PRIu64
+                    " wake_closes=%" PRIu64 " completion_enqueues=%" PRIu64 " completion_resolves=%" PRIu64
+                    " ready_to_kernel_cycles=%" PRIu64 " ready_to_kernel_max=%" PRIu64 " idle_iterations=%" PRIu64,
+                    bootstrap_tasks, ready_enqueues, ready_batches, ready_pops, ready_steals, ready_cas_retries,
+                    ready_link_waits, ready_link_wait_max, state_polls, fanin_loads, wake_registers, wake_cas_retries,
+                    wake_closed_retries, wake_migrations, wake_closes, completion_enqueues, completion_resolves,
+                    ready_to_kernel_cycles, ready_to_kernel_max_cycles, idle_iterations
+                );
+            }
+        }
+    }
+
     if (skip_tensor_copy_back) {
         LOG_WARN("Skipping tensor copy-back because execution failed");
     } else {


### PR DESCRIPTION
## Summary
- This is PR 6 of 6 in the A5 HBG resident-scheduler stack and depends on #2049. After #2049 merges, retarget this PR to `main`.
- Copy resident scheduler state back after successful execution and reject incomplete task controls, wake lists, Ready state, dispatch slots, completion state, or scheduler counters instead of silently accepting residual state.
- Update the A5 HBG runtime, submission, and device-log documentation to describe the AICore-owned ordinary path and the isolated AICPU compatibility path retained for Graph replay.
- Fix the onboard architecture gate to use `npu-smi info -t board -i 0`, recognize `Ascend950DT`/`Ascend950PR`, and retry through a no-device `task-submit` job when direct DCMI access is restricted.
- The final head passes the editable build, pre-commit checks, focused scheduler UTs, and relevant A5sim HBG scenes. A5 paged-attention-unroll Case1 improved from 1273.021 us to 1269.669 us on-device (-0.263%, 800 samples per revision; paired 95% CI -5.020 to -1.682 us).
