### PR TITLE
Docs: keep the qwen skill's Path 0 a pointer, and gate before the lock

### DIFF
--- a/.claude/skills/multi-repo-qwen-setup/SKILL.md
+++ b/.claude/skills/multi-repo-qwen-setup/SKILL.md
@@ -36,30 +36,24 @@ styles**. They measure different things; don't confuse them:
   AIC + 16 AIV + orchestration, plus the vendored CANN FusedInferAttentionScore
   extern under `kernels/paged_attention_cce/`; golden in
   `simpler_setup/goldens/qwen3_14b_decode.py`). No pypto / pypto-lib / JIT
-  descent — it builds in this repo and runs through either entry point below.
-  Budget ~5 min wall and a 38 GiB fixture (weights + paged KV, bf16), and note
-  it needs CANN devkit headers to build the attention extern. Onboard rules
-  still apply (per-die lock + `onboard-arch-precheck`):
+  descent — it builds and runs like any simpler example. Budget ~5 min wall and
+  a 38 GiB fixture (weights + paged KV, bf16), and note it needs CANN devkit
+  headers to build the attention extern. Onboard rules still apply (per-die
+  lock + `onboard-arch-precheck`):
 
   ```bash
-  # Thin manual pytest wrapper:
+  .claude/skills/onboard-arch-precheck/check.sh a2a3 || exit 1
   task-submit --device auto --device-num 1 --run "\
-    .claude/skills/onboard-arch-precheck/check.sh a2a3 && \
     python -m pytest examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode \
-      --platform a2a3 --device \"\$TASK_DEVICE\" --manual include"
-
-  # Canonical standalone driver; add --rounds N --skip-golden to benchmark:
-  task-submit --device auto --device-num 1 --run "\
-    .claude/skills/onboard-arch-precheck/check.sh a2a3 && \
-    python examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/main.py \
-      -p a2a3 -d \"\$TASK_DEVICE\""
+      --platform a2a3 --device \$TASK_DEVICE --manual include"
+  # standalone driver (canonical direct entry; --rounds N --skip-golden to
+  # benchmark): python .../qwen3_14b_decode/main.py -p a2a3 -d \$TASK_DEVICE
   ```
 
   This is **not** a cross-repo path, so the rest of this skill (§1 setup,
-  §2–§6) does not apply to it — use the thin pytest wrapper or invoke the
-  standalone driver directly (see the example's own `README.md`). It's listed
-  here only so you know it exists before reaching for the heavier cross-repo
-  paths below.
+  §2–§6) does not apply to it — run it per the example's own `README.md`,
+  which owns both entry points' full recipes. It's listed here only so you
+  know it exists before reaching for the heavier cross-repo paths below.
 - **Path A — serving runner (pypto-serving).** Full engine: builds an
   `Engine` and runs `generate` over a prompt. Entry
   `examples/model/qwen3_14b/npu_generate.py`, flags `--model-dir --prompt


### PR DESCRIPTION
## What

Restores `multi-repo-qwen-setup`'s **Path 0** to the pointer it is designed to be, and moves `onboard-arch-precheck` back outside the device lock. Single file, docs only.

## Why

**Path 0 is a pointer, not a recipe.** This skill is the qwen3 run guide — §1 explicitly defers environment setup to [`multi-repo-setup`](../multi-repo-setup/SKILL.md). Path 0's own closing sentence says the reader should use the example's own `README.md`, and the bullet exists "only so you know it exists before reaching for the heavier cross-repo paths below". #2041 grew it into two full `task-submit` blocks duplicating that README while the same paragraph still defers to it, so the two now have to be kept in sync for no gain.

**The precheck gates on silicon, not on a device.** #2041 also moved `check.sh` inside `task-submit --run`. That is the wrong side of the lock:

- `check.sh` needs **root** for DCMI where a host restricts it — not an allocation. `detect_silicon()` already handles that itself, escalating through a `task-submit --run` that carries **no `--device`**, so it takes no lock and waits behind none. That retry landed in `39b56928` (#2043), the merge-base of #2041.
- Measured on an a2a3 box where bare `npu-smi info -t board -i 0 -c 0` fails (`dcmi module initialize failed`, exit 187): `check.sh a2a3` run standalone, no `task-submit` wrapper, no allocation, on an expired cache (56001 s > 3600 s TTL) → **exit 0 in 1.8 s**, leaving `task_20260828_175025_304043615780 … 1s ok npu-smi info -t board -i 0 -c 0` in the queue with no device.
- Inside an allocated job the same refusal costs the full queue wait plus an occupied die on a shared box, lands as a failed task in `task-submit --list` instead of a pre-flight exit, and flattens `check.sh`'s `0` / `1` (cannot detect) / `2` (mismatch) exit codes into one non-zero.

`.claude/rules/running-onboard.md` ("Pre-flight") and `onboard-arch-precheck/SKILL.md` ("refuse … **BEFORE any device is locked**", plus a worked example) both place the gate before the lock; `running-onboard.md` also states the underlying rule directly: *"Escalated queries pass no `--device`, so they allocate no card and wait behind none — the wrapper is about privilege, never about the lock."*

## What is kept from #2041

Both of its factual corrections stay, unchanged:

- the case is described as a **standalone driver with a thin manual pytest wrapper**, not a `SceneTestCase`;
- **`main.py`** is named as the canonical direct entry (the retained one-line comment also records `--rounds N --skip-golden`).

## Verification

- `pre-commit run --files .claude/skills/multi-repo-qwen-setup/SKILL.md` — all hooks pass (`markdownlint-cli2`, `check-english-only`, `check-headers`, …).
- Replayed the retained `--run` payload through the real submission path (outer shell → `task-submit`'s `COMMAND=` task file → `task-daemon`'s `while IFS='=' read -r key value` parse): 0 embedded newlines, so no truncation, and the literal `$TASK_DEVICE` survives for the `task-daemon` branch that skips auto-injecting `--device`.
- `.claude/` is in `NON_CODE`, so this skips every arch and category gated job per `.claude/rules/ci-change-detection.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
