### PR TITLE
Fix: address scheduler profiling and xdist follow-ups

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -901,7 +901,7 @@ def _base_pytest_argv(session, *, strip_options=()):
 
 
 def _resolve_max_parallel(cfg, platform: str, device_ids: list[int]) -> int:
-    """Parse the -j/--max-parallel CLI value; 'auto' → platform-aware default."""
+    """Parse --max-parallel; 'auto' selects a platform-aware default."""
     raw = cfg.getoption("--max-parallel", default="auto")
     if raw in (None, "", "auto"):
         return _ps.default_max_parallel(platform or "", device_ids)
@@ -912,6 +912,56 @@ def _resolve_max_parallel(cfg, platform: str, device_ids: list[int]) -> int:
     if val < 1:
         raise pytest.UsageError(f"--max-parallel must be >= 1, got {val}")
     return val
+
+
+def _invocation_has_option(cfg, options):
+    """Return whether the original command line contains one of ``options``."""
+    for arg in cfg.invocation_params.args:
+        text = str(arg)
+        if text in options or any(text.startswith(f"{option}=") for option in options):
+            return True
+    return False
+
+
+def _l2_xdist_options(cfg, max_parallel: int):
+    """Return whether L2 uses xdist, child defaults, and the worker label.
+
+    ``numprocesses`` arrives here as ``None`` or ``0``. A top-level ``-n N``
+    with N > 0 puts xdist in distribution mode, and its ``pytest_runtestloop``
+    runs the whole session before this dispatcher's own hook is reached, so a
+    positive worker count is only ever seen from a direct caller.
+
+    ``--pdb`` is serial whatever ``numprocesses`` says: xdist zeroes the worker
+    count only for ``-n auto`` / ``-n logical``, so a bare ``--pdb`` arrives
+    with it unset — and the L2 child inherits ``--pdb``, which xdist rejects
+    with a usage error as soon as ``-n`` puts the child in distribution mode.
+    """
+    plugin_active = cfg.pluginmanager.hasplugin("xdist")
+    if not plugin_active or cfg.getoption("usepdb", default=False):
+        return False, [], None
+
+    requested_workers = cfg.getoption("numprocesses", default=None)
+    if requested_workers == 0:
+        return False, [], None
+
+    if requested_workers is None and max_parallel <= 1:
+        return False, [], None
+
+    options = []
+    if requested_workers is None:
+        options.extend(["-n", str(max_parallel)])
+    # xdist rewrites its effective default from ``no`` to ``load`` as soon as
+    # ``-n`` is active. Inspect the original command line so that derived
+    # ``load`` does not masquerade as an explicit user choice. ``-d`` is
+    # xdist's shortcut for ``--dist=load`` and overrides a ``--dist`` passed
+    # alongside it, so it is an explicit choice too. The scan sees the
+    # invocation argv only: a ``--dist`` coming from ini ``addopts`` reads as
+    # unset here, and ``addopts`` is prepended to the child's argv, so the
+    # appended default wins over it.
+    if not _invocation_has_option(cfg, {"--dist", "-d"}):
+        options.extend(["--dist", "loadfile"])
+    worker_label = requested_workers if requested_workers is not None else max_parallel
+    return True, options, worker_label
 
 
 def _emit_group(header: str, body: str) -> None:
@@ -1061,8 +1111,8 @@ def _dispatch_test_phases(session, resource_specs):  # noqa: PLR0912
     # worker slices --device 0-7 down to one id in pytest_configure (above),
     # and the session-scoped st_worker fixture reuses one ChipWorker per
     # (runtime, device).
-    xdist_active = max_parallel > 1 and cfg.pluginmanager.hasplugin("xdist")
-    if max_parallel > 1 and not xdist_active and not cfg.pluginmanager.is_blocked("xdist"):
+    xdist_active, xdist_options, xdist_workers = _l2_xdist_options(cfg, max_parallel)
+    if max_parallel > 1 and not cfg.pluginmanager.hasplugin("xdist") and not cfg.pluginmanager.is_blocked("xdist"):
         print(
             "\n[warning] --max-parallel > 1 but the pytest-xdist plugin is not active; "
             "falling back to serial L2 phase. Install or enable pytest-xdist to use L2 parallelism.\n",
@@ -1071,7 +1121,7 @@ def _dispatch_test_phases(session, resource_specs):  # noqa: PLR0912
     for rt in l2_runtimes:
         cmd = base_args + ["--runtime", rt, "--level", "2"]
         if xdist_active:
-            cmd += ["-n", str(max_parallel), "--dist", "loadfile"]
+            cmd += xdist_options
         # Per-runtime sink for the in-process poison guards (issue #1110). Each
         # xdist worker appends the classes it poison-skips; we re-run them in a
         # fresh subprocess after this one exits so they don't silently lose
@@ -1085,7 +1135,7 @@ def _dispatch_test_phases(session, resource_specs):  # noqa: PLR0912
         # need to buffer their stdout — we can stream it directly through
         # the group markers. ``::group::`` on its own line before the run
         # opens the fold; ``::endgroup::`` after closes it.
-        label = f"L2 {rt}" + (f" [-n {max_parallel}]" if xdist_active else "")
+        label = f"L2 {rt}" + (f" [-n {xdist_workers}]" if xdist_active else "")
         start = time.monotonic()
         print(f"::group::{label}", flush=True)
         result = subprocess.run(cmd, check=False, cwd=cwd, env=run_env)

--- a/docs/dfx/chip-swimlane-profiling.md
+++ b/docs/dfx/chip-swimlane-profiling.md
@@ -50,10 +50,11 @@ available.
   `release` / `dummy` / `early_dispatch` / `drain` / `graph_prepare`), plus
   nested phases.
   In `tensormap_and_ringbuffer`, `resolve` is nested within `complete` or
-  `dummy`; in `host_build_graph`, `resolve`, `async_poll`, and `dummy` are
-  standalone, mutually exclusive phases on the dedicated P thread. HBG
-  `resolve` uses that P thread's main scheduler lane; TMR's nested `resolve`
-  uses a sibling scheduler sub-lane. The drain sub-phases are nested within
+  `dummy`; in `host_build_graph`, `resolve_standalone`, `async_poll`, and
+  `dummy` are standalone, mutually exclusive phases on the dedicated P
+  thread. The converter renders `resolve_standalone` as `resolve` on that P
+  thread's main scheduler lane; TMR's nested `resolve` uses a sibling
+  scheduler sub-lane. The drain sub-phases are nested within
   their `drain` bar,
   and two **separate-lane**
   phases (`dummy_task` and `predicated_skip`, sampled immediately before
@@ -268,7 +269,8 @@ field but render differently in Perfetto:
 | `early_dispatch` | outer | sched | blocks staged by speculative early-dispatch this pass |
 | `drain` | outer | sched | blocks staged by this thread's global sync-start drain pass |
 | `graph_prepare` | outer | sched | Graph Definition nodes expanded this pass |
-| `resolve` | inner (TMR); P-thread outer (HBG) | TMR sched sub-lane; HBG P sched lane | consumers visited in `on_task_complete` (TMR); completed SPSC slots (HBG) |
+| `resolve` | inner (TMR) | TMR sched sub-lane | consumers visited in `on_task_complete` |
+| `resolve_standalone` | P-thread outer (HBG); rendered as `resolve` | HBG P sched lane | completed SPSC slots |
 | `drain_prepare` | inner | sched, nested in `drain` | subtasks prepared for global sync-start publication |
 | `drain_publish` | inner | sched, nested in `drain` | subtasks published during global sync-start staging |
 | `dummy_task` | separate-lane | Worker View AICPU_N (pid=4) | one dummy entering `on_task_complete()`; full identity is in `task_id` |
@@ -709,7 +711,7 @@ Both architectures use split phase streams:
   several (e.g. Complete, AsyncPoll, Dispatch, Release, plus Resolve).
   `ChipSwimlaneSchedPhaseKind` spans the outer phases
   (Complete, Dispatch, Release, Dummy, EarlyDispatch, AsyncPoll, Drain,
-  GraphPrepare), runtime-specific Resolve, the inner drain phases
+  GraphPrepare, ResolveStandalone), TMR's inner Resolve, the inner drain phases
   (DrainPrepare, DrainPublish), and
   the separate-lane markers (DummyTask, PredicatedSkip) — see §3.2 for how
   each is rendered. Carries loop_iter + tasks_processed + pop_hit /

--- a/docs/dfx/sched-overhead-model.md
+++ b/docs/dfx/sched-overhead-model.md
@@ -113,9 +113,14 @@ python -m simpler_setup.tools.sched_overhead_analysis \
 
 For TMR captures, Resolve is nested in Complete or Dummy and is excluded from
 the phase total to avoid double counting. For HBG captures, Resolve is
-standalone work on the P thread and is included. Empty HBG async polling is
-reported as compact `AsyncPoll(0)` bars, so its measured CPU cost contributes
-to the scheduler budget instead of being reconstructed as idle. HBG's S
+standalone work on the P thread and is included. The two are told apart by the
+`resolve_standalone` phase discriminator the HBG P thread emits, not by
+timestamp containment; a capture predating that discriminator falls back to
+containment, where a Resolve ending exactly at its Complete or Dummy parent's
+end counts as standalone. Both spellings report under the `resolve` label.
+Empty HBG async polling is reported as compact `AsyncPoll(0)` bars, so its
+measured CPU cost contributes to the scheduler budget instead of being
+reconstructed as idle. HBG's S
 threads detect AICore FIN and dispatch work, while its P thread resolves
 completion state and dependencies. Part 5 reports their loop rates separately;
 the Tail-OH-to-loop comparison uses only S-thread loops because Tail OH ends at

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -852,10 +852,27 @@ pytest --runtime <rt> --level 2 --device 8-11 -n 4 --dist loadfile
 
 `pytest-xdist` starts 4 workers (`gw0`..`gw3`). Each worker's `pytest_configure` slices `--device 8-11` down to a single id (`gw0` → `8`, `gw1` → `9`, ...), and `st_worker` is session-scoped, so the worker initializes exactly one `ChipWorker(device=N)` and reuses it for every L2 class routed to it. `--dist loadfile` keeps all cases from one test file on the same worker, amortizing any file-level setup cost.
 
-An explicit `-p no:xdist` is authoritative for the L2 children inherited from
-the top-level invocation. The dispatcher omits `-n` and `--dist`, so each L2
-runtime subprocess executes serially. Resource-phase subprocess concurrency
-continues to follow `--max-parallel` because it does not use pytest-xdist.
+An explicit `-p no:xdist` or `-n 0` is authoritative for the L2 children
+inherited from the top-level invocation. The dispatcher does not append xdist
+options in either case, so each L2 runtime subprocess executes serially. `--pdb`
+reaches the same state, and reaches it on its own gate rather than through the
+worker count: xdist zeroes that count only for `-n auto` / `-n logical`, while
+a bare `--pdb` leaves it unset — and since the L2 child inherits `--pdb`, an
+appended `-n` would make xdist reject the child with
+`--pdb is incompatible with distributing tests`. An explicit top-level `--dist`
+(or its `-d` shortcut) is preserved too; the dispatcher adds only the options
+the invocation left unset.
+
+A top-level `-n N` with N > 0 is a different case: it puts xdist in
+distribution mode, whose `pytest_runtestloop` claims the session before this
+dispatcher's hook runs, so the phase split does not happen at all and every
+collected level runs in one flat xdist fanout. Size L2 parallelism with
+`--max-parallel`, not with a top-level `-n`.
+
+Resource-phase subprocess concurrency continues to follow `--max-parallel`
+because it does not use pytest-xdist. If plugin autoloading is disabled without
+blocking xdist explicitly, the dispatcher warns before falling back to serial
+L2 execution.
 
 ### L2 phase — standalone fanout
 

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -2211,17 +2211,17 @@ class SceneTestCase:
         # slot but the dispatcher doesn't actually run tests here.
         args.device = device_ids[0]
 
-        # Resolve -j (max parallel) — 'auto' is CPU-aware on sim, device-count on hardware.
+        # Resolve --max-parallel; 'auto' is CPU-aware on sim and device-count on hardware.
         if args.max_parallel in (None, "", "auto"):
             args.max_parallel = default_max_parallel(args.platform, device_ids)
         else:
             try:
                 args.max_parallel = int(args.max_parallel)
             except (TypeError, ValueError):
-                print(f"ERROR: -j must be 'auto' or an integer, got {args.max_parallel!r}", file=sys.stderr)
+                print(f"ERROR: --max-parallel must be 'auto' or an integer, got {args.max_parallel!r}", file=sys.stderr)
                 sys.exit(2)
             if args.max_parallel < 1:
-                print(f"ERROR: -j must be >= 1, got {args.max_parallel}", file=sys.stderr)
+                print(f"ERROR: --max-parallel must be >= 1, got {args.max_parallel}", file=sys.stderr)
                 sys.exit(2)
         # Profiling + parallelism is safe: each test case sets its own
         # `output_prefix` on CallConfig (see run_class_cases) so diagnostic
@@ -2448,9 +2448,9 @@ def _dispatch_test_phases_standalone(module_name, selected_by_cls, args):  # noq
     l2_failed = False
     for rt in sorted(l2_by_runtime):
         classes = l2_by_runtime[rt]
-        # Chunk count = min(-j, number of classes). We intentionally do NOT
+        # Chunk count = min(--max-parallel, number of classes). We intentionally do NOT
         # include len(device_ids) here: each chunk uses 1 device and at most
-        # max_parallel chunks run concurrently, so a pool bigger than -j just
+        # max_parallel chunks run concurrently, so a larger device pool just
         # leaves unused ids. Fewer, larger chunks also amortize ChipWorker
         # init (layer-4 reuse) over more cases.
         n = min(args.max_parallel, len(classes))

--- a/simpler_setup/tools/sched_overhead_analysis.py
+++ b/simpler_setup/tools/sched_overhead_analysis.py
@@ -35,15 +35,13 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-_SCHED_OUTER_PHASES = (
-    "complete",
-    "async_poll",
-    "dispatch",
-    "release",
-    "dummy",
-    "early_dispatch",
-    "drain",
-    "graph_prepare",
+from simpler_setup.tools.scheduler_phase_records import (
+    SCHED_OUTER_PHASES as _SCHED_OUTER_PHASES,
+)
+from simpler_setup.tools.scheduler_phase_records import (
+    canonical_sched_phase,
+    nested_resolve_record_ids,
+    scheduler_thread_role,
 )
 
 
@@ -229,23 +227,12 @@ def parse_scheduler_from_json_phases(data):  # noqa: PLR0912
         # thread. Count only the latter so the P thread is not dropped without
         # double-counting TMR's nested bars.
         outer_recs = [r for r in records if r.get("phase") in _SCHED_OUTER_PHASES]
-        resolve_parents = sorted(
-            (
-                (r.get("start_time_us", 0), r.get("end_time_us", 0))
-                for r in outer_recs
-                if r.get("phase") in ("complete", "dummy")
-            ),
-            key=lambda interval: interval[0],
-        )
-        resolve_parent_starts = [interval[0] for interval in resolve_parents]
-
-        def is_nested_resolve(rec):
-            start = rec.get("start_time_us", 0)
-            end = rec.get("end_time_us", 0)
-            parent_idx = bisect.bisect_right(resolve_parent_starts, start) - 1
-            return parent_idx >= 0 and end <= resolve_parents[parent_idx][1]
-
-        standalone_resolve = [r for r in records if r.get("phase") == "resolve" and not is_nested_resolve(r)]
+        nested_resolve_ids = nested_resolve_record_ids(records)
+        standalone_resolve = [
+            record
+            for record in records
+            if canonical_sched_phase(record.get("phase")) == "resolve" and id(record) not in nested_resolve_ids
+        ]
         work_recs = sorted(
             outer_recs + standalone_resolve,
             key=lambda r: r.get("start_time_us", 0),
@@ -261,7 +248,7 @@ def parse_scheduler_from_json_phases(data):  # noqa: PLR0912
         prev_end = None
 
         for rec in work_recs:
-            phase = rec["phase"]
+            phase = canonical_sched_phase(rec["phase"])
             start = rec.get("start_time_us", 0)
             end = rec.get("end_time_us", 0)
             # Idle = wall-clock gap between this record and the previous
@@ -297,16 +284,10 @@ def parse_scheduler_from_json_phases(data):  # noqa: PLR0912
         finishes_per_loop = total_finishes / loops if loops > 0 else 0.0
         pop_total = pop_hit + pop_miss
         pop_hit_rate = pop_hit / pop_total * 100 if pop_total > 0 else 0.0
-        phases_seen = {rec["phase"] for rec in work_recs}
+        phases_seen = {canonical_sched_phase(rec["phase"]) for rec in work_recs}
         if phase_us["idle"] > 0:
             phases_seen.add("idle")
-        scheduler_only_phases = {"complete", "dispatch", "release", "early_dispatch", "drain", "graph_prepare"}
-        has_scheduler_work = bool(phases_seen & scheduler_only_phases)
-        has_resolution_work = bool(phases_seen & {"resolve", "async_poll", "dummy"})
-        is_unassigned_thread = bool(assigned_thread_indices) and tid not in assigned_thread_indices
-        is_resolution_thread = (
-            has_resolution_work and not has_scheduler_work and (bool(standalone_resolve) or is_unassigned_thread)
-        )
+        role = scheduler_thread_role(records, assigned_thread_indices, tid, nested_resolve_ids)
 
         t = {
             # `completed` remains the legacy logical-task field used by the
@@ -322,7 +303,7 @@ def parse_scheduler_from_json_phases(data):  # noqa: PLR0912
             "pop_miss": pop_miss,
             "pop_hit_rate": pop_hit_rate,
             "format": "json_phase",
-            "role": "resolution" if is_resolution_thread else "scheduler",
+            "role": role,
             "phases_seen": phases_seen,
         }
         for p, us in phase_us.items():

--- a/simpler_setup/tools/scheduler_phase_records.py
+++ b/simpler_setup/tools/scheduler_phase_records.py
@@ -1,0 +1,85 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Shared scheduler-phase classification for profiling tools."""
+
+import bisect
+
+SCHED_OUTER_PHASES = (
+    "complete",
+    "async_poll",
+    "dispatch",
+    "release",
+    "dummy",
+    "early_dispatch",
+    "drain",
+    "graph_prepare",
+)
+
+_SCHEDULER_WORK_PHASES = frozenset({"complete", "dispatch", "release", "early_dispatch", "drain", "graph_prepare"})
+_RESOLUTION_WORK_PHASES = frozenset({"resolve", "resolve_standalone", "async_poll", "dummy"})
+
+
+def canonical_sched_phase(phase):
+    """Map a wire-level phase discriminator to its report label."""
+    return "resolve" if phase == "resolve_standalone" else phase
+
+
+def nested_resolve_record_ids(records):
+    """Return Resolve records contained by a Complete or Dummy parent.
+
+    Containment is strict at the end and inclusive at the start. Only a trace
+    recorded before the ``resolve_standalone`` discriminator can carry a
+    standalone Resolve under this label, and there the P thread's Resolve abuts
+    a neighbouring Dummy bar rather than sitting inside it, so a Resolve ending
+    exactly at its candidate parent's end is P-thread work.
+
+    The start stays inclusive because TMR opens a Dummy bar and times the first
+    dummy's Resolve two ``get_sys_cnt_aicpu()`` reads apart, which share one
+    a2a3 sys-cnt tick (20 ns at 50 MHz) often enough that a strict start would
+    report genuinely nested Resolve work as standalone and double-count it.
+    """
+    parents = sorted(
+        (
+            (record.get("start_time_us", 0), record.get("end_time_us", 0))
+            for record in records
+            if record.get("phase") in ("complete", "dummy")
+        ),
+        key=lambda interval: interval[0],
+    )
+    parent_starts = [interval[0] for interval in parents]
+    nested = set()
+    for record in records:
+        if record.get("phase") != "resolve":
+            continue
+        start_us = record.get("start_time_us", 0)
+        end_us = record.get("end_time_us", 0)
+        parent_idx = bisect.bisect_right(parent_starts, start_us) - 1
+        if parent_idx < 0:
+            continue
+        if end_us < parents[parent_idx][1]:
+            nested.add(id(record))
+    return nested
+
+
+def scheduler_thread_role(records, assigned_thread_indices, thread_idx, nested_resolve_ids):
+    """Classify a scheduler-phase thread as scheduler or resolution."""
+    raw_phases = {record.get("phase") for record in records}
+    phases = {canonical_sched_phase(phase) for phase in raw_phases}
+    has_scheduler_work = bool(phases & _SCHEDULER_WORK_PHASES)
+    has_resolution_work = bool(raw_phases & _RESOLUTION_WORK_PHASES)
+    is_unassigned_thread = bool(assigned_thread_indices) and thread_idx not in assigned_thread_indices
+    has_standalone_resolve = any(
+        record.get("phase") == "resolve_standalone"
+        or (record.get("phase") == "resolve" and id(record) not in nested_resolve_ids)
+        for record in records
+    )
+    is_resolution_thread = (
+        has_resolution_work and not has_scheduler_work and (has_standalone_resolve or is_unassigned_thread)
+    )
+    return "resolution" if is_resolution_thread else "scheduler"

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -36,6 +36,11 @@ from pathlib import Path
 from typing import Any
 
 from simpler_setup.tools.clock_correlation import build_clock_alignment
+from simpler_setup.tools.scheduler_phase_records import (
+    canonical_sched_phase,
+    nested_resolve_record_ids,
+    scheduler_thread_role,
+)
 
 
 def _func_id_to_letter(func_id):
@@ -137,28 +142,6 @@ def _decode_in_graph_task_id(task_id):
         return None
     local = tid & 0xFFFFFFFF
     return local >> 10, local & 0x3FF
-
-
-def _nested_resolve_record_ids(records):
-    """Return Resolve records contained by a Complete or Dummy parent."""
-    parents = sorted(
-        (
-            (record.get("start_time_us", 0), record.get("end_time_us", 0))
-            for record in records
-            if record.get("phase") in ("complete", "dummy")
-        ),
-        key=lambda interval: interval[0],
-    )
-    parent_starts = [interval[0] for interval in parents]
-    nested = set()
-    for record in records:
-        if record.get("phase") != "resolve":
-            continue
-        start_us = record.get("start_time_us", 0)
-        parent_idx = bisect.bisect_right(parent_starts, start_us) - 1
-        if parent_idx >= 0 and record.get("end_time_us", 0) <= parents[parent_idx][1]:
-            nested.add(id(record))
-    return nested
 
 
 def _collect_graph_execution_instances(tasks, scheduler_phases):  # noqa: PLR0912
@@ -1825,17 +1808,10 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
         for thread_idx, thread_records in enumerate(scheduler_phases):
             tid = sched_lane_tid(thread_idx, 0)
             resolve_tid = sched_lane_tid(thread_idx, 1)
-            nested_resolve_ids = _nested_resolve_record_ids(thread_records)
-            thread_phase_names = {record.get("phase") for record in thread_records}
-            scheduler_only_phases = {"complete", "dispatch", "release", "early_dispatch", "drain", "graph_prepare"}
-            has_scheduler_work = bool(thread_phase_names & scheduler_only_phases)
-            has_resolution_work = bool(thread_phase_names & {"resolve", "async_poll", "dummy"})
-            is_unassigned_thread = bool(assigned_thread_indices) and thread_idx not in assigned_thread_indices
-            has_standalone_resolve = any(
-                record.get("phase") == "resolve" and id(record) not in nested_resolve_ids for record in thread_records
-            )
+            nested_resolve_ids = nested_resolve_record_ids(thread_records)
             is_resolution_thread = (
-                has_resolution_work and not has_scheduler_work and (has_standalone_resolve or is_unassigned_thread)
+                scheduler_thread_role(thread_records, assigned_thread_indices, thread_idx, nested_resolve_ids)
+                == "resolution"
             )
 
             # Thread name metadata
@@ -1871,7 +1847,8 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             # virtual worker, so we route them to Worker View (pid=4) AICPU_N
             # (where N = the AICPU id of the sched thread that drained them).
             for record in thread_records:
-                phase = record.get("phase", "unknown")
+                raw_phase = record.get("phase", "unknown")
+                phase = canonical_sched_phase(raw_phase)
                 if phase in ("dummy_task", "predicated_skip"):
                     start_us = record["start_time_us"]
                     end_us = record["end_time_us"]
@@ -1986,7 +1963,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                         tasks_processed = matched_finish_rows
                         phase_args["tasks_processed"] = tasks_processed
                 display_name = f"{phase}({tasks_processed})"
-                event_tid = resolve_tid if phase == "resolve" and id(record) in nested_resolve_ids else tid
+                event_tid = resolve_tid if raw_phase == "resolve" and id(record) in nested_resolve_ids else tid
                 events.append(
                     {
                         "args": phase_args,

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -22,9 +22,9 @@
 #include "aicpu/platform_regs.h"
 #include "callable.h"
 #include "common/chip_swimlane_profiling.h"
-#include "host_build_graph/async_poll_phase_accumulator.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
+#include "host_build_graph/async_poll_phase_accumulator.h"
 #include "host_build_graph/runtime_core.h"
 #include "runtime.h"
 #include "spin_hint.h"
@@ -51,7 +51,22 @@ static_assert(sizeof(simpler::hbg::Tensor) == TASKPAYLOAD_TENSOR_STRIDE);
 // Dispatch helpers
 // =============================================================================
 
-namespace {}
+namespace {
+#if SIMPLER_DFX
+void capture_shared_ready_depth(SchedulerState *scheduler, int16_t shared_depth[CHIP_SWIMLANE_NUM_QUEUE_SHAPES]) {
+    // Each shape's dispatch depth combines its regular lane with the sync-start
+    // lane; both feed dispatch_ready_tasks for that shape. The clamp is
+    // load-bearing: CHIP_PROF_READYQUEUE_SIZE is in the low thousands today but
+    // grows with platform scaling, and a depth above 32767 would wrap to a
+    // negative int16_t and silently corrupt the snapshot.
+    constexpr size_t kMax = static_cast<size_t>(std::numeric_limits<int16_t>::max());
+    for (int shape = 0; shape < CHIP_SWIMLANE_NUM_QUEUE_SHAPES; shape++) {
+        const size_t depth = scheduler->ready_queues[shape].size() + scheduler->ready_sync_queues[shape].size();
+        shared_depth[shape] = static_cast<int16_t>(std::min(depth, kMax));
+    }
+}
+#endif
+}  // namespace
 
 // The early-dispatch core bitmask (EARLY_DISPATCH_CORE_MASK_WORDS * 64 bits) must cover
 // every global core_id, and the per-core doorbell table is sized to match.
@@ -904,17 +919,10 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
     chip_swimlane.chip_swimlane_enabled = (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED);
 
     const bool record_sched_phases = chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES;
-    auto capture_shared_depth = [&](int16_t shared_depth[CHIP_SWIMLANE_NUM_QUEUE_SHAPES]) {
-        constexpr size_t kMax = static_cast<size_t>(std::numeric_limits<int16_t>::max());
-        for (int shape = 0; shape < CHIP_SWIMLANE_NUM_QUEUE_SHAPES; shape++) {
-            const size_t depth = sched_->ready_queues[shape].size() + sched_->ready_sync_queues[shape].size();
-            shared_depth[shape] = static_cast<int16_t>(std::min(depth, kMax));
-        }
-    };
     auto record_p_phase = [&](ChipSwimlaneSchedPhaseKind kind, uint64_t start_time, uint64_t end_time,
                               uint32_t tasks_processed, const int16_t shared_at_start[CHIP_SWIMLANE_NUM_QUEUE_SHAPES]) {
         int16_t shared_at_end[CHIP_SWIMLANE_NUM_QUEUE_SHAPES];
-        capture_shared_depth(shared_at_end);
+        capture_shared_ready_depth(sched_, shared_at_end);
         chip_swimlane_aicpu_record_sched_phase(
             thread_idx, kind, start_time, end_time, chip_swimlane.sched_loop_count, tasks_processed,
             /*pop_hit=*/0, /*pop_miss=*/0, shared_at_start, shared_at_end
@@ -968,7 +976,7 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
                 if (record_sched_phases && resolve_t0 == 0) {
                     resolve_t0 = get_sys_cnt_aicpu();
                     flush_async_poll(resolve_t0);
-                    capture_shared_depth(resolve_shared_at_start);
+                    capture_shared_ready_depth(sched_, resolve_shared_at_start);
                 }
 #endif
 #if SIMPLER_SCHED_PROFILING
@@ -990,7 +998,7 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
 #if SIMPLER_DFX
         if (resolve_t0 != 0) {
             record_p_phase(
-                ChipSwimlaneSchedPhaseKind::Resolve, resolve_t0, get_sys_cnt_aicpu(), resolve_count,
+                ChipSwimlaneSchedPhaseKind::ResolveStandalone, resolve_t0, get_sys_cnt_aicpu(), resolve_count,
                 resolve_shared_at_start
             );
         }
@@ -1007,7 +1015,7 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
             uint64_t async_poll_t0 = 0;
             if (record_sched_phases) {
                 if (!async_poll_phase.active()) {
-                    capture_shared_depth(async_poll_shared_at_start);
+                    capture_shared_ready_depth(sched_, async_poll_shared_at_start);
                     async_poll_phase.begin();
                 }
                 async_poll_t0 = get_sys_cnt_aicpu();
@@ -1058,7 +1066,7 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
                 if (record_sched_phases && dummy_t0 == 0) {
                     dummy_t0 = get_sys_cnt_aicpu();
                     flush_async_poll(dummy_t0);
-                    capture_shared_depth(dummy_shared_at_start);
+                    capture_shared_ready_depth(sched_, dummy_shared_at_start);
                 }
 #endif
                 for (int di = 0; di < dummy_got; di++) {
@@ -1229,17 +1237,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     bool iter_shared_sampled = false;
     auto get_or_sample_shared = [&]() -> const int16_t * {
         if (!iter_shared_sampled) {
-            // Clamp to int16_t max before narrowing. CHIP_PROF_READYQUEUE_SIZE
-            // is in the low thousands today but could grow with platform
-            // scaling — without clamp, sizes above 32767 wrap to negatives
-            // and silently corrupt the snapshot.
-            constexpr size_t kMax = static_cast<size_t>(std::numeric_limits<int16_t>::max());
-            for (int s = 0; s < CHIP_SWIMLANE_NUM_QUEUE_SHAPES; s++) {
-                // Total normal-source ready depth of shape `s` = regular ready lane + the
-                // sync_start Tier-0 lane; both feed dispatch_ready_tasks for this shape.
-                const size_t qsize = sched_->ready_queues[s].size() + sched_->ready_sync_queues[s].size();
-                iter_shared_snapshot[s] = static_cast<int16_t>(std::min(qsize, kMax));
-            }
+            capture_shared_ready_depth(sched_, iter_shared_snapshot);
             iter_shared_sampled = true;
         }
         return iter_shared_snapshot;

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -22,9 +22,9 @@
 #include "aicpu/platform_regs.h"
 #include "callable.h"
 #include "common/chip_swimlane_profiling.h"
-#include "host_build_graph/async_poll_phase_accumulator.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
+#include "host_build_graph/async_poll_phase_accumulator.h"
 #include "host_build_graph/runtime_core.h"
 #include "runtime.h"
 #include "spin_hint.h"
@@ -52,7 +52,22 @@ static_assert(sizeof(simpler::hbg::Tensor) == TASKPAYLOAD_TENSOR_STRIDE);
 // Dispatch helpers
 // =============================================================================
 
-namespace {}
+namespace {
+#if SIMPLER_DFX
+void capture_shared_ready_depth(SchedulerState *scheduler, int16_t shared_depth[CHIP_SWIMLANE_NUM_QUEUE_SHAPES]) {
+    // Each shape's dispatch depth combines its regular lane with the sync-start
+    // lane; both feed dispatch_ready_tasks for that shape. The clamp is
+    // load-bearing: CHIP_PROF_READYQUEUE_SIZE is in the low thousands today but
+    // grows with platform scaling, and a depth above 32767 would wrap to a
+    // negative int16_t and silently corrupt the snapshot.
+    constexpr size_t kMax = static_cast<size_t>(std::numeric_limits<int16_t>::max());
+    for (int shape = 0; shape < CHIP_SWIMLANE_NUM_QUEUE_SHAPES; shape++) {
+        const size_t depth = scheduler->ready_queues[shape].size() + scheduler->ready_sync_queues[shape].size();
+        shared_depth[shape] = static_cast<int16_t>(std::min(depth, kMax));
+    }
+}
+#endif
+}  // namespace
 
 // The early-dispatch core bitmask (EARLY_DISPATCH_CORE_MASK_WORDS * 64 bits) must cover
 // every global core_id, and the per-core doorbell table is sized to match.
@@ -905,17 +920,10 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
     chip_swimlane.chip_swimlane_enabled = (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED);
 
     const bool record_sched_phases = chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES;
-    auto capture_shared_depth = [&](int16_t shared_depth[CHIP_SWIMLANE_NUM_QUEUE_SHAPES]) {
-        constexpr size_t kMax = static_cast<size_t>(std::numeric_limits<int16_t>::max());
-        for (int shape = 0; shape < CHIP_SWIMLANE_NUM_QUEUE_SHAPES; shape++) {
-            const size_t depth = sched_->ready_queues[shape].size() + sched_->ready_sync_queues[shape].size();
-            shared_depth[shape] = static_cast<int16_t>(std::min(depth, kMax));
-        }
-    };
     auto record_p_phase = [&](ChipSwimlaneSchedPhaseKind kind, uint64_t start_time, uint64_t end_time,
                               uint32_t tasks_processed, const int16_t shared_at_start[CHIP_SWIMLANE_NUM_QUEUE_SHAPES]) {
         int16_t shared_at_end[CHIP_SWIMLANE_NUM_QUEUE_SHAPES];
-        capture_shared_depth(shared_at_end);
+        capture_shared_ready_depth(sched_, shared_at_end);
         chip_swimlane_aicpu_record_sched_phase(
             thread_idx, kind, start_time, end_time, chip_swimlane.sched_loop_count, tasks_processed,
             /*pop_hit=*/0, /*pop_miss=*/0, shared_at_start, shared_at_end
@@ -969,7 +977,7 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
                 if (record_sched_phases && resolve_t0 == 0) {
                     resolve_t0 = get_sys_cnt_aicpu();
                     flush_async_poll(resolve_t0);
-                    capture_shared_depth(resolve_shared_at_start);
+                    capture_shared_ready_depth(sched_, resolve_shared_at_start);
                 }
 #endif
 #if SIMPLER_SCHED_PROFILING
@@ -991,7 +999,7 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
 #if SIMPLER_DFX
         if (resolve_t0 != 0) {
             record_p_phase(
-                ChipSwimlaneSchedPhaseKind::Resolve, resolve_t0, get_sys_cnt_aicpu(), resolve_count,
+                ChipSwimlaneSchedPhaseKind::ResolveStandalone, resolve_t0, get_sys_cnt_aicpu(), resolve_count,
                 resolve_shared_at_start
             );
         }
@@ -1008,7 +1016,7 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
             uint64_t async_poll_t0 = 0;
             if (record_sched_phases) {
                 if (!async_poll_phase.active()) {
-                    capture_shared_depth(async_poll_shared_at_start);
+                    capture_shared_ready_depth(sched_, async_poll_shared_at_start);
                     async_poll_phase.begin();
                 }
                 async_poll_t0 = get_sys_cnt_aicpu();
@@ -1059,7 +1067,7 @@ int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread
                 if (record_sched_phases && dummy_t0 == 0) {
                     dummy_t0 = get_sys_cnt_aicpu();
                     flush_async_poll(dummy_t0);
-                    capture_shared_depth(dummy_shared_at_start);
+                    capture_shared_ready_depth(sched_, dummy_shared_at_start);
                 }
 #endif
                 for (int di = 0; di < dummy_got; di++) {
@@ -1230,17 +1238,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     bool iter_shared_sampled = false;
     auto get_or_sample_shared = [&]() -> const int16_t * {
         if (!iter_shared_sampled) {
-            // Clamp to int16_t max before narrowing. CHIP_PROF_READYQUEUE_SIZE
-            // is in the low thousands today but could grow with platform
-            // scaling — without clamp, sizes above 32767 wrap to negatives
-            // and silently corrupt the snapshot.
-            constexpr size_t kMax = static_cast<size_t>(std::numeric_limits<int16_t>::max());
-            for (int s = 0; s < CHIP_SWIMLANE_NUM_QUEUE_SHAPES; s++) {
-                // Total normal-source ready depth of shape `s` = regular ready lane + the
-                // sync_start Tier-0 lane; both feed dispatch_ready_tasks for this shape.
-                const size_t qsize = sched_->ready_queues[s].size() + sched_->ready_sync_queues[s].size();
-                iter_shared_snapshot[s] = static_cast<int16_t>(std::min(qsize, kMax));
-            }
+            capture_shared_ready_depth(sched_, iter_shared_snapshot);
             iter_shared_sampled = true;
         }
         return iter_shared_snapshot;

--- a/src/common/platform/include/common/chip_swimlane_profiling.h
+++ b/src/common/platform/include/common/chip_swimlane_profiling.h
@@ -497,9 +497,10 @@ static_assert(sizeof(ChipSwimlaneDataHeader) % 64 == 0, "ChipSwimlaneDataHeader 
  *     DrainPublish. Resolve is contained by Complete or Dummy there.
  *
  *   HBG RESOLUTION-THREAD OUTER:
- *     Resolve, AsyncPoll, and Dummy. The host_build_graph runtime hands FIN'd
- *     slots from S threads to a dedicated P thread, so these are standalone,
- *     mutually exclusive P-thread bars rather than nested S-thread work.
+ *     ResolveStandalone, AsyncPoll, and Dummy. The host_build_graph runtime
+ *     hands FIN'd slots from S threads to a dedicated P thread, so these are
+ *     standalone, mutually exclusive P-thread bars rather than nested
+ *     S-thread work.
  *
  *   SEPARATE-LANE (converter routes to Worker View pid=4, not the sched lane):
  *     DummyTask and PredicatedSkip. One zero-width marker per dependency-only
@@ -522,10 +523,9 @@ enum class ChipSwimlaneSchedPhaseKind : uint32_t {
     EarlyDispatch = 5,  // try_early_dispatch: early-dispatch pre-staging
                         // of a flagged producer's consumer's gated blocks.
                         // tasks_processed = blocks staged this pass.
-    // Inner in tensormap_and_ringbuffer (parent: Complete | Dummy); standalone
-    // P-thread outer phase in host_build_graph.
+    // Inner in tensormap_and_ringbuffer (parent: Complete | Dummy).
     Resolve = 6,  // Complete ready work after FIN observation. tasks_processed
-                  // is consumers visited (TMR) or completed SPSC slots (HBG).
+                  // is consumers visited.
     // Separate-lane (Worker View pid=4 AICPU_N)
     DummyTask = 7,      // Per-dummy identity marker (zero-width). phase_data.dummy_task
                         // carries the local/ring components of the full task identity.
@@ -550,6 +550,10 @@ enum class ChipSwimlaneSchedPhaseKind : uint32_t {
     // phase_data.graph_task identifies the ring-0 outer Graph task and
     // tasks_processed is the number of in-graph tasks patched in this slice.
     GraphPrepare = 13,
+    // Outer on host_build_graph's dedicated P thread. Kept distinct from the
+    // nested TMR Resolve so post-processing never infers the role from rounded
+    // timestamps. tasks_processed is completed SPSC slots.
+    ResolveStandalone = 14,
 };
 
 /** Index layout of the queue-depth snapshot arrays below: AIC=0, AIV=1, MIX=2.

--- a/src/common/platform/shared/host/chip_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/chip_swimlane_collector.cpp
@@ -1157,6 +1157,8 @@ int ChipSwimlaneCollector::export_swimlane_json() {
                 return "early_dispatch";
             case ChipSwimlaneSchedPhaseKind::Resolve:
                 return "resolve";
+            case ChipSwimlaneSchedPhaseKind::ResolveStandalone:
+                return "resolve_standalone";
             case ChipSwimlaneSchedPhaseKind::DummyTask:
                 return "dummy_task";
             case ChipSwimlaneSchedPhaseKind::PredicatedSkip:

--- a/tests/st/a2a3/host_build_graph/dfx/chip_swimlane/test_scheduler_phases.py
+++ b/tests/st/a2a3/host_build_graph/dfx/chip_swimlane/test_scheduler_phases.py
@@ -79,14 +79,14 @@ class TestSchedulerPhases(SceneTestCase):
             ]
             assert len(resolution_threads) == 1, f"expected one core-less P thread, found {len(resolution_threads)}"
             resolution_thread = resolution_threads[0]
-            required = {"resolve", "dummy"}
+            required = {"resolve_standalone", "dummy"}
             emitted = {record.get("phase") for record in resolution_thread}
             assert required <= emitted, f"missing P-thread phases: {sorted(required - emitted)}"
 
             records = [record for record in resolution_thread if record.get("phase") in required]
             assert all(record["loop_iter"] > 0 for record in records)
             assert all(record["end_time_us"] >= record["start_time_us"] for record in records)
-            assert sum(record["tasks_processed"] for record in records if record["phase"] == "resolve") >= 1
+            assert sum(record["tasks_processed"] for record in records if record["phase"] == "resolve_standalone") >= 1
             assert sum(record["tasks_processed"] for record in records if record["phase"] == "dummy") == 1
             assert len(resolution_thread) < 64, "P-thread phase aggregation produced excessive records"
 

--- a/tests/st/a5/host_build_graph/dfx/chip_swimlane/test_scheduler_phases.py
+++ b/tests/st/a5/host_build_graph/dfx/chip_swimlane/test_scheduler_phases.py
@@ -79,14 +79,14 @@ class TestSchedulerPhases(SceneTestCase):
             ]
             assert len(resolution_threads) == 1, f"expected one core-less P thread, found {len(resolution_threads)}"
             resolution_thread = resolution_threads[0]
-            required = {"resolve", "dummy"}
+            required = {"resolve_standalone", "dummy"}
             emitted = {record.get("phase") for record in resolution_thread}
             assert required <= emitted, f"missing P-thread phases: {sorted(required - emitted)}"
 
             records = [record for record in resolution_thread if record.get("phase") in required]
             assert all(record["loop_iter"] > 0 for record in records)
             assert all(record["end_time_us"] >= record["start_time_us"] for record in records)
-            assert sum(record["tasks_processed"] for record in records if record["phase"] == "resolve") >= 1
+            assert sum(record["tasks_processed"] for record in records if record["phase"] == "resolve_standalone") >= 1
             assert sum(record["tasks_processed"] for record in records if record["phase"] == "dummy") == 1
             assert len(resolution_thread) < 64, "P-thread phase aggregation produced excessive records"
 

--- a/tests/ut/py/test_l2_dispatch.py
+++ b/tests/ut/py/test_l2_dispatch.py
@@ -26,10 +26,21 @@ def _load_root_conftest():
 
 
 class _Config:
-    def __init__(self, *, xdist_active: bool, xdist_blocked: bool, disable_arg: bool = False):
+    def __init__(
+        self,
+        *,
+        xdist_active: bool,
+        xdist_blocked: bool,
+        disable_arg: bool = False,
+        xdist_numprocesses=None,
+        xdist_dist="no",
+        usepdb=False,
+        extra_args=(),
+    ):
         args = ["first.py", "second.py"]
         if disable_arg:
             args.extend(["-p", "no:xdist"])
+        args.extend(extra_args)
         args.extend(["--max-parallel", "2"])
         self.invocation_params = SimpleNamespace(
             args=tuple(args),
@@ -39,6 +50,9 @@ class _Config:
             hasplugin=lambda name: name == "xdist" and xdist_active,
             is_blocked=lambda name: name == "xdist" and xdist_blocked,
         )
+        self._xdist_numprocesses = xdist_numprocesses
+        self._xdist_dist = xdist_dist
+        self._usepdb = usepdb
 
     def getoption(self, name, default=None):
         return {
@@ -47,6 +61,9 @@ class _Config:
             "--platform": "a2a3sim",
             "--manual": "include",
             "--max-parallel": "2",
+            "numprocesses": self._xdist_numprocesses,
+            "dist": self._xdist_dist,
+            "usepdb": self._usepdb,
         }.get(name, default)
 
 
@@ -99,3 +116,138 @@ def test_l2_dispatch_adds_xdist_options_when_plugin_is_active(monkeypatch):
         "--dist",
         "loadfile",
     ]
+
+
+def test_l2_dispatch_warns_and_stays_serial_when_xdist_is_not_loaded(monkeypatch, capsys):
+    cf = _load_root_conftest()
+    commands = []
+
+    def fake_run(command, **_kwargs):
+        commands.append(command)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(cf.subprocess, "run", fake_run)
+    config = _Config(xdist_active=False, xdist_blocked=False)
+    items = [SimpleNamespace(cls=SimpleNamespace(_st_runtime="host_build_graph", _st_level=2))]
+    session = SimpleNamespace(config=config, items=items, testsfailed=0, testscollected=0)
+
+    assert cf._dispatch_test_phases(session, []) is True
+    assert "pytest-xdist plugin is not active" in capsys.readouterr().out
+    assert "-n" not in commands[0]
+    assert "--dist" not in commands[0]
+
+
+def test_l2_dispatch_honors_xdist_disabled_with_numprocesses_zero(monkeypatch):
+    cf = _load_root_conftest()
+    commands = []
+
+    def fake_run(command, **_kwargs):
+        commands.append(command)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(cf.subprocess, "run", fake_run)
+    config = _Config(
+        xdist_active=True,
+        xdist_blocked=False,
+        xdist_numprocesses=0,
+        extra_args=("-n", "0"),
+    )
+    items = [SimpleNamespace(cls=SimpleNamespace(_st_runtime="host_build_graph", _st_level=2))]
+    session = SimpleNamespace(config=config, items=items, testsfailed=0, testscollected=0)
+
+    assert cf._dispatch_test_phases(session, []) is True
+    assert commands[0].count("-n") == 1
+    assert commands[0][commands[0].index("-n") + 1] == "0"
+    assert "--dist" not in commands[0]
+
+
+def test_l2_dispatch_preserves_explicit_xdist_worker_count_and_distribution(monkeypatch):
+    # A positive `-n` reaches the dispatcher only from a direct caller such as
+    # this test: under pytest it puts xdist in distribution mode, whose
+    # pytest_runtestloop claims the session first.
+    cf = _load_root_conftest()
+    commands = []
+
+    def fake_run(command, **_kwargs):
+        commands.append(command)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(cf.subprocess, "run", fake_run)
+    config = _Config(
+        xdist_active=True,
+        xdist_blocked=False,
+        xdist_numprocesses=1,
+        xdist_dist="loadscope",
+        extra_args=("-n", "1", "--dist", "loadscope"),
+    )
+    items = [SimpleNamespace(cls=SimpleNamespace(_st_runtime="host_build_graph", _st_level=2))]
+    session = SimpleNamespace(config=config, items=items, testsfailed=0, testscollected=0)
+
+    assert cf._dispatch_test_phases(session, []) is True
+    assert commands[0].count("-n") == 1
+    assert commands[0].count("--dist") == 1
+    assert commands[0][commands[0].index("-n") + 1] == "1"
+    assert commands[0][commands[0].index("--dist") + 1] == "loadscope"
+
+
+def test_l2_dispatch_adds_distribution_default_when_only_worker_count_is_explicit(monkeypatch):
+    cf = _load_root_conftest()
+    commands = []
+
+    def fake_run(command, **_kwargs):
+        commands.append(command)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(cf.subprocess, "run", fake_run)
+    config = _Config(
+        xdist_active=True,
+        xdist_blocked=False,
+        xdist_numprocesses=1,
+        xdist_dist="load",
+        extra_args=("-n", "1"),
+    )
+    items = [SimpleNamespace(cls=SimpleNamespace(_st_runtime="host_build_graph", _st_level=2))]
+    session = SimpleNamespace(config=config, items=items, testsfailed=0, testscollected=0)
+
+    assert cf._dispatch_test_phases(session, []) is True
+    assert commands[0].count("-n") == 1
+    assert commands[0][-2:] == ["--dist", "loadfile"]
+
+
+def test_l2_dispatch_treats_the_dist_shortcut_as_an_explicit_distribution(monkeypatch):
+    cf = _load_root_conftest()
+    commands = []
+
+    def fake_run(command, **_kwargs):
+        commands.append(command)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(cf.subprocess, "run", fake_run)
+    config = _Config(xdist_active=True, xdist_blocked=False, xdist_dist="load", extra_args=("-d",))
+    items = [SimpleNamespace(cls=SimpleNamespace(_st_runtime="host_build_graph", _st_level=2))]
+    session = SimpleNamespace(config=config, items=items, testsfailed=0, testscollected=0)
+
+    assert cf._dispatch_test_phases(session, []) is True
+    assert commands[0][-2:] == ["-n", "2"]
+    assert "--dist" not in commands[0]
+
+
+def test_l2_dispatch_stays_serial_under_pdb_without_an_explicit_worker_count(monkeypatch):
+    # xdist zeroes `numprocesses` only for `-n auto` / `-n logical`, so a bare
+    # `--pdb` arrives with it unset. The child inherits `--pdb`, and xdist
+    # rejects that combination once `-n` puts the child in distribution mode.
+    cf = _load_root_conftest()
+    commands = []
+
+    def fake_run(command, **_kwargs):
+        commands.append(command)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(cf.subprocess, "run", fake_run)
+    config = _Config(xdist_active=True, xdist_blocked=False, usepdb=True, extra_args=("--pdb",))
+    items = [SimpleNamespace(cls=SimpleNamespace(_st_runtime="host_build_graph", _st_level=2))]
+    session = SimpleNamespace(config=config, items=items, testsfailed=0, testscollected=0)
+
+    assert cf._dispatch_test_phases(session, []) is True
+    assert "-n" not in commands[0]
+    assert "--dist" not in commands[0]

--- a/tests/ut/py/test_sched_overhead_analysis.py
+++ b/tests/ut/py/test_sched_overhead_analysis.py
@@ -246,6 +246,42 @@ def test_parse_scheduler_counts_hbg_p_thread_standalone_phases():
     assert threads[0]["phases_seen"] == {"resolve", "async_poll", "dummy", "idle"}
 
 
+def test_parse_scheduler_uses_explicit_hbg_resolve_discriminator_at_parent_boundary():
+    data = {
+        "aicpu_scheduler_phases": [
+            [
+                {"phase": "dummy", "start_time_us": 1.0, "end_time_us": 2.0, "loop_iter": 1},
+                {
+                    "phase": "resolve_standalone",
+                    "start_time_us": 2.0,
+                    "end_time_us": 2.0,
+                    "loop_iter": 2,
+                },
+            ]
+        ]
+    }
+
+    threads = parse_scheduler_from_json_phases(data)
+
+    assert threads[0]["role"] == "resolution"
+    assert threads[0]["phases_seen"] == {"dummy", "resolve"}
+
+
+def test_parse_scheduler_treats_legacy_resolve_touching_parent_boundary_as_standalone():
+    data = {
+        "aicpu_scheduler_phases": [
+            [
+                {"phase": "complete", "start_time_us": 1.0, "end_time_us": 2.0, "loop_iter": 1},
+                {"phase": "resolve", "start_time_us": 2.0, "end_time_us": 2.0, "loop_iter": 2},
+            ]
+        ]
+    }
+
+    threads = parse_scheduler_from_json_phases(data)
+
+    assert threads[0]["phases_seen"] == {"complete", "resolve"}
+
+
 def test_parse_scheduler_does_not_double_count_tmr_nested_resolve():
     data = {
         "aicpu_scheduler_phases": [
@@ -273,6 +309,40 @@ def test_parse_scheduler_does_not_double_count_tmr_nested_resolve():
     assert threads[0]["total_us"] == 8.0
     assert threads[0]["role"] == "scheduler"
     assert threads[0]["phases_seen"] == {"complete", "dummy", "idle"}
+
+
+def test_parse_scheduler_does_not_double_count_tmr_resolve_starting_with_its_parent():
+    # TMR stamps a Dummy bar's start and the first dummy's Resolve two
+    # get_sys_cnt_aicpu() reads apart, so on a2a3's 20 ns sys-cnt tick they
+    # routinely coincide. The Resolve is still nested and still excluded.
+    data = {
+        "aicpu_scheduler_phases": [
+            [
+                {
+                    "phase": "dummy",
+                    "start_time_us": 1.0,
+                    "end_time_us": 5.0,
+                    "loop_iter": 1,
+                    "tasks_processed": 2,
+                },
+                {"phase": "resolve", "start_time_us": 1.0, "end_time_us": 3.0, "loop_iter": 1},
+                {
+                    "phase": "dispatch",
+                    "start_time_us": 5.0,
+                    "end_time_us": 6.0,
+                    "loop_iter": 1,
+                    "tasks_processed": 1,
+                },
+            ]
+        ]
+    }
+
+    threads = parse_scheduler_from_json_phases(data)
+
+    assert threads[0]["dummy_us"] == 4.0
+    assert threads[0]["resolve_us"] == 0.0
+    assert threads[0]["total_us"] == 5.0
+    assert threads[0]["role"] == "scheduler"
 
 
 def test_scheduler_loop_summary_keeps_scheduler_and_resolution_rates_separate():

--- a/tests/ut/py/test_swimlane_converter.py
+++ b/tests/ut/py/test_swimlane_converter.py
@@ -847,7 +847,7 @@ def test_hbg_resolution_thread_uses_one_lane_and_exports_queue_depths(tmp_path):
         [],
         [
             {
-                "phase": "resolve",
+                "phase": "resolve_standalone",
                 "start_time_us": 1.0,
                 "end_time_us": 2.0,
                 "tasks_processed": 1,


### PR DESCRIPTION
## Summary

- give the HBG resolution thread its own `resolve_standalone` phase kind, so the
  converter and the overhead analysis no longer infer outer-vs-nested Resolve from
  rounded device timestamps; the converter still renders it as `resolve` on the P
  thread's main scheduler lane, and TMR's nested Resolve keeps its sub-lane
- share the phase classification, the nested-Resolve detection and the ready-queue
  depth sampling that the two profiling tools — and both arch copies of the HBG
  scheduler — had duplicated
- honor `-n 0`, `-p no:xdist`, and an explicit `--dist` (or its `-d` shortcut) in
  the L2 dispatcher: it now appends only the options the invocation left unset,
  instead of a fixed `-n <max-parallel> --dist loadfile`
- document that a top-level `-n N` with N > 0 never reaches the phase dispatcher —
  xdist's distribution mode claims `pytest_runtestloop` before this conftest's
  hook runs — so `--max-parallel` is what sizes L2 parallelism

Follow-ups to #2031 and #2054.

## Validation

- `pytest tests/ut/py`: 2082 passed, 24 skipped
- a2a3 + a5 HBG scheduler-phase scene tests pass; their exported records carry
  `resolve_standalone` on the core-less P thread
- `scheduler_dispatch.cpp` (a2a3 + a5) and `chip_swimlane_collector.cpp` rebuilt in
  all four onboard/sim configurations: clean
- ruff check + format, pyright, markdownlint, header / English-only / retired-name
  lints, clang-format: clean
- checked against pytest-xdist 3.8.0 that `--dist loadscope` and `-d` without `-n`
  still reach the dispatcher, while `-n 2` does not
