### PR TITLE
Add: kernel-mode C ABI skeleton and wire headers (K1)

### DIFF
--- a/docs/dynamic-linking.md
+++ b/docs/dynamic-linking.md
@@ -304,7 +304,9 @@ ChipWorker.init(device_id, bins)                       # Python wrapper
            simpler_unregister_callable, get_pipeline_contract,
            supports_concurrent_native_prepare_ctx,
            get_arena_bank_gm_heap_base_ctx, get_retained_temp_addr_ctx,
-           finalize_device
+           finalize_device, simpler_kernel_mode_supported,
+           simpler_kernel_mode_init, simpler_kernel_mode_prepare_callable,
+           simpler_kernel_mode_launch
     create_device_context() → DeviceContextHandle
     allocate zeroed, aligned, stable native-run storage per pipeline slot
     simpler_init(ctx, device_id, aicpu*, aicpu_size, aicore*, aicore_size, ...)

--- a/docs/user/reference/python-api.md
+++ b/docs/user/reference/python-api.md
@@ -112,7 +112,10 @@ ChipCallable.build(
 
 `ArgDirection` is `SCALAR`, `IN`, `OUT`, or `INOUT`. The signature list is
 positional and defines the task-arg order. `func_id` must match the id the
-orchestration submits. `ChipCallable` exposes `binary_size`.
+orchestration submits. `ChipCallable` exposes `binary_size` and
+`scalar_count`. `scalar_count` counts the signature's `SCALAR` entries,
+including for callables loaded from cached bytes. The tensor count is
+`sig_count - scalar_count`.
 
 Public `Worker` calls use `TaskArgs` containing address-free `Tensor` views at
 every level. The L2 leaf resolves those views into the internal

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -2779,6 +2779,14 @@ NB_MODULE(_task_interface, m) {
         )
 
         .def_prop_ro(
+            "scalar_count",
+            [](const PyChipCallable &self) -> int32_t {
+                return self.get().scalar_count();
+            },
+            "Number of SCALAR entries in the orchestration signature."
+        )
+
+        .def_prop_ro(
             "child_count",
             [](const PyChipCallable &self) -> int32_t {
                 return self.get().child_count();

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -148,6 +148,22 @@ int DeviceRunner::ensure_acl_ready(int device_id) {
         LOG_ERROR("ensure_acl_ready: invalid device_id %d", device_id);
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    // aclInit / aclrtSetDevice below, and the aclFinalize this records
+    // responsibility for, are acts of device ownership, so reaching this entry
+    // makes the context a program context. Latching here rather than merely
+    // testing is_kernel() closes the unclaimed path: ensure_acl_ready_ctx is a
+    // standalone initialization entry that callers reach without simpler_init
+    // (tests/ut/cpp/hardware/test_comm_lifecycle.cpp), and an unlatched context
+    // that took ACL ownership would later let a kernel latch coexist with
+    // acl_ready_, whose finalize resets a device this context does not own.
+    // Latching before the first ACL call is also what keeps the refusal
+    // side-effect-free. The latch is write-once: an ACL failure below leaves
+    // the identity in place, and a repeat call re-latches the same mode.
+    const int mode_rc = execution_mode_latch().latch(SIMPLER_MODE_PROGRAM);
+    if (mode_rc != 0) {
+        LOG_ERROR("ensure_acl_ready: refused — this context already belongs to kernel mode");
+        return mode_rc;
+    }
 
     // aclInit is process-wide; CANN returns ACL_ERROR_REPEAT_INITIALIZE if it
     // has already been initialized (possibly by another owner), which we
@@ -793,6 +809,14 @@ int DeviceRunner::force_reset_device() {
     if (device_id_ < 0) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    // aclrtResetDeviceForce would reset the caller's device and ACL context;
+    // a kernel-mode context owns neither (see ensure_acl_ready()), so error
+    // recovery on that path never resets the device out from under the host
+    // process.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("force_reset_device: refused — a kernel-mode context does not own the caller's device");
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
     // aclrtResetDeviceForce is an ACL API; bring ACL up for the whole sequence,
     // released on scope exit so a repeated poison-then-reset cycle in a
     // long-lived process leaks no ACL state.
@@ -1007,10 +1031,15 @@ int DeviceRunner::finalize() {
         return abandon_rc != 0 ? abandon_rc : reset_rc;
     }
 
-    int rc = attach_current_thread(device_id_);
-    if (rc != 0) {
-        LOG_ERROR("Failed to attach finalize thread to device %d: %d", device_id_, rc);
-        return rc;
+    // A kernel-mode context runs on the caller's already-current device, so
+    // this thread needs no bind and the context owns no device state to adopt.
+    int rc = 0;
+    if (!execution_mode_latch().is_kernel()) {
+        rc = attach_current_thread(device_id_);
+        if (rc != 0) {
+            LOG_ERROR("Failed to attach finalize thread to device %d: %d", device_id_, rc);
+            return rc;
+        }
     }
 
     // Cleanup performance profiling (including a2a3's dep_gen). Normally
@@ -1057,7 +1086,7 @@ int DeviceRunner::finalize() {
                 if (rc == 0) rc = finalize_rc;
             }
             acl_ready_ = false;
-        } else {
+        } else if (!execution_mode_latch().is_kernel()) {
             int reset_rc = rtDeviceReset(device_id_);
             if (reset_rc != 0) {
                 LOG_ERROR("rtDeviceReset(%d) failed during finalize: %d", device_id_, reset_rc);

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -107,6 +107,22 @@ int DeviceRunner::ensure_acl_ready(int device_id) {
         LOG_ERROR("ensure_acl_ready: invalid device_id %d", device_id);
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    // aclInit / aclrtSetDevice below, and the aclFinalize this records
+    // responsibility for, are acts of device ownership, so reaching this entry
+    // makes the context a program context. Latching here rather than merely
+    // testing is_kernel() closes the unclaimed path: ensure_acl_ready_ctx is a
+    // standalone initialization entry that callers reach without simpler_init
+    // (tests/ut/cpp/hardware/test_comm_lifecycle.cpp), and an unlatched context
+    // that took ACL ownership would later let a kernel latch coexist with
+    // acl_ready_, whose finalize resets a device this context does not own.
+    // Latching before the first ACL call is also what keeps the refusal
+    // side-effect-free. The latch is write-once: an ACL failure below leaves
+    // the identity in place, and a repeat call re-latches the same mode.
+    const int mode_rc = execution_mode_latch().latch(SIMPLER_MODE_PROGRAM);
+    if (mode_rc != 0) {
+        LOG_ERROR("ensure_acl_ready: refused — this context already belongs to kernel mode");
+        return mode_rc;
+    }
 
     // aclInit is process-wide; CANN returns 100002 if it has already been
     // initialized (possibly by another owner), which we treat as success.
@@ -749,6 +765,14 @@ int DeviceRunner::force_reset_device() {
     if (device_id_ < 0) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    // aclrtResetDeviceForce would reset the caller's device and ACL context;
+    // a kernel-mode context owns neither (see ensure_acl_ready()), so error
+    // recovery on that path never resets the device out from under the host
+    // process.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("force_reset_device: refused — a kernel-mode context does not own the caller's device");
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
     // aclrtResetDeviceForce is an ACL API; bring ACL up for the whole sequence,
     // released on scope exit so a repeated poison-then-reset cycle in a
     // long-lived process leaks no ACL state.
@@ -889,10 +913,15 @@ int DeviceRunner::finalize() {
         return abandon_rc != 0 ? abandon_rc : reset_rc;
     }
 
-    int rc = attach_current_thread(device_id_);
-    if (rc != 0) {
-        LOG_ERROR("Failed to attach finalize thread to device %d: %d", device_id_, rc);
-        return rc;
+    // A kernel-mode context runs on the caller's already-current device, so
+    // this thread needs no bind and the context owns no device state to adopt.
+    int rc = 0;
+    if (!execution_mode_latch().is_kernel()) {
+        rc = attach_current_thread(device_id_);
+        if (rc != 0) {
+            LOG_ERROR("Failed to attach finalize thread to device %d: %d", device_id_, rc);
+            return rc;
+        }
     }
 
     // Cleanup all profiling subsystems (free shm + per-buffer dev/host
@@ -923,7 +952,7 @@ int DeviceRunner::finalize() {
             if (rc == 0) rc = finalize_rc;
         }
         acl_ready_ = false;
-    } else {
+    } else if (!execution_mode_latch().is_kernel()) {
         int reset_rc = rtDeviceReset(device_id_);
         if (reset_rc != 0) {
             LOG_ERROR("rtDeviceReset(%d) failed during finalize: %d", device_id_, reset_rc);

--- a/src/common/platform/include/host/execution_mode_latch.h
+++ b/src/common/platform/include/host/execution_mode_latch.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <mutex>
+
+#include "execution_mode.h"
+#include "runtime_c_api.h"
+
+/**
+ * Write-once execution identity of one device context.
+ *
+ * A context's mode is a property of its construction, not a state that
+ * evolves: the C ABI creates contexts mode-less (`create_device_context`
+ * takes no parameters), so the first init entry to run completes the
+ * construction by latching the mode, and the latch never changes afterwards
+ * — not on finalize, not on error. `simpler_init` latches PROGRAM before
+ * touching any runner state, so a live program context is never unlatched
+ * and the program/kernel mutual exclusion is enforced on every init, not by
+ * anyone remembering a separate claim step. Re-initializing a finalized
+ * context under the same mode stays possible (latching the held mode is
+ * idempotent); changing a context's identity is not. That permission is real
+ * for PROGRAM, whose finalize resets device_id_ to -1; whether a KERNEL
+ * context may be re-initialized is decided by the kernel context's own
+ * lifecycle, not by this latch.
+ *
+ * There is no unlatch and no rollback: an init that fails after latching
+ * leaves the context on that identity permanently, so a handle from a failed
+ * kernel init can never be recycled into a program context. Latching is
+ * therefore the step an init takes once it has decided which identity it is
+ * constructing, and an init that adopts device state must roll that state
+ * back itself.
+ *
+ * Every kernel-mode guard keys on is_kernel(), which is false until an init
+ * latches KERNEL — so the guards arm exactly when a kernel context comes
+ * into existence.
+ */
+class ExecutionModeLatch {
+public:
+    /** Latch the identity. Idempotent for the held mode; a different mode
+        returns PTO_RUNTIME_ERR_INVALID_STATE. */
+    int latch(SimplerExecutionMode mode) {
+        std::scoped_lock lock(mutex_);
+        if (latched_ && mode_ != mode) return PTO_RUNTIME_ERR_INVALID_STATE;
+        mode_ = mode;
+        latched_ = true;
+        return 0;
+    }
+
+    bool is_kernel() const {
+        std::scoped_lock lock(mutex_);
+        return latched_ && mode_ == SIMPLER_MODE_KERNEL;
+    }
+
+    bool is_latched() const {
+        std::scoped_lock lock(mutex_);
+        return latched_;
+    }
+
+    /** The held mode; meaningful only once is_latched(). */
+    SimplerExecutionMode latched_mode() const {
+        std::scoped_lock lock(mutex_);
+        return mode_;
+    }
+
+private:
+    mutable std::mutex mutex_;
+    bool latched_{false};
+    SimplerExecutionMode mode_{SIMPLER_MODE_PROGRAM};
+};

--- a/src/common/platform/include/host/kernel_entry_validation.h
+++ b/src/common/platform/include/host/kernel_entry_validation.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "callable.h"
+#include "callable_protocol.h"
+#include "runtime_c_api.h"
+
+/**
+ * Structural argument validation shared by every host-runtime component's
+ * kernel-mode entries. Both platform c_api implementations (onboard and sim)
+ * route through these checks, so a stub and a real implementation accept and
+ * reject exactly the same arguments. Each function returns 0 or
+ * PTO_RUNTIME_ERR_INVALID_ARGUMENT and mutates nothing; logging stays with
+ * the callers.
+ */
+
+/* A binary buffer and its size describe one object, so they are valid only
+   present-together or absent-together. */
+inline bool kernel_binary_span_is_consistent(const void *binary, size_t size) {
+    return (binary == nullptr) == (size == 0);
+}
+
+/* Kernel mode fixes an arena region's capacity at its first commit: a captured
+   graph retains the committed base address, so growing the region (which
+   reallocates) or releasing it invalidates an address the graph still names.
+   A shrink is permitted — it keeps both the base and the committed size.
+
+   A caller must evaluate this over every region it is about to touch before
+   mutating any of them. The arena commit sequence rolls back all regions on
+   failure, and that rollback releases the very bases this refusal exists to
+   preserve, so a refusal raised mid-sequence destroys what it is protecting. */
+inline bool kernel_arena_change_is_forbidden(bool committed, size_t cached_size, size_t requested_size) {
+    if (!committed) return false;
+    if (requested_size == 0) return cached_size != 0;
+    return requested_size > cached_size;
+}
+
+inline int validate_kernel_init_args(
+    const void *ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
+    size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size, const void *config,
+    uint64_t context_generation
+) {
+    if (ctx == nullptr || config == nullptr) return PTO_RUNTIME_ERR_INVALID_ARGUMENT;
+    if (device_id < 0 || context_generation == 0) return PTO_RUNTIME_ERR_INVALID_ARGUMENT;
+    if (!kernel_binary_span_is_consistent(aicpu_binary, aicpu_size) ||
+        !kernel_binary_span_is_consistent(aicore_binary, aicore_size) ||
+        !kernel_binary_span_is_consistent(dispatcher_binary, dispatcher_size)) {
+        return PTO_RUNTIME_ERR_INVALID_ARGUMENT;
+    }
+    return 0;
+}
+
+inline int validate_kernel_prepare_callable_args(
+    const void *ctx, int32_t callable_id, const void *callable, size_t callable_size, const void *caller_stream
+) {
+    if (ctx == nullptr || callable == nullptr || caller_stream == nullptr) return PTO_RUNTIME_ERR_INVALID_ARGUMENT;
+    if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) return PTO_RUNTIME_ERR_INVALID_ARGUMENT;
+    if (callable_size < sizeof(ChipCallable)) return PTO_RUNTIME_ERR_INVALID_ARGUMENT;
+    /* ChipCallable's storage_ is CALLABLE_CHILD_ALIGN-aligned relative to the
+       header, so a misaligned image puts every child at a misaligned address. */
+    if (reinterpret_cast<uintptr_t>(callable) % alignof(ChipCallable) != 0) return PTO_RUNTIME_ERR_INVALID_ARGUMENT;
+    return 0;
+}
+
+inline int
+validate_kernel_launch_args(const void *ctx, int32_t callable_id, const void *args, const void *caller_stream) {
+    if (ctx == nullptr || args == nullptr || caller_stream == nullptr) return PTO_RUNTIME_ERR_INVALID_ARGUMENT;
+    if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) return PTO_RUNTIME_ERR_INVALID_ARGUMENT;
+    return 0;
+}

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -25,9 +25,11 @@
  */
 
 #include "callable.h"
+#include "callable_protocol.h"
 #include "call_config.h"
 #include "device_runner_base.h"
 #include "host/dep_gen_collector.h"  // make_deps_json_path
+#include "host/kernel_entry_validation.h"
 #include "prepare_callable_common.h"
 #include "runtime_c_api.h"
 #include "task_args_wire.h"
@@ -438,6 +440,17 @@ int simpler_init(
     if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
 
     DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
+
+    // Latching the identity is the first thing this entry does, so a context
+    // that already belongs to kernel mode is refused before any process- or
+    // runner-state mutation below. Latching PROGRAM is idempotent, which is
+    // what lets an init -> finalize -> init sequence on the same device run
+    // again.
+    const int latch_rc = runner->execution_mode_latch().latch(SIMPLER_MODE_PROGRAM);
+    if (latch_rc != 0) {
+        LOG_ERROR("simpler_init: refused — this context already belongs to kernel mode");
+        return latch_rc;
+    }
 
     // CANN dlog must be levelled BEFORE the device context is opened
     // (rtSetDevice inside attach_current_thread): CANN snapshots the
@@ -1214,6 +1227,49 @@ int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info) {
     } catch (...) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+}
+
+/* ===========================================================================
+ * Kernel-mode lifecycle
+ *
+ * This backend reports kernel mode unsupported: supported() is 0 and init
+ * refuses after the shared structural validation, so no context here ever
+ * latches kernel mode and prepare/launch reject with INVALID_STATE.
+ * Argument validation is shared with every other component through
+ * kernel_entry_validation.h, so an argument this stub accepts is one a real
+ * implementation accepts.
+ * =========================================================================== */
+
+int simpler_kernel_mode_supported(DeviceContextHandle) { return 0; }
+
+int simpler_kernel_mode_init(
+    DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *config, uint64_t context_generation
+) {
+    const int rc = validate_kernel_init_args(
+        ctx, device_id, aicpu_binary, aicpu_size, aicore_binary, aicore_size, dispatcher_binary, dispatcher_size,
+        config, context_generation
+    );
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_init: kernel mode is not supported by this host runtime");
+    return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
+
+int simpler_kernel_mode_prepare_callable(
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+) {
+    const int rc = validate_kernel_prepare_callable_args(ctx, callable_id, callable, callable_size, caller_stream);
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_prepare_callable: no live kernel context on this device context");
+    return PTO_RUNTIME_ERR_INVALID_STATE;
+}
+
+int simpler_kernel_mode_launch(DeviceContextHandle ctx, int32_t callable_id, const void *args, void *caller_stream) {
+    const int rc = validate_kernel_launch_args(ctx, callable_id, args, caller_stream);
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_launch: no live kernel context on this device context");
+    return PTO_RUNTIME_ERR_INVALID_STATE;
 }
 
 }  // extern "C"

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -372,6 +372,39 @@ int DeviceRunnerBase::setup_static_arena(
     // so their callers don't have to re-acquire.
     ArenaBank &bank = this->arena_bank(arena_bank);
 
+    // Captured graphs can retain committed base addresses, so kernel mode
+    // forbids growing or releasing a region that is already committed. The
+    // check covers all three regions and completes before the first
+    // commit_region call, which is what makes the refusal side-effect-free:
+    // a refusal raised from inside the commit sequence would fall into the
+    // unified rollback below, whose release() calls free the very base
+    // addresses the refusal exists to preserve.
+    if (execution_mode_latch().is_kernel()) {
+        const struct {
+            const DeviceArena &arena;
+            size_t cached_size;
+            size_t requested_size;
+            const char *name;
+        } regions[] = {
+            {bank.gm_heap, bank.cached_gm_heap_size, gm_heap_size, "gm_heap"},
+            {bank.gm_sm, bank.cached_gm_sm_size, gm_sm_size, "gm_sm"},
+            {bank.runtime_pool, bank.cached_runtime_arena_size, runtime_arena_size, "runtime_pool"},
+        };
+        for (const auto &region : regions) {
+            if (!kernel_arena_change_is_forbidden(
+                    region.arena.is_committed(), region.cached_size, region.requested_size
+                )) {
+                continue;
+            }
+            LOG_ERROR(
+                "setup_static_arena: kernel mode forbids %s committed region %s (cached %zu, requested %zu)",
+                region.requested_size == 0 ? "releasing" : "growing", region.name, region.cached_size,
+                region.requested_size
+            );
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
+    }
+
     bool arena_changed = false;
     auto commit_region = [&arena_changed](DeviceArena &arena, size_t &cached_size, size_t requested_size) -> int {
         if (requested_size == 0) {
@@ -441,6 +474,10 @@ int DeviceRunnerBase::setup_static_arena(
 }
 
 std::thread DeviceRunnerBase::create_thread(std::function<void()> fn) {
+    // A freshly spawned thread carries no CANN device context of its own, so
+    // this bind creates one rather than taking anything from the caller — it
+    // is the one rtSetDevice a borrowed-device context still owns, and it is
+    // scoped to a thread this runner created.
     int dev_id = device_id_;
     return std::thread([dev_id, fn = std::move(fn)]() {
         rtSetDevice(dev_id);
@@ -448,7 +485,7 @@ std::thread DeviceRunnerBase::create_thread(std::function<void()> fn) {
     });
 }
 
-int DeviceRunnerBase::attach_current_thread(int device_id) {
+int DeviceRunnerBase::bind_current_thread(int device_id) {
     if (device_id < 0) {
         LOG_ERROR("Invalid device_id: %d", device_id);
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -468,13 +505,57 @@ int DeviceRunnerBase::attach_current_thread(int device_id) {
         ACL_LOG_ERROR_DETAIL(rc);
         return rc;
     }
+    return 0;
+}
 
-    // simpler_init performs the only lifetime write. Prepared-run admission
-    // and execution subsequently attach different host threads, so repeated
-    // same-value writes here would still be a C++ data race.
+int DeviceRunnerBase::attach_current_thread(int device_id) {
+    // rtSetDevice and the op-execute watchdog below are acts of device
+    // ownership, so this entry belongs to a program context. A kernel context
+    // reaches its device through adopt_borrowed_device instead; the one caller
+    // here that runs under both identities is DeviceRunner::finalize(), which
+    // skips this call on a kernel latch.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("attach_current_thread: refused — a kernel-mode context does not own the caller's device");
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
+
+    int rc = bind_current_thread(device_id);
+    if (rc != 0) return rc;
+
+    // Both writers of device_id_ — this one and adopt_borrowed_device — guard
+    // on the still-unset value, and both run before any prepare, execution or
+    // collector thread attaches. Prepared-run admission and execution
+    // subsequently attach different host threads, so repeated same-value
+    // writes here would still be a C++ data race.
     if (device_id_ == -1) {
         timeout_config_ = resolve_onboard_timeout_config();
         configure_aicore_op_timeout();
+        device_id_ = device_id;
+    }
+    return 0;
+}
+
+int DeviceRunnerBase::adopt_borrowed_device(int device_id) {
+    // The caller already holds this device current on its own threads, so the
+    // only thing a kernel context takes from it is the identity: no
+    // rtSetDevice, and no configure_aicore_op_timeout, which would rewrite the
+    // op-execute watchdog for every other user of that card. Resolving the
+    // timeout config is pure environment parsing and stays, because the stream
+    // and scheduler timeouts derived from it are read on both identities.
+    if (!execution_mode_latch().is_kernel()) {
+        LOG_ERROR("adopt_borrowed_device: refused — the context has not latched kernel mode");
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
+    if (device_id < 0) {
+        LOG_ERROR("Invalid device_id: %d", device_id);
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    if (device_id_ != -1 && device_id_ != device_id) {
+        LOG_ERROR("DeviceRunner already on device %d; close before adopting device %d", device_id_, device_id);
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    if (device_id_ == -1) {
+        timeout_config_ = resolve_onboard_timeout_config();
         device_id_ = device_id;
     }
     return 0;

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -19,8 +19,9 @@
  *   - The trivial tensor-memory wrappers (`allocate_tensor`,
  *     `free_tensor`, `copy_*_device`).
  *   - The arena-pool accessors (`acquire_pooled_gm_heap`, etc.).
- *   - Device lifecycle: `attach_current_thread`,
- *     `configure_aicore_op_timeout`, `ensure_device_initialized`,
+ *   - Device lifecycle: `bind_current_thread`, `attach_current_thread`,
+ *     `adopt_borrowed_device`, `configure_aicore_op_timeout`,
+ *     `ensure_device_initialized`,
  *     `ensure_binaries_loaded`, persistent AICPU/AICore streams,
  *     dispatcher/executor bytes, `LoadAicpuOp`, `KernelArgsHelper`.
  *   - block_dim resolution: `query_max_block_dim`, `resolve_block_dim`.
@@ -65,8 +66,10 @@
 #include "aicpu_loader/host/load_aicpu_op.h"
 #include "host/chip_swimlane_collector.h"
 #include "host/dfx_run_config.h"
+#include "host/execution_mode_latch.h"
 #include "host/host_phase_records.h"
 #include "host/host_phase_run_state.h"
+#include "host/kernel_entry_validation.h"
 #include "host/memory_allocator.h"
 #include "host/pmu_collector.h"
 #include "host/runtime_timeout_config.h"
@@ -135,6 +138,15 @@ public:
      * distinct buffers; tests read this to prove the split is real.
      */
     uint64_t retained_temp_addr(uint32_t slot_id) const;
+
+    /**
+     * This context's execution identity, latched once by whichever init entry
+     * constructs it. Every kernel-mode guard on the ACL-lifecycle and arena
+     * paths keys on is_kernel(); `attach_current_thread` refuses outright on a
+     * kernel latch, which is what keeps the program-mode entries and the
+     * per-thread device bind off a borrowed device.
+     */
+    ExecutionModeLatch &execution_mode_latch() { return execution_mode_latch_; }
 
     /** Allocate / free / copy on the per-Worker `MemoryAllocator` + CANN runtime. */
     void *allocate_tensor(std::size_t bytes);
@@ -217,17 +229,37 @@ public:
     std::thread create_thread(std::function<void()> fn);
 
     /**
-     * Attach the current host thread to the target device.
+     * Bind the calling thread to a device, taking nothing else from it.
      *
-     * Required before host-side runtime initialization may allocate or
-     * free device memory on the current thread. Idempotent for the same
-     * id; errors if called with a different id after a prior attach.
-     * No streams are created here.
+     * Idempotent for the same id; errors if called with a different id after
+     * a prior adopt. Creates no streams and records no identity.
+     *
+     * @param device_id  Device ID (0-15)
+     * @return 0 on success, error code on failure.
+     */
+    int bind_current_thread(int device_id);
+
+    /**
+     * Bind the current host thread and adopt the device for a program
+     * context: on the first call it also resolves the timeout config, writes
+     * the card's op-execute watchdog, and records device_id_.
+     *
+     * Required before host-side runtime initialization may allocate or free
+     * device memory on the current thread. Refuses with
+     * PTO_RUNTIME_ERR_INVALID_STATE on a context latched to kernel mode, which
+     * owns neither the bind nor the watchdog.
      *
      * @param device_id  Device ID (0-15)
      * @return 0 on success, error code on failure.
      */
     int attach_current_thread(int device_id);
+    /**
+     * Record which device a kernel-mode context runs on. Takes no device side
+     * effect: the caller already holds the device current, so this neither
+     * binds the thread nor touches the card's op-execute watchdog. Requires
+     * the execution-mode latch to already read kernel.
+     */
+    int adopt_borrowed_device(int device_id);
 
     /**
      * One-shot device initialization. Performs, in order:
@@ -305,7 +337,7 @@ public:
         sdma_warmup_binary_ = std::move(sdma_warmup_binary);
     }
 
-    /** The device id captured by simpler_init's `attach_current_thread` call. */
+    /** Which device this context is on; -1 until an init entry adopts one. */
     int device_id() const { return device_id_; }
 
     /**
@@ -1213,9 +1245,16 @@ protected:
 
     // ---- State shared by both a2a3 and a5 ---------------------------------
     //
-    // `device_id_` is written once by simpler_init and is immutable while
-    // native prepare, execution, and collector threads attach to the runner.
+    // Which device this context is on — not a claim of ownership, which the
+    // execution-mode latch carries instead. Written once before any prepare,
+    // execution or collector thread attaches: `attach_current_thread` writes
+    // it for a program context and `adopt_borrowed_device` for a kernel one, both
+    // guarded on the still-unset value, so repeated same-value writes from
+    // later-attaching threads cannot race.
     int device_id_{-1};
+    // This context's execution identity. Write-once: the first init entry to
+    // run latches it, and it never changes afterwards.
+    ExecutionModeLatch execution_mode_latch_;
     int block_dim_{0};
     int cores_per_blockdim_{PLATFORM_CORES_PER_BLOCKDIM};
     int worker_count_{0};  // Stored for print_handshake_results

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -24,9 +24,11 @@
 #include "runtime_c_api.h"
 
 #include "callable.h"
+#include "callable_protocol.h"
 #include "call_config.h"
 #include "device_runner_base.h"
 #include "host/dep_gen_collector.h"  // make_deps_json_path
+#include "host/kernel_entry_validation.h"
 #include "prepare_callable_common.h"
 #include "task_args_wire.h"
 #include "native_run_context.h"
@@ -436,6 +438,18 @@ int simpler_init(
     if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
 
     SimDeviceRunnerBase *runner = static_cast<SimDeviceRunnerBase *>(ctx);
+
+    // Latching the identity is the first thing this entry does, so a context
+    // that already belongs to kernel mode is refused before any process- or
+    // runner-state mutation below. Latching PROGRAM is idempotent, which is
+    // what lets an init -> finalize -> init sequence on the same device run
+    // again.
+    const int latch_rc = runner->execution_mode_latch().latch(SIMPLER_MODE_PROGRAM);
+    if (latch_rc != 0) {
+        LOG_ERROR("simpler_init: refused — this context already belongs to kernel mode");
+        return latch_rc;
+    }
+
     runner->set_dma_workspace_request(enable_sdma != 0);
 
     int rc;
@@ -1019,6 +1033,49 @@ size_t committed_device_memory_ctx(DeviceContextHandle ctx) {
 int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info) {
     if (ctx == NULL || info == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
+
+/* ===========================================================================
+ * Kernel-mode lifecycle
+ *
+ * Simulation never supports kernel mode: it has no real streams for a caller
+ * to lend. supported() is 0 and init refuses after the shared structural
+ * validation, so no context here ever latches kernel mode and
+ * prepare/launch reject with INVALID_STATE. Argument validation is shared
+ * with every other component through kernel_entry_validation.h, so an
+ * argument this stub accepts is one the onboard path accepts too.
+ * =========================================================================== */
+
+int simpler_kernel_mode_supported(DeviceContextHandle) { return 0; }
+
+int simpler_kernel_mode_init(
+    DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *config, uint64_t context_generation
+) {
+    const int rc = validate_kernel_init_args(
+        ctx, device_id, aicpu_binary, aicpu_size, aicore_binary, aicore_size, dispatcher_binary, dispatcher_size,
+        config, context_generation
+    );
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_init: kernel mode is not supported by the simulator");
+    return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
+
+int simpler_kernel_mode_prepare_callable(
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+) {
+    const int rc = validate_kernel_prepare_callable_args(ctx, callable_id, callable, callable_size, caller_stream);
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_prepare_callable: no live kernel context on this device context");
+    return PTO_RUNTIME_ERR_INVALID_STATE;
+}
+
+int simpler_kernel_mode_launch(DeviceContextHandle ctx, int32_t callable_id, const void *args, void *caller_stream) {
+    const int rc = validate_kernel_launch_args(ctx, callable_id, args, caller_stream);
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_launch: no live kernel context on this device context");
+    return PTO_RUNTIME_ERR_INVALID_STATE;
 }
 
 }  // extern "C"

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -55,6 +55,7 @@
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "platform_comm/comm.h"
+#include "host/execution_mode_latch.h"
 #include "host/memory_allocator.h"
 #include "host/chip_swimlane_collector.h"
 #include "host/dfx_run_config.h"
@@ -278,6 +279,14 @@ public:
     void set_dma_workspace_request(bool enable_sdma) { sdma_requested_ = enable_sdma; }
     int ensure_dma_workspace_provisioned();
     int device_id() const { return device_id_; }
+
+    /**
+     * This context's execution identity, latched once by whichever init entry
+     * constructs it. Simulation supports program mode only: it has no device
+     * streams for a caller to lend.
+     */
+    ExecutionModeLatch &execution_mode_latch() { return execution_mode_latch_; }
+
     uint64_t last_device_wall_ns() const { return device_wall_ns_; }
     // Per-phase AICPU wall (ns) from the most recent run; RunWall aliases
     // last_device_wall_ns(). 0 for a phase that was never stamped. Used to emit
@@ -386,13 +395,19 @@ protected:
     // --- Shared state (protected so subclass execution / init_* / finalize()
     // can read or write directly) ----------------------------------------
 
-    // Configuration. device_id_ is set once in attach_current_thread() during
-    // simpler_init and read afterwards; the user's call sequence is single-
-    // threaded with respect to it so plain int is sufficient.
+    // Configuration. device_id_ is which device this context is on — not a
+    // claim of ownership, which the execution-mode latch carries instead. Set
+    // once in attach_current_thread() during simpler_init and read afterwards;
+    // the user's call sequence is single-threaded with respect to it so plain
+    // int is sufficient.
     int device_id_{-1};
     int block_dim_{0};
     int cores_per_blockdim_{PLATFORM_CORES_PER_BLOCKDIM};
     int worker_count_{0};
+
+    // This context's execution identity. Write-once: the first init entry to
+    // run latches it, and it never changes afterwards.
+    ExecutionModeLatch execution_mode_latch_;
 
     // Executor binaries — populated once via set_executors() during simpler_init,
     // owned for the rest of the runner's lifetime.

--- a/src/common/task_interface/callable.h
+++ b/src/common/task_interface/callable.h
@@ -40,9 +40,19 @@
 #include <cstring>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "arg_direction.h"
+
+// signature contains sig_count validated entries.
+inline int32_t count_scalar_args(const ArgDirection *signature, int32_t sig_count) {
+    int32_t scalar_count = 0;
+    for (int32_t i = 0; i < sig_count; ++i) {
+        if (signature[i] == ArgDirection::SCALAR) ++scalar_count;
+    }
+    return scalar_count;
+}
 
 // ============================================================================
 // Forward declaration
@@ -129,6 +139,15 @@ struct Callable {
     uint32_t func_name_len() const { return func_name_len_; }
     const char *config_name() const { return config_name_; }
     uint32_t config_name_len() const { return config_name_len_; }
+    int32_t scalar_count() const {
+        if (sig_count_ < 0 || sig_count_ > MaxSig) {
+            throw std::invalid_argument(
+                "Callable: signature count " + std::to_string(sig_count_) + " is outside the supported range [0, " +
+                std::to_string(MaxSig) + "]"
+            );
+        }
+        return count_scalar_args(signature_, sig_count_);
+    }
 
     const Child &child(int32_t i) const {
         if (i < 0 || i >= child_count_) throw std::out_of_range("Callable: child index out of range");
@@ -176,6 +195,41 @@ static_assert(
     offsetof(ChipCallable, storage_) % CALLABLE_CHILD_ALIGN == 0,
     "ChipCallable.storage_ must be CALLABLE_CHILD_ALIGN-aligned for SIMT kernel binaries"
 );
+
+// Callable bytes are shipped through L3/L4 IPC and the on-disk kernel cache,
+// so the header layout is wire ABI. The constants below encode
+// CHIP_MAX_TENSOR_ARGS = 256, CORE_MAX_TENSOR_ARGS = 32,
+// CALLABLE_FUNC_NAME_MAX = 64, and MaxChildren = 1024; a deliberate capacity
+// change updates them in the same commit.
+static_assert(
+    std::is_trivially_copyable_v<ChipCallable> && std::is_standard_layout_v<ChipCallable>,
+    "ChipCallable wire ABI: must stay memcpy-able POD"
+);
+static_assert(
+    std::is_trivially_copyable_v<CoreCallable> && std::is_standard_layout_v<CoreCallable>,
+    "CoreCallable wire ABI: must stay memcpy-able POD"
+);
+static_assert(offsetof(ChipCallable, signature_) == 0, "ChipCallable wire ABI: signature offset changed");
+static_assert(offsetof(ChipCallable, sig_count_) == 1024, "ChipCallable wire ABI: sig_count offset changed");
+static_assert(offsetof(ChipCallable, binary_size_) == 1028, "ChipCallable wire ABI: binary_size offset changed");
+static_assert(offsetof(ChipCallable, func_name_) == 1032, "ChipCallable wire ABI: func_name offset changed");
+static_assert(offsetof(ChipCallable, func_name_len_) == 1096, "ChipCallable wire ABI: func_name_len offset changed");
+static_assert(offsetof(ChipCallable, child_func_ids_) == 1100, "ChipCallable wire ABI: child_func_ids offset changed");
+static_assert(offsetof(ChipCallable, child_offsets_) == 5196, "ChipCallable wire ABI: child_offsets offset changed");
+static_assert(offsetof(ChipCallable, child_count_) == 9292, "ChipCallable wire ABI: child_count offset changed");
+static_assert(offsetof(ChipCallable, config_name_) == 9296, "ChipCallable wire ABI: config_name offset changed");
+static_assert(
+    offsetof(ChipCallable, config_name_len_) == 9360, "ChipCallable wire ABI: config_name_len offset changed"
+);
+static_assert(offsetof(ChipCallable, storage_) == 9376, "ChipCallable wire ABI: storage offset changed");
+static_assert(sizeof(ChipCallable) == 9376, "ChipCallable wire ABI: header size changed");
+static_assert(offsetof(CoreCallable, signature_) == 0, "CoreCallable wire ABI: signature offset changed");
+static_assert(offsetof(CoreCallable, sig_count_) == 128, "CoreCallable wire ABI: sig_count offset changed");
+static_assert(offsetof(CoreCallable, binary_size_) == 132, "CoreCallable wire ABI: binary_size offset changed");
+static_assert(offsetof(CoreCallable, resolved_addr_) == 136, "CoreCallable wire ABI: resolved_addr offset changed");
+static_assert(offsetof(CoreCallable, storage_) == 144, "CoreCallable wire ABI: storage offset changed");
+static_assert(sizeof(CoreCallable) == 144, "CoreCallable wire ABI: header size changed");
+static_assert(CoreCallable::binary_data_offset() == 192, "CoreCallable wire ABI: binary data offset changed");
 
 // ============================================================================
 // Factory: make_callable for static leaf

--- a/src/common/task_interface/execution_mode.h
+++ b/src/common/task_interface/execution_mode.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The one definition of a context's execution mode, shared by every layer
+ * that names it: the host-side identity latch on the platform runners, the
+ * invocation wire header, and the C ABI documentation. A context's mode is
+ * decided by which init entry runs first and never changes afterwards.
+ */
+
+#pragma once
+
+typedef enum SimplerExecutionMode {
+    /* Historical exclusive-device semantics, claimed by simpler_init. */
+    SIMPLER_MODE_PROGRAM = 0,
+    /* Borrowed-device semantics, claimed by simpler_kernel_mode_init. */
+    SIMPLER_MODE_KERNEL = 1,
+} SimplerExecutionMode;

--- a/src/common/task_interface/kernel_invocation_header.h
+++ b/src/common/task_interface/kernel_invocation_header.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Unified invocation-args wire header (host → AICPU).
+ *
+ * Every kernel-mode launch ships one immutable args snapshot to the AICPU:
+ * this fixed header followed by `payload_bytes` of runtime-specific payload.
+ * The header is the shared envelope both runtimes use; the payload format
+ * under it belongs to each runtime (tensormap_and_ringbuffer carries
+ * graph-build input, host_build_graph carries a serialized graph blob) and is
+ * not constrained here. AICPU dispatch consumers must validate identity,
+ * generation, and capacity before consuming the payload, and reject nonzero
+ * host_copy_tensor_count or reserved_. Producers must zero-initialize the
+ * complete header before assigning invocation fields.
+ *
+ * Both sides of this wire are produced by the same build (`build_runtimes.py`
+ * emits the host runtime and the AICPU executor into one
+ * `build/lib/{arch}/{variant}/{runtime}/`), so the struct carries no version
+ * or size negotiation: evolving it means changing both sides in one tree.
+ * The layout is still shipped by memcpy through CANN's HostArgs deep copy, so
+ * the struct is POD, position-independent, and carries no pointers.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "execution_mode.h"
+
+typedef struct SimplerKernelInvocationHeader {
+    uint32_t mode;       /* SimplerExecutionMode of the issuing context */
+    int32_t callable_id; /* target callable; matches the prepared registration */
+    /* Occupancy generation of the residency slot `callable_id` resolves to —
+       a property of the slot, not of the callable in it. The counter advances
+       when the slot takes a different tenant, so a generation carried by the
+       callable could not detect slot reuse. Zero means "not recorded"; a live
+       generation starts at 1, matching PipelineSlotLease and CanonicalIdentity.
+       The comparison belongs on the AICPU dispatch path because replay does
+       not return to the host, so a stale captured snapshot has to be caught
+       on-device. */
+    uint64_t generation;
+    /* Byte length of the runtime-specific payload that follows this header. */
+    uint64_t payload_bytes;
+    /* Arg counts of this invocation. ChipCallable's sig_count includes both
+       tensors and scalars. Consumers count its ArgDirection::SCALAR entries,
+       compare scalar_count with that count, and compare tensor_count with
+       sig_count minus that count. */
+    int32_t tensor_count;
+    int32_t scalar_count;
+    /* Reserved host-only duplicate tensor count; must be zero. */
+    int32_t host_copy_tensor_count;
+    uint32_t reserved_; /* Must be zero. */
+} SimplerKernelInvocationHeader;
+
+#ifdef __cplusplus
+#include <type_traits>
+
+static_assert(
+    std::is_trivially_copyable_v<SimplerKernelInvocationHeader> &&
+    std::is_standard_layout_v<SimplerKernelInvocationHeader>
+);
+static_assert(sizeof(SimplerKernelInvocationHeader) == 40);
+static_assert(offsetof(SimplerKernelInvocationHeader, mode) == 0);
+static_assert(offsetof(SimplerKernelInvocationHeader, callable_id) == 4);
+static_assert(offsetof(SimplerKernelInvocationHeader, generation) == 8);
+static_assert(offsetof(SimplerKernelInvocationHeader, payload_bytes) == 16);
+static_assert(offsetof(SimplerKernelInvocationHeader, tensor_count) == 24);
+static_assert(offsetof(SimplerKernelInvocationHeader, scalar_count) == 28);
+static_assert(offsetof(SimplerKernelInvocationHeader, host_copy_tensor_count) == 32);
+static_assert(offsetof(SimplerKernelInvocationHeader, reserved_) == 36);
+#endif

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -201,6 +201,10 @@ void ChipWorker::init(
     bind_host_log_state(handle, "host runtime");
 
     GetPipelineContractFn get_pipeline_contract_fn = nullptr;
+    KernelSupportedFn kernel_supported_fn = nullptr;
+    KernelInitFn kernel_init_fn = nullptr;
+    KernelPrepareCallableFn kernel_prepare_callable_fn = nullptr;
+    KernelLaunchFn kernel_launch_fn = nullptr;
     try {
         create_device_context_fn_ = load_symbol<CreateDeviceContextFn>(handle, "create_device_context");
         destroy_device_context_fn_ = load_symbol<DestroyDeviceContextFn>(handle, "destroy_device_context");
@@ -232,11 +236,13 @@ void ChipWorker::init(
         get_run_stream_set_create_count_fn_ =
             load_symbol<GetAicpuDlopenCountFn>(handle, "get_run_stream_set_create_count");
         finalize_device_fn_ = load_symbol<FinalizeDeviceFn>(handle, "finalize_device");
-        // ACL lifecycle + comm_* are part of the uniform host_runtime.so ABI.
-        // Every platform runtime exports all of them — runtimes that do not
-        // have a real backend (today: a5) ship not-supported stubs rather
-        // than omitting the symbols.  This keeps ChipWorker.init platform-
-        // agnostic: no per-symbol probing, no half-loaded extension groups.
+        // ACL lifecycle + comm_* + kernel mode are part of the uniform
+        // host_runtime.so ABI. Every platform runtime exports all of them —
+        // runtimes that do not have a real backend (today: a5 for comm, every
+        // variant for kernel mode) ship not-supported stubs rather than
+        // omitting the symbols, so these groups resolve unconditionally and
+        // never half-load. simpler_kernel_mode_supported answers the runtime
+        // capability question at call time; it does not gate symbol resolution.
         ensure_acl_ready_fn_ = load_symbol<EnsureAclReadyFn>(handle, "ensure_acl_ready_ctx");
         create_comm_stream_fn_ = load_symbol<CreateCommStreamFn>(handle, "create_comm_stream_ctx");
         destroy_comm_stream_fn_ = load_symbol<DestroyCommStreamFn>(handle, "destroy_comm_stream_ctx");
@@ -253,6 +259,11 @@ void ChipWorker::init(
         comm_global_domain_release_fn_ = load_symbol<CommGlobalDomainReleaseFn>(handle, "comm_global_domain_release");
         comm_barrier_fn_ = load_symbol<CommBarrierFn>(handle, "comm_barrier");
         comm_destroy_fn_ = load_symbol<CommDestroyFn>(handle, "comm_destroy");
+        kernel_supported_fn = load_symbol<KernelSupportedFn>(handle, "simpler_kernel_mode_supported");
+        kernel_init_fn = load_symbol<KernelInitFn>(handle, "simpler_kernel_mode_init");
+        kernel_prepare_callable_fn =
+            load_symbol<KernelPrepareCallableFn>(handle, "simpler_kernel_mode_prepare_callable");
+        kernel_launch_fn = load_symbol<KernelLaunchFn>(handle, "simpler_kernel_mode_launch");
     } catch (...) {
         throw;
     }
@@ -380,6 +391,10 @@ void ChipWorker::init(
         comm_global_domain_release_fn_ = nullptr;
         comm_barrier_fn_ = nullptr;
         comm_destroy_fn_ = nullptr;
+        kernel_supported_fn_ = nullptr;
+        kernel_init_fn_ = nullptr;
+        kernel_prepare_callable_fn_ = nullptr;
+        kernel_launch_fn_ = nullptr;
         runtime_bufs_.clear();
         throw;
     }
@@ -439,11 +454,19 @@ void ChipWorker::init(
         comm_global_domain_release_fn_ = nullptr;
         comm_barrier_fn_ = nullptr;
         comm_destroy_fn_ = nullptr;
+        kernel_supported_fn_ = nullptr;
+        kernel_init_fn_ = nullptr;
+        kernel_prepare_callable_fn_ = nullptr;
+        kernel_launch_fn_ = nullptr;
         runtime_bufs_.clear();
         throw std::runtime_error("simpler_init failed with code " + std::to_string(init_rc));
     }
 
     lib_handle_ = host_guard.release();
+    kernel_supported_fn_ = kernel_supported_fn;
+    kernel_init_fn_ = kernel_init_fn;
+    kernel_prepare_callable_fn_ = kernel_prepare_callable_fn;
+    kernel_launch_fn_ = kernel_launch_fn;
     device_id_ = device_id;
     // Published only once the runtime is up: the rollback paths above leave the
     // default K=1 contract in place, so a failed init never reports the counts
@@ -529,6 +552,10 @@ void ChipWorker::finalize() {
     comm_global_domain_release_fn_ = nullptr;
     comm_barrier_fn_ = nullptr;
     comm_destroy_fn_ = nullptr;
+    kernel_supported_fn_ = nullptr;
+    kernel_init_fn_ = nullptr;
+    kernel_prepare_callable_fn_ = nullptr;
+    kernel_launch_fn_ = nullptr;
     runtime_bufs_.clear();
     pipeline_generations_.reset();
     pipeline_contract_ = {PTO_PIPELINE_CONTRACT_ABI_VERSION, 0, 1, {}};

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -296,6 +296,10 @@ private:
     using CommGlobalDomainReleaseFn = int (*)(uint64_t);
     using CommBarrierFn = int (*)(void *);
     using CommDestroyFn = int (*)(void *);
+    using KernelSupportedFn = decltype(&simpler_kernel_mode_supported);
+    using KernelInitFn = decltype(&simpler_kernel_mode_init);
+    using KernelPrepareCallableFn = decltype(&simpler_kernel_mode_prepare_callable);
+    using KernelLaunchFn = decltype(&simpler_kernel_mode_launch);
 
     struct CommSession {
         void *handle = nullptr;
@@ -356,6 +360,10 @@ private:
     CommGlobalDomainReleaseFn comm_global_domain_release_fn_ = nullptr;
     CommBarrierFn comm_barrier_fn_ = nullptr;
     CommDestroyFn comm_destroy_fn_ = nullptr;
+    KernelSupportedFn kernel_supported_fn_ = nullptr;
+    KernelInitFn kernel_init_fn_ = nullptr;
+    KernelPrepareCallableFn kernel_prepare_callable_fn_ = nullptr;
+    KernelLaunchFn kernel_launch_fn_ = nullptr;
     void *device_ctx_ = nullptr;
     std::vector<CommSession> comm_sessions_;
     std::unordered_map<uint64_t, size_t> comm_session_index_;

--- a/src/common/worker/runtime_c_api.h
+++ b/src/common/worker/runtime_c_api.h
@@ -30,6 +30,9 @@
  *                   simpler_unregister_callable,
  *                   get_aicpu_dlopen_count, get_host_dlopen_count,
  *                   get_run_stream_set_create_count
+ *   - kernel mode:  simpler_kernel_mode_supported, simpler_kernel_mode_init,
+ *                   simpler_kernel_mode_prepare_callable,
+ *                   simpler_kernel_mode_launch
  *   - pipeline:     get_pipeline_contract,
  *                   supports_concurrent_native_prepare_ctx,
  *                   get_arena_bank_gm_heap_base_ctx,
@@ -102,6 +105,11 @@ enum {
     /* The request names a capability this platform/runtime does not implement. */
     PTO_RUNTIME_ERR_UNSUPPORTED = PTO_RUNTIME_ERR_BASE - 1,
     PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE = PTO_RUNTIME_ERR_BASE - 2,
+    /* The call is structurally valid but conflicts with the context's
+       execution mode or lifecycle (e.g. launch before kernel initialization). */
+    PTO_RUNTIME_ERR_INVALID_STATE = PTO_RUNTIME_ERR_BASE - 3,
+    /* A caller supplied an invalid pointer, id, size, or other argument. */
+    PTO_RUNTIME_ERR_INVALID_ARGUMENT = PTO_RUNTIME_ERR_BASE - 4,
 };
 
 /** Return values from simpler_poll_run(). */
@@ -324,7 +332,8 @@ int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *de
  *      separate call. Only `prewarm_config->runtime_env` is read.
  *
  * Returns 0 on success, negative on attach, provisioning, or prewarm-build
- * failure.
+ * failure, and PTO_RUNTIME_ERR_INVALID_STATE when the context is already
+ * latched to kernel mode.
  */
 int simpler_init(
     DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
@@ -522,6 +531,122 @@ size_t get_host_dlopen_count(DeviceContextHandle ctx);
  * bootstrap pair.
  */
 size_t get_run_stream_set_create_count(DeviceContextHandle ctx);
+
+/* ===========================================================================
+ * Kernel-mode lifecycle (four entries + finalize_device)
+ *
+ * A context has one of two execution modes for its whole lifetime, decided by
+ * which init entry runs first. simpler_init latches program mode — the
+ * exclusive-device path driven through the prepared-run family
+ * above. simpler_kernel_mode_init latches kernel mode, which borrows the
+ * caller's already-current device and caller-owned stream to enqueue one
+ * bounded asynchronous operator per launch: no device reset, no internal
+ * stream/device synchronize on the prepare/launch/close paths, zero
+ * allocation at launch, and no capture/model-state queries, so a launch is
+ * capturable by ACLGraph as an ordinary node.
+ *
+ * Identity is a write-once property of the context, not a state that evolves:
+ * ExecutionModeLatch on the platform runner holds it, the first init entry to
+ * run latches it, and it never changes — not on finalize, not on error. There
+ * is no separate declaration call to forget, and no unlatch, so a handle from
+ * a failed kernel init can never be recycled into a program context.
+ * simpler_init latches PROGRAM before touching any process or runner state, so
+ * the mutual exclusion is enforced on every program init. Every kernel-mode
+ * guard on the device/ACL lifecycle and arena paths keys on the latch reading
+ * kernel. A call that conflicts with the context's execution mode returns
+ * PTO_RUNTIME_ERR_INVALID_STATE.
+ *
+ * Kernel-mode capacity is a mode invariant, not a gated state: `config` is
+ * context-static, so each pooled arena region is committed at most once and
+ * never grown or released afterwards. The platform arena reports a growth or
+ * release request under kernel mode as a capacity invariant break
+ * (PTO_RUNTIME_ERR_INTERNAL), and capacity intent travels in
+ * CallConfig.runtime_env like everywhere else.
+ *
+ * Every host_runtime.so exports all four entries below, so a consumer resolves
+ * them unconditionally like the rest of the uniform ABI; supported answers the
+ * capability question at call time rather than gating symbol resolution.
+ * Variants without kernel-mode support
+ * export stubs that run the same structural validation and then refuse —
+ * supported returns 0, init reports PTO_RUNTIME_ERR_UNSUPPORTED, and
+ * prepare_callable and launch report PTO_RUNTIME_ERR_INVALID_STATE because
+ * no kernel context is live. The fifth lifecycle entry is the existing
+ * finalize_device(): in kernel mode it releases only context-owned resources
+ * and never resets the device or finalizes ACL. device_id_ records which
+ * device a context is on rather than a claim on it, so a kernel context
+ * reaches that teardown path; the platform finalize() skips the per-thread
+ * device bind on a kernel latch, because the caller already holds its own
+ * device current.
+ *
+ * Structural argument errors return PTO_RUNTIME_ERR_INVALID_ARGUMENT before
+ * capability or lifecycle checks. These entries accept only POD structs,
+ * serialized blobs, and device/stream pointers — never framework objects.
+ * The caller stream is always an explicit parameter and is never stored
+ * beyond the call or destroyed by simpler.
+ * =========================================================================== */
+
+/**
+ * Return nonzero when this runtime can execute kernel-mode launches.
+ *
+ * This is the capability question a caller asks before choosing between the
+ * kernel-mode entries and the program-mode prepared-run family. It is callable
+ * on a context that create_device_context() has returned but that no init has
+ * touched; at that point the context exists but names no device —
+ * create_device_context() takes no device and device_id_ is still unset — so an
+ * implementation must answer from the runtime build alone, never from init
+ * state or device identity. `ctx` is accepted for signature symmetry with the
+ * rest of the family and must not be dereferenced for a device.
+ */
+int simpler_kernel_mode_supported(DeviceContextHandle ctx);
+
+/**
+ * Initialize a kernel-mode context on the caller's already-current device.
+ *
+ * A successful call latches kernel mode on the context — mutually exclusive
+ * with the program-mode simpler_init — and the latch controls the
+ * kernel-mode guards on the platform's device/ACL lifecycle and arena paths.
+ *
+ * Takes no device ownership: no device reset, no ACL init/finalize, and no
+ * stream or device synchronize on this path. Creates only context-owned
+ * persistent handles used by asynchronous preparation and launch. `config`
+ * is context-static; launches never mutate it. `context_generation` is a
+ * nonzero host-process-unique identity minted by the caller for sequential
+ * contexts; generation zero is invalid.
+ */
+int simpler_kernel_mode_init(
+    DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *config, uint64_t context_generation
+);
+
+/**
+ * Stage one callable for kernel-mode launches, outside ACLGraph capture.
+ *
+ * `callable` points to a canonical ChipCallable image of exactly
+ * `callable_size` bytes. Validating every flexible-array offset before the
+ * image is hashed or uploaded is the implementation's obligation; the shared
+ * entry validation checks only the image's alignment, its size floor, and the
+ * callable id range. Preparation may allocate persistent state and
+ * enqueue asynchronous device work on `caller_stream`, but never synchronizes
+ * a stream or device — preparation errors surface through the caller's own
+ * warmup + synchronize. The stream is borrowed for this call only.
+ */
+int simpler_kernel_mode_prepare_callable(
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+);
+
+/**
+ * Enqueue one bounded asynchronous kernel-mode operator invocation.
+ *
+ * `args` points to a ChipStorageTaskArgs POD whose tensor addresses are
+ * caller-owned device addresses; they are passed through without ever being
+ * dereferenced on the host. A launch performs no device malloc/free, no
+ * tensor staging, no synchronize, no capture-state query, and no
+ * stream-to-model attachment — keeping those out of the launch path is the
+ * implementation's obligation. A return of 0 means the sequence was enqueued;
+ * device execution may still be in flight and may still fail asynchronously.
+ */
+int simpler_kernel_mode_launch(DeviceContextHandle ctx, int32_t callable_id, const void *args, void *caller_stream);
 
 #ifdef __cplusplus
 }

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -500,6 +500,37 @@ set_tests_properties(test_native_run_acceptance PROPERTIES LABELS "no_hardware")
 # callers invoke it from different host threads.
 add_common_utils_test(test_host_api common/test_host_api.cpp)
 
+# Kernel-mode entry argument validation: shared by every host-runtime
+# component (real implementation and stub alike), so its rejection rules are
+# provable here without any device or built .so.
+add_executable(test_kernel_entry_validation common/test_kernel_entry_validation.cpp)
+target_include_directories(test_kernel_entry_validation PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/worker
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+    # src/common is needed so `#include "utils/device_arena.h"` resolves.
+    ${CMAKE_SOURCE_DIR}/../../../src/common
+)
+target_link_libraries(test_kernel_entry_validation PRIVATE ${GTEST_MAIN_LIB} ${GTEST_LIB} pthread)
+add_test(NAME test_kernel_entry_validation COMMAND test_kernel_entry_validation)
+set_tests_properties(test_kernel_entry_validation PROPERTIES LABELS "no_hardware")
+
+# Write-once execution identity: the latch both runner bases hold and every
+# kernel-mode guard reads.
+add_executable(test_execution_mode_latch
+    common/test_execution_mode_latch.cpp
+)
+target_include_directories(test_execution_mode_latch PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/worker
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+)
+target_link_libraries(test_execution_mode_latch PRIVATE ${GTEST_MAIN_LIB} ${GTEST_LIB} pthread)
+add_test(NAME test_execution_mode_latch COMMAND test_execution_mode_latch)
+set_tests_properties(test_execution_mode_latch PROPERTIES LABELS "no_hardware")
+
 # Runtime extension payloads are per-run state even though the collector's
 # shared-memory resources remain resident across runs.
 add_executable(test_chip_swimlane_collector
@@ -544,7 +575,9 @@ set_tests_properties(test_sim_run_completion PROPERTIES LABELS "no_hardware")
 add_task_interface_test(test_buffer types/test_buffer.cpp)
 add_task_interface_test(test_child_memory types/test_child_memory.cpp)
 add_task_interface_test(test_chip_max_tensor_args types/test_chip_max_tensor_args.cpp)
+add_task_interface_test(test_callable_scalar_count types/test_callable_scalar_count.cpp)
 add_task_interface_test(test_call_config types/test_call_config.cpp)
+add_task_interface_test(test_kernel_invocation_header types/test_kernel_invocation_header.cpp)
 
 # Contract test for upload_chip_callable_buffer caller-buffer immutability.
 # Pulls both task_interface (callable.h) and src/common (utils/fnv1a_64.h),

--- a/tests/ut/cpp/common/test_execution_mode_latch.cpp
+++ b/tests/ut/cpp/common/test_execution_mode_latch.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+// Write-once execution identity. Both platform runner bases hold one and every
+// kernel-mode guard reads it, so these cases pin the whole contract the guards
+// depend on: the unlatched start state, idempotence for the held mode, mutual
+// exclusion in both directions, and re-latching across a finalized lifetime.
+
+#include <gtest/gtest.h>
+
+#include "host/execution_mode_latch.h"
+
+namespace {
+
+TEST(ExecutionModeLatch, StartsUnlatched) {
+    ExecutionModeLatch latch;
+    EXPECT_FALSE(latch.is_latched());
+    EXPECT_FALSE(latch.is_kernel());
+}
+
+TEST(ExecutionModeLatch, LatchingIsIdempotentForTheHeldMode) {
+    ExecutionModeLatch latch;
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_TRUE(latch.is_latched());
+    EXPECT_EQ(latch.latched_mode(), SIMPLER_MODE_PROGRAM);
+    EXPECT_FALSE(latch.is_kernel());
+}
+
+TEST(ExecutionModeLatch, ModesAreMutuallyExclusiveInBothDirections) {
+    ExecutionModeLatch program;
+    EXPECT_EQ(program.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_EQ(program.latch(SIMPLER_MODE_KERNEL), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_FALSE(program.is_kernel());
+
+    ExecutionModeLatch kernel;
+    EXPECT_EQ(kernel.latch(SIMPLER_MODE_KERNEL), 0);
+    EXPECT_EQ(kernel.latch(SIMPLER_MODE_PROGRAM), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_TRUE(kernel.is_kernel());
+}
+
+// finalize resets a runner's device state but not its identity, so the
+// init -> finalize -> init sequence the program path already supports must
+// still latch cleanly the second time.
+TEST(ExecutionModeLatch, SameModeRelatchesAfterAFinalizedLifetime) {
+    ExecutionModeLatch latch;
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_EQ(latch.latched_mode(), SIMPLER_MODE_PROGRAM);
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_KERNEL), PTO_RUNTIME_ERR_INVALID_STATE);
+}
+
+}  // namespace

--- a/tests/ut/cpp/common/test_kernel_entry_validation.cpp
+++ b/tests/ut/cpp/common/test_kernel_entry_validation.cpp
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+#include "host/kernel_entry_validation.h"
+#include "utils/device_arena.h"
+
+namespace {
+
+int dummy_ctx_storage = 0;
+void *const kCtx = &dummy_ctx_storage;
+const uint8_t kBinary[4] = {1, 2, 3, 4};
+const int kConfigStorage = 0;
+const void *const kConfig = &kConfigStorage;
+int dummy_stream_storage = 0;
+void *const kStream = &dummy_stream_storage;
+alignas(ChipCallable) const unsigned char kCallableImage[sizeof(ChipCallable)] = {};
+
+TEST(KernelEntryValidation, BinarySpanRequiresPointerAndSizeTogether) {
+    EXPECT_TRUE(kernel_binary_span_is_consistent(nullptr, 0));
+    EXPECT_TRUE(kernel_binary_span_is_consistent(kBinary, sizeof(kBinary)));
+    EXPECT_FALSE(kernel_binary_span_is_consistent(nullptr, 4));
+    EXPECT_FALSE(kernel_binary_span_is_consistent(kBinary, 0));
+}
+
+TEST(KernelEntryValidation, InitAcceptsConsistentArgs) {
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1),
+        0
+    );
+}
+
+TEST(KernelEntryValidation, InitRejectsEachStructuralViolation) {
+    EXPECT_EQ(
+        validate_kernel_init_args(
+            nullptr, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1
+        ),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, nullptr, 1),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, -1, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, kConfig, 0),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+    // One inconsistent span per position, in both directions.
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, nullptr, 4, kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, 0, kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), nullptr, 4, nullptr, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, 0, nullptr, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), kBinary, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 4, kConfig, 1),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+}
+
+TEST(KernelEntryValidation, PrepareCallableChecksIdRangeAndImageSize) {
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable), kStream), 0);
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(
+            kCtx, MAX_REGISTERED_CALLABLE_IDS - 1, kCallableImage, sizeof(ChipCallable), kStream
+        ),
+        0
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(nullptr, 0, kCallableImage, sizeof(ChipCallable), kStream),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, nullptr, sizeof(ChipCallable), kStream),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable), nullptr),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, -1, kCallableImage, sizeof(ChipCallable), kStream),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(
+            kCtx, MAX_REGISTERED_CALLABLE_IDS, kCallableImage, sizeof(ChipCallable), kStream
+        ),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable) - 1, kStream),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+    // storage_ sits at a CALLABLE_CHILD_ALIGN offset from the header, so an
+    // image the caller placed off-alignment puts every child off-alignment.
+    static_assert(alignof(ChipCallable) > 1, "a misaligned image must be expressible");
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage + 1, sizeof(ChipCallable), kStream),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+}
+
+TEST(KernelEntryValidation, LaunchChecksPointersAndIdRange) {
+    EXPECT_EQ(validate_kernel_launch_args(kCtx, 0, kCallableImage, kStream), 0);
+    EXPECT_EQ(validate_kernel_launch_args(nullptr, 0, kCallableImage, kStream), PTO_RUNTIME_ERR_INVALID_ARGUMENT);
+    EXPECT_EQ(validate_kernel_launch_args(kCtx, 0, nullptr, kStream), PTO_RUNTIME_ERR_INVALID_ARGUMENT);
+    EXPECT_EQ(validate_kernel_launch_args(kCtx, 0, kCallableImage, nullptr), PTO_RUNTIME_ERR_INVALID_ARGUMENT);
+    EXPECT_EQ(validate_kernel_launch_args(kCtx, -1, kCallableImage, kStream), PTO_RUNTIME_ERR_INVALID_ARGUMENT);
+    EXPECT_EQ(
+        validate_kernel_launch_args(kCtx, MAX_REGISTERED_CALLABLE_IDS, kCallableImage, kStream),
+        PTO_RUNTIME_ERR_INVALID_ARGUMENT
+    );
+}
+
+TEST(KernelArenaGuard, UncommittedRegionAcceptsAnyRequest) {
+    // Kernel mode must be able to establish capacity once, so nothing about an
+    // uncommitted region is refusable.
+    EXPECT_FALSE(kernel_arena_change_is_forbidden(false, 0, 0));
+    EXPECT_FALSE(kernel_arena_change_is_forbidden(false, 0, 4096));
+    EXPECT_FALSE(kernel_arena_change_is_forbidden(false, 4096, 8192));
+}
+
+TEST(KernelArenaGuard, CommittedRegionRefusesGrowAndRelease) {
+    EXPECT_TRUE(kernel_arena_change_is_forbidden(true, 4096, 4097));
+    EXPECT_TRUE(kernel_arena_change_is_forbidden(true, 4096, 0));
+}
+
+TEST(KernelArenaGuard, CommittedRegionAllowsSameSizeAndShrink) {
+    // A shrink keeps the base and the committed size, so a captured graph's
+    // addresses survive it.
+    EXPECT_FALSE(kernel_arena_change_is_forbidden(true, 4096, 4096));
+    EXPECT_FALSE(kernel_arena_change_is_forbidden(true, 4096, 2048));
+    // Committed with nothing cached: asking for nothing changes nothing.
+    EXPECT_FALSE(kernel_arena_change_is_forbidden(true, 0, 0));
+}
+
+struct CountingBackend {
+    int frees = 0;
+    static void *alloc(void * /*ctx*/, size_t size) { return std::malloc(size); }
+    static void free_fn(void *ctx, void *ptr) {
+        static_cast<CountingBackend *>(ctx)->frees++;
+        std::free(ptr);
+    }
+};
+
+TEST(KernelArenaGuard, RefusalScanOverCommittedRegionsReleasesNothing) {
+    // setup_static_arena's three-region shape. The guard is evaluated over
+    // every region before any of them is touched, so reaching a refusal must
+    // leave each committed peer's base, size and committed flag intact —
+    // the arena commit sequence's rollback would free exactly these.
+    CountingBackend backend;
+    DeviceArena gm_heap(&CountingBackend::alloc, &CountingBackend::free_fn, &backend);
+    DeviceArena gm_sm(&CountingBackend::alloc, &CountingBackend::free_fn, &backend);
+    DeviceArena runtime_pool(&CountingBackend::alloc, &CountingBackend::free_fn, &backend);
+
+    const size_t cached[] = {4096, 2048, 1024};
+    DeviceArena *arenas[] = {&gm_heap, &gm_sm, &runtime_pool};
+    for (size_t i = 0; i < 3; ++i) {
+        arenas[i]->reserve(cached[i], 64);
+        ASSERT_NE(arenas[i]->commit(), nullptr);
+    }
+    const int frees_after_commit = backend.frees;
+    void *const bases[] = {gm_heap.base(), gm_sm.base(), runtime_pool.base()};
+
+    // The third region asks to grow; the first two are unchanged requests.
+    const size_t requested[] = {4096, 2048, 8192};
+    bool refused = false;
+    for (size_t i = 0; i < 3 && !refused; ++i) {
+        refused = kernel_arena_change_is_forbidden(arenas[i]->is_committed(), cached[i], requested[i]);
+    }
+
+    EXPECT_TRUE(refused);
+    EXPECT_EQ(backend.frees, frees_after_commit);
+    for (size_t i = 0; i < 3; ++i) {
+        EXPECT_TRUE(arenas[i]->is_committed());
+        EXPECT_EQ(arenas[i]->base(), bases[i]);
+    }
+}
+
+}  // namespace

--- a/tests/ut/cpp/types/test_callable_scalar_count.cpp
+++ b/tests/ut/cpp/types/test_callable_scalar_count.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstddef>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "callable.h"
+
+namespace {
+
+std::vector<uint8_t> build_chip_callable(int32_t scalar_entries) {
+    std::vector<ArgDirection> sig{ArgDirection::IN, ArgDirection::OUT};
+    for (int32_t i = 0; i < scalar_entries; ++i)
+        sig.push_back(ArgDirection::SCALAR);
+
+    ArgDirection core_sig[1] = {ArgDirection::IN};
+    const uint8_t kernel[] = {0x01, 0x02, 0x03, 0x04};
+    auto core = make_callable<CORE_MAX_TENSOR_ARGS>(core_sig, 1, kernel, sizeof(kernel));
+
+    const uint8_t fake_orch_so[] = {0x7f, 'E', 'L', 'F'};
+    int32_t child_ids[1] = {3};
+    std::vector<uint8_t> children[1] = {std::move(core)};
+
+    return make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
+        sig.data(), static_cast<int32_t>(sig.size()), "orch_fn", fake_orch_so, sizeof(fake_orch_so), child_ids,
+        children, 1, "cfg_name"
+    );
+}
+
+}  // namespace
+
+TEST(CallableScalarCount, DerivesTensorScalarSplitFromSignature) {
+    for (int32_t count : {0, 1, 7, CHIP_MAX_SCALAR_ARGS, CHIP_MAX_TENSOR_ARGS - 2}) {
+        auto buf = build_chip_callable(count);
+        const auto *callable = reinterpret_cast<const ChipCallable *>(buf.data());
+        EXPECT_EQ(callable->scalar_count(), count);
+        EXPECT_EQ(callable->sig_count(), 2 + count);
+        EXPECT_EQ(callable->sig_count() - callable->scalar_count(), 2);
+    }
+}
+
+TEST(CallableScalarCount, EmptySignatureHasNoScalars) {
+    auto buf = make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
+        nullptr, 0, "orch_fn", nullptr, 0, nullptr, nullptr, 0, ""
+    );
+    const auto *callable = reinterpret_cast<const ChipCallable *>(buf.data());
+    EXPECT_EQ(callable->scalar_count(), 0);
+}
+
+TEST(CallableScalarCount, CachedBlobUsesSignatureRegardlessOfPadding) {
+    auto buf = build_chip_callable(9);
+    const auto *callable = reinterpret_cast<const ChipCallable *>(buf.data());
+    constexpr size_t padding_begin = offsetof(ChipCallable, config_name_len_) + sizeof(uint32_t);
+    constexpr size_t padding_size = offsetof(ChipCallable, storage_) - padding_begin;
+    for (size_t i = padding_begin; i < offsetof(ChipCallable, storage_); ++i) {
+        ASSERT_EQ(buf[i], 0);
+    }
+    EXPECT_EQ(callable->scalar_count(), 9);
+    std::memset(buf.data() + padding_begin, 0xff, padding_size);
+    EXPECT_EQ(callable->scalar_count(), 9);
+    EXPECT_EQ(callable->sig_count(), 11);
+    EXPECT_EQ(std::string(callable->func_name(), callable->func_name_len()), "orch_fn");
+    EXPECT_EQ(std::string(callable->config_name(), callable->config_name_len()), "cfg_name");
+    ASSERT_EQ(callable->child_count(), 1);
+    EXPECT_EQ(callable->child_func_id(0), 3);
+    EXPECT_EQ(callable->child(0).binary_size(), 4u);
+}
+
+TEST(CallableScalarCount, RejectsCorruptSignatureCountBeforeScanning) {
+    for (int32_t count : {-1, CHIP_MAX_TENSOR_ARGS + 1}) {
+        auto buf = build_chip_callable(9);
+        auto *callable = reinterpret_cast<ChipCallable *>(buf.data());
+        callable->sig_count_ = count;
+        EXPECT_THROW(callable->scalar_count(), std::invalid_argument);
+    }
+}

--- a/tests/ut/cpp/types/test_kernel_invocation_header.cpp
+++ b/tests/ut/cpp/types/test_kernel_invocation_header.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+#include "kernel_invocation_header.h"
+
+namespace {
+
+TEST(KernelInvocationHeaderWire, ModeValuesArePinned) {
+    EXPECT_EQ(SIMPLER_MODE_PROGRAM, 0);
+    EXPECT_EQ(SIMPLER_MODE_KERNEL, 1);
+}
+
+TEST(KernelInvocationHeaderWire, MatchesWireLayoutAndSurvivesMemcpy) {
+    SimplerKernelInvocationHeader header{};
+    header.mode = SIMPLER_MODE_KERNEL;
+    header.callable_id = 17;
+    header.generation = 0x1122334455667788ull;
+    header.payload_bytes = 4096;
+    header.tensor_count = 12;
+    header.scalar_count = 5;
+
+    unsigned char wire[sizeof(SimplerKernelInvocationHeader)];
+    std::memcpy(wire, &header, sizeof(header));
+    SimplerKernelInvocationHeader restored{};
+    std::memcpy(&restored, wire, sizeof(restored));
+
+    EXPECT_EQ(restored.mode, static_cast<uint32_t>(SIMPLER_MODE_KERNEL));
+    EXPECT_EQ(restored.callable_id, 17);
+    EXPECT_EQ(restored.generation, 0x1122334455667788ull);
+    EXPECT_EQ(restored.payload_bytes, 4096u);
+    EXPECT_EQ(restored.tensor_count, 12);
+    EXPECT_EQ(restored.scalar_count, 5);
+    EXPECT_EQ(restored.host_copy_tensor_count, 0);
+    EXPECT_EQ(restored.reserved_, 0u);
+
+    const unsigned char expected[40] = {
+        1, 0, 0, 0, 17, 0, 0, 0, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0, 0x10, 0, 0,
+        0, 0, 0, 0, 12, 0, 0, 0, 5,    0,    0,    0,    0,    0,    0,    0,    0, 0,    0, 0,
+    };
+    EXPECT_EQ(std::memcmp(wire, expected, sizeof(expected)), 0);
+}
+
+TEST(KernelInvocationHeaderWire, ZeroInitializedBlobReadsAsEmpty) {
+    unsigned char wire[sizeof(SimplerKernelInvocationHeader)] = {};
+    SimplerKernelInvocationHeader header;
+    std::memcpy(&header, wire, sizeof(header));
+    EXPECT_EQ(header.mode, static_cast<uint32_t>(SIMPLER_MODE_PROGRAM));
+    EXPECT_EQ(header.payload_bytes, 0u);
+    EXPECT_EQ(header.tensor_count, 0);
+    EXPECT_EQ(header.scalar_count, 0);
+    EXPECT_EQ(header.host_copy_tensor_count, 0);
+    EXPECT_EQ(header.reserved_, 0u);
+}
+
+}  // namespace

--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -10,7 +10,10 @@
 
 import json
 import os
+import shutil
+import subprocess
 import threading
+from pathlib import Path
 
 import pytest
 from _task_interface import CallConfig, RuntimeEnv, _ChipWorker  # pyright: ignore[reportMissingImports]
@@ -164,6 +167,168 @@ class TestCallConfig:
 # ============================================================================
 # ChipWorker state machine tests
 # ============================================================================
+
+
+_KERNEL_LIFECYCLE_SYMBOLS = (
+    "simpler_kernel_mode_init",
+    "simpler_kernel_mode_prepare_callable",
+    "simpler_kernel_mode_launch",
+)
+
+
+@pytest.fixture(scope="module")
+def kernel_symbol_runtime(tmp_path_factory):
+    """Build real DSOs with a selectable kernel capability and export surface."""
+    compiler = shutil.which("c++") or shutil.which("g++")
+    assert compiler is not None, "kernel symbol tests require a C++ compiler"
+    build_dir = tmp_path_factory.mktemp("kernel_symbol_runtime")
+    worker_headers = Path(__file__).resolve().parents[3] / "src" / "common" / "worker"
+    unused_symbols = """
+        device_malloc_ctx device_free_ctx committed_device_memory_ctx device_memory_info_ctx
+        copy_to_device_ctx copy_from_device_ctx simpler_register_callable simpler_run
+        simpler_prepare_run simpler_launch_run simpler_poll_run simpler_wait_run simpler_finalize_run
+        supports_concurrent_native_prepare_ctx get_arena_bank_gm_heap_base_ctx get_retained_temp_addr_ctx
+        simpler_unregister_callable get_aicpu_dlopen_count get_host_dlopen_count get_run_stream_set_create_count
+        ensure_acl_ready_ctx create_comm_stream_ctx destroy_comm_stream_ctx comm_init comm_alloc_windows
+        comm_get_local_window_base comm_get_window_size comm_derive_context comm_alloc_domain_windows
+        comm_release_domain_windows comm_global_domain_prepare comm_global_domain_import
+        comm_global_domain_release comm_barrier comm_destroy
+    """.split()
+    cache = {}
+
+    def build(*, supported=0, missing=(), init_result=0):
+        key = (supported, missing, init_result)
+        if key in cache:
+            return cache[key]
+        source = build_dir / f"runtime_{len(cache)}.cpp"
+        sentinels = source.with_suffix(".sentinels.cpp")
+        library = source.with_suffix(".so")
+        source.write_text(
+            '#include "runtime_c_api.h"\n'
+            "#include <cstdlib>\n"
+            "static int live_contexts = 0;\n"
+            "struct ContextLeakCheck {\n"
+            "    ~ContextLeakCheck() { if (live_contexts != 0) std::abort(); }\n"
+            "};\n"
+            "static ContextLeakCheck context_leak_check;\n"
+            "struct SimplerHostLogState;\n"
+            'extern "C" int simpler_host_log_bind_state(SimplerHostLogState *) { return 0; }\n'
+            "DeviceContextHandle create_device_context() { ++live_contexts; return new uint64_t{0}; }\n"
+            "void destroy_device_context(DeviceContextHandle ctx) {\n"
+            "    --live_contexts; delete static_cast<uint64_t *>(ctx);\n"
+            "}\n"
+            "int finalize_device(DeviceContextHandle) { return 0; }\n"
+            "size_t get_runtime_size() { return sizeof(uint64_t); }\n"
+            "size_t get_runtime_alignment() { return alignof(uint64_t); }\n"
+            "const PipelineContract *get_pipeline_contract() {\n"
+            "    static const PipelineContract contract{PTO_PIPELINE_CONTRACT_ABI_VERSION, 0, 1, {}};\n"
+            "    return &contract;\n"
+            "}\n"
+            "int simpler_init(DeviceContextHandle ctx, int, const uint8_t *, size_t, const uint8_t *, size_t,\n"
+            "                 const uint8_t *, size_t, const CallConfig *, int, const void *, uint64_t) {\n"
+            "    *static_cast<uint64_t *>(ctx) = 1;\n"
+            f"    return {init_result};\n"
+            "}\n"
+            + (
+                "int simpler_kernel_mode_supported(DeviceContextHandle ctx) {\n"
+                "    if (ctx == nullptr || *static_cast<uint64_t *>(ctx) != 0) std::abort();\n"
+                f"    return {supported};\n"
+                "}\n"
+                if "simpler_kernel_mode_supported" not in missing
+                else ""
+            ),
+            encoding="utf-8",
+        )
+        # These symbols are only resolved during init; any invocation is a test failure.
+        # A separate TU keeps the sentinels independent of the C ABI parameter lists.
+        sentinels.write_text(
+            "#include <cstdlib>\n"
+            + "".join(
+                f'extern "C" void {symbol}() {{ std::abort(); }}\n'
+                for symbol in (*unused_symbols, *_KERNEL_LIFECYCLE_SYMBOLS)
+                if symbol not in missing
+            ),
+            encoding="utf-8",
+        )
+        subprocess.run(
+            [
+                compiler,
+                "-std=c++17",
+                "-shared",
+                "-fPIC",
+                "-I",
+                str(worker_headers),
+                str(source),
+                str(sentinels),
+                "-o",
+                str(library),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        cache[key] = library
+        return library
+
+    return build
+
+
+class TestChipWorkerKernelSymbols:
+    def test_unsupported_runtime_still_exports_lifecycle_symbols(self, kernel_symbol_runtime):
+        # A runtime that cannot run kernel mode reports so through supported()
+        # and still exports the whole family, the same way the comm group ships
+        # not-supported stubs rather than omitting symbols.
+        runtime = kernel_symbol_runtime(supported=0)
+        worker = _ChipWorker()
+        try:
+            worker.init(str(runtime), os.devnull, os.devnull, "", device_id=0)
+            assert worker.initialized
+            assert worker.device_id == 0
+        finally:
+            worker.finalize()
+        assert not worker.initialized
+        assert worker.runtime_slot_count == 0
+
+    def test_supported_runtime_with_complete_lifecycle_symbols(self, kernel_symbol_runtime):
+        runtime = kernel_symbol_runtime(supported=1)
+        worker = _ChipWorker()
+        try:
+            worker.init(str(runtime), os.devnull, os.devnull, "", device_id=0)
+            assert worker.initialized
+        finally:
+            worker.finalize()
+
+    @pytest.mark.parametrize("missing", (*_KERNEL_LIFECYCLE_SYMBOLS, "simpler_kernel_mode_supported"))
+    def test_missing_required_kernel_symbol_allows_retry(self, kernel_symbol_runtime, missing):
+        # Every kernel-mode entry is required of every runtime, so any one of
+        # them missing fails init regardless of what supported() would answer.
+        incomplete = kernel_symbol_runtime(supported=1, missing=(missing,))
+        complete = kernel_symbol_runtime(supported=0)
+        worker = _ChipWorker()
+        try:
+            with pytest.raises(RuntimeError, match=f"dlsym failed for '{missing}'"):
+                worker.init(str(incomplete), os.devnull, os.devnull, "", device_id=0)
+            assert not worker.initialized
+            assert worker.device_id == -1
+            assert worker.runtime_slot_count == 0
+            worker.init(str(complete), os.devnull, os.devnull, "", device_id=0)
+            assert worker.initialized
+        finally:
+            worker.finalize()
+
+    def test_program_init_failure_after_kernel_symbol_resolution_allows_retry(self, kernel_symbol_runtime):
+        failing = kernel_symbol_runtime(supported=1, init_result=-1000)
+        complete = kernel_symbol_runtime(supported=0)
+        worker = _ChipWorker()
+        try:
+            with pytest.raises(RuntimeError, match="simpler_init failed with code -1000"):
+                worker.init(str(failing), os.devnull, os.devnull, "", device_id=0)
+            assert not worker.initialized
+            assert worker.runtime_slot_count == 0
+            worker.init(str(complete), os.devnull, os.devnull, "", device_id=0)
+            assert worker.initialized
+        finally:
+            worker.finalize()
 
 
 class TestChipWorkerStateMachine:

--- a/tests/ut/py/test_host_runtime_abi.py
+++ b/tests/ut/py/test_host_runtime_abi.py
@@ -23,6 +23,15 @@ _NEWLY_REQUIRED_PIPELINE_SYMBOLS = {
     "get_retained_temp_addr_ctx",
     "supports_concurrent_native_prepare_ctx",
 }
+# Kernel-mode lifecycle surface: every host-runtime component exports all of
+# these; components without kernel-mode support export validating stubs that
+# report unsupported rather than omitting the symbols.
+_KERNEL_MODE_SYMBOLS = {
+    "simpler_kernel_mode_init",
+    "simpler_kernel_mode_launch",
+    "simpler_kernel_mode_prepare_callable",
+    "simpler_kernel_mode_supported",
+}
 _REMOVED_AMBIENT_SELECTION_SYMBOLS = {
     "select_arena_bank_ctx",
     "select_pipeline_slot_ctx",
@@ -73,4 +82,5 @@ def test_host_runtime_exports_required_pipeline_symbols(arch: str, variant: str,
     symbols = _defined_external_symbols(runtime_path)
 
     assert _NEWLY_REQUIRED_PIPELINE_SYMBOLS <= symbols, sorted(_NEWLY_REQUIRED_PIPELINE_SYMBOLS - symbols)
+    assert _KERNEL_MODE_SYMBOLS <= symbols, sorted(_KERNEL_MODE_SYMBOLS - symbols)
     assert symbols.isdisjoint(_REMOVED_AMBIENT_SELECTION_SYMBOLS), sorted(symbols & _REMOVED_AMBIENT_SELECTION_SYMBOLS)

--- a/tests/ut/py/test_task_interface.py
+++ b/tests/ut/py/test_task_interface.py
@@ -1406,6 +1406,50 @@ class TestChipCallable:
         assert "sig_count=2" in r
         assert "child_count=1" in r
 
+    def test_scalar_count_without_scalars_is_zero(self):
+        chip = ChipCallable.build(
+            signature=[ArgDirection.IN],
+            func_name="test_func",
+            binary=b"\x00",
+            children=[],
+        )
+        assert chip.scalar_count == 0
+
+    def test_scalar_count_derived_from_signature(self):
+        chip = ChipCallable.build(
+            signature=[ArgDirection.IN, ArgDirection.OUT] + [ArgDirection.SCALAR] * 5,
+            func_name="test_func",
+            binary=b"\x00",
+            children=[],
+        )
+        assert chip.scalar_count == 5
+
+    def test_scalar_count_survives_from_bytes(self):
+        chip = ChipCallable.build(
+            signature=[ArgDirection.IN] + [ArgDirection.SCALAR] * 7,
+            func_name="test_func",
+            binary=b"\x00",
+            children=[],
+        )
+        raw = ctypes.string_at(int(chip.buffer_ptr()), int(chip.buffer_size()))
+        clone = ChipCallable.from_bytes(raw)
+        assert clone.scalar_count == 7
+
+    @pytest.mark.parametrize("signature_count", [-1, 257])
+    def test_scalar_count_rejects_corrupt_cached_signature_count(self, signature_count):
+        chip = ChipCallable.build(
+            signature=[ArgDirection.IN, ArgDirection.SCALAR],
+            func_name="test_func",
+            binary=b"\x00",
+            children=[],
+        )
+        raw = bytearray(ctypes.string_at(int(chip.buffer_ptr()), int(chip.buffer_size())))
+        # The wire signature contains 256 int32 ArgDirection entries before sig_count.
+        struct.pack_into("<i", raw, 256 * struct.calcsize("<i"), signature_count)
+        clone = ChipCallable.from_bytes(bytes(raw))
+        with pytest.raises(ValueError, match=rf"signature count {signature_count}.*256"):
+            _ = clone.scalar_count
+
 
 # ============================================================================
 # ChipTensor.child_memory


### PR DESCRIPTION
## Summary

Add the shared kernel-mode C ABI and contracts for contexts that borrow the caller's device and stream. The program entry latches PROGRAM before changing runner or process state. `ExecutionModeLatch` is write-once and idempotent for the same mode; failures and finalization never roll it back or permit a switch to the other mode.

All current backends report kernel mode unsupported. This PR defines and tests the shared contracts; it does not enable kernel launches or allocate kernel execution resources in production.

**Scope.** This gate carries the surface the downstream PRs must agree on, plus the guards that make *program* mode safe today. The persistent execution resources — hidden stream pair, event set, and phase machine — are **not** here: they have no consumer in this change, ship in no library, and the K2 branch already stacked on this one revises the event set from four entries to five with an ordering constraint this change has no way to see. They belong to the change that implements them.

## Contracts and implementation

- Four C entries: `simpler_kernel_mode_supported`, `simpler_kernel_mode_init`, `simpler_kernel_mode_prepare_callable`, and `simpler_kernel_mode_launch`. Kernel close reuses `finalize_device`. Every built component exports all four, and `ChipWorker` resolves them unconditionally like the rest of the uniform ABI — shipping not-supported stubs is already this repo's answer for an unsupported capability, so the probe answers the capability question at call time rather than deciding which symbols get resolved.
- `simpler_kernel_mode_supported` runs before any init, and `create_device_context()` takes no device, so an implementation answers from the runtime build alone; `ctx` is accepted for signature symmetry and must not be dereferenced for a device.
- The invocation envelope is exactly 40 bytes, with assertions for every field offset and explicit zero-only `host_copy_tensor_count` and `reserved_` fields. Runtime-specific payloads follow it. Both wire endpoints are built together, without version negotiation.
- Kernel-entry structural argument errors return `INVALID_ARGUMENT` (-1004), explicit mode/lifecycle guards return `INVALID_STATE` (-1003), and an unavailable capability returns `UNSUPPORTED` (-1001). `INTERNAL` (-1000) remains reserved for internal invariants, including forbidden changes to committed kernel arena capacity.
- `ChipCallable::scalar_count()` and the Python read-only property derive the count from the signature through `count_scalar_args`. No scalar-count field, sentinel, or extra factory argument is added. The original C++/Python construction interfaces, callable sizes, and field offsets remain intact and are protected by layout assertions.
- Onboard thread attachment is split into `bind_current_thread` (thread binding), `attach_current_thread` (program ownership and watchdog setup), and `adopt_borrowed_device` (record a borrowed device). Mode guards read the single latch. `ensure_acl_ready` latches PROGRAM before its first ACL call, because that entry is reachable without `simpler_init` and taking ACL ownership is itself what makes a context a program context. The sim arena has no kernel-only branch.

| Contract | Enforced here | Required by production integration |
| --- | --- | --- |
| Context identity | Program init latches PROGRAM; latch unit tests cover exclusivity and persistence | Kernel init latches KERNEL and rejects program reuse |
| Kernel entries | Shared structural validation and uniform unsupported stubs | Supported init, prepare, launch, and close |
| Invocation envelope | Fixed layout and byte-level tests | Populate residency generation; validate identity, generation, counts, capacity, and zero-only fields on AICPU |
| Persistent resources | Not in this PR | Owned by the change that implements them, together with enqueue/close serialization and graph-resource lifetime |
| Borrowed device and capacity | Onboard guard sites, ownership separation, and a capacity refusal decided across every region before any is touched | Real-context guard rejection tests |

A kernel-mode capacity refusal is decided over all three arena regions before the commit sequence begins, so it returns without reaching the rollback that would release the committed bases a captured graph still names. Program-mode rollback semantics are unchanged. No production entry latches KERNEL in this PR, so the onboard kernel branches remain unreachable until integration enables support. `context_generation` is checked for nonzero by the stub but is not persisted by it.

## Testing

Verified on Linux against a worktree-local venv built with `build.targets=build_package_sim`:

- CTest: **144/144** passed (hardware tests excluded), including the new `test_execution_mode_latch`.
- Python unit suite: **2254 passed, 7 skipped, 0 failed** (`-m "not requires_hardware"`), including the reworked `ChipWorker` dlsym cases — an unsupported runtime still exports the whole family, and any missing entry fails init whatever the probe would answer.
- `clang-format`, `ruff check`, `ruff format`, and `markdownlint-cli2` clean on every changed file.

CI has been re-triggered by the latest push; see the checks below for the authoritative result.
