### PR TITLE
examples: add standalone Qwen3 TMR decode benchmark

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/README.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/README.md
@@ -1,0 +1,83 @@
+# Qwen3-14B Standalone TMR Decode
+
+This example runs the post-prefill Qwen3-14B decode workload directly through
+Simpler's `tensormap_and_ringbuffer` runtime. It never imports or starts
+Serving. A fixture contains the KV snapshot and golden metadata produced by
+one prefill; each run restores that snapshot and executes the consumed 127
+decode dispatches. The `single` and `dual` modes are separate Python entry
+points so the dual-slot pipeline cannot change the single-slot execution
+layout.
+
+## Running
+
+`run_standalone_0p1.sh` is environment-driven so it can be used with a local
+checkout, a CI worker, or a `task-submit` command. Supply the device and
+output directory as positional arguments, and select `single` or `dual` as the
+optional third argument:
+
+```bash
+PYTHON_BIN=/path/to/python \
+PYPTO_ROOT=/path/to/pypto \
+PYPTO_LIB_ROOT=/path/to/pypto-lib \
+PTOAS_ROOT=/path/to/ptoas \
+FIXTURE_ROOT=/path/to/fixture/qualification \
+MODEL_DIR=/path/to/Qwen3-14B \
+ARTIFACT_SOURCE=/path/to/artifact/qualification \
+bash run_standalone_0p1.sh DEVICE_ID OUTPUT_DIR [single|dual] [STEPS]
+```
+
+The default is a zero-warmup, one-measured-run qualification. `STEPS` defaults
+to 127 and may be reduced for a fast validation run. The caller owns output
+and input locations; no private absolute paths are embedded in this case.
+
+Required environment variables are `PYTHON_BIN`, `PYPTO_ROOT`,
+`PYPTO_LIB_ROOT`, `PTOAS_ROOT`, `FIXTURE_ROOT`, `MODEL_DIR`, and
+`ARTIFACT_SOURCE`. No `pypto-serving` path is required at runtime, and the
+large KV/artifact payloads are deliberately kept outside the source repository.
+
+## Reproducibility
+
+`stack_manifest.json` records the exact software and input contract used to
+produce the reference fixture and artifact. The reference stack is Simpler
+`56511f80`, PyPTO `f1a2f35f`, pypto-lib `7f8d7ea8`, Python 3.10, torch/torch-npu
+2.6, CANN 9.0 and PTOAS 0.57. Reproduce those versions when comparing against
+the frozen numbers; regenerate the artifact when using a different PyPTO or
+pypto-lib ABI.
+
+The case fixes batch size 16, 127 consumed decode dispatches, steady skip 5,
+ring task/dependency capacity 131072, and ring heaps 1/1/1/8 GiB. Every output
+token is checked against the fixture golden before the run succeeds.
+
+Dual mode keeps immutable weights, RoPE and the autoregressive KV cache shared.
+It uses separate metadata, logits and next-hidden buffers for the two in-flight
+frames. The dual validator requires strict native slot 0/1 alternation,
+independent per-slot generations, prepared dispatches after the first frame,
+serialized device execution and an exact full-output golden SHA.
+
+## Metrics
+
+- `effective_ms`: `chip.run.runner_run.device_wall.sched` for each decode
+  dispatch. The steady set contains 122 rows after skipping the first five.
+- `rts_completion_interval_ms`: consecutive `chip.run` completion timestamps
+  within the decode sequence. This is the standalone decode TPOT proxy, not a
+  full Serving request TPOT.
+- `runner_run_ms`: host child span around the runtime call.
+
+`trace_summary.json` contains aggregate statistics. The native Simpler STRACE
+log is exported to `profile/simpler_strace_timeline.json`, which can be opened
+by Perfetto.
+
+## Correctness Contract
+
+A successful run requires:
+
+- 127 decode dispatches on the selected slot(s);
+- monotonically increasing generation and completion order;
+- every sampled token matching the 127-step golden;
+- the first decode input matching the fixture's prefill token;
+- fixture, model and artifact checksum validation before device execution;
+- native device STRACE phases present and alignable to their host invocation.
+
+The scripts are a hardware benchmark entry point rather than a default CI
+scene test. Preserve the generated `benchmark.json`, `trace_summary.json`,
+timeline and `SHA256SUMS` files with each result.

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/benchmark.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/benchmark.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Run Serving-equivalent Qwen decode directly through Simpler."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import importlib.util
+import json
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+
+
+BATCH = 16
+STEPS = 127
+SAMPLED_IDS_PAD = 8
+HIDDEN = 5120
+PADDED_VOCAB = 152064
+RING_TASK_WINDOW = 131072
+RING_DEP_POOL = 131072
+RING_HEAP = [1073741824, 1073741824, 1073741824, 8589934592]
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    here = Path(__file__).resolve().parent
+    parser.add_argument("--fixture", type=Path, required=True)
+    parser.add_argument("--model-dir", type=Path, required=True)
+    parser.add_argument("--artifact-work-dir", type=Path, required=True)
+    parser.add_argument("--artifact-source", type=Path)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--mode", choices=("single", "dual"), required=True)
+    parser.add_argument("--device-id", type=int, default=0)
+    parser.add_argument("--warmup-runs", type=int, default=1)
+    parser.add_argument("--measured-runs", type=int, default=5)
+    parser.add_argument("--steady-skip", type=int, default=5)
+    parser.add_argument("--inter-run-wait", type=float, default=5.0)
+    parser.add_argument("--profile-only", action="store_true")
+    parser.add_argument("--qualification-steps", type=int)
+    parser.add_argument("--fixture-module", type=Path, default=here / "fixture.py")
+    parser.add_argument("--weights-module", type=Path, default=here / "weights.py")
+    return parser.parse_args()
+
+
+def _base_name(name: str) -> str:
+    return name.split("__ssa_", 1)[0]
+
+
+def _shared_slot_state(fixture: Any) -> list[dict[str, torch.Tensor]]:
+    block_table = fixture.metadata["block_table"].reshape(-1)
+    slots = []
+    for _ in range(2):
+        slots.append(
+            {
+                "seq_lens": fixture.metadata["seq_lens_after_first_token"]
+                .clone()
+                .share_memory_(),
+                "block_table": block_table.clone().share_memory_(),
+                "initial_block_table": block_table.clone(),
+                "slot_mapping": fixture.metadata["next_slot_mapping"]
+                .clone()
+                .share_memory_(),
+                "sampled_ids_host": torch.zeros(
+                    (BATCH, SAMPLED_IDS_PAD), dtype=torch.int32
+                ).share_memory_(),
+            }
+        )
+    return slots
+
+
+def _update_slot(
+    slot: dict[str, torch.Tensor], golden: dict[str, torch.Tensor], step: int
+) -> None:
+    slot["seq_lens"].copy_(golden["seq_lens"][step])
+    slot["slot_mapping"].copy_(golden["slot_mapping"][step])
+    positions = slot["seq_lens"] - 1
+    if not torch.equal(slot["slot_mapping"].remainder(128), positions.remainder(128)):
+        raise RuntimeError(f"slot mapping offset mismatch at decode step {step}")
+    logical_blocks = positions.div(128, rounding_mode="floor")
+    page_ids = slot["slot_mapping"].div(128, rounding_mode="floor")
+    for row in range(BATCH):
+        slot["block_table"][row * 32 + int(logical_blocks[row])] = page_ids[row]
+    slot["sampled_ids_host"].zero_()
+
+
+def _ordered_args(param_names: list[str], values: dict[str, Any]) -> tuple[Any, ...]:
+    missing = [name for name in param_names if name not in values]
+    if missing:
+        raise ValueError(f"decode artifact parameters have no runtime value: {missing}")
+    return tuple(values[name] for name in param_names)
+
+
+def _run_sequence(
+    *,
+    rt: Any,
+    compiled: Any,
+    run_config: Any,
+    param_names: list[str],
+    resident: dict[str, Any],
+    slots: list[dict[str, torch.Tensor]],
+    golden: dict[str, torch.Tensor],
+    mode: str,
+    steps: int,
+    sampled_ids_host_abi: bool,
+) -> dict[str, Any]:
+    initial_host = torch.zeros((BATCH, SAMPLED_IDS_PAD), dtype=torch.int32)
+    initial_host[:, 0] = golden["decode_input_token_ids"][0]
+    rt.copy_to(
+        resident["initial_tokens"].data_ptr,
+        initial_host.data_ptr(),
+        initial_host.nbytes,
+    )
+    for slot in slots:
+        slot["block_table"].copy_(slot["initial_block_table"])
+    completions = []
+    token_rows: list[list[int]] = []
+    started = time.perf_counter()
+
+    def read_sampled_ids(slot_id: int, step: int) -> list[int]:
+        if sampled_ids_host_abi:
+            host = slots[slot_id]["sampled_ids_host"]
+        else:
+            host = torch.empty((BATCH, SAMPLED_IDS_PAD), dtype=torch.int32)
+            rt.copy_from(
+                host.data_ptr(),
+                resident["sampled"][step % 2].data_ptr,
+                host.nbytes,
+            )
+        return [int(value) for value in host[:, 0].tolist()]
+
+    def submit(step: int):
+        slot_id = 0 if mode == "single" else step % 2
+        _update_slot(slots[slot_id], golden, step)
+        token_input = (
+            resident["initial_tokens"]
+            if step == 0
+            else resident["sampled"][(step - 1) % 2]
+        )
+        values = {
+            **resident["weights"],
+            **slots[slot_id],
+            "rope_cos": resident["rope_cos"],
+            "rope_sin": resident["rope_sin"],
+            "k_cache": resident["k_cache"],
+            "v_cache": resident["v_cache"],
+            "out": resident["out"],
+            "sampled_ids_in": token_input,
+            "sampled_ids": resident["sampled"][step % 2],
+            "next_hidden": resident["next_hidden"],
+        }
+        return slot_id, rt.submit(
+            compiled,
+            *_ordered_args(param_names, values),
+            config=run_config,
+        )
+
+    if mode == "single":
+        for step in range(steps):
+            slot_id, handle = submit(step)
+            handle.result()
+            completions.append(time.perf_counter())
+            row = read_sampled_ids(slot_id, step)
+            token_rows.append(row)
+    else:
+        pending = []
+        for step in range(min(2, steps)):
+            slot_id, handle = submit(step)
+            pending.append((step, slot_id, handle))
+        next_step = 2
+        while pending:
+            step, slot_id, handle = pending.pop(0)
+            handle.result()
+            completions.append(time.perf_counter())
+            row = read_sampled_ids(slot_id, step)
+            token_rows.append(row)
+            if next_step < steps:
+                next_slot, next_handle = submit(next_step)
+                pending.append((next_step, next_slot, next_handle))
+                next_step += 1
+
+    expected = golden["decode_output_token_ids"][:steps].tolist()
+    if token_rows != expected:
+        for step, (actual, wanted) in enumerate(zip(token_rows, expected, strict=True)):
+            if actual != wanted:
+                raise RuntimeError(f"golden token mismatch at decode step {step}")
+        raise RuntimeError("golden token sequence mismatch")
+    intervals = [
+        (right - left) * 1000.0 for left, right in zip(completions, completions[1:])
+    ]
+    return {
+        "wall_s": time.perf_counter() - started,
+        "completion_intervals_ms": intervals,
+        "token_rows": token_rows,
+        "valid": True,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.qualification_steps is not None:
+        if args.profile_only or not 1 <= args.qualification_steps <= STEPS:
+            raise ValueError(
+                "qualification_steps must be in [1, 127] and cannot profile"
+            )
+        args.warmup_runs = 0
+        args.measured_runs = 1
+        args.inter_run_wait = 0.0
+        decode_steps = args.qualification_steps
+    elif args.profile_only:
+        if args.warmup_runs != 1:
+            raise ValueError("profile-only requires one complete warmup sequence")
+        args.measured_runs = 1
+        decode_steps = STEPS
+    elif args.warmup_runs != 1 or args.measured_runs != 5:
+        raise ValueError("formal execution requires exactly 1 warmup + 5 measured runs")
+    else:
+        decode_steps = STEPS
+    if args.output_dir.exists():
+        raise FileExistsError(args.output_dir)
+    args.output_dir.mkdir(parents=True)
+
+    fixture_module = _load_module(
+        args.fixture_module.resolve(), "_serving_effective_fixture"
+    )
+    weights_module = _load_module(
+        args.weights_module.resolve(), "_serving_effective_weights"
+    )
+    fixture = fixture_module.load_fixture(
+        args.fixture,
+        expected_versions=None,
+    )
+    fixture.require_executable()
+    fixture.verify_external_inputs(args.model_dir.resolve())
+    golden = fixture.load_golden()
+
+    artifact_source = (args.artifact_source or fixture.artifact_dir).resolve()
+    artifact_manifest = json.loads((artifact_source / "manifest.json").read_text())
+    if args.artifact_work_dir.exists():
+        raise FileExistsError(args.artifact_work_dir)
+    shutil.copytree(artifact_source, args.artifact_work_dir)
+    decode_dir = (
+        args.artifact_work_dir / artifact_manifest["programs"]["decode"]["path"]
+    )
+    distributed_meta = json.loads((decode_dir / "distributed_meta.json").read_text())
+    param_names = [_base_name(param["name"]) for param in distributed_meta["params"]]
+    if len(param_names) not in {25, 26}:
+        raise ValueError(f"unsupported decode ABI with {len(param_names)} parameters")
+    sampled_ids_host_abi = "sampled_ids_host" in param_names
+
+    from pypto.ir.distributed_compiled_program import (
+        DistributedCompiledProgram,
+        DistributedConfig,
+    )
+    from pypto.runtime import RunConfig
+
+    distributed = DistributedConfig(
+        device_ids=[args.device_id],
+        runtime="tensormap_and_ringbuffer",
+        aicpu_thread_num=int(
+            distributed_meta["distributed_config"]["aicpu_thread_num"]
+        ),
+    )
+    compiled = DistributedCompiledProgram.from_dir(
+        decode_dir,
+        platform="a2a3",
+        distributed_config=distributed,
+    )
+    run_config = RunConfig(
+        platform="a2a3",
+        device_id=args.device_id,
+        ring_task_window=RING_TASK_WINDOW,
+        ring_dep_pool=RING_DEP_POOL,
+        ring_heap=RING_HEAP,
+    )
+    slots = _shared_slot_state(fixture)
+
+    with compiled.prepare(config=run_config) as rt:
+        device_weights = {}
+        for name, host in weights_module.iter_kernel_weights(args.model_dir.resolve()):
+            device_weights[name] = rt.alloc_tensor(
+                tuple(host.shape), host.dtype, init=host
+            )
+            del host
+            gc.collect()
+        rope_cos_host, rope_sin_host = weights_module.rope_tables(
+            args.model_dir.resolve()
+        )
+        rope_cos = rt.alloc_tensor(
+            tuple(rope_cos_host.shape), rope_cos_host.dtype, init=rope_cos_host
+        )
+        rope_sin = rt.alloc_tensor(
+            tuple(rope_sin_host.shape), rope_sin_host.dtype, init=rope_sin_host
+        )
+        del rope_cos_host, rope_sin_host
+        k_cache = fixture.allocate_kv(rt, "key")
+        v_cache = fixture.allocate_kv(rt, "value")
+        resident = {
+            "weights": device_weights,
+            "rope_cos": rope_cos,
+            "rope_sin": rope_sin,
+            "k_cache": k_cache,
+            "v_cache": v_cache,
+            "out": rt.alloc_tensor((BATCH, PADDED_VOCAB), torch.float32),
+            "next_hidden": rt.alloc_tensor((BATCH, HIDDEN), torch.bfloat16),
+            "initial_tokens": rt.alloc_tensor((BATCH, SAMPLED_IDS_PAD), torch.int32),
+            "sampled": [
+                rt.alloc_tensor((BATCH, SAMPLED_IDS_PAD), torch.int32),
+                rt.alloc_tensor((BATCH, SAMPLED_IDS_PAD), torch.int32),
+            ],
+        }
+        runs = []
+        for kind, count in (
+            ("warmup", args.warmup_runs),
+            ("measured", args.measured_runs),
+        ):
+            for run_index in range(count):
+                result = _run_sequence(
+                    rt=rt,
+                    compiled=compiled,
+                    run_config=run_config,
+                    param_names=param_names,
+                    resident=resident,
+                    slots=slots,
+                    golden=golden,
+                    mode=args.mode,
+                    steps=decode_steps,
+                    sampled_ids_host_abi=sampled_ids_host_abi,
+                )
+                result.update({"kind": kind, "run": run_index + 1})
+                runs.append(result)
+                is_last = kind == "measured" and run_index + 1 == count
+                if not is_last:
+                    time.sleep(args.inter_run_wait)
+
+    output = {
+        "schema": 1,
+        "campaign_kind": (
+            "qualification"
+            if args.qualification_steps is not None
+            else "diagnostic_profiling"
+            if args.profile_only
+            else "formal_performance"
+        ),
+        "official_performance": not args.profile_only
+        and args.qualification_steps is None,
+        "scenario": {
+            "runtime": "tensormap_and_ringbuffer",
+            "mode": args.mode,
+            "batch_size": BATCH,
+            "decode_dispatches": decode_steps,
+            "warmup_runs": args.warmup_runs,
+            "measured_runs": args.measured_runs,
+            "retain_all_measured_runs": True,
+            "steady_skip_dispatches": args.steady_skip,
+            "inter_run_wait_s": args.inter_run_wait,
+            "fixture": str(fixture.root),
+            "fixture_artifact_source": str(fixture.artifact_dir),
+            "artifact_source": str(artifact_source),
+            "artifact_work_dir": str(args.artifact_work_dir),
+            "ring_task_window": RING_TASK_WINDOW,
+            "ring_dep_pool": RING_DEP_POOL,
+            "ring_heap": RING_HEAP,
+            "kv_reuse": "decode positions are overwritten before attention reads them",
+        },
+        "runs": runs,
+        "correctness": {
+            "all_runs_valid": all(run["valid"] for run in runs),
+            "cross_run_tokens_identical": len(
+                {json.dumps(run["token_rows"]) for run in runs}
+            )
+            == 1,
+            "golden_tokens_identical": True,
+        },
+    }
+    (args.output_dir / "benchmark.json").write_text(
+        json.dumps(output, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/benchmark.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/benchmark.py
@@ -77,6 +77,7 @@ def _shared_slot_state(fixture: Any) -> list[dict[str, torch.Tensor]]:
                 "seq_lens": fixture.metadata["seq_lens_after_first_token"].clone().share_memory_(),
                 "block_table": block_table.clone().share_memory_(),
                 "initial_block_table": block_table.clone(),
+                "page_size": torch.tensor(int(fixture.manifest["physical_layout"]["page_size"])),
                 "slot_mapping": fixture.metadata["next_slot_mapping"].clone().share_memory_(),
                 "sampled_ids_host": torch.zeros((BATCH, SAMPLED_IDS_PAD), dtype=torch.int32).share_memory_(),
             }
@@ -84,16 +85,25 @@ def _shared_slot_state(fixture: Any) -> list[dict[str, torch.Tensor]]:
     return slots
 
 
-def _update_slot(slot: dict[str, torch.Tensor], golden: dict[str, torch.Tensor], step: int) -> None:
+def _update_slot(
+    slot: dict[str, torch.Tensor],
+    golden: dict[str, torch.Tensor],
+    step: int,
+) -> None:
     slot["seq_lens"].copy_(golden["seq_lens"][step])
     slot["slot_mapping"].copy_(golden["slot_mapping"][step])
     positions = slot["seq_lens"] - 1
-    if not torch.equal(slot["slot_mapping"].remainder(128), positions.remainder(128)):
+    page_size = int(slot["page_size"])
+    if not torch.equal(
+        slot["slot_mapping"].remainder(page_size),
+        positions.remainder(page_size),
+    ):
         raise RuntimeError(f"slot mapping offset mismatch at decode step {step}")
-    logical_blocks = positions.div(128, rounding_mode="floor")
-    page_ids = slot["slot_mapping"].div(128, rounding_mode="floor")
+    logical_blocks = positions.div(page_size, rounding_mode="floor")
+    page_ids = slot["slot_mapping"].div(page_size, rounding_mode="floor")
+    block_table_stride = slot["block_table"].numel() // BATCH
     for row in range(BATCH):
-        slot["block_table"][row * 32 + int(logical_blocks[row])] = page_ids[row]
+        slot["block_table"][row * block_table_stride + int(logical_blocks[row])] = page_ids[row]
     slot["sampled_ids_host"].zero_()
 
 

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/benchmark.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/benchmark.py
@@ -23,7 +23,6 @@ from typing import Any
 
 import torch
 
-
 BATCH = 16
 STEPS = 127
 SAMPLED_IDS_PAD = 8
@@ -75,25 +74,17 @@ def _shared_slot_state(fixture: Any) -> list[dict[str, torch.Tensor]]:
     for _ in range(2):
         slots.append(
             {
-                "seq_lens": fixture.metadata["seq_lens_after_first_token"]
-                .clone()
-                .share_memory_(),
+                "seq_lens": fixture.metadata["seq_lens_after_first_token"].clone().share_memory_(),
                 "block_table": block_table.clone().share_memory_(),
                 "initial_block_table": block_table.clone(),
-                "slot_mapping": fixture.metadata["next_slot_mapping"]
-                .clone()
-                .share_memory_(),
-                "sampled_ids_host": torch.zeros(
-                    (BATCH, SAMPLED_IDS_PAD), dtype=torch.int32
-                ).share_memory_(),
+                "slot_mapping": fixture.metadata["next_slot_mapping"].clone().share_memory_(),
+                "sampled_ids_host": torch.zeros((BATCH, SAMPLED_IDS_PAD), dtype=torch.int32).share_memory_(),
             }
         )
     return slots
 
 
-def _update_slot(
-    slot: dict[str, torch.Tensor], golden: dict[str, torch.Tensor], step: int
-) -> None:
+def _update_slot(slot: dict[str, torch.Tensor], golden: dict[str, torch.Tensor], step: int) -> None:
     slot["seq_lens"].copy_(golden["seq_lens"][step])
     slot["slot_mapping"].copy_(golden["slot_mapping"][step])
     positions = slot["seq_lens"] - 1
@@ -154,11 +145,7 @@ def _run_sequence(
     def submit(step: int):
         slot_id = 0 if mode == "single" else step % 2
         _update_slot(slots[slot_id], golden, step)
-        token_input = (
-            resident["initial_tokens"]
-            if step == 0
-            else resident["sampled"][(step - 1) % 2]
-        )
+        token_input = resident["initial_tokens"] if step == 0 else resident["sampled"][(step - 1) % 2]
         values = {
             **resident["weights"],
             **slots[slot_id],
@@ -185,7 +172,7 @@ def _run_sequence(
             row = read_sampled_ids(slot_id, step)
             token_rows.append(row)
     else:
-        pending = []
+        pending: list[tuple[int, int, Any]] = []
         for step in range(min(2, steps)):
             slot_id, handle = submit(step)
             pending.append((step, slot_id, handle))
@@ -201,15 +188,15 @@ def _run_sequence(
                 pending.append((next_step, next_slot, next_handle))
                 next_step += 1
 
-    expected = golden["decode_output_token_ids"][:steps].tolist()
+    expected: list[list[int]] = golden["decode_output_token_ids"][:steps].tolist()
     if token_rows != expected:
-        for step, (actual, wanted) in enumerate(zip(token_rows, expected, strict=True)):
+        if len(token_rows) != len(expected):
+            raise RuntimeError("golden token sequence length mismatch")
+        for step, (actual, wanted) in enumerate(zip(token_rows, expected)):
             if actual != wanted:
                 raise RuntimeError(f"golden token mismatch at decode step {step}")
         raise RuntimeError("golden token sequence mismatch")
-    intervals = [
-        (right - left) * 1000.0 for left, right in zip(completions, completions[1:])
-    ]
+    intervals = [(right - left) * 1000.0 for left, right in zip(completions, completions[1:])]
     return {
         "wall_s": time.perf_counter() - started,
         "completion_intervals_ms": intervals,
@@ -222,9 +209,7 @@ def main() -> int:
     args = _parse_args()
     if args.qualification_steps is not None:
         if args.profile_only or not 1 <= args.qualification_steps <= STEPS:
-            raise ValueError(
-                "qualification_steps must be in [1, 127] and cannot profile"
-            )
+            raise ValueError("qualification_steps must be in [1, 127] and cannot profile")
         args.warmup_runs = 0
         args.measured_runs = 1
         args.inter_run_wait = 0.0
@@ -242,12 +227,8 @@ def main() -> int:
         raise FileExistsError(args.output_dir)
     args.output_dir.mkdir(parents=True)
 
-    fixture_module = _load_module(
-        args.fixture_module.resolve(), "_serving_effective_fixture"
-    )
-    weights_module = _load_module(
-        args.weights_module.resolve(), "_serving_effective_weights"
-    )
+    fixture_module = _load_module(args.fixture_module.resolve(), "_serving_effective_fixture")
+    weights_module = _load_module(args.weights_module.resolve(), "_serving_effective_weights")
     fixture = fixture_module.load_fixture(
         args.fixture,
         expected_versions=None,
@@ -261,27 +242,23 @@ def main() -> int:
     if args.artifact_work_dir.exists():
         raise FileExistsError(args.artifact_work_dir)
     shutil.copytree(artifact_source, args.artifact_work_dir)
-    decode_dir = (
-        args.artifact_work_dir / artifact_manifest["programs"]["decode"]["path"]
-    )
+    decode_dir = args.artifact_work_dir / artifact_manifest["programs"]["decode"]["path"]
     distributed_meta = json.loads((decode_dir / "distributed_meta.json").read_text())
     param_names = [_base_name(param["name"]) for param in distributed_meta["params"]]
     if len(param_names) not in {25, 26}:
         raise ValueError(f"unsupported decode ABI with {len(param_names)} parameters")
     sampled_ids_host_abi = "sampled_ids_host" in param_names
 
-    from pypto.ir.distributed_compiled_program import (
+    from pypto.ir.distributed_compiled_program import (  # noqa: PLC0415 -- hardware-only dependency
         DistributedCompiledProgram,
         DistributedConfig,
     )
-    from pypto.runtime import RunConfig
+    from pypto.runtime import RunConfig  # noqa: PLC0415 -- hardware-only dependency
 
     distributed = DistributedConfig(
         device_ids=[args.device_id],
         runtime="tensormap_and_ringbuffer",
-        aicpu_thread_num=int(
-            distributed_meta["distributed_config"]["aicpu_thread_num"]
-        ),
+        aicpu_thread_num=int(distributed_meta["distributed_config"]["aicpu_thread_num"]),
     )
     compiled = DistributedCompiledProgram.from_dir(
         decode_dir,
@@ -300,20 +277,12 @@ def main() -> int:
     with compiled.prepare(config=run_config) as rt:
         device_weights = {}
         for name, host in weights_module.iter_kernel_weights(args.model_dir.resolve()):
-            device_weights[name] = rt.alloc_tensor(
-                tuple(host.shape), host.dtype, init=host
-            )
+            device_weights[name] = rt.alloc_tensor(tuple(host.shape), host.dtype, init=host)
             del host
             gc.collect()
-        rope_cos_host, rope_sin_host = weights_module.rope_tables(
-            args.model_dir.resolve()
-        )
-        rope_cos = rt.alloc_tensor(
-            tuple(rope_cos_host.shape), rope_cos_host.dtype, init=rope_cos_host
-        )
-        rope_sin = rt.alloc_tensor(
-            tuple(rope_sin_host.shape), rope_sin_host.dtype, init=rope_sin_host
-        )
+        rope_cos_host, rope_sin_host = weights_module.rope_tables(args.model_dir.resolve())
+        rope_cos = rt.alloc_tensor(tuple(rope_cos_host.shape), rope_cos_host.dtype, init=rope_cos_host)
+        rope_sin = rt.alloc_tensor(tuple(rope_sin_host.shape), rope_sin_host.dtype, init=rope_sin_host)
         del rope_cos_host, rope_sin_host
         k_cache = fixture.allocate_kv(rt, "key")
         v_cache = fixture.allocate_kv(rt, "value")
@@ -364,8 +333,7 @@ def main() -> int:
             if args.profile_only
             else "formal_performance"
         ),
-        "official_performance": not args.profile_only
-        and args.qualification_steps is None,
+        "official_performance": not args.profile_only and args.qualification_steps is None,
         "scenario": {
             "runtime": "tensormap_and_ringbuffer",
             "mode": args.mode,
@@ -388,10 +356,7 @@ def main() -> int:
         "runs": runs,
         "correctness": {
             "all_runs_valid": all(run["valid"] for run in runs),
-            "cross_run_tokens_identical": len(
-                {json.dumps(run["token_rows"]) for run in runs}
-            )
-            == 1,
+            "cross_run_tokens_identical": len({json.dumps(run["token_rows"]) for run in runs}) == 1,
             "golden_tokens_identical": True,
         },
     }

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/benchmark_dual.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/benchmark_dual.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Run Serving-equivalent Qwen decode directly through Simpler."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import importlib.util
+import json
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+
+
+BATCH = 16
+STEPS = 127
+SAMPLED_IDS_PAD = 8
+HIDDEN = 5120
+PADDED_VOCAB = 152064
+RING_TASK_WINDOW = 131072
+RING_DEP_POOL = 131072
+RING_HEAP = [1073741824, 1073741824, 1073741824, 8589934592]
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    here = Path(__file__).resolve().parent
+    parser.add_argument("--fixture", type=Path, required=True)
+    parser.add_argument("--model-dir", type=Path, required=True)
+    parser.add_argument("--artifact-work-dir", type=Path, required=True)
+    parser.add_argument("--artifact-source", type=Path)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--mode", choices=("single", "dual"), required=True)
+    parser.add_argument("--device-id", type=int, default=0)
+    parser.add_argument("--warmup-runs", type=int, default=1)
+    parser.add_argument("--measured-runs", type=int, default=5)
+    parser.add_argument("--steady-skip", type=int, default=5)
+    parser.add_argument("--inter-run-wait", type=float, default=5.0)
+    parser.add_argument("--profile-only", action="store_true")
+    parser.add_argument("--qualification-steps", type=int)
+    parser.add_argument("--fixture-module", type=Path, default=here / "fixture.py")
+    parser.add_argument("--weights-module", type=Path, default=here / "weights.py")
+    return parser.parse_args()
+
+
+def _base_name(name: str) -> str:
+    return name.split("__ssa_", 1)[0]
+
+
+def _shared_slot_state(fixture: Any) -> list[dict[str, torch.Tensor]]:
+    block_table = fixture.metadata["block_table"].reshape(-1)
+    slots = []
+    for _ in range(2):
+        slots.append(
+            {
+                "seq_lens": fixture.metadata["seq_lens_after_first_token"]
+                .clone()
+                .share_memory_(),
+                "block_table": block_table.clone().share_memory_(),
+                "initial_block_table": block_table.clone(),
+                "slot_mapping": fixture.metadata["next_slot_mapping"]
+                .clone()
+                .share_memory_(),
+                "sampled_ids_host": torch.zeros(
+                    (BATCH, SAMPLED_IDS_PAD), dtype=torch.int32
+                ).share_memory_(),
+            }
+        )
+    return slots
+
+
+def _update_slot(
+    slot: dict[str, torch.Tensor], golden: dict[str, torch.Tensor], step: int
+) -> None:
+    slot["seq_lens"].copy_(golden["seq_lens"][step])
+    slot["slot_mapping"].copy_(golden["slot_mapping"][step])
+    positions = slot["seq_lens"] - 1
+    if not torch.equal(slot["slot_mapping"].remainder(128), positions.remainder(128)):
+        raise RuntimeError(f"slot mapping offset mismatch at decode step {step}")
+    logical_blocks = positions.div(128, rounding_mode="floor")
+    page_ids = slot["slot_mapping"].div(128, rounding_mode="floor")
+    for row in range(BATCH):
+        slot["block_table"][row * 32 + int(logical_blocks[row])] = page_ids[row]
+    slot["sampled_ids_host"].zero_()
+
+
+def _ordered_args(param_names: list[str], values: dict[str, Any]) -> tuple[Any, ...]:
+    missing = [name for name in param_names if name not in values]
+    if missing:
+        raise ValueError(f"decode artifact parameters have no runtime value: {missing}")
+    return tuple(values[name] for name in param_names)
+
+
+def _slot_value(value: Any, slot_id: int) -> Any:
+    return value[slot_id] if isinstance(value, list) else value
+
+
+def _sampled_value(resident: dict[str, Any], step: int, mode: str) -> Any:
+    index = step % 2 if mode == "single" else step
+    return resident["sampled"][index]
+
+
+def _run_sequence(
+    *,
+    rt: Any,
+    compiled: Any,
+    run_config: Any,
+    param_names: list[str],
+    resident: dict[str, Any],
+    slots: list[dict[str, torch.Tensor]],
+    golden: dict[str, torch.Tensor],
+    mode: str,
+    steps: int,
+    sampled_ids_host_abi: bool,
+) -> dict[str, Any]:
+    initial_host = torch.zeros((BATCH, SAMPLED_IDS_PAD), dtype=torch.int32)
+    initial_host[:, 0] = golden["decode_input_token_ids"][0]
+    rt.copy_to(
+        resident["initial_tokens"].data_ptr,
+        initial_host.data_ptr(),
+        initial_host.nbytes,
+    )
+    for slot in slots:
+        slot["block_table"].copy_(slot["initial_block_table"])
+    completions = []
+    token_rows: list[list[int]] = []
+    started = time.perf_counter()
+
+    def read_sampled_ids(slot_id: int, step: int) -> list[int]:
+        if sampled_ids_host_abi:
+            host = slots[slot_id]["sampled_ids_host"]
+        else:
+            device_sampled = _sampled_value(resident, step, mode)
+            host = torch.empty((BATCH, SAMPLED_IDS_PAD), dtype=torch.int32)
+            rt.copy_from(
+                host.data_ptr(),
+                device_sampled.data_ptr,
+                host.nbytes,
+            )
+        return [int(value) for value in host[:, 0].tolist()]
+
+    def submit(step: int):
+        slot_id = 0 if mode == "single" else step % 2
+        _update_slot(slots[slot_id], golden, step)
+        token_input = (
+            resident["initial_tokens"]
+            if step == 0
+            else _sampled_value(resident, step - 1, mode)
+        )
+        values = {
+            **resident["weights"],
+            **slots[slot_id],
+            "rope_cos": resident["rope_cos"],
+            "rope_sin": resident["rope_sin"],
+            "k_cache": resident["k_cache"],
+            "v_cache": resident["v_cache"],
+            "out": _slot_value(resident["out"], slot_id),
+            "sampled_ids_in": token_input,
+            "sampled_ids": _sampled_value(resident, step, mode),
+            "next_hidden": _slot_value(resident["next_hidden"], slot_id),
+        }
+        return slot_id, rt.submit(
+            compiled,
+            *_ordered_args(param_names, values),
+            config=run_config,
+        )
+
+    if mode == "single":
+        for step in range(steps):
+            slot_id, handle = submit(step)
+            handle.result()
+            completions.append(time.perf_counter())
+            row = read_sampled_ids(slot_id, step)
+            token_rows.append(row)
+    else:
+        pending = []
+        completed = []
+        for step in range(min(2, steps)):
+            slot_id, handle = submit(step)
+            pending.append((step, slot_id, handle))
+        next_step = 2
+        while pending:
+            step, slot_id, handle = pending.pop(0)
+            handle.result()
+            completions.append(time.perf_counter())
+            completed.append((step, slot_id))
+            if next_step < steps:
+                next_slot, next_handle = submit(next_step)
+                pending.append((next_step, next_slot, next_handle))
+                next_step += 1
+        token_rows.extend(
+            read_sampled_ids(slot_id, step) for step, slot_id in completed
+        )
+
+    expected = golden["decode_output_token_ids"][:steps].tolist()
+    if token_rows != expected:
+        for step, (actual, wanted) in enumerate(zip(token_rows, expected, strict=True)):
+            if actual != wanted:
+                raise RuntimeError(f"golden token mismatch at decode step {step}")
+        raise RuntimeError("golden token sequence mismatch")
+    intervals = [
+        (right - left) * 1000.0 for left, right in zip(completions, completions[1:])
+    ]
+    return {
+        "wall_s": time.perf_counter() - started,
+        "completion_intervals_ms": intervals,
+        "token_rows": token_rows,
+        "valid": True,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.qualification_steps is not None:
+        if args.profile_only or not 1 <= args.qualification_steps <= STEPS:
+            raise ValueError(
+                "qualification_steps must be in [1, 127] and cannot profile"
+            )
+        args.warmup_runs = 0
+        args.measured_runs = 1
+        args.inter_run_wait = 0.0
+        decode_steps = args.qualification_steps
+    elif args.profile_only:
+        if args.warmup_runs != 1:
+            raise ValueError("profile-only requires one complete warmup sequence")
+        args.measured_runs = 1
+        decode_steps = STEPS
+    elif args.warmup_runs != 1 or args.measured_runs != 5:
+        raise ValueError("formal execution requires exactly 1 warmup + 5 measured runs")
+    else:
+        decode_steps = STEPS
+    if args.output_dir.exists():
+        raise FileExistsError(args.output_dir)
+    args.output_dir.mkdir(parents=True)
+
+    fixture_module = _load_module(
+        args.fixture_module.resolve(), "_serving_effective_fixture"
+    )
+    weights_module = _load_module(
+        args.weights_module.resolve(), "_serving_effective_weights"
+    )
+    fixture = fixture_module.load_fixture(
+        args.fixture,
+        expected_versions=None,
+    )
+    fixture.require_executable()
+    fixture.verify_external_inputs(args.model_dir.resolve())
+    golden = fixture.load_golden()
+
+    artifact_source = (args.artifact_source or fixture.artifact_dir).resolve()
+    artifact_manifest = json.loads((artifact_source / "manifest.json").read_text())
+    if args.artifact_work_dir.exists():
+        raise FileExistsError(args.artifact_work_dir)
+    shutil.copytree(artifact_source, args.artifact_work_dir)
+    decode_dir = (
+        args.artifact_work_dir / artifact_manifest["programs"]["decode"]["path"]
+    )
+    distributed_meta = json.loads((decode_dir / "distributed_meta.json").read_text())
+    param_names = [_base_name(param["name"]) for param in distributed_meta["params"]]
+    if len(param_names) not in {25, 26}:
+        raise ValueError(f"unsupported decode ABI with {len(param_names)} parameters")
+    sampled_ids_host_abi = "sampled_ids_host" in param_names
+
+    from pypto.ir.distributed_compiled_program import (
+        DistributedCompiledProgram,
+        DistributedConfig,
+    )
+    from pypto.runtime import RunConfig
+
+    distributed = DistributedConfig(
+        device_ids=[args.device_id],
+        runtime="tensormap_and_ringbuffer",
+        aicpu_thread_num=int(
+            distributed_meta["distributed_config"]["aicpu_thread_num"]
+        ),
+    )
+    compiled = DistributedCompiledProgram.from_dir(
+        decode_dir,
+        platform="a2a3",
+        distributed_config=distributed,
+    )
+    run_config = RunConfig(
+        platform="a2a3",
+        device_id=args.device_id,
+        ring_task_window=RING_TASK_WINDOW,
+        ring_dep_pool=RING_DEP_POOL,
+        ring_heap=RING_HEAP,
+    )
+    slots = _shared_slot_state(fixture)
+
+    with compiled.prepare(config=run_config) as rt:
+        device_weights = {}
+        for name, host in weights_module.iter_kernel_weights(args.model_dir.resolve()):
+            device_weights[name] = rt.alloc_tensor(
+                tuple(host.shape), host.dtype, init=host
+            )
+            del host
+            gc.collect()
+        rope_cos_host, rope_sin_host = weights_module.rope_tables(
+            args.model_dir.resolve()
+        )
+        rope_cos = rt.alloc_tensor(
+            tuple(rope_cos_host.shape), rope_cos_host.dtype, init=rope_cos_host
+        )
+        rope_sin = rt.alloc_tensor(
+            tuple(rope_sin_host.shape), rope_sin_host.dtype, init=rope_sin_host
+        )
+        del rope_cos_host, rope_sin_host
+        k_cache = fixture.allocate_kv(rt, "key")
+        v_cache = fixture.allocate_kv(rt, "value")
+        resident = {
+            "weights": device_weights,
+            "rope_cos": rope_cos,
+            "rope_sin": rope_sin,
+            "k_cache": k_cache,
+            "v_cache": v_cache,
+            "out": (
+                rt.alloc_tensor((BATCH, PADDED_VOCAB), torch.float32)
+                if args.mode == "single"
+                else [
+                    rt.alloc_tensor((BATCH, PADDED_VOCAB), torch.float32)
+                    for _ in range(2)
+                ]
+            ),
+            "next_hidden": (
+                rt.alloc_tensor((BATCH, HIDDEN), torch.bfloat16)
+                if args.mode == "single"
+                else [
+                    rt.alloc_tensor((BATCH, HIDDEN), torch.bfloat16) for _ in range(2)
+                ]
+            ),
+            "initial_tokens": rt.alloc_tensor((BATCH, SAMPLED_IDS_PAD), torch.int32),
+            "sampled": [
+                rt.alloc_tensor((BATCH, SAMPLED_IDS_PAD), torch.int32)
+                for _ in range(2 if args.mode == "single" else decode_steps)
+            ],
+        }
+        runs = []
+        for kind, count in (
+            ("warmup", args.warmup_runs),
+            ("measured", args.measured_runs),
+        ):
+            for run_index in range(count):
+                result = _run_sequence(
+                    rt=rt,
+                    compiled=compiled,
+                    run_config=run_config,
+                    param_names=param_names,
+                    resident=resident,
+                    slots=slots,
+                    golden=golden,
+                    mode=args.mode,
+                    steps=decode_steps,
+                    sampled_ids_host_abi=sampled_ids_host_abi,
+                )
+                result.update({"kind": kind, "run": run_index + 1})
+                runs.append(result)
+                is_last = kind == "measured" and run_index + 1 == count
+                if not is_last:
+                    time.sleep(args.inter_run_wait)
+
+    output = {
+        "schema": 1,
+        "campaign_kind": (
+            "qualification"
+            if args.qualification_steps is not None
+            else "diagnostic_profiling"
+            if args.profile_only
+            else "formal_performance"
+        ),
+        "official_performance": not args.profile_only
+        and args.qualification_steps is None,
+        "scenario": {
+            "runtime": "tensormap_and_ringbuffer",
+            "mode": args.mode,
+            "batch_size": BATCH,
+            "decode_dispatches": decode_steps,
+            "warmup_runs": args.warmup_runs,
+            "measured_runs": args.measured_runs,
+            "retain_all_measured_runs": True,
+            "steady_skip_dispatches": args.steady_skip,
+            "inter_run_wait_s": args.inter_run_wait,
+            "fixture": str(fixture.root),
+            "fixture_artifact_source": str(fixture.artifact_dir),
+            "artifact_source": str(artifact_source),
+            "artifact_work_dir": str(args.artifact_work_dir),
+            "ring_task_window": RING_TASK_WINDOW,
+            "ring_dep_pool": RING_DEP_POOL,
+            "ring_heap": RING_HEAP,
+            "kv_reuse": "decode positions are overwritten before attention reads them",
+        },
+        "runs": runs,
+        "correctness": {
+            "all_runs_valid": all(run["valid"] for run in runs),
+            "cross_run_tokens_identical": len(
+                {json.dumps(run["token_rows"]) for run in runs}
+            )
+            == 1,
+            "golden_tokens_identical": True,
+        },
+    }
+    (args.output_dir / "benchmark.json").write_text(
+        json.dumps(output, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/benchmark_dual.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/benchmark_dual.py
@@ -77,6 +77,7 @@ def _shared_slot_state(fixture: Any) -> list[dict[str, torch.Tensor]]:
                 "seq_lens": fixture.metadata["seq_lens_after_first_token"].clone().share_memory_(),
                 "block_table": block_table.clone().share_memory_(),
                 "initial_block_table": block_table.clone(),
+                "page_size": torch.tensor(int(fixture.manifest["physical_layout"]["page_size"])),
                 "slot_mapping": fixture.metadata["next_slot_mapping"].clone().share_memory_(),
                 "sampled_ids_host": torch.zeros((BATCH, SAMPLED_IDS_PAD), dtype=torch.int32).share_memory_(),
             }
@@ -84,16 +85,25 @@ def _shared_slot_state(fixture: Any) -> list[dict[str, torch.Tensor]]:
     return slots
 
 
-def _update_slot(slot: dict[str, torch.Tensor], golden: dict[str, torch.Tensor], step: int) -> None:
+def _update_slot(
+    slot: dict[str, torch.Tensor],
+    golden: dict[str, torch.Tensor],
+    step: int,
+) -> None:
     slot["seq_lens"].copy_(golden["seq_lens"][step])
     slot["slot_mapping"].copy_(golden["slot_mapping"][step])
     positions = slot["seq_lens"] - 1
-    if not torch.equal(slot["slot_mapping"].remainder(128), positions.remainder(128)):
+    page_size = int(slot["page_size"])
+    if not torch.equal(
+        slot["slot_mapping"].remainder(page_size),
+        positions.remainder(page_size),
+    ):
         raise RuntimeError(f"slot mapping offset mismatch at decode step {step}")
-    logical_blocks = positions.div(128, rounding_mode="floor")
-    page_ids = slot["slot_mapping"].div(128, rounding_mode="floor")
+    logical_blocks = positions.div(page_size, rounding_mode="floor")
+    page_ids = slot["slot_mapping"].div(page_size, rounding_mode="floor")
+    block_table_stride = slot["block_table"].numel() // BATCH
     for row in range(BATCH):
-        slot["block_table"][row * 32 + int(logical_blocks[row])] = page_ids[row]
+        slot["block_table"][row * block_table_stride + int(logical_blocks[row])] = page_ids[row]
     slot["sampled_ids_host"].zero_()
 
 
@@ -183,7 +193,7 @@ def _run_sequence(
             token_rows.append(row)
     else:
         pending: list[tuple[int, int, Any]] = []
-        completed = []
+        completed: list[tuple[int, int]] = []
         for step in range(min(2, steps)):
             slot_id, handle = submit(step)
             pending.append((step, slot_id, handle))
@@ -192,12 +202,16 @@ def _run_sequence(
             step, slot_id, handle = pending.pop(0)
             handle.result()
             completions.append(time.perf_counter())
-            completed.append((step, slot_id))
+            if sampled_ids_host_abi:
+                token_rows.append(read_sampled_ids(slot_id, step))
+            else:
+                completed.append((step, slot_id))
             if next_step < steps:
                 next_slot, next_handle = submit(next_step)
                 pending.append((next_step, next_slot, next_handle))
                 next_step += 1
-        token_rows.extend(read_sampled_ids(slot_id, step) for step, slot_id in completed)
+        if not sampled_ids_host_abi:
+            token_rows.extend(read_sampled_ids(slot_id, step) for step, slot_id in completed)
 
     expected: list[list[int]] = golden["decode_output_token_ids"][:steps].tolist()
     if token_rows != expected:

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/benchmark_dual.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/benchmark_dual.py
@@ -23,7 +23,6 @@ from typing import Any
 
 import torch
 
-
 BATCH = 16
 STEPS = 127
 SAMPLED_IDS_PAD = 8
@@ -75,25 +74,17 @@ def _shared_slot_state(fixture: Any) -> list[dict[str, torch.Tensor]]:
     for _ in range(2):
         slots.append(
             {
-                "seq_lens": fixture.metadata["seq_lens_after_first_token"]
-                .clone()
-                .share_memory_(),
+                "seq_lens": fixture.metadata["seq_lens_after_first_token"].clone().share_memory_(),
                 "block_table": block_table.clone().share_memory_(),
                 "initial_block_table": block_table.clone(),
-                "slot_mapping": fixture.metadata["next_slot_mapping"]
-                .clone()
-                .share_memory_(),
-                "sampled_ids_host": torch.zeros(
-                    (BATCH, SAMPLED_IDS_PAD), dtype=torch.int32
-                ).share_memory_(),
+                "slot_mapping": fixture.metadata["next_slot_mapping"].clone().share_memory_(),
+                "sampled_ids_host": torch.zeros((BATCH, SAMPLED_IDS_PAD), dtype=torch.int32).share_memory_(),
             }
         )
     return slots
 
 
-def _update_slot(
-    slot: dict[str, torch.Tensor], golden: dict[str, torch.Tensor], step: int
-) -> None:
+def _update_slot(slot: dict[str, torch.Tensor], golden: dict[str, torch.Tensor], step: int) -> None:
     slot["seq_lens"].copy_(golden["seq_lens"][step])
     slot["slot_mapping"].copy_(golden["slot_mapping"][step])
     positions = slot["seq_lens"] - 1
@@ -164,11 +155,7 @@ def _run_sequence(
     def submit(step: int):
         slot_id = 0 if mode == "single" else step % 2
         _update_slot(slots[slot_id], golden, step)
-        token_input = (
-            resident["initial_tokens"]
-            if step == 0
-            else _sampled_value(resident, step - 1, mode)
-        )
+        token_input = resident["initial_tokens"] if step == 0 else _sampled_value(resident, step - 1, mode)
         values = {
             **resident["weights"],
             **slots[slot_id],
@@ -195,7 +182,7 @@ def _run_sequence(
             row = read_sampled_ids(slot_id, step)
             token_rows.append(row)
     else:
-        pending = []
+        pending: list[tuple[int, int, Any]] = []
         completed = []
         for step in range(min(2, steps)):
             slot_id, handle = submit(step)
@@ -210,19 +197,17 @@ def _run_sequence(
                 next_slot, next_handle = submit(next_step)
                 pending.append((next_step, next_slot, next_handle))
                 next_step += 1
-        token_rows.extend(
-            read_sampled_ids(slot_id, step) for step, slot_id in completed
-        )
+        token_rows.extend(read_sampled_ids(slot_id, step) for step, slot_id in completed)
 
-    expected = golden["decode_output_token_ids"][:steps].tolist()
+    expected: list[list[int]] = golden["decode_output_token_ids"][:steps].tolist()
     if token_rows != expected:
-        for step, (actual, wanted) in enumerate(zip(token_rows, expected, strict=True)):
+        if len(token_rows) != len(expected):
+            raise RuntimeError("golden token sequence length mismatch")
+        for step, (actual, wanted) in enumerate(zip(token_rows, expected)):
             if actual != wanted:
                 raise RuntimeError(f"golden token mismatch at decode step {step}")
         raise RuntimeError("golden token sequence mismatch")
-    intervals = [
-        (right - left) * 1000.0 for left, right in zip(completions, completions[1:])
-    ]
+    intervals = [(right - left) * 1000.0 for left, right in zip(completions, completions[1:])]
     return {
         "wall_s": time.perf_counter() - started,
         "completion_intervals_ms": intervals,
@@ -235,9 +220,7 @@ def main() -> int:
     args = _parse_args()
     if args.qualification_steps is not None:
         if args.profile_only or not 1 <= args.qualification_steps <= STEPS:
-            raise ValueError(
-                "qualification_steps must be in [1, 127] and cannot profile"
-            )
+            raise ValueError("qualification_steps must be in [1, 127] and cannot profile")
         args.warmup_runs = 0
         args.measured_runs = 1
         args.inter_run_wait = 0.0
@@ -255,12 +238,8 @@ def main() -> int:
         raise FileExistsError(args.output_dir)
     args.output_dir.mkdir(parents=True)
 
-    fixture_module = _load_module(
-        args.fixture_module.resolve(), "_serving_effective_fixture"
-    )
-    weights_module = _load_module(
-        args.weights_module.resolve(), "_serving_effective_weights"
-    )
+    fixture_module = _load_module(args.fixture_module.resolve(), "_serving_effective_fixture")
+    weights_module = _load_module(args.weights_module.resolve(), "_serving_effective_weights")
     fixture = fixture_module.load_fixture(
         args.fixture,
         expected_versions=None,
@@ -274,27 +253,23 @@ def main() -> int:
     if args.artifact_work_dir.exists():
         raise FileExistsError(args.artifact_work_dir)
     shutil.copytree(artifact_source, args.artifact_work_dir)
-    decode_dir = (
-        args.artifact_work_dir / artifact_manifest["programs"]["decode"]["path"]
-    )
+    decode_dir = args.artifact_work_dir / artifact_manifest["programs"]["decode"]["path"]
     distributed_meta = json.loads((decode_dir / "distributed_meta.json").read_text())
     param_names = [_base_name(param["name"]) for param in distributed_meta["params"]]
     if len(param_names) not in {25, 26}:
         raise ValueError(f"unsupported decode ABI with {len(param_names)} parameters")
     sampled_ids_host_abi = "sampled_ids_host" in param_names
 
-    from pypto.ir.distributed_compiled_program import (
+    from pypto.ir.distributed_compiled_program import (  # noqa: PLC0415 -- hardware-only dependency
         DistributedCompiledProgram,
         DistributedConfig,
     )
-    from pypto.runtime import RunConfig
+    from pypto.runtime import RunConfig  # noqa: PLC0415 -- hardware-only dependency
 
     distributed = DistributedConfig(
         device_ids=[args.device_id],
         runtime="tensormap_and_ringbuffer",
-        aicpu_thread_num=int(
-            distributed_meta["distributed_config"]["aicpu_thread_num"]
-        ),
+        aicpu_thread_num=int(distributed_meta["distributed_config"]["aicpu_thread_num"]),
     )
     compiled = DistributedCompiledProgram.from_dir(
         decode_dir,
@@ -313,20 +288,12 @@ def main() -> int:
     with compiled.prepare(config=run_config) as rt:
         device_weights = {}
         for name, host in weights_module.iter_kernel_weights(args.model_dir.resolve()):
-            device_weights[name] = rt.alloc_tensor(
-                tuple(host.shape), host.dtype, init=host
-            )
+            device_weights[name] = rt.alloc_tensor(tuple(host.shape), host.dtype, init=host)
             del host
             gc.collect()
-        rope_cos_host, rope_sin_host = weights_module.rope_tables(
-            args.model_dir.resolve()
-        )
-        rope_cos = rt.alloc_tensor(
-            tuple(rope_cos_host.shape), rope_cos_host.dtype, init=rope_cos_host
-        )
-        rope_sin = rt.alloc_tensor(
-            tuple(rope_sin_host.shape), rope_sin_host.dtype, init=rope_sin_host
-        )
+        rope_cos_host, rope_sin_host = weights_module.rope_tables(args.model_dir.resolve())
+        rope_cos = rt.alloc_tensor(tuple(rope_cos_host.shape), rope_cos_host.dtype, init=rope_cos_host)
+        rope_sin = rt.alloc_tensor(tuple(rope_sin_host.shape), rope_sin_host.dtype, init=rope_sin_host)
         del rope_cos_host, rope_sin_host
         k_cache = fixture.allocate_kv(rt, "key")
         v_cache = fixture.allocate_kv(rt, "value")
@@ -339,17 +306,12 @@ def main() -> int:
             "out": (
                 rt.alloc_tensor((BATCH, PADDED_VOCAB), torch.float32)
                 if args.mode == "single"
-                else [
-                    rt.alloc_tensor((BATCH, PADDED_VOCAB), torch.float32)
-                    for _ in range(2)
-                ]
+                else [rt.alloc_tensor((BATCH, PADDED_VOCAB), torch.float32) for _ in range(2)]
             ),
             "next_hidden": (
                 rt.alloc_tensor((BATCH, HIDDEN), torch.bfloat16)
                 if args.mode == "single"
-                else [
-                    rt.alloc_tensor((BATCH, HIDDEN), torch.bfloat16) for _ in range(2)
-                ]
+                else [rt.alloc_tensor((BATCH, HIDDEN), torch.bfloat16) for _ in range(2)]
             ),
             "initial_tokens": rt.alloc_tensor((BATCH, SAMPLED_IDS_PAD), torch.int32),
             "sampled": [
@@ -390,8 +352,7 @@ def main() -> int:
             if args.profile_only
             else "formal_performance"
         ),
-        "official_performance": not args.profile_only
-        and args.qualification_steps is None,
+        "official_performance": not args.profile_only and args.qualification_steps is None,
         "scenario": {
             "runtime": "tensormap_and_ringbuffer",
             "mode": args.mode,
@@ -414,10 +375,7 @@ def main() -> int:
         "runs": runs,
         "correctness": {
             "all_runs_valid": all(run["valid"] for run in runs),
-            "cross_run_tokens_identical": len(
-                {json.dumps(run["token_rows"]) for run in runs}
-            )
-            == 1,
+            "cross_run_tokens_identical": len({json.dumps(run["token_rows"]) for run in runs}) == 1,
             "golden_tokens_identical": True,
         },
     }

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/export_strace_timeline.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/export_strace_timeline.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Export aligned Simpler host and device STRACE spans as a Chrome trace."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+from trace_effective import Span, parse_spans
+
+
+def _event(
+    span: Span,
+    *,
+    category: str,
+    pid: int,
+    timestamp_ns: int,
+    args: dict[str, object],
+) -> dict[str, object]:
+    return {
+        "name": span.name,
+        "cat": category,
+        "ph": "X",
+        "pid": pid,
+        "tid": span.tid,
+        "ts": timestamp_ns / 1000.0,
+        "dur": span.duration_ms * 1000.0,
+        "args": args,
+    }
+
+
+def export(log_path: Path, output_dir: Path) -> dict[str, object]:
+    spans = parse_spans(log_path)
+    by_inv: dict[tuple[int, int], list[Span]] = {}
+    for span in spans:
+        by_inv.setdefault((span.pid, span.inv), []).append(span)
+
+    events: list[dict[str, object]] = []
+    for pid in sorted({span.pid for span in spans}):
+        for output_pid, name in (
+            (pid, f"Simpler Host pid={pid}"),
+            (pid + 20_000_000, f"AICPU device phases pid={pid}"),
+            (pid + 30_000_000, f"AICore scheduler pid={pid}"),
+        ):
+            events.append(
+                {
+                    "name": "process_name",
+                    "ph": "M",
+                    "pid": output_pid,
+                    "tid": 0,
+                    "args": {"name": name},
+                }
+            )
+
+    phase_counts: Counter[str] = Counter()
+    unaligned = 0
+    host_count = 0
+    for (pid, inv), group in by_inv.items():
+        host_runner = next(
+            (
+                span
+                for span in group
+                if span.name.endswith(".runner_run") and span.attrs.get("clk") != "dev"
+            ),
+            None,
+        )
+        for span in group:
+            attrs: dict[str, object] = {"inv": inv, "hid": span.hid, **span.attrs}
+            if span.attrs.get("clk") != "dev":
+                host_count += 1
+                events.append(
+                    _event(
+                        span,
+                        category="simpler_host",
+                        pid=pid,
+                        timestamp_ns=span.timestamp_ns,
+                        args=attrs,
+                    )
+                )
+                continue
+            if host_runner is None:
+                unaligned += 1
+                continue
+            phase_counts[span.name] += 1
+            is_aicpu = span.name.endswith(".orch")
+            attrs["alignment"] = "chip.run.runner_run start"
+            events.append(
+                _event(
+                    span,
+                    category="aicpu" if is_aicpu else "aicore",
+                    pid=pid + (20_000_000 if is_aicpu else 30_000_000),
+                    timestamp_ns=host_runner.timestamp_ns + span.timestamp_ns,
+                    args=attrs,
+                )
+            )
+
+    required = (
+        "chip.run.runner_run.device_wall",
+        "chip.run.runner_run.device_wall.orch",
+        "chip.run.runner_run.device_wall.sched",
+    )
+    missing = [name for name in required if phase_counts[name] == 0]
+    if missing:
+        raise RuntimeError(f"missing native device STRACE phases: {missing}")
+    if unaligned:
+        raise RuntimeError(f"native device STRACE has {unaligned} unaligned spans")
+
+    events.sort(
+        key=lambda event: (
+            float(event.get("ts", 0)),
+            int(event["pid"]),
+            int(event["tid"]),
+        )
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    timeline_path = output_dir / "simpler_strace_timeline.json"
+    timeline_path.write_text(
+        json.dumps(
+            {
+                "traceEvents": events,
+                "displayTimeUnit": "ms",
+                "metadata": {
+                    "schema": "simpler-strace-chrome-timeline-v1",
+                    "device_clock_alignment": "per-invocation chip.run.runner_run start",
+                },
+            },
+            separators=(",", ":"),
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    summary = {
+        "schema": "simpler-strace-timeline-summary-v1",
+        "passed": True,
+        "timeline": timeline_path.name,
+        "trace_event_count": len(events),
+        "host_span_count": host_count,
+        "device_span_count": sum(phase_counts.values()),
+        "unaligned_device_span_count": unaligned,
+        "device_phase_counts": dict(sorted(phase_counts.items())),
+        "aicpu_phase": "chip.run.runner_run.device_wall.orch",
+        "aicore_phase": "chip.run.runner_run.device_wall.sched",
+    }
+    (output_dir / "simpler_strace_timeline_summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    print(
+        json.dumps(
+            export(args.log.resolve(), args.output_dir.resolve()),
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/export_strace_timeline.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/export_strace_timeline.py
@@ -15,8 +15,23 @@ import argparse
 import json
 from collections import Counter
 from pathlib import Path
+from typing import TypedDict
 
 from trace_effective import Span, parse_spans
+
+
+class TraceEventBase(TypedDict):
+    name: str
+    ph: str
+    pid: int
+    tid: int
+    args: dict[str, object]
+
+
+class TraceEvent(TraceEventBase, total=False):
+    cat: str
+    ts: float
+    dur: float
 
 
 def _event(
@@ -26,7 +41,7 @@ def _event(
     pid: int,
     timestamp_ns: int,
     args: dict[str, object],
-) -> dict[str, object]:
+) -> TraceEvent:
     return {
         "name": span.name,
         "cat": category,
@@ -45,7 +60,7 @@ def export(log_path: Path, output_dir: Path) -> dict[str, object]:
     for span in spans:
         by_inv.setdefault((span.pid, span.inv), []).append(span)
 
-    events: list[dict[str, object]] = []
+    events: list[TraceEvent] = []
     for pid in sorted({span.pid for span in spans}):
         for output_pid, name in (
             (pid, f"Simpler Host pid={pid}"),
@@ -67,11 +82,7 @@ def export(log_path: Path, output_dir: Path) -> dict[str, object]:
     host_count = 0
     for (pid, inv), group in by_inv.items():
         host_runner = next(
-            (
-                span
-                for span in group
-                if span.name.endswith(".runner_run") and span.attrs.get("clk") != "dev"
-            ),
+            (span for span in group if span.name.endswith(".runner_run") and span.attrs.get("clk") != "dev"),
             None,
         )
         for span in group:

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/fixture.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/fixture.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Load and validate a portable Serving-TMR prefill fixture."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator
+
+import torch
+from safetensors.torch import load_file
+
+
+SCHEMA_NAME = "serving-tmr-standalone-fixture-v1"
+EXPECTED_METADATA = {
+    "prompt_token_ids": ((16, 3338), torch.int32),
+    "seq_lens_after_first_token": ((16,), torch.int32),
+    "next_slot_mapping": ((16,), torch.int32),
+    "first_generated_token_ids": ((16,), torch.int32),
+    "block_table": ((16, 32), torch.int32),
+    "tokens_used_after_prefill": ((16,), torch.int32),
+}
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _json_type_matches(value: Any, expected: str) -> bool:
+    return {
+        "object": isinstance(value, dict),
+        "array": isinstance(value, list),
+        "boolean": isinstance(value, bool),
+        "string": isinstance(value, str),
+        "integer": isinstance(value, int) and not isinstance(value, bool),
+        "number": isinstance(value, (int, float)) and not isinstance(value, bool),
+    }.get(expected, True)
+
+
+def _condition_matches(value: Any, schema: dict[str, Any]) -> bool:
+    if not isinstance(value, dict):
+        return False
+    for name, rule in schema.get("properties", {}).items():
+        if name not in value:
+            return False
+        if "const" in rule and value[name] != rule["const"]:
+            return False
+    return True
+
+
+def _validate_json_schema(
+    value: Any, schema: dict[str, Any], path: str = "manifest"
+) -> None:
+    expected_type = schema.get("type")
+    if expected_type is not None and not _json_type_matches(value, expected_type):
+        raise ValueError(f"{path} must have JSON type {expected_type}")
+    if "const" in schema and value != schema["const"]:
+        raise ValueError(f"{path} must equal {schema['const']!r}")
+
+    if isinstance(value, dict):
+        required = schema.get("required", [])
+        missing = sorted(set(required) - set(value))
+        if missing:
+            raise ValueError(f"{path} is missing required fields: {missing}")
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False:
+            extras = sorted(set(value) - set(properties))
+            if extras:
+                raise ValueError(f"{path} has unsupported fields: {extras}")
+        for name, rule in properties.items():
+            if name in value:
+                _validate_json_schema(value[name], rule, f"{path}.{name}")
+
+    if isinstance(value, list):
+        if len(value) < schema.get("minItems", 0):
+            raise ValueError(f"{path} has too few items")
+        if "maxItems" in schema and len(value) > schema["maxItems"]:
+            raise ValueError(f"{path} has too many items")
+
+    for rule in schema.get("allOf", []):
+        if _condition_matches(value, rule.get("if", {})):
+            _validate_json_schema(value, rule.get("then", {}), path)
+
+
+def _verify_sums(root: Path) -> dict[Path, str]:
+    sums_path = root / "SHA256SUMS"
+    if not sums_path.is_file():
+        raise FileNotFoundError(sums_path)
+    expected: dict[Path, str] = {}
+    for line in sums_path.read_text(encoding="utf-8").splitlines():
+        digest, relative = line.split(None, 1)
+        relative_path = Path(relative.removeprefix("./"))
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            raise ValueError(f"invalid SHA256SUMS path: {relative}")
+        if relative_path in expected:
+            raise ValueError(f"duplicate SHA256SUMS path: {relative_path}")
+        expected[relative_path] = digest
+    actual = {
+        path.relative_to(root)
+        for path in root.rglob("*")
+        if path.is_file() and path.name != "SHA256SUMS"
+    }
+    if set(expected) != actual:
+        raise ValueError(
+            f"SHA256SUMS file set mismatch: missing={sorted(actual - set(expected))} "
+            f"extra={sorted(set(expected) - actual)}"
+        )
+    for relative, digest in expected.items():
+        if _sha256(root / relative) != digest:
+            raise ValueError(f"SHA256 mismatch: {relative}")
+    return expected
+
+
+@dataclass(frozen=True)
+class Fixture:
+    root: Path
+    manifest: dict[str, Any]
+    metadata: dict[str, torch.Tensor]
+
+    @property
+    def metadata_only(self) -> bool:
+        return bool(self.manifest["metadata_only"])
+
+    @property
+    def artifact_dir(self) -> Path:
+        return (self.root / self.manifest["artifact"]["path"]).resolve()
+
+    @property
+    def golden_path(self) -> Path:
+        return (self.root / self.manifest["golden_contract"]["path"]).resolve()
+
+    def require_executable(self) -> None:
+        if self.metadata_only:
+            raise RuntimeError(
+                "metadata-only fixture cannot allocate device state or execute"
+            )
+
+    def iter_kv_shards(self, kind: str) -> Iterator[tuple[int, Path, str]]:
+        self.require_executable()
+        entries = [
+            entry for entry in self.manifest["kv_shards"] if entry["kind"] == kind
+        ]
+        for entry in sorted(entries, key=lambda item: int(item["layer"])):
+            yield int(entry["layer"]), self.root / entry["path"], entry["tensor"]
+
+    def verify_external_inputs(self, model_dir: Path) -> None:
+        for entry in self.manifest["checkpoint_files"]:
+            path = model_dir / entry["name"]
+            if not path.is_file() or path.stat().st_size != int(entry["bytes"]):
+                raise ValueError(f"checkpoint file mismatch: {entry['name']}")
+            if _sha256(path) != entry["sha256"]:
+                raise ValueError(f"checkpoint SHA256 mismatch: {entry['name']}")
+
+    def verify_artifact_and_golden(self) -> None:
+        self.require_executable()
+        artifact = self.manifest["artifact"]
+        if _sha256(self.artifact_dir / "manifest.json") != artifact["manifest_sha256"]:
+            raise ValueError("artifact manifest SHA256 mismatch")
+        if _sha256(self.artifact_dir / "SHA256SUMS") != artifact["sha256sums_sha256"]:
+            raise ValueError("artifact SHA256SUMS mismatch")
+        _verify_sums(self.artifact_dir)
+        if not self.golden_path.is_file():
+            raise FileNotFoundError(self.golden_path)
+        _verify_sums(self.golden_path.parent)
+
+    def load_golden(self) -> dict[str, torch.Tensor]:
+        self.require_executable()
+        golden = load_file(str(self.golden_path), device="cpu")
+        shapes = self.manifest["golden_contract"]["tensor_shapes"]
+        if set(golden) != set(shapes):
+            raise ValueError("golden tensor names do not match the fixture contract")
+        for name, shape in shapes.items():
+            tensor = golden[name]
+            if tensor.dtype != torch.int32 or tuple(tensor.shape) != tuple(shape):
+                raise ValueError(f"golden tensor contract mismatch: {name}")
+        if not torch.equal(golden["step_index"], torch.arange(127, dtype=torch.int32)):
+            raise ValueError("golden step_index must be 0..126")
+        if not torch.equal(
+            golden["decode_input_token_ids"][0],
+            self.metadata["first_generated_token_ids"],
+        ):
+            raise ValueError("golden first decode input differs from the prefill token")
+        layout = self.manifest["physical_layout"]
+        page_size = int(layout["page_size"])
+        num_pages = int(layout["num_pages"])
+        positions = golden["seq_lens"] - 1
+        slots = golden["slot_mapping"]
+        if not torch.equal(slots.remainder(page_size), positions.remainder(page_size)):
+            raise ValueError("golden slot_mapping offset differs from seq_lens")
+        page_ids = slots.div(page_size, rounding_mode="floor")
+        if int(page_ids.min()) < 0 or int(page_ids.max()) >= num_pages:
+            raise ValueError("golden slot_mapping page is outside physical KV storage")
+        return golden
+
+    def allocate_kv(self, runtime: Any, kind: str) -> Any:
+        self.require_executable()
+        layout = self.manifest["physical_layout"]
+        num_layers = int(layout["num_layers"])
+        num_pages = int(layout["num_pages"])
+        num_kv_heads = int(layout["num_kv_heads"])
+        page_size = int(layout["page_size"])
+        head_dim = int(layout["head_dim"])
+        rows = num_layers * num_pages * num_kv_heads * page_size
+        used_page_ids = self.metadata["used_page_ids"].to(torch.long)
+        host = torch.zeros((rows, head_dim), dtype=torch.bfloat16)
+        host_layers = host.view(
+            num_layers, num_pages, num_kv_heads, page_size, head_dim
+        )
+        entries = list(self.iter_kv_shards(kind))
+        if [layer for layer, _, _ in entries] != list(range(num_layers)):
+            raise ValueError(f"{kind} KV shards do not cover every layer")
+        for layer, path, tensor_name in entries:
+            shard = load_file(str(path), device="cpu")[tensor_name]
+            expected_shape = (len(used_page_ids), num_kv_heads, page_size, head_dim)
+            if shard.dtype != torch.bfloat16 or tuple(shard.shape) != expected_shape:
+                raise ValueError(f"KV shard contract mismatch: {path.name}")
+            host_layers[layer].index_copy_(0, used_page_ids, shard)
+            del shard
+        return runtime.alloc_tensor(tuple(host.shape), host.dtype, init=host)
+
+
+def _validate_metadata(
+    manifest: dict[str, Any], metadata: dict[str, torch.Tensor]
+) -> None:
+    expected_names = set(EXPECTED_METADATA) | {"used_page_ids", "allocated_page_ids"}
+    if set(metadata) != expected_names:
+        raise ValueError("metadata tensor names do not match fixture schema v1")
+    for name, (shape, dtype) in EXPECTED_METADATA.items():
+        tensor = metadata[name]
+        if tuple(tensor.shape) != shape or tensor.dtype != dtype:
+            raise ValueError(f"metadata tensor contract mismatch: {name}")
+    for name in ("used_page_ids", "allocated_page_ids"):
+        tensor = metadata[name]
+        if tensor.ndim != 1 or tensor.dtype != torch.int32:
+            raise ValueError(f"metadata tensor contract mismatch: {name}")
+
+    layout = manifest["physical_layout"]
+    num_pages = int(layout["num_pages"])
+    page_size = int(layout["page_size"])
+    block_table = metadata["block_table"]
+    allocated = sorted(
+        {int(value) for value in block_table.flatten().tolist() if value >= 0}
+    )
+    if allocated != metadata["allocated_page_ids"].tolist():
+        raise ValueError("allocated_page_ids differs from block_table")
+    if not allocated or allocated[0] < 0 or allocated[-1] >= num_pages:
+        raise ValueError("block_table page is outside physical KV storage")
+
+    prompt_tokens = int(manifest["prompt_tokens"])
+    used_blocks_per_row = math.ceil(prompt_tokens / page_size)
+    used = sorted(
+        {
+            int(value)
+            for value in block_table[:, :used_blocks_per_row].flatten().tolist()
+            if value >= 0
+        }
+    )
+    if used != metadata["used_page_ids"].tolist():
+        raise ValueError("used_page_ids differs from the prompt block mapping")
+    if len(used) != int(layout["used_page_count"]):
+        raise ValueError("used_page_count differs from metadata")
+
+    page_index, page_offset = divmod(prompt_tokens, page_size)
+    expected_slots = block_table[:, page_index] * page_size + page_offset
+    if not torch.equal(expected_slots, metadata["next_slot_mapping"]):
+        raise ValueError("next_slot_mapping does not name the first decode position")
+    if not torch.equal(
+        metadata["seq_lens_after_first_token"],
+        torch.full((16,), prompt_tokens + 1, dtype=torch.int32),
+    ):
+        raise ValueError("seq_lens_after_first_token is inconsistent with the prompt")
+    if not torch.equal(
+        metadata["tokens_used_after_prefill"],
+        torch.full((16,), prompt_tokens, dtype=torch.int32),
+    ):
+        raise ValueError("tokens_used_after_prefill is inconsistent with the prompt")
+    if not torch.equal(
+        metadata["prompt_token_ids"], metadata["prompt_token_ids"][0].repeat(16, 1)
+    ):
+        raise ValueError("batch prompt rows must be identical")
+
+
+def load_fixture(
+    root: Path, expected_versions: dict[str, str] | None = None
+) -> Fixture:
+    root = root.resolve()
+    fixture_sums = _verify_sums(root)
+    manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+    schema = json.loads((root / "manifest.schema.json").read_text(encoding="utf-8"))
+    _validate_json_schema(manifest, schema)
+    if manifest["schema"] != SCHEMA_NAME:
+        raise ValueError(f"unsupported fixture schema: {manifest['schema']}")
+    boundary = manifest["snapshot_boundary"]
+    required_boundary = {
+        "all_chunked_prefill_complete": True,
+        "first_token_produced": True,
+        "actual_decode_dispatches_before_snapshot": 0,
+        "prefill_and_sampling_fences_retired": True,
+    }
+    for name, expected in required_boundary.items():
+        if boundary.get(name) != expected:
+            raise ValueError(f"snapshot boundary mismatch: {name}")
+    if expected_versions is not None:
+        for name, expected in expected_versions.items():
+            if manifest["versions"].get(name) != expected:
+                raise ValueError(f"fixture version mismatch: {name}")
+
+    metadata_path = root / manifest["metadata"]["path"]
+    if _sha256(metadata_path) != manifest["metadata"]["sha256"]:
+        raise ValueError("metadata SHA256 differs from manifest")
+    metadata = load_file(str(metadata_path), device="cpu")
+    _validate_metadata(manifest, metadata)
+
+    fixture = Fixture(root=root, manifest=manifest, metadata=metadata)
+    if not fixture.metadata_only:
+        expected_shards = 2 * int(manifest["kv_shard_contract"]["layers"])
+        if len(manifest["kv_shards"]) != expected_shards:
+            raise ValueError(f"full fixture must contain {expected_shards} KV shards")
+        for entry in manifest["kv_shards"]:
+            path = root / entry["path"]
+            if (
+                path.stat().st_size != int(entry["bytes"])
+                or fixture_sums.get(Path(entry["path"])) != entry["sha256"]
+            ):
+                raise ValueError(f"KV shard checksum mismatch: {entry['path']}")
+        fixture.verify_artifact_and_golden()
+    return fixture
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    fixture = load_fixture(_parse_args().fixture)
+    print(
+        json.dumps(
+            {
+                "fixture": str(fixture.root),
+                "schema": fixture.manifest["schema"],
+                "metadata_only": fixture.metadata_only,
+                "used_page_count": len(fixture.metadata["used_page_ids"]),
+                "decode_dispatches_remaining": fixture.manifest[
+                    "decode_dispatches_remaining"
+                ],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/fixture.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/fixture.py
@@ -15,13 +15,13 @@ import argparse
 import hashlib
 import json
 import math
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
 
 import torch
 from safetensors.torch import load_file
-
 
 SCHEMA_NAME = "serving-tmr-standalone-fixture-v1"
 EXPECTED_METADATA = {
@@ -64,9 +64,7 @@ def _condition_matches(value: Any, schema: dict[str, Any]) -> bool:
     return True
 
 
-def _validate_json_schema(
-    value: Any, schema: dict[str, Any], path: str = "manifest"
-) -> None:
+def _validate_json_schema(value: Any, schema: dict[str, Any], path: str = "manifest") -> None:
     expected_type = schema.get("type")
     if expected_type is not None and not _json_type_matches(value, expected_type):
         raise ValueError(f"{path} must have JSON type {expected_type}")
@@ -111,11 +109,7 @@ def _verify_sums(root: Path) -> dict[Path, str]:
         if relative_path in expected:
             raise ValueError(f"duplicate SHA256SUMS path: {relative_path}")
         expected[relative_path] = digest
-    actual = {
-        path.relative_to(root)
-        for path in root.rglob("*")
-        if path.is_file() and path.name != "SHA256SUMS"
-    }
+    actual = {path.relative_to(root) for path in root.rglob("*") if path.is_file() and path.name != "SHA256SUMS"}
     if set(expected) != actual:
         raise ValueError(
             f"SHA256SUMS file set mismatch: missing={sorted(actual - set(expected))} "
@@ -147,15 +141,11 @@ class Fixture:
 
     def require_executable(self) -> None:
         if self.metadata_only:
-            raise RuntimeError(
-                "metadata-only fixture cannot allocate device state or execute"
-            )
+            raise RuntimeError("metadata-only fixture cannot allocate device state or execute")
 
     def iter_kv_shards(self, kind: str) -> Iterator[tuple[int, Path, str]]:
         self.require_executable()
-        entries = [
-            entry for entry in self.manifest["kv_shards"] if entry["kind"] == kind
-        ]
+        entries = [entry for entry in self.manifest["kv_shards"] if entry["kind"] == kind]
         for entry in sorted(entries, key=lambda item: int(item["layer"])):
             yield int(entry["layer"]), self.root / entry["path"], entry["tensor"]
 
@@ -219,9 +209,7 @@ class Fixture:
         rows = num_layers * num_pages * num_kv_heads * page_size
         used_page_ids = self.metadata["used_page_ids"].to(torch.long)
         host = torch.zeros((rows, head_dim), dtype=torch.bfloat16)
-        host_layers = host.view(
-            num_layers, num_pages, num_kv_heads, page_size, head_dim
-        )
+        host_layers = host.view(num_layers, num_pages, num_kv_heads, page_size, head_dim)
         entries = list(self.iter_kv_shards(kind))
         if [layer for layer, _, _ in entries] != list(range(num_layers)):
             raise ValueError(f"{kind} KV shards do not cover every layer")
@@ -235,9 +223,7 @@ class Fixture:
         return runtime.alloc_tensor(tuple(host.shape), host.dtype, init=host)
 
 
-def _validate_metadata(
-    manifest: dict[str, Any], metadata: dict[str, torch.Tensor]
-) -> None:
+def _validate_metadata(manifest: dict[str, Any], metadata: dict[str, torch.Tensor]) -> None:
     expected_names = set(EXPECTED_METADATA) | {"used_page_ids", "allocated_page_ids"}
     if set(metadata) != expected_names:
         raise ValueError("metadata tensor names do not match fixture schema v1")
@@ -254,9 +240,7 @@ def _validate_metadata(
     num_pages = int(layout["num_pages"])
     page_size = int(layout["page_size"])
     block_table = metadata["block_table"]
-    allocated = sorted(
-        {int(value) for value in block_table.flatten().tolist() if value >= 0}
-    )
+    allocated = sorted({int(value) for value in block_table.flatten().tolist() if value >= 0})
     if allocated != metadata["allocated_page_ids"].tolist():
         raise ValueError("allocated_page_ids differs from block_table")
     if not allocated or allocated[0] < 0 or allocated[-1] >= num_pages:
@@ -264,13 +248,7 @@ def _validate_metadata(
 
     prompt_tokens = int(manifest["prompt_tokens"])
     used_blocks_per_row = math.ceil(prompt_tokens / page_size)
-    used = sorted(
-        {
-            int(value)
-            for value in block_table[:, :used_blocks_per_row].flatten().tolist()
-            if value >= 0
-        }
-    )
+    used = sorted({int(value) for value in block_table[:, :used_blocks_per_row].flatten().tolist() if value >= 0})
     if used != metadata["used_page_ids"].tolist():
         raise ValueError("used_page_ids differs from the prompt block mapping")
     if len(used) != int(layout["used_page_count"]):
@@ -290,15 +268,11 @@ def _validate_metadata(
         torch.full((16,), prompt_tokens, dtype=torch.int32),
     ):
         raise ValueError("tokens_used_after_prefill is inconsistent with the prompt")
-    if not torch.equal(
-        metadata["prompt_token_ids"], metadata["prompt_token_ids"][0].repeat(16, 1)
-    ):
+    if not torch.equal(metadata["prompt_token_ids"], metadata["prompt_token_ids"][0].repeat(16, 1)):
         raise ValueError("batch prompt rows must be identical")
 
 
-def load_fixture(
-    root: Path, expected_versions: dict[str, str] | None = None
-) -> Fixture:
+def load_fixture(root: Path, expected_versions: dict[str, str] | None = None) -> Fixture:
     root = root.resolve()
     fixture_sums = _verify_sums(root)
     manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
@@ -334,10 +308,7 @@ def load_fixture(
             raise ValueError(f"full fixture must contain {expected_shards} KV shards")
         for entry in manifest["kv_shards"]:
             path = root / entry["path"]
-            if (
-                path.stat().st_size != int(entry["bytes"])
-                or fixture_sums.get(Path(entry["path"])) != entry["sha256"]
-            ):
+            if path.stat().st_size != int(entry["bytes"]) or fixture_sums.get(Path(entry["path"])) != entry["sha256"]:
                 raise ValueError(f"KV shard checksum mismatch: {entry['path']}")
         fixture.verify_artifact_and_golden()
     return fixture
@@ -358,9 +329,7 @@ def main() -> int:
                 "schema": fixture.manifest["schema"],
                 "metadata_only": fixture.metadata_only,
                 "used_page_count": len(fixture.metadata["used_page_ids"]),
-                "decode_dispatches_remaining": fixture.manifest[
-                    "decode_dispatches_remaining"
-                ],
+                "decode_dispatches_remaining": fixture.manifest["decode_dispatches_remaining"],
             },
             sort_keys=True,
         )

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/run_standalone_0p1.sh
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/run_standalone_0p1.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+set -eo pipefail
+
+DEVICE_ID="${1:?usage: run_standalone_0p1.sh DEVICE_ID OUTPUT_ROOT [MODE] [STEPS]}"
+OUTPUT_ROOT="${2:?usage: run_standalone_0p1.sh DEVICE_ID OUTPUT_ROOT [MODE] [STEPS]}"
+MODE="${3:-single}"
+STEPS="${4:-127}"
+: "${PYTHON_BIN:?set PYTHON_BIN to the isolated Python interpreter}"
+: "${PYPTO_ROOT:?set PYPTO_ROOT to the PyPTO checkout}"
+: "${PYPTO_LIB_ROOT:?set PYPTO_LIB_ROOT to the matching pypto-lib checkout}"
+: "${PTOAS_ROOT:?set PTOAS_ROOT to the matching PTOAS installation}"
+: "${FIXTURE_ROOT:?set FIXTURE_ROOT to the prefill KV snapshot}"
+: "${MODEL_DIR:?set MODEL_DIR to the Qwen3-14B checkpoint}"
+: "${ARTIFACT_SOURCE:?set ARTIFACT_SOURCE to the decode artifact}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+case "$MODE" in
+  single) BENCHMARK="$SCRIPT_DIR/benchmark.py" ;;
+  dual) BENCHMARK="$SCRIPT_DIR/benchmark_dual.py" ;;
+  *) echo "mode must be single or dual: $MODE" >&2; exit 2 ;;
+esac
+if (( STEPS < 1 || STEPS > 127 )); then
+  echo "steps must be in [1, 127]: $STEPS" >&2
+  exit 2
+fi
+STEADY_SKIP=5
+if (( STEPS <= STEADY_SKIP )); then
+  STEADY_SKIP=0
+fi
+RESULT="$OUTPUT_ROOT/results/${MODE}_0warmup_1measured"
+ARTIFACT_WORK="$OUTPUT_ROOT/artifact_work/${MODE}_0warmup_1measured"
+RUNLOG="$OUTPUT_ROOT/logs/${MODE}_0warmup_1measured"
+
+test ! -e "$RESULT"
+test ! -e "$ARTIFACT_WORK"
+eval "$(pypto-setup --export)"
+test -f "$ASCEND_HOME_PATH/set_env.sh"
+source "$ASCEND_HOME_PATH/set_env.sh"
+set -u
+
+mkdir -p "$OUTPUT_ROOT/results" "$OUTPUT_ROOT/artifact_work" "$RUNLOG"
+export PYTHONNOUSERSITE=1
+export PYTHONDONTWRITEBYTECODE=1
+export PYTHONPATH="$PYPTO_ROOT/python:$PYPTO_LIB_ROOT:$REPO_ROOT/python:$SCRIPT_DIR"
+export PATH="$PTOAS_ROOT/bin:$PATH"
+export PYPTO_PROG_BUILD_DIR="$OUTPUT_ROOT/compile_cache"
+export ASCEND_PROCESS_LOG_PATH="$RUNLOG/ascend"
+export SIMPLER_DEVICE_STRACE_ENABLE=1
+unset PTO2_OP_EXECUTE_TIMEOUT_US PTO2_STREAM_SYNC_TIMEOUT_MS
+unset PTO2_RING_DEP_POOL PTO2_RING_TASK_WINDOW PTO2_RING_HEAP
+unset PYPTO_RING_DEP_POOL PYPTO_RING_TASK_WINDOW PYPTO_RING_HEAP
+
+mkdir -p "$ASCEND_PROCESS_LOG_PATH" "$PYPTO_PROG_BUILD_DIR"
+npu-smi info -t board -i "$DEVICE_ID" -c 0 > "$RUNLOG/device_before.txt" 2>&1 || true
+capture_after() {
+  npu-smi info -t board -i "$DEVICE_ID" -c 0 > "$RUNLOG/device_after.txt" 2>&1 || true
+}
+trap capture_after EXIT
+
+"$PYTHON_BIN" "$BENCHMARK" \
+  --fixture "$FIXTURE_ROOT" \
+  --fixture-module "$SCRIPT_DIR/fixture.py" \
+  --weights-module "$SCRIPT_DIR/weights.py" \
+  --model-dir "$MODEL_DIR" \
+  --artifact-source "$ARTIFACT_SOURCE" \
+  --artifact-work-dir "$ARTIFACT_WORK" \
+  --output-dir "$RESULT" \
+  --mode "$MODE" \
+  --device-id "$DEVICE_ID" \
+  --warmup-runs 0 \
+  --measured-runs 1 \
+  --steady-skip "$STEADY_SKIP" \
+  --inter-run-wait 0 \
+  --qualification-steps "$STEPS" \
+  2>&1 | tee "$RUNLOG/run.log"
+
+cp "$RUNLOG/run.log" "$RESULT/run.log"
+cp "$RUNLOG/device_before.txt" "$RESULT/device_before.txt"
+"$PYTHON_BIN" "$SCRIPT_DIR/trace_effective.py" \
+  --log "$RESULT/run.log" \
+  --output "$RESULT/trace_summary.json" \
+  --warmup-runs 0 \
+  --measured-runs 1 \
+  --steps "$STEPS" \
+  --steady-skip "$STEADY_SKIP"
+"$PYTHON_BIN" "$SCRIPT_DIR/export_strace_timeline.py" \
+  --log "$RESULT/run.log" \
+  --output-dir "$RESULT/profile"
+
+if [[ "$MODE" == "dual" ]]; then
+  "$PYTHON_BIN" "$SCRIPT_DIR/validate_dual_result.py" \
+    --result "$RESULT" \
+    --fixture "$FIXTURE_ROOT" \
+    --golden-manifest "$FIXTURE_ROOT/../../golden/qualification/manifest.json" \
+    --steps "$STEPS"
+fi
+
+checksum_files=(
+  "$RESULT/benchmark.json"
+  "$RESULT/trace_summary.json"
+  "$RESULT/profile/simpler_strace_timeline.json"
+)
+if [[ "$MODE" == "dual" ]]; then
+  checksum_files+=("$RESULT/dual_validation.json")
+fi
+sha256sum "${checksum_files[@]}" > "$RESULT/SHA256SUMS"

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/selftest.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/selftest.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""CPU checks for standalone single/dual buffer selection and slot metadata."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import torch
+
+import benchmark
+
+
+DUAL_PATH = Path(__file__).with_name("benchmark_dual.py")
+DUAL_SPEC = importlib.util.spec_from_file_location("benchmark_dual", DUAL_PATH)
+assert DUAL_SPEC is not None and DUAL_SPEC.loader is not None
+benchmark_dual = importlib.util.module_from_spec(DUAL_SPEC)
+sys.modules[DUAL_SPEC.name] = benchmark_dual
+DUAL_SPEC.loader.exec_module(benchmark_dual)
+
+
+def main() -> int:
+    assert callable(benchmark._run_sequence)
+    assert callable(benchmark_dual._run_sequence)
+
+    initial = torch.full((16 * 32,), -1, dtype=torch.int32)
+    initial.view(16, 32)[:, :27] = torch.arange(432, dtype=torch.int32).view(16, 27)
+    slots = []
+    for _ in range(2):
+        slots.append(
+            {
+                "seq_lens": torch.zeros(16, dtype=torch.int32),
+                "slot_mapping": torch.zeros(16, dtype=torch.int32),
+                "block_table": initial.clone(),
+                "sampled_ids_host": torch.zeros((16, 8), dtype=torch.int32),
+            }
+        )
+    golden = {
+        "seq_lens": torch.full((2, 16), 3457, dtype=torch.int32),
+        "slot_mapping": torch.stack(
+            (torch.arange(432, 448, dtype=torch.int32) * 128,) * 2
+        ),
+    }
+    benchmark._update_slot(slots[0], golden, 0)
+    assert torch.all(slots[1]["block_table"].view(16, 32)[:, 27] == -1)
+    benchmark._update_slot(slots[1], golden, 1)
+    assert torch.equal(
+        slots[0]["block_table"].view(16, 32)[:, 27],
+        torch.arange(432, 448, dtype=torch.int32),
+    )
+    assert torch.equal(
+        slots[1]["block_table"].view(16, 32)[:, 27],
+        torch.arange(432, 448, dtype=torch.int32),
+    )
+    print("standalone single/dual CPU checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/selftest.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/selftest.py
@@ -15,10 +15,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
-import torch
-
 import benchmark
-
+import torch
 
 DUAL_PATH = Path(__file__).with_name("benchmark_dual.py")
 DUAL_SPEC = importlib.util.spec_from_file_location("benchmark_dual", DUAL_PATH)
@@ -46,9 +44,7 @@ def main() -> int:
         )
     golden = {
         "seq_lens": torch.full((2, 16), 3457, dtype=torch.int32),
-        "slot_mapping": torch.stack(
-            (torch.arange(432, 448, dtype=torch.int32) * 128,) * 2
-        ),
+        "slot_mapping": torch.stack((torch.arange(432, 448, dtype=torch.int32) * 128,) * 2),
     }
     benchmark._update_slot(slots[0], golden, 0)
     assert torch.all(slots[1]["block_table"].view(16, 32)[:, 27] == -1)

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/stack_manifest.json
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/stack_manifest.json
@@ -1,0 +1,42 @@
+{
+  "schema": "simpler-qwen3-14b-standalone-decode-baseline-v2",
+  "software": {
+    "simpler": "56511f80f469458b6103b0d25e11fb800bc1d8a5",
+    "simpler_patch": "TaskTensor shim from compare1_compat",
+    "pypto": "f1a2f35f0fe36248f9302f60b56b2865adbf92ed",
+    "pypto_lib": "7f8d7ea816d2817cef5962e56dccc66fbbaa3c44",
+    "python": "3.10",
+    "torch": "2.6.0",
+    "torch_npu": "2.6.0",
+    "cann": "9.0.0",
+    "ptoas": "0.57"
+  },
+  "workload": {
+    "model": "Qwen3-14B",
+    "dtype": "bfloat16",
+    "prompt_tokens": 3338,
+    "batch_size": 16,
+    "output_tokens": 128,
+    "consumed_decode_dispatches": 127,
+    "pure_warmup_runs": 0,
+    "pure_measured_runs": 1,
+    "steady_skip_dispatches": 5,
+    "runtime_slots": [0, 1],
+    "kv_backing_page_count": 691,
+    "ring_task_window": 131072,
+    "ring_dep_pool": 131072,
+    "ring_heap_bytes": [1073741824, 1073741824, 1073741824, 8589934592]
+  },
+  "runtime_dependency": {
+    "pypto_serving_required": false,
+    "prefill_required": false,
+    "fixture_kind": "frozen post-prefill KV snapshot"
+  },
+  "input_digests": {
+    "fixture_manifest": "provided-by-caller",
+    "fixture_sha256sums": "provided-by-caller",
+    "artifact_manifest": "provided-by-caller",
+    "artifact_sha256sums": "provided-by-caller",
+    "golden_manifest": "provided-by-caller"
+  }
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/trace_effective.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/trace_effective.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Extract Serving-compatible runtime timing from a pure Simpler STRACE log."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+
+
+_STRACE_RE = re.compile(
+    r"\[STRACE\]\s+v=(?P<version>\d+)\s+pid=(?P<pid>\d+)\s+tid=(?P<tid>\d+)\s+"
+    r"inv=(?P<inv>\d+)\s+hid=(?P<hid>[0-9a-fA-F]+)\s+depth=(?P<depth>\d+)\s+"
+    r"name=(?P<name>\S+)\s+ts=(?P<ts>\d+)\s+dur=(?P<dur>\d+)(?:\s+(?P<attrs>.*))?"
+)
+_ATTR_RE = re.compile(r"(?P<key>[A-Za-z_][A-Za-z0-9_]*)=(?P<value>\S+)")
+
+
+@dataclass(frozen=True)
+class Span:
+    pid: int
+    tid: int
+    inv: int
+    hid: str
+    name: str
+    timestamp_ns: int
+    duration_ms: float
+    attrs: dict[str, str]
+
+
+def _parse_attrs(text: str | None) -> dict[str, str]:
+    if not text:
+        return {}
+    return {
+        match.group("key"): match.group("value") for match in _ATTR_RE.finditer(text)
+    }
+
+
+def parse_spans(log_path: Path) -> list[Span]:
+    spans = []
+    for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = _STRACE_RE.search(line)
+        if match is None:
+            continue
+        spans.append(
+            Span(
+                pid=int(match.group("pid")),
+                tid=int(match.group("tid")),
+                inv=int(match.group("inv")),
+                hid=match.group("hid"),
+                name=match.group("name"),
+                timestamp_ns=int(match.group("ts")),
+                duration_ms=int(match.group("dur")) / 1_000_000.0,
+                attrs=_parse_attrs(match.group("attrs")),
+            )
+        )
+    return spans
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    low = math.floor(position)
+    high = math.ceil(position)
+    if low == high:
+        return ordered[low]
+    return ordered[low] + (ordered[high] - ordered[low]) * (position - low)
+
+
+def _stats(values: list[float]) -> dict[str, float | int]:
+    if not values:
+        raise ValueError("cannot summarize an empty metric")
+    mean = statistics.fmean(values)
+    return {
+        "count": len(values),
+        "mean": mean,
+        "std": statistics.pstdev(values) if len(values) > 1 else 0.0,
+        "min": min(values),
+        "p50": _percentile(values, 0.50),
+        "p95": _percentile(values, 0.95),
+        "p99": _percentile(values, 0.99),
+        "max": max(values),
+    }
+
+
+def _span_by_suffix(spans: list[Span], suffix: str) -> Span | None:
+    matches = [span for span in spans if span.name.endswith(suffix)]
+    if len(matches) > 1:
+        raise ValueError(f"invocation has multiple spans ending in {suffix!r}")
+    return matches[0] if matches else None
+
+
+def _required_duration(spans: list[Span], suffix: str) -> float:
+    span = _span_by_suffix(spans, suffix)
+    if span is None:
+        raise ValueError(f"invocation is missing span ending in {suffix!r}")
+    return span.duration_ms
+
+
+def invocation_rows(spans: list[Span]) -> list[dict[str, float | int | bool]]:
+    roots = [span for span in spans if span.name in {"chip.run", "simpler_run"}]
+    if not roots:
+        raise ValueError("no chip.run or simpler_run root spans found")
+
+    spans_by_inv: dict[int, list[Span]] = {}
+    for span in spans:
+        spans_by_inv.setdefault(span.inv, []).append(span)
+
+    rows = []
+    seen_dispatches = set()
+    for root in roots:
+        dispatch_id = int(root.attrs.get("dispatch_id", root.inv))
+        if dispatch_id in seen_dispatches:
+            raise ValueError(f"duplicate root span for dispatch {dispatch_id}")
+        seen_dispatches.add(dispatch_id)
+        invocation = spans_by_inv[root.inv]
+        node_dispatch = _span_by_suffix(invocation, "node.dispatch")
+        attrs = (
+            root.attrs
+            if node_dispatch is None
+            else {**node_dispatch.attrs, **root.attrs}
+        )
+        effective = _required_duration(invocation, ".runner_run.device_wall.sched")
+        rows.append(
+            {
+                "dispatch_id": dispatch_id,
+                "slot_id": int(attrs.get("slot_id", -1)),
+                "generation": int(attrs.get("generation", -1)),
+                "prepare_only": attrs.get("prepare_only", "0") == "1",
+                "root_start_ns": root.timestamp_ns,
+                "root_completion_ns": root.timestamp_ns
+                + round(root.duration_ms * 1_000_000),
+                "chip_run_lifecycle_ms": root.duration_ms,
+                "runner_run_ms": _required_duration(invocation, ".runner_run"),
+                "effective_ms": effective,
+                "device_wall_ms": _required_duration(
+                    invocation, ".runner_run.device_wall"
+                ),
+                "args_ms": _required_duration(invocation, ".bind.args"),
+                "validate_ms": _required_duration(invocation, ".validate"),
+            }
+        )
+    return sorted(rows, key=lambda row: int(row["dispatch_id"]))
+
+
+def summarize_campaign(
+    rows: list[dict[str, float | int | bool]],
+    *,
+    warmup_runs: int,
+    measured_runs: int,
+    steps: int,
+    steady_skip: int,
+) -> dict[str, object]:
+    expected = (warmup_runs + measured_runs) * steps
+    if len(rows) != expected:
+        raise ValueError(f"expected {expected} dispatches, found {len(rows)}")
+    if steps <= steady_skip:
+        raise ValueError("steady_skip must be smaller than steps")
+
+    measured = rows[warmup_runs * steps :]
+    latency_metrics = (
+        "runner_run_ms",
+        "effective_ms",
+        "device_wall_ms",
+        "args_ms",
+        "validate_ms",
+    )
+    run_summaries = []
+    pooled = {metric: [] for metric in ("rts_completion_interval_ms", *latency_metrics)}
+    diagnostic_lifecycles = []
+    for run_index in range(measured_runs):
+        start = run_index * steps
+        run_rows = measured[start : start + steps]
+        steady_rows = run_rows[steady_skip:]
+        dispatches = [int(row["dispatch_id"]) for row in run_rows]
+        completions = [int(row["root_completion_ns"]) for row in run_rows]
+        if any(
+            current <= previous for previous, current in zip(dispatches, dispatches[1:])
+        ):
+            raise ValueError(
+                f"run {run_index + 1} dispatch ids are not strictly increasing"
+            )
+        if any(
+            current <= previous
+            for previous, current in zip(completions, completions[1:])
+        ):
+            raise ValueError(
+                f"run {run_index + 1} root completions are not strictly increasing"
+            )
+
+        interval_values = [
+            (completions[index] - completions[index - 1]) / 1_000_000.0
+            for index in range(steady_skip, steps)
+        ]
+        metric_stats = {"rts_completion_interval_ms": _stats(interval_values)}
+        pooled["rts_completion_interval_ms"].extend(interval_values)
+        for metric in latency_metrics:
+            values = [float(row[metric]) for row in steady_rows]
+            metric_stats[metric] = _stats(values)
+            pooled[metric].extend(values)
+        lifecycle_values = [float(row["chip_run_lifecycle_ms"]) for row in steady_rows]
+        diagnostic_lifecycles.extend(lifecycle_values)
+        run_summaries.append(
+            {
+                "run": run_index + 1,
+                "dispatch_first": int(run_rows[0]["dispatch_id"]),
+                "dispatch_last": int(run_rows[-1]["dispatch_id"]),
+                "steady_dispatch_count": len(steady_rows),
+                "metrics": metric_stats,
+                "diagnostic_metrics": {
+                    "chip_run_lifecycle_ms": _stats(lifecycle_values),
+                },
+            }
+        )
+
+    official = {}
+    for metric in pooled:
+        run_means = [float(run["metrics"][metric]["mean"]) for run in run_summaries]
+        official[metric] = {
+            "run_means": run_means,
+            "run_mean_stats": _stats(run_means),
+            "pooled_steady_stats": _stats(pooled[metric]),
+        }
+
+    return {
+        "schema": 2,
+        "aggregation": {
+            "warmup_runs": warmup_runs,
+            "measured_runs": measured_runs,
+            "retained_run_numbers": list(range(1, measured_runs + 1)),
+            "drop_high_low_run": False,
+            "steps_per_run": steps,
+            "steady_skip_dispatches": steady_skip,
+            "steady_dispatches_per_run": steps - steady_skip,
+        },
+        "dispatch_contract": {
+            "total": len(rows),
+            "warmup": warmup_runs * steps,
+            "measured": measured_runs * steps,
+        },
+        "runs": run_summaries,
+        "official_metrics": official,
+        "diagnostic_metrics": {
+            "chip_run_lifecycle_ms": {
+                "status": "diagnostic_only",
+                "reason": "async-overlapped invocation lifetime is not frame latency or throughput",
+                "pooled_steady_stats": _stats(diagnostic_lifecycles),
+            }
+        },
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--warmup-runs", type=int, default=1)
+    parser.add_argument("--measured-runs", type=int, default=5)
+    parser.add_argument("--steps", type=int, default=127)
+    parser.add_argument("--steady-skip", type=int, default=5)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    summary = summarize_campaign(
+        invocation_rows(parse_spans(args.log)),
+        warmup_runs=args.warmup_runs,
+        measured_runs=args.measured_runs,
+        steps=args.steps,
+        steady_skip=args.steady_skip,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/trace_effective.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/trace_effective.py
@@ -182,10 +182,12 @@ def summarize_campaign(
             raise ValueError(f"run {run_index + 1} root completions are not strictly increasing")
 
         interval_values = [
-            (completions[index] - completions[index - 1]) / 1_000_000.0 for index in range(steady_skip, steps)
+            (completions[index] - completions[index - 1]) / 1_000_000.0 for index in range(max(1, steady_skip), steps)
         ]
-        metric_stats = {"rts_completion_interval_ms": _stats(interval_values)}
-        pooled["rts_completion_interval_ms"].extend(interval_values)
+        metric_stats = {}
+        if interval_values:
+            metric_stats["rts_completion_interval_ms"] = _stats(interval_values)
+            pooled["rts_completion_interval_ms"].extend(interval_values)
         for metric in latency_metrics:
             values = [float(row[metric]) for row in steady_rows]
             metric_stats[metric] = _stats(values)
@@ -207,6 +209,8 @@ def summarize_campaign(
 
     official = {}
     for metric, values in pooled.items():
+        if not values:
+            continue
         run_means = [float(run["metrics"][metric]["mean"]) for run in run_summaries]
         official[metric] = {
             "run_means": run_means,

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/trace_effective.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/trace_effective.py
@@ -19,7 +19,6 @@ import statistics
 from dataclasses import dataclass
 from pathlib import Path
 
-
 _STRACE_RE = re.compile(
     r"\[STRACE\]\s+v=(?P<version>\d+)\s+pid=(?P<pid>\d+)\s+tid=(?P<tid>\d+)\s+"
     r"inv=(?P<inv>\d+)\s+hid=(?P<hid>[0-9a-fA-F]+)\s+depth=(?P<depth>\d+)\s+"
@@ -43,9 +42,7 @@ class Span:
 def _parse_attrs(text: str | None) -> dict[str, str]:
     if not text:
         return {}
-    return {
-        match.group("key"): match.group("value") for match in _ATTR_RE.finditer(text)
-    }
+    return {match.group("key"): match.group("value") for match in _ATTR_RE.finditer(text)}
 
 
 def parse_spans(log_path: Path) -> list[Span]:
@@ -127,11 +124,7 @@ def invocation_rows(spans: list[Span]) -> list[dict[str, float | int | bool]]:
         seen_dispatches.add(dispatch_id)
         invocation = spans_by_inv[root.inv]
         node_dispatch = _span_by_suffix(invocation, "node.dispatch")
-        attrs = (
-            root.attrs
-            if node_dispatch is None
-            else {**node_dispatch.attrs, **root.attrs}
-        )
+        attrs = root.attrs if node_dispatch is None else {**node_dispatch.attrs, **root.attrs}
         effective = _required_duration(invocation, ".runner_run.device_wall.sched")
         rows.append(
             {
@@ -140,14 +133,11 @@ def invocation_rows(spans: list[Span]) -> list[dict[str, float | int | bool]]:
                 "generation": int(attrs.get("generation", -1)),
                 "prepare_only": attrs.get("prepare_only", "0") == "1",
                 "root_start_ns": root.timestamp_ns,
-                "root_completion_ns": root.timestamp_ns
-                + round(root.duration_ms * 1_000_000),
+                "root_completion_ns": root.timestamp_ns + round(root.duration_ms * 1_000_000),
                 "chip_run_lifecycle_ms": root.duration_ms,
                 "runner_run_ms": _required_duration(invocation, ".runner_run"),
                 "effective_ms": effective,
-                "device_wall_ms": _required_duration(
-                    invocation, ".runner_run.device_wall"
-                ),
+                "device_wall_ms": _required_duration(invocation, ".runner_run.device_wall"),
                 "args_ms": _required_duration(invocation, ".bind.args"),
                 "validate_ms": _required_duration(invocation, ".validate"),
             }
@@ -186,23 +176,13 @@ def summarize_campaign(
         steady_rows = run_rows[steady_skip:]
         dispatches = [int(row["dispatch_id"]) for row in run_rows]
         completions = [int(row["root_completion_ns"]) for row in run_rows]
-        if any(
-            current <= previous for previous, current in zip(dispatches, dispatches[1:])
-        ):
-            raise ValueError(
-                f"run {run_index + 1} dispatch ids are not strictly increasing"
-            )
-        if any(
-            current <= previous
-            for previous, current in zip(completions, completions[1:])
-        ):
-            raise ValueError(
-                f"run {run_index + 1} root completions are not strictly increasing"
-            )
+        if any(current <= previous for previous, current in zip(dispatches, dispatches[1:])):
+            raise ValueError(f"run {run_index + 1} dispatch ids are not strictly increasing")
+        if any(current <= previous for previous, current in zip(completions, completions[1:])):
+            raise ValueError(f"run {run_index + 1} root completions are not strictly increasing")
 
         interval_values = [
-            (completions[index] - completions[index - 1]) / 1_000_000.0
-            for index in range(steady_skip, steps)
+            (completions[index] - completions[index - 1]) / 1_000_000.0 for index in range(steady_skip, steps)
         ]
         metric_stats = {"rts_completion_interval_ms": _stats(interval_values)}
         pooled["rts_completion_interval_ms"].extend(interval_values)
@@ -226,12 +206,12 @@ def summarize_campaign(
         )
 
     official = {}
-    for metric in pooled:
+    for metric, values in pooled.items():
         run_means = [float(run["metrics"][metric]["mean"]) for run in run_summaries]
         official[metric] = {
             "run_means": run_means,
             "run_mean_stats": _stats(run_means),
-            "pooled_steady_stats": _stats(pooled[metric]),
+            "pooled_steady_stats": _stats(values),
         }
 
     return {
@@ -283,9 +263,7 @@ def main() -> int:
         steady_skip=args.steady_skip,
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(
-        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
+    args.output.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return 0
 
 

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/validate_dual_result.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/validate_dual_result.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Validate one standalone dual-slot decode result."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+
+from safetensors.torch import load_file
+
+from trace_effective import invocation_rows, parse_spans
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _full_output_sha(first_tokens: list[int], token_rows: list[list[int]]) -> str:
+    per_request = [
+        [int(first_tokens[batch])] + [int(row[batch]) for row in token_rows]
+        for batch in range(len(first_tokens))
+    ]
+    payload = json.dumps(per_request, separators=(",", ":")).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--result", type=Path, required=True)
+    parser.add_argument("--fixture", type=Path, required=True)
+    parser.add_argument("--golden-manifest", type=Path, required=True)
+    parser.add_argument("--steps", type=int, required=True)
+    args = parser.parse_args()
+
+    benchmark = json.loads((args.result / "benchmark.json").read_text())
+    trace = json.loads((args.result / "trace_summary.json").read_text())
+    run = benchmark["runs"][0]
+    scenario = benchmark["scenario"]
+    _require(benchmark["correctness"]["all_runs_valid"], "benchmark correctness failed")
+    _require(scenario["mode"] == "dual", "result is not dual-slot")
+    _require(
+        scenario["warmup_runs"] == 0 and scenario["measured_runs"] == 1, "expected 0+1"
+    )
+    _require(scenario["decode_dispatches"] == args.steps, "decode step count mismatch")
+    _require(
+        run["valid"] and len(run["token_rows"]) == args.steps, "incomplete token rows"
+    )
+
+    rows = invocation_rows(parse_spans(args.result / "run.log"))
+    _require(len(rows) == args.steps, "native dispatch count mismatch")
+    expected_slots = [index % 2 for index in range(args.steps)]
+    actual_slots = [int(row["slot_id"]) for row in rows]
+    _require(actual_slots == expected_slots, "native slots do not strictly alternate")
+
+    generations = [0, 0]
+    for row in rows:
+        slot = int(row["slot_id"])
+        generations[slot] += 1
+        _require(
+            int(row["generation"]) == generations[slot],
+            "slot generation is not monotonic",
+        )
+    _require(not bool(rows[0]["prepare_only"]), "first dispatch must start immediately")
+    _require(
+        all(bool(row["prepare_only"]) for row in rows[1:]),
+        "later dispatch was not prepared",
+    )
+
+    host_runners = sorted(
+        (
+            span
+            for span in parse_spans(args.result / "run.log")
+            if span.name.endswith(".runner_run") and span.attrs.get("clk") != "dev"
+        ),
+        key=lambda span: span.timestamp_ns,
+    )
+    _require(len(host_runners) == args.steps, "runner span count mismatch")
+    for previous, current in zip(host_runners, host_runners[1:]):
+        previous_end = previous.timestamp_ns + round(previous.duration_ms * 1_000_000)
+        _require(current.timestamp_ns >= previous_end, "device runner spans overlap")
+
+    aggregation = trace["aggregation"]
+    steady_skip = int(aggregation["steady_skip_dispatches"])
+    expected_steady = args.steps - steady_skip
+    effective = trace["official_metrics"]["effective_ms"]["pooled_steady_stats"]
+    _require(effective["count"] == expected_steady, "steady Effective count mismatch")
+
+    full_output_sha = None
+    if args.steps == 127:
+        fixture_manifest = json.loads((args.fixture / "manifest.json").read_text())
+        metadata = load_file(str(args.fixture / fixture_manifest["metadata"]["path"]))
+        golden_manifest = json.loads(args.golden_manifest.read_text())
+        full_output_sha = _full_output_sha(
+            metadata["first_generated_token_ids"].tolist(), run["token_rows"]
+        )
+        _require(
+            full_output_sha == golden_manifest["full_128_output_token_ids_sha256"],
+            "full output token SHA differs from golden",
+        )
+
+    slots = Counter(actual_slots)
+    result = {
+        "schema": "simpler-tmr-dual-qualification-v1",
+        "passed": True,
+        "steps": args.steps,
+        "warmup_runs": 0,
+        "measured_runs": 1,
+        "runtime_slots": {str(slot): count for slot, count in sorted(slots.items())},
+        "final_slot_generations": {"0": generations[0], "1": generations[1]},
+        "prepare_only_after_first": True,
+        "device_runner_serial": True,
+        "full_128_output_token_ids_sha256": full_output_sha,
+        "rts_completion_interval_ms": trace["official_metrics"][
+            "rts_completion_interval_ms"
+        ]["pooled_steady_stats"],
+        "runner_run_ms": trace["official_metrics"]["runner_run_ms"][
+            "pooled_steady_stats"
+        ],
+        "effective_ms": effective,
+        "effective_over_50ms_count": sum(
+            float(row["effective_ms"]) > 50.0 for row in rows[steady_skip:]
+        ),
+        "effective_over_70ms_count": sum(
+            float(row["effective_ms"]) > 70.0 for row in rows[steady_skip:]
+        ),
+    }
+    output = args.result / "dual_validation.json"
+    output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/validate_dual_result.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/validate_dual_result.py
@@ -54,6 +54,11 @@ def main() -> int:
 
     rows = invocation_rows(parse_spans(args.result / "run.log"))
     _require(len(rows) == args.steps, "native dispatch count mismatch")
+    dispatch_ids = [int(row["dispatch_id"]) for row in rows]
+    _require(
+        all(current == previous + 1 for previous, current in zip(dispatch_ids, dispatch_ids[1:])),
+        "native dispatch IDs are not contiguous",
+    )
     expected_slots = [index % 2 for index in range(args.steps)]
     actual_slots = [int(row["slot_id"]) for row in rows]
     _require(actual_slots == expected_slots, "native slots do not strictly alternate")
@@ -114,12 +119,14 @@ def main() -> int:
         "prepare_only_after_first": True,
         "device_runner_serial": True,
         "full_128_output_token_ids_sha256": full_output_sha,
-        "rts_completion_interval_ms": trace["official_metrics"]["rts_completion_interval_ms"]["pooled_steady_stats"],
         "runner_run_ms": trace["official_metrics"]["runner_run_ms"]["pooled_steady_stats"],
         "effective_ms": effective,
         "effective_over_50ms_count": sum(float(row["effective_ms"]) > 50.0 for row in rows[steady_skip:]),
         "effective_over_70ms_count": sum(float(row["effective_ms"]) > 70.0 for row in rows[steady_skip:]),
     }
+    rts_metric = trace["official_metrics"].get("rts_completion_interval_ms")
+    if rts_metric is not None:
+        result["rts_completion_interval_ms"] = rts_metric["pooled_steady_stats"]
     output = args.result / "dual_validation.json"
     output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
     print(json.dumps(result, indent=2, sort_keys=True))

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/validate_dual_result.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/validate_dual_result.py
@@ -18,7 +18,6 @@ from collections import Counter
 from pathlib import Path
 
 from safetensors.torch import load_file
-
 from trace_effective import invocation_rows, parse_spans
 
 
@@ -29,8 +28,7 @@ def _require(condition: bool, message: str) -> None:
 
 def _full_output_sha(first_tokens: list[int], token_rows: list[list[int]]) -> str:
     per_request = [
-        [int(first_tokens[batch])] + [int(row[batch]) for row in token_rows]
-        for batch in range(len(first_tokens))
+        [int(first_tokens[batch])] + [int(row[batch]) for row in token_rows] for batch in range(len(first_tokens))
     ]
     payload = json.dumps(per_request, separators=(",", ":")).encode()
     return hashlib.sha256(payload).hexdigest()
@@ -50,13 +48,9 @@ def main() -> int:
     scenario = benchmark["scenario"]
     _require(benchmark["correctness"]["all_runs_valid"], "benchmark correctness failed")
     _require(scenario["mode"] == "dual", "result is not dual-slot")
-    _require(
-        scenario["warmup_runs"] == 0 and scenario["measured_runs"] == 1, "expected 0+1"
-    )
+    _require(scenario["warmup_runs"] == 0 and scenario["measured_runs"] == 1, "expected 0+1")
     _require(scenario["decode_dispatches"] == args.steps, "decode step count mismatch")
-    _require(
-        run["valid"] and len(run["token_rows"]) == args.steps, "incomplete token rows"
-    )
+    _require(run["valid"] and len(run["token_rows"]) == args.steps, "incomplete token rows")
 
     rows = invocation_rows(parse_spans(args.result / "run.log"))
     _require(len(rows) == args.steps, "native dispatch count mismatch")
@@ -102,9 +96,7 @@ def main() -> int:
         fixture_manifest = json.loads((args.fixture / "manifest.json").read_text())
         metadata = load_file(str(args.fixture / fixture_manifest["metadata"]["path"]))
         golden_manifest = json.loads(args.golden_manifest.read_text())
-        full_output_sha = _full_output_sha(
-            metadata["first_generated_token_ids"].tolist(), run["token_rows"]
-        )
+        full_output_sha = _full_output_sha(metadata["first_generated_token_ids"].tolist(), run["token_rows"])
         _require(
             full_output_sha == golden_manifest["full_128_output_token_ids_sha256"],
             "full output token SHA differs from golden",
@@ -122,19 +114,11 @@ def main() -> int:
         "prepare_only_after_first": True,
         "device_runner_serial": True,
         "full_128_output_token_ids_sha256": full_output_sha,
-        "rts_completion_interval_ms": trace["official_metrics"][
-            "rts_completion_interval_ms"
-        ]["pooled_steady_stats"],
-        "runner_run_ms": trace["official_metrics"]["runner_run_ms"][
-            "pooled_steady_stats"
-        ],
+        "rts_completion_interval_ms": trace["official_metrics"]["rts_completion_interval_ms"]["pooled_steady_stats"],
+        "runner_run_ms": trace["official_metrics"]["runner_run_ms"]["pooled_steady_stats"],
         "effective_ms": effective,
-        "effective_over_50ms_count": sum(
-            float(row["effective_ms"]) > 50.0 for row in rows[steady_skip:]
-        ),
-        "effective_over_70ms_count": sum(
-            float(row["effective_ms"]) > 70.0 for row in rows[steady_skip:]
-        ),
+        "effective_over_50ms_count": sum(float(row["effective_ms"]) > 50.0 for row in rows[steady_skip:]),
+        "effective_over_70ms_count": sum(float(row["effective_ms"]) > 70.0 for row in rows[steady_skip:]),
     }
     output = args.result / "dual_validation.json"
     output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/validate_standalone.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/validate_standalone.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Validate the frozen inputs for the standalone Qwen decode benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _verify_sums(root: Path) -> int:
+    lines = (root / "SHA256SUMS").read_text(encoding="utf-8").splitlines()
+    for line in lines:
+        digest, name = line.split(None, 1)
+        relative = Path(name.removeprefix("./"))
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ValueError(f"unsafe checksum path: {relative}")
+        if _sha256(root / relative) != digest:
+            raise ValueError(f"checksum mismatch: {relative}")
+    return len(lines)
+
+
+def _load_module(path: Path):
+    spec = importlib.util.spec_from_file_location("standalone_fixture", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", type=Path, required=True)
+    parser.add_argument("--artifact", type=Path, required=True)
+    parser.add_argument("--model-dir", type=Path, required=True)
+    parser.add_argument("--stack-manifest", type=Path, required=True)
+    parser.add_argument("--fixture-module", type=Path, required=True)
+    args = parser.parse_args()
+
+    stack = json.loads(args.stack_manifest.read_text(encoding="utf-8"))
+    inputs = stack["inputs"]
+    if _sha256(args.fixture / "manifest.json") != inputs["fixture_manifest_sha256"]:
+        raise ValueError("fixture manifest differs from the frozen stack manifest")
+    if _sha256(args.fixture / "SHA256SUMS") != inputs["fixture_sha256sums_sha256"]:
+        raise ValueError("fixture SHA256SUMS differs from the frozen stack manifest")
+    if _sha256(args.artifact / "SHA256SUMS") != inputs["artifact_sha256sums_sha256"]:
+        raise ValueError("artifact SHA256SUMS differs from the frozen stack manifest")
+
+    fixture_module = _load_module(args.fixture_module.resolve())
+    fixture = fixture_module.load_fixture(
+        args.fixture.resolve(), expected_versions=None
+    )
+    fixture.require_executable()
+    fixture.verify_external_inputs(args.model_dir.resolve())
+    golden = fixture.load_golden()
+    expected_prompt_hash = stack["workload"]["prompt_token_ids_sha256"]
+    if fixture.manifest["prompt"]["token_ids_sha256"] != expected_prompt_hash:
+        raise ValueError("fixture prompt token IDs differ from the frozen workload")
+    if int(fixture.manifest["physical_layout"]["num_pages"]) != 691:
+        raise ValueError("fixture KV backing capacity must match compare1_compat")
+
+    artifact_file_count = _verify_sums(args.artifact.resolve())
+    decode_meta_path = args.artifact / "decode" / "distributed_meta.json"
+    if _sha256(decode_meta_path) != inputs["decode_distributed_meta_sha256"]:
+        raise ValueError("decode distributed metadata differs from the frozen baseline")
+    decode_meta = json.loads(decode_meta_path.read_text(encoding="utf-8"))
+    params = [item["name"].split("__ssa_", 1)[0] for item in decode_meta["params"]]
+    if len(params) != 25 or "sampled_ids" not in params or "sampled_ids_host" in params:
+        raise ValueError("expected the compare1_compat 25-parameter decode ABI")
+    config = decode_meta["distributed_config"]
+    if (
+        config["runtime"] != "tensormap_and_ringbuffer"
+        or config["aicpu_thread_num"] != 4
+    ):
+        raise ValueError("decode runtime configuration differs from compare1_compat")
+
+    result = {
+        "schema": "simpler-standalone-decode-cpu-gate-v1",
+        "passed": True,
+        "runtime_requires_pypto_serving": False,
+        "fixture_schema": fixture.manifest["schema"],
+        "used_page_count": len(fixture.metadata["used_page_ids"]),
+        "golden_decode_steps": int(golden["step_index"].numel()),
+        "prompt_token_ids_sha256": expected_prompt_hash,
+        "kv_backing_page_count": int(fixture.manifest["physical_layout"]["num_pages"]),
+        "decode_abi_parameter_count": len(params),
+        "artifact_file_count": artifact_file_count,
+        "runtime": config["runtime"],
+        "aicpu_thread_num": config["aicpu_thread_num"],
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/validate_standalone.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/validate_standalone.py
@@ -68,9 +68,7 @@ def main() -> int:
         raise ValueError("artifact SHA256SUMS differs from the frozen stack manifest")
 
     fixture_module = _load_module(args.fixture_module.resolve())
-    fixture = fixture_module.load_fixture(
-        args.fixture.resolve(), expected_versions=None
-    )
+    fixture = fixture_module.load_fixture(args.fixture.resolve(), expected_versions=None)
     fixture.require_executable()
     fixture.verify_external_inputs(args.model_dir.resolve())
     golden = fixture.load_golden()
@@ -89,10 +87,7 @@ def main() -> int:
     if len(params) != 25 or "sampled_ids" not in params or "sampled_ids_host" in params:
         raise ValueError("expected the compare1_compat 25-parameter decode ABI")
     config = decode_meta["distributed_config"]
-    if (
-        config["runtime"] != "tensormap_and_ringbuffer"
-        or config["aicpu_thread_num"] != 4
-    ):
+    if config["runtime"] != "tensormap_and_ringbuffer" or config["aicpu_thread_num"] != 4:
         raise ValueError("decode runtime configuration differs from compare1_compat")
 
     result = {

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/weights.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/weights.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Qwen3-14B checkpoint conversion for the decode callable ABI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterator
+
+import torch
+from safetensors import safe_open
+
+
+NUM_LAYERS = 40
+HEAD_DIM = 128
+HIDDEN = 5120
+PADDED_VOCAB = 152064
+MAX_SEQ_LEN = 4096
+
+
+class CheckpointReader:
+    def __init__(self, model_dir: Path):
+        self.model_dir = model_dir
+        index = json.loads((model_dir / "model.safetensors.index.json").read_text())
+        self.weight_map: dict[str, str] = index["weight_map"]
+
+    def load(self, name: str) -> torch.Tensor:
+        shard = self.weight_map.get(name)
+        if shard is None:
+            raise KeyError(name)
+        with safe_open(self.model_dir / shard, framework="pt", device="cpu") as handle:
+            return handle.get_tensor(name)
+
+    def load_optional(self, name: str, default: torch.Tensor) -> torch.Tensor:
+        return self.load(name) if name in self.weight_map else default
+
+
+def _stack_layers(
+    reader: CheckpointReader,
+    suffix: str,
+    *,
+    dtype: torch.dtype,
+    transpose: bool,
+) -> torch.Tensor:
+    layers = []
+    for layer in range(NUM_LAYERS):
+        tensor = reader.load(f"model.layers.{layer}.{suffix}")
+        tensor = tensor.transpose(0, 1) if transpose else tensor.view(1, -1)
+        layers.append(tensor.to(dtype).contiguous())
+    return torch.cat(layers, dim=0).contiguous()
+
+
+def iter_kernel_weights(model_dir: Path) -> Iterator[tuple[str, torch.Tensor]]:
+    reader = CheckpointReader(model_dir)
+    rules = (
+        ("input_rms_weight", "input_layernorm.weight", torch.float32, False),
+        ("wq", "self_attn.q_proj.weight", torch.bfloat16, True),
+        ("wk", "self_attn.k_proj.weight", torch.bfloat16, True),
+        ("wv", "self_attn.v_proj.weight", torch.bfloat16, True),
+        ("wo", "self_attn.o_proj.weight", torch.bfloat16, True),
+        ("w_gate", "mlp.gate_proj.weight", torch.bfloat16, True),
+        ("w_up", "mlp.up_proj.weight", torch.bfloat16, True),
+        ("w_down", "mlp.down_proj.weight", torch.bfloat16, True),
+        ("post_rms_weight", "post_attention_layernorm.weight", torch.float32, False),
+    )
+    for target, suffix, dtype, transpose in rules:
+        yield target, _stack_layers(reader, suffix, dtype=dtype, transpose=transpose)
+
+    for target, suffix in (
+        ("q_norm_weight", "q_norm.weight"),
+        ("k_norm_weight", "k_norm.weight"),
+    ):
+        layers = []
+        for layer in range(NUM_LAYERS):
+            layers.append(
+                reader.load_optional(
+                    f"model.layers.{layer}.self_attn.{suffix}",
+                    torch.ones(HEAD_DIM, dtype=torch.float32),
+                )
+                .view(1, -1)
+                .float()
+            )
+        yield target, torch.cat(layers, dim=0).contiguous()
+
+    yield (
+        "final_norm_weight",
+        reader.load("model.norm.weight").view(1, -1).float().contiguous(),
+    )
+
+    embed = reader.load("model.embed_tokens.weight").to(torch.bfloat16).contiguous()
+    if embed.shape[0] < PADDED_VOCAB:
+        padding = torch.zeros(
+            (PADDED_VOCAB - embed.shape[0], HIDDEN), dtype=embed.dtype
+        )
+        embed = torch.cat((embed, padding), dim=0).contiguous()
+    yield "embed_weight", embed
+
+    lm_name = (
+        "lm_head.weight"
+        if "lm_head.weight" in reader.weight_map
+        else "model.embed_tokens.weight"
+    )
+    lm_head = reader.load(lm_name).to(torch.bfloat16).contiguous()
+    if lm_head.shape[0] < PADDED_VOCAB:
+        padding = lm_head[:1].expand(PADDED_VOCAB - lm_head.shape[0], -1).clone()
+        lm_head = torch.cat((lm_head, padding), dim=0).contiguous()
+    yield "lm_head_weight", lm_head
+
+
+def rope_tables(model_dir: Path) -> tuple[torch.Tensor, torch.Tensor]:
+    config = json.loads((model_dir / "config.json").read_text())
+    theta = float(config.get("rope_theta", 1_000_000.0))
+    half = HEAD_DIM // 2
+    positions = torch.arange(MAX_SEQ_LEN, dtype=torch.float32).unsqueeze(1)
+    inv_freq = 1.0 / (theta ** (torch.arange(half, dtype=torch.float32) / half))
+    angles = positions * inv_freq.unsqueeze(0)
+    return (
+        torch.cat((angles.cos(), angles.cos()), dim=1).contiguous(),
+        torch.cat((angles.sin(), angles.sin()), dim=1).contiguous(),
+    )

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/weights.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_serving_effective/weights.py
@@ -12,12 +12,11 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Iterator
 
 import torch
 from safetensors import safe_open
-
 
 NUM_LAYERS = 40
 HEAD_DIM = 128
@@ -97,17 +96,11 @@ def iter_kernel_weights(model_dir: Path) -> Iterator[tuple[str, torch.Tensor]]:
 
     embed = reader.load("model.embed_tokens.weight").to(torch.bfloat16).contiguous()
     if embed.shape[0] < PADDED_VOCAB:
-        padding = torch.zeros(
-            (PADDED_VOCAB - embed.shape[0], HIDDEN), dtype=embed.dtype
-        )
+        padding = torch.zeros((PADDED_VOCAB - embed.shape[0], HIDDEN), dtype=embed.dtype)
         embed = torch.cat((embed, padding), dim=0).contiguous()
     yield "embed_weight", embed
 
-    lm_name = (
-        "lm_head.weight"
-        if "lm_head.weight" in reader.weight_map
-        else "model.embed_tokens.weight"
-    )
+    lm_name = "lm_head.weight" if "lm_head.weight" in reader.weight_map else "model.embed_tokens.weight"
     lm_head = reader.load(lm_name).to(torch.bfloat16).contiguous()
     if lm_head.shape[0] < PADDED_VOCAB:
         padding = lm_head[:1].expand(PADDED_VOCAB - lm_head.shape[0], -1).clone()

--- a/tests/ut/py/test_qwen3_14b_serving_effective.py
+++ b/tests/ut/py/test_qwen3_14b_serving_effective.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+
+CASE_DIR = (
+    Path(__file__).resolve().parents[3]
+    / "examples"
+    / "a2a3"
+    / "tensormap_and_ringbuffer"
+    / "qwen3_14b_serving_effective"
+)
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+benchmark = _load_module("qwen3_14b_tmr_benchmark", CASE_DIR / "benchmark.py")
+benchmark_dual = _load_module(
+    "qwen3_14b_tmr_benchmark_dual", CASE_DIR / "benchmark_dual.py"
+)
+trace_effective = _load_module(
+    "qwen3_14b_tmr_trace_effective", CASE_DIR / "trace_effective.py"
+)
+
+
+def _slot() -> dict[str, torch.Tensor]:
+    block_table = torch.full((16 * 32,), -1, dtype=torch.int32)
+    block_table.view(16, 32)[:, :27] = torch.arange(432, dtype=torch.int32).view(16, 27)
+    return {
+        "seq_lens": torch.zeros(16, dtype=torch.int32),
+        "slot_mapping": torch.zeros(16, dtype=torch.int32),
+        "block_table": block_table,
+        "sampled_ids_host": torch.zeros((16, 8), dtype=torch.int32),
+    }
+
+
+def test_single_update_slot_installs_new_page() -> None:
+    slot = _slot()
+    page_ids = torch.arange(432, 448, dtype=torch.int32)
+    golden = {
+        "seq_lens": torch.full((127, 16), 3457, dtype=torch.int32),
+        "slot_mapping": torch.zeros((127, 16), dtype=torch.int32),
+    }
+    golden["slot_mapping"][118] = page_ids * 128
+
+    benchmark._update_slot(slot, golden, 118)
+
+    assert torch.equal(slot["block_table"].view(16, 32)[:, 27], page_ids)
+
+
+def test_dual_slot_updates_do_not_share_block_table() -> None:
+    slots = [_slot(), _slot()]
+    page_ids = torch.arange(432, 448, dtype=torch.int32)
+    golden = {
+        "seq_lens": torch.full((2, 16), 3457, dtype=torch.int32),
+        "slot_mapping": torch.stack((page_ids * 128, page_ids * 128)),
+    }
+
+    benchmark_dual._update_slot(slots[0], golden, 0)
+    assert torch.all(slots[1]["block_table"].view(16, 32)[:, 27] == -1)
+    benchmark_dual._update_slot(slots[1], golden, 1)
+    assert torch.equal(slots[0]["block_table"].view(16, 32)[:, 27], page_ids)
+    assert torch.equal(slots[1]["block_table"].view(16, 32)[:, 27], page_ids)
+
+
+def test_update_slot_rejects_page_offset_mismatch() -> None:
+    slot = _slot()
+    golden = {
+        "seq_lens": torch.full((1, 16), 3457, dtype=torch.int32),
+        "slot_mapping": torch.ones((1, 16), dtype=torch.int32),
+    }
+
+    with pytest.raises(RuntimeError, match="offset mismatch"):
+        benchmark._update_slot(slot, golden, 0)
+
+
+def test_trace_summary_uses_steady_completion_intervals(tmp_path: Path) -> None:
+    lines = []
+    for inv, timestamp in ((1, 1_000_000_000), (2, 1_040_000_000)):
+        common = f"[STRACE] v=1 pid=1 tid=1 inv={inv} hid=abc depth=2"
+        lines.extend(
+            [
+                f"{common} name=chip.run ts={timestamp} dur=40000000 dispatch_id={inv} slot_id=0 generation={inv} prepare_only=0",
+                f"{common} name=node.dispatch ts={timestamp} dur=1 dispatch_id={inv} slot_id=0 generation={inv} prepare_only=0",
+                f"{common} name=chip.run.runner_run ts={timestamp} dur=39000000",
+                f"{common} name=chip.run.runner_run.device_wall ts={timestamp} dur=38000000",
+                f"{common} name=chip.run.runner_run.device_wall.sched ts={timestamp} dur=37000000",
+                f"{common} name=chip.run.bind.args ts={timestamp} dur=1000000",
+                f"{common} name=chip.run.validate ts={timestamp} dur=1000000",
+            ]
+        )
+    log = tmp_path / "strace.log"
+    log.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    rows = trace_effective.invocation_rows(trace_effective.parse_spans(log))
+    summary = trace_effective.summarize_campaign(
+        rows, warmup_runs=0, measured_runs=1, steps=2, steady_skip=1
+    )
+
+    assert summary["dispatch_contract"]["total"] == 2
+    assert summary["official_metrics"]["rts_completion_interval_ms"][
+        "pooled_steady_stats"
+    ]["mean"] == pytest.approx(40.0)
+    assert summary["official_metrics"]["effective_ms"]["pooled_steady_stats"][
+        "mean"
+    ] == pytest.approx(37.0)

--- a/tests/ut/py/test_qwen3_14b_serving_effective.py
+++ b/tests/ut/py/test_qwen3_14b_serving_effective.py
@@ -10,6 +10,7 @@
 import importlib.util
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -44,6 +45,8 @@ def _slot() -> dict[str, torch.Tensor]:
         "seq_lens": torch.zeros(16, dtype=torch.int32),
         "slot_mapping": torch.zeros(16, dtype=torch.int32),
         "block_table": block_table,
+        "initial_block_table": block_table.clone(),
+        "page_size": torch.tensor(128),
         "sampled_ids_host": torch.zeros((16, 8), dtype=torch.int32),
     }
 
@@ -88,6 +91,85 @@ def test_update_slot_rejects_page_offset_mismatch() -> None:
         benchmark._update_slot(slot, golden, 0)
 
 
+def test_update_slot_uses_fixture_page_size_and_tensor_stride() -> None:
+    block_table = torch.full((16 * 4,), -1, dtype=torch.int32)
+    slot = {
+        "seq_lens": torch.zeros(16, dtype=torch.int32),
+        "slot_mapping": torch.zeros(16, dtype=torch.int32),
+        "block_table": block_table,
+        "page_size": torch.tensor(4),
+        "sampled_ids_host": torch.zeros((16, 8), dtype=torch.int32),
+    }
+    page_ids = torch.arange(16, dtype=torch.int32)
+    golden = {
+        "seq_lens": torch.full((1, 16), 9, dtype=torch.int32),
+        "slot_mapping": (page_ids * 4).unsqueeze(0),
+    }
+
+    benchmark._update_slot(slot, golden, 0)
+
+    assert torch.equal(slot["block_table"].view(16, 4)[:, 2], page_ids)
+
+
+def test_dual_host_sample_is_read_before_slot_reuse() -> None:
+    class Handle:
+        def __init__(self, target: torch.Tensor, token: int) -> None:
+            self.target = target
+            self.token = token
+
+        def result(self) -> None:
+            self.target[:, 0] = self.token
+
+    class Runtime:
+        def __init__(self) -> None:
+            self.submissions = 0
+
+        def copy_to(self, *_args) -> None:
+            pass
+
+        def submit(self, _compiled, sampled_ids_host, *, config):
+            del config
+            handle = Handle(sampled_ids_host, 10 + self.submissions)
+            self.submissions += 1
+            return handle
+
+    steps = 3
+    golden = {
+        "decode_input_token_ids": torch.zeros((steps, 16), dtype=torch.int32),
+        "decode_output_token_ids": torch.stack(
+            [torch.full((16,), 10 + step, dtype=torch.int32) for step in range(steps)]
+        ),
+        "seq_lens": torch.ones((steps, 16), dtype=torch.int32),
+        "slot_mapping": torch.zeros((steps, 16), dtype=torch.int32),
+    }
+    resident = {
+        "weights": {},
+        "initial_tokens": SimpleNamespace(data_ptr=0),
+        "sampled": [None] * steps,
+        "rope_cos": None,
+        "rope_sin": None,
+        "k_cache": None,
+        "v_cache": None,
+        "out": [None, None],
+        "next_hidden": [None, None],
+    }
+
+    result = benchmark_dual._run_sequence(
+        rt=Runtime(),
+        compiled=None,
+        run_config=None,
+        param_names=["sampled_ids_host"],
+        resident=resident,
+        slots=[_slot(), _slot()],
+        golden=golden,
+        mode="dual",
+        steps=steps,
+        sampled_ids_host_abi=True,
+    )
+
+    assert result["token_rows"] == golden["decode_output_token_ids"].tolist()
+
+
 def test_trace_summary_uses_steady_completion_intervals(tmp_path: Path) -> None:
     lines = []
     for inv, timestamp in ((1, 1_000_000_000), (2, 1_040_000_000)):
@@ -116,3 +198,31 @@ def test_trace_summary_uses_steady_completion_intervals(tmp_path: Path) -> None:
         40.0
     )
     assert summary["official_metrics"]["effective_ms"]["pooled_steady_stats"]["mean"] == pytest.approx(37.0)
+
+
+def test_trace_summary_does_not_create_zero_interval_at_skip_zero(tmp_path: Path) -> None:
+    lines = []
+    for inv, timestamp in ((1, 1_000_000_000), (2, 1_040_000_000)):
+        common = f"[STRACE] v=1 pid=1 tid=1 inv={inv} hid=abc depth=2"
+        lines.extend(
+            [
+                f"{common} name=chip.run ts={timestamp} dur=40000000 dispatch_id={inv}",
+                f"{common} name=chip.run.runner_run ts={timestamp} dur=39000000",
+                f"{common} name=chip.run.runner_run.device_wall ts={timestamp} dur=38000000",
+                f"{common} name=chip.run.runner_run.device_wall.sched ts={timestamp} dur=37000000",
+                f"{common} name=chip.run.bind.args ts={timestamp} dur=1000000",
+                f"{common} name=chip.run.validate ts={timestamp} dur=1000000",
+            ]
+        )
+    log = tmp_path / "strace-zero-skip.log"
+    log.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    rows = trace_effective.invocation_rows(trace_effective.parse_spans(log))
+    summary = trace_effective.summarize_campaign(rows, warmup_runs=0, measured_runs=1, steps=2, steady_skip=0)
+    intervals = summary["official_metrics"]["rts_completion_interval_ms"]["pooled_steady_stats"]
+
+    assert intervals["count"] == 1
+    assert intervals["mean"] == pytest.approx(40.0)
+
+    one_step = trace_effective.summarize_campaign(rows[:1], warmup_runs=0, measured_runs=1, steps=1, steady_skip=0)
+    assert "rts_completion_interval_ms" not in one_step["official_metrics"]

--- a/tests/ut/py/test_qwen3_14b_serving_effective.py
+++ b/tests/ut/py/test_qwen3_14b_serving_effective.py
@@ -14,7 +14,6 @@ from pathlib import Path
 import pytest
 import torch
 
-
 CASE_DIR = (
     Path(__file__).resolve().parents[3]
     / "examples"
@@ -34,12 +33,8 @@ def _load_module(name: str, path: Path):
 
 
 benchmark = _load_module("qwen3_14b_tmr_benchmark", CASE_DIR / "benchmark.py")
-benchmark_dual = _load_module(
-    "qwen3_14b_tmr_benchmark_dual", CASE_DIR / "benchmark_dual.py"
-)
-trace_effective = _load_module(
-    "qwen3_14b_tmr_trace_effective", CASE_DIR / "trace_effective.py"
-)
+benchmark_dual = _load_module("qwen3_14b_tmr_benchmark_dual", CASE_DIR / "benchmark_dual.py")
+trace_effective = _load_module("qwen3_14b_tmr_trace_effective", CASE_DIR / "trace_effective.py")
 
 
 def _slot() -> dict[str, torch.Tensor]:
@@ -99,8 +94,10 @@ def test_trace_summary_uses_steady_completion_intervals(tmp_path: Path) -> None:
         common = f"[STRACE] v=1 pid=1 tid=1 inv={inv} hid=abc depth=2"
         lines.extend(
             [
-                f"{common} name=chip.run ts={timestamp} dur=40000000 dispatch_id={inv} slot_id=0 generation={inv} prepare_only=0",
-                f"{common} name=node.dispatch ts={timestamp} dur=1 dispatch_id={inv} slot_id=0 generation={inv} prepare_only=0",
+                f"{common} name=chip.run ts={timestamp} dur=40000000 "
+                f"dispatch_id={inv} slot_id=0 generation={inv} prepare_only=0",
+                f"{common} name=node.dispatch ts={timestamp} dur=1 "
+                f"dispatch_id={inv} slot_id=0 generation={inv} prepare_only=0",
                 f"{common} name=chip.run.runner_run ts={timestamp} dur=39000000",
                 f"{common} name=chip.run.runner_run.device_wall ts={timestamp} dur=38000000",
                 f"{common} name=chip.run.runner_run.device_wall.sched ts={timestamp} dur=37000000",
@@ -112,14 +109,10 @@ def test_trace_summary_uses_steady_completion_intervals(tmp_path: Path) -> None:
     log.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
     rows = trace_effective.invocation_rows(trace_effective.parse_spans(log))
-    summary = trace_effective.summarize_campaign(
-        rows, warmup_runs=0, measured_runs=1, steps=2, steady_skip=1
-    )
+    summary = trace_effective.summarize_campaign(rows, warmup_runs=0, measured_runs=1, steps=2, steady_skip=1)
 
     assert summary["dispatch_contract"]["total"] == 2
-    assert summary["official_metrics"]["rts_completion_interval_ms"][
-        "pooled_steady_stats"
-    ]["mean"] == pytest.approx(40.0)
-    assert summary["official_metrics"]["effective_ms"]["pooled_steady_stats"][
-        "mean"
-    ] == pytest.approx(37.0)
+    assert summary["official_metrics"]["rts_completion_interval_ms"]["pooled_steady_stats"]["mean"] == pytest.approx(
+        40.0
+    )
+    assert summary["official_metrics"]["effective_ms"]["pooled_steady_stats"]["mean"] == pytest.approx(37.0)


### PR DESCRIPTION
## Summary
- add a standalone Qwen3-14B post-prefill TMR decode case for the tensormap_and_ringbuffer runtime
- support isolated single-slot and dual-slot entry points with fixture, golden, checksum, and native STRACE validation
- keep the 8.5 GiB KV snapshot, compiled artifact, model, and benchmark results external to the source tree

## Validation
- `python3 -m py_compile` for all case and test Python files
- `bash -n` for the standalone runner
- copyright-header, English-only, retired-name, and `git diff --check` hooks
- Ruff check and format check
- CPU pytest: 7 passed in the isolated 686 environment

The frozen reference contract is documented in `stack_manifest.json`; the case does not require pypto-serving at runtime.


## Review fixes
- read 26-parameter dual-slot host samples before slot reuse
- validate contiguous native dispatch IDs and fixture-defined KV page layout
- avoid synthetic zero RTS intervals while preserving the 122-sample formal metric
