### PR TITLE
Perf: skip the empty Tier-0 staging order in the a5 dispatch loop

### DIFF
--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/orchestrator.cpp
@@ -648,6 +648,17 @@ static bool prepare_task(
     out->slot_state->logical_block_num = block_num;
     out->slot_state->active_mask = active_mask;
     out->slot_state->task_attrs = task_attrs;
+    if (task_attrs.requires_sync_start()) {
+        // Ordered before the wiring publish below, which is the first read of
+        // this slot by any scheduler thread, so the latch is set before the
+        // task can be routed to ready_sync_queues.
+        //
+        // Tier-0 priority is best-effort for an entry that becomes visible
+        // mid-iteration: a thread already past its Tier-0 checkpoint picks that
+        // entry up on its next pass, whether the checkpoint is this latch or
+        // the six queue probes it stands in for.
+        orch->scheduler->sync_task_seen.store(1, std::memory_order_release);
+    }
     // fanin_count is set during Orch-side wiring
     scope_tasks_push(orch, out->slot_state);
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
@@ -537,6 +537,19 @@ struct SchedulerState {
     // stop-the-world drain, per-core MIX placement, head-start spacing).
     ChipReadyQueue ready_sync_queues[NUM_RESOURCE_SHAPES];
 
+    // Set when the orchestrator submits a task with requires_sync_start(), and
+    // stays set for the rest of the epoch. Only such a task reaches
+    // ready_sync_queues[], so while this is clear those queues hold nothing and
+    // the dispatch loop skips the whole Tier-0 staging order -- six shape probes
+    // per iteration, each a load on a line every scheduler thread writes.
+    //
+    // Release here, acquire on the dispatch loop's load: observing it set also
+    // makes visible the submission that set it.
+    //
+    // Own cache line: written once per epoch, read once per dispatch iteration,
+    // so it never joins the lines the scheduler threads already contend for.
+    alignas(64) std::atomic<uint32_t> sync_task_seen;
+
     // Dependency-only tasks (active_mask is empty, shape == DUMMY). Drained by
     // the dispatch loop and completed inline -- never goes to AICore.
     ChipReadyQueue dummy_ready_queue;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -528,19 +528,26 @@ void SchedulerContext::dispatch_ready_tasks(
     // (sync_start > MIX > C/V within the normal source). Same order and machinery,
     // fed from ready_sync_queues; an oversized cohort arms the stop-the-world drain
     // (entered_drain), which also short-circuits the regular tier below.
-    run_staging_order(
-        thread_idx, pmu_active,
-        [&](ResourceShape shape, CoreTracker::DispatchPhase phase) {
-            dispatch_shape(
-                thread_idx, sched_->ready_sync_queues, shape, phase, tracker, entered_drain, made_progress, try_pushed
-            );
-            return entered_drain;
-        },
-        [&] {
-            return has_residual_sync_mix();
-        }
-    );
-    if (entered_drain) return;
+    // Skip Tier-0 entirely until the orchestrator has submitted a sync_start
+    // task. Without one the staging order below can only probe six empty queues
+    // per iteration. The acquire pairs with the release in prepare_task(), so
+    // observing the latch set also makes that task's submission visible.
+    if (sched_->sync_task_seen.load(std::memory_order_acquire) != 0) {
+        run_staging_order(
+            thread_idx, pmu_active,
+            [&](ResourceShape shape, CoreTracker::DispatchPhase phase) {
+                dispatch_shape(
+                    thread_idx, sched_->ready_sync_queues, shape, phase, tracker, entered_drain, made_progress,
+                    try_pushed
+                );
+                return entered_drain;
+            },
+            [&] {
+                return has_residual_sync_mix();
+            }
+        );
+        if (entered_drain) return;
+    }
 
     // Tier 1: regular ready work.
     run_staging_order(

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime_init.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime_init.cpp
@@ -168,6 +168,7 @@ bool SchedulerState::init_data_from_layout(const SchedulerLayout &layout, Device
     sched->advance_pending_mask.store(0, std::memory_order_relaxed);
     sched->publication_request_mask.store(0, std::memory_order_relaxed);
     sched->publication_ack_mask.store(0, std::memory_order_relaxed);
+    sched->sync_task_seen.store(0, std::memory_order_relaxed);
 #if SIMPLER_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
     sched->tasks_consumed.store(0, std::memory_order_relaxed);
@@ -232,6 +233,7 @@ void SchedulerState::reset_for_reuse(const SchedulerLayout &layout, void *sm_dev
     sched->advance_pending_mask.store(0, std::memory_order_relaxed);
     sched->publication_request_mask.store(0, std::memory_order_relaxed);
     sched->publication_ack_mask.store(0, std::memory_order_relaxed);
+    sched->sync_task_seen.store(0, std::memory_order_relaxed);
 #if SIMPLER_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
     sched->tasks_consumed.store(0, std::memory_order_relaxed);


### PR DESCRIPTION
`dispatch_ready_tasks` runs `run_staging_order` twice per iteration:
once over `ready_sync_queues` (Tier-0) and once over `ready_queues`.
Each pass probes up to six shape/phase combinations, so the loop pays
twelve queue probes per iteration whatever is actually queued.
Scheduler profiling agrees: thread 0 reported 1419 pop atomics against
113 loop iterations, i.e. 12.6 per iteration.

Only a task with `requires_sync_start()` can ever reach Tier-0, so a
program without one leaves those six probes reading empty queues for
its entire run. This adds a latch, `sync_task_seen`, and skips the
Tier-0 staging order while it is clear.

## Where the latch is armed, and what it does and does not guarantee

The latch is set in `prepare_task()`, at SUBMIT — not on the
ready-queue push, so arming cannot depend on what
`ChipReadyQueue::push` returns (it reports `false` on a full queue).

It does NOT make the latch instantaneous. A thread can read it clear,
the arming store can land, the push can land, and that thread can
still spend the rest of its iteration in Tier-1. The accurate
statement is that **Tier-0 priority is best-effort for an entry that
becomes visible mid-iteration**: a thread already past its Tier-0
checkpoint picks it up on its next pass, whether that checkpoint is
this latch load or the six queue probes it stands in for. The latch
load happens no later than the first of those probes would have.

The store is release and the dispatch-loop load is acquire, so
observing the latch set also makes that task's submission visible.
`sync_task_seen` sits on its own cache line — written once per epoch,
read once per dispatch iteration. Programs that DO use sync_start are
unaffected: the latch stays set for the rest of the epoch and Tier-0
runs unconditionally.

## Measurement, with a placebo control

DSv4-Pro decode attention on a5, interleaved A/B with a runtime
rebuild per arm, 100 rounds per arm, golden PASS on every completed
variant arm.

Because the effect is small and the HCA baseline spreads about 2.4%
run to run, the harness was first checked against itself: a **placebo
arm whose only difference from base is one added comment line**.

| arm | delta | reps won by "variant" |
|---|---:|---|
| placebo, 3 reps | -0.55% | 2 of 3 |
| placebo, 5 reps | **-0.18%** | 3 of 5 |

At five reps the placebo is indistinguishable from zero and its
per-rep split is a coin flip, so the harness has no meaningful
directional bias toward the second arm. Note the three-rep placebo
landed at -0.55% with a 2-of-3 split — a three-rep result of that size
is not separable from noise, which is why HCA was given five.

Against that control, the real change:

| kernel | observed range | reps |
|---|---|---|
| SWA | -1.0% to -2.3% | 3, 3, 2 |
| CSA | -0.6% to -1.6% | 3, 3 |
| HCA | -1.7% to -2.0% | 3, 5 |

Every one of those runs won every completed rep, which the placebo
does not. The honest reading is **a real effect of roughly 1-2%**, not
a settled per-kernel figure.

One caveat for anyone stacking this with other decode work: measured
together with a separate pypto-lib change, the two do not sum on HCA.
Both appear to attack the same scheduler-idle slack, so quote a
stacked measurement rather than adding separate ones.

## A note for anyone comparing DFX data across versions

Skipping Tier-0 removes six empty probes per iteration from `pop_miss`
and `g_sched_pop_atomic_count`. The 12.6 pops/iteration quoted above
is a pre-change number; after this, a non-sync_start program reads
about half that. The documented meaning of those counters does not
change, but the denominator does.

## Scope

Four files, +46/-13, in `a5/tensormap_and_ringbuffer` only.
`a2a3/tensormap_and_ringbuffer` and both `host_build_graph` runtimes
carry the same two-tier staging structure and could take the same
latch — a2a3/tmr in particular has a matching `prepare_task` and a
verbatim-corresponding insertion point. They are left for a follow-up
for one reason only: **only a5 hardware was available to measure on**,
and this is a performance change that should not ship to a platform it
has not been measured on.

No behaviour change for sync_start programs and no change to the
ready-dispatch policy itself.
