### PR TITLE
Refactor: make [STRACE] the only host-side timeline format

### DIFF
--- a/.claude/skills/hbg-bind-phases/SKILL.md
+++ b/.claude/skills/hbg-bind-phases/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hbg-bind-phases
-description: Measure host_build_graph's `bind` phases — the host-side stage between "caller data in place" and "device can start" (orchestration, Definition upload, H2D), also called the bind path or control plane — on the dsv4 and qwen decode cases, and compare two branches. Use when the user asks how long bind or the control plane takes, whether a change moved host_orch / graph_upload / sm_h2d / arena_h2d, or to A/B a host-side change. This is the HOST stage with the device run skipped — for on-device latency use `benchmark` or `perf-example-device` instead.
+description: Measure host_build_graph's `bind` phases — the host-side stage between "caller data in place" and "device can start" (orchestration, Definition upload, H2D), also called the bind path or control plane — on the dsv4 and qwen decode cases, and compare two branches. Use when the user asks how long bind or the control plane takes, whether a change moved host_orch / graph_upload / arena_h2d, or to A/B a host-side change. This is the HOST stage with the device run skipped — for on-device latency use `benchmark` or `perf-example-device` instead.
 ---
 
 # Measuring the `host_build_graph` bind phases
@@ -37,7 +37,7 @@ TAIL="--rounds 6 --log-level timing"                                 # per mode
 echo "[stamp] $HEAD_SHA env $ENVS python $CASE $TAIL" >"$LOG"
 task-submit --device auto --device-num "$DEVICES" --timeout "$TIMEOUT" --max-time "$TIMEOUT" \
   --run "env $ENVS python $CASE $TAIL -d \$TASK_DEVICE" >>"$LOG" 2>&1
-grep -c 'bind phase=' "$LOG"          # numbers mode: must be > 0
+grep -c 'name=chip.run.bind\.' "$LOG"   # numbers mode: must be > 0
 ```
 
 `env` prefixes the assignments so they survive coming from a variable, and the
@@ -55,7 +55,7 @@ destroys an earlier log, and its own output looks entirely normal.
 **`--log-level timing` pins a condition rather than enabling anything.**
 `python/simpler/_log.py` puts the `simpler` logger at TIMING on import and
 `Worker` snapshots that one logger for the host log and for every forked chip
-child, so the `bind phase=` records are already on without it. What passing it
+child, so the segment spans are already on without it. What passing it
 buys is the `[stamp]` line: the level is the one measurement condition with no
 record of its own in the log — unlike `torch_backend_autoload` — so a run that
 omits the flag leaves it implicit in whatever that commit's default happens to
@@ -64,7 +64,7 @@ stamp showing it.
 
 **In timeline mode that last check reports 0 on a run that worked.** A diagnostic
 flag makes `CallConfig.output_prefix` non-empty, and a non-empty prefix moves
-every host-log record — `bind phase=` lines and `[STRACE]` spans alike — out of
+every host-log record — every `[STRACE]` span included — out of
 `$LOG` into `outputs/<case>_<ts>/host.<pid>.log`, one file per process. Grep those
 instead, and feed the finisher both (see the timeline command below).
 
@@ -83,7 +83,7 @@ instead, and feed the finisher both (see the timeline command below).
 Neither case needs a `--level`: each driver runs its `Worker` in this process,
 so its chip children write straight to the log the `task-submit --run` command
 is redirected into. (Under the scene-test module runner they did not: it
-captured the child's stdout and the log ended up with zero `bind phase=` lines
+captured the child's stdout and the log ended up with zero segment spans
 while the run still passed.)
 
 ## The two modes
@@ -102,15 +102,15 @@ per-event artifact a directory; `--enable-chip-swimlane` raises
 `NotImplementedError` at level 3.
 
 ```bash
-# numbers — the bind lines are in $LOG, since no diagnostic flag is on
-python -m simpler_setup.tools.hbg_bind_phases "$LOG" --rounds 6
+# numbers — the segment spans are in $LOG, since no diagnostic flag is on
+python -m simpler_setup.tools.hbg_bind_phases "$LOG"
 
 # timeline — only an artifact newer than this run's own marker counts
 RECORDS=$(find outputs -name host_phase_records.jsonl -newer "$MARK")
 echo "$RECORDS"          # must name exactly one file; empty ⇒ this run wrote none,
                          # so stop rather than reading a previous run's artifact
 D=$(dirname "$RECORDS")
-grep -c 'bind phase=' "$D"/host.*.log    # must be > 0; $LOG has none in this mode
+grep -c 'name=chip.run.bind\.' "$D"/host.*.log   # must be > 0; $LOG has none in this mode
 # The clock anchors are split — the invoking process wrote its own to $LOG, each
 # chip child wrote its own under $D — so parse the concatenation, not either half.
 cat "$LOG" "$D"/host.*.log > "$D/bind_timeline.log"
@@ -121,7 +121,7 @@ python -m simpler_setup.tools.strace_timing "$D/bind_timeline.log" \
 
 ## Before reporting a number
 
-- `grep -c 'bind phase='` was `> 0` — in `$LOG` for numbers mode, in
+- `grep -c 'name=chip.run.bind\.'` was `> 0` — in `$LOG` for numbers mode, in
   `$D/host.*.log` for timeline mode — and the table shows a `[stamp]` line.
 - Quote the stamp with the number. A number without the command and commit that
   produced it cannot be compared to anything.

--- a/docs/dfx/hbg-bind-phases.md
+++ b/docs/dfx/hbg-bind-phases.md
@@ -4,8 +4,8 @@
 executes anything, so the host-side **`bind` stage** — argument staging,
 orchestration, the Graph Definition, and every H2D copy — is a first-class cost.
 `bind` is the `chip.run.bind` `[STRACE]` span both runtimes emit; only this one
-subdivides it into **phases**, one `bind phase=<p>` line each. This page is what
-those phases are, how to measure them on the two decode networks that exercise
+subdivides it into **segments**, one `chip.run.bind.<segment>` span each. This
+page is what those segments are, how to measure them on the two decode networks that exercise
 them, and the traps that make a measurement wrong rather than merely noisy.
 
 For the marker grammar and the tool's other views, see
@@ -20,8 +20,9 @@ only once the lesson is an invariant its code depends on.
 
 ## What the segments are
 
-`SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1` makes the runtime emit one `bind phase=`
-line per segment per bind at `LOG_TIMING`:
+`SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1` makes the runtime emit one
+`chip.run.bind.<segment>` `[STRACE]` span per segment per bind, at depth 2 inside
+the `chip.run.bind` span:
 
 | Segment | What it covers |
 | ------- | -------------- |
@@ -32,40 +33,39 @@ line per segment per bind at `LOG_TIMING`:
 | `arena_h2d` | one H2D of the arena's copied zone and the shared-memory image |
 | `host_view_close` | closing per-run tensor-access regions and any optional device mappings; the current bind path installs none (`count=0 bytes=0`) |
 
-The **control plane** is `host_orch + graph_upload + relocate + sm_h2d +
-arena_h2d`: everything between "the caller's data is in place" and "the device
-can start". It is what the < 1 ms target applies to. `args` is excluded because
-it scales with the caller's tensor bytes, not with the graph. `host_view_close`
-stays excluded so current reports remain comparable with older logs, although
-the current bind path has no device mappings to close.
+The **control plane** is `host_orch + graph_upload + arena_h2d`: everything
+between "the caller's data is in place" and "the device can start". It is what
+the < 1 ms target applies to. `args` is excluded because it scales with the
+caller's tensor bytes, not with the graph. `host_view_close` stays excluded so
+current reports remain comparable with older logs, although the current bind path
+has no device mappings to close.
 
-**Two of those five are retired kinds a current run does not emit.** `relocate`
-and `sm_h2d` date from when the shared-memory image was relocated and copied on
+**Two kinds were retired from the set, not merely from the output.** `relocate`
+and `sm_h2d` dated from when the shared-memory image was relocated and copied on
 its own; it now travels inside the single `arena_h2d` copy as that segment's
-`sm=`. `hbg_bind_phases` keeps both in its control-plane set so a log that
-predates the change still totals correctly, and names them under its `total` row
-as absent from every bind. The table above is what a current run emits: ten
-segments, three of them control plane.
+`sm=`. Neither had a recording site for as long as the change has been in, so
+both were removed from `HostPhaseKind` — a log that predates the change still
+carries their lines, but no current tool totals them. The table above is what a
+current run emits: ten segments, three of them control plane.
 
 **The control plane is a sum of costs, not an interval.** Its three segments are
 not adjacent: `static_arena`, `shared_mem` and `gm_heap` run between
 `graph_upload` and `arena_h2d`, so the segments do not form one contiguous
 window. Sum the ones the bind has; do not subtract two timestamps.
 
-**A bind runs its segments in one order and prints them in another**, and the
-two are easy to confuse because only the second is visible in a log.
+**A bind runs its segments in one order and emits them in another.** Execution is
+the sequence `runtime_maker.cpp` calls them in, which each span's `ts` records:
 
-| order | segments |
-| ----- | -------- |
-| **execution** — the sequence `runtime_maker.cpp` calls them in, and what `start_ns` shows | `args`, `arena_build`, `runtime_init`, `host_orch`, `graph_upload`, `static_arena`, `shared_mem`, `gm_heap`, `arena_h2d`, `host_view_close` |
-| **emission** — `HostPhaseKind` order, printed as one burst when the bind ends | `args`, `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init`, `host_orch`, `graph_upload`, `arena_h2d`, `host_view_close` |
+```text
+args, arena_build, runtime_init, host_orch, graph_upload,
+static_arena, shared_mem, gm_heap, arena_h2d, host_view_close
+```
 
-The execution order is what puts `static_arena`, `shared_mem` and `gm_heap`
-between `graph_upload` and `arena_h2d`, which is why the control plane is a sum
-and not an interval. The emission order is what a line-by-line reader of the log
-sees; `host_view_close` is last in both, and `arena_h2d` second to last, so
-reading `arena_h2d` as the segment that closes a bind shifts every
-`host_view_close` into the following bind.
+That order is what puts `static_arena`, `shared_mem` and `gm_heap` between
+`graph_upload` and `arena_h2d`, which is why the control plane is a sum and not an
+interval. Emission is `HostPhaseKind` order, all of it at the end of the bind —
+which matters to nothing, because each span carries its own `ts` and its own
+`(pid, inv)`. Reading a log by line order is not how the segments are grouped.
 
 ## Prerequisites
 
@@ -102,14 +102,14 @@ of the cases and the cases get edited.** They read 47 / 129 tasks and 40 / 86
 submissions on `4d31f482`; they previously read 1131 tasks and 20 replays for
 DeepSeek-V4, from before its orchestration moved most task submission onto the
 recording threads. Re-read them from a current log rather than trusting this
-table — a bind's `host_orch` and `graph_upload` lines carry both.
+table — a bind's `host_orch` and `graph_upload` spans carry both.
 
 ## Recipe A — stable numbers, many rounds
 
 The ready-made invocation for either case lives in the
 [`hbg-bind-phases`](../../.claude/skills/hbg-bind-phases/SKILL.md) skill;
-`python -m simpler_setup.tools.hbg_bind_phases <log> --rounds N` turns its log into
-per-phase statistics. This section is what the switches mean and why the traps
+`python -m simpler_setup.tools.hbg_bind_phases <log>` turns its log into
+per-segment statistics. This section is what the switches mean and why the traps
 below exist.
 
 Six rounds is the working minimum: this box is shared, and a single bind has been
@@ -123,7 +123,7 @@ Four switches and one flag make the measurement, and each is load-bearing:
 
 | Switch | Why |
 | ------ | --- |
-| `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1` | emits the `bind phase=` lines at all |
+| `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1` | emits the segment spans at all |
 | `--log-level timing` | pins the level the report is read at, and is the only way it reaches the `[stamp]` line; TIMING is already the default, so this records a condition rather than enabling one |
 | `TORCH_DEVICE_BACKEND_AUTOLOAD=0` | keeps CPU golden imports from loading `torch_npu`; the `torch_backend_autoload` timing record confirms the effective setting and observed module state |
 | `SIMPLER_SKIP_DEVICE_RUN=1` | returns at `simpler_launch_run`, so the host path is measured without a working device run |
@@ -170,7 +170,7 @@ once that case's device execution works.
 
 Both cases now run through standalone `main.py` drivers. Qwen owns its L2
 `Worker` in the invoked process, while dsv4 owns its L3 `Worker`; neither needs
-module-runner `--runtime` / `--level` forwarding to expose `bind phase=` lines.
+module-runner `--runtime` / `--level` forwarding to expose the segment spans.
 
 A 2-rank case emits one bind per rank per round, so six rounds is twelve binds.
 Pass `--rounds` to the parser so it infers the rank count and drops one cold bind
@@ -188,24 +188,21 @@ not report. The log lands in `outputs/hbg_bind_stats_<sha>.log` unless `-o` name
 it:
 
 ```bash
-grep -oE 'bind phase=[a-z0-9_]+ start_ns=[0-9]+ dur_ns=[0-9]+[^[]*' outputs/hbg_bind_stats_<sha>.log
+grep -oE 'name=chip\.run\.bind\.[a-z0-9_]+ ts=[0-9]+ dur=[0-9]+[^[]*' outputs/hbg_bind_stats_<sha>.log
 ```
 
-The character class has to admit digits. `[a-z_]+` matches no segment whose name
-carries one, so it silently drops every `arena_h2d` line — the only H2D
-left, and the one that itemizes the whole upload. On a two-bind log that is 18
-lines where 20 exist, with nothing to say a segment went missing.
+The character class has to admit digits, or it drops every `arena_h2d` — the only
+H2D left, and the one that itemizes the whole upload.
 
-Each line carries `start_ns` (a `CLOCK_MONOTONIC` timestamp) plus the segment's
-own attributes — `tasks=` and `heap_used=` on `host_orch`, `defs=`, `bytes=`,
-`submissions=` and `spilled=` on `graph_upload`, and `arena_h2d`'s itemized upload.
-Group the
-lines into binds — a bind prints each segment it has once, so a segment name you
-have already seen is the first line of the next bind; do **not** close on
-`arena_h2d`, which is second to last — then sum the control-plane segments
-**within each bind** and take the minimum of those sums. Never sum
-minima taken across binds; that total belongs to no bind and can point the wrong
-way (see below).
+Each span carries `ts` (a `CLOCK_MONOTONIC` timestamp), `dur`, `pid` and `inv`,
+plus the segment's own attributes — the six kernel counters on all of them, then
+`tasks=` and `heap_used=` on `host_orch`, `defs=`, `bytes=`, `submissions=` and
+`spilled=` on `graph_upload`, and `arena_h2d`'s itemized upload. **A bind is one
+`(pid, inv)`**, so grouping needs no inference from order: `inv` is the run epoch
+the enclosing `chip.run.bind` allocated, and two ranks writing one stream cannot
+be confused for each other. Sum the control-plane segments **within each bind**
+and take the minimum of those sums. Never sum minima taken across binds; that
+total belongs to no bind and can point the wrong way (see below).
 
 **`spilled=` should be 0 on every bind but the first.** It counts the Definition
 objects the recorders could not build inside the retained staging, which
@@ -316,7 +313,7 @@ binds, and compare those. A min of sums is not a sum of mins and the two can
 disagree in sign — each segment's minimum comes from whichever bind was quietest
 *for that segment*, so summing per-segment minima produces a total no bind
 achieved. On one dsv4 comparison the sum-of-minima moved −0.30 ms while the
-minimum-of-sums moved +0.16 ms, from the same log. `hbg_phase_stats` reports the
+minimum-of-sums moved +0.16 ms, from the same log. `hbg_bind_phases` reports the
 minimum-of-sums as its `total` row; never assemble a total by hand from the
 per-phase `min` column.
 
@@ -334,7 +331,7 @@ work answers in one run what a duration comparison cannot answer in ten.
 
 ## Recipe B — one round with a swimlane
 
-The summed `bind phase=` lines cannot be placed on a timeline inside
+The summed `host-orch phase=` lines cannot be placed on a timeline inside
 `host_orch`: they are cost shares. The per-event view comes from the runtime's
 per-producer record pool, written to `outputs/<case>_<ts>/host_phase_records.jsonl` —
 one record per orchestrator operation, each with its own interval.
@@ -344,7 +341,7 @@ silently:
 
 1. **`SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE=1`**, which is what arms the pool.
    `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` does not: it gates the summed
-   `bind phase=` lines alone, so Recipe A's environment collects no records.
+   the segment spans alone, so Recipe A's environment collects no records.
 2. **A diagnostic flag must be on**, because that is what makes
    `CallConfig.output_prefix` non-empty. `--enable-scope-stats` is the cheapest
    choice when only Host phase records are needed. `--enable-chip-swimlane` is
@@ -363,12 +360,12 @@ swimlane for a case that hangs on device is cheaper to take with the variable se
 than to take by waiting out the stall.
 
 **The flag that satisfies condition 2 also moves the log.** A non-empty
-`CallConfig.output_prefix` redirects every host-log record — `bind phase=` lines
+`CallConfig.output_prefix` redirects every host-log record — segment spans
 and `[STRACE]` spans alike — from stderr into `outputs/<case>_<ts>/host.<pid>.log`,
 one file per process ([`python/simpler/worker.py`](../../python/simpler/worker.py)
 sets the directory on the L3 submit path and in the forked chip child;
 [`src/common/log/host_log.cpp`](../../src/common/log/host_log.cpp) opens the file).
-So Recipe A's `grep -c 'bind phase=' "$LOG"` reports **0** for a Recipe B run that
+So Recipe A's `grep -c 'name=chip.run.bind\.' "$LOG"` reports **0** for a Recipe B run that
 worked perfectly, and the finisher must read the prefix's own logs. Measured on a
 2-rank dsv4 run: `$LOG` alone yields `No [STRACE] markers found` and drops every
 phase record, while `$LOG` plus the prefix's logs attaches all 4186 of them.
@@ -418,11 +415,11 @@ signal than any duration on a shared box.
 
 | Trap | Symptom | What to do |
 | ---- | ------- | ---------- |
-| Any diagnostic flag on (so, every Recipe B run) | `$LOG` has zero `bind phase=` lines and no `[STRACE]` markers, run passes | the non-empty `output_prefix` moved the host log to `outputs/<case>_<ts>/host.<pid>.log`; grep and parse those too |
-| A `SceneTestCase` with `device_count > 1` run through the module runner | log has zero `bind phase=` lines, test passes | give the child command `--runtime <rt> --level 3`; a standalone `main.py` case needs nothing |
+| Any diagnostic flag on (so, every Recipe B run) | `$LOG` has no `[STRACE]` markers at all, run passes | the non-empty `output_prefix` moved the host log to `outputs/<case>_<ts>/host.<pid>.log`; grep and parse those too |
+| A `SceneTestCase` with `device_count > 1` run through the module runner | log has zero segment spans, test passes | give the child command `--runtime <rt> --level 3`; a standalone `main.py` case needs nothing |
 | `SIMPLER_SKIP_DEVICE_RUN=0` | run still skips the device, "PASSED" means nothing ran | `unset` the variable |
 | `--rounds 6` with `--enable-scope-stats` | no `outputs/<case>_<ts>/` artifacts, plus a `disabled: --rounds > 1` warning | one round for artifacts, many rounds for numbers |
-| Only `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` set for Recipe B | `bind phase=` lines present, no `host_phase_records.jsonl` | the records are a separate switch: also export `SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE=1` |
+| Only `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` set for Recipe B | segment spans present, no `host_phase_records.jsonl` | the records are a separate switch: also export `SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE=1` |
 | Comparing a log with no `[stamp]` first line | the parser says so above the table | re-run it through the recipe; conditions cannot be recovered from memory |
 | Subtracting timestamps for the control plane | ~300 ms instead of ~3 ms | sum the segments; `arena_h2d` is not adjacent |
 | Summing per-segment minima by hand | a total no bind achieved; can invert the sign | read the tool's `total` row — the minimum of the per-bind sums |
@@ -471,8 +468,8 @@ meant to outlive it.
 † The three upload rows are the markers as they read at that commit, before the
 upload was restructured: `graph_upload`'s `bytes=` then also counted the Graph
 submission block, `sm_h2d` was still a copy of its own, and `arena_h2d` was the
-copied zone alone. A run today emits no `sm_h2d`, counts only the Definition
-objects in `graph_upload`, carries no submission block at all, and ships both
+copied zone alone. A run today has no `sm_h2d` kind at all, counts only the
+Definition objects in `graph_upload`, carries no submission block, and ships both
 remaining regions in `arena_h2d` — so the same case reports different figures for
 the same work.
 

--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -35,7 +35,7 @@ configure, and the runtime never derives the path itself.
 
 **The destination belongs to the logger, not to a record.** Everything that logger
 writes follows it: `LOG_*` records, `[STRACE]` spans, `[CLOCK_ANCHOR]`, the
-`bind phase=` summaries, and the spans Python emits through
+`host-orch phase=` cost-share summaries, and the spans Python emits through
 `unified_log_host_span`. Nothing declares an intent and no record kind is treated
 specially, so there is no state in which part of a run's log is in one place and
 part in another. The first non-empty directory in a process wins, and it is the
@@ -153,7 +153,10 @@ output sees the original text; a consumer reading the raw log does not.
 chip.run                                      (= host_wall)
 ├─ chip.run.bind
 │  ├─ chip.run.bind.args        (ntensor=N: per-tensor device_malloc + H2D)
-│  └─ chip.run.bind.prebuilt    (prebuilt runtime-arena cache hit or build + upload)
+│  ├─ chip.run.bind.prebuilt    (TMR: prebuilt runtime-arena cache hit or build + upload)
+│  └─ .{arena_build,static_arena,gm_heap,shared_mem,runtime_init,host_orch,
+│       graph_upload,arena_h2d,host_view_close}
+│           HBG host prepare-path segments, with SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1
 ├─ chip.run.runner_run          (device enqueue + completion drain)
 │  └─ chip.run.runner_run.device_wall      (whole on-NPU AICPU wall)
 │     └─ .{preamble,so_load,graph_build,config_validate,arena_wire,sm_reset,post_orch,orch,sched}
@@ -188,7 +191,7 @@ including time the caller spends polling or doing other host work; blocking
 | ----- | ---------- |
 | 0 | `chip.run` |
 | 1 | `chip.run.bind`, `chip.run.runner_run`, `chip.run.claim_release`, `chip.run.validate` |
-| 2 | `chip.run.bind.args`, `chip.run.bind.prebuilt`, `chip.run.runner_run.device_wall` |
+| 2 | `chip.run.bind.args`, `chip.run.bind.prebuilt`, the other HBG `chip.run.bind.*` segments, `chip.run.runner_run.device_wall` |
 | 3 | TMR phase spans `chip.run.runner_run.device_wall.{preamble,so_load,graph_build,config_validate,arena_wire,sm_reset,post_orch,orch,sched}` and optional `task_slot_*` spans |
 
 ## Host scheduler spans
@@ -314,14 +317,24 @@ per-invocation lane, so each call renders as an isolated nested tree in
 `--swimlane` is a separate view. Host slices keep their real OS pid/tid, and
 task submission-to-dispatch handoffs render as flow arrows.
 
-A runtime may subdivide a stage it owns, which the markers deliberately do not
-describe — the marker grammar is a fixed per-run-stage contract, and a runtime's
-internal breakdown of one stage does not belong in it. `--host-phase-records`
-takes such a breakdown from the artifact the runtime wrote and draws each record
-inside its `chip.run.bind`, matched on `(pid, inv)`. Both sides are the same
-`CLOCK_MONOTONIC` axis, so nothing is converted. Without the artifact the tool
-still recovers the stage's own segments from the runtime's timing log lines; where
-both are present the artifact wins, so a segment is not drawn twice. See
+**A runtime subdivides a stage it owns with these same markers.** `[STRACE]` is
+the one timeline format: an interval a reader can place on a timeline is a span,
+whoever measured it and however it was captured. `chip.run.bind.args` and
+`chip.run.bind.prebuilt` come from the tensormap runtime rather than the
+platform; the device sub-phases are the TMR AICPU's own breakdown, read back from
+a cycle buffer and re-emitted as spans; and `ext.` (below) admits producers
+outside this repository entirely. So the grammar was never a fixed per-run-stage
+set, and a stage's segments do not need a second format.
+
+What the collection mechanism may be, on the other hand, is open: an RAII scope,
+a fixed-slot device buffer, or a host record pool are all ways to *measure*, and
+each one ends by emitting a span. `--host-phase-records` reads such a pool from
+the artifact the runtime wrote and draws the per-event operations inside their
+`chip.run.bind`, matched on `(pid, inv)`. Both sides are the same
+`CLOCK_MONOTONIC` axis, so nothing is converted. A bind segment the log already
+carries as a span is skipped rather than drawn twice, and the log's copy is the
+one kept — it carries the segment's attributes, where an artifact record carries
+only `detail`. See
 [host_build_graph's profiling levels](../../src/a2a3/runtime/host_build_graph/docs/profiling_levels.md)
 for what that runtime records, and
 [hbg-bind-phases.md](hbg-bind-phases.md) for what those segments are and

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -14,8 +14,8 @@ no repo checkout required.
 - **[sched_overhead_analysis](#sched_overhead_analysis)** — scheduler overhead / Tail OH breakdown
 - **[critical_path](#critical_path)** — chip swimlane critical-path compute/stall analysis
 - **[strace_timing](#strace_timing)** — per-stage `chip.run` breakdown (host + AICPU phases) from `[STRACE]` log markers → TPOT table, per-round table (`--rounds-table`), nested tree (`--tree`), or Perfetto JSON
-- **[hbg_bind_phases](#hbg_bind_phases)** — `host_build_graph` `bind`-stage phases from `bind phase=` log markers → per-phase min/median/max plus the control-plane total
-- **[phase_time_split](#phase_time_split)** — the same `bind phase=` markers split into on-CPU and off-CPU per phase, from per-thread CPU clocks, with cold and warm binds reported separately
+- **[hbg_bind_phases](#hbg_bind_phases)** — `host_build_graph` `bind`-stage segments from the `chip.run.bind.*` spans → per-segment min/median/max plus the control-plane total
+- **[phase_time_split](#phase_time_split)** — the same segment spans split into on-CPU and off-CPU per segment, from per-thread CPU clocks, with cold and warm binds reported separately
 - **[dump_viewer](#dump_viewer)** — inspect / export args dumps (see [docs/args-dump.md](../../docs/dfx/args-dump.md) for full workflow)
 - **[deps_viewer](#deps_viewer)** — `deps.json` (dep_gen) → text or pan/zoom HTML dependency graph
 
@@ -420,41 +420,35 @@ The swimlane is the only view that renders `ext.` spans: every table and
 
 ## hbg_bind_phases
 
-Per-phase statistics for `host_build_graph`'s **`bind` stage** from the
-`bind phase=` markers a run emits under `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1` at
-`LOG_TIMING`. One line per segment per bind pass; see
+Per-segment statistics for `host_build_graph`'s **`bind` stage** from the
+`chip.run.bind.<segment>` `[STRACE]` spans a run emits under
+`SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1`. One span per segment per bind; see
 [docs/dfx/hbg-bind-phases.md](../../docs/dfx/hbg-bind-phases.md) for
 what the segments are, the invocation that produces them, and how to compare two
 runs.
 
 ```bash
-# min / median / max per phase over the warm passes, plus the control-plane total
-python -m simpler_setup.tools.hbg_bind_phases path/to/log --rounds 6
+# min / median / max per segment over the warm binds, plus the control-plane total
+python -m simpler_setup.tools.hbg_bind_phases path/to/log
+python -m simpler_setup.tools.hbg_bind_phases outputs/<case>_<ts>/    # a directory of host.*.log
 ```
 
-Passing `--rounds` is what lets it infer the rank count, so it drops one cold
-warm-up pass **per rank** rather than one in total; `--ranks` sets that directly
-and `--keep-first` keeps the cold passes. A run whose every pass is a rank's
-warm-up — `--rounds 1` — is refused rather than reported, since the one number it
-could print is the cold one. Three grouping rules are encoded rather than left to
-the caller, because each silently produces a wrong number: a repeated segment
-name opens the next pass (the segments are not contiguous in time, so timestamp
-order does not group them, and no single segment reliably closes a pass — reading
-`arena_h2d` as the closing one shifted every `host_view_close` by a pass), the
-control-plane total is summed **within** a pass before any minimum is taken, and
-the first pass of each rank is warm-up.
+**A bind is one `(pid, inv)`.** A span carries both, so grouping needs no rank
+count, no round count and no inference from emission order — concurrent ranks
+writing one stream separate by pid, and each bind by the run epoch its
+`chip.run.bind` allocated. `--keep-first` keeps the cold binds; by default the
+earliest bind of each pid is dropped as warm-up, which is exactly one per rank.
+A run whose every bind is a rank's warm-up is refused rather than reported, since
+the one number it could print is the cold one.
 
-Grouping on the repeat assumes each pass prints its segments as an uninterrupted
-burst. That holds on every log measured so far, but nothing enforces it: ranks
-share one stream and the line prefix carries no pid, and the thread id it does
-carry is identical across ranks. A burst split by another rank's is therefore
-reported as a pass whose segment set differs from its neighbours', which the
-non-uniform-segment warning names rather than passing off as a number.
+Two rules stay encoded rather than left to the caller, because each silently
+produces a wrong number: the control-plane total is summed **within** a bind
+before any minimum is taken, and the first bind of each rank is warm-up.
 
-A run whose control plane is missing a phase entirely — a change can retire one —
-is still totalled, over the phases it has, with the absent ones named. A phase
-missing from only *some* passes is a truncated log instead, and those passes are
-excluded with a warning. If the log's first line is a `[stamp]` line naming the
+A run whose control plane is missing a segment entirely — a change can retire one
+— is still totalled, over the segments it has, with the absent ones named. A
+segment missing from only *some* binds means those binds lost records, and they
+are excluded with a warning. If the log's first line is a `[stamp]` line naming the
 command and commit, it is echoed above the table. Distinct
 `torch_backend_autoload` records are printed alongside it. Missing stamps or
 autoload records produce an explicit comparison warning.
@@ -463,7 +457,7 @@ autoload records produce an explicit comparison warning.
 
 ## phase_time_split
 
-The same `bind phase=` markers, read for a different question: was a segment
+The same segment spans, read for a different question: was a segment
 **running** or **waiting**? A duration cannot say, and the answer decides where to
 look next — an on-CPU segment is split further by its fault count and by the
 syscalls inside its window, while an off-CPU one is a wait, and `nvcsw` versus

--- a/simpler_setup/tools/__init__.py
+++ b/simpler_setup/tools/__init__.py
@@ -16,5 +16,6 @@ Invoke via ``python -m simpler_setup.tools.<name>``:
 - ``deps_viewer``           : deps.json -> text or pan/zoom HTML dependency graph
 - ``dump_viewer``           : inspect args dumps
 - ``strace_timing``         : per-stage / per-round timing from [STRACE] log markers
-- ``hbg_bind_phases``       : per-phase host_build_graph bind statistics from `bind phase=` markers
+- ``hbg_bind_phases``       : per-segment host_build_graph bind statistics from the chip.run.bind.* spans
+- ``phase_time_split``      : the same segments split into on-CPU and off-CPU, from per-thread CPU clocks
 """

--- a/simpler_setup/tools/hbg_bind_phases.py
+++ b/simpler_setup/tools/hbg_bind_phases.py
@@ -7,11 +7,15 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Per-phase statistics from a `bind phase=` LOG_TIMING breakdown.
+"""Per-phase statistics from the `chip.run.bind.*` spans of a host_build_graph run.
 
 Reads the log a `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 --rounds N` run leaves
-behind and reports each bind phase's minimum, median and maximum across the warm
-binds, plus the control-plane total.
+behind and reports each bind segment's minimum, median and maximum across the
+warm binds, plus the control-plane total.
+
+The spread is the point: a change smaller than the range beside it cannot be
+demonstrated. `strace_timing --tree` gives the median alone, and its default
+table a mean, so neither answers "is this difference real".
 
 What the phases are, and how to compare two runs:
 docs/dfx/hbg-bind-phases.md.
@@ -21,8 +25,16 @@ import argparse
 import re
 import statistics
 import sys
+from collections.abc import Sequence
+from pathlib import Path
 
-PHASE_LINE = re.compile(r"bind phase=(\w+) start_ns=(\d+) dur_ns=(\d+)")
+from simpler_setup.tools.strace_timing import expand_log_source, parse_spans
+
+# The stage the segments subdivide. A span one level below it is a segment; one
+# two levels below (`chip.run.bind.host_orch.<op>`) is an orchestrator operation
+# from the per-event artifact, which is not a segment of the stage.
+BIND_SPAN = "chip.run.bind"
+
 # The recipe's first log line, recording the command and the commit the run used.
 # Two runs are comparable only if it matches, so it is echoed above the table.
 STAMP_LINE = re.compile(r"^\[stamp\] (.*)$")
@@ -36,7 +48,7 @@ TORCH_AUTOLOAD_LINE = re.compile(
 # The segments between "the caller's data is in place" and "the device can run".
 # `args` is a per-byte staging cost. `host_view_close` remains excluded for
 # comparison with historical mapped-view logs; current binds close no mappings.
-CONTROL_PLANE = ("host_orch", "graph_upload", "relocate", "sm_h2d", "arena_h2d")
+CONTROL_PLANE = ("host_orch", "graph_upload", "arena_h2d")
 
 # Display order: the bind stage's own sequence, so a reader can follow it down.
 PHASE_ORDER = (
@@ -48,163 +60,140 @@ PHASE_ORDER = (
     "static_arena",
     "shared_mem",
     "gm_heap",
-    "relocate",
-    "sm_h2d",
     "arena_h2d",
     "host_view_close",
 )
 
 
-def parse_binds(path: str) -> list[dict[str, float]]:
-    """Group `bind phase=` lines into binds, in milliseconds.
+def parse_binds(paths: Sequence[Path]) -> list[dict]:
+    """Group bind-segment spans into binds, in milliseconds.
 
-    A bind emits every segment it has once, so a repeated segment name is the
-    first line of the next bind. Grouping on the repeat rather than on a named
-    closing segment survives a bind that omits a segment, a change to the
-    emission order, and a new segment being added; the segments are not
-    contiguous in time, so timestamp order does not group them.
+    A span carries `pid` and `inv`, so a bind is exactly the segments sharing one
+    `(pid, inv)` — the run epoch the enclosing `chip.run.bind` allocated. Nothing
+    is inferred from emission order or from which segment came last, and
+    concurrent ranks writing one stream cannot be confused for each other.
 
-    This assumes each bind's burst reaches the log uninterrupted, and **nothing
-    enforces that**. Ranks write one stream through no lock, the line prefix
-    carries no pid, and its thread id is identical across ranks — measured as one
-    value over all 400 bind lines of a two-rank run — so there is no field to
-    group by instead.
-
-    It also assumes no bind omits a segment its successor emits *before* any they
-    share, which would put that segment in the earlier bind. `args` is emitted
-    unconditionally and first, so today nothing can precede a shared segment.
-
-    Both assumptions fail the same visible way — a bind whose segment set differs
-    from its neighbours' — which `warn_on_ragged_binds` names. That is why the
-    boundary stays free of any knowledge about segment order: an order constant
-    gone stale would split every bind at the same point, leaving the sets uniform
-    and the mis-grouping undetectable.
+    Each bind is `{"pid", "inv", "ts", <segment>: ms, ...}`; `ts` is its earliest
+    segment start, which orders the binds a rank ran.
     """
-    binds: list[dict[str, float]] = []
-    current: dict[str, float] = {}
-    with open(path, encoding="utf-8", errors="replace") as handle:
-        for line in handle:
-            match = PHASE_LINE.search(line)
-            if match is None:
-                continue
-            phase, _start_ns, dur_ns = match.group(1), int(match.group(2)), int(match.group(3))
-            if phase in current:
-                binds.append(current)
-                current = {}
-            current[phase] = dur_ns / 1e6
-    if current:
-        binds.append(current)
+    prefix = f"{BIND_SPAN}."
+    binds: dict[tuple, dict] = {}
+    for path in paths:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            for span in parse_spans(handle):
+                if span.is_device or not span.name.startswith(prefix):
+                    continue
+                phase = span.name[len(prefix) :]
+                if "." in phase:
+                    # An orchestrator operation inside host_orch, not a segment.
+                    continue
+                bind = binds.setdefault((span.pid, span.inv), {"pid": span.pid, "inv": span.inv, "ts": span.ts})
+                bind[phase] = span.dur / 1e6
+                bind["ts"] = min(bind["ts"], span.ts)
+    ordered = sorted(binds.values(), key=lambda b: (b["pid"], b["ts"]))
     # A group without `host_orch` is not a bind.
-    return [b for b in binds if "host_orch" in b]
+    return [b for b in ordered if "host_orch" in b]
 
 
-def parse_stamp(path: str) -> str:
+def cold_binds(binds: Sequence[dict]) -> set[tuple]:
+    """The `(pid, inv)` of each rank's first bind, which is warm-up.
+
+    One per pid, and exactly the first one that rank ran — where the old
+    line-based tool had to be told a rank count and drop that many from the
+    front of a single interleaved stream.
+    """
+    first: dict[int, dict] = {}
+    for bind in binds:
+        current = first.get(bind["pid"])
+        if current is None or bind["ts"] < current["ts"]:
+            first[bind["pid"]] = bind
+    return {(b["pid"], b["inv"]) for b in first.values()}
+
+
+def parse_stamp(paths: Sequence[Path]) -> str:
     """The run's environment stamp, or "" for a log this script did not produce."""
-    with open(path, encoding="utf-8", errors="replace") as handle:
-        for line in handle:
-            match = STAMP_LINE.match(line.rstrip("\n"))
-            if match is not None:
-                return match.group(1)
+    for path in paths:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                match = STAMP_LINE.match(line.rstrip("\n"))
+                if match is not None:
+                    return match.group(1)
     return ""
 
 
-def parse_torch_autoload(path: str) -> list[str]:
+def parse_torch_autoload(paths: Sequence[Path]) -> list[str]:
     """Unique torch backend autoload records in log order."""
     records: list[str] = []
     seen: set[str] = set()
-    with open(path, encoding="utf-8", errors="replace") as handle:
-        for line in handle:
-            match = TORCH_AUTOLOAD_LINE.search(line)
-            if match is None:
-                continue
-            record = match.group(1)
-            if record not in seen:
-                seen.add(record)
-                records.append(record)
+    for path in paths:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                match = TORCH_AUTOLOAD_LINE.search(line)
+                if match is None:
+                    continue
+                record = match.group(1)
+                if record not in seen:
+                    seen.add(record)
+                    records.append(record)
     return records
 
 
-def spread(values: list[float]) -> tuple[float, float, float]:
+def spread(values: Sequence[float]) -> tuple[float, float, float]:
     """Minimum, median and maximum. The median averages the two central values."""
     return min(values), statistics.median(values), max(values)
 
 
-def warn_on_ragged_binds(binds: list[dict[str, float]]) -> None:
-    """Report binds whose segment set differs from their neighbours'.
-
-    `parse_binds` assumes each bind's segments reach the log as an uninterrupted
-    burst, and nothing enforces that. A rank whose burst was split by another
-    rank's, and a truncated log, both leave a bind short of segments its
-    neighbours have; either way the rows below are not all describing the same
-    thing, so name it rather than print a clean table over it.
-    """
-    everywhere = {k for k in binds[0] if all(k in b for b in binds)}
-    ragged = sorted({k for b in binds for k in b} - everywhere)
-    if not ragged:
-        return
-    verb = "is" if len(ragged) == 1 else "are"
-    print(f"\n  WARNING: not every bind has the same segments; {', '.join(ragged)}")
-    print(f"  {verb} missing from some. A bind is grouped by its first repeated segment")
-    print("  name, so a rank whose burst was split by another rank's, and a truncated")
-    print("  log, both land here -- read the counts column before quoting a duration.")
-
-
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("log", help="run log carrying the `bind phase=` lines")
     parser.add_argument(
-        "--ranks",
-        type=int,
-        default=None,
-        help="ranks in the run; the first bind of each is warm-up and is dropped. "
-        "Default: inferred as the number of binds divided by the round count when "
-        "--rounds is given, else 1.",
+        "log",
+        nargs="+",
+        help="run log(s) carrying the `chip.run.bind.*` spans, or a directory of host.*.log files",
     )
-    parser.add_argument("--rounds", type=int, default=None, help="rounds the run was given, to infer --ranks")
-    parser.add_argument("--keep-first", action="store_true", help="keep the cold bind in the statistics")
+    parser.add_argument("--keep-first", action="store_true", help="keep each rank's cold bind in the statistics")
     args = parser.parse_args()
 
-    binds = parse_binds(args.log)
+    paths = [path for source in args.log for path in expand_log_source(source)]
+
+    binds = parse_binds(paths)
     if not binds:
         print(
-            f"{args.log}: no `bind phase=` lines. Either SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 "
-            "was not set, or a diagnostic flag made CallConfig.output_prefix non-empty and "
-            "moved the whole host log to outputs/<case>_<ts>/host.<pid>.log -- parse those "
-            "instead. The log level is not a cause: TIMING is the default. "
-            "See docs/dfx/hbg-bind-phases.md.",
+            f"{' '.join(args.log)}: no `chip.run.bind.<segment>` spans. Either "
+            "SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 was not set, or a diagnostic flag made "
+            "CallConfig.output_prefix non-empty and moved the whole host log to "
+            "outputs/<case>_<ts>/host.<pid>.log -- parse those instead. The log level is not a "
+            "cause: TIMING is the default. See docs/dfx/hbg-bind-phases.md.",
             file=sys.stderr,
         )
         return 1
 
-    ranks = args.ranks
-    if ranks is None:
-        ranks = max(1, len(binds) // args.rounds) if args.rounds else 1
-    dropped = 0 if args.keep_first else min(ranks, len(binds))
-    warm = binds[dropped:]
+    cold = set() if args.keep_first else cold_binds(binds)
+    warm = [b for b in binds if (b["pid"], b["inv"]) not in cold]
+    ranks = len({b["pid"] for b in binds})
     if not warm:
         print(
-            f"{args.log}: {len(binds)} bind(s) over {ranks} rank(s), all of them cold. The first "
-            "bind of each rank is warm-up, so a warm bind needs --rounds 2 or more; --keep-first "
-            "reports the cold binds instead.",
+            f"{' '.join(args.log)}: {len(binds)} bind(s) over {ranks} rank(s), all of them cold. The "
+            "first bind of each rank is warm-up, so a warm bind needs --rounds 2 or more on the run; "
+            "--keep-first reports the cold binds instead.",
             file=sys.stderr,
         )
         return 1
 
-    print(f"{args.log}")
-    stamp = parse_stamp(args.log)
+    print(f"{' '.join(args.log)}")
+    stamp = parse_stamp(paths)
     if stamp:
         print(f"  {stamp}")
     else:
         print("  (no `[stamp]` line: the command and commit behind these numbers have")
         print("   to be established by hand before comparing them to anything)")
-    torch_autoload = parse_torch_autoload(args.log)
+    torch_autoload = parse_torch_autoload(paths)
     if torch_autoload:
         for record in torch_autoload:
             print(f"  {record}")
     else:
         print("  (no `torch_backend_autoload` record: backend-autoload state")
         print("   must be established before comparing this log)")
-    print(f"  {len(binds)} binds, {len(warm)} warm ({dropped} cold dropped, ranks={ranks})\n")
+    print(f"  {len(binds)} binds, {len(warm)} warm ({len(cold)} cold dropped, ranks={ranks})\n")
     print(f"  {'phase':<18}{'min':>10}{'median':>10}{'max':>10}   n")
     for phase in PHASE_ORDER:
         values = [b[phase] for b in warm if phase in b]
@@ -214,18 +203,16 @@ def main() -> int:
         mark = "*" if phase in CONTROL_PLANE else " "
         print(f" {mark}{phase:<18}{low:>10.3f}{mid:>10.3f}{high:>10.3f}  {len(values):3d}")
 
-    unknown = sorted({k for b in warm for k in b} - set(PHASE_ORDER))
+    known = set(PHASE_ORDER) | {"pid", "inv", "ts"}
+    unknown = sorted({k for b in warm for k in b} - known)
     if unknown:
-        print(f"\n  phases this tool does not know about: {', '.join(unknown)}")
+        print(f"\n  segments this tool does not know about: {', '.join(unknown)}")
         print("  (add them to PHASE_ORDER, and to CONTROL_PLANE if a dispatch change can move them)")
 
-    warn_on_ragged_binds(warm)
-
-    # The control-plane set is not fixed: a change can retire a phase outright, so
-    # the total covers the phases this run has and names the ones absent from every
-    # bind. Absent from only some binds is a truncated log rather than a retired
-    # phase, and would understate a bind, so those binds are excluded and warned
-    # about.
+    # The control-plane set is not fixed: a change can retire a segment outright,
+    # so the total covers the segments this run has and names the ones absent from
+    # every bind. Absent from only some binds means those binds lost records, and
+    # would understate the total, so they are excluded and warned about.
     present = [k for k in CONTROL_PLANE if any(k in b for b in warm)]
     partial = [k for k in present if not all(k in b for b in warm)]
     retired = [k for k in CONTROL_PLANE if k not in present]
@@ -236,12 +223,12 @@ def main() -> int:
         print("\n  * = control plane, summed within each bind and then:")
         print(f"    total{'':<13}{low:>10.3f}{mid:>10.3f}{high:>10.3f}  {len(totals):3d}   (ms)")
         if retired:
-            print(f"    over {len(present)} of {len(CONTROL_PLANE)} phases; absent from every")
+            print(f"    over {len(present)} of {len(CONTROL_PLANE)} segments; absent from every")
             print(f"    bind: {', '.join(retired)}")
         if partial:
             print(f"    WARNING: {', '.join(partial)} is missing from some binds but not all;")
             print("    those binds are excluded, and the total may not describe the run")
-        print("\n  Compare by min, over the same phase set, against a log with the same")
+        print("\n  Compare by min, over the same segment set, against a log with the same")
         print("  stamp and torch autoload state; see docs/dfx/hbg-bind-phases.md 'Comparing two branches'.")
     else:
         print(f"\n  no bind carries any of {CONTROL_PLANE}; the control-plane total is not computable")

--- a/simpler_setup/tools/phase_time_split.py
+++ b/simpler_setup/tools/phase_time_split.py
@@ -7,10 +7,10 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Split a bind phase's wall time into running and waiting, per phase and per thread.
+"""Split a bind segment's wall time into running and waiting, per segment and per thread.
 
-Reads the `bind phase=` markers a run emits under
-`SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1`. A phase's duration alone cannot say whether it
+Reads the `chip.run.bind.*` spans a run emits under
+`SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1`. A segment's duration alone cannot say whether it
 was computing or blocked, and that decides where to look next:
 
   on-CPU dominates   -> it is running. Split it by the fault count and by the syscalls
@@ -38,22 +38,59 @@ import re
 import statistics
 import sys
 
+from simpler_setup.tools.strace_timing import expand_log_source, parse_spans
+
 FIELDS = ("minflt", "tminflt", "nivcsw", "nvcsw", "cpu_ns", "rec_cpu_ns")
-MARKER = re.compile(r"bind phase=(?P<phase>[a-z_]+) start_ns=\d+ dur_ns=(?P<dur>\d+)(?P<rest>.*)")
+# The stage the segments subdivide. A name one level below it is a segment; two
+# levels below is an orchestrator operation, which carries none of these counters.
+BIND_SPAN = "chip.run.bind"
 
 
-def parse(path):
+def parse(paths):
+    """One row per bind segment, with the counters its attributes carry.
+
+    A counter is `None` when the attribute string was truncated before it — the
+    logger marks such a field with `~` — so a caller can report the row as
+    incomplete instead of computing over a missing number.
+    """
+    prefix = f"{BIND_SPAN}."
     rows = []
-    for line in open(path, errors="replace"):
-        marker = MARKER.search(line)
-        if not marker:
-            continue
-        row = {"phase": marker.group("phase"), "dur_us": int(marker.group("dur")) / 1000.0}
-        for field in FIELDS:
-            hit = re.search(rf"\b{field}=(\d+)", marker.group("rest"))
-            row[field] = int(hit.group(1)) if hit else None
-        rows.append(row)
+    for path in paths:
+        with open(path, errors="replace") as handle:
+            for span in parse_spans(handle):
+                if span.is_device or not span.name.startswith(prefix):
+                    continue
+                phase = span.name[len(prefix) :]
+                if "." in phase:
+                    continue
+                row = {
+                    "phase": phase,
+                    "pid": span.pid,
+                    "inv": span.inv,
+                    "ts": span.ts,
+                    "dur_us": span.dur / 1000.0,
+                }
+                for field in FIELDS:
+                    hit = re.search(rf"\b{field}=(\d+)", span.attrs)
+                    row[field] = int(hit.group(1)) if hit else None
+                rows.append(row)
     return rows
+
+
+def cold_keys(rows):
+    """The `(pid, inv)` of each rank's first bind, which is warm-up.
+
+    A span carries the run epoch its bind was allocated, so the cold bind is the
+    earliest one that pid ran rather than a count of leading rows the caller has
+    to supply.
+    """
+    earliest = {}
+    for row in rows:
+        key = (row["pid"], row["inv"])
+        current = earliest.get(row["pid"])
+        if current is None or row["ts"] < current[1]:
+            earliest[row["pid"]] = (key, row["ts"])
+    return {key for key, _ in earliest.values()}
 
 
 def summarise(group):
@@ -87,16 +124,36 @@ def summarise(group):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("log", help="run log carrying `bind phase=` markers")
-    parser.add_argument("--ranks", type=int, default=2, help="binds to treat as cold, one per rank (default 2)")
-    parser.add_argument("--phase", default=None, help="only this phase")
+    parser.add_argument(
+        "log", nargs="+", help="run log(s) carrying `chip.run.bind.*` spans, or a directory of host.*.log files"
+    )
+    parser.add_argument("--phase", default=None, help="only this segment")
     args = parser.parse_args()
 
-    rows = parse(args.log)
+    paths = [path for source in args.log for path in expand_log_source(source)]
+    rows = parse(paths)
     if not rows:
-        sys.exit(f"{args.log}: no `bind phase=` markers — was SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 set?")
-    if rows[0]["cpu_ns"] is None:
-        sys.exit(f"{args.log}: markers carry no cpu_ns — this log predates the per-thread CPU clocks")
+        sys.exit(
+            f"{' '.join(args.log)}: no `chip.run.bind.<segment>` spans — was SIMPLER_HBG_BIND_BREAKDOWN_ENABLE=1 set?"
+        )
+    if all(row["cpu_ns"] is None for row in rows):
+        sys.exit(f"{' '.join(args.log)}: spans carry no cpu_ns — this log predates the per-thread CPU clocks")
+
+    # Warm-up is decided over every bind the log holds, before any row is
+    # dropped: a bind whose attributes were truncated is still a bind that ran,
+    # and dropping it first would promote its successor to cold and move a warm
+    # bind's numbers into the cold row.
+    # Warm-up is decided over every bind the log holds, before any row is
+    # dropped: a bind whose attributes were truncated is still a bind that ran,
+    # and dropping it first would promote its successor to cold and move a warm
+    # bind's numbers into the cold row.
+    cold = cold_keys(rows)
+
+    # A row missing a counter had its attribute string truncated, so every figure
+    # derived from that counter would be a guess. Report how many rather than
+    # compute over them or abort the whole table.
+    incomplete = [row for row in rows if any(row[field] is None for field in FIELDS)]
+    rows = [row for row in rows if row not in incomplete]
 
     phases = {}
     for row in rows:
@@ -112,7 +169,11 @@ def main():
     for phase, group in phases.items():
         if args.phase and phase != args.phase:
             continue
-        for label, part in (("cold", group[: args.ranks]), ("warm", group[args.ranks :])):
+        by_warmth = {
+            "cold": [row for row in group if (row["pid"], row["inv"]) in cold],
+            "warm": [row for row in group if (row["pid"], row["inv"]) not in cold],
+        }
+        for label, part in by_warmth.items():
             if not part:
                 continue
             stats = summarise(part)
@@ -126,6 +187,10 @@ def main():
             )
     print("\nmedians over the binds in each group; times in us. cpu/offcpu are the bind")
     print("thread's own, reccpu is every recording worker's, so rec/dur is concurrency.")
+    if incomplete:
+        print(f"{len(incomplete)} span(s) had a truncated attribute string and are excluded: a")
+        print("  counter the logger cut is missing entirely, and every figure over it would")
+        print("  be a guess. The attribute field is 192 bytes; see docs/dfx/hbg-bind-phases.md.")
     if flagged:
         print("! at least one bind reported more CPU than the segment's own wall, so its")
         print("  counter mark covers a different span than its duration: that row's")

--- a/simpler_setup/tools/strace_timing.py
+++ b/simpler_setup/tools/strace_timing.py
@@ -78,15 +78,6 @@ _STRACE_RE = re.compile(
 # A record start, matched independently of whether the rest of that record
 # survived the write that emitted it.
 _STRACE_HEAD_RE = re.compile(r"\[STRACE\]\s+v=\d+")
-# `bind phase=` timing lines from a runtime with a host prepare path. Not
-# `[STRACE]` markers by design — they are a runtime's breakdown of one stage, not
-# a platform run stage. Every line is written at the end of the pass, off the path
-# being measured, so the line carries its own `start_ns` rather than leaving the
-# interval to be inferred from the log prefix's emission time.
-_BIND_PHASE_RE = re.compile(
-    r"\[mono_ns=\d+\]\[T0x(?P<tid_hex>[0-9a-fA-F]+)\]\[TIMING\]\s+\S+:\s+"
-    r"\[[^\]]*\]\s+bind phase=(?P<phase>\w+)\s+start_ns=(?P<start>\d+)\s+dur_ns=(?P<dur>\d+)(?P<attrs>[^\r\n]*)",
-)
 # The writer's own loss report, emitted at each quiescent boundary when the drop
 # total has grown. The counters live in process memory and die with it, so this
 # record is the only way a reader holding just the log learns that records are
@@ -112,13 +103,16 @@ _PERCENT_ESCAPE_RE = re.compile(r"%([0-9A-Fa-f]{2})")
 _LOG_FILE_GLOB = "host.*.log"
 
 
-def _expand_log_source(source):
+def expand_log_source(source):
     """Resolve one CLI input to the files to read.
 
     A directory expands to its per-process log files, so a run's
     ``output_prefix`` can be passed as-is instead of being globbed by the caller.
     Sorted, because a reader comparing two runs should not have to care that the
     shell and the filesystem disagree about order.
+
+    Public because the other log readers in this package take the same input and
+    must resolve it the same way.
     """
     path = pathlib.Path(source)
     if not path.is_dir():
@@ -988,7 +982,7 @@ def load_host_phase_records(paths):
     return passes
 
 
-# The bind stage's own segments, whose durations partition it. Everything else a
+# The bind stage's own segments, each one interval inside it. Everything else a
 # pass records is an orchestrator operation nested inside the host_orch segment.
 _BIND_PHASE_NAMES = frozenset(
     {
@@ -1000,8 +994,6 @@ _BIND_PHASE_NAMES = frozenset(
         "runtime_init",
         "host_orch",
         "graph_upload",
-        "relocate",
-        "sm_h2d",
         "arena_h2d",
         "host_view_close",
     }
@@ -1030,14 +1022,23 @@ def host_record_spans(spans, passes):
 
     The clock needs no conversion: both sides are the same CLOCK_MONOTONIC axis.
 
+    **A segment the log already carries as a span is skipped here.** The runtime
+    emits each bind segment as a `[STRACE]` span, and that span carries the
+    segment's attributes — byte and tensor counts, fault and CPU counters — where
+    this artifact carries only ``detail``. So the log wins and the artifact fills
+    in the segments it has that the log does not: a run whose breakdown switch was
+    off collects records without emitting spans, and then the artifact is the only
+    source. Orchestrator operations have no span form at all and always come from
+    here.
+
     Returns the spans, the number of passes with no matching ``bind`` span, and
-    the ``(pid, inv)`` keys the artifact covered — a caller uses the last to avoid
-    drawing the same segment twice from the log lines as well.
+    the number of records skipped as already present in the log.
     """
     bind_by_key = {(span.pid, span.inv): span for span in spans if span.name == _PREPARE_SPAN and not span.is_device}
+    already_in_log = {(span.pid, span.inv, span.name) for span in spans if not span.is_device}
     out = []
     dropped_passes = 0
-    covered_keys = set()
+    skipped_records = 0
     for one_pass in passes:
         key = (one_pass.get("pid"), one_pass.get("inv"))
         parent = bind_by_key.get(key)
@@ -1061,10 +1062,12 @@ def host_record_spans(spans, passes):
             is_record_worker = "tid" in record and record_tid != parent.tid
             if phase in _BIND_PHASE_NAMES:
                 name = f"{_PREPARE_SPAN}.{phase}"
+                if (parent.pid, parent.inv, name) in already_in_log:
+                    skipped_records += 1
+                    continue
                 depth = parent.depth + 1
                 record_tid = parent.tid
                 phase_thread = "host_main"
-                covered_keys.add(key)
             else:
                 name = f"{_PREPARE_SPAN}.host_orch.{phase}"
                 depth = parent.depth + 2
@@ -1087,53 +1090,7 @@ def host_record_spans(spans, passes):
                     attrs=(f"detail={record.get('detail', 0)} src=host_phase_records host_phase_thread={phase_thread}"),
                 )
             )
-    return out, dropped_passes, frozenset(covered_keys)
-
-
-def bind_phase_spans(text, spans, skip_keys=frozenset()):
-    """Recover `bind phase=` timing lines as spans nested under their ``bind``.
-
-    Without these the swimlane draws ``chip.run.bind`` as one empty bar, which
-    for a runtime with a host prepare path is most of the trace: on a 40-layer
-    qwen decode the stage is seconds of tensor staging and host-view teardown,
-    while the orchestration inside it is around a millisecond. The per-event
-    records then land in well under a pixel with nothing to indicate where to zoom.
-
-    The line carries its own ``start_ns``. The owning invocation is whichever
-    ``chip.run.bind`` of that thread contains the interval; a phase outside
-    every bind is dropped rather than guessed at.
-
-    ``skip_keys`` holds the ``(pid, inv)`` a record artifact already covered, so
-    the same segment is not drawn twice when both channels are present.
-    """
-    binds = [span for span in spans if span.name == _PREPARE_SPAN and not span.is_device]
-    out = []
-    for match in _BIND_PHASE_RE.finditer(text):
-        start = int(match["start"])
-        dur = int(match["dur"])
-        parent = next(
-            (b for b in binds if b.ts <= start and start + dur <= b.ts + b.dur),
-            None,
-        )
-        if parent is None or (parent.pid, parent.inv) in skip_keys:
-            continue
-        out.append(
-            Span(
-                pid=parent.pid,
-                # The log's T0x id is a pthread handle, not the tid the markers
-                # carry, so take the lane from the enclosing bind and keep the
-                # raw value only as an attribute.
-                tid=parent.tid,
-                inv=parent.inv,
-                hid=parent.hid,
-                depth=parent.depth + 1,
-                name=f"{_PREPARE_SPAN}.{match['phase']}",
-                ts=start,
-                dur=dur,
-                attrs=f"{match['attrs'].strip()} log_thread=0x{match['tid_hex']} src=bind_phase".strip(),
-            )
-        )
-    return out
+    return out, dropped_passes, skipped_records
 
 
 def _process_label(pid, process_spans):
@@ -1403,21 +1360,20 @@ def print_tree(buckets, stream=sys.stdout):
         print(file=stream)
 
 
-def write_host_swimlane(args, spans, lines, anchors):
+def write_host_swimlane(args, spans, anchors):
     """Write the host swimlane, adding whatever prepare-path detail is available.
 
-    A runtime's own stage breakdown reaches this view through two channels that
-    describe the same segments: the per-event artifact, and the timing lines in the
-    log. The artifact wins for any pass it covers and the lines fill in the rest —
-    a run with no output directory has no artifact at all, and then the lines are
-    the only source.
+    A runtime's bind segments are `[STRACE]` spans and are already in ``spans``.
+    The per-event artifact adds what has no span form — the orchestrator
+    operations inside ``host_orch`` — and stands in for the segments themselves on
+    a run that collected records without emitting their spans.
     """
     lane_spans = spans
     record_count = 0
-    covered = frozenset()
+    skipped = 0
     if args.host_phase_records:
         passes = load_host_phase_records(args.host_phase_records)
-        extra, orphaned, covered = host_record_spans(spans, passes)
+        extra, orphaned, skipped = host_record_spans(spans, passes)
         lane_spans = lane_spans + extra
         record_count = len(extra)
         if orphaned:
@@ -1426,17 +1382,14 @@ def write_host_swimlane(args, spans, lines, anchors):
                 "in this log and were dropped — is the log from the same run as the artifact?",
                 file=sys.stderr,
             )
-    phase_spans = bind_phase_spans("".join(lines), spans, skip_keys=covered)
-    if phase_spans:
-        lane_spans = lane_spans + phase_spans
     with open(args.swimlane, "w", encoding="utf-8") as f:
         json.dump(to_host_swimlane(lane_spans, anchors=anchors), f)
     host_count = sum(not span.is_device for span in spans)
     extras = []
-    if phase_spans:
-        extras.append(f"{len(phase_spans)} bind phases")
     if record_count:
         extras.append(f"{record_count} host phase records")
+    if args.host_phase_records and skipped:
+        extras.append(f"{skipped} segment(s) already in the log")
     suffix = (", " + ", ".join(extras)) if extras else ""
     print(
         f"Wrote host swimlane: {args.swimlane} "
@@ -1464,10 +1417,10 @@ def main(argv=None):
         "--host-phase-records",
         action="append",
         metavar="PATH",
-        help="a host_phase_records.jsonl from the same run; its per-event bind segments and "
-        "orchestrator operations are drawn inside the matching chip.run.bind. Repeatable. Only "
-        "affects --swimlane, because the summed host-orch timing lines are cost shares and cannot "
-        "be placed on a timeline",
+        help="a host_phase_records.jsonl from the same run; its per-event orchestrator operations are "
+        "drawn inside the matching chip.run.bind, along with any bind segment the log does not "
+        "already carry as a span. Repeatable. Only affects --swimlane, because the summed host-orch "
+        "timing lines are cost shares and cannot be placed on a timeline",
     )
     ap.add_argument(
         "--rounds-table",
@@ -1499,7 +1452,7 @@ def main(argv=None):
         if source == "-":
             lines.extend(sys.stdin.readlines())
             continue
-        for path in _expand_log_source(source):
+        for path in expand_log_source(source):
             with open(path, encoding="utf-8", errors="replace") as f:
                 lines.extend(f.readlines())
 
@@ -1551,7 +1504,7 @@ def main(argv=None):
         print(f"Wrote Chrome trace: {args.trace_out} ({len(keyed)} spans)")
 
     if args.swimlane:
-        write_host_swimlane(args, spans, lines, anchors)
+        write_host_swimlane(args, spans, anchors)
 
     return 0
 

--- a/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a2a3/runtime/host_build_graph/docs/profiling_levels.md
@@ -240,12 +240,12 @@ appear.
 
 ### What is recorded
 
-Sixteen kinds, all on the host monotonic clock the `[STRACE]` host spans use,
+Twenty-one kinds, all on the host monotonic clock the `[STRACE]` host spans use,
 so records and spans read against each other with no alignment step.
 
 | Group | Kinds |
 | ----- | ----- |
-| Bind segments (partition the stage) | `args`, `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init`, `host_orch`, `graph_upload`, `sm_h2d`, `arena_h2d`, `host_view_close` |
+| Bind segments (one interval each, inside the stage) | `args`, `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init`, `host_orch`, `graph_upload`, `arena_h2d`, `host_view_close` |
 | Orchestrator operations (inside `host_orch`) | `submit_task`, `alloc_tensors`, `record_in_graph_task`, `graph_submit`, `build_definition`, `graph_begin`, `recording_wait`, `graph_commit`, `submit_admit`, `record_handoff`, `generated_args` |
 
 Three of the orchestrator kinds end with a task submitted — `submit_task`,
@@ -270,7 +270,11 @@ the wrong one produces a number that reads as data and is not:
   count). That is the whole contract.
 - **A quantity about a segment is an attribute** — `bytes=`, `heap_used=`,
   `spilled=`, `minflt=`, `nvcsw=`. It goes in the segment's attribute string,
-  which is what the `bind phase=` line prints.
+  which is what the segment's span carries. That string is capped at the span
+  attribute field's width (`SIMPLER_HOST_SPAN_ATTRIBUTES_CAPACITY`), and the
+  kernel counters are formatted first, so an overlong one loses a caller quantity
+  the artifact's `detail` can still supply rather than a counter nothing else
+  carries.
 
 So: **a new interval to name earns a new kind; a new quantity about an interval
 that already exists is an attribute on it.** Adding a kind to carry a statistic
@@ -286,7 +290,7 @@ printed as `detail_sum` for as long as the column was unconditional.
 
 | Switch | Turns on |
 | ------ | -------- |
-| `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` (env, off unless it starts with `1`, `t` or `T`) | the `LOG_TIMING` breakdown; needs no records, no rebuild, and works at any `--rounds` |
+| `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` (env, off unless it starts with `1`, `t` or `T`) | the breakdown in the log — segment spans plus the `host-orch` cost-share lines; needs no records, no rebuild, and works at any `--rounds` |
 | `SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE` (env, same spelling) | per-event collection into the pool, which reaches `host_phase_records.jsonl` when the run has an output directory |
 | `--enable-chip-swimlane 4` (CallConfig `chip_swimlane_level`) | per-event collection *and* the host lane in `chip_swimlane_records.json`, with its records clock-aligned against the device timeline |
 
@@ -319,11 +323,15 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
 
 ### The three views
 
-- **`LOG_TIMING` lines**, at the default log threshold, gated by
-  `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE`. One `bind phase=<p> start_ns=<n>
-  dur_ns=<n> <attrs>` line per segment, plus one `host-orch phase=<p>
-  total_ns=<n> count=<k> detail_sum=<n> dropped=<n>` line per orchestrator kind.
-  They come from per-kind counters, not from the record pool. The counters use
+- **The log**, at the default threshold, gated by
+  `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE`. Two shapes, because a segment and a cost
+  share are different things: one `[STRACE]` span named
+  `chip.run.bind.<segment>` per segment, carrying `ts` / `dur` / `<attrs>` at
+  depth 2 inside the `chip.run.bind` span; and one `host-orch phase=<p>
+  total_ns=<n> count=<k> detail_sum=<n> dropped=<n>` `LOG_TIMING` line per
+  orchestrator kind, which stays a line because those kinds nest inside each
+  other and a total over them is not an interval.
+  Both come from per-kind counters, not from the record pool. The counters use
   lock-free atomic additions across the main and recording-worker lanes, with
   every phase isolated on its own cache line so concurrent `graph_submit` and
   `record_in_graph_task` updates do not false-share. The per-event pool is armed when the
@@ -334,9 +342,11 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
   makes this the channel for steady state, where `--rounds > 1` switches every
   artifact collector off.
 
-  Every line is written at the end of the bind, keeping the log write off the path
-  being measured. The line therefore carries its own `start_ns`; the log prefix
-  timestamps the write, not the segment.
+  Both are written at the end of the bind, keeping the write off the path being
+  measured. The span therefore carries its own `ts`, taken when the segment
+  opened, rather than leaving its start to be inferred from when the record was
+  written — `STRACE_HOST_SPAN_AT_A` exists for that, and `chip.run` itself is
+  emitted the same way.
 
 - **`host_phase_records.jsonl`** in the per-case output directory, when a
   collecting bind has one. One JSON Lines object per bind carrying `pid` / `inv`
@@ -355,7 +365,7 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
   | Key | Kinds | Rendered as |
   | --- | ----- | ----------- |
   | `host_orchestrator_phases` | the task-submitting kinds | `Host Orchestrator` process |
-  | `host_device_uploads` | `graph_upload`, `sm_h2d`, `arena_h2d`, with byte counts | `Host Prepare` / `H2D` lane |
+  | `host_device_uploads` | `graph_upload`, `arena_h2d`, with byte counts | `Host Prepare` / `H2D` lane |
 
   The upload lane is the one place the whole question — orchestration plus H2D
   inside a millisecond — is visible against the device execution it precedes; the
@@ -365,13 +375,15 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
   against `recorded_records` (the submit projection), plus `pool_records` for the
   whole population — a pool count above the projection is normal, not incomplete.
 
-The stage's *duration* is already published as the `chip.run.bind` `[STRACE]`
-marker, so the marker and this breakdown are a total and its parts rather than two
-spellings of one number. The parts are not markers themselves: the marker grammar
-is the platform's public per-run-stage contract (see `runtime_c_api.h` and
-[docs/dfx/host-trace.md](../../../../../docs/dfx/host-trace.md)), whose consumers
-key off a fixed stage set, and a runtime's internal breakdown of one stage does
-not belong in it.
+The stage's *duration* is the `chip.run.bind` `[STRACE]` span, and its segments
+are `[STRACE]` spans one level below it, so the two are a stage and its parts in
+one format. A runtime subdividing a stage it owns is ordinary: the tensormap
+runtime's `chip.run.bind.args` and `chip.run.bind.prebuilt` do it, and the device
+sub-phases are that runtime's own AICPU breakdown, read back from a cycle buffer
+and re-emitted as spans (see `runtime_c_api.h` and
+[docs/dfx/host-trace.md](../../../../../docs/dfx/host-trace.md)). What is *not*
+a span is a summed cost share over kinds that nest inside each other — those have
+no honest position on a timeline, and they are the `host-orch phase=` lines.
 
 ### Cost and capacity
 

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -239,16 +239,28 @@ record_bind_phase(HostPhaseKind kind, const BindPhaseMark &mark, const char *att
     auto since = [](uint64_t current, uint64_t mark) {
         return current >= mark ? current - mark : 0;
     };
+    // Counters first, caller attributes after. The buffer is the span attribute
+    // field's own width, so an overlong segment loses its tail: a caller's
+    // quantity is recoverable from the artifact's `detail` or the run's own
+    // sizing, while the counters are this record's only copy and phase_time_split
+    // has nothing to fall back on.
     char with_counters[kBindAttrsCapacity];
-    snprintf(
+    const int formatted = snprintf(
         with_counters, sizeof(with_counters),
-        "%s%sminflt=%" PRIu64 " tminflt=%" PRIu64 " nivcsw=%" PRIu64 " nvcsw=%" PRIu64 " cpu_ns=%" PRIu64
-        " rec_cpu_ns=%" PRIu64,
-        attrs, *attrs == '\0' ? "" : " ", since(now.minflt, mark.counters.minflt),
-        since(now.thread_minflt, mark.counters.thread_minflt), since(now.nivcsw, mark.counters.nivcsw),
-        since(now.nvcsw, mark.counters.nvcsw), since(now.cpu_ns, mark.counters.cpu_ns),
-        since(now.recorder_cpu_ns, mark.counters.recorder_cpu_ns)
+        "minflt=%" PRIu64 " tminflt=%" PRIu64 " nivcsw=%" PRIu64 " nvcsw=%" PRIu64 " cpu_ns=%" PRIu64
+        " rec_cpu_ns=%" PRIu64 "%s%s",
+        since(now.minflt, mark.counters.minflt), since(now.thread_minflt, mark.counters.thread_minflt),
+        since(now.nivcsw, mark.counters.nivcsw), since(now.nvcsw, mark.counters.nvcsw),
+        since(now.cpu_ns, mark.counters.cpu_ns), since(now.recorder_cpu_ns, mark.counters.recorder_cpu_ns),
+        *attrs == '\0' ? "" : " ", attrs
     );
+    // Mark the cut here, because nothing downstream can: this buffer is exactly
+    // as wide as the span's attribute field, so the value the logger receives
+    // already fits and its own `~` marker never fires. An unmarked truncation
+    // reads as a complete attribute list that is one field short.
+    if (formatted >= static_cast<int>(sizeof(with_counters))) {
+        with_counters[sizeof(with_counters) - 2] = '~';
+    }
     host_phase_record_bind(
         static_cast<uint32_t>(kind), static_cast<uint64_t>(start_ns), with_counters, payload,
         static_cast<uint64_t>(end_ns)
@@ -951,7 +963,8 @@ int32_t run_host_orchestration(
     }
     {
         // The widest attribute string a segment formats: eight uint64 fields plus
-        // their labels, which is what sets kBindAttrsCapacity's margin.
+        // their labels. With the counters ahead of it in the recorded string, this
+        // is the tail a truncation eats first.
         char attrs[kBindAttrsCapacity];
         snprintf(
             attrs, sizeof(attrs),

--- a/src/a5/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a5/runtime/host_build_graph/docs/profiling_levels.md
@@ -247,12 +247,12 @@ appear.
 
 ### What is recorded
 
-Sixteen kinds, all on the host monotonic clock the `[STRACE]` host spans use,
+Twenty-one kinds, all on the host monotonic clock the `[STRACE]` host spans use,
 so records and spans read against each other with no alignment step.
 
 | Group | Kinds |
 | ----- | ----- |
-| Bind segments (partition the stage) | `args`, `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init`, `host_orch`, `graph_upload`, `sm_h2d`, `arena_h2d`, `host_view_close` |
+| Bind segments (one interval each, inside the stage) | `args`, `arena_build`, `static_arena`, `gm_heap`, `shared_mem`, `runtime_init`, `host_orch`, `graph_upload`, `arena_h2d`, `host_view_close` |
 | Orchestrator operations (inside `host_orch`) | `submit_task`, `alloc_tensors`, `record_in_graph_task`, `graph_submit`, `build_definition`, `graph_begin`, `recording_wait`, `graph_commit`, `submit_admit`, `record_handoff`, `generated_args` |
 
 Three of the orchestrator kinds end with a task submitted — `submit_task`,
@@ -277,7 +277,11 @@ the wrong one produces a number that reads as data and is not:
   count). That is the whole contract.
 - **A quantity about a segment is an attribute** — `bytes=`, `heap_used=`,
   `spilled=`, `minflt=`, `nvcsw=`. It goes in the segment's attribute string,
-  which is what the `bind phase=` line prints.
+  which is what the segment's span carries. That string is capped at the span
+  attribute field's width (`SIMPLER_HOST_SPAN_ATTRIBUTES_CAPACITY`), and the
+  kernel counters are formatted first, so an overlong one loses a caller quantity
+  the artifact's `detail` can still supply rather than a counter nothing else
+  carries.
 
 So: **a new interval to name earns a new kind; a new quantity about an interval
 that already exists is an attribute on it.** Adding a kind to carry a statistic
@@ -293,7 +297,7 @@ printed as `detail_sum` for as long as the column was unconditional.
 
 | Switch | Turns on |
 | ------ | -------- |
-| `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` (env, off unless it starts with `1`, `t` or `T`) | the `LOG_TIMING` breakdown; needs no records, no rebuild, and works at any `--rounds` |
+| `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` (env, off unless it starts with `1`, `t` or `T`) | the breakdown in the log — segment spans plus the `host-orch` cost-share lines; needs no records, no rebuild, and works at any `--rounds` |
 | `SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE` (env, same spelling) | per-event collection into the pool, which reaches `host_phase_records.jsonl` when the run has an output directory |
 | `--enable-chip-swimlane 4` (CallConfig `chip_swimlane_level`) | per-event collection *and* the host lane in `chip_swimlane_records.json`, with its records clock-aligned against the device timeline |
 
@@ -326,11 +330,15 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
 
 ### The three views
 
-- **`LOG_TIMING` lines**, at the default log threshold, gated by
-  `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE`. One `bind phase=<p> start_ns=<n>
-  dur_ns=<n> <attrs>` line per segment, plus one `host-orch phase=<p>
-  total_ns=<n> count=<k> detail_sum=<n> dropped=<n>` line per orchestrator kind.
-  They come from per-kind counters, not from the record pool. The counters use
+- **The log**, at the default threshold, gated by
+  `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE`. Two shapes, because a segment and a cost
+  share are different things: one `[STRACE]` span named
+  `chip.run.bind.<segment>` per segment, carrying `ts` / `dur` / `<attrs>` at
+  depth 2 inside the `chip.run.bind` span; and one `host-orch phase=<p>
+  total_ns=<n> count=<k> detail_sum=<n> dropped=<n>` `LOG_TIMING` line per
+  orchestrator kind, which stays a line because those kinds nest inside each
+  other and a total over them is not an interval.
+  Both come from per-kind counters, not from the record pool. The counters use
   lock-free atomic additions across the main and recording-worker lanes, with
   every phase isolated on its own cache line so concurrent `graph_submit` and
   `record_in_graph_task` updates do not false-share. The per-event pool is armed when the
@@ -341,9 +349,11 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
   makes this the channel for steady state, where `--rounds > 1` switches every
   artifact collector off.
 
-  Every line is written at the end of the bind, keeping the log write off the path
-  being measured. The line therefore carries its own `start_ns`; the log prefix
-  timestamps the write, not the segment.
+  Both are written at the end of the bind, keeping the write off the path being
+  measured. The span therefore carries its own `ts`, taken when the segment
+  opened, rather than leaving its start to be inferred from when the record was
+  written — `STRACE_HOST_SPAN_AT_A` exists for that, and `chip.run` itself is
+  emitted the same way.
 
 - **`host_phase_records.jsonl`** in the per-case output directory, when a
   collecting bind has one. One JSON Lines object per bind carrying `pid` / `inv`
@@ -362,7 +372,7 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
   | Key | Kinds | Rendered as |
   | --- | ----- | ----------- |
   | `host_orchestrator_phases` | the task-submitting kinds | `Host Orchestrator` process |
-  | `host_device_uploads` | `graph_upload`, `sm_h2d`, `arena_h2d`, with byte counts | `Host Prepare` / `H2D` lane |
+  | `host_device_uploads` | `graph_upload`, `arena_h2d`, with byte counts | `Host Prepare` / `H2D` lane |
 
   The upload lane is the one place the whole question — orchestration plus H2D
   inside a millisecond — is visible against the device execution it precedes; the
@@ -372,13 +382,15 @@ python -m pytest <case> --platform <platform> --device 0 --enable-chip-swimlane 
   against `recorded_records` (the submit projection), plus `pool_records` for the
   whole population — a pool count above the projection is normal, not incomplete.
 
-The stage's *duration* is already published as the `chip.run.bind` `[STRACE]`
-marker, so the marker and this breakdown are a total and its parts rather than two
-spellings of one number. The parts are not markers themselves: the marker grammar
-is the platform's public per-run-stage contract (see `runtime_c_api.h` and
-[docs/dfx/host-trace.md](../../../../../docs/dfx/host-trace.md)), whose consumers
-key off a fixed stage set, and a runtime's internal breakdown of one stage does
-not belong in it.
+The stage's *duration* is the `chip.run.bind` `[STRACE]` span, and its segments
+are `[STRACE]` spans one level below it, so the two are a stage and its parts in
+one format. A runtime subdividing a stage it owns is ordinary: the tensormap
+runtime's `chip.run.bind.args` and `chip.run.bind.prebuilt` do it, and the device
+sub-phases are that runtime's own AICPU breakdown, read back from a cycle buffer
+and re-emitted as spans (see `runtime_c_api.h` and
+[docs/dfx/host-trace.md](../../../../../docs/dfx/host-trace.md)). What is *not*
+a span is a summed cost share over kinds that nest inside each other — those have
+no honest position on a timeline, and they are the `host-orch phase=` lines.
 
 ### Cost and capacity
 

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -244,16 +244,28 @@ record_bind_phase(HostPhaseKind kind, const BindPhaseMark &mark, const char *att
     auto since = [](uint64_t current, uint64_t mark) {
         return current >= mark ? current - mark : 0;
     };
+    // Counters first, caller attributes after. The buffer is the span attribute
+    // field's own width, so an overlong segment loses its tail: a caller's
+    // quantity is recoverable from the artifact's `detail` or the run's own
+    // sizing, while the counters are this record's only copy and phase_time_split
+    // has nothing to fall back on.
     char with_counters[kBindAttrsCapacity];
-    snprintf(
+    const int formatted = snprintf(
         with_counters, sizeof(with_counters),
-        "%s%sminflt=%" PRIu64 " tminflt=%" PRIu64 " nivcsw=%" PRIu64 " nvcsw=%" PRIu64 " cpu_ns=%" PRIu64
-        " rec_cpu_ns=%" PRIu64,
-        attrs, *attrs == '\0' ? "" : " ", since(now.minflt, mark.counters.minflt),
-        since(now.thread_minflt, mark.counters.thread_minflt), since(now.nivcsw, mark.counters.nivcsw),
-        since(now.nvcsw, mark.counters.nvcsw), since(now.cpu_ns, mark.counters.cpu_ns),
-        since(now.recorder_cpu_ns, mark.counters.recorder_cpu_ns)
+        "minflt=%" PRIu64 " tminflt=%" PRIu64 " nivcsw=%" PRIu64 " nvcsw=%" PRIu64 " cpu_ns=%" PRIu64
+        " rec_cpu_ns=%" PRIu64 "%s%s",
+        since(now.minflt, mark.counters.minflt), since(now.thread_minflt, mark.counters.thread_minflt),
+        since(now.nivcsw, mark.counters.nivcsw), since(now.nvcsw, mark.counters.nvcsw),
+        since(now.cpu_ns, mark.counters.cpu_ns), since(now.recorder_cpu_ns, mark.counters.recorder_cpu_ns),
+        *attrs == '\0' ? "" : " ", attrs
     );
+    // Mark the cut here, because nothing downstream can: this buffer is exactly
+    // as wide as the span's attribute field, so the value the logger receives
+    // already fits and its own `~` marker never fires. An unmarked truncation
+    // reads as a complete attribute list that is one field short.
+    if (formatted >= static_cast<int>(sizeof(with_counters))) {
+        with_counters[sizeof(with_counters) - 2] = '~';
+    }
     host_phase_record_bind(
         static_cast<uint32_t>(kind), static_cast<uint64_t>(start_ns), with_counters, payload,
         static_cast<uint64_t>(end_ns)
@@ -1305,7 +1317,8 @@ int32_t run_host_orchestration(
     }
     {
         // The widest attribute string a segment formats: eight uint64 fields plus
-        // their labels, which is what sets kBindAttrsCapacity's margin.
+        // their labels. With the counters ahead of it in the recorded string, this
+        // is the tail a truncation eats first.
         char attrs[kBindAttrsCapacity];
         snprintf(
             attrs, sizeof(attrs),

--- a/src/common/host_build_graph/host/host_phase_trace.cpp
+++ b/src/common/host_build_graph/host/host_phase_trace.cpp
@@ -165,6 +165,14 @@ void drain_in_flight_records(TraceState &s) {
 
 bool is_bind_kind(uint32_t kind) { return kind < static_cast<uint32_t>(HostPhaseKind::OrchSubmitTask); }
 
+// The stage these segments subdivide, and their level in the span tree. The
+// platform opens `chip.run.bind` at depth 1 (src/common/platform/{onboard,sim}/
+// host/c_api_shared.cpp) and the flush below runs inside that scope on the same
+// thread, so a segment of it is depth 2 — the level a lexical STRACE scope there
+// would print, and the one the tensormap runtime's own chip.run.bind.args uses.
+constexpr const char *kBindSpanName = "chip.run.bind";
+constexpr int kBindSegmentSpanDepth = 2;
+
 // Opt-in spelling shared by this runtime's switches, matching the runtime's
 // other default-off switch, SIMPLER_TMR_SERIAL_ORCH_SCHED_ENABLE, so that
 // `=false` / `=off` / `=no` read as off rather than as a non-zero string.
@@ -395,13 +403,22 @@ void host_phase_trace_end() {
         const char *name = host_phase_kind_name(static_cast<HostPhaseKind>(kind));
         if (is_bind_kind(kind)) {
             // One occurrence per bind, so the summed time is the segment's own
-            // duration and the twelve of them partition the bind stage. The line
-            // carries its own start because every line is written at the end of
-            // the bind, off the path being measured — the write time says nothing
-            // about when the segment ran.
-            LOG_TIMING(
-                "bind phase=%s start_ns=%llu dur_ns=%llu %s", name, static_cast<unsigned long long>(first_start_ns),
-                static_cast<unsigned long long>(total_ns), s.bind_attrs[kind].data()
+            // duration. The span carries its own start because it is emitted at
+            // the end of the bind, off the path being measured — the emit time
+            // says nothing about when the segment ran. STRACE_HOST_SPAN_AT_A is
+            // the form for exactly that; `chip.run` itself is emitted this way.
+            if (count != 1) {
+                LOG_WARN(
+                    "bind segment %s recorded %llu times in one bind; its span reports their sum from the "
+                    "earliest start",
+                    name, static_cast<unsigned long long>(count)
+                );
+            }
+            char span_name[SIMPLER_HOST_SPAN_NAME_CAPACITY];
+            snprintf(span_name, sizeof(span_name), "%s.%s", kBindSpanName, name);
+            STRACE_HOST_SPAN_AT_A(
+                span_name, static_cast<long long>(first_start_ns), static_cast<long long>(total_ns),
+                kBindSegmentSpanDepth, s.bind_attrs[kind].data()
             );
             continue;
         }

--- a/src/common/host_build_graph/host_phase_trace.h
+++ b/src/common/host_build_graph/host_phase_trace.h
@@ -14,22 +14,26 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "common/host_span.h"
+
 /**
  * One bind segment's attribute string, for every buffer on the path from the
- * caller that formats it to the store that holds it until flush.
+ * caller that formats it to the span field it ends up in.
  *
- * It is one number rather than a size per buffer because the two ends have to
- * agree: a caller formats its own attributes and then `record_bind_phase`
- * appends this thread's fault and context-switch deltas, and the store copies
- * the result in with `snprintf`, which truncates in silence. Nine separate
- * literals cannot state that relationship, and the widest of them was already
- * larger than the store.
+ * It is one number rather than a size per buffer because the ends have to agree:
+ * a caller formats its own attributes, `record_bind_phase` appends this thread's
+ * fault and context-switch deltas, the store copies the result in with
+ * `snprintf`, and the logger copies it once more into the span's attribute
+ * field — every one of those truncates in silence. Nine separate literals cannot
+ * state that relationship, and the widest of them was already larger than the
+ * store.
  *
- * The margin is deliberate: the widest segment formats about 100 bytes today
- * (`arena_h2d`'s itemized upload plus the counters), so a workload whose counts
- * grow a digit does not start dropping a trailing attribute.
+ * It is the span field's own width, so the value the logger receives always
+ * fits and its own `~` marker never fires. `record_bind_phase` therefore marks
+ * its own truncation: without that, an overlong attribute list would arrive
+ * looking complete and one field short.
  */
-constexpr size_t kBindAttrsCapacity = 256;
+constexpr size_t kBindAttrsCapacity = SIMPLER_HOST_SPAN_ATTRIBUTES_CAPACITY;
 
 /**
  * Timing of this runtime's prepare path: the bind stage's segments and the host

--- a/src/common/log/host_log.cpp
+++ b/src/common/log/host_log.cpp
@@ -64,11 +64,10 @@ std::atomic<void (*)(size_t)> g_after_queue_claim_hook{nullptr};
 std::atomic<void (*)()> g_before_gap_wait_hook{nullptr};
 #endif
 
-// POSIX guarantees atomic pipe writes up to _POSIX_PIPE_BUF (512 bytes). A
-// conservative bound for the logger prefix, fixed-width STRACE fields, and
-// newline is 256 bytes, leaving the other half for the encoded text fields.
-constexpr size_t kHostSpanNameCapacity = 64;
-constexpr size_t kHostSpanAttributesCapacity = 192;
+// The two text-field widths live in common/host_span.h, where a producer that
+// formats a field can size its buffer to the same number.
+constexpr size_t kHostSpanNameCapacity = SIMPLER_HOST_SPAN_NAME_CAPACITY;
+constexpr size_t kHostSpanAttributesCapacity = SIMPLER_HOST_SPAN_ATTRIBUTES_CAPACITY;
 static_assert(kHostSpanNameCapacity + kHostSpanAttributesCapacity <= _POSIX_PIPE_BUF - 256);
 static_assert(kRecordCapacity >= 2);
 

--- a/src/common/log/include/common/host_span.h
+++ b/src/common/log/include/common/host_span.h
@@ -18,6 +18,20 @@ extern "C" {
 #endif
 
 /*
+ * Widths of the two text fields a span record carries, published because a
+ * producer that formats one of them has to size its own buffer to match: the
+ * logger copies with `snprintf`, which truncates in silence, and a producer
+ * whose buffer is wider than the field truncates twice — once unmarked in the
+ * record it hands over, once marked by the logger.
+ *
+ * POSIX guarantees atomic pipe writes up to _POSIX_PIPE_BUF (512 bytes), and a
+ * conservative bound for the logger prefix, the fixed-width STRACE fields, and
+ * the newline is 256 bytes, which leaves these two the other half.
+ */
+#define SIMPLER_HOST_SPAN_NAME_CAPACITY 64
+#define SIMPLER_HOST_SPAN_ATTRIBUTES_CAPACITY 192
+
+/*
  * One span record on its way to the logger. A stack temporary, handed to the
  * link-time unified_log_host_span in the same DSO, so it carries no version or
  * size word: the two producers are inline in this repository's headers and the

--- a/src/common/platform/include/common/chip_swimlane_profiling.h
+++ b/src/common/platform/include/common/chip_swimlane_profiling.h
@@ -677,8 +677,7 @@ inline bool host_phase_kind_submits_task(HostPhaseKind kind) {
  * stage is host-only setup with no device counterpart.
  */
 inline bool host_phase_kind_is_device_upload(HostPhaseKind kind) {
-    return kind == HostPhaseKind::BindGraphUpload || kind == HostPhaseKind::BindSmH2d ||
-           kind == HostPhaseKind::BindArenaH2d;
+    return kind == HostPhaseKind::BindGraphUpload || kind == HostPhaseKind::BindArenaH2d;
 }
 
 /**
@@ -712,10 +711,6 @@ inline const char *host_phase_kind_name(HostPhaseKind kind) {
         return "host_orch";
     case HostPhaseKind::BindGraphUpload:
         return "graph_upload";
-    case HostPhaseKind::BindRelocate:
-        return "relocate";
-    case HostPhaseKind::BindSmH2d:
-        return "sm_h2d";
     case HostPhaseKind::BindArenaH2d:
         return "arena_h2d";
     case HostPhaseKind::BindHostViewClose:

--- a/src/common/platform/include/common/host_phase_kind.h
+++ b/src/common/platform/include/common/host_phase_kind.h
@@ -34,10 +34,12 @@
 /**
  * What one HostPhaseRecord measured.
  *
- * The bind kinds partition the bind stage: their durations sum to the
- * `chip.run.bind` span. The orchestrator kinds are nested inside BindHostOrch
- * and do not partition it — some are sub-operations of others. Each orchestrator
- * kind is recorded at exactly one site, named beside it.
+ * The bind kinds cover segments of the bind stage: each is one interval inside
+ * the `chip.run.bind` span, and their durations do not sum to it — the gap
+ * between one segment closing and the next opening belongs to neither. The
+ * orchestrator kinds are nested inside BindHostOrch and overlap each other, some
+ * being sub-operations of others. Each kind is recorded at exactly one site,
+ * named beside it.
  */
 enum class HostPhaseKind : uint32_t {
     BindArgs = 0,
@@ -48,8 +50,6 @@ enum class HostPhaseKind : uint32_t {
     BindRuntimeInit,
     BindHostOrch,
     BindGraphUpload,
-    BindRelocate,
-    BindSmH2d,
     BindArenaH2d,
     BindHostViewClose,
     // Recorded by the host orchestrator (host_build_graph/host/orchestrator.cpp).

--- a/tests/ut/py/test_hbg_bind_phases_grouping.py
+++ b/tests/ut/py/test_hbg_bind_phases_grouping.py
@@ -6,128 +6,93 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Grouping of `bind phase=` lines into binds."""
+"""Grouping bind-segment spans into binds.
+
+A bind is the set of segments sharing one `(pid, inv)`. The tests below pin that
+key, and in particular the case the previous line-based grouping could not
+express: two ranks writing one stream, whose segment bursts interleave.
+"""
 
 from __future__ import annotations
 
-import sys
+from simpler_setup.tools.hbg_bind_phases import cold_binds, parse_binds
 
-from simpler_setup.tools import hbg_bind_phases
-
-# A bind emits its segments in one contiguous burst, in this order. `arena_h2d`
-# is second to last, so it does not close a bind; `host_view_close` does.
-EMISSION_ORDER = (
-    "args",
-    "arena_build",
-    "static_arena",
-    "gm_heap",
-    "shared_mem",
-    "runtime_init",
-    "host_orch",
-    "graph_upload",
-    "arena_h2d",
-    "host_view_close",
-)
+SEGMENTS = ("args", "host_orch", "graph_upload", "arena_h2d")
 
 
-def _write_binds(path, count: int, *, order=EMISSION_ORDER, omit: tuple[str, ...] = ()) -> None:
-    """One line per segment per bind, each duration encoding its own bind index."""
-    lines = ["[stamp] command commit=abc"]
-    clock = 0
-    for bind_index in range(count):
-        for phase in order:
-            if phase in omit:
-                continue
-            clock += 1
-            # dur_ns = (bind_index + 1) ms, so a misattributed segment is visible.
-            lines.append(f"bind phase={phase} start_ns={clock} dur_ns={(bind_index + 1) * 1000000}")
+def _span(pid: int, inv: int, phase: str, ts: int, dur_ns: int) -> str:
+    return f"[STRACE] v=1 pid={pid} tid={pid} inv={inv} hid=abc depth=2 name=chip.run.bind.{phase} ts={ts} dur={dur_ns}"
+
+
+def _write(path, lines: list[str]):
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return [path]
 
 
-def test_each_segment_lands_in_its_own_bind(tmp_path):
-    log = tmp_path / "run.log"
-    _write_binds(log, 3)
+def test_two_ranks_writing_one_stream_are_not_confused_for_each_other(tmp_path):
+    """The case the old grouping could not see.
 
-    binds = hbg_bind_phases.parse_binds(str(log))
-
-    assert len(binds) == 3
-    for index, bind in enumerate(binds):
-        assert sorted(bind) == sorted(EMISSION_ORDER), f"bind {index} is not whole"
-        for phase, duration in bind.items():
-            assert duration == index + 1, f"bind {index} carries another bind's {phase}"
-
-
-def test_a_bind_missing_its_closing_segment_does_not_swallow_the_next(tmp_path):
-    """An interrupted bind stays one bind rather than merging with its successor."""
-    log = tmp_path / "partial.log"
-    _write_binds(log, 1)
-    with log.open("a", encoding="utf-8") as handle:
-        for phase in ("args", "host_orch", "arena_h2d"):
-            handle.write(f"bind phase={phase} start_ns=999 dur_ns=2000000\n")
-
-    binds = hbg_bind_phases.parse_binds(str(log))
-
-    assert len(binds) == 2
-    assert binds[0]["host_view_close"] == 1
-    assert binds[1]["host_orch"] == 2
-    assert "host_view_close" not in binds[1]
-
-
-def test_a_bind_omitting_a_leading_segment_is_reported(tmp_path, monkeypatch, capsys):
-    """A bind short of a leading segment absorbs the next bind's copy of it.
-
-    Grouping closes on a repeated name, so a segment the previous bind lacks and
-    the next one emits before any they share lands in the previous bind. `args`
-    is emitted unconditionally and first, so no current bind can omit it — this
-    pins what happens if that ever changes, and that the reader is told.
+    Ranks share the capture fd and their bursts interleave, and the log prefix's
+    thread id is identical across them. `inv` is allocated per run per process,
+    so `(pid, inv)` separates them with nothing inferred from order.
     """
-    log = tmp_path / "no_args.log"
-    _write_binds(log, 1, order=EMISSION_ORDER[1:])
-    with log.open("a", encoding="utf-8") as handle:
-        for phase in EMISSION_ORDER:
-            handle.write(f"bind phase={phase} start_ns=999 dur_ns=2000000\n")
+    lines = []
+    for index, phase in enumerate(SEGMENTS):
+        # One segment from each rank, alternating, for two binds per rank.
+        lines.append(_span(11, 1, phase, 1_000 + index, 1_000_000))
+        lines.append(_span(22, 1, phase, 1_500 + index, 2_000_000))
+        lines.append(_span(11, 2, phase, 9_000 + index, 3_000_000))
+        lines.append(_span(22, 2, phase, 9_500 + index, 4_000_000))
 
-    binds = hbg_bind_phases.parse_binds(str(log))
+    binds = parse_binds(_write(tmp_path / "run.log", lines))
 
-    assert [len(bind) for bind in binds] == [10, 9]
-    assert binds[0]["args"] == 2, "the second bind's args landed in the first"
-    assert "args" not in binds[1]
+    assert len(binds) == 4
+    assert {(b["pid"], b["inv"]) for b in binds} == {(11, 1), (11, 2), (22, 1), (22, 2)}
+    for bind in binds:
+        assert sorted(k for k in bind if k in SEGMENTS) == sorted(SEGMENTS)
+    by_key = {(b["pid"], b["inv"]): b for b in binds}
+    assert by_key[(11, 1)]["host_orch"] == 1.0
+    assert by_key[(22, 2)]["host_orch"] == 4.0
 
-    monkeypatch.setattr(sys, "argv", ["hbg_bind_phases", str(log), "--keep-first"])
-    assert hbg_bind_phases.main() == 0
-    out = capsys.readouterr().out
-    assert "not every bind has the same segments; args" in out
+
+def test_each_rank_contributes_exactly_one_cold_bind(tmp_path):
+    """Warm-up is per rank and is the earliest bind that rank ran, not a count."""
+    lines = []
+    for pid, base in ((11, 1_000), (22, 500)):
+        for inv, offset in ((1, 0), (2, 10_000), (3, 20_000)):
+            for index, phase in enumerate(SEGMENTS):
+                lines.append(_span(pid, inv, phase, base + offset + index, 1_000_000))
+
+    binds = parse_binds(_write(tmp_path / "run.log", lines))
+
+    assert cold_binds(binds) == {(11, 1), (22, 1)}
 
 
-def test_a_split_burst_is_reported_rather_than_passed_off_as_a_bind(tmp_path, monkeypatch, capsys):
-    """Grouping assumes uninterrupted bursts, and nothing enforces that.
+def test_a_group_without_host_orch_is_not_a_bind(tmp_path):
+    """`host_orch` is the segment that makes a bind a bind; without it the
+    records describe something else that happened to share the key."""
+    lines = [
+        _span(11, 1, "args", 1_000, 1_000_000),
+        _span(11, 1, "arena_h2d", 1_100, 1_000_000),
+        _span(11, 2, "args", 2_000, 1_000_000),
+        _span(11, 2, "host_orch", 2_100, 1_000_000),
+    ]
 
-    Ranks share one stream through no lock and the line prefix carries no pid, so
-    one rank's burst can land inside another's. The result is binds whose segment
-    sets differ, which has to reach the reader.
-    """
-    log = tmp_path / "split_burst.log"
-    lines = ["[stamp] command commit=abc"]
+    binds = parse_binds(_write(tmp_path / "run.log", lines))
 
-    def emit(phase: str, rank: int) -> None:
-        lines.append(f"bind phase={phase} start_ns={len(lines)} dur_ns={rank * 1000000}")
+    assert [(b["pid"], b["inv"]) for b in binds] == [(11, 2)]
 
-    for phase in EMISSION_ORDER[:4]:  # rank 1 starts
-        emit(phase, 1)
-    for phase in EMISSION_ORDER:  # rank 2 lands whole, inside it
-        emit(phase, 2)
-    for phase in EMISSION_ORDER[4:]:  # rank 1 finishes
-        emit(phase, 1)
-    log.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
-    binds = hbg_bind_phases.parse_binds(str(log))
-    assert [len(bind) for bind in binds] == [10, 6], "the split burst is not silently made whole"
+def test_orchestrator_operations_are_not_segments(tmp_path):
+    """`chip.run.bind.host_orch.<op>` sits a level deeper and is not a segment of
+    the stage, so it must not become a column."""
+    lines = [
+        _span(11, 1, "host_orch", 1_000, 1_000_000),
+        _span(11, 1, "host_orch.graph_submit", 1_100, 50_000),
+        _span(11, 1, "host_orch.build_definition", 1_200, 60_000),
+    ]
 
-    # --keep-first so both binds are reported; dropping the cold one would leave a
-    # single bind, whose segment set is trivially uniform with itself.
-    monkeypatch.setattr(sys, "argv", ["hbg_bind_phases", str(log), "--keep-first"])
-    assert hbg_bind_phases.main() == 0
-    out = capsys.readouterr().out
-    assert "not every bind has the same segments" in out
-    for phase in ("args", "arena_build", "static_arena", "gm_heap"):
-        assert phase in out
+    binds = parse_binds(_write(tmp_path / "run.log", lines))
+
+    assert len(binds) == 1
+    assert sorted(k for k in binds[0] if k not in ("pid", "inv", "ts")) == ["host_orch"]

--- a/tests/ut/py/test_hbg_bind_phases_torch_autoload.py
+++ b/tests/ut/py/test_hbg_bind_phases_torch_autoload.py
@@ -15,15 +15,20 @@ import sys
 from simpler_setup.tools import hbg_bind_phases
 
 
+def _span(pid: int, inv: int, phase: str, ts: int, dur_ns: int) -> str:
+    return f"[STRACE] v=1 pid={pid} tid={pid} inv={inv} hid=abc depth=2 name=chip.run.bind.{phase} ts={ts} dur={dur_ns}"
+
+
 def _write_log(path, autoload_records: tuple[str, ...]) -> None:
+    """One rank, two binds — enough that the cold one leaves a warm one behind."""
     lines = ["[stamp] command commit=abc"]
     lines.extend(f"TIMING simpler: {record}" for record in autoload_records)
     lines.extend(
         [
-            "bind phase=host_orch start_ns=1 dur_ns=1000000",
-            "bind phase=arena_h2d start_ns=2 dur_ns=1000000",
-            "bind phase=host_orch start_ns=3 dur_ns=500000",
-            "bind phase=arena_h2d start_ns=4 dur_ns=500000",
+            _span(7, 1, "host_orch", 1_000, 1_000_000),
+            _span(7, 1, "arena_h2d", 1_001_000, 1_000_000),
+            _span(7, 2, "host_orch", 3_000_000, 500_000),
+            _span(7, 2, "arena_h2d", 3_500_000, 500_000),
         ]
     )
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -40,7 +45,7 @@ def test_report_shows_each_torch_autoload_state(tmp_path, monkeypatch, capsys):
         "effective=enabled torch_imported=true torch_npu_loaded=true"
     )
     _write_log(log, (first, first, second))
-    monkeypatch.setattr(sys, "argv", ["hbg_bind_phases", str(log), "--rounds", "2"])
+    monkeypatch.setattr(sys, "argv", ["hbg_bind_phases", str(log)])
 
     assert hbg_bind_phases.main() == 0
 
@@ -52,7 +57,7 @@ def test_report_shows_each_torch_autoload_state(tmp_path, monkeypatch, capsys):
 def test_report_warns_when_torch_autoload_state_is_missing(tmp_path, monkeypatch, capsys):
     log = tmp_path / "run.log"
     _write_log(log, ())
-    monkeypatch.setattr(sys, "argv", ["hbg_bind_phases", str(log), "--rounds", "2"])
+    monkeypatch.setattr(sys, "argv", ["hbg_bind_phases", str(log)])
 
     assert hbg_bind_phases.main() == 0
 
@@ -66,4 +71,4 @@ def test_parser_accepts_record_without_raw_fields(tmp_path):
     record = "torch_backend_autoload setting=0 effective=disabled torch_imported=true torch_npu_loaded=false"
     _write_log(log, (record,))
 
-    assert hbg_bind_phases.parse_torch_autoload(str(log)) == [record]
+    assert hbg_bind_phases.parse_torch_autoload([log]) == [record]

--- a/tests/ut/py/test_host_timing_is_strace_only.py
+++ b/tests/ut/py/test_host_timing_is_strace_only.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""`[STRACE]` is the only timeline format the host emits.
+
+Three layers, and this file pins the boundary between the first two:
+
+- **`TIMING` is a log level** — the envelope every host record rides in.
+- **`[STRACE]` is the timing system built on it**, and the only format that
+  carries an *interval*. Everything a reader can place on a timeline goes
+  through it, whether it was measured by an RAII scope or read back from a
+  fixed-slot capture buffer and re-emitted (`STRACE_HOST_SPAN_AT`,
+  `STRACE_DEV_SPAN_AT`).
+- **A summed cost share is not an interval** and stays an ordinary `LOG_TIMING`
+  line. Sub-operations that nest inside each other cannot honestly be drawn as
+  bars, so they report a total and a count instead.
+
+The concrete failure this prevents: the host prepare path once printed
+`bind phase=<p> start_ns=<n> dur_ns=<n>` at `LOG_TIMING`, which is an interval in
+a second format. It grew its own regex in `strace_timing.py`, two dedicated
+tools, and a grouping heuristic that existed only because the line carried no
+`pid`/`inv` — the keys a `[STRACE]` record has by construction.
+
+A start plus a duration is the signature of that mistake, so that is what this
+test looks for.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+# A start timestamp in a log line is the marker of an interval reported outside
+# `[STRACE]`. `[STRACE]` itself writes `ts=`, and it is not emitted through
+# LOG_TIMING format strings — `HostLogger::log_host_span` builds the record.
+_INTERVAL_START_KEYS = ("start_ns=", "start_us=", "begin_ns=")
+
+# The shapes a LOG_TIMING line may legitimately carry, as a reader's map rather
+# than as an assertion: summed cost shares (`total_ns=`/`count=`), the
+# orchestrator's own step totals, the clock anchor's two absolute readings, the
+# writer's drop counters, and queue-occupancy probes.
+_ALLOWED_SHAPES = ("total_ns=", "count=", "ns=", "mono_ns=", "wall_ns=", "dropped=", "queue")
+
+_SOURCE_ROOT = pathlib.Path(__file__).resolve().parents[3] / "src"
+_STRING_LITERAL = re.compile(r'"((?:[^"\\]|\\.)*)"')
+
+
+def _log_timing_format_strings(text: str) -> list[str]:
+    """Every `LOG_TIMING(...)` call's format string, adjacent literals joined.
+
+    C++ concatenates adjacent string literals, so a format string wrapped across
+    lines is several literals in the source and one string to the compiler. The
+    scan therefore takes the whole call — balanced to its closing paren — and
+    joins every literal in it.
+    """
+    formats = []
+    for match in re.finditer(r"\bLOG_TIMING\s*\(", text):
+        depth = 0
+        end = len(text)
+        for index in range(match.end() - 1, len(text)):
+            char = text[index]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    end = index
+                    break
+        formats.append("".join(literal.group(1) for literal in _STRING_LITERAL.finditer(text[match.end() : end])))
+    return formats
+
+
+def _sources(root: pathlib.Path) -> list[pathlib.Path]:
+    return sorted(path for pattern in ("**/*.cpp", "**/*.h") for path in root.glob(pattern))
+
+
+def _interval_carrying_lines(root: pathlib.Path) -> list[str]:
+    """Every LOG_TIMING format string under `root` that carries a start timestamp."""
+    offenders = []
+    for path in _sources(root):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for fmt in _log_timing_format_strings(text):
+            if any(key in fmt for key in _INTERVAL_START_KEYS):
+                offenders.append(f"{path.relative_to(root.parent)}: {fmt}")
+    return offenders
+
+
+def test_no_log_timing_line_reports_an_interval():
+    """An interval outside `[STRACE]` is a second timeline format."""
+    offenders = _interval_carrying_lines(_SOURCE_ROOT)
+
+    assert offenders == [], (
+        "these LOG_TIMING lines carry a start timestamp, so they report an interval in a second "
+        "timeline format. Emit a span instead — STRACE_HOST_SPAN_AT_A takes an already-measured "
+        "start and duration, which is what the host prepare path uses for its bind segments:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_the_scan_actually_reaches_the_log_timing_call_sites():
+    """A positive control: an empty scan would pass the assertion above vacuously.
+
+    Both halves matter — that files are being read at all, and that the format
+    strings inside them are recovered — because either failing silently turns the
+    invariant into a test that can never fail.
+    """
+    sources = _sources(_SOURCE_ROOT)
+    assert len(sources) > 100, f"only {len(sources)} sources found under {_SOURCE_ROOT}"
+
+    formats = [fmt for path in sources for fmt in _log_timing_format_strings(path.read_text(errors="replace"))]
+    assert len(formats) > 10, f"only {len(formats)} LOG_TIMING format strings recovered"
+    assert any(any(shape in fmt for shape in _ALLOWED_SHAPES) for fmt in formats), (
+        "no LOG_TIMING line matched any known shape, so the scan is probably not recovering format strings correctly"
+    )
+
+
+def test_multi_line_format_strings_are_joined_before_the_check():
+    """The scan has to see one string where the source has three literals.
+
+    A format string split across lines is how the offending line was written, so
+    a scan that tested each literal on its own would miss `start_ns=` sitting in
+    the second one.
+    """
+    source = """
+    LOG_TIMING(
+        "bind phase=%s "
+        "start_ns=%llu "
+        "dur_ns=%llu",
+        name, start, dur
+    );
+    """
+
+    assert _log_timing_format_strings(source) == ["bind phase=%s start_ns=%llu dur_ns=%llu"]
+
+
+def test_a_reintroduced_interval_line_is_caught(tmp_path):
+    """The invariant is green today, so prove it can go red.
+
+    Without this the assertion above would keep passing if the scan silently
+    stopped finding anything — and a guard that cannot fail is not a guard. The
+    summed-share line beside the offender is the other half: the check has to
+    admit what a LOG_TIMING line may legitimately carry.
+    """
+    source_root = tmp_path / "src"
+    (source_root / "runtime").mkdir(parents=True)
+    (source_root / "runtime" / "clean.cpp").write_text(
+        'LOG_TIMING("host-orch phase=%s total_ns=%llu count=%llu", name, total, count);\n', encoding="utf-8"
+    )
+    (source_root / "runtime" / "offender.cpp").write_text(
+        'LOG_TIMING(\n    "bind phase=%s "\n    "start_ns=%llu dur_ns=%llu",\n    name, start, dur\n);\n',
+        encoding="utf-8",
+    )
+
+    offenders = _interval_carrying_lines(source_root)
+
+    assert offenders == ["src/runtime/offender.cpp: bind phase=%s start_ns=%llu dur_ns=%llu"]

--- a/tests/ut/py/test_phase_time_split.py
+++ b/tests/ut/py/test_phase_time_split.py
@@ -13,23 +13,33 @@ import pytest
 from simpler_setup.tools import phase_time_split
 
 
-def _marker(phase, dur_ns, cpu_ns, rec_cpu_ns, minflt=0, tminflt=0, nvcsw=0, nivcsw=0):
+def _span(phase, dur_ns, cpu_ns, rec_cpu_ns, *, faults=None, pid=7, inv=1, ts=1000):
+    counters = {"minflt": 0, "tminflt": 0, "nivcsw": 0, "nvcsw": 0, **(faults or {})}
     return (
-        f"[TIMING] host_phase_trace_end: bind phase={phase} start_ns=1000 dur_ns={dur_ns} "
-        f"minflt={minflt} tminflt={tminflt} nivcsw={nivcsw} nvcsw={nvcsw} "
+        f"[STRACE] v=1 pid={pid} tid={pid} inv={inv} hid=abc depth=2 "
+        f"name=chip.run.bind.{phase} ts={ts} dur={dur_ns} "
+        f"minflt={counters['minflt']} tminflt={counters['tminflt']} "
+        f"nivcsw={counters['nivcsw']} nvcsw={counters['nvcsw']} "
         f"cpu_ns={cpu_ns} rec_cpu_ns={rec_cpu_ns}\n"
     )
 
 
 def test_parse_reads_every_counter(tmp_path):
     log = tmp_path / "run.log"
-    log.write_text(_marker("host_orch", 2_000_000, 1_500_000, 8_000_000, minflt=99, tminflt=7, nvcsw=3, nivcsw=1))
+    log.write_text(
+        _span(
+            "host_orch", 2_000_000, 1_500_000, 8_000_000, faults={"minflt": 99, "tminflt": 7, "nvcsw": 3, "nivcsw": 1}
+        )
+    )
 
-    rows = phase_time_split.parse(str(log))
+    rows = phase_time_split.parse([log])
 
     assert len(rows) == 1
     assert rows[0] == {
         "phase": "host_orch",
+        "pid": 7,
+        "inv": 1,
+        "ts": 1000,
         "dur_us": 2000.0,
         "minflt": 99,
         "tminflt": 7,
@@ -40,11 +50,68 @@ def test_parse_reads_every_counter(tmp_path):
     }
 
 
-def test_parse_ignores_lines_without_a_marker(tmp_path):
+def test_parse_ignores_records_that_are_not_bind_segments(tmp_path):
+    """Only a segment of the stage counts: not another span, and not an
+    orchestrator operation one level deeper, which carries none of the counters."""
     log = tmp_path / "run.log"
-    log.write_text("some other TIMING line\n" + _marker("graph_upload", 1000, 1000, 0))
+    log.write_text(
+        "some other TIMING line\n"
+        + "[STRACE] v=1 pid=7 tid=7 inv=1 hid=abc depth=1 name=chip.run.bind ts=1 dur=9\n"
+        + "[STRACE] v=1 pid=7 tid=7 inv=1 hid=abc depth=3 name=chip.run.bind.host_orch.graph_submit ts=2 dur=3\n"
+        + _span("graph_upload", 1000, 1000, 0)
+    )
 
-    assert [row["phase"] for row in phase_time_split.parse(str(log))] == ["graph_upload"]
+    assert [row["phase"] for row in phase_time_split.parse([log])] == ["graph_upload"]
+
+
+def test_a_truncated_cold_bind_does_not_promote_its_successor(tmp_path, monkeypatch, capsys):
+    """Warm-up is decided before any row is dropped.
+
+    A bind whose attribute string was cut is still a bind that ran. Excluding it
+    from the statistics first would make the *next* bind the earliest one left,
+    and that bind's numbers — genuinely warm — would be reported as the cold row.
+    """
+    log = tmp_path / "run.log"
+    log.write_text(
+        # The rank's first bind, truncated: no rec_cpu_ns.
+        "[STRACE] v=1 pid=7 tid=7 inv=1 hid=abc depth=2 name=chip.run.bind.host_orch ts=1000 dur=9000000 "
+        "minflt=1 tminflt=1 nivcsw=0 nvcsw=0 cpu_ns=9000000 rec_cpu~\n"
+        + _span("host_orch", 2_000_000, 1_500_000, 0, pid=7, inv=2, ts=20_000)
+        + _span("host_orch", 2_100_000, 1_600_000, 0, pid=7, inv=3, ts=30_000)
+    )
+    monkeypatch.setattr("sys.argv", ["phase_time_split", str(log)])
+
+    phase_time_split.main()
+
+    rows = [line for line in capsys.readouterr().out.splitlines() if line.startswith("host_orch")]
+    # The cold bind is the truncated one, which no row describes, so the two
+    # intact binds are both warm rather than one of them standing in for it.
+    assert len(rows) == 1
+    assert "warm" in rows[0]
+    assert "2100.0" not in rows[0]  # median of 2000 and 2100, not one of them alone
+
+
+def test_a_truncated_attribute_string_is_reported_rather_than_computed_over(tmp_path, monkeypatch, capsys):
+    """The logger caps the attribute field and marks a cut with `~`.
+
+    A counter it cut is absent, not zero, so the row is excluded and counted — a
+    figure derived from a missing counter would be a guess, and treating the
+    absence as 0 would read as a segment that took no CPU.
+    """
+    log = tmp_path / "run.log"
+    log.write_text(
+        _span("host_orch", 2_000_000, 1_500_000, 0, pid=7, inv=1)
+        + _span("host_orch", 2_000_000, 1_400_000, 0, pid=7, inv=2)
+        + "[STRACE] v=1 pid=7 tid=7 inv=3 hid=abc depth=2 name=chip.run.bind.host_orch ts=9000 dur=2000000 "
+        "minflt=1 tminflt=1 nivcsw=0 nvcsw=0 cpu_ns=1500000 rec_cpu~\n"
+    )
+    monkeypatch.setattr("sys.argv", ["phase_time_split", str(log)])
+
+    phase_time_split.main()
+
+    output = capsys.readouterr().out
+    assert "1 span(s) had a truncated attribute string" in output
+    assert len([line for line in output.splitlines() if "host_orch" in line]) == 2
 
 
 def test_off_cpu_is_the_wall_the_bind_thread_did_not_run():
@@ -151,7 +218,10 @@ def test_medians_are_taken_per_bind_not_across_columns():
 def test_a_log_without_the_cpu_counters_is_refused(tmp_path, monkeypatch):
     """Refusing beats printing zeros: a pre-counters log would read as all-on-CPU."""
     log = tmp_path / "run.log"
-    log.write_text("[TIMING] bind phase=host_orch start_ns=1000 dur_ns=2000 minflt=1 nivcsw=0 nvcsw=0\n")
+    log.write_text(
+        "[STRACE] v=1 pid=7 tid=7 inv=1 hid=abc depth=2 name=chip.run.bind.host_orch ts=1000 dur=2000 "
+        "minflt=1 nivcsw=0 nvcsw=0\n"
+    )
     monkeypatch.setattr("sys.argv", ["phase_time_split", str(log)])
 
     with pytest.raises(SystemExit) as exit_info:
@@ -174,10 +244,11 @@ def test_a_log_with_no_markers_at_all_is_refused(tmp_path, monkeypatch):
 def test_cold_and_warm_are_reported_separately(tmp_path, monkeypatch, capsys):
     log = tmp_path / "run.log"
     log.write_text(
-        _marker("host_orch", 4_000_000, 3_000_000, 0)  # cold, one per rank
-        + _marker("host_orch", 4_000_000, 3_000_000, 0)
-        + _marker("host_orch", 1_000_000, 900_000, 0)
-        + _marker("host_orch", 1_000_000, 900_000, 0)
+        # Two ranks; each rank's earliest bind is its warm-up.
+        _span("host_orch", 4_000_000, 3_000_000, 0, pid=7, inv=1, ts=1_000)
+        + _span("host_orch", 4_000_000, 3_000_000, 0, pid=8, inv=1, ts=1_100)
+        + _span("host_orch", 1_000_000, 900_000, 0, pid=7, inv=2, ts=9_000)
+        + _span("host_orch", 1_000_000, 900_000, 0, pid=8, inv=2, ts=9_100)
     )
     monkeypatch.setattr("sys.argv", ["phase_time_split", str(log)])
 

--- a/tests/ut/py/test_strace_timing.py
+++ b/tests/ut/py/test_strace_timing.py
@@ -1039,10 +1039,10 @@ def test_host_record_spans_nest_bind_segments_and_orchestrator_operations(tmp_pa
         }
     ]
 
-    out, orphaned, covered = host_record_spans(spans, passes)
+    out, orphaned, skipped = host_record_spans(spans, passes)
 
     assert orphaned == 0
-    assert covered == frozenset({(9, 5)})
+    assert skipped == 0
     by_name = {span.name: span for span in out}
     bind_depth = spans[0].depth
     assert by_name["chip.run.bind.args"].depth == bind_depth + 1
@@ -1126,11 +1126,67 @@ def test_host_record_spans_drop_passes_with_no_matching_bind(tmp_path):
     spans = list(parse_spans([_span_record(pid=9, tid=9, inv=5, name="chip.run.bind", ts=1_000, dur=500)]))
     passes = [{"pid": 9, "inv": 999, "records": [{"phase": "args", "start_ns": 1_000, "end_ns": 1_100}]}]
 
-    out, orphaned, covered = host_record_spans(spans, passes)
+    out, orphaned, skipped = host_record_spans(spans, passes)
 
     assert out == []
     assert orphaned == 1
-    assert covered == frozenset()
+    assert skipped == 0
+
+
+def test_a_bind_segment_the_log_already_carries_is_not_drawn_twice(tmp_path):
+    """Both channels describe the same segment, and the log's copy is the one kept.
+
+    The runtime emits each bind segment as a span, and that span carries the
+    segment's own attributes — byte counts, fault and CPU counters — where the
+    artifact record carries only `detail`. Drawing both would put two bars on one
+    interval, and keeping the artifact's would lose the attributes.
+    """
+    spans = list(
+        parse_spans(
+            [
+                _span_record(pid=9, tid=9, inv=5, name="chip.run.bind", ts=1_000, dur=500),
+                _span_record(
+                    pid=9, tid=9, inv=5, name="chip.run.bind.args", ts=1_000, dur=100, depth=2, attrs="bytes=4096"
+                ),
+            ]
+        )
+    )
+    passes = [
+        {
+            "pid": 9,
+            "inv": 5,
+            "records": [
+                {"phase": "args", "start_ns": 1_000, "end_ns": 1_100, "detail": 4096, "tid": 9},
+                {"phase": "graph_submit", "start_ns": 1_200, "end_ns": 1_250, "detail": 77, "tid": 9},
+            ],
+        }
+    ]
+
+    out, orphaned, skipped = host_record_spans(spans, passes)
+
+    assert orphaned == 0
+    assert skipped == 1
+    assert [span.name for span in out] == ["chip.run.bind.host_orch.graph_submit"]
+
+    drawn = [span for span in spans + out if span.name == "chip.run.bind.args"]
+    assert len(drawn) == 1
+    assert "bytes=4096" in drawn[0].attrs
+
+
+def test_a_bind_segment_only_the_artifact_has_is_still_drawn():
+    """A run may collect records without emitting the segments' spans.
+
+    The breakdown switch and the record pool are separate conditions, so a
+    chip-swimlane capture arms the pool with the switch off. Then the artifact is
+    the only source for the segments and must still be admitted.
+    """
+    spans = list(parse_spans([_span_record(pid=9, tid=9, inv=5, name="chip.run.bind", ts=1_000, dur=500)]))
+    passes = [{"pid": 9, "inv": 5, "records": [{"phase": "args", "start_ns": 1_000, "end_ns": 1_100, "tid": 9}]}]
+
+    out, orphaned, skipped = host_record_spans(spans, passes)
+
+    assert (orphaned, skipped) == (0, 0)
+    assert [span.name for span in out] == ["chip.run.bind.args"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`[STRACE]` is the host's timeline format — one record per interval, and every view in `strace_timing.py` is built from it. `host_build_graph`'s bind breakdown was the one interval-shaped data that stopped short of it, going out as `bind phase=<p> start_ns=<n> dur_ns=<n>` `LOG_TIMING` lines: a second timeline format with its own regex, its own two tools, and 44 lines of span synthesis to put it back on the timeline it was already on.

Each segment is now `chip.run.bind.<segment>` at depth 2, emitted from the same end-of-bind flush inside the `STRACE("chip.run.bind")` scope, so `(inv, hid)` and the depth are right by construction.

- **Two dead kinds go first.** `BindRelocate` / `BindSmH2d` have no recording site in either arch; they showed up in every report as "absent from every bind". Three places also disagreed about how many bind kinds exist (12 / 12 / 11 — a run emits 10), and they do not partition the stage: the gap between one segment closing and the next opening belongs to neither.
- **A bind is `(pid, inv)`.** `hbg_bind_phases` loses ~100 lines whose only purpose was inventing that key — the repeated-segment-name grouping, `--ranks`/`--rounds` back-inference, the ragged-bind warning, the "do not close on `arena_h2d`" trap. Its docstring said *"there is no field to group by instead"*; a span has two, so concurrent ranks interleaving one stream now separate exactly.
- **`--tree` and the TPOT table show the segments with no flag and no artifact.** The empty `chip.run.bind` bar is populated.
- **The gate does not change.** `SIMPLER_HBG_BIND_BREAKDOWN_ENABLE` stays default-off on purpose: `TraceState::active` is one flag serving two consumers, so arming the segments also arms every per-task `ORCH_PHASE_*` hook (~3700 extra clock reads inside the `host_orch` segment being measured on dsv4). This change is about the format, not the default — default output volume is unchanged at zero.
- **Dedup inverts.** `host_record_spans` keeps its bind branch (a chip-swimlane capture arms the pool with the switch off, and is then the only source), but the log's span now wins: it carries the segment's attributes where an artifact record carries only `detail`.
- **The attribute buffer is now the span field's own width** (was 256 against 192, so an overlong segment truncated twice — once unmarked). The kernel counters are formatted first, so a truncation eats a quantity the artifact still has rather than a counter `phase_time_split` cannot work without.

Three docs stated the opposite design as an invariant (*"the marker grammar is a fixed per-run-stage contract, and a runtime's internal breakdown of one stage does not belong in it"*). They are rewritten, because the tree already contradicts the premise three ways: the tensormap runtime subdivides its own bind stage with `chip.run.bind.args` / `.prebuilt`, the device sub-phases are that runtime's internal breakdown at depth 3, and `ext.` opened the namespace to producers outside this repo.

`tests/ut/py/test_host_timing_is_strace_only.py` pins the invariant: no `LOG_TIMING` format string in `src/` may carry a start timestamp. It carries its own positive control and a case proving it can go red. The summed `host-orch phase=` cost shares stay `LOG_TIMING` lines — kinds that nest inside each other have no honest position on a timeline.

The three `grep -c 'bind phase='` acceptance gates in the `hbg-bind-phases` skill move to the span pattern in the same change; leaving them would make every future invocation report a working run as "no data".

## Testing

- [x] `pytest tests/ut -m "not requires_hardware"` — 2125 passed, 7 skipped
- [x] cpput — 134/134 passed (clean build)
- [x] Simulation tests pass — `native_run_lifecycle` + `graph_execution` on `a2a3sim`; runtimes build for a2a3 / a5 / a2a3sim / a5sim
- [x] End to end on `a2a3sim` with the breakdown on: ten segments at depth 2 with `ts`/`dur` inside the enclosing `chip.run.bind`, attributes complete with no `~`; `hbg_bind_phases` reporting `2 binds, 1 warm` with no rank or round argument; `phase_time_split` splitting all ten including `arena_h2d`; `--swimlane --host-phase-records` drawing each segment exactly once (`10 segment(s) already in the log`)
- [ ] **Hardware tests not run.** The `hbg-bind-phases` skill's two modes on the qwen and dsv4 decode cases, and the before/after control-plane comparison, need 1–2 h of NPU time and have not been done. The numbers this change could perturb are the ones that recipe reads, so it is worth running before merge.

One item from the plan was dropped deliberately: a scene-test assertion on real data. `host_phase_breakdown_enabled()` caches in a `static const bool`, so flipping the env in-process does nothing, and automating it needs a subprocess — which inside a scene test would re-enter the same test method. The contract is covered by the sim verification above plus `test_strace_timing.py`'s synthetic cases; depth / `(inv, hid)` / truncation on real data stay a manual check in the skill's recipe, whose gates this change already updated.
