### PR TITLE
Refactor: provision the async-DMA workspace inside simpler_init

### DIFF
--- a/docs/comm-domain.md
+++ b/docs/comm-domain.md
@@ -269,9 +269,12 @@ streams sit in the device fault/sync domain, a fault on that Worker slows its
 teardown; keep SDMA workloads on their own Worker (and, in CI, their own task)
 so ordinary workloads are unaffected — see
 [docs/investigations/2026-07-a2a3-sdma-fault-teardown.md](investigations/2026-07-a2a3-sdma-fault-teardown.md)
-and issue #1425. `enable_sdma` is currently honored only by the a2a3 onboard
-`tensormap_and_ringbuffer` runtime; host-build-graph, simulation, a5, and
-provider-disabled builds fail Worker init fast when it is set. A5 provisions
+and issue #1425. `enable_sdma` is honored by **both** a2a3 onboard runtimes: the
+PTO-SDMA provider is compiled into every a2a3 onboard `host_runtime.so`, so the
+gate is the platform, not the runtime. Only `tensormap_and_ringbuffer` is
+exercised with it, so host-build-graph's path from a provisioned address to a
+kernel's `get_dma_workspace` is unverified rather than closed. Simulation, a5,
+and provider-disabled builds fail Worker init fast when it is set. A5 provisions
 its communication-context SDMA workspace by default; this is separate from
 the Worker-level workspace mechanism controlled by `enable_sdma`.
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -189,8 +189,8 @@ self._impl.init(host_path, aicpu_path, aicore_path, dispatcher_path,
 2. Load `libhost_runtime.so` with `RTLD_LOCAL`.
 3. Resolve the runtime's binder from its handle and pass the shared state before
    resolving or calling its regular C API.
-4. Call `simpler_init(...)` to configure CANN, attach the device, and take
-   ownership of executor binaries.
+4. Call `simpler_init(...)` to configure CANN, attach the device, take ownership
+   of executor binaries, and provision the async-DMA workspace.
 5. When the runtime later loads a generated host orchestration SO or sim
    AICore SO, resolve that SO's binder from its own handle and pass the same
    state before invoking its entry point.

--- a/src/common/platform/include/common/dma_workspace.h
+++ b/src/common/platform/include/common/dma_workspace.h
@@ -34,11 +34,15 @@
  * docs/investigations/2026-07-a2a3-sdma-fault-teardown.md. A Worker declines it
  * by leaving `enable_sdma` off, which is the default.
  *
- * Current support matrix: SDMA is available only on a2a3 onboard with the
- * tensormap_and_ringbuffer runtime. URMA is reserved for the future a5
- * per-domain provider. Host-build-graph, simulation, a5, and builds without
- * the a2a3 PTO-SDMA provider reject a request for SDMA during Worker
- * initialization, when the workspace would be provisioned.
+ * Current support matrix: the a2a3 onboard PTO-SDMA provider is compiled into
+ * every a2a3 onboard host_runtime, so both runtimes there provision SDMA on
+ * request — the gate is the platform, not the runtime. Only
+ * tensormap_and_ringbuffer is exercised with it, so host-build-graph's path from
+ * a provisioned address to a kernel's get_dma_workspace is unverified rather
+ * than closed. URMA is reserved for the future a5 per-domain provider.
+ * Simulation, a5, and builds without the a2a3 PTO-SDMA provider reject a request
+ * for SDMA during Worker initialization, when the workspace would be
+ * provisioned.
  */
 
 #ifndef PLATFORM_COMMON_DMA_WORKSPACE_H_

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -391,7 +391,7 @@ int finalize_device(DeviceContextHandle ctx) {
 int simpler_init(
     DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
     const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
-    const CallConfig *prewarm_config
+    const CallConfig *prewarm_config, int enable_sdma, const void *sdma_warmup_binary, uint64_t sdma_warmup_size
 ) {
     if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
 
@@ -430,16 +430,25 @@ int simpler_init(
             std::vector<uint8_t> dispatcher_vec(dispatcher_binary, dispatcher_binary + dispatcher_size);
             runner->set_dispatcher_binary(std::move(dispatcher_vec));
         }
+        // Recorded before the bring-up below, which provisions the workspace and
+        // publishes its addresses in the same one-shot simpler_aicpu_init launch.
+        const uint8_t *warmup_bytes = static_cast<const uint8_t *>(sdma_warmup_binary);
+        std::vector<uint8_t> warmup_vec;
+        if (warmup_bytes != NULL && sdma_warmup_size > 0) {
+            warmup_vec.assign(warmup_bytes, warmup_bytes + sdma_warmup_size);
+        }
+        runner->set_dma_workspace_request(enable_sdma != 0, std::move(warmup_vec));
     } catch (...) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     // Eagerly run the one-shot device setup: create persistent AICPU/AICore
-    // streams, upload the dispatcher + inner SO bundle, and resolve the per-
-    // symbol rtFuncHandle for per-task launch — so the first simpler_register_callable
-    // / simpler_run does not pay any of these costs. Streams live until
-    // finalize_device; the cached rtFuncHandle on LoadAicpuOp and the
-    // preinstall file both live until ~DeviceRunner.
+    // streams, upload the dispatcher + inner SO bundle, resolve the per-symbol
+    // rtFuncHandle for per-task launch, and provision + publish + warm the
+    // async-DMA workspaces — so the first simpler_register_callable / simpler_run
+    // does not pay any of these costs. Streams live until finalize_device; the
+    // cached rtFuncHandle on LoadAicpuOp and the preinstall file both live until
+    // ~DeviceRunner.
     try {
         rc = runner->ensure_device_initialized();
     } catch (...) {
@@ -1145,19 +1154,6 @@ int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info) {
         info->free_bytes = static_cast<uint64_t>(free_bytes);
         info->total_bytes = static_cast<uint64_t>(total_bytes);
         return 0;
-    } catch (...) {
-        return PTO_RUNTIME_ERR_INTERNAL;
-    }
-}
-
-int simpler_provision_dma_workspace(
-    DeviceContextHandle ctx, int enable_sdma, const void *sdma_warmup_binary, uint64_t sdma_warmup_size
-) {
-    if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
-    try {
-        return static_cast<DeviceRunnerBase *>(ctx)->provision_dma_workspace(
-            enable_sdma != 0, sdma_warmup_binary, static_cast<size_t>(sdma_warmup_size)
-        );
     } catch (...) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -549,7 +549,15 @@ int DeviceRunnerBase::ensure_device_initialized() {
     rc = ensure_binaries_loaded();
     if (rc != 0) return rc;
 
-    return ensure_aicpu_init_launched();
+    // Before the AICPU init launch: that launch is what publishes the workspace
+    // addresses, and it happens once.
+    rc = ensure_dma_workspace_provisioned();
+    if (rc != 0) return rc;
+
+    rc = ensure_aicpu_init_launched();
+    if (rc != 0) return rc;
+
+    return ensure_dma_workspace_warmed();
 }
 
 int DeviceRunnerBase::ensure_aicpu_init_launched() {
@@ -563,10 +571,10 @@ int DeviceRunnerBase::ensure_aicpu_init_launched() {
     // Per-device scheduler watchdog override, resolved once at attach into
     // timeout_config_. 0 -> the AICPU scheduler keeps its compile-time default.
     init_args.scheduler_timeout_ms = timeout_config_.scheduler_timeout_ms;
-    // Publish the provisioned async-DMA workspace addresses (all-zero until a
-    // Worker opts into SDMA). provision_dma_workspace() re-launches this entry to
-    // re-latch them; the AICPU SO stays resident, so the latest values survive
-    // every subsequent per-task launch.
+    // Publish the provisioned async-DMA workspace addresses (all-zero unless the
+    // Worker opted into SDMA). ensure_dma_workspace_provisioned() runs first, so
+    // this single launch carries them; the AICPU SO stays resident, and the
+    // values survive every subsequent per-task launch.
     for (int kind = 0; kind < DMA_WORKSPACE_KIND_COUNT; ++kind) {
         init_args.dma_workspace_addr[kind] = dma_workspace_addr_[kind];
     }
@@ -982,16 +990,17 @@ int DeviceRunnerBase::unregister_callable(int32_t callable_id) {
 
 bool DeviceRunnerBase::has_callable(int32_t callable_id) const { return callables_.count(callable_id) != 0; }
 
-int DeviceRunnerBase::provision_dma_workspace(
-    bool enable_sdma, const void *sdma_warmup_binary, size_t sdma_warmup_size
-) {
+int DeviceRunnerBase::ensure_dma_workspace_provisioned() {
+    if (dma_workspace_handle_ != nullptr) {
+        return 0;
+    }
     const uint32_t supported = dma_workspace_supported_mask();
     constexpr uint32_t kSdmaBit = uint32_t{1} << DMA_WORKSPACE_SDMA;
     // Opting in on a device that cannot provide SDMA is a caller error, not a
     // silent no-op: a Worker built for TPREFETCH_ASYNC must not reach its first
     // run reading a zero workspace address.
-    if (enable_sdma && (supported & kSdmaBit) == 0) {
-        LOG_ERROR("provision_dma_workspace: SDMA requested where unsupported (supported=0x%x)", supported);
+    if (sdma_requested_ && (supported & kSdmaBit) == 0) {
+        LOG_ERROR("dma workspace: SDMA requested where unsupported (supported=0x%x)", supported);
         return PTO_RUNTIME_ERR_UNSUPPORTED;
     }
     // Everything this device supports, minus what the caller declined. SDMA is
@@ -1000,7 +1009,10 @@ int DeviceRunnerBase::provision_dma_workspace(
     // post-fault reset budget, so a Worker that did not ask for it must not end
     // up holding them. Every other supported engine carries no such cost and is
     // provisioned unconditionally.
-    const uint32_t required_mask = enable_sdma ? supported : (supported & ~kSdmaBit);
+    const uint32_t required_mask = sdma_requested_ ? supported : (supported & ~kSdmaBit);
+    if (required_mask == 0) {
+        return 0;
+    }
     // Dormant while one engine is supported, since required_mask is a subset of
     // supported. It arms itself on the day dma_workspace_supported_mask() widens,
     // which is the day the single-handle contract breaks — dma_workspace_release()
@@ -1009,14 +1021,10 @@ int DeviceRunnerBase::provision_dma_workspace(
     // that silent type confusion.
     if ((required_mask & (required_mask - 1)) != 0) {
         LOG_ERROR(
-            "provision_dma_workspace: mask=0x%x names %d engines; one handle owns one provider", required_mask,
+            "dma workspace: mask=0x%x names %d engines; one handle owns one provider", required_mask,
             __builtin_popcount(required_mask)
         );
         return PTO_RUNTIME_ERR_UNSUPPORTED;
-    }
-    if (dma_workspace_handle_ != nullptr) {
-        LOG_ERROR("provision_dma_workspace: workspace already provisioned");
-        return PTO_RUNTIME_ERR_INTERNAL;
     }
 
     for (int kind = 0; kind < DMA_WORKSPACE_KIND_COUNT; ++kind)
@@ -1026,41 +1034,34 @@ int DeviceRunnerBase::provision_dma_workspace(
     int rc =
         dma_workspace_provision(required_mask, dma_workspace_addr_, DMA_WORKSPACE_KIND_COUNT, &dma_workspace_handle_);
     if (rc != 0) {
-        LOG_ERROR("provision_dma_workspace: mask=0x%x failed: %d", required_mask, rc);
+        LOG_ERROR("dma workspace: mask=0x%x failed: %d", required_mask, rc);
         for (int kind = 0; kind < DMA_WORKSPACE_KIND_COUNT; ++kind)
             dma_workspace_addr_[kind] = 0;
         dma_workspace_handle_ = nullptr;
         return rc;
     }
+    return 0;
+}
 
-    // Re-latch the resident AICPU globals: simpler_aicpu_init publishes the
-    // provisioned addresses into g_dma_workspace_addr, which the scheduler
-    // prefills into every core's GlobalContext (get_dma_workspace). The AICPU SO
-    // stays dlopen'd, so the values survive every subsequent per-task launch.
-    aicpu_init_launched_ = false;
-    rc = ensure_aicpu_init_launched();
+int DeviceRunnerBase::ensure_dma_workspace_warmed() {
+    if (dma_workspace_handle_ == nullptr || sdma_warmed_) {
+        return 0;
+    }
+    // An unavailable warmup leaves init successful, because the only cost is
+    // first-call latency. A device error does not: the card the warmup just
+    // faulted on would otherwise reach the first run. No dma_workspace_release()
+    // on that path — launch_sdma_warmup_kernel() has marked the runner unusable,
+    // and per-resource release on a faulted card is exactly what finalize()'s
+    // fatal path exists to avoid. The workspace handle stays set so that path
+    // still sees an SDMA generation and applies its handoff delay.
+    const int rc = launch_sdma_warmup_kernel(sdma_warmup_binary_.data(), sdma_warmup_binary_.size());
     if (rc != 0) {
-        LOG_ERROR("provision_dma_workspace: re-latch of simpler_aicpu_init failed: %d", rc);
-        dma_workspace_release(dma_workspace_handle_);
-        dma_workspace_handle_ = nullptr;
-        for (int kind = 0; kind < DMA_WORKSPACE_KIND_COUNT; ++kind)
-            dma_workspace_addr_[kind] = 0;
+        LOG_ERROR("dma workspace: sdma warmup left the device unusable: %d", rc);
         return rc;
     }
-
-    // Deliberately after the re-latch: warming needs the live workspace. An
-    // unavailable warmup leaves provisioning successful, because the only cost is
-    // first-call latency. A device error does not: the card the warmup just faulted
-    // on would otherwise reach the first run. No dma_workspace_release() on that
-    // path — launch_sdma_warmup_kernel() has marked the runner unusable, and
-    // per-resource release on a faulted card is exactly what finalize()'s fatal
-    // path exists to avoid. The workspace handle stays set so that path still sees
-    // an SDMA generation and applies its handoff delay.
-    rc = launch_sdma_warmup_kernel(sdma_warmup_binary, sdma_warmup_size);
-    if (rc != 0) {
-        LOG_ERROR("provision_dma_workspace: sdma warmup left the device unusable: %d", rc);
-        return rc;
-    }
+    sdma_warmed_ = true;
+    sdma_warmup_binary_.clear();
+    sdma_warmup_binary_.shrink_to_fit();
     return 0;
 }
 
@@ -1460,6 +1461,7 @@ int DeviceRunnerBase::finalize_common_impl(bool abandon_device_resources) {
     // the SDMA warmup ELF's separate handle.
     aicore_bin_handle_ = nullptr;
     sdma_warmup_bin_handle_ = nullptr;
+    sdma_warmed_ = false;
     binaries_loaded_ = false;
     // The inner AICPU SO is unloaded with the binaries above, so its latched
     // globals are gone too — clear the one-shot guard so a reused runner

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -234,10 +234,17 @@ public:
      *      by the subclass `finalize()`).
      *   3. Bootstrap the dispatcher + register the inner AICPU SO via
      *      `ensure_binaries_loaded()`.
+     *   4. Provision the requested async-DMA workspaces via
+     *      `ensure_dma_workspace_provisioned()`.
+     *   5. Launch `simpler_aicpu_init` via `ensure_aicpu_init_launched()`,
+     *      which publishes step 4's addresses along with the other resident
+     *      invariants. Step 4 precedes it so that publication is one launch.
+     *   6. Warm the SDMA control path via `ensure_dma_workspace_warmed()`,
+     *      which needs both the live workspace and the AICore stream.
      *
-     * Called from `simpler_init` after executor + dispatcher bytes have
-     * been cached on the runner. Idempotent: subsequent calls
-     * short-circuit on `binaries_loaded_`.
+     * Called from `simpler_init` after executor + dispatcher bytes and the
+     * async-DMA request have been cached on the runner. Idempotent: each step
+     * short-circuits on its own guard.
      *
      * @return 0 on success, error code on failure.
      */
@@ -273,6 +280,27 @@ public:
      */
     void set_dispatcher_binary(std::vector<uint8_t> dispatcher_so_binary) {
         dispatcher_so_binary_ = std::move(dispatcher_so_binary);
+    }
+
+    /**
+     * Record this Worker's async-DMA request. Called by simpler_init before its
+     * `ensure_device_initialized()`, which is where the request is acted on —
+     * the workspace has to exist before the one-shot `simpler_aicpu_init` launch
+     * that publishes its addresses.
+     *
+     * `enable_sdma` opts into the SDMA workspace; every other engine
+     * `dma_workspace_supported_mask()` names is provisioned regardless. SDMA is
+     * declinable because its workspace cannot be obtained without also creating
+     * 48 CP-process STARS streams, which halves this Worker's post-fault reset
+     * budget. Opting in where SDMA is unsupported fails device init.
+     *
+     * `sdma_warmup_binary` is the vector-only ELF that walks the SDMA control
+     * path once per channel once the workspace is live. An empty buffer only
+     * costs first-call latency.
+     */
+    void set_dma_workspace_request(bool enable_sdma, std::vector<uint8_t> sdma_warmup_binary) {
+        sdma_requested_ = enable_sdma;
+        sdma_warmup_binary_ = std::move(sdma_warmup_binary);
     }
 
     /** The device id captured by simpler_init's `attach_current_thread` call. */
@@ -394,27 +422,6 @@ public:
      * calls without a matching `simpler_register_callable`.
      */
     bool has_callable(int32_t callable_id) const;
-
-    /**
-     * Provision this device's async-DMA workspaces once at Worker init and latch
-     * their device addresses into the resident KernelArgs so every subsequent run
-     * carries them (AICPU injects them into GlobalContext via get_dma_workspace).
-     * Provisions every engine dma_workspace_supported_mask() names, except SDMA
-     * unless `enable_sdma` is set — SDMA is declinable because its workspace
-     * cannot be obtained without also creating 48 CP-process STARS streams, which
-     * halves this Worker's post-fault reset budget. `enable_sdma` on a
-     * platform/runtime without SDMA is rejected, so such a Worker fails fast. The
-     * provider handle is released by finalize_common().
-     *
-     * `sdma_warmup_binary` / `sdma_warmup_size`, when non-empty, are handed to
-     * launch_sdma_warmup_kernel() once the workspace is live. An absent or
-     * unrunnable warmup does NOT fail provisioning; a warmup whose device launch or
-     * sync fails does, and leaves the runner marked unusable.
-     *
-     * @return 0 on success, negative on unsupported/failed provisioning.
-     */
-    int
-    provision_dma_workspace(bool enable_sdma, const void *sdma_warmup_binary = nullptr, size_t sdma_warmup_size = 0);
 
     /**
      * Content-derived stable identity for a registered callable: the
@@ -684,8 +691,9 @@ public:
 
     /**
      * Walk the SDMA control path once per channel, so the first TPREFETCH_ASYNC
-     * of a run does not pay it. Called from provision_dma_workspace() once the
-     * workspace is live, on `stream_aicore_`, and synchronized before returning.
+     * of a run does not pay it. Called from ensure_dma_workspace_warmed() once
+     * the workspace is live, on `stream_aicore_`, and synchronized before
+     * returning.
      *
      * `binary` is a vector-only ELF, registered separately from the executor
      * (`RT_DEV_BINARY_MAGIC_ELF_AIVEC`, its own handle) because the executor is a
@@ -809,13 +817,37 @@ protected:
 
     /**
      * Initial launch of `simpler_aicpu_init`, latching the invariants (orch
-     * device id, log config) into the resident AICPU SO globals. Idempotent via
-     * `aicpu_init_launched_`; called from
-     * `ensure_device_initialized()` after the binaries are loaded.
+     * device id, log config, provisioned async-DMA workspace addresses) into the
+     * resident AICPU SO globals. Idempotent via `aicpu_init_launched_`; called
+     * from `ensure_device_initialized()` after the binaries are loaded and the
+     * workspaces are provisioned, so one launch publishes everything.
      *
      * @return 0 on success, error code on failure.
      */
     int ensure_aicpu_init_launched();
+
+    /**
+     * Provision the async-DMA workspaces this Worker asked for (see
+     * `set_dma_workspace_request`) and record their device addresses in
+     * `dma_workspace_addr_`, ready for `ensure_aicpu_init_launched()` to
+     * publish. Idempotent: a runner that already holds a provider handle, and
+     * one whose request declined the only declinable engine on a device that
+     * supports nothing else, both no-op. The handle is released by
+     * `finalize_common()`, including on a later step's failure.
+     *
+     * @return 0 on success, negative on unsupported/failed provisioning.
+     */
+    int ensure_dma_workspace_provisioned();
+
+    /**
+     * Walk the SDMA control path once, after `ensure_aicpu_init_launched()` has
+     * published the workspace addresses. No-op without a provisioned workspace.
+     * One-shot via `sdma_warmed_`, which also releases the warmup ELF bytes.
+     *
+     * @return 0 on success or a skipped warmup, error code when the warmup
+     *         faulted the card.
+     */
+    int ensure_dma_workspace_warmed();
 
     /**
      * Query the maximum block_dim the stream can host.
@@ -1054,8 +1086,14 @@ protected:
     // DmaWorkspaceKind. Published into InitArgs by ensure_aicpu_init_launched()
     // so the resident AICPU SO latches them into g_dma_workspace_addr; the
     // scheduler prefills each core's GlobalContext from there. All-zero until a
-    // Worker opts into SDMA via provision_dma_workspace().
+    // Worker opts into SDMA via set_dma_workspace_request().
     uint64_t dma_workspace_addr_[DMA_WORKSPACE_KIND_COUNT]{};
+    // This Worker's async-DMA request, recorded by set_dma_workspace_request()
+    // before device bring-up. `sdma_warmup_binary_` is released once
+    // ensure_dma_workspace_warmed() has consumed it.
+    bool sdma_requested_{false};
+    bool sdma_warmed_{false};
+    std::vector<uint8_t> sdma_warmup_binary_;
     std::unordered_set<int32_t> aicpu_seen_callable_ids_;
     // Monotonic count of successful AICPU dlopens (incremented after prewarm
     // or first-run fallback succeeds; never decremented). Diverges from

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -377,7 +377,7 @@ int finalize_device(DeviceContextHandle ctx) {
 int simpler_init(
     DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
     const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
-    const CallConfig *prewarm_config
+    const CallConfig *prewarm_config, int enable_sdma, const void *sdma_warmup_binary, uint64_t sdma_warmup_size
 ) {
     // Sim has no AICPU dispatcher (the simulator runs AICPU in-process). Accept
     // the parameters for ABI parity with the onboard implementation and ignore
@@ -385,8 +385,15 @@ int simpler_init(
     // and the dispatcher / preinstall load path on sim isn't taken anyway.
     (void)dispatcher_binary;
     (void)dispatcher_size;
+    // Simulation provides no async-DMA workspaces, so there is nothing for a
+    // warmup ELF to warm either.
+    (void)sdma_warmup_binary;
+    (void)sdma_warmup_size;
 
     if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
+    // Opting into SDMA fails here rather than at the first kernel read, so such
+    // a Worker cannot come up on sim at all.
+    if (enable_sdma != 0) return PTO_RUNTIME_ERR_UNSUPPORTED;
 
     SimDeviceRunnerBase *runner = static_cast<SimDeviceRunnerBase *>(ctx);
 
@@ -953,18 +960,6 @@ size_t committed_device_memory_ctx(DeviceContextHandle ctx) {
 int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info) {
     if (ctx == NULL || info == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     return PTO_RUNTIME_ERR_UNSUPPORTED;
-}
-
-int simpler_provision_dma_workspace(
-    DeviceContextHandle ctx, int enable_sdma, const void *sdma_warmup_binary, uint64_t sdma_warmup_size
-) {
-    // Simulation provides no async-DMA workspaces; opting into SDMA fails fast
-    // so such a Worker cannot come up on sim. With no workspace there is
-    // likewise nothing for the warmup ELF to warm.
-    (void)ctx;
-    (void)sdma_warmup_binary;
-    (void)sdma_warmup_size;
-    return enable_sdma == 0 ? 0 : PTO_RUNTIME_ERR_UNSUPPORTED;
 }
 
 }  // extern "C"

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -231,8 +231,6 @@ void ChipWorker::init(
         get_host_dlopen_count_fn_ = load_symbol<GetAicpuDlopenCountFn>(handle, "get_host_dlopen_count");
         get_run_stream_set_create_count_fn_ =
             load_symbol<GetAicpuDlopenCountFn>(handle, "get_run_stream_set_create_count");
-        simpler_provision_dma_workspace_fn_ =
-            load_symbol<SimplerProvisionDmaWorkspaceFn>(handle, "simpler_provision_dma_workspace");
         finalize_device_fn_ = load_symbol<FinalizeDeviceFn>(handle, "finalize_device");
         // ACL lifecycle + comm_* are part of the uniform host_runtime.so ABI.
         // Every platform runtime exports all of them — runtimes that do not
@@ -297,10 +295,11 @@ void ChipWorker::init(
 
     // One-shot platform-side init: attach the calling thread to `device_id`
     // (rtSetDevice on onboard, sim bind+acquire on sim), transfer ownership
-    // of the executor binaries to the DeviceRunner, and (onboard) sync CANN
-    // dlog from HostLogger. Subsequent device-ops re-attach their caller
-    // threads idempotently against the recorded device id; subsequent
-    // register_callable / run invocations reuse the cached binaries.
+    // of the executor binaries to the DeviceRunner, provision this Worker's
+    // async-DMA workspaces, and (onboard) sync CANN dlog from HostLogger.
+    // Subsequent device-ops re-attach their caller threads idempotently against
+    // the recorded device id; subsequent register_callable / run invocations
+    // reuse the cached binaries.
     //
     // read_binary_file may throw — defer the dlsym/dlclose rollback to the
     // catch block so the buffers and any partially-resolved handle are torn
@@ -319,12 +318,24 @@ void ChipWorker::init(
             dispatcher_bytes = read_binary_file(dispatcher_path);
         }
         const uint8_t *dispatcher_ptr = dispatcher_bytes.empty() ? nullptr : dispatcher_bytes.data();
+        // The warmup ELF rides simpler_init because it warms the workspace that
+        // init provisions. Absent on arches that build no such ELF and on tests
+        // driving _ChipWorker.init directly; the platform then skips the warmup
+        // and the first TPREFETCH_ASYNC pays the cold control path instead. Read
+        // only when the Worker opted in, so a stale path on a non-SDMA Worker is
+        // never touched.
+        std::vector<uint8_t> warmup_bytes;
+        if (enable_sdma && !sdma_warmup_path.empty()) {
+            warmup_bytes = read_binary_file(sdma_warmup_path);
+        }
+        const uint8_t *warmup_ptr = warmup_bytes.empty() ? nullptr : warmup_bytes.data();
         // `prewarm_config` (fork-constant, COW-delivered) rides simpler_init: the
         // platform builds + caches the prebuilt runtime-arena for its ring sizing
         // right after the device comes up. Null => no prewarm.
         init_rc = simpler_init_fn_(
             device_ctx_, device_id, aicpu_bytes.data(), aicpu_bytes.size(), aicore_bytes.data(), aicore_bytes.size(),
-            dispatcher_ptr, dispatcher_bytes.size(), prewarm_config
+            dispatcher_ptr, dispatcher_bytes.size(), prewarm_config, enable_sdma ? 1 : 0, warmup_ptr,
+            warmup_bytes.size()
         );
     } catch (...) {
         destroy_device_context_fn_(device_ctx_);
@@ -354,7 +365,6 @@ void ChipWorker::init(
         get_aicpu_dlopen_count_fn_ = nullptr;
         get_host_dlopen_count_fn_ = nullptr;
         get_run_stream_set_create_count_fn_ = nullptr;
-        simpler_provision_dma_workspace_fn_ = nullptr;
         finalize_device_fn_ = nullptr;
         ensure_acl_ready_fn_ = nullptr;
         create_comm_stream_fn_ = nullptr;
@@ -376,9 +386,16 @@ void ChipWorker::init(
     if (init_rc != 0) {
         // Symmetric teardown: drop the device context, clear all dlsym'd
         // function pointers, dlclose, and discard cached binaries so the
-        // ChipWorker is back to its zero-initialized state. Mirror finalize()
-        // exactly minus finalize_device_fn_ (we never reached the
-        // initialized_=true point, so device-side teardown is unnecessary).
+        // ChipWorker is back to its zero-initialized state.
+        //
+        // No finalize_device_fn_ call, even though simpler_init does real device
+        // work and may fail after it: destroy_device_context deletes the runner,
+        // and its destructor runs the platform's finalize() — including the
+        // fatal path that reclaims a card an SDMA warmup faulted. Calling
+        // finalize_device explicitly here would be worse than redundant on sim,
+        // where it releases whichever device *this thread* is bound to; a Worker
+        // that failed before attaching would tear down a sibling Worker's live
+        // sim context.
         destroy_device_context_fn_(device_ctx_);
         device_ctx_ = nullptr;
         create_device_context_fn_ = nullptr;
@@ -406,7 +423,6 @@ void ChipWorker::init(
         get_aicpu_dlopen_count_fn_ = nullptr;
         get_host_dlopen_count_fn_ = nullptr;
         get_run_stream_set_create_count_fn_ = nullptr;
-        simpler_provision_dma_workspace_fn_ = nullptr;
         finalize_device_fn_ = nullptr;
         ensure_acl_ready_fn_ = nullptr;
         create_comm_stream_fn_ = nullptr;
@@ -435,37 +451,6 @@ void ChipWorker::init(
     pipeline_contract_ = resolved_contract;
     initialized_ = true;
 
-    // Provision async-DMA workspaces (SDMA) once, now that the device is up. The
-    // addresses are latched into the resident KernelArgs so every run carries
-    // them. On failure, roll the whole Worker back through finalize() so no
-    // half-provisioned state leaks, then surface the error.
-    if (enable_sdma) {
-        // The warmup ELF rides provisioning because it needs the workspace it
-        // warms. Absent on arches that build no such ELF and on tests driving
-        // _ChipWorker.init directly; the platform then skips the warmup and the
-        // first TPREFETCH_ASYNC pays the cold control path instead.
-        std::vector<uint8_t> warmup_bytes;
-        if (!sdma_warmup_path.empty()) {
-            // initialized_ is already published above, so an escape from here must
-            // roll the Worker back exactly like the provisioning failure below;
-            // otherwise init() reports failure with the device context and host
-            // library still live.
-            try {
-                warmup_bytes = read_binary_file(sdma_warmup_path);
-            } catch (...) {
-                finalize();
-                throw;
-            }
-        }
-        const uint8_t *warmup_ptr = warmup_bytes.empty() ? nullptr : warmup_bytes.data();
-        int prov_rc = simpler_provision_dma_workspace_fn_(device_ctx_, 1, warmup_ptr, warmup_bytes.size());
-        if (prov_rc != 0) {
-            finalize();
-            throw std::runtime_error(
-                "async-DMA (SDMA) workspace provisioning failed with code " + std::to_string(prov_rc)
-            );
-        }
-    }
     run_lane_ = std::make_unique<ChipRunLane>(*this);
 }
 
@@ -528,7 +513,6 @@ void ChipWorker::finalize() {
     get_aicpu_dlopen_count_fn_ = nullptr;
     get_host_dlopen_count_fn_ = nullptr;
     get_run_stream_set_create_count_fn_ = nullptr;
-    simpler_provision_dma_workspace_fn_ = nullptr;
     finalize_device_fn_ = nullptr;
     ensure_acl_ready_fn_ = nullptr;
     create_comm_stream_fn_ = nullptr;

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -79,12 +79,14 @@ public:
     /// only one a caller can decline — every other supported engine is
     /// provisioned unconditionally, and SDMA is conditional only because its
     /// workspace is inseparable from 48 CP-process STARS streams whose
-    /// post-fault release CANN does not bound. Provisioning fails fast (init
-    /// throws) on a platform/runtime without SDMA support.
+    /// post-fault release CANN does not bound. Provisioning rides simpler_init,
+    /// so a platform/runtime without SDMA support fails init (this throws) and
+    /// no Worker reaches a run with a zero address it expected to be live.
     /// `sdma_warmup_path`, when non-empty, is the vector-only ELF that walks the
-    /// SDMA control path once per channel during that provisioning, moving the
-    /// cold-start cost off the first TPREFETCH_ASYNC. Optional: an empty path (or
-    /// an arch that builds no such ELF) only costs that first-call latency.
+    /// SDMA control path once per channel once that workspace is live, moving
+    /// the cold-start cost off the first TPREFETCH_ASYNC. Read only when
+    /// `enable_sdma` is set; an empty path (or an arch that builds no such ELF)
+    /// only costs that first-call latency.
     void init(
         const std::string &host_lib_path, const std::string &aicpu_path, const std::string &aicore_path,
         const std::string &dispatcher_path, int device_id, const CallConfig *prewarm_config = nullptr,
@@ -263,7 +265,8 @@ private:
     using GetDeviceMemoryInfoFn = decltype(&device_memory_info_ctx);
     // From host_runtime.so. Single platform-side init that does (a) thread
     // attach + device-id record, (b) executor binary takeover, (c) onboard
-    // CANN dlog sync. Reads the current log level off HostLogger itself.
+    // CANN dlog sync, (d) async-DMA workspace provisioning. Reads the current
+    // log level off HostLogger itself.
     using SimplerInitFn = decltype(&simpler_init);
     using SimplerRegisterCallableFn = int (*)(void *, int32_t, const void *);
     using SimplerRunFn = decltype(&simpler_run);
@@ -275,7 +278,6 @@ private:
     using GetPipelineContractFn = const PipelineContract *(*)();
     using SimplerUnregisterCallableFn = int (*)(void *, int32_t);
     using GetAicpuDlopenCountFn = size_t (*)(void *);
-    using SimplerProvisionDmaWorkspaceFn = int (*)(void *, int, const void *, uint64_t);
     using FinalizeDeviceFn = int (*)(void *);
     using EnsureAclReadyFn = int (*)(void *, int);
     using CreateCommStreamFn = void *(*)(void *);
@@ -338,7 +340,6 @@ private:
     GetAicpuDlopenCountFn get_aicpu_dlopen_count_fn_ = nullptr;
     GetAicpuDlopenCountFn get_host_dlopen_count_fn_ = nullptr;
     GetAicpuDlopenCountFn get_run_stream_set_create_count_fn_ = nullptr;
-    SimplerProvisionDmaWorkspaceFn simpler_provision_dma_workspace_fn_ = nullptr;
     FinalizeDeviceFn finalize_device_fn_ = nullptr;
     EnsureAclReadyFn ensure_acl_ready_fn_ = nullptr;
     CreateCommStreamFn create_comm_stream_fn_ = nullptr;

--- a/src/common/worker/runtime_c_api.h
+++ b/src/common/worker/runtime_c_api.h
@@ -29,8 +29,7 @@
  *                   simpler_finalize_run, simpler_run,
  *                   simpler_unregister_callable,
  *                   get_aicpu_dlopen_count, get_host_dlopen_count,
- *                   get_run_stream_set_create_count,
- *                   simpler_provision_dma_workspace
+ *                   get_run_stream_set_create_count
  *   - pipeline:     get_pipeline_contract,
  *                   supports_concurrent_native_prepare_ctx,
  *                   get_arena_bank_gm_heap_base_ctx,
@@ -289,19 +288,48 @@ int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *de
  *      simpler_run invocations reuse this resident pair — no binary bytes
  *      cross the C ABI on per-run paths.
  *
- *   4. When `prewarm_config` is non-null, build + upload + cache the prebuilt
+ *   4. Provision this device's async-DMA workspaces and latch their device
+ *      addresses into the resident AICPU globals, so every subsequent run
+ *      carries them (the scheduler prefills each core's GlobalContext from
+ *      there, and kernels read them through get_dma_workspace(args, kind); a
+ *      kind this device did not provision reads back 0). The addresses are
+ *      published by the same one-shot AICPU init launch that step 2's device
+ *      bring-up performs, so provisioning is ordered before it rather than
+ *      re-latching afterwards.
+ *
+ *      Every engine the platform supports is provisioned except SDMA, which is
+ *      provisioned only when `enable_sdma` is non-zero. SDMA is the one engine
+ *      a caller can decline, and the parameter is a flag rather than an engine
+ *      set for that reason: its workspace cannot be obtained without also
+ *      creating 48 CP-process STARS streams, and a Worker holding those gets a
+ *      single device-reset attempt after an AICore fault instead of three, so
+ *      defaulting it on would put every Worker in that population.
+ *      `enable_sdma` on a platform/runtime without SDMA support fails init, so
+ *      a Worker opting in on sim / a5 / hbg fails fast rather than reaching its
+ *      first run reading a zero workspace address.
+ *
+ *      `sdma_warmup_binary` / `sdma_warmup_size` carry the vector-only ELF that
+ *      walks the SDMA control path once per channel against the workspace just
+ *      provisioned, so the first TPREFETCH_ASYNC does not pay that cold start.
+ *      A null/empty buffer, or a warmup the platform cannot run, still
+ *      initializes successfully — the only cost is first-call latency. A warmup
+ *      whose device launch or sync fails does fail init, because that card is
+ *      then poisoned.
+ *
+ *   5. When `prewarm_config` is non-null, build + upload + cache the prebuilt
  *      runtime-arena for its `runtime_env` ring sizing (tensormap_and_ringbuffer;
  *      a no-op for runtimes without a prebuilt arena). The device is up by this
  *      point, so the first simpler_run with matching sizing skips the (~800ms)
  *      cold build. The sizing is fork-constant, so it rides init rather than a
  *      separate call. Only `prewarm_config->runtime_env` is read.
  *
- * Returns 0 on success, negative on attach or prewarm-build failure.
+ * Returns 0 on success, negative on attach, provisioning, or prewarm-build
+ * failure.
  */
 int simpler_init(
     DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
     const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
-    const CallConfig *prewarm_config
+    const CallConfig *prewarm_config, int enable_sdma, const void *sdma_warmup_binary, uint64_t sdma_warmup_size
 );
 
 /**
@@ -494,35 +522,6 @@ size_t get_host_dlopen_count(DeviceContextHandle ctx);
  * bootstrap pair.
  */
 size_t get_run_stream_set_create_count(DeviceContextHandle ctx);
-
-/**
- * Provision this device's async-DMA workspaces once at Worker init, latching
- * their device addresses into the resident KernelArgs so every subsequent run
- * carries them. Every engine the platform supports is provisioned except SDMA,
- * which is provisioned only when `enable_sdma` is non-zero.
- *
- * SDMA is the one engine a caller can decline, and the parameter is a flag
- * rather than an engine set for that reason. Its workspace cannot be obtained
- * without also creating 48 CP-process STARS streams, and a Worker holding those
- * gets a single device-reset attempt after an AICore fault instead of three, so
- * defaulting it on would put every Worker in that population. Selecting among
- * provisioned engines is the kernel's job, through get_dma_workspace(args,
- * kind); a kind this device did not provision reads back 0.
- *
- * `enable_sdma` on a platform/runtime without SDMA support is rejected, so a
- * Worker opting in on sim / a5 / hbg fails fast. Returns 0 on success, negative
- * on unsupported/failed provisioning.
- *
- * `sdma_warmup_binary` / `sdma_warmup_size` carry the vector-only ELF that walks
- * the SDMA control path once per channel against the workspace just provisioned,
- * so the first TPREFETCH_ASYNC does not pay that cold start. A null/empty buffer,
- * or a warmup the platform cannot run, skips it and still provisions
- * successfully — the only cost is first-call latency. A warmup whose device launch
- * or sync fails does fail provisioning, because that card is then poisoned.
- */
-int simpler_provision_dma_workspace(
-    DeviceContextHandle ctx, int enable_sdma, const void *sdma_warmup_binary, uint64_t sdma_warmup_size
-);
 
 #ifdef __cplusplus
 }

--- a/tests/ut/py/test_worker/test_dma_workspace_sim.py
+++ b/tests/ut/py/test_worker/test_dma_workspace_sim.py
@@ -1,0 +1,59 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ruff: noqa: PLC0415
+"""Sim-backend test for the async-DMA workspace request carried by ``simpler_init``.
+
+Simulation provides no async-DMA engine, so ``enable_sdma=True`` has no workspace
+to hand a kernel. The contract is that such a Worker fails to come up rather than
+reaching its first run reading a zero address it expected to be live — the
+rejection is the only thing standing between an unsupported request and a silent
+wrong answer, and it is easy to lose to a refactor that derives the provisioned
+set from what the platform supports (an empty set looks like success).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _make_sim_worker(*, enable_sdma: bool):
+    from simpler.worker import Worker
+
+    from simpler_setup.runtime_builder import RuntimeBuilder
+
+    try:
+        RuntimeBuilder(platform="a2a3sim").get_binaries("tensormap_and_ringbuffer")
+    except FileNotFoundError as e:
+        pytest.skip(f"a2a3sim runtime binaries unavailable: {e}")
+    return Worker(
+        level=2,
+        device_id=0,
+        platform="a2a3sim",
+        runtime="tensormap_and_ringbuffer",
+        enable_sdma=enable_sdma,
+    )
+
+
+class TestSimRejectsSdma:
+    def test_enable_sdma_fails_init(self):
+        worker = _make_sim_worker(enable_sdma=True)
+        # -1001 is PTO_RUNTIME_ERR_UNSUPPORTED. Pinning the code, not just "some
+        # exception", is what distinguishes a rejected request from sim failing
+        # to start for an unrelated reason.
+        with pytest.raises(RuntimeError, match=r"simpler_init failed with code -1001"):
+            worker.init()
+        worker.close()
+
+    def test_without_sdma_init_succeeds(self):
+        # Positive control: the same Worker comes up when it does not ask for an
+        # engine sim has no provider for, so the failure above is attributable to
+        # the request rather than to sim being unable to start at all.
+        worker = _make_sim_worker(enable_sdma=False)
+        worker.init()
+        worker.close()


### PR DESCRIPTION
## Summary

The async-DMA workspace addresses reach a kernel through the resident AICPU
globals that `simpler_aicpu_init` latches. Provisioning ran *after* device
bring-up had already launched that entry, so it cleared `aicpu_init_launched_`
and launched it a second time to republish — a re-run that works only because
the entry happens to be idempotent, and that left a one-shot guard two call
sites reset for different reasons.

Ordering provisioning **before** the launch makes it publish on the first one.
`ensure_device_initialized()` now runs the whole bring-up in sequence — streams,
binaries, provision, AICPU init, SDMA warmup — each step behind its own guard,
with the request recorded on the runner beforehand exactly like the executor and
dispatcher bytes already are.

That leaves nothing for a separate entry point to do:

- `simpler_provision_dma_workspace` is **deleted** — one fewer exported symbol
  (verified absent from all 8 `libhost_runtime.so`), one fewer `dlsym` and one
  fewer function-pointer member in `ChipWorker`.
- `simpler_init` takes `enable_sdma` + the warmup ELF instead.
- No provisioning failure arrives after `initialized_` is published, so the
  bespoke `finalize()` rollback in `ChipWorker::init` is gone; `simpler_init`'s
  own rollback covers it.
- Simulation rejects the request in `simpler_init` directly rather than deriving
  an empty set from a provider it does not have.

The public Python surface is unchanged: `Worker(..., enable_sdma=True)` and
`ChipWorker::init` keep their signatures.

## Measured

Same test, same box, `prefetch_async_demo` on a2a3 onboard, counting
`launch_aicpu_payload simpler_aicpu_init` in the host log:

| | `simpler_aicpu_init` launches |
| --- | --- |
| `upstream/main` @ 55b7e0fe3 | **2** |
| this branch | **1** |

Warmup still reports `48/48 channels warmed`, i.e. the single launch does carry
the addresses.

## Doc corrections

Two claims that predate this change, measured while establishing where
provisioning may run:

- `enable_sdma` was documented as honored only by `tensormap_and_ringbuffer`,
  with host-build-graph rejecting it (`dma_workspace.h`, `docs/comm-domain.md`;
  the wording dates to #1406). The PTO-SDMA provider is compiled into every a2a3
  onboard `host_runtime.so`, so the gate is the platform, not the runtime — a
  `host_build_graph` Worker with `enable_sdma=True` initializes successfully
  (verified onboard). Only `tensormap_and_ringbuffer` is exercised with it, so
  host-build-graph's path from the address to `get_dma_workspace` is
  **unverified rather than closed**; the docs now say that.
  `docs/capability-survey.md` already said "the provider is always compiled" and
  needed no change.
- `docs/logging.md` enumerated what `simpler_init` does and no longer covered
  provisioning.

## Testing

All run locally on this box; onboard work through `task-submit`.

- **cpput** — 128/128 pass (default build type, per `_ut-no-hardware.yml`).
- **pyut** — 2096 passed, 18 skipped.
- **st a2a3sim** — 33 cases, 0 failures.
- **st a5sim** — 29 cases, 0 failures.
- **st a2a3 onboard** (`--manual exclude`) — 67 cases, 0 failures. Includes the
  non-SDMA `aicore_op_timeout` fault-injection arm.
- **st a2a3 onboard `-m sdma`** — 2/2 pass, including
  `test_sdma_worker_aicore_fault_teardown_is_bounded` (19.1 s, limit 30 s), the
  case that exercises fatal teardown with 48 CP-process STARS streams live.
- **New**: `tests/ut/py/test_worker/test_dma_workspace_sim.py` pins the sim
  rejection to `PTO_RUNTIME_ERR_UNSUPPORTED` at init, with a positive control
  that the same Worker comes up without the request. Without it, a future
  refactor that derives the provisioned set from the supported set would degrade
  an unsupported request to a silent empty-set success.
- Linters: clang-format, clang-tidy, ruff, pyright, markdownlint,
  `check_retired_names`, `check_headers`, `check_english_only` — all clean.

Relates to #1425 (the `enable_sdma` quarantine this keeps intact), and follows
#2088 / #2089 on the same surface.
