### PR TITLE
feat(worker): add extensible chip-child control dispatch

### DIFF
--- a/docs/user/reference/python-api.md
+++ b/docs/user/reference/python-api.md
@@ -14,7 +14,7 @@ types live in `simpler.task_interface`. Both resolve on first access, so
 extension.
 
 ```python
-from simpler import Worker           # or: from simpler.worker import Worker
+from simpler import Worker, register_chip_control_extension
 from simpler.task_interface import (
     ArgDirection, CallConfig, ChipCallable, ChipStorageTaskArgs,
     ChipTensor, CoreCallable, DataType, TaskArgs, TaskHandle,
@@ -38,6 +38,7 @@ into `**config` and validated later. The recognized keys:
 | `device_id` | L2 | the single chip this worker drives |
 | `device_ids` | L3+ | one chip child process per entry |
 | `num_sub_workers` | L3+ | host-side Python callables to fork |
+| `py_control_timeout_s` | L3+ | finite timeout for Python control-plane operations; defaults to 30 seconds |
 | `enable_sdma` | a2a3 | provisions the SDMA workspace; defaults to `False` |
 | `heap_ring_size` | all | heap ring sizing |
 | `remote_heap_ring_size`, `remote_session_timeout_s` | L4 | remote-session sizing and timeout |
@@ -55,6 +56,41 @@ else raises. Remote-worker and remote-memory calls require `level >= 4`.
 | `add_remote_worker(spec: RemoteWorkerSpec) -> int` | L4; see the remote-L3 design doc |
 | `init(prewarm_config=None)` | Resolves runtime binaries, opens the device, forks children. First place setup errors appear |
 | `close()` | Releases the device and reaps children. Put it in a `finally` — a skipped `close()` leaves the device held |
+
+### Chip-control extensions
+
+Chip-control extensions let a trusted integration run a short synchronous
+control operation inside every chip-child process owned by one L3 Worker. They
+are not available on L2 or L4+ Workers.
+
+```python
+def handler(chip_worker, payload: bytes, device_id: int):
+    ...
+    return None
+
+register_chip_control_extension("my-extension", handler)
+worker = Worker(level=3, ..., py_control_timeout_s=30.0)
+worker.init()
+worker.run_chip_control_extension("my-extension", b"request")
+```
+
+Registration must happen before that Worker's `init()`. The Worker snapshots
+the process-wide registry when startup begins, and every chip child receives
+the same snapshot. Registering another name later affects only Workers whose
+`init()` has not started.
+
+The handler receives the child-local `ChipWorker`, an immutable payload, and
+the physical device id. Returning `None` or another false value succeeds;
+returning a true value reports its string form as an error. Raising also fails
+the operation. Handlers run synchronously while ordinary runs are excluded, so
+they must return promptly or move long-running work to an asynchronous service.
+`timeout_s=None` uses the Worker's finite `py_control_timeout_s`; an explicit
+timeout must also be positive and finite.
+
+The call broadcasts concurrently and returns only after every chip child has
+responded. If some handlers succeed and another fails, the successful effects
+are not rolled back; the caller receives one aggregated `RuntimeError` naming
+the first reported child error.
 
 ### Memory
 

--- a/docs/user/reference/python-api.md
+++ b/docs/user/reference/python-api.md
@@ -39,6 +39,8 @@ into `**config` and validated later. The recognized keys:
 | `device_ids` | L3+ | one chip child process per entry |
 | `num_sub_workers` | L3+ | host-side Python callables to fork |
 | `py_control_timeout_s` | L3+ | finite timeout for Python control-plane operations; defaults to 30 seconds |
+| `external_transfer_max_pending` | L3 | maximum unretired external transfers across all local chips; defaults to 2 |
+| `external_transfer_max_bytes` | L3 | maximum sum of in-flight transfer span lengths; defaults to 1 GiB |
 | `enable_sdma` | a2a3 | provisions the SDMA workspace; defaults to `False` |
 | `heap_ring_size` | all | heap ring sizing |
 | `remote_heap_ring_size`, `remote_session_timeout_s` | L4 | remote-session sizing and timeout |
@@ -91,6 +93,87 @@ The call broadcasts concurrently and returns only after every chip child has
 responded. If some handlers succeed and another fails, the successful effects
 are not rolled back; the caller receives one aggregated `RuntimeError` naming
 the first reported child error.
+
+Asynchronous device access must use the managed external-transfer API below.
+A chip-control extension's admission fence ends when its handler returns; it
+does not protect background DMA launched by that handler.
+
+### Managed external transfers
+
+An external transfer names registered allocations, not caller-supplied device
+pointers. The Runtime validates ownership, access rights, and byte extents,
+routes to the allocation's chip, binds the transfer thread to that device,
+and retains the operation until the provider certifies that device access has
+stopped. Only local L3 `DEVICE_MALLOC` allocations are supported; communication
+windows and remote workers are rejected.
+
+```python
+from simpler import (
+    ExternalBufferRange, ExternalTransferResult,
+    register_external_transfer_provider,
+)
+from simpler.buffer import AccessMode
+
+def storage_provider(request, cancellation):
+    if cancellation.requested:
+        return ExternalTransferResult(False, error="cancelled before access")
+    # A trusted adapter performs and fences its device access here.
+    # request.buffers contains checked address/nbytes/access spans.
+    # request.payload contains adapter-specific metadata, not KV bytes.
+    return ExternalTransferResult()
+
+register_external_transfer_provider("storage", storage_provider)  # before worker.init()
+# After initialization and allocation of kv_buffer:
+transfer = worker.submit_external_transfer(
+    "storage",
+    (ExternalBufferRange(kv_buffer, offset=0, nbytes=4096, access=AccessMode.WRITE),),
+    payload=b"object metadata",
+)
+transfer.wait(timeout=30)
+```
+
+The provider is trusted native integration code, **not a sandbox**. It receives
+no `ChipWorker`, allocator, or runtime stream. It must not reset the device,
+change its runtime-owned context/streams, free supplied memory, or retain
+addresses/registrations beyond its result. Adapter-owned streams, memory
+registration and SDK work must be drained and released before returning.
+Internal SDK memory is not included in Runtime's committed-memory accounting.
+
+| Event | Resource semantics |
+| ----- | ------------------ |
+| `ExternalTransferResult(succeeded=True)` | All access stopped; `wait()` returns the bytes payload |
+| `ExternalTransferResult(succeeded=False, error=...)` | All access stopped; `wait()` raises `RuntimeError` |
+| Unexpected exception or invalid result | Quiescence unconfirmed; `wait()` raises `ExternalTransferUnconfirmedError`, buffers stay retained |
+| `wait(timeout=...)` expires | Only the wait expires; buffers stay retained |
+| `request_cancel()` | Cooperative flag only; no thread interruption or DMA cancellation |
+| Submission acknowledgement is lost | `ExternalTransferSubmissionError.handle` retains the operation; do not blindly resubmit |
+
+The two exception types are available from `simpler.external_transfer`.
+`done()` checks completion without blocking and retires a confirmed result;
+it returns `False` for unconfirmed quiescence. `result()` aliases `wait()`.
+Handles remain observable after `Worker.close()` has begun. Close drains them
+within its existing cleanup budget; if access is still outstanding it leaves
+the tree intact and CLOSED. A later close can retry after confirmed completion.
+An unconfirmed provider exception requires external recovery; this API does
+not force-reset a device or pretend a stopped Python thread proves DMA stopped.
+
+Submission must occur outside orchestration callbacks and after compute runs
+complete. While any transfer remains unretired, compute submission and device
+control (including copy/free and legacy chip extensions) fail fast. Transfers
+may overlap one another across different chips or nonconflicting ranges;
+overlapping reads are allowed, overlapping access involving a write is refused.
+Serving still owns KV page pinning and reuse. This conservative implementation
+does not provide compute/transfer overlap or automatic prefix-cache scheduling.
+
+Capacity checks reject submissions before dispatch. The byte limit counts
+submitted span lengths, not whole pinned allocations or SDK staging memory.
+Each bounded slot has a fork-inherited event; completion uses a small
+shared-memory result and a wakeup, without mailbox polling or KV host staging.
+Payloads are limited to 1 MiB, results to 4096 bytes, and requests to 65536 spans.
+`timeout_s` bounds the control acknowledgement only and defaults to
+`py_control_timeout_s`; it is not a backend DMA deadline. A Mooncake adapter
+must translate backend failures into a result only when it can certify no
+further access, and publish a cache manifest only after every shard succeeds.
 
 ### Memory
 

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -3193,6 +3193,7 @@ NB_MODULE(_task_interface, m) {
         .def("free", &ChipWorker::free, nb::arg("ptr"))
         .def("copy_to", &ChipWorker::copy_to, nb::arg("dst"), nb::arg("src"), nb::arg("size"))
         .def("copy_from", &ChipWorker::copy_from, nb::arg("dst"), nb::arg("src"), nb::arg("size"))
+        .def("_bind_external_transfer_thread", &ChipWorker::bind_external_transfer_thread)
         .def(
             "comm_init", &ChipWorker::comm_init, nb::arg("rank"), nb::arg("nranks"), nb::arg("rootinfo_path"),
             "Initialize a communicator for this rank.  ChipWorker owns ACL + stream "

--- a/python/simpler/__init__.py
+++ b/python/simpler/__init__.py
@@ -37,6 +37,7 @@ from ._log import (
 __all__ = [
     "DEFAULT_THRESHOLD",
     "Worker",
+    "register_chip_control_extension",
     "NUL",
     "TIMING",
     "get_current_config",
@@ -46,7 +47,13 @@ __all__ = [
 ]
 
 # name -> (module, attribute). Resolved by __getattr__ on first access.
-_LAZY_ATTRS = {"Worker": (f"{__name__}.worker", "Worker")}
+_LAZY_ATTRS = {
+    "Worker": (f"{__name__}.worker", "Worker"),
+    "register_chip_control_extension": (
+        f"{__name__}.worker",
+        "register_chip_control_extension",
+    ),
+}
 _LAZY_SUBMODULES = ("comm_endpoints", "task_interface")
 
 

--- a/python/simpler/__init__.py
+++ b/python/simpler/__init__.py
@@ -37,6 +37,11 @@ from ._log import (
 __all__ = [
     "DEFAULT_THRESHOLD",
     "Worker",
+    "ExternalBufferRange",
+    "ExternalTransferHandle",
+    "ExternalTransferRequest",
+    "ExternalTransferResult",
+    "register_external_transfer_provider",
     "register_chip_control_extension",
     "NUL",
     "TIMING",
@@ -55,6 +60,15 @@ _LAZY_ATTRS = {
     ),
 }
 _LAZY_SUBMODULES = ("comm_endpoints", "task_interface")
+
+for _name in (
+    "ExternalBufferRange",
+    "ExternalTransferHandle",
+    "ExternalTransferRequest",
+    "ExternalTransferResult",
+    "register_external_transfer_provider",
+):
+    _LAZY_ATTRS[_name] = (f"{__name__}.external_transfer", _name)
 
 
 def __getattr__(name: str) -> Any:

--- a/python/simpler/external_transfer.py
+++ b/python/simpler/external_transfer.py
@@ -1,0 +1,318 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Cooperative, runtime-managed access to chip buffers by trusted transports."""
+
+from __future__ import annotations
+
+import base64
+import ctypes
+import json
+import math
+import multiprocessing
+import struct
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from multiprocessing.shared_memory import SharedMemory
+from typing import Any
+
+from _task_interface import _mailbox_load_i32, _mailbox_store_i32
+
+from .buffer import AccessMode, Buffer
+
+_RESULT_BYTES = 4096
+_HEADER = struct.Struct("<IIII")  # cancellation, outcome, payload length, error length
+_SUCCEEDED, _FAILED, _UNCONFIRMED = 1, 2, 3
+_providers: dict[str, ExternalTransferProvider] = {}
+_providers_lock = threading.Lock()
+
+
+@dataclass(frozen=True)
+class ExternalBufferRange:
+    """An allocation identity plus a byte range and required device access."""
+
+    buffer: Buffer
+    offset: int
+    nbytes: int
+    access: AccessMode
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.buffer, Buffer):
+            raise TypeError("external transfer range requires a Buffer, not a device pointer")
+        if type(self.offset) is not int or self.offset < 0:
+            raise ValueError("external transfer offset must be a non-negative integer")
+        if type(self.nbytes) is not int or self.nbytes <= 0:
+            raise ValueError("external transfer nbytes must be a positive integer")
+        if self.access not in (AccessMode.READ, AccessMode.WRITE, AccessMode.READWRITE):
+            raise ValueError("external transfer access must be READ, WRITE, or READWRITE")
+
+
+@dataclass(frozen=True)
+class ExternalTransferSpan:
+    """A checked chip-local address; valid only until the provider returns."""
+
+    address: int
+    nbytes: int
+    access: AccessMode
+
+
+@dataclass(frozen=True)
+class ExternalTransferRequest:
+    """Provider input, without allocation, stream, or ChipWorker capabilities."""
+
+    device_id: int
+    buffers: tuple[ExternalTransferSpan, ...]
+    payload: bytes
+
+
+@dataclass(frozen=True)
+class ExternalTransferResult:
+    """Returning this result certifies that all access to the supplied spans has stopped.
+
+    Failure is also a quiescence certificate. An exception is NOT one: it leaves
+    the operation retained and prevents normal Worker teardown.
+    """
+
+    succeeded: bool = True
+    payload: bytes = b""
+    error: str = ""
+
+
+class ExternalTransferCancellation:
+    """Cooperative cancellation request; observing it does not complete a transfer."""
+
+    def __init__(self, address: int):
+        self._address = address
+
+    @property
+    def requested(self) -> bool:
+        return bool(_mailbox_load_i32(self._address))
+
+
+ExternalTransferProvider = Callable[[ExternalTransferRequest, ExternalTransferCancellation], ExternalTransferResult]
+
+
+def register_external_transfer_provider(name: str, provider: ExternalTransferProvider) -> None:
+    """Register a trusted provider before Worker.init() snapshots the registry.
+
+    Runtime binds the chip-child background thread to its device before calling
+    the provider. Providers must not reset the device or change runtime-owned
+    contexts, streams, allocations, or allocator state.
+    """
+    if not isinstance(name, str) or not name or len(name.encode("utf-8")) > 255:
+        raise ValueError("external transfer provider name must contain 1..255 UTF-8 bytes")
+    if not callable(provider):
+        raise TypeError("external transfer provider must be callable")
+    with _providers_lock:
+        if name in _providers and _providers[name] is not provider:
+            raise ValueError(f"external transfer provider {name!r} is already registered")
+        _providers[name] = provider
+
+
+def _snapshot_providers() -> dict[str, ExternalTransferProvider]:
+    with _providers_lock:
+        return dict(_providers)
+
+
+class ExternalTransferSubmissionError(RuntimeError):
+    """Submission has an uncertain outcome; handle retains the destination resources."""
+
+    def __init__(self, handle: ExternalTransferHandle):
+        super().__init__("external transfer submission was not acknowledged; resources remain retained")
+        self.handle = handle
+
+
+class ExternalTransferUnconfirmedError(RuntimeError):
+    """The provider did not certify quiescence; resources must not be reclaimed."""
+
+
+class ExternalTransferHandle:
+    """A retained external operation. Timeouts never release its buffers.
+
+    Observe completion with done()/wait()/result(); Worker.close() also drains
+    handles. request_cancel() only sets a cooperative request flag.
+    """
+
+    def __init__(self, pool: _ExternalTransferPool, slot: int, buffers: tuple, worker_id: int):
+        self._pool = pool
+        self._slot = slot
+        self._buffers = buffers
+        self._worker_id = worker_id
+        self._wait_lock = threading.Lock()
+        self._state_lock = threading.Lock()
+        self._outcome: tuple[int, bytes, str] | None = None
+        self._retired = False
+        self._shm = SharedMemory(create=True, size=_HEADER.size + _RESULT_BYTES)
+        self._shm.buf[:] = bytes(self._shm.size)
+
+    @property
+    def nbytes(self) -> int:
+        return sum(span.nbytes for span in self._buffers)
+
+    def request_cancel(self) -> bool:
+        """Request cancellation, returning False if an outcome has already been observed."""
+        with self._state_lock:
+            if self._outcome is not None:
+                return False
+            address = ctypes.addressof(ctypes.c_char.from_buffer(self._shm.buf))
+            _mailbox_store_i32(address, 1)
+            return True
+
+    def done(self) -> bool:
+        """Return whether quiescence is confirmed; also retire a completed operation."""
+        try:
+            self.wait(0)
+        except TimeoutError:
+            return False
+        except ExternalTransferUnconfirmedError:
+            return False
+        except RuntimeError:
+            return self._retired
+        return True
+
+    def wait(self, timeout: float | None = None) -> bytes:
+        """Wait for quiescence and return the payload, or raise on failure/timeout."""
+        if timeout is not None and (not math.isfinite(timeout) or timeout < 0):
+            raise ValueError("external transfer timeout must be non-negative and finite, or None")
+        deadline = None if timeout is None else time.monotonic() + timeout
+        acquired = self._wait_lock.acquire() if deadline is None else self._wait_lock.acquire(timeout=timeout)
+        if not acquired:
+            raise TimeoutError("external transfer is still in flight")
+        try:
+            if self._outcome is None:
+                remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+                if not self._pool.signals[self._slot].wait(timeout=remaining):
+                    raise TimeoutError("external transfer is still in flight; buffers remain retained")
+                self._observe_outcome()
+            assert self._outcome is not None
+            code, payload, error = self._outcome
+            if code == _UNCONFIRMED:
+                raise ExternalTransferUnconfirmedError(error)
+            self._retire_resources()
+            if code == _FAILED:
+                raise RuntimeError(error or "external transfer failed")
+            return payload
+        finally:
+            self._wait_lock.release()
+
+    def result(self, timeout: float | None = None) -> bytes:
+        """Alias for wait()."""
+        return self.wait(timeout)
+
+    def _observe_outcome(self) -> None:
+        with self._state_lock:
+            code, payload_size, error_size = struct.unpack_from("<III", self._shm.buf, 4)
+            if code not in (_SUCCEEDED, _FAILED) or payload_size + error_size > _RESULT_BYTES:
+                code = _UNCONFIRMED
+            raw = bytes(self._shm.buf[_HEADER.size : _HEADER.size + min(payload_size + error_size, _RESULT_BYTES)])
+            self._outcome = (code, raw[:payload_size], raw[payload_size:].decode("utf-8", "replace"))
+
+    def _retire_resources(self) -> None:
+        if self._retired:
+            return
+        with self._state_lock:
+            self._shm.close()
+            try:
+                self._shm.unlink()
+            except FileNotFoundError:
+                pass
+        self._pool.retire(self)
+        self._retired = True
+
+
+class _ExternalTransferPool:
+    def __init__(self, count: int, max_bytes: int, retire: Callable[[ExternalTransferHandle], None]):
+        self.signals = tuple(multiprocessing.get_context("fork").Event() for _ in range(count))
+        self.max_bytes = max_bytes
+        self.pending: dict[int, ExternalTransferHandle] = {}
+        self.retire = retire
+
+    def reserve(self, spans: tuple[ExternalTransferSpan, ...], worker_id: int) -> ExternalTransferHandle:
+        if len(self.pending) >= len(self.signals):
+            raise RuntimeError("external transfer pending-count limit exceeded")
+        if sum(h.nbytes for h in self.pending.values()) + sum(s.nbytes for s in spans) > self.max_bytes:
+            raise RuntimeError("external transfer pending-byte limit exceeded")
+        existing = [span for h in self.pending.values() if h._worker_id == worker_id for span in h._buffers]
+        last_end = last_write_end = 0
+        for span in sorted((*existing, *spans), key=lambda span: span.address):
+            if span.address < last_write_end or (span.access != AccessMode.READ and span.address < last_end):
+                raise RuntimeError("external transfer conflicts with another buffer access")
+            last_end = max(last_end, span.address + span.nbytes)
+            if span.access != AccessMode.READ:
+                last_write_end = max(last_write_end, span.address + span.nbytes)
+        slot = next(slot for slot in range(len(self.signals)) if slot not in self.pending)
+        self.signals[slot].clear()
+        handle = ExternalTransferHandle(self, slot, spans, worker_id)
+        self.pending[slot] = handle
+        return handle
+
+
+def _start_chip_transfer(
+    payload: bytes,
+    device_id: int,
+    providers: dict,
+    signals: tuple,
+    bind_thread: Callable[[], None],
+) -> None:
+    command = json.loads(payload)
+    provider = providers[command["provider"]]
+    signal = signals[command["slot"]]
+    request = ExternalTransferRequest(
+        device_id,
+        tuple(
+            ExternalTransferSpan(address, nbytes, AccessMode(access)) for address, nbytes, access in command["spans"]
+        ),
+        base64.b64decode(command["payload"], validate=True),
+    )
+    shm = SharedMemory(name=command["completion"])
+    if shm.size != _HEADER.size + _RESULT_BYTES:
+        shm.close()
+        raise ValueError("external transfer completion backing has an invalid size")
+    try:
+        threading.Thread(
+            target=_run_chip_transfer,
+            args=(provider, request, shm, signal, bind_thread),
+            daemon=True,
+            name=f"external-transfer-{command['slot']}",
+        ).start()
+    except BaseException:
+        shm.close()
+        raise
+
+
+def _run_chip_transfer(
+    provider: ExternalTransferProvider,
+    request: ExternalTransferRequest,
+    shm: SharedMemory,
+    signal: Any,
+    bind_thread: Callable[[], None],
+) -> None:
+    code, payload, error = _UNCONFIRMED, b"", b""
+    try:
+        bind_thread()
+        token = ExternalTransferCancellation(ctypes.addressof(ctypes.c_char.from_buffer(shm.buf)))
+        result = provider(request, token)
+        if not isinstance(result, ExternalTransferResult) or type(result.succeeded) is not bool:
+            raise TypeError("external transfer provider must return ExternalTransferResult")
+        if not isinstance(result.payload, bytes) or not isinstance(result.error, str):
+            raise TypeError("external transfer result requires a bytes payload and a str error")
+        payload, error = result.payload, result.error.encode("utf-8")
+        if len(payload) + len(error) > _RESULT_BYTES:
+            payload, error = b"", b"external transfer result exceeds the 4096-byte limit"
+            code = _FAILED
+        else:
+            code = _SUCCEEDED if result.succeeded else _FAILED
+    except BaseException as exc:
+        payload, error = b"", f"provider quiescence unconfirmed: {type(exc).__name__}: {exc}".encode()[:_RESULT_BYTES]
+    shm.buf[_HEADER.size : _HEADER.size + len(payload) + len(error)] = payload + error
+    # The cancellation word is independently accessed through native atomics.
+    struct.pack_into("<III", shm.buf, 4, code, len(payload), len(error))
+    shm.close()
+    signal.set()

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -1778,3 +1778,6 @@ class ChipWorker:
     def device_memory_info(self) -> DeviceMemoryInfo:
         """Device-wide ACL_HBM_MEM free/total byte snapshot."""
         return self._impl.device_memory_info()
+
+    def _bind_external_transfer_thread(self) -> None:
+        self._impl._bind_external_transfer_thread()

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -630,6 +630,26 @@ _CTRL_DELEGATED_REGION = 26
 _LOCAL_GLOBAL_CONTROL_HEADER = struct.Struct("<IIQ")
 _CTRL_OP_NAMES[_CTRL_GLOBAL_DOMAIN_NODE] = "global_domain"
 _CTRL_OP_NAMES[_CTRL_DELEGATED_REGION] = "delegated_region"
+_CTRL_CHIP_EXTENSION = 27
+_CTRL_OP_NAMES[_CTRL_CHIP_EXTENSION] = "chip_extension"
+
+_CHIP_EXTENSION_HEADER = struct.Struct("!H")
+_chip_control_extensions: dict[str, Any] = {}
+_chip_control_extensions_lock = threading.Lock()
+
+
+def register_chip_control_extension(name: str, handler) -> None:
+    """Register a trusted handler for level-3 Workers created by a later ``init()``."""
+    if not isinstance(name, str) or not name or len(name.encode("utf-8")) > 255:
+        raise ValueError("chip control extension name must contain 1 to 255 UTF-8 bytes")
+    if not callable(handler):
+        raise TypeError("chip control extension handler must be callable")
+    with _chip_control_extensions_lock:
+        existing = _chip_control_extensions.get(name)
+        if existing is not None and existing is not handler:
+            raise ValueError(f"chip control extension {name!r} is already registered")
+        _chip_control_extensions[name] = handler
+
 
 # Layout of the CTRL_COMM_INIT request shm.
 _COMM_INIT_HEADER = struct.Struct("<II")  # rank (u32), nranks (u32)
@@ -1683,6 +1703,34 @@ def _read_ctrl_staged_shm_name(buf: memoryview) -> str:
     raw = bytes(buf[_OFF_ARGS : _OFF_ARGS + _CTRL_SHM_NAME_BYTES])
     nul = raw.find(b"\x00")
     return raw[: nul if nul >= 0 else _CTRL_SHM_NAME_BYTES].decode("utf-8", "replace")
+
+
+def _read_ctrl_staged_payload(buf: memoryview) -> bytes:
+    staged, payload, payload_size = _open_ctrl_payload(buf, what="chip control extension")
+    try:
+        return bytes(payload[:payload_size])
+    finally:
+        payload.release()
+        staged.close()
+
+
+def _handle_chip_control_extension(
+    cw: ChipWorker, buf: memoryview, device_id: int, extensions: dict[str, Any]
+) -> None:
+    envelope = _read_ctrl_staged_payload(buf)
+    if len(envelope) < _CHIP_EXTENSION_HEADER.size:
+        raise ValueError("chip control extension envelope is truncated")
+    (name_size,) = _CHIP_EXTENSION_HEADER.unpack_from(envelope)
+    name_end = _CHIP_EXTENSION_HEADER.size + name_size
+    if name_size == 0 or name_end > len(envelope):
+        raise ValueError("chip control extension name is invalid")
+    name = envelope[_CHIP_EXTENSION_HEADER.size : name_end].decode("utf-8")
+    handler = extensions.get(name)
+    if handler is None:
+        raise KeyError(f"chip control extension {name!r} was not registered before Worker.init()")
+    error = handler(cw, envelope[name_end:], device_id)
+    if error:
+        raise RuntimeError(str(error))
 
 
 def _allocate_local_slot(registry: dict[int, Any]) -> int:
@@ -2797,6 +2845,7 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
     identity_table: dict[bytes, int],
     identity_refs: dict[bytes, int],
     owner_instance_id: bytes,
+    chip_control_extensions: dict[str, Any],
     *,
     chip_platform: str,
     chip_runtime: str = "",
@@ -3006,6 +3055,8 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
             elif sub_cmd == _CTRL_DEVICE_MEMORY_INFO:
                 info = cw.device_memory_info()
                 _DEVICE_MEMORY_INFO.pack_into(buf, _CTRL_OFF_RESULT, info.free_bytes, info.total_bytes)
+            elif sub_cmd == _CTRL_CHIP_EXTENSION:
+                _handle_chip_control_extension(cw, buf, device_id, chip_control_extensions)
             elif sub_cmd == _CTRL_IMPORT_RELEASE:
                 import_registry.unregister(_unpack_identity_wire(_read_control_digest(buf)))
             elif sub_cmd == CTRL_GLOBAL_DOMAIN_PREPARE:
@@ -3306,6 +3357,7 @@ def _chip_process_loop(  # noqa: PLR0913 -- fork-child entry: all context (bins,
     identity_table: dict[bytes, int],
     identity_refs: dict[bytes, int],
     owner_instance_id: bytes,
+    chip_control_extensions: dict[str, Any],
     log_level: int = 25,
     platform: str = "",
     runtime: str = "",
@@ -3384,6 +3436,7 @@ def _chip_process_loop(  # noqa: PLR0913 -- fork-child entry: all context (bins,
             identity_table,
             identity_refs,
             owner_instance_id,
+            chip_control_extensions,
             chip_platform=platform,
             chip_runtime=runtime,
             prepared=prepared,
@@ -4526,6 +4579,7 @@ class Worker:
         self._registry_lock = threading.Lock()
         self._pending_unregister_cids: set[int] = set()
         self._pending_remote_unregister_hashids: set[bytes] = set()
+        self._chip_control_extension_names: frozenset[str] = frozenset()
         self._py_control_timeout_s = float(config.get("py_control_timeout_s", _PY_CONTROL_TIMEOUT_S))
         # Upper bound on how long the readiness barrier waits for a forked child
         # to report INIT_READY/INIT_FAILED before treating it as hung. Must be
@@ -7890,6 +7944,12 @@ class Worker:
                 (digest, state.target, state.ref_count, state.kind, state.target_namespace)
                 for digest, state in self._identity_registry.items()
             ]
+        if self.level == 3:
+            with _chip_control_extensions_lock:
+                chip_control_extensions = dict(_chip_control_extensions)
+            self._chip_control_extension_names = frozenset(chip_control_extensions)
+        else:
+            chip_control_extensions = {}
 
         # Seed this process's logger before the first fork: the spans its own
         # scheduler emits obey the Python logger level, and every child inherits
@@ -7986,6 +8046,7 @@ class Worker:
                                 target_namespace="LOCAL_CHIP",
                             ),
                             self._owner_instance_id,
+                            chip_control_extensions,
                             log_level=chip_log_level,
                             platform=str(self._config["platform"]),
                             runtime=str(self._config["runtime"]),
@@ -10583,6 +10644,39 @@ class Worker:
         nbytes = max(0, host_nbytes - host_offset) if nbytes is None else int(nbytes)
         _require_copy_span(host_nbytes, host_offset, nbytes, side=host_side, api=api)
         return device_offset, host_offset, nbytes
+
+    def run_chip_control_extension(
+        self,
+        name: str,
+        payload: bytes,
+        *,
+        timeout_s: float | None = None,
+    ) -> None:
+        """Run a registered extension synchronously in every level-3 chip child."""
+        if self.level != 3:
+            raise TypeError("chip control extensions require a level-3 Worker")
+        with self._operation_lease("run_chip_control_extension"):
+            assert self._worker is not None
+            if name not in self._chip_control_extension_names:
+                raise KeyError(f"chip control extension {name!r} was not registered before this Worker.init()")
+            name_bytes = name.encode("utf-8")
+            envelope = _CHIP_EXTENSION_HEADER.pack(len(name_bytes)) + name_bytes + bytes(payload)
+            effective_timeout_s = self._py_control_timeout_s if timeout_s is None else float(timeout_s)
+            if not (effective_timeout_s > 0 and math.isfinite(effective_timeout_s)):
+                raise ValueError("chip control extension timeout_s must be a positive finite number of seconds")
+            with self._device_control_admission("run_chip_control_extension"):
+                results = self._worker.broadcast_control_all(
+                    WorkerType.NEXT_LEVEL,
+                    _CTRL_CHIP_EXTENSION,
+                    envelope,
+                    None,
+                    timeout_s=effective_timeout_s,
+                )
+            errors = self._control_errors(list(results))
+            if errors:
+                raise RuntimeError(
+                    f"chip control extension {name!r} failed on {len(errors)} child workers; first error: {errors[0]}"
+                )
 
     @staticmethod
     def _require_device_end(handle: Buffer, *, api: str) -> None:

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -59,6 +59,7 @@ Usage::
 
 from __future__ import annotations
 
+import base64
 import contextlib
 import ctypes
 import enum
@@ -209,6 +210,15 @@ from .comm_region import (
     materialize_region_instance,
     project_region_allocation_spec,
     validate_single_owner_region_shape,
+)
+from .external_transfer import (
+    ExternalBufferRange,
+    ExternalTransferHandle,
+    ExternalTransferSpan,
+    ExternalTransferSubmissionError,
+    _ExternalTransferPool,
+    _snapshot_providers,
+    _start_chip_transfer,
 )
 from .global_comm_domain import (
     CTRL_GLOBAL_DOMAIN_COPY_FROM,
@@ -632,6 +642,8 @@ _CTRL_OP_NAMES[_CTRL_GLOBAL_DOMAIN_NODE] = "global_domain"
 _CTRL_OP_NAMES[_CTRL_DELEGATED_REGION] = "delegated_region"
 _CTRL_CHIP_EXTENSION = 27
 _CTRL_OP_NAMES[_CTRL_CHIP_EXTENSION] = "chip_extension"
+_CTRL_EXTERNAL_TRANSFER = 28
+_CTRL_OP_NAMES[_CTRL_EXTERNAL_TRANSFER] = "external_transfer"
 
 _CHIP_EXTENSION_HEADER = struct.Struct("!H")
 _chip_control_extensions: dict[str, Any] = {}
@@ -1714,9 +1726,7 @@ def _read_ctrl_staged_payload(buf: memoryview) -> bytes:
         staged.close()
 
 
-def _handle_chip_control_extension(
-    cw: ChipWorker, buf: memoryview, device_id: int, extensions: dict[str, Any]
-) -> None:
+def _handle_chip_control_extension(cw: ChipWorker, buf: memoryview, device_id: int, extensions: dict[str, Any]) -> None:
     envelope = _read_ctrl_staged_payload(buf)
     if len(envelope) < _CHIP_EXTENSION_HEADER.size:
         raise ValueError("chip control extension envelope is truncated")
@@ -2852,6 +2862,8 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
     on_task_done_success=None,
     prepared: set[int] | None = None,
     task_frame_count: int = 1,
+    external_transfer_providers: dict | None = None,
+    external_transfer_signals: tuple = (),
 ) -> None:
     """Chip-process handlers for `_run_mailbox_loop`.
 
@@ -3057,6 +3069,19 @@ def _run_chip_main_loop(  # noqa: PLR0913, PLR0915 -- fork-child entry: every de
                 _DEVICE_MEMORY_INFO.pack_into(buf, _CTRL_OFF_RESULT, info.free_bytes, info.total_bytes)
             elif sub_cmd == _CTRL_CHIP_EXTENSION:
                 _handle_chip_control_extension(cw, buf, device_id, chip_control_extensions)
+            elif sub_cmd == _CTRL_EXTERNAL_TRANSFER:
+                staged, staged_buf, size = _open_ctrl_payload(buf, what="external transfer")
+                try:
+                    _start_chip_transfer(
+                        bytes(staged_buf[:size]),
+                        device_id,
+                        external_transfer_providers or {},
+                        external_transfer_signals,
+                        cw._bind_external_transfer_thread,
+                    )
+                finally:
+                    staged_buf.release()
+                    staged.close()
             elif sub_cmd == _CTRL_IMPORT_RELEASE:
                 import_registry.unregister(_unpack_identity_wire(_read_control_digest(buf)))
             elif sub_cmd == CTRL_GLOBAL_DOMAIN_PREPARE:
@@ -3363,6 +3388,8 @@ def _chip_process_loop(  # noqa: PLR0913 -- fork-child entry: all context (bins,
     runtime: str = "",
     prewarm_config=None,
     enable_sdma: bool = False,
+    external_transfer_providers: dict | None = None,
+    external_transfer_signals: tuple = (),
 ) -> None:
     """Runs in forked child process. Loads host_runtime.so in own address space.
 
@@ -3426,6 +3453,12 @@ def _chip_process_loop(  # noqa: PLR0913 -- fork-child entry: all context (bins,
     sys.stderr.flush()
 
     try:
+        external_transfer_kwargs = {}
+        if external_transfer_signals:
+            external_transfer_kwargs = {
+                "external_transfer_providers": external_transfer_providers,
+                "external_transfer_signals": external_transfer_signals,
+            }
         _run_chip_main_loop(
             cw,
             buf,
@@ -3441,6 +3474,7 @@ def _chip_process_loop(  # noqa: PLR0913 -- fork-child entry: all context (bins,
             chip_runtime=runtime,
             prepared=prepared,
             task_frame_count=_local_task_frame_count(platform, runtime, int(cw.pipeline_depth)),
+            **external_transfer_kwargs,
         )
     finally:
         cw.finalize()
@@ -4579,8 +4613,7 @@ class Worker:
         self._registry_lock = threading.Lock()
         self._pending_unregister_cids: set[int] = set()
         self._pending_remote_unregister_hashids: set[bytes] = set()
-        self._chip_control_extension_names: frozenset[str] = frozenset()
-        self._py_control_timeout_s = float(config.get("py_control_timeout_s", _PY_CONTROL_TIMEOUT_S))
+        self._init_chip_control_state(config)
         # Upper bound on how long the readiness barrier waits for a forked child
         # to report INIT_READY/INIT_FAILED before treating it as hung. Must be
         # finite, else the deadline can never trip and the "bounded startup"
@@ -7944,12 +7977,7 @@ class Worker:
                 (digest, state.target, state.ref_count, state.kind, state.target_namespace)
                 for digest, state in self._identity_registry.items()
             ]
-        if self.level == 3:
-            with _chip_control_extensions_lock:
-                chip_control_extensions = dict(_chip_control_extensions)
-            self._chip_control_extension_names = frozenset(chip_control_extensions)
-        else:
-            chip_control_extensions = {}
+        chip_control_extensions = self._snapshot_chip_integrations()
 
         # Seed this process's logger before the first fork: the spans its own
         # scheduler emits obey the Python logger level, and every child inherits
@@ -8047,6 +8075,10 @@ class Worker:
                             ),
                             self._owner_instance_id,
                             chip_control_extensions,
+                            external_transfer_providers=self._external_transfer_providers,
+                            external_transfer_signals=(
+                                self._external_transfers.signals if self._external_transfers is not None else ()
+                            ),
                             log_level=chip_log_level,
                             platform=str(self._config["platform"]),
                             runtime=str(self._config["runtime"]),
@@ -10645,6 +10677,147 @@ class Worker:
         _require_copy_span(host_nbytes, host_offset, nbytes, side=host_side, api=api)
         return device_offset, host_offset, nbytes
 
+    def _init_chip_control_state(self, config: dict) -> None:
+        self._chip_control_extension_names: frozenset[str] = frozenset()
+        self._external_transfer_providers: dict = {}
+        self._external_transfers: _ExternalTransferPool | None = None
+        self._py_control_timeout_s = float(config.get("py_control_timeout_s", _PY_CONTROL_TIMEOUT_S))
+
+    def _snapshot_chip_integrations(self) -> dict:
+        if self.level != 3:
+            return {}
+        with _chip_control_extensions_lock:
+            extensions = dict(_chip_control_extensions)
+        self._chip_control_extension_names = frozenset(extensions)
+        self._snapshot_external_transfers()
+        return extensions
+
+    def _snapshot_external_transfers(self) -> None:
+        self._external_transfer_providers = _snapshot_providers()
+        if self._external_transfer_providers:
+            count = self._config.get("external_transfer_max_pending", 2)
+            max_bytes = self._config.get("external_transfer_max_bytes", 1024 * 1024 * 1024)
+            if type(count) is not int or count <= 0 or type(max_bytes) is not int or max_bytes <= 0:
+                raise ValueError("external transfer limits must be positive integers")
+            self._external_transfers = _ExternalTransferPool(count, max_bytes, self._retire_external_transfer)
+
+    def submit_external_transfer(
+        self,
+        provider: str,
+        buffers: tuple[ExternalBufferRange, ...],
+        payload: bytes = b"",
+        *,
+        timeout_s: float | None = None,
+    ) -> ExternalTransferHandle:
+        """Submit trusted external access to one local chip's DEVICE_MALLOC buffers.
+
+        The control timeout bounds submission acknowledgement, not DMA. An
+        uncertain submission raises ExternalTransferSubmissionError carrying
+        the retained handle. Compute and device control are excluded until
+        all external handles have confirmed quiescence through wait()/done().
+        """
+        if self.level != 3:
+            raise TypeError("external transfers require a level-3 Worker")
+        if _callback_frame_for(self) is not None or id(self) in _held_control_reservations():
+            raise RuntimeError("external transfers must be submitted outside orchestration/control callbacks")
+        effective_timeout = self._py_control_timeout_s if timeout_s is None else float(timeout_s)
+        if not (effective_timeout > 0 and math.isfinite(effective_timeout)):
+            raise ValueError("external transfer timeout_s must be positive and finite")
+        if not isinstance(payload, bytes) or len(payload) > 1024 * 1024:
+            raise ValueError("external transfer payload must be bytes of at most 1 MiB")
+        ranges = tuple(buffers)
+        if not ranges or len(ranges) > 65536 or any(not isinstance(r, ExternalBufferRange) for r in ranges):
+            raise ValueError("external transfer requires 1..65536 ExternalBufferRange entries")
+        with self._operation_lease("submit_external_transfer"), self._submit_mu.exclusive():
+            self._require_no_ordered_cleanup_failure("submit_external_transfer")
+            if provider not in self._external_transfer_providers or self._external_transfers is None:
+                raise KeyError(f"external transfer provider {provider!r} was not registered before Worker.init()")
+            with self._hierarchical_start_cv:
+                if self._accepted_run_handles or self._abandoned_run_handles:
+                    raise RuntimeError("external transfer requires all compute runs to have completed")
+            spans, worker_id = self._external_transfer_spans(ranges)
+            with self._hierarchical_start_cv:
+                handle = self._external_transfers.reserve(spans, worker_id)
+            try:
+                command = json.dumps(
+                    {
+                        "provider": provider,
+                        "slot": handle._slot,
+                        "completion": handle._shm.name,
+                        "spans": [(s.address, s.nbytes, int(s.access)) for s in spans],
+                        "payload": base64.b64encode(payload).decode("ascii"),
+                    }
+                ).encode("utf-8")
+                assert self._worker is not None
+                self._worker.control_payload(
+                    WorkerType.NEXT_LEVEL,
+                    worker_id,
+                    _CTRL_EXTERNAL_TRANSFER,
+                    command,
+                    effective_timeout,
+                )
+            except BaseException as exc:
+                raise ExternalTransferSubmissionError(handle) from exc
+            return handle
+
+    def _external_transfer_spans(
+        self,
+        ranges: tuple[ExternalBufferRange, ...],
+    ) -> tuple[tuple[ExternalTransferSpan, ...], int]:
+        spans = []
+        worker_ids = set()
+        with self._child_prov_lock:
+            for region in ranges:
+                if region.buffer.closed:
+                    raise ValueError("external transfer buffer is closed")
+                capabilities = []
+                if region.access in (AccessMode.READ, AccessMode.READWRITE):
+                    capabilities.append(BufferCapability.COPY_FROM)
+                if region.access in (AccessMode.WRITE, AccessMode.READWRITE):
+                    capabilities.append(BufferCapability.COPY_TO)
+                for capability in capabilities:
+                    registered = self._require_device_capability_locked(
+                        region.buffer.identity,
+                        capability,
+                        region.nbytes,
+                        offset=region.offset,
+                        api="submit_external_transfer",
+                    )
+                if registered.backend_kind != BackendKind.DEVICE_MALLOC:
+                    raise ValueError("external transfers currently require DEVICE_MALLOC, not communication windows")
+                worker_ids.add(int(registered.owner_worker_id))
+                spans.append(ExternalTransferSpan(int(registered.base) + region.offset, region.nbytes, region.access))
+        if len(worker_ids) != 1:
+            raise ValueError("one external transfer must target exactly one chip worker")
+        worker_id = worker_ids.pop()
+        self._check_chip_worker_id(worker_id)
+        return tuple(spans), worker_id
+
+    def _retire_external_transfer(self, handle: ExternalTransferHandle) -> None:
+        with self._hierarchical_start_cv:
+            assert self._external_transfers is not None
+            if self._external_transfers.pending.get(handle._slot) is handle:
+                self._external_transfers.pending.pop(handle._slot)
+            self._hierarchical_start_cv.notify_all()
+
+    def _require_no_external_transfers(self, api: str) -> None:
+        with self._hierarchical_start_cv:
+            if self._external_transfers is not None and self._external_transfers.pending:
+                raise RuntimeError(
+                    f"Worker.{api}: external transfer(s) still in flight; observe their completion first"
+                )
+
+    def _drain_external_transfers(self, deadline: float) -> None:
+        with self._hierarchical_start_cv:
+            handles = tuple(self._external_transfers.pending.values()) if self._external_transfers else ()
+        for handle in handles:
+            try:
+                handle.wait(max(0.0, deadline - _monotonic()))
+            except RuntimeError:
+                with self._hierarchical_start_cv:
+                    if self._external_transfers is not None and handle in self._external_transfers.pending.values():
+                        raise
+
     def run_chip_control_extension(
         self,
         name: str,
@@ -11159,6 +11332,7 @@ class Worker:
             # mailbox control that the whole-run FIFO cannot order against this
             # run's control, so we wait for that teardown and this worker
             # degrades to depth one for exactly those runs.
+            self._require_no_external_transfers("submit")
             predecessor = self._cleanup_bearing_predecessor()
             if predecessor is not None:
                 predecessor._wait_for_handoff()
@@ -11325,6 +11499,7 @@ class Worker:
             yield
             return
         with self._submit_mu.shared():
+            self._require_no_external_transfers(api)
             with self._hierarchical_start_cv:
                 if self._ordered_cleanup_error is not None:
                     raise RuntimeError(
@@ -11735,6 +11910,7 @@ class Worker:
         pending remote frees/import-releases."""
         return (
             self._has_native_tree()
+            or bool(self._external_transfers and self._external_transfers.pending)
             or bool(self._sub_pids or self._chip_pids or self._next_level_pids)
             or bool(self._sub_shms or self._chip_shms or self._next_level_shms)
             or any(group.process is not None or group.ready_dir is not None for group in self._mpi_l3_groups)
@@ -11751,6 +11927,8 @@ class Worker:
         """One-line inventory of the resource categories still present, for the
         terminal-close error synthesized when teardown leaves a residual."""
         parts: list[str] = []
+        if self._external_transfers and self._external_transfers.pending:
+            parts.append(f"{len(self._external_transfers.pending)} external transfer(s)")
         if self._has_native_tree():
             parts.append("native tree")
         n_pids = len(self._sub_pids) + len(self._chip_pids) + len(self._next_level_pids)
@@ -11941,6 +12119,7 @@ class Worker:
                 # drained, so this is the complete accepted set. Wait outside
                 # the lifecycle CV: handle retirement acquires the same lock.
                 assert drain_deadline is not None
+                self._drain_external_transfers(drain_deadline)
                 for handle in handles_to_drain:
                     remaining = drain_deadline - _monotonic()
                     if remaining <= 0:

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -1105,6 +1105,16 @@ void ChipWorker::copy_from(uint64_t dst, uint64_t src, size_t size) {
     }
 }
 
+void ChipWorker::bind_external_transfer_thread() {
+    if (!initialized_) {
+        throw std::runtime_error("ChipWorker not initialized; call init() first");
+    }
+    int rc = ensure_acl_ready_fn_(device_ctx_, device_id_);
+    if (rc != 0) {
+        throw std::runtime_error("external transfer thread binding failed with code " + std::to_string(rc));
+    }
+}
+
 uint64_t ChipWorker::comm_init(int rank, int nranks, const std::string &rootinfo_path) {
     if (!initialized_) {
         throw std::runtime_error("ChipWorker not initialized; call init() first");

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -182,6 +182,8 @@ public:
     void free(uint64_t ptr);
     void copy_to(uint64_t dst, uint64_t src, size_t size);
     void copy_from(uint64_t dst, uint64_t src, size_t size);
+    // Binds a runtime-owned transfer thread; callers must retain the worker until it exits.
+    void bind_external_transfer_thread();
 
     /// Distributed communication primitives (optional — only available when
     /// the bound runtime exports comm_*).  Wraps the backend-neutral C API

--- a/tests/ut/py/test_worker/_harness.py
+++ b/tests/ut/py/test_worker/_harness.py
@@ -253,6 +253,9 @@ class FakeChipWorker:
     def free(self, ptr: int) -> None:
         self._blocks.pop(int(ptr), None)
 
+    def _bind_external_transfer_thread(self) -> None:
+        pass
+
     def copy_to(self, dst: int, src: int, size: int) -> None:
         ctypes.memmove(dst, src, size)
 

--- a/tests/ut/py/test_worker/test_comm_provider_control.py
+++ b/tests/ut/py/test_worker/test_comm_provider_control.py
@@ -102,6 +102,8 @@ _OCCUPIED_WORKER_CONTROL_COMMANDS = frozenset(
         24,  # _CTRL_GLOBAL_DOMAIN_NODE
         25,  # _CTRL_DEVICE_MEMORY_INFO
         26,  # _CTRL_DELEGATED_REGION
+        27,  # _CTRL_CHIP_EXTENSION
+        28,  # _CTRL_EXTERNAL_TRANSFER
     }
 )
 _ALLOCATE_SUCCESS_OUTCOME = bytes.fromhex(
@@ -1370,6 +1372,8 @@ def test_control_command_26_is_delegated_region_and_16_17_remain_retired():
             "_CTRL_GLOBAL_DOMAIN_NODE",
             "_CTRL_DEVICE_MEMORY_INFO",
             "_CTRL_DELEGATED_REGION",
+            "_CTRL_CHIP_EXTENSION",
+            "_CTRL_EXTERNAL_TRANSFER",
         }
     }
     assert set(command_ids.values()) == _OCCUPIED_WORKER_CONTROL_COMMANDS

--- a/tests/ut/py/test_worker/test_external_transfer.py
+++ b/tests/ut/py/test_worker/test_external_transfer.py
@@ -1,0 +1,414 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Managed transfer lifetimes, admission, and real fork/control round trips."""
+
+import ctypes
+import multiprocessing
+import threading
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+import simpler.external_transfer as transfers
+import simpler.worker as worker_mod
+from simpler import ExternalBufferRange, ExternalTransferResult, Worker, register_external_transfer_provider
+from simpler.buffer import AccessMode, CanonicalIdentity, create_host_shared_buffer, wrap_device_malloc
+from simpler.external_transfer import ExternalTransferSubmissionError, ExternalTransferUnconfirmedError
+from simpler.task_interface import ChipWorker, DataType
+
+from ._harness import fake_chip_l3, requires_sim_binaries
+
+
+@pytest.fixture(autouse=True)
+def provider_registry(monkeypatch):
+    monkeypatch.setattr(transfers, "_providers", {})
+
+
+@pytest.fixture
+def local_worker():
+    worker = Worker(level=3, device_ids=[0, 1])
+    worker._lifecycle = worker_mod._Lifecycle.READY
+    worker._chip_shms = [object(), object()]
+    block = ctypes.create_string_buffer(64)
+    buffer = wrap_device_malloc(ctypes.addressof(block), 64, worker._owner_instance_id, 1, "L3", owner_worker_id=0)
+    worker._record_device_alloc(buffer)
+    worker._external_transfer_providers = {"test": lambda request, token: ExternalTransferResult()}
+    worker._external_transfers = transfers._ExternalTransferPool(2, 64, worker._retire_external_transfer)
+
+    def control(_kind, worker_id, opcode, payload, timeout):
+        assert opcode == worker_mod._CTRL_EXTERNAL_TRANSFER
+        assert worker_id == 0
+        assert timeout == 30.0
+        transfers._start_chip_transfer(
+            payload,
+            7,
+            worker._external_transfer_providers,
+            worker._external_transfers.signals,
+            lambda: None,
+        )
+        return payload
+
+    worker._worker = SimpleNamespace(control_payload=control, free=lambda *_args: None)
+    yield worker, buffer, block
+    # Only host-backed fake providers run here; tests join them before this fixture returns.
+    for handle in tuple(worker._external_transfers.pending.values()):
+        handle._shm.close()
+        handle._shm.unlink()
+    worker._external_transfers.pending.clear()
+    worker._chip_shms = []
+    worker._worker = None
+    worker.close()
+
+
+def _range(buffer, offset=0, nbytes=8, access=AccessMode.WRITE):
+    return ExternalBufferRange(buffer, offset, nbytes, access)
+
+
+def test_registration_and_snapshot(local_worker):
+    worker, _, _ = local_worker
+
+    def provider(_request, _token):
+        return ExternalTransferResult()
+
+    register_external_transfer_provider("one", provider)
+    register_external_transfer_provider("one", provider)
+    with pytest.raises(ValueError, match="already registered"):
+        register_external_transfer_provider("one", lambda request, token: ExternalTransferResult())
+    worker._snapshot_external_transfers()
+    register_external_transfer_provider("late", provider)
+    assert set(worker._external_transfer_providers) == {"one"}
+
+
+@pytest.mark.parametrize("level", [2, 4])
+def test_rejects_unsupported_levels(level):
+    with pytest.raises(TypeError, match="level-3"):
+        Worker(level=level).submit_external_transfer("test", ())
+
+
+@pytest.mark.parametrize("offset,nbytes", [(-1, 8), (0, 0), (0, -1), (0.5, 8), (0, True)])
+def test_range_validation(local_worker, offset, nbytes):
+    _, buffer, _ = local_worker
+    with pytest.raises(ValueError):
+        _range(buffer, offset, nbytes)
+
+
+@pytest.mark.parametrize("timeout", [0, -1, float("nan"), float("inf")])
+def test_control_timeout_validation(local_worker, timeout):
+    worker, buffer, _ = local_worker
+    with pytest.raises(ValueError, match="positive and finite"):
+        worker.submit_external_transfer("test", (_range(buffer),), timeout_s=timeout)
+    assert not worker._external_transfers.pending
+
+
+def test_private_snapshot_defeats_mutated_pointer_and_extent(local_worker):
+    worker, buffer, block = local_worker
+    original = buffer.base
+    observed = []
+
+    def provider(request, _token):
+        observed.append(request)
+        ctypes.memset(request.buffers[0].address, 65, request.buffers[0].nbytes)
+        return ExternalTransferResult(payload=b"written")
+
+    worker._external_transfer_providers["test"] = provider
+    buffer.base, buffer.nbytes, buffer.owner_worker_id = 1, 1024, 1
+    handle = worker.submit_external_transfer("test", (_range(buffer, 4, 8),))
+    assert handle.result(5) == b"written"
+    assert handle.done()
+    assert not handle.request_cancel()
+    assert observed[0].buffers[0].address == original + 4
+    assert observed[0].device_id == 7
+    assert bytes(block)[4:12] == b"A" * 8
+    with pytest.raises(ValueError, match="overruns"):
+        worker.submit_external_transfer("test", (_range(buffer, 60, 8),))
+
+
+def test_stale_foreign_closed_and_read_only_buffers(local_worker):
+    worker, buffer, _ = local_worker
+    with pytest.raises(ValueError, match="not a live"):
+        identity = CanonicalIdentity(worker._owner_instance_id, 99, 1)
+        worker.submit_external_transfer("test", (_range(replace(buffer, identity=identity)),))
+    readonly = replace(buffer, access=AccessMode.READ)
+    worker._record_device_alloc(readonly)
+    with pytest.raises(ValueError, match="needs WRITE"):
+        worker.submit_external_transfer("test", (_range(buffer),))
+    worker._record_device_alloc(buffer)
+    buffer.close()
+    with pytest.raises(ValueError, match="closed"):
+        worker.submit_external_transfer("test", (_range(buffer),))
+
+
+def test_cancel_and_timeout_keep_memory_and_compute_excluded(local_worker):
+    worker, buffer, _ = local_worker
+    entered, finish = threading.Event(), threading.Event()
+
+    def provider(_request, token):
+        entered.set()
+        assert finish.wait(5)
+        return ExternalTransferResult(succeeded=False, error=f"cancelled={token.requested}")
+
+    worker._external_transfer_providers["test"] = provider
+    handle = worker.submit_external_transfer("test", (_range(buffer),))
+    try:
+        assert entered.wait(5)
+        assert handle.request_cancel()
+        assert not handle.done()
+        with pytest.raises(TimeoutError):
+            handle.wait(0.01)
+        with pytest.raises(RuntimeError, match="external transfer"):
+            worker.free(buffer)
+        with pytest.raises(RuntimeError, match="external transfer"):
+            worker.submit(lambda *_args: None)
+        host = create_host_shared_buffer(8, worker._owner_instance_id, 99)
+        try:
+            with pytest.raises(RuntimeError, match="external transfer"):
+                worker.copy_to(buffer, host)
+        finally:
+            host.close()
+        assert buffer.identity in worker._child_alloc
+    finally:
+        finish.set()
+        with pytest.raises(RuntimeError, match="cancelled=True"):
+            handle.wait(5)
+    assert handle.done()
+    worker.free(buffer)
+    assert buffer.identity not in worker._child_alloc
+
+
+def test_backpressure_and_overlapping_writes(local_worker):
+    worker, buffer, _ = local_worker
+    finish = threading.Event()
+
+    def provider(_request, _token):
+        assert finish.wait(5)
+        return ExternalTransferResult()
+
+    worker._external_transfer_providers["test"] = provider
+    first = worker.submit_external_transfer("test", (_range(buffer, nbytes=32),))
+    second = None
+    try:
+        with pytest.raises(RuntimeError, match="conflicts"):
+            worker.submit_external_transfer("test", (_range(buffer),))
+        with pytest.raises(RuntimeError, match="byte limit"):
+            worker.submit_external_transfer("test", (_range(buffer, nbytes=64),))
+        second = worker.submit_external_transfer("test", (_range(buffer, 32, 8),))
+        with pytest.raises(RuntimeError, match="count limit"):
+            worker.submit_external_transfer("test", (_range(buffer, 48, 8),))
+    finally:
+        finish.set()
+        first.wait(5)
+        if second:
+            second.wait(5)
+
+
+def test_submission_ack_loss_retains_handle_and_late_completion(local_worker):
+    worker, buffer, _ = local_worker
+    control = worker._worker.control_payload
+
+    def lost_ack(*args):
+        control(*args)
+        raise TimeoutError("ack lost")
+
+    worker._worker.control_payload = lost_ack
+    with pytest.raises(ExternalTransferSubmissionError) as caught:
+        worker.submit_external_transfer("test", (_range(buffer),))
+    assert worker._external_transfers.pending
+    assert caught.value.handle.wait(5) == b""
+    assert not worker._external_transfers.pending
+
+
+def test_interrupted_completion_can_be_observed_again(local_worker, monkeypatch):
+    worker, buffer, _ = local_worker
+    handle = worker.submit_external_transfer("test", (_range(buffer),))
+    observe = handle._observe_outcome
+
+    def interrupt():
+        raise KeyboardInterrupt("after wakeup")
+
+    monkeypatch.setattr(handle, "_observe_outcome", interrupt)
+    with pytest.raises(KeyboardInterrupt):
+        handle.wait(5)
+    assert worker._external_transfers.pending
+    monkeypatch.setattr(handle, "_observe_outcome", observe)
+    assert handle.wait(5) == b""
+    assert not worker._external_transfers.pending
+
+
+def test_interrupted_retirement_can_be_retried(local_worker, monkeypatch):
+    worker, buffer, _ = local_worker
+    handle = worker.submit_external_transfer("test", (_range(buffer),))
+    retire = handle._pool.retire
+
+    def interrupt(_handle):
+        raise KeyboardInterrupt("after shared memory cleanup")
+
+    monkeypatch.setattr(handle._pool, "retire", interrupt)
+    with pytest.raises(KeyboardInterrupt):
+        handle.wait(5)
+    assert worker._external_transfers.pending
+    monkeypatch.setattr(handle._pool, "retire", retire)
+    assert handle.wait(5) == b""
+    assert not worker._external_transfers.pending
+
+
+def test_overlapping_reads_allowed_but_duplicate_writes_rejected(local_worker):
+    worker, buffer, _ = local_worker
+    with pytest.raises(RuntimeError, match="conflicts"):
+        worker.submit_external_transfer("test", (_range(buffer), _range(buffer)))
+    read = _range(buffer, access=AccessMode.READ)
+    first = worker.submit_external_transfer("test", (read,))
+    second = worker.submit_external_transfer("test", (read,))
+    assert first.wait(5) == second.wait(5) == b""
+
+
+def test_mixed_chip_request_rejected(local_worker):
+    worker, buffer, _ = local_worker
+    other = wrap_device_malloc(4096, 16, worker._owner_instance_id, 2, "L3", owner_worker_id=1)
+    worker._record_device_alloc(other)
+    with pytest.raises(ValueError, match="exactly one chip"):
+        worker.submit_external_transfer("test", (_range(buffer), _range(other)))
+    assert not worker._external_transfers.pending
+
+
+def test_unexpected_exception_does_not_certify_quiescence(local_worker):
+    worker, buffer, _ = local_worker
+
+    def provider(_request, _token):
+        raise RuntimeError("backend lost")
+
+    worker._external_transfer_providers["test"] = provider
+    handle = worker.submit_external_transfer("test", (_range(buffer),))
+    with pytest.raises(ExternalTransferUnconfirmedError, match="backend lost"):
+        handle.wait(5)
+    assert not handle.done()
+    assert worker._external_transfers.pending
+    with pytest.raises(RuntimeError, match="external transfer"):
+        worker.free(buffer)
+
+
+@requires_sim_binaries
+def test_forked_chip_direct_transfer_target_and_slot_reuse(monkeypatch):
+    def provider(request, _token):
+        span = request.buffers[0]
+        ctypes.memset(span.address, request.payload[0], span.nbytes)
+        return ExternalTransferResult(payload=str(request.device_id).encode())
+
+    register_external_transfer_provider("fill", provider)
+    with fake_chip_l3(monkeypatch, device_ids=(3, 5), external_transfer_max_pending=1) as worker:
+        buffer = worker.alloc_child_tensor(1, (16,), DataType.UINT8)
+        for value in (65, 66, 67):
+            handle = worker.submit_external_transfer("fill", (_range(buffer, 4, 8),), bytes([value]))
+            assert handle.wait(5) == b"5"
+            output = worker.create_buffer(16)
+            worker.copy_from(output, buffer)
+            assert bytes(output.shm.buf)[4:12] == bytes([value]) * 8
+            worker.release_buffer(output)
+        worker.free(buffer)
+
+
+@requires_sim_binaries
+def test_close_timeout_defers_teardown_and_can_retry(monkeypatch):
+    finish = multiprocessing.get_context("fork").Event()
+
+    def provider(_request, _token):
+        assert finish.wait(10)
+        return ExternalTransferResult()
+
+    register_external_transfer_provider("blocked", provider)
+    with fake_chip_l3(monkeypatch) as worker:
+        buffer = worker.alloc_child_tensor(0, (16,), DataType.UINT8)
+        handle = worker.submit_external_transfer("blocked", (_range(buffer),))
+        try:
+            with monkeypatch.context() as context:
+                context.setattr(worker_mod, "_ROLLBACK_GRACEFUL_TIMEOUT_S", 0.02)
+                with pytest.raises(TimeoutError, match="buffers remain retained"):
+                    worker.close()
+            assert worker._lifecycle == worker_mod._Lifecycle.CLOSED
+            assert not worker._teardown_attempted
+            assert worker._worker is not None
+            assert buffer.identity in worker._child_alloc
+        finally:
+            finish.set()
+            handle.wait(5)
+        worker.close()
+        assert worker._worker is None
+
+
+@requires_sim_binaries
+def test_close_drains_unobserved_completed_transfers(monkeypatch):
+    register_external_transfer_provider("done", lambda request, token: ExternalTransferResult())
+    with fake_chip_l3(monkeypatch) as worker:
+        buffer = worker.alloc_child_tensor(0, (8,), DataType.UINT8)
+        handle = worker.submit_external_transfer("done", (_range(buffer),))
+        worker.close()
+        assert handle.done()
+        assert not worker._external_transfers.pending
+
+
+def test_native_thread_binding_requires_initialization():
+    with pytest.raises(RuntimeError, match="not initialized"):
+        ChipWorker()._bind_external_transfer_thread()
+
+
+@requires_sim_binaries
+def test_native_simulator_transfer():
+    def provider(request, _token):
+        span = request.buffers[0]
+        ctypes.memset(span.address, 90, span.nbytes)
+        return ExternalTransferResult()
+
+    register_external_transfer_provider("native-sim", provider)
+    worker = Worker(level=3, device_ids=[0], platform="a2a3sim", runtime="tensormap_and_ringbuffer")
+    try:
+        worker.init()
+        buffer = worker.alloc_child_tensor(0, (16,), DataType.UINT8)
+        worker.submit_external_transfer("native-sim", (_range(buffer, 4, 8),)).wait(5)
+        output = worker.create_buffer(16)
+        worker.copy_from(output, buffer)
+        assert bytes(output.shm.buf)[4:12] == b"Z" * 8
+        worker.release_buffer(output)
+        worker.free(buffer)
+    finally:
+        worker.close()
+
+
+@pytest.mark.requires_hardware
+def test_onboard_hbm_transfer(st_platform, st_device_ids):
+    def provider(request, _token):
+        acl = ctypes.CDLL("libascendcl.so")
+        get_device = acl.aclrtGetDevice
+        get_device.argtypes, get_device.restype = [ctypes.POINTER(ctypes.c_int32)], ctypes.c_int32
+        current = ctypes.c_int32(-1)
+        status = get_device(ctypes.byref(current))
+        if status != 0 or current.value != request.device_id:
+            return ExternalTransferResult(False, error=f"thread device mismatch: {status}, {current.value}")
+        memset = acl.aclrtMemset
+        memset.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int32, ctypes.c_size_t]
+        memset.restype = ctypes.c_int32
+        span = request.buffers[0]
+        status = memset(span.address, span.nbytes, 90, span.nbytes)
+        return ExternalTransferResult(status == 0, error=f"aclrtMemset status={status}")
+
+    register_external_transfer_provider("onboard", provider)
+    worker = Worker(level=3, device_ids=st_device_ids, platform=st_platform, runtime="tensormap_and_ringbuffer")
+    try:
+        worker.init()
+        buffer = worker.alloc_child_tensor(0, (4096,), DataType.UINT8)
+        worker.submit_external_transfer("onboard", (_range(buffer, 256, 1024),)).wait(10)
+        output = worker.create_buffer(4096)
+        worker.copy_from(output, buffer)
+        assert bytes(output.shm.buf)[256:1280] == b"Z" * 1024
+        worker.release_buffer(output)
+        worker.free(buffer)
+    finally:
+        worker.close()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -1052,6 +1052,7 @@ class _TwoFrameLoopHarness:
                 self.identity_table,
                 self.identity_refs,
                 worker_mod.mint_owner_instance_id(),
+                {},
             ),
             kwargs={
                 "chip_platform": "a2a3",
@@ -8069,7 +8070,7 @@ class TestChipMainLoopDigestRegister:
             identity_refs = {}
         t = threading.Thread(
             target=_run_chip_main_loop,
-            args=(cw, buf, 0, state_addr, 0, registry, identity_table, identity_refs, mint_owner_instance_id()),
+            args=(cw, buf, 0, state_addr, 0, registry, identity_table, identity_refs, mint_owner_instance_id(), {}),
             kwargs={"chip_platform": ""},
             daemon=True,
         )

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -244,6 +244,7 @@ def test_chip_process_loop_inits_runs_and_finalizes(monkeypatch):
             {},
             {},
             worker_mod.mint_owner_instance_id(),
+            {},
             platform="a2a3",
             runtime="tensormap_and_ringbuffer",
         )
@@ -1855,6 +1856,122 @@ def _unique_chip_callable(index: int):
 # ---------------------------------------------------------------------------
 # Test: lifecycle (init / close without submitting any tasks)
 # ---------------------------------------------------------------------------
+
+
+class TestChipControlExtensions:
+    def test_registration_is_idempotent_only_for_the_same_handler(self, monkeypatch):
+        monkeypatch.setattr(worker_mod, "_chip_control_extensions", {})
+
+        def first(_chip_worker, _payload, _device_id):
+            return None
+
+        def second(_chip_worker, _payload, _device_id):
+            return None
+
+        worker_mod.register_chip_control_extension("test.extension", first)
+        worker_mod.register_chip_control_extension("test.extension", first)
+        with pytest.raises(ValueError, match="already registered"):
+            worker_mod.register_chip_control_extension("test.extension", second)
+
+    @pytest.mark.parametrize("level", (2, 4))
+    def test_only_level_three_is_supported(self, level):
+        worker = Worker(level=level)
+        with pytest.raises(TypeError, match="level-3 Worker"):
+            worker.run_chip_control_extension("test.extension", b"")
+
+    def test_default_timeout_and_child_errors_are_forwarded(self, monkeypatch):
+        calls = []
+
+        class FakeWorker:
+            def broadcast_control_all(self, worker_type, sub_cmd, payload, digest, timeout_s):
+                calls.append((worker_type, sub_cmd, payload, digest, timeout_s))
+                return [_FakeControlResult("NEXT_LEVEL", 0, False, "injected extension failure")]
+
+        worker = Worker(level=3, py_control_timeout_s=7.25)
+        worker._lifecycle = worker_mod._Lifecycle.READY
+        worker._worker = FakeWorker()
+        worker._chip_control_extension_names = frozenset({"test.extension"})
+        monkeypatch.setattr(
+            worker,
+            "_device_control_admission",
+            lambda _api: worker_mod.contextlib.nullcontext(),
+        )
+
+        with pytest.raises(RuntimeError, match="injected extension failure"):
+            worker.run_chip_control_extension("test.extension", b"payload")
+
+        assert calls[0][0] is WorkerType.NEXT_LEVEL
+        assert calls[0][1] == worker_mod._CTRL_CHIP_EXTENSION
+        assert calls[0][3] is None
+        assert calls[0][4] == 7.25
+        name_size = worker_mod._CHIP_EXTENSION_HEADER.unpack_from(calls[0][2])[0]
+        name_start = worker_mod._CHIP_EXTENSION_HEADER.size
+        assert calls[0][2][name_start : name_start + name_size] == b"test.extension"
+        assert calls[0][2][name_start + name_size :] == b"payload"
+
+    def test_rejects_unbounded_timeout(self, monkeypatch):
+        worker = Worker(level=3)
+        worker._lifecycle = worker_mod._Lifecycle.READY
+        worker._worker = cast(Any, object())
+        worker._chip_control_extension_names = frozenset({"test.extension"})
+        monkeypatch.setattr(
+            worker,
+            "_device_control_admission",
+            lambda _api: worker_mod.contextlib.nullcontext(),
+        )
+
+        for timeout_s in (0.0, -1.0, float("inf"), float("nan")):
+            with pytest.raises(ValueError, match="positive finite"):
+                worker.run_chip_control_extension("test.extension", b"payload", timeout_s=timeout_s)
+
+    @requires_sim_binaries
+    def test_registered_handler_runs_in_every_chip_child_and_registry_is_frozen(self, monkeypatch):
+        monkeypatch.setattr(worker_mod, "_chip_control_extensions", {})
+        observed = SharedMemory(create=True, size=8)
+        observed_buf = observed.buf
+        assert observed_buf is not None
+        observed_buf[:] = bytes(8)
+
+        try:
+            with fake_chip_l3(monkeypatch, device_ids=(0, 1), init=False) as worker:
+
+                def handler(chip_worker, payload, device_id):
+                    if chip_worker.pipeline_depth != 1 or payload != b"payload":
+                        return "handler arguments did not match"
+                    struct.pack_into("i", observed_buf, int(device_id) * 4, int(device_id) + 1)
+                    return None
+
+                worker_mod.register_chip_control_extension("test.inherited", handler)
+                worker.init()
+                worker.run_chip_control_extension("test.inherited", b"payload")
+                assert struct.unpack_from("ii", observed_buf) == (1, 2)
+
+                worker_mod.register_chip_control_extension("test.late", handler)
+                with pytest.raises(KeyError, match="before this Worker.init"):
+                    worker.run_chip_control_extension("test.late", b"payload")
+        finally:
+            observed_buf.release()
+            observed.close()
+            observed.unlink()
+
+    @requires_sim_binaries
+    def test_handler_return_and_exception_propagate_from_chip_child(self, monkeypatch):
+        monkeypatch.setattr(worker_mod, "_chip_control_extensions", {})
+
+        def returns_error(_chip_worker, _payload, _device_id):
+            return "returned extension failure"
+
+        def raises_error(_chip_worker, _payload, _device_id):
+            raise RuntimeError("raised extension failure")
+
+        with fake_chip_l3(monkeypatch, init=False) as worker:
+            worker_mod.register_chip_control_extension("test.return", returns_error)
+            worker_mod.register_chip_control_extension("test.raise", raises_error)
+            worker.init()
+            with pytest.raises(RuntimeError, match="returned extension failure"):
+                worker.run_chip_control_extension("test.return", b"payload")
+            with pytest.raises(RuntimeError, match="raised extension failure"):
+                worker.run_chip_control_extension("test.raise", b"payload")
 
 
 class TestLifecycle:


### PR DESCRIPTION
## Summary

- expose `register_chip_control_extension()` from the `simpler` package
- add `Worker.run_chip_control_extension()` for level-3+ workers to broadcast a named byte payload to local chip children
- dispatch extension payloads through the existing worker control path and propagate child-side failures to the caller

## Motivation

Some downstream runtimes need to initialize and control services inside the persistent chip-child process that owns the device context and HBM allocations. For example, a Mooncake-backed external KV cache must initialize its transfer client and register NPU memory in the process that owns those buffers.

The existing task APIs are intended for scheduled compute work and do not provide a lifecycle/control channel for this use case. Implementing a generic named extension keeps storage-specific dependencies and protocols out of Simpler while allowing trusted downstream integrations to run short control operations in chip children.

## Design

- Extensions are registered by name in the parent before `Worker.init()`, so forked chip children inherit the handler registry.
- `run_chip_control_extension()` wraps the extension name and payload in a control envelope and broadcasts it to `WorkerType.NEXT_LEVEL` children.
- Each chip child resolves the registered handler and invokes it as `handler(chip_worker, payload, device_id)`.
- A missing registration, malformed envelope, or non-empty handler error is surfaced through the existing control-result aggregation.
- Registration is idempotent for the same handler and rejects replacing an existing name with a different handler.
- The API is a synchronous control-plane mechanism. Extension handlers should return promptly and move long-running work to their own asynchronous execution path.

## Scope

This PR only adds the generic chip-child control mechanism. Mooncake initialization, transfer state, polling, cancellation, and buffer-layout logic remain in the downstream serving integration.

## Validation

- The API is exercised by the downstream PyPTO Serving Mooncake bridge for client initialization, HBM registration, transfer submission, polling, cancellation, and cleanup.
