### PR TITLE
Add: host_build_graph early dispatch via an ED publish list

### DIFF
--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -126,7 +126,7 @@ scalar `rt_orchestration_done` publishes into the runtime header.
 **Why the scheduler state is device-written.** `SchedulerState` holds no
 per-run content: `sm_header` and the task-header pointer derive from a pooled SM base,
 queue capacities are compile-time constants, polling reserves no wiring or
-dependency pool (readiness comes from the task table's `completion_flags`, which
+dependency pool (readiness comes from the task table's `progress_flags`, which
 the task header owns), and it has no host-side entry point at all. So the host would
 only be writing an initialization pattern — 203,392 bytes
 of it, dominated by `AsyncWaitList::entries` — for the device to receive and never
@@ -181,7 +181,7 @@ past `total_tasks`. So the SM H2D shipped each run is bounded, not capacity-size
 the contract that keeps `bind` proportional to the workload.
 
 The header is zeroed on the host; `descriptors`, `payloads`, `slot_states` and
-`completion_flags` are each written per task at submit. Per-slot reset is
+`progress_flags` are each written per task at submit. Per-slot reset is
 init-on-write in `orch::prepare_task` as each slot is claimed — there is no
 table-wide reset. In the mirror those four live prefixes are a full reservation
 apart, so `compact_live_image` restacks them (plus the three argument pools) into
@@ -214,7 +214,7 @@ therefore also its slot index: ids run `0..capacity-1`, never wrap, and every
 segment is indexed by the id directly — there is no slot mask, so the capacity need
 not be a power of two.
 
-Completion is published per task, in `completion_flags[local_id]`, and reclaims
+Completion is published per task, in `progress_flags[local_id]`, and reclaims
 neither task slots nor heap.
 
 There is no post-run sweep that makes graph space reusable. Runtime destruction
@@ -299,9 +299,18 @@ producer transition and does not require periodic dependency polling.
 The dispatchable shapes are `AIC`, `AIV`, and `MIX`; dependency-only `DUMMY`
 tasks use a dedicated queue and complete without AICore dispatch.
 
-Early producer propagation is currently disabled in HBG. The shared scheduler
-retains early-staging code for parity with `tensormap_and_ringbuffer`, but HBG's
-boot classifier and wake lists are the active readiness path.
+Early dispatch is detected by the publish list, the wake list's dual keyed on
+publication instead of completion. The host qualifies candidates at submit
+(at least one producer, every producer flagged and none of them a Graph shell —
+a shell has no publication event — no dispatch predicate, dispatchable
+shape) and sorts
+a candidate's fanin row by ascending local id; a candidate hangs on its
+latest-submitted unpublished producer, the producer's publish event seals the
+chain (sentinel
+exchange) and hands the detached waiters to idle threads, and an all-published
+rescan verdict queues the candidate for pre-staging. Release rings the staged
+doorbells at the ready funnel (`push_ready_routed`), the moment readiness is
+decided. Completion readiness itself remains the boot classifier + wake lists.
 
 ## 7. Dispatch and Completion
 

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -598,7 +598,7 @@ int32_t run_host_orchestration(
     // The dep_gen graph belongs to the orchestration that is about to run.
     dep_gen_host_graph_begin_capture();
 
-    // Init-on-write: descriptors, payloads, slot_states and completion_flags are
+    // Init-on-write: descriptors, payloads, slot_states and progress_flags are
     // each written per task at submit and read only for [0, total_tasks). Zero
     // only the fixed-size header here; the per-slot segments are initialized in
     // orch::prepare_task and shipped bounded to total_tasks below.

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.cpp
@@ -108,4 +108,31 @@ void SchedulerState::print_queues() {
         (unsigned long long)sched->early_sync_start_queue.enqueue_pos.load(std::memory_order_relaxed),
         (unsigned long long)sched->early_sync_start_queue.max_occupancy.load(std::memory_order_relaxed)
     );
+    const uint64_t pub_drops = sched->ed_publish_drain_drops.load(std::memory_order_relaxed);
+    LOG_TIMING(
+        "QPROBE ed_pubdrain pushes=%llu maxocc=%llu cap=%llu drops=%llu",
+        (unsigned long long)sched->ed_publish_drain_queue.enqueue_pos.load(std::memory_order_relaxed),
+        (unsigned long long)sched->ed_publish_drain_queue.max_occupancy.load(std::memory_order_relaxed),
+        (unsigned long long)sched->ed_publish_drain_queue.capacity, (unsigned long long)pub_drops
+    );
+    if (pub_drops > 0) {
+        LOG_WARN(
+            "[EARLY_DISPATCH] publish-drain queue dropped %llu chain(s); those candidates fell back to normal "
+            "dispatch",
+            (unsigned long long)pub_drops
+        );
+    }
+#if SIMPLER_SCHED_PROFILING
+    LOG_TIMING(
+        "QPROBE ed_publist registered=%llu immediate=%llu seals=%llu detached=%llu rescanned=%llu rehangs=%llu "
+        "ready=%llu",
+        (unsigned long long)sched->ed_publish_stats.registered.load(std::memory_order_relaxed),
+        (unsigned long long)sched->ed_publish_stats.immediate_at_intake.load(std::memory_order_relaxed),
+        (unsigned long long)sched->ed_publish_stats.publish_seals.load(std::memory_order_relaxed),
+        (unsigned long long)sched->ed_publish_stats.chains_detached.load(std::memory_order_relaxed),
+        (unsigned long long)sched->ed_publish_stats.waiters_rescanned.load(std::memory_order_relaxed),
+        (unsigned long long)sched->ed_publish_stats.rehangs.load(std::memory_order_relaxed),
+        (unsigned long long)sched->ed_publish_stats.candidates_ready.load(std::memory_order_relaxed)
+    );
+#endif
 }

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -15,11 +15,11 @@
  * The Scheduler is responsible for:
  * 1. Maintaining per-resource-shape ready queues
  * 2. Polling-completion dependency resolution: a GLOBAL task is ready when every
- *    producer named in its inline fanin has set its completion_flags byte, an
+ *    producer named in its inline fanin has set its progress_flags byte, an
  *    IN_GRAPH one when every producer in its Graph's fanin wire has reached
  *    task_state == COMPLETED (that table has no flag bytes); a producer publishes
  *    completion + drains its wake list on finish
- * 3. Publishing completion (task_state PENDING -> COMPLETED, completion_flags byte)
+ * 3. Publishing completion (task_state PENDING -> COMPLETED, progress_flags byte)
  * 4. Two-stage mixed-task completion (subtask done bits -> mixed-task complete)
  *
  * The Scheduler runs on Device AI_CPU. host_build_graph is scheduler-only (the
@@ -470,6 +470,7 @@ struct SchedulerLayout {
     size_t off_graph_prepare_queue_slots;
     size_t off_early_dispatch_queue_slots[NUM_RESOURCE_SHAPES];
     size_t off_early_sync_start_queue_slots;
+    size_t off_ed_publish_drain_queue_slots;
     ReadyQueueCapacities capacities;
 };
 
@@ -489,7 +490,7 @@ struct SchedulerState {
         SharedMemoryTaskHeader *tasks;
 
         // Polling: no dep_pool. Readiness is derived from the task table's
-        // completion_flags; there is no arena-side wiring pool to reserve or wire.
+        // progress_flags; there is no arena-side wiring pool to reserve or wire.
         // The `tasks` field stores the device address of the SM task header —
         // computed via offset arithmetic, no SM dereference.
         bool init_data_from_layout(void *sm_dev_base);
@@ -552,6 +553,21 @@ struct SchedulerState {
     }
 
     void push_ready_routed(ChipTaskSlotState *slot_state) {
+        // Early-dispatch release: a pre-staged candidate launches by doorbell
+        // right here — the moment its readiness is decided — and skips the
+        // queue round-trip. Only host-qualified candidates can hold a staging
+        // claim, so every other task pays one hot-line flag test. A ready
+        // sync_start candidate also publishes to its drain owner, which may
+        // already hold it for an all-or-nothing stage.
+        if ((slot_state->ed_flags & ED_FLAG_CANDIDATE) != 0) {
+            const bool early_handled = try_early_dispatch_release(*slot_state);
+            if (slot_state->task_attrs.requires_sync_start()) {
+                const bool drain_owned = publish_ready_to_early_sync_drain(slot_state->to_payload());
+                if (early_handled || drain_owned) return;
+            } else if (early_handled) {
+                return;
+            }
+        }
         bool pushed;
         if (slot_state->task_kind == TaskKind::GRAPH) {
             pushed = graph_ready_queue.push(slot_state);
@@ -580,24 +596,35 @@ struct SchedulerState {
 
     // ---- Polling completion primitives ---------------------------------------
     // Readiness: a task is ready iff every producer named in its inline fanin has
-    // set its completion_flags byte. A producer is named by its local id alone, so
+    // set its progress_flags byte. A producer is named by its local id alone, so
     // there is no per-edge indirection.
 
     // Unmet-fanin classification. Returns -1 (all fanins met -> route to ready)
     // or the index of an unmet fanin (register on that producer's wake list).
     // Scan direction is load-bearing: the builder fills the fanin region in
-    // submission order, so the last unmet entry is the latest-submitted
-    // producer -- the one likeliest to complete last. Targeting it minimises
+    // submission order (and an early-dispatch candidate's row is sorted by
+    // local id, making the order exact), so the last unmet entry is the
+    // latest-submitted producer -- the one likeliest to complete last.
+    // Targeting it minimises
     // wake-list transfers (a consumer re-registered onto a second producer once
     // its first one completes) and the CAS traffic those transfers put on the
     // lists. The decision is terminal: tasks are never re-polled; a producer's
     // completion re-scans its waiters via on_mixed_task_complete's wake drain.
-    int classify_fanin_state(const ChipTaskSlotState *s) const {
+    // Resumes at the wake-scan cursor: entries above it were completed at the
+    // last classification and completion bits are monotonic, so re-walking
+    // them cannot change the verdict. An unmet verdict records itself as the
+    // new cursor — the caller hangs the task exactly there, and this
+    // classifier is the task's only owner at that moment.
+    int classify_fanin_state(ChipTaskSlotState *s) const {
         const TaskPayload &p = s->to_payload();
         const SharedMemoryTaskHeader &tasks = *task_view.tasks;
         const int32_t *fanin = p.fanin_data();
-        for (int32_t i = p.fanin_count - 1; i >= 0; i--) {
-            if (!tasks.is_completion_flag_set(fanin[i])) return i;
+        const int32_t start = s->wake_scan_cursor < p.fanin_count ? s->wake_scan_cursor : p.fanin_count - 1;
+        for (int32_t i = start; i >= 0; i--) {
+            if (!tasks.is_completion_flag_set(fanin[i])) {
+                s->wake_scan_cursor = static_cast<uint8_t>(i);
+                return i;
+            }
         }
         return -1;
     }
@@ -605,7 +632,7 @@ struct SchedulerState {
     // Register `consumer` on `producer`'s wake list. If the producer already
     // completed (head == SENTINEL), re-classify against ALL fanins: route to
     // ready only when every fanin is met, else re-target the next unmet producer
-    // and retry. Monotonic completion_flags guarantee termination.
+    // and retry. Monotonic progress_flags guarantee termination.
     void register_wake(ChipTaskSlotState *producer, ChipTaskSlotState *consumer) {
         SharedMemoryTaskHeader &tasks = *task_view.tasks;
         while (true) {
@@ -628,7 +655,7 @@ struct SchedulerState {
     }
 
     // Producer completion under polling: publish the task_state completion
-    // mirror + the device-visible completion_flags byte, then drain the wake list
+    // mirror + the device-visible progress_flags byte, then drain the wake list
     // (route/re-register each waiter). Whole-graph-resident hbg
     // has no device slot reclaim, so nothing advances a reclaim cursor here.
     void on_mixed_task_complete(ChipTaskSlotState &slot_state) {
@@ -637,6 +664,10 @@ struct SchedulerState {
 
         slot_state.mark_completed();  // completion mirror (task_state = COMPLETED)
         tasks.set_completion_flag(task_id);
+        // The completion byte carries the publish bit, so a tracked producer
+        // that never published (DUMMY, predicate-retired) still releases its
+        // publish-list waiters here. Idempotent after a publish-time seal.
+        if ((slot_state.ed_flags & ED_FLAG_TRACKED) != 0) seal_ed_publish_list(slot_state);
 
         ChipTaskSlotState *waiter = slot_state.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
         while (waiter != nullptr && waiter != WAKE_LIST_SENTINEL) {
@@ -717,6 +748,29 @@ struct SchedulerState {
     // otherwise. HBG producer propagation currently leaves this queue dormant.
     ChipReadyQueue early_sync_start_queue;
 
+    // Pending-drain queue of the publish list. Each entry is the head of a
+    // waiter chain a producer's publish event sealed and detached; idle
+    // threads pop one per Phase 4b pass and rescan its waiters. A full queue
+    // drops the chain — those candidates miss early dispatch and proceed on
+    // the normal ready path; nothing blocks. The drop count surfaces at
+    // teardown (no log on the dispatch path).
+    ChipReadyQueue ed_publish_drain_queue;
+    std::atomic<uint64_t> ed_publish_drain_drops{0};
+
+#if SIMPLER_SCHED_PROFILING
+    // Publish-list probe. Relaxed counters, read once at teardown.
+    struct EdPublishListStats {
+        std::atomic<uint64_t> registered{0};           // candidates hung at intake
+        std::atomic<uint64_t> immediate_at_intake{0};  // all-published already at intake
+        std::atomic<uint64_t> publish_seals{0};        // tracked producers fully published
+        std::atomic<uint64_t> chains_detached{0};      // seals that handed off a non-empty chain
+        std::atomic<uint64_t> waiters_rescanned{0};
+        std::atomic<uint64_t> rehangs{0};           // bet missed: waiter moved to another producer
+        std::atomic<uint64_t> candidates_ready{0};  // all-published verdicts (ED triggers)
+    };
+    EdPublishListStats ed_publish_stats;
+#endif
+
     static inline void ring_one_doorbell(uint64_t reg_addr, uint32_t token) {
         volatile uint64_t *dmb = reinterpret_cast<volatile uint64_t *>(get_reg_ptr(reg_addr, RegId::DATA_MAIN_BASE));
         uint64_t tk = static_cast<uint64_t>(token);
@@ -759,9 +813,187 @@ struct SchedulerState {
         );
     }
 
+    // All-published verdict -> ED queue. The exactly-once claim is the
+    // NONE->STAGING CAS: a consumer that already became ready lost the state
+    // to the release path's NONE->DISPATCHED and is dropped here. A failed
+    // push returns the claim so readiness takes the ordinary queue path.
+    inline void enqueue_early_dispatch_candidate(ChipTaskSlotState &consumer) {
+        uint8_t expected = EARLY_DISPATCH_NONE;
+        if (!consumer.to_payload().early_dispatch_state.compare_exchange_strong(
+                expected, EARLY_DISPATCH_STAGING, std::memory_order_seq_cst, std::memory_order_seq_cst
+            )) {
+            return;
+        }
+        const uint64_t task_id = static_cast<uint64_t>(consumer.to_descriptor().task_id.raw);
+        // A sync_start cohort parks in the shape-agnostic queue so one owner can
+        // choose an all-or-nothing local stage or the global-drain fallback.
+        const bool queued =
+            consumer.task_attrs.requires_sync_start() ?
+                early_sync_start_queue.push_tagged(&consumer, task_id) :
+                early_dispatch_queues[static_cast<int32_t>(consumer.active_mask.to_shape())].push_tagged(
+                    &consumer, task_id
+                );
+        if (!queued) {
+            expected = EARLY_DISPATCH_STAGING;
+            consumer.to_payload().early_dispatch_state.compare_exchange_strong(
+                expected, EARLY_DISPATCH_NONE, std::memory_order_seq_cst, std::memory_order_seq_cst
+            );
+        }
+    }
+
+    // Early-dispatch release, run at the ready funnel the moment readiness is
+    // decided. Returns true when the task is fully handled (every block
+    // launches by doorbell) and must NOT be queued. Returns false to route
+    // normally: never pre-staged, or a partially staged SPMD consumer whose
+    // remaining blocks dispatch off the ready queue from next_block_idx.
+    // Lock-free claim shared with the stagers: winning CAS NONE->DISPATCHED
+    // means not pre-staged; otherwise flip STAGING->DISPATCHED and
+    // destructively claim the published doorbell bits — a late stager rings
+    // only the bits this pass did not take, so each gated core has exactly
+    // one doorbell writer.
+    inline bool try_early_dispatch_release(ChipTaskSlotState &slot_state) {
+        TaskPayload &payload = slot_state.to_payload();
+        uint8_t expect = EARLY_DISPATCH_NONE;
+        if (payload.early_dispatch_state.compare_exchange_strong(
+                expect, EARLY_DISPATCH_DISPATCHED, std::memory_order_seq_cst, std::memory_order_seq_cst
+            )) {
+            return false;
+        }
+        // Defensive: a duplicate that observes an in-progress launch must never
+        // route the same partial task a second time.
+        if (expect != EARLY_DISPATCH_STAGING) return true;
+        const bool sync_start = slot_state.task_attrs.requires_sync_start();
+        if (!sync_start && !try_claim_early_dispatch_launch(payload)) return true;
+        expect = EARLY_DISPATCH_STAGING;
+        payload.early_dispatch_state.compare_exchange_strong(
+            expect, EARLY_DISPATCH_DISPATCHED, std::memory_order_seq_cst, std::memory_order_seq_cst
+        );
+        if (sync_start) {
+            // The flip to DISPATCHED is only the producer-released half of the
+            // rendezvous; the ring fires once every gated core also occupies a
+            // running slot, from whichever half completes second.
+            maybe_rendezvous_ring(slot_state);
+        } else {
+            for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
+                uint64_t owned = claim_all_staged_doorbell_bits(payload.staged_core_mask[w]);
+                ring_staged_doorbell_bits(w, owned);
+            }
+            wmb();
+            payload.early_dispatch_launch_state.store(EARLY_DISPATCH_LAUNCH_COMPLETE, std::memory_order_seq_cst);
+        }
+        // A still-queued early-dispatch entry for this consumer is now
+        // DISPATCHED and is dropped when a peer pops it.
+        return slot_state.next_block_idx.load(std::memory_order_seq_cst) >= slot_state.logical_block_num;
+    }
+
+    // Publication accounting for the producers early dispatch watches. Only
+    // ED_FLAG_TRACKED tasks pay: the host set that bit exactly on the
+    // producers of at least one candidate. When the count reaches the task's
+    // logical blocks, the publish byte-bit is set and the publish list is
+    // sealed — everything past that leaves the dispatch path.
+    //
+    // "Published" counts placement, not launch: a gated candidate's staged
+    // blocks publish here too, so its consumers may pre-stage while it still
+    // waits for its own doorbell. Such chains cannot deadlock on cores: a
+    // consumer is detected only after this seal, hence after every producer
+    // block already occupies its slot, so every waits-for edge between gated
+    // tasks points from a later-staged task to an earlier-staged one — the
+    // earliest unreleased gated task has only completed or released
+    // producers, rings, and unwinds the chain in staging order. (The
+    // reclaiming tensormap_and_ringbuffer runtime instead defers propagation
+    // to launch visibility; whole-graph-resident hbg holds no reclaimable
+    // resource a gated chain could pin, so placement is the sufficient gate.)
     inline void record_published_blocks(ChipTaskSlotState &slot_state, int32_t count) {
-        if (count <= 0 || !slot_state.task_attrs.allow_early_resolve()) return;
-        slot_state.to_payload().published_block_count.fetch_add(static_cast<int16_t>(count), std::memory_order_seq_cst);
+        if (count <= 0 || (slot_state.ed_flags & ED_FLAG_TRACKED) == 0) return;
+        const int16_t total = static_cast<int16_t>(
+            slot_state.to_payload().published_block_count.fetch_add(
+                static_cast<int16_t>(count), std::memory_order_seq_cst
+            ) +
+            count
+        );
+        if (total == slot_state.logical_block_num) seal_ed_publish_list(slot_state);
+    }
+
+    // Publish event of a tracked producer: publish bit, then seal. The order
+    // pairs with the acquire loads in advance_ed_publish_scan — a scanner that
+    // meets the sentinel is guaranteed to read the bit as set. The exchange
+    // makes the seal exactly-once (a second call gets the sentinel back), so
+    // the completion path can call this too for tracked producers that never
+    // publish (DUMMY / predicate-retired), whose completion byte carries the
+    // publish bit. A full pending-drain queue drops the chain: those
+    // candidates miss early dispatch, nothing blocks.
+    inline void seal_ed_publish_list(ChipTaskSlotState &slot_state) {
+        // The sentinel is monotone (set once, never cleared), so an
+        // already-sealed list needs neither the flag RMW nor the exchange.
+        if (slot_state.ed_publish_list_head.load(std::memory_order_acquire) == ED_PUBLISH_LIST_SENTINEL) return;
+        const int32_t local_id = slot_state.to_descriptor().task_id.local_id();
+        task_view.tasks->set_publish_flag(local_id);
+        ChipTaskSlotState *head =
+            slot_state.ed_publish_list_head.exchange(ED_PUBLISH_LIST_SENTINEL, std::memory_order_acq_rel);
+        if (head == ED_PUBLISH_LIST_SENTINEL) return;
+#if SIMPLER_SCHED_PROFILING
+        ed_publish_stats.publish_seals.fetch_add(1, std::memory_order_relaxed);
+#endif
+        if (head == nullptr) return;
+#if SIMPLER_SCHED_PROFILING
+        ed_publish_stats.chains_detached.fetch_add(1, std::memory_order_relaxed);
+#endif
+        if (!ed_publish_drain_queue.push(head)) {
+            ed_publish_drain_drops.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+
+    // Resume candidate `c`'s publish scan at its cursor. The row is sorted and
+    // publish bits are monotonic, so entries above the cursor stay published
+    // forever and each entry is loaded once per life. Returns true when every
+    // producer is published — the early-dispatch trigger; false when `c` was
+    // re-hung on a still-unpublished producer's publish list. A hang CAS that
+    // meets the sentinel treats the producer as published and advances.
+    bool advance_ed_publish_scan(ChipTaskSlotState &c) {
+        SharedMemoryTaskHeader &tasks = *task_view.tasks;
+        const TaskPayload &p = c.to_payload();
+        const int32_t *fanin = p.fanin_data();
+        int32_t i = c.ed_publish_scan_cursor;
+        while (i >= 0) {
+            if (tasks.is_publish_flag_set(fanin[i])) {
+                i--;
+                continue;
+            }
+            ChipTaskSlotState &producer = tasks.get_slot_state_by_task_id(fanin[i]);
+            ChipTaskSlotState *expected = producer.ed_publish_list_head.load(std::memory_order_acquire);
+            bool hung = false;
+            while (expected != ED_PUBLISH_LIST_SENTINEL) {
+                c.next_in_ed_publish_list = expected;
+                if (producer.ed_publish_list_head.compare_exchange_weak(
+                        expected, &c, std::memory_order_acq_rel, std::memory_order_acquire
+                    )) {
+                    hung = true;
+                    break;
+                }
+            }
+            if (hung) {
+                c.ed_publish_scan_cursor = static_cast<uint8_t>(i);
+                return false;
+            }
+            // Sentinel: the producer published between the bit load and here.
+            i--;
+        }
+        return true;
+    }
+
+    // Publish-list registration at intake. Only called for a candidate that
+    // is not yet ready (its completion classification hung it on a wake list).
+    // Returns true when every producer is already published at intake.
+    bool register_on_ed_publish_list(ChipTaskSlotState &c) {
+        c.ed_publish_scan_cursor = static_cast<uint8_t>(c.to_payload().fanin_count - 1);
+#if SIMPLER_SCHED_PROFILING
+        ed_publish_stats.registered.fetch_add(1, std::memory_order_relaxed);
+#endif
+        const bool all_published = advance_ed_publish_scan(c);
+#if SIMPLER_SCHED_PROFILING
+        if (all_published) ed_publish_stats.immediate_at_intake.fetch_add(1, std::memory_order_relaxed);
+#endif
+        return all_published;
     }
 
     // Ring one sync_start cohort from its stable staged_core_mask. The caller owns
@@ -857,23 +1089,6 @@ struct SchedulerState {
         );
         return true;
     }
-
-    inline bool retry_sync_start_rendezvous_after_staging(ChipTaskSlotState &slot_state) {
-        if (!maybe_rendezvous_ring(slot_state)) return false;
-        propagate_dispatch_fanin(slot_state);
-        return true;
-    }
-
-    // Milestone 1: early-dispatch (predicated / allow_early_resolve) is stubbed.
-    // This producer-push propagation walked the wiring fanout list bumping each
-    // consumer's dispatch_fanin to pre-stage early-dispatch candidates — all of
-    // which (fanout_head, dispatch_fanin, fanin_actual_count, dispatch_propagated)
-    // are gone under polling. Nothing pre-stages into early_dispatch_queues /
-    // early_sync_start_queue, so tasks reach cores only through the normal ready
-    // path (wake drain -> push_ready_routed). Milestone 2 replaces this with the
-    // consumer-pull publish_flags design. sync_start cohorts still launch via
-    // ready_sync_queues (unaffected).
-    void propagate_dispatch_fanin(ChipTaskSlotState & /*p*/) {}
 
     int get_ready_tasks_batch(ChipReadyQueue *queues, ResourceShape shape, ChipTaskSlotState **out, int max_count) {
         return queues[static_cast<int32_t>(shape)].pop_batch(out, max_count);
@@ -1137,7 +1352,7 @@ struct SchedulerState {
 #endif
     ) {
         // Polling completion: publish the task_state completion mirror + the
-        // device-visible completion_flags byte and drain the wake list (route or
+        // device-visible progress_flags byte and drain the wake list (route or
         // re-register each waiter). Replaces the
         // fanout-list walk + fanin_refcount decrements of the wiring model.
         on_mixed_task_complete(slot_state);

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -219,7 +219,7 @@ void SchedulerContext::log_stall_diagnostics(
             ChipTaskSlotState &slot_state = tasks.get_slot_state_by_task_id(si);
             ChipTaskState st = slot_state.task_state.load(std::memory_order_relaxed);
             // Polling: no fanin_refcount. Recompute met/total from the inline
-            // fanin ids vs the completion_flags (rc = satisfied producers,
+            // fanin ids vs the progress_flags (rc = satisfied producers,
             // fi = raw producer count) so the stall dump still shows readiness.
             int32_t fi = slot_state.to_payload().fanin_count;
             int32_t rc = 0;
@@ -1098,6 +1098,16 @@ void SchedulerContext::classify_partition(int32_t thread_idx, int32_t nthreads) 
         } else {
             int32_t prod_local = slot.to_payload().fanin_data()[state];
             sched_->register_wake(&tasks.get_slot_state_by_task_id(prod_local), &slot);
+            // A not-yet-ready candidate also enters the publish list, hung on
+            // its latest-submitted unpublished producer — or, when every
+            // producer is already published at intake (pre-completed fanin),
+            // goes straight to the ED queue. An already-ready task never does:
+            // there is nothing left to pre-stage ahead of.
+            if ((slot.ed_flags & ED_FLAG_CANDIDATE) != 0) {
+                if (sched_->register_on_ed_publish_list(slot)) {
+                    sched_->enqueue_early_dispatch_candidate(slot);
+                }
+            }
         }
     }
 }

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -191,7 +191,7 @@ void SchedulerContext::complete_slot_task(
         }
 #endif
         // 3S+1P: hand the finished task to the dedicated resolution (P) thread.
-        // P publishes completion_flags and drains the wake list — and owns
+        // P publishes progress_flags and drains the wake list — and owns
         // completed_tasks_, so this scheduler thread neither
         // resolves nor bumps completed_this_turn. (The Resolve swimlane bar is
         // emitted by P, not here.)
@@ -272,7 +272,7 @@ void SchedulerContext::check_running_cores_for_completion(
         // waiting for its doorbell — it physically cannot ACK/FIN yet, so
         // reading its COND (MMIO, and the core is hot-spinning on its own SPR)
         // every poll is pure waste that drags out the completion phase. The
-        // doorbell (try_early_dispatch_release) flips early_dispatch_state to DISPATCHED, at
+        // producer-release doorbell flips early_dispatch_state to DISPATCHED, at
         // which point the core becomes pollable again and its FIN is caught.
         // Cheap cacheable load; no MMIO. Pending slot is empty while gated.
         {
@@ -396,9 +396,7 @@ void SchedulerContext::check_running_cores_for_completion(
                 promote_pending_to_running(core);  // Case 2 or Case 3 (with pending)
                 if (sync_start_promote) {
                     promoted->to_payload().running_slot_count.fetch_add(1, std::memory_order_seq_cst);
-                    if (sched_->maybe_rendezvous_ring(*promoted)) {
-                        sched_->propagate_dispatch_fanin(*promoted);
-                    }
+                    sched_->maybe_rendezvous_ring(*promoted);
                 }
             } else {
                 clear_running_slot(core);  // Case 1 or Case 3 (no pending)
@@ -752,7 +750,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     // attempt remains published while the gate is open; the next drain owner advances it
     // behind the -1 sentinel. Followers identify reopen by gate-open or attempt change.
     // `slot_state` is a local holding the fa_fused slot (not drain_state_), so it stays valid for
-    // the propagate below even if a new drain reuses pending_task after reopen.
+    // the rendezvous retry below even if a new drain reuses pending_task after reopen.
     std::atomic_thread_fence(std::memory_order_release);
     drain_state_.pending_task.store(nullptr, std::memory_order_release);
     drain_state_.drain_stage_go.store(0, std::memory_order_relaxed);
@@ -763,9 +761,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     // ahead of drain completion and fail while running_slot_count is still incomplete. When
     // every block landed directly in a running slot, no pending promotion remains to retry it.
     if (gated) {
-        sched_->retry_sync_start_rendezvous_after_staging(*slot_state);
-    } else {
-        sched_->propagate_dispatch_fanin(*slot_state);
+        sched_->maybe_rendezvous_ring(*slot_state);
     }
     SchedulerState::finish_early_sync_drain(slot_state->to_payload());
 }

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -142,7 +142,7 @@ public:
 
     // Dedicated resolution (P) thread entry (3S+1P). Owns no cores: drains the
     // per-S CompletedTaskQueues and runs on_task_complete for each finished task
-    // (completion_flags publish + wake-list drain), making P
+    // (progress_flags publish + wake-list drain), making P
     // the sole producer of the ready queues. Owns completed_tasks_ / termination.
     int32_t run_resolution_thread(Runtime *runtime, int32_t thread_idx);
 

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -425,9 +425,9 @@ void SchedulerContext::dispatch_shape(
                 }
             }
 
-            // (Early-dispatch pre-staged tasks never reach this ready-pop: they are
-            // released by their doorbell in release_fanin_and_check_ready the
-            // instant their last producer completes — see try_early_dispatch_release.)
+            // (Early-dispatch pre-staged tasks never reach this ready-pop: the
+            // completion path rings their doorbell the instant their last
+            // producer completes, bypassing the ready queue.)
 
             if (slot_state->task_attrs.requires_sync_start()) {
                 if (is_pending) {
@@ -501,7 +501,6 @@ void SchedulerContext::dispatch_shape(
         flush_publish();
         for (int i = 0; i < published_n; i++) {
             sched_->record_published_blocks(*published_list[i], published_counts[i]);
-            sched_->propagate_dispatch_fanin(*published_list[i]);
         }
 #if SIMPLER_SCHED_PROFILING
         chip_swimlane.sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
@@ -708,19 +707,14 @@ int32_t SchedulerContext::stage_consumer_blocks(
         wmb();
     }
     sched_->record_published_blocks(*c, staged);
-    // Retry unconditionally after publication. The guards are cheap, and a
-    // pre-ring state read can become stale if release completes before this
-    // count update.
-    sched_->propagate_dispatch_fanin(*c);
     return staged;
 }
 
 // Early-dispatch analog of dispatch_shape: drain early_dispatch_queues[shape] and
 // pre-stage claimed block ranges onto this thread's `shape` cores for `phase`. IDLE
 // stages onto idle cores (RUNNING slot, gated); PENDING stages onto a running core's
-// gated pending slot. Candidates are pushed to the shape's queue EVENT-DRIVEN by
-// propagate_dispatch_fanin, so the shape is the queue index (no per-consumer
-// to_shape()). Returns the number of blocks staged.
+// gated pending slot. A candidate is queued under its own shape, so the shape is
+// the queue index (no per-consumer to_shape()). Returns the number of blocks staged.
 int32_t
 SchedulerContext::early_dispatch_shape(int32_t thread_idx, ResourceShape shape, CoreTracker::DispatchPhase phase) {
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -773,9 +767,9 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, ResourceShape shape, 
         int32_t freecores = bucket.has_value() ? bucket.count() : 0;
         if (freecores == 0) {  // no cores for this shape+phase — give this + the unprocessed rest back
             // A dropped candidate keeps its STAGING claim and is recovered by the
-            // producer release: try_early_dispatch_release rings whatever is staged
-            // and routes the unstaged remainder to the ready queue, because it
-            // returns on next_block_idx rather than on the claim state.
+            // producer release, which rings whatever is staged and routes the
+            // unstaged remainder to the ready queue: release decides on
+            // next_block_idx rather than on the claim state.
             if (!sched_->early_dispatch_queues[s].push_batch_tagged(&batch[bi], &task_id_snapshots[bi], got - bi))
                 LOG_DEBUG(
                     "[EARLY_DISPATCH] queue full on batch re-push, dropping %d candidate(s) to normal dispatch",
@@ -830,6 +824,33 @@ int32_t SchedulerContext::try_early_dispatch(
 
     int32_t total_staged = 0;
 
+    // Publish-list drain: rescan the waiters a producer's publish event
+    // detached. An all-published verdict claims the candidate and queues it
+    // for pre-staging. The batch bound keeps one huge-fanout chain from
+    // long-tailing a single idle pass; the remainder goes back to the queue.
+    ChipTaskSlotState *waiter = nullptr;
+    if (sched_->ed_publish_drain_queue.size() > 0 && sched_->ed_publish_drain_queue.pop_batch(&waiter, 1) == 1) {
+        int32_t processed = 0;
+        while (waiter != nullptr && processed < ED_PUBLISH_DRAIN_BATCH_MAX) {
+            ChipTaskSlotState *next = waiter->next_in_ed_publish_list;
+            const bool all_published = sched_->advance_ed_publish_scan(*waiter);
+#if SIMPLER_SCHED_PROFILING
+            sched_->ed_publish_stats.waiters_rescanned.fetch_add(1, std::memory_order_relaxed);
+            if (all_published) {
+                sched_->ed_publish_stats.candidates_ready.fetch_add(1, std::memory_order_relaxed);
+            } else {
+                sched_->ed_publish_stats.rehangs.fetch_add(1, std::memory_order_relaxed);
+            }
+#endif
+            if (all_published) sched_->enqueue_early_dispatch_candidate(*waiter);
+            processed++;
+            waiter = next;
+        }
+        if (waiter != nullptr && !sched_->ed_publish_drain_queue.push(waiter)) {
+            sched_->ed_publish_drain_drops.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+
     // ===== Tier 0: sync_start cohorts (highest occupancy tier, all-or-nothing) =====
     // sync_start candidates park in their own shape-agnostic queue. They cannot ride
     // early_dispatch_shape's per-thread partial range-claim: a partial cohort would strand
@@ -860,7 +881,7 @@ int32_t SchedulerContext::try_early_dispatch(
                 c->to_payload().running_slot_count.store(
                     static_cast<int16_t>(staged.running_cores), std::memory_order_seq_cst
                 );
-                sched_->retry_sync_start_rendezvous_after_staging(*c);
+                sched_->maybe_rendezvous_ring(*c);
                 SchedulerState::finish_early_sync_drain(c->to_payload());
                 total_staged += staged.staged_blocks;
             } else if (enter_drain_mode(c, c->logical_block_num)) {
@@ -899,7 +920,7 @@ int32_t SchedulerContext::try_early_dispatch(
 // =============================================================================
 
 // P owns no AICore cores. It drains the per-S CompletedTaskQueues and runs
-// on_task_complete for every finished task: publish completion_flags, drain the
+// on_task_complete for every finished task: publish progress_flags, drain the
 // wake list (route/re-register waiters into the ready queues). As the sole
 // producer of the ready queues its enqueues never contend. P owns
 // completed_tasks_ and the terminal completed_ flip, so the S threads keep

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -126,7 +126,7 @@ scalar `rt_orchestration_done` publishes into the runtime header.
 **Why the scheduler state is device-written.** `SchedulerState` holds no
 per-run content: `sm_header` and the task-header pointer derive from a pooled SM base,
 queue capacities are compile-time constants, polling reserves no wiring or
-dependency pool (readiness comes from the task table's `completion_flags`, which
+dependency pool (readiness comes from the task table's `progress_flags`, which
 the task header owns), and it has no host-side entry point at all. So the host would
 only be writing an initialization pattern — 203,392 bytes
 of it, dominated by `AsyncWaitList::entries` — for the device to receive and never
@@ -181,7 +181,7 @@ past `total_tasks`. So the SM H2D shipped each run is bounded, not capacity-size
 the contract that keeps `bind` proportional to the workload.
 
 The header is zeroed on the host; `descriptors`, `payloads`, `slot_states` and
-`completion_flags` are each written per task at submit. Per-slot reset is
+`progress_flags` are each written per task at submit. Per-slot reset is
 init-on-write in `orch::prepare_task` as each slot is claimed — there is no
 table-wide reset. In the mirror those four live prefixes are a full reservation
 apart, so `compact_live_image` restacks them (plus the three argument pools) into
@@ -214,7 +214,7 @@ therefore also its slot index: ids run `0..capacity-1`, never wrap, and every
 segment is indexed by the id directly — there is no slot mask, so the capacity need
 not be a power of two.
 
-Completion is published per task, in `completion_flags[local_id]`, and reclaims
+Completion is published per task, in `progress_flags[local_id]`, and reclaims
 neither task slots nor heap.
 
 There is no post-run sweep that makes graph space reusable. Runtime destruction
@@ -299,9 +299,18 @@ producer transition and does not require periodic dependency polling.
 The dispatchable shapes are `AIC`, `AIV`, and `MIX`; dependency-only `DUMMY`
 tasks use a dedicated queue and complete without AICore dispatch.
 
-Early producer propagation is currently disabled in HBG. The shared scheduler
-retains early-staging code for parity with `tensormap_and_ringbuffer`, but HBG's
-boot classifier and wake lists are the active readiness path.
+Early dispatch is detected by the publish list, the wake list's dual keyed on
+publication instead of completion. The host qualifies candidates at submit
+(at least one producer, every producer flagged and none of them a Graph shell —
+a shell has no publication event — no dispatch predicate, dispatchable
+shape) and sorts
+a candidate's fanin row by ascending local id; a candidate hangs on its
+latest-submitted unpublished producer, the producer's publish event seals the
+chain (sentinel
+exchange) and hands the detached waiters to idle threads, and an all-published
+rescan verdict queues the candidate for pre-staging. Release rings the staged
+doorbells at the ready funnel (`push_ready_routed`), the moment readiness is
+decided. Completion readiness itself remains the boot classifier + wake lists.
 
 ## 7. Dispatch and Completion
 

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -598,7 +598,7 @@ int32_t run_host_orchestration(
     // The dep_gen graph belongs to the orchestration that is about to run.
     dep_gen_host_graph_begin_capture();
 
-    // Init-on-write: descriptors, payloads, slot_states and completion_flags are
+    // Init-on-write: descriptors, payloads, slot_states and progress_flags are
     // each written per task at submit and read only for [0, total_tasks). Zero
     // only the fixed-size header here; the per-slot segments are initialized in
     // orch::prepare_task and shipped bounded to total_tasks below.

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.cpp
@@ -108,4 +108,31 @@ void SchedulerState::print_queues() {
         (unsigned long long)sched->early_sync_start_queue.enqueue_pos.load(std::memory_order_relaxed),
         (unsigned long long)sched->early_sync_start_queue.max_occupancy.load(std::memory_order_relaxed)
     );
+    const uint64_t pub_drops = sched->ed_publish_drain_drops.load(std::memory_order_relaxed);
+    LOG_TIMING(
+        "QPROBE ed_pubdrain pushes=%llu maxocc=%llu cap=%llu drops=%llu",
+        (unsigned long long)sched->ed_publish_drain_queue.enqueue_pos.load(std::memory_order_relaxed),
+        (unsigned long long)sched->ed_publish_drain_queue.max_occupancy.load(std::memory_order_relaxed),
+        (unsigned long long)sched->ed_publish_drain_queue.capacity, (unsigned long long)pub_drops
+    );
+    if (pub_drops > 0) {
+        LOG_WARN(
+            "[EARLY_DISPATCH] publish-drain queue dropped %llu chain(s); those candidates fell back to normal "
+            "dispatch",
+            (unsigned long long)pub_drops
+        );
+    }
+#if SIMPLER_SCHED_PROFILING
+    LOG_TIMING(
+        "QPROBE ed_publist registered=%llu immediate=%llu seals=%llu detached=%llu rescanned=%llu rehangs=%llu "
+        "ready=%llu",
+        (unsigned long long)sched->ed_publish_stats.registered.load(std::memory_order_relaxed),
+        (unsigned long long)sched->ed_publish_stats.immediate_at_intake.load(std::memory_order_relaxed),
+        (unsigned long long)sched->ed_publish_stats.publish_seals.load(std::memory_order_relaxed),
+        (unsigned long long)sched->ed_publish_stats.chains_detached.load(std::memory_order_relaxed),
+        (unsigned long long)sched->ed_publish_stats.waiters_rescanned.load(std::memory_order_relaxed),
+        (unsigned long long)sched->ed_publish_stats.rehangs.load(std::memory_order_relaxed),
+        (unsigned long long)sched->ed_publish_stats.candidates_ready.load(std::memory_order_relaxed)
+    );
+#endif
 }

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -15,11 +15,11 @@
  * The Scheduler is responsible for:
  * 1. Maintaining per-resource-shape ready queues
  * 2. Polling-completion dependency resolution: a GLOBAL task is ready when every
- *    producer named in its inline fanin has set its completion_flags byte, an
+ *    producer named in its inline fanin has set its progress_flags byte, an
  *    IN_GRAPH one when every producer in its Graph's fanin wire has reached
  *    task_state == COMPLETED (that table has no flag bytes); a producer publishes
  *    completion + drains its wake list on finish
- * 3. Publishing completion (task_state PENDING -> COMPLETED, completion_flags byte)
+ * 3. Publishing completion (task_state PENDING -> COMPLETED, progress_flags byte)
  * 4. Two-stage mixed-task completion (subtask done bits -> mixed-task complete)
  *
  * The Scheduler runs on Device AI_CPU. host_build_graph is scheduler-only (the
@@ -481,6 +481,7 @@ struct SchedulerLayout {
     size_t off_graph_prepare_queue_slots;
     size_t off_early_dispatch_queue_slots[NUM_RESOURCE_SHAPES];
     size_t off_early_sync_start_queue_slots;
+    size_t off_ed_publish_drain_queue_slots;
     ReadyQueueCapacities capacities;
 };
 
@@ -500,7 +501,7 @@ struct SchedulerState {
         SharedMemoryTaskHeader *tasks;
 
         // Polling: no dep_pool. Readiness is derived from the task table's
-        // completion_flags; there is no arena-side wiring pool to reserve or wire.
+        // progress_flags; there is no arena-side wiring pool to reserve or wire.
         // The `tasks` field stores the device address of the SM task header —
         // computed via offset arithmetic, no SM dereference.
         bool init_data_from_layout(void *sm_dev_base);
@@ -563,6 +564,21 @@ struct SchedulerState {
     }
 
     void push_ready_routed(ChipTaskSlotState *slot_state) {
+        // Early-dispatch release: a pre-staged candidate launches by doorbell
+        // right here — the moment its readiness is decided — and skips the
+        // queue round-trip. Only host-qualified candidates can hold a staging
+        // claim, so every other task pays one hot-line flag test. A ready
+        // sync_start candidate also publishes to its drain owner, which may
+        // already hold it for an all-or-nothing stage.
+        if ((slot_state->ed_flags & ED_FLAG_CANDIDATE) != 0) {
+            const bool early_handled = try_early_dispatch_release(*slot_state);
+            if (slot_state->task_attrs.requires_sync_start()) {
+                const bool drain_owned = publish_ready_to_early_sync_drain(slot_state->to_payload());
+                if (early_handled || drain_owned) return;
+            } else if (early_handled) {
+                return;
+            }
+        }
         bool pushed;
         if (slot_state->task_kind == TaskKind::GRAPH) {
             pushed = graph_ready_queue.push(slot_state);
@@ -591,24 +607,35 @@ struct SchedulerState {
 
     // ---- Polling completion primitives ---------------------------------------
     // Readiness: a task is ready iff every producer named in its inline fanin has
-    // set its completion_flags byte. A producer is named by its local id alone, so
+    // set its progress_flags byte. A producer is named by its local id alone, so
     // there is no per-edge indirection.
 
     // Unmet-fanin classification. Returns -1 (all fanins met -> route to ready)
     // or the index of an unmet fanin (register on that producer's wake list).
     // Scan direction is load-bearing: the builder fills the fanin region in
-    // submission order, so the last unmet entry is the latest-submitted
-    // producer -- the one likeliest to complete last. Targeting it minimises
+    // submission order (and an early-dispatch candidate's row is sorted by
+    // local id, making the order exact), so the last unmet entry is the
+    // latest-submitted producer -- the one likeliest to complete last.
+    // Targeting it minimises
     // wake-list transfers (a consumer re-registered onto a second producer once
     // its first one completes) and the CAS traffic those transfers put on the
     // lists. The decision is terminal: tasks are never re-polled; a producer's
     // completion re-scans its waiters via on_mixed_task_complete's wake drain.
-    int classify_fanin_state(const ChipTaskSlotState *s) const {
+    // Resumes at the wake-scan cursor: entries above it were completed at the
+    // last classification and completion bits are monotonic, so re-walking
+    // them cannot change the verdict. An unmet verdict records itself as the
+    // new cursor — the caller hangs the task exactly there, and this
+    // classifier is the task's only owner at that moment.
+    int classify_fanin_state(ChipTaskSlotState *s) const {
         const TaskPayload &p = s->to_payload();
         const SharedMemoryTaskHeader &tasks = *task_view.tasks;
         const int32_t *fanin = p.fanin_data();
-        for (int32_t i = p.fanin_count - 1; i >= 0; i--) {
-            if (!tasks.is_completion_flag_set(fanin[i])) return i;
+        const int32_t start = s->wake_scan_cursor < p.fanin_count ? s->wake_scan_cursor : p.fanin_count - 1;
+        for (int32_t i = start; i >= 0; i--) {
+            if (!tasks.is_completion_flag_set(fanin[i])) {
+                s->wake_scan_cursor = static_cast<uint8_t>(i);
+                return i;
+            }
         }
         return -1;
     }
@@ -616,7 +643,7 @@ struct SchedulerState {
     // Register `consumer` on `producer`'s wake list. If the producer already
     // completed (head == SENTINEL), re-classify against ALL fanins: route to
     // ready only when every fanin is met, else re-target the next unmet producer
-    // and retry. Monotonic completion_flags guarantee termination.
+    // and retry. Monotonic progress_flags guarantee termination.
     void register_wake(ChipTaskSlotState *producer, ChipTaskSlotState *consumer) {
         SharedMemoryTaskHeader &tasks = *task_view.tasks;
         while (true) {
@@ -639,7 +666,7 @@ struct SchedulerState {
     }
 
     // Producer completion under polling: publish the task_state completion
-    // mirror + the device-visible completion_flags byte, then drain the wake list
+    // mirror + the device-visible progress_flags byte, then drain the wake list
     // (route/re-register each waiter). Whole-graph-resident hbg
     // has no device slot reclaim, so nothing advances a reclaim cursor here.
     void on_mixed_task_complete(ChipTaskSlotState &slot_state) {
@@ -648,6 +675,10 @@ struct SchedulerState {
 
         slot_state.mark_completed();  // completion mirror (task_state = COMPLETED)
         tasks.set_completion_flag(task_id);
+        // The completion byte carries the publish bit, so a tracked producer
+        // that never published (DUMMY, predicate-retired) still releases its
+        // publish-list waiters here. Idempotent after a publish-time seal.
+        if ((slot_state.ed_flags & ED_FLAG_TRACKED) != 0) seal_ed_publish_list(slot_state);
 
         ChipTaskSlotState *waiter = slot_state.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
         while (waiter != nullptr && waiter != WAKE_LIST_SENTINEL) {
@@ -728,6 +759,29 @@ struct SchedulerState {
     // otherwise. HBG producer propagation currently leaves this queue dormant.
     ChipReadyQueue early_sync_start_queue;
 
+    // Pending-drain queue of the publish list. Each entry is the head of a
+    // waiter chain a producer's publish event sealed and detached; idle
+    // threads pop one per Phase 4b pass and rescan its waiters. A full queue
+    // drops the chain — those candidates miss early dispatch and proceed on
+    // the normal ready path; nothing blocks. The drop count surfaces at
+    // teardown (no log on the dispatch path).
+    ChipReadyQueue ed_publish_drain_queue;
+    std::atomic<uint64_t> ed_publish_drain_drops{0};
+
+#if SIMPLER_SCHED_PROFILING
+    // Publish-list probe. Relaxed counters, read once at teardown.
+    struct EdPublishListStats {
+        std::atomic<uint64_t> registered{0};           // candidates hung at intake
+        std::atomic<uint64_t> immediate_at_intake{0};  // all-published already at intake
+        std::atomic<uint64_t> publish_seals{0};        // tracked producers fully published
+        std::atomic<uint64_t> chains_detached{0};      // seals that handed off a non-empty chain
+        std::atomic<uint64_t> waiters_rescanned{0};
+        std::atomic<uint64_t> rehangs{0};           // bet missed: waiter moved to another producer
+        std::atomic<uint64_t> candidates_ready{0};  // all-published verdicts (ED triggers)
+    };
+    EdPublishListStats ed_publish_stats;
+#endif
+
     static inline void ring_one_doorbell(uint64_t reg_addr, uint32_t token) {
         volatile uint64_t *dmb = reinterpret_cast<volatile uint64_t *>(get_reg_ptr(reg_addr, RegId::DATA_MAIN_BASE));
         uint64_t tk = static_cast<uint64_t>(token);
@@ -770,9 +824,187 @@ struct SchedulerState {
         );
     }
 
+    // All-published verdict -> ED queue. The exactly-once claim is the
+    // NONE->STAGING CAS: a consumer that already became ready lost the state
+    // to the release path's NONE->DISPATCHED and is dropped here. A failed
+    // push returns the claim so readiness takes the ordinary queue path.
+    inline void enqueue_early_dispatch_candidate(ChipTaskSlotState &consumer) {
+        uint8_t expected = EARLY_DISPATCH_NONE;
+        if (!consumer.to_payload().early_dispatch_state.compare_exchange_strong(
+                expected, EARLY_DISPATCH_STAGING, std::memory_order_seq_cst, std::memory_order_seq_cst
+            )) {
+            return;
+        }
+        const uint64_t task_id = static_cast<uint64_t>(consumer.to_descriptor().task_id.raw);
+        // A sync_start cohort parks in the shape-agnostic queue so one owner can
+        // choose an all-or-nothing local stage or the global-drain fallback.
+        const bool queued =
+            consumer.task_attrs.requires_sync_start() ?
+                early_sync_start_queue.push_tagged(&consumer, task_id) :
+                early_dispatch_queues[static_cast<int32_t>(consumer.active_mask.to_shape())].push_tagged(
+                    &consumer, task_id
+                );
+        if (!queued) {
+            expected = EARLY_DISPATCH_STAGING;
+            consumer.to_payload().early_dispatch_state.compare_exchange_strong(
+                expected, EARLY_DISPATCH_NONE, std::memory_order_seq_cst, std::memory_order_seq_cst
+            );
+        }
+    }
+
+    // Early-dispatch release, run at the ready funnel the moment readiness is
+    // decided. Returns true when the task is fully handled (every block
+    // launches by doorbell) and must NOT be queued. Returns false to route
+    // normally: never pre-staged, or a partially staged SPMD consumer whose
+    // remaining blocks dispatch off the ready queue from next_block_idx.
+    // Lock-free claim shared with the stagers: winning CAS NONE->DISPATCHED
+    // means not pre-staged; otherwise flip STAGING->DISPATCHED and
+    // destructively claim the published doorbell bits — a late stager rings
+    // only the bits this pass did not take, so each gated core has exactly
+    // one doorbell writer.
+    inline bool try_early_dispatch_release(ChipTaskSlotState &slot_state) {
+        TaskPayload &payload = slot_state.to_payload();
+        uint8_t expect = EARLY_DISPATCH_NONE;
+        if (payload.early_dispatch_state.compare_exchange_strong(
+                expect, EARLY_DISPATCH_DISPATCHED, std::memory_order_seq_cst, std::memory_order_seq_cst
+            )) {
+            return false;
+        }
+        // Defensive: a duplicate that observes an in-progress launch must never
+        // route the same partial task a second time.
+        if (expect != EARLY_DISPATCH_STAGING) return true;
+        const bool sync_start = slot_state.task_attrs.requires_sync_start();
+        if (!sync_start && !try_claim_early_dispatch_launch(payload)) return true;
+        expect = EARLY_DISPATCH_STAGING;
+        payload.early_dispatch_state.compare_exchange_strong(
+            expect, EARLY_DISPATCH_DISPATCHED, std::memory_order_seq_cst, std::memory_order_seq_cst
+        );
+        if (sync_start) {
+            // The flip to DISPATCHED is only the producer-released half of the
+            // rendezvous; the ring fires once every gated core also occupies a
+            // running slot, from whichever half completes second.
+            maybe_rendezvous_ring(slot_state);
+        } else {
+            for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
+                uint64_t owned = claim_all_staged_doorbell_bits(payload.staged_core_mask[w]);
+                ring_staged_doorbell_bits(w, owned);
+            }
+            wmb();
+            payload.early_dispatch_launch_state.store(EARLY_DISPATCH_LAUNCH_COMPLETE, std::memory_order_seq_cst);
+        }
+        // A still-queued early-dispatch entry for this consumer is now
+        // DISPATCHED and is dropped when a peer pops it.
+        return slot_state.next_block_idx.load(std::memory_order_seq_cst) >= slot_state.logical_block_num;
+    }
+
+    // Publication accounting for the producers early dispatch watches. Only
+    // ED_FLAG_TRACKED tasks pay: the host set that bit exactly on the
+    // producers of at least one candidate. When the count reaches the task's
+    // logical blocks, the publish byte-bit is set and the publish list is
+    // sealed — everything past that leaves the dispatch path.
+    //
+    // "Published" counts placement, not launch: a gated candidate's staged
+    // blocks publish here too, so its consumers may pre-stage while it still
+    // waits for its own doorbell. Such chains cannot deadlock on cores: a
+    // consumer is detected only after this seal, hence after every producer
+    // block already occupies its slot, so every waits-for edge between gated
+    // tasks points from a later-staged task to an earlier-staged one — the
+    // earliest unreleased gated task has only completed or released
+    // producers, rings, and unwinds the chain in staging order. (The
+    // reclaiming tensormap_and_ringbuffer runtime instead defers propagation
+    // to launch visibility; whole-graph-resident hbg holds no reclaimable
+    // resource a gated chain could pin, so placement is the sufficient gate.)
     inline void record_published_blocks(ChipTaskSlotState &slot_state, int32_t count) {
-        if (count <= 0 || !slot_state.task_attrs.allow_early_resolve()) return;
-        slot_state.to_payload().published_block_count.fetch_add(static_cast<int16_t>(count), std::memory_order_seq_cst);
+        if (count <= 0 || (slot_state.ed_flags & ED_FLAG_TRACKED) == 0) return;
+        const int16_t total = static_cast<int16_t>(
+            slot_state.to_payload().published_block_count.fetch_add(
+                static_cast<int16_t>(count), std::memory_order_seq_cst
+            ) +
+            count
+        );
+        if (total == slot_state.logical_block_num) seal_ed_publish_list(slot_state);
+    }
+
+    // Publish event of a tracked producer: publish bit, then seal. The order
+    // pairs with the acquire loads in advance_ed_publish_scan — a scanner that
+    // meets the sentinel is guaranteed to read the bit as set. The exchange
+    // makes the seal exactly-once (a second call gets the sentinel back), so
+    // the completion path can call this too for tracked producers that never
+    // publish (DUMMY / predicate-retired), whose completion byte carries the
+    // publish bit. A full pending-drain queue drops the chain: those
+    // candidates miss early dispatch, nothing blocks.
+    inline void seal_ed_publish_list(ChipTaskSlotState &slot_state) {
+        // The sentinel is monotone (set once, never cleared), so an
+        // already-sealed list needs neither the flag RMW nor the exchange.
+        if (slot_state.ed_publish_list_head.load(std::memory_order_acquire) == ED_PUBLISH_LIST_SENTINEL) return;
+        const int32_t local_id = slot_state.to_descriptor().task_id.local_id();
+        task_view.tasks->set_publish_flag(local_id);
+        ChipTaskSlotState *head =
+            slot_state.ed_publish_list_head.exchange(ED_PUBLISH_LIST_SENTINEL, std::memory_order_acq_rel);
+        if (head == ED_PUBLISH_LIST_SENTINEL) return;
+#if SIMPLER_SCHED_PROFILING
+        ed_publish_stats.publish_seals.fetch_add(1, std::memory_order_relaxed);
+#endif
+        if (head == nullptr) return;
+#if SIMPLER_SCHED_PROFILING
+        ed_publish_stats.chains_detached.fetch_add(1, std::memory_order_relaxed);
+#endif
+        if (!ed_publish_drain_queue.push(head)) {
+            ed_publish_drain_drops.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+
+    // Resume candidate `c`'s publish scan at its cursor. The row is sorted and
+    // publish bits are monotonic, so entries above the cursor stay published
+    // forever and each entry is loaded once per life. Returns true when every
+    // producer is published — the early-dispatch trigger; false when `c` was
+    // re-hung on a still-unpublished producer's publish list. A hang CAS that
+    // meets the sentinel treats the producer as published and advances.
+    bool advance_ed_publish_scan(ChipTaskSlotState &c) {
+        SharedMemoryTaskHeader &tasks = *task_view.tasks;
+        const TaskPayload &p = c.to_payload();
+        const int32_t *fanin = p.fanin_data();
+        int32_t i = c.ed_publish_scan_cursor;
+        while (i >= 0) {
+            if (tasks.is_publish_flag_set(fanin[i])) {
+                i--;
+                continue;
+            }
+            ChipTaskSlotState &producer = tasks.get_slot_state_by_task_id(fanin[i]);
+            ChipTaskSlotState *expected = producer.ed_publish_list_head.load(std::memory_order_acquire);
+            bool hung = false;
+            while (expected != ED_PUBLISH_LIST_SENTINEL) {
+                c.next_in_ed_publish_list = expected;
+                if (producer.ed_publish_list_head.compare_exchange_weak(
+                        expected, &c, std::memory_order_acq_rel, std::memory_order_acquire
+                    )) {
+                    hung = true;
+                    break;
+                }
+            }
+            if (hung) {
+                c.ed_publish_scan_cursor = static_cast<uint8_t>(i);
+                return false;
+            }
+            // Sentinel: the producer published between the bit load and here.
+            i--;
+        }
+        return true;
+    }
+
+    // Publish-list registration at intake. Only called for a candidate that
+    // is not yet ready (its completion classification hung it on a wake list).
+    // Returns true when every producer is already published at intake.
+    bool register_on_ed_publish_list(ChipTaskSlotState &c) {
+        c.ed_publish_scan_cursor = static_cast<uint8_t>(c.to_payload().fanin_count - 1);
+#if SIMPLER_SCHED_PROFILING
+        ed_publish_stats.registered.fetch_add(1, std::memory_order_relaxed);
+#endif
+        const bool all_published = advance_ed_publish_scan(c);
+#if SIMPLER_SCHED_PROFILING
+        if (all_published) ed_publish_stats.immediate_at_intake.fetch_add(1, std::memory_order_relaxed);
+#endif
+        return all_published;
     }
 
     // Ring one sync_start cohort from its stable staged_core_mask. The caller owns
@@ -868,23 +1100,6 @@ struct SchedulerState {
         );
         return true;
     }
-
-    inline bool retry_sync_start_rendezvous_after_staging(ChipTaskSlotState &slot_state) {
-        if (!maybe_rendezvous_ring(slot_state)) return false;
-        propagate_dispatch_fanin(slot_state);
-        return true;
-    }
-
-    // Milestone 1: early-dispatch (predicated / allow_early_resolve) is stubbed.
-    // This producer-push propagation walked the wiring fanout list bumping each
-    // consumer's dispatch_fanin to pre-stage early-dispatch candidates — all of
-    // which (fanout_head, dispatch_fanin, fanin_actual_count, dispatch_propagated)
-    // are gone under polling. Nothing pre-stages into early_dispatch_queues /
-    // early_sync_start_queue, so tasks reach cores only through the normal ready
-    // path (wake drain -> push_ready_routed). Milestone 2 replaces this with the
-    // consumer-pull publish_flags design. sync_start cohorts still launch via
-    // ready_sync_queues (unaffected).
-    void propagate_dispatch_fanin(ChipTaskSlotState & /*p*/) {}
 
     int get_ready_tasks_batch(ChipReadyQueue *queues, ResourceShape shape, ChipTaskSlotState **out, int max_count) {
         return queues[static_cast<int32_t>(shape)].pop_batch(out, max_count);
@@ -1148,7 +1363,7 @@ struct SchedulerState {
 #endif
     ) {
         // Polling completion: publish the task_state completion mirror + the
-        // device-visible completion_flags byte and drain the wake list (route or
+        // device-visible progress_flags byte and drain the wake list (route or
         // re-register each waiter). Replaces the
         // fanout-list walk + fanin_refcount decrements of the wiring model.
         on_mixed_task_complete(slot_state);

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -219,7 +219,7 @@ void SchedulerContext::log_stall_diagnostics(
             ChipTaskSlotState &slot_state = tasks.get_slot_state_by_task_id(si);
             ChipTaskState st = slot_state.task_state.load(std::memory_order_relaxed);
             // Polling: no fanin_refcount. Recompute met/total from the inline
-            // fanin ids vs the completion_flags (rc = satisfied producers,
+            // fanin ids vs the progress_flags (rc = satisfied producers,
             // fi = raw producer count) so the stall dump still shows readiness.
             int32_t fi = slot_state.to_payload().fanin_count;
             int32_t rc = 0;
@@ -1098,6 +1098,16 @@ void SchedulerContext::classify_partition(int32_t thread_idx, int32_t nthreads) 
         } else {
             int32_t prod_local = slot.to_payload().fanin_data()[state];
             sched_->register_wake(&tasks.get_slot_state_by_task_id(prod_local), &slot);
+            // A not-yet-ready candidate also enters the publish list, hung on
+            // its latest-submitted unpublished producer — or, when every
+            // producer is already published at intake (pre-completed fanin),
+            // goes straight to the ED queue. An already-ready task never does:
+            // there is nothing left to pre-stage ahead of.
+            if ((slot.ed_flags & ED_FLAG_CANDIDATE) != 0) {
+                if (sched_->register_on_ed_publish_list(slot)) {
+                    sched_->enqueue_early_dispatch_candidate(slot);
+                }
+            }
         }
     }
 }

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -191,7 +191,7 @@ void SchedulerContext::complete_slot_task(
         }
 #endif
         // 3S+1P: hand the finished task to the dedicated resolution (P) thread.
-        // P publishes completion_flags and drains the wake list — and owns
+        // P publishes progress_flags and drains the wake list — and owns
         // completed_tasks_, so this scheduler thread neither
         // resolves nor bumps completed_this_turn. (The Resolve swimlane bar is
         // emitted by P, not here.)
@@ -277,7 +277,7 @@ void SchedulerContext::check_running_cores_for_completion(
         // waiting for its doorbell — it physically cannot ACK/FIN yet, so
         // reading its COND (MMIO, and the core is hot-spinning on its own SPR)
         // every poll is pure waste that drags out the completion phase. The
-        // doorbell (try_early_dispatch_release) flips early_dispatch_state to DISPATCHED, at
+        // producer-release doorbell flips early_dispatch_state to DISPATCHED, at
         // which point the core becomes pollable again and its FIN is caught.
         // Cheap cacheable load; no MMIO. Pending slot is empty while gated.
         {
@@ -401,9 +401,7 @@ void SchedulerContext::check_running_cores_for_completion(
                 promote_pending_to_running(core);  // Case 2 or Case 3 (with pending)
                 if (sync_start_promote) {
                     promoted->to_payload().running_slot_count.fetch_add(1, std::memory_order_seq_cst);
-                    if (sched_->maybe_rendezvous_ring(*promoted)) {
-                        sched_->propagate_dispatch_fanin(*promoted);
-                    }
+                    sched_->maybe_rendezvous_ring(*promoted);
                 }
             } else {
                 clear_running_slot(core);  // Case 1 or Case 3 (no pending)
@@ -757,7 +755,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     // attempt remains published while the gate is open; the next drain owner advances it
     // behind the -1 sentinel. Followers identify reopen by gate-open or attempt change.
     // `slot_state` is a local holding the fa_fused slot (not drain_state_), so it stays valid for
-    // the propagate below even if a new drain reuses pending_task after reopen.
+    // the rendezvous retry below even if a new drain reuses pending_task after reopen.
     std::atomic_thread_fence(std::memory_order_release);
     drain_state_.pending_task.store(nullptr, std::memory_order_release);
     drain_state_.drain_stage_go.store(0, std::memory_order_relaxed);
@@ -768,9 +766,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     // ahead of drain completion and fail while running_slot_count is still incomplete. When
     // every block landed directly in a running slot, no pending promotion remains to retry it.
     if (gated) {
-        sched_->retry_sync_start_rendezvous_after_staging(*slot_state);
-    } else {
-        sched_->propagate_dispatch_fanin(*slot_state);
+        sched_->maybe_rendezvous_ring(*slot_state);
     }
     SchedulerState::finish_early_sync_drain(slot_state->to_payload());
 }

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -142,7 +142,7 @@ public:
 
     // Dedicated resolution (P) thread entry (3S+1P). Owns no cores: drains the
     // per-S CompletedTaskQueues and runs on_task_complete for each finished task
-    // (completion_flags publish + wake-list drain), making P
+    // (progress_flags publish + wake-list drain), making P
     // the sole producer of the ready queues. Owns completed_tasks_ / termination.
     int32_t run_resolution_thread(Runtime *runtime, int32_t thread_idx);
 

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -426,9 +426,9 @@ void SchedulerContext::dispatch_shape(
                 }
             }
 
-            // (Early-dispatch pre-staged tasks never reach this ready-pop: they are
-            // released by their doorbell in release_fanin_and_check_ready the
-            // instant their last producer completes — see try_early_dispatch_release.)
+            // (Early-dispatch pre-staged tasks never reach this ready-pop: the
+            // completion path rings their doorbell the instant their last
+            // producer completes, bypassing the ready queue.)
 
             if (slot_state->task_attrs.requires_sync_start()) {
                 if (is_pending) {
@@ -502,7 +502,6 @@ void SchedulerContext::dispatch_shape(
         flush_publish();
         for (int i = 0; i < published_n; i++) {
             sched_->record_published_blocks(*published_list[i], published_counts[i]);
-            sched_->propagate_dispatch_fanin(*published_list[i]);
         }
 #if SIMPLER_SCHED_PROFILING
         chip_swimlane.sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
@@ -709,19 +708,14 @@ int32_t SchedulerContext::stage_consumer_blocks(
         wmb();
     }
     sched_->record_published_blocks(*c, staged);
-    // Retry unconditionally after publication. The guards are cheap, and a
-    // pre-ring state read can become stale if release completes before this
-    // count update.
-    sched_->propagate_dispatch_fanin(*c);
     return staged;
 }
 
 // Early-dispatch analog of dispatch_shape: drain early_dispatch_queues[shape] and
 // pre-stage claimed block ranges onto this thread's `shape` cores for `phase`. IDLE
 // stages onto idle cores (RUNNING slot, gated); PENDING stages onto a running core's
-// gated pending slot. Candidates are pushed to the shape's queue EVENT-DRIVEN by
-// propagate_dispatch_fanin, so the shape is the queue index (no per-consumer
-// to_shape()). Returns the number of blocks staged.
+// gated pending slot. A candidate is queued under its own shape, so the shape is
+// the queue index (no per-consumer to_shape()). Returns the number of blocks staged.
 int32_t
 SchedulerContext::early_dispatch_shape(int32_t thread_idx, ResourceShape shape, CoreTracker::DispatchPhase phase) {
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -774,9 +768,9 @@ SchedulerContext::early_dispatch_shape(int32_t thread_idx, ResourceShape shape, 
         int32_t freecores = bucket.has_value() ? bucket.count() : 0;
         if (freecores == 0) {  // no cores for this shape+phase — give this + the unprocessed rest back
             // A dropped candidate keeps its STAGING claim and is recovered by the
-            // producer release: try_early_dispatch_release rings whatever is staged
-            // and routes the unstaged remainder to the ready queue, because it
-            // returns on next_block_idx rather than on the claim state.
+            // producer release, which rings whatever is staged and routes the
+            // unstaged remainder to the ready queue: release decides on
+            // next_block_idx rather than on the claim state.
             if (!sched_->early_dispatch_queues[s].push_batch_tagged(&batch[bi], &task_id_snapshots[bi], got - bi))
                 LOG_DEBUG(
                     "[EARLY_DISPATCH] queue full on batch re-push, dropping %d candidate(s) to normal dispatch",
@@ -831,6 +825,33 @@ int32_t SchedulerContext::try_early_dispatch(
 
     int32_t total_staged = 0;
 
+    // Publish-list drain: rescan the waiters a producer's publish event
+    // detached. An all-published verdict claims the candidate and queues it
+    // for pre-staging. The batch bound keeps one huge-fanout chain from
+    // long-tailing a single idle pass; the remainder goes back to the queue.
+    ChipTaskSlotState *waiter = nullptr;
+    if (sched_->ed_publish_drain_queue.size() > 0 && sched_->ed_publish_drain_queue.pop_batch(&waiter, 1) == 1) {
+        int32_t processed = 0;
+        while (waiter != nullptr && processed < ED_PUBLISH_DRAIN_BATCH_MAX) {
+            ChipTaskSlotState *next = waiter->next_in_ed_publish_list;
+            const bool all_published = sched_->advance_ed_publish_scan(*waiter);
+#if SIMPLER_SCHED_PROFILING
+            sched_->ed_publish_stats.waiters_rescanned.fetch_add(1, std::memory_order_relaxed);
+            if (all_published) {
+                sched_->ed_publish_stats.candidates_ready.fetch_add(1, std::memory_order_relaxed);
+            } else {
+                sched_->ed_publish_stats.rehangs.fetch_add(1, std::memory_order_relaxed);
+            }
+#endif
+            if (all_published) sched_->enqueue_early_dispatch_candidate(*waiter);
+            processed++;
+            waiter = next;
+        }
+        if (waiter != nullptr && !sched_->ed_publish_drain_queue.push(waiter)) {
+            sched_->ed_publish_drain_drops.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+
     // ===== Tier 0: sync_start cohorts (highest occupancy tier, all-or-nothing) =====
     // sync_start candidates park in their own shape-agnostic queue. They cannot ride
     // early_dispatch_shape's per-thread partial range-claim: a partial cohort would strand
@@ -861,7 +882,7 @@ int32_t SchedulerContext::try_early_dispatch(
                 c->to_payload().running_slot_count.store(
                     static_cast<int16_t>(staged.running_cores), std::memory_order_seq_cst
                 );
-                sched_->retry_sync_start_rendezvous_after_staging(*c);
+                sched_->maybe_rendezvous_ring(*c);
                 SchedulerState::finish_early_sync_drain(c->to_payload());
                 total_staged += staged.staged_blocks;
             } else if (enter_drain_mode(c, c->logical_block_num)) {
@@ -900,7 +921,7 @@ int32_t SchedulerContext::try_early_dispatch(
 // =============================================================================
 
 // P owns no AICore cores. It drains the per-S CompletedTaskQueues and runs
-// on_task_complete for every finished task: publish completion_flags, drain the
+// on_task_complete for every finished task: publish progress_flags, drain the
 // wake list (route/re-register waiters into the ready queues). As the sole
 // producer of the ready queues its enqueues never contend. P owns
 // completed_tasks_ and the terminal completed_ flip, so the S threads keep

--- a/src/common/host_build_graph/device/graph_execution.cpp
+++ b/src/common/host_build_graph/device/graph_execution.cpp
@@ -49,8 +49,6 @@ void reset_graph_payload(TaskPayload &payload) {
     for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; ++w) {
         payload.staged_core_mask[w].store(0, std::memory_order_relaxed);
     }
-    payload.dispatch_fanin.store(0, std::memory_order_relaxed);
-    payload.dispatch_propagated.store(0, std::memory_order_relaxed);
     payload.published_block_count.store(0, std::memory_order_relaxed);
     payload.early_dispatch_launch_state.store(EARLY_DISPATCH_LAUNCH_NONE, std::memory_order_relaxed);
     payload.running_slot_count.store(0, std::memory_order_relaxed);

--- a/src/common/host_build_graph/host/orchestrator.cpp
+++ b/src/common/host_build_graph/host/orchestrator.cpp
@@ -1304,7 +1304,7 @@ append_fanin_or_fail(OrchestratorState &orch, TaskId producer_task_id, int32_t *
     // its own storage index and hbg never recycles a slot, so the entry that id
     // names is the producer's by construction — there is no stale-slot case to
     // screen for. A COMPLETED producer is a real fanin edge under polling (its
-    // completion_flags byte is set), so it is not screened out either.
+    // progress_flags byte is set), so it is not screened out either.
     if (fanin_mark_seen(orch, producer_task_id)) {
         return true;
     }
@@ -1402,7 +1402,7 @@ static bool prepare_task(
     // past total_tasks, so this claim-time write is the only per-slot SM reset and
     // the unclaimed tail is neither initialized nor read.
     out->slot_state->reset_for_reuse();
-    orch->sm_header->tasks.completion_flags[out->alloc_result.task_id].store(0, std::memory_order_relaxed);
+    orch->sm_header->tasks.progress_flags[out->alloc_result.task_id].store(0, std::memory_order_relaxed);
 
     out->payload->prefetch(args.tensor_count(), args.scalar_count());
 
@@ -1759,6 +1759,36 @@ static TaskOutputTensors submit_task_common(
     debug_assert(orch->fanin_pool_cursor == static_cast<int32_t>(payload.fanin_data() - orch->fanin_pool));
     orch->fanin_pool_cursor += CHIP_ALIGN_UP(payload.fanin_count, ARG_POOL_ALIGN / (int32_t)sizeof(int32_t));
 
+    // Early-dispatch qualification, decided once here where the fanin region is
+    // final. The conjunction is order-independent, so it runs on the row as
+    // filled; only a CANDIDATE's row is then sorted by producer local id — ids
+    // come from the forward-only bump allocator, so ascending id order IS
+    // submission order and the sorted row's tail names the latest-submitted
+    // producer, the one the publish-list bet hangs on. Non-candidate rows keep
+    // their fill order: a flag-free graph schedules exactly as it always has.
+    int32_t *const fanin_row = payload.fanin_data();
+    SharedMemoryTaskHeader &sm_tasks = orch->sm_header->tasks;
+    bool ed_candidate =
+        payload.fanin_count > 0 && !task_attrs.has_predicate() && active_mask.to_shape() != ResourceShape::DUMMY;
+    for (int32_t i = 0; ed_candidate && i < payload.fanin_count; i++) {
+        const ChipTaskSlotState &producer = sm_tasks.get_slot_state_by_task_id(fanin_row[i]);
+        if (producer.task_kind == TaskKind::GRAPH) {
+            // A Graph shell has no publication event, so its consumers schedule
+            // normally.
+            ed_candidate = false;
+        } else if (!producer.task_attrs.allow_early_resolve()) {
+            ed_candidate = false;
+        }
+    }
+    if (ed_candidate) {
+        std::sort(fanin_row, fanin_row + payload.fanin_count);
+        prepared.slot_state->ed_flags |= ED_FLAG_CANDIDATE;
+        // Every producer of a candidate must record its publication state.
+        for (int32_t i = 0; i < payload.fanin_count; i++) {
+            sm_tasks.get_slot_state_by_task_id(fanin_row[i]).ed_flags |= ED_FLAG_TRACKED;
+        }
+    }
+
     ORCH_STEP_LAP(g_orch_fanin_ns);
     ORCH_PHASE_END(HostPhaseKind::OrchSubmitTask, task_id.raw);
 
@@ -1887,8 +1917,6 @@ void graph_reset_outer_payload(TaskPayload &payload) {
     payload.early_dispatch_state.store(EARLY_DISPATCH_NONE, std::memory_order_relaxed);
     for (auto &word : payload.staged_core_mask)
         word.store(0, std::memory_order_relaxed);
-    payload.dispatch_fanin.store(0, std::memory_order_relaxed);
-    payload.dispatch_propagated.store(0, std::memory_order_relaxed);
     payload.published_block_count.store(0, std::memory_order_relaxed);
     payload.early_dispatch_launch_state.store(EARLY_DISPATCH_LAUNCH_NONE, std::memory_order_relaxed);
     payload.running_slot_count.store(0, std::memory_order_relaxed);
@@ -1952,7 +1980,7 @@ bool graph_submit_outer(
     // list against every consumer, and a stale completion flag would report the
     // Graph done before it ran.
     slot.reset_for_reuse();
-    tasks.completion_flags[allocation.task_id].store(0, std::memory_order_relaxed);
+    tasks.progress_flags[allocation.task_id].store(0, std::memory_order_relaxed);
 
     // Graph boundaries use the same compact argument pools as ordinary tasks. The
     // outer payload carries the invocation data; graph_context only names the
@@ -2911,15 +2939,14 @@ TaskOutputTensors OrchestratorState::alloc_tensors(const CoreTaskArgs &args) {
         //
         // Flag the creator so it does NOT suppress its consumers' early-dispatch.
         // Under the direct-only model an unflagged producer disqualifies its
-        // consumer, and a pre-completed producer only seeds dispatch_fanin when
-        // flagged. A buffer allocation is pure memory whose output is ready at
+        // consumer. A buffer allocation is pure memory whose output is ready at
         // creation — it should always be transparent, never a barrier. Unlike a
         // codegen task there is no Arg-driven hint to honor here, so mark it
         // unconditionally.
         prepared.slot_state->task_attrs.set_early_resolve(true);
         prepared.slot_state->mark_completed();  // GLOBAL task, so task_state is only the completion mirror
-        // Polling: pre-set the device-visible completion_flags byte in the H2D
-        // image. Consumers poll completion_flags (not task_state), so a hidden-alloc
+        // Polling: pre-set the device-visible progress_flags byte in the H2D
+        // image. Consumers poll progress_flags (not task_state), so a hidden-alloc
         // producer completed here on the host must publish its flag too — otherwise
         // every consumer register_wakes on a producer that never runs on device and
         // the run hangs.

--- a/src/common/host_build_graph/runtime_types.h
+++ b/src/common/host_build_graph/runtime_types.h
@@ -276,6 +276,15 @@ static_assert(offsetof(TaskDescriptor, packed_buffer_base) == 24, "packed_buffer
  * by bulk tensor and scalar data. Fanin is always inline: it is hard-capped at
  * CHIP_MAX_FANIN and there is no spill pool.
  */
+// Host early-dispatch verdicts for ChipTaskSlotState::ed_flags (bitmask).
+inline constexpr uint8_t ED_FLAG_CANDIDATE = 1u << 0;
+inline constexpr uint8_t ED_FLAG_TRACKED = 1u << 1;
+
+// Publish-list drain batch bound: waiters one Phase 4b pass rescans before
+// the remainder goes back to the pending-drain queue, so one huge-fanout
+// producer cannot make a single idle pass long-tailed.
+inline constexpr int32_t ED_PUBLISH_DRAIN_BATCH_MAX = 32;
+
 // Early-dispatch claim states for TaskPayload::early_dispatch_state.
 enum EarlyDispatchState : uint8_t {
     EARLY_DISPATCH_NONE = 0,       // not pre-staged
@@ -325,7 +334,7 @@ struct TaskPayload {
     //
     // fanin holds flat position-independent producer local task ids. A producer is
     // named by its local id alone, so no per-edge indirection is stored. Scanned by
-    // classify_fanin_state against the shared-memory completion_flags. Hard-capped at
+    // classify_fanin_state against the shared-memory progress_flags. Hard-capped at
     // CHIP_MAX_FANIN (no dep-pool spill). Unbound on an in-graph task, whose
     // dependencies live in the Definition's fanin CSR instead.
     simpler::hbg::SelfRelativePtr<simpler::hbg::Tensor> tensors;
@@ -345,14 +354,6 @@ struct TaskPayload {
     // the completed mask stable for its single launch owner, whether staging is local
     // or uses the global drain fallback.
     alignas(64) std::atomic<uint64_t> staged_core_mask[EARLY_DISPATCH_CORE_MASK_WORDS]{};
-    // Early-dispatch CANDIDATE detection, event-driven and counted rather than
-    // polled: seeded to 0 at submit with the producers already complete, then a
-    // flagged producer bumps each consumer after all of its logical blocks are
-    // published (propagate_dispatch_fanin).
-    // dispatch_fanin == fanin_actual_count  <=>  every producer is
-    // flagged-and-fully-published or was
-    // pre-completed  =>  this task is an early-dispatch candidate (push early_dispatch_queues[shape]).
-    std::atomic<int32_t> dispatch_fanin{0};  // CONSUMER side: fully-published + pre-completed producers
     // Number of logical blocks whose payloads and MMIO tokens are published.
     // Claimed-but-unpublished blocks do not make a producer launch-visible. Its
     // seq_cst updates pair with early_dispatch_state to avoid losing the final
@@ -367,7 +368,6 @@ struct TaskPayload {
     // mask and a late stager rings only its remaining bits. A sync_start consumer
     // preserves the mask for rendezvous counting and its single launch pass.
     std::atomic<uint8_t> early_dispatch_state{0};
-    std::atomic<uint8_t> dispatch_propagated{0};  // PRODUCER side: once-guard for fanout propagation
     // The launch owner publishes COMPLETE only after all owned doorbells are
     // visible, keeping fanout private until every gated block has launched.
     std::atomic<uint8_t> early_dispatch_launch_state{EARLY_DISPATCH_LAUNCH_NONE};
@@ -497,18 +497,14 @@ struct TaskPayload {
         // prepare_task only allocates/binds. prefetch() warms this
         // line (cache line 1) so these writes land in warm cache.
         //
-        // early_dispatch_state / staged_core_mask / dispatch_fanin are all CONSUMER-side: a
-        // task whose own allow_early_resolve is false still has them touched when
-        // one of ITS producers is flagged (propagate_dispatch_fanin bumps
-        // dispatch_fanin and may CAS early_dispatch_state on any consumer, independent of the
-        // consumer's own hint). So they MUST be zeroed here unconditionally.
-        // Publication, propagation, and launch fields share this same
-        // per-submit lifetime and are reset here too.
+        // early_dispatch_state / staged_core_mask are CONSUMER-side: a task
+        // whose own allow_early_resolve is false can still have them touched
+        // by the release path, independent of the consumer's own hint. So they
+        // MUST be zeroed here unconditionally. Publication and launch fields
+        // share this same per-submit lifetime and are reset here too.
         early_dispatch_state.store(EARLY_DISPATCH_NONE, std::memory_order_relaxed);
         for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++)
             staged_core_mask[w].store(0, std::memory_order_relaxed);
-        dispatch_fanin.store(0, std::memory_order_relaxed);
-        dispatch_propagated.store(0, std::memory_order_relaxed);
         published_block_count.store(0, std::memory_order_relaxed);
         early_dispatch_launch_state.store(EARLY_DISPATCH_LAUNCH_NONE, std::memory_order_relaxed);
         running_slot_count.store(0, std::memory_order_relaxed);
@@ -563,7 +559,7 @@ static_assert(sizeof(simpler::hbg::Tensor) == 128, "simpler::hbg::Tensor must be
  * belongs to, and both are load-bearing:
  *
  *   - A GLOBAL task holds a slot in the SM task table, so its readiness truth is
- *     `completion_flags[local_id]` — a byte-per-slot array, which is what lets a
+ *     `progress_flags[local_id]` — a byte-per-slot array, which is what lets a
  *     fanin scan read many producers out of one cache line. `task_state` is then
  *     a mirror, read only by the cold-path stall dump.
  *   - An IN_GRAPH task lives in its Graph's own storage and has no slot in that
@@ -582,6 +578,19 @@ struct alignas(64) ChipTaskSlotState {
     // WAKE_LIST_SENTINEL and routes every waiter. Reset to nullptr at init.
     std::atomic<ChipTaskSlotState *> wake_list_head{nullptr};
     ChipTaskSlotState *next_in_wake_list{nullptr};
+
+    // --- ED publish list: the early-dispatch dual of the wake list above ---
+    // An ED candidate whose fanin scan finds an unpublished producer registers
+    // on that producer's publish list (CAS push through
+    // next_in_ed_publish_list). When the producer's last logical block is
+    // published, the dispatch path exchanges ed_publish_list_head to
+    // ED_PUBLISH_LIST_SENTINEL — sealing the list forever — and hands the
+    // detached waiters to the pending-drain queue for an idle thread to
+    // rescan. A registration CAS that meets the sentinel knows the producer is
+    // published and advances its scan instead of hanging. Only candidates and
+    // their producers ever touch these.
+    std::atomic<ChipTaskSlotState *> ed_publish_list_head{nullptr};
+    ChipTaskSlotState *next_in_ed_publish_list{nullptr};
 
     // Graph membership, and which of the two Graph structs this points at is
     // decided by task_kind rather than by anything stored here:
@@ -617,7 +626,7 @@ struct alignas(64) ChipTaskSlotState {
     // Completion state. PENDING at submit; COMPLETED at whichever completion path
     // owns this slot. For an IN_GRAPH task this is the readiness truth the device
     // itself polls (graph_first_unmet_producer); for a GLOBAL task it mirrors
-    // completion_flags[slot], which is what the device reads instead. Also read by
+    // progress_flags[slot], which is what the device reads instead. Also read by
     // the cold-path stall dump.
     std::atomic<ChipTaskState> task_state;
 
@@ -636,9 +645,37 @@ struct alignas(64) ChipTaskSlotState {
     std::atomic<bool> any_subtask_deferred{false};
     TaskKind task_kind{TaskKind::KERNEL};
 
-    // Keeps the record at one cache line. Members run widest-first, so their sizes
-    // sum to exactly the bytes this leaves and the record carries no padding.
-    uint8_t reserved[23];
+    // Early-dispatch verdicts, decided by the host orchestrator once this task's
+    // fanin region is final (this slot is part of the host-built SM image).
+    // Plain-write on the single-threaded submit path, before the slot is
+    // scheduler-visible; the device only ever reads them.
+    //   ED_FLAG_CANDIDATE  every producer carries allow_early_resolve, no
+    //                      dispatch predicate, dispatchable shape, fanin >= 1
+    //   ED_FLAG_TRACKED    at least one candidate names this task as a producer,
+    //                      so its publication state must be recorded
+    uint8_t ed_flags{0};
+
+    // Publish-list scan cursor of an ED candidate: the fanin-row index this
+    // task is hung on in the publish list. The row is sorted and publish bits
+    // are monotonic, so indices above the cursor are known-published forever
+    // and every rescan resumes here — each row entry is loaded once per life.
+    uint8_t ed_publish_scan_cursor{0};
+
+    // Completion-chain scan cursor: the fanin-row index this task last hung at
+    // in the wake list. Completion bits are monotonic, so indices above the
+    // cursor stay completed forever and every reclassification resumes here
+    // instead of re-walking the row's completed tail. 0xFF = never hung; the
+    // scan start folds it to fanin_count - 1. The classifier owning this task
+    // is its only writer, so a plain byte suffices.
+    uint8_t wake_scan_cursor{0xFF};
+    // Both cursors store fanin-row indices in a byte; 0xFF is wake's never-hung
+    // sentinel. append_fanin_or_fail hard-caps rows at CHIP_MAX_FANIN with a
+    // named fatal, and this ties any future cap raise to the cursor width.
+    static_assert(CHIP_MAX_FANIN < 0xFF, "scan cursors are uint8_t and 0xFF is reserved");
+
+    // Keeps the record at one cache line. Members run widest-first up to the
+    // byte block above, so their sizes sum to exactly the bytes this leaves.
+    uint8_t reserved[4];
 
     int32_t claim_block_range(int32_t block_limit, int32_t max_count, int32_t &start) {
         int16_t current = next_block_idx.load(std::memory_order_relaxed);
@@ -658,8 +695,8 @@ struct alignas(64) ChipTaskSlotState {
     }
 
     // Publishes completion. For an IN_GRAPH task this store is the whole
-    // publication — that task has no completion_flags byte. For a GLOBAL task it
-    // accompanies the completion_flags[slot] store that on_mixed_task_complete
+    // publication — that task has no progress_flags byte. For a GLOBAL task it
+    // accompanies the progress_flags[slot] store that on_mixed_task_complete
     // makes, and is the copy the cold-path stall dump reads.
     void mark_completed() { task_state.store(CHIP_TASK_COMPLETED, std::memory_order_release); }
 
@@ -684,6 +721,14 @@ struct alignas(64) ChipTaskSlotState {
         in_graph_local_id = -1;
         graph_context = nullptr;
         task_kind = TaskKind::KERNEL;
+        // ED_FLAG_TRACKED is only ever set by a consumer submitted AFTER this
+        // slot was claimed (producers precede consumers), so clearing at claim
+        // time cannot race a tracker.
+        ed_flags = 0;
+        ed_publish_scan_cursor = 0;
+        wake_scan_cursor = 0xFF;
+        ed_publish_list_head.store(nullptr, std::memory_order_relaxed);
+        next_in_ed_publish_list = nullptr;
         // Note: active_mask and task_attrs are per-submit-constant fields
         // rewritten in prepare_task on every reuse, so they are not reset here.
         // Payload early-dispatch/fanin fields are (re)initialized in
@@ -702,7 +747,10 @@ struct alignas(64) ChipTaskSlotState {
 static_assert(sizeof(ChipTaskSlotState) == 64);
 // Pins the widest-first order that leaves the record padding-free: every member
 // before `reserved` is naturally aligned where the one before it ends.
-static_assert(offsetof(ChipTaskSlotState, reserved) == 41, "ChipTaskSlotState grew interior padding");
+static_assert(
+    offsetof(ChipTaskSlotState, ed_publish_list_head) == 16, "the ED publish pair sits right after its wake-list twin"
+);
+static_assert(offsetof(ChipTaskSlotState, reserved) == 60, "ChipTaskSlotState grew interior padding");
 
 // =============================================================================
 // Per-Task Storage
@@ -809,3 +857,8 @@ inline const ChipTaskSlotState &TaskPayload::to_slot() const {
 // Sentinel marking a wake list as "owner already completed; no more
 // registrations accepted". Distinct from any real slot_state pointer.
 inline ChipTaskSlotState *const WAKE_LIST_SENTINEL = reinterpret_cast<ChipTaskSlotState *>(static_cast<uintptr_t>(0x1));
+
+// Publish-list analog: "owner already published; no more registrations". Set
+// once by the owner's publish event, never cleared within a run.
+inline ChipTaskSlotState *const ED_PUBLISH_LIST_SENTINEL =
+    reinterpret_cast<ChipTaskSlotState *>(static_cast<uintptr_t>(0x1));

--- a/src/common/host_build_graph/shared/runtime_init.cpp
+++ b/src/common/host_build_graph/shared/runtime_init.cpp
@@ -90,6 +90,7 @@ SchedulerLayout SchedulerState::reserve_layout(DeviceArena &arena) {
         layout.off_early_dispatch_queue_slots[i] = ready_queue_reserve_layout(arena, CHIP_EARLY_DISPATCH_QUEUE_SIZE);
     }
     layout.off_early_sync_start_queue_slots = ready_queue_reserve_layout(arena, CHIP_EARLY_DISPATCH_QUEUE_SIZE);
+    layout.off_ed_publish_drain_queue_slots = ready_queue_reserve_layout(arena, CHIP_EARLY_DISPATCH_QUEUE_SIZE);
     for (int i = 0; i < NUM_RESOURCE_SHAPES; i++) {
         layout.off_ready_queue_slots[i] = ready_queue_reserve_layout(arena, READY_QUEUE_CAPACITY_LIMIT);
     }
@@ -100,7 +101,7 @@ SchedulerLayout SchedulerState::reserve_layout(DeviceArena &arena) {
     layout.off_graph_ready_queue_slots = ready_queue_reserve_layout(arena, READY_QUEUE_CAPACITY_LIMIT);
     layout.off_graph_prepare_queue_slots = ready_queue_reserve_layout(arena, READY_QUEUE_CAPACITY_LIMIT);
     // Polling: no dep_pool arena region — producer dependencies are inline ids on
-    // the payload and readiness is via completion_flags.
+    // the payload and readiness is via progress_flags.
     return layout;
 }
 
@@ -129,6 +130,7 @@ bool SchedulerState::init_data_from_layout(const SchedulerLayout &layout, Device
         ready_queue_init_data_from_layout(&sched->early_dispatch_queues[i], CHIP_EARLY_DISPATCH_QUEUE_SIZE);
     }
     ready_queue_init_data_from_layout(&sched->early_sync_start_queue, CHIP_EARLY_DISPATCH_QUEUE_SIZE);
+    ready_queue_init_data_from_layout(&sched->ed_publish_drain_queue, CHIP_EARLY_DISPATCH_QUEUE_SIZE);
 
     // Polling: no dep_pool arena region to initialize.
     (void)arena;
@@ -155,6 +157,7 @@ void SchedulerState::seed_queue_slots() {
         sched->early_dispatch_queues[i].seed_slots();
     }
     sched->early_sync_start_queue.seed_slots();
+    sched->ed_publish_drain_queue.seed_slots();
 }
 
 void SchedulerState::wire_arena_pointers(const SchedulerLayout &layout, DeviceArena &arena) {
@@ -174,6 +177,7 @@ void SchedulerState::wire_arena_pointers(const SchedulerLayout &layout, DeviceAr
         );
     }
     ready_queue_wire_arena_pointers(&sched->early_sync_start_queue, arena, layout.off_early_sync_start_queue_slots);
+    ready_queue_wire_arena_pointers(&sched->ed_publish_drain_queue, arena, layout.off_ed_publish_drain_queue_slots);
 }
 
 void SchedulerState::destroy() {
@@ -192,6 +196,7 @@ void SchedulerState::destroy() {
         ready_queue_destroy(&sched->early_dispatch_queues[i]);
     }
     ready_queue_destroy(&sched->early_sync_start_queue);
+    ready_queue_destroy(&sched->ed_publish_drain_queue);
 }
 
 // =============================================================================

--- a/src/common/host_build_graph/shared/shared_memory.cpp
+++ b/src/common/host_build_graph/shared/shared_memory.cpp
@@ -41,7 +41,7 @@ void SharedMemoryHandle::setup_pointers(uint64_t pitch) {
     char *base = (char *)sm_base;
     header = (SharedMemoryHeader *)base;
 
-    // storage / completion_flags — offsets from the single source
+    // storage / progress_flags — offsets from the single source
     // of truth (sm_layout::segment_offsets), so this setup and the
     // device-address helpers cannot drift.
     //
@@ -52,7 +52,7 @@ void SharedMemoryHandle::setup_pointers(uint64_t pitch) {
     auto off = sm_layout::segment_offsets(sm_layout::image_extents({pitch, 0, 0, 0}));
     auto &tasks = header->tasks;
     tasks.task_storage = (ChipTaskStorage *)(base + off.storage);
-    tasks.completion_flags = (std::atomic<uint8_t> *)(base + off.completion_flags);
+    tasks.progress_flags = (std::atomic<uint8_t> *)(base + off.progress_flags);
 }
 
 bool SharedMemoryHandle::init(void *sm_base_arg, uint64_t sm_size_arg, uint64_t max_tasks) {

--- a/src/common/host_build_graph/shared_memory.h
+++ b/src/common/host_build_graph/shared_memory.h
@@ -79,21 +79,41 @@ struct alignas(64) SharedMemoryTaskHeader {
     //
     // A hidden-alloc task is the one flag the host presets to 1: it completes during
     // orchestration, and a consumer polls this array rather than task_state.
-    std::atomic<uint8_t> *completion_flags;
+    std::atomic<uint8_t> *progress_flags;
 
     // Tasks this run submitted, i.e. the slot count the two segments above are
     // pitched to. Written once by the host after orchestration (run_host_orchestration)
     // and read-only from then on, so it packs into the padding rather than taking a
     // line of its own. Bounds every slot-indexed walk: no slot at or above it was
-    // claimed, and the bytes past completion_flags[total_tasks - 1] are not flags.
+    // claimed, and the bytes past progress_flags[total_tasks - 1] are not flags.
     int32_t total_tasks;
 
+    // One byte carries two monotonic facts about a task, each its own bit:
+    //   COMPLETED  every subtask finished; the readiness truth consumers scan
+    //   PUBLISHED  every logical block's payload + MMIO token is written; the
+    //              early-dispatch publish list scans this bit, and completion
+    //              implies it (a finished task occupies no cores)
+    // Completion is a plain store of both bits. Publication is a fetch_or:
+    // the publish-side bookkeeping can run after the block's FIN has already
+    // been observed, so a plain store could erase a completion that landed
+    // in between — OR preserves it under either ordering.
+    static constexpr uint8_t TASK_FLAG_COMPLETED = 1u << 0;
+    static constexpr uint8_t TASK_FLAG_PUBLISHED = 1u << 1;
+
     bool is_completion_flag_set(int32_t local_id, std::memory_order order = std::memory_order_acquire) const {
-        return completion_flags[local_id].load(order) != 0;
+        return (progress_flags[local_id].load(order) & TASK_FLAG_COMPLETED) != 0;
     }
 
     void set_completion_flag(int32_t local_id, std::memory_order order = std::memory_order_release) const {
-        completion_flags[local_id].store(1, order);
+        progress_flags[local_id].store(TASK_FLAG_COMPLETED | TASK_FLAG_PUBLISHED, order);
+    }
+
+    bool is_publish_flag_set(int32_t local_id, std::memory_order order = std::memory_order_acquire) const {
+        return (progress_flags[local_id].load(order) & TASK_FLAG_PUBLISHED) != 0;
+    }
+
+    void set_publish_flag(int32_t local_id) const {
+        progress_flags[local_id].fetch_or(TASK_FLAG_PUBLISHED, std::memory_order_release);
     }
 
     // A task id is its own storage index, so the three records it names are reached
@@ -225,7 +245,7 @@ inline SharedMemoryTaskHeader *task_header_addr(void *sm_dev_base) noexcept {
 }
 
 // Byte offsets (from the SM base) of the image's segments. The layout is: header, then
-// storage -> completion_flags -> the three argument pools, every segment
+// storage -> progress_flags -> the three argument pools, every segment
 // CHIP_ALIGN_UP-padded. ImageExtents dimensions them: the mirror for the worst case the
 // API allows, the image for what this bind holds, which is what makes the live prefixes
 // contiguous and the upload one copy.
@@ -235,11 +255,11 @@ inline SharedMemoryTaskHeader *task_header_addr(void *sm_dev_base) noexcept {
 // restack's change of pitch untouched.
 //
 // The pools sit last because nothing on the device resolves a segment past
-// completion_flags: a payload names its argument regions by delta, so the two
+// progress_flags: a payload names its argument regions by delta, so the two
 // slot-pitched offsets are all the attach path computes.
 struct SegmentOffsets {
     uint64_t storage;
-    uint64_t completion_flags;  // polling-completion byte array (1 byte/slot)
+    uint64_t progress_flags;  // polling-completion byte array (1 byte/slot)
     uint64_t fanin_pool;
     uint64_t tensor_pool;
     uint64_t scalar_pool;
@@ -276,7 +296,7 @@ inline SegmentOffsets segment_offsets(const ImageExtents &e) noexcept {
     SegmentOffsets o{};
     o.storage = off;
     off += CHIP_ALIGN_UP(e.slots * sizeof(ChipTaskStorage), CHIP_ALIGN_SIZE);
-    o.completion_flags = off;
+    o.progress_flags = off;
     off += CHIP_ALIGN_UP(e.slots * sizeof(std::atomic<uint8_t>), CHIP_ALIGN_SIZE);
     o.fanin_pool = off;
     off += CHIP_ALIGN_UP(e.fanin_elems * sizeof(int32_t), CHIP_ALIGN_SIZE);
@@ -407,14 +427,14 @@ inline uint64_t compact_live_image(
     std::memcpy(out_base, mirror_base, to.storage);
     auto &out_tasks = reinterpret_cast<SharedMemoryHeader *>(out_base)->tasks;
     out_tasks.task_storage = nullptr;
-    out_tasks.completion_flags = nullptr;
+    out_tasks.progress_flags = nullptr;
 
     const uint64_t nt = used.submitted_tasks;
     // One copy for all three of a task's records: ChipTaskStorage is fixed-size, so
     // the mirror and the image share a stride. Each pool is likewise one copy of its
     // own prefix.
     std::memcpy(out_base + to.storage, mirror_base + from.storage, nt * sizeof(ChipTaskStorage));
-    std::memcpy(out_base + to.completion_flags, mirror_base + from.completion_flags, nt * sizeof(std::atomic<uint8_t>));
+    std::memcpy(out_base + to.progress_flags, mirror_base + from.progress_flags, nt * sizeof(std::atomic<uint8_t>));
     std::memcpy(out_base + to.fanin_pool, mirror_base + from.fanin_pool, used.fanin_elems * sizeof(int32_t));
     std::memcpy(
         out_base + to.tensor_pool, mirror_base + from.tensor_pool, used.tensor_elems * sizeof(simpler::hbg::Tensor)

--- a/tests/st/a2a3/host_build_graph/chained_early_dispatch/kernels/orchestration/chained_early_dispatch_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/chained_early_dispatch/kernels/orchestration/chained_early_dispatch_orch.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Chained Early-Dispatch Orchestration (host_build_graph)
+ *
+ * A two-level ED chain: the middle task is both a candidate and a tracked
+ * producer. While the slow root still runs, P1 is pre-staged gated; its staged
+ * blocks publish (publication counts placement, not launch), which makes C a
+ * candidate while P1 itself still waits for its doorbell — a gated producer
+ * with a gated consumer chained behind it. Release then cascades in staging
+ * order: P0 completes -> P1's doorbells ring -> P1 completes -> C's ring.
+ *
+ * Tasks (each writes one cache line per block via the shared slow-write
+ * kernel):
+ *   P0: AIC blocks=8, base_cl=0,  long spin, allow_early_resolve=true
+ *   P1: AIC blocks=8, base_cl=8,  short spin, allow_early_resolve=true, dep=[P0]
+ *   C:  AIV blocks=8, base_cl=16, no spin, dep=[P1]
+ *
+ * Args layout: [output]
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "orchestration_api.h"  // NOLINT(build/include_subdir)
+#include "arg_with_deps.h"      // NOLINT(build/include_subdir)
+
+#define FUNC_WRITE_AIC 0
+#define FUNC_WRITE_AIV 1
+
+extern "C" {
+
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return OrchestrationConfig{
+        .expected_arg_count = 1,
+    };
+}
+
+// The root spins long enough for the scheduler to pre-stage P1 while P0 runs,
+// and for C's detection to fire off P1's gated publication.
+static constexpr int64_t ROOT_SPIN_ITERS = 10000000;
+static constexpr int64_t MID_SPIN_ITERS = 100000;
+static constexpr int32_t BLOCKS = 8;
+
+static TaskId submit_slow(
+    int32_t kernel_id, bool aic, const simpler::hbg::Tensor &out, int64_t base_cl, int64_t spin, TaskId dep,
+    bool flagged
+) {
+    CoreTaskArgsWithDeps<2> args;
+    args.add_inout(out);
+    args.add_scalar(base_cl);
+    args.add_scalar(spin);
+    args.launch_spec.set_block_num(BLOCKS);
+    args.set_allow_early_resolve(flagged);
+    if (dep.is_valid()) args.add_dep(dep);
+    return aic ? rt_submit_aic_task(kernel_id, args).task_id() : rt_submit_aiv_task(kernel_id, args).task_id();
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
+    const simpler::hbg::Tensor &out = orch_args.tensor(0).ref();
+
+    rt_scope_begin(ScopeMode::MANUAL);
+    TaskId p0 = submit_slow(FUNC_WRITE_AIC, true, out, 0, ROOT_SPIN_ITERS, TaskId::invalid(), /*flagged=*/true);
+    TaskId p1 = submit_slow(FUNC_WRITE_AIC, true, out, BLOCKS, MID_SPIN_ITERS, p0, /*flagged=*/true);
+    submit_slow(FUNC_WRITE_AIV, false, out, 2 * BLOCKS, 0, p1, /*flagged=*/false);
+    rt_scope_end();
+
+    LOG_INFO("[chained_early_dispatch] P0(%d) -> P1(%d, candidate+tracked) -> C(%d)", BLOCKS, BLOCKS, BLOCKS);
+}
+
+}  // extern "C"

--- a/tests/st/a2a3/host_build_graph/chained_early_dispatch/test_chained_early_dispatch.py
+++ b/tests/st/a2a3/host_build_graph/chained_early_dispatch/test_chained_early_dispatch.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""A two-level early-dispatch chain: gated producer with a gated consumer behind it.
+
+While the slow root P0 runs, P1 (candidate: its producer is flagged) is
+pre-staged gated; its staged blocks publish — publication counts placement, not
+launch — so C becomes a candidate and pre-stages behind the still-gated P1.
+Release cascades in staging order: P0 completes -> P1's doorbells ring -> P1
+completes -> C's. The golden checks every cell landed, i.e. the chain neither
+deadlocked nor dropped a block. Kernels are shared with the
+tensormap_and_ringbuffer early-dispatch scenes.
+"""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+
+FLOATS_PER_CACHE_LINE = 16
+BLOCKS = 8
+SEGMENTS = 3
+TOTAL_CL = SEGMENTS * BLOCKS
+
+SLOW_KERNEL = "../../tensormap_and_ringbuffer/spmd_sync_start_early_dispatch/kernels/aiv/kernel_spmd_write_slow.cpp"
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestChainedEarlyDispatchHbg(SceneTestCase):
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/chained_early_dispatch_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "WRITE_AIC",
+                "source": SLOW_KERNEL,
+                "core_type": "aic",
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 1,
+                "name": "WRITE_AIV",
+                "source": SLOW_KERNEL,
+                "core_type": "aiv",
+                "signature": [D.INOUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "Case1",
+            "platforms": ["a2a3sim", "a2a3"],
+            "params": {},
+        }
+    ]
+
+    def generate_args(self, params):
+        return TaskArgsBuilder(
+            TensorArg("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+        )
+
+    def compute_golden(self, args, params):
+        expected = args.output.reshape(TOTAL_CL, FLOATS_PER_CACHE_LINE)
+        for segment in range(SEGMENTS):
+            for block_idx in range(BLOCKS):
+                expected[segment * BLOCKS + block_idx, 0] = float(block_idx)
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a2a3/host_build_graph/spmd_sync_start_early_dispatch/kernels/orchestration/spmd_sync_start_early_dispatch_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/spmd_sync_start_early_dispatch/kernels/orchestration/spmd_sync_start_early_dispatch_orch.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SPMD Sync-Start Early-Dispatch Orchestration (host_build_graph)
+ *
+ * Exercises the sync_start early-dispatch path (gated drain + running-slot
+ * rendezvous) under the publish-list detector: a FLAGGED producer's full
+ * publication makes a require_sync_start consumer an early-dispatch candidate.
+ * The consumer is pre-staged gated across idle running slots AND (once idle
+ * runs out) busy cores' pending slots, then all blocks are released together
+ * at the rendezvous once every block occupies a running slot and the producer
+ * completes.
+ *
+ * Tasks (the producer writes one cache line per block; the MIX consumer writes
+ * one per participating core, so three cache lines per block):
+ *   P: AIC block_num=50, base_cl=0, allow_early_resolve=true
+ *   C: MIX block_num=24, base_cl=50, require_sync_start=true, dep=[P]
+ *
+ * Args layout: [output]
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "orchestration_api.h"  // NOLINT(build/include_subdir)
+#include "arg_with_deps.h"      // NOLINT(build/include_subdir)
+
+#define FUNC_SPMD_WRITE_AIC 0
+#define FUNC_SPMD_MIX_AIC 1
+#define FUNC_SPMD_MIX_AIV0 2
+#define FUNC_SPMD_MIX_AIV1 3
+
+extern "C" {
+
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return OrchestrationConfig{
+        .expected_arg_count = 2,
+    };
+}
+
+// spin_iters chosen so the producer stays on-core long enough for the scheduler to
+// process the consumer as an early-dispatch candidate WHILE the producer is running
+// (a fast producer would finish first and route the consumer through the ready path).
+static constexpr int64_t PRODUCER_SPIN_ITERS = 10000000;
+
+static constexpr int32_t PRODUCER_BLOCKS = 50;
+
+static TaskId submit_producer(const simpler::hbg::Tensor &out, int16_t block_num, int64_t base_cl) {
+    CoreTaskArgs args;
+    args.add_inout(out);
+    args.add_scalar(base_cl);
+    args.add_scalar(PRODUCER_SPIN_ITERS);
+    args.launch_spec.set_block_num(block_num);
+    args.set_allow_early_resolve(true);  // flagged: consumers may early-dispatch off it
+    return rt_submit_aic_task(FUNC_SPMD_WRITE_AIC, args).task_id();
+}
+
+static void submit_sync_consumer(const simpler::hbg::Tensor &out, int16_t block_num, int64_t base_cl, TaskId dep) {
+    MixedKernels kernels;
+    kernels.aic_kernel_id = FUNC_SPMD_MIX_AIC;
+    kernels.aiv0_kernel_id = FUNC_SPMD_MIX_AIV0;
+    kernels.aiv1_kernel_id = FUNC_SPMD_MIX_AIV1;
+    CoreTaskArgsWithDeps<4> args;
+    args.add_inout(out);
+    args.add_scalar(base_cl);
+    args.launch_spec.set_block_num(block_num);
+    args.launch_spec.set_require_sync_start(true);  // atomic cohort launch
+    args.add_dep(dep);                              // sole producer, flagged -> early-dispatch candidate
+    rt_submit_task(kernels, args);
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
+    const simpler::hbg::Tensor &ext_output = orch_args.tensor(0).ref();
+    const simpler::hbg::Tensor &layout = orch_args.tensor(1).ref();
+
+    // The consumer must occupy every AIC slot for the strand this case looks
+    // for, and require_sync_start needs every block of it co-resident — so its
+    // width is exactly this run's cluster count. The producer stays wider than
+    // the device on purpose; it carries no sync_start, so no cap applies.
+    const int32_t sync_blocks = rt_available_cluster_count();
+
+    rt_scope_begin(ScopeMode::MANUAL);
+    TaskId prod = submit_producer(ext_output, PRODUCER_BLOCKS, 0);
+    submit_sync_consumer(ext_output, static_cast<int16_t>(sync_blocks), PRODUCER_BLOCKS, prod);
+    rt_scope_end();
+
+    uint32_t idx[1] = {0};
+    set_tensor_data<int32_t>(layout, 1, idx, sync_blocks);
+
+    LOG_INFO(
+        "[spmd_sync_start_early_dispatch] producer (%d) + MIX sync_start consumer (%d)", PRODUCER_BLOCKS, sync_blocks
+    );
+}
+
+}  // extern "C"

--- a/tests/st/a2a3/host_build_graph/spmd_sync_start_early_dispatch/test_spmd_sync_start_early_dispatch.py
+++ b/tests/st/a2a3/host_build_graph/spmd_sync_start_early_dispatch/test_spmd_sync_start_early_dispatch.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""A wide flagged producer feeds a MIX sync_start early-dispatch consumer (hbg).
+
+Exercises host_build_graph's publish-list detector end to end: the host marks
+the consumer a candidate, its publish-list rescan fires when the producer's
+last block publishes, the gated cohort pre-stages, and the rendezvous releases
+every block together once the producer completes. The consumer must not stage
+until every producer block range has reserved a core slot; otherwise it
+occupies every AIC slot and strands the producer's unclaimed remainder.
+
+The consumer cohort is exactly this run's cluster count: it must occupy every
+AIC slot, and require_sync_start needs every block of it co-resident. The
+orchestration reports the width it used and the golden is rebuilt from it. The
+producer stays wider than the device on purpose — it carries no sync_start.
+Kernels are shared with the tensormap_and_ringbuffer twin of this scene.
+"""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+
+FLOATS_PER_CACHE_LINE = 16
+PRODUCER_BLOCKS = 50
+SYNC_BASE_CL = PRODUCER_BLOCKS
+# Widest the platform allows: one consumer block per cluster.
+MAX_CLUSTERS = 24
+TOTAL_CL = SYNC_BASE_CL + MAX_CLUSTERS * 3
+
+TMR_TWIN = "../../tensormap_and_ringbuffer"
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestSpmdSyncStartEarlyDispatchHbg(SceneTestCase):
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/spmd_sync_start_early_dispatch_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT, D.INOUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "SPMD_WRITE_AIC",
+                "source": f"{TMR_TWIN}/spmd_sync_start_early_dispatch/kernels/aiv/kernel_spmd_write_slow.cpp",
+                "core_type": "aic",
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 1,
+                "name": "SPMD_MIX_AIC",
+                "source": f"{TMR_TWIN}/spmd_multiblock_mix/kernels/aic/kernel_spmd_mix.cpp",
+                "core_type": "aic",
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 2,
+                "name": "SPMD_MIX_AIV0",
+                "source": f"{TMR_TWIN}/spmd_multiblock_mix/kernels/aiv/kernel_spmd_mix.cpp",
+                "core_type": "aiv",
+                "signature": [D.INOUT],
+            },
+            {
+                "func_id": 3,
+                "name": "SPMD_MIX_AIV1",
+                "source": f"{TMR_TWIN}/spmd_multiblock_mix/kernels/aiv/kernel_spmd_mix.cpp",
+                "core_type": "aiv",
+                "signature": [D.INOUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "Case1",
+            "platforms": ["a2a3sim", "a2a3"],
+            "params": {},
+        }
+    ]
+
+    def generate_args(self, params):
+        return TaskArgsBuilder(
+            TensorArg("output", torch.zeros(TOTAL_CL * FLOATS_PER_CACHE_LINE, dtype=torch.float32)),
+            TensorArg("layout", torch.zeros(1, dtype=torch.int32)),
+        )
+
+    def compute_golden(self, args, params):
+        # Both outputs are checked against the reported wave cap in compare_outputs.
+        pass
+
+    def compare_outputs(self, test_args, golden_args, output_names, params):
+        sync_blocks = int(test_args.layout[0])
+        assert 1 <= sync_blocks <= MAX_CLUSTERS, f"consumer width {sync_blocks} outside [1, {MAX_CLUSTERS}]"
+        expected = torch.zeros(TOTAL_CL, dtype=torch.float32)
+        for block_idx in range(PRODUCER_BLOCKS):
+            expected[block_idx] = float(block_idx)
+        for block_idx in range(sync_blocks):
+            for slot in range(3):
+                expected[SYNC_BASE_CL + block_idx * 3 + slot] = float(block_idx)
+        actual = test_args.output.reshape(TOTAL_CL, FLOATS_PER_CACHE_LINE)[:, 0]
+        assert torch.equal(actual, expected), f"slots disagree with the reported consumer width {sync_blocks}"
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -963,6 +963,18 @@ target_sources(test_hbg_slot_claim PRIVATE
     ${HBG_ORCH_SHARED_SOURCES}
     ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
 )
+# Drives the real orchestrator submit path to pin the early-dispatch
+# qualification verdicts (ed_flags) and the sorted fanin rows.
+add_a2a3_hbg_runtime_test(test_hbg_ed_qualification common/test_hbg_ed_qualification.cpp)
+target_sources(test_hbg_ed_qualification PRIVATE
+    ${HBG_ORCH_SHARED_SOURCES}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+)
+add_a5_hbg_runtime_test(test_a5_hbg_ed_qualification common/test_hbg_ed_qualification.cpp)
+target_sources(test_a5_hbg_ed_qualification PRIVATE
+    ${HBG_ORCH_SHARED_SOURCES}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+)
 add_a2a3_hbg_runtime_test(test_hbg_graph_recording_bounds common/test_hbg_graph_recording_bounds.cpp)
 target_sources(test_hbg_graph_recording_bounds PRIVATE
     ${HBG_ORCH_SHARED_SOURCES}

--- a/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
@@ -77,14 +77,14 @@ protected:
         sm_arena.release();
     }
 
-    // Fill the task table (storage entries / completion_flags) with poison.
+    // Fill the task table (storage entries / progress_flags) with poison.
     // init_header wrote only the header, so this is the state the table
     // is in before any submit writes it — modelling the never-zeroed device SM.
     void poison_task_table() {
         auto &tasks = sm_handle->header->tasks;
         const size_t n = static_cast<size_t>(CHIP_DEFAULT_GRAPH_TASKS);
         std::memset(tasks.task_storage, POISON, n * sizeof(ChipTaskStorage));
-        std::memset(tasks.completion_flags, POISON, n * sizeof(std::atomic<uint8_t>));
+        std::memset(tasks.progress_flags, POISON, n * sizeof(std::atomic<uint8_t>));
     }
 };
 
@@ -147,10 +147,14 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
         // real enum, never poison.
         const ChipTaskState state = st.task_state.load(std::memory_order_relaxed);
         EXPECT_TRUE(state == CHIP_TASK_PENDING || state == CHIP_TASK_COMPLETED);
-        // Completion flag is written to a real 0/1 (pending vs pre-completed), not a
-        // poison byte (0xAA).
-        const uint8_t cflag = tasks.completion_flags[local].load(std::memory_order_relaxed);
-        EXPECT_LE(cflag, uint8_t{1});
+        // Completion flag is written to a real value (pending vs pre-completed),
+        // not a poison byte (0xAA).
+        const uint8_t cflag = tasks.progress_flags[local].load(std::memory_order_relaxed);
+        // 0 = pending; a pre-completed hidden alloc carries COMPLETED|PUBLISHED.
+        EXPECT_TRUE(
+            cflag == 0 ||
+            cflag == (SharedMemoryTaskHeader::TASK_FLAG_COMPLETED | SharedMemoryTaskHeader::TASK_FLAG_PUBLISHED)
+        );
         // Payload counts are real, not the poison bit pattern.
         EXPECT_GE(pl.fanin_count, 0);
         EXPECT_LE(pl.fanin_count, CHIP_MAX_FANIN);

--- a/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
@@ -76,14 +76,14 @@ protected:
         sm_arena.release();
     }
 
-    // Fill the task table (storage entries / completion_flags) with poison.
+    // Fill the task table (storage entries / progress_flags) with poison.
     // init_header wrote only the header, so this is the state the table
     // is in before any submit writes it — modelling the never-zeroed device SM.
     void poison_task_table() {
         auto &tasks = sm_handle->header->tasks;
         const size_t n = static_cast<size_t>(CHIP_DEFAULT_GRAPH_TASKS);
         std::memset(tasks.task_storage, POISON, n * sizeof(ChipTaskStorage));
-        std::memset(tasks.completion_flags, POISON, n * sizeof(std::atomic<uint8_t>));
+        std::memset(tasks.progress_flags, POISON, n * sizeof(std::atomic<uint8_t>));
     }
 };
 
@@ -146,10 +146,14 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
         // real enum, never poison.
         const ChipTaskState state = st.task_state.load(std::memory_order_relaxed);
         EXPECT_TRUE(state == CHIP_TASK_PENDING || state == CHIP_TASK_COMPLETED);
-        // Completion flag is written to a real 0/1 (pending vs pre-completed), not a
-        // poison byte (0xAA).
-        const uint8_t cflag = tasks.completion_flags[local].load(std::memory_order_relaxed);
-        EXPECT_LE(cflag, uint8_t{1});
+        // Completion flag is written to a real value (pending vs pre-completed),
+        // not a poison byte (0xAA).
+        const uint8_t cflag = tasks.progress_flags[local].load(std::memory_order_relaxed);
+        // 0 = pending; a pre-completed hidden alloc carries COMPLETED|PUBLISHED.
+        EXPECT_TRUE(
+            cflag == 0 ||
+            cflag == (SharedMemoryTaskHeader::TASK_FLAG_COMPLETED | SharedMemoryTaskHeader::TASK_FLAG_PUBLISHED)
+        );
         // Payload counts are real, not the poison bit pattern.
         EXPECT_GE(pl.fanin_count, 0);
         EXPECT_LE(pl.fanin_count, CHIP_MAX_FANIN);

--- a/tests/ut/cpp/common/test_hbg_ed_qualification.cpp
+++ b/tests/ut/cpp/common/test_hbg_ed_qualification.cpp
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Early-dispatch qualification contract, decided by the host at submit:
+ *
+ *   ED_FLAG_CANDIDATE  every producer carries allow_early_resolve, no dispatch
+ *                      predicate, dispatchable shape, fanin >= 1
+ *   ED_FLAG_TRACKED    at least one candidate names this task as a producer
+ *
+ * and a candidate's fanin row is sorted by ascending producer local id
+ * (= submission order, ids are bump-allocated), so the device's backward
+ * fanin scans target the latest-submitted producer; non-candidate rows keep
+ * their fill order.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "utils/device_arena.h"
+#include "scheduler/scheduler.h"
+#include "host_build_graph/orchestrator.h"
+#include "host_build_graph/shared_memory.h"
+#include "host_build_graph/task_id.h"
+
+class HbgEdQualificationTest : public ::testing::Test {
+protected:
+    DeviceArena sm_arena;
+    DeviceArena runtime_arena;
+    SharedMemoryHandle *sm_handle = nullptr;
+    OrchestratorState orch{};
+    SchedulerState sched{};
+    SchedulerLayout sched_layout{};
+    std::vector<char> gm_heap;
+    std::vector<TensorCreateInfo> create_infos;
+
+    void SetUp() override {
+        sm_handle = SharedMemoryHandle::create_and_init_default(sm_arena);
+        ASSERT_NE(sm_handle, nullptr);
+        gm_heap.resize(1 << 16);
+        create_infos.reserve(16);
+
+        sched_layout = SchedulerState::reserve_layout(runtime_arena);
+        ASSERT_NE(runtime_arena.commit(), nullptr);
+
+        ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
+        sched.wire_arena_pointers(sched_layout, runtime_arena);
+        sched.seed_queue_slots();
+        ASSERT_TRUE(orch.init(sm_handle->sm_base, gm_heap.data(), gm_heap.size(), CHIP_DEFAULT_GRAPH_TASKS));
+        orch.begin_scope();
+    }
+
+    void TearDown() override {
+        sched.destroy();
+        runtime_arena.release();
+        sm_arena.release();
+    }
+
+    // One AIV producer with an output tensor; `flagged` sets allow_early_resolve.
+    TaskId submit_producer(bool flagged) {
+        uint32_t shape[] = {16};
+        CoreTaskArgs args;
+        create_infos.emplace_back(shape, 1, DataType::FLOAT32);
+        args.add_output(create_infos.back());
+        args.set_allow_early_resolve(flagged);
+        MixedKernels mixed{};
+        mixed.aiv0_kernel_id = 0;
+        TaskOutputTensors out = orch.submit_task(mixed, args);
+        EXPECT_TRUE(out.task_id().is_valid());
+        return out.task_id();
+    }
+
+    // One AIV consumer depending on `deps`, in the given order.
+    TaskId submit_consumer(const TaskId *deps, uint32_t dep_count) {
+        uint32_t shape[] = {16};
+        CoreTaskArgs args;
+        create_infos.emplace_back(shape, 1, DataType::FLOAT32);
+        args.add_output(create_infos.back());
+        args.set_dependencies(deps, dep_count);
+        MixedKernels mixed{};
+        mixed.aiv0_kernel_id = 0;
+        TaskOutputTensors out = orch.submit_task(mixed, args);
+        EXPECT_TRUE(out.task_id().is_valid());
+        return out.task_id();
+    }
+
+    const ChipTaskSlotState &slot_of(TaskId id) {
+        return sm_handle->header->tasks.get_slot_state_by_task_id(id.local_id());
+    }
+
+    const TaskPayload &payload_of(TaskId id) { return sm_handle->header->tasks.storage_at(id.local_id()).payload; }
+};
+
+TEST_F(HbgEdQualificationTest, AllFlaggedProducersMakeCandidateAndTrackProducers) {
+    TaskId p1 = submit_producer(/*flagged=*/true);
+    TaskId p2 = submit_producer(/*flagged=*/true);
+    // Dependencies handed over in reverse submission order: the sorted row must
+    // not depend on declaration order.
+    TaskId deps[] = {p2, p1};
+    TaskId c = submit_consumer(deps, 2);
+
+    EXPECT_NE(slot_of(c).ed_flags & ED_FLAG_CANDIDATE, 0);
+    EXPECT_NE(slot_of(p1).ed_flags & ED_FLAG_TRACKED, 0);
+    EXPECT_NE(slot_of(p2).ed_flags & ED_FLAG_TRACKED, 0);
+
+    const TaskPayload &pl = payload_of(c);
+    ASSERT_EQ(pl.fanin_count, 2);
+    EXPECT_EQ(pl.fanin_data()[0], p1.local_id());
+    EXPECT_EQ(pl.fanin_data()[1], p2.local_id());
+}
+
+TEST_F(HbgEdQualificationTest, OneUnflaggedProducerDisqualifies) {
+    TaskId p1 = submit_producer(/*flagged=*/true);
+    TaskId p2 = submit_producer(/*flagged=*/false);
+    // Reverse submission order: a fill-order row must keep p2 before p1, so
+    // this assertion fails if non-candidate rows were sorted too.
+    TaskId deps[] = {p2, p1};
+    TaskId c = submit_consumer(deps, 2);
+
+    EXPECT_EQ(slot_of(c).ed_flags & ED_FLAG_CANDIDATE, 0);
+    // No candidate, so neither producer is tracked.
+    EXPECT_EQ(slot_of(p1).ed_flags & ED_FLAG_TRACKED, 0);
+    EXPECT_EQ(slot_of(p2).ed_flags & ED_FLAG_TRACKED, 0);
+
+    // A non-candidate row keeps its fill order (here p2 then p1).
+    const TaskPayload &pl = payload_of(c);
+    ASSERT_EQ(pl.fanin_count, 2);
+    EXPECT_EQ(pl.fanin_data()[0], p2.local_id());
+    EXPECT_EQ(pl.fanin_data()[1], p1.local_id());
+}
+
+TEST_F(HbgEdQualificationTest, DummyConsumerIsNotCandidate) {
+    TaskId p1 = submit_producer(/*flagged=*/true);
+    TaskId deps[] = {p1};
+    CoreTaskArgs args;
+    args.set_dependencies(deps, 1);
+    TaskOutputTensors dummy = orch.submit_dummy_task(args);
+    ASSERT_TRUE(dummy.task_id().is_valid());
+
+    EXPECT_EQ(slot_of(dummy.task_id()).ed_flags & ED_FLAG_CANDIDATE, 0);
+    EXPECT_EQ(slot_of(p1).ed_flags & ED_FLAG_TRACKED, 0);
+}
+
+// The wake-scan cursor: each classification resumes where the last one hung
+// and never re-walks the row's completed tail. Monotonic completion bits make
+// the resume equivalent to a full rescan, so hang decisions are unchanged.
+TEST_F(HbgEdQualificationTest, WakeScanCursorResumesAndNeverRewalks) {
+    TaskId p1 = submit_producer(/*flagged=*/false);
+    TaskId p2 = submit_producer(/*flagged=*/false);
+    TaskId p3 = submit_producer(/*flagged=*/false);
+    TaskId deps[] = {p1, p2, p3};
+    TaskId c = submit_consumer(deps, 3);
+
+    ChipTaskSlotState &c_slot = sm_handle->header->tasks.get_slot_state_by_task_id(c.local_id());
+    auto &tasks = sm_handle->header->tasks;
+    const int32_t *row = c_slot.to_payload().fanin_data();
+
+    // Never hung: cursor is the 0xFF sentinel and the first scan starts at the
+    // row's tail.
+    EXPECT_EQ(c_slot.wake_scan_cursor, 0xFF);
+    EXPECT_EQ(sched.classify_fanin_state(&c_slot), 2);
+    EXPECT_EQ(c_slot.wake_scan_cursor, 2);
+
+    // The hung-at producer completes: the rescan resumes at the cursor and
+    // walks down to the next unmet entry.
+    tasks.set_completion_flag(row[2]);
+    EXPECT_EQ(sched.classify_fanin_state(&c_slot), 1);
+    EXPECT_EQ(c_slot.wake_scan_cursor, 1);
+
+    // Entries above the cursor completing do not move it (nothing rescans
+    // them); completing the remaining tail yields the ready verdict.
+    tasks.set_completion_flag(row[0]);
+    EXPECT_EQ(sched.classify_fanin_state(&c_slot), 1);
+    EXPECT_EQ(c_slot.wake_scan_cursor, 1);
+    tasks.set_completion_flag(row[1]);
+    EXPECT_EQ(sched.classify_fanin_state(&c_slot), -1);
+}
+
+TEST_F(HbgEdQualificationTest, RootIsNotCandidate) {
+    TaskId root = submit_producer(/*flagged=*/true);
+    EXPECT_EQ(slot_of(root).ed_flags & ED_FLAG_CANDIDATE, 0);
+}
+
+// The publish-list lifecycle, driven at the SchedulerState level: register ->
+// hang on the latest-submitted producer -> publish seals and detaches the
+// chain -> cursor rescan re-hangs on the next unpublished producer -> the
+// last publish yields the all-published verdict and the ED-queue claim.
+TEST_F(HbgEdQualificationTest, PublishListDetectsAllPublished) {
+    TaskId p1 = submit_producer(/*flagged=*/true);
+    TaskId p2 = submit_producer(/*flagged=*/true);
+    TaskId deps[] = {p1, p2};
+    TaskId c = submit_consumer(deps, 2);
+
+    ChipTaskSlotState &c_slot = sm_handle->header->tasks.get_slot_state_by_task_id(c.local_id());
+    ChipTaskSlotState &p1_slot = sm_handle->header->tasks.get_slot_state_by_task_id(p1.local_id());
+    ChipTaskSlotState &p2_slot = sm_handle->header->tasks.get_slot_state_by_task_id(p2.local_id());
+
+    // Intake: nothing published -> hangs on p2, the row's tail.
+    ASSERT_FALSE(sched.register_on_ed_publish_list(c_slot));
+    EXPECT_EQ(p2_slot.ed_publish_list_head.load(std::memory_order_relaxed), &c_slot);
+    EXPECT_EQ(c_slot.ed_publish_scan_cursor, 1);
+
+    // p2 publishes its only block: chain seals, detached head reaches the
+    // pending-drain queue.
+    sched.record_published_blocks(p2_slot, 1);
+    EXPECT_EQ(p2_slot.ed_publish_list_head.load(std::memory_order_relaxed), ED_PUBLISH_LIST_SENTINEL);
+    ChipTaskSlotState *detached = nullptr;
+    ASSERT_EQ(sched.ed_publish_drain_queue.pop_batch(&detached, 1), 1);
+    ASSERT_EQ(detached, &c_slot);
+
+    // Rescan: p1 still unpublished -> re-hang on p1, cursor advanced.
+    ASSERT_FALSE(sched.advance_ed_publish_scan(*detached));
+    EXPECT_EQ(p1_slot.ed_publish_list_head.load(std::memory_order_relaxed), &c_slot);
+    EXPECT_EQ(c_slot.ed_publish_scan_cursor, 0);
+
+    // p1 publishes: rescan reaches the all-published verdict; the claim CAS
+    // moves the candidate to STAGING and its shape queue.
+    sched.record_published_blocks(p1_slot, 1);
+    ASSERT_EQ(sched.ed_publish_drain_queue.pop_batch(&detached, 1), 1);
+    ASSERT_EQ(detached, &c_slot);
+    ASSERT_TRUE(sched.advance_ed_publish_scan(*detached));
+    sched.enqueue_early_dispatch_candidate(*detached);
+    EXPECT_EQ(c_slot.to_payload().early_dispatch_state.load(std::memory_order_relaxed), EARLY_DISPATCH_STAGING);
+    ChipTaskSlotState *staged = nullptr;
+    ASSERT_EQ(sched.early_dispatch_queues[static_cast<int32_t>(ResourceShape::AIV)].pop_batch(&staged, 1), 1);
+    EXPECT_EQ(staged, &c_slot);
+}
+
+// A two-level ED chain: the middle task is both a candidate (its own producer
+// is flagged) and a tracked producer. Its seal must fire on full publication
+// even while it is itself STAGING — gated, doorbell not yet rung — so its
+// consumer's verdict and claim follow while the whole chain is still gated.
+TEST_F(HbgEdQualificationTest, GatedCandidateSealsWhileStagingAndReleasesItsConsumer) {
+    TaskId p0 = submit_producer(/*flagged=*/true);
+    TaskId deps0[] = {p0};
+    TaskId p1 = submit_consumer(deps0, 1);  // candidate AND tracked (C depends on it)
+    ChipTaskSlotState &p1_slot =
+        sm_handle->header->tasks.get_slot_state_by_task_id(static_cast<int32_t>(p1.local_id()));
+    // p1 must be flagged for C to qualify; the host wrote CANDIDATE from p0's
+    // flag, and TRACKED lands below when C qualifies against p1's flag.
+    p1_slot.task_attrs.set_early_resolve(true);
+    TaskId deps1[] = {p1};
+    TaskId c = submit_consumer(deps1, 1);
+    ChipTaskSlotState &c_slot = sm_handle->header->tasks.get_slot_state_by_task_id(static_cast<int32_t>(c.local_id()));
+    ASSERT_NE(p1_slot.ed_flags & ED_FLAG_CANDIDATE, 0);
+    ASSERT_NE(p1_slot.ed_flags & ED_FLAG_TRACKED, 0);
+    ASSERT_NE(c_slot.ed_flags & ED_FLAG_CANDIDATE, 0);
+
+    // Intake: p1 hangs on p0's publish list, C hangs on p1's.
+    ASSERT_FALSE(sched.register_on_ed_publish_list(p1_slot));
+    ASSERT_FALSE(sched.register_on_ed_publish_list(c_slot));
+
+    // p0 publishes: p1's rescan reaches the verdict and p1 is claimed STAGING
+    // (pre-staged, doorbell not rung — the gated state).
+    ChipTaskSlotState &p0_slot =
+        sm_handle->header->tasks.get_slot_state_by_task_id(static_cast<int32_t>(p0.local_id()));
+    sched.record_published_blocks(p0_slot, 1);
+    ChipTaskSlotState *detached = nullptr;
+    ASSERT_EQ(sched.ed_publish_drain_queue.pop_batch(&detached, 1), 1);
+    ASSERT_EQ(detached, &p1_slot);
+    ASSERT_TRUE(sched.advance_ed_publish_scan(*detached));
+    sched.enqueue_early_dispatch_candidate(*detached);
+    ASSERT_EQ(p1_slot.to_payload().early_dispatch_state.load(std::memory_order_relaxed), EARLY_DISPATCH_STAGING);
+
+    // p1's (gated) blocks publish while it is STAGING: the seal fires anyway —
+    // publication counts placement, not launch — and hands C to the drain.
+    sched.record_published_blocks(p1_slot, 1);
+    EXPECT_EQ(p1_slot.ed_publish_list_head.load(std::memory_order_relaxed), ED_PUBLISH_LIST_SENTINEL);
+    ASSERT_EQ(sched.ed_publish_drain_queue.pop_batch(&detached, 1), 1);
+    ASSERT_EQ(detached, &c_slot);
+    ASSERT_TRUE(sched.advance_ed_publish_scan(*detached));
+    sched.enqueue_early_dispatch_candidate(*detached);
+    EXPECT_EQ(c_slot.to_payload().early_dispatch_state.load(std::memory_order_relaxed), EARLY_DISPATCH_STAGING);
+}
+
+// Untracked producers must not pay the publish accounting, and the release
+// path's NONE->DISPATCHED claim keeps a never-staged task on the normal route.
+TEST_F(HbgEdQualificationTest, ReleaseClaimsNeverStagedTaskForNormalRoute) {
+    TaskId p1 = submit_producer(/*flagged=*/false);
+    ChipTaskSlotState &p1_slot = sm_handle->header->tasks.get_slot_state_by_task_id(p1.local_id());
+    // Untracked: publication leaves no publish state behind.
+    sched.record_published_blocks(p1_slot, 1);
+    EXPECT_EQ(p1_slot.to_payload().published_block_count.load(std::memory_order_relaxed), 0);
+    EXPECT_EQ(p1_slot.ed_publish_list_head.load(std::memory_order_relaxed), nullptr);
+
+    TaskId p2 = submit_producer(/*flagged=*/true);
+    TaskId deps[] = {p2};
+    TaskId c = submit_consumer(deps, 1);
+    ChipTaskSlotState &c_slot = sm_handle->header->tasks.get_slot_state_by_task_id(c.local_id());
+    // Never staged: release wins NONE->DISPATCHED and reports "route normally".
+    EXPECT_FALSE(sched.try_early_dispatch_release(c_slot));
+    EXPECT_EQ(c_slot.to_payload().early_dispatch_state.load(std::memory_order_relaxed), EARLY_DISPATCH_DISPATCHED);
+    // A later enqueue attempt (stale drain verdict) is dropped by the claim.
+    sched.enqueue_early_dispatch_candidate(c_slot);
+    EXPECT_EQ(c_slot.to_payload().early_dispatch_state.load(std::memory_order_relaxed), EARLY_DISPATCH_DISPATCHED);
+}

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -430,7 +430,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     execution->task_at(1).payload.scalar_data()[0] = 31415;
     storage.payload.tensor_data()[0].version = 1618;
     storage.slot.completed_subtasks.store(1, std::memory_order_relaxed);
-    storage.payload.dispatch_fanin.store(1, std::memory_order_relaxed);
+    storage.payload.published_block_count.store(1, std::memory_order_relaxed);
 
     execution = heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(second_boundary.data()), 99);
     ASSERT_NE(execution, nullptr);
@@ -449,7 +449,7 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     EXPECT_EQ(storage.payload.tensor_data()[0].buffer.addr, reinterpret_cast<uint64_t>(second_boundary.data()));
     EXPECT_EQ(execution->task_at(1).payload.tensor_data()[0].buffer.addr, reinterpret_cast<uint64_t>(heap.base() + 16));
     EXPECT_EQ(storage.slot.completed_subtasks.load(std::memory_order_relaxed), 0);
-    EXPECT_EQ(storage.payload.dispatch_fanin.load(std::memory_order_relaxed), 0);
+    EXPECT_EQ(storage.payload.published_block_count.load(std::memory_order_relaxed), 0);
     EXPECT_EQ(storage.payload.dump_metadata.dump_arg_mask, uint64_t{1} << 0);
 }
 
@@ -767,7 +767,7 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
         ASSERT_EQ(storage.slot.task_state.load(std::memory_order_relaxed), CHIP_TASK_PENDING);
         ASSERT_EQ(storage.slot.task_kind, TaskKind::KERNEL);
         ASSERT_EQ(storage.slot.completed_subtasks.load(std::memory_order_relaxed), 0);
-        ASSERT_EQ(storage.payload.dispatch_fanin.load(std::memory_order_relaxed), 0);
+        ASSERT_EQ(storage.payload.published_block_count.load(std::memory_order_relaxed), 0);
         ASSERT_EQ(storage.payload.tensor_count, 1);
         ASSERT_EQ(storage.payload.scalar_count, 1);
         // A tensor address of 0xAAAAAAAAAAAAAAAA would mean the fill leaked

--- a/tests/ut/cpp/common/test_hbg_slot_claim.cpp
+++ b/tests/ut/cpp/common/test_hbg_slot_claim.cpp
@@ -90,7 +90,7 @@ protected:
         state.completed_subtasks.store(7, std::memory_order_relaxed);
         state.next_block_idx.store(3, std::memory_order_relaxed);
         state.in_graph_local_id = 11;
-        sm_handle->header->tasks.completion_flags[slot].store(1, std::memory_order_relaxed);
+        sm_handle->header->tasks.progress_flags[slot].store(1, std::memory_order_relaxed);
     }
 
     void expect_slot_pristine(int32_t slot) {
@@ -101,7 +101,7 @@ protected:
         EXPECT_FALSE(state.has_any_subtask_deferred());
         EXPECT_EQ(state.completed_subtasks.load(std::memory_order_relaxed), 0);
         EXPECT_EQ(state.next_block_idx.load(std::memory_order_relaxed), 0);
-        EXPECT_EQ(sm_handle->header->tasks.completion_flags[slot].load(std::memory_order_relaxed), 0)
+        EXPECT_EQ(sm_handle->header->tasks.progress_flags[slot].load(std::memory_order_relaxed), 0)
             << "a stale completion flag reports this task done before it has run";
     }
 };

--- a/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
+++ b/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
@@ -77,7 +77,7 @@ public:
         tasks.total_tasks = static_cast<int32_t>(SUBMITTED);
         storage_ = reinterpret_cast<ChipTaskStorage *>(image_.base() + off.storage);
         tasks.task_storage = storage_;
-        tasks.completion_flags = completion_flags();
+        tasks.progress_flags = progress_flags();
 
         // Each live slot takes a packed region in each pool, exactly as the
         // orchestrator's bump cursors hand them out, and gets content that identifies
@@ -102,7 +102,7 @@ public:
                 entry.payload.fanin_data()[j] = static_cast<int32_t>(0x50 + i * 0x10 + j);
             }
             entry.slot.in_graph_local_id = static_cast<int32_t>(200 + i);
-            completion_flags()[i].store(static_cast<uint8_t>(i & 1), std::memory_order_relaxed);
+            progress_flags()[i].store(static_cast<uint8_t>(i & 1), std::memory_order_relaxed);
         }
         // A slot past the submitted prefix, to prove it does not travel.
         storage_[SUBMITTED].task.task_id = TaskId::make_global(0xBEEF);
@@ -143,9 +143,9 @@ public:
     int32_t *fanin_pool() {
         return reinterpret_cast<int32_t *>(image_.base() + sm_layout::segment_offsets(WINDOW).fanin_pool);
     }
-    std::atomic<uint8_t> *completion_flags() {
+    std::atomic<uint8_t> *progress_flags() {
         return reinterpret_cast<std::atomic<uint8_t> *>(
-            image_.base() + sm_layout::segment_offsets(WINDOW).completion_flags
+            image_.base() + sm_layout::segment_offsets(WINDOW).progress_flags
         );
     }
 
@@ -195,8 +195,8 @@ struct Compacted {
     simpler::hbg::Tensor *tensor_pool() {
         return reinterpret_cast<simpler::hbg::Tensor *>(image.base() + off().tensor_pool);
     }
-    std::atomic<uint8_t> *completion_flags() {
-        return reinterpret_cast<std::atomic<uint8_t> *>(image.base() + off().completion_flags);
+    std::atomic<uint8_t> *progress_flags() {
+        return reinterpret_cast<std::atomic<uint8_t> *>(image.base() + off().progress_flags);
     }
 };
 
@@ -222,7 +222,7 @@ TEST(HbgSmCompaction, CarriesEveryLiveSlotsContent) {
         EXPECT_EQ(entry.payload.tensor_count, TENSORS_PER_TASK) << "slot " << i;
         EXPECT_EQ(entry.payload.tensor_data()[0].buffer.addr, 0x1000 + i * 0x10) << "slot " << i;
         EXPECT_EQ(entry.slot.in_graph_local_id, static_cast<int32_t>(200 + i)) << "slot " << i;
-        EXPECT_EQ(compacted.completion_flags()[i].load(std::memory_order_relaxed), static_cast<uint8_t>(i & 1))
+        EXPECT_EQ(compacted.progress_flags()[i].load(std::memory_order_relaxed), static_cast<uint8_t>(i & 1))
             << "slot " << i;
     }
     // The header's pitch-independent fields come across; the mirror slot past the
@@ -276,7 +276,7 @@ TEST(HbgSmCompaction, LeavesNoHostPointerInTheHeader) {
 
     auto &tasks = reinterpret_cast<const SharedMemoryHeader *>(compacted.image.base())->tasks;
     EXPECT_EQ(tasks.task_storage, nullptr);
-    EXPECT_EQ(tasks.completion_flags, nullptr);
+    EXPECT_EQ(tasks.progress_flags, nullptr);
 }
 
 // A bind that submits nothing still ships its header and still attaches. Its pools
@@ -422,8 +422,8 @@ TEST(HbgSmCompaction, SegmentLayoutHoldsForANonPowerOfTwoCapacity) {
         // The storage sits right after the padded header, whatever the pitch.
         EXPECT_EQ(off.storage, CHIP_ALIGN_UP(sizeof(SharedMemoryHeader), CHIP_ALIGN_SIZE)) << "capacity " << capacity;
 
-        const uint64_t starts[] = {off.storage,     off.completion_flags, off.fanin_pool,
-                                   off.tensor_pool, off.scalar_pool,      off.end};
+        const uint64_t starts[] = {off.storage,     off.progress_flags, off.fanin_pool,
+                                   off.tensor_pool, off.scalar_pool,    off.end};
         const uint64_t spans[] = {
             capacity * sizeof(ChipTaskStorage), capacity * sizeof(std::atomic<uint8_t>),
             e.fanin_elems * sizeof(int32_t),    e.tensor_elems * sizeof(simpler::hbg::Tensor),


### PR DESCRIPTION
## Summary

host_build_graph's early-dispatch execution machinery (staging queues, doorbell table, gated cores, sync_start rendezvous, the AICore `src_payload` wait) has been dormant since polling dependency resolution removed the TMR-style producer-push detector. This PR wires a detector that fits the polling model — an **ED publish list**, the completion wake list's dual keyed on publication — instead of reinstating per-edge fanout walks.

- **Host qualification (bind time)**: a task is an ED candidate iff it has at least one producer, every producer carries `allow_early_resolve` and none of them is a Graph shell (a shell has no publication event; such disqualifications are counted in `ed_shell_disqualified`), it has no dispatch predicate and a dispatchable shape; producers get a tracked bit and a candidate's fanin row is sorted by local id (= submission order) so backward scans target the latest-submitted producer exactly. Non-candidate rows keep fill order — **a flag-free graph schedules exactly as before**.
- **ED publish list (device)**: the per-task progress byte (`progress_flags`, renamed from `completion_flags`) gains a monotonic PUBLISHED bit beside COMPLETED; a candidate hangs on its latest-submitted unpublished producer; a tracked producer's full publication seals its list with a sentinel exchange (registration CASes meeting the sentinel re-check — no stranded waiters) and hands the detached waiters to a pending-drain queue; idle threads rescan from a per-candidate cursor (total row loads bounded to fanin+1) and all-published verdicts claim candidates into the existing ED staging queues. The dispatch-path publish signal is O(1) regardless of fanout; a full drain queue only drops lists back to normal dispatch (teardown WARN).
- **Release**: `push_ready_routed` rings staged doorbells the moment readiness is decided (STAGING→DISPATCHED claim, destructive doorbell-bit split with late stagers, sync_start via the existing rendezvous); partially staged SPMD consumers fall through for their remaining blocks.
- **Completion wake scan gets the same cursor treatment** (`wake_scan_cursor`): `classify_fanin_state` resumes at the index the task last hung at — verdict-identical to a full rescan (completion bits are monotonic, hang decisions unchanged) while the row's completed tail is never re-walked; bounds a bet-miss cascade on a dense-fanin task from O(F²) to O(F) rescanned entries. A `static_assert` ties `CHIP_MAX_FANIN` to the byte-wide cursors.
- **Cleanup**: the dead TMR remnants (`dispatch_fanin`, `dispatch_propagated`, empty `propagate_dispatch_fanin` stub, comments naming TMR-only functions) are removed. All new fields fit existing reserved space: `sizeof(TaskPayload)==192` and `sizeof(ChipTaskSlotState)==64` both hold.

Scope: top-level tasks only; in-graph ED follows separately (its prerequisites — Definition CSR row sort, per-execution flag array — are mapped out and the list code is parameterized for reuse).

## Testing

- [x] UT (both arches): qualification verdicts, sorted candidate rows, publish-list lifecycle (register → seal → cursor rescan → verdict → claim), release claims, wake-cursor resume — 130/130 ctest
- [x] New ST scene: the sync_start early-dispatch case now runs against host_build_graph (kernels shared with the tensormap_and_ringbuffer twin) — passes on a2a3sim and a2a3 silicon
- [x] Full hbg suites green on a2a3sim and a5sim; TMR ED scenes unaffected
- [x] `hbg-bind-phases` qwen A/B (3 interleaved repetitions): host_orch unmoved
- [x] qwen device A/B on pinned dies: ED queues provably idle on this in-graph-dominated workload (queue probes all zero) and device wall within same-binary environmental spread
