### PR TITLE
Perf: align A5 TMR hot function entries

### DIFF
--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/hot_entry_alignment.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/hot_entry_alignment.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#if defined(__aarch64__) && defined(__linux__) && (defined(__GNUC__) || defined(__clang__))
+#define SIMPLER_A5_TMR_HOT_ENTRY_ALIGN __attribute__((aligned(64)))
+#else
+#define SIMPLER_A5_TMR_HOT_ENTRY_ALIGN
+#endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
@@ -30,6 +30,7 @@
 #include "common/dep_gen.h"
 #include "common/unified_log.h"
 #include "dep_compute.h"
+#include "hot_entry_alignment.h"
 #include "runtime_types.h"
 #include "shared_memory.h"
 #include "tensormap_and_ringbuffer/task_id_encoding.h"
@@ -888,7 +889,7 @@ static bool ensure_tensormap_capacity(OrchestratorState *orch, int32_t needed) {
 // kernel_ids (all INVALID_KERNEL_ID for dummy). Performs tensormap sync, fanin
 // computation (explicit_deps + auto), output registration, slot init, and
 // Orch-side wiring/ready publication.
-static TaskOutputTensors submit_task_common(
+SIMPLER_A5_TMR_HOT_ENTRY_ALIGN static TaskOutputTensors submit_task_common(
     OrchestratorState *orch, const CoreTaskArgs &args, ActiveMask active_mask, TaskAttrs task_attrs,
     int32_t aic_kernel_id, int32_t aiv0_kernel_id, int32_t aiv1_kernel_id
 ) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -19,6 +19,7 @@
 #include "common/chip_swimlane_profiling.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
+#include "hot_entry_alignment.h"
 #include "runtime_core.h"
 #include "runtime.h"
 #include "spin_hint.h"
@@ -75,7 +76,7 @@ SlotTransition SchedulerContext::decide_slot_transition(
 }
 
 // Complete one slot's task: subtask counting, mixed completion, deferred release, profiling.
-void SchedulerContext::complete_slot_task(
+SIMPLER_A5_TMR_HOT_ENTRY_ALIGN void SchedulerContext::complete_slot_task(
     ChipTaskSlotState &slot_state, int32_t expected_reg_task_id, [[maybe_unused]] SubtaskSlot subslot,
     [[maybe_unused]] int32_t thread_idx, int32_t core_id, Handshake *hank, int32_t &completed_this_turn,
     ChipTaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -24,6 +24,7 @@
 #include "common/chip_swimlane_profiling.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
+#include "hot_entry_alignment.h"
 #include "runtime_core.h"
 #include "runtime.h"
 #include "spin_hint.h"
@@ -839,7 +840,7 @@ int32_t SchedulerContext::try_early_dispatch(
 // Main scheduler dispatch loop
 // =============================================================================
 
-int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_idx) {
+SIMPLER_A5_TMR_HOT_ENTRY_ALIGN int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_idx) {
     always_assert(sched_ != nullptr);
     CoreTracker &tracker = core_trackers_[thread_idx];
 


### PR DESCRIPTION
## Summary

- add an internal 64-byte function-entry alignment attribute for Linux AArch64 builds
- align the A5 tensormap-and-ringbuffer submit, scheduler dispatch, and completion hot entries
- leave non-Linux and non-AArch64 targets unchanged

This applies the mitigation discussed in #2071. Without an explicit compile-time alignment requirement, unrelated code changes can move hot function entries and make performance-debugging results unpredictable. This change stabilizes the selected entry boundaries; it does not claim that alignment always improves performance.

## Binary verification

The locally built A5 onboard AICPU shared object is AArch64 and places all three selected entries on 64-byte boundaries:

- submit_task_common: 0x1c6c0
- SchedulerContext::complete_slot_task: 0x25180
- SchedulerContext::resolve_and_dispatch: 0x2edc0

Artifact SHA-256: 9a80175755e086400bc96ab480209965ad41ba77b4db3be7e706d3d978151d8a

## Testing

- editable package/runtime build: passed
- targeted pre-commit hooks for all changed files: passed
- C++ unit tests: 126/126 passed
- Python no-hardware unit tests: 2078 passed; 2 existing workflow compiler-symlink contract tests failed locally without touching the tested workflow files

No performance benchmarks were run, and this PR makes no performance-benefit claim.