### PR TITLE
Refactor: fix the swimlane pool layout at compile time

### DIFF
--- a/src/common/platform/include/common/chip_swimlane_profiling.h
+++ b/src/common/platform/include/common/chip_swimlane_profiling.h
@@ -832,50 +832,54 @@ inline ChipSwimlaneAicpuTaskPool *get_perf_buffer_state(void *base_ptr, int core
  *
  * Layout (after the fixed ChipSwimlaneDataHeader, which carries the phase
  * metadata fields):
- *   [ChipSwimlaneAicpuTaskPool       × num_cores]
- *   [ChipSwimlaneAicoreTaskPool      × num_cores]
+ *   [ChipSwimlaneAicpuTaskPool       × PLATFORM_MAX_CORES]
+ *   [ChipSwimlaneAicoreTaskPool      × PLATFORM_MAX_CORES]
  *   [ChipSwimlaneAicpuSchedPhasePool × PLATFORM_MAX_AICPU_THREADS]
- *   [ChipSwimlaneAicpuOrchPhasePool  × num_orch_phase_threads]
+ *   [ChipSwimlaneAicpuOrchPhasePool  × PLATFORM_MAX_AICPU_THREADS]
  *
- * @param num_cores               Number of AICore instances
- * @param num_sched_phase_threads Retained for API compatibility; scheduler allocation uses the platform maximum
- * @param num_orch_phase_threads  Number of orchestrator-phase pools
+ * Every array is dimensioned by a platform maximum, not by the run. The host
+ * and the AICPU both address this region, and each used to supply its own core
+ * count to locate the arrays — the host the run's, the device its worker_count.
+ * A single basis they cannot disagree about is the point: the pool *states* are
+ * a fixed grid, and only the record buffers hanging off them are allocated per
+ * run. header->num_cores therefore still means "cores this run uses" and is not
+ * an addressing input.
+ *
  * @return Total bytes needed for header + all buffer states
  */
-inline size_t
-calc_perf_data_size_with_phases(int num_cores, int /*num_sched_phase_threads*/, int num_orch_phase_threads) {
-    return calc_perf_data_size(num_cores) + num_cores * sizeof(ChipSwimlaneAicoreTaskPool) +
+inline size_t calc_perf_data_size_with_phases() {
+    return calc_perf_data_size(PLATFORM_MAX_CORES) + PLATFORM_MAX_CORES * sizeof(ChipSwimlaneAicoreTaskPool) +
            PLATFORM_MAX_AICPU_THREADS * sizeof(ChipSwimlaneAicpuSchedPhasePool) +
-           num_orch_phase_threads * sizeof(ChipSwimlaneAicpuOrchPhasePool);
+           PLATFORM_MAX_AICPU_THREADS * sizeof(ChipSwimlaneAicpuOrchPhasePool);
 }
 
 /**
  * Get ChipSwimlaneAicoreTaskPool array start address (located immediately
  * after the ChipSwimlaneAicpuTaskPool array).
  */
-inline ChipSwimlaneAicoreTaskPool *get_aicore_buffer_states(void *base_ptr, int num_cores) {
+inline ChipSwimlaneAicoreTaskPool *get_aicore_buffer_states(void *base_ptr) {
     return reinterpret_cast<ChipSwimlaneAicoreTaskPool *>(
-        reinterpret_cast<char *>(base_ptr) + calc_perf_data_size(num_cores)
+        reinterpret_cast<char *>(base_ptr) + calc_perf_data_size(PLATFORM_MAX_CORES)
     );
 }
 
-inline ChipSwimlaneAicoreTaskPool *get_aicore_buffer_state(void *base_ptr, int num_cores, int core_index) {
-    return &get_aicore_buffer_states(base_ptr, num_cores)[core_index];
+inline ChipSwimlaneAicoreTaskPool *get_aicore_buffer_state(void *base_ptr, int core_index) {
+    return &get_aicore_buffer_states(base_ptr)[core_index];
 }
 
 /**
  * Get ChipSwimlaneAicpuSchedPhasePool array start address (located immediately
  * after the ChipSwimlaneAicoreTaskPool array).
  */
-inline ChipSwimlaneAicpuSchedPhasePool *get_sched_phase_buffer_states(void *base_ptr, int num_cores) {
+inline ChipSwimlaneAicpuSchedPhasePool *get_sched_phase_buffer_states(void *base_ptr) {
     return reinterpret_cast<ChipSwimlaneAicpuSchedPhasePool *>(
-        reinterpret_cast<char *>(base_ptr) + calc_perf_data_size(num_cores) +
-        num_cores * sizeof(ChipSwimlaneAicoreTaskPool)
+        reinterpret_cast<char *>(base_ptr) + calc_perf_data_size(PLATFORM_MAX_CORES) +
+        PLATFORM_MAX_CORES * sizeof(ChipSwimlaneAicoreTaskPool)
     );
 }
 
-inline ChipSwimlaneAicpuSchedPhasePool *get_sched_phase_buffer_state(void *base_ptr, int num_cores, int thread_idx) {
-    return &get_sched_phase_buffer_states(base_ptr, num_cores)[thread_idx];
+inline ChipSwimlaneAicpuSchedPhasePool *get_sched_phase_buffer_state(void *base_ptr, int thread_idx) {
+    return &get_sched_phase_buffer_states(base_ptr)[thread_idx];
 }
 
 /**
@@ -890,15 +894,15 @@ inline ChipSwimlaneAicpuSchedPhasePool *get_sched_phase_buffer_state(void *base_
  * AICPU's iteration count (actual) — otherwise AICPU reads the orch array
  * from inside the (still allocated) sched array tail, corrupting both.
  */
-inline ChipSwimlaneAicpuOrchPhasePool *get_orch_phase_buffer_states(void *base_ptr, int num_cores) {
+inline ChipSwimlaneAicpuOrchPhasePool *get_orch_phase_buffer_states(void *base_ptr) {
     return reinterpret_cast<ChipSwimlaneAicpuOrchPhasePool *>(
-        reinterpret_cast<char *>(get_sched_phase_buffer_states(base_ptr, num_cores)) +
+        reinterpret_cast<char *>(get_sched_phase_buffer_states(base_ptr)) +
         PLATFORM_MAX_AICPU_THREADS * sizeof(ChipSwimlaneAicpuSchedPhasePool)
     );
 }
 
-inline ChipSwimlaneAicpuOrchPhasePool *get_orch_phase_buffer_state(void *base_ptr, int num_cores, int thread_idx) {
-    return &get_orch_phase_buffer_states(base_ptr, num_cores)[thread_idx];
+inline ChipSwimlaneAicpuOrchPhasePool *get_orch_phase_buffer_state(void *base_ptr, int thread_idx) {
+    return &get_orch_phase_buffer_states(base_ptr)[thread_idx];
 }
 
 #ifdef __cplusplus

--- a/src/common/platform/include/host/chip_swimlane_collector.h
+++ b/src/common/platform/include/host/chip_swimlane_collector.h
@@ -231,21 +231,21 @@ struct ChipSwimlaneModule {
             break;
         }
         case ChipSwimlaneBufferKind::AicpuSchedPhase: {
-            auto *state = get_sched_phase_buffer_state(shm, num_cores, static_cast<int>(entry.core_index));
+            auto *state = get_sched_phase_buffer_state(shm, static_cast<int>(entry.core_index));
             site.free_queue = &state->free_queue;
             site.buffer_size = sizeof(ChipSwimlaneAicpuSchedPhaseBuffer);
             site.info.type = ProfBufferType::AICPU_SCHED_PHASE;
             break;
         }
         case ChipSwimlaneBufferKind::AicpuOrchPhase: {
-            auto *state = get_orch_phase_buffer_state(shm, num_cores, static_cast<int>(entry.core_index));
+            auto *state = get_orch_phase_buffer_state(shm, static_cast<int>(entry.core_index));
             site.free_queue = &state->free_queue;
             site.buffer_size = sizeof(ChipSwimlaneAicpuOrchPhaseBuffer);
             site.info.type = ProfBufferType::AICPU_ORCH_PHASE;
             break;
         }
         case ChipSwimlaneBufferKind::AicoreTask: {
-            auto *ac_state = get_aicore_buffer_state(shm, num_cores, static_cast<int>(entry.core_index));
+            auto *ac_state = get_aicore_buffer_state(shm, static_cast<int>(entry.core_index));
             site.free_queue = &ac_state->free_queue;
             site.buffer_size = sizeof(ChipSwimlaneAicoreTaskBuffer);
             site.info.type = ProfBufferType::AICORE_TASK;
@@ -268,7 +268,7 @@ struct ChipSwimlaneModule {
 
         // AicoreTask: per-core (kind 3)
         for (int i = 0; i < num_cores; i++) {
-            auto *ac_state = get_aicore_buffer_state(shm, num_cores, i);
+            auto *ac_state = get_aicore_buffer_state(shm, i);
             cb(/*kind=*/static_cast<int>(ChipSwimlaneBufferKind::AicoreTask), &ac_state->free_queue,
                sizeof(ChipSwimlaneAicoreTaskBuffer));
         }
@@ -282,7 +282,7 @@ struct ChipSwimlaneModule {
             num_sched_phase_threads = 0;
         }
         for (int t = 0; t < num_sched_phase_threads; t++) {
-            auto *state = get_sched_phase_buffer_state(shm, num_cores, t);
+            auto *state = get_sched_phase_buffer_state(shm, t);
             cb(/*kind=*/static_cast<int>(ChipSwimlaneBufferKind::AicpuSchedPhase), &state->free_queue,
                sizeof(ChipSwimlaneAicpuSchedPhaseBuffer));
         }
@@ -293,7 +293,7 @@ struct ChipSwimlaneModule {
             num_orch_phase_threads = 0;
         }
         for (int t = 0; t < num_orch_phase_threads; t++) {
-            auto *state = get_orch_phase_buffer_state(shm, num_cores, t);
+            auto *state = get_orch_phase_buffer_state(shm, t);
             cb(/*kind=*/static_cast<int>(ChipSwimlaneBufferKind::AicpuOrchPhase), &state->free_queue,
                sizeof(ChipSwimlaneAicpuOrchPhaseBuffer));
         }

--- a/src/common/platform/shared/aicpu/chip_swimlane_collector_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/chip_swimlane_collector_aicpu.cpp
@@ -330,7 +330,7 @@ void chip_swimlane_aicpu_init(int worker_count) {
     // Pop first buffer from free_queue for each core
     for (int i = 0; i < worker_count; i++) {
         ChipSwimlaneAicpuTaskPool *state = get_perf_buffer_state(chip_swimlane_base, i);
-        ChipSwimlaneAicoreTaskPool *ac_state = get_aicore_buffer_state(chip_swimlane_base, worker_count, i);
+        ChipSwimlaneAicoreTaskPool *ac_state = get_aicore_buffer_state(chip_swimlane_base, i);
 
         s_aicpu_task_pools[i] = state;
         s_aicore_task_pools[i] = ac_state;
@@ -798,7 +798,7 @@ static Buffer *prime_phase_pool(
     return buf;
 }
 
-void chip_swimlane_aicpu_init_phase(int worker_count, int num_sched_phase_threads, int num_orch_phase_threads) {
+void chip_swimlane_aicpu_init_phase(int /*worker_count*/, int num_sched_phase_threads, int num_orch_phase_threads) {
     void *chip_swimlane_base = reinterpret_cast<void *>(g_platform_chip_swimlane_base);
     if (chip_swimlane_base == nullptr) {
         LOG_ERROR("chip_swimlane_data_base is NULL, cannot initialize phase profiling");
@@ -819,7 +819,7 @@ void chip_swimlane_aicpu_init_phase(int worker_count, int num_sched_phase_thread
     if (orch_n > PLATFORM_MAX_AICPU_THREADS) orch_n = PLATFORM_MAX_AICPU_THREADS;
 
     for (int t = 0; t < sched_n; t++) {
-        auto *state = get_sched_phase_buffer_state(chip_swimlane_base, worker_count, t);
+        auto *state = get_sched_phase_buffer_state(chip_swimlane_base, t);
         s_sched_phase_pools[t] = state;
         s_current_sched_phase_buffers[t] = prime_phase_pool<ChipSwimlaneAicpuSchedPhaseBuffer>(
             state, t, ChipSwimlaneBufferKind::AicpuSchedPhase, &s_current_sched_phase_buffers[t], "sched"
@@ -831,7 +831,7 @@ void chip_swimlane_aicpu_init_phase(int worker_count, int num_sched_phase_thread
     }
 
     for (int t = 0; t < orch_n; t++) {
-        auto *state = get_orch_phase_buffer_state(chip_swimlane_base, worker_count, t);
+        auto *state = get_orch_phase_buffer_state(chip_swimlane_base, t);
         s_orch_phase_pools[t] = state;
         s_current_orch_phase_buffers[t] = prime_phase_pool<ChipSwimlaneAicpuOrchPhaseBuffer>(
             state, t, ChipSwimlaneBufferKind::AicpuOrchPhase, &s_current_orch_phase_buffers[t], "orch"

--- a/src/common/platform/shared/host/chip_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/chip_swimlane_collector.cpp
@@ -145,7 +145,7 @@ int ChipSwimlaneCollector::initialize(
     // both sched and orch — AICPU picks the actual counts at init_phase time
     // and writes them into the header.
     int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
-    size_t total_size = calc_perf_data_size_with_phases(num_aicore, num_phase_threads, num_phase_threads);
+    size_t total_size = calc_perf_data_size_with_phases();
 
     LOG_DEBUG("Shared memory allocation plan:");
     LOG_DEBUG("  Number of cores:      %d", num_aicore);
@@ -276,7 +276,7 @@ int ChipSwimlaneCollector::initialize(
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     for (int i = 0; i < num_aicore; i++) {
-        ChipSwimlaneAicoreTaskPool *ac_state = get_aicore_buffer_state(perf_host_ptr, num_aicore, i);
+        ChipSwimlaneAicoreTaskPool *ac_state = get_aicore_buffer_state(perf_host_ptr, i);
         memset(ac_state, 0, sizeof(ChipSwimlaneAicoreTaskPool));
 
         const int initial_free_count = kAicoreInitialFreeCount;
@@ -348,13 +348,13 @@ int ChipSwimlaneCollector::initialize(
     // allocated only for the first buffer_count pools. For sched the two are
     // equal; orch is a single instance (pool 0), so it zeroes all slots but
     // allocates buffers for just pool 0 — no buffers wasted on unused slots.
-    auto init_phase_pools = [&](auto *buffer_tag, ChipSwimlaneAicpuTaskPool *(*get_state)(void *, int, int),
-                                int state_count, int buffer_count, int buffers_per_thread, ProfBufferType recycle_kind,
+    auto init_phase_pools = [&](auto *buffer_tag, ChipSwimlaneAicpuTaskPool *(*get_state)(void *, int), int state_count,
+                                int buffer_count, int buffers_per_thread, ProfBufferType recycle_kind,
                                 const char *kind_label) -> int {
         using Buffer = std::remove_pointer_t<decltype(buffer_tag)>;
         constexpr size_t buffer_bytes = sizeof(Buffer);
         for (int t = 0; t < state_count; t++) {
-            auto *state = get_state(perf_host_ptr, num_aicore, t);
+            auto *state = get_state(perf_host_ptr, t);
             memset(state, 0, sizeof(ChipSwimlaneAicpuTaskPool));
             if (t >= buffer_count) continue;  // zeroed state only; no buffers (unused slot)
             const int initial_free_count =
@@ -405,8 +405,8 @@ int ChipSwimlaneCollector::initialize(
         ) != 0) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
-    auto orch_get_state = [](void *base, int n_cores, int t) {
-        return get_orch_phase_buffer_state(base, n_cores, t);
+    auto orch_get_state = [](void *base, int t) {
+        return get_orch_phase_buffer_state(base, t);
     };
     const int orch_buffer_count = chip_swimlane_level_ >= ChipSwimlaneLevel::ORCH_PHASES && !host_orchestrated_ ? 1 : 0;
     if (init_phase_pools(
@@ -802,7 +802,7 @@ void ChipSwimlaneCollector::reconcile_counters() {
     reconcile_one(
         "SCHED_PHASE", "thread", PLATFORM_MAX_AICPU_THREADS,
         [this](int thread_index) {
-            return get_sched_phase_buffer_state(shm_host_, num_aicore_, thread_index);
+            return get_sched_phase_buffer_state(shm_host_, thread_index);
         },
         [](void *host_ptr) {
             return reinterpret_cast<ChipSwimlaneAicpuSchedPhaseBuffer *>(host_ptr)->count;
@@ -813,7 +813,7 @@ void ChipSwimlaneCollector::reconcile_counters() {
     reconcile_one(
         "ORCH_PHASE", "thread", PLATFORM_MAX_AICPU_THREADS,
         [this](int thread_index) {
-            return get_orch_phase_buffer_state(shm_host_, num_aicore_, thread_index);
+            return get_orch_phase_buffer_state(shm_host_, thread_index);
         },
         [](void *host_ptr) {
             return reinterpret_cast<ChipSwimlaneAicpuOrchPhaseBuffer *>(host_ptr)->count;
@@ -1332,7 +1332,7 @@ int ChipSwimlaneCollector::finalize(
         state->head.current_buf_ptr = 0;
         drain_free_queue(state->free_queue);
 
-        ChipSwimlaneAicoreTaskPool *ac_state = get_aicore_buffer_state(shm_host_, num_aicore_, i);
+        ChipSwimlaneAicoreTaskPool *ac_state = get_aicore_buffer_state(shm_host_, i);
         release_one_buffer(reinterpret_cast<void *>(ac_state->head.current_buf_ptr), unregister_cb, free_cb);
         ac_state->head.current_buf_ptr = 0;
         drain_free_queue(ac_state->free_queue);
@@ -1358,10 +1358,10 @@ int ChipSwimlaneCollector::finalize(
     };
     int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
     for (int t = 0; t < num_phase_threads; t++) {
-        release_phase_pool(get_sched_phase_buffer_state(shm_host_, num_aicore_, t));
+        release_phase_pool(get_sched_phase_buffer_state(shm_host_, t));
     }
     for (int t = 0; t < num_phase_threads; t++) {
-        release_phase_pool(get_orch_phase_buffer_state(shm_host_, num_aicore_, t));
+        release_phase_pool(get_orch_phase_buffer_state(shm_host_, t));
     }
 
     // Main shm: unregister + free as a pair, same as every other buffer.


### PR DESCRIPTION
## Summary

The swimlane shared-memory region holds four pool arrays, and **only the first
one starts at a fixed offset**. The other three were located from `num_cores` —
which the host and the AICPU each supplied themselves: the host from the run's
core count, the device from its `worker_count`. They agree today only because
those two numbers happen to be equal.

That is a poor invariant for a host↔device addressing contract. Nothing declares
it, nothing checks it, and breaking it is **silent** — the two sides then read
and write different addresses in one region, and swimlane records go missing
with no error on either side. The signature is a *negative* `silent_loss` in
reconcile:

```
SCHED_PHASE count mismatch (collected=2 + dropped=0 != device_total=0, silent_loss=-2)
```

Records cannot be lost below zero, so that can only mean the two sides are
addressing different memory.

## What changes

Offsets now derive from `PLATFORM_MAX_CORES`, and **the accessors stop taking
the parameter at all**:

```cpp
-get_aicore_buffer_state(void *base, int num_cores, int core_index)
+get_aicore_buffer_state(void *base, int core_index)
```

There is nothing left for the two sides to disagree about, and every call site
was found by the compiler rather than by inspection — which is the reason for
removing the parameter instead of passing a maximum through it.

Only the pool **state** grid is dimensioned by the maximum; the record buffers
hanging off it are still allocated for the cores a run actually uses.
`header->num_cores` therefore keeps meaning "cores this run launched" and stops
being an addressing input — it still bounds iteration and validates a core
index.

## This extends an existing rule rather than inventing one

The sched and orch arrays **already** did exactly this, and their comment
records an earlier instance of the same bug:

> The OFFSET must match the host's alloc layout (max), not AICPU's iteration
> count (actual) — otherwise AICPU reads the orch array from inside the (still
> allocated) sched array tail, corrupting both.

This PR applies that to the remaining dimension, so all four arrays are on one
convention instead of two.

## Testing

- [x] All four variants build (a2a3/a5 × onboard/sim)
- [x] **Every DFX channel, both arches, one channel per invocation as CI runs
  them**: chip_swimlane / PMU / args_dump / dep_gen (tmr) / scope_stats /
  dep_gen (hbg) — 12/12 green. This is the gate that matters here; the plain
  scene-test sweep passes no diagnostic flags and cannot see a swimlane layout
  fault at all.
- [x] cpput 128/128
- [x] a5sim sweep: 18 + 46 passed
- [x] a2a3sim sweep: 43 passed, 1 pre-existing failure
  (`TestSpmdPagedAttentionHighPerf::b4_h32_kv8_s512_bs128_fp16`, `manual: True`,
  reproduced with the identical `max_diff=0.0625` on a clean base)
- [x] clang-format
- [ ] No onboard run locally — this box is a2a3 silicon; covered by CI

Groundwork for #2078: making the collectors resident requires their allocation
to stop depending on a single run, and this contract had to become run-independent
first. The residency change itself — per-run state reset, idempotent
`initialize()`, dropping the per-run `finalize_collectors` / start, `stop()` →
`quiesce()` — follows separately.
