### PR TITLE
Add: A5 RTT die-preflight scheduler placement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,11 @@ if(SKBUILD_MODE)
     # sanitizer build is requested.
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/cmake/
             DESTINATION simpler_setup/_assets/cmake)
+    # The public affinity preflight CLI builds and invokes this hardware
+    # backend from either a source checkout or an installed wheel.
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/simpler_setup/tools/aicpu_device_query/
+            DESTINATION simpler_setup/tools/aicpu_device_query
+            PATTERN "build" EXCLUDE)
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/build/lib/
             DESTINATION simpler_setup/_assets/build/lib
             OPTIONAL

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import contextlib
 import ctypes
+import subprocess
 import sys
 import threading
 import uuid
@@ -1289,6 +1290,129 @@ def _initialize_host_log(log_level: int | None = None, *, defer_writer: bool = F
     _log.attach_unified_log_handler(_native_emit_host_log, _native_host_log_directory)
 
 
+def _is_a5_onboard_bins(bins: Any) -> bool:
+    """True when binaries look like a5 onboard (dispatcher + host under .../a5/...)."""
+    dispatcher = getattr(bins, "dispatcher_path", None)
+    if dispatcher is None or str(dispatcher) == "":
+        return False
+    host = getattr(bins, "host_path", None)
+    if host is None:
+        return False
+    return "a5" in Path(host).parts
+
+
+def _affinity_plan_paths(device_id: int) -> tuple[Path, Path]:
+    """Resolve the exact per-device JSON and runtime companion paths."""
+    from simpler_setup.tools.rtt_die_preflight import cpus_side_path, default_plan_path  # noqa: PLC0415
+
+    plan = default_plan_path(int(device_id))
+    return plan, cpus_side_path(plan)
+
+
+def _ensure_a5_affinity_cpus(device_id: int, bins: Any) -> None:
+    """If a5 onboard and .cpus side file is missing, run rtt_die_preflight --probe.
+
+    Never raises into ChipWorker.init: probe failure leaves prepare to use
+    OCCUPY contiguous fallback. Prints start / skip / done / fail for operators.
+    """
+    if not _is_a5_onboard_bins(bins):
+        return
+
+    from simpler_setup.tools.rtt_die_preflight import (  # noqa: PLC0415
+        HELPER_BUILD_TIMEOUT_SECONDS,
+        PREFLIGHT_TIMEOUT_SECONDS,
+        plan_files_look_usable,
+        timeout_record_looks_usable,
+        timeout_record_path,
+    )
+
+    plan, side = _affinity_plan_paths(device_id)
+    timeout_record = timeout_record_path(plan)
+    if plan_files_look_usable(plan, device_id):
+        print(f"[affinity-preflight] device={device_id} skip, using existing {side}", flush=True)
+        return
+    if timeout_record_looks_usable(timeout_record, device_id):
+        print(
+            f"[affinity-preflight] device={device_id} skip, previous probe timed out; "
+            "runtime will use OCCUPY contiguous fallback",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+
+    print(
+        f"[affinity-preflight] device={device_id} start → valid plan missing; probing to {plan}…",
+        flush=True,
+    )
+    cmd = [
+        sys.executable,
+        "-m",
+        "simpler_setup.tools.rtt_die_preflight",
+        "--device",
+        str(int(device_id)),
+        "--probe",
+        "--plan-source",
+        "auto-first-run",
+        "--out",
+        str(plan),
+    ]
+    # Outer timeout is only a safety net covering helper builds + the 30s probe.
+    # The CLI alone decides whether a device-probe timeout warrants a permanent
+    # `.timeout` marker; a hung helper build must not permanently skip probing.
+    try:
+        completed = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=HELPER_BUILD_TIMEOUT_SECONDS + PREFLIGHT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"[affinity-preflight] device={device_id} exceeded helper-build+probe safety budget "
+            f"({HELPER_BUILD_TIMEOUT_SECONDS + PREFLIGHT_TIMEOUT_SECONDS}s); "
+            "runtime will use OCCUPY contiguous fallback",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+    except OSError as exc:
+        print(
+            f"[affinity-preflight] device={device_id} failed to spawn preflight ({exc}); "
+            "runtime will use OCCUPY contiguous fallback",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+    if completed.stdout:
+        sys.stdout.write(completed.stdout)
+        if not completed.stdout.endswith("\n"):
+            sys.stdout.write("\n")
+        sys.stdout.flush()
+    if completed.stderr:
+        sys.stderr.write(completed.stderr)
+        if not completed.stderr.endswith("\n"):
+            sys.stderr.write("\n")
+        sys.stderr.flush()
+    if timeout_record_looks_usable(timeout_record, device_id):
+        print(
+            f"[affinity-preflight] device={device_id} timed out; runtime will use OCCUPY contiguous fallback",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+    if completed.returncode != 0 or not plan_files_look_usable(plan, device_id):
+        err = (completed.stderr or "").strip() or f"exit={completed.returncode}"
+        last = err.splitlines()[-1] if err else "unknown"
+        print(
+            f"[affinity-preflight] device={device_id} failed ({last}); runtime will use OCCUPY contiguous fallback",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+    print(f"[affinity-preflight] device={device_id} done → wrote {plan} and {side}", flush=True)
+
+
 def _start_host_log_writer() -> None:
     """Start the process-owned writer after the process's final local fork."""
     if not _native_start_host_log_writer():
@@ -1420,6 +1544,7 @@ class ChipWorker:
 
         try:
             _initialize_host_log(log_level)
+            _ensure_a5_affinity_cpus(int(device_id), bins)
 
             # C++ retains libcpu_sim_context.so in the sim process registry,
             # loads host_runtime.so, and binds both private logger copies.

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -19,6 +19,7 @@ no repo checkout required.
 - **[dump_viewer](#dump_viewer)** — inspect / export args dumps (see [docs/args-dump.md](../../docs/dfx/args-dump.md) for full workflow)
 - **[deps_viewer](#deps_viewer)** — `deps.json` (dep_gen) → text or pan/zoom HTML dependency graph
 - **[wait_reduction_sim](#wait_reduction_sim)** — `deps.json` (dep_gen) → bounded-bitmap WAIT reduction coverage vs the full-DAG upper bound, per BL
+- **[rtt_die_preflight](#rtt_die_preflight)** — full AICPU affinity preflight → per-device `aicpu_affinity_plan.<id>.json` (authoritative `allowed_cpus`; backend: `aicpu_device_query/`)
 
 For CLIs that allow an omitted input, auto-detection paths
 (`outputs/*/chip_swimlane_records.json`, `outputs/*/args_dump/`) are resolved
@@ -911,6 +912,49 @@ For batch-run hardware regression, see the dev-only script
 - Install graphviz: `brew install graphviz` (macOS) or `apt install graphviz` (Debian/Ubuntu)
 - Verify with `which dot`; should print a path
 - Use a different layout engine with `--engine sfdp` for very large graphs
+
+---
+
+## rtt_die_preflight
+
+Full A5 AICPU affinity preflight. Invokes
+`simpler_setup/tools/aicpu_device_query` (`--rtt-json`) to:
+
+1. enumerate the user AICPU pool (serial `aicpu_num=1`)
+2. elect the orchestrator via atomic-flag pairwise handshake (1000 iters)
+3. score non-orch threads with COND die sums (100 samples/core)
+4. pack physical picks `{die0,die1,die1,die0}` into logical
+   `[S0,S1,S2,S3,O]` so **S0/S1 own die0 and S2/S3 own die1**
+
+Writes one independent schema-v3 pair per device:
+`build/config/aicpu_affinity_plan.<device_id>.json` and the matching `.cpus`
+companion. Independent files avoid shared-JSON lost updates during parallel L3
+initialization. A probe requires a complete pool of 5–14 CPUs. Any enumeration,
+measurement, or validation failure writes neither file; the runtime then uses
+OCCUPY-contiguous allocation in memory.
+
+On a5 onboard `ChipWorker.init`, if the JSON/side pair is missing or structurally
+invalid the Python wrapper runs this CLI (`--plan-source auto-first-run`) with
+the exact per-device `--out` path and prints start / done / fail. `DeviceRunner`
+only reads the side file. A valid five-thread plan is used for four schedulers;
+other requested widths, or a missing/invalid plan, warn and use exactly the
+requested number of OCCUPY-contiguous CPUs. C++ never spawns Python.
+The automatic device probe is bounded by 30 seconds after helper compilation;
+helper/dispatcher builds use a separate budget and are excluded from that
+timer. A device-probe timeout writes a per-device `.timeout` record and later
+automatic initialization skips probing and falls back directly. An explicit
+manual `--probe` clears the record before retrying. A helper-build timeout
+does not write `.timeout`.
+
+```bash
+task-submit --device auto --device-num 1 --run \
+  'python -m simpler_setup.tools.rtt_die_preflight --device "$TASK_DEVICE" --probe'
+
+# Offline authoritative write (plan_source=manual):
+python -m simpler_setup.tools.rtt_die_preflight --device 0 \
+  --soc Ascend950PR_9599 --allowed-cpus 3,4,5,6,8 \
+  --occupy-cpus 3,4,5,6,7,8
+```
 
 ---
 

--- a/simpler_setup/tools/__init__.py
+++ b/simpler_setup/tools/__init__.py
@@ -19,4 +19,5 @@ Invoke via ``python -m simpler_setup.tools.<name>``:
 - ``strace_timing``         : per-stage / per-round timing from [STRACE] log markers
 - ``hbg_bind_phases``       : per-segment host_build_graph bind statistics from the chip.run.bind.* spans
 - ``phase_time_split``      : the same segments split into on-CPU and off-CPU, from per-thread CPU clocks
+- ``rtt_die_preflight``     : A5 affinity preflight → allowed_cpus plan (uses aicpu_device_query)
 """

--- a/simpler_setup/tools/aicpu_device_query/README.md
+++ b/simpler_setup/tools/aicpu_device_query/README.md
@@ -1,0 +1,199 @@
+# aicpu_device_query (affinity preflight backend)
+
+Shipped under `simpler_setup/tools/` (not `tools/cann-examples/`). Invoked by
+`python -m simpler_setup.tools.rtt_die_preflight` for production A5
+`ALLOWED_CPUS` plans. Also supports device-side `halGetDeviceInfo` queries and
+`--json` topology diagnostics via the same dispatcher bootstrap as the
+production `simpler` runtime.
+
+Runs queries that CANN's header flags as "used in device" — `AICPU + OS_SCHED`,
+`AICPU + PF_*`, `CCPU/DCPU/TSCPU + OCCUPY`, etc. — which always return failure
+from host code.
+
+## What it answered
+
+On a3 (`Ascend910_9392`), running `query_device_hal 4` returned:
+
+```text
+AICPU + OS_SCHED      rc=0  val=0x1     ← AICPU OS owns cpu_id 0
+AICPU + OCCUPY        rc=0  val=0xfc    ← cpu_id 2..7 are the 6 user cores
+AICPU + PF_OCCUPY     rc=0  val=0xfc    ← matches OCCUPY → no vNPU slicing
+AICPU + PF_CORE_NUM   rc=0  val=0x6     ← PF view = 6, confirms no virtualization
+CCPU  + OCCUPY        rc=0  val=0x1     ← CCPU has 1 core, occupied
+DCPU/TSCPU queries fail (rc=3) — module-level access restricted device-side
+```
+
+Combined with the absence of vNPU mode, this closes the long-standing "is
+the AICPU 8 → 6 gap OS-reservation or PG fab-disable?" question on a3:
+
+- **cpu_id 0** = AICPU OS scheduler (`OS_SCHED` bit 0)
+- **cpu_id 1** = PG fab-disabled (not in any module's OCCUPY mask, no
+  virtualization can hide it)
+- **cpu_id 2..7** = 6 user-schedulable AICPU cores
+
+The full writeup is in
+[`src/a2a3/docs/hardware.md`](../../../src/a2a3/docs/hardware.md#device-side-probe-resolves-the-aicpu-question).
+
+On a5 (`Ascend950PR_9599`), running `query_device_hal 0` returned:
+
+```text
+AICPU + OS_SCHED      rc=0  val=0x1     ← AICPU OS owns cpu_id 0
+AICPU + OCCUPY        rc=0  val=0x1f8   ← cpu_id 3..8 are the 6 user cores
+                                          (DIFFERS from host-side 0x1fe)
+AICPU + PF_OCCUPY     rc=0  val=0x1f8   ← matches OCCUPY → no vNPU slicing
+AICPU + PF_CORE_NUM   rc=0  val=0x6     ← PF view = 6, confirms no virtualization
+AICPU + CORE_NUM      rc=3              ← restricted device-side on a5 (worked on a3)
+CCPU  + OCCUPY        rc=0  val=0x1     ← CCPU has 1 core, occupied
+DCPU/TSCPU queries fail (rc=3) — module-level access restricted device-side
+```
+
+The 2-bit host-vs-device OCCUPY divergence (host `0x1fe`, device `0x1f8`)
+exactly matches DSMI CPU_TOPO's single SMT pair at cpu_id 1, 2 — the
+AICPU OS keeps the SMT pair for itself rather than exposing it to user
+kernel dispatch. So the a5 9 → 6 gap is:
+
+- **cpu_id 0** = AICPU OS scheduler (`OS_SCHED` bit 0)
+- **cpu_id 1, 2** = SMT pair on phy_cpu_id 1, AICPU-OS-reserved (present
+  in host-side OCCUPY so **not** PG fab-disabled — a5 does not have the
+  a3-style fab-disable pattern)
+- **cpu_id 3..8** = 6 user-schedulable AICPU cores
+
+Full writeup: [`src/a5/docs/hardware.md`](../../../src/a5/docs/hardware.md#device-side-probe-resolves-the-aicpu-question).
+
+## Architecture
+
+Three pieces, exact same wiring as the production runtime's AICPU upload
+chain — see [`src/common/aicpu_dispatcher/README.md`](../../../src/common/aicpu_dispatcher/README.md)
+for the dispatcher's role and
+[`docs/aicpu-kernel-launch-mechanisms.md`](../../../docs/aicpu-kernel-launch-mechanisms.md)
+for why this method (Path A) and not tar.gz pre-deployment or the
+broken Path B (`KERNEL_TYPE_AICPU_CUSTOM`, issue #822).
+
+```text
++---------------------+        rtAicpuKernelLaunchExWithArgs (KFC, libaicpu_extend_kernels)
+|   host launcher     | ---->  bootstrap: libaicpu_extend_kernels dlopens dispatcher SO,
+|  query_device_hal   |        which writes our inner SO bytes to /usr/lib64/aicpu_kernels/0/...
++---------------------+
+          |
+          | rtsBinaryLoadFromFile (JSON), rtsFuncGetByName, rtsLaunchCpuKernel
+          v
++---------------------+
+|  libaicpu_query.so  |   query: halGetDeviceInfo -> QueryResult[]
+|  (inner SO)         |   affinity: enum / handshake orch / COND die scores
++---------------------+   -> writes pool metrics to GM
+          |
+          | D2H aclrtMemcpy
+          v
++---------------------+
+|   host launcher     | pretty-prints the results
++---------------------+
+```
+
+The dispatcher is reused unchanged from the standard runtime build. Select the
+A2/A3 or A5 artifact through `SIMPLER_DISPATCHER_SO`; the A5 artifact is the
+default because `--json` performs A5 topology classification.
+
+## Build
+
+```bash
+export ASCEND_HOME_PATH=/usr/local/Ascend/ascend-toolkit/latest
+
+# 1. cross-compile device SO
+cd device
+mkdir -p build && cd build
+cmake .. \
+    -DCMAKE_C_COMPILER=${ASCEND_HOME_PATH}/tools/hcc/bin/aarch64-target-linux-gnu-gcc \
+    -DCMAKE_CXX_COMPILER=${ASCEND_HOME_PATH}/tools/hcc/bin/aarch64-target-linux-gnu-g++
+cmake --build .
+
+# 2. host launcher
+cd ../../host
+mkdir -p build && cd build
+cmake ..
+cmake --build .
+```
+
+If the Ascend driver is installed outside `/usr/local/Ascend/driver`, configure
+the host build with
+`-DASCEND_DRIVER_LIB_DIR=/path/to/driver/lib64/driver`.
+
+## Run
+
+The dispatcher SO comes from a normal `pip install .` runtime build —
+build the runtime first if you have not.
+
+```bash
+export SIMPLER_DISPATCHER_SO=$REPO/build/lib/a5/dispatcher/libsimpler_aicpu_dispatcher.so
+export SIMPLER_AICPU_QUERY_SO=$REPO/build/cache/aicpu_device_query/device/libaicpu_query.so
+
+# Always run hardware work via task-submit on this dev box (see
+# .claude/rules/running-onboard.md).
+task-submit --device auto --device-num 1 \
+    --run "$REPO/build/cache/aicpu_device_query/host/query_device_hal \$TASK_DEVICE"
+
+# A5 only: topology JSON.
+task-submit --device auto --device-num 1 \
+    --run "$REPO/build/cache/aicpu_device_query/host/query_device_hal \$TASK_DEVICE --json"
+
+# A5 only: public affinity preflight. The Python CLI invokes this tool's
+# --rtt-json mode, validates every measurement, and writes an independent
+# aicpu_affinity_plan.<device_id>.json/.cpus pair. Probe failure writes no
+# artifacts; production DeviceRunner then uses OCCUPY-contiguous allocation.
+task-submit --device auto --device-num 1 --run \
+    'python -m simpler_setup.tools.rtt_die_preflight --device "$TASK_DEVICE" --probe'
+```
+
+The public Python command (`rtt_die_preflight`) builds helper artifacts under
+`build/cache/aicpu_device_query/` and launches `query_device_hal` directly; it
+does not write into the packaged tool-source directory. The explicit paths
+above remain useful when developing the standalone host/device binaries.
+
+`--json` keeps diagnostics on stderr and writes only the JSON document to
+stdout. The document includes topology source, FG/PG classification, all
+logical-CPU metadata, device masks, selection policy, active count, full OCCUPY
+launch count, and `[S..., O]` affinity. Production runtimes do **not** use this
+FG/PG selection for `ALLOWED_CPUS`; `--json` is for tooling and diagnostics.
+
+`--rtt-json` runs the full affinity preflight (schema v3):
+
+1. use a complete verified topology pool when available; otherwise require
+   serial `aicpu_num=1` discovery to reproduce the complete OCCUPY set
+2. multi-thread atomic-flag pairwise handshake (1000 iters) to elect orch
+3. serialized COND die scoring for non-orch threads (100 samples/core)
+4. emit raw pool metrics; Python packs phys `{die0,die1,die1,die0}` into
+   logical `[S0,S1,S2,S3,O]` (S0/S1→die0, S2/S3→die1)
+
+Pool size `< 5` emits `pool_too_small` and skips handshake/COND; the public
+Python command treats that as failure and writes no files. Pools above the
+verified launch maximum of 14 are also rejected. Launch uses the OCCUPY
+popcount so the gate sees the full user pool.
+
+## Running on each arch
+
+The same CMakeLists builds for a3 and a5 — only the dispatcher SO you
+point at via `SIMPLER_DISPATCHER_SO` is per-arch:
+
+- a3: `build/lib/a2a3/dispatcher/libsimpler_aicpu_dispatcher.so`
+- a5: `build/lib/a5/dispatcher/libsimpler_aicpu_dispatcher.so`
+
+`libascend_hal.so` lives at the same relative path
+(`${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/devlib/...`) on
+both arches. Both `Ascend910_9392` (a3) and `Ascend950PR_9599` (a5)
+have been validated with this tool — see "What it answered" above.
+
+## Scope and limits
+
+- This is **not** a generic device-side HAL inspector. The hardcoded
+  query list in `host/query_device_hal.cpp` reflects the A3/A5 occupancy
+  and virtualization questions plus A5 classification. Extending the list to
+  other modules / infoTypes is a small edit — `requests` vector + the
+  `kModuleName`/`kInfoName` switches.
+- The RTT mode is A5-only: it relies on the A5 per-core `halResMap` layout,
+  two dies of 18 AICores, and `REG_SPR_COND_OFFSET` from platform config.
+- The inner SO uses local device id 0 (`self_did = 0`) — validated as
+  the correct convention from inside an AICPU OS process. Passing the
+  host's logical device id from inside the kernel returns rc=1 for all
+  AICPU queries.
+- "Used in device" PF queries that work device-side (`PF_OCCUPY`,
+  `PF_CORE_NUM`) are useful for confirming SR-IOV/vNPU state — they
+  must equal `OCCUPY` / `CORE_NUM` when not in a virtualized split.

--- a/simpler_setup/tools/aicpu_device_query/device/CMakeLists.txt
+++ b/simpler_setup/tools/aicpu_device_query/device/CMakeLists.txt
@@ -1,0 +1,60 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+#
+# Cross-compiles aicpu_query.so for AICPU device side.
+# Caller must set CMAKE_C_COMPILER / CMAKE_CXX_COMPILER to the aarch64
+# cross toolchain (e.g. ${ASCEND_HOME_PATH}/tools/hcc/bin/aarch64-target-linux-gnu-g++).
+
+cmake_minimum_required(VERSION 3.16)
+project(aicpu_query LANGUAGES C CXX)
+
+set(SIMPLER_ROOT "" CACHE PATH "Simpler source or installed _assets root")
+if(NOT SIMPLER_ROOT)
+    get_filename_component(SIMPLER_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE)
+endif()
+if(NOT EXISTS "${SIMPLER_ROOT}/src/a5/platform/include/common/platform_config.h")
+    message(FATAL_ERROR "SIMPLER_ROOT=${SIMPLER_ROOT} does not contain the required packaged/source src tree")
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+if(NOT DEFINED ENV{ASCEND_HOME_PATH})
+    message(FATAL_ERROR "ASCEND_HOME_PATH must be set")
+endif()
+set(ASCEND_HOME_PATH $ENV{ASCEND_HOME_PATH})
+
+add_library(aicpu_query SHARED aicpu_query.cpp)
+
+target_include_directories(aicpu_query PRIVATE
+    ${ASCEND_HOME_PATH}/include
+    ${SIMPLER_ROOT}/src/a5/platform/include
+)
+
+target_compile_options(aicpu_query PRIVATE
+    -Wall -Wextra -O2 -fPIC -fno-common -g
+)
+
+# Link device-side libascend_hal.so so halGetDeviceInfo resolves.
+target_link_directories(aicpu_query PRIVATE
+    # CANN is installed under the host architecture directory even though this
+    # target is cross-compiled for aarch64.
+    ${ASCEND_HOME_PATH}/${CMAKE_HOST_SYSTEM_PROCESSOR}-linux/devlib/linux/aarch64/
+    ${ASCEND_HOME_PATH}/${CMAKE_HOST_SYSTEM_PROCESSOR}-linux/devlib/device/
+)
+
+target_link_libraries(aicpu_query PRIVATE ascend_hal)
+
+# Build-id needed: dispatcher fingerprints by ELF Build-ID (FNV-1a fallback only
+# fires when no build-id note is present).
+set_target_properties(aicpu_query PROPERTIES
+    LINK_FLAGS "-Wl,--build-id"
+    OUTPUT_NAME "aicpu_query"
+)

--- a/simpler_setup/tools/aicpu_device_query/device/aicpu_query.cpp
+++ b/simpler_setup/tools/aicpu_device_query/device/aicpu_query.cpp
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+//
+// aicpu_query.cpp — device-side AICPU SO that runs HAL queries plus the full
+// affinity preflight (serial enum helper, atomic-flag handshake orch election,
+// COND die scoring for non-orchestrator threads).
+
+#include <cstdint>
+#include <cstring>
+#include <sched.h>
+
+#include <driver/ascend_hal_base.h>
+
+#include "common/platform_config.h"
+#include "../shared/rtt_probe_types.h"
+
+namespace {
+
+constexpr uint32_t kHalSuccess = 0;
+
+struct DeviceArgs {
+    uint64_t reserved_pre[12];
+    uint64_t q_input_addr;
+    uint64_t q_input_count;
+    uint64_t q_output_addr;
+};
+
+struct KernelArgs {
+    uint64_t _pad[5];
+    void *device_args;
+};
+
+#pragma pack(push, 4)
+struct QueryRequest {
+    int32_t module_type;
+    int32_t info_type;
+};
+struct QueryResult {
+    int32_t rc;
+    int32_t _pad;
+    int64_t value;
+};
+#pragma pack(pop)
+static_assert(sizeof(QueryRequest) == 8, "QueryRequest size drift");
+static_assert(sizeof(QueryResult) == 16, "QueryResult size drift");
+
+extern "C" void DlogRecord(int moduleId, int level, const char *fmt, ...);
+
+constexpr int kDlogModuleCcecpu = 3;
+constexpr int kDlogLevelError = 3;
+
+void DiagLog(const char *msg) { DlogRecord(kDlogModuleCcecpu, kDlogLevelError, "[aicpu-query] %s", msg); }
+
+inline uint64_t SysCntAicpu() {
+    uint64_t value;
+    __asm__ volatile("mrs %0, cntvct_el0" : "=r"(value));
+    return value;
+}
+
+inline uint64_t SysCntFrequencyAicpu() {
+    uint64_t value;
+    __asm__ volatile("mrs %0, cntfrq_el0" : "=r"(value));
+    return value;
+}
+
+void TouchDie(const uint64_t *aicore_regs, uint32_t first_core, uint32_t cores_per_die, uint32_t samples_per_core) {
+    volatile uint32_t sink = 0;
+    for (uint32_t core = first_core; core < first_core + cores_per_die; ++core) {
+        auto *cond = reinterpret_cast<volatile uint32_t *>(aicore_regs[core] + REG_SPR_COND_OFFSET);
+        for (uint32_t sample = 0; sample < samples_per_core; ++sample) {
+            sink = *cond;
+        }
+    }
+    (void)sink;
+}
+
+uint64_t MeasureDieTotalTicks(
+    const uint64_t *aicore_regs, uint32_t first_core, uint32_t cores_per_die, uint32_t samples_per_core
+) {
+    const uint64_t begin = SysCntAicpu();
+    TouchDie(aicore_regs, first_core, cores_per_die, samples_per_core);
+    return SysCntAicpu() - begin;
+}
+
+void SetProbeError(AffinityPreflightOutput *output, AffinityProbeError error) {
+    uint32_t expected = static_cast<uint32_t>(AffinityProbeError::kNone);
+    (void)__atomic_compare_exchange_n(
+        &output->error_code, &expected, static_cast<uint32_t>(error), false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE
+    );
+}
+
+bool WaitForProbeValue(AffinityPreflightOutput *output, uint32_t *value, uint32_t target) {
+    const uint64_t begin = SysCntAicpu();
+    const uint64_t timeout_ticks = SysCntFrequencyAicpu() * kAffinityBarrierTimeoutSeconds;
+    while (__atomic_load_n(value, __ATOMIC_ACQUIRE) < target) {
+        if (__atomic_load_n(&output->error_code, __ATOMIC_ACQUIRE) !=
+            static_cast<uint32_t>(AffinityProbeError::kNone)) {
+            return false;
+        }
+        if (SysCntAicpu() - begin >= timeout_ticks) {
+            SetProbeError(output, AffinityProbeError::kBarrierTimeout);
+            return false;
+        }
+        __asm__ volatile("yield");
+    }
+    return true;
+}
+
+bool WaitEq(AffinityPreflightOutput *output, volatile uint32_t *cell, uint32_t expected) {
+    const uint64_t begin = SysCntAicpu();
+    const uint64_t timeout_ticks = SysCntFrequencyAicpu() * kAffinityBarrierTimeoutSeconds;
+    while (__atomic_load_n(cell, __ATOMIC_ACQUIRE) != expected) {
+        if (__atomic_load_n(&output->error_code, __ATOMIC_ACQUIRE) !=
+            static_cast<uint32_t>(AffinityProbeError::kNone)) {
+            return false;
+        }
+        if (SysCntAicpu() - begin >= timeout_ticks) {
+            SetProbeError(output, AffinityProbeError::kBarrierTimeout);
+            return false;
+        }
+        __asm__ volatile("yield");
+    }
+    return true;
+}
+
+uint64_t HandshakePair(
+    AffinityPreflightOutput *output, uint32_t initiator, uint32_t responder, uint32_t my_idx, uint32_t iters
+) {
+    volatile uint32_t *req = &output->handshake_req[initiator][responder];
+    volatile uint32_t *ack = &output->handshake_ack[responder][initiator];
+    const uint64_t begin = SysCntAicpu();
+    for (uint32_t iter = 1; iter <= iters; ++iter) {
+        if (my_idx == initiator) {
+            __atomic_store_n(req, iter, __ATOMIC_RELEASE);
+            if (!WaitEq(output, ack, iter)) return 0;
+        } else if (my_idx == responder) {
+            if (!WaitEq(output, req, iter)) return 0;
+            __atomic_store_n(ack, iter, __ATOMIC_RELEASE);
+        }
+    }
+    return SysCntAicpu() - begin;
+}
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default"))) int simpler_aicpu_init(void *args) {
+    (void)args;
+    return 0;
+}
+
+__attribute__((visibility("default"))) int simpler_aicpu_query(void *args) {
+    if (args == nullptr) {
+        DiagLog("simpler_aicpu_query: args==nullptr");
+        return 1;
+    }
+    auto *k = reinterpret_cast<KernelArgs *>(args);
+    auto *d = reinterpret_cast<DeviceArgs *>(k->device_args);
+    if (d == nullptr) {
+        DiagLog("simpler_aicpu_query: device_args==nullptr");
+        return 1;
+    }
+    if (d->q_input_addr == 0 || d->q_output_addr == 0 || d->q_input_count == 0) {
+        DiagLog("simpler_aicpu_query: empty I/O buffers");
+        return 1;
+    }
+
+    auto *requests = reinterpret_cast<const QueryRequest *>(d->q_input_addr);
+    auto *results = reinterpret_cast<QueryResult *>(d->q_output_addr);
+    const uint64_t n = d->q_input_count;
+    const uint32_t self_did = 0;
+
+    for (uint64_t i = 0; i < n; ++i) {
+        int64_t value = 0;
+        drvError_t rc = halGetDeviceInfo(self_did, requests[i].module_type, requests[i].info_type, &value);
+        results[i].rc = static_cast<int32_t>(rc);
+        results[i]._pad = 0;
+        results[i].value = (rc == kHalSuccess) ? value : 0;
+    }
+
+    return 0;
+}
+
+// Phase 1 helper: launched with aicpu_num=1; records sched_getcpu().
+__attribute__((visibility("default"))) int simpler_aicpu_affinity_enum(void *args) {
+    if (args == nullptr) {
+        DiagLog("simpler_aicpu_affinity_enum: args==nullptr");
+        return 1;
+    }
+    auto *kernel_args = reinterpret_cast<KernelArgs *>(args);
+    auto *device_args = reinterpret_cast<AffinityEnumDeviceArgs *>(kernel_args->device_args);
+    if (device_args == nullptr || device_args->output_addr == 0) {
+        DiagLog("simpler_aicpu_affinity_enum: invalid buffers");
+        return 1;
+    }
+    auto *output = reinterpret_cast<AffinityEnumOutput *>(device_args->output_addr);
+    output->cpu_id = sched_getcpu();
+    __atomic_store_n(&output->ready, 1u, __ATOMIC_RELEASE);
+    return 0;
+}
+
+__attribute__((visibility("default"))) int simpler_aicpu_affinity_preflight(void *args) {
+    if (args == nullptr) {
+        DiagLog("simpler_aicpu_affinity_preflight: args==nullptr");
+        return 1;
+    }
+    auto *kernel_args = reinterpret_cast<KernelArgs *>(args);
+    auto *device_args = reinterpret_cast<AffinityPreflightDeviceArgs *>(kernel_args->device_args);
+    if (device_args == nullptr || device_args->output_addr == 0 || device_args->aicore_regs_addr == 0 ||
+        device_args->user_pool_addr == 0) {
+        DiagLog("simpler_aicpu_affinity_preflight: invalid buffers");
+        return 1;
+    }
+    const uint32_t pool_count = device_args->pool_count;
+    if (pool_count < 2 || pool_count > kAffinityMaxPool || device_args->aicore_count == 0 ||
+        device_args->aicore_count % PLATFORM_NUM_DIES != 0 || device_args->handshake_iters == 0 ||
+        device_args->samples_per_core == 0) {
+        DiagLog("simpler_aicpu_affinity_preflight: invalid topology");
+        return 1;
+    }
+
+    const int cpu_id = sched_getcpu();
+    const auto *user_pool = reinterpret_cast<const int32_t *>(device_args->user_pool_addr);
+    int32_t pool_idx = -1;
+    for (uint32_t idx = 0; idx < pool_count; ++idx) {
+        if (user_pool[idx] == cpu_id) {
+            pool_idx = static_cast<int32_t>(idx);
+            break;
+        }
+    }
+    if (pool_idx < 0) return 0;
+
+    auto *output = reinterpret_cast<AffinityPreflightOutput *>(device_args->output_addr);
+    const auto *aicore_regs = reinterpret_cast<const uint64_t *>(device_args->aicore_regs_addr);
+    const uint32_t cores_per_die = device_args->aicore_count / PLATFORM_NUM_DIES;
+    const uint32_t iters = device_args->handshake_iters;
+
+    const uint32_t bit = 1u << static_cast<uint32_t>(pool_idx);
+    const uint32_t previous = __atomic_fetch_or(&output->claimed_mask, bit, __ATOMIC_ACQ_REL);
+    if ((previous & bit) != 0) {
+        SetProbeError(output, AffinityProbeError::kDuplicatePool);
+        return 1;
+    }
+
+    AffinityPoolSlot &slot = output->slots[pool_idx];
+    slot.pool_idx = pool_idx;
+    slot.cpu_id = cpu_id;
+
+    __atomic_add_fetch(&output->ready_count, 1u, __ATOMIC_ACQ_REL);
+    if (!WaitForProbeValue(output, &output->ready_count, pool_count)) return 1;
+    if (pool_idx == 0) {
+        __atomic_store_n(&output->pool_count, pool_count, __ATOMIC_RELEASE);
+    }
+
+    // Phase 2: pairwise atomic-flag handshake for every unordered pair.
+    uint64_t handshake_sum = 0;
+    uint32_t handshake_pairs = 0;
+    for (uint32_t i = 0; i < pool_count; ++i) {
+        for (uint32_t j = i + 1; j < pool_count; ++j) {
+            const uint64_t ticks = HandshakePair(output, i, j, static_cast<uint32_t>(pool_idx), iters);
+            if (__atomic_load_n(&output->error_code, __ATOMIC_ACQUIRE) !=
+                static_cast<uint32_t>(AffinityProbeError::kNone)) {
+                return 1;
+            }
+            if (static_cast<uint32_t>(pool_idx) == i || static_cast<uint32_t>(pool_idx) == j) {
+                const uint64_t avg = ticks / static_cast<uint64_t>(iters);
+                handshake_sum += avg;
+                ++handshake_pairs;
+                if (static_cast<uint32_t>(pool_idx) == i) {
+                    // Store avg+1 so a true zero average still publishes.
+                    const uint64_t published_avg = avg + 1;
+                    __atomic_store_n(
+                        &output->handshake_pair_ticks[i * kAffinityMaxPool + j], published_avg, __ATOMIC_RELEASE
+                    );
+                    __atomic_store_n(
+                        &output->handshake_pair_ticks[j * kAffinityMaxPool + i], published_avg, __ATOMIC_RELEASE
+                    );
+                }
+            }
+            // All threads wait until the pair's matrix entry is published.
+            volatile uint64_t *published = &output->handshake_pair_ticks[i * kAffinityMaxPool + j];
+            const uint64_t begin = SysCntAicpu();
+            const uint64_t timeout_ticks = SysCntFrequencyAicpu() * kAffinityBarrierTimeoutSeconds;
+            while (__atomic_load_n(published, __ATOMIC_ACQUIRE) == 0) {
+                if (__atomic_load_n(&output->error_code, __ATOMIC_ACQUIRE) !=
+                    static_cast<uint32_t>(AffinityProbeError::kNone)) {
+                    return 1;
+                }
+                if (SysCntAicpu() - begin >= timeout_ticks) {
+                    SetProbeError(output, AffinityProbeError::kBarrierTimeout);
+                    return 1;
+                }
+                __asm__ volatile("yield");
+            }
+        }
+    }
+
+    slot.avg_handshake_ticks =
+        handshake_pairs > 0 ? handshake_sum / static_cast<uint64_t>(handshake_pairs) : UINT64_MAX;
+    __atomic_store_n(&slot.handshake_valid, 1u, __ATOMIC_RELEASE);
+
+    for (uint32_t idx = 0; idx < pool_count; ++idx) {
+        if (!WaitForProbeValue(output, &output->slots[idx].handshake_valid, 1u)) return 1;
+    }
+
+    // Elect orch: minimum average handshake latency; tie-break on smaller pool_idx.
+    if (pool_idx == 0) {
+        uint32_t best = 0;
+        uint64_t best_avg = output->slots[0].avg_handshake_ticks;
+        for (uint32_t idx = 1; idx < pool_count; ++idx) {
+            const uint64_t avg = output->slots[idx].avg_handshake_ticks;
+            if (avg < best_avg || (avg == best_avg && idx < best)) {
+                best = idx;
+                best_avg = avg;
+            }
+        }
+        output->slots[best].is_orch = 1;
+        __atomic_store_n(&output->orch_pool_idx, best, __ATOMIC_RELEASE);
+        __atomic_store_n(&output->handshake_done, 1u, __ATOMIC_RELEASE);
+    }
+    if (!WaitForProbeValue(output, &output->handshake_done, 1u)) return 1;
+    const uint32_t orch_idx = __atomic_load_n(&output->orch_pool_idx, __ATOMIC_ACQUIRE);
+
+    // Phase 3: serial COND die scoring for non-orch threads.
+    for (uint32_t turn = 0; turn < pool_count; ++turn) {
+        if (turn == orch_idx) {
+            if (static_cast<uint32_t>(pool_idx) == turn) {
+                slot.die0_sum_ticks = 0;
+                slot.die1_sum_ticks = 0;
+                __atomic_store_n(&slot.die_valid, 1u, __ATOMIC_RELEASE);
+            }
+        } else if (static_cast<uint32_t>(pool_idx) == turn) {
+            TouchDie(aicore_regs, 0, cores_per_die, kAffinityWarmupSamplesPerCore);
+            TouchDie(aicore_regs, cores_per_die, cores_per_die, kAffinityWarmupSamplesPerCore);
+            slot.die0_sum_ticks = MeasureDieTotalTicks(aicore_regs, 0, cores_per_die, device_args->samples_per_core);
+            slot.die1_sum_ticks =
+                MeasureDieTotalTicks(aicore_regs, cores_per_die, cores_per_die, device_args->samples_per_core);
+            __atomic_store_n(&slot.die_valid, 1u, __ATOMIC_RELEASE);
+        }
+        if (!WaitForProbeValue(output, &output->slots[turn].die_valid, 1u)) return 1;
+    }
+
+    if (pool_idx == 0) {
+        __atomic_store_n(&output->die_done, 1u, __ATOMIC_RELEASE);
+    }
+    if (!WaitForProbeValue(output, &output->die_done, 1u)) return 1;
+    return 0;
+}
+
+// Back-compat alias used by older host descriptors.
+__attribute__((visibility("default"))) int simpler_aicpu_rtt_probe(void *args) {
+    return simpler_aicpu_affinity_preflight(args);
+}
+
+}  // extern "C"

--- a/simpler_setup/tools/aicpu_device_query/host/CMakeLists.txt
+++ b/simpler_setup/tools/aicpu_device_query/host/CMakeLists.txt
@@ -1,0 +1,66 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+cmake_minimum_required(VERSION 3.16)
+project(query_device_hal LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(NOT DEFINED ENV{ASCEND_HOME_PATH})
+    message(FATAL_ERROR "ASCEND_HOME_PATH must be set")
+endif()
+set(ASCEND_HOME_PATH $ENV{ASCEND_HOME_PATH})
+
+add_executable(query_device_hal query_device_hal.cpp rtt_probe_host.cpp)
+
+set(SIMPLER_ROOT "" CACHE PATH "Simpler source or installed _assets root")
+if(NOT SIMPLER_ROOT)
+    get_filename_component(SIMPLER_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE)
+endif()
+if(NOT EXISTS "${SIMPLER_ROOT}/src/a5/platform/onboard/host/aicpu_topology_probe.cpp")
+    message(FATAL_ERROR "SIMPLER_ROOT=${SIMPLER_ROOT} does not contain the required packaged/source src tree")
+endif()
+set(A5_TOPOLOGY_DIR "${SIMPLER_ROOT}/src/a5/platform/onboard/host")
+target_sources(query_device_hal PRIVATE
+    "${A5_TOPOLOGY_DIR}/aicpu_topology_probe.cpp"
+    "${SIMPLER_ROOT}/src/common/log/host_log.cpp"
+    "${SIMPLER_ROOT}/src/common/log/unified_log_host.cpp"
+)
+add_custom_command(TARGET query_device_hal POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${A5_TOPOLOGY_DIR}/aicpu_cpu_topo_fallback.json"
+        "$<TARGET_FILE_DIR:query_device_hal>/aicpu_cpu_topo_fallback.json"
+)
+
+# runtime/rt.h transitively needs profiling.
+target_include_directories(query_device_hal PRIVATE
+    ${ASCEND_HOME_PATH}/include
+    ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/pkg_inc
+    ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/pkg_inc/runtime
+    ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/pkg_inc/runtime/runtime
+    ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/pkg_inc/profiling
+    ${A5_TOPOLOGY_DIR}
+    ${SIMPLER_ROOT}/src/a5/platform/include
+    ${SIMPLER_ROOT}/src/common/platform/include
+    ${SIMPLER_ROOT}/src/common/log/include
+    ${SIMPLER_ROOT}/src/common/log
+)
+
+set(ASCEND_DRIVER_LIB_DIR "/usr/local/Ascend/driver/lib64/driver"
+    CACHE PATH "Directory containing libascend_hal.so")
+target_link_directories(query_device_hal PRIVATE
+    ${ASCEND_HOME_PATH}/lib64
+    ${ASCEND_HOME_PATH}/runtime/lib64
+    ${ASCEND_DRIVER_LIB_DIR}
+)
+
+# ascendcl for aclrt*, runtime for rt*/rts* (rtAicpuKernelLaunchExWithArgs,
+# rtsBinaryLoadFromFile, rtsFuncGetByName, rtsLaunchCpuKernel).
+target_link_libraries(query_device_hal PRIVATE ascendcl runtime ascend_hal ${CMAKE_DL_LIBS} pthread)

--- a/simpler_setup/tools/aicpu_device_query/host/query_device_hal.cpp
+++ b/simpler_setup/tools/aicpu_device_query/host/query_device_hal.cpp
@@ -1,0 +1,582 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+//
+// query_device_hal — host-side launcher for the device-side HAL query SO.
+//
+// Pipeline:
+//   1. read dispatcher SO bytes + inner SO bytes from disk
+//   2. aclInit + aclrtSetDevice
+//   3. allocate GM for:
+//        - dispatcher SO bytes
+//        - inner SO bytes
+//        - DeviceArgs struct (160 B)
+//        - QueryRequest[]  input
+//        - QueryResult[]   output
+//   4. memcpy bytes H2D
+//   5. rtAicpuKernelLaunchExWithArgs(KERNEL_TYPE_AICPU_KFC, AST_DYN_AICPU, ...) —
+//      libaicpu_extend_kernels dlopens dispatcher, runs DynInit which writes
+//      inner SO bytes to /usr/lib64/aicpu_kernels/0/aicpu_kernels_device/simpler_inner_<fp>_<dev>.so
+//   6. aclrtSynchronizeStream
+//   7. generate JSON descriptor pointing at the preinstall path
+//   8. rtsBinaryLoadFromFile(json_path, cpuKernelMode=0)
+//   9. rtsFuncGetByName("simpler_aicpu_query_<fp>") -> query func handle
+//  10. populate DeviceArgs with q_input_addr/count/output_addr (and reset header)
+//  11. rtsLaunchCpuKernel(func, stream, kernelArgs, blockDim=1)
+//  12. aclrtSynchronizeStream
+//  13. D2H copy QueryResult[]
+//  14. pretty-print
+//
+// Reuses the production dispatcher SO (built at build/lib/a2a3/dispatcher/);
+// inner SO is our own libaicpu_query.so built next door.
+
+#include <acl/acl.h>
+#include <runtime/rt.h>
+#include <runtime/runtime/rts/rts_kernel.h>
+
+#include "aicpu_topology_probe.h"
+#include "host_log.h"
+#include "rtt_probe_host.h"
+#include "../shared/rtt_probe_types.h"
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+// ELF Build-ID fingerprinting — must match the dispatcher's hash so the
+// derived preinstall basename agrees. We inline a minimal Build-ID reader
+// here rather than reach into src/common/utils/elf_build_id.h to keep the
+// example tool standalone.
+namespace fp {
+
+bool ElfBuildId(const char *data, size_t len, uint64_t *out) {
+    if (len < 64) return false;
+    if (std::memcmp(
+            data,
+            "\x7f"
+            "ELF",
+            4
+        ) != 0)
+        return false;
+    // 64-bit ELF header layout (ELFCLASS64 = 2 at offset 4).
+    if (data[4] != 2) return false;
+    uint64_t e_shoff;
+    uint16_t e_shentsize, e_shnum, e_shstrndx;
+    std::memcpy(&e_shoff, data + 40, 8);
+    std::memcpy(&e_shentsize, data + 58, 2);
+    std::memcpy(&e_shnum, data + 60, 2);
+    std::memcpy(&e_shstrndx, data + 62, 2);
+    if (e_shentsize != 64 || e_shoff + (uint64_t)e_shentsize * e_shnum > len) return false;
+    // strtab section header.
+    const char *strtab = nullptr;
+    {
+        const char *sh = data + e_shoff + (uint64_t)e_shentsize * e_shstrndx;
+        uint64_t off;
+        uint64_t sz;
+        std::memcpy(&off, sh + 24, 8);
+        std::memcpy(&sz, sh + 32, 8);
+        if (off + sz > len) return false;
+        strtab = data + off;
+    }
+    // Iterate sections, find one named ".note.gnu.build-id" with sh_type 7 (NOTE).
+    for (uint16_t i = 0; i < e_shnum; ++i) {
+        const char *sh = data + e_shoff + (uint64_t)e_shentsize * i;
+        uint32_t sh_name;
+        uint32_t sh_type;
+        uint64_t sh_off;
+        uint64_t sh_size;
+        std::memcpy(&sh_name, sh + 0, 4);
+        std::memcpy(&sh_type, sh + 4, 4);
+        std::memcpy(&sh_off, sh + 24, 8);
+        std::memcpy(&sh_size, sh + 32, 8);
+        if (sh_type != 7) continue;
+        const char *nm = strtab + sh_name;
+        if (std::strcmp(nm, ".note.gnu.build-id") != 0) continue;
+        // Parse note header.
+        if (sh_size < 16 || sh_off + sh_size > len) return false;
+        const char *p = data + sh_off;
+        uint32_t namesz, descsz, type;
+        std::memcpy(&namesz, p + 0, 4);
+        std::memcpy(&descsz, p + 4, 4);
+        std::memcpy(&type, p + 8, 4);
+        if (type != 3 || descsz < 8) return false;
+        size_t name_aligned = (namesz + 3u) & ~3u;
+        const char *desc = p + 12 + name_aligned;
+        std::memcpy(out, desc, 8);
+        return true;
+    }
+    return false;
+}
+
+uint64_t Fnv1a(const char *data, size_t len) {
+    uint64_t h = 0xcbf29ce484222325ULL;
+    for (size_t i = 0; i < len; ++i) {
+        h ^= (unsigned char)data[i];
+        h *= 0x100000001b3ULL;
+    }
+    return h;
+}
+
+uint64_t Compute(const char *data, size_t len) {
+    uint64_t fp;
+    if (ElfBuildId(data, len, &fp)) return fp;
+    return Fnv1a(data, len);
+}
+
+}  // namespace fp
+
+namespace {
+
+constexpr size_t kDeviceArgsBytes = 160;
+
+#define ACL_CHECK(call, msg)                                                    \
+    do {                                                                        \
+        aclError _rc = (call);                                                  \
+        if (_rc != ACL_SUCCESS) {                                               \
+            std::fprintf(stderr, "%s failed: %d (%s)\n", #call, (int)_rc, msg); \
+            return 1;                                                           \
+        }                                                                       \
+    } while (0)
+
+#define RT_CHECK(call, msg)                                                     \
+    do {                                                                        \
+        rtError_t _rc = (call);                                                 \
+        if (_rc != RT_ERROR_NONE) {                                             \
+            std::fprintf(stderr, "%s failed: %d (%s)\n", #call, (int)_rc, msg); \
+            return 1;                                                           \
+        }                                                                       \
+    } while (0)
+
+bool ReadFile(const std::string &path, std::vector<char> *out) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f.is_open()) {
+        std::fprintf(stderr, "open %s failed: %s\n", path.c_str(), std::strerror(errno));
+        return false;
+    }
+    f.seekg(0, std::ios::end);
+    out->resize((size_t)f.tellg());
+    f.seekg(0);
+    f.read(out->data(), out->size());
+    return f.good() || f.eof();
+}
+
+struct DevBuf {
+    void *ptr{nullptr};
+    aclError Alloc(size_t n) {
+        aclError rc = aclrtMalloc(&ptr, n, ACL_MEM_MALLOC_HUGE_FIRST);
+        if (rc != ACL_SUCCESS) ptr = nullptr;
+        return rc;
+    }
+    ~DevBuf() {
+        if (ptr) aclrtFree(ptr);
+    }
+};
+
+#pragma pack(push, 4)
+struct QueryRequest {
+    int32_t module_type;
+    int32_t info_type;
+};
+struct QueryResult {
+    int32_t rc;
+    int32_t _pad;
+    int64_t value;
+};
+#pragma pack(pop)
+
+const char *kModuleName(int32_t m) {
+    switch (m) {
+    case 0:
+        return "SYSTEM";
+    case 1:
+        return "AICPU";
+    case 2:
+        return "CCPU";
+    case 3:
+        return "DCPU";
+    case 4:
+        return "AICORE";
+    case 5:
+        return "TSCPU";
+    case 7:
+        return "VECTOR_CORE";
+    default:
+        return "?";
+    }
+}
+const char *kInfoName(int32_t i) {
+    switch (i) {
+    case 1:
+        return "CORE_NUM";
+    case 5:
+        return "OS_SCHED";
+    case 6:
+        return "IN_USED";
+    case 8:
+        return "OCCUPY";
+    case 20:
+        return "PF_CORE_NUM";
+    case 21:
+        return "PF_OCCUPY";
+    case 41:
+        return "DIE_NUM";
+    default:
+        // Most ENV/VERSION etc constants have specific numbers; just print id.
+        static thread_local char buf[16];
+        std::snprintf(buf, sizeof(buf), "INFO_%d", i);
+        return buf;
+    }
+}
+
+// Dispatcher's DeviceArgs layout. We populate the bootstrap fields
+// (offsets 96 / 104 / 112 / 120 / 128) before bootstrapping and overwrite
+// query fields (96 / 104 / 112) afterwards to repoint the same DeviceArgs
+// buffer at the request/output. (The dispatcher only reads them during Init;
+// the inner SO sees the rewrite at Launch time.)
+//   bootstrap:
+//     96  aicpu_so_bin (dispatcher bytes)
+//     104 aicpu_so_len
+//     112 device_id
+//     120 inner_so_bin
+//     128 inner_so_len
+//   query:
+//     96  q_input_addr  (overwrites aicpu_so_bin slot, but dispatcher is done)
+//     104 q_input_count
+//     112 q_output_addr (overwrites device_id slot, but dispatcher is done)
+//
+// We use ONE DeviceArgs buffer for both phases to keep the example small.
+constexpr size_t kBootstrapDispBin = 96;
+constexpr size_t kBootstrapDispLen = 104;
+constexpr size_t kBootstrapDevId = 112;
+constexpr size_t kBootstrapInnerBin = 120;
+constexpr size_t kBootstrapInnerLen = 128;
+constexpr size_t kQInputAddr = 96;
+constexpr size_t kQInputCount = 104;
+constexpr size_t kQOutputAddr = 112;
+
+void WriteU64(char *buf, size_t off, uint64_t v) { std::memcpy(buf + off, &v, sizeof(v)); }
+
+std::string MakePreinstallPath(uint64_t fp, int device_id) {
+    char buf[256];
+    std::snprintf(
+        buf, sizeof(buf), "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device/simpler_inner_%016lx_%d.so", fp, device_id
+    );
+    return buf;
+}
+
+std::string MakeJsonDescriptor(uint64_t fp, const std::string &so_basename, bool include_rtt_probe) {
+    char init_op[128], query_op[128];
+    std::snprintf(init_op, sizeof(init_op), "simpler_aicpu_init_%016lx", fp);
+    std::snprintf(query_op, sizeof(query_op), "simpler_aicpu_query_%016lx", fp);
+    // Match the schema CANN's rtsBinaryLoadFromFile expects (top-level
+    // object keyed by opType, each opType maps to an opInfo block).
+    // Defaults from AicpuOpConfig in src/common/host/load_aicpu_op.h.
+    auto entry = [&](const char *op, const char *fn) {
+        std::string s = "  \"";
+        s += op;
+        s += "\": {\n    \"opInfo\": {\n";
+        s += "      \"functionName\": \"";
+        s += fn;
+        s += "\",\n      \"kernelSo\": \"";
+        s += so_basename;
+        s += "\",\n      \"opKernelLib\": \"AICPUKernel\",\n";
+        s += "      \"computeCost\": \"100\",\n";
+        s += "      \"engine\": \"DNN_VM_AICPU\",\n";
+        s += "      \"flagAsync\": \"False\",\n";
+        s += "      \"flagPartial\": \"False\",\n";
+        s += "      \"userDefined\": \"False\"\n";
+        s += "    }\n  }";
+        return s;
+    };
+    std::string s = "{\n";
+    s += entry(init_op, "simpler_aicpu_init");
+    s += ",\n";
+    s += entry(query_op, "simpler_aicpu_query");
+    if (include_rtt_probe) {
+        s += ",\n";
+        s += aicpu_device_query::MakeAffinityEnumDescriptorEntry(fp, so_basename);
+        s += ",\n";
+        s += aicpu_device_query::MakeAffinityPreflightDescriptorEntry(fp, so_basename);
+        s += ",\n";
+        s += aicpu_device_query::MakeRttDescriptorEntry(fp, so_basename);
+    }
+    s += "\n}\n";
+    return s;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    if (argc < 2 || argc > 3 ||
+        (argc == 3 && std::strcmp(argv[2], "--json") != 0 && std::strcmp(argv[2], "--rtt-json") != 0)) {
+        std::fprintf(stderr, "usage: %s <device_id> [--json|--rtt-json]\n", argv[0]);
+        return 1;
+    }
+    // This executable owns its logger state; no loader binds it.
+    HostLogger::get_instance().set_level(simpler::log::LogLevel::TIMING);
+
+    int device_id = std::atoi(argv[1]);
+    const bool json_output = argc == 3 && std::strcmp(argv[2], "--json") == 0;
+    const bool rtt_output = argc == 3 && std::strcmp(argv[2], "--rtt-json") == 0;
+    const bool machine_output = json_output || rtt_output;
+
+    const char *dispatcher_path_env = std::getenv("SIMPLER_DISPATCHER_SO");
+    std::string dispatcher_path =
+        dispatcher_path_env ? dispatcher_path_env : "build/lib/a5/dispatcher/libsimpler_aicpu_dispatcher.so";
+    const char *inner_path_env = std::getenv("SIMPLER_AICPU_QUERY_SO");
+    std::string inner_path =
+        inner_path_env ? inner_path_env : "build/cache/aicpu_device_query/device/libaicpu_query.so";
+
+    std::vector<char> dispatcher_bytes;
+    std::vector<char> inner_bytes;
+    if (!ReadFile(dispatcher_path, &dispatcher_bytes)) return 1;
+    if (!ReadFile(inner_path, &inner_bytes)) return 1;
+
+    // Built-in initial query set — exactly what the kernel.cpp probe ran, so
+    // we can sanity-check against the on-record results.
+    constexpr size_t kOsSchedRequestIndex = 0;
+    constexpr size_t kOccupyRequestIndex = 1;
+    constexpr size_t kPfOccupyRequestIndex = 4;
+    std::vector<QueryRequest> requests = {
+        {1 /* AICPU */, 5 /* OS_SCHED */},     {1 /* AICPU */, 8 /* OCCUPY */},     {1 /* AICPU */, 1 /* CORE_NUM */},
+        {1 /* AICPU */, 20 /* PF_CORE_NUM */}, {1 /* AICPU */, 21 /* PF_OCCUPY */}, {2 /* CCPU */, 8 /* OCCUPY */},
+        {2 /* CCPU */, 1 /* CORE_NUM */},      {3 /* DCPU */, 8 /* OCCUPY */},      {3 /* DCPU */, 1 /* CORE_NUM */},
+        {5 /* TSCPU */, 8 /* OCCUPY */},       {5 /* TSCPU */, 1 /* CORE_NUM */},
+    };
+    std::vector<QueryResult> results(requests.size());
+
+    ACL_CHECK(aclInit(nullptr), "aclInit");
+    ACL_CHECK(aclrtSetDevice(device_id), "aclrtSetDevice");
+    aclrtStream stream = nullptr;
+    ACL_CHECK(aclrtCreateStream(&stream), "aclrtCreateStream");
+
+    // ---- Allocate GM ----
+    DevBuf dev_dispatcher, dev_inner, dev_args, dev_qin, dev_qout;
+    ACL_CHECK(dev_dispatcher.Alloc(dispatcher_bytes.size()), "dispatcher GM");
+    ACL_CHECK(dev_inner.Alloc(inner_bytes.size()), "inner GM");
+    ACL_CHECK(dev_args.Alloc(kDeviceArgsBytes), "DeviceArgs GM");
+    ACL_CHECK(dev_qin.Alloc(requests.size() * sizeof(QueryRequest)), "qin GM");
+    ACL_CHECK(dev_qout.Alloc(results.size() * sizeof(QueryResult)), "qout GM");
+
+    // ---- H2D dispatcher + inner SO + DeviceArgs (bootstrap fields) ----
+    ACL_CHECK(
+        aclrtMemcpy(
+            dev_dispatcher.ptr, dispatcher_bytes.size(), dispatcher_bytes.data(), dispatcher_bytes.size(),
+            ACL_MEMCPY_HOST_TO_DEVICE
+        ),
+        "H2D dispatcher"
+    );
+    ACL_CHECK(
+        aclrtMemcpy(
+            dev_inner.ptr, inner_bytes.size(), inner_bytes.data(), inner_bytes.size(), ACL_MEMCPY_HOST_TO_DEVICE
+        ),
+        "H2D inner"
+    );
+    char hostargs[kDeviceArgsBytes] = {};
+    WriteU64(hostargs, kBootstrapDispBin, reinterpret_cast<uint64_t>(dev_dispatcher.ptr));
+    WriteU64(hostargs, kBootstrapDispLen, dispatcher_bytes.size());
+    WriteU64(hostargs, kBootstrapDevId, (uint64_t)device_id);
+    WriteU64(hostargs, kBootstrapInnerBin, reinterpret_cast<uint64_t>(dev_inner.ptr));
+    WriteU64(hostargs, kBootstrapInnerLen, inner_bytes.size());
+    ACL_CHECK(
+        aclrtMemcpy(dev_args.ptr, kDeviceArgsBytes, hostargs, kDeviceArgsBytes, ACL_MEMCPY_HOST_TO_DEVICE),
+        "H2D DeviceArgs(bootstrap)"
+    );
+
+    // ---- Bootstrap via libaicpu_extend_kernels ----
+    {
+        struct Args {
+            struct {
+                uint64_t unused[5] = {0};
+                uint64_t device_args_ptr = 0;
+                uint64_t pad[20] = {0};
+            } k_args;
+            char kernel_name[32];
+            char so_name[32];
+            char op_name[32];
+        } args = {};
+        args.k_args.device_args_ptr = reinterpret_cast<uint64_t>(dev_args.ptr);
+        std::strncpy(args.kernel_name, "DynTileFwkKernelServerInit", sizeof(args.kernel_name) - 1);
+        std::strncpy(args.so_name, "libaicpu_extend_kernels.so", sizeof(args.so_name) - 1);
+        args.op_name[0] = '\0';
+
+        rtAicpuArgsEx_t rt_args = {};
+        rt_args.args = &args;
+        rt_args.argsSize = sizeof(args);
+        rt_args.kernelNameAddrOffset = offsetof(Args, kernel_name);
+        rt_args.soNameAddrOffset = offsetof(Args, so_name);
+
+        RT_CHECK(
+            rtAicpuKernelLaunchExWithArgs(
+                rtKernelType_t::KERNEL_TYPE_AICPU_KFC, "AST_DYN_AICPU", 1, &rt_args, nullptr, stream, 0
+            ),
+            "rtAicpuKernelLaunchExWithArgs(bootstrap)"
+        );
+    }
+    {
+        const aclError rc = aclrtSynchronizeStreamWithTimeout(stream, kAffinityHostSyncTimeoutMs);
+        if (rc != ACL_SUCCESS) {
+            std::fprintf(stderr, "aclrtSynchronizeStreamWithTimeout failed: %d (sync after bootstrap)\n", (int)rc);
+            return rc == ACL_ERROR_RT_STREAM_SYNC_TIMEOUT ? kAffinityPreflightTimeoutExitCode : 1;
+        }
+    }
+
+    // ---- Fingerprint inner SO + write JSON descriptor ----
+    uint64_t fp = fp::Compute(inner_bytes.data(), inner_bytes.size());
+    std::string so_basename = "simpler_inner_" + [&] {
+        char b[24];
+        std::snprintf(b, sizeof(b), "%016lx_%d.so", fp, device_id);
+        return std::string(b);
+    }();
+    std::string preinstall_path = MakePreinstallPath(fp, device_id);
+    if (!machine_output) std::printf("[bootstrap] inner SO at %s (fp=%016lx)\n", preinstall_path.c_str(), fp);
+
+    char json_path_buf[128];
+    std::snprintf(json_path_buf, sizeof(json_path_buf), "/tmp/simpler_inner_%016lx_%d.json", fp, getpid());
+    std::string json_path = json_path_buf;
+    {
+        std::string json = MakeJsonDescriptor(fp, so_basename, rtt_output);
+        std::ofstream f(json_path);
+        if (!f.is_open()) {
+            std::fprintf(stderr, "open %s failed\n", json_path.c_str());
+            return 1;
+        }
+        f << json;
+    }
+
+    rtLoadBinaryOption_t option = {};
+    option.optionId = RT_LOAD_BINARY_OPT_CPU_KERNEL_MODE;
+    option.value.cpuKernelMode = 0;
+    rtLoadBinaryConfig_t load_config = {};
+    load_config.options = &option;
+    load_config.numOpt = 1;
+    void *binary_handle = nullptr;
+    RT_CHECK(rtsBinaryLoadFromFile(json_path.c_str(), &load_config, &binary_handle), "rtsBinaryLoadFromFile");
+    std::remove(json_path.c_str());
+
+    rtFuncHandle init_handle = nullptr, query_handle = nullptr;
+    {
+        char init_op[128], query_op[128];
+        std::snprintf(init_op, sizeof(init_op), "simpler_aicpu_init_%016lx", fp);
+        std::snprintf(query_op, sizeof(query_op), "simpler_aicpu_query_%016lx", fp);
+        RT_CHECK(rtsFuncGetByName(binary_handle, init_op, &init_handle), "rtsFuncGetByName init");
+        RT_CHECK(rtsFuncGetByName(binary_handle, query_op, &query_handle), "rtsFuncGetByName query");
+    }
+
+    // ---- Rewrite DeviceArgs to point at the query I/O buffers ----
+    ACL_CHECK(
+        aclrtMemcpy(
+            dev_qin.ptr, requests.size() * sizeof(QueryRequest), requests.data(),
+            requests.size() * sizeof(QueryRequest), ACL_MEMCPY_HOST_TO_DEVICE
+        ),
+        "H2D QueryRequest"
+    );
+    std::memset(hostargs, 0, sizeof(hostargs));
+    WriteU64(hostargs, kQInputAddr, reinterpret_cast<uint64_t>(dev_qin.ptr));
+    WriteU64(hostargs, kQInputCount, (uint64_t)requests.size());
+    WriteU64(hostargs, kQOutputAddr, reinterpret_cast<uint64_t>(dev_qout.ptr));
+    ACL_CHECK(
+        aclrtMemcpy(dev_args.ptr, kDeviceArgsBytes, hostargs, kDeviceArgsBytes, ACL_MEMCPY_HOST_TO_DEVICE),
+        "H2D DeviceArgs(query)"
+    );
+
+    // ---- Launch simpler_aicpu_query ----
+    {
+        struct LaunchArgs {
+            uint64_t _pad[5] = {0};
+            uint64_t device_args_ptr = 0;
+            uint64_t reserved[20] = {0};
+        } la = {};
+        la.device_args_ptr = reinterpret_cast<uint64_t>(dev_args.ptr);
+
+        rtCpuKernelArgs_t cpu_args = {};
+        cpu_args.baseArgs.args = &la;
+        cpu_args.baseArgs.argsSize = sizeof(la);
+        rtLaunchKernelAttr_t attr = {};
+        rtKernelLaunchCfg_t cfg = {&attr, 0};
+        RT_CHECK(rtsLaunchCpuKernel(query_handle, 1u, stream, &cfg, &cpu_args), "rtsLaunchCpuKernel query");
+    }
+    {
+        const aclError rc = aclrtSynchronizeStreamWithTimeout(stream, kAffinityHostSyncTimeoutMs);
+        if (rc != ACL_SUCCESS) {
+            std::fprintf(stderr, "aclrtSynchronizeStreamWithTimeout failed: %d (sync after query)\n", (int)rc);
+            return rc == ACL_ERROR_RT_STREAM_SYNC_TIMEOUT ? kAffinityPreflightTimeoutExitCode : 1;
+        }
+    }
+
+    // ---- D2H read results ----
+    ACL_CHECK(
+        aclrtMemcpy(
+            results.data(), results.size() * sizeof(QueryResult), dev_qout.ptr, results.size() * sizeof(QueryResult),
+            ACL_MEMCPY_DEVICE_TO_HOST
+        ),
+        "D2H QueryResult"
+    );
+
+    if (machine_output) {
+        pto::a5::AicpuDeviceOccupancy occupancy;
+        occupancy.os_sched = static_cast<uint64_t>(results[kOsSchedRequestIndex].value);
+        occupancy.os_sched_valid = results[kOsSchedRequestIndex].rc == 0;
+        occupancy.occupy = static_cast<uint64_t>(results[kOccupyRequestIndex].value);
+        occupancy.occupy_valid = results[kOccupyRequestIndex].rc == 0;
+        occupancy.pf_occupy = static_cast<uint64_t>(results[kPfOccupyRequestIndex].value);
+        occupancy.pf_occupy_valid = results[kPfOccupyRequestIndex].rc == 0;
+
+        pto::a5::AicpuTopology topology;
+        if (!pto::a5::probe_aicpu_topology(static_cast<uint32_t>(device_id), occupancy, topology)) {
+            std::fprintf(stderr, "A5 AICPU topology probe failed for device %d\n", device_id);
+            return 1;
+        }
+        if (topology.soc_name.find("Ascend950") == std::string::npos) {
+            std::fprintf(stderr, "A5 classification is unsupported for SoC %s\n", topology.soc_name.c_str());
+            return 1;
+        }
+
+        if (json_output) {
+            pto::a5::AicpuLaunchPlan launch_plan;
+            std::string plan_error;
+            if (!pto::a5::build_aicpu_launch_plan(topology, 0, launch_plan, plan_error)) {
+                std::fprintf(stderr, "A5 AICPU launch planning failed: %s\n", plan_error.c_str());
+                return 1;
+            }
+            pto::a5::AicpuSelectionPolicy policy = pto::a5::AicpuSelectionPolicy::kScenario;
+            if (topology.generic_selection_only) {
+                policy = pto::a5::AicpuSelectionPolicy::kGeneric;
+            } else if (topology.scenario_type == pto::a5::AicpuScenarioType::kUnknown) {
+                policy = pto::a5::AicpuSelectionPolicy::kSequentialFallback;
+            }
+            std::fputs(pto::a5::format_aicpu_topology_json(topology, policy, launch_plan).c_str(), stdout);
+        } else if (!aicpu_device_query::RunAffinityPreflight(
+                       device_id, binary_handle, fp, dev_args.ptr, kDeviceArgsBytes, stream, topology
+                   )) {
+            return aicpu_device_query::LastAffinityProbeTimedOut() ? kAffinityPreflightTimeoutExitCode : 1;
+        }
+    } else {
+        // ---- Pretty-print ----
+        std::printf("\n=== device=%d  device-side HAL view (via dispatcher + inner SO) ===\n", device_id);
+        for (size_t i = 0; i < requests.size(); ++i) {
+            std::printf(
+                "  %-12s + %-14s  rc=%d  val=0x%lx (%ld)\n", kModuleName(requests[i].module_type),
+                kInfoName(requests[i].info_type), results[i].rc, (long)results[i].value, (long)results[i].value
+            );
+        }
+    }
+
+    ACL_CHECK(aclrtDestroyStream(stream), "destroy stream");
+    ACL_CHECK(aclrtResetDevice(device_id), "reset device");
+    aclFinalize();
+    return 0;
+}

--- a/simpler_setup/tools/aicpu_device_query/host/rtt_probe_host.cpp
+++ b/simpler_setup/tools/aicpu_device_query/host/rtt_probe_host.cpp
@@ -1,0 +1,407 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "rtt_probe_host.h"
+
+#include "aicpu_topology_probe.h"
+#include "common/acl_hal_device.h"
+#include "common/platform_config.h"
+#include "host/host_regs.h"
+#include "../shared/rtt_probe_types.h"
+
+#include <driver/ascend_hal.h>
+#include <runtime/runtime/rts/rts_kernel.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <dlfcn.h>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace aicpu_device_query {
+namespace {
+
+thread_local bool g_affinity_probe_timed_out = false;
+
+class DeviceBuffer {
+public:
+    DeviceBuffer() = default;
+    DeviceBuffer(const DeviceBuffer &) = delete;
+    DeviceBuffer &operator=(const DeviceBuffer &) = delete;
+
+    ~DeviceBuffer() {
+        if (ptr_ != nullptr) aclrtFree(ptr_);
+    }
+
+    bool Allocate(size_t bytes, const char *description) {
+        const aclError rc = aclrtMalloc(&ptr_, bytes, ACL_MEM_MALLOC_HUGE_FIRST);
+        if (rc == ACL_SUCCESS) return true;
+        ptr_ = nullptr;
+        std::fprintf(stderr, "aclrtMalloc failed: %d (%s)\n", static_cast<int>(rc), description);
+        return false;
+    }
+
+    void *get() const { return ptr_; }
+
+private:
+    void *ptr_{nullptr};
+};
+
+bool CheckAcl(aclError rc, const char *call, const char *description) {
+    if (rc == ACL_SUCCESS) return true;
+    g_affinity_probe_timed_out = rc == ACL_ERROR_RT_STREAM_SYNC_TIMEOUT;
+    std::fprintf(stderr, "%s failed: %d (%s)\n", call, static_cast<int>(rc), description);
+    return false;
+}
+
+bool MapAicoreRegisters(int device_id, std::vector<uint64_t> *registers) {
+    using HalResMapFn = int (*)(uint32_t, struct res_map_info *, uint64_t *, uint32_t *);
+    auto hal_res_map = reinterpret_cast<HalResMapFn>(dlsym(nullptr, "halResMap"));
+    if (hal_res_map == nullptr) {
+        std::fprintf(stderr, "halResMap not found: %s\n", dlerror());
+        return false;
+    }
+
+    const auto physical_device_id = static_cast<uint32_t>(pto::acl_to_hal_device_id(device_id));
+    struct res_map_info map_info = {};
+    map_info.target_proc_type = PROCESS_CP1;
+    map_info.res_type = RES_AICORE;
+    registers->assign(DAV_3510::PLATFORM_MAX_PHYSICAL_CORES, 0);
+    for (uint32_t core = 0; core < DAV_3510::PLATFORM_MAX_PHYSICAL_CORES; ++core) {
+        map_info.res_id = core;
+        uint32_t length = REG_AICORE_MAP_SIZE;
+        const int rc = hal_res_map(physical_device_id, &map_info, &(*registers)[core], &length);
+        if (rc != 0) {
+            std::fprintf(stderr, "halResMap failed for AICore %u: %d\n", core, rc);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ResolveNamed(void *binary_handle, uint64_t fingerprint, const char *base_name, rtFuncHandle *handle) {
+    char op_type[128];
+    std::snprintf(op_type, sizeof(op_type), "%s_%016lx", base_name, fingerprint);
+    const rtError_t rc = rtsFuncGetByName(binary_handle, op_type, handle);
+    if (rc == RT_ERROR_NONE) return true;
+    std::fprintf(stderr, "rtsFuncGetByName %s failed: %d\n", base_name, static_cast<int>(rc));
+    return false;
+}
+
+bool LaunchCpu(rtFuncHandle handle, uint32_t block_dim, void *device_args, aclrtStream stream) {
+    struct LaunchArgs {
+        uint64_t pad[5] = {0};
+        uint64_t device_args_ptr = 0;
+        uint64_t reserved[20] = {0};
+    } launch_args = {};
+    launch_args.device_args_ptr = reinterpret_cast<uint64_t>(device_args);
+
+    rtCpuKernelArgs_t cpu_args = {};
+    cpu_args.baseArgs.args = &launch_args;
+    cpu_args.baseArgs.argsSize = sizeof(launch_args);
+    rtLaunchKernelAttr_t attr = {};
+    rtKernelLaunchCfg_t cfg = {&attr, 0};
+    const rtError_t rc = rtsLaunchCpuKernel(handle, block_dim, stream, &cfg, &cpu_args);
+    if (rc == RT_ERROR_NONE) return true;
+    std::fprintf(stderr, "rtsLaunchCpuKernel failed: %d\n", static_cast<int>(rc));
+    return false;
+}
+
+std::string MakeDescriptorEntry(
+    uint64_t fingerprint, const std::string &so_basename, const char *op_type_base, const char *function_name
+) {
+    char op_type[128];
+    std::snprintf(op_type, sizeof(op_type), "%s_%016lx", op_type_base, fingerprint);
+    std::string descriptor = "  \"";
+    descriptor += op_type;
+    descriptor += "\": {\n    \"opInfo\": {\n";
+    descriptor += "      \"functionName\": \"";
+    descriptor += function_name;
+    descriptor += "\",\n      \"kernelSo\": \"";
+    descriptor += so_basename;
+    descriptor += "\",\n      \"opKernelLib\": \"AICPUKernel\",\n";
+    descriptor += "      \"computeCost\": \"100\",\n      \"engine\": \"DNN_VM_AICPU\",\n";
+    descriptor += "      \"flagAsync\": \"False\",\n      \"flagPartial\": \"False\",\n";
+    descriptor += "      \"userDefined\": \"False\"\n    }\n  }";
+    return descriptor;
+}
+
+std::vector<int32_t> EnumerateUserPool(
+    rtFuncHandle enum_handle, void *device_args, size_t device_args_bytes, aclrtStream stream,
+    const pto::a5::AicpuTopology &topology
+) {
+    std::vector<int32_t> occupy_cpus;
+    for (const auto &cpu : topology.os_schedulable_cpus) {
+        occupy_cpus.push_back(cpu.cpu_id);
+    }
+    std::sort(occupy_cpus.begin(), occupy_cpus.end());
+    occupy_cpus.erase(std::unique(occupy_cpus.begin(), occupy_cpus.end()), occupy_cpus.end());
+    if (occupy_cpus.size() > static_cast<size_t>(PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
+        std::fprintf(
+            stderr, "affinity preflight OCCUPY population %zu exceeds supported launch maximum %d\n",
+            occupy_cpus.size(), PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH
+        );
+        return {};
+    }
+
+    // Driver and verified-JSON topology already provide the complete OCCUPY
+    // intersection. Use it directly instead of hoping repeated one-thread
+    // launches eventually visit every CPU. An incomplete topology falls back
+    // to the serial discovery path below and must still prove completeness.
+    if (topology.source != pto::a5::AicpuTopologySource::kOccupyFallback) {
+        std::vector<int32_t> topology_cpus;
+        if (pto::a5::build_complete_topology_user_pool(topology, topology_cpus)) return topology_cpus;
+        std::fprintf(stderr, "affinity preflight topology does not completely cover OCCUPY; trying serial discovery\n");
+    }
+
+    DeviceBuffer enum_out;
+    if (!enum_out.Allocate(sizeof(AffinityEnumOutput), "affinity enum output")) return {};
+
+    std::set<int32_t> seen;
+    const int attempts = static_cast<int>(occupy_cpus.size()) * 3 + 4;
+    for (int attempt = 0; attempt < attempts; ++attempt) {
+        AffinityEnumOutput host_out = {};
+        if (!CheckAcl(
+                aclrtMemcpy(enum_out.get(), sizeof(host_out), &host_out, sizeof(host_out), ACL_MEMCPY_HOST_TO_DEVICE),
+                "aclrtMemcpy", "zero enum output"
+            )) {
+            return {};
+        }
+        std::vector<uint8_t> host_args(device_args_bytes, 0);
+        auto *args = reinterpret_cast<AffinityEnumDeviceArgs *>(host_args.data());
+        args->output_addr = reinterpret_cast<uint64_t>(enum_out.get());
+        if (!CheckAcl(
+                aclrtMemcpy(
+                    device_args, device_args_bytes, host_args.data(), device_args_bytes, ACL_MEMCPY_HOST_TO_DEVICE
+                ),
+                "aclrtMemcpy", "enum device args"
+            )) {
+            return {};
+        }
+        if (!LaunchCpu(enum_handle, 1u, device_args, stream)) return {};
+        if (!CheckAcl(
+                aclrtSynchronizeStreamWithTimeout(stream, kAffinityHostSyncTimeoutMs),
+                "aclrtSynchronizeStreamWithTimeout", "enum sync"
+            )) {
+            return {};
+        }
+        if (!CheckAcl(
+                aclrtMemcpy(&host_out, sizeof(host_out), enum_out.get(), sizeof(host_out), ACL_MEMCPY_DEVICE_TO_HOST),
+                "aclrtMemcpy", "enum D2H"
+            )) {
+            return {};
+        }
+        if (host_out.ready == 0 || host_out.cpu_id < 0) continue;
+        seen.insert(host_out.cpu_id);
+        if (!occupy_cpus.empty() && seen.size() >= occupy_cpus.size()) break;
+    }
+
+    const std::vector<int32_t> pool(seen.begin(), seen.end());
+    if (pool != occupy_cpus) {
+        std::fprintf(
+            stderr, "affinity preflight serial discovery incomplete: saw %zu of %zu OCCUPY CPUs\n", pool.size(),
+            occupy_cpus.size()
+        );
+        return {};
+    }
+    return pool;
+}
+
+std::string FormatAffinityJson(
+    int device_id, const pto::a5::AicpuTopology &topology, const std::vector<int32_t> &user_pool,
+    const AffinityPreflightOutput &output
+) {
+    std::ostringstream json;
+    json << "{\n  \"schema_version\": 3,\n"
+         << "  \"measurement_method\": \"atomic-flag-orch+cond-die-v1\",\n"
+         << "  \"soc_name\": \"" << topology.soc_name << "\",\n"
+         << "  \"device_id\": " << device_id << ",\n"
+         << "  \"handshake_iters\": " << kAffinityHandshakeIters << ",\n"
+         << "  \"samples_per_core\": " << kAffinitySamplesPerCore << ",\n"
+         << "  \"user_pool_cpus\": [";
+    for (size_t i = 0; i < user_pool.size(); ++i) {
+        if (i) json << ", ";
+        json << user_pool[i];
+    }
+    json << "],\n  \"orch_pool_idx\": " << output.orch_pool_idx << ",\n  \"pool\": [\n";
+    for (uint32_t idx = 0; idx < output.pool_count; ++idx) {
+        const AffinityPoolSlot &slot = output.slots[idx];
+        if (idx) json << ",\n";
+        json << "    {\"pool_idx\": " << slot.pool_idx << ", \"cpu_id\": " << slot.cpu_id
+             << ", \"avg_handshake_ticks\": " << slot.avg_handshake_ticks
+             << ", \"die0_sum_ticks\": " << slot.die0_sum_ticks << ", \"die1_sum_ticks\": " << slot.die1_sum_ticks
+             << ", \"is_orch\": " << slot.is_orch << "}";
+    }
+    json << "\n  ]\n}\n";
+    return json.str();
+}
+
+}  // namespace
+
+std::string MakeRttDescriptorEntry(uint64_t fingerprint, const std::string &so_basename) {
+    return MakeDescriptorEntry(fingerprint, so_basename, "simpler_aicpu_rtt_probe", "simpler_aicpu_rtt_probe");
+}
+
+std::string MakeAffinityEnumDescriptorEntry(uint64_t fingerprint, const std::string &so_basename) {
+    return MakeDescriptorEntry(fingerprint, so_basename, "simpler_aicpu_affinity_enum", "simpler_aicpu_affinity_enum");
+}
+
+std::string MakeAffinityPreflightDescriptorEntry(uint64_t fingerprint, const std::string &so_basename) {
+    return MakeDescriptorEntry(
+        fingerprint, so_basename, "simpler_aicpu_affinity_preflight", "simpler_aicpu_affinity_preflight"
+    );
+}
+
+bool RunAffinityPreflight(
+    int device_id, void *binary_handle, uint64_t fingerprint, void *device_args, size_t device_args_bytes,
+    aclrtStream stream, const pto::a5::AicpuTopology &topology
+) {
+    g_affinity_probe_timed_out = false;
+    rtFuncHandle enum_handle = nullptr;
+    rtFuncHandle preflight_handle = nullptr;
+    if (!ResolveNamed(binary_handle, fingerprint, "simpler_aicpu_affinity_enum", &enum_handle)) return false;
+    if (!ResolveNamed(binary_handle, fingerprint, "simpler_aicpu_affinity_preflight", &preflight_handle)) {
+        // Fall back to legacy symbol name if present.
+        if (!ResolveNamed(binary_handle, fingerprint, "simpler_aicpu_rtt_probe", &preflight_handle)) return false;
+    }
+
+    const std::vector<int32_t> user_pool =
+        EnumerateUserPool(enum_handle, device_args, device_args_bytes, stream, topology);
+    if (user_pool.size() < 2) {
+        std::fprintf(stderr, "affinity preflight needs at least 2 user CPUs; got %zu\n", user_pool.size());
+        return false;
+    }
+    if (user_pool.size() > static_cast<size_t>(PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH) ||
+        user_pool.size() > kAffinityMaxPool) {
+        std::fprintf(
+            stderr, "affinity preflight pool %zu exceeds supported launch maximum %d\n", user_pool.size(),
+            PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH
+        );
+        return false;
+    }
+    if (user_pool.size() < 5) {
+        // Emit a shrink-only probe result so Python can skip full packing.
+        std::ostringstream json;
+        json << "{\n  \"schema_version\": 3,\n"
+             << "  \"measurement_method\": \"atomic-flag-orch+cond-die-v1\",\n"
+             << "  \"soc_name\": \"" << topology.soc_name << "\",\n"
+             << "  \"device_id\": " << device_id << ",\n"
+             << "  \"pool_too_small\": true,\n"
+             << "  \"user_pool_cpus\": [";
+        for (size_t i = 0; i < user_pool.size(); ++i) {
+            if (i) json << ", ";
+            json << user_pool[i];
+        }
+        json << "]\n}\n";
+        std::fputs(json.str().c_str(), stdout);
+        return true;
+    }
+
+    std::vector<uint64_t> aicore_registers;
+    if (!MapAicoreRegisters(device_id, &aicore_registers)) return false;
+
+    DeviceBuffer pool_buf, regs_buf, out_buf;
+    if (!pool_buf.Allocate(user_pool.size() * sizeof(int32_t), "user pool") ||
+        !regs_buf.Allocate(aicore_registers.size() * sizeof(uint64_t), "aicore regs") ||
+        !out_buf.Allocate(sizeof(AffinityPreflightOutput), "preflight output")) {
+        return false;
+    }
+    AffinityPreflightOutput zero_out = {};
+    if (!CheckAcl(
+            aclrtMemcpy(
+                pool_buf.get(), user_pool.size() * sizeof(int32_t), user_pool.data(),
+                user_pool.size() * sizeof(int32_t), ACL_MEMCPY_HOST_TO_DEVICE
+            ),
+            "aclrtMemcpy", "H2D pool"
+        ) ||
+        !CheckAcl(
+            aclrtMemcpy(
+                regs_buf.get(), aicore_registers.size() * sizeof(uint64_t), aicore_registers.data(),
+                aicore_registers.size() * sizeof(uint64_t), ACL_MEMCPY_HOST_TO_DEVICE
+            ),
+            "aclrtMemcpy", "H2D regs"
+        ) ||
+        !CheckAcl(
+            aclrtMemcpy(out_buf.get(), sizeof(zero_out), &zero_out, sizeof(zero_out), ACL_MEMCPY_HOST_TO_DEVICE),
+            "aclrtMemcpy", "H2D output"
+        )) {
+        return false;
+    }
+
+    std::vector<uint8_t> host_args(device_args_bytes, 0);
+    auto *args = reinterpret_cast<AffinityPreflightDeviceArgs *>(host_args.data());
+    args->output_addr = reinterpret_cast<uint64_t>(out_buf.get());
+    args->aicore_regs_addr = reinterpret_cast<uint64_t>(regs_buf.get());
+    args->user_pool_addr = reinterpret_cast<uint64_t>(pool_buf.get());
+    args->pool_count = static_cast<uint32_t>(user_pool.size());
+    args->aicore_count = DAV_3510::PLATFORM_MAX_PHYSICAL_CORES;
+    args->handshake_iters = kAffinityHandshakeIters;
+    args->samples_per_core = kAffinitySamplesPerCore;
+    if (!CheckAcl(
+            aclrtMemcpy(device_args, device_args_bytes, host_args.data(), device_args_bytes, ACL_MEMCPY_HOST_TO_DEVICE),
+            "aclrtMemcpy", "preflight device args"
+        )) {
+        return false;
+    }
+
+    const uint32_t launch_count = static_cast<uint32_t>(
+        topology.device_occupancy.occupy_valid ? __builtin_popcountll(topology.device_occupancy.occupy) :
+                                                 user_pool.size()
+    );
+    if (!LaunchCpu(preflight_handle, launch_count, device_args, stream)) return false;
+    if (!CheckAcl(
+            aclrtSynchronizeStreamWithTimeout(stream, kAffinityHostSyncTimeoutMs), "aclrtSynchronizeStreamWithTimeout",
+            "preflight sync"
+        )) {
+        return false;
+    }
+
+    AffinityPreflightOutput output = {};
+    if (!CheckAcl(
+            aclrtMemcpy(&output, sizeof(output), out_buf.get(), sizeof(output), ACL_MEMCPY_DEVICE_TO_HOST),
+            "aclrtMemcpy", "preflight D2H"
+        )) {
+        return false;
+    }
+    if (output.error_code != static_cast<uint32_t>(AffinityProbeError::kNone)) {
+        std::fprintf(stderr, "affinity preflight device error_code=%u\n", output.error_code);
+        return false;
+    }
+    if (output.pool_count != user_pool.size() || output.handshake_done == 0 || output.die_done == 0) {
+        std::fprintf(stderr, "affinity preflight incomplete output\n");
+        return false;
+    }
+    // Normalize pair ticks (device stored avg+1).
+    for (uint32_t i = 0; i < output.pool_count; ++i) {
+        for (uint32_t j = 0; j < output.pool_count; ++j) {
+            uint64_t &cell = output.handshake_pair_ticks[i * kAffinityMaxPool + j];
+            if (cell > 0) --cell;
+        }
+    }
+
+    std::fputs(FormatAffinityJson(device_id, topology, user_pool, output).c_str(), stdout);
+    return true;
+}
+
+bool LastAffinityProbeTimedOut() { return g_affinity_probe_timed_out; }
+
+bool RunRttProbe(
+    int device_id, void *binary_handle, uint64_t fingerprint, void *device_args, size_t device_args_bytes,
+    aclrtStream stream, const pto::a5::AicpuTopology &topology, const pto::a5::AicpuLaunchPlan &
+) {
+    return RunAffinityPreflight(
+        device_id, binary_handle, fingerprint, device_args, device_args_bytes, stream, topology
+    );
+}
+
+}  // namespace aicpu_device_query

--- a/simpler_setup/tools/aicpu_device_query/host/rtt_probe_host.h
+++ b/simpler_setup/tools/aicpu_device_query/host/rtt_probe_host.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <acl/acl.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace pto::a5 {
+struct AicpuLaunchPlan;
+struct AicpuTopology;
+}  // namespace pto::a5
+
+namespace aicpu_device_query {
+
+std::string MakeRttDescriptorEntry(uint64_t fingerprint, const std::string &so_basename);
+std::string MakeAffinityEnumDescriptorEntry(uint64_t fingerprint, const std::string &so_basename);
+std::string MakeAffinityPreflightDescriptorEntry(uint64_t fingerprint, const std::string &so_basename);
+
+// Full affinity preflight: serial enum of the user pool, atomic-flag orch
+// election, COND die scoring. Emits schema_version=3 JSON on stdout.
+bool RunAffinityPreflight(
+    int device_id, void *binary_handle, uint64_t fingerprint, void *device_args, size_t device_args_bytes,
+    aclrtStream stream, const pto::a5::AicpuTopology &topology
+);
+
+bool LastAffinityProbeTimedOut();
+
+// Back-compat name used by query_device_hal.cpp.
+bool RunRttProbe(
+    int device_id, void *binary_handle, uint64_t fingerprint, void *device_args, size_t device_args_bytes,
+    aclrtStream stream, const pto::a5::AicpuTopology &topology, const pto::a5::AicpuLaunchPlan &launch_plan
+);
+
+}  // namespace aicpu_device_query

--- a/simpler_setup/tools/aicpu_device_query/shared/rtt_probe_types.h
+++ b/simpler_setup/tools/aicpu_device_query/shared/rtt_probe_types.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+// Full AICPU affinity preflight protocol (replaces the earlier 4-scheduler-only
+// COND RTT probe). Host enumerates the user pool, launches one thread per pool
+// CPU, measures pairwise atomic-flag handshake latency, then measures COND
+// access sums for non-orchestrator threads.
+
+constexpr uint32_t kAffinityMaxPool = 16;
+constexpr uint32_t kAffinitySchedCount = 4;
+constexpr uint32_t kAffinityHandshakeIters = 1000;
+constexpr uint32_t kAffinitySamplesPerCore = 100;
+constexpr uint32_t kAffinityWarmupSamplesPerCore = 8;
+constexpr uint32_t kAffinityBarrierTimeoutSeconds = 30;
+constexpr int32_t kAffinityHostSyncTimeoutMs = 30000;
+constexpr int32_t kAffinityPreflightTimeoutExitCode = 124;
+
+// Legacy aliases kept so existing include sites compile during the transition.
+constexpr uint32_t kRttProbeSchedulerCount = kAffinitySchedCount;
+constexpr uint32_t kRttProbeSamplesPerCore = kAffinitySamplesPerCore;
+constexpr uint32_t kRttProbeWarmupSamplesPerCore = kAffinityWarmupSamplesPerCore;
+constexpr uint32_t kRttProbeBarrierTimeoutSeconds = kAffinityBarrierTimeoutSeconds;
+
+enum class AffinityProbeError : uint32_t {
+    kNone = 0,
+    kDuplicatePool = 1,
+    kBarrierTimeout = 2,
+    kInvalidPool = 3,
+};
+
+using RttProbeError = AffinityProbeError;
+
+struct AffinityPoolSlot {
+    int32_t pool_idx;
+    int32_t cpu_id;
+    uint64_t avg_handshake_ticks;
+    uint64_t die0_sum_ticks;
+    uint64_t die1_sum_ticks;
+    uint32_t handshake_valid;
+    uint32_t die_valid;
+    uint32_t is_orch;
+    uint32_t reserved;
+};
+
+struct AffinityPreflightOutput {
+    uint32_t ready_count;
+    uint32_t claimed_mask;
+    uint32_t error_code;
+    uint32_t pool_count;
+    uint32_t orch_pool_idx;
+    uint32_t handshake_done;
+    uint32_t die_done;
+    uint32_t reserved;
+    AffinityPoolSlot slots[kAffinityMaxPool];
+    // Symmetric pair average ticks; index = i * kAffinityMaxPool + j (i != j).
+    uint64_t handshake_pair_ticks[kAffinityMaxPool * kAffinityMaxPool];
+    // Atomic flag handshake scratch (req/ack). Host zeroes before launch.
+    uint32_t handshake_req[kAffinityMaxPool][kAffinityMaxPool];
+    uint32_t handshake_ack[kAffinityMaxPool][kAffinityMaxPool];
+};
+
+// Serial enum (aicpu_num=1): one thread writes its sched_getcpu into slot 0.
+struct AffinityEnumOutput {
+    uint32_t ready;
+    int32_t cpu_id;
+    uint32_t reserved[2];
+};
+
+struct AffinityEnumDeviceArgs {
+    uint64_t reserved_pre[12];
+    uint64_t output_addr;
+};
+
+// Reuses the dispatcher's 160-byte DeviceArgs buffer. Fields start at offset 96.
+struct AffinityPreflightDeviceArgs {
+    uint64_t reserved_pre[12];
+    uint64_t output_addr;
+    uint64_t aicore_regs_addr;
+    uint64_t user_pool_addr;
+    uint32_t pool_count;
+    uint32_t aicore_count;
+    uint32_t handshake_iters;
+    uint32_t samples_per_core;
+};
+
+using RttProbeDeviceArgs = AffinityPreflightDeviceArgs;
+using RttProbeOutput = AffinityPreflightOutput;
+using RttProbeSlot = AffinityPoolSlot;
+
+static_assert(sizeof(AffinityPreflightDeviceArgs) <= 160, "affinity probe args exceed DeviceArgs storage");
+static_assert(sizeof(AffinityEnumDeviceArgs) <= 160, "affinity enum args exceed DeviceArgs storage");
+static_assert(std::is_trivially_copyable_v<AffinityPoolSlot> && std::is_standard_layout_v<AffinityPoolSlot>);
+static_assert(
+    std::is_trivially_copyable_v<AffinityPreflightOutput> && std::is_standard_layout_v<AffinityPreflightOutput>
+);
+static_assert(
+    std::is_trivially_copyable_v<AffinityPreflightDeviceArgs> && std::is_standard_layout_v<AffinityPreflightDeviceArgs>
+);

--- a/simpler_setup/tools/rtt_die_preflight.py
+++ b/simpler_setup/tools/rtt_die_preflight.py
@@ -1,0 +1,909 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Full A5 AICPU affinity preflight: orch via atomic-flag handshake, sched via COND die scores."""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Mapping, Sequence
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from simpler_setup.environment import PROJECT_ROOT
+
+SCHEDULER_COUNT = 4
+PROBE_SCHEMA_VERSION = 3
+PLAN_SCHEMA_VERSION = 3
+MEASUREMENT_METHOD = "atomic-flag-orch+cond-die-v1"
+PLAN_SOURCE_PROBE_FAILED = "probe-failed-contiguous"
+PLAN_SOURCE_MANUAL = "manual"
+PLAN_SOURCE_AUTO_FIRST_RUN = "auto-first-run"
+SUPPORTED_PLAN_SOURCES = frozenset(
+    {MEASUREMENT_METHOD, PLAN_SOURCE_PROBE_FAILED, PLAN_SOURCE_MANUAL, PLAN_SOURCE_AUTO_FIRST_RUN}
+)
+# Phys pick die0,die1,die1,die0 → pack to logical [P0,P3,P1,P2] so S0/S1→die0, S2/S3→die1.
+PHYS_PICK_DIES = (0, 1, 1, 0)
+PROBE_SAMPLES_PER_CORE = 100
+ACTIVE_THREAD_COUNT = SCHEDULER_COUNT + 1
+MAX_LAUNCH_THREAD_COUNT = 14
+PREFLIGHT_TIMEOUT_SECONDS = 30
+# Helper/dispatcher compilation is outside the device-probe budget.
+HELPER_BUILD_TIMEOUT_SECONDS = 600
+PREFLIGHT_TIMEOUT_EXIT_CODE = 124
+TIMEOUT_RECORD_SCHEMA_VERSION = 1
+PLAN_ENV = "SIMPLER_AICPU_AFFINITY_PLAN"
+RELATIVE_PLAN = Path("build/config/aicpu_affinity_plan.json")
+
+
+class AffinityProbeTimeout(subprocess.TimeoutExpired):
+    """Raised only when the device RTT/COND probe exceeds PREFLIGHT_TIMEOUT_SECONDS."""
+
+
+_TOOL = Path(__file__).resolve().parent / "aicpu_device_query"
+_CACHE = PROJECT_ROOT / "build" / "cache" / "aicpu_device_query"
+_DISPATCHER = PROJECT_ROOT / "build" / "lib" / "a5" / "dispatcher" / "libsimpler_aicpu_dispatcher.so"
+_CACHE_LOCK = _CACHE / ".build.lock"
+_CACHE_STAMP = _CACHE / ".build.stamp"
+
+
+def _with_device_suffix(path: Path, device_id: int) -> Path:
+    """Resolve a base/template path to one device's JSON without doubling an existing suffix."""
+    raw = str(path)
+    if "{device}" in raw:
+        return Path(raw.replace("{device}", str(device_id)))
+    suffix = path.suffix if path.suffix else ".json"
+    stem = path.name[: -len(path.suffix)] if path.suffix else path.name
+    if not stem.endswith(f".{device_id}"):
+        stem += f".{device_id}"
+    return path.with_name(f"{stem}{suffix}")
+
+
+def default_plan_path(device_id: int) -> Path:
+    """Return the absolute per-device plan path shared by auto-preflight and the runtime reader."""
+    configured = os.environ.get(PLAN_ENV, "").strip()
+    base = Path(configured) if configured else Path.cwd() / RELATIVE_PLAN
+    return _with_device_suffix(base, device_id).resolve()
+
+
+def cpus_side_path(plan_path: Path) -> Path:
+    """Return the thin runtime companion path for one exact per-device JSON path."""
+    return plan_path.with_suffix(".cpus")
+
+
+def timeout_record_path(plan_path: Path) -> Path:
+    """Return the per-device automatic-preflight timeout marker path."""
+    return plan_path.with_suffix(".timeout")
+
+
+def timeout_record_looks_usable(path: Path, device_id: int) -> bool:
+    """Return whether an automatic preflight timeout marker is valid for this device."""
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+        return (
+            isinstance(record, dict)
+            and record.get("schema_version") == TIMEOUT_RECORD_SCHEMA_VERSION
+            and record.get("device_id") == int(device_id)
+            and record.get("status") == "timeout"
+            and record.get("timeout_seconds") == PREFLIGHT_TIMEOUT_SECONDS
+        )
+    except (OSError, UnicodeError, TypeError, ValueError, json.JSONDecodeError):
+        return False
+
+
+def write_timeout_record(plan_path: Path, device_id: int, *, reason: str) -> Path:
+    """Atomically persist the marker that suppresses repeated automatic probes."""
+    marker = timeout_record_path(plan_path)
+    _atomic_write_text(
+        marker,
+        json.dumps(
+            {
+                "schema_version": TIMEOUT_RECORD_SCHEMA_VERSION,
+                "device_id": int(device_id),
+                "status": "timeout",
+                "timeout_seconds": PREFLIGHT_TIMEOUT_SECONDS,
+                "reason": reason,
+                "created_at": int(time.time()),
+            },
+            indent=2,
+        )
+        + "\n",
+    )
+    return marker
+
+
+def clear_timeout_record(plan_path: Path) -> None:
+    """Allow an explicit manual probe to retry after an automatic timeout."""
+    timeout_record_path(plan_path).unlink(missing_ok=True)
+
+
+def _helper_source_files() -> list[Path]:
+    """Return source files that affect the standalone query helper artifacts."""
+    roots = (
+        _TOOL,
+        PROJECT_ROOT / "src" / "a5" / "platform" / "include",
+        PROJECT_ROOT / "src" / "a5" / "platform" / "onboard" / "host",
+        PROJECT_ROOT / "src" / "common" / "log",
+        PROJECT_ROOT / "src" / "common" / "platform" / "include",
+    )
+    return sorted(
+        {
+            path
+            for root in roots
+            if root.exists()
+            for path in (root.rglob("*") if root.is_dir() else (root,))
+            if path.is_file()
+        }
+    )
+
+
+def _helper_source_fingerprint(env: Mapping[str, str]) -> str:
+    """Hash helper sources and toolchain identity for the shared build cache."""
+    digest = hashlib.sha256()
+    for key in ("ASCEND_HOME_PATH", "CC", "CXX"):
+        digest.update(key.encode("utf-8"))
+        digest.update(b"=")
+        digest.update(env.get(key, "").encode("utf-8"))
+        digest.update(b"\0")
+    for path in _helper_source_files():
+        try:
+            relative = path.relative_to(PROJECT_ROOT)
+            digest.update(str(relative).encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(path.read_bytes())
+        except OSError as exc:
+            raise RuntimeError(f"cannot fingerprint helper source {path}: {exc}") from exc
+    return digest.hexdigest()
+
+
+@contextmanager
+def _helper_build_lock(*, deadline: float | None = None, timeout_seconds: float = HELPER_BUILD_TIMEOUT_SECONDS):
+    """Serialize helper builds across processes under the helper-build budget."""
+    _CACHE.mkdir(parents=True, exist_ok=True)
+    with _CACHE_LOCK.open("w", encoding="utf-8") as lock_file:
+        locked = False
+        try:
+            while not locked:
+                try:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    locked = True
+                except OSError as exc:
+                    if exc.errno not in (errno.EACCES, errno.EAGAIN):
+                        raise
+                    if deadline is not None and time.monotonic() >= deadline:
+                        raise subprocess.TimeoutExpired("aicpu_device_query build lock", timeout_seconds)
+                    time.sleep(0.05)
+            yield
+        finally:
+            if locked:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _artifact_looks_usable(path: Path) -> bool:
+    try:
+        return path.is_file() and path.stat().st_size > 0
+    except OSError:
+        return False
+
+
+def _cache_stamp_matches(fingerprint: str) -> bool:
+    try:
+        record = json.loads(_CACHE_STAMP.read_text(encoding="utf-8"))
+        return record.get("schema_version") == 1 and record.get("fingerprint") == fingerprint
+    except (OSError, UnicodeError, TypeError, AttributeError, ValueError, json.JSONDecodeError):
+        return False
+
+
+def _write_cache_stamp(fingerprint: str) -> None:
+    _atomic_write_text(
+        _CACHE_STAMP,
+        json.dumps({"schema_version": 1, "fingerprint": fingerprint}, sort_keys=True) + "\n",
+    )
+
+
+def _run_with_deadline(
+    command: Sequence[str],
+    *,
+    deadline: float | None = None,
+    timeout_seconds: float = PREFLIGHT_TIMEOUT_SECONDS,
+    timeout_error: type[subprocess.TimeoutExpired] = subprocess.TimeoutExpired,
+    **kwargs: Any,
+) -> Any:
+    """Run one child process under an absolute deadline (probe or helper-build)."""
+    if deadline is not None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise timeout_error(command, timeout_seconds)
+        kwargs["timeout"] = remaining
+    try:
+        return subprocess.run(command, check=kwargs.pop("check", False), **kwargs)
+    except subprocess.TimeoutExpired as exc:
+        if timeout_error is subprocess.TimeoutExpired:
+            raise
+        raise timeout_error(exc.cmd, timeout_seconds) from exc
+
+
+def _require_int(value: object, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field} must be an integer")
+    return value
+
+
+def validate_cpu_list(
+    values: Sequence[object], field: str, *, min_count: int, max_count: int = MAX_LAUNCH_THREAD_COUNT
+) -> list[int]:
+    """Validate a unique AICPU id list against the driver mask width and supported launch bound."""
+    cpus = [_require_int(value, f"{field}[]") for value in values]
+    if not min_count <= len(cpus) <= max_count:
+        raise ValueError(f"{field} must contain between {min_count} and {max_count} CPUs")
+    if len(set(cpus)) != len(cpus):
+        raise ValueError(f"{field} contains duplicate CPUs")
+    if any(cpu < 0 or cpu >= 64 for cpu in cpus):
+        raise ValueError(f"{field} CPU ids must be in [0, 63]")
+    return cpus
+
+
+def occupy_mask_from_cpus(cpus: Sequence[int]) -> int:
+    """Encode validated logical CPU ids as the driver's 64-bit OCCUPY mask."""
+    mask = 0
+    for cpu in cpus:
+        mask |= 1 << int(cpu)
+    return mask
+
+
+def validate_device_node(
+    device_node: Mapping[str, Any], *, expected_soc: str, expected_device: int
+) -> tuple[list[int], list[int]]:
+    """Validate the complete persisted JSON/side contract before either file is published."""
+    if not expected_soc.startswith("Ascend950") or device_node.get("soc_name") != expected_soc:
+        raise ValueError(f"unsupported or mismatched plan soc_name: {device_node.get('soc_name')!r}")
+    if _require_int(device_node.get("device_id"), "device_id") != expected_device:
+        raise ValueError("plan device_id does not match --device")
+    if _require_int(device_node.get("active_count"), "active_count") != ACTIVE_THREAD_COUNT:
+        raise ValueError(f"plan active_count must be {ACTIVE_THREAD_COUNT}")
+    source = device_node.get("plan_source")
+    if source not in SUPPORTED_PLAN_SOURCES:
+        raise ValueError(f"unsupported plan_source: {source!r}")
+    raw_pool = device_node.get("user_pool_cpus")
+    raw_allowed = device_node.get("allowed_cpus")
+    if not isinstance(raw_pool, list) or not isinstance(raw_allowed, list):
+        raise ValueError("user_pool_cpus and allowed_cpus must be arrays")
+    pool = validate_cpu_list(raw_pool, "user_pool_cpus", min_count=ACTIVE_THREAD_COUNT)
+    allowed = validate_cpu_list(
+        raw_allowed, "allowed_cpus", min_count=ACTIVE_THREAD_COUNT, max_count=ACTIVE_THREAD_COUNT
+    )
+    if not set(allowed).issubset(pool):
+        raise ValueError("allowed_cpus must be a subset of user_pool_cpus")
+    raw_mask = device_node.get("occupy_mask")
+    try:
+        occupy_mask = int(raw_mask, 0) if isinstance(raw_mask, str) else _require_int(raw_mask, "occupy_mask")
+    except ValueError as exc:
+        raise ValueError("occupy_mask must be a valid 64-bit integer") from exc
+    if occupy_mask <= 0 or occupy_mask >= 1 << 64 or occupy_mask != occupy_mask_from_cpus(pool):
+        raise ValueError("occupy_mask must exactly match user_pool_cpus")
+    if _require_int(device_node.get("orch_cpu"), "orch_cpu") != allowed[-1]:
+        raise ValueError("orch_cpu must be the last allowed CPU")
+    schedulers = device_node.get("schedulers")
+    if not isinstance(schedulers, list) or len(schedulers) != SCHEDULER_COUNT:
+        raise ValueError(f"schedulers must contain exactly {SCHEDULER_COUNT} entries")
+    for idx, scheduler in enumerate(schedulers):
+        if not isinstance(scheduler, dict):
+            raise ValueError("scheduler entries must be objects")
+        if _require_int(scheduler.get("logical_idx"), "logical_idx") != idx:
+            raise ValueError("scheduler logical_idx values must be contiguous")
+        if _require_int(scheduler.get("cpu_id"), "scheduler.cpu_id") != allowed[idx]:
+            raise ValueError("scheduler CPU order must match allowed_cpus")
+        if _require_int(scheduler.get("assigned_die"), "assigned_die") != (0 if idx < 2 else 1):
+            raise ValueError("scheduler assigned_die must match the logical die contract")
+    return pool, allowed
+
+
+def side_file_looks_usable(path: Path, device_id: int) -> bool:
+    """Perform the hardware-independent subset of side-file validation used before auto-probing."""
+    try:
+        entries: dict[str, str] = {}
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line or line.startswith("#"):
+                continue
+            key, separator, value = line.partition("=")
+            if not separator or key in entries:
+                return False
+            entries[key] = value
+        required = {"schema_version", "device_id", "soc", "source", "occupy_mask", "active_count", "cpus"}
+        if set(entries) != required:
+            return False
+        if int(entries["schema_version"], 10) != PLAN_SCHEMA_VERSION:
+            return False
+        if int(entries["device_id"], 10) != device_id or int(entries["active_count"], 10) != ACTIVE_THREAD_COUNT:
+            return False
+        if not entries["soc"].startswith("Ascend950") or entries["source"] not in SUPPORTED_PLAN_SOURCES:
+            return False
+        cpu_parts = entries["cpus"].split(",")
+        if any(not part.strip() for part in cpu_parts):
+            return False
+        cpus = validate_cpu_list(
+            [int(part.strip(), 10) for part in cpu_parts],
+            "cpus",
+            min_count=ACTIVE_THREAD_COUNT,
+            max_count=ACTIVE_THREAD_COUNT,
+        )
+        occupy_mask = int(entries["occupy_mask"], 0)
+        pool_count = bin(occupy_mask).count("1")
+        return (
+            0 < occupy_mask < 1 << 64
+            and ACTIVE_THREAD_COUNT <= pool_count <= MAX_LAUNCH_THREAD_COUNT
+            and all((occupy_mask >> cpu) & 1 for cpu in cpus)
+        )
+    except (OSError, UnicodeError, ValueError):
+        return False
+
+
+def _ascend_env(*, deadline: float | None = None) -> dict[str, str]:
+    home = os.environ.get("ASCEND_HOME_PATH", "").strip()
+    home_p = (
+        Path(home)
+        if home
+        else next(
+            (
+                p
+                for p in (Path("/usr/local/Ascend/ascend-toolkit/latest"), Path("/usr/local/Ascend/cann-9.2.0"))
+                if p.is_dir()
+            ),
+            None,
+        )
+    )
+    if home_p is None or not (home_p / "set_env.sh").is_file():
+        raise RuntimeError("ASCEND_HOME_PATH not found")
+    out = _run_with_deadline(
+        ["bash", "-c", f'source "{home_p / "set_env.sh"}" && env -0'],
+        deadline=deadline,
+        timeout_seconds=HELPER_BUILD_TIMEOUT_SECONDS,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    env = dict(os.environ)
+    for entry in out.stdout.split(b"\0"):
+        if b"=" in entry:
+            k, _, v = entry.partition(b"=")
+            env[k.decode()] = v.decode()
+    env["ASCEND_HOME_PATH"] = str(home_p)
+    return env
+
+
+def _cmake_build(
+    src: Path, build: Path, env: dict[str, str], *, cross: bool = False, deadline: float | None = None
+) -> None:
+    cfg = ["cmake", "-S", str(src), "-B", str(build), f"-DSIMPLER_ROOT={PROJECT_ROOT}"]
+    if cross:
+        ah = Path(env["ASCEND_HOME_PATH"]) / "tools" / "hcc" / "bin"
+        cfg += [
+            f"-DCMAKE_C_COMPILER={ah / 'aarch64-target-linux-gnu-gcc'}",
+            f"-DCMAKE_CXX_COMPILER={ah / 'aarch64-target-linux-gnu-g++'}",
+        ]
+    _run_with_deadline(
+        cfg,
+        deadline=deadline,
+        timeout_seconds=HELPER_BUILD_TIMEOUT_SECONDS,
+        check=True,
+        cwd=PROJECT_ROOT,
+        env=env,
+    )
+    _run_with_deadline(
+        ["cmake", "--build", str(build), f"-j{os.cpu_count() or 1}"],
+        deadline=deadline,
+        timeout_seconds=HELPER_BUILD_TIMEOUT_SECONDS,
+        check=True,
+        cwd=PROJECT_ROOT,
+        env=env,
+    )
+
+
+def _ensure_query_device_hal_artifacts() -> tuple[Path, dict[str, str]]:
+    """Compile helper/dispatcher artifacts under the helper-build budget (not the probe budget)."""
+    if not (_TOOL / "host").is_dir():
+        raise RuntimeError(f"aicpu_device_query sources missing under {_TOOL}")
+    if shutil.which("cmake") is None:
+        raise RuntimeError("cmake is required to build the aicpu_device_query backend")
+    build_deadline = time.monotonic() + HELPER_BUILD_TIMEOUT_SECONDS
+    env = _ascend_env(deadline=build_deadline)
+    dispatcher_override = bool(env.get("SIMPLER_DISPATCHER_SO"))
+    query_override = bool(env.get("SIMPLER_AICPU_QUERY_SO"))
+    dispatcher = Path(env["SIMPLER_DISPATCHER_SO"]) if dispatcher_override else _DISPATCHER
+    query_so = Path(env["SIMPLER_AICPU_QUERY_SO"]) if query_override else _CACHE / "device" / "libaicpu_query.so"
+    host_bin = _CACHE / "host" / "query_device_hal"
+
+    with _helper_build_lock(deadline=build_deadline, timeout_seconds=HELPER_BUILD_TIMEOUT_SECONDS):
+        if not _artifact_looks_usable(dispatcher):
+            if dispatcher_override:
+                raise RuntimeError(f"Missing dispatcher SO: {dispatcher}")
+            _run_with_deadline(
+                [
+                    sys.executable,
+                    "-m",
+                    "simpler_setup.build_runtimes",
+                    "--lib-dir",
+                    str(PROJECT_ROOT / "build" / "lib"),
+                    "--cache-dir",
+                    str(PROJECT_ROOT / "build" / "cache"),
+                    "--platforms",
+                    "a5",
+                ],
+                deadline=build_deadline,
+                timeout_seconds=HELPER_BUILD_TIMEOUT_SECONDS,
+                check=True,
+                cwd=PROJECT_ROOT,
+                env={**env, "PYTHONPATH": f"{PROJECT_ROOT}{os.pathsep}{env.get('PYTHONPATH', '')}"},
+            )
+            dispatcher = _DISPATCHER
+            if not _artifact_looks_usable(dispatcher):
+                raise RuntimeError(f"Missing dispatcher SO: {dispatcher}")
+
+        fingerprint = _helper_source_fingerprint(env)
+        stamp_matches = _cache_stamp_matches(fingerprint)
+        if not query_override and (not _artifact_looks_usable(query_so) or not stamp_matches):
+            _cmake_build(_TOOL / "device", _CACHE / "device", env, cross=True, deadline=build_deadline)
+            query_so = _CACHE / "device" / "libaicpu_query.so"
+        if not _artifact_looks_usable(query_so):
+            raise RuntimeError(f"Missing query SO: {query_so}")
+        if not _artifact_looks_usable(host_bin) or not stamp_matches:
+            _cmake_build(_TOOL / "host", _CACHE / "host", env, deadline=build_deadline)
+        if not _artifact_looks_usable(host_bin):
+            raise RuntimeError(f"Missing host launcher: {host_bin}")
+        if not stamp_matches:
+            _write_cache_stamp(fingerprint)
+
+    env = {**env, "SIMPLER_DISPATCHER_SO": str(dispatcher), "SIMPLER_AICPU_QUERY_SO": str(query_so)}
+    return host_bin, env
+
+
+def _run_query_device_hal(device_id: int, mode: str) -> str:
+    """Ensure helpers exist, then run query_device_hal under the 30s probe budget only."""
+    if mode not in ("--rtt-json", "--json"):
+        raise ValueError(f"unsupported mode: {mode}")
+    host_bin, env = _ensure_query_device_hal_artifacts()
+    probe_deadline = time.monotonic() + PREFLIGHT_TIMEOUT_SECONDS
+    return _run_with_deadline(
+        [str(host_bin), str(device_id), mode],
+        deadline=probe_deadline,
+        timeout_seconds=PREFLIGHT_TIMEOUT_SECONDS,
+        timeout_error=AffinityProbeTimeout,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        cwd=PROJECT_ROOT,
+        env=env,
+    ).stdout
+
+
+def pick_orchestrator(pool: Sequence[Mapping[str, Any]]) -> int:
+    """Return pool_idx with the smallest avg_handshake_ticks (tie: smaller idx)."""
+    if not pool:
+        raise ValueError("empty pool")
+    best = min(pool, key=lambda e: (int(e["avg_handshake_ticks"]), int(e["pool_idx"])))
+    return int(best["pool_idx"])
+
+
+def pack_schedulers_from_die_scores(
+    candidates: Sequence[Mapping[str, Any]],
+) -> tuple[list[int], list[dict[str, Any]]]:
+    """Phys die0,die1,die1,die0 picks → logical [P0,P3,P1,P2] (S0/S1 die0, S2/S3 die1)."""
+    if len(candidates) < SCHEDULER_COUNT:
+        raise ValueError(f"need at least {SCHEDULER_COUNT} non-orch candidates")
+    remaining = [dict(e) for e in candidates]
+    picks: list[dict[str, Any]] = []
+    for target_die in PHYS_PICK_DIES:
+        key = "die0_sum_ticks" if target_die == 0 else "die1_sum_ticks"
+        remaining.sort(key=lambda e, k=key: (int(e[k]), int(e["cpu_id"])))
+        chosen = dict(remaining.pop(0))
+        chosen["assigned_die"] = target_die
+        picks.append(chosen)
+    logical = [picks[0], picks[3], picks[1], picks[2]]
+    for i, entry in enumerate(logical):
+        entry["logical_idx"] = i
+        entry["assigned_die"] = 0 if i < 2 else 1
+    return [int(e["cpu_id"]) for e in logical], logical
+
+
+def build_allowed_cpus_from_probe(probe: Mapping[str, Any]) -> dict[str, Any]:
+    """Turn device probe JSON into an authoritative device plan node."""
+    if probe.get("pool_too_small"):
+        raise ValueError("RTT preflight requires 4 scheduler CPUs and 1 orchestrator CPU")
+
+    raw_user_pool = probe.get("user_pool_cpus")
+    if not isinstance(raw_user_pool, list):
+        raise ValueError("user_pool_cpus must be an array")
+    user_pool = validate_cpu_list(raw_user_pool, "user_pool_cpus", min_count=ACTIVE_THREAD_COUNT)
+
+    pool_raw = probe.get("pool")
+    if not isinstance(pool_raw, list) or len(pool_raw) != len(user_pool):
+        raise ValueError("probe pool must contain exactly one entry per user_pool CPU")
+
+    pool_entries: list[dict[str, Any]] = []
+    for raw in pool_raw:
+        if not isinstance(raw, dict):
+            raise ValueError("pool entry must be an object")
+        pool_entries.append(
+            {
+                "pool_idx": _require_int(raw.get("pool_idx"), "pool_idx"),
+                "cpu_id": _require_int(raw.get("cpu_id"), "cpu_id"),
+                "avg_handshake_ticks": _require_int(raw.get("avg_handshake_ticks"), "avg_handshake_ticks"),
+                "die0_sum_ticks": _require_int(raw.get("die0_sum_ticks"), "die0_sum_ticks"),
+                "die1_sum_ticks": _require_int(raw.get("die1_sum_ticks"), "die1_sum_ticks"),
+                "is_orch": _require_int(raw.get("is_orch"), "is_orch"),
+            }
+        )
+
+    pool_indices = [int(entry["pool_idx"]) for entry in pool_entries]
+    if sorted(pool_indices) != list(range(len(user_pool))):
+        raise ValueError("probe pool_idx values must cover [0, pool_count)")
+    by_idx = sorted(pool_entries, key=lambda entry: int(entry["pool_idx"]))
+    if [int(entry["cpu_id"]) for entry in by_idx] != user_pool:
+        raise ValueError("probe pool CPU order does not match user_pool_cpus")
+    if any(int(entry["avg_handshake_ticks"]) <= 0 for entry in pool_entries):
+        raise ValueError("probe handshake measurements must be positive")
+    for entry in pool_entries:
+        if int(entry["is_orch"]) not in (0, 1):
+            raise ValueError("probe is_orch must be 0 or 1")
+        if not int(entry["is_orch"]) and (int(entry["die0_sum_ticks"]) <= 0 or int(entry["die1_sum_ticks"]) <= 0):
+            raise ValueError("scheduler die measurements must be positive")
+
+    orch_idx = _require_int(probe.get("orch_pool_idx"), "orch_pool_idx")
+    orch_entries = [e for e in pool_entries if int(e["pool_idx"]) == orch_idx]
+    marked_orchestrators = [entry for entry in pool_entries if int(entry["is_orch"]) == 1]
+    if len(orch_entries) != 1 or marked_orchestrators != orch_entries:
+        raise ValueError("probe must mark exactly the reported orchestrator")
+    orch = orch_entries[0]
+    sched_cpus, schedulers = pack_schedulers_from_die_scores(
+        [e for e in pool_entries if int(e["pool_idx"]) != orch_idx]
+    )
+    allowed = sched_cpus + [int(orch["cpu_id"])]
+    if len(set(allowed)) != len(allowed):
+        raise ValueError("allowed_cpus contains duplicates")
+
+    return {
+        "soc_name": probe["soc_name"],
+        "device_id": _require_int(probe.get("device_id"), "device_id"),
+        "architecture": "a5",
+        "plan_source": MEASUREMENT_METHOD,
+        "measurement_method": MEASUREMENT_METHOD,
+        "user_pool_cpus": user_pool,
+        "occupy_mask": f"0x{occupy_mask_from_cpus(user_pool):x}",
+        "active_count": ACTIVE_THREAD_COUNT,
+        "allowed_cpus": allowed,
+        "orch_cpu": int(orch["cpu_id"]),
+        "orch_avg_handshake_ticks": int(orch["avg_handshake_ticks"]),
+        "schedulers": [
+            {
+                "logical_idx": int(s["logical_idx"]),
+                "cpu_id": int(s["cpu_id"]),
+                "assigned_die": int(s["assigned_die"]),
+                "die0_sum_ticks": int(s["die0_sum_ticks"]),
+                "die1_sum_ticks": int(s["die1_sum_ticks"]),
+            }
+            for s in schedulers
+        ],
+        "pool_too_small": False,
+    }
+
+
+def validate_probe_result(raw: object, expected_device: int) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ValueError("probe output must be a JSON object")
+    if _require_int(raw.get("schema_version"), "schema_version") != PROBE_SCHEMA_VERSION:
+        raise ValueError("unsupported affinity probe schema_version")
+    if raw.get("measurement_method") != MEASUREMENT_METHOD:
+        raise ValueError("unsupported measurement_method")
+    soc_name = raw.get("soc_name")
+    if not isinstance(soc_name, str) or not soc_name.startswith("Ascend950"):
+        raise ValueError(f"unsupported probe soc_name: {soc_name!r}")
+    if _require_int(raw.get("device_id"), "device_id") != expected_device:
+        raise ValueError("probe output device_id does not match --device")
+    if raw.get("pool_too_small"):
+        raise ValueError("RTT preflight pool has fewer than 5 CPUs")
+    if _require_int(raw.get("samples_per_core", PROBE_SAMPLES_PER_CORE), "samples_per_core") != PROBE_SAMPLES_PER_CORE:
+        raise ValueError("unexpected samples_per_core")
+    # Fully validate the measurements before the caller is allowed to persist them.
+    build_allowed_cpus_from_probe(raw)
+    return raw  # type: ignore[return-value]
+
+
+def run_affinity_probe(device_id: int) -> dict[str, Any]:
+    try:
+        stdout = _run_query_device_hal(device_id, "--rtt-json")
+    except AffinityProbeTimeout:
+        raise
+    except subprocess.CalledProcessError as exc:
+        if exc.returncode == PREFLIGHT_TIMEOUT_EXIT_CODE:
+            raise AffinityProbeTimeout(exc.cmd, PREFLIGHT_TIMEOUT_SECONDS) from exc
+        raise RuntimeError(f"affinity probe backend failed with exit code {exc.returncode}") from exc
+    try:
+        raw = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("affinity probe backend returned invalid JSON") from exc
+    return validate_probe_result(raw, device_id)
+
+
+def make_device_plan(*, soc_name: str, device_id: int, device_node: Mapping[str, Any]) -> dict[str, Any]:
+    """Build a schema-v3 JSON document containing exactly one device."""
+    return {
+        "schema_version": PLAN_SCHEMA_VERSION,
+        "_comment": (
+            "A5 AICPU affinity plan (authoritative allowed_cpus). "
+            "Logical S0/S1 own die0; S2/S3 own die1. Generated by simpler_setup.tools.rtt_die_preflight."
+        ),
+        "socs": {soc_name: {"devices": {str(device_id): dict(device_node)}}},
+    }
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", delete=False
+        ) as temporary:
+            temporary_name = temporary.name
+            temporary.write(text)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        os.replace(temporary_name, path)
+    finally:
+        if temporary_name is not None:
+            Path(temporary_name).unlink(missing_ok=True)
+
+
+def _side_file_text(device_node: Mapping[str, Any]) -> str:
+    return (
+        f"schema_version={PLAN_SCHEMA_VERSION}\n"
+        f"device_id={int(device_node['device_id'])}\n"
+        f"soc={device_node['soc_name']}\n"
+        f"source={device_node['plan_source']}\n"
+        f"occupy_mask={device_node['occupy_mask']}\n"
+        f"active_count={int(device_node['active_count'])}\n"
+        f"cpus={','.join(str(int(cpu)) for cpu in device_node['allowed_cpus'])}\n"
+    )
+
+
+def plan_files_look_usable(plan_path: Path, device_id: int) -> bool:
+    """Validate that an existing JSON/side pair is one coherent generated device plan."""
+    try:
+        raw = json.loads(plan_path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict) or raw.get("schema_version") != PLAN_SCHEMA_VERSION:
+            return False
+        socs = raw.get("socs")
+        if not isinstance(socs, dict) or len(socs) != 1:
+            return False
+        soc_name, soc_node = next(iter(socs.items()))
+        if not isinstance(soc_name, str) or not isinstance(soc_node, dict):
+            return False
+        devices = soc_node.get("devices")
+        if not isinstance(devices, dict) or set(devices) != {str(device_id)}:
+            return False
+        device_node = devices[str(device_id)]
+        if not isinstance(device_node, dict):
+            return False
+        validate_device_node(device_node, expected_soc=soc_name, expected_device=device_id)
+        side = cpus_side_path(plan_path)
+        return side_file_looks_usable(side, device_id) and side.read_text(encoding="utf-8") == _side_file_text(
+            device_node
+        )
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+        return False
+
+
+def atomic_write_plan_and_side(path: Path, plan: Mapping[str, Any], device_node: Mapping[str, Any]) -> None:
+    """Publish JSON first and the runtime-authoritative side file last, rolling back on write failure."""
+    side = cpus_side_path(path)
+    previous = {target: target.read_text(encoding="utf-8") if target.is_file() else None for target in (path, side)}
+    published: list[Path] = []
+    try:
+        _atomic_write_text(path, json.dumps(plan, indent=2) + "\n")
+        published.append(path)
+        _atomic_write_text(side, _side_file_text(device_node))
+        published.append(side)
+    except (OSError, UnicodeError):
+        for target in reversed(published):
+            old_text = previous[target]
+            if old_text is None:
+                target.unlink(missing_ok=True)
+            else:
+                _atomic_write_text(target, old_text)
+        raise
+
+
+def build_contiguous_fallback_node(
+    *,
+    soc_name: str,
+    device_id: int,
+    occupy_cpus: Sequence[int],
+    plan_source: str = PLAN_SOURCE_PROBE_FAILED,
+) -> dict[str, Any]:
+    """Build an explicitly requested five-thread contiguous plan. Probe failures never call this."""
+    pool = validate_cpu_list(occupy_cpus, "occupy_cpus", min_count=ACTIVE_THREAD_COUNT)
+    allowed = list(pool[:ACTIVE_THREAD_COUNT])
+    return {
+        "soc_name": soc_name,
+        "device_id": device_id,
+        "architecture": "a5",
+        "plan_source": plan_source,
+        "user_pool_cpus": pool,
+        "occupy_mask": f"0x{occupy_mask_from_cpus(pool):x}",
+        "active_count": ACTIVE_THREAD_COUNT,
+        "allowed_cpus": allowed,
+        "orch_cpu": allowed[-1],
+        "schedulers": [
+            {
+                "logical_idx": idx,
+                "cpu_id": cpu,
+                "assigned_die": 0 if idx < 2 else 1,
+                "die0_sum_ticks": 0,
+                "die1_sum_ticks": 0,
+            }
+            for idx, cpu in enumerate(allowed[:-1])
+        ],
+        "pool_too_small": False,
+    }
+
+
+def build_device_node_from_allowed(
+    *,
+    soc_name: str,
+    device_id: int,
+    allowed_cpus: Sequence[int],
+    occupy_cpus: Sequence[int],
+    plan_source: str = PLAN_SOURCE_MANUAL,
+) -> dict[str, Any]:
+    allowed = validate_cpu_list(
+        allowed_cpus, "allowed_cpus", min_count=ACTIVE_THREAD_COUNT, max_count=ACTIVE_THREAD_COUNT
+    )
+    occupy = validate_cpu_list(occupy_cpus, "occupy_cpus", min_count=ACTIVE_THREAD_COUNT)
+    if not set(allowed).issubset(occupy):
+        raise ValueError("allowed_cpus must be a subset of occupy_cpus")
+    if plan_source not in SUPPORTED_PLAN_SOURCES:
+        raise ValueError(f"unsupported plan_source: {plan_source}")
+    return {
+        "soc_name": soc_name,
+        "device_id": device_id,
+        "architecture": "a5",
+        "plan_source": plan_source,
+        "user_pool_cpus": occupy,
+        "occupy_mask": f"0x{occupy_mask_from_cpus(occupy):x}",
+        "active_count": ACTIVE_THREAD_COUNT,
+        "allowed_cpus": allowed,
+        "orch_cpu": allowed[-1],
+        "schedulers": [
+            {
+                "logical_idx": idx,
+                "cpu_id": int(cpu),
+                "assigned_die": 0 if idx < 2 else 1,
+                "die0_sum_ticks": 0,
+                "die1_sum_ticks": 0,
+            }
+            for idx, cpu in enumerate(allowed[:-1])
+        ],
+        "pool_too_small": False,
+    }
+
+
+def parse_int_list(text: str) -> list[int]:
+    return [int(part.strip()) for part in text.replace(";", ",").split(",") if part.strip()]
+
+
+def persist_device_plan(out_path: Path, *, soc_name: str, device_id: int, device_node: dict[str, Any]) -> None:
+    validate_device_node(device_node, expected_soc=soc_name, expected_device=device_id)
+    plan = make_device_plan(soc_name=soc_name, device_id=device_id, device_node=device_node)
+    atomic_write_plan_and_side(out_path, plan, device_node)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Probe A5 AICPU affinity and write the authoritative allowed_cpus plan."
+    )
+    parser.add_argument("--device", type=int, default=0, help="Logical ACL device id")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Exact per-device JSON path (default: build/config/aicpu_affinity_plan.<device>.json)",
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--probe", action="store_true", help="Run the full affinity preflight on device")
+    mode.add_argument(
+        "--allowed-cpus",
+        help="Offline authoritative allowed_cpus (exactly S0,S1,S2,S3,O); requires --soc and --occupy-cpus",
+    )
+    mode.add_argument(
+        "--fallback-occupy",
+        help="Write contiguous fallback plan from occupy CPU list (comma-separated); requires --soc",
+    )
+    parser.add_argument("--soc", help="SoC name for offline / fallback modes")
+    parser.add_argument("--occupy-cpus", help="Full OCCUPY CPU list required by offline --allowed-cpus")
+    parser.add_argument(
+        "--plan-source",
+        default=None,
+        choices=sorted(SUPPORTED_PLAN_SOURCES),
+        help="Optional plan_source override (e.g. auto-first-run when ChipWorker.init probes)",
+    )
+    args = parser.parse_args(argv)
+
+    out_path = args.out.resolve() if args.out is not None else default_plan_path(args.device)
+    try:
+        if args.probe:
+            if args.soc is not None or args.occupy_cpus is not None:
+                parser.error("--probe obtains --soc and OCCUPY from hardware")
+            if args.plan_source != PLAN_SOURCE_AUTO_FIRST_RUN:
+                clear_timeout_record(out_path)
+            probe = run_affinity_probe(args.device)
+            device_node = build_allowed_cpus_from_probe(probe)
+            if args.plan_source is not None:
+                device_node["plan_source"] = args.plan_source
+            soc_name = device_node["soc_name"]
+        elif args.fallback_occupy is not None:
+            if args.soc is None or args.occupy_cpus is not None:
+                parser.error("--fallback-occupy requires --soc and cannot be combined with --occupy-cpus")
+            clear_timeout_record(out_path)
+            soc_name = args.soc
+            device_node = build_contiguous_fallback_node(
+                soc_name=soc_name,
+                device_id=args.device,
+                occupy_cpus=parse_int_list(args.fallback_occupy),
+                plan_source=args.plan_source if args.plan_source is not None else PLAN_SOURCE_PROBE_FAILED,
+            )
+        else:
+            if args.soc is None or args.allowed_cpus is None or args.occupy_cpus is None:
+                parser.error("offline mode requires --soc, --allowed-cpus, and --occupy-cpus")
+            clear_timeout_record(out_path)
+            soc_name = args.soc
+            device_node = build_device_node_from_allowed(
+                soc_name=soc_name,
+                device_id=args.device,
+                allowed_cpus=parse_int_list(args.allowed_cpus),
+                occupy_cpus=parse_int_list(args.occupy_cpus),
+                plan_source=args.plan_source if args.plan_source is not None else PLAN_SOURCE_MANUAL,
+            )
+
+        persist_device_plan(out_path, soc_name=soc_name, device_id=args.device, device_node=device_node)
+    except AffinityProbeTimeout:
+        marker = write_timeout_record(out_path, args.device, reason="preflight-timeout")
+        print(
+            f"rtt_die_preflight: device probe timed out after {PREFLIGHT_TIMEOUT_SECONDS}s; "
+            f"wrote timeout record {marker}; no affinity plan written",
+            file=sys.stderr,
+        )
+        return 1
+    except subprocess.TimeoutExpired as exc:
+        print(
+            f"rtt_die_preflight: helper build timed out after {exc.timeout}s; no affinity plan written",
+            file=sys.stderr,
+        )
+        return 1
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
+        print(f"rtt_die_preflight: {exc}; no affinity plan written", file=sys.stderr)
+        return 1
+    side = cpus_side_path(out_path)
+    print(
+        f"Wrote affinity plan: {out_path} side={side} soc={soc_name} device={args.device} "
+        f"allowed_cpus={device_node['allowed_cpus']} source={device_node['plan_source']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/a5/docs/aicpu-affinity-preflight.md
+++ b/src/a5/docs/aicpu-affinity-preflight.md
@@ -1,0 +1,206 @@
+# A5 AICPU Affinity Preflight — Design
+
+The Ascend950 (a5) affinity preflight measures the user AICPU pool and writes
+an authoritative five-thread placement, ordered as `[S0,S1,S2,S3,O]`. The
+production runtime reads the small line-oriented companion file; it does not
+run RTT measurement or re-rank the result.
+
+Related hardware/OCCUPY background: [hardware.md](hardware.md).
+Tool entry points: `python -m simpler_setup.tools.rtt_die_preflight` and
+`simpler_setup/tools/aicpu_device_query/`.
+
+## Runtime contract
+
+`aicpu_thread_num` is the total active AICPU count: one orchestrator plus the
+remaining scheduler threads. It is separate from the physical launch count,
+which is always `popcount(OCCUPY)` so the affinity gate sees the complete user
+pool.
+
+- Total active count 5 means four schedulers plus one orchestrator. Both auto
+  mode and an explicit value of 5 may consume a valid RTT plan.
+- Explicit total counts 2–4 are honored exactly. The runtime warns that the
+  four-scheduler RTT layout does not apply and selects that many CPUs in
+  ascending OCCUPY-bit order.
+- Auto mode normally resolves to 5, but shrinks to the available OCCUPY count
+  when the pool is smaller. The shrink path also warns and uses contiguous
+  OCCUPY-bit selection.
+- An explicit active count greater than the OCCUPY population fails prepare.
+- The supported physical launch population is 2–14. It is never clamped.
+
+Schedulers own balanced contiguous AICore-cluster ranges using
+`[t*N/A, (t+1)*N/A)`. For the measured four-scheduler shape, logical S0/S1 own
+the first half (die0) and S2/S3 own the second half (die1).
+
+## Layering
+
+```text
+ChipWorker.init (Python, a5 onboard)
+  resolve exact per-device JSON + .cpus paths
+  missing/invalid artifacts -> rtt_die_preflight --probe --out <JSON>
+                         |
+                         v
+Preflight toolchain (selection authority)
+  topology/serial enum -> handshake orch -> COND die scores -> pack
+  success: publish one-device JSON and matching .cpus
+  failure: publish nothing
+                         |
+                         v
+DeviceRunner (thin production consumer)
+  OCCUPY -> full launch count
+  active==5 and valid side plan -> use [S0,S1,S2,S3,O]
+  otherwise -> warn as applicable and use contiguous [S...,O]
+                         |
+                         v
+Device affinity gate + balanced contiguous AICore ownership
+```
+
+`DeviceRunner` never invokes Python. `ChipWorker.init` reports probe
+start/skip/done/fail, but a failed automatic preflight does not abort init:
+the runtime subsequently uses contiguous OCCUPY allocation without writing a
+fallback plan.
+
+The automatic preflight gives the device RTT/COND probe a fixed 30-second
+wall-clock budget after helper compilation finishes. Helper/dispatcher
+builds use a separate longer budget and do not consume the probe timer. A
+device-probe timeout writes a per-device `.timeout` record beside the plan;
+later automatic initialization reads that record and immediately uses the
+OCCUPY fallback without probing again. An explicit manual `--probe` clears
+the record before retrying. A helper-build timeout fails the probe without
+writing `.timeout`, so a later init may retry once artifacts can be built.
+
+## Measurement and packing
+
+Public CLI:
+
+```bash
+python -m simpler_setup.tools.rtt_die_preflight --device N --probe
+```
+
+The backend is `simpler_setup/tools/aicpu_device_query` in `--rtt-json` mode.
+Wheel installs pass the installed simpler source root explicitly to both CMake
+configure steps, so the backend does not depend on a repository-relative
+directory depth.
+
+The probe first reads topology and OCCUPY. When driver or verified JSON
+topology exactly covers the OCCUPY CPU set, it enumerates that complete list
+directly. Otherwise it runs the existing serialized one-thread discovery, but
+accepts the result only if it exactly equals the OCCUPY set. Partial sampling
+is a probe failure, not a smaller real pool. Pools larger than 14 are rejected.
+
+| Phase | Work | Output |
+| ----- | ---- | ------ |
+| 1 | Complete user-pool enumeration | `user_pool_cpus` |
+| 2 | Atomic-flag pairwise handshake, 1000 iterations | orchestrator with minimum average peer latency |
+| 3 | Serialized non-orchestrator COND scoring, 100 samples/core | `die0_sum_ticks`, `die1_sum_ticks` |
+| 4 | Physical picks in die order `{0,1,1,0}`, packed as `[P0,P3,P1,P2,O]` | `[S0,S1,S2,S3,O]` |
+
+The full measured path requires at least five and at most 14 unique user CPUs.
+Missing/incomplete enumeration, a pool smaller than five, failed RTT/COND,
+malformed output, or an invalid plan all return nonzero and leave the artifact
+paths untouched.
+
+Offline operators may deliberately write either a fully specified manual plan
+or an explicit contiguous five-thread plan:
+
+```bash
+python -m simpler_setup.tools.rtt_die_preflight --device 0 \
+  --soc Ascend950PR_9599 \
+  --allowed-cpus 3,4,5,6,7 \
+  --occupy-cpus 3,4,5,6,7,8
+
+python -m simpler_setup.tools.rtt_die_preflight --device 0 \
+  --soc Ascend950PR_9599 --fallback-occupy 3,4,5,6,7,8
+```
+
+`--fallback-occupy` is an explicit administrative write. It is never invoked
+automatically after a failed probe.
+
+## Per-device artifacts and paths
+
+The default files for device `N` are:
+
+```text
+build/config/aicpu_affinity_plan.N.json
+build/config/aicpu_affinity_plan.N.cpus
+```
+
+Each JSON document contains exactly one device under the schema-v3
+`socs.<soc>.devices.<device_id>` shape. Devices never read-modify-write a
+shared document, so parallel multi-card initialization cannot lose another
+device's update.
+
+`SIMPLER_AICPU_AFFINITY_PLAN` may name a base path such as `plan.json` or a
+template such as `plan.{device}.json`. A base becomes `plan.N.json`; a template
+substitutes `N`. `--out` is already the exact per-device JSON path and is not
+renamed. In every case the companion replaces the JSON filename extension
+with `.cpus`. Python's producer, init hook, and C++ consumer use the same
+derivation.
+
+The JSON and companion are written through temporary files and atomic rename.
+If either publication fails, the pair is rolled back to its previous state.
+Probe/validation failure occurs before publication and does not create either
+file.
+
+The runtime companion has exactly seven keys:
+
+```text
+schema_version=3
+device_id=0
+soc=Ascend950PR_9599
+source=atomic-flag-orch+cond-die-v1
+occupy_mask=0x1f8
+active_count=5
+cpus=3,4,5,6,7
+```
+
+Before applying the file, C++ requires the exact schema version, device id,
+SoC, supported source, current OCCUPY mask, active count 5, and exactly five
+unique CPU ids in `[0,63]`, all present in OCCUPY. Missing, duplicate, or
+unknown keys are rejected. The cache key includes path, device, SoC, OCCUPY,
+size, and modification time, and only successful validations are cached.
+
+## Runtime sequence
+
+On `ChipWorker.init` for a5 onboard:
+
+1. Resolve the per-device JSON and companion paths.
+2. Skip only when both JSON and the hardware-independent companion structure
+   are present and valid.
+3. If a `.timeout` record is present, skip probing and use OCCUPY-contiguous
+   placement.
+4. Otherwise run `rtt_die_preflight --device N --probe --out <exact JSON>`.
+5. Report non-timeout failure without synthesizing or writing a fallback.
+
+On `DeviceRunner::prepare_execution`:
+
+1. Query OCCUPY and reject populations outside `[2,14]`.
+2. Resolve the exact requested/automatic active count; reject an explicit
+   value larger than the pool.
+3. For active count 5, validate and apply the per-device companion. On any
+   miss or mismatch, warn and select the first five OCCUPY bits.
+4. For active counts 2–4, warn and select exactly that many OCCUPY bits.
+5. Launch `popcount(OCCUPY)` physical threads and let the device affinity gate
+   retain the ordered active set.
+
+Recovery, reset, and finalize clear both OCCUPY and affinity caches.
+
+## Non-goals
+
+- Do not move RTT/COND measurement into the production runtime.
+- Do not let C++ spawn Python.
+- Do not change a2a3 behavior.
+- Do not remove `aicpu_topology_probe`; tooling and unit tests still use it.
+- Do not use diagnostic FG/PG selection for production `ALLOWED_CPUS`.
+
+## File map
+
+| Role | Path |
+| ---- | ---- |
+| Ranking, validation, persistence | `simpler_setup/tools/rtt_die_preflight.py` |
+| Device enum, handshake, COND | `simpler_setup/tools/aicpu_device_query/` |
+| Python init hook | `python/simpler/task_interface.py` |
+| Side-file reader and contiguous helper | `src/a5/platform/onboard/host/affinity_allowed_file.*` |
+| Production consumer | `src/a5/platform/onboard/host/device_runner.cpp` |
+| Affinity gate | `src/common/platform/onboard/aicpu/platform_aicpu_affinity.cpp` |
+| Balanced cluster partition | `src/a5/platform/include/common/scheduler_cluster_partition.h` |
+| Topology diagnostics/probe support | `src/a5/platform/onboard/host/aicpu_topology_probe.*` |

--- a/src/a5/docs/hardware.md
+++ b/src/a5/docs/hardware.md
@@ -264,39 +264,38 @@ Scenario A (OCCUPY=0x1f8, 6 user cpus):
   the failure as `aclrtSynchronizeStream rc=507000` (runtime internal)
   after the launch.
 
-The runtime implements the safe choice: a one-thread preflight AICPU query
-reads device-side OCCUPY, then the host topology probe sets
-`runtime->aicpu_launch_count = popcount(OCCUPY)`. The host's `rtsLaunchCpuKernel` is called with
-that exact value. `PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 14`
-remains a compile-time **upper bound** (array sizes, headroom), not the
-actual launch count. See:
+The runtime implements the safe choice: its one-thread topology query reads
+device-side OCCUPY, then the host sets
+`runtime->aicpu_launch_count = popcount(OCCUPY)`. The host's `rtsLaunchCpuKernel`
+is called with that exact value.
+`PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 14` remains a compile-time
+**upper bound** (array sizes, headroom), not the actual launch count.
 
-- `src/a5/platform/onboard/host/aicpu_topology_probe.{h,cpp}` — probe +
-  cluster-first packing
-- `src/a5/platform/onboard/host/device_runner.cpp` — fills
-  `aicpu_allowed_cpus[]` + `aicpu_launch_count` in Runtime, launches
-  with that count
-- `src/common/platform/onboard/aicpu/platform_aicpu_affinity.cpp` —
-  `platform_aicpu_affinity_gate_filter()` (the post-hoc classifier)
+### AICPU affinity preflight (authoritative ALLOWED_CPUS)
 
-If CPU_TOPO does not match FG, PG1, or PG2 by **surviving cluster/die
-layout** (logical CPU count is not a gate), the runtime uses a deterministic
-fallback: valid metadata is sorted by `(die, cluster,
-physical CPU, hyperthread, logical CPU)`; OCCUPY-only metadata reduces this to
-logical CPU ID order. Automatic mode keeps at most five and may shrink to the
-available count. A manual request from 2 through 5 must be satisfied exactly.
-The last selection is the Orchestrator and preceding selections are
-Schedulers. The launch count remains the full device-side OCCUPY population
-required by the filter gate and may therefore exceed the active cap. On
-`Ascend950PR_9599`, a measured 9-logical layout with four clusters classifies
-as FG. Scheduler SMT availability is recorded separately and does not define
-another scenario. When live CPU_TOPO was unavailable, the JSON or OCCUPY-only
-source independently triggers the required warning.
+Core selection for production `ALLOWED_CPUS` is owned by an explicit preflight
+tool, not by FG/PG packing inside `DeviceRunner`. Design, layering, plan
+artifacts, and runtime contract:
+
+→ **[aicpu-affinity-preflight.md](aicpu-affinity-preflight.md)**
+
+Short summary: the tool elects orch (atomic-flag handshake) and packs
+schedulers from COND die scores into logical `[S0,S1,S2,S3,O]`
+(S0/S1→die0, S2/S3→die1), and writes an independent per-device JSON/`.cpus`
+pair. Python `ChipWorker.init` attempts preflight before attach. Failure writes
+no files; runtime then uses OCCUPY-contiguous placement. A valid RTT plan is
+used only for the five-thread shape (four schedulers plus one orchestrator),
+while explicit totals 2–4 are honored with a warning and contiguous placement.
+The physical launch count remains the full OCCUPY population, capped at the
+verified maximum of 14. AICore ownership is balanced and contiguous by logical
+scheduler index.
+
+FG/PG helpers in `aicpu_topology_probe` remain for
+`aicpu-device-query --json` / UT only.
 
 The 0x7ffe SKU's dispatch behavior at `aicpu_num=14` has **not yet
 been measured** — once an a5 0x7ffe device runs an a5 onboard test,
 update this section with the observed (cpu_id → thread) spread. If
 launching 14 threads on 0x7ffe does not reach all 14 cpu_ids (i.e.
 CANN has a tighter dispatch policy than OCCUPY implies), that is a
-stronger constraint and `compute_allowed_cpus` would need to factor in
-the actual reachable set.
+stronger constraint and the supported launch bound would need to be revised.

--- a/src/a5/platform/include/common/scheduler_cluster_partition.h
+++ b/src/a5/platform/include/common/scheduler_cluster_partition.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstdint>
+
+struct SchedulerClusterRange {
+    int32_t begin{0};
+    int32_t end{0};
+};
+
+// Balanced contiguous partition: scheduler t owns [t*N/A, (t+1)*N/A).
+constexpr SchedulerClusterRange scheduler_cluster_range(int32_t total_clusters, int32_t active, int32_t thread_idx) {
+    if (total_clusters < 0 || active <= 0 || thread_idx < 0 || thread_idx >= active) return {};
+    return {
+        static_cast<int32_t>((static_cast<int64_t>(thread_idx) * total_clusters) / active),
+        static_cast<int32_t>((static_cast<int64_t>(thread_idx + 1) * total_clusters) / active),
+    };
+}

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -60,6 +60,7 @@ list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${PTO_ISA_ROOT}/include")
 set(HOST_RUNTIME_SOURCES "")
 list(APPEND HOST_RUNTIME_SOURCES ${SIMPLER_HOST_LOG_SOURCES})
 list(APPEND HOST_RUNTIME_SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/affinity_allowed_file.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/aicpu_topology_probe.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/device_runner.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/memory_allocator.cpp"

--- a/src/a5/platform/onboard/host/affinity_allowed_file.cpp
+++ b/src/a5/platform/onboard/host/affinity_allowed_file.cpp
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "affinity_allowed_file.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <cctype>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "common/platform_config.h"
+
+namespace pto::a5 {
+namespace {
+
+constexpr char kEnvAffinityPlanPath[] = "SIMPLER_AICPU_AFFINITY_PLAN";
+constexpr char kDefaultAffinityPlanRelative[] = "build/config/aicpu_affinity_plan.json";
+constexpr int32_t kAffinityPlanSchemaVersion = 3;
+constexpr int32_t kAffinityPlanActiveCount = 5;
+
+bool is_supported_affinity_plan_source(const std::string &source) {
+    return source == "atomic-flag-orch+cond-die-v1" || source == "manual" || source == "auto-first-run" ||
+           source == "probe-failed-contiguous";
+}
+
+bool parse_i32(const std::string &text, int32_t &out) {
+    if (text.empty()) return false;
+    errno = 0;
+    char *end = nullptr;
+    const long value = std::strtol(text.c_str(), &end, 10);
+    if (errno != 0 || end == text.c_str() || *end != '\0' || value < std::numeric_limits<int32_t>::min() ||
+        value > std::numeric_limits<int32_t>::max()) {
+        return false;
+    }
+    out = static_cast<int32_t>(value);
+    return true;
+}
+
+bool parse_u64(const std::string &text, uint64_t &out) {
+    if (text.empty() || text[0] == '-') return false;
+    errno = 0;
+    char *end = nullptr;
+    const unsigned long long value = std::strtoull(text.c_str(), &end, 0);
+    if (errno != 0 || end == text.c_str() || *end != '\0') return false;
+    out = static_cast<uint64_t>(value);
+    return true;
+}
+
+bool parse_csv_int_list(const std::string &text, std::vector<int32_t> &out) {
+    out.clear();
+    if (text.empty()) return false;
+    const char *p = text.c_str();
+    while (true) {
+        while (std::isspace(static_cast<unsigned char>(*p)))
+            ++p;
+        if (*p == '\0') return false;
+        char *end = nullptr;
+        const long value = std::strtol(p, &end, 10);
+        if (end == p || value < std::numeric_limits<int32_t>::min() || value > std::numeric_limits<int32_t>::max()) {
+            return false;
+        }
+        out.push_back(static_cast<int32_t>(value));
+        p = end;
+        while (std::isspace(static_cast<unsigned char>(*p)))
+            ++p;
+        if (*p == '\0') return true;
+        if (*p != ',') return false;
+        ++p;
+    }
+}
+
+}  // namespace
+
+std::string affinity_cpus_side_path(int32_t device_id) {
+    const char *env = std::getenv(kEnvAffinityPlanPath);
+    std::string plan = (env != nullptr && env[0] != '\0') ? env : kDefaultAffinityPlanRelative;
+    const std::string id = std::to_string(device_id);
+    const std::string placeholder = "{device}";
+    bool used_placeholder = false;
+    for (size_t pos = plan.find(placeholder); pos != std::string::npos; pos = plan.find(placeholder, pos + id.size())) {
+        plan.replace(pos, placeholder.size(), id);
+        used_placeholder = true;
+    }
+
+    std::filesystem::path plan_path(plan);
+    if (!used_placeholder) {
+        const std::string device_suffix = "." + id;
+        std::string extension = plan_path.extension().string();
+        std::string stem = plan_path.filename().string();
+        if (!extension.empty()) stem.resize(stem.size() - extension.size());
+        if (stem.size() < device_suffix.size() ||
+            stem.compare(stem.size() - device_suffix.size(), device_suffix.size(), device_suffix) != 0) {
+            stem += device_suffix;
+        }
+        if (extension.empty()) extension = ".json";
+        plan_path = plan_path.parent_path() / (stem + extension);
+    }
+    plan_path.replace_extension(".cpus");
+    return plan_path.string();
+}
+
+bool resolve_aicpu_active_count(
+    int32_t requested_active_count, int32_t launch_count, int32_t &active_count, bool &use_rtt_plan
+) {
+    active_count = 0;
+    use_rtt_plan = false;
+    if (launch_count < 2 || launch_count > PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH || requested_active_count < 0 ||
+        requested_active_count == 1 || requested_active_count > PLATFORM_MAX_AICPU_THREADS) {
+        return false;
+    }
+    const int32_t desired = requested_active_count == 0 ? std::min(PLATFORM_DEFAULT_AICPU_THREAD_NUM, launch_count) :
+                                                          requested_active_count;
+    if (desired > launch_count) return false;
+    active_count = desired;
+    use_rtt_plan = active_count == PLATFORM_DEFAULT_AICPU_THREAD_NUM;
+    return true;
+}
+
+bool build_occupy_contiguous_allowed(uint64_t occupy, int32_t active_count, std::vector<int32_t> &allowed_cpus) {
+    allowed_cpus.clear();
+    if (occupy == 0 || active_count < 2 || active_count > kAffinityPlanActiveCount) return false;
+    allowed_cpus.reserve(static_cast<size_t>(active_count));
+    for (int32_t cpu = 0; cpu < 64 && static_cast<int32_t>(allowed_cpus.size()) < active_count; ++cpu) {
+        if (((occupy >> cpu) & 1ULL) != 0) allowed_cpus.push_back(cpu);
+    }
+    if (allowed_cpus.size() == static_cast<size_t>(active_count)) return true;
+    allowed_cpus.clear();
+    return false;
+}
+
+bool load_affinity_cpus_side_file(
+    const char *soc_name, int32_t device_id, uint64_t current_occupy, std::vector<int32_t> &allowed_cpus,
+    std::string &plan_source
+) {
+    allowed_cpus.clear();
+    plan_source.clear();
+    if (soc_name == nullptr || soc_name[0] == '\0' || device_id < 0 || current_occupy == 0) return false;
+
+    std::ifstream input(affinity_cpus_side_path(device_id));
+    if (!input) return false;
+
+    std::string file_soc;
+    std::string cpus_text;
+    int32_t schema_version = -1;
+    int32_t file_device_id = -1;
+    int32_t active_count = -1;
+    uint64_t file_occupy = 0;
+    std::set<std::string> keys;
+    std::string line;
+    while (std::getline(input, line)) {
+        if (line.empty() || line[0] == '#') continue;
+        const size_t eq = line.find('=');
+        if (eq == std::string::npos) return false;
+        const std::string key = line.substr(0, eq);
+        const std::string value = line.substr(eq + 1);
+        if (!keys.insert(key).second) return false;
+        if (key == "schema_version") {
+            if (!parse_i32(value, schema_version)) return false;
+        } else if (key == "device_id") {
+            if (!parse_i32(value, file_device_id)) return false;
+        } else if (key == "soc") {
+            file_soc = value;
+        } else if (key == "source") {
+            plan_source = value;
+        } else if (key == "occupy_mask") {
+            if (!parse_u64(value, file_occupy)) return false;
+        } else if (key == "active_count") {
+            if (!parse_i32(value, active_count)) return false;
+        } else if (key == "cpus") {
+            cpus_text = value;
+        } else {
+            return false;
+        }
+    }
+
+    if (keys.size() != 7 || schema_version != kAffinityPlanSchemaVersion || file_device_id != device_id ||
+        active_count != kAffinityPlanActiveCount || file_soc != soc_name || file_occupy != current_occupy) {
+        return false;
+    }
+    if (!is_supported_affinity_plan_source(plan_source)) return false;
+    if (!parse_csv_int_list(cpus_text, allowed_cpus) || allowed_cpus.size() != kAffinityPlanActiveCount) return false;
+    {
+        std::vector<int32_t> unique = allowed_cpus;
+        std::sort(unique.begin(), unique.end());
+        if (std::unique(unique.begin(), unique.end()) != unique.end()) return false;
+    }
+    for (int32_t cpu : allowed_cpus) {
+        if (cpu < 0 || cpu >= 64 || ((current_occupy >> cpu) & 1ULL) == 0) return false;
+    }
+    return true;
+}
+
+}  // namespace pto::a5

--- a/src/a5/platform/onboard/host/affinity_allowed_file.h
+++ b/src/a5/platform/onboard/host/affinity_allowed_file.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace pto::a5 {
+
+// Reads the line-oriented companion file written by rtt_die_preflight:
+//   build/config/aicpu_affinity_plan.<device_id>.cpus
+//   (or the per-device path derived from SIMPLER_AICPU_AFFINITY_PLAN)
+// Format:
+//   schema_version=3
+//   device_id=<logical ACL device id>
+//   soc=<name>
+//   source=<token>
+//   occupy_mask=<hex or decimal u64>
+//   active_count=5
+//   cpus=<csv>
+std::string affinity_cpus_side_path(int32_t device_id);
+
+// Resolve the total active AICPU count from user configuration and the full
+// OCCUPY launch population. requested_active_count=0 is auto. The measured RTT
+// plan applies only to the exact 4-scheduler + 1-orchestrator shape.
+bool resolve_aicpu_active_count(
+    int32_t requested_active_count, int32_t launch_count, int32_t &active_count, bool &use_rtt_plan
+);
+
+// Select exactly active_count CPUs in ascending OCCUPY bit order. The last
+// position is the orchestrator; preceding positions are scheduler slots.
+bool build_occupy_contiguous_allowed(uint64_t occupy, int32_t active_count, std::vector<int32_t> &allowed_cpus);
+
+bool load_affinity_cpus_side_file(
+    const char *soc_name, int32_t device_id, uint64_t current_occupy, std::vector<int32_t> &allowed_cpus,
+    std::string &plan_source
+);
+
+}  // namespace pto::a5

--- a/src/a5/platform/onboard/host/aicpu_topology_probe.cpp
+++ b/src/a5/platform/onboard/host/aicpu_topology_probe.cpp
@@ -184,6 +184,35 @@ bool enumerate_cpus_from_occupy(uint64_t occupy, std::vector<AicpuLogicalCpu> &o
     return !out_user_cpus.empty();
 }
 
+bool build_complete_topology_user_pool(const AicpuTopology &topology, std::vector<int32_t> &out_cpu_ids) {
+    out_cpu_ids.clear();
+    if (topology.source == AicpuTopologySource::kOccupyFallback || !topology.device_occupancy.occupy_valid ||
+        topology.device_occupancy.occupy == 0) {
+        return false;
+    }
+    std::vector<AicpuLogicalCpu> occupy_cpus;
+    if (!enumerate_cpus_from_occupy(topology.device_occupancy.occupy, occupy_cpus) ||
+        occupy_cpus.size() > static_cast<size_t>(PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
+        return false;
+    }
+    out_cpu_ids.reserve(topology.os_schedulable_cpus.size());
+    for (const auto &cpu : topology.os_schedulable_cpus)
+        out_cpu_ids.push_back(cpu.cpu_id);
+    std::sort(out_cpu_ids.begin(), out_cpu_ids.end());
+    if (std::unique(out_cpu_ids.begin(), out_cpu_ids.end()) != out_cpu_ids.end() ||
+        out_cpu_ids.size() != occupy_cpus.size()) {
+        out_cpu_ids.clear();
+        return false;
+    }
+    for (size_t idx = 0; idx < occupy_cpus.size(); ++idx) {
+        if (out_cpu_ids[idx] != occupy_cpus[idx].cpu_id) {
+            out_cpu_ids.clear();
+            return false;
+        }
+    }
+    return true;
+}
+
 namespace {
 bool validate_cpu_topology(const std::vector<AicpuLogicalCpu> &cpus);
 bool validate_cpu_ids(const std::vector<AicpuLogicalCpu> &cpus);

--- a/src/a5/platform/onboard/host/aicpu_topology_probe.h
+++ b/src/a5/platform/onboard/host/aicpu_topology_probe.h
@@ -95,6 +95,11 @@ bool probe_aicpu_topology(
 // Returns false when the mask is empty.
 bool enumerate_cpus_from_occupy(uint64_t occupy, std::vector<AicpuLogicalCpu> &out_user_cpus);
 
+// Return the complete user pool directly when driver or verified-JSON CPU_TOPO
+// covers every authoritative OCCUPY bit. OCCUPY-only topology and partial
+// metadata return false so callers can use an explicit discovery fallback.
+bool build_complete_topology_user_pool(const AicpuTopology &topology, std::vector<int32_t> &out_cpu_ids);
+
 // Load the full logical CPU_TOPO for a packaged fallback whose SoC and every
 // constraint declared by that entry (host architecture and/or OCCUPY) match.
 // Output is not OCCUPY-filtered. `out_generic_selection_only` reports entries

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -29,11 +29,17 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <iostream>
 #include <string>
+#include <system_error>
+#include <utility>
 #include <vector>
 
+#include "affinity_allowed_file.h"
 #include "aicpu_topology_probe.h"
 #include "callable.h"
 #include "callable_protocol.h"
@@ -47,7 +53,21 @@
 
 namespace {
 constexpr const char *kAicpuTopologyQueryName = "simpler_aicpu_query_topology";
+
+int popcount_u64(uint64_t value) {
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_popcountll(value);
+#else
+    int count = 0;
+    while (value != 0) {
+        count += static_cast<int>(value & 1u);
+        value >>= 1;
+    }
+    return count;
+#endif
 }
+
+}  // namespace
 
 // dep_gen has two shapes, one per orchestration site, and each runtime provides
 // the strong symbols for the one it uses:
@@ -223,31 +243,53 @@ int DeviceRunner::query_aicpu_device_occupancy(pto::a5::AicpuDeviceOccupancy &ou
     return 0;
 }
 
-int DeviceRunner::query_aicpu_topology(pto::a5::AicpuTopology &out) {
-    if (aicpu_topology_cached_) {
-        out = aicpu_topology_;
-        return 0;
+bool DeviceRunner::load_cached_affinity_plan(const char *soc_name, uint64_t current_occupy) {
+    const std::string soc = soc_name == nullptr ? std::string{} : std::string(soc_name);
+    const std::string path = pto::a5::affinity_cpus_side_path(device_id_);
+    std::error_code ec;
+    const uint64_t file_size = static_cast<uint64_t>(std::filesystem::file_size(path, ec));
+    if (ec) {
+        affinity_plan_cache_.reset();
+        return false;
+    }
+    const auto mtime = std::filesystem::last_write_time(path, ec);
+    if (ec) {
+        affinity_plan_cache_.reset();
+        return false;
+    }
+    const int64_t mtime_ticks = static_cast<int64_t>(mtime.time_since_epoch().count());
+    auto &cache = affinity_plan_cache_;
+    if (cache.matches(soc, path, device_id_, current_occupy, file_size, mtime_ticks)) return true;
+
+    cache.reset();
+    std::vector<int32_t> allowed_cpus;
+    std::string source;
+    if (soc.empty() ||
+        !pto::a5::load_affinity_cpus_side_file(soc.c_str(), device_id_, current_occupy, allowed_cpus, source)) {
+        LOG_INFO(
+            "Affinity .cpus side file missing/invalid for soc=%s device=%d occupy=0x%llx; "
+            "prepare will use OCCUPY contiguous fallback (Python ChipWorker.init owns preflight)",
+            soc.empty() ? "(unknown)" : soc.c_str(), device_id_, static_cast<unsigned long long>(current_occupy)
+        );
+        return false;
     }
 
-    pto::a5::AicpuDeviceOccupancy occupancy;
-    int rc = query_aicpu_device_occupancy(occupancy);
-    if (rc != 0) return rc;
-
-    pto::a5::AicpuTopology topology;
-    if (!pto::a5::probe_aicpu_topology(static_cast<uint32_t>(device_id_), occupancy, topology))
-        return PTO_RUNTIME_ERR_INTERNAL;
-
-    aicpu_topology_ = std::move(topology);
-    aicpu_topology_cached_ = true;
-    out = aicpu_topology_;
-    return 0;
+    cache.soc = soc;
+    cache.path = path;
+    cache.device_id = device_id_;
+    cache.occupy = current_occupy;
+    cache.file_size = file_size;
+    cache.mtime_ticks = mtime_ticks;
+    cache.valid = true;
+    cache.source = std::move(source);
+    cache.allowed_cpus = std::move(allowed_cpus);
+    return true;
 }
 
-void DeviceRunner::clear_aicpu_topology_cache() {
+void DeviceRunner::clear_aicpu_caches() {
     aicpu_device_occupancy_cached_ = false;
     aicpu_device_occupancy_ = {};
-    aicpu_topology_cached_ = false;
-    aicpu_topology_ = {};
+    affinity_plan_cache_.reset();
 }
 
 void DeviceRunner::set_dep_gen_enabled(bool enable) {
@@ -274,7 +316,6 @@ int DeviceRunner::prepare_execution(
     });
     const int block_dim = runtime.get_worker_count() / cores_per_blockdim_;
     int requested_aicpu_num = config.aicpu_thread_num;
-    const bool automatic_aicpu_num = requested_aicpu_num == 0;
     // A prior AICore launch/sync error poisoned the device context and the
     // in-place drain could not clear it. Refuse to run rather than cascade
     // into halResMap rc=62 (init_aicore_register_addresses) or rtMalloc
@@ -293,8 +334,7 @@ int DeviceRunner::prepare_execution(
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (validate_launch_aicpu_num(requested_aicpu_num) != 0) return PTO_RUNTIME_ERR_INTERNAL;
-    int active_aicpu_num = automatic_aicpu_num ? PLATFORM_DEFAULT_AICPU_THREAD_NUM : requested_aicpu_num;
-    runtime.set_aicpu_thread_num(active_aicpu_num);
+    int active_aicpu_num = 0;
 
     int rc = ensure_device_initialized();
     if (rc != 0) {
@@ -333,79 +373,89 @@ int DeviceRunner::prepare_execution(
 
     resolve_task_binary_addrs(runtime);
 
-    // a5-specific: probe the AICPU topology + compute ALLOWED_CPUS for the
-    // filter-style gate (see src/common/platform/onboard/aicpu/
-    // platform_aicpu_affinity.cpp::platform_aicpu_affinity_gate_filter).
-    // Convention: indices 0..active-2 are scheduler slots and the last slot
-    // is the orchestrator. In auto mode only, unknown shapes may reduce the
-    // active count to the available pool, but execution keeps at least one of
-    // each role.
+    // A5-specific: only the default 4-scheduler + 1-orchestrator shape consumes
+    // the Python RTT plan. Other valid widths, missing/invalid plans, and probe
+    // failures all use OCCUPY-bit contiguous [S..., O]. Runtime never spawns
+    // Python or probes RTT. AICore ownership is contiguous by logical sched idx.
     {
-        pto::a5::AicpuTopology topology;
         runtime.set_aicpu_allowed_cpu_count(0);
-        if (query_aicpu_topology(topology) != 0) {
-            LOG_ERROR("AICPU topology probe failed; affinity gate will not launch");
+        pto::a5::AicpuDeviceOccupancy occupancy;
+        if (query_aicpu_device_occupancy(occupancy) != 0) {
+            LOG_ERROR("AICPU OCCUPY query failed; cannot set affinity launch_count");
             return PTO_RUNTIME_ERR_INTERNAL;
         }
-        pto::a5::AicpuLaunchPlan launch_plan;
-        std::string plan_error;
-        if (!pto::a5::build_aicpu_launch_plan(topology, requested_aicpu_num, launch_plan, plan_error)) {
+        const char *soc = aclrtGetSocName();
+        const int32_t launch_count = occupancy.occupy_valid ? popcount_u64(occupancy.occupy) : 0;
+        if (launch_count < 2 || launch_count > PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH) {
             LOG_ERROR(
-                "cannot build AICPU launch plan: soc=%s scenario=%s occupy=0x%llx reason=%s",
-                topology.soc_name.empty() ? "(unknown)" : topology.soc_name.c_str(),
-                pto::a5::aicpu_scenario_name(topology.scenario_type),
-                static_cast<unsigned long long>(topology.device_occupancy.occupy), plan_error.c_str()
+                "AICPU OCCUPY population=%d is outside supported launch range [2,%d]", launch_count,
+                PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH
             );
             return PTO_RUNTIME_ERR_INTERNAL;
         }
-        const auto &allowed = launch_plan.allowed_cpus;
-        active_aicpu_num = launch_plan.effective_active_count;
+        bool rtt_shape = false;
+        if (!pto::a5::resolve_aicpu_active_count(requested_aicpu_num, launch_count, active_aicpu_num, rtt_shape)) {
+            LOG_ERROR(
+                "requested aicpu_thread_num=%d cannot be satisfied by OCCUPY population=%d", requested_aicpu_num,
+                launch_count
+            );
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
+
+        std::vector<int32_t> allowed;
+        std::string source;
+        if (rtt_shape && load_cached_affinity_plan(soc, occupancy.occupy)) {
+            allowed = affinity_plan_cache_.allowed_cpus;
+            source = affinity_plan_cache_.source;
+        } else if (occupancy.occupy_valid &&
+                   pto::a5::build_occupy_contiguous_allowed(occupancy.occupy, active_aicpu_num, allowed)) {
+            source = "runtime-occupy-contiguous";
+            if (rtt_shape) {
+                LOG_WARN(
+                    "AICPU RTT affinity plan missing/invalid for device %d (soc=%s); using OCCUPY contiguous "
+                    "placement for 4 schedulers",
+                    device_id_, soc == nullptr ? "(unknown)" : soc
+                );
+            } else {
+                LOG_WARN(
+                    "AICPU RTT affinity requires 4 schedulers; resolved %d scheduler(s) from "
+                    "aicpu_thread_num=%d, using OCCUPY contiguous placement",
+                    active_aicpu_num - 1, requested_aicpu_num
+                );
+            }
+        } else {
+            LOG_ERROR(
+                "OCCUPY contiguous AICPU placement failed for device %d (soc=%s active=%d)", device_id_,
+                soc == nullptr ? "(unknown)" : soc, active_aicpu_num
+            );
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
+
+        if (allowed.size() != static_cast<size_t>(active_aicpu_num)) {
+            LOG_ERROR("AICPU placement returned %zu CPUs for active count %d", allowed.size(), active_aicpu_num);
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
         runtime.set_aicpu_thread_num(active_aicpu_num);
         {
             const size_t cap = runtime.aicpu_allowed_cpus_capacity();
             if (allowed.size() > cap) {
-                LOG_ERROR("AICPU selection returned %zu > cap %zu", allowed.size(), cap);
+                LOG_ERROR("AICPU plan returned %zu > cap %zu", allowed.size(), cap);
                 return PTO_RUNTIME_ERR_INTERNAL;
             }
             int32_t *allowed_cpus = runtime.get_aicpu_allowed_cpus();
             for (size_t i = 0; i < allowed.size(); ++i)
                 allowed_cpus[i] = allowed[i];
             runtime.set_aicpu_allowed_cpu_count(static_cast<int32_t>(allowed.size()));
-            runtime.set_aicpu_launch_count(launch_plan.launch_count);
+            runtime.set_aicpu_launch_count(launch_count);
             std::string dump;
             for (size_t i = 0; i < allowed.size(); ++i) {
                 if (i) dump += ", ";
                 dump += std::to_string(allowed[i]);
                 if (i + 1 == allowed.size()) dump += "(orch)";
             }
-            if (launch_plan.warn_cpu_topology_unavailable) {
-                LOG_WARN(
-                    "AICPU CPU_TOPO unavailable; using %s: soc=%s occupy=0x%llx "
-                    "stable_reachable=%d requested=%d effective=%d affinity=[%s]%s",
-                    pto::a5::aicpu_topology_source_name(topology.source),
-                    topology.soc_name.empty() ? "(unknown)" : topology.soc_name.c_str(),
-                    static_cast<unsigned long long>(topology.device_occupancy.occupy),
-                    launch_plan.stable_reachable_count, requested_aicpu_num, active_aicpu_num, dump.c_str(),
-                    topology.source == pto::a5::AicpuTopologySource::kOccupyFallback ?
-                        "; physical/SMT/cluster/die placement is unknown" :
-                        ""
-                );
-            }
-            if (launch_plan.warn_stable_reachable_below_default) {
-                LOG_WARN(
-                    "AICPU stable reachable CPUs below active capacity: soc=%s scenario=%s occupy=0x%llx "
-                    "stable_reachable=%d capacity=%d requested=%d effective=%d affinity=[%s]",
-                    topology.soc_name.empty() ? "(unknown)" : topology.soc_name.c_str(),
-                    pto::a5::aicpu_scenario_name(topology.scenario_type),
-                    static_cast<unsigned long long>(topology.device_occupancy.occupy),
-                    launch_plan.stable_reachable_count, PLATFORM_DEFAULT_AICPU_THREAD_NUM, requested_aicpu_num,
-                    active_aicpu_num, dump.c_str()
-                );
-            }
             LOG_INFO(
-                "AICPU ALLOWED_CPUS = [%s] (scenario=%s active=%d launch=%d user_cpus=%zu)", dump.c_str(),
-                pto::a5::aicpu_scenario_name(topology.scenario_type), active_aicpu_num, launch_plan.launch_count,
-                topology.os_schedulable_cpus.size()
+                "AICPU ALLOWED_CPUS = [%s] (source=%s active=%d launch=%d)", dump.c_str(), source.c_str(),
+                active_aicpu_num, launch_count
             );
         }
     }
@@ -740,7 +790,7 @@ void DeviceRunner::recover_device_or_mark_unusable(int aicore_rc) {
             aicore_rc
         );
     }
-    clear_aicpu_topology_cache();
+    clear_aicpu_caches();
     device_unusable_.store(true, std::memory_order_release);
 }
 
@@ -812,7 +862,7 @@ private:
 }  // namespace
 
 int DeviceRunner::force_reset_device() {
-    clear_aicpu_topology_cache();
+    clear_aicpu_caches();
     if (device_id_ < 0) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
@@ -1000,7 +1050,7 @@ int DeviceRunner::finalize() {
 
     // Only the healthy path reaches here: a poisoned card returned from the
     // fatal branch at the top of finalize(), which owns the force reset.
-    clear_aicpu_topology_cache();
+    clear_aicpu_caches();
     device_id_ = -1;
     device_unusable_.store(false, std::memory_order_release);
     return rc;

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -286,16 +286,50 @@ private:
     bool enable_dep_gen_{false};
 
     int query_aicpu_device_occupancy(pto::a5::AicpuDeviceOccupancy &out);
-    int query_aicpu_topology(pto::a5::AicpuTopology &out);
-    void clear_aicpu_topology_cache();
-    // Device-side occupancy and the merged Host topology are immutable during
-    // one DeviceRunner attach/reset lifetime. Cache successful probes only;
-    // allowed CPU selection still runs per call because the requested active
-    // count may change. Recovery, reset, and finalize clear both values.
+    bool load_cached_affinity_plan(const char *soc_name, uint64_t current_occupy);
+    // Clears OCCUPY + affinity side-file memo (not AICore/ELF/arena caches).
+    void clear_aicpu_caches();
+    // Device-side occupancy is immutable during one DeviceRunner attach/reset
+    // lifetime. AffinityPlanCache memoizes only validated side-file hits and
+    // includes the hardware mask plus file identity in its key. Preflight is
+    // owned by Python ChipWorker.init; prepare falls back to OCCUPY contiguous
+    // when the .cpus file is absent or invalid.
+    // Recovery, reset, and finalize call clear_aicpu_caches().
     bool aicpu_device_occupancy_cached_{false};
     pto::a5::AicpuDeviceOccupancy aicpu_device_occupancy_{};
-    bool aicpu_topology_cached_{false};
-    pto::a5::AicpuTopology aicpu_topology_{};
+
+    struct AffinityPlanCache {
+        std::string soc;
+        std::string path;
+        int32_t device_id{-1};
+        uint64_t occupy{0};
+        uint64_t file_size{0};
+        int64_t mtime_ticks{0};
+        bool valid{false};
+        std::string source;
+        std::vector<int32_t> allowed_cpus;
+
+        void reset() {
+            soc.clear();
+            path.clear();
+            device_id = -1;
+            occupy = 0;
+            file_size = 0;
+            mtime_ticks = 0;
+            valid = false;
+            source.clear();
+            allowed_cpus.clear();
+        }
+
+        bool matches(
+            const std::string &soc_name, const std::string &file_path, int32_t id, uint64_t current_occupy,
+            uint64_t current_file_size, int64_t current_mtime_ticks
+        ) const {
+            return valid && soc == soc_name && path == file_path && device_id == id && occupy == current_occupy &&
+                   file_size == current_file_size && mtime_ticks == current_mtime_ticks;
+        }
+    };
+    AffinityPlanCache affinity_plan_cache_{};
 
     int init_pmu(
         int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id,

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -23,6 +23,7 @@
 #include "common/memory_barrier.h"
 #include "common/chip_swimlane_profiling.h"
 #include "common/platform_config.h"
+#include "common/scheduler_cluster_partition.h"
 #include "host_build_graph/runtime_status.h"
 #include "host_build_graph/runtime_core.h"
 #include "host_build_graph/shared_memory.h"
@@ -296,9 +297,8 @@ void SchedulerContext::log_stall_diagnostics(
     }
 
     // CLUSTER lines: one per cluster this thread owns.
-    // cluster_id = local_cluster_idx * active_sched_threads_ + thread_idx, matching the
-    // round-robin assignment in assign_cores_to_threads.
     int32_t ast = active_sched_threads_ > 0 ? active_sched_threads_ : aicpu_thread_num_;
+    const int32_t cluster_begin = scheduler_cluster_range(aic_count_, ast, thread_idx).begin;
     for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
         int32_t offset = cli * 3;
         int32_t aic_id = tracker.get_aic_core_id(offset);
@@ -307,7 +307,7 @@ void SchedulerContext::log_stall_diagnostics(
         bool aic_idle = tracker.is_aic_core_idle(offset);
         bool aiv0_idle = tracker.is_aiv0_core_idle(offset);
         bool aiv1_idle = tracker.is_aiv1_core_idle(offset);
-        int32_t cluster_id = cli * ast + thread_idx;
+        int32_t cluster_id = cluster_begin + cli;
         char aic_buf[192], aiv0_buf[192], aiv1_buf[192];
         format_core_status(
             aic_buf, sizeof(aic_buf), aic_id, aic_idle, &core_exec_states_[aic_id], core_exec_states_[aic_id].reg_addr
@@ -689,11 +689,10 @@ void SchedulerContext::handshake_partition(Runtime *runtime, int32_t tidx, int32
 }
 
 // =============================================================================
-// Assign discovered cores to scheduler threads (cluster-aligned round-robin).
+// Assign discovered cores to scheduler threads (balanced contiguous ranges).
 // =============================================================================
 bool SchedulerContext::assign_cores_to_threads() {
-    // Cluster-aligned round-robin assignment: cluster ci -> sched thread ci % active_sched_threads_.
-    // Each cluster = 1 AIC + 2 adjacent AIV; the triple is always kept together.
+    // Cluster-aligned assignment: each cluster = 1 AIC + 2 adjacent AIV.
     //
     // 3S+1P: the last AICPU thread is the core-less resolution thread (P); cores
     // partition across the remaining (aicpu_thread_num_ - 1) scheduler threads
@@ -721,34 +720,29 @@ bool SchedulerContext::assign_cores_to_threads() {
     }
 
     LOG_INFO(
-        "Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)", cluster_count,
-        active_sched_threads_, aic_count_, aiv_count_
+        "Assigning cores (balanced contiguous): %d clusters across %d sched threads "
+        "(%d AIC, %d AIV)",
+        cluster_count, active_sched_threads_, aic_count_, aiv_count_
     );
 
     // running_reg_task_id / pending_reg_task_id for every serviced core are reset
     // in handshake_partition's sweep.
 
-    // Count clusters per thread first (round-robin may distribute unevenly)
-    int32_t clusters_per_thread[MAX_AICPU_THREADS] = {};
-    for (int32_t ci = 0; ci < cluster_count; ci++) {
-        clusters_per_thread[ci % active_sched_threads_]++;
-    }
-    for (int32_t i = 0; i < active_sched_threads_; i++) {
-        core_trackers_[i].init(clusters_per_thread[i]);
-    }
-
-    int32_t cluster_idx_per_thread[MAX_AICPU_THREADS] = {};
-
-    for (int32_t ci = 0; ci < cluster_count; ci++) {
-        int32_t t = ci % active_sched_threads_;
-
-        int32_t aic_wid = aic_worker_ids_[ci];
-        int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
-        int32_t aiv1_wid = aiv_worker_ids_[2 * ci + 1];
-
-        core_trackers_[t].set_cluster(cluster_idx_per_thread[t]++, aic_wid, aiv0_wid, aiv1_wid);
-
-        LOG_DEBUG("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
+    // Contiguous slices: thread t owns [t*N/A, (t+1)*N/A).
+    const int32_t active = active_sched_threads_;
+    for (int32_t t = 0; t < active; t++) {
+        const SchedulerClusterRange range = scheduler_cluster_range(cluster_count, active, t);
+        const int32_t begin = range.begin;
+        const int32_t end = range.end;
+        core_trackers_[t].init(end - begin);
+        int32_t local = 0;
+        for (int32_t ci = begin; ci < end; ci++) {
+            int32_t aic_wid = aic_worker_ids_[ci];
+            int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
+            int32_t aiv1_wid = aiv_worker_ids_[2 * ci + 1];
+            core_trackers_[t].set_cluster(local++, aic_wid, aiv0_wid, aiv1_wid);
+            LOG_DEBUG("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
+        }
     }
 
     for (int32_t t = 0; t < aicpu_thread_num_; t++) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -24,6 +24,7 @@
 #include "common/memory_barrier.h"
 #include "common/chip_swimlane_profiling.h"
 #include "common/platform_config.h"
+#include "common/scheduler_cluster_partition.h"
 #include "runtime_core.h"
 #include "shared_memory.h"
 #include "runtime.h"
@@ -312,9 +313,8 @@ void SchedulerContext::log_stall_diagnostics(
     }
 
     // CLUSTER lines: one per cluster this thread owns.
-    // cluster_id = local_cluster_idx * active_sched_threads_ + thread_idx, matching the
-    // round-robin assignment in assign_cores_to_threads.
     int32_t ast = active_sched_threads_ > 0 ? active_sched_threads_ : aicpu_thread_num_;
+    const int32_t cluster_begin = scheduler_cluster_range(aic_count_, ast, thread_idx).begin;
     for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
         int32_t offset = cli * PLATFORM_CORES_PER_BLOCKDIM;
         int32_t aic_id = tracker.get_aic_core_id(offset);
@@ -323,7 +323,7 @@ void SchedulerContext::log_stall_diagnostics(
         bool aic_idle = tracker.is_aic_core_idle(offset);
         bool aiv0_idle = tracker.is_aiv0_core_idle(offset);
         bool aiv1_idle = tracker.is_aiv1_core_idle(offset);
-        int32_t cluster_id = cli * ast + thread_idx;
+        int32_t cluster_id = cluster_begin + cli;
         char aic_buf[128], aiv0_buf[128], aiv1_buf[128];
         format_core_status(
             aic_buf, sizeof(aic_buf), aic_id, aic_idle, &core_exec_states_[aic_id], core_exec_states_[aic_id].reg_addr
@@ -796,16 +796,19 @@ void SchedulerContext::handshake_partition(Runtime *runtime, int32_t tidx, int32
 
 // Handshake exactly the cores this scheduler thread will later manage. Blocked
 // core layout ([0,N/3) AIC, [N/3,N) AIV) makes ownership predictable before
-// handshake: cluster ci = {ci, N/3+2ci, N/3+2ci+1}, assigned to thread
-// ci % active_threads. Same protocol as handshake_partition, but over the owned
+// handshake: cluster ci = {ci, N/3+2ci, N/3+2ci+1}, assigned to thread via
+// balanced contiguous ranges. Same protocol as handshake_partition, but over the owned
 // set instead of a contiguous slice.
 void SchedulerContext::handshake_owned_clusters(Runtime *runtime, int32_t tidx, int32_t active_threads) {
     Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->dev.workers);
     const int32_t aic_n = cores_total_num_ / PLATFORM_CORES_PER_BLOCKDIM;
+    const SchedulerClusterRange range = scheduler_cluster_range(aic_n, active_threads, tidx);
+    const int32_t begin = range.begin;
+    const int32_t end = range.end;
 
     int32_t owned[RUNTIME_MAX_WORKER];
     int32_t own_n = 0;
-    for (int32_t ci = tidx; ci < aic_n; ci += active_threads) {
+    for (int32_t ci = begin; ci < end; ++ci) {
         owned[own_n++] = ci;                  // AIC
         owned[own_n++] = aic_n + 2 * ci;      // AIV0
         owned[own_n++] = aic_n + 2 * ci + 1;  // AIV1
@@ -894,20 +897,22 @@ void SchedulerContext::handshake_owned_clusters(Runtime *runtime, int32_t tidx, 
 }
 
 // =============================================================================
-// Per-thread self-assignment (barrier-free init). Thread tidx owns the clusters
-// ci with ci % active_sched_threads_ == tidx (same round-robin as
-// assign_cores_to_threads), and the blocked layout gives their worker ids
-// directly, so a thread populates its own CoreTracker + per-core sub_block_id
-// right after handshaking its own clusters, with no all-thread barrier.
+// Per-thread self-assignment (barrier-free init). Thread tidx owns the
+// balanced contiguous range of clusters (same as assign_cores_to_threads), and the
+// blocked layout gives their worker ids directly, so a thread populates its own
+// CoreTracker + per-core sub_block_id right after handshaking its own clusters,
+// with no all-thread barrier.
 // =============================================================================
 void SchedulerContext::assign_own_clusters(int32_t tidx) {
     const int32_t aic_n = cores_total_num_ / PLATFORM_CORES_PER_BLOCKDIM;
     const int32_t active = active_sched_threads_;
+    // Contiguous slice: [t*N/A, (t+1)*N/A). With A=4 this is quarters.
+    const SchedulerClusterRange range = scheduler_cluster_range(aic_n, active, tidx);
+    const int32_t begin = range.begin;
+    const int32_t end = range.end;
+    const int32_t own_n = end - begin;
 
     CoreTracker &tracker = core_trackers_[tidx];
-    int32_t own_n = 0;
-    for (int32_t ci = tidx; ci < aic_n; ci += active)
-        own_n++;
     // Mirrors the check assign_cores_to_threads() makes on the serial path. A
     // thread owning more clusters than CoreTracker can hold used to write past
     // core_id_map_ into the next tracker, which is the orchestrator's on the
@@ -924,7 +929,7 @@ void SchedulerContext::assign_own_clusters(int32_t tidx) {
     tracker.init(own_n);
 
     int32_t local = 0;
-    for (int32_t ci = tidx; ci < aic_n; ci += active) {
+    for (int32_t ci = begin; ci < end; ++ci) {
         tracker.set_cluster(local++, ci, aic_n + 2 * ci, aic_n + 2 * ci + 1);
     }
 
@@ -989,10 +994,9 @@ void SchedulerContext::post_handshake_profiling_init() {
 }
 
 // =============================================================================
-// Assign discovered cores to scheduler threads (cluster-aligned round-robin).
+// Assign discovered cores to scheduler threads (balanced contiguous ranges).
 // =============================================================================
 bool SchedulerContext::assign_cores_to_threads() {
-    // Cluster-aligned round-robin assignment: cluster ci -> sched thread ci % active_sched_threads_.
     // Each cluster = 1 AIC + 2 adjacent AIV; the triple is always kept together.
     active_sched_threads_ = (sched_thread_num_ > 0) ? sched_thread_num_ : aicpu_thread_num_;
     int32_t cluster_count = aic_count_;
@@ -1007,34 +1011,29 @@ bool SchedulerContext::assign_cores_to_threads() {
     }
 
     LOG_INFO(
-        "Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)", cluster_count,
-        active_sched_threads_, aic_count_, aiv_count_
+        "Assigning cores (balanced contiguous): %d clusters across %d sched threads "
+        "(%d AIC, %d AIV)",
+        cluster_count, active_sched_threads_, aic_count_, aiv_count_
     );
 
     // running_reg_task_id / pending_reg_task_id for every serviced core are reset
     // in handshake_partition's sweep.
 
-    // Count clusters per thread first (round-robin may distribute unevenly)
-    int32_t clusters_per_thread[MAX_AICPU_THREADS] = {};
-    for (int32_t ci = 0; ci < cluster_count; ci++) {
-        clusters_per_thread[ci % active_sched_threads_]++;
-    }
-    for (int32_t i = 0; i < active_sched_threads_; i++) {
-        core_trackers_[i].init(clusters_per_thread[i]);
-    }
-
-    int32_t cluster_idx_per_thread[MAX_AICPU_THREADS] = {};
-
-    for (int32_t ci = 0; ci < cluster_count; ci++) {
-        int32_t t = ci % active_sched_threads_;
-
-        int32_t aic_wid = aic_worker_ids_[ci];
-        int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
-        int32_t aiv1_wid = aiv_worker_ids_[2 * ci + 1];
-
-        core_trackers_[t].set_cluster(cluster_idx_per_thread[t]++, aic_wid, aiv0_wid, aiv1_wid);
-
-        LOG_DEBUG("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
+    // Contiguous slices: thread t owns [t*N/A, (t+1)*N/A).
+    const int32_t active = active_sched_threads_;
+    for (int32_t t = 0; t < active; t++) {
+        const SchedulerClusterRange range = scheduler_cluster_range(cluster_count, active, t);
+        const int32_t begin = range.begin;
+        const int32_t end = range.end;
+        core_trackers_[t].init(end - begin);
+        int32_t local = 0;
+        for (int32_t ci = begin; ci < end; ci++) {
+            int32_t aic_wid = aic_worker_ids_[ci];
+            int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
+            int32_t aiv1_wid = aiv_worker_ids_[2 * ci + 1];
+            core_trackers_[t].set_cluster(local++, aic_wid, aiv0_wid, aiv1_wid);
+            LOG_DEBUG("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
+        }
     }
 
     for (int32_t t = 0; t < aicpu_thread_num_; t++) {

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -1437,6 +1437,23 @@ target_link_libraries(test_a5_aicpu_topology_fallback PRIVATE
 add_test(NAME test_a5_aicpu_topology_fallback COMMAND test_a5_aicpu_topology_fallback)
 set_tests_properties(test_a5_aicpu_topology_fallback PROPERTIES LABELS "no_hardware")
 
+add_executable(test_a5_affinity_allowed_file
+    a5/test_affinity_allowed_file.cpp
+    ${A5_ONBOARD_HOST_DIR}/affinity_allowed_file.cpp
+)
+target_include_directories(test_a5_affinity_allowed_file PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${A5_ONBOARD_HOST_DIR}
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/platform/include
+)
+target_link_libraries(test_a5_affinity_allowed_file PRIVATE
+    ${GTEST_MAIN_LIB}
+    ${GTEST_LIB}
+    pthread
+)
+add_test(NAME test_a5_affinity_allowed_file COMMAND test_a5_affinity_allowed_file)
+set_tests_properties(test_a5_affinity_allowed_file PROPERTIES LABELS "no_hardware")
+
 # Hardware-gated tests.  Block is only entered when the project is configured
 # with -DSIMPLER_ENABLE_HARDWARE_TESTS=ON.  CI's no-hw `ut` job does not pass
 # this flag, so nothing here is compiled there — this is the structural

--- a/tests/ut/cpp/a5/test_affinity_allowed_file.cpp
+++ b/tests/ut/cpp/a5/test_affinity_allowed_file.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+#include <unistd.h>
+#include <vector>
+
+#include "affinity_allowed_file.h"
+
+namespace {
+
+constexpr const char *kPlanEnv = "SIMPLER_AICPU_AFFINITY_PLAN";
+constexpr uint64_t kOccupy = UINT64_C(0x1f8);  // CPUs 3..8.
+
+class PlanPathFixture : public ::testing::Test {
+protected:
+    void SetUp() override {
+        const char *old = std::getenv(kPlanEnv);
+        if (old != nullptr) {
+            had_old_env_ = true;
+            old_env_ = old;
+        }
+        directory_ = std::filesystem::temp_directory_path() /
+                     ("simpler-affinity-side-" + std::to_string(static_cast<long long>(getpid())) + "-" +
+                      std::to_string(sequence_++));
+        std::filesystem::create_directories(directory_);
+        base_ = directory_ / "plan.json";
+        ASSERT_EQ(setenv(kPlanEnv, base_.c_str(), 1), 0);
+    }
+
+    void TearDown() override {
+        if (had_old_env_) {
+            (void)setenv(kPlanEnv, old_env_.c_str(), 1);
+        } else {
+            (void)unsetenv(kPlanEnv);
+        }
+        std::error_code ec;
+        std::filesystem::remove_all(directory_, ec);
+    }
+
+    std::filesystem::path side_path(int32_t device_id = 0) const { return pto::a5::affinity_cpus_side_path(device_id); }
+
+    void write_side(const std::string &text) const {
+        std::ofstream output(side_path());
+        ASSERT_TRUE(output.good());
+        output << text;
+        ASSERT_TRUE(output.good());
+    }
+
+    static std::string valid_side() {
+        return "schema_version=3\n"
+               "device_id=0\n"
+               "soc=Ascend950PR_9599\n"
+               "source=manual\n"
+               "occupy_mask=0x1f8\n"
+               "active_count=5\n"
+               "cpus=3,4,5,6,7\n";
+    }
+
+    static std::string replacing(std::string text, const std::string &from, const std::string &to) {
+        const size_t pos = text.find(from);
+        EXPECT_NE(pos, std::string::npos);
+        if (pos != std::string::npos) text.replace(pos, from.size(), to);
+        return text;
+    }
+
+private:
+    static inline int sequence_ = 0;
+    bool had_old_env_{false};
+    std::string old_env_;
+
+protected:
+    std::filesystem::path directory_;
+    std::filesystem::path base_;
+};
+
+TEST_F(PlanPathFixture, DerivesPerDevicePathFromBaseTemplateOrExactSuffix) {
+    EXPECT_EQ(side_path(2), directory_ / "plan.2.cpus");
+
+    const std::string templated = (directory_ / "custom.{device}.json").string();
+    ASSERT_EQ(setenv(kPlanEnv, templated.c_str(), 1), 0);
+    EXPECT_EQ(side_path(3), directory_ / "custom.3.cpus");
+
+    const std::string exact = (directory_ / "custom.4.json").string();
+    ASSERT_EQ(setenv(kPlanEnv, exact.c_str(), 1), 0);
+    EXPECT_EQ(side_path(4), directory_ / "custom.4.cpus");
+
+    const std::string alternate_suffix = (directory_ / "custom.5.plan").string();
+    ASSERT_EQ(setenv(kPlanEnv, alternate_suffix.c_str(), 1), 0);
+    EXPECT_EQ(side_path(5), directory_ / "custom.5.cpus");
+}
+
+TEST(A5AffinityAllowedFile, BuildsExactContiguousWidthWithoutClamping) {
+    std::vector<int32_t> allowed;
+    ASSERT_TRUE(pto::a5::build_occupy_contiguous_allowed(kOccupy, 2, allowed));
+    EXPECT_EQ(allowed, (std::vector<int32_t>{3, 4}));
+    ASSERT_TRUE(pto::a5::build_occupy_contiguous_allowed(kOccupy, 4, allowed));
+    EXPECT_EQ(allowed, (std::vector<int32_t>{3, 4, 5, 6}));
+    ASSERT_TRUE(pto::a5::build_occupy_contiguous_allowed(kOccupy, 5, allowed));
+    EXPECT_EQ(allowed, (std::vector<int32_t>{3, 4, 5, 6, 7}));
+    EXPECT_FALSE(pto::a5::build_occupy_contiguous_allowed(UINT64_C(0x18), 3, allowed));
+    EXPECT_TRUE(allowed.empty());
+}
+
+TEST(A5AffinityAllowedFile, HonorsExplicitActiveCountAndUsesRttOnlyForFourSchedulers) {
+    int32_t active = 0;
+    bool use_rtt = false;
+    for (int32_t requested : {2, 3, 4}) {
+        ASSERT_TRUE(pto::a5::resolve_aicpu_active_count(requested, 6, active, use_rtt));
+        EXPECT_EQ(active, requested);
+        EXPECT_FALSE(use_rtt);
+    }
+    ASSERT_TRUE(pto::a5::resolve_aicpu_active_count(5, 6, active, use_rtt));
+    EXPECT_EQ(active, 5);
+    EXPECT_TRUE(use_rtt);
+
+    ASSERT_TRUE(pto::a5::resolve_aicpu_active_count(0, 6, active, use_rtt));
+    EXPECT_EQ(active, 5);
+    EXPECT_TRUE(use_rtt);
+    ASSERT_TRUE(pto::a5::resolve_aicpu_active_count(0, 3, active, use_rtt));
+    EXPECT_EQ(active, 3);
+    EXPECT_FALSE(use_rtt);
+
+    EXPECT_FALSE(pto::a5::resolve_aicpu_active_count(5, 4, active, use_rtt));
+    EXPECT_FALSE(pto::a5::resolve_aicpu_active_count(1, 6, active, use_rtt));
+    EXPECT_FALSE(pto::a5::resolve_aicpu_active_count(6, 6, active, use_rtt));
+    EXPECT_FALSE(pto::a5::resolve_aicpu_active_count(0, 15, active, use_rtt));
+}
+
+TEST_F(PlanPathFixture, LoadsOnlyTheExactHardwareAndSchemaContract) {
+    write_side(valid_side());
+    std::vector<int32_t> allowed;
+    std::string source;
+    ASSERT_TRUE(pto::a5::load_affinity_cpus_side_file("Ascend950PR_9599", 0, kOccupy, allowed, source));
+    EXPECT_EQ(allowed, (std::vector<int32_t>{3, 4, 5, 6, 7}));
+    EXPECT_EQ(source, "manual");
+}
+
+TEST_F(PlanPathFixture, RejectsMalformedStaleAndUnsafePlans) {
+    const std::vector<std::string> invalid = {
+        replacing(valid_side(), "schema_version=3", "schema_version=2"),
+        replacing(valid_side(), "device_id=0", "device_id=1"),
+        replacing(valid_side(), "soc=Ascend950PR_9599", "soc=Ascend950PR_other"),
+        replacing(valid_side(), "source=manual", "source=unknown"),
+        replacing(valid_side(), "occupy_mask=0x1f8", "occupy_mask=0xf8"),
+        replacing(valid_side(), "active_count=5", "active_count=4"),
+        replacing(valid_side(), "cpus=3,4,5,6,7", "cpus=3,4,5,6"),
+        replacing(valid_side(), "cpus=3,4,5,6,7", "cpus=3,4,5,6,9"),
+        replacing(valid_side(), "cpus=3,4,5,6,7", "cpus=3,4,5,6,6"),
+        replacing(valid_side(), "cpus=3,4,5,6,7", "cpus=3,,4,5,6,7"),
+        replacing(valid_side(), "cpus=3,4,5,6,7", "cpus=3,4,5,6,7,"),
+        valid_side() + "unknown=value\n",
+    };
+    for (const auto &text : invalid) {
+        write_side(text);
+        std::vector<int32_t> allowed;
+        std::string source;
+        EXPECT_FALSE(pto::a5::load_affinity_cpus_side_file("Ascend950PR_9599", 0, kOccupy, allowed, source));
+    }
+}
+
+}  // namespace

--- a/tests/ut/cpp/a5/test_aicpu_topology_fallback.cpp
+++ b/tests/ut/cpp/a5/test_aicpu_topology_fallback.cpp
@@ -18,6 +18,7 @@
 
 #include "aicpu_topology_probe.h"
 #include "common/platform_config.h"
+#include "common/scheduler_cluster_partition.h"
 
 extern "C" {
 void unified_log_error(const char *, const char *, ...) {}
@@ -35,6 +36,7 @@ using pto::a5::AicpuSelectionPolicy;
 using pto::a5::AicpuTopology;
 using pto::a5::AicpuTopologySource;
 using pto::a5::build_aicpu_launch_plan;
+using pto::a5::build_complete_topology_user_pool;
 using pto::a5::classify_aicpu_scenario;
 using pto::a5::compute_allowed_cpus;
 using pto::a5::compute_scenario_allowed_cpus;
@@ -83,6 +85,52 @@ TEST(A5AicpuTopologyFallback, EnumeratesBoundaryCpuIdsAndRejectsEmptyMask) {
     cpus = {{1, 1, 0, 0, 0}};
     EXPECT_FALSE(enumerate_cpus_from_occupy(0, cpus));
     EXPECT_TRUE(cpus.empty());
+}
+
+TEST(A5AicpuTopologyFallback, UsesOnlyCompleteDriverOrVerifiedJsonPool) {
+    AicpuTopology topology;
+    topology.source = AicpuTopologySource::kDriver;
+    topology.os_schedulable_cpus = {{5, 2, 1, 1, 0}, {3, 1, 1, 0, 0}, {4, 2, 0, 1, 0}};
+    set_device_occupy(topology, (1ULL << 3) | (1ULL << 4) | (1ULL << 5));
+    std::vector<int32_t> pool;
+    ASSERT_TRUE(build_complete_topology_user_pool(topology, pool));
+    EXPECT_EQ(pool, (std::vector<int32_t>{3, 4, 5}));
+
+    topology.source = AicpuTopologySource::kJsonFallback;
+    EXPECT_TRUE(build_complete_topology_user_pool(topology, pool));
+
+    topology.source = AicpuTopologySource::kOccupyFallback;
+    EXPECT_FALSE(build_complete_topology_user_pool(topology, pool));
+    EXPECT_TRUE(pool.empty());
+
+    topology.source = AicpuTopologySource::kDriver;
+    topology.os_schedulable_cpus.pop_back();
+    EXPECT_FALSE(build_complete_topology_user_pool(topology, pool));
+    EXPECT_TRUE(pool.empty());
+}
+
+TEST(A5AicpuTopologyFallback, RejectsTopologyPoolBeyondVerifiedLaunchMaximum) {
+    AicpuTopology topology;
+    topology.source = AicpuTopologySource::kDriver;
+    ASSERT_TRUE(enumerate_cpus_from_occupy((1ULL << 15) - 1, topology.os_schedulable_cpus));
+    set_device_occupy(topology, (1ULL << 15) - 1);
+    std::vector<int32_t> pool;
+    EXPECT_FALSE(build_complete_topology_user_pool(topology, pool));
+    EXPECT_TRUE(pool.empty());
+}
+
+TEST(A5SchedulerClusterPartition, FourSchedulersCoverBalancedContiguousRanges) {
+    for (int32_t cluster_count : {28, 36}) {
+        int32_t previous_end = 0;
+        for (int32_t thread = 0; thread < 4; ++thread) {
+            const SchedulerClusterRange range = scheduler_cluster_range(cluster_count, 4, thread);
+            EXPECT_EQ(range.begin, previous_end);
+            EXPECT_GE(range.end - range.begin, cluster_count / 4);
+            EXPECT_LE(range.end - range.begin, (cluster_count + 3) / 4);
+            previous_end = range.end;
+        }
+        EXPECT_EQ(previous_end, cluster_count);
+    }
 }
 
 #if defined(__x86_64__)
@@ -527,6 +575,59 @@ TEST(A5AicpuTopologySelection, KnownScenarioRejectsUnsupportedActiveCount) {
     EXPECT_TRUE(allowed.empty());
     EXPECT_FALSE(compute_scenario_allowed_cpus(topology, 6, allowed));
     EXPECT_TRUE(allowed.empty());
+}
+
+TEST(A5AicpuLaunchPlan, FiveThreadFgHasNoRuntimeRttToggle) {
+    const auto all = make_physical_range(0, 7);
+    AicpuTopology topology;
+    topology.source = AicpuTopologySource::kDriver;
+    topology.scenario_type = AicpuScenarioType::kFg;
+    topology.os_schedulable_cpus = primaries(all);
+    std::reverse(topology.os_schedulable_cpus.begin(), topology.os_schedulable_cpus.end());
+    uint64_t occupy = 0;
+    for (const auto &cpu : topology.os_schedulable_cpus)
+        occupy |= 1ULL << cpu.cpu_id;
+    set_device_occupy(topology, occupy);
+
+    AicpuLaunchPlan plan;
+    std::string error;
+    ASSERT_TRUE(build_aicpu_launch_plan(topology, 0, plan, error)) << error;
+    EXPECT_EQ(plan.effective_active_count, 5);
+    EXPECT_EQ(plan.allowed_cpus.size(), 5u);
+    const std::string json = format_aicpu_topology_json(topology, AicpuSelectionPolicy::kScenario, plan);
+    EXPECT_EQ(json.find("rtt_die_preflight"), std::string::npos);
+    EXPECT_EQ(json.find("sched_aicore_assignment_mode"), std::string::npos);
+    EXPECT_EQ(json.find("mode 3"), std::string::npos);
+}
+
+TEST(A5AicpuLaunchPlan, OccupyOnlyStillBuildsFiveWhenMaskIsFive) {
+    AicpuTopology topology;
+    topology.source = AicpuTopologySource::kOccupyFallback;
+    topology.scenario_type = AicpuScenarioType::kUnknown;
+    ASSERT_TRUE(enumerate_cpus_from_occupy(0x3eU, topology.os_schedulable_cpus));
+    set_device_occupy(topology, 0x3eU);
+    std::reverse(topology.os_schedulable_cpus.begin(), topology.os_schedulable_cpus.end());
+
+    AicpuLaunchPlan plan;
+    std::string error;
+    ASSERT_TRUE(build_aicpu_launch_plan(topology, 0, plan, error)) << error;
+    EXPECT_EQ(plan.effective_active_count, 5);
+    EXPECT_EQ(
+        std::vector<int32_t>(plan.allowed_cpus.begin(), plan.allowed_cpus.end() - 1), (std::vector<int32_t>{1, 2, 3, 4})
+    );
+}
+
+TEST(A5AicpuLaunchPlan, EffectiveCountFourStillBuilds) {
+    AicpuTopology topology;
+    topology.source = AicpuTopologySource::kDriver;
+    topology.scenario_type = AicpuScenarioType::kUnknown;
+    topology.os_schedulable_cpus = {{1, 0, 0, 0, 0}, {3, 2, 0, 1, 0}, {5, 4, 0, 2, 1}, {7, 6, 0, 3, 1}};
+    set_device_occupy(topology, (1ULL << 1) | (1ULL << 3) | (1ULL << 5) | (1ULL << 7));
+
+    AicpuLaunchPlan plan;
+    std::string error;
+    ASSERT_TRUE(build_aicpu_launch_plan(topology, 0, plan, error)) << error;
+    EXPECT_EQ(plan.effective_active_count, 4);
 }
 
 }  // namespace

--- a/tests/ut/py/test_rtt_die_preflight.py
+++ b/tests/ut/py/test_rtt_die_preflight.py
@@ -1,0 +1,438 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Unit tests for A5 AICPU affinity preflight ranking and plan writes."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from simpler_setup.tools import rtt_die_preflight as preflight
+
+
+def test_pick_orchestrator_min_avg_tiebreak():
+    pool = [
+        {"pool_idx": 0, "avg_handshake_ticks": 100},
+        {"pool_idx": 1, "avg_handshake_ticks": 50},
+        {"pool_idx": 2, "avg_handshake_ticks": 50},
+        {"pool_idx": 3, "avg_handshake_ticks": 80},
+    ]
+    assert preflight.pick_orchestrator(pool) == 1
+
+
+def test_pack_schedulers_phys_order_to_logical_die_contract():
+    # Candidates after orch removal. Scores chosen so phys picks are:
+    # die0 best=cpu10, die1 best=cpu20, die1 2nd=cpu21, die0 2nd=cpu11
+    candidates = [
+        {"cpu_id": 10, "die0_sum_ticks": 100, "die1_sum_ticks": 900},
+        {"cpu_id": 11, "die0_sum_ticks": 200, "die1_sum_ticks": 800},
+        {"cpu_id": 20, "die0_sum_ticks": 900, "die1_sum_ticks": 100},
+        {"cpu_id": 21, "die0_sum_ticks": 800, "die1_sum_ticks": 150},
+    ]
+    allowed, schedulers = preflight.pack_schedulers_from_die_scores(candidates)
+    assert allowed == [10, 11, 20, 21]
+    assert [s["assigned_die"] for s in schedulers] == [0, 0, 1, 1]
+    assert [s["logical_idx"] for s in schedulers] == [0, 1, 2, 3]
+
+
+def test_build_allowed_cpus_from_probe_full():
+    probe = {
+        "schema_version": 3,
+        "measurement_method": preflight.MEASUREMENT_METHOD,
+        "soc_name": "Ascend950PR_9599",
+        "device_id": 0,
+        "user_pool_cpus": [3, 4, 5, 6, 7, 8],
+        "orch_pool_idx": 5,
+        "pool": [
+            {
+                "pool_idx": 0,
+                "cpu_id": 3,
+                "avg_handshake_ticks": 40,
+                "die0_sum_ticks": 100,
+                "die1_sum_ticks": 900,
+                "is_orch": 0,
+            },
+            {
+                "pool_idx": 1,
+                "cpu_id": 4,
+                "avg_handshake_ticks": 41,
+                "die0_sum_ticks": 200,
+                "die1_sum_ticks": 800,
+                "is_orch": 0,
+            },
+            {
+                "pool_idx": 2,
+                "cpu_id": 5,
+                "avg_handshake_ticks": 42,
+                "die0_sum_ticks": 900,
+                "die1_sum_ticks": 100,
+                "is_orch": 0,
+            },
+            {
+                "pool_idx": 3,
+                "cpu_id": 6,
+                "avg_handshake_ticks": 43,
+                "die0_sum_ticks": 800,
+                "die1_sum_ticks": 150,
+                "is_orch": 0,
+            },
+            {
+                "pool_idx": 4,
+                "cpu_id": 7,
+                "avg_handshake_ticks": 44,
+                "die0_sum_ticks": 700,
+                "die1_sum_ticks": 700,
+                "is_orch": 0,
+            },
+            {
+                "pool_idx": 5,
+                "cpu_id": 8,
+                "avg_handshake_ticks": 10,
+                "die0_sum_ticks": 0,
+                "die1_sum_ticks": 0,
+                "is_orch": 1,
+            },
+        ],
+    }
+    node = preflight.build_allowed_cpus_from_probe(probe)
+    assert node["orch_cpu"] == 8
+    assert node["allowed_cpus"][-1] == 8
+    assert len(node["allowed_cpus"]) == 5
+    assert node["schedulers"][0]["assigned_die"] == 0
+    assert node["schedulers"][1]["assigned_die"] == 0
+    assert node["schedulers"][2]["assigned_die"] == 1
+    assert node["schedulers"][3]["assigned_die"] == 1
+    assert node["plan_source"] == preflight.MEASUREMENT_METHOD
+    assert node["device_id"] == 0
+    assert node["active_count"] == 5
+    assert node["occupy_mask"] == "0x1f8"
+
+
+def test_build_allowed_cpus_pool_too_small():
+    probe = {
+        "schema_version": 3,
+        "measurement_method": preflight.MEASUREMENT_METHOD,
+        "soc_name": "Ascend950PR_9599",
+        "device_id": 0,
+        "pool_too_small": True,
+        "user_pool_cpus": [3, 4, 5],
+    }
+    with pytest.raises(ValueError, match="requires 4 scheduler"):
+        preflight.build_allowed_cpus_from_probe(probe)
+
+
+def test_contiguous_fallback_and_side_file(tmp_path: Path):
+    out = tmp_path / "aicpu_affinity_plan.json"
+    node = preflight.build_contiguous_fallback_node(
+        soc_name="Ascend950PR_9599",
+        device_id=1,
+        occupy_cpus=[8, 3, 4, 5, 6, 7],
+        plan_source=preflight.PLAN_SOURCE_PROBE_FAILED,
+    )
+    # Contiguous order preserves input order (not resorted).
+    assert node["allowed_cpus"] == [8, 3, 4, 5, 6]
+    assert node["orch_cpu"] == 6
+    preflight.persist_device_plan(out, soc_name="Ascend950PR_9599", device_id=1, device_node=node)
+    side = preflight.cpus_side_path(out)
+    assert side.is_file()
+    text = side.read_text(encoding="utf-8")
+    assert "schema_version=3\n" in text
+    assert "device_id=1\n" in text
+    assert "soc=Ascend950PR_9599\n" in text
+    assert f"source={preflight.PLAN_SOURCE_PROBE_FAILED}\n" in text
+    assert "occupy_mask=0x1f8\n" in text
+    assert "active_count=5\n" in text
+    assert "cpus=8,3,4,5,6\n" in text
+    assert preflight.side_file_looks_usable(side, 1)
+
+
+def test_cli_fallback_occupy(tmp_path: Path):
+    out = tmp_path / "plan.json"
+    rc = preflight.main(
+        [
+            "--device",
+            "0",
+            "--soc",
+            "Ascend950PR_9599",
+            "--fallback-occupy",
+            "3,4,5,6,7,8",
+            "--out",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    loaded = json.loads(out.read_text(encoding="utf-8"))
+    assert loaded["socs"]["Ascend950PR_9599"]["devices"]["0"]["allowed_cpus"] == [3, 4, 5, 6, 7]
+    assert loaded["socs"]["Ascend950PR_9599"]["devices"]["0"]["plan_source"] == (preflight.PLAN_SOURCE_PROBE_FAILED)
+    side = preflight.cpus_side_path(out).read_text(encoding="utf-8")
+    assert "cpus=3,4,5,6,7\n" in side
+    assert f"source={preflight.PLAN_SOURCE_PROBE_FAILED}\n" in side
+
+
+def test_validate_probe_rejects_old_schema():
+    with pytest.raises(ValueError, match="schema_version"):
+        preflight.validate_probe_result(
+            {
+                "schema_version": 2,
+                "measurement_method": "serialized-cond-rtt-v2",
+                "soc_name": "Ascend950PR_9599",
+                "device_id": 0,
+            },
+            0,
+        )
+
+
+def test_per_device_plans_do_not_merge_or_overwrite(tmp_path: Path):
+    out0 = tmp_path / "aicpu_affinity_plan.0.json"
+    out1 = tmp_path / "aicpu_affinity_plan.1.json"
+    node0 = preflight.build_device_node_from_allowed(
+        soc_name="Ascend950PR_9599",
+        device_id=0,
+        allowed_cpus=[3, 4, 5, 6, 7],
+        occupy_cpus=[3, 4, 5, 6, 7, 8],
+        plan_source="manual",
+    )
+    preflight.persist_device_plan(out0, soc_name="Ascend950PR_9599", device_id=0, device_node=node0)
+
+    node1 = preflight.build_device_node_from_allowed(
+        soc_name="Ascend950PR_9599",
+        device_id=1,
+        allowed_cpus=[10, 11, 12, 13, 14],
+        occupy_cpus=[10, 11, 12, 13, 14, 15],
+        plan_source="manual",
+    )
+    preflight.persist_device_plan(out1, soc_name="Ascend950PR_9599", device_id=1, device_node=node1)
+
+    loaded0 = json.loads(out0.read_text(encoding="utf-8"))
+    loaded1 = json.loads(out1.read_text(encoding="utf-8"))
+    assert set(loaded0["socs"]["Ascend950PR_9599"]["devices"]) == {"0"}
+    assert set(loaded1["socs"]["Ascend950PR_9599"]["devices"]) == {"1"}
+
+
+def test_cli_offline_allowed_cpus(tmp_path: Path):
+    out = tmp_path / "plan.json"
+    rc = preflight.main(
+        [
+            "--device",
+            "2",
+            "--soc",
+            "Ascend950PR_9599",
+            "--allowed-cpus",
+            "3,4,5,6,7",
+            "--occupy-cpus",
+            "3,4,5,6,7,8",
+            "--out",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    loaded = json.loads(out.read_text(encoding="utf-8"))
+    assert loaded["socs"]["Ascend950PR_9599"]["devices"]["2"]["allowed_cpus"] == [3, 4, 5, 6, 7]
+
+
+def test_default_plan_path_is_per_device_and_honors_base_or_template(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv(preflight.PLAN_ENV, raising=False)
+    assert preflight.default_plan_path(2) == tmp_path / "build/config/aicpu_affinity_plan.2.json"
+
+    monkeypatch.setenv(preflight.PLAN_ENV, str(tmp_path / "custom.json"))
+    assert preflight.default_plan_path(3) == tmp_path / "custom.3.json"
+    monkeypatch.setenv(preflight.PLAN_ENV, str(tmp_path / "custom.{device}.json"))
+    assert preflight.default_plan_path(4) == tmp_path / "custom.4.json"
+    monkeypatch.setenv(preflight.PLAN_ENV, str(tmp_path / "custom.plan"))
+    assert preflight.default_plan_path(5) == tmp_path / "custom.5.plan"
+    assert preflight.cpus_side_path(preflight.default_plan_path(5)) == tmp_path / "custom.5.cpus"
+
+
+def test_timeout_record_is_per_device_and_clearable(tmp_path: Path):
+    plan = tmp_path / "plan.2.json"
+    marker = preflight.write_timeout_record(plan, 2, reason="test")
+    assert marker == preflight.timeout_record_path(plan)
+    assert preflight.timeout_record_looks_usable(marker, 2)
+    assert not preflight.timeout_record_looks_usable(marker, 1)
+
+    preflight.clear_timeout_record(plan)
+    assert not marker.exists()
+
+
+def test_helper_cache_stamp_is_atomic_and_fingerprint_specific(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(preflight, "_CACHE_STAMP", tmp_path / ".build.stamp")
+    preflight._write_cache_stamp("fingerprint-a")
+    assert preflight._cache_stamp_matches("fingerprint-a")
+    assert not preflight._cache_stamp_matches("fingerprint-b")
+
+
+def test_probe_timeout_writes_record_and_manual_probe_clears_it(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    out = tmp_path / "plan.0.json"
+
+    def timeout_probe(_device_id: int):
+        raise preflight.AffinityProbeTimeout("probe", preflight.PREFLIGHT_TIMEOUT_SECONDS)
+
+    monkeypatch.setattr(preflight, "run_affinity_probe", timeout_probe)
+    assert preflight.main(["--device", "0", "--probe", "--plan-source", "auto-first-run", "--out", str(out)]) == 1
+    marker = preflight.timeout_record_path(out)
+    assert preflight.timeout_record_looks_usable(marker, 0)
+
+    def fail_probe(_device_id: int):
+        raise RuntimeError("manual retry")
+
+    monkeypatch.setattr(preflight, "run_affinity_probe", fail_probe)
+    assert preflight.main(["--device", "0", "--probe", "--out", str(out)]) == 1
+    assert not marker.exists()
+
+
+def test_helper_build_timeout_does_not_write_timeout_record(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    out = tmp_path / "plan.0.json"
+
+    def build_timeout(_device_id: int):
+        raise subprocess.TimeoutExpired("cmake --build", preflight.HELPER_BUILD_TIMEOUT_SECONDS)
+
+    monkeypatch.setattr(preflight, "run_affinity_probe", build_timeout)
+    assert preflight.main(["--device", "0", "--probe", "--plan-source", "auto-first-run", "--out", str(out)]) == 1
+    assert not preflight.timeout_record_path(out).exists()
+    assert not out.exists()
+
+
+def test_query_device_hal_probe_budget_starts_after_helper_build(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    host_bin = tmp_path / "query_device_hal"
+    host_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    calls: list[dict[str, object]] = []
+    clock = {"now": 1000.0}
+
+    def fake_monotonic() -> float:
+        return clock["now"]
+
+    def capture_run(command, **kwargs):
+        calls.append({"command": list(command), "timeout": kwargs.get("timeout")})
+        return subprocess.CompletedProcess(command, 0, stdout="{}", stderr="")
+
+    monkeypatch.setattr(preflight.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(
+        preflight,
+        "_ensure_query_device_hal_artifacts",
+        lambda: (host_bin, {"ASCEND_HOME_PATH": "/ascend"}),
+    )
+    monkeypatch.setattr(preflight.subprocess, "run", capture_run)
+
+    # Simulate a long helper build finishing before the probe starts.
+    clock["now"] = 1000.0 + 120.0
+    assert preflight._run_query_device_hal(0, "--rtt-json") == "{}"
+    assert calls and calls[0]["command"] == [str(host_bin), "0", "--rtt-json"]
+    assert calls[0]["timeout"] == pytest.approx(preflight.PREFLIGHT_TIMEOUT_SECONDS, abs=0.01)
+
+
+def test_probe_failure_writes_no_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    out = tmp_path / "plan.0.json"
+
+    def fail_probe(_device_id: int):
+        raise RuntimeError("synthetic probe failure")
+
+    monkeypatch.setattr(preflight, "run_affinity_probe", fail_probe)
+    assert preflight.main(["--device", "0", "--probe", "--out", str(out)]) == 1
+    assert not out.exists()
+    assert not preflight.cpus_side_path(out).exists()
+
+
+def test_probe_failure_does_not_modify_existing_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    out = tmp_path / "plan.0.json"
+    side = preflight.cpus_side_path(out)
+    out.write_text("old-json\n", encoding="utf-8")
+    side.write_text("old-side\n", encoding="utf-8")
+
+    def fail_probe(_device_id: int):
+        raise RuntimeError("synthetic probe failure")
+
+    monkeypatch.setattr(preflight, "run_affinity_probe", fail_probe)
+    assert preflight.main(["--device", "0", "--probe", "--out", str(out)]) == 1
+    assert out.read_text(encoding="utf-8") == "old-json\n"
+    assert side.read_text(encoding="utf-8") == "old-side\n"
+
+
+def test_pair_publish_rolls_back_when_side_write_fails(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    out = tmp_path / "plan.0.json"
+    side = preflight.cpus_side_path(out)
+    out.write_text("old-json\n", encoding="utf-8")
+    side.write_text("old-side\n", encoding="utf-8")
+    node = preflight.build_device_node_from_allowed(
+        soc_name="Ascend950PR_9599",
+        device_id=0,
+        allowed_cpus=[3, 4, 5, 6, 7],
+        occupy_cpus=[3, 4, 5, 6, 7, 8],
+    )
+    plan = preflight.make_device_plan(soc_name="Ascend950PR_9599", device_id=0, device_node=node)
+    original_write = preflight._atomic_write_text
+
+    def fail_side(path: Path, text: str):
+        if path == side:
+            raise OSError("synthetic side write failure")
+        original_write(path, text)
+
+    monkeypatch.setattr(preflight, "_atomic_write_text", fail_side)
+    with pytest.raises(OSError, match="synthetic side"):
+        preflight.atomic_write_plan_and_side(out, plan, node)
+    assert out.read_text(encoding="utf-8") == "old-json\n"
+    assert side.read_text(encoding="utf-8") == "old-side\n"
+
+
+@pytest.mark.parametrize(
+    "allowed,occupy,error",
+    [
+        ([3, 4, 5, 6], [3, 4, 5, 6, 7], "allowed_cpus must contain"),
+        ([3, 4, 5, 6, 7, 8], [3, 4, 5, 6, 7, 8], "allowed_cpus must contain"),
+        ([3, 4, 5, 6, 64], [3, 4, 5, 6, 64], "CPU ids"),
+        ([3, 4, 5, 6, 9], [3, 4, 5, 6, 7, 8], "subset"),
+    ],
+)
+def test_manual_plan_rejects_invalid_allowed_or_occupy(allowed: list[int], occupy: list[int], error: str):
+    with pytest.raises(ValueError, match=error):
+        preflight.build_device_node_from_allowed(
+            soc_name="Ascend950PR_9599", device_id=0, allowed_cpus=allowed, occupy_cpus=occupy
+        )
+
+
+def test_side_file_validation_rejects_stale_or_legacy_contract(tmp_path: Path):
+    legacy = tmp_path / "legacy.cpus"
+    legacy.write_text("soc=Ascend950PR_9599\nsource=manual\ncpus=3,4,5,6,7\n", encoding="utf-8")
+    assert not preflight.side_file_looks_usable(legacy, 0)
+
+    node = preflight.build_device_node_from_allowed(
+        soc_name="Ascend950PR_9599",
+        device_id=0,
+        allowed_cpus=[3, 4, 5, 6, 7],
+        occupy_cpus=[3, 4, 5, 6, 7, 8],
+    )
+    plan = tmp_path / "plan.0.json"
+    preflight.persist_device_plan(plan, soc_name="Ascend950PR_9599", device_id=0, device_node=node)
+    side = preflight.cpus_side_path(plan)
+    assert preflight.side_file_looks_usable(side, 0)
+    assert preflight.plan_files_look_usable(plan, 0)
+    assert not preflight.side_file_looks_usable(side, 1)
+
+    loaded = json.loads(plan.read_text(encoding="utf-8"))
+    loaded["socs"]["Ascend950PR_9599"]["devices"]["0"]["plan_source"] = "auto-first-run"
+    plan.write_text(json.dumps(loaded), encoding="utf-8")
+    assert not preflight.plan_files_look_usable(plan, 0)
+
+    malformed = side.read_text(encoding="utf-8").replace("cpus=3,4,5,6,7", "cpus=3,,4,5,6,7")
+    side.write_text(malformed, encoding="utf-8")
+    assert not preflight.side_file_looks_usable(side, 0)
+
+
+def test_cmake_build_passes_project_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    calls: list[list[str]] = []
+
+    def record(command: list[str], **_kwargs):
+        calls.append(command)
+
+    monkeypatch.setattr(preflight.subprocess, "run", record)
+    preflight._cmake_build(tmp_path / "src", tmp_path / "build", {"ASCEND_HOME_PATH": "/ascend"})
+    assert f"-DSIMPLER_ROOT={preflight.PROJECT_ROOT}" in calls[0]

--- a/tests/ut/py/test_task_interface.py
+++ b/tests/ut/py/test_task_interface.py
@@ -13,6 +13,7 @@ import ctypes
 import gc
 import itertools
 import struct
+import subprocess
 import weakref
 from multiprocessing.shared_memory import SharedMemory
 from types import SimpleNamespace
@@ -57,7 +58,13 @@ from simpler.task_interface import (
     _remote_sidecar_for,
 )
 
+from simpler_setup.tools import rtt_die_preflight
+
 _REF_BID = itertools.count(1)
+
+
+def _a5_onboard_bins():
+    return SimpleNamespace(dispatcher_path="/tmp/a5/dispatcher.so", host_path="/tmp/a5/host.so")
 
 
 def _dev_ref(addr, shapes, dtype, tag=None):
@@ -1478,3 +1485,80 @@ class TestAddRefAccessSubset:
             assert args.tensor_count() == 3
         finally:
             h.close()
+
+
+class TestA5AffinityPreflightBootstrap:
+    def test_auto_probe_receives_exact_per_device_out_path(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv(rtt_die_preflight.PLAN_ENV, raising=False)
+        calls = []
+
+        def fail_probe(command, **_kwargs):
+            calls.append(command)
+            return SimpleNamespace(returncode=1, stdout="", stderr="synthetic failure")
+
+        monkeypatch.setattr(task_interface_module.subprocess, "run", fail_probe)
+        task_interface_module._ensure_a5_affinity_cpus(2, _a5_onboard_bins())
+
+        expected = tmp_path / "build/config/aicpu_affinity_plan.2.json"
+        assert calls and calls[0][-2:] == ["--out", str(expected)]
+        assert not expected.exists()
+        assert not expected.with_suffix(".cpus").exists()
+
+    def test_valid_plan_skips_auto_probe(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv(rtt_die_preflight.PLAN_ENV, raising=False)
+        plan = rtt_die_preflight.default_plan_path(1)
+        node = rtt_die_preflight.build_device_node_from_allowed(
+            soc_name="Ascend950PR_9599",
+            device_id=1,
+            allowed_cpus=[3, 4, 5, 6, 7],
+            occupy_cpus=[3, 4, 5, 6, 7, 8],
+        )
+        rtt_die_preflight.persist_device_plan(plan, soc_name="Ascend950PR_9599", device_id=1, device_node=node)
+
+        def unexpected_probe(*_args, **_kwargs):
+            raise AssertionError("valid plan should skip preflight")
+
+        monkeypatch.setattr(task_interface_module.subprocess, "run", unexpected_probe)
+        task_interface_module._ensure_a5_affinity_cpus(1, _a5_onboard_bins())
+
+    def test_timeout_record_skips_auto_probe(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv(rtt_die_preflight.PLAN_ENV, raising=False)
+        plan = rtt_die_preflight.default_plan_path(3)
+        rtt_die_preflight.write_timeout_record(plan, 3, reason="test")
+
+        def unexpected_probe(*_args, **_kwargs):
+            raise AssertionError("timeout record should skip preflight")
+
+        monkeypatch.setattr(task_interface_module.subprocess, "run", unexpected_probe)
+        task_interface_module._ensure_a5_affinity_cpus(3, _a5_onboard_bins())
+
+    def test_safety_budget_timeout_does_not_write_timeout_record(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv(rtt_die_preflight.PLAN_ENV, raising=False)
+
+        def timeout_probe(*_args, **_kwargs):
+            raise subprocess.TimeoutExpired(
+                "probe",
+                rtt_die_preflight.HELPER_BUILD_TIMEOUT_SECONDS + rtt_die_preflight.PREFLIGHT_TIMEOUT_SECONDS,
+            )
+
+        monkeypatch.setattr(task_interface_module.subprocess, "run", timeout_probe)
+        task_interface_module._ensure_a5_affinity_cpus(4, _a5_onboard_bins())
+        plan = rtt_die_preflight.default_plan_path(4)
+        assert not plan.with_suffix(".timeout").exists()
+
+    def test_cli_probe_timeout_record_is_honored(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv(rtt_die_preflight.PLAN_ENV, raising=False)
+        plan = rtt_die_preflight.default_plan_path(5)
+
+        def probe_writes_timeout(*_args, **_kwargs):
+            rtt_die_preflight.write_timeout_record(plan, 5, reason="preflight-timeout")
+            return SimpleNamespace(returncode=1, stdout="", stderr="device probe timed out")
+
+        monkeypatch.setattr(task_interface_module.subprocess, "run", probe_writes_timeout)
+        task_interface_module._ensure_a5_affinity_cpus(5, _a5_onboard_bins())
+        assert rtt_die_preflight.timeout_record_looks_usable(plan.with_suffix(".timeout"), 5)


### PR DESCRIPTION
## Summary

- Add the A5 full-pool affinity preflight: enumerate the authoritative user
  pool, elect the orchestrator with a 1000-iteration atomic-flag pairwise
  handshake, score non-orchestrator CPUs with 100 COND samples per core, and
  pack the result as logical `[S0,S1,S2,S3,O]` with S0/S1 on die0 and S2/S3 on
  die1.
- Honor `aicpu_thread_num` as the total active AICPU count. The RTT plan is
  consumed only for the exact four-scheduler plus one-orchestrator shape. Valid
  totals 2–4 are honored exactly, warn, and use contiguous OCCUPY-bit
  placement; auto mode shrinks the same way when fewer than five CPUs exist.
- Keep the physical launch count equal to `popcount(OCCUPY)` and reject pools
  outside the verified `[2,14]` range instead of clamping them.
- Prefer a complete driver/verified-JSON topology pool. If topology is
  unavailable or incomplete, retain serialized one-thread discovery but
  accept it only when it reproduces the complete OCCUPY set; partial sampling
  is a probe failure.
- Write independent per-device schema-v3 JSON/`.cpus` pairs, eliminating the
  shared-JSON lost-update race. Python bootstrap, CLI `--out`, and the C++
  consumer now derive the same exact paths, including base and `{device}`
  templates.
- Treat all automatic probe, measurement, and validation failures as
  non-persistent: no fallback file is created or replaced. Runtime warns and
  uses in-memory contiguous allocation instead.
- Strictly validate the runtime companion against schema, device, SoC, source,
  current OCCUPY, active count 5, and five unique in-range CPUs. Missing,
  duplicate, unknown, stale, or hardware-mismatched fields fall back safely;
  only valid hits are cached, keyed by hardware state and file identity.
- Make the packaged CLI backend configure/build from a wheel by passing the
  installed `_assets` root to CMake and resolving device link libraries under
  the CANN host-architecture directory.
- Use one shared balanced-contiguous cluster partition helper in the A5 TMR
  and HBG scheduler paths, and update the design/tool documentation to match
  the current v3 implementation.

## Placement invariant

`aicpu_thread_num` is distinct from the physical launch count. The former is
the active role count; the latter covers the whole OCCUPY pool so the device
affinity gate can retain the ordered active set. Scheduler `t` owns the
balanced contiguous cluster range `[t*N/A, (t+1)*N/A)`. With four schedulers,
the first two ranges cover die0 and the last two cover die1.

The explicit offline `--fallback-occupy` mode remains available as an
administrative write. It is never invoked automatically after probe failure.

## Test plan

- [x] Relevant Python unit tests: 147 passed.
- [x] New/updated A5 topology, active-count, side-plan, path, failure,
  rollback, and 28/36-cluster tests passed.
- [x] All no-hardware C++ tests in Debug configuration: 116/116 passed.
- [x] Editable package build completed, compiling the A5 TMR/HBG runtimes.
- [x] Built and installed a fresh wheel in an isolated virtual environment;
  both packaged host and cross-device CLI backends configured and built.
- [x] Staged pre-commit suite passed, including clang-format, clang-tidy,
  cpplint, markdownlint, ruff, and pyright.
- [ ] Onboard repeated-probe validation. The repository's known A5 precheck
  issue still uses an unsupported `npu-smi -c` option, so no device workload
  was launched in this change.
- [ ] Fresh PR CI.
