### PR TITLE
Fix: align A5 HBG scheduler helpers with TMR

### DIFF
--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_graph.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_graph.h
@@ -25,10 +25,6 @@
 #define __aicore__
 #endif
 
-#ifndef __host__
-#define __host__
-#endif
-
 inline constexpr uint32_t SCHEDULER_GRAPH_TASK_DESCRIPTOR_STRIDE = 40;
 // TaskPayload includes the early-dispatch cache line in this wire layout.
 inline constexpr uint32_t SCHEDULER_GRAPH_TASK_PAYLOAD_STRIDE = 192;
@@ -90,18 +86,17 @@ static_assert(sizeof(SchedulerTaskInfo) == 24, "root classification result layou
 static_assert(sizeof(SchedulerTaskShape) == 24, "task shape result layout changed");
 static_assert(sizeof(SchedulerDispatchPredicate) == 24, "dispatch predicate layout changed");
 
-inline __host__ __aicore__ __gm__ uint8_t *
-scheduler_graph_descriptor(const SchedulerGraphView &graph, int64_t task_id) {
+inline __aicore__ __gm__ uint8_t *scheduler_graph_descriptor(const SchedulerGraphView &graph, int64_t task_id) {
     uint64_t slot = static_cast<uint64_t>(task_id);
     return reinterpret_cast<__gm__ uint8_t *>(graph.descriptors_address) +
            slot * SCHEDULER_GRAPH_TASK_DESCRIPTOR_STRIDE;
 }
-inline __host__ __aicore__ __gm__ uint8_t *scheduler_graph_payload(const SchedulerGraphView &graph, int64_t task_id) {
+inline __aicore__ __gm__ uint8_t *scheduler_graph_payload(const SchedulerGraphView &graph, int64_t task_id) {
     uint64_t slot = static_cast<uint64_t>(task_id);
     return reinterpret_cast<__gm__ uint8_t *>(graph.payloads_address) + slot * SCHEDULER_GRAPH_TASK_PAYLOAD_STRIDE;
 }
 
-inline __host__ __aicore__ int32_t
+inline __aicore__ int32_t
 scheduler_graph_fanin_id(const SchedulerGraphView &graph, int64_t task_id, int32_t fanin_index) {
     __gm__ uint8_t *payload = scheduler_graph_payload(graph, task_id);
     __gm__ uint8_t *field = payload + TASKPAYLOAD_FANIN_DELTA_OFFSET;
@@ -109,7 +104,7 @@ scheduler_graph_fanin_id(const SchedulerGraphView &graph, int64_t task_id, int32
     return reinterpret_cast<__gm__ int32_t *>(field + delta)[fanin_index];
 }
 
-inline __host__ __aicore__ SchedulerGraphResult
+inline __aicore__ SchedulerGraphResult
 scheduler_classify_task_shape(const SchedulerGraphView &graph, int64_t task_id, SchedulerTaskShape *shape) {
     if (shape == nullptr) return SchedulerGraphResult::UNSUPPORTED_SHAPE;
     *shape = {
@@ -160,7 +155,7 @@ scheduler_classify_task_shape(const SchedulerGraphView &graph, int64_t task_id, 
     return SchedulerGraphResult::OK;
 }
 
-inline __host__ __aicore__ SchedulerGraphResult scheduler_materialize_task_payload_resolved(
+inline __aicore__ SchedulerGraphResult scheduler_materialize_task_payload_resolved(
     const SchedulerGraphView &graph, const SchedulerTaskInfo &task, uint64_t function_bin_address,
     __gm__ DispatchPayload *dispatch_payload, int32_t block_idx = 0, int32_t block_num = 1
 ) {

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
@@ -18,6 +18,14 @@
 #include "common/platform_config.h"
 #include "dispatch_payload.h"
 
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__
+#endif
+
 #if !defined(__CCE_AICORE__)
 #include "runtime_types.h"
 #if __has_include("spin_hint.h")
@@ -615,18 +623,6 @@ inline uint64_t sync_start_drain_ack_subtree_token(uint64_t attempt) {
     return attempt | SYNC_START_DRAIN_ACK_SUBTREE_READY;
 }
 
-#ifndef __gm__
-#define __gm__
-#endif
-
-#ifndef __aicore__
-#define __aicore__
-#endif
-
-#ifndef __host__
-#define __host__
-#endif
-
 #endif
 
 // =============================================================================
@@ -712,33 +708,29 @@ struct alignas(16) SchedulerTaskMetadata {
     int32_t timing_slot;
 };
 
-inline __host__ __aicore__ bool scheduler_task_is_executable(uint8_t flags) {
-    return (flags & SCHEDULER_TASK_EXECUTABLE) != 0;
-}
+inline __aicore__ bool scheduler_task_is_executable(uint8_t flags) { return (flags & SCHEDULER_TASK_EXECUTABLE) != 0; }
 
-inline __host__ __aicore__ bool scheduler_task_has_fanin(uint8_t flags) {
-    return (flags & SCHEDULER_TASK_HAS_FANIN) != 0;
-}
+inline __aicore__ bool scheduler_task_has_fanin(uint8_t flags) { return (flags & SCHEDULER_TASK_HAS_FANIN) != 0; }
 
-inline __host__ __aicore__ bool scheduler_task_is_mix(uint8_t flags) { return (flags & SCHEDULER_TASK_MIX) != 0; }
+inline __aicore__ bool scheduler_task_is_mix(uint8_t flags) { return (flags & SCHEDULER_TASK_MIX) != 0; }
 
-inline __host__ __aicore__ bool scheduler_task_is_spmd(uint8_t flags) { return (flags & SCHEDULER_TASK_SPMD) != 0; }
+inline __aicore__ bool scheduler_task_is_spmd(uint8_t flags) { return (flags & SCHEDULER_TASK_SPMD) != 0; }
 
-inline __host__ __aicore__ bool scheduler_task_requires_sync_start(uint8_t flags) {
+inline __aicore__ bool scheduler_task_requires_sync_start(uint8_t flags) {
     return (flags & SCHEDULER_TASK_SYNC_START) != 0;
 }
 
-inline __host__ __aicore__ bool scheduler_task_is_inline(uint8_t flags) { return (flags & SCHEDULER_TASK_INLINE) != 0; }
+inline __aicore__ bool scheduler_task_is_inline(uint8_t flags) { return (flags & SCHEDULER_TASK_INLINE) != 0; }
 
-inline __host__ __aicore__ bool scheduler_task_has_predicate(uint8_t flags) {
+inline __aicore__ bool scheduler_task_has_predicate(uint8_t flags) {
     return (flags & SCHEDULER_TASK_HAS_PREDICATE) != 0;
 }
 
-inline __host__ __aicore__ bool scheduler_task_is_gang(uint8_t flags) {
+inline __aicore__ bool scheduler_task_is_gang(uint8_t flags) {
     return (flags & (SCHEDULER_TASK_MIX | SCHEDULER_TASK_SPMD)) != 0;
 }
 
-inline __host__ __aicore__ uint32_t scheduler_task_priority_bit(uint8_t flags) {
+inline __aicore__ uint32_t scheduler_task_priority_bit(uint8_t flags) {
     if (scheduler_task_requires_sync_start(flags)) return 1U;
     if (scheduler_task_is_mix(flags)) return 2U;
     if (scheduler_task_is_spmd(flags)) return 4U;
@@ -1221,6 +1213,11 @@ static_assert(offsetof(SchedulerWorkerContext, completion_enqueue_cycles) == 640
 static_assert(offsetof(SchedulerWorkerContext, scheduler_tail_trace) == 768, "scheduler tail trace offset changed");
 static_assert(sizeof(SchedulerTaskTrace) == 384, "task trace layout changed");
 
+template <typename T>
+inline __aicore__ __gm__ T *scheduler_state_at(__gm__ void *base, uint64_t offset) {
+    return reinterpret_cast<__gm__ T *>(reinterpret_cast<__gm__ uint8_t *>(base) + offset);
+}
+
 #if !defined(__CCE_AICORE__)
 #include <type_traits>
 static_assert(std::is_standard_layout_v<SchedulerTaskMetadata> && std::is_trivially_copyable_v<SchedulerTaskMetadata>);
@@ -1249,7 +1246,6 @@ static_assert(
     std::is_standard_layout_v<SchedulerWorkerContext> && std::is_trivially_copyable_v<SchedulerWorkerContext>
 );
 static_assert(std::is_standard_layout_v<SchedulerTailTrace> && std::is_trivially_copyable_v<SchedulerTailTrace>);
-#endif
 
 inline bool scheduler_layout_checked_add(uint64_t lhs, uint64_t rhs, uint64_t *out) {
     if (out == nullptr || rhs > UINT64_MAX - lhs) return false;
@@ -1335,11 +1331,6 @@ inline bool scheduler_plan_layout(
     return true;
 }
 
-template <typename T>
-inline __host__ __aicore__ __gm__ T *scheduler_state_at(__gm__ void *base, uint64_t offset) {
-    return reinterpret_cast<__gm__ T *>(reinterpret_cast<__gm__ uint8_t *>(base) + offset);
-}
-
 inline bool scheduler_init_data_from_layout(void *base, const AicoreSchedulerLayout &layout) {
     if (base == nullptr || (reinterpret_cast<uintptr_t>(base) & (SCHEDULER_STATE_ALIGNMENT - 1)) != 0) return false;
     __builtin_memset(base, 0, static_cast<size_t>(layout.total_size));
@@ -1386,3 +1377,4 @@ inline bool scheduler_init_data_from_layout(void *base, const AicoreSchedulerLay
         participants[i].task_id = SCHEDULER_TASK_ID_INVALID;
     return true;
 }
+#endif


### PR DESCRIPTION
## Problem

The A5 HBG scheduler contracts added shared helpers with declarations such as:

```cpp
inline __host__ __aicore__ bool scheduler_task_is_executable(...)
```

During a real A5 AICore build, CCEC defines `__CCE_AICORE__`, so the host-only fallback block in `scheduler_types.h` is skipped. `__aicore__` expands to `[aicore]`, while `__host__` remains an unknown token. The resulting declaration is effectively `inline __host__ [aicore] bool ...`, which CCEC cannot parse and prevents both AIC and AIV executor objects from compiling.

A5sim and the C++ unit tests did not catch this because their host compiler path expands both qualifiers to empty tokens. There is also a second boundary issue: after removing `__host__`, CCEC still sees host-only layout and initialization functions that call the now-AICore-qualified `scheduler_state_at`, producing an invalid host-to-AICore call.

## Why this change

TMR already uses one consistent cross-target convention: shared helpers are declared with `__aicore__` only. Platform headers provide the real AICore annotation for CCEC, while host builds define it to an empty fallback. Matching that convention avoids a separate CUDA-style `__host__` compatibility layer and makes the Host/AICore boundary explicit.

## Changes

- move the `__gm__` and `__aicore__` fallbacks to the shared portion of `scheduler_types.h`
- remove all `__host__` fallbacks and `__host__ __aicore__` declarations from the new scheduler contracts
- declare shared graph, metadata, and state-address helpers with `inline __aicore__`, matching TMR
- keep `scheduler_state_at` available to both Host and AICore translation units
- isolate type-trait validation, layout planning, and state initialization behind the existing host-only `!__CCE_AICORE__` boundary

## Testing

- [x] C++ no-hardware unit tests (123/123)
- [x] `test_a5_hbg_scheduler_contracts`
- [x] A5 package build
- [x] direct CCEC compilation of AIC and AIV executor objects
- [x] A5sim scene-test sweep (54/54)
- [x] pre-commit hooks for changed files