### PR TITLE
feat(dfx): unify chip-swimlane scheduler schema

### DIFF
--- a/docs/dfx/chip-swimlane-profiling.md
+++ b/docs/dfx/chip-swimlane-profiling.md
@@ -28,12 +28,12 @@ end-to-end runtime numbers. Two cases dominate the profiler diet:
   pinpoints the fix.
 
 chip swimlane profiling captures both: per-task `(start, end,
-dispatch, finish)` records on the AICore side, plus per-iteration
-phase records on the AICPU scheduler side and per-submit orchestrator
+dispatch, finish)` records, plus per-iteration phase records from the active
+AICPU or AICore scheduler producer and per-submit orchestrator
 envelopes. The host writes a Chrome Trace Event JSON
-that loads directly in Perfetto, and the same file feeds a
-scheduler-overhead deep-dive report when a device log is
-available.
+that loads directly in Perfetto. For the scheduler-overhead deep-dive, capture
+`deps.json` separately and invoke `sched_overhead_analysis` explicitly; see its
+[tool documentation](../../simpler_setup/tools/README.md#sched_overhead_analysis).
 
 ## 2. Overview
 
@@ -45,7 +45,7 @@ available.
   `chip_swimlane_records.json` with `deps.json` from
   [`dep_gen`](dep-gen.md) at post-process time; see
   [§3.5](#35-dependency-arrows-from-dep_gen).
-- **AICPU scheduler phases** — per-iteration breakdown into mutually
+- **Scheduler phases** — producer-specific per-iteration breakdown. AICPU uses mutually
   time-exclusive **outer** phases (`complete` / `async_poll` / `dispatch` /
   `release` / `dummy` / `early_dispatch` / `drain` / `graph_prepare`), plus
   nested phases.
@@ -106,9 +106,9 @@ backward-compatible with the old boolean behavior).
 | Level | Collects | Notes |
 | ----- | -------- | ----- |
 | 0 | Nothing (disabled) | Default when flag is absent |
-| 1 | AICore timing only (start_time_us/end_time_us/task_id/func_id/core_type) | No AICPU timestamps |
-| 2 | + dispatch_time_us, finish_time_us | Full per-task AICPU record |
-| 3 | + scheduler phases (`aicpu_scheduler_phases[]`) | Skips orchestrator phases |
+| 1 | AICore timing only (start_time_us/end_time_us/task_id/func_id/core_type) | No Scheduler timestamps |
+| 2 | + Scheduler per-task dispatch_time_us, finish_time_us | Producer is identified as `aicpu` or `aicore` |
+| 3 | + scheduler phases (`scheduler_records`) | Skips orchestrator phases |
 | 4 | + orchestrator phases (`aicpu_orchestrator_phases[]`) | Full collection |
 
 Dependency arrows are not produced by any swimlane level — see
@@ -135,13 +135,13 @@ The flag sets `CallConfig::enable_chip_swimlane` to the chosen
 level. The host then allocates the per-core / per-thread shared
 region and publishes its base address through
 `kernel_args.chip_swimlane_data_base`. AICore writes timing into
-per-task WIP slots; AICPU commits the records on FIN. Per-task
-dispatch/finish timestamps are recorded only at level >= 2,
+per-task WIP slots; the active Scheduler records dispatch/finish timestamps.
+Per-task Scheduler timestamps are recorded only at level >= 2,
 scheduler phase records only at level >= 3, and orchestrator phase
 records only at level >= 4.
 
 The JSON output `"chip_swimlane_level"` field is the captured perf_level:
-`1` = AICore timing only, `2` = +AICPU dispatch/finish,
+`1` = AICore timing only, `2` = +Scheduler per-task dispatch/finish,
 `3` = +scheduler phases, `4` = +orchestrator phases.
 
 Chip-swimlane collection is disabled when `--rounds > 1` so benchmark
@@ -231,31 +231,51 @@ layers to be aware of:**
     "core_to_thread": [<int>, ...]     // optional; level >= 3 only
   },
 
-  // Bulk task streams — flat array of tuples. Column order is fixed.
+  // Bulk task streams. Tuple column order is fixed.
   //   aicore_tasks: [core_id, task_token_raw, reg_task_id,
   //                  start_cycles, end_cycles]
-  //   aicpu_tasks:  [core_id, reg_task_id,
-  //                  dispatch_cycles, finish_cycles]
+  //   scheduler_tasks.records: [core_id, reg_task_id,
+  //                             dispatch_cycles, finish_cycles]
   "aicore_tasks": [[...], ...],
-  "aicpu_tasks":  [[...], ...],
+  "scheduler_tasks": {
+    "schema_version": 1,
+    "producer": "<aicpu|aicore>",
+    "records": [[...], ...]
+  },
 
-  // Per-scheduler-thread arrays of objects (level >= 3 only).
-  //   sched record: {kind, start_cycles, end_cycles, loop_iter,
-  //                  tasks_processed, [pop_hit, pop_miss]}
+  // Producer-neutral per-Scheduler streams (level >= 3 only).
+  "scheduler_records": {
+    "schema_version": 1,
+    "streams": [{
+      "platform": "<a2a3|a5>",
+      "runtime": "<host_build_graph|tensormap_and_ringbuffer>",
+      "producer": "<aicpu|aicore>",
+      "scheduler_id": <int>,
+      "worker_id": <int>,
+      "core_type": "<aicpu|aic|aiv>",
+      "physical_core_id": "<int|null>",
+      "capture": {"committed": <int>, "dropped": <int>, "truncated": <bool>},
+      "records": [{"start_cycles": <int>, "end_cycles": <int>,
+                   "loop_iter": <int>, "kind": <str>,
+                   "tasks_processed": <int>, "task_id": "<int|null>"}],
+      "metrics": [{"record_index": <int>, ...}]
+    }]
+  },
+
+  // Orchestrator records (level >= 4 only).
   //   orch record:  {submit_idx, task_id, start_cycles, end_cycles}
-  // pop_hit / pop_miss are present only on Dispatch records.
-  "aicpu_scheduler_phases":    [ [ {...}, ... ], ... ],
   "aicpu_orchestrator_phases": [ [ {...}, ... ], ... ]   // level >= 4 only
 }
 ```
 
 All timestamps on disk are raw `get_sys_cnt` cycles (uint64). The
-join key between `aicore_tasks` and `aicpu_tasks` is
+join key between `aicore_tasks` and `scheduler_tasks.records` is
 `(core_id, reg_task_id)` — *not* `task_token_raw`, because SPMD
 `block_num > num_cores` and MIX cluster spread can dispatch the same
 `task_token_raw` to the same core multiple times. AICore is the
-canonical producer of `task_token_raw`; AICPU only stamps the
-dispatch / finish timestamps and the per-core join token.
+canonical producer of `task_token_raw`; the Scheduler producer stamps the
+dispatch / finish timestamps and the per-core join token. Archived raw files
+with the former `aicpu_tasks` array remain readable as `producer: "aicpu"`.
 
 #### Reader output (µs domain)
 
@@ -268,15 +288,16 @@ microseconds, downstream code sees:
 | `func_id` | Kernel function id. Always `-1` on disk; resolved post-process from `deps.json::tasks[].kernel_ids[3]` (see `swimlane_converter.resolve_func_id_from_kernel_map`) |
 | `core_id` / `core_type` | Physical core index and `"aic"` / `"aiv"` string |
 | `start_time_us` / `end_time_us` / `duration_us` | AICore execution window in microseconds |
-| `dispatch_time_us` | AICPU timestamp when this task was dispatched (filled at level >= 2; `0.0` at level 1) |
-| `finish_time_us` | AICPU timestamp when AICPU observed FIN (filled at level >= 2; `0.0` at level 1) |
+| `dispatch_time_us` | Scheduler timestamp when dispatch publication completed (filled at level >= 2) |
+| `finish_time_us` | Scheduler timestamp when completion processing began (filled at level >= 2) |
 
 Note: per-task records carry **no** fanout edges. Dependency arrows
 come from a separate `deps.json` (dep_gen) joined at convert time —
 see [§3.5](#35-dependency-arrows-from-dep_gen).
 
-Phase records (per scheduler thread, level >= 3 for
-`aicpu_scheduler_phases[]` and level >= 4 for
+Phase records (per Scheduler stream, level >= 3 in raw
+`scheduler_records`—also exposed through the legacy reader alias
+`aicpu_scheduler_phases`—and level >= 4 for
 `aicpu_orchestrator_phases[]`):
 
 | Field | Meaning |
@@ -446,13 +467,13 @@ same lane structure — the directory form repeats it once per Rank under the
 
 - **Orchestrator** (pid=1) — per-submit `orch_submit` envelope
   blocks (level >= 4).
-- **AICPU Scheduler** (pid=2) — per-iteration scheduler phase
+- **Scheduler** (pid=2) — per-iteration scheduler phase
   blocks coloured by `phase` (level >= 3). Outer phases appear as sibling bars
   on each scheduler thread's first `Sched_N` lane. TMR's nested `resolve`
   appears on an adjacent `Sched_N` sub-lane; HBG's standalone `resolve` stays
   on the P thread's first lane. `drain_prepare` and `drain_publish` nest within
   `drain`.
-- **Scheduler View** (pid=3) — task-execution overlay using AICPU
+- **Scheduler View** (pid=3) — task-execution overlay using Scheduler
   dispatch/finish timestamps (level >= 2), with the same labels
   as Worker View.
 - **Worker View** (pid=4) — one swim-lane per physical worker:
@@ -496,12 +517,10 @@ whether a `deps.json` is present** (see
   prints a one-line hint). Re-run with `--enable-dep-gen` (or join an
   existing `deps.json`) to recover names and arrows.
 
-When the run also emitted a device log (`device-*` file under
-`outputs/`), `swimlane_converter` resolves the nearest log by
-mtime and runs `sched_overhead_analysis` automatically. The
-report is printed to stdout; it correlates AICPU phase records
-with the device log to attribute each scheduler iteration to a
-specific overhead source.
+`swimlane_converter` does not run the scheduler-overhead deep-dive. Capture
+`deps.json` and `chip_swimlane_records.json` in separate runs, then invoke
+`sched_overhead_analysis` explicitly as described in the
+[tool documentation](../../simpler_setup/tools/README.md#sched_overhead_analysis).
 
 The scheduler-budget parser counts every mutually exclusive outer phase and
 standalone HBG P-thread `resolve` bars. It excludes only `resolve` records whose
@@ -564,7 +583,7 @@ Two artifacts, one join:
 | `chip_swimlane_records.json` | `--enable-chip-swimlane` | Per-task / per-phase timing for one run |
 | `merged_swimlane.json` | `swimlane_converter` | Perfetto trace = timing joined to the graph |
 
-**Default workflow (paired flags, recommended for most runs):**
+**Co-capture workflow (functional debugging and CI smoke):**
 
 ```bash
 python test_my_case.py --platform a2a3 \
@@ -573,10 +592,11 @@ python test_my_case.py --platform a2a3 \
 
 Both artifacts land under the same `<output_prefix>/`; the
 converter auto-detects `deps.json` and emits flow arrows. This is the
-right default for CI smoke, single debugging runs, and small/medium
-workloads.
+convenient path for CI smoke and one-off functional debugging. Do not use
+co-captured timing for strict scheduler-overhead measurement because dep_gen
+adds per-submit work to the measured run.
 
-**Split workflow (two launches, recommended for strict perf
+**Split workflow (two launches, required for strict scheduler-overhead
 measurement):**
 
 ```bash
@@ -594,9 +614,8 @@ python -m simpler_setup.tools.swimlane_converter \
 
 Use this when:
 
-- You're measuring overhead at the µs level and want each profiler in
-  isolation (combined per-round overhead is still well under 10 µs on
-  measured workloads, but if you need certainty, split).
+- You're measuring scheduler overhead and need the swimlane timing run free
+  from dep_gen instrumentation.
 - The same topology is being measured under several configurations
   (one `dep_gen` capture amortizes across N swimlane runs).
 - A workload is so large that the dep_gen replay validation gate
@@ -1251,11 +1270,9 @@ overwrites `task_id` with the full encoding on FIN
 wrote the WIP slot but AICPU never committed.
 
 **Scheduler-overhead deep-dive missing from converter output.**
-The converter runs `sched_overhead_analysis` only when a device
-log is resolvable. Pass `-d <device-id>` or place a `device-*`
-log under `outputs/` close in time to the `chip_swimlane_records.json`
-mtime; see `simpler_setup/tools/README.md` for the resolver
-rules.
+This is expected: the converter does not run `sched_overhead_analysis`.
+Capture `deps.json` and `chip_swimlane_records.json` in separate runs, then
+pass both paths to the analysis CLI; see `simpler_setup/tools/README.md`.
 
 ## 9. Related docs
 

--- a/simpler_setup/runtime_builder.py
+++ b/simpler_setup/runtime_builder.py
@@ -389,6 +389,11 @@ class RuntimeBuilder:
                     pto_root = ensure_pto_isa_root(verbose=True)
                 defines["PTO_ISA_ROOT"] = pto_root
             if target == "host":
+                # host_runtime.so is built once per runtime implementation, so
+                # bake that immutable artifact identity into the shared host
+                # platform code.  Runtime code must not grow a virtual/static
+                # API merely to report the directory it was compiled from.
+                defines["SIMPLER_RUNTIME_NAME"] = name
                 if build_pto_isa_commit:
                     defines["SIMPLER_PTO_ISA_BUILD_COMMIT"] = build_pto_isa_commit
                 for opt_in_define in ("SIMPLER_ENABLE_PTO_URMA_WORKSPACE",):

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -272,30 +272,10 @@ accurately alongside the swimlane capture. Run
 [`sched_overhead_analysis`](#sched_overhead_analysis) manually with both
 artifacts to get the scheduler-starvation / critical-path report.
 
-### Integration with run_example.py
-
-When running a test with profiling enabled, the converter is invoked automatically:
-
-```bash
-# Run the test with profiling enabled - merged_swimlane.json is generated automatically after the test passes
-python examples/scripts/run_example.py \
-    -k examples/host_build_graph/vector_example/kernels \
-    -g examples/host_build_graph/vector_example/golden.py \
-    --enable-chip-swimlane
-```
-
-After the test passes, the tool will:
-
-1. Auto-detect the latest `chip_swimlane_records_*.json` in outputs/
-2. Load function names from the kernel_config.py specified via `-k`
-3. Produce `merged_swimlane_*.json` for visualization
-4. Print the task statistics and scheduler overhead deep-dive report to the console
-
----
-
 ## sched_overhead_analysis
 
-Answer **"is the AICPU scheduler the bottleneck, or is it starved?"** by
+Answer **"is the scheduler the bottleneck, or is it starved?"** for either an
+AICPU or AICore scheduler by
 measuring, dependency- and MIX-aware, how much of the makespan a free core has
 ready, undispatched work — vs. legitimately busy or dependency-limited. Full
 model: [docs/dfx/sched-overhead-model.md](../../docs/dfx/sched-overhead-model.md).
@@ -305,9 +285,10 @@ model: [docs/dfx/sched-overhead-model.md](../../docs/dfx/sched-overhead-model.md
 `sched_overhead_analysis` needs **two artifacts, captured in SEPARATE runs**
 (co-running the flags perturbs timing — `dep_gen` adds per-submit overhead):
 
-1. **Perf profiling data** (`chip_swimlane_records_*.json`, level >= 3) from a
-   `--enable-chip-swimlane` run — per-task dispatch/start/end/finish +
-   `aicpu_scheduler_phases`.
+1. **Perf profiling data** (`chip_swimlane_records_*.json`, level >= 2) from a
+   `--enable-chip-swimlane` run — per-task dispatch/start/end/finish. Level >= 3
+   also supplies `scheduler_records` for the phase breakdown (legacy artifacts
+   with `aicpu_scheduler_phases` remain readable).
 2. **`deps.json`** (the task DAG) from a separate `--enable-dep-gen` run. It
    drives `ready(C) = max(producer.end)`, which is what separates scheduler
    bubbles from dependency stalls. **Required** — the tool errors without it.
@@ -333,7 +314,7 @@ python -m simpler_setup.tools.sched_overhead_analysis \
 
 | Option | Description |
 | ------ | ----------- |
-| `--chip-swimlane-records-json` | Path to the chip_swimlane_records_*.json file (level >= 3). If omitted, the latest under outputs/ is auto-selected. |
+| `--chip-swimlane-records-json` | Path to the chip_swimlane_records_*.json file (level >= 2). If omitted, the latest under outputs/ is auto-selected. |
 | `--deps-json` | Path to deps.json from a `--enable-dep-gen` run. **Required.** Falls back to a `deps.json` sibling of the perf JSON if present. |
 
 ### Outputs
@@ -343,10 +324,11 @@ Emitted in six parts:
 - **Part 1: Overhead verdict** — per-engine overhead (idle T-core *and* a ready, undispatched T-task, MIX-aware) + system `all_overhead` / `has_overhead`, all as % of makespan. An engine with no ready work is not overhead (dependency-mandated idle, not waste).
 - **Part 2: aicore switch** — the pre-dispatched pickup gap (`dispatch < prev_end`), reported **per core** (min/mean/max, ~0.8 µs each), the overhead-vs-independent split, and the makespan switch bound `[min over cores, sum of per-engine minima]`.
 - **Part 3 / 4: Head / Tail OH distributions** — P10–P99 + mean + total (per-task pickup and detect-latency magnitude).
-- **Part 5: AICPU scheduler loop breakdown** — per-thread loops, ns/loop, complete/dispatch/idle phase ratios, pop_hit / pop_miss, fanout / fanin, + the tail-vs-loop cause analysis.
+- **Part 5: Scheduler phase breakdown** — Level >= 3 reports the producer's phases. AICPU includes per-thread loop, queue-pop, fanout/fanin, and tail-vs-loop metrics; AICore reports its bootstrap/fanin/ready/dispatch/complete/refill/resolve/idle phase totals without applying AICPU-only queue formulas. At Level 2 this section is explicitly marked unavailable while Parts 1–4 and 6 remain available.
 - **Part 6: Critical-path latency attribution** — along the makespan path, scheduler-injected µs vs compute µs ("scheduler adds X% to the critical path").
 
-The perf JSON must be captured at chip_swimlane_level >= 3 so that `aicpu_scheduler_phases` is non-empty (rerun the case with `--enable-chip-swimlane` if the tool reports the field is missing).
+The common dependency-aware analysis works at chip_swimlane_level >= 2 for
+both scheduler producers. Capture level >= 3 when phase attribution is needed.
 
 ---
 
@@ -711,9 +693,13 @@ not from the perf JSON. See [`swimlane_converter --deps-json`](#swimlane_convert
 Top-level layout depends on `chip_swimlane_level`:
 
 - All levels: `chip_swimlane_level`, `tasks[]` (per-task fields above).
-- `>= 3`: also `aicpu_scheduler_phases[]` (per-thread phase records:
-  scan / complete / dispatch / idle) and `core_to_thread[]` (core_id →
-  scheduler thread index).
+- A5 HBG `>= 2`: also `aicpu_lifecycle_records[]`; the converter renders the
+  real handshake, topology/configuration, context-publication, bootstrap-wait,
+  register-release, and exit timestamps under `AICPU Lifecycle`.
+- `>= 3`: also `scheduler_records.streams[]`. Every Record has the common
+  `start_cycles`, `end_cycles`, `loop_iter`, `kind`, `tasks_processed`, and
+  nullable `task_id` fields. Stream metadata selects the AICPU or AICore
+  interpretation; producer-specific counters live in `metrics[]`.
 - `>= 4`: also `aicpu_orchestrator_phases[]` (per-task orchestrator
   phase records).
 

--- a/simpler_setup/tools/deps_viewer.py
+++ b/simpler_setup/tools/deps_viewer.py
@@ -709,8 +709,8 @@ def _load_task_meta(deps_path, func_names=None):
     if not perf_path.exists():
         return {}
     try:
-        # Route through swimlane_converter.read_perf_data so v2 raw on-disk
-        # JSON (aicore_tasks/aicpu_tasks flat tuples in cycle domain) gets
+        # Route through swimlane_converter.read_perf_data so raw on-disk
+        # JSON (AICore and Scheduler tuples in the cycle domain) gets
         # joined into the v1-shape dict this function expects. Direct
         # json.load would see no top-level `tasks` array on v2 and silently
         # return {} — leaving every node uncolored / unlabeled.

--- a/simpler_setup/tools/sched_overhead_analysis.py
+++ b/simpler_setup/tools/sched_overhead_analysis.py
@@ -11,8 +11,9 @@
 
 Inputs (BOTH required, captured in SEPARATE runs — do not co-run the flags, as
 dep_gen perturbs the swimlane timing):
-  1. Per-task perf profiling data (chip_swimlane_records_*.json) with
-     ``aicpu_scheduler_phases``, from a ``--enable-chip-swimlane`` (level >= 3) run.
+  1. Per-task perf profiling data (chip_swimlane_records_*.json) from a
+     ``--enable-chip-swimlane`` level >= 2 run. Level >= 3 additionally supplies
+     ``scheduler_records`` for the producer-specific phase breakdown.
   2. deps.json (the task DAG) from a separate ``--enable-dep-gen`` run. It drives
      ready(C) = max(producer.end), which separates scheduler bubbles from
      dependency stalls. Required — the report errors without it.
@@ -20,7 +21,7 @@ dep_gen perturbs the swimlane timing):
 Report (see docs/dfx/sched-overhead-model.md for the model):
   Part 1 Overhead verdict (per-engine + system all/has overhead, % of makespan) |
   Part 2 aicore switch (per-core pickup totals + makespan bound) |
-  Part 3/4 Head/Tail OH distributions | Part 5 scheduler loop budget |
+  Part 3/4 Head/Tail OH distributions | Part 5 scheduler phase budget |
   Part 6 critical-path attribution.
 
 Usage:
@@ -178,12 +179,14 @@ def auto_select_chip_swimlane_records_json():
 
 
 def parse_scheduler_from_json_phases(data):  # noqa: PLR0912
-    """Extract scheduler Phase breakdown from chip_swimlane_records JSON.
+    """Extract Scheduler phase breakdown from decoded swimlane data.
 
     Computes per-thread loop counts, logical task counts, FIN/retire counts,
-    and phase totals from aicpu_scheduler_phases records (present at
-    chip_swimlane_level >= 3). Complete.tasks_processed is a FIN/retire count;
-    logical task counts are reconstructed from the final finish row per task.
+    and phase totals from the normalized ``scheduler_records`` stream lists
+    produced by ``swimlane_converter._decode_perf_data``. These records are
+    present at chip_swimlane_level >= 3. Complete.tasks_processed is a
+    FIN/retire count; logical task counts are reconstructed from the final
+    finish row per task.
 
     Returns:
         dict: Thread data keyed by thread index, with per-phase us / pct,
@@ -191,7 +194,7 @@ def parse_scheduler_from_json_phases(data):  # noqa: PLR0912
               and finishes_per_loop. Returns
               empty dict if phase data is not available.
     """
-    phases_by_thread = data.get("aicpu_scheduler_phases", [])
+    phases_by_thread = data.get("scheduler_records") or data.get("aicpu_scheduler_phases", [])
     if not phases_by_thread:
         return {}
 
@@ -320,6 +323,60 @@ def parse_scheduler_from_json_phases(data):  # noqa: PLR0912
         threads[tid] = t
 
     return threads
+
+
+def print_aicore_scheduler_phase_breakdown(data):
+    """Print AICore Scheduler phase totals without AICPU queue assumptions."""
+    scheduler_records = data.get("scheduler_records") or []
+    scheduler_streams = data.get("scheduler_streams") or []
+    totals = defaultdict(float)
+    counts = defaultdict(int)
+    dropped = 0
+    for stream_index, records in enumerate(scheduler_records):
+        for record in records:
+            kind = canonical_sched_phase(record.get("phase", "unknown"))
+            totals[kind] += max(0.0, record.get("end_time_us", 0.0) - record.get("start_time_us", 0.0))
+            counts[kind] += 1
+        if stream_index < len(scheduler_streams):
+            capture = scheduler_streams[stream_index].get("capture") or {}
+            dropped += int(capture.get("dropped") or 0)
+
+    print("=" * 90)
+    print("Part 5: AICore scheduler phase breakdown")
+    print("=" * 90)
+    if not scheduler_records:
+        print("  (phase records unavailable at chip-swimlane Level 2; capture Level >= 3 for this section)")
+        print("=" * 90)
+        return
+
+    print(f"  Scheduler streams: {len(scheduler_records)}")
+    print("  Phase time is summed over AICore scheduler streams and can exceed wall-clock time.")
+    print()
+    for kind in sorted(totals):
+        print(f"  {kind:<16} records={counts[kind]:>6} total={totals[kind]:>10.3f} us")
+    print(f"  dropped={dropped}")
+    print("  Queue-pop and AICPU polling-loop metrics are producer-specific and are omitted.")
+    print("=" * 90)
+
+
+def print_critical_path(preds_by_id, end_by_id, finish_by_id, start_by_id, dispatch_by_id, w0):
+    """Print dependency-aware critical-path latency attribution."""
+    cp = compute_critical_path(preds_by_id, end_by_id, finish_by_id, start_by_id, dispatch_by_id, w0)
+    print()
+    print("=" * 90)
+    print("Part 6: Critical-path latency attribution")
+    print("=" * 90)
+    if cp and cp["span"] > 0:
+        sched_pct = cp["sched"] / cp["span"] * 100
+        exec_pct = cp["exec"] / cp["span"] * 100
+        print(f"  Makespan-determining path: {cp['hops']} hops, span {cp['span']:.1f} us")
+        print(f"    Compute (exec) on path : {cp['exec']:.1f} us ({exec_pct:.1f}%)")
+        print(f"    Scheduler injected     : {cp['sched']:.1f} us ({sched_pct:.1f}%)")
+        print(f"    Other (dep wait on path): {max(0.0, cp['span'] - cp['exec'] - cp['sched']):.1f} us")
+        print(f"  -> scheduler adds ~{sched_pct:.1f}% to the critical path's end-to-end latency.")
+    else:
+        print("  (could not resolve a critical path from the DAG)")
+    print("=" * 90)
 
 
 def _summarize_scheduler_loops(threads):
@@ -686,8 +743,12 @@ def compute_critical_path(preds_by_id, end_by_id, finish_by_id, start_by_id, dis
         exec_total += max(0.0, end_by_id.get(cur, 0.0) - start_by_id.get(cur, 0.0))
         if not preds:
             # root: dispatch->start head
-            sched_total += max(0.0, start_by_id.get(cur, w0) - dispatch_by_id.get(cur, w0))
-            path_start = min(path_start, start_by_id.get(cur, w0))
+            root_dispatch = dispatch_by_id.get(cur, start_by_id.get(cur, w0))
+            sched_total += max(0.0, start_by_id.get(cur, w0) - root_dispatch)
+            # The root's dispatch->start delay is part of scheduler latency,
+            # so the path span must begin at dispatch as well. Starting at the
+            # kernel start made scheduler+compute exceed 100% of the span.
+            path_start = min(path_start, root_dispatch)
             break
         pend, p = max(preds)
         sched_total += max(0.0, start_by_id.get(cur, 0.0) - pend)  # producer.end -> consumer.start
@@ -743,11 +804,20 @@ def run_analysis(  # noqa: PLR0912, PLR0915
     else:
         # Lazy import to avoid an import cycle: swimlane_converter imports
         # run_analysis from this module at top level. read_perf_data does the
-        # AICore↔AICPU join — direct json.load would see only the raw
-        # aicore_tasks / aicpu_tasks arrays.
+        # AICore↔Scheduler join; direct json.load sees only the raw streams.
         from .swimlane_converter import read_perf_data  # noqa: PLC0415
 
         data = read_perf_data(chip_swimlane_records_path)
+    scheduler_producers = {
+        stream.get("producer") for stream in data.get("scheduler_streams", []) if stream.get("producer")
+    }
+    task_producer = data.get("scheduler_task_producer")
+    if task_producer:
+        scheduler_producers.add(task_producer)
+    if len(scheduler_producers) > 1:
+        print("Error: mixed AICPU/AICore scheduler producers are unsupported", file=sys.stderr)
+        return 1
+    scheduler_producer = next(iter(scheduler_producers), "aicpu")
     tasks = data["tasks"]
     n_total = len(tasks)
 
@@ -895,15 +965,23 @@ def run_analysis(  # noqa: PLR0912, PLR0915
     print_distribution("Tail OH", tails)
     print()
 
-    # === Part 5: AICPU scheduler loop breakdown (+ tail-vs-loop cause analysis) ===
+    # === Part 5: producer-specific scheduler phase breakdown ===
+    # Parts 1-4 and 6 are based on the common per-task dispatch/start/end/finish
+    # contract and therefore apply equally to AICPU and AICore schedulers.
+    if scheduler_producer == "aicore":
+        print_aicore_scheduler_phase_breakdown(data)
+        print_critical_path(preds_by_id, end_by_id, finish_by_id, start_by_id, dispatch_by_id, w0)
+        return 0
+
     threads = parse_scheduler_from_json_phases(data)
     if not threads:
-        print(
-            "Error: perf JSON has no aicpu_scheduler_phases — rerun the case "
-            "with --enable-chip-swimlane so phase data is captured.",
-            file=sys.stderr,
-        )
-        return 1
+        print("=" * 90)
+        print("Part 5: AICPU scheduler loop breakdown")
+        print("=" * 90)
+        print("  (phase records unavailable at chip-swimlane Level 2; capture Level >= 3 for this section)")
+        print("=" * 90)
+        print_critical_path(preds_by_id, end_by_id, finish_by_id, start_by_id, dispatch_by_id, w0)
+        return 0
 
     # Per-thread fanout / fanin from the (already-loaded, required) deps.json.
     dag_stats_available = True
@@ -1057,22 +1135,7 @@ def run_analysis(  # noqa: PLR0912, PLR0915
     print("=" * 90)
 
     # === Part 6: Critical-path latency attribution ===
-    cp = compute_critical_path(preds_by_id, end_by_id, finish_by_id, start_by_id, dispatch_by_id, w0)
-    print()
-    print("=" * 90)
-    print("Part 6: Critical-path latency attribution")
-    print("=" * 90)
-    if cp and cp["span"] > 0:
-        sched_pct = cp["sched"] / cp["span"] * 100
-        exec_pct = cp["exec"] / cp["span"] * 100
-        print(f"  Makespan-determining path: {cp['hops']} hops, span {cp['span']:.1f} us")
-        print(f"    Compute (exec) on path : {cp['exec']:.1f} us ({exec_pct:.1f}%)")
-        print(f"    Scheduler injected     : {cp['sched']:.1f} us ({sched_pct:.1f}%)")
-        print(f"    Other (dep wait on path): {max(0.0, cp['span'] - cp['exec'] - cp['sched']):.1f} us")
-        print(f"  -> scheduler adds ~{sched_pct:.1f}% to the critical path's end-to-end latency.")
-    else:
-        print("  (could not resolve a critical path from the DAG)")
-    print("=" * 90)
+    print_critical_path(preds_by_id, end_by_id, finish_by_id, start_by_id, dispatch_by_id, w0)
 
     return 0
 

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -236,7 +236,7 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
     """Decode performance data from an already-loaded swimlane document.
 
     Host dumps raw cycle-domain per-stream records plus metadata; this
-    function does the AICore↔AICPU join. Schema:
+    function joins AICore execution records with Scheduler task timing. Schema:
 
         {
           "chip_swimlane_level": <1..4>,
@@ -248,8 +248,13 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
           },
           "aicore_tasks": [[core_id, task_token_raw, reg_task_id, start_cycles,
                             end_cycles, receive_to_start_cycles], ...],
-          "aicpu_tasks":  [[core_id, reg_task_id, dispatch_cycles, finish_cycles], ...],
-          "aicpu_scheduler_phases":     [ [ {kind, start_cycles, end_cycles, ...}, ... ], ... ],
+          "scheduler_tasks": {
+            "schema_version": 1,
+            "producer": "<aicpu|aicore>",
+            "records": [[core_id, reg_task_id, dispatch_cycles, finish_cycles], ...]
+          },
+          "scheduler_records": {"schema_version": 1, "streams": [...]},
+          "aicpu_lifecycle_records": [{worker_id, aicpu_thread_id, ..._cycles}, ...],
           "aicpu_orchestrator_phases":  [ [ {submit_idx, task_id, start_cycles, end_cycles}, ... ], ... ],
           "host_orchestrator_phases":   [ [ {submit_idx, task_id, start_host_ns, end_host_ns}, ... ], ... ]
         }
@@ -270,7 +275,7 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
 
     Returns a dict shaped for `generate_chrome_trace_json`,
     `print_task_statistics`, and `sched_overhead_analysis`: `tasks`,
-    `aicpu_scheduler_phases`, `aicpu_orchestrator_phases`,
+    `scheduler_records` (plus the legacy internal alias), `aicpu_orchestrator_phases`,
     `core_to_thread`.
 
     The join logic that used to live in `export_swimlane_json` (host C++):
@@ -281,10 +286,11 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
         phase, orch)
       - cycles → µs via `clock_freq_hz` from metadata (a2a3=50 MHz, a5=1 GHz —
         the freq MUST come from the host, never be hardcoded here)
-      - join `aicpu_tasks` by `(core_id, reg_task_id)`; unmatched rows are
+      - join `scheduler_tasks.records` by `(core_id, reg_task_id)`; unmatched rows are
         dropped and counted
-      - TASK_TIMING (level=1): aicpu_tasks is empty by construction, so
-        synthesize one task per aicore record (dispatch/finish = 0)
+      - archived JSON with `aicpu_tasks` is accepted as an AICPU-produced stream
+      - level 1 accepts AICore-only task records; higher levels require Scheduler
+        dispatch/finish timing for every emitted task
       - sort joined `tasks` by `task_id` (= task_token_raw)
       - convert phase records from `*_cycles` → `*_time_us`
 
@@ -303,8 +309,114 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
     core_to_thread = list(metadata.get("core_to_thread") or [])
 
     aicore_rows = data.get("aicore_tasks") or []
-    aicpu_rows = data.get("aicpu_tasks") or []
-    sched_phases_raw = data.get("aicpu_scheduler_phases") or []
+    scheduler_task_section = data.get("scheduler_tasks")
+    legacy_aicpu_rows = data.get("aicpu_tasks")
+    if scheduler_task_section is not None:
+        if legacy_aicpu_rows is not None:
+            raise ValueError("both scheduler_tasks and legacy aicpu_tasks are present")
+        if not isinstance(scheduler_task_section, dict):
+            raise ValueError("scheduler_tasks must be an object")
+        scheduler_task_schema_version = int(scheduler_task_section.get("schema_version") or 0)
+        if scheduler_task_schema_version != 1:
+            raise ValueError(f"Unsupported scheduler_tasks schema_version: {scheduler_task_schema_version}")
+        scheduler_task_producer = scheduler_task_section.get("producer")
+        if scheduler_task_producer not in ("aicpu", "aicore"):
+            raise ValueError("scheduler_tasks.producer must be 'aicpu' or 'aicore'")
+        scheduler_task_rows = scheduler_task_section.get("records")
+        if not isinstance(scheduler_task_rows, list) or any(
+            not isinstance(row, list) or len(row) != 4 for row in scheduler_task_rows
+        ):
+            raise ValueError("scheduler_tasks.records must contain four-column arrays")
+    else:
+        scheduler_task_rows = legacy_aicpu_rows or []
+        scheduler_task_producer = "aicpu" if legacy_aicpu_rows is not None else None
+    lifecycle_raw = data.get("aicpu_lifecycle_records") or []
+    if not isinstance(lifecycle_raw, list) or any(not isinstance(record, dict) for record in lifecycle_raw):
+        raise ValueError("aicpu_lifecycle_records must be an array of objects")
+    scheduler_stream_metadata = []
+    scheduler_section = data.get("scheduler_records")
+    if scheduler_section is not None:
+        if not isinstance(scheduler_section, dict):
+            raise ValueError("scheduler_records must be an object")
+        scheduler_schema_version = int(scheduler_section.get("schema_version") or 0)
+        if scheduler_schema_version != 1:
+            raise ValueError(f"Unsupported scheduler_records schema_version: {scheduler_schema_version}")
+        scheduler_streams = scheduler_section.get("streams")
+        if not isinstance(scheduler_streams, list):
+            raise ValueError("scheduler_records.streams must be an array")
+        sched_phases_raw = []
+        for stream_index, stream in enumerate(scheduler_streams):
+            if not isinstance(stream, dict):
+                raise ValueError(f"scheduler_records.streams[{stream_index}] must be an object")
+            records = stream.get("records")
+            metrics = stream.get("metrics") or []
+            if not isinstance(records, list) or not isinstance(metrics, list):
+                raise ValueError(f"scheduler stream {stream_index} records/metrics must be arrays")
+            record_fields = {
+                "start_cycles",
+                "end_cycles",
+                "loop_iter",
+                "kind",
+                "tasks_processed",
+                "task_id",
+            }
+            merged_records = []
+            for record_index, record in enumerate(records):
+                if not isinstance(record, dict) or set(record) != record_fields:
+                    raise ValueError(
+                        f"scheduler stream {stream_index} record {record_index} must contain exactly "
+                        f"{sorted(record_fields)}"
+                    )
+                if int(record["end_cycles"]) < int(record["start_cycles"]):
+                    raise ValueError(f"scheduler stream {stream_index} record {record_index} has a negative interval")
+                merged_records.append(dict(record))
+            for metric in metrics:
+                if not isinstance(metric, dict) or "record_index" not in metric:
+                    raise ValueError(f"scheduler stream {stream_index} has malformed metrics")
+                record_index = int(metric["record_index"])
+                if record_index < 0 or record_index >= len(merged_records):
+                    raise ValueError(
+                        f"scheduler stream {stream_index} metric record_index {record_index} is out of range"
+                    )
+                metric_values = {key: value for key, value in metric.items() if key != "record_index"}
+                overwritten_fields = set(metric_values) & record_fields
+                if overwritten_fields:
+                    raise ValueError(
+                        f"scheduler stream {stream_index} metric overwrites fixed record fields: "
+                        f"{sorted(overwritten_fields)}"
+                    )
+                merged_records[record_index].update(metric_values)
+            sched_phases_raw.append(merged_records)
+            scheduler_stream_metadata.append(
+                {
+                    key: stream.get(key)
+                    for key in (
+                        "platform",
+                        "runtime",
+                        "producer",
+                        "scheduler_id",
+                        "worker_id",
+                        "core_type",
+                        "physical_core_id",
+                        "capture",
+                    )
+                }
+            )
+    else:
+        sched_phases_raw = data.get("aicpu_scheduler_phases") or []
+        scheduler_stream_metadata = [
+            {
+                "platform": None,
+                "runtime": None,
+                "producer": "aicpu",
+                "scheduler_id": index,
+                "worker_id": index,
+                "core_type": "aicpu",
+                "physical_core_id": None,
+                "capture": None,
+            }
+            for index in range(len(sched_phases_raw))
+        ]
     orch_phases_raw = data.get("aicpu_orchestrator_phases") or []
     host_orch_phases_raw = data.get("host_orchestrator_phases") or []
     raw_host_capture = metadata.get("host_capture")
@@ -379,15 +491,49 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
     # (6 cols) both parse — archived JSON from before the receive_time split
     # still loads with r2s_cycles defaulting to 0.
     aicore_lookup: dict[tuple[int, int], tuple[int, int, int, int]] = {}
-    for row in aicore_rows:
+    for row_index, row in enumerate(aicore_rows):
+        if not isinstance(row, list) or len(row) not in (5, 6):
+            raise ValueError(f"aicore_tasks[{row_index}] must contain five or six columns")
         core_id, task_token_raw, reg_task_id, start_cycles, end_cycles, *rest = row
+        start_cycles = int(start_cycles)
+        end_cycles = int(end_cycles)
         r2s_cycles = int(rest[0]) if rest else 0
-        aicore_lookup[(int(core_id), int(reg_task_id))] = (
+        if not (0 < start_cycles <= end_cycles):
+            raise ValueError(f"aicore_tasks[{row_index}] has invalid timing: expected 0 < start_cycles <= end_cycles")
+        if not (0 <= r2s_cycles < start_cycles):
+            raise ValueError(
+                f"aicore_tasks[{row_index}] has invalid receive_to_start_cycles: "
+                "expected 0 <= receive_to_start_cycles < start_cycles"
+            )
+        key = (int(core_id), int(reg_task_id))
+        if key in aicore_lookup:
+            raise ValueError(f"duplicate aicore_tasks join key: {key}")
+        aicore_lookup[key] = (
             int(task_token_raw),
-            int(start_cycles),
-            int(end_cycles),
+            start_cycles,
+            end_cycles,
             r2s_cycles,
         )
+
+    scheduler_task_keys = [(int(row[0]), int(row[1])) for row in scheduler_task_rows]
+    if len(scheduler_task_keys) != len(set(scheduler_task_keys)):
+        raise ValueError("scheduler_tasks contains duplicate (core_id, reg_task_id) join keys")
+    for row_index, row in enumerate(scheduler_task_rows):
+        dispatch_cycles = int(row[2])
+        finish_cycles = int(row[3])
+        if not (0 < dispatch_cycles <= finish_cycles):
+            raise ValueError(
+                f"scheduler_tasks.records[{row_index}] has invalid timing: "
+                "expected 0 < dispatch_cycles <= finish_cycles"
+            )
+    if level >= 2:
+        missing_scheduler_keys = sorted(set(aicore_lookup) - set(scheduler_task_keys))
+        if missing_scheduler_keys:
+            preview = ", ".join(str(key) for key in missing_scheduler_keys[:3])
+            raise ValueError(
+                f"level {level} requires Scheduler task timing for every AICore task; "
+                f"missing {len(missing_scheduler_keys)} join key(s): {preview}"
+            )
 
     # base_time = min non-zero timestamp across every stream that will be
     # emitted. Used as the cycle-domain zero for all µs conversions.
@@ -409,7 +555,7 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
         r2s_c = int(row[5]) if len(row) > 5 else 0
         _track(start_c - r2s_c)
         _track(end_c)
-    for _, _, d, f in aicpu_rows:
+    for _, _, d, f in scheduler_task_rows:
         _track(int(d))
         _track(int(f))
     for thread_records in sched_phases_raw:
@@ -420,6 +566,21 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
         for pr in thread_records:
             _track(int(pr.get("start_cycles", 0)))
             _track(int(pr.get("end_cycles", 0)))
+    lifecycle_cycle_fields = (
+        "handshake_observed_cycles",
+        "handshake_partition_complete_cycles",
+        "config_start_cycles",
+        "topology_complete_cycles",
+        "context_publish_complete_cycles",
+        "bootstrap_wait_start_cycles",
+        "bootstrap_complete_cycles",
+        "register_release_cycles",
+        "exit_signal_cycles",
+        "exit_ack_cycles",
+    )
+    for record in lifecycle_raw:
+        for field in lifecycle_cycle_fields:
+            _track(int(record.get(field, 0)))
 
     if base_time_cycles is None:
         base_time_cycles = 0
@@ -429,12 +590,14 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
         start_cycles = int(row[3])
         receive_to_start_cycles = int(row[5]) if len(row) > 5 else 0
         device_timestamps.extend((start_cycles - receive_to_start_cycles, start_cycles, int(row[4])))
-    for _, _, dispatch_cycles, finish_cycles in aicpu_rows:
+    for _, _, dispatch_cycles, finish_cycles in scheduler_task_rows:
         device_timestamps.extend((int(dispatch_cycles), int(finish_cycles)))
     for phase_threads in (sched_phases_raw, orch_phases_raw):
         for thread_records in phase_threads:
             for phase in thread_records:
                 device_timestamps.extend((int(phase.get("start_cycles", 0)), int(phase.get("end_cycles", 0))))
+    for record in lifecycle_raw:
+        device_timestamps.extend(int(record.get(field, 0)) for field in lifecycle_cycle_fields)
 
     clock_alignment = None
     if host_mode or clock_anchor_mode:
@@ -478,8 +641,8 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
     tasks = []
     unmatched_per_core: dict[int, int] = defaultdict(int)
 
-    if aicpu_rows:
-        for row in aicpu_rows:
+    if scheduler_task_rows:
+        for row in scheduler_task_rows:
             core_id, reg_task_id, dispatch_cycles, finish_cycles = row
             core_id = int(core_id)
             reg_task_id = int(reg_task_id)
@@ -488,9 +651,11 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
                 unmatched_per_core[core_id] += 1
                 continue
             task_token_raw, start_cycles, end_cycles, r2s_cycles = ac
+            dispatch_cycles = int(dispatch_cycles)
+            finish_cycles = int(finish_cycles)
             start_us = _to_us(start_cycles)
             end_us = _to_us(end_cycles)
-            dispatch_us = _to_us(int(dispatch_cycles))
+            dispatch_us = _to_us(dispatch_cycles)
             receive_us = _to_us(start_cycles - r2s_cycles)
             local_setup_us = start_us - receive_us
             tasks.append(
@@ -504,15 +669,13 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
                     "end_time_us": end_us,
                     "duration_us": end_us - start_us,
                     "dispatch_time_us": dispatch_us,
-                    "finish_time_us": _to_us(int(finish_cycles)),
+                    "finish_time_us": _to_us(finish_cycles),
                     "receive_time_us": receive_us,
                     "local_setup_us": local_setup_us,
                     "propagation_us": receive_us - dispatch_us,
                 }
             )
-    elif level == 1:
-        # TASK_TIMING fallback: AICPU records are absent (complete_task
-        # bypassed). The AICore stream alone is the source of truth.
+    elif aicore_rows and level == 1:
         for row in aicore_rows:
             core_id, task_token_raw, _reg_task_id, start_cycles, end_cycles, *rest = row
             r2s_cycles = int(rest[0]) if rest else 0
@@ -532,13 +695,13 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
                     "start_time_us": start_us,
                     "end_time_us": end_us,
                     "duration_us": end_us - start_us,
-                    "dispatch_time_us": 0.0,
-                    "finish_time_us": 0.0,
                     "receive_time_us": receive_us,
                     "local_setup_us": local_setup_us,
-                    # propagation_us requires AICPU dispatch_ts; absent at level 1.
+                    # propagation_us requires a Scheduler dispatch timestamp.
                 }
             )
+    elif aicore_rows:
+        raise ValueError(f"level {level} requires Scheduler task timing records")
 
     tasks.sort(key=lambda t: int(t["task_id"]))
 
@@ -547,7 +710,8 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
         worst = sorted(unmatched_per_core.items(), key=lambda kv: -kv[1])[:3]
         worst_str = ", ".join(f"core {c}: {n}" for c, n in worst)
         print(
-            f"Warning: {total_unmatched} aicpu_task(s) had no matching AICore record (top offenders: {worst_str}); "
+            f"Warning: {total_unmatched} Scheduler task timing record(s) had no matching AICore record "
+            f"(producer={scheduler_task_producer}, top offenders: {worst_str}); "
             "the missing AICore buffer(s) were dropped on rotation. Bump PLATFORM_AICORE_BUFFERS_PER_CORE if you "
             "see this regularly.",
             file=sys.stderr,
@@ -584,6 +748,18 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
             out["phase"] = "orch_submit"
             converted.append(out)
         aicpu_orchestrator_phases.append(converted)
+
+    aicpu_lifecycle_records = []
+    for record_index, record in enumerate(lifecycle_raw):
+        converted = dict(record)
+        for field in lifecycle_cycle_fields:
+            if field not in converted:
+                continue
+            cycles = int(converted.pop(field))
+            if cycles > 0:
+                converted[field.removesuffix("_cycles") + "_time_us"] = _to_us(cycles)
+        converted["record_index"] = record_index
+        aicpu_lifecycle_records.append(converted)
 
     host_device_uploads = []
     for pr in data.get("host_device_uploads") or []:
@@ -622,11 +798,17 @@ def _decode_perf_data(data, *, timeline_origin_ns=None):  # noqa: PLR0912, PLR09
         "chip_swimlane_level": level,
         "tasks": tasks,
     }
+    if scheduler_task_producer is not None:
+        out["scheduler_task_producer"] = scheduler_task_producer
     if aicpu_scheduler_phases:
         out["aicpu_scheduler_phases"] = aicpu_scheduler_phases
+        out["scheduler_records"] = aicpu_scheduler_phases
+        out["scheduler_streams"] = scheduler_stream_metadata
     if aicpu_orchestrator_phases:
         out["aicpu_orchestrator_phases"] = aicpu_orchestrator_phases
         out["orchestrator_source"] = "aicpu"
+    if aicpu_lifecycle_records:
+        out["aicpu_lifecycle_records"] = aicpu_lifecycle_records
     if host_device_uploads:
         out["host_device_uploads"] = host_device_uploads
     if host_mode:
@@ -1054,7 +1236,7 @@ def print_task_statistics(tasks, func_id_to_name=None, chip_swimlane_level=None)
     """Print task statistics grouped by func_id.
 
     Exec = kernel execution time (end_time_us - start_time_us) on AICore.
-    Latency = AICPU view: finish_time_us - dispatch_time_us (includes head OH + Exec + tail OH).
+    Latency = Scheduler view: finish_time_us - dispatch_time_us (includes head OH + Exec + tail OH).
     High Latency with low Exec means scheduler/polling overhead (tail OH = finish_ts recorded
     when the scheduler loop next sees the completed handshake; reordering the loop to process
     completed tasks first reduces this).
@@ -1062,10 +1244,12 @@ def print_task_statistics(tasks, func_id_to_name=None, chip_swimlane_level=None)
     Args:
         tasks: List of task dicts
         func_id_to_name: Optional dict mapping func_id to function name
-        chip_swimlane_level: Source collection level. Level 1 has no AICPU
-            dispatch/finish timestamps, so latency-derived metrics are unavailable.
+        chip_swimlane_level: Source collection level. Level 2 and above include
+            Scheduler per-task dispatch/finish timestamps.
     """
-    has_aicpu_timing = chip_swimlane_level is None or chip_swimlane_level >= 2
+    has_scheduler_timing = any(
+        task.get("dispatch_time_us", -1) >= 0 and task.get("finish_time_us", 0) > 0 for task in tasks
+    )
 
     # Group tasks by func_id with extended metrics
     func_stats: defaultdict[Any, dict[str, Any]] = defaultdict(
@@ -1102,7 +1286,7 @@ def print_task_statistics(tasks, func_id_to_name=None, chip_swimlane_level=None)
             func_stats[func_id]["local_setups"].append(task["local_setup_us"])
 
         # Calculate new metrics if dispatch_time_us and finish_time_us are available
-        if has_aicpu_timing and "dispatch_time_us" in task and "finish_time_us" in task:
+        if has_scheduler_timing and "dispatch_time_us" in task and "finish_time_us" in task:
             dispatch_time = task["dispatch_time_us"]
             finish_time = task["finish_time_us"]
 
@@ -1136,8 +1320,8 @@ def print_task_statistics(tasks, func_id_to_name=None, chip_swimlane_level=None)
     print("Task Statistics by Function")
     level_descriptions = {
         1: "AICore timing only",
-        2: "AICore + AICPU timing",
-        3: "AICore + AICPU timing + scheduler phases",
+        2: "AICore + Scheduler task timing",
+        3: "AICore + Scheduler task timing + scheduler phases",
         4: "full collection with orchestrator phases",
     }
     if chip_swimlane_level is None:
@@ -1195,10 +1379,10 @@ def print_task_statistics(tasks, func_id_to_name=None, chip_swimlane_level=None)
         # Calculate execution ratio: total_exec_time / total_latency
         exec_ratio = (stats["total_exec_time"] / stats["total_latency"] * 100) if stats["total_latency"] > 0 else 0
 
-        latency_str = f"{avg_latency:.2f}" if has_aicpu_timing else "-"
-        exec_ratio_str = f"{exec_ratio:.1f}%" if has_aicpu_timing else "-"
-        head_str = f"{avg_head_overhead:.2f}" if has_aicpu_timing else "-"
-        tail_str = f"{avg_tail_overhead:.2f}" if has_aicpu_timing else "-"
+        latency_str = f"{avg_latency:.2f}" if has_scheduler_timing else "-"
+        exec_ratio_str = f"{exec_ratio:.1f}%" if has_scheduler_timing else "-"
+        head_str = f"{avg_head_overhead:.2f}" if has_scheduler_timing else "-"
+        tail_str = f"{avg_tail_overhead:.2f}" if has_scheduler_timing else "-"
         prop_str = f"{avg_propagation:>12.2f}" if avg_propagation is not None else f"{'-':>12}"
         local_str = f"{avg_local_setup:>13.2f}" if avg_local_setup is not None else f"{'-':>13}"
         print(
@@ -1212,21 +1396,21 @@ def print_task_statistics(tasks, func_id_to_name=None, chip_swimlane_level=None)
 
     # Calculate total latency (sum of all latencies)
     total_latency_sum = sum(stats["total_latency"] for stats in func_stats.values())
-    total_latency_str = f"{total_latency_sum:.2f}" if has_aicpu_timing else "-"
+    total_latency_str = f"{total_latency_sum:.2f}" if has_scheduler_timing else "-"
     print(f"{'TOTAL':<21} {total_count:>5}   {total_duration:>12.2f}  {total_latency_str:>15}")
 
     # Print total test execution time
-    if has_aicpu_timing and min_dispatch_time != float("inf") and max_finish_time != float("-inf"):
+    if has_scheduler_timing and min_dispatch_time != float("inf") and max_finish_time != float("-inf"):
         total_test_time = max_finish_time - min_dispatch_time
         print(f"\nTotal Test Time: {total_test_time:.2f} us (from earliest dispatch to latest finish)")
-    elif chip_swimlane_level == 1 and min_aicore_time != float("inf") and max_aicore_time != float("-inf"):
+    elif not has_scheduler_timing and min_aicore_time != float("inf") and max_aicore_time != float("-inf"):
         aicore_observed_span = max_aicore_time - min_aicore_time
         print(
             f"\nAICore Observed Span: {aicore_observed_span:.2f} us (from earliest AICore receive to latest AICore end)"
         )
 
     # Task execution vs Scheduler overhead summary
-    if has_aicpu_timing and total_count > 0 and total_latency_sum > 0:
+    if has_scheduler_timing and total_count > 0 and total_latency_sum > 0:
         avg_exec_us = total_duration / total_count
         avg_latency_us = total_latency_sum / total_count
         exec_latency_ratio_pct = total_duration / total_latency_sum * 100
@@ -1265,7 +1449,7 @@ def build_overhead_counter_events(tasks, deps_edges, pid=2):  # noqa: PLR0912
     absent from the perf set falls back to its own dispatch (no unverifiable
     early readiness). Needs ``deps_edges`` (pred -> [succ]); returns [] without it.
     """
-    if not deps_edges or not tasks:
+    if not deps_edges or not tasks or any(task.get("dispatch_time_us") is None for task in tasks):
         return []
 
     def _u64(x):
@@ -1387,6 +1571,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     func_id_to_name=None,
     verbose=False,
     scheduler_phases=None,
+    scheduler_streams=None,
     orchestrator_phases=None,
     core_to_thread=None,
     orchestrator_name=None,
@@ -1397,6 +1582,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     deps_block_map=None,
     emit_overhead=False,
     host_device_uploads=None,
+    aicpu_lifecycle_records=None,
 ):
     """Generate Chrome Trace Event Format JSON from task data.
 
@@ -1404,20 +1590,22 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
         tasks: List of task dicts with fields:
             - task_id, func_id, core_id, core_type
             - start_time_us, end_time_us, duration_us
-            - dispatch_time_us (optional, AICPU dispatch timestamp)
-            - finish_time_us (optional, AICPU finish timestamp)
+            - dispatch_time_us (optional, Scheduler dispatch timestamp)
+            - finish_time_us (optional, Scheduler finish timestamp)
         output_path: Path to output JSON file
         func_id_to_name: Optional dict mapping func_id to function name
         verbose: Print progress information
-        scheduler_phases: Optional list of per-thread phase record lists (chip_swimlane_level >= 3)
+        scheduler_phases: Optional list of per-scheduler record lists (chip_swimlane_level >= 3)
+        scheduler_streams: Optional metadata for each scheduler record list
         orchestrator_phases: Optional list of per-task orchestrator phase records (chip_swimlane_level >= 4)
         core_to_thread: Optional list mapping core_id (index) to scheduler thread index (-1 = unassigned)
+        aicpu_lifecycle_records: Optional A5 HBG AICPU control-plane lifecycle records
 
     Generates processes in the trace:
         - pid=5 "Graph Execution": one end-to-end envelope per Graph task
         - pid=1 "Host/AICPU Orchestrator": orchestrator phase bars (chip_swimlane_level >= 4)
-        - pid=2 "AICPU Scheduler": scheduler phase bars (chip_swimlane_level >= 3)
-        - pid=3 "Scheduler View": dispatch_time_us to finish_time_us (AICPU perspective)
+        - pid=2 "AICPU/AICore Scheduler": scheduler record bars (chip_swimlane_level >= 3)
+        - pid=3 "Scheduler View": dispatch_time_us to finish_time_us
         - pid=4 "Worker View": per-subtask kernel execution on physical cores
     """
     if verbose:
@@ -1456,6 +1644,72 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
 
     # Step 2: Generate JSON events
     events = []
+
+    if aicpu_lifecycle_records:
+        events.append(
+            {"args": {"name": "AICPU Lifecycle"}, "cat": "__metadata", "name": "process_name", "ph": "M", "pid": 6}
+        )
+        events.append(
+            {"args": {"sort_index": 2}, "cat": "__metadata", "name": "process_sort_index", "ph": "M", "pid": 6}
+        )
+        lifecycle_intervals = (
+            ("handshake_partition", "handshake_observed_time_us", "handshake_partition_complete_time_us"),
+            ("topology_config", "config_start_time_us", "topology_complete_time_us"),
+            ("context_publish", "topology_complete_time_us", "context_publish_complete_time_us"),
+            ("bootstrap_wait", "bootstrap_wait_start_time_us", "bootstrap_complete_time_us"),
+            ("exit_wait", "exit_signal_time_us", "exit_ack_time_us"),
+        )
+        for record in aicpu_lifecycle_records:
+            worker_id = int(record.get("worker_id", record.get("record_index", 0)))
+            thread_id = int(record.get("aicpu_thread_id", -1))
+            tid = 60000 + worker_id
+            events.append(
+                {
+                    "args": {"name": f"worker_{worker_id} (AICPU thread {thread_id})"},
+                    "cat": "__metadata",
+                    "name": "thread_name",
+                    "ph": "M",
+                    "pid": 6,
+                    "tid": tid,
+                }
+            )
+            identity = {
+                "worker_id": worker_id,
+                "aicpu_thread_id": thread_id,
+                "core_type": record.get("core_type"),
+                "physical_core_id": record.get("physical_core_id"),
+            }
+            for name, start_field, end_field in lifecycle_intervals:
+                start = float(record.get(start_field, 0.0))
+                end = float(record.get(end_field, 0.0))
+                if end <= 0 or end < start:
+                    continue
+                events.append(
+                    {
+                        "args": identity,
+                        "cat": "aicpu_lifecycle",
+                        "name": name,
+                        "ph": "X",
+                        "pid": 6,
+                        "tid": tid,
+                        "ts": start,
+                        "dur": end - start,
+                    }
+                )
+            if "register_release_time_us" in record:
+                register_release = float(record["register_release_time_us"])
+                events.append(
+                    {
+                        "args": identity,
+                        "cat": "aicpu_lifecycle",
+                        "name": "register_release",
+                        "ph": "i",
+                        "s": "t",
+                        "pid": 6,
+                        "tid": tid,
+                        "ts": register_release,
+                    }
+                )
 
     # Metadata event: Process names and sort order.
     # pid is renumbered in pipeline order (top → bottom in Perfetto):
@@ -1518,10 +1772,12 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     events.append({"args": {"name": "Worker View"}, "cat": "__metadata", "name": "process_name", "ph": "M", "pid": 4})
     events.append({"args": {"sort_index": 4}, "cat": "__metadata", "name": "process_sort_index", "ph": "M", "pid": 4})
 
-    # Check if any task has AICPU timestamps
-    has_aicpu_data = any(task.get("dispatch_time_us", 0) >= 0 and task.get("finish_time_us", 0) > 0 for task in tasks)
+    # Check if any task has Scheduler timestamps.
+    has_scheduler_task_data = any(
+        task.get("dispatch_time_us", 0) >= 0 and task.get("finish_time_us", 0) > 0 for task in tasks
+    )
 
-    if has_aicpu_data:
+    if has_scheduler_task_data:
         events.append(
             {"args": {"name": "Scheduler View"}, "cat": "__metadata", "name": "process_name", "ph": "M", "pid": 3}
         )
@@ -1548,8 +1804,8 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     # Duration events (Complete events "X")
     # Build task_id -> event_id mapping for flow events
     task_to_event_id: dict[tuple[int, int], int] = {}
-    task_to_aicpu_event_id: dict[tuple[int, int], int] = {}
-    task_to_aicpu_tid: dict[tuple[int, int], int] = {}
+    task_to_scheduler_event_id: dict[tuple[int, int], int] = {}
+    task_to_scheduler_tid: dict[tuple[int, int], int] = {}
     aicpu_worker_anchor_map: dict[int, list[dict]] = defaultdict(list)
     event_id = 0
 
@@ -1643,21 +1899,21 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     # Scheduler View duration events (dispatch_time to finish_time)
     # Assign overlapping tasks on the same core to different tids so Perfetto
     # renders each bar on its own row (Perfetto requires strict nesting on a tid).
-    if has_aicpu_data:
+    if has_scheduler_task_data:
         # Build per-core sorted task lists and assign sub-lanes.
         # Each core gets a base tid from core_to_tid; overlapping tasks get base+1.
-        _core_aicpu_tasks: dict[int, list] = defaultdict(list)
+        _core_scheduler_tasks: dict[int, list] = defaultdict(list)
         for task in tasks:
             d = task.get("dispatch_time_us", 0)
             f = task.get("finish_time_us", 0)
             if d < 0 or f <= 0:
                 continue
-            _core_aicpu_tasks[task["core_id"]].append(task)
-        for ct_list in _core_aicpu_tasks.values():
+            _core_scheduler_tasks[task["core_id"]].append(task)
+        for ct_list in _core_scheduler_tasks.values():
             ct_list.sort(key=lambda t: t["dispatch_time_us"])
 
-        aicpu_tid_set: set[int] = set()
-        for core_id, ct_list in _core_aicpu_tasks.items():
+        scheduler_tid_set: set[int] = set()
+        for core_id, ct_list in _core_scheduler_tasks.items():
             base_tid = core_to_tid[core_id]
             # Greedy lane assignment: track finish time per sub-lane
             lane_finish = [0.0]  # lane 0 = base_tid
@@ -1673,16 +1929,16 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     lane_finish.append(0.0)
                 lane_finish[assigned] = task["finish_time_us"]
                 tid = base_tid if assigned == 0 else base_tid + assigned
-                task_to_aicpu_tid[(task["task_id"], task["core_id"])] = tid
-                aicpu_tid_set.add(tid)
+                task_to_scheduler_tid[(task["task_id"], task["core_id"])] = tid
+                scheduler_tid_set.add(tid)
 
         # Thread name metadata for Scheduler View (one entry per unique tid used)
         for core_id, base_tid in core_to_tid.items():
-            ct_list = _core_aicpu_tasks.get(core_id)
+            ct_list = _core_scheduler_tasks.get(core_id)
             core_type_str = ct_list[0]["core_type"].upper() if ct_list else "unknown"
             base_name = f"{core_type_str}_{core_id}"
             # Base lane always gets metadata (even if no tasks, for consistency)
-            if base_tid in aicpu_tid_set or not aicpu_tid_set:
+            if base_tid in scheduler_tid_set or not scheduler_tid_set:
                 events.append(
                     {
                         "args": {"name": base_name},
@@ -1695,7 +1951,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                 )
             # Overflow lane (at most one: dual-slot dispatch means max 2 concurrent tasks per core)
             overflow_tid = base_tid + 1
-            if overflow_tid in aicpu_tid_set:
+            if overflow_tid in scheduler_tid_set:
                 events.append(
                     {
                         "args": {"name": base_name},
@@ -1714,8 +1970,8 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             if dispatch_us < 0 or finish_us <= 0:
                 continue
 
-            tid = task_to_aicpu_tid.get((task["task_id"], task["core_id"]), core_to_tid[task["core_id"]])
-            aicpu_dur = finish_us - dispatch_us
+            tid = task_to_scheduler_tid.get((task["task_id"], task["core_id"]), core_to_tid[task["core_id"]])
+            scheduler_duration_us = finish_us - dispatch_us
 
             # Get function name if available (task(rXtY) when no deps.json
             # resolved the func_id; see _task_display_name).
@@ -1729,7 +1985,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                         "event-hint": f"Task:{tdisp}, FuncId:{func_id}, CoreId:{task['core_id']}",
                         "dispatch-time-us": dispatch_us,
                         "finish-time-us": finish_us,
-                        "aicpu-duration-us": aicpu_dur,
+                        "scheduler-duration-us": scheduler_duration_us,
                         "taskId": task["task_id"],
                     },
                     "cat": "event",
@@ -1739,10 +1995,10 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     "pid": 3,
                     "tid": tid,
                     "ts": dispatch_us,
-                    "dur": aicpu_dur,
+                    "dur": scheduler_duration_us,
                 }
             )
-            task_to_aicpu_event_id[(task["task_id"], task["core_id"])] = event_id
+            task_to_scheduler_event_id[(task["task_id"], task["core_id"])] = event_id
             event_id += 1
 
     flow_id = 0
@@ -1757,8 +2013,10 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             return 30000 + thread_idx * 10 + lane
 
         # Process metadata
+        producers = {stream.get("producer") for stream in (scheduler_streams or []) if stream.get("producer")}
+        scheduler_process_name = "AICore Scheduler" if producers == {"aicore"} else "AICPU Scheduler"
         events.append(
-            {"args": {"name": "AICPU Scheduler"}, "cat": "__metadata", "name": "process_name", "ph": "M", "pid": 2}
+            {"args": {"name": scheduler_process_name}, "cat": "__metadata", "name": "process_name", "ph": "M", "pid": 2}
         )
         events.append(
             {"args": {"sort_index": 2}, "cat": "__metadata", "name": "process_sort_index", "ph": "M", "pid": 2}
@@ -1784,6 +2042,12 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             "drain_prepare": "cq_build_attempt_runnable",  # inner: cluster scan + build_payload
             "drain_publish": "cq_build_attempt_passed",  # inner: MMIO write_reg per subtask (the cohort launch)
             "graph_prepare": "rail_animation",  # bounded Scheduler-side Definition expansion
+            "bootstrap": "rail_animation",
+            "fanin": "cq_build_running",
+            "ready_claim": "cq_build_attempt_runnable",
+            "ready_steal": "cq_build_attempt_failed",
+            "direct_refill": "cq_build_attempt_passed",
+            "idle": "grey",
             # Inner in TMR; standalone on HBG's dedicated P thread.
             "resolve": "vsync_highlight_color",  # on_task_complete: walk consumer list
             # Separate-lane (Worker View AICPU_N) — fallback color if it ever lands on Sched
@@ -1857,9 +2121,17 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             )
 
             # Thread name metadata
+            stream = scheduler_streams[thread_idx] if scheduler_streams and thread_idx < len(scheduler_streams) else {}
+            scheduler_id = stream.get("scheduler_id", thread_idx)
+            worker_id = stream.get("worker_id")
+            core_type = stream.get("core_type")
+            physical_core_id = stream.get("physical_core_id")
+            lane_name = f"Sched_{scheduler_id}"
+            if stream.get("producer") == "aicore":
+                lane_name = f"Scheduler_{scheduler_id} ({core_type}_{physical_core_id}, worker {worker_id})"
             events.append(
                 {
-                    "args": {"name": f"Sched_{thread_idx}"},
+                    "args": {"name": lane_name},
                     "cat": "__metadata",
                     "name": "thread_name",
                     "ph": "M",
@@ -1954,6 +2226,12 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     "drain_prepare",
                     "drain_publish",
                     "graph_prepare",
+                    "bootstrap",
+                    "fanin",
+                    "ready_claim",
+                    "ready_steal",
+                    "direct_refill",
+                    "idle",
                 ):
                     continue
                 start_us = record["start_time_us"]
@@ -2325,8 +2603,8 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
         if hb_violation_count > 0:
             print(f"  Happens-before violations: {hb_violation_count} edge(s) flagged as 'hb_violation'")
 
-    # Scheduler View dependency mirror (AICPU timestamps).
-    if has_aicpu_data:
+    # Scheduler View dependency mirror (Scheduler timestamps).
+    if has_scheduler_task_data:
         for pred_id, succ_ids in edges_by_pred.items():
             if pred_id not in task_map:
                 continue
@@ -2352,34 +2630,34 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     src_finish_us = pred_row.get("finish_time_us", 0)
                     dst_dispatch_us = succ_row.get("dispatch_time_us", 0)
                     dst_finish_us = succ_row.get("finish_time_us", 0)
-                    # Skip when AICPU timestamps are missing or zero (matches Scheduler
+                    # Skip when Scheduler timestamps are missing or zero (matches Scheduler
                     # View bar emission, which rejects finish_us <= 0).
                     if src_dispatch_us < 0 or src_finish_us <= 0 or dst_dispatch_us < 0 or dst_finish_us <= 0:
                         continue
-                    aicpu_hb_violated = src_finish_us > dst_dispatch_us
-                    aicpu_flow_name = "hb_violation" if aicpu_hb_violated else "dependency"
+                    scheduler_hb_violated = src_finish_us > dst_dispatch_us
+                    scheduler_flow_name = "hb_violation" if scheduler_hb_violated else "dependency"
                     _append_dependency_flow_pair(
                         events,
                         flow_id,
-                        aicpu_flow_name,
+                        scheduler_flow_name,
                         3,
-                        task_to_aicpu_tid.get(
+                        task_to_scheduler_tid.get(
                             (pred_row["task_id"], pred_row["core_id"]), core_to_tid[pred_row["core_id"]]
                         ),
                         src_dispatch_us,
-                        task_to_aicpu_event_id.get((pred_row["task_id"], pred_row["core_id"])),
+                        task_to_scheduler_event_id.get((pred_row["task_id"], pred_row["core_id"])),
                         3,
-                        task_to_aicpu_tid.get(
+                        task_to_scheduler_tid.get(
                             (succ_row["task_id"], succ_row["core_id"]), core_to_tid[succ_row["core_id"]]
                         ),
                         dst_dispatch_us,
-                        task_to_aicpu_event_id.get((succ_row["task_id"], succ_row["core_id"])),
+                        task_to_scheduler_event_id.get((succ_row["task_id"], succ_row["core_id"])),
                         input_task_count=input_task_count,
                         output_task_count=output_task_count,
                     )
                     flow_id += 1
 
-    # Complete-phase flow arrows. The complete phase wraps the AICPU's
+    # Complete-phase flow arrows. The complete phase wraps the Scheduler's
     # completion-polling loop: it observes AICore subtask FINs, increments
     # the slot's per-task subtask counter, and on the LAST subtask of a
     # logical task it walks the fanout list and releases each consumer's
@@ -2387,14 +2665,14 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     #
     # Inbound: per-task, NOT per-subtask. A task is logically "completed"
     # only when its LAST subtask is observed (the one that triggers
-    # phase_complete_count++ in firmware). For SPMD with N subtasks across
+    # logical completion count in firmware). For SPMD with N subtasks across
     # N cores, the earlier N-1 subtasks just bump the slot's
     # completed_subtasks counter inside whatever complete phase happened to
     # poll them; only the LAST subtask's finish actually completes the
     # task. So per task: take max(finish_time_us) across its subtasks and
     # find the complete phase that CONTAINS that time. Each task view starts
     # its visual arrow on the same independently selected anchor it uses for
-    # SPMD dependency arrows, then lands at the last subtask's AICPU finish
+    # SPMD dependency arrows, then lands at the last subtask's Scheduler finish
     # timestamp inside the complete phase. This keeps related SPMD flows
     # consistent within each view without changing completion attribution.
     #
@@ -2427,7 +2705,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
         # subtask's core — typical case is the same thread observed
         # earlier subtasks too, but we don't assume. Each task view selects its
         # own earliest visible subtask slice; both flows end at the LAST
-        # subtask's AICPU finish timestamp, preserving completion attribution.
+        # subtask's Scheduler finish timestamp, preserving completion attribution.
         task_to_complete: dict[int, dict] = {}
         task_last_subtask: dict[int, tuple[float, float, int]] = {}  # tid -> (last_end_us, last_finish_us, core_id)
         task_worker_anchors: dict[int, list[dict]] = {}
@@ -2514,14 +2792,14 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                 flow_id += 1
 
             for anchor in task_scheduler_anchors[tid]:
-                # Scheduler View (pid=3): anchor on the AICPU dispatch→finish
+                # Scheduler View (pid=3): anchor on the Scheduler dispatch→finish
                 # bar (source ts = finish_time_us). Skip when the anchor has
-                # no AICPU finish — its pid=3 bar doesn't exist to bind to.
+                # no Scheduler finish — its pid=3 bar doesn't exist to bind to.
                 anchor_finish_us = anchor.get("finish_time_us")
                 if anchor_finish_us is None or anchor_finish_us <= 0:
                     continue
-                sched_src_tid = task_to_aicpu_tid.get((tid, anchor["core_id"]), core_to_tid[anchor["core_id"]])
-                sched_src_event_id = task_to_aicpu_event_id.get((tid, anchor["core_id"]))
+                sched_src_tid = task_to_scheduler_tid.get((tid, anchor["core_id"]), core_to_tid[anchor["core_id"]])
+                sched_src_event_id = task_to_scheduler_event_id.get((tid, anchor["core_id"]))
                 events.append(
                     {
                         "cat": "flow",
@@ -2646,7 +2924,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     flow_id += 1
 
     # Scheduler DISPATCH → task execution arrows
-    if scheduler_phases and has_aicpu_data:
+    if scheduler_phases and has_scheduler_task_data:
         # Build core_id → scheduler thread mapping.
         # Prefer explicit core_to_thread from perf JSON (written by AICPU after orchestration).
         # Fall back to voting heuristic for older data without the mapping.
@@ -2693,7 +2971,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             if matched_thread is not None:
                 sched_tid = sched_lane_tid(matched_thread, 0)
                 core_tid = core_to_tid[task["core_id"]]
-                aicpu_tid = task_to_aicpu_tid.get((task["task_id"], task["core_id"]), core_tid)
+                scheduler_view_tid = task_to_scheduler_tid.get((task["task_id"], task["core_id"]), core_tid)
 
                 # Flow: scheduler DISPATCH → Worker View task start
                 events.append(
@@ -2722,7 +3000,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                 flow_id += 1
 
                 # Flow: scheduler DISPATCH → Scheduler View task start
-                aicpu_eid = task_to_aicpu_event_id.get((task["task_id"], task["core_id"]))
+                scheduler_event_id = task_to_scheduler_event_id.get((task["task_id"], task["core_id"]))
                 events.append(
                     {
                         "cat": "flow",
@@ -2740,12 +3018,12 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     "name": "dispatch",
                     "ph": "f",
                     "pid": 3,
-                    "tid": aicpu_tid,
+                    "tid": scheduler_view_tid,
                     "ts": dispatch_us,
                     "bp": "e",
                 }
-                if aicpu_eid is not None:
-                    flow_f["bind_id"] = aicpu_eid
+                if scheduler_event_id is not None:
+                    flow_f["bind_id"] = scheduler_event_id
                 events.append(flow_f)
                 flow_id += 1
 
@@ -2782,7 +3060,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                 elif existing is None and phase == "orch_params":
                     orch_anchor_by_task[tid_k] = (record, orch_idx, "params→dispatch")
 
-        if has_aicpu_data and orch_anchor_by_task:
+        if has_scheduler_task_data and orch_anchor_by_task:
             for task in tasks:
                 tid = normalize_task_id_int(task.get("task_id"))
                 if tid is None:
@@ -3405,11 +3683,13 @@ def _generate_l3_trace(args, root):  # noqa: PLR0912
             args.verbose,
             orchestrator_name=artifacts["orchestrator_name"],
             scheduler_phases=data.get("aicpu_scheduler_phases"),
+            scheduler_streams=data.get("scheduler_streams"),
             orchestrator_phases=data.get("aicpu_orchestrator_phases"),
             orchestrator_source=data.get("orchestrator_source"),
             timeline_metadata=data.get("timeline_metadata"),
             core_to_thread=data.get("core_to_thread"),
             host_device_uploads=data.get("host_device_uploads"),
+            aicpu_lifecycle_records=data.get("aicpu_lifecycle_records"),
             deps_edges=artifacts["deps_edges"],
             deps_kernel_map=artifacts["deps_kernel_map"],
             deps_block_map=artifacts["deps_block_map"],
@@ -3522,11 +3802,13 @@ def main():
             args.verbose,
             orchestrator_name=orchestrator_name,
             scheduler_phases=data.get("aicpu_scheduler_phases"),
+            scheduler_streams=data.get("scheduler_streams"),
             orchestrator_phases=data.get("aicpu_orchestrator_phases"),
             orchestrator_source=data.get("orchestrator_source"),
             timeline_metadata=data.get("timeline_metadata"),
             core_to_thread=data.get("core_to_thread"),
             host_device_uploads=data.get("host_device_uploads"),
+            aicpu_lifecycle_records=data.get("aicpu_lifecycle_records"),
             deps_edges=deps_edges,
             deps_kernel_map=deps_kernel_map,
             deps_block_map=deps_block_map,

--- a/src/a2a3/platform/include/common/scheduler_profiling.h
+++ b/src/a2a3/platform/include/common/scheduler_profiling.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+inline constexpr const char *CHIP_SWIMLANE_ARCHITECTURE_NAME = "a2a3";
+
+/** Discriminator for Scheduler phase records.
+ *
+ * The roles share one enum so the on-device record carries one discriminator:
+ *
+ *   OUTER (mutually time-exclusive within an iteration; emit advances the
+ *   phase anchor): Complete, Dispatch, Release, Dummy, EarlyDispatch,
+ *   AsyncPoll, Drain, and GraphPrepare.
+ *
+ *   INNER (no anchor advance; Perfetto nests by containment): Resolve in the
+ *   tensormap_and_ringbuffer runtime, plus DrainPrepare and DrainPublish.
+ *
+ *   HBG RESOLUTION-THREAD OUTER: ResolveStandalone, AsyncPoll, and Dummy. The
+ *   host_build_graph runtime hands completed slots from Scheduler threads to a
+ *   dedicated resolution thread, so these are standalone bars.
+ *
+ *   SEPARATE-LANE (Worker View rather than the Scheduler lane): DummyTask and
+ *   PredicatedSkip identity markers.
+ */
+enum class ChipSwimlaneSchedPhaseKind : uint32_t {
+    Complete = 0,            // Observe FINs and run completion work inline.
+                             // tasks_processed = finished subtasks + sub-block retires.
+    Dispatch = 1,            // Publish ready tasks to AICore.
+                             // tasks_processed = subtasks published.
+    Release = 2,             // Deferred-release drain.
+                             // tasks_processed = slots released.
+    Dummy = 4,               // Explicit-dummy and false-predicate drain.
+                             // tasks_processed = dummy tasks consumed.
+    EarlyDispatch = 5,       // Pre-stage a flagged producer's gated consumers.
+                             // tasks_processed = blocks staged.
+    Resolve = 6,             // Nested completion work after FIN observation.
+                             // tasks_processed = consumers visited.
+    DummyTask = 7,           // Zero-width dependency-only task identity marker.
+    Drain = 8,               // sync_start stop-the-world drain attempt.
+    DrainPrepare = 9,        // Nested sync_start staging prepare pass.
+                             // tasks_processed = subtasks prepared.
+    DrainPublish = 10,       // Nested sync_start MMIO publication pass.
+                             // tasks_processed = subtasks published.
+    AsyncPoll = 11,          // Async-engine completion polling.
+                             // tasks_processed = async subtasks completed.
+    PredicatedSkip = 12,     // Zero-width identity marker for a task retired
+                             // because its dispatch predicate was false.
+    GraphPrepare = 13,       // Bounded Graph Definition materialization slice.
+                             // tasks_processed = in-graph tasks patched.
+    ResolveStandalone = 14,  // Dedicated HBG resolution-thread work.
+                             // tasks_processed = completed SPSC slots.
+};
+
+/** Queue-depth array layout: AIC=0, AIV=1, MIX=2.
+ *
+ * Must match ResourceShape's first three values. Kept local so this
+ * architecture-owned ABI header remains runtime-independent.
+ */
+constexpr int CHIP_SWIMLANE_NUM_QUEUE_SHAPES = 3;
+
+/**
+ * AICPU Scheduler phase record (64 bytes).
+ *
+ * Position in the per-thread buffer is the thread identity. All timestamps are
+ * raw system-counter cycles.
+ *
+ * ``phase_data`` is tagged by ``kind``: Dispatch uses ``dispatch``;
+ * DummyTask and PredicatedSkip use ``dummy_task``; GraphPrepare uses
+ * ``graph_task``. Other kinds store zero in the union.
+ *
+ * Queue-depth snapshots use the [AIC, AIV, MIX] indexes above and capture
+ * ready-queue occupancy at phase boundaries. They remain zero below
+ * SCHED_PHASES.
+ */
+struct ChipSwimlaneAicpuSchedPhaseRecord {
+    uint64_t start_time;              // Phase start, in system-counter cycles
+    uint64_t end_time;                // Phase end, in system-counter cycles
+    uint32_t loop_iter;               // Scheduler-loop iteration on this thread
+    ChipSwimlaneSchedPhaseKind kind;  // Tagged-union discriminator
+    uint32_t tasks_processed;         // Work items processed in this phase
+    union {
+        struct {
+            uint32_t pop_hit;   // Ready-queue hit delta since the previous Dispatch
+            uint32_t pop_miss;  // Ready-queue miss delta since the previous Dispatch
+        } dispatch;
+        struct {
+            uint32_t local_id;  // task_id bits [31:0]
+            uint32_t ring_id;   // task_id bits [63:32]
+        } dummy_task;
+        struct {
+            uint32_t local_id;  // outer Graph task_id bits [31:0]
+            uint32_t ring_id;   // outer Graph task_id bits [63:32]
+        } graph_task;
+    } phase_data;
+    int16_t shared_depth_at_start[CHIP_SWIMLANE_NUM_QUEUE_SHAPES];  // Ready depths at phase entry
+    int16_t shared_depth_at_end[CHIP_SWIMLANE_NUM_QUEUE_SHAPES];    // Ready depths at phase exit
+    uint32_t _pad[4];                                               // Keep the wire record at 64 bytes
+};
+
+static_assert(
+    sizeof(decltype(ChipSwimlaneAicpuSchedPhaseRecord::phase_data)) == 8,
+    "ChipSwimlaneAicpuSchedPhaseRecord phase data must remain 8 bytes"
+);
+static_assert(
+    offsetof(ChipSwimlaneAicpuSchedPhaseRecord, phase_data) == 28,
+    "ChipSwimlaneAicpuSchedPhaseRecord phase data offset drift"
+);
+static_assert(sizeof(ChipSwimlaneAicpuSchedPhaseRecord) == 64, "ChipSwimlaneAicpuSchedPhaseRecord layout drift");

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -118,7 +118,13 @@ target_compile_options(host_runtime
 
 # Platform name baked into the shared get_platform() impl in
 # src/common/platform/shared/host/platform_compile_info.cpp.
-target_compile_definitions(host_runtime PRIVATE SIMPLER_PLATFORM_NAME="a2a3")
+if(NOT DEFINED SIMPLER_RUNTIME_NAME OR SIMPLER_RUNTIME_NAME STREQUAL "")
+    message(FATAL_ERROR "host_runtime requires -DSIMPLER_RUNTIME_NAME=<runtime>")
+endif()
+target_compile_definitions(host_runtime PRIVATE
+    SIMPLER_PLATFORM_NAME="a2a3"
+    SIMPLER_RUNTIME_NAME="${SIMPLER_RUNTIME_NAME}"
+)
 
 if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE)
     target_compile_definitions(host_runtime PRIVATE SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=1)

--- a/src/a2a3/platform/sim/host/CMakeLists.txt
+++ b/src/a2a3/platform/sim/host/CMakeLists.txt
@@ -100,7 +100,13 @@ target_compile_options(host_runtime
 
 # Platform name baked into the shared get_platform() impl in
 # src/common/platform/shared/host/platform_compile_info.cpp.
-target_compile_definitions(host_runtime PRIVATE SIMPLER_PLATFORM_NAME="a2a3sim")
+if(NOT DEFINED SIMPLER_RUNTIME_NAME OR SIMPLER_RUNTIME_NAME STREQUAL "")
+    message(FATAL_ERROR "host_runtime requires -DSIMPLER_RUNTIME_NAME=<runtime>")
+endif()
+target_compile_definitions(host_runtime PRIVATE
+    SIMPLER_PLATFORM_NAME="a2a3sim"
+    SIMPLER_RUNTIME_NAME="${SIMPLER_RUNTIME_NAME}"
+)
 
 # Include directories
 target_include_directories(host_runtime

--- a/src/a5/platform/include/common/scheduler_profiling.h
+++ b/src/a5/platform/include/common/scheduler_profiling.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+inline constexpr const char *CHIP_SWIMLANE_ARCHITECTURE_NAME = "a5";
+
+/** Discriminator for Scheduler phase records.
+ *
+ * The roles share one enum so the on-device record carries one discriminator:
+ *
+ *   OUTER (mutually time-exclusive within an iteration; emit advances the
+ *   phase anchor): Complete, Dispatch, Release, Dummy, EarlyDispatch,
+ *   AsyncPoll, Drain, and GraphPrepare.
+ *
+ *   INNER (no anchor advance; Perfetto nests by containment): Resolve in the
+ *   tensormap_and_ringbuffer runtime, plus DrainPrepare and DrainPublish.
+ *
+ *   HBG RESOLUTION-THREAD OUTER: ResolveStandalone, AsyncPoll, and Dummy. The
+ *   host_build_graph runtime hands completed slots from Scheduler threads to a
+ *   dedicated resolution thread, so these are standalone bars.
+ *
+ *   SEPARATE-LANE (Worker View rather than the Scheduler lane): DummyTask and
+ *   PredicatedSkip identity markers.
+ */
+enum class ChipSwimlaneSchedPhaseKind : uint32_t {
+    Complete = 0,            // Observe FINs and run completion work inline.
+                             // tasks_processed = finished subtasks + sub-block retires.
+    Dispatch = 1,            // Publish ready tasks to AICore.
+                             // tasks_processed = subtasks published.
+    Release = 2,             // Deferred-release drain.
+                             // tasks_processed = slots released.
+    Dummy = 4,               // Explicit-dummy and false-predicate drain.
+                             // tasks_processed = dummy tasks consumed.
+    EarlyDispatch = 5,       // Pre-stage a flagged producer's gated consumers.
+                             // tasks_processed = blocks staged.
+    Resolve = 6,             // Nested completion work after FIN observation.
+                             // tasks_processed = consumers visited.
+    DummyTask = 7,           // Zero-width dependency-only task identity marker.
+    Drain = 8,               // sync_start stop-the-world drain attempt.
+    DrainPrepare = 9,        // Nested sync_start staging prepare pass.
+                             // tasks_processed = subtasks prepared.
+    DrainPublish = 10,       // Nested sync_start MMIO publication pass.
+                             // tasks_processed = subtasks published.
+    AsyncPoll = 11,          // Async-engine completion polling.
+                             // tasks_processed = async subtasks completed.
+    PredicatedSkip = 12,     // Zero-width identity marker for a task retired
+                             // because its dispatch predicate was false.
+    GraphPrepare = 13,       // Bounded Graph Definition materialization slice.
+                             // tasks_processed = in-graph tasks patched.
+    ResolveStandalone = 14,  // Dedicated HBG resolution-thread work.
+                             // tasks_processed = completed SPSC slots.
+};
+
+/** Queue-depth array layout: AIC=0, AIV=1, MIX=2.
+ *
+ * Must match ResourceShape's first three values. Kept local so this
+ * architecture-owned ABI header remains runtime-independent.
+ */
+constexpr int CHIP_SWIMLANE_NUM_QUEUE_SHAPES = 3;
+
+/**
+ * AICPU Scheduler phase record (64 bytes).
+ *
+ * Position in the per-thread buffer is the thread identity. All timestamps are
+ * raw system-counter cycles.
+ *
+ * ``phase_data`` is tagged by ``kind``: Dispatch uses ``dispatch``;
+ * DummyTask and PredicatedSkip use ``dummy_task``; GraphPrepare uses
+ * ``graph_task``. Other kinds store zero in the union.
+ *
+ * Queue-depth snapshots use the [AIC, AIV, MIX] indexes above and capture
+ * ready-queue occupancy at phase boundaries. They remain zero below
+ * SCHED_PHASES.
+ */
+struct ChipSwimlaneAicpuSchedPhaseRecord {
+    uint64_t start_time;              // Phase start, in system-counter cycles
+    uint64_t end_time;                // Phase end, in system-counter cycles
+    uint32_t loop_iter;               // Scheduler-loop iteration on this thread
+    ChipSwimlaneSchedPhaseKind kind;  // Tagged-union discriminator
+    uint32_t tasks_processed;         // Work items processed in this phase
+    union {
+        struct {
+            uint32_t pop_hit;   // Ready-queue hit delta since the previous Dispatch
+            uint32_t pop_miss;  // Ready-queue miss delta since the previous Dispatch
+        } dispatch;
+        struct {
+            uint32_t local_id;  // task_id bits [31:0]
+            uint32_t ring_id;   // task_id bits [63:32]
+        } dummy_task;
+        struct {
+            uint32_t local_id;  // outer Graph task_id bits [31:0]
+            uint32_t ring_id;   // outer Graph task_id bits [63:32]
+        } graph_task;
+    } phase_data;
+    int16_t shared_depth_at_start[CHIP_SWIMLANE_NUM_QUEUE_SHAPES];  // Ready depths at phase entry
+    int16_t shared_depth_at_end[CHIP_SWIMLANE_NUM_QUEUE_SHAPES];    // Ready depths at phase exit
+    uint32_t _pad[4];                                               // Keep the wire record at 64 bytes
+};
+
+static_assert(
+    sizeof(decltype(ChipSwimlaneAicpuSchedPhaseRecord::phase_data)) == 8,
+    "ChipSwimlaneAicpuSchedPhaseRecord phase data must remain 8 bytes"
+);
+static_assert(
+    offsetof(ChipSwimlaneAicpuSchedPhaseRecord, phase_data) == 28,
+    "ChipSwimlaneAicpuSchedPhaseRecord phase data offset drift"
+);
+static_assert(sizeof(ChipSwimlaneAicpuSchedPhaseRecord) == 64, "ChipSwimlaneAicpuSchedPhaseRecord layout drift");

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -128,7 +128,13 @@ target_compile_options(host_runtime
 
 # Platform name baked into the shared get_platform() impl in
 # src/common/platform/shared/host/platform_compile_info.cpp.
-target_compile_definitions(host_runtime PRIVATE SIMPLER_PLATFORM_NAME="a5")
+if(NOT DEFINED SIMPLER_RUNTIME_NAME OR SIMPLER_RUNTIME_NAME STREQUAL "")
+    message(FATAL_ERROR "host_runtime requires -DSIMPLER_RUNTIME_NAME=<runtime>")
+endif()
+target_compile_definitions(host_runtime PRIVATE
+    SIMPLER_PLATFORM_NAME="a5"
+    SIMPLER_RUNTIME_NAME="${SIMPLER_RUNTIME_NAME}"
+)
 
 if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE)
     target_compile_definitions(host_runtime PRIVATE SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=1)

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -78,6 +78,14 @@ extern "C" __attribute__((weak, visibility("hidden"))) int dep_gen_host_graph_em
     return -1;
 }
 
+// Each host_runtime.so links one runtime source set. A5 HBG replaces this
+// no-op with the publisher for its resident scheduler state.
+extern "C" __attribute__((weak, visibility("hidden"))) bool publish_runtime_chip_swimlane_extensions(
+    Runtime * /*runtime*/
+) noexcept {
+    return true;
+}
+
 // =============================================================================
 // DeviceRunner Implementation
 // =============================================================================
@@ -624,11 +632,17 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
         recover_device_or_mark_unusable(rc);
         // Emergency shutdown may already have flushed diagnostics. Export the
         // manifest on the error path exactly once.
+        if (enable_chip_swimlane_ && !publish_runtime_chip_swimlane_extensions(prepared.runtime)) {
+            LOG_WARN("Runtime chip-swimlane extension publication failed");
+        }
         teardown_shared_collectors_after_run(false);
         return rc;
     }
 
     read_device_wall_ns();
+    if (enable_chip_swimlane_ && !publish_runtime_chip_swimlane_extensions(prepared.runtime)) {
+        LOG_WARN("Runtime chip-swimlane extension publication failed");
+    }
     teardown_shared_collectors_after_run(true);
 
     // a5-specific dep_gen teardown: host-orch emits the graph its orchestration

--- a/src/a5/platform/sim/host/CMakeLists.txt
+++ b/src/a5/platform/sim/host/CMakeLists.txt
@@ -101,7 +101,13 @@ target_compile_options(host_runtime
 
 # Platform name baked into the shared get_platform() impl in
 # src/common/platform/shared/host/platform_compile_info.cpp.
-target_compile_definitions(host_runtime PRIVATE SIMPLER_PLATFORM_NAME="a5sim")
+if(NOT DEFINED SIMPLER_RUNTIME_NAME OR SIMPLER_RUNTIME_NAME STREQUAL "")
+    message(FATAL_ERROR "host_runtime requires -DSIMPLER_RUNTIME_NAME=<runtime>")
+endif()
+target_compile_definitions(host_runtime PRIVATE
+    SIMPLER_PLATFORM_NAME="a5sim"
+    SIMPLER_RUNTIME_NAME="${SIMPLER_RUNTIME_NAME}"
+)
 
 # Include directories
 target_include_directories(host_runtime

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -74,6 +74,14 @@ extern "C" __attribute__((weak, visibility("hidden"))) int dep_gen_host_graph_em
     return -1;
 }
 
+// Each host_runtime.so links one runtime source set. A5 HBG replaces this
+// no-op with the publisher for its resident scheduler state.
+extern "C" __attribute__((weak, visibility("hidden"))) bool publish_runtime_chip_swimlane_extensions(
+    Runtime * /*runtime*/
+) noexcept {
+    return true;
+}
+
 // a5 sim: malloc / free wrappers shared by the four profiling subsystems'
 // init_* methods. Plain function pointers convert implicitly into the
 // framework's std::function alloc / free shapes. Kept on the subclass (not
@@ -677,6 +685,9 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
         chip_swimlane_collector_.read_phase_header_metadata();
         chip_swimlane_collector_.reconcile_counters();
         publish_host_phase_records_to_swimlane();
+        if (!publish_runtime_chip_swimlane_extensions(active_run_->runtime)) {
+            LOG_WARN("Runtime chip-swimlane extension publication failed");
+        }
         chip_swimlane_collector_.export_swimlane_json();
     }
 

--- a/src/a5/runtime/host_build_graph/aicore/aicore_legacy_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_legacy_executor.cpp
@@ -282,7 +282,7 @@ legacy_aicore_execute(__gm__ Runtime *runtime, int block_idx, CoreType core_type
             //   - reg_task_id is `task_id` (= reg_val, the per-core dispatch
             //     token AICore just read from DATA_MAIN_BASE). Per-dispatch
             //     unique within this core; host uses it as the join key
-            //     against the AICPU record stream. Required for correctness
+            //     against the Scheduler task record stream. Required for correctness
             //     under SPMD (block_num > num_cores) and MIX cluster spread,
             //     where multiple dispatches of the same task share the same
             //     task_token_raw.

--- a/src/common/platform/include/common/chip_swimlane_extension.h
+++ b/src/common/platform/include/common/chip_swimlane_extension.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+/** Fixed extension slots emitted by runtime-owned chip-swimlane producers. */
+enum class ChipSwimlaneExtensionSection : uint32_t {
+    AicoreTasks = 0,
+    SchedulerTasks = 1,
+    SchedulerRecords = 2,
+    AicpuLifecycleRecords = 3,
+    Count = 4,
+};
+
+inline constexpr bool chip_swimlane_extension_section_is_valid(ChipSwimlaneExtensionSection section) {
+    return static_cast<uint32_t>(section) < static_cast<uint32_t>(ChipSwimlaneExtensionSection::Count);
+}
+
+inline constexpr const char *chip_swimlane_extension_section_name(ChipSwimlaneExtensionSection section) {
+    switch (section) {
+    case ChipSwimlaneExtensionSection::AicoreTasks:
+        return "aicore_tasks";
+    case ChipSwimlaneExtensionSection::SchedulerTasks:
+        return "scheduler_tasks";
+    case ChipSwimlaneExtensionSection::SchedulerRecords:
+        return "scheduler_records";
+    case ChipSwimlaneExtensionSection::AicpuLifecycleRecords:
+        return "aicpu_lifecycle_records";
+    case ChipSwimlaneExtensionSection::Count:
+        break;
+    }
+    return nullptr;
+}
+
+inline constexpr bool chip_swimlane_extension_section_is_object(ChipSwimlaneExtensionSection section) {
+    return section == ChipSwimlaneExtensionSection::SchedulerTasks ||
+           section == ChipSwimlaneExtensionSection::SchedulerRecords;
+}
+
+/** Validate the bounded payload envelope; payload contents come only from internal serializers. */
+inline bool
+chip_swimlane_extension_has_expected_root(ChipSwimlaneExtensionSection section, std::string_view json_value) noexcept {
+    if (!chip_swimlane_extension_section_is_valid(section)) return false;
+    const size_t first = json_value.find_first_not_of(" \t\r\n");
+    const size_t last = json_value.find_last_not_of(" \t\r\n");
+    if (first == std::string_view::npos) return false;
+    const bool expects_object = chip_swimlane_extension_section_is_object(section);
+    return json_value[first] == (expects_object ? '{' : '[') && json_value[last] == (expects_object ? '}' : ']');
+}

--- a/src/common/platform/include/common/chip_swimlane_profiling.h
+++ b/src/common/platform/include/common/chip_swimlane_profiling.h
@@ -62,6 +62,7 @@
 #include "common/dfx_backpressure_device.h"
 #include "common/host_phase_kind.h"
 #include "common/platform_config.h"
+#include "common/scheduler_profiling.h"
 
 // =============================================================================
 // chip swimlane_level — granularity ladder for the chip swimlane profiler.
@@ -483,133 +484,6 @@ static_assert(sizeof(ChipSwimlaneDataHeader) % 64 == 0, "ChipSwimlaneDataHeader 
 //   splits live in the device cold-path log as cumulative counters
 //   (`g_orch_*_cycle`) — they answer "which sub-step dominates overall";
 //   the per-submit envelope answers "which submit was slow".
-
-/** Discriminator for the SCHED phase records (the orch side has no kind).
- *
- * Three role classes, but they share one enum so the on-device record carries
- * a single discriminator byte:
- *
- *   OUTER (mutually time-exclusive within an iter; emit advances _t0_phase):
- *     Complete, Dispatch, Release, Dummy, EarlyDispatch, AsyncPoll, Drain,
- *     GraphPrepare.
- *     Every iter is a sequence of zero-or-more outer bars + optional gap.
- *
- *   INNER (no anchor advance; Perfetto auto-nests by time containment):
- *     Resolve in the tensormap_and_ringbuffer runtime, plus DrainPrepare and
- *     DrainPublish. Resolve is contained by Complete or Dummy there.
- *
- *   HBG RESOLUTION-THREAD OUTER:
- *     ResolveStandalone, AsyncPoll, and Dummy. The host_build_graph runtime
- *     hands FIN'd slots from S threads to a dedicated P thread, so these are
- *     standalone, mutually exclusive P-thread bars rather than nested
- *     S-thread work.
- *
- *   SEPARATE-LANE (converter routes to Worker View pid=4, not the sched lane):
- *     DummyTask and PredicatedSkip. One zero-width marker per dependency-only
- *     completion keeps the DAG node visible on its handling AICPU's lane; the
- *     surrounding Dummy outer bar (sched lane) carries the actual drain time,
- *     and Resolve inside that bar carries the consumer-release work.
- */
-enum class ChipSwimlaneSchedPhaseKind : uint32_t {
-    // Outer
-    Complete = 0,       // check_running_cores_for_completion: observe FINs +
-                        // run on_task_complete inline. tasks_processed = FIN'd
-                        // subtasks + sub-block retires this iter.
-    Dispatch = 1,       // dispatch_ready_tasks: publish ready tasks to AICore.
-                        // tasks_processed = subtasks published this iter.
-    Release = 2,        // Deferred-release drain (on_task_release work).
-                        // tasks_processed = slots released this iter.
-    Dummy = 4,          // dummy_drain outer bar: covers explicit dummies and
-                        // false-predicate tasks popped this iter.
-                        // tasks_processed = dummy_got count.
-    EarlyDispatch = 5,  // try_early_dispatch: early-dispatch pre-staging
-                        // of a flagged producer's consumer's gated blocks.
-                        // tasks_processed = blocks staged this pass.
-    // Inner in tensormap_and_ringbuffer (parent: Complete | Dummy).
-    Resolve = 6,  // Complete ready work after FIN observation. tasks_processed
-                  // is consumers visited.
-    // Separate-lane (Worker View pid=4 AICPU_N)
-    DummyTask = 7,      // Per-dummy identity marker (zero-width). phase_data.dummy_task
-                        // carries the local/ring components of the full task identity.
-    Drain = 8,          // handle_drain_mode outer: the sync_start stop-the-world drain
-                        // (ack barrier + availability + parallel stage + finalize).
-                        // One bar per dispatch-loop iteration that enters the drain,
-                        // so retries show as multiple bars. Otherwise this time is a
-                        // swimlane blind spot (the loop `continue`s past all records).
-    DrainPrepare = 9,   // inner: this thread's global sync_start staging prepare pass
-                        // (cluster scan + build_payload). tasks_processed = subtasks.
-    DrainPublish = 10,  // inner: this thread's global sync_start staging publish pass
-                        // (MMIO write_reg per subtask). tasks_processed = subtasks.
-    // Outer (sched lane): async-wait completion polling, split out of Complete
-    // so async-engine (SDMA/RoCE/URMA/CCU) wait time is attributed to its own
-    // bar. tasks_processed = async subtasks completed this iter.
-    AsyncPoll = 11,
-    // Separate-lane (Worker View pid=4 AICPU_N)
-    PredicatedSkip = 12,  // Per-task marker for a real task retired inline because
-                          // its dispatch predicate evaluated false. Uses the same
-                          // phase_data.dummy_task identity payload as DummyTask.
-    // Outer (sched lane): one bounded Graph Definition materialization slice.
-    // phase_data.graph_task identifies the ring-0 outer Graph task and
-    // tasks_processed is the number of in-graph tasks patched in this slice.
-    GraphPrepare = 13,
-    // Outer on host_build_graph's dedicated P thread. Kept distinct from the
-    // nested TMR Resolve so post-processing never infers the role from rounded
-    // timestamps. tasks_processed is completed SPSC slots.
-    ResolveStandalone = 14,
-};
-
-/** Index layout of the queue-depth snapshot arrays below: AIC=0, AIV=1, MIX=2.
- *  Must match ResourceShape's first three values (see submit_types.h).
- *  Hardcoded here rather than included to keep this header runtime-independent. */
-constexpr int CHIP_SWIMLANE_NUM_QUEUE_SHAPES = 3;
-
-/**
- * AICPU scheduler phase record (64 bytes).
- *
- * Position in the per-thread buffer is the identity — no thread_id field.
- *
- * phase_data is tagged by kind: Dispatch uses its ready-queue counters and
- * DummyTask and PredicatedSkip use the local/ring components of the full task
- * id. Other kinds store zero in the Dispatch view.
- *
- * Queue-depth snapshots (shared_depth_*) record the per-shape scheduler ready
- * queue occupancy at phase boundaries. They surface the dep-release-then-
- * discovery latency that head OH alone can't distinguish from register-write
- * latency. Filled with 0 below SCHED_PHASES.
- */
-struct ChipSwimlaneAicpuSchedPhaseRecord {
-    uint64_t start_time;              // Phase start timestamp
-    uint64_t end_time;                // Phase end timestamp
-    uint32_t loop_iter;               // Scheduler-loop iteration number on this thread
-    ChipSwimlaneSchedPhaseKind kind;  // see enum above
-    uint32_t tasks_processed;         // Tasks processed in this phase batch
-    union {
-        struct {
-            uint32_t pop_hit;   // Ready-queue hit delta since the previous Dispatch emit
-            uint32_t pop_miss;  // Ready-queue miss delta since the previous Dispatch emit
-        } dispatch;
-        struct {
-            uint32_t local_id;  // task_id bits [31:0]
-            uint32_t ring_id;   // task_id bits [63:32]
-        } dummy_task;
-        struct {
-            uint32_t local_id;  // outer Graph task_id bits [31:0]
-            uint32_t ring_id;   // outer Graph task_id bits [63:32]
-        } graph_task;
-    } phase_data;
-    int16_t shared_depth_at_start[CHIP_SWIMLANE_NUM_QUEUE_SHAPES];  // sched->ready_queues[shape].size()
-    int16_t shared_depth_at_end[CHIP_SWIMLANE_NUM_QUEUE_SHAPES];
-    uint32_t _pad[4];  // 64B alignment padding
-};
-static_assert(
-    sizeof(decltype(ChipSwimlaneAicpuSchedPhaseRecord::phase_data)) == 8,
-    "ChipSwimlaneAicpuSchedPhaseRecord phase data must remain 8 bytes"
-);
-static_assert(
-    offsetof(ChipSwimlaneAicpuSchedPhaseRecord, phase_data) == 28,
-    "ChipSwimlaneAicpuSchedPhaseRecord phase data offset drift"
-);
-static_assert(sizeof(ChipSwimlaneAicpuSchedPhaseRecord) == 64, "ChipSwimlaneAicpuSchedPhaseRecord layout drift");
 
 /**
  * AICPU orchestrator phase record (32 bytes).

--- a/src/common/platform/include/common/host_api.h
+++ b/src/common/platform/include/common/host_api.h
@@ -13,6 +13,8 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "common/chip_swimlane_extension.h"
+
 /**
  * Host API function pointers for device memory operations.
  * Allows a runtime to use pluggable device-memory backends.
@@ -145,6 +147,9 @@ struct HostApiOps {
     uint32_t (*get_chip_swimlane_level)(void *runner_ctx);
     void *(*host_phase_pool_arm)(void *runner_ctx, int producer_wants_records);
     void (*host_phase_pool_finish)(void *runner_ctx, uint64_t submitted_tasks, uint64_t invocation_id);
+    bool (*publish_chip_swimlane_extension)(
+        void *runner_ctx, ChipSwimlaneExtensionSection section, const char *json_value, size_t json_size
+    );
 };
 
 /**
@@ -251,6 +256,18 @@ public:
     void host_phase_pool_finish(uint64_t submitted_tasks, uint64_t invocation_id) const noexcept {
         if (ops_->host_phase_pool_finish != nullptr) {
             ops_->host_phase_pool_finish(runner_ctx_, submitted_tasks, invocation_id);
+        }
+    }
+    bool publish_chip_swimlane_extension(
+        ChipSwimlaneExtensionSection section, const char *json_value, size_t json_size
+    ) const noexcept {
+        if (ops_->publish_chip_swimlane_extension == nullptr || !chip_swimlane_extension_section_is_valid(section) ||
+            json_value == nullptr)
+            return false;
+        try {
+            return ops_->publish_chip_swimlane_extension(runner_ctx_, section, json_value, json_size);
+        } catch (...) {
+            return false;
         }
     }
 

--- a/src/common/platform/include/host/chip_swimlane_collector.h
+++ b/src/common/platform/include/host/chip_swimlane_collector.h
@@ -25,12 +25,14 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
 
+#include "common/chip_swimlane_extension.h"
 #include "common/chip_swimlane_profiling.h"
 #include "host/clock_correlation.h"
 #include "common/memory_barrier.h"
@@ -398,8 +400,8 @@ public:
 
     /**
      * Start a run's collection window: bind its artifact configuration, drop the
-     * previous run's records and counters, and — once the region exists —
-     * republish the level the device reads.
+     * previous run's records, counters, and runtime extensions, and — once the
+     * region exists — republish the level the device reads.
      *
      * The collector initializes once and serves every run, so this is the only
      * point at which a run's records, counters and device level are established;
@@ -415,9 +417,12 @@ public:
     void begin_run(const std::string &output_prefix, ChipSwimlaneLevel chip_swimlane_level) {
         output_prefix_ = output_prefix;
         chip_swimlane_level_ = chip_swimlane_level;
+        json_extensions_.fill({});
         reset_collector_shards();
         publish_run_config();
     }
+
+    bool set_json_extension(ChipSwimlaneExtensionSection section, const std::string &json_value);
 
     /**
      * Per-buffer callback invoked by ProfilerBase's poll loop. Dispatches on
@@ -593,6 +598,7 @@ private:
     // Per-task output directory captured at initialize() time. Consumed by
     // export_swimlane_json() to build <prefix>/chip_swimlane_records.json.
     std::string output_prefix_;
+    std::array<std::string, static_cast<size_t>(ChipSwimlaneExtensionSection::Count)> json_extensions_{};
 
     // Merged data, populated from per-collector shards after collector threads join.
     std::vector<std::vector<ChipSwimlaneAicpuTaskRecord>> collected_perf_records_;

--- a/src/common/platform/include/host/scheduler_profiling_json.h
+++ b/src/common/platform/include/host/scheduler_profiling_json.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "common/scheduler_profiling.h"
+
+inline const char *chip_swimlane_scheduler_kind_name(ChipSwimlaneSchedPhaseKind kind) {
+    switch (kind) {
+    case ChipSwimlaneSchedPhaseKind::Complete:
+        return "complete";
+    case ChipSwimlaneSchedPhaseKind::Dispatch:
+        return "dispatch";
+    case ChipSwimlaneSchedPhaseKind::Release:
+        return "release";
+    case ChipSwimlaneSchedPhaseKind::Dummy:
+        return "dummy";
+    case ChipSwimlaneSchedPhaseKind::EarlyDispatch:
+        return "early_dispatch";
+    case ChipSwimlaneSchedPhaseKind::Resolve:
+        return "resolve";
+    case ChipSwimlaneSchedPhaseKind::ResolveStandalone:
+        return "resolve_standalone";
+    case ChipSwimlaneSchedPhaseKind::DummyTask:
+        return "dummy_task";
+    case ChipSwimlaneSchedPhaseKind::PredicatedSkip:
+        return "predicated_skip";
+    case ChipSwimlaneSchedPhaseKind::Drain:
+        return "drain";
+    case ChipSwimlaneSchedPhaseKind::DrainPrepare:
+        return "drain_prepare";
+    case ChipSwimlaneSchedPhaseKind::DrainPublish:
+        return "drain_publish";
+    case ChipSwimlaneSchedPhaseKind::AsyncPoll:
+        return "async_poll";
+    case ChipSwimlaneSchedPhaseKind::GraphPrepare:
+        return "graph_prepare";
+    }
+    return "unknown";
+}
+
+inline void chip_swimlane_write_scheduler_records(
+    std::ostream &out, const std::vector<std::vector<ChipSwimlaneAicpuSchedPhaseRecord>> &streams,
+    const std::vector<uint32_t> &dropped_records, const std::string &runtime_name
+) {
+    out << "{\n    \"schema_version\": 1,\n    \"streams\": [";
+    bool first_stream = true;
+    for (size_t stream_index = 0; stream_index < streams.size(); ++stream_index) {
+        const auto &records = streams[stream_index];
+        if (records.empty()) continue;
+        const uint32_t dropped = stream_index < dropped_records.size() ? dropped_records[stream_index] : 0;
+        if (!first_stream) out << ",";
+        out << "\n      {\"platform\": \"" << CHIP_SWIMLANE_ARCHITECTURE_NAME << "\", \"runtime\": \"" << runtime_name
+            << "\", \"producer\": \"aicpu\", \"scheduler_id\": " << stream_index << ", \"worker_id\": " << stream_index
+            << ", \"core_type\": \"aicpu\", \"physical_core_id\": null, \"capture\": {\"committed\": " << records.size()
+            << ", \"dropped\": " << dropped << ", \"truncated\": " << (dropped == 0 ? "false" : "true")
+            << "}, \"records\": [";
+        for (size_t record_index = 0; record_index < records.size(); ++record_index) {
+            const auto &record = records[record_index];
+            if (record_index != 0) out << ",";
+            out << "\n        {\"start_cycles\": " << record.start_time << ", \"end_cycles\": " << record.end_time
+                << ", \"loop_iter\": " << record.loop_iter << ", \"kind\": \""
+                << chip_swimlane_scheduler_kind_name(record.kind)
+                << "\", \"tasks_processed\": " << record.tasks_processed << ", \"task_id\": ";
+            if (record.kind == ChipSwimlaneSchedPhaseKind::DummyTask ||
+                record.kind == ChipSwimlaneSchedPhaseKind::PredicatedSkip) {
+                out
+                    << ((static_cast<uint64_t>(record.phase_data.dummy_task.ring_id) << 32) |
+                        record.phase_data.dummy_task.local_id);
+            } else if (record.kind == ChipSwimlaneSchedPhaseKind::GraphPrepare) {
+                out
+                    << ((static_cast<uint64_t>(record.phase_data.graph_task.ring_id) << 32) |
+                        record.phase_data.graph_task.local_id);
+            } else {
+                out << "null";
+            }
+            out << "}";
+        }
+        if (!records.empty()) out << "\n      ";
+        out << "], \"metrics\": [";
+        for (size_t record_index = 0; record_index < records.size(); ++record_index) {
+            const auto &record = records[record_index];
+            if (record_index != 0) out << ",";
+            out << "\n        {\"record_index\": " << record_index;
+            if (record.kind == ChipSwimlaneSchedPhaseKind::Dispatch) {
+                out << ", \"pop_hit\": " << record.phase_data.dispatch.pop_hit
+                    << ", \"pop_miss\": " << record.phase_data.dispatch.pop_miss;
+            }
+            out << ", \"shared_at_start\": [" << record.shared_depth_at_start[0] << ","
+                << record.shared_depth_at_start[1] << "," << record.shared_depth_at_start[2]
+                << "], \"shared_at_end\": [" << record.shared_depth_at_end[0] << "," << record.shared_depth_at_end[1]
+                << "," << record.shared_depth_at_end[2] << "]}";
+        }
+        if (!records.empty()) out << "\n      ";
+        out << "]}";
+        first_stream = false;
+    }
+    if (!first_stream) out << "\n    ";
+    out << "]\n  }";
+}

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -206,6 +206,13 @@ static uint32_t get_chip_swimlane_level(void *runner_ctx) {
     return static_cast<DeviceRunnerBase *>(runner_ctx)->chip_swimlane_level();
 }
 
+static bool publish_chip_swimlane_extension(
+    void *runner_ctx, ChipSwimlaneExtensionSection section, const char *json_value, size_t json_size
+) {
+    return runner_ctx != nullptr &&
+           static_cast<DeviceRunnerBase *>(runner_ctx)->publish_chip_swimlane_extension(section, json_value, json_size);
+}
+
 static void *host_phase_pool_arm(void *runner_ctx, int producer_wants_records) {
     if (runner_ctx == nullptr) return nullptr;
     return static_cast<DeviceRunnerBase *>(runner_ctx)->host_phase_pool_arm(producer_wants_records != 0);
@@ -317,6 +324,7 @@ static const HostApiOps g_host_api_ops = {
     .get_chip_swimlane_level = get_chip_swimlane_level,
     .host_phase_pool_arm = host_phase_pool_arm,
     .host_phase_pool_finish = host_phase_pool_finish,
+    .publish_chip_swimlane_extension = publish_chip_swimlane_extension,
 };
 
 /* ===========================================================================

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -733,6 +733,11 @@ public:
         enable_chip_swimlane_ = (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED);
     }
     uint32_t chip_swimlane_level() const { return static_cast<uint32_t>(chip_swimlane_level_); }
+    bool
+    publish_chip_swimlane_extension(ChipSwimlaneExtensionSection section, const char *json_value, size_t json_size) {
+        return json_value != nullptr &&
+               chip_swimlane_collector_.set_json_extension(section, std::string(json_value, json_size));
+    }
     HostPhaseRecordPool *host_phase_pool_arm(bool producer_wants_records) noexcept;
     void host_phase_pool_finish(uint64_t submitted_tasks, uint64_t invocation_id) noexcept {
         host_phase_records_.finish(submitted_tasks, invocation_id);

--- a/src/common/platform/shared/host/chip_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/chip_swimlane_collector.cpp
@@ -20,6 +20,7 @@
 
 #include "host/chip_swimlane_collector.h"
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <cctype>
@@ -36,7 +37,12 @@
 #include "common/memory_barrier.h"
 #include "common/unified_log.h"
 #include "host/profiling_copy.h"
+#include "host/scheduler_profiling_json.h"
 #include "../../../worker/runtime_c_api.h"
+
+#ifndef SIMPLER_RUNTIME_NAME
+#error "SIMPLER_RUNTIME_NAME must be defined by RuntimeBuilder"
+#endif
 
 // =============================================================================
 // ChipSwimlaneCollector Implementation
@@ -94,6 +100,14 @@ ChipSwimlaneCollector::~ChipSwimlaneCollector() {
     }
 }
 
+bool ChipSwimlaneCollector::set_json_extension(ChipSwimlaneExtensionSection section, const std::string &json_value) {
+    if (!chip_swimlane_extension_has_expected_root(section, json_value)) return false;
+    std::string &slot = json_extensions_[static_cast<size_t>(section)];
+    if (!slot.empty()) return false;
+    slot = json_value;
+    return true;
+}
+
 int ChipSwimlaneCollector::initialize(
     int num_aicore, int aicpu_thread_num, int device_id, const ChipSwimlaneAllocCallback &alloc_cb,
     ChipSwimlaneRegisterCallback register_cb, const ChipSwimlaneFreeCallback &free_cb
@@ -135,6 +149,7 @@ int ChipSwimlaneCollector::initialize(
     total_orch_phase_collected_ = 0;
     has_phase_data_ = false;
     collector_shards_merged_ = false;
+    json_extensions_.fill({});
 
     // Stash the memory context on the base up-front so alloc_paired_buffer
     // sees consistent values during init. shm_host_ stays nullptr until the
@@ -990,11 +1005,23 @@ int ChipSwimlaneCollector::export_swimlane_json() {
     }
     merge_collector_shards();
 
+    auto extension = [this](ChipSwimlaneExtensionSection section) -> const std::string * {
+        const std::string &value = json_extensions_[static_cast<size_t>(section)];
+        return value.empty() ? nullptr : &value;
+    };
+    const std::string *scheduler_extension = extension(ChipSwimlaneExtensionSection::SchedulerRecords);
+    const std::string *aicore_tasks_extension = extension(ChipSwimlaneExtensionSection::AicoreTasks);
+    const std::string *scheduler_tasks_extension = extension(ChipSwimlaneExtensionSection::SchedulerTasks);
+    const std::string *aicpu_lifecycle_extension = extension(ChipSwimlaneExtensionSection::AicpuLifecycleRecords);
+
     // Every stream is independently useful for DFX. In particular, a legal
     // HBG can contain only host-side dummy/hidden-allocation records and no
     // AICore dispatch at all.
-    bool has_any_records =
-        !host_submit_records_.empty() || !host_upload_records_.empty() || clock_correlation_session_.started();
+    bool has_any_records = !host_submit_records_.empty() || !host_upload_records_.empty() ||
+                           clock_correlation_session_.started() ||
+                           std::any_of(json_extensions_.begin(), json_extensions_.end(), [](const auto &value) {
+                               return !value.empty();
+                           });
     for (const auto &core_records : collected_perf_records_) {
         if (!core_records.empty()) {
             has_any_records = true;
@@ -1016,6 +1043,18 @@ int ChipSwimlaneCollector::export_swimlane_json() {
         return false;
     };
     const bool has_aicpu_orch_phases = any_phase_records(collected_orch_phase_records_);
+    const bool has_aicpu_scheduler_records = any_phase_records(collected_sched_phase_records_);
+    if (scheduler_extension != nullptr && has_aicpu_scheduler_records) {
+        LOG_ERROR("Both runtime and AICPU scheduler records are present; refusing ambiguous export");
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    const bool has_aicore_tasks = any_phase_records(collected_aicore_records_);
+    const bool has_platform_scheduler_tasks = any_phase_records(collected_perf_records_);
+    if ((aicore_tasks_extension != nullptr && has_aicore_tasks) ||
+        (scheduler_tasks_extension != nullptr && has_platform_scheduler_tasks)) {
+        LOG_ERROR("Both runtime and platform task records are present; refusing ambiguous export");
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
     has_any_records = has_any_records || any_phase_records(collected_sched_phase_records_) || has_aicpu_orch_phases;
     if (!has_any_records) {
         LOG_WARN("Warning: No performance data to export.");
@@ -1175,121 +1214,70 @@ int ChipSwimlaneCollector::export_swimlane_json() {
     // of swimlane_converter.py's v2 reader.
     //
     //   aicore_tasks: [core_id, task_token_raw, reg_task_id, start_cycles, end_cycles, receive_to_start_cycles]
-    //   aicpu_tasks:  [core_id, reg_task_id, dispatch_cycles, finish_cycles]
+    //   scheduler_tasks.records: [core_id, reg_task_id, dispatch_cycles, finish_cycles]
     {
         // copy_aicore_buffer already drops r.start_time == 0 slots when
         // collecting from the device side, so no defensive filter here.
-        outfile << "  \"aicore_tasks\": [";
-        bool first = true;
-        size_t total = 0;
-        for (size_t core_idx = 0; core_idx < collected_aicore_records_.size(); core_idx++) {
-            for (const auto &r : collected_aicore_records_[core_idx]) {
-                if (!first) outfile << ",";
-                outfile << "\n    [" << core_idx << ", " << r.task_token_raw << ", " << r.reg_task_id << ", "
-                        << r.start_time << ", " << r.end_time << ", " << r.receive_to_start_cycles << "]";
-                first = false;
-                total++;
-            }
-        }
-        if (!first) outfile << "\n  ";
-        outfile << "]";
-        LOG_INFO("  aicore_tasks: %zu records", total);
-    }
-    {
-        outfile << ",\n  \"aicpu_tasks\": [";
-        bool first = true;
-        size_t total = 0;
-        for (size_t core_idx = 0; core_idx < collected_perf_records_.size(); core_idx++) {
-            for (const auto &r : collected_perf_records_[core_idx]) {
-                if (!first) outfile << ",";
-                outfile << "\n    [" << core_idx << ", " << r.reg_task_id << ", " << r.dispatch_time << ", "
-                        << r.finish_time << "]";
-                first = false;
-                total++;
-            }
-        }
-        if (!first) outfile << "\n  ";
-        outfile << "]";
-        LOG_INFO("  aicpu_tasks: %zu records", total);
-    }
-
-    // Phase records keep their per-thread sub-array shape so the python
-    // consumer's existing iteration pattern (one thread per inner list) stays
-    // unchanged; only the field names move from *_us to *_cycles.
-    if (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES) {
-        auto sched_phase_name = [](ChipSwimlaneSchedPhaseKind kind) -> const char * {
-            switch (kind) {
-            case ChipSwimlaneSchedPhaseKind::Complete:
-                return "complete";
-            case ChipSwimlaneSchedPhaseKind::Dispatch:
-                return "dispatch";
-            case ChipSwimlaneSchedPhaseKind::Release:
-                return "release";
-            case ChipSwimlaneSchedPhaseKind::Dummy:
-                return "dummy";
-            case ChipSwimlaneSchedPhaseKind::EarlyDispatch:
-                return "early_dispatch";
-            case ChipSwimlaneSchedPhaseKind::Resolve:
-                return "resolve";
-            case ChipSwimlaneSchedPhaseKind::ResolveStandalone:
-                return "resolve_standalone";
-            case ChipSwimlaneSchedPhaseKind::DummyTask:
-                return "dummy_task";
-            case ChipSwimlaneSchedPhaseKind::PredicatedSkip:
-                return "predicated_skip";
-            case ChipSwimlaneSchedPhaseKind::Drain:
-                return "drain";
-            case ChipSwimlaneSchedPhaseKind::DrainPrepare:
-                return "drain_prepare";
-            case ChipSwimlaneSchedPhaseKind::DrainPublish:
-                return "drain_publish";
-            case ChipSwimlaneSchedPhaseKind::AsyncPoll:
-                return "async_poll";
-            case ChipSwimlaneSchedPhaseKind::GraphPrepare:
-                return "graph_prepare";
-            }
-            return "unknown";
-        };
-
-        auto emit_depth_array = [&outfile](const char *key, const int16_t arr[CHIP_SWIMLANE_NUM_QUEUE_SHAPES]) {
-            outfile << ", \"" << key << "\": [" << arr[0] << "," << arr[1] << "," << arr[2] << "]";
-        };
-        outfile << ",\n  \"aicpu_scheduler_phases\": [\n";
-        for (size_t t = 0; t < collected_sched_phase_records_.size(); t++) {
-            outfile << "    [";
+        outfile << "  \"" << chip_swimlane_extension_section_name(ChipSwimlaneExtensionSection::AicoreTasks) << "\": ";
+        if (aicore_tasks_extension != nullptr) {
+            outfile << *aicore_tasks_extension;
+        } else {
+            outfile << "[";
             bool first = true;
-            for (const auto &pr : collected_sched_phase_records_[t]) {
-                if (!first) outfile << ",";
-                outfile << "\n      {\"kind\": \"" << sched_phase_name(pr.kind) << "\""
-                        << ", \"start_cycles\": " << pr.start_time << ", \"end_cycles\": " << pr.end_time
-                        << ", \"loop_iter\": " << pr.loop_iter << ", \"tasks_processed\": " << pr.tasks_processed;
-                if (pr.kind == ChipSwimlaneSchedPhaseKind::Dispatch) {
-                    outfile << ", \"pop_hit\": " << pr.phase_data.dispatch.pop_hit
-                            << ", \"pop_miss\": " << pr.phase_data.dispatch.pop_miss;
+            size_t total = 0;
+            for (size_t core_idx = 0; core_idx < collected_aicore_records_.size(); core_idx++) {
+                for (const auto &r : collected_aicore_records_[core_idx]) {
+                    if (!first) outfile << ",";
+                    outfile << "\n    [" << core_idx << ", " << r.task_token_raw << ", " << r.reg_task_id << ", "
+                            << r.start_time << ", " << r.end_time << ", " << r.receive_to_start_cycles << "]";
+                    first = false;
+                    total++;
                 }
-                if (pr.kind == ChipSwimlaneSchedPhaseKind::DummyTask ||
-                    pr.kind == ChipSwimlaneSchedPhaseKind::PredicatedSkip) {
-                    uint64_t task_id = (static_cast<uint64_t>(pr.phase_data.dummy_task.ring_id) << 32) |
-                                       pr.phase_data.dummy_task.local_id;
-                    outfile << ", \"task_id\": " << task_id;
+            }
+            if (!first) outfile << "\n  ";
+            outfile << "]";
+            LOG_INFO("  aicore_tasks: %zu records", total);
+        }
+    }
+    if (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHEDULE_TIMING) {
+        outfile << ",\n  \"" << chip_swimlane_extension_section_name(ChipSwimlaneExtensionSection::SchedulerTasks)
+                << "\": ";
+        if (scheduler_tasks_extension != nullptr) {
+            outfile << *scheduler_tasks_extension;
+        } else {
+            outfile << "{\n    \"schema_version\": 1,\n    \"producer\": \"aicpu\",\n    \"records\": [";
+            bool first = true;
+            size_t total = 0;
+            for (size_t core_idx = 0; core_idx < collected_perf_records_.size(); core_idx++) {
+                for (const auto &r : collected_perf_records_[core_idx]) {
+                    if (!first) outfile << ",";
+                    outfile << "\n    [" << core_idx << ", " << r.reg_task_id << ", " << r.dispatch_time << ", "
+                            << r.finish_time << "]";
+                    first = false;
+                    total++;
                 }
-                if (pr.kind == ChipSwimlaneSchedPhaseKind::GraphPrepare) {
-                    uint64_t task_id = (static_cast<uint64_t>(pr.phase_data.graph_task.ring_id) << 32) |
-                                       pr.phase_data.graph_task.local_id;
-                    outfile << ", \"task_id\": " << task_id;
-                }
-                // Queue-depth snapshots — [AIC, AIV, MIX] per ChipSwimlaneAicpuSchedPhaseRecord docstring.
-                emit_depth_array("shared_at_start", pr.shared_depth_at_start);
-                emit_depth_array("shared_at_end", pr.shared_depth_at_end);
-                outfile << "}";
-                first = false;
             }
             if (!first) outfile << "\n    ";
-            outfile << "]";
-            if (t < collected_sched_phase_records_.size() - 1) outfile << ",";
-            outfile << "\n";
+            outfile << "]\n  }";
+            LOG_INFO("  scheduler_tasks: %zu AICPU records", total);
         }
-        outfile << "  ]";
+    }
+
+    if (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES) {
+        outfile << ",\n  \"" << chip_swimlane_extension_section_name(ChipSwimlaneExtensionSection::SchedulerRecords)
+                << "\": ";
+        if (scheduler_extension != nullptr) {
+            outfile << *scheduler_extension;
+        } else {
+            std::vector<uint32_t> dropped_records(collected_sched_phase_records_.size());
+            for (size_t t = 0; t < collected_sched_phase_records_.size(); ++t) {
+                const auto *pool = get_sched_phase_buffer_state(shm_host_, static_cast<int>(t));
+                dropped_records[t] = pool->head.dropped_record_count;
+            }
+            chip_swimlane_write_scheduler_records(
+                outfile, collected_sched_phase_records_, dropped_records, SIMPLER_RUNTIME_NAME
+            );
+        }
 
         if (has_aicpu_orch_phases) {
             size_t orch_lanes = static_cast<size_t>(get_chip_swimlane_header(shm_host_)->num_orch_phase_threads);
@@ -1338,6 +1326,12 @@ int ChipSwimlaneCollector::export_swimlane_json() {
             if (!first) outfile << "\n    ";
             outfile << "]";
         }
+    }
+
+    if (aicpu_lifecycle_extension != nullptr) {
+        outfile << ",\n  \""
+                << chip_swimlane_extension_section_name(ChipSwimlaneExtensionSection::AicpuLifecycleRecords)
+                << "\": " << *aicpu_lifecycle_extension;
     }
 
     outfile << "\n}\n";
@@ -1486,6 +1480,7 @@ int ChipSwimlaneCollector::finalize(
     host_phase_total_records_ = 0;
     host_phase_dropped_records_ = 0;
     host_phase_submitted_tasks_ = 0;
+    json_extensions_.fill({});
     clear_memory_context();
 
     LOG_DEBUG("Performance profiling cleanup complete");

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -190,6 +190,13 @@ static uint32_t get_chip_swimlane_level(void *runner_ctx) {
     return static_cast<SimDeviceRunnerBase *>(runner_ctx)->chip_swimlane_level();
 }
 
+static bool publish_chip_swimlane_extension(
+    void *runner_ctx, ChipSwimlaneExtensionSection section, const char *json_value, size_t json_size
+) {
+    return runner_ctx != nullptr && static_cast<SimDeviceRunnerBase *>(runner_ctx)
+                                        ->publish_chip_swimlane_extension(section, json_value, json_size);
+}
+
 static void *host_phase_pool_arm(void *runner_ctx, int producer_wants_records) {
     if (runner_ctx == nullptr) return nullptr;
     return static_cast<SimDeviceRunnerBase *>(runner_ctx)->host_phase_pool_arm(producer_wants_records != 0);
@@ -302,6 +309,7 @@ static const HostApiOps g_host_api_ops = {
     .get_chip_swimlane_level = get_chip_swimlane_level,
     .host_phase_pool_arm = host_phase_pool_arm,
     .host_phase_pool_finish = host_phase_pool_finish,
+    .publish_chip_swimlane_extension = publish_chip_swimlane_extension,
 };
 
 /* ===========================================================================

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -273,6 +273,11 @@ public:
         enable_chip_swimlane_ = (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED);
     }
     uint32_t chip_swimlane_level() const { return static_cast<uint32_t>(chip_swimlane_level_); }
+    bool
+    publish_chip_swimlane_extension(ChipSwimlaneExtensionSection section, const char *json_value, size_t json_size) {
+        return json_value != nullptr &&
+               chip_swimlane_collector_.set_json_extension(section, std::string(json_value, json_size));
+    }
     HostPhaseRecordPool *host_phase_pool_arm(bool producer_wants_records) noexcept;
     void host_phase_pool_finish(uint64_t submitted_tasks, uint64_t invocation_id) noexcept {
         host_phase_records_.finish(submitted_tasks, invocation_id);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/_swimlane_validate.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/_swimlane_validate.py
@@ -39,7 +39,7 @@ _REQUIRED_TASK_FIELDS = (
     "start_time_us",
     "end_time_us",
     # receive_time_us / local_setup_us are populated unconditionally by the
-    # AICore-side capture (v3 schema). propagation_us requires AICPU dispatch_ts
+    # AICore-side capture (v3 schema). propagation_us requires Scheduler dispatch_ts
     # and is therefore only present at level≥2 — not in this required-set.
     "receive_time_us",
     "local_setup_us",
@@ -68,15 +68,19 @@ def validate_perf_artifact(case_label: str, *, since: float, expected_task_count
     out_dir = max(matches, key=lambda p: p.stat().st_mtime)
     perf = out_dir / "chip_swimlane_records.json"
     assert perf.exists(), f"chip_swimlane_records.json missing under {out_dir} — swimlane capture failed?"
+    raw = json.loads(perf.read_text())
 
     # Read via the swimlane_converter loader so v2 host JSON gets joined into
     # the v1-shaped dict the rest of this validator (and the differential
     # oracle below) expects. Direct json.load(perf) would see only raw
-    # aicore_tasks / aicpu_tasks arrays under v2.
+    # aicore_tasks / scheduler_tasks raw streams.
     data = read_perf_data(perf)
-    assert data.get("chip_swimlane_level") in (1, 2, 3, 4), (
-        f"unexpected chip_swimlane_level: {data.get('chip_swimlane_level')}"
-    )
+    level = data.get("chip_swimlane_level")
+    assert level in (1, 2, 3, 4), f"unexpected chip_swimlane_level: {level}"
+    if level >= 2:
+        assert data.get("scheduler_task_producer") == "aicpu"
+        assert raw["scheduler_tasks"]["schema_version"] == 1
+        assert raw["scheduler_tasks"]["producer"] == "aicpu"
     tasks = data.get("tasks")
     assert isinstance(tasks, list), "tasks field missing or not a list"
     assert len(tasks) > 0, f"perf records empty under {perf}"

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/_swimlane_validate.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/_swimlane_validate.py
@@ -39,7 +39,7 @@ _REQUIRED_TASK_FIELDS = (
     "start_time_us",
     "end_time_us",
     # receive_time_us / local_setup_us are populated unconditionally by the
-    # AICore-side capture (v3 schema). propagation_us requires AICPU dispatch_ts
+    # AICore-side capture (v3 schema). propagation_us requires Scheduler dispatch_ts
     # and is therefore only present at level≥2 — not in this required-set.
     "receive_time_us",
     "local_setup_us",
@@ -80,15 +80,19 @@ def validate_perf_artifact(
     out_dir = max(matches, key=lambda p: p.stat().st_mtime)
     perf = out_dir / "chip_swimlane_records.json"
     assert perf.exists(), f"chip_swimlane_records.json missing under {out_dir} — swimlane capture failed?"
+    raw = json.loads(perf.read_text())
 
     # Read via the swimlane_converter loader so v2 host JSON gets joined into
     # the v1-shaped dict the rest of this validator (and the differential
     # oracle below) expects. Direct json.load(perf) would see only raw
-    # aicore_tasks / aicpu_tasks arrays under v2.
+    # aicore_tasks / scheduler_tasks raw streams.
     data = read_perf_data(perf)
-    assert data.get("chip_swimlane_level") in (1, 2, 3, 4), (
-        f"unexpected chip_swimlane_level: {data.get('chip_swimlane_level')}"
-    )
+    level = data.get("chip_swimlane_level")
+    assert level in (1, 2, 3, 4), f"unexpected chip_swimlane_level: {level}"
+    if level >= 2:
+        assert data.get("scheduler_task_producer") == "aicpu"
+        assert raw["scheduler_tasks"]["schema_version"] == 1
+        assert raw["scheduler_tasks"]["producer"] == "aicpu"
     tasks = data.get("tasks")
     assert isinstance(tasks, list), "tasks field missing or not a list"
     assert len(tasks) > 0, f"perf records empty under {perf}"

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -472,6 +472,31 @@ set_tests_properties(test_native_run_acceptance PROPERTIES LABELS "no_hardware")
 # callers invoke it from different host threads.
 add_common_utils_test(test_host_api common/test_host_api.cpp)
 
+# Runtime extension payloads are per-run state even though the collector's
+# shared-memory resources remain resident across runs.
+add_executable(test_chip_swimlane_collector
+    common/test_chip_swimlane_collector.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/host/chip_swimlane_collector.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/host/clock_correlation.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/sim/host/profiling_copy.cpp
+    ${CMAKE_SOURCE_DIR}/stubs/test_stubs.cpp
+)
+target_compile_definitions(test_chip_swimlane_collector PRIVATE SIMPLER_RUNTIME_NAME="test_runtime")
+target_include_directories(test_chip_swimlane_collector PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common
+)
+target_link_libraries(test_chip_swimlane_collector PRIVATE
+    ${GTEST_MAIN_LIB}
+    ${GTEST_LIB}
+    pthread
+)
+add_test(NAME test_chip_swimlane_collector COMMAND test_chip_swimlane_collector)
+set_tests_properties(test_chip_swimlane_collector PROPERTIES LABELS "no_hardware")
+
 # Sim kernel threads publish one sticky completion state. A gated unit test
 # proves submission and completion are separate without relying on kernel
 # duration or host scheduling.

--- a/tests/ut/cpp/common/test_chip_swimlane_collector.cpp
+++ b/tests/ut/cpp/common/test_chip_swimlane_collector.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include "common/chip_swimlane_extension.h"
+#include "common/chip_swimlane_profiling.h"
+#include "host/chip_swimlane_collector.h"
+
+TEST(ChipSwimlaneCollectorTest, BeginRunReleasesRuntimeExtensionSlots) {
+    ChipSwimlaneCollector collector;
+
+    collector.begin_run("first", ChipSwimlaneLevel::TASK_TIMING);
+    ASSERT_TRUE(collector.set_json_extension(ChipSwimlaneExtensionSection::AicoreTasks, "[]"));
+    EXPECT_FALSE(collector.set_json_extension(ChipSwimlaneExtensionSection::AicoreTasks, "[]"));
+
+    collector.begin_run("second", ChipSwimlaneLevel::TASK_TIMING);
+    EXPECT_TRUE(collector.set_json_extension(ChipSwimlaneExtensionSection::AicoreTasks, "[]"));
+}

--- a/tests/ut/cpp/common/test_host_api.cpp
+++ b/tests/ut/cpp/common/test_host_api.cpp
@@ -15,10 +15,12 @@
 #include <condition_variable>
 #include <cstdint>
 #include <mutex>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 
 #include "common/host_api.h"
+#include "common/chip_swimlane_extension.h"
 
 namespace {
 
@@ -83,6 +85,10 @@ bool all_equal(const std::vector<uint32_t> &values, uint32_t expected) {
     });
 }
 
+bool throwing_extension_callback(void *, ChipSwimlaneExtensionSection, const char *, size_t) {
+    throw std::runtime_error("publication failed");
+}
+
 }  // namespace
 
 TEST(HostApiTest, BoundRunnerSlotAndBankSurviveConcurrentCrossThreadCalls) {
@@ -124,4 +130,34 @@ TEST(HostApiTest, BoundRunnerSlotAndBankSurviveConcurrentCrossThreadCalls) {
     EXPECT_TRUE(all_equal(runner_a.arena_banks, kRunnerABank));
     EXPECT_TRUE(all_equal(runner_b.pipeline_slots, kRunnerBSlot));
     EXPECT_TRUE(all_equal(runner_b.arena_banks, kRunnerBBank));
+}
+
+TEST(HostApiTest, PublicationExceptionsBecomeFailureResults) {
+    HostApiOps ops{};
+    ops.publish_chip_swimlane_extension = throwing_extension_callback;
+    const HostApi api(nullptr, 0, 0, &ops);
+
+    EXPECT_FALSE(api.publish_chip_swimlane_extension(ChipSwimlaneExtensionSection::SchedulerRecords, "{}", 2));
+}
+
+TEST(ChipSwimlaneExtensionTest, ExposesOnlyFixedSectionNamesAndShapes) {
+    EXPECT_STREQ(chip_swimlane_extension_section_name(ChipSwimlaneExtensionSection::AicoreTasks), "aicore_tasks");
+    EXPECT_STREQ(
+        chip_swimlane_extension_section_name(ChipSwimlaneExtensionSection::SchedulerRecords), "scheduler_records"
+    );
+    EXPECT_STREQ(chip_swimlane_extension_section_name(ChipSwimlaneExtensionSection::SchedulerTasks), "scheduler_tasks");
+    EXPECT_STREQ(
+        chip_swimlane_extension_section_name(ChipSwimlaneExtensionSection::AicpuLifecycleRecords),
+        "aicpu_lifecycle_records"
+    );
+    EXPECT_TRUE(chip_swimlane_extension_section_is_object(ChipSwimlaneExtensionSection::SchedulerTasks));
+    EXPECT_TRUE(chip_swimlane_extension_section_is_object(ChipSwimlaneExtensionSection::SchedulerRecords));
+    EXPECT_FALSE(chip_swimlane_extension_section_is_object(ChipSwimlaneExtensionSection::AicoreTasks));
+    EXPECT_FALSE(chip_swimlane_extension_section_is_valid(ChipSwimlaneExtensionSection::Count));
+    EXPECT_EQ(chip_swimlane_extension_section_name(ChipSwimlaneExtensionSection::Count), nullptr);
+    EXPECT_TRUE(chip_swimlane_extension_has_expected_root(ChipSwimlaneExtensionSection::SchedulerRecords, " {} "));
+    EXPECT_TRUE(chip_swimlane_extension_has_expected_root(ChipSwimlaneExtensionSection::SchedulerTasks, " {} "));
+    EXPECT_TRUE(chip_swimlane_extension_has_expected_root(ChipSwimlaneExtensionSection::AicoreTasks, " [] "));
+    EXPECT_FALSE(chip_swimlane_extension_has_expected_root(ChipSwimlaneExtensionSection::SchedulerRecords, "[]"));
+    EXPECT_FALSE(chip_swimlane_extension_has_expected_root(ChipSwimlaneExtensionSection::AicoreTasks, "{}"));
 }

--- a/tests/ut/py/test_runtime_builder.py
+++ b/tests/ut/py/test_runtime_builder.py
@@ -397,7 +397,10 @@ class TestRuntimeBuilderGetBinaries:
             "SIMPLER_TENSORMAP_PROFILING": "0",
         }
         for call in mock_instance.compile.call_args_list:
-            assert call.kwargs["cmake_defines"] == expected_defaults
+            expected = dict(expected_defaults)
+            if call.args[0] == "host":
+                expected["SIMPLER_RUNTIME_NAME"] = "test_rt"
+            assert call.kwargs["cmake_defines"] == expected
 
     @patch("simpler_setup.runtime_builder.RuntimeCompiler")
     def test_reuses_prebuilt_shared_libraries(self, MockCompiler, tmp_path, default_test_platform, test_arch):
@@ -434,7 +437,10 @@ class TestRuntimeBuilderGetBinaries:
 
         assert mock_instance.compile.call_count == 3
         for call in mock_instance.compile.call_args_list:
-            assert call.kwargs["cmake_defines"] == config
+            expected = dict(config)
+            if call.args[0] == "host":
+                expected["SIMPLER_RUNTIME_NAME"] = "test_rt"
+            assert call.kwargs["cmake_defines"] == expected
 
     @patch("simpler_setup.runtime_builder.RuntimeCompiler")
     def test_resolves_paths_relative_to_config(self, MockCompiler, tmp_path, default_test_platform, test_arch):
@@ -527,6 +533,7 @@ class TestRuntimeBuilderGetBinaries:
             **profiling,
             "PTO_ISA_ROOT": "/tmp/pto-isa",
             "SIMPLER_PTO_ISA_BUILD_COMMIT": pin,
+            "SIMPLER_RUNTIME_NAME": "test_rt",
         }
         # aicore needs the checkout path too, for the SDMA warmup kernel's
         # vector-only target, but not the commit stamp (that keys the host ccache).

--- a/tests/ut/py/test_sched_overhead_analysis.py
+++ b/tests/ut/py/test_sched_overhead_analysis.py
@@ -22,6 +22,7 @@ from simpler_setup.tools.sched_overhead_analysis import (
     parse_scheduler_from_json_phases,
     per_id_timing,
     print_distribution,
+    run_analysis,
 )
 
 
@@ -35,6 +36,71 @@ def _task(core_id, dispatch, start, end, finish, core_type="aic"):
         "finish_time_us": float(finish),
         "duration_us": float(end - start),
     }
+
+
+def test_aicore_scheduler_runs_common_analysis_and_own_phase_breakdown(tmp_path, capsys):
+    perf_path = tmp_path / "chip_swimlane_records.json"
+    perf_path.write_text("{}")
+    deps_path = tmp_path / "deps.json"
+    deps_path.write_text('{"edges": []}')
+    task = _task(0, 1, 2, 4, 5)
+    task["task_id"] = 1
+    data = {
+        "tasks": [task],
+        "scheduler_task_producer": "aicore",
+        "scheduler_records": [[{"phase": "ready_claim", "start_time_us": 1.0, "end_time_us": 1.5}]],
+        "scheduler_streams": [{"producer": "aicore", "capture": {"committed": 1, "dropped": 0, "truncated": False}}],
+    }
+
+    assert run_analysis(perf_path, print_sources=False, perf_data=data, deps_json_path=deps_path) == 0
+    output = capsys.readouterr().out
+    assert "Part 1: Overhead verdict" in output
+    assert "Part 3: Head OH" in output
+    assert "Part 4: Tail OH" in output
+    assert "Part 5: AICore scheduler phase breakdown" in output
+    assert "ready_claim" in output
+    assert "Part 6: Critical-path latency attribution" in output
+    assert "AICPU scheduler loop breakdown" not in output
+
+
+def test_level_two_aicore_runs_common_analysis_without_phase_records(tmp_path, capsys):
+    perf_path = tmp_path / "chip_swimlane_records.json"
+    perf_path.write_text("{}")
+    deps_path = tmp_path / "deps.json"
+    deps_path.write_text('{"edges": []}')
+    task = _task(0, 1, 2, 4, 5)
+    task["task_id"] = 1
+    data = {
+        "tasks": [task],
+        "scheduler_task_producer": "aicore",
+    }
+
+    assert run_analysis(perf_path, print_sources=False, perf_data=data, deps_json_path=deps_path) == 0
+    output = capsys.readouterr().out
+    assert "Part 1: Overhead verdict" in output
+    assert "Part 5: AICore scheduler phase breakdown" in output
+    assert "phase records unavailable at chip-swimlane Level 2" in output
+    assert "Part 6: Critical-path latency attribution" in output
+
+
+def test_level_two_aicpu_runs_common_analysis_without_phase_records(tmp_path, capsys):
+    perf_path = tmp_path / "chip_swimlane_records.json"
+    perf_path.write_text("{}")
+    deps_path = tmp_path / "deps.json"
+    deps_path.write_text('{"edges": []}')
+    task = _task(0, 1, 2, 4, 5)
+    task["task_id"] = 1
+    data = {
+        "tasks": [task],
+        "scheduler_task_producer": "aicpu",
+    }
+
+    assert run_analysis(perf_path, print_sources=False, perf_data=data, deps_json_path=deps_path) == 0
+    output = capsys.readouterr().out
+    assert "Part 1: Overhead verdict" in output
+    assert "Part 5: AICPU scheduler loop breakdown" in output
+    assert "phase records unavailable at chip-swimlane Level 2" in output
+    assert "Part 6: Critical-path latency attribution" in output
 
 
 def test_head_first_task_uses_start_minus_dispatch():
@@ -140,6 +206,17 @@ def test_critical_path_splits_exec_vs_scheduler():
     assert cp["hops"] == 1
     assert abs(cp["exec"] - 10.0) < 1e-6  # A 5 + B 5
     assert abs(cp["sched"] - 2.0) < 1e-6  # B.start - A.end
+    assert cp["sched"] + cp["exec"] <= cp["span"]
+
+
+def test_critical_path_span_includes_root_dispatch_head():
+    tasks = [_gtask(1, 0, 1, 3, 8, 9)]
+    _ready, _gating, end_by_id, *_ = build_task_graph(tasks, {"edges": []}, 3.0)
+    dispatch, start, _end, finish = per_id_timing(tasks)
+
+    cp = compute_critical_path({}, end_by_id, finish, start, dispatch, 3.0)
+
+    assert cp == {"hops": 0, "span": 8.0, "sched": 2.0, "exec": 5.0}
 
 
 def test_print_distribution(capsys):

--- a/tests/ut/py/test_swimlane_converter.py
+++ b/tests/ut/py/test_swimlane_converter.py
@@ -235,6 +235,65 @@ def test_l3_directory_merge_uses_common_host_origin_and_rank_namespaces(tmp_path
     assert worker_events[8]["ts"] == 10.5
 
 
+def test_l3_directory_merge_keeps_scheduler_streams_and_lifecycle_records(tmp_path):
+    root = tmp_path / "dfx_outputs"
+    for rank in (0, 1):
+        capture_dir = _write_l3_rank(root, rank, host_shift_ns=rank * 10_000, task_id=rank + 7)
+        records_path = capture_dir / "chip_swimlane_records.json"
+        records = json.loads(records_path.read_text())
+        device_base = records["aicore_tasks"][0][3] - 1_000
+        records["scheduler_records"] = {
+            "schema_version": 1,
+            "streams": [
+                {
+                    "platform": "a5",
+                    "runtime": "host_build_graph",
+                    "producer": "aicore",
+                    "scheduler_id": rank + 2,
+                    "worker_id": rank + 4,
+                    "core_type": "aiv",
+                    "physical_core_id": rank,
+                    "capture": {"committed": 1, "dropped": 0, "truncated": False},
+                    "records": [
+                        {
+                            "start_cycles": device_base + 700,
+                            "end_cycles": device_base + 750,
+                            "loop_iter": 0,
+                            "kind": "ready_claim",
+                            "tasks_processed": 1,
+                            "task_id": rank + 7,
+                        }
+                    ],
+                    "metrics": [],
+                }
+            ],
+        }
+        records["aicpu_lifecycle_records"] = [
+            {
+                "worker_id": rank + 4,
+                "aicpu_thread_id": rank,
+                "core_type": "aiv",
+                "physical_core_id": rank,
+                "register_release_cycles": device_base + 600,
+            }
+        ]
+        records_path.write_text(json.dumps(records))
+
+    output = tmp_path / "l3.json"
+    args = sc._build_parser().parse_args([str(root), "--dispatch", "d0", "-o", str(output)])
+
+    sc._generate_l3_trace(args, root)
+
+    events = json.loads(output.read_text())["traceEvents"]
+    process_names = {
+        event["args"]["name"] for event in events if event.get("ph") == "M" and event.get("name") == "process_name"
+    }
+    assert "rank0 / AICore Scheduler" in process_names
+    assert "rank1 / AICore Scheduler" in process_names
+    register_releases = [event for event in events if event.get("name") == "register_release"]
+    assert {event["args"]["rank"] for event in register_releases} == {0, 1}
+
+
 def test_l3_parent_dispatch_identity_pairs_different_local_capture_indexes(tmp_path):
     root = tmp_path / "dfx_outputs"
     rank0 = _write_l3_rank(root, 0, host_shift_ns=0, task_id=7, dispatch="d0")
@@ -372,7 +431,11 @@ def test_l3_directory_merge_rejects_different_or_missing_host_clock_domains(tmp_
         sc._generate_l3_trace(args, root)
 
 
-def test_task_statistics_level_one_hides_aicpu_metrics(capsys):
+@pytest.mark.parametrize(
+    ("level", "description"),
+    [(1, "AICore timing only"), (3, "AICore + Scheduler task timing + scheduler phases")],
+)
+def test_task_statistics_without_scheduler_timestamps_hides_scheduler_metrics(capsys, level, description):
     tasks = [
         {
             "task_id": 1,
@@ -389,12 +452,12 @@ def test_task_statistics_level_one_hides_aicpu_metrics(capsys):
         }
     ]
 
-    sc.print_task_statistics(tasks, {"0": "kernel"}, chip_swimlane_level=1)
+    sc.print_task_statistics(tasks, {"0": "kernel"}, chip_swimlane_level=level)
 
     output = capsys.readouterr().out
     row = next(line for line in output.splitlines() if line.startswith("0        kernel"))
     total = next(line for line in output.splitlines() if line.startswith("TOTAL"))
-    assert "Source chip_swimlane_level: 1 (AICore timing only; recorded in chip_swimlane_records.json)" in output
+    assert f"Source chip_swimlane_level: {level} ({description}; recorded in chip_swimlane_records.json)" in output
     assert row.split() == ["0", "kernel", "1", "5.00", "-", "-", "-", "-", "-", "0.50"]
     assert total.split() == ["TOTAL", "1", "5.00", "-"]
     assert "AICore Observed Span: 5.50 us (from earliest AICore receive to latest AICore end)" in output
@@ -464,6 +527,7 @@ def test_host_orchestrator_phases_without_anchors_are_marked_unaligned(tmp_path)
 
     data = sc.read_perf_data(raw)
 
+    assert data["scheduler_task_producer"] == "aicpu"
     assert data["orchestrator_source"] == "host"
     assert data["aicpu_orchestrator_phases"][0][0]["start_time_us"] == 0.0
     assert data["aicpu_orchestrator_phases"][0][0]["end_time_us"] == 2.0
@@ -574,6 +638,403 @@ def test_aicpu_orchestrator_uses_host_timeline_when_clock_anchors_exist(tmp_path
     assert data["timeline_metadata"]["clock_alignment"]["status"] == "calibrated"
     assert data["timeline_metadata"]["host_clock_domain_id"] == "same-boot"
     assert data["timeline_metadata"]["source_timeline_origin_ns"] == 1_000
+
+
+def test_aicore_scheduler_records_keep_common_shape_and_stream_metadata(tmp_path):
+    raw = tmp_path / "chip_swimlane_records.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "chip_swimlane_level": 3,
+                "metadata": {"clock_freq_hz": 1_000_000_000, "num_cores": 1, "core_types": ["aiv"]},
+                "aicore_tasks": [[0, 7, 7, 120, 180, 10]],
+                "scheduler_tasks": {
+                    "schema_version": 1,
+                    "producer": "aicore",
+                    "records": [[0, 7, 115, 185]],
+                },
+                "aicpu_lifecycle_records": [
+                    {
+                        "worker_id": 6,
+                        "aicpu_thread_id": 1,
+                        "core_type": "aiv",
+                        "physical_core_id": 9,
+                        "handshake_observed_cycles": 90,
+                        "handshake_partition_complete_cycles": 91,
+                        "config_start_cycles": 92,
+                        "topology_complete_cycles": 93,
+                        "context_publish_complete_cycles": 94,
+                        "bootstrap_wait_start_cycles": 95,
+                        "bootstrap_complete_cycles": 96,
+                        "register_release_cycles": 97,
+                        "exit_signal_cycles": 181,
+                        "exit_ack_cycles": 182,
+                    }
+                ],
+                "scheduler_records": {
+                    "schema_version": 1,
+                    "streams": [
+                        {
+                            "platform": "a5",
+                            "runtime": "host_build_graph",
+                            "producer": "aicore",
+                            "scheduler_id": 2,
+                            "worker_id": 6,
+                            "core_type": "aiv",
+                            "physical_core_id": 9,
+                            "capture": {"committed": 2, "dropped": 0, "truncated": False},
+                            "records": [
+                                {
+                                    "start_cycles": 100,
+                                    "end_cycles": 110,
+                                    "loop_iter": 3,
+                                    "kind": "ready_claim",
+                                    "tasks_processed": 1,
+                                    "task_id": 7,
+                                },
+                                {
+                                    "start_cycles": 111,
+                                    "end_cycles": 119,
+                                    "loop_iter": 3,
+                                    "kind": "idle",
+                                    "tasks_processed": 0,
+                                    "task_id": None,
+                                },
+                            ],
+                            "metrics": [{"record_index": 0, "claim_retries": 2}],
+                        }
+                    ],
+                },
+            }
+        )
+    )
+
+    data = sc.read_perf_data(raw)
+
+    assert [task["task_id"] for task in data["tasks"]] == [7]
+    assert data["scheduler_task_producer"] == "aicore"
+    assert data["tasks"][0]["dispatch_time_us"] == pytest.approx(0.025)
+    assert data["tasks"][0]["finish_time_us"] == pytest.approx(0.095)
+    assert data["scheduler_streams"][0]["producer"] == "aicore"
+    assert data["scheduler_records"][0][0]["claim_retries"] == 2
+    assert data["scheduler_records"][0][1]["task_id"] is None
+    assert data["aicpu_lifecycle_records"][0]["register_release_time_us"] == pytest.approx(0.007)
+
+    trace_path = tmp_path / "merged_swimlane.json"
+    sc.generate_chrome_trace_json(
+        data["tasks"],
+        str(trace_path),
+        scheduler_phases=data["scheduler_records"],
+        scheduler_streams=data["scheduler_streams"],
+        aicpu_lifecycle_records=data["aicpu_lifecycle_records"],
+    )
+    events = json.loads(trace_path.read_text())["traceEvents"]
+    assert any(
+        event.get("name") == "process_name" and event.get("args", {}).get("name") == "AICore Scheduler"
+        for event in events
+    )
+    assert any(event.get("cat") == "scheduler" and event.get("name") == "idle(0)" for event in events)
+    assert any(
+        event.get("name") == "process_name" and event.get("args", {}).get("name") == "AICPU Lifecycle"
+        for event in events
+    )
+    assert any(event.get("cat") == "aicpu_lifecycle" and event.get("name") == "bootstrap_wait" for event in events)
+
+
+def test_level_two_rejects_missing_scheduler_task_timing(tmp_path):
+    raw = tmp_path / "chip_swimlane_records.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "chip_swimlane_level": 2,
+                "metadata": {"clock_freq_hz": 1_000_000_000, "num_cores": 1, "core_types": ["aiv"]},
+                "aicore_tasks": [[0, 7, 7, 120, 180, 10]],
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="level 2 requires Scheduler task timing for every AICore task"):
+        sc.read_perf_data(raw)
+
+
+@pytest.mark.parametrize("producer", ["aicpu", "aicore"])
+def test_level_two_accepts_task_timing_from_either_scheduler_producer(tmp_path, producer):
+    raw = tmp_path / "chip_swimlane_records.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "chip_swimlane_level": 2,
+                "metadata": {"clock_freq_hz": 1_000_000_000, "num_cores": 1, "core_types": ["aiv"]},
+                "aicore_tasks": [[0, 7, 7, 120, 180, 10]],
+                "scheduler_tasks": {
+                    "schema_version": 1,
+                    "producer": producer,
+                    "records": [[0, 7, 115, 185]],
+                },
+            }
+        )
+    )
+
+    data = sc.read_perf_data(raw)
+
+    assert data["scheduler_task_producer"] == producer
+    assert data["tasks"][0]["dispatch_time_us"] == pytest.approx(0.005)
+    assert data["tasks"][0]["finish_time_us"] == pytest.approx(0.075)
+
+
+@pytest.mark.parametrize("dispatch_cycles,finish_cycles", [(125, 185), (115, 175)])
+def test_level_two_accepts_cross_producer_clock_skew(tmp_path, dispatch_cycles, finish_cycles):
+    raw = tmp_path / "chip_swimlane_records.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "chip_swimlane_level": 2,
+                "metadata": {"clock_freq_hz": 1_000_000_000, "num_cores": 1, "core_types": ["aiv"]},
+                "aicore_tasks": [[0, 7, 7, 120, 180, 10]],
+                "scheduler_tasks": {
+                    "schema_version": 1,
+                    "producer": "aicpu",
+                    "records": [[0, 7, dispatch_cycles, finish_cycles]],
+                },
+            }
+        )
+    )
+
+    data = sc.read_perf_data(raw)
+
+    assert data["tasks"][0]["task_id"] == 7
+
+
+@pytest.mark.parametrize(
+    "aicore_timing,scheduler_timing,error",
+    [
+        ((180, 120, 10), (115, 185), "expected 0 < start_cycles <= end_cycles"),
+        ((120, 180, 120), (115, 185), "expected 0 <= receive_to_start_cycles < start_cycles"),
+        ((120, 180, 10), (185, 115), "expected 0 < dispatch_cycles <= finish_cycles"),
+    ],
+)
+def test_level_two_rejects_invalid_same_producer_timing(tmp_path, aicore_timing, scheduler_timing, error):
+    start_cycles, end_cycles, receive_to_start_cycles = aicore_timing
+    dispatch_cycles, finish_cycles = scheduler_timing
+    raw = tmp_path / "chip_swimlane_records.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "chip_swimlane_level": 2,
+                "metadata": {"clock_freq_hz": 1_000_000_000, "num_cores": 1, "core_types": ["aiv"]},
+                "aicore_tasks": [[0, 7, 7, start_cycles, end_cycles, receive_to_start_cycles]],
+                "scheduler_tasks": {
+                    "schema_version": 1,
+                    "producer": "aicpu",
+                    "records": [[0, 7, dispatch_cycles, finish_cycles]],
+                },
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match=error):
+        sc.read_perf_data(raw)
+
+
+def test_level_one_accepts_aicore_only_timing(tmp_path):
+    raw = tmp_path / "chip_swimlane_records.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "chip_swimlane_level": 1,
+                "metadata": {"clock_freq_hz": 1_000_000_000, "num_cores": 1, "core_types": ["aiv"]},
+                "aicore_tasks": [[0, 7, 7, 120, 180, 10]],
+            }
+        )
+    )
+
+    data = sc.read_perf_data(raw)
+
+    assert [task["task_id"] for task in data["tasks"]] == [7]
+    assert "dispatch_time_us" not in data["tasks"][0]
+    assert "finish_time_us" not in data["tasks"][0]
+    assert "scheduler_task_producer" not in data
+
+
+def test_level_one_skips_overhead_counters_without_scheduler_timing(tmp_path):
+    trace_path = tmp_path / "merged_swimlane.json"
+    sc.generate_chrome_trace_json(
+        [
+            {
+                "task_id": 7,
+                "func_id": -1,
+                "core_id": 0,
+                "core_type": "aiv",
+                "start_time_us": 1.0,
+                "end_time_us": 2.0,
+                "duration_us": 1.0,
+                "receive_time_us": 0.5,
+                "local_setup_us": 0.5,
+            }
+        ],
+        str(trace_path),
+        deps_edges={7: [8]},
+        emit_overhead=True,
+    )
+
+    events = json.loads(trace_path.read_text())["traceEvents"]
+    assert not any(event.get("cat") == "overhead" for event in events)
+
+
+@pytest.mark.parametrize(
+    ("scheduler_tasks", "error"),
+    [
+        ({"schema_version": 2, "producer": "aicore", "records": []}, "schema_version"),
+        ({"schema_version": 1, "producer": "host", "records": []}, "producer"),
+        ({"schema_version": 1, "producer": "aicore", "records": [[0, 1, 2]]}, "four-column"),
+    ],
+)
+def test_scheduler_tasks_reject_schema_drift(tmp_path, scheduler_tasks, error):
+    raw = tmp_path / "chip_swimlane_records.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "chip_swimlane_level": 2,
+                "metadata": {"clock_freq_hz": 1_000_000_000},
+                "aicore_tasks": [],
+                "scheduler_tasks": scheduler_tasks,
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match=error):
+        sc.read_perf_data(raw)
+
+
+def test_scheduler_tasks_reject_ambiguous_legacy_stream(tmp_path):
+    raw = tmp_path / "chip_swimlane_records.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "chip_swimlane_level": 2,
+                "metadata": {"clock_freq_hz": 1_000_000_000},
+                "aicore_tasks": [],
+                "scheduler_tasks": {"schema_version": 1, "producer": "aicore", "records": []},
+                "aicpu_tasks": [],
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="both scheduler_tasks and legacy aicpu_tasks"):
+        sc.read_perf_data(raw)
+
+
+def test_scheduler_records_reject_schema_drift(tmp_path):
+    raw = tmp_path / "chip_swimlane_records.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "chip_swimlane_level": 3,
+                "metadata": {"clock_freq_hz": 1_000_000_000},
+                "scheduler_records": {
+                    "schema_version": 1,
+                    "streams": [{"records": [{"kind": "idle"}], "metrics": []}],
+                },
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="must contain exactly"):
+        sc.read_perf_data(raw)
+
+
+def test_scheduler_metrics_cannot_overwrite_fixed_record_fields(tmp_path):
+    raw = tmp_path / "chip_swimlane_records.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "chip_swimlane_level": 3,
+                "metadata": {"clock_freq_hz": 1_000_000_000},
+                "scheduler_records": {
+                    "schema_version": 1,
+                    "streams": [
+                        {
+                            "records": [
+                                {
+                                    "start_cycles": 10,
+                                    "end_cycles": 20,
+                                    "loop_iter": 0,
+                                    "kind": "idle",
+                                    "tasks_processed": 0,
+                                    "task_id": None,
+                                }
+                            ],
+                            "metrics": [{"record_index": 0, "start_cycles": 30}],
+                        }
+                    ],
+                },
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="metric overwrites fixed record fields"):
+        sc.read_perf_data(raw)
+
+
+def test_lifecycle_interval_can_start_at_relative_time_origin(tmp_path):
+    trace_path = tmp_path / "merged_swimlane.json"
+    sc.generate_chrome_trace_json(
+        [],
+        str(trace_path),
+        aicpu_lifecycle_records=[
+            {
+                "worker_id": 0,
+                "aicpu_thread_id": 1,
+                "handshake_observed_time_us": 0.0,
+                "handshake_partition_complete_time_us": 2.0,
+            }
+        ],
+    )
+
+    events = json.loads(trace_path.read_text())["traceEvents"]
+    interval = next(event for event in events if event.get("name") == "handshake_partition")
+    assert interval["ts"] == 0.0
+    assert interval["dur"] == 2.0
+
+
+def test_lifecycle_register_release_can_be_at_relative_time_origin(tmp_path):
+    raw = tmp_path / "chip_swimlane_records.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "chip_swimlane_level": 1,
+                "metadata": {"clock_freq_hz": 1_000_000_000, "num_cores": 1, "core_types": ["aiv"]},
+                "aicore_tasks": [[0, 7, 7, 120, 180, 10]],
+                "aicpu_lifecycle_records": [{"worker_id": 0, "register_release_cycles": 90}],
+            }
+        )
+    )
+
+    data = sc.read_perf_data(raw)
+    assert data["aicpu_lifecycle_records"][0]["register_release_time_us"] == 0.0
+
+    trace_path = tmp_path / "merged_swimlane.json"
+    sc.generate_chrome_trace_json(
+        data["tasks"],
+        str(trace_path),
+        aicpu_lifecycle_records=data["aicpu_lifecycle_records"],
+    )
+
+    events = json.loads(trace_path.read_text())["traceEvents"]
+    register_release = next(event for event in events if event.get("name") == "register_release")
+    assert register_release["ts"] == 0.0
+
+
+def test_lifecycle_omits_missing_register_release(tmp_path):
+    trace_path = tmp_path / "merged_swimlane.json"
+    sc.generate_chrome_trace_json(
+        [],
+        str(trace_path),
+        aicpu_lifecycle_records=[{"worker_id": 0}],
+    )
+
+    events = json.loads(trace_path.read_text())["traceEvents"]
+    assert not any(event.get("name") == "register_release" for event in events)
 
 
 def test_host_capture_is_complete_when_the_pool_holds_more_than_the_submit_projection(tmp_path):


### PR DESCRIPTION
## Why

Chip-swimlane producers currently expose Scheduler timing through
architecture- and runtime-specific shapes plus an open-ended extension
interface. This makes consumer tooling depend on producer identity and leaves
artifact sections unconstrained. Establishing one bounded schema lets current
and future Scheduler producers share the same analysis pipeline while keeping
device ABIs architecture-owned.

## What changed

- Move Scheduler record ABIs into the A2/A3 and A5 architecture trees while
  keeping their JSON serialization shared and host-only.
- Replace arbitrary chip-swimlane extension names with four fixed internal
  slots: AICore tasks, Scheduler tasks, Scheduler records, and AICPU lifecycle
  records. Each linked runtime selects the publishers it owns.
- Normalize the version-1 Scheduler task/phase schema across the converter,
  dependency viewer, and scheduler-overhead analysis.
- Keep `swimlane_converter` compatible with archived `aicpu_tasks` and
  `aicpu_scheduler_phases` artifacts while validating new records more
  strictly.
- Reset extension slots at each run and derive emitted section keys from the
  shared slot-name contract.
- Update the DFX documentation and unit coverage for the new contract.

## Correctness and scope

- The on-disk schema remains version 1.
- Device-facing Scheduler record layouts remain architecture-owned; only the
  host serializer is shared.
- This PR defines schema publication, serialization, and consumption; it does
  not introduce a new profiling producer.
- The A5 host-build-graph publisher remains follow-up work in the second commit
  of #2104; that PR should later rebase and drop the schema commit duplicated
  here.
- Cross-producer timestamp ordering is intentionally not enforced for either
  AICore or AICPU, matching the existing main-branch contract.

## Reviewer guide

The highest-risk boundaries are the fixed extension-slot publication path and
the converter's new-schema/legacy-schema normalization and validation.

## Testing

- [x] Editable package/runtime build after rebasing onto `upstream/main`
- [x] Python unit tests for runtime builder, converter, and overhead analysis — 143 passed
- [x] C++ no-hardware unit suite — 135/135 passed
- [x] A2/A3 and A5 simulation coverage for TMR/HBG chip-swimlane plus collector residency — 12 passed
- [x] TMR profiling levels 1–4 on A2/A3 sim, A5 sim, and A5 onboard — 12/12 semantic swimlane comparisons passed against `upstream/main`
- [x] Pre-commit hooks for all touched files; local clang-tidy 22 reports one pre-existing warning in untouched `buffer_pool_manager.h`
