### PR TITLE
Refactor: bind the DFX collectors' per-run output separately

### DIFF
--- a/src/a2a3/platform/include/host/pmu_collector.h
+++ b/src/a2a3/platform/include/host/pmu_collector.h
@@ -216,10 +216,20 @@ public:
      * @param device_id                    Device ID (for register_cb)
      * @return 0 on success, non-zero on failure
      */
+    // Allocates the device-side resources.
+    //
+    // Per-run configuration (CSV destination, event selection) is bound
+    // separately by set_run_output(), which must be called before init() so the
+    // event type reaches the device header and the CSV header string.
     int init(
-        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type,
-        const PmuAllocCallback &alloc_cb, PmuRegisterCallback register_cb, const PmuFreeCallback &free_cb, int device_id
+        int num_cores, int num_threads, const PmuAllocCallback &alloc_cb, PmuRegisterCallback register_cb,
+        const PmuFreeCallback &free_cb, int device_id
     );
+
+    void set_run_output(const std::string &csv_path, PmuEventType event_type) {
+        csv_path_ = csv_path;
+        event_type_ = event_type;
+    }
 
     void start(const profiling_common::ThreadFactory &thread_factory);
 

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -1151,9 +1151,9 @@ int DeviceRunner::init_chip_swimlane(
         return mem_alloc_.free(dev_ptr);
     };
 
-    int rc = chip_swimlane_collector_.initialize(
-        num_aicore, aicpu_thread_num, device_id, chip_swimlane_level_, alloc_cb, register_cb, free_cb, output_prefix_
-    );
+    chip_swimlane_collector_.set_run_output(output_prefix_, chip_swimlane_level_);
+    int rc =
+        chip_swimlane_collector_.initialize(num_aicore, aicpu_thread_num, device_id, alloc_cb, register_cb, free_cb);
     if (rc != 0) {
         return rc;
     }
@@ -1189,9 +1189,8 @@ int DeviceRunner::init_args_dump(Runtime &runtime, int device_id, KernelArgsHelp
         return mem_alloc_.free(dev_ptr);
     };
 
-    int rc = dump_collector_.initialize(
-        num_dump_threads, device_id, alloc_cb, register_cb, free_cb, output_prefix_, dump_args_level_
-    );
+    dump_collector_.set_run_output(output_prefix_, dump_args_level_);
+    int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, register_cb, free_cb);
     if (rc != 0) {
         return rc;
     }
@@ -1225,8 +1224,8 @@ int DeviceRunner::init_pmu(
         return mem_alloc_.free(dev_ptr);
     };
 
-    int rc =
-        pmu_collector_.init(num_cores, num_threads, csv_path, event_type, alloc_cb, register_cb, free_cb, device_id);
+    pmu_collector_.set_run_output(csv_path, event_type);
+    int rc = pmu_collector_.init(num_cores, num_threads, alloc_cb, register_cb, free_cb, device_id);
     if (rc != 0) {
         return rc;
     }

--- a/src/a2a3/platform/shared/host/pmu_collector.cpp
+++ b/src/a2a3/platform/shared/host/pmu_collector.cpp
@@ -69,8 +69,8 @@ PmuCollector::~PmuCollector() { stop(); }
 // ---------------------------------------------------------------------------
 
 int PmuCollector::init(
-    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type,
-    const PmuAllocCallback &alloc_cb, PmuRegisterCallback register_cb, const PmuFreeCallback &free_cb, int device_id
+    int num_cores, int num_threads, const PmuAllocCallback &alloc_cb, PmuRegisterCallback register_cb,
+    const PmuFreeCallback &free_cb, int device_id
 ) {
     if (num_cores <= 0 || num_threads <= 0 || alloc_cb == nullptr || free_cb == nullptr) {
         LOG_ERROR("PmuCollector::init: invalid arguments");
@@ -90,8 +90,6 @@ int PmuCollector::init(
 
     num_cores_ = num_cores;
     num_threads_ = num_threads;
-    event_type_ = event_type;
-    csv_path_ = csv_path;
     buffers_registered_ = (register_cb != nullptr);
 
     reset_collector_shards();
@@ -131,7 +129,7 @@ int PmuCollector::init(
     std::memset(shm_host_, 0, shm_size_);
 
     PmuDataHeader *hdr = get_pmu_header(shm_host_);
-    hdr->event_type = static_cast<uint32_t>(event_type);
+    hdr->event_type = static_cast<uint32_t>(event_type_);
     hdr->num_cores = static_cast<uint32_t>(num_cores);
 
     // ---- Allocate per-core PmuBuffers and populate free_queues + recycled pool ----
@@ -183,7 +181,7 @@ int PmuCollector::init(
     // ---- Build CSV header string ----
     {
         std::string header = "thread_id,core_id,task_id,func_id,core_type,pmu_total_cycles";
-        const PmuEventConfig *evt = pmu_resolve_event_config_a2a3(event_type);
+        const PmuEventConfig *evt = pmu_resolve_event_config_a2a3(event_type_);
         if (evt == nullptr) {
             evt = &PMU_EVENTS_A2A3_PIPE_UTIL;
         }

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -864,9 +864,8 @@ int DeviceRunner::init_chip_swimlane(int num_aicore, int aicpu_thread_num, int d
         return mem_alloc_.free(dev_ptr);
     };
 
-    int rc = chip_swimlane_collector_.initialize(
-        num_aicore, aicpu_thread_num, device_id, chip_swimlane_level_, alloc_cb, nullptr, free_cb, output_prefix_
-    );
+    chip_swimlane_collector_.set_run_output(output_prefix_, chip_swimlane_level_);
+    int rc = chip_swimlane_collector_.initialize(num_aicore, aicpu_thread_num, device_id, alloc_cb, nullptr, free_cb);
     if (rc != 0) {
         return rc;
     }
@@ -888,9 +887,8 @@ int DeviceRunner::init_args_dump(Runtime &runtime, int device_id) {
         return mem_alloc_.free(dev_ptr);
     };
 
-    int rc = dump_collector_.initialize(
-        num_dump_threads, device_id, alloc_cb, nullptr, free_cb, output_prefix_, dump_args_level_
-    );
+    dump_collector_.set_run_output(output_prefix_, dump_args_level_);
+    int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, nullptr, free_cb);
     if (rc != 0) {
         return rc;
     }
@@ -909,7 +907,8 @@ int DeviceRunner::init_pmu(
         return mem_alloc_.free(dev_ptr);
     };
 
-    int rc = pmu_collector_.init(num_cores, num_threads, csv_path, event_type, alloc_cb, nullptr, free_cb, -1);
+    pmu_collector_.set_run_output(csv_path, event_type);
+    int rc = pmu_collector_.init(num_cores, num_threads, alloc_cb, nullptr, free_cb, -1);
     if (rc != 0) {
         return rc;
     }

--- a/src/a5/platform/include/host/pmu_collector.h
+++ b/src/a5/platform/include/host/pmu_collector.h
@@ -225,10 +225,20 @@ public:
      * @param device_id                         Device ID (for register_cb)
      * @return 0 on success, non-zero on failure
      */
+    // Allocates the device-side resources.
+    //
+    // Per-run configuration (CSV destination, event selection) is bound
+    // separately by set_run_output(), which must be called before init() so the
+    // event type reaches the device header and the CSV header string.
     int init(
-        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type,
-        const PmuAllocCallback &alloc_cb, PmuRegisterCallback register_cb, const PmuFreeCallback &free_cb, int device_id
+        int num_cores, int num_threads, const PmuAllocCallback &alloc_cb, PmuRegisterCallback register_cb,
+        const PmuFreeCallback &free_cb, int device_id
     );
+
+    void set_run_output(const std::string &csv_path, PmuEventType event_type) {
+        csv_path_ = csv_path;
+        event_type_ = event_type;
+    }
 
     void start(const profiling_common::ThreadFactory &thread_factory);
 

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -1015,9 +1015,9 @@ int DeviceRunner::init_chip_swimlane(
     auto free_cb = [this](void *dev_ptr) -> int {
         return mem_alloc_.free(dev_ptr);
     };
+    chip_swimlane_collector_.set_run_output(output_prefix_, chip_swimlane_level_);
     int rc = chip_swimlane_collector_.initialize(
-        num_aicore, aicpu_thread_num, device_id, chip_swimlane_level_, alloc_cb,
-        /*register_cb=*/nullptr, free_cb, output_prefix_
+        num_aicore, aicpu_thread_num, device_id, alloc_cb, /*register_cb=*/nullptr, free_cb
     );
     if (rc == 0) {
         kernel_args.args.chip_swimlane_data_base =
@@ -1037,9 +1037,8 @@ int DeviceRunner::init_args_dump(Runtime &runtime, int device_id, KernelArgsHelp
     auto free_cb = [this](void *dev_ptr) -> int {
         return mem_alloc_.free(dev_ptr);
     };
-    int rc = dump_collector_.initialize(
-        num_dump_threads, device_id, alloc_cb, /*register_cb=*/nullptr, free_cb, output_prefix_, dump_args_level_
-    );
+    dump_collector_.set_run_output(output_prefix_, dump_args_level_);
+    int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, /*register_cb=*/nullptr, free_cb);
     if (rc != 0) {
         return rc;
     }
@@ -1058,9 +1057,8 @@ int DeviceRunner::init_pmu(
     auto free_cb = [this](void *dev_ptr) -> int {
         return mem_alloc_.free(dev_ptr);
     };
-    int rc = pmu_collector_.init(
-        num_cores, num_threads, csv_path, event_type, alloc_cb, /*register_cb=*/nullptr, free_cb, device_id
-    );
+    pmu_collector_.set_run_output(csv_path, event_type);
+    int rc = pmu_collector_.init(num_cores, num_threads, alloc_cb, /*register_cb=*/nullptr, free_cb, device_id);
     if (rc == 0) {
         kernel_args.args.pmu_data_base = reinterpret_cast<uint64_t>(pmu_collector_.get_pmu_shm_device_ptr());
         kernel_args.args.aicore_pmu_ring_addrs =

--- a/src/a5/platform/shared/host/pmu_collector.cpp
+++ b/src/a5/platform/shared/host/pmu_collector.cpp
@@ -75,8 +75,8 @@ PmuCollector::~PmuCollector() { stop(); }
 // ---------------------------------------------------------------------------
 
 int PmuCollector::init(
-    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type,
-    const PmuAllocCallback &alloc_cb, PmuRegisterCallback register_cb, const PmuFreeCallback &free_cb, int device_id
+    int num_cores, int num_threads, const PmuAllocCallback &alloc_cb, PmuRegisterCallback register_cb,
+    const PmuFreeCallback &free_cb, int device_id
 ) {
     if (num_cores <= 0 || num_threads <= 0 || alloc_cb == nullptr || free_cb == nullptr) {
         LOG_ERROR("PmuCollector::init: invalid arguments");
@@ -100,8 +100,6 @@ int PmuCollector::init(
 
     num_cores_ = num_cores;
     num_threads_ = num_threads;
-    event_type_ = event_type;
-    csv_path_ = csv_path;
 
     reset_collector_shards();
     if (csv_file_.is_open()) {
@@ -143,7 +141,7 @@ int PmuCollector::init(
 
     std::memset(shm_host_local, 0, shm_size);
     PmuDataHeader *hdr = get_pmu_header(shm_host_local);
-    hdr->event_type = static_cast<uint32_t>(event_type);
+    hdr->event_type = static_cast<uint32_t>(event_type_);
     hdr->num_cores = static_cast<uint32_t>(num_cores);
 
     // ---- Allocate the per-core ring-address table for AICore. The ring
@@ -214,7 +212,7 @@ int PmuCollector::init(
     // ---- Build CSV header string (file is opened lazily on first record) ----
     {
         std::string header = "thread_id,core_id,task_id,func_id,core_type,pmu_total_cycles";
-        const PmuEventConfig *evt = pmu_resolve_event_config_a5(event_type);
+        const PmuEventConfig *evt = pmu_resolve_event_config_a5(event_type_);
         if (evt == nullptr) {
             evt = &PMU_EVENTS_A5_PIPE_UTIL;
         }

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -840,9 +840,9 @@ void DeviceRunner::finalize_collectors() {
 }
 
 int DeviceRunner::init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id) {
+    chip_swimlane_collector_.set_run_output(output_prefix_, chip_swimlane_level_);
     int rc = chip_swimlane_collector_.initialize(
-        num_aicore, aicpu_thread_num, device_id, chip_swimlane_level_, prof_alloc_cb,
-        /*register_cb=*/nullptr, prof_free_cb, output_prefix_
+        num_aicore, aicpu_thread_num, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb
     );
     if (rc == 0) {
         kernel_args_.chip_swimlane_data_base =
@@ -856,10 +856,9 @@ int DeviceRunner::init_chip_swimlane(int num_aicore, int aicpu_thread_num, int d
 int DeviceRunner::init_args_dump(Runtime &runtime, int device_id) {
     int num_dump_threads = runtime.get_aicpu_thread_num();
 
-    int rc = dump_collector_.initialize(
-        num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, output_prefix_,
-        dump_args_level_
-    );
+    dump_collector_.set_run_output(output_prefix_, dump_args_level_);
+    int rc =
+        dump_collector_.initialize(num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb);
     if (rc != 0) {
         return rc;
     }
@@ -871,9 +870,9 @@ int DeviceRunner::init_args_dump(Runtime &runtime, int device_id) {
 int DeviceRunner::init_pmu(
     int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int /*device_id*/
 ) {
+    pmu_collector_.set_run_output(csv_path, event_type);
     int rc = pmu_collector_.init(
-        num_cores, num_threads, csv_path, event_type, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb,
-        /*device_id=*/-1
+        num_cores, num_threads, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, /*device_id=*/-1
     );
     if (rc == 0) {
         kernel_args_.pmu_data_base = reinterpret_cast<uint64_t>(pmu_collector_.get_pmu_shm_device_ptr());

--- a/src/common/platform/include/host/args_dump_collector.h
+++ b/src/common/platform/include/host/args_dump_collector.h
@@ -224,10 +224,26 @@ public:
      *                          before any dispatch.
      * @return 0 on success, error code on failure
      */
+    // Allocates the device-side resources: header, per-thread DumpBufferStates,
+    // DumpMetaBuffers and payload arenas.
+    //
+    // The per-run configuration (output prefix, level) is NOT taken here — it
+    // is bound separately via set_run_output(), which the caller must call
+    // before initialize().
     int initialize(
         int num_dump_threads, int device_id, const DumpAllocCallback &alloc_cb, DumpRegisterCallback register_cb,
-        const DumpFreeCallback &free_cb, const std::string &output_prefix, DumpArgsLevel dump_args_level
+        const DumpFreeCallback &free_cb
     );
+
+    // Per-run artifact configuration. Must be set before initialize(): the
+    // level is copied into DumpDataHeader there, so a later change would move
+    // only the host-side copy and leave the device on the previous one. The
+    // prefix is read when the writer thread starts lazily on the first
+    // collected buffer.
+    void set_run_output(const std::string &output_prefix, DumpArgsLevel dump_args_level) {
+        output_prefix_ = output_prefix;
+        dump_args_level_ = dump_args_level;
+    }
 
     void start(const profiling_common::ThreadFactory &thread_factory);
 

--- a/src/common/platform/include/host/chip_swimlane_collector.h
+++ b/src/common/platform/include/host/chip_swimlane_collector.h
@@ -379,11 +379,25 @@ public:
      *                                 upstream.
      * @return 0 on success, error code on failure
      */
+    // Allocates the device-side resources.
+    //
+    // num_aicore defines the shared-memory layout: every pool array after the
+    // first starts at an offset computed from it, and the AICPU side computes
+    // the same offsets from its own worker count. The two must agree, so this
+    // takes the run's dimension rather than a platform maximum.
+    //
+    // Per-run configuration (artifact prefix, level) is bound separately by
+    // set_run_output(), which must be called before initialize(): the level
+    // reaches the device header and selects the orch phase pool here.
     int initialize(
-        int num_aicore, int aicpu_thread_num, int device_id, ChipSwimlaneLevel chip_swimlane_level,
-        const ChipSwimlaneAllocCallback &alloc_cb, ChipSwimlaneRegisterCallback register_cb,
-        const ChipSwimlaneFreeCallback &free_cb, const std::string &output_prefix
+        int num_aicore, int aicpu_thread_num, int device_id, const ChipSwimlaneAllocCallback &alloc_cb,
+        ChipSwimlaneRegisterCallback register_cb, const ChipSwimlaneFreeCallback &free_cb
     );
+
+    void set_run_output(const std::string &output_prefix, ChipSwimlaneLevel chip_swimlane_level) {
+        output_prefix_ = output_prefix;
+        chip_swimlane_level_ = chip_swimlane_level;
+    }
 
     /**
      * Per-buffer callback invoked by ProfilerBase's poll loop. Dispatches on

--- a/src/common/platform/shared/host/args_dump_collector.cpp
+++ b/src/common/platform/shared/host/args_dump_collector.cpp
@@ -91,7 +91,7 @@ void ArgsDumpCollector::merge_collector_shards() {
 
 int ArgsDumpCollector::initialize(
     int num_dump_threads, int device_id, const DumpAllocCallback &alloc_cb, DumpRegisterCallback register_cb,
-    const DumpFreeCallback &free_cb, const std::string &output_prefix, DumpArgsLevel dump_args_level
+    const DumpFreeCallback &free_cb
 ) {
     if (shm_host_ != nullptr) {
         LOG_ERROR("ArgsDumpCollector already initialized");
@@ -110,8 +110,6 @@ int ArgsDumpCollector::initialize(
     set_aicpu_thread_num(num_dump_threads);
 
     num_dump_threads_ = num_dump_threads;
-    output_prefix_ = output_prefix;
-    dump_args_level_ = dump_args_level;
     reset_collector_shards();
     total_dropped_record_count_.store(0, std::memory_order_relaxed);
     total_truncated_count_.store(0, std::memory_order_relaxed);
@@ -151,7 +149,7 @@ int ArgsDumpCollector::initialize(
     header->magic = ARGS_DUMP_MAGIC;
     header->num_dump_threads = static_cast<uint32_t>(num_dump_threads);
     header->records_per_buffer = PLATFORM_DUMP_RECORDS_PER_BUFFER;
-    header->dump_args_level = static_cast<uint32_t>(dump_args_level);
+    header->dump_args_level = static_cast<uint32_t>(dump_args_level_);
 
     uint64_t arena_size = calc_dump_arena_size();
     header->arena_size_per_thread = arena_size;

--- a/src/common/platform/shared/host/chip_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/chip_swimlane_collector.cpp
@@ -84,12 +84,21 @@ ChipSwimlaneCollector::~ChipSwimlaneCollector() {
 }
 
 int ChipSwimlaneCollector::initialize(
-    int num_aicore, int aicpu_thread_num, int device_id, ChipSwimlaneLevel chip_swimlane_level,
-    const ChipSwimlaneAllocCallback &alloc_cb, ChipSwimlaneRegisterCallback register_cb,
-    const ChipSwimlaneFreeCallback &free_cb, const std::string &output_prefix
+    int num_aicore, int aicpu_thread_num, int device_id, const ChipSwimlaneAllocCallback &alloc_cb,
+    ChipSwimlaneRegisterCallback register_cb, const ChipSwimlaneFreeCallback &free_cb
 ) {
     if (shm_host_ != nullptr) {
         LOG_ERROR("ChipSwimlaneCollector already initialized");
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    if (num_aicore <= 0 || num_aicore > PLATFORM_MAX_CORES) {
+        LOG_ERROR("Invalid number of AICores: %d (max=%d)", num_aicore, PLATFORM_MAX_CORES);
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    if (aicpu_thread_num <= 0 || aicpu_thread_num > PLATFORM_MAX_AICPU_THREADS) {
+        LOG_ERROR(
+            "Invalid number of AICPU threads: %d (valid range: 1-%d)", aicpu_thread_num, PLATFORM_MAX_AICPU_THREADS
+        );
         return PTO_RUNTIME_ERR_INTERNAL;
     }
 
@@ -102,25 +111,12 @@ int ChipSwimlaneCollector::initialize(
 
     LOG_INFO("Initializing performance profiling");
 
-    if (num_aicore <= 0 || num_aicore > PLATFORM_MAX_CORES) {
-        LOG_ERROR("Invalid number of AICores: %d (max=%d)", num_aicore, PLATFORM_MAX_CORES);
-        return PTO_RUNTIME_ERR_INTERNAL;
-    }
-    if (aicpu_thread_num <= 0 || aicpu_thread_num > PLATFORM_MAX_AICPU_THREADS) {
-        LOG_ERROR(
-            "Invalid number of AICPU threads: %d (valid range: 1-%d)", aicpu_thread_num, PLATFORM_MAX_AICPU_THREADS
-        );
-        return PTO_RUNTIME_ERR_INTERNAL;
-    }
-
     // Must precede the recycled-lane seeding below: push_recycled() folds its
     // shard argument modulo the manager's shard count.
     set_aicpu_thread_num(aicpu_thread_num);
 
     num_aicore_ = num_aicore;
     aicpu_thread_num_ = aicpu_thread_num;
-    chip_swimlane_level_ = chip_swimlane_level;
-    output_prefix_ = output_prefix;
     total_perf_collected_ = 0;
     total_sched_phase_collected_ = 0;
     total_orch_phase_collected_ = 0;

--- a/tests/ut/cpp/common/test_args_dump_collector.cpp
+++ b/tests/ut/cpp/common/test_args_dump_collector.cpp
@@ -48,10 +48,8 @@ TEST(ArgsDumpCollectorTest, MergesConcurrentShardRecordsIntoManifest) {
     constexpr int kRecordsPerShard = 32;
     constexpr int kShardCount = DumpModule::kMaxCollectorThreads;
     ArgsDumpCollector collector;
-    ASSERT_EQ(
-        collector.initialize(kShardCount, 0, test_alloc, nullptr, test_free, test_dir.string(), DumpArgsLevel::HYBRID),
-        0
-    );
+    collector.set_run_output(test_dir.string(), DumpArgsLevel::HYBRID);
+    ASSERT_EQ(collector.initialize(kShardCount, 0, test_alloc, nullptr, test_free), 0);
 
     std::vector<DumpMetaBuffer> buffers(kShardCount);
     std::atomic<int> ready_workers{0};
@@ -111,9 +109,8 @@ TEST(ArgsDumpCollectorTest, BackpressureReleaseWaitsForAllPublishedPayloads) {
     constexpr int kArenaCount = 2;
     constexpr uint64_t kPayloadSize = sizeof(uint64_t);
     TestArgsDumpCollector collector;
-    ASSERT_EQ(
-        collector.initialize(kArenaCount, 0, test_alloc, nullptr, test_free, test_dir.string(), DumpArgsLevel::FULL), 0
-    );
+    collector.set_run_output(test_dir.string(), DumpArgsLevel::FULL);
+    ASSERT_EQ(collector.initialize(kArenaCount, 0, test_alloc, nullptr, test_free), 0);
 
     auto *device_base = collector.get_dump_shm_device_ptr();
     ASSERT_NE(device_base, nullptr);
@@ -178,7 +175,8 @@ TEST(ArgsDumpCollectorTest, BackpressureReleaseDoesNotOffsetPayloadsAcrossThread
     ASSERT_TRUE(std::filesystem::create_directories(test_dir));
 
     TestArgsDumpCollector collector;
-    ASSERT_EQ(collector.initialize(2, 0, test_alloc, nullptr, test_free, test_dir.string(), DumpArgsLevel::FULL), 0);
+    collector.set_run_output(test_dir.string(), DumpArgsLevel::FULL);
+    ASSERT_EQ(collector.initialize(2, 0, test_alloc, nullptr, test_free), 0);
 
     auto *device_base = collector.get_dump_shm_device_ptr();
     ASSERT_NE(device_base, nullptr);

--- a/tests/ut/cpp/common/test_pmu_collector.cpp
+++ b/tests/ut/cpp/common/test_pmu_collector.cpp
@@ -42,9 +42,8 @@ TEST(PmuCollectorTest, PreservesShardFilesWhenFinalCsvCannotBeOpened) {
     ASSERT_TRUE(std::filesystem::create_directories(csv_path));
 
     PmuCollector collector;
-    ASSERT_EQ(
-        collector.init(1, 1, csv_path.string(), PmuEventType::PIPE_UTILIZATION, test_alloc, nullptr, test_free, 0), 0
-    );
+    collector.set_run_output(csv_path.string(), PmuEventType::PIPE_UTILIZATION);
+    ASSERT_EQ(collector.init(1, 1, test_alloc, nullptr, test_free, 0), 0);
 
     PmuBuffer buffer{};
     buffer.count = 1;
@@ -76,12 +75,8 @@ TEST(PmuCollectorTest, MergesConcurrentShardWritesIntoFinalCsv) {
     constexpr int kRecordsPerShard = 64;
     constexpr int kShardCount = PmuModule::kMaxCollectorThreads;
     PmuCollector collector;
-    ASSERT_EQ(
-        collector.init(
-            1, kShardCount, csv_path.string(), PmuEventType::PIPE_UTILIZATION, test_alloc, nullptr, test_free, 0
-        ),
-        0
-    );
+    collector.set_run_output(csv_path.string(), PmuEventType::PIPE_UTILIZATION);
+    ASSERT_EQ(collector.init(1, kShardCount, test_alloc, nullptr, test_free, 0), 0);
 
     std::atomic<int> ready_workers{0};
     std::atomic<bool> start_workers{false};


### PR DESCRIPTION
## Summary

Each DFX collector's `initialize()` / `init()` took two unrelated kinds of
argument: **the device resources to allocate**, and **the current run's artifact
configuration**. Those have different lifetimes — resources belong to the device,
configuration to a run — and conflating them is part of what forces the
collectors to be torn down and rebuilt every run (#2078).

The configuration now has its own binder, `set_run_output()`, on the three
collectors that have one:

| collector | moved to `set_run_output()` |
| --- | --- |
| swimlane | `output_prefix`, `chip_swimlane_level` |
| args_dump | `output_prefix`, `dump_args_level` |
| pmu (a2a3 + a5) | `csv_path`, `event_type` |

Callers bind it before `initialize()`, which is where the runners already sat:
`apply_call_config()` runs inside `simpler_prepare_run`, ahead of
`prepare_execution`. `dep_gen` and `scope_stats` have no per-run arguments and
are untouched.

`initialize()` still runs once per run, so the level still reaches the device
header from the member the setter wrote. **No behaviour changes.**

## The sizing arguments deliberately stay

An earlier revision of this PR also moved `num_aicore` / `aicpu_thread_num` to
the platform maxima, on the reasoning that a collector outliving a run cannot be
sized to that run. CI caught that, and the reason is worth recording:

**`num_aicore` is not a capacity number — it is the addressing basis for the
shared-memory layout.** Only the first pool array starts at a fixed offset;
every one after it is derived from `num_aicore`:

```
get_aicore_buffer_states(base, num_cores)      = base + calc_perf_data_size(num_cores)
get_sched_phase_buffer_states(base, num_cores) = base + calc_perf_data_size(num_cores)
                                                      + num_cores * sizeof(AicoreTaskPool)
```

The AICPU side computes those same offsets from **its own** worker count
(`chip_swimlane_collector_aicpu.cpp:333`, `:822`). Widening only the host's basis
desynchronizes two views of one region: each side then reads and writes different
addresses in it. The symptom is silent — no error anywhere, just

```
PERF        count mismatch (collected=5 + dropped=0 != device_total=34, silent_loss=29)
SCHED_PHASE count mismatch (collected=2 + dropped=0 != device_total=0,  silent_loss=-2)
```

A **negative** `silent_loss` is the giveaway: records cannot be lost below zero,
so the two sides must be addressing different memory.

Making the layout independent of a run requires changing both sides in one
commit, and belongs with the residency work rather than here.

## Testing

- [x] All four variants build (a2a3/a5 × onboard/sim)
- [x] cpput **128/128** — the collector tests call these signatures directly and
  were updated
- [x] a5sim full sweep: `host_build_graph` 18 passed, `tensormap_and_ringbuffer`
  46 passed
- [x] **DFX lanes on both arches**, which is what the plain sweep misses because
  it passes no diagnostic flags: a5 `chip_swimlane` 4 passed; a2a3 `dfx` 3 + 9
  passed — all with `--enable-chip-swimlane --enable-dep-gen`
- [x] clang-format, cpplint, check-headers, check-english-only,
  check-retired-names, check-kernel-wire-isolation
- [x] Everything above re-run after rebasing onto #2094, which touches
  `dep_gen_host_graph.h` and the hbg orchestration API
- [ ] No onboard run locally — this box is a2a3 silicon; covered by CI

Step 2 of the plan in
https://github.com/hw-native-sys/simpler/issues/2078#issuecomment-5488058867,
following #2091.
