### PR TITLE
Refactor: make host_build_graph's includes say what each file uses

### DIFF
--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -8,47 +8,26 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
-#include <unistd.h>
-
 #include <atomic>
-#include <cinttypes>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#ifdef __linux__
-#include <sys/mman.h>
-#endif
 
-#include "aicpu/device_time.h"
 #include "aicpu/device_phase_aicpu.h"
-#include "callable_protocol.h"
-#include "dispatch_payload.h"
 #include "runtime.h"
 #include "spin_hint.h"
 
 // Runtime headers (full struct definition for create/destroy + SIMPLER_SCOPE)
 #include "host_build_graph/runtime_core.h"
-#include "host_build_graph/runtime_types.h"
 #include "host_build_graph/shared_memory.h"
 
-// Performance profiling headers
-#include "aicpu/chip_swimlane_collector_aicpu.h"
-#include "aicpu/args_dump_aicpu.h"
-#include "common/chip_swimlane_profiling.h"
 #include "common/unified_log.h"
 
 // Register-based communication
 #include "aicpu/platform_aicpu_affinity.h"
 #include "aicpu/platform_regs.h"
-#include "common/platform_config.h"
 #include "utils/thread_completion_gate.h"
-
-// Core type definitions
-#include "common/core_type.h"
-
-// CoreCallable for resolved dispatch address
-#include "callable.h"
 
 // Scheduler data structures (CoreExecState, CoreTracker, etc.)
 #include "scheduler/scheduler_types.h"

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -48,13 +48,12 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <unordered_map>
 #include <vector>
 
+#include "assert_compat.h"
 #include "host_build_graph/runtime_status.h"
-#include "host_build_graph/common.h"
 #include "host_build_graph/dep_gen_host_graph.h"
 #include "host_build_graph/graph_execution.h"
 #include "host_build_graph/host_tensor_access.h"
@@ -72,7 +71,7 @@
 #include "../../../../common/worker/runtime_c_api.h"
 #include "callable.h"
 #include "common/host_log_binding.h"
-#include "common/log_clock.h"
+#include "common/host_phase_kind.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "host_log.h"

--- a/src/a2a3/runtime/host_build_graph/orchestration/common.cpp
+++ b/src/a2a3/runtime/host_build_graph/orchestration/common.cpp
@@ -8,13 +8,13 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+#include "assert_compat.h"
 #include "host_build_graph/common.h"
 
 #ifdef __linux__
 #include <cxxabi.h>
 #include <dlfcn.h>
 #include <execinfo.h>
-#include <unistd.h>
 
 #include <array>
 #include <cstring>

--- a/src/a2a3/runtime/host_build_graph/orchestration/orchestration_api.h
+++ b/src/a2a3/runtime/host_build_graph/orchestration/orchestration_api.h
@@ -30,30 +30,22 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <array>
-#include <algorithm>
-#include <condition_variable>
 #include <cstring>
 #include <ctime>
 #include <functional>
-#include <mutex>
-#include <thread>
 #include <tuple>
 #include <type_traits>
-#include <utility>
-#include <vector>
 
 // Type headers needed by orchestration
-#include "host_build_graph/common.h"            // framework_bind_runtime / framework_current_runtime
-#include "common/host_phase_kind.h"             // HostPhaseKind, for the phase records below
-#include "host_build_graph/graph_cache.h"       // Graph Execution key and result helpers
-#include "host_build_graph/graph_host_state.h"  // GRAPH_MAX_DEFINITIONS
-#include "host_build_graph/runtime_ops.h"       // RuntimeOps, RuntimeContext forward declaration
-#include "host_build_graph/runtime_types.h"     // SIMPLER_ERROR_*
-#include "host_build_graph/submit_types.h"      // MixedKernels, INVALID_KERNEL_ID, subtask slots
-#include "types.h"                              // Arg, TaskOutputTensors, TensorArgType
-#include "task_args.h"                          // ChipStorageTaskArgs, simpler::hbg::Tensor
-#include "tensor.h"                             // simpler::hbg::Tensor, TensorCreateInfo
+#include "assert_compat.h"                    // debug_assert
+#include "host_build_graph/common.h"          // framework_bind_runtime / framework_current_runtime
+#include "common/host_phase_kind.h"           // HostPhaseKind, for the phase records below
+#include "host_build_graph/graph_cache.h"     // Graph Execution key and result helpers
+#include "host_build_graph/runtime_ops.h"     // RuntimeOps, RuntimeContext forward declaration
+#include "host_build_graph/runtime_status.h"  // SIMPLER_ERROR_*
+#include "host_build_graph/submit_types.h"    // MixedKernels, INVALID_KERNEL_ID, subtask slots
+#include "types.h"                            // Arg, TaskOutputTensors, TensorArgType
+#include "tensor.h"                           // simpler::hbg::Tensor, TensorCreateInfo
 
 // =============================================================================
 // simpler::hbg::Tensor Factory Helpers

--- a/src/a2a3/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
@@ -14,7 +14,6 @@
 #include <atomic>
 #include <cstdint>
 
-#include "aicore_completion_mailbox_types.h"
 #include "host_build_graph/constants.h"
 #include "host_build_graph/task_id.h"
 

--- a/src/a2a3/runtime/host_build_graph/runtime/async_wait.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/async_wait.h
@@ -12,14 +12,13 @@
 #pragma once
 
 #include <atomic>
-#include <cstddef>
 #include <cstdint>
 
-#include "aicpu/platform_regs.h"
 #include "backend/sdma/sdma_completion_scheduler.h"
-#include "intrinsic.h"
 #include "aicore_completion_mailbox.h"
+#include "aicore_completion_mailbox_types.h"
 #include "host_build_graph/completion_token.h"
+#include "host_build_graph/runtime_status.h"
 #include "host_build_graph/runtime_types.h"
 
 struct SchedulerState;

--- a/src/a2a3/runtime/host_build_graph/runtime/backend/sdma/sdma_completion_scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/backend/sdma/sdma_completion_scheduler.h
@@ -11,12 +11,11 @@
 
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 
-#include "aicpu/platform_regs.h"
-#include "aicore_completion_mailbox.h"
+#include "aicpu/cache_maintenance.h"
 #include "host_build_graph/completion_token.h"
+#include "host_build_graph/constants.h"
 #include "host_build_graph/runtime_status.h"
 
 inline uintptr_t sdma_completion_cache_line(const volatile void *addr) {

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -34,18 +34,23 @@
 
 #include <atomic>
 
-#include "common/core_type.h"
 #include "common/memory_barrier.h"
 #include "utils/device_arena.h"
 #include "aicpu/platform_regs.h"  // get_reg_ptr / RegId for the early-dispatch doorbell
 #include "async_wait.h"
 #include "host_build_graph/graph_execution.h"
 #include "host_build_graph/task_id.h"
-#include "host_build_graph/task_allocator.h"
+#include "host_build_graph/runtime_status.h"
 #include "host_build_graph/runtime_types.h"
 #include "host_build_graph/shared_memory.h"
+// Defines the SIMPLER_*_PROFILING levels the conditionals below test. An #if on an
+// undefined macro evaluates to 0, so a profiling block reached through a transitive
+// include would switch itself off silently if that path ever went away.
+#include "profiling_config.h"
 
-#include "aicpu/device_time.h"  // get_sys_cnt_aicpu (used by early-dispatch doorbell timing too)
+#if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
+#include "aicpu/device_time.h"  // get_sys_cnt_aicpu, used only by the timed blocks below
+#endif
 #if SIMPLER_SCHED_PROFILING
 #define SCHED_CYCLE_START() uint64_t _st0 = get_sys_cnt_aicpu(), _st1
 #define SCHED_CYCLE_LAP(acc)        \

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -13,6 +13,7 @@
 #include <cinttypes>
 #include <cstdio>
 
+#include "assert_compat.h"
 #include "common/unified_log.h"
 #include "aicpu/device_time.h"
 #include "aicpu/chip_swimlane_collector_aicpu.h"
@@ -22,6 +23,7 @@
 #include "common/memory_barrier.h"
 #include "common/chip_swimlane_profiling.h"
 #include "common/platform_config.h"
+#include "host_build_graph/runtime_status.h"
 #include "host_build_graph/runtime_core.h"
 #include "host_build_graph/shared_memory.h"
 #include "runtime.h"

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -10,14 +10,12 @@
  */
 #include "scheduler_context.h"
 
-#include <algorithm>
-
 #include "common/unified_log.h"
 #include "aicpu/device_time.h"
-#include "aicpu/platform_regs.h"
 #include "common/chip_swimlane_profiling.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
+#include "host_build_graph/runtime_status.h"
 #include "host_build_graph/runtime_core.h"
 #include "runtime.h"
 #include "spin_hint.h"

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 
+#include "assert_compat.h"
 #include "aicpu/device_phase_aicpu.h"
 #include "aicpu/platform_regs.h"
 #include "common/chip_swimlane_profiling.h"
@@ -19,7 +20,6 @@
 
 #include "scheduler/scheduler.h"
 
-#include "aicore_completion_mailbox.h"
 #include "dispatch_payload.h"
 
 // runtime.h cannot be included here — it pulls in Handshake, which this header

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -14,17 +14,18 @@
 #include <cinttypes>
 #include <limits>
 
-#include "host_build_graph/common.h"  // debug_assert
+#include "assert_compat.h"  // debug_assert
+#include "host_build_graph/common.h"
 
 #include "common/unified_log.h"
 #include "aicpu/aicpu_device_config.h"
 #include "aicpu/device_time.h"
-#include "aicpu/platform_regs.h"
 #include "callable.h"
 #include "common/chip_swimlane_profiling.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "host_build_graph/async_poll_phase_accumulator.h"
+#include "host_build_graph/runtime_status.h"
 #include "host_build_graph/runtime_core.h"
 #include "runtime.h"
 #include "spin_hint.h"

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "assert_compat.h"
 #include "common/core_type.h"
 #include "common/platform_config.h"
 #include "host_build_graph/runtime_types.h"

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -8,29 +8,21 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
-#include <unistd.h>
-
 #include <atomic>
-#include <algorithm>
 #include <cinttypes>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#ifdef __linux__
-#include <sys/mman.h>
-#endif
 
 #include "aicore_lifecycle.h"
 #include "aicore_scheduler_error.h"
 #include "aicore_scheduler_state.h"
 #include "aicpu/aicpu_device_config.h"
 #include "aicpu/cache_maintenance.h"
-#include "aicpu/args_dump_aicpu.h"
 #include "aicpu/chip_swimlane_collector_aicpu.h"
 #include "aicpu/device_phase_aicpu.h"
 #include "aicpu/device_time.h"
-#include "aicpu/pmu_collector_aicpu.h"
 #include "host_build_graph/runtime_status.h"
 #include "host_build_graph/shared_memory.h"
 #include "runtime.h"

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -50,13 +50,12 @@
 #include <mutex>
 #include <optional>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <unordered_map>
 #include <vector>
 
+#include "assert_compat.h"
 #include "host_build_graph/runtime_status.h"
-#include "host_build_graph/common.h"
 #include "host_build_graph/dep_gen_host_graph.h"
 #include "host_build_graph/graph_execution.h"
 #include "scheduler/scheduler_graph.h"
@@ -76,7 +75,7 @@
 #include "../../../../common/worker/runtime_c_api.h"
 #include "callable.h"
 #include "common/host_log_binding.h"
-#include "common/log_clock.h"
+#include "common/host_phase_kind.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "host_log.h"

--- a/src/a5/runtime/host_build_graph/orchestration/common.cpp
+++ b/src/a5/runtime/host_build_graph/orchestration/common.cpp
@@ -8,13 +8,13 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+#include "assert_compat.h"
 #include "host_build_graph/common.h"
 
 #ifdef __linux__
 #include <cxxabi.h>
 #include <dlfcn.h>
 #include <execinfo.h>
-#include <unistd.h>
 
 #include <array>
 #include <cstring>

--- a/src/a5/runtime/host_build_graph/orchestration/orchestration_api.h
+++ b/src/a5/runtime/host_build_graph/orchestration/orchestration_api.h
@@ -30,30 +30,22 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <array>
-#include <algorithm>
-#include <condition_variable>
 #include <cstring>
 #include <ctime>
 #include <functional>
-#include <mutex>
-#include <thread>
 #include <tuple>
 #include <type_traits>
-#include <utility>
-#include <vector>
 
 // Type headers needed by orchestration
-#include "host_build_graph/common.h"            // framework_bind_runtime / framework_current_runtime
-#include "common/host_phase_kind.h"             // HostPhaseKind, for the phase records below
-#include "host_build_graph/graph_cache.h"       // Graph Execution key and result helpers
-#include "host_build_graph/graph_host_state.h"  // GRAPH_MAX_DEFINITIONS
-#include "host_build_graph/runtime_ops.h"       // RuntimeOps, RuntimeContext forward declaration
-#include "host_build_graph/runtime_types.h"     // SIMPLER_ERROR_*
-#include "host_build_graph/submit_types.h"      // MixedKernels, INVALID_KERNEL_ID, subtask slots
-#include "types.h"                              // Arg, TaskOutputTensors, TensorArgType
-#include "task_args.h"                          // ChipStorageTaskArgs, simpler::hbg::Tensor
-#include "tensor.h"                             // simpler::hbg::Tensor, TensorCreateInfo
+#include "assert_compat.h"                    // debug_assert
+#include "host_build_graph/common.h"          // framework_bind_runtime / framework_current_runtime
+#include "common/host_phase_kind.h"           // HostPhaseKind, for the phase records below
+#include "host_build_graph/graph_cache.h"     // Graph Execution key and result helpers
+#include "host_build_graph/runtime_ops.h"     // RuntimeOps, RuntimeContext forward declaration
+#include "host_build_graph/runtime_status.h"  // SIMPLER_ERROR_*
+#include "host_build_graph/submit_types.h"    // MixedKernels, INVALID_KERNEL_ID, subtask slots
+#include "types.h"                            // Arg, TaskOutputTensors, TensorArgType
+#include "tensor.h"                           // simpler::hbg::Tensor, TensorCreateInfo
 
 // =============================================================================
 // simpler::hbg::Tensor Factory Helpers

--- a/src/a5/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
+++ b/src/a5/runtime/host_build_graph/runtime/aicore_completion_mailbox.h
@@ -14,7 +14,6 @@
 #include <atomic>
 #include <cstdint>
 
-#include "aicore_completion_mailbox_types.h"
 #include "host_build_graph/constants.h"
 #include "host_build_graph/task_id.h"
 

--- a/src/a5/runtime/host_build_graph/runtime/async_wait.h
+++ b/src/a5/runtime/host_build_graph/runtime/async_wait.h
@@ -12,14 +12,13 @@
 #pragma once
 
 #include <atomic>
-#include <cstddef>
 #include <cstdint>
 
-#include "aicpu/platform_regs.h"
 #include "backend/sdma/sdma_completion_scheduler.h"
-#include "intrinsic.h"
 #include "aicore_completion_mailbox.h"
+#include "aicore_completion_mailbox_types.h"
 #include "host_build_graph/completion_token.h"
+#include "host_build_graph/runtime_status.h"
 #include "host_build_graph/runtime_types.h"
 
 struct SchedulerState;

--- a/src/a5/runtime/host_build_graph/runtime/backend/sdma/sdma_completion_scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/backend/sdma/sdma_completion_scheduler.h
@@ -11,11 +11,8 @@
 
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 
-#include "aicpu/platform_regs.h"
-#include "aicore_completion_mailbox.h"
 #include "host_build_graph/completion_token.h"
 #include "host_build_graph/runtime_status.h"
 

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -34,19 +34,24 @@
 
 #include <atomic>
 
-#include "common/core_type.h"
 #include "common/memory_barrier.h"
 #include "utils/device_arena.h"
 #include "aicpu/platform_regs.h"  // get_reg_ptr / RegId for the early-dispatch doorbell
 #include "async_wait.h"
 #include "host_build_graph/graph_execution.h"
 #include "host_build_graph/task_id.h"
-#include "host_build_graph/task_allocator.h"
+#include "host_build_graph/runtime_status.h"
 #include "host_build_graph/runtime_types.h"
 #include "host_build_graph/shared_memory.h"
 #include "scheduler_graph.h"
+// Defines the SIMPLER_*_PROFILING levels the conditionals below test. An #if on an
+// undefined macro evaluates to 0, so a profiling block reached through a transitive
+// include would switch itself off silently if that path ever went away.
+#include "profiling_config.h"
 
-#include "aicpu/device_time.h"  // get_sys_cnt_aicpu (used by early-dispatch doorbell timing too)
+#if SIMPLER_ORCH_PROFILING || SIMPLER_SCHED_PROFILING
+#include "aicpu/device_time.h"  // get_sys_cnt_aicpu, used only by the timed blocks below
+#endif
 
 // scheduler_graph.h states the storage layout as literals, because the AICore .o
 // that reads it cannot include runtime_types.h. This translation unit sees both,

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -13,6 +13,7 @@
 #include <cinttypes>
 #include <cstdio>
 
+#include "assert_compat.h"
 #include "common/unified_log.h"
 #include "aicpu/device_time.h"
 #include "aicpu/chip_swimlane_collector_aicpu.h"
@@ -22,6 +23,7 @@
 #include "common/memory_barrier.h"
 #include "common/chip_swimlane_profiling.h"
 #include "common/platform_config.h"
+#include "host_build_graph/runtime_status.h"
 #include "host_build_graph/runtime_core.h"
 #include "host_build_graph/shared_memory.h"
 #include "runtime.h"

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -10,14 +10,12 @@
  */
 #include "scheduler_context.h"
 
-#include <algorithm>
-
 #include "common/unified_log.h"
 #include "aicpu/device_time.h"
-#include "aicpu/platform_regs.h"
 #include "common/chip_swimlane_profiling.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
+#include "host_build_graph/runtime_status.h"
 #include "host_build_graph/runtime_core.h"
 #include "runtime.h"
 #include "spin_hint.h"

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 
+#include "assert_compat.h"
 #include "aicpu/device_phase_aicpu.h"
 #include "aicpu/platform_regs.h"
 #include "common/chip_swimlane_profiling.h"
@@ -19,7 +20,6 @@
 
 #include "scheduler/scheduler.h"
 
-#include "aicore_completion_mailbox.h"
 #include "dispatch_payload.h"
 
 // runtime.h cannot be included here — it pulls in Handshake, which this header

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -14,17 +14,18 @@
 #include <cinttypes>
 #include <limits>
 
-#include "host_build_graph/common.h"  // debug_assert
+#include "assert_compat.h"  // debug_assert
+#include "host_build_graph/common.h"
 
 #include "common/unified_log.h"
 #include "aicpu/aicpu_device_config.h"
 #include "aicpu/device_time.h"
-#include "aicpu/platform_regs.h"
 #include "callable.h"
 #include "common/chip_swimlane_profiling.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "host_build_graph/async_poll_phase_accumulator.h"
+#include "host_build_graph/runtime_status.h"
 #include "host_build_graph/runtime_core.h"
 #include "runtime.h"
 #include "spin_hint.h"

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "assert_compat.h"
 #include "common/core_type.h"
 #include "common/platform_config.h"
 #include "dispatch_payload.h"

--- a/src/common/host_build_graph/common.h
+++ b/src/common/host_build_graph/common.h
@@ -11,15 +11,7 @@
 
 #pragma once
 
-#include <stdio.h>
 #include <stdlib.h>
-
-// Assertion macros (always_assert / debug_assert), AssertionError, and the
-// MAYBE_UNINITIALIZED diagnostics live in the shared header so the unified
-// simpler::hbg::Tensor (src/common/task_interface/tensor.h) can use them without depending
-// on this runtime-specific header. assert_impl / get_stacktrace are defined in
-// orchestration/common.cpp for runtime targets.
-#include "assert_compat.h"
 
 // Framework-internal TLS bridge. The executor binds the current thread's
 // runtime before invoking the orchestration entry, so orchestration helpers can

--- a/src/common/host_build_graph/completion_token.h
+++ b/src/common/host_build_graph/completion_token.h
@@ -13,7 +13,6 @@
 
 #include <stdint.h>
 
-#include "aicore_completion_mailbox_types.h"
 #include "host_build_graph/runtime_status.h"
 
 // CompletionToken is the runtime-internal POD that backend submit handlers

--- a/src/common/host_build_graph/dep_gen_host_graph.h
+++ b/src/common/host_build_graph/dep_gen_host_graph.h
@@ -58,7 +58,6 @@
 
 #include <cstdint>
 
-#include "host_build_graph/task_id.h"
 #include "host_build_graph/tensormap.h"
 #include "host_build_graph/types.h"  // TensorRef
 #include "tensor.h"

--- a/src/common/host_build_graph/device/graph_execution.cpp
+++ b/src/common/host_build_graph/device/graph_execution.cpp
@@ -13,9 +13,7 @@
 
 #include <algorithm>
 #include <cstring>
-#include <new>
 
-#include "graph_cache.h"
 #include "host_build_graph/task_id.h"
 
 namespace {

--- a/src/common/host_build_graph/host/graph_recorder_pool.cpp
+++ b/src/common/host_build_graph/host/graph_recorder_pool.cpp
@@ -13,7 +13,6 @@
 #include <functional>
 #include <utility>
 
-#include "graph_host_state.h"
 // The ops implementations below need the full RuntimeContext, which is why the
 // header does not include this: a translation unit cannot see both it and
 // orchestration_api.h's partial definition.

--- a/src/common/host_build_graph/host/host_phase_trace.cpp
+++ b/src/common/host_build_graph/host/host_phase_trace.cpp
@@ -21,13 +21,19 @@
 #include <atomic>
 #include <array>
 #include <cstdlib>
-#include <functional>
 #include <mutex>
-#include <thread>
 
 #if defined(__linux__)
 #include <sys/syscall.h>
 #include <unistd.h>
+#endif
+
+// The thread-id fallback below runs only where SYS_gettid is unavailable, and it is
+// the sole user of these two. SYS_gettid comes from <sys/syscall.h>, so this test
+// has to follow that include.
+#if !(defined(__linux__) && defined(SYS_gettid))
+#include <functional>
+#include <thread>
 #endif
 
 #include "common/host_api.h"

--- a/src/common/host_build_graph/host/orchestrator.cpp
+++ b/src/common/host_build_graph/host/orchestrator.cpp
@@ -43,8 +43,8 @@
 #include <utility>
 #include <vector>
 
+#include "assert_compat.h"
 #include "common/host_phase_kind.h"
-#include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "host_build_graph/dep_gen_host_graph.h"
 #include "host_build_graph/dep_compute.h"
@@ -52,6 +52,7 @@
 #include "graph_execution.h"
 #include "graph_host_state.h"
 #include "host_build_graph/task_id.h"
+#include "host_build_graph/runtime_status.h"
 #include "host_build_graph/runtime_types.h"
 #include "host_build_graph/shared_memory.h"
 #include "host_build_graph/tensormap.h"

--- a/src/common/host_build_graph/host/runtime_core.cpp
+++ b/src/common/host_build_graph/host/runtime_core.cpp
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 
 #include "common/unified_log.h"
+#include "host_build_graph/runtime_status.h"
 #include "host_build_graph/host_tensor_access.h"
 #include "host_build_graph/task_id.h"
 

--- a/src/common/host_build_graph/host/tensormap.cpp
+++ b/src/common/host_build_graph/host/tensormap.cpp
@@ -27,12 +27,12 @@
 #include "host_build_graph/tensormap.h"
 
 #include <stdlib.h>
-#include <string.h>
 
 #include <new>
 
-#include "host_build_graph/common.h"
+#include "assert_compat.h"
 #include "common/unified_log.h"
+#include "host_build_graph/runtime_types.h"
 
 // =============================================================================
 // TensorMap Lookup Chain Length Statistics (compile-time toggle)

--- a/src/common/host_build_graph/orchestrator.h
+++ b/src/common/host_build_graph/orchestrator.h
@@ -31,9 +31,9 @@
 #include <memory>
 #include <type_traits>
 
-#include "common/chip_swimlane_profiling.h"
 #include "host_build_graph/task_allocator.h"
 #include "graph_cache.h"
+#include "host_build_graph/runtime_status.h"
 #include "host_build_graph/runtime_types.h"
 #include "host_build_graph/submit_types.h"
 #include "host_build_graph/shared_memory.h"

--- a/src/common/host_build_graph/runtime.h
+++ b/src/common/host_build_graph/runtime.h
@@ -30,16 +30,12 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdio.h>   // for fprintf, printf
-#include <string.h>  // for memset
 
 #include <vector>
 
 #include "common/core_type.h"
-#include "common/chip_swimlane_profiling.h"
 #include "common/platform_config.h"
 #include "aicpu/platform_aicpu_affinity.h"  // MAX_GATE_THREADS (aicpu_allowed_cpus bound)
-#include "dispatch_payload.h"
 #include "task_args.h"
 #include "host_build_graph/entry_args.h"  // EntryArgsStorage
 

--- a/src/common/host_build_graph/runtime_core.h
+++ b/src/common/host_build_graph/runtime_core.h
@@ -37,13 +37,8 @@
 #include <type_traits>
 
 #include "utils/device_arena.h"
-#include "host_build_graph/runtime_types.h"
-#include "graph_cache.h"
 #include "host_build_graph/runtime_ops.h"
-#include "host_build_graph/submit_types.h"
 #include "host_build_graph/shared_memory.h"
-#include "host_build_graph/task_allocator.h"
-#include "host_build_graph/tensormap.h"
 #include "scheduler/scheduler.h"
 #include "host_build_graph/orchestrator.h"
 #include "aicore_completion_mailbox.h"

--- a/src/common/host_build_graph/runtime_types.h
+++ b/src/common/host_build_graph/runtime_types.h
@@ -32,17 +32,22 @@
 #include <cstddef>
 #include <type_traits>
 
+#include "assert_compat.h"
+// Defines SIMPLER_DFX and the SIMPLER_*_PROFILING levels the conditionals in this
+// header test, so it has to precede them rather than sit inside one: an #if on an
+// undefined macro evaluates to 0, and a profiling block guarded that way would
+// switch itself off and report nothing. A macro named only in a preprocessor
+// condition is not a reference an include-cleaner can see, so this include reads
+// as unused to those tools.
 #include "profiling_config.h"
 #include "host_build_graph/constants.h"
-#include "host_build_graph/runtime_status.h"
 // NOTE (host_build_graph divergence from tensormap_and_ringbuffer): the
 // dispatch_payload.h include is intentionally dropped here. This header is
 // reached by a path-qualified include, and dispatch_payload.h uses #pragma once
 // (path-keyed), so leaving it in double-defines DispatchPayload against
 // tensormap_and_ringbuffer's copy inside the shared host-dispatcher TU.
-// runtime_types.h never references DispatchPayload itself; consumers that
-// need it include it via runtime.h directly.
-#include "aicore_completion_mailbox.h"
+// runtime_types.h never references DispatchPayload itself; the consumers that
+// need it include dispatch_payload.h directly.
 #include "common/args_dump_task_metadata.h"
 #include "host_build_graph/self_relative_ptr.h"
 #include "host_build_graph/submit_types.h"

--- a/src/common/host_build_graph/shared/runtime.cpp
+++ b/src/common/host_build_graph/shared/runtime.cpp
@@ -17,9 +17,9 @@
 
 #include "host_build_graph/runtime.h"
 
+#include <cstring>
+
 #include "common/unified_log.h"
-#include "host_build_graph/runtime_types.h"
-#include "host_build_graph/shared_memory.h"
 
 // =============================================================================
 // Constructor
@@ -27,11 +27,11 @@
 
 Runtime::Runtime() {
     // Initialize handshake buffers
-    memset(workers, 0, sizeof(workers));
+    std::memset(workers, 0, sizeof(workers));
     worker_count = 0;
     aicpu_thread_num = 1;
     ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
-    memset(aicpu_allowed_cpus, 0, sizeof(aicpu_allowed_cpus));
+    std::memset(aicpu_allowed_cpus, 0, sizeof(aicpu_allowed_cpus));
     aicpu_allowed_cpu_count = 0;
     aicpu_launch_count = 0;
     host_total_tasks = 0;

--- a/src/common/host_build_graph/shared/shared_memory.cpp
+++ b/src/common/host_build_graph/shared/shared_memory.cpp
@@ -21,7 +21,7 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
-#include "common/unified_log.h"
+#include "host_build_graph/runtime_status.h"
 
 // =============================================================================
 // Size Calculation

--- a/src/common/host_build_graph/shared_memory.h
+++ b/src/common/host_build_graph/shared_memory.h
@@ -37,6 +37,7 @@
 
 #include <cstring>
 
+#include "assert_compat.h"
 #include "utils/device_arena.h"
 #include "graph_execution.h"
 #include "host_build_graph/runtime_types.h"

--- a/src/common/host_build_graph/task_allocator.h
+++ b/src/common/host_build_graph/task_allocator.h
@@ -20,13 +20,12 @@
 
 #pragma once
 
-#include <algorithm>
 #include <atomic>
 #include <inttypes.h>
-#include <type_traits>
 
+#include "assert_compat.h"
+#include "host_build_graph/runtime_status.h"
 #include "host_build_graph/runtime_types.h"
-#include "host_build_graph/shared_memory.h"
 #include "common/unified_log.h"
 
 // =============================================================================

--- a/src/common/host_build_graph/tensor.h
+++ b/src/common/host_build_graph/tensor.h
@@ -15,7 +15,6 @@
 
 #pragma once
 
-#include <memory.h>
 #include <stdint.h>
 
 #include <algorithm>
@@ -27,7 +26,6 @@
 #include "assert_compat.h"
 #include "data_type.h"
 #include "host_build_graph/task_id.h"
-#include "task_interface/arg_direction.h"
 #include "task_interface/tensor.h"
 
 namespace simpler::hbg {

--- a/src/common/host_build_graph/tensor_create_info.h
+++ b/src/common/host_build_graph/tensor_create_info.h
@@ -26,9 +26,9 @@
 #pragma once
 
 #include <cstring>
-#include <memory.h>
 #include <stdint.h>
 
+#include "assert_compat.h"
 #include "data_type.h"
 #include "tensor.h"
 

--- a/src/common/host_build_graph/tensormap.h
+++ b/src/common/host_build_graph/tensormap.h
@@ -49,10 +49,10 @@
 
 #include <memory>
 
-#include "host_build_graph/common.h"
+#include "assert_compat.h"
 #include "host_build_graph/task_id.h"
+#include "host_build_graph/tensor_create_info.h"
 #include "profiling_config.h"
-#include "host_build_graph/runtime_types.h"
 #include "tensor.h"
 
 // Overlap geometry types. Relocated here from tensor.h: they are used only by

--- a/src/common/host_build_graph/types.h
+++ b/src/common/host_build_graph/types.h
@@ -37,6 +37,7 @@
 #include <arm_neon.h>
 #endif
 
+#include "assert_compat.h"
 #include "aicpu/dump_arg_selection.h"
 #include "common/device_phase.h"
 #include "data_type.h"

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -22,6 +22,8 @@
 #include <utility>
 #include <vector>
 
+#include "host_build_graph/runtime_status.h"
+
 #include "graph_cache.h"
 #include "graph_execution.h"
 #include "runtime_status/error_names.h"


### PR DESCRIPTION
Every translation unit and header under `host_build_graph` now includes what it uses and nothing else, so a reader can tell a file's dependencies from its include block instead of following a chain of headers that happened to carry something along.

**105 includes removed, 51 added** — a net 54 fewer — where the using file had been relying on a transitive path.

## Three headers had become unofficial hubs

`runtime_types.h` carried `runtime_status.h` and `aicore_completion_mailbox.h`; `common.h` carried `assert_compat.h`; and `runtime.h` carried `<stdio.h>` and `<string.h>` under comments that named symbols — *"for fprintf, printf"*, *"for memset"* — `runtime.h` itself never uses. None of the three used what it carried; consumers did, without naming it. All are gone, and the files reaching `SIMPLER_ERROR_*`, `always_assert`, `debug_assert` and `std::memset` through them now include those headers directly.

Same shape at smaller scale: `tensormap.h` takes `tensor_create_info.h`, `async_wait.h` takes `aicore_completion_mailbox_types.h`, `runtime_maker.cpp` takes `host_phase_kind.h`, `sdma_completion_scheduler.h` takes `constants.h` and `cache_maintenance.h`.

## One include moves inside its conditional, one moves ahead of it

`scheduler.h`'s `aicpu/device_time.h`: all eight uses of `get_sys_cnt_aicpu` sit inside `SIMPLER_*_PROFILING` blocks, so an unconditional include claimed a dependency the file only has when timing is compiled in. Its comment also claimed early-dispatch doorbell timing used it, which no call site does.

The same file now includes `profiling_config.h` *ahead* of that conditional rather than receiving the levels through `runtime_types.h`. The order happens to work today, but an `#if` on an undefined macro evaluates to 0 — so a profiling block that reaches its levels transitively switches itself off silently the day someone tidies the header it came through. That is the failure mode the table below exists to avoid, and the file was subject to it.

## Four kinds kept despite the tooling saying otherwise

A pass with clang-tidy's `misc-include-cleaner` produced the candidate list, but it reads several correct includes as unused. Each of these was confirmed by deleting it and watching the build:

| header | what the tool cannot see |
|---|---|
| `profiling_config.h` ×5 | supplies the macros the `#if` conditions test — putting it *inside* one would make the condition evaluate to 0 and **silently disable the feature** |
| `runtime_core.h` in `scheduler_cold_path.cpp` ×2 | `rt->scheduler` needs the complete `RuntimeContext`; the tool finds a forward declaration first and stops |
| `aicore.h` + `aicore_profiling_state.h` | AICore builtins (`read_reg`, `get_physical_core_id`, ...) a host-side parser cannot resolve |
| two pto `async .hpp` | same — `pto::comm::sdma::detail::*` behind `__ubuf__` types |

## Why four build configurations

A header that only matters inside `#if SIMPLER_DFX` or a profiling block is invisible to a single build — deleting it passes, and the breakage only appears when someone turns that flag on. So every batch was checked against **default, `SIMPLER_ORCH_PROFILING`, `SIMPLER_SCHED_PROFILING` and `SIMPLER_DFX=0`**, across both architectures and both platform variants.

That is also why "the build passed" was not treated as evidence of completeness: a *missed* include leaves the build green by definition. Completeness came from re-running the scan until it reported nothing but the known exceptions.

## Test

- 4 profiling configurations × 4 platforms (a2a3/a5 × sim/onboard), zero warnings; `tensormap_and_ringbuffer` rebuilt on all 4 platforms to confirm the shared headers are unaffected
- `ctest`: 128/128
- Scene tests: a2a3sim 10 passed, a5sim 13 passed — the only thing that exercises the orchestration `.so`, which the `orchestration_api.h` changes reach

Rebased onto #2090, which rewrote `a5`'s `aicpu_executor.cpp`. Every include this PR had removed from that file was re-checked against the new code: `<cinttypes>` (`PRIu64`), `aicpu/device_time.h`, `chip_swimlane_collector_aicpu.h`, `platform_regs.h` and `platform_config.h` are now genuinely used and stay; `<unistd.h>`, `<algorithm>`, `sys/mman.h`, `args_dump_aicpu.h` and `pmu_collector_aicpu.h` are not and are removed.

Split out of #2098, which keeps the two behavioural changes it was mixed with.
