### PR TITLE
Add A5 HBG AICore scheduler contracts

### DIFF
--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -17,6 +17,7 @@
 #include "common/platform_config.h"  // Register-based communication
 #include "dispatch_payload.h"
 #include "runtime.h"
+#include "scheduler/scheduler_memory.h"
 
 /**
  * Unified function pointer type for kernel dispatch

--- a/src/a5/runtime/host_build_graph/common/intrinsic.h
+++ b/src/a5/runtime/host_build_graph/common/intrinsic.h
@@ -62,8 +62,8 @@
  *     issue #900 (PR #899 spmd_paged_attention_highperf); the kernel
  *     compiled, ran without error, and produced wrong output. Use
  *     `get_sub_block_id(args)` instead, which reads from the runtime's
- *     `GlobalContext.sub_block_id` that the scheduler initializes per
- *     AIV core in `scheduler_cold_path.cpp::SchedulerContext::init`.
+ *     `GlobalContext.sub_block_id`. Resident graph materialization sets it
+ *     from the selected AIV task subslot before every dispatch publication.
  *
  *   - `get_block_idx()` and `get_block_num()` are not redirected to
  *     simpler's LocalContext either — use the `(args)` variants below
@@ -106,9 +106,9 @@ static constexpr int32_t PAYLOAD_LOCAL_CONTEXT_INDEX = SPMD_LOCAL_CONTEXT_INDEX;
 static constexpr int32_t PAYLOAD_GLOBAL_CONTEXT_INDEX = SPMD_GLOBAL_CONTEXT_INDEX;
 
 /**
- * Per-core global context, stored in DispatchPayload.
- * Initialized once at runtime startup (init_global_context) based on each
- * core's cluster position.  Never modified after initialization.
+ * Per-dispatch global context, stored in DispatchPayload. Resident graph
+ * materialization sets sub_block_id from the selected AIV task subslot; the
+ * legacy scheduler seeds the equivalent per-core value during startup.
  */
 struct GlobalContext {
     // AIV lane within cluster: 0=AIV0(left), 1=AIV1(right).

--- a/src/a5/runtime/host_build_graph/runtime/async_wait.h
+++ b/src/a5/runtime/host_build_graph/runtime/async_wait.h
@@ -33,7 +33,7 @@ inline constexpr int32_t MAX_ASYNC_WAITS = 64;
 // application layer: translating drained messages into wait-list state.
 
 inline uintptr_t mailbox_cache_line(const volatile void *addr) {
-    return reinterpret_cast<uintptr_t>(addr) & ~(uintptr_t(CHIP_ALIGN_SIZE) - 1u);
+    return reinterpret_cast<uintptr_t>(addr) & ~(static_cast<uintptr_t>(CHIP_ALIGN_SIZE) - 1u);
 }
 
 struct CompletionCondition;

--- a/src/a5/runtime/host_build_graph/runtime/dispatch_payload.h
+++ b/src/a5/runtime/host_build_graph/runtime/dispatch_payload.h
@@ -17,13 +17,14 @@
  * array, and embedded SPMD context (LocalContext + GlobalContext).  AICPU
  * maintains a static array of these (one per core).
  *
- * GlobalContext (sub_block_id) is initialized once at runtime startup via
- * init_global_context() and never modified afterwards.
+ * GlobalContext (sub_block_id) is populated by the scheduler path. The legacy
+ * scheduler seeds each per-core slot at startup; resident graph materialization
+ * writes the selected task subslot before every dispatch publication.
  *
  * build_payload() refreshes the function address, LocalContext's hot fields,
  * and either the ready-path argument prefix or the gated-path source pointer.
- * Context pointers, GlobalContext, and the async-completion slab metadata are
- * initialized once per core and payload buffer.
+ * Context pointers and async-completion slab metadata are initialized once per
+ * core and payload buffer.
  *
  * AICore caches a pointer to its per-core slot at startup and reads from
  * it on each dispatch.  The struct is cache-line aligned to avoid false
@@ -71,6 +72,7 @@ constexpr uint32_t TASKPAYLOAD_SCALAR_COUNT_OFFSET = 4;
 // a region's address is (src + <field offset>) + <the int32 delta stored there>.
 constexpr uint32_t TASKPAYLOAD_TENSORS_DELTA_OFFSET = 12;
 constexpr uint32_t TASKPAYLOAD_SCALARS_DELTA_OFFSET = 16;
+constexpr uint32_t TASKPAYLOAD_FANIN_DELTA_OFFSET = 20;
 // Cache line 9 (byte 576) holds the AICPU-only DispatchPredicate. Scalars follow it,
 // then tensors — the tensor array is last because it is the only region whose used
 // extent varies per task, so a task's read set is a contiguous prefix.
@@ -116,9 +118,10 @@ struct alignas(64) DispatchPayload {
      *  the idle AICore fills them from src_payload during its gate wait. */
     uint64_t args[DISPATCH_MAX_ARGS];
 
-    /** Per-core global context: sub_block_id (AIV lane identity). Cold: written once
-     *  at init, never per dispatch, so it lives in the tail (not the CL0 control
-     *  block). args[SPMD_GLOBAL_CONTEXT_INDEX] points here. */
+    /** Per-dispatch global context: sub_block_id identifies the selected AIV
+     *  task subslot. The resident scheduler writes it during materialization;
+     *  the legacy scheduler seeds the equivalent per-core value at startup.
+     *  args[SPMD_GLOBAL_CONTEXT_INDEX] points here. */
     GlobalContext global_context;
     // No explicit tail padding: alignas(64) rounds sizeof up to 512 (8 cache lines).
 

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -44,6 +44,7 @@ static_assert(offsetof(TaskPayload, tensor_count) == TASKPAYLOAD_TENSOR_COUNT_OF
 static_assert(offsetof(TaskPayload, scalar_count) == TASKPAYLOAD_SCALAR_COUNT_OFFSET);
 static_assert(offsetof(TaskPayload, tensors) == TASKPAYLOAD_TENSORS_DELTA_OFFSET);
 static_assert(offsetof(TaskPayload, scalars) == TASKPAYLOAD_SCALARS_DELTA_OFFSET);
+static_assert(offsetof(TaskPayload, fanin) == TASKPAYLOAD_FANIN_DELTA_OFFSET);
 static_assert(sizeof(simpler::hbg::Tensor) == TASKPAYLOAD_TENSOR_STRIDE);
 
 // =============================================================================

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_graph.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_graph.h
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "common/core_type.h"
+#include "dispatch_payload.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__
+#endif
+
+#ifndef __host__
+#define __host__
+#endif
+
+inline constexpr uint32_t SCHEDULER_GRAPH_TASK_DESCRIPTOR_STRIDE = 40;
+// TaskPayload includes the early-dispatch cache line in this wire layout.
+inline constexpr uint32_t SCHEDULER_GRAPH_TASK_PAYLOAD_STRIDE = 192;
+inline constexpr uint32_t SCHEDULER_GRAPH_TASK_ID_OFFSET = 0;
+inline constexpr uint32_t SCHEDULER_GRAPH_KERNEL_IDS_OFFSET = 8;
+inline constexpr uint32_t SCHEDULER_GRAPH_FANIN_COUNT_OFFSET = 8;
+inline constexpr uint32_t SCHEDULER_GRAPH_PREDICATE_OFFSET = 128;
+inline constexpr int32_t SCHEDULER_GRAPH_MAX_FANIN = 128;
+inline constexpr uint32_t SCHEDULER_CORE_CALLABLE_RESOLVED_ADDR_OFFSET = 136;
+inline constexpr int32_t SCHEDULER_GRAPH_INVALID_KERNEL_ID = -1;
+
+enum class SchedulerGraphResult : uint64_t {
+    OK = 0,
+    EMPTY = 1,
+    INVALID_TASK_COUNT = 2,
+    INVALID_TASK_ID = 3,
+    UNSUPPORTED_SHAPE = 5,
+    INVALID_ARGUMENTS = 6,
+    INVALID_CALLABLE = 7,
+    INVALID_FANIN_COUNT = 8,
+    INVALID_FANIN_ID = 9,
+};
+
+struct SchedulerGraphView {
+    uint64_t descriptors_address;
+    uint64_t payloads_address;
+    uint64_t task_count;
+    // Kept in the wire view for diagnostics. HBG task ids directly index the
+    // whole-graph-resident tables and never wrap, so this value must not be
+    // used to mask an id (the configured capacity need not be a power of two).
+    uint64_t task_window_mask;
+};
+
+struct SchedulerTaskInfo {
+    int64_t task_id;
+    int32_t kernel_id;
+    int32_t subtask_slot;
+    CoreType core_type;
+};
+
+struct SchedulerTaskShape {
+    int64_t task_id;
+    int32_t kernel_ids[3];
+    uint8_t active_mask;
+    uint8_t reserved[3];
+};
+
+struct SchedulerDispatchPredicate {
+    uint64_t addr;
+    int64_t target;
+    uint8_t elem_size;
+    uint8_t op;
+};
+
+static_assert(sizeof(SchedulerGraphView) == 32, "read-only graph view layout changed");
+static_assert(offsetof(SchedulerGraphView, descriptors_address) == 0, "descriptor address offset changed");
+static_assert(offsetof(SchedulerGraphView, payloads_address) == 8, "payload address offset changed");
+static_assert(sizeof(SchedulerTaskInfo) == 24, "root classification result layout changed");
+static_assert(sizeof(SchedulerTaskShape) == 24, "task shape result layout changed");
+static_assert(sizeof(SchedulerDispatchPredicate) == 24, "dispatch predicate layout changed");
+
+inline __host__ __aicore__ __gm__ uint8_t *
+scheduler_graph_descriptor(const SchedulerGraphView &graph, int64_t task_id) {
+    uint64_t slot = static_cast<uint64_t>(task_id);
+    return reinterpret_cast<__gm__ uint8_t *>(graph.descriptors_address) +
+           slot * SCHEDULER_GRAPH_TASK_DESCRIPTOR_STRIDE;
+}
+inline __host__ __aicore__ __gm__ uint8_t *scheduler_graph_payload(const SchedulerGraphView &graph, int64_t task_id) {
+    uint64_t slot = static_cast<uint64_t>(task_id);
+    return reinterpret_cast<__gm__ uint8_t *>(graph.payloads_address) + slot * SCHEDULER_GRAPH_TASK_PAYLOAD_STRIDE;
+}
+
+inline __host__ __aicore__ int32_t
+scheduler_graph_fanin_id(const SchedulerGraphView &graph, int64_t task_id, int32_t fanin_index) {
+    __gm__ uint8_t *payload = scheduler_graph_payload(graph, task_id);
+    __gm__ uint8_t *field = payload + TASKPAYLOAD_FANIN_DELTA_OFFSET;
+    int32_t delta = *reinterpret_cast<__gm__ int32_t *>(field);
+    return reinterpret_cast<__gm__ int32_t *>(field + delta)[fanin_index];
+}
+
+inline __host__ __aicore__ SchedulerGraphResult
+scheduler_classify_task_shape(const SchedulerGraphView &graph, int64_t task_id, SchedulerTaskShape *shape) {
+    if (shape == nullptr) return SchedulerGraphResult::UNSUPPORTED_SHAPE;
+    *shape = {
+        -1,
+        {SCHEDULER_GRAPH_INVALID_KERNEL_ID, SCHEDULER_GRAPH_INVALID_KERNEL_ID, SCHEDULER_GRAPH_INVALID_KERNEL_ID},
+        0,
+        {0, 0, 0}
+    };
+    if (graph.task_count == 0) return SchedulerGraphResult::EMPTY;
+    if (graph.descriptors_address == 0 || graph.payloads_address == 0 || task_id < 0 ||
+        static_cast<uint64_t>(task_id) >= graph.task_count) {
+        return SchedulerGraphResult::INVALID_TASK_COUNT;
+    }
+
+    __gm__ uint8_t *descriptor = scheduler_graph_descriptor(graph, task_id);
+    __gm__ uint8_t *payload = scheduler_graph_payload(graph, task_id);
+    uint64_t stored_task_id = *reinterpret_cast<__gm__ uint64_t *>(descriptor + SCHEDULER_GRAPH_TASK_ID_OFFSET);
+    if (stored_task_id != static_cast<uint64_t>(task_id)) return SchedulerGraphResult::INVALID_TASK_ID;
+
+    int32_t fanin_count = *reinterpret_cast<__gm__ int32_t *>(payload + SCHEDULER_GRAPH_FANIN_COUNT_OFFSET);
+    if (fanin_count < 0 || fanin_count > SCHEDULER_GRAPH_MAX_FANIN) {
+        return SchedulerGraphResult::INVALID_FANIN_COUNT;
+    }
+    __gm__ uint8_t *fanin_field = payload + TASKPAYLOAD_FANIN_DELTA_OFFSET;
+    if (fanin_count > 0 && *reinterpret_cast<__gm__ int32_t *>(fanin_field) == 0) {
+        return SchedulerGraphResult::INVALID_FANIN_ID;
+    }
+    for (int32_t i = 0; i < fanin_count; ++i) {
+        int32_t producer = scheduler_graph_fanin_id(graph, task_id, i);
+        if (producer < 0 || producer >= task_id) return SchedulerGraphResult::INVALID_FANIN_ID;
+        for (int32_t prior = 0; prior < i; ++prior) {
+            if (scheduler_graph_fanin_id(graph, task_id, prior) == producer) {
+                return SchedulerGraphResult::INVALID_FANIN_ID;
+            }
+        }
+    }
+
+    __gm__ int32_t *kernel_ids = reinterpret_cast<__gm__ int32_t *>(descriptor + SCHEDULER_GRAPH_KERNEL_IDS_OFFSET);
+    for (int32_t slot = 0; slot < 3; ++slot) {
+        if (kernel_ids[slot] == SCHEDULER_GRAPH_INVALID_KERNEL_ID) continue;
+        if (kernel_ids[slot] < 0) return SchedulerGraphResult::UNSUPPORTED_SHAPE;
+        shape->kernel_ids[slot] = kernel_ids[slot];
+        shape->active_mask |= static_cast<uint8_t>(1U << slot);
+    }
+    if (shape->active_mask == 0) return SchedulerGraphResult::UNSUPPORTED_SHAPE;
+
+    shape->task_id = task_id;
+    return SchedulerGraphResult::OK;
+}
+
+inline __host__ __aicore__ SchedulerGraphResult scheduler_materialize_task_payload_resolved(
+    const SchedulerGraphView &graph, const SchedulerTaskInfo &task, uint64_t function_bin_address,
+    __gm__ DispatchPayload *dispatch_payload, int32_t block_idx = 0, int32_t block_num = 1
+) {
+    if (dispatch_payload == nullptr || function_bin_address == 0 || block_idx < 0 || block_num <= 0 ||
+        block_idx >= block_num) {
+        return SchedulerGraphResult::INVALID_CALLABLE;
+    }
+    if (graph.payloads_address == 0 || task.task_id < 0 || static_cast<uint64_t>(task.task_id) >= graph.task_count) {
+        return SchedulerGraphResult::INVALID_TASK_COUNT;
+    }
+    __gm__ uint8_t *payload = scheduler_graph_payload(graph, task.task_id);
+    int32_t tensor_count = *reinterpret_cast<__gm__ int32_t *>(payload + TASKPAYLOAD_TENSOR_COUNT_OFFSET);
+    int32_t scalar_count = *reinterpret_cast<__gm__ int32_t *>(payload + TASKPAYLOAD_SCALAR_COUNT_OFFSET);
+    if (tensor_count < 0 || tensor_count > MAX_TENSOR_ARGS || scalar_count < 0 || scalar_count > MAX_SCALAR_ARGS ||
+        tensor_count + scalar_count > SPMD_LOCAL_CONTEXT_INDEX) {
+        return SchedulerGraphResult::INVALID_ARGUMENTS;
+    }
+
+    __gm__ uint8_t *tensors_field = payload + TASKPAYLOAD_TENSORS_DELTA_OFFSET;
+    __gm__ uint8_t *scalars_field = payload + TASKPAYLOAD_SCALARS_DELTA_OFFSET;
+    int32_t tensors_delta = *reinterpret_cast<__gm__ int32_t *>(tensors_field);
+    int32_t scalars_delta = *reinterpret_cast<__gm__ int32_t *>(scalars_field);
+    if ((tensor_count > 0 && tensors_delta == 0) || (scalar_count > 0 && scalars_delta == 0)) {
+        return SchedulerGraphResult::INVALID_ARGUMENTS;
+    }
+    dispatch_payload->function_bin_addr = function_bin_address;
+    __gm__ uint8_t *tensors = tensors_field + tensors_delta;
+    __gm__ uint64_t *scalars = reinterpret_cast<__gm__ uint64_t *>(scalars_field + scalars_delta);
+    int32_t n = 0;
+    for (int32_t i = 0; i < tensor_count; ++i) {
+        dispatch_payload->args[n++] =
+            reinterpret_cast<uint64_t>(tensors + static_cast<uint64_t>(i) * TASKPAYLOAD_TENSOR_STRIDE);
+    }
+    for (int32_t i = 0; i < scalar_count; ++i)
+        dispatch_payload->args[n++] = scalars[i];
+
+    dispatch_payload->src_payload = 0;
+    dispatch_payload->local_context.block_idx = block_idx;
+    dispatch_payload->local_context.block_num = block_num;
+    // The AICore scheduler has no deferred-completion slab. Mark the context
+    // non-deferred so async backend adapters take their synchronous fallback.
+    dispatch_payload->local_context.async_ctx.task_token.raw = TaskId::invalid().raw;
+    dispatch_payload->args[PAYLOAD_LOCAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload->local_context);
+    dispatch_payload->args[PAYLOAD_GLOBAL_CONTEXT_INDEX] =
+        reinterpret_cast<uint64_t>(&dispatch_payload->global_context);
+    dispatch_payload->global_context.sub_block_id = task.subtask_slot == 2 ? 1 : 0;
+    return SchedulerGraphResult::OK;
+}

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_memory.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_memory.h
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "scheduler_types.h"
+
+inline __aicore__ void scheduler_writeback_cache_line(__gm__ void *address) {
+#if defined(__CCE_AICORE__)
+    dcci(address, SINGLE_CACHE_LINE, CACHELINE_OUT);
+#else
+    (void)address;
+#endif
+}
+
+inline __aicore__ void scheduler_writeback_cache_line(volatile __gm__ void *address) {
+    scheduler_writeback_cache_line(const_cast<__gm__ void *>(address));
+}
+
+inline __aicore__ void scheduler_cache_barrier() {
+#if defined(__CCE_AICORE__)
+    dsb((mem_dsb_t)0);
+#else
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+#endif
+}
+
+inline __aicore__ void scheduler_publish_cache_line(__gm__ void *address) {
+    scheduler_writeback_cache_line(address);
+    scheduler_cache_barrier();
+}
+
+inline __aicore__ void scheduler_publish_cache_line(volatile __gm__ void *address) {
+    scheduler_publish_cache_line(const_cast<__gm__ void *>(address));
+}
+
+inline __aicore__ void scheduler_invalidate_cache_line(__gm__ void *address) {
+#if defined(__CCE_AICORE__)
+    dcci(address, SINGLE_CACHE_LINE);
+#else
+    (void)address;
+#endif
+}
+
+inline __aicore__ void scheduler_invalidate_cache_line(volatile __gm__ void *address) {
+    scheduler_invalidate_cache_line(const_cast<__gm__ void *>(address));
+}
+
+inline __aicore__ void scheduler_observe_cache_line(__gm__ void *address) {
+    scheduler_invalidate_cache_line(address);
+    scheduler_cache_barrier();
+}
+
+inline __aicore__ void scheduler_observe_cache_line(volatile __gm__ void *address) {
+    scheduler_observe_cache_line(const_cast<__gm__ void *>(address));
+}
+
+inline __aicore__ void scheduler_observe_data_cache(__gm__ void *address) {
+#if defined(__CCE_AICORE__)
+    dcci(address, ENTIRE_DATA_CACHE);
+    dsb((mem_dsb_t)0);
+#else
+    (void)address;
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+#endif
+}
+
+inline __aicore__ void scheduler_publish_dispatch_payload(__gm__ DispatchPayload *payload) {
+#if defined(__CCE_AICORE__)
+    for (uint64_t offset = 0; offset < sizeof(DispatchPayload); offset += 64) {
+        dcci(reinterpret_cast<__gm__ uint8_t *>(payload) + offset, SINGLE_CACHE_LINE, CACHELINE_OUT);
+    }
+    dsb((mem_dsb_t)0);
+#else
+    (void)payload;
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+#endif
+}
+
+inline __aicore__ void scheduler_observe_dispatch_payload_control(__gm__ DispatchPayload *payload) {
+#if defined(__CCE_AICORE__)
+    dcci(payload, SINGLE_CACHE_LINE);
+#else
+    (void)payload;
+#endif
+}
+
+inline __aicore__ void scheduler_observe_dispatch_payload_arguments(__gm__ DispatchPayload *payload) {
+#if defined(__CCE_AICORE__)
+    for (uint64_t offset = 64; offset < sizeof(DispatchPayload); offset += 64) {
+        dcci(reinterpret_cast<__gm__ uint8_t *>(payload) + offset, SINGLE_CACHE_LINE);
+    }
+#else
+    (void)payload;
+#endif
+}
+
+inline __aicore__ void scheduler_observe_dispatch_payload_barrier() {
+#if defined(__CCE_AICORE__)
+    dsb((mem_dsb_t)0);
+#else
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+#endif
+}
+
+// A5 ld_dev bypasses the scalar DCache. It is only an observation/prefilter
+// primitive; ownership changes use the CAS/exchange/fetch wrappers below.
+// Publication-protected metadata is invalidated separately before consumption.
+inline __aicore__ int64_t scheduler_gm_query(__gm__ volatile int64_t &value, int order = __ATOMIC_ACQUIRE) {
+#if defined(__CCE_AICORE__)
+    (void)order;
+    __gm__ int64_t *signed_address = const_cast<__gm__ int64_t *>(&value);
+    __gm__ uint64_t *address = reinterpret_cast<__gm__ uint64_t *>(signed_address);
+    return static_cast<int64_t>(static_cast<uint64_t>(__builtin_cce_ld_dev(address, 0)));
+#else
+    return __atomic_load_n(&value, order);
+#endif
+}
+
+inline __aicore__ uint64_t scheduler_gm_query(__gm__ volatile uint64_t &value, int order = __ATOMIC_ACQUIRE) {
+#if defined(__CCE_AICORE__)
+    (void)order;
+    return static_cast<uint64_t>(__builtin_cce_ld_dev(const_cast<__gm__ uint64_t *>(&value), 0));
+#else
+    return __atomic_load_n(&value, order);
+#endif
+}
+
+inline __aicore__ uint64_t scheduler_gm_query_u32_pair(__gm__ volatile uint32_t *values, int order = __ATOMIC_ACQUIRE) {
+#if defined(__CCE_AICORE__)
+    (void)order;
+    __gm__ uint32_t *first = const_cast<__gm__ uint32_t *>(values);
+    __gm__ uint64_t *address = reinterpret_cast<__gm__ uint64_t *>(first);
+    return static_cast<uint64_t>(__builtin_cce_ld_dev(address, 0));
+#else
+    const uint64_t low = __atomic_load_n(&values[0], order);
+    const uint64_t high = __atomic_load_n(&values[1], order);
+    return low | (high << 32);
+#endif
+}
+
+inline __aicore__ void
+scheduler_gm_store(__gm__ volatile int64_t &value, int64_t desired, int order = __ATOMIC_RELEASE) {
+#if defined(__CCE_AICORE__)
+    (void)order;
+    st_dev(
+        static_cast<uint64_t>(desired), reinterpret_cast<__gm__ uint64_t *>(const_cast<__gm__ int64_t *>(&value)), 0
+    );
+    OUT_OF_ORDER_STORE_BARRIER();
+#else
+    __atomic_store_n(&value, desired, order);
+#endif
+}
+
+inline __aicore__ void
+scheduler_gm_store(__gm__ volatile uint64_t &value, uint64_t desired, int order = __ATOMIC_RELEASE) {
+#if defined(__CCE_AICORE__)
+    (void)order;
+    st_dev(desired, const_cast<__gm__ uint64_t *>(&value), 0);
+    OUT_OF_ORDER_STORE_BARRIER();
+#else
+    __atomic_store_n(&value, desired, order);
+#endif
+}
+
+inline __aicore__ void
+scheduler_gm_store(__gm__ volatile uint32_t &value, uint32_t desired, int order = __ATOMIC_RELEASE) {
+#if defined(__CCE_AICORE__)
+    (void)order;
+    st_dev(desired, const_cast<__gm__ uint32_t *>(&value), 0);
+    OUT_OF_ORDER_STORE_BARRIER();
+#else
+    __atomic_store_n(&value, desired, order);
+#endif
+}
+
+inline __aicore__ void
+scheduler_gm_publish(__gm__ volatile uint64_t &value, uint64_t desired, int order = __ATOMIC_RELEASE) {
+#if defined(__CCE_AICORE__)
+    (void)order;
+    (void)atomicExch(const_cast<__gm__ uint64_t *>(&value), desired);
+#else
+    __atomic_store_n(&value, desired, order);
+#endif
+}
+
+inline __aicore__ int64_t
+scheduler_gm_exchange(__gm__ volatile int64_t &value, int64_t desired, int order = __ATOMIC_ACQ_REL) {
+#if defined(__CCE_AICORE__)
+    (void)order;
+    return atomicExch(const_cast<__gm__ int64_t *>(&value), desired);
+#else
+    return __atomic_exchange_n(&value, desired, order);
+#endif
+}
+
+inline __aicore__ uint64_t
+scheduler_gm_fetch_add(__gm__ volatile uint64_t &value, uint64_t delta, int order = __ATOMIC_ACQ_REL) {
+#if defined(__CCE_AICORE__)
+    (void)order;
+    return atomicAdd(const_cast<__gm__ uint64_t *>(&value), delta);
+#else
+    return __atomic_fetch_add(&value, delta, order);
+#endif
+}
+
+inline __aicore__ int64_t scheduler_gm_compare_exchange(
+    __gm__ volatile int64_t &value, int64_t expected, int64_t desired, int success_order = __ATOMIC_ACQ_REL,
+    int failure_order = __ATOMIC_ACQUIRE
+) {
+#if defined(__CCE_AICORE__)
+    (void)success_order;
+    (void)failure_order;
+    return atomicCAS(const_cast<__gm__ int64_t *>(&value), expected, desired);
+#else
+    int64_t observed = expected;
+    (void)__atomic_compare_exchange_n(&value, &observed, desired, false, success_order, failure_order);
+    return observed;
+#endif
+}
+
+inline __aicore__ uint64_t scheduler_gm_compare_exchange(
+    __gm__ volatile uint64_t &value, uint64_t expected, uint64_t desired, int success_order = __ATOMIC_ACQ_REL,
+    int failure_order = __ATOMIC_ACQUIRE
+) {
+#if defined(__CCE_AICORE__)
+    (void)success_order;
+    (void)failure_order;
+    return atomicCAS(const_cast<__gm__ uint64_t *>(&value), expected, desired);
+#else
+    uint64_t observed = expected;
+    (void)__atomic_compare_exchange_n(&value, &observed, desired, false, success_order, failure_order);
+    return observed;
+#endif
+}
+
+inline __aicore__ uint64_t
+scheduler_gm_fetch_or(__gm__ volatile uint64_t &value, uint64_t bits, int order = __ATOMIC_ACQ_REL) {
+#if defined(__CCE_AICORE__)
+    (void)order;
+    uint64_t observed = scheduler_gm_query(value);
+    while ((observed & bits) != bits) {
+        uint64_t actual = scheduler_gm_compare_exchange(value, observed, observed | bits);
+        if (actual == observed) break;
+        observed = actual;
+    }
+    return observed;
+#else
+    return __atomic_fetch_or(&value, bits, order);
+#endif
+}
+
+inline __aicore__ uint64_t
+scheduler_gm_fetch_and(__gm__ volatile uint64_t &value, uint64_t bits, int order = __ATOMIC_ACQ_REL) {
+#if defined(__CCE_AICORE__)
+    (void)order;
+    uint64_t observed = scheduler_gm_query(value);
+    while ((observed & bits) != observed) {
+        uint64_t actual = scheduler_gm_compare_exchange(value, observed, observed & bits);
+        if (actual == observed) break;
+        observed = actual;
+    }
+    return observed;
+#else
+    return __atomic_fetch_and(&value, bits, order);
+#endif
+}

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_topology.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_topology.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+struct SchedulerClusterCoordinate {
+    int32_t cluster_index;
+    int32_t cluster_lane;
+};
+
+// The mixed-kernel launch index is the stable hardware-topology coordinate:
+// AIC indices occupy [0, cluster_count), followed by the two AIV subblocks of
+// every Cluster. Real A5 physical_core_id values are sparse and are only valid
+// for register addressing, so they must not be treated as a dense topology.
+// Resolver selection remains dynamic and is performed after discovery.
+inline bool scheduler_cluster_coordinate_from_worker(
+    int32_t worker_id, bool is_aic, int32_t cluster_count, int32_t aiv_per_cluster,
+    SchedulerClusterCoordinate *coordinate
+) {
+    if (coordinate == nullptr || worker_id < 0 || cluster_count <= 0 || aiv_per_cluster <= 0) return false;
+    if (is_aic) {
+        if (worker_id >= cluster_count) return false;
+        *coordinate = {worker_id, 0};
+        return true;
+    }
+    const int32_t aiv_launch_rank = worker_id - cluster_count;
+    if (aiv_launch_rank < 0 || aiv_launch_rank >= cluster_count * aiv_per_cluster) return false;
+    *coordinate = {aiv_launch_rank / aiv_per_cluster, 1 + aiv_launch_rank % aiv_per_cluster};
+    return true;
+}

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
@@ -16,8 +16,13 @@
 
 #include "common/core_type.h"
 #include "common/platform_config.h"
+#include "dispatch_payload.h"
+
+#if !defined(__CCE_AICORE__)
 #include "runtime_types.h"
+#if __has_include("spin_hint.h")
 #include "spin_hint.h"
+#endif
 
 // host_build_graph host-orch build: RuntimeContext embeds SchedulerState by
 // value, so this header is compiled into the host libhost_runtime.so. The AICPU
@@ -27,7 +32,9 @@
 // host). host_runtime_EXPORTS is CMake's auto-define for the host shared-lib
 // target, so the AICPU/AICore builds keep the real platform constant.
 #ifdef host_runtime_EXPORTS
-constexpr int32_t PLATFORM_SCHEDULER_TIMEOUT_MS = 2000;
+constexpr int32_t HBG_LEGACY_SCHEDULER_TIMEOUT_MS = 2000;
+#else
+constexpr int32_t HBG_LEGACY_SCHEDULER_TIMEOUT_MS = PLATFORM_ONBOARD_SCHEDULER_TIMEOUT_MS;
 #endif
 
 // =============================================================================
@@ -79,7 +86,7 @@ constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator erro
 // the AICPU can flush diagnostics before the host-visible timeout chain fires.
 // Sim has no STARS or ACL stream-sync timeout, but uses the same no-progress
 // watchdog shape. See spin_hint.h for the per-variant rationale.
-constexpr int32_t SCHEDULER_TIMEOUT_MS = PLATFORM_SCHEDULER_TIMEOUT_MS;
+constexpr int32_t SCHEDULER_TIMEOUT_MS = HBG_LEGACY_SCHEDULER_TIMEOUT_MS;
 constexpr uint64_t SCHEDULER_TIMEOUT_CYCLES =
     static_cast<uint64_t>(SCHEDULER_TIMEOUT_MS) * (PLATFORM_PROF_SYS_CNT_FREQ / 1000);
 constexpr int32_t STALL_DUMP_READY_MAX = 8;
@@ -170,7 +177,7 @@ public:
         // A mask with exactly `offset` set. The shift lives here so a caller
         // cannot silently narrow it by writing `1ULL << offset`, which is
         // undefined once offset reaches 64.
-        static BitStates bit(int32_t offset) { return BitStates(Storage(1) << offset); }
+        static BitStates bit(int32_t offset) { return BitStates(static_cast<Storage>(1) << offset); }
 
         BitStates operator~() const { return BitStates(~states_); }
         BitStates operator&(const BitStates &other) const { return BitStates(states_ & other.states_); }
@@ -187,7 +194,7 @@ public:
             return __builtin_popcountll(static_cast<uint64_t>(states_)) +
                    __builtin_popcountll(static_cast<uint64_t>(states_ >> 64));
         }
-        void clear_bit(int32_t offset) { states_ &= ~(Storage(1) << offset); }
+        void clear_bit(int32_t offset) { states_ &= ~(static_cast<Storage>(1) << offset); }
 
         // Extract the lowest set bit from mask, clear it, and return its position.
         // Returns -1 if mask is empty.
@@ -606,4 +613,776 @@ inline uint64_t sync_start_drain_next_attempt(uint64_t attempt) {
 
 inline uint64_t sync_start_drain_ack_subtree_token(uint64_t attempt) {
     return attempt | SYNC_START_DRAIN_ACK_SUBTREE_READY;
+}
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__
+#endif
+
+#ifndef __host__
+#define __host__
+#endif
+
+#endif
+
+// =============================================================================
+// Resident AICore scheduler wire contracts
+//
+// These types are shared by Host, AICPU lifecycle, and AICore workers.
+// =============================================================================
+inline constexpr uint64_t SCHEDULER_STATE_ALIGNMENT = 128;
+inline constexpr uint64_t SCHEDULER_WORKER_CAPACITY = 108;
+inline constexpr uint32_t SCHEDULER_PENDING_SLOT_COUNT = 2;
+inline constexpr uint32_t SCHEDULER_CALLABLE_CAPACITY = 1024;
+inline constexpr uint32_t SCHEDULER_CORE_TYPE_COUNT = 2;
+inline constexpr uint32_t SCHEDULER_CLUSTER_CAPACITY = SCHEDULER_WORKER_CAPACITY / 3;
+inline constexpr uint32_t SCHEDULER_GANG_COHORT_COUNT = 2;
+inline constexpr uint32_t SCHEDULER_READY_DIRECTORY_RESOLVERS_PER_SHARD = 7;
+inline constexpr uint32_t SCHEDULER_READY_DIRECTORY_SHARD_COUNT =
+    (SCHEDULER_CLUSTER_CAPACITY + SCHEDULER_READY_DIRECTORY_RESOLVERS_PER_SHARD - 1) /
+    SCHEDULER_READY_DIRECTORY_RESOLVERS_PER_SHARD;
+inline constexpr int64_t SCHEDULER_TASK_ID_INVALID = -1;
+inline constexpr int64_t SCHEDULER_WAKE_LIST_OPEN = -1;
+inline constexpr int64_t SCHEDULER_WAKE_LIST_CLOSED = -2;
+inline constexpr int64_t SCHEDULER_INBOX_EMPTY = -1;
+inline constexpr int64_t SCHEDULER_INBOX_LINK_UNPUBLISHED = -2;
+inline constexpr uint64_t SCHEDULER_READY_PENDING_EMPTY = UINT64_MAX;
+
+enum class SchedulerTaskState : int64_t {
+    BLOCKED = 0,
+    READY = 1,
+    DONE = 2,
+    DISPATCHING = 3,
+};
+
+enum class SchedulerReadySource : uint8_t {
+    LOCAL = 0,
+    STOLEN = 1,
+};
+
+enum class SchedulerDispatchSlotState : uint8_t {
+    EMPTY = 0,
+    FREE = 1,
+    FILLING = 2,
+    READY = 3,
+    GATED = 4,
+};
+
+enum SchedulerTaskMetadataFlags : uint8_t {
+    SCHEDULER_TASK_EXECUTABLE = 1U << 0,
+    SCHEDULER_TASK_HAS_FANIN = 1U << 1,
+    SCHEDULER_TASK_MIX = 1U << 2,
+    SCHEDULER_TASK_SPMD = 1U << 3,
+    SCHEDULER_TASK_SYNC_START = 1U << 4,
+    SCHEDULER_TASK_INLINE = 1U << 5,
+    SCHEDULER_TASK_HAS_PREDICATE = 1U << 6,
+};
+
+#if !defined(__CCE_AICORE__)
+// Derive the compact AICore metadata from the established HBG scheduling
+// types. This is a host-only projection: ActiveMask and TaskAttrs remain the
+// source of truth, while SchedulerTaskMetadata stays a 16-byte GM read model.
+inline uint8_t scheduler_task_metadata_flags_from_submit_state(
+    ActiveMask active_mask, TaskAttrs task_attrs, int32_t logical_block_num, bool has_fanin, bool inline_task
+) {
+    uint8_t flags = SCHEDULER_TASK_EXECUTABLE;
+    const uint32_t active_subtasks = static_cast<uint32_t>(__builtin_popcount(active_mask.core_mask()));
+    if (has_fanin) flags |= SCHEDULER_TASK_HAS_FANIN;
+    if (active_subtasks > 1) flags |= SCHEDULER_TASK_MIX;
+    if (logical_block_num > 1) flags |= SCHEDULER_TASK_SPMD;
+    if (task_attrs.requires_sync_start()) flags |= SCHEDULER_TASK_SYNC_START;
+    if (inline_task) flags |= SCHEDULER_TASK_INLINE;
+    if (task_attrs.has_predicate()) flags |= SCHEDULER_TASK_HAS_PREDICATE;
+    return flags;
+}
+#endif
+
+constexpr int32_t SCHEDULER_TASK_TIMING_SLOT_COUNT = 16;
+
+struct alignas(16) SchedulerTaskMetadata {
+    uint16_t kernel_ids[3];
+    uint8_t active_mask;
+    uint8_t flags;
+    uint16_t logical_block_num;
+    uint16_t total_required_subtasks;
+    int32_t timing_slot;
+};
+
+inline __host__ __aicore__ bool scheduler_task_is_executable(uint8_t flags) {
+    return (flags & SCHEDULER_TASK_EXECUTABLE) != 0;
+}
+
+inline __host__ __aicore__ bool scheduler_task_has_fanin(uint8_t flags) {
+    return (flags & SCHEDULER_TASK_HAS_FANIN) != 0;
+}
+
+inline __host__ __aicore__ bool scheduler_task_is_mix(uint8_t flags) { return (flags & SCHEDULER_TASK_MIX) != 0; }
+
+inline __host__ __aicore__ bool scheduler_task_is_spmd(uint8_t flags) { return (flags & SCHEDULER_TASK_SPMD) != 0; }
+
+inline __host__ __aicore__ bool scheduler_task_requires_sync_start(uint8_t flags) {
+    return (flags & SCHEDULER_TASK_SYNC_START) != 0;
+}
+
+inline __host__ __aicore__ bool scheduler_task_is_inline(uint8_t flags) { return (flags & SCHEDULER_TASK_INLINE) != 0; }
+
+inline __host__ __aicore__ bool scheduler_task_has_predicate(uint8_t flags) {
+    return (flags & SCHEDULER_TASK_HAS_PREDICATE) != 0;
+}
+
+inline __host__ __aicore__ bool scheduler_task_is_gang(uint8_t flags) {
+    return (flags & (SCHEDULER_TASK_MIX | SCHEDULER_TASK_SPMD)) != 0;
+}
+
+inline __host__ __aicore__ uint32_t scheduler_task_priority_bit(uint8_t flags) {
+    if (scheduler_task_requires_sync_start(flags)) return 1U;
+    if (scheduler_task_is_mix(flags)) return 2U;
+    if (scheduler_task_is_spmd(flags)) return 4U;
+    return 0;
+}
+
+struct alignas(128) SchedulerTaskControl {
+    // Cross-core state publication and wake-list RMWs share the first line.
+    volatile int64_t state;
+    volatile int64_t wake_list_head;
+    uint8_t atomic_line_padding[48];
+
+    // next_waiter links the dependency wake list while BLOCKED and the Ready
+    // inbox after routing.
+    int64_t next_waiter;
+    int32_t next_fanin_index;
+    int32_t waiting_producer;
+    uint64_t completion_resolve_start_cycles;
+    uint64_t completion_resolve_end_cycles;
+    uint64_t ready_publish_cycles;
+    uint64_t resolver_worker_id;
+    uint8_t scheduler_line_padding[16];
+};
+
+struct alignas(64) SchedulerCompletionInbox {
+    volatile uint32_t completed_generations[SCHEDULER_PENDING_SLOT_COUNT];
+    uint8_t completion_line_padding[56];
+};
+
+struct alignas(128) SchedulerReadyInbox {
+    volatile int64_t head;
+    uint8_t atomic_line_padding[120];
+};
+
+struct alignas(64) SchedulerReadyOwnerQueue {
+    // Head and tail are one owner-only device word so an ld_dev cannot
+    // observe endpoints from different updates.
+    volatile uint64_t pending_endpoints{SCHEDULER_READY_PENDING_EMPTY};
+    volatile uint64_t advertised{0};
+    uint8_t owner_line_padding[48];
+};
+
+struct alignas(128) SchedulerReadyOwnerState {
+    SchedulerReadyOwnerQueue queues[SCHEDULER_CORE_TYPE_COUNT];
+};
+
+enum class SchedulerGangCohortState : uint64_t {
+    FREE = 0,
+    DRAINING = 1,
+    STAGING = 2,
+    RELEASING = 3,
+    DISPATCHING = 4,
+    EXECUTING = 5,
+    RETIRING = 6,
+};
+
+struct alignas(128) SchedulerGangCoordinator {
+    volatile uint64_t ready_priority_bits;
+    uint8_t priority_line_padding[56];
+
+    volatile uint64_t active_dispatch_cohort;
+    uint64_t next_generation;
+    uint64_t scan_cursor;
+    uint64_t gang_task_count;
+    uint64_t resolver_count;
+    uint64_t cohort_count;
+    uint64_t reserved0;
+    uint64_t owner_reserved;
+
+    uint64_t admitted_count;
+    uint64_t sync_drain_count;
+    uint64_t mix_dispatch_count;
+    uint64_t spmd_dispatch_count;
+    uint64_t capacity_reject_count;
+    uint64_t reserved[3];
+};
+
+struct alignas(128) SchedulerGangCohort {
+    volatile uint64_t state;
+    int64_t task_id;
+    uint64_t generation;
+    uint64_t priority_bit;
+    uint64_t active_mask;
+    uint64_t logical_block_num;
+    uint64_t participant_count;
+    uint64_t local_stride;
+    uint64_t admitted_cycles;
+    uint64_t drain_complete_cycles;
+    uint64_t stage_complete_cycles;
+    uint64_t dispatch_complete_cycles;
+    uint64_t completion_cycles;
+    uint64_t reserved[3];
+};
+
+// One Resolver owns one participant cell. The second line contains generation
+// tokens observed only by its parent in the binary Resolver tree.
+struct alignas(128) SchedulerGangParticipant {
+    volatile uint64_t config_generation;
+    int64_t task_id;
+    uint32_t active_mask;
+    uint32_t logical_block_num;
+    uint32_t local_expected_subtasks;
+    uint32_t local_published_subtasks;
+    uint32_t local_completed_subtasks;
+    uint32_t block_stride;
+    uint32_t next_block[2];
+    uint32_t participant_count;
+    uint32_t forwarded_state;
+    uint64_t forwarded_generation;
+
+    volatile uint64_t drain_local_token;
+    volatile uint64_t drain_subtree_token;
+    volatile uint64_t stage_local_token;
+    volatile uint64_t stage_subtree_token;
+    volatile uint64_t dispatch_local_token;
+    volatile uint64_t dispatch_subtree_token;
+    volatile uint64_t completion_local_token;
+    volatile uint64_t completion_subtree_token;
+};
+
+// Each Resolver polls its own command line. Resolver0 seeds the root and every
+// parent forwards transitions to two children, avoiding a globally contended
+// cohort line and bounding sync-start release skew by the tree depth.
+struct alignas(128) SchedulerGangCommand {
+    volatile uint64_t generation[SCHEDULER_GANG_COHORT_COUNT];
+    volatile uint64_t state[SCHEDULER_GANG_COHORT_COUNT];
+    uint8_t padding[96];
+};
+
+struct alignas(64) SchedulerReadyDirectoryShard {
+    volatile uint64_t bits;
+    uint8_t cache_line_padding[64 - sizeof(uint64_t)];
+};
+
+struct alignas(128) SchedulerReadyDirectory {
+    SchedulerReadyDirectoryShard core_types[SCHEDULER_CORE_TYPE_COUNT][SCHEDULER_READY_DIRECTORY_SHARD_COUNT];
+    volatile uint64_t bootstrap_ready_types[SCHEDULER_WORKER_CAPACITY];
+};
+
+// Resolver-owned metadata occupies the first line. The Executor polls only
+// publication in the second line.
+struct alignas(128) SchedulerDispatchSlot {
+    int64_t task_id;
+    uint64_t ready_inbox_index;
+    uint64_t claim_start_cycles;
+    uint64_t claim_end_cycles;
+    uint64_t claim_worker_id;
+    uint16_t kernel_id;
+    uint8_t subtask_slot;
+    uint8_t has_fanin;
+    uint8_t ready_source;
+    uint8_t pending_slot;
+    uint16_t block_num;
+    uint32_t generation;
+    uint32_t block_idx;
+    uint32_t cohort_generation;
+    uint8_t cohort_index;
+    uint8_t gang;
+    uint8_t metadata_padding[2];
+
+    volatile uint64_t publication;
+    uint8_t publication_padding[56];
+};
+
+struct alignas(128) SchedulerRunControl {
+    uint64_t config_reserved_prefix[2];
+    uint64_t active_worker_count;
+    uint64_t expected_task_count;
+    uint64_t inline_completed_count;
+    uint64_t aic_active_worker_count;
+    uint64_t aiv_active_worker_count;
+    uint64_t dispatch_reserved;
+    volatile uint64_t dispatch_payloads_offset;
+    uint64_t task_metadata_offset;
+    uint64_t ready_inboxes_offset;
+    uint64_t ready_directory_offset;
+    uint64_t directory_reserved;
+    uint64_t gang_coordinator_offset;
+    uint64_t gang_cohorts_offset;
+    uint64_t resolver_count;
+
+    volatile uint64_t executed_task_count;
+    volatile uint64_t resolved_task_count;
+    volatile uint64_t bootstrap_arrived_count;
+    volatile uint64_t bootstrap_complete;
+    uint64_t completion_wait_start_cycles;
+    uint64_t bootstrap_complete_cycles;
+    uint64_t all_tasks_resolved_cycles;
+    uint64_t shutdown_ready_cycles;
+    uint64_t completion_poll_count;
+    uint64_t completion_poll_cycles;
+    uint64_t error_poll_count;
+    volatile uint64_t bootstrap_scan_arrived_count;
+    volatile uint64_t bootstrap_scan_complete;
+    uint64_t lifecycle_reserved[3];
+
+    volatile uint64_t error_claimed;
+    volatile uint64_t scheduler_error;
+    volatile uint64_t error_task_id;
+    volatile uint64_t error_core_id;
+    volatile uint64_t error_core_type;
+    volatile uint64_t error_graph_task_count;
+    volatile uint64_t error_descriptors_address;
+    volatile uint64_t error_payloads_address;
+    volatile uint64_t error_task_window_mask;
+    uint64_t error_reserved[7];
+};
+
+struct alignas(128) AicpuCoreLifecycleTrace {
+    uint64_t worker_id;
+    uint64_t aicpu_thread_id;
+    uint64_t core_type;
+    uint64_t physical_core_id;
+    uint64_t handshake_observed_cycles;
+    uint64_t handshake_partition_complete_cycles;
+    uint64_t config_start_cycles;
+    uint64_t topology_complete_cycles;
+    uint64_t context_publish_complete_cycles;
+    uint64_t bootstrap_wait_start_cycles;
+    uint64_t bootstrap_complete_cycles;
+    uint64_t register_release_cycles;
+    uint64_t exit_signal_cycles;
+    uint64_t exit_ack_cycles;
+    uint64_t reserved[2];
+};
+
+struct alignas(128) SchedulerTailTrace {
+    volatile uint64_t valid;
+    uint64_t start_cycles;
+    uint64_t end_cycles;
+    uint64_t completion_scan_cycles;
+    uint64_t completion_consume_cycles;
+    uint64_t completion_resolve_cycles;
+    uint64_t completion_ready_publish_cycles;
+    uint64_t completion_refill_cycles;
+    uint64_t completion_finalize_cycles;
+    uint64_t gang_service_cycles;
+    uint64_t dispatch_probe_cycles[SCHEDULER_CORE_TYPE_COUNT];
+    uint64_t dispatch_claim_cycles[SCHEDULER_CORE_TYPE_COUNT];
+    uint64_t dispatch_prepare_cycles[SCHEDULER_CORE_TYPE_COUNT];
+    uint64_t dispatch_materialize_cycles[SCHEDULER_CORE_TYPE_COUNT];
+    uint64_t dispatch_publish_cycles[SCHEDULER_CORE_TYPE_COUNT];
+    uint64_t ready_poll_cycles;
+    uint64_t backoff_cycles;
+};
+
+struct alignas(128) SchedulerWorkerContext {
+    volatile int32_t core_type;
+    int32_t physical_core_id;
+    volatile int32_t type_rank;
+    volatile int32_t active;
+    volatile uint64_t run_control_offset;
+    volatile uint64_t task_controls_offset;
+    volatile uint64_t graph_descriptors_address;
+    volatile uint64_t graph_payloads_address;
+    volatile uint64_t scheduler_state_base_address;
+    volatile uint64_t dispatch_payload_offset;
+    volatile uint64_t trace_cells_offset;
+    volatile uint64_t task_window_mask;
+    volatile uint64_t graph_task_count;
+    volatile uint64_t worker_index;
+    volatile uint64_t completion_inboxes_offset;
+    volatile uint64_t inbox_index;
+    volatile uint64_t ready_owner_states_offset;
+    uint64_t runtime_offset_padding;
+
+    volatile uint64_t task_metadata_offset;
+    volatile uint64_t ready_inboxes_offset;
+    volatile uint64_t ready_directory_offset;
+    uint64_t scheduling_reserved;
+    volatile uint64_t worker_contexts_offset;
+    volatile uint64_t dispatch_slots_offset;
+    volatile uint64_t callable_addresses_offset;
+    volatile uint64_t runtime_worker_count;
+    volatile uint64_t bootstrap_done;
+    uint64_t bootstrap_scan_end_cycles;
+    uint64_t target_bootstrap_start_cycles;
+    uint64_t target_bootstrap_end_cycles;
+    uint64_t bootstrap_target_aic_cycles;
+    uint64_t bootstrap_target_aiv_cycles;
+    uint64_t bootstrap_ready_claim_aic_cycles;
+    uint64_t bootstrap_ready_claim_aiv_cycles;
+
+    volatile uint64_t gang_coordinator_offset;
+    volatile uint64_t gang_cohorts_offset;
+    volatile uint64_t gang_participants_offset;
+    volatile uint64_t gang_commands_offset;
+    volatile uint64_t resolver_count;
+    volatile uint64_t cluster_count;
+    volatile uint64_t cluster_index;
+    volatile uint64_t resolver_index;
+    volatile uint64_t resolver_worker_id;
+    volatile uint64_t is_resolver;
+    volatile uint64_t cluster_worker_ids[3];
+    uint64_t topology_reserved[3];
+
+    uint64_t bootstrap_task_count;
+    uint64_t ready_enqueue_count;
+    uint64_t ready_batch_count;
+    uint64_t ready_pop_count;
+    uint64_t ready_steal_count;
+    uint64_t ready_cas_retry_count;
+    uint64_t ready_link_wait_count;
+    uint64_t ready_link_wait_max;
+    uint64_t ready_stats_reserved[2];
+    uint64_t executed_task_count;
+    uint64_t task_state_poll_count;
+    uint64_t fanin_state_load_count;
+    uint64_t wake_register_count;
+    uint64_t idle_iteration_count;
+    uint64_t backoff_cycles;
+
+    uint64_t wake_cas_retry_count;
+    uint64_t wake_closed_retry_count;
+    uint64_t wake_migrate_count;
+    uint64_t wake_close_count;
+    uint64_t completion_enqueue_count;
+    uint64_t completion_resolve_count;
+    uint64_t completion_stats_reserved[6];
+    uint64_t ready_to_kernel_cycles;
+    uint64_t ready_to_kernel_max_cycles;
+    uint64_t payload_cycles;
+    uint64_t kernel_cycles;
+
+    uint64_t completion_enqueue_cycles;
+    uint64_t bootstrap_start_cycles;
+    uint64_t bootstrap_end_cycles;
+    uint64_t drain_start_cycles;
+    uint64_t drain_end_cycles;
+    uint64_t exit_wait_start_cycles;
+    uint64_t exit_observed_cycles;
+    uint64_t final_stats_publish_start_cycles;
+    uint64_t final_stats_publish_end_cycles;
+    uint64_t exit_ack_publish_cycles;
+    uint64_t bootstrap_slot_fill_aic_cycles;
+    uint64_t bootstrap_slot_fill_aiv_cycles;
+    uint64_t termination_reserved[4];
+
+    SchedulerTailTrace scheduler_tail_trace;
+};
+
+struct alignas(128) SchedulerTaskTrace {
+    volatile uint64_t valid;
+    uint64_t ready_source;
+    uint64_t worker_id;
+    uint64_t task_id;
+    uint64_t claim_worker_id;
+    uint64_t claim_start_cycles;
+    uint64_t claim_end_cycles;
+    uint64_t previous_trace_commit_end_cycles;
+
+    uint64_t kernel_start_cycles;
+    uint64_t kernel_end_cycles;
+    uint64_t completion_end_cycles;
+    uint64_t ready_scan_start_cycles;
+    uint64_t ready_observe_cycles;
+    uint64_t completion_bookkeeping_end_cycles;
+    uint64_t completion_id;
+    uint64_t completion_inbox_index;
+
+    uint64_t ready_transition_cycles;
+    uint64_t inter_task_completion_service_cycles;
+    uint64_t inter_task_dispatch_aic_cycles;
+    uint64_t inter_task_dispatch_aiv_cycles;
+    uint64_t inter_task_ready_poll_cycles;
+    uint64_t inter_task_backoff_cycles;
+    uint64_t aicore_entry_cycles;
+    uint64_t handshake_publish_cycles;
+
+    uint64_t register_release_cycles;
+    uint64_t descriptor_cache_observed_cycles;
+    uint64_t completion_prepare_start_cycles;
+    uint64_t refill_resolver_worker_id;
+    uint64_t refill_start_cycles;
+    uint64_t refill_end_cycles;
+    uint64_t refill_task_id;
+    uint64_t inter_task_completion_refill_cycles;
+
+    uint64_t inter_task_completion_scan_cycles;
+    uint64_t inter_task_completion_consume_cycles;
+    uint64_t inter_task_completion_resolve_cycles;
+    uint64_t inter_task_completion_ready_publish_cycles;
+    uint64_t inter_task_completion_finalize_cycles;
+    uint64_t inter_task_gang_service_cycles;
+    uint64_t inter_task_dispatch_probe_cycles[SCHEDULER_CORE_TYPE_COUNT];
+    uint64_t inter_task_dispatch_claim_cycles[SCHEDULER_CORE_TYPE_COUNT];
+    uint64_t inter_task_dispatch_prepare_cycles[SCHEDULER_CORE_TYPE_COUNT];
+    uint64_t inter_task_dispatch_materialize_cycles[SCHEDULER_CORE_TYPE_COUNT];
+    uint64_t inter_task_dispatch_publish_cycles[SCHEDULER_CORE_TYPE_COUNT];
+};
+
+struct AicoreSchedulerLayout {
+    uint64_t total_size;
+    uint64_t task_count;
+    uint64_t aic_task_count;
+    uint64_t aiv_task_count;
+    uint64_t run_control_offset;
+    uint64_t aicpu_lifecycle_traces_offset;
+    uint64_t worker_contexts_offset;
+    uint64_t dispatch_payloads_offset;
+    uint64_t dispatch_slots_offset;
+    uint64_t callable_addresses_offset;
+    uint64_t task_metadata_offset;
+    uint64_t task_controls_offset;
+    uint64_t completion_inboxes_offset;
+    uint64_t ready_inboxes_offset;
+    uint64_t ready_owner_states_offset;
+    uint64_t ready_directory_offset;
+    uint64_t trace_cells_offset;
+    uint64_t gang_coordinator_offset;
+    uint64_t gang_cohorts_offset;
+    uint64_t gang_participants_offset;
+    uint64_t gang_commands_offset;
+    uint64_t executable_task_count;
+    uint64_t executable_subtask_count;
+    uint64_t gang_task_count;
+    uint64_t aic_worker_demand;
+    uint64_t aiv_worker_demand;
+};
+
+static_assert(sizeof(SchedulerTaskMetadata) == 16, "task metadata layout changed");
+static_assert(alignof(SchedulerTaskMetadata) == 16, "task metadata alignment changed");
+static_assert(sizeof(SchedulerTaskControl) == 128, "task control layout changed");
+static_assert(alignof(SchedulerTaskControl) == 128, "task control alignment changed");
+static_assert(offsetof(SchedulerTaskControl, next_waiter) == 64, "waiter metadata needs its own line");
+static_assert(sizeof(SchedulerCompletionInbox) == 64, "completion line must occupy one cache line");
+static_assert(alignof(SchedulerCompletionInbox) == 64, "completion line alignment changed");
+static_assert(offsetof(SchedulerCompletionInbox, completed_generations) == 0, "completion generations must lead line");
+static_assert(
+    sizeof(decltype(SchedulerCompletionInbox::completed_generations)) == sizeof(uint64_t),
+    "completion generations must fit one 64-bit device load"
+);
+static_assert(sizeof(SchedulerReadyInbox) == 128, "ready inbox layout changed");
+static_assert(alignof(SchedulerReadyInbox) == 128, "ready inbox alignment changed");
+static_assert(sizeof(SchedulerReadyOwnerQueue) == 64, "ready owner queue must occupy one cache line");
+static_assert(alignof(SchedulerReadyOwnerQueue) == 64, "ready owner queue alignment changed");
+static_assert(sizeof(SchedulerReadyOwnerState) == 128, "ready owner state must occupy two cache lines");
+static_assert(alignof(SchedulerReadyOwnerState) == 128, "ready owner state alignment changed");
+static_assert(sizeof(SchedulerGangCoordinator) == 256, "gang coordinator layout changed");
+static_assert(alignof(SchedulerGangCoordinator) == 128, "gang coordinator alignment changed");
+static_assert(
+    offsetof(SchedulerGangCoordinator, active_dispatch_cohort) == 64,
+    "owner-only gang state must not share the priority line"
+);
+static_assert(sizeof(SchedulerGangCohort) == 128, "gang cohort layout changed");
+static_assert(alignof(SchedulerGangCohort) == 128, "gang cohort alignment changed");
+static_assert(sizeof(SchedulerGangParticipant) == 128, "gang participant layout changed");
+static_assert(alignof(SchedulerGangParticipant) == 128, "gang participant alignment changed");
+static_assert(sizeof(SchedulerGangCommand) == 128, "gang command layout changed");
+static_assert(alignof(SchedulerGangCommand) == 128, "gang command alignment changed");
+static_assert(sizeof(SchedulerReadyDirectoryShard) == 64, "ready directory shard must occupy one cache line");
+static_assert(alignof(SchedulerReadyDirectoryShard) == 64, "ready directory shard alignment changed");
+static_assert(
+    offsetof(SchedulerReadyDirectory, bootstrap_ready_types) ==
+        SCHEDULER_CORE_TYPE_COUNT * SCHEDULER_READY_DIRECTORY_SHARD_COUNT * 64,
+    "bootstrap flags must follow the ready directory shards"
+);
+static_assert(
+    sizeof(SchedulerReadyDirectory) == ((offsetof(SchedulerReadyDirectory, bootstrap_ready_types) +
+                                         SCHEDULER_WORKER_CAPACITY * sizeof(uint64_t) + 127) /
+                                        128 * 128),
+    "ready directory layout changed"
+);
+static_assert(sizeof(SchedulerDispatchSlot) == 128, "dispatch slot must occupy two cache lines");
+static_assert(alignof(SchedulerDispatchSlot) == 128, "dispatch slot alignment changed");
+static_assert(offsetof(SchedulerDispatchSlot, publication) == 64, "dispatch publication needs its own line");
+static_assert(sizeof(SchedulerRunControl) == 384, "run control layout changed");
+static_assert(alignof(SchedulerRunControl) == 128, "run control alignment changed");
+static_assert(offsetof(SchedulerRunControl, executed_task_count) == 128, "lifecycle atomics need their own line");
+static_assert(offsetof(SchedulerRunControl, error_claimed) == 256, "error state needs its own line");
+static_assert(sizeof(AicpuCoreLifecycleTrace) == 128, "AICPU lifecycle trace layout changed");
+static_assert(sizeof(SchedulerTailTrace) == 256, "scheduler tail trace layout changed");
+static_assert(sizeof(SchedulerWorkerContext) == 1024, "worker context layout changed");
+static_assert(alignof(SchedulerWorkerContext) == 128, "worker context alignment changed");
+static_assert(offsetof(SchedulerWorkerContext, task_metadata_offset) == 128, "runtime offsets changed");
+static_assert(offsetof(SchedulerWorkerContext, gang_coordinator_offset) == 256, "topology offsets changed");
+static_assert(offsetof(SchedulerWorkerContext, bootstrap_task_count) == 384, "worker stats offset changed");
+static_assert(offsetof(SchedulerWorkerContext, wake_cas_retry_count) == 512, "wake stats offset changed");
+static_assert(offsetof(SchedulerWorkerContext, completion_enqueue_cycles) == 640, "termination stats offset changed");
+static_assert(offsetof(SchedulerWorkerContext, scheduler_tail_trace) == 768, "scheduler tail trace offset changed");
+static_assert(sizeof(SchedulerTaskTrace) == 384, "task trace layout changed");
+
+#if !defined(__CCE_AICORE__)
+#include <type_traits>
+static_assert(std::is_standard_layout_v<SchedulerTaskMetadata> && std::is_trivially_copyable_v<SchedulerTaskMetadata>);
+static_assert(std::is_standard_layout_v<SchedulerTaskControl> && std::is_trivially_copyable_v<SchedulerTaskControl>);
+static_assert(
+    std::is_standard_layout_v<SchedulerCompletionInbox> && std::is_trivially_copyable_v<SchedulerCompletionInbox>
+);
+static_assert(std::is_standard_layout_v<SchedulerReadyInbox> && std::is_trivially_copyable_v<SchedulerReadyInbox>);
+static_assert(
+    std::is_standard_layout_v<SchedulerReadyOwnerState> && std::is_trivially_copyable_v<SchedulerReadyOwnerState>
+);
+static_assert(
+    std::is_standard_layout_v<SchedulerGangCoordinator> && std::is_trivially_copyable_v<SchedulerGangCoordinator>
+);
+static_assert(std::is_standard_layout_v<SchedulerGangCohort> && std::is_trivially_copyable_v<SchedulerGangCohort>);
+static_assert(
+    std::is_standard_layout_v<SchedulerGangParticipant> && std::is_trivially_copyable_v<SchedulerGangParticipant>
+);
+static_assert(std::is_standard_layout_v<SchedulerGangCommand> && std::is_trivially_copyable_v<SchedulerGangCommand>);
+static_assert(
+    std::is_standard_layout_v<SchedulerReadyDirectory> && std::is_trivially_copyable_v<SchedulerReadyDirectory>
+);
+static_assert(std::is_standard_layout_v<SchedulerDispatchSlot> && std::is_trivially_copyable_v<SchedulerDispatchSlot>);
+static_assert(std::is_standard_layout_v<SchedulerRunControl> && std::is_trivially_copyable_v<SchedulerRunControl>);
+static_assert(
+    std::is_standard_layout_v<SchedulerWorkerContext> && std::is_trivially_copyable_v<SchedulerWorkerContext>
+);
+static_assert(std::is_standard_layout_v<SchedulerTailTrace> && std::is_trivially_copyable_v<SchedulerTailTrace>);
+#endif
+
+inline bool scheduler_layout_checked_add(uint64_t lhs, uint64_t rhs, uint64_t *out) {
+    if (out == nullptr || rhs > UINT64_MAX - lhs) return false;
+    *out = lhs + rhs;
+    return true;
+}
+
+inline bool scheduler_layout_checked_mul(uint64_t lhs, uint64_t rhs, uint64_t *out) {
+    if (out == nullptr || (lhs != 0 && rhs > UINT64_MAX / lhs)) return false;
+    *out = lhs * rhs;
+    return true;
+}
+
+inline bool scheduler_layout_checked_align(uint64_t value, uint64_t alignment, uint64_t *out) {
+    if (out == nullptr || alignment == 0 || (alignment & (alignment - 1)) != 0) return false;
+    uint64_t added = 0;
+    if (!scheduler_layout_checked_add(value, alignment - 1, &added)) return false;
+    *out = added & ~(alignment - 1);
+    return true;
+}
+
+inline bool scheduler_layout_reserve(uint64_t *cursor, uint64_t size, uint64_t alignment, uint64_t *offset) {
+    uint64_t aligned = 0;
+    if (cursor == nullptr || offset == nullptr || !scheduler_layout_checked_align(*cursor, alignment, &aligned))
+        return false;
+    uint64_t end = 0;
+    if (!scheduler_layout_checked_add(aligned, size, &end)) return false;
+    *offset = aligned;
+    *cursor = end;
+    return true;
+}
+
+inline bool scheduler_plan_layout(
+    uint64_t task_count, uint64_t aic_task_count, uint64_t aiv_task_count, AicoreSchedulerLayout *layout
+) {
+    if (layout == nullptr || aic_task_count > task_count || aiv_task_count > task_count) return false;
+    AicoreSchedulerLayout next{};
+    next.task_count = task_count;
+    next.aic_task_count = aic_task_count;
+    next.aiv_task_count = aiv_task_count;
+    uint64_t cursor = 0;
+    uint64_t bytes = 0;
+#define SCHEDULER_RESERVE_ARRAY(count, type, field)                 \
+    (scheduler_layout_checked_mul((count), sizeof(type), &bytes) && \
+     scheduler_layout_reserve(&cursor, bytes, alignof(type), &next.field))
+    if (!scheduler_layout_reserve(
+            &cursor, sizeof(SchedulerRunControl), alignof(SchedulerRunControl), &next.run_control_offset
+        ) ||
+        !SCHEDULER_RESERVE_ARRAY(SCHEDULER_WORKER_CAPACITY, AicpuCoreLifecycleTrace, aicpu_lifecycle_traces_offset) ||
+        !SCHEDULER_RESERVE_ARRAY(SCHEDULER_WORKER_CAPACITY, SchedulerWorkerContext, worker_contexts_offset) ||
+        !SCHEDULER_RESERVE_ARRAY(
+            SCHEDULER_WORKER_CAPACITY * SCHEDULER_PENDING_SLOT_COUNT, DispatchPayload, dispatch_payloads_offset
+        ) ||
+        !SCHEDULER_RESERVE_ARRAY(
+            SCHEDULER_WORKER_CAPACITY * SCHEDULER_PENDING_SLOT_COUNT, SchedulerDispatchSlot, dispatch_slots_offset
+        ) ||
+        !SCHEDULER_RESERVE_ARRAY(SCHEDULER_CALLABLE_CAPACITY, uint64_t, callable_addresses_offset) ||
+        !SCHEDULER_RESERVE_ARRAY(task_count, SchedulerTaskMetadata, task_metadata_offset) ||
+        !SCHEDULER_RESERVE_ARRAY(task_count, SchedulerTaskControl, task_controls_offset) ||
+        !SCHEDULER_RESERVE_ARRAY(SCHEDULER_WORKER_CAPACITY, SchedulerCompletionInbox, completion_inboxes_offset) ||
+        !SCHEDULER_RESERVE_ARRAY(
+            SCHEDULER_CORE_TYPE_COUNT * SCHEDULER_WORKER_CAPACITY, SchedulerReadyInbox, ready_inboxes_offset
+        ) ||
+        !SCHEDULER_RESERVE_ARRAY(SCHEDULER_CLUSTER_CAPACITY, SchedulerReadyOwnerState, ready_owner_states_offset) ||
+        !scheduler_layout_reserve(
+            &cursor, sizeof(SchedulerReadyDirectory), alignof(SchedulerReadyDirectory), &next.ready_directory_offset
+        ) ||
+        !scheduler_layout_reserve(
+            &cursor, sizeof(SchedulerGangCoordinator), alignof(SchedulerGangCoordinator), &next.gang_coordinator_offset
+        ) ||
+        !SCHEDULER_RESERVE_ARRAY(SCHEDULER_GANG_COHORT_COUNT, SchedulerGangCohort, gang_cohorts_offset) ||
+        !SCHEDULER_RESERVE_ARRAY(
+            SCHEDULER_GANG_COHORT_COUNT * SCHEDULER_CLUSTER_CAPACITY, SchedulerGangParticipant, gang_participants_offset
+        ) ||
+        !SCHEDULER_RESERVE_ARRAY(SCHEDULER_CLUSTER_CAPACITY, SchedulerGangCommand, gang_commands_offset) ||
+        !SCHEDULER_RESERVE_ARRAY(task_count, SchedulerTaskTrace, trace_cells_offset) ||
+        !scheduler_layout_checked_align(cursor, SCHEDULER_STATE_ALIGNMENT, &next.total_size)) {
+#undef SCHEDULER_RESERVE_ARRAY
+        return false;
+    }
+#undef SCHEDULER_RESERVE_ARRAY
+    *layout = next;
+    return true;
+}
+
+template <typename T>
+inline __host__ __aicore__ __gm__ T *scheduler_state_at(__gm__ void *base, uint64_t offset) {
+    return reinterpret_cast<__gm__ T *>(reinterpret_cast<__gm__ uint8_t *>(base) + offset);
+}
+
+inline bool scheduler_init_data_from_layout(void *base, const AicoreSchedulerLayout &layout) {
+    if (base == nullptr || (reinterpret_cast<uintptr_t>(base) & (SCHEDULER_STATE_ALIGNMENT - 1)) != 0) return false;
+    __builtin_memset(base, 0, static_cast<size_t>(layout.total_size));
+    auto *controls = scheduler_state_at<SchedulerTaskControl>(base, layout.task_controls_offset);
+    for (uint64_t i = 0; i < layout.task_count; ++i) {
+        controls[i].state = static_cast<int64_t>(SchedulerTaskState::BLOCKED);
+        controls[i].wake_list_head = SCHEDULER_WAKE_LIST_OPEN;
+        controls[i].next_waiter = SCHEDULER_TASK_ID_INVALID;
+        controls[i].waiting_producer = static_cast<int32_t>(SCHEDULER_TASK_ID_INVALID);
+    }
+    auto *slots = scheduler_state_at<SchedulerDispatchSlot>(base, layout.dispatch_slots_offset);
+    for (uint64_t i = 0; i < SCHEDULER_WORKER_CAPACITY * SCHEDULER_PENDING_SLOT_COUNT; ++i) {
+        slots[i].task_id = SCHEDULER_TASK_ID_INVALID;
+        slots[i].publication = static_cast<uint64_t>(SchedulerDispatchSlotState::EMPTY);
+    }
+    auto *ready = scheduler_state_at<SchedulerReadyInbox>(base, layout.ready_inboxes_offset);
+    for (uint64_t i = 0; i < SCHEDULER_CORE_TYPE_COUNT * SCHEDULER_WORKER_CAPACITY; ++i)
+        ready[i].head = SCHEDULER_INBOX_EMPTY;
+    auto *ready_owners = scheduler_state_at<SchedulerReadyOwnerState>(base, layout.ready_owner_states_offset);
+    for (uint64_t owner = 0; owner < SCHEDULER_CLUSTER_CAPACITY; ++owner) {
+        for (uint32_t type = 0; type < SCHEDULER_CORE_TYPE_COUNT; ++type)
+            ready_owners[owner].queues[type].pending_endpoints = SCHEDULER_READY_PENDING_EMPTY;
+    }
+    auto *contexts = scheduler_state_at<SchedulerWorkerContext>(base, layout.worker_contexts_offset);
+    for (uint64_t worker = 0; worker < SCHEDULER_WORKER_CAPACITY; ++worker) {
+        contexts[worker].physical_core_id = -1;
+        contexts[worker].cluster_index = UINT64_MAX;
+        contexts[worker].resolver_index = UINT64_MAX;
+        contexts[worker].resolver_worker_id = UINT64_MAX;
+        contexts[worker].cluster_worker_ids[0] = UINT64_MAX;
+        contexts[worker].cluster_worker_ids[1] = UINT64_MAX;
+        contexts[worker].cluster_worker_ids[2] = UINT64_MAX;
+    }
+    auto *coordinator = scheduler_state_at<SchedulerGangCoordinator>(base, layout.gang_coordinator_offset);
+    coordinator->active_dispatch_cohort = UINT64_MAX;
+    coordinator->cohort_count = SCHEDULER_GANG_COHORT_COUNT;
+    auto *cohorts = scheduler_state_at<SchedulerGangCohort>(base, layout.gang_cohorts_offset);
+    for (uint32_t i = 0; i < SCHEDULER_GANG_COHORT_COUNT; ++i) {
+        cohorts[i].state = static_cast<uint64_t>(SchedulerGangCohortState::FREE);
+        cohorts[i].task_id = SCHEDULER_TASK_ID_INVALID;
+    }
+    auto *participants = scheduler_state_at<SchedulerGangParticipant>(base, layout.gang_participants_offset);
+    for (uint32_t i = 0; i < SCHEDULER_GANG_COHORT_COUNT * SCHEDULER_CLUSTER_CAPACITY; ++i)
+        participants[i].task_id = SCHEDULER_TASK_ID_INVALID;
+    return true;
 }

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -906,6 +906,7 @@ target_sources(test_hbg_submit_poison PRIVATE
     ${HBG_RUNTIME_DIR}/shared/runtime.cpp
     ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
 )
+add_a5_hbg_runtime_test(test_a5_hbg_scheduler_contracts a5/test_hbg_scheduler_contracts.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_graph_submit_failure common/test_hbg_graph_submit_failure.cpp)
 target_sources(test_hbg_graph_submit_failure PRIVATE
     ${HBG_RUNTIME_DIR}/orchestrator_core/orchestrator.cpp

--- a/tests/ut/cpp/a5/test_hbg_scheduler_contracts.cpp
+++ b/tests/ut/cpp/a5/test_hbg_scheduler_contracts.cpp
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+#include "runtime_types.h"
+#include "scheduler/scheduler_graph.h"
+#include "scheduler/scheduler_topology.h"
+#include "scheduler/scheduler_types.h"
+
+namespace {
+
+class SchedulerStateBuffer {
+public:
+    explicit SchedulerStateBuffer(const AicoreSchedulerLayout &layout) :
+        base_(std::aligned_alloc(SCHEDULER_STATE_ALIGNMENT, layout.total_size)) {
+        EXPECT_NE(base_, nullptr);
+        if (base_ != nullptr) EXPECT_TRUE(scheduler_init_data_from_layout(base_, layout));
+    }
+    ~SchedulerStateBuffer() { std::free(base_); }
+    void *base() const { return base_; }
+
+private:
+    void *base_{nullptr};
+};
+
+class GraphBuffer {
+public:
+    explicit GraphBuffer(size_t task_count) :
+        task_count_(task_count),
+        image_(std::make_unique<GraphImage>()) {
+        while (capacity_ < std::max<size_t>(task_count, 1))
+            capacity_ <<= 1;
+        if (capacity_ > kMaxTaskCount) throw std::invalid_argument("test graph exceeds GraphBuffer capacity");
+        descriptors_ = image_->descriptors.data();
+        payloads_ = image_->payloads.data();
+        fanins_ = image_->fanins.data();
+        for (size_t task = 0; task < capacity_; ++task) {
+            descriptors_[task].task_id = TaskId{static_cast<uint64_t>(task)};
+            payloads_[task].bind_regions(
+                nullptr, nullptr, fanins_ + task * static_cast<size_t>(SCHEDULER_GRAPH_MAX_FANIN)
+            );
+            if (payloads_[task].fanin_data() == nullptr) {
+                throw std::logic_error("test graph fanin region must share its contiguous image");
+            }
+            for (int slot = 0; slot < 3; ++slot)
+                descriptors_[task].kernel_id[slot] = INVALID_KERNEL_ID;
+        }
+    }
+
+    void executable(size_t task, uint8_t subtask_slot, std::vector<int32_t> fanins = {}) {
+        ASSERT_LT(task, task_count_);
+        ASSERT_LT(subtask_slot, 3);
+        ASSERT_LE(fanins.size(), static_cast<size_t>(SCHEDULER_GRAPH_MAX_FANIN));
+        descriptors_[task].kernel_id[subtask_slot] = 1;
+        payloads_[task].fanin_count = static_cast<int32_t>(fanins.size());
+        ASSERT_TRUE(fanins.empty() || payloads_[task].fanin_data() != nullptr);
+        std::copy(fanins.begin(), fanins.end(), payloads_[task].fanin_data());
+    }
+
+    TaskPayload &payload(size_t task) { return payloads_[task]; }
+
+    SchedulerGraphView graph() const {
+        return {
+            reinterpret_cast<uint64_t>(descriptors_),
+            reinterpret_cast<uint64_t>(payloads_),
+            task_count_,
+            capacity_ - 1,
+        };
+    }
+
+private:
+    static constexpr size_t kMaxTaskCount = 16;
+    struct alignas(64) GraphImage {
+        std::array<TaskDescriptor, kMaxTaskCount> descriptors{};
+        std::array<TaskPayload, kMaxTaskCount> payloads{};
+        std::array<int32_t, kMaxTaskCount * SCHEDULER_GRAPH_MAX_FANIN> fanins{};
+    };
+
+    size_t task_count_;
+    size_t capacity_{1};
+    std::unique_ptr<GraphImage> image_;
+    TaskDescriptor *descriptors_{nullptr};
+    TaskPayload *payloads_{nullptr};
+    int32_t *fanins_{nullptr};
+};
+
+TEST(SchedulerState, PlansAndInitializesReadyState) {
+    EXPECT_EQ(sizeof(TaskPayload), SCHEDULER_GRAPH_TASK_PAYLOAD_STRIDE);
+    EXPECT_EQ(offsetof(TaskPayload, predicate), SCHEDULER_GRAPH_PREDICATE_OFFSET);
+    AicoreSchedulerLayout layout{};
+    ASSERT_TRUE(scheduler_plan_layout(5, 3, 2, &layout));
+    EXPECT_EQ(layout.total_size % SCHEDULER_STATE_ALIGNMENT, 0u);
+    EXPECT_EQ(layout.task_metadata_offset % alignof(SchedulerTaskMetadata), 0u);
+    EXPECT_EQ(layout.ready_inboxes_offset % alignof(SchedulerReadyInbox), 0u);
+    EXPECT_EQ(layout.ready_owner_states_offset % alignof(SchedulerReadyOwnerState), 0u);
+    EXPECT_EQ(layout.ready_directory_offset % alignof(SchedulerReadyDirectory), 0u);
+    EXPECT_EQ(layout.completion_inboxes_offset % alignof(SchedulerCompletionInbox), 0u);
+
+    SchedulerStateBuffer storage(layout);
+    auto *controls = scheduler_state_at<SchedulerTaskControl>(storage.base(), layout.task_controls_offset);
+    for (uint64_t task = 0; task < layout.task_count; ++task) {
+        EXPECT_EQ(controls[task].state, static_cast<int64_t>(SchedulerTaskState::BLOCKED));
+        EXPECT_EQ(controls[task].wake_list_head, SCHEDULER_WAKE_LIST_OPEN);
+    }
+    auto *completion = scheduler_state_at<SchedulerCompletionInbox>(storage.base(), layout.completion_inboxes_offset);
+    for (uint64_t worker = 0; worker < SCHEDULER_WORKER_CAPACITY; ++worker) {
+        EXPECT_EQ(completion[worker].completed_generations[0], 0u);
+        EXPECT_EQ(completion[worker].completed_generations[1], 0u);
+    }
+    auto *ready = scheduler_state_at<SchedulerReadyInbox>(storage.base(), layout.ready_inboxes_offset);
+    for (uint64_t inbox = 0; inbox < SCHEDULER_CORE_TYPE_COUNT * SCHEDULER_WORKER_CAPACITY; ++inbox)
+        EXPECT_EQ(ready[inbox].head, SCHEDULER_INBOX_EMPTY);
+    auto *ready_owners = scheduler_state_at<SchedulerReadyOwnerState>(storage.base(), layout.ready_owner_states_offset);
+    for (uint64_t owner = 0; owner < SCHEDULER_CLUSTER_CAPACITY; ++owner) {
+        for (uint32_t type = 0; type < SCHEDULER_CORE_TYPE_COUNT; ++type)
+            EXPECT_EQ(ready_owners[owner].queues[type].pending_endpoints, SCHEDULER_READY_PENDING_EMPTY);
+    }
+
+    auto *directory = scheduler_state_at<SchedulerReadyDirectory>(storage.base(), layout.ready_directory_offset);
+    auto shard0 = reinterpret_cast<uintptr_t>(&directory->core_types[0][0]);
+    auto shard1 = reinterpret_cast<uintptr_t>(&directory->core_types[0][1]);
+    auto aiv_shard0 = reinterpret_cast<uintptr_t>(&directory->core_types[1][0]);
+    EXPECT_EQ(shard1 - shard0, 64u);
+    EXPECT_EQ(aiv_shard0 - shard0, SCHEDULER_READY_DIRECTORY_SHARD_COUNT * 64u);
+}
+
+TEST(SchedulerState, PreservesCacheLineAlignmentAndArrayStride) {
+    EXPECT_EQ(alignof(SchedulerTaskControl), 128u);
+    EXPECT_EQ(alignof(SchedulerCompletionInbox), 64u);
+    EXPECT_EQ(alignof(SchedulerReadyOwnerState), 128u);
+    EXPECT_EQ(alignof(SchedulerDispatchSlot), 128u);
+    EXPECT_EQ(alignof(SchedulerRunControl), 128u);
+    EXPECT_EQ(alignof(SchedulerWorkerContext), 128u);
+
+    std::array<SchedulerTaskControl, 2> controls{};
+    std::array<SchedulerDispatchSlot, 2> dispatch_slots{};
+    std::array<SchedulerWorkerContext, 2> contexts{};
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(&controls[1]) - reinterpret_cast<uintptr_t>(&controls[0]), 128u);
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(&dispatch_slots[1]) - reinterpret_cast<uintptr_t>(&dispatch_slots[0]), 128u);
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(&contexts[1]) - reinterpret_cast<uintptr_t>(&contexts[0]), 1024u);
+    EXPECT_EQ(offsetof(SchedulerTaskControl, state) / 64, offsetof(SchedulerTaskControl, wake_list_head) / 64);
+    EXPECT_NE(offsetof(SchedulerTaskControl, state) / 64, offsetof(SchedulerTaskControl, next_waiter) / 64);
+    EXPECT_NE(offsetof(SchedulerDispatchSlot, task_id) / 64, offsetof(SchedulerDispatchSlot, publication) / 64);
+}
+
+TEST(SchedulerMetadata, ProjectsExistingSubmitTypesWithoutChangingTheirSemantics) {
+    TaskAttrs attrs{};
+    attrs.set_sync_start();
+    attrs.set_predicate();
+    attrs.set_timing_slot(7);
+    const uint8_t flags = scheduler_task_metadata_flags_from_submit_state(
+        ActiveMask(SUBTASK_MASK_AIC | SUBTASK_MASK_AIV0), attrs, 2, true, false
+    );
+    EXPECT_TRUE(scheduler_task_is_executable(flags));
+    EXPECT_TRUE(scheduler_task_has_fanin(flags));
+    EXPECT_TRUE(scheduler_task_is_mix(flags));
+    EXPECT_TRUE(scheduler_task_is_spmd(flags));
+    EXPECT_TRUE(scheduler_task_requires_sync_start(flags));
+    EXPECT_TRUE(scheduler_task_has_predicate(flags));
+    EXPECT_FALSE(scheduler_task_is_inline(flags));
+    EXPECT_EQ(attrs.timing_slot(), 7);
+
+    const uint8_t inline_flags =
+        scheduler_task_metadata_flags_from_submit_state(ActiveMask(SUBTASK_MASK_AIV0), TaskAttrs{}, 1, false, true);
+    EXPECT_EQ(inline_flags, SCHEDULER_TASK_EXECUTABLE | SCHEDULER_TASK_INLINE);
+}
+
+TEST(SchedulerGraph, NonPowerOfTwoWindowKeepsDirectTaskIdIndexing) {
+    struct alignas(64) GraphImage {
+        std::array<TaskDescriptor, 3> descriptors{};
+        std::array<TaskPayload, 3> payloads{};
+        std::array<std::array<int32_t, SCHEDULER_GRAPH_MAX_FANIN>, 3> fanins{};
+    } image;
+    auto &descriptors = image.descriptors;
+    auto &payloads = image.payloads;
+    auto &fanins = image.fanins;
+    for (size_t task = 0; task < descriptors.size(); ++task) {
+        descriptors[task].task_id = TaskId{task};
+        for (int slot = 0; slot < 3; ++slot)
+            descriptors[task].kernel_id[slot] = INVALID_KERNEL_ID;
+        payloads[task].bind_regions(nullptr, nullptr, fanins[task].data());
+    }
+    descriptors[1].kernel_id[0] = 1;
+    SchedulerGraphView graph{
+        reinterpret_cast<uint64_t>(descriptors.data()), reinterpret_cast<uint64_t>(payloads.data()), 3, 2
+    };
+
+    EXPECT_EQ(scheduler_graph_descriptor(graph, 1), reinterpret_cast<uint8_t *>(&descriptors[1]));
+    EXPECT_EQ(scheduler_graph_payload(graph, 1), reinterpret_cast<uint8_t *>(&payloads[1]));
+    SchedulerTaskShape shape{};
+    EXPECT_EQ(scheduler_classify_task_shape(graph, 1, &shape), SchedulerGraphResult::OK);
+    EXPECT_EQ(shape.task_id, 1);
+}
+
+TEST(SchedulerGraph, ValidatesNonEmptyFanins) {
+    GraphBuffer graph(3);
+    graph.executable(0, 0);
+    graph.executable(1, 0, {0});
+    graph.executable(2, 0, {1, 1});
+
+    SchedulerTaskShape shape{};
+    EXPECT_EQ(scheduler_classify_task_shape(graph.graph(), 1, &shape), SchedulerGraphResult::OK);
+    EXPECT_EQ(scheduler_classify_task_shape(graph.graph(), 2, &shape), SchedulerGraphResult::INVALID_FANIN_ID);
+}
+
+TEST(SchedulerGraph, RejectsUnboundNonEmptyFaninRegion) {
+    GraphBuffer graph(2);
+    graph.executable(0, 0);
+    graph.executable(1, 0, {0});
+    graph.payload(1).bind_regions(nullptr, nullptr, nullptr);
+
+    SchedulerTaskShape shape{};
+    EXPECT_EQ(scheduler_classify_task_shape(graph.graph(), 1, &shape), SchedulerGraphResult::INVALID_FANIN_ID);
+}
+
+TEST(SchedulerDispatchPayload, DisablesDeferredCompletionWithoutASlab) {
+    GraphBuffer graph(1);
+    graph.executable(0, 0);
+    DispatchPayload payload{};
+    payload.local_context.async_ctx.task_token = TaskId{17};
+    SchedulerTaskInfo task{0, 1, 0, CoreType::AIC};
+
+    ASSERT_EQ(
+        scheduler_materialize_task_payload_resolved(graph.graph(), task, 0x1000, &payload), SchedulerGraphResult::OK
+    );
+    EXPECT_TRUE(payload.local_context.async_ctx.task_token.is_invalid());
+    EXPECT_EQ(payload.global_context.sub_block_id, 0);
+
+    task.subtask_slot = 2;
+    task.core_type = CoreType::AIV;
+    ASSERT_EQ(
+        scheduler_materialize_task_payload_resolved(graph.graph(), task, 0x1000, &payload), SchedulerGraphResult::OK
+    );
+    EXPECT_EQ(payload.global_context.sub_block_id, 1);
+}
+
+TEST(SchedulerDispatchPayload, RejectsInvalidGraphBoundsBeforeReadingPayload) {
+    GraphBuffer graph(1);
+    graph.executable(0, 0);
+    DispatchPayload payload{};
+
+    SchedulerTaskInfo out_of_range{1, 1, 0, CoreType::AIC};
+    EXPECT_EQ(
+        scheduler_materialize_task_payload_resolved(graph.graph(), out_of_range, 0x1000, &payload),
+        SchedulerGraphResult::INVALID_TASK_COUNT
+    );
+
+    SchedulerGraphView missing_payload = graph.graph();
+    missing_payload.payloads_address = 0;
+    SchedulerTaskInfo valid_task{0, 1, 0, CoreType::AIC};
+    EXPECT_EQ(
+        scheduler_materialize_task_payload_resolved(missing_payload, valid_task, 0x1000, &payload),
+        SchedulerGraphResult::INVALID_TASK_COUNT
+    );
+}
+
+TEST(SchedulerDispatchPayload, RejectsUnboundNonEmptyArgumentRegions) {
+    GraphBuffer graph(1);
+    graph.executable(0, 0);
+    DispatchPayload payload{};
+    SchedulerTaskInfo task{0, 1, 0, CoreType::AIC};
+
+    graph.payload(0).tensor_count = 1;
+    EXPECT_EQ(
+        scheduler_materialize_task_payload_resolved(graph.graph(), task, 0x1000, &payload),
+        SchedulerGraphResult::INVALID_ARGUMENTS
+    );
+
+    graph.payload(0).tensor_count = 0;
+    graph.payload(0).scalar_count = 1;
+    EXPECT_EQ(
+        scheduler_materialize_task_payload_resolved(graph.graph(), task, 0x1000, &payload),
+        SchedulerGraphResult::INVALID_ARGUMENTS
+    );
+}
+
+TEST(SchedulerClusterTopology, UsesMixedKernelLaunchCoordinate) {
+    constexpr int32_t kClusters = 4;
+    SchedulerClusterCoordinate coordinate{};
+    ASSERT_TRUE(scheduler_cluster_coordinate_from_worker(2, true, kClusters, 2, &coordinate));
+    EXPECT_EQ(coordinate.cluster_index, 2);
+    EXPECT_EQ(coordinate.cluster_lane, 0);
+    ASSERT_TRUE(scheduler_cluster_coordinate_from_worker(9, false, kClusters, 2, &coordinate));
+    EXPECT_EQ(coordinate.cluster_index, 2);
+    EXPECT_EQ(coordinate.cluster_lane, 2);
+    EXPECT_FALSE(scheduler_cluster_coordinate_from_worker(12, false, kClusters, 2, &coordinate));
+}
+
+}  // namespace


### PR DESCRIPTION
## Why

The A5 `host_build_graph` scheduler needs a stable shared contract before dependency resolution and dispatch can move onto resident AICore workers. The contract must preserve the existing `ActiveMask`, `TaskAttrs`, `TaskPayload`, and legacy AICPU scheduler behavior while giving later scheduler layers bounded graph access and cache-line-stable state.

## What changed

- Add the scheduler state layout, sizing and initialization helpers, graph view, GM access primitives, and worker-to-cluster topology mapping.
- Project compact AICore metadata from the existing submit contracts without changing their semantics.
- Keep direct whole-graph task indexing for arbitrary capacities, reject invalid graph and fanin bounds before payload access, and bind the fanin wire offset to `TaskPayload`.
- Add focused C++ coverage for state planning/alignment, metadata projection, non-power-of-two indexing, fanin validation, dispatch guards, and mixed-kernel launch coordinates.
- Keep the legacy AICPU scheduler buildable; this PR defines contracts only and does not cut production scheduling over to AICore.

## Testing

- [x] `cmake -B tests/ut/cpp/build -S tests/ut/cpp && cmake --build tests/ut/cpp/build --target test_a5_hbg_scheduler_contracts -j 16 && ctest --test-dir tests/ut/cpp/build -R "^test_a5_hbg_scheduler_contracts$" --output-on-failure` — target built and 1/1 test passed.
- [x] `git diff --check origin/main...HEAD` — passed.
- `pre-commit run --from-ref origin/main --to-ref HEAD` passed every other applicable hook and successfully built the sim runtimes, but the local image has no `clang-tidy` executable, so that hook could not run locally; CI will run the complete gate.