### PR TITLE
Refactor: give host_build_graph one signed counting domain

### DIFF
--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -526,15 +526,14 @@ bool bind_graph_definitions(
             return false;
         }
         GraphExecutionStorageLayout storage_layout{};
-        if (definition->task_count == 0 || definition->task_count > MAX_IN_GRAPH_TASKS ||
+        if (definition->task_count <= 0 || definition->task_count > MAX_IN_GRAPH_TASKS ||
             definition->full_key != upload->full_key ||
             !graph_execution_storage_layout(
-                static_cast<int32_t>(definition->task_count), definition->tensor_arg_count,
-                definition->scalar_arg_count, &storage_layout
+                definition->task_count, definition->tensor_arg_count, definition->scalar_arg_count, &storage_layout
             ) ||
             storage_layout.total_bytes != definition->execution_storage_bytes ||
-            upload->outer_slot->to_payload().tensor_count != static_cast<int32_t>(definition->boundary_count) ||
-            upload->outer_slot->to_payload().scalar_count != static_cast<int32_t>(definition->boundary_scalar_count)) {
+            upload->outer_slot->to_payload().tensor_count != definition->boundary_count ||
+            upload->outer_slot->to_payload().scalar_count != definition->boundary_scalar_count) {
             LOG_ERROR("host-orch: invalid Graph Definition for task");
             return false;
         }
@@ -561,7 +560,7 @@ bool bind_graph_definitions(
                 LOG_ERROR("host-orch: invalid Graph Definition in-graph task array");
                 return false;
             }
-            for (uint32_t i = 0; i < definition->task_count; ++i) {
+            for (int32_t i = 0; i < definition->task_count; ++i) {
                 // Sizing takes the kind materialize will give this task. add_task
                 // singles out GRAPH and routes everything else by shape, and a Graph
                 // body member is never the shell, so the shape decides. Derived here

--- a/src/a2a3/runtime/host_build_graph/orchestration/orchestration_api.h
+++ b/src/a2a3/runtime/host_build_graph/orchestration/orchestration_api.h
@@ -507,9 +507,7 @@ static inline uint64_t rt_graph_function_id(Function function) {
 template <typename Invoke>
 static inline GraphSubmitResult rt_submit_graph_impl(uint64_t graph_key, const GraphTaskArgs &args, Invoke invoke) {
     debug_assert(!args.has_error && "Graph boundary GraphTaskArgs construction failed");
-    debug_assert(
-        args.tensor_count() <= static_cast<int32_t>(GRAPH_MAX_TENSOR_ARGS) && "Graph boundary exceeds the tensor limit"
-    );
+    debug_assert(args.tensor_count() <= GRAPH_MAX_TENSOR_ARGS && "Graph boundary exceeds the tensor limit");
     debug_assert(
         args.explicit_dep_count() == 0 && "Explicit dependencies crossing the Graph boundary are not supported"
     );

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -632,7 +632,7 @@ struct SchedulerState {
     // (route/re-register each waiter). Whole-graph-resident hbg
     // has no device slot reclaim, so nothing advances a reclaim cursor here.
     void on_mixed_task_complete(ChipTaskSlotState &slot_state) {
-        const int32_t task_id = static_cast<int32_t>(simpler::hbg::task_local_id(slot_state.to_descriptor().task_id));
+        const int32_t task_id = simpler::hbg::task_local_id(slot_state.to_descriptor().task_id);
         SharedMemoryTaskHeader &tasks = *task_view.tasks;
 
         slot_state.mark_completed();  // completion mirror (task_state = COMPLETED)
@@ -892,10 +892,10 @@ struct SchedulerState {
     // Scheduler polling only chooses which already-wired producer a consumer
     // waits on at this instant; it never recomputes producer relationships.
     int32_t graph_first_unmet_producer(const GraphExecution &execution, const ChipTaskSlotState &consumer) const {
-        const uint32_t task_index = static_cast<uint32_t>(consumer.in_graph_task_index);
-        const uint32_t begin = execution.fanin_offsets[task_index];
-        const uint32_t end = execution.fanin_offsets[task_index + 1];
-        for (uint32_t edge = begin; edge < end; ++edge) {
+        const int32_t task_index = consumer.in_graph_task_index;
+        const int32_t begin = execution.fanin_offsets[task_index];
+        const int32_t end = execution.fanin_offsets[task_index + 1];
+        for (int32_t edge = begin; edge < end; ++edge) {
             const uint16_t producer_index = execution.fanin_indices[edge];
             const ChipTaskSlotState &producer = execution.task_at(producer_index).slot;
             if (producer.task_state.load(std::memory_order_acquire) != CHIP_TASK_COMPLETED) {
@@ -1072,13 +1072,8 @@ struct SchedulerState {
             outcome.error_code = SIMPLER_ERROR_INVALID_ARGS;
             return outcome;
         }
-        const int32_t saved_task_index = slot_state.in_graph_task_index;
-        if (saved_task_index < 0) {
-            outcome.error_code = SIMPLER_ERROR_INVALID_ARGS;
-            return outcome;
-        }
-        const uint32_t task_index = static_cast<uint32_t>(saved_task_index);
-        if (task_index >= static_cast<uint32_t>(execution->task_count)) {
+        const int32_t task_index = slot_state.in_graph_task_index;
+        if (task_index < 0 || task_index >= execution->task_count) {
             outcome.error_code = SIMPLER_ERROR_INVALID_ARGS;
             return outcome;
         }

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -191,8 +191,8 @@ void SchedulerContext::complete_slot_task(
         }
 #endif
         // 3S+1P: hand the finished task to the dedicated resolution (P) thread.
-        // P publishes completion_flags, drains the wake list, and advances the
-        // watermark — and owns completed_tasks_, so this scheduler thread neither
+        // P publishes completion_flags and drains the wake list — and owns
+        // completed_tasks_, so this scheduler thread neither
         // resolves nor bumps completed_this_turn. (The Resolve swimlane bar is
         // emitted by P, not here.)
         sp_queues_[thread_idx].push(&slot_state);

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -142,7 +142,7 @@ public:
 
     // Dedicated resolution (P) thread entry (3S+1P). Owns no cores: drains the
     // per-S CompletedTaskQueues and runs on_task_complete for each finished task
-    // (completion_flags publish + wake-list drain + watermark advance), making P
+    // (completion_flags publish + wake-list drain), making P
     // the sole producer of the ready queues. Owns completed_tasks_ / termination.
     int32_t run_resolution_thread(Runtime *runtime, int32_t thread_idx);
 

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -900,11 +900,10 @@ int32_t SchedulerContext::try_early_dispatch(
 
 // P owns no AICore cores. It drains the per-S CompletedTaskQueues and runs
 // on_task_complete for every finished task: publish completion_flags, drain the
-// wake list (route/re-register waiters into the ready queues), advance the
-// watermark. As the sole producer of the ready queues its enqueues never
-// contend. P owns completed_tasks_ and the terminal completed_ flip, so the S
-// threads keep dispatching until P has resolved the whole graph (watermark fully
-// advanced) — the host's wait_for_consumers never observes a stranded prefix.
+// wake list (route/re-register waiters into the ready queues). As the sole
+// producer of the ready queues its enqueues never contend. P owns
+// completed_tasks_ and the terminal completed_ flip, so the S threads keep
+// dispatching until P has resolved the whole graph.
 int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread_idx) {
     always_assert(sched_ != nullptr);
     SharedMemoryHeader *header = sched_->sm_header;

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -526,15 +526,14 @@ bool bind_graph_definitions(
             return false;
         }
         GraphExecutionStorageLayout storage_layout{};
-        if (definition->task_count == 0 || definition->task_count > MAX_IN_GRAPH_TASKS ||
+        if (definition->task_count <= 0 || definition->task_count > MAX_IN_GRAPH_TASKS ||
             definition->full_key != upload->full_key ||
             !graph_execution_storage_layout(
-                static_cast<int32_t>(definition->task_count), definition->tensor_arg_count,
-                definition->scalar_arg_count, &storage_layout
+                definition->task_count, definition->tensor_arg_count, definition->scalar_arg_count, &storage_layout
             ) ||
             storage_layout.total_bytes != definition->execution_storage_bytes ||
-            upload->outer_slot->to_payload().tensor_count != static_cast<int32_t>(definition->boundary_count) ||
-            upload->outer_slot->to_payload().scalar_count != static_cast<int32_t>(definition->boundary_scalar_count)) {
+            upload->outer_slot->to_payload().tensor_count != definition->boundary_count ||
+            upload->outer_slot->to_payload().scalar_count != definition->boundary_scalar_count) {
             LOG_ERROR("host-orch: invalid Graph Definition for task");
             return false;
         }
@@ -561,7 +560,7 @@ bool bind_graph_definitions(
                 LOG_ERROR("host-orch: invalid Graph Definition in-graph task array");
                 return false;
             }
-            for (uint32_t i = 0; i < definition->task_count; ++i) {
+            for (int32_t i = 0; i < definition->task_count; ++i) {
                 // Sizing takes the kind materialize will give this task. add_task
                 // singles out GRAPH and routes everything else by shape, and a Graph
                 // body member is never the shell, so the shape decides. Derived here

--- a/src/a5/runtime/host_build_graph/orchestration/orchestration_api.h
+++ b/src/a5/runtime/host_build_graph/orchestration/orchestration_api.h
@@ -507,9 +507,7 @@ static inline uint64_t rt_graph_function_id(Function function) {
 template <typename Invoke>
 static inline GraphSubmitResult rt_submit_graph_impl(uint64_t graph_key, const GraphTaskArgs &args, Invoke invoke) {
     debug_assert(!args.has_error && "Graph boundary GraphTaskArgs construction failed");
-    debug_assert(
-        args.tensor_count() <= static_cast<int32_t>(GRAPH_MAX_TENSOR_ARGS) && "Graph boundary exceeds the tensor limit"
-    );
+    debug_assert(args.tensor_count() <= GRAPH_MAX_TENSOR_ARGS && "Graph boundary exceeds the tensor limit");
     debug_assert(
         args.explicit_dep_count() == 0 && "Explicit dependencies crossing the Graph boundary are not supported"
     );

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -643,7 +643,7 @@ struct SchedulerState {
     // (route/re-register each waiter). Whole-graph-resident hbg
     // has no device slot reclaim, so nothing advances a reclaim cursor here.
     void on_mixed_task_complete(ChipTaskSlotState &slot_state) {
-        const int32_t task_id = static_cast<int32_t>(simpler::hbg::task_local_id(slot_state.to_descriptor().task_id));
+        const int32_t task_id = simpler::hbg::task_local_id(slot_state.to_descriptor().task_id);
         SharedMemoryTaskHeader &tasks = *task_view.tasks;
 
         slot_state.mark_completed();  // completion mirror (task_state = COMPLETED)
@@ -903,10 +903,10 @@ struct SchedulerState {
     // Scheduler polling only chooses which already-wired producer a consumer
     // waits on at this instant; it never recomputes producer relationships.
     int32_t graph_first_unmet_producer(const GraphExecution &execution, const ChipTaskSlotState &consumer) const {
-        const uint32_t task_index = static_cast<uint32_t>(consumer.in_graph_task_index);
-        const uint32_t begin = execution.fanin_offsets[task_index];
-        const uint32_t end = execution.fanin_offsets[task_index + 1];
-        for (uint32_t edge = begin; edge < end; ++edge) {
+        const int32_t task_index = consumer.in_graph_task_index;
+        const int32_t begin = execution.fanin_offsets[task_index];
+        const int32_t end = execution.fanin_offsets[task_index + 1];
+        for (int32_t edge = begin; edge < end; ++edge) {
             const uint16_t producer_index = execution.fanin_indices[edge];
             const ChipTaskSlotState &producer = execution.task_at(producer_index).slot;
             if (producer.task_state.load(std::memory_order_acquire) != CHIP_TASK_COMPLETED) {
@@ -1083,13 +1083,8 @@ struct SchedulerState {
             outcome.error_code = SIMPLER_ERROR_INVALID_ARGS;
             return outcome;
         }
-        const int32_t saved_task_index = slot_state.in_graph_task_index;
-        if (saved_task_index < 0) {
-            outcome.error_code = SIMPLER_ERROR_INVALID_ARGS;
-            return outcome;
-        }
-        const uint32_t task_index = static_cast<uint32_t>(saved_task_index);
-        if (task_index >= static_cast<uint32_t>(execution->task_count)) {
+        const int32_t task_index = slot_state.in_graph_task_index;
+        if (task_index < 0 || task_index >= execution->task_count) {
             outcome.error_code = SIMPLER_ERROR_INVALID_ARGS;
             return outcome;
         }

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -191,8 +191,8 @@ void SchedulerContext::complete_slot_task(
         }
 #endif
         // 3S+1P: hand the finished task to the dedicated resolution (P) thread.
-        // P publishes completion_flags, drains the wake list, and advances the
-        // watermark — and owns completed_tasks_, so this scheduler thread neither
+        // P publishes completion_flags and drains the wake list — and owns
+        // completed_tasks_, so this scheduler thread neither
         // resolves nor bumps completed_this_turn. (The Resolve swimlane bar is
         // emitted by P, not here.)
         sp_queues_[thread_idx].push(&slot_state);

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -142,7 +142,7 @@ public:
 
     // Dedicated resolution (P) thread entry (3S+1P). Owns no cores: drains the
     // per-S CompletedTaskQueues and runs on_task_complete for each finished task
-    // (completion_flags publish + wake-list drain + watermark advance), making P
+    // (completion_flags publish + wake-list drain), making P
     // the sole producer of the ready queues. Owns completed_tasks_ / termination.
     int32_t run_resolution_thread(Runtime *runtime, int32_t thread_idx);
 

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -901,11 +901,10 @@ int32_t SchedulerContext::try_early_dispatch(
 
 // P owns no AICore cores. It drains the per-S CompletedTaskQueues and runs
 // on_task_complete for every finished task: publish completion_flags, drain the
-// wake list (route/re-register waiters into the ready queues), advance the
-// watermark. As the sole producer of the ready queues its enqueues never
-// contend. P owns completed_tasks_ and the terminal completed_ flip, so the S
-// threads keep dispatching until P has resolved the whole graph (watermark fully
-// advanced) — the host's wait_for_consumers never observes a stranded prefix.
+// wake list (route/re-register waiters into the ready queues). As the sole
+// producer of the ready queues its enqueues never contend. P owns
+// completed_tasks_ and the terminal completed_ flip, so the S threads keep
+// dispatching until P has resolved the whole graph.
 int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread_idx) {
     always_assert(sched_ != nullptr);
     SharedMemoryHeader *header = sched_->sm_header;

--- a/src/common/host_build_graph/device/graph_execution.cpp
+++ b/src/common/host_build_graph/device/graph_execution.cpp
@@ -21,8 +21,7 @@
 namespace {
 
 GraphExecution *acquire_execution_storage(
-    uintptr_t storage_addr, size_t storage_bytes, int32_t task_count, uint32_t tensor_arg_count,
-    uint32_t scalar_arg_count
+    uintptr_t storage_addr, size_t storage_bytes, int32_t task_count, int32_t tensor_arg_count, int32_t scalar_arg_count
 ) {
     GraphExecutionStorageLayout layout{};
     // ChipTaskStorage, not GraphExecution: the in-graph task array's alignment is the widest
@@ -61,6 +60,10 @@ void reset_graph_payload(TaskPayload &payload) {
 bool bind_graph_topology(GraphExecution &execution) {
     if (execution.definition == nullptr) return false;
     const GraphDefinition &definition = *execution.definition;
+    // Re-checked rather than inherited from graph_execution_localize: every section
+    // below is fetched with task_count or task_count + 1, so a wire value outside this
+    // range overflows the increment before any bound check can see it.
+    if (definition.task_count <= 0 || definition.task_count > MAX_IN_GRAPH_TASKS) return false;
     // GRAPH_MAX_SCALAR_ARGS, not MAX_SCALAR_ARGS: this counts the scalars the
     // Graph BOUNDARY carries, which the recorder sizes with
     // GraphTaskArgs = Arg<GRAPH_MAX_TENSOR_ARGS, GRAPH_MAX_SCALAR_ARGS> and the
@@ -69,14 +72,14 @@ bool bind_graph_topology(GraphExecution &execution) {
     // InGraphTaskDefinition::scalar_count below, which is checked separately; using
     // it here rejected every boundary wider than one kernel call could take.
     if (definition.boundary_scalar_count > GRAPH_MAX_SCALAR_ARGS) return false;
-    const uint32_t *fanin_offsets =
-        graph_definition_array<uint32_t>(definition, definition.off_fanin_offsets, definition.task_count + 1);
+    const int32_t *fanin_offsets =
+        graph_definition_array<int32_t>(definition, definition.off_fanin_offsets, definition.task_count + 1);
     const uint16_t *fanin_indices =
         definition.edge_count == 0 ?
             nullptr :
             graph_definition_array<uint16_t>(definition, definition.off_fanin_indices, definition.edge_count);
-    const uint32_t *fanout_offsets =
-        graph_definition_array<uint32_t>(definition, definition.off_fanout_offsets, definition.task_count + 1);
+    const int32_t *fanout_offsets =
+        graph_definition_array<int32_t>(definition, definition.off_fanout_offsets, definition.task_count + 1);
     const uint16_t *fanout_indices =
         definition.edge_count == 0 ?
             nullptr :
@@ -98,14 +101,17 @@ bool bind_graph_topology(GraphExecution &execution) {
 
     uint64_t required_heap = 0;
     constexpr uint8_t VALID_ACTIVE_MASK = (1U << SUBTASK_SLOT_COUNT) - 1U;
-    for (uint32_t i = 0; i < definition.task_count; ++i) {
+    for (int32_t i = 0; i < definition.task_count; ++i) {
         const InGraphTaskDefinition &task = tasks[i];
         if (in_graph_task_offsets[i] != required_heap || task.total_output_size < 0 || task.tensor_count < 0 ||
             task.tensor_count > MAX_TENSOR_ARGS || task.scalar_count < 0 || task.scalar_count > MAX_SCALAR_ARGS ||
-            task.tensor_offset > definition.tensor_arg_count ||
-            static_cast<uint32_t>(task.tensor_count) > definition.tensor_arg_count - task.tensor_offset ||
+            // Negative before the span tests, which cannot see it on their own: a
+            // negative offset is below tensor_arg_count and *widens* the remaining
+            // span it is subtracted from, so both comparisons below pass.
+            task.tensor_offset < 0 || task.scalar_offset < 0 || task.tensor_offset > definition.tensor_arg_count ||
+            task.tensor_count > definition.tensor_arg_count - task.tensor_offset ||
             task.scalar_offset > definition.scalar_arg_count ||
-            static_cast<uint32_t>(task.scalar_count) > definition.scalar_arg_count - task.scalar_offset ||
+            task.scalar_count > definition.scalar_arg_count - task.scalar_offset ||
             (task.active_mask & ~VALID_ACTIVE_MASK) != 0 || task.logical_block_num <= 0 ||
             task.total_required_subtasks < 0) {
             return false;
@@ -120,26 +126,26 @@ bool bind_graph_topology(GraphExecution &execution) {
     }
     if (required_heap != definition.required_heap) return false;
 
-    uint32_t observed_roots = 0;
-    for (uint32_t consumer = 0; consumer < definition.task_count; ++consumer) {
-        const uint32_t begin = fanin_offsets[consumer];
-        const uint32_t end = fanin_offsets[consumer + 1];
+    int32_t observed_roots = 0;
+    for (int32_t consumer = 0; consumer < definition.task_count; ++consumer) {
+        const int32_t begin = fanin_offsets[consumer];
+        const int32_t end = fanin_offsets[consumer + 1];
         if (begin > end || end > definition.edge_count) return false;
         if (begin == end) observed_roots++;
-        for (uint32_t edge = begin; edge < end; ++edge) {
+        for (int32_t edge = begin; edge < end; ++edge) {
             if (fanin_indices[edge] >= consumer) return false;
         }
     }
     if (observed_roots != definition.root_count) return false;
-    for (uint32_t i = 0; i < definition.root_count; ++i) {
+    for (int32_t i = 0; i < definition.root_count; ++i) {
         const uint16_t root = roots[i];
         if (root >= definition.task_count || fanin_offsets[root] != fanin_offsets[root + 1]) return false;
     }
-    for (uint32_t producer = 0; producer < definition.task_count; ++producer) {
-        const uint32_t begin = fanout_offsets[producer];
-        const uint32_t end = fanout_offsets[producer + 1];
+    for (int32_t producer = 0; producer < definition.task_count; ++producer) {
+        const int32_t begin = fanout_offsets[producer];
+        const int32_t end = fanout_offsets[producer + 1];
         if (begin > end || end > definition.edge_count) return false;
-        for (uint32_t edge = begin; edge < end; ++edge) {
+        for (int32_t edge = begin; edge < end; ++edge) {
             if (fanout_indices[edge] <= producer || fanout_indices[edge] >= definition.task_count) return false;
         }
     }
@@ -277,10 +283,9 @@ GraphExecution *graph_execution_localize(ChipTaskSlotState &outer_slot) {
         reinterpret_cast<GraphDefinitionHeader *>(definition_addr - sizeof(GraphDefinitionHeader));
     const GraphDefinition *definition = graph_definition_object_framed(*definition_header);
     TaskPayload &payload = outer_slot.to_payload();
-    if (definition == nullptr || definition->total_bytes == 0 || definition->task_count == 0 ||
-        definition->task_count > MAX_IN_GRAPH_TASKS ||
-        payload.tensor_count != static_cast<int32_t>(definition->boundary_count) ||
-        payload.scalar_count != static_cast<int32_t>(definition->boundary_scalar_count) ||
+    if (definition == nullptr || definition->total_bytes == 0 || definition->task_count <= 0 ||
+        definition->task_count > MAX_IN_GRAPH_TASKS || payload.tensor_count != definition->boundary_count ||
+        payload.scalar_count != definition->boundary_scalar_count ||
         (payload.tensor_count != 0 && payload.tensor_data() == nullptr) ||
         (payload.scalar_count != 0 && payload.scalar_data() == nullptr)) {
         return nullptr;
@@ -294,17 +299,17 @@ GraphExecution *graph_execution_localize(ChipTaskSlotState &outer_slot) {
         return nullptr;
     }
     GraphExecution *execution = acquire_execution_storage(
-        outer_base + definition->required_heap, definition->execution_storage_bytes,
-        static_cast<int32_t>(definition->task_count), definition->tensor_arg_count, definition->scalar_arg_count
+        outer_base + definition->required_heap, definition->execution_storage_bytes, definition->task_count,
+        definition->tensor_arg_count, definition->scalar_arg_count
     );
     if (execution == nullptr) return nullptr;
 
     execution->definition = definition;
     execution->outer_slot = &outer_slot;
     execution->boundary_tensors = reinterpret_cast<const GraphTensor *>(payload.tensor_data());
-    execution->boundary_tensor_count = static_cast<uint32_t>(payload.tensor_count);
+    execution->boundary_tensor_count = payload.tensor_count;
     execution->boundary_scalars = payload.scalar_data();
-    execution->boundary_scalar_count = static_cast<uint32_t>(payload.scalar_count);
+    execution->boundary_scalar_count = payload.scalar_count;
     if (!bind_graph_topology(*execution)) {
         execution->retired_tasks.store(execution->task_count, std::memory_order_relaxed);
         graph_execution_mark_completed(*execution);
@@ -400,9 +405,8 @@ GraphMaterializeResult graph_execution_materialize_slice(
         TaskPayload &payload = storage->payload;
         ChipTaskSlotState &slot = storage->slot;
 
-        task.task_id = simpler::hbg::make_in_graph_task(
-            simpler::hbg::task_local_id(outer_slot.to_descriptor().task_id), static_cast<uint32_t>(i)
-        );
+        task.task_id =
+            simpler::hbg::make_in_graph_task(simpler::hbg::task_local_id(outer_slot.to_descriptor().task_id), i);
         const InGraphTaskDefinition &source = tasks[i];
         const uint64_t task_offset = in_graph_task_offsets[i];
         const uint64_t output_bytes = CHIP_ALIGN_UP(static_cast<uint64_t>(source.total_output_size), CHIP_ALIGN_SIZE);
@@ -426,11 +430,10 @@ GraphMaterializeResult graph_execution_materialize_slice(
         payload.scalar_count = source.scalar_count;
         payload.dump_metadata = source.dump_metadata;
         if (source.tensor_count < 0 || source.tensor_count > MAX_TENSOR_ARGS || source.scalar_count < 0 ||
-            source.scalar_count > MAX_SCALAR_ARGS ||
-            static_cast<uint32_t>(source.tensor_count) > definition.tensor_arg_count ||
-            static_cast<uint32_t>(source.scalar_count) > definition.scalar_arg_count ||
-            source.tensor_offset > definition.tensor_arg_count - static_cast<uint32_t>(source.tensor_count) ||
-            source.scalar_offset > definition.scalar_arg_count - static_cast<uint32_t>(source.scalar_count)) {
+            source.scalar_count > MAX_SCALAR_ARGS || source.tensor_offset < 0 || source.scalar_offset < 0 ||
+            source.tensor_count > definition.tensor_arg_count || source.scalar_count > definition.scalar_arg_count ||
+            source.tensor_offset > definition.tensor_arg_count - source.tensor_count ||
+            source.scalar_offset > definition.scalar_arg_count - source.scalar_count) {
             execution.materialize_busy.store(0, std::memory_order_release);
             return GraphMaterializeResult::INVALID;
         }
@@ -444,7 +447,7 @@ GraphMaterializeResult graph_execution_materialize_slice(
         );
         simpler::hbg::Tensor *task_tensors = payload.tensor_data();
         for (int32_t j = 0; j < source.tensor_count; ++j) {
-            const uint32_t tensor_index = source.tensor_offset + static_cast<uint32_t>(j);
+            const int32_t tensor_index = source.tensor_offset + j;
             GraphTensor rebound;
             if (!graph_rebind_tensor(
                     execution, tasks, in_graph_task_offsets, definition_tensors[tensor_index],
@@ -458,7 +461,7 @@ GraphMaterializeResult graph_execution_materialize_slice(
         }
         uint64_t *task_scalars = payload.scalar_data();
         for (int32_t j = 0; j < source.scalar_count; ++j) {
-            const uint32_t scalar_index = source.scalar_offset + static_cast<uint32_t>(j);
+            const int32_t scalar_index = source.scalar_offset + j;
             const GraphScalarSourceRef &ref = scalar_sources[scalar_index];
             if (ref.source == static_cast<uint8_t>(GraphScalarSource::STATIC_VALUE)) {
                 task_scalars[j] = definition_scalars[scalar_index];
@@ -484,7 +487,7 @@ GraphMaterializeResult graph_execution_materialize_slice(
         }
         // Resolved after the reset, which clears the predicate every task starts from.
         if (source.predicate_slot != 0) {
-            const uint32_t predicate_index = static_cast<uint32_t>(source.predicate_slot) - 1;
+            const int32_t predicate_index = static_cast<int32_t>(source.predicate_slot) - 1;
             GraphTensor operand;
             // OWN_OUTPUT is a valid source for a tensor arg but never for an
             // operand: it would bind the predicate to the buffer this task has

--- a/src/common/host_build_graph/graph_cache.h
+++ b/src/common/host_build_graph/graph_cache.h
@@ -66,8 +66,7 @@ constexpr uint64_t graph_const_hash_impl(const char *s, uint64_t h) {
 constexpr uint64_t GRAPH_KEY(const char *s) { return graph_const_hash_impl(s, 1469598103934665603ULL); }
 
 inline bool rt_graph_args_cacheable(const GraphTaskArgs &args) {
-    if (args.has_error || args.tensor_count() <= 0 ||
-        args.tensor_count() > static_cast<int32_t>(GRAPH_MAX_TENSOR_ARGS)) {
+    if (args.has_error || args.tensor_count() <= 0 || args.tensor_count() > GRAPH_MAX_TENSOR_ARGS) {
         return false;
     }
     for (int32_t i = 0; i < args.tensor_count(); ++i) {

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -22,9 +22,9 @@
 #include "host_build_graph/runtime_types.h"
 #include "tensor.h"
 
-inline constexpr uint32_t MAX_IN_GRAPH_TASKS = 1024;
+inline constexpr int32_t MAX_IN_GRAPH_TASKS = 1024;
 static_assert(
-    MAX_IN_GRAPH_TASKS <= (1u << simpler::hbg::IN_GRAPH_TASK_INDEX_BITS),
+    MAX_IN_GRAPH_TASKS <= (1 << simpler::hbg::IN_GRAPH_TASK_INDEX_BITS),
     "an in-graph task index must fit the low field of an IN_GRAPH task id"
 );
 inline constexpr int32_t GRAPH_MATERIALIZE_SLICE_TASKS = 4;
@@ -111,8 +111,11 @@ struct InGraphTaskDefinition {
     int32_t tensor_count;
     int32_t scalar_count;
     int32_t total_output_size;
-    uint32_t tensor_offset;
-    uint32_t scalar_offset;
+    // Element indices into the Definition's argument pools, not byte offsets: each
+    // pairs with the count above it to form [offset, offset + count), so it carries
+    // that count's type.
+    int32_t tensor_offset;
+    int32_t scalar_offset;
     ArgsDumpTaskMetadata dump_metadata;
 };
 
@@ -161,15 +164,23 @@ static_assert(sizeof(GraphDefinitionHeader) % GRAPH_DEFINITION_OBJECT_ALIGN == 0
 struct GraphDefinition {
     uint64_t full_key;
     uint64_t required_heap;
+    // The header splits by range, not by name. Everything that counts *things* is
+    // signed: each is capped by MAX_IN_GRAPH_TASKS times a per-task constant, so the
+    // largest of them (edge_count, at 1024 x 1023) still clears INT32_MAX by three
+    // orders of magnitude, and a signed count makes a corrupt wire value testable
+    // with `< 0` instead of turning it into a huge index. Everything that counts
+    // *bytes* stays unsigned because graph_layout_section dimensions the image
+    // against UINT32_MAX: total_bytes and the off_ fields below reach 4 GB by design,
+    // and halving that range would be a functional change.
     uint32_t total_bytes;
-    uint32_t task_count;
-    uint32_t edge_count;
-    uint32_t root_count;
-    uint32_t boundary_count;
-    uint32_t boundary_scalar_count;
-    uint32_t tensor_arg_count;
-    uint32_t scalar_arg_count;
-    uint32_t predicate_count;
+    int32_t task_count;
+    int32_t edge_count;
+    int32_t root_count;
+    int32_t boundary_count;
+    int32_t boundary_scalar_count;
+    int32_t tensor_arg_count;
+    int32_t scalar_arg_count;
+    int32_t predicate_count;
     // Bytes the GraphExecution header, in-graph task array and in-graph task
     // argument pools need in the outer Graph task's heap tail. Invocation
     // boundaries live in the outer task payload's compact argument-pool regions
@@ -285,11 +296,14 @@ inline bool graph_tensor_wire_valid(const GraphTensor &tensor) {
     return tensor.start_offset <= buffer_elements && tensor.extent_elem <= buffer_elements - tensor.start_offset;
 }
 
+// A section's length is the same int32 every counting field of the header carries.
+// A negative one is rejected outright rather than left to wrap through the size_t
+// comparison, so a corrupt header cannot widen a section by either route.
 template <typename T>
-inline const T *graph_definition_array(const GraphDefinition &definition, uint32_t offset, uint32_t count) {
-    if (offset == 0 || offset > definition.total_bytes || offset % alignof(T) != 0) return nullptr;
+inline const T *graph_definition_array(const GraphDefinition &definition, uint32_t offset, int32_t count) {
+    if (count < 0 || offset == 0 || offset > definition.total_bytes || offset % alignof(T) != 0) return nullptr;
     const size_t remaining = static_cast<size_t>(definition.total_bytes - offset);
-    if (count > remaining / sizeof(T)) return nullptr;
+    if (static_cast<size_t>(count) > remaining / sizeof(T)) return nullptr;
     return reinterpret_cast<const T *>(reinterpret_cast<const uint8_t *>(&definition) + offset);
 }
 
@@ -334,7 +348,7 @@ struct GraphExecution {
     int32_t task_count{0};
     int32_t materialized_tasks{0};
     int32_t constructed_tasks{0};
-    uint32_t consumed_tensor_args{0};
+    int32_t consumed_tensor_args{0};
     ChipTaskSlotState *outer_slot{nullptr};
     ChipTaskStorage *tasks{nullptr};
     ChipTaskStorage *task_storage{nullptr};
@@ -344,12 +358,12 @@ struct GraphExecution {
     simpler::hbg::Tensor *task_tensor_pool{nullptr};
     uint64_t *task_scalar_pool{nullptr};
     const GraphDefinition *definition{nullptr};
-    const uint32_t *fanin_offsets{nullptr};
+    const int32_t *fanin_offsets{nullptr};
     const uint16_t *fanin_indices{nullptr};
     const GraphTensor *boundary_tensors{nullptr};
-    uint32_t boundary_tensor_count{0};
+    int32_t boundary_tensor_count{0};
     const uint64_t *boundary_scalars{nullptr};
-    uint32_t boundary_scalar_count{0};
+    int32_t boundary_scalar_count{0};
 
     ChipTaskStorage &task_at(int32_t index) const { return task_storage[index]; }
 };
@@ -397,9 +411,10 @@ struct GraphExecutionStorageLayout {
 };
 
 inline bool graph_execution_storage_layout(
-    int32_t task_count, uint32_t tensor_arg_count, uint32_t scalar_arg_count, GraphExecutionStorageLayout *out
+    int32_t task_count, int32_t tensor_arg_count, int32_t scalar_arg_count, GraphExecutionStorageLayout *out
 ) {
-    if (out == nullptr || task_count <= 0 || task_count > static_cast<int32_t>(MAX_IN_GRAPH_TASKS)) {
+    if (out == nullptr || task_count <= 0 || task_count > MAX_IN_GRAPH_TASKS || tensor_arg_count < 0 ||
+        scalar_arg_count < 0) {
         return false;
     }
     constexpr size_t ALIGNMENT = alignof(ChipTaskStorage);
@@ -411,7 +426,7 @@ inline bool graph_execution_storage_layout(
 }
 
 inline bool graph_execution_storage_bytes(
-    int32_t task_count, uint32_t tensor_arg_count, uint32_t scalar_arg_count, size_t *storage_bytes
+    int32_t task_count, int32_t tensor_arg_count, int32_t scalar_arg_count, size_t *storage_bytes
 ) {
     GraphExecutionStorageLayout layout{};
     if (storage_bytes == nullptr ||

--- a/src/common/host_build_graph/shared/orchestrator.cpp
+++ b/src/common/host_build_graph/shared/orchestrator.cpp
@@ -335,15 +335,15 @@ struct RecordedInGraphTask {
     // carries no address into storage the recording owns. The element addresses are handed
     // to the caller through TaskOutputTensors and have to stay valid while the rest of the
     // body records, which the pool satisfies by being allocated at the cap and never growing.
-    uint32_t tensor_offset{0};
-    uint32_t tensor_count{0};
+    int32_t tensor_offset{0};
+    int32_t tensor_count{0};
     // Ranges into the recording's flat arrays. tensor_sources has one entry per
     // tensor, so tensor_count is its count too.
-    uint32_t tensor_source_offset{0};
-    uint32_t scalar_offset{0};
-    uint32_t scalar_count{0};
-    uint32_t fanin_offset{0};
-    uint32_t fanin_count{0};
+    int32_t tensor_source_offset{0};
+    int32_t scalar_offset{0};
+    int32_t scalar_count{0};
+    int32_t fanin_offset{0};
+    int32_t fanin_count{0};
     // Index into the recording's predicates, or -1 when the task carries none.
     int32_t predicate_index{-1};
     ArgsDumpTaskMetadata dump_metadata;
@@ -394,7 +394,7 @@ static_assert(
 struct GraphRecordedOutputRange {
     uintptr_t begin;
     uintptr_t end;
-    uint32_t task_index;
+    int32_t task_index;
 };
 
 // The Graph boundary as the submitting thread captured it, deep-copied because the
@@ -424,7 +424,10 @@ struct GraphRecording {
     // How many of `tasks` this recording has filled. The array itself is never cleared
     // and graph_recording_reserve_storage sizes it to the in-graph task cap, so a body is
     // recorded into slots that already exist: a recorded task makes no allocation at all.
-    size_t task_count{0};
+    // An over-cap body is marked unsupported but keeps recording so it can finish, so this
+    // is not bounded by MAX_IN_GRAPH_TASKS while it runs -- what bounds it is the storage
+    // each further task claims, which exhausts memory long before the counter's range.
+    int32_t task_count{0};
     // Every recorded task's tensor arguments, packed end to end in one region this
     // recording bumps through, and the reason a task holds an offset rather than its own
     // buffer: a body's tensors then occupy the bytes they need instead of a page per task
@@ -435,7 +438,7 @@ struct GraphRecording {
     // so the region costs no page until a body writes one; each element a task uses is
     // value-initialized before it is filled.
     std::unique_ptr<simpler::hbg::Tensor[]> task_tensor_pool;
-    uint32_t task_tensor_cursor{0};
+    int32_t task_tensor_cursor{0};
     // Flat per-task arrays, indexed by the ranges on RecordedInGraphTask. Held here rather
     // than on each recorded task so recording a graph pays no allocation per task per array,
     // and reserved to the in-graph task cap by graph_recording_reserve_storage so it pays no
@@ -443,7 +446,7 @@ struct GraphRecording {
     std::vector<GraphRecordedTensorSourceRef> tensor_sources;
     std::vector<uint64_t> scalars;
     std::vector<GraphRecordedScalarSourceRef> scalar_sources;
-    std::vector<size_t> internal_fanins;
+    std::vector<int32_t> internal_fanins;
     std::vector<GraphRecordedOutputRange> output_ranges;
     // Indexed by RecordedInGraphTask::predicate_index; only predicated tasks
     // contribute an entry.
@@ -693,7 +696,7 @@ constexpr size_t GRAPH_RECORD_TENSOR_POOL_ELEMS =
 // and the id's low field is that index and nothing else. That is what keeps the
 // index inside the MAX_IN_GRAPH_TASKS task chains the recording's hazard map is
 // dimensioned for.
-constexpr uint32_t GRAPH_RECORD_NO_OWNING_GRAPH = 0;
+constexpr int32_t GRAPH_RECORD_NO_OWNING_GRAPH = 0;
 
 // Stand the recording's hazard map up on its own allocation. Failure is
 // reported to the caller, which abandons the recording rather than producing a
@@ -773,7 +776,7 @@ void unbind_recorder_boundary() {
 // Returns false when the pool cannot be allocated, which the caller treats like a hazard
 // map it could not stand up.
 bool graph_recording_reserve_storage(GraphRecording &recording) {
-    constexpr size_t kInGraphTaskCap = MAX_IN_GRAPH_TASKS;
+    constexpr size_t kInGraphTaskCap = static_cast<size_t>(MAX_IN_GRAPH_TASKS);
     recording.task_tensor_pool.reset(new (std::nothrow) simpler::hbg::Tensor[GRAPH_RECORD_TENSOR_POOL_ELEMS]);
     if (recording.task_tensor_pool == nullptr) return false;
     recording.tasks.resize(kInGraphTaskCap);
@@ -820,7 +823,7 @@ bool graph_recording_reset(GraphRecording &recording, const GraphInflightRecordi
     // Definition that can never be published, unbounded, for the process's life -- so an
     // over-cap recording gives its storage back instead of passing it on. This is what
     // makes the bound documented on GraphRecording::task_count true rather than nominal.
-    if (recording.tasks.size() > MAX_IN_GRAPH_TASKS) {
+    if (recording.tasks.size() > static_cast<size_t>(MAX_IN_GRAPH_TASKS)) {
         recording = GraphRecording{};
     }
     if (!graph_recording_stand_up(recording)) {
@@ -966,25 +969,35 @@ std::optional<GraphDefinition> graph_layout_definition(const GraphRecording &rec
         return std::nullopt;
     }
 
-    size_t total_tensors = 0;
-    size_t total_scalars = 0;
-    size_t total_fanins = 0;
-    size_t root_count = 0;
-    size_t predicate_count = 0;
+    int32_t total_tensors = 0;
+    int32_t total_scalars = 0;
+    int32_t total_fanins = 0;
+    int32_t root_count = 0;
+    int32_t predicate_count = 0;
     // task_count, not tasks.size(): the array keeps the slots a longer body left behind,
     // and those are not part of this recording.
-    for (size_t i = 0; i < recording.task_count; ++i) {
+    // The flat arrays a recorded task indexes into. Each is grown only by the recorder,
+    // bounded by MAX_IN_GRAPH_TASKS times a per-task constant, so its length is an
+    // int32 and every range test below stays in the offsets' own domain.
+    const int32_t recorded_tensor_sources = static_cast<int32_t>(recording.tensor_sources.size());
+    const int32_t recorded_scalars = static_cast<int32_t>(recording.scalars.size());
+    const int32_t recorded_scalar_sources = static_cast<int32_t>(recording.scalar_sources.size());
+    const int32_t recorded_fanins = static_cast<int32_t>(recording.internal_fanins.size());
+    for (int32_t i = 0; i < recording.task_count; ++i) {
         const RecordedInGraphTask &source = recording.tasks[i];
-        if (source.tensor_count > UINT32_MAX - total_tensors || source.scalar_count > UINT32_MAX - total_scalars ||
-            source.fanin_count > UINT32_MAX - total_fanins ||
-            source.tensor_source_offset > recording.tensor_sources.size() ||
-            source.tensor_count > recording.tensor_sources.size() - source.tensor_source_offset ||
-            source.scalar_offset > recording.scalars.size() ||
-            source.scalar_count > recording.scalars.size() - source.scalar_offset ||
-            source.scalar_offset > recording.scalar_sources.size() ||
-            source.scalar_count > recording.scalar_sources.size() - source.scalar_offset ||
-            source.fanin_offset > recording.internal_fanins.size() ||
-            source.fanin_count > recording.internal_fanins.size() - source.fanin_offset) {
+        // Negative first, so every count and offset below is a valid length by the time
+        // it is compared and each remaining-span subtraction is non-negative. The
+        // running-total tests bound each accumulator at the width its Definition field
+        // carries rather than at the accumulator's own.
+        if (source.tensor_count < 0 || source.scalar_count < 0 || source.fanin_count < 0 ||
+            source.tensor_source_offset < 0 || source.scalar_offset < 0 || source.fanin_offset < 0 ||
+            source.tensor_count > INT32_MAX - total_tensors || source.scalar_count > INT32_MAX - total_scalars ||
+            source.fanin_count > INT32_MAX - total_fanins || source.tensor_source_offset > recorded_tensor_sources ||
+            source.tensor_count > recorded_tensor_sources - source.tensor_source_offset ||
+            source.scalar_offset > recorded_scalars || source.scalar_count > recorded_scalars - source.scalar_offset ||
+            source.scalar_offset > recorded_scalar_sources ||
+            source.scalar_count > recorded_scalar_sources - source.scalar_offset ||
+            source.fanin_offset > recorded_fanins || source.fanin_count > recorded_fanins - source.fanin_offset) {
             return std::nullopt;
         }
         total_tensors += source.tensor_count;
@@ -997,18 +1010,17 @@ std::optional<GraphDefinition> graph_layout_definition(const GraphRecording &rec
 
     GraphDefinition definition{};
     definition.full_key = recording.full_key;
-    definition.task_count = static_cast<uint32_t>(recording.task_count);
-    definition.edge_count = static_cast<uint32_t>(total_fanins);
-    definition.root_count = static_cast<uint32_t>(root_count);
-    definition.boundary_count = static_cast<uint32_t>(recording.boundary_tensors().size());
-    definition.boundary_scalar_count = static_cast<uint32_t>(recording.boundary_scalar_count());
-    definition.tensor_arg_count = static_cast<uint32_t>(total_tensors);
-    definition.scalar_arg_count = static_cast<uint32_t>(total_scalars);
-    definition.predicate_count = static_cast<uint32_t>(predicate_count);
+    definition.task_count = recording.task_count;
+    definition.edge_count = total_fanins;
+    definition.root_count = root_count;
+    definition.boundary_count = static_cast<int32_t>(recording.boundary_tensors().size());
+    definition.boundary_scalar_count = recording.boundary_scalar_count();
+    definition.tensor_arg_count = total_tensors;
+    definition.scalar_arg_count = total_scalars;
+    definition.predicate_count = predicate_count;
     size_t execution_storage_bytes = 0;
     if (!graph_execution_storage_bytes(
-            static_cast<int32_t>(definition.task_count), definition.tensor_arg_count, definition.scalar_arg_count,
-            &execution_storage_bytes
+            definition.task_count, definition.tensor_arg_count, definition.scalar_arg_count, &execution_storage_bytes
         ) ||
         execution_storage_bytes > UINT32_MAX) {
         return std::nullopt;
@@ -1016,9 +1028,9 @@ std::optional<GraphDefinition> graph_layout_definition(const GraphRecording &rec
     definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
 
     size_t image_bytes = sizeof(GraphDefinition);
-    if (!graph_layout_section<uint32_t>(recording.task_count + 1, &image_bytes, &definition.off_fanout_offsets) ||
+    if (!graph_layout_section<int32_t>(recording.task_count + 1, &image_bytes, &definition.off_fanout_offsets) ||
         !graph_layout_section<uint16_t>(total_fanins, &image_bytes, &definition.off_fanout_indices) ||
-        !graph_layout_section<uint32_t>(recording.task_count + 1, &image_bytes, &definition.off_fanin_offsets) ||
+        !graph_layout_section<int32_t>(recording.task_count + 1, &image_bytes, &definition.off_fanin_offsets) ||
         !graph_layout_section<uint16_t>(total_fanins, &image_bytes, &definition.off_fanin_indices) ||
         !graph_layout_section<uint16_t>(root_count, &image_bytes, &definition.off_root_indices) ||
         !graph_layout_section<uint64_t>(recording.task_count, &image_bytes, &definition.off_in_graph_task_offsets) ||
@@ -1058,9 +1070,9 @@ bool graph_fill_definition(const GraphRecording &recording, GraphDefinition defi
     const size_t total_fanins = definition.edge_count;
     const size_t root_count = definition.root_count;
     const size_t predicate_count = definition.predicate_count;
-    auto *fanout_offsets = graph_image_section<uint32_t>(image, definition.off_fanout_offsets);
+    auto *fanout_offsets = graph_image_section<int32_t>(image, definition.off_fanout_offsets);
     auto *fanout_indices = graph_image_section<uint16_t>(image, definition.off_fanout_indices);
-    auto *fanin_offsets = graph_image_section<uint32_t>(image, definition.off_fanin_offsets);
+    auto *fanin_offsets = graph_image_section<int32_t>(image, definition.off_fanin_offsets);
     auto *fanin_indices = graph_image_section<uint16_t>(image, definition.off_fanin_indices);
     auto *roots = graph_image_section<uint16_t>(image, definition.off_root_indices);
     auto *in_graph_task_offsets = graph_image_section<uint64_t>(image, definition.off_in_graph_task_offsets);
@@ -1080,13 +1092,11 @@ bool graph_fill_definition(const GraphRecording &recording, GraphDefinition defi
     // A producer's fanout count is accumulated across the consumer walk below and then
     // prefix-summed in place, so every entry has to start at zero — including [0],
     // which nothing else writes and which the device checks is zero.
-    std::fill_n(fanout_offsets, recording.task_count + 1, 0U);
+    std::fill_n(fanout_offsets, recording.task_count + 1, 0);
     fanin_offsets[0] = 0;
-    for (size_t i = 0; i < recording.task_count; ++i) {
+    for (int32_t i = 0; i < recording.task_count; ++i) {
         const RecordedInGraphTask &source = recording.tasks[i];
-        if (source.total_output_size > static_cast<size_t>(INT32_MAX) ||
-            source.tensor_count > static_cast<uint32_t>(INT32_MAX) ||
-            source.scalar_count > static_cast<uint32_t>(INT32_MAX) || source.fanin_count > UINT16_MAX) {
+        if (source.total_output_size > static_cast<size_t>(INT32_MAX) || source.fanin_count > UINT16_MAX) {
             return false;
         }
         in_graph_task_offsets[i] = required_heap;
@@ -1095,13 +1105,13 @@ bool graph_fill_definition(const GraphRecording &recording, GraphDefinition defi
         required_heap += output_bytes;
 
         if (source.fanin_count == 0) roots[root_cursor++] = static_cast<uint16_t>(i);
-        for (uint32_t f = 0; f < source.fanin_count; ++f) {
-            const size_t producer = recording.internal_fanins[source.fanin_offset + f];
+        for (int32_t f = 0; f < source.fanin_count; ++f) {
+            const int32_t producer = recording.internal_fanins[source.fanin_offset + f];
             if (producer >= i) return false;
             fanin_indices[fanin_cursor++] = static_cast<uint16_t>(producer);
             fanout_offsets[producer + 1]++;
         }
-        fanin_offsets[i + 1] = static_cast<uint32_t>(fanin_cursor);
+        fanin_offsets[i + 1] = static_cast<int32_t>(fanin_cursor);
 
         InGraphTaskDefinition &task = tasks[i];
         std::copy(source.kernel_ids.begin(), source.kernel_ids.end(), std::begin(task.kernel_id));
@@ -1109,11 +1119,11 @@ bool graph_fill_definition(const GraphRecording &recording, GraphDefinition defi
         task.task_attrs = source.task_attrs.raw();
         task.logical_block_num = source.logical_block_num;
         task.total_required_subtasks = source.total_required_subtasks;
-        task.tensor_count = static_cast<int32_t>(source.tensor_count);
-        task.scalar_count = static_cast<int32_t>(source.scalar_count);
+        task.tensor_count = source.tensor_count;
+        task.scalar_count = source.scalar_count;
         task.total_output_size = static_cast<int32_t>(source.total_output_size);
-        task.tensor_offset = static_cast<uint32_t>(tensor_cursor);
-        task.scalar_offset = static_cast<uint32_t>(scalar_cursor);
+        task.tensor_offset = static_cast<int32_t>(tensor_cursor);
+        task.scalar_offset = static_cast<int32_t>(scalar_cursor);
         task.dump_metadata = source.dump_metadata;
         task.predicate_slot = 0;
         if (source.predicate_index >= 0) {
@@ -1132,7 +1142,7 @@ bool graph_fill_definition(const GraphRecording &recording, GraphDefinition defi
             task.predicate_slot = static_cast<uint16_t>(++predicate_cursor);
         }
         const simpler::hbg::Tensor *source_tensors = recording.task_tensors(source);
-        for (size_t t = 0; t < source.tensor_count; ++t) {
+        for (int32_t t = 0; t < source.tensor_count; ++t) {
             if (source_tensors[t].ndims > MAX_TENSOR_DIMS) return false;
             tensors[tensor_cursor] = graph_tensor_pack(source_tensors[t]);
             std::optional<GraphTensorSourceRef> packed_source =
@@ -1141,7 +1151,7 @@ bool graph_fill_definition(const GraphRecording &recording, GraphDefinition defi
             tensor_sources[tensor_cursor] = *packed_source;
             tensor_cursor++;
         }
-        for (size_t scalar_index = 0; scalar_index < source.scalar_count; ++scalar_index) {
+        for (int32_t scalar_index = 0; scalar_index < source.scalar_count; ++scalar_index) {
             std::optional<GraphScalarSourceRef> packed_source =
                 graph_pack_scalar_source(recording.scalar_sources[source.scalar_offset + scalar_index]);
             if (!packed_source.has_value() ||
@@ -1160,12 +1170,12 @@ bool graph_fill_definition(const GraphRecording &recording, GraphDefinition defi
         return false;
     }
     definition.required_heap = required_heap;
-    for (size_t i = 0; i < recording.task_count; ++i)
+    for (int32_t i = 0; i < recording.task_count; ++i)
         fanout_offsets[i + 1] += fanout_offsets[i];
-    std::vector<uint32_t> cursors(fanout_offsets, fanout_offsets + recording.task_count);
-    for (size_t consumer = 0; consumer < recording.task_count; ++consumer) {
-        for (uint32_t f = fanin_offsets[consumer]; f < fanin_offsets[consumer + 1]; ++f) {
-            const size_t producer = fanin_indices[f];
+    std::vector<int32_t> cursors(fanout_offsets, fanout_offsets + recording.task_count);
+    for (int32_t consumer = 0; consumer < recording.task_count; ++consumer) {
+        for (int32_t f = fanin_offsets[consumer]; f < fanin_offsets[consumer + 1]; ++f) {
+            const int32_t producer = fanin_indices[f];
             fanout_indices[cursors[producer]++] = static_cast<uint16_t>(consumer);
         }
     }
@@ -1272,7 +1282,7 @@ static void next_fanin_seen_epoch(OrchestratorState *orch) {
 // established that the producer is a GLOBAL task whose local id is a valid table
 // entry.
 static bool fanin_mark_seen(OrchestratorState &orch, TaskId producer_task_id) {
-    const int32_t prod_local = static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id));
+    const int32_t prod_local = simpler::hbg::task_local_id(producer_task_id);
     if (prod_local < 0) {
         return false;
     }
@@ -1319,7 +1329,7 @@ append_fanin_or_fail(OrchestratorState &orch, TaskId producer_task_id, int32_t *
     // unclaimed — or out-of-range — slot. Only ids handed back by a previous submit
     // are valid here, and those are below active_count() because hbg mints them in
     // order and never recycles one.
-    const int32_t prod_local = static_cast<int32_t>(simpler::hbg::task_local_id(producer_task_id));
+    const int32_t prod_local = simpler::hbg::task_local_id(producer_task_id);
     if (prod_local < 0 || prod_local >= orch.task_allocator.active_count()) {
         orch.report_fatal(
             SIMPLER_ERROR_INVALID_ARGS, __FUNCTION__,
@@ -1400,7 +1410,7 @@ static bool prepare_task(
         return false;
     }
 
-    out->task_id = simpler::hbg::make_global_task(static_cast<uint32_t>(out->alloc_result.task_id));
+    out->task_id = simpler::hbg::make_global_task(out->alloc_result.task_id);
     ChipTaskStorage &storage = orch->sm_header->tasks.storage_at(out->alloc_result.task_id);
     out->slot_state = &storage.slot;
     out->task = &storage.task;
@@ -1806,10 +1816,10 @@ static TaskOutputTensors submit_task_common(
 namespace {
 
 bool graph_boundary_matches(const GraphDefinition &definition, const GraphTaskArgs &args) {
-    if (args.scalar_count() != static_cast<int32_t>(definition.boundary_scalar_count) ||
-        args.explicit_dep_count() != 0 || args.tensor_count() != static_cast<int32_t>(definition.boundary_count)) {
+    if (args.scalar_count() != definition.boundary_scalar_count || args.explicit_dep_count() != 0 ||
+        args.tensor_count() != definition.boundary_count) {
         LOG_WARN(
-            "[GraphExecution] fixed boundary contract mismatch: tensors=%d/%u scalars=%d/%u explicit_deps=%u",
+            "[GraphExecution] fixed boundary contract mismatch: tensors=%d/%d scalars=%d/%d explicit_deps=%u",
             args.tensor_count(), definition.boundary_count, args.scalar_count(), definition.boundary_scalar_count,
             args.explicit_dep_count()
         );
@@ -1970,7 +1980,7 @@ bool graph_submit_outer(
         orch_mark_fatal(orch, SIMPLER_ERROR_HEAP_RING_DEADLOCK);
         return false;
     }
-    const TaskId task_id = simpler::hbg::make_global_task(static_cast<uint32_t>(allocation.task_id));
+    const TaskId task_id = simpler::hbg::make_global_task(allocation.task_id);
     SharedMemoryTaskHeader &tasks = orch->sm_header->tasks;
     ChipTaskStorage &storage = tasks.storage_at(allocation.task_id);
     TaskDescriptor &task = storage.task;
@@ -2139,13 +2149,12 @@ TaskOutputTensors graph_record_submit_in_graph_task(
     TaskOutputTensors result;
     GraphRecording &recording = *active_graph_recording(orch);
 
-    const size_t task_index = recording.task_count;
+    const int32_t task_index = recording.task_count;
     // A recorded task lives in the IN_GRAPH id space, so an id the body hands
     // around says which of the two kinds of thing it names without any arithmetic:
     // an IN_GRAPH id is a task of this body, indexed by its low field; a GLOBAL id is
     // a task submitted before the Graph, which nothing in the body may depend on.
-    const TaskId task_id =
-        simpler::hbg::make_in_graph_task(GRAPH_RECORD_NO_OWNING_GRAPH, static_cast<uint32_t>(task_index));
+    const TaskId task_id = simpler::hbg::make_in_graph_task(GRAPH_RECORD_NO_OWNING_GRAPH, task_index);
     result.set_task_id(task_id);
 
     if (task_index >= MAX_IN_GRAPH_TASKS || args.has_error) {
@@ -2167,7 +2176,7 @@ TaskOutputTensors graph_record_submit_in_graph_task(
     // the slot back to a freshly recorded task's state. An over-cap body grows `tasks`,
     // which moves the slots, but the addresses handed to the caller live in the recording's
     // tensor pool rather than in a slot, so a move cannot invalidate them.
-    if (task_index >= recording.tasks.size()) recording.tasks.emplace_back();
+    if (task_index >= static_cast<int32_t>(recording.tasks.size())) recording.tasks.emplace_back();
     RecordedInGraphTask &task = recording.tasks[task_index];
     task.reset();
     task.kernel_ids[static_cast<int>(SubtaskSlot::AIC)] = aic_kernel_id;
@@ -2206,16 +2215,16 @@ TaskOutputTensors graph_record_submit_in_graph_task(
         return result;
     }
     task.tensor_offset = recording.task_tensor_cursor;
-    task.tensor_count = static_cast<uint32_t>(tensor_count);
-    recording.task_tensor_cursor += static_cast<uint32_t>(tensor_count);
+    task.tensor_count = tensor_count;
+    recording.task_tensor_cursor += tensor_count;
     simpler::hbg::Tensor *task_tensors = recording.task_tensors(task);
     // Value-initialized before the fill, not merely claimed: the slice holds whatever the
     // previous body left in it, and simpler::hbg::Tensor::init_from writes strides only up
     // to the new tensor's ndims, so a narrower tensor would inherit a wider one's trailing
     // strides.
-    std::fill_n(task_tensors, static_cast<size_t>(tensor_count), simpler::hbg::Tensor{});
+    std::fill_n(task_tensors, tensor_count, simpler::hbg::Tensor{});
     for (int32_t i = 0; i < tensor_count; ++i) {
-        simpler::hbg::Tensor &slot_tensor = task_tensors[static_cast<size_t>(i)];
+        simpler::hbg::Tensor &slot_tensor = task_tensors[i];
         if (args.tag(i) != TensorArgType::OUTPUT) {
             slot_tensor.copy(args.tensor(i).ref());
         } else {
@@ -2229,10 +2238,10 @@ TaskOutputTensors graph_record_submit_in_graph_task(
     // The addresses handed out here are into the pool, which never moves, so they stay
     // valid for the rest of this recording.
     for (int32_t i = 0; i < tensor_count; ++i) {
-        if (args.tag(i) == TensorArgType::OUTPUT) result.materialize_output(task_tensors[static_cast<size_t>(i)]);
+        if (args.tag(i) == TensorArgType::OUTPUT) result.materialize_output(task_tensors[i]);
     }
-    task.scalar_offset = static_cast<uint32_t>(recording.scalars.size());
-    task.scalar_count = static_cast<uint32_t>(args.scalar_count());
+    task.scalar_offset = static_cast<int32_t>(recording.scalars.size());
+    task.scalar_count = args.scalar_count();
     recording.scalars.insert(recording.scalars.end(), args.scalars(), args.scalars() + args.scalar_count());
 #if SIMPLER_DFX
     task.dump_metadata.dump_arg_mask = args.dump_arg_mask();
@@ -2243,23 +2252,22 @@ TaskOutputTensors graph_record_submit_in_graph_task(
     // Classify each scalar's source: a plain literal is static Definition data,
     // while a value copied from a boundary scalar is refreshed on replay. A
     // mutable tracked boundary scalar is not supported and falls back.
-    recording.scalar_sources.resize(static_cast<size_t>(task.scalar_offset) + task.scalar_count);
+    recording.scalar_sources.resize(task.scalar_offset + task.scalar_count);
     for (int32_t i = 0; i < args.scalar_count(); ++i) {
         GraphRecordedScalarSourceRef source = graph_classify_scalar(recording, args, i);
         if (source.source == GraphRecordedScalarSource::INVALIDATED_BOUNDARY) recording.unsupported = true;
-        recording.scalar_sources[static_cast<size_t>(task.scalar_offset) + static_cast<size_t>(i)] = source;
+        recording.scalar_sources[task.scalar_offset + i] = source;
     }
 
     // Classify each tensor's source, then derive internal fanins from the
     // INTERNAL classifications plus any explicit internal dependency.
-    task.tensor_source_offset = static_cast<uint32_t>(recording.tensor_sources.size());
-    recording.tensor_sources.resize(static_cast<size_t>(task.tensor_source_offset) + tensor_count);
+    task.tensor_source_offset = static_cast<int32_t>(recording.tensor_sources.size());
+    recording.tensor_sources.resize(task.tensor_source_offset + tensor_count);
     for (int32_t i = 0; i < tensor_count; ++i) {
         // The out-pointer is used only for the duration of the call, so pointing
         // it into the flat array is safe even though a later task of this body grows it.
         if (!graph_classify_tensor(
-                recording, task, static_cast<int32_t>(task_index), task_tensors[static_cast<size_t>(i)],
-                &recording.tensor_sources[static_cast<size_t>(task.tensor_source_offset) + static_cast<size_t>(i)]
+                recording, task, task_index, task_tensors[i], &recording.tensor_sources[task.tensor_source_offset + i]
             )) {
             recording.unsupported = true;
         }
@@ -2291,7 +2299,7 @@ TaskOutputTensors graph_record_submit_in_graph_task(
             operand == nullptr ? 0 : operand->compute_flat_offset(pred.operand.indices, pred.operand.ndims);
         if (operand == nullptr || operand->ndims > MAX_TENSOR_DIMS || pred.operand.ndims > operand->ndims ||
             flat_offset < operand->start_offset || flat_offset - operand->start_offset >= operand->extent_elem_cache ||
-            !graph_classify_tensor(recording, task, static_cast<int32_t>(task_index), *operand, &recorded.source) ||
+            !graph_classify_tensor(recording, task, task_index, *operand, &recorded.source) ||
             recorded.source.source == GraphRecordedTensorSource::OWN_OUTPUT) {
             recording.unsupported = true;
         } else {
@@ -2303,18 +2311,18 @@ TaskOutputTensors graph_record_submit_in_graph_task(
         recording.predicates.push_back(recorded);
     }
 
-    task.fanin_offset = static_cast<uint32_t>(recording.internal_fanins.size());
+    task.fanin_offset = static_cast<int32_t>(recording.internal_fanins.size());
     // Dedup within this task's own range: the flat array's earlier entries belong
     // to the body's earlier tasks.
-    auto add_fanin = [&recording, &task](size_t producer) {
+    auto add_fanin = [&recording, &task](int32_t producer) {
         const auto begin = recording.internal_fanins.begin() + task.fanin_offset;
         if (std::find(begin, recording.internal_fanins.end(), producer) == recording.internal_fanins.end()) {
             recording.internal_fanins.push_back(producer);
         }
     };
-    for (uint32_t i = 0; i < static_cast<uint32_t>(tensor_count); ++i) {
+    for (int32_t i = 0; i < tensor_count; ++i) {
         const GraphRecordedTensorSourceRef &source = recording.tensor_sources[task.tensor_source_offset + i];
-        if (source.source == GraphRecordedTensorSource::INTERNAL) add_fanin(source.source_index);
+        if (source.source == GraphRecordedTensorSource::INTERNAL) add_fanin(static_cast<int32_t>(source.source_index));
     }
 
     // Inferred hazards, on the same terms as the ordinary path. The loop above only
@@ -2347,7 +2355,7 @@ TaskOutputTensors graph_record_submit_in_graph_task(
             // Definition instead, so the run fails by name at graph_commit rather
             // than on a hard assert here.
             LOG_WARN(
-                "[GraphExecution] recording hazard map exhausted at in-graph task %zu (%d entries); Graph abandoned",
+                "[GraphExecution] recording hazard map exhausted at in-graph task %d (%d entries); Graph abandoned",
                 task_index, GRAPH_RECORD_TENSORMAP_POOL_SIZE
             );
             recording.unsupported = true;
@@ -2358,9 +2366,9 @@ TaskOutputTensors graph_record_submit_in_graph_task(
                 // its own fanin already orders the whole body behind that task and the
                 // Definition carries no edge of its own.
                 if (simpler::hbg::is_global_task(producer)) return true;
-                const uint32_t producer_index = simpler::hbg::task_local_id(producer);
-                if (producer_index < static_cast<uint32_t>(task_index)) {
-                    add_fanin(static_cast<size_t>(producer_index));
+                const int32_t producer_index = simpler::hbg::task_local_id(producer);
+                if (producer_index < task_index) {
+                    add_fanin(producer_index);
                 }
                 return true;
             };
@@ -2387,17 +2395,17 @@ TaskOutputTensors graph_record_submit_in_graph_task(
             if (!represented_by_boundary) recording.unsupported = true;
             continue;
         }
-        const uint32_t dep_index = simpler::hbg::task_local_id(dep);
-        if (dep_index >= static_cast<uint32_t>(task_index)) {
+        const int32_t dep_index = simpler::hbg::task_local_id(dep);
+        if (dep_index >= task_index) {
             // A task of this body that is not yet recorded: the Definition's edges are
             // acyclic by construction, so a forward reference cannot be expressed.
             recording.unsupported = true;
             continue;
         }
-        add_fanin(static_cast<size_t>(dep_index));
+        add_fanin(dep_index);
     }
 
-    task.fanin_count = static_cast<uint32_t>(recording.internal_fanins.size() - task.fanin_offset);
+    task.fanin_count = static_cast<int32_t>(recording.internal_fanins.size() - task.fanin_offset);
     if (task.record_packed_base != 0 && task.total_output_size != 0 &&
         task.total_output_size <= UINTPTR_MAX - task.record_packed_base) {
         const uintptr_t begin = task.record_packed_base;
@@ -2406,7 +2414,7 @@ TaskOutputTensors graph_record_submit_in_graph_task(
         // than assumed: a mid-recording heap rollback would break it, and today
         // the only rollback is graph_end's, after every task of the body is recorded.
         always_assert(recording.output_ranges.empty() || recording.output_ranges.back().end <= begin);
-        recording.output_ranges.push_back({begin, end, static_cast<uint32_t>(task_index)});
+        recording.output_ranges.push_back({begin, end, task_index});
     }
     // Published last: until this advances, the slot is not part of the recording, so
     // nothing that scans the recorded tasks can see the task being built.
@@ -2655,7 +2663,7 @@ bool OrchestratorState::graph_end() {
         return false;
     }
     LOG_DEBUG(
-        "[GraphExecution] define key=0x%llx tasks=%u bytes=%u", static_cast<unsigned long long>(header->full_key),
+        "[GraphExecution] define key=0x%llx tasks=%d bytes=%u", static_cast<unsigned long long>(header->full_key),
         header->task_count, header->total_bytes
     );
     bool ready = false;
@@ -2957,10 +2965,9 @@ TaskOutputTensors OrchestratorState::alloc_tensors(const CoreTaskArgs &args) {
         // image. Consumers poll completion_flags (not task_state), so a hidden-alloc
         // producer completed here on the host must publish its flag too — otherwise
         // every consumer register_wakes on a producer that never runs on device and
-        // the run hangs. (The device watermark walk transparently steps past this
-        // pre-set flag when a later on-device task completes.)
+        // the run hangs.
         SharedMemoryTaskHeader &done_tasks = orch->sm_header->tasks;
-        int32_t done_local = static_cast<int32_t>(simpler::hbg::task_local_id(prepared.task_id));
+        int32_t done_local = simpler::hbg::task_local_id(prepared.task_id);
         done_tasks.set_completion_flag(done_local);
     }
     orch->inline_completed_tasks++;

--- a/src/common/host_build_graph/shared_memory.h
+++ b/src/common/host_build_graph/shared_memory.h
@@ -172,7 +172,7 @@ struct SharedMemoryHandle {
 
     // Attach to an ALREADY-populated shared memory region: point the handle and
     // the task header's segment pointers (storage / completion flags)
-    // at `sm_base`, but do NOT reset the watermark / slot states.
+    // at `sm_base`, but do NOT reset the slot states.
     // Used by host_build_graph host-orch, where the host orchestrator populated
     // the SM and H2D'd it; the device must re-point at its own SM base without
     // wiping the contents (unlike init, which also resets the header).

--- a/src/common/host_build_graph/task_id_encoding.h
+++ b/src/common/host_build_graph/task_id_encoding.h
@@ -52,12 +52,19 @@ enum class TaskIdSpace : uint32_t { GLOBAL = 0, IN_GRAPH = 1 };
 // within that Graph. graph_execution.h asserts MAX_IN_GRAPH_TASKS fits the index.
 inline constexpr uint32_t IN_GRAPH_TASK_INDEX_BITS = 10;
 
-constexpr TaskId make_global_task(uint32_t local_id) {
-    return TaskId{(static_cast<uint64_t>(TaskIdSpace::GLOBAL) << 32) | static_cast<uint64_t>(local_id)};
+// A local id is signed throughout this runtime — it is a task-table index, and the
+// table, the completion flags and the fanin payload all address slots with int32_t.
+// The low field is therefore narrowed to uint32_t before it is widened into the raw
+// word, so a negative value cannot sign-extend over the id-space bits above it.
+constexpr TaskId make_global_task(int32_t local_id) {
+    return TaskId{
+        (static_cast<uint64_t>(TaskIdSpace::GLOBAL) << 32) | static_cast<uint64_t>(static_cast<uint32_t>(local_id))
+    };
 }
 
-constexpr TaskId make_in_graph_task(uint32_t graph_local_id, uint32_t task_index) {
-    const uint32_t packed = (graph_local_id << IN_GRAPH_TASK_INDEX_BITS) | task_index;
+constexpr TaskId make_in_graph_task(int32_t graph_local_id, int32_t task_index) {
+    const uint32_t packed =
+        (static_cast<uint32_t>(graph_local_id) << IN_GRAPH_TASK_INDEX_BITS) | static_cast<uint32_t>(task_index);
     return TaskId{(static_cast<uint64_t>(TaskIdSpace::IN_GRAPH) << 32) | static_cast<uint64_t>(packed)};
 }
 
@@ -70,7 +77,8 @@ constexpr bool is_global_task(TaskId id) { return task_id_space(id) == TaskIdSpa
 
 // The low 32 bits. A task-table local id for a GLOBAL task; the packed pair above
 // for an IN_GRAPH one, which is why callers that resolve a table slot must gate on
-// is_global_task() first.
-constexpr uint32_t task_local_id(TaskId id) { return static_cast<uint32_t>(id.raw & 0xFFFFFFFFu); }
+// is_global_task() first. Both fit int32_t: a table index is bounded by the run's
+// task capacity, and a packed pair by MAX_IN_GRAPH_TASKS above that same capacity.
+constexpr int32_t task_local_id(TaskId id) { return static_cast<int32_t>(id.raw & 0xFFFFFFFFu); }
 
 }  // namespace simpler::hbg

--- a/src/common/host_build_graph/tensormap.h
+++ b/src/common/host_build_graph/tensormap.h
@@ -565,8 +565,7 @@ struct ChipTensorMap {
         g_insert_count++;
 #endif
         uint32_t bucket_index = hash(addr);
-        auto local_id = simpler::hbg::task_local_id(producer_task_id);
-        const int32_t task_slot = local_id;
+        const int32_t task_slot = simpler::hbg::task_local_id(producer_task_id);
         // A producer's low id field is a task chain index directly, so the id space a
         // caller inserts under has to be the one this map was dimensioned for: a
         // whole-run map takes task capacity, a Graph recording's takes MAX_IN_GRAPH_TASKS.
@@ -607,7 +606,7 @@ struct ChipTensorMap {
         // Update predecessor's next pointer (O(1) via prev_in_task)
         if (entry.prev_in_task == nullptr) {
             // Entry is the head of its task chain, update task_entry_heads
-            int32_t local_id = static_cast<int32_t>(simpler::hbg::task_local_id(entry.producer_task_id));
+            int32_t local_id = simpler::hbg::task_local_id(entry.producer_task_id);
             const int32_t task_slot = local_id;
             debug_assert(task_slot >= 0 && task_slot < max_tasks);
             task_entry_heads[task_slot] = entry.next_in_task;

--- a/src/common/host_build_graph/types.h
+++ b/src/common/host_build_graph/types.h
@@ -691,8 +691,8 @@ private:
 using CoreTaskArgs = Arg<MAX_TENSOR_ARGS, MAX_SCALAR_ARGS>;
 
 // Tensor and scalar capacity of a Graph boundary.
-inline constexpr uint32_t GRAPH_MAX_TENSOR_ARGS = 128;
-inline constexpr uint32_t GRAPH_MAX_SCALAR_ARGS = 64;
+inline constexpr int32_t GRAPH_MAX_TENSOR_ARGS = 128;
+inline constexpr int32_t GRAPH_MAX_SCALAR_ARGS = 64;
 
 // Boundary arguments of a Graph. Sized independently of CoreTaskArgs because the
 // outer GRAPH payload carries the whole boundary, while materialize stages only

--- a/tests/ut/cpp/a2a3/test_graph_activation.cpp
+++ b/tests/ut/cpp/a2a3/test_graph_activation.cpp
@@ -78,7 +78,7 @@ TEST_F(GraphActivationTest, WakeRoutesConsumerWhenProducerCompletedBeforeRegiste
     init_in_graph_task(tasks[1], 1, CHIP_TASK_PENDING);      // consumer of task 0
     tasks[0].slot.wake_list_head.store(WAKE_LIST_SENTINEL);  // its wake list already drained
 
-    std::vector<uint32_t> fanin_offsets{0, 0, 1};  // task 0 is a root; task 1 <- {0}
+    std::vector<int32_t> fanin_offsets{0, 0, 1};  // task 0 is a root; task 1 <- {0}
     std::vector<uint16_t> fanin_indices{0};
     GraphExecution exec{};
     exec.tasks = exec.task_storage = tasks.get();
@@ -103,7 +103,7 @@ TEST_F(GraphActivationTest, IncrementalPublishRoutesCompletedDepsAndWakeChainsPe
     init_in_graph_task(tasks[2], 2, CHIP_TASK_PENDING);    // consumer of task 0 (completed)
     init_in_graph_task(tasks[3], 3, CHIP_TASK_PENDING);    // consumer of task 1 (pending)
 
-    std::vector<uint32_t> fanin_offsets{0, 0, 0, 1, 2};  // task 2 <- {0}, task 3 <- {1}
+    std::vector<int32_t> fanin_offsets{0, 0, 0, 1, 2};  // task 2 <- {0}, task 3 <- {1}
     std::vector<uint16_t> fanin_indices{0, 1};
     GraphExecution exec{};
     exec.tasks = exec.task_storage = tasks.get();

--- a/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
@@ -140,7 +140,7 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
         const ChipTaskSlotState &st = entry.slot;
 
         // Descriptor: the task id is written to this exact local id.
-        EXPECT_EQ(simpler::hbg::task_local_id(desc.task_id), static_cast<uint32_t>(local));
+        EXPECT_EQ(simpler::hbg::task_local_id(desc.task_id), local);
         // task_state is written at submit (reset_for_reuse skips it): PENDING for a
         // dispatchable task, COMPLETED for a pre-completed hidden-alloc. Either way a
         // real enum, never poison.
@@ -179,7 +179,7 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     // The consumer's fanin is written: two duplicate deps dedupe to one.
     const TaskPayload &cons_pl = tasks.storage_at(simpler::hbg::task_local_id(consumer.task_id())).payload;
     EXPECT_EQ(cons_pl.fanin_count, 1);
-    EXPECT_EQ(cons_pl.fanin_data()[0], static_cast<int32_t>(simpler::hbg::task_local_id(root.task_id())));
+    EXPECT_EQ(cons_pl.fanin_data()[0], simpler::hbg::task_local_id(root.task_id()));
 }
 
 TEST_F(HbgSubmitPoisonTest, InvalidDispatchPredicateIsRejectedBeforeTaskAllocation) {

--- a/tests/ut/cpp/a5/test_graph_activation.cpp
+++ b/tests/ut/cpp/a5/test_graph_activation.cpp
@@ -78,7 +78,7 @@ TEST_F(GraphActivationTest, WakeRoutesConsumerWhenProducerCompletedBeforeRegiste
     init_in_graph_task(tasks[1], 1, CHIP_TASK_PENDING);      // consumer of task 0
     tasks[0].slot.wake_list_head.store(WAKE_LIST_SENTINEL);  // its wake list already drained
 
-    std::vector<uint32_t> fanin_offsets{0, 0, 1};  // task 0 is a root; task 1 <- {0}
+    std::vector<int32_t> fanin_offsets{0, 0, 1};  // task 0 is a root; task 1 <- {0}
     std::vector<uint16_t> fanin_indices{0};
     GraphExecution exec{};
     exec.tasks = exec.task_storage = tasks.get();
@@ -103,7 +103,7 @@ TEST_F(GraphActivationTest, IncrementalPublishRoutesCompletedDepsAndWakeChainsPe
     init_in_graph_task(tasks[2], 2, CHIP_TASK_PENDING);    // consumer of task 0 (completed)
     init_in_graph_task(tasks[3], 3, CHIP_TASK_PENDING);    // consumer of task 1 (pending)
 
-    std::vector<uint32_t> fanin_offsets{0, 0, 0, 1, 2};  // task 2 <- {0}, task 3 <- {1}
+    std::vector<int32_t> fanin_offsets{0, 0, 0, 1, 2};  // task 2 <- {0}, task 3 <- {1}
     std::vector<uint16_t> fanin_indices{0, 1};
     GraphExecution exec{};
     exec.tasks = exec.task_storage = tasks.get();

--- a/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
@@ -139,7 +139,7 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
         const ChipTaskSlotState &st = entry.slot;
 
         // Descriptor: the task id is written to this exact local id.
-        EXPECT_EQ(simpler::hbg::task_local_id(desc.task_id), static_cast<uint32_t>(local));
+        EXPECT_EQ(simpler::hbg::task_local_id(desc.task_id), local);
         // task_state is written at submit (reset_for_reuse skips it): PENDING for a
         // dispatchable task, COMPLETED for a pre-completed hidden-alloc. Either way a
         // real enum, never poison.
@@ -178,5 +178,5 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
     // The consumer's fanin is written: two duplicate deps dedupe to one.
     const TaskPayload &cons_pl = tasks.storage_at(simpler::hbg::task_local_id(consumer.task_id())).payload;
     EXPECT_EQ(cons_pl.fanin_count, 1);
-    EXPECT_EQ(cons_pl.fanin_data()[0], static_cast<int32_t>(simpler::hbg::task_local_id(root.task_id())));
+    EXPECT_EQ(cons_pl.fanin_data()[0], simpler::hbg::task_local_id(root.task_id()));
 }

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -56,9 +56,9 @@ std::vector<std::byte>
 make_test_definition(uint64_t graph_key, uint64_t boundary_address, uint32_t boundary_scalar_count = 1) {
     std::vector<std::byte> image(sizeof(GraphDefinition));
 
-    std::vector<uint32_t> fanin_offsets{0, 0, 1};
+    std::vector<int32_t> fanin_offsets{0, 0, 1};
     std::vector<uint16_t> fanin_indices{0};
-    std::vector<uint32_t> fanout_offsets{0, 1, 1};
+    std::vector<int32_t> fanout_offsets{0, 1, 1};
     std::vector<uint16_t> fanout_indices{1};
     std::vector<uint16_t> roots{0};
     std::vector<uint64_t> in_graph_task_offsets{0, 64};
@@ -114,8 +114,7 @@ make_test_definition(uint64_t graph_key, uint64_t boundary_address, uint32_t bou
     definition.off_scalar_sources = append_section(image, scalar_sources);
     size_t execution_storage_bytes = 0;
     graph_execution_storage_bytes(
-        static_cast<int32_t>(definition.task_count), definition.tensor_arg_count, definition.scalar_arg_count,
-        &execution_storage_bytes
+        definition.task_count, definition.tensor_arg_count, definition.scalar_arg_count, &execution_storage_bytes
     );
     definition.execution_storage_bytes = static_cast<uint32_t>(execution_storage_bytes);
     definition.total_bytes = static_cast<uint32_t>(image.size());
@@ -229,8 +228,8 @@ public:
         std::memset(boundary_tensors_.data(), 0, TENSOR_SLOTS * sizeof(simpler::hbg::Tensor));
         const GraphTensor boundary = make_test_tensor(boundary_address);
         new (boundary_tensors_.data()) GraphTensor{boundary};
-        storage_entry_.payload.tensor_count = static_cast<int32_t>(definition->boundary_count);
-        storage_entry_.payload.scalar_count = static_cast<int32_t>(definition->boundary_scalar_count);
+        storage_entry_.payload.tensor_count = definition->boundary_count;
+        storage_entry_.payload.scalar_count = definition->boundary_scalar_count;
         std::fill_n(boundary_scalars_.data(), definition->boundary_scalar_count, uint64_t{0});
         if (definition->boundary_scalar_count != 0) {
             boundary_scalars_[definition->boundary_scalar_count - 1] = boundary_scalar;
@@ -372,7 +371,7 @@ TEST(GraphExecutionStorage, RejectsInvalidInGraphTaskCount) {
 
     EXPECT_FALSE(graph_execution_storage_bytes(0, 1, 1, &storage_bytes));
     EXPECT_FALSE(graph_execution_storage_bytes(-1, 1, 1, &storage_bytes));
-    EXPECT_FALSE(graph_execution_storage_bytes(static_cast<int32_t>(MAX_IN_GRAPH_TASKS) + 1, 1, 1, &storage_bytes));
+    EXPECT_FALSE(graph_execution_storage_bytes(MAX_IN_GRAPH_TASKS + 1, 1, 1, &storage_bytes));
     // A Definition with no arguments at all still needs its in-graph task array.
     EXPECT_TRUE(graph_execution_storage_bytes(1, 0, 0, &storage_bytes));
     EXPECT_GE(storage_bytes, sizeof(GraphExecution) + sizeof(ChipTaskStorage));
@@ -523,6 +522,56 @@ TEST(GraphDefinitionObject, RejectsHeaderFramingAnotherGraph) {
         << "the object localizes while its header and image agree";
 
     definition_object.reframe_full_key(GRAPH_KEY_VALUE + 1);
+    EXPECT_EQ(heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(boundary.data()), 17), nullptr);
+}
+
+// task_count is read off the wire and signed, so a corrupt Definition can present a
+// non-positive one. Two layers refuse it -- graph_execution_localize's own gate and
+// graph_execution_storage_layout behind it -- and this pins the contract rather than
+// either implementation: whichever layer moves, a Definition with no tasks must not
+// localize. It matters because every CSR section is fetched with `task_count + 1`, so a
+// -1 that reached bind_graph_topology would ask for zero elements, get a live pointer,
+// and read fanin_offsets one slot before the array.
+TEST(GraphDefinitionObject, RejectsNonPositiveInGraphTaskCount) {
+    constexpr uint64_t GRAPH_KEY_VALUE = 0x4567;
+    std::array<uint8_t, 64> boundary{};
+    for (const int32_t task_count : {-1, 0}) {
+        std::vector<std::byte> definition =
+            make_test_definition(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()));
+        reinterpret_cast<GraphDefinition *>(definition.data())->task_count = task_count;
+        const TestDefinitionObject definition_object(definition);
+        OuterHeap heap(definition);
+        EXPECT_EQ(
+            heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(boundary.data()), 17), nullptr
+        ) << "task_count="
+          << task_count;
+    }
+}
+
+// An in-graph task's pool offsets are signed, which makes a negative one representable
+// where the unsigned span tests used to reject it as a huge value. Signed, those tests go
+// blind: a negative offset is below tensor_arg_count, and subtracting it *widens* the
+// remaining span, so both `offset > count` and `count > total - offset` pass. Only the
+// explicit negative test in bind_graph_topology rejects it, and it belongs there rather
+// than in the per-slice materialize path, which runs after the pointer is bound.
+TEST(GraphDefinitionObject, RejectsNegativeInGraphTaskArgOffset) {
+    constexpr uint64_t GRAPH_KEY_VALUE = 0x4567;
+    std::array<uint8_t, 64> boundary{};
+    std::vector<std::byte> definition =
+        make_test_definition(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()));
+    {
+        const TestDefinitionObject definition_object(definition);
+        OuterHeap heap(definition);
+        ASSERT_NE(
+            heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(boundary.data()), 17), nullptr
+        ) << "the unmodified Definition localizes";
+    }
+
+    auto *header = reinterpret_cast<GraphDefinition *>(definition.data());
+    auto *tasks = reinterpret_cast<InGraphTaskDefinition *>(definition.data() + header->off_in_graph_tasks);
+    tasks[1].tensor_offset = -1;
+    const TestDefinitionObject definition_object(definition);
+    OuterHeap heap(definition);
     EXPECT_EQ(heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(boundary.data()), 17), nullptr);
 }
 

--- a/tests/ut/cpp/common/test_hbg_graph_recording_bounds.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_recording_bounds.cpp
@@ -96,7 +96,7 @@ TEST_F(HbgGraphRecordingBoundsTest, RecordedTaskIsKeyedByItsIndexNotByTheRunsNum
         filler.add_input(boundary);
         ASSERT_TRUE(orch.submit_dummy_task(filler).task_id().is_valid()) << "filler task " << i;
     }
-    ASSERT_EQ(orch.task_allocator.active_count(), static_cast<int32_t>(MAX_IN_GRAPH_TASKS));
+    ASSERT_EQ(orch.task_allocator.active_count(), MAX_IN_GRAPH_TASKS);
 
     GraphTaskArgs boundary_args;
     boundary_args.add_input(boundary);
@@ -114,7 +114,7 @@ TEST_F(HbgGraphRecordingBoundsTest, RecordedTaskIsKeyedByItsIndexNotByTheRunsNum
     EXPECT_EQ(simpler::hbg::task_id_space(in_graph_task_id), simpler::hbg::TaskIdSpace::IN_GRAPH)
         << "a recorded task must not take a GLOBAL id: nothing resolves it against the task table, and its low "
            "field is what keys the recording's hazard map";
-    EXPECT_EQ(simpler::hbg::task_local_id(in_graph_task_id), 0u)
+    EXPECT_EQ(simpler::hbg::task_local_id(in_graph_task_id), 0)
         << "the first recorded task's low field is task index 0, independent of how many tasks the run has "
            "already allocated";
     EXPECT_LT(simpler::hbg::task_local_id(in_graph_task_id), MAX_IN_GRAPH_TASKS);

--- a/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_submit_failure.cpp
@@ -511,7 +511,7 @@ TEST_F(HbgGraphSubmitFailureTest, CachedGraphUsesFinalTaskWindowSlot) {
 
     EXPECT_FALSE(replay.execute_block);
     ASSERT_TRUE(replay.task_id.is_valid());
-    EXPECT_EQ(simpler::hbg::task_local_id(replay.task_id), static_cast<uint32_t>(allocator.capacity() - 1));
+    EXPECT_EQ(simpler::hbg::task_local_id(replay.task_id), allocator.capacity() - 1);
     EXPECT_EQ(allocator.active_count(), allocator.capacity());
     EXPECT_EQ(allocator.active_count(), allocator.capacity());
     EXPECT_EQ(orch.fatal_code.load(std::memory_order_acquire), SIMPLER_ERROR_NONE);
@@ -819,7 +819,7 @@ TEST_F(HbgGraphSubmitFailureTest, AnOrdinaryAllocationInterleavesWithADeferredSh
     EXPECT_GT(orch.task_allocator.heap_top(), heap_after_ordinary)
         << "the shell's block sits above the ordinary task's, not before it";
     SharedMemoryTaskHeader &tasks = sm_handle->header->tasks;
-    const int32_t shell_slot = static_cast<int32_t>(simpler::hbg::task_local_id(graph.task_id));
+    const int32_t shell_slot = simpler::hbg::task_local_id(graph.task_id);
     const TaskDescriptor *shell = &tasks.storage_at(shell_slot).task;
     ASSERT_NE(shell, nullptr);
     ASSERT_NE(shell->packed_buffer_base, nullptr);
@@ -979,8 +979,8 @@ TEST_F(HbgGraphSubmitFailureTest, AHiddenAllocTaskLeavesItsDispatchPredicateDefi
     ASSERT_TRUE(outputs.task_id().is_valid());
     ASSERT_FALSE(orch.is_fatal());
 
-    const uint64_t slot = simpler::hbg::task_local_id(outputs.task_id());
-    ASSERT_LT(slot, static_cast<uint64_t>(kPoisonedSlots)) << "the submitted slot must be one this test poisoned";
+    const int32_t slot = simpler::hbg::task_local_id(outputs.task_id());
+    ASSERT_LT(slot, kPoisonedSlots) << "the submitted slot must be one this test poisoned";
     EXPECT_EQ(storage[slot].payload.predicate.op, PredicateOp::NONE);
     EXPECT_EQ(storage[slot].payload.predicate.addr, 0u);
 }

--- a/tests/ut/cpp/common/test_hbg_slot_claim.cpp
+++ b/tests/ut/cpp/common/test_hbg_slot_claim.cpp
@@ -178,7 +178,7 @@ TEST_F(HbgSlotClaimTest, CachedGraphReplayClaimsAPoisonedSlot) {
     poison_slot(1);
     const GraphScopeResult replay = orch.graph_begin(0x51ADC1A2, boundary_args, 0x1736);
     ASSERT_TRUE(replay.task_id.is_valid());
-    ASSERT_EQ(simpler::hbg::task_local_id(replay.task_id), 1u);
+    ASSERT_EQ(simpler::hbg::task_local_id(replay.task_id), 1);
 
     expect_slot_pristine(1);
 }

--- a/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
+++ b/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
@@ -84,7 +84,7 @@ public:
         // the slot so the compaction can be checked element by element.
         for (uint64_t i = 0; i < SUBMITTED; ++i) {
             ChipTaskStorage &entry = storage_[i];
-            entry.task.task_id = simpler::hbg::make_global_task(static_cast<uint32_t>(i));
+            entry.task.task_id = simpler::hbg::make_global_task(static_cast<int32_t>(i));
             entry.payload.tensor_count = TENSORS_PER_TASK;
             entry.payload.scalar_count = SCALARS_PER_TASK;
             entry.payload.fanin_count = FANIN_PER_TASK;
@@ -218,7 +218,7 @@ TEST(HbgSmCompaction, CarriesEveryLiveSlotsContent) {
 
     for (uint64_t i = 0; i < SUBMITTED; ++i) {
         const ChipTaskStorage &entry = compacted.storage[i];
-        EXPECT_EQ(simpler::hbg::task_local_id(entry.task.task_id), i) << "slot " << i;
+        EXPECT_EQ(simpler::hbg::task_local_id(entry.task.task_id), static_cast<int32_t>(i)) << "slot " << i;
         EXPECT_EQ(entry.payload.tensor_count, TENSORS_PER_TASK) << "slot " << i;
         EXPECT_EQ(entry.payload.tensor_data()[0].buffer.addr, 0x1000 + i * 0x10) << "slot " << i;
         EXPECT_EQ(entry.slot.in_graph_task_index, static_cast<int32_t>(200 + i)) << "slot " << i;


### PR DESCRIPTION
## Problem

`host_build_graph` mixed `uint32_t` and `int32_t` for the same quantities, so
every boundary between them carried a `static_cast`.

- `simpler::hbg::task_local_id()` returned `uint32_t`, while every consumer of a
  local id — the task table, `completion_flags`, the tensormap task chains, the
  fanin payload, `TaskAllocResult` — addresses slots with `int32_t`.
- `GraphDefinition` had the same split: its counts were unsigned while the
  `payload.tensor_count` / `args.scalar_count()` / `InGraphTaskDefinition::tensor_count`
  they are compared against are signed. Those `static_cast`s were the scar.

## Change

One rule, applied to the whole runtime: **things are counted signed, bytes are
counted unsigned.**

`int32_t` — `task_local_id()` and the `make_*_task()` encoders;
`GraphDefinition`'s `task_count` / `edge_count` / `root_count` /
`boundary_count` / `boundary_scalar_count` / `tensor_arg_count` /
`scalar_arg_count` / `predicate_count`; the CSR `fanin_offsets` /
`fanout_offsets` arrays; `InGraphTaskDefinition`'s element indices into the
argument pools; `GraphRecording` and `RecordedInGraphTask`'s counts and offsets;
`MAX_IN_GRAPH_TASKS` and `GRAPH_MAX_{TENSOR,SCALAR}_ARGS`.

`uint32_t` — `total_bytes`, `execution_storage_bytes` and the twelve `off_*`
fields. These are dimensioned against `UINT32_MAX` by `graph_layout_section` and
reach 4 GB by design, so narrowing them would be a functional change, not a
cleanup.

Every field moved to `int32_t` is capped by `MAX_IN_GRAPH_TASKS` times a
per-task constant. The largest is `edge_count` at 1024 x 1023 ≈ 1.05M — three
orders of magnitude below `INT32_MAX`.

`sizeof` is unchanged for every device-copied struct, so the wire layout does
not move.

## The hazard signing introduces, and how it is closed

Signing the pool offsets makes a negative value *representable* where the
unsigned span tests previously rejected it as a huge one. Signed, those tests go
blind — a negative offset is below `tensor_arg_count`, and subtracting it
**widens** the remaining span, so both comparisons pass:

```c
task.tensor_offset > definition.tensor_arg_count                     // -1 > 2   → false
task.tensor_count  > definition.tensor_arg_count - task.tensor_offset //  1 > 3   → false
```

`bind_graph_topology` therefore rejects a negative offset outright, at the
one-time validator rather than in the per-slice materialize path, and
`graph_layout_definition` does the same for every count and offset it reads —
which is also what makes its remaining-span subtractions provably non-negative.
`GraphDefinitionObject.RejectsNegativeInGraphTaskArgOffset` fails without that
check (verified by reverting the guard: the Definition localizes successfully).

## Two guards tightened, not fixed

Stated plainly because an earlier revision of this description called them
defects, and neither is:

- `graph_execution_localize` gated `task_count` with `== 0`, which reads as if
  `-1` slips through. It does not: `graph_execution_storage_layout` behind it has
  always rejected `task_count <= 0`, and its parameter was already `int32_t`, so
  the out-of-bounds read that gate appears to permit is unreachable. The gate now
  says `<= 0` itself, and `bind_graph_topology` re-checks the range it depends on
  instead of inheriting it. `RejectsNonPositiveInGraphTaskCount` pins the
  contract across both layers.
- `graph_layout_definition` bounded its running totals at `UINT32_MAX` while the
  fields they land in are 32-bit and really cap at 32,768 tensors / 16,384
  scalars. Neither the old bound nor the new `INT32_MAX` one can fire; the new
  one merely agrees with the type it feeds.

Stale comments describing the removed scheduler watermark are dropped from the
two schedulers and `shared_memory.h`.

## Verification

| | |
| ---- | ---- |
| 4 hbg variants (a2a3/a5 × sim/onboard) | build clean, no warnings |
| `ctest -LE requires_hardware` | 127/127 passed (incl. 2 new) |
| **a2a3 onboard** via `task-submit` | hbg 35 passed / 1 skipped, tmr 2 passed |
| `tests/st/a2a3/host_build_graph --platform a2a3sim` | 10 passed, 7 skipped |
| `tests/st/a5/host_build_graph --platform a5sim` | 7 passed |
| pre-commit (clang-format / clang-tidy / cpplint) | passed |

a5 onboard not run — this box is a2a3 silicon (`onboard-arch-precheck a5` exits 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)