### PR TITLE
Fix: restore the hbg submit-poison predicate tests to the current fatal API

### DIFF
--- a/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
@@ -193,9 +193,9 @@ TEST_F(HbgSubmitPoisonTest, InvalidDispatchPredicateIsRejectedBeforeTaskAllocati
     kernels.aiv0_kernel_id = 0;
 
     EXPECT_FALSE(orch.submit_task(kernels, args).task_id().is_valid());
-    EXPECT_TRUE(orch.fatal);
+    EXPECT_TRUE(orch.is_fatal());
     EXPECT_EQ(orch.task_allocator.active_count(), 0);
-    EXPECT_EQ(sm_handle->header->orch_error_code.load(std::memory_order_acquire), SIMPLER_ERROR_INVALID_ARGS);
+    EXPECT_EQ(orch.fatal_code.load(std::memory_order_acquire), SIMPLER_ERROR_INVALID_ARGS);
 }
 
 TEST_F(HbgSubmitPoisonTest, OutOfRangeDispatchPredicateIndexIsRejected) {
@@ -215,7 +215,7 @@ TEST_F(HbgSubmitPoisonTest, OutOfRangeDispatchPredicateIndexIsRejected) {
     kernels.aiv0_kernel_id = 0;
 
     EXPECT_FALSE(orch.submit_task(kernels, args).task_id().is_valid());
-    EXPECT_TRUE(orch.fatal);
+    EXPECT_TRUE(orch.is_fatal());
     EXPECT_EQ(orch.task_allocator.active_count(), 0);
-    EXPECT_EQ(sm_handle->header->orch_error_code.load(std::memory_order_acquire), SIMPLER_ERROR_INVALID_ARGS);
+    EXPECT_EQ(orch.fatal_code.load(std::memory_order_acquire), SIMPLER_ERROR_INVALID_ARGS);
 }


### PR DESCRIPTION
## What

`test_hbg_submit_poison` does not compile on `main`.

```
tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp:196:22: error:
  'struct OrchestratorState' has no member named 'fatal'; did you mean 'is_fatal'?
tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp:198:34: error:
  'struct SharedMemoryHeader' has no member named 'orch_error_code'; did you mean 'sched_error_code'?
```

(and the same pair again at 218/220)

## Why it happened

Two merged changes disagree about where the orchestrator's fatal state lives:

- #2068 consolidated it into the single atomic `OrchestratorState::fatal_code`,
  read through `is_fatal()`, and left the SM header with only its
  `sched_error_*` fields.
- #2063 added two dispatch-predicate tests that assert against the old
  `orch.fatal` / `header->orch_error_code`.

They were developed in parallel and touch different regions of the file, so
git merged them without a conflict. The disagreement is only visible at
compile time, which is why it landed.

## The fix

Assert through the field that holds the state now. The codes are unchanged,
so both tests still pin `SIMPLER_ERROR_INVALID_ARGS` — this restores the
tests rather than weakening them.

```diff
-    EXPECT_TRUE(orch.fatal);
+    EXPECT_TRUE(orch.is_fatal());
     EXPECT_EQ(orch.task_allocator.active_count(), 0);
-    EXPECT_EQ(sm_handle->header->orch_error_code.load(std::memory_order_acquire), SIMPLER_ERROR_INVALID_ARGS);
+    EXPECT_EQ(orch.fatal_code.load(std::memory_order_acquire), SIMPLER_ERROR_INVALID_ARGS);
```

## Testing

```
cmake --build build -j 16     # exit 0, 0 errors
ctest --test-dir build -j 8   # exit 0, 126/126 passed
```

Both restored tests exercise the path they were written for — the fatal is
latched by `resolve_dispatch_predicate` with code 5
(`SIMPLER_ERROR_INVALID_ARGS`) in each:

```
[ RUN      ] HbgSubmitPoisonTest.InvalidDispatchPredicateIsRejectedBeforeTaskAllocation
[ERROR] resolve_dispatch_predicate: FATAL(code=5): dispatch predicate has an invalid operand tensor
[       OK ] HbgSubmitPoisonTest.InvalidDispatchPredicateIsRejectedBeforeTaskAllocation
[ RUN      ] HbgSubmitPoisonTest.OutOfRangeDispatchPredicateIndexIsRejected
[ERROR] resolve_dispatch_predicate: FATAL(code=5): dispatch predicate index is outside the operand tensor
[       OK ] HbgSubmitPoisonTest.OutOfRangeDispatchPredicateIndexIsRejected
```
