### PR TITLE
Fix: preserve explicit dependency flags in dep_gen replay

### DIFF
--- a/docs/dfx/dep-gen.md
+++ b/docs/dfx/dep-gen.md
@@ -73,6 +73,10 @@ inputs to each submit are captured and the graph is reconstructed afterwards.
   This is the guarantee against silent shotgun modifications — anyone
   who changes `compute_task_fanin` semantics will trip the gate
   immediately and know to update the annotated mirror.
+  Explicit deps are a common captured input to both passes, so this gate
+  cannot independently validate their recorded kind bytes. The a2a3/a5
+  dep_gen chain scene tests validate that capture/replay round-trip across
+  inline and overflow records.
 - **Output.** `<output_prefix>/deps.json` — strided-Tensor schema with
   `tasks[]`, `tensors[]`, and tensor-annotated `edges[]` (see §4).
 
@@ -218,7 +222,7 @@ Each edge is `{pred, succ}` plus annotation. Fields:
 | `pred`, `succ` | uint64 (string) | always | `TaskId::raw` of producer and consumer |
 | `arg` | int32 | always | Consumer's arg-slot index; `-1` for `explicit` source |
 | `source` | string | always | `explicit` (from `explicit_deps[]`), `creator` (`owner_task_id` retention), or `tensormap` (overlap lookup hit) |
-| `flags` | string array | always | Subset of `["wait", "retain"]` — the edge's `DepFlags`. `wait` = ordering (readiness); `retain` = producer lifetime held until the consumer releases. `creator` edges are `["wait","retain"]`; `tensormap` edges `["wait"]`. `explicit` edges are **always recorded as `["wait","retain"]`**: the `DepGenRecord` does not carry per-dep kinds, so a replayed explicit dep cannot distinguish the ordering-only `CoreTaskArgsWithDeps::add_dep_wait()` API from the default. The differential gate is unaffected (both passes read the same constant). At runtime an `add_dep_wait()` edge is genuinely `["wait"]`; that distinction is a known replay limitation, not written to `deps.json`. |
+| `flags` | string array | `tensormap_and_ringbuffer` | Subset of `["wait", "retain"]` — the edge's `DepFlags`. `wait` = ordering (readiness); `retain` = producer lifetime held until the consumer releases. `creator` edges are `["wait","retain"]`; `tensormap` edges `["wait"]`. `explicit` edges start with the per-dependency kind captured at submit time, so `CoreTaskArgsWithDeps::add_dep_wait()` emits `["wait"]` while the default dependency kind emits `["wait","retain"]`. When the same producer is also the creator of an input, replay matches runtime fanin dedup by OR-accumulating the creator's flags into the explicit edge. The host_build_graph writer does not currently emit this field. |
 | `overlap` | string | `source=tensormap` | `covered` (producer slice fully contains consumer slice) or `other` |
 | `tensor_id` | uint64 (string) | not `explicit` | Identity of the underlying tensor; cross-references `tensors[]` |
 | `consumer_dtype` | string | not `explicit` | Element type the consumer reads as |
@@ -365,13 +369,14 @@ slots that overlay normal record slots in the buffer.
 | Submit `explicit_dep_count` | Chain shape | Per-submit slots used |
 | --------------------------- | ----------- | --------------------- |
 | `0 ≤ dc ≤ 64` | base only — fast path, no chain bookkeeping | 1 |
-| `65 ≤ dc ≤ 646` | base (64 deps) + 1 overflow (up to 582 deps) | 2 |
-| `647 ≤ dc ≤ 1228` | base + 2 overflow | 3 |
-| general | base + `⌈(dc − 64) / 582⌉` overflow | `1 + ⌈(dc − 64) / 582⌉` |
+| `65 ≤ dc ≤ 588` | base (64 deps) + 1 overflow (up to 524 deps) | 2 |
+| `589 ≤ dc ≤ 1112` | base + 2 overflow | 3 |
+| general | base + `⌈(dc − 64) / 524⌉` overflow | `1 + ⌈(dc − 64) / 524⌉` |
 
-**Wire format.** An overflow record reinterprets the same 4672-byte slot
-as `{ task_id (8) + flags (4) + dep_count (2) + _reserved (2) + deps[582] }` —
-no tensor blobs (those live on the base record). Replay distinguishes
+**Wire format.** An overflow record reinterprets the same 4736-byte slot
+as `{ task_id (8) + flags (4) + dep_count (2) + _reserved (2) +
+deps[524] + kinds[524] }`; `kinds[]` is a byte-for-byte parallel array of
+`DepFlags`. There are no tensor blobs (those live on the base record). Replay distinguishes
 the two views by `flags & DEP_GEN_FLAG_OVERFLOW`. Chain records always
 share the base's `task_id`, and the last one sets
 `DEP_GEN_FLAG_LAST_OVERFLOW` so replay knows the chain is complete
@@ -387,7 +392,7 @@ base via `task_id`.
 
 **Truncation tail.** A submit whose chain exceeds the buffer's slot
 budget (`PLATFORM_DEP_GEN_RECORDS_PER_BUFFER = 1024` slots → roughly
-`64 + 1023 × 582 = 595450` deps max in the best case) is logged via
+`64 + 1023 × 524 = 536116` deps max in the best case) is logged via
 `LOG_ERROR` and truncated to the largest dc that fits. Runtime
 correctness is unaffected — `CoreTaskArgs::set_dependencies` keeps the full dep
 list; only the dep_gen replay graph loses the tail.
@@ -398,7 +403,7 @@ list; only the dep_gen replay graph loses the tail.
 
 | Layer | File | Role |
 | ----- | ---- | ---- |
-| Shared-mem layout | `src/{a2a3,a5}/platform/include/common/dep_gen.h` | `DepGenRecord` (4672 B base, cache-line aligned, ≤64 inline explicit_deps, per-task `block_num`) + `DepGenOverflowRecord` chain view (≤582 deps per slot) + SPSC ring + per-thread ready queue. Byte-identical layout across platforms. |
+| Shared-mem layout | `src/common/platform/include/common/dep_gen.h` | `DepGenRecord` (4736 B base, cache-line aligned, ≤64 inline explicit deps and parallel kinds, per-task `block_num`) + `DepGenOverflowRecord` chain view (≤524 dep/kind pairs per slot) + SPSC ring + per-thread ready queue. The layout is shared across platforms. |
 | AICPU writer | `src/{a2a3,a5}/platform/include/aicpu/dep_gen_collector_aicpu.h`, `src/common/platform/shared/aicpu/dep_gen_collector_aicpu.cpp` | Single-instance write path; weak-fallback exported to host build. Both platforms share the same writer implementation — the writer accesses its own device-side view of shared memory, independent of how host↔device transport is implemented. |
 | Host collector | `src/common/platform/include/host/dep_gen_collector.h`, `src/common/platform/shared/host/dep_gen_collector.cpp` | `ProfilerBase<DepGenCollector, DepGenModule>` — drains ring → `records_` vector. On non-SVM platforms it uses the base `alloc_paired_buffer`, which malloc's a host shadow + `copy_to_device`'s it and registers it via `add_malloc_shadow` so teardown can free it; `reconcile_counters` explicitly `copy_from_device`'s the BufferState before reading, and `finalize` lets `BufferPoolManager::clear_mappings()` release all shadows as the single source of truth. |
 | Capture call site (device-orch) | `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp` `submit_task_common` | One conditional block that snapshots inputs into the ring when `is_dep_gen_enabled()`; fires for both `submit_task` and `submit_dummy_task`. The schema carries `kernel_ids[3] = {aic, aiv0, aiv1}` so the swimlane post-processor can resolve `task_id → kernel` from `deps.json` at level=1 where the AICore record is the sole device-side identity source. Inactive subslots stay at `INVALID_KERNEL_ID = -1`. It also carries the SPMD logical block num (`block_num` on a2a3, `core_num` on a5's launch spec) as `tasks[].block_num`. |

--- a/docs/dfx/dfx-buffer-capacity-audit.md
+++ b/docs/dfx/dfx-buffer-capacity-audit.md
@@ -81,7 +81,7 @@ drains" — **independent of how many buffers you preallocate.** Hence
 | scope_stats | low (per scope enter/exit) | small (52B) | **≈1** | 8 | 8× |
 | l2 task | high (one per task, flood is huge) | small (32B) | **≈4** | 4/8 | 1–2× |
 | l2 phase | high | small W **but buffer is huge (16384)** | T_fill ≫ W → **≪16** | 16 | several× |
-| dep_gen | high (per submit, AICPU at full speed) | **large** (4672B record) | **explodes** under flood | 4 | far short |
+| dep_gen | high (per submit, AICPU at full speed) | **large** (4736B current record) | **explodes** under flood | 4 | far short |
 
 Reasoning per row:
 
@@ -95,7 +95,7 @@ Reasoning per row:
 - **l2 phase**: viewed differently — the per-buffer capacity 16384 is enormous, so
   filling one takes `T_fill = 16384/λ`, far larger than W (recycle latency). So the
   number of phase buffers simultaneously in flight is ≪ 16. Configured 16 is over.
-- **dep_gen**: λ high × W **large** (4672B record drains slowly) → under flood L
+- **dep_gen**: λ high × W **large** (4736B current record drains slowly) → under flood L
   exceeds any realistic config → **sizing can't fix it** (proven via the dynamic
   form `drop ∝ (λ−µ)T` in §5.2).
 
@@ -235,8 +235,9 @@ drop ≈ (P − R) × T − N × S      P=produce rate, R=host drain rate, N×S=
   | 8×2048 SLOT8 | 16384 | 73 MB | 24576 |
   | batch=16 (4096 submits/burst) | — | — | **0** |
 
-- **The only variable is R** (host drain rate), pinned by record size (4672B) +
-  bandwidth.
+- **The only variable is R** (host drain rate), pinned by record size + bandwidth.
+  These measurements used the then-current 4672B record; the current 4736B
+  dep/kind wire record is 1.37% larger, which does not change the sizing conclusion.
 - **Corollary**: a real layer-serial decoder (qwen3: 40 residual layers, layer
   N+1 waits on N) has `P<R` and is already zero-drop → **dep_gen needs no
   enlargement.** Surviving a 65536 flood would need ≥146 MB in flight, paid for a
@@ -319,7 +320,7 @@ separate fix (fewer threads / merged mgmt / scheduling priority).
 | l2 AicoreTask | `AICORE_BUFFER_SIZE` (1024) | `AICORE_BUFFERS_PER_CORE` (4) | 32B | per-core |
 | l2 phase | `PHASE_RECORDS_PER_THREAD` (16384) | `PROF_{SCHED,ORCH}_BUFFERS_PER_THREAD` (6/8) | 64/32B | per-thread |
 | pmu | `PMU_RECORDS_PER_BUFFER` (512) | `PMU_BUFFERS_PER_CORE` (2) | 64B | per-core |
-| dep_gen | `DEP_GEN_RECORDS_PER_BUFFER` (1024) | `DEP_GEN_BUFFERS_PER_INSTANCE` (4) | 4672B | per-instance |
+| dep_gen | `DEP_GEN_RECORDS_PER_BUFFER` (1024) | `DEP_GEN_BUFFERS_PER_INSTANCE` (4) | 4736B | per-instance |
 | scope_stats | `SCOPE_STATS_RECORDS_PER_BUFFER` (512) | `SCOPE_STATS_BUFFERS_PER_INSTANCE` (4) | 52B | per-instance |
 | args_dump | `PLATFORM_DUMP_RECORDS_PER_BUFFER` (256) + arena | `PLATFORM_DUMP_BUFFERS_PER_THREAD` (8) | 128B+tensor | per-thread |
 

--- a/docs/dfx/global-backpressure-design.md
+++ b/docs/dfx/global-backpressure-design.md
@@ -86,9 +86,16 @@ Every barrier and contention spin is bounded by
 scales per arch — a2a3 50 MHz, a5 1000 MHz). The budget exists **only** to break
 an infinite spin on host crash or hardware failure; it is not a normal-path
 wait. When it expires the writer breaks to its single failure exit
-(`return false`), and the caller (`switch_buffer`) accounts the dropped records.
-A 30-second expiry therefore means "the host is gone", not "the buffer was
-briefly full".
+(`return false`) only while ownership remains on the device: a full ready queue
+before publication, or an empty free queue while claiming a replacement. The
+caller then accounts the affected records as dropped.
+
+The push gate runs after the writer publishes the ready entry and advances the
+queue tail. That tail advance transfers ownership to the host and cannot be
+rolled back, so a push-gate timeout ends the park but the enqueue remains
+successful; reporting failure there would let the caller clear and reuse a
+host-owned buffer. A 30-second expiry still means "the host is gone", not "the
+buffer was briefly full".
 
 ## Host side — the freeze state machine
 

--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -337,14 +337,14 @@ constexpr int PLATFORM_PMU_TIMEOUT_SECONDS = 30;
 
 /**
  * Number of DepGenRecord entries per DepGenBuffer.
- * Each DepGenRecord is 4672 B (16 ChipTensor blobs + small header), so a buffer
+ * Each DepGenRecord is 4736 B (32 ChipTensor blobs + small header), so a buffer
  * of 1024 records is ~4.6 MB; draining one copies that over SVM.
  * Guaranteed one-shot capacity = BUFFERS_PER_INSTANCE × RECORDS_PER_BUFFER
  * records — the size of a back-to-back submit flood the pool absorbs even if
  * the host never drains. At 4×1024 that is 4096 submits, which aligns
  * dep_gen's in-flight record count with the scope_stats / l2 AicoreTask pools
  * (also 4096) per the #977 cross-subsystem review. By in-flight BYTES dep_gen
- * cannot align (its 4672 B record is 70–90× the others); that tension is
+ * cannot align (its 4736 B record is 70–90× the others); that tension is
  * inherent — see docs/dfx/dfx-buffer-capacity-audit.md.
  * History: original 32 (commit 77ef83c0) → #977 commit 3f977e54 overshot to
  * 2048 → 1024 here (#977 Primary's actual proposal; the 2× was no gain).

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -42,8 +42,10 @@
  * knows to mirror the change in the annot pass.
  *
  * STEP 1 (explicit_deps) is emitted at the call site (per dep_compute.h's
- * "kept at call site" note); both passes run the same explicit-deps loop, so
- * the comparison covers it too.
+ * "kept at call site" note). Both passes seed explicit edges from the same
+ * captured dep/kind arrays, so the differential check includes their effect
+ * but cannot independently validate those bytes. Scene tests validate the
+ * capture/replay round-trip for explicit kinds.
  *
  * STEP 4 (`register_task_outputs`) runs on BOTH tensor maps after both passes
  * complete, keeping `tm_oracle` and `tm_annot` bit-equivalent for the next
@@ -545,10 +547,12 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
     // (producer, flags) mapping rather than the producer-ID set alone.
     std::unordered_map<uint64_t, DepFlags> oracle_preds;
     std::unordered_map<uint64_t, DepFlags> annot_preds;
+    std::unordered_map<uint64_t, size_t> explicit_edge_index;
 
     // Scratch buffer for assembling full dep lists across overflow chains.
     // Declared outside the loop so it can be reused (clear() keeps capacity).
     std::vector<uint64_t> full_deps_buf;
+    std::vector<uint8_t> full_kinds_buf;
 
     for (size_t rec_i = 0; rec_i < num_records; rec_i++) {
         const DepGenRecord &rec = records[rec_i];
@@ -563,6 +567,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
 
         oracle_preds.clear();
         annot_preds.clear();
+        explicit_edge_index.clear();
 
         int32_t tc = static_cast<int32_t>(rec.tensor_count);
         if (tc > CORE_MAX_TENSOR_ARGS) {
@@ -575,16 +580,18 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
 
         // Assemble the full dep list. Fast path: ≤ DEP_GEN_MAX_EXPLICIT_DEPS,
         // no chain, point straight at rec.explicit_deps. Slow path: gather
-        // base + chain into full_deps_buf and point at the buffer.
+        // base + chain into full_deps_buf/full_kinds_buf and point at the buffers.
         //
         // `explicit_dep_count` / `over->dep_count` originate from device
         // shared memory and are bounded by the writer to the array sizes, but
         // we clamp on read too so a corrupted record never drives an OOB read
-        // off the end of rec.explicit_deps[64] / over->deps[582].
+        // off the end of rec.explicit_deps[64] / over->deps[524].
         const uint64_t *deps_data;
+        const uint8_t *kinds_data;
         int32_t dc;
         if (rec.flags & DEP_GEN_FLAG_HAS_OVERFLOW) {
             full_deps_buf.clear();
+            full_kinds_buf.clear();
             uint16_t base_dc = rec.explicit_dep_count;
             if (base_dc > DEP_GEN_MAX_EXPLICIT_DEPS) {
                 LOG_ERROR(
@@ -594,7 +601,9 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
                 base_dc = DEP_GEN_MAX_EXPLICIT_DEPS;
             }
             full_deps_buf.reserve(static_cast<size_t>(base_dc) + DEP_GEN_OVERFLOW_DEPS_PER_RECORD);
+            full_kinds_buf.reserve(static_cast<size_t>(base_dc) + DEP_GEN_OVERFLOW_DEPS_PER_RECORD);
             full_deps_buf.insert(full_deps_buf.end(), rec.explicit_deps, rec.explicit_deps + base_dc);
+            full_kinds_buf.insert(full_kinds_buf.end(), rec.explicit_dep_kinds, rec.explicit_dep_kinds + base_dc);
             bool chain_complete = false;
             for (size_t j = rec_i + 1; j < num_records; j++) {
                 const DepGenRecord &maybe = records[j];
@@ -623,6 +632,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
                     over_dc = DEP_GEN_OVERFLOW_DEPS_PER_RECORD;
                 }
                 full_deps_buf.insert(full_deps_buf.end(), over->deps, over->deps + over_dc);
+                full_kinds_buf.insert(full_kinds_buf.end(), over->kinds, over->kinds + over_dc);
                 if (over->flags & DEP_GEN_FLAG_LAST_OVERFLOW) {
                     chain_complete = true;
                     break;
@@ -636,9 +646,11 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
                 );
             }
             deps_data = full_deps_buf.data();
+            kinds_data = full_kinds_buf.data();
             dc = static_cast<int32_t>(full_deps_buf.size());
         } else {
             deps_data = rec.explicit_deps;
+            kinds_data = rec.explicit_dep_kinds;
             uint16_t base_dc = rec.explicit_dep_count;
             if (base_dc > DEP_GEN_MAX_EXPLICIT_DEPS) {
                 LOG_ERROR(
@@ -698,27 +710,43 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         task_table.push_back(std::move(task_entry));
 
         // ============ STEP 1 — explicit_deps (call-site emit) ============
-        // Same loop on both passes; they MUST produce identical sets here
-        // because they read the same record. Annot records explicit edges
-        // with consumer_arg_idx = -1 (not tied to any tensor arg). Reads
-        // from deps_data (base record's explicit_deps[] on fast path, the
-        // gathered base+chain buffer on overflow path).
+        // Both passes seed explicit edges from the same captured record. The
+        // differential check therefore covers their interaction with creator
+        // and tensormap edges, while scene tests independently validate the
+        // captured kind bytes. Annot records explicit edges with
+        // consumer_arg_idx = -1 (not tied to any tensor arg). deps_data comes
+        // from the base record on the fast path or the gathered base+chain
+        // buffer on overflow; kinds_data is its parallel semantics array.
         for (int32_t i = 0; i < dc; i++) {
             uint64_t pred_raw = deps_data[i];
-            // Explicit deps are recorded conservatively as DEP_WAIT|DEP_RETAIN;
-            // the DepGenRecord does not carry per-dep kinds, matching Arg's
-            // set_dependencies default.
-            oracle_preds[pred_raw] |= (DEP_WAIT | DEP_RETAIN);
+            const uint8_t raw_kind = kinds_data[i];
+            constexpr uint8_t kKnownDepFlags = static_cast<uint8_t>(DEP_WAIT | DEP_RETAIN);
+            if ((raw_kind & static_cast<uint8_t>(~kKnownDepFlags)) != 0) {
+                // Unknown semantics make the artifact untrustworthy. Reject
+                // the trace instead of emitting a plausible but altered graph.
+                LOG_ERROR(
+                    "dep_gen replay: invalid explicit dep flags 0x%02x at task_id=%" PRIu64 " dep_idx=%d", raw_kind,
+                    rec.task_id, i
+                );
+                tm_oracle.destroy();
+                tm_annot.destroy();
+                return -7;
+            }
+            const DepFlags kind = static_cast<DepFlags>(raw_kind);
+            oracle_preds[pred_raw] |= kind;
             bool first = annot_preds.find(pred_raw) == annot_preds.end();
-            annot_preds[pred_raw] |= (DEP_WAIT | DEP_RETAIN);
+            annot_preds[pred_raw] |= kind;
             if (first) {
                 EdgeAnnot e{};
                 e.pred = pred_raw;
                 e.succ = rec.task_id;
                 e.consumer_arg_idx = -1;
                 e.source = EdgeSource::EXPLICIT;
-                e.flags = DEP_WAIT | DEP_RETAIN;
+                e.flags = kind;
+                explicit_edge_index.emplace(pred_raw, annot_edges.size());
                 annot_edges.push_back(e);
+            } else {
+                annot_edges[explicit_edge_index.at(pred_raw)].flags |= kind;
             }
         }
 
@@ -742,6 +770,10 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
                 bool first = annot_preds.find(producer.raw) == annot_preds.end();
                 annot_preds[producer.raw] |= (DEP_WAIT | DEP_RETAIN);
                 if (!first) {
+                    auto explicit_it = explicit_edge_index.find(producer.raw);
+                    if (explicit_it != explicit_edge_index.end()) {
+                        annot_edges[explicit_it->second].flags |= (DEP_WAIT | DEP_RETAIN);
+                    }
                     return;  // already covered by an earlier emit on this record
                 }
                 EdgeAnnot e{};

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
@@ -62,7 +62,8 @@ static_assert(
 // (same pattern as get_sys_cnt_aicpu / chip_swimlane_aicpu_record_orch_phase below).
 extern "C" __attribute__((weak, visibility("hidden"))) bool is_dep_gen_enabled() { return false; }
 __attribute__((weak, visibility("hidden"))) void dep_gen_aicpu_record_submit(
-    uint64_t, bool, bool, int, const void *const *, const uint8_t *, int, const uint64_t *, int, const int32_t[3]
+    uint64_t, bool, bool, int, const void *const *, const uint8_t *, int, const uint64_t *, const uint8_t *, uint8_t,
+    int, const int32_t[3]
 ) {}
 
 // Scope_stats enable gate, queried via the same predicate idiom as
@@ -936,7 +937,8 @@ static TaskOutputTensors submit_task_common(
         dep_gen_aicpu_record_submit(
             task_id.raw, orch->in_manual_scope(), args.allow_early_resolve(), tc, tensor_ptrs, arg_types_u8,
             static_cast<int>(args.explicit_dep_count()), reinterpret_cast<const uint64_t *>(args.explicit_deps_data()),
-            args.launch_spec.block_num(), kernel_ids_capture
+            reinterpret_cast<const uint8_t *>(args.explicit_dep_kinds_data()),
+            static_cast<uint8_t>(DEP_WAIT | DEP_RETAIN), args.launch_spec.block_num(), kernel_ids_capture
         );
     }
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/types.h
@@ -496,6 +496,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
     }
 
     const TaskId *explicit_deps_data() const { return explicit_deps_; }
+    const DepFlags *explicit_dep_kinds_data() const { return explicit_dep_kinds_; }
 
     /**
      * Add scalar values. Types are deduced per argument; each value is

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -378,14 +378,14 @@ constexpr int PLATFORM_PMU_TIMEOUT_SECONDS = 30;
 
 /**
  * Number of DepGenRecord entries per DepGenBuffer.
- * Each DepGenRecord is 4672 B (16 ChipTensor blobs + small header). At 4×1024 =
+ * Each DepGenRecord is 4736 B (32 ChipTensor blobs + small header). At 4×1024 =
  * 4096 in-flight records (~19 MB), aligning dep_gen's in-flight count with the
  * scope_stats / l2 AicoreTask pools (also 4096) per the #977 cross-subsystem
  * review. History: original 32 (dropped 50% on unroll Case1) → #977 commit
  * overshot to 2048 → 1024 here (#977 Primary's actual proposal). Flood drops
  * are rate-bound, not capacity-bound — buffer sizing cannot fix them; real
  * dependency-paced workloads never drop. dep_gen is opt-in (--enable-dep-gen).
- * a5 record size (4672 B) and cohort (4096) are identical to a2a3, so the same
+ * a5 record size (4736 B) and cohort (4096) are identical to a2a3, so the same
  * 1024 applies; **a5-silicon validation still pending**. See
  * docs/dfx/dfx-buffer-capacity-audit.md.
  */

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -42,8 +42,10 @@
  * knows to mirror the change in the annot pass.
  *
  * STEP 1 (explicit_deps) is emitted at the call site (per dep_compute.h's
- * "kept at call site" note); both passes run the same explicit-deps loop, so
- * the comparison covers it too.
+ * "kept at call site" note). Both passes seed explicit edges from the same
+ * captured dep/kind arrays, so the differential check includes their effect
+ * but cannot independently validate those bytes. Scene tests validate the
+ * capture/replay round-trip for explicit kinds.
  *
  * STEP 4 (`register_task_outputs`) runs on BOTH tensor maps after both passes
  * complete, keeping `tm_oracle` and `tm_annot` bit-equivalent for the next
@@ -545,10 +547,12 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
     // (producer, flags) mapping rather than the producer-ID set alone.
     std::unordered_map<uint64_t, DepFlags> oracle_preds;
     std::unordered_map<uint64_t, DepFlags> annot_preds;
+    std::unordered_map<uint64_t, size_t> explicit_edge_index;
 
     // Scratch buffer for assembling full dep lists across overflow chains.
     // Declared outside the loop so it can be reused (clear() keeps capacity).
     std::vector<uint64_t> full_deps_buf;
+    std::vector<uint8_t> full_kinds_buf;
 
     for (size_t rec_i = 0; rec_i < num_records; rec_i++) {
         const DepGenRecord &rec = records[rec_i];
@@ -563,6 +567,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
 
         oracle_preds.clear();
         annot_preds.clear();
+        explicit_edge_index.clear();
 
         int32_t tc = static_cast<int32_t>(rec.tensor_count);
         if (tc > CORE_MAX_TENSOR_ARGS) {
@@ -575,16 +580,18 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
 
         // Assemble the full dep list. Fast path: ≤ DEP_GEN_MAX_EXPLICIT_DEPS,
         // no chain, point straight at rec.explicit_deps. Slow path: gather
-        // base + chain into full_deps_buf and point at the buffer.
+        // base + chain into full_deps_buf/full_kinds_buf and point at the buffers.
         //
         // `explicit_dep_count` / `over->dep_count` originate from device
         // shared memory and are bounded by the writer to the array sizes, but
         // we clamp on read too so a corrupted record never drives an OOB read
-        // off the end of rec.explicit_deps[64] / over->deps[582].
+        // off the end of rec.explicit_deps[64] / over->deps[524].
         const uint64_t *deps_data;
+        const uint8_t *kinds_data;
         int32_t dc;
         if (rec.flags & DEP_GEN_FLAG_HAS_OVERFLOW) {
             full_deps_buf.clear();
+            full_kinds_buf.clear();
             uint16_t base_dc = rec.explicit_dep_count;
             if (base_dc > DEP_GEN_MAX_EXPLICIT_DEPS) {
                 LOG_ERROR(
@@ -594,7 +601,9 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
                 base_dc = DEP_GEN_MAX_EXPLICIT_DEPS;
             }
             full_deps_buf.reserve(static_cast<size_t>(base_dc) + DEP_GEN_OVERFLOW_DEPS_PER_RECORD);
+            full_kinds_buf.reserve(static_cast<size_t>(base_dc) + DEP_GEN_OVERFLOW_DEPS_PER_RECORD);
             full_deps_buf.insert(full_deps_buf.end(), rec.explicit_deps, rec.explicit_deps + base_dc);
+            full_kinds_buf.insert(full_kinds_buf.end(), rec.explicit_dep_kinds, rec.explicit_dep_kinds + base_dc);
             bool chain_complete = false;
             for (size_t j = rec_i + 1; j < num_records; j++) {
                 const DepGenRecord &maybe = records[j];
@@ -623,6 +632,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
                     over_dc = DEP_GEN_OVERFLOW_DEPS_PER_RECORD;
                 }
                 full_deps_buf.insert(full_deps_buf.end(), over->deps, over->deps + over_dc);
+                full_kinds_buf.insert(full_kinds_buf.end(), over->kinds, over->kinds + over_dc);
                 if (over->flags & DEP_GEN_FLAG_LAST_OVERFLOW) {
                     chain_complete = true;
                     break;
@@ -636,9 +646,11 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
                 );
             }
             deps_data = full_deps_buf.data();
+            kinds_data = full_kinds_buf.data();
             dc = static_cast<int32_t>(full_deps_buf.size());
         } else {
             deps_data = rec.explicit_deps;
+            kinds_data = rec.explicit_dep_kinds;
             uint16_t base_dc = rec.explicit_dep_count;
             if (base_dc > DEP_GEN_MAX_EXPLICIT_DEPS) {
                 LOG_ERROR(
@@ -698,27 +710,43 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         task_table.push_back(std::move(task_entry));
 
         // ============ STEP 1 — explicit_deps (call-site emit) ============
-        // Same loop on both passes; they MUST produce identical sets here
-        // because they read the same record. Annot records explicit edges
-        // with consumer_arg_idx = -1 (not tied to any tensor arg). Reads
-        // from deps_data (base record's explicit_deps[] on fast path, the
-        // gathered base+chain buffer on overflow path).
+        // Both passes seed explicit edges from the same captured record. The
+        // differential check therefore covers their interaction with creator
+        // and tensormap edges, while scene tests independently validate the
+        // captured kind bytes. Annot records explicit edges with
+        // consumer_arg_idx = -1 (not tied to any tensor arg). deps_data comes
+        // from the base record on the fast path or the gathered base+chain
+        // buffer on overflow; kinds_data is its parallel semantics array.
         for (int32_t i = 0; i < dc; i++) {
             uint64_t pred_raw = deps_data[i];
-            // Explicit deps are recorded conservatively as DEP_WAIT|DEP_RETAIN;
-            // the DepGenRecord does not carry per-dep kinds, matching Arg's
-            // set_dependencies default.
-            oracle_preds[pred_raw] |= (DEP_WAIT | DEP_RETAIN);
+            const uint8_t raw_kind = kinds_data[i];
+            constexpr uint8_t kKnownDepFlags = static_cast<uint8_t>(DEP_WAIT | DEP_RETAIN);
+            if ((raw_kind & static_cast<uint8_t>(~kKnownDepFlags)) != 0) {
+                // Unknown semantics make the artifact untrustworthy. Reject
+                // the trace instead of emitting a plausible but altered graph.
+                LOG_ERROR(
+                    "dep_gen replay: invalid explicit dep flags 0x%02x at task_id=%" PRIu64 " dep_idx=%d", raw_kind,
+                    rec.task_id, i
+                );
+                tm_oracle.destroy();
+                tm_annot.destroy();
+                return -7;
+            }
+            const DepFlags kind = static_cast<DepFlags>(raw_kind);
+            oracle_preds[pred_raw] |= kind;
             bool first = annot_preds.find(pred_raw) == annot_preds.end();
-            annot_preds[pred_raw] |= (DEP_WAIT | DEP_RETAIN);
+            annot_preds[pred_raw] |= kind;
             if (first) {
                 EdgeAnnot e{};
                 e.pred = pred_raw;
                 e.succ = rec.task_id;
                 e.consumer_arg_idx = -1;
                 e.source = EdgeSource::EXPLICIT;
-                e.flags = DEP_WAIT | DEP_RETAIN;
+                e.flags = kind;
+                explicit_edge_index.emplace(pred_raw, annot_edges.size());
                 annot_edges.push_back(e);
+            } else {
+                annot_edges[explicit_edge_index.at(pred_raw)].flags |= kind;
             }
         }
 
@@ -742,6 +770,10 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
                 bool first = annot_preds.find(producer.raw) == annot_preds.end();
                 annot_preds[producer.raw] |= (DEP_WAIT | DEP_RETAIN);
                 if (!first) {
+                    auto explicit_it = explicit_edge_index.find(producer.raw);
+                    if (explicit_it != explicit_edge_index.end()) {
+                        annot_edges[explicit_it->second].flags |= (DEP_WAIT | DEP_RETAIN);
+                    }
                     return;  // already covered by an earlier emit on this record
                 }
                 EdgeAnnot e{};

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
@@ -62,7 +62,8 @@ static_assert(
 // (same pattern as get_sys_cnt_aicpu / chip_swimlane_aicpu_record_orch_phase below).
 extern "C" __attribute__((weak, visibility("hidden"))) bool is_dep_gen_enabled() { return false; }
 __attribute__((weak, visibility("hidden"))) void dep_gen_aicpu_record_submit(
-    uint64_t, bool, bool, int, const void *const *, const uint8_t *, int, const uint64_t *, int, const int32_t[3]
+    uint64_t, bool, bool, int, const void *const *, const uint8_t *, int, const uint64_t *, const uint8_t *, uint8_t,
+    int, const int32_t[3]
 ) {}
 
 // Scope_stats enable gate, queried via the same predicate idiom as
@@ -938,7 +939,8 @@ static TaskOutputTensors submit_task_common(
         dep_gen_aicpu_record_submit(
             task_id.raw, orch->in_manual_scope(), args.allow_early_resolve(), tc, tensor_ptrs, arg_types_u8,
             static_cast<int>(args.explicit_dep_count()), reinterpret_cast<const uint64_t *>(args.explicit_deps_data()),
-            args.launch_spec.core_num(), kernel_ids_capture
+            reinterpret_cast<const uint8_t *>(args.explicit_dep_kinds_data()),
+            static_cast<uint8_t>(DEP_WAIT | DEP_RETAIN), args.launch_spec.core_num(), kernel_ids_capture
         );
     }
 #endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/types.h
@@ -497,6 +497,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
     }
 
     const TaskId *explicit_deps_data() const { return explicit_deps_; }
+    const DepFlags *explicit_dep_kinds_data() const { return explicit_dep_kinds_; }
 
     /**
      * Add scalar values. Types are deduced per argument; each value is

--- a/src/common/platform/include/aicpu/dep_gen_collector_aicpu.h
+++ b/src/common/platform/include/aicpu/dep_gen_collector_aicpu.h
@@ -34,13 +34,12 @@
  *   - tensor data passed via opaque void* pointers (memcpy'd into the
  *     DEP_GEN_TENSOR_SIZE-byte slot; static_asserted against sizeof(ChipTensor)
  *     in the .cpp)
- *   - explicit_deps passed as uint64*
+ *   - explicit_deps passed as uint64* and per-dep kinds as uint8_t*
  *
  * No-op when dep_gen is disabled (is_dep_gen_enabled() returns false).
  */
 
-#ifndef SRC_COMMON_PLATFORM_INCLUDE_AICPU_DEP_GEN_COLLECTOR_AICPU_H_
-#define SRC_COMMON_PLATFORM_INCLUDE_AICPU_DEP_GEN_COLLECTOR_AICPU_H_
+#pragma once
 
 #include <cstdint>
 
@@ -104,6 +103,9 @@ void dep_gen_aicpu_init();
  * @param explicit_dep_count  Number of explicit_deps — no static cap; truncated only when the
  *                            chain would not fit in a single DepGenBuffer
  * @param explicit_deps_raw   Per-dep TaskId::raw (length = explicit_dep_count)
+ * @param explicit_dep_kinds_raw Per-dep DepFlags byte, or nullptr to apply
+ *                            default_explicit_dep_kind to every dependency
+ * @param default_explicit_dep_kind DepFlags byte used when explicit_dep_kinds_raw is nullptr
  * @param block_num           SPMD logical block count; 1 means non-SPMD
  * @param kernel_ids          Per-subslot kernel id triple {AIC, AIV0, AIV1};
  *                            inactive subslots use INVALID_KERNEL_ID (-1).
@@ -113,8 +115,8 @@ void dep_gen_aicpu_init();
  */
 void dep_gen_aicpu_record_submit(
     uint64_t task_id_raw, bool in_manual_scope, bool early_dispatch, int tensor_count, const void *const *tensor_ptrs,
-    const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw, int block_num,
-    const int32_t kernel_ids[3]
+    const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw,
+    const uint8_t *explicit_dep_kinds_raw, uint8_t default_explicit_dep_kind, int block_num, const int32_t kernel_ids[3]
 );
 
 /**
@@ -128,5 +130,3 @@ void dep_gen_aicpu_flush();
  * Clear file-local bookkeeping (current_buf cache, etc.). Called at shutdown.
  */
 void dep_gen_aicpu_finalize();
-
-#endif  // SRC_COMMON_PLATFORM_INCLUDE_AICPU_DEP_GEN_COLLECTOR_AICPU_H_

--- a/src/common/platform/include/aicpu/profiler_device_engine.h
+++ b/src/common/platform/include/aicpu/profiler_device_engine.h
@@ -29,9 +29,11 @@ namespace profiling_device {
 // The push/pop gates here implement the device half of the block-on-contention
 // backpressure protocol: on a full ready queue or empty free queue the writer
 // parks at its buffer-switch gate (via dfx_backpressure_device.h) until the host
-// clears the freeze, and only breaks to the single failure exit when the
-// 30-second host-crash backstop (Module::kBackpressureWaitCycles) trips. Full
-// design — dual-signal freeze, conjunction release, (0,0) escape-window and
+// clears the freeze. A pre-publication queue wait reports failure when the
+// 30-second host-crash backstop (Module::kBackpressureWaitCycles) trips. A
+// post-publication push-gate timeout leaves the enqueue successful because the
+// ready-queue tail already transferred buffer ownership to the host. Full design
+// — dual-signal freeze, conjunction release, (0,0) escape-window and
 // deadlock-freedom arguments — in docs/dfx/global-backpressure-design.md.
 template <typename Module>
 struct DeviceProfilerEngine {
@@ -147,11 +149,9 @@ struct DeviceProfilerEngine {
         // reaches its push gate during rq_freeze converges here → one aligned
         // common-mode gap; production resumes only after the host clears the
         // freeze (conjunction release).
-        if (!dfx_backpressure::push_freeze_barrier(header, Module::kBackpressureWaitCycles)) {
-            // Gate timeout: the entry is already published to the ready queue,
-            // so the caller (switch_buffer) accounts the dropped records.
-            return -1;
-        }
+        // The tail advance transfers ownership to the host and cannot be rolled
+        // back. A gate timeout must not make callers clear or reuse this buffer.
+        (void)dfx_backpressure::push_freeze_barrier(header, Module::kBackpressureWaitCycles);
         return 0;
     }
 

--- a/src/common/platform/include/common/dep_gen.h
+++ b/src/common/platform/include/common/dep_gen.h
@@ -38,11 +38,11 @@
  * runtime-agnostic.
  */
 
-#ifndef SRC_COMMON_PLATFORM_INCLUDE_COMMON_DEP_GEN_H_
-#define SRC_COMMON_PLATFORM_INCLUDE_COMMON_DEP_GEN_H_
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 #include "arg_direction.h"  // CORE_MAX_TENSOR_ARGS
 #include "common/dfx_backpressure_device.h"
@@ -93,32 +93,35 @@ enum DepGenRecordFlags : uint32_t {
  * Per-submit_task capture. Replay reads these to reconstruct the dep graph.
  *
  * Layout:
- *   - task_id, flags, counts, explicit_deps, arg_types, kernel_id in the first
- *     cache lines
+ *   - task_id, flags, counts, explicit_deps, explicit_dep_kinds, arg_types,
+ *     kernel_id in the first cache lines
  *   - tensors[] (32 × 128 B opaque blobs) at the tail; covers ~88% of the entry
  *
- * Total size: 8 + 4 + 4 + 64*8 + 32 + 12 (kernel_id) + 4 (block_num) + 32*128
- *           = 4672 bytes.
- * Aligned to 64 B → 4672 B (already a multiple of 64). kernel_id + block_num
- * together pad tensors[] up to offset 576 = 9 * 64 so each 128-byte tensor
+ * Total size: 8 + 4 + 4 + 64*8 + 64 + 32 + 12 (kernel_id) + 4 (block_num) + 32*128
+ *           = 4736 bytes.
+ * Aligned to 64 B → 4736 B (already a multiple of 64). kernel_id + block_num
+ * together pad tensors[] up to offset 640 = 10 * 64 so each 128-byte tensor
  * blob covers exactly two cache lines instead of straddling three.
  */
 struct DepGenRecord {
-    uint64_t task_id;                                   // TaskId::raw, in the minting runtime's layout
-    uint32_t flags;                                     // DepGenRecordFlags bitmask
-    uint16_t tensor_count;                              // number of valid ChipTensor slots
-    uint16_t explicit_dep_count;                        // number of valid explicit_dep slots
-    uint64_t explicit_deps[DEP_GEN_MAX_EXPLICIT_DEPS];  // TaskId::raw, length = explicit_dep_count
-    uint8_t arg_types[CORE_MAX_TENSOR_ARGS];            // TensorArgType, length = tensor_count
+    uint64_t task_id;                                       // TaskId::raw, in the minting runtime's layout
+    uint32_t flags;                                         // DepGenRecordFlags bitmask
+    uint16_t tensor_count;                                  // number of valid ChipTensor slots
+    uint16_t explicit_dep_count;                            // number of valid explicit_dep slots
+    uint64_t explicit_deps[DEP_GEN_MAX_EXPLICIT_DEPS];      // TaskId::raw, length = explicit_dep_count
+    uint8_t explicit_dep_kinds[DEP_GEN_MAX_EXPLICIT_DEPS];  // DepFlags, parallel to explicit_deps[]
+    uint8_t arg_types[CORE_MAX_TENSOR_ARGS];                // TensorArgType, length = tensor_count
     int32_t kernel_id[3];  // per-subslot kernel id (AIC, AIV0, AIV1); INVALID_KERNEL_ID = -1
     uint32_t block_num;    // SPMD logical block count; 1 means non-SPMD
     uint8_t tensors[CORE_MAX_TENSOR_ARGS][DEP_GEN_TENSOR_SIZE];  // opaque ChipTensor blobs
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(DepGenRecord) == 4672, "DepGenRecord size changed — update header comment + docs/dfx/dep-gen.md");
+static_assert(sizeof(DepGenRecord) == 4736, "DepGenRecord size changed — update header comment + docs/dfx/dep-gen.md");
 static_assert(sizeof(DepGenRecord) % 64 == 0, "DepGenRecord must be cache-line aligned");
 static_assert(offsetof(DepGenRecord, tensors) % 64 == 0, "DepGenRecord::tensors[] must start on a cache-line boundary");
-static_assert(offsetof(DepGenRecord, tensors) == 576, "DepGenRecord::tensors offset changed — update header comment");
+static_assert(offsetof(DepGenRecord, tensors) == 640, "DepGenRecord::tensors offset changed — update header comment");
+static_assert(std::is_trivially_copyable_v<DepGenRecord>, "DepGenRecord must remain trivially copyable");
+static_assert(std::is_standard_layout_v<DepGenRecord>, "DepGenRecord must remain standard layout");
 
 // =============================================================================
 // DepGenOverflowRecord — chain extension for submits with >DEP_GEN_MAX_EXPLICIT_DEPS deps
@@ -128,10 +131,11 @@ static_assert(offsetof(DepGenRecord, tensors) == 576, "DepGenRecord::tensors off
  * Number of deps carried by a single overflow record. Sized so a
  * DepGenOverflowRecord exactly overlays a DepGenRecord slot in the buffer.
  *
- * Layout: 16-byte header (task_id + flags + dep_count + _reserved) + deps[].
- * deps[] occupies (sizeof(DepGenRecord) - 16) / sizeof(uint64_t) = 582 entries.
+ * Layout: 16-byte header (task_id + flags + dep_count + _reserved) + parallel
+ * deps[] and kinds[] arrays. The largest pair of arrays that fits in one
+ * DepGenRecord slot carries 524 entries.
  */
-constexpr int DEP_GEN_OVERFLOW_DEPS_PER_RECORD = 582;
+constexpr int DEP_GEN_OVERFLOW_DEPS_PER_RECORD = 524;
 
 /**
  * Reinterpret-view of a DepGenRecord slot when flags & DEP_GEN_FLAG_OVERFLOW.
@@ -155,6 +159,7 @@ struct DepGenOverflowRecord {
     uint16_t dep_count;  // number of valid entries in deps[]
     uint16_t _reserved;
     uint64_t deps[DEP_GEN_OVERFLOW_DEPS_PER_RECORD];  // TaskId::raw, length = dep_count
+    uint8_t kinds[DEP_GEN_OVERFLOW_DEPS_PER_RECORD];  // DepFlags, parallel to deps[]
 } __attribute__((aligned(64)));
 
 static_assert(
@@ -163,6 +168,10 @@ static_assert(
 static_assert(
     alignof(DepGenOverflowRecord) == alignof(DepGenRecord), "DepGenOverflowRecord alignment must match DepGenRecord"
 );
+static_assert(
+    std::is_trivially_copyable_v<DepGenOverflowRecord>, "DepGenOverflowRecord must remain trivially copyable"
+);
+static_assert(std::is_standard_layout_v<DepGenOverflowRecord>, "DepGenOverflowRecord must remain standard layout");
 
 /**
  * Number of buffer slots (1 base + N overflow records) needed to capture a
@@ -324,5 +333,3 @@ inline DepGenBufferState *get_dep_gen_buffer_state(void *base_ptr, int instance_
     return reinterpret_cast<DepGenBufferState *>(reinterpret_cast<char *>(base_ptr) + sizeof(DepGenDataHeader)) +
            instance_index;
 }
-
-#endif  // SRC_COMMON_PLATFORM_INCLUDE_COMMON_DEP_GEN_H_

--- a/src/common/platform/shared/aicpu/dep_gen_collector_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/dep_gen_collector_aicpu.cpp
@@ -166,8 +166,8 @@ void dep_gen_aicpu_init() {
 
 void dep_gen_aicpu_record_submit(
     uint64_t task_id_raw, bool in_manual_scope, bool early_dispatch, int tensor_count, const void *const *tensor_ptrs,
-    const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw, int block_num,
-    const int32_t kernel_ids[3]
+    const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw,
+    const uint8_t *explicit_dep_kinds_raw, uint8_t default_explicit_dep_kind, int block_num, const int32_t kernel_ids[3]
 ) {
     if (!g_enable_dep_gen) {
         return;
@@ -309,6 +309,11 @@ void dep_gen_aicpu_record_submit(
     // explicit_deps (tail of the entry, packed; replay reads only the first base_dc entries)
     if (base_dc > 0) {
         memcpy(rec->explicit_deps, explicit_deps_raw, static_cast<size_t>(base_dc) * sizeof(uint64_t));
+        if (explicit_dep_kinds_raw != nullptr) {
+            memcpy(rec->explicit_dep_kinds, explicit_dep_kinds_raw, static_cast<size_t>(base_dc));
+        } else {
+            memset(rec->explicit_dep_kinds, default_explicit_dep_kind, static_cast<size_t>(base_dc));
+        }
     }
 
     // arg_types
@@ -370,6 +375,11 @@ void dep_gen_aicpu_record_submit(
         over->_reserved = 0;
         if (chunk > 0) {
             memcpy(over->deps, explicit_deps_raw + written, static_cast<size_t>(chunk) * sizeof(uint64_t));
+            if (explicit_dep_kinds_raw != nullptr) {
+                memcpy(over->kinds, explicit_dep_kinds_raw + written, static_cast<size_t>(chunk));
+            } else {
+                memset(over->kinds, default_explicit_dep_kind, static_cast<size_t>(chunk));
+            }
         }
         written += chunk;
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
@@ -14,16 +14,17 @@
  * overflow chain wire format.
  *
  * Submits N producers each writing X[0] = 42.0, then a dummy_T whose only
- * dependency surface is set_dependencies({all N producer ids}, N), then a
- * consumer that explicit-depends on the barrier and copies X[0] -> Y[0].
+ * dependency surface is set_dependencies_with_kinds({all N producer ids}, N), then a
+ * consumer that ordering-depends on the barrier and copies X[0] -> Y[0].
  *
  * Picking N > DEP_GEN_MAX_EXPLICIT_DEPS (=64) forces the dep_gen capture to
  * spill into one or more DepGenOverflowRecord slots; picking N to span the
- * 64 + k*326 boundaries exercises both single- and multi-overflow chains.
+ * 64 + k*524 boundaries exercises both single- and multi-overflow chains.
  *
  * Args layout: [X, Y, scalar(N)]
  *   - X: every producer writes it (tensormap auto-deps the chain so the
- *        SENTINEL is preserved); consumer reads it.
+ *        SENTINEL is preserved); consumer reads it. The value check is an
+ *        execution sanity check; deps.json verifies the explicit barrier.
  *   - Y: consumer writes it; host checks Y[0] == SENTINEL.
  *
  * Scalar: N (1 .. MAX_PRODUCERS).
@@ -36,9 +37,10 @@
 #define FUNC_WRITE_CONST 0
 #define FUNC_COPY_FIRST 1
 
-// Stack room for producer_ids[]. 500 covers everything we expect to test;
+// Stack room for producer_ids[] and producer_kinds[]. 600 covers the second
+// overflow boundary (64 + 524 + 1);
 // CHIP_DEP_LIST_POOL_SIZE (16384) is the real ceiling on a per-ring basis.
-static constexpr int32_t MAX_PRODUCERS = 500;
+static constexpr int32_t MAX_PRODUCERS = 600;
 
 extern "C" {
 
@@ -61,14 +63,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     }
 
     TaskId producer_ids[MAX_PRODUCERS];
+    DepFlags producer_kinds[MAX_PRODUCERS];
 
     // N producers each INOUT X. tensormap auto-deps them in a chain, so X[0]
-    // stays at SENTINEL through all of them — the host only checks the final
-    // value, which proves the barrier waited for every producer to finish.
+    // stays at SENTINEL through all of them. The final value is an execution
+    // sanity check; the deps.json assertions verify the explicit barrier.
     for (int32_t i = 0; i < n; i++) {
         CoreTaskArgs args;
         args.add_inout(ext_X);
         producer_ids[i] = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
+        producer_kinds[i] = (i % 2 == 0) ? DEP_WAIT : (DEP_WAIT | DEP_RETAIN);
     }
 
     // Dummy barrier with explicit deps on ALL N producers. dc=n > 64 forces
@@ -76,19 +80,35 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     TaskId barrier_id;
     {
         CoreTaskArgs args;
-        args.set_dependencies(producer_ids, n);
+        args.set_dependencies_with_kinds(producer_ids, producer_kinds, n);
         barrier_id = rt_submit_dummy_task(args).task_id();
     }
 
-    // Consumer: explicit dep on barrier only, reads X, writes Y.
+    // Consumer: ordering-only dep on barrier, reads X, writes Y.
     {
-        CoreTaskArgs args;
-        TaskId consumer_deps[] = {barrier_id};
-        args.set_dependencies(consumer_deps, 1);
+        CoreTaskArgsWithDeps<1> args;
+        args.add_dep_wait(barrier_id);
         args.add_input(ext_X);
         args.add_inout(ext_Y);
         rt_submit_aic_task(FUNC_COPY_FIRST, args);
     }
+
+    // The final pair reaches the same producer through an explicit ordering
+    // dependency and runtime-output ownership. FaninBuilder folds both reasons
+    // into one WAIT|RETAIN edge.
+    uint32_t owned_shape[1] = {1};
+    TensorCreateInfo owned_ci(owned_shape, 1, DataType::FLOAT32);
+    CoreTaskArgs creator_args;
+    creator_args.add_output(owned_ci);
+    TaskOutputTensors creator_outputs = rt_submit_dummy_task(creator_args);
+    const simpler::tmr::Tensor &owned = creator_outputs.get_ref(0);
+
+    TaskId combined_dep = creator_outputs.task_id();
+    DepFlags combined_kind = DEP_WAIT;
+    CoreTaskArgs combined_args;
+    combined_args.set_dependencies_with_kinds(&combined_dep, &combined_kind, 1);
+    combined_args.add_input(owned);
+    rt_submit_dummy_task(combined_args);
 }
 
 }  // extern "C"

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
@@ -16,18 +16,19 @@ the tail in deps.json; this test verifies every explicit dep edge survives
 the round-trip writer → host collector → replay → deps.json.
 
 Test shape (chain_barrier_orch.cpp): N producers each INOUT X, then a dummy
-barrier `set_dependencies({all N producer ids})`, then a consumer
-`set_dependencies({barrier_id})` reading X and writing Y. With N spanning
-the {64, 65, 390, 391} boundaries we exercise:
+barrier `set_dependencies_with_kinds({all N producer ids})`, then a consumer
+`add_dep_wait(barrier_id)` reading X and writing Y. With N spanning
+the {64, 65, 588, 589} boundaries we exercise:
 
   - n=64: base only (no chain) — sanity baseline
   - n=65: base + 1 overflow record (1 dep in overflow)
   - n=200: base + 1 overflow (136 deps in overflow)
-  - n=391: base + 2 overflow (326 + 1 deps across two overflows)
+  - n=589: base + 2 overflow (524 + 1 deps across two overflows)
 
 Validation: the barrier task in deps.json must have exactly N predecessors,
 all of which are the producer ids. The consumer must have one explicit
-predecessor — the barrier.
+predecessor — the barrier. A final dummy pair verifies that an explicit WAIT
+and creator retention for the same producer merge into one WAIT|RETAIN edge.
 """
 
 import json
@@ -109,11 +110,11 @@ class TestDepGenChain(SceneTestCase):
             "params": {"n": 200},
         },
         {
-            "name": "n_391_two_overflow",
+            "name": "n_589_two_overflow",
             "platforms": ["a2a3sim", "a2a3"],
             "manual": ["a2a3sim"],
             "config": {"aicpu_thread_num": 2},
-            "params": {"n": 391},
+            "params": {"n": 589},
         },
     ]
 
@@ -130,9 +131,8 @@ class TestDepGenChain(SceneTestCase):
 
     def compute_golden(self, args, params):
         # Producers each write SENTINEL to X[0]; consumer copies X[0] -> Y[0].
-        # If the barrier didn't actually wait for all producers, the consumer
-        # could race ahead and copy INIT_VAL instead — making the host check
-        # a defacto sanity gate even before we look at deps.json.
+        # Tensormap dependencies also order these accesses, so this value check
+        # is an execution sanity gate; deps.json validates the explicit barrier.
         args.x[0] = self.SENTINEL
         args.y[0] = self.SENTINEL
 
@@ -151,8 +151,9 @@ class TestDepGenChain(SceneTestCase):
 
         With dep_gen on, deps.json must contain N edges from the producers to
         the barrier task (one per `set_dependencies` entry the orchestration
-        emitted), plus the consumer's one explicit edge back from the barrier.
-        Pre-chain code would truncate the producer→barrier edge set to 16/64.
+        emitted), plus the consumer's one explicit edge back from the barrier
+        and the final cross-source dedup probe. Pre-chain code would truncate
+        the producer→barrier edge set to 16/64.
         """
         case_name = case["name"]
         n = int(case["params"]["n"])
@@ -178,6 +179,7 @@ class TestDepGenChain(SceneTestCase):
         with deps_path.open() as f:
             deps = json.load(f)
 
+        tasks = deps.get("tasks", [])
         raw_edges = deps.get("edges", [])
         # Project annotated edges → (pred, succ) — we only care about graph
         # structure here; the annot-vs-oracle agreement gate already ran
@@ -213,12 +215,61 @@ class TestDepGenChain(SceneTestCase):
         # round-trip assertion: pre-chain code drops anything past index 63.
         assert len(barrier_preds) == n, f"barrier has {len(barrier_preds)} preds, expected {n}"
 
-        # Consumer must explicit-depend on the barrier — exactly one outgoing
-        # explicit edge from the barrier.
-        outgoing_explicit_from_barrier = {succ for pred, succ in explicit_edges if pred == barrier_id}
+        # Check the raw list before indexing it so duplicate emitted edges
+        # cannot be hidden by the producer-keyed map.
+        barrier_explicit_edge_list = [
+            e
+            for e in raw_edges
+            if isinstance(e, dict) and e.get("source") == "explicit" and int(e.get("succ", -1)) == barrier_id
+        ]
+        assert len(barrier_explicit_edge_list) == n, (
+            f"barrier emitted {len(barrier_explicit_edge_list)} explicit edges, expected exactly {n}"
+        )
+        barrier_explicit_edges = {int(e["pred"]): e for e in barrier_explicit_edge_list}
+        assert len(barrier_explicit_edges) == n
+
+        # Derive producer order from tasks[] rather than TaskId numeric order.
+        # The barrier alternates WAIT and WAIT|RETAIN kinds, validating the
+        # parallel kind array across the base and every overflow record.
+        barrier_task_idx = next((idx for idx, task in enumerate(tasks) if int(task["task_id"]) == barrier_id), None)
+        assert barrier_task_idx is not None, f"barrier task {barrier_id} is missing from tasks[]"
+        producer_ids = [
+            int(task["task_id"]) for task in tasks[:barrier_task_idx] if int(task["task_id"]) in barrier_preds
+        ]
+        assert len(producer_ids) == n, f"found {len(producer_ids)} ordered barrier producers, expected {n}"
+        for idx, producer_id in enumerate(producer_ids):
+            edge = barrier_explicit_edges[producer_id]
+            expected_flags = ["wait"] if idx % 2 == 0 else ["wait", "retain"]
+            assert edge.get("flags") == expected_flags, (
+                f"barrier dep {idx} flags are {edge.get('flags')}, expected {expected_flags}"
+            )
+
+        # Consumer must have one ordering-only explicit edge from the barrier.
+        outgoing_explicit_from_barrier = [
+            e for e in raw_edges if e.get("source") == "explicit" and int(e.get("pred", -1)) == barrier_id
+        ]
         assert len(outgoing_explicit_from_barrier) == 1, (
             f"barrier {barrier_id} has {len(outgoing_explicit_from_barrier)} outgoing explicit edges, "
             f"expected 1 (the consumer)"
+        )
+        assert outgoing_explicit_from_barrier[0].get("flags") == ["wait"], (
+            f"barrier ordering edge flags are {outgoing_explicit_from_barrier[0].get('flags')}, expected ['wait']"
+        )
+
+        # The final two dummy tasks exercise cross-source dedup: the consumer
+        # explicitly waits on the producer and reads its runtime-owned output.
+        assert len(tasks) >= 2
+        combined_pred = int(tasks[-2]["task_id"])
+        combined_succ = int(tasks[-1]["task_id"])
+        combined_edges = [
+            e for e in raw_edges if int(e.get("pred", -1)) == combined_pred and int(e.get("succ", -1)) == combined_succ
+        ]
+        assert len(combined_edges) == 1, (
+            f"combined dependency {combined_pred}->{combined_succ} has {len(combined_edges)} edges, expected 1"
+        )
+        assert combined_edges[0].get("source") == "explicit"
+        assert combined_edges[0].get("flags") == ["wait", "retain"], (
+            f"combined dependency flags are {combined_edges[0].get('flags')}, expected ['wait', 'retain']"
         )
 
 

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
@@ -14,16 +14,17 @@
  * overflow chain wire format.
  *
  * Submits N producers each writing X[0] = 42.0, then a dummy_T whose only
- * dependency surface is set_dependencies({all N producer ids}, N), then a
- * consumer that explicit-depends on the barrier and copies X[0] -> Y[0].
+ * dependency surface is set_dependencies_with_kinds({all N producer ids}, N), then a
+ * consumer that ordering-depends on the barrier and copies X[0] -> Y[0].
  *
  * Picking N > DEP_GEN_MAX_EXPLICIT_DEPS (=64) forces the dep_gen capture to
  * spill into one or more DepGenOverflowRecord slots; picking N to span the
- * 64 + k*326 boundaries exercises both single- and multi-overflow chains.
+ * 64 + k*524 boundaries exercises both single- and multi-overflow chains.
  *
  * Args layout: [X, Y, scalar(N)]
  *   - X: every producer writes it (tensormap auto-deps the chain so the
- *        SENTINEL is preserved); consumer reads it.
+ *        SENTINEL is preserved); consumer reads it. The value check is an
+ *        execution sanity check; deps.json verifies the explicit barrier.
  *   - Y: consumer writes it; host checks Y[0] == SENTINEL.
  *
  * Scalar: N (1 .. MAX_PRODUCERS).
@@ -36,9 +37,10 @@
 #define FUNC_WRITE_CONST 0
 #define FUNC_COPY_FIRST 1
 
-// Stack room for producer_ids[]. 500 covers everything we expect to test;
+// Stack room for producer_ids[] and producer_kinds[]. 600 covers the second
+// overflow boundary (64 + 524 + 1);
 // CHIP_DEP_LIST_POOL_SIZE (16384) is the real ceiling on a per-ring basis.
-static constexpr int32_t MAX_PRODUCERS = 500;
+static constexpr int32_t MAX_PRODUCERS = 600;
 
 extern "C" {
 
@@ -61,14 +63,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     }
 
     TaskId producer_ids[MAX_PRODUCERS];
+    DepFlags producer_kinds[MAX_PRODUCERS];
 
     // N producers each INOUT X. tensormap auto-deps them in a chain, so X[0]
-    // stays at SENTINEL through all of them — the host only checks the final
-    // value, which proves the barrier waited for every producer to finish.
+    // stays at SENTINEL through all of them. The final value is an execution
+    // sanity check; the deps.json assertions verify the explicit barrier.
     for (int32_t i = 0; i < n; i++) {
         CoreTaskArgs args;
         args.add_inout(ext_X);
         producer_ids[i] = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
+        producer_kinds[i] = (i % 2 == 0) ? DEP_WAIT : (DEP_WAIT | DEP_RETAIN);
     }
 
     // Dummy barrier with explicit deps on ALL N producers. dc=n > 64 forces
@@ -76,19 +80,35 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     TaskId barrier_id;
     {
         CoreTaskArgs args;
-        args.set_dependencies(producer_ids, n);
+        args.set_dependencies_with_kinds(producer_ids, producer_kinds, n);
         barrier_id = rt_submit_dummy_task(args).task_id();
     }
 
-    // Consumer: explicit dep on barrier only, reads X, writes Y.
+    // Consumer: ordering-only dep on barrier, reads X, writes Y.
     {
-        CoreTaskArgs args;
-        TaskId consumer_deps[] = {barrier_id};
-        args.set_dependencies(consumer_deps, 1);
+        CoreTaskArgsWithDeps<1> args;
+        args.add_dep_wait(barrier_id);
         args.add_input(ext_X);
         args.add_inout(ext_Y);
         rt_submit_aic_task(FUNC_COPY_FIRST, args);
     }
+
+    // The final pair reaches the same producer through an explicit ordering
+    // dependency and runtime-output ownership. FaninBuilder folds both reasons
+    // into one WAIT|RETAIN edge.
+    uint32_t owned_shape[1] = {1};
+    TensorCreateInfo owned_ci(owned_shape, 1, DataType::FLOAT32);
+    CoreTaskArgs creator_args;
+    creator_args.add_output(owned_ci);
+    TaskOutputTensors creator_outputs = rt_submit_dummy_task(creator_args);
+    const simpler::tmr::Tensor &owned = creator_outputs.get_ref(0);
+
+    TaskId combined_dep = creator_outputs.task_id();
+    DepFlags combined_kind = DEP_WAIT;
+    CoreTaskArgs combined_args;
+    combined_args.set_dependencies_with_kinds(&combined_dep, &combined_kind, 1);
+    combined_args.add_input(owned);
+    rt_submit_dummy_task(combined_args);
 }
 
 }  // extern "C"

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
@@ -16,18 +16,19 @@ the tail in deps.json; this test verifies every explicit dep edge survives
 the round-trip writer → host collector → replay → deps.json.
 
 Test shape (chain_barrier_orch.cpp): N producers each INOUT X, then a dummy
-barrier `set_dependencies({all N producer ids})`, then a consumer
-`set_dependencies({barrier_id})` reading X and writing Y. With N spanning
-the {64, 65, 390, 391} boundaries we exercise:
+barrier `set_dependencies_with_kinds({all N producer ids})`, then a consumer
+`add_dep_wait(barrier_id)` reading X and writing Y. With N spanning
+the {64, 65, 588, 589} boundaries we exercise:
 
   - n=64: base only (no chain) — sanity baseline
   - n=65: base + 1 overflow record (1 dep in overflow)
   - n=200: base + 1 overflow (136 deps in overflow)
-  - n=391: base + 2 overflow (326 + 1 deps across two overflows)
+  - n=589: base + 2 overflow (524 + 1 deps across two overflows)
 
 Validation: the barrier task in deps.json must have exactly N predecessors,
 all of which are the producer ids. The consumer must have one explicit
-predecessor — the barrier.
+predecessor — the barrier. A final dummy pair verifies that an explicit WAIT
+and creator retention for the same producer merge into one WAIT|RETAIN edge.
 """
 
 import json
@@ -105,11 +106,11 @@ class TestDepGenChain(SceneTestCase):
             "params": {"n": 200},
         },
         {
-            "name": "n_391_two_overflow",
+            "name": "n_589_two_overflow",
             "platforms": ["a5sim", "a5"],
             "manual": ["a5sim"],
             "config": {"aicpu_thread_num": 2},
-            "params": {"n": 391},
+            "params": {"n": 589},
         },
     ]
 
@@ -126,9 +127,8 @@ class TestDepGenChain(SceneTestCase):
 
     def compute_golden(self, args, params):
         # Producers each write SENTINEL to X[0]; consumer copies X[0] -> Y[0].
-        # If the barrier didn't actually wait for all producers, the consumer
-        # could race ahead and copy INIT_VAL instead — making the host check
-        # a defacto sanity gate even before we look at deps.json.
+        # Tensormap dependencies also order these accesses, so this value check
+        # is an execution sanity gate; deps.json validates the explicit barrier.
         args.x[0] = self.SENTINEL
         args.y[0] = self.SENTINEL
 
@@ -147,8 +147,9 @@ class TestDepGenChain(SceneTestCase):
 
         With dep_gen on, deps.json must contain N edges from the producers to
         the barrier task (one per `set_dependencies` entry the orchestration
-        emitted), plus the consumer's one explicit edge back from the barrier.
-        Pre-chain code would truncate the producer→barrier edge set to 16/64.
+        emitted), plus the consumer's one explicit edge back from the barrier
+        and the final cross-source dedup probe. Pre-chain code would truncate
+        the producer→barrier edge set to 16/64.
         """
         case_name = case["name"]
         n = int(case["params"]["n"])
@@ -174,6 +175,7 @@ class TestDepGenChain(SceneTestCase):
         with deps_path.open() as f:
             deps = json.load(f)
 
+        tasks = deps.get("tasks", [])
         raw_edges = deps.get("edges", [])
         # Project annotated edges → (pred, succ) — we only care about graph
         # structure here; the annot-vs-oracle agreement gate already ran
@@ -209,12 +211,61 @@ class TestDepGenChain(SceneTestCase):
         # round-trip assertion: pre-chain code drops anything past index 63.
         assert len(barrier_preds) == n, f"barrier has {len(barrier_preds)} preds, expected {n}"
 
-        # Consumer must explicit-depend on the barrier — exactly one outgoing
-        # explicit edge from the barrier.
-        outgoing_explicit_from_barrier = {succ for pred, succ in explicit_edges if pred == barrier_id}
+        # Check the raw list before indexing it so duplicate emitted edges
+        # cannot be hidden by the producer-keyed map.
+        barrier_explicit_edge_list = [
+            e
+            for e in raw_edges
+            if isinstance(e, dict) and e.get("source") == "explicit" and int(e.get("succ", -1)) == barrier_id
+        ]
+        assert len(barrier_explicit_edge_list) == n, (
+            f"barrier emitted {len(barrier_explicit_edge_list)} explicit edges, expected exactly {n}"
+        )
+        barrier_explicit_edges = {int(e["pred"]): e for e in barrier_explicit_edge_list}
+        assert len(barrier_explicit_edges) == n
+
+        # Derive producer order from tasks[] rather than TaskId numeric order.
+        # The barrier alternates WAIT and WAIT|RETAIN kinds, validating the
+        # parallel kind array across the base and every overflow record.
+        barrier_task_idx = next((idx for idx, task in enumerate(tasks) if int(task["task_id"]) == barrier_id), None)
+        assert barrier_task_idx is not None, f"barrier task {barrier_id} is missing from tasks[]"
+        producer_ids = [
+            int(task["task_id"]) for task in tasks[:barrier_task_idx] if int(task["task_id"]) in barrier_preds
+        ]
+        assert len(producer_ids) == n, f"found {len(producer_ids)} ordered barrier producers, expected {n}"
+        for idx, producer_id in enumerate(producer_ids):
+            edge = barrier_explicit_edges[producer_id]
+            expected_flags = ["wait"] if idx % 2 == 0 else ["wait", "retain"]
+            assert edge.get("flags") == expected_flags, (
+                f"barrier dep {idx} flags are {edge.get('flags')}, expected {expected_flags}"
+            )
+
+        # Consumer must have one ordering-only explicit edge from the barrier.
+        outgoing_explicit_from_barrier = [
+            e for e in raw_edges if e.get("source") == "explicit" and int(e.get("pred", -1)) == barrier_id
+        ]
         assert len(outgoing_explicit_from_barrier) == 1, (
             f"barrier {barrier_id} has {len(outgoing_explicit_from_barrier)} outgoing explicit edges, "
             f"expected 1 (the consumer)"
+        )
+        assert outgoing_explicit_from_barrier[0].get("flags") == ["wait"], (
+            f"barrier ordering edge flags are {outgoing_explicit_from_barrier[0].get('flags')}, expected ['wait']"
+        )
+
+        # The final two dummy tasks exercise cross-source dedup: the consumer
+        # explicitly waits on the producer and reads its runtime-owned output.
+        assert len(tasks) >= 2
+        combined_pred = int(tasks[-2]["task_id"])
+        combined_succ = int(tasks[-1]["task_id"])
+        combined_edges = [
+            e for e in raw_edges if int(e.get("pred", -1)) == combined_pred and int(e.get("succ", -1)) == combined_succ
+        ]
+        assert len(combined_edges) == 1, (
+            f"combined dependency {combined_pred}->{combined_succ} has {len(combined_edges)} edges, expected 1"
+        )
+        assert combined_edges[0].get("source") == "explicit"
+        assert combined_edges[0].get("flags") == ["wait", "retain"], (
+            f"combined dependency flags are {combined_edges[0].get('flags')}, expected ['wait', 'retain']"
         )
 
 

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -85,6 +85,7 @@ endif()
 # have had if the sources were listed directly.
 # ---------------------------------------------------------------------------
 set(A2A3_RUNTIME_DIR ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/runtime)
+set(A2A3_HOST_DIR ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/host)
 
 add_library(a2a3_rt_objs OBJECT
     ${A2A3_RUNTIME_DIR}/ring_buffer.cpp
@@ -107,7 +108,7 @@ target_include_directories(a2a3_rt_objs PUBLIC
 )
 
 function(add_a2a3_runtime_test name src)
-    add_executable(${name} ${src})
+    add_executable(${name} ${src} ${ARGN})
     target_include_directories(${name} PRIVATE ${GTEST_INCLUDE_DIRS})
     target_link_libraries(${name} PRIVATE
         a2a3_rt_objs
@@ -774,6 +775,7 @@ add_executable(test_dep_gen_collector_aicpu
 )
 target_include_directories(test_dep_gen_collector_aicpu PRIVATE
     ${GTEST_INCLUDE_DIRS}
+    ${A2A3_RUNTIME_DIR}
     ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/include
     ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
     ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
@@ -1034,6 +1036,8 @@ add_a2a3_runtime_test(test_task_state       a2a3/test_task_state.cpp)
 add_a2a3_runtime_test(test_ready_queue      a2a3/test_ready_queue.cpp)
 add_a2a3_runtime_test(test_shared_memory    a2a3/test_shared_memory.cpp)
 add_a2a3_runtime_test(test_a2a3_tensormap   a2a3/test_tensormap.cpp)
+add_a2a3_runtime_test(test_dep_gen_replay common/test_dep_gen_replay.cpp ${A2A3_HOST_DIR}/dep_gen_replay.cpp)
+target_include_directories(test_dep_gen_replay PRIVATE ${A2A3_HOST_DIR})
 add_a2a3_runtime_test(test_fanin_pool       a2a3/test_fanin_pool.cpp)
 add_a2a3_orchestrator_runtime_test(test_a2a3_orchestrator_fanin a2a3/test_orchestrator_fanin.cpp)
 add_a2a3_orchestrator_runtime_test(test_wiring a2a3/test_wiring.cpp)

--- a/tests/ut/cpp/common/test_dep_gen_collector_aicpu.cpp
+++ b/tests/ut/cpp/common/test_dep_gen_collector_aicpu.cpp
@@ -26,6 +26,9 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <vector>
+
+#include "types.h"
 
 namespace {
 
@@ -72,12 +75,18 @@ protected:
         free(shm_);
     }
 
-    void record_one_submit(uint64_t task_id_raw) {
+    void record_one_submit(uint64_t task_id_raw) { record_submit(task_id_raw, 0, nullptr, nullptr); }
+
+    void record_submit(
+        uint64_t task_id_raw, int explicit_dep_count, const uint64_t *explicit_deps_raw,
+        const uint8_t *explicit_dep_kinds_raw,
+        uint8_t default_explicit_dep_kind = static_cast<uint8_t>(DEP_WAIT | DEP_RETAIN)
+    ) {
         const int32_t kernel_ids[3] = {-1, -1, -1};
         dep_gen_aicpu_record_submit(
             task_id_raw, /*in_manual_scope=*/false, /*early_dispatch=*/false, /*tensor_count=*/0,
-            /*tensor_ptrs=*/nullptr, /*arg_types=*/nullptr, /*explicit_dep_count=*/0, /*explicit_deps_raw=*/nullptr,
-            /*block_num=*/1, kernel_ids
+            /*tensor_ptrs=*/nullptr, /*arg_types=*/nullptr, explicit_dep_count, explicit_deps_raw,
+            explicit_dep_kinds_raw, default_explicit_dep_kind, /*block_num=*/1, kernel_ids
         );
     }
 
@@ -115,6 +124,72 @@ TEST_F(DepGenCollectorAicpuTest, SubmitAfterOrchThreadIdxIsRecordedAndFlushed) {
     EXPECT_EQ(header_->queue_tails[0], 1u);
     EXPECT_EQ(header_->queues[0][0].buffer_ptr, reinterpret_cast<uint64_t>(buffer_));
     EXPECT_EQ(state_->current_buf_ptr, 0u);
+}
+
+TEST_F(DepGenCollectorAicpuTest, NullKindsUseDefaultForEveryDependency) {
+    dep_gen_aicpu_set_orch_thread_idx(0);
+    constexpr int kDepCount = DEP_GEN_MAX_EXPLICIT_DEPS + 1;
+    std::vector<uint64_t> deps(kDepCount);
+    for (int i = 0; i < kDepCount; ++i) {
+        deps[i] = 0x100u + static_cast<uint64_t>(i);
+    }
+
+    record_submit(0x1234, kDepCount, deps.data(), nullptr, /*default_explicit_dep_kind=*/3);
+
+    ASSERT_EQ(buffer_->count, 2u);
+    const DepGenRecord &record = buffer_->records[0];
+    ASSERT_EQ(record.explicit_dep_count, DEP_GEN_MAX_EXPLICIT_DEPS);
+    for (int i = 0; i < DEP_GEN_MAX_EXPLICIT_DEPS; ++i) {
+        EXPECT_EQ(record.explicit_deps[i], deps[i]);
+        EXPECT_EQ(record.explicit_dep_kinds[i], 3u);
+    }
+
+    const auto *overflow = reinterpret_cast<const DepGenOverflowRecord *>(&buffer_->records[1]);
+    ASSERT_EQ(overflow->dep_count, 1u);
+    EXPECT_EQ(overflow->deps[0], deps.back());
+    EXPECT_EQ(overflow->kinds[0], 3u);
+}
+
+TEST_F(DepGenCollectorAicpuTest, MixedKindsSurviveTwoOverflowRecords) {
+    dep_gen_aicpu_set_orch_thread_idx(0);
+    constexpr int kDepCount = DEP_GEN_MAX_EXPLICIT_DEPS + DEP_GEN_OVERFLOW_DEPS_PER_RECORD + 1;
+    std::vector<uint64_t> deps(kDepCount);
+    std::vector<uint8_t> kinds(kDepCount);
+    for (int i = 0; i < kDepCount; ++i) {
+        deps[i] = 0x1000u + static_cast<uint64_t>(i);
+        kinds[i] = (i % 2 == 0) ? 1u : 3u;
+    }
+
+    record_submit(0x5678, kDepCount, deps.data(), kinds.data());
+
+    ASSERT_EQ(buffer_->count, 3u);
+    EXPECT_EQ(state_->total_record_count, 1u);
+    EXPECT_EQ(state_->total_overflow_record_count, 2u);
+
+    const DepGenRecord &base = buffer_->records[0];
+    ASSERT_EQ(base.explicit_dep_count, DEP_GEN_MAX_EXPLICIT_DEPS);
+    EXPECT_NE(base.flags & DEP_GEN_FLAG_HAS_OVERFLOW, 0u);
+    for (int i = 0; i < DEP_GEN_MAX_EXPLICIT_DEPS; ++i) {
+        EXPECT_EQ(base.explicit_deps[i], deps[i]);
+        EXPECT_EQ(base.explicit_dep_kinds[i], kinds[i]);
+    }
+
+    const auto *first = reinterpret_cast<const DepGenOverflowRecord *>(&buffer_->records[1]);
+    ASSERT_EQ(first->dep_count, DEP_GEN_OVERFLOW_DEPS_PER_RECORD);
+    EXPECT_NE(first->flags & DEP_GEN_FLAG_OVERFLOW, 0u);
+    EXPECT_EQ(first->flags & DEP_GEN_FLAG_LAST_OVERFLOW, 0u);
+    for (int i = 0; i < DEP_GEN_OVERFLOW_DEPS_PER_RECORD; ++i) {
+        const int dep_idx = DEP_GEN_MAX_EXPLICIT_DEPS + i;
+        EXPECT_EQ(first->deps[i], deps[dep_idx]);
+        EXPECT_EQ(first->kinds[i], kinds[dep_idx]);
+    }
+
+    const auto *last = reinterpret_cast<const DepGenOverflowRecord *>(&buffer_->records[2]);
+    ASSERT_EQ(last->dep_count, 1u);
+    EXPECT_NE(last->flags & DEP_GEN_FLAG_OVERFLOW, 0u);
+    EXPECT_NE(last->flags & DEP_GEN_FLAG_LAST_OVERFLOW, 0u);
+    EXPECT_EQ(last->deps[0], deps.back());
+    EXPECT_EQ(last->kinds[0], kinds.back());
 }
 
 }  // namespace

--- a/tests/ut/cpp/common/test_dep_gen_replay.cpp
+++ b/tests/ut/cpp/common/test_dep_gen_replay.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "dep_gen_replay.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+
+#include <unistd.h>
+
+#include "common/dep_gen.h"
+#include "tensormap_and_ringbuffer/task_id_encoding.h"
+
+namespace {
+
+std::filesystem::path output_path() {
+    return std::filesystem::temp_directory_path() /
+           ("simpler_dep_gen_invalid_flags_" + std::to_string(::getpid()) + ".json");
+}
+
+}  // namespace
+
+TEST(DepGenReplayTest, RejectsUnknownExplicitDepFlagBits) {
+    const std::filesystem::path path = output_path();
+    std::filesystem::remove(path);
+
+    DepGenRecord record{};
+    record.task_id = simpler::tmr::make_task_id(0, 2).raw;
+    record.explicit_dep_count = 1;
+    record.explicit_deps[0] = simpler::tmr::make_task_id(0, 1).raw;
+    record.explicit_dep_kinds[0] = 0xff;
+
+    EXPECT_EQ(dep_gen_replay_emit_deps_json(&record, 1, path.c_str()), -7);
+    EXPECT_FALSE(std::filesystem::exists(path));
+}

--- a/tests/ut/cpp/common/test_profiler_device_engine.cpp
+++ b/tests/ut/cpp/common/test_profiler_device_engine.cpp
@@ -117,6 +117,33 @@ TEST(ProfilerDeviceEngineTest, SwitchPublishesOldBufferAndPopsReplacement) {
     EXPECT_EQ(new_buffer.count, 0u);
 }
 
+TEST(ProfilerDeviceEngineTest, SwitchDoesNotReusePublishedBufferAfterPushGateTimeout) {
+    FakeHeader header;
+    FakeState state;
+    FakeBuffer old_buffer;
+    FakeBuffer new_buffer;
+    FakeBuffer *current = &old_buffer;
+    state.current_ptr = reinterpret_cast<uint64_t>(&old_buffer);
+    state.current_seq = 7;
+    old_buffer.count = 3;
+    header.backpressure.rq_freeze_active = 1;
+    state.free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(&new_buffer);
+    state.free_queue.tail = 1;
+
+    Engine::switch_buffer(context(&header, &current), &state);
+
+    EXPECT_EQ(header.queue_tails[0], 1u);
+    EXPECT_EQ(header.queues[0][0].buffer_ptr, reinterpret_cast<uint64_t>(&old_buffer));
+    EXPECT_EQ(header.queues[0][0].buffer_seq, 7u);
+    EXPECT_EQ(state.dropped, 0u);
+    EXPECT_EQ(old_buffer.count, 3u);
+    EXPECT_EQ(state.free_queue.head, 1u);
+    EXPECT_EQ(state.current_ptr, reinterpret_cast<uint64_t>(&new_buffer));
+    EXPECT_EQ(state.current_seq, 8u);
+    EXPECT_EQ(current, &new_buffer);
+    EXPECT_EQ(new_buffer.count, 0u);
+}
+
 TEST(ProfilerDeviceEngineTest, SwitchClearsCurrentBufferWhenReplacementIsUnavailable) {
     FakeHeader header;
     FakeState state;


### PR DESCRIPTION
## Summary

- Capture per-dependency WAIT/RETAIN flags in inline and overflow dep_gen records.
- Replay explicit edges with their recorded flags while preserving runtime OR-dedup semantics with creator dependencies, and reject records containing unknown flag bits.
- Preserve DFX buffer ownership after a ready entry is published when the push gate times out. `DeviceProfilerEngine` is shared by PMU, scope stats, L2 phase/task profiling, dep_gen, and args dump; this independent correctness fix was uncovered while investigating #1827.
- Cover inline, single-overflow, multi-overflow, wait-only, and explicit/creator dedup cases on A2/A3 and A5, and update the DFX documentation.

## Differential Gate Scope

Explicit dependencies are captured input shared by the oracle and annotated replay passes, so the differential gate cannot independently validate their recorded kind bytes. The A2/A3 and A5 dep_gen chain scene tests validate the capture/replay round trip across inline and overflow records.

`DepGenRecord` changes from 4672 to 4736 bytes. Host and device runtime artifacts must be rebuilt together rather than mixed with partial incremental outputs.

## Testing

- C++ unit tests: 125/125 passed, including `test_dep_gen_replay`, `test_dep_gen_collector_aicpu`, and `test_profiler_device_engine`.
- A2/A3 simulation dep_gen scene tests with manual cases: 2 passed.
- A5 simulation dep_gen scene tests with manual cases: 2 passed.
- A2/A3 onboard dep_gen scene tests with manual cases: 2 passed.
- `pre-commit run --from-ref upstream/main --to-ref HEAD`.
- A5 onboard was not run locally because this host has A2/A3 silicon; PR CI covers A5 hardware.

Fixes #1827
