### PR TITLE
Fix: provide SDMA workspace on simulator

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -500,14 +500,15 @@ def pytest_configure(config):
         "fixtures and standalone runners build its Worker with enable_sdma=True "
         "unless worker_workspace=False selects a platform-provisioned "
         "communication-domain workspace. "
-        "Worker-global provisioning creates 48 "
+        "On onboard a2a3, worker-global provisioning creates 48 "
         "device-only STARS streams that sit in the device fault domain, which "
         "makes a later AICore fault on that device cost minutes instead of "
         "~0.3 s (#1425). Two consequences follow from the one marker: such a "
         "test never shares an L2 Worker (the pool key carries the flag) and it "
         "sorts after every ordinary test, so fault-injection cases run on a "
         "device that has never provisioned. The a2a3 CI additionally runs them "
-        "in a step of their own via -m sdma until #1425 is fixed",
+        "in a step of their own via -m sdma until #1425 is fixed. On sim platforms, "
+        "the workspace is inert scratch and no hardware streams are created.",
     )
     config.addinivalue_line(
         "markers",

--- a/docs/aicore-kernel-programming.md
+++ b/docs/aicore-kernel-programming.md
@@ -73,7 +73,7 @@ and the runtime provisions the SDMA workspace once at init, latches its address
 into `KernelArgs`, and injects it into every run's `GlobalContext`. A Worker
 that does not opt in creates no SDMA streams, and `get_dma_workspace` returns
 `nullptr`. Provisioning fails fast (Worker init raises) on a platform/runtime
-without SDMA support. Every event submitted through the workspace must be waited
+without support for the requested workspace kind. Every event submitted through the workspace must be waited
 before the kernel returns or registered with the runtime's deferred-completion
 mechanism.
 An invalid kind or unprovisioned slot returns `nullptr` and must not be used to

--- a/docs/comm-domain.md
+++ b/docs/comm-domain.md
@@ -216,7 +216,7 @@ symmetric window is realized:
 | Window memory | POSIX shm + `ftruncate`, mmap'd per rank | a2a3: Fabric V2 handle exchange (`ACL_MEM_SHARE_HANDLE_TYPE_FABRIC`), falling back to VMM + shareable-handle IPC where Fabric is unsupported. a5: VMM shareable handles only. Cross-card P2P via `aclrtDeviceEnablePeerAccess` on both |
 | Subset barrier | shm-header atomic, `allocation_id`-scoped | file barriers, `allocation_id`-scoped |
 | Window init | window zeroed before the subset barrier (`memset`) | window zeroed before the handle is announced (`aclrtMemset`) |
-| Async-DMA workspace | n/a | a2a3: opt-in per Worker (`enable_sdma`); a5: SDMA by default, URMA as an opt-in alternative |
+| Async-DMA workspace | opt-in per Worker (`enable_sdma`, provisions inert 16 KiB scratch without STARS streams) | a2a3: opt-in per Worker (`enable_sdma`); a5: SDMA by default, URMA as an opt-in alternative |
 
 The window is zero-initialized on both backends so scratch/signal protocols see
 a known starting state (matching the historical static-path contract).

--- a/examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo/kernels/aiv/kernel_prefetch_copy.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo/kernels/aiv/kernel_prefetch_copy.cpp
@@ -62,8 +62,9 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     GlobalData in_global(in);
     GlobalData out_global(out);
 
-    // Runtime-injected SDMA workspace -- no user arg. The host refuses this
-    // marked callable unless SDMA is supported and provisioning succeeded.
+    // Runtime-injected SDMA workspace -- no user arg. On supported platforms
+    // (including sim, which provides inert scratch), get_dma_workspace returns
+    // a non-null address when the Worker requested SDMA; nullptr means injection failed.
     __gm__ uint8_t *sdma_workspace = get_dma_workspace(args, DMA_WORKSPACE_SDMA);
     if (sdma_workspace == nullptr) {
         pipe_barrier(PIPE_ALL);

--- a/examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo/test_prefetch_async_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo/test_prefetch_async_demo.py
@@ -7,21 +7,28 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Single-card TPREFETCH_ASYNC smoke test for onboard a2a3.
+"""Single-card TPREFETCH_ASYNC smoke test.
 
 Exercises the runtime-injected SDMA workspace: a Worker created with
-``enable_sdma=True`` provisions the PTO-ISA async-SDMA workspace once at init and
-injects its address into every kernel's GlobalContext, so the kernel obtains it
-via ``get_dma_workspace(args, DMA_WORKSPACE_SDMA)`` -- no workspace is threaded
-as a user arg. A Worker without ``enable_sdma`` creates no SDMA streams and its
+``enable_sdma=True`` provisions the workspace once at init and injects its
+address into every kernel's GlobalContext, so the kernel obtains it via
+``get_dma_workspace(args, DMA_WORKSPACE_SDMA)`` -- no workspace is threaded as a
+user arg. A Worker without ``enable_sdma`` creates no SDMA streams and its
 kernels read a zero workspace address.
 The kernel prefetches ``in`` into L2, waits on the returned event, then copies
 ``in`` to ``out``.
 
 The prefetch is a pure cache hint that changes no value, so ``out == in``
 bit-exactly is the property under test -- together with the event wait actually
-completing rather than hanging. The device log (``[SDMA] Created 48 STARS
-streams OK``) confirms the real SDMA path ran rather than the skip branch.
+completing rather than hanging. Because the kernel returns without writing
+``out`` on a null workspace, that equality also proves the address it read was
+live.
+
+Onboard a2a3 runs the real engine; the device log (``[SDMA] Created 48 STARS
+streams OK``) confirms the real SDMA path ran rather than the skip branch. On
+a2a3sim the workspace is inert scratch and ``TPREFETCH_ASYNC`` is a no-op
+(pto-isa ``cpu/TPrefetchAsync.hpp``), so what the sim case covers is the
+injection path: a live address reaches the kernel.
 
 Unlike the SDMA completion demo this needs no comm domain: the workspace is a
 runtime-owned per-device resource, so a single device is enough.
@@ -65,7 +72,7 @@ class TestPrefetchAsyncDemo(SceneTestCase):
     CASES = [
         {
             "name": "prefetch_copy",
-            "platforms": ["a2a3"],
+            "platforms": ["a2a3sim", "a2a3"],
             "config": {},
             "params": {},
         },

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -2927,7 +2927,7 @@ NB_MODULE(_task_interface, m) {
             "given, its ring sizing is built + cached inside init (fork-constant, no "
             "cross-process control command). A no-op for runtimes without a prebuilt arena. "
             "When enable_sdma is True, provisions the async-DMA (SDMA) workspace at init so "
-            "kernels can use get_dma_workspace; init raises if the platform lacks SDMA."
+            "kernels can use get_dma_workspace; init raises if the platform lacks support for the requested workspace."
         )
         .def("finalize", &ChipWorker::finalize)
         .def(

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -32,6 +32,7 @@
 #include "aicpu/platform_aicpu_affinity.h"
 #include "call_config.h"
 #include "callable_protocol.h"
+#include "common/dma_workspace.h"
 #include "common/host_log_binding.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
@@ -203,6 +204,16 @@ int DeviceRunner::ensure_binaries_loaded() {
             return PTO_RUNTIME_ERR_INTERNAL;
         if (!load_sym("set_platform_scope_stats_base", reinterpret_cast<void **>(&set_platform_scope_stats_base_func_)))
             return PTO_RUNTIME_ERR_INTERNAL;
+
+        // Publish provisioned DMA workspace addresses into the resident AICPU SO.
+        using SetDmaWorkspaceAddrFunc = void (*)(int, unsigned long long);
+        SetDmaWorkspaceAddrFunc set_dma_workspace_addr_func = nullptr;
+        if (!load_sym("set_dma_workspace_addr", reinterpret_cast<void **>(&set_dma_workspace_addr_func))) {
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
+        for (int kind = 0; kind < DMA_WORKSPACE_KIND_COUNT; ++kind) {
+            set_dma_workspace_addr_func(kind, dma_workspace_addr_[kind]);
+        }
 
         // The AICPU sim SO binds its private HostLogger before the compatibility
         // level setter can emit a clock anchor.
@@ -840,6 +851,14 @@ int DeviceRunner::finalize() {
     if (device_wall_dev_ptr_ != nullptr) {
         free_tensor(device_wall_dev_ptr_);
         device_wall_dev_ptr_ = nullptr;
+    }
+
+    if (dma_workspace_handle_ != nullptr) {
+        dma_workspace_release(dma_workspace_handle_);
+        dma_workspace_handle_ = nullptr;
+    }
+    for (int kind = 0; kind < DMA_WORKSPACE_KIND_COUNT; ++kind) {
+        dma_workspace_addr_[kind] = 0;
     }
 
     mem_alloc_.finalize();

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -33,6 +33,7 @@
 #include "aicpu/platform_aicpu_affinity.h"
 #include "call_config.h"
 #include "callable_protocol.h"
+#include "common/dma_workspace.h"
 #include "common/host_log_binding.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
@@ -203,6 +204,16 @@ int DeviceRunner::ensure_binaries_loaded() {
             return PTO_RUNTIME_ERR_INTERNAL;
         if (!load_sym("set_platform_scope_stats_base", reinterpret_cast<void **>(&set_platform_scope_stats_base_func_)))
             return PTO_RUNTIME_ERR_INTERNAL;
+
+        // Publish provisioned DMA workspace addresses into the resident AICPU SO.
+        using SetDmaWorkspaceAddrFunc = void (*)(int, unsigned long long);
+        SetDmaWorkspaceAddrFunc set_dma_workspace_addr_func = nullptr;
+        if (!load_sym("set_dma_workspace_addr", reinterpret_cast<void **>(&set_dma_workspace_addr_func))) {
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
+        for (int kind = 0; kind < DMA_WORKSPACE_KIND_COUNT; ++kind) {
+            set_dma_workspace_addr_func(kind, dma_workspace_addr_[kind]);
+        }
 
         // The AICPU sim SO binds its private HostLogger before the compatibility
         // level setter can emit a clock anchor.
@@ -801,6 +812,14 @@ int DeviceRunner::finalize() {
     prebuilt_runtime_arena_cache_sm_base_ = nullptr;
     prebuilt_runtime_arena_cache_runtime_arena_base_ = nullptr;
     prebuilt_runtime_arena_cache_image_.clear();
+
+    if (dma_workspace_handle_ != nullptr) {
+        dma_workspace_release(dma_workspace_handle_);
+        dma_workspace_handle_ = nullptr;
+    }
+    for (int kind = 0; kind < DMA_WORKSPACE_KIND_COUNT; ++kind) {
+        dma_workspace_addr_[kind] = 0;
+    }
 
     mem_alloc_.finalize();
     clear_cpu_sim_shared_storage();

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -397,14 +397,18 @@ int simpler_init(
 
     int rc;
     try {
-        rc = runner->ensure_dma_workspace_provisioned();
+        rc = runner->attach_current_thread(device_id);
     } catch (...) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (rc != 0) return rc;
 
+    // Provisioning follows the attach because the release path depends on it:
+    // finalize() returns early on a runner that never attached, and its
+    // dma_workspace_release() sits past that guard, so a block acquired before
+    // the attach would outlive the runner.
     try {
-        rc = runner->attach_current_thread(device_id);
+        rc = runner->ensure_dma_workspace_provisioned();
     } catch (...) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -385,19 +385,24 @@ int simpler_init(
     // and the dispatcher / preinstall load path on sim isn't taken anyway.
     (void)dispatcher_binary;
     (void)dispatcher_size;
-    // Simulation provides no async-DMA workspaces, so there is nothing for a
-    // warmup ELF to warm either.
+    // Simulation drives no SDMA control path, so the warmup ELF has nothing to
+    // walk.
     (void)sdma_warmup_binary;
     (void)sdma_warmup_size;
 
     if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
-    // Opting into SDMA fails here rather than at the first kernel read, so such
-    // a Worker cannot come up on sim at all.
-    if (enable_sdma != 0) return PTO_RUNTIME_ERR_UNSUPPORTED;
 
     SimDeviceRunnerBase *runner = static_cast<SimDeviceRunnerBase *>(ctx);
+    runner->set_dma_workspace_request(enable_sdma != 0);
 
     int rc;
+    try {
+        rc = runner->ensure_dma_workspace_provisioned();
+    } catch (...) {
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    if (rc != 0) return rc;
+
     try {
         rc = runner->attach_current_thread(device_id);
     } catch (...) {

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -301,6 +301,46 @@ int SimDeviceRunnerBase::ensure_device_initialized() {
     return ensure_binaries_loaded();
 }
 
+int SimDeviceRunnerBase::ensure_dma_workspace_provisioned() {
+    if (dma_workspace_handle_ != nullptr) {
+        return 0;
+    }
+    const uint32_t supported = dma_workspace_supported_mask();
+    constexpr uint32_t kSdmaBit = uint32_t{1} << DMA_WORKSPACE_SDMA;
+    if (sdma_requested_ && (supported & kSdmaBit) == 0) {
+        LOG_ERROR("dma workspace: SDMA requested where unsupported (supported=0x%x)", supported);
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
+
+    const uint32_t required_mask = sdma_requested_ ? supported : (supported & ~kSdmaBit);
+    if (required_mask == 0) {
+        return 0;
+    }
+    if ((required_mask & (required_mask - 1)) != 0) {
+        LOG_ERROR(
+            "dma workspace: mask=0x%x names %d engines; one handle owns one provider", required_mask,
+            __builtin_popcount(required_mask)
+        );
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
+
+    for (int kind = 0; kind < DMA_WORKSPACE_KIND_COUNT; ++kind) {
+        dma_workspace_addr_[kind] = 0;
+    }
+
+    int rc =
+        dma_workspace_provision(required_mask, dma_workspace_addr_, DMA_WORKSPACE_KIND_COUNT, &dma_workspace_handle_);
+    if (rc != 0) {
+        LOG_ERROR("dma workspace: mask=0x%x failed: %d", required_mask, rc);
+        for (int kind = 0; kind < DMA_WORKSPACE_KIND_COUNT; ++kind) {
+            dma_workspace_addr_[kind] = 0;
+        }
+        dma_workspace_handle_ = nullptr;
+        return rc;
+    }
+    return 0;
+}
+
 int SimDeviceRunnerBase::prepare_launch_shape(Runtime &runtime, const CallConfig &config) {
     if (config.aicpu_thread_num == 1 || config.aicpu_thread_num < 0 ||
         config.aicpu_thread_num > PLATFORM_MAX_AICPU_THREADS) {

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -259,10 +259,6 @@ public:
      */
     void set_dma_workspace_request(bool enable_sdma) { sdma_requested_ = enable_sdma; }
     int ensure_dma_workspace_provisioned();
-    uint64_t dma_workspace_addr(int kind) const {
-        if (kind < 0 || kind >= DMA_WORKSPACE_KIND_COUNT) return 0;
-        return dma_workspace_addr_[kind];
-    }
     int device_id() const { return device_id_; }
     uint64_t last_device_wall_ns() const { return device_wall_ns_; }
     // Per-phase AICPU wall (ns) from the most recent run; RunWall aliases

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -51,8 +51,10 @@
 #include "common/kernel_args.h"
 #include "common/device_phase.h"
 #include "common/chip_swimlane_profiling.h"
+#include "common/dma_workspace.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
+#include "platform_comm/comm.h"
 #include "host/memory_allocator.h"
 #include "host/chip_swimlane_collector.h"
 #include "host/host_phase_records.h"
@@ -251,6 +253,16 @@ public:
         aicpu_so_binary_ = std::move(aicpu_so_binary);
         aicore_kernel_binary_ = std::move(aicore_kernel_binary);
     }
+
+    /**
+     * Record whether this Worker asked for an async-DMA workspace.
+     */
+    void set_dma_workspace_request(bool enable_sdma) { sdma_requested_ = enable_sdma; }
+    int ensure_dma_workspace_provisioned();
+    uint64_t dma_workspace_addr(int kind) const {
+        if (kind < 0 || kind >= DMA_WORKSPACE_KIND_COUNT) return 0;
+        return dma_workspace_addr_[kind];
+    }
     int device_id() const { return device_id_; }
     uint64_t last_device_wall_ns() const { return device_wall_ns_; }
     // Per-phase AICPU wall (ns) from the most recent run; RunWall aliases
@@ -338,6 +350,10 @@ protected:
     // owned for the rest of the runner's lifetime.
     std::vector<uint8_t> aicpu_so_binary_;
     std::vector<uint8_t> aicore_kernel_binary_;
+
+    bool sdma_requested_{false};
+    void *dma_workspace_handle_{nullptr};
+    uint64_t dma_workspace_addr_[DMA_WORKSPACE_KIND_COUNT]{};
 
     MemoryAllocator mem_alloc_;
     std::array<void *, PTO_PIPELINE_MAX_DEPTH> retained_temp_addrs_{};

--- a/src/common/platform_comm/comm_sim.cpp
+++ b/src/common/platform_comm/comm_sim.cpp
@@ -281,8 +281,9 @@ extern "C" CommHandle comm_init(int rank, int nranks, void *stream, const char *
 extern "C" uint32_t dma_workspace_supported_mask(void) { return uint32_t{1} << DMA_WORKSPACE_SDMA; }
 
 extern "C" int dma_workspace_provision(uint32_t required_mask, uint64_t *addr_out, int count, void **handle_out) {
-    if (!addr_out || !handle_out || count < DMA_WORKSPACE_KIND_COUNT) return -1;
-    for (int i = 0; i < count; ++i) addr_out[i] = 0;
+    if (!addr_out || !handle_out || count < 0) return -1;
+    for (int i = 0; i < count; ++i)
+        addr_out[i] = 0;
     *handle_out = nullptr;
 
     constexpr uint32_t kSdmaBit = uint32_t{1} << DMA_WORKSPACE_SDMA;
@@ -292,7 +293,12 @@ extern "C" int dma_workspace_provision(uint32_t required_mask, uint64_t *addr_ou
     if ((required_mask & kSdmaBit) == 0) {
         return 0;
     }
+    if (count <= DMA_WORKSPACE_SDMA) return -1;
 
+    // The size a2a3 onboard provisions: there the 16 KB block *is* the descriptor
+    // table for 48 CP-process STARS streams (docs/comm-domain.md). Simulation
+    // drives no engine, so the block is inert scratch — matching the onboard
+    // budget only keeps a kernel sized against it in bounds on both backends.
     constexpr size_t kSimDmaWorkspaceBytes = 16 * 1024;
     void *workspace = std::malloc(kSimDmaWorkspaceBytes);
     if (workspace == nullptr) {

--- a/src/common/platform_comm/comm_sim.cpp
+++ b/src/common/platform_comm/comm_sim.cpp
@@ -278,18 +278,38 @@ extern "C" CommHandle comm_init(int rank, int nranks, void *stream, const char *
     return nullptr;
 }
 
-extern "C" uint32_t dma_workspace_supported_mask(void) { return 0; }
+extern "C" uint32_t dma_workspace_supported_mask(void) { return uint32_t{1} << DMA_WORKSPACE_SDMA; }
 
 extern "C" int dma_workspace_provision(uint32_t required_mask, uint64_t *addr_out, int count, void **handle_out) {
-    // No async-DMA hardware under simulation; 0 makes every engine a no-op.
-    if (!addr_out || !handle_out || count < 0) return -1;
+    if (!addr_out || !handle_out || count < DMA_WORKSPACE_KIND_COUNT) return -1;
+    for (int i = 0; i < count; ++i) addr_out[i] = 0;
     *handle_out = nullptr;
-    for (int i = 0; i < count; ++i)
-        addr_out[i] = 0;
-    return required_mask == 0 ? 0 : -1;
+
+    constexpr uint32_t kSdmaBit = uint32_t{1} << DMA_WORKSPACE_SDMA;
+    if ((required_mask & ~kSdmaBit) != 0) {
+        return -1;
+    }
+    if ((required_mask & kSdmaBit) == 0) {
+        return 0;
+    }
+
+    constexpr size_t kSimDmaWorkspaceBytes = 16 * 1024;
+    void *workspace = std::malloc(kSimDmaWorkspaceBytes);
+    if (workspace == nullptr) {
+        return -1;
+    }
+    std::memset(workspace, 0, kSimDmaWorkspaceBytes);
+
+    addr_out[DMA_WORKSPACE_SDMA] = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(workspace));
+    *handle_out = workspace;
+    return 0;
 }
 
-extern "C" void dma_workspace_release(void *handle) { (void)handle; }
+extern "C" void dma_workspace_release(void *handle) {
+    if (handle != nullptr) {
+        std::free(handle);
+    }
+}
 
 extern "C" int comm_alloc_windows(CommHandle h, size_t win_size, uint64_t *device_ctx_out) try {
     if (h == nullptr || device_ctx_out == nullptr) return -1;

--- a/tests/ut/py/test_worker/test_dma_workspace_sim.py
+++ b/tests/ut/py/test_worker/test_dma_workspace_sim.py
@@ -70,9 +70,11 @@ class TestSimProvisionsSdmaWorkspace:
         finally:
             worker.close()
 
-    def test_finalize_and_reinitialize_allocates_fresh_workspace(self):
-        # Reinitializing a finalized simulator runner must re-provision fresh
-        # workspace rather than retaining a dangling pointer from a previous run.
+    def test_two_sdma_workers_share_a_device_in_sequence(self):
+        # Each Worker owns its own runner, so the workspace is per-runner state:
+        # the second provisions a block of its own after the first released at
+        # close(). A process-level cache or a shared handle in
+        # dma_workspace_provision() would break that, and is what this pins.
         worker1 = _make_sim_worker(enable_sdma=True)
         try:
             worker1.init()

--- a/tests/ut/py/test_worker/test_dma_workspace_sim.py
+++ b/tests/ut/py/test_worker/test_dma_workspace_sim.py
@@ -9,12 +9,20 @@
 # ruff: noqa: PLC0415
 """Sim-backend test for the async-DMA workspace request carried by ``simpler_init``.
 
-Simulation provides no async-DMA engine, so ``enable_sdma=True`` has no workspace
-to hand a kernel. The contract is that such a Worker fails to come up rather than
-reaching its first run reading a zero address it expected to be live — the
-rejection is the only thing standing between an unsupported request and a silent
-wrong answer, and it is easy to lose to a refactor that derives the provisioned
-set from what the platform supports (an empty set looks like success).
+Simulation has no async-DMA engine, but ``enable_sdma=True`` still hands the
+kernel a live workspace address: an inert block, published through the same
+``set_dma_workspace_addr`` path onboard feeds from ``InitArgs``. The contract a
+kernel relies on is that a non-zero address means the workspace is there to use —
+a zero address where a live one was expected is a silent wrong answer rather than
+an error, because a kernel that branches on null (see
+``examples/a2a3/tensormap_and_ringbuffer/prefetch_async_demo``) skips its work and
+fails a golden comparison instead of reporting anything. Provisioning inert
+scratch keeps that contract on sim, where nothing dereferences the block:
+``TPREFETCH_ASYNC`` is a no-op stub (pto-isa ``cpu/TPrefetchAsync.hpp``) and the
+async transfers that would read it have no CPU-sim implementation at all.
+
+A Worker that does not ask for SDMA keeps a zero address, which is what makes the
+address meaningful as a signal.
 """
 
 from __future__ import annotations
@@ -40,20 +48,39 @@ def _make_sim_worker(*, enable_sdma: bool):
     )
 
 
-class TestSimRejectsSdma:
-    def test_enable_sdma_fails_init(self):
+class TestSimProvisionsSdmaWorkspace:
+    def test_enable_sdma_init_succeeds(self):
+        # An SDMA-enabled Worker comes up on sim. It used to be rejected here
+        # with PTO_RUNTIME_ERR_UNSUPPORTED (-1001), which kept every kernel that
+        # merely hints a prefetch off the simulator.
         worker = _make_sim_worker(enable_sdma=True)
-        # -1001 is PTO_RUNTIME_ERR_UNSUPPORTED. Pinning the code, not just "some
-        # exception", is what distinguishes a rejected request from sim failing
-        # to start for an unrelated reason.
-        with pytest.raises(RuntimeError, match=r"simpler_init failed with code -1001"):
+        try:
             worker.init()
-        worker.close()
+        finally:
+            worker.close()
 
     def test_without_sdma_init_succeeds(self):
-        # Positive control: the same Worker comes up when it does not ask for an
-        # engine sim has no provider for, so the failure above is attributable to
-        # the request rather than to sim being unable to start at all.
+        # Control: coming up is not itself evidence the request was honoured, so
+        # pair it with the Worker that asks for nothing. The workspace address
+        # each one hands a kernel is covered end-to-end by the a2a3
+        # prefetch_async_demo scene test, which reads it on-device.
         worker = _make_sim_worker(enable_sdma=False)
-        worker.init()
-        worker.close()
+        try:
+            worker.init()
+        finally:
+            worker.close()
+
+    def test_finalize_and_reinitialize_allocates_fresh_workspace(self):
+        # Reinitializing a finalized simulator runner must re-provision fresh
+        # workspace rather than retaining a dangling pointer from a previous run.
+        worker1 = _make_sim_worker(enable_sdma=True)
+        try:
+            worker1.init()
+        finally:
+            worker1.close()
+
+        worker2 = _make_sim_worker(enable_sdma=True)
+        try:
+            worker2.init()
+        finally:
+            worker2.close()


### PR DESCRIPTION
## Summary

Fix simulator Worker initialization for kernels that request the
runtime-owned SDMA workspace.

The simulator previously rejected `enable_sdma=True` during
`simpler_init()` with `PTO_RUNTIME_ERR_UNSUPPORTED (-1001)`. This prevented
prefetch-only workloads from running on `a2a3sim` and `a5sim`, even though
`TPREFETCH_ASYNC` is a no-op in CPU simulation.

This change provides an inert SDMA workspace on simulator while preserving
the workspace address contract expected by kernels.

## Changes

- Accept SDMA workspace requests in the simulator C API.
- Record the request in `SimDeviceRunnerBase`.
- Allocate and zero-initialize a 16 KiB inert workspace in both a2a3sim and
  a5sim runners.
- Publish the workspace through `set_dma_workspace_addr`.
- Keep unrequested workspace kinds, including URMA, at address zero.
- Enable `prefetch_async_demo` on `a2a3sim`.
- Update simulator workspace unit tests for the new initialization contract.

The simulator workspace is only inert scratch. It does not claim to support
real asynchronous DMA transfers such as `TGET_ASYNC` or `TPUT_ASYNC`.

## Validation

- `tests/ut/py/test_worker/test_dma_workspace_sim.py`
- `prefetch_async_demo` on `a2a3sim`
- Full `a2a3sim` simulation suite
- Full `a5sim` simulation suite

All validation commands completed with exit code `0`. The simulation suites
reported passed, deselected, and warnings only, with no failed or errored
tests.

## Scope

- Onboard a2a3 behavior is unchanged.
- Onboard a5 behavior is unchanged.
- URMA remains unsupported on simulator.
- Real asynchronous DMA instructions remain governed by simulator instruction
  support.

Fixes #2103