### PR TITLE
Refactor: reduce the clock anchor to one offset reading

### DIFF
--- a/docs/dfx/chip-swimlane-profiling.md
+++ b/docs/dfx/chip-swimlane-profiling.md
@@ -197,10 +197,12 @@ rejected until the layout also carries a node namespace. Every Rank must expose
 the same complete set of local capture indexes; the postprocessor refuses
 asymmetric sets instead of guessing pairings.
 
-Cross-Rank merging needs `--enable-chip-swimlane 4` on every Rank, because the
-Host/Device clock anchors that level 4 collects are what put the Ranks on a
-common timeline. A lower level still captures per Rank; the postprocessor then
-converts each `rankN/dN` capture on its own relative timeline and says so.
+Cross-Rank merging needs `--enable-chip-swimlane 4` on every Rank, because
+`_validate_l3_rank_data` requires the level outright: only level 4 carries the
+orchestrator phase records the merge is built around. The Host/Device clock
+anchors no longer gate it — every enabled level collects them, so a lower level
+is converted onto the Host timeline too, and it is the merge alone that
+refuses it.
 
 `chip_swimlane_records.json` carries the raw records. **There are two
 layers to be aware of:**
@@ -399,38 +401,44 @@ remains the compatibility selector for old captures and for independently
 submitted per-Rank tasks; it fails if available sidecars show that the selected
 paths belong to different parent groups.
 
-Host-orchestrated level-4 runs retain their existing clock anchors. For
-Device/AICPU orchestration, anchors are additionally enabled only when the
-ChipWorker marks the capture with `CallConfig.capture_clock_anchors`, which it
-does for an L3 chip-swimlane capture, at the common launch boundary before
-collectors and kernels start. Both modes sample again after AICPU/AICore
-execution completes. Existing single-card Device/AICPU level-4 captures
-therefore keep their prior relative timeline and do not pay the new anchor cost.
+A swimlane capture places its device records on the Host clock, so enabling the
+swimlane enables the anchor. `CallConfig.capture_clock_anchors` remains an
+internal marker set by a ChipWorker child; it does not produce a standalone
+artifact without the swimlane.
 
-`capture_clock_anchors` says only *what the runtime does* — sample the two
-clocks — never why. Rank, group and merge are concepts of the layer above: the
-platform runner that reads this flag has no notion of a Rank, and no runtime or
-platform code parses the `rankN/dN` path. The two are deliberately separate
-switches, because the directory is artifact separation that every diagnostic
-needs while the anchors are consumed only by the swimlane reader. An L3 run with
-`--enable-dep-gen` alone therefore gets its own `rankN/dN` directory and pays no
-anchor cost.
+Rank, group and merge are concepts of the layer above: the platform runner has
+no notion of a Rank, and no runtime or platform code parses the `rankN/dN`
+path. The marker and the `rankN/dN` directory are separate because the
+directory provides artifact separation for every diagnostic. An L3 run with
+`--enable-dep-gen` alone therefore gets its own `rankN/dN` directory and pays
+no anchor cost.
 
-**The opening anchor sits at a different point in each runtime**, because each
-takes it at the earliest point preceding every device timestamp it records:
+**Both runtimes take one reading, at the same point** — the launch boundary,
+before collectors and kernels start. Onboard reaches it through
+`start_shared_collectors_for_run()`; the sim platform has no such function and
+calls `begin_clock_correlation_session_if_needed()` inline in
+`launch_execution`. For `host_build_graph` this moved the reading from bind
+(`host_phase_pool_arm`) to launch, so it no longer precedes that runtime's Host
+orchestration phases — which a single offset reading does not require.
 
-| Runtime | Opening anchor | Calibrated interval covers |
-| ------- | -------------- | -------------------------- |
-| `host_build_graph` | before Host orchestration (`host_phase_pool_arm`) | bind, H2D, and execution |
-| `tensormap_and_ringbuffer` | before kernel launch (`start_shared_collectors_for_run`) | execution only |
+One reading is sufficient because it supplies an **offset** and nothing else:
+the scale is the platform's counter frequency. It therefore pins the two clock
+domains rather than bounding an interval the records must fall inside, and a
+timestamp either side of it maps by the same arithmetic — which is why the
+placement no longer has to precede every device timestamp a runtime records.
 
-Both close on `post_device_execution`. So the two runtimes' calibrated intervals
-are not comparable in length, and a `host_build_graph` interpolation spans work
-a `tensormap_and_ringbuffer` one does not. This does not affect
-`max_uncertainty_ns`, which depends only on each anchor group's own sampling
-RTT. The serialized position name `pre_host_orchestration` predates the
-Device/AICPU case — read it as "start of the calibrated interval", not as a
-claim about Host orchestration.
+```text
+host_ns(cycles) = anchor.host_mid_ns + (cycles - anchor.device_cycles) × 1e9 / clock_freq_hz
+```
+
+`max_uncertainty_ns` is half the selected sample's Host bracket round trip,
+plus Device and Host timestamp quantization; comparing two devices costs the
+sum of their two. The serialized position name `pre_host_orchestration` is an
+on-wire value in every existing capture — read it as the offset reading.
+
+Captures written before this shape can also carry a `post_device_execution`
+group. The reader ignores it; only the offset reading participates in the
+mapping.
 
 The default output depends on which input form was used, and `-o` overrides
 either:

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -220,7 +220,7 @@ struct CallConfig {
     int32_t enable_pmu = 0;           // 0 = disabled; >0 selects PMU event type
     int32_t enable_dep_gen = 0;
     int32_t enable_scope_stats = 0;
-    int32_t capture_clock_anchors = 0; // set by the ChipWorker child, not by callers
+    int32_t capture_clock_anchors = 0; // internal ChipWorker marker; not a caller knob
     char    output_prefix[1024] = {};
     // future fields here - same POD used at all levels
 };

--- a/docs/user/reference/python-api.md
+++ b/docs/user/reference/python-api.md
@@ -140,7 +140,7 @@ takes a device pointer; `DataType` carries the element types.
 | `enable_pmu` | `0` | `0` off; `>0` selects the event type |
 | `enable_dep_gen` | `0` | Emit the dependency graph |
 | `enable_scope_stats` | `0` | Writes `<output_prefix>/scope_stats/scope_stats.jsonl` |
-| `capture_clock_anchors` | `False` | Anchors the Host and Device clocks so device timestamps land on an absolute Host timeline. Set by the ChipWorker child for an L3 chip-swimlane capture; not a caller knob |
+| `capture_clock_anchors` | `False` | Internal marker set by a ChipWorker child for an L3 chip-swimlane capture; not a caller knob. Enabling the chip swimlane anchors its Host and Device clocks |
 | `output_prefix` | `""` | **Required whenever any diagnostic is enabled** |
 | `runtime_env` | — | `ring_task_window`, `ring_heap`, `ring_dep_pool`; `tensormap_and_ringbuffer` only |
 

--- a/simpler_setup/tools/clock_correlation.py
+++ b/simpler_setup/tools/clock_correlation.py
@@ -8,12 +8,18 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
+"""Map device timestamps onto the Host CLOCK_MONOTONIC axis.
+
+The platform counter frequency supplies the scale. One paired Host/Device
+reading supplies the offset, and the same mapping applies on either side of
+that reading.
+"""
+
 from dataclasses import dataclass
 from typing import Optional
 
-_A0_POSITION = "pre_host_orchestration"
-_A2_POSITION = "post_device_execution"
-_METHOD = "nominal_frequency_offset_interp_v1"
+_ANCHOR_POSITION = "pre_host_orchestration"
+_METHOD = "nominal_frequency_offset_v1"
 
 
 @dataclass(frozen=True)
@@ -32,16 +38,14 @@ class ClockAlignment:
     reason: Optional[str]
     frequency_hz: int
     host_timestamp_quantization_ns: int = 0
-    start: Optional[ClockAnchor] = None
-    end: Optional[ClockAnchor] = None
-    pre_anchor_group_duration_ns: Optional[int] = None
-    post_anchor_group_duration_ns: Optional[int] = None
+    anchor: Optional[ClockAnchor] = None
+    anchor_group_duration_ns: Optional[int] = None
 
     @property
     def anchor_uncertainty_ns(self):
-        if self.start is None or self.end is None:
+        if self.anchor is None:
             return None
-        return max(self.start.uncertainty_ns, self.end.uncertainty_ns)
+        return self.anchor.uncertainty_ns
 
     @property
     def max_uncertainty_ns(self):
@@ -59,40 +63,17 @@ class ClockAlignment:
         }
         if self.reason is not None:
             out["reason"] = self.reason
-        if self.start is not None and self.end is not None:
-            out["selected_sample_idx"] = {
-                self.start.position: self.start.sample_idx,
-                self.end.position: self.end.sample_idx,
-            }
-        group_durations = {
-            _A0_POSITION: self.pre_anchor_group_duration_ns,
-            _A2_POSITION: self.post_anchor_group_duration_ns,
-        }
-        if any(duration is not None for duration in group_durations.values()):
-            out["anchor_group_duration_ns"] = group_durations
+        if self.anchor is not None:
+            out["selected_sample_idx"] = {self.anchor.position: self.anchor.sample_idx}
+        if self.anchor_group_duration_ns is not None:
+            out["anchor_group_duration_ns"] = {_ANCHOR_POSITION: self.anchor_group_duration_ns}
         return out
 
-    def contains(self, device_cycles):
-        return (
-            self.status == "calibrated"
-            and self.start is not None
-            and self.end is not None
-            and self.start.device_cycles <= device_cycles <= self.end.device_cycles
-        )
-
     def map_cycles_to_host_ns(self, device_cycles):
-        if self.start is None or self.end is None or not self.contains(device_cycles):
-            raise ValueError(f"device timestamp {device_cycles} is outside calibrated anchor coverage")
-
-        start = self.start
-        end = self.end
-        delta_cycles = device_cycles - start.device_cycles
-        span_cycles = end.device_cycles - start.device_cycles
-        nominal_delta_ns = _mul_div_toward_zero(delta_cycles, 1_000_000_000, self.frequency_hz)
-        nominal_end_ns = start.host_mid_ns + _mul_div_toward_zero(span_cycles, 1_000_000_000, self.frequency_hz)
-        end_correction_ns = end.host_mid_ns - nominal_end_ns
-        correction_ns = _mul_div_toward_zero(end_correction_ns, delta_cycles, span_cycles)
-        return start.host_mid_ns + nominal_delta_ns + correction_ns
+        if self.anchor is None:
+            raise ValueError(f"device timestamp {device_cycles} has no calibration anchor")
+        delta_cycles = device_cycles - self.anchor.device_cycles
+        return self.anchor.host_mid_ns + _mul_div_toward_zero(delta_cycles, 1_000_000_000, self.frequency_hz)
 
 
 def _mul_div_toward_zero(value, multiplier, divisor):
@@ -137,10 +118,10 @@ def _parse_anchor(sample, position, device_quantization_ns):
     )
 
 
-def _anchor_group_duration_ns(samples, position):
+def _anchor_group_duration_ns(samples):
     bounds = []
     for sample in samples:
-        if not isinstance(sample, dict) or sample.get("position") != position:
+        if not isinstance(sample, dict) or sample.get("position") != _ANCHOR_POSITION:
             continue
         try:
             before = int(sample["host_before_ns"])
@@ -154,70 +135,58 @@ def _anchor_group_duration_ns(samples, position):
     return max(after for _, after in bounds) - min(before for before, _ in bounds)
 
 
-def build_clock_alignment(  # noqa: PLR0912
-    clock_anchors, frequency_hz, device_timestamps=(), host_timestamp_quantization_ns=0
-):
-    host_timestamp_quantization_ns = int(host_timestamp_quantization_ns)
+def _resolve_samples(clock_anchors, frequency_hz, host_timestamp_quantization_ns):
+    """Return `(samples, device_quantization_ns, reason)`; `reason` names the refusal."""
     if host_timestamp_quantization_ns < 0:
-        return _unaligned(frequency_hz, "invalid_host_timestamp_quantization")
+        return None, 0, "invalid_host_timestamp_quantization"
     if frequency_hz <= 0:
-        return _unaligned(frequency_hz, "invalid_device_frequency", host_timestamp_quantization_ns)
+        return None, 0, "invalid_device_frequency"
     if not isinstance(clock_anchors, dict):
-        return _unaligned(frequency_hz, "missing_clock_anchors", host_timestamp_quantization_ns)
+        return None, 0, "missing_clock_anchors"
     samples = clock_anchors.get("samples")
     if not isinstance(samples, list):
-        return _unaligned(frequency_hz, "missing_clock_anchor_samples", host_timestamp_quantization_ns)
+        return None, 0, "missing_clock_anchor_samples"
     if clock_anchors.get("device_timestamp_unit") != "syscnt_cycles":
-        return _unaligned(frequency_hz, "unsupported_device_timestamp_unit", host_timestamp_quantization_ns)
+        return None, 0, "unsupported_device_timestamp_unit"
     raw_unit = clock_anchors.get("raw_device_timestamp_unit", "syscnt_cycles")
     if raw_unit == "device_uptime_us":
         # aclrtEventGetTimestamp has microsecond resolution. Normalizing it to
         # cycles does not recover the discarded sub-microsecond portion.
-        device_quantization_ns = 1_000
-    elif raw_unit == "syscnt_cycles":
-        device_quantization_ns = 0
-    else:
-        return _unaligned(frequency_hz, "unsupported_raw_device_timestamp_unit", host_timestamp_quantization_ns)
+        return samples, 1_000, None
+    if raw_unit == "syscnt_cycles":
+        return samples, 0, None
+    return None, 0, "unsupported_raw_device_timestamp_unit"
 
-    valid_by_position = {_A0_POSITION: [], _A2_POSITION: []}
+
+def build_clock_alignment(clock_anchors, frequency_hz, host_timestamp_quantization_ns=0):
+    host_timestamp_quantization_ns = int(host_timestamp_quantization_ns)
+    samples, device_quantization_ns, reason = _resolve_samples(
+        clock_anchors, frequency_hz, host_timestamp_quantization_ns
+    )
+    if samples is None:
+        # A negative host quantization is not a usable value to report back.
+        return _unaligned(frequency_hz, reason, max(host_timestamp_quantization_ns, 0))
+
+    candidates = []
     for sample in samples:
-        if not isinstance(sample, dict):
+        if not isinstance(sample, dict) or sample.get("position") != _ANCHOR_POSITION:
             continue
-        position = sample.get("position")
-        if position not in valid_by_position:
-            continue
-        anchor = _parse_anchor(sample, position, device_quantization_ns)
-        if anchor is not None:
-            valid_by_position[position].append(anchor)
+        parsed = _parse_anchor(sample, _ANCHOR_POSITION, device_quantization_ns)
+        if parsed is not None:
+            candidates.append(parsed)
 
-    if not valid_by_position[_A0_POSITION]:
-        return _unaligned(frequency_hz, "no_valid_pre_host_orchestration_anchor", host_timestamp_quantization_ns)
-    if not valid_by_position[_A2_POSITION]:
-        return _unaligned(frequency_hz, "no_valid_post_device_execution_anchor", host_timestamp_quantization_ns)
+    if not candidates:
+        return _unaligned(frequency_hz, "no_valid_anchor", host_timestamp_quantization_ns)
 
-    start = min(valid_by_position[_A0_POSITION], key=lambda anchor: (anchor.rtt_ns, anchor.sample_idx))
-    end = min(valid_by_position[_A2_POSITION], key=lambda anchor: (anchor.rtt_ns, anchor.sample_idx))
-    if end.host_mid_ns <= start.host_mid_ns:
-        return _unaligned(frequency_hz, "host_anchor_order_invalid", host_timestamp_quantization_ns)
-    if end.device_cycles <= start.device_cycles:
-        return _unaligned(frequency_hz, "device_anchor_order_invalid", host_timestamp_quantization_ns)
+    # A wider bracket means a less certain instant, so the narrowest round trip
+    # is the sharpest reading of the pair; sample_idx breaks ties reproducibly.
+    anchor = min(candidates, key=lambda candidate: (candidate.rtt_ns, candidate.sample_idx))
 
-    alignment = ClockAlignment(
+    return ClockAlignment(
         status="calibrated",
         reason=None,
         frequency_hz=frequency_hz,
         host_timestamp_quantization_ns=host_timestamp_quantization_ns,
-        start=start,
-        end=end,
-        pre_anchor_group_duration_ns=_anchor_group_duration_ns(samples, _A0_POSITION),
-        post_anchor_group_duration_ns=_anchor_group_duration_ns(samples, _A2_POSITION),
+        anchor=anchor,
+        anchor_group_duration_ns=_anchor_group_duration_ns(samples),
     )
-    for timestamp in device_timestamps:
-        timestamp = int(timestamp)
-        if timestamp > 0 and not alignment.contains(timestamp):
-            return _unaligned(
-                frequency_hz,
-                "device_timestamps_outside_anchor_coverage",
-                host_timestamp_quantization_ns,
-            )
-    return alignment

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -424,28 +424,15 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
     if base_time_cycles is None:
         base_time_cycles = 0
 
-    device_timestamps = []
-    for row in aicore_rows:
-        start_cycles = int(row[3])
-        receive_to_start_cycles = int(row[5]) if len(row) > 5 else 0
-        device_timestamps.extend((start_cycles - receive_to_start_cycles, start_cycles, int(row[4])))
-    for _, _, dispatch_cycles, finish_cycles in aicpu_rows:
-        device_timestamps.extend((int(dispatch_cycles), int(finish_cycles)))
-    for phase_threads in (sched_phases_raw, orch_phases_raw):
-        for thread_records in phase_threads:
-            for phase in thread_records:
-                device_timestamps.extend((int(phase.get("start_cycles", 0)), int(phase.get("end_cycles", 0))))
-
     clock_alignment = None
     if host_mode or clock_anchor_mode:
         clock_alignment = build_clock_alignment(
             metadata.get("clock_anchors"),
             clock_freq_hz,
-            device_timestamps,
             metadata.get("host_timestamp_quantization_ns", 0),
         )
-        if host_origin_ns == 0 and clock_alignment.start is not None:
-            host_origin_ns = clock_alignment.start.host_mid_ns
+        if host_origin_ns == 0 and clock_alignment.anchor is not None:
+            host_origin_ns = clock_alignment.anchor.host_mid_ns
 
     source_host_origin_ns = host_origin_ns
     if timeline_origin_ns is not None:

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -694,7 +694,7 @@ int DeviceRunner::reap_run() {
         // JSON manifest, i.e. unusable for triage. reconcile/export are not
         // idempotent, so this runs only on the error return; the success path
         // still exports exactly once below.
-        teardown_shared_collectors_after_run(false);
+        teardown_shared_collectors_after_run();
         return rc;
     }
 
@@ -702,7 +702,7 @@ int DeviceRunner::reap_run() {
 
     // Tear down collectors. stop() joins mgmt then collector in the only safe
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
-    teardown_shared_collectors_after_run(true);
+    teardown_shared_collectors_after_run();
 
     // a2a3-only dep_gen teardown: host-orch emits the graph its orchestration
     // built on this same thread; device-orch stops the collector, reconciles the

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -558,7 +558,7 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
                     return create_thread(std::move(fn));
                 };
                 if (enable_chip_swimlane_) {
-                    if (capture_clock_anchors_) begin_clock_correlation_session_if_needed();
+                    begin_clock_correlation_session_if_needed();
                     chip_swimlane_collector_.start(thread_factory);
                 }
                 if (enable_dump_args_) dump_collector_.start(thread_factory);
@@ -683,13 +683,13 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
     int runtime_rc = run_completion_.first_error();
     if (runtime_rc != 0) {
         LOG_ERROR("AICPU execution failed with rc=%d", runtime_rc);
-        finish_clock_correlation_session(false);
+        finish_clock_correlation_session();
         return runtime_rc;
     }
 
     // Tear down collectors. stop() joins mgmt then collector in the only safe
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
-    finish_clock_correlation_session(true);
+    finish_clock_correlation_session();
     if (enable_chip_swimlane_) {
         chip_swimlane_collector_.stop();
         chip_swimlane_collector_.read_phase_header_metadata();

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -615,12 +615,12 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
         recover_device_or_mark_unusable(rc);
         // Emergency shutdown may already have flushed diagnostics. Export the
         // manifest on the error path exactly once.
-        teardown_shared_collectors_after_run(false);
+        teardown_shared_collectors_after_run();
         return rc;
     }
 
     read_device_wall_ns();
-    teardown_shared_collectors_after_run(true);
+    teardown_shared_collectors_after_run();
 
     // a5-specific dep_gen teardown: host-orch emits the graph its orchestration
     // built on this same thread; device-orch stops the collector, reconciles the

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -530,7 +530,7 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
                     return create_thread(std::move(fn));
                 };
                 if (enable_chip_swimlane_) {
-                    if (capture_clock_anchors_) begin_clock_correlation_session_if_needed();
+                    begin_clock_correlation_session_if_needed();
                     chip_swimlane_collector_.start(thread_factory);
                 }
                 if (enable_dump_args_) dump_collector_.start(thread_factory);
@@ -656,13 +656,13 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
     int runtime_rc = run_completion_.first_error();
     if (runtime_rc != 0) {
         LOG_ERROR("AICPU execution failed with rc=%d", runtime_rc);
-        finish_clock_correlation_session(false);
+        finish_clock_correlation_session();
         return runtime_rc;
     }
 
     // Tear down collectors. stop() joins mgmt then collector in the only safe
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
-    finish_clock_correlation_session(true);
+    finish_clock_correlation_session();
     if (enable_chip_swimlane_) {
         chip_swimlane_collector_.stop();
         chip_swimlane_collector_.read_phase_header_metadata();

--- a/src/common/platform/include/host/clock_correlation.h
+++ b/src/common/platform/include/host/clock_correlation.h
@@ -21,22 +21,17 @@ namespace simpler::dfx {
 
 constexpr std::size_t kClockAnchorSamplesPerPosition = 3;
 
-// The two ends of the calibrated interval. Device timestamps outside
-// [HostOrchestrationBegin, DeviceExecutionComplete] cannot be mapped to the
-// Host clock, so the opening anchor is taken at whatever point in a runtime's
-// sequence precedes every device timestamp it will record:
+// Where in a run the paired reading is taken. It supplies the offset that maps
+// this device's timestamps onto the Host clock; the scale comes from the
+// platform's counter frequency, so one reading is enough and it pins the two
+// domains rather than bounding an interval they must fall inside. A timestamp
+// either side of it maps by the same arithmetic.
 //
-//   host_build_graph            before Host orchestration (host_phase_pool_arm),
-//                               so the interval also spans bind and H2D
-//   tensormap_and_ringbuffer    before kernel launch (start_shared_collectors_
-//                               for_run), the earliest point it has
-//
-// The serialized name "pre_host_orchestration" predates the second case and is
-// kept because it is an on-wire value in every existing capture; read it as
-// "start of the calibrated interval", not as a claim about Host orchestration.
+// The serialized name stays "pre_host_orchestration": it is an on-wire value in
+// every existing capture. It names a position in one runtime's sequence, which
+// both runtimes no longer share — read it as the offset reading.
 enum class ClockAnchorPosition : uint32_t {
-    HostOrchestrationBegin = 0,
-    DeviceExecutionComplete = 1,
+    HostOffset = 0,
 };
 
 enum class ClockAnchorErrorStage : uint32_t {
@@ -49,7 +44,7 @@ enum class ClockAnchorErrorStage : uint32_t {
 };
 
 struct ClockAnchorSample {
-    ClockAnchorPosition position{ClockAnchorPosition::HostOrchestrationBegin};
+    ClockAnchorPosition position{ClockAnchorPosition::HostOffset};
     uint32_t sample_idx{0};
     uint64_t host_before_ns{0};
     // Exact backend value plus the same instant normalized to the platform

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -663,7 +663,7 @@ static int cleanup_failed_prepare(OnboardNativeRunContext *state, int execution_
     char trace_attrs[sizeof(state->trace_attrs)];
     std::memcpy(trace_attrs, state->trace_attrs, sizeof(trace_attrs));
     if (clear_gm_sm) state->runtime.set_gm_sm_ptr(nullptr);
-    state->runner->finish_clock_correlation_session(false, !state->runner->can_accept_run());
+    state->runner->finish_clock_correlation_session(!state->runner->can_accept_run());
     int validation_rc = PTO_RUNTIME_ERR_INTERNAL;
     try {
         validation_rc = validate_runtime_impl(&state->runtime, &state->host_api, execution_rc);
@@ -1034,7 +1034,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
     // Correlation state is runner-wide. Finish it before releasing either
     // ownership token, after which a successor may begin capture and replace
     // the provider/session.
-    state->runner->finish_clock_correlation_session(false, !state->runner->can_accept_run());
+    state->runner->finish_clock_correlation_session(!state->runner->can_accept_run());
     if (state->runner_claimed) {
         // The point a successor's launch becomes admissible. Ordering a
         // successor's device work against this boundary is what separates a

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -1281,15 +1281,12 @@ void DeviceRunnerBase::apply_call_config(const CallConfig &config) {
     // without dep_gen falls through to the base no-op.
     set_dep_gen_enabled(config.enable_dep_gen != 0);
     set_scope_stats_enabled(config.enable_scope_stats != 0);
-    capture_clock_anchors_ = config.capture_clock_anchors != 0;
+    // Every swimlane artifact carries Host/Device clock correlation.
+    capture_clock_anchors_ = config.capture_clock_anchors != 0 || config.enable_chip_swimlane != 0;
     set_output_prefix(config.output_prefix);
 }
 
 HostPhaseRecordPool *DeviceRunnerBase::host_phase_pool_arm(bool producer_wants_records) noexcept {
-    if (clock_correlation_provider_ != nullptr) {
-        clock_correlation_provider_->release(false);
-        clock_correlation_provider_.reset();
-    }
     const bool swimlane_wants_records = chip_swimlane_level_ == ChipSwimlaneLevel::ORCH_PHASES;
     const bool artifact_wants_records = producer_wants_records && !output_prefix_.empty();
     chip_swimlane_collector_.set_host_orchestrated(swimlane_wants_records);
@@ -1302,14 +1299,11 @@ HostPhaseRecordPool *DeviceRunnerBase::host_phase_pool_arm(bool producer_wants_r
     } catch (...) {
         LOG_WARN("Host phase pool could not be armed; this pass collects no per-event records");
     }
-    if (!swimlane_wants_records) return pool;
-
-    begin_clock_correlation_session_if_needed();
     return pool;
 }
 
 void DeviceRunnerBase::begin_clock_correlation_session_if_needed() noexcept {
-    if (chip_swimlane_level_ != ChipSwimlaneLevel::ORCH_PHASES || chip_swimlane_collector_.clock_correlation_active()) {
+    if (!capture_clock_anchors_ || chip_swimlane_collector_.clock_correlation_active()) {
         return;
     }
     try {
@@ -1319,7 +1313,7 @@ void DeviceRunnerBase::begin_clock_correlation_session_if_needed() noexcept {
         );
         chip_swimlane_collector_.record_clock_anchor_samples(
             simpler::dfx::capture_clock_anchor_group(
-                *clock_correlation_provider_, simpler::dfx::ClockAnchorPosition::HostOrchestrationBegin
+                *clock_correlation_provider_, simpler::dfx::ClockAnchorPosition::HostOffset
             )
         );
     } catch (...) {
@@ -1343,25 +1337,13 @@ void DeviceRunnerBase::publish_host_phase_records_to_swimlane() {
     );
 }
 
-void DeviceRunnerBase::finish_clock_correlation_session(
-    bool capture_device_complete, bool abandon_device_resources
-) noexcept {
+void DeviceRunnerBase::finish_clock_correlation_session(bool abandon_device_resources) noexcept {
     if (!chip_swimlane_collector_.clock_correlation_active()) {
         if (clock_correlation_provider_ != nullptr) {
             clock_correlation_provider_->release(abandon_device_resources);
             clock_correlation_provider_.reset();
         }
         return;
-    }
-
-    if (capture_device_complete && clock_correlation_provider_ != nullptr) {
-        try {
-            chip_swimlane_collector_.record_clock_anchor_samples(
-                simpler::dfx::capture_clock_anchor_group(
-                    *clock_correlation_provider_, simpler::dfx::ClockAnchorPosition::DeviceExecutionComplete
-                )
-            );
-        } catch (...) {}
     }
     chip_swimlane_collector_.finish_clock_correlation_session();
     if (clock_correlation_provider_ != nullptr) {
@@ -1400,7 +1382,7 @@ int DeviceRunnerBase::finalize_common_impl(bool abandon_device_resources) {
         if (err != 0 && rc == 0) rc = err;
     };
 
-    finish_clock_correlation_session(false, abandon_device_resources);
+    finish_clock_correlation_session(abandon_device_resources);
 
     // Teardown invariant: finalize_common() is the single place that releases
     // every RTS/device-owning resource, and the subclass runs it BEFORE its
@@ -1893,7 +1875,7 @@ void DeviceRunnerBase::start_shared_collectors_for_run() {
         return create_thread(std::move(fn));
     };
     if (enable_chip_swimlane_) {
-        if (capture_clock_anchors_) begin_clock_correlation_session_if_needed();
+        begin_clock_correlation_session_if_needed();
         chip_swimlane_collector_.start(thread_factory);
     }
     if (enable_dump_args_) {
@@ -1921,12 +1903,12 @@ void DeviceRunnerBase::write_host_phase_records_artifact() {
     }
 }
 
-void DeviceRunnerBase::teardown_shared_collectors_after_run(bool device_execution_complete) {
+void DeviceRunnerBase::teardown_shared_collectors_after_run() {
     // Tear down collectors. stop() joins mgmt then collector in the only safe
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
     // Diagnostic exports use the per-task `output_prefix_` directory the user
     // set on CallConfig (CallConfig::validate() enforces non-empty upstream).
-    finish_clock_correlation_session(device_execution_complete, !can_accept_run());
+    finish_clock_correlation_session(!can_accept_run());
     if (enable_chip_swimlane_) {
         chip_swimlane_collector_.stop();
         chip_swimlane_collector_.read_phase_header_metadata();

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -740,7 +740,7 @@ public:
     const simpler::dfx::HostPhaseRecordStore &host_phase_records() const { return host_phase_records_; }
     /** Hand this pass's records to the swimlane reader, just before its export. */
     void publish_host_phase_records_to_swimlane();
-    /** Start the level-4 Host/Device clock correlation once per run. */
+    /** Start the Host/Device clock correlation once per swimlane run. */
     void begin_clock_correlation_session_if_needed() noexcept;
     /**
      * Write this pass's per-event host phase records to `output_prefix_`.
@@ -751,7 +751,7 @@ public:
      * every path that can end a run may call this unconditionally.
      */
     void write_host_phase_records_artifact();
-    void finish_clock_correlation_session(bool capture_device_complete, bool abandon_device_resources) noexcept;
+    void finish_clock_correlation_session(bool abandon_device_resources) noexcept;
     void set_dump_args_enabled(int level) {
         dump_args_level_ = static_cast<DumpArgsLevel>(level);
         enable_dump_args_ = (dump_args_level_ != DumpArgsLevel::OFF);
@@ -979,7 +979,7 @@ protected:
      * `dep_gen_collector_` + its `dep_gen_replay_emit_deps_json` export)
      * inline their own teardown after calling this helper.
      */
-    void teardown_shared_collectors_after_run(bool device_execution_complete);
+    void teardown_shared_collectors_after_run();
 
     /**
      * Shared body of `finalize()`. Each arch subclass's `finalize()`
@@ -1301,6 +1301,7 @@ protected:
     bool enable_scope_stats_{false};
     ChipSwimlaneLevel chip_swimlane_level_{ChipSwimlaneLevel::DISABLED};  // resolved from set_chip_swimlane_enabled()
     PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};         // resolved from set_pmu_enabled()
-    bool capture_clock_anchors_{false};                                   // from CallConfig::capture_clock_anchors
-    std::string output_prefix_{};                                         // diagnostic artifact root directory
+    // Set by CallConfig::capture_clock_anchors or by the swimlane being enabled.
+    bool capture_clock_anchors_{false};
+    std::string output_prefix_{};  // diagnostic artifact root directory
 };

--- a/src/common/platform/shared/host/chip_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/chip_swimlane_collector.cpp
@@ -1060,7 +1060,7 @@ int ChipSwimlaneCollector::export_swimlane_json() {
     if (clock_correlation_session_.started()) {
         uint64_t host_timeline_origin_ns = 0;
         for (const auto &sample : clock_correlation_session_.samples()) {
-            if (sample.position != simpler::dfx::ClockAnchorPosition::HostOrchestrationBegin || !sample.valid()) {
+            if (sample.position != simpler::dfx::ClockAnchorPosition::HostOffset || !sample.valid()) {
                 continue;
             }
             const uint64_t midpoint = sample.host_before_ns + (sample.host_after_ns - sample.host_before_ns) / 2;

--- a/src/common/platform/shared/host/clock_correlation.cpp
+++ b/src/common/platform/shared/host/clock_correlation.cpp
@@ -18,10 +18,8 @@ namespace simpler::dfx {
 
 const char *clock_anchor_position_name(ClockAnchorPosition position) {
     switch (position) {
-    case ClockAnchorPosition::HostOrchestrationBegin:
+    case ClockAnchorPosition::HostOffset:
         return "pre_host_orchestration";
-    case ClockAnchorPosition::DeviceExecutionComplete:
-        return "post_device_execution";
     }
     return "unknown";
 }

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -621,7 +621,7 @@ static int cleanup_failed_prepare(SimNativeRunContext *state, int execution_rc, 
     const uint64_t trace_hid = state->trace_hid;
     const long long trace_start_ns = state->trace_start_ns;
     if (clear_gm_sm) state->runtime.set_gm_sm_ptr(nullptr);
-    state->runner->finish_clock_correlation_session(false);
+    state->runner->finish_clock_correlation_session();
     int validation_rc = PTO_RUNTIME_ERR_INTERNAL;
     try {
         validation_rc = validate_runtime_impl(&state->runtime, &state->host_api, execution_rc);
@@ -869,7 +869,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
 
     // Correlation state is runner-wide. Finish it before releasing the claim,
     // after which a successor may begin capture and replace the provider/session.
-    state->runner->finish_clock_correlation_session(false);
+    state->runner->finish_clock_correlation_session();
     if (state->runner_claimed) {
         state->runner->release_native_run(state);
         state->runner_claimed = false;

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -721,15 +721,12 @@ void SimDeviceRunnerBase::apply_call_config(const CallConfig &config) {
     // a2a3 and a5 override set_dep_gen_enabled; an arch without dep_gen no-ops.
     set_dep_gen_enabled(config.enable_dep_gen != 0);
     set_scope_stats_enabled(config.enable_scope_stats != 0);
-    capture_clock_anchors_ = config.capture_clock_anchors != 0;
+    // Every swimlane artifact carries Host/Device clock correlation.
+    capture_clock_anchors_ = config.capture_clock_anchors != 0 || config.enable_chip_swimlane != 0;
     set_output_prefix(config.output_prefix);
 }
 
 HostPhaseRecordPool *SimDeviceRunnerBase::host_phase_pool_arm(bool producer_wants_records) noexcept {
-    if (clock_correlation_provider_ != nullptr) {
-        clock_correlation_provider_->release(false);
-        clock_correlation_provider_.reset();
-    }
     const bool swimlane_wants_records = chip_swimlane_level_ == ChipSwimlaneLevel::ORCH_PHASES;
     const bool artifact_wants_records = producer_wants_records && !output_prefix_.empty();
     chip_swimlane_collector_.set_host_orchestrated(swimlane_wants_records);
@@ -742,14 +739,11 @@ HostPhaseRecordPool *SimDeviceRunnerBase::host_phase_pool_arm(bool producer_want
     } catch (...) {
         LOG_WARN("Host phase pool could not be armed; this pass collects no per-event records");
     }
-    if (!swimlane_wants_records) return pool;
-
-    begin_clock_correlation_session_if_needed();
     return pool;
 }
 
 void SimDeviceRunnerBase::begin_clock_correlation_session_if_needed() noexcept {
-    if (chip_swimlane_level_ != ChipSwimlaneLevel::ORCH_PHASES || chip_swimlane_collector_.clock_correlation_active()) {
+    if (!capture_clock_anchors_ || chip_swimlane_collector_.clock_correlation_active()) {
         return;
     }
     try {
@@ -759,7 +753,7 @@ void SimDeviceRunnerBase::begin_clock_correlation_session_if_needed() noexcept {
         );
         chip_swimlane_collector_.record_clock_anchor_samples(
             simpler::dfx::capture_clock_anchor_group(
-                *clock_correlation_provider_, simpler::dfx::ClockAnchorPosition::HostOrchestrationBegin
+                *clock_correlation_provider_, simpler::dfx::ClockAnchorPosition::HostOffset
             )
         );
     } catch (...) {
@@ -783,20 +777,11 @@ void SimDeviceRunnerBase::publish_host_phase_records_to_swimlane() {
     );
 }
 
-void SimDeviceRunnerBase::finish_clock_correlation_session(bool capture_device_complete) noexcept {
+void SimDeviceRunnerBase::finish_clock_correlation_session() noexcept {
     if (!chip_swimlane_collector_.clock_correlation_active()) {
         if (clock_correlation_provider_ != nullptr) clock_correlation_provider_->release(false);
         clock_correlation_provider_.reset();
         return;
-    }
-    if (capture_device_complete && clock_correlation_provider_ != nullptr) {
-        try {
-            chip_swimlane_collector_.record_clock_anchor_samples(
-                simpler::dfx::capture_clock_anchor_group(
-                    *clock_correlation_provider_, simpler::dfx::ClockAnchorPosition::DeviceExecutionComplete
-                )
-            );
-        } catch (...) {}
     }
     chip_swimlane_collector_.finish_clock_correlation_session();
     if (clock_correlation_provider_ != nullptr) clock_correlation_provider_->release(false);

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -280,9 +280,9 @@ public:
     const simpler::dfx::HostPhaseRecordStore &host_phase_records() const { return host_phase_records_; }
     /** Hand this pass's records to the swimlane reader, just before its export. */
     void publish_host_phase_records_to_swimlane();
-    /** Start the level-4 Host/Device clock correlation once per run. */
+    /** Start the Host/Device clock correlation once per swimlane run. */
     void begin_clock_correlation_session_if_needed() noexcept;
-    void finish_clock_correlation_session(bool capture_device_complete) noexcept;
+    void finish_clock_correlation_session() noexcept;
     void set_dump_args_enabled(int level) {
         dump_args_level_ = static_cast<DumpArgsLevel>(level);
         enable_dump_args_ = (dump_args_level_ != DumpArgsLevel::OFF);
@@ -514,8 +514,9 @@ protected:
     bool enable_scope_stats_{false};
     ChipSwimlaneLevel chip_swimlane_level_{ChipSwimlaneLevel::DISABLED};  // resolved from set_chip_swimlane_enabled()
     PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};         // resolved from set_pmu_enabled()
-    bool capture_clock_anchors_{false};                                   // from CallConfig::capture_clock_anchors
-    std::string output_prefix_{};                                         // diagnostic artifact root directory
+    // Set by CallConfig::capture_clock_anchors or by the swimlane being enabled.
+    bool capture_clock_anchors_{false};
+    std::string output_prefix_{};  // diagnostic artifact root directory
 };
 
 namespace simpler::common::sim_host {

--- a/src/common/task_interface/call_config.h
+++ b/src/common/task_interface/call_config.h
@@ -117,10 +117,11 @@ struct CallConfig {
     int32_t enable_pmu = 0;  // 0 = disabled; >0 = enabled, value selects event type
     int32_t enable_dep_gen = 0;
     int32_t enable_scope_stats = 0;  // writes <output_prefix>/scope_stats/scope_stats.jsonl
-    // Anchor the Host and Device clocks for this capture even when no Host
-    // orchestration records exist, which is what places its device timestamps on
-    // an absolute Host timeline. Independent of why a caller wants that timeline:
-    // the runtime samples the anchors and never learns who consumes them.
+    // Internal ChipWorker marker, not a caller knob. A ChipWorker child sets it
+    // alongside enable_chip_swimlane and it stays on the wire for that, but it
+    // no longer gates anything on its own: the runtime anchors the clocks
+    // whenever the chip swimlane is enabled, so setting this without the
+    // swimlane samples no anchors and produces no standalone artifact.
     int32_t capture_clock_anchors = 0;
     RuntimeEnv runtime_env;  // per-task ring sizing
     char output_prefix[1024] = {};

--- a/tests/ut/py/test_clock_correlation.py
+++ b/tests/ut/py/test_clock_correlation.py
@@ -32,7 +32,7 @@ def _anchors(samples, raw_unit="syscnt_cycles"):
     }
 
 
-def test_alignment_selects_minimum_rtt_and_interpolates_offset_with_integer_math():
+def test_alignment_selects_minimum_rtt_and_offsets_at_the_nominal_frequency():
     anchors = _anchors(
         [
             _sample("pre_host_orchestration", 0, 900, 100, 1_100),
@@ -42,75 +42,90 @@ def test_alignment_selects_minimum_rtt_and_interpolates_offset_with_integer_math
         ]
     )
 
-    alignment = build_clock_alignment(anchors, 1_000_000_000, [100, 2_100, 4_100])
+    alignment = build_clock_alignment(anchors, 1_000_000_000)
 
     assert alignment.status == "calibrated"
-    assert alignment.metadata()["selected_sample_idx"] == {
-        "pre_host_orchestration": 1,
-        "post_device_execution": 1,
-    }
-    assert alignment.max_uncertainty_ns == 20
-    assert alignment.metadata()["anchor_group_duration_ns"] == {
-        "pre_host_orchestration": 200,
-        "post_device_execution": 400,
-    }
+    assert alignment.metadata()["selected_sample_idx"] == {"pre_host_orchestration": 1}
+    assert alignment.max_uncertainty_ns == 10
+    assert alignment.metadata()["anchor_group_duration_ns"] == {"pre_host_orchestration": 200}
+    # A closing anchor from an older capture is ignored.
     assert alignment.map_cycles_to_host_ns(100) == 1_000
-    assert alignment.map_cycles_to_host_ns(2_100) == 3_050
-    assert alignment.map_cycles_to_host_ns(4_100) == 5_100
+    assert alignment.map_cycles_to_host_ns(2_100) == 3_000
+    assert alignment.map_cycles_to_host_ns(4_100) == 5_000
+
+
+def test_mapping_needs_only_one_anchor():
+    anchors = _anchors([_sample("pre_host_orchestration", 0, 990, 100, 1_010)])
+
+    alignment = build_clock_alignment(anchors, 1_000_000_000)
+
+    assert alignment.status == "calibrated"
+    assert alignment.map_cycles_to_host_ns(9_100) == 10_000
+
+
+def test_the_anchor_is_a_pin_and_extrapolates_equally_either_side():
+    # The single reading supplies an offset, not the bound of a calibrated
+    # interval, so a cycle count below the anchor maps by the same arithmetic
+    # as one above it. host_mid_ns = 999_900 + 200 // 2.
+    anchors = _anchors([_sample("pre_host_orchestration", 0, 999_900, 5_000, 1_000_100)])
+
+    alignment = build_clock_alignment(anchors, 1_000_000_000)
+
+    assert alignment.map_cycles_to_host_ns(5_000) == 1_000_000
+    assert alignment.map_cycles_to_host_ns(6_500) == 1_001_500
+    assert alignment.map_cycles_to_host_ns(3_500) == 998_500
+
+
+def test_mapping_rounds_toward_zero_on_both_sides_of_the_anchor():
+    # 3 GHz: one cycle is 1/3 ns, so a 5-cycle delta is 1.67 ns and has to be
+    # truncated. Truncation is toward zero, which keeps the two directions
+    # symmetric; floor division alone would bias the pre-anchor side away.
+    anchors = _anchors([_sample("pre_host_orchestration", 0, 999_900, 5_000, 1_000_100)])
+
+    alignment = build_clock_alignment(anchors, 3_000_000_000)
+
+    assert alignment.map_cycles_to_host_ns(5_005) == 1_000_001
+    assert alignment.map_cycles_to_host_ns(4_995) == 999_999
 
 
 def test_alignment_preserves_low_bits_for_large_cycle_values():
     ref = 10**18
-    anchors = _anchors(
-        [
-            _sample("pre_host_orchestration", 0, 9_999_999_990, ref, 10_000_000_010),
-            _sample("post_device_execution", 0, 10_000_003_990, ref + 4_000, 10_000_004_010),
-        ]
-    )
+    anchors = _anchors([_sample("pre_host_orchestration", 0, 9_999_999_990, ref, 10_000_000_010)])
 
-    alignment = build_clock_alignment(anchors, 1_000_000_000, [ref + 1])
+    alignment = build_clock_alignment(anchors, 1_000_000_000)
 
     assert alignment.map_cycles_to_host_ns(ref + 1) == 10_000_000_001
 
 
 def test_acl_event_microsecond_quantization_is_included_in_uncertainty():
     anchors = _anchors(
-        [
-            _sample("pre_host_orchestration", 0, 990, 100, 1_010),
-            _sample("post_device_execution", 0, 4_990, 4_100, 5_010),
-        ],
+        [_sample("pre_host_orchestration", 0, 990, 100, 1_010)],
         raw_unit="device_uptime_us",
     )
 
-    alignment = build_clock_alignment(anchors, 1_000_000_000, [100, 4_100])
+    alignment = build_clock_alignment(anchors, 1_000_000_000)
 
     assert alignment.max_uncertainty_ns == 1_010
 
 
 def test_host_record_quantization_is_included_in_cross_domain_uncertainty():
-    anchors = _anchors(
-        [
-            _sample("pre_host_orchestration", 0, 990, 100, 1_010),
-            _sample("post_device_execution", 0, 4_980, 4_100, 5_020),
-        ]
-    )
+    anchors = _anchors([_sample("pre_host_orchestration", 0, 990, 100, 1_010)])
 
     alignment = build_clock_alignment(
         anchors,
         50_000_000,
-        [100, 4_100],
         host_timestamp_quantization_ns=20,
     )
 
-    assert alignment.anchor_uncertainty_ns == 20
-    assert alignment.max_uncertainty_ns == 40
+    assert alignment.anchor_uncertainty_ns == 10
+    assert alignment.max_uncertainty_ns == 30
     assert alignment.metadata()["host_timestamp_quantization_ns"] == 20
 
 
 @pytest.mark.parametrize(
-    ("anchors", "timestamps", "reason"),
+    ("anchors", "reason"),
     [
-        ({}, [], "missing_clock_anchor_samples"),
+        ({}, "missing_clock_anchor_samples"),
         (
             _anchors(
                 [
@@ -118,23 +133,12 @@ def test_host_record_quantization_is_included_in_cross_domain_uncertainty():
                     _sample("post_device_execution", 0, 4_990, 4_100, 5_010),
                 ]
             ),
-            [],
-            "no_valid_pre_host_orchestration_anchor",
-        ),
-        (
-            _anchors(
-                [
-                    _sample("pre_host_orchestration", 0, 990, 100, 1_010),
-                    _sample("post_device_execution", 0, 4_990, 4_100, 5_010),
-                ]
-            ),
-            [99],
-            "device_timestamps_outside_anchor_coverage",
+            "no_valid_anchor",
         ),
     ],
 )
-def test_alignment_fails_closed(anchors, timestamps, reason):
-    alignment = build_clock_alignment(anchors, 1_000_000_000, timestamps)
+def test_alignment_fails_closed(anchors, reason):
+    alignment = build_clock_alignment(anchors, 1_000_000_000)
 
     assert alignment.status == "unaligned"
     assert alignment.reason == reason

--- a/tests/ut/py/test_swimlane_converter.py
+++ b/tests/ut/py/test_swimlane_converter.py
@@ -212,7 +212,7 @@ def test_l3_directory_merge_uses_common_host_origin_and_rank_namespaces(tmp_path
     trace = json.loads(output.read_text())
     assert trace["metadata"]["global_origin_ns"] == 1_500
     assert trace["metadata"]["host_clock_domain_id"] == "same-boot"
-    assert trace["metadata"]["cross_rank_uncertainty_ns"] == 40
+    assert trace["metadata"]["cross_rank_uncertainty_ns"] == 20
     assert trace["metadata"]["pre_anchor_group_duration_spread_ns"] == 0
     assert trace["metadata"]["pre_anchor_group_duration_max_ns"] == 20
     assert trace["metadata"]["dispatch_pairing"] == "local_capture_index"
@@ -475,7 +475,7 @@ def test_host_orchestrator_phases_without_anchors_are_marked_unaligned(tmp_path)
         "relation": "host_orchestration_precedes_device",
         "clock_alignment": {
             "status": "unaligned",
-            "method": "nominal_frequency_offset_interp_v1",
+            "method": "nominal_frequency_offset_v1",
             "anchor_uncertainty_ns": None,
             "host_timestamp_quantization_ns": 0,
             "max_uncertainty_ns": None,
@@ -569,7 +569,7 @@ def test_aicpu_orchestrator_uses_host_timeline_when_clock_anchors_exist(tmp_path
     data = sc.read_perf_data(raw)
 
     assert data["orchestrator_source"] == "aicpu"
-    assert data["tasks"][0]["start_time_us"] == 2.05
+    assert data["tasks"][0]["start_time_us"] == 2.0
     assert data["timeline_metadata"]["layout"] == "clock_aligned"
     assert data["timeline_metadata"]["clock_alignment"]["status"] == "calibrated"
     assert data["timeline_metadata"]["host_clock_domain_id"] == "same-boot"
@@ -687,26 +687,20 @@ def test_host_and_device_timestamps_use_calibrated_clock_alignment(tmp_path):
 
     assert data["aicpu_orchestrator_phases"][0][0]["start_time_us"] == 0.0
     assert data["aicpu_orchestrator_phases"][0][0]["end_time_us"] == 0.3
-    assert data["tasks"][0]["dispatch_time_us"] == 1.447
-    assert data["tasks"][0]["start_time_us"] == 1.55
+    assert data["tasks"][0]["dispatch_time_us"] == 1.4
+    assert data["tasks"][0]["start_time_us"] == 1.5
     assert data["timeline_metadata"] == {
         "layout": "clock_aligned",
         "trace_status": "complete",
         "relation": "host_orchestration_precedes_device",
         "clock_alignment": {
             "status": "calibrated",
-            "method": "nominal_frequency_offset_interp_v1",
-            "anchor_uncertainty_ns": 20,
+            "method": "nominal_frequency_offset_v1",
+            "anchor_uncertainty_ns": 10,
             "host_timestamp_quantization_ns": 0,
-            "max_uncertainty_ns": 20,
-            "selected_sample_idx": {
-                "pre_host_orchestration": 0,
-                "post_device_execution": 0,
-            },
-            "anchor_group_duration_ns": {
-                "pre_host_orchestration": 20,
-                "post_device_execution": 40,
-            },
+            "max_uncertainty_ns": 10,
+            "selected_sample_idx": {"pre_host_orchestration": 0},
+            "anchor_group_duration_ns": {"pre_host_orchestration": 20},
         },
         "host_capture": {
             "status": "complete",


### PR DESCRIPTION
Map device timestamps onto the Host clock from a single paired reading. The
anchor supplies an offset and nothing else, because the scale is the platform's
counter frequency.

Follow-up to the L3 multi-rank swimlane (#2058 / #2099); closes no issue of its
own.

## What the device records are missing is an origin, not a scale

A capture carries its two domains explicitly — `device_clock_domain:
device_syscnt_cycles` against `orchestrator_clock_domain: host_monotonic_ns` —
and `clock_freq_hz` is known a priori from the platform. So every interval
inside the device domain is already computable: a duration, a gap between two
tasks, the span of a scheduler phase are all `cycles x 1e9 / clock_freq_hz` and
need no calibration at all.

What the device side cannot supply is where any of that sits on the Host clock.
Its timestamps are syscnt counts against a device-boot epoch with no defined
relation to `CLOCK_MONOTONIC`. The records give spans without a start.

The same shape shows up one layer up, in the host trace. `to_host_swimlane`
keeps every `clk=dev` span out of Perfetto's visible `traceEvents` and parks it
in `unalignedDeviceSpans`, because "Chrome Trace JSON has one timestamp axis, so
raw `clk=dev` events cannot be rendered alongside host events without either a
false clock alignment or a huge empty interval". Those spans, `device_wall`
among them, carry lengths and nothing that says where to put them. An offset is
the missing half in both places.

That leaves exactly one unknown scalar, and `metadata.timeline_relation:
host_orchestration_precedes_device` is what the format could assert without it:
an ordering, never a distance. An anchor measures that one scalar. A second
reading would be measuring the scale, which was never missing.

## How accurate the stitch has to be

A swimlane is read to see where work sits relative to other work: which Rank
started late, how long a submit gap is, whether a device segment overlaps the
host orchestration that queued it. Those features are milliseconds wide — the
device segments in the captures below run 0.1 to 10.7 ms, the submit gaps 1.5 to
3.0 ms. Placing a block within tens of microseconds is comfortably inside what
the picture needs, and the error is declared rather than assumed: each block
carries `max_uncertainty_ns` (14.0-28.5 us in these runs) and a cross-domain
comparison costs the sum of two (49.3 us for four Ranks).

This is the reason the residual correction is not worth its cost. It is not
merely that a second reading is noisy — it is that the quantity it corrects,
1.8-8.1 us, sits below the bound the consumer already tolerates.

## Why one reading is enough in practice

The second reading only contributed a residual the calibration interval was too
short to measure. Across four Ranks of a `TestAllreduceTwophaseP4` capture the
implied frequency swung between -813 and +2105 ppm with inconsistent sign,
while the correction it produced stayed an order of magnitude below the
sampling noise it was computed from (30-58 us).

```text
host_ns(cycles) = anchor.host_mid_ns + (cycles - anchor.device_cycles) x 1e9 / clock_freq_hz
```

Supplying an offset pins the two clock domains rather than bounding an interval
the records must fall inside, so a timestamp either side of it maps by the same
arithmetic. That removes the placement constraint that made each runtime open
its interval at a different point, and both now read at the launch boundary.

## What changes

- Anchor the clocks for any enabled chip swimlane instead of level 4 alone. A
  capture below that level is placed on the Host timeline too, rather than on
  its own relative one, so the seam a fail-soft conversion used to leave
  unmeasured is gone for single-card captures as well. Cross-Rank merging still
  requires level 4, now because `_validate_l3_rank_data` asks for the
  orchestrator phase records only that level carries.
- Drop the closing reading and the coverage check it fed: with the anchor a pin
  there is no interval left for a timestamp to fall outside of.
- `CallConfig::capture_clock_anchors` stays on the wire as the ChipWorker
  marker it already was, but no longer gates anything on its own.

## Verification

`pytest tests/ut/py` — 2121 passed, 24 skipped.

Onboard a2a3, both runtimes at level 4:

- **`TestAllreduceTwophaseP4`, 4 cards.** All four Ranks calibrated;
  `global_origin_ns` equals the minimum per-Rank origin, so the anchor supplies
  the offset and the earliest event still sets the origin. The four Ranks end
  within an 11 us window (7798-7809 us) — a collective rendezvous is what a
  correct alignment should show, and the agreement sits inside the declared
  49.3 us cross-Rank bound. No negative timestamps.
- **`TestBatchPagedAttentionHostBuildGraph`, 1 card.** `layout: clock_aligned`,
  no unaligned device spans, 4096 AICore tasks all after the anchor. The host
  orchestration lane (0-3362 us) and the device lanes (38208-40831 us) sit on
  one axis; the fail-soft layout would have placed the device segment at
  307.9-345.7 us, 36 ms off, with the error unmeasurable by construction.
- Recomputing the formula by hand for each Rank reproduces the emitted
  timestamps exactly.

New unit tests cover the mapping either side of the anchor and the toward-zero
truncation that keeps the two directions symmetric.