### PR TITLE
Refactor: drop SimplerHostSpan's version and size words

### DIFF
--- a/src/common/log/host_log.cpp
+++ b/src/common/log/host_log.cpp
@@ -887,8 +887,7 @@ const char *HostLogger::log_directory() const {
 
 void HostLogger::log_host_span(const SimplerHostSpan *span) {
     if (!is_enabled(LogLevel::TIMING)) return;
-    if (span == nullptr || span->abi_version != SIMPLER_HOST_SPAN_ABI_VERSION ||
-        span->struct_size < sizeof(SimplerHostSpan) || span->name == nullptr) {
+    if (span == nullptr || span->name == nullptr) {
         return;
     }
     const std::string name = encode_host_span_field(span->name, kHostSpanNameCapacity, false);

--- a/src/common/log/include/common/host_span.h
+++ b/src/common/log/include/common/host_span.h
@@ -13,15 +13,18 @@
 
 #include <stdint.h>
 
-#define SIMPLER_HOST_SPAN_ABI_VERSION 1U
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/*
+ * One span record on its way to the logger. A stack temporary, handed to the
+ * link-time unified_log_host_span in the same DSO, so it carries no version or
+ * size word: the two producers are inline in this repository's headers and the
+ * validator is compiled from the same header in the same build, which leaves
+ * nothing for such a word to detect.
+ */
 typedef struct SimplerHostSpan {
-    uint32_t abi_version;
-    uint32_t struct_size;
     uint64_t invocation_id;
     uint64_t callable_hash;
     int32_t depth;

--- a/src/common/log/include/common/host_span_scope.h
+++ b/src/common/log/include/common/host_span_scope.h
@@ -42,18 +42,7 @@ inline void emit(
     int64_t duration_ns, const char *attributes
 ) noexcept {
     if (!enabled()) return;
-    const SimplerHostSpan span{
-        SIMPLER_HOST_SPAN_ABI_VERSION,
-        sizeof(SimplerHostSpan),
-        invocation_id,
-        callable_hash,
-        depth,
-        0,
-        timestamp_ns,
-        duration_ns,
-        name,
-        attributes
-    };
+    const SimplerHostSpan span{invocation_id, callable_hash, depth, 0, timestamp_ns, duration_ns, name, attributes};
     unified_log_host_span(&span);
 }
 

--- a/src/common/log/include/common/strace.h
+++ b/src/common/log/include/common/strace.h
@@ -101,18 +101,7 @@ inline void emit_record(
     const char *name, uint64_t invocation_id, uint64_t callable_hash, int32_t depth, int64_t timestamp_ns,
     int64_t duration_ns, const char *attributes
 ) {
-    const SimplerHostSpan span{
-        SIMPLER_HOST_SPAN_ABI_VERSION,
-        sizeof(SimplerHostSpan),
-        invocation_id,
-        callable_hash,
-        depth,
-        0,
-        timestamp_ns,
-        duration_ns,
-        name,
-        attributes
-    };
+    const SimplerHostSpan span{invocation_id, callable_hash, depth, 0, timestamp_ns, duration_ns, name, attributes};
     unified_log_host_span(&span);
 }
 

--- a/tests/ut/cpp/a5/test_host_log_off.cpp
+++ b/tests/ut/cpp/a5/test_host_log_off.cpp
@@ -337,16 +337,7 @@ TEST(HostLogTest, LongHumanRecordFitsPortableAtomicWriteBound) {
 TEST(HostLogTest, HostSpanEscapesDelimitersAndFitsAtomicPipeRecord) {
     const std::string name = "bad name\n[STRACE]=x";
     const std::string attributes = "run_id=7 role=worker\n[STRACE] injected=1 " + std::string(4096, 'x');
-    const SimplerHostSpan span{SIMPLER_HOST_SPAN_ABI_VERSION,
-                               sizeof(SimplerHostSpan),
-                               7,
-                               0x1234,
-                               0,
-                               0,
-                               100,
-                               25,
-                               name.c_str(),
-                               attributes.c_str()};
+    const SimplerHostSpan span{7, 0x1234, 0, 0, 100, 25, name.c_str(), attributes.c_str()};
 
     auto captured = run_with_config(LogLevel::TIMING, [&] {
         unified_log_host_span(&span);
@@ -402,12 +393,8 @@ TEST(HostLogTest, LogDirectorySendsEveryRecordToOneAsyncFilePerProcess) {
     ScopedLogDirectory scoped_log_directory(directory);
     ASSERT_STREQ(HostLogger::get_instance().log_directory(), directory);
 
-    const SimplerHostSpan nested{
-        SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 7, 0x1234, 1, 0, 100, 25, "chip.run.bind", "run_id=7"
-    };
-    const SimplerHostSpan root{
-        SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 7, 0x1234, 0, 0, 90, 50, "chip.run", "run_id=7"
-    };
+    const SimplerHostSpan nested{7, 0x1234, 1, 0, 100, 25, "chip.run.bind", "run_id=7"};
+    const SimplerHostSpan root{7, 0x1234, 0, 0, 90, 50, "chip.run", "run_id=7"};
     g_shared_log_state.clock_anchor_pid = 0;
     const auto captured = run_with_config(LogLevel::TIMING, [&] {
         unified_log_host_span(&nested);
@@ -479,9 +466,7 @@ TEST(HostLogTest, ForkBoundaryDrainsParentAndChildOpensItsOwnFile) {
     // test in this binary left behind.
     HostLogger::get_instance().set_level(LogLevel::TIMING);
 
-    const SimplerHostSpan parent_span{
-        SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 8, 0x1234, 1, 0, 100, 25, "parent.span", ""
-    };
+    const SimplerHostSpan parent_span{8, 0x1234, 1, 0, 100, 25, "parent.span", ""};
     unified_log_host_span(&parent_span);
     // Production uses this same quiescent boundary before a hierarchical
     // Worker forks: accepted parent records are drained and the thread joined.
@@ -490,9 +475,7 @@ TEST(HostLogTest, ForkBoundaryDrainsParentAndChildOpensItsOwnFile) {
     const pid_t child = fork();
     ASSERT_GE(child, 0);
     if (child == 0) {
-        const SimplerHostSpan child_span{
-            SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 9, 0x1234, 0, 0, 200, 25, "child.span", ""
-        };
+        const SimplerHostSpan child_span{9, 0x1234, 0, 0, 200, 25, "child.span", ""};
         HostLogger::get_instance().set_level(LogLevel::TIMING);
         unified_log_host_span(&child_span);
         if (!HostLogger::get_instance().flush()) _exit(3);
@@ -522,10 +505,7 @@ TEST(HostLogTest, ForkBoundaryDrainsParentAndChildOpensItsOwnFile) {
 }
 
 TEST(HostLogTest, DisabledHostSpanProducesNoRecord) {
-    const SimplerHostSpan span{
-        SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 7, 0x1234, 0, 0, 100, 25, "node.dispatch",
-        "run_id=7 role=scheduler"
-    };
+    const SimplerHostSpan span{7, 0x1234, 0, 0, 100, 25, "node.dispatch", "run_id=7 role=scheduler"};
 
     auto captured = run_with_config(LogLevel::WARN, [&] {
         unified_log_host_span(&span);
@@ -544,16 +524,7 @@ TEST(HostLogTest, AllHostSpanEmitPathsPreserve64BitInvocationIds) {
         { simpler::strace::StraceScope scope("scope_path"); }
         simpler::strace::emit_host_span_at("explicit_path", 100, 25, 0);
 
-        const SimplerHostSpan span{SIMPLER_HOST_SPAN_ABI_VERSION,
-                                   sizeof(SimplerHostSpan),
-                                   invocation_id,
-                                   callable_hash,
-                                   0,
-                                   0,
-                                   200,
-                                   30,
-                                   "c_abi_path",
-                                   ""};
+        const SimplerHostSpan span{invocation_id, callable_hash, 0, 0, 200, 30, "c_abi_path", ""};
         unified_log_host_span(&span);
     });
 
@@ -575,16 +546,7 @@ TEST(HostLogTest, HostSpanTruncationDropsAWholeEscapeRatherThanItsLastByte) {
     // 3 (leading escape) + 186 + 3 (trailing escape) is exactly the 192-byte
     // attribute budget, so the next byte truncates on an escape boundary.
     const std::string attributes = "\n" + std::string(186, 'x') + "\ny";
-    const SimplerHostSpan span{SIMPLER_HOST_SPAN_ABI_VERSION,
-                               sizeof(SimplerHostSpan),
-                               7,
-                               0x1234,
-                               0,
-                               0,
-                               100,
-                               25,
-                               "node.dispatch",
-                               attributes.c_str()};
+    const SimplerHostSpan span{7, 0x1234, 0, 0, 100, 25, "node.dispatch", attributes.c_str()};
 
     auto captured = run_with_config(LogLevel::TIMING, [&] {
         unified_log_host_span(&span);

--- a/tests/ut/cpp/common/test_host_log_unbound.cpp
+++ b/tests/ut/cpp/common/test_host_log_unbound.cpp
@@ -19,9 +19,7 @@ TEST(HostLogUnboundTest, PrivateModuleStateStartsSilent) {
     EXPECT_EQ(HostLogger::get_instance().level(), static_cast<int>(simpler::log::LogLevel::NUL));
     EXPECT_EQ(unified_log_host_span_enabled(), 0);
 
-    const SimplerHostSpan span{
-        SIMPLER_HOST_SPAN_ABI_VERSION, sizeof(SimplerHostSpan), 1, 0, 0, 0, 100, 25, "node.dispatch", "run_id=1"
-    };
+    const SimplerHostSpan span{1, 0, 0, 0, 100, 25, "node.dispatch", "run_id=1"};
     testing::internal::CaptureStderr();
     HostLogger::get_instance().log(simpler::log::LogLevel::ERROR, "unbound", "must stay silent");
     unified_log_host_span(&span);


### PR DESCRIPTION
## Summary

`SimplerHostSpan` carried an `abi_version` / `struct_size` handshake that cannot detect anything, and this removes it. Same reasoning as the one #2029 took out of `SimplerHostLogState` — the project rule is that an internal format whose producer and consumer both live in this repository gets no version word.

Here the case is **stronger than the state struct's**, which is why it is worth spelling out rather than just asserting the rule.

## The span crosses no boundary

A `SimplerHostSpan` is a stack temporary:

```cpp
// src/common/log/include/common/strace.h — and host_span_scope.h, identically
const SimplerHostSpan span{invocation_id, callable_hash, depth, 0, timestamp_ns, duration_ns, name, attributes};
unified_log_host_span(&span);
```

`unified_log_host_span` is a **link-time** symbol (not `dlsym`'d like `simpler_host_log_bind_state`), and `unified_log_host.cpp` sits in `SIMPLER_HOST_LOG_SOURCES` alongside `host_log.cpp`, so every host DSO compiles its own copy. The span is therefore constructed and consumed **inside one DSO, in one build**.

That makes both comparisons tautologies:

- the producers set `abi_version` to `SIMPLER_HOST_SPAN_ABI_VERSION`; the validator compares against `SIMPLER_HOST_SPAN_ABI_VERSION`
- the producers set `struct_size` to `sizeof(SimplerHostSpan)`; the validator compares against `sizeof(SimplerHostSpan)`

All three sites come from the same header. There is no configuration in which they disagree.

Contrast with `SimplerHostLogState`, where two independently built DSOs could at least *in principle* bind the same allocation — that word still came out (in #2029, because the run-time-compiled orchestration SO hashes the header's whole include closure into its scene-test cache key), but it was at least guarding a real boundary. This one is not.

## Checked before removing, not assumed

- **Every producer and consumer is in-repo.** `git grep -l "SimplerHostSpan\|unified_log_host_span"` lands only in `src/common/log/`, `tests/ut/cpp/`, and two docs. Zero hits in `build/pypto` or `build/pto-isa`.
- **Two production producers**, both inline in this repo's headers (`host_span_scope.h`, `strace.h`); **one validator**, in `host_log.cpp`. The two other `unified_log_host_span` definitions are test stubs/overrides (`test_stubs.cpp`, `test_scheduler.cpp`) that validate nothing.
- No doc mentioned the span ABI, so nothing there went stale.

## What stays

`log_host_span` keeps the check that **can** fail — a null span or a null `name`:

```cpp
if (span == nullptr || span->name == nullptr) return;
```

`reserved` stays too: it is padding the layout wants, not a protocol field.

## Testing

| | |
| --- | --- |
| cpput | **132/132** |
| pyut | 2102 passed, 18 skipped |
| st a2a3sim / a5sim | 33 / 29, no failures |
| st a2a3 onboard | 67, no failures |
| linters | clang-format, clang-tidy, ruff, pyright, markdownlint, retired-names, headers, english-only — clean |

One pyut re-run: `test_failed_startup_reaps_children_no_leak` failed once and passed on re-run. It is the known load-sensitive child-reap budget in `test_startup_readiness.py` — the box was at load average ~69, the failure is a reap deadline rather than an assertion about logging, and this diff removes two integer fields from a span struct with no path to child reaping.

Follows #2029, which removed the same pair from `SimplerHostLogState`.
