### PR TITLE
Docs: state that the device log threshold is fixed at device init

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -337,13 +337,49 @@ message tag.
 | `_ChipWorker.init()` | Load sim context and host runtime, then bind each module's logger state | `src/common/worker/chip_worker.cpp` |
 | `simpler_init` | Onboard maps the bound threshold to CANN; attach and take executor binaries | `src/common/platform/{onboard,sim}/host/c_api_shared.cpp` |
 | Nested host load | Bind generated host orchestration/AICore logger state before entry | runtime maker / sim device runner |
-| AICPU init | Sim binds the live host state; onboard snapshots CANN policy | platform AICPU init |
+| AICPU init | Sim binds the live host state; onboard snapshots CANN policy **and latches `InitArgs.log_level` once for the Worker's life** | platform AICPU init |
 
 The Python level is still sampled during worker initialization. Calling
 `logger.setLevel(...)` does not itself call the native setter; recreate or
 reinitialize the worker to apply a new Python configuration. Within a process,
 all bound host modules observe a native state update immediately instead of
 requiring threshold fan-out to every DSO.
+
+### The threshold is live on the host and fixed on the device
+
+Two different lifetimes, and the boundary is the silicon rather than the
+language:
+
+| reader | when a `set_level` takes effect |
+| ------ | ------------------------------- |
+| Every host module in the process, including a `dlopen`ed one | **immediately** — each reads `state()->threshold` on every record |
+| Sim AICPU | **immediately** — it runs in the host process as a bound consumer of the same state |
+| **Onboard AICPU** | **never; it keeps the threshold it was given at device init** |
+
+Onboard AICPU receives the threshold once, in `InitArgs.log_level`, and
+`simpler_aicpu_init` pushes it into a device-side flag. That entry runs once per
+Worker, so the value it latched is the value for that Worker's life.
+
+**This is a design decision, not a gap.** Raising verbosity mid-run to chase a
+device-side problem is not a workflow this runtime supports: recreate the Worker
+with the level you want. Two reasons it is not worth supporting:
+
+- A `Worker` is cheap to recreate, so the workaround costs nothing a debugging
+  session would notice.
+- Device log volume is exactly where an accidental `DEBUG` is most expensive —
+  `codestyle.md` rule 7 forbids logging on AICPU hot paths precisely because
+  `device_log` writes serialize on the single AICPU op and can trip the
+  op-execute timeout. A threshold that can be raised into that from outside is a
+  liability rather than a feature.
+
+Delivering it would also cost more than it looks. The threshold could ride an
+existing per-run payload, but making it *immediately* live needs either a device
+launch per `set_level` — the opposite direction from #2092, which exists to make
+`simpler_aicpu_init` launch exactly once — or a new host-writable device-resident
+location polled outside any launch.
+
+So: **any claim that "the log level is live" is scoped to host modules.** State
+it that way when writing one.
 
 ### The Python logger is a client, not a second system
 

--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -139,6 +139,8 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_init(void *a
     }
 
     InitArgs *init_args = reinterpret_cast<InitArgs *>(arg);
+    // One-shot for the Worker's life: this entry runs once and no host-side
+    // set_level reaches here afterwards. Deliberate — see docs/logging.md.
     set_log_level(static_cast<int>(init_args->log_level));
     set_orch_device_id(static_cast<int>(init_args->device_id));
     set_scheduler_timeout_ms(static_cast<int>(init_args->scheduler_timeout_ms));

--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -169,6 +169,8 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_init(void *a
     }
 
     InitArgs *init_args = reinterpret_cast<InitArgs *>(arg);
+    // One-shot for the Worker's life: this entry runs once and no host-side
+    // set_level reaches here afterwards. Deliberate — see docs/logging.md.
     set_log_level(static_cast<int>(init_args->log_level));
     set_orch_device_id(static_cast<int>(init_args->device_id));
     set_scheduler_timeout_ms(static_cast<int>(init_args->scheduler_timeout_ms));

--- a/src/common/log/include/host_log.h
+++ b/src/common/log/include/host_log.h
@@ -59,6 +59,14 @@ public:
     // Owner initialization starts the bounded writer by default. Hierarchical
     // workers defer it until their final local fork so no process forks with a
     // C++ thread already running.
+    //
+    // Takes effect immediately for every host module in the process, since each
+    // reads the bound state's threshold per record — sim AICPU included, because
+    // it is one of them. It does NOT reach onboard AICPU, which latches
+    // InitArgs.log_level once in simpler_aicpu_init and keeps it for the
+    // Worker's life; that is deliberate, not missing (see docs/logging.md,
+    // "The threshold is live on the host and fixed on the device"). Recreate the
+    // Worker to change the device threshold.
     void set_level(simpler::log::LogLevel level, bool defer_writer = false);
     bool start_writer();
 

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -567,6 +567,10 @@ int DeviceRunnerBase::ensure_aicpu_init_launched() {
 
     InitArgs init_args{};
     init_args.device_id = static_cast<uint32_t>(device_id_);
+    // The device threshold is set here and never again: this entry launches once
+    // per Worker, so a later host-side set_level does not reach the AICPU. That is
+    // the intended contract, not a missing refresh — recreate the Worker to change
+    // it. docs/logging.md records why.
     init_args.log_level = static_cast<uint32_t>(HostLogger::get_instance().level());
     // Per-device scheduler watchdog override, resolved once at attach into
     // timeout_config_. 0 -> the AICPU scheduler keeps its compile-time default.


### PR DESCRIPTION
## Summary

Closes #2109 by recording the contract rather than building a mechanism for it.

I filed #2109 as a defect. It is not one — the device threshold being fixed at device init is a **design decision**, and the actual defect was that nothing said so. This documents it.

## Two lifetimes, and only one was described

| reader | when a `set_level` takes effect |
| --- | --- |
| Every host module in the process, including a `dlopen`ed one | **immediately** — each reads `state()->threshold` per record |
| Sim AICPU | **immediately** — it runs in the host process as one of them |
| **Onboard AICPU** | **never; it keeps what device init gave it** |

`simpler_aicpu_init` latches `InitArgs.log_level` into a device-side flag, and that entry runs once per Worker.

What the docs said before:

- `docs/logging.md` — *"all bound host modules observe a native state update immediately instead of requiring threshold fan-out to every DSO."* Correct as written, and easy to read as "live everywhere".
- the configuration-flow table's onboard AICPU row described only CANN policy, not our own one-shot flag.
- `set_level` carried no note about its reach at all.

## Why it stays one-shot

Raising verbosity mid-run to chase a device-side problem is not a workflow this runtime supports; recreate the Worker with the level you want.

- A `Worker` is cheap to recreate, so the workaround costs nothing a debugging session would notice.
- Device log volume is exactly where an accidental `DEBUG` is most expensive. `codestyle.md` rule 7 forbids AICPU hot-path logging because `device_log` writes serialize on the single AICPU op and can trip the op-execute timeout — a threshold outside code can raise into that is a liability, not a feature.

The doc also records what delivering it would cost, so the next person does not have to re-derive it: making it *immediately* live needs either a device launch per `set_level` — the opposite direction from #2092, which exists to make `simpler_aicpu_init` launch exactly once — or a new host-writable device-resident location polled outside any launch.

I did start down the "make it work" path before this was settled, and found the threshold could ride an existing per-run payload (`KernelArgs` is host-built per run and read by `simpler_aicpu_exec`, and onboard `set_log_level` is a single bool store, so a per-run refresh would be nearly free and give next-run granularity). That is recorded in the doc as the cheap option that still is not worth taking, since there is no use case asking for it. Better to write it down than to leave it as a discovery someone repeats.

## What changed

- `docs/logging.md` — a new "The threshold is live on the host and fixed on the device" section with the table above and the rationale; the configuration-flow table's AICPU row now names the latch.
- `src/common/log/include/host_log.h` — `set_level` scopes its own liveness claim and points at the doc.
- `src/common/platform/onboard/host/device_runner_base.cpp` — the `InitArgs.log_level` fill says it is the only time it happens.
- `src/a2a3/…/aicpu/kernel.cpp` and `src/a5/…/aicpu/kernel.cpp` — the `set_log_level` call says it is one-shot. Both trees, since they are near-duplicates and a contract note that lands in one is stale in the other.

No behaviour change: comments and docs only.

## Testing

| | |
| --- | --- |
| cpput | 132/132 |
| pyut | 2102 passed, 18 skipped |
| st a2a3sim / a5sim | 33 / 29 |
| st a2a3 onboard | 67 |
| linters | clang-format, clang-tidy, ruff, pyright, markdownlint, retired-names, headers, english-only — clean |

The onboard sweep is the one that matters here: the two annotated lines are on the AICPU init path, and although the edit is comment-only, all four platforms were rebuilt and the sweep run rather than assuming a comment cannot break a build.
