### PR TITLE
Fix A5 HBG Ready scheduler correctness contracts

### DIFF
--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -18,6 +18,7 @@
 #include "dispatch_payload.h"
 #include "runtime.h"
 #include "scheduler/scheduler_memory.h"
+#include "scheduler/scheduler_ready.h"
 
 /**
  * Unified function pointer type for kernel dispatch

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_ready.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_ready.h
@@ -44,8 +44,7 @@ struct SchedulerReadyStats {
     uint64_t pop_count{0};
     uint64_t steal_count{0};
     uint64_t cas_retry_count{0};
-    uint64_t link_wait_count{0};
-    uint64_t link_wait_max{0};
+    uint64_t contention_giveup_count{0};
 };
 
 struct SchedulerCompletionStats {
@@ -140,9 +139,9 @@ inline __aicore__ uint32_t scheduler_metadata_core_type_index(uint8_t subtask_sl
 }
 
 inline __aicore__ uint8_t scheduler_metadata_single_subtask_slot(uint8_t active_mask) {
-    if ((active_mask & 1U) != 0) return 0;
-    if ((active_mask & 2U) != 0) return 1;
-    return 2;
+    if (active_mask == 1U) return 0;
+    if (active_mask == 2U) return 1;
+    return UINT8_MAX;
 }
 
 inline __aicore__ SchedulerPredicateResult
@@ -466,6 +465,7 @@ inline __aicore__ bool scheduler_bootstrap_ready_batch_append(
     SchedulerReadyBatch *batch, SchedulerReadyStats *stats, bool trace_enabled = false
 ) {
     if (batch == nullptr || task_id < 0 || static_cast<uint64_t>(task_id) >= context->graph_task_count) return false;
+    // next_waiter belongs to exactly one wake or Ready chain while the task is live.
     __gm__ SchedulerTaskControl *control = scheduler_task_control_at(scheduler_state_base, context, task_id);
     scheduler_gm_store(control->state, static_cast<int64_t>(SchedulerTaskState::READY));
     control->next_waiter = SCHEDULER_INBOX_EMPTY;
@@ -494,11 +494,12 @@ inline __aicore__ bool scheduler_bootstrap_ready_batch_publish(
     uint64_t inbox_index, SchedulerReadyBatch *batch, SchedulerReadyStats *stats, uint64_t *ready_types
 ) {
     if (batch == nullptr || batch->head == SCHEDULER_INBOX_EMPTY) return true;
-    if (core_type_index >= SCHEDULER_CORE_TYPE_COUNT || inbox_index >= SCHEDULER_WORKER_CAPACITY || batch->tail < 0 ||
+    if (core_type_index >= SCHEDULER_CORE_TYPE_COUNT || inbox_index >= SCHEDULER_RESOLVER_CAPACITY || batch->tail < 0 ||
         ready_types == nullptr)
         return false;
     __gm__ SchedulerReadyInbox *inbox =
         scheduler_ready_inbox_at(scheduler_state_base, context, core_type_index, inbox_index);
+    scheduler_cache_barrier();
     scheduler_gm_store(inbox->head, batch->head);
     *ready_types |= UINT64_C(1) << core_type_index;
     if (stats != nullptr) ++stats->batch_count;
@@ -506,9 +507,10 @@ inline __aicore__ bool scheduler_bootstrap_ready_batch_publish(
     return true;
 }
 
-inline __aicore__ void scheduler_bootstrap_ready_directory_publish(
+inline __aicore__ bool scheduler_bootstrap_ready_directory_publish(
     __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context, uint64_t resolver_count
 ) {
+    if (resolver_count == 0 || resolver_count > SCHEDULER_RESOLVER_CAPACITY) return false;
     __gm__ SchedulerReadyDirectory *directory = scheduler_ready_directory_at(scheduler_state_base, context);
     for (uint64_t inbox_index = 0; inbox_index < resolver_count; inbox_index += 8)
         scheduler_invalidate_cache_line(&directory->bootstrap_ready_types[inbox_index]);
@@ -531,6 +533,7 @@ inline __aicore__ void scheduler_bootstrap_ready_directory_publish(
             scheduler_publish_cache_line(&directory->core_types[type][shard]);
         }
     }
+    return true;
 }
 
 inline __aicore__ bool scheduler_ready_batch_append(
@@ -538,6 +541,7 @@ inline __aicore__ bool scheduler_ready_batch_append(
     SchedulerReadyBatch *batch, SchedulerReadyStats *stats, bool trace_enabled = false
 ) {
     if (batch == nullptr || task_id < 0 || static_cast<uint64_t>(task_id) >= context->graph_task_count) return false;
+    // next_waiter belongs to exactly one wake or Ready chain while the task is live.
     __gm__ SchedulerTaskControl *control = scheduler_task_control_at(scheduler_state_base, context, task_id);
     scheduler_gm_store(control->state, static_cast<int64_t>(SchedulerTaskState::READY));
     control->next_waiter = SCHEDULER_INBOX_EMPTY;
@@ -632,7 +636,7 @@ inline __aicore__ bool scheduler_ready_owner_maintain_type(
     __gm__ SchedulerReadyOwnerState *owner_state
 ) {
     if (owner_state == nullptr || core_type_index >= SCHEDULER_CORE_TYPE_COUNT ||
-        context->inbox_index >= SCHEDULER_WORKER_CAPACITY)
+        context->inbox_index >= SCHEDULER_RESOLVER_CAPACITY)
         return false;
     __gm__ SchedulerReadyOwnerQueue *owner_queue = &owner_state->queues[core_type_index];
     __gm__ SchedulerReadyInbox *inbox =
@@ -684,67 +688,58 @@ inline __aicore__ bool scheduler_ready_owner_maintain(
 inline __aicore__ bool scheduler_ready_batch_push(
     __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context, uint32_t core_type_index,
     uint64_t inbox_index, SchedulerReadyBatch *batch, SchedulerReadyStats *stats,
-    __gm__ SchedulerReadyOwnerState *owner_state = nullptr
+    __gm__ SchedulerReadyOwnerState *owner_state
 ) {
-    if (batch == nullptr || batch->head == SCHEDULER_INBOX_EMPTY) return true;
-    if (core_type_index >= SCHEDULER_CORE_TYPE_COUNT || inbox_index >= SCHEDULER_WORKER_CAPACITY || batch->tail < 0)
+    if (batch == nullptr || owner_state == nullptr || core_type_index >= SCHEDULER_CORE_TYPE_COUNT ||
+        inbox_index >= SCHEDULER_RESOLVER_CAPACITY || inbox_index != context->inbox_index)
         return false;
+    if (batch->head == SCHEDULER_INBOX_EMPTY) return true;
+    if (batch->tail < 0) return false;
     __gm__ SchedulerReadyInbox *inbox =
         scheduler_ready_inbox_at(scheduler_state_base, context, core_type_index, inbox_index);
-    if (owner_state == nullptr) {
-        if (scheduler_gm_query(inbox->head) != SCHEDULER_INBOX_EMPTY) return false;
+    __gm__ SchedulerReadyOwnerQueue *owner_queue = &owner_state->queues[core_type_index];
+    const int64_t head = scheduler_gm_query(inbox->head);
+    if (head < SCHEDULER_INBOX_EMPTY) return false;
+    const uint64_t pending = scheduler_ready_owner_pending_load(owner_queue);
+    const int64_t pending_head = scheduler_ready_pending_head(pending);
+    const int64_t pending_tail = scheduler_ready_pending_tail(pending);
+    if (head == SCHEDULER_INBOX_EMPTY && pending_head != SCHEDULER_INBOX_EMPTY) {
+        if (pending_head < 0 || pending_tail < 0) return false;
+        scheduler_cache_barrier();
+        scheduler_gm_store(inbox->head, pending_head);
+        scheduler_cache_barrier();
+        scheduler_ready_owner_pending_reset(owner_queue);
+        if (scheduler_gm_query(owner_queue->advertised) == 0) {
+            scheduler_ready_directory_set(
+                scheduler_ready_directory_at(scheduler_state_base, context), core_type_index, inbox_index
+            );
+            scheduler_gm_store(owner_queue->advertised, UINT64_C(1));
+        }
+    } else if (pending_head == SCHEDULER_INBOX_EMPTY && pending_tail != SCHEDULER_INBOX_EMPTY) {
+        return false;
+    }
+    const int64_t published_head = scheduler_gm_query(inbox->head);
+    if (published_head == SCHEDULER_INBOX_EMPTY) {
         scheduler_cache_barrier();
         scheduler_gm_store(inbox->head, batch->head);
-        scheduler_ready_directory_set(
-            scheduler_ready_directory_at(scheduler_state_base, context), core_type_index, inbox_index
-        );
+        if (scheduler_gm_query(owner_queue->advertised) == 0) {
+            scheduler_ready_directory_set(
+                scheduler_ready_directory_at(scheduler_state_base, context), core_type_index, inbox_index
+            );
+            scheduler_gm_store(owner_queue->advertised, UINT64_C(1));
+        }
+        scheduler_ready_batch_reset(batch);
     } else {
-        if (inbox_index != context->inbox_index) return false;
-        __gm__ SchedulerReadyOwnerQueue *owner_queue = &owner_state->queues[core_type_index];
-        const int64_t head = scheduler_gm_query(inbox->head);
-        if (head < SCHEDULER_INBOX_EMPTY) return false;
-        const uint64_t pending = scheduler_ready_owner_pending_load(owner_queue);
-        const int64_t pending_head = scheduler_ready_pending_head(pending);
-        const int64_t pending_tail = scheduler_ready_pending_tail(pending);
-        if (head == SCHEDULER_INBOX_EMPTY && pending_head != SCHEDULER_INBOX_EMPTY) {
-            if (pending_head < 0 || pending_tail < 0) return false;
-            scheduler_cache_barrier();
-            scheduler_gm_store(inbox->head, pending_head);
-            scheduler_cache_barrier();
-            scheduler_ready_owner_pending_reset(owner_queue);
-            if (scheduler_gm_query(owner_queue->advertised) == 0) {
-                scheduler_ready_directory_set(
-                    scheduler_ready_directory_at(scheduler_state_base, context), core_type_index, inbox_index
-                );
-                scheduler_gm_store(owner_queue->advertised, UINT64_C(1));
-            }
-        } else if (pending_head == SCHEDULER_INBOX_EMPTY && pending_tail != SCHEDULER_INBOX_EMPTY) {
-            return false;
+        if (published_head < SCHEDULER_INBOX_EMPTY) return false;
+        if (scheduler_gm_query(owner_queue->advertised) == 0) {
+            scheduler_ready_directory_set(
+                scheduler_ready_directory_at(scheduler_state_base, context), core_type_index, inbox_index
+            );
+            scheduler_gm_store(owner_queue->advertised, UINT64_C(1));
         }
-        const int64_t published_head = scheduler_gm_query(inbox->head);
-        if (published_head == SCHEDULER_INBOX_EMPTY) {
-            scheduler_cache_barrier();
-            scheduler_gm_store(inbox->head, batch->head);
-            if (scheduler_gm_query(owner_queue->advertised) == 0) {
-                scheduler_ready_directory_set(
-                    scheduler_ready_directory_at(scheduler_state_base, context), core_type_index, inbox_index
-                );
-                scheduler_gm_store(owner_queue->advertised, UINT64_C(1));
-            }
-            scheduler_ready_batch_reset(batch);
-        } else {
-            if (published_head < SCHEDULER_INBOX_EMPTY) return false;
-            if (scheduler_gm_query(owner_queue->advertised) == 0) {
-                scheduler_ready_directory_set(
-                    scheduler_ready_directory_at(scheduler_state_base, context), core_type_index, inbox_index
-                );
-                scheduler_gm_store(owner_queue->advertised, UINT64_C(1));
-            }
-            if (!scheduler_ready_owner_pending_append(scheduler_state_base, context, owner_queue, batch)) return false;
-        }
+        if (!scheduler_ready_owner_pending_append(scheduler_state_base, context, owner_queue, batch)) return false;
     }
     if (stats != nullptr) ++stats->batch_count;
-    if (owner_state == nullptr) scheduler_ready_batch_reset(batch);
     return true;
 }
 
@@ -769,24 +764,6 @@ inline __aicore__ bool scheduler_ready_pop_from_inbox(
         }
         __gm__ SchedulerTaskControl *control = scheduler_task_control_at(scheduler_state_base, context, head);
         int64_t next = scheduler_observe_next_waiter(control);
-        uint64_t waits = 0;
-        bool head_changed = false;
-        while (next == SCHEDULER_INBOX_LINK_UNPUBLISHED && waits < UINT64_C(1048576)) {
-            if (scheduler_gm_query(inbox->head) != head) {
-                head_changed = true;
-                break;
-            }
-            ++waits;
-            next = scheduler_observe_next_waiter(control);
-        }
-        if (stats != nullptr) {
-            stats->link_wait_count += waits;
-            if (waits > stats->link_wait_max) stats->link_wait_max = waits;
-        }
-        if (head_changed) {
-            if (stats != nullptr) ++stats->cas_retry_count;
-            continue;
-        }
         if (next < SCHEDULER_INBOX_EMPTY) {
             scheduler_record_error(
                 run_control, head, SchedulerGraphResult::INVALID_ARGUMENTS, &graph, context,
@@ -803,6 +780,8 @@ inline __aicore__ bool scheduler_ready_pop_from_inbox(
         *task_id = head;
         return true;
     }
+    // Bounded contention may defer a non-empty inbox to a later scheduling iteration.
+    if (stats != nullptr) ++stats->contention_giveup_count;
     return true;
 }
 
@@ -817,11 +796,10 @@ inline __aicore__ uint64_t scheduler_load_ready_directory_shard(
     return scheduler_gm_query(directory->core_types[core_type_index][shard].bits) & valid_bits;
 }
 
-static __attribute__((noinline)) __aicore__ bool scheduler_steal_ready_from_shard(
+inline __aicore__ bool scheduler_steal_ready_from_shard(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context,
     __gm__ SchedulerRunControl *run_control, uint32_t core_type_index, uint64_t shard_begin, uint64_t shard_end,
-    uint64_t start, uint64_t *victim_cursor, uint64_t bits, SchedulerReadyStats *stats, SchedulerReadyClaim *claim,
-    bool trace_enabled
+    uint64_t start, uint64_t bits, SchedulerReadyStats *stats, SchedulerReadyClaim *claim, bool trace_enabled
 ) {
     int64_t task_id = SCHEDULER_TASK_ID_INVALID;
     bits &= ~(UINT64_C(1) << (context->inbox_index - shard_begin));
@@ -836,7 +814,6 @@ static __attribute__((noinline)) __aicore__ bool scheduler_steal_ready_from_shar
             uint32_t bit_index = static_cast<uint32_t>(__builtin_ctzll(candidates));
             candidates &= candidates - 1;
             uint64_t victim = shard_begin + bit_index;
-            *victim_cursor = victim + 1 == shard_end ? shard_begin : victim + 1;
             if (!scheduler_ready_pop_from_inbox(
                     graph, scheduler_state_base, context, run_control, core_type_index, victim, &task_id, stats
                 ))
@@ -857,15 +834,16 @@ static __attribute__((noinline)) __aicore__ bool scheduler_steal_ready_from_shar
 inline __aicore__ bool scheduler_claim_ready_for_slot(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context,
     __gm__ SchedulerRunControl *run_control, uint64_t resolver_count, uint32_t core_type_index, uint64_t *victim_cursor,
-    SchedulerReadyStats *stats, SchedulerReadyClaim *claim, bool trace_enabled = false,
-    __gm__ SchedulerReadyOwnerState *owner_state = nullptr
+    SchedulerReadyStats *stats, SchedulerReadyClaim *claim, __gm__ SchedulerReadyOwnerState *owner_state,
+    bool trace_enabled = false
 ) {
-    if (victim_cursor == nullptr || claim == nullptr || resolver_count == 0) return false;
+    if (victim_cursor == nullptr || claim == nullptr || owner_state == nullptr || resolver_count == 0 ||
+        resolver_count > SCHEDULER_RESOLVER_CAPACITY || context->inbox_index >= resolver_count ||
+        core_type_index >= SCHEDULER_CORE_TYPE_COUNT)
+        return false;
     *claim = {};
     claim->claim_start_cycles = trace_enabled ? scheduler_cycles() : 0;
-    if (owner_state != nullptr &&
-        !scheduler_ready_owner_maintain_type(scheduler_state_base, context, core_type_index, owner_state))
-        return false;
+    if (!scheduler_ready_owner_maintain_type(scheduler_state_base, context, core_type_index, owner_state)) return false;
     int64_t task_id = SCHEDULER_TASK_ID_INVALID;
     if (!scheduler_ready_pop_from_inbox(
             graph, scheduler_state_base, context, run_control, core_type_index, context->inbox_index, &task_id, stats
@@ -889,11 +867,12 @@ inline __aicore__ bool scheduler_claim_ready_for_slot(
         scheduler_load_ready_directory_shard(directory, resolver_count, core_type_index, context->inbox_index);
     if (bits != 0 && !scheduler_steal_ready_from_shard(
                          graph, scheduler_state_base, context, run_control, core_type_index, shard_begin, shard_end,
-                         start, victim_cursor, bits, stats, claim, trace_enabled
+                         start, bits, stats, claim, trace_enabled
                      ))
         return false;
+    const uint64_t cursor_base = claim->task_id >= 0 ? claim->inbox_index : start;
+    *victim_cursor = cursor_base + 1 == shard_end ? shard_begin : cursor_base + 1;
     if (claim->task_id >= 0) return true;
-    *victim_cursor = start + 1 == shard_end ? shard_begin : start + 1;
     claim->claim_end_cycles = trace_enabled ? scheduler_cycles() : 0;
     return true;
 }
@@ -902,6 +881,9 @@ inline __aicore__ bool scheduler_ready_directory_nonempty(
     __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context, uint64_t resolver_count,
     uint32_t core_type_index
 ) {
+    if (resolver_count == 0 || resolver_count > SCHEDULER_RESOLVER_CAPACITY || context->inbox_index >= resolver_count ||
+        core_type_index >= SCHEDULER_CORE_TYPE_COUNT)
+        return false;
     __gm__ SchedulerReadyDirectory *directory = scheduler_ready_directory_at(scheduler_state_base, context);
     return scheduler_load_ready_directory_shard(directory, resolver_count, core_type_index, context->inbox_index) != 0;
 }
@@ -940,11 +922,13 @@ inline __aicore__ bool scheduler_fill_dispatch_slot(
     metadata.total_required_subtasks = metadata_source->total_required_subtasks;
     metadata.timing_slot = metadata_source->timing_slot;
     const uint8_t subtask_slot = scheduler_metadata_single_subtask_slot(metadata.active_mask);
-    const uint16_t kernel_id = metadata.kernel_ids[subtask_slot];
     __gm__ SchedulerWorkerContext *target =
         scheduler_worker_context_at(scheduler_state_base, resolver, slot_claim.worker_id);
     scheduler_observe_cache_line(target);
-    if (!scheduler_task_is_executable(metadata.flags) || scheduler_task_is_gang(metadata.flags) ||
+    if (subtask_slot == UINT8_MAX ||
+        (target->core_type != static_cast<int32_t>(CoreType::AIC) &&
+         target->core_type != static_cast<int32_t>(CoreType::AIV)) ||
+        !scheduler_task_is_executable(metadata.flags) || scheduler_task_is_gang(metadata.flags) ||
         scheduler_metadata_core_type_index(subtask_slot) != scheduler_core_type_index(target->core_type)) {
         scheduler_record_error(
             run_control, ready_claim.task_id, SchedulerGraphResult::UNSUPPORTED_SHAPE, &graph, resolver,
@@ -952,6 +936,7 @@ inline __aicore__ bool scheduler_fill_dispatch_slot(
         );
         return false;
     }
+    const uint16_t kernel_id = metadata.kernel_ids[subtask_slot];
     __gm__ SchedulerDispatchSlot *slot =
         scheduler_dispatch_slot_at(scheduler_state_base, resolver, slot_claim.worker_id, slot_claim.slot_index);
     uint32_t generation = slot_claim.generation + 1;
@@ -1045,10 +1030,11 @@ inline __aicore__ bool scheduler_fill_dispatch_slot(
 inline __aicore__ bool scheduler_resolve_completion(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context,
     __gm__ SchedulerRunControl *run_control, int64_t task_id, SchedulerWakeStats *wake_stats,
-    SchedulerReadyStats *ready_stats, SchedulerCompletionStats *completion_stats, bool trace_enabled = false,
-    bool validate_done_state = true, uint64_t *ready_publish_cycles = nullptr,
-    __gm__ SchedulerReadyOwnerState *owner_state = nullptr
+    SchedulerReadyStats *ready_stats, SchedulerCompletionStats *completion_stats,
+    __gm__ SchedulerReadyOwnerState *owner_state, bool trace_enabled = false, bool validate_done_state = true,
+    uint64_t *ready_publish_cycles = nullptr
 ) {
+    if (owner_state == nullptr) return false;
     __gm__ SchedulerTaskControl *control = scheduler_task_control_at(scheduler_state_base, context, task_id);
     if (validate_done_state && scheduler_gm_query(control->state) != static_cast<int64_t>(SchedulerTaskState::DONE)) {
         scheduler_record_error(
@@ -1086,6 +1072,8 @@ inline __aicore__ bool scheduler_resolve_completion(
         if (wake_stats != nullptr) ++wake_stats->wake_migrate_count;
         SchedulerRouteResult route =
             scheduler_route_task(graph, scheduler_state_base, context, run_control, waiter, wake_stats);
+        // A fatal scheduler error makes any READY transition in this local batch terminal;
+        // an unpublished partial batch is never reused as successful scheduler state.
         if (route == SchedulerRouteResult::ERROR) return false;
         if (route == SchedulerRouteResult::READY_TO_ENQUEUE) {
             __gm__ SchedulerTaskMetadata *metadata = scheduler_task_metadata_at(scheduler_state_base, context, waiter);
@@ -1099,18 +1087,25 @@ inline __aicore__ bool scheduler_resolve_completion(
             }
             if (scheduler_task_is_gang(metadata->flags)) {
                 scheduler_publish_gang_ready(scheduler_state_base, context, waiter_control, metadata->flags);
-            } else if (!scheduler_ready_batch_append(
-                           scheduler_state_base, context, waiter,
-                           &batches[scheduler_metadata_core_type_index(
-                               scheduler_metadata_single_subtask_slot(metadata->active_mask)
-                           )],
-                           ready_stats, trace_enabled
-                       )) {
-                scheduler_record_error(
-                    run_control, waiter, SchedulerGraphResult::INVALID_ARGUMENTS, &graph, context,
-                    SchedulerErrorSite::COMPLETION_READY_APPEND_FAILED
-                );
-                return false;
+            } else {
+                const uint8_t subtask_slot = scheduler_metadata_single_subtask_slot(metadata->active_mask);
+                if (subtask_slot == UINT8_MAX) {
+                    scheduler_record_error(
+                        run_control, waiter, SchedulerGraphResult::UNSUPPORTED_SHAPE, &graph, context,
+                        SchedulerErrorSite::COMPLETION_INVALID_SHAPE
+                    );
+                    return false;
+                }
+                if (!scheduler_ready_batch_append(
+                        scheduler_state_base, context, waiter,
+                        &batches[scheduler_metadata_core_type_index(subtask_slot)], ready_stats, trace_enabled
+                    )) {
+                    scheduler_record_error(
+                        run_control, waiter, SchedulerGraphResult::INVALID_ARGUMENTS, &graph, context,
+                        SchedulerErrorSite::COMPLETION_READY_APPEND_FAILED
+                    );
+                    return false;
+                }
             }
         }
         waiter = next;

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
@@ -636,16 +636,16 @@ inline constexpr uint32_t SCHEDULER_PENDING_SLOT_COUNT = 2;
 inline constexpr uint32_t SCHEDULER_CALLABLE_CAPACITY = 1024;
 inline constexpr uint32_t SCHEDULER_CORE_TYPE_COUNT = 2;
 inline constexpr uint32_t SCHEDULER_CLUSTER_CAPACITY = SCHEDULER_WORKER_CAPACITY / 3;
+inline constexpr uint32_t SCHEDULER_RESOLVER_CAPACITY = SCHEDULER_CLUSTER_CAPACITY;
 inline constexpr uint32_t SCHEDULER_GANG_COHORT_COUNT = 2;
 inline constexpr uint32_t SCHEDULER_READY_DIRECTORY_RESOLVERS_PER_SHARD = 7;
 inline constexpr uint32_t SCHEDULER_READY_DIRECTORY_SHARD_COUNT =
-    (SCHEDULER_CLUSTER_CAPACITY + SCHEDULER_READY_DIRECTORY_RESOLVERS_PER_SHARD - 1) /
+    (SCHEDULER_RESOLVER_CAPACITY + SCHEDULER_READY_DIRECTORY_RESOLVERS_PER_SHARD - 1) /
     SCHEDULER_READY_DIRECTORY_RESOLVERS_PER_SHARD;
 inline constexpr int64_t SCHEDULER_TASK_ID_INVALID = -1;
 inline constexpr int64_t SCHEDULER_WAKE_LIST_OPEN = -1;
 inline constexpr int64_t SCHEDULER_WAKE_LIST_CLOSED = -2;
 inline constexpr int64_t SCHEDULER_INBOX_EMPTY = -1;
-inline constexpr int64_t SCHEDULER_INBOX_LINK_UNPUBLISHED = -2;
 inline constexpr uint64_t SCHEDULER_READY_PENDING_EMPTY = UINT64_MAX;
 
 enum class SchedulerTaskState : int64_t {
@@ -913,6 +913,7 @@ enum class SchedulerErrorSite : uint64_t {
     COMPLETION_WAITER_NOT_EXECUTABLE = 64,
     COMPLETION_READY_APPEND_FAILED = 65,
     COMPLETION_READY_PUBLISH_FAILED = 66,
+    COMPLETION_INVALID_SHAPE = 67,
 };
 
 struct alignas(128) SchedulerRunControl {
@@ -1059,9 +1060,8 @@ struct alignas(128) SchedulerWorkerContext {
     uint64_t ready_pop_count;
     uint64_t ready_steal_count;
     uint64_t ready_cas_retry_count;
-    uint64_t ready_link_wait_count;
-    uint64_t ready_link_wait_max;
-    uint64_t ready_stats_reserved[2];
+    uint64_t ready_contention_giveup_count;
+    uint64_t ready_stats_reserved[3];
     uint64_t executed_task_count;
     uint64_t task_state_poll_count;
     uint64_t fanin_state_load_count;
@@ -1209,10 +1209,20 @@ static_assert(sizeof(SchedulerGangCommand) == 128, "gang command layout changed"
 static_assert(alignof(SchedulerGangCommand) == 128, "gang command alignment changed");
 static_assert(sizeof(SchedulerReadyDirectoryShard) == 64, "ready directory shard must occupy one cache line");
 static_assert(alignof(SchedulerReadyDirectoryShard) == 64, "ready directory shard alignment changed");
+static_assert(SCHEDULER_RESOLVER_CAPACITY <= SCHEDULER_WORKER_CAPACITY, "resolver capacity exceeds worker storage");
+static_assert(
+    SCHEDULER_READY_DIRECTORY_SHARD_COUNT * SCHEDULER_READY_DIRECTORY_RESOLVERS_PER_SHARD >=
+        SCHEDULER_RESOLVER_CAPACITY,
+    "ready directory does not cover every resolver"
+);
 static_assert(
     offsetof(SchedulerReadyDirectory, bootstrap_ready_types) ==
         SCHEDULER_CORE_TYPE_COUNT * SCHEDULER_READY_DIRECTORY_SHARD_COUNT * 64,
     "bootstrap flags must follow the ready directory shards"
+);
+static_assert(
+    offsetof(SchedulerReadyDirectory, bootstrap_ready_types) % 64 == 0,
+    "bootstrap flags must begin on a cache-line boundary"
 );
 static_assert(
     sizeof(SchedulerReadyDirectory) == ((offsetof(SchedulerReadyDirectory, bootstrap_ready_types) +
@@ -1336,7 +1346,7 @@ inline bool scheduler_plan_layout(
         !SCHEDULER_RESERVE_ARRAY(
             SCHEDULER_CORE_TYPE_COUNT * SCHEDULER_WORKER_CAPACITY, SchedulerReadyInbox, ready_inboxes_offset
         ) ||
-        !SCHEDULER_RESERVE_ARRAY(SCHEDULER_CLUSTER_CAPACITY, SchedulerReadyOwnerState, ready_owner_states_offset) ||
+        !SCHEDULER_RESERVE_ARRAY(SCHEDULER_RESOLVER_CAPACITY, SchedulerReadyOwnerState, ready_owner_states_offset) ||
         !scheduler_layout_reserve(
             &cursor, sizeof(SchedulerReadyDirectory), alignof(SchedulerReadyDirectory), &next.ready_directory_offset
         ) ||
@@ -1377,7 +1387,7 @@ inline bool scheduler_init_data_from_layout(void *base, const AicoreSchedulerLay
     for (uint64_t i = 0; i < SCHEDULER_CORE_TYPE_COUNT * SCHEDULER_WORKER_CAPACITY; ++i)
         ready[i].head = SCHEDULER_INBOX_EMPTY;
     auto *ready_owners = scheduler_state_at<SchedulerReadyOwnerState>(base, layout.ready_owner_states_offset);
-    for (uint64_t owner = 0; owner < SCHEDULER_CLUSTER_CAPACITY; ++owner) {
+    for (uint64_t owner = 0; owner < SCHEDULER_RESOLVER_CAPACITY; ++owner) {
         for (uint32_t type = 0; type < SCHEDULER_CORE_TYPE_COUNT; ++type)
             ready_owners[owner].queues[type].pending_endpoints = SCHEDULER_READY_PENDING_EMPTY;
     }

--- a/tests/ut/cpp/a5/test_hbg_scheduler_ready.cpp
+++ b/tests/ut/cpp/a5/test_hbg_scheduler_ready.cpp
@@ -120,6 +120,8 @@ struct FixtureStorage {
         scheduler_state = std::make_unique<SchedulerStateBuffer>(layout);
         run_control = scheduler_state_at<SchedulerRunControl>(scheduler_state->base(), layout.run_control_offset);
         contexts = scheduler_state_at<SchedulerWorkerContext>(scheduler_state->base(), layout.worker_contexts_offset);
+        owner_states =
+            scheduler_state_at<SchedulerReadyOwnerState>(scheduler_state->base(), layout.ready_owner_states_offset);
         run_control->aiv_active_worker_count = workers;
         run_control->resolver_count = workers;
         for (uint64_t worker = 0; worker < workers; ++worker) {
@@ -146,6 +148,7 @@ struct FixtureStorage {
             context.runtime_worker_count = workers;
             context.worker_index = worker;
             context.inbox_index = worker;
+            scheduler_ready_owner_init(&owner_states[worker]);
         }
         metadata = scheduler_state_at<SchedulerTaskMetadata>(scheduler_state->base(), layout.task_metadata_offset);
         callable_addresses = scheduler_state_at<uint64_t>(scheduler_state->base(), layout.callable_addresses_offset);
@@ -165,6 +168,7 @@ struct FixtureStorage {
     std::unique_ptr<SchedulerStateBuffer> scheduler_state;
     SchedulerRunControl *run_control{nullptr};
     SchedulerWorkerContext *contexts{nullptr};
+    SchedulerReadyOwnerState *owner_states{nullptr};
     SchedulerTaskMetadata *metadata{nullptr};
     uint64_t *callable_addresses{nullptr};
 };
@@ -225,14 +229,13 @@ TEST(SchedulerBootstrap, PublishesExclusiveInboxAndAggregatesDirectory) {
     ASSERT_TRUE(
         scheduler_bootstrap_ready_batch_append(storage.scheduler_state->base(), &storage.contexts[1], 1, &batch, &stats)
     );
-    scheduler_cache_barrier();
     uint64_t ready_types = 0;
     ASSERT_TRUE(scheduler_bootstrap_ready_batch_publish(
         storage.scheduler_state->base(), &storage.contexts[1], 0, 0, &batch, &stats, &ready_types
     ));
     auto *directory = scheduler_ready_directory_at(storage.scheduler_state->base(), &storage.contexts[1]);
     directory->bootstrap_ready_types[0] = ready_types;
-    scheduler_bootstrap_ready_directory_publish(storage.scheduler_state->base(), &storage.contexts[1], 2);
+    ASSERT_TRUE(scheduler_bootstrap_ready_directory_publish(storage.scheduler_state->base(), &storage.contexts[1], 2));
 
     auto *controls =
         scheduler_state_at<SchedulerTaskControl>(storage.scheduler_state->base(), storage.layout.task_controls_offset);
@@ -245,6 +248,54 @@ TEST(SchedulerBootstrap, PublishesExclusiveInboxAndAggregatesDirectory) {
     EXPECT_EQ(stats.batch_count, 1u);
 }
 
+TEST(SchedulerReadyInbox, RejectsResolverCapacityBoundary) {
+    FixtureStorage storage(1, 1);
+    SchedulerReadyStats stats{};
+    SchedulerReadyBatch batch{};
+    ASSERT_TRUE(scheduler_ready_batch_append(storage.scheduler_state->base(), &storage.contexts[0], 0, &batch, &stats));
+    uint64_t ready_types = 0;
+
+    EXPECT_FALSE(scheduler_bootstrap_ready_batch_publish(
+        storage.scheduler_state->base(), &storage.contexts[0], 0, SCHEDULER_RESOLVER_CAPACITY, &batch, &stats,
+        &ready_types
+    ));
+    storage.contexts[0].inbox_index = SCHEDULER_RESOLVER_CAPACITY;
+    EXPECT_FALSE(scheduler_ready_owner_maintain_type(
+        storage.scheduler_state->base(), &storage.contexts[0], 0, &storage.owner_states[0]
+    ));
+    EXPECT_FALSE(scheduler_ready_batch_push(
+        storage.scheduler_state->base(), &storage.contexts[0], 0, SCHEDULER_RESOLVER_CAPACITY, &batch, &stats,
+        &storage.owner_states[0]
+    ));
+    storage.contexts[0].inbox_index = 0;
+    EXPECT_FALSE(scheduler_bootstrap_ready_directory_publish(
+        storage.scheduler_state->base(), &storage.contexts[0], SCHEDULER_RESOLVER_CAPACITY + 1
+    ));
+}
+
+TEST(SchedulerReadyInbox, RequiresOwnerStateForPublishAndClaim) {
+    FixtureStorage storage(1, 1);
+    GraphBuffer graph(1);
+    graph.executable(0, 0);
+    SchedulerReadyStats stats{};
+    SchedulerReadyBatch batch{};
+    ASSERT_TRUE(scheduler_ready_batch_append(storage.scheduler_state->base(), &storage.contexts[0], 0, &batch, &stats));
+
+    EXPECT_FALSE(
+        scheduler_ready_batch_push(storage.scheduler_state->base(), &storage.contexts[0], 0, 0, &batch, &stats, nullptr)
+    );
+    uint64_t cursor = 0;
+    SchedulerReadyClaim claim{};
+    EXPECT_FALSE(scheduler_claim_ready_for_slot(
+        graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, 1, 0, &cursor,
+        &stats, &claim, nullptr
+    ));
+    EXPECT_FALSE(scheduler_resolve_completion(
+        graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, 0, nullptr, nullptr,
+        nullptr, nullptr
+    ));
+}
+
 TEST(SchedulerReadyInbox, BatchPushAndOwnerMaintenancePreserveFifoAndDirectory) {
     constexpr uint64_t kTasks = 4;
     FixtureStorage storage(kTasks, 1);
@@ -252,7 +303,7 @@ TEST(SchedulerReadyInbox, BatchPushAndOwnerMaintenancePreserveFifoAndDirectory) 
     for (uint64_t task = 0; task < kTasks; ++task)
         graph.executable(task, 0);
     SchedulerReadyBatch batch{};
-    SchedulerReadyOwnerState owner_state{};
+    SchedulerReadyOwnerState &owner_state = storage.owner_states[0];
     SchedulerReadyStats stats{};
     for (uint64_t task = 0; task < kTasks; ++task)
         ASSERT_TRUE(
@@ -312,7 +363,7 @@ TEST(SchedulerReadyInbox, OwnerPromotesPendingBankAfterPublishedBankDrains) {
     GraphBuffer graph(kTasks);
     for (uint64_t task = 0; task < kTasks; ++task)
         graph.executable(task, 0);
-    SchedulerReadyOwnerState owner_state{};
+    SchedulerReadyOwnerState &owner_state = storage.owner_states[0];
     SchedulerReadyStats stats{};
     SchedulerReadyBatch published{};
     SchedulerReadyBatch pending{};
@@ -365,7 +416,7 @@ TEST(SchedulerReadyInbox, OlderPendingBankPrecedesBatchArrivingAfterDrain) {
     GraphBuffer graph(kTasks);
     for (uint64_t task = 0; task < kTasks; ++task)
         graph.executable(task, 0);
-    SchedulerReadyOwnerState owner_state{};
+    SchedulerReadyOwnerState &owner_state = storage.owner_states[0];
     SchedulerReadyStats stats{};
     for (int64_t task = 0; task < 2; ++task) {
         SchedulerReadyBatch batch{};
@@ -408,7 +459,7 @@ TEST(SchedulerReadyInbox, ThiefCannotObserveOrPromoteOwnerPendingBank) {
     GraphBuffer graph(2);
     graph.executable(0, 0);
     graph.executable(1, 0);
-    SchedulerReadyOwnerState owner_state{};
+    SchedulerReadyOwnerState &owner_state = storage.owner_states[1];
     SchedulerReadyStats stats{};
     for (int64_t task = 0; task < 2; ++task) {
         SchedulerReadyBatch batch{};
@@ -445,15 +496,15 @@ TEST(SchedulerReadyInbox, StealsOnlyFromMarkedVictim) {
     SchedulerReadyBatch batch{};
     SchedulerReadyStats stats{};
     ASSERT_TRUE(scheduler_ready_batch_append(storage.scheduler_state->base(), &storage.contexts[1], 0, &batch, &stats));
-    ASSERT_TRUE(
-        scheduler_ready_batch_push(storage.scheduler_state->base(), &storage.contexts[1], 0, 1, &batch, &stats)
-    );
+    ASSERT_TRUE(scheduler_ready_batch_push(
+        storage.scheduler_state->base(), &storage.contexts[1], 0, 1, &batch, &stats, &storage.owner_states[1]
+    ));
 
     uint64_t cursor = 1;
     SchedulerReadyClaim claim{};
     ASSERT_TRUE(scheduler_claim_ready_for_slot(
         graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, 2, 0, &cursor,
-        &stats, &claim
+        &stats, &claim, &storage.owner_states[0]
     ));
     EXPECT_EQ(claim.task_id, 0);
     EXPECT_EQ(claim.inbox_index, 1u);
@@ -479,7 +530,7 @@ TEST(SchedulerReadyInbox, BootstrapPublishesIndependentDirectoryShards) {
     directory->bootstrap_ready_types[7] = UINT64_C(1) << 1;
     directory->bootstrap_ready_types[13] = (UINT64_C(1) << 0) | (UINT64_C(1) << 1);
 
-    scheduler_bootstrap_ready_directory_publish(storage.scheduler_state->base(), &storage.contexts[0], 14);
+    ASSERT_TRUE(scheduler_bootstrap_ready_directory_publish(storage.scheduler_state->base(), &storage.contexts[0], 14));
 
     EXPECT_EQ(directory->core_types[0][0].bits, (UINT64_C(1) << 0) | (UINT64_C(1) << 6));
     EXPECT_EQ(directory->core_types[1][0].bits, 0u);
@@ -498,21 +549,21 @@ TEST(SchedulerReadyInbox, SparseDirectoryWrapsWithinShard) {
     ASSERT_TRUE(
         scheduler_ready_batch_append(storage.scheduler_state->base(), &storage.contexts[13], 0, &high_batch, &stats)
     );
-    ASSERT_TRUE(
-        scheduler_ready_batch_push(storage.scheduler_state->base(), &storage.contexts[13], 0, 13, &high_batch, &stats)
-    );
+    ASSERT_TRUE(scheduler_ready_batch_push(
+        storage.scheduler_state->base(), &storage.contexts[13], 0, 13, &high_batch, &stats, &storage.owner_states[13]
+    ));
     ASSERT_TRUE(
         scheduler_ready_batch_append(storage.scheduler_state->base(), &storage.contexts[8], 1, &low_batch, &stats)
     );
-    ASSERT_TRUE(
-        scheduler_ready_batch_push(storage.scheduler_state->base(), &storage.contexts[8], 0, 8, &low_batch, &stats)
-    );
+    ASSERT_TRUE(scheduler_ready_batch_push(
+        storage.scheduler_state->base(), &storage.contexts[8], 0, 8, &low_batch, &stats, &storage.owner_states[8]
+    ));
 
     uint64_t cursor = 12;
     SchedulerReadyClaim claim{};
     ASSERT_TRUE(scheduler_claim_ready_for_slot(
         graph.graph(), storage.scheduler_state->base(), &storage.contexts[7], storage.run_control, 14, 0, &cursor,
-        &stats, &claim
+        &stats, &claim, &storage.owner_states[7]
     ));
     EXPECT_EQ(claim.task_id, 0);
     EXPECT_EQ(claim.inbox_index, 13u);
@@ -520,7 +571,7 @@ TEST(SchedulerReadyInbox, SparseDirectoryWrapsWithinShard) {
 
     ASSERT_TRUE(scheduler_claim_ready_for_slot(
         graph.graph(), storage.scheduler_state->base(), &storage.contexts[7], storage.run_control, 14, 0, &cursor,
-        &stats, &claim
+        &stats, &claim, &storage.owner_states[7]
     ));
     EXPECT_EQ(claim.task_id, 1);
     EXPECT_EQ(claim.inbox_index, 8u);
@@ -534,22 +585,22 @@ TEST(SchedulerReadyInbox, DoesNotStealAcrossDirectoryShards) {
     SchedulerReadyBatch batch{};
     SchedulerReadyStats stats{};
     ASSERT_TRUE(scheduler_ready_batch_append(storage.scheduler_state->base(), &storage.contexts[8], 0, &batch, &stats));
-    ASSERT_TRUE(
-        scheduler_ready_batch_push(storage.scheduler_state->base(), &storage.contexts[8], 0, 8, &batch, &stats)
-    );
+    ASSERT_TRUE(scheduler_ready_batch_push(
+        storage.scheduler_state->base(), &storage.contexts[8], 0, 8, &batch, &stats, &storage.owner_states[8]
+    ));
 
     uint64_t cursor = 1;
     SchedulerReadyClaim claim{};
     ASSERT_TRUE(scheduler_claim_ready_for_slot(
         graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, 14, 0, &cursor,
-        &stats, &claim
+        &stats, &claim, &storage.owner_states[0]
     ));
     EXPECT_EQ(claim.task_id, SCHEDULER_TASK_ID_INVALID);
 
     cursor = 8;
     ASSERT_TRUE(scheduler_claim_ready_for_slot(
         graph.graph(), storage.scheduler_state->base(), &storage.contexts[7], storage.run_control, 14, 0, &cursor,
-        &stats, &claim
+        &stats, &claim, &storage.owner_states[7]
     ));
     EXPECT_EQ(claim.task_id, 0);
     EXPECT_EQ(claim.inbox_index, 8u);
@@ -566,6 +617,90 @@ TEST(SchedulerDispatch, RejectsKernelIdBeforeCallableTableAccess) {
     SchedulerReadyClaim ready_claim{};
     ready_claim.task_id = 0;
 
+    EXPECT_FALSE(scheduler_fill_dispatch_slot(
+        graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, slot_claim,
+        ready_claim
+    ));
+    EXPECT_EQ(storage.run_control->scheduler_error, static_cast<uint64_t>(SchedulerGraphResult::INVALID_CALLABLE));
+    EXPECT_EQ(storage.run_control->error_site, static_cast<uint64_t>(SchedulerErrorSite::DISPATCH_INVALID_CALLABLE));
+}
+
+TEST(SchedulerDispatch, RejectsInvalidSingleSubtaskShapeBeforeMetadataIndex) {
+    FixtureStorage storage(1, 1);
+    GraphBuffer graph(1);
+    graph.executable(0, 0);
+    storage.contexts[0].core_type = static_cast<int32_t>(CoreType::AIC);
+    storage.metadata[0].active_mask = 0;
+    SchedulerFreeSlotClaim slot_claim{0, 0, 0};
+    SchedulerReadyClaim ready_claim{};
+    ready_claim.task_id = 0;
+
+    EXPECT_FALSE(scheduler_fill_dispatch_slot(
+        graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, slot_claim,
+        ready_claim
+    ));
+    EXPECT_EQ(storage.run_control->scheduler_error, static_cast<uint64_t>(SchedulerGraphResult::UNSUPPORTED_SHAPE));
+    EXPECT_EQ(storage.run_control->error_site, static_cast<uint64_t>(SchedulerErrorSite::DISPATCH_INVALID_SHAPE));
+}
+
+TEST(SchedulerDispatch, RejectsCoreTypeMismatch) {
+    FixtureStorage storage(1, 1);
+    GraphBuffer graph(1);
+    graph.executable(0, 0);
+    storage.contexts[0].core_type = static_cast<int32_t>(CoreType::AIV);
+    SchedulerFreeSlotClaim slot_claim{0, 0, 0};
+    SchedulerReadyClaim ready_claim{};
+    ready_claim.task_id = 0;
+
+    EXPECT_FALSE(scheduler_fill_dispatch_slot(
+        graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, slot_claim,
+        ready_claim
+    ));
+    EXPECT_EQ(storage.run_control->error_site, static_cast<uint64_t>(SchedulerErrorSite::DISPATCH_INVALID_SHAPE));
+}
+
+TEST(SchedulerDispatch, RejectsUnknownTargetCoreType) {
+    FixtureStorage storage(1, 1);
+    GraphBuffer graph(1);
+    graph.executable(0, 1);
+    storage.contexts[0].core_type = 2;
+    storage.metadata[0].kernel_ids[1] = 1;
+    storage.metadata[0].active_mask = 2;
+    SchedulerFreeSlotClaim slot_claim{0, 0, 0};
+    SchedulerReadyClaim ready_claim{};
+    ready_claim.task_id = 0;
+
+    EXPECT_FALSE(scheduler_fill_dispatch_slot(
+        graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, slot_claim,
+        ready_claim
+    ));
+    EXPECT_EQ(storage.run_control->scheduler_error, static_cast<uint64_t>(SchedulerGraphResult::UNSUPPORTED_SHAPE));
+    EXPECT_EQ(storage.run_control->error_site, static_cast<uint64_t>(SchedulerErrorSite::DISPATCH_INVALID_SHAPE));
+}
+
+TEST(SchedulerDispatch, WrapsGenerationAndRejectsZeroCallable) {
+    FixtureStorage storage(2, 1);
+    GraphBuffer graph(2);
+    graph.executable(0, 0);
+    graph.executable(1, 0);
+    storage.contexts[0].core_type = static_cast<int32_t>(CoreType::AIC);
+    SchedulerFreeSlotClaim slot_claim{0, 0, UINT32_MAX};
+    SchedulerReadyClaim ready_claim{};
+    ready_claim.task_id = 0;
+
+    ASSERT_TRUE(scheduler_fill_dispatch_slot(
+        graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, slot_claim,
+        ready_claim
+    ));
+    auto *slot = scheduler_dispatch_slot_at(storage.scheduler_state->base(), &storage.contexts[0], 0, 0);
+    EXPECT_EQ(slot->generation, 1u);
+    EXPECT_EQ(scheduler_dispatch_generation(slot->publication), 1u);
+
+    storage.callable_addresses[1] = 0;
+    storage.run_control->error_claimed = 0;
+    storage.run_control->scheduler_error = 0;
+    slot_claim.slot_index = 1;
+    ready_claim.task_id = 1;
     EXPECT_FALSE(scheduler_fill_dispatch_slot(
         graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, slot_claim,
         ready_claim
@@ -612,10 +747,37 @@ TEST(SchedulerDispatch, AcceptsLastCallableAndInlineSentinel) {
 TEST(SchedulerPredicate, DistinguishesFailedAndMalformedPredicates) {
     GraphBuffer graph(1);
     graph.executable(0, 0);
-    alignas(8) int64_t value = 3;
-    graph.predicate(0, reinterpret_cast<uint64_t>(&value), 8, static_cast<uint8_t>(PredicateOp::GT), 4);
-    EXPECT_EQ(scheduler_evaluate_task_predicate(graph.graph(), 0), SchedulerPredicateResult::FAIL);
-    graph.predicate(0, reinterpret_cast<uint64_t>(&value), 8, static_cast<uint8_t>(PredicateOp::LE), 4);
+    alignas(8) int64_t value = 5;
+    struct PredicateCase {
+        PredicateOp op;
+        int64_t pass_target;
+        int64_t fail_target;
+    };
+    constexpr std::array<PredicateCase, 6> cases{{
+        {PredicateOp::EQ, 5, 6},
+        {PredicateOp::NE, 6, 5},
+        {PredicateOp::GT, 4, 5},
+        {PredicateOp::LT, 6, 5},
+        {PredicateOp::GE, 5, 6},
+        {PredicateOp::LE, 5, 4},
+    }};
+    constexpr std::array<uint8_t, 4> element_sizes{1, 2, 4, 8};
+    for (uint8_t element_size : element_sizes) {
+        for (const PredicateCase &predicate_case : cases) {
+            graph.predicate(
+                0, reinterpret_cast<uint64_t>(&value), element_size, static_cast<uint8_t>(predicate_case.op),
+                predicate_case.pass_target
+            );
+            EXPECT_EQ(scheduler_evaluate_task_predicate(graph.graph(), 0), SchedulerPredicateResult::PASS);
+            graph.predicate(
+                0, reinterpret_cast<uint64_t>(&value), element_size, static_cast<uint8_t>(predicate_case.op),
+                predicate_case.fail_target
+            );
+            EXPECT_EQ(scheduler_evaluate_task_predicate(graph.graph(), 0), SchedulerPredicateResult::FAIL);
+        }
+    }
+
+    graph.predicate(0, 0, 0, static_cast<uint8_t>(PredicateOp::NONE));
     EXPECT_EQ(scheduler_evaluate_task_predicate(graph.graph(), 0), SchedulerPredicateResult::PASS);
 
     graph.predicate(0, 0, 8, static_cast<uint8_t>(PredicateOp::GT));
@@ -684,9 +846,9 @@ TEST(SchedulerReadyInbox, ConcurrentConsumersNeverDuplicateTask) {
             scheduler_ready_batch_append(storage.scheduler_state->base(), &storage.contexts[0], task, &batch, nullptr)
         );
     }
-    ASSERT_TRUE(
-        scheduler_ready_batch_push(storage.scheduler_state->base(), &storage.contexts[0], 0, 0, &batch, nullptr)
-    );
+    ASSERT_TRUE(scheduler_ready_batch_push(
+        storage.scheduler_state->base(), &storage.contexts[0], 0, 0, &batch, nullptr, &storage.owner_states[0]
+    ));
     std::vector<std::atomic<uint32_t>> seen(kTasks);
     std::atomic<uint64_t> claimed{0};
     std::atomic<bool> failed{false};
@@ -726,8 +888,7 @@ TEST(SchedulerReadyInbox, OwnerPushRacesThiefWithoutLosingTasks) {
     GraphBuffer graph(kTasks);
     for (uint64_t task = 0; task < kTasks; ++task)
         graph.executable(task, 0);
-    SchedulerReadyOwnerState owner_state{};
-    scheduler_ready_owner_init(&owner_state);
+    SchedulerReadyOwnerState &owner_state = storage.owner_states[0];
     std::vector<std::atomic<uint32_t>> seen(kTasks);
     std::atomic<uint64_t> claimed{0};
     std::atomic<bool> failed{false};
@@ -795,8 +956,7 @@ TEST(SchedulerReadyInbox, PendingPromotionRacesThiefWithoutReplayingTasks) {
     GraphBuffer graph(kTasks);
     for (uint64_t task = 0; task < kTasks; ++task)
         graph.executable(task, 0);
-    SchedulerReadyOwnerState owner_state{};
-    scheduler_ready_owner_init(&owner_state);
+    SchedulerReadyOwnerState &owner_state = storage.owner_states[0];
     SchedulerReadyBatch published{};
     ASSERT_TRUE(
         scheduler_ready_batch_append(storage.scheduler_state->base(), &storage.contexts[0], 0, &published, nullptr)
@@ -895,7 +1055,7 @@ TEST(SchedulerReadyWake, ConcurrentRegistrationAndCloseResolveEveryConsumerExact
         scheduler_gm_store(controls[0].state, static_cast<int64_t>(SchedulerTaskState::DONE));
         if (!scheduler_resolve_completion(
                 graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, 0, nullptr,
-                nullptr, nullptr
+                nullptr, nullptr, &storage.owner_states[0]
             ))
             failed.store(true, std::memory_order_relaxed);
     });
@@ -940,7 +1100,7 @@ TEST(SchedulerReadyWake, WakeResolvePublishesConsumerToResolverLocalInbox) {
     controls[0].state = static_cast<int64_t>(SchedulerTaskState::DONE);
     ASSERT_TRUE(scheduler_resolve_completion(
         graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, 0, &wake, &ready,
-        &completion
+        &completion, &storage.owner_states[0]
     ));
     EXPECT_EQ(completion.resolve_count, 1u);
     int64_t task = SCHEDULER_TASK_ID_INVALID;
@@ -962,7 +1122,7 @@ TEST(SchedulerReadyWake, WakeResolveQueuesBehindOlderPublishedWork) {
     SchedulerWakeStats wake{};
     SchedulerReadyStats ready{};
     SchedulerCompletionStats completion{};
-    SchedulerReadyOwnerState owner_state{};
+    SchedulerReadyOwnerState &owner_state = storage.owner_states[0];
     EXPECT_EQ(
         scheduler_route_task(
             graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, 1, &wake
@@ -979,7 +1139,7 @@ TEST(SchedulerReadyWake, WakeResolveQueuesBehindOlderPublishedWork) {
     controls[0].state = static_cast<int64_t>(SchedulerTaskState::DONE);
     ASSERT_TRUE(scheduler_resolve_completion(
         graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, 0, &wake, &ready,
-        &completion, false, true, nullptr, &owner_state
+        &completion, &owner_state, false, true, nullptr
     ));
     EXPECT_EQ(completion.resolve_count, 1u);
     EXPECT_EQ(scheduler_ready_pending_head(owner_state.queues[0].pending_endpoints), 1);
@@ -996,6 +1156,31 @@ TEST(SchedulerReadyWake, WakeResolveQueuesBehindOlderPublishedWork) {
         graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, 0, 0, &task, &ready
     ));
     EXPECT_EQ(task, 1);
+}
+
+TEST(SchedulerReadyWake, RejectsInvalidWaiterShapeBeforeReadyBatchIndex) {
+    FixtureStorage storage(2, 1);
+    GraphBuffer graph(2);
+    graph.executable(0, 0);
+    graph.executable(1, 0, {0});
+    storage.metadata[1].active_mask = 0;
+    storage.metadata[1].flags |= SCHEDULER_TASK_HAS_FANIN;
+    ASSERT_EQ(
+        scheduler_route_task(
+            graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, 1, nullptr
+        ),
+        SchedulerRouteResult::WAITING
+    );
+    auto *controls =
+        scheduler_state_at<SchedulerTaskControl>(storage.scheduler_state->base(), storage.layout.task_controls_offset);
+    controls[0].state = static_cast<int64_t>(SchedulerTaskState::DONE);
+
+    EXPECT_FALSE(scheduler_resolve_completion(
+        graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, 0, nullptr, nullptr,
+        nullptr, &storage.owner_states[0]
+    ));
+    EXPECT_EQ(storage.run_control->scheduler_error, static_cast<uint64_t>(SchedulerGraphResult::UNSUPPORTED_SHAPE));
+    EXPECT_EQ(storage.run_control->error_site, static_cast<uint64_t>(SchedulerErrorSite::COMPLETION_INVALID_SHAPE));
 }
 
 }  // namespace


### PR DESCRIPTION
## Problem

#2063 introduced the A5 HBG dependency-to-Ready layer. Review of that layer
found several contracts that should be closed before the single-lane
dispatch/completion work in #2072 builds further on Ready routing: resolver
bounds were wider than the allocated Ready directory, owner state was optional
on owner-only operations, and malformed task shapes could reach metadata arrays
before validation.

## Changes

### Harden Ready ownership and bounds

- Bound inbox, directory, claim, and bootstrap operations by Resolver capacity,
  and reject zero or oversized Resolver counts.
- Require Resolver-local owner state for Ready publication, claims, and
  completion wakeups; only the owner can promote its pending bank.
- Add the bootstrap publication barrier and keep the victim cursor under one
  writer after each steal attempt.
- Remove the unreachable unpublished-link wait protocol. Bounded CAS contention
  is reported as a give-up statistic while preserving the scheduler worker wire
  layout.

### Reject malformed scheduler metadata early

- Return an invalid sentinel for zero- or multi-bit single-subtask masks and
  validate it before indexing kernel metadata.
- Reject unknown dispatch target core types, core-type mismatches, invalid
  callables, and generation-zero wraparound through stable scheduler errors.
- Reject malformed completion waiter shapes before indexing Ready batches and
  report the dedicated completion error site.
- Compile the Ready helpers through the A5 AICore executor so device-side
  compilation covers the header used by the production A5 path.

## Correctness and scope

- The effective diff is confined to `src/a5/runtime/host_build_graph` and its
  A5 C++ unit test.
- Shared HBG predicate validation and the A2/A3 regression tests remain
  unchanged from `main`.
- Scheduler worker layout size and offsets remain unchanged.
- This PR does not switch the production scheduler entry path or add Gang
  scheduling; those remain outside this corrective change.

## Reviewer guide

- Verify the mandatory owner-state path preserves published-before-pending FIFO
  order and that only the owner promotes its pending bank.
- Check every Resolver index against `SCHEDULER_RESOLVER_CAPACITY`, especially
  bootstrap publication and shard traversal.
- Check dispatch/completion shape validation occurs before metadata indexing
  and that all failure paths avoid partial publication.
- Confirm the effective diff contains no common or A2/A3 changes.

## Testing

- [x] Changed-file pre-commit: all hooks passed.
- [x] Full non-hardware C++ build and CTest: 126/126 passed.
- [x] Targeted A5 HBG Ready unit test: 31/31 passed.
- [x] Shared HBG submit-poison unit test: 3/3 passed.
- [x] Editable package/CCEC build completed successfully.
- [x] A5 simulator HBG scenes: 12 passed, 279 deselected.
- [x] Scope audit: exactly four A5 files differ from `main`.
- [x] GitHub CI: all required checks passed, including A5 onboard.
- [ ] A5 onboard hardware testing was not run locally.
