### PR TITLE
Refactor: make the DFX collectors resident across runs

### DIFF
--- a/src/a2a3/platform/include/host/pmu_collector.h
+++ b/src/a2a3/platform/include/host/pmu_collector.h
@@ -219,17 +219,22 @@ public:
     // Allocates the device-side resources.
     //
     // Per-run configuration (CSV destination, event selection) is bound
-    // separately by set_run_output(), which must be called before init() so the
-    // event type reaches the device header and the CSV header string.
+    // separately by begin_run(), which must run before this on the first run so
+    // the event type reaches the device header and the CSV header string.
     int init(
         int num_cores, int num_threads, const PmuAllocCallback &alloc_cb, PmuRegisterCallback register_cb,
         const PmuFreeCallback &free_cb, int device_id
     );
 
-    void set_run_output(const std::string &csv_path, PmuEventType event_type) {
-        csv_path_ = csv_path;
-        event_type_ = event_type;
-    }
+    // Start a run's collection window: bind its CSV destination and event
+    // selection, drop the previous run's shard state, rebuild the CSV header
+    // (its columns are named by the event config), and — once the region exists
+    // — republish the event type the device reads.
+    //
+    // The collector initializes once and serves every run, so this is the only
+    // point at which a run's shard files, CSV columns and device event type are
+    // established; init() establishes none of them.
+    void begin_run(const std::string &csv_path, PmuEventType event_type);
 
     void start(const profiling_common::ThreadFactory &thread_factory);
 
@@ -318,6 +323,7 @@ private:
     bool ensure_csv_shard_open(size_t shard);
     bool ensure_csv_open();
     bool close_csv_shards();
+    void rebuild_csv_header();
     void cleanup_csv_shards();
 };
 

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -351,6 +351,15 @@ int DeviceRunner::prepare_execution(
     }
 
     // Initialize per-subsystem shared memory.
+    //
+    // Collectors stay initialized across runs, so pools built for an earlier
+    // run's core / AICPU-thread counts have to go before this run seeds pools
+    // and recycled lanes at different ones.
+    if (collector_shape_is_stale(num_aicore, runtime.get_aicpu_thread_num(), launch_aicpu_num)) {
+        finalize_collectors();
+    }
+    latch_collector_shape(num_aicore, runtime.get_aicpu_thread_num(), launch_aicpu_num);
+
     if (enable_chip_swimlane_) {
         rc = init_chip_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_, execution->kernel_args);
         if (rc != 0) {
@@ -471,7 +480,8 @@ void DeviceRunner::cleanup_execution(PreparedExecution &prepared, bool retire_ai
 
     // Collectors must stop before their backing arguments are released; the
     // per-run stream retires last. Each cleanup operation is idempotent.
-    finalize_collectors(abandon);
+    // The collectors' device resources are not per-run: they are released in
+    // finalize(), which owns them for the worker's lifetime.
     if (abandon) {
         prepared.kernel_args.abandon_after_device_failure();
     } else {
@@ -715,7 +725,7 @@ int DeviceRunner::reap_run() {
                 LOG_ERROR("dep_gen host graph emit failed (%d) — deps.json not produced", rc);
             }
         } else {
-            dep_gen_collector_.stop();
+            dep_gen_collector_.quiesce();
             if (dep_gen_collector_.reconcile_counters()) {
                 const auto &records = dep_gen_collector_.records();
                 int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
@@ -1151,7 +1161,7 @@ int DeviceRunner::init_chip_swimlane(
         return mem_alloc_.free(dev_ptr);
     };
 
-    chip_swimlane_collector_.set_run_output(output_prefix_, chip_swimlane_level_);
+    chip_swimlane_collector_.begin_run(output_prefix_, chip_swimlane_level_);
     int rc =
         chip_swimlane_collector_.initialize(num_aicore, aicpu_thread_num, device_id, alloc_cb, register_cb, free_cb);
     if (rc != 0) {
@@ -1189,7 +1199,7 @@ int DeviceRunner::init_args_dump(Runtime &runtime, int device_id, KernelArgsHelp
         return mem_alloc_.free(dev_ptr);
     };
 
-    dump_collector_.set_run_output(output_prefix_, dump_args_level_);
+    dump_collector_.begin_run(output_prefix_, dump_args_level_);
     int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, register_cb, free_cb);
     if (rc != 0) {
         return rc;
@@ -1224,7 +1234,7 @@ int DeviceRunner::init_pmu(
         return mem_alloc_.free(dev_ptr);
     };
 
-    pmu_collector_.set_run_output(csv_path, event_type);
+    pmu_collector_.begin_run(csv_path, event_type);
     int rc = pmu_collector_.init(num_cores, num_threads, alloc_cb, register_cb, free_cb, device_id);
     if (rc != 0) {
         return rc;
@@ -1235,6 +1245,7 @@ int DeviceRunner::init_pmu(
 }
 
 int DeviceRunner::init_dep_gen(int num_threads, int device_id, KernelArgsHelper &kernel_args) {
+    dep_gen_collector_.begin_run();
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
     };
@@ -1266,6 +1277,7 @@ int DeviceRunner::init_dep_gen(int num_threads, int device_id, KernelArgsHelper 
 }
 
 int DeviceRunner::init_scope_stats(int num_threads, int device_id, KernelArgsHelper &kernel_args) {
+    scope_stats_collector_.begin_run();
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
     };
@@ -1298,6 +1310,7 @@ int DeviceRunner::init_scope_stats(int num_threads, int device_id, KernelArgsHel
 }
 
 void DeviceRunner::finalize_collectors(bool abandon_device_resources) {
+    clear_collector_shape();
     auto healthy_unregister_cb = [](void *dev_ptr, int device_id) -> int {
         HalHostUnregisterFn fn = get_halHostUnregister();
         if (fn != nullptr) {

--- a/src/a2a3/platform/shared/host/pmu_collector.cpp
+++ b/src/a2a3/platform/shared/host/pmu_collector.cpp
@@ -83,6 +83,12 @@ int PmuCollector::init(
         );
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    if (initialized_) {
+        // Already holding this run's device resources. They are not per-run:
+        // configuration arrives via begin_run() and the layout is fixed at
+        // compile time, so there is nothing here left to re-apply.
+        return 0;
+    }
 
     // Must precede the recycled-lane seeding below: push_recycled() folds its
     // shard argument modulo the manager's shard count.
@@ -178,24 +184,7 @@ int PmuCollector::init(
         }
     }
 
-    // ---- Build CSV header string ----
-    {
-        std::string header = "thread_id,core_id,task_id,func_id,core_type,pmu_total_cycles";
-        const PmuEventConfig *evt = pmu_resolve_event_config_a2a3(event_type_);
-        if (evt == nullptr) {
-            evt = &PMU_EVENTS_A2A3_PIPE_UTIL;
-        }
-        for (int i = 0; i < PMU_COUNTER_COUNT_A2A3; i++) {
-            const char *name = evt->counter_names[i];
-            if (name == nullptr || name[0] == '\0') {
-                continue;
-            }
-            header += ',';
-            header += name;
-        }
-        header += ",event_type\n";
-        csv_header_ = std::move(header);
-    }
+    rebuild_csv_header();
 
     initialized_ = true;
     // Hand the memory context to the base. start(tf) (inherited) will assemble
@@ -262,6 +251,73 @@ void PmuCollector::cleanup_csv_shards() {
         if (path.empty()) continue;
         std::error_code ec;
         std::filesystem::remove(path, ec);
+    }
+}
+
+void PmuCollector::rebuild_csv_header() {
+    // Columns are named by the event config, so this is per-run state: a run
+    // that selects a different event type needs different column names.
+    std::string header = "thread_id,core_id,task_id,func_id,core_type,pmu_total_cycles";
+    const PmuEventConfig *evt = pmu_resolve_event_config_a2a3(event_type_);
+    if (evt == nullptr) {
+        evt = &PMU_EVENTS_A2A3_PIPE_UTIL;
+    }
+    for (int i = 0; i < PMU_COUNTER_COUNT_A2A3; i++) {
+        const char *name = evt->counter_names[i];
+        if (name == nullptr || name[0] == '\0') {
+            continue;
+        }
+        header += ',';
+        header += name;
+    }
+    header += ",event_type\n";
+    csv_header_ = std::move(header);
+}
+
+void PmuCollector::begin_run(const std::string &csv_path, PmuEventType event_type) {
+    // Before reset_collector_shards(): it rebuilds the shard paths from csv_path_.
+    csv_path_ = csv_path;
+    event_type_ = event_type;
+
+    reset_collector_shards();
+    if (csv_file_.is_open()) {
+        csv_file_.close();
+    }
+    execution_complete_.store(false, std::memory_order_release);
+    rebuild_csv_header();
+
+    // Before the first init() there is no region; init() writes the event type
+    // from the member just set. Afterwards the device needs the new value by
+    // another route — one narrow field, not a bulk write-back, so it cannot race
+    // the AICPU's own header fields.
+    if (shm_host_ != nullptr) {
+        PmuDataHeader *hdr = get_pmu_header(shm_host_);
+        hdr->event_type = static_cast<uint32_t>(event_type_);
+        wmb();
+        (void)manager_.write_range_to_device(&hdr->event_type, sizeof(hdr->event_type));
+
+        // The per-core record counters are producer-side and never reset by the
+        // device, so they carry the previous run's totals into this run's
+        // reconcile. The two are adjacent, so one write-back per core covers
+        // them and leaves the device-owned fields beside them alone.
+        // a2a3 orders these dropped-then-total and has no mismatch counter;
+        // a5's layout differs, so neither the order nor the span is shared.
+        static_assert(
+            offsetof(PmuBufferState, total_record_count) ==
+                offsetof(PmuBufferState, dropped_record_count) + sizeof(uint32_t),
+            "the two counters must stay adjacent for this single write-back to cover both"
+        );
+        // The region holds num_cores_ states (calc_pmu_data_size), so that is
+        // the bound — a wider loop writes past its end. The runner rebuilds this
+        // collector when a run's core count changes, so a resident one is never
+        // asked to reset a state it does not own.
+        for (int c = 0; c < num_cores_; c++) {
+            PmuBufferState *state = get_pmu_buffer_state(shm_host_, c);
+            state->dropped_record_count = 0;
+            state->total_record_count = 0;
+            wmb();
+            (void)manager_.write_range_to_device(&state->dropped_record_count, 2 * sizeof(uint32_t));
+        }
     }
 }
 

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -116,7 +116,8 @@ void DeviceRunner::cleanup_active_run() noexcept {
         mem_alloc_.free(active_run_->reg_blocks);
         active_run_->reg_blocks = nullptr;
     }
-    finalize_collectors();
+    // The collectors' device resources are not per-run: they are released in
+    // finalize(), which owns them for the worker's lifetime.
     active_run_.reset();
 }
 
@@ -395,6 +396,14 @@ int DeviceRunner::prepare_execution(
     }
 
     last_runtime_ = &runtime;
+
+    // Collectors stay initialized across runs, so pools built for an earlier
+    // run's core / AICPU-thread counts have to go before this run seeds pools
+    // and recycled lanes at different ones.
+    if (collector_shape_is_stale(num_aicore, runtime.get_aicpu_thread_num(), launch_aicpu_num)) {
+        finalize_collectors();
+    }
+    latch_collector_shape(num_aicore, runtime.get_aicpu_thread_num(), launch_aicpu_num);
 
     if (enable_chip_swimlane_) {
         rc = init_chip_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_);
@@ -691,7 +700,7 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
     finish_clock_correlation_session(true);
     if (enable_chip_swimlane_) {
-        chip_swimlane_collector_.stop();
+        chip_swimlane_collector_.quiesce();
         chip_swimlane_collector_.read_phase_header_metadata();
         chip_swimlane_collector_.reconcile_counters();
         publish_host_phase_records_to_swimlane();
@@ -699,13 +708,13 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
     }
 
     if (enable_dump_args_) {
-        dump_collector_.stop();
+        dump_collector_.quiesce();
         dump_collector_.reconcile_counters();
         dump_collector_.export_dump_files();
     }
 
     if (enable_pmu_) {
-        pmu_collector_.stop();
+        pmu_collector_.quiesce();
         pmu_collector_.reconcile_counters();
     }
 
@@ -719,7 +728,7 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
                 LOG_ERROR("dep_gen host graph emit failed (%d) — deps.json not produced", rc);
             }
         } else {
-            dep_gen_collector_.stop();
+            dep_gen_collector_.quiesce();
             if (dep_gen_collector_.reconcile_counters()) {
                 const auto &records = dep_gen_collector_.records();
                 int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
@@ -739,7 +748,7 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
     }
 
     if (enable_scope_stats_) {
-        scope_stats_collector_.stop();
+        scope_stats_collector_.quiesce();
         scope_stats_collector_.reconcile_counters();
         scope_stats_collector_.write_jsonl(output_prefix_);
     }
@@ -811,8 +820,9 @@ int DeviceRunner::finalize() {
         return 0;
     }
 
-    // cleanup_active_run() normally stops active collectors; this is the
-    // backstop for the initialized-but-never-enqueued case.
+    // Collectors outlive every run on this runner, so this is where their device
+    // resources are released — including for a runner that only ever initialized
+    // them and never enqueued.
     finalize_collectors();
 
     release_callable_state();
@@ -870,7 +880,7 @@ int DeviceRunner::init_chip_swimlane(int num_aicore, int aicpu_thread_num, int d
         return mem_alloc_.free(dev_ptr);
     };
 
-    chip_swimlane_collector_.set_run_output(output_prefix_, chip_swimlane_level_);
+    chip_swimlane_collector_.begin_run(output_prefix_, chip_swimlane_level_);
     int rc = chip_swimlane_collector_.initialize(num_aicore, aicpu_thread_num, device_id, alloc_cb, nullptr, free_cb);
     if (rc != 0) {
         return rc;
@@ -893,7 +903,7 @@ int DeviceRunner::init_args_dump(Runtime &runtime, int device_id) {
         return mem_alloc_.free(dev_ptr);
     };
 
-    dump_collector_.set_run_output(output_prefix_, dump_args_level_);
+    dump_collector_.begin_run(output_prefix_, dump_args_level_);
     int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, nullptr, free_cb);
     if (rc != 0) {
         return rc;
@@ -913,7 +923,7 @@ int DeviceRunner::init_pmu(
         return mem_alloc_.free(dev_ptr);
     };
 
-    pmu_collector_.set_run_output(csv_path, event_type);
+    pmu_collector_.begin_run(csv_path, event_type);
     int rc = pmu_collector_.init(num_cores, num_threads, alloc_cb, nullptr, free_cb, -1);
     if (rc != 0) {
         return rc;
@@ -924,6 +934,7 @@ int DeviceRunner::init_pmu(
 }
 
 int DeviceRunner::init_dep_gen(int num_threads, int /*device_id*/) {
+    dep_gen_collector_.begin_run();
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
     };
@@ -941,6 +952,7 @@ int DeviceRunner::init_dep_gen(int num_threads, int /*device_id*/) {
 }
 
 int DeviceRunner::init_scope_stats(int num_threads) {
+    scope_stats_collector_.begin_run();
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
     };
@@ -959,6 +971,7 @@ int DeviceRunner::init_scope_stats(int num_threads) {
 }
 
 void DeviceRunner::finalize_collectors() {
+    clear_collector_shape();
     auto free_cb = [this](void *dev_ptr) -> int {
         return mem_alloc_.free(dev_ptr);
     };

--- a/src/a5/platform/include/host/pmu_collector.h
+++ b/src/a5/platform/include/host/pmu_collector.h
@@ -228,17 +228,22 @@ public:
     // Allocates the device-side resources.
     //
     // Per-run configuration (CSV destination, event selection) is bound
-    // separately by set_run_output(), which must be called before init() so the
-    // event type reaches the device header and the CSV header string.
+    // separately by begin_run(), which must run before this on the first run so
+    // the event type reaches the device header and the CSV header string.
     int init(
         int num_cores, int num_threads, const PmuAllocCallback &alloc_cb, PmuRegisterCallback register_cb,
         const PmuFreeCallback &free_cb, int device_id
     );
 
-    void set_run_output(const std::string &csv_path, PmuEventType event_type) {
-        csv_path_ = csv_path;
-        event_type_ = event_type;
-    }
+    // Start a run's collection window: bind its CSV destination and event
+    // selection, drop the previous run's shard state, rebuild the CSV header
+    // (its columns are named by the event config), and — once the region exists
+    // — republish the event type the device reads.
+    //
+    // The collector initializes once and serves every run, so this is the only
+    // point at which a run's shard files, CSV columns and device event type are
+    // established; init() establishes none of them.
+    void begin_run(const std::string &csv_path, PmuEventType event_type);
 
     void start(const profiling_common::ThreadFactory &thread_factory);
 
@@ -334,6 +339,7 @@ private:
     bool ensure_csv_shard_open(size_t shard);
     bool ensure_csv_open();
     bool close_csv_shards();
+    void rebuild_csv_header();
     void cleanup_csv_shards();
 };
 

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -398,6 +398,15 @@ int DeviceRunner::prepare_execution(
     }
 
     // Initialize per-subsystem shared memory.
+    //
+    // Collectors stay initialized across runs, so pools built for an earlier
+    // run's core / AICPU-thread counts have to go before this run seeds pools
+    // and recycled lanes at different ones.
+    if (collector_shape_is_stale(num_aicore, runtime.get_aicpu_thread_num(), active_aicpu_num)) {
+        finalize_collectors();
+    }
+    latch_collector_shape(num_aicore, runtime.get_aicpu_thread_num(), active_aicpu_num);
+
     if (enable_chip_swimlane_) {
         rc = init_chip_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_, execution->kernel_args);
         if (rc != 0) {
@@ -633,7 +642,7 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
                 LOG_ERROR("dep_gen host graph emit failed (%d) — deps.json not produced", emit_rc);
             }
         } else {
-            dep_gen_collector_.stop();
+            dep_gen_collector_.quiesce();
             if (dep_gen_collector_.reconcile_counters()) {
                 const auto &records = dep_gen_collector_.records();
                 int replay_rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
@@ -658,7 +667,8 @@ void DeviceRunner::cleanup_execution(PreparedExecution &prepared, bool launched)
     const bool abandon = device_unusable_.load(std::memory_order_acquire);
 
     // Collectors stop before device/runtime arguments and register buffers.
-    finalize_collectors(abandon);
+    // The collectors' device resources are not per-run: they are released in
+    // finalize(), which owns them for the worker's lifetime.
     if (abandon) {
         prepared.kernel_args.abandon_after_device_failure();
     } else {
@@ -980,11 +990,11 @@ int DeviceRunner::finalize() {
 // `launch_aicpu_kernel` and `launch_aicore_kernel` live on `DeviceRunnerBase`.
 
 void DeviceRunner::finalize_collectors(bool abandon_device_resources) {
-    // On drain or enqueue rollback, release the diagnostics collectors' shared
-    // memory. They are only re-initialized per run, so a
-    // Worker reused across runs (e.g. a pytest session-scoped worker pool) would
-    // otherwise re-enter init_chip_swimlane() with stale state still allocated.
-    // Matches a2a3's finalize_collectors().
+    // Release the diagnostics collectors' shared memory. Collectors survive an
+    // ordinary run, so the callers of this are the paths where their pools must
+    // not: drain, enqueue rollback, a run whose core / AICPU-thread counts
+    // differ from the pools', and Worker finalize.
+    clear_collector_shape();
     auto free_cb = [this, abandon_device_resources](void *dev_ptr) -> int {
         if (abandon_device_resources) return 0;
         return mem_alloc_.free(dev_ptr);
@@ -1015,7 +1025,7 @@ int DeviceRunner::init_chip_swimlane(
     auto free_cb = [this](void *dev_ptr) -> int {
         return mem_alloc_.free(dev_ptr);
     };
-    chip_swimlane_collector_.set_run_output(output_prefix_, chip_swimlane_level_);
+    chip_swimlane_collector_.begin_run(output_prefix_, chip_swimlane_level_);
     int rc = chip_swimlane_collector_.initialize(
         num_aicore, aicpu_thread_num, device_id, alloc_cb, /*register_cb=*/nullptr, free_cb
     );
@@ -1037,7 +1047,7 @@ int DeviceRunner::init_args_dump(Runtime &runtime, int device_id, KernelArgsHelp
     auto free_cb = [this](void *dev_ptr) -> int {
         return mem_alloc_.free(dev_ptr);
     };
-    dump_collector_.set_run_output(output_prefix_, dump_args_level_);
+    dump_collector_.begin_run(output_prefix_, dump_args_level_);
     int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, /*register_cb=*/nullptr, free_cb);
     if (rc != 0) {
         return rc;
@@ -1057,7 +1067,7 @@ int DeviceRunner::init_pmu(
     auto free_cb = [this](void *dev_ptr) -> int {
         return mem_alloc_.free(dev_ptr);
     };
-    pmu_collector_.set_run_output(csv_path, event_type);
+    pmu_collector_.begin_run(csv_path, event_type);
     int rc = pmu_collector_.init(num_cores, num_threads, alloc_cb, /*register_cb=*/nullptr, free_cb, device_id);
     if (rc == 0) {
         kernel_args.args.pmu_data_base = reinterpret_cast<uint64_t>(pmu_collector_.get_pmu_shm_device_ptr());
@@ -1068,6 +1078,7 @@ int DeviceRunner::init_pmu(
 }
 
 int DeviceRunner::init_scope_stats(int num_threads, int device_id, KernelArgsHelper &kernel_args) {
+    scope_stats_collector_.begin_run();
     // a5: register_cb=nullptr, so the collector mallocs a host shadow per
     // device buffer + rtMemcpy's the zeroed shadow to device (see
     // ProfilerBase::alloc_paired_buffer). No halHostRegister on a5.
@@ -1087,6 +1098,7 @@ int DeviceRunner::init_scope_stats(int num_threads, int device_id, KernelArgsHel
 }
 
 int DeviceRunner::init_dep_gen(int num_threads, int device_id, KernelArgsHelper &kernel_args) {
+    dep_gen_collector_.begin_run();
     // a5: register_cb=nullptr, so the collector mallocs a host shadow per
     // device buffer + rtMemcpy's the zeroed shadow to device. No
     // halHostRegister on a5 (matches PMU / chip swimlane / dump collectors).

--- a/src/a5/platform/shared/host/pmu_collector.cpp
+++ b/src/a5/platform/shared/host/pmu_collector.cpp
@@ -90,8 +90,10 @@ int PmuCollector::init(
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (initialized_) {
-        LOG_ERROR("PmuCollector already initialized");
-        return PTO_RUNTIME_ERR_INTERNAL;
+        // Already holding this run's device resources. They are not per-run:
+        // configuration arrives via begin_run() and the layout is fixed at
+        // compile time, so there is nothing here left to re-apply.
+        return 0;
     }
 
     // Must precede the recycled-lane seeding below: push_recycled() folds its
@@ -209,24 +211,7 @@ int PmuCollector::init(
     // free_queue contents) to device.
     profiling_copy_to_device(shm_dev_local, shm_host_local, shm_size);
 
-    // ---- Build CSV header string (file is opened lazily on first record) ----
-    {
-        std::string header = "thread_id,core_id,task_id,func_id,core_type,pmu_total_cycles";
-        const PmuEventConfig *evt = pmu_resolve_event_config_a5(event_type_);
-        if (evt == nullptr) {
-            evt = &PMU_EVENTS_A5_PIPE_UTIL;
-        }
-        for (int i = 0; i < PMU_COUNTER_COUNT_A5; i++) {
-            const char *name = evt->counter_names[i];
-            if (name == nullptr || name[0] == '\0') {
-                continue;
-            }
-            header += ',';
-            header += name;
-        }
-        header += ",event_type\n";
-        csv_header_ = std::move(header);
-    }
+    rebuild_csv_header();
 
     LOG_INFO(
         "PMU collector initialized: %d cores, %d threads, SHM=0x%lx, CSV=%s (opened on first record)", num_cores,
@@ -300,6 +285,72 @@ void PmuCollector::cleanup_csv_shards() {
         if (path.empty()) continue;
         std::error_code ec;
         std::filesystem::remove(path, ec);
+    }
+}
+
+void PmuCollector::rebuild_csv_header() {
+    // Columns are named by the event config, so this is per-run state: a run
+    // that selects a different event type needs different column names.
+    std::string header = "thread_id,core_id,task_id,func_id,core_type,pmu_total_cycles";
+    const PmuEventConfig *evt = pmu_resolve_event_config_a5(event_type_);
+    if (evt == nullptr) {
+        evt = &PMU_EVENTS_A5_PIPE_UTIL;
+    }
+    for (int i = 0; i < PMU_COUNTER_COUNT_A5; i++) {
+        const char *name = evt->counter_names[i];
+        if (name == nullptr || name[0] == '\0') {
+            continue;
+        }
+        header += ',';
+        header += name;
+    }
+    header += ",event_type\n";
+    csv_header_ = std::move(header);
+}
+
+void PmuCollector::begin_run(const std::string &csv_path, PmuEventType event_type) {
+    // Before reset_collector_shards(): it rebuilds the shard paths from csv_path_.
+    csv_path_ = csv_path;
+    event_type_ = event_type;
+
+    reset_collector_shards();
+    if (csv_file_.is_open()) {
+        csv_file_.close();
+    }
+    execution_complete_.store(false, std::memory_order_release);
+    rebuild_csv_header();
+
+    // Before the first init() there is no region; init() writes the event type
+    // from the member just set. Afterwards the device needs the new value by
+    // another route — one narrow field, not a bulk write-back, so it cannot race
+    // the AICPU's own header fields.
+    if (shm_host_ != nullptr) {
+        PmuDataHeader *hdr = get_pmu_header(shm_host_);
+        hdr->event_type = static_cast<uint32_t>(event_type_);
+        wmb();
+        (void)manager_.write_range_to_device(&hdr->event_type, sizeof(hdr->event_type));
+
+        // The per-core record counters are producer-side and never reset by the
+        // device, so they carry the previous run's totals into this run's
+        // reconcile. The three are adjacent, so one write-back per core covers
+        // them and leaves the device-owned fields beside them alone.
+        static_assert(
+            offsetof(PmuBufferState, mismatch_record_count) ==
+                offsetof(PmuBufferState, total_record_count) + 2 * sizeof(uint32_t),
+            "the three counters must stay adjacent for this single write-back to cover them"
+        );
+        // The region holds num_cores_ states (calc_pmu_data_size), so that is
+        // the bound — a wider loop writes past its end. The runner rebuilds this
+        // collector when a run's core count changes, so a resident one is never
+        // asked to reset a state it does not own.
+        for (int c = 0; c < num_cores_; c++) {
+            PmuBufferState *state = get_pmu_buffer_state(shm_host_, c);
+            state->total_record_count = 0;
+            state->dropped_record_count = 0;
+            state->mismatch_record_count = 0;
+            wmb();
+            (void)manager_.write_range_to_device(&state->total_record_count, 3 * sizeof(uint32_t));
+        }
     }
 }
 

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -120,7 +120,8 @@ void DeviceRunner::cleanup_active_run() noexcept {
         mem_alloc_.free(active_run_->reg_blocks);
         active_run_->reg_blocks = nullptr;
     }
-    finalize_collectors();
+    // The collectors' device resources are not per-run: they are released in
+    // finalize(), which owns them for the worker's lifetime.
     active_run_.reset();
 }
 
@@ -390,6 +391,14 @@ int DeviceRunner::prepare_execution(
     }
 
     last_runtime_ = &runtime;
+
+    // Collectors stay initialized across runs, so pools built for an earlier
+    // run's core / AICPU-thread counts have to go before this run seeds pools
+    // and recycled lanes at different ones.
+    if (collector_shape_is_stale(num_aicore, runtime.get_aicpu_thread_num(), launch_aicpu_num)) {
+        finalize_collectors();
+    }
+    latch_collector_shape(num_aicore, runtime.get_aicpu_thread_num(), launch_aicpu_num);
 
     if (enable_chip_swimlane_) {
         rc = init_chip_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_);
@@ -664,7 +673,7 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
     finish_clock_correlation_session(true);
     if (enable_chip_swimlane_) {
-        chip_swimlane_collector_.stop();
+        chip_swimlane_collector_.quiesce();
         chip_swimlane_collector_.read_phase_header_metadata();
         chip_swimlane_collector_.reconcile_counters();
         publish_host_phase_records_to_swimlane();
@@ -672,13 +681,13 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
     }
 
     if (enable_dump_args_) {
-        dump_collector_.stop();
+        dump_collector_.quiesce();
         dump_collector_.reconcile_counters();
         dump_collector_.export_dump_files();
     }
 
     if (enable_pmu_) {
-        pmu_collector_.stop();
+        pmu_collector_.quiesce();
         pmu_collector_.reconcile_counters();
     }
 
@@ -692,7 +701,7 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
                 LOG_ERROR("dep_gen host graph emit failed (%d) — deps.json not produced", emit_rc);
             }
         } else {
-            dep_gen_collector_.stop();
+            dep_gen_collector_.quiesce();
             if (dep_gen_collector_.reconcile_counters()) {
                 const auto &records = dep_gen_collector_.records();
                 int replay_rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
@@ -712,7 +721,7 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
     }
 
     if (enable_scope_stats_) {
-        scope_stats_collector_.stop();
+        scope_stats_collector_.quiesce();
         scope_stats_collector_.reconcile_counters();
         scope_stats_collector_.write_jsonl(output_prefix_);
     }
@@ -780,8 +789,9 @@ int DeviceRunner::finalize() {
         return 0;
     }
 
-    // cleanup_active_run() normally stops active collectors; this is the
-    // backstop for the initialized-but-never-enqueued case.
+    // Collectors outlive every run on this runner, so this is where their device
+    // resources are released — including for a runner that only ever initialized
+    // them and never enqueued.
     finalize_collectors();
 
     release_callable_state();
@@ -827,6 +837,7 @@ int DeviceRunner::finalize() {
 // =============================================================================
 
 void DeviceRunner::finalize_collectors() {
+    clear_collector_shape();
     if (chip_swimlane_collector_.is_initialized()) {
         chip_swimlane_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb);
     }
@@ -846,7 +857,7 @@ void DeviceRunner::finalize_collectors() {
 }
 
 int DeviceRunner::init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id) {
-    chip_swimlane_collector_.set_run_output(output_prefix_, chip_swimlane_level_);
+    chip_swimlane_collector_.begin_run(output_prefix_, chip_swimlane_level_);
     int rc = chip_swimlane_collector_.initialize(
         num_aicore, aicpu_thread_num, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb
     );
@@ -862,7 +873,7 @@ int DeviceRunner::init_chip_swimlane(int num_aicore, int aicpu_thread_num, int d
 int DeviceRunner::init_args_dump(Runtime &runtime, int device_id) {
     int num_dump_threads = runtime.get_aicpu_thread_num();
 
-    dump_collector_.set_run_output(output_prefix_, dump_args_level_);
+    dump_collector_.begin_run(output_prefix_, dump_args_level_);
     int rc =
         dump_collector_.initialize(num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb);
     if (rc != 0) {
@@ -876,7 +887,7 @@ int DeviceRunner::init_args_dump(Runtime &runtime, int device_id) {
 int DeviceRunner::init_pmu(
     int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int /*device_id*/
 ) {
-    pmu_collector_.set_run_output(csv_path, event_type);
+    pmu_collector_.begin_run(csv_path, event_type);
     int rc = pmu_collector_.init(
         num_cores, num_threads, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, /*device_id=*/-1
     );
@@ -889,6 +900,7 @@ int DeviceRunner::init_pmu(
 }
 
 int DeviceRunner::init_scope_stats(int num_threads) {
+    scope_stats_collector_.begin_run();
     // a5 sim: register_cb=nullptr, so the collector mallocs a host shadow per
     // device buffer; sim's profiling_copy_* are plain memcpys, so the dev/host
     // shadow path collapses to one allocation pair without address-space tricks.
@@ -904,6 +916,7 @@ int DeviceRunner::init_scope_stats(int num_threads) {
 }
 
 int DeviceRunner::init_dep_gen(int num_threads, int /*device_id*/) {
+    dep_gen_collector_.begin_run();
     // a5 sim: register_cb=nullptr; sim's profiling_copy_* are plain memcpys, so
     // the dev/host shadow path collapses to one allocation pair.
     int rc =

--- a/src/common/platform/include/host/args_dump_collector.h
+++ b/src/common/platform/include/host/args_dump_collector.h
@@ -228,22 +228,22 @@ public:
     // DumpMetaBuffers and payload arenas.
     //
     // The per-run configuration (output prefix, level) is NOT taken here — it
-    // is bound separately via set_run_output(), which the caller must call
-    // before initialize().
+    // is bound separately via begin_run(), which the caller must run before this
+    // on the first run.
     int initialize(
         int num_dump_threads, int device_id, const DumpAllocCallback &alloc_cb, DumpRegisterCallback register_cb,
         const DumpFreeCallback &free_cb
     );
 
-    // Per-run artifact configuration. Must be set before initialize(): the
-    // level is copied into DumpDataHeader there, so a later change would move
-    // only the host-side copy and leave the device on the previous one. The
-    // prefix is read when the writer thread starts lazily on the first
-    // collected buffer.
-    void set_run_output(const std::string &output_prefix, DumpArgsLevel dump_args_level) {
-        output_prefix_ = output_prefix;
-        dump_args_level_ = dump_args_level;
-    }
+    // Start a run's collection window: bind its artifact configuration, drop the
+    // previous run's shard state and counters, and — once the region exists —
+    // republish the level the device reads. The prefix is read when the writer
+    // thread starts lazily on the first collected buffer.
+    //
+    // The collector initializes once and serves every run, so this is the only
+    // point at which a run's collected records, dropped/truncated counts and
+    // device level are established; initialize() establishes none of them.
+    void begin_run(const std::string &output_prefix, DumpArgsLevel dump_args_level);
 
     void start(const profiling_common::ThreadFactory &thread_factory);
 

--- a/src/common/platform/include/host/chip_swimlane_collector.h
+++ b/src/common/platform/include/host/chip_swimlane_collector.h
@@ -381,22 +381,42 @@ public:
      */
     // Allocates the device-side resources.
     //
-    // num_aicore defines the shared-memory layout: every pool array after the
-    // first starts at an offset computed from it, and the AICPU side computes
-    // the same offsets from its own worker count. The two must agree, so this
-    // takes the run's dimension rather than a platform maximum.
+    // The pool-array offsets are fixed at compile time from PLATFORM_MAX_CORES,
+    // so the host and AICPU sides cannot disagree about them. num_aicore and
+    // aicpu_thread_num decide which of those fixed slots get buffers, and a
+    // core's recycled lane is assigned modulo aicpu_thread_num — so a collector
+    // that outlives a run holds pools shaped for those two counts, and the
+    // caller rebuilds it when a later run changes them.
     //
     // Per-run configuration (artifact prefix, level) is bound separately by
-    // set_run_output(), which must be called before initialize(): the level
-    // reaches the device header and selects the orch phase pool here.
+    // begin_run(), which must run before this on the first run: the level
+    // selects the orch phase pool here.
     int initialize(
         int num_aicore, int aicpu_thread_num, int device_id, const ChipSwimlaneAllocCallback &alloc_cb,
         ChipSwimlaneRegisterCallback register_cb, const ChipSwimlaneFreeCallback &free_cb
     );
 
-    void set_run_output(const std::string &output_prefix, ChipSwimlaneLevel chip_swimlane_level) {
+    /**
+     * Start a run's collection window: bind its artifact configuration, drop the
+     * previous run's records and counters, and — once the region exists —
+     * republish the level the device reads.
+     *
+     * The collector initializes once and serves every run, so this is the only
+     * point at which a run's records, counters and device level are established;
+     * initialize() establishes none of them. Skip it and this run's artifact
+     * carries the records every earlier run collected, reconcile compares an
+     * accumulated collected count against one run's device total, and the device
+     * stays on whichever level the first run asked for.
+     *
+     * Before the first initialize() there is no region and no shard storage yet;
+     * reset_collector_shards() is then a no-op over empty extents, and
+     * initialize() picks the level up from the member this sets.
+     */
+    void begin_run(const std::string &output_prefix, ChipSwimlaneLevel chip_swimlane_level) {
         output_prefix_ = output_prefix;
         chip_swimlane_level_ = chip_swimlane_level;
+        reset_collector_shards();
+        publish_run_config();
     }
 
     /**
@@ -510,6 +530,10 @@ public:
      * called after stop() so the shm region has settled.
      */
     void read_phase_header_metadata();
+
+    // Push the run's level into the device-visible header. A no-op before the
+    // region exists, and a single narrow field write once it does.
+    void publish_run_config();
 
     /**
      * Sum per-core / per-thread total_record_count and dropped_record_count

--- a/src/common/platform/include/host/dep_gen_collector.h
+++ b/src/common/platform/include/host/dep_gen_collector.h
@@ -193,6 +193,23 @@ public:
     );
 
     /**
+     * Start a run's collection window. Clears what the previous run left in the
+     * in-memory record set and its counter, and zeroes the device-side record
+     * counters reconcile compares against.
+     *
+     * The collector initializes once and serves every run, so this is the only
+     * point at which they are cleared; init() clears none of them, and nothing on
+     * the device clears the record counters — they are documented as monotonic.
+     * Skip it and the second run's deps.json carries the first run's edges, and
+     * reconcile compares one run's collected count against a device total
+     * accumulated over both, which suppresses the export.
+     *
+     * Called with the device quiesced, so the AICPU is not writing these and the
+     * collector threads are idle.
+     */
+    void begin_run();
+
+    /**
      * Device pointer to the DepGenDataHeader. Set kernel_args.dep_gen_data_base
      * to this after init() so AICPU can find the shared memory via
      * set_platform_dep_gen_base().

--- a/src/common/platform/include/host/profiler_base.h
+++ b/src/common/platform/include/host/profiler_base.h
@@ -870,6 +870,11 @@ public:
      */
     void start(const ThreadFactory &thread_factory) {
         if (shm_host_ == nullptr) return;
+        // Idempotent, like Derived::init(): the collector is resident across
+        // runs, so every run's arming reaches this and only the first should
+        // spawn. Without the guard each run would append another full set of
+        // threads to the same collector.
+        if (!collector_threads_.empty()) return;
 
         if (!thread_num_set_) {
             LOG_WARN(

--- a/src/common/platform/include/host/scope_stats_collector.h
+++ b/src/common/platform/include/host/scope_stats_collector.h
@@ -165,6 +165,16 @@ public:
         const ScopeStatsFreeCallback &free_cb, int device_id
     );
 
+    // Start a run's collection window: drop the previous run's records, its
+    // counter, and the recovered-buffer bookkeeping reconcile_counters() leaves
+    // behind. execution_complete_ is re-armed because it is what tells the
+    // collector loop a run is still producing.
+    //
+    // The collector initializes once and serves every run, so this is the only
+    // point at which they are cleared; init() clears none of them, and left
+    // alone they accumulate across runs.
+    void begin_run();
+
     // Device pointer to the ScopeStatsDataHeader. Set
     // kernel_args.scope_stats_data_base to this after init().
     void *get_scope_stats_shm_device_ptr() const { return shm_dev_; }

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -1928,7 +1928,7 @@ void DeviceRunnerBase::teardown_shared_collectors_after_run(bool device_executio
     // set on CallConfig (CallConfig::validate() enforces non-empty upstream).
     finish_clock_correlation_session(device_execution_complete, !can_accept_run());
     if (enable_chip_swimlane_) {
-        chip_swimlane_collector_.stop();
+        chip_swimlane_collector_.quiesce();
         chip_swimlane_collector_.read_phase_header_metadata();
         chip_swimlane_collector_.reconcile_counters();
         publish_host_phase_records_to_swimlane();
@@ -1938,18 +1938,18 @@ void DeviceRunnerBase::teardown_shared_collectors_after_run(bool device_executio
     write_host_phase_records_artifact();
 
     if (enable_dump_args_) {
-        dump_collector_.stop();
+        dump_collector_.quiesce();
         dump_collector_.reconcile_counters();
         dump_collector_.export_dump_files();
     }
 
     if (enable_pmu_) {
-        pmu_collector_.stop();
+        pmu_collector_.quiesce();
         pmu_collector_.reconcile_counters();
     }
 
     if (enable_scope_stats_) {
-        scope_stats_collector_.stop();
+        scope_stats_collector_.quiesce();
         scope_stats_collector_.reconcile_counters();
         scope_stats_collector_.write_jsonl(output_prefix_);
     }

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -982,6 +982,40 @@ protected:
     void teardown_shared_collectors_after_run(bool device_execution_complete);
 
     /**
+     * The core and AICPU-thread counts a resident collector's pools were built
+     * for.
+     *
+     * Collector pool topology is derived from those counts: buffer seeding
+     * covers pools [0, aicpu_thread_num), and a core's recycled lane is
+     * `(core / PLATFORM_CORES_PER_BLOCKDIM) % aicpu_thread_num`. A collector
+     * that stays initialized across runs therefore holds pools shaped for the
+     * run that built them, so a later run with different counts must rebuild
+     * them rather than reuse pools whose lanes it maps differently.
+     */
+    struct CollectorShape {
+        bool latched{false};
+        int num_aicore{0};
+        int aicpu_thread_num{0};
+        int launch_aicpu_num{0};
+    };
+
+    /** True once collectors are built and this run's counts differ from theirs. */
+    bool collector_shape_is_stale(int num_aicore, int aicpu_thread_num, int launch_aicpu_num) const {
+        return collector_shape_.latched &&
+               (collector_shape_.num_aicore != num_aicore || collector_shape_.aicpu_thread_num != aicpu_thread_num ||
+                collector_shape_.launch_aicpu_num != launch_aicpu_num);
+    }
+
+    void latch_collector_shape(int num_aicore, int aicpu_thread_num, int launch_aicpu_num) {
+        collector_shape_ = CollectorShape{true, num_aicore, aicpu_thread_num, launch_aicpu_num};
+    }
+
+    /** Called by the subclass's finalize_collectors(): no pools are built now. */
+    void clear_collector_shape() { collector_shape_ = CollectorShape{}; }
+
+    CollectorShape collector_shape_{};
+
+    /**
      * Shared body of `finalize()`. Each arch subclass's `finalize()`
      * handles: (a) the early-return + thread attach prologue, (b) any
      * arch-specific collector teardown (e.g. a2a3's `dep_gen_collector_`),

--- a/src/common/platform/shared/host/args_dump_collector.cpp
+++ b/src/common/platform/shared/host/args_dump_collector.cpp
@@ -62,6 +62,54 @@ size_t ArgsDumpCollector::normalize_collector_shard(int collector_shard) const {
     return static_cast<size_t>(collector_shard);
 }
 
+void ArgsDumpCollector::begin_run(const std::string &output_prefix, DumpArgsLevel dump_args_level) {
+    output_prefix_ = output_prefix;
+    dump_args_level_ = dump_args_level;
+    reset_collector_shards();
+    total_dropped_record_count_.store(0, std::memory_order_relaxed);
+    total_truncated_count_.store(0, std::memory_order_relaxed);
+    last_progress_ms_.store(0, std::memory_order_relaxed);
+    for (auto &count : written_payload_counts_) {
+        count.store(0, std::memory_order_relaxed);
+    }
+
+    // Before the first initialize() there is no region; initialize() writes the
+    // level from the member just set. Afterwards the device needs the new value
+    // by another route, and it is one narrow field rather than a bulk write-back
+    // so it cannot race the AICPU's own header fields.
+    if (shm_host_ != nullptr) {
+        DumpDataHeader *header = get_dump_header(shm_host_);
+        header->dump_args_level = static_cast<uint32_t>(dump_args_level_);
+        wmb();
+        (void)manager_.write_range_to_device(&header->dump_args_level, sizeof(header->dump_args_level));
+
+        // The per-thread payload counters are what reconcile compares against,
+        // and nothing on the device resets them. published/completed/dropped are
+        // contiguous, so one write-back per thread covers them.
+        //
+        // arena_write_offset is deliberately NOT reset: it is a monotonic cursor
+        // the host reads modulo arena_size, so it stays correct across runs.
+        static_assert(
+            offsetof(DumpBufferState, dropped_record_count) ==
+                offsetof(DumpBufferState, published_payload_count) + 2 * sizeof(uint64_t),
+            "the payload counters must stay contiguous for this single write-back to cover them"
+        );
+        constexpr size_t kCounterSpan = 2 * sizeof(uint64_t) + sizeof(uint32_t);
+        // The region holds num_dump_threads_ states (calc_dump_data_size), so
+        // that is the bound — a wider loop writes past its end. The runner
+        // rebuilds this collector when a run's thread count changes, so a
+        // resident one is never asked to reset a state it does not own.
+        for (int t = 0; t < num_dump_threads_; t++) {
+            DumpBufferState *state = get_dump_buffer_state(shm_host_, t);
+            state->published_payload_count = 0;
+            state->completed_payload_count = 0;
+            state->dropped_record_count = 0;
+            wmb();
+            (void)manager_.write_range_to_device(&state->published_payload_count, kCounterSpan);
+        }
+    }
+}
+
 void ArgsDumpCollector::reset_collector_shards() {
     const size_t shard_count = static_cast<size_t>(manager_.shard_count());
     collected_.clear();
@@ -94,8 +142,10 @@ int ArgsDumpCollector::initialize(
     const DumpFreeCallback &free_cb
 ) {
     if (shm_host_ != nullptr) {
-        LOG_ERROR("ArgsDumpCollector already initialized");
-        return PTO_RUNTIME_ERR_INTERNAL;
+        // Already holding this run's device resources. They are not per-run:
+        // configuration arrives via begin_run() and the layout is fixed at
+        // compile time, so there is nothing here left to re-apply.
+        return 0;
     }
     if (num_dump_threads <= 0 || num_dump_threads > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR(

--- a/src/common/platform/shared/host/chip_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/chip_swimlane_collector.cpp
@@ -99,8 +99,10 @@ int ChipSwimlaneCollector::initialize(
     ChipSwimlaneRegisterCallback register_cb, const ChipSwimlaneFreeCallback &free_cb
 ) {
     if (shm_host_ != nullptr) {
-        LOG_ERROR("ChipSwimlaneCollector already initialized");
-        return PTO_RUNTIME_ERR_INTERNAL;
+        // Already holding this run's device resources. They are not per-run:
+        // configuration arrives via begin_run() and the layout is fixed at
+        // compile time, so there is nothing here left to re-apply.
+        return 0;
     }
     if (num_aicore <= 0 || num_aicore > PLATFORM_MAX_CORES) {
         LOG_ERROR("Invalid number of AICores: %d (max=%d)", num_aicore, PLATFORM_MAX_CORES);
@@ -831,6 +833,52 @@ void ChipSwimlaneCollector::reconcile_counters() {
         },
         sizeof(ChipSwimlaneAicpuOrchPhaseBuffer), total_orch_phase_collected_, /*optional=*/true
     );
+}
+
+void ChipSwimlaneCollector::publish_run_config() {
+    // Nothing to publish before the region exists; initialize() writes the level
+    // from the member begin_run() just set.
+    if (shm_host_ == nullptr) return;
+
+    ChipSwimlaneDataHeader *header = get_chip_swimlane_header(shm_host_);
+    header->chip_swimlane_level = static_cast<uint32_t>(chip_swimlane_level_);
+    wmb();
+    // One field, not the region: a bulk write-back would race the AICPU's own
+    // header fields (phase thread counts, core_to_thread) — see
+    // buffer_pool_manager.h's note on narrow write_range_to_device calls. On SVM
+    // platforms copy_to_device is null and this is a no-op, because the store
+    // above already landed in device-visible memory.
+    (void)manager_.write_range_to_device(&header->chip_swimlane_level, sizeof(header->chip_swimlane_level));
+
+    // The pools' record counters are producer-side and never reset by the
+    // device, so they carry the previous run's totals into this run's reconcile
+    // unless cleared here.
+    //
+    // total_record_count and dropped_record_count are adjacent, so one narrow
+    // write covers both and leaves the device-owned fields in the same cache
+    // line (current_buf_ptr, current_buf_seq) untouched.
+    auto reset_head = [this](ChipSwimlaneActiveHead *head) {
+        head->total_record_count = 0;
+        head->dropped_record_count = 0;
+        wmb();
+        static_assert(
+            offsetof(ChipSwimlaneActiveHead, dropped_record_count) ==
+                offsetof(ChipSwimlaneActiveHead, total_record_count) + sizeof(uint32_t),
+            "the two counters must stay adjacent for this single write-back to cover both"
+        );
+        (void)manager_.write_range_to_device(&head->total_record_count, 2 * sizeof(uint32_t));
+    };
+
+    // Every slot, not just this run's: the grid is dimensioned by the platform
+    // maximum and a later run may use more cores than the one that dirtied them.
+    for (int i = 0; i < PLATFORM_MAX_CORES; i++) {
+        reset_head(&get_perf_buffer_state(shm_host_, i)->head);
+        reset_head(&get_aicore_buffer_state(shm_host_, i)->head);
+    }
+    for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+        reset_head(&get_sched_phase_buffer_state(shm_host_, t)->head);
+        reset_head(&get_orch_phase_buffer_state(shm_host_, t)->head);
+    }
 }
 
 void ChipSwimlaneCollector::read_phase_header_metadata() {

--- a/src/common/platform/shared/host/dep_gen_collector.cpp
+++ b/src/common/platform/shared/host/dep_gen_collector.cpp
@@ -47,8 +47,10 @@ int DepGenCollector::init(
     const DepGenFreeCallback &free_cb, int device_id
 ) {
     if (initialized_) {
-        LOG_ERROR("DepGenCollector already initialized");
-        return PTO_RUNTIME_ERR_INTERNAL;
+        // Already holding this run's device resources. They are not per-run:
+        // configuration arrives via begin_run() and the layout is fixed at
+        // compile time, so there is nothing here left to re-apply.
+        return 0;
     }
     if (num_threads <= 0 || num_threads > PLATFORM_MAX_AICPU_THREADS || alloc_cb == nullptr || free_cb == nullptr) {
         LOG_ERROR(
@@ -153,6 +155,34 @@ int DepGenCollector::init(
 // ---------------------------------------------------------------------------
 // Record accumulation (in-memory — no disk hop)
 // ---------------------------------------------------------------------------
+
+void DepGenCollector::begin_run() {
+    {
+        std::scoped_lock lock(records_mutex_);
+        records_.clear();
+    }
+    total_collected_ = 0;
+
+    // Nothing on the device yet before the first init(); its memset covers this.
+    if (shm_host_ == nullptr) return;
+
+    // The device's record counters are monotonic by contract (see dep_gen.h), so
+    // they carry the previous run's totals into this one's reconcile. Zeroing
+    // them is safe here and only here: the caller has quiesced the device, so
+    // the AICPU is not writing them concurrently.
+    DepGenBufferState *state = get_dep_gen_buffer_state(shm_host_, 0);
+    state->total_record_count = 0;
+    state->dropped_record_count = 0;
+    state->total_overflow_record_count = 0;
+    wmb();
+    // Narrow write-backs, not the region: a bulk push would clobber the
+    // device-owned fields next to these (current_buf_ptr, free_queue.head).
+    (void)manager_.write_range_to_device(&state->total_record_count, sizeof(state->total_record_count));
+    (void)manager_.write_range_to_device(&state->dropped_record_count, sizeof(state->dropped_record_count));
+    (void)manager_.write_range_to_device(
+        &state->total_overflow_record_count, sizeof(state->total_overflow_record_count)
+    );
+}
 
 void DepGenCollector::append_buffer_records(const void *buf_host_ptr) {
     const DepGenBuffer *buf = reinterpret_cast<const DepGenBuffer *>(buf_host_ptr);

--- a/src/common/platform/shared/host/scope_stats_collector.cpp
+++ b/src/common/platform/shared/host/scope_stats_collector.cpp
@@ -60,8 +60,10 @@ int ScopeStatsCollector::init(
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     if (initialized_) {
-        LOG_ERROR("ScopeStatsCollector already initialized");
-        return PTO_RUNTIME_ERR_INTERNAL;
+        // Already holding this run's device resources. They are not per-run:
+        // configuration arrives via begin_run() and the layout is fixed at
+        // compile time, so there is nothing here left to re-apply.
+        return 0;
     }
 
     // Must precede the recycled-lane seeding below: push_recycled() folds its
@@ -151,6 +153,35 @@ int ScopeStatsCollector::init(
 // ---------------------------------------------------------------------------
 // Record accumulation (in-memory)
 // ---------------------------------------------------------------------------
+
+void ScopeStatsCollector::begin_run() {
+    {
+        std::scoped_lock lock(records_mutex_);
+        records_.clear();
+    }
+    total_collected_ = 0;
+    recovered_current_buf_ = 0;
+    recovered_current_total_ = 0;
+    execution_complete_.store(false, std::memory_order_release);
+
+    if (shm_host_ == nullptr) return;
+
+    // The device's record counters are producer-side and never reset by it, so
+    // they carry the previous run's totals into this run's reconcile. The old
+    // finalize/init cycle cleared them implicitly by memsetting a fresh region.
+    // The two are adjacent, so one write-back covers both and leaves the
+    // device-owned fields in the same line alone.
+    ScopeStatsBufferState *state = get_scope_stats_buffer_state(shm_host_, 0);
+    state->dropped_record_count = 0;
+    state->total_record_count = 0;
+    wmb();
+    static_assert(
+        offsetof(ScopeStatsBufferState, total_record_count) ==
+            offsetof(ScopeStatsBufferState, dropped_record_count) + sizeof(uint32_t),
+        "the two counters must stay adjacent for this single write-back to cover both"
+    );
+    (void)manager_.write_range_to_device(&state->dropped_record_count, 2 * sizeof(uint32_t));
+}
 
 void ScopeStatsCollector::append_buffer_records(const void *buf_host_ptr) {
     const ScopeStatsBuffer *buf = reinterpret_cast<const ScopeStatsBuffer *>(buf_host_ptr);

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -506,6 +506,40 @@ protected:
     PmuCollector pmu_collector_;
     ScopeStatsCollector scope_stats_collector_;
 
+    /**
+     * The core and AICPU-thread counts a resident collector's pools were built
+     * for.
+     *
+     * Collector pool topology is derived from those counts: buffer seeding
+     * covers pools [0, aicpu_thread_num), and a core's recycled lane is
+     * `(core / PLATFORM_CORES_PER_BLOCKDIM) % aicpu_thread_num`. A collector
+     * that stays initialized across runs therefore holds pools shaped for the
+     * run that built them, so a later run with different counts must rebuild
+     * them rather than reuse pools whose lanes it maps differently.
+     */
+    struct CollectorShape {
+        bool latched{false};
+        int num_aicore{0};
+        int aicpu_thread_num{0};
+        int launch_aicpu_num{0};
+    };
+
+    /** True once collectors are built and this run's counts differ from theirs. */
+    bool collector_shape_is_stale(int num_aicore, int aicpu_thread_num, int launch_aicpu_num) const {
+        return collector_shape_.latched &&
+               (collector_shape_.num_aicore != num_aicore || collector_shape_.aicpu_thread_num != aicpu_thread_num ||
+                collector_shape_.launch_aicpu_num != launch_aicpu_num);
+    }
+
+    void latch_collector_shape(int num_aicore, int aicpu_thread_num, int launch_aicpu_num) {
+        collector_shape_ = CollectorShape{true, num_aicore, aicpu_thread_num, launch_aicpu_num};
+    }
+
+    /** Called by the subclass's finalize_collectors(): no pools are built now. */
+    void clear_collector_shape() { collector_shape_ = CollectorShape{}; }
+
+    CollectorShape collector_shape_{};
+
     // Enablement flags. Written before enqueue and read by execution helpers.
     bool enable_chip_swimlane_{false};
     bool enable_dump_args_{false};

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/residency/test_collector_residency.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/residency/test_collector_residency.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Several diagnostic runs on one worker, each with its own output prefix.
+
+The collectors are resident: their device resources and threads are created on
+the first run that needs them and released at ``finalize_device``. Everything
+that describes a single run therefore has to be reset between runs, and nothing
+in the framework exercises that — ``--rounds > 1`` disables every diagnostic
+channel (``effective_diagnostic_options``), so "one worker, several runs, DFX
+on" does not otherwise occur in the test suite.
+
+Two distinct failures are covered, both silent — they produce *wrong artifacts*
+rather than an error:
+
+* **Leaked per-run state.** A record vector or device counter carried over makes
+  a run's artifact describe an earlier one. For ``deps.json`` a leaked device
+  counter makes ``reconcile_counters`` compare one run's collected count against
+  a device total accumulated over both, which suppresses the export entirely.
+  For the swimlane the observed shape is subtler than duplication: the merge of
+  the collector shards is latched by a "already merged" flag, so a second run
+  re-exports the *first run's records verbatim* — same count, same everything.
+  A count or non-emptiness check therefore cannot see it, and neither can
+  comparing the two runs' payloads, which are identical by construction. What
+  separates them is time: the runs are sequential, so their record windows
+  cannot overlap, and a re-export of stale records lands in the earlier window.
+
+* **A latched pool shape.** Collector pools are seeded for the core and
+  AICPU-thread counts of the run that built them, and a core's recycled lane is
+  assigned modulo the thread count. A run with different counts must rebuild
+  them, so the last run here asks for a different ``aicpu_thread_num`` and must
+  still produce a complete artifact.
+
+Scope, stated plainly: this catches dep_gen and the swimlane export. The other
+three channels (pmu, args_dump, scope_stats) reconcile with a WARN and export
+anyway, so a leaked counter there does not change their artifacts and this test
+would not see it — their resets rest on being structurally identical to the two
+that are covered. Asserting on the reconcile warnings is not an option: they are
+emitted by the C++ HostLogger, which does not route through Python's logging, so
+a ``caplog`` assertion silently matches nothing (measured, not assumed).
+
+The collectors are shared code, so one arch covers them. It is a2a3 because that
+is the arch with a host-map path: a resident collector that leaks a
+halHostRegister mapping across runs fails the next one at rc=8, and only the
+onboard a2a3 lane can observe it.
+"""
+
+import json
+
+import torch
+from simpler.task_interface import ArgDirection as D
+from simpler.task_interface import CallConfig
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+from simpler_setup.scene_test import _build_l2_ref_args, build_output_prefix
+
+KERNELS_BASE = "../../../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
+
+# Runs 0 and 1 share a shape, so residency keeps their pools. Run 2 changes it,
+# which forces the collectors to rebuild.
+RUN_THREAD_COUNTS = (2, 2, 3)
+
+EXPECTED_TASKS = 5
+EXPECTED_EDGES = 6
+
+# An aicore_tasks record is
+# [core_id, task_token_raw, reg_task_id, start_cycles, end_cycles, receive_to_start_cycles].
+RECORD_START = 3
+RECORD_END = 4
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestCollectorResidency(SceneTestCase):
+    """Drive two runs through one worker with dep_gen and swimlane on."""
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{KERNELS_BASE}/orchestration/example_orchestration.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "source": f"{KERNELS_BASE}/aiv/kernel_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "source": f"{KERNELS_BASE}/aiv/kernel_add_scalar.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.OUT],
+            },
+            {
+                "func_id": 2,
+                "source": f"{KERNELS_BASE}/aiv/kernel_mul.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "repeated_runs",
+            "platforms": ["a2a3sim", "a2a3"],
+            "manual": ["a2a3sim"],
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        SIZE = 128 * 128
+        return TaskArgsBuilder(
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
+        )
+
+    def compute_golden(self, args, params):
+        args.f[:] = (args.a + args.b + 1) * (args.a + args.b + 2) + (args.a + args.b)
+
+    @staticmethod
+    def _aicore_records(prefix):
+        path = prefix / "chip_swimlane_records.json"
+        assert path.exists(), f"chip_swimlane_records.json missing under {prefix}"
+        with path.open() as f:
+            return json.load(f).get("aicore_tasks", [])
+
+    @staticmethod
+    def _deps(prefix):
+        path = prefix / "deps.json"
+        assert path.exists(), (
+            f"deps.json missing under {prefix}. A resident collector whose device counters were "
+            f"not reset fails reconcile_counters() and skips the export."
+        )
+        with path.open() as f:
+            return json.load(f)
+
+    def test_run(self, st_platform, st_worker, request):
+        # Deliberately does NOT call super().test_run(): the standard loop routes
+        # repeats through --rounds, which turns the diagnostics off. This drives
+        # Worker.run directly so every run keeps dep_gen and swimlane enabled.
+        cases = self._matching_cases(st_platform, request)
+        if not cases:
+            return
+        case = cases[0]
+
+        callable_obj = self.build_callable(st_platform)
+        handle = st_worker.register(callable_obj)
+        orch_sig = self.CALLABLE.get("orchestration", {}).get("signature", [])
+
+        artifacts = []
+        for run_index, thread_count in enumerate(RUN_THREAD_COUNTS):
+            prefix = build_output_prefix(f"{type(self).__name__}_{case['name']}_run{run_index}")
+            args = self.generate_args(case.get("params", {}))
+            chip_args, _output_names = _build_l2_ref_args(args, orch_sig, st_worker)
+
+            config = CallConfig()
+            # dep_gen is a bool; chip_swimlane is a level.
+            config.enable_dep_gen = True
+            config.enable_chip_swimlane = 1
+            config.aicpu_thread_num = thread_count
+            config.output_prefix = str(prefix)
+            st_worker.run(handle, chip_args, config)
+            artifacts.append(prefix)
+
+        assert len(set(artifacts)) == len(artifacts), "the runs shared an output prefix; the test proves nothing"
+
+        # Every run's set must be complete on its own, including the one that
+        # rebuilt the pools at a new shape.
+        for run_index, prefix in enumerate(artifacts):
+            deps = self._deps(prefix)
+            tasks, edges = deps.get("tasks", []), deps.get("edges", [])
+            assert len(tasks) == EXPECTED_TASKS, (
+                f"run {run_index}: expected {EXPECTED_TASKS} tasks, got {len(tasks)}. More than that "
+                f"means an earlier run's records were not cleared from the in-memory set."
+            )
+            assert len(edges) == EXPECTED_EDGES, f"run {run_index}: expected {EXPECTED_EDGES} edges, got {len(edges)}"
+            assert self._aicore_records(prefix), (
+                f"run {run_index}: swimlane captured no records. An unreset collected counter makes "
+                f"reconcile drop the whole run."
+            )
+
+        # The runs are sequential, so each one's records must lie entirely after
+        # the previous one's. Re-exported stale records fail this while matching
+        # on every other observable.
+        previous_end = None
+        for run_index, prefix in enumerate(artifacts):
+            records = self._aicore_records(prefix)
+            first_start = min(record[RECORD_START] for record in records)
+            last_end = max(record[RECORD_END] for record in records)
+            if previous_end is not None:
+                assert first_start > previous_end, (
+                    f"run {run_index}'s records start at {first_start}, which is not after run "
+                    f"{run_index - 1}'s last record end {previous_end}. A resident collector that keeps "
+                    f"the previous run's merged records re-exports them under this run's prefix."
+                )
+            previous_end = last_end
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/ut/cpp/common/test_args_dump_collector.cpp
+++ b/tests/ut/cpp/common/test_args_dump_collector.cpp
@@ -48,7 +48,7 @@ TEST(ArgsDumpCollectorTest, MergesConcurrentShardRecordsIntoManifest) {
     constexpr int kRecordsPerShard = 32;
     constexpr int kShardCount = DumpModule::kMaxCollectorThreads;
     ArgsDumpCollector collector;
-    collector.set_run_output(test_dir.string(), DumpArgsLevel::HYBRID);
+    collector.begin_run(test_dir.string(), DumpArgsLevel::HYBRID);
     ASSERT_EQ(collector.initialize(kShardCount, 0, test_alloc, nullptr, test_free), 0);
 
     std::vector<DumpMetaBuffer> buffers(kShardCount);
@@ -109,7 +109,7 @@ TEST(ArgsDumpCollectorTest, BackpressureReleaseWaitsForAllPublishedPayloads) {
     constexpr int kArenaCount = 2;
     constexpr uint64_t kPayloadSize = sizeof(uint64_t);
     TestArgsDumpCollector collector;
-    collector.set_run_output(test_dir.string(), DumpArgsLevel::FULL);
+    collector.begin_run(test_dir.string(), DumpArgsLevel::FULL);
     ASSERT_EQ(collector.initialize(kArenaCount, 0, test_alloc, nullptr, test_free), 0);
 
     auto *device_base = collector.get_dump_shm_device_ptr();
@@ -175,7 +175,7 @@ TEST(ArgsDumpCollectorTest, BackpressureReleaseDoesNotOffsetPayloadsAcrossThread
     ASSERT_TRUE(std::filesystem::create_directories(test_dir));
 
     TestArgsDumpCollector collector;
-    collector.set_run_output(test_dir.string(), DumpArgsLevel::FULL);
+    collector.begin_run(test_dir.string(), DumpArgsLevel::FULL);
     ASSERT_EQ(collector.initialize(2, 0, test_alloc, nullptr, test_free), 0);
 
     auto *device_base = collector.get_dump_shm_device_ptr();

--- a/tests/ut/cpp/common/test_pmu_collector.cpp
+++ b/tests/ut/cpp/common/test_pmu_collector.cpp
@@ -42,7 +42,7 @@ TEST(PmuCollectorTest, PreservesShardFilesWhenFinalCsvCannotBeOpened) {
     ASSERT_TRUE(std::filesystem::create_directories(csv_path));
 
     PmuCollector collector;
-    collector.set_run_output(csv_path.string(), PmuEventType::PIPE_UTILIZATION);
+    collector.begin_run(csv_path.string(), PmuEventType::PIPE_UTILIZATION);
     ASSERT_EQ(collector.init(1, 1, test_alloc, nullptr, test_free, 0), 0);
 
     PmuBuffer buffer{};
@@ -75,7 +75,7 @@ TEST(PmuCollectorTest, MergesConcurrentShardWritesIntoFinalCsv) {
     constexpr int kRecordsPerShard = 64;
     constexpr int kShardCount = PmuModule::kMaxCollectorThreads;
     PmuCollector collector;
-    collector.set_run_output(csv_path.string(), PmuEventType::PIPE_UTILIZATION);
+    collector.begin_run(csv_path.string(), PmuEventType::PIPE_UTILIZATION);
     ASSERT_EQ(collector.init(1, kShardCount, test_alloc, nullptr, test_free, 0), 0);
 
     std::atomic<int> ready_workers{0};


### PR DESCRIPTION
## Summary

The five host-side DFX collectors were worker-level objects with run-level resource lifetime: every run initialized them, started their threads, and finalized them again. They now initialize once per worker and are released at `finalize_device`, so a worker that runs repeatedly no longer rebuilds five shared-memory regions and their thread sets on each run.

Part of #2078.

Three parts of the collectors depended on that per-run rebuild, and each had to be handled for residency to be correct.

**Draining.** `stop()` guaranteed the two queue levels were drained *by joining the threads that consume them* — joining mgmt proved its final sweep landed, joining the collector shards proved the shards were consumed. `quiesce()` supplies the same guarantee through a two-phase epoch handshake, so the threads observe the run boundary and survive it. `start()` becomes idempotent for the same reason `init()` is: otherwise each run appends another full set of threads to the same collector.

**Per-run state.** `initialize()` cleared it as a byproduct of allocating a fresh region, so each collector now takes a `begin_run()` that binds the run's artifact configuration and drops everything describing a single run. That includes the **device-side record counters**, the easiest half to miss: the AICPU never resets them, they are documented as monotonic, and reconcile compares the host's collected count against them — so a carried counter makes dep_gen skip its export entirely. Each reset is a narrow `write_range_to_device` over adjacent counters rather than a bulk write-back, so it cannot race the AICPU-owned fields sharing their cache line.

**Pool topology.** Buffer seeding covers pools `[0, aicpu_thread_num)`, and a core's recycled lane is `(core / CORES_PER_BLOCKDIM) % aicpu_thread_num`, so a collector's pools are shaped for the core and AICPU-thread counts of the run that built them. The runners latch those counts and rebuild the collectors when a later run differs — scene tests sharing a directory share a worker and do vary `aicpu_thread_num`. The pool-array offsets stay a compile-time constant (#2107), so this changes no host/device sizing contract.

## Testing

`tests/st/a2a3/tensormap_and_ringbuffer/dfx/residency` covers both failure modes. It drives `Worker.run` twice at one shape and once at another, bypassing the `--rounds` path that disables every diagnostic — which is why "one worker, several runs, DFX on" occurs nowhere else in the suite. It lives on a2a3 because that is the arch with a host-map path, where a leaked `halHostRegister` mapping fails the next run at rc=8.

Both failures are silent and produce *wrong artifacts* rather than errors, so the assertions are specific rather than "non-empty":

- the runs are sequential, so each run's swimlane records must start after the previous run's last record ends;
- every run's `deps.json` must be complete on its own.

Both were confirmed to be load-bearing by reverting each fix in turn:

| Fix reverted | Result |
| ------------ | ------ |
| swimlane per-run record reset | `run 1's records start at …, which is not after run 0's last record end …` — run 1 re-exported run 0's records verbatim (same count, same content) |
| pool-shape rebuild | run 2 lost `deps.json` entirely — reconcile failed and the export was skipped |

Gate run on `upstream/main@4e4d3a4ad` + this commit:

- [x] DFX channels, one per invocation as CI runs them: 12 runs (5 channels × a2a3sim/a5sim, plus hbg dep_gen on both) — all pass
- [x] a2a3 **onboard** (real silicon, via `task-submit`): all 7 channels including residency
- [x] `a5sim` sweep — pass
- [x] `a2a3sim` sweep — 44 passed; the one failure (`TestSpmdPagedAttentionHighPerf::b4_h32_kv8_s512_bs128_fp16`, `max_diff=0.0625`) is pre-existing, reproduced identically on a clean base build, and is `manual`-only so the per-PR lane deselects it
- [x] cpput 132/132, pyut 2126/2126
- [x] clang-format, cpplint, the four `tests/lint` hooks, ruff, pyright

The pmu and args_dump C++ unit tests follow the renamed entry point.
