### PR TITLE
Fix: give the hbg async wait list an empty state at boot

### DIFF
--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -133,6 +133,15 @@ of it, dominated by `AsyncWaitList::entries` — for the device to receive and n
 read. `RuntimeContext` therefore holds a *pointer* to it, wired from
 `off_scheduler` on each side, and the AICPU calls `init_data_from_layout` at boot.
 
+"Never read" holds for `entries` itself, not for the scalars that index it. The
+region arrives holding the pooled allocation's previous generation, so every
+field the dispatch loop reads before anything writes it needs a value from
+`init_data_from_layout`: the queue headers, and `AsyncWaitList`'s `busy` and
+`count`. A residual `count` is the length the resolution thread's poll walks
+`entries` by, so it reads past the region and faults on an address that belongs
+to no mapping (issue #2121); a residual `busy` is the same miss inverted, making
+every drain a no-op and stranding deferred completions.
+
 **Why the queue slots are device-written.** `push` claims `slots[pos & mask]` only
 when that slot's `sequence` already equals `pos`, so an empty queue is a
 `0..capacity-1` ramp, not zeroed memory: on zeroed slots position 0 happens to

--- a/src/a2a3/runtime/host_build_graph/runtime/async_wait.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/async_wait.h
@@ -153,6 +153,17 @@ struct AsyncWaitList {
     // Read by scheduler shutdown / l2 perf summary; not on the hot path.
     std::atomic<uint64_t> mpsc_skipped_count{0};
 
+    // Empty state of a wait list sitting on the arena's device-only zone, whose
+    // bytes are whatever the pooled allocation last held. `count` bounds every
+    // read of entries[], and a drain assigns an entry in full before raising the
+    // count that admits it, so clearing the three scalars is the whole reset —
+    // the 190 KB entries[] region needs no per-bind sweep.
+    void reset_for_reuse() {
+        busy.store(0, std::memory_order_relaxed);
+        count = 0;
+        mpsc_skipped_count.store(0, std::memory_order_relaxed);
+    }
+
     bool try_lock() {
         int32_t expected = 0;
         return busy.compare_exchange_strong(expected, 1, std::memory_order_acquire, std::memory_order_relaxed);

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -133,6 +133,15 @@ of it, dominated by `AsyncWaitList::entries` — for the device to receive and n
 read. `RuntimeContext` therefore holds a *pointer* to it, wired from
 `off_scheduler` on each side, and the AICPU calls `init_data_from_layout` at boot.
 
+"Never read" holds for `entries` itself, not for the scalars that index it. The
+region arrives holding the pooled allocation's previous generation, so every
+field the dispatch loop reads before anything writes it needs a value from
+`init_data_from_layout`: the queue headers, and `AsyncWaitList`'s `busy` and
+`count`. A residual `count` is the length the resolution thread's poll walks
+`entries` by, so it reads past the region and faults on an address that belongs
+to no mapping (issue #2121); a residual `busy` is the same miss inverted, making
+every drain a no-op and stranding deferred completions.
+
 **Why the queue slots are device-written.** `push` claims `slots[pos & mask]` only
 when that slot's `sequence` already equals `pos`, so an empty queue is a
 `0..capacity-1` ramp, not zeroed memory: on zeroed slots position 0 happens to

--- a/src/a5/runtime/host_build_graph/runtime/async_wait.h
+++ b/src/a5/runtime/host_build_graph/runtime/async_wait.h
@@ -153,6 +153,17 @@ struct AsyncWaitList {
     // Read by scheduler shutdown / l2 perf summary; not on the hot path.
     std::atomic<uint64_t> mpsc_skipped_count{0};
 
+    // Empty state of a wait list sitting on the arena's device-only zone, whose
+    // bytes are whatever the pooled allocation last held. `count` bounds every
+    // read of entries[], and a drain assigns an entry in full before raising the
+    // count that admits it, so clearing the three scalars is the whole reset —
+    // the 190 KB entries[] region needs no per-bind sweep.
+    void reset_for_reuse() {
+        busy.store(0, std::memory_order_relaxed);
+        count = 0;
+        mpsc_skipped_count.store(0, std::memory_order_relaxed);
+    }
+
     bool try_lock() {
         int32_t expected = 0;
         return busy.compare_exchange_strong(expected, 1, std::memory_order_acquire, std::memory_order_relaxed);

--- a/src/common/host_build_graph/shared/runtime_init.cpp
+++ b/src/common/host_build_graph/shared/runtime_init.cpp
@@ -132,6 +132,12 @@ bool SchedulerState::init_data_from_layout(const SchedulerLayout &layout, Device
     ready_queue_init_data_from_layout(&sched->early_sync_start_queue, CHIP_EARLY_DISPATCH_QUEUE_SIZE);
     ready_queue_init_data_from_layout(&sched->ed_publish_drain_queue, CHIP_EARLY_DISPATCH_QUEUE_SIZE);
 
+    // The wait list shares the queues' device-only zone, so its bytes are the
+    // pooled allocation's previous generation too. A residual `count` is what
+    // the resolution thread's poll walks entries[] by, so it has to be reset
+    // here even though nothing in the list travels with the image.
+    sched->async_wait_list.reset_for_reuse();
+
     // Polling: no dep_pool arena region to initialize.
     (void)arena;
     (void)layout;

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -910,6 +910,12 @@ add_a2a3_hbg_runtime_test(test_hbg_core_tracker common/test_hbg_core_tracker.cpp
 # shared init TU (and the orchestrator/SM members that TU refers to).
 add_a2a3_hbg_runtime_test(test_hbg_ready_queue_seed common/test_hbg_ready_queue_seed.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_mailbox_init common/test_hbg_mailbox_init.cpp)
+# Same reason as the seed test: it drives the real init_data_from_layout.
+add_a2a3_hbg_runtime_test(test_hbg_async_wait_init common/test_hbg_async_wait_init.cpp)
+target_sources(test_hbg_async_wait_init PRIVATE
+    ${HBG_ORCH_SHARED_SOURCES}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+)
 add_a2a3_hbg_runtime_test(test_hbg_self_relative_ptr common/test_hbg_self_relative_ptr.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_sm_compaction common/test_hbg_sm_compaction.cpp)
 add_a2a3_hbg_runtime_test(test_hbg_scheduler_drain common/test_hbg_scheduler_drain.cpp)
@@ -1007,6 +1013,11 @@ target_sources(test_a5_hbg_slot_claim PRIVATE
 add_a5_hbg_runtime_test(test_a5_hbg_core_tracker common/test_hbg_core_tracker.cpp)
 add_a5_hbg_runtime_test(test_a5_hbg_ready_queue_seed common/test_hbg_ready_queue_seed.cpp)
 add_a5_hbg_runtime_test(test_a5_hbg_mailbox_init common/test_hbg_mailbox_init.cpp)
+add_a5_hbg_runtime_test(test_a5_hbg_async_wait_init common/test_hbg_async_wait_init.cpp)
+target_sources(test_a5_hbg_async_wait_init PRIVATE
+    ${HBG_ORCH_SHARED_SOURCES}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+)
 add_a5_hbg_runtime_test(test_a5_hbg_self_relative_ptr common/test_hbg_self_relative_ptr.cpp)
 add_a5_hbg_runtime_test(test_a5_hbg_sm_compaction common/test_hbg_sm_compaction.cpp)
 target_sources(test_a5_hbg_ready_queue_seed PRIVATE

--- a/tests/ut/cpp/common/test_hbg_async_wait_init.cpp
+++ b/tests/ut/cpp/common/test_hbg_async_wait_init.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The async wait list lives inside SchedulerState, which is reserved in the
+ * arena's device-only zone: no constructor runs over it and no image is copied
+ * onto it, so it reaches the AICPU holding whatever the pooled allocation last
+ * had. init_data_from_layout is what makes it an empty list.
+ *
+ * host_build_graph only: the tensormap_and_ringbuffer wait list travels with
+ * that runtime's uploaded image.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <new>
+
+#include "scheduler/scheduler.h"
+
+namespace {
+
+// Scheduler state on memory holding a prior generation's bytes, which is what
+// the pooled arena hands the AICPU. Deliberately no constructor and no
+// placement-new: the product reaches this object through region_ptr + a cast,
+// and value-initializing here would supply exactly the reset under test.
+class DirtySchedulerState {
+public:
+    explicit DirtySchedulerState(uint8_t fill) :
+        raw_(::operator new(sizeof(SchedulerState), std::align_val_t{alignof(SchedulerState)})) {
+        std::memset(raw_, fill, sizeof(SchedulerState));
+    }
+
+    ~DirtySchedulerState() { ::operator delete(raw_, std::align_val_t{alignof(SchedulerState)}); }
+
+    DirtySchedulerState(const DirtySchedulerState &) = delete;
+    DirtySchedulerState &operator=(const DirtySchedulerState &) = delete;
+
+    SchedulerState *get() { return reinterpret_cast<SchedulerState *>(raw_); }
+
+private:
+    void *raw_;
+};
+
+}  // namespace
+
+// The window this closes: a residual `count` is a length the resolution
+// thread's poll trusts. It reads entries[count - 1] before anything has written
+// an entry, so a fill large enough to land past the region faults on a wild
+// address instead of reporting an empty list (issue #2121).
+TEST(HbgAsyncWaitInit, DirtyDeviceZoneStartsEmpty) {
+    DeviceArena scheduler_arena;
+    DeviceArena sm_arena;
+    SharedMemoryHandle *sm_handle = SharedMemoryHandle::create_and_init_default(sm_arena);
+    ASSERT_NE(sm_handle, nullptr);
+    const SchedulerLayout layout = SchedulerState::reserve_layout(scheduler_arena);
+    DirtySchedulerState dirty(0xAA);
+    SchedulerState *sched = dirty.get();
+    ASSERT_NE(sched->async_wait_list.count, 0) << "the fill must reach the wait list for this to test anything";
+
+    ASSERT_TRUE(sched->init_data_from_layout(layout, scheduler_arena, sm_handle->header));
+
+    EXPECT_EQ(sched->async_wait_list.count, 0);
+    EXPECT_EQ(sched->async_wait_list.busy.load(std::memory_order_relaxed), 0);
+    EXPECT_EQ(sched->async_wait_list.mpsc_skipped_count.load(std::memory_order_relaxed), 0U);
+}
+
+// A residual `busy` is the quiet half of the same miss: the poll takes the list
+// only through try_lock, so a non-zero fill would make every drain a no-op and
+// strand deferred completions rather than crash.
+TEST(HbgAsyncWaitInit, DirtyDeviceZoneYieldsATakeableLock) {
+    DeviceArena scheduler_arena;
+    DeviceArena sm_arena;
+    SharedMemoryHandle *sm_handle = SharedMemoryHandle::create_and_init_default(sm_arena);
+    ASSERT_NE(sm_handle, nullptr);
+    const SchedulerLayout layout = SchedulerState::reserve_layout(scheduler_arena);
+    DirtySchedulerState dirty(0xFF);
+    SchedulerState *sched = dirty.get();
+
+    ASSERT_TRUE(sched->init_data_from_layout(layout, scheduler_arena, sm_handle->header));
+
+    EXPECT_TRUE(sched->async_wait_list.try_lock());
+    sched->async_wait_list.unlock();
+    EXPECT_TRUE(sched->async_wait_list.try_lock());
+}
+
+// Re-binding the same pooled region is the ordinary case, so the reset must
+// also recover a list an earlier run left holding entries.
+TEST(HbgAsyncWaitInit, RebindRecoversAListLeftPopulated) {
+    DeviceArena scheduler_arena;
+    DeviceArena sm_arena;
+    SharedMemoryHandle *sm_handle = SharedMemoryHandle::create_and_init_default(sm_arena);
+    ASSERT_NE(sm_handle, nullptr);
+    const SchedulerLayout layout = SchedulerState::reserve_layout(scheduler_arena);
+    DirtySchedulerState dirty(0x00);
+    SchedulerState *sched = dirty.get();
+    ASSERT_TRUE(sched->init_data_from_layout(layout, scheduler_arena, sm_handle->header));
+
+    sched->async_wait_list.count = 3;
+    ASSERT_TRUE(sched->async_wait_list.try_lock());
+
+    ASSERT_TRUE(sched->init_data_from_layout(layout, scheduler_arena, sm_handle->header));
+
+    EXPECT_EQ(sched->async_wait_list.count, 0);
+    EXPECT_TRUE(sched->async_wait_list.try_lock());
+}


### PR DESCRIPTION
Fixes #2121.

## What the fault actually is

Not the early-dispatch machinery. A native backtrace (`LD_PRELOAD` SIGSEGV handler with a register dump — `faulthandler` prints only the Python stack, which is why the issue could not name the faulting frame) puts it in the resolution thread:

```text
AsyncWaitList::poll_and_complete<false>+0xb8
  <- SchedulerContext::run_resolution_thread
  <- AicpuExecutor::run
```

`+0xb8` is the load of `entries[count - 1].condition_count`. Reconstructing `count` from the faulting registers across four captures: **58995, 59123, 65536** — against a bound of `MAX_ASYNC_WAITS == 64`. The read lands past the region on an unmapped page (`si_code == SEGV_MAPERR`).

## Why `count` is garbage

`SchedulerState` is reserved in the runtime arena's **device-only zone**: no constructor runs over it, no image is copied onto it, and `DeviceRunner` pools the buffer across runs. It reaches the AICPU holding whatever the previous generation left — which `aicpu_executor.cpp` already says in as many words.

Every other region in that zone is given an empty state by its own initializer:

| region | initializer |
| ------ | ----------- |
| queue headers | `ready_queue_init_data_from_layout` |
| queue slot ramps | `SchedulerState::seed_queue_slots` |
| completion mailbox | `AICoreCompletionMailbox::init_empty` |
| `sm_handle` | `memset` + `attach_populated` |
| **`AsyncWaitList`** | **none** |

So `count` is a residual length the P thread's poll trusts, and `busy` is the same miss inverted — the poll takes the list only through `try_lock`, so a non-zero fill would make every drain a no-op and strand deferred completions instead of crashing.

An instrumented boot read settles boot-garbage vs. mid-run corruption:

```text
BAD count=59123 boot_count=59123 boot_busy=0 raw64=0xe6f3 next64=0x0
```

`boot_count == count`, and the 8 bytes at that offset are `0xe6f3` with a zero upper half — leftover data, not a stray write from any code path.

## The fix

The `tensormap_and_ringbuffer` twin already resets its wait list from the equivalent point via `AsyncWaitList::reset_for_reuse()`. hbg's forked copy of `async_wait.h` lost the method; this restores it under the same name in both arch copies and calls it beside the queue initializers in the shared `SchedulerState::init_data_from_layout`, which both the a2a3 and the a5 hbg boot paths reach.

`entries` itself still needs no sweep — a drain assigns an entry in full before raising the count that admits it, so the three scalars are the whole reset and the 190 KB array stays untouched per bind.

## Why it looked new, and why #2095 is not at fault

> The commit message states this section's mechanism less precisely (it says #2095 "moved `count` to another offset"). `count`'s offset did **not** move; the text below is the corrected account.

`count`'s offset is unchanged by #2095. That PR added exactly two members to `SchedulerState` — `ed_publish_drain_queue` and `ed_publish_drain_drops` — and both are declared *after* `async_wait_list`. The doorbell table and the other early-dispatch queues predate it (#2095 wired up machinery it describes as already "dormant"). So:

```text
offsetof(SchedulerState, async_wait_list)  = 1856      unchanged
offsetof(AsyncWaitList,  count)            = 198664    unchanged
→ count within SchedulerState              = 200520    unchanged
→ count within the arena = off_scheduler + 200520      unchanged
  (off_scheduler is preceded only by sm_handle + the mailbox, neither touched)
```

What #2095 changed is the arena's **total size**: +192 B for one more `ChipReadyQueue` header, +64 B for the drop counter and its alignment, and +1536 B for the 64-slot reservation that queue needs — about +1.8 KB on a ~4 MB arena.

The arena is one `malloc(N)` that nobody zeroes. `count` is whatever the previous owner of those four bytes left there. Changing `N` changes which heap block the allocator hands back, and therefore which generation's residue sits under a fixed offset:

```text
before: malloc(N0)        -> A0 ;  A0+off = 00 00 00 00  -> count = 0      -> poll returns, bug invisible
after:  malloc(N0 + 1792) -> A1 ;  A1+off = 73 e6 00 00  -> count = 58995  -> entries[58994] is ~183 MB out
```

The three observed values (58995, 59123, 65536) all read as stale data rather than anything the runtime writes — `0x10000` in particular looks like a leftover size field.

This also explains the two facts the issue reports. **The case alone never reproduces it** because a fresh process's large allocation comes back zeroed, whereas in a directory sweep the chip child is forked from a pytest worker whose heap a dozen earlier tests have already dirtied. **All four crashes were the same case** because the arena size also depends on each test's own `task_capacity`, so every scene test has a different `N` — #2095 introduced a new test and therefore a new `N`, and that is the one that lands on a dirty block.

Strictly, #2095 is not even a necessary condition: any change to arena size, reservation order, or process heap history can make this appear or disappear. It is simply the change that happened to trip it. Nothing in the early-dispatch path writes to that address.

## Verification

- **Repro sweep** `pytest tests/st/a2a3/host_build_graph -n 4 --platform a2a3sim --device 0-15`, host load average 40–60 to match the issue's conditions: **4 segfaults in 133 sweeps before the fix, 0 in 120 sweeps after.** (The commit message says "~90 sweeps" for the before figure; 133 is the correct count, so the real pre-fix rate is 3.0%, not 4.4%. Breakdown: 2 crashes in a 48-sweep loop, 0 in 30, then 1 each in two loops stopped at sweeps 20 and 27 on the capture, plus 8 clean sweeps in an earlier loop.)
- Separately, on an instrumented build carrying a range check on `count`, two loops caught the out-of-range value at sweeps 5 and 2 (`BAD count=59123 boot_count=59123`) — those were intercepted rather than allowed to fault, so they are not in the 4 above.
- **New ut-cpp** `test_hbg_async_wait_init` (registered for both arches) drives the real `init_data_from_layout` over 0xAA/0xFF-filled scheduler storage — no placement-new, since value-initializing would supply the very reset under test. All three cases fail without the fix (`count` reads back `-1431655766`, `try_lock` refuses) and pass with it.
- `ctest -LE requires_hardware`: **134/134 pass**.
- Scene suites: `examples tests/st --platform a2a3sim` and `--platform a5sim` both exit 0, hbg and tmr groups PASS.
- pre-commit clean.

## Not covered

Onboard (`--platform a2a3` / `a5`) was not run — the change is in a host-CPU-side boot path shared by sim and onboard, and CI's hardware jobs will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
