### PR TITLE
Fix: wire the DeepSeek-V4 decode driver's log level, and make the hbg-bind-phases recipe fillable

### DIFF
--- a/.claude/skills/hbg-bind-phases/SKILL.md
+++ b/.claude/skills/hbg-bind-phases/SKILL.md
@@ -14,14 +14,18 @@ still yields its whole host picture.
 
 ## The recipe
 
-Fill in `ENVS`, `CASE`, `TAIL` from the two tables below, then run it verbatim.
+Fill in `NAME`, `DEVICES`, `TIMEOUT`, `CASE` from the case table and `ENVS`,
+`TAIL` from the mode table, then run it verbatim.
 `pip install --no-build-isolation -e .` first, and again after every `HEAD` move.
 
 ```bash
 HEAD_SHA=$(git rev-parse --short HEAD)
-LOG="outputs/bind_${HEAD_SHA}.log"; mkdir -p outputs
+NAME="<case>_<mode>"                    # e.g. qwen_numbers — see below
+LOG="outputs/bind_${NAME}_${HEAD_SHA}.log"; mkdir -p outputs
 MARK="outputs/.bind_start"; : >"$MARK"   # fixed mtime; "$LOG" keeps being appended to
 
+DEVICES=<N>                                            # per case
+TIMEOUT=<seconds>                                      # per case
 ENVS="SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 \
 TORCH_DEVICE_BACKEND_AUTOLOAD=0 SIMPLER_SKIP_DEVICE_RUN=1"          # + mode delta
 CASE="examples/.../<entry>.py -p a2a3"                # exactly as the case table gives it
@@ -29,7 +33,7 @@ TAIL="--rounds 6 --log-level timing"                                 # per mode
 
 .claude/skills/onboard-arch-precheck/check.sh a2a3 || exit 1
 echo "[stamp] $HEAD_SHA env $ENVS python $CASE $TAIL" >"$LOG"
-task-submit --device auto --device-num <N> --timeout 3600 --max-time 3600 \
+task-submit --device auto --device-num "$DEVICES" --timeout "$TIMEOUT" --max-time "$TIMEOUT" \
   --run "env $ENVS python $CASE $TAIL -d \$TASK_DEVICE" >>"$LOG" 2>&1
 grep -c 'bind phase=' "$LOG"          # numbers mode: must be > 0
 ```
@@ -37,6 +41,21 @@ grep -c 'bind phase=' "$LOG"          # numbers mode: must be > 0
 `env` prefixes the assignments so they survive coming from a variable, and the
 `[stamp]` line is the same string that runs — which is what makes two logs
 comparable. Never hand-edit one arm's command without the other's.
+
+**`NAME` carries the case and the mode because `$LOG` is opened with a
+truncating `>`.** Two cases at one commit, or the same case in both modes, would
+otherwise write the same path and the second run would destroy the first log
+without saying so.
+
+**`--log-level timing` pins a condition rather than enabling anything.**
+`python/simpler/_log.py` puts the `simpler` logger at TIMING on import and
+`Worker` snapshots that one logger for the host log and for every forked chip
+child, so the `bind phase=` records are already on without it. What passing it
+buys is the `[stamp]` line: the level is the one measurement condition with no
+record of its own in the log — unlike `torch_backend_autoload` — so a run that
+omits the flag leaves it implicit in whatever that commit's default happens to
+be. Two arms of a cross-commit A/B can then run at different levels with neither
+stamp showing it.
 
 **In timeline mode that last check reports 0 on a run that worked.** A diagnostic
 flag makes `CallConfig.output_prefix` non-empty, and a non-empty prefix moves
@@ -48,11 +67,13 @@ instead, and feed the finisher both (see the timeline command below).
 
 | Property | dsv4 FLASH decode | qwen3-14b decode |
 | -------- | ----------------- | ---------------- |
-| `--device-num` | 2 | 1 |
+| `NAME` prefix | `dsv4` | `qwen` |
+| `DEVICES` | 2 | 1 |
 | entry point | standalone driver — it owns its `Worker`, so no `--case` / `--manual` / `--level` and no module runner | standalone driver with the same ownership model |
 | `CASE` | `examples/a2a3/host_build_graph/deepseek_v4_flash_decode/main.py -p a2a3 --skip-golden` | `examples/a2a3/host_build_graph/qwen3_14b_decode/main.py -p a2a3 --skip-golden` |
 | parameters | child memory; **`--skip-golden` is not optional here** — without it the driver first streams a 42.6 GiB-per-rank fixture you are not measuring | device-resident buffers; the valid fixture is streamed once, and `--skip-golden` skips only torch/D2H |
-| timeout | 3600 (cold compile is minutes) | 2400 |
+| `TIMEOUT` | 3600 (cold compile is minutes) | 2400 |
+| emits `torch_backend_autoload` | **no** — the parser says so above the table, and a dsv4 A/B has no in-log witness for the autoload state | yes |
 
 Neither case needs a `--level`: each driver runs its `Worker` in this process,
 so its chip children write straight to the log the `task-submit --run` command
@@ -64,6 +85,7 @@ while the run still passed.)
 
 | Field | numbers | timeline |
 | ----- | ------- | -------- |
+| `NAME` suffix | `_numbers` | `_timeline` |
 | `ENVS` delta | none | `+ SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE=1` |
 | `TAIL` | `--rounds 6 --log-level timing` | `--rounds 1 --enable-pmu 2 --log-level timing` |
 | finish with | the parser, below | `strace_timing`, below |

--- a/.claude/skills/hbg-bind-phases/SKILL.md
+++ b/.claude/skills/hbg-bind-phases/SKILL.md
@@ -14,14 +14,16 @@ still yields its whole host picture.
 
 ## The recipe
 
-Fill in `NAME`, `DEVICES`, `TIMEOUT`, `CASE` from the case table and `ENVS`,
-`TAIL` from the mode table, then run it verbatim.
+Fill in `NAME`, `RUN`, `DEVICES`, `TIMEOUT`, `CASE` from the case table and
+`ENVS`, `TAIL` from the mode table, then run it verbatim.
 `pip install --no-build-isolation -e .` first, and again after every `HEAD` move.
 
 ```bash
 HEAD_SHA=$(git rev-parse --short HEAD)
 NAME="<case>_<mode>"                    # e.g. qwen_numbers — see below
-LOG="outputs/bind_${NAME}_${HEAD_SHA}.log"; mkdir -p outputs
+RUN=<n>                                 # repetition: 1, 2, … within one A/B session
+LOG="outputs/bind_${NAME}_${HEAD_SHA}_r${RUN}.log"; mkdir -p outputs
+[ -e "$LOG" ] && { echo "refusing to overwrite $LOG — bump RUN"; exit 1; }
 MARK="outputs/.bind_start"; : >"$MARK"   # fixed mtime; "$LOG" keeps being appended to
 
 DEVICES=<N>                                            # per case
@@ -42,10 +44,13 @@ grep -c 'bind phase=' "$LOG"          # numbers mode: must be > 0
 `[stamp]` line is the same string that runs — which is what makes two logs
 comparable. Never hand-edit one arm's command without the other's.
 
-**`NAME` carries the case and the mode because `$LOG` is opened with a
-truncating `>`.** Two cases at one commit, or the same case in both modes, would
-otherwise write the same path and the second run would destroy the first log
-without saying so.
+**`$LOG` is opened with a truncating `>`, so its name has to separate every run
+this skill tells you to make.** `NAME` separates the two cases and the two modes,
+`HEAD_SHA` the two arms of a comparison, and `RUN` the repetitions — the
+comparison protocol runs each arm more than once, so `base, measure, base,
+measure` is two runs per commit that agree on case, mode and sha. The guard turns
+a forgotten `RUN` into a refusal; without all three fields a later run silently
+destroys an earlier log, and its own output looks entirely normal.
 
 **`--log-level timing` pins a condition rather than enabling anything.**
 `python/simpler/_log.py` puts the `simpler` logger at TIMING on import and

--- a/docs/dfx/hbg-bind-phases.md
+++ b/docs/dfx/hbg-bind-phases.md
@@ -101,10 +101,29 @@ Four switches and one flag make the measurement, and each is load-bearing:
 | Switch | Why |
 | ------ | --- |
 | `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1` | emits the `bind phase=` lines at all |
-| `--log-level timing` | enables the TIMING records used by the report; this is the SceneTest default |
+| `--log-level timing` | pins the level the report is read at, and is the only way it reaches the `[stamp]` line; TIMING is already the default, so this records a condition rather than enabling one |
 | `TORCH_DEVICE_BACKEND_AUTOLOAD=0` | keeps CPU golden imports from loading `torch_npu`; the `torch_backend_autoload` timing record confirms the effective setting and observed module state |
 | `SIMPLER_SKIP_DEVICE_RUN=1` | returns at `simpler_launch_run`, so the host path is measured without a working device run |
 | `--skip-golden` | with the device skipped the outputs a golden check compares are never produced. Qwen still streams its valid fixture once before the measured rounds; on dsv4 the flag also skips the 42.6 GiB-per-rank fixture upload |
+
+**`--log-level` overrides a level that is already TIMING; it does not turn the
+records on.** There is one control point and it is the Python logger named
+`simpler`: [`python/simpler/_log.py`](../../python/simpler/_log.py) sets it to
+TIMING at import when nothing else has, and `Worker` snapshots that logger's
+effective level once — feeding it to the host log and to every forked chip
+child, which is why the same level governs the host and device sides.
+`configure_logging()` in
+[`simpler_setup/log_config.py`](../../simpler_setup/log_config.py) is the only
+way a CLI moves that snapshot; there is no environment variable.
+
+The recipe passes `--log-level timing` anyway, because **the level is the one
+measurement condition with no record of its own in the log.** Autoload state has
+`torch_backend_autoload`; the level has nothing, so a run that omits the flag
+leaves it implicit in whichever default that commit compiled in. Two arms of a
+cross-commit A/B could then run at different levels with neither `[stamp]`
+showing it — the same silent-mismatch failure the autoload record exists to
+prevent. Passing it puts the level in the stamp, where a `diff` of the two first
+lines catches a mismatch.
 
 SceneTest and the standalone Qwen driver emit one `torch_backend_autoload`
 record per interpreter after torch-dependent argument preparation and before
@@ -114,6 +133,13 @@ observed module state and is the authoritative field if the environment changed
 after torch was imported. `raw` is the JSON-encoded environment value (`null`
 when unset); values longer than 64 characters carry their first 64 characters
 and `raw_truncated=true`, keeping the record single-line and bounded.
+
+**The dsv4 driver is neither of those two, so a dsv4 log carries no such
+record** — `hbg_bind_phases` prints "backend-autoload state must be established
+before comparing this log" on every dsv4 measurement. The check below that this
+is the one condition already known to have produced a wrong number therefore has
+no in-log witness on that case; the `[stamp]` line is all a dsv4 A/B has, so both
+arms must be read off it by hand.
 
 **`SIMPLER_SKIP_DEVICE_RUN` is presence-based.** `SIMPLER_SKIP_DEVICE_RUN=0` still
 skips; `unset` it. It is a temporary handle from the dsv4 bring-up and is deleted

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/main.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/main.py
@@ -82,6 +82,7 @@ from simpler_setup.goldens.deepseek_v4_flash_decode import (
     T,
     param_tensors,
 )
+from simpler_setup.log_config import DEFAULT_LOG_LEVEL, LOG_LEVEL_CHOICES, configure_logging
 from simpler_setup.parallel_scheduler import device_range_to_list
 from simpler_setup.scene_test import (
     build_output_prefix,
@@ -910,6 +911,7 @@ def parse_args(argv=None) -> argparse.Namespace:
     )
     parser.add_argument("--enable-dep-gen", action="store_true", help="Enable dep_gen capture (needs --rounds 1)")
     parser.add_argument("--enable-scope-stats", action="store_true", help="Emit per-scope ring-fill peaks")
+    parser.add_argument("--log-level", choices=LOG_LEVEL_CHOICES, default=DEFAULT_LOG_LEVEL)
     parser.add_argument("--compile-only", action="store_true", help="compile the kernels and exit, no device needed")
     parser.add_argument("--compile-workers", type=int, default=None)
     return parser.parse_args(argv)
@@ -917,6 +919,7 @@ def parse_args(argv=None) -> argparse.Namespace:
 
 def main(argv=None, **overrides) -> int:
     cli = parse_args(argv)
+    configure_logging(cli.log_level)
     return run(
         device_range_to_list(cli.device),
         cli.platform,

--- a/simpler_setup/tools/hbg_bind_phases.py
+++ b/simpler_setup/tools/hbg_bind_phases.py
@@ -128,9 +128,11 @@ def main() -> int:
     binds = parse_binds(args.log)
     if not binds:
         print(
-            f"{args.log}: no `bind phase=` lines. SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 and "
-            "--log-level timing must both be set, and a multi-device case must be "
-            "invoked as its own child command -- see docs/dfx/hbg-bind-phases.md.",
+            f"{args.log}: no `bind phase=` lines. Either SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 "
+            "was not set, or a diagnostic flag made CallConfig.output_prefix non-empty and "
+            "moved the whole host log to outputs/<case>_<ts>/host.<pid>.log -- parse those "
+            "instead. The log level is not a cause: TIMING is the default. "
+            "See docs/dfx/hbg-bind-phases.md.",
             file=sys.stderr,
         )
         return 1


### PR DESCRIPTION
Found by running the `hbg-bind-phases` skill on `main`. One driver gap, and two
recipe fields that were not fillable.

## 1. The DeepSeek-V4 driver could not move its log level

Both decode cases are standalone drivers of the same shape — a thin
`host_build_graph` entry that loads its `tensormap_and_ringbuffer` sibling and
calls its `main()` — and the DeepSeek-V4 option set is otherwise a **strict
subset** of Qwen's:

| | options |
| --- | --- |
| both | `-p` `-d` `--rounds` `--skip-golden` `--seed` `--dump-args` `--enable-pmu` `--enable-dep-gen` `--enable-scope-stats` `--compile-only` `--compile-workers` |
| Qwen only | `--case` `--manual` `--seq-len` `--enable-chip-swimlane` `--enable-swimlane-overhead` `--log-level` |

`--case` / `--manual` / `--seq-len` are Qwen's own domain. `--log-level` is not:
it is a generic knob that arrived with #2041 and was not carried across.

Logging has a single control point. `python/simpler/_log.py` puts the Python
logger named `simpler` at TIMING on import when nothing else has, and `Worker`
reads that logger's effective level **once**, feeding it to
`_initialize_host_log()` and to every forked chip child as `log_level=` — which
is why one level governs the host and the device side. `configure_logging()` in
`simpler_setup/log_config.py` is the only way a CLI moves that snapshot; its
docstring is explicit that there is no environment variable.

A driver that never calls it is therefore pinned at TIMING — it cannot be raised
to `debug` to chase a problem, nor lowered to `warn` / `null` to cut noise, on
either side. The driver now declares the option where Qwen declares it and calls
`configure_logging(cli.log_level)` as the first statement of `main()`, before the
snapshot. The default is `timing`, so a run that passes nothing is unchanged.

The concrete symptom was the documented recipe passing `--log-level timing`,
which the driver rejected *after* `task-submit` had taken both dies:

```text
[npu-lock] 获取设备 1 的锁 / 获取设备 3 的锁
main.py: error: unrecognized arguments: --log-level timing
=== 任务失败 (exit=2) ===
```

## 2. `$LOG` named neither the case nor the mode, so one run truncated the other

`LOG="outputs/bind_${HEAD_SHA}.log"`, written with a truncating `>`. The skill
documents two cases and two modes at one commit, and `LOG` is not among the
fields the "fill in ... then run it verbatim" instruction lists. Measuring Qwen
and then DeepSeek-V4 at one `HEAD` destroyed the Qwen log, silently — the second
run's output looks entirely normal. The name now carries a `NAME` field naming
the case and the mode.

## 3. `--device-num` and the timeout were not fillable

`--device-num <N>` was a placeholder but `--timeout 3600 --max-time 3600` was a
literal, inside a block introduced as "run it verbatim", although the case table
gives 3600 for DeepSeek-V4 and 2400 for Qwen. Both are now `DEVICES` and
`TIMEOUT`, listed in the instruction sentence.

## Why `--log-level timing` stays in the recipe

`TAIL` is unchanged from `main` — the flag is still passed. Neither file said why
a flag whose own default is already `timing` is worth passing, and both now do:
**the level is the one measurement condition with no record of its own in the
log.** Autoload state has `torch_backend_autoload`, which
`docs/dfx/hbg-bind-phases.md` requires both arms of a comparison to carry; the
level has nothing. Omitting the flag leaves it implicit in whichever default a
commit compiled in, so two arms of a cross-commit A/B could run at different
levels with neither `[stamp]` showing it — the same silent mismatch the autoload
record exists to prevent. Passing it puts the level in the stamp, where a `diff`
of the two first lines catches it.

The case table also now records that the DeepSeek-V4 driver emits no
`torch_backend_autoload` record — it is neither of the two emitters the doc
names, and under `--skip-golden` it does no torch-dependent argument
preparation, which is where the record is written — so a reader knows before
running that a comparison on that case has only its `[stamp]` line as witness.

## Verification

The edited recipe was filled in and run verbatim for both cases:

```text
qwen_numbers exit=0 bind_lines=60
dsv4_numbers exit=0 bind_lines=120
[stamp] cca3b6ff env SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 TORCH_DEVICE_BACKEND_AUTOLOAD=0 \
        SIMPLER_SKIP_DEVICE_RUN=1 python .../deepseek_v4_flash_decode/main.py \
        -p a2a3 --skip-golden --rounds 6 --log-level timing
```

DeepSeek-V4 completes with the flag it used to reject, both logs survive instead
of one overwriting the other, and the level is in the stamp. Both entry paths
were also exercised with the driver change stashed, where argparse rejects the
option with `unrecognized arguments: --log-level info`.

`tests/ut/py/{test_qwen3_14b_decode_driver,test_log_config}.py`: 38 passed.
`pre-commit` passes on all three files.

No test is added for the driver change. It makes one driver conform to a
convention two of the repository's twenty-three standalone `main.py` cases
follow, and the failure mode is a loud argparse rejection rather than anything
silent. A test asserting "this driver declares `--log-level`" would imply a
contract the other twenty-one do not meet; if that contract is ever wanted it
belongs in one parametrized test over an explicit driver list, not one file per
case.

## Not in this PR

Two further defects found in the same session, in the tool and the doc rather
than in the recipe:

- `simpler_setup/tools/hbg_bind_phases.py` sets `BIND_CLOSING_PHASE =
  "arena_h2d"` with the comment "The last segment of a bind". It is not: every
  bind emits its ten lines in one contiguous burst ending `graph_upload,
  arena_h2d, host_view_close`, verified on 46/46 binds across three logs. Each
  bind's `host_view_close` is therefore attached to the next group, so the
  reported statistics for that phase include the cold bind and exclude the last
  warm one. No other phase is affected, and `host_view_close` is excluded from
  the control plane, so current headline numbers are unaffected.
- `docs/dfx/hbg-bind-phases.md` states "`arena_h2d` runs *after*
  `host_view_close`" — the same error in prose, which is presumably why neither
  was caught. The conclusion it draws (the control plane is a sum, not an
  interval) holds for a different reason: `static_arena` / `shared_mem` /
  `gm_heap` run between `graph_upload` and `arena_h2d`.
