### PR TITLE
Refactor: hbg unifies the task progress byte into a sequential state enum

### DIFF
--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -126,7 +126,7 @@ scalar `rt_orchestration_done` publishes into the runtime header.
 **Why the scheduler state is device-written.** `SchedulerState` holds no
 per-run content: `sm_header` and the task-header pointer derive from a pooled SM base,
 queue capacities are compile-time constants, polling reserves no wiring or
-dependency pool (readiness comes from the task table's `progress_flags`, which
+dependency pool (readiness comes from the task table's `task_states`, which
 the task header owns), and it has no host-side entry point at all. So the host would
 only be writing an initialization pattern — 203,392 bytes
 of it, dominated by `AsyncWaitList::entries` — for the device to receive and never
@@ -190,7 +190,7 @@ past `total_tasks`. So the SM H2D shipped each run is bounded, not capacity-size
 the contract that keeps `bind` proportional to the workload.
 
 The header is zeroed on the host; `descriptors`, `payloads`, `slot_states` and
-`progress_flags` are each written per task at submit. Per-slot reset is
+`task_states` are each written per task at submit. Per-slot reset is
 init-on-write in `orch::prepare_task` as each slot is claimed — there is no
 table-wide reset. In the mirror those four live prefixes are a full reservation
 apart, so `compact_live_image` restacks them (plus the three argument pools) into
@@ -223,7 +223,7 @@ therefore also its slot index: ids run `0..capacity-1`, never wrap, and every
 segment is indexed by the id directly — there is no slot mask, so the capacity need
 not be a power of two.
 
-Completion is published per task, in `progress_flags[local_id]`, and reclaims
+Completion is published per task, in `task_states[local_id]`, and reclaims
 neither task slots nor heap.
 
 There is no post-run sweep that makes graph space reusable. Runtime destruction
@@ -287,7 +287,7 @@ TensorMap maps tensor regions to producer task IDs. For every task:
 3. OUTPUT/INOUT regions register the new task as producer.
 4. Each producer tracks its highest consumer local ID for completion metadata.
 
-There is no fanout adjacency or dependency pool. A per-slot completion flag is
+There is no fanout adjacency or dependency pool. A per-slot progress state is
 the readiness truth on device.
 
 ## 6. Boot Classification and Wake Lists

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -597,7 +597,7 @@ int32_t run_host_orchestration(
     // The dep_gen graph belongs to the orchestration that is about to run.
     dep_gen_host_graph_begin_capture();
 
-    // Init-on-write: descriptors, payloads, slot_states and progress_flags are
+    // Init-on-write: descriptors, payloads, slot_states and task_states are
     // each written per task at submit and read only for [0, total_tasks). Zero
     // only the fixed-size header here; the per-slot segments are initialized in
     // orch::prepare_task and shipped bounded to total_tasks below.

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -15,11 +15,11 @@
  * The Scheduler is responsible for:
  * 1. Maintaining per-resource-shape ready queues
  * 2. Polling-completion dependency resolution: a GLOBAL task is ready when every
- *    producer named in its inline fanin has set its progress_flags byte, an
+ *    producer named in its inline fanin has a COMPLETED task_states byte, an
  *    IN_GRAPH one when every producer in its Graph's fanin wire has reached
  *    task_state == COMPLETED (that table has no flag bytes); a producer publishes
  *    completion + drains its wake list on finish
- * 3. Publishing completion (task_state PENDING -> COMPLETED, progress_flags byte)
+ * 3. Publishing completion (task_state PENDING -> COMPLETED, task_states byte)
  * 4. Two-stage mixed-task completion (subtask done bits -> mixed-task complete)
  *
  * The Scheduler runs on Device AI_CPU. host_build_graph is scheduler-only (the
@@ -495,7 +495,7 @@ struct SchedulerState {
         SharedMemoryTaskHeader *tasks;
 
         // Polling: no dep_pool. Readiness is derived from the task table's
-        // progress_flags; there is no arena-side wiring pool to reserve or wire.
+        // task_states; there is no arena-side wiring pool to reserve or wire.
         // The `tasks` field stores the device address of the SM task header —
         // computed via offset arithmetic, no SM dereference.
         bool init_data_from_layout(void *sm_dev_base);
@@ -601,7 +601,7 @@ struct SchedulerState {
 
     // ---- Polling completion primitives ---------------------------------------
     // Readiness: a task is ready iff every producer named in its inline fanin has
-    // set its progress_flags byte. A producer is named by its local id alone, so
+    // a COMPLETED task_states byte. A producer is named by its local id alone, so
     // there is no per-edge indirection.
 
     // Unmet-fanin classification. Returns -1 (all fanins met -> route to ready)
@@ -616,7 +616,7 @@ struct SchedulerState {
     // lists. The decision is terminal: tasks are never re-polled; a producer's
     // completion re-scans its waiters via on_mixed_task_complete's wake drain.
     // Resumes at the wake-scan cursor: entries above it were completed at the
-    // last classification and completion bits are monotonic, so re-walking
+    // last classification and the task_states byte is monotone, so re-walking
     // them cannot change the verdict. An unmet verdict records itself as the
     // new cursor — the caller hangs the task exactly there, and this
     // classifier is the task's only owner at that moment.
@@ -626,7 +626,7 @@ struct SchedulerState {
         const int32_t *fanin = p.fanin_data();
         const int32_t start = s->wake_scan_cursor < p.fanin_count ? s->wake_scan_cursor : p.fanin_count - 1;
         for (int32_t i = start; i >= 0; i--) {
-            if (!tasks.is_completion_flag_set(fanin[i])) {
+            if (!tasks.is_completed(fanin[i])) {
                 s->wake_scan_cursor = static_cast<uint8_t>(i);
                 return i;
             }
@@ -637,7 +637,7 @@ struct SchedulerState {
     // Register `consumer` on `producer`'s wake list. If the producer already
     // completed (head == SENTINEL), re-classify against ALL fanins: route to
     // ready only when every fanin is met, else re-target the next unmet producer
-    // and retry. Monotonic progress_flags guarantee termination.
+    // and retry. The monotone task_states bytes guarantee termination.
     void register_wake(ChipTaskSlotState *producer, ChipTaskSlotState *consumer) {
         SharedMemoryTaskHeader &tasks = *task_view.tasks;
         while (true) {
@@ -660,7 +660,7 @@ struct SchedulerState {
     }
 
     // Producer completion under polling: publish the task_state completion
-    // mirror + the device-visible progress_flags byte, then drain the wake list
+    // mirror + the device-visible task_states byte, then drain the wake list
     // (route/re-register each waiter). Whole-graph-resident hbg
     // has no device slot reclaim, so nothing advances a reclaim cursor here.
     void on_mixed_task_complete(ChipTaskSlotState &slot_state) {
@@ -668,10 +668,10 @@ struct SchedulerState {
         SharedMemoryTaskHeader &tasks = *task_view.tasks;
 
         slot_state.mark_completed();  // completion mirror (task_state = COMPLETED)
-        tasks.set_completion_flag(task_id);
-        // The completion byte carries the publish bit, so a tracked producer
-        // that never published (DUMMY, predicate-retired) still releases its
-        // publish-list waiters here. Idempotent after a publish-time seal.
+        tasks.store_completed(task_id);
+        // COMPLETED >= PUBLISHED, so a tracked producer that never published
+        // (DUMMY, predicate-retired) still releases its publish-list waiters
+        // here. Idempotent after a publish-time seal.
         if ((slot_state.ed_flags & ED_FLAG_TRACKED) != 0) seal_ed_publish_list(slot_state);
 
         ChipTaskSlotState *waiter = slot_state.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
@@ -894,8 +894,8 @@ struct SchedulerState {
     // Publication accounting for the producers early dispatch watches. Only
     // ED_FLAG_TRACKED tasks pay: the host set that bit exactly on the
     // producers of at least one candidate. When the count reaches the task's
-    // logical blocks, the publish byte-bit is set and the publish list is
-    // sealed — everything past that leaves the dispatch path.
+    // logical blocks, the state byte advances to PUBLISHED and the caller seals
+    // the publish list — everything past that leaves the dispatch path.
     //
     // "Published" counts placement, not launch: a gated candidate's staged
     // blocks publish here too, so its consumers may pre-stage while it still
@@ -908,31 +908,50 @@ struct SchedulerState {
     // reclaiming tensormap_and_ringbuffer runtime instead defers propagation
     // to launch visibility; whole-graph-resident hbg holds no reclaimable
     // resource a gated chain could pin, so placement is the sufficient gate.)
-    inline void record_published_blocks(ChipTaskSlotState &slot_state, int32_t count) {
-        if (count <= 0 || (slot_state.ed_flags & ED_FLAG_TRACKED) == 0) return;
+    // Called BEFORE the batch's MMIO token writes, with the count that batch is
+    // about to publish. Returns true when this call reached the task's total,
+    // i.e. this caller owns the seal and must call seal_ed_publish_list once its
+    // tokens are flushed.
+    //
+    // The call site owes one precondition, and it is the one to re-check when
+    // adding a publish site: every block counted here has its token written by
+    // this same caller before it returns. A path that could reach the total and
+    // then not emit those tokens would publish a task whose blocks never launch,
+    // and its consumers would wait on a completion that cannot arrive.
+    //
+    // Accounting ahead of the tokens is what makes the state byte a plain
+    // sequential store: it puts PUBLISHED before every token this task will
+    // ever emit, so PUBLISHED ≺ token ≺ FIN ≺ COMPLETED holds no matter how
+    // fast a core FINs or how sibling publishers interleave — the total-reaching
+    // thread's store precedes its own tokens, and those tokens' FINs gate the
+    // all-FIN completion. Cores are claimed at prepare time, before any of this,
+    // so a consumer staged off the early PUBLISHED cannot occupy cores the
+    // producer's in-flight blocks still need.
+    inline bool account_published_blocks(ChipTaskSlotState &slot_state, int32_t count) {
+        if (count <= 0 || (slot_state.ed_flags & ED_FLAG_TRACKED) == 0) return false;
         const int16_t total = static_cast<int16_t>(
             slot_state.to_payload().published_block_count.fetch_add(
                 static_cast<int16_t>(count), std::memory_order_seq_cst
             ) +
             count
         );
-        if (total == slot_state.logical_block_num) seal_ed_publish_list(slot_state);
+        if (total != slot_state.logical_block_num) return false;
+        task_view.tasks->store_published(slot_state.to_descriptor().task_id.local_id());
+        return true;
     }
 
-    // Publish event of a tracked producer: publish bit, then seal. The order
-    // pairs with the acquire loads in advance_ed_publish_scan — a scanner that
-    // meets the sentinel is guaranteed to read the bit as set. The exchange
-    // makes the seal exactly-once (a second call gets the sentinel back), so
-    // the completion path can call this too for tracked producers that never
-    // publish (DUMMY / predicate-retired), whose completion byte carries the
-    // publish bit. A full pending-drain queue drops the chain: those
+    // Seal event of a tracked producer, after its tokens are flushed. The
+    // PUBLISHED store already happened in account_published_blocks, so a scanner
+    // that meets the sentinel is guaranteed to read the byte as published. The
+    // exchange makes the seal exactly-once (a second call gets the sentinel
+    // back), so the completion path can call this too for tracked producers that
+    // never publish (DUMMY / predicate-retired), whose COMPLETED byte already
+    // compares as published. A full pending-drain queue drops the chain: those
     // candidates miss early dispatch, nothing blocks.
     inline void seal_ed_publish_list(ChipTaskSlotState &slot_state) {
         // The sentinel is monotone (set once, never cleared), so an
-        // already-sealed list needs neither the flag RMW nor the exchange.
+        // already-sealed list needs no exchange.
         if (slot_state.ed_publish_list_head.load(std::memory_order_acquire) == ED_PUBLISH_LIST_SENTINEL) return;
-        const int32_t local_id = slot_state.to_descriptor().task_id.local_id();
-        task_view.tasks->set_publish_flag(local_id);
         ChipTaskSlotState *head =
             slot_state.ed_publish_list_head.exchange(ED_PUBLISH_LIST_SENTINEL, std::memory_order_acq_rel);
         if (head == ED_PUBLISH_LIST_SENTINEL) return;
@@ -949,7 +968,7 @@ struct SchedulerState {
     }
 
     // Resume candidate `c`'s publish scan at its cursor. The row is sorted and
-    // publish bits are monotonic, so entries above the cursor stay published
+    // the state byte is monotone, so entries above the cursor stay published
     // forever and each entry is loaded once per life. Returns true when every
     // producer is published — the early-dispatch trigger; false when `c` was
     // re-hung on a still-unpublished producer's publish list. A hang CAS that
@@ -960,7 +979,7 @@ struct SchedulerState {
         const int32_t *fanin = p.fanin_data();
         int32_t i = c.ed_publish_scan_cursor;
         while (i >= 0) {
-            if (tasks.is_publish_flag_set(fanin[i])) {
+            if (tasks.is_published(fanin[i])) {
                 i--;
                 continue;
             }
@@ -1357,7 +1376,7 @@ struct SchedulerState {
 #endif
     ) {
         // Polling completion: publish the task_state completion mirror + the
-        // device-visible progress_flags byte and drain the wake list (route or
+        // device-visible task_states byte and drain the wake list (route or
         // re-register each waiter). Replaces the
         // fanout-list walk + fanin_refcount decrements of the wiring model.
         on_mixed_task_complete(slot_state);

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -221,14 +221,14 @@ void SchedulerContext::log_stall_diagnostics(
             ChipTaskSlotState &slot_state = tasks.get_slot_state_by_task_id(si);
             ChipTaskState st = slot_state.task_state.load(std::memory_order_relaxed);
             // Polling: no fanin_refcount. Recompute met/total from the inline
-            // fanin ids vs the progress_flags (rc = satisfied producers,
+            // fanin ids vs the task_states array (rc = satisfied producers,
             // fi = raw producer count) so the stall dump still shows readiness.
             int32_t fi = slot_state.to_payload().fanin_count;
             int32_t rc = 0;
             {
                 const int32_t *fanin = slot_state.to_payload().fanin_data();
                 for (int32_t k = 0; k < fi; k++) {
-                    if (tasks.is_completion_flag_set(fanin[k], std::memory_order_relaxed)) rc++;
+                    if (tasks.is_completed(fanin[k], std::memory_order_relaxed)) rc++;
                 }
             }
             int32_t kid_aic = slot_state.to_descriptor().kernel_id[0];
@@ -236,8 +236,9 @@ void SchedulerContext::log_stall_diagnostics(
             int32_t kid_aiv1 = slot_state.to_descriptor().kernel_id[2];
             int64_t task_id = static_cast<int64_t>(slot_state.to_descriptor().task_id.raw);
             if (st >= CHIP_TASK_COMPLETED) continue;
-            // task_state has no intermediate ready/running value — it
-            // stays PENDING until the worker stores COMPLETED. Classify
+            // The slot mirror has no intermediate ready/running value — it
+            // stays PENDING until the worker stores COMPLETED (PUBLISHED
+            // lives in the task_states array, not here). Classify
             // by the ground truth instead: a slot is RUNNING iff some
             // core has it as running_slot_state. A task occupies at most
             // 3 cores (one cluster), all under the same owner thread by
@@ -1086,7 +1087,7 @@ void SchedulerContext::classify_partition(int32_t thread_idx, int32_t nthreads) 
     const int32_t lo = static_cast<int32_t>((static_cast<int64_t>(submitted) * thread_idx) / nthreads);
     const int32_t hi = static_cast<int32_t>((static_cast<int64_t>(submitted) * (thread_idx + 1)) / nthreads);
     for (int32_t id = lo; id < hi; id++) {
-        if (tasks.is_completion_flag_set(id)) {
+        if (tasks.is_completed(id)) {
             continue;  // completed on the host (hidden alloc); nothing to dispatch
         }
         ChipTaskSlotState &slot = tasks.get_slot_state_by_task_id(id);

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -189,7 +189,7 @@ void SchedulerContext::complete_slot_task(
         }
 #endif
         // 3S+1P: hand the finished task to the dedicated resolution (P) thread.
-        // P publishes progress_flags and drains the wake list — and owns
+        // P publishes task_states and drains the wake list — and owns
         // completed_tasks_, so this scheduler thread neither
         // resolves nor bumps completed_this_turn. (The Resolve swimlane bar is
         // emitted by P, not here.)
@@ -529,6 +529,8 @@ SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
                     thread_idx, core_offset, *slot_state, shape, to_pending, start + b, &handles[handle_count], gated
                 );
             }
+            // Account before the tokens, seal after them (see account_published_blocks).
+            const bool owns_seal = sched_->account_published_blocks(*slot_state, claim);
             wmb();
             uint64_t dispatch_ts = 0;
 #if SIMPLER_DFX
@@ -577,7 +579,7 @@ SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
                 );
             }
 #endif
-            sched_->record_published_blocks(*slot_state, claim);
+            if (owns_seal) sched_->seal_ed_publish_list(*slot_state);
             // AIC/AIV running placement (whole block on idle cores); MIX running cores are
             // counted per-cluster above (mix_cluster_idle_core_count).
             if (gated && shape != ResourceShape::MIX && !to_pending) result.running_cores += handle_count;

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -142,7 +142,7 @@ public:
 
     // Dedicated resolution (P) thread entry (3S+1P). Owns no cores: drains the
     // per-S CompletedTaskQueues and runs on_task_complete for each finished task
-    // (progress_flags publish + wake-list drain), making P
+    // (task_states publish + wake-list drain), making P
     // the sole producer of the ready queues. Owns completed_tasks_ / termination.
     int32_t run_resolution_thread(Runtime *runtime, int32_t thread_idx);
 

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -396,20 +396,37 @@ void SchedulerContext::dispatch_shape(
         // Flush prepared-but-unpublished handles. Required before
         // `enter_drain_mode` so the drain coordinator sees cores as occupied,
         // and at the per-task boundary when `any_sync_start` is true.
+        //
+        // The publication ledger is settled around the flush, not after it:
+        // every task whose blocks are in `handles[]` accounts BEFORE the token
+        // writes (so PUBLISHED precedes the tokens whose FINs drive completion)
+        // and the tasks that reached their total seal AFTER, once their tokens
+        // are out.
         auto flush_publish = [&]() {
-            if (handle_count == 0) return;
-            wmb();
-            uint64_t dispatch_ts = 0;
+            int seal_n = 0;
+            for (int i = 0; i < published_n; i++) {
+                if (sched_->account_published_blocks(*published_list[i], published_counts[i])) {
+                    published_list[seal_n++] = published_list[i];
+                }
+            }
+            published_n = 0;
+            if (handle_count != 0) {
+                wmb();
+                uint64_t dispatch_ts = 0;
 #if SIMPLER_DFX
-            if (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHEDULE_TIMING) {
-                dispatch_ts = get_sys_cnt_aicpu();
-            }
+                if (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHEDULE_TIMING) {
+                    dispatch_ts = get_sys_cnt_aicpu();
+                }
 #endif
-            for (int i = 0; i < handle_count; i++) {
-                publish_subtask_to_core(handles[i], dispatch_ts, thread_idx);
+                for (int i = 0; i < handle_count; i++) {
+                    publish_subtask_to_core(handles[i], dispatch_ts, thread_idx);
+                }
+                handle_count = 0;
+                made_progress = true;
             }
-            handle_count = 0;
-            made_progress = true;
+            for (int i = 0; i < seal_n; i++) {
+                sched_->seal_ed_publish_list(*published_list[i]);
+            }
         };
 
         for (int bi = 0; bi < got; bi++) {
@@ -500,9 +517,6 @@ void SchedulerContext::dispatch_shape(
         }
 
         flush_publish();
-        for (int i = 0; i < published_n; i++) {
-            sched_->record_published_blocks(*published_list[i], published_counts[i]);
-        }
 #if SIMPLER_SCHED_PROFILING
         chip_swimlane.sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
 #endif
@@ -668,6 +682,8 @@ int32_t SchedulerContext::stage_consumer_blocks(
     };
     if (idle.has_value()) prepare_from(idle, /*to_pending=*/false);
     if (pend.has_value()) prepare_from(pend, /*to_pending=*/true);
+    // Account before the tokens, seal after them (see account_published_blocks).
+    const bool owns_seal = sched_->account_published_blocks(*c, staged);
     if (n > 0) {
         wmb();
         for (int i = 0; i < n; i++) {
@@ -683,9 +699,16 @@ int32_t SchedulerContext::stage_consumer_blocks(
     for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++)
         if (my_cores[w] != 0) c->to_payload().staged_core_mask[w].fetch_or(my_cores[w], std::memory_order_seq_cst);
 
-    // Full publication and release are independent events. The seq_cst
-    // state/launch/count operations form a two-sided handshake. A released
-    // block must ring before contributing to the publication count.
+    // Full publication and release are independent events. Doorbell ownership
+    // is a two-sided seq_cst handshake between the fetch_or above and the
+    // release path's early_dispatch_state store: each staged bit is claimed
+    // exactly once, by whichever side observes the other's write, so a bit the
+    // releaser missed is rung below and a bit it took is not rung twice.
+    // published_block_count takes no part in that handshake, which is why the
+    // accounting above may precede these rings: a consumer released by the
+    // resulting publication cannot take cores this task's blocks already hold
+    // (prepare_block_for_dispatch claimed them before any of this) and holds
+    // nothing the rings below wait on.
     bool released =
         staged > 0 && c->to_payload().early_dispatch_state.load(std::memory_order_seq_cst) == EARLY_DISPATCH_DISPATCHED;
 
@@ -707,7 +730,7 @@ int32_t SchedulerContext::stage_consumer_blocks(
         }
         wmb();
     }
-    sched_->record_published_blocks(*c, staged);
+    if (owns_seal) sched_->seal_ed_publish_list(*c);
     return staged;
 }
 
@@ -921,7 +944,7 @@ int32_t SchedulerContext::try_early_dispatch(
 // =============================================================================
 
 // P owns no AICore cores. It drains the per-S CompletedTaskQueues and runs
-// on_task_complete for every finished task: publish progress_flags, drain the
+// on_task_complete for every finished task: publish task_states, drain the
 // wake list (route/re-register waiters into the ready queues). As the sole
 // producer of the ready queues its enqueues never contend. P owns
 // completed_tasks_ and the terminal completed_ flip, so the S threads keep

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -126,7 +126,7 @@ scalar `rt_orchestration_done` publishes into the runtime header.
 **Why the scheduler state is device-written.** `SchedulerState` holds no
 per-run content: `sm_header` and the task-header pointer derive from a pooled SM base,
 queue capacities are compile-time constants, polling reserves no wiring or
-dependency pool (readiness comes from the task table's `progress_flags`, which
+dependency pool (readiness comes from the task table's `task_states`, which
 the task header owns), and it has no host-side entry point at all. So the host would
 only be writing an initialization pattern — 203,392 bytes
 of it, dominated by `AsyncWaitList::entries` — for the device to receive and never
@@ -190,7 +190,7 @@ past `total_tasks`. So the SM H2D shipped each run is bounded, not capacity-size
 the contract that keeps `bind` proportional to the workload.
 
 The header is zeroed on the host; `descriptors`, `payloads`, `slot_states` and
-`progress_flags` are each written per task at submit. Per-slot reset is
+`task_states` are each written per task at submit. Per-slot reset is
 init-on-write in `orch::prepare_task` as each slot is claimed — there is no
 table-wide reset. In the mirror those four live prefixes are a full reservation
 apart, so `compact_live_image` restacks them (plus the three argument pools) into
@@ -223,7 +223,7 @@ therefore also its slot index: ids run `0..capacity-1`, never wrap, and every
 segment is indexed by the id directly — there is no slot mask, so the capacity need
 not be a power of two.
 
-Completion is published per task, in `progress_flags[local_id]`, and reclaims
+Completion is published per task, in `task_states[local_id]`, and reclaims
 neither task slots nor heap.
 
 There is no post-run sweep that makes graph space reusable. Runtime destruction
@@ -287,7 +287,7 @@ TensorMap maps tensor regions to producer task IDs. For every task:
 3. OUTPUT/INOUT regions register the new task as producer.
 4. Each producer tracks its highest consumer local ID for completion metadata.
 
-There is no fanout adjacency or dependency pool. A per-slot completion flag is
+There is no fanout adjacency or dependency pool. A per-slot progress state is
 the readiness truth on device.
 
 ## 6. Boot Classification and Wake Lists

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -946,7 +946,7 @@ int32_t run_host_orchestration(
     // The dep_gen graph belongs to the orchestration that is about to run.
     dep_gen_host_graph_begin_capture();
 
-    // Init-on-write: descriptors, payloads, slot_states and progress_flags are
+    // Init-on-write: descriptors, payloads, slot_states and task_states are
     // each written per task at submit and read only for [0, total_tasks). Zero
     // only the fixed-size header here; the per-slot segments are initialized in
     // orch::prepare_task and shipped bounded to total_tasks below.

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -15,11 +15,11 @@
  * The Scheduler is responsible for:
  * 1. Maintaining per-resource-shape ready queues
  * 2. Polling-completion dependency resolution: a GLOBAL task is ready when every
- *    producer named in its inline fanin has set its progress_flags byte, an
+ *    producer named in its inline fanin has a COMPLETED task_states byte, an
  *    IN_GRAPH one when every producer in its Graph's fanin wire has reached
  *    task_state == COMPLETED (that table has no flag bytes); a producer publishes
  *    completion + drains its wake list on finish
- * 3. Publishing completion (task_state PENDING -> COMPLETED, progress_flags byte)
+ * 3. Publishing completion (task_state PENDING -> COMPLETED, task_states byte)
  * 4. Two-stage mixed-task completion (subtask done bits -> mixed-task complete)
  *
  * The Scheduler runs on Device AI_CPU. host_build_graph is scheduler-only (the
@@ -506,7 +506,7 @@ struct SchedulerState {
         SharedMemoryTaskHeader *tasks;
 
         // Polling: no dep_pool. Readiness is derived from the task table's
-        // progress_flags; there is no arena-side wiring pool to reserve or wire.
+        // task_states; there is no arena-side wiring pool to reserve or wire.
         // The `tasks` field stores the device address of the SM task header —
         // computed via offset arithmetic, no SM dereference.
         bool init_data_from_layout(void *sm_dev_base);
@@ -612,7 +612,7 @@ struct SchedulerState {
 
     // ---- Polling completion primitives ---------------------------------------
     // Readiness: a task is ready iff every producer named in its inline fanin has
-    // set its progress_flags byte. A producer is named by its local id alone, so
+    // a COMPLETED task_states byte. A producer is named by its local id alone, so
     // there is no per-edge indirection.
 
     // Unmet-fanin classification. Returns -1 (all fanins met -> route to ready)
@@ -627,7 +627,7 @@ struct SchedulerState {
     // lists. The decision is terminal: tasks are never re-polled; a producer's
     // completion re-scans its waiters via on_mixed_task_complete's wake drain.
     // Resumes at the wake-scan cursor: entries above it were completed at the
-    // last classification and completion bits are monotonic, so re-walking
+    // last classification and the task_states byte is monotone, so re-walking
     // them cannot change the verdict. An unmet verdict records itself as the
     // new cursor — the caller hangs the task exactly there, and this
     // classifier is the task's only owner at that moment.
@@ -637,7 +637,7 @@ struct SchedulerState {
         const int32_t *fanin = p.fanin_data();
         const int32_t start = s->wake_scan_cursor < p.fanin_count ? s->wake_scan_cursor : p.fanin_count - 1;
         for (int32_t i = start; i >= 0; i--) {
-            if (!tasks.is_completion_flag_set(fanin[i])) {
+            if (!tasks.is_completed(fanin[i])) {
                 s->wake_scan_cursor = static_cast<uint8_t>(i);
                 return i;
             }
@@ -648,7 +648,7 @@ struct SchedulerState {
     // Register `consumer` on `producer`'s wake list. If the producer already
     // completed (head == SENTINEL), re-classify against ALL fanins: route to
     // ready only when every fanin is met, else re-target the next unmet producer
-    // and retry. Monotonic progress_flags guarantee termination.
+    // and retry. The monotone task_states bytes guarantee termination.
     void register_wake(ChipTaskSlotState *producer, ChipTaskSlotState *consumer) {
         SharedMemoryTaskHeader &tasks = *task_view.tasks;
         while (true) {
@@ -671,7 +671,7 @@ struct SchedulerState {
     }
 
     // Producer completion under polling: publish the task_state completion
-    // mirror + the device-visible progress_flags byte, then drain the wake list
+    // mirror + the device-visible task_states byte, then drain the wake list
     // (route/re-register each waiter). Whole-graph-resident hbg
     // has no device slot reclaim, so nothing advances a reclaim cursor here.
     void on_mixed_task_complete(ChipTaskSlotState &slot_state) {
@@ -679,10 +679,10 @@ struct SchedulerState {
         SharedMemoryTaskHeader &tasks = *task_view.tasks;
 
         slot_state.mark_completed();  // completion mirror (task_state = COMPLETED)
-        tasks.set_completion_flag(task_id);
-        // The completion byte carries the publish bit, so a tracked producer
-        // that never published (DUMMY, predicate-retired) still releases its
-        // publish-list waiters here. Idempotent after a publish-time seal.
+        tasks.store_completed(task_id);
+        // COMPLETED >= PUBLISHED, so a tracked producer that never published
+        // (DUMMY, predicate-retired) still releases its publish-list waiters
+        // here. Idempotent after a publish-time seal.
         if ((slot_state.ed_flags & ED_FLAG_TRACKED) != 0) seal_ed_publish_list(slot_state);
 
         ChipTaskSlotState *waiter = slot_state.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
@@ -905,8 +905,8 @@ struct SchedulerState {
     // Publication accounting for the producers early dispatch watches. Only
     // ED_FLAG_TRACKED tasks pay: the host set that bit exactly on the
     // producers of at least one candidate. When the count reaches the task's
-    // logical blocks, the publish byte-bit is set and the publish list is
-    // sealed — everything past that leaves the dispatch path.
+    // logical blocks, the state byte advances to PUBLISHED and the caller seals
+    // the publish list — everything past that leaves the dispatch path.
     //
     // "Published" counts placement, not launch: a gated candidate's staged
     // blocks publish here too, so its consumers may pre-stage while it still
@@ -919,31 +919,50 @@ struct SchedulerState {
     // reclaiming tensormap_and_ringbuffer runtime instead defers propagation
     // to launch visibility; whole-graph-resident hbg holds no reclaimable
     // resource a gated chain could pin, so placement is the sufficient gate.)
-    inline void record_published_blocks(ChipTaskSlotState &slot_state, int32_t count) {
-        if (count <= 0 || (slot_state.ed_flags & ED_FLAG_TRACKED) == 0) return;
+    // Called BEFORE the batch's MMIO token writes, with the count that batch is
+    // about to publish. Returns true when this call reached the task's total,
+    // i.e. this caller owns the seal and must call seal_ed_publish_list once its
+    // tokens are flushed.
+    //
+    // The call site owes one precondition, and it is the one to re-check when
+    // adding a publish site: every block counted here has its token written by
+    // this same caller before it returns. A path that could reach the total and
+    // then not emit those tokens would publish a task whose blocks never launch,
+    // and its consumers would wait on a completion that cannot arrive.
+    //
+    // Accounting ahead of the tokens is what makes the state byte a plain
+    // sequential store: it puts PUBLISHED before every token this task will
+    // ever emit, so PUBLISHED ≺ token ≺ FIN ≺ COMPLETED holds no matter how
+    // fast a core FINs or how sibling publishers interleave — the total-reaching
+    // thread's store precedes its own tokens, and those tokens' FINs gate the
+    // all-FIN completion. Cores are claimed at prepare time, before any of this,
+    // so a consumer staged off the early PUBLISHED cannot occupy cores the
+    // producer's in-flight blocks still need.
+    inline bool account_published_blocks(ChipTaskSlotState &slot_state, int32_t count) {
+        if (count <= 0 || (slot_state.ed_flags & ED_FLAG_TRACKED) == 0) return false;
         const int16_t total = static_cast<int16_t>(
             slot_state.to_payload().published_block_count.fetch_add(
                 static_cast<int16_t>(count), std::memory_order_seq_cst
             ) +
             count
         );
-        if (total == slot_state.logical_block_num) seal_ed_publish_list(slot_state);
+        if (total != slot_state.logical_block_num) return false;
+        task_view.tasks->store_published(slot_state.to_descriptor().task_id.local_id());
+        return true;
     }
 
-    // Publish event of a tracked producer: publish bit, then seal. The order
-    // pairs with the acquire loads in advance_ed_publish_scan — a scanner that
-    // meets the sentinel is guaranteed to read the bit as set. The exchange
-    // makes the seal exactly-once (a second call gets the sentinel back), so
-    // the completion path can call this too for tracked producers that never
-    // publish (DUMMY / predicate-retired), whose completion byte carries the
-    // publish bit. A full pending-drain queue drops the chain: those
+    // Seal event of a tracked producer, after its tokens are flushed. The
+    // PUBLISHED store already happened in account_published_blocks, so a scanner
+    // that meets the sentinel is guaranteed to read the byte as published. The
+    // exchange makes the seal exactly-once (a second call gets the sentinel
+    // back), so the completion path can call this too for tracked producers that
+    // never publish (DUMMY / predicate-retired), whose COMPLETED byte already
+    // compares as published. A full pending-drain queue drops the chain: those
     // candidates miss early dispatch, nothing blocks.
     inline void seal_ed_publish_list(ChipTaskSlotState &slot_state) {
         // The sentinel is monotone (set once, never cleared), so an
-        // already-sealed list needs neither the flag RMW nor the exchange.
+        // already-sealed list needs no exchange.
         if (slot_state.ed_publish_list_head.load(std::memory_order_acquire) == ED_PUBLISH_LIST_SENTINEL) return;
-        const int32_t local_id = slot_state.to_descriptor().task_id.local_id();
-        task_view.tasks->set_publish_flag(local_id);
         ChipTaskSlotState *head =
             slot_state.ed_publish_list_head.exchange(ED_PUBLISH_LIST_SENTINEL, std::memory_order_acq_rel);
         if (head == ED_PUBLISH_LIST_SENTINEL) return;
@@ -960,7 +979,7 @@ struct SchedulerState {
     }
 
     // Resume candidate `c`'s publish scan at its cursor. The row is sorted and
-    // publish bits are monotonic, so entries above the cursor stay published
+    // the state byte is monotone, so entries above the cursor stay published
     // forever and each entry is loaded once per life. Returns true when every
     // producer is published — the early-dispatch trigger; false when `c` was
     // re-hung on a still-unpublished producer's publish list. A hang CAS that
@@ -971,7 +990,7 @@ struct SchedulerState {
         const int32_t *fanin = p.fanin_data();
         int32_t i = c.ed_publish_scan_cursor;
         while (i >= 0) {
-            if (tasks.is_publish_flag_set(fanin[i])) {
+            if (tasks.is_published(fanin[i])) {
                 i--;
                 continue;
             }
@@ -1368,7 +1387,7 @@ struct SchedulerState {
 #endif
     ) {
         // Polling completion: publish the task_state completion mirror + the
-        // device-visible progress_flags byte and drain the wake list (route or
+        // device-visible task_states byte and drain the wake list (route or
         // re-register each waiter). Replaces the
         // fanout-list walk + fanin_refcount decrements of the wiring model.
         on_mixed_task_complete(slot_state);

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -221,14 +221,14 @@ void SchedulerContext::log_stall_diagnostics(
             ChipTaskSlotState &slot_state = tasks.get_slot_state_by_task_id(si);
             ChipTaskState st = slot_state.task_state.load(std::memory_order_relaxed);
             // Polling: no fanin_refcount. Recompute met/total from the inline
-            // fanin ids vs the progress_flags (rc = satisfied producers,
+            // fanin ids vs the task_states array (rc = satisfied producers,
             // fi = raw producer count) so the stall dump still shows readiness.
             int32_t fi = slot_state.to_payload().fanin_count;
             int32_t rc = 0;
             {
                 const int32_t *fanin = slot_state.to_payload().fanin_data();
                 for (int32_t k = 0; k < fi; k++) {
-                    if (tasks.is_completion_flag_set(fanin[k], std::memory_order_relaxed)) rc++;
+                    if (tasks.is_completed(fanin[k], std::memory_order_relaxed)) rc++;
                 }
             }
             int32_t kid_aic = slot_state.to_descriptor().kernel_id[0];
@@ -236,8 +236,9 @@ void SchedulerContext::log_stall_diagnostics(
             int32_t kid_aiv1 = slot_state.to_descriptor().kernel_id[2];
             int64_t task_id = static_cast<int64_t>(slot_state.to_descriptor().task_id.raw);
             if (st >= CHIP_TASK_COMPLETED) continue;
-            // task_state has no intermediate ready/running value — it
-            // stays PENDING until the worker stores COMPLETED. Classify
+            // The slot mirror has no intermediate ready/running value — it
+            // stays PENDING until the worker stores COMPLETED (PUBLISHED
+            // lives in the task_states array, not here). Classify
             // by the ground truth instead: a slot is RUNNING iff some
             // core has it as running_slot_state. A task occupies at most
             // 3 cores (one cluster), all under the same owner thread by
@@ -1086,7 +1087,7 @@ void SchedulerContext::classify_partition(int32_t thread_idx, int32_t nthreads) 
     const int32_t lo = static_cast<int32_t>((static_cast<int64_t>(submitted) * thread_idx) / nthreads);
     const int32_t hi = static_cast<int32_t>((static_cast<int64_t>(submitted) * (thread_idx + 1)) / nthreads);
     for (int32_t id = lo; id < hi; id++) {
-        if (tasks.is_completion_flag_set(id)) {
+        if (tasks.is_completed(id)) {
             continue;  // completed on the host (hidden alloc); nothing to dispatch
         }
         ChipTaskSlotState &slot = tasks.get_slot_state_by_task_id(id);

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -189,7 +189,7 @@ void SchedulerContext::complete_slot_task(
         }
 #endif
         // 3S+1P: hand the finished task to the dedicated resolution (P) thread.
-        // P publishes progress_flags and drains the wake list — and owns
+        // P publishes task_states and drains the wake list — and owns
         // completed_tasks_, so this scheduler thread neither
         // resolves nor bumps completed_this_turn. (The Resolve swimlane bar is
         // emitted by P, not here.)
@@ -534,6 +534,8 @@ SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
                     thread_idx, core_offset, *slot_state, shape, to_pending, start + b, &handles[handle_count], gated
                 );
             }
+            // Account before the tokens, seal after them (see account_published_blocks).
+            const bool owns_seal = sched_->account_published_blocks(*slot_state, claim);
             wmb();
             uint64_t dispatch_ts = 0;
 #if SIMPLER_DFX
@@ -582,7 +584,7 @@ SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
                 );
             }
 #endif
-            sched_->record_published_blocks(*slot_state, claim);
+            if (owns_seal) sched_->seal_ed_publish_list(*slot_state);
             // AIC/AIV running placement (whole block on idle cores); MIX running cores are
             // counted per-cluster above (mix_cluster_idle_core_count).
             if (gated && shape != ResourceShape::MIX && !to_pending) result.running_cores += handle_count;

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -142,7 +142,7 @@ public:
 
     // Dedicated resolution (P) thread entry (3S+1P). Owns no cores: drains the
     // per-S CompletedTaskQueues and runs on_task_complete for each finished task
-    // (progress_flags publish + wake-list drain), making P
+    // (task_states publish + wake-list drain), making P
     // the sole producer of the ready queues. Owns completed_tasks_ / termination.
     int32_t run_resolution_thread(Runtime *runtime, int32_t thread_idx);
 

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -397,20 +397,37 @@ void SchedulerContext::dispatch_shape(
         // Flush prepared-but-unpublished handles. Required before
         // `enter_drain_mode` so the drain coordinator sees cores as occupied,
         // and at the per-task boundary when `any_sync_start` is true.
+        //
+        // The publication ledger is settled around the flush, not after it:
+        // every task whose blocks are in `handles[]` accounts BEFORE the token
+        // writes (so PUBLISHED precedes the tokens whose FINs drive completion)
+        // and the tasks that reached their total seal AFTER, once their tokens
+        // are out.
         auto flush_publish = [&]() {
-            if (handle_count == 0) return;
-            wmb();
-            uint64_t dispatch_ts = 0;
+            int seal_n = 0;
+            for (int i = 0; i < published_n; i++) {
+                if (sched_->account_published_blocks(*published_list[i], published_counts[i])) {
+                    published_list[seal_n++] = published_list[i];
+                }
+            }
+            published_n = 0;
+            if (handle_count != 0) {
+                wmb();
+                uint64_t dispatch_ts = 0;
 #if SIMPLER_DFX
-            if (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHEDULE_TIMING) {
-                dispatch_ts = get_sys_cnt_aicpu();
-            }
+                if (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHEDULE_TIMING) {
+                    dispatch_ts = get_sys_cnt_aicpu();
+                }
 #endif
-            for (int i = 0; i < handle_count; i++) {
-                publish_subtask_to_core(handles[i], dispatch_ts, thread_idx);
+                for (int i = 0; i < handle_count; i++) {
+                    publish_subtask_to_core(handles[i], dispatch_ts, thread_idx);
+                }
+                handle_count = 0;
+                made_progress = true;
             }
-            handle_count = 0;
-            made_progress = true;
+            for (int i = 0; i < seal_n; i++) {
+                sched_->seal_ed_publish_list(*published_list[i]);
+            }
         };
 
         for (int bi = 0; bi < got; bi++) {
@@ -501,9 +518,6 @@ void SchedulerContext::dispatch_shape(
         }
 
         flush_publish();
-        for (int i = 0; i < published_n; i++) {
-            sched_->record_published_blocks(*published_list[i], published_counts[i]);
-        }
 #if SIMPLER_SCHED_PROFILING
         chip_swimlane.sched_dispatch_setup_cycle += (get_sys_cnt_aicpu() - t_setup_start);
 #endif
@@ -669,6 +683,8 @@ int32_t SchedulerContext::stage_consumer_blocks(
     };
     if (idle.has_value()) prepare_from(idle, /*to_pending=*/false);
     if (pend.has_value()) prepare_from(pend, /*to_pending=*/true);
+    // Account before the tokens, seal after them (see account_published_blocks).
+    const bool owns_seal = sched_->account_published_blocks(*c, staged);
     if (n > 0) {
         wmb();
         for (int i = 0; i < n; i++) {
@@ -684,9 +700,16 @@ int32_t SchedulerContext::stage_consumer_blocks(
     for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; w++)
         if (my_cores[w] != 0) c->to_payload().staged_core_mask[w].fetch_or(my_cores[w], std::memory_order_seq_cst);
 
-    // Full publication and release are independent events. The seq_cst
-    // state/launch/count operations form a two-sided handshake. A released
-    // block must ring before contributing to the publication count.
+    // Full publication and release are independent events. Doorbell ownership
+    // is a two-sided seq_cst handshake between the fetch_or above and the
+    // release path's early_dispatch_state store: each staged bit is claimed
+    // exactly once, by whichever side observes the other's write, so a bit the
+    // releaser missed is rung below and a bit it took is not rung twice.
+    // published_block_count takes no part in that handshake, which is why the
+    // accounting above may precede these rings: a consumer released by the
+    // resulting publication cannot take cores this task's blocks already hold
+    // (prepare_block_for_dispatch claimed them before any of this) and holds
+    // nothing the rings below wait on.
     bool released =
         staged > 0 && c->to_payload().early_dispatch_state.load(std::memory_order_seq_cst) == EARLY_DISPATCH_DISPATCHED;
 
@@ -708,7 +731,7 @@ int32_t SchedulerContext::stage_consumer_blocks(
         }
         wmb();
     }
-    sched_->record_published_blocks(*c, staged);
+    if (owns_seal) sched_->seal_ed_publish_list(*c);
     return staged;
 }
 
@@ -922,7 +945,7 @@ int32_t SchedulerContext::try_early_dispatch(
 // =============================================================================
 
 // P owns no AICore cores. It drains the per-S CompletedTaskQueues and runs
-// on_task_complete for every finished task: publish progress_flags, drain the
+// on_task_complete for every finished task: publish task_states, drain the
 // wake list (route/re-register waiters into the ready queues). As the sole
 // producer of the ready queues its enqueues never contend. P owns
 // completed_tasks_ and the terminal completed_ flip, so the S threads keep

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -436,8 +436,8 @@ dependency wiring remains an Orchestrator responsibility:
   packed windows;
 - materialization registers each non-root on one producer selected from its
   saved fanin CSR;
-- an in-graph task's release/acquire `task_state` is its Graph-local completion flag, so
-  such tasks need neither shared-memory completion flags nor task-table slots;
+- an in-graph task's release/acquire `task_state` is its Graph-local completion truth, so
+  such tasks need neither a shared-memory `task_states` byte nor a task-table slot;
 - producer completion closes and drains only its current wake-list rather than
   traversing the saved fanout CSR;
 - a woken consumer scans its saved fanin CSR and either enters its shape queue
@@ -461,7 +461,7 @@ outer GRAPH
 ```
 
 In-graph tasks count as zero tasks of the run itself. The last one to complete
-finishes the one outer Graph task, publishes that task's completion flag, wakes
+finishes the one outer Graph task, publishes that task's `task_states` byte, wakes
 external consumers, and contributes one to the host-visible completion count.
 
 Localization or materialization failure is fail-fast: the Scheduler latches an

--- a/src/common/host_build_graph/host/orchestrator.cpp
+++ b/src/common/host_build_graph/host/orchestrator.cpp
@@ -1370,7 +1370,7 @@ append_fanin_or_fail(OrchestratorState &orch, TaskId producer_task_id, int32_t *
     // its own storage index and hbg never recycles a slot, so the entry that id
     // names is the producer's by construction — there is no stale-slot case to
     // screen for. A COMPLETED producer is a real fanin edge under polling (its
-    // progress_flags byte is set), so it is not screened out either.
+    // task_states byte says so), so it is not screened out either.
     if (fanin_mark_seen(orch, producer_task_id)) {
         return true;
     }
@@ -1462,13 +1462,13 @@ static bool prepare_task(
     orch->tensor_pool_cursor += args.tensor_count();
     orch->scalar_pool_cursor += scalar_span;
 
-    // Init-on-write: this slot's dynamic scheduling fields and completion flag are
+    // Init-on-write: this slot's dynamic scheduling fields and progress state are
     // initialized here, as the orchestrator claims the slot. whole-graph-resident
     // hbg claims slots [0, total_tasks) exactly once and the device reads no slot
     // past total_tasks, so this claim-time write is the only per-slot SM reset and
     // the unclaimed tail is neither initialized nor read.
     out->slot_state->reset_for_reuse();
-    orch->sm_header->tasks.progress_flags[out->alloc_result.task_id].store(0, std::memory_order_relaxed);
+    orch->sm_header->tasks.reset_task_state(out->alloc_result.task_id);
 
     out->payload->prefetch(args.tensor_count(), args.scalar_count());
 
@@ -2041,12 +2041,12 @@ bool graph_submit_outer(
     ChipTaskSlotState &slot = storage.slot;
 
     // Init-on-write, as in prepare_task: this slot's dynamic scheduling fields and
-    // completion flag are established here, at the claim, because nothing else
+    // progress state are established here, at the claim, because nothing else
     // writes them. A stale wake_list_head of WAKE_LIST_SENTINEL would close the
-    // list against every consumer, and a stale completion flag would report the
+    // list against every consumer, and a stale progress state would report the
     // Graph done before it ran.
     slot.reset_for_reuse();
-    tasks.progress_flags[allocation.task_id].store(0, std::memory_order_relaxed);
+    tasks.reset_task_state(allocation.task_id);
 
     // Graph boundaries use the same compact argument pools as ordinary tasks. The
     // outer payload carries the invocation data; graph_context only names the
@@ -3003,14 +3003,14 @@ TaskOutputTensors OrchestratorState::alloc_tensors(const CoreTaskArgs &args) {
         // unconditionally.
         prepared.slot_state->task_attrs.set_early_resolve(true);
         prepared.slot_state->mark_completed();  // GLOBAL task, so task_state is only the completion mirror
-        // Polling: pre-set the device-visible progress_flags byte in the H2D
-        // image. Consumers poll progress_flags (not task_state), so a hidden-alloc
-        // producer completed here on the host must publish its flag too — otherwise
-        // every consumer register_wakes on a producer that never runs on device and
-        // the run hangs.
+        // Polling: pre-set the device-visible task_states byte in the H2D
+        // image. Consumers poll task_states (not the slot's task_state), so a
+        // hidden-alloc producer completed here on the host must publish its byte
+        // too — otherwise every consumer register_wakes on a producer that never
+        // runs on device and the run hangs.
         SharedMemoryTaskHeader &done_tasks = orch->sm_header->tasks;
         int32_t done_local = prepared.task_id.local_id();
-        done_tasks.set_completion_flag(done_local);
+        done_tasks.store_completed(done_local);
     }
     orch->inline_completed_tasks++;
 

--- a/src/common/host_build_graph/runtime_types.h
+++ b/src/common/host_build_graph/runtime_types.h
@@ -172,25 +172,34 @@ inline constexpr int32_t ARG_POOL_ALIGN = 64;
 /**
  * Task state enumeration
  *
- * State transitions:
- *   PENDING -> COMPLETED
+ * State transitions (strictly linear, values ordered so readers can use
+ * ordered comparisons: `>= CHIP_TASK_PUBLISHED` asks "every block placed?",
+ * `>= CHIP_TASK_COMPLETED` asks "every subtask finished?"):
+ *   PENDING -> PUBLISHED -> COMPLETED
  *
- * The slot stays in PENDING from submit through "ready in queue" and "running
+ * The task stays in PENDING from submit through "ready in queue" and "running
  * on a worker": readiness comes from the producers' completion state, and
  * running-vs-idle from the per-core running_slot_state -- neither from this
  * field. Which completion state carries readiness depends on the task's id
  * space; see ChipTaskSlotState below.
  *
  * Conditions:
- *   PENDING->COMPLETED:   all subtasks finish (set by scheduler) or task is a
- *                         hidden alloc completed inline by the orchestrator
+ *   PENDING->PUBLISHED:   every logical block's payload + MMIO token is
+ *                         written (placement, not launch). Only the SM
+ *                         task_states byte of an ED_FLAG_TRACKED task takes
+ *                         this value; the slot-resident mirror never does.
+ *   ->COMPLETED:          all subtasks finish (set by scheduler) or task is a
+ *                         hidden alloc completed inline by the orchestrator.
+ *                         Completion implies publication (a finished task
+ *                         occupies no cores), so COMPLETED > PUBLISHED.
  *
  * COMPLETED is terminal: no slot is recycled before the run ends, so nothing
  * advances a task past it.
  */
 typedef enum : uint8_t {
-    CHIP_TASK_PENDING = 0,   // Submitted; awaiting fanin, queued, or dispatched
-    CHIP_TASK_COMPLETED = 1  // Execution finished, output may still be in use
+    CHIP_TASK_PENDING = 0,    // Submitted; awaiting fanin, queued, or dispatched
+    CHIP_TASK_PUBLISHED = 1,  // Every logical block placed on a core (tracked producers only)
+    CHIP_TASK_COMPLETED = 2   // Execution finished, output may still be in use
 } ChipTaskState;
 
 /**
@@ -345,7 +354,7 @@ struct TaskPayload {
     //
     // fanin holds flat position-independent producer local task ids. A producer is
     // named by its local id alone, so no per-edge indirection is stored. Scanned by
-    // classify_fanin_state against the shared-memory progress_flags. Hard-capped at
+    // classify_fanin_state against the shared-memory task_states. Hard-capped at
     // CHIP_MAX_FANIN (no dep-pool spill). Unbound on an in-graph task, whose
     // dependencies live in the Definition's fanin CSR instead.
     simpler::hbg::SelfRelativePtr<simpler::hbg::Tensor> tensors;
@@ -559,7 +568,9 @@ static_assert(
 static_assert(sizeof(simpler::hbg::Tensor) == 128, "simpler::hbg::Tensor must be 2 cache lines");
 
 /**
- * Per-task slot scheduling state (scheduler-private, NOT in shared memory)
+ * Per-task slot scheduling state. Only the scheduler mutates it, but it lives
+ * wherever its ChipTaskStorage does: the SM image's storage segment for a
+ * GLOBAL task, the GraphExecution image for an IN_GRAPH one.
  *
  * 64 bytes = one cache line. Under the polling completion model a task's
  * readiness is derived from its producers' completion state; producer completion
@@ -570,16 +581,17 @@ static_assert(sizeof(simpler::hbg::Tensor) == 128, "simpler::hbg::Tensor must be
  * belongs to, and both are load-bearing:
  *
  *   - A GLOBAL task holds a slot in the SM task table, so its readiness truth is
- *     `progress_flags[local_id]` — a byte-per-slot array, which is what lets a
+ *     `task_states[local_id]` — a byte-per-slot array, which is what lets a
  *     fanin scan read many producers out of one cache line. `task_state` is then
  *     a mirror, read only by the cold-path stall dump.
  *   - An IN_GRAPH task lives in its Graph's own storage and has no slot in that
- *     table, hence no flag byte. `task_state` IS its readiness truth, read on the
- *     device by graph_first_unmet_producer; only the outer Graph shell (a GLOBAL
- *     task) gets a flag when the body finishes.
+ *     table, hence no byte there. `task_state` IS its readiness truth, read on
+ *     the device by graph_first_unmet_producer; only the outer Graph shell (a
+ *     GLOBAL task) gets its byte advanced when the body finishes.
  *
  * So a completion publishes both for a GLOBAL task and `task_state` alone for an
- * IN_GRAPH one.
+ * IN_GRAPH one. `task_state` itself only ever holds PENDING or COMPLETED; the
+ * PUBLISHED middle value exists in the task_states array alone.
  */
 struct alignas(64) ChipTaskSlotState {
     // --- Wake list: last-fanin notification (intrusive, lock-free) ---
@@ -634,10 +646,11 @@ struct alignas(64) ChipTaskSlotState {
     // ranges through claim_block_range().
     std::atomic<int16_t> next_block_idx{0};
 
-    // Completion state. PENDING at submit; COMPLETED at whichever completion path
-    // owns this slot. For an IN_GRAPH task this is the readiness truth the device
-    // itself polls (graph_first_unmet_producer); for a GLOBAL task it mirrors
-    // progress_flags[slot], which is what the device reads instead. Also read by
+    // Completion state, PENDING or COMPLETED only (never PUBLISHED). PENDING at
+    // submit; COMPLETED at whichever completion path owns this slot. For an
+    // IN_GRAPH task this is the readiness truth the device itself polls
+    // (graph_first_unmet_producer); for a GLOBAL task it mirrors
+    // task_states[slot], which is what the device reads instead. Also read by
     // the cold-path stall dump.
     std::atomic<ChipTaskState> task_state;
 
@@ -667,13 +680,13 @@ struct alignas(64) ChipTaskSlotState {
     uint8_t ed_flags{0};
 
     // Publish-list scan cursor of an ED candidate: the fanin-row index this
-    // task is hung on in the publish list. The row is sorted and publish bits
-    // are monotonic, so indices above the cursor are known-published forever
+    // task is hung on in the publish list. The row is sorted and the state byte
+    // is monotone, so indices above the cursor are known-published forever
     // and every rescan resumes here — each row entry is loaded once per life.
     uint8_t ed_publish_scan_cursor{0};
 
     // Completion-chain scan cursor: the fanin-row index this task last hung at
-    // in the wake list. Completion bits are monotonic, so indices above the
+    // in the wake list. The state byte is monotone, so indices above the
     // cursor stay completed forever and every reclassification resumes here
     // instead of re-walking the row's completed tail. 0xFF = never hung; the
     // scan start folds it to fanin_count - 1. The classifier owning this task
@@ -706,8 +719,8 @@ struct alignas(64) ChipTaskSlotState {
     }
 
     // Publishes completion. For an IN_GRAPH task this store is the whole
-    // publication — that task has no progress_flags byte. For a GLOBAL task it
-    // accompanies the progress_flags[slot] store that on_mixed_task_complete
+    // publication — that task has no task_states byte. For a GLOBAL task it
+    // accompanies the task_states[slot] store that on_mixed_task_complete
     // makes, and is the copy the cold-path stall dump reads.
     void mark_completed() { task_state.store(CHIP_TASK_COMPLETED, std::memory_order_release); }
 

--- a/src/common/host_build_graph/shared/runtime_init.cpp
+++ b/src/common/host_build_graph/shared/runtime_init.cpp
@@ -65,7 +65,7 @@ bool SchedulerState::TaskHeaderView::init_data_from_layout(void *sm_dev_base) {
     tasks = sm_layout::task_header_addr(sm_dev_base);
 
     // Per-slot SM-side initialization (reset_for_reuse + active_mask, and clearing
-    // the completion flag) happens init-on-write in orch::prepare_task as each slot
+    // the progress state) happens init-on-write in orch::prepare_task as each slot
     // is claimed; host prebuilt-arena init skips SM access here.
 
     return true;
@@ -101,7 +101,7 @@ SchedulerLayout SchedulerState::reserve_layout(DeviceArena &arena) {
     layout.off_graph_ready_queue_slots = ready_queue_reserve_layout(arena, READY_QUEUE_CAPACITY_LIMIT);
     layout.off_graph_prepare_queue_slots = ready_queue_reserve_layout(arena, READY_QUEUE_CAPACITY_LIMIT);
     // Polling: no dep_pool arena region — producer dependencies are inline ids on
-    // the payload and readiness is via progress_flags.
+    // the payload and readiness is via the task_states array.
     return layout;
 }
 

--- a/src/common/host_build_graph/shared/shared_memory.cpp
+++ b/src/common/host_build_graph/shared/shared_memory.cpp
@@ -41,7 +41,7 @@ void SharedMemoryHandle::setup_pointers(uint64_t pitch) {
     char *base = (char *)sm_base;
     header = (SharedMemoryHeader *)base;
 
-    // storage / progress_flags — offsets from the single source
+    // storage / task_states — offsets from the single source
     // of truth (sm_layout::segment_offsets), so this setup and the
     // device-address helpers cannot drift.
     //
@@ -52,7 +52,7 @@ void SharedMemoryHandle::setup_pointers(uint64_t pitch) {
     auto off = sm_layout::segment_offsets(sm_layout::image_extents({pitch, 0, 0, 0}));
     auto &tasks = header->tasks;
     tasks.task_storage = (ChipTaskStorage *)(base + off.storage);
-    tasks.progress_flags = (std::atomic<uint8_t> *)(base + off.progress_flags);
+    tasks.task_states = (std::atomic<ChipTaskState> *)(base + off.task_states);
 }
 
 bool SharedMemoryHandle::init(void *sm_base_arg, uint64_t sm_size_arg, uint64_t max_tasks) {
@@ -102,7 +102,7 @@ bool SharedMemoryHandle::attach_populated(
     is_owner = false;
     setup_pointers(live_slots);
     // Deliberately NO init_header: the SM already holds the host orchestrator's
-    // task graph (storage entries and completion flags).
+    // task graph (storage entries and task states).
     return true;
 }
 
@@ -145,7 +145,7 @@ void SharedMemoryHandle::init_header() {
     header->sched_error_thread.store(-1, std::memory_order_relaxed);
 
     // Per-slot init (slot.reset_for_reuse() + active_mask, and clearing the
-    // completion flag) happens init-on-write in orch::prepare_task as each slot
+    // progress state) happens init-on-write in orch::prepare_task as each slot
     // [0, total_tasks) is claimed, so the SM init/upload cost tracks the task
     // count, not the size the table was dimensioned for. The device reads no slot
     // past total_tasks, so the unclaimed tail is left uninitialized.

--- a/src/common/host_build_graph/shared_memory.h
+++ b/src/common/host_build_graph/shared_memory.h
@@ -18,7 +18,7 @@
  *   | SharedMemoryHeader        |  (task count + segment pointers + scheduler error state)
  *   +---------------------------+
  *   | ChipTaskStorage[]         |  (descriptor + slot state + payload, per task)
- *   | std::atomic<uint8_t>[]    |  (completion flags, one byte per task)
+ *   | std::atomic<ChipTaskState>[] |  (progress state, one byte per task)
  *   +---------------------------+
  *   | fanin / tensor / scalar   |  (the argument pools payloads name by delta)
  *   +---------------------------+
@@ -65,56 +65,70 @@ struct alignas(64) SharedMemoryTaskHeader {
     // holding that task's descriptor, slot state and payload — see ChipTaskStorage.
     ChipTaskStorage *task_storage;
 
-    // Polling-completion state (device-addressed array, one byte per slot).
-    // 0 = pending, 1 = task fully COMPLETED. Writer = the task's completer at
-    // on_mixed_task_complete; reader = consumer fanin polling (is_completion_flag_set).
-    // Cleared per-slot in orch::prepare_task as each slot is claimed. Indexed by
-    // local task id, like the storage array — so it covers GLOBAL tasks only. An
-    // IN_GRAPH task holds no slot here and publishes completion through its own
+    // Polling-progress state (device-addressed array, one ChipTaskState byte per
+    // slot): PENDING -> PUBLISHED -> COMPLETED. Writers = the total-reaching
+    // publisher at account_published_blocks (PUBLISHED) and the task's completer
+    // at on_mixed_task_complete (COMPLETED); readers = consumer fanin polling
+    // (is_completed) and the ED publish scan (is_published). Reset per-slot in
+    // orch::prepare_task as each slot is claimed. Indexed by local task id, like
+    // the storage array — so it covers GLOBAL tasks only. An IN_GRAPH task holds
+    // no slot here and publishes completion through its own
     // ChipTaskSlotState::task_state instead; the Graph's outer shell is the GLOBAL
-    // task that carries a flag for the whole body.
+    // task that carries the byte for the whole body.
     //
     // A byte array of its own rather than a field of ChipTaskStorage: a fanin scan
-    // reads many producers' flags at once, which one cache line answers here and
+    // reads many producers' states at once, which one cache line answers here and
     // would take one line per producer inside the storage stride.
     //
-    // A hidden-alloc task is the one flag the host presets to 1: it completes during
-    // orchestration, and a consumer polls this array rather than task_state.
-    std::atomic<uint8_t> *progress_flags;
+    // A hidden-alloc task is the one byte the host presets to COMPLETED: it
+    // completes during orchestration, and a consumer polls this array rather than
+    // task_state.
+    //
+    // Reads are only meaningful under the init-on-write discipline above, and
+    // the ordered comparisons make that stricter than a bit test would: an
+    // unwritten byte holds whatever the device memory held, and every value but
+    // PENDING and PUBLISHED reads as completed. Nothing reads a slot the
+    // orchestrator has not claimed — total_tasks bounds every walk, and the
+    // claim resets the byte — which is what keeps the tail out of reach.
+    std::atomic<ChipTaskState> *task_states;
 
     // Tasks this run submitted, i.e. the slot count the two segments above are
     // pitched to. Written once by the host after orchestration (run_host_orchestration)
     // and read-only from then on, so it packs into the padding rather than taking a
     // line of its own. Bounds every slot-indexed walk: no slot at or above it was
-    // claimed, and the bytes past progress_flags[total_tasks - 1] are not flags.
+    // claimed, and the bytes past task_states[total_tasks - 1] are not states.
     int32_t total_tasks;
 
-    // One byte carries two monotonic facts about a task, each its own bit:
-    //   COMPLETED  every subtask finished; the readiness truth consumers scan
-    //   PUBLISHED  every logical block's payload + MMIO token is written; the
-    //              early-dispatch publish list scans this bit, and completion
-    //              implies it (a finished task occupies no cores)
-    // Completion is a plain store of both bits. Publication is a fetch_or:
-    // the publish-side bookkeeping can run after the block's FIN has already
-    // been observed, so a plain store could erase a completion that landed
-    // in between — OR preserves it under either ordering.
-    static constexpr uint8_t TASK_FLAG_COMPLETED = 1u << 0;
-    static constexpr uint8_t TASK_FLAG_PUBLISHED = 1u << 1;
+    // The byte holds a ChipTaskState and only ever advances:
+    //   PENDING -> PUBLISHED -> COMPLETED
+    // Both transitions are plain stores; monotonicity is by construction, not
+    // by encoding. The total-reaching publisher stores PUBLISHED before its
+    // batch's MMIO token writes, every block's FIN follows its token, and the
+    // all-FIN completer stores COMPLETED — so PUBLISHED ≺ token ≺ FIN ≺
+    // COMPLETED and no writer can regress the byte. Readers use ordered
+    // comparisons: COMPLETED implies published (a finished task occupies no
+    // cores), which is what lets a tracked producer that never publishes
+    // (DUMMY, predicate-retired) release its publish-list waiters through the
+    // completion store alone.
 
-    bool is_completion_flag_set(int32_t local_id, std::memory_order order = std::memory_order_acquire) const {
-        return (progress_flags[local_id].load(order) & TASK_FLAG_COMPLETED) != 0;
+    bool is_completed(int32_t local_id, std::memory_order order = std::memory_order_acquire) const {
+        return task_states[local_id].load(order) >= CHIP_TASK_COMPLETED;
     }
 
-    void set_completion_flag(int32_t local_id, std::memory_order order = std::memory_order_release) const {
-        progress_flags[local_id].store(TASK_FLAG_COMPLETED | TASK_FLAG_PUBLISHED, order);
+    void store_completed(int32_t local_id, std::memory_order order = std::memory_order_release) const {
+        task_states[local_id].store(CHIP_TASK_COMPLETED, order);
     }
 
-    bool is_publish_flag_set(int32_t local_id, std::memory_order order = std::memory_order_acquire) const {
-        return (progress_flags[local_id].load(order) & TASK_FLAG_PUBLISHED) != 0;
+    bool is_published(int32_t local_id, std::memory_order order = std::memory_order_acquire) const {
+        return task_states[local_id].load(order) >= CHIP_TASK_PUBLISHED;
     }
 
-    void set_publish_flag(int32_t local_id) const {
-        progress_flags[local_id].fetch_or(TASK_FLAG_PUBLISHED, std::memory_order_release);
+    void store_published(int32_t local_id, std::memory_order order = std::memory_order_release) const {
+        task_states[local_id].store(CHIP_TASK_PUBLISHED, order);
+    }
+
+    void reset_task_state(int32_t local_id) const {
+        task_states[local_id].store(CHIP_TASK_PENDING, std::memory_order_relaxed);
     }
 
     // A task id is its own storage index, so the three records it names are reached
@@ -192,7 +206,7 @@ struct SharedMemoryHandle {
     bool init(void *sm_base, uint64_t sm_size, uint64_t max_tasks);
 
     // Attach to an ALREADY-populated shared memory region: point the handle and
-    // the task header's segment pointers (storage / completion flags)
+    // the task header's segment pointers (storage / task states)
     // at `sm_base`, but do NOT reset the slot states.
     // Used by host_build_graph host-orch, where the host orchestrator populated
     // the SM and H2D'd it; the device must re-point at its own SM base without
@@ -246,7 +260,7 @@ inline SharedMemoryTaskHeader *task_header_addr(void *sm_dev_base) noexcept {
 }
 
 // Byte offsets (from the SM base) of the image's segments. The layout is: header, then
-// storage -> progress_flags -> the three argument pools, every segment
+// storage -> task_states -> the three argument pools, every segment
 // CHIP_ALIGN_UP-padded. ImageExtents dimensions them: the mirror for the worst case the
 // API allows, the image for what this bind holds, which is what makes the live prefixes
 // contiguous and the upload one copy.
@@ -256,11 +270,11 @@ inline SharedMemoryTaskHeader *task_header_addr(void *sm_dev_base) noexcept {
 // restack's change of pitch untouched.
 //
 // The pools sit last because nothing on the device resolves a segment past
-// progress_flags: a payload names its argument regions by delta, so the two
+// task_states: a payload names its argument regions by delta, so the two
 // slot-pitched offsets are all the attach path computes.
 struct SegmentOffsets {
     uint64_t storage;
-    uint64_t progress_flags;  // polling-completion byte array (1 byte/slot)
+    uint64_t task_states;  // polling-progress ChipTaskState array (1 byte/slot)
     uint64_t fanin_pool;
     uint64_t tensor_pool;
     uint64_t scalar_pool;
@@ -297,8 +311,8 @@ inline SegmentOffsets segment_offsets(const ImageExtents &e) noexcept {
     SegmentOffsets o{};
     o.storage = off;
     off += CHIP_ALIGN_UP(e.slots * sizeof(ChipTaskStorage), CHIP_ALIGN_SIZE);
-    o.progress_flags = off;
-    off += CHIP_ALIGN_UP(e.slots * sizeof(std::atomic<uint8_t>), CHIP_ALIGN_SIZE);
+    o.task_states = off;
+    off += CHIP_ALIGN_UP(e.slots * sizeof(std::atomic<ChipTaskState>), CHIP_ALIGN_SIZE);
     o.fanin_pool = off;
     off += CHIP_ALIGN_UP(e.fanin_elems * sizeof(int32_t), CHIP_ALIGN_SIZE);
     o.tensor_pool = off;
@@ -428,14 +442,14 @@ inline uint64_t compact_live_image(
     std::memcpy(out_base, mirror_base, to.storage);
     auto &out_tasks = reinterpret_cast<SharedMemoryHeader *>(out_base)->tasks;
     out_tasks.task_storage = nullptr;
-    out_tasks.progress_flags = nullptr;
+    out_tasks.task_states = nullptr;
 
     const uint64_t nt = used.submitted_tasks;
     // One copy for all three of a task's records: ChipTaskStorage is fixed-size, so
     // the mirror and the image share a stride. Each pool is likewise one copy of its
     // own prefix.
     std::memcpy(out_base + to.storage, mirror_base + from.storage, nt * sizeof(ChipTaskStorage));
-    std::memcpy(out_base + to.progress_flags, mirror_base + from.progress_flags, nt * sizeof(std::atomic<uint8_t>));
+    std::memcpy(out_base + to.task_states, mirror_base + from.task_states, nt * sizeof(std::atomic<ChipTaskState>));
     std::memcpy(out_base + to.fanin_pool, mirror_base + from.fanin_pool, used.fanin_elems * sizeof(int32_t));
     std::memcpy(
         out_base + to.tensor_pool, mirror_base + from.tensor_pool, used.tensor_elems * sizeof(simpler::hbg::Tensor)

--- a/src/common/host_build_graph/task_id.h
+++ b/src/common/host_build_graph/task_id.h
@@ -71,7 +71,7 @@ struct TaskId {
     static constexpr TaskId invalid() { return TaskId{UINT64_MAX}; }
 
     // A local id is signed throughout this runtime — it is a task-table index, and the
-    // table, the completion flags and the fanin payload all address slots with int32_t.
+    // table, the task states and the fanin payload all address slots with int32_t.
     // The low field is therefore narrowed to uint32_t before it is widened into the raw
     // word, so a negative value cannot sign-extend over the id-space bits above it.
     static constexpr TaskId make_global(int32_t local_id) {

--- a/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
@@ -77,14 +77,14 @@ protected:
         sm_arena.release();
     }
 
-    // Fill the task table (storage entries / progress_flags) with poison.
+    // Fill the task table (storage entries / task_states) with poison.
     // init_header wrote only the header, so this is the state the table
     // is in before any submit writes it — modelling the never-zeroed device SM.
     void poison_task_table() {
         auto &tasks = sm_handle->header->tasks;
         const size_t n = static_cast<size_t>(CHIP_DEFAULT_GRAPH_TASKS);
         std::memset(tasks.task_storage, POISON, n * sizeof(ChipTaskStorage));
-        std::memset(tasks.progress_flags, POISON, n * sizeof(std::atomic<uint8_t>));
+        std::memset(tasks.task_states, POISON, n * sizeof(std::atomic<ChipTaskState>));
     }
 };
 
@@ -147,14 +147,10 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
         // real enum, never poison.
         const ChipTaskState state = st.task_state.load(std::memory_order_relaxed);
         EXPECT_TRUE(state == CHIP_TASK_PENDING || state == CHIP_TASK_COMPLETED);
-        // Completion flag is written to a real value (pending vs pre-completed),
+        // The progress byte is written to a real state (pending vs pre-completed),
         // not a poison byte (0xAA).
-        const uint8_t cflag = tasks.progress_flags[local].load(std::memory_order_relaxed);
-        // 0 = pending; a pre-completed hidden alloc carries COMPLETED|PUBLISHED.
-        EXPECT_TRUE(
-            cflag == 0 ||
-            cflag == (SharedMemoryTaskHeader::TASK_FLAG_COMPLETED | SharedMemoryTaskHeader::TASK_FLAG_PUBLISHED)
-        );
+        const ChipTaskState sm_state = tasks.task_states[local].load(std::memory_order_relaxed);
+        EXPECT_TRUE(sm_state == CHIP_TASK_PENDING || sm_state == CHIP_TASK_COMPLETED);
         // Payload counts are real, not the poison bit pattern.
         EXPECT_GE(pl.fanin_count, 0);
         EXPECT_LE(pl.fanin_count, CHIP_MAX_FANIN);

--- a/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
@@ -76,14 +76,14 @@ protected:
         sm_arena.release();
     }
 
-    // Fill the task table (storage entries / progress_flags) with poison.
+    // Fill the task table (storage entries / task_states) with poison.
     // init_header wrote only the header, so this is the state the table
     // is in before any submit writes it — modelling the never-zeroed device SM.
     void poison_task_table() {
         auto &tasks = sm_handle->header->tasks;
         const size_t n = static_cast<size_t>(CHIP_DEFAULT_GRAPH_TASKS);
         std::memset(tasks.task_storage, POISON, n * sizeof(ChipTaskStorage));
-        std::memset(tasks.progress_flags, POISON, n * sizeof(std::atomic<uint8_t>));
+        std::memset(tasks.task_states, POISON, n * sizeof(std::atomic<ChipTaskState>));
     }
 };
 
@@ -146,14 +146,10 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
         // real enum, never poison.
         const ChipTaskState state = st.task_state.load(std::memory_order_relaxed);
         EXPECT_TRUE(state == CHIP_TASK_PENDING || state == CHIP_TASK_COMPLETED);
-        // Completion flag is written to a real value (pending vs pre-completed),
+        // The progress byte is written to a real state (pending vs pre-completed),
         // not a poison byte (0xAA).
-        const uint8_t cflag = tasks.progress_flags[local].load(std::memory_order_relaxed);
-        // 0 = pending; a pre-completed hidden alloc carries COMPLETED|PUBLISHED.
-        EXPECT_TRUE(
-            cflag == 0 ||
-            cflag == (SharedMemoryTaskHeader::TASK_FLAG_COMPLETED | SharedMemoryTaskHeader::TASK_FLAG_PUBLISHED)
-        );
+        const ChipTaskState sm_state = tasks.task_states[local].load(std::memory_order_relaxed);
+        EXPECT_TRUE(sm_state == CHIP_TASK_PENDING || sm_state == CHIP_TASK_COMPLETED);
         // Payload counts are real, not the poison bit pattern.
         EXPECT_GE(pl.fanin_count, 0);
         EXPECT_LE(pl.fanin_count, CHIP_MAX_FANIN);

--- a/tests/ut/cpp/common/test_hbg_ed_qualification.cpp
+++ b/tests/ut/cpp/common/test_hbg_ed_qualification.cpp
@@ -65,6 +65,12 @@ protected:
         sm_arena.release();
     }
 
+    // A whole publish event as the dispatch path performs it: account for the
+    // blocks before their tokens go out, then seal once they have.
+    void publish_blocks(ChipTaskSlotState &slot_state, int32_t count) {
+        if (sched.account_published_blocks(slot_state, count)) sched.seal_ed_publish_list(slot_state);
+    }
+
     // One AIV producer with an output tensor; `flagged` sets allow_early_resolve.
     TaskId submit_producer(bool flagged) {
         uint32_t shape[] = {16};
@@ -151,7 +157,7 @@ TEST_F(HbgEdQualificationTest, DummyConsumerIsNotCandidate) {
 }
 
 // The wake-scan cursor: each classification resumes where the last one hung
-// and never re-walks the row's completed tail. Monotonic completion bits make
+// and never re-walks the row's completed tail. The monotone state byte makes
 // the resume equivalent to a full rescan, so hang decisions are unchanged.
 TEST_F(HbgEdQualificationTest, WakeScanCursorResumesAndNeverRewalks) {
     TaskId p1 = submit_producer(/*flagged=*/false);
@@ -172,16 +178,16 @@ TEST_F(HbgEdQualificationTest, WakeScanCursorResumesAndNeverRewalks) {
 
     // The hung-at producer completes: the rescan resumes at the cursor and
     // walks down to the next unmet entry.
-    tasks.set_completion_flag(row[2]);
+    tasks.store_completed(row[2]);
     EXPECT_EQ(sched.classify_fanin_state(&c_slot), 1);
     EXPECT_EQ(c_slot.wake_scan_cursor, 1);
 
     // Entries above the cursor completing do not move it (nothing rescans
     // them); completing the remaining tail yields the ready verdict.
-    tasks.set_completion_flag(row[0]);
+    tasks.store_completed(row[0]);
     EXPECT_EQ(sched.classify_fanin_state(&c_slot), 1);
     EXPECT_EQ(c_slot.wake_scan_cursor, 1);
-    tasks.set_completion_flag(row[1]);
+    tasks.store_completed(row[1]);
     EXPECT_EQ(sched.classify_fanin_state(&c_slot), -1);
 }
 
@@ -211,7 +217,7 @@ TEST_F(HbgEdQualificationTest, PublishListDetectsAllPublished) {
 
     // p2 publishes its only block: chain seals, detached head reaches the
     // pending-drain queue.
-    sched.record_published_blocks(p2_slot, 1);
+    publish_blocks(p2_slot, 1);
     EXPECT_EQ(p2_slot.ed_publish_list_head.load(std::memory_order_relaxed), ED_PUBLISH_LIST_SENTINEL);
     ChipTaskSlotState *detached = nullptr;
     ASSERT_EQ(sched.ed_publish_drain_queue.pop_batch(&detached, 1), 1);
@@ -224,7 +230,7 @@ TEST_F(HbgEdQualificationTest, PublishListDetectsAllPublished) {
 
     // p1 publishes: rescan reaches the all-published verdict; the claim CAS
     // moves the candidate to STAGING and its shape queue.
-    sched.record_published_blocks(p1_slot, 1);
+    publish_blocks(p1_slot, 1);
     ASSERT_EQ(sched.ed_publish_drain_queue.pop_batch(&detached, 1), 1);
     ASSERT_EQ(detached, &c_slot);
     ASSERT_TRUE(sched.advance_ed_publish_scan(*detached));
@@ -233,6 +239,60 @@ TEST_F(HbgEdQualificationTest, PublishListDetectsAllPublished) {
     ChipTaskSlotState *staged = nullptr;
     ASSERT_EQ(sched.early_dispatch_queues[static_cast<int32_t>(ResourceShape::AIV)].pop_batch(&staged, 1), 1);
     EXPECT_EQ(staged, &c_slot);
+}
+
+// The publish event is two calls around the caller's MMIO token writes, and the
+// state byte belongs to the first: a scanner that meets the sentinel therefore
+// always reads the producer as published, never the reverse. The window between
+// them is where a caller's tokens go, so it is entered here deliberately.
+TEST_F(HbgEdQualificationTest, PublishedStateIsVisibleBeforeTheChainSeals) {
+    TaskId p = submit_producer(/*flagged=*/true);
+    TaskId deps[] = {p};
+    TaskId c = submit_consumer(deps, 1);
+
+    auto &tasks = sm_handle->header->tasks;
+    ChipTaskSlotState &p_slot = tasks.get_slot_state_by_task_id(p.local_id());
+    ChipTaskSlotState &c_slot = tasks.get_slot_state_by_task_id(c.local_id());
+    const int32_t p_local = p.local_id();
+
+    ASSERT_FALSE(sched.register_on_ed_publish_list(c_slot));
+    ASSERT_FALSE(tasks.is_published(p_local));
+
+    // Accounting reaches the total: the byte says published, the chain is still
+    // open, and the waiter has not been detached yet.
+    ASSERT_TRUE(sched.account_published_blocks(p_slot, p_slot.logical_block_num));
+    EXPECT_TRUE(tasks.is_published(p_local));
+    EXPECT_EQ(p_slot.ed_publish_list_head.load(std::memory_order_relaxed), &c_slot);
+    ChipTaskSlotState *detached = nullptr;
+    EXPECT_EQ(sched.ed_publish_drain_queue.pop_batch(&detached, 1), 0);
+
+    // The seal closes the chain and hands the waiter over.
+    sched.seal_ed_publish_list(p_slot);
+    EXPECT_EQ(p_slot.ed_publish_list_head.load(std::memory_order_relaxed), ED_PUBLISH_LIST_SENTINEL);
+    ASSERT_EQ(sched.ed_publish_drain_queue.pop_batch(&detached, 1), 1);
+    EXPECT_EQ(detached, &c_slot);
+    EXPECT_TRUE(sched.advance_ed_publish_scan(*detached));
+}
+
+// A tracked producer that never publishes (DUMMY, predicate-retired) reaches
+// COMPLETED without passing through PUBLISHED, and the ordered comparison is
+// what still releases its publish-list waiters.
+TEST_F(HbgEdQualificationTest, CompletionAloneCountsAsPublished) {
+    TaskId p = submit_producer(/*flagged=*/true);
+    TaskId deps[] = {p};
+    TaskId c = submit_consumer(deps, 1);
+
+    auto &tasks = sm_handle->header->tasks;
+    const int32_t p_local = p.local_id();
+    ChipTaskSlotState &c_slot = tasks.get_slot_state_by_task_id(c.local_id());
+
+    ASSERT_FALSE(sched.register_on_ed_publish_list(c_slot));
+    ASSERT_FALSE(tasks.is_published(p_local));
+
+    tasks.store_completed(p_local);
+    EXPECT_EQ(tasks.task_states[p_local].load(std::memory_order_relaxed), CHIP_TASK_COMPLETED);
+    EXPECT_TRUE(tasks.is_published(p_local));
+    EXPECT_TRUE(tasks.is_completed(p_local));
 }
 
 // A two-level ED chain: the middle task is both a candidate (its own producer
@@ -263,7 +323,7 @@ TEST_F(HbgEdQualificationTest, GatedCandidateSealsWhileStagingAndReleasesItsCons
     // (pre-staged, doorbell not rung — the gated state).
     ChipTaskSlotState &p0_slot =
         sm_handle->header->tasks.get_slot_state_by_task_id(static_cast<int32_t>(p0.local_id()));
-    sched.record_published_blocks(p0_slot, 1);
+    publish_blocks(p0_slot, 1);
     ChipTaskSlotState *detached = nullptr;
     ASSERT_EQ(sched.ed_publish_drain_queue.pop_batch(&detached, 1), 1);
     ASSERT_EQ(detached, &p1_slot);
@@ -273,7 +333,7 @@ TEST_F(HbgEdQualificationTest, GatedCandidateSealsWhileStagingAndReleasesItsCons
 
     // p1's (gated) blocks publish while it is STAGING: the seal fires anyway —
     // publication counts placement, not launch — and hands C to the drain.
-    sched.record_published_blocks(p1_slot, 1);
+    publish_blocks(p1_slot, 1);
     EXPECT_EQ(p1_slot.ed_publish_list_head.load(std::memory_order_relaxed), ED_PUBLISH_LIST_SENTINEL);
     ASSERT_EQ(sched.ed_publish_drain_queue.pop_batch(&detached, 1), 1);
     ASSERT_EQ(detached, &c_slot);
@@ -288,7 +348,7 @@ TEST_F(HbgEdQualificationTest, ReleaseClaimsNeverStagedTaskForNormalRoute) {
     TaskId p1 = submit_producer(/*flagged=*/false);
     ChipTaskSlotState &p1_slot = sm_handle->header->tasks.get_slot_state_by_task_id(p1.local_id());
     // Untracked: publication leaves no publish state behind.
-    sched.record_published_blocks(p1_slot, 1);
+    publish_blocks(p1_slot, 1);
     EXPECT_EQ(p1_slot.to_payload().published_block_count.load(std::memory_order_relaxed), 0);
     EXPECT_EQ(p1_slot.ed_publish_list_head.load(std::memory_order_relaxed), nullptr);
 

--- a/tests/ut/cpp/common/test_hbg_slot_claim.cpp
+++ b/tests/ut/cpp/common/test_hbg_slot_claim.cpp
@@ -90,7 +90,7 @@ protected:
         state.completed_subtasks.store(7, std::memory_order_relaxed);
         state.next_block_idx.store(3, std::memory_order_relaxed);
         state.in_graph_local_id = 11;
-        sm_handle->header->tasks.progress_flags[slot].store(1, std::memory_order_relaxed);
+        sm_handle->header->tasks.store_completed(slot);
     }
 
     void expect_slot_pristine(int32_t slot) {
@@ -101,8 +101,8 @@ protected:
         EXPECT_FALSE(state.has_any_subtask_deferred());
         EXPECT_EQ(state.completed_subtasks.load(std::memory_order_relaxed), 0);
         EXPECT_EQ(state.next_block_idx.load(std::memory_order_relaxed), 0);
-        EXPECT_EQ(sm_handle->header->tasks.progress_flags[slot].load(std::memory_order_relaxed), 0)
-            << "a stale completion flag reports this task done before it has run";
+        EXPECT_EQ(sm_handle->header->tasks.task_states[slot].load(std::memory_order_relaxed), CHIP_TASK_PENDING)
+            << "a stale progress state reports this task done before it has run";
     }
 };
 

--- a/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
+++ b/tests/ut/cpp/common/test_hbg_sm_compaction.cpp
@@ -77,7 +77,7 @@ public:
         tasks.total_tasks = static_cast<int32_t>(SUBMITTED);
         storage_ = reinterpret_cast<ChipTaskStorage *>(image_.base() + off.storage);
         tasks.task_storage = storage_;
-        tasks.progress_flags = progress_flags();
+        tasks.task_states = task_states();
 
         // Each live slot takes a packed region in each pool, exactly as the
         // orchestrator's bump cursors hand them out, and gets content that identifies
@@ -102,7 +102,7 @@ public:
                 entry.payload.fanin_data()[j] = static_cast<int32_t>(0x50 + i * 0x10 + j);
             }
             entry.slot.in_graph_local_id = static_cast<int32_t>(200 + i);
-            progress_flags()[i].store(static_cast<uint8_t>(i & 1), std::memory_order_relaxed);
+            task_states()[i].store(i & 1 ? CHIP_TASK_COMPLETED : CHIP_TASK_PENDING, std::memory_order_relaxed);
         }
         // A slot past the submitted prefix, to prove it does not travel.
         storage_[SUBMITTED].task.task_id = TaskId::make_global(0xBEEF);
@@ -143,9 +143,9 @@ public:
     int32_t *fanin_pool() {
         return reinterpret_cast<int32_t *>(image_.base() + sm_layout::segment_offsets(WINDOW).fanin_pool);
     }
-    std::atomic<uint8_t> *progress_flags() {
-        return reinterpret_cast<std::atomic<uint8_t> *>(
-            image_.base() + sm_layout::segment_offsets(WINDOW).progress_flags
+    std::atomic<ChipTaskState> *task_states() {
+        return reinterpret_cast<std::atomic<ChipTaskState> *>(
+            image_.base() + sm_layout::segment_offsets(WINDOW).task_states
         );
     }
 
@@ -195,8 +195,8 @@ struct Compacted {
     simpler::hbg::Tensor *tensor_pool() {
         return reinterpret_cast<simpler::hbg::Tensor *>(image.base() + off().tensor_pool);
     }
-    std::atomic<uint8_t> *progress_flags() {
-        return reinterpret_cast<std::atomic<uint8_t> *>(image.base() + off().progress_flags);
+    std::atomic<ChipTaskState> *task_states() {
+        return reinterpret_cast<std::atomic<ChipTaskState> *>(image.base() + off().task_states);
     }
 };
 
@@ -222,8 +222,8 @@ TEST(HbgSmCompaction, CarriesEveryLiveSlotsContent) {
         EXPECT_EQ(entry.payload.tensor_count, TENSORS_PER_TASK) << "slot " << i;
         EXPECT_EQ(entry.payload.tensor_data()[0].buffer.addr, 0x1000 + i * 0x10) << "slot " << i;
         EXPECT_EQ(entry.slot.in_graph_local_id, static_cast<int32_t>(200 + i)) << "slot " << i;
-        EXPECT_EQ(compacted.progress_flags()[i].load(std::memory_order_relaxed), static_cast<uint8_t>(i & 1))
-            << "slot " << i;
+        const ChipTaskState expected_state = i & 1 ? CHIP_TASK_COMPLETED : CHIP_TASK_PENDING;
+        EXPECT_EQ(compacted.task_states()[i].load(std::memory_order_relaxed), expected_state) << "slot " << i;
     }
     // The header's pitch-independent fields come across; the mirror slot past the
     // prefix does not.
@@ -276,7 +276,7 @@ TEST(HbgSmCompaction, LeavesNoHostPointerInTheHeader) {
 
     auto &tasks = reinterpret_cast<const SharedMemoryHeader *>(compacted.image.base())->tasks;
     EXPECT_EQ(tasks.task_storage, nullptr);
-    EXPECT_EQ(tasks.progress_flags, nullptr);
+    EXPECT_EQ(tasks.task_states, nullptr);
 }
 
 // A bind that submits nothing still ships its header and still attaches. Its pools
@@ -422,10 +422,10 @@ TEST(HbgSmCompaction, SegmentLayoutHoldsForANonPowerOfTwoCapacity) {
         // The storage sits right after the padded header, whatever the pitch.
         EXPECT_EQ(off.storage, CHIP_ALIGN_UP(sizeof(SharedMemoryHeader), CHIP_ALIGN_SIZE)) << "capacity " << capacity;
 
-        const uint64_t starts[] = {off.storage,     off.progress_flags, off.fanin_pool,
-                                   off.tensor_pool, off.scalar_pool,    off.end};
+        const uint64_t starts[] = {off.storage,     off.task_states, off.fanin_pool,
+                                   off.tensor_pool, off.scalar_pool, off.end};
         const uint64_t spans[] = {
-            capacity * sizeof(ChipTaskStorage), capacity * sizeof(std::atomic<uint8_t>),
+            capacity * sizeof(ChipTaskStorage), capacity * sizeof(std::atomic<ChipTaskState>),
             e.fanin_elems * sizeof(int32_t),    e.tensor_elems * sizeof(simpler::hbg::Tensor),
             e.scalar_elems * sizeof(uint64_t),
         };


### PR DESCRIPTION
## Summary

Implements #2106, plus the re-encode it enables.

The per-task progress byte encoded a linear progression through bit-containment
values (`0x0 -> 0x2 -> 0x3`) so a lock-free `fetch_or` would double as a
monotone-max. That trick was load-bearing: the PUBLISHED bookkeeping ran *after*
the final MMIO token write while the FIN -> completion chain forks off that same
token write, leaving the two writes causally unordered. A plain store of a
sequential value could let a late publish regress an already-completed byte and
livelock the wake-list sentinel protocol.

**Establish the order by construction instead.** `record_published_blocks` splits
into `account_published_blocks`, called *before* a batch's token writes and
returning whether this caller reached the task's total, and the existing
`seal_ed_publish_list`, called *after* the flush. The PUBLISHED store therefore
precedes every token the task emits, and those tokens' FINs gate the all-FIN
completion, so `PUBLISHED < token < FIN < COMPLETED` holds regardless of how
sibling publishers interleave. Cores are claimed at prepare time, before any
bookkeeping, so a consumer staged off the earlier PUBLISHED cannot occupy cores
the producer's in-flight blocks still need.

**With the ordering guaranteed, the byte becomes a state.** `ChipTaskState` gains
`PUBLISHED` between `PENDING` and `COMPLETED`, and the array is written with plain
stores. Readers use ordered comparisons, and `COMPLETED > PUBLISHED` is what lets
a tracked producer that never publishes (DUMMY, predicate-retired) release its
publish-list waiters through the completion store alone.

This also removes the redundancy of two spellings for one fact: `progress_flags`
is renamed `task_states`, and `TASK_FLAG_*` / `is_completion_flag_set` /
`is_publish_flag_set` give way to `is_completed` / `is_published` /
`store_completed` / `store_published` / `reset_task_state`.

The columnar byte-array layout is unchanged and deliberate: under the polling
model a fanin scan reads many producers' states at once, which one cache line
answers here and would take one line per producer inside the `ChipTaskStorage`
stride. The slot-resident `task_state` mirror is also unchanged — it stays
`PENDING` or `COMPLETED` and remains the in-graph readiness truth.

Also corrects the `ChipTaskSlotState` header comment, which claimed the struct is
"NOT in shared memory" while a GLOBAL task's slot lives in the SM image's storage
segment.

Both arches and all three publish sites (`dispatch_shape`,
`stage_consumer_blocks`, `stage_sync_start_cores`) move together.

## Testing

- [x] Simulation tests pass — a2a3 `host_build_graph` 12 passed / 7 skipped, a5
      `host_build_graph` 13 passed
- [x] C++ unit tests — 134/134 (`ctest -LE requires_hardware`)
- [x] Hardware A/B, a2a3 `host_build_graph`, 8 cases x 30 rounds, baseline
      (merge-base) built in its own worktree venv, both arms sequential on one
      pinned die: every device delta within +/-1.1%, none above the 2% review
      threshold; `qwen3_14b_decode` +1.06%
- [x] Host `bind` phases, qwen, base/HEAD interleaved twice: the two repetitions
      disagree in sign (+5.8% / -12.7% on a ~0.3 ms control-plane min-of-sums),
      which per `docs/dfx/hbg-bind-phases.md` means no resolvable host movement —
      as expected, since the host side performs the same stores in the same places

Fixes #2106