### PR TITLE
Refactor: rename maybe_rendezvous_ring to try_launch_sync_start_cohort

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -877,7 +877,7 @@ struct SchedulerState {
             // The flip to DISPATCHED is only the producer-released half of the
             // rendezvous; the ring fires once every gated core also occupies a
             // running slot, from whichever half completes second.
-            maybe_rendezvous_ring(slot_state);
+            try_launch_sync_start_cohort(slot_state);
         } else {
             for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
                 uint64_t owned = claim_all_staged_doorbell_bits(payload.staged_core_mask[w]);
@@ -1072,7 +1072,7 @@ struct SchedulerState {
     // release and each pending->running promotion); whichever observes the second half
     // wins the launch latch and rings exactly once. Returns true only to that winner,
     // which may then expose the cohort to its fanout.
-    inline bool maybe_rendezvous_ring(ChipTaskSlotState &slot_state) {
+    inline bool try_launch_sync_start_cohort(ChipTaskSlotState &slot_state) {
         // running_slot_count is the publication seed: every staged_core_mask OR
         // happens-before its final store. Read the seed first, then the mask, so
         // observing the final count cannot be paired with a partially published

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -394,7 +394,7 @@ void SchedulerContext::check_running_cores_for_completion(
                 promote_pending_to_running(core);  // Case 2 or Case 3 (with pending)
                 if (sync_start_promote) {
                     promoted->to_payload().running_slot_count.fetch_add(1, std::memory_order_seq_cst);
-                    sched_->maybe_rendezvous_ring(*promoted);
+                    sched_->try_launch_sync_start_cohort(*promoted);
                 }
             } else {
                 clear_running_slot(core);  // Case 1 or Case 3 (no pending)
@@ -736,7 +736,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     }
     if (gated) {
         // Seed the rendezvous with the running-slot cores staged across all threads; pending
-        // cores advance it as they promote. maybe_rendezvous_ring (producer release) rings iff
+        // cores advance it as they promote. try_launch_sync_start_cohort (producer release) rings iff
         // this already equals popcount(staged_core_mask) — i.e. no pending spill.
         slot_state->to_payload().running_slot_count.store(
             static_cast<int16_t>(drain_state_.drain_running_staged.load(std::memory_order_acquire)),
@@ -759,7 +759,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     // ahead of drain completion and fail while running_slot_count is still incomplete. When
     // every block landed directly in a running slot, no pending promotion remains to retry it.
     if (gated) {
-        sched_->maybe_rendezvous_ring(*slot_state);
+        sched_->try_launch_sync_start_cohort(*slot_state);
     }
     SchedulerState::finish_early_sync_drain(slot_state->to_payload());
 }

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -882,7 +882,7 @@ int32_t SchedulerContext::try_early_dispatch(
                 c->to_payload().running_slot_count.store(
                     static_cast<int16_t>(staged.running_cores), std::memory_order_seq_cst
                 );
-                sched_->maybe_rendezvous_ring(*c);
+                sched_->try_launch_sync_start_cohort(*c);
                 SchedulerState::finish_early_sync_drain(c->to_payload());
                 total_staged += staged.staged_blocks;
             } else if (enter_drain_mode(c, c->logical_block_num)) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -673,7 +673,7 @@ logical clusters even though each block may stage multiple cores.
    barrier also serializes a global coordinator with any local staging that raced drain
    publication: the local scheduler cannot ack until its tracker mutations are complete.
 4. **Rendezvous launch** — both paths publish every `staged_core_mask` word before storing
-   the final `running_slot_count` seed. `maybe_rendezvous_ring` reads the seed first and then
+   the final `running_slot_count` seed. `try_launch_sync_start_cohort` reads the seed first and then
    the mask; when the counts match **and** the producer has released, one launch-latch winner
    rings every gated core's doorbell together.
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
@@ -888,7 +888,7 @@ struct SchedulerState {
     // release and each pending->running promotion); whichever observes the second half
     // wins the launch latch and rings exactly once. Returns true only to that winner,
     // which may then expose the cohort to its fanout.
-    inline bool maybe_rendezvous_ring(ChipTaskSlotState &slot_state) {
+    inline bool try_launch_sync_start_cohort(ChipTaskSlotState &slot_state) {
         // running_slot_count is the publication seed: every staged_core_mask OR
         // happens-before its final store. Read the seed first, then the mask, so
         // observing the final count cannot be paired with a partially published
@@ -912,7 +912,7 @@ struct SchedulerState {
     }
 
     inline bool retry_sync_start_rendezvous_after_staging(ChipTaskSlotState &slot_state) {
-        if (!maybe_rendezvous_ring(slot_state)) return false;
+        if (!try_launch_sync_start_cohort(slot_state)) return false;
         propagate_dispatch_fanin(slot_state);
         return true;
     }
@@ -1047,12 +1047,12 @@ struct SchedulerState {
         // Producer released: ring the gated cores. A non-sync_start consumer launches
         // each block the instant its doorbell fires. A sync_start consumer instead holds
         // for the rendezvous — every gated core must occupy a running slot first — so the
-        // flip to DISPATCHED above is only the producer-released half; maybe_rendezvous_ring
+        // flip to DISPATCHED above is only the producer-released half; try_launch_sync_start_cohort
         // rings now iff running_slot_count already reached popcount(staged_core_mask) (all
         // gated cores took idle running slots), else the last pending->running promotion rings.
         bool launched = true;
         if (sync_start) {
-            launched = maybe_rendezvous_ring(slot_state);
+            launched = try_launch_sync_start_cohort(slot_state);
         } else {
             // Destructively claim every published bit. A stager racing this pass
             // can claim only bits that land after the exchange, so each gated core

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -454,7 +454,7 @@ void SchedulerContext::check_running_cores_for_completion(
                 promote_pending_to_running(core);  // Case 2 or Case 3 (with pending)
                 if (sync_start_promote) {
                     promoted->payload->running_slot_count.fetch_add(1, std::memory_order_seq_cst);
-                    if (sched_->maybe_rendezvous_ring(*promoted)) {
+                    if (sched_->try_launch_sync_start_cohort(*promoted)) {
                         sched_->propagate_dispatch_fanin(*promoted);
                     }
                 }
@@ -792,7 +792,7 @@ void SchedulerContext::handle_drain_mode(
     }
     if (gated) {
         // Seed the rendezvous with the running-slot cores staged across all threads; pending
-        // cores advance it as they promote. maybe_rendezvous_ring (producer release) rings iff
+        // cores advance it as they promote. try_launch_sync_start_cohort (producer release) rings iff
         // this already equals popcount(staged_core_mask) — i.e. no pending spill.
         slot_state->payload->running_slot_count.store(
             static_cast<int16_t>(drain_state_.drain_running_staged.load(std::memory_order_acquire)),

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -888,7 +888,7 @@ struct SchedulerState {
             // The flip to DISPATCHED is only the producer-released half of the
             // rendezvous; the ring fires once every gated core also occupies a
             // running slot, from whichever half completes second.
-            maybe_rendezvous_ring(slot_state);
+            try_launch_sync_start_cohort(slot_state);
         } else {
             for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
                 uint64_t owned = claim_all_staged_doorbell_bits(payload.staged_core_mask[w]);
@@ -1083,7 +1083,7 @@ struct SchedulerState {
     // release and each pending->running promotion); whichever observes the second half
     // wins the launch latch and rings exactly once. Returns true only to that winner,
     // which may then expose the cohort to its fanout.
-    inline bool maybe_rendezvous_ring(ChipTaskSlotState &slot_state) {
+    inline bool try_launch_sync_start_cohort(ChipTaskSlotState &slot_state) {
         // running_slot_count is the publication seed: every staged_core_mask OR
         // happens-before its final store. Read the seed first, then the mask, so
         // observing the final count cannot be paired with a partially published

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -399,7 +399,7 @@ void SchedulerContext::check_running_cores_for_completion(
                 promote_pending_to_running(core);  // Case 2 or Case 3 (with pending)
                 if (sync_start_promote) {
                     promoted->to_payload().running_slot_count.fetch_add(1, std::memory_order_seq_cst);
-                    sched_->maybe_rendezvous_ring(*promoted);
+                    sched_->try_launch_sync_start_cohort(*promoted);
                 }
             } else {
                 clear_running_slot(core);  // Case 1 or Case 3 (no pending)
@@ -741,7 +741,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     }
     if (gated) {
         // Seed the rendezvous with the running-slot cores staged across all threads; pending
-        // cores advance it as they promote. maybe_rendezvous_ring (producer release) rings iff
+        // cores advance it as they promote. try_launch_sync_start_cohort (producer release) rings iff
         // this already equals popcount(staged_core_mask) — i.e. no pending spill.
         slot_state->to_payload().running_slot_count.store(
             static_cast<int16_t>(drain_state_.drain_running_staged.load(std::memory_order_acquire)),
@@ -764,7 +764,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx, [[maybe_unused]] ui
     // ahead of drain completion and fail while running_slot_count is still incomplete. When
     // every block landed directly in a running slot, no pending promotion remains to retry it.
     if (gated) {
-        sched_->maybe_rendezvous_ring(*slot_state);
+        sched_->try_launch_sync_start_cohort(*slot_state);
     }
     SchedulerState::finish_early_sync_drain(slot_state->to_payload());
 }

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -883,7 +883,7 @@ int32_t SchedulerContext::try_early_dispatch(
                 c->to_payload().running_slot_count.store(
                     static_cast<int16_t>(staged.running_cores), std::memory_order_seq_cst
                 );
-                sched_->maybe_rendezvous_ring(*c);
+                sched_->try_launch_sync_start_cohort(*c);
                 SchedulerState::finish_early_sync_drain(c->to_payload());
                 total_staged += staged.staged_blocks;
             } else if (enter_drain_mode(c, c->logical_block_num)) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -694,7 +694,7 @@ two all-or-nothing cases:
 4. **Rendezvous launch** — after the complete `staged_core_mask` is published,
    `running_slot_count` is seeded with the staged running-slot cores. The rendezvous reads
    that seed before the full mask; when it equals `popcount(staged_core_mask)` **and** the
-   producer has released, `maybe_rendezvous_ring` rings every gated core's doorbell
+   producer has released, `try_launch_sync_start_cohort` rings every gated core's doorbell
    together — the cohort starts as one.
 
 If a global drain is published concurrently after Case A's zero check, its ack barrier

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
@@ -877,7 +877,7 @@ struct SchedulerState {
         }
     }
 
-    inline bool maybe_rendezvous_ring(ChipTaskSlotState &slot_state) {
+    inline bool try_launch_sync_start_cohort(ChipTaskSlotState &slot_state) {
         // Staging publishes the complete mask before seeding running_slot_count.
         // Read the seed first: observing the final seq_cst seed then orders every
         // mask read after all of the stager's mask updates. Reading the mask first
@@ -901,7 +901,7 @@ struct SchedulerState {
     }
 
     inline bool retry_sync_start_rendezvous_after_staging(ChipTaskSlotState &slot_state) {
-        if (!maybe_rendezvous_ring(slot_state)) return false;
+        if (!try_launch_sync_start_cohort(slot_state)) return false;
         propagate_dispatch_fanin(slot_state);
         return true;
     }
@@ -997,7 +997,7 @@ struct SchedulerState {
         );
         bool launched = true;
         if (sync_start) {
-            launched = maybe_rendezvous_ring(slot_state);
+            launched = try_launch_sync_start_cohort(slot_state);
         } else {
             for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++) {
                 uint64_t owned = claim_all_staged_doorbell_bits(slot_state.payload->staged_core_mask[w]);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -402,7 +402,7 @@ void SchedulerContext::check_running_cores_for_completion(
                 promote_pending_to_running(core);
                 if (sync_start_promote) {
                     promoted->payload->running_slot_count.fetch_add(1, std::memory_order_seq_cst);
-                    if (sched_->maybe_rendezvous_ring(*promoted)) {
+                    if (sched_->try_launch_sync_start_cohort(*promoted)) {
                         sched_->propagate_dispatch_fanin(*promoted);
                     }
                 }


### PR DESCRIPTION
## What

Mechanical rename of the sync_start launch arbiter, `SchedulerState::maybe_rendezvous_ring` → `try_launch_sync_start_cohort`, across all four scheduler trees (a2a3/a5 × host_build_graph/tensormap_and_ringbuffer): 24 occurrences in 12 files — definitions, call sites, comments naming the identifier, and the two TMR `RUNTIME_LOGIC.md` sections.

## Why

- **`ring` is a load-bearing noun in this codebase** (`ChipRingBuffer`, `ring_task_window`, `HEAP_RING`), and this was the only doorbell-ringing identifier where the verb appeared without `doorbell` to disambiguate — worse, in suffix position, so `rendezvous_ring` reads as a noun phrase ("the rendezvous ring") rather than "maybe ring the rendezvous". Every sibling self-disambiguates: `ring_one_doorbell`, `ring_all_staged_doorbells`, `ring_claimed_local_doorbell`.
- **`maybe_` was the lone exception to the local `try_` convention** for may-fail bool helpers (`try_claim_early_dispatch_launch`, `try_early_dispatch_release`, `try_claim_early_sync_drain`).
- **"ring" names only the middle step.** The function checks both rendezvous halves (all gated cores hold running slots AND the producer released), wins the launch latch, rings every staged doorbell, and publishes `LAUNCH_COMPLETE` — it is the cohort launch arbiter, and `launch` matches the `EARLY_DISPATCH_LAUNCH_*` states it drives.

The `ring_*_doorbell*` helpers keep the verb (always disambiguated by `doorbell`), and TMR's `retry_sync_start_rendezvous_after_staging` wrapper is unchanged. No behavior change.

## Verification

- `grep -rn maybe_rendezvous_ring src/` returns zero matches.
- Full C++ UT build (CI-matching configuration, no `CMAKE_BUILD_TYPE`) exits 0.
- Scheduler UTs pass on all four trees: `test_scheduler_state`, `test_a5_scheduler_state`, `test_hbg_scheduler_drain`, `test_a5_hbg_scheduler_drain`, `test_a5_hbg_scheduler_dispatch`.