### PR TITLE
Feature: publish simpler.trace for a caller's own host spans

### DIFF
--- a/.claude/rules/project-layout.md
+++ b/.claude/rules/project-layout.md
@@ -6,13 +6,13 @@ How this repo organizes Python packages, the build system, and example / test di
 
 | Package | Source | What's in wheel | Use for |
 | ------- | ------ | --------------- | ------- |
-| `simpler` | `python/simpler/` | `task_interface`, `worker`, `env_manager` only | Runtime user API: `Worker` plus the task/callable types |
+| `simpler` | `python/simpler/` | Every module in the package | Runtime user API: `Worker`, the task/callable types, and `trace` for putting your own spans on the host timeline |
 | `simpler_setup` | `simpler_setup/` | All files + `_assets/{src,build/lib}` | **Also user-facing**, not internal-only: `KernelCompiler`, `SceneTestCase` / `scene_test`, `TensorArg`, `Scalar`, `TaskArgsBuilder`, `ensure_pto_isa_root`, `make_chip_tensor_arg`, plus the `simpler_setup.tools` CLIs. A kernel cannot be compiled without it |
 | `_task_interface` | `python/bindings/` | nanobind `.so` at wheel root | Internal nanobind module |
 
-`simpler` exposes `Worker` and the `task_interface` submodule lazily (PEP 562
-`__getattr__`), so `from simpler import Worker` works while `import simpler` does
-not require the `_task_interface` extension. Importing `simpler` only configures
+`simpler` exposes `Worker` and the `task_interface` and `trace` submodules lazily
+(PEP 562 `__getattr__`), so `from simpler import Worker` works while
+`import simpler` does not require the `_task_interface` extension. Importing `simpler` only configures
 the Python logger; it performs no native `dlopen`. Once `_task_interface` is
 loaded, it owns the process's host-log state. `Worker.init()` seeds that state
 before the first fork, and each host runtime module compiles a private logger
@@ -22,7 +22,7 @@ a `ChipWorker` consumes; `simpler_setup.TensorArg` is the address-free
 scene-test arg spec `NamedTuple`. They are separate types in separate
 namespaces.
 
-The 4 files `kernel_compiler.py`, `runtime_compiler.py`, `toolchain.py`, `elf_parser.py` exist in **both** `python/simpler/` and `simpler_setup/` during transition. The `simpler_setup/` copies are authoritative; the `python/simpler/` copies are excluded from wheel via `pyproject.toml::wheel.exclude`. New code must `import` from `simpler_setup.*`, not `simpler.*`, for these four.
+The 4 files `kernel_compiler.py`, `runtime_compiler.py`, `toolchain.py`, `elf_parser.py` exist in **both** `python/simpler/` and `simpler_setup/` during transition. The `simpler_setup/` copies are authoritative and are the ones new code must `import` from (`simpler_setup.*`, not `simpler.*`). Both copies ship: `wheel.packages` takes `python/simpler` whole, and the `wheel.exclude` that once dropped the `python/simpler` copies was removed in #552 — so the duplication is a source-tree convention, not a packaging one.
 
 ## Build System Lookup
 

--- a/docs/dfx/README.md
+++ b/docs/dfx/README.md
@@ -22,7 +22,7 @@ Analysis CLIs that consume these outputs are documented in
 | Document | What it covers |
 | -------- | -------------- |
 | [L2 Timing](l2-timing.md) | `host_wall` / `device_wall` / Effective / Orch / Sched breakdown from `[STRACE]` |
-| [Host runtime trace markers](host-trace.md) | The `[STRACE]` marker set emitted by the host runtime |
+| [Host runtime trace markers](host-trace.md) | The `[STRACE]` marker set emitted by the host runtime, and `simpler.trace` for emitting your own |
 | [The host_build_graph bind phases](hbg-bind-phases.md) | What the bind segments are, the switches that expose them, and how to compare two branches on the qwen and dsv4 decode cases |
 | [Device-side phase timing](device-phases.md) | Fixed AICPU phases and the variable-phase plan |
 | [Scheduler-Overhead Model](sched-overhead-model.md) | Is the scheduler the bottleneck, or starved — the model behind `--overhead` |

--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -291,6 +291,82 @@ above under the `ext.` heading near the end of the file. A repository adapting t
 this namespace can read those tests as the specification and mirror them against
 its own emitter.
 
+## Emitting your own spans with `simpler.trace`
+
+A caller puts its own phases on this timeline through `simpler.trace`
+([`python/simpler/trace.py`](../../python/simpler/trace.py)), rather than
+formatting records itself. One producer, one span, one gate is the whole surface:
+
+```python
+from simpler import trace
+
+with trace.span("my_phase", batch=16, layer=3):
+    ...
+
+@trace.span("my_func")
+def f(): ...
+
+with trace.span("checkpoint", token=17):   # a marker is a span of no work
+    pass
+
+if trace.enabled():                        # only then build costly attributes
+    with trace.span("expensive", **compute_attrs()):
+        ...
+```
+
+A library names itself, so its spans attribute to it wherever it is imported; a
+caller that names nothing writes under `ext.app.`:
+
+```python
+tracer = trace.producer("pypto")          # -> ext.pypto.<span>
+with tracer.span("decode_layer", layer=3):
+    ...
+```
+
+There is deliberately **no separate instant/marker call**. A zero-duration event
+would be a second event concept, and `dur=0` is already what our own emitting
+side writes for a phase that was never stamped — `c_api_shared.cpp` skips a device
+phase whose duration reads back 0 — so a public API producing it would put two
+meanings on one value. A marker is a span whose body does no work, which records a
+real short interval instead.
+
+Three properties hold by construction, which is the reason to call this rather
+than the seven-argument `_emit_host_span` underneath it:
+
+| Property | How |
+| -------- | --- |
+| **One clock** | the wrapper reads `_monotonic_now_ns`, the extension's binding for the `steady_clock` every host record's prefix and every C++ span is stamped with. A caller never handles a timestamp, so this does not rest on Python's `time.monotonic` mapping to the same clock as C++'s on the platform in hand. |
+| **One namespace** | every name is prefixed `ext.<producer>.`, so `trace.span("node.dispatch")` emits `ext.pypto.node.dispatch` — one of our level words is only ever a leaf. Nothing validates the name against them, because nothing a caller passes can reach them. |
+| **One gate** | `trace.enabled()` is `unified_log_host_span_enabled()`, the same runtime query the C++ emit sites read, and it is false in a build with host spans compiled out. Every producer asks that one query. |
+
+`inv`, `hid` and `depth` are our correlation keys and stay off this surface — a
+caller has no value for them and no external span reaches the views that read
+them, so each record carries 0. Correlation goes in an attribute like any other
+field. A producer name is one dot-free word (attribution splits on dots); a span
+name may be dotted to nest, and both are percent-encoded by the record writer, so
+neither can inject the record grammar. The default producer is the constant `app`
+rather than a name derived from the running program: every such derivation is a
+heuristic with its own special cases, and one `trace.producer(...)` call names an
+application better than any of them.
+
+Cost of one `with trace.span(name, k=v, k2=v2)` attempt, measured on this repo's
+aarch64 dev box (median of 7 batches, 200k iterations each): **995 ns with the
+gate closed** against **8998 ns emitting**. The closed-gate figure is dominated by
+Python itself — an empty pure-Python `with` block costs 272 ns there and the gate
+query 166 ns — so a genuinely hot loop should ask `trace.enabled()` once rather
+than open a span per iteration. That is what the query is public for.
+
+**This API does not make the record format a supported external contract.** The
+`v=1` field exists for that decision; making it is separate from offering the
+emitter.
+
+**It is also not a side channel for callers.** `[STRACE]` is the one timeline
+format (see *Reading the markers* below), and a caller's interval is a span for
+the same reason a runtime's own bind segment is. What the reserved namespace
+separates is *whose* span it is, not which format it uses — a producer outside
+this repository writes the same records, on the same clock, through the same
+gate, and they render on the same lanes.
+
 ## Reading the markers — `strace_timing.py`
 
 ```bash
@@ -322,7 +398,7 @@ the one timeline format: an interval a reader can place on a timeline is a span,
 whoever measured it and however it was captured. `chip.run.bind.args` and
 `chip.run.bind.prebuilt` come from the tensormap runtime rather than the
 platform; the device sub-phases are the TMR AICPU's own breakdown, read back from
-a cycle buffer and re-emitted as spans; and `ext.` (below) admits producers
+a cycle buffer and re-emitted as spans; and `ext.` (above) admits producers
 outside this repository entirely. So the grammar was never a fixed per-run-stage
 set, and a stage's segments do not need a second format.
 

--- a/docs/user/reference/python-api.md
+++ b/docs/user/reference/python-api.md
@@ -9,12 +9,12 @@ Treat the source as authoritative when the two disagree, and fix this page in th
 same change.
 
 `Worker` is available from the package root; the remaining task and callable
-types live in `simpler.task_interface`. Both resolve on first access, so
-`import simpler` alone stays cheap and does not require the `_task_interface`
-extension.
+types live in `simpler.task_interface`, and the tracing helpers in
+`simpler.trace`. All of them resolve on first access, so `import simpler` alone
+stays cheap and does not require the `_task_interface` extension.
 
 ```python
-from simpler import Worker           # or: from simpler.worker import Worker
+from simpler import Worker, trace     # or: from simpler.worker import Worker
 from simpler.task_interface import (
     ArgDirection, CallConfig, ChipCallable, ChipStorageTaskArgs,
     ChipTensor, CoreCallable, DataType, TaskArgs, TaskHandle,
@@ -146,6 +146,30 @@ takes a device pointer; `DataType` carries the element types.
 
 `validate()` runs at every submit/run entry point and throws if a diagnostic is
 on without `output_prefix`, or if a ring override breaks the ring's constraints.
+
+## `simpler.trace`
+
+Puts your own phases on the same host timeline the runtime's spans land on, on
+the same clock and in the same log. One producer, one span, one gate:
+
+| Name | Use |
+| ---- | --- |
+| `span(name, **attributes)` | A timed region, as a `with` block or a decorator. Emits even when the block raises, and does not swallow the exception. A marker is a span whose body does no work — there is no separate zero-duration call |
+| `producer(name)` | A `Producer` with the same `span` / `enabled`, for a library that wants its own name instead of the default `app` |
+| `enabled()` | Whether spans are being emitted right now — ask before building attributes that cost more than the span |
+
+```python
+from simpler import trace
+
+with trace.span("my_phase", batch=16, layer=3):
+    ...
+```
+
+Names are prefixed `ext.<producer>.`, so your spans can never be mistaken for
+the runtime's own. See
+[host trace markers](../../dfx/host-trace.md#emitting-your-own-spans-with-simplertrace)
+for what the namespace guarantees in each view, the cost of one attempt, and how
+to read the records back.
 
 ## `simpler_setup`
 

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -62,6 +62,7 @@
 #include "chip_worker.h"
 #include "common/host_span_names.h"
 #include "common/host_span_scope.h"
+#include "common/log_clock.h"
 #include "host_log.h"
 #include "data_type.h"
 #include "worker_chip_orch_comm.h"
@@ -1711,6 +1712,14 @@ NB_MODULE(_task_interface, m) {
             return simpler::host_trace::enabled();
         },
         "Return whether this extension currently emits TIMING-level host spans."
+    );
+    m.def(
+        "_monotonic_now_ns",
+        [] {
+            return simpler::log::monotonic_now_ns();
+        },
+        "Read the clock every host record is stamped with, so a Python-timed span shares one clock with the C++ "
+        "spans by construction rather than by both platforms happening to map their monotonic clock the same way."
     );
     m.def(
         "_host_log_directory",

--- a/python/simpler/__init__.py
+++ b/python/simpler/__init__.py
@@ -16,10 +16,11 @@ shared state; each host module contains its own logger implementation and binds
 to that state immediately after it is loaded. Onboard `simpler_init` also maps
 the threshold onto CANN's coarser dlog ladder.
 
-`Worker` and the `task_interface` submodule resolve on first attribute access
-rather than at import time: both pull in the `_task_interface` extension, so
-eager imports here would make `import simpler` fail wherever that extension is
-missing or stale, including for callers that only want the logging helpers.
+`Worker` and the `task_interface` and `trace` submodules resolve on first
+attribute access rather than at import time: they pull in the `_task_interface`
+extension, so eager imports here would make `import simpler` fail wherever that
+extension is missing or stale, including for callers that only want the logging
+helpers.
 """
 
 import importlib
@@ -43,11 +44,12 @@ __all__ = [
     "get_logger",
     "comm_endpoints",
     "task_interface",
+    "trace",
 ]
 
 # name -> (module, attribute). Resolved by __getattr__ on first access.
 _LAZY_ATTRS = {"Worker": (f"{__name__}.worker", "Worker")}
-_LAZY_SUBMODULES = ("comm_endpoints", "task_interface")
+_LAZY_SUBMODULES = ("comm_endpoints", "task_interface", "trace")
 
 
 def __getattr__(name: str) -> Any:

--- a/python/simpler/trace.py
+++ b/python/simpler/trace.py
@@ -1,0 +1,225 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Put a caller's own spans on the host timeline.
+
+One producer, one span, one gate — the whole surface:
+
+```python
+from simpler import trace
+
+with trace.span("my_phase", batch=16, layer=3):
+    ...
+
+@trace.span("my_func")
+def f(): ...
+
+with trace.span("checkpoint", token=17):   # a marker is a span of no work
+    pass
+
+if trace.enabled():                        # only then build costly attributes
+    with trace.span("expensive", **compute_attrs()):
+        ...
+
+tracer = trace.producer("pypto")           # a library names itself
+```
+
+There is no separate instant/marker call: a zero-duration event would be a second
+event concept, and `dur=0` already means "this phase was never stamped" on the
+emitting side of our own spans. A marker is a span whose body does no work, which
+records a real short interval instead of a value that means something else.
+
+Three properties hold by construction rather than by documentation, which is why
+this surface exists at all next to the seven-argument `_emit_host_span`:
+
+- **One clock.** A caller never handles a timestamp; the wrapper reads
+  `_monotonic_now_ns`, the same clock every host record is stamped with.
+- **One namespace.** Every name emitted here is prefixed `ext.<producer>.`, so a
+  caller cannot land a span in one of ours whatever it passes.
+- **One gate.** `enabled()` is the runtime host-span query the C++ emit sites
+  read, not a second notion of "on".
+
+This is not a side channel for callers. `[STRACE]` is the host's one timeline
+format, and a caller's interval is a span for the same reason a runtime's own
+bind segment is; what the reserved namespace separates is *whose* span it is, not
+which format it uses.
+
+See [docs/dfx/host-trace.md](../../docs/dfx/host-trace.md) for the record grammar
+and what the `ext.` namespace guarantees in each view.
+"""
+
+import functools
+import inspect
+import re
+from typing import Any, Callable, Optional
+
+from _task_interface import (  # pyright: ignore[reportMissingImports]
+    _emit_host_span,
+    _host_spans_active,
+    _monotonic_now_ns,
+)
+
+__all__ = ["Producer", "enabled", "producer", "span"]
+
+# The leading word reserved for producers outside simpler: `ext.<producer>.<span>`.
+# `simpler_setup.tools.strace_timing.span_family` reads it.
+_RESERVED_WORD = "ext"
+
+# A producer segment is one dot-free word, because attribution splits the name on
+# dots and reads the second segment. Everything else is percent-encoded by the
+# record writer rather than rejected, so this is the only spelling constraint.
+_PRODUCER_PATTERN = re.compile(r"\A[A-Za-z0-9_-]+\Z")
+
+# The producer a caller that names none writes under. Deliberately a constant
+# rather than a name derived from the running program: every derivation is a
+# heuristic with its own special cases, and one call to `producer()` names an
+# application better than any of them.
+_UNNAMED_APPLICATION = "app"
+
+
+def _emit(name: str, start_ns: int, duration_ns: int, attributes: dict) -> None:
+    """Write one span record.
+
+    `inv` and `hid` are our correlation keys — a native run epoch and a callable
+    digest — and `depth` is our scheduler's nesting counter. An external span
+    reaches no view that reads them, and a caller has no value to put in them, so
+    all three are 0.
+    """
+    payload = " ".join(f"{key}={value}" for key, value in attributes.items())
+    _emit_host_span(name, 0, 0, 0, start_ns, duration_ns, payload)
+
+
+class Span:
+    """One named region of a caller's code, times itself, emits on exit.
+
+    Both uses re-read the gate at the moment they run, never at the moment the
+    span was created: a `with` block on `__enter__`, a decorated call on every
+    call. A module decorated while the threshold was still at its default
+    therefore starts producing spans as soon as a worker seeds a lower one.
+
+    A decorated `async def` gets a coroutine wrapper, so its span covers the
+    body's execution rather than the coroutine's creation.
+
+    One instance times one scope, since it holds the one start timestamp:
+    entering the same instance twice before its first exit mispairs the two.
+    `span()` returns a fresh instance per call, and the decorator times each call
+    without touching the instance, so only a stored-and-shared instance can reach
+    that.
+    """
+
+    __slots__ = ("_attributes", "_name", "_start_ns")
+
+    def __init__(self, name: str, attributes: dict) -> None:
+        self._name = name
+        self._attributes = attributes
+        self._start_ns: Optional[int] = None
+
+    def __enter__(self) -> "Span":
+        self._start_ns = _monotonic_now_ns() if _host_spans_active() else None
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> bool:
+        start_ns = self._start_ns
+        self._start_ns = None
+        if start_ns is not None:
+            _emit(self._name, start_ns, _monotonic_now_ns() - start_ns, self._attributes)
+        return False
+
+    def __call__(self, function: Callable[..., Any]) -> Callable[..., Any]:
+        name = self._name
+        attributes = self._attributes
+
+        if inspect.iscoroutinefunction(function):
+            # A sync wrapper around a coroutine function would time the coroutine's
+            # *creation* — a few hundred nanoseconds — and close the span before the
+            # body ran at all. The choice is made here, at decoration, so the call
+            # path carries no extra test.
+            @functools.wraps(function)
+            async def async_wrapper(*args, **kwargs):
+                if not _host_spans_active():
+                    return await function(*args, **kwargs)
+                start_ns = _monotonic_now_ns()
+                try:
+                    return await function(*args, **kwargs)
+                finally:
+                    _emit(name, start_ns, _monotonic_now_ns() - start_ns, attributes)
+
+            return async_wrapper
+
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            if not _host_spans_active():
+                return function(*args, **kwargs)
+            start_ns = _monotonic_now_ns()
+            try:
+                return function(*args, **kwargs)
+            finally:
+                _emit(name, start_ns, _monotonic_now_ns() - start_ns, attributes)
+
+        return wrapper
+
+    def __repr__(self) -> str:
+        return f"Span({self._name!r})"
+
+
+class Producer:
+    """One named external producer, owning the `ext.<name>.` segment of the namespace."""
+
+    __slots__ = ("_prefix", "name")
+
+    def __init__(self, name: str) -> None:
+        if not isinstance(name, str) or not _PRODUCER_PATTERN.match(name):
+            raise ValueError(
+                f"producer name must be one word of letters, digits, '_' or '-' — got {name!r}. "
+                "Attribution splits ext.<producer>.<span> on dots, so a dotted name names no producer."
+            )
+        self.name = name
+        self._prefix = f"{_RESERVED_WORD}.{name}."
+
+    def span(self, name: str, **attributes: Any) -> Span:
+        """A span named `ext.<producer>.<name>`, for use as a context manager or a decorator.
+
+        The name is refused when empty whether or not the gate is open, so an
+        unnamed span — `ext.<producer>.`, which attributes to nobody — fails the
+        same way in a run with spans off as in one with them on.
+        """
+        if not name:
+            raise ValueError("span name must be non-empty: ext.<producer>. names a producer but no span")
+        return Span(self._prefix + name, attributes)
+
+    def enabled(self) -> bool:
+        """Whether this process is emitting host spans right now.
+
+        Worth asking before building attributes that cost more than the span. Every
+        producer asks the same gate: this is the runtime query the C++ emit sites
+        read, and it is false in a build with host spans compiled out, so there is
+        one answer rather than two.
+        """
+        return _host_spans_active()
+
+    def __repr__(self) -> str:
+        return f"Producer({self.name!r})"
+
+
+def producer(name: str) -> Producer:
+    """A producer that names itself, for a library instrumenting its own code.
+
+    A library takes one of these rather than the module-level `span`, whose
+    producer is the unnamed default shared by whatever else in the process did not
+    name itself either.
+    """
+    return Producer(name)
+
+
+# The module-level surface is one producer's own methods, the shape `random`
+# exposes a hidden `Random` instance's: one call layer rather than a wrapper per
+# function, and no second implementation to drift from this one.
+_APPLICATION = Producer(_UNNAMED_APPLICATION)
+
+span = _APPLICATION.span
+enabled = _APPLICATION.enabled

--- a/tests/ut/py/test_trace_api.py
+++ b/tests/ut/py/test_trace_api.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""The public `simpler.trace` surface.
+
+The properties under test are the ones the API exists to make hold by
+construction: a caller's span lands in the reserved namespace and nowhere else,
+it is stamped with the clock the C++ spans use, and it costs a gate query when
+the gate is closed.
+"""
+
+import asyncio
+import subprocess
+import sys
+import textwrap
+
+import pytest
+import simpler
+from simpler import trace
+
+from simpler_setup.tools.strace_timing import external_producer, parse_spans, span_family
+
+
+@pytest.fixture
+def emitted(monkeypatch):
+    """Capture what reaches `_emit_host_span`, with the gate held open."""
+    records = []
+    monkeypatch.setattr(trace, "_host_spans_active", lambda: True)
+    monkeypatch.setattr(trace, "_emit_host_span", lambda *args: records.append(args))
+    return records
+
+
+@pytest.fixture
+def gate_closed(monkeypatch):
+    """Hold the runtime gate shut and fail the test if anything still emits."""
+
+    def unexpected(*args):
+        raise AssertionError(f"emitted with host spans off: {args}")
+
+    monkeypatch.setattr(trace, "_host_spans_active", lambda: False)
+    monkeypatch.setattr(trace, "_emit_host_span", unexpected)
+
+
+def _emit_in_child(tmp_path, body):
+    """Emit real records from a child process; return its spans and its stdout.
+
+    A child, because the host logger binds its directory once per process and a
+    test that bound this one's would take the whole session's records with it.
+    Whatever the body prints goes to stdout, since the logger owns stderr until
+    the directory is bound.
+    """
+    script = textwrap.dedent(
+        """
+        from _task_interface import _monotonic_now_ns, _set_host_log_directory
+        from simpler import TIMING, trace
+        from simpler.task_interface import _flush_host_log, _initialize_host_log
+
+        _initialize_host_log(TIMING)
+        _set_host_log_directory({directory!r})
+        {body}
+        _flush_host_log()
+        """
+    ).format(directory=str(tmp_path), body=textwrap.dedent(body).strip())
+    completed = subprocess.run([sys.executable, "-c", script], check=True, capture_output=True, text=True)
+    lines = []
+    for log in sorted(tmp_path.glob("host.*.log")):
+        lines.extend(log.read_text(encoding="utf-8").splitlines())
+    return list(parse_spans(lines)), completed.stdout
+
+
+def test_a_span_this_api_emits_reads_back_as_an_external_producers_own(tmp_path):
+    """End to end: the record a caller writes classifies as external and attributes to it."""
+    spans, _ = _emit_in_child(
+        tmp_path,
+        """
+        tracer = trace.producer("pypto")
+        with tracer.span("decode_layer", batch=16, layer=3):
+            pass
+        """,
+    )
+
+    assert [span.name for span in spans] == ["ext.pypto.decode_layer"]
+    span = spans[0]
+    assert span_family(span.name) == "external"
+    assert external_producer(span.name) == "pypto"
+    assert span.dur > 0
+    assert set(span.attrs.split()) == {"batch=16", "layer=3"}
+
+
+def test_a_caller_cannot_land_a_span_in_one_of_our_families(emitted):
+    """The prefix is unconditional, so one of our words is only ever a leaf.
+
+    Nothing validates the name against our level words, because there is nothing
+    a caller could pass that reaches them: the producer segment sits between
+    `ext.` and whatever it wrote. A rejecting check would add a failure mode
+    without adding a guarantee.
+    """
+    tracer = trace.producer("pypto")
+    for impersonation in ("node.dispatch", "chip.run", "core.task", "network1.submit", "ext.other.span"):
+        with tracer.span(impersonation):
+            pass
+
+    names = [record[0] for record in emitted]
+    assert names == [
+        "ext.pypto.node.dispatch",
+        "ext.pypto.chip.run",
+        "ext.pypto.core.task",
+        "ext.pypto.network1.submit",
+        "ext.pypto.ext.other.span",
+    ]
+    for name in names:
+        assert span_family(name) == "external"
+        assert external_producer(name) == "pypto"
+
+
+def test_a_closed_gate_emits_nothing_and_says_so(gate_closed):
+    """`enabled()` and the emit paths read one gate, so they cannot disagree."""
+    assert not trace.enabled()
+    assert not trace.producer("pypto").enabled()
+
+    with trace.span("phase", batch=16):
+        pass
+
+    @trace.span("decorated")
+    def work():
+        return 7
+
+    assert work() == 7
+
+
+def test_the_span_carries_the_clock_the_native_records_are_stamped_with(tmp_path):
+    """One clock by construction: the wrapper reads it, the caller never does.
+
+    The child prints the native clock either side of the span, so the assertion
+    is that the record's own `ts` lies inside that window — not that two clocks
+    on this platform happen to agree.
+    """
+    spans, stdout = _emit_in_child(
+        tmp_path,
+        """
+        before = _monotonic_now_ns()
+        with trace.producer("pypto").span("phase"):
+            pass
+        after = _monotonic_now_ns()
+        print(before, after)
+        """,
+    )
+    before, after = (int(value) for value in stdout.split())
+
+    assert len(spans) == 1
+    assert before <= spans[0].ts
+    assert spans[0].ts + spans[0].dur <= after
+
+
+def test_a_caller_that_names_no_producer_writes_under_the_unnamed_one(emitted):
+    """The default is a constant, not a name derived from the running program."""
+    with trace.span("phase"):
+        pass
+
+    (name,) = [record[0] for record in emitted]
+    assert name == "ext.app.phase"
+    assert external_producer(name) == "app"
+
+
+def test_a_marker_is_a_span_of_no_work_and_never_reports_zero_duration(emitted):
+    """There is no separate instant call, and no record carries `dur=0`.
+
+    `dur=0` is what our own emitting side writes for a phase that was never
+    stamped — `c_api_shared.cpp` skips a device phase whose duration reads back 0
+    — so a public API that produced it would put two meanings on one value.
+    """
+    assert not hasattr(trace, "instant")
+
+    with trace.span("checkpoint", token=17):
+        pass
+
+    (record,) = emitted
+    assert record[5] > 0
+    assert record[6] == "token=17"
+
+
+def test_a_raising_block_still_emits_its_span_and_still_raises(emitted):
+    """`with` is the shape a caller reaches for around code that can fail."""
+    with pytest.raises(ValueError, match="boom"), trace.span("phase"):
+        raise ValueError("boom")
+
+    (name,) = [record[0] for record in emitted]
+    assert span_family(name) == "external"
+    assert name.endswith(".phase")
+
+
+def test_a_decorated_function_is_timed_per_call_not_per_decoration(monkeypatch):
+    """The gate is read when the call runs, so a later threshold change is honored.
+
+    Decoration happens at import, and a worker seeds the threshold well after
+    that. Freezing the decision at decoration time would silently drop every span
+    from a module imported before `Worker.init`.
+    """
+    records = []
+    monkeypatch.setattr(trace, "_emit_host_span", lambda *args: records.append(args))
+    monkeypatch.setattr(trace, "_host_spans_active", lambda: False)
+
+    @trace.producer("pypto").span("work", role="test")
+    def work(value):
+        return value * 2
+
+    assert work(3) == 6
+    assert records == []
+
+    monkeypatch.setattr(trace, "_host_spans_active", lambda: True)
+    assert work(4) == 8
+    assert [record[0] for record in records] == ["ext.pypto.work"]
+    assert records[0][6] == "role=test"
+
+
+def test_a_decorated_function_keeps_its_identity(emitted):
+    @trace.span("work")
+    def work():
+        """Docstring."""
+
+    assert work.__name__ == "work"
+    assert work.__doc__ == "Docstring."
+
+
+def test_a_decorated_coroutine_is_timed_over_its_body_not_its_creation(emitted):
+    """A sync wrapper would close the span before the body ran at all.
+
+    Calling a coroutine function returns immediately with a coroutine; the work
+    happens at `await`. So the span has to cover the await, or it reports a few
+    hundred nanoseconds of object construction for a function that took
+    milliseconds — wrong data rather than no data.
+    """
+
+    @trace.span("work")
+    async def work(value):
+        await asyncio.sleep(0.01)
+        return value * 2
+
+    assert asyncio.iscoroutinefunction(work)
+    assert asyncio.run(work(3)) == 6
+
+    (record,) = emitted
+    assert record[0].endswith(".work")
+    # 10 ms of sleep, so anything near the cost of creating the coroutine fails.
+    assert record[5] > 5_000_000
+
+
+def test_a_raising_coroutine_still_emits_its_span_and_still_raises(emitted):
+    @trace.span("work")
+    async def work():
+        await asyncio.sleep(0)
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        asyncio.run(work())
+
+    assert [record[0].split(".")[-1] for record in emitted] == ["work"]
+
+
+def test_a_decorated_coroutine_is_gated_per_call_like_the_sync_one(monkeypatch):
+    records = []
+    monkeypatch.setattr(trace, "_emit_host_span", lambda *args: records.append(args))
+    monkeypatch.setattr(trace, "_host_spans_active", lambda: False)
+
+    @trace.span("work")
+    async def work():
+        return 7
+
+    assert asyncio.run(work()) == 7
+    assert records == []
+
+    monkeypatch.setattr(trace, "_host_spans_active", lambda: True)
+    assert asyncio.run(work()) == 7
+    assert len(records) == 1
+
+
+def test_our_correlation_keys_stay_out_of_the_public_surface(emitted):
+    """`inv` / `hid` / `depth` are ours; a caller has no value for them.
+
+    They are the keys the invocation-keyed views group on, and no external span
+    reaches those views, so every record from here carries 0 rather than a value
+    a caller invented.
+    """
+    with trace.span("phase"):
+        pass
+
+    _, invocation, callable_hash, depth, _, _, _ = emitted[0]
+    assert (invocation, callable_hash, depth) == (0, 0, 0)
+
+
+def test_a_producer_name_that_would_break_attribution_is_refused():
+    """A dotted producer shifts the segments attribution reads."""
+    for refused in ("pypto.lib", "", "with space", "a=b"):
+        with pytest.raises(ValueError):
+            trace.producer(refused)
+
+    with pytest.raises(ValueError):
+        trace.producer(None)  # pyright: ignore[reportArgumentType] -- a caller unchecked by a type checker
+
+
+def test_a_span_with_no_name_of_its_own_is_refused(gate_closed):
+    """`ext.<producer>.` names a producer and no span, so it attributes to nobody."""
+    with pytest.raises(ValueError):
+        trace.span("")
+    with pytest.raises(ValueError):
+        trace.producer("pypto").span("")
+
+
+def test_trace_is_advertised_next_to_the_other_public_surface():
+    assert "trace" in simpler.__all__
+    assert "trace" in dir(simpler)
+    assert simpler.trace is trace
+
+
+def test_importing_simpler_does_not_require_the_extension():
+    """`import simpler` stays usable where `_task_interface` is missing or stale.
+
+    The build-stamp guard makes a stale extension an ordinary state of a source
+    tree, and the logging helpers must survive it. `trace` is one more lazy
+    submodule, so it is the attribute access that needs the extension, not the
+    package import.
+    """
+    code = (
+        "import sys; sys.modules['_task_interface'] = None; "
+        "import simpler; print('trace' in simpler.__all__); "
+        "\ntry:\n    simpler.trace\n    print('LOADED')\nexcept ImportError:\n    print('BLOCKED')"
+    )
+    out = subprocess.run(  # noqa: S603 -- fixed argv, no shell
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    )
+    assert out.stdout.split() == ["True", "BLOCKED"], f"{out.stdout!r} {out.stderr!r}"


### PR DESCRIPTION
## Summary

Implements [#1794](https://github.com/hw-native-sys/simpler/issues/1794): a public Python surface for putting a caller's own phases on the host timeline. Today `_task_interface._emit_host_span` is the only way in — seven arguments, three of which (`invocation_id`, `callable_hash`, `depth`) are our internal correlation keys a caller can only fill with zeros, plus a timestamp the caller has to source itself. So pypto-lib parses our `[STRACE]` output and prints its own phase timings in a second format instead of writing into ours.

```python
from simpler import trace

with trace.span("my_phase", batch=16, layer=3):
    ...

@trace.span("my_func")
def f(): ...

with trace.span("checkpoint", token=17):   # a marker is a span of no work
    pass

if trace.enabled():                        # only then build costly attributes
    with trace.span("expensive", **compute_attrs()):
        ...

tracer = trace.producer("pypto")           # a library names itself
```

One producer, one span, one gate is the whole surface. Three properties hold by construction, which is the reason to call this rather than the entry point underneath it:

- **One clock.** The wrapper reads the clock, so a caller never handles a timestamp. The new `_task_interface._monotonic_now_ns` binding exposes `simpler::log::monotonic_now_ns` — the `steady_clock` every host record's prefix and every C++ span already use — rather than leaving Python on `time.monotonic_ns()` and relying on both mapping to `CLOCK_MONOTONIC`. That agreement is a platform property, not a guarantee, and it is what `test_the_span_carries_the_clock_the_native_records_are_stamped_with` would catch on a platform that broke it. The binding also measures cheaper than Python's clock here: 85 ns against 134 ns per call.
- **One namespace.** Every name is prefixed `ext.<producer>.`, so `trace.span("node.dispatch")` emits `ext.pypto.node.dispatch`. One of our level words is only ever a leaf, which is why nothing validates the name against them: there is nothing a caller can pass that reaches our families, and a rejecting check would add a failure mode without adding a guarantee.
- **One gate.** `trace.enabled()` is `unified_log_host_span_enabled()`, the query the C++ emit sites read. No second notion of "on", no new environment variable or macro, no new verbosity level.

**Not a side channel.** #2128 made `[STRACE]` the host's one timeline format, so a caller's interval is a span for the same reason a runtime's own bind segment is; the reserved namespace separates *whose* span it is, not which format it uses. That is why this waited for #2128 rather than landing first and claiming only that it "uses the `[STRACE]` family".

Two things #1794's sketch asks for are deliberately absent, both because they would put a second rule beside one of the three above:

- **No `instant()`.** A zero-duration span would be a second event concept, and `dur=0` is already what our own emitting side writes for a phase that was never stamped, so a public API producing it would put two meanings on one value. A marker is `with trace.span("checkpoint"): pass`, which records a real short interval.
- **No producer name derived from the running program.** The default is the constant `app`. Deriving one from `argv[0]` needs a chain of special cases — strip `.py`, fall back to the parent directory for `__main__`, substitute illegal characters, fall back again when empty — and one `trace.producer("my_bench")` call names an application better than any of them.

Cost of one `with trace.span(name, k=v, k2=v2)` attempt, median of 7 batches of 200k iterations on this aarch64 box: 995 ns gate-closed against 8998 ns emitting. The closed-gate figure is Python's own floor rather than this path's work — an empty pure-Python `with` block costs 272 ns there and the gate query 166 ns — so a caller in a genuinely hot loop asks `trace.enabled()` once instead of opening a span per iteration. That is what the public query is for.

Also corrects a stale cross-reference #2128 left in the same file: the principle paragraph pointed at `ext.` as "(below)" when that section is above it.

This PR does not declare the record format a supported external contract; the `v=1` field exists for that decision and making it is separate from offering the emitter.

## Testing

- [x] `pytest tests/ut -m "not requires_hardware"` — 2140 passed, 7 skipped
- [x] cpput — 134/134 passed
- [x] Simulation tests pass — full pyut and cpput at this base; `import simpler` still works with `_task_interface` unimportable (`test_importing_simpler_does_not_require_the_extension`)
- [x] End to end: a nested real run renders in `--swimlane` as `external producer pypto/smoke_trace (pid=N)` with the caller's spans nested, attributes intact, and stays out of the `(pid, inv)`-keyed tables — the documented `ext.` guarantees in both directions
- [x] Each of the three regressions confirmed red before green (blanking the prefix reddens the family and impersonation cases; making `__enter__` skip the gate reddens the closed-gate case)
- [ ] Hardware tests — not applicable: this is a host-side Python surface with no device path. CI's onboard jobs cover that nothing else regressed.

Fixes #1794
