### PR TITLE
Refactor: merge the hbg task table into one ChipTaskStorage array

### DIFF
--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -307,7 +307,6 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
         if (boot_ok) {
             runtime_bind_ops(rt);
-            runtime->set_slot_states_ptr(nullptr);
 
             sched_ctx_.bind_runtime(rt);
 

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -507,8 +507,7 @@ bool bind_graph_definitions(
 
     for (size_t index = 0; index < count; ++index) {
         std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
-        if (!upload.has_value() || upload->outer_slot == nullptr || upload->outer_slot->task_kind != TaskKind::GRAPH ||
-            upload->outer_slot->task == nullptr || upload->outer_slot->payload == nullptr) {
+        if (!upload.has_value() || upload->outer_slot == nullptr || upload->outer_slot->task_kind != TaskKind::GRAPH) {
             LOG_ERROR("host-orch: invalid pending Graph task");
             return false;
         }
@@ -534,13 +533,14 @@ bool bind_graph_definitions(
                 definition->scalar_arg_count, &storage_layout
             ) ||
             storage_layout.total_bytes != definition->execution_storage_bytes ||
-            upload->outer_slot->payload->tensor_count != static_cast<int32_t>(definition->boundary_count) ||
-            upload->outer_slot->payload->scalar_count != static_cast<int32_t>(definition->boundary_scalar_count)) {
+            upload->outer_slot->to_payload().tensor_count != static_cast<int32_t>(definition->boundary_count) ||
+            upload->outer_slot->to_payload().scalar_count != static_cast<int32_t>(definition->boundary_scalar_count)) {
             LOG_ERROR("host-orch: invalid Graph Definition for task");
             return false;
         }
-        const uintptr_t outer_base = reinterpret_cast<uintptr_t>(upload->outer_slot->task->packed_buffer_base);
-        const uintptr_t outer_end = reinterpret_cast<uintptr_t>(upload->outer_slot->task->packed_buffer_end);
+        const uintptr_t outer_base =
+            reinterpret_cast<uintptr_t>(upload->outer_slot->to_descriptor().packed_buffer_base);
+        const uintptr_t outer_end = reinterpret_cast<uintptr_t>(upload->outer_slot->to_descriptor().packed_buffer_end);
         if (outer_end < outer_base || definition->required_heap > UINTPTR_MAX - outer_base ||
             storage_layout.total_bytes > outer_end - outer_base ||
             definition->required_heap > outer_end - outer_base - storage_layout.total_bytes) {
@@ -548,7 +548,7 @@ bool bind_graph_definitions(
             return false;
         }
         const uintptr_t storage_addr = outer_base + definition->required_heap;
-        if (storage_addr % alignof(InGraphTaskStorage) != 0) {
+        if (storage_addr % alignof(ChipTaskStorage) != 0) {
             LOG_ERROR("host-orch: Graph runtime storage address is misaligned");
             return false;
         }
@@ -616,7 +616,7 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: host SM mirror of %" PRIu64 " bytes unavailable", sm_size);
         return PTO_RUNTIME_ERR_INTERNAL;
     }
-    std::memset(host_sm, 0, sm_segs.descriptors);
+    std::memset(host_sm, 0, sm_segs.storage);
 
     // Re-point the orchestrator half at the host SM (scheduler keeps device SM).
     // Host-owned and destroyed with this frame, so rt->orchestrator is dropped on
@@ -909,7 +909,7 @@ int32_t run_host_orchestration(
         reinterpret_cast<uint64_t>(gm_heap) < HEAP_VIRTUAL_BASE && "device memory reaches into the virtual heap window"
     );
     // The alignment bind_graph_definitions checked on the virtual base — a Graph
-    // task's runtime storage must land on alignof(InGraphTaskStorage) — carries to
+    // task's runtime storage must land on alignof(ChipTaskStorage) — carries to
     // the real base only while the two are congruent: both are aligned to
     // kDefaultBaseAlign, and that covers the storage's own requirement.
     static_assert(
@@ -917,7 +917,7 @@ int32_t run_host_orchestration(
         "the virtual heap base must share the committed region's alignment"
     );
     static_assert(
-        alignof(InGraphTaskStorage) <= DeviceArena::kDefaultBaseAlign,
+        alignof(ChipTaskStorage) <= DeviceArena::kDefaultBaseAlign,
         "an in-graph task's storage alignment must be covered by the heap region's base alignment"
     );
     always_assert(reinterpret_cast<uint64_t>(gm_heap) % DeviceArena::kDefaultBaseAlign == 0);

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -559,7 +559,7 @@ struct SchedulerState {
         } else {
             ResourceShape shape = slot_state->active_mask.to_shape();
             if (shape == ResourceShape::DUMMY ||
-                (slot_state->task_attrs.has_predicate() && !slot_state->payload->predicate.pass())) {
+                (slot_state->task_attrs.has_predicate() && !slot_state->to_payload().predicate.pass())) {
                 pushed = dummy_ready_queue.push(slot_state);
             } else if (slot_state->task_attrs.requires_sync_start()) {
                 pushed = ready_sync_queues[static_cast<int32_t>(shape)].push(slot_state);
@@ -594,7 +594,7 @@ struct SchedulerState {
     // lists. The decision is terminal: tasks are never re-polled; a producer's
     // completion re-scans its waiters via on_mixed_task_complete's wake drain.
     int classify_fanin_state(const ChipTaskSlotState *s) const {
-        const TaskPayload &p = *s->payload;
+        const TaskPayload &p = s->to_payload();
         const SharedMemoryTaskHeader &tasks = *task_view.tasks;
         const int32_t *fanin = p.fanin_data();
         for (int32_t i = p.fanin_count - 1; i >= 0; i--) {
@@ -624,7 +624,7 @@ struct SchedulerState {
                 push_ready_routed(consumer);
                 return;
             }
-            producer = &tasks.get_slot_state_by_task_id(consumer->payload->fanin_data()[state]);
+            producer = &tasks.get_slot_state_by_task_id(consumer->to_payload().fanin_data()[state]);
         }
     }
 
@@ -635,7 +635,7 @@ struct SchedulerState {
     // watermark >= producer.last_consumer_local_id). Whole-graph-resident hbg
     // has no device slot reclaim, so nothing advances a reclaim cursor here.
     void on_mixed_task_complete(ChipTaskSlotState &slot_state) {
-        const int32_t task_id = static_cast<int32_t>(simpler::hbg::task_local_id(slot_state.task->task_id));
+        const int32_t task_id = static_cast<int32_t>(simpler::hbg::task_local_id(slot_state.to_descriptor().task_id));
         SharedMemoryTaskHeader &tasks = *task_view.tasks;
 
         slot_state.mark_completed();  // host-visible mirror (task_state = COMPLETED)
@@ -644,7 +644,7 @@ struct SchedulerState {
         ChipTaskSlotState *waiter = slot_state.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
         while (waiter != nullptr && waiter != WAKE_LIST_SENTINEL) {
             ChipTaskSlotState *next = waiter->next_in_wake_list;
-            if (waiter->payload->fanin_count == 1) {
+            if (waiter->to_payload().fanin_count == 1) {
                 push_ready_routed(waiter);  // single-fanin waiter was waiting only on us
                 waiter = next;
                 continue;
@@ -653,7 +653,7 @@ struct SchedulerState {
             if (state < 0) {
                 push_ready_routed(waiter);
             } else {
-                register_wake(&tasks.get_slot_state_by_task_id(waiter->payload->fanin_data()[state]), waiter);
+                register_wake(&tasks.get_slot_state_by_task_id(waiter->to_payload().fanin_data()[state]), waiter);
             }
             waiter = next;
         }
@@ -775,7 +775,7 @@ struct SchedulerState {
 
     inline void record_published_blocks(ChipTaskSlotState &slot_state, int32_t count) {
         if (count <= 0 || !slot_state.task_attrs.allow_early_resolve()) return;
-        slot_state.payload->published_block_count.fetch_add(static_cast<int16_t>(count), std::memory_order_seq_cst);
+        slot_state.to_payload().published_block_count.fetch_add(static_cast<int16_t>(count), std::memory_order_seq_cst);
     }
 
     // Ring one sync_start cohort from its stable staged_core_mask. The caller owns
@@ -783,7 +783,7 @@ struct SchedulerState {
     // global staging completes, while the corresponding per-core table entries are live.
     inline void ring_all_staged_doorbells(ChipTaskSlotState &slot_state) {
         for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
-            uint64_t bits = slot_state.payload->staged_core_mask[w].load(std::memory_order_seq_cst);
+            uint64_t bits = slot_state.to_payload().staged_core_mask[w].load(std::memory_order_seq_cst);
             while (bits != 0) {
                 int core_id = w * 64 + __builtin_ctzll(bits);
                 bits &= bits - 1;
@@ -816,14 +816,16 @@ struct SchedulerState {
 
     inline void cancel_early_sync_drain(ChipTaskSlotState &slot_state) {
         uint8_t previous =
-            slot_state.payload->early_sync_drain_state.exchange(EARLY_SYNC_DRAIN_NONE, std::memory_order_seq_cst);
+            slot_state.to_payload().early_sync_drain_state.exchange(EARLY_SYNC_DRAIN_NONE, std::memory_order_seq_cst);
         if ((previous & EARLY_SYNC_DRAIN_OWNER) == 0) return;
         if ((previous & EARLY_SYNC_DRAIN_READY) != 0) {
             push_ready_routed(&slot_state);
             return;
         }
-        if (slot_state.payload->early_dispatch_state.load(std::memory_order_seq_cst) == EARLY_DISPATCH_STAGING) {
-            early_sync_start_queue.push_tagged(&slot_state, static_cast<uint64_t>(slot_state.task->task_id.raw));
+        if (slot_state.to_payload().early_dispatch_state.load(std::memory_order_seq_cst) == EARLY_DISPATCH_STAGING) {
+            early_sync_start_queue.push_tagged(
+                &slot_state, static_cast<uint64_t>(slot_state.to_descriptor().task_id.raw)
+            );
         }
     }
 
@@ -852,19 +854,19 @@ struct SchedulerState {
         // happens-before its final store. Read the seed first, then the mask, so
         // observing the final count cannot be paired with a partially published
         // mask when producer release races staging.
-        int32_t running_cores = slot_state.payload->running_slot_count.load(std::memory_order_seq_cst);
+        int32_t running_cores = slot_state.to_payload().running_slot_count.load(std::memory_order_seq_cst);
         int32_t staged_cores = 0;
         for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++)
             staged_cores +=
-                __builtin_popcountll(slot_state.payload->staged_core_mask[w].load(std::memory_order_seq_cst));
+                __builtin_popcountll(slot_state.to_payload().staged_core_mask[w].load(std::memory_order_seq_cst));
         if (staged_cores == 0) return false;
         if (running_cores != staged_cores) return false;
-        if (slot_state.payload->early_dispatch_state.load(std::memory_order_seq_cst) != EARLY_DISPATCH_DISPATCHED)
+        if (slot_state.to_payload().early_dispatch_state.load(std::memory_order_seq_cst) != EARLY_DISPATCH_DISPATCHED)
             return false;
-        if (!try_claim_early_dispatch_launch(*slot_state.payload)) return false;
+        if (!try_claim_early_dispatch_launch(slot_state.to_payload())) return false;
         ring_all_staged_doorbells(slot_state);
         wmb();
-        slot_state.payload->early_dispatch_launch_state.store(
+        slot_state.to_payload().early_dispatch_launch_state.store(
             EARLY_DISPATCH_LAUNCH_COMPLETE, std::memory_order_release
         );
         return true;

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -149,8 +149,8 @@ void format_core_status(
     int64_t task_id_raw = -1;
     if (core_state && core_state->running_slot_state) {
         int32_t subslot = static_cast<int32_t>(core_state->running_subslot);
-        kernel = core_state->running_slot_state->task->kernel_id[subslot];
-        task_id_raw = static_cast<int64_t>(core_state->running_slot_state->task->task_id.raw);
+        kernel = core_state->running_slot_state->to_descriptor().kernel_id[subslot];
+        task_id_raw = static_cast<int64_t>(core_state->running_slot_state->to_descriptor().task_id.raw);
     }
     uint64_t cond_reg = read_reg(reg_addr_for_cond, RegId::COND);
     int32_t hw_state = EXTRACT_TASK_STATE(cond_reg);
@@ -221,18 +221,18 @@ void SchedulerContext::log_stall_diagnostics(
             // Polling: no fanin_refcount. Recompute met/total from the inline
             // fanin ids vs the completion_flags (rc = satisfied producers,
             // fi = raw producer count) so the stall dump still shows readiness.
-            int32_t fi = slot_state.payload != nullptr ? slot_state.payload->fanin_count : 0;
+            int32_t fi = slot_state.to_payload().fanin_count;
             int32_t rc = 0;
-            if (slot_state.payload != nullptr) {
-                const int32_t *fanin = slot_state.payload->fanin_data();
+            {
+                const int32_t *fanin = slot_state.to_payload().fanin_data();
                 for (int32_t k = 0; k < fi; k++) {
                     if (tasks.is_completion_flag_set(fanin[k], std::memory_order_relaxed)) rc++;
                 }
             }
-            int32_t kid_aic = slot_state.task->kernel_id[0];
-            int32_t kid_aiv0 = slot_state.task->kernel_id[1];
-            int32_t kid_aiv1 = slot_state.task->kernel_id[2];
-            int64_t task_id = static_cast<int64_t>(slot_state.task->task_id.raw);
+            int32_t kid_aic = slot_state.to_descriptor().kernel_id[0];
+            int32_t kid_aiv0 = slot_state.to_descriptor().kernel_id[1];
+            int32_t kid_aiv1 = slot_state.to_descriptor().kernel_id[2];
+            int64_t task_id = static_cast<int64_t>(slot_state.to_descriptor().task_id.raw);
             if (st >= CHIP_TASK_COMPLETED) continue;
             // task_state has no intermediate ready/running value — it
             // stays PENDING until the worker stores COMPLETED. Classify
@@ -364,19 +364,23 @@ int32_t SchedulerContext::handle_timeout_exit(
         // Capture the in-flight kernels' partial output before signalling the
         // cores to exit, so the dump reflects the live stuck state.
         if (is_dump_args_enabled()) {
-            dump_running_task_outputs<SUBTASK_SLOT_COUNT>(
-                thread_idx, cores_total_num_,
+            dump_running_task_outputs(
+                cores_total_num_,
                 [this](int32_t cid) {
                     return core_exec_states_[cid].running_slot_state;
                 },
-                [](ActiveMask active_mask, int raw_subtask_id) {
-                    return active_mask.subtask_active(static_cast<SubtaskSlot>(raw_subtask_id));
-                },
-                [this](int32_t func_id) {
-                    return get_function_bin_addr(func_id);
-                },
-                [](const ChipTaskSlotState &slot_state) {
-                    return &slot_state.payload->dump_metadata;
+                [this, thread_idx](const ChipTaskSlotState &slot_state) {
+                    dump_args_for_task<SUBTASK_SLOT_COUNT>(
+                        thread_idx, slot_state.to_descriptor(), slot_state.to_payload(), slot_state.active_mask,
+                        ArgsDumpStage::AFTER_COMPLETION,
+                        [](ActiveMask active_mask, int raw_subtask_id) {
+                            return active_mask.subtask_active(static_cast<SubtaskSlot>(raw_subtask_id));
+                        },
+                        [this](int32_t func_id) {
+                            return get_function_bin_addr(func_id);
+                        },
+                        &slot_state.to_payload().dump_metadata
+                    );
                 }
             );
         }
@@ -1086,13 +1090,13 @@ void SchedulerContext::classify_partition(int32_t thread_idx, int32_t nthreads) 
         ChipTaskSlotState &slot = tasks.get_slot_state_by_task_id(id);
         if (slot.task_kind == TaskKind::GRAPH) {
             if (graph_execution_localize(slot) == nullptr) slot.graph_context = nullptr;
-            if (!sched_->push_graph_prepare(&slot, slot.task->task_id.raw, thread_idx)) return;
+            if (!sched_->push_graph_prepare(&slot, slot.to_descriptor().task_id.raw, thread_idx)) return;
         }
         int32_t state = sched_->classify_fanin_state(&slot);
         if (state < 0) {
             sched_->push_ready_routed(&slot);
         } else {
-            int32_t prod_local = slot.payload->fanin_data()[state];
+            int32_t prod_local = slot.to_payload().fanin_data()[state];
             sched_->register_wake(&tasks.get_slot_state_by_task_id(prod_local), &slot);
         }
     }

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -104,7 +104,8 @@ void SchedulerContext::complete_slot_task(
     AICoreCompletionMailbox *mailbox = rt_ != nullptr ? rt_->aicore_mailbox : nullptr;
     bool defer_completion_to_consumer = false;
 
-    if (slot_state.payload != nullptr) {
+    // Scoped so the slab reference does not outlive the drain below it.
+    {
         volatile DeferredCompletionSlab *deferred_slab = &deferred_slab_per_core_[core_id][expected_reg_task_id & 1];
         int32_t slab_err = deferred_slab->error_code;
         if (slab_err != SIMPLER_ERROR_NONE) {
@@ -133,7 +134,7 @@ void SchedulerContext::complete_slot_task(
             // be this thread or a later one).
             slot_state.mark_any_subtask_deferred();
 
-            const TaskId token = slot_state.task->task_id;
+            const TaskId token = slot_state.to_descriptor().task_id;
             for (uint32_t i = 0; i < cond_count; ++i) {
                 volatile DeferredCompletionEntry *e = &deferred_slab->entries[i];
                 while (!mailbox->try_push_condition(
@@ -161,10 +162,12 @@ void SchedulerContext::complete_slot_task(
     }
 #endif
 
-    if (task_complete && slot_state.payload != nullptr && slot_state.has_any_subtask_deferred()) {
+    if (task_complete && slot_state.has_any_subtask_deferred()) {
         // Some subtask of this task registered conditions; finish the
         // registration by handing the slot_state off to the consumer.
-        while (!mailbox->try_push_normal_done(slot_state.task->task_id, reinterpret_cast<uint64_t>(&slot_state))) {
+        while (
+            !mailbox->try_push_normal_done(slot_state.to_descriptor().task_id, reinterpret_cast<uint64_t>(&slot_state))
+        ) {
             sched_->async_wait_list.mpsc_skipped_count.fetch_add(1, std::memory_order_relaxed);
             SPIN_WAIT_HINT();
         }
@@ -175,14 +178,15 @@ void SchedulerContext::complete_slot_task(
 #if SIMPLER_DFX
         if (is_dump_args_enabled()) {
             dump_args_for_task<SUBTASK_SLOT_COUNT>(
-                thread_idx, slot_state, ArgsDumpStage::AFTER_COMPLETION,
+                thread_idx, slot_state.to_descriptor(), slot_state.to_payload(), slot_state.active_mask,
+                ArgsDumpStage::AFTER_COMPLETION,
                 [](ActiveMask active_mask, int raw_subtask_id) {
                     return active_mask.subtask_active(static_cast<SubtaskSlot>(raw_subtask_id));
                 },
                 [this](int32_t func_id) {
                     return get_function_bin_addr(func_id);
                 },
-                &slot_state.payload->dump_metadata
+                &slot_state.to_payload().dump_metadata
             );
         }
 #endif
@@ -215,7 +219,7 @@ void SchedulerContext::complete_slot_task(
             ) != 0) {
             LOG_ERROR(
                 "Core %d: chip_swimlane_aicpu_complete_task failed for task 0x%" PRIx64, core_id,
-                static_cast<uint64_t>(slot_state.task->task_id.raw)
+                static_cast<uint64_t>(slot_state.to_descriptor().task_id.raw)
             );
         }
 #if SIMPLER_SCHED_PROFILING
@@ -225,8 +229,8 @@ void SchedulerContext::complete_slot_task(
 
     if (is_pmu_enabled()) {
         pmu_aicpu_record_task(
-            core_id, thread_idx, slot_state.task->task_id.raw,
-            slot_state.task->kernel_id[static_cast<int32_t>(subslot)], hank[core_id].core_type
+            core_id, thread_idx, slot_state.to_descriptor().task_id.raw,
+            slot_state.to_descriptor().kernel_id[static_cast<int32_t>(subslot)], hank[core_id].core_type
         );
     }
 #endif
@@ -273,8 +277,8 @@ void SchedulerContext::check_running_cores_for_completion(
         // Cheap cacheable load; no MMIO. Pending slot is empty while gated.
         {
             ChipTaskSlotState *rs = core.running_slot_state;
-            if (rs != nullptr && rs->payload != nullptr &&
-                rs->payload->early_dispatch_state.load(std::memory_order_relaxed) == EARLY_DISPATCH_STAGING) {
+            if (rs != nullptr &&
+                rs->to_payload().early_dispatch_state.load(std::memory_order_relaxed) == EARLY_DISPATCH_STAGING) {
                 continue;
             }
         }
@@ -312,11 +316,11 @@ void SchedulerContext::check_running_cores_for_completion(
         // as a normal task and wait for an ack that never comes -> deadlock (the
         // nondeterministic sync_start stall).
         uint8_t pending_ss =
-            (core.pending_slot_state != nullptr && core.pending_slot_state->payload != nullptr) ?
-                core.pending_slot_state->payload->early_dispatch_state.load(std::memory_order_relaxed) :
+            core.pending_slot_state != nullptr ?
+                core.pending_slot_state->to_payload().early_dispatch_state.load(std::memory_order_relaxed) :
                 static_cast<uint8_t>(EARLY_DISPATCH_NONE);
         bool pending_gated =
-            (core.pending_slot_state != nullptr && core.pending_slot_state->payload != nullptr &&
+            (core.pending_slot_state != nullptr &&
              (pending_ss == EARLY_DISPATCH_STAGING ||
               (pending_ss == EARLY_DISPATCH_DISPATCHED && core.pending_slot_state->task_attrs.requires_sync_start())));
         SlotTransition t = decide_slot_transition(
@@ -391,7 +395,7 @@ void SchedulerContext::check_running_cores_for_completion(
                 bool sync_start_promote = pending_gated && promoted->task_attrs.requires_sync_start();
                 promote_pending_to_running(core);  // Case 2 or Case 3 (with pending)
                 if (sync_start_promote) {
-                    promoted->payload->running_slot_count.fetch_add(1, std::memory_order_seq_cst);
+                    promoted->to_payload().running_slot_count.fetch_add(1, std::memory_order_seq_cst);
                     if (sched_->maybe_rendezvous_ring(*promoted)) {
                         sched_->propagate_dispatch_fanin(*promoted);
                     }
@@ -564,7 +568,7 @@ SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
             if (gated) {
                 for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
                     if (my_mask[w] != 0) {
-                        slot_state->payload->staged_core_mask[w].fetch_or(my_mask[w], std::memory_order_seq_cst);
+                        slot_state->to_payload().staged_core_mask[w].fetch_or(my_mask[w], std::memory_order_seq_cst);
                     }
                 }
             }
@@ -676,7 +680,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     // OWNER is acquired before the drain is published and persists through
     // completion, so every staging thread makes the same gate decision even if
     // producer release changes early_dispatch_state during the barrier.
-    bool gated = slot_state->payload != nullptr && SchedulerState::owns_early_sync_drain(*slot_state->payload);
+    bool gated = SchedulerState::owns_early_sync_drain(slot_state->to_payload());
 
     if (coordinator) {
         ResourceShape shape = slot_state->active_mask.to_shape();
@@ -738,7 +742,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
         // Seed the rendezvous with the running-slot cores staged across all threads; pending
         // cores advance it as they promote. maybe_rendezvous_ring (producer release) rings iff
         // this already equals popcount(staged_core_mask) — i.e. no pending spill.
-        slot_state->payload->running_slot_count.store(
+        slot_state->to_payload().running_slot_count.store(
             static_cast<int16_t>(drain_state_.drain_running_staged.load(std::memory_order_acquire)),
             std::memory_order_seq_cst
         );
@@ -763,5 +767,5 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     } else {
         sched_->propagate_dispatch_fanin(*slot_state);
     }
-    SchedulerState::finish_early_sync_drain(*slot_state->payload);
+    SchedulerState::finish_early_sync_drain(slot_state->to_payload());
 }

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -125,10 +125,10 @@ void SchedulerContext::build_payload(
     bool force_gate
 ) {
     int32_t slot_idx = static_cast<int32_t>(subslot);
-    uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
+    uint64_t callable_addr = get_function_bin_addr(slot_state.to_descriptor().kernel_id[slot_idx]);
     const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
     dispatch_payload.function_bin_addr = callable->resolved_addr();
-    auto &payload = *slot_state.payload;
+    auto &payload = slot_state.to_payload();
     // A claimed early-stage range stays gated even if producer completion flips
     // the shared state before this payload is built. All other dispatches run on
     // pickup.
@@ -165,7 +165,7 @@ void SchedulerContext::build_payload(
     // AsyncCtx::make(non-null) result). args[PAYLOAD_LOCAL_CONTEXT_INDEX] /
     // [PAYLOAD_GLOBAL_CONTEXT_INDEX] are per-(core, buf_idx) constants, also
     // prefilled in init().
-    dispatch_payload.local_context.async_ctx.task_token = slot_state.task->task_id;
+    dispatch_payload.local_context.async_ctx.task_token = slot_state.to_descriptor().task_id;
 }
 
 SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
@@ -211,9 +211,9 @@ SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
         "Thread %d: Dispatched %s %s task %" PRId64 " kernel_id=[%d,%d,%d] block_idx=%d/total_blocks=%d to"
         " core_offset=%d core_id=%d reg_task_id=%u",
         thread_idx, to_pending ? "pending" : "idle", subslot_name(subslot),
-        static_cast<int64_t>(slot_state.task->task_id.raw), slot_state.task->kernel_id[0],
-        slot_state.task->kernel_id[1], slot_state.task->kernel_id[2], block_idx, slot_state.logical_block_num,
-        core_offset, core_id, reg_task_id
+        static_cast<int64_t>(slot_state.to_descriptor().task_id.raw), slot_state.to_descriptor().kernel_id[0],
+        slot_state.to_descriptor().kernel_id[1], slot_state.to_descriptor().kernel_id[2], block_idx,
+        slot_state.logical_block_num, core_offset, core_id, reg_task_id
     );
 
     // AICore buffer rotation lives on the dispatch path: count this dispatch
@@ -248,14 +248,15 @@ int SchedulerContext::prepare_block_for_dispatch(
 #if SIMPLER_DFX
     if (is_dump_args_enabled()) {
         dump_args_for_task<SUBTASK_SLOT_COUNT>(
-            thread_idx, slot_state, ArgsDumpStage::BEFORE_DISPATCH,
+            thread_idx, slot_state.to_descriptor(), slot_state.to_payload(), slot_state.active_mask,
+            ArgsDumpStage::BEFORE_DISPATCH,
             [](ActiveMask active_mask, int raw_subtask_id) {
                 return active_mask.subtask_active(static_cast<SubtaskSlot>(raw_subtask_id));
             },
             [this](int32_t func_id) {
                 return get_function_bin_addr(func_id);
             },
-            &slot_state.payload->dump_metadata
+            &slot_state.to_payload().dump_metadata
         );
     }
 #endif
@@ -665,13 +666,13 @@ int32_t SchedulerContext::stage_consumer_blocks(
     // Publish all this thread's gated cores into the shared mask in one OR per word
     // (vs one per subtask) so release sees them; seq_cst keeps the self-ring order.
     for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++)
-        if (my_cores[w] != 0) c->payload->staged_core_mask[w].fetch_or(my_cores[w], std::memory_order_seq_cst);
+        if (my_cores[w] != 0) c->to_payload().staged_core_mask[w].fetch_or(my_cores[w], std::memory_order_seq_cst);
 
     // Full publication and release are independent events. The seq_cst
     // state/launch/count operations form a two-sided handshake. A released
     // block must ring before contributing to the publication count.
     bool released =
-        staged > 0 && c->payload->early_dispatch_state.load(std::memory_order_seq_cst) == EARLY_DISPATCH_DISPATCHED;
+        staged > 0 && c->to_payload().early_dispatch_state.load(std::memory_order_seq_cst) == EARLY_DISPATCH_DISPATCHED;
 
     // Claim only bits the release path did not take. Local handles remain valid
     // even if the shared per-core table is reused before this thread resumes.
@@ -680,7 +681,7 @@ int32_t SchedulerContext::stage_consumer_blocks(
         for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
             if (my_cores[w] != 0) {
                 owned[w] =
-                    SchedulerState::claim_late_staged_doorbell_bits(c->payload->staged_core_mask[w], my_cores[w]);
+                    SchedulerState::claim_late_staged_doorbell_bits(c->to_payload().staged_core_mask[w], my_cores[w]);
             }
         }
         for (int i = 0; i < n; i++) {
@@ -736,8 +737,8 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, ResourceShape shape, 
     int got = sched_->early_dispatch_queues[s].pop_batch_tagged(batch, task_id_snapshots, cores.count());
     for (int bi = 0; bi < got; bi++) {
         ChipTaskSlotState *c = batch[bi];
-        if (static_cast<uint64_t>(c->task->task_id.raw) != task_id_snapshots[bi]) continue;
-        if (c->payload->early_dispatch_state.load(std::memory_order_acquire) != EARLY_DISPATCH_STAGING)
+        if (static_cast<uint64_t>(c->to_descriptor().task_id.raw) != task_id_snapshots[bi]) continue;
+        if (c->to_payload().early_dispatch_state.load(std::memory_order_acquire) != EARLY_DISPATCH_STAGING)
             continue;  // released
 
         // The single free-core bucket for this phase. For MIX, an active-mask-aware
@@ -775,7 +776,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, ResourceShape shape, 
             if (!sched_->early_dispatch_queues[s].push_tagged(c, task_id_snapshots[bi]))
                 LOG_DEBUG(
                     "[EARLY_DISPATCH] queue full on re-push, consumer=%" PRId64,
-                    static_cast<int64_t>(c->task->task_id.raw)
+                    static_cast<int64_t>(c->to_descriptor().task_id.raw)
                 );
         }
         // stage_consumer_blocks fills the idle bucket (RUNNING slot) then the pend
@@ -823,10 +824,10 @@ int32_t SchedulerContext::try_early_dispatch(
     // STAGING -> DISPATCHED. A non-STAGING pop was already released and is dropped.
     uint64_t sync_task_id_snapshot = 0;
     if (ChipTaskSlotState *c = sched_->early_sync_start_queue.pop_tagged(&sync_task_id_snapshot)) {
-        bool current_sync_task =
-            static_cast<uint64_t>(c->task->task_id.raw) == sync_task_id_snapshot && c->task_attrs.requires_sync_start();
-        if (current_sync_task && SchedulerState::try_claim_early_sync_drain(*c->payload)) {
-            if (c->payload->early_dispatch_state.load(std::memory_order_seq_cst) != EARLY_DISPATCH_STAGING) {
+        bool current_sync_task = static_cast<uint64_t>(c->to_descriptor().task_id.raw) == sync_task_id_snapshot &&
+                                 c->task_attrs.requires_sync_start();
+        if (current_sync_task && SchedulerState::try_claim_early_sync_drain(c->to_payload())) {
+            if (c->to_payload().early_dispatch_state.load(std::memory_order_seq_cst) != EARLY_DISPATCH_STAGING) {
                 sched_->cancel_early_sync_drain(*c);
             } else if (drain_state_.sync_start_pending.load(std::memory_order_acquire) == 0 &&
                        tracker.count_available_blocks(
@@ -835,20 +836,20 @@ int32_t SchedulerContext::try_early_dispatch(
                 // From this point onward the operation is all-or-nothing. Only this
                 // scheduler mutates its tracker, and global drain coordinators must
                 // wait for this scheduler's generation-tagged ack before inspecting it.
-                SchedulerState::mark_early_sync_drain_armed(*c->payload);
+                SchedulerState::mark_early_sync_drain_armed(c->to_payload());
                 always_assert(c->next_block_idx.load(std::memory_order_seq_cst) == 0);
                 SyncStartStageResult staged = stage_sync_start_cores(
                     c, c->logical_block_num, thread_idx, /*gated=*/true, /*record_drain_phases=*/false
                 );
                 always_assert(staged.staged_blocks == c->logical_block_num);
-                c->payload->running_slot_count.store(
+                c->to_payload().running_slot_count.store(
                     static_cast<int16_t>(staged.running_cores), std::memory_order_seq_cst
                 );
                 sched_->retry_sync_start_rendezvous_after_staging(*c);
-                SchedulerState::finish_early_sync_drain(*c->payload);
+                SchedulerState::finish_early_sync_drain(c->to_payload());
                 total_staged += staged.staged_blocks;
             } else if (enter_drain_mode(c, c->logical_block_num)) {
-                SchedulerState::mark_early_sync_drain_armed(*c->payload);
+                SchedulerState::mark_early_sync_drain_armed(c->to_payload());
             } else {
                 sched_->cancel_early_sync_drain(*c);
             }
@@ -1410,7 +1411,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         if (thread_idx < active_sched_threads_) {
             ChipTaskSlotState *graph_slot = sched_->graph_ready_queue.pop();
             if (graph_slot != nullptr) {
-                if (graph_slot->task != nullptr && graph_slot->task_kind == TaskKind::GRAPH) {
+                if (graph_slot->task_kind == TaskKind::GRAPH) {
                     (void)sched_->activate_graph_task(*graph_slot);
                     made_progress = true;
                 } else {
@@ -1422,8 +1423,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             uint64_t prepare_task_id = 0;
             ChipTaskSlotState *prepare_slot = sched_->graph_prepare_queue.pop_tagged(&prepare_task_id);
             if (prepare_slot != nullptr) {
-                const bool valid_slot = prepare_slot->task != nullptr && prepare_slot->task_kind == TaskKind::GRAPH &&
-                                        prepare_slot->task->task_id.raw == prepare_task_id;
+                const bool valid_slot = prepare_slot->task_kind == TaskKind::GRAPH &&
+                                        prepare_slot->to_descriptor().task_id.raw == prepare_task_id;
                 if (!valid_slot) {
                     fail_scheduler(runtime, thread_idx, SIMPLER_ERROR_INVALID_ARGS);
                     break;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -450,16 +450,22 @@ int32_t SchedulerContext::handle_timeout_exit(
         // Capture the in-flight kernels' partial output before signalling the
         // cores to exit, so the dump reflects the live stuck state.
         if (is_dump_args_enabled()) {
-            dump_running_task_outputs<SUBTASK_SLOT_COUNT>(
-                thread_idx, cores_total_num_,
+            dump_running_task_outputs(
+                cores_total_num_,
                 [this](int32_t cid) {
                     return core_exec_states_[cid].running_slot_state;
                 },
-                [](ActiveMask active_mask, int raw_subtask_id) {
-                    return active_mask.subtask_active(static_cast<SubtaskSlot>(raw_subtask_id));
-                },
-                [this](int32_t func_id) {
-                    return get_function_bin_addr(func_id);
+                [this, thread_idx](const ChipTaskSlotState &slot_state) {
+                    dump_args_for_task<SUBTASK_SLOT_COUNT>(
+                        thread_idx, *slot_state.task, *slot_state.payload, slot_state.active_mask,
+                        ArgsDumpStage::AFTER_COMPLETION,
+                        [](ActiveMask active_mask, int raw_subtask_id) {
+                            return active_mask.subtask_active(static_cast<SubtaskSlot>(raw_subtask_id));
+                        },
+                        [this](int32_t func_id) {
+                            return get_function_bin_addr(func_id);
+                        }
+                    );
                 }
             );
         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -179,7 +179,8 @@ void SchedulerContext::complete_slot_task(
 #if SIMPLER_DFX
         if (is_dump_args_enabled()) {
             dump_args_for_task<SUBTASK_SLOT_COUNT>(
-                thread_idx, slot_state, ArgsDumpStage::AFTER_COMPLETION,
+                thread_idx, *slot_state.task, *slot_state.payload, slot_state.active_mask,
+                ArgsDumpStage::AFTER_COMPLETION,
                 [](ActiveMask active_mask, int raw_subtask_id) {
                     return active_mask.subtask_active(static_cast<SubtaskSlot>(raw_subtask_id));
                 },

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -243,7 +243,7 @@ int SchedulerContext::prepare_block_for_dispatch(
 #if SIMPLER_DFX
     if (is_dump_args_enabled()) {
         dump_args_for_task<SUBTASK_SLOT_COUNT>(
-            thread_idx, slot_state, ArgsDumpStage::BEFORE_DISPATCH,
+            thread_idx, *slot_state.task, *slot_state.payload, slot_state.active_mask, ArgsDumpStage::BEFORE_DISPATCH,
             [](ActiveMask active_mask, int raw_subtask_id) {
                 return active_mask.subtask_active(static_cast<SubtaskSlot>(raw_subtask_id));
             },

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -307,7 +307,6 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
         if (boot_ok) {
             runtime_bind_ops(rt);
-            runtime->set_slot_states_ptr(nullptr);
 
             sched_ctx_.bind_runtime(rt);
 

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -507,8 +507,7 @@ bool bind_graph_definitions(
 
     for (size_t index = 0; index < count; ++index) {
         std::optional<GraphHostUpload> upload = graph_host_upload(graph_state, index);
-        if (!upload.has_value() || upload->outer_slot == nullptr || upload->outer_slot->task_kind != TaskKind::GRAPH ||
-            upload->outer_slot->task == nullptr || upload->outer_slot->payload == nullptr) {
+        if (!upload.has_value() || upload->outer_slot == nullptr || upload->outer_slot->task_kind != TaskKind::GRAPH) {
             LOG_ERROR("host-orch: invalid pending Graph task");
             return false;
         }
@@ -534,13 +533,14 @@ bool bind_graph_definitions(
                 definition->scalar_arg_count, &storage_layout
             ) ||
             storage_layout.total_bytes != definition->execution_storage_bytes ||
-            upload->outer_slot->payload->tensor_count != static_cast<int32_t>(definition->boundary_count) ||
-            upload->outer_slot->payload->scalar_count != static_cast<int32_t>(definition->boundary_scalar_count)) {
+            upload->outer_slot->to_payload().tensor_count != static_cast<int32_t>(definition->boundary_count) ||
+            upload->outer_slot->to_payload().scalar_count != static_cast<int32_t>(definition->boundary_scalar_count)) {
             LOG_ERROR("host-orch: invalid Graph Definition for task");
             return false;
         }
-        const uintptr_t outer_base = reinterpret_cast<uintptr_t>(upload->outer_slot->task->packed_buffer_base);
-        const uintptr_t outer_end = reinterpret_cast<uintptr_t>(upload->outer_slot->task->packed_buffer_end);
+        const uintptr_t outer_base =
+            reinterpret_cast<uintptr_t>(upload->outer_slot->to_descriptor().packed_buffer_base);
+        const uintptr_t outer_end = reinterpret_cast<uintptr_t>(upload->outer_slot->to_descriptor().packed_buffer_end);
         if (outer_end < outer_base || definition->required_heap > UINTPTR_MAX - outer_base ||
             storage_layout.total_bytes > outer_end - outer_base ||
             definition->required_heap > outer_end - outer_base - storage_layout.total_bytes) {
@@ -548,7 +548,7 @@ bool bind_graph_definitions(
             return false;
         }
         const uintptr_t storage_addr = outer_base + definition->required_heap;
-        if (storage_addr % alignof(InGraphTaskStorage) != 0) {
+        if (storage_addr % alignof(ChipTaskStorage) != 0) {
             LOG_ERROR("host-orch: Graph runtime storage address is misaligned");
             return false;
         }
@@ -616,7 +616,7 @@ int32_t run_host_orchestration(
         LOG_ERROR("host-orch: host SM mirror of %" PRIu64 " bytes unavailable", sm_size);
         return PTO_RUNTIME_ERR_INTERNAL;
     }
-    std::memset(host_sm, 0, sm_segs.descriptors);
+    std::memset(host_sm, 0, sm_segs.storage);
 
     // Re-point the orchestrator half at the host SM (scheduler keeps device SM).
     // Host-owned and destroyed with this frame, so rt->orchestrator is dropped on
@@ -909,7 +909,7 @@ int32_t run_host_orchestration(
         reinterpret_cast<uint64_t>(gm_heap) < HEAP_VIRTUAL_BASE && "device memory reaches into the virtual heap window"
     );
     // The alignment bind_graph_definitions checked on the virtual base — a Graph
-    // task's runtime storage must land on alignof(InGraphTaskStorage) — carries to
+    // task's runtime storage must land on alignof(ChipTaskStorage) — carries to
     // the real base only while the two are congruent: both are aligned to
     // kDefaultBaseAlign, and that covers the storage's own requirement.
     static_assert(
@@ -917,7 +917,7 @@ int32_t run_host_orchestration(
         "the virtual heap base must share the committed region's alignment"
     );
     static_assert(
-        alignof(InGraphTaskStorage) <= DeviceArena::kDefaultBaseAlign,
+        alignof(ChipTaskStorage) <= DeviceArena::kDefaultBaseAlign,
         "an in-graph task's storage alignment must be covered by the heap region's base alignment"
     );
     always_assert(reinterpret_cast<uint64_t>(gm_heap) % DeviceArena::kDefaultBaseAlign == 0);

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -45,8 +45,19 @@
 #include "host_build_graph/task_allocator.h"
 #include "host_build_graph/runtime_types.h"
 #include "host_build_graph/shared_memory.h"
+#include "scheduler_graph.h"
 
 #include "aicpu/device_time.h"  // get_sys_cnt_aicpu (weak; used by early-dispatch doorbell timing too)
+
+// scheduler_graph.h states the storage layout as literals, because the AICore .o
+// that reads it cannot include runtime_types.h. This translation unit sees both,
+// so the literals are checked against the types here — in every AICPU TU that
+// builds the A5 scheduler, rather than only in the contract UT.
+static_assert(sizeof(ChipTaskStorage) == SCHEDULER_GRAPH_TASK_STORAGE_STRIDE);
+static_assert(offsetof(ChipTaskStorage, task) == SCHEDULER_GRAPH_DESCRIPTOR_OFFSET);
+static_assert(offsetof(ChipTaskStorage, payload) == SCHEDULER_GRAPH_PAYLOAD_OFFSET);
+static_assert(offsetof(TaskPayload, predicate) == SCHEDULER_GRAPH_PREDICATE_OFFSET);
+
 #if SIMPLER_SCHED_PROFILING
 #define SCHED_CYCLE_START() uint64_t _st0 = get_sys_cnt_aicpu(), _st1
 #define SCHED_CYCLE_LAP(acc)        \
@@ -559,7 +570,7 @@ struct SchedulerState {
         } else {
             ResourceShape shape = slot_state->active_mask.to_shape();
             if (shape == ResourceShape::DUMMY ||
-                (slot_state->task_attrs.has_predicate() && !slot_state->payload->predicate.pass())) {
+                (slot_state->task_attrs.has_predicate() && !slot_state->to_payload().predicate.pass())) {
                 pushed = dummy_ready_queue.push(slot_state);
             } else if (slot_state->task_attrs.requires_sync_start()) {
                 pushed = ready_sync_queues[static_cast<int32_t>(shape)].push(slot_state);
@@ -594,7 +605,7 @@ struct SchedulerState {
     // lists. The decision is terminal: tasks are never re-polled; a producer's
     // completion re-scans its waiters via on_mixed_task_complete's wake drain.
     int classify_fanin_state(const ChipTaskSlotState *s) const {
-        const TaskPayload &p = *s->payload;
+        const TaskPayload &p = s->to_payload();
         const SharedMemoryTaskHeader &tasks = *task_view.tasks;
         const int32_t *fanin = p.fanin_data();
         for (int32_t i = p.fanin_count - 1; i >= 0; i--) {
@@ -624,7 +635,7 @@ struct SchedulerState {
                 push_ready_routed(consumer);
                 return;
             }
-            producer = &tasks.get_slot_state_by_task_id(consumer->payload->fanin_data()[state]);
+            producer = &tasks.get_slot_state_by_task_id(consumer->to_payload().fanin_data()[state]);
         }
     }
 
@@ -635,7 +646,7 @@ struct SchedulerState {
     // watermark >= producer.last_consumer_local_id). Whole-graph-resident hbg
     // has no device slot reclaim, so nothing advances a reclaim cursor here.
     void on_mixed_task_complete(ChipTaskSlotState &slot_state) {
-        const int32_t task_id = static_cast<int32_t>(simpler::hbg::task_local_id(slot_state.task->task_id));
+        const int32_t task_id = static_cast<int32_t>(simpler::hbg::task_local_id(slot_state.to_descriptor().task_id));
         SharedMemoryTaskHeader &tasks = *task_view.tasks;
 
         slot_state.mark_completed();  // host-visible mirror (task_state = COMPLETED)
@@ -644,7 +655,7 @@ struct SchedulerState {
         ChipTaskSlotState *waiter = slot_state.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
         while (waiter != nullptr && waiter != WAKE_LIST_SENTINEL) {
             ChipTaskSlotState *next = waiter->next_in_wake_list;
-            if (waiter->payload->fanin_count == 1) {
+            if (waiter->to_payload().fanin_count == 1) {
                 push_ready_routed(waiter);  // single-fanin waiter was waiting only on us
                 waiter = next;
                 continue;
@@ -653,7 +664,7 @@ struct SchedulerState {
             if (state < 0) {
                 push_ready_routed(waiter);
             } else {
-                register_wake(&tasks.get_slot_state_by_task_id(waiter->payload->fanin_data()[state]), waiter);
+                register_wake(&tasks.get_slot_state_by_task_id(waiter->to_payload().fanin_data()[state]), waiter);
             }
             waiter = next;
         }
@@ -775,7 +786,7 @@ struct SchedulerState {
 
     inline void record_published_blocks(ChipTaskSlotState &slot_state, int32_t count) {
         if (count <= 0 || !slot_state.task_attrs.allow_early_resolve()) return;
-        slot_state.payload->published_block_count.fetch_add(static_cast<int16_t>(count), std::memory_order_seq_cst);
+        slot_state.to_payload().published_block_count.fetch_add(static_cast<int16_t>(count), std::memory_order_seq_cst);
     }
 
     // Ring one sync_start cohort from its stable staged_core_mask. The caller owns
@@ -783,7 +794,7 @@ struct SchedulerState {
     // global staging completes, while the corresponding per-core table entries are live.
     inline void ring_all_staged_doorbells(ChipTaskSlotState &slot_state) {
         for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
-            uint64_t bits = slot_state.payload->staged_core_mask[w].load(std::memory_order_seq_cst);
+            uint64_t bits = slot_state.to_payload().staged_core_mask[w].load(std::memory_order_seq_cst);
             while (bits != 0) {
                 int core_id = w * 64 + __builtin_ctzll(bits);
                 bits &= bits - 1;
@@ -816,14 +827,16 @@ struct SchedulerState {
 
     inline void cancel_early_sync_drain(ChipTaskSlotState &slot_state) {
         uint8_t previous =
-            slot_state.payload->early_sync_drain_state.exchange(EARLY_SYNC_DRAIN_NONE, std::memory_order_seq_cst);
+            slot_state.to_payload().early_sync_drain_state.exchange(EARLY_SYNC_DRAIN_NONE, std::memory_order_seq_cst);
         if ((previous & EARLY_SYNC_DRAIN_OWNER) == 0) return;
         if ((previous & EARLY_SYNC_DRAIN_READY) != 0) {
             push_ready_routed(&slot_state);
             return;
         }
-        if (slot_state.payload->early_dispatch_state.load(std::memory_order_seq_cst) == EARLY_DISPATCH_STAGING) {
-            early_sync_start_queue.push_tagged(&slot_state, static_cast<uint64_t>(slot_state.task->task_id.raw));
+        if (slot_state.to_payload().early_dispatch_state.load(std::memory_order_seq_cst) == EARLY_DISPATCH_STAGING) {
+            early_sync_start_queue.push_tagged(
+                &slot_state, static_cast<uint64_t>(slot_state.to_descriptor().task_id.raw)
+            );
         }
     }
 
@@ -852,19 +865,19 @@ struct SchedulerState {
         // happens-before its final store. Read the seed first, then the mask, so
         // observing the final count cannot be paired with a partially published
         // mask when producer release races staging.
-        int32_t running_cores = slot_state.payload->running_slot_count.load(std::memory_order_seq_cst);
+        int32_t running_cores = slot_state.to_payload().running_slot_count.load(std::memory_order_seq_cst);
         int32_t staged_cores = 0;
         for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++)
             staged_cores +=
-                __builtin_popcountll(slot_state.payload->staged_core_mask[w].load(std::memory_order_seq_cst));
+                __builtin_popcountll(slot_state.to_payload().staged_core_mask[w].load(std::memory_order_seq_cst));
         if (staged_cores == 0) return false;
         if (running_cores != staged_cores) return false;
-        if (slot_state.payload->early_dispatch_state.load(std::memory_order_seq_cst) != EARLY_DISPATCH_DISPATCHED)
+        if (slot_state.to_payload().early_dispatch_state.load(std::memory_order_seq_cst) != EARLY_DISPATCH_DISPATCHED)
             return false;
-        if (!try_claim_early_dispatch_launch(*slot_state.payload)) return false;
+        if (!try_claim_early_dispatch_launch(slot_state.to_payload())) return false;
         ring_all_staged_doorbells(slot_state);
         wmb();
-        slot_state.payload->early_dispatch_launch_state.store(
+        slot_state.to_payload().early_dispatch_launch_state.store(
             EARLY_DISPATCH_LAUNCH_COMPLETE, std::memory_order_release
         );
         return true;

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -149,8 +149,8 @@ void format_core_status(
     int64_t task_id_raw = -1;
     if (core_state && core_state->running_slot_state) {
         int32_t subslot = static_cast<int32_t>(core_state->running_subslot);
-        kernel = core_state->running_slot_state->task->kernel_id[subslot];
-        task_id_raw = static_cast<int64_t>(core_state->running_slot_state->task->task_id.raw);
+        kernel = core_state->running_slot_state->to_descriptor().kernel_id[subslot];
+        task_id_raw = static_cast<int64_t>(core_state->running_slot_state->to_descriptor().task_id.raw);
     }
     uint64_t cond_reg = read_reg(reg_addr_for_cond, RegId::COND);
     int32_t hw_state = EXTRACT_TASK_STATE(cond_reg);
@@ -221,18 +221,18 @@ void SchedulerContext::log_stall_diagnostics(
             // Polling: no fanin_refcount. Recompute met/total from the inline
             // fanin ids vs the completion_flags (rc = satisfied producers,
             // fi = raw producer count) so the stall dump still shows readiness.
-            int32_t fi = slot_state.payload != nullptr ? slot_state.payload->fanin_count : 0;
+            int32_t fi = slot_state.to_payload().fanin_count;
             int32_t rc = 0;
-            if (slot_state.payload != nullptr) {
-                const int32_t *fanin = slot_state.payload->fanin_data();
+            {
+                const int32_t *fanin = slot_state.to_payload().fanin_data();
                 for (int32_t k = 0; k < fi; k++) {
                     if (tasks.is_completion_flag_set(fanin[k], std::memory_order_relaxed)) rc++;
                 }
             }
-            int32_t kid_aic = slot_state.task->kernel_id[0];
-            int32_t kid_aiv0 = slot_state.task->kernel_id[1];
-            int32_t kid_aiv1 = slot_state.task->kernel_id[2];
-            int64_t task_id = static_cast<int64_t>(slot_state.task->task_id.raw);
+            int32_t kid_aic = slot_state.to_descriptor().kernel_id[0];
+            int32_t kid_aiv0 = slot_state.to_descriptor().kernel_id[1];
+            int32_t kid_aiv1 = slot_state.to_descriptor().kernel_id[2];
+            int64_t task_id = static_cast<int64_t>(slot_state.to_descriptor().task_id.raw);
             if (st >= CHIP_TASK_COMPLETED) continue;
             // task_state has no intermediate ready/running value — it
             // stays PENDING until the worker stores COMPLETED. Classify
@@ -364,19 +364,23 @@ int32_t SchedulerContext::handle_timeout_exit(
         // Capture the in-flight kernels' partial output before signalling the
         // cores to exit, so the dump reflects the live stuck state.
         if (is_dump_args_enabled()) {
-            dump_running_task_outputs<SUBTASK_SLOT_COUNT>(
-                thread_idx, cores_total_num_,
+            dump_running_task_outputs(
+                cores_total_num_,
                 [this](int32_t cid) {
                     return core_exec_states_[cid].running_slot_state;
                 },
-                [](ActiveMask active_mask, int raw_subtask_id) {
-                    return active_mask.subtask_active(static_cast<SubtaskSlot>(raw_subtask_id));
-                },
-                [this](int32_t func_id) {
-                    return get_function_bin_addr(func_id);
-                },
-                [](const ChipTaskSlotState &slot_state) {
-                    return &slot_state.payload->dump_metadata;
+                [this, thread_idx](const ChipTaskSlotState &slot_state) {
+                    dump_args_for_task<SUBTASK_SLOT_COUNT>(
+                        thread_idx, slot_state.to_descriptor(), slot_state.to_payload(), slot_state.active_mask,
+                        ArgsDumpStage::AFTER_COMPLETION,
+                        [](ActiveMask active_mask, int raw_subtask_id) {
+                            return active_mask.subtask_active(static_cast<SubtaskSlot>(raw_subtask_id));
+                        },
+                        [this](int32_t func_id) {
+                            return get_function_bin_addr(func_id);
+                        },
+                        &slot_state.to_payload().dump_metadata
+                    );
                 }
             );
         }
@@ -1086,13 +1090,13 @@ void SchedulerContext::classify_partition(int32_t thread_idx, int32_t nthreads) 
         ChipTaskSlotState &slot = tasks.get_slot_state_by_task_id(id);
         if (slot.task_kind == TaskKind::GRAPH) {
             if (graph_execution_localize(slot) == nullptr) slot.graph_context = nullptr;
-            if (!sched_->push_graph_prepare(&slot, slot.task->task_id.raw, thread_idx)) return;
+            if (!sched_->push_graph_prepare(&slot, slot.to_descriptor().task_id.raw, thread_idx)) return;
         }
         int32_t state = sched_->classify_fanin_state(&slot);
         if (state < 0) {
             sched_->push_ready_routed(&slot);
         } else {
-            int32_t prod_local = slot.payload->fanin_data()[state];
+            int32_t prod_local = slot.to_payload().fanin_data()[state];
             sched_->register_wake(&tasks.get_slot_state_by_task_id(prod_local), &slot);
         }
     }

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -104,7 +104,8 @@ void SchedulerContext::complete_slot_task(
     AICoreCompletionMailbox *mailbox = rt_ != nullptr ? rt_->aicore_mailbox : nullptr;
     bool defer_completion_to_consumer = false;
 
-    if (slot_state.payload != nullptr) {
+    // Scoped so the slab reference does not outlive the drain below it.
+    {
         volatile DeferredCompletionSlab *deferred_slab = &deferred_slab_per_core_[core_id][expected_reg_task_id & 1];
         int32_t slab_err = deferred_slab->error_code;
         if (slab_err != SIMPLER_ERROR_NONE) {
@@ -133,7 +134,7 @@ void SchedulerContext::complete_slot_task(
             // be this thread or a later one).
             slot_state.mark_any_subtask_deferred();
 
-            const TaskId token = slot_state.task->task_id;
+            const TaskId token = slot_state.to_descriptor().task_id;
             for (uint32_t i = 0; i < cond_count; ++i) {
                 volatile DeferredCompletionEntry *e = &deferred_slab->entries[i];
                 while (!mailbox->try_push_condition(
@@ -161,10 +162,12 @@ void SchedulerContext::complete_slot_task(
     }
 #endif
 
-    if (task_complete && slot_state.payload != nullptr && slot_state.has_any_subtask_deferred()) {
+    if (task_complete && slot_state.has_any_subtask_deferred()) {
         // Some subtask of this task registered conditions; finish the
         // registration by handing the slot_state off to the consumer.
-        while (!mailbox->try_push_normal_done(slot_state.task->task_id, reinterpret_cast<uint64_t>(&slot_state))) {
+        while (
+            !mailbox->try_push_normal_done(slot_state.to_descriptor().task_id, reinterpret_cast<uint64_t>(&slot_state))
+        ) {
             sched_->async_wait_list.mpsc_skipped_count.fetch_add(1, std::memory_order_relaxed);
             SPIN_WAIT_HINT();
         }
@@ -175,14 +178,15 @@ void SchedulerContext::complete_slot_task(
 #if SIMPLER_DFX
         if (is_dump_args_enabled()) {
             dump_args_for_task<SUBTASK_SLOT_COUNT>(
-                thread_idx, slot_state, ArgsDumpStage::AFTER_COMPLETION,
+                thread_idx, slot_state.to_descriptor(), slot_state.to_payload(), slot_state.active_mask,
+                ArgsDumpStage::AFTER_COMPLETION,
                 [](ActiveMask active_mask, int raw_subtask_id) {
                     return active_mask.subtask_active(static_cast<SubtaskSlot>(raw_subtask_id));
                 },
                 [this](int32_t func_id) {
                     return get_function_bin_addr(func_id);
                 },
-                &slot_state.payload->dump_metadata
+                &slot_state.to_payload().dump_metadata
             );
         }
 #endif
@@ -215,7 +219,7 @@ void SchedulerContext::complete_slot_task(
             ) != 0) {
             LOG_ERROR(
                 "Core %d: chip_swimlane_aicpu_complete_task failed for task 0x%" PRIx64, core_id,
-                static_cast<uint64_t>(slot_state.task->task_id.raw)
+                static_cast<uint64_t>(slot_state.to_descriptor().task_id.raw)
             );
         }
 #if SIMPLER_SCHED_PROFILING
@@ -230,8 +234,8 @@ void SchedulerContext::complete_slot_task(
         // runtime's id space, so it would never match. The task identity travels
         // separately for the PmuRecord.
         pmu_aicpu_complete_record(
-            core_id, thread_idx, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
-            slot_state.task->kernel_id[static_cast<int32_t>(subslot)], hank[core_id].core_type
+            core_id, thread_idx, static_cast<uint32_t>(expected_reg_task_id), slot_state.to_descriptor().task_id.raw,
+            slot_state.to_descriptor().kernel_id[static_cast<int32_t>(subslot)], hank[core_id].core_type
         );
     }
 #endif
@@ -278,8 +282,8 @@ void SchedulerContext::check_running_cores_for_completion(
         // Cheap cacheable load; no MMIO. Pending slot is empty while gated.
         {
             ChipTaskSlotState *rs = core.running_slot_state;
-            if (rs != nullptr && rs->payload != nullptr &&
-                rs->payload->early_dispatch_state.load(std::memory_order_relaxed) == EARLY_DISPATCH_STAGING) {
+            if (rs != nullptr &&
+                rs->to_payload().early_dispatch_state.load(std::memory_order_relaxed) == EARLY_DISPATCH_STAGING) {
                 continue;
             }
         }
@@ -317,11 +321,11 @@ void SchedulerContext::check_running_cores_for_completion(
         // as a normal task and wait for an ack that never comes -> deadlock (the
         // nondeterministic sync_start stall).
         uint8_t pending_ss =
-            (core.pending_slot_state != nullptr && core.pending_slot_state->payload != nullptr) ?
-                core.pending_slot_state->payload->early_dispatch_state.load(std::memory_order_relaxed) :
+            core.pending_slot_state != nullptr ?
+                core.pending_slot_state->to_payload().early_dispatch_state.load(std::memory_order_relaxed) :
                 static_cast<uint8_t>(EARLY_DISPATCH_NONE);
         bool pending_gated =
-            (core.pending_slot_state != nullptr && core.pending_slot_state->payload != nullptr &&
+            (core.pending_slot_state != nullptr &&
              (pending_ss == EARLY_DISPATCH_STAGING ||
               (pending_ss == EARLY_DISPATCH_DISPATCHED && core.pending_slot_state->task_attrs.requires_sync_start())));
         SlotTransition t = decide_slot_transition(
@@ -396,7 +400,7 @@ void SchedulerContext::check_running_cores_for_completion(
                 bool sync_start_promote = pending_gated && promoted->task_attrs.requires_sync_start();
                 promote_pending_to_running(core);  // Case 2 or Case 3 (with pending)
                 if (sync_start_promote) {
-                    promoted->payload->running_slot_count.fetch_add(1, std::memory_order_seq_cst);
+                    promoted->to_payload().running_slot_count.fetch_add(1, std::memory_order_seq_cst);
                     if (sched_->maybe_rendezvous_ring(*promoted)) {
                         sched_->propagate_dispatch_fanin(*promoted);
                     }
@@ -569,7 +573,7 @@ SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
             if (gated) {
                 for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
                     if (my_mask[w] != 0) {
-                        slot_state->payload->staged_core_mask[w].fetch_or(my_mask[w], std::memory_order_seq_cst);
+                        slot_state->to_payload().staged_core_mask[w].fetch_or(my_mask[w], std::memory_order_seq_cst);
                     }
                 }
             }
@@ -681,7 +685,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     // OWNER is acquired before the drain is published and persists through
     // completion, so every staging thread makes the same gate decision even if
     // producer release changes early_dispatch_state during the barrier.
-    bool gated = slot_state->payload != nullptr && SchedulerState::owns_early_sync_drain(*slot_state->payload);
+    bool gated = SchedulerState::owns_early_sync_drain(slot_state->to_payload());
 
     if (coordinator) {
         ResourceShape shape = slot_state->active_mask.to_shape();
@@ -743,7 +747,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
         // Seed the rendezvous with the running-slot cores staged across all threads; pending
         // cores advance it as they promote. maybe_rendezvous_ring (producer release) rings iff
         // this already equals popcount(staged_core_mask) — i.e. no pending spill.
-        slot_state->payload->running_slot_count.store(
+        slot_state->to_payload().running_slot_count.store(
             static_cast<int16_t>(drain_state_.drain_running_staged.load(std::memory_order_acquire)),
             std::memory_order_seq_cst
         );
@@ -768,5 +772,5 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     } else {
         sched_->propagate_dispatch_fanin(*slot_state);
     }
-    SchedulerState::finish_early_sync_drain(*slot_state->payload);
+    SchedulerState::finish_early_sync_drain(slot_state->to_payload());
 }

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -126,10 +126,10 @@ void SchedulerContext::build_payload(
     bool force_gate
 ) {
     int32_t slot_idx = static_cast<int32_t>(subslot);
-    uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
+    uint64_t callable_addr = get_function_bin_addr(slot_state.to_descriptor().kernel_id[slot_idx]);
     const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
     dispatch_payload.function_bin_addr = callable->resolved_addr();
-    auto &payload = *slot_state.payload;
+    auto &payload = slot_state.to_payload();
     // A claimed early-stage range stays gated even if producer completion flips
     // the shared state before this payload is built. All other dispatches run on
     // pickup.
@@ -166,7 +166,7 @@ void SchedulerContext::build_payload(
     // AsyncCtx::make(non-null) result). args[PAYLOAD_LOCAL_CONTEXT_INDEX] /
     // [PAYLOAD_GLOBAL_CONTEXT_INDEX] are per-(core, buf_idx) constants, also
     // prefilled in init().
-    dispatch_payload.local_context.async_ctx.task_token = slot_state.task->task_id;
+    dispatch_payload.local_context.async_ctx.task_token = slot_state.to_descriptor().task_id;
 }
 
 SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
@@ -212,9 +212,9 @@ SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
         "Thread %d: Dispatched %s %s task %" PRId64 " kernel_id=[%d,%d,%d] block_idx=%d/total_blocks=%d to"
         " core_offset=%d core_id=%d reg_task_id=%u",
         thread_idx, to_pending ? "pending" : "idle", subslot_name(subslot),
-        static_cast<int64_t>(slot_state.task->task_id.raw), slot_state.task->kernel_id[0],
-        slot_state.task->kernel_id[1], slot_state.task->kernel_id[2], block_idx, slot_state.logical_block_num,
-        core_offset, core_id, reg_task_id
+        static_cast<int64_t>(slot_state.to_descriptor().task_id.raw), slot_state.to_descriptor().kernel_id[0],
+        slot_state.to_descriptor().kernel_id[1], slot_state.to_descriptor().kernel_id[2], block_idx,
+        slot_state.logical_block_num, core_offset, core_id, reg_task_id
     );
 
     // AICore buffer rotation lives on the dispatch path: count this dispatch
@@ -249,14 +249,15 @@ int SchedulerContext::prepare_block_for_dispatch(
 #if SIMPLER_DFX
     if (is_dump_args_enabled()) {
         dump_args_for_task<SUBTASK_SLOT_COUNT>(
-            thread_idx, slot_state, ArgsDumpStage::BEFORE_DISPATCH,
+            thread_idx, slot_state.to_descriptor(), slot_state.to_payload(), slot_state.active_mask,
+            ArgsDumpStage::BEFORE_DISPATCH,
             [](ActiveMask active_mask, int raw_subtask_id) {
                 return active_mask.subtask_active(static_cast<SubtaskSlot>(raw_subtask_id));
             },
             [this](int32_t func_id) {
                 return get_function_bin_addr(func_id);
             },
-            &slot_state.payload->dump_metadata
+            &slot_state.to_payload().dump_metadata
         );
     }
 #endif
@@ -666,13 +667,13 @@ int32_t SchedulerContext::stage_consumer_blocks(
     // Publish all this thread's gated cores into the shared mask in one OR per word
     // (vs one per subtask) so release sees them; seq_cst keeps the self-ring order.
     for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++)
-        if (my_cores[w] != 0) c->payload->staged_core_mask[w].fetch_or(my_cores[w], std::memory_order_seq_cst);
+        if (my_cores[w] != 0) c->to_payload().staged_core_mask[w].fetch_or(my_cores[w], std::memory_order_seq_cst);
 
     // Full publication and release are independent events. The seq_cst
     // state/launch/count operations form a two-sided handshake. A released
     // block must ring before contributing to the publication count.
     bool released =
-        staged > 0 && c->payload->early_dispatch_state.load(std::memory_order_seq_cst) == EARLY_DISPATCH_DISPATCHED;
+        staged > 0 && c->to_payload().early_dispatch_state.load(std::memory_order_seq_cst) == EARLY_DISPATCH_DISPATCHED;
 
     // Claim only bits the release path did not take. Local handles remain valid
     // even if the shared per-core table is reused before this thread resumes.
@@ -681,7 +682,7 @@ int32_t SchedulerContext::stage_consumer_blocks(
         for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
             if (my_cores[w] != 0) {
                 owned[w] =
-                    SchedulerState::claim_late_staged_doorbell_bits(c->payload->staged_core_mask[w], my_cores[w]);
+                    SchedulerState::claim_late_staged_doorbell_bits(c->to_payload().staged_core_mask[w], my_cores[w]);
             }
         }
         for (int i = 0; i < n; i++) {
@@ -737,8 +738,8 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, ResourceShape shape, 
     int got = sched_->early_dispatch_queues[s].pop_batch_tagged(batch, task_id_snapshots, cores.count());
     for (int bi = 0; bi < got; bi++) {
         ChipTaskSlotState *c = batch[bi];
-        if (static_cast<uint64_t>(c->task->task_id.raw) != task_id_snapshots[bi]) continue;
-        if (c->payload->early_dispatch_state.load(std::memory_order_acquire) != EARLY_DISPATCH_STAGING)
+        if (static_cast<uint64_t>(c->to_descriptor().task_id.raw) != task_id_snapshots[bi]) continue;
+        if (c->to_payload().early_dispatch_state.load(std::memory_order_acquire) != EARLY_DISPATCH_STAGING)
             continue;  // released
 
         // The single free-core bucket for this phase. For MIX, an active-mask-aware
@@ -776,7 +777,7 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, ResourceShape shape, 
             if (!sched_->early_dispatch_queues[s].push_tagged(c, task_id_snapshots[bi]))
                 LOG_DEBUG(
                     "[EARLY_DISPATCH] queue full on re-push, consumer=%" PRId64,
-                    static_cast<int64_t>(c->task->task_id.raw)
+                    static_cast<int64_t>(c->to_descriptor().task_id.raw)
                 );
         }
         // stage_consumer_blocks fills the idle bucket (RUNNING slot) then the pend
@@ -824,10 +825,10 @@ int32_t SchedulerContext::try_early_dispatch(
     // STAGING -> DISPATCHED. A non-STAGING pop was already released and is dropped.
     uint64_t sync_task_id_snapshot = 0;
     if (ChipTaskSlotState *c = sched_->early_sync_start_queue.pop_tagged(&sync_task_id_snapshot)) {
-        bool current_sync_task =
-            static_cast<uint64_t>(c->task->task_id.raw) == sync_task_id_snapshot && c->task_attrs.requires_sync_start();
-        if (current_sync_task && SchedulerState::try_claim_early_sync_drain(*c->payload)) {
-            if (c->payload->early_dispatch_state.load(std::memory_order_seq_cst) != EARLY_DISPATCH_STAGING) {
+        bool current_sync_task = static_cast<uint64_t>(c->to_descriptor().task_id.raw) == sync_task_id_snapshot &&
+                                 c->task_attrs.requires_sync_start();
+        if (current_sync_task && SchedulerState::try_claim_early_sync_drain(c->to_payload())) {
+            if (c->to_payload().early_dispatch_state.load(std::memory_order_seq_cst) != EARLY_DISPATCH_STAGING) {
                 sched_->cancel_early_sync_drain(*c);
             } else if (drain_state_.sync_start_pending.load(std::memory_order_acquire) == 0 &&
                        tracker.count_available_blocks(
@@ -836,20 +837,20 @@ int32_t SchedulerContext::try_early_dispatch(
                 // From this point onward the operation is all-or-nothing. Only this
                 // scheduler mutates its tracker, and global drain coordinators must
                 // wait for this scheduler's generation-tagged ack before inspecting it.
-                SchedulerState::mark_early_sync_drain_armed(*c->payload);
+                SchedulerState::mark_early_sync_drain_armed(c->to_payload());
                 always_assert(c->next_block_idx.load(std::memory_order_seq_cst) == 0);
                 SyncStartStageResult staged = stage_sync_start_cores(
                     c, c->logical_block_num, thread_idx, /*gated=*/true, /*record_drain_phases=*/false
                 );
                 always_assert(staged.staged_blocks == c->logical_block_num);
-                c->payload->running_slot_count.store(
+                c->to_payload().running_slot_count.store(
                     static_cast<int16_t>(staged.running_cores), std::memory_order_seq_cst
                 );
                 sched_->retry_sync_start_rendezvous_after_staging(*c);
-                SchedulerState::finish_early_sync_drain(*c->payload);
+                SchedulerState::finish_early_sync_drain(c->to_payload());
                 total_staged += staged.staged_blocks;
             } else if (enter_drain_mode(c, c->logical_block_num)) {
-                SchedulerState::mark_early_sync_drain_armed(*c->payload);
+                SchedulerState::mark_early_sync_drain_armed(c->to_payload());
             } else {
                 sched_->cancel_early_sync_drain(*c);
             }
@@ -1411,7 +1412,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         if (thread_idx < active_sched_threads_) {
             ChipTaskSlotState *graph_slot = sched_->graph_ready_queue.pop();
             if (graph_slot != nullptr) {
-                if (graph_slot->task != nullptr && graph_slot->task_kind == TaskKind::GRAPH) {
+                if (graph_slot->task_kind == TaskKind::GRAPH) {
                     (void)sched_->activate_graph_task(*graph_slot);
                     made_progress = true;
                 } else {
@@ -1423,8 +1424,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             uint64_t prepare_task_id = 0;
             ChipTaskSlotState *prepare_slot = sched_->graph_prepare_queue.pop_tagged(&prepare_task_id);
             if (prepare_slot != nullptr) {
-                const bool valid_slot = prepare_slot->task != nullptr && prepare_slot->task_kind == TaskKind::GRAPH &&
-                                        prepare_slot->task->task_id.raw == prepare_task_id;
+                const bool valid_slot = prepare_slot->task_kind == TaskKind::GRAPH &&
+                                        prepare_slot->to_descriptor().task_id.raw == prepare_task_id;
                 if (!valid_slot) {
                     fail_scheduler(runtime, thread_idx, SIMPLER_ERROR_INVALID_ARGS);
                     break;

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_graph.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_graph.h
@@ -25,9 +25,15 @@
 #define __aicore__
 #endif
 
-inline constexpr uint32_t SCHEDULER_GRAPH_TASK_DESCRIPTOR_STRIDE = 40;
+// A task's three records share one ChipTaskStorage, so AICore reaches both the
+// ones it reads from a single base: the array strides by the storage, and each
+// record sits at a fixed offset inside it. These are literals because the AICore
+// .o cannot include runtime_types.h; scheduler.h checks them against the types at
+// compile time, and the contract UT again at run time.
+inline constexpr uint32_t SCHEDULER_GRAPH_TASK_STORAGE_STRIDE = 320;
+inline constexpr uint32_t SCHEDULER_GRAPH_DESCRIPTOR_OFFSET = 0;
 // TaskPayload includes the early-dispatch cache line in this wire layout.
-inline constexpr uint32_t SCHEDULER_GRAPH_TASK_PAYLOAD_STRIDE = 192;
+inline constexpr uint32_t SCHEDULER_GRAPH_PAYLOAD_OFFSET = 128;
 inline constexpr uint32_t SCHEDULER_GRAPH_TASK_ID_OFFSET = 0;
 inline constexpr uint32_t SCHEDULER_GRAPH_KERNEL_IDS_OFFSET = 8;
 inline constexpr uint32_t SCHEDULER_GRAPH_FANIN_COUNT_OFFSET = 8;
@@ -49,8 +55,13 @@ enum class SchedulerGraphResult : uint64_t {
 };
 
 struct SchedulerGraphView {
-    uint64_t descriptors_address;
-    uint64_t payloads_address;
+    // Base of the ChipTaskStorage array. One address, because a task's descriptor
+    // and payload are members of one entry rather than peers in two arrays.
+    uint64_t storage_address;
+    // Held so the view keeps its 32-byte wire size. A producer writes 0; the two
+    // entry points below reject a non-zero read, so a later field cannot be
+    // reintroduced over a value some earlier producer already put here.
+    uint64_t reserved;
     uint64_t task_count;
     // Kept in the wire view for diagnostics. HBG task ids directly index the
     // whole-graph-resident tables and never wrap, so this value must not be
@@ -80,20 +91,20 @@ struct SchedulerDispatchPredicate {
 };
 
 static_assert(sizeof(SchedulerGraphView) == 32, "read-only graph view layout changed");
-static_assert(offsetof(SchedulerGraphView, descriptors_address) == 0, "descriptor address offset changed");
-static_assert(offsetof(SchedulerGraphView, payloads_address) == 8, "payload address offset changed");
+static_assert(offsetof(SchedulerGraphView, storage_address) == 0, "storage address offset changed");
 static_assert(sizeof(SchedulerTaskInfo) == 24, "root classification result layout changed");
 static_assert(sizeof(SchedulerTaskShape) == 24, "task shape result layout changed");
 static_assert(sizeof(SchedulerDispatchPredicate) == 24, "dispatch predicate layout changed");
 
-inline __aicore__ __gm__ uint8_t *scheduler_graph_descriptor(const SchedulerGraphView &graph, int64_t task_id) {
+inline __aicore__ __gm__ uint8_t *scheduler_graph_storage(const SchedulerGraphView &graph, int64_t task_id) {
     uint64_t slot = static_cast<uint64_t>(task_id);
-    return reinterpret_cast<__gm__ uint8_t *>(graph.descriptors_address) +
-           slot * SCHEDULER_GRAPH_TASK_DESCRIPTOR_STRIDE;
+    return reinterpret_cast<__gm__ uint8_t *>(graph.storage_address) + slot * SCHEDULER_GRAPH_TASK_STORAGE_STRIDE;
+}
+inline __aicore__ __gm__ uint8_t *scheduler_graph_descriptor(const SchedulerGraphView &graph, int64_t task_id) {
+    return scheduler_graph_storage(graph, task_id) + SCHEDULER_GRAPH_DESCRIPTOR_OFFSET;
 }
 inline __aicore__ __gm__ uint8_t *scheduler_graph_payload(const SchedulerGraphView &graph, int64_t task_id) {
-    uint64_t slot = static_cast<uint64_t>(task_id);
-    return reinterpret_cast<__gm__ uint8_t *>(graph.payloads_address) + slot * SCHEDULER_GRAPH_TASK_PAYLOAD_STRIDE;
+    return scheduler_graph_storage(graph, task_id) + SCHEDULER_GRAPH_PAYLOAD_OFFSET;
 }
 
 inline __aicore__ int32_t
@@ -114,8 +125,8 @@ scheduler_classify_task_shape(const SchedulerGraphView &graph, int64_t task_id, 
         {0, 0, 0}
     };
     if (graph.task_count == 0) return SchedulerGraphResult::EMPTY;
-    if (graph.descriptors_address == 0 || graph.payloads_address == 0 || task_id < 0 ||
-        static_cast<uint64_t>(task_id) >= graph.task_count) {
+    if (graph.reserved != 0) return SchedulerGraphResult::INVALID_ARGUMENTS;
+    if (graph.storage_address == 0 || task_id < 0 || static_cast<uint64_t>(task_id) >= graph.task_count) {
         return SchedulerGraphResult::INVALID_TASK_COUNT;
     }
 
@@ -163,7 +174,8 @@ inline __aicore__ SchedulerGraphResult scheduler_materialize_task_payload_resolv
         block_idx >= block_num) {
         return SchedulerGraphResult::INVALID_CALLABLE;
     }
-    if (graph.payloads_address == 0 || task.task_id < 0 || static_cast<uint64_t>(task.task_id) >= graph.task_count) {
+    if (graph.reserved != 0) return SchedulerGraphResult::INVALID_ARGUMENTS;
+    if (graph.storage_address == 0 || task.task_id < 0 || static_cast<uint64_t>(task.task_id) >= graph.task_count) {
         return SchedulerGraphResult::INVALID_TASK_COUNT;
     }
     __gm__ uint8_t *payload = scheduler_graph_payload(graph, task.task_id);

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_ready.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_ready.h
@@ -311,8 +311,7 @@ inline __aicore__ void scheduler_record_error(
     scheduler_gm_store(run_control->error_task_id, static_cast<uint64_t>(task_id));
     if (graph != nullptr) {
         scheduler_gm_store(run_control->error_graph_task_count, graph->task_count);
-        scheduler_gm_store(run_control->error_descriptors_address, graph->descriptors_address);
-        scheduler_gm_store(run_control->error_payloads_address, graph->payloads_address);
+        scheduler_gm_store(run_control->error_storage_address, graph->storage_address);
         scheduler_gm_store(run_control->error_task_window_mask, graph->task_window_mask);
     }
     if (context != nullptr) {

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
@@ -953,8 +953,8 @@ struct alignas(128) SchedulerRunControl {
     volatile uint64_t error_core_id;
     volatile uint64_t error_core_type;
     volatile uint64_t error_graph_task_count;
-    volatile uint64_t error_descriptors_address;
-    volatile uint64_t error_payloads_address;
+    volatile uint64_t error_storage_address;
+    volatile uint64_t error_reserved_address;
     volatile uint64_t error_task_window_mask;
     volatile uint64_t error_site;
     uint64_t error_reserved[6];
@@ -1005,8 +1005,13 @@ struct alignas(128) SchedulerWorkerContext {
     volatile int32_t active;
     volatile uint64_t run_control_offset;
     volatile uint64_t task_controls_offset;
-    volatile uint64_t graph_descriptors_address;
-    volatile uint64_t graph_payloads_address;
+    // Base of this run's ChipTaskStorage array. One address: a task's descriptor
+    // and payload are members of one entry, so AICore strides by the storage.
+    volatile uint64_t graph_storage_address;
+    // Held so the wire layout survived the collapse from two addresses to one.
+    // Whoever wires this context up must write 0 here and reject a non-zero read,
+    // or a later field can be reintroduced over a value someone else is using.
+    volatile uint64_t graph_reserved_address;
     volatile uint64_t scheduler_state_base_address;
     volatile uint64_t dispatch_payload_offset;
     volatile uint64_t trace_cells_offset;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -456,16 +456,22 @@ int32_t SchedulerContext::handle_timeout_exit(
         // Capture the in-flight kernels' partial output before signalling the
         // cores to exit, so the dump reflects the live stuck state.
         if (is_dump_args_enabled()) {
-            dump_running_task_outputs<SUBTASK_SLOT_COUNT>(
-                thread_idx, cores_total_num_,
+            dump_running_task_outputs(
+                cores_total_num_,
                 [this](int32_t cid) {
                     return core_exec_states_[cid].running_slot_state;
                 },
-                [](ActiveMask active_mask, int raw_subtask_id) {
-                    return active_mask.subtask_active(static_cast<SubtaskSlot>(raw_subtask_id));
-                },
-                [this](int32_t func_id) {
-                    return get_function_bin_addr(func_id);
+                [this, thread_idx](const ChipTaskSlotState &slot_state) {
+                    dump_args_for_task<SUBTASK_SLOT_COUNT>(
+                        thread_idx, *slot_state.task, *slot_state.payload, slot_state.active_mask,
+                        ArgsDumpStage::AFTER_COMPLETION,
+                        [](ActiveMask active_mask, int raw_subtask_id) {
+                            return active_mask.subtask_active(static_cast<SubtaskSlot>(raw_subtask_id));
+                        },
+                        [this](int32_t func_id) {
+                            return get_function_bin_addr(func_id);
+                        }
+                    );
                 }
             );
         }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -162,7 +162,8 @@ void SchedulerContext::complete_slot_task(
 #if SIMPLER_DFX
         if (is_dump_args_enabled()) {
             dump_args_for_task<SUBTASK_SLOT_COUNT>(
-                thread_idx, slot_state, ArgsDumpStage::AFTER_COMPLETION,
+                thread_idx, *slot_state.task, *slot_state.payload, slot_state.active_mask,
+                ArgsDumpStage::AFTER_COMPLETION,
                 [](ActiveMask active_mask, int raw_subtask_id) {
                     return active_mask.subtask_active(static_cast<SubtaskSlot>(raw_subtask_id));
                 },

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -212,7 +212,7 @@ int SchedulerContext::prepare_block_for_dispatch(
 #if SIMPLER_DFX
     if (is_dump_args_enabled()) {
         dump_args_for_task<SUBTASK_SLOT_COUNT>(
-            thread_idx, slot_state, ArgsDumpStage::BEFORE_DISPATCH,
+            thread_idx, *slot_state.task, *slot_state.payload, slot_state.active_mask, ArgsDumpStage::BEFORE_DISPATCH,
             [](ActiveMask active_mask, int raw_subtask_id) {
                 return active_mask.subtask_active(static_cast<SubtaskSlot>(raw_subtask_id));
             },

--- a/src/common/host_build_graph/device/graph_execution.cpp
+++ b/src/common/host_build_graph/device/graph_execution.cpp
@@ -25,10 +25,10 @@ GraphExecution *acquire_execution_storage(
     uint32_t scalar_arg_count
 ) {
     GraphExecutionStorageLayout layout{};
-    // InGraphTaskStorage, not GraphExecution: the in-graph task array's alignment is the widest
+    // ChipTaskStorage, not GraphExecution: the in-graph task array's alignment is the widest
     // the storage carries, and tasks_offset only rounds up relative to this base, so
     // an under-aligned base would leave every alignas(64) in-graph task entry misaligned.
-    if (storage_addr == 0 || storage_addr % alignof(InGraphTaskStorage) != 0 ||
+    if (storage_addr == 0 || storage_addr % alignof(ChipTaskStorage) != 0 ||
         !graph_execution_storage_layout(task_count, tensor_arg_count, scalar_arg_count, &layout) ||
         layout.total_bytes > storage_bytes) {
         return nullptr;
@@ -37,7 +37,7 @@ GraphExecution *acquire_execution_storage(
     execution->task_count = task_count;
     execution->remaining_tasks.store(task_count, std::memory_order_relaxed);
     auto *base = reinterpret_cast<uint8_t *>(execution);
-    execution->task_storage = reinterpret_cast<InGraphTaskStorage *>(base + layout.tasks_offset);
+    execution->task_storage = reinterpret_cast<ChipTaskStorage *>(base + layout.tasks_offset);
     execution->task_tensor_pool = reinterpret_cast<simpler::hbg::Tensor *>(base + layout.tensors_offset);
     execution->task_scalar_pool = reinterpret_cast<uint64_t *>(base + layout.scalars_offset);
     return execution;
@@ -263,9 +263,8 @@ bool graph_predicate_resolve(
 }  // namespace
 
 GraphExecution *graph_execution_localize(ChipTaskSlotState &outer_slot) {
-    if (outer_slot.task_kind != TaskKind::GRAPH || outer_slot.task == nullptr || outer_slot.payload == nullptr ||
-        outer_slot.task->packed_buffer_base == nullptr || outer_slot.task->packed_buffer_end == nullptr ||
-        outer_slot.graph_context == nullptr) {
+    if (outer_slot.task_kind != TaskKind::GRAPH || outer_slot.to_descriptor().packed_buffer_base == nullptr ||
+        outer_slot.to_descriptor().packed_buffer_end == nullptr || outer_slot.graph_context == nullptr) {
         return nullptr;
     }
 
@@ -277,7 +276,7 @@ GraphExecution *graph_execution_localize(ChipTaskSlotState &outer_slot) {
     auto *definition_header =
         reinterpret_cast<GraphDefinitionHeader *>(definition_addr - sizeof(GraphDefinitionHeader));
     const GraphDefinition *definition = graph_definition_object_framed(*definition_header);
-    TaskPayload &payload = *outer_slot.payload;
+    TaskPayload &payload = outer_slot.to_payload();
     if (definition == nullptr || definition->total_bytes == 0 || definition->task_count == 0 ||
         definition->task_count > MAX_IN_GRAPH_TASKS ||
         payload.tensor_count != static_cast<int32_t>(definition->boundary_count) ||
@@ -287,8 +286,8 @@ GraphExecution *graph_execution_localize(ChipTaskSlotState &outer_slot) {
         return nullptr;
     }
 
-    const uintptr_t outer_base = reinterpret_cast<uintptr_t>(outer_slot.task->packed_buffer_base);
-    const uintptr_t outer_end = reinterpret_cast<uintptr_t>(outer_slot.task->packed_buffer_end);
+    const uintptr_t outer_base = reinterpret_cast<uintptr_t>(outer_slot.to_descriptor().packed_buffer_base);
+    const uintptr_t outer_end = reinterpret_cast<uintptr_t>(outer_slot.to_descriptor().packed_buffer_end);
     if (outer_end < outer_base || definition->required_heap > UINTPTR_MAX - outer_base ||
         definition->execution_storage_bytes > outer_end - outer_base ||
         definition->required_heap > outer_end - outer_base - definition->execution_storage_bytes) {
@@ -319,9 +318,8 @@ GraphMaterializeResult graph_execution_materialize_slice(
     ChipTaskSlotState &outer_slot, GraphExecution &execution, int32_t max_tasks, int32_t *tasks_materialized
 ) {
     if (tasks_materialized != nullptr) *tasks_materialized = 0;
-    if (outer_slot.task_kind != TaskKind::GRAPH || outer_slot.task == nullptr ||
-        outer_slot.task->packed_buffer_base == nullptr || max_tasks <= 0 || execution.definition == nullptr ||
-        execution.task_storage == nullptr) {
+    if (outer_slot.task_kind != TaskKind::GRAPH || outer_slot.to_descriptor().packed_buffer_base == nullptr ||
+        max_tasks <= 0 || execution.definition == nullptr || execution.task_storage == nullptr) {
         return GraphMaterializeResult::INVALID;
     }
 
@@ -391,11 +389,11 @@ GraphMaterializeResult graph_execution_materialize_slice(
 
     const int32_t first = execution.materialized_tasks;
     const int32_t last = std::min(execution.task_count, first + max_tasks);
-    const uintptr_t outer_base = reinterpret_cast<uintptr_t>(outer_slot.task->packed_buffer_base);
+    const uintptr_t outer_base = reinterpret_cast<uintptr_t>(outer_slot.to_descriptor().packed_buffer_base);
     for (int32_t i = first; i < last; ++i) {
-        InGraphTaskStorage *storage = &execution.task_at(i);
+        ChipTaskStorage *storage = &execution.task_at(i);
         if (i >= execution.constructed_tasks) {
-            storage = new (storage) InGraphTaskStorage;
+            storage = new (storage) ChipTaskStorage;
             execution.constructed_tasks++;
         }
         TaskDescriptor &task = storage->task;
@@ -403,7 +401,7 @@ GraphMaterializeResult graph_execution_materialize_slice(
         ChipTaskSlotState &slot = storage->slot;
 
         task.task_id = simpler::hbg::make_in_graph_task(
-            simpler::hbg::task_local_id(outer_slot.task->task_id), static_cast<uint32_t>(i)
+            simpler::hbg::task_local_id(outer_slot.to_descriptor().task_id), static_cast<uint32_t>(i)
         );
         const InGraphTaskDefinition &source = tasks[i];
         const uint64_t task_offset = in_graph_task_offsets[i];
@@ -415,7 +413,6 @@ GraphMaterializeResult graph_execution_materialize_slice(
 
         slot.reset_for_reuse();
         slot.task_state.store(CHIP_TASK_PENDING, std::memory_order_relaxed);
-        slot.bind_buffers(&payload, &task);
         slot.active_mask = ActiveMask(source.active_mask);
         slot.task_attrs = TaskAttrs(source.task_attrs);
         slot.total_required_subtasks = source.total_required_subtasks;

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -373,7 +373,7 @@ records on either side of H2D.
 
 In-graph tasks consume no task-table slots. Their descriptor, payload, slot
 state, and argument pools live in the tail of the outer `GRAPH` task's own heap block,
-past `required_heap`: `[GraphExecution][InGraphTaskStorage...][tensor pool][scalar pool]`. One
+past `required_heap`: `[GraphExecution][ChipTaskStorage...][tensor pool][scalar pool]`. One
 `TaskAllocator::alloc` covers both the packed outputs and this execution storage,
 so they are reclaimed together without a separate device allocation or release path.
 

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -313,16 +313,6 @@ enum class GraphMaterializeResult : uint8_t {
     PREPARED = 3,
 };
 
-struct alignas(64) InGraphTaskStorage {
-    TaskDescriptor task;
-    ChipTaskSlotState slot;
-    // The payload carries its argument regions as deltas into pools past the task
-    // array, so its size is the same for every task and the slot names it by a delta
-    // from the slot's own address. Field order here therefore constrains nothing, and
-    // task_at strides the storage by this type.
-    TaskPayload payload;
-};
-
 inline constexpr uint8_t GRAPH_EXECUTION_STATE_MASK = 0x7;
 inline constexpr uint8_t GRAPH_EXECUTION_EXTERNAL_READY = 0x8;
 
@@ -346,8 +336,8 @@ struct GraphExecution {
     int32_t constructed_tasks{0};
     uint32_t consumed_tensor_args{0};
     ChipTaskSlotState *outer_slot{nullptr};
-    InGraphTaskStorage *tasks{nullptr};
-    InGraphTaskStorage *task_storage{nullptr};
+    ChipTaskStorage *tasks{nullptr};
+    ChipTaskStorage *task_storage{nullptr};
     // This execution's task argument pools, in the storage tail past task_storage.
     // Every task payload's tensor and scalar deltas point here; its pool position is
     // the Definition's tensor_offset / scalar_offset.
@@ -361,14 +351,14 @@ struct GraphExecution {
     const uint64_t *boundary_scalars{nullptr};
     uint32_t boundary_scalar_count{0};
 
-    InGraphTaskStorage &task_at(int32_t index) const { return task_storage[index]; }
+    ChipTaskStorage &task_at(int32_t index) const { return task_storage[index]; }
 };
 
-static_assert(std::is_trivially_destructible_v<InGraphTaskStorage>);
+static_assert(std::is_trivially_destructible_v<ChipTaskStorage>);
 // The tensor pool starts right after the in-graph task array, and the scalar pool starts
 // after a whole number of ChipTensors.
 static_assert(
-    alignof(InGraphTaskStorage) % alignof(simpler::hbg::Tensor) == 0,
+    alignof(ChipTaskStorage) % alignof(simpler::hbg::Tensor) == 0,
     "an in-graph task entry must be at least simpler::hbg::Tensor-aligned: the tensor pool follows the "
     "in-graph task array"
 );
@@ -379,7 +369,7 @@ static_assert(std::is_trivially_destructible_v<GraphExecution>);
 // The whole storage is aligned for its widest member, so one base check covers the
 // header as well as the in-graph task array that follows it.
 static_assert(
-    alignof(InGraphTaskStorage) % alignof(GraphExecution) == 0,
+    alignof(ChipTaskStorage) % alignof(GraphExecution) == 0,
     "the in-graph task array's alignment must subsume the execution header's"
 );
 static_assert(sizeof(GraphTensor) <= sizeof(simpler::hbg::Tensor));
@@ -390,7 +380,7 @@ inline constexpr size_t graph_boundary_tensor_pool_slots(uint32_t tensor_count) 
 }
 
 // The outer GRAPH task's heap tail occupies
-// [GraphExecution][InGraphTaskStorage x task_count][simpler::hbg::Tensor x tensor_arg_count]
+// [GraphExecution][ChipTaskStorage x task_count][simpler::hbg::Tensor x tensor_arg_count]
 // [uint64_t x scalar_arg_count].
 //
 // The last two regions are the in-graph task payloads' argument pools, indexed by the
@@ -412,9 +402,9 @@ inline bool graph_execution_storage_layout(
     if (out == nullptr || task_count <= 0 || task_count > static_cast<int32_t>(MAX_IN_GRAPH_TASKS)) {
         return false;
     }
-    constexpr size_t ALIGNMENT = alignof(InGraphTaskStorage);
+    constexpr size_t ALIGNMENT = alignof(ChipTaskStorage);
     out->tasks_offset = (sizeof(GraphExecution) + ALIGNMENT - 1) & ~(ALIGNMENT - 1);
-    out->tensors_offset = out->tasks_offset + static_cast<size_t>(task_count) * sizeof(InGraphTaskStorage);
+    out->tensors_offset = out->tasks_offset + static_cast<size_t>(task_count) * sizeof(ChipTaskStorage);
     out->scalars_offset = out->tensors_offset + static_cast<size_t>(tensor_arg_count) * sizeof(simpler::hbg::Tensor);
     out->total_bytes = out->scalars_offset + static_cast<size_t>(scalar_arg_count) * sizeof(uint64_t);
     return true;

--- a/src/common/host_build_graph/runtime.h
+++ b/src/common/host_build_graph/runtime.h
@@ -184,8 +184,7 @@ public:
 private:
     // Kernel binary tracking for cleanup
 
-    void *gm_sm_ptr_;        // GM pointer to shared memory (device)
-    void *slot_states_ptr_;  // Pointer to ChipTaskSlotState array (scheduler-private, for profiling)
+    void *gm_sm_ptr_;                                   // GM pointer to shared memory (device)
     simpler::hbg::EntryArgsStorage orch_args_storage_;  // Entry args, adopted on the host
 
     // Prebuilt-arena fast path (trb only). Set by the host before rtMemcpy'ing
@@ -245,7 +244,6 @@ public:
     void *get_gm_sm_ptr() const;
     const simpler::hbg::EntryArgsStorage &get_orch_args() const;
     void set_gm_sm_ptr(void *p);
-    void set_slot_states_ptr(void *p);
     void set_orch_args(const ChipStorageTaskArgs &args);
 
     // Prebuilt-arena fast path (trb only). Set by host's

--- a/src/common/host_build_graph/runtime_types.h
+++ b/src/common/host_build_graph/runtime_types.h
@@ -233,6 +233,7 @@ struct OutputLayout {
 // =============================================================================
 
 struct ChipTaskSlotState;  // Forward declaration (defined below)
+struct TaskPayload;        // Forward declaration (defined below)
 
 // =============================================================================
 // Task Descriptor
@@ -247,7 +248,7 @@ struct ChipTaskSlotState;  // Forward declaration (defined below)
  *
  * Fields set by Orchestrator at submission, read by Scheduler for dispatch.
  */
-struct TaskDescriptor {
+struct alignas(64) TaskDescriptor {
     // Task identity. See src/common/host_build_graph/task_id_encoding.h: the
     // upper 32 bits are this runtime's id space, not a ring index.
     TaskId task_id;
@@ -258,11 +259,21 @@ struct TaskDescriptor {
     // Packed output buffer (all outputs packed into single contiguous buffer)
     void *packed_buffer_base;  // Start of packed buffer in GM Heap
     void *packed_buffer_end;   // End of packed buffer (for heap reclamation)
+
+    // Pads the descriptor to the cache line ChipTaskStorage places the slot state
+    // on, which is what makes that container's slot offset equal to this size.
+    uint8_t reserved[24];
+
+    // This task's other two records, defined below once ChipTaskStorage is complete.
+    ChipTaskSlotState &to_slot();
+    const ChipTaskSlotState &to_slot() const;
+    TaskPayload &to_payload();
+    const TaskPayload &to_payload() const;
 };
 
 // A 4-byte alignment pad follows kernel_id[3]; the scheduler and shared-memory
 // ABI depend on the descriptor size and packed_buffer_base offset staying fixed.
-static_assert(sizeof(TaskDescriptor) == 40, "TaskDescriptor size is part of the shared-memory ABI");
+static_assert(sizeof(TaskDescriptor) == 64, "TaskDescriptor size is part of the shared-memory ABI");
 static_assert(offsetof(TaskDescriptor, packed_buffer_base) == 24, "packed_buffer_base offset must be unchanged");
 
 // =============================================================================
@@ -514,6 +525,12 @@ struct TaskPayload {
         running_slot_count.store(0, std::memory_order_relaxed);
         early_sync_drain_state.store(EARLY_SYNC_DRAIN_NONE, std::memory_order_relaxed);
     }
+
+    // This task's other two records, defined below once ChipTaskStorage is complete.
+    TaskDescriptor &to_descriptor();
+    const TaskDescriptor &to_descriptor() const;
+    ChipTaskSlotState &to_slot();
+    const ChipTaskSlotState &to_slot() const;
 };
 
 // TaskPayload layout verification (offsetof requires complete type). The counts
@@ -583,12 +600,6 @@ struct alignas(64) ChipTaskSlotState {
     // the host completion-wait and the cold-path stall dump.
     std::atomic<ChipTaskState> task_state;
 
-    // --- Per-slot constant, re-bound by orch::prepare_task each submit ---
-    // Self-relative, so the SM image needs no pointer fix-up on its way to the
-    // device: both targets sit in the same block as this field.
-    simpler::hbg::SelfRelativePtr<TaskPayload> payload;
-    simpler::hbg::SelfRelativePtr<TaskDescriptor> task;
-
     // --- Wake list: last-fanin notification (intrusive, lock-free) ---
     // A pending consumer whose fanin scan finds an unmet producer registers on
     // that producer's wake list (CAS push through next_in_wake_list). On
@@ -643,6 +654,9 @@ struct alignas(64) ChipTaskSlotState {
     // so the outer task cannot be mistaken for an in-graph one.
     void *graph_context{nullptr};
 
+    // Keeps the record at one cache line now that the two deltas are gone.
+    uint8_t reserved[16];
+
     int32_t claim_block_range(int32_t block_limit, int32_t max_count, int32_t &start) {
         int16_t current = next_block_idx.load(std::memory_order_relaxed);
         while (current < block_limit && max_count > 0) {
@@ -660,11 +674,6 @@ struct alignas(64) ChipTaskSlotState {
         return 0;
     }
 
-    void bind_buffers(TaskPayload *p, TaskDescriptor *t) {
-        payload.set(p);
-        task.set(t);
-    }
-
     // Publishes completion. For an IN_GRAPH task this store is the whole
     // publication — that task has no completion_flags byte. For a GLOBAL task it
     // accompanies the completion_flags[slot] store that on_mixed_task_complete
@@ -679,8 +688,8 @@ struct alignas(64) ChipTaskSlotState {
      * Reset dynamic scheduling fields to their pristine values. Called once per
      * slot as the orchestrator claims it in prepare_task, and again as an
      * in-graph task's storage is materialized — whole-graph-resident hbg has no
-     * execution-time slot recycle. Skips payload/task (bound once) and
-     * task_state (the orchestrator sets PENDING when it populates the slot).
+     * execution-time slot recycle. Skips task_state (the orchestrator sets PENDING
+     * when it populates the slot).
      * wake_list_head starts nullptr (open for registration), NOT SENTINEL.
      */
     void reset_for_reuse() {
@@ -698,9 +707,119 @@ struct alignas(64) ChipTaskSlotState {
         // Payload early-dispatch/fanin fields are (re)initialized in
         // TaskPayload::init on every submit, before the slot is visible.
     }
+
+    // This task's other two records, defined below once ChipTaskStorage is complete.
+    // They are that type's layout rather than stored state: a record is always a
+    // member of one, so the distances are fixed and no delta is kept here.
+    TaskPayload &to_payload();
+    const TaskPayload &to_payload() const;
+    TaskDescriptor &to_descriptor();
+    const TaskDescriptor &to_descriptor() const;
 };
 
 static_assert(sizeof(ChipTaskSlotState) == 64);
+
+// =============================================================================
+// Per-Task Storage
+// =============================================================================
+
+/**
+ * One task's three shared-memory records, held together so their relative
+ * positions are a property of this type rather than data any of them stores.
+ *
+ * Every hbg task's records live in one of these — that is the invariant the
+ * accessors below rest on, and none of the three types may be instantiated on its
+ * own. A GLOBAL task's storage sits in the shared-memory storage segment, indexed by
+ * its local task id (SharedMemoryTaskHeader::storage_at); an IN_GRAPH task's sits in
+ * its Graph's own heap tail, indexed by its position in the body
+ * (GraphExecution::task_at). The two therefore share one addressing rule, which is
+ * what lets the scheduler reach a task's descriptor and payload from its slot state
+ * with neither record naming the other.
+ *
+ * Field order is part of the layout AICore reads: it resolves a descriptor and a
+ * payload from this type's base by the byte offsets in scheduler_graph.h. That
+ * header is A5-only and cannot be reached from here, so the reverse lookup lives
+ * on the A5 side, in scheduler.h — the asserts below only pin this type's own
+ * shape.
+ */
+struct alignas(64) ChipTaskStorage {
+    TaskDescriptor task;
+    ChipTaskSlotState slot;
+    // The payload carries its argument regions as deltas into pools past the task
+    // array, so its size is the same for every task and the storage array strides by
+    // this type.
+    TaskPayload payload;
+};
+
+// offsetof is defined for a standard-layout type, which is what the accessors need.
+static_assert(std::is_standard_layout_v<ChipTaskStorage>);
+static_assert(std::is_trivially_destructible_v<ChipTaskStorage>);
+static_assert(sizeof(ChipTaskStorage) == 320);
+static_assert(offsetof(ChipTaskStorage, slot) == sizeof(TaskDescriptor));
+static_assert(offsetof(ChipTaskStorage, payload) == offsetof(ChipTaskStorage, slot) + sizeof(ChipTaskSlotState));
+
+// A record's siblings, reached by ChipTaskStorage's own layout. Valid because none of
+// the three types is ever instantiated outside one — that is the invariant the whole
+// set rests on, and the only thing a caller has to keep true.
+//
+// Each distance is a function-local compile-time constant, so an accessor is one
+// constant displacement and nothing about the layout leaks into a namespace. They are
+// ptrdiff_t because half of them are negative.
+#define CHIP_TASK_STORAGE_DELTA(from, to) \
+    (static_cast<ptrdiff_t>(offsetof(ChipTaskStorage, to)) - static_cast<ptrdiff_t>(offsetof(ChipTaskStorage, from)))
+
+inline ChipTaskSlotState &TaskDescriptor::to_slot() {
+    constexpr ptrdiff_t kDelta = CHIP_TASK_STORAGE_DELTA(task, slot);
+    return *reinterpret_cast<ChipTaskSlotState *>(reinterpret_cast<char *>(this) + kDelta);
+}
+inline const ChipTaskSlotState &TaskDescriptor::to_slot() const {
+    constexpr ptrdiff_t kDelta = CHIP_TASK_STORAGE_DELTA(task, slot);
+    return *reinterpret_cast<const ChipTaskSlotState *>(reinterpret_cast<const char *>(this) + kDelta);
+}
+inline TaskPayload &TaskDescriptor::to_payload() {
+    constexpr ptrdiff_t kDelta = CHIP_TASK_STORAGE_DELTA(task, payload);
+    return *reinterpret_cast<TaskPayload *>(reinterpret_cast<char *>(this) + kDelta);
+}
+inline const TaskPayload &TaskDescriptor::to_payload() const {
+    constexpr ptrdiff_t kDelta = CHIP_TASK_STORAGE_DELTA(task, payload);
+    return *reinterpret_cast<const TaskPayload *>(reinterpret_cast<const char *>(this) + kDelta);
+}
+
+inline TaskDescriptor &ChipTaskSlotState::to_descriptor() {
+    constexpr ptrdiff_t kDelta = CHIP_TASK_STORAGE_DELTA(slot, task);
+    return *reinterpret_cast<TaskDescriptor *>(reinterpret_cast<char *>(this) + kDelta);
+}
+inline const TaskDescriptor &ChipTaskSlotState::to_descriptor() const {
+    constexpr ptrdiff_t kDelta = CHIP_TASK_STORAGE_DELTA(slot, task);
+    return *reinterpret_cast<const TaskDescriptor *>(reinterpret_cast<const char *>(this) + kDelta);
+}
+inline TaskPayload &ChipTaskSlotState::to_payload() {
+    constexpr ptrdiff_t kDelta = CHIP_TASK_STORAGE_DELTA(slot, payload);
+    return *reinterpret_cast<TaskPayload *>(reinterpret_cast<char *>(this) + kDelta);
+}
+inline const TaskPayload &ChipTaskSlotState::to_payload() const {
+    constexpr ptrdiff_t kDelta = CHIP_TASK_STORAGE_DELTA(slot, payload);
+    return *reinterpret_cast<const TaskPayload *>(reinterpret_cast<const char *>(this) + kDelta);
+}
+
+inline TaskDescriptor &TaskPayload::to_descriptor() {
+    constexpr ptrdiff_t kDelta = CHIP_TASK_STORAGE_DELTA(payload, task);
+    return *reinterpret_cast<TaskDescriptor *>(reinterpret_cast<char *>(this) + kDelta);
+}
+inline const TaskDescriptor &TaskPayload::to_descriptor() const {
+    constexpr ptrdiff_t kDelta = CHIP_TASK_STORAGE_DELTA(payload, task);
+    return *reinterpret_cast<const TaskDescriptor *>(reinterpret_cast<const char *>(this) + kDelta);
+}
+inline ChipTaskSlotState &TaskPayload::to_slot() {
+    constexpr ptrdiff_t kDelta = CHIP_TASK_STORAGE_DELTA(payload, slot);
+    return *reinterpret_cast<ChipTaskSlotState *>(reinterpret_cast<char *>(this) + kDelta);
+}
+inline const ChipTaskSlotState &TaskPayload::to_slot() const {
+    constexpr ptrdiff_t kDelta = CHIP_TASK_STORAGE_DELTA(payload, slot);
+    return *reinterpret_cast<const ChipTaskSlotState *>(reinterpret_cast<const char *>(this) + kDelta);
+}
+
+#undef CHIP_TASK_STORAGE_DELTA
 
 // Sentinel marking a wake list as "owner already completed; no more
 // registrations accepted". Distinct from any real slot_state pointer.

--- a/src/common/host_build_graph/self_relative_ptr.h
+++ b/src/common/host_build_graph/self_relative_ptr.h
@@ -20,9 +20,8 @@
  *
  * The block is `memcpy`'d to the device as one image, so a delta between two
  * addresses inside it is invariant under the move while a raw pointer is not.
- * Every user has to satisfy that precondition: a GLOBAL task's payload and
- * descriptor live in the same shared-memory image as its slot state, and a Graph
- * task's live in the same InGraphTaskStorage.
+ * Every user has to satisfy that precondition: a task payload's argument regions
+ * live in the same image as the payload itself, in the pools past the task array.
  *
  * A zero delta means unbound — a field can never coincide with its own target.
  * Zeroed memory therefore reads as null, which is what the slot's pristine state

--- a/src/common/host_build_graph/shared/orchestrator.cpp
+++ b/src/common/host_build_graph/shared/orchestrator.cpp
@@ -1315,17 +1315,25 @@ static bool append_fanin_or_fail(
         );
         return false;
     }
-    ChipTaskSlotState *prod_state = &orch.sm_header->tasks.get_slot_state_by_task_id(
-        static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id))
-    );
-    // Skip a stale/reused producer slot: the cached owner id no longer resolves
-    // to this producer (defensive — whole-graph-resident hbg does not reuse slots
-    // at build time). A COMPLETED producer IS a real fanin edge under polling (its
-    // completion_flags byte is set), so it is not skipped.
-    if (prod_state->task == nullptr ||
-        simpler::hbg::task_local_id(prod_state->task->task_id) != simpler::hbg::task_local_id(producer_task_id)) {
-        return true;
+    // An id past what this run has claimed names no task: get_slot_state_by_task_id
+    // does not bounds-check, so accepting it would write last_consumer_local_id into
+    // an unclaimed — or out-of-range — slot and record a fanin edge to nothing. Only
+    // ids handed back by a previous submit are valid here, and those are below
+    // active_count() because hbg mints them in order and never recycles one.
+    const int32_t prod_local = static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id));
+    if (prod_local < 0 || prod_local >= orch.task_allocator.active_count()) {
+        orch.report_fatal(
+            SIMPLER_ERROR_INVALID_ARGS, __FUNCTION__,
+            "producer task %#llx names slot %d, which this run has not submitted (%d claimed)",
+            static_cast<unsigned long long>(producer_task_id.raw), prod_local, orch.task_allocator.active_count()
+        );
+        return false;
     }
+    // A local id is its own storage index and hbg never recycles a slot, so this
+    // entry is the producer's by construction — there is no stale-slot case to
+    // screen for. A COMPLETED producer is a real fanin edge under polling (its
+    // completion_flags byte is set), so it is not screened out either.
+    ChipTaskSlotState *prod_state = &orch.sm_header->tasks.get_slot_state_by_task_id(prod_local);
     // Dedup by producer local id, which is also its task-table slot.
     if (fanin_mark_seen(orch, producer_task_id)) {
         return true;
@@ -1344,7 +1352,7 @@ static bool append_fanin_or_fail(
         orch_mark_fatal(&orch, SIMPLER_ERROR_FANIN_CAPACITY_EXCEEDED);
         return false;
     }
-    fanin_slots[fanin_count++] = static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id));
+    fanin_slots[fanin_count++] = prod_local;
 
     // Reclaim gate: record this task as a consumer of the producer. The producer
     // slot retires once the completed_watermark reaches this consumer id.
@@ -1402,9 +1410,10 @@ static bool prepare_task(
     }
 
     out->task_id = simpler::hbg::make_global_task(static_cast<uint32_t>(out->alloc_result.task_id));
-    out->slot_state = &orch->sm_header->tasks.get_slot_state_by_task_id(out->alloc_result.task_id);
-    out->task = &orch->sm_header->tasks.task_descriptors[out->alloc_result.task_id];
-    out->payload = &orch->sm_header->tasks.task_payloads[out->alloc_result.task_id];
+    ChipTaskStorage &storage = orch->sm_header->tasks.storage_at(out->alloc_result.task_id);
+    out->slot_state = &storage.slot;
+    out->task = &storage.task;
+    out->payload = &storage.payload;
 
     // Bind the three argument regions before prefetch() and init(), both of which
     // dereference them. The scalar cursor advances in whole cache lines because init()
@@ -1433,16 +1442,6 @@ static bool prepare_task(
     orch->sm_header->tasks.completion_flags[out->alloc_result.task_id].store(0, std::memory_order_relaxed);
 
     out->payload->prefetch(args.tensor_count(), args.scalar_count());
-
-    // Re-bind payload/task pointers each submit. Value is per-slot constant
-    // (same as &task_payloads[slot] / &task_descriptors[slot]), but writing
-    // here lets TaskHeaderView::init() skip the O(max_tasks) bind loop.
-    // Both writes hit the same 64B slot_state cache line we're about to
-    // dirty below, so the extra cost is two stores on an already-hot line.
-    // Must precede the Orch-side wiring publish at the end of
-    // submit_task_common — that publish is the first read of slot_state->task /
-    // slot_state->payload by scheduler threads.
-    out->slot_state->bind_buffers(out->payload, out->task);
 
     // prepare_task does NO payload writes: all payload content (tensors/scalars +
     // early-dispatch fields) is initialized in TaskPayload::init, the
@@ -1987,9 +1986,10 @@ bool graph_submit_outer(
     }
     const TaskId task_id = simpler::hbg::make_global_task(static_cast<uint32_t>(allocation.task_id));
     SharedMemoryTaskHeader &tasks = orch->sm_header->tasks;
-    TaskDescriptor &task = tasks.task_descriptors[allocation.task_id];
-    TaskPayload &payload = tasks.task_payloads[allocation.task_id];
-    ChipTaskSlotState &slot = tasks.get_slot_state_by_task_id(allocation.task_id);
+    ChipTaskStorage &storage = tasks.storage_at(allocation.task_id);
+    TaskDescriptor &task = storage.task;
+    TaskPayload &payload = storage.payload;
+    ChipTaskSlotState &slot = storage.slot;
 
     // Init-on-write, as in prepare_task: this slot's dynamic scheduling fields and
     // completion flag are established here, at the claim, because nothing else
@@ -1999,7 +1999,6 @@ bool graph_submit_outer(
     slot.reset_for_reuse();
     tasks.completion_flags[allocation.task_id].store(0, std::memory_order_relaxed);
 
-    slot.bind_buffers(&payload, &task);
     // Graph boundaries use the same compact argument pools as ordinary tasks. The
     // outer payload carries the invocation data; graph_context only names the
     // shared Definition until device initialization replaces it with GraphExecution.
@@ -2115,8 +2114,7 @@ bool graph_finalize_pending_submissions(OrchestratorState *orch, GraphHostState 
                                                 graph_record_definition(*state, definition_it->second);
         if (definition == nullptr || definition->execution_storage_bytes == 0 ||
             definition->required_heap > UINT64_MAX - definition->execution_storage_bytes ||
-            pending.outer_slot == nullptr || pending.outer_slot->task == nullptr ||
-            pending.outer_slot->task_kind != TaskKind::GRAPH) {
+            pending.outer_slot == nullptr || pending.outer_slot->task_kind != TaskKind::GRAPH) {
             if (failed_key != nullptr) *failed_key = pending.full_key;
             return false;
         }
@@ -2131,8 +2129,9 @@ bool graph_finalize_pending_submissions(OrchestratorState *orch, GraphHostState 
             if (failed_key != nullptr) *failed_key = pending.full_key;
             return false;
         }
-        pending.outer_slot->task->packed_buffer_base = packed_base;
-        pending.outer_slot->task->packed_buffer_end = packed_end;
+        TaskDescriptor &outer_task = pending.outer_slot->to_descriptor();
+        outer_task.packed_buffer_base = packed_base;
+        outer_task.packed_buffer_end = packed_end;
         pending.deferred_heap = false;
     }
     return true;

--- a/src/common/host_build_graph/shared/runtime.cpp
+++ b/src/common/host_build_graph/shared/runtime.cpp
@@ -39,7 +39,6 @@ Runtime::Runtime() {
 
     // Initialize shared-memory / orchestration argument plumbing
     gm_sm_ptr_ = nullptr;
-    slot_states_ptr_ = nullptr;
     orch_args_storage_.clear();
     prebuilt_arena_base_ = nullptr;
     prebuilt_runtime_offset_ = 0;
@@ -63,7 +62,6 @@ Runtime::Runtime() {
 void *Runtime::get_gm_sm_ptr() const { return gm_sm_ptr_; }
 const simpler::hbg::EntryArgsStorage &Runtime::get_orch_args() const { return orch_args_storage_; }
 void Runtime::set_gm_sm_ptr(void *p) { gm_sm_ptr_ = p; }
-void Runtime::set_slot_states_ptr(void *p) { slot_states_ptr_ = p; }
 // The one place a boundary ChipTensor becomes this runtime's Tensor. Called from
 // the host, before any orchestration runs, so nothing inside the runtime — on the
 // host or on the AICPU — ever holds the boundary form.

--- a/src/common/host_build_graph/shared/runtime_core.cpp
+++ b/src/common/host_build_graph/shared/runtime_core.cpp
@@ -212,7 +212,7 @@ static bool wait_for_tensor_ready(
         auto &tasks = orch.sm_header->tasks;
         int32_t local_id = static_cast<int32_t>(simpler::hbg::task_local_id(producer));
         auto &slot = tasks.get_slot_state_by_task_id(local_id);
-        if (slot.task == nullptr || slot.task->task_id != producer) {
+        if (slot.to_descriptor().task_id != producer) {
             orch.report_fatal(
                 SIMPLER_ERROR_INVALID_ARGS, caller,
                 "tensor producer task %#llx does not match the descriptor bound to slot %d",
@@ -225,7 +225,7 @@ static bool wait_for_tensor_ready(
     };
 
     auto wait_one_producer = [&](const ChipTaskSlotState &slot) {
-        int32_t local_id = static_cast<int32_t>(simpler::hbg::task_local_id(slot.task->task_id));
+        int32_t local_id = static_cast<int32_t>(simpler::hbg::task_local_id(slot.to_descriptor().task_id));
         uint64_t t0 = get_sys_cnt_aicpu();
         int32_t spin_count = 0;
         while (slot.task_state.load(std::memory_order_acquire) < CHIP_TASK_COMPLETED) {
@@ -251,7 +251,7 @@ static bool wait_for_tensor_ready(
     };
 
     auto wait_one_consumers = [&](const ChipTaskSlotState &slot) {
-        int32_t local_id = simpler::hbg::task_local_id(slot.task->task_id);
+        int32_t local_id = simpler::hbg::task_local_id(slot.to_descriptor().task_id);
         uint64_t t0 = get_sys_cnt_aicpu();
         int32_t spin_count = 0;
         // Polling: all consumers of this producer have retired once the

--- a/src/common/host_build_graph/shared/shared_memory.cpp
+++ b/src/common/host_build_graph/shared/shared_memory.cpp
@@ -41,19 +41,17 @@ void SharedMemoryHandle::setup_pointers(uint64_t pitch) {
     char *base = (char *)sm_base;
     header = (SharedMemoryHeader *)base;
 
-    // descriptors / payloads / slot_states — offsets from the single source
+    // storage / completion_flags — offsets from the single source
     // of truth (sm_layout::segment_offsets), so this setup and the
     // device-address helpers cannot drift.
     //
-    // Only the four slot-pitched segments, and no argument pool: the pool extents
-    // differ between the mirror and the image, while these four depend on the pitch
+    // Only the two slot-pitched segments, and no argument pool: the pool extents
+    // differ between the mirror and the image, while these two depend on the pitch
     // alone. The orchestrator holds the mirror's pool bases; the device resolves an
     // argument region through the payload's delta and needs no base at all.
     auto off = sm_layout::segment_offsets(sm_layout::image_extents({pitch, 0, 0, 0}));
     auto &tasks = header->tasks;
-    tasks.task_descriptors = (TaskDescriptor *)(base + off.descriptors);
-    tasks.task_payloads = (TaskPayload *)(base + off.payloads);
-    tasks.slot_states = (ChipTaskSlotState *)(base + off.slot_states);
+    tasks.task_storage = (ChipTaskStorage *)(base + off.storage);
     tasks.completion_flags = (std::atomic<uint8_t> *)(base + off.completion_flags);
 }
 
@@ -83,21 +81,20 @@ bool SharedMemoryHandle::attach_populated(
 ) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
     // A pitch above `max_tasks` names a slot the host could not have built, and one
-    // below what the host used would place every segment past the descriptors
+    // below what the host used would place every segment past the storage
     // short. This is the whole contract between the two sides, checked once at
     // attach rather than trusted.
     if (live_slots == 0 || live_slots > max_tasks) return false;
-    // The image must at least hold the four slot-pitched segments; anything beyond
+    // The image must at least hold the two slot-pitched segments; anything beyond
     // that is its argument pools, whose extents are the bind's cursors and are not
-    // recomputable here. The first pool's offset is exactly where those four end.
+    // recomputable here. The first pool's offset is exactly where those two end.
     const uint64_t slots_end = sm_layout::segment_offsets(sm_layout::image_extents({live_slots, 0, 0, 0})).fanin_pool;
     if (image_bytes < slots_end) return false;
     // The region holds the compacted image, so that is what has to fit — the
     // dimensioned size is no longer its size.
     if (sm_size_arg < image_bytes) return false;
-    // A slot state names its payload and descriptor by an int32 delta from its own
-    // address, and a payload names its argument regions the same way, so no two
-    // positions in the image may be further apart than that.
+    // A payload names its argument regions by an int32 delta from its own address, so
+    // no two positions in the image may be further apart than that.
     if (image_bytes > static_cast<uint64_t>(INT32_MAX)) return false;
 
     sm_base = sm_base_arg;
@@ -105,7 +102,7 @@ bool SharedMemoryHandle::attach_populated(
     is_owner = false;
     setup_pointers(live_slots);
     // Deliberately NO init_header: the SM already holds the host orchestrator's
-    // task graph (descriptors, slot states, completion flags).
+    // task graph (storage entries and completion flags).
     return true;
 }
 
@@ -151,7 +148,7 @@ void SharedMemoryHandle::init_header() {
     header->sched_error_code.store(SIMPLER_ERROR_NONE, std::memory_order_relaxed);
     header->sched_error_thread.store(-1, std::memory_order_relaxed);
 
-    // Per-slot init (slot_states.reset_for_reuse() + active_mask, and clearing the
+    // Per-slot init (slot.reset_for_reuse() + active_mask, and clearing the
     // completion flag) happens init-on-write in orch::prepare_task as each slot
     // [0, total_tasks) is claimed, so the SM init/upload cost tracks the task
     // count, not the size the table was dimensioned for. The device reads no slot

--- a/src/common/host_build_graph/shared_memory.h
+++ b/src/common/host_build_graph/shared_memory.h
@@ -17,9 +17,10 @@
  *   +---------------------------+
  *   | SharedMemoryHeader        |  (completion watermark + scheduler error state)
  *   +---------------------------+
- *   | TaskDescriptor[]          |
- *   | TaskPayload[]             |
- *   | ChipTaskSlotState[]       |
+ *   | ChipTaskStorage[]         |  (descriptor + slot state + payload, per task)
+ *   | std::atomic<uint8_t>[]    |  (completion flags, one byte per task)
+ *   +---------------------------+
+ *   | fanin / tensor / scalar   |  (the argument pools payloads name by delta)
  *   +---------------------------+
  *
  * Design principles:
@@ -68,25 +69,28 @@ struct alignas(64) SharedMemoryTaskHeader {
     // (concurrent CAS-advance by completing threads).
     alignas(64) std::atomic<int32_t> completed_watermark;
 
-    // Segment pointers (host-side, set by setup_pointers)
-    alignas(64) TaskDescriptor *task_descriptors;
-    TaskPayload *task_payloads;
-    ChipTaskSlotState *slot_states;
+    // The task storage array (host-side, set by setup_pointers). One entry per slot,
+    // holding that task's descriptor, slot state and payload — see ChipTaskStorage.
+    alignas(64) ChipTaskStorage *task_storage;
 
     // Polling-completion state (device-addressed array, one byte per slot).
     // 0 = pending, 1 = task fully COMPLETED. Writer = the task's completer at
     // on_mixed_task_complete; reader = consumer fanin polling (is_completion_flag_set).
     // Cleared per-slot in orch::prepare_task as each slot is claimed. Indexed by
-    // local task id, like every other segment — so it covers GLOBAL tasks only. An
+    // local task id, like the storage array — so it covers GLOBAL tasks only. An
     // IN_GRAPH task holds no slot here and publishes completion through its own
     // ChipTaskSlotState::task_state instead; the Graph's outer shell is the GLOBAL
     // task that carries a flag for the whole body.
+    //
+    // A byte array of its own rather than a field of ChipTaskStorage: a fanin scan
+    // reads many producers' flags at once, which one cache line answers here and
+    // would take one line per producer inside the storage stride.
     //
     // A hidden-alloc task is the one flag the host presets to 1: it completes during
     // orchestration, and a consumer polls this array rather than task_state.
     std::atomic<uint8_t> *completion_flags;
 
-    // Tasks this run submitted, i.e. the slot count the four segments above are
+    // Tasks this run submitted, i.e. the slot count the two segments above are
     // pitched to. Written once by the host after orchestration (run_host_orchestration)
     // and read-only from then on, so it packs into the padding rather than taking a
     // line of its own. Bounds the completed_watermark walk: no slot at or above it was
@@ -126,23 +130,18 @@ struct alignas(64) SharedMemoryTaskHeader {
         }
     }
 
-    // A task id is its own slot index, so every segment is indexed directly.
-    TaskDescriptor &get_task_by_task_id(int32_t local_id) { return task_descriptors[local_id]; }
-
-    // No get_payload_by_task_id here: a payload is reached through its slot
-    // state's `payload` delta, which the image's restack rebinds to the real
-    // address.
-
-    ChipTaskSlotState &get_slot_state_by_task_id(int32_t local_id) { return slot_states[local_id]; }
+    // A task id is its own storage index, so the three records it names are reached
+    // by one index into one array.
+    ChipTaskStorage &storage_at(int32_t local_id) { return task_storage[local_id]; }
+    TaskDescriptor &get_task_by_task_id(int32_t local_id) { return task_storage[local_id].task; }
+    ChipTaskSlotState &get_slot_state_by_task_id(int32_t local_id) { return task_storage[local_id].slot; }
 };
 
 static_assert(sizeof(SharedMemoryTaskHeader) == 128, "SharedMemoryTaskHeader layout drift");
-static_assert(
-    offsetof(SharedMemoryTaskHeader, task_descriptors) == 64, "SharedMemoryTaskHeader task_descriptors layout drift"
-);
+static_assert(offsetof(SharedMemoryTaskHeader, task_storage) == 64, "SharedMemoryTaskHeader task_storage layout drift");
 // The device reads this one out of the H2D'd header, so it is pinned separately from the
 // segment pointers above, which are host-side only.
-static_assert(offsetof(SharedMemoryTaskHeader, total_tasks) == 96, "SharedMemoryTaskHeader total_tasks layout drift");
+static_assert(offsetof(SharedMemoryTaskHeader, total_tasks) == 80, "SharedMemoryTaskHeader total_tasks layout drift");
 
 /**
  * Shared memory header structure
@@ -206,7 +205,7 @@ struct SharedMemoryHandle {
     bool init(void *sm_base, uint64_t sm_size, uint64_t max_tasks);
 
     // Attach to an ALREADY-populated shared memory region: point the handle and
-    // the task header's segment pointers (descriptors / payloads / slot_states)
+    // the task header's segment pointers (storage / completion flags)
     // at `sm_base`, but do NOT reset the watermark / slot states.
     // Used by host_build_graph host-orch, where the host orchestrator populated
     // the SM and H2D'd it; the device must re-point at its own SM base without
@@ -215,7 +214,7 @@ struct SharedMemoryHandle {
     // `live_slots` is the pitch the uploaded arrays were laid out with — the
     // number of slots the host actually submitted, not the `max_tasks` the mirror
     // was dimensioned for. It must match what the host used or every segment past
-    // the descriptors resolves to the wrong address, so both sides derive it from
+    // the storage resolves to the wrong address, so both sides derive it from
     // the same count.
     // Every task id is below it, and indexes its slot directly.
     //
@@ -242,8 +241,8 @@ private:
 // =============================================================================
 //
 // When the host pre-builds a runtime-arena image, it needs the device-side
-// addresses of several SM sub-fields (the task header, the task_descriptors
-// arrays) so it can wire them into the scheduler init_data path without
+// addresses of several SM sub-fields (the task header, the task storage
+// array) so it can wire them into the scheduler init_data path without
 // dereferencing the SM — the SM lives in device memory and cannot be touched
 // from host.
 //
@@ -260,18 +259,20 @@ inline SharedMemoryTaskHeader *task_header_addr(void *sm_dev_base) noexcept {
 }
 
 // Byte offsets (from the SM base) of the image's segments. The layout is: header, then
-// descriptors -> payloads -> slot_states -> completion_flags -> the three argument
-// pools, every segment CHIP_ALIGN_UP-padded. ImageExtents dimensions them: the
-// mirror for the worst case the API allows, the image for what this bind holds, which
-// is what makes the live prefixes contiguous and the upload one copy.
+// storage -> completion_flags -> the three argument pools, every segment
+// CHIP_ALIGN_UP-padded. ImageExtents dimensions them: the mirror for the worst case the
+// API allows, the image for what this bind holds, which is what makes the live prefixes
+// contiguous and the upload one copy.
+//
+// One storage segment, not three: a task's descriptor, slot state and payload sit in one
+// ChipTaskStorage, so their relative positions are that type's layout and survive the
+// restack's change of pitch untouched.
 //
 // The pools sit last because nothing on the device resolves a segment past
-// completion_flags: a payload names its argument regions by delta, so the four
+// completion_flags: a payload names its argument regions by delta, so the two
 // slot-pitched offsets are all the attach path computes.
 struct SegmentOffsets {
-    uint64_t descriptors;
-    uint64_t payloads;
-    uint64_t slot_states;
+    uint64_t storage;
     uint64_t completion_flags;  // polling-completion byte array (1 byte/slot)
     uint64_t fanin_pool;
     uint64_t tensor_pool;
@@ -307,12 +308,8 @@ inline ImageExtents mirror_extents(uint64_t max_tasks) noexcept {
 inline SegmentOffsets segment_offsets(const ImageExtents &e) noexcept {
     uint64_t off = CHIP_ALIGN_UP(sizeof(SharedMemoryHeader), CHIP_ALIGN_SIZE);
     SegmentOffsets o{};
-    o.descriptors = off;
-    off += CHIP_ALIGN_UP(e.slots * sizeof(TaskDescriptor), CHIP_ALIGN_SIZE);
-    o.payloads = off;
-    off += CHIP_ALIGN_UP(e.slots * sizeof(TaskPayload), CHIP_ALIGN_SIZE);
-    o.slot_states = off;
-    off += CHIP_ALIGN_UP(e.slots * sizeof(ChipTaskSlotState), CHIP_ALIGN_SIZE);
+    o.storage = off;
+    off += CHIP_ALIGN_UP(e.slots * sizeof(ChipTaskStorage), CHIP_ALIGN_SIZE);
     o.completion_flags = off;
     off += CHIP_ALIGN_UP(e.slots * sizeof(std::atomic<uint8_t>), CHIP_ALIGN_SIZE);
     o.fanin_pool = off;
@@ -406,11 +403,12 @@ inline uint64_t rebased_heap_addr(uint64_t addr, const HeapRebase &rebase) noexc
 //   - the task header's segment pointers name the mirror's arrays, so they leave as
 //     null rather than carrying host addresses into device memory (the device
 //     resolves them in attach_populated);
-//   - a slot state names its payload and descriptor, and a payload names its three
-//     argument regions, by a delta from the naming field's own address; the restack
-//     changed those distances, so every one is re-taken against the image. A region
-//     keeps its position within its pool, so the re-take is the same arithmetic with
-//     the image's bases;
+//   - a payload names its three argument regions by a delta from the naming field's
+//     own address; the restack changed those distances, so every one is re-taken
+//     against the image. A region keeps its position within its pool, so the re-take
+//     is the same arithmetic with the image's bases. A task's own three records need
+//     no such re-take: they share one ChipTaskStorage, so their distances are that
+//     type's layout and the change of pitch cannot reach them;
 //   - every heap address the orchestrator wrote is in the HEAP_VIRTUAL_BASE window,
 //     so `rebase` moves it onto the device region committed after orchestration.
 //     Three fields carry one: a descriptor's packed buffer bounds (read on the
@@ -438,21 +436,18 @@ inline uint64_t compact_live_image(
     const SegmentOffsets from = segment_offsets(mirror);
     const SegmentOffsets to = segment_offsets(image_extents(used));
 
-    // The header and the descriptors offset are pitch-independent, so the header
+    // The header and the storage offset are pitch-independent, so the header
     // lands where it already was.
-    std::memcpy(out_base, mirror_base, to.descriptors);
+    std::memcpy(out_base, mirror_base, to.storage);
     auto &out_tasks = reinterpret_cast<SharedMemoryHeader *>(out_base)->tasks;
-    out_tasks.task_descriptors = nullptr;
-    out_tasks.task_payloads = nullptr;
-    out_tasks.slot_states = nullptr;
+    out_tasks.task_storage = nullptr;
     out_tasks.completion_flags = nullptr;
 
     const uint64_t nt = used.submitted_tasks;
-    std::memcpy(out_base + to.descriptors, mirror_base + from.descriptors, nt * sizeof(TaskDescriptor));
-    // One copy, not one per payload: TaskPayload is fixed-size, so the mirror and
-    // the image share a stride. Each pool is likewise one copy of its own prefix.
-    std::memcpy(out_base + to.payloads, mirror_base + from.payloads, nt * sizeof(TaskPayload));
-    std::memcpy(out_base + to.slot_states, mirror_base + from.slot_states, nt * sizeof(ChipTaskSlotState));
+    // One copy for all three of a task's records: ChipTaskStorage is fixed-size, so
+    // the mirror and the image share a stride. Each pool is likewise one copy of its
+    // own prefix.
+    std::memcpy(out_base + to.storage, mirror_base + from.storage, nt * sizeof(ChipTaskStorage));
     std::memcpy(out_base + to.completion_flags, mirror_base + from.completion_flags, nt * sizeof(std::atomic<uint8_t>));
     std::memcpy(out_base + to.fanin_pool, mirror_base + from.fanin_pool, used.fanin_elems * sizeof(int32_t));
     std::memcpy(
@@ -460,10 +455,8 @@ inline uint64_t compact_live_image(
     );
     std::memcpy(out_base + to.scalar_pool, mirror_base + from.scalar_pool, used.scalar_elems * sizeof(uint64_t));
 
-    auto *out_slots = reinterpret_cast<ChipTaskSlotState *>(out_base + to.slot_states);
-    auto *out_descriptors = reinterpret_cast<TaskDescriptor *>(out_base + to.descriptors);
-    auto *out_payloads = reinterpret_cast<TaskPayload *>(out_base + to.payloads);
-    const auto *mirror_payloads = reinterpret_cast<const TaskPayload *>(mirror_base + from.payloads);
+    auto *out_storage = reinterpret_cast<ChipTaskStorage *>(out_base + to.storage);
+    const auto *mirror_storage = reinterpret_cast<const ChipTaskStorage *>(mirror_base + from.storage);
     auto *out_fanin = reinterpret_cast<int32_t *>(out_base + to.fanin_pool);
     auto *out_tensors = reinterpret_cast<simpler::hbg::Tensor *>(out_base + to.tensor_pool);
     auto *out_scalars = reinterpret_cast<uint64_t *>(out_base + to.scalar_pool);
@@ -476,8 +469,9 @@ inline uint64_t compact_live_image(
     // pool — and the translation below depends on it, so it is asserted rather than
     // re-derived.
     for (uint64_t i = 0; i < nt; ++i) {
-        out_slots[i].bind_buffers(&out_payloads[i], &out_descriptors[i]);
-        const TaskPayload &src = mirror_payloads[i];
+        ChipTaskStorage &out_entry = out_storage[i];
+        TaskPayload &out_payload = out_entry.payload;
+        const TaskPayload &src = mirror_storage[i].payload;
         const simpler::hbg::Tensor *src_tensors = src.tensor_data();
         const uint64_t *src_scalars = src.scalar_data();
         const int32_t *src_fanin = src.fanin_data();
@@ -492,7 +486,7 @@ inline uint64_t compact_live_image(
         debug_assert(
             src_fanin == nullptr || (src_fanin >= mirror_fanin && src_fanin <= mirror_fanin + used.fanin_elems)
         );
-        out_payloads[i].bind_regions(
+        out_payload.bind_regions(
             src_tensors == nullptr ? nullptr : out_tensors + (src_tensors - mirror_tensors),
             src_scalars == nullptr ? nullptr : out_scalars + (src_scalars - mirror_scalars),
             src_fanin == nullptr ? nullptr : out_fanin + (src_fanin - mirror_fanin)
@@ -503,24 +497,24 @@ inline uint64_t compact_live_image(
         // simpler::hbg::Tensor slots graph_boundary_tensor_pool_slots reserves for them. Walking
         // the pool itself as one simpler::hbg::Tensor array would reach only the first boundary
         // of each Graph and rewrite bytes in the middle of the rest.
-        if (out_slots[i].task_kind == TaskKind::GRAPH) {
-            auto *boundaries = reinterpret_cast<GraphTensor *>(out_payloads[i].tensor_data());
-            for (int32_t j = 0; j < out_payloads[i].tensor_count; ++j) {
+        if (out_entry.slot.task_kind == TaskKind::GRAPH) {
+            auto *boundaries = reinterpret_cast<GraphTensor *>(out_payload.tensor_data());
+            for (int32_t j = 0; j < out_payload.tensor_count; ++j) {
                 boundaries[j].buffer_addr = rebased_heap_addr(boundaries[j].buffer_addr, rebase);
             }
         } else {
-            simpler::hbg::Tensor *tensors = out_payloads[i].tensor_data();
-            for (int32_t j = 0; j < out_payloads[i].tensor_count; ++j) {
+            simpler::hbg::Tensor *tensors = out_payload.tensor_data();
+            for (int32_t j = 0; j < out_payload.tensor_count; ++j) {
                 tensors[j].buffer.addr = rebased_heap_addr(tensors[j].buffer.addr, rebase);
             }
         }
-        TaskDescriptor &out_task = out_descriptors[i];
+        TaskDescriptor &out_task = out_entry.task;
         out_task.packed_buffer_base = reinterpret_cast<void *>(
             rebased_heap_addr(reinterpret_cast<uint64_t>(out_task.packed_buffer_base), rebase)
         );
         out_task.packed_buffer_end =
             reinterpret_cast<void *>(rebased_heap_addr(reinterpret_cast<uint64_t>(out_task.packed_buffer_end), rebase));
-        out_payloads[i].predicate.addr = rebased_heap_addr(out_payloads[i].predicate.addr, rebase);
+        out_payload.predicate.addr = rebased_heap_addr(out_payload.predicate.addr, rebase);
     }
     return to.end;
 }

--- a/src/common/platform/include/aicpu/args_dump_aicpu.h
+++ b/src/common/platform/include/aicpu/args_dump_aicpu.h
@@ -93,23 +93,30 @@ bool has_dump_arg_flag(ArgsDumpArgMask arg_mask, int32_t arg_index);
 bool try_log_dump_args_layout_mismatch();
 int dump_arg_record(int thread_idx, const ArgsDumpInfo &info);
 
-template <int MaxSubtaskSlots, typename SlotStateT, typename IsSubtaskActiveFn, typename GetFunctionBinAddrFn>
+// Takes the three records it reads rather than a slot state to reach them from.
+// The two runtimes hold that relation differently — a ring slot names its records by
+// pointer, host_build_graph's storage by layout — and neither is this dump's concern,
+// so a caller passes what it already has in hand. The types differ per runtime too,
+// hence the deduced parameters.
+template <
+    int MaxSubtaskSlots, typename TaskDescriptorT, typename TaskPayloadT, typename ActiveMaskT,
+    typename IsSubtaskActiveFn, typename GetFunctionBinAddrFn>
 inline void dump_args_for_task(
-    int32_t thread_idx, const SlotStateT &slot_state, ArgsDumpStage stage, IsSubtaskActiveFn is_subtask_active,
-    GetFunctionBinAddrFn get_function_bin_addr, const ArgsDumpTaskMetadata *task_metadata = nullptr
+    int32_t thread_idx, const TaskDescriptorT &descriptor, const TaskPayloadT &pl, const ActiveMaskT &active_mask,
+    ArgsDumpStage stage, IsSubtaskActiveFn is_subtask_active, GetFunctionBinAddrFn get_function_bin_addr,
+    const ArgsDumpTaskMetadata *task_metadata = nullptr
 ) {
     // The record's func_ids[] must hold every active subtask's id. MaxSubtaskSlots
     // is SUBTASK_SLOT_COUNT at every call site, so this ties the record array
     // size (platform layer) to the runtime subtask cap and catches any drift.
     static_assert(MaxSubtaskSlots <= ARGS_DUMP_MAX_FUNC_IDS, "ARGS_DUMP_MAX_FUNC_IDS must cover MaxSubtaskSlots");
-    const auto &pl = *slot_state.payload;
     ArgsDumpArgMask dump_arg_mask = ARGS_DUMP_ARG_MASK_NONE;
     ArgsDumpArgMask dump_arg_flags = ARGS_DUMP_ARG_MASK_NONE;
     if (task_metadata != nullptr) {
         dump_arg_mask = task_metadata->dump_arg_mask;
         dump_arg_flags = task_metadata->dump_arg_flags;
     } else if (should_load_dump_args_task_masks()) {
-        get_dump_args_task_masks(slot_state.task->task_id.raw, &dump_arg_mask, &dump_arg_flags);
+        get_dump_args_task_masks(descriptor.task_id.raw, &dump_arg_mask, &dump_arg_flags);
     }
     if (!should_dump_task(dump_arg_mask)) {
         return;
@@ -123,10 +130,10 @@ inline void dump_args_for_task(
     const CoreCallable *sig_src = nullptr;
 
     for (int raw_subtask_id = 0; raw_subtask_id < MaxSubtaskSlots; raw_subtask_id++) {
-        if (!is_subtask_active(slot_state.active_mask, raw_subtask_id)) {
+        if (!is_subtask_active(active_mask, raw_subtask_id)) {
             continue;
         }
-        uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[raw_subtask_id]);
+        uint64_t callable_addr = get_function_bin_addr(descriptor.kernel_id[raw_subtask_id]);
         if (callable_addr == 0) {
             return;
         }
@@ -135,7 +142,7 @@ inline void dump_args_for_task(
             sig_src = cand;
         }
         if (active_count < ARGS_DUMP_MAX_FUNC_IDS) {
-            active_fids[active_count++] = slot_state.task->kernel_id[raw_subtask_id];
+            active_fids[active_count++] = descriptor.kernel_id[raw_subtask_id];
         }
     }
     if (sig_src == nullptr) {
@@ -189,7 +196,7 @@ inline void dump_args_for_task(
             info.shapes[d] = t.shapes[d];
             info.strides[d] = t.strides[d];
         }
-        info.task_id = slot_state.task->task_id.raw;
+        info.task_id = descriptor.task_id.raw;
         info.arg_index = slot;
         info.role = role;
         info.stage = stage;
@@ -209,7 +216,7 @@ inline void dump_args_for_task(
         LOG_WARN(
             "Thread %d: task 0x%" PRIx64
             ": signature covers %d tensor slots but payload has %d; the rest are not dumped.",
-            thread_idx, static_cast<uint64_t>(slot_state.task->task_id.raw), covered_count, pl.tensor_count
+            thread_idx, static_cast<uint64_t>(descriptor.task_id.raw), covered_count, pl.tensor_count
         );
     }
 
@@ -225,7 +232,7 @@ inline void dump_args_for_task(
             has_scalar_dtypes = true;
         } else {
             has_scalar_dtypes =
-                get_dump_args_task_scalar_dtypes(slot_state.task->task_id.raw, &dtype_scalar_count, scalar_dtypes);
+                get_dump_args_task_scalar_dtypes(descriptor.task_id.raw, &dtype_scalar_count, scalar_dtypes);
         }
         const uint64_t *pl_scalars = pl.scalar_data();
         for (int32_t scalar_index = 0; scalar_index < pl.scalar_count; scalar_index++) {
@@ -234,7 +241,7 @@ inline void dump_args_for_task(
                 continue;
             }
             ArgsDumpInfo info = {};
-            info.task_id = slot_state.task->task_id.raw;
+            info.task_id = descriptor.task_id.raw;
             info.role = ArgsDumpRole::INPUT;
             info.stage = stage;
             info.dtype = (has_scalar_dtypes && scalar_index < static_cast<int32_t>(dtype_scalar_count)) ?
@@ -272,15 +279,12 @@ inline void dump_args_for_task(
 //                              nullptr if idle. A cluster's cores share one
 //                              SlotState pointer; pointer identity is used to
 //                              emit each running task exactly once.
-//   is_subtask_active / get_function_bin_addr — same callbacks as
-//   dump_args_for_task.
-template <
-    int MaxSubtaskSlots, typename GetRunningSlotFn, typename IsSubtaskActiveFn, typename GetFunctionBinAddrFn,
-    typename GetTaskMetadataFn>
-inline void dump_running_task_outputs(
-    int32_t thread_idx, int32_t cores_total_num, GetRunningSlotFn get_running_slot, IsSubtaskActiveFn is_subtask_active,
-    GetFunctionBinAddrFn get_function_bin_addr, GetTaskMetadataFn get_task_metadata
-) {
+//   dump_one(slot)          -> dumps that task, by calling dump_args_for_task with
+//                              the records the caller's own slot representation
+//                              reaches. Keeping the extraction there is what lets
+//                              the two runtimes hold that relation differently.
+template <typename GetRunningSlotFn, typename DumpOneFn>
+inline void dump_running_task_outputs(int32_t cores_total_num, GetRunningSlotFn get_running_slot, DumpOneFn dump_one) {
     for (int32_t cid = 0; cid < cores_total_num; cid++) {
         auto *running = get_running_slot(cid);
         if (running == nullptr) {
@@ -297,24 +301,8 @@ inline void dump_running_task_outputs(
         if (already_dumped) {
             continue;
         }
-        dump_args_for_task<MaxSubtaskSlots>(
-            thread_idx, *running, ArgsDumpStage::AFTER_COMPLETION, is_subtask_active, get_function_bin_addr,
-            get_task_metadata(*running)
-        );
+        dump_one(*running);
     }
-}
-
-template <int MaxSubtaskSlots, typename GetRunningSlotFn, typename IsSubtaskActiveFn, typename GetFunctionBinAddrFn>
-inline void dump_running_task_outputs(
-    int32_t thread_idx, int32_t cores_total_num, GetRunningSlotFn get_running_slot, IsSubtaskActiveFn is_subtask_active,
-    GetFunctionBinAddrFn get_function_bin_addr
-) {
-    dump_running_task_outputs<MaxSubtaskSlots>(
-        thread_idx, cores_total_num, get_running_slot, is_subtask_active, get_function_bin_addr,
-        [](const auto &) -> const ArgsDumpTaskMetadata * {
-            return nullptr;
-        }
-    );
 }
 
 template <typename TensorInfoT>

--- a/tests/ut/cpp/a2a3/test_graph_activation.cpp
+++ b/tests/ut/cpp/a2a3/test_graph_activation.cpp
@@ -58,15 +58,14 @@ protected:
     // One in-graph task whose slot is a routable single-block KERNEL/AIC
     // task in the given completion state, with its payload wired the way
     // materialization leaves it for the wake/route path.
-    static void init_in_graph_task(InGraphTaskStorage &task, int32_t task_index, ChipTaskState state) {
-        memset(&task, 0, sizeof(InGraphTaskStorage));
+    static void init_in_graph_task(ChipTaskStorage &task, int32_t task_index, ChipTaskState state) {
+        memset(&task, 0, sizeof(ChipTaskStorage));
         task.slot.task_state.store(state);
         task.slot.in_graph_task_index = task_index;
         task.slot.active_mask = ActiveMask(SUBTASK_MASK_AIC);
         task.slot.task_kind = TaskKind::KERNEL;
         task.slot.total_required_subtasks = 1;
         task.slot.logical_block_num = 1;
-        task.slot.payload.set(&task.payload);
     }
 };
 
@@ -74,7 +73,7 @@ protected:
 // == SENTINEL) reaches graph_first_unmet_producer, which reads task_state and
 // routes it — it is never lost on the closed wake list.
 TEST_F(GraphActivationTest, WakeRoutesConsumerWhenProducerCompletedBeforeRegister) {
-    auto tasks = std::make_unique<InGraphTaskStorage[]>(2);
+    auto tasks = std::make_unique<ChipTaskStorage[]>(2);
     init_in_graph_task(tasks[0], 0, CHIP_TASK_COMPLETED);    // producer, already completed
     init_in_graph_task(tasks[1], 1, CHIP_TASK_PENDING);      // consumer of task 0
     tasks[0].slot.wake_list_head.store(WAKE_LIST_SENTINEL);  // its wake list already drained
@@ -98,7 +97,7 @@ TEST_F(GraphActivationTest, WakeRoutesConsumerWhenProducerCompletedBeforeRegiste
 // publish time, and wake-chains one with a still-pending producer so it
 // routes exactly once that producer completes and drains its wake list.
 TEST_F(GraphActivationTest, IncrementalPublishRoutesCompletedDepsAndWakeChainsPending) {
-    auto tasks = std::make_unique<InGraphTaskStorage[]>(4);
+    auto tasks = std::make_unique<ChipTaskStorage[]>(4);
     init_in_graph_task(tasks[0], 0, CHIP_TASK_COMPLETED);  // root, completed
     init_in_graph_task(tasks[1], 1, CHIP_TASK_PENDING);    // root, pending
     init_in_graph_task(tasks[2], 2, CHIP_TASK_PENDING);    // consumer of task 0 (completed)
@@ -133,11 +132,10 @@ TEST_F(GraphActivationTest, IncrementalPublishRoutesCompletedDepsAndWakeChainsPe
 TEST_F(GraphActivationTest, CompleteTaskAcceptsCompletionBeforeActive) {
     GraphDefinition definition{};
     auto complete_in_state = [&](GraphExecutionState state) {
-        auto task = std::make_unique<InGraphTaskStorage[]>(1);
-        memset(task.get(), 0, sizeof(InGraphTaskStorage));
+        auto task = std::make_unique<ChipTaskStorage[]>(1);
+        memset(task.get(), 0, sizeof(ChipTaskStorage));
         task[0].slot.in_graph_task_index = 0;
         task[0].slot.total_required_subtasks = 1;
-        task[0].slot.payload.set(&task[0].payload);
 
         GraphExecution exec{};
         exec.definition = &definition;
@@ -170,11 +168,12 @@ TEST_F(GraphActivationTest, CompleteTaskAcceptsCompletionBeforeActive) {
 // struct's layout, no fault and no error code.
 TEST_F(GraphActivationTest, CompleteTaskTakesTheOrdinaryPathForTheOuterGraphTask) {
     GraphDefinition definition{};
-    TaskDescriptor outer_task{};
-    outer_task.task_id = simpler::hbg::make_global_task(0);
+    // A whole storage entry, not a bare slot state: a slot reaches its descriptor by
+    // ChipTaskStorage's layout, so one on its own would resolve outside itself.
+    ChipTaskStorage outer{};
+    outer.task.task_id = simpler::hbg::make_global_task(0);
 
-    ChipTaskSlotState slot{};
-    slot.task.set(&outer_task);
+    ChipTaskSlotState &slot = outer.slot;
     slot.task_kind = TaskKind::GRAPH;
     slot.graph_context = &definition;
 

--- a/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
@@ -76,15 +76,13 @@ protected:
         sm_arena.release();
     }
 
-    // Fill the task table (descriptors / payloads / slot_states / completion_flags)
-    // with poison. init_header wrote only the header, so this is the state the table
+    // Fill the task table (storage entries / completion_flags) with poison.
+    // init_header wrote only the header, so this is the state the table
     // is in before any submit writes it — modelling the never-zeroed device SM.
     void poison_task_table() {
         auto &tasks = sm_handle->header->tasks;
         const size_t n = static_cast<size_t>(CHIP_DEFAULT_GRAPH_TASKS);
-        std::memset(tasks.task_descriptors, POISON, n * sizeof(TaskDescriptor));
-        std::memset(tasks.task_payloads, POISON, n * sizeof(TaskPayload));
-        std::memset(tasks.slot_states, POISON, n * sizeof(ChipTaskSlotState));
+        std::memset(tasks.task_storage, POISON, n * sizeof(ChipTaskStorage));
         std::memset(tasks.completion_flags, POISON, n * sizeof(std::atomic<uint8_t>));
     }
 };
@@ -136,9 +134,10 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     // Every claimed slot's device-read fields must carry real values, not poison.
     for (int32_t local = 0; local < total; local++) {
         SCOPED_TRACE(testing::Message() << "slot local_id=" << local);
-        const TaskDescriptor &desc = tasks.task_descriptors[local];
-        const TaskPayload &pl = tasks.task_payloads[local];
-        const ChipTaskSlotState &st = tasks.slot_states[local];
+        const ChipTaskStorage &entry = tasks.storage_at(local);
+        const TaskDescriptor &desc = entry.task;
+        const TaskPayload &pl = entry.payload;
+        const ChipTaskSlotState &st = entry.slot;
 
         // Descriptor: the task id is written to this exact local id.
         EXPECT_EQ(simpler::hbg::task_local_id(desc.task_id), static_cast<uint32_t>(local));
@@ -165,8 +164,9 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     }
 
     // Field-specific coverage on the real task: tensors, scalar, packed output buffer.
-    const TaskDescriptor &root_desc = tasks.task_descriptors[simpler::hbg::task_local_id(root.task_id())];
-    const TaskPayload &root_pl = tasks.task_payloads[simpler::hbg::task_local_id(root.task_id())];
+    const ChipTaskStorage &root_entry = tasks.storage_at(simpler::hbg::task_local_id(root.task_id()));
+    const TaskDescriptor &root_desc = root_entry.task;
+    const TaskPayload &root_pl = root_entry.payload;
     EXPECT_EQ(root_pl.tensor_count, 1);
     EXPECT_EQ(root_pl.scalar_count, 1);
     EXPECT_EQ(root_pl.dump_metadata.dump_arg_mask, (uint64_t{1} << 0) | (uint64_t{1} << 1));
@@ -177,7 +177,7 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     EXPECT_EQ(root_desc.kernel_id[static_cast<int>(SubtaskSlot::AIV0)], 0);
 
     // The consumer's fanin is written: two duplicate deps dedupe to one.
-    const TaskPayload &cons_pl = tasks.task_payloads[simpler::hbg::task_local_id(consumer.task_id())];
+    const TaskPayload &cons_pl = tasks.storage_at(simpler::hbg::task_local_id(consumer.task_id())).payload;
     EXPECT_EQ(cons_pl.fanin_count, 1);
     EXPECT_EQ(cons_pl.fanin_data()[0], static_cast<int32_t>(simpler::hbg::task_local_id(root.task_id())));
 }

--- a/tests/ut/cpp/a5/test_graph_activation.cpp
+++ b/tests/ut/cpp/a5/test_graph_activation.cpp
@@ -58,15 +58,14 @@ protected:
     // One in-graph task whose slot is a routable single-block KERNEL/AIC
     // task in the given completion state, with its payload wired the way
     // materialization leaves it for the wake/route path.
-    static void init_in_graph_task(InGraphTaskStorage &task, int32_t task_index, ChipTaskState state) {
-        memset(&task, 0, sizeof(InGraphTaskStorage));
+    static void init_in_graph_task(ChipTaskStorage &task, int32_t task_index, ChipTaskState state) {
+        memset(&task, 0, sizeof(ChipTaskStorage));
         task.slot.task_state.store(state);
         task.slot.in_graph_task_index = task_index;
         task.slot.active_mask = ActiveMask(SUBTASK_MASK_AIC);
         task.slot.task_kind = TaskKind::KERNEL;
         task.slot.total_required_subtasks = 1;
         task.slot.logical_block_num = 1;
-        task.slot.payload.set(&task.payload);
     }
 };
 
@@ -74,7 +73,7 @@ protected:
 // == SENTINEL) reaches graph_first_unmet_producer, which reads task_state and
 // routes it — it is never lost on the closed wake list.
 TEST_F(GraphActivationTest, WakeRoutesConsumerWhenProducerCompletedBeforeRegister) {
-    auto tasks = std::make_unique<InGraphTaskStorage[]>(2);
+    auto tasks = std::make_unique<ChipTaskStorage[]>(2);
     init_in_graph_task(tasks[0], 0, CHIP_TASK_COMPLETED);    // producer, already completed
     init_in_graph_task(tasks[1], 1, CHIP_TASK_PENDING);      // consumer of task 0
     tasks[0].slot.wake_list_head.store(WAKE_LIST_SENTINEL);  // its wake list already drained
@@ -98,7 +97,7 @@ TEST_F(GraphActivationTest, WakeRoutesConsumerWhenProducerCompletedBeforeRegiste
 // publish time, and wake-chains one with a still-pending producer so it
 // routes exactly once that producer completes and drains its wake list.
 TEST_F(GraphActivationTest, IncrementalPublishRoutesCompletedDepsAndWakeChainsPending) {
-    auto tasks = std::make_unique<InGraphTaskStorage[]>(4);
+    auto tasks = std::make_unique<ChipTaskStorage[]>(4);
     init_in_graph_task(tasks[0], 0, CHIP_TASK_COMPLETED);  // root, completed
     init_in_graph_task(tasks[1], 1, CHIP_TASK_PENDING);    // root, pending
     init_in_graph_task(tasks[2], 2, CHIP_TASK_PENDING);    // consumer of task 0 (completed)
@@ -133,11 +132,10 @@ TEST_F(GraphActivationTest, IncrementalPublishRoutesCompletedDepsAndWakeChainsPe
 TEST_F(GraphActivationTest, CompleteTaskAcceptsCompletionBeforeActive) {
     GraphDefinition definition{};
     auto complete_in_state = [&](GraphExecutionState state) {
-        auto task = std::make_unique<InGraphTaskStorage[]>(1);
-        memset(task.get(), 0, sizeof(InGraphTaskStorage));
+        auto task = std::make_unique<ChipTaskStorage[]>(1);
+        memset(task.get(), 0, sizeof(ChipTaskStorage));
         task[0].slot.in_graph_task_index = 0;
         task[0].slot.total_required_subtasks = 1;
-        task[0].slot.payload.set(&task[0].payload);
 
         GraphExecution exec{};
         exec.definition = &definition;
@@ -170,11 +168,12 @@ TEST_F(GraphActivationTest, CompleteTaskAcceptsCompletionBeforeActive) {
 // struct's layout, no fault and no error code.
 TEST_F(GraphActivationTest, CompleteTaskTakesTheOrdinaryPathForTheOuterGraphTask) {
     GraphDefinition definition{};
-    TaskDescriptor outer_task{};
-    outer_task.task_id = simpler::hbg::make_global_task(0);
+    // A whole storage entry, not a bare slot state: a slot reaches its descriptor by
+    // ChipTaskStorage's layout, so one on its own would resolve outside itself.
+    ChipTaskStorage outer{};
+    outer.task.task_id = simpler::hbg::make_global_task(0);
 
-    ChipTaskSlotState slot{};
-    slot.task.set(&outer_task);
+    ChipTaskSlotState &slot = outer.slot;
     slot.task_kind = TaskKind::GRAPH;
     slot.graph_context = &definition;
 

--- a/tests/ut/cpp/a5/test_hbg_scheduler_contracts.cpp
+++ b/tests/ut/cpp/a5/test_hbg_scheduler_contracts.cpp
@@ -48,19 +48,18 @@ public:
         while (capacity_ < std::max<size_t>(task_count, 1))
             capacity_ <<= 1;
         if (capacity_ > kMaxTaskCount) throw std::invalid_argument("test graph exceeds GraphBuffer capacity");
-        descriptors_ = image_->descriptors.data();
-        payloads_ = image_->payloads.data();
+        storage_ = image_->storage.data();
         fanins_ = image_->fanins.data();
         for (size_t task = 0; task < capacity_; ++task) {
-            descriptors_[task].task_id = TaskId{static_cast<uint64_t>(task)};
-            payloads_[task].bind_regions(
+            storage_[task].task.task_id = TaskId{static_cast<uint64_t>(task)};
+            storage_[task].payload.bind_regions(
                 nullptr, nullptr, fanins_ + task * static_cast<size_t>(SCHEDULER_GRAPH_MAX_FANIN)
             );
-            if (payloads_[task].fanin_data() == nullptr) {
+            if (storage_[task].payload.fanin_data() == nullptr) {
                 throw std::logic_error("test graph fanin region must share its contiguous image");
             }
             for (int slot = 0; slot < 3; ++slot)
-                descriptors_[task].kernel_id[slot] = INVALID_KERNEL_ID;
+                storage_[task].task.kernel_id[slot] = INVALID_KERNEL_ID;
         }
     }
 
@@ -68,18 +67,19 @@ public:
         ASSERT_LT(task, task_count_);
         ASSERT_LT(subtask_slot, 3);
         ASSERT_LE(fanins.size(), static_cast<size_t>(SCHEDULER_GRAPH_MAX_FANIN));
-        descriptors_[task].kernel_id[subtask_slot] = 1;
-        payloads_[task].fanin_count = static_cast<int32_t>(fanins.size());
-        ASSERT_TRUE(fanins.empty() || payloads_[task].fanin_data() != nullptr);
-        std::copy(fanins.begin(), fanins.end(), payloads_[task].fanin_data());
+        storage_[task].task.kernel_id[subtask_slot] = 1;
+        storage_[task].payload.fanin_count = static_cast<int32_t>(fanins.size());
+        ASSERT_TRUE(fanins.empty() || storage_[task].payload.fanin_data() != nullptr);
+        std::copy(fanins.begin(), fanins.end(), storage_[task].payload.fanin_data());
     }
 
-    TaskPayload &payload(size_t task) { return payloads_[task]; }
+    TaskPayload &payload(size_t task) { return storage_[task].payload; }
+    ChipTaskStorage *storage() { return storage_; }
 
     SchedulerGraphView graph() const {
         return {
-            reinterpret_cast<uint64_t>(descriptors_),
-            reinterpret_cast<uint64_t>(payloads_),
+            reinterpret_cast<uint64_t>(storage_),
+            0,
             task_count_,
             capacity_ - 1,
         };
@@ -87,22 +87,27 @@ public:
 
 private:
     static constexpr size_t kMaxTaskCount = 16;
+    // One storage array, as production has it — the descriptor and payload of a
+    // task are members of one entry. Two parallel arrays would model the layout
+    // this runtime no longer uses and would let the wire strides drift unnoticed.
     struct alignas(64) GraphImage {
-        std::array<TaskDescriptor, kMaxTaskCount> descriptors{};
-        std::array<TaskPayload, kMaxTaskCount> payloads{};
+        std::array<ChipTaskStorage, kMaxTaskCount> storage{};
         std::array<int32_t, kMaxTaskCount * SCHEDULER_GRAPH_MAX_FANIN> fanins{};
     };
 
     size_t task_count_;
     size_t capacity_{1};
     std::unique_ptr<GraphImage> image_;
-    TaskDescriptor *descriptors_{nullptr};
-    TaskPayload *payloads_{nullptr};
+    ChipTaskStorage *storage_{nullptr};
     int32_t *fanins_{nullptr};
 };
 
 TEST(SchedulerState, PlansAndInitializesReadyState) {
-    EXPECT_EQ(sizeof(TaskPayload), SCHEDULER_GRAPH_TASK_PAYLOAD_STRIDE);
+    // The reverse lookup for the wire constants AICore addresses with. They are
+    // literals there because the AICore .o cannot see these types; here it can.
+    EXPECT_EQ(sizeof(ChipTaskStorage), SCHEDULER_GRAPH_TASK_STORAGE_STRIDE);
+    EXPECT_EQ(offsetof(ChipTaskStorage, task), SCHEDULER_GRAPH_DESCRIPTOR_OFFSET);
+    EXPECT_EQ(offsetof(ChipTaskStorage, payload), SCHEDULER_GRAPH_PAYLOAD_OFFSET);
     EXPECT_EQ(offsetof(TaskPayload, predicate), SCHEDULER_GRAPH_PREDICATE_OFFSET);
     AicoreSchedulerLayout layout{};
     ASSERT_TRUE(scheduler_plan_layout(5, 3, 2, &layout));
@@ -182,28 +187,60 @@ TEST(SchedulerMetadata, ProjectsExistingSubmitTypesWithoutChangingTheirSemantics
     EXPECT_EQ(inline_flags, SCHEDULER_TASK_EXECUTABLE | SCHEDULER_TASK_INLINE);
 }
 
+// AICore addresses a task's records by literal offsets, because its .o cannot see
+// the types. The reverse lookup in PlansAndInitializesReadyState only proves the
+// constants carry the right values; it cannot catch a helper that strides by the
+// wrong one. That failure is invisible at task 0 — every candidate stride agrees
+// there — so this walks several tasks and checks both records of each against the
+// entry they belong to.
+TEST(SchedulerGraph, AddressesEveryTaskAtTheStorageStride) {
+    constexpr size_t kTasks = 4;
+    struct alignas(64) GraphImage {
+        std::array<ChipTaskStorage, kTasks> storage{};
+    } image;
+    auto &storage = image.storage;
+    SchedulerGraphView graph{reinterpret_cast<uint64_t>(storage.data()), 0, kTasks, kTasks - 1};
+
+    for (size_t task = 0; task < kTasks; ++task) {
+        SCOPED_TRACE(testing::Message() << "task " << task);
+        EXPECT_EQ(
+            scheduler_graph_descriptor(graph, static_cast<int64_t>(task)),
+            reinterpret_cast<uint8_t *>(&storage[task].task)
+        );
+        EXPECT_EQ(
+            scheduler_graph_payload(graph, static_cast<int64_t>(task)),
+            reinterpret_cast<uint8_t *>(&storage[task].payload)
+        );
+    }
+
+    // Consecutive tasks are one whole storage apart, not one record apart. The
+    // pre-merge strides (64 for a descriptor, 192 for a payload) satisfy the loop
+    // above at task 0 and fail it everywhere else; this states the step directly.
+    const auto *first = scheduler_graph_descriptor(graph, 0);
+    const auto *second = scheduler_graph_descriptor(graph, 1);
+    EXPECT_EQ(second - first, SCHEDULER_GRAPH_TASK_STORAGE_STRIDE);
+    EXPECT_EQ(scheduler_graph_payload(graph, 0) - scheduler_graph_descriptor(graph, 0), SCHEDULER_GRAPH_PAYLOAD_OFFSET);
+}
+
 TEST(SchedulerGraph, NonPowerOfTwoWindowKeepsDirectTaskIdIndexing) {
     struct alignas(64) GraphImage {
-        std::array<TaskDescriptor, 3> descriptors{};
-        std::array<TaskPayload, 3> payloads{};
+        std::array<ChipTaskStorage, 3> storage{};
         std::array<std::array<int32_t, SCHEDULER_GRAPH_MAX_FANIN>, 3> fanins{};
     } image;
-    auto &descriptors = image.descriptors;
-    auto &payloads = image.payloads;
+    auto &storage = image.storage;
     auto &fanins = image.fanins;
-    for (size_t task = 0; task < descriptors.size(); ++task) {
-        descriptors[task].task_id = TaskId{task};
+    for (size_t task = 0; task < storage.size(); ++task) {
+        storage[task].task.task_id = TaskId{task};
         for (int slot = 0; slot < 3; ++slot)
-            descriptors[task].kernel_id[slot] = INVALID_KERNEL_ID;
-        payloads[task].bind_regions(nullptr, nullptr, fanins[task].data());
+            storage[task].task.kernel_id[slot] = INVALID_KERNEL_ID;
+        storage[task].payload.bind_regions(nullptr, nullptr, fanins[task].data());
     }
-    descriptors[1].kernel_id[0] = 1;
-    SchedulerGraphView graph{
-        reinterpret_cast<uint64_t>(descriptors.data()), reinterpret_cast<uint64_t>(payloads.data()), 3, 2
-    };
+    storage[1].task.kernel_id[0] = 1;
+    SchedulerGraphView graph{reinterpret_cast<uint64_t>(storage.data()), 0, 3, 2};
 
-    EXPECT_EQ(scheduler_graph_descriptor(graph, 1), reinterpret_cast<uint8_t *>(&descriptors[1]));
-    EXPECT_EQ(scheduler_graph_payload(graph, 1), reinterpret_cast<uint8_t *>(&payloads[1]));
+    // Both records of task 1 resolve from the one base, at that entry's stride.
+    EXPECT_EQ(scheduler_graph_descriptor(graph, 1), reinterpret_cast<uint8_t *>(&storage[1].task));
+    EXPECT_EQ(scheduler_graph_payload(graph, 1), reinterpret_cast<uint8_t *>(&storage[1].payload));
     SchedulerTaskShape shape{};
     EXPECT_EQ(scheduler_classify_task_shape(graph, 1, &shape), SchedulerGraphResult::OK);
     EXPECT_EQ(shape.task_id, 1);
@@ -228,6 +265,28 @@ TEST(SchedulerGraph, RejectsUnboundNonEmptyFaninRegion) {
 
     SchedulerTaskShape shape{};
     EXPECT_EQ(scheduler_classify_task_shape(graph.graph(), 1, &shape), SchedulerGraphResult::INVALID_FANIN_ID);
+}
+
+// The view's reserved word exists so its wire size survived the collapse from two
+// addresses to one. A non-zero read means the producer is writing a field this
+// build does not know about, so both entry points refuse rather than proceed on a
+// view they cannot fully interpret.
+TEST(SchedulerGraph, RejectsAViewWithANonZeroReservedWord) {
+    GraphBuffer graph(1);
+    graph.executable(0, 0);
+
+    SchedulerGraphView dirty = graph.graph();
+    dirty.reserved = 1;
+
+    SchedulerTaskShape shape{};
+    EXPECT_EQ(scheduler_classify_task_shape(dirty, 0, &shape), SchedulerGraphResult::INVALID_ARGUMENTS);
+
+    DispatchPayload payload{};
+    SchedulerTaskInfo task{0, 1, 0, CoreType::AIC};
+    EXPECT_EQ(
+        scheduler_materialize_task_payload_resolved(dirty, task, 0x1000, &payload),
+        SchedulerGraphResult::INVALID_ARGUMENTS
+    );
 }
 
 TEST(SchedulerDispatchPayload, DisablesDeferredCompletionWithoutASlab) {
@@ -262,11 +321,11 @@ TEST(SchedulerDispatchPayload, RejectsInvalidGraphBoundsBeforeReadingPayload) {
         SchedulerGraphResult::INVALID_TASK_COUNT
     );
 
-    SchedulerGraphView missing_payload = graph.graph();
-    missing_payload.payloads_address = 0;
+    SchedulerGraphView missing_storage = graph.graph();
+    missing_storage.storage_address = 0;
     SchedulerTaskInfo valid_task{0, 1, 0, CoreType::AIC};
     EXPECT_EQ(
-        scheduler_materialize_task_payload_resolved(missing_payload, valid_task, 0x1000, &payload),
+        scheduler_materialize_task_payload_resolved(missing_storage, valid_task, 0x1000, &payload),
         SchedulerGraphResult::INVALID_TASK_COUNT
     );
 }

--- a/tests/ut/cpp/a5/test_hbg_scheduler_ready.cpp
+++ b/tests/ut/cpp/a5/test_hbg_scheduler_ready.cpp
@@ -48,19 +48,18 @@ public:
         while (capacity_ < std::max<size_t>(task_count, 1))
             capacity_ <<= 1;
         if (capacity_ > kMaxTaskCount) throw std::invalid_argument("test graph exceeds GraphBuffer capacity");
-        descriptors_ = image_->descriptors.data();
-        payloads_ = image_->payloads.data();
+        storage_ = image_->storage.data();
         fanins_ = image_->fanins.data();
         for (size_t task = 0; task < capacity_; ++task) {
-            descriptors_[task].task_id = TaskId{static_cast<uint64_t>(task)};
-            payloads_[task].bind_regions(
+            storage_[task].task.task_id = TaskId{static_cast<uint64_t>(task)};
+            storage_[task].payload.bind_regions(
                 nullptr, nullptr, fanins_ + task * static_cast<size_t>(SCHEDULER_GRAPH_MAX_FANIN)
             );
-            if (payloads_[task].fanin_data() == nullptr) {
+            if (storage_[task].payload.fanin_data() == nullptr) {
                 throw std::logic_error("test graph fanin region must share its contiguous image");
             }
             for (int slot = 0; slot < 3; ++slot)
-                descriptors_[task].kernel_id[slot] = INVALID_KERNEL_ID;
+                storage_[task].task.kernel_id[slot] = INVALID_KERNEL_ID;
         }
     }
 
@@ -68,32 +67,32 @@ public:
         ASSERT_LT(task, task_count_);
         ASSERT_LT(subtask_slot, 3);
         ASSERT_LE(fanins.size(), static_cast<size_t>(SCHEDULER_GRAPH_MAX_FANIN));
-        descriptors_[task].kernel_id[subtask_slot] = 1;
-        payloads_[task].fanin_count = static_cast<int32_t>(fanins.size());
-        ASSERT_TRUE(fanins.empty() || payloads_[task].fanin_data() != nullptr);
-        std::copy(fanins.begin(), fanins.end(), payloads_[task].fanin_data());
+        storage_[task].task.kernel_id[subtask_slot] = 1;
+        storage_[task].payload.fanin_count = static_cast<int32_t>(fanins.size());
+        ASSERT_TRUE(fanins.empty() || storage_[task].payload.fanin_data() != nullptr);
+        std::copy(fanins.begin(), fanins.end(), storage_[task].payload.fanin_data());
     }
 
     void mixed(size_t task, uint8_t active_mask) {
         ASSERT_LT(task, task_count_);
         for (uint8_t subtask_slot = 0; subtask_slot < 3; ++subtask_slot) {
-            if ((active_mask & (1U << subtask_slot)) != 0) descriptors_[task].kernel_id[subtask_slot] = 1;
+            if ((active_mask & (1U << subtask_slot)) != 0) storage_[task].task.kernel_id[subtask_slot] = 1;
         }
-        payloads_[task].fanin_count = 0;
+        storage_[task].payload.fanin_count = 0;
     }
 
     void predicate(size_t task, uint64_t addr, uint8_t elem_size, uint8_t op, int64_t target = 0) {
         ASSERT_LT(task, task_count_);
-        payloads_[task].predicate.addr = addr;
-        payloads_[task].predicate.target = target;
-        payloads_[task].predicate.elem_size = elem_size;
-        payloads_[task].predicate.op = static_cast<PredicateOp>(op);
+        storage_[task].payload.predicate.addr = addr;
+        storage_[task].payload.predicate.target = target;
+        storage_[task].payload.predicate.elem_size = elem_size;
+        storage_[task].payload.predicate.op = static_cast<PredicateOp>(op);
     }
 
     SchedulerGraphView graph() const {
         return {
-            reinterpret_cast<uint64_t>(descriptors_),
-            reinterpret_cast<uint64_t>(payloads_),
+            reinterpret_cast<uint64_t>(storage_),
+            0,
             task_count_,
             capacity_ - 1,
         };
@@ -101,17 +100,17 @@ public:
 
 private:
     static constexpr size_t kMaxTaskCount = 8192;
+    // One storage array, as production has it — see the same note in
+    // test_hbg_scheduler_contracts.cpp.
     struct alignas(64) GraphImage {
-        std::array<TaskDescriptor, kMaxTaskCount> descriptors{};
-        std::array<TaskPayload, kMaxTaskCount> payloads{};
+        std::array<ChipTaskStorage, kMaxTaskCount> storage{};
         std::array<int32_t, kMaxTaskCount * SCHEDULER_GRAPH_MAX_FANIN> fanins{};
     };
 
     size_t task_count_;
     size_t capacity_{1};
     std::unique_ptr<GraphImage> image_;
-    TaskDescriptor *descriptors_{nullptr};
-    TaskPayload *payloads_{nullptr};
+    ChipTaskStorage *storage_{nullptr};
     int32_t *fanins_{nullptr};
 };
 

--- a/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
@@ -75,15 +75,13 @@ protected:
         sm_arena.release();
     }
 
-    // Fill the task table (descriptors / payloads / slot_states / completion_flags)
-    // with poison. init_header wrote only the header, so this is the state the table
+    // Fill the task table (storage entries / completion_flags) with poison.
+    // init_header wrote only the header, so this is the state the table
     // is in before any submit writes it — modelling the never-zeroed device SM.
     void poison_task_table() {
         auto &tasks = sm_handle->header->tasks;
         const size_t n = static_cast<size_t>(CHIP_DEFAULT_GRAPH_TASKS);
-        std::memset(tasks.task_descriptors, POISON, n * sizeof(TaskDescriptor));
-        std::memset(tasks.task_payloads, POISON, n * sizeof(TaskPayload));
-        std::memset(tasks.slot_states, POISON, n * sizeof(ChipTaskSlotState));
+        std::memset(tasks.task_storage, POISON, n * sizeof(ChipTaskStorage));
         std::memset(tasks.completion_flags, POISON, n * sizeof(std::atomic<uint8_t>));
     }
 };
@@ -135,9 +133,10 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     // Every claimed slot's device-read fields must carry real values, not poison.
     for (int32_t local = 0; local < total; local++) {
         SCOPED_TRACE(testing::Message() << "slot local_id=" << local);
-        const TaskDescriptor &desc = tasks.task_descriptors[local];
-        const TaskPayload &pl = tasks.task_payloads[local];
-        const ChipTaskSlotState &st = tasks.slot_states[local];
+        const ChipTaskStorage &entry = tasks.storage_at(local);
+        const TaskDescriptor &desc = entry.task;
+        const TaskPayload &pl = entry.payload;
+        const ChipTaskSlotState &st = entry.slot;
 
         // Descriptor: the task id is written to this exact local id.
         EXPECT_EQ(simpler::hbg::task_local_id(desc.task_id), static_cast<uint32_t>(local));
@@ -164,8 +163,9 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     }
 
     // Field-specific coverage on the real task: tensors, scalar, packed output buffer.
-    const TaskDescriptor &root_desc = tasks.task_descriptors[simpler::hbg::task_local_id(root.task_id())];
-    const TaskPayload &root_pl = tasks.task_payloads[simpler::hbg::task_local_id(root.task_id())];
+    const ChipTaskStorage &root_entry = tasks.storage_at(simpler::hbg::task_local_id(root.task_id()));
+    const TaskDescriptor &root_desc = root_entry.task;
+    const TaskPayload &root_pl = root_entry.payload;
     EXPECT_EQ(root_pl.tensor_count, 1);
     EXPECT_EQ(root_pl.scalar_count, 1);
     EXPECT_EQ(root_pl.dump_metadata.dump_arg_mask, (uint64_t{1} << 0) | (uint64_t{1} << 1));
@@ -176,7 +176,7 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     EXPECT_EQ(root_desc.kernel_id[static_cast<int>(SubtaskSlot::AIV0)], 0);
 
     // The consumer's fanin is written: two duplicate deps dedupe to one.
-    const TaskPayload &cons_pl = tasks.task_payloads[simpler::hbg::task_local_id(consumer.task_id())];
+    const TaskPayload &cons_pl = tasks.storage_at(simpler::hbg::task_local_id(consumer.task_id())).payload;
     EXPECT_EQ(cons_pl.fanin_count, 1);
     EXPECT_EQ(cons_pl.fanin_data()[0], static_cast<int32_t>(simpler::hbg::task_local_id(root.task_id())));
 }

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -162,11 +162,11 @@ class AlignedStorage {
 public:
     explicit AlignedStorage(size_t bytes, uint8_t fill = 0) :
         bytes_(bytes) {
-        data_ = ::operator new(bytes, std::align_val_t(alignof(InGraphTaskStorage)));
+        data_ = ::operator new(bytes, std::align_val_t(alignof(ChipTaskStorage)));
         std::memset(data_, fill, bytes);
     }
 
-    ~AlignedStorage() { ::operator delete(data_, std::align_val_t(alignof(InGraphTaskStorage))); }
+    ~AlignedStorage() { ::operator delete(data_, std::align_val_t(alignof(ChipTaskStorage))); }
 
     void *data() const { return data_; }
     uint8_t *bytes() const { return static_cast<uint8_t *>(data_); }
@@ -198,11 +198,10 @@ public:
         const auto *definition = reinterpret_cast<const GraphDefinition *>(definition_image.data());
         heap_bytes_ = static_cast<size_t>(definition->required_heap);
         storage_ = std::make_unique<AlignedStorage>(heap_bytes_ + definition->execution_storage_bytes, fill);
-        task_.packed_buffer_base = base();
-        task_.packed_buffer_end = end();
-        slot_.task_kind = TaskKind::GRAPH;
-        slot_.bind_buffers(&payload_, &task_);
-        payload_.bind_regions(boundary_tensors_.data(), boundary_scalars_.data(), nullptr);
+        storage_entry_.task.packed_buffer_base = base();
+        storage_entry_.task.packed_buffer_end = end();
+        storage_entry_.slot.task_kind = TaskKind::GRAPH;
+        storage_entry_.payload.bind_regions(boundary_tensors_.data(), boundary_scalars_.data(), nullptr);
     }
 
     uint8_t *base() const { return storage_->bytes(); }
@@ -230,22 +229,23 @@ public:
         std::memset(boundary_tensors_.data(), 0, TENSOR_SLOTS * sizeof(simpler::hbg::Tensor));
         const GraphTensor boundary = make_test_tensor(boundary_address);
         new (boundary_tensors_.data()) GraphTensor{boundary};
-        payload_.tensor_count = static_cast<int32_t>(definition->boundary_count);
-        payload_.scalar_count = static_cast<int32_t>(definition->boundary_scalar_count);
+        storage_entry_.payload.tensor_count = static_cast<int32_t>(definition->boundary_count);
+        storage_entry_.payload.scalar_count = static_cast<int32_t>(definition->boundary_scalar_count);
         std::fill_n(boundary_scalars_.data(), definition->boundary_scalar_count, uint64_t{0});
         if (definition->boundary_scalar_count != 0) {
             boundary_scalars_[definition->boundary_scalar_count - 1] = boundary_scalar;
         }
-        slot_.graph_context = const_cast<GraphDefinition *>(definition);
-        return graph_execution_localize(slot_);
+        storage_entry_.slot.graph_context = const_cast<GraphDefinition *>(definition);
+        return graph_execution_localize(storage_entry_.slot);
     }
 
 private:
     size_t heap_bytes_{0};
     std::unique_ptr<AlignedStorage> storage_;
-    TaskDescriptor task_{};
-    TaskPayload payload_{};
-    ChipTaskSlotState slot_{};
+    // One storage entry, as production has it: a slot state reaches its descriptor
+    // and payload by ChipTaskStorage's layout, so three separate members would
+    // resolve outside themselves.
+    ChipTaskStorage storage_entry_{};
     std::array<simpler::hbg::Tensor, TENSOR_SLOTS> boundary_tensors_{};
     std::array<uint64_t, SCALAR_SPAN> boundary_scalars_{};
 };
@@ -315,9 +315,9 @@ TEST(GraphExecutionStorage, ComputesAlignedExactSize) {
     GraphExecutionStorageLayout layout{};
 
     ASSERT_TRUE(graph_execution_storage_layout(TASK_COUNT, TENSOR_ARGS, SCALAR_ARGS, &layout));
-    EXPECT_EQ(layout.tasks_offset % alignof(InGraphTaskStorage), 0U);
+    EXPECT_EQ(layout.tasks_offset % alignof(ChipTaskStorage), 0U);
     EXPECT_GE(layout.tasks_offset, sizeof(GraphExecution));
-    EXPECT_EQ(layout.tensors_offset, layout.tasks_offset + TASK_COUNT * sizeof(InGraphTaskStorage));
+    EXPECT_EQ(layout.tensors_offset, layout.tasks_offset + TASK_COUNT * sizeof(ChipTaskStorage));
     EXPECT_EQ(layout.tensors_offset % alignof(simpler::hbg::Tensor), 0U);
     EXPECT_EQ(layout.scalars_offset, layout.tensors_offset + TENSOR_ARGS * sizeof(simpler::hbg::Tensor));
     EXPECT_EQ(layout.total_bytes, layout.scalars_offset + SCALAR_ARGS * sizeof(uint64_t));
@@ -375,7 +375,7 @@ TEST(GraphExecutionStorage, RejectsInvalidInGraphTaskCount) {
     EXPECT_FALSE(graph_execution_storage_bytes(static_cast<int32_t>(MAX_IN_GRAPH_TASKS) + 1, 1, 1, &storage_bytes));
     // A Definition with no arguments at all still needs its in-graph task array.
     EXPECT_TRUE(graph_execution_storage_bytes(1, 0, 0, &storage_bytes));
-    EXPECT_GE(storage_bytes, sizeof(GraphExecution) + sizeof(InGraphTaskStorage));
+    EXPECT_GE(storage_bytes, sizeof(GraphExecution) + sizeof(ChipTaskStorage));
 }
 
 // A resubmission gets the same heap tail back, so the bytes it starts from are
@@ -394,20 +394,22 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
         heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(first_boundary.data()), 17);
     ASSERT_NE(execution, nullptr);
 
-    TaskDescriptor outer_task{};
+    // A whole storage entry: the slot reaches its descriptor by ChipTaskStorage's
+    // layout, so a bare slot state would resolve outside itself.
+    ChipTaskStorage outer{};
+    TaskDescriptor &outer_task = outer.task;
     outer_task.task_id = simpler::hbg::make_global_task(7);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
-    ChipTaskSlotState outer_slot{};
+    ChipTaskSlotState &outer_slot = outer.slot;
     outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task.set(&outer_task);
     outer_slot.graph_context = execution;
 
     // The execution and in-graph task storage both occupy the outer heap tail after
     // required_heap.
     EXPECT_EQ(static_cast<void *>(execution), heap.execution());
     EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
-    InGraphTaskStorage &storage = execution->task_at(0);
+    ChipTaskStorage &storage = execution->task_at(0);
     ASSERT_EQ(storage.payload.scalar_count, 1);
     ASSERT_EQ(storage.payload.tensor_count, 1);
     EXPECT_EQ(storage.payload.scalar_data()[0], 17U);
@@ -470,13 +472,13 @@ TEST(GraphExecutionReplay, MaterializesBoundaryScalarPoolWiderThanTaskPayload) {
         heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(boundary.data()), 21);
     ASSERT_NE(execution, nullptr);
 
-    TaskDescriptor outer_task{};
+    ChipTaskStorage outer{};
+    TaskDescriptor &outer_task = outer.task;
     outer_task.task_id = simpler::hbg::make_global_task(7);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
-    ChipTaskSlotState outer_slot{};
+    ChipTaskSlotState &outer_slot = outer.slot;
     outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task.set(&outer_task);
     outer_slot.graph_context = execution;
 
     EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
@@ -657,7 +659,7 @@ TEST(GraphExecutionErrors, InvalidInGraphTaskCompletionIsReported) {
 TEST(GraphExecutionProgress, InGraphTaskResolutionIsNotAHostCompletion) {
     SchedulerState scheduler{};
     GraphDefinition definition{};
-    InGraphTaskStorage task{};
+    ChipTaskStorage task{};
     GraphExecution execution{};
     execution.definition = &definition;
     execution.tasks = &task;
@@ -696,13 +698,13 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
         heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(boundary.data()), 17);
     ASSERT_NE(execution, nullptr);
 
-    TaskDescriptor outer_task{};
+    ChipTaskStorage outer{};
+    TaskDescriptor &outer_task = outer.task;
     outer_task.task_id = simpler::hbg::make_global_task(5);
     outer_task.packed_buffer_base = heap.base();
     outer_task.packed_buffer_end = heap.end();
-    ChipTaskSlotState outer_slot{};
+    ChipTaskSlotState &outer_slot = outer.slot;
     outer_slot.task_kind = TaskKind::GRAPH;
-    outer_slot.task.set(&outer_task);
     outer_slot.graph_context = execution;
 
     EXPECT_EQ(static_cast<void *>(execution), heap.execution());
@@ -712,7 +714,7 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
     // not the 0xAA fill: state machine, counters and atomics all start from
     // values only the device side wrote.
     for (int32_t i = 0; i < execution->task_count; ++i) {
-        const InGraphTaskStorage &storage = execution->task_at(i);
+        const ChipTaskStorage &storage = execution->task_at(i);
         ASSERT_EQ(storage.slot.task_state.load(std::memory_order_relaxed), CHIP_TASK_PENDING);
         ASSERT_EQ(storage.slot.task_kind, TaskKind::KERNEL);
         ASSERT_EQ(storage.slot.completed_subtasks.load(std::memory_order_relaxed), 0);

--- a/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
@@ -48,7 +48,7 @@ protected:
 
     // A Graph task's heap allocation covers its tasks' packed outputs *and* the
     // execution storage the device materializes into, so the pool has to hold a
-    // GraphExecution header plus one InGraphTaskStorage (~5 KB) on top of the
+    // GraphExecution header plus one ChipTaskStorage (~5 KB) on top of the
     // outputs. 4 KB used to be enough when the storage came from a separate
     // device allocation.
     static constexpr size_t HEAP_BYTES = 64 * 1024;
@@ -133,10 +133,10 @@ TEST_F(HbgGraphSubmitFailureTest, InFlightGraphInvocationsReserveHeapOnlyAtCommi
     // Distinct bases alone would still pass if finalization handed out a wrong
     // extent, so pin the length the Definition asks for and the disjointness two
     // shells of one Graph must have.
-    const auto *first_base = static_cast<const char *>(first_upload->outer_slot->task->packed_buffer_base);
-    const auto *first_end = static_cast<const char *>(first_upload->outer_slot->task->packed_buffer_end);
-    const auto *second_base = static_cast<const char *>(second_upload->outer_slot->task->packed_buffer_base);
-    const auto *second_end = static_cast<const char *>(second_upload->outer_slot->task->packed_buffer_end);
+    const auto *first_base = static_cast<const char *>(first_upload->outer_slot->to_descriptor().packed_buffer_base);
+    const auto *first_end = static_cast<const char *>(first_upload->outer_slot->to_descriptor().packed_buffer_end);
+    const auto *second_base = static_cast<const char *>(second_upload->outer_slot->to_descriptor().packed_buffer_base);
+    const auto *second_end = static_cast<const char *>(second_upload->outer_slot->to_descriptor().packed_buffer_end);
     const GraphHostDefinitionList definitions = graph_host_definitions(*graph_state);
     ASSERT_EQ(definitions.entries.size(), 1u);
     ASSERT_EQ(definitions.entries[0].full_key, first_upload->full_key);
@@ -258,8 +258,8 @@ TEST_F(HbgGraphSubmitFailureTest, WorkerRecordsWhileMainThreadSubmitsSameHashShe
         const std::optional<GraphHostUpload> upload = graph_host_upload(*graph_state, i);
         ASSERT_TRUE(upload.has_value());
         EXPECT_EQ(upload->full_key, definition->full_key) << "shell " << i;
-        const auto *base = static_cast<const char *>(upload->outer_slot->task->packed_buffer_base);
-        const auto *end = static_cast<const char *>(upload->outer_slot->task->packed_buffer_end);
+        const auto *base = static_cast<const char *>(upload->outer_slot->to_descriptor().packed_buffer_base);
+        const auto *end = static_cast<const char *>(upload->outer_slot->to_descriptor().packed_buffer_end);
         EXPECT_EQ(static_cast<uint64_t>(end - base), expected_extent) << "shell " << i;
         ranges.emplace_back(base, end);
     }
@@ -719,8 +719,8 @@ TEST_F(HbgGraphSubmitFailureTest, ConcurrentDefinitionsFinalizeInSubmissionOrder
         const std::optional<GraphHostUpload> upload = graph_host_upload(*graph_state, i);
         ASSERT_TRUE(upload.has_value()) << "Graph " << i;
         EXPECT_NE(upload->full_key, 0u) << "Graph " << i;
-        const auto *base = static_cast<const char *>(upload->outer_slot->task->packed_buffer_base);
-        const auto *end = static_cast<const char *>(upload->outer_slot->task->packed_buffer_end);
+        const auto *base = static_cast<const char *>(upload->outer_slot->to_descriptor().packed_buffer_base);
+        const auto *end = static_cast<const char *>(upload->outer_slot->to_descriptor().packed_buffer_end);
         ASSERT_NE(base, nullptr) << "Graph " << i;
         ASSERT_GT(end, base) << "Graph " << i;
         if (previous_end != nullptr) {
@@ -820,7 +820,7 @@ TEST_F(HbgGraphSubmitFailureTest, AnOrdinaryAllocationInterleavesWithADeferredSh
         << "the shell's block sits above the ordinary task's, not before it";
     SharedMemoryTaskHeader &tasks = sm_handle->header->tasks;
     const int32_t shell_slot = static_cast<int32_t>(simpler::hbg::task_local_id(graph.task_id));
-    const TaskDescriptor *shell = tasks.slot_states[shell_slot].task.get();
+    const TaskDescriptor *shell = &tasks.storage_at(shell_slot).task;
     ASSERT_NE(shell, nullptr);
     ASSERT_NE(shell->packed_buffer_base, nullptr);
     EXPECT_GE(
@@ -956,8 +956,8 @@ TEST_F(HbgGraphSubmitFailureTest, RecordsAGraphWhoseBoundaryLivesInTheHeapWindow
 // storage is reused raw memory that no constructor runs over, and compact_live_image
 // translates every submitted slot's predicate.addr as a graph-heap address.
 TEST_F(HbgGraphSubmitFailureTest, AHiddenAllocTaskLeavesItsDispatchPredicateDefined) {
-    TaskPayload *payloads = sm_handle->header->tasks.task_payloads;
-    ASSERT_NE(payloads, nullptr);
+    ChipTaskStorage *storage = sm_handle->header->tasks.task_storage;
+    ASSERT_NE(storage, nullptr);
     // 0x4A repeated has 01 as its top two bits, so read as an address it lands
     // inside [HEAP_VIRTUAL_BASE, GRAPH_RECORD_VIRTUAL_BASE) — the quarter of the
     // 64-bit range that the rebase would mistake for a graph-heap allocation. The
@@ -965,10 +965,10 @@ TEST_F(HbgGraphSubmitFailureTest, AHiddenAllocTaskLeavesItsDispatchPredicateDefi
     // slot is poisoned the way a reused one would be.
     constexpr int kPoisonedSlots = 8;
     for (int i = 0; i < kPoisonedSlots; ++i) {
-        std::memset(&payloads[i].predicate, 0x4A, sizeof(payloads[i].predicate));
+        std::memset(&storage[i].payload.predicate, 0x4A, sizeof(storage[i].payload.predicate));
     }
-    ASSERT_GE(payloads[0].predicate.addr, HEAP_VIRTUAL_BASE);
-    ASSERT_LT(payloads[0].predicate.addr, GRAPH_RECORD_VIRTUAL_BASE);
+    ASSERT_GE(storage[0].payload.predicate.addr, HEAP_VIRTUAL_BASE);
+    ASSERT_LT(storage[0].payload.predicate.addr, GRAPH_RECORD_VIRTUAL_BASE);
 
     orch.begin_scope();
     uint32_t shape[] = {16};
@@ -981,6 +981,6 @@ TEST_F(HbgGraphSubmitFailureTest, AHiddenAllocTaskLeavesItsDispatchPredicateDefi
 
     const uint64_t slot = simpler::hbg::task_local_id(outputs.task_id());
     ASSERT_LT(slot, static_cast<uint64_t>(kPoisonedSlots)) << "the submitted slot must be one this test poisoned";
-    EXPECT_EQ(payloads[slot].predicate.op, PredicateOp::NONE);
-    EXPECT_EQ(payloads[slot].predicate.addr, 0u);
+    EXPECT_EQ(storage[slot].payload.predicate.op, PredicateOp::NONE);
+    EXPECT_EQ(storage[slot].payload.predicate.addr, 0u);
 }

--- a/tests/ut/cpp/common/test_hbg_self_relative_ptr.cpp
+++ b/tests/ut/cpp/common/test_hbg_self_relative_ptr.cpp
@@ -94,38 +94,40 @@ TEST(HbgSelfRelativePtr, SurvivesABlockCopyToAnotherAddress) {
     EXPECT_EQ(moved->to_after.get(), &moved->after_payload);
 }
 
-// bind_buffers is the only writer, and the slot state it writes into is copied as
-// part of the same image as its payload and descriptor.
-TEST(HbgSelfRelativePtr, SlotStateBindingSurvivesTheImageCopy) {
-    struct Image {
-        TaskDescriptor descriptor;
-        TaskPayload payload;
-        ChipTaskSlotState slot;
-    };
-
-    // Real objects, not byte buffers: the slot state is alignas(64), which
+// A task's three records reach each other by ChipTaskStorage's layout alone, so the
+// resolution is against whichever copy of the storage the caller holds — nothing is
+// stored, and an image copy needs no fix-up.
+TEST(HbgSelfRelativePtr, SiblingAccessorsResolveWithinTheirOwnStorage) {
+    // Real objects, not byte buffers: the storage is alignas(64), which
     // std::vector<std::byte>::data() does not promise.
-    Image source{};
-    Image destination{};
-    Image *origin = &source;
-    origin->slot.bind_buffers(&origin->payload, &origin->descriptor);
-    ASSERT_EQ(origin->slot.payload.get(), &origin->payload);
-    ASSERT_EQ(origin->slot.task.get(), &origin->descriptor);
+    ChipTaskStorage source{};
+    ChipTaskStorage destination{};
 
-    std::memcpy(&destination, &source, sizeof(Image));
-    Image *moved = &destination;
-    ASSERT_NE(reinterpret_cast<void *>(moved), reinterpret_cast<void *>(origin));
+    EXPECT_EQ(&source.slot.to_payload(), &source.payload);
+    EXPECT_EQ(&source.slot.to_descriptor(), &source.task);
+    EXPECT_EQ(&source.task.to_slot(), &source.slot);
+    EXPECT_EQ(&source.task.to_payload(), &source.payload);
+    EXPECT_EQ(&source.payload.to_slot(), &source.slot);
+    EXPECT_EQ(&source.payload.to_descriptor(), &source.task);
 
-    EXPECT_EQ(moved->slot.payload.get(), &moved->payload);
-    EXPECT_EQ(moved->slot.task.get(), &moved->descriptor);
+    std::memcpy(&destination, &source, sizeof(ChipTaskStorage));
+    ASSERT_NE(reinterpret_cast<void *>(&destination), reinterpret_cast<void *>(&source));
+
+    // The copy's records name the copy, not the original.
+    EXPECT_EQ(&destination.slot.to_payload(), &destination.payload);
+    EXPECT_EQ(&destination.slot.to_descriptor(), &destination.task);
+    EXPECT_EQ(&destination.payload.to_slot(), &destination.slot);
 }
 
-// The descriptor ABI AICore consumes and the one-cache-line slot state are both
-// unchanged by the representation: the eight bytes the two deltas save become
-// tail padding inside the same 64.
+// The descriptor and the one-cache-line slot state both occupy exactly the cache
+// line ChipTaskStorage places them on, so the container's slot offset is the
+// descriptor's size and its payload offset is twice that.
 TEST(HbgSelfRelativePtr, KeepsTheSharedMemoryAbiSizes) {
     EXPECT_EQ(sizeof(ChipTaskSlotState), 64u);
-    EXPECT_EQ(sizeof(TaskDescriptor), 40u);
-    EXPECT_EQ(sizeof(SelfRelativePtr<TaskPayload>), 4u);
+    EXPECT_EQ(sizeof(TaskDescriptor), 64u);
+    EXPECT_EQ(sizeof(SelfRelativePtr<simpler::hbg::Tensor>), 4u);
     EXPECT_EQ(offsetof(TaskDescriptor, packed_buffer_base), 24u);
+    EXPECT_EQ(sizeof(ChipTaskStorage), 320u);
+    EXPECT_EQ(offsetof(ChipTaskStorage, slot), sizeof(TaskDescriptor));
+    EXPECT_EQ(offsetof(ChipTaskStorage, payload), offsetof(ChipTaskStorage, slot) + sizeof(ChipTaskSlotState));
 }

--- a/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
+++ b/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
@@ -76,40 +76,38 @@ public:
         auto &tasks = header->tasks;
         tasks.completed_watermark.store(-1, std::memory_order_relaxed);
         tasks.total_tasks = static_cast<int32_t>(SUBMITTED);
-        tasks.task_descriptors = descriptors();
-        tasks.task_payloads = payloads();
-        tasks.slot_states = slot_states();
+        storage_ = reinterpret_cast<ChipTaskStorage *>(image_.base() + off.storage);
+        tasks.task_storage = storage_;
         tasks.completion_flags = completion_flags();
-        (void)off;
 
         // Each live slot takes a packed region in each pool, exactly as the
         // orchestrator's bump cursors hand them out, and gets content that identifies
         // the slot so the compaction can be checked element by element.
         for (uint64_t i = 0; i < SUBMITTED; ++i) {
-            descriptors()[i].task_id = simpler::hbg::make_global_task(static_cast<uint32_t>(i));
-            payloads()[i].tensor_count = TENSORS_PER_TASK;
-            payloads()[i].scalar_count = SCALARS_PER_TASK;
-            payloads()[i].fanin_count = FANIN_PER_TASK;
-            payloads()[i].bind_regions(
+            ChipTaskStorage &entry = storage_[i];
+            entry.task.task_id = simpler::hbg::make_global_task(static_cast<uint32_t>(i));
+            entry.payload.tensor_count = TENSORS_PER_TASK;
+            entry.payload.scalar_count = SCALARS_PER_TASK;
+            entry.payload.fanin_count = FANIN_PER_TASK;
+            entry.payload.bind_regions(
                 tensor_pool() + i * TENSORS_PER_TASK, scalar_pool() + i * SCALARS_PER_TASK,
                 fanin_pool() + i * FANIN_STRIDE
             );
             for (int32_t j = 0; j < TENSORS_PER_TASK; ++j) {
-                payloads()[i].tensor_data()[j].buffer.addr = 0x1000 + i * 0x10 + j;
+                entry.payload.tensor_data()[j].buffer.addr = 0x1000 + i * 0x10 + j;
             }
             for (int32_t j = 0; j < SCALARS_PER_TASK; ++j) {
-                payloads()[i].scalar_data()[j] = 0x3000 + i * 0x10 + j;
+                entry.payload.scalar_data()[j] = 0x3000 + i * 0x10 + j;
             }
             for (int32_t j = 0; j < FANIN_PER_TASK; ++j) {
-                payloads()[i].fanin_data()[j] = static_cast<int32_t>(0x50 + i * 0x10 + j);
+                entry.payload.fanin_data()[j] = static_cast<int32_t>(0x50 + i * 0x10 + j);
             }
-            slot_states()[i].last_consumer_local_id = static_cast<int32_t>(i);
-            slot_states()[i].in_graph_task_index = static_cast<int32_t>(200 + i);
-            slot_states()[i].bind_buffers(&payloads()[i], &descriptors()[i]);
+            entry.slot.last_consumer_local_id = static_cast<int32_t>(i);
+            entry.slot.in_graph_task_index = static_cast<int32_t>(200 + i);
             completion_flags()[i].store(static_cast<uint8_t>(i & 1), std::memory_order_relaxed);
         }
         // A slot past the submitted prefix, to prove it does not travel.
-        descriptors()[SUBMITTED].task_id = simpler::hbg::make_global_task(0xBEEF);
+        storage_[SUBMITTED].task.task_id = simpler::hbg::make_global_task(0xBEEF);
     }
 
     // Overwrite the three fields that can hold a graph-heap address with ones out
@@ -118,11 +116,12 @@ public:
     // is what makes "only heap addresses move" checkable on the same image.
     void plant_heap_addresses() {
         for (uint64_t i = 0; i < SUBMITTED; ++i) {
+            ChipTaskStorage &entry = storage_[i];
             const uint64_t packed = HEAP_VIRTUAL_BASE + i * kPackedStride;
-            descriptors()[i].packed_buffer_base = reinterpret_cast<void *>(packed);
-            descriptors()[i].packed_buffer_end = reinterpret_cast<void *>(packed + kPackedStride);
-            payloads()[i].predicate.addr = packed + 8;
-            payloads()[i].tensor_data()[0].buffer.addr = packed;
+            entry.task.packed_buffer_base = reinterpret_cast<void *>(packed);
+            entry.task.packed_buffer_end = reinterpret_cast<void *>(packed + kPackedStride);
+            entry.payload.predicate.addr = packed + 8;
+            entry.payload.tensor_data()[0].buffer.addr = packed;
         }
     }
 
@@ -133,12 +132,10 @@ public:
 
     const char *base() const { return image_.base(); }
 
-    TaskDescriptor *descriptors() {
-        return reinterpret_cast<TaskDescriptor *>(image_.base() + sm_layout::segment_offsets(WINDOW).descriptors);
-    }
-    TaskPayload *payloads() {
-        return reinterpret_cast<TaskPayload *>(image_.base() + sm_layout::segment_offsets(WINDOW).payloads);
-    }
+    // A task's three records share one storage entry, so each is reached by
+    // indexing this array and naming the member — never by striding an array of
+    // that record's own type, which the merged layout no longer has.
+    ChipTaskStorage *storage() { return storage_; }
     simpler::hbg::Tensor *tensor_pool() {
         return reinterpret_cast<simpler::hbg::Tensor *>(image_.base() + sm_layout::segment_offsets(WINDOW).tensor_pool);
     }
@@ -148,9 +145,6 @@ public:
     int32_t *fanin_pool() {
         return reinterpret_cast<int32_t *>(image_.base() + sm_layout::segment_offsets(WINDOW).fanin_pool);
     }
-    ChipTaskSlotState *slot_states() {
-        return reinterpret_cast<ChipTaskSlotState *>(image_.base() + sm_layout::segment_offsets(WINDOW).slot_states);
-    }
     std::atomic<uint8_t> *completion_flags() {
         return reinterpret_cast<std::atomic<uint8_t> *>(
             image_.base() + sm_layout::segment_offsets(WINDOW).completion_flags
@@ -159,6 +153,7 @@ public:
 
 private:
     AlignedImage image_;
+    ChipTaskStorage *storage_{nullptr};
 };
 
 // What a bind of `submitted` tasks put in the pools, given the per-task shape the
@@ -180,6 +175,10 @@ struct Compacted {
     AlignedImage image;
     uint64_t bytes;
     sm_layout::BindUsage used;
+    // Resolved at construction, like the three above it. The three records of a
+    // task are this array plus a member, so nothing here hands out a per-record
+    // accessor — that is the shape the merged layout removed.
+    ChipTaskStorage *storage{nullptr};
 
     explicit Compacted(
         Mirror &mirror, uint64_t submitted = SUBMITTED, const sm_layout::HeapRebase &rebase = kNoHeapAddresses
@@ -188,16 +187,13 @@ struct Compacted {
         bytes(0),
         used(usage_for(submitted)) {
         bytes = sm_layout::compact_live_image(mirror.base(), WINDOW, used, rebase, image.base());
+        storage = reinterpret_cast<ChipTaskStorage *>(image.base() + off().storage);
     }
 
     sm_layout::SegmentOffsets off(uint64_t submitted = SUBMITTED) const {
         return sm_layout::segment_offsets(sm_layout::image_extents(usage_for(submitted)));
     }
 
-    TaskPayload *payload_at(uint64_t i) { return reinterpret_cast<TaskPayload *>(image.base() + off().payloads) + i; }
-    TaskDescriptor *descriptors() { return reinterpret_cast<TaskDescriptor *>(image.base() + off().descriptors); }
-    TaskPayload *payloads() { return payload_at(0); }
-    ChipTaskSlotState *slot_states() { return reinterpret_cast<ChipTaskSlotState *>(image.base() + off().slot_states); }
     simpler::hbg::Tensor *tensor_pool() {
         return reinterpret_cast<simpler::hbg::Tensor *>(image.base() + off().tensor_pool);
     }
@@ -223,11 +219,12 @@ TEST(HbgSmCompaction, CarriesEveryLiveSlotsContent) {
     Compacted compacted(mirror);
 
     for (uint64_t i = 0; i < SUBMITTED; ++i) {
-        EXPECT_EQ(simpler::hbg::task_local_id(compacted.descriptors()[i].task_id), i) << "slot " << i;
-        EXPECT_EQ(compacted.payload_at(i)->tensor_count, TENSORS_PER_TASK) << "slot " << i;
-        EXPECT_EQ(compacted.payload_at(i)->tensor_data()[0].buffer.addr, 0x1000 + i * 0x10) << "slot " << i;
-        EXPECT_EQ(compacted.slot_states()[i].last_consumer_local_id, static_cast<int32_t>(i)) << "slot " << i;
-        EXPECT_EQ(compacted.slot_states()[i].in_graph_task_index, static_cast<int32_t>(200 + i)) << "slot " << i;
+        const ChipTaskStorage &entry = compacted.storage[i];
+        EXPECT_EQ(simpler::hbg::task_local_id(entry.task.task_id), i) << "slot " << i;
+        EXPECT_EQ(entry.payload.tensor_count, TENSORS_PER_TASK) << "slot " << i;
+        EXPECT_EQ(entry.payload.tensor_data()[0].buffer.addr, 0x1000 + i * 0x10) << "slot " << i;
+        EXPECT_EQ(entry.slot.last_consumer_local_id, static_cast<int32_t>(i)) << "slot " << i;
+        EXPECT_EQ(entry.slot.in_graph_task_index, static_cast<int32_t>(200 + i)) << "slot " << i;
         EXPECT_EQ(compacted.completion_flags()[i].load(std::memory_order_relaxed), static_cast<uint8_t>(i & 1))
             << "slot " << i;
     }
@@ -240,16 +237,17 @@ TEST(HbgSmCompaction, CarriesEveryLiveSlotsContent) {
     EXPECT_EQ(tasks.total_tasks, static_cast<int32_t>(SUBMITTED));
 }
 
-// The load-bearing one. Restacking changes the distance between a slot state and
-// its payload, so a binding copied verbatim would resolve to the mirror — a host
-// address, in device memory.
-TEST(HbgSmCompaction, RebindsEverySlotInsideTheImage) {
+// A slot state's siblings are ChipTaskStorage's own layout, so the restack's change
+// of pitch cannot move them apart: each record of a shipped entry resolves to that
+// same entry, with nothing re-taken.
+TEST(HbgSmCompaction, SlotBindingsSurviveTheChangeOfPitch) {
     Mirror mirror;
     Compacted compacted(mirror);
 
     for (uint64_t i = 0; i < SUBMITTED; ++i) {
-        EXPECT_EQ(compacted.slot_states()[i].payload.get(), compacted.payload_at(i)) << "slot " << i;
-        EXPECT_EQ(compacted.slot_states()[i].task.get(), &compacted.descriptors()[i]) << "slot " << i;
+        const ChipTaskStorage &entry = compacted.storage[i];
+        EXPECT_EQ(&entry.slot.to_payload(), &entry.payload) << "slot " << i;
+        EXPECT_EQ(&entry.slot.to_descriptor(), &entry.task) << "slot " << i;
     }
 }
 
@@ -261,17 +259,15 @@ TEST(HbgSmCompaction, BindingsSurviveTheCopyToTheDevice) {
 
     AlignedImage landed(compacted.bytes);
     std::memcpy(landed.base(), compacted.image.base(), compacted.bytes);
-    // The image's own layout, not the mirror's. The four slot-pitched offsets happen
+    // The image's own layout, not the mirror's. The two slot-pitched offsets happen
     // to agree between the two, but reading them off the mirror overload here would
     // stop being true the moment a pool moved ahead of them.
     const auto off = compacted.off();
-    auto *slots = reinterpret_cast<ChipTaskSlotState *>(landed.base() + off.slot_states);
-    auto *payloads = reinterpret_cast<TaskPayload *>(landed.base() + off.payloads);
-    auto *descriptors = reinterpret_cast<TaskDescriptor *>(landed.base() + off.descriptors);
+    auto *storage = reinterpret_cast<ChipTaskStorage *>(landed.base() + off.storage);
 
     for (uint64_t i = 0; i < SUBMITTED; ++i) {
-        EXPECT_EQ(slots[i].payload.get(), &payloads[i]) << "slot " << i;
-        EXPECT_EQ(slots[i].task.get(), &descriptors[i]) << "slot " << i;
+        EXPECT_EQ(&storage[i].slot.to_payload(), &storage[i].payload) << "slot " << i;
+        EXPECT_EQ(&storage[i].slot.to_descriptor(), &storage[i].task) << "slot " << i;
     }
 }
 
@@ -283,9 +279,7 @@ TEST(HbgSmCompaction, LeavesNoHostPointerInTheHeader) {
     Compacted compacted(mirror);
 
     auto &tasks = reinterpret_cast<const SharedMemoryHeader *>(compacted.image.base())->tasks;
-    EXPECT_EQ(tasks.task_descriptors, nullptr);
-    EXPECT_EQ(tasks.task_payloads, nullptr);
-    EXPECT_EQ(tasks.slot_states, nullptr);
+    EXPECT_EQ(tasks.task_storage, nullptr);
     EXPECT_EQ(tasks.completion_flags, nullptr);
 }
 
@@ -300,7 +294,7 @@ TEST(HbgSmCompaction, ZeroSubmittedShipsTheHeaderAlone) {
     EXPECT_LT(compacted.bytes, sm_layout::segment_offsets(1).end);
     auto &tasks = reinterpret_cast<const SharedMemoryHeader *>(compacted.image.base())->tasks;
     EXPECT_EQ(tasks.total_tasks, static_cast<int32_t>(SUBMITTED));
-    EXPECT_EQ(tasks.task_descriptors, nullptr);
+    EXPECT_EQ(tasks.task_storage, nullptr);
 }
 
 // The pools ship what the bind used, not what the mirror is dimensioned for. That
@@ -315,7 +309,8 @@ TEST(HbgSmCompaction, PackedPoolsShipFewerBytesAndStillResolve) {
     EXPECT_LT(compacted.bytes, sm_layout::segment_offsets(WINDOW).end);
 
     for (uint64_t i = 0; i < SUBMITTED; ++i) {
-        TaskPayload *shipped = compacted.payload_at(i);
+        const ChipTaskStorage &entry = compacted.storage[i];
+        const TaskPayload *shipped = &entry.payload;
         EXPECT_EQ(shipped->tensor_count, TENSORS_PER_TASK) << "slot " << i;
         EXPECT_EQ(shipped->scalar_count, SCALARS_PER_TASK) << "slot " << i;
         EXPECT_EQ(shipped->fanin_count, FANIN_PER_TASK) << "slot " << i;
@@ -331,7 +326,7 @@ TEST(HbgSmCompaction, PackedPoolsShipFewerBytesAndStillResolve) {
             EXPECT_EQ(shipped->fanin_data()[j], static_cast<int32_t>(0x50 + i * 0x10 + j))
                 << "slot " << i << " arg " << j;
         }
-        EXPECT_EQ(compacted.slot_states()[i].payload.get(), shipped) << "slot " << i;
+        EXPECT_EQ(&entry.slot.to_payload(), shipped) << "slot " << i;
     }
 }
 
@@ -352,7 +347,7 @@ TEST(HbgSmCompaction, RebindsEveryArgumentRegionInsideTheImage) {
     const char *fanin_end = fanin_begin + compacted.used.fanin_elems * sizeof(int32_t);
 
     for (uint64_t i = 0; i < SUBMITTED; ++i) {
-        TaskPayload *shipped = compacted.payload_at(i);
+        const TaskPayload *shipped = &compacted.storage[i].payload;
         const char *t = reinterpret_cast<const char *>(shipped->tensor_data());
         const char *s = reinterpret_cast<const char *>(shipped->scalar_data());
         const char *f = reinterpret_cast<const char *>(shipped->fanin_data());
@@ -373,13 +368,14 @@ TEST(HbgSmCompaction, UnboundRegionsStayUnbound) {
     Mirror mirror;
     // Slot 2 stands in for the outer GRAPH task.
     constexpr uint64_t GRAPH_SLOT = 2;
-    mirror.payloads()[GRAPH_SLOT].tensor_count = 0;
-    mirror.payloads()[GRAPH_SLOT].scalar_count = 0;
-    mirror.payloads()[GRAPH_SLOT].bind_regions(nullptr, nullptr, mirror.fanin_pool() + GRAPH_SLOT * FANIN_STRIDE);
+    TaskPayload &graph_payload = mirror.storage()[GRAPH_SLOT].payload;
+    graph_payload.tensor_count = 0;
+    graph_payload.scalar_count = 0;
+    graph_payload.bind_regions(nullptr, nullptr, mirror.fanin_pool() + GRAPH_SLOT * FANIN_STRIDE);
 
     Compacted compacted(mirror);
 
-    TaskPayload *shipped = compacted.payload_at(GRAPH_SLOT);
+    const TaskPayload *shipped = &compacted.storage[GRAPH_SLOT].payload;
     EXPECT_EQ(shipped->tensor_data(), nullptr);
     EXPECT_EQ(shipped->scalar_data(), nullptr);
     // Its fanin region still resolves, and still inside the image.
@@ -390,8 +386,8 @@ TEST(HbgSmCompaction, UnboundRegionsStayUnbound) {
         EXPECT_EQ(shipped->fanin_data()[j], static_cast<int32_t>(0x50 + GRAPH_SLOT * 0x10 + j)) << "arg " << j;
     }
     // Its neighbours are untouched by the unbound slot.
-    EXPECT_EQ(compacted.payload_at(1)->tensor_data()[0].buffer.addr, 0x1000 + 1 * 0x10);
-    EXPECT_EQ(compacted.payload_at(3)->tensor_data()[0].buffer.addr, 0x1000 + 3 * 0x10);
+    EXPECT_EQ(compacted.storage[1].payload.tensor_data()[0].buffer.addr, 0x1000 + 1 * 0x10);
+    EXPECT_EQ(compacted.storage[3].payload.tensor_data()[0].buffer.addr, 0x1000 + 3 * 0x10);
 }
 
 // A slot names its payload, and a payload names its regions, by an int32 delta, so
@@ -427,16 +423,14 @@ TEST(HbgSmCompaction, SegmentLayoutHoldsForANonPowerOfTwoCapacity) {
         const sm_layout::ImageExtents e = sm_layout::mirror_extents(capacity);
         const sm_layout::SegmentOffsets off = sm_layout::segment_offsets(e);
 
-        // The descriptors sit right after the padded header, whatever the pitch.
-        EXPECT_EQ(off.descriptors, CHIP_ALIGN_UP(sizeof(SharedMemoryHeader), CHIP_ALIGN_SIZE))
-            << "capacity " << capacity;
+        // The storage sits right after the padded header, whatever the pitch.
+        EXPECT_EQ(off.storage, CHIP_ALIGN_UP(sizeof(SharedMemoryHeader), CHIP_ALIGN_SIZE)) << "capacity " << capacity;
 
-        const uint64_t starts[] = {off.descriptors, off.payloads,    off.slot_states, off.completion_flags,
-                                   off.fanin_pool,  off.tensor_pool, off.scalar_pool, off.end};
+        const uint64_t starts[] = {off.storage,     off.completion_flags, off.fanin_pool,
+                                   off.tensor_pool, off.scalar_pool,      off.end};
         const uint64_t spans[] = {
-            capacity * sizeof(TaskDescriptor),    capacity * sizeof(TaskPayload),
-            capacity * sizeof(ChipTaskSlotState), capacity * sizeof(std::atomic<uint8_t>),
-            e.fanin_elems * sizeof(int32_t),      e.tensor_elems * sizeof(simpler::hbg::Tensor),
+            capacity * sizeof(ChipTaskStorage), capacity * sizeof(std::atomic<uint8_t>),
+            e.fanin_elems * sizeof(int32_t),    e.tensor_elems * sizeof(simpler::hbg::Tensor),
             e.scalar_elems * sizeof(uint64_t),
         };
         for (size_t i = 0; i < std::size(spans); ++i) {
@@ -459,14 +453,13 @@ TEST(HbgSmCompaction, MovesEveryHeapAddressOntoTheRealBase) {
     Compacted compacted(mirror, SUBMITTED, {REAL_BASE, Mirror::kHeapUsed});
 
     for (uint64_t i = 0; i < SUBMITTED; ++i) {
+        const ChipTaskStorage &entry = compacted.storage[i];
         const uint64_t packed = REAL_BASE + i * Mirror::kPackedStride;
-        EXPECT_EQ(reinterpret_cast<uint64_t>(compacted.descriptors()[i].packed_buffer_base), packed) << "slot " << i;
-        EXPECT_EQ(
-            reinterpret_cast<uint64_t>(compacted.descriptors()[i].packed_buffer_end), packed + Mirror::kPackedStride
-        ) << "slot "
-          << i;
-        EXPECT_EQ(compacted.payload_at(i)->predicate.addr, packed + 8) << "slot " << i;
-        EXPECT_EQ(compacted.payload_at(i)->tensor_data()[0].buffer.addr, packed) << "slot " << i;
+        EXPECT_EQ(reinterpret_cast<uint64_t>(entry.task.packed_buffer_base), packed) << "slot " << i;
+        EXPECT_EQ(reinterpret_cast<uint64_t>(entry.task.packed_buffer_end), packed + Mirror::kPackedStride)
+            << "slot " << i;
+        EXPECT_EQ(entry.payload.predicate.addr, packed + 8) << "slot " << i;
+        EXPECT_EQ(entry.payload.tensor_data()[0].buffer.addr, packed) << "slot " << i;
     }
 }
 
@@ -481,7 +474,7 @@ TEST(HbgSmCompaction, LeavesNonHeapAddressesAlone) {
 
     // Tensor 1 of every task kept the address the Mirror gave it.
     for (uint64_t i = 0; i < SUBMITTED; ++i) {
-        EXPECT_EQ(compacted.payload_at(i)->tensor_data()[1].buffer.addr, 0x1000 + i * 0x10 + 1) << "slot " << i;
+        EXPECT_EQ(compacted.storage[i].payload.tensor_data()[1].buffer.addr, 0x1000 + i * 0x10 + 1) << "slot " << i;
     }
 }
 
@@ -497,7 +490,7 @@ TEST(HbgSmCompaction, RebaseIsANoOpWhenNothingCameFromTheHeap) {
     ASSERT_EQ(rebased.bytes, plain.bytes);
     EXPECT_EQ(std::memcmp(rebased.image.base(), plain.image.base(), rebased.bytes), 0);
     for (uint64_t i = 0; i < SUBMITTED; ++i) {
-        EXPECT_EQ(rebased.payload_at(i)->predicate.addr, 0u) << "slot " << i;
+        EXPECT_EQ(rebased.storage[i].payload.predicate.addr, 0u) << "slot " << i;
     }
 }
 
@@ -521,9 +514,10 @@ TEST(HbgSmCompaction, MovesEveryGraphBoundaryAddressOntoTheRealBase) {
     // One GRAPH task whose boundaries all live in the graph heap. task_kind is what
     // tells the restack which element type this task's region holds.
     constexpr uint64_t GRAPH_SLOT = 0;
-    mirror.slot_states()[GRAPH_SLOT].task_kind = TaskKind::GRAPH;
-    mirror.payloads()[GRAPH_SLOT].tensor_count = static_cast<int32_t>(BOUNDARIES);
-    auto *boundaries = reinterpret_cast<GraphTensor *>(mirror.payloads()[GRAPH_SLOT].tensor_data());
+    ChipTaskStorage &graph_entry = mirror.storage()[GRAPH_SLOT];
+    graph_entry.slot.task_kind = TaskKind::GRAPH;
+    graph_entry.payload.tensor_count = static_cast<int32_t>(BOUNDARIES);
+    auto *boundaries = reinterpret_cast<GraphTensor *>(graph_entry.payload.tensor_data());
     for (uint32_t j = 0; j < BOUNDARIES; ++j) {
         boundaries[j] = GraphTensor{};
         boundaries[j].buffer_addr = HEAP_VIRTUAL_BASE + 0x1000 * (j + 1);
@@ -531,7 +525,7 @@ TEST(HbgSmCompaction, MovesEveryGraphBoundaryAddressOntoTheRealBase) {
     }
 
     Compacted compacted(mirror, SUBMITTED, {REAL_BASE, 1ULL << 30});
-    const auto *shipped = reinterpret_cast<const GraphTensor *>(compacted.payload_at(GRAPH_SLOT)->tensor_data());
+    const auto *shipped = reinterpret_cast<const GraphTensor *>(compacted.storage[GRAPH_SLOT].payload.tensor_data());
     for (uint32_t j = 0; j < BOUNDARIES; ++j) {
         EXPECT_EQ(shipped[j].buffer_addr, REAL_BASE + 0x1000 * (j + 1)) << "boundary " << j;
         EXPECT_EQ(shipped[j].buffer_size, 0x40u) << "boundary " << j << " had a neighbouring field rewritten";


### PR DESCRIPTION
## What

A task's descriptor, slot state and payload were three shared-memory segments
indexed in parallel, while an in-graph task already held the same three in one
container. Both kinds of hbg task now live in a `ChipTaskStorage`, so their
relative positions are that type's layout rather than data any of them stores.

```
before   [TaskDescriptor x N][TaskPayload x N][ChipTaskSlotState x N][flags x N][pools]
after    [ChipTaskStorage x N][flags x N][pools]
```

`completion_flags` deliberately stays its own dense byte array: a fanin scan
reads many producers' flags at once, which one cache line answers there and
would take one line per producer inside the 320-byte storage stride.

## Why it is correct

- **The restack no longer re-takes a slot's bindings.** `compact_live_image`
  changed the pitch between the mirror and the shipped image, so a slot's
  delta to its payload had to be re-derived. Inside one `ChipTaskStorage` that
  distance *is* the type's layout, so it survives the change of pitch and the
  three segment copies collapse into one.
- **Binding checks go with the bindings.** A slot's descriptor is always
  present now, so every `task == nullptr` screen is unreachable. Where such a
  screen was also doing a second job, that job is kept explicitly: the one in
  `append_fanin_or_fail` was the only thing rejecting a producer id this run
  never submitted, so it is now a bound against `active_count()` — the old
  form only approximated it, and `get_slot_state_by_task_id` does not
  bounds-check.
- **The A5 AICore graph view resolves from one base.** It addressed a
  descriptor and a payload from two bases at their own strides, which only
  held while the three records were parallel arrays. Both now come from the
  storage array — one base, one 320-byte stride, a fixed offset per record.
- **`args_dump_aicpu.h` no longer forces one member spelling on both
  runtimes.** It took a slot state and reached the records from it, which only
  worked while `tensormap_and_ringbuffer` and `host_build_graph` spelled that
  relation identically. It now takes the records; `dump_running_task_outputs`
  takes a per-slot callback. **`tensormap_and_ringbuffer`'s data structures are
  untouched** — only its six call sites pass `*slot.task` / `*slot.payload`
  explicitly.

## Cost

`TaskDescriptor` is padded to the 64-byte line the storage places the slot
state on. `offsetof(packed_buffer_base)` is unchanged, which is what AICore
reads, but the size is not free everywhere:

| | before | after |
| --- | --- | --- |
| in-graph task | 320 B | 320 B — the padding already existed in the container |
| **GLOBAL task in SM** | **296 B** | **320 B (+8%)**, and this region is H2D'd |

Also worth knowing: `TaskDescriptor::reserved[24]` and
`ChipTaskSlotState::reserved[16]` are never written, and the SM mirror is not
zero-filled (init-on-write), so 40 bytes per task of uninitialized host memory
travel to the device. Functionally inert — nothing reads them — but it would
show up in any future hash or byte-compare of the image.

## Layout guarantees

Three asserts hold the invariant the sibling accessors rest on:

```cpp
static_assert(std::is_standard_layout_v<ChipTaskStorage>);
static_assert(offsetof(ChipTaskStorage, slot) == sizeof(TaskDescriptor));
static_assert(offsetof(ChipTaskStorage, payload)
              == offsetof(ChipTaskStorage, slot) + sizeof(ChipTaskSlotState));
```

`to_slot` / `to_descriptor` / `to_payload` (all six directions, const and
non-const) are each one function-local `constexpr` displacement. None of the
three types may be instantiated outside a `ChipTaskStorage` — the UTs that
held bare records were changed to hold whole entries, so that invariant is
true in-tree rather than merely stated.

The A5 wire constants stay literals because the AICore `.o` cannot include
`runtime_types.h`. `test_hbg_scheduler_contracts` reverse-looks-up all three
through `offsetof`, where the types are visible, so a layout change fails the
build instead of silently mis-addressing.

## Testing

Verified on this branch with #2074 applied on top, since that fix is what makes
`test_hbg_submit_poison` compile at all (see below). All judged by exit code.

| | exit | result |
| --- | --- | --- |
| full build | 0 | 6 runtime variants (a2a3/a5 × onboard/sim/dispatcher) + nanobind binding |
| cpput | 0 | 126/126 |
| ST `a5sim` | 0 | no failures |
| ST `a2a3sim` | 0 | no failures |

ST sim needs an explicit device pool (`--device 0-3`); some L3 cases declare
`device_count=2` and the default pool holds one.

## Depends on #2074

`test_hbg_submit_poison` does not compile on `main`:
`tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp:196,198,218,220` use `orch.fatal`
and `header->orch_error_code`, both retired by #2068, in two tests added by
#2063. The two changes touch different regions of the file, so git merged them
without a conflict and the disagreement only surfaces at compile time.

The failing region is byte-identical between this branch and `upstream/main`,
and this branch does not touch `tests/ut/cpp/CMakeLists.txt`. #2074 fixes it in
four lines; this PR rebases cleanly once that lands.
