### PR TITLE
feat(dfx): profile A5 HBG AICore scheduler

### DIFF
--- a/.github/workflows/_st-sim-a5.yml
+++ b/.github/workflows/_st-sim-a5.yml
@@ -116,7 +116,19 @@ jobs:
       - name: chip_swimlane smoke (a5 host_build_graph)
         if: inputs.include_dfx_smokes
         run: |
-          .venv/bin/python -m pytest tests/st/a5/host_build_graph/dfx/chip_swimlane/ \
+          for level in 1 2; do
+            .venv/bin/python -m pytest \
+              tests/st/a5/host_build_graph/dfx/chip_swimlane/test_scheduler_phases.py \
+              --case TestSchedulerPhases::resolve_dummy \
+              --platform a5sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
+              --require-pto-isa --manual "${{ inputs.manual_mode == 'only' && 'only' || 'include' }}" \
+              --enable-chip-swimlane "$level"
+          done
+          .venv/bin/python -m pytest \
+            tests/st/a5/host_build_graph/dfx/chip_swimlane/test_scheduler_phases.py \
+            tests/st/a5/host_build_graph/single_core_dag/test_single_core_dag.py \
+            --case TestSchedulerPhases::resolve_dummy \
+            --case TestHbgSingleCoreDag::mixed_multi_root_64 \
             --platform a5sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
             --require-pto-isa --manual "${{ inputs.manual_mode == 'only' && 'only' || 'include' }}" \
             --enable-chip-swimlane 3

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -178,83 +178,46 @@ publish_worker_stats(__gm__ SchedulerWorkerContext *context, const SchedulerWork
     scheduler_gm_publish(context->bootstrap_ready_claim_aiv_cycles, stats.bootstrap_ready_claim_cycles[1]);
 }
 
-__aicore__ __attribute__((always_inline)) void commit_task_trace(
-    __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context, const SchedulerExecutionRecord &record,
-    uint64_t ready_scan_start, uint64_t ready_observe, uint64_t kernel_start, uint64_t kernel_end,
-    uint64_t completion_end, uint64_t bookkeeping_end, uint64_t previous_trace_commit_end, uint64_t aicore_entry_cycles,
-    uint64_t handshake_publish_cycles, uint64_t register_release_cycles, uint64_t descriptor_cache_observed_cycles,
-    uint64_t completion_id, uint64_t completion_inbox_index, const SchedulerInterTaskTiming &inter_task_timing
+// Keep the pre-kernel timestamps out of the indirect kernel call's live set.
+// Inlining this path makes the resident loop spill enough state to fault on A5.
+__aicore__ __attribute__((noinline)) void stage_task_trace_before_execution(
+    __gm__ SchedulerDispatchSlot *slot, uint64_t ready_scan_start, uint64_t ready_observe, uint64_t completion_id,
+    uint64_t completion_inbox_index, bool phase_timing_enabled
 ) {
-    __gm__ SchedulerTaskTrace *cells =
-        scheduler_state_at<SchedulerTaskTrace>(scheduler_state_base, context->trace_cells_offset);
-    __gm__ SchedulerTaskTrace *trace = &cells[record.task_id];
-    trace->ready_source = static_cast<uint64_t>(record.ready_source);
-    trace->worker_id = context->worker_index;
-    trace->task_id = static_cast<uint64_t>(record.task_id);
-    trace->claim_worker_id = record.claim_worker_id;
-    trace->claim_start_cycles = record.claim_start_cycles;
-    trace->claim_end_cycles = record.claim_end_cycles;
-    trace->previous_trace_commit_end_cycles = previous_trace_commit_end;
-    trace->kernel_start_cycles = kernel_start;
-    trace->kernel_end_cycles = kernel_end;
-    trace->completion_end_cycles = completion_end;
-    trace->ready_scan_start_cycles = ready_scan_start;
-    trace->ready_observe_cycles = ready_observe;
-    trace->completion_bookkeeping_end_cycles = bookkeeping_end;
-    trace->completion_id = completion_id;
-    trace->completion_inbox_index = completion_inbox_index;
-    scheduler_observe_cache_line(&trace->ready_transition_cycles);
-    trace->inter_task_completion_service_cycles = inter_task_timing.completion_service_cycles;
-    trace->inter_task_dispatch_aic_cycles = inter_task_timing.dispatch_cycles[0];
-    trace->inter_task_dispatch_aiv_cycles = inter_task_timing.dispatch_cycles[1];
-    trace->inter_task_ready_poll_cycles = inter_task_timing.ready_poll_cycles;
-    trace->inter_task_backoff_cycles = inter_task_timing.backoff_cycles;
-    trace->inter_task_completion_scan_cycles = inter_task_timing.completion.scan_cycles;
-    trace->inter_task_completion_consume_cycles = inter_task_timing.completion.consume_cycles;
-    trace->inter_task_completion_resolve_cycles = inter_task_timing.completion.resolve_cycles;
-    trace->inter_task_completion_ready_publish_cycles = inter_task_timing.completion.ready_publish_cycles;
-    trace->inter_task_completion_refill_cycles = inter_task_timing.completion.refill_cycles;
-    trace->inter_task_completion_finalize_cycles = inter_task_timing.completion.finalize_cycles;
-    trace->inter_task_gang_service_cycles = inter_task_timing.gang_service_cycles;
-    for (uint32_t type = 0; type < SCHEDULER_CORE_TYPE_COUNT; ++type) {
-        trace->inter_task_dispatch_probe_cycles[type] = inter_task_timing.dispatch.probe_cycles[type];
-        trace->inter_task_dispatch_claim_cycles[type] = inter_task_timing.dispatch.claim_cycles[type];
-        trace->inter_task_dispatch_prepare_cycles[type] = inter_task_timing.dispatch.prepare_cycles[type];
-        trace->inter_task_dispatch_materialize_cycles[type] = inter_task_timing.dispatch.materialize_cycles[type];
-        trace->inter_task_dispatch_publish_cycles[type] = inter_task_timing.dispatch.publish_cycles[type];
+    __gm__ SchedulerExecutorTaskTrace *trace = &slot->executor_trace;
+    scheduler_gm_store(trace->ready_observe_cycles, ready_observe);
+    if (phase_timing_enabled) {
+        scheduler_gm_store(trace->ready_scan_start_cycles, ready_scan_start);
+        scheduler_gm_store(trace->completion_id, completion_id);
+        scheduler_gm_store(trace->completion_inbox_index, completion_inbox_index);
     }
-    if (previous_trace_commit_end == 0) {
-        trace->aicore_entry_cycles = aicore_entry_cycles;
-        trace->handshake_publish_cycles = handshake_publish_cycles;
-        trace->register_release_cycles = register_release_cycles;
-        trace->descriptor_cache_observed_cycles = descriptor_cache_observed_cycles;
-        scheduler_publish_cache_line(&trace->register_release_cycles);
-    }
-    scheduler_publish_cache_line(&trace->kernel_start_cycles);
-    scheduler_publish_cache_line(&trace->ready_transition_cycles);
-    trace->valid = 1;
-    scheduler_publish_cache_line(trace);
 }
 
-__aicore__ __attribute__((always_inline)) void commit_task_timing_trace(
-    __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context, int64_t task_id, uint64_t kernel_start,
-    uint64_t kernel_end
+// Publish the staging generation only after every field is device-visible. The
+// completion token follows this call, so the Scheduler cannot observe a partial
+// Executor trace.
+__aicore__ __attribute__((noinline)) void stage_task_trace_before_completion(
+    __gm__ SchedulerDispatchSlot *slot, uint64_t kernel_start, uint64_t kernel_end, uint64_t completion_ready,
+    bool phase_timing_enabled
 ) {
-    __gm__ SchedulerTaskTrace *cells =
-        scheduler_state_at<SchedulerTaskTrace>(scheduler_state_base, context->trace_cells_offset);
-    __gm__ SchedulerTaskTrace *trace = &cells[task_id];
-    trace->kernel_start_cycles = kernel_start;
-    trace->kernel_end_cycles = kernel_end;
-    scheduler_publish_cache_line(&trace->kernel_start_cycles);
+    __gm__ SchedulerExecutorTaskTrace *trace = &slot->executor_trace;
+    scheduler_gm_store(trace->kernel_start_cycles, kernel_start);
+    scheduler_gm_store(trace->kernel_end_cycles, kernel_end);
+    if (phase_timing_enabled) {
+        scheduler_gm_store(trace->completion_end_cycles, completion_ready);
+        scheduler_gm_store(trace->completion_bookkeeping_end_cycles, completion_ready);
+    }
+    scheduler_gm_publish(trace->generation, slot->generation);
 }
 
 __aicore__ bool bootstrap_ready_graph(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *scheduler,
-    __gm__ SchedulerRunControl *run_control, uint64_t scheduler_count, SchedulerWorkerStats *stats, bool trace_enabled,
-    SchedulerDeferredAivQueue *deferred_aiv, __gm__ SchedulerReadyOwnerState *ready_owner
+    __gm__ SchedulerRunControl *run_control, uint64_t scheduler_count, SchedulerWorkerStats *stats,
+    uint64_t profiling_level, SchedulerDeferredAivQueue *deferred_aiv, __gm__ SchedulerReadyOwnerState *ready_owner
 ) {
     if (scheduler_count == 0 || scheduler->inbox_index >= scheduler_count || ready_owner == nullptr) return false;
-    if (trace_enabled) stats->bootstrap_start_cycles = scheduler_cycles();
+    const bool phase_timing_enabled = scheduler_phase_timing_enabled(profiling_level);
+    if (phase_timing_enabled) stats->bootstrap_start_cycles = scheduler_cycles();
     SchedulerReadyBatch batches[SCHEDULER_CORE_TYPE_COUNT]{};
     uint64_t tasks_per_scheduler = graph.task_count / scheduler_count;
     uint64_t remainder = graph.task_count % scheduler_count;
@@ -266,36 +229,48 @@ __aicore__ bool bootstrap_ready_graph(
             scheduler_task_metadata_at(scheduler_state_base, scheduler, static_cast<int64_t>(task_id));
         scheduler_observe_cache_line(metadata);
         if (!scheduler_task_is_executable(metadata->flags)) continue;
+        const bool has_fanin = scheduler_task_has_fanin(metadata->flags);
+        const uint64_t fanin_start_cycles = phase_timing_enabled && has_fanin ? scheduler_cycles() : 0;
         SchedulerRouteResult route =
-            scheduler_task_has_fanin(metadata->flags) ?
-                scheduler_bootstrap_route_task(
-                    graph, scheduler_state_base, scheduler, run_control, static_cast<int64_t>(task_id), &stats->wake
-                ) :
-                SchedulerRouteResult::READY_TO_ENQUEUE;
+            has_fanin ? scheduler_bootstrap_route_task(
+                            graph, scheduler_state_base, scheduler, run_control, static_cast<int64_t>(task_id),
+                            phase_timing_enabled ? &stats->wake : nullptr
+                        ) :
+                        SchedulerRouteResult::READY_TO_ENQUEUE;
+        if (phase_timing_enabled && has_fanin) {
+            __gm__ SchedulerTaskTrace *traces =
+                scheduler_state_at<SchedulerTaskTrace>(scheduler_state_base, scheduler->trace_cells_offset);
+            __gm__ SchedulerTaskTrace *trace = &traces[task_id];
+            trace->fanin_start_cycles = fanin_start_cycles;
+            trace->fanin_end_cycles = scheduler_cycles();
+            trace->fanin_scheduler_worker_id = scheduler->worker_index;
+            trace->fanin_loop_iter = 0;
+            scheduler_publish_cache_line(&trace->ready_transition_cycles);
+        }
         if (route == SchedulerRouteResult::ERROR) return false;
         if (route == SchedulerRouteResult::READY_TO_ENQUEUE &&
             !scheduler_bootstrap_ready_batch_append(
                 scheduler_state_base, scheduler, static_cast<int64_t>(task_id),
                 &batches[scheduler_metadata_core_type_index(scheduler_metadata_single_subtask_slot(metadata
                                                                                                        ->active_mask))],
-                &stats->ready, trace_enabled
+                phase_timing_enabled ? &stats->ready : nullptr, profiling_level
             )) {
             return false;
         }
-        ++stats->bootstrap_task_count;
+        if (phase_timing_enabled) ++stats->bootstrap_task_count;
     }
     scheduler_cache_barrier();
     uint64_t ready_types = 0;
     for (uint32_t type = 0; type < SCHEDULER_CORE_TYPE_COUNT; ++type) {
         if (!scheduler_bootstrap_ready_batch_publish(
-                scheduler_state_base, scheduler, type, scheduler->inbox_index, &batches[type], &stats->ready,
-                &ready_types
+                scheduler_state_base, scheduler, type, scheduler->inbox_index, &batches[type],
+                phase_timing_enabled ? &stats->ready : nullptr, &ready_types
             ))
             return false;
     }
     __gm__ SchedulerReadyDirectory *ready_directory = scheduler_ready_directory_at(scheduler_state_base, scheduler);
     scheduler_gm_store(ready_directory->bootstrap_ready_types[scheduler->inbox_index], ready_types);
-    if (trace_enabled) stats->bootstrap_scan_end_cycles = scheduler_cycles();
+    if (phase_timing_enabled) stats->bootstrap_scan_end_cycles = scheduler_cycles();
 
     uint64_t arrived = scheduler_gm_fetch_add(run_control->bootstrap_scan_arrived_count, UINT64_C(1)) + 1;
     if (arrived == scheduler_count) {
@@ -324,11 +299,11 @@ __aicore__ bool bootstrap_ready_graph(
             ready_owner->queues[type].advertised, (ready_types & (UINT64_C(1) << type)) != 0 ? UINT64_C(1) : UINT64_C(0)
         );
     }
-    if (trace_enabled) stats->target_bootstrap_start_cycles = scheduler_cycles();
+    if (phase_timing_enabled) stats->target_bootstrap_start_cycles = scheduler_cycles();
 
     for (uint32_t cluster_lane = 0; cluster_lane < PLATFORM_CORES_PER_BLOCKDIM; ++cluster_lane) {
         const uint64_t worker_id = scheduler->cluster_worker_ids[cluster_lane];
-        uint64_t target_start = trace_enabled ? scheduler_cycles() : 0;
+        uint64_t target_start = phase_timing_enabled ? scheduler_cycles() : 0;
         __gm__ SchedulerWorkerContext *target = scheduler_worker_context_at(scheduler_state_base, scheduler, worker_id);
         scheduler_observe_cache_line(target);
         scheduler_observe_cache_line(&target->task_metadata_offset);
@@ -341,9 +316,9 @@ __aicore__ bool bootstrap_ready_graph(
             scheduler_initialize_free_slot(slot);
         }
         scheduler_gm_publish(target->bootstrap_done, UINT64_C(1));
-        if (trace_enabled) stats->bootstrap_target_cycles[type] += scheduler_cycles() - target_start;
+        if (phase_timing_enabled) stats->bootstrap_target_cycles[type] += scheduler_cycles() - target_start;
     }
-    if (trace_enabled) stats->target_bootstrap_end_cycles = scheduler_cycles();
+    if (phase_timing_enabled) stats->target_bootstrap_end_cycles = scheduler_cycles();
 
     // Prepare the first executable wave while the sole DMB launch gate is
     // still closed.
@@ -353,8 +328,9 @@ __aicore__ bool bootstrap_ready_graph(
     };
     bool fill_failed = false;
     (void)scheduler_fill_cluster_normal_slots(
-        graph, scheduler_state_base, scheduler, run_control, ready_victim_cursors, &stats->ready, trace_enabled, 0,
-        nullptr, deferred_aiv, ready_owner, &fill_failed
+        graph, scheduler_state_base, scheduler, run_control, ready_victim_cursors,
+        phase_timing_enabled ? &stats->ready : nullptr, profiling_level, 0, nullptr, deferred_aiv, ready_owner,
+        &fill_failed
     );
     if (fill_failed) return false;
     // No peer can make progress while the launch gate is closed. Materialize
@@ -362,7 +338,7 @@ __aicore__ bool bootstrap_ready_graph(
     // never cross the bootstrap boundary.
     while (deferred_aiv != nullptr && deferred_aiv->count != 0) {
         if (!scheduler_publish_deferred_aiv_local(
-                graph, scheduler_state_base, scheduler, run_control, deferred_aiv, trace_enabled, nullptr
+                graph, scheduler_state_base, scheduler, run_control, deferred_aiv, profiling_level, nullptr
             ))
             return false;
     }
@@ -371,16 +347,17 @@ __aicore__ bool bootstrap_ready_graph(
     // one and only DMB release. Schedulers do not wait on another barrier.
     arrived = scheduler_gm_fetch_add(run_control->bootstrap_arrived_count, UINT64_C(1)) + 1;
     if (arrived == scheduler_count) scheduler_gm_publish(run_control->bootstrap_complete, UINT64_C(1));
-    if (trace_enabled) stats->bootstrap_end_cycles = scheduler_cycles();
+    if (phase_timing_enabled) stats->bootstrap_end_cycles = scheduler_cycles();
     return true;
 }
 
 __aicore__ bool run_ready_dispatch_loop(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context,
-    __gm__ SchedulerRunControl *run_control, SchedulerWorkerStats *stats, bool trace_enabled,
-    uint64_t aicore_entry_cycles, uint64_t handshake_publish_cycles, uint64_t register_release_cycles,
-    uint64_t descriptor_cache_observed_cycles, SchedulerDeferredAivQueue *deferred_aiv
+    __gm__ SchedulerRunControl *run_control, SchedulerWorkerStats *stats, uint64_t profiling_level,
+    SchedulerDeferredAivQueue *deferred_aiv
 ) {
+    const bool task_timing_enabled = scheduler_task_timing_enabled(profiling_level);
+    const bool phase_timing_enabled = scheduler_phase_timing_enabled(profiling_level);
     uint64_t scheduler_count = scheduler_gm_query(run_control->scheduler_count);
     bool scheduler_worker = context->is_scheduler != 0;
     if (scheduler_count == 0) return false;
@@ -393,16 +370,23 @@ __aicore__ bool run_ready_dispatch_loop(
         scheduler_worker ? (context->inbox_index + 1) % scheduler_count : 0,
     };
     uint64_t seen_publication[SCHEDULER_PENDING_SLOT_COUNT]{};
-    uint64_t previous_trace_commit_end = 0;
-    uint64_t inter_task_start_cycles = register_release_cycles;
+    uint64_t inter_task_start_cycles = context->trace_register_release_cycles;
     uint32_t scan_start = 0;
     uint32_t backoff_iterations = kInitialBackoffIterations;
     uint32_t scheduler_error_poll_count = 0;
+    uint32_t loop_iter = 0;
+    uint64_t idle_start_cycles = 0;
+    bool idle_active = false;
     SchedulerInterTaskTiming inter_task_timing{};
     while (true) {
         if (static_cast<uint32_t>(read_reg(RegId::DATA_MAIN_BASE)) == AICORE_EXIT_SIGNAL) {
-            if (trace_enabled) {
+            if (phase_timing_enabled) {
                 stats->exit_observed_cycles = get_sys_cnt_aicore();
+                if (scheduler_worker && idle_active) {
+                    scheduler_append_idle_activity(
+                        scheduler_state_base, context, idle_start_cycles, stats->exit_observed_cycles
+                    );
+                }
                 publish_scheduler_tail_trace(
                     context, inter_task_start_cycles, stats->exit_observed_cycles, inter_task_timing
                 );
@@ -413,6 +397,9 @@ __aicore__ bool run_ready_dispatch_loop(
             scheduler_error_poll_count = 0;
             if (scheduler_gm_query(run_control->scheduler_error) != 0) return false;
         }
+
+        if (phase_timing_enabled && scheduler_worker) context->profiling_loop_iter = loop_iter++;
+        const uint64_t idle_candidate_start = phase_timing_enabled && scheduler_worker ? scheduler_cycles() : 0;
 
         bool scheduler_progress = false;
         if (scheduler_worker && !scheduler_ready_owner_maintain(scheduler_state_base, context, ready_owner)) {
@@ -426,27 +413,29 @@ __aicore__ bool run_ready_dispatch_loop(
         if (scheduler_worker && deferred_aiv != nullptr && deferred_aiv->count != 0) {
             const uint32_t deferred_before = deferred_aiv->count;
             if (!scheduler_drain_deferred_aiv_to_peer(
-                    graph, scheduler_state_base, context, run_control, deferred_aiv, &stats->wake, &stats->ready,
-                    &stats->completion, trace_enabled, nullptr, nullptr, ready_owner
+                    graph, scheduler_state_base, context, run_control, deferred_aiv,
+                    phase_timing_enabled ? &stats->wake : nullptr, phase_timing_enabled ? &stats->ready : nullptr,
+                    phase_timing_enabled ? &stats->completion : nullptr, profiling_level, nullptr, nullptr, ready_owner
                 ))
                 return false;
             scheduler_progress = deferred_aiv->count != deferred_before;
             if (deferred_aiv->count != 0 && !scheduler_publish_deferred_aiv_local(
                                                 graph, scheduler_state_base, context, run_control, deferred_aiv,
-                                                trace_enabled, &preferred_ready_slot
+                                                profiling_level, &preferred_ready_slot
                                             ))
                 return false;
         }
         if (scheduler_worker && preferred_ready_slot == UINT32_MAX) {
-            uint64_t operation_start = trace_enabled ? get_sys_cnt_aicore() : 0;
+            uint64_t operation_start = phase_timing_enabled ? get_sys_cnt_aicore() : 0;
             uint64_t direct_refilled_slot_mask = 0;
             SchedulerCompletionServiceTiming completion_timing{};
             const bool completion_progress = scheduler_service_cluster_completions(
-                graph, scheduler_state_base, context, run_control, &stats->wake, &stats->ready, &stats->completion,
-                ready_victim_cursors, trace_enabled, &direct_refilled_slot_mask,
-                trace_enabled ? &completion_timing : nullptr, ready_owner
+                graph, scheduler_state_base, context, run_control, phase_timing_enabled ? &stats->wake : nullptr,
+                phase_timing_enabled ? &stats->ready : nullptr, phase_timing_enabled ? &stats->completion : nullptr,
+                ready_victim_cursors, profiling_level, &direct_refilled_slot_mask,
+                phase_timing_enabled ? &completion_timing : nullptr, ready_owner
             );
-            if (trace_enabled) {
+            if (phase_timing_enabled) {
                 uint64_t completion_total = get_sys_cnt_aicore() - operation_start;
                 uint64_t completion_detail = completion_timing.consume_cycles + completion_timing.resolve_cycles +
                                              completion_timing.ready_publish_cycles + completion_timing.refill_cycles +
@@ -462,17 +451,17 @@ __aicore__ bool run_ready_dispatch_loop(
                 inter_task_timing.completion.finalize_cycles += completion_timing.finalize_cycles;
             }
             scheduler_progress = completion_progress;
-            operation_start = trace_enabled ? get_sys_cnt_aicore() : 0;
+            operation_start = phase_timing_enabled ? get_sys_cnt_aicore() : 0;
             SchedulerNormalDispatchTiming dispatch_timing{};
             bool fill_failed = false;
             const bool dispatch_progress = scheduler_fill_cluster_normal_slots(
-                graph, scheduler_state_base, context, run_control, ready_victim_cursors, &stats->ready, trace_enabled,
-                direct_refilled_slot_mask, trace_enabled ? &dispatch_timing : nullptr, deferred_aiv, ready_owner,
-                &fill_failed
+                graph, scheduler_state_base, context, run_control, ready_victim_cursors,
+                phase_timing_enabled ? &stats->ready : nullptr, profiling_level, direct_refilled_slot_mask,
+                phase_timing_enabled ? &dispatch_timing : nullptr, deferred_aiv, ready_owner, &fill_failed
             );
             scheduler_progress = dispatch_progress || scheduler_progress;
             if (fill_failed) return false;
-            if (trace_enabled) {
+            if (phase_timing_enabled) {
                 inter_task_timing.dispatch_cycles[0] += get_sys_cnt_aicore() - operation_start;
                 for (uint32_t type = 0; type < SCHEDULER_CORE_TYPE_COUNT; ++type) {
                     inter_task_timing.dispatch.probe_cycles[type] += dispatch_timing.probe_cycles[type];
@@ -485,27 +474,34 @@ __aicore__ bool run_ready_dispatch_loop(
             if (deferred_aiv != nullptr && deferred_aiv->count != 0) {
                 const uint32_t deferred_before = deferred_aiv->count;
                 if (!scheduler_drain_deferred_aiv_to_peer(
-                        graph, scheduler_state_base, context, run_control, deferred_aiv, &stats->wake, &stats->ready,
-                        &stats->completion, trace_enabled, nullptr, nullptr, ready_owner
+                        graph, scheduler_state_base, context, run_control, deferred_aiv,
+                        phase_timing_enabled ? &stats->wake : nullptr, phase_timing_enabled ? &stats->ready : nullptr,
+                        phase_timing_enabled ? &stats->completion : nullptr, profiling_level, nullptr, nullptr,
+                        ready_owner
                     ))
                     return false;
                 scheduler_progress = scheduler_progress || deferred_aiv->count != deferred_before;
                 if (deferred_aiv->count != 0 && !scheduler_publish_deferred_aiv_local(
                                                     graph, scheduler_state_base, context, run_control, deferred_aiv,
-                                                    trace_enabled, &preferred_ready_slot
+                                                    profiling_level, &preferred_ready_slot
                                                 ))
                     return false;
             }
         }
 
+        if (phase_timing_enabled && scheduler_worker && scheduler_progress && idle_active) {
+            scheduler_append_idle_activity(scheduler_state_base, context, idle_start_cycles, idle_candidate_start);
+            idle_active = false;
+        }
+
         int32_t ready_slot = -1;
         uint64_t ready_publication = 0;
-        uint64_t ready_scan_start = trace_enabled ? get_sys_cnt_aicore() : 0;
+        uint64_t ready_scan_start = phase_timing_enabled ? get_sys_cnt_aicore() : 0;
         if (preferred_ready_slot != UINT32_MAX) {
             __gm__ SchedulerDispatchSlot *slot =
                 scheduler_dispatch_slot_at(scheduler_state_base, context, context->worker_index, preferred_ready_slot);
             const uint64_t publication = scheduler_gm_query(slot->publication);
-            ++stats->task_state_poll_count;
+            if (phase_timing_enabled) ++stats->task_state_poll_count;
             if (publication == seen_publication[preferred_ready_slot] ||
                 scheduler_dispatch_state(publication) != SchedulerDispatchSlotState::READY) {
                 scheduler_record_error(
@@ -522,7 +518,7 @@ __aicore__ bool run_ready_dispatch_loop(
                 __gm__ SchedulerDispatchSlot *slot =
                     scheduler_dispatch_slot_at(scheduler_state_base, context, context->worker_index, slot_index);
                 uint64_t publication = scheduler_gm_query(slot->publication);
-                ++stats->task_state_poll_count;
+                if (phase_timing_enabled) ++stats->task_state_poll_count;
                 if (publication != seen_publication[slot_index] &&
                     scheduler_dispatch_state(publication) == SchedulerDispatchSlotState::READY) {
                     ready_slot = static_cast<int32_t>(slot_index);
@@ -531,7 +527,7 @@ __aicore__ bool run_ready_dispatch_loop(
                 }
             }
         }
-        uint64_t ready_poll_end = trace_enabled ? get_sys_cnt_aicore() : 0;
+        uint64_t ready_poll_end = phase_timing_enabled ? get_sys_cnt_aicore() : 0;
 
         if (ready_slot >= 0) {
             uint32_t slot_index = static_cast<uint32_t>(ready_slot);
@@ -542,6 +538,10 @@ __aicore__ bool run_ready_dispatch_loop(
                 context->dispatch_payload_offset + static_cast<uint64_t>(slot_index) * sizeof(DispatchPayload)
             );
             uint64_t ready_observe = get_sys_cnt_aicore();
+            if (phase_timing_enabled && scheduler_worker && idle_active) {
+                scheduler_append_idle_activity(scheduler_state_base, context, idle_start_cycles, ready_observe);
+                idle_active = false;
+            }
             scheduler_invalidate_cache_line(slot);
             scheduler_observe_dispatch_payload_control(payload);
             scheduler_observe_dispatch_payload_arguments(payload);
@@ -564,16 +564,23 @@ __aicore__ bool run_ready_dispatch_loop(
                 static_cast<SchedulerReadySource>(slot->ready_source),
             };
             const bool commit_scheduler_trace =
-                trace_enabled && should_commit_scheduler_trace(scheduler_state_base, context, slot);
+                task_timing_enabled && should_commit_scheduler_trace(scheduler_state_base, context, slot);
             __gm__ SchedulerTaskMetadata *task_metadata =
                 scheduler_task_metadata_at(scheduler_state_base, context, record.task_id);
             scheduler_observe_cache_line(task_metadata);
             const bool commit_task_timing = task_metadata->timing_slot >= 0 &&
                                             task_metadata->timing_slot < SCHEDULER_TASK_TIMING_SLOT_COUNT &&
                                             should_commit_scheduler_trace(scheduler_state_base, context, slot);
+            if (commit_scheduler_trace || commit_task_timing) {
+                uint64_t local_completion_index = stats->completion.enqueue_count;
+                stage_task_trace_before_execution(
+                    slot, ready_scan_start, ready_observe, scheduler_completion_id(context, local_completion_index),
+                    context->scheduler_index, phase_timing_enabled
+                );
+            }
             OUT_OF_ORDER_STORE_BARRIER();
             uint64_t kernel_start = get_sys_cnt_aicore();
-            if (trace_enabled) {
+            if (phase_timing_enabled) {
                 __gm__ SchedulerTaskControl *control =
                     scheduler_task_control_at(scheduler_state_base, context, record.task_id);
                 scheduler_observe_cache_line(&control->next_waiter);
@@ -587,52 +594,53 @@ __aicore__ bool run_ready_dispatch_loop(
             execute_task(payload);
             uint64_t kernel_end = get_sys_cnt_aicore();
             scheduler_publish_dispatch_payload(payload);
-            uint64_t completion_start = get_sys_cnt_aicore();
-            uint64_t local_completion_index = stats->completion.enqueue_count;
-            uint64_t completion_id = scheduler_completion_id(context, local_completion_index);
-            uint64_t completion_inbox_index = context->scheduler_index;
             __gm__ SchedulerCompletionInbox *completion_line =
                 scheduler_completion_inbox_at(scheduler_state_base, context, context->worker_index);
+            uint64_t completion_start = get_sys_cnt_aicore();
+            if (commit_scheduler_trace || commit_task_timing) {
+                uint64_t completion_ready = phase_timing_enabled ? get_sys_cnt_aicore() : 0;
+                stage_task_trace_before_completion(
+                    slot, kernel_start, kernel_end, completion_ready, phase_timing_enabled
+                );
+            }
             scheduler_gm_store(completion_line->completed_generations[slot_index], slot->generation);
-            ++stats->completion.enqueue_count;
+            if (phase_timing_enabled) ++stats->completion.enqueue_count;
             uint64_t completion_end = get_sys_cnt_aicore();
-            ++stats->executed_task_count;
-            stats->payload_cycles += kernel_start - ready_observe;
-            stats->kernel_cycles += kernel_end - kernel_start;
-            stats->completion_enqueue_cycles += completion_end - completion_start;
+            if (phase_timing_enabled) {
+                ++stats->executed_task_count;
+                stats->payload_cycles += kernel_start - ready_observe;
+                stats->kernel_cycles += kernel_end - kernel_start;
+                stats->completion_enqueue_cycles += completion_end - completion_start;
+            }
             scan_start = (slot_index + 1) % SCHEDULER_PENDING_SLOT_COUNT;
             backoff_iterations = kInitialBackoffIterations;
             if (commit_scheduler_trace) {
-                uint64_t bookkeeping_end = get_sys_cnt_aicore();
-                commit_task_trace(
-                    scheduler_state_base, context, record, ready_scan_start, ready_observe, kernel_start, kernel_end,
-                    completion_end, bookkeeping_end, previous_trace_commit_end, aicore_entry_cycles,
-                    handshake_publish_cycles, register_release_cycles, descriptor_cache_observed_cycles, completion_id,
-                    completion_inbox_index, inter_task_timing
-                );
-                previous_trace_commit_end = get_sys_cnt_aicore();
-                inter_task_start_cycles = previous_trace_commit_end;
-            } else if (commit_task_timing) {
-                commit_task_timing_trace(scheduler_state_base, context, record.task_id, kernel_start, kernel_end);
-            } else if (trace_enabled) {
+                inter_task_start_cycles = get_sys_cnt_aicore();
+            } else if (phase_timing_enabled) {
                 inter_task_start_cycles = get_sys_cnt_aicore();
             }
             inter_task_timing.reset();
             continue;
         }
 
-        if (trace_enabled) inter_task_timing.ready_poll_cycles += ready_poll_end - ready_scan_start;
+        if (phase_timing_enabled) inter_task_timing.ready_poll_cycles += ready_poll_end - ready_scan_start;
 
         if (scheduler_progress) {
             backoff_iterations = kInitialBackoffIterations;
             continue;
         }
-        ++stats->idle_iteration_count;
+        if (phase_timing_enabled) ++stats->idle_iteration_count;
         uint64_t backoff_start = get_sys_cnt_aicore();
         local_backoff(backoff_iterations);
         uint64_t backoff_end = get_sys_cnt_aicore();
-        stats->backoff_cycles += backoff_end - backoff_start;
-        if (trace_enabled) inter_task_timing.backoff_cycles += backoff_end - backoff_start;
+        if (phase_timing_enabled) stats->backoff_cycles += backoff_end - backoff_start;
+        if (phase_timing_enabled) {
+            inter_task_timing.backoff_cycles += backoff_end - backoff_start;
+            if (scheduler_worker && !idle_active) {
+                idle_start_cycles = idle_candidate_start;
+                idle_active = true;
+            }
+        }
         if (backoff_iterations < kMaximumBackoffIterations) backoff_iterations <<= 1;
     }
     return true;
@@ -649,15 +657,15 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
         legacy_aicore_execute(runtime, block_idx, core_type);
         return;
     }
-    bool trace_enabled = SIMPLER_GET_DFX_FLAG(profiling_flag, SIMPLER_DFX_FLAG_CHIP_SWIMLANE);
-    uint64_t aicore_entry_cycles = trace_enabled ? get_sys_cnt_aicore() : 0;
+    const bool chip_swimlane_enabled = SIMPLER_GET_DFX_FLAG(profiling_flag, SIMPLER_DFX_FLAG_CHIP_SWIMLANE);
+    uint64_t aicore_entry_cycles = chip_swimlane_enabled ? get_sys_cnt_aicore() : 0;
     handshake->physical_core_id = get_physical_core_id();
     handshake->core_type = core_type;
     OUT_OF_ORDER_STORE_BARRIER();
     handshake->aicore_done = block_idx + 1;
     dcci(handshake, SINGLE_CACHE_LINE, CACHELINE_OUT);
     dsb((mem_dsb_t)0);
-    uint64_t handshake_publish_cycles = trace_enabled ? get_sys_cnt_aicore() : 0;
+    uint64_t handshake_publish_cycles = chip_swimlane_enabled ? get_sys_cnt_aicore() : 0;
 
     // AICPU publishes the fully configured context through GM. This lets
     // AICore perform all pre-kernel work without consuming a DMB launch.
@@ -708,6 +716,9 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
     __gm__ SchedulerRunControl *run_control =
         scheduler_state_at<SchedulerRunControl>(scheduler_state_base, context->run_control_offset);
     scheduler_observe_cache_line(run_control);
+    scheduler_observe_cache_line(&run_control->chip_swimlane_level);
+    const uint64_t profiling_level = scheduler_gm_query(run_control->chip_swimlane_level);
+    const bool phase_timing_enabled = scheduler_phase_timing_enabled(profiling_level);
     SchedulerGraphView graph{
         context->graph_storage_address,
         context->graph_reserved_address,
@@ -720,7 +731,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
     uint64_t descriptor_cache_observed_cycles = 0;
     if (context->active != 0) {
         scheduler_observe_data_cache(reinterpret_cast<__gm__ void *>(graph.storage_address));
-        descriptor_cache_observed_cycles = trace_enabled ? get_sys_cnt_aicore() : 0;
+        descriptor_cache_observed_cycles = phase_timing_enabled ? get_sys_cnt_aicore() : 0;
         if (context->is_scheduler != 0) {
             ready_owner = scheduler_ready_owner_state_at(scheduler_state_base, context);
             scheduler_ready_owner_init(ready_owner);
@@ -728,7 +739,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
         if (context->is_scheduler != 0 &&
             !bootstrap_ready_graph(
                 graph, scheduler_state_base, context, run_control, scheduler_gm_query(run_control->scheduler_count),
-                &stats, trace_enabled, &deferred_aiv, ready_owner
+                &stats, profiling_level, &deferred_aiv, ready_owner
             )) {
             scheduler_record_error(
                 run_control, SCHEDULER_TASK_ID_INVALID, SchedulerGraphResult::INVALID_ARGUMENTS, &graph, context,
@@ -756,19 +767,26 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
         SPIN_WAIT_HINT();
     }
     if (startup_signal == AICORE_EXIT_SIGNAL || register_release_timed_out) {
-        if (trace_enabled) stats.exit_observed_cycles = get_sys_cnt_aicore();
+        if (phase_timing_enabled) stats.exit_observed_cycles = get_sys_cnt_aicore();
     } else {
-        uint64_t register_release_cycles = trace_enabled ? get_sys_cnt_aicore() : 0;
+        uint64_t register_release_cycles = phase_timing_enabled ? get_sys_cnt_aicore() : 0;
+        if (phase_timing_enabled) {
+            context->trace_aicore_entry_cycles = aicore_entry_cycles;
+            context->trace_handshake_publish_cycles = handshake_publish_cycles;
+            context->trace_register_release_cycles = register_release_cycles;
+            context->trace_descriptor_cache_observed_cycles = descriptor_cache_observed_cycles;
+            scheduler_publish_cache_line(&context->trace_aicore_entry_cycles);
+            scheduler_publish_cache_line(&context->trace_register_release_cycles);
+        }
         write_reg(RegId::COND, AICORE_IDLE_VALUE);
         if (context->active != 0) {
             (void)run_ready_dispatch_loop(
-                graph, scheduler_state_base, context, run_control, &stats, trace_enabled, aicore_entry_cycles,
-                handshake_publish_cycles, register_release_cycles, descriptor_cache_observed_cycles, &deferred_aiv
+                graph, scheduler_state_base, context, run_control, &stats, profiling_level, &deferred_aiv
             );
         }
     }
 
-    if (trace_enabled && stats.exit_wait_start_cycles == 0) stats.exit_wait_start_cycles = get_sys_cnt_aicore();
+    if (phase_timing_enabled && stats.exit_wait_start_cycles == 0) stats.exit_wait_start_cycles = get_sys_cnt_aicore();
     const uint64_t exit_wait_start = get_sys_cnt_aicore();
     while (stats.exit_observed_cycles == 0 &&
            static_cast<uint32_t>(read_reg(RegId::DATA_MAIN_BASE)) != AICORE_EXIT_SIGNAL) {
@@ -783,10 +801,10 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
         }
         SPIN_WAIT_HINT();
     }
-    if (trace_enabled && stats.exit_observed_cycles == 0) stats.exit_observed_cycles = get_sys_cnt_aicore();
-    if (trace_enabled) stats.final_stats_publish_start_cycles = get_sys_cnt_aicore();
-    publish_worker_stats(context, stats);
-    if (trace_enabled) {
+    if (phase_timing_enabled && stats.exit_observed_cycles == 0) stats.exit_observed_cycles = get_sys_cnt_aicore();
+    if (phase_timing_enabled) {
+        stats.final_stats_publish_start_cycles = get_sys_cnt_aicore();
+        publish_worker_stats(context, stats);
         stats.final_stats_publish_end_cycles = get_sys_cnt_aicore();
         stats.exit_ack_publish_cycles = get_sys_cnt_aicore();
         context->final_stats_publish_end_cycles = stats.final_stats_publish_end_cycles;

--- a/src/a5/runtime/host_build_graph/aicpu/aicore_lifecycle.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicore_lifecycle.cpp
@@ -41,6 +41,8 @@ uint64_t resident_scheduler_timeout_cycles() {
                             SCHEDULER_TIMEOUT_CYCLES;
 }
 
+bool lifecycle_timing_enabled() { return get_chip_swimlane_level() >= ChipSwimlaneLevel::SCHEDULE_TIMING; }
+
 void record_lifecycle_timeout(Runtime *runtime, SchedulerErrorSite error_site) {
     SchedulerWorkerContext *context = aicore_scheduler_bootstrap_context(runtime);
     if (context == nullptr) return;
@@ -69,10 +71,9 @@ int32_t AicoreLifecycle::pre_handshake_init(Runtime *runtime, int32_t aicpu_thre
     handshake_failed_.store(false, std::memory_order_release);
 
     const bool chip_swimlane_enabled = is_chip_swimlane_enabled();
-    if (chip_swimlane_enabled || is_pmu_enabled() || is_dump_args_enabled()) {
+    if (is_pmu_enabled() || is_dump_args_enabled()) {
         LOG_WARN(
-            "A5 HBG AICore Scheduler diagnostics are best-effort: artifacts may be absent or incomplete and do not "
-            "yet describe Scheduler scheduling"
+            "A5 HBG AICore Scheduler PMU/argument diagnostics are best-effort: artifacts may be absent or incomplete"
         );
     }
     if (chip_swimlane_enabled) chip_swimlane_aicpu_init(core_count_);
@@ -121,7 +122,7 @@ void AicoreLifecycle::handshake_partition(Runtime *runtime, int32_t tidx, int32_
             }
             ready[ready_count++] = {
                 i, physical_core_id, regs[physical_core_id], handshake->core_type,
-                is_chip_swimlane_enabled() ? get_sys_cnt_aicpu() : 0
+                lifecycle_timing_enabled() ? get_sys_cnt_aicpu() : 0
             };
         }
         if (scheduler_watchdog_expired(wait_start, get_sys_cnt_aicpu(), timeout_cycles)) {
@@ -138,7 +139,7 @@ void AicoreLifecycle::handshake_partition(Runtime *runtime, int32_t tidx, int32_
                                   nullptr,       core.handshake_observed_cycles, 0};
         physical_core_ids_[core.worker_id] = core.physical_core_id;
     }
-    const uint64_t partition_complete_cycles = is_chip_swimlane_enabled() ? get_sys_cnt_aicpu() : 0;
+    const uint64_t partition_complete_cycles = lifecycle_timing_enabled() ? get_sys_cnt_aicpu() : 0;
     for (int32_t i = lo; i < hi; ++i)
         cores_[i].handshake_partition_complete_cycles = partition_complete_cycles;
 }
@@ -150,8 +151,8 @@ int32_t AicoreLifecycle::post_handshake_init(Runtime *runtime) {
         return -1;
     cache_invalidate_range(bootstrap_context, 256);
     void *scheduler_state_base = aicore_scheduler_state_base(bootstrap_context);
-    const bool trace_enabled = is_chip_swimlane_enabled();
-    const uint64_t config_start_cycles = trace_enabled ? get_sys_cnt_aicpu() : 0;
+    const bool record_lifecycle_timing = lifecycle_timing_enabled();
+    const uint64_t config_start_cycles = record_lifecycle_timing ? get_sys_cnt_aicpu() : 0;
 
     auto *run_control = aicore_scheduler_run_control(bootstrap_context);
     if (scheduler_state_base == nullptr || run_control == nullptr) return -1;
@@ -296,7 +297,7 @@ int32_t AicoreLifecycle::post_handshake_init(Runtime *runtime) {
         run_control->bootstrap_complete = 1;
     }
 
-    const uint64_t topology_complete_cycles = trace_enabled ? get_sys_cnt_aicpu() : 0;
+    const uint64_t topology_complete_cycles = record_lifecycle_timing ? get_sys_cnt_aicpu() : 0;
     for (int32_t i = 0; i < core_count_; ++i)
         lifecycle_traces[i].topology_complete_cycles = topology_complete_cycles;
 
@@ -325,7 +326,7 @@ void AicoreLifecycle::publish_context_partition(Runtime *runtime, int32_t thread
     }
     if (hi > lo) cache_flush_range(&handshakes[lo], static_cast<size_t>(hi - lo) * sizeof(Handshake));
     wmb();
-    const uint64_t publish_complete_cycles = is_chip_swimlane_enabled() ? get_sys_cnt_aicpu() : 0;
+    const uint64_t publish_complete_cycles = lifecycle_timing_enabled() ? get_sys_cnt_aicpu() : 0;
     for (int32_t i = lo; i < hi; ++i) {
         if (cores_[i].trace != nullptr) cores_[i].trace->context_publish_complete_cycles = publish_complete_cycles;
     }
@@ -337,8 +338,8 @@ int32_t AicoreLifecycle::wait_bootstrap_complete(Runtime *runtime) {
     cache_invalidate_range(context, 128);
     auto *run_control = aicore_scheduler_run_control(context);
     if (run_control == nullptr) return -1;
-    const bool trace_enabled = is_chip_swimlane_enabled();
-    const uint64_t wait_start_cycles = trace_enabled ? get_sys_cnt_aicpu() : 0;
+    const bool record_lifecycle_timing = lifecycle_timing_enabled();
+    const uint64_t wait_start_cycles = record_lifecycle_timing ? get_sys_cnt_aicpu() : 0;
     const uint64_t watchdog_start = get_sys_cnt_aicpu();
     const uint64_t timeout_cycles = resident_scheduler_timeout_cycles();
     uint32_t error_poll_count = 0;
@@ -361,7 +362,7 @@ int32_t AicoreLifecycle::wait_bootstrap_complete(Runtime *runtime) {
         }
         SPIN_WAIT_HINT();
     }
-    const uint64_t complete_cycles = trace_enabled ? get_sys_cnt_aicpu() : 0;
+    const uint64_t complete_cycles = record_lifecycle_timing ? get_sys_cnt_aicpu() : 0;
     for (int32_t i = 0; i < core_count_; ++i) {
         if (cores_[i].trace == nullptr) continue;
         cores_[i].trace->bootstrap_wait_start_cycles = wait_start_cycles;

--- a/src/a5/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a5/runtime/host_build_graph/docs/profiling_levels.md
@@ -8,11 +8,9 @@ The runtime uses a hierarchical profiling system with compile-time macros to con
 
 > **A5 HBG scheduler selection.** Diagnostic flags never select the scheduler.
 > Ordinary DAGs remain on the A5 HBG AICore Scheduler, while Graph replay
-> remains on its explicit legacy compatibility path. Until AICore Scheduler
-> profiling lands, chip-swimlane, PMU, and argument-dump collection for
-> ordinary DAGs is best-effort; artifacts may be absent or incomplete and must
-> not be used as evidence of AICore Scheduler behavior or as a profiling-on
-> performance baseline.
+> remains on its explicit AICPU compatibility path. Both producers export the
+> same `scheduler_records` schema; stream metadata identifies `producer` so
+> tools never apply AICPU scheduling assumptions to AICore intervals.
 > **host_build_graph (host-orch) note.** The profiling **macros** below
 > (`SIMPLER_DFX`, `SIMPLER_ORCH_PROFILING`, …) are shared with
 > `tensormap_and_ringbuffer`. But the orchestrator-timing **device-log lines**
@@ -173,7 +171,7 @@ Thread X: Scheduler summary: total_time=XXXus, loops=XXX, tasks_scheduled=XXX
 ```
 
 Per-thread fanout / fanin edge counts and ready-queue pop hit / miss
-stats live in `aicpu_scheduler_phases[]` (in `chip_swimlane_records.json`
+stats live in `scheduler_records.streams[]` (in `chip_swimlane_records.json`
 captured at chip_swimlane_level >= 3) and `deps.json`; consume them via
 `simpler_setup/tools/sched_overhead_analysis.py`.
 
@@ -415,13 +413,16 @@ mirrors the PMU pattern — two independent channels (one binary, one int):
 
 - **Binary on/off** — `KernelArgs::enable_profiling_flag` bit1
   (`SIMPLER_DFX_FLAG_CHIP_SWIMLANE`). Set by the host whenever level > 0; read
-  by AICore (which only needs on/off to decide whether to write timing) and
-  by AICPU kernel entry via `set_chip_swimlane_enabled(bool)`.
+  by AICore for the initial profiler activation and by AICPU kernel entry via
+  `set_chip_swimlane_enabled(bool)`.
 - **Granular level (0–4)** — `ChipSwimlaneDataHeader::chip_swimlane_level`
   (shared memory). Host writes it in `ChipSwimlaneCollector::initialize`; AICPU
   promotes it from the header in `chip_swimlane_aicpu_init` and exposes it via
   `get_chip_swimlane_level()` (typed `ChipSwimlaneLevel`) for
-  `>= SCHEDULE_TIMING / SCHED_PHASES / ORCH_PHASES` gates.
+  `>= SCHEDULE_TIMING / SCHED_PHASES / ORCH_PHASES` gates. The A5 HBG host also
+  copies the level into `SchedulerRunControl`, where the AICore Scheduler reads
+  it once and gates task timing, per-task scheduling timing, and phase timing
+  independently.
 
 On sim, the binary on/off travels via the dlsym'd `set_chip_swimlane_enabled`
 entry point; the granular level still goes through the shared-memory
@@ -434,6 +435,23 @@ header just like on onboard.
 | 2 | + Scheduler per-task dispatch_time, finish_time |
 | 3 | + Scheduler phases (`SCHED_*`) |
 | 4 | + Orchestrator phases (full) |
+
+The A5 HBG AICore Scheduler records the same per-task timing contract as the
+AICPU Scheduler: `dispatch_time` is the end of dispatch publication and
+`finish_time` is when the Scheduler starts processing the completion. The raw
+`scheduler_tasks.producer` field identifies which Scheduler produced these
+timestamps. At level 2 and above, A5 HBG also exports AICPU lifecycle timestamps
+for handshake, topology/configuration, context publication, bootstrap wait,
+register release, and exit; these are supplemental control-plane records.
+
+At level 3 and above, A5 HBG AICore Scheduler task intervals reuse the per-task
+trace. Consecutive taskless scheduler-loop iterations are coalesced into one
+`idle` interval and stored in one fixed-capacity, no-wrap buffer per Scheduler;
+overflow increments `capture.dropped` and sets `capture.truncated`. Coalescing
+keeps capture size dependent on idle-to-active transitions instead of Host CPU
+speed in simulation. The buffer is not allocated below level 3. Interval
+endpoints are captured at operation entry and exit; no interval is synthesized
+from aggregate durations.
 
 At level 1 the AICore record carries the full `task_token_raw`
 (a `TaskId::raw`; see `src/common/host_build_graph/task_id.h`), read straight from

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -49,6 +49,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <unordered_map>
@@ -74,6 +75,7 @@
 #include "../../../../common/task_interface/call_config.h"
 #include "../../../../common/worker/runtime_c_api.h"
 #include "callable.h"
+#include "common/chip_swimlane_profiling.h"
 #include "common/host_log_binding.h"
 #include "common/host_phase_kind.h"
 #include "common/platform_config.h"
@@ -94,6 +96,12 @@ static_assert(
     SIMPLER_ERROR_READY_QUEUE_OVERFLOW <= PTO_RUNTIME_LATCHED_CODE_MAX &&
         PTO_RUNTIME_ERR_BASE < -PTO_RUNTIME_LATCHED_CODE_MAX,
     "host-side C API codes must stay below the negation of every latched device code"
+);
+static_assert(
+    SCHEDULER_PROFILING_TASK_TIMING_LEVEL == static_cast<uint64_t>(ChipSwimlaneLevel::TASK_TIMING) &&
+        SCHEDULER_PROFILING_SCHEDULE_TIMING_LEVEL == static_cast<uint64_t>(ChipSwimlaneLevel::SCHEDULE_TIMING) &&
+        SCHEDULER_PROFILING_SCHED_PHASES_LEVEL == static_cast<uint64_t>(ChipSwimlaneLevel::SCHED_PHASES),
+    "AICore Scheduler profiling levels must match the chip-swimlane contract"
 );
 
 extern "C" const PipelineContract *get_pipeline_contract(void) {
@@ -372,10 +380,298 @@ struct SchedulerStateOwner {
     void *state_base;
     uint64_t allocation_size;
     AicoreSchedulerLayout layout;
+    const HostApi *api;
 };
 
 std::mutex scheduler_state_owners_mutex;
 std::unordered_map<Runtime *, SchedulerStateOwner> scheduler_state_owners;
+
+struct SchedulerJsonRecord {
+    uint64_t start_cycles;
+    uint64_t end_cycles;
+    uint64_t loop_iter;
+    const char *kind;
+    uint64_t tasks_processed;
+    uint64_t task_id;
+    bool has_task;
+};
+
+const char *scheduler_core_type_name(int32_t core_type) {
+    return core_type == static_cast<int32_t>(CoreType::AIC) ? "aic" : "aiv";
+}
+
+void append_scheduler_record(
+    std::vector<SchedulerJsonRecord> *records, uint64_t start_cycles, uint64_t end_cycles, uint64_t loop_iter,
+    const char *kind, uint64_t tasks_processed, uint64_t task_id = 0, bool has_task = true
+) {
+    if (records == nullptr || start_cycles == 0 || end_cycles < start_cycles) return;
+    records->push_back({start_cycles, end_cycles, loop_iter, kind, tasks_processed, task_id, has_task});
+}
+
+bool publish_aicore_scheduler_profiling(Runtime *runtime, const HostApi *api) {
+    const uint32_t level = api->chip_swimlane_level();
+    if (level == 0) return true;
+
+    SchedulerStateOwner owner{};
+    {
+        std::scoped_lock lock(scheduler_state_owners_mutex);
+        auto it = scheduler_state_owners.find(runtime);
+        if (it == scheduler_state_owners.end()) return true;
+        owner = it->second;
+    }
+
+    std::vector<uint8_t> storage(static_cast<size_t>(owner.layout.total_size + SCHEDULER_STATE_ALIGNMENT - 1));
+    const uintptr_t aligned_address = (reinterpret_cast<uintptr_t>(storage.data()) + SCHEDULER_STATE_ALIGNMENT - 1) &
+                                      ~(static_cast<uintptr_t>(SCHEDULER_STATE_ALIGNMENT) - 1);
+    void *host_base = reinterpret_cast<void *>(aligned_address);
+    if (api->copy_from_device(host_base, owner.state_base, static_cast<size_t>(owner.layout.total_size)) != 0) {
+        LOG_WARN("A5 HBG: failed to copy AICore Scheduler profiling state");
+        return false;
+    }
+
+    const auto *contexts = scheduler_state_at<SchedulerWorkerContext>(host_base, owner.layout.worker_contexts_offset);
+    const auto *traces = scheduler_state_at<SchedulerTaskTrace>(host_base, owner.layout.trace_cells_offset);
+    const auto *controls = scheduler_state_at<SchedulerTaskControl>(host_base, owner.layout.task_controls_offset);
+
+    std::ostringstream tasks_json;
+    tasks_json << "[";
+    bool first_task = true;
+    for (uint64_t task_id = 0; task_id < owner.layout.task_count; ++task_id) {
+        const SchedulerTaskTrace &trace = traces[task_id];
+        if (trace.valid == 0 || trace.kernel_start_cycles == 0 || trace.kernel_end_cycles < trace.kernel_start_cycles ||
+            trace.worker_id >= SCHEDULER_WORKER_CAPACITY)
+            continue;
+        const uint64_t receive_to_start =
+            trace.ready_observe_cycles != 0 && trace.kernel_start_cycles >= trace.ready_observe_cycles ?
+                trace.kernel_start_cycles - trace.ready_observe_cycles :
+                0;
+        if (!first_task) tasks_json << ",";
+        tasks_json << "\n    [" << trace.worker_id << ", " << task_id << ", " << task_id << ", "
+                   << trace.kernel_start_cycles << ", " << trace.kernel_end_cycles << ", " << receive_to_start << "]";
+        first_task = false;
+    }
+    if (!first_task) tasks_json << "\n  ";
+    tasks_json << "]";
+    const std::string task_payload = tasks_json.str();
+    if (!api->publish_chip_swimlane_extension(
+            ChipSwimlaneExtensionSection::AicoreTasks, task_payload.c_str(), task_payload.size()
+        )) {
+        LOG_WARN("A5 HBG: failed to publish AICore task records");
+        return false;
+    }
+
+    if (level >= static_cast<uint32_t>(ChipSwimlaneLevel::SCHEDULE_TIMING)) {
+        std::ostringstream scheduler_tasks_json;
+        scheduler_tasks_json << "{\n    \"schema_version\": 1,\n    \"producer\": \"aicore\",\n    \"records\": [";
+        bool first_scheduler_task = true;
+        for (uint64_t task_id = 0; task_id < owner.layout.task_count; ++task_id) {
+            const SchedulerTaskTrace &trace = traces[task_id];
+            if (trace.valid == 0 || trace.kernel_start_cycles == 0 ||
+                trace.kernel_end_cycles < trace.kernel_start_cycles || trace.worker_id >= SCHEDULER_WORKER_CAPACITY)
+                continue;
+            if (trace.dispatch_end_cycles == 0 || trace.complete_start_cycles < trace.kernel_end_cycles) {
+                LOG_WARN("A5 HBG: incomplete Scheduler task timing for task id=%" PRIu64, task_id);
+                return false;
+            }
+            if (!first_scheduler_task) scheduler_tasks_json << ",";
+            scheduler_tasks_json << "\n      [" << trace.worker_id << ", " << task_id << ", "
+                                 << trace.dispatch_end_cycles << ", " << trace.complete_start_cycles << "]";
+            first_scheduler_task = false;
+        }
+        if (!first_scheduler_task) scheduler_tasks_json << "\n    ";
+        scheduler_tasks_json << "]\n  }";
+        const std::string scheduler_tasks_payload = scheduler_tasks_json.str();
+        if (!api->publish_chip_swimlane_extension(
+                ChipSwimlaneExtensionSection::SchedulerTasks, scheduler_tasks_payload.c_str(),
+                scheduler_tasks_payload.size()
+            )) {
+            LOG_WARN("A5 HBG: failed to publish AICore Scheduler task timing");
+            return false;
+        }
+
+        const auto *lifecycle =
+            scheduler_state_at<AicpuCoreLifecycleTrace>(host_base, owner.layout.aicpu_lifecycle_traces_offset);
+        std::ostringstream lifecycle_json;
+        lifecycle_json << "[";
+        bool first = true;
+        for (uint64_t worker = 0; worker < SCHEDULER_WORKER_CAPACITY; ++worker) {
+            const AicpuCoreLifecycleTrace &trace = lifecycle[worker];
+            if (trace.handshake_observed_cycles == 0) continue;
+            if (!first) lifecycle_json << ",";
+            lifecycle_json << "\n    {\"worker_id\": " << trace.worker_id
+                           << ", \"aicpu_thread_id\": " << trace.aicpu_thread_id << ", \"core_type\": \""
+                           << scheduler_core_type_name(static_cast<int32_t>(trace.core_type))
+                           << "\", \"physical_core_id\": " << trace.physical_core_id
+                           << ", \"handshake_observed_cycles\": " << trace.handshake_observed_cycles
+                           << ", \"handshake_partition_complete_cycles\": " << trace.handshake_partition_complete_cycles
+                           << ", \"config_start_cycles\": " << trace.config_start_cycles
+                           << ", \"topology_complete_cycles\": " << trace.topology_complete_cycles
+                           << ", \"context_publish_complete_cycles\": " << trace.context_publish_complete_cycles
+                           << ", \"bootstrap_wait_start_cycles\": " << trace.bootstrap_wait_start_cycles
+                           << ", \"bootstrap_complete_cycles\": " << trace.bootstrap_complete_cycles
+                           << ", \"register_release_cycles\": " << trace.register_release_cycles
+                           << ", \"exit_signal_cycles\": " << trace.exit_signal_cycles
+                           << ", \"exit_ack_cycles\": " << trace.exit_ack_cycles << "}";
+            first = false;
+        }
+        if (!first) lifecycle_json << "\n  ";
+        lifecycle_json << "]";
+        const std::string lifecycle_payload = lifecycle_json.str();
+        if (!api->publish_chip_swimlane_extension(
+                ChipSwimlaneExtensionSection::AicpuLifecycleRecords, lifecycle_payload.c_str(), lifecycle_payload.size()
+            )) {
+            LOG_WARN("A5 HBG: failed to publish AICPU lifecycle records");
+            return false;
+        }
+    }
+
+    if (level < static_cast<uint32_t>(ChipSwimlaneLevel::SCHED_PHASES)) return true;
+
+    std::vector<std::vector<SchedulerJsonRecord>> records(SCHEDULER_WORKER_CAPACITY);
+    for (uint64_t worker = 0; worker < SCHEDULER_WORKER_CAPACITY; ++worker) {
+        const SchedulerWorkerContext &context = contexts[worker];
+        if (context.is_scheduler == 0 || context.worker_index >= SCHEDULER_WORKER_CAPACITY) continue;
+        append_scheduler_record(
+            &records[context.worker_index], context.bootstrap_start_cycles, context.bootstrap_end_cycles, 0,
+            "bootstrap", context.bootstrap_task_count, 0, false
+        );
+    }
+    for (uint64_t task_id = 0; task_id < owner.layout.task_count; ++task_id) {
+        const SchedulerTaskTrace &trace = traces[task_id];
+        if (trace.fanin_scheduler_worker_id < SCHEDULER_WORKER_CAPACITY) {
+            append_scheduler_record(
+                &records[trace.fanin_scheduler_worker_id], trace.fanin_start_cycles, trace.fanin_end_cycles,
+                trace.fanin_loop_iter, "fanin", 1, task_id
+            );
+        }
+        if (trace.claim_worker_id < SCHEDULER_WORKER_CAPACITY) {
+            append_scheduler_record(
+                &records[trace.claim_worker_id], trace.claim_start_cycles, trace.claim_end_cycles,
+                trace.claim_loop_iter,
+                trace.ready_source == static_cast<uint64_t>(SchedulerReadySource::STOLEN) ? "ready_steal" :
+                                                                                            "ready_claim",
+                1, task_id
+            );
+        }
+        if (trace.dispatch_scheduler_worker_id < SCHEDULER_WORKER_CAPACITY) {
+            append_scheduler_record(
+                &records[trace.dispatch_scheduler_worker_id], trace.dispatch_start_cycles, trace.dispatch_end_cycles,
+                trace.dispatch_loop_iter, "dispatch", 1, task_id
+            );
+        }
+        if (trace.complete_scheduler_worker_id < SCHEDULER_WORKER_CAPACITY) {
+            append_scheduler_record(
+                &records[trace.complete_scheduler_worker_id], trace.complete_start_cycles, trace.complete_end_cycles,
+                trace.complete_loop_iter, "complete", 1, task_id
+            );
+        }
+        if (trace.refill_scheduler_worker_id < SCHEDULER_WORKER_CAPACITY) {
+            append_scheduler_record(
+                &records[trace.refill_scheduler_worker_id], trace.refill_start_cycles, trace.refill_end_cycles,
+                trace.refill_loop_iter, "direct_refill", 1, trace.refill_task_id
+            );
+        }
+        const SchedulerTaskControl &control = controls[task_id];
+        if (control.scheduler_worker_id < SCHEDULER_WORKER_CAPACITY) {
+            append_scheduler_record(
+                &records[control.scheduler_worker_id], control.completion_resolve_start_cycles,
+                control.completion_resolve_end_cycles, control.completion_resolve_loop_iter, "resolve", 1, task_id
+            );
+        }
+    }
+
+    std::vector<uint32_t> dropped_by_worker(SCHEDULER_WORKER_CAPACITY);
+    if (owner.layout.activity_buffers_offset != 0) {
+        const auto *activity =
+            scheduler_state_at<SchedulerActivityBuffer>(host_base, owner.layout.activity_buffers_offset);
+        for (uint64_t worker = 0; worker < SCHEDULER_WORKER_CAPACITY; ++worker) {
+            const SchedulerWorkerContext &context = contexts[worker];
+            if (context.is_scheduler == 0) continue;
+            if (context.scheduler_index >= SCHEDULER_CLUSTER_CAPACITY) {
+                LOG_WARN(
+                    "A5 HBG: invalid Scheduler activity index for worker=%" PRIu64 ": %" PRIu64, worker,
+                    context.scheduler_index
+                );
+                return false;
+            }
+            const SchedulerActivityBuffer &buffer = activity[context.scheduler_index];
+            const uint32_t committed = buffer.committed;
+            if (!scheduler_activity_record_count_valid(committed)) {
+                LOG_WARN("A5 HBG: invalid Scheduler activity count for worker=%" PRIu64 ": %u", worker, committed);
+                return false;
+            }
+            for (uint32_t index = 0; index < committed; ++index) {
+                const SchedulerIdleRecord &record = buffer.records[index];
+                append_scheduler_record(
+                    &records[worker], record.start_time, record.end_time, record.loop_iter, "idle", 0, 0, false
+                );
+            }
+            dropped_by_worker[worker] = buffer.dropped;
+        }
+    }
+
+    std::ostringstream scheduler_json;
+    scheduler_json << "{\n    \"schema_version\": 1,\n    \"streams\": [";
+    bool first_stream = true;
+    for (uint64_t worker = 0; worker < SCHEDULER_WORKER_CAPACITY; ++worker) {
+        const SchedulerWorkerContext &context = contexts[worker];
+        const uint32_t dropped = dropped_by_worker[worker];
+        if (context.is_scheduler == 0 || (records[worker].empty() && dropped == 0)) continue;
+        std::sort(records[worker].begin(), records[worker].end(), [](const auto &lhs, const auto &rhs) {
+            if (lhs.start_cycles != rhs.start_cycles) return lhs.start_cycles < rhs.start_cycles;
+            if (lhs.end_cycles != rhs.end_cycles) return lhs.end_cycles < rhs.end_cycles;
+            return std::strcmp(lhs.kind, rhs.kind) < 0;
+        });
+        if (!first_stream) scheduler_json << ",";
+        scheduler_json << "\n      {\"platform\": \"a5\", \"runtime\": \"host_build_graph\", "
+                          "\"producer\": \"aicore\", \"scheduler_id\": "
+                       << context.scheduler_index << ", \"worker_id\": " << worker << ", \"core_type\": \""
+                       << scheduler_core_type_name(context.core_type)
+                       << "\", \"physical_core_id\": " << context.physical_core_id
+                       << ", \"capture\": {\"committed\": " << records[worker].size() << ", \"dropped\": " << dropped
+                       << ", \"truncated\": " << (dropped == 0 ? "false" : "true") << "}, \"records\": [";
+        for (size_t index = 0; index < records[worker].size(); ++index) {
+            const SchedulerJsonRecord &record = records[worker][index];
+            if (index != 0) scheduler_json << ",";
+            scheduler_json << "\n        {\"start_cycles\": " << record.start_cycles
+                           << ", \"end_cycles\": " << record.end_cycles << ", \"loop_iter\": " << record.loop_iter
+                           << ", \"kind\": \"" << record.kind << "\", \"tasks_processed\": " << record.tasks_processed
+                           << ", \"task_id\": ";
+            if (record.has_task) scheduler_json << record.task_id;
+            else scheduler_json << "null";
+            scheduler_json << "}";
+        }
+        if (!records[worker].empty()) scheduler_json << "\n      ";
+        scheduler_json << "], \"metrics\": []}";
+        first_stream = false;
+    }
+    if (!first_stream) scheduler_json << "\n    ";
+    scheduler_json << "]\n  }";
+    const std::string scheduler_payload = scheduler_json.str();
+    if (!api->publish_chip_swimlane_extension(
+            ChipSwimlaneExtensionSection::SchedulerRecords, scheduler_payload.c_str(), scheduler_payload.size()
+        )) {
+        LOG_WARN("A5 HBG: failed to publish AICore Scheduler records");
+        return false;
+    }
+    return true;
+}
+
+extern "C" bool publish_runtime_chip_swimlane_extensions(Runtime *runtime) noexcept {
+    try {
+        if (runtime == nullptr) return true;
+        const HostApi *api = nullptr;
+        {
+            std::scoped_lock lock(scheduler_state_owners_mutex);
+            auto it = scheduler_state_owners.find(runtime);
+            if (it == scheduler_state_owners.end()) return true;
+            api = it->second.api;
+        }
+        return api != nullptr && publish_aicore_scheduler_profiling(runtime, api);
+    } catch (...) {
+        return false;
+    }
+}
 
 // host_build_graph is host-orchestration-first: the HOST dlopens the
 // orchestration .so and runs it to completion. Every cross-task reference the
@@ -816,7 +1112,10 @@ bool create_scheduler_state(
     }
 
     AicoreSchedulerLayout layout{};
-    if (!scheduler_plan_layout(static_cast<uint64_t>(total_tasks), aic_task_count, aiv_task_count, &layout) ||
+    if (!scheduler_plan_layout(
+            static_cast<uint64_t>(total_tasks), aic_task_count, aiv_task_count, &layout,
+            api->chip_swimlane_level() >= static_cast<uint32_t>(ChipSwimlaneLevel::SCHED_PHASES)
+        ) ||
         layout.total_size > std::numeric_limits<uint64_t>::max() - (SCHEDULER_STATE_ALIGNMENT - 1)) {
         LOG_ERROR("A5 HBG AICore scheduler: scheduler state layout overflow");
         return false;
@@ -877,6 +1176,7 @@ bool create_scheduler_state(
     run_control->aiv_task_count = aiv_task_count;
     run_control->aic_worker_demand = aic_worker_demand;
     run_control->aiv_worker_demand = aiv_worker_demand;
+    run_control->chip_swimlane_level = api->chip_swimlane_level();
     run_control->dispatch_payloads_offset = layout.dispatch_payloads_offset;
     run_control->task_metadata_offset = layout.task_metadata_offset;
     run_control->ready_inboxes_offset = layout.ready_inboxes_offset;
@@ -943,7 +1243,8 @@ bool create_scheduler_state(
     {
         std::scoped_lock lock(scheduler_state_owners_mutex);
         scheduler_state_owners.emplace(
-            runtime, SchedulerStateOwner{allocation, reinterpret_cast<void *>(aligned_address), allocation_size, layout}
+            runtime,
+            SchedulerStateOwner{allocation, reinterpret_cast<void *>(aligned_address), allocation_size, layout, api}
         );
     }
     LOG_INFO("A5 HBG: selected AICore Scheduler for %d tasks", total_tasks);

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.h
@@ -15,11 +15,26 @@
 
 #include "scheduler_ready.h"
 
+inline __aicore__ void scheduler_account_failed_completion(
+    const SchedulerGraphView &graph, __gm__ SchedulerWorkerContext *scheduler, __gm__ SchedulerRunControl *run_control,
+    int64_t task_id, SchedulerErrorSite error_site
+) {
+    // Preserve a more specific error already latched by the failing helper. The
+    // fallback covers argument/invariant guards that only report false.
+    scheduler_record_error(
+        run_control, task_id, SchedulerGraphResult::INVALID_ARGUMENTS, &graph, scheduler, error_site
+    );
+    // AICPU may treat the completion count as the terminal graph token. Publish
+    // the error first so this failed completion can never look like success.
+    scheduler_cache_barrier();
+    scheduler_gm_fetch_add(run_control->resolved_task_count, UINT64_C(1));
+}
+
 inline __aicore__ bool scheduler_service_cluster_completion_slot(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *scheduler,
     __gm__ SchedulerRunControl *run_control, uint32_t cluster_lane, uint32_t pending_slot,
     uint32_t completed_generation, SchedulerWakeStats *wake_stats, SchedulerReadyStats *ready_stats,
-    SchedulerCompletionStats *completion_stats, uint64_t *ready_victim_cursors, bool trace_enabled,
+    SchedulerCompletionStats *completion_stats, uint64_t *ready_victim_cursors, uint64_t profiling_level,
     const SchedulerReadyClaim *replacement_ready, bool *direct_refilled,
     SchedulerCompletionServiceTiming *timing = nullptr, __gm__ SchedulerReadyOwnerState *owner_state = nullptr
 ) {
@@ -45,16 +60,76 @@ inline __aicore__ bool scheduler_service_cluster_completion_slot(
         return false;
     }
 
-    const bool record_timeline = timing != nullptr;
-    uint64_t operation_start = record_timeline ? scheduler_cycles() : 0;
+    const bool chip_task_timing_enabled = scheduler_task_timing_enabled(profiling_level);
+    const bool schedule_timing_enabled = scheduler_schedule_timing_enabled(profiling_level);
+    const bool phase_timing_enabled = scheduler_phase_timing_enabled(profiling_level);
+    const bool record_timeline = phase_timing_enabled;
+    const uint64_t completion_start = schedule_timing_enabled ? scheduler_cycles() : 0;
+    uint64_t operation_start = record_timeline ? completion_start : 0;
     scheduler_observe_cache_line(slot);
     const int64_t task_id = slot->task_id;
+    if (task_id < 0 || static_cast<uint64_t>(task_id) >= graph.task_count) {
+        scheduler_record_error(run_control, task_id, SchedulerGraphResult::INVALID_TASK_ID, &graph, scheduler);
+        return false;
+    }
     if (slot->gang != 0) {
         scheduler_record_error(
             run_control, task_id, SchedulerGraphResult::UNSUPPORTED_SHAPE, &graph, scheduler,
             SchedulerErrorSite::COMPLETION_UNEXPECTED_GANG_SLOT
         );
         return false;
+    }
+    __gm__ SchedulerTaskMetadata *metadata = scheduler_task_metadata_at(scheduler_state_base, scheduler, task_id);
+    scheduler_observe_cache_line(metadata);
+    const bool sampled_task_timing_enabled =
+        metadata->timing_slot >= 0 && metadata->timing_slot < SCHEDULER_TASK_TIMING_SLOT_COUNT;
+    __gm__ SchedulerExecutorTaskTrace *executor_trace = &slot->executor_trace;
+    if (chip_task_timing_enabled || sampled_task_timing_enabled) {
+        if (scheduler_gm_query(executor_trace->generation) != completed_generation) {
+            scheduler_record_error(
+                run_control, task_id, SchedulerGraphResult::INVALID_ARGUMENTS, &graph, scheduler,
+                SchedulerErrorSite::COMPLETION_GENERATION_MISMATCH
+            );
+            return false;
+        }
+        scheduler_observe_cache_line(executor_trace);
+        scheduler_observe_cache_line(&executor_trace->completion_inbox_index);
+    }
+    __gm__ SchedulerTaskTrace *completed_trace = nullptr;
+    if (chip_task_timing_enabled || sampled_task_timing_enabled) {
+        __gm__ SchedulerTaskTrace *traces =
+            scheduler_state_at<SchedulerTaskTrace>(scheduler_state_base, scheduler->trace_cells_offset);
+        completed_trace = &traces[task_id];
+    }
+    if (chip_task_timing_enabled) {
+        scheduler_observe_cache_line(completed_trace);
+        scheduler_observe_cache_line(&completed_trace->kernel_start_cycles);
+        completed_trace->kernel_start_cycles = executor_trace->kernel_start_cycles;
+        completed_trace->kernel_end_cycles = executor_trace->kernel_end_cycles;
+        completed_trace->ready_observe_cycles = executor_trace->ready_observe_cycles;
+        if (schedule_timing_enabled) completed_trace->complete_start_cycles = completion_start;
+        if (phase_timing_enabled) {
+            scheduler_observe_cache_line(&completed_trace->ready_transition_cycles);
+            scheduler_observe_cache_line(&completed_trace->dispatch_start_cycles);
+            scheduler_observe_cache_line(&completed_trace->refill_scheduler_worker_id);
+            scheduler_observe_cache_line(&completed_trace->descriptor_cache_observed_cycles);
+            completed_trace->completion_end_cycles = executor_trace->completion_end_cycles;
+            completed_trace->ready_scan_start_cycles = executor_trace->ready_scan_start_cycles;
+            completed_trace->completion_bookkeeping_end_cycles = executor_trace->completion_bookkeeping_end_cycles;
+            completed_trace->completion_id = executor_trace->completion_id;
+            completed_trace->completion_inbox_index = executor_trace->completion_inbox_index;
+            scheduler_observe_cache_line(&target->trace_aicore_entry_cycles);
+            scheduler_observe_cache_line(&target->trace_register_release_cycles);
+            completed_trace->descriptor_cache_observed_cycles = target->trace_descriptor_cache_observed_cycles;
+            completed_trace->aicore_entry_cycles = target->trace_aicore_entry_cycles;
+            completed_trace->handshake_publish_cycles = target->trace_handshake_publish_cycles;
+            completed_trace->register_release_cycles = target->trace_register_release_cycles;
+            completed_trace->complete_scheduler_worker_id = scheduler->worker_index;
+            completed_trace->complete_loop_iter = scheduler->profiling_loop_iter;
+        }
+    } else if (completed_trace != nullptr) {
+        completed_trace->kernel_start_cycles = executor_trace->kernel_start_cycles;
+        completed_trace->kernel_end_cycles = executor_trace->kernel_end_cycles;
     }
     const uint8_t completed_subtask_slot = slot->subtask_slot;
     scheduler_gm_store(completion_line->completed_generations[pending_slot], UINT32_C(0));
@@ -71,16 +146,14 @@ inline __aicore__ bool scheduler_service_cluster_completion_slot(
     scheduler_gm_store(control->state, static_cast<int64_t>(SchedulerTaskState::DONE));
     if (!scheduler_resolve_completion(
             graph, scheduler_state_base, scheduler, run_control, task_id, wake_stats, ready_stats, completion_stats,
-            owner_state, trace_enabled, false, timing == nullptr ? nullptr : &ready_publish_cycles
-        ))
+            owner_state, profiling_level, false, timing == nullptr ? nullptr : &ready_publish_cycles
+        )) {
+        scheduler_account_failed_completion(
+            graph, scheduler, run_control, task_id, SchedulerErrorSite::COMPLETION_RESOLVE_FAILED
+        );
         return false;
-    if (timing != nullptr) timing->ready_publish_cycles += ready_publish_cycles;
-    uint64_t resolved_count_start = timing == nullptr ? 0 : scheduler_cycles();
-    scheduler_gm_fetch_add(run_control->resolved_task_count, UINT64_C(1));
-    if (timing != nullptr) {
-        finalize_cycles = scheduler_cycles() - resolved_count_start;
-        timing->finalize_cycles += finalize_cycles;
     }
+    if (timing != nullptr) timing->ready_publish_cycles += ready_publish_cycles;
     refill_start_cycles = record_timeline ? scheduler_cycles() : 0;
     SchedulerReadyClaim ready{};
     bool ready_available = replacement_ready != nullptr;
@@ -92,17 +165,25 @@ inline __aicore__ bool scheduler_service_cluster_completion_slot(
         const uint32_t core_type = scheduler_metadata_core_type_index(completed_subtask_slot);
         if (!scheduler_claim_ready_for_slot(
                 graph, scheduler_state_base, scheduler, run_control, scheduler->scheduler_count, core_type,
-                &ready_victim_cursors[core_type], ready_stats, &ready, owner_state, trace_enabled
-            ))
+                &ready_victim_cursors[core_type], ready_stats, &ready, owner_state, profiling_level
+            )) {
+            scheduler_account_failed_completion(
+                graph, scheduler, run_control, task_id, SchedulerErrorSite::COMPLETION_REFILL_CLAIM_FAILED
+            );
             return false;
+        }
         ready_available = ready.task_id >= 0;
     }
     if (ready_available) {
         SchedulerFreeSlotClaim claim{worker_id, pending_slot, slot->generation};
         if (!scheduler_fill_dispatch_slot(
-                graph, scheduler_state_base, scheduler, run_control, claim, ready, trace_enabled
-            ))
+                graph, scheduler_state_base, scheduler, run_control, claim, ready, profiling_level
+            )) {
+            scheduler_account_failed_completion(
+                graph, scheduler, run_control, task_id, SchedulerErrorSite::COMPLETION_REFILL_DISPATCH_FAILED
+            );
             return false;
+        }
         refilled = true;
     }
     refill_end_cycles = record_timeline ? scheduler_cycles() : 0;
@@ -126,6 +207,38 @@ inline __aicore__ bool scheduler_service_cluster_completion_slot(
     }
     const uint64_t completion_end = record_timeline ? scheduler_cycles() : 0;
     if (timing != nullptr) timing->finalize_cycles += completion_end - operation_start;
+    if (chip_task_timing_enabled) {
+        if (phase_timing_enabled) {
+            completed_trace->complete_end_cycles = completion_end;
+        }
+        if (phase_timing_enabled && refilled) {
+            completed_trace->refill_scheduler_worker_id = scheduler->worker_index;
+            completed_trace->refill_start_cycles = refill_start_cycles;
+            completed_trace->refill_end_cycles = refill_end_cycles;
+            completed_trace->refill_task_id = static_cast<uint64_t>(ready.task_id);
+            completed_trace->refill_loop_iter = scheduler->profiling_loop_iter;
+        }
+        scheduler_writeback_cache_line(completed_trace);
+        scheduler_writeback_cache_line(&completed_trace->kernel_start_cycles);
+        if (phase_timing_enabled) scheduler_writeback_cache_line(&completed_trace->ready_transition_cycles);
+        if (schedule_timing_enabled) scheduler_writeback_cache_line(&completed_trace->dispatch_start_cycles);
+        if (phase_timing_enabled) scheduler_writeback_cache_line(&completed_trace->refill_scheduler_worker_id);
+        if (phase_timing_enabled) scheduler_writeback_cache_line(&completed_trace->descriptor_cache_observed_cycles);
+        scheduler_cache_barrier();
+        scheduler_gm_publish(completed_trace->valid, UINT64_C(1));
+        // AICPU treats resolved_task_count as the graph-completion token. Keep
+        // valid globally ordered before that token so host collection cannot
+        // race the final trace publication.
+        scheduler_cache_barrier();
+    } else if (completed_trace != nullptr) {
+        scheduler_publish_cache_line(&completed_trace->kernel_start_cycles);
+    }
+    const uint64_t resolved_count_start = timing == nullptr ? 0 : scheduler_cycles();
+    scheduler_gm_fetch_add(run_control->resolved_task_count, UINT64_C(1));
+    if (timing != nullptr) {
+        finalize_cycles = scheduler_cycles() - resolved_count_start;
+        timing->finalize_cycles += finalize_cycles;
+    }
     if (direct_refilled != nullptr) *direct_refilled = refilled;
     return true;
 }
@@ -138,7 +251,7 @@ inline __aicore__ uint32_t scheduler_completion_catchup_mask(uint32_t initial_co
 inline __aicore__ bool scheduler_service_cluster_completions(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *scheduler,
     __gm__ SchedulerRunControl *run_control, SchedulerWakeStats *wake_stats, SchedulerReadyStats *ready_stats,
-    SchedulerCompletionStats *completion_stats, uint64_t *ready_victim_cursors = nullptr, bool trace_enabled = false,
+    SchedulerCompletionStats *completion_stats, uint64_t *ready_victim_cursors = nullptr, uint64_t profiling_level = 0,
     uint64_t *direct_refilled_slot_mask = nullptr, SchedulerCompletionServiceTiming *timing = nullptr,
     __gm__ SchedulerReadyOwnerState *owner_state = nullptr
 ) {
@@ -171,7 +284,7 @@ inline __aicore__ bool scheduler_service_cluster_completions(
                 if (!scheduler_service_cluster_completion_slot(
                         graph, scheduler_state_base, scheduler, run_control, cluster_lane, pending_slot,
                         completed_generation, wake_stats, ready_stats, completion_stats, ready_victim_cursors,
-                        trace_enabled, nullptr, &direct_refilled, timing, owner_state
+                        profiling_level, nullptr, &direct_refilled, timing, owner_state
                     ))
                     return false;
                 if (direct_refilled && direct_refilled_slot_mask != nullptr)

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.h
@@ -70,7 +70,7 @@ inline __aicore__ bool scheduler_normal_aiv_worker_precedes(
 inline __aicore__ bool scheduler_fill_cluster_normal_slots(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *scheduler,
     __gm__ SchedulerRunControl *run_control, uint64_t *ready_victim_cursors, SchedulerReadyStats *ready_stats,
-    bool trace_enabled, uint64_t skip_slot_mask = 0, SchedulerNormalDispatchTiming *timing = nullptr,
+    uint64_t profiling_level, uint64_t skip_slot_mask = 0, SchedulerNormalDispatchTiming *timing = nullptr,
     SchedulerDeferredAivQueue *deferred_aiv = nullptr, __gm__ SchedulerReadyOwnerState *owner_state = nullptr,
     bool *failed = nullptr
 ) {
@@ -104,7 +104,7 @@ inline __aicore__ bool scheduler_fill_cluster_normal_slots(
                 SchedulerReadyClaim ready{};
                 if (!scheduler_claim_ready_for_slot(
                         graph, scheduler_state_base, scheduler, run_control, scheduler->scheduler_count, aic_core_type,
-                        &ready_victim_cursors[aic_core_type], ready_stats, &ready, owner_state, trace_enabled
+                        &ready_victim_cursors[aic_core_type], ready_stats, &ready, owner_state, profiling_level
                     )) {
                     if (failed != nullptr) *failed = true;
                     return progress;
@@ -126,7 +126,7 @@ inline __aicore__ bool scheduler_fill_cluster_normal_slots(
                 );
                 SchedulerDispatchFillTiming fill_timing{};
                 if (!scheduler_fill_dispatch_slot(
-                        graph, scheduler_state_base, scheduler, run_control, claim, ready, trace_enabled,
+                        graph, scheduler_state_base, scheduler, run_control, claim, ready, profiling_level,
                         timing == nullptr ? nullptr : &fill_timing
                     )) {
                     if (failed != nullptr) *failed = true;
@@ -226,7 +226,7 @@ inline __aicore__ bool scheduler_fill_cluster_normal_slots(
             SchedulerReadyClaim ready{};
             if (!scheduler_claim_ready_for_slot(
                     graph, scheduler_state_base, scheduler, run_control, scheduler->scheduler_count, aiv_core_type,
-                    &ready_victim_cursors[aiv_core_type], ready_stats, &ready, owner_state, trace_enabled
+                    &ready_victim_cursors[aiv_core_type], ready_stats, &ready, owner_state, profiling_level
                 )) {
                 scheduler_gm_store(
                     slot->publication,
@@ -252,7 +252,7 @@ inline __aicore__ bool scheduler_fill_cluster_normal_slots(
             }
             SchedulerDispatchFillTiming fill_timing{};
             if (!scheduler_fill_dispatch_slot(
-                    graph, scheduler_state_base, scheduler, run_control, claim, ready, trace_enabled,
+                    graph, scheduler_state_base, scheduler, run_control, claim, ready, profiling_level,
                     timing == nullptr ? nullptr : &fill_timing
                 )) {
                 if (failed != nullptr) *failed = true;
@@ -317,7 +317,7 @@ scheduler_deferred_aiv_peer_lane(__gm__ void *scheduler_state_base, __gm__ Sched
 inline __aicore__ bool scheduler_drain_deferred_aiv_to_peer(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *scheduler,
     __gm__ SchedulerRunControl *run_control, SchedulerDeferredAivQueue *queue, SchedulerWakeStats *wake_stats,
-    SchedulerReadyStats *ready_stats, SchedulerCompletionStats *completion_stats, bool trace_enabled,
+    SchedulerReadyStats *ready_stats, SchedulerCompletionStats *completion_stats, uint64_t profiling_level,
     SchedulerCompletionServiceTiming *completion_timing = nullptr,
     SchedulerNormalDispatchTiming *dispatch_timing = nullptr, __gm__ SchedulerReadyOwnerState *owner_state = nullptr
 ) {
@@ -353,7 +353,7 @@ inline __aicore__ bool scheduler_drain_deferred_aiv_to_peer(
                 if (!scheduler_fill_dispatch_slot(
                         graph, scheduler_state_base, scheduler, run_control,
                         SchedulerFreeSlotClaim{peer_worker_id, pending_slot, generation}, queue->entries[0].ready,
-                        trace_enabled, dispatch_timing == nullptr ? nullptr : &fill_timing
+                        profiling_level, dispatch_timing == nullptr ? nullptr : &fill_timing
                     ))
                     return false;
                 if (dispatch_timing != nullptr) {
@@ -372,7 +372,7 @@ inline __aicore__ bool scheduler_drain_deferred_aiv_to_peer(
                 if (!scheduler_service_cluster_completion_slot(
                         graph, scheduler_state_base, scheduler, run_control, static_cast<uint32_t>(peer_lane),
                         pending_slot, completed_generation, wake_stats, ready_stats, completion_stats, nullptr,
-                        trace_enabled, &queue->entries[0].ready, &refilled, completion_timing, owner_state
+                        profiling_level, &queue->entries[0].ready, &refilled, completion_timing, owner_state
                     ) ||
                     !refilled)
                     return false;
@@ -389,7 +389,7 @@ inline __aicore__ bool scheduler_drain_deferred_aiv_to_peer(
 
 inline __aicore__ bool scheduler_publish_deferred_aiv_local(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *scheduler,
-    __gm__ SchedulerRunControl *run_control, SchedulerDeferredAivQueue *queue, bool trace_enabled,
+    __gm__ SchedulerRunControl *run_control, SchedulerDeferredAivQueue *queue, uint64_t profiling_level,
     uint32_t *published_slot, SchedulerNormalDispatchTiming *timing = nullptr
 ) {
     if (published_slot != nullptr) *published_slot = UINT32_MAX;
@@ -420,7 +420,7 @@ inline __aicore__ bool scheduler_publish_deferred_aiv_local(
     const uint32_t aiv_core_type = static_cast<uint32_t>(CoreType::AIV);
     SchedulerDispatchFillTiming fill_timing{};
     if (!scheduler_fill_dispatch_slot(
-            graph, scheduler_state_base, scheduler, run_control, entry.reserved_slot, entry.ready, trace_enabled,
+            graph, scheduler_state_base, scheduler, run_control, entry.reserved_slot, entry.ready, profiling_level,
             timing == nullptr ? nullptr : &fill_timing
         ))
         return false;

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_layout.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_layout.h
@@ -39,6 +39,7 @@ struct AicoreSchedulerLayout {
     uint64_t ready_owner_states_offset;
     uint64_t ready_directory_offset;
     uint64_t trace_cells_offset;
+    uint64_t activity_buffers_offset;
     uint64_t gang_coordinator_offset;
     uint64_t gang_cohorts_offset;
     uint64_t gang_participants_offset;

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_ready.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_ready.h
@@ -123,7 +123,7 @@ struct SchedulerDispatchFillTiming {
 };
 
 inline __aicore__ uint64_t scheduler_cycles() {
-#if defined(__CCE_AICORE__)
+#if defined(__CCE_AICORE__) || defined(__CPU_SIM)
     return get_sys_cnt_aicore();
 #else
     return 0;
@@ -274,6 +274,40 @@ inline __aicore__ __gm__ SchedulerWorkerContext *scheduler_worker_context_at(
     return scheduler_state_at<SchedulerWorkerContext>(
         scheduler_state_base, context->worker_contexts_offset + worker_id * sizeof(SchedulerWorkerContext)
     );
+}
+
+inline __aicore__ __gm__ SchedulerActivityBuffer *
+scheduler_activity_buffer_at(__gm__ void *scheduler_state_base, __gm__ const SchedulerWorkerContext *context) {
+    if (context->activity_buffers_offset == 0 || context->is_scheduler == 0 ||
+        context->scheduler_index >= SCHEDULER_CLUSTER_CAPACITY)
+        return nullptr;
+    return scheduler_state_at<SchedulerActivityBuffer>(
+        scheduler_state_base,
+        context->activity_buffers_offset + context->scheduler_index * sizeof(SchedulerActivityBuffer)
+    );
+}
+
+inline __aicore__ void scheduler_append_idle_activity(
+    __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context, uint64_t start_cycles,
+    uint64_t end_cycles
+) {
+    __gm__ SchedulerActivityBuffer *buffer = scheduler_activity_buffer_at(scheduler_state_base, context);
+    if (buffer == nullptr || end_cycles < start_cycles) return;
+    const uint64_t capture_counts = scheduler_gm_query_u32_pair(&buffer->committed);
+    const uint32_t committed = static_cast<uint32_t>(capture_counts);
+    if (committed >= SCHEDULER_ACTIVITY_CAPACITY) {
+        scheduler_gm_store(buffer->dropped, static_cast<uint32_t>(capture_counts >> 32) + 1);
+        return;
+    }
+    __gm__ SchedulerIdleRecord *record = &buffer->records[committed];
+    record->start_time = start_cycles;
+    record->end_time = end_cycles;
+    record->loop_iter = static_cast<uint32_t>(context->profiling_loop_iter);
+    record->reserved = 0;
+    scheduler_writeback_cache_line(record);
+    scheduler_writeback_cache_line(&record->reserved);
+    scheduler_cache_barrier();
+    scheduler_gm_store(buffer->committed, committed + 1);
 }
 
 inline __aicore__ __gm__ SchedulerDispatchSlot *scheduler_dispatch_slot_at(
@@ -459,7 +493,7 @@ inline __aicore__ SchedulerRouteResult scheduler_bootstrap_route_task(
 
 inline __aicore__ bool scheduler_bootstrap_ready_batch_append(
     __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context, int64_t task_id,
-    SchedulerReadyBatch *batch, SchedulerReadyStats *stats, bool trace_enabled = false
+    SchedulerReadyBatch *batch, SchedulerReadyStats *stats, uint64_t profiling_level = 0
 ) {
     if (batch == nullptr || task_id < 0 || static_cast<uint64_t>(task_id) >= context->graph_task_count) return false;
     // next_waiter belongs to exactly one wake or Ready chain while the task is live.
@@ -475,7 +509,7 @@ inline __aicore__ bool scheduler_bootstrap_ready_batch_append(
         scheduler_writeback_cache_line(&tail->next_waiter);
     }
     batch->tail = task_id;
-    if (trace_enabled) {
+    if (scheduler_phase_timing_enabled(profiling_level)) {
         __gm__ SchedulerTaskTrace *cells =
             scheduler_state_at<SchedulerTaskTrace>(scheduler_state_base, context->trace_cells_offset);
         cells[task_id].ready_transition_cycles = scheduler_cycles();
@@ -534,7 +568,7 @@ inline __aicore__ bool scheduler_bootstrap_ready_directory_publish(
 
 inline __aicore__ bool scheduler_ready_batch_append(
     __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context, int64_t task_id,
-    SchedulerReadyBatch *batch, SchedulerReadyStats *stats, bool trace_enabled = false
+    SchedulerReadyBatch *batch, SchedulerReadyStats *stats, uint64_t profiling_level = 0
 ) {
     if (batch == nullptr || task_id < 0 || static_cast<uint64_t>(task_id) >= context->graph_task_count) return false;
     // next_waiter belongs to exactly one wake or Ready chain while the task is live.
@@ -551,7 +585,7 @@ inline __aicore__ bool scheduler_ready_batch_append(
         scheduler_publish_cache_line(&tail->next_waiter);
     }
     batch->tail = task_id;
-    if (trace_enabled) {
+    if (scheduler_phase_timing_enabled(profiling_level)) {
         __gm__ SchedulerTaskTrace *cells =
             scheduler_state_at<SchedulerTaskTrace>(scheduler_state_base, context->trace_cells_offset);
         __gm__ SchedulerTaskTrace *trace = &cells[task_id];
@@ -795,7 +829,7 @@ inline __aicore__ uint64_t scheduler_load_ready_directory_shard(
 inline __aicore__ bool scheduler_steal_ready_from_shard(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context,
     __gm__ SchedulerRunControl *run_control, uint32_t core_type_index, uint64_t shard_begin, uint64_t shard_end,
-    uint64_t start, uint64_t bits, SchedulerReadyStats *stats, SchedulerReadyClaim *claim, bool trace_enabled
+    uint64_t start, uint64_t bits, SchedulerReadyStats *stats, SchedulerReadyClaim *claim, uint64_t profiling_level
 ) {
     int64_t task_id = SCHEDULER_TASK_ID_INVALID;
     bits &= ~(UINT64_C(1) << (context->inbox_index - shard_begin));
@@ -818,7 +852,7 @@ inline __aicore__ bool scheduler_steal_ready_from_shard(
                 claim->task_id = task_id;
                 claim->inbox_index = victim;
                 claim->source = SchedulerReadySource::STOLEN;
-                claim->claim_end_cycles = trace_enabled ? scheduler_cycles() : 0;
+                claim->claim_end_cycles = scheduler_phase_timing_enabled(profiling_level) ? scheduler_cycles() : 0;
                 if (stats != nullptr) ++stats->steal_count;
                 return true;
             }
@@ -831,14 +865,14 @@ inline __aicore__ bool scheduler_claim_ready_for_slot(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context,
     __gm__ SchedulerRunControl *run_control, uint64_t scheduler_count, uint32_t core_type_index,
     uint64_t *victim_cursor, SchedulerReadyStats *stats, SchedulerReadyClaim *claim,
-    __gm__ SchedulerReadyOwnerState *owner_state, bool trace_enabled = false
+    __gm__ SchedulerReadyOwnerState *owner_state, uint64_t profiling_level = 0
 ) {
     if (victim_cursor == nullptr || claim == nullptr || owner_state == nullptr || scheduler_count == 0 ||
         scheduler_count > SCHEDULER_CAPACITY || context->inbox_index >= scheduler_count ||
         core_type_index >= SCHEDULER_CORE_TYPE_COUNT)
         return false;
     *claim = {};
-    claim->claim_start_cycles = trace_enabled ? scheduler_cycles() : 0;
+    claim->claim_start_cycles = scheduler_phase_timing_enabled(profiling_level) ? scheduler_cycles() : 0;
     if (!scheduler_ready_owner_maintain_type(scheduler_state_base, context, core_type_index, owner_state)) return false;
     int64_t task_id = SCHEDULER_TASK_ID_INVALID;
     if (!scheduler_ready_pop_from_inbox(
@@ -848,7 +882,7 @@ inline __aicore__ bool scheduler_claim_ready_for_slot(
     if (task_id >= 0) {
         claim->task_id = task_id;
         claim->inbox_index = context->inbox_index;
-        claim->claim_end_cycles = trace_enabled ? scheduler_cycles() : 0;
+        claim->claim_end_cycles = scheduler_phase_timing_enabled(profiling_level) ? scheduler_cycles() : 0;
         return true;
     }
 
@@ -863,13 +897,13 @@ inline __aicore__ bool scheduler_claim_ready_for_slot(
         scheduler_load_ready_directory_shard(directory, scheduler_count, core_type_index, context->inbox_index);
     if (bits != 0 && !scheduler_steal_ready_from_shard(
                          graph, scheduler_state_base, context, run_control, core_type_index, shard_begin, shard_end,
-                         start, bits, stats, claim, trace_enabled
+                         start, bits, stats, claim, profiling_level
                      ))
         return false;
     const uint64_t cursor_base = claim->task_id >= 0 ? claim->inbox_index : start;
     *victim_cursor = cursor_base + 1 == shard_end ? shard_begin : cursor_base + 1;
     if (claim->task_id >= 0) return true;
-    claim->claim_end_cycles = trace_enabled ? scheduler_cycles() : 0;
+    claim->claim_end_cycles = scheduler_phase_timing_enabled(profiling_level) ? scheduler_cycles() : 0;
     return true;
 }
 
@@ -898,13 +932,17 @@ inline __aicore__ void scheduler_initialize_free_slot(__gm__ SchedulerDispatchSl
 inline __aicore__ bool scheduler_fill_dispatch_slot(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *scheduler,
     __gm__ SchedulerRunControl *run_control, const SchedulerFreeSlotClaim &slot_claim,
-    const SchedulerReadyClaim &ready_claim, bool trace_enabled = false, SchedulerDispatchFillTiming *timing = nullptr
+    const SchedulerReadyClaim &ready_claim, uint64_t profiling_level = 0, SchedulerDispatchFillTiming *timing = nullptr
 ) {
     if (ready_claim.task_id < 0 || static_cast<uint64_t>(ready_claim.task_id) >= graph.task_count ||
         slot_claim.worker_id >= scheduler->runtime_worker_count ||
         slot_claim.slot_index >= SCHEDULER_PENDING_SLOT_COUNT)
         return false;
     const bool record_timeline = timing != nullptr;
+    const bool task_timing_enabled = scheduler_task_timing_enabled(profiling_level);
+    const bool schedule_timing_enabled = scheduler_schedule_timing_enabled(profiling_level);
+    const bool phase_timing_enabled = scheduler_phase_timing_enabled(profiling_level);
+    const uint64_t dispatch_start_cycles = phase_timing_enabled ? scheduler_cycles() : 0;
     uint64_t operation_start = record_timeline ? scheduler_cycles() : 0;
     __gm__ SchedulerTaskMetadata *metadata_source =
         scheduler_task_metadata_at(scheduler_state_base, scheduler, ready_claim.task_id);
@@ -1011,13 +1049,33 @@ inline __aicore__ bool scheduler_fill_dispatch_slot(
     scheduler_publish_dispatch_payload(payload);
     __gm__ SchedulerTaskControl *control =
         scheduler_task_control_at(scheduler_state_base, scheduler, ready_claim.task_id);
-    if (trace_enabled) {
+    if (phase_timing_enabled) {
         scheduler_observe_cache_line(&control->next_waiter);
         control->ready_publish_cycles = scheduler_cycles();
         scheduler_publish_cache_line(&control->next_waiter);
     }
     uint64_t publish_end = record_timeline ? scheduler_cycles() : 0;
     if (timing != nullptr) timing->publish_cycles += publish_end - materialize_end;
+    if (task_timing_enabled) {
+        __gm__ SchedulerTaskTrace *traces =
+            scheduler_state_at<SchedulerTaskTrace>(scheduler_state_base, scheduler->trace_cells_offset);
+        __gm__ SchedulerTaskTrace *trace = &traces[ready_claim.task_id];
+        trace->worker_id = slot_claim.worker_id;
+        trace->task_id = static_cast<uint64_t>(ready_claim.task_id);
+        if (phase_timing_enabled) {
+            trace->ready_source = static_cast<uint64_t>(ready_claim.source);
+            trace->claim_worker_id = scheduler->worker_index;
+            trace->claim_start_cycles = ready_claim.claim_start_cycles;
+            trace->claim_end_cycles = ready_claim.claim_end_cycles;
+            trace->claim_loop_iter = scheduler->profiling_loop_iter;
+            trace->dispatch_start_cycles = dispatch_start_cycles;
+            trace->dispatch_scheduler_worker_id = scheduler->worker_index;
+            trace->dispatch_loop_iter = scheduler->profiling_loop_iter;
+        }
+        if (schedule_timing_enabled) trace->dispatch_end_cycles = scheduler_cycles();
+        scheduler_publish_cache_line(trace);
+        if (schedule_timing_enabled) scheduler_publish_cache_line(&trace->dispatch_start_cycles);
+    }
     scheduler_gm_publish(
         slot->publication, scheduler_dispatch_publication(generation, SchedulerDispatchSlotState::READY)
     );
@@ -1028,7 +1086,7 @@ inline __aicore__ bool scheduler_resolve_completion(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context,
     __gm__ SchedulerRunControl *run_control, int64_t task_id, SchedulerWakeStats *wake_stats,
     SchedulerReadyStats *ready_stats, SchedulerCompletionStats *completion_stats,
-    __gm__ SchedulerReadyOwnerState *owner_state, bool trace_enabled = false, bool validate_done_state = true,
+    __gm__ SchedulerReadyOwnerState *owner_state, uint64_t profiling_level = 0, bool validate_done_state = true,
     uint64_t *ready_publish_cycles = nullptr
 ) {
     if (owner_state == nullptr) return false;
@@ -1040,11 +1098,13 @@ inline __aicore__ bool scheduler_resolve_completion(
         );
         return false;
     }
-    uint64_t resolve_start = trace_enabled ? scheduler_cycles() : 0;
-    if (trace_enabled) {
+    const bool phase_timing_enabled = scheduler_phase_timing_enabled(profiling_level);
+    uint64_t resolve_start = phase_timing_enabled ? scheduler_cycles() : 0;
+    if (phase_timing_enabled) {
         scheduler_observe_cache_line(&control->next_waiter);
         control->completion_resolve_start_cycles = resolve_start;
         control->scheduler_worker_id = context->worker_index;
+        control->completion_resolve_loop_iter = context->profiling_loop_iter;
     }
     int64_t waiter = scheduler_gm_exchange(control->wake_list_head, SCHEDULER_WAKE_LIST_CLOSED);
     if (waiter == SCHEDULER_WAKE_LIST_CLOSED) {
@@ -1095,7 +1155,7 @@ inline __aicore__ bool scheduler_resolve_completion(
                 }
                 if (!scheduler_ready_batch_append(
                         scheduler_state_base, context, waiter,
-                        &batches[scheduler_metadata_core_type_index(subtask_slot)], ready_stats, trace_enabled
+                        &batches[scheduler_metadata_core_type_index(subtask_slot)], ready_stats, profiling_level
                     )) {
                     scheduler_record_error(
                         run_control, waiter, SchedulerGraphResult::INVALID_ARGUMENTS, &graph, context,
@@ -1120,7 +1180,7 @@ inline __aicore__ bool scheduler_resolve_completion(
         }
     }
     if (ready_publish_cycles != nullptr) *ready_publish_cycles += scheduler_cycles() - ready_publish_start;
-    if (trace_enabled) {
+    if (phase_timing_enabled) {
         control->completion_resolve_end_cycles = scheduler_cycles();
         scheduler_publish_cache_line(&control->next_waiter);
     }

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
@@ -627,6 +627,26 @@ inline constexpr uint32_t SCHEDULER_CORE_TYPE_COUNT = 2;
 inline constexpr uint32_t SCHEDULER_CLUSTER_CAPACITY = SCHEDULER_WORKER_CAPACITY / 3;
 inline constexpr uint32_t SCHEDULER_CAPACITY = SCHEDULER_CLUSTER_CAPACITY;
 inline constexpr uint32_t SCHEDULER_GANG_COHORT_COUNT = 2;
+inline constexpr uint32_t SCHEDULER_ACTIVITY_CAPACITY = 1024;
+inline constexpr uint64_t SCHEDULER_PROFILING_TASK_TIMING_LEVEL = 1;
+inline constexpr uint64_t SCHEDULER_PROFILING_SCHEDULE_TIMING_LEVEL = 2;
+inline constexpr uint64_t SCHEDULER_PROFILING_SCHED_PHASES_LEVEL = 3;
+
+inline __aicore__ bool scheduler_task_timing_enabled(uint64_t level) {
+    return level >= SCHEDULER_PROFILING_TASK_TIMING_LEVEL;
+}
+
+inline __aicore__ bool scheduler_schedule_timing_enabled(uint64_t level) {
+    return level >= SCHEDULER_PROFILING_SCHEDULE_TIMING_LEVEL;
+}
+
+inline __aicore__ bool scheduler_phase_timing_enabled(uint64_t level) {
+    return level >= SCHEDULER_PROFILING_SCHED_PHASES_LEVEL;
+}
+
+inline constexpr bool scheduler_activity_record_count_valid(uint32_t committed) noexcept {
+    return committed <= SCHEDULER_ACTIVITY_CAPACITY;
+}
 inline constexpr uint32_t SCHEDULER_READY_DIRECTORY_OWNERS_PER_SHARD = 7;
 inline constexpr uint32_t SCHEDULER_READY_DIRECTORY_SHARD_COUNT =
     (SCHEDULER_CAPACITY + SCHEDULER_READY_DIRECTORY_OWNERS_PER_SHARD - 1) / SCHEDULER_READY_DIRECTORY_OWNERS_PER_SHARD;
@@ -647,6 +667,22 @@ enum class SchedulerReadySource : uint8_t {
     LOCAL = 0,
     STOLEN = 1,
 };
+
+struct SchedulerIdleRecord {
+    uint64_t start_time;
+    uint64_t end_time;
+    uint32_t loop_iter;
+    uint32_t reserved;
+};
+static_assert(sizeof(SchedulerIdleRecord) == 24, "Scheduler idle record layout changed");
+
+struct alignas(64) SchedulerActivityBuffer {
+    volatile uint32_t committed;
+    volatile uint32_t dropped;
+    uint32_t reserved[2];
+    SchedulerIdleRecord records[SCHEDULER_ACTIVITY_CAPACITY];
+};
+static_assert(sizeof(SchedulerActivityBuffer) % 64 == 0, "scheduler activity buffer must be cache aligned");
 
 enum class SchedulerDispatchSlotState : uint8_t {
     EMPTY = 0,
@@ -740,7 +776,8 @@ struct alignas(128) SchedulerTaskControl {
     uint64_t completion_resolve_end_cycles;
     uint64_t ready_publish_cycles;
     uint64_t scheduler_worker_id;
-    uint8_t scheduler_line_padding[16];
+    uint64_t completion_resolve_loop_iter;
+    uint8_t scheduler_line_padding[8];
 };
 
 struct alignas(64) SchedulerCompletionInbox {
@@ -858,8 +895,25 @@ struct alignas(128) SchedulerReadyDirectory {
     volatile uint64_t bootstrap_ready_types[SCHEDULER_WORKER_CAPACITY];
 };
 
+// The Executor publishes this per-slot payload before the completion generation.
+// The generation is the release/acquire hand-off to the Scheduler; neither side
+// writes the final per-task trace concurrently.
+struct alignas(128) SchedulerExecutorTaskTrace {
+    volatile uint64_t generation;
+    uint64_t kernel_start_cycles;
+    uint64_t kernel_end_cycles;
+    uint64_t ready_scan_start_cycles;
+    uint64_t ready_observe_cycles;
+    uint64_t completion_end_cycles;
+    uint64_t completion_bookkeeping_end_cycles;
+    uint64_t completion_id;
+
+    uint64_t completion_inbox_index;
+    uint64_t reserved[7];
+};
+
 // Scheduler-owned metadata occupies the first line. The Executor polls only
-// publication in the second line.
+// publication in the second line and owns the trailing trace payload.
 struct alignas(128) SchedulerDispatchSlot {
     int64_t task_id;
     uint64_t ready_inbox_index;
@@ -881,6 +935,8 @@ struct alignas(128) SchedulerDispatchSlot {
 
     volatile uint64_t publication;
     uint8_t publication_padding[56];
+
+    SchedulerExecutorTaskTrace executor_trace;
 };
 
 // Stable device-side localization for the first scheduler failure. These values
@@ -903,6 +959,9 @@ enum class SchedulerErrorSite : uint64_t {
     COMPLETION_READY_APPEND_FAILED = 65,
     COMPLETION_READY_PUBLISH_FAILED = 66,
     COMPLETION_INVALID_SHAPE = 67,
+    COMPLETION_RESOLVE_FAILED = 68,
+    COMPLETION_REFILL_CLAIM_FAILED = 69,
+    COMPLETION_REFILL_DISPATCH_FAILED = 70,
     COMPLETION_UNEXPECTED_GANG_SLOT = 73,
     COMPLETION_GENERATION_MISMATCH = 74,
     DEFERRED_RESERVATION_INVALID_OWNER = 75,
@@ -955,7 +1014,8 @@ struct alignas(128) SchedulerRunControl {
     volatile uint64_t bootstrap_scan_arrived_count;
     volatile uint64_t bootstrap_scan_complete;
     volatile uint64_t scheduler_timeout_cycles;
-    uint64_t lifecycle_reserved[2];
+    volatile uint64_t chip_swimlane_level;
+    uint64_t lifecycle_reserved;
 
     volatile uint64_t error_claimed;
     volatile uint64_t scheduler_error;
@@ -1036,7 +1096,7 @@ struct alignas(128) SchedulerWorkerContext {
     volatile uint64_t task_metadata_offset;
     volatile uint64_t ready_inboxes_offset;
     volatile uint64_t ready_directory_offset;
-    uint64_t scheduling_reserved;
+    volatile uint64_t activity_buffers_offset;
     volatile uint64_t worker_contexts_offset;
     volatile uint64_t dispatch_slots_offset;
     volatile uint64_t callable_addresses_offset;
@@ -1061,7 +1121,8 @@ struct alignas(128) SchedulerWorkerContext {
     volatile uint64_t scheduler_worker_id;
     volatile uint64_t is_scheduler;
     volatile uint64_t cluster_worker_ids[3];
-    uint64_t topology_reserved[3];
+    volatile uint64_t profiling_loop_iter;
+    uint64_t topology_reserved[2];
 
     uint64_t bootstrap_task_count;
     uint64_t ready_enqueue_count;
@@ -1084,7 +1145,11 @@ struct alignas(128) SchedulerWorkerContext {
     uint64_t wake_close_count;
     uint64_t completion_enqueue_count;
     uint64_t completion_resolve_count;
-    uint64_t completion_stats_reserved[6];
+    uint64_t trace_aicore_entry_cycles;
+    uint64_t trace_handshake_publish_cycles;
+    uint64_t trace_register_release_cycles;
+    uint64_t trace_descriptor_cache_observed_cycles;
+    uint64_t completion_stats_reserved[2];
     uint64_t ready_to_kernel_cycles;
     uint64_t ready_to_kernel_max_cycles;
     uint64_t payload_cycles;
@@ -1108,6 +1173,8 @@ struct alignas(128) SchedulerWorkerContext {
 };
 
 struct alignas(128) SchedulerTaskTrace {
+    // Dispatch publishes this line before READY; completion publishes valid.
+    // Bootstrap owns only the fanin line and must not dirty this cache line.
     volatile uint64_t valid;
     uint64_t ready_source;
     uint64_t worker_id;
@@ -1115,7 +1182,7 @@ struct alignas(128) SchedulerTaskTrace {
     uint64_t claim_worker_id;
     uint64_t claim_start_cycles;
     uint64_t claim_end_cycles;
-    uint64_t previous_trace_commit_end_cycles;
+    uint64_t claim_loop_iter;
 
     uint64_t kernel_start_cycles;
     uint64_t kernel_end_cycles;
@@ -1127,34 +1194,33 @@ struct alignas(128) SchedulerTaskTrace {
     uint64_t completion_inbox_index;
 
     uint64_t ready_transition_cycles;
-    uint64_t inter_task_completion_service_cycles;
-    uint64_t inter_task_dispatch_aic_cycles;
-    uint64_t inter_task_dispatch_aiv_cycles;
-    uint64_t inter_task_ready_poll_cycles;
-    uint64_t inter_task_backoff_cycles;
+    uint64_t fanin_start_cycles;
+    uint64_t fanin_end_cycles;
+    uint64_t fanin_scheduler_worker_id;
+    uint64_t fanin_loop_iter;
     uint64_t aicore_entry_cycles;
     uint64_t handshake_publish_cycles;
-
     uint64_t register_release_cycles;
-    uint64_t descriptor_cache_observed_cycles;
-    uint64_t completion_prepare_start_cycles;
+
+    // The dispatching Scheduler owns this cache line through completion.
+    uint64_t dispatch_start_cycles;
+    uint64_t dispatch_end_cycles;
+    uint64_t dispatch_scheduler_worker_id;
+    uint64_t dispatch_loop_iter;
+    uint64_t complete_start_cycles;
+    uint64_t complete_end_cycles;
+    uint64_t complete_scheduler_worker_id;
+    uint64_t complete_loop_iter;
     uint64_t refill_scheduler_worker_id;
     uint64_t refill_start_cycles;
     uint64_t refill_end_cycles;
     uint64_t refill_task_id;
-    uint64_t inter_task_completion_refill_cycles;
+    uint64_t refill_loop_iter;
+    uint64_t completion_reserved[3];
 
-    uint64_t inter_task_completion_scan_cycles;
-    uint64_t inter_task_completion_consume_cycles;
-    uint64_t inter_task_completion_resolve_cycles;
-    uint64_t inter_task_completion_ready_publish_cycles;
-    uint64_t inter_task_completion_finalize_cycles;
-    uint64_t inter_task_gang_service_cycles;
-    uint64_t inter_task_dispatch_probe_cycles[SCHEDULER_CORE_TYPE_COUNT];
-    uint64_t inter_task_dispatch_claim_cycles[SCHEDULER_CORE_TYPE_COUNT];
-    uint64_t inter_task_dispatch_prepare_cycles[SCHEDULER_CORE_TYPE_COUNT];
-    uint64_t inter_task_dispatch_materialize_cycles[SCHEDULER_CORE_TYPE_COUNT];
-    uint64_t inter_task_dispatch_publish_cycles[SCHEDULER_CORE_TYPE_COUNT];
+    // The completion Scheduler consolidates the Executor's staged timing here.
+    uint64_t descriptor_cache_observed_cycles;
+    uint64_t executor_reserved[7];
 };
 
 static_assert(sizeof(SchedulerTaskMetadata) == 16, "task metadata layout changed");
@@ -1209,9 +1275,17 @@ static_assert(
                                         128 * 128),
     "ready directory layout changed"
 );
-static_assert(sizeof(SchedulerDispatchSlot) == 128, "dispatch slot must occupy two cache lines");
+static_assert(sizeof(SchedulerExecutorTaskTrace) == 128, "executor trace must occupy two cache lines");
+static_assert(alignof(SchedulerExecutorTaskTrace) == 128, "executor trace alignment changed");
+static_assert(offsetof(SchedulerExecutorTaskTrace, generation) == 0, "executor trace generation must lead payload");
+static_assert(
+    offsetof(SchedulerExecutorTaskTrace, completion_inbox_index) == 64,
+    "executor trace lifecycle must start on its second cache line"
+);
+static_assert(sizeof(SchedulerDispatchSlot) == 256, "dispatch slot layout changed");
 static_assert(alignof(SchedulerDispatchSlot) == 128, "dispatch slot alignment changed");
 static_assert(offsetof(SchedulerDispatchSlot, publication) == 64, "dispatch publication needs its own line");
+static_assert(offsetof(SchedulerDispatchSlot, executor_trace) == 128, "executor trace needs exclusive cache lines");
 static_assert(sizeof(SchedulerRunControl) == 384, "run control layout changed");
 static_assert(alignof(SchedulerRunControl) == 128, "run control alignment changed");
 static_assert(offsetof(SchedulerRunControl, executed_task_count) == 128, "lifecycle atomics need their own line");
@@ -1228,6 +1302,22 @@ static_assert(offsetof(SchedulerWorkerContext, wake_cas_retry_count) == 512, "wa
 static_assert(offsetof(SchedulerWorkerContext, completion_enqueue_cycles) == 640, "termination stats offset changed");
 static_assert(offsetof(SchedulerWorkerContext, scheduler_tail_trace) == 768, "scheduler tail trace offset changed");
 static_assert(sizeof(SchedulerTaskTrace) == 384, "task trace layout changed");
+static_assert(
+    offsetof(SchedulerTaskTrace, dispatch_start_cycles) % 64 == 0,
+    "Scheduler-owned dispatch and completion fields must begin on a cache-line boundary"
+);
+static_assert(
+    offsetof(SchedulerTaskTrace, complete_loop_iter) / 64 == offsetof(SchedulerTaskTrace, dispatch_start_cycles) / 64,
+    "dispatch and completion fields must share their Scheduler-owned cache line"
+);
+static_assert(
+    offsetof(SchedulerTaskTrace, refill_scheduler_worker_id) % 64 == 0,
+    "Scheduler-owned refill fields must begin on a cache-line boundary"
+);
+static_assert(
+    offsetof(SchedulerTaskTrace, descriptor_cache_observed_cycles) % 64 == 0,
+    "consolidated descriptor timing must begin on a cache-line boundary"
+);
 
 template <typename T>
 inline __aicore__ __gm__ T *scheduler_state_at(__gm__ void *base, uint64_t offset) {
@@ -1237,6 +1327,10 @@ inline __aicore__ __gm__ T *scheduler_state_at(__gm__ void *base, uint64_t offse
 #if !defined(__CCE_AICORE__)
 #include <type_traits>
 static_assert(std::is_standard_layout_v<AicoreSchedulerLayout> && std::is_trivially_copyable_v<AicoreSchedulerLayout>);
+static_assert(std::is_standard_layout_v<SchedulerIdleRecord> && std::is_trivially_copyable_v<SchedulerIdleRecord>);
+static_assert(
+    std::is_standard_layout_v<SchedulerActivityBuffer> && std::is_trivially_copyable_v<SchedulerActivityBuffer>
+);
 static_assert(std::is_standard_layout_v<SchedulerTaskMetadata> && std::is_trivially_copyable_v<SchedulerTaskMetadata>);
 static_assert(std::is_standard_layout_v<SchedulerTaskControl> && std::is_trivially_copyable_v<SchedulerTaskControl>);
 static_assert(
@@ -1263,6 +1357,7 @@ static_assert(
     std::is_standard_layout_v<SchedulerWorkerContext> && std::is_trivially_copyable_v<SchedulerWorkerContext>
 );
 static_assert(std::is_standard_layout_v<SchedulerTailTrace> && std::is_trivially_copyable_v<SchedulerTailTrace>);
+static_assert(std::is_standard_layout_v<SchedulerTaskTrace> && std::is_trivially_copyable_v<SchedulerTaskTrace>);
 
 inline bool scheduler_layout_checked_add(uint64_t lhs, uint64_t rhs, uint64_t *out) {
     if (out == nullptr || rhs > UINT64_MAX - lhs) return false;
@@ -1296,7 +1391,8 @@ inline bool scheduler_layout_reserve(uint64_t *cursor, uint64_t size, uint64_t a
 }
 
 inline bool scheduler_plan_layout(
-    uint64_t task_count, uint64_t aic_task_count, uint64_t aiv_task_count, AicoreSchedulerLayout *layout
+    uint64_t task_count, uint64_t aic_task_count, uint64_t aiv_task_count, AicoreSchedulerLayout *layout,
+    bool enable_activity_profiling = false
 ) {
     if (layout == nullptr || aic_task_count > task_count || aiv_task_count > task_count) return false;
     AicoreSchedulerLayout next{};
@@ -1339,6 +1435,8 @@ inline bool scheduler_plan_layout(
         ) ||
         !SCHEDULER_RESERVE_ARRAY(SCHEDULER_CLUSTER_CAPACITY, SchedulerGangCommand, gang_commands_offset) ||
         !SCHEDULER_RESERVE_ARRAY(task_count, SchedulerTaskTrace, trace_cells_offset) ||
+        (enable_activity_profiling &&
+         !SCHEDULER_RESERVE_ARRAY(SCHEDULER_CLUSTER_CAPACITY, SchedulerActivityBuffer, activity_buffers_offset)) ||
         !scheduler_layout_checked_align(cursor, SCHEDULER_STATE_ALIGNMENT, &next.total_size)) {
 #undef SCHEDULER_RESERVE_ARRAY
         return false;
@@ -1377,6 +1475,7 @@ inline bool scheduler_init_data_from_layout(void *base, const AicoreSchedulerLay
         contexts[worker].cluster_index = UINT64_MAX;
         contexts[worker].scheduler_index = UINT64_MAX;
         contexts[worker].scheduler_worker_id = UINT64_MAX;
+        contexts[worker].activity_buffers_offset = layout.activity_buffers_offset;
         contexts[worker].cluster_worker_ids[0] = UINT64_MAX;
         contexts[worker].cluster_worker_ids[1] = UINT64_MAX;
         contexts[worker].cluster_worker_ids[2] = UINT64_MAX;

--- a/tests/st/a5/host_build_graph/dfx/chip_swimlane/kernels/aiv/kernel_empty.cpp
+++ b/tests/st/a5/host_build_graph/dfx/chip_swimlane/kernels/aiv/kernel_empty.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) { (void)args; }

--- a/tests/st/a5/host_build_graph/dfx/chip_swimlane/kernels/orchestration/scheduler_phases_orch.cpp
+++ b/tests/st/a5/host_build_graph/dfx/chip_swimlane/kernels/orchestration/scheduler_phases_orch.cpp
@@ -15,7 +15,9 @@
 
 namespace {
 
-constexpr int kNoopKernel = 0;
+constexpr int kWriteKernel = 0;
+constexpr int kEmptyKernel = 1;
+constexpr int kFanout = 32;
 
 }  // namespace
 
@@ -29,13 +31,26 @@ __attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_c
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &args) {
     const simpler::hbg::Tensor &input = args.tensor(0).ref();
 
-    CoreTaskArgs normal_args;
-    normal_args.add_inout(input);
-    normal_args.launch_spec.set_block_num(1);
-    const TaskId normal_task = rt_submit_aiv_task(kNoopKernel, normal_args).task_id();
+    CoreTaskArgs root_args;
+    root_args.launch_spec.set_block_num(1);
+    const TaskId root = rt_submit_aiv_task(kEmptyKernel, root_args).task_id();
+
+    TaskId children[kFanout];
+    for (int child = 0; child < kFanout; ++child) {
+        CoreTaskArgs child_args;
+        child_args.set_dependencies(&root, 1);
+        child_args.launch_spec.set_block_num(1);
+        children[child] = rt_submit_aiv_task(kEmptyKernel, child_args).task_id();
+    }
+
+    CoreTaskArgs final_args;
+    final_args.add_inout(input);
+    final_args.set_dependencies(children, kFanout);
+    final_args.launch_spec.set_block_num(1);
+    const TaskId final_task = rt_submit_aiv_task(kWriteKernel, final_args).task_id();
 
     CoreTaskArgs dummy_args;
-    dummy_args.set_dependencies(&normal_task, 1);
+    dummy_args.set_dependencies(&final_task, 1);
     rt_submit_dummy_task(dummy_args);
 }
 

--- a/tests/st/a5/host_build_graph/dfx/chip_swimlane/test_scheduler_phases.py
+++ b/tests/st/a5/host_build_graph/dfx/chip_swimlane/test_scheduler_phases.py
@@ -10,10 +10,16 @@
 
 from __future__ import annotations
 
+import json
+
 import torch
 from simpler.task_interface import ArgDirection as D
 
 from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
+
+FANOUT_WIDTH = 32
+EXPECTED_PROFILED_TASKS = 1 + FANOUT_WIDTH + 1 + 1  # root + children + final + terminal dummy
 
 
 @scene_test(level=2, runtime="host_build_graph")
@@ -30,6 +36,12 @@ class TestSchedulerPhases(SceneTestCase):
                 "source": "kernels/aiv/kernel_noop.cpp",
                 "core_type": "aiv",
                 "signature": [D.INOUT],
+            },
+            {
+                "func_id": 1,
+                "source": "kernels/aiv/kernel_empty.cpp",
+                "core_type": "aiv",
+                "signature": [],
             },
         ],
     }
@@ -50,6 +62,61 @@ class TestSchedulerPhases(SceneTestCase):
 
     def compute_golden(self, args, params):
         args.input[0] = 1
+
+    def test_run(self, st_platform, st_worker, request):
+        outputs_dir = _outputs_dir()
+        previous_outputs = (
+            {path: path.stat().st_mtime_ns for path in outputs_dir.iterdir()} if outputs_dir.exists() else {}
+        )
+        super().test_run(st_platform, st_worker, request)
+        level = self._effective_enable_chip_swimlane(request)
+        if level == 0:
+            return
+
+        for case in self._matching_cases(st_platform, request):
+            case_label = _sanitize_for_filename(f"TestSchedulerPhases_{case['name']}")
+            matches = [
+                path
+                for path in outputs_dir.glob(f"{case_label}_*")
+                if path not in previous_outputs or path.stat().st_mtime_ns > previous_outputs[path]
+            ]
+            assert matches, f"no output directory created for {case_label}"
+            output_prefix = max(matches, key=lambda path: path.stat().st_mtime_ns)
+            raw = json.loads((output_prefix / "chip_swimlane_records.json").read_text())
+            aicore_rows = raw["aicore_tasks"]
+            assert len(aicore_rows) == EXPECTED_PROFILED_TASKS, (
+                f"task timing covers {len(aicore_rows)} tasks, expected {EXPECTED_PROFILED_TASKS} "
+                "for the fanout/fanin DAG and terminal dummy"
+            )
+
+            if level >= 2:
+                scheduler_tasks = raw["scheduler_tasks"]
+                assert scheduler_tasks["schema_version"] == 1
+                assert scheduler_tasks["producer"] == "aicore"
+                scheduler_rows = scheduler_tasks["records"]
+                assert len(scheduler_rows) == len(aicore_rows)
+                aicore_by_key = {(int(row[0]), int(row[2])): row for row in aicore_rows}
+                assert {(int(row[0]), int(row[1])) for row in scheduler_rows} == set(aicore_by_key)
+                for core_id, reg_task_id, dispatch_cycles, finish_cycles in scheduler_rows:
+                    aicore_row = aicore_by_key[(int(core_id), int(reg_task_id))]
+                    assert 0 < dispatch_cycles <= aicore_row[3] <= aicore_row[4] <= finish_cycles
+                assert raw["aicpu_lifecycle_records"], "AICPU lifecycle records are missing"
+            else:
+                assert "scheduler_tasks" not in raw
+                assert "aicpu_lifecycle_records" not in raw
+
+            if level >= 3:
+                streams = raw["scheduler_records"]["streams"]
+                assert streams, "A5 HBG AICore Scheduler records are missing"
+                assert all(stream["producer"] == "aicore" for stream in streams)
+                assert all(stream["capture"]["dropped"] == 0 for stream in streams)
+                emitted_kinds = {record["kind"] for stream in streams for record in stream["records"]}
+                required_kinds = {"bootstrap", "fanin", "dispatch", "complete", "resolve", "idle"}
+                assert required_kinds <= emitted_kinds, (
+                    f"missing Scheduler kinds: {sorted(required_kinds - emitted_kinds)}"
+                )
+            else:
+                assert "scheduler_records" not in raw
 
 
 if __name__ == "__main__":

--- a/tests/st/a5/host_build_graph/single_core_dag/test_single_core_dag.py
+++ b/tests/st/a5/host_build_graph/single_core_dag/test_single_core_dag.py
@@ -10,11 +10,13 @@
 """Correctness gates for homogeneous and mixed AIC/AIV dependency graphs."""
 
 import ctypes
+import json
 
 import torch
 from simpler.task_interface import ArgDirection as D
 
 from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 
 GRAPH_CASES = {
     "chain_64": (0, 64),
@@ -85,6 +87,64 @@ class TestHbgSingleCoreDag(SceneTestCase):
     def compute_golden(self, args, params):
         count = params["task_count"]
         args.task_state[: count * 8 : 8] = torch.arange(1, count + 1, dtype=torch.int64)
+
+    def test_run(self, st_platform, st_worker, request):
+        outputs_dir = _outputs_dir()
+        previous_outputs = (
+            {path: path.stat().st_mtime_ns for path in outputs_dir.iterdir()} if outputs_dir.exists() else {}
+        )
+        super().test_run(st_platform, st_worker, request)
+        level = self._effective_enable_chip_swimlane(request)
+        if level == 0:
+            return
+
+        record_fields = {"start_cycles", "end_cycles", "loop_iter", "kind", "tasks_processed", "task_id"}
+        for case in self._matching_cases(st_platform, request):
+            case_label = _sanitize_for_filename(f"TestHbgSingleCoreDag_{case['name']}")
+            matches = [
+                path
+                for path in outputs_dir.glob(f"{case_label}_*")
+                if path not in previous_outputs or path.stat().st_mtime_ns > previous_outputs[path]
+            ]
+            assert matches, f"no output directory created for {case_label}"
+            output_prefix = max(matches, key=lambda path: path.stat().st_mtime_ns)
+            perf_path = output_prefix / "chip_swimlane_records.json"
+            raw = json.loads(perf_path.read_text())
+            aicore_rows = raw["aicore_tasks"]
+            assert aicore_rows, "AICore task records are missing"
+            if level >= 2:
+                scheduler_tasks = raw["scheduler_tasks"]
+                assert scheduler_tasks["schema_version"] == 1
+                assert scheduler_tasks["producer"] == "aicore"
+                scheduler_rows = scheduler_tasks["records"]
+                aicore_by_key = {(int(row[0]), int(row[2])): row for row in aicore_rows}
+                assert {(int(row[0]), int(row[1])) for row in scheduler_rows} == set(aicore_by_key)
+                for core_id, reg_task_id, dispatch_cycles, finish_cycles in scheduler_rows:
+                    aicore_row = aicore_by_key[(int(core_id), int(reg_task_id))]
+                    assert 0 < dispatch_cycles <= aicore_row[3] <= aicore_row[4] <= finish_cycles
+                assert raw["aicpu_lifecycle_records"], "AICPU lifecycle records are missing"
+            if level < 3:
+                continue
+            streams = raw["scheduler_records"]["streams"]
+            assert streams, "A5 HBG AICore Scheduler records are missing"
+            assert all(stream["producer"] == "aicore" for stream in streams)
+            assert all(stream["platform"] == "a5" and stream["runtime"] == "host_build_graph" for stream in streams)
+            records = [record for stream in streams for record in stream["records"]]
+            assert all(set(record) == record_fields for record in records)
+            assert all(0 < record["start_cycles"] <= record["end_cycles"] for record in records)
+            required_kinds = {"bootstrap", "dispatch", "complete", "resolve", "idle"}
+            if case["params"]["graph_case"] != GRAPH_CASES["multi_root_64"][0]:
+                required_kinds.add("fanin")
+            emitted_kinds = {record["kind"] for record in records}
+            assert required_kinds <= emitted_kinds, f"missing Scheduler kinds: {sorted(required_kinds - emitted_kinds)}"
+            profiled_task_ids = {int(row[1]) for row in raw["aicore_tasks"]}
+            for kind in ("dispatch", "complete"):
+                recorded_task_ids = {int(record["task_id"]) for record in records if record["kind"] == kind}
+                assert recorded_task_ids == profiled_task_ids, (
+                    f"{kind} records do not cover every profiled task: "
+                    f"missing={sorted(profiled_task_ids - recorded_task_ids)} "
+                    f"unexpected={sorted(recorded_task_ids - profiled_task_ids)}"
+                )
 
 
 if __name__ == "__main__":

--- a/tests/ut/cpp/a5/test_hbg_scheduler_contracts.cpp
+++ b/tests/ut/cpp/a5/test_hbg_scheduler_contracts.cpp
@@ -208,16 +208,29 @@ TEST(SchedulerState, PreservesCacheLineAlignmentAndArrayStride) {
     EXPECT_EQ(alignof(SchedulerDispatchSlot), 128u);
     EXPECT_EQ(alignof(SchedulerRunControl), 128u);
     EXPECT_EQ(alignof(SchedulerWorkerContext), 128u);
+    EXPECT_EQ(alignof(SchedulerTaskTrace), 128u);
 
     std::array<SchedulerTaskControl, 2> controls{};
     std::array<SchedulerDispatchSlot, 2> dispatch_slots{};
     std::array<SchedulerWorkerContext, 2> contexts{};
     EXPECT_EQ(reinterpret_cast<uintptr_t>(&controls[1]) - reinterpret_cast<uintptr_t>(&controls[0]), 128u);
-    EXPECT_EQ(reinterpret_cast<uintptr_t>(&dispatch_slots[1]) - reinterpret_cast<uintptr_t>(&dispatch_slots[0]), 128u);
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(&dispatch_slots[1]) - reinterpret_cast<uintptr_t>(&dispatch_slots[0]), 256u);
     EXPECT_EQ(reinterpret_cast<uintptr_t>(&contexts[1]) - reinterpret_cast<uintptr_t>(&contexts[0]), 1024u);
     EXPECT_EQ(offsetof(SchedulerTaskControl, state) / 64, offsetof(SchedulerTaskControl, wake_list_head) / 64);
     EXPECT_NE(offsetof(SchedulerTaskControl, state) / 64, offsetof(SchedulerTaskControl, next_waiter) / 64);
     EXPECT_NE(offsetof(SchedulerDispatchSlot, task_id) / 64, offsetof(SchedulerDispatchSlot, publication) / 64);
+    EXPECT_EQ(offsetof(SchedulerDispatchSlot, executor_trace), 128u);
+    EXPECT_EQ(
+        offsetof(SchedulerTaskTrace, dispatch_start_cycles) / 64, offsetof(SchedulerTaskTrace, complete_loop_iter) / 64
+    );
+    EXPECT_NE(
+        offsetof(SchedulerTaskTrace, dispatch_start_cycles) / 64,
+        offsetof(SchedulerTaskTrace, descriptor_cache_observed_cycles) / 64
+    );
+    EXPECT_NE(
+        offsetof(SchedulerTaskTrace, refill_scheduler_worker_id) / 64,
+        offsetof(SchedulerTaskTrace, descriptor_cache_observed_cycles) / 64
+    );
 }
 
 TEST(SchedulerMetadata, ProjectsExistingSubmitTypesWithoutChangingTheirSemantics) {

--- a/tests/ut/cpp/a5/test_hbg_scheduler_dispatch.cpp
+++ b/tests/ut/cpp/a5/test_hbg_scheduler_dispatch.cpp
@@ -147,6 +147,7 @@ struct FixtureStorage {
             metadata[task].logical_block_num = 1;
             metadata[task].total_required_subtasks = 1;
             metadata[task].flags = SCHEDULER_TASK_EXECUTABLE;
+            metadata[task].timing_slot = -1;
         }
     }
 
@@ -218,6 +219,31 @@ void occupy_normal_slot(
     );
 }
 
+SchedulerDispatchSlot *
+prepare_completed_normal_slot(FixtureStorage &storage, SchedulerWorkerContext &scheduler, uint64_t worker_id = 0) {
+    scheduler.is_scheduler = 1;
+    scheduler.scheduler_index = 0;
+    scheduler.scheduler_count = 1;
+    scheduler.inbox_index = 0;
+    scheduler.cluster_worker_ids[0] = worker_id;
+    scheduler.cluster_worker_ids[1] = scheduler.worker_index;
+    scheduler.cluster_worker_ids[2] = UINT64_MAX;
+    storage.run_control->scheduler_count = 1;
+    auto *slot = scheduler_dispatch_slot_at(storage.scheduler_state->base(), &scheduler, worker_id, 0);
+    scheduler_initialize_free_slot(slot);
+    slot->task_id = 0;
+    slot->subtask_slot = 0;
+    slot->gang = 0;
+    scheduler_gm_store(
+        slot->publication, scheduler_dispatch_publication(slot->generation, SchedulerDispatchSlotState::READY)
+    );
+    auto *completion_line = scheduler_completion_inbox_at(storage.scheduler_state->base(), &scheduler, worker_id);
+    completion_line->completed_generations[0] = slot->generation;
+    auto *control = scheduler_task_control_at(storage.scheduler_state->base(), &scheduler, 0);
+    control->state = static_cast<int64_t>(SchedulerTaskState::READY);
+    return slot;
+}
+
 TEST(SchedulerCompletionInbox, PacksBothGenerationSlotsInOneDeviceWord) {
     alignas(uint64_t) volatile uint32_t generations[SCHEDULER_PENDING_SLOT_COUNT] = {
         UINT32_C(0x11223344), UINT32_C(0x55667788)
@@ -242,6 +268,10 @@ TEST(SchedulerClusterCompletion, SpscGenerationCompletesNormalTask) {
     scheduler_initialize_free_slot(slot);
     slot->task_id = 0;
     slot->gang = 0;
+    slot->executor_trace.generation = slot->generation;
+    slot->executor_trace.kernel_start_cycles = 100;
+    slot->executor_trace.kernel_end_cycles = 200;
+    storage.metadata[0].timing_slot = 0;
     scheduler_gm_store(
         slot->publication, scheduler_dispatch_publication(slot->generation, SchedulerDispatchSlotState::READY)
     );
@@ -261,6 +291,11 @@ TEST(SchedulerClusterCompletion, SpscGenerationCompletesNormalTask) {
     EXPECT_EQ(control->state, static_cast<int64_t>(SchedulerTaskState::DONE));
     EXPECT_EQ(control->wake_list_head, SCHEDULER_WAKE_LIST_CLOSED);
     EXPECT_EQ(storage.run_control->resolved_task_count, 1u);
+    auto *traces =
+        scheduler_state_at<SchedulerTaskTrace>(storage.scheduler_state->base(), storage.layout.trace_cells_offset);
+    EXPECT_EQ(traces[0].kernel_start_cycles, 100u);
+    EXPECT_EQ(traces[0].kernel_end_cycles, 200u);
+    EXPECT_EQ(traces[0].valid, 0u);
 }
 
 TEST(SchedulerClusterCompletion, RejectsStaleCompletionGenerationAtNamedSite) {
@@ -318,6 +353,64 @@ TEST(SchedulerClusterCompletion, RejectsUnexpectedGangSlotAtNamedSite) {
     );
 }
 
+TEST(SchedulerClusterCompletion, AccountsCompletedTaskWhenResolveFails) {
+    FixtureStorage storage(1, 2);
+    GraphBuffer graph(1);
+    graph.executable(0, 0);
+    SchedulerWorkerContext &scheduler = storage.contexts[1];
+    SchedulerDispatchSlot *slot = prepare_completed_normal_slot(storage, scheduler);
+
+    EXPECT_FALSE(scheduler_service_cluster_completion_slot(
+        graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, 0, 0, slot->generation,
+        nullptr, nullptr, nullptr, nullptr, 0, nullptr, nullptr, nullptr, nullptr
+    ));
+    EXPECT_EQ(storage.run_control->resolved_task_count, 1u);
+    EXPECT_NE(storage.run_control->scheduler_error, 0u);
+    EXPECT_EQ(storage.run_control->error_site, static_cast<uint64_t>(SchedulerErrorSite::COMPLETION_RESOLVE_FAILED));
+}
+
+TEST(SchedulerClusterCompletion, AccountsCompletedTaskWhenRefillClaimFails) {
+    FixtureStorage storage(1, 2);
+    GraphBuffer graph(1);
+    graph.executable(0, 0);
+    SchedulerWorkerContext &scheduler = storage.contexts[1];
+    SchedulerDispatchSlot *slot = prepare_completed_normal_slot(storage, scheduler);
+    SchedulerReadyOwnerState &owner_state = storage.owner_states[scheduler.inbox_index];
+    owner_state.queues[0].pending_endpoints = scheduler_ready_pending_pack(SCHEDULER_INBOX_EMPTY, 0);
+    uint64_t ready_victim_cursors[SCHEDULER_CORE_TYPE_COUNT]{};
+
+    EXPECT_FALSE(scheduler_service_cluster_completion_slot(
+        graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, 0, 0, slot->generation,
+        nullptr, nullptr, nullptr, ready_victim_cursors, 0, nullptr, nullptr, nullptr, &owner_state
+    ));
+    EXPECT_EQ(storage.run_control->resolved_task_count, 1u);
+    EXPECT_NE(storage.run_control->scheduler_error, 0u);
+    EXPECT_EQ(
+        storage.run_control->error_site, static_cast<uint64_t>(SchedulerErrorSite::COMPLETION_REFILL_CLAIM_FAILED)
+    );
+}
+
+TEST(SchedulerClusterCompletion, AccountsCompletedTaskWhenRefillDispatchFails) {
+    FixtureStorage storage(1, 2);
+    GraphBuffer graph(1);
+    graph.executable(0, 0);
+    SchedulerWorkerContext &scheduler = storage.contexts[1];
+    SchedulerDispatchSlot *slot = prepare_completed_normal_slot(storage, scheduler);
+    SchedulerReadyClaim replacement{};
+    replacement.task_id = 1;
+
+    EXPECT_FALSE(scheduler_service_cluster_completion_slot(
+        graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, 0, 0, slot->generation,
+        nullptr, nullptr, nullptr, nullptr, 0, &replacement, nullptr, nullptr,
+        &storage.owner_states[scheduler.inbox_index]
+    ));
+    EXPECT_EQ(storage.run_control->resolved_task_count, 1u);
+    EXPECT_NE(storage.run_control->scheduler_error, 0u);
+    EXPECT_EQ(
+        storage.run_control->error_site, static_cast<uint64_t>(SchedulerErrorSite::COMPLETION_REFILL_DISPATCH_FAILED)
+    );
+}
+
 TEST(SchedulerClusterCompletion, PropagatesTraceToCompletionAndWokenTask) {
     FixtureStorage storage(2, 3);
     GraphBuffer graph(2);
@@ -342,6 +435,9 @@ TEST(SchedulerClusterCompletion, PropagatesTraceToCompletionAndWokenTask) {
     auto *slot = scheduler_dispatch_slot_at(storage.scheduler_state->base(), &scheduler, 0, 0);
     scheduler_initialize_free_slot(slot);
     slot->task_id = 0;
+    slot->executor_trace.generation = slot->generation;
+    slot->executor_trace.kernel_start_cycles = 100;
+    slot->executor_trace.kernel_end_cycles = 200;
     scheduler_gm_store(
         slot->publication, scheduler_dispatch_publication(slot->generation, SchedulerDispatchSlotState::READY)
     );
@@ -358,12 +454,16 @@ TEST(SchedulerClusterCompletion, PropagatesTraceToCompletionAndWokenTask) {
     SchedulerCompletionStats completion_stats{};
     ASSERT_TRUE(scheduler_service_cluster_completions(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, &wake_stats, &ready_stats,
-        &completion_stats, nullptr, true, nullptr, nullptr, &storage.owner_states[scheduler.inbox_index]
+        &completion_stats, nullptr, SCHEDULER_PROFILING_SCHED_PHASES_LEVEL, nullptr, nullptr,
+        &storage.owner_states[scheduler.inbox_index]
     ));
     EXPECT_EQ(producer->completion_resolve_start_cycles, 0u);
     EXPECT_EQ(producer->completion_resolve_end_cycles, 0u);
     EXPECT_EQ(producer->scheduler_worker_id, scheduler.worker_index);
     EXPECT_EQ(traces[1].ready_transition_cycles, 0u);
+    EXPECT_EQ(traces[0].valid, 1u);
+    EXPECT_EQ(traces[0].kernel_start_cycles, 100u);
+    EXPECT_EQ(traces[0].kernel_end_cycles, 200u);
     auto *waiter = scheduler_task_control_at(storage.scheduler_state->base(), &scheduler, 1);
     EXPECT_EQ(waiter->state, static_cast<int64_t>(SchedulerTaskState::READY));
 }

--- a/tests/ut/cpp/a5/test_hbg_scheduler_ready.cpp
+++ b/tests/ut/cpp/a5/test_hbg_scheduler_ready.cpp
@@ -173,6 +173,77 @@ struct FixtureStorage {
     uint64_t *callable_addresses{nullptr};
 };
 
+TEST(SchedulerActivityBuffer, IsAllocatedOnlyWhenRequestedAndNeverWraps) {
+    AicoreSchedulerLayout disabled{};
+    ASSERT_TRUE(scheduler_plan_layout(1, 1, 0, &disabled));
+    EXPECT_EQ(disabled.activity_buffers_offset, 0u);
+
+    AicoreSchedulerLayout enabled{};
+    ASSERT_TRUE(scheduler_plan_layout(1, 1, 0, &enabled, true));
+    ASSERT_NE(enabled.activity_buffers_offset, 0u);
+    EXPECT_EQ(
+        enabled.total_size - disabled.total_size,
+        static_cast<uint64_t>(SCHEDULER_CLUSTER_CAPACITY) * sizeof(SchedulerActivityBuffer)
+    );
+    SchedulerStateBuffer storage(enabled);
+    auto *contexts = scheduler_state_at<SchedulerWorkerContext>(storage.base(), enabled.worker_contexts_offset);
+    auto *buffers = scheduler_state_at<SchedulerActivityBuffer>(storage.base(), enabled.activity_buffers_offset);
+    contexts[0].worker_index = SCHEDULER_WORKER_CAPACITY - 1;
+    contexts[0].is_scheduler = 1;
+    contexts[0].scheduler_index = SCHEDULER_CLUSTER_CAPACITY - 1;
+    contexts[0].profiling_loop_iter = 17;
+    SchedulerActivityBuffer &buffer = buffers[SCHEDULER_CLUSTER_CAPACITY - 1];
+    buffer.committed = SCHEDULER_ACTIVITY_CAPACITY - 1;
+
+    scheduler_append_idle_activity(storage.base(), &contexts[0], 10, 20);
+    scheduler_append_idle_activity(storage.base(), &contexts[0], 30, 40);
+
+    EXPECT_EQ(buffer.committed, SCHEDULER_ACTIVITY_CAPACITY);
+    EXPECT_EQ(buffer.dropped, 1u);
+    const SchedulerIdleRecord &last = buffer.records[SCHEDULER_ACTIVITY_CAPACITY - 1];
+    EXPECT_EQ(last.start_time, 10u);
+    EXPECT_EQ(last.end_time, 20u);
+    EXPECT_EQ(last.loop_iter, 17u);
+}
+
+TEST(SchedulerActivityBuffer, RejectsCorruptCommittedCountOnHost) {
+    EXPECT_TRUE(scheduler_activity_record_count_valid(SCHEDULER_ACTIVITY_CAPACITY));
+    EXPECT_FALSE(scheduler_activity_record_count_valid(SCHEDULER_ACTIVITY_CAPACITY + 1));
+}
+
+TEST(SchedulerProfilingLevel, EnablesOnlyTheRequestedGranularity) {
+    EXPECT_FALSE(scheduler_task_timing_enabled(0));
+    EXPECT_TRUE(scheduler_task_timing_enabled(SCHEDULER_PROFILING_TASK_TIMING_LEVEL));
+    EXPECT_FALSE(scheduler_schedule_timing_enabled(SCHEDULER_PROFILING_TASK_TIMING_LEVEL));
+    EXPECT_TRUE(scheduler_schedule_timing_enabled(SCHEDULER_PROFILING_SCHEDULE_TIMING_LEVEL));
+    EXPECT_FALSE(scheduler_phase_timing_enabled(SCHEDULER_PROFILING_SCHEDULE_TIMING_LEVEL));
+    EXPECT_TRUE(scheduler_phase_timing_enabled(SCHEDULER_PROFILING_SCHED_PHASES_LEVEL));
+}
+
+TEST(SchedulerProfilingLevel, DispatchWritesTaskIdentityBeforePhaseDetails) {
+    for (uint64_t level = 0; level <= SCHEDULER_PROFILING_SCHED_PHASES_LEVEL; ++level) {
+        FixtureStorage storage(1, 2);
+        GraphBuffer graph(1);
+        graph.executable(0, 0);
+        storage.contexts[1].core_type = static_cast<int32_t>(CoreType::AIC);
+        SchedulerReadyClaim ready_claim{};
+        ready_claim.task_id = 0;
+        ready_claim.claim_start_cycles = 123;
+        ready_claim.claim_end_cycles = 456;
+
+        ASSERT_TRUE(scheduler_fill_dispatch_slot(
+            graph.graph(), storage.scheduler_state->base(), &storage.contexts[1], storage.run_control,
+            SchedulerFreeSlotClaim{1, 0, 0}, ready_claim, level
+        ));
+        auto *traces =
+            scheduler_state_at<SchedulerTaskTrace>(storage.scheduler_state->base(), storage.layout.trace_cells_offset);
+        EXPECT_EQ(traces[0].worker_id, level == 0 ? 0u : storage.contexts[1].worker_index);
+        EXPECT_EQ(traces[0].task_id, 0u);
+        EXPECT_EQ(traces[0].claim_start_cycles, level >= SCHEDULER_PROFILING_SCHED_PHASES_LEVEL ? 123u : 0u);
+        EXPECT_EQ(traces[0].claim_end_cycles, level >= SCHEDULER_PROFILING_SCHED_PHASES_LEVEL ? 456u : 0u);
+    }
+}
+
 TEST(SchedulerBootstrap, RegistersOnlyOnFirstExecutableProducer) {
     FixtureStorage storage(4, 2);
     GraphBuffer graph(4);


### PR DESCRIPTION
## Why

#2119 established the A5 HBG Scheduler terminology, and #2127 provides the
shared chip-swimlane extension contract. A5 HBG still needs the runtime-side
producer that captures its AICore-owned scheduling timeline.

This PR contains only that A5 HBG profiling increment.

## What changed

- Record AICore task timing, AICPU lifecycle events, Scheduler task intervals,
  and Scheduler phases under the existing profiling level contract:
  L1=AICore timing, L2=+Scheduler task timing, L3=+Scheduler phases,
  L4=+Orchestrator phases.
- Stage pre-kernel timestamps outside the callable live set and let the
  Scheduler consolidate each task trace before publishing it as valid.
- Keep bootstrap fanin profiling on its owned cache line so it cannot overwrite
  completed AICore task identity on hardware.
- Capture Scheduler idle intervals in a fixed-size Device buffer and reject a
  copied-back committed count that exceeds that fixed extent before Host reads
  any record.
- Publish the A5 HBG extensions locally from `RuntimeMaker`; the shared
  `SceneTest` output and return-value contracts remain unchanged, and the A5
  tests discover their generated artifacts directly.

## Correctness and scope

- Rebased onto `upstream/main` at `5d046b193`; exactly one commit remains in
  this PR.
- The shared schema, serializer, and `SceneTest` implementation are not part of
  this diff. The change is limited to the A5 `host_build_graph` producer and
  its tests/documentation.
- Device activity-buffer capacity is the compile-time
  `SCHEDULER_ACTIVITY_CAPACITY`; Device bounds writes by it and Host validates
  `committed` against the same value.

## Validation after the latest rebase

- [x] Editable A5sim package/runtime build completed successfully.
- [x] A5 HBG Scheduler activity-buffer C++ test: 1/1 passed.
- [x] A5 HBG profiling scene tests: 2/2 passed on a5sim at Level 3.
- [x] Pre-commit passed, including clang-format, clang-tidy, cpplint, ruff, and
  pyright.
- [ ] A5 onboard was not rerun locally because the available host is A2/A3;
  the mandatory architecture precheck was not bypassed.

Earlier validation of the feature patch included 20/20 A5 HBG onboard runs
across profiling Levels 1-4 and A5 TMR regression coverage at every level.
